### PR TITLE
feat(theta): gauge-side Z2 collapse and positive-class zero branch in scoped class

### DIFF
--- a/docs/THETA_GAUGE_Z2_CHARACTER_COLLAPSE_ODD_SUPPORT_AND_POSITIVE_CLASS_ZERO_BRANCH_SELECTION_BOUNDED_THEOREM_NOTE_2026-07-03.md
+++ b/docs/THETA_GAUGE_Z2_CHARACTER_COLLAPSE_ODD_SUPPORT_AND_POSITIVE_CLASS_ZERO_BRANCH_SELECTION_BOUNDED_THEOREM_NOTE_2026-07-03.md
@@ -3,8 +3,8 @@
 **Date:** 2026-07-03
 **Type:** bounded_theorem
 **Claim type:** bounded_theorem (exact character-collapse and class-selection
-statements on the landed carrier's sector lattice and inside the landed
-positive weight class; not a terminal no-go, not a discharge of the theta
+statements on the current-main carrier's sector lattice and inside the
+current-main positive weight class; not a terminal no-go, not a discharge of the theta
 admission, and no claim that the physical action class lies in the positive
 class — that adjudication remains open).
 **Status authority:** independent audit lane only. This note does not set an
@@ -17,26 +17,26 @@ re-grade any Tier-A admission, or claim Strong-CP closure.
 
 ## Question
 
-The mass side of the theta admission has a landed two-step structure: the
-continuous determinant phase is erased down to the discrete set `{0, pi}`,
+The mass-side source chain for the theta admission has a two-step structure:
+the continuous determinant phase is erased down to the discrete set `{0, pi}`,
 and the `+-i lambda` pairing then forces the zero branch on the K-real
 Case-A surface for both signs of the mass
 ([`THETA_MASS_ORIENTATION_ZERO_BRANCH_PAIRING_FORCED_ON_K_REAL_SURFACE_NARROW_THEOREM_NOTE_2026-07-01.md`](THETA_MASS_ORIENTATION_ZERO_BRANCH_PAIRING_FORCED_ON_K_REAL_SURFACE_NARROW_THEOREM_NOTE_2026-07-01.md)).
 
-The gauge side has the carrier: the theta slot is the character weight
-`e^{i theta Q}` on the flux sectors, with odd support (`Q = 1` at unit
+The gauge side has a current-main carrier source: the theta slot is the
+character weight `e^{i theta Q}` on the flux sectors, with odd support (`Q = 1` at unit
 complementary fluxes)
 ([`THETA_4D_CARRIER_FLUX_COHOMOLOGY_INTERSECTION_PAIRING_CLOSED_BRANCH_AND_DEFECT_CLOSURE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md`](THETA_4D_CARRIER_FLUX_COHOMOLOGY_INTERSECTION_PAIRING_CLOSED_BRANCH_AND_DEFECT_CLOSURE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md)),
-and a derived weight class: the multi-plaquette gluing produces sector
-weights that are strictly positive on every sector and conjugation-paired,
+and a current-main positive-class source: the multi-plaquette gluing produces
+sector weights that are strictly positive on every sector and conjugation-paired,
 as members of the positive `2 pi`-periodic class-weight family
 ([`GAUGE_MULTIPLAQUETTE_CHARACTER_GLUING_EMERGENT_INTEGER_SECTOR_RECORD_CONTEXT_AND_ACTION_PAIRING_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md`](GAUGE_MULTIPLAQUETTE_CHARACTER_GLUING_EMERGENT_INTEGER_SECTOR_RECORD_CONTEXT_AND_ACTION_PAIRING_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md)).
-A companion analysis currently in review derives that the named axiom
-surfaces supply no orientation datum, so supplied-structure constructions
-are even under the sector inversion `Q -> -Q`; in this note that statement
-enters only as a named hypothesis ("orientation-evenness"), re-earned in
-miniature by the runner, and the note's theorems are unconditional given
-their stated hypotheses.
+A companion analysis currently in review is expected to derive that the named
+axiom surfaces supply no orientation datum, so supplied-structure
+constructions are even under the sector inversion `Q -> -Q`; in this note
+that statement enters only as a named hypothesis ("orientation-evenness"),
+re-earned in miniature by the runner, and the note's theorems are conditional
+only on their stated hypotheses.
 
 Question answered here: does the gauge side have the same two-step
 structure as the mass side — a discrete collapse followed by a forced
@@ -44,7 +44,8 @@ branch selection — and what exactly does each step?
 
 ## Answer
 
-Yes, with the mechanisms precisely located:
+Within the stated hypotheses and classes, yes, with the mechanisms precisely
+located:
 
 1. **Collapse (Theorem 1).** An orientation-even weight in the theta slot
    — a multiplicative character `w(Q) = e^{i theta Q}` of the sector group
@@ -68,7 +69,7 @@ Yes, with the mechanisms precisely located:
    non-supply cannot distinguish the two branches, and a second, distinct
    mechanism must make the selection.
 
-3. **Selection (Theorem 2).** Inside the derived weight class — per-sector
+3. **Selection (Theorem 2).** Inside the cited positive class — per-sector
    weights induced by strictly positive, conjugation-paired dual
    coefficients (heat-kernel member `c_n = e^{-t n^2/2}`; Wilson members
    `c_n(beta) = I_n(beta)`; `SU(3)` Wilson duals at `beta = 6` positive
@@ -77,17 +78,17 @@ Yes, with the mechanisms precisely located:
    sectors by `-1`; odd-`Q` sectors exist (unit complementary fluxes);
    hence the `pi`-branch family attains negative values and is **not a
    member of the positive class**, while `theta = 0` reproduces the class
-   identically. Within the derived class the zero branch is selected —
+   identically. Within the cited positive class the zero branch is selected —
    the gauge twin of the mass side's `+-i lambda` pairing, with
-   positivity of the derived coefficients playing the role the eigenvalue
+   positivity of the cited class coefficients playing the role the eigenvalue
    pairing plays for `det(M + m) >= 0`.
 
 4. **Two-sided assembly (Corollary).** With the gauge branch selected to
-   `0` within the derived positive class and the mass branch selected to
-   `0` on the K-real Case-A surface (landed), the branch table
-   `{0, pi} x {0, pi}` for `theta_bar = theta_gauge + arg det M` lands on
-   the `theta_bar = 0` cell — within the stated surfaces and classes, and
-   with the class-to-physical-action adjudication named below as the
+   `0` within the cited positive class and the mass branch selected to `0`
+   on the K-real Case-A surface (cited source), the formal branch table
+   `{0, pi} x {0, pi}` for `theta_bar = theta_gauge + arg det M` selects
+   the `theta_bar = 0` cell — within the stated surfaces and classes only,
+   and with the class-to-physical-action adjudication named below as the
    remaining item.
 
 ## Authorities and premises
@@ -96,7 +97,7 @@ Yes, with the mechanisms precisely located:
   — the theta slot as the sector character `e^{i theta Q}`, the pairing
   `Q`, and its odd support (`Q = 1` at unit complementary fluxes).
 - [`GAUGE_MULTIPLAQUETTE_CHARACTER_GLUING_EMERGENT_INTEGER_SECTOR_RECORD_CONTEXT_AND_ACTION_PAIRING_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md`](GAUGE_MULTIPLAQUETTE_CHARACTER_GLUING_EMERGENT_INTEGER_SECTOR_RECORD_CONTEXT_AND_ACTION_PAIRING_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md)
-  — the derived weight class: strictly positive sector weights,
+  — the cited positive class: strictly positive sector weights,
   conjugation pairing, the positive `2 pi`-periodic class-weight family
   and its heat-kernel/Wilson members.
 - [`THETA_MASS_ORIENTATION_ZERO_BRANCH_PAIRING_FORCED_ON_K_REAL_SURFACE_NARROW_THEOREM_NOTE_2026-07-01.md`](THETA_MASS_ORIENTATION_ZERO_BRANCH_PAIRING_FORCED_ON_K_REAL_SURFACE_NARROW_THEOREM_NOTE_2026-07-01.md)
@@ -104,11 +105,13 @@ Yes, with the mechanisms precisely located:
   `+-i lambda` pairing-forced zero branch on the K-real Case-A surface.
 - [`THETA_LINK_STAR_GLUING_FRAME_CORRELATION_PAIR_COMPOSITE_DAGGER_EVENNESS_AND_ODD_BRANCH_PHASE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md`](THETA_LINK_STAR_GLUING_FRAME_CORRELATION_PAIR_COMPOSITE_DAGGER_EVENNESS_AND_ODD_BRANCH_PHASE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md)
   — dagger/bar evenness of supplied pair reads (the evenness hypothesis's
-  landed holonomy-level face).
+  current source-side holonomy-level face).
 - Orientation-evenness hypothesis: carried from the in-review native
   orientation non-supply analysis (referenced in prose only; not a
   dependency edge). Its use here is confined to the stated hypothesis of
   Theorem 1, re-earned in miniature by the runner's swap-closed check.
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+  — current axiom context; no axiom edit is made here.
 
 ## Theorem statements and proofs
 
@@ -126,7 +129,7 @@ inversion-fixed character set on a 720-point unitary grid is exactly
 `{+1, -1}` (A1). Both hypotheses are necessary: `w(Q) = cos(0.3 Q)` is
 even but not multiplicative and lies outside `{0, pi}` (A2); on the even
 sublattice `2Z` the fixed set is the four fourth roots of unity —
-strictly larger — so the odd support delivered by the carrier is
+strictly larger — so the odd support delivered by the cited carrier source is
 load-bearing (A3). The evenness hypothesis itself is re-earned in
 miniature: the alpha-odd holonomy insertion sums to zero exactly over
 swap-closed pairs (A4a).
@@ -136,7 +139,7 @@ swap-closed pairs (A4a).
 In the weight class with strictly positive, conjugation-paired dual
 coefficients, every induced sector weight is strictly positive; the
 `theta = pi` branch is not realizable in the class, and `theta = 0`
-reproduces the class. Hence the derived class selects the zero branch of
+reproduces the class. Hence the cited positive class selects the zero branch of
 Theorem 1's `Z2`.
 
 *Proof.* Positivity of coefficients makes each sector weight a product /
@@ -151,7 +154,7 @@ by `-1` and so attains negative values exactly there (B3b) — outside the
 positive class. Two-mechanism honesty: the signed family satisfies every
 Theorem-1 constraint (it is the `theta = pi` character and is
 orientation-blind under the frame swap) yet exits the class (B4) — the
-selection is done by the positivity of the derived coefficients, not by
+selection is done by the positivity of the cited positive-class coefficients, not by
 orientation non-supply.
 
 ### Corollary (two-sided branch table)
@@ -159,27 +162,27 @@ orientation non-supply.
 The mass-side mirror is re-earned in miniature: real antisymmetric `M`
 has spectrum in `+-i lambda` pairs and `det(M + m I) >= 0` for both signs
 of `m`, and a real symmetric perturbation loses the guarantee (B5a-b,
-consistency mirror of the landed theorem — no new mass-side claim). The
+consistency mirror of the cited mass-side source — no new mass-side claim). The
 branch table over `{0, pi} x {0, pi}` with the gauge branch selected by
-Theorem 2 and the mass branch selected by the landed pairing theorem
-lands on `theta_bar = 0` (B6) — within the stated surfaces and classes.
+Theorem 2 and the mass branch selected by the cited pairing source formally
+selects `theta_bar = 0` (B6) — within the stated surfaces and classes only.
 
 ## What this note does and does not claim
 
-- **No physical-action claim.** Theorem 2 operates within the derived
-  positive conjugation-paired weight class — the class the
+- **No physical-action claim.** Theorem 2 operates within the cited positive
+  conjugation-paired weight class — the class the
   multi-plaquette gluing produced on its surface. Whether the physical
   action class lies in (or reduces to) this class on the full carrier is
   the standing action-level pairing adjudication; this note does not
   decide it, and nothing here asserts the physical value of `theta_bar`
   or anything about measured quantities.
 - **The collapse is conditional on its named hypotheses**: the character
-  form of the theta slot (the landed carrier's `e^{i theta Q}` shape),
+  form of the theta slot (the cited carrier source's `e^{i theta Q}` shape),
   orientation-evenness (hypothesis; derivation in review), and odd
-  support (landed). Each is exhibited as load-bearing.
+  support (cited source). Each is exhibited as load-bearing.
 - **The `pi` branch is not excluded by orientation non-supply** — it is
   orientation-blind, and this note says so explicitly; positivity of the
-  derived class is the selecting mechanism. A future account that leaves
+  cited positive class is the selecting mechanism. A future account that leaves
   the positive class (e.g. sign-carrying weight families) would reopen
   the branch selection, not the collapse.
 - The mass-side content is cited, not re-graded; the runner's Case-A
@@ -189,9 +192,9 @@ lands on `theta_bar = 0` (B6) — within the stated surfaces and classes.
 
 1. **Class-to-action adjudication**: whether the physical action class on
    the carrier lies in the positive conjugation-paired class — the
-   assembly item for the audit lane on the landed chain; together with
+   assembly item for the audit lane on the cited chain; together with
    the evenness grading (residual 3) it is what stands between the branch
-   table and an unconditional gauge-side zero branch.
+   table and a physical gauge-side zero branch.
 2. **Surface extension on the mass side**: beyond the staggered-only
    Case-A / K-real surface — the sister lane's account.
 3. **Orientation non-supply derivation**: the in-review companion; when

--- a/docs/THETA_GAUGE_Z2_CHARACTER_COLLAPSE_ODD_SUPPORT_AND_POSITIVE_CLASS_ZERO_BRANCH_SELECTION_BOUNDED_THEOREM_NOTE_2026-07-03.md
+++ b/docs/THETA_GAUGE_Z2_CHARACTER_COLLAPSE_ODD_SUPPORT_AND_POSITIVE_CLASS_ZERO_BRANCH_SELECTION_BOUNDED_THEOREM_NOTE_2026-07-03.md
@@ -1,0 +1,207 @@
+# The Gauge-Side Theta Dial Collapses to {0, pi} for Orientation-Even Character Weights on the Odd-Support Sector Lattice, and the Derived Positive Conjugation-Paired Weight Class Selects the Zero Branch — the Gauge Twin of the Mass-Side Pairing-Forced Zero Branch (Bounded Theorem)
+
+**Date:** 2026-07-03
+**Type:** bounded_theorem
+**Claim type:** bounded_theorem (exact character-collapse and class-selection
+statements on the landed carrier's sector lattice and inside the landed
+positive weight class; not a terminal no-go, not a discharge of the theta
+admission, and no claim that the physical action class lies in the positive
+class — that adjudication remains open).
+**Status authority:** independent audit lane only. This note does not set an
+audit verdict, edit registries, register primitives, change axioms, retire or
+re-grade any Tier-A admission, or claim Strong-CP closure.
+**Primary runner:**
+[`scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py`](../scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py)
+**Runner cache:**
+[`logs/runner-cache/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.txt`](../logs/runner-cache/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.txt)
+
+## Question
+
+The mass side of the theta admission has a landed two-step structure: the
+continuous determinant phase is erased down to the discrete set `{0, pi}`,
+and the `+-i lambda` pairing then forces the zero branch on the K-real
+Case-A surface for both signs of the mass
+([`THETA_MASS_ORIENTATION_ZERO_BRANCH_PAIRING_FORCED_ON_K_REAL_SURFACE_NARROW_THEOREM_NOTE_2026-07-01.md`](THETA_MASS_ORIENTATION_ZERO_BRANCH_PAIRING_FORCED_ON_K_REAL_SURFACE_NARROW_THEOREM_NOTE_2026-07-01.md)).
+
+The gauge side has the carrier: the theta slot is the character weight
+`e^{i theta Q}` on the flux sectors, with odd support (`Q = 1` at unit
+complementary fluxes)
+([`THETA_4D_CARRIER_FLUX_COHOMOLOGY_INTERSECTION_PAIRING_CLOSED_BRANCH_AND_DEFECT_CLOSURE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md`](THETA_4D_CARRIER_FLUX_COHOMOLOGY_INTERSECTION_PAIRING_CLOSED_BRANCH_AND_DEFECT_CLOSURE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md)),
+and a derived weight class: the multi-plaquette gluing produces sector
+weights that are strictly positive on every sector and conjugation-paired,
+as members of the positive `2 pi`-periodic class-weight family
+([`GAUGE_MULTIPLAQUETTE_CHARACTER_GLUING_EMERGENT_INTEGER_SECTOR_RECORD_CONTEXT_AND_ACTION_PAIRING_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md`](GAUGE_MULTIPLAQUETTE_CHARACTER_GLUING_EMERGENT_INTEGER_SECTOR_RECORD_CONTEXT_AND_ACTION_PAIRING_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md)).
+A companion analysis currently in review derives that the named axiom
+surfaces supply no orientation datum, so supplied-structure constructions
+are even under the sector inversion `Q -> -Q`; in this note that statement
+enters only as a named hypothesis ("orientation-evenness"), re-earned in
+miniature by the runner, and the note's theorems are unconditional given
+their stated hypotheses.
+
+Question answered here: does the gauge side have the same two-step
+structure as the mass side — a discrete collapse followed by a forced
+branch selection — and what exactly does each step?
+
+## Answer
+
+Yes, with the mechanisms precisely located:
+
+1. **Collapse (Theorem 1).** An orientation-even weight in the theta slot
+   — a multiplicative character `w(Q) = e^{i theta Q}` of the sector group
+   with `w(Q) = w(-Q)` — must satisfy `e^{2 i theta Q} = 1` on the
+   support; with odd support (`Q = 1` realized), this forces
+
+   ```text
+   theta in {0, pi} .
+   ```
+
+   The continuous theta dial dies without any orientation import; one bit
+   survives. Both hypotheses are load-bearing (runner-witnessed): evenness
+   alone does not collapse (a non-multiplicative even weight exists), and
+   on an even-support sublattice the fixed set is strictly larger (the
+   four fourth roots of unity).
+
+2. **The surviving bit is not reachable by the collapse mechanism
+   (two-mechanism honesty).** The `theta = pi` character `(-1)^Q` is
+   orientation-blind — `(-1)^Q = (-1)^{-Q}`, and it is invariant under
+   the spatial frame swap that flips `Q` itself. So orientation
+   non-supply cannot distinguish the two branches, and a second, distinct
+   mechanism must make the selection.
+
+3. **Selection (Theorem 2).** Inside the derived weight class — per-sector
+   weights induced by strictly positive, conjugation-paired dual
+   coefficients (heat-kernel member `c_n = e^{-t n^2/2}`; Wilson members
+   `c_n(beta) = I_n(beta)`; `SU(3)` Wilson duals at `beta = 6` positive
+   and conjugation-paired, re-earned by quadrature) — every sector weight
+   is strictly positive. The `theta = pi` branch multiplies odd-`Q`
+   sectors by `-1`; odd-`Q` sectors exist (unit complementary fluxes);
+   hence the `pi`-branch family attains negative values and is **not a
+   member of the positive class**, while `theta = 0` reproduces the class
+   identically. Within the derived class the zero branch is selected —
+   the gauge twin of the mass side's `+-i lambda` pairing, with
+   positivity of the derived coefficients playing the role the eigenvalue
+   pairing plays for `det(M + m) >= 0`.
+
+4. **Two-sided assembly (Corollary).** With the gauge branch selected to
+   `0` within the derived positive class and the mass branch selected to
+   `0` on the K-real Case-A surface (landed), the branch table
+   `{0, pi} x {0, pi}` for `theta_bar = theta_gauge + arg det M` lands on
+   the `theta_bar = 0` cell — within the stated surfaces and classes, and
+   with the class-to-physical-action adjudication named below as the
+   remaining item.
+
+## Authorities and premises
+
+- [`THETA_4D_CARRIER_FLUX_COHOMOLOGY_INTERSECTION_PAIRING_CLOSED_BRANCH_AND_DEFECT_CLOSURE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md`](THETA_4D_CARRIER_FLUX_COHOMOLOGY_INTERSECTION_PAIRING_CLOSED_BRANCH_AND_DEFECT_CLOSURE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md)
+  — the theta slot as the sector character `e^{i theta Q}`, the pairing
+  `Q`, and its odd support (`Q = 1` at unit complementary fluxes).
+- [`GAUGE_MULTIPLAQUETTE_CHARACTER_GLUING_EMERGENT_INTEGER_SECTOR_RECORD_CONTEXT_AND_ACTION_PAIRING_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md`](GAUGE_MULTIPLAQUETTE_CHARACTER_GLUING_EMERGENT_INTEGER_SECTOR_RECORD_CONTEXT_AND_ACTION_PAIRING_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md)
+  — the derived weight class: strictly positive sector weights,
+  conjugation pairing, the positive `2 pi`-periodic class-weight family
+  and its heat-kernel/Wilson members.
+- [`THETA_MASS_ORIENTATION_ZERO_BRANCH_PAIRING_FORCED_ON_K_REAL_SURFACE_NARROW_THEOREM_NOTE_2026-07-01.md`](THETA_MASS_ORIENTATION_ZERO_BRANCH_PAIRING_FORCED_ON_K_REAL_SURFACE_NARROW_THEOREM_NOTE_2026-07-01.md)
+  — the mass-side twin: erasure to `{0, pi}` (its cited chain) and the
+  `+-i lambda` pairing-forced zero branch on the K-real Case-A surface.
+- [`THETA_LINK_STAR_GLUING_FRAME_CORRELATION_PAIR_COMPOSITE_DAGGER_EVENNESS_AND_ODD_BRANCH_PHASE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md`](THETA_LINK_STAR_GLUING_FRAME_CORRELATION_PAIR_COMPOSITE_DAGGER_EVENNESS_AND_ODD_BRANCH_PHASE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md)
+  — dagger/bar evenness of supplied pair reads (the evenness hypothesis's
+  landed holonomy-level face).
+- Orientation-evenness hypothesis: carried from the in-review native
+  orientation non-supply analysis (referenced in prose only; not a
+  dependency edge). Its use here is confined to the stated hypothesis of
+  Theorem 1, re-earned in miniature by the runner's swap-closed check.
+
+## Theorem statements and proofs
+
+### Theorem 1 (Z2 collapse on odd support)
+
+Let `w` be a sector weight in the theta slot: a multiplicative character
+`w(Q) = z^Q` of the sector group `Z`, orientation-even (`w(Q) = w(-Q)`),
+with `Q = 1` in the sector support. Then `z^2 = 1`, i.e.
+`theta in {0, pi}`.
+
+*Proof.* Evenness plus multiplicativity give `z^{2Q} = 1` for every
+supported `Q`; `Q = 1` gives `z^2 = 1`, so `z in {+1, -1}` — the trivial
+character (`theta = 0`) or the sign character (`theta = pi`). Runner: the
+inversion-fixed character set on a 720-point unitary grid is exactly
+`{+1, -1}` (A1). Both hypotheses are necessary: `w(Q) = cos(0.3 Q)` is
+even but not multiplicative and lies outside `{0, pi}` (A2); on the even
+sublattice `2Z` the fixed set is the four fourth roots of unity —
+strictly larger — so the odd support delivered by the carrier is
+load-bearing (A3). The evenness hypothesis itself is re-earned in
+miniature: the alpha-odd holonomy insertion sums to zero exactly over
+swap-closed pairs (A4a).
+
+### Theorem 2 (positive-class zero-branch selection)
+
+In the weight class with strictly positive, conjugation-paired dual
+coefficients, every induced sector weight is strictly positive; the
+`theta = pi` branch is not realizable in the class, and `theta = 0`
+reproduces the class. Hence the derived class selects the zero branch of
+Theorem 1's `Z2`.
+
+*Proof.* Positivity of coefficients makes each sector weight a product /
+positive combination of positive terms: on a matched-label closed surface
+`Z_n = c_n^A > 0` with `Z_n = Z_{-n}` (runner earns this by two
+independent code paths, B1); the `SU(3)` Wilson duals at `beta = 6` are
+positive and conjugation-paired by direct antisymmetrized-Weyl quadrature
+with an orthonormality gate (B2a-c); per-plane positive weights make
+every carrier sector weight positive, including on the odd-support
+witnesses where `Q = 1` (B3a). The `pi` branch multiplies odd-`Q` sectors
+by `-1` and so attains negative values exactly there (B3b) — outside the
+positive class. Two-mechanism honesty: the signed family satisfies every
+Theorem-1 constraint (it is the `theta = pi` character and is
+orientation-blind under the frame swap) yet exits the class (B4) — the
+selection is done by the positivity of the derived coefficients, not by
+orientation non-supply.
+
+### Corollary (two-sided branch table)
+
+The mass-side mirror is re-earned in miniature: real antisymmetric `M`
+has spectrum in `+-i lambda` pairs and `det(M + m I) >= 0` for both signs
+of `m`, and a real symmetric perturbation loses the guarantee (B5a-b,
+consistency mirror of the landed theorem — no new mass-side claim). The
+branch table over `{0, pi} x {0, pi}` with the gauge branch selected by
+Theorem 2 and the mass branch selected by the landed pairing theorem
+lands on `theta_bar = 0` (B6) — within the stated surfaces and classes.
+
+## What this note does and does not claim
+
+- **No physical-action claim.** Theorem 2 operates within the derived
+  positive conjugation-paired weight class — the class the
+  multi-plaquette gluing produced on its surface. Whether the physical
+  action class lies in (or reduces to) this class on the full carrier is
+  the standing action-level pairing adjudication; this note does not
+  decide it, and nothing here asserts the physical value of `theta_bar`
+  or anything about measured quantities.
+- **The collapse is conditional on its named hypotheses**: the character
+  form of the theta slot (the landed carrier's `e^{i theta Q}` shape),
+  orientation-evenness (hypothesis; derivation in review), and odd
+  support (landed). Each is exhibited as load-bearing.
+- **The `pi` branch is not excluded by orientation non-supply** — it is
+  orientation-blind, and this note says so explicitly; positivity of the
+  derived class is the selecting mechanism. A future account that leaves
+  the positive class (e.g. sign-carrying weight families) would reopen
+  the branch selection, not the collapse.
+- The mass-side content is cited, not re-graded; the runner's Case-A
+  checks are consistency mirrors in miniature, not new mass-side claims.
+
+## Residuals and next paths
+
+1. **Class-to-action adjudication**: whether the physical action class on
+   the carrier lies in the positive conjugation-paired class — the
+   assembly item for the audit lane on the landed chain; together with
+   the evenness grading (residual 3) it is what stands between the branch
+   table and an unconditional gauge-side zero branch.
+2. **Surface extension on the mass side**: beyond the staggered-only
+   Case-A / K-real surface — the sister lane's account.
+3. **Orientation non-supply derivation**: the in-review companion; when
+   graded, Theorem 1's evenness hypothesis becomes a cited theorem and
+   this note's collapse is premise-complete on the gauge side.
+4. **The consolidation frontier this opens**: the admissibility rule's
+   behavior under improper maps is unconstrained by the axiom text
+   (proper covariance is required; improper behavior is an open
+   property). Settling it would either make the framework achiral at rule
+   level (pushing weak-sector chirality to an emergent mechanism) or
+   supply a derived orientation source that must then appear in both the
+   chirality gate and any theta-slot account — one datum, multiple
+   shadows.

--- a/docs/audit/AUDIT_LEDGER.md
+++ b/docs/audit/AUDIT_LEDGER.md
@@ -23,7 +23,7 @@ Publication-facing tables MUST read `effective_status`; `claim_type` is the audi
 | **retained_bounded** | 849 |
 | _retained_pending_chain_ | 4 |
 | open_gate | 24 |
-| unaudited | 1965 |
+| unaudited | 1968 |
 | meta | 313 |
 | ~~audited_numerical_match~~ | 10 |
 | ~~audited_renaming~~ | 19 |
@@ -59,40 +59,40 @@ Publication-facing tables MUST read `effective_status`; `claim_type` is the audi
 
 | audit_status | count |
 |---|---:|
-| `audit_in_progress` | 11 |
-| `audited_clean` | 1222 |
+| `audit_in_progress` | 12 |
+| `audited_clean` | 1221 |
 | `audited_conditional` | 25 |
 | `audited_decoration` | 47 |
 | `audited_failed` | 23 |
 | `audited_numerical_match` | 10 |
 | `audited_renaming` | 19 |
-| `unaudited` | 2278 |
+| `unaudited` | 2281 |
 
 | claim_type | count |
 |---|---:|
-| `bounded_theorem` | 1920 |
+| `bounded_theorem` | 1922 |
 | `decoration` | 50 |
 | `meta` | 319 |
 | `no_go` | 433 |
 | `open_gate` | 171 |
-| `positive_theorem` | 742 |
+| `positive_theorem` | 743 |
 
 | criticality | count |
 |---|---:|
-| `critical` | 660 |
-| `high` | 465 |
-| `medium` | 924 |
-| `leaf` | 1586 |
+| `critical` | 668 |
+| `high` | 457 |
+| `medium` | 925 |
+| `leaf` | 1588 |
 
 - **Retained pending chain closure:** 4
 - **Citation cycles detected:** 14
 
 ### Runner classification (static heuristic)
 
-- runners classified: 3299
-- runners with (C) first-principles compute hits: 1729
+- runners classified: 3302
+- runners with (C) first-principles compute hits: 1730
 - runners with (D) external comparator hits: 1061
-- decoration candidates (no C, no D): 688
+- decoration candidates (no C, no D): 690
 
 ## Top 25 by load-bearing score (topology only)
 
@@ -100,31 +100,31 @@ Criticality and load-bearing score are computed from the citation graph alone. T
 
 | # | claim_id | claim_type | criticality | desc | score | audit_status | effective |
 |---:|---|---|---|---:|---:|---|---|
-| 1 | `minimal_axioms` | meta | critical | 1860 | 184.86 | `unaudited` | meta |
-| 2 | `three_generation_observable_theorem_note` | positive_theorem | critical | 1148 | 67.17 | `audited_clean` | **retained** |
+| 1 | `minimal_axioms` | meta | critical | 1863 | 186.36 | `unaudited` | meta |
+| 2 | `three_generation_observable_theorem_note` | positive_theorem | critical | 1149 | 67.17 | `audited_clean` | **retained** |
 | 3 | `quark_route2_exact_readout_map_note_2026-04-19` | positive_theorem | critical | 198 | 65.14 | `audited_clean` | **retained** |
-| 4 | `graph_first_su3_integration_note` | positive_theorem | critical | 1578 | 65.12 | `audited_clean` | **retained** |
-| 5 | `observable_principle_from_axiom_note` | bounded_theorem | critical | 1201 | 64.23 | `unaudited` | unaudited |
-| 6 | `plaquette_self_consistency_note` | bounded_theorem | critical | 1248 | 54.29 | `audited_clean` | **retained_bounded** |
-| 7 | `minimal_axioms_2026-05-03` | meta | critical | 1153 | 48.17 | `unaudited` | meta |
-| 8 | `key_terminology` | meta | critical | 1252 | 46.79 | `unaudited` | meta |
-| 9 | `staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac` | bounded_theorem | critical | 1000 | 44.47 | `unaudited` | unaudited |
-| 10 | `yt_ward_identity_derivation_theorem` | bounded_theorem | critical | 1000 | 43.47 | `unaudited` | unaudited |
-| 11 | `anomaly_forces_time_theorem` | bounded_theorem | critical | 1380 | 43.43 | `unaudited` | unaudited |
-| 12 | `alpha_s_derived_note` | bounded_theorem | critical | 1137 | 42.15 | `unaudited` | unaudited |
-| 13 | `cl3_color_automorphism_theorem` | bounded_theorem | critical | 1096 | 41.60 | `unaudited` | unaudited |
-| 14 | `native_gauge_closure_note` | positive_theorem | critical | 1540 | 41.59 | `audited_clean` | **retained** |
-| 15 | `staggered_dirac_realization_gate_note_2026-05-03` | bounded_theorem | critical | 1000 | 39.47 | `unaudited` | unaudited |
-| 16 | `yt_ew_color_projection_theorem` | no_go | critical | 1062 | 38.55 | `audited_clean` | **retained_no_go** |
-| 17 | `axiom_first_reflection_positivity_theorem_note_2026-04-29` | bounded_theorem | critical | 1043 | 38.53 | `unaudited` | unaudited |
-| 18 | `cpt_exact_note` | positive_theorem | critical | 1170 | 36.69 | `audited_clean` | **retained** |
-| 19 | `ckm_cp_phase_structural_identity_theorem_note_2026-04-24` | positive_theorem | critical | 1074 | 36.57 | `unaudited` | unaudited |
+| 4 | `graph_first_su3_integration_note` | positive_theorem | critical | 1579 | 65.13 | `audited_clean` | **retained** |
+| 5 | `observable_principle_from_axiom_note` | bounded_theorem | critical | 1202 | 64.23 | `unaudited` | unaudited |
+| 6 | `plaquette_self_consistency_note` | bounded_theorem | critical | 1249 | 53.29 | `audited_clean` | **retained_bounded** |
+| 7 | `minimal_axioms_2026-05-03` | meta | critical | 1154 | 48.17 | `unaudited` | meta |
+| 8 | `key_terminology` | meta | critical | 1254 | 46.79 | `unaudited` | meta |
+| 9 | `staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac` | bounded_theorem | critical | 1001 | 44.47 | `unaudited` | unaudited |
+| 10 | `yt_ward_identity_derivation_theorem` | bounded_theorem | critical | 1001 | 43.47 | `unaudited` | unaudited |
+| 11 | `anomaly_forces_time_theorem` | bounded_theorem | critical | 1381 | 43.43 | `unaudited` | unaudited |
+| 12 | `alpha_s_derived_note` | bounded_theorem | critical | 1138 | 42.15 | `unaudited` | unaudited |
+| 13 | `native_gauge_closure_note` | positive_theorem | critical | 1541 | 41.59 | `audited_clean` | **retained** |
+| 14 | `cl3_color_automorphism_theorem` | bounded_theorem | critical | 1097 | 40.60 | `unaudited` | unaudited |
+| 15 | `staggered_dirac_realization_gate_note_2026-05-03` | bounded_theorem | critical | 1001 | 39.47 | `unaudited` | unaudited |
+| 16 | `yt_ew_color_projection_theorem` | no_go | critical | 1063 | 38.55 | `audited_clean` | **retained_no_go** |
+| 17 | `axiom_first_reflection_positivity_theorem_note_2026-04-29` | bounded_theorem | critical | 1044 | 37.53 | `unaudited` | unaudited |
+| 18 | `cpt_exact_note` | positive_theorem | critical | 1171 | 36.70 | `audited_clean` | **retained** |
+| 19 | `ckm_cp_phase_structural_identity_theorem_note_2026-04-24` | positive_theorem | critical | 1075 | 36.57 | `unaudited` | unaudited |
 | 20 | `s3_time_theta_to_slice_coupling_note` | open_gate | critical | 126 | 35.99 | `unaudited` | unaudited |
-| 21 | `three_generation_structure_note` | bounded_theorem | critical | 1206 | 35.74 | `audited_clean` | **retained_bounded** |
-| 22 | `wolfenstein_lambda_a_structural_identities_theorem_note_2026-04-24` | positive_theorem | critical | 1071 | 35.07 | `unaudited` | unaudited |
-| 23 | `staggered_dirac_bz_corner_forcing_theorem_note_2026-05-07` | bounded_theorem | critical | 1002 | 34.97 | `unaudited` | unaudited |
-| 24 | `koide_circulant_character_derivation_note_2026-04-18` | bounded_theorem | critical | 293 | 34.70 | `unaudited` | unaudited |
-| 25 | `s3_time_bilinear_tensor_primitive_note` | open_gate | critical | 1154 | 34.17 | `unaudited` | unaudited |
+| 21 | `three_generation_structure_note` | bounded_theorem | critical | 1207 | 35.74 | `audited_clean` | **retained_bounded** |
+| 22 | `wolfenstein_lambda_a_structural_identities_theorem_note_2026-04-24` | positive_theorem | critical | 1072 | 35.07 | `unaudited` | unaudited |
+| 23 | `staggered_dirac_bz_corner_forcing_theorem_note_2026-05-07` | bounded_theorem | critical | 1003 | 34.97 | `unaudited` | unaudited |
+| 24 | `koide_circulant_character_derivation_note_2026-04-18` | bounded_theorem | critical | 294 | 34.70 | `unaudited` | unaudited |
+| 25 | `s3_time_bilinear_tensor_primitive_note` | open_gate | critical | 1155 | 34.17 | `unaudited` | unaudited |
 
 
 ## Applied audits
@@ -142,6 +142,7 @@ Criticality and load-bearing score are computed from the citation graph alone. T
 | `quark_route2_e_channel_readout_naturality_no_go_note_2026-04-28` | no_go | audit_in_progress | **retained_no_go** | cross_family | codex-gpt-5.5 | A | - |
 | `record_classical_semigroup_boundary_2026-06-06` | positive_theorem | audit_in_progress | **retained** | cross_family | codex-gpt-5.5 | A | - |
 | `record_clock_rate_normalization_gate_2026-06-06` | positive_theorem | audit_in_progress | **retained** | cross_family | codex-gpt-5.5 | A | - |
+| `self_gravity_entropy_note_2026-04-11` | bounded_theorem | audit_in_progress | **retained_bounded** | fresh_context | codex-gpt-5.5 | C | - |
 | `abj_epsilon_index_square_block_no_go_note_2026-05-30` | no_go | ~~audited_clean~~ | **retained_no_go** | fresh_context | codex-gpt-5.5 | A | - |
 | `abj_p_comp_scale_free_singlet_completion_classification_note_2026-06-18` | bounded_theorem | ~~audited_clean~~ | **retained_bounded** | fresh_context | codex-gpt-5.5 | A | - |
 | `abj_p_rec_spintaste_clifford_core_bridge_note_2026-06-18` | bounded_theorem | ~~audited_clean~~ | **retained_bounded** | fresh_context | codex-gpt-5.5 | A | - |
@@ -1069,7 +1070,6 @@ Criticality and load-bearing score are computed from the citation graph alone. T
 | `self_consistency_structured_null_note_2026-04-11` | bounded_theorem | ~~audited_clean~~ | **retained_bounded** | cross_family | codex-gpt-5 | C | - |
 | `self_gravity_backreaction_closure_note` | no_go | ~~audited_clean~~ | **retained_no_go** | fresh_context | codex-gpt-5 | C | - |
 | `self_gravity_born_hardening_note` | no_go | ~~audited_clean~~ | **retained_no_go** | cross_family | codex-gpt-5.5 | C | - |
-| `self_gravity_entropy_note_2026-04-11` | bounded_theorem | ~~audited_clean~~ | **retained_bounded** | fresh_context | codex-gpt-5.5 | C | - |
 | `self_gravity_failure_diagnosis` | no_go | ~~audited_clean~~ | **retained_no_go** | cross_family | codex-gpt-5.5 | C | - |
 | `self_gravity_scaling_note_2026-04-10` | bounded_theorem | ~~audited_clean~~ | **retained_bounded** | cross_family | codex-gpt-5 | B | - |
 | `seventh_family_diagonal_boundary_note` | bounded_theorem | ~~audited_clean~~ | **retained_bounded** | cross_family | codex-gpt-5.5 | A | - |
@@ -14910,19 +14910,6 @@ Five-judge panel breakdown: 4x ('first', 'audited_clean', 'no_go', 'A'); 1x ('se
 - **chain closes:** True — The note is a bounded no-go, not a positive retained mechanism claim. With no cited dependencies, the current runner directly reproduces the zero-epsilon identity, the nonzero-coupling non-convergence, and the non-machine-clean end-to-end Born audit that support that bounded conclusion.
 - **rationale:** The bounded claim surface is narrow: it asserts that the exact zero-coupling identity survives while the nonzero self-gravity/backreaction lane does not promote under strict reduction and Born controls. The current runner recomputes those controls from the stated lattice setup and matches the note's reported values, including zero-epsilon identity, failed nonlinear convergence for nonzero couplings, and nonzero end-to-end Born residual. No upstream dependency or hidden retained mechanism is needed for this bounded no-go read; residual risk is only that the runner is slow and has unclassified output lines, not that the stated bounded conclusion overreaches the computed evidence.
 - **auditor confidence:** high
-
-### `self_gravity_entropy_note_2026-04-11`
-
-- **Note:** [`SELF_GRAVITY_ENTROPY_NOTE_2026-04-11.md`](../../docs/SELF_GRAVITY_ENTROPY_NOTE_2026-04-11.md)
-- **claim_type:** `bounded_theorem`
-- **claim_scope:** Bounded finite diagnostic for scripts/frontier_self_gravity_entropy.py: for the helper-defined MASS=0.30, MU2=0.22, DT=0.12, G_SELF=50.0, N_ITER=20 graph-family packet and listed cuts/ensembles, the single-particle binary occupancy entropy table is mixed and does not establish robust boundary-controlled or area-law-like scaling.
-- **audit_status:** ~~audited_clean~~
-- **effective_status:** **retained_bounded**  (reason: `self`)
-- **auditor:** `codex-self-gravity-entropy-2026-05-26-fresh-context-auditor`  (codex-gpt-5.5; independence=fresh_context)
-- **load-bearing step:** This simple entropy observable does not currently support an area-law claim.  _(class `C`)_
-- **chain closes:** True — The source note's numeric tables and aggregate readout match the cached runner output for the primary script, and the helper source shows the constants and graph families used. The closure is only the finite script-defined diagnostic; it does not inherit or prove a broader self-gravity mechanism or many-body entropy statement.
-- **rationale:** Runner output is completed and matches the source note, but it contains no PASS/assert checks, so runner_check_breakdown is zero and the audit treats the printed finite tables as the evidence surface. The finite data show mixed boundary correlations (+0.122, -0.399, +0.983; ensemble +0.285, -0.088, +0.489) and the observable is explicitly capped at ln(2), so the note's cautious non-support conclusion follows. N1-N8 no-go discipline was applied to the tempting broader area-law obstruction reading: fewer than five alternative area-law routes are closed, upstream no-go witnesses attack mechanism closure rather than this entropy residual, and the runner itself reports some boundary sensitivity; therefore the audit records a bounded finite diagnostic, not a no_go.
-- **auditor confidence:** medium
 
 ### `self_gravity_failure_diagnosis`
 

--- a/docs/audit/AUDIT_QUEUE.md
+++ b/docs/audit/AUDIT_QUEUE.md
@@ -1,13 +1,13 @@
 # Audit Queue
 
-**Total pending:** 1976
-**Ready (all deps at retained-grade/metadata tiers or accepted premises: axiom/primitive nodes and Tier-A admitted derivation targets):** 139
+**Total pending:** 1980
+**Ready (all deps at retained-grade/metadata tiers or accepted premises: axiom/primitive nodes and Tier-A admitted derivation targets):** 142
 
 By criticality:
-- `critical`: 420
+- `critical`: 421
 - `high`: 292
-- `medium`: 524
-- `leaf`: 740
+- `medium`: 525
+- `leaf`: 742
 
 Auditor (current best Codex GPT model at maximum reasoning by default) should pull from the top of this list. Critical claims require cross-confirmation by a second independent clean-room auditor before `audited_clean` lands.
 
@@ -15,56 +15,56 @@ Auditor (current best Codex GPT model at maximum reasoning by default) should pu
 
 | # | claim_id | claim_type | reason | criticality | desc | score | ready | indep required | runner |
 |---:|---|---|---|---|---:|---:|:---:|---|---|
-| 1 | `no_per_site_chirality_theorem_note_2026-05-02` | no_go | unaudited | critical | 1399 | 18.95 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/no_per_site_chirality_check.py` |
-| 2 | `tensor_product_translation_fermion_operator_bridge_narrow_theorem_note_2026-05-25` | positive_theorem | unaudited | critical | 1246 | 21.78 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/tensor_product_translation_fermion_operator_bridge_check_2026_05_25.py` |
-| 3 | `real_diagonal_source_det_positivity_and_log_readout_lemma_note_2026-06-08` | bounded_theorem | unaudited | critical | 1207 | 16.74 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_real_diagonal_source_det_positivity_lemma_2026_06_08.py` |
-| 4 | `staggered_dirac_substep1_grassmann_forcing_bridge_narrow_theorem_note_2026-05-16` | positive_theorem | unaudited | critical | 1107 | 30.61 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_staggered_dirac_substep1_grassmann_forcing_bridge_2026_05_16.py` |
-| 5 | `ew_current_matching_rule_open_gate_note_2026-05-03` | no_go | unaudited | critical | 1106 | 22.61 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_ew_current_matching_rule_no_go.py` |
-| 6 | `cl3_taste_generation_theorem` | bounded_theorem | unaudited | critical | 1091 | 24.59 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_cl3_taste_abstract_c8_orbit_scope_2026_06_12.py` |
-| 7 | `g_bare_parent_finite_link_wilson_beta6_bridge_note_2026-06-18` | bounded_theorem | unaudited | critical | 1076 | 14.07 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/g_bare_parent_finite_link_wilson_beta6_bridge_2026_06_18.py` |
-| 8 | `staggered_dirac_substep1_u4_conditional_single_module_narrow_bounded_note_2026-05-17` | positive_theorem | unaudited | critical | 1073 | 16.07 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_staggered_dirac_substep1_u4_conditional_single_module_2026_05_17.py` |
-| 9 | `axiom_first_rp_two_step_transfer_matrix_positivity_note_2026-05-28` | bounded_theorem | unaudited | critical | 1070 | 25.07 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/axiom_first_rp_two_step_transfer_matrix_positivity.py` |
-| 10 | `staggered_dirac_substep1_statistics_agnostic_no_forcing_note_2026-05-25` | no_go | unaudited | critical | 1034 | 18.02 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_staggered_dirac_substep1_statistics_agnostic_no_forcing_discriminator.py` |
-| 11 | `axiom_first_cluster_decomposition_theorem_note_2026-04-29` | bounded_theorem | unaudited | critical | 1022 | 22.50 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/axiom_first_cluster_decomposition_check.py` |
-| 12 | `gleason_on_qubit_lattice_projection_lattice_narrow_theorem_note_2026-05-20` | positive_theorem | unaudited | critical | 1012 | 16.98 | Y | fresh_context_or_stronger_with_cross_confirmation | - |
-| 13 | `busch_povm_effect_gleason_qubit_authority_bridge_narrow_theorem_note_2026-06-05` | bounded_theorem | unaudited | critical | 1012 | 15.98 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_busch_povm_effect_gleason_qubit_2026_06_05.py` |
-| 14 | `record_clock_rate_normalization_gate_2026-06-06` | positive_theorem | audit_in_progress | critical | 1011 | 15.98 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_record_clock_rate_normalization_gate_2026_06_06.py` |
-| 15 | `record_formation_not_unconditionally_forced_by_minimal_axioms_narrow_no_go_note_2026-06-06` | no_go | unaudited | critical | 1008 | 17.98 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_record_formation_not_unconditionally_forced_by_minimal_axioms.py` |
-| 16 | `tensor_composition_requires_local_tomography_beyond_locality_narrow_no_go_note_2026-06-03` | no_go | unaudited | critical | 1004 | 14.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_tensor_composition_requires_local_tomography_exact.py` |
-| 17 | `quantum_local_algebra_does_not_force_boost_action_faith_no_go_note_2026-06-02` | no_go | unaudited | critical | 1003 | 15.97 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/quantum_local_algebra_boost_action_faith_no_go_2026_06_02.py` |
-| 18 | `pmns_graph_first_residual_antiunitary_narrow_theorem_note_2026-05-16` | positive_theorem | audit_in_progress | critical | 1002 | 14.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_pmns_graph_first_residual_antiunitary_2026-05-16.py` |
-| 19 | `dm_leptogenesis_pmns_transport_selector_firewall_note_2026-06-17` | no_go | audit_in_progress | critical | 1002 | 13.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_dm_leptogenesis_pmns_transport_selector_firewall_2026_06_17.py` |
-| 20 | `record_local_finite_atom_availability_narrow_theorem_note_2026-06-17` | positive_theorem | unaudited | critical | 1002 | 13.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_record_local_finite_atom_availability_2026_06_17.py` |
-| 21 | `dm_leptogenesis_pmns_transport_extremal_source_candidate_note_2026-04-16` | bounded_theorem | audit_in_progress | critical | 1001 | 16.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_dm_leptogenesis_pmns_transport_extremal_source_candidate.py` |
-| 22 | `observable_principle_record_scalar_map_no_go_note_2026-06-05` | no_go | unaudited | critical | 1001 | 15.97 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_observable_principle_record_scalar_map_no_go_2026_06_05.py` |
-| 23 | `pmns_graph_first_axis_alignment_note` | bounded_theorem | audit_in_progress | critical | 1001 | 14.97 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_pmns_graph_first_axis_alignment.py` |
-| 24 | `pmns_tm2_residual_consequence_bounded_note_2026-05-26` | bounded_theorem | audit_in_progress | critical | 1001 | 13.97 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/pmns_tm2_residual_consequence_runner.py` |
-| 25 | `single_clock_physical_clock_admission_inventory_n5_support_note_2026-06-17` | bounded_theorem | unaudited | critical | 1001 | 13.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py` |
-| 26 | `yt_ward_identity_derivation_theorem` | bounded_theorem | unaudited | critical | 1000 | 43.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_yt_ward_identity_derivation.py` |
-| 27 | `gauge_vacuum_plaquette_residual_environment_all_weight_convolution_identification_narrow_theorem_note_2026-05-17` | bounded_theorem | unaudited | critical | 388 | 13.10 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_gauge_vacuum_plaquette_residual_environment_all_weight_convolution_identification.py` |
-| 28 | `koide_higgs_dressed_resolvent_root_theorem_note_2026-04-20` | positive_theorem | unaudited | critical | 338 | 10.40 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_koide_higgs_dressed_resolvent_root_theorem.py` |
-| 29 | `koide_q_delta_linking_relation_theorem_note_2026-04-20` | decoration | unaudited | critical | 323 | 13.34 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_koide_q_delta_formal_ratio_repair.py` |
-| 30 | `higgs_mass_from_axiom_status_correction_audit_note_2026-05-02` | open_gate | unaudited | critical | 297 | 11.22 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_higgs_mass_status_audit.py` |
-| 31 | `lattice_greens_maradudin_asymptotic_accepted_premise_bridge_bounded_note_2026-05-27` | bounded_theorem | unaudited | critical | 292 | 8.70 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py` |
-| 32 | `clifford_chirality_dimension_narrow_theorem_note_2026-05-10` | positive_theorem | unaudited | critical | 266 | 9.06 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_clifford_chirality_dimension_narrow.py` |
-| 33 | `poisson_self_gravity_mechanism_note` | no_go | audit_in_progress | critical | 251 | 12.48 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/poisson_self_gravity_mechanism.py` |
-| 34 | `quark_route2_e_channel_readout_naturality_no_go_note_2026-04-28` | no_go | audit_in_progress | critical | 190 | 28.08 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_quark_route2_e_channel_readout_naturality_no_go.py` |
-| 35 | `rconn_kappa_ew_register_not_read_color_trace_open_gate_note_2026-06-08` | open_gate | unaudited | critical | 63 | 14.00 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_rconn_kappa_ew_register_not_read.py` |
-| 36 | `record_classical_semigroup_boundary_2026-06-06` | positive_theorem | audit_in_progress | critical | 43 | 17.96 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_record_classical_semigroup_boundary_2026_06_06.py` |
-| 37 | `abj_p_hy_retained_bounded_supplier_wiring_note_2026-06-18` | bounded_theorem | unaudited | critical | 1385 | 13.94 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_abj_phy_retained_bounded_supplier_wiring_2026_06_18.py` |
-| 38 | `anomaly_forces_time_abj_inconsistency_accepted_premise_bridge_bounded_note_2026-05-26` | bounded_theorem | unaudited | critical | 1384 | 15.44 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/anomaly_forces_time_abj_inconsistency_accepted_premise_runner.py` |
-| 39 | `anomaly_forces_time_theorem` | bounded_theorem | unaudited | critical | 1380 | 43.43 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_anomaly_forces_time.py` |
-| 40 | `s3_time_spacetime_tensor_primitive_note` | bounded_theorem | unaudited | critical | 1212 | 15.74 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_s3_time_spacetime_tensor_primitive.py` |
-| 41 | `observable_principle_t1d_determinant_readout_independence_no_go_note_2026-06-16` | no_go | unaudited | critical | 1205 | 15.74 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_observable_principle_t1d_determinant_readout_independence_2026_06_16.py` |
-| 42 | `observable_principle_t1d_positive_diagonal_readout_classifier_note_2026-06-18` | bounded_theorem | unaudited | critical | 1203 | 14.73 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/observable_principle_t1d_positive_diagonal_readout_classifier_2026_06_18.py` |
-| 43 | `observable_principle_t1d_determinant_context_quotient_bridge_note_2026-06-18` | bounded_theorem | unaudited | critical | 1202 | 15.23 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/observable_principle_t1d_determinant_context_quotient_bridge_2026_06_18.py` |
-| 44 | `observable_principle_from_axiom_note` | bounded_theorem | unaudited | critical | 1201 | 64.23 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_hierarchy_observable_principle_from_axiom.py` |
-| 45 | `staggered_dirac_kinetic_class_forcing_narrow_theorem_note_2026-06-10` | bounded_theorem | unaudited | critical | 1193 | 20.22 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/staggered_dirac_kinetic_class_forcing_check_2026_06_10.py` |
-| 46 | `one_generation_matter_closure_note` | bounded_theorem | unaudited | critical | 1162 | 29.68 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_right_handed_sector.py` |
-| 47 | `s3_time_transfer_matrix_bridge_note` | bounded_theorem | unaudited | critical | 1157 | 15.68 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_s3_time_transfer_matrix_bridge.py` |
-| 48 | `s3_time_bilinear_tensor_primitive_note` | open_gate | unaudited | critical | 1154 | 34.17 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_s3_time_bilinear_tensor_primitive.py` |
-| 49 | `yt_vertex_power_derivation` | bounded_theorem | unaudited | critical | 1140 | 15.16 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_vertex_power.py` |
-| 50 | `yt_vertex_power_operator_counting_lemma_note_2026-05-17` | bounded_theorem | unaudited | critical | 1139 | 14.65 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_yt_vertex_power_operator_counting_lemma.py` |
+| 1 | `no_per_site_chirality_theorem_note_2026-05-02` | no_go | unaudited | critical | 1401 | 19.45 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/no_per_site_chirality_check.py` |
+| 2 | `tensor_product_translation_fermion_operator_bridge_narrow_theorem_note_2026-05-25` | positive_theorem | unaudited | critical | 1247 | 22.29 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/tensor_product_translation_fermion_operator_bridge_check_2026_05_25.py` |
+| 3 | `real_diagonal_source_det_positivity_and_log_readout_lemma_note_2026-06-08` | bounded_theorem | unaudited | critical | 1209 | 16.24 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_real_diagonal_source_det_positivity_lemma_2026_06_08.py` |
+| 4 | `staggered_dirac_substep1_grassmann_forcing_bridge_narrow_theorem_note_2026-05-16` | positive_theorem | unaudited | critical | 1108 | 30.61 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_staggered_dirac_substep1_grassmann_forcing_bridge_2026_05_16.py` |
+| 5 | `ew_current_matching_rule_open_gate_note_2026-05-03` | no_go | unaudited | critical | 1108 | 22.11 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_ew_current_matching_rule_no_go.py` |
+| 6 | `cl3_taste_generation_theorem` | bounded_theorem | unaudited | critical | 1092 | 24.59 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_cl3_taste_abstract_c8_orbit_scope_2026_06_12.py` |
+| 7 | `g_bare_parent_finite_link_wilson_beta6_bridge_note_2026-06-18` | bounded_theorem | unaudited | critical | 1077 | 14.07 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/g_bare_parent_finite_link_wilson_beta6_bridge_2026_06_18.py` |
+| 8 | `staggered_dirac_substep1_u4_conditional_single_module_narrow_bounded_note_2026-05-17` | positive_theorem | unaudited | critical | 1074 | 16.07 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_staggered_dirac_substep1_u4_conditional_single_module_2026_05_17.py` |
+| 9 | `axiom_first_rp_two_step_transfer_matrix_positivity_note_2026-05-28` | bounded_theorem | unaudited | critical | 1071 | 24.07 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/axiom_first_rp_two_step_transfer_matrix_positivity.py` |
+| 10 | `staggered_dirac_substep1_statistics_agnostic_no_forcing_note_2026-05-25` | no_go | unaudited | critical | 1035 | 18.02 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_staggered_dirac_substep1_statistics_agnostic_no_forcing_discriminator.py` |
+| 11 | `axiom_first_cluster_decomposition_theorem_note_2026-04-29` | bounded_theorem | unaudited | critical | 1023 | 22.50 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/axiom_first_cluster_decomposition_check.py` |
+| 12 | `gleason_on_qubit_lattice_projection_lattice_narrow_theorem_note_2026-05-20` | positive_theorem | unaudited | critical | 1013 | 16.99 | Y | fresh_context_or_stronger_with_cross_confirmation | - |
+| 13 | `busch_povm_effect_gleason_qubit_authority_bridge_narrow_theorem_note_2026-06-05` | bounded_theorem | unaudited | critical | 1013 | 15.99 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_busch_povm_effect_gleason_qubit_2026_06_05.py` |
+| 14 | `record_clock_rate_normalization_gate_2026-06-06` | positive_theorem | audit_in_progress | critical | 1012 | 15.98 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_record_clock_rate_normalization_gate_2026_06_06.py` |
+| 15 | `record_formation_not_unconditionally_forced_by_minimal_axioms_narrow_no_go_note_2026-06-06` | no_go | unaudited | critical | 1009 | 17.98 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_record_formation_not_unconditionally_forced_by_minimal_axioms.py` |
+| 16 | `tensor_composition_requires_local_tomography_beyond_locality_narrow_no_go_note_2026-06-03` | no_go | unaudited | critical | 1005 | 14.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_tensor_composition_requires_local_tomography_exact.py` |
+| 17 | `quantum_local_algebra_does_not_force_boost_action_faith_no_go_note_2026-06-02` | no_go | unaudited | critical | 1004 | 15.97 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/quantum_local_algebra_boost_action_faith_no_go_2026_06_02.py` |
+| 18 | `pmns_graph_first_residual_antiunitary_narrow_theorem_note_2026-05-16` | positive_theorem | audit_in_progress | critical | 1003 | 14.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_pmns_graph_first_residual_antiunitary_2026-05-16.py` |
+| 19 | `dm_leptogenesis_pmns_transport_selector_firewall_note_2026-06-17` | no_go | audit_in_progress | critical | 1003 | 13.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_dm_leptogenesis_pmns_transport_selector_firewall_2026_06_17.py` |
+| 20 | `record_local_finite_atom_availability_narrow_theorem_note_2026-06-17` | positive_theorem | unaudited | critical | 1003 | 13.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_record_local_finite_atom_availability_2026_06_17.py` |
+| 21 | `dm_leptogenesis_pmns_transport_extremal_source_candidate_note_2026-04-16` | bounded_theorem | audit_in_progress | critical | 1002 | 16.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_dm_leptogenesis_pmns_transport_extremal_source_candidate.py` |
+| 22 | `observable_principle_record_scalar_map_no_go_note_2026-06-05` | no_go | unaudited | critical | 1002 | 15.97 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_observable_principle_record_scalar_map_no_go_2026_06_05.py` |
+| 23 | `pmns_graph_first_axis_alignment_note` | bounded_theorem | audit_in_progress | critical | 1002 | 14.97 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_pmns_graph_first_axis_alignment.py` |
+| 24 | `pmns_tm2_residual_consequence_bounded_note_2026-05-26` | bounded_theorem | audit_in_progress | critical | 1002 | 13.97 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/pmns_tm2_residual_consequence_runner.py` |
+| 25 | `single_clock_physical_clock_admission_inventory_n5_support_note_2026-06-17` | bounded_theorem | unaudited | critical | 1002 | 13.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py` |
+| 26 | `yt_ward_identity_derivation_theorem` | bounded_theorem | unaudited | critical | 1001 | 43.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_yt_ward_identity_derivation.py` |
+| 27 | `gauge_vacuum_plaquette_residual_environment_all_weight_convolution_identification_narrow_theorem_note_2026-05-17` | bounded_theorem | unaudited | critical | 389 | 13.11 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/audit_companion_gauge_vacuum_plaquette_residual_environment_all_weight_convolution_identification.py` |
+| 28 | `koide_higgs_dressed_resolvent_root_theorem_note_2026-04-20` | positive_theorem | unaudited | critical | 339 | 10.41 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_koide_higgs_dressed_resolvent_root_theorem.py` |
+| 29 | `koide_q_delta_linking_relation_theorem_note_2026-04-20` | decoration | unaudited | critical | 324 | 13.34 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_koide_q_delta_formal_ratio_repair.py` |
+| 30 | `higgs_mass_from_axiom_status_correction_audit_note_2026-05-02` | open_gate | unaudited | critical | 298 | 11.22 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_higgs_mass_status_audit.py` |
+| 31 | `lattice_greens_maradudin_asymptotic_accepted_premise_bridge_bounded_note_2026-05-27` | bounded_theorem | unaudited | critical | 293 | 8.70 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py` |
+| 32 | `clifford_chirality_dimension_narrow_theorem_note_2026-05-10` | positive_theorem | unaudited | critical | 267 | 9.07 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_clifford_chirality_dimension_narrow.py` |
+| 33 | `poisson_self_gravity_mechanism_note` | no_go | audit_in_progress | critical | 252 | 12.48 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/poisson_self_gravity_mechanism.py` |
+| 34 | `self_gravity_entropy_note_2026-04-11` | bounded_theorem | audit_in_progress | critical | 250 | 8.47 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_self_gravity_entropy.py` |
+| 35 | `quark_route2_e_channel_readout_naturality_no_go_note_2026-04-28` | no_go | audit_in_progress | critical | 190 | 28.08 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_quark_route2_e_channel_readout_naturality_no_go.py` |
+| 36 | `rconn_kappa_ew_register_not_read_color_trace_open_gate_note_2026-06-08` | open_gate | unaudited | critical | 63 | 14.00 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_rconn_kappa_ew_register_not_read.py` |
+| 37 | `record_classical_semigroup_boundary_2026-06-06` | positive_theorem | audit_in_progress | critical | 43 | 17.96 | Y | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_record_classical_semigroup_boundary_2026_06_06.py` |
+| 38 | `abj_p_hy_retained_bounded_supplier_wiring_note_2026-06-18` | bounded_theorem | unaudited | critical | 1386 | 13.94 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_abj_phy_retained_bounded_supplier_wiring_2026_06_18.py` |
+| 39 | `anomaly_forces_time_abj_inconsistency_accepted_premise_bridge_bounded_note_2026-05-26` | bounded_theorem | unaudited | critical | 1385 | 15.44 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/anomaly_forces_time_abj_inconsistency_accepted_premise_runner.py` |
+| 40 | `anomaly_forces_time_theorem` | bounded_theorem | unaudited | critical | 1381 | 43.43 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_anomaly_forces_time.py` |
+| 41 | `s3_time_spacetime_tensor_primitive_note` | bounded_theorem | unaudited | critical | 1213 | 15.75 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_s3_time_spacetime_tensor_primitive.py` |
+| 42 | `observable_principle_t1d_determinant_readout_independence_no_go_note_2026-06-16` | no_go | unaudited | critical | 1206 | 15.74 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_observable_principle_t1d_determinant_readout_independence_2026_06_16.py` |
+| 43 | `observable_principle_t1d_positive_diagonal_readout_classifier_note_2026-06-18` | bounded_theorem | unaudited | critical | 1204 | 14.73 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/observable_principle_t1d_positive_diagonal_readout_classifier_2026_06_18.py` |
+| 44 | `observable_principle_t1d_determinant_context_quotient_bridge_note_2026-06-18` | bounded_theorem | unaudited | critical | 1203 | 15.23 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/observable_principle_t1d_determinant_context_quotient_bridge_2026_06_18.py` |
+| 45 | `observable_principle_from_axiom_note` | bounded_theorem | unaudited | critical | 1202 | 64.23 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_hierarchy_observable_principle_from_axiom.py` |
+| 46 | `staggered_dirac_kinetic_class_forcing_narrow_theorem_note_2026-06-10` | bounded_theorem | unaudited | critical | 1193 | 19.72 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/staggered_dirac_kinetic_class_forcing_check_2026_06_10.py` |
+| 47 | `one_generation_matter_closure_note` | bounded_theorem | unaudited | critical | 1163 | 29.68 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_right_handed_sector.py` |
+| 48 | `s3_time_transfer_matrix_bridge_note` | bounded_theorem | unaudited | critical | 1158 | 15.68 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_s3_time_transfer_matrix_bridge.py` |
+| 49 | `s3_time_bilinear_tensor_primitive_note` | open_gate | unaudited | critical | 1155 | 34.17 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_s3_time_bilinear_tensor_primitive.py` |
+| 50 | `yt_vertex_power_derivation` | bounded_theorem | unaudited | critical | 1141 | 15.16 |  | fresh_context_or_stronger_with_cross_confirmation | `scripts/frontier_vertex_power.py` |
 
 ## Citation cycle break targets
 
@@ -72,14 +72,14 @@ Auditor (current best Codex GPT model at maximum reasoning by default) should pu
 
 | # | cycle_id | length | max_desc | primary break target | criticality | audit_status |
 |---:|---|---:|---:|---|---|---|
-| 1 | `cycle-0001` | 3 | 1000 | `axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03` | critical | unaudited |
-| 2 | `cycle-0002` | 35 | 1000 | `axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03` | critical | unaudited |
-| 3 | `cycle-0003` | 35 | 1000 | `axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03` | critical | unaudited |
-| 4 | `cycle-0004` | 36 | 1000 | `axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03` | critical | unaudited |
-| 5 | `cycle-0005` | 36 | 1000 | `axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03` | critical | unaudited |
-| 6 | `cycle-0006` | 2 | 377 | `quark_cp_carrier_completion_note_2026-04-18` | critical | unaudited |
-| 7 | `cycle-0007` | 2 | 285 | `bridge_gap_hk_cube_perron_note_2026-05-06` | critical | unaudited |
-| 8 | `cycle-0008` | 3 | 285 | `bridge_gap_action_form_uniqueness_no_go_note_2026-05-06` | critical | unaudited |
+| 1 | `cycle-0001` | 3 | 1001 | `axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03` | critical | unaudited |
+| 2 | `cycle-0002` | 35 | 1001 | `axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03` | critical | unaudited |
+| 3 | `cycle-0003` | 35 | 1001 | `axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03` | critical | unaudited |
+| 4 | `cycle-0004` | 36 | 1001 | `axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03` | critical | unaudited |
+| 5 | `cycle-0005` | 36 | 1001 | `axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03` | critical | unaudited |
+| 6 | `cycle-0006` | 2 | 378 | `quark_cp_carrier_completion_note_2026-04-18` | critical | unaudited |
+| 7 | `cycle-0007` | 2 | 286 | `bridge_gap_hk_cube_perron_note_2026-05-06` | critical | unaudited |
+| 8 | `cycle-0008` | 3 | 286 | `bridge_gap_action_form_uniqueness_no_go_note_2026-05-06` | critical | unaudited |
 | 9 | `cycle-0009` | 2 | 58 | `hubble_lane5_cosmic_history_ratio_necessity_no_go_note_2026-04-26` | high | unaudited |
 | 10 | `cycle-0010` | 2 | 1 | `ep_record_stiffness_conditional_shared_coupling_template_note_2026-06-07` | leaf | unaudited |
 | 11 | `cycle-0011` | 2 | 1 | `gate_b_context_independence_no_go_note_2026-06-17` | leaf | unaudited |

--- a/docs/audit/data/audit_queue.json
+++ b/docs/audit/data/audit_queue.json
@@ -1,9 +1,9 @@
 {
   "by_criticality": {
-    "critical": 420,
+    "critical": 421,
     "high": 292,
-    "leaf": 740,
-    "medium": 524
+    "leaf": 742,
+    "medium": 525
   },
   "cycle_break_target_count": 14,
   "cycle_break_targets": [
@@ -16,7 +16,7 @@
       "cycle_id": "cycle-0001",
       "cycle_length": 3,
       "instruction": "Re-audit this node with the prompt instruction that its co-cycle citations ['single_clock_apbc_axis_label_bridge_bounded_theorem_note_2026-06-16', 'single_clock_axis_selection_from_record_durability_narrow_no_go_note_2026-06-11'] are informational/'see also' references, not load-bearing dependencies. If the chain truly closes without those citations, return audited_clean and name the non-load-bearing co-cycle links in the rationale; a separate source-graph repair pass must then strip or rewrite those markdown links before effective_status can leave retained_pending_chain. Otherwise return audited_conditional with repair_class=missing_dependency_edge naming the node that should be promoted upstream.",
-      "max_transitive_descendants": 1000,
+      "max_transitive_descendants": 1001,
       "primary_break_target": "axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03",
       "primary_break_target_audit_status": "unaudited",
       "primary_break_target_criticality": "critical",
@@ -63,7 +63,7 @@
       "cycle_id": "cycle-0002",
       "cycle_length": 35,
       "instruction": "Re-audit this node with the prompt instruction that its co-cycle citations ['dm_leptogenesis_exact_kernel_closure_note_2026-04-15', 'dm_leptogenesis_ne_projected_source_law_derivation_note_2026-04-16', 'dm_leptogenesis_ne_projected_source_triplet_sign_theorem_note_2026-04-16', 'dm_neutrino_codd_bosonic_normalization_theorem_note_2026-04-15', 'dm_neutrino_exact_h_source_surface_preimage_bundle_theorem_note_2026-04-16', 'dm_neutrino_source_surface_active_affine_point_selection_boundary_note_2026-04-16', 'dm_neutrino_source_surface_active_half_plane_theorem_note_2026-04-16', 'dm_neutrino_source_surface_p3_sylvester_linear_path_signature_theorem_note_2026-04-18', 'dm_neutrino_source_surface_shift_quotient_bundle_theorem_note_2026-04-16', 'higgs_mass_derived_note', 'higgs_vacuum_explicit_systematic_note', 'higgs_z3_charge_pmns_gauge_redundancy_theorem_note_2026-04-17', 'neutrino_dirac_z3_support_trichotomy_note', 'neutrino_mass_reduction_to_dirac_note', 'observable_principle_p1_br_license_from_record_capacity_narrow_no_go_note_2026-06-10', 'observable_principle_p1_cap_k_from_finite_speed_registration_narrow_theorem_note_2026-06-10', 'observable_principle_p1_exponent_barrier_parameter_selector_narrow_theorem_note_2026-06-10', 'observable_principle_p1_nu_license_from_retained_surface_narrow_no_go_note_2026-06-10', 'pmns_from_dm_neutrino_source_h_diagonalization_closure_theorem_note_2026-04-17', 'pmns_sector_exchange_nonforcing_note', 'pmns_sector_orientation_orbit_note', 'pmns_selector_bank_nonrealization_note', 'pmns_selector_class_space_uniqueness_note', 'pmns_selector_sector_odd_reduction_note', 'pmns_selector_unique_amplitude_slot_note', 'pmns_tm2_magic_residual_dynamical_generator_narrow_theorem_note_2026-06-05', 'pmns_tm2_trimaximal_column_from_record_central_sector_narrow_theorem_note_2026-06-05', 'record_outcome_observable_principle_canonical_proposal_note_2026-06-05', 'single_clock_apbc_axis_label_bridge_bounded_theorem_note_2026-06-16', 'single_clock_axis_selection_from_record_durability_narrow_no_go_note_2026-06-11', 'staggered_dirac_gate_closure_synthesis_theorem_note_2026-05-17', 'staggered_dirac_realization_gate_note_2026-05-03', 'yt_flagship_boundary_note', 'yt_ward_identity_derivation_theorem'] are informational/'see also' references, not load-bearing dependencies. If the chain truly closes without those citations, return audited_clean and name the non-load-bearing co-cycle links in the rationale; a separate source-graph repair pass must then strip or rewrite those markdown links before effective_status can leave retained_pending_chain. Otherwise return audited_conditional with repair_class=missing_dependency_edge naming the node that should be promoted upstream.",
-      "max_transitive_descendants": 1000,
+      "max_transitive_descendants": 1001,
       "primary_break_target": "axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03",
       "primary_break_target_audit_status": "unaudited",
       "primary_break_target_criticality": "critical",
@@ -110,7 +110,7 @@
       "cycle_id": "cycle-0003",
       "cycle_length": 35,
       "instruction": "Re-audit this node with the prompt instruction that its co-cycle citations ['dm_leptogenesis_exact_kernel_closure_note_2026-04-15', 'dm_leptogenesis_ne_projected_source_law_derivation_note_2026-04-16', 'dm_leptogenesis_ne_projected_source_triplet_sign_theorem_note_2026-04-16', 'dm_neutrino_codd_bosonic_normalization_theorem_note_2026-04-15', 'dm_neutrino_exact_h_source_surface_preimage_bundle_theorem_note_2026-04-16', 'dm_neutrino_source_surface_active_affine_point_selection_boundary_note_2026-04-16', 'dm_neutrino_source_surface_active_half_plane_theorem_note_2026-04-16', 'dm_neutrino_source_surface_p3_sylvester_linear_path_signature_theorem_note_2026-04-18', 'dm_neutrino_source_surface_shift_quotient_bundle_theorem_note_2026-04-16', 'higgs_mass_derived_note', 'higgs_vacuum_explicit_systematic_note', 'higgs_z3_charge_pmns_gauge_redundancy_theorem_note_2026-04-17', 'neutrino_dirac_z3_support_trichotomy_note', 'neutrino_mass_reduction_to_dirac_note', 'observable_principle_p1_br_license_from_record_capacity_narrow_no_go_note_2026-06-10', 'observable_principle_p1_cap_k_from_finite_speed_registration_narrow_theorem_note_2026-06-10', 'observable_principle_p1_exponent_barrier_parameter_selector_narrow_theorem_note_2026-06-10', 'observable_principle_p1_nu_license_from_retained_surface_narrow_no_go_note_2026-06-10', 'pmns_from_dm_neutrino_source_h_diagonalization_closure_theorem_note_2026-04-17', 'pmns_sector_exchange_nonforcing_note', 'pmns_sector_orientation_orbit_note', 'pmns_selector_bank_nonrealization_note', 'pmns_selector_class_space_uniqueness_note', 'pmns_selector_sector_odd_reduction_note', 'pmns_selector_unique_amplitude_slot_note', 'pmns_tm2_magic_residual_dynamical_generator_narrow_theorem_note_2026-06-05', 'pmns_tm2_trimaximal_column_from_record_central_sector_narrow_theorem_note_2026-06-05', 'record_outcome_observable_principle_canonical_proposal_note_2026-06-05', 'single_clock_apbc_axis_label_bridge_bounded_theorem_note_2026-06-16', 'single_clock_axis_selection_from_record_durability_narrow_no_go_note_2026-06-11', 'staggered_dirac_physical_species_direct_theorem_note_2026-05-07', 'staggered_dirac_realization_gate_note_2026-05-03', 'yt_flagship_boundary_note', 'yt_ward_identity_derivation_theorem'] are informational/'see also' references, not load-bearing dependencies. If the chain truly closes without those citations, return audited_clean and name the non-load-bearing co-cycle links in the rationale; a separate source-graph repair pass must then strip or rewrite those markdown links before effective_status can leave retained_pending_chain. Otherwise return audited_conditional with repair_class=missing_dependency_edge naming the node that should be promoted upstream.",
-      "max_transitive_descendants": 1000,
+      "max_transitive_descendants": 1001,
       "primary_break_target": "axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03",
       "primary_break_target_audit_status": "unaudited",
       "primary_break_target_criticality": "critical",
@@ -158,7 +158,7 @@
       "cycle_id": "cycle-0004",
       "cycle_length": 36,
       "instruction": "Re-audit this node with the prompt instruction that its co-cycle citations ['dm_leptogenesis_exact_kernel_closure_note_2026-04-15', 'dm_leptogenesis_ne_projected_source_law_derivation_note_2026-04-16', 'dm_leptogenesis_ne_projected_source_triplet_sign_theorem_note_2026-04-16', 'dm_neutrino_codd_bosonic_normalization_theorem_note_2026-04-15', 'dm_neutrino_exact_h_source_surface_preimage_bundle_theorem_note_2026-04-16', 'dm_neutrino_source_surface_active_affine_point_selection_boundary_note_2026-04-16', 'dm_neutrino_source_surface_active_half_plane_theorem_note_2026-04-16', 'dm_neutrino_source_surface_p3_sylvester_linear_path_signature_theorem_note_2026-04-18', 'dm_neutrino_source_surface_shift_quotient_bundle_theorem_note_2026-04-16', 'higgs_mass_derived_note', 'higgs_vacuum_explicit_systematic_note', 'higgs_z3_charge_pmns_gauge_redundancy_theorem_note_2026-04-17', 'neutrino_dirac_z3_support_trichotomy_note', 'neutrino_mass_reduction_to_dirac_note', 'observable_principle_p1_br_license_from_record_capacity_narrow_no_go_note_2026-06-10', 'observable_principle_p1_cap_k_from_finite_speed_registration_narrow_theorem_note_2026-06-10', 'observable_principle_p1_exponent_barrier_parameter_selector_narrow_theorem_note_2026-06-10', 'observable_principle_p1_nu_license_from_retained_surface_narrow_no_go_note_2026-06-10', 'pmns_from_dm_neutrino_source_h_diagonalization_closure_theorem_note_2026-04-17', 'pmns_sector_exchange_nonforcing_note', 'pmns_sector_orientation_orbit_note', 'pmns_selector_bank_nonrealization_note', 'pmns_selector_class_space_uniqueness_note', 'pmns_selector_sector_odd_reduction_note', 'pmns_selector_unique_amplitude_slot_note', 'pmns_tm2_magic_residual_dynamical_generator_narrow_theorem_note_2026-06-05', 'pmns_tm2_trimaximal_column_from_record_central_sector_narrow_theorem_note_2026-06-05', 'record_outcome_observable_principle_canonical_proposal_note_2026-06-05', 'single_clock_apbc_axis_label_bridge_bounded_theorem_note_2026-06-16', 'single_clock_axis_selection_from_record_durability_narrow_no_go_note_2026-06-11', 'staggered_dirac_gate_closure_synthesis_theorem_note_2026-05-17', 'staggered_dirac_realization_gate_note_2026-05-03', 'staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac', 'yt_flagship_boundary_note', 'yt_ward_identity_derivation_theorem'] are informational/'see also' references, not load-bearing dependencies. If the chain truly closes without those citations, return audited_clean and name the non-load-bearing co-cycle links in the rationale; a separate source-graph repair pass must then strip or rewrite those markdown links before effective_status can leave retained_pending_chain. Otherwise return audited_conditional with repair_class=missing_dependency_edge naming the node that should be promoted upstream.",
-      "max_transitive_descendants": 1000,
+      "max_transitive_descendants": 1001,
       "primary_break_target": "axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03",
       "primary_break_target_audit_status": "unaudited",
       "primary_break_target_criticality": "critical",
@@ -206,7 +206,7 @@
       "cycle_id": "cycle-0005",
       "cycle_length": 36,
       "instruction": "Re-audit this node with the prompt instruction that its co-cycle citations ['dm_leptogenesis_exact_kernel_closure_note_2026-04-15', 'dm_leptogenesis_ne_projected_source_law_derivation_note_2026-04-16', 'dm_leptogenesis_ne_projected_source_triplet_sign_theorem_note_2026-04-16', 'dm_neutrino_codd_bosonic_normalization_theorem_note_2026-04-15', 'dm_neutrino_exact_h_source_surface_preimage_bundle_theorem_note_2026-04-16', 'dm_neutrino_source_surface_active_affine_point_selection_boundary_note_2026-04-16', 'dm_neutrino_source_surface_active_half_plane_theorem_note_2026-04-16', 'dm_neutrino_source_surface_p3_sylvester_linear_path_signature_theorem_note_2026-04-18', 'dm_neutrino_source_surface_shift_quotient_bundle_theorem_note_2026-04-16', 'higgs_mass_derived_note', 'higgs_vacuum_explicit_systematic_note', 'higgs_z3_charge_pmns_gauge_redundancy_theorem_note_2026-04-17', 'neutrino_dirac_z3_support_trichotomy_note', 'neutrino_mass_reduction_to_dirac_note', 'observable_principle_p1_br_license_from_record_capacity_narrow_no_go_note_2026-06-10', 'observable_principle_p1_cap_k_from_finite_speed_registration_narrow_theorem_note_2026-06-10', 'observable_principle_p1_exponent_barrier_parameter_selector_narrow_theorem_note_2026-06-10', 'observable_principle_p1_nu_license_from_retained_surface_narrow_no_go_note_2026-06-10', 'pmns_from_dm_neutrino_source_h_diagonalization_closure_theorem_note_2026-04-17', 'pmns_sector_exchange_nonforcing_note', 'pmns_sector_orientation_orbit_note', 'pmns_selector_bank_nonrealization_note', 'pmns_selector_class_space_uniqueness_note', 'pmns_selector_sector_odd_reduction_note', 'pmns_selector_unique_amplitude_slot_note', 'pmns_tm2_magic_residual_dynamical_generator_narrow_theorem_note_2026-06-05', 'pmns_tm2_trimaximal_column_from_record_central_sector_narrow_theorem_note_2026-06-05', 'record_outcome_observable_principle_canonical_proposal_note_2026-06-05', 'single_clock_apbc_axis_label_bridge_bounded_theorem_note_2026-06-16', 'single_clock_axis_selection_from_record_durability_narrow_no_go_note_2026-06-11', 'staggered_dirac_realization_gate_note_2026-05-03', 'staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac', 'staggered_dirac_substep4_labeling_no_go_note_2026-05-17', 'yt_flagship_boundary_note', 'yt_ward_identity_derivation_theorem'] are informational/'see also' references, not load-bearing dependencies. If the chain truly closes without those citations, return audited_clean and name the non-load-bearing co-cycle links in the rationale; a separate source-graph repair pass must then strip or rewrite those markdown links before effective_status can leave retained_pending_chain. Otherwise return audited_conditional with repair_class=missing_dependency_edge naming the node that should be promoted upstream.",
-      "max_transitive_descendants": 1000,
+      "max_transitive_descendants": 1001,
       "primary_break_target": "axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03",
       "primary_break_target_audit_status": "unaudited",
       "primary_break_target_criticality": "critical",
@@ -220,7 +220,7 @@
       "cycle_id": "cycle-0006",
       "cycle_length": 2,
       "instruction": "Re-audit this node with the prompt instruction that its co-cycle citations ['quark_cp_carrier_slot_minimality_theorem_note_2026-06-17'] are informational/'see also' references, not load-bearing dependencies. If the chain truly closes without those citations, return audited_clean and name the non-load-bearing co-cycle links in the rationale; a separate source-graph repair pass must then strip or rewrite those markdown links before effective_status can leave retained_pending_chain. Otherwise return audited_conditional with repair_class=missing_dependency_edge naming the node that should be promoted upstream.",
-      "max_transitive_descendants": 377,
+      "max_transitive_descendants": 378,
       "primary_break_target": "quark_cp_carrier_completion_note_2026-04-18",
       "primary_break_target_audit_status": "unaudited",
       "primary_break_target_criticality": "critical",
@@ -234,7 +234,7 @@
       "cycle_id": "cycle-0007",
       "cycle_length": 2,
       "instruction": "Re-audit this node with the prompt instruction that its co-cycle citations ['bridge_gap_hk_thermodynamic_stretch_note_2026-05-06'] are informational/'see also' references, not load-bearing dependencies. If the chain truly closes without those citations, return audited_clean and name the non-load-bearing co-cycle links in the rationale; a separate source-graph repair pass must then strip or rewrite those markdown links before effective_status can leave retained_pending_chain. Otherwise return audited_conditional with repair_class=missing_dependency_edge naming the node that should be promoted upstream.",
-      "max_transitive_descendants": 285,
+      "max_transitive_descendants": 286,
       "primary_break_target": "bridge_gap_hk_cube_perron_note_2026-05-06",
       "primary_break_target_audit_status": "unaudited",
       "primary_break_target_criticality": "critical",
@@ -249,7 +249,7 @@
       "cycle_id": "cycle-0008",
       "cycle_length": 3,
       "instruction": "Re-audit this node with the prompt instruction that its co-cycle citations ['bridge_gap_hk_cube_perron_note_2026-05-06', 'bridge_gap_hk_thermodynamic_stretch_note_2026-05-06'] are informational/'see also' references, not load-bearing dependencies. If the chain truly closes without those citations, return audited_clean and name the non-load-bearing co-cycle links in the rationale; a separate source-graph repair pass must then strip or rewrite those markdown links before effective_status can leave retained_pending_chain. Otherwise return audited_conditional with repair_class=missing_dependency_edge naming the node that should be promoted upstream.",
-      "max_transitive_descendants": 285,
+      "max_transitive_descendants": 286,
       "primary_break_target": "bridge_gap_action_form_uniqueness_no_go_note_2026-05-06",
       "primary_break_target_audit_status": "unaudited",
       "primary_break_target_criticality": "critical",
@@ -348,7 +348,7 @@
       "claim_id": "no_per_site_chirality_theorem_note_2026-05-02",
       "claim_scope": null,
       "claim_type": "no_go",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -356,15 +356,15 @@
         "minimal_axioms",
         "cl3_pauli_irrep_uniqueness_narrow_theorem_note_2026-05-10"
       ],
-      "direct_in_degree": 11,
+      "direct_in_degree": 12,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 18.951,
+      "load_bearing_score": 19.453,
       "note_path": "docs/NO_PER_SITE_CHIRALITY_THEOREM_NOTE_2026-05-02.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/no_per_site_chirality_check.py",
-      "transitive_descendants": 1399
+      "transitive_descendants": 1401
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -373,22 +373,22 @@
       "claim_id": "tensor_product_translation_fermion_operator_bridge_narrow_theorem_note_2026-05-25",
       "claim_scope": null,
       "claim_type": "positive_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
       "deps": [
         "minimal_axioms"
       ],
-      "direct_in_degree": 17,
+      "direct_in_degree": 18,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 21.784,
+      "load_bearing_score": 22.285,
       "note_path": "docs/TENSOR_PRODUCT_TRANSLATION_FERMION_OPERATOR_BRIDGE_NARROW_THEOREM_NOTE_2026-05-25.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/tensor_product_translation_fermion_operator_bridge_check_2026_05_25.py",
-      "transitive_descendants": 1246
+      "transitive_descendants": 1247
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -397,22 +397,22 @@
       "claim_id": "real_diagonal_source_det_positivity_and_log_readout_lemma_note_2026-06-08",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
       "deps": [
         "minimal_axioms"
       ],
-      "direct_in_degree": 5,
+      "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.738,
+      "load_bearing_score": 16.241,
       "note_path": "docs/REAL_DIAGONAL_SOURCE_DET_POSITIVITY_AND_LOG_READOUT_LEMMA_NOTE_2026-06-08.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/audit_companion_real_diagonal_source_det_positivity_lemma_2026_06_08.py",
-      "transitive_descendants": 1207
+      "transitive_descendants": 1209
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -434,12 +434,12 @@
       "direct_in_degree": 35,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 30.614,
+      "load_bearing_score": 30.615,
       "note_path": "docs/STAGGERED_DIRAC_SUBSTEP1_GRASSMANN_FORCING_BRIDGE_NARROW_THEOREM_NOTE_2026-05-16.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/audit_companion_staggered_dirac_substep1_grassmann_forcing_bridge_2026_05_16.py",
-      "transitive_descendants": 1107
+      "transitive_descendants": 1108
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -448,22 +448,22 @@
       "claim_id": "ew_current_matching_rule_open_gate_note_2026-05-03",
       "claim_scope": null,
       "claim_type": "no_go",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
       "deps": [
         "ew_current_fierz_channel_decomposition_note_2026-05-01"
       ],
-      "direct_in_degree": 17,
+      "direct_in_degree": 18,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 22.612,
+      "load_bearing_score": 22.115,
       "note_path": "docs/EW_CURRENT_MATCHING_RULE_OPEN_GATE_NOTE_2026-05-03.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/frontier_ew_current_matching_rule_no_go.py",
-      "transitive_descendants": 1106
+      "transitive_descendants": 1108
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -483,12 +483,12 @@
       "direct_in_degree": 23,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 24.593,
+      "load_bearing_score": 24.594,
       "note_path": "docs/CL3_TASTE_GENERATION_THEOREM.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/audit_companion_cl3_taste_abstract_c8_orbit_scope_2026_06_12.py",
-      "transitive_descendants": 1091
+      "transitive_descendants": 1092
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -508,12 +508,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.073,
+      "load_bearing_score": 14.074,
       "note_path": "docs/G_BARE_PARENT_FINITE_LINK_WILSON_BETA6_BRIDGE_NOTE_2026-06-18.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/g_bare_parent_finite_link_wilson_beta6_bridge_2026_06_18.py",
-      "transitive_descendants": 1076
+      "transitive_descendants": 1077
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -533,12 +533,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.069,
+      "load_bearing_score": 16.07,
       "note_path": "docs/STAGGERED_DIRAC_SUBSTEP1_U4_CONDITIONAL_SINGLE_MODULE_NARROW_BOUNDED_NOTE_2026-05-17.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/audit_companion_staggered_dirac_substep1_u4_conditional_single_module_2026_05_17.py",
-      "transitive_descendants": 1073
+      "transitive_descendants": 1074
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -547,7 +547,7 @@
       "claim_id": "axiom_first_rp_two_step_transfer_matrix_positivity_note_2026-05-28",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -555,12 +555,12 @@
       "direct_in_degree": 22,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 25.065,
+      "load_bearing_score": 24.066,
       "note_path": "docs/AXIOM_FIRST_RP_TWO_STEP_TRANSFER_MATRIX_POSITIVITY_NOTE_2026-05-28.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/axiom_first_rp_two_step_transfer_matrix_positivity.py",
-      "transitive_descendants": 1070
+      "transitive_descendants": 1071
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -579,12 +579,12 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 18.015,
+      "load_bearing_score": 18.017,
       "note_path": "docs/STAGGERED_DIRAC_SUBSTEP1_STATISTICS_AGNOSTIC_NO_FORCING_NOTE_2026-05-25.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/frontier_staggered_dirac_substep1_statistics_agnostic_no_forcing_discriminator.py",
-      "transitive_descendants": 1034
+      "transitive_descendants": 1035
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -606,12 +606,12 @@
       "direct_in_degree": 19,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 22.499,
+      "load_bearing_score": 22.5,
       "note_path": "docs/AXIOM_FIRST_CLUSTER_DECOMPOSITION_THEOREM_NOTE_2026-04-29.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/axiom_first_cluster_decomposition_check.py",
-      "transitive_descendants": 1022
+      "transitive_descendants": 1023
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -630,12 +630,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.984,
+      "load_bearing_score": 16.986,
       "note_path": "docs/GLEASON_ON_QUBIT_LATTICE_PROJECTION_LATTICE_NARROW_THEOREM_NOTE_2026-05-20.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": null,
-      "transitive_descendants": 1012
+      "transitive_descendants": 1013
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -654,12 +654,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.984,
+      "load_bearing_score": 15.986,
       "note_path": "docs/BUSCH_POVM_EFFECT_GLEASON_QUBIT_AUTHORITY_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/audit_companion_busch_povm_effect_gleason_qubit_2026_06_05.py",
-      "transitive_descendants": 1012
+      "transitive_descendants": 1013
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -676,12 +676,12 @@
       "direct_in_degree": 6,
       "effective_status": "retained",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.983,
+      "load_bearing_score": 15.984,
       "note_path": "docs/RECORD_CLOCK_RATE_NORMALIZATION_GATE_2026-06-06.md",
       "queue_reason": "audit_in_progress",
       "ready": true,
       "runner_path": "scripts/frontier_record_clock_rate_normalization_gate_2026_06_06.py",
-      "transitive_descendants": 1011
+      "transitive_descendants": 1012
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -700,12 +700,12 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.979,
+      "load_bearing_score": 17.98,
       "note_path": "docs/RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/frontier_record_formation_not_unconditionally_forced_by_minimal_axioms.py",
-      "transitive_descendants": 1008
+      "transitive_descendants": 1009
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -724,12 +724,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.473,
+      "load_bearing_score": 14.474,
       "note_path": "docs/TENSOR_COMPOSITION_REQUIRES_LOCAL_TOMOGRAPHY_BEYOND_LOCALITY_NARROW_NO_GO_NOTE_2026-06-03.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/audit_companion_tensor_composition_requires_local_tomography_exact.py",
-      "transitive_descendants": 1004
+      "transitive_descendants": 1005
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -748,12 +748,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.972,
+      "load_bearing_score": 15.973,
       "note_path": "docs/QUANTUM_LOCAL_ALGEBRA_DOES_NOT_FORCE_BOOST_ACTION_FAITH_NO_GO_NOTE_2026-06-02.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/quantum_local_algebra_boost_action_faith_no_go_2026_06_02.py",
-      "transitive_descendants": 1003
+      "transitive_descendants": 1004
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -774,12 +774,12 @@
       "direct_in_degree": 3,
       "effective_status": "retained",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.47,
+      "load_bearing_score": 14.472,
       "note_path": "docs/PMNS_GRAPH_FIRST_RESIDUAL_ANTIUNITARY_NARROW_THEOREM_NOTE_2026-05-16.md",
       "queue_reason": "audit_in_progress",
       "ready": true,
       "runner_path": "scripts/frontier_pmns_graph_first_residual_antiunitary_2026-05-16.py",
-      "transitive_descendants": 1002
+      "transitive_descendants": 1003
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -796,12 +796,12 @@
       "direct_in_degree": 1,
       "effective_status": "retained_no_go",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.47,
+      "load_bearing_score": 13.472,
       "note_path": "docs/DM_LEPTOGENESIS_PMNS_TRANSPORT_SELECTOR_FIREWALL_NOTE_2026-06-17.md",
       "queue_reason": "audit_in_progress",
       "ready": true,
       "runner_path": "scripts/frontier_dm_leptogenesis_pmns_transport_selector_firewall_2026_06_17.py",
-      "transitive_descendants": 1002
+      "transitive_descendants": 1003
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -820,12 +820,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.47,
+      "load_bearing_score": 13.472,
       "note_path": "docs/RECORD_LOCAL_FINITE_ATOM_AVAILABILITY_NARROW_THEOREM_NOTE_2026-06-17.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/frontier_record_local_finite_atom_availability_2026_06_17.py",
-      "transitive_descendants": 1002
+      "transitive_descendants": 1003
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -846,12 +846,12 @@
       "helper_runner_paths": [
         "scripts/dm_leptogenesis_exact_common.py"
       ],
-      "load_bearing_score": 16.469,
+      "load_bearing_score": 16.47,
       "note_path": "docs/DM_LEPTOGENESIS_PMNS_TRANSPORT_EXTREMAL_SOURCE_CANDIDATE_NOTE_2026-04-16.md",
       "queue_reason": "audit_in_progress",
       "ready": true,
       "runner_path": "scripts/frontier_dm_leptogenesis_pmns_transport_extremal_source_candidate.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -870,12 +870,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.969,
+      "load_bearing_score": 15.97,
       "note_path": "docs/OBSERVABLE_PRINCIPLE_RECORD_SCALAR_MAP_NO_GO_NOTE_2026-06-05.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/frontier_observable_principle_record_scalar_map_no_go_2026_06_05.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -898,12 +898,12 @@
       "direct_in_degree": 4,
       "effective_status": "retained_bounded",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.969,
+      "load_bearing_score": 14.97,
       "note_path": "docs/PMNS_GRAPH_FIRST_AXIS_ALIGNMENT_NOTE.md",
       "queue_reason": "audit_in_progress",
       "ready": true,
       "runner_path": "scripts/frontier_pmns_graph_first_axis_alignment.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -920,12 +920,12 @@
       "direct_in_degree": 2,
       "effective_status": "retained_bounded",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.969,
+      "load_bearing_score": 13.97,
       "note_path": "docs/PMNS_TM2_RESIDUAL_CONSEQUENCE_BOUNDED_NOTE_2026-05-26.md",
       "queue_reason": "audit_in_progress",
       "ready": true,
       "runner_path": "scripts/pmns_tm2_residual_consequence_runner.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -942,12 +942,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.469,
+      "load_bearing_score": 13.47,
       "note_path": "docs/SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -972,12 +972,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 43.467,
+      "load_bearing_score": 43.469,
       "note_path": "docs/YT_WARD_IDENTITY_DERIVATION_THEOREM.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/frontier_yt_ward_identity_derivation.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1001,12 +1001,12 @@
       "direct_in_degree": 9,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.104,
+      "load_bearing_score": 13.107,
       "note_path": "docs/GAUGE_VACUUM_PLAQUETTE_RESIDUAL_ENVIRONMENT_ALL_WEIGHT_CONVOLUTION_IDENTIFICATION_NARROW_THEOREM_NOTE_2026-05-17.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/audit_companion_gauge_vacuum_plaquette_residual_environment_all_weight_convolution_identification.py",
-      "transitive_descendants": 388
+      "transitive_descendants": 389
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1027,12 +1027,12 @@
       "helper_runner_paths": [
         "scripts/frontier_higgs_dressed_propagator_v1.py"
       ],
-      "load_bearing_score": 10.405,
+      "load_bearing_score": 10.409,
       "note_path": "docs/KOIDE_HIGGS_DRESSED_RESOLVENT_ROOT_THEOREM_NOTE_2026-04-20.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/frontier_koide_higgs_dressed_resolvent_root_theorem.py",
-      "transitive_descendants": 338
+      "transitive_descendants": 339
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1051,12 +1051,12 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.34,
+      "load_bearing_score": 13.344,
       "note_path": "docs/KOIDE_Q_DELTA_LINKING_RELATION_THEOREM_NOTE_2026-04-20.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/frontier_koide_q_delta_formal_ratio_repair.py",
-      "transitive_descendants": 323
+      "transitive_descendants": 324
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1077,12 +1077,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 11.219,
+      "load_bearing_score": 11.224,
       "note_path": "docs/HIGGS_MASS_FROM_AXIOM_STATUS_CORRECTION_AUDIT_NOTE_2026-05-02.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/frontier_higgs_mass_status_audit.py",
-      "transitive_descendants": 297
+      "transitive_descendants": 298
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1102,12 +1102,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.695,
+      "load_bearing_score": 8.7,
       "note_path": "docs/LATTICE_GREENS_MARADUDIN_ASYMPTOTIC_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-27.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py",
-      "transitive_descendants": 292
+      "transitive_descendants": 293
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1126,12 +1126,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.061,
+      "load_bearing_score": 9.066,
       "note_path": "docs/CLIFFORD_CHIRALITY_DIMENSION_NARROW_THEOREM_NOTE_2026-05-10.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/frontier_clifford_chirality_dimension_narrow.py",
-      "transitive_descendants": 266
+      "transitive_descendants": 267
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1153,12 +1153,40 @@
         "scripts/poisson_self_gravity_loop.py",
         "scripts/poisson_self_gravity_loop_v3.py"
       ],
-      "load_bearing_score": 12.477,
+      "load_bearing_score": 12.483,
       "note_path": "docs/POISSON_SELF_GRAVITY_MECHANISM_NOTE.md",
       "queue_reason": "audit_in_progress",
       "ready": true,
       "runner_path": "scripts/poisson_self_gravity_mechanism.py",
-      "transitive_descendants": 251
+      "transitive_descendants": 252
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
+      "audit_status": "audit_in_progress",
+      "blocker": "awaiting_cross_confirmation",
+      "claim_id": "self_gravity_entropy_note_2026-04-11",
+      "claim_scope": "Bounded finite diagnostic for scripts/frontier_self_gravity_entropy.py: for the helper-defined MASS=0.30, MU2=0.22, DT=0.12, G_SELF=50.0, N_ITER=20 graph-family packet and listed cuts/ensembles, the single-particle binary occupancy entropy table is mixed and does not establish robust boundary-controlled or area-law-like scaling.",
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "audited_pending_cross_confirmation_after_criticality_bump",
+      "criticality": "critical",
+      "criticality_rank": 3,
+      "cross_confirmation_status": "awaiting_second",
+      "deps": [
+        "staggered_3d_self_gravity_sign_note_2026-04-11",
+        "self_gravity_backreaction_closure_note",
+        "poisson_self_gravity_mechanism_note"
+      ],
+      "direct_in_degree": 1,
+      "effective_status": "retained_bounded",
+      "helper_runner_paths": [
+        "scripts/frontier_staggered_self_gravity.py"
+      ],
+      "load_bearing_score": 8.472,
+      "note_path": "docs/SELF_GRAVITY_ENTROPY_NOTE_2026-04-11.md",
+      "queue_reason": "audit_in_progress",
+      "ready": true,
+      "runner_path": "scripts/frontier_self_gravity_entropy.py",
+      "transitive_descendants": 250
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1255,12 +1283,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.937,
+      "load_bearing_score": 13.938,
       "note_path": "docs/ABJ_P_HY_RETAINED_BOUNDED_SUPPLIER_WIRING_NOTE_2026-06-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_abj_phy_retained_bounded_supplier_wiring_2026_06_18.py",
-      "transitive_descendants": 1385
+      "transitive_descendants": 1386
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1288,12 +1316,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.436,
+      "load_bearing_score": 15.437,
       "note_path": "docs/ANOMALY_FORCES_TIME_ABJ_INCONSISTENCY_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-26.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/anomaly_forces_time_abj_inconsistency_accepted_premise_runner.py",
-      "transitive_descendants": 1384
+      "transitive_descendants": 1385
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1318,12 +1346,12 @@
       "direct_in_degree": 60,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 43.431,
+      "load_bearing_score": 43.433,
       "note_path": "docs/ANOMALY_FORCES_TIME_THEOREM.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_anomaly_forces_time.py",
-      "transitive_descendants": 1380
+      "transitive_descendants": 1381
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1347,12 +1375,12 @@
       "helper_runner_paths": [
         "scripts/_frontier_loader.py"
       ],
-      "load_bearing_score": 15.744,
+      "load_bearing_score": 15.746,
       "note_path": "docs/S3_TIME_SPACETIME_TENSOR_PRIMITIVE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_s3_time_spacetime_tensor_primitive.py",
-      "transitive_descendants": 1212
+      "transitive_descendants": 1213
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1361,7 +1389,7 @@
       "claim_id": "observable_principle_t1d_determinant_readout_independence_no_go_note_2026-06-16",
       "claim_scope": null,
       "claim_type": "no_go",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -1372,12 +1400,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.736,
+      "load_bearing_score": 15.737,
       "note_path": "docs/OBSERVABLE_PRINCIPLE_T1D_DETERMINANT_READOUT_INDEPENDENCE_NO_GO_NOTE_2026-06-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_observable_principle_t1d_determinant_readout_independence_2026_06_16.py",
-      "transitive_descendants": 1205
+      "transitive_descendants": 1206
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1386,7 +1414,7 @@
       "claim_id": "observable_principle_t1d_positive_diagonal_readout_classifier_note_2026-06-18",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -1397,12 +1425,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.734,
+      "load_bearing_score": 14.735,
       "note_path": "docs/OBSERVABLE_PRINCIPLE_T1D_POSITIVE_DIAGONAL_READOUT_CLASSIFIER_NOTE_2026-06-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/observable_principle_t1d_positive_diagonal_readout_classifier_2026_06_18.py",
-      "transitive_descendants": 1203
+      "transitive_descendants": 1204
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1411,7 +1439,7 @@
       "claim_id": "observable_principle_t1d_determinant_context_quotient_bridge_note_2026-06-18",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -1421,12 +1449,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.232,
+      "load_bearing_score": 15.234,
       "note_path": "docs/OBSERVABLE_PRINCIPLE_T1D_DETERMINANT_CONTEXT_QUOTIENT_BRIDGE_NOTE_2026-06-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/observable_principle_t1d_determinant_context_quotient_bridge_2026_06_18.py",
-      "transitive_descendants": 1202
+      "transitive_descendants": 1203
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1451,12 +1479,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 64.231,
+      "load_bearing_score": 64.232,
       "note_path": "docs/OBSERVABLE_PRINCIPLE_FROM_AXIOM_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_hierarchy_observable_principle_from_axiom.py",
-      "transitive_descendants": 1201
+      "transitive_descendants": 1202
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1475,10 +1503,10 @@
         "tensor_product_translation_fermion_operator_bridge_narrow_theorem_note_2026-05-25",
         "fermion_parity_z2_grading_theorem_note_2026-05-02"
       ],
-      "direct_in_degree": 14,
+      "direct_in_degree": 13,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 20.222,
+      "load_bearing_score": 19.722,
       "note_path": "docs/STAGGERED_DIRAC_KINETIC_CLASS_FORCING_NARROW_THEOREM_NOTE_2026-06-10.md",
       "queue_reason": "unaudited",
       "ready": false,
@@ -1503,12 +1531,12 @@
       "direct_in_degree": 33,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 29.684,
+      "load_bearing_score": 29.685,
       "note_path": "docs/ONE_GENERATION_MATTER_CLOSURE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_right_handed_sector.py",
-      "transitive_descendants": 1162
+      "transitive_descendants": 1163
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1532,12 +1560,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.677,
+      "load_bearing_score": 15.679,
       "note_path": "docs/S3_TIME_TRANSFER_MATRIX_BRIDGE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_s3_time_transfer_matrix_bridge.py",
-      "transitive_descendants": 1157
+      "transitive_descendants": 1158
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1560,12 +1588,12 @@
       "helper_runner_paths": [
         "scripts/_frontier_loader.py"
       ],
-      "load_bearing_score": 34.174,
+      "load_bearing_score": 34.175,
       "note_path": "docs/S3_TIME_BILINEAR_TENSOR_PRIMITIVE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_s3_time_bilinear_tensor_primitive.py",
-      "transitive_descendants": 1154
+      "transitive_descendants": 1155
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1586,12 +1614,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.156,
+      "load_bearing_score": 15.157,
       "note_path": "docs/YT_VERTEX_POWER_DERIVATION.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_vertex_power.py",
-      "transitive_descendants": 1140
+      "transitive_descendants": 1141
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1613,12 +1641,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.655,
+      "load_bearing_score": 14.656,
       "note_path": "docs/YT_VERTEX_POWER_OPERATOR_COUNTING_LEMMA_NOTE_2026-05-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_vertex_power_operator_counting_lemma.py",
-      "transitive_descendants": 1139
+      "transitive_descendants": 1140
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1642,12 +1670,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 42.152,
+      "load_bearing_score": 42.154,
       "note_path": "docs/ALPHA_S_DERIVED_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_alpha_s_derived_bounded_chain.py",
-      "transitive_descendants": 1137
+      "transitive_descendants": 1138
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1672,12 +1700,12 @@
       "direct_in_degree": 38,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 32.128,
+      "load_bearing_score": 32.129,
       "note_path": "docs/STANDARD_MODEL_HYPERCHARGE_UNIQUENESS_THEOREM_NOTE_2026-04-24.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_sm_hypercharge_uniqueness.py",
-      "transitive_descendants": 1118
+      "transitive_descendants": 1119
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1699,12 +1727,12 @@
       "direct_in_degree": 13,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 19.624,
+      "load_bearing_score": 19.625,
       "note_path": "docs/S3_ANOMALY_SPACETIME_LIFT_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_s3_anomaly_spacetime_lift.py",
-      "transitive_descendants": 1115
+      "transitive_descendants": 1116
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1724,12 +1752,12 @@
       "direct_in_degree": 11,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 18.619,
+      "load_bearing_score": 18.62,
       "note_path": "docs/UNIVERSAL_GR_TENSOR_VARIATIONAL_CANDIDATE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_universal_gr_tensor_variational_candidate.py",
-      "transitive_descendants": 1111
+      "transitive_descendants": 1112
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1750,12 +1778,12 @@
       "direct_in_degree": 9,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.618,
+      "load_bearing_score": 17.619,
       "note_path": "docs/UNIVERSAL_GR_TENSOR_QUOTIENT_UNIQUENESS_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_universal_gr_tensor_quotient_uniqueness.py",
-      "transitive_descendants": 1110
+      "transitive_descendants": 1111
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1777,12 +1805,12 @@
       "direct_in_degree": 13,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 19.614,
+      "load_bearing_score": 19.615,
       "note_path": "docs/UNIVERSAL_GR_POLARIZATION_FRAME_BUNDLE_BLOCKER_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_universal_gr_polarization_frame_bundle.py",
-      "transitive_descendants": 1107
+      "transitive_descendants": 1108
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1806,12 +1834,12 @@
       "helper_runner_paths": [
         "scripts/_frontier_loader.py"
       ],
-      "load_bearing_score": 14.111,
+      "load_bearing_score": 14.112,
       "note_path": "docs/S3_TIME_BILINEAR_TENSOR_ACTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_s3_time_bilinear_tensor_action.py",
-      "transitive_descendants": 1105
+      "transitive_descendants": 1106
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1835,12 +1863,12 @@
         "scripts/_frontier_loader.py",
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 33.11,
+      "load_bearing_score": 33.111,
       "note_path": "docs/CKM_ATLAS_AXIOM_CLOSURE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_ckm_atlas_axiom_closure.py",
-      "transitive_descendants": 1104
+      "transitive_descendants": 1105
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1849,7 +1877,7 @@
       "claim_id": "cl3_color_automorphism_theorem",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -1860,12 +1888,12 @@
       "direct_in_degree": 55,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 41.599,
+      "load_bearing_score": 40.601,
       "note_path": "docs/CL3_COLOR_AUTOMORPHISM_THEOREM.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/verify_cl3_sm_embedding.py",
-      "transitive_descendants": 1096
+      "transitive_descendants": 1097
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1888,12 +1916,12 @@
       "direct_in_degree": 11,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 18.594,
+      "load_bearing_score": 18.595,
       "note_path": "docs/UNIVERSAL_GR_A1_INVARIANT_SECTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_universal_gr_a1_invariant_section.py",
-      "transitive_descendants": 1092
+      "transitive_descendants": 1093
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1917,12 +1945,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 36.57,
+      "load_bearing_score": 36.571,
       "note_path": "docs/CKM_CP_PHASE_STRUCTURAL_IDENTITY_THEOREM_NOTE_2026-04-24.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_ckm_cp_phase_structural_identity.py",
-      "transitive_descendants": 1074
+      "transitive_descendants": 1075
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1943,12 +1971,12 @@
       "direct_in_degree": 20,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 23.07,
+      "load_bearing_score": 23.071,
       "note_path": "docs/G_BARE_DERIVATION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_g_bare_derivation.py",
-      "transitive_descendants": 1074
+      "transitive_descendants": 1075
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1973,12 +2001,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 35.066,
+      "load_bearing_score": 35.067,
       "note_path": "docs/WOLFENSTEIN_LAMBDA_A_STRUCTURAL_IDENTITIES_THEOREM_NOTE_2026-04-24.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_wolfenstein_lambda_a_structural_identities.py",
-      "transitive_descendants": 1071
+      "transitive_descendants": 1072
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -1999,12 +2027,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 26.566,
+      "load_bearing_score": 26.567,
       "note_path": "docs/CKM_ATLAS_TRIANGLE_RIGHT_ANGLE_THEOREM_NOTE_2026-04-24.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_ckm_atlas_triangle_right_angle.py",
-      "transitive_descendants": 1071
+      "transitive_descendants": 1072
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2023,12 +2051,12 @@
       "direct_in_degree": 16,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 21.065,
+      "load_bearing_score": 21.066,
       "note_path": "docs/NEUTRINO_MAJORANA_OPERATOR_AXIOM_FIRST_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_operator.py",
-      "transitive_descendants": 1070
+      "transitive_descendants": 1071
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2047,12 +2075,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.562,
+      "load_bearing_score": 16.563,
       "note_path": "docs/NEUTRINO_MAJORANA_NATIVE_GAUSSIAN_NO_GO_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_native_gaussian_nogo.py",
-      "transitive_descendants": 1068
+      "transitive_descendants": 1069
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2072,12 +2100,12 @@
       "direct_in_degree": 9,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.559,
+      "load_bearing_score": 17.561,
       "note_path": "docs/NEUTRINO_MAJORANA_FINITE_NORMAL_GRAMMAR_NO_GO_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_finite_normal_grammar_nogo.py",
-      "transitive_descendants": 1066
+      "transitive_descendants": 1067
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2098,12 +2126,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.058,
+      "load_bearing_score": 16.059,
       "note_path": "docs/NEUTRINO_MAJORANA_PFAFFIAN_EXTENSION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_pfaffian_extension.py",
-      "transitive_descendants": 1065
+      "transitive_descendants": 1066
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2124,12 +2152,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.557,
+      "load_bearing_score": 13.558,
       "note_path": "docs/NEUTRINO_MAJORANA_PFAFFIAN_AXIOM_BOUNDARY_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_pfaffian_axiom_boundary.py",
-      "transitive_descendants": 1064
+      "transitive_descendants": 1065
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2151,12 +2179,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.055,
+      "load_bearing_score": 17.057,
       "note_path": "docs/NEUTRINO_MAJORANA_PFAFFIAN_NO_FORCING_THEOREM_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_pfaffian_no_forcing_theorem.py",
-      "transitive_descendants": 1063
+      "transitive_descendants": 1064
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2175,12 +2203,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.055,
+      "load_bearing_score": 15.057,
       "note_path": "docs/NEUTRINO_MAJORANA_CURRENT_ATLAS_NONREALIZATION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_current_atlas_nonrealization.py",
-      "transitive_descendants": 1063
+      "transitive_descendants": 1064
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2204,12 +2232,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.554,
+      "load_bearing_score": 15.555,
       "note_path": "docs/NEUTRINO_MAJORANA_CHARGE_TWO_PRIMITIVE_REDUCTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_charge_two_primitive_reduction.py",
-      "transitive_descendants": 1062
+      "transitive_descendants": 1063
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2231,12 +2259,12 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 18.053,
+      "load_bearing_score": 18.054,
       "note_path": "docs/NEUTRINO_MAJORANA_UNIQUE_SOURCE_SLOT_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_unique_source_slot.py",
-      "transitive_descendants": 1061
+      "transitive_descendants": 1062
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2260,12 +2288,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 32.051,
+      "load_bearing_score": 32.053,
       "note_path": "docs/CKM_MAGNITUDES_STRUCTURAL_COUNTS_THEOREM_NOTE_2026-04-25.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_ckm_magnitudes_structural_counts.py",
-      "transitive_descendants": 1060
+      "transitive_descendants": 1061
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2287,12 +2315,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.051,
+      "load_bearing_score": 16.053,
       "note_path": "docs/NEUTRINO_MAJORANA_PHASE_REMOVAL_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_phase_removal.py",
-      "transitive_descendants": 1060
+      "transitive_descendants": 1061
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2314,12 +2342,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.046,
+      "load_bearing_score": 17.047,
       "note_path": "docs/NEUTRINO_MAJORANA_CANONICAL_LOCAL_BLOCK_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_canonical_local_block.py",
-      "transitive_descendants": 1056
+      "transitive_descendants": 1057
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2328,7 +2356,7 @@
       "claim_id": "axiom_first_reflection_positivity_wilson_temporal_gauge_bridge_narrow_theorem_note_2026-06-05",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -2341,12 +2369,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 18.043,
+      "load_bearing_score": 17.044,
       "note_path": "docs/AXIOM_FIRST_REFLECTION_POSITIVITY_WILSON_TEMPORAL_GAUGE_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/audit_companion_reflection_positivity_wilson_temporal_gauge_2026_06_05.py",
-      "transitive_descendants": 1054
+      "transitive_descendants": 1055
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2369,12 +2397,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.042,
+      "load_bearing_score": 17.043,
       "note_path": "docs/NEUTRINO_MAJORANA_Z3_NONACTIVATION_THEOREM_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_z3_nonactivation_theorem.py",
-      "transitive_descendants": 1053
+      "transitive_descendants": 1054
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2398,12 +2426,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 26.54,
+      "load_bearing_score": 26.542,
       "note_path": "docs/CKM_NLO_BARRED_TRIANGLE_PROTECTED_GAMMA_THEOREM_NOTE_2026-04-25.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_ckm_nlo_barred_triangle_protected_gamma.py",
-      "transitive_descendants": 1052
+      "transitive_descendants": 1053
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2426,12 +2454,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.539,
+      "load_bearing_score": 15.54,
       "note_path": "docs/NEUTRINO_MAJORANA_LOCAL_PFAFFIAN_UNIQUENESS_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_local_pfaffian_uniqueness.py",
-      "transitive_descendants": 1051
+      "transitive_descendants": 1052
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2454,12 +2482,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.539,
+      "load_bearing_score": 13.54,
       "note_path": "docs/NEUTRINO_MAJORANA_OBSERVABLE_PRINCIPLE_OBSTRUCTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_observable_principle_obstruction.py",
-      "transitive_descendants": 1051
+      "transitive_descendants": 1052
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2482,12 +2510,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.538,
+      "load_bearing_score": 13.539,
       "note_path": "docs/NEUTRINO_MAJORANA_CURRENT_STACK_EXHAUSTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_current_stack_exhaustion.py",
-      "transitive_descendants": 1050
+      "transitive_descendants": 1051
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2509,12 +2537,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.036,
+      "load_bearing_score": 16.038,
       "note_path": "docs/NEUTRINO_MAJORANA_NAMBU_SOURCE_PRINCIPLE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_nambu_source_principle.py",
-      "transitive_descendants": 1049
+      "transitive_descendants": 1050
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2535,12 +2563,12 @@
       "direct_in_degree": 9,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.535,
+      "load_bearing_score": 17.536,
       "note_path": "docs/NEUTRINO_MAJORANA_SOURCE_RAY_THEOREM_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_source_ray_theorem.py",
-      "transitive_descendants": 1048
+      "transitive_descendants": 1049
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2559,39 +2587,14 @@
         "gstar_thermal_seven_eighths_stefan_boltzmann_bridge_narrow_theorem_note_2026-06-06",
         "hierarchy_seven_eighths_riemann_dirichlet_dimensional_anchor_narrow_theorem_note_2026-05-10"
       ],
-      "direct_in_degree": 4,
+      "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.032,
+      "load_bearing_score": 14.532,
       "note_path": "docs/AXIOM_FIRST_FERMIONIC_STEFAN_BOLTZMANN_NARROW_THEOREM_NOTE_2026-05-26.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_axiom_first_fermionic_stefan_boltzmann_narrow.py",
-      "transitive_descendants": 1046
-    },
-    {
-      "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "staggered_kernel_satisfies_z_point_cone_certificate_narrow_theorem_note_2026-06-11",
-      "claim_scope": null,
-      "claim_type": "positive_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "critical",
-      "criticality_rank": 3,
-      "cross_confirmation_status": null,
-      "deps": [
-        "minimal_axioms",
-        "tensor_product_translation_fermion_operator_bridge_narrow_theorem_note_2026-05-25"
-      ],
-      "direct_in_degree": 4,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 15.032,
-      "note_path": "docs/STAGGERED_KERNEL_SATISFIES_Z_POINT_CONE_CERTIFICATE_NARROW_THEOREM_NOTE_2026-06-11.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/staggered_kernel_z_certificate_check_2026_06_11.py",
       "transitive_descendants": 1046
     },
     {
@@ -2613,12 +2616,37 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.531,
+      "load_bearing_score": 14.532,
       "note_path": "docs/NEUTRINO_MAJORANA_NAMBU_RADIAL_OBSERVABLE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_nambu_radial_observable.py",
-      "transitive_descendants": 1045
+      "transitive_descendants": 1046
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "staggered_kernel_satisfies_z_point_cone_certificate_narrow_theorem_note_2026-06-11",
+      "claim_scope": null,
+      "claim_type": "positive_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "critical",
+      "criticality_rank": 3,
+      "cross_confirmation_status": null,
+      "deps": [
+        "minimal_axioms",
+        "tensor_product_translation_fermion_operator_bridge_narrow_theorem_note_2026-05-25"
+      ],
+      "direct_in_degree": 3,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 14.532,
+      "note_path": "docs/STAGGERED_KERNEL_SATISFIES_Z_POINT_CONE_CERTIFICATE_NARROW_THEOREM_NOTE_2026-06-11.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/staggered_kernel_z_certificate_check_2026_06_11.py",
+      "transitive_descendants": 1046
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2639,12 +2667,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.029,
+      "load_bearing_score": 14.031,
       "note_path": "docs/NEUTRINO_MAJORANA_NAMBU_QUADRATIC_COMPARATOR_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_nambu_quadratic_comparator.py",
-      "transitive_descendants": 1044
+      "transitive_descendants": 1045
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2667,12 +2695,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.029,
+      "load_bearing_score": 14.031,
       "note_path": "docs/P_FLUX_SELECTION_VIA_FSB_K_AND_Z_CERTIFICATE_CONDITIONAL_THEOREM_NOTE_2026-06-11.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/p_flux_selection_via_fsb_k_check_2026_06_11.py",
-      "transitive_descendants": 1044
+      "transitive_descendants": 1045
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2681,7 +2709,7 @@
       "claim_id": "axiom_first_reflection_positivity_theorem_note_2026-04-29",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -2699,12 +2727,12 @@
       "helper_runner_paths": [
         "scripts/axiom_first_rp_two_step_transfer_matrix_positivity.py"
       ],
-      "load_bearing_score": 38.528,
+      "load_bearing_score": 37.529,
       "note_path": "docs/AXIOM_FIRST_REFLECTION_POSITIVITY_THEOREM_NOTE_2026-04-29.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/axiom_first_reflection_positivity_wilson_temporal_reroute_2026_06_08.py",
-      "transitive_descendants": 1043
+      "transitive_descendants": 1044
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2726,12 +2754,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.028,
+      "load_bearing_score": 16.029,
       "note_path": "docs/NEUTRINO_MAJORANA_BACKGROUND_NORMALIZATION_THEOREM_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_background_normalization_theorem.py",
-      "transitive_descendants": 1043
+      "transitive_descendants": 1044
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2752,36 +2780,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.528,
+      "load_bearing_score": 15.529,
       "note_path": "docs/NEUTRINO_MAJORANA_STAIRCASE_BLINDNESS_THEOREM_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_staircase_blindness_theorem.py",
-      "transitive_descendants": 1043
-    },
-    {
-      "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "hopping_bilinear_hermiticity_theorem_note_2026-05-02",
-      "claim_scope": null,
-      "claim_type": "positive_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "critical",
-      "criticality_rank": 3,
-      "cross_confirmation_status": null,
-      "deps": [
-        "tensor_product_translation_fermion_operator_bridge_narrow_theorem_note_2026-05-25"
-      ],
-      "direct_in_degree": 8,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 17.025,
-      "note_path": "docs/HOPPING_BILINEAR_HERMITICITY_THEOREM_NOTE_2026-05-02.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/hopping_bilinear_hermiticity_check.py",
-      "transitive_descendants": 1041
+      "transitive_descendants": 1044
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2802,11 +2806,35 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.025,
+      "load_bearing_score": 16.027,
       "note_path": "docs/NEUTRINO_MAJORANA_AXIS_EXCHANGE_FIXED_POINT_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_axis_exchange_fixed_point.py",
+      "transitive_descendants": 1042
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "hopping_bilinear_hermiticity_theorem_note_2026-05-02",
+      "claim_scope": null,
+      "claim_type": "positive_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "critical",
+      "criticality_rank": 3,
+      "cross_confirmation_status": null,
+      "deps": [
+        "tensor_product_translation_fermion_operator_bridge_narrow_theorem_note_2026-05-25"
+      ],
+      "direct_in_degree": 7,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 16.525,
+      "note_path": "docs/HOPPING_BILINEAR_HERMITICITY_THEOREM_NOTE_2026-05-02.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/hopping_bilinear_hermiticity_check.py",
       "transitive_descendants": 1041
     },
     {
@@ -2830,12 +2858,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.524,
+      "load_bearing_score": 15.525,
       "note_path": "docs/NEUTRINO_MAJORANA_SELF_DUAL_STAIRCASE_LIFT_OBSTRUCTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_self_dual_staircase_lift_obstruction.py",
-      "transitive_descendants": 1040
+      "transitive_descendants": 1041
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2856,12 +2884,12 @@
       "direct_in_degree": 13,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 19.522,
+      "load_bearing_score": 19.524,
       "note_path": "docs/STAGGERED_DIRAC_SUBSTEP2_KAHLER_DIRAC_EQUIVALENCE_NARROW_THEOREM_NOTE_2026-05-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/audit_companion_staggered_dirac_substep2_kahler_dirac_equivalence_exact_2026_05_17.py",
-      "transitive_descendants": 1039
+      "transitive_descendants": 1040
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2883,12 +2911,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 17.521,
+      "load_bearing_score": 17.522,
       "note_path": "docs/YT_ZERO_IMPORT_AUTHORITY_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_ward_identity_derivation.py",
-      "transitive_descendants": 1038
+      "transitive_descendants": 1039
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2909,12 +2937,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 19.52,
+      "load_bearing_score": 19.521,
       "note_path": "docs/YT_BOUNDARY_THEOREM.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_boundary_consistency.py",
-      "transitive_descendants": 1037
+      "transitive_descendants": 1038
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2940,12 +2968,12 @@
       "direct_in_degree": 13,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 19.518,
+      "load_bearing_score": 19.52,
       "note_path": "docs/AXIOM_FIRST_LATTICE_NOETHER_THEOREM_NOTE_2026-04-29.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/axiom_first_lattice_noether_check.py",
-      "transitive_descendants": 1036
+      "transitive_descendants": 1037
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2967,12 +2995,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 16.017,
+      "load_bearing_score": 16.018,
       "note_path": "docs/UP_TYPE_MASS_RATIO_CKM_INVERSION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_mass_ratio_up_sector.py",
-      "transitive_descendants": 1035
+      "transitive_descendants": 1036
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -2998,12 +3026,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 17.015,
+      "load_bearing_score": 17.017,
       "note_path": "docs/QUARK_MASS_RATIOS_TASTE_STAIRCASE_SUPPORT_NOTE_2026-04-25.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_quark_mass_ratios_taste_staircase_support.py",
-      "transitive_descendants": 1034
+      "transitive_descendants": 1035
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3025,12 +3053,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.015,
+      "load_bearing_score": 15.017,
       "note_path": "docs/NEUTRINO_MAJORANA_ENDPOINT_EXCHANGE_MIDPOINT_THEOREM_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_endpoint_exchange_midpoint_theorem.py",
-      "transitive_descendants": 1034
+      "transitive_descendants": 1035
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3051,12 +3079,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.514,
+      "load_bearing_score": 16.515,
       "note_path": "docs/NEUTRINO_MAJORANA_ADJACENT_SINGLET_PLACEMENT_THEOREM_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_adjacent_singlet_placement_theorem.py",
-      "transitive_descendants": 1033
+      "transitive_descendants": 1034
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3079,12 +3107,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.014,
+      "load_bearing_score": 16.015,
       "note_path": "docs/CKM_FROM_MASS_HIERARCHY_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_ckm_from_mass_hierarchy.py",
-      "transitive_descendants": 1033
+      "transitive_descendants": 1034
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3103,12 +3131,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.513,
+      "load_bearing_score": 14.514,
       "note_path": "docs/DM_NEUTRINO_BOSONIC_NORMALIZATION_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_bosonic_normalization_theorem.py",
-      "transitive_descendants": 1032
+      "transitive_descendants": 1033
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3117,7 +3145,7 @@
       "claim_id": "axiom_first_spectrum_condition_blocked_time_normalization_bridge_narrow_theorem_note_2026-06-05",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -3127,12 +3155,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.011,
+      "load_bearing_score": 15.013,
       "note_path": "docs/AXIOM_FIRST_SPECTRUM_CONDITION_BLOCKED_TIME_NORMALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/audit_companion_spectrum_condition_blocked_time_normalization_2026_06_05.py",
-      "transitive_descendants": 1031
+      "transitive_descendants": 1032
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3152,12 +3180,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.011,
+      "load_bearing_score": 15.013,
       "note_path": "docs/DM_NEUTRINO_SCHUR_SUPPRESSION_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_schur_suppression_theorem.py",
-      "transitive_descendants": 1031
+      "transitive_descendants": 1032
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3178,12 +3206,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.51,
+      "load_bearing_score": 14.511,
       "note_path": "docs/NEUTRINO_MAJORANA_RESIDUAL_SHARING_SPLIT_THEOREM_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_residual_sharing_split_theorem.py",
-      "transitive_descendants": 1030
+      "transitive_descendants": 1031
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3191,8 +3219,8 @@
       "blocker": null,
       "claim_id": "axiom_first_spectrum_condition_theorem_note_2026-04-29",
       "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "needs_reaudit_after_invalidation",
+      "claim_type": "positive_theorem",
+      "claim_type_provenance": "migration_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -3207,12 +3235,12 @@
       "direct_in_degree": 23,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 24.508,
+      "load_bearing_score": 24.51,
       "note_path": "docs/AXIOM_FIRST_SPECTRUM_CONDITION_THEOREM_NOTE_2026-04-29.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/axiom_first_spectrum_condition_check.py",
-      "transitive_descendants": 1029
+      "transitive_descendants": 1030
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3234,12 +3262,12 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 18.008,
+      "load_bearing_score": 18.01,
       "note_path": "docs/AXIOM_FIRST_SPIN_STATISTICS_THEOREM_NOTE_2026-04-29.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/axiom_first_spin_statistics_check.py",
-      "transitive_descendants": 1029
+      "transitive_descendants": 1030
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3261,12 +3289,12 @@
       "direct_in_degree": 9,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.508,
+      "load_bearing_score": 17.51,
       "note_path": "docs/DM_NEUTRINO_ATMOSPHERIC_SCALE_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_atmospheric_scale_theorem.py",
-      "transitive_descendants": 1029
+      "transitive_descendants": 1030
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3286,12 +3314,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.008,
+      "load_bearing_score": 14.01,
       "note_path": "docs/DM_Z3_TEXTURE_FACTOR_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_z3_texture_factor_theorem.py",
-      "transitive_descendants": 1029
+      "transitive_descendants": 1030
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3312,12 +3340,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.507,
+      "load_bearing_score": 15.508,
       "note_path": "docs/DM_LEPTOGENESIS_UNIVERSAL_YUKAWA_NO_GO_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_universal_yukawa_nogo.py",
-      "transitive_descendants": 1028
+      "transitive_descendants": 1029
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3339,12 +3367,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.007,
+      "load_bearing_score": 14.008,
       "note_path": "docs/CKM_SCHUR_COMPLEMENT_THEOREM.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_ckm_schur_complement.py",
-      "transitive_descendants": 1028
+      "transitive_descendants": 1029
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3366,12 +3394,12 @@
       "direct_in_degree": 15,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 20.506,
+      "load_bearing_score": 20.507,
       "note_path": "docs/BMINUSL_ANOMALY_FREEDOM_THEOREM_NOTE_2026-04-24.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_bminusl_anomaly_freedom.py",
-      "transitive_descendants": 1027
+      "transitive_descendants": 1028
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3392,12 +3420,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.506,
+      "load_bearing_score": 14.507,
       "note_path": "docs/DM_NEUTRINO_CKM_TEXTURE_TRANSFER_NO_GO_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_ckm_texture_transfer_nogo.py",
-      "transitive_descendants": 1027
+      "transitive_descendants": 1028
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3417,12 +3445,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.004,
+      "load_bearing_score": 14.006,
       "note_path": "docs/DM_NEUTRINO_CP_KERNEL_DEFORMATION_NECESSITY_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_cp_kernel_deformation_necessity.py",
-      "transitive_descendants": 1026
+      "transitive_descendants": 1027
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3444,12 +3472,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.003,
+      "load_bearing_score": 15.004,
       "note_path": "docs/DM_NEUTRINO_Z3_CIRCULANT_CP_TOOL_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_z3_circulant_cp_tool.py",
-      "transitive_descendants": 1025
+      "transitive_descendants": 1026
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3468,12 +3496,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.0,
+      "load_bearing_score": 16.001,
       "note_path": "docs/DM_NEUTRINO_TWO_HIGGS_RIGHT_GRAM_BRIDGE_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_two_higgs_right_gram_bridge.py",
-      "transitive_descendants": 1023
+      "transitive_descendants": 1024
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3493,12 +3521,12 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.994,
+      "load_bearing_score": 17.996,
       "note_path": "docs/DM_NEUTRINO_SINGLET_DOUBLET_CP_SLOT_TOOL_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_singlet_doublet_cp_slot_tool.py",
-      "transitive_descendants": 1019
+      "transitive_descendants": 1020
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3518,12 +3546,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.993,
+      "load_bearing_score": 13.994,
       "note_path": "docs/DM_NEUTRINO_TWO_HIGGS_23_SYMMETRIC_SLOT_NO_GO_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_two_higgs_23_symmetric_slot_nogo.py",
-      "transitive_descendants": 1018
+      "transitive_descendants": 1019
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3544,12 +3572,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.992,
+      "load_bearing_score": 13.993,
       "note_path": "docs/DM_NEUTRINO_CANONICAL_TWO_HIGGS_SLOT_NO_GO_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_canonical_two_higgs_slot_nogo.py",
-      "transitive_descendants": 1017
+      "transitive_descendants": 1018
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3571,12 +3599,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.99,
+      "load_bearing_score": 16.992,
       "note_path": "docs/MICROCAUSALITY_FINITE_RANGE_H_AND_VLR_BRIDGE_THEOREM_NOTE_2026-05-09.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/microcausality_finite_range_h_bridge_2026_05_09.py",
-      "transitive_descendants": 1016
+      "transitive_descendants": 1017
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3599,12 +3627,12 @@
       "helper_runner_paths": [
         "scripts/_frontier_loader.py"
       ],
-      "load_bearing_score": 16.49,
+      "load_bearing_score": 16.492,
       "note_path": "docs/S3_TIME_TENSOR_PRIMITIVE_PROTOTYPE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_s3_time_tensor_primitive_prototype.py",
-      "transitive_descendants": 1016
+      "transitive_descendants": 1017
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3627,12 +3655,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.49,
+      "load_bearing_score": 14.492,
       "note_path": "docs/DM_NEUTRINO_POSTCANONICAL_EXTENSION_CLASS_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_postcanonical_extension_class.py",
-      "transitive_descendants": 1016
+      "transitive_descendants": 1017
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3652,12 +3680,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.989,
+      "load_bearing_score": 13.99,
       "note_path": "docs/DM_NEUTRINO_POSTCANONICAL_SLOT_SUPPORT_CLASS_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_postcanonical_slot_support_class.py",
-      "transitive_descendants": 1015
+      "transitive_descendants": 1016
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3680,12 +3708,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.987,
+      "load_bearing_score": 15.989,
       "note_path": "docs/AXIOM_FIRST_CPT_THEOREM_STRETCH_NOTE_2026-04-29.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/axiom_first_cpt_check.py",
-      "transitive_descendants": 1014
+      "transitive_descendants": 1015
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3706,12 +3734,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.487,
+      "load_bearing_score": 13.489,
       "note_path": "docs/DM_NEUTRINO_POSTCANONICAL_RIGHT_FRAME_OBSTRUCTION_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_postcanonical_right_frame_obstruction.py",
-      "transitive_descendants": 1014
+      "transitive_descendants": 1015
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3732,12 +3760,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.986,
+      "load_bearing_score": 16.987,
       "note_path": "docs/DM_NEUTRINO_WEAK_EVEN_SWAP_REDUCTION_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_weak_even_swap_reduction_theorem.py",
-      "transitive_descendants": 1013
+      "transitive_descendants": 1014
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3760,12 +3788,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.986,
+      "load_bearing_score": 16.987,
       "note_path": "docs/TRANSFER_MATRIX_LOG_QUASILOCALITY_NARROW_THEOREM_NOTE_2026-06-10.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/transfer_matrix_log_quasilocality_check_2026_06_10.py",
-      "transitive_descendants": 1013
+      "transitive_descendants": 1014
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3787,12 +3815,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.486,
+      "load_bearing_score": 16.487,
       "note_path": "docs/DM_NEUTRINO_POSTCANONICAL_POLAR_SECTION_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_postcanonical_polar_section.py",
-      "transitive_descendants": 1013
+      "transitive_descendants": 1014
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3815,12 +3843,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.984,
+      "load_bearing_score": 14.986,
       "note_path": "docs/STAGGERED_DIRAC_SUBSTEP1_STATISTICS_GL_F_CONDITIONAL_DISCRIMINATOR_BOUNDED_THEOREM_NOTE_2026-06-10.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/staggered_dirac_substep1_statistics_selection_check_2026_06_10.py",
-      "transitive_descendants": 1012
+      "transitive_descendants": 1013
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3840,12 +3868,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.484,
+      "load_bearing_score": 13.486,
       "note_path": "docs/DM_NEUTRINO_POLAR_ALIGNED_CORE_NO_GO_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_polar_aligned_core_nogo.py",
-      "transitive_descendants": 1012
+      "transitive_descendants": 1013
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3866,12 +3894,12 @@
       "direct_in_degree": 23,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 24.483,
+      "load_bearing_score": 24.484,
       "note_path": "docs/R_BASE_GROUP_THEORY_DERIVATION_THEOREM_NOTE_2026-04-24.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_r_base_group_theory_derivation.py",
-      "transitive_descendants": 1011
+      "transitive_descendants": 1012
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3891,12 +3919,12 @@
       "direct_in_degree": 14,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 19.983,
+      "load_bearing_score": 19.984,
       "note_path": "docs/DM_NEUTRINO_POSITIVE_POLAR_H_CP_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_positive_polar_h_cp_theorem.py",
-      "transitive_descendants": 1011
+      "transitive_descendants": 1012
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3919,12 +3947,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.983,
+      "load_bearing_score": 16.984,
       "note_path": "docs/AXIOM_FIRST_KMS_CONDITION_THEOREM_NOTE_2026-05-01.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/axiom_first_kms_condition_check.py",
-      "transitive_descendants": 1011
+      "transitive_descendants": 1012
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3943,12 +3971,12 @@
       "direct_in_degree": 13,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 19.48,
+      "load_bearing_score": 19.482,
       "note_path": "docs/OMEGA_LAMBDA_DERIVATION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_omega_lambda_arithmetic_cascade.py",
-      "transitive_descendants": 1009
+      "transitive_descendants": 1010
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3967,12 +3995,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.48,
+      "load_bearing_score": 16.482,
       "note_path": "docs/DM_NEUTRINO_BREAKING_TRIPLET_CP_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_breaking_triplet_cp_theorem.py",
-      "transitive_descendants": 1009
+      "transitive_descendants": 1010
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -3997,12 +4025,12 @@
       "direct_in_degree": 13,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 19.479,
+      "load_bearing_score": 19.48,
       "note_path": "docs/STAGGERED_DIRAC_GRASSMANN_FORCING_THEOREM_NOTE_2026-05-07.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/probe_grassmann_forcing_dependency_chain.py",
-      "transitive_descendants": 1008
+      "transitive_descendants": 1009
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4023,12 +4051,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.979,
+      "load_bearing_score": 14.98,
       "note_path": "docs/BUSCH_POVM_EXTENSION_ON_QUBIT_LATTICE_NARROW_THEOREM_NOTE_2026-05-20.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/audit_companion_busch_povm_effect_gleason_qubit_2026_06_05.py",
-      "transitive_descendants": 1008
+      "transitive_descendants": 1009
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4051,12 +4079,12 @@
       "helper_runner_paths": [
         "scripts/transfer_matrix_log_quasilocality_check_2026_06_10.py"
       ],
-      "load_bearing_score": 14.477,
+      "load_bearing_score": 14.479,
       "note_path": "docs/FREE_BILINEAR_QUASILOCAL_LR_BRIDGE_THEOREM_NOTE_2026-06-10.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/free_bilinear_quasilocal_lr_bridge_2026_06_10.py",
-      "transitive_descendants": 1007
+      "transitive_descendants": 1008
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4077,12 +4105,12 @@
       "direct_in_degree": 19,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 22.476,
+      "load_bearing_score": 22.477,
       "note_path": "docs/N_EFF_FROM_THREE_GENERATIONS_THEOREM_NOTE_2026-04-24.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_n_eff_from_three_generations.py",
-      "transitive_descendants": 1006
+      "transitive_descendants": 1007
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4101,12 +4129,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.976,
+      "load_bearing_score": 15.977,
       "note_path": "docs/DM_NEUTRINO_TRIPLET_CHARACTER_SOURCE_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_triplet_character_source_theorem.py",
-      "transitive_descendants": 1006
+      "transitive_descendants": 1007
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4131,12 +4159,12 @@
       "direct_in_degree": 22,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 23.974,
+      "load_bearing_score": 23.976,
       "note_path": "docs/CKM_A_SQUARED_BELOW_W2_Y_QUANTUM_CLOSURE_THEOREM_NOTE_2026-04-25.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_ckm_a_squared_below_w2_y_quantum_closure.py",
-      "transitive_descendants": 1005
+      "transitive_descendants": 1006
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4165,12 +4193,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.474,
+      "load_bearing_score": 15.476,
       "note_path": "docs/AXIOM_FIRST_STEFAN_BOLTZMANN_THEOREM_NOTE_2026-05-01.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/axiom_first_stefan_boltzmann_check.py",
-      "transitive_descendants": 1005
+      "transitive_descendants": 1006
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4179,7 +4207,7 @@
       "claim_id": "g_bare_constraint_vs_convention_theorem_note_2026-05-03",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -4190,12 +4218,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.473,
+      "load_bearing_score": 15.474,
       "note_path": "docs/G_BARE_CONSTRAINT_VS_CONVENTION_THEOREM_NOTE_2026-05-03.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_g_bare_constraint_surface_check.py",
-      "transitive_descendants": 1004
+      "transitive_descendants": 1005
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4204,7 +4232,7 @@
       "claim_id": "magnitude_temporal_factor_is_count_not_rate_2026-06-06",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -4219,12 +4247,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.473,
+      "load_bearing_score": 14.474,
       "note_path": "docs/MAGNITUDE_TEMPORAL_FACTOR_IS_COUNT_NOT_RATE_2026-06-06.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/magnitude_temporal_factor_is_count_not_rate_2026_06_06.py",
-      "transitive_descendants": 1004
+      "transitive_descendants": 1005
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4246,12 +4274,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.972,
+      "load_bearing_score": 15.973,
       "note_path": "docs/DM_NEUTRINO_K00_BOSONIC_NORMALIZATION_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_k00_bosonic_normalization_theorem.py",
-      "transitive_descendants": 1003
+      "transitive_descendants": 1004
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4272,12 +4300,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.972,
+      "load_bearing_score": 13.973,
       "note_path": "docs/GAUGE_MATTER_CLOSURE_GATES_2026-04-12.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_gauge_matter_closure_gates_source_packet.py",
-      "transitive_descendants": 1003
+      "transitive_descendants": 1004
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4300,12 +4328,12 @@
       "direct_in_degree": 44,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 34.97,
+      "load_bearing_score": 34.972,
       "note_path": "docs/STAGGERED_DIRAC_BZ_CORNER_FORCING_THEOREM_NOTE_2026-05-07.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/probe_bz_corner_decomposition.py",
-      "transitive_descendants": 1002
+      "transitive_descendants": 1003
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4327,12 +4355,12 @@
       "direct_in_degree": 11,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 18.47,
+      "load_bearing_score": 18.472,
       "note_path": "docs/NEUTRINO_MAJORANA_CURRENT_STACK_ZERO_LAW_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_current_stack_zero_law.py",
-      "transitive_descendants": 1002
+      "transitive_descendants": 1003
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4355,12 +4383,12 @@
       "helper_runner_paths": [
         "scripts/dm_leptogenesis_exact_common.py"
       ],
-      "load_bearing_score": 15.97,
+      "load_bearing_score": 15.972,
       "note_path": "docs/DM_LEPTOGENESIS_HRAD_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_hrad_theorem.py",
-      "transitive_descendants": 1002
+      "transitive_descendants": 1003
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4381,12 +4409,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.97,
+      "load_bearing_score": 15.972,
       "note_path": "docs/DM_NEUTRINO_VEVEN_BOSONIC_NORMALIZATION_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_veven_bosonic_normalization_theorem.py",
-      "transitive_descendants": 1002
+      "transitive_descendants": 1003
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4408,12 +4436,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.47,
+      "load_bearing_score": 14.472,
       "note_path": "docs/DM_NEUTRINO_TWO_HIGGS_MINIMALITY_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_two_higgs_minimality_theorem.py",
-      "transitive_descendants": 1002
+      "transitive_descendants": 1003
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4434,12 +4462,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.97,
+      "load_bearing_score": 13.972,
       "note_path": "docs/DM_NEUTRINO_ODD_CIRCULANT_CURRENT_STACK_ZERO_LAW_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_odd_circulant_current_stack_zero_law.py",
-      "transitive_descendants": 1002
+      "transitive_descendants": 1003
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4463,12 +4491,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.97,
+      "load_bearing_score": 13.972,
       "note_path": "docs/MAGNITUDE_READS_MINIMAL_RECORD_BLOCK_2026-06-06.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/magnitude_reads_minimal_record_block_2026_06_06.py",
-      "transitive_descendants": 1002
+      "transitive_descendants": 1003
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4489,12 +4517,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.97,
+      "load_bearing_score": 13.972,
       "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_P2_FROM_QUBIT_TRACE_NOTE_2026-05-20.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/audit_companion_observable_principle_p1_p2_qubit_trace_2026_05_22.py",
-      "transitive_descendants": 1002
+      "transitive_descendants": 1003
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4516,12 +4544,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.47,
+      "load_bearing_score": 13.472,
       "note_path": "docs/DM_NEUTRINO_TWO_HIGGS_CONTINUITY_SHEET_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_two_higgs_continuity_sheet_theorem.py",
-      "transitive_descendants": 1002
+      "transitive_descendants": 1003
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4551,12 +4579,12 @@
         "scripts/free_bilinear_quasilocal_lr_bridge_2026_06_10.py",
         "scripts/transfer_matrix_log_quasilocality_check_2026_06_10.py"
       ],
-      "load_bearing_score": 22.469,
+      "load_bearing_score": 22.47,
       "note_path": "docs/AXIOM_FIRST_MICROCAUSALITY_LIEB_ROBINSON_THEOREM_NOTE_2026-05-01.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/axiom_first_microcausality_check.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4577,12 +4605,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.469,
+      "load_bearing_score": 16.47,
       "note_path": "docs/AXIOM_FIRST_REEH_SCHLIEDER_THEOREM_NOTE_2026-05-01.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/axiom_first_reeh_schlieder_check.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4604,12 +4632,12 @@
         "scripts/dm_leptogenesis_exact_common.py",
         "scripts/frontier_dm_neutrino_positive_polar_h_cp_theorem.py"
       ],
-      "load_bearing_score": 16.469,
+      "load_bearing_score": 16.47,
       "note_path": "docs/DM_NEUTRINO_EXACT_H_SOURCE_SURFACE_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_exact_h_source_surface_theorem.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4631,12 +4659,12 @@
       "helper_runner_paths": [
         "scripts/dm_leptogenesis_exact_common.py"
       ],
-      "load_bearing_score": 15.969,
+      "load_bearing_score": 15.97,
       "note_path": "docs/DM_LEPTOGENESIS_TRANSPORT_INTEGRAL_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_transport_integral_theorem.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4657,12 +4685,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.969,
+      "load_bearing_score": 15.97,
       "note_path": "docs/NEUTRINO_MAJORANA_LOWER_LEVEL_PAIRING_NOGO_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_lower_level_pairing_nogo.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4681,12 +4709,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.469,
+      "load_bearing_score": 15.47,
       "note_path": "docs/LEPTON_SHARED_HIGGS_UNIVERSALITY_UNDERDETERMINATION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_lepton_shared_higgs_universality_underdetermination.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4705,12 +4733,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.969,
+      "load_bearing_score": 14.97,
       "note_path": "docs/PMNS_MINIMAL_BRANCH_NONSELECTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_minimal_branch_nonselection.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4730,12 +4758,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.469,
+      "load_bearing_score": 14.47,
       "note_path": "docs/RECORD_UNBOUNDED_FINITE_ADDITIVITY_SCHEMA_2026-06-06.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_record_unbounded_additivity_schema_2026_06_06.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4755,12 +4783,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.969,
+      "load_bearing_score": 13.97,
       "note_path": "docs/NEUTRINO_MAJORANA_NUR_CHARACTER_BOUNDARY_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_nur_character_boundary.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4783,12 +4811,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.969,
+      "load_bearing_score": 13.97,
       "note_path": "docs/NEUTRINO_MAJORANA_NUR_CHARGE2_PRIMITIVE_REDUCTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_nur_charge2_primitive_reduction.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4810,12 +4838,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 13.969,
+      "load_bearing_score": 13.97,
       "note_path": "docs/YT_EFT_BRIDGE_THEOREM.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_eft_bridge.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4835,12 +4863,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.469,
+      "load_bearing_score": 13.47,
       "note_path": "docs/DM_NEUTRINO_BREAKING_TRIPLET_AXIOM_LAW_ATTEMPT_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_breaking_triplet_axiom_law_attempt.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4862,12 +4890,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.469,
+      "load_bearing_score": 13.47,
       "note_path": "docs/DM_NEUTRINO_ODD_MIXED_BRIDGE_EXTENSION_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_odd_mixed_bridge_extension.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4886,12 +4914,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.469,
+      "load_bearing_score": 13.47,
       "note_path": "docs/DM_NEUTRINO_TRIPLET_EVEN_RESPONSE_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_triplet_even_response_theorem.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4911,12 +4939,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.469,
+      "load_bearing_score": 13.47,
       "note_path": "docs/DM_STRONG_CP_GAMMA_TRANSFER_NO_GO_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_strong_cp_gamma_transfer_nogo.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4938,12 +4966,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.469,
+      "load_bearing_score": 13.47,
       "note_path": "docs/LOCAL_TOMOGRAPHY_FROM_QUBIT_COMPLEX_STRUCTURE_NARROW_THEOREM_NOTE_2026-06-03.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/audit_companion_local_tomography_from_complex_structure_exact.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4964,12 +4992,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.469,
+      "load_bearing_score": 13.47,
       "note_path": "docs/P2_PHASE_BLINDNESS_FROM_RP_TRANSFER_TRACE_BRIDGE_NOTE_2026-05-28.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/p2_phase_blindness_rp_transfer_trace_bridge_2026_05_28.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -4991,12 +5019,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.469,
+      "load_bearing_score": 13.47,
       "note_path": "docs/SINGLE_CLOCK_BLOCKED_TIME_UNIT_SPLIT_N2_SUPPORT_NOTE_2026-06-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/single_clock_blocked_time_unit_split_n2_support_2026_06_17.py",
-      "transitive_descendants": 1001
+      "transitive_descendants": 1002
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5027,12 +5055,12 @@
       "direct_in_degree": 63,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 44.467,
+      "load_bearing_score": 44.469,
       "note_path": "docs/STAGGERED_DIRAC_SUBSTEP4_AC_NARROW_BOUNDED_NOTE_2026-05-07_substep4ac.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_staggered_dirac_substep4_ac_check_2026_05_07_substep4ac.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5063,12 +5091,12 @@
       "direct_in_degree": 53,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 39.467,
+      "load_bearing_score": 39.469,
       "note_path": "docs/STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/staggered_dirac_realization_gate_synthesis_check_2026_06_09.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5101,12 +5129,12 @@
         "scripts/frontier_dm_neutrino_source_surface_intrinsic_slot_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py"
       ],
-      "load_bearing_score": 31.467,
+      "load_bearing_score": 31.469,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_ACTIVE_HALF_PLANE_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_active_half_plane_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5139,12 +5167,12 @@
         "scripts/frontier_dm_neutrino_source_surface_intrinsic_slot_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py"
       ],
-      "load_bearing_score": 27.467,
+      "load_bearing_score": 27.469,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_ACTIVE_AFFINE_POINT_SELECTION_BOUNDARY_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_active_affine_point_selection_boundary.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5179,12 +5207,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 26.467,
+      "load_bearing_score": 26.469,
       "note_path": "docs/HIGGS_MASS_DERIVED_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_higgs_mass_full_3loop.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5217,12 +5245,12 @@
       "direct_in_degree": 24,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 24.967,
+      "load_bearing_score": 24.969,
       "note_path": "docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/axiom_first_single_clock_codimension1_evolution_check.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5256,12 +5284,12 @@
         "scripts/frontier_dm_neutrino_source_surface_intrinsic_slot_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py"
       ],
-      "load_bearing_score": 24.467,
+      "load_bearing_score": 24.469,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_Z3_DOUBLET_BLOCK_POINT_SELECTION_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_z3_doublet_block_point_selection_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5289,12 +5317,12 @@
         "scripts/frontier_dm_neutrino_hermitian_bridge_carrier.py",
         "scripts/frontier_dm_neutrino_positive_polar_h_cp_theorem.py"
       ],
-      "load_bearing_score": 22.967,
+      "load_bearing_score": 22.969,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_CARRIER_NORMAL_FORM_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_carrier_normal_form.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5322,12 +5350,12 @@
         "scripts/frontier_dm_neutrino_positive_polar_h_cp_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_carrier_normal_form.py"
       ],
-      "load_bearing_score": 22.467,
+      "load_bearing_score": 22.469,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_SHIFT_QUOTIENT_BUNDLE_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5353,12 +5381,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 22.467,
+      "load_bearing_score": 22.469,
       "note_path": "docs/YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_bz_quadrature_full_staggered_pt.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5383,12 +5411,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 21.467,
+      "load_bearing_score": 21.469,
       "note_path": "docs/HIGGS_VACUUM_EXPLICIT_SYSTEMATIC_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_higgs_mass_full_3loop.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5416,12 +5444,12 @@
       "helper_runner_paths": [
         "scripts/dm_leptogenesis_exact_common.py"
       ],
-      "load_bearing_score": 20.967,
+      "load_bearing_score": 20.969,
       "note_path": "docs/DM_LEPTOGENESIS_TRANSPORT_STATUS_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_transport_status.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5444,12 +5472,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 20.967,
+      "load_bearing_score": 20.969,
       "note_path": "docs/YT_QFP_INSENSITIVITY_SUPPORT_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_qfp_insensitivity.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5476,12 +5504,12 @@
         "scripts/frontier_dm_leptogenesis_flavor_column_functional_theorem.py",
         "scripts/frontier_dm_leptogenesis_pmns_projector_interface.py"
       ],
-      "load_bearing_score": 20.467,
+      "load_bearing_score": 20.469,
       "note_path": "docs/DM_LEPTOGENESIS_NE_PROJECTED_SOURCE_LAW_DERIVATION_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_ne_projected_source_law_derivation.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5506,12 +5534,12 @@
       "direct_in_degree": 15,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 20.467,
+      "load_bearing_score": 20.469,
       "note_path": "docs/SU2_WEAK_BETA_COEFFICIENT_STRUCTURAL_CLOSED_FORM_THEOREM_NOTE_2026-04-26.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_su2_weak_beta_coefficient_structural_closed_form.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5534,12 +5562,12 @@
       "direct_in_degree": 15,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 20.467,
+      "load_bearing_score": 20.469,
       "note_path": "docs/YT_EXACT_SCHUR_NORMAL_FORM_UNIQUENESS_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_exact_schur_normal_form_uniqueness.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5562,12 +5590,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 20.467,
+      "load_bearing_score": 20.469,
       "note_path": "docs/YT_P1_DELTA_R_FERMION_REGULATOR_DEPENDENCE_AND_SCALAR_NTASTE_RESOLUTION_NOTE_2026-06-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_bz_quadrature_full_staggered_pt.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5591,12 +5619,12 @@
         "scripts/frontier_dm_leptogenesis_flavor_column_functional_theorem.py",
         "scripts/frontier_dm_leptogenesis_pmns_projector_interface.py"
       ],
-      "load_bearing_score": 19.967,
+      "load_bearing_score": 19.969,
       "note_path": "docs/DM_LEPTOGENESIS_NE_CHARGED_SOURCE_RESPONSE_REDUCTION_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_ne_charged_source_response_reduction.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5618,12 +5646,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 19.967,
+      "load_bearing_score": 19.969,
       "note_path": "docs/HIERARCHY_BOSONIC_BILINEAR_SELECTOR_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_hierarchy_bosonic_bilinear_selector.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5654,12 +5682,12 @@
         "scripts/frontier_dm_neutrino_source_surface_carrier_normal_form.py",
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py"
       ],
-      "load_bearing_score": 19.467,
+      "load_bearing_score": 19.469,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_INTRINSIC_SLOT_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_intrinsic_slot_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5680,12 +5708,12 @@
       "direct_in_degree": 13,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 19.467,
+      "load_bearing_score": 19.469,
       "note_path": "docs/NEUTRINO_MASS_REDUCTION_TO_DIRAC_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_mass_reduction_to_dirac.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5705,12 +5733,12 @@
       "direct_in_degree": 13,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 19.467,
+      "load_bearing_score": 19.469,
       "note_path": "docs/YT_CONSTRUCTIVE_UV_BRIDGE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_constructive_uv_bridge.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5747,12 +5775,12 @@
         "scripts/frontier_dm_neutrino_source_surface_intrinsic_slot_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py"
       ],
-      "load_bearing_score": 18.967,
+      "load_bearing_score": 18.969,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_SCHUR_SCALAR_BASELINE_THEOREM_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_schur_scalar_baseline_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5778,12 +5806,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 18.967,
+      "load_bearing_score": 18.969,
       "note_path": "docs/YT_P2_TASTE_STAIRCASE_BETA_FUNCTIONS_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p2_taste_staircase_beta.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5807,12 +5835,12 @@
         "scripts/dm_leptogenesis_exact_common.py",
         "scripts/frontier_dm_leptogenesis_pmns_projector_interface.py"
       ],
-      "load_bearing_score": 18.467,
+      "load_bearing_score": 18.469,
       "note_path": "docs/DM_LEPTOGENESIS_PMNS_ACTIVE_PROJECTOR_REDUCTION_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_pmns_active_projector_reduction.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5852,12 +5880,12 @@
         "scripts/frontier_pmns_uniform_scalar_deformation_boundary.py",
         "scripts/pmns_lower_level_utils.py"
       ],
-      "load_bearing_score": 17.967,
+      "load_bearing_score": 17.969,
       "note_path": "docs/NEUTRINO_TWO_AMPLITUDE_LAST_MILE_REDUCTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_two_amplitude_last_mile.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5890,12 +5918,12 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.967,
+      "load_bearing_score": 17.969,
       "note_path": "docs/PMNS_FROM_DM_NEUTRINO_SOURCE_H_DIAGONALIZATION_CLOSURE_THEOREM_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_from_dm_neutrino_source_h_diagonalization_closure_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5914,12 +5942,12 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.967,
+      "load_bearing_score": 17.969,
       "note_path": "docs/PMNS_SELECTOR_UNIQUE_AMPLITUDE_SLOT_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_selector_unique_amplitude_slot.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5941,12 +5969,12 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.967,
+      "load_bearing_score": 17.969,
       "note_path": "docs/YT_BRIDGE_HESSIAN_SELECTOR_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_bridge_hessian_selector.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -5967,12 +5995,12 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.967,
+      "load_bearing_score": 17.969,
       "note_path": "docs/YT_INTERACTING_BRIDGE_LOCALITY_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_interacting_bridge_locality.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6000,12 +6028,12 @@
         "scripts/frontier_dm_leptogenesis_pmns_projector_interface.py",
         "scripts/frontier_dm_neutrino_breaking_triplet_cp_theorem.py"
       ],
-      "load_bearing_score": 17.467,
+      "load_bearing_score": 17.469,
       "note_path": "docs/DM_LEPTOGENESIS_NE_PROJECTED_SOURCE_TRIPLET_SIGN_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_ne_projected_source_triplet_sign_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6024,12 +6052,12 @@
       "direct_in_degree": 9,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.467,
+      "load_bearing_score": 17.469,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_P3_SYLVESTER_LINEAR_PATH_SIGNATURE_THEOREM_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_p3_sylvester_linear_path_signature_theorem_2026_04_18.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6051,12 +6079,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 17.467,
+      "load_bearing_score": 17.469,
       "note_path": "docs/HIGGS_MASS_HIERARCHY_CORRECTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_higgs_mass_hierarchy_correction.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6078,12 +6106,12 @@
       "direct_in_degree": 9,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.467,
+      "load_bearing_score": 17.469,
       "note_path": "docs/LEPTON_SINGLE_HIGGS_PMNS_TRIVIALITY_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_lepton_single_higgs_pmns_triviality.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6103,12 +6131,12 @@
       "direct_in_degree": 9,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.467,
+      "load_bearing_score": 17.469,
       "note_path": "docs/NEUTRINO_DIRAC_TWO_HIGGS_CANONICAL_REDUCTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_dirac_two_higgs_canonical_reduction.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6132,12 +6160,12 @@
         "scripts/frontier_dm_leptogenesis_pmns_active_projector_reduction.py",
         "scripts/frontier_dm_leptogenesis_pmns_projector_interface.py"
       ],
-      "load_bearing_score": 16.967,
+      "load_bearing_score": 16.969,
       "note_path": "docs/DM_LEPTOGENESIS_PMNS_OBSERVABLE_RELATIVE_ACTION_LAW_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_pmns_observable_relative_action_law.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6159,12 +6187,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.967,
+      "load_bearing_score": 16.969,
       "note_path": "docs/NEUTRINO_DIRAC_Z3_SUPPORT_TRICHOTOMY_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_dirac_z3_support_trichotomy.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6185,12 +6213,12 @@
       "helper_runner_paths": [
         "scripts/pmns_lower_level_utils.py"
       ],
-      "load_bearing_score": 16.967,
+      "load_bearing_score": 16.969,
       "note_path": "docs/PMNS_ACTIVE_FOUR_REAL_SOURCE_FROM_TRANSPORT_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_active_four_real_source_from_transport.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6211,12 +6239,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.967,
+      "load_bearing_score": 16.969,
       "note_path": "docs/PMNS_SELECTOR_CURRENT_STACK_ZERO_LAW_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_selector_current_stack_zero_law.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6236,12 +6264,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.967,
+      "load_bearing_score": 16.969,
       "note_path": "docs/YT_BRIDGE_REARRANGEMENT_PRINCIPLE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_bridge_rearrangement_principle.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6266,12 +6294,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 16.967,
+      "load_bearing_score": 16.969,
       "note_path": "docs/YT_P1_REP_A_REP_B_CANCELLATION_THEOREM_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_rep_ab_cancellation.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6294,12 +6322,12 @@
       "helper_runner_paths": [
         "scripts/dm_leptogenesis_exact_common.py"
       ],
-      "load_bearing_score": 16.467,
+      "load_bearing_score": 16.469,
       "note_path": "docs/DM_LEPTOGENESIS_EXACT_KERNEL_CLOSURE_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_exact_kernel_closure.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6327,12 +6355,12 @@
         "scripts/frontier_dm_leptogenesis_pmns_projector_interface.py",
         "scripts/frontier_dm_neutrino_breaking_triplet_cp_theorem.py"
       ],
-      "load_bearing_score": 16.467,
+      "load_bearing_score": 16.469,
       "note_path": "docs/DM_LEPTOGENESIS_PMNS_BREAKING_TRIPLET_SOURCE_LAW_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_pmns_breaking_triplet_source_law.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6369,12 +6397,12 @@
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_z3_doublet_block_point_selection_theorem.py"
       ],
-      "load_bearing_score": 16.467,
+      "load_bearing_score": 16.469,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_Z3_DOUBLET_BLOCK_CURRENT_BANK_BLINDNESS_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_z3_doublet_block_current_bank_blindness_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6394,12 +6422,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.467,
+      "load_bearing_score": 16.469,
       "note_path": "docs/HIGGS_Z3_CHARGE_PMNS_GAUGE_REDUNDANCY_THEOREM_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_higgs_z3_charge_pmns_gauge_redundancy_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6435,12 +6463,12 @@
         "scripts/frontier_pmns_uniform_scalar_deformation_boundary.py",
         "scripts/pmns_lower_level_utils.py"
       ],
-      "load_bearing_score": 16.467,
+      "load_bearing_score": 16.469,
       "note_path": "docs/PMNS_C3_NONTRIVIAL_CURRENT_BOUNDARY_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_c3_nontrivial_current_boundary.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6460,12 +6488,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.467,
+      "load_bearing_score": 16.469,
       "note_path": "docs/PMNS_SCALAR_BRIDGE_NONREALIZATION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_scalar_bridge_nonrealization.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6486,12 +6514,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.467,
+      "load_bearing_score": 16.469,
       "note_path": "docs/PMNS_SECTOR_EXCHANGE_NONFORCING_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_sector_exchange_nonforcing.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6513,12 +6541,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.467,
+      "load_bearing_score": 16.469,
       "note_path": "docs/PMNS_SELECTOR_SIGN_TO_BRANCH_REDUCTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_selector_sign_to_branch_reduction.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6539,12 +6567,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.467,
+      "load_bearing_score": 16.469,
       "note_path": "docs/YT_BRIDGE_HIGHER_ORDER_CORRECTIONS_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_bridge_higher_order_corrections.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6566,12 +6594,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.467,
+      "load_bearing_score": 16.469,
       "note_path": "docs/YT_BRIDGE_NONLOCAL_CORRECTIONS_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_bridge_nonlocal_corrections.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6595,12 +6623,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 16.467,
+      "load_bearing_score": 16.469,
       "note_path": "docs/YT_P1_H_UNIT_RENORMALIZATION_FRAMEWORK_NATIVE_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_h_unit_renormalization.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6625,12 +6653,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.967,
+      "load_bearing_score": 15.969,
       "note_path": "docs/CHARGED_LEPTON_UE_IDENTITY_VIA_Z3_TRICHOTOMY_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_charged_lepton_ue_identity_via_z3_trichotomy.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6654,12 +6682,12 @@
       "helper_runner_paths": [
         "scripts/dm_leptogenesis_exact_common.py"
       ],
-      "load_bearing_score": 15.967,
+      "load_bearing_score": 15.969,
       "note_path": "docs/DM_LEPTOGENESIS_TRANSPORT_DECOMPOSITION_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_transport_decomposition_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6690,12 +6718,12 @@
         "scripts/frontier_dm_neutrino_source_surface_carrier_normal_form.py",
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py"
       ],
-      "load_bearing_score": 15.967,
+      "load_bearing_score": 15.969,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_M_SPECTATOR_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_m_spectator_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6715,12 +6743,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.967,
+      "load_bearing_score": 15.969,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_PERTURBATIVE_UNIQUENESS_THEOREM_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_perturbative_uniqueness_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6744,12 +6772,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.967,
+      "load_bearing_score": 15.969,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_Z3_PARITY_SPLIT_THEOREM_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_z3_parity_split_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6770,12 +6798,12 @@
       "helper_runner_paths": [
         "scripts/pmns_lower_level_utils.py"
       ],
-      "load_bearing_score": 15.967,
+      "load_bearing_score": 15.969,
       "note_path": "docs/PMNS_LOWER_LEVEL_END_TO_END_CLOSURE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_lower_level_end_to_end_closure.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6798,12 +6826,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.967,
+      "load_bearing_score": 15.969,
       "note_path": "docs/PMNS_SECTOR_ORIENTATION_ORBIT_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_sector_orientation_orbit.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6823,12 +6851,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.967,
+      "load_bearing_score": 15.969,
       "note_path": "docs/PMNS_SELECTOR_SECTOR_ODD_REDUCTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_sector_odd_bridge_reduction.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6875,12 +6903,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.967,
+      "load_bearing_score": 15.969,
       "note_path": "docs/STAGGERED_DIRAC_GATE_CLOSURE_SYNTHESIS_THEOREM_NOTE_2026-05-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_staggered_dirac_gate_closure_synthesis_2026_05_17.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6907,12 +6935,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.967,
+      "load_bearing_score": 15.969,
       "note_path": "docs/STAGGERED_DIRAC_PHYSICAL_SPECIES_DIRECT_THEOREM_NOTE_2026-05-07.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/probe_three_states_direct_derivation.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6935,12 +6963,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.967,
+      "load_bearing_score": 15.969,
       "note_path": "docs/YT_BRIDGE_MOMENT_CLOSURE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_bridge_moment_closure.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -6968,12 +6996,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 15.967,
+      "load_bearing_score": 15.969,
       "note_path": "docs/YT_P1_I_S_LATTICE_PT_CITATION_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_i_s_reaudit_packet_2026_06_12.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7006,12 +7034,12 @@
         "scripts/frontier_dm_leptogenesis_pmns_transport_extremal_source_candidate.py",
         "scripts/frontier_dm_neutrino_breaking_triplet_cp_theorem.py"
       ],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/DM_LEPTOGENESIS_PMNS_SELECTOR_BANK_CP_SHEET_BLINDNESS_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_pmns_selector_bank_cp_sheet_blindness_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7033,12 +7061,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/DM_NEUTRINO_CODD_BOSONIC_NORMALIZATION_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_codd_bosonic_normalization_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7061,12 +7089,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/DM_NEUTRINO_SOURCE_AMPLITUDE_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_amplitude_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7101,12 +7129,12 @@
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_z3_doublet_block_point_selection_theorem.py"
       ],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/DM_NEUTRINO_SOURCE_BANK_Z3_DOUBLET_BLOCK_SELECTION_OBSTRUCTION_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_bank_z3_doublet_block_selection_obstruction_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7139,12 +7167,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_PARITY_MIXING_SELECTION_OBSTRUCTION_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_parity_mixing_selection_obstruction.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7176,12 +7204,12 @@
         "scripts/frontier_dm_neutrino_source_surface_intrinsic_slot_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py"
       ],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_SLOT_TORSION_BOUNDARY_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_slot_torsion_boundary_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7211,12 +7239,12 @@
         "scripts/frontier_pmns_uniform_scalar_deformation_boundary.py",
         "scripts/pmns_lower_level_utils.py"
       ],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/PMNS_CURRENT_BANK_VALUE_SELECTION_NOGO_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_current_bank_value_selection_nogo.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7241,12 +7269,12 @@
         "scripts/frontier_pmns_oriented_cycle_selection_structure.py",
         "scripts/pmns_lower_level_utils.py"
       ],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/PMNS_ORIENTED_CYCLE_REDUCED_CHANNEL_NONSELECTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_oriented_cycle_reduced_channel_nonselection.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7267,12 +7295,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/PMNS_SELECTOR_CLASS_SPACE_UNIQUENESS_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_selector_class_space_uniqueness.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7294,12 +7322,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/PMNS_SELECTOR_NONUNIVERSAL_SUPPORT_REDUCTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_selector_nonuniversal_support_reduction.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7325,12 +7353,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/STAGGERED_DIRAC_SUBSTEP4_LABELING_NO_GO_NOTE_2026-05-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/audit_companion_staggered_dirac_substep4_labeling_no_go_2026_05_17.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7353,12 +7381,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/YT_BRIDGE_ACTION_INVARIANT_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_bridge_action_invariant.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7380,12 +7408,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/YT_P1_LOOP_GEOMETRIC_BOUND_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_loop_geometric_bound.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7408,12 +7436,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 15.467,
+      "load_bearing_score": 15.469,
       "note_path": "docs/YT_P2_V_MATCHING_THEOREM_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p2_v_matching.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7440,12 +7468,12 @@
         "scripts/frontier_dm_leptogenesis_pmns_observable_relative_action_law.py",
         "scripts/frontier_dm_leptogenesis_pmns_projector_interface.py"
       ],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/DM_LEPTOGENESIS_PMNS_RELATIVE_ACTION_STATIONARITY_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_pmns_relative_action_stationarity_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7469,12 +7497,12 @@
         "scripts/dm_leptogenesis_exact_common.py",
         "scripts/frontier_dm_neutrino_positive_polar_h_cp_theorem.py"
       ],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/DM_NEUTRINO_EXACT_H_SOURCE_SURFACE_PREIMAGE_BUNDLE_THEOREM_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_exact_h_source_surface_preimage_bundle_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7514,12 +7542,12 @@
         "scripts/frontier_dm_neutrino_source_surface_intrinsic_slot_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py"
       ],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/DM_NEUTRINO_OBSERVABLE_BANK_EXHAUSTION_THEOREM_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_observable_bank_exhaustion_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7555,12 +7583,12 @@
         "scripts/frontier_dm_neutrino_source_surface_intrinsic_slot_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py"
       ],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_CUBIC_VARIATIONAL_OBSTRUCTION_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_cubic_variational_obstruction.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7596,12 +7624,12 @@
         "scripts/frontier_dm_neutrino_source_surface_intrinsic_slot_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py"
       ],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_INFO_GEOMETRIC_SELECTION_OBSTRUCTION_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_info_geometric_selection_obstruction.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7634,12 +7662,12 @@
         "scripts/frontier_dm_neutrino_source_surface_intrinsic_slot_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py"
       ],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_SCALAR_BASELINE_ACTIVE_QUADRATIC_DIAGNOSTIC_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_scalar_baseline_active_quadratic_diagnostic.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7677,12 +7705,12 @@
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_z3_doublet_block_point_selection_theorem.py"
       ],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_Z3_DOUBLET_BLOCK_FULL_CLOSURE_BOUNDARY_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_z3_doublet_block_full_closure_boundary.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7702,12 +7730,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/DM_NEUTRINO_Z3_CHARACTER_TRANSFER_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_z3_character_transfer_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7728,12 +7756,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/LEPTON_SHARED_HIGGS_UNIVERSALITY_COLLAPSE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_lepton_shared_higgs_universality_collapse.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7760,12 +7788,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/NEUTRINO_MAJORANA_RETAINED_LANE_PACKET_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_neutrino_majorana_current_stack_zero_law.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7786,12 +7814,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/PMNS_CORNER_TRANSPORT_ACTIVE_BLOCK_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_corner_transport_active_block.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7810,12 +7838,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/PMNS_SELECTOR_BANK_NONREALIZATION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_selector_bank_nonrealization.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7837,12 +7865,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/YT_BRIDGE_ENDPOINT_SHIFT_BOUND_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_bridge_endpoint_shift_bound.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7865,12 +7893,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/YT_EW_COUPLING_BRIDGE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_ew_coupling_derivation.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7893,12 +7921,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/YT_EXACT_COARSE_GRAINED_BRIDGE_OPERATOR_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_exact_coarse_grained_bridge_operator.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7917,12 +7945,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/YT_EXPLICIT_SYSTEMATIC_BUDGET_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_explicit_systematic_budget.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7942,12 +7970,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/YT_P1_COLOR_FACTOR_RETENTION_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_color_factor_retention.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -7970,12 +7998,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/YT_P1_DELTA_1_BZ_COMPUTATION_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_delta_1_bz.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8002,12 +8030,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/YT_P1_DELTA_2_BZ_COMPUTATION_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_delta_2_bz.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8031,12 +8059,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 14.967,
+      "load_bearing_score": 14.969,
       "note_path": "docs/YT_P1_DELTA_3_BZ_COMPUTATION_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_delta_3_bz.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8062,12 +8090,12 @@
         "scripts/frontier_dm_leptogenesis_pmns_projector_interface.py",
         "scripts/frontier_dm_neutrino_breaking_triplet_cp_theorem.py"
       ],
-      "load_bearing_score": 14.467,
+      "load_bearing_score": 14.469,
       "note_path": "docs/DM_LEPTOGENESIS_PMNS_CP_BRIDGE_BOUNDARY_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_pmns_cp_bridge_boundary.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8091,12 +8119,12 @@
         "scripts/frontier_dm_leptogenesis_pmns_active_projector_reduction.py",
         "scripts/frontier_dm_leptogenesis_pmns_projector_interface.py"
       ],
-      "load_bearing_score": 14.467,
+      "load_bearing_score": 14.469,
       "note_path": "docs/DM_LEPTOGENESIS_PMNS_MICROSCOPIC_D_LAST_MILE_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_pmns_microscopic_d_last_mile.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8126,12 +8154,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.467,
+      "load_bearing_score": 14.469,
       "note_path": "docs/EW_COUPLING_DERIVATION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/ew_coupling_bounded_status_runner_2026_05_03.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8166,12 +8194,12 @@
         "scripts/frontier_pmns_uniform_scalar_deformation_boundary.py",
         "scripts/pmns_lower_level_utils.py"
       ],
-      "load_bearing_score": 14.467,
+      "load_bearing_score": 14.469,
       "note_path": "docs/PMNS_C3_CHARACTER_MODE_REDUCTION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_c3_character_mode_reduction.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8194,12 +8222,12 @@
         "scripts/frontier_pmns_lower_level_end_to_end_closure.py",
         "scripts/pmns_lower_level_utils.py"
       ],
-      "load_bearing_score": 14.467,
+      "load_bearing_score": 14.469,
       "note_path": "docs/PMNS_SOLE_AXIOM_HW1_SOURCE_TRANSFER_BOUNDARY_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_pmns_sole_axiom_hw1_source_transfer_boundary.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8221,12 +8249,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.467,
+      "load_bearing_score": 14.469,
       "note_path": "docs/YT_BRIDGE_OPERATOR_CLOSURE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_bridge_operator_closure.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8250,12 +8278,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.467,
+      "load_bearing_score": 14.469,
       "note_path": "docs/YT_BRIDGE_UV_CLASS_UNIQUENESS_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_bridge_uv_class_uniqueness.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8277,12 +8305,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.467,
+      "load_bearing_score": 14.469,
       "note_path": "docs/YT_P1_SHARED_FIERZ_NO_GO_SUB_THEOREM_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_shared_fierz_no_go.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8307,12 +8335,12 @@
         "scripts/frontier_dm_leptogenesis_pmns_active_projector_reduction.py",
         "scripts/frontier_dm_leptogenesis_pmns_projector_interface.py"
       ],
-      "load_bearing_score": 13.967,
+      "load_bearing_score": 13.969,
       "note_path": "docs/DM_LEPTOGENESIS_NE_ACTIVE_COLUMN_AXIOM_BOUNDARY_NOTE_2026-04-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_leptogenesis_ne_active_column_axiom_boundary.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8333,12 +8361,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.967,
+      "load_bearing_score": 13.969,
       "note_path": "docs/DM_NEUTRINO_HERMITIAN_BRIDGE_CARRIER_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_hermitian_bridge_carrier.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8361,12 +8389,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.967,
+      "load_bearing_score": 13.969,
       "note_path": "docs/DM_NEUTRINO_WEAK_TRIPLET_TRANSFER_CLASS_THEOREM_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_weak_triplet_transfer_class_theorem.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8397,12 +8425,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.967,
+      "load_bearing_score": 13.969,
       "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_BR_LICENSE_FROM_RECORD_CAPACITY_NARROW_NO_GO_NOTE_2026-06-10.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/observable_principle_p1_br_license_check_2026_06_10.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8433,12 +8461,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.967,
+      "load_bearing_score": 13.969,
       "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_CAP_K_FROM_FINITE_SPEED_REGISTRATION_NARROW_THEOREM_NOTE_2026-06-10.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/observable_principle_p1_cap_k_check_2026_06_10.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8463,12 +8491,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.967,
+      "load_bearing_score": 13.969,
       "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_EXPONENT_BARRIER_PARAMETER_SELECTOR_NARROW_THEOREM_NOTE_2026-06-10.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/observable_principle_p1_exponent_attack_2026_06_10.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8494,12 +8522,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.967,
+      "load_bearing_score": 13.969,
       "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_NU_LICENSE_FROM_RETAINED_SURFACE_NARROW_NO_GO_NOTE_2026-06-10.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/observable_principle_p1_nu_license_check_2026_06_10.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8521,12 +8549,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.967,
+      "load_bearing_score": 13.969,
       "note_path": "docs/PMNS_TM2_TRIMAXIMAL_COLUMN_FROM_RECORD_CENTRAL_SECTOR_NARROW_THEOREM_NOTE_2026-06-05.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/pmns_tm2_trimaximal_from_record_central_sector_runner.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8548,12 +8576,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.967,
+      "load_bearing_score": 13.969,
       "note_path": "docs/YT_FLAGSHIP_BOUNDARY_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_flagship_boundary_contract.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8576,12 +8604,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 13.967,
+      "load_bearing_score": 13.969,
       "note_path": "docs/YT_P1_I_S_REVISION_VERIFICATION_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_i_s_revision_verification.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8606,12 +8634,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 13.967,
+      "load_bearing_score": 13.969,
       "note_path": "docs/YT_P2_TASTE_STAIRCASE_TRANSPORT_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p2_taste_staircase_transport.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8631,12 +8659,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.467,
+      "load_bearing_score": 13.469,
       "note_path": "docs/DM_NEUTRINO_Z3_PHASE_LIFT_MIXED_BRIDGE_NOTE_2026-04-15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_z3_phase_lift_bridge.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8660,12 +8688,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.467,
+      "load_bearing_score": 13.469,
       "note_path": "docs/PMNS_TM2_MAGIC_RESIDUAL_DYNAMICAL_GENERATOR_NARROW_THEOREM_NOTE_2026-06-05.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/pmns_tm2_magic_residual_dynamical_generator_runner.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8685,12 +8713,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.467,
+      "load_bearing_score": 13.469,
       "note_path": "docs/SINGLE_CLOCK_APBC_AXIS_LABEL_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_single_clock_apbc_axis_label_bridge_2026_06_16.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8720,12 +8748,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.467,
+      "load_bearing_score": 13.469,
       "note_path": "docs/SINGLE_CLOCK_AXIS_SELECTION_FROM_RECORD_DURABILITY_NARROW_NO_GO_NOTE_2026-06-11.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/single_clock_axis_selection_check_2026_06_11.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8750,12 +8778,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.467,
+      "load_bearing_score": 13.469,
       "note_path": "docs/STAGGERED_DIRAC_GATE_AC_PHI_LAMBDA_LABELING_CONVENTION_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-26.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/staggered_dirac_gate_ac_phi_lambda_labeling_convention_accepted_premise_runner.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8784,12 +8812,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 13.467,
+      "load_bearing_score": 13.469,
       "note_path": "docs/YT_P1_DELTA_R_SM_RGE_CROSSCHECK_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_delta_r_sm_rge_crosscheck.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8809,12 +8837,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.467,
+      "load_bearing_score": 13.469,
       "note_path": "docs/YT_P1_I_S_NATIVE_KERNEL_SETTLED_BOUNDED_THEOREM_NOTE_2026-06-16.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/yt_p1_i_s_native_kernel_settled_2026_06_16.py",
-      "transitive_descendants": 1000
+      "transitive_descendants": 1001
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8836,12 +8864,12 @@
       "direct_in_degree": 16,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.6,
+      "load_bearing_score": 16.604,
       "note_path": "docs/G_BARE_STRUCTURAL_NORMALIZATION_THEOREM_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_g_bare_structural_normalization.py",
-      "transitive_descendants": 387
+      "transitive_descendants": 388
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8862,12 +8890,12 @@
       "direct_in_degree": 15,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.085,
+      "load_bearing_score": 16.089,
       "note_path": "docs/GAUGE_VACUUM_PLAQUETTE_SPATIAL_ENVIRONMENT_CHARACTER_MEASURE_THEOREM_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_gauge_vacuum_plaquette_spatial_environment_character_measure.py",
-      "transitive_descendants": 383
+      "transitive_descendants": 384
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8887,12 +8915,12 @@
       "direct_in_degree": 9,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.085,
+      "load_bearing_score": 13.089,
       "note_path": "docs/GAUGE_VACUUM_PLAQUETTE_RESIDUAL_ENVIRONMENT_IDENTIFICATION_THEOREM_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_gauge_vacuum_plaquette_residual_environment_identification.py",
-      "transitive_descendants": 383
+      "transitive_descendants": 384
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8914,12 +8942,12 @@
         "scripts/canonical_plaquette_surface.py",
         "scripts/frontier_quark_mass_ratio_full_solve.py"
       ],
-      "load_bearing_score": 15.062,
+      "load_bearing_score": 15.066,
       "note_path": "docs/QUARK_CP_CARRIER_COMPLETION_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_quark_cp_carrier_completion.py",
-      "transitive_descendants": 377
+      "transitive_descendants": 378
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8938,12 +8966,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.062,
+      "load_bearing_score": 9.066,
       "note_path": "docs/QUARK_CP_CARRIER_SLOT_MINIMALITY_THEOREM_NOTE_2026-06-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_quark_cp_carrier_slot_minimality_2026_06_17.py",
-      "transitive_descendants": 377
+      "transitive_descendants": 378
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8965,12 +8993,12 @@
         "scripts/canonical_plaquette_surface.py",
         "scripts/frontier_quark_mass_ratio_full_solve.py"
       ],
-      "load_bearing_score": 14.551,
+      "load_bearing_score": 14.555,
       "note_path": "docs/QUARK_PROJECTOR_RAY_PHASE_COMPLETION_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_quark_projector_ray_phase_completion.py",
-      "transitive_descendants": 374
+      "transitive_descendants": 375
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -8993,12 +9021,12 @@
       "direct_in_degree": 30,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 23.547,
+      "load_bearing_score": 23.551,
       "note_path": "docs/CHARGED_LEPTON_MASS_HIERARCHY_REVIEW_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_charged_lepton_observable_curvature.py",
-      "transitive_descendants": 373
+      "transitive_descendants": 374
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9022,12 +9050,12 @@
         "scripts/frontier_quark_mass_ratio_full_solve.py",
         "scripts/frontier_quark_projector_ray_phase_completion.py"
       ],
-      "load_bearing_score": 19.043,
+      "load_bearing_score": 19.047,
       "note_path": "docs/QUARK_PROJECTOR_PARAMETER_AUDIT_NOTE_2026-04-19.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_quark_projector_parameter_audit.py",
-      "transitive_descendants": 372
+      "transitive_descendants": 373
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9036,7 +9064,7 @@
       "claim_id": "su3_casimir_fundamental_theorem_note_2026-05-02",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -9046,12 +9074,12 @@
       "direct_in_degree": 17,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 17.043,
+      "load_bearing_score": 17.047,
       "note_path": "docs/SU3_CASIMIR_FUNDAMENTAL_THEOREM_NOTE_2026-05-02.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/su3_casimir_fundamental_check.py",
-      "transitive_descendants": 372
+      "transitive_descendants": 373
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9072,12 +9100,12 @@
       "direct_in_degree": 36,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 26.539,
+      "load_bearing_score": 26.543,
       "note_path": "docs/CL3_SM_EMBEDDING_THEOREM.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/verify_cl3_sm_embedding.py",
-      "transitive_descendants": 371
+      "transitive_descendants": 372
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9102,12 +9130,12 @@
       "direct_in_degree": 33,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 24.996,
+      "load_bearing_score": 25.0,
       "note_path": "docs/GAUGE_VACUUM_PLAQUETTE_TENSOR_TRANSFER_PERRON_SOLVE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_gauge_vacuum_plaquette_tensor_transfer_perron_solve.py",
-      "transitive_descendants": 360
+      "transitive_descendants": 361
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9127,12 +9155,12 @@
       "direct_in_degree": 45,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 30.892,
+      "load_bearing_score": 30.897,
       "note_path": "docs/CHARGED_LEPTON_KOIDE_CONE_ALGEBRAIC_EQUIVALENCE_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_charged_lepton_observable_curvature.py",
-      "transitive_descendants": 335
+      "transitive_descendants": 336
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9158,12 +9186,12 @@
         "scripts/frontier_same_source_metric_ansatz_scan.py",
         "scripts/frontier_tensor_support_center_excess_law.py"
       ],
-      "load_bearing_score": 10.375,
+      "load_bearing_score": 10.379,
       "note_path": "docs/QUARK_BIMODULE_LO_SHELL_NORMALIZATION_THEOREM_NOTE_2026-04-19.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_quark_bimodule_lo_shell_normalization_theorem.py",
-      "transitive_descendants": 331
+      "transitive_descendants": 332
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9185,12 +9213,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 10.375,
+      "load_bearing_score": 10.379,
       "note_path": "docs/QUARK_JTS_AFFINE_PHYSICAL_CARRIER_THEOREM_NOTE_2026-04-19.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_quark_issr1_bicac_forcing.py",
-      "transitive_descendants": 331
+      "transitive_descendants": 332
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9210,12 +9238,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.375,
+      "load_bearing_score": 9.379,
       "note_path": "docs/SCALAR_TENSOR_RAY_MAGNITUDE_BRIDGE_NOTE_2026-04-19.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_quark_up_amplitude_rpsr_conditional.py",
-      "transitive_descendants": 331
+      "transitive_descendants": 332
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9235,12 +9263,12 @@
       "direct_in_degree": 26,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 21.371,
+      "load_bearing_score": 21.375,
       "note_path": "docs/SM_ONE_HIGGS_YUKAWA_GAUGE_SELECTION_THEOREM_NOTE_2026-04-26.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_sm_one_higgs_yukawa_gauge_selection.py",
-      "transitive_descendants": 330
+      "transitive_descendants": 331
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9263,12 +9291,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 10.371,
+      "load_bearing_score": 10.375,
       "note_path": "docs/STRC_LO_COLLINEARITY_THEOREM_NOTE_2026-04-19.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_strc_lo_collinearity_theorem.py",
-      "transitive_descendants": 330
+      "transitive_descendants": 331
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9289,12 +9317,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 11.366,
+      "load_bearing_score": 11.371,
       "note_path": "docs/YT_P3_MSBAR_TO_POLE_K3_COLOR_FACTOR_RETENTION_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p3_msbar_to_pole_k3.py",
-      "transitive_descendants": 329
+      "transitive_descendants": 330
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9313,12 +9341,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 10.866,
+      "load_bearing_score": 10.871,
       "note_path": "docs/DM_DPLE_DIMENSION_PARAMETRIC_EXTREMUM_THEOREM_NOTE_2026-04-19.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_dple_theorem.py",
-      "transitive_descendants": 329
+      "transitive_descendants": 330
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9354,12 +9382,12 @@
         "scripts/frontier_higgs_dressed_propagator_v1.py",
         "scripts/frontier_koide_selected_line_cyclic_response_bridge.py"
       ],
-      "load_bearing_score": 16.353,
+      "load_bearing_score": 16.358,
       "note_path": "docs/KOIDE_BERRY_PHASE_THEOREM_NOTE_2026-04-19.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_berry_phase_theorem.py",
-      "transitive_descendants": 326
+      "transitive_descendants": 327
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9368,7 +9396,7 @@
       "claim_id": "cl3_quark_antiquark_color_singlet_theorem_note_2026-05-02",
       "claim_scope": null,
       "claim_type": "decoration",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -9378,12 +9406,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.353,
+      "load_bearing_score": 11.358,
       "note_path": "docs/CL3_QUARK_ANTIQUARK_COLOR_SINGLET_THEOREM_NOTE_2026-05-02.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_quark_antiquark_color_singlet_check.py",
-      "transitive_descendants": 326
+      "transitive_descendants": 327
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9407,12 +9435,12 @@
       "direct_in_degree": 17,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.844,
+      "load_bearing_score": 16.849,
       "note_path": "docs/SU2_WITTEN_Z2_ANOMALY_THEOREM_NOTE_2026-04-24.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_su2_witten_z2_anomaly.py",
-      "transitive_descendants": 324
+      "transitive_descendants": 325
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9433,12 +9461,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.84,
+      "load_bearing_score": 9.844,
       "note_path": "docs/YT_P3_MSBAR_TO_POLE_K2_INTEGRAL_CITATION_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p3_k2_integrals.py",
-      "transitive_descendants": 323
+      "transitive_descendants": 324
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9447,7 +9475,7 @@
       "claim_id": "g_bare_hilbert_schmidt_rigidity_theorem_note_2026-05-07",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -9460,12 +9488,12 @@
       "direct_in_degree": 28,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 22.335,
+      "load_bearing_score": 22.34,
       "note_path": "docs/G_BARE_HILBERT_SCHMIDT_RIGIDITY_THEOREM_NOTE_2026-05-07.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_g_bare_hs_rigidity_narrow.py",
-      "transitive_descendants": 322
+      "transitive_descendants": 323
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9484,12 +9512,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 10.831,
+      "load_bearing_score": 10.835,
       "note_path": "docs/KOIDE_BERRY_BUNDLE_OBSTRUCTION_THEOREM_NOTE_2026-04-19.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_berry_bundle_obstruction_theorem.py",
-      "transitive_descendants": 321
+      "transitive_descendants": 322
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9512,12 +9540,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 10.331,
+      "load_bearing_score": 10.335,
       "note_path": "docs/YT_P3_MSBAR_TO_POLE_K2_COLOR_FACTOR_RETENTION_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p3_msbar_to_pole_k2.py",
-      "transitive_descendants": 321
+      "transitive_descendants": 322
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9539,12 +9567,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.831,
+      "load_bearing_score": 8.835,
       "note_path": "docs/SCALAR_SELECTOR_CYCLE1_SCIENCE_REVIEW_NOTE_2026-04-19.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_moment_ratio_uniformity_theorem.py",
-      "transitive_descendants": 321
+      "transitive_descendants": 322
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9564,37 +9592,12 @@
       "direct_in_degree": 14,
       "effective_status": "retained_pending_chain",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.326,
+      "load_bearing_score": 15.331,
       "note_path": "docs/G_BARE_CONSTRAINT_VS_CONVENTION_RESTATEMENT_NOTE_2026-05-07.md",
       "queue_reason": "audit_in_progress",
       "ready": false,
       "runner_path": "scripts/frontier_g_bare_audit_residual_closure.py",
-      "transitive_descendants": 320
-    },
-    {
-      "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "cl3_baryon_qqq_color_singlet_theorem_note_2026-05-02",
-      "claim_scope": null,
-      "claim_type": "positive_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
-      "criticality": "critical",
-      "criticality_rank": 3,
-      "cross_confirmation_status": null,
-      "deps": [
-        "cl3_quark_antiquark_color_singlet_theorem_note_2026-05-02",
-        "cl3_color_automorphism_theorem"
-      ],
-      "direct_in_degree": 4,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 13.326,
-      "note_path": "docs/CL3_BARYON_QQQ_COLOR_SINGLET_THEOREM_NOTE_2026-05-02.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/cl3_baryon_qqq_color_singlet_check.py",
-      "transitive_descendants": 320
+      "transitive_descendants": 321
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9618,12 +9621,37 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.326,
+      "load_bearing_score": 13.331,
       "note_path": "docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_z3_qubit_radian_bridge_no_go.py",
-      "transitive_descendants": 320
+      "transitive_descendants": 321
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "cl3_baryon_qqq_color_singlet_theorem_note_2026-05-02",
+      "claim_scope": null,
+      "claim_type": "positive_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "critical",
+      "criticality_rank": 3,
+      "cross_confirmation_status": null,
+      "deps": [
+        "cl3_quark_antiquark_color_singlet_theorem_note_2026-05-02",
+        "cl3_color_automorphism_theorem"
+      ],
+      "direct_in_degree": 4,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 10.331,
+      "note_path": "docs/CL3_BARYON_QQQ_COLOR_SINGLET_THEOREM_NOTE_2026-05-02.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/cl3_baryon_qqq_color_singlet_check.py",
+      "transitive_descendants": 321
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9646,12 +9674,12 @@
       "direct_in_degree": 11,
       "effective_status": "retained_pending_chain",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.822,
+      "load_bearing_score": 13.826,
       "note_path": "docs/N_F_BOUNDED_Z2_REDUCTION_THEOREM_NOTE_2026-05-07_w2.md",
       "queue_reason": "audit_in_progress",
       "ready": false,
       "runner_path": "scripts/cl3_n_f_derivation_2026_05_07_w2_check.py",
-      "transitive_descendants": 319
+      "transitive_descendants": 320
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9671,12 +9699,12 @@
       "direct_in_degree": 12,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.313,
+      "load_bearing_score": 14.317,
       "note_path": "docs/CHARGED_LEPTON_DIRECT_WARD_FREE_YUKAWA_NO_GO_NOTE_2026-04-26.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_charged_lepton_direct_ward_free_yukawa_no_go.py",
-      "transitive_descendants": 317
+      "transitive_descendants": 318
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9701,12 +9729,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 11.813,
+      "load_bearing_score": 11.817,
       "note_path": "docs/YT_P1_DELTA_R_MASTER_ASSEMBLY_THEOREM_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_delta_r_master_assembly.py",
-      "transitive_descendants": 317
+      "transitive_descendants": 318
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9729,12 +9757,12 @@
       "direct_in_degree": 14,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.304,
+      "load_bearing_score": 15.308,
       "note_path": "docs/LH_ANOMALY_TRACE_CATALOG_THEOREM_NOTE_2026-04-25.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_lh_anomaly_trace_catalog.py",
-      "transitive_descendants": 315
+      "transitive_descendants": 316
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9764,12 +9792,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 15.304,
+      "load_bearing_score": 15.308,
       "note_path": "docs/YT_P1_DELTA_R_2_LOOP_EXTENSION_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p1_delta_r_2_loop_extension.py",
-      "transitive_descendants": 315
+      "transitive_descendants": 316
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9790,12 +9818,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.304,
+      "load_bearing_score": 9.308,
       "note_path": "docs/YT_P3_K_SERIES_GEOMETRIC_BOUND_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p3_k_series_geometric_bound.py",
-      "transitive_descendants": 315
+      "transitive_descendants": 316
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9817,12 +9845,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.799,
+      "load_bearing_score": 8.804,
       "note_path": "docs/YT_P2_F_YT_LOOP_GEOMETRIC_BOUND_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p2_f_yt_loop_geometric_bound.py",
-      "transitive_descendants": 314
+      "transitive_descendants": 315
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9845,12 +9873,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.799,
+      "load_bearing_score": 8.804,
       "note_path": "docs/YT_P3_MSBAR_TO_POLE_K1_FRAMEWORK_NATIVE_DERIVATION_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_p3_msbar_to_pole_k1.py",
-      "transitive_descendants": 314
+      "transitive_descendants": 315
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9896,12 +9924,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 17.295,
+      "load_bearing_score": 17.299,
       "note_path": "docs/YT_UV_TO_IR_TRANSPORT_OBSTRUCTION_THEOREM_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_uv_to_ir_transport_obstruction.py",
-      "transitive_descendants": 313
+      "transitive_descendants": 314
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9925,12 +9953,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 17.785,
+      "load_bearing_score": 17.79,
       "note_path": "docs/DOWN_TYPE_MASS_RATIO_CKM_DUAL_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_mass_ratio_ckm_dual.py",
-      "transitive_descendants": 311
+      "transitive_descendants": 312
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9949,12 +9977,12 @@
       "direct_in_degree": 11,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.762,
+      "load_bearing_score": 13.767,
       "note_path": "docs/KOIDE_BRANNEN_PHASE_REDUCTION_THEOREM_NOTE_2026-04-20.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_brannen_phase_reduction_theorem.py",
-      "transitive_descendants": 306
+      "transitive_descendants": 307
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -9974,12 +10002,12 @@
       "direct_in_degree": 9,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 12.743,
+      "load_bearing_score": 12.748,
       "note_path": "docs/STRUCTURAL_NO_GO_SURVEY_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_charged_lepton_z3_source_response_crosscheck.py",
-      "transitive_descendants": 302
+      "transitive_descendants": 303
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10002,12 +10030,12 @@
       "direct_in_degree": 15,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 15.714,
+      "load_bearing_score": 15.719,
       "note_path": "docs/HIGHER_ORDER_STRUCTURAL_THEOREMS_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_higgs_dressed_propagator_v1.py",
-      "transitive_descendants": 296
+      "transitive_descendants": 297
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10030,12 +10058,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 11.709,
+      "load_bearing_score": 11.714,
       "note_path": "docs/LATTICE_PHYSICAL_MATCHING_CLUSTER_OBSTRUCTION_NOTE_2026-05-02.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_lattice_physical_matching_cluster_obstruction.py",
-      "transitive_descendants": 295
+      "transitive_descendants": 296
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10055,12 +10083,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.709,
+      "load_bearing_score": 9.714,
       "note_path": "docs/KOIDE_CIRCULANT_CHARACTER_BRIDGE_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_circulant_character_bridge.py",
-      "transitive_descendants": 295
+      "transitive_descendants": 296
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10083,12 +10111,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.709,
+      "load_bearing_score": 9.714,
       "note_path": "docs/KOIDE_SQRTM_AMPLITUDE_PRINCIPLE_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_sqrtm_amplitude_principle.py",
-      "transitive_descendants": 295
+      "transitive_descendants": 296
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10118,12 +10146,12 @@
       "direct_in_degree": 53,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 34.7,
+      "load_bearing_score": 34.705,
       "note_path": "docs/KOIDE_CIRCULANT_CHARACTER_DERIVATION_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/koide_circulant_character_derivation_check_2026_06_09.py",
-      "transitive_descendants": 293
+      "transitive_descendants": 294
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10148,12 +10176,12 @@
       "direct_in_degree": 21,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 18.69,
+      "load_bearing_score": 18.695,
       "note_path": "docs/GRAVITY_CLEAN_DERIVATION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_gravity_clean_weak_field_composition_certificate_2026_06_11.py",
-      "transitive_descendants": 291
+      "transitive_descendants": 292
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10174,12 +10202,12 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.19,
+      "load_bearing_score": 13.195,
       "note_path": "docs/KOIDE_BRANNEN_CALLAN_HARVEY_CANDIDATE_NOTE_2026-04-22.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_brannen_callan_harvey_candidate.py",
-      "transitive_descendants": 291
+      "transitive_descendants": 292
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10204,12 +10232,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.19,
+      "load_bearing_score": 9.195,
       "note_path": "docs/GAUGE_SCALAR_BRIDGE_3PLUS1_NATIVE_TUBE_STAGING_GATE_2026-05-03.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_gauge_scalar_bridge_3plus1_native_tube_staging.py",
-      "transitive_descendants": 291
+      "transitive_descendants": 292
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10230,12 +10258,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 10.18,
+      "load_bearing_score": 10.185,
       "note_path": "docs/SU3_CUBE_FULL_RHO_PERRON_2026-05-04.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_su3_cube_full_rho_perron_2026_05_04.py",
-      "transitive_descendants": 289
+      "transitive_descendants": 290
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10257,12 +10285,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.67,
+      "load_bearing_score": 9.675,
       "note_path": "docs/BRIDGE_GAP_HK_TIME_DERIVATION_NOTE_2026-05-06.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/probe_hk_time_derivation.py",
-      "transitive_descendants": 287
+      "transitive_descendants": 288
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10285,12 +10313,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.67,
+      "load_bearing_score": 9.675,
       "note_path": "docs/RH_SECTOR_ANOMALY_CANCELLATION_IDENTITIES_NOTE_2026-05-02.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_rh_sector_anomaly_cancellation_identities.py",
-      "transitive_descendants": 287
+      "transitive_descendants": 288
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10312,12 +10340,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.665,
+      "load_bearing_score": 9.67,
       "note_path": "docs/BRIDGE_GAP_HK_PLAQUETTE_CLOSED_FORM_NOTE_2026-05-06.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/probe_hk_plaquette_closed_form.py",
-      "transitive_descendants": 286
+      "transitive_descendants": 287
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10338,12 +10366,12 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.16,
+      "load_bearing_score": 13.165,
       "note_path": "docs/KOIDE_BRANNEN_GEOMETRY_DIRAC_SUPPORT_NOTE_2026-04-22.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_brannen_route3_geometry_support.py",
-      "transitive_descendants": 285
+      "transitive_descendants": 286
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10366,12 +10394,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 11.66,
+      "load_bearing_score": 11.665,
       "note_path": "docs/BRIDGE_GAP_ACTION_FORM_UNIQUENESS_NO_GO_NOTE_2026-05-06.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_bridge_gap_action_form_uniqueness_no_go.py",
-      "transitive_descendants": 285
+      "transitive_descendants": 286
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10395,12 +10423,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.16,
+      "load_bearing_score": 9.165,
       "note_path": "docs/BRIDGE_GAP_HK_THERMODYNAMIC_STRETCH_NOTE_2026-05-06.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_hk_thermodynamic_stretch_source_packet.py",
-      "transitive_descendants": 285
+      "transitive_descendants": 286
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10423,12 +10451,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.66,
+      "load_bearing_score": 8.665,
       "note_path": "docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/probe_hk_cube_perron_l2_2026_05_06.py",
-      "transitive_descendants": 285
+      "transitive_descendants": 286
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10453,12 +10481,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 11.155,
+      "load_bearing_score": 11.16,
       "note_path": "docs/N_F_TRACE_SPACE_BOUNDED_OBSTRUCTION_NOTE_2026-05-07_w2binary.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_n_f_v3_trace_check_2026-05-07_w2binary.py",
-      "transitive_descendants": 284
+      "transitive_descendants": 285
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10483,12 +10511,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.15,
+      "load_bearing_score": 9.155,
       "note_path": "docs/PER_SITE_SU2_BRIDGE_BOUNDED_OBSTRUCTION_NOTE_2026-05-07_w2bridge.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_per_site_su2_bridge_check_2026_05_07_w2bridge.py",
-      "transitive_descendants": 283
+      "transitive_descendants": 284
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10516,12 +10544,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 14.145,
+      "load_bearing_score": 14.15,
       "note_path": "docs/YT_BOTTOM_YUKAWA_RETENTION_ANALYSIS_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_bottom_yukawa_retention.py",
-      "transitive_descendants": 282
+      "transitive_descendants": 283
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10546,12 +10574,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.645,
+      "load_bearing_score": 9.65,
       "note_path": "docs/N_F_V3_NORMALIZATION_BOUNDED_NOTE_2026-05-07_w2norm.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_n_f_v3_normalization_check_2026_05_07_w2norm.py",
-      "transitive_descendants": 282
+      "transitive_descendants": 283
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10582,36 +10610,12 @@
       "direct_in_degree": 9,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 12.64,
+      "load_bearing_score": 12.645,
       "note_path": "docs/L3A_V3_TRACE_SURFACE_BOUNDED_OBSTRUCTION_NOTE_2026-05-07_l3a.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_l3a_v3_check_2026_05_07_l3a.py",
-      "transitive_descendants": 281
-    },
-    {
-      "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "su3_dabc_symmetric_theorem_note_2026-05-02",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
-      "criticality": "critical",
-      "criticality_rank": 3,
-      "cross_confirmation_status": null,
-      "deps": [
-        "cl3_color_automorphism_theorem"
-      ],
-      "direct_in_degree": 1,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 12.64,
-      "note_path": "docs/SU3_DABC_SYMMETRIC_THEOREM_NOTE_2026-05-02.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/su3_dabc_symmetric_check.py",
-      "transitive_descendants": 281
+      "transitive_descendants": 282
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10635,12 +10639,36 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.14,
+      "load_bearing_score": 9.145,
       "note_path": "docs/LHCM_Y_NORMALIZATION_FROM_ANOMALY_AND_CONVENTION_NOTE_2026-05-02.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_lhcm_y_normalization.py",
-      "transitive_descendants": 281
+      "transitive_descendants": 282
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "su3_dabc_symmetric_theorem_note_2026-05-02",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "critical",
+      "criticality_rank": 3,
+      "cross_confirmation_status": null,
+      "deps": [
+        "cl3_color_automorphism_theorem"
+      ],
+      "direct_in_degree": 1,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 8.645,
+      "note_path": "docs/SU3_DABC_SYMMETRIC_THEOREM_NOTE_2026-05-02.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/su3_dabc_symmetric_check.py",
+      "transitive_descendants": 282
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10649,7 +10677,7 @@
       "claim_id": "rh_completion_color_anti_fundamental_narrow_theorem_note_2026-05-17",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -10660,12 +10688,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 12.634,
+      "load_bearing_score": 8.64,
       "note_path": "docs/RH_COMPLETION_COLOR_ANTI_FUNDAMENTAL_NARROW_THEOREM_NOTE_2026-05-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/audit_companion_rh_completion_color_anti_fundamental_exact_2026_05_17.py",
-      "transitive_descendants": 280
+      "transitive_descendants": 281
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10674,7 +10702,7 @@
       "claim_id": "su3_cubic_anomaly_cancellation_theorem_note_2026-04-24",
       "claim_scope": null,
       "claim_type": "positive_theorem",
-      "claim_type_provenance": "needs_reaudit_after_invalidation",
+      "claim_type_provenance": "migration_hint",
       "criticality": "critical",
       "criticality_rank": 3,
       "cross_confirmation_status": null,
@@ -10687,12 +10715,12 @@
       "direct_in_degree": 13,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.629,
+      "load_bearing_score": 14.634,
       "note_path": "docs/SU3_CUBIC_ANOMALY_CANCELLATION_THEOREM_NOTE_2026-04-24.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_su3_cubic_anomaly_cancellation.py",
-      "transitive_descendants": 279
+      "transitive_descendants": 280
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10711,12 +10739,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 10.124,
+      "load_bearing_score": 10.129,
       "note_path": "docs/HIGGS_Y_FROM_LHCM_AND_YUKAWA_STRUCTURE_NOTE_2026-05-02.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_higgs_y_from_lhcm_yukawa.py",
-      "transitive_descendants": 278
+      "transitive_descendants": 279
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10739,12 +10767,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.587,
+      "load_bearing_score": 8.593,
       "note_path": "docs/HIERARCHY_B3_STAGGERED_SUPPLIER_CASCADE_NOTE_2026-06-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_hierarchy_b3_staggered_supplier_cascade_2026_06_17.py",
-      "transitive_descendants": 271
+      "transitive_descendants": 272
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10765,12 +10793,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.587,
+      "load_bearing_score": 8.593,
       "note_path": "docs/SM_HYPERCHARGE_UNIQUENESS_WITHOUT_NU_R_INPUT_THEOREM_NOTE_2026-05-02.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_sm_hypercharge_no_nu_r_derivation.py",
-      "transitive_descendants": 271
+      "transitive_descendants": 272
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10790,12 +10818,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.587,
+      "load_bearing_score": 8.593,
       "note_path": "docs/SU3_ANOMALY_FORCED_3BAR_COMPLETION_THEOREM_NOTE_2026-05-02.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_su3_anomaly_forced_3bar_completion.py",
-      "transitive_descendants": 271
+      "transitive_descendants": 272
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10821,12 +10849,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 17.582,
+      "load_bearing_score": 17.587,
       "note_path": "docs/HIERARCHY_FORMULA_HONEST_STATUS_NOTE_2026-05-10.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_hierarchy_formula_honest_status.py",
-      "transitive_descendants": 270
+      "transitive_descendants": 271
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10851,12 +10879,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.582,
+      "load_bearing_score": 9.587,
       "note_path": "docs/UNIFIED_MATTER_CONTENT_EWSB_HARNESS_THEOREM_NOTE_2026-05-03.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_unified_matter_content_ewsb_harness.py",
-      "transitive_descendants": 270
+      "transitive_descendants": 271
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10883,12 +10911,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.077,
+      "load_bearing_score": 9.082,
       "note_path": "docs/COMPOSITE_HIGGS_MECHANISM_NOTE_2026-05-03.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_composite_higgs_mechanism.py",
-      "transitive_descendants": 269
+      "transitive_descendants": 270
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10918,12 +10946,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 12.055,
+      "load_bearing_score": 12.061,
       "note_path": "docs/A3_ROUTE1_HIGGS_YUKAWA_C3_BREAKING_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_r1.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_a3_route1_higgs_yukawa_2026_05_08_r1.py",
-      "transitive_descendants": 265
+      "transitive_descendants": 266
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10945,12 +10973,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.055,
+      "load_bearing_score": 9.061,
       "note_path": "docs/HIGGS_LATTICE_TASTE_COUNT_AND_WJ_FORM_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/audit_companion_higgs_lattice_taste_count_wj_form_2026_06_05.py",
-      "transitive_descendants": 265
+      "transitive_descendants": 266
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -10977,12 +11005,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 10.033,
+      "load_bearing_score": 10.039,
       "note_path": "docs/YT_GENERATION_HIERARCHY_PRIMITIVE_ANALYSIS_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_generation_hierarchy_primitive.py",
-      "transitive_descendants": 261
+      "transitive_descendants": 262
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11014,12 +11042,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 11.528,
+      "load_bearing_score": 11.533,
       "note_path": "docs/AXIOM_FIRST_SM_ANOMALY_CANCELLATION_COMPLETE_THEOREM_NOTE_2026-05-03.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/axiom_first_sm_anomaly_cancellation_complete_check.py",
-      "transitive_descendants": 260
+      "transitive_descendants": 261
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11040,12 +11068,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 11.028,
+      "load_bearing_score": 11.033,
       "note_path": "docs/KOIDE_EXPLICIT_CALCULATIONS_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_eta_lefschetz_spectral_flow.py",
-      "transitive_descendants": 260
+      "transitive_descendants": 261
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11069,12 +11097,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.528,
+      "load_bearing_score": 9.533,
       "note_path": "docs/YT_H_UNIT_FLAVOR_COLUMN_DECOMPOSITION_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_h_unit_flavor_column.py",
-      "transitive_descendants": 260
+      "transitive_descendants": 261
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11104,12 +11132,12 @@
       "direct_in_degree": 13,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 14.522,
+      "load_bearing_score": 14.528,
       "note_path": "docs/KOIDE_A1_ROUTE_F_CASIMIR_DIFFERENCE_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_routef.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_route_f_casimir_difference_2026_05_08_routef.py",
-      "transitive_descendants": 259
+      "transitive_descendants": 260
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11139,12 +11167,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 10.511,
+      "load_bearing_score": 10.517,
       "note_path": "docs/A3_ROUTE5_NO_PROPER_QUOTIENT_SHARPENED_OBSTRUCTION_NOTE_2026-05-08_r5.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_a3_route5_no_proper_quotient_2026_05_08_r5.py",
-      "transitive_descendants": 257
+      "transitive_descendants": 258
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11181,12 +11209,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 10.011,
+      "load_bearing_score": 10.017,
       "note_path": "docs/A3_ROUTE3_ANOMALY_INFLOW_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_r3.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_a3_route3_anomaly_inflow_2026_05_08_r3.py",
-      "transitive_descendants": 257
+      "transitive_descendants": 258
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11212,12 +11240,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.511,
+      "load_bearing_score": 8.517,
       "note_path": "docs/YT_CLASS_6_C3_BREAKING_OPERATOR_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_class_6_c3_breaking.py",
-      "transitive_descendants": 257
+      "transitive_descendants": 258
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11244,12 +11272,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.511,
+      "load_bearing_score": 8.517,
       "note_path": "docs/YT_CLASS_7_SPONTANEOUS_C3_BREAKING_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_yt_class_7_spontaneous_c3.py",
-      "transitive_descendants": 257
+      "transitive_descendants": 258
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11276,12 +11304,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.506,
+      "load_bearing_score": 9.511,
       "note_path": "docs/A3_ROUTE2_SINGLE_CLOCK_C3_OBSTRUCTION_NOTE_2026-05-08_r2.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_a3_route2_single_clock_2026_05_08_r2.py",
-      "transitive_descendants": 256
+      "transitive_descendants": 257
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11305,12 +11333,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.506,
+      "load_bearing_score": 9.511,
       "note_path": "docs/A3_ROUTE4_SPIN6_CHAIN_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_r4.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_a3_route4_spin6_chain_2026_05_08_r4.py",
-      "transitive_descendants": 256
+      "transitive_descendants": 257
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11340,12 +11368,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.006,
+      "load_bearing_score": 9.011,
       "note_path": "docs/A3_R1_REVIEW_CONFIRMS_OBSTRUCTION_NOTE_2026-05-08_r1hr.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_a3_r1_hostile_review_2026_05_08_r1hr.py",
-      "transitive_descendants": 256
+      "transitive_descendants": 257
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11369,12 +11397,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.5,
+      "load_bearing_score": 9.506,
       "note_path": "docs/A3_OPTION_C_BRANNEN_RIVERO_PHYSICAL_LATTICE_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_optC.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_a3_option_c_brannen_rivero_2026_05_08_optC.py",
-      "transitive_descendants": 255
+      "transitive_descendants": 256
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11397,12 +11425,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.977,
+      "load_bearing_score": 9.983,
       "note_path": "docs/HIERARCHY_DIMENSIONAL_COMPRESSION_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_hierarchy_dimensional_compression_taste_authority_2026_06_15.py",
-      "transitive_descendants": 251
+      "transitive_descendants": 252
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11436,12 +11464,12 @@
       "helper_runner_paths": [
         "scripts/canonical_plaquette_surface.py"
       ],
-      "load_bearing_score": 19.466,
+      "load_bearing_score": 19.472,
       "note_path": "docs/COMPLETE_PREDICTION_CHAIN_2026_04_15.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_complete_prediction_chain.py",
-      "transitive_descendants": 249
+      "transitive_descendants": 250
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11471,12 +11499,12 @@
       "direct_in_degree": 18,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.665,
+      "load_bearing_score": 16.672,
       "note_path": "docs/KOIDE_A1_PROBE_PLANCHEREL_PETER_WEYL_BOUNDED_OBSTRUCTION_NOTE_2026-05-09_probe12.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_probe_plancherel_peter_weyl_2026_05_09_probe12.py",
-      "transitive_descendants": 202
+      "transitive_descendants": 203
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -11511,12 +11539,12 @@
       "direct_in_degree": 17,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 16.158,
+      "load_bearing_score": 16.165,
       "note_path": "docs/KOIDE_A1_PROBE_REAL_STRUCTURE_BOUNDED_OBSTRUCTION_NOTE_2026-05-09_probe13.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_probe_real_structure_2026_05_09_probe13.py",
-      "transitive_descendants": 201
+      "transitive_descendants": 202
     },
     {
       "audit_independence_required": "fresh_context_or_stronger_with_cross_confirmation",
@@ -12318,12 +12346,12 @@
       "direct_in_degree": 12,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.637,
+      "load_bearing_score": 13.644,
       "note_path": "docs/PER_SITE_SU2_SPIN_HALF_THEOREM_NOTE_2026-05-02.md",
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/per_site_su2_spin_half_check.py",
-      "transitive_descendants": 198
+      "transitive_descendants": 199
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -12592,12 +12620,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 10.46,
+      "load_bearing_score": 10.466,
       "note_path": "docs/KOIDE_A1_PROBE_GRAVITY_PHASE_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_probe3.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_probe_gravity_phase_2026_05_08_probe3.py",
-      "transitive_descendants": 248
+      "transitive_descendants": 249
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -12618,12 +12646,12 @@
       "direct_in_degree": 11,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.413,
+      "load_bearing_score": 13.419,
       "note_path": "docs/CKM_BROCARD_POLYNOMIAL_VIETA_STRUCTURAL_INTEGERS_THEOREM_NOTE_2026-04-25.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_ckm_brocard_polynomial_vieta_structural_integers.py",
-      "transitive_descendants": 240
+      "transitive_descendants": 241
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -12646,12 +12674,12 @@
       "direct_in_degree": 11,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.413,
+      "load_bearing_score": 13.419,
       "note_path": "docs/KOIDE_Q_DELTA_CLOSURE_PACKAGE_README_2026-04-21.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_Q_eq_3delta_identity.py",
-      "transitive_descendants": 240
+      "transitive_descendants": 241
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -12683,12 +12711,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.407,
+      "load_bearing_score": 9.413,
       "note_path": "docs/KOIDE_A1_ROUTE_E_KOSTANT_WEYL_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_routee.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_route_e_kostant_weyl_2026_05_08_routee.py",
-      "transitive_descendants": 239
+      "transitive_descendants": 240
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -12712,12 +12740,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.907,
+      "load_bearing_score": 8.913,
       "note_path": "docs/A3_R5_REVIEW_CONFIRMS_OBSTRUCTION_NOTE_2026-05-08_r5hr.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_a3_r5_hostile_review_2026_05_08_r5hr.py",
-      "transitive_descendants": 239
+      "transitive_descendants": 240
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -12739,12 +12767,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.407,
+      "load_bearing_score": 8.413,
       "note_path": "docs/KOIDE_A1_PHYSICAL_BRIDGE_ATTEMPT_2026-04-22.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_a1_physical_bridge_attempt_nogo_2026_04_22.py",
-      "transitive_descendants": 239
+      "transitive_descendants": 240
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -12763,12 +12791,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.407,
+      "load_bearing_score": 8.413,
       "note_path": "docs/SU3_Z3_APBC_VARIANT_PROBE_2026-05-04.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_su3_cube_z3_apbc_attempt_2026_05_04.py",
-      "transitive_descendants": 239
+      "transitive_descendants": 240
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -12799,12 +12827,12 @@
       "direct_in_degree": 7,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 11.401,
+      "load_bearing_score": 11.407,
       "note_path": "docs/KOIDE_A1_PROBE_RP_FROBENIUS_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_probe1.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_probe_rp_frobenius_2026_05_08_probe1.py",
-      "transitive_descendants": 238
+      "transitive_descendants": 239
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -12839,12 +12867,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 10.401,
+      "load_bearing_score": 10.407,
       "note_path": "docs/KOIDE_A1_ROUTE_D_NEWTON_GIRARD_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_routed.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_route_d_newton_girard_2026_05_08_routed.py",
-      "transitive_descendants": 238
+      "transitive_descendants": 239
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -12876,12 +12904,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.901,
+      "load_bearing_score": 9.907,
       "note_path": "docs/KOIDE_A1_PROBE_RG_FIXED_POINT_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_probe5.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_probe_rg_fixed_point_2026_05_08_probe5.py",
-      "transitive_descendants": 238
+      "transitive_descendants": 239
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -12909,12 +12937,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.901,
+      "load_bearing_score": 9.907,
       "note_path": "docs/KOIDE_A1_PROBE_SPECTRAL_ACTION_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_probe4.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_probe_spectral_action_2026_05_08_probe4.py",
-      "transitive_descendants": 238
+      "transitive_descendants": 239
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -12946,12 +12974,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.401,
+      "load_bearing_score": 9.407,
       "note_path": "docs/KOIDE_A1_PROBE_OPERATOR_CLASS_BOUNDED_NOTE_2026-05-08_probe6.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_probe_operator_class_2026_05_08_probe6.py",
-      "transitive_descendants": 238
+      "transitive_descendants": 239
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -12982,12 +13010,12 @@
       "direct_in_degree": 3,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.401,
+      "load_bearing_score": 9.407,
       "note_path": "docs/KOIDE_A1_PROBE_Z2_C3_PAIRING_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_probe7.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_probe_z2_c3_pairing_2026_05_08_probe7.py",
-      "transitive_descendants": 238
+      "transitive_descendants": 239
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -13017,12 +13045,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.901,
+      "load_bearing_score": 8.907,
       "note_path": "docs/KOIDE_A1_PROBE_FLAVOR_ANOMALY_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_probe2.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_probe_flavor_anomaly_2026_05_08_probe2.py",
-      "transitive_descendants": 238
+      "transitive_descendants": 239
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -13054,12 +13082,12 @@
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.401,
+      "load_bearing_score": 8.407,
       "note_path": "docs/KOIDE_A1_ROUTE_A_KOIDE_NISHIURA_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_routea.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_route_a_koide_nishiura_2026_05_08_routea.py",
-      "transitive_descendants": 238
+      "transitive_descendants": 239
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -13082,12 +13110,12 @@
       "direct_in_degree": 10,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 12.592,
+      "load_bearing_score": 12.6,
       "note_path": "docs/INTERNAL_EXTERNAL_SU2_MERGER_FROM_UNIVERSAL_PROPERTY_NARROW_THEOREM_NOTE_2026-05-27.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/internal_external_su2_merger_runner.py",
-      "transitive_descendants": 192
+      "transitive_descendants": 193
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -13119,12 +13147,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 11.484,
+      "load_bearing_score": 11.492,
       "note_path": "docs/KOIDE_A1_DERIVATION_STATUS_NOTE.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_route_a_koide_nishiura_2026_05_08_routea.py",
-      "transitive_descendants": 178
+      "transitive_descendants": 179
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -13386,31 +13414,6 @@
       "audit_independence_required": "fresh_context_or_stronger",
       "audit_status": "unaudited",
       "blocker": null,
-      "claim_id": "universal_qg_uv_finite_partition_note",
-      "claim_scope": null,
-      "claim_type": "positive_theorem",
-      "claim_type_provenance": "migration_hint",
-      "criticality": "high",
-      "criticality_rank": 2,
-      "cross_confirmation_status": null,
-      "deps": [
-        "universal_gr_lorentzian_global_atlas_closure_note",
-        "universal_qg_projective_schur_closure_note"
-      ],
-      "direct_in_degree": 14,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 14.19,
-      "note_path": "docs/UNIVERSAL_QG_UV_FINITE_PARTITION_NOTE.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/frontier_universal_qg_uv_finite_partition.py",
-      "transitive_descendants": 145
-    },
-    {
-      "audit_independence_required": "fresh_context_or_stronger",
-      "audit_status": "unaudited",
-      "blocker": null,
       "claim_id": "koide_a1_probe_retained_u1_hunt_bounded_obstruction_note_2026-05-09_probe14",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
@@ -13432,12 +13435,12 @@
       "direct_in_degree": 8,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 11.19,
+      "load_bearing_score": 11.2,
       "note_path": "docs/KOIDE_A1_PROBE_RETAINED_U1_HUNT_BOUNDED_OBSTRUCTION_NOTE_2026-05-09_probe14.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_a1_probe_retained_u1_hunt_2026_05_09_probe14.py",
-      "transitive_descendants": 145
+      "transitive_descendants": 146
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -13460,11 +13463,36 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.69,
+      "load_bearing_score": 9.7,
       "note_path": "docs/KOIDE_GENERATION_ID_CL3_GRADE1_BRIDGE_NARROW_THEOREM_NOTE_2026-06-02.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_generation_id_cl3_grade1_bridge.py",
+      "transitive_descendants": 146
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "universal_qg_uv_finite_partition_note",
+      "claim_scope": null,
+      "claim_type": "positive_theorem",
+      "claim_type_provenance": "migration_hint",
+      "criticality": "high",
+      "criticality_rank": 2,
+      "cross_confirmation_status": null,
+      "deps": [
+        "universal_gr_lorentzian_global_atlas_closure_note",
+        "universal_qg_projective_schur_closure_note"
+      ],
+      "direct_in_degree": 14,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 14.19,
+      "note_path": "docs/UNIVERSAL_QG_UV_FINITE_PARTITION_NOTE.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/frontier_universal_qg_uv_finite_partition.py",
       "transitive_descendants": 145
     },
     {
@@ -13551,33 +13579,6 @@
       "audit_independence_required": "fresh_context_or_stronger",
       "audit_status": "unaudited",
       "blocker": null,
-      "claim_id": "universal_qg_pl_sobolev_interface_note",
-      "claim_scope": null,
-      "claim_type": "positive_theorem",
-      "claim_type_provenance": "migration_hint",
-      "criticality": "high",
-      "criticality_rank": 2,
-      "cross_confirmation_status": null,
-      "deps": [
-        "universal_qg_pl_field_interface_note",
-        "universal_qg_pl_weak_form_note",
-        "universal_qg_canonical_refinement_net_note",
-        "universal_qg_abstract_gaussian_completion_note"
-      ],
-      "direct_in_degree": 14,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 14.119,
-      "note_path": "docs/UNIVERSAL_QG_PL_SOBOLEV_INTERFACE_NOTE.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/frontier_universal_qg_pl_sobolev_interface.py",
-      "transitive_descendants": 138
-    },
-    {
-      "audit_independence_required": "fresh_context_or_stronger",
-      "audit_status": "unaudited",
-      "blocker": null,
       "claim_id": "koide_bae_probe_wilson_chain_mass_note_2026-05-09_probe19",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
@@ -13601,11 +13602,38 @@
       "direct_in_degree": 9,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 11.619,
+      "load_bearing_score": 11.629,
       "note_path": "docs/KOIDE_BAE_PROBE_WILSON_CHAIN_MASS_NOTE_2026-05-09_probe19.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_bae_probe_wilson_chain_mass_2026_05_09_probe19.py",
+      "transitive_descendants": 139
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "universal_qg_pl_sobolev_interface_note",
+      "claim_scope": null,
+      "claim_type": "positive_theorem",
+      "claim_type_provenance": "migration_hint",
+      "criticality": "high",
+      "criticality_rank": 2,
+      "cross_confirmation_status": null,
+      "deps": [
+        "universal_qg_pl_field_interface_note",
+        "universal_qg_pl_weak_form_note",
+        "universal_qg_canonical_refinement_net_note",
+        "universal_qg_abstract_gaussian_completion_note"
+      ],
+      "direct_in_degree": 14,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 14.119,
+      "note_path": "docs/UNIVERSAL_QG_PL_SOBOLEV_INTERFACE_NOTE.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/frontier_universal_qg_pl_sobolev_interface.py",
       "transitive_descendants": 138
     },
     {
@@ -13755,12 +13783,12 @@
         "scripts/frontier_dm_neutrino_source_surface_intrinsic_slot_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py"
       ],
-      "load_bearing_score": 10.066,
+      "load_bearing_score": 10.077,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_ACTIVE_CURVATURE_23_SYMMETRIC_BASELINE_BOUNDARY_THEOREM_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_active_curvature_23_symmetric_baseline_boundary.py",
-      "transitive_descendants": 133
+      "transitive_descendants": 134
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -13793,40 +13821,12 @@
         "scripts/frontier_dm_neutrino_source_surface_intrinsic_slot_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py"
       ],
-      "load_bearing_score": 9.055,
+      "load_bearing_score": 9.066,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_ACTIVE_PARITY_COMPATIBLE_DIAGONAL_BASELINE_THEOREM_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_active_parity_compatible_diagonal_baseline_theorem.py",
-      "transitive_descendants": 132
-    },
-    {
-      "audit_independence_required": "fresh_context_or_stronger",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "universal_qg_canonical_smooth_gravitational_weak_measure_note",
-      "claim_scope": null,
-      "claim_type": "positive_theorem",
-      "claim_type_provenance": "default_positive_theorem",
-      "criticality": "high",
-      "criticality_rank": 2,
-      "cross_confirmation_status": null,
-      "deps": [
-        "universal_qg_optional_textbook_comparison_note",
-        "universal_qg_canonical_textbook_weak_measure_equivalence_note",
-        "universal_qg_smooth_gravitational_global_solution_class_note",
-        "universal_qg_smooth_gravitational_local_identification_note",
-        "universal_qg_smooth_gravitational_global_atlas_note"
-      ],
-      "direct_in_degree": 11,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 12.544,
-      "note_path": "docs/UNIVERSAL_QG_CANONICAL_SMOOTH_GRAVITATIONAL_WEAK_MEASURE_NOTE.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/frontier_universal_qg_canonical_smooth_gravitational_weak_measure.py",
-      "transitive_descendants": 131
+      "transitive_descendants": 133
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -13865,12 +13865,70 @@
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_z3_doublet_block_point_selection_theorem.py"
       ],
-      "load_bearing_score": 11.044,
+      "load_bearing_score": 11.055,
       "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_PARITY_COMPATIBLE_OBSERVABLE_SELECTOR_THEOREM_NOTE_2026-04-17.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_parity_compatible_observable_selector_theorem.py",
+      "transitive_descendants": 132
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "universal_qg_canonical_smooth_gravitational_weak_measure_note",
+      "claim_scope": null,
+      "claim_type": "positive_theorem",
+      "claim_type_provenance": "default_positive_theorem",
+      "criticality": "high",
+      "criticality_rank": 2,
+      "cross_confirmation_status": null,
+      "deps": [
+        "universal_qg_optional_textbook_comparison_note",
+        "universal_qg_canonical_textbook_weak_measure_equivalence_note",
+        "universal_qg_smooth_gravitational_global_solution_class_note",
+        "universal_qg_smooth_gravitational_local_identification_note",
+        "universal_qg_smooth_gravitational_global_atlas_note"
+      ],
+      "direct_in_degree": 11,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 12.544,
+      "note_path": "docs/UNIVERSAL_QG_CANONICAL_SMOOTH_GRAVITATIONAL_WEAK_MEASURE_NOTE.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/frontier_universal_qg_canonical_smooth_gravitational_weak_measure.py",
       "transitive_descendants": 131
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "koide_bae_probe_wilson_dimensional_consistency_bounded_note_2026-05-09_probe26",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "high",
+      "criticality_rank": 2,
+      "cross_confirmation_status": null,
+      "deps": [
+        "koide_circulant_character_bridge_narrow_theorem_note_2026-05-09",
+        "complete_prediction_chain_2026_04_15",
+        "staggered_dirac_bz_corner_forcing_theorem_note_2026-05-07",
+        "koide_circulant_character_derivation_note_2026-04-18",
+        "koide_circulant_wilson_target_note_2026-04-18",
+        "koide_a1_probe_operator_class_bounded_note_2026-05-08_probe6",
+        "koide_a1_probe_retained_u1_hunt_bounded_obstruction_note_2026-05-09_probe14"
+      ],
+      "direct_in_degree": 3,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 8.533,
+      "note_path": "docs/KOIDE_BAE_PROBE_WILSON_DIMENSIONAL_CONSISTENCY_BOUNDED_NOTE_2026-05-09_probe26.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/cl3_koide_bae_probe_wilson_dimensional_consistency_2026_05_09_probe26.py",
+      "transitive_descendants": 130
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -13897,36 +13955,6 @@
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_universal_qg_canonical_smooth_geometric_action.py",
-      "transitive_descendants": 129
-    },
-    {
-      "audit_independence_required": "fresh_context_or_stronger",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "koide_bae_probe_wilson_dimensional_consistency_bounded_note_2026-05-09_probe26",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "high",
-      "criticality_rank": 2,
-      "cross_confirmation_status": null,
-      "deps": [
-        "koide_circulant_character_bridge_narrow_theorem_note_2026-05-09",
-        "complete_prediction_chain_2026_04_15",
-        "staggered_dirac_bz_corner_forcing_theorem_note_2026-05-07",
-        "koide_circulant_character_derivation_note_2026-04-18",
-        "koide_circulant_wilson_target_note_2026-04-18",
-        "koide_a1_probe_operator_class_bounded_note_2026-05-08_probe6",
-        "koide_a1_probe_retained_u1_hunt_bounded_obstruction_note_2026-05-09_probe14"
-      ],
-      "direct_in_degree": 3,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 8.522,
-      "note_path": "docs/KOIDE_BAE_PROBE_WILSON_DIMENSIONAL_CONSISTENCY_BOUNDED_NOTE_2026-05-09_probe26.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/cl3_koide_bae_probe_wilson_dimensional_consistency_2026_05_09_probe26.py",
       "transitive_descendants": 129
     },
     {
@@ -13993,12 +14021,12 @@
       "direct_in_degree": 12,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 13.0,
+      "load_bearing_score": 13.011,
       "note_path": "docs/KOIDE_BAE_PROBE_F1_CANONICAL_FUNCTIONAL_BOUNDED_OBSTRUCTION_NOTE_2026-05-09_probe18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_bae_probe_f1_canonical_functional_2026_05_09_probe18.py",
-      "transitive_descendants": 127
+      "transitive_descendants": 128
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -14026,12 +14054,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.0,
+      "load_bearing_score": 9.011,
       "note_path": "docs/KOIDE_BAE_PROBE_NATIVE_LATTICE_FLOW_BOUNDED_OBSTRUCTION_NOTE_2026-05-09_probe21.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_bae_probe_native_lattice_flow_2026_05_09_probe21.py",
-      "transitive_descendants": 127
+      "transitive_descendants": 128
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -14070,12 +14098,12 @@
       "direct_in_degree": 12,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 12.989,
+      "load_bearing_score": 13.0,
       "note_path": "docs/KOIDE_BAE_PROBE_PHYSICAL_EXTREMIZATION_BOUNDED_OBSTRUCTION_NOTE_2026-05-09_probe25.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_bae_probe_physical_extremization_2026_05_09_probe25.py",
-      "transitive_descendants": 126
+      "transitive_descendants": 127
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -14154,12 +14182,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.943,
+      "load_bearing_score": 8.954,
       "note_path": "docs/KOIDE_BAE_PROBE_PHI_FROM_Z3_CHARACTER_NOTE_2026-05-09_probe24.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_bae_probe_phi_from_z3_character_2026_05_09_probe24.py",
-      "transitive_descendants": 122
+      "transitive_descendants": 123
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -14191,12 +14219,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 7.907,
+      "load_bearing_score": 7.919,
       "note_path": "docs/KOIDE_BAE_PROBE_SPECTRUM_CONE_BOUNDED_OBSTRUCTION_NOTE_2026-05-09_probe22.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_bae_probe_spectrum_cone_2026_05_09_probe22.py",
-      "transitive_descendants": 119
+      "transitive_descendants": 120
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -14267,12 +14295,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 9.383,
+      "load_bearing_score": 9.395,
       "note_path": "docs/KOIDE_BAE_PROBE_KAPPA_PREDICTION_TEST_PARTIAL_FALSIFICATION_NOTE_2026-05-09_probe29.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_bae_probe_kappa_prediction_test_2026_05_09_probe29.py",
-      "transitive_descendants": 117
+      "transitive_descendants": 118
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -14307,12 +14335,12 @@
         "scripts/frontier_dm_neutrino_source_surface_shift_quotient_bundle_theorem.py",
         "scripts/frontier_dm_neutrino_source_surface_z3_doublet_block_point_selection_theorem.py"
       ],
-      "load_bearing_score": 10.333,
+      "load_bearing_score": 10.345,
       "note_path": "docs/KOIDE_SELECTED_SLICE_FROZEN_BANK_DECOMPOSITION_NOTE_2026-04-18.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_selected_slice_frozen_bank_decomposition.py",
-      "transitive_descendants": 113
+      "transitive_descendants": 114
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -14578,12 +14606,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 8.728,
+      "load_bearing_score": 8.741,
       "note_path": "docs/LEPTON_BLOCK_SCALAR_SINGLET_COMPOSITE_UNIQUENESS_D17_PRIME_THEOREM_NOTE_2026-05-10.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_lepton_block_scalar_singlet_composite_uniqueness.py",
-      "transitive_descendants": 105
+      "transitive_descendants": 106
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -14610,31 +14638,6 @@
       "ready": false,
       "runner_path": "scripts/frontier_record_formation_dynamics_constraint_2026_06_05.py",
       "transitive_descendants": 103
-    },
-    {
-      "audit_independence_required": "fresh_context_or_stronger",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "record_classicalization_dynamics_firewall_2026-06-05",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "high",
-      "criticality_rank": 2,
-      "cross_confirmation_status": null,
-      "deps": [
-        "minimal_axioms",
-        "record_generation_readout_two_sectors_2026-06-05"
-      ],
-      "direct_in_degree": 11,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 12.172,
-      "note_path": "docs/RECORD_CLASSICALIZATION_DYNAMICS_FIREWALL_2026-06-05.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/frontier_record_typing_firewall_exact_2026_06_05.py",
-      "transitive_descendants": 101
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -14669,11 +14672,36 @@
         "scripts/frontier_dm_neutrino_source_surface_z3_doublet_block_point_selection_theorem.py",
         "scripts/frontier_higgs_dressed_propagator_v1.py"
       ],
-      "load_bearing_score": 10.172,
+      "load_bearing_score": 10.187,
       "note_path": "docs/KOIDE_Z3_SCALAR_POTENTIAL_SUPPORT_NOTE_2026-04-19.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_z3_scalar_potential.py",
+      "transitive_descendants": 102
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "record_classicalization_dynamics_firewall_2026-06-05",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "high",
+      "criticality_rank": 2,
+      "cross_confirmation_status": null,
+      "deps": [
+        "minimal_axioms",
+        "record_generation_readout_two_sectors_2026-06-05"
+      ],
+      "direct_in_degree": 11,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 12.172,
+      "note_path": "docs/RECORD_CLASSICALIZATION_DYNAMICS_FIREWALL_2026-06-05.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/frontier_record_typing_firewall_exact_2026_06_05.py",
       "transitive_descendants": 101
     },
     {
@@ -14695,12 +14723,12 @@
       "direct_in_degree": 12,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 12.585,
+      "load_bearing_score": 12.6,
       "note_path": "docs/G_BARE_TWO_WARD_SAME_1PI_PINNING_THEOREM_NOTE_2026-04-19.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_gbare_same_1pi_admitted_residue_repair.py",
-      "transitive_descendants": 95
+      "transitive_descendants": 96
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -15022,6 +15050,35 @@
       "audit_independence_required": "fresh_context_or_stronger",
       "audit_status": "unaudited",
       "blocker": null,
+      "claim_id": "g_bare_two_ward_closure_note_2026-04-18",
+      "claim_scope": null,
+      "claim_type": "positive_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "high",
+      "criticality_rank": 2,
+      "cross_confirmation_status": null,
+      "deps": [
+        "g_bare_two_ward_rep_b_independence_theorem_note_2026-04-19",
+        "g_bare_two_ward_same_1pi_pinning_theorem_note_2026-04-19",
+        "yt_ward_identity_derivation_theorem",
+        "g_bare_rigidity_theorem_note",
+        "g_bare_structural_normalization_theorem_note_2026-04-18",
+        "g_bare_forced_by_ward_rep_b_independence_theorem_note_2026-05-09"
+      ],
+      "direct_in_degree": 5,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 8.858,
+      "note_path": "docs/G_BARE_TWO_WARD_CLOSURE_NOTE_2026-04-18.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/frontier_g_bare_two_ward_closure.py",
+      "transitive_descendants": 81
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger",
+      "audit_status": "unaudited",
+      "blocker": null,
       "claim_id": "ckm_neutron_edm_bound_note",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
@@ -15043,35 +15100,6 @@
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_ckm_neutron_edm_bound.py",
-      "transitive_descendants": 80
-    },
-    {
-      "audit_independence_required": "fresh_context_or_stronger",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "g_bare_two_ward_closure_note_2026-04-18",
-      "claim_scope": null,
-      "claim_type": "positive_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "high",
-      "criticality_rank": 2,
-      "cross_confirmation_status": null,
-      "deps": [
-        "g_bare_two_ward_rep_b_independence_theorem_note_2026-04-19",
-        "g_bare_two_ward_same_1pi_pinning_theorem_note_2026-04-19",
-        "yt_ward_identity_derivation_theorem",
-        "g_bare_rigidity_theorem_note",
-        "g_bare_structural_normalization_theorem_note_2026-04-18",
-        "g_bare_forced_by_ward_rep_b_independence_theorem_note_2026-05-09"
-      ],
-      "direct_in_degree": 5,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 8.84,
-      "note_path": "docs/G_BARE_TWO_WARD_CLOSURE_NOTE_2026-04-18.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/frontier_g_bare_two_ward_closure.py",
       "transitive_descendants": 80
     },
     {
@@ -19069,6 +19097,30 @@
       "audit_independence_required": "fresh_context_or_stronger",
       "audit_status": "unaudited",
       "blocker": null,
+      "claim_id": "g_bare_rescaling_freedom_removal_theorem_note_2026-05-03",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "high",
+      "criticality_rank": 2,
+      "cross_confirmation_status": null,
+      "deps": [
+        "cl3_color_automorphism_theorem"
+      ],
+      "direct_in_degree": 9,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 10.115,
+      "note_path": "docs/G_BARE_RESCALING_FREEDOM_REMOVAL_THEOREM_NOTE_2026-05-03.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/frontier_g_bare_rescaling_conditional_algebra_check.py",
+      "transitive_descendants": 48
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger",
+      "audit_status": "unaudited",
+      "blocker": null,
       "claim_id": "cl3_sm_embedding_master_note",
       "claim_scope": null,
       "claim_type": "positive_theorem",
@@ -19143,30 +19195,6 @@
       "ready": false,
       "runner_path": "scripts/frontier_koide_reviewer_stress_test.py",
       "transitive_descendants": 48
-    },
-    {
-      "audit_independence_required": "fresh_context_or_stronger",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "g_bare_rescaling_freedom_removal_theorem_note_2026-05-03",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
-      "criticality": "high",
-      "criticality_rank": 2,
-      "cross_confirmation_status": null,
-      "deps": [
-        "cl3_color_automorphism_theorem"
-      ],
-      "direct_in_degree": 9,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 10.085,
-      "note_path": "docs/G_BARE_RESCALING_FREEDOM_REMOVAL_THEOREM_NOTE_2026-05-03.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/frontier_g_bare_rescaling_conditional_algebra_check.py",
-      "transitive_descendants": 47
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -19351,12 +19379,12 @@
       "direct_in_degree": 5,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 7.822,
+      "load_bearing_score": 7.858,
       "note_path": "docs/G_BARE_TWO_WARD_H_UNIT_RESIDUE_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-26.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/g_bare_two_ward_h_unit_residue_accepted_premise_runner.py",
-      "transitive_descendants": 39
+      "transitive_descendants": 40
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -19389,6 +19417,31 @@
       "audit_independence_required": "fresh_context_or_stronger",
       "audit_status": "unaudited",
       "blocker": null,
+      "claim_id": "alpha_convention_i2_accepted_premise_bridge_bounded_note_2026-05-27",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "high",
+      "criticality_rank": 2,
+      "cross_confirmation_status": null,
+      "deps": [
+        "alpha_lm_geometric_mean_identity_theorem_note_2026-04-24",
+        "g_bare_two_ward_h_unit_residue_accepted_premise_bridge_bounded_note_2026-05-26"
+      ],
+      "direct_in_degree": 7,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 8.785,
+      "note_path": "docs/ALPHA_CONVENTION_I2_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-27.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/alpha_convention_i2_accepted_premise_runner.py",
+      "transitive_descendants": 38
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger",
+      "audit_status": "unaudited",
+      "blocker": null,
       "claim_id": "lorentz_boost_free_staggered_fermion_2point_so4_narrow_theorem_note_2026-05-29",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
@@ -19409,31 +19462,6 @@
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_lorentz_boost_free_staggered_fermion_2point_so4.py",
-      "transitive_descendants": 37
-    },
-    {
-      "audit_independence_required": "fresh_context_or_stronger",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "alpha_convention_i2_accepted_premise_bridge_bounded_note_2026-05-27",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "high",
-      "criticality_rank": 2,
-      "cross_confirmation_status": null,
-      "deps": [
-        "alpha_lm_geometric_mean_identity_theorem_note_2026-04-24",
-        "g_bare_two_ward_h_unit_residue_accepted_premise_bridge_bounded_note_2026-05-26"
-      ],
-      "direct_in_degree": 7,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 8.748,
-      "note_path": "docs/ALPHA_CONVENTION_I2_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-27.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/alpha_convention_i2_accepted_premise_runner.py",
       "transitive_descendants": 37
     },
     {
@@ -19588,12 +19616,12 @@
       "direct_in_degree": 6,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 7.858,
+      "load_bearing_score": 7.907,
       "note_path": "docs/SUPERTRACE_INDEX_HOLOMORPHIC_ROUTE_TO_KOIDE_R_HALF_OPEN_LEAD_NOTE_2026-06-04.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/audit_companion_supertrace_index_route_to_koide_multiplicity_open_lead_exact.py",
-      "transitive_descendants": 28
+      "transitive_descendants": 29
     },
     {
       "audit_independence_required": "fresh_context_or_stronger",
@@ -19860,7 +19888,7 @@
       "claim_id": "su3_adjoint_casimir_theorem_note_2026-05-02",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "high",
       "criticality_rank": 2,
       "cross_confirmation_status": null,
@@ -20207,6 +20235,34 @@
       "audit_independence_required": "fresh_context_or_stronger",
       "audit_status": "unaudited",
       "blocker": null,
+      "claim_id": "strong_cp_operator_basis_and_mass_orientation_theorem_note_2026-05-19",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "high",
+      "criticality_rank": 2,
+      "cross_confirmation_status": null,
+      "deps": [
+        "wilson_real_positive_measure_bounded_premise_bridge_note_2026-06-03",
+        "staggered_scalar_mass_class_bounded_premise_bridge_note_2026-06-03",
+        "cl3_normalization_i3_accepted_premise_bridge_bounded_note_2026-05-27",
+        "staggered_only_det_positivity_case_a_note_2026-05-17",
+        "reflection_positivity_gauge_half_cauchy_schwarz_narrow_theorem_note_2026-05-10"
+      ],
+      "direct_in_degree": 6,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 6.907,
+      "note_path": "docs/STRONG_CP_OPERATOR_BASIS_AND_MASS_ORIENTATION_THEOREM_NOTE_2026-05-19.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/frontier_strong_cp_operator_basis_real_2026_05_19.py",
+      "transitive_descendants": 14
+    },
+    {
+      "audit_independence_required": "fresh_context_or_stronger",
+      "audit_status": "unaudited",
+      "blocker": null,
       "claim_id": "gauge_vacuum_plaquette_adjacent_word_contraction_derived_narrow_theorem_note_2026-06-12",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
@@ -20289,34 +20345,6 @@
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/alpha_bare_four_pi_from_z3_plancherel_bridge_2026_05_26.py",
-      "transitive_descendants": 13
-    },
-    {
-      "audit_independence_required": "fresh_context_or_stronger",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "strong_cp_operator_basis_and_mass_orientation_theorem_note_2026-05-19",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "high",
-      "criticality_rank": 2,
-      "cross_confirmation_status": null,
-      "deps": [
-        "wilson_real_positive_measure_bounded_premise_bridge_note_2026-06-03",
-        "staggered_scalar_mass_class_bounded_premise_bridge_note_2026-06-03",
-        "cl3_normalization_i3_accepted_premise_bridge_bounded_note_2026-05-27",
-        "staggered_only_det_positivity_case_a_note_2026-05-17",
-        "reflection_positivity_gauge_half_cauchy_schwarz_narrow_theorem_note_2026-05-10"
-      ],
-      "direct_in_degree": 6,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 6.807,
-      "note_path": "docs/STRONG_CP_OPERATOR_BASIS_AND_MASS_ORIENTATION_THEOREM_NOTE_2026-05-19.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/frontier_strong_cp_operator_basis_real_2026_05_19.py",
       "transitive_descendants": 13
     },
     {
@@ -21741,7 +21769,7 @@
       "claim_id": "u4_closes_under_qubit_reframe_narrow_theorem_note_2026-05-20",
       "claim_scope": null,
       "claim_type": "positive_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "medium",
       "criticality_rank": 1,
       "cross_confirmation_status": null,
@@ -21843,10 +21871,35 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
+      "claim_id": "gauge_multiplaquette_character_gluing_emergent_integer_sector_record_context_and_action_pairing_residual_bounded_theorem_note_2026-07-02",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "minimal_axioms",
+        "gauge_vacuum_plaquette_transfer_operator_character_recurrence_note"
+      ],
+      "direct_in_degree": 2,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 2.585,
+      "note_path": "docs/GAUGE_MULTIPLAQUETTE_CHARACTER_GLUING_EMERGENT_INTEGER_SECTOR_RECORD_CONTEXT_AND_ACTION_PAIRING_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md",
+      "queue_reason": "unaudited",
+      "ready": true,
+      "runner_path": "scripts/gauge_multiplaquette_character_gluing_emergent_integer_sector_2026_07_02.py",
+      "transitive_descendants": 2
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
       "claim_id": "post_record_directed_certificate_examples_2026-06-06",
       "claim_scope": null,
       "claim_type": "positive_theorem",
-      "claim_type_provenance": "needs_reaudit_after_invalidation",
+      "claim_type_provenance": "migration_hint",
       "criticality": "medium",
       "criticality_rank": 1,
       "cross_confirmation_status": null,
@@ -22211,6 +22264,32 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
+      "claim_id": "g_bare_forced_by_ward_rep_b_independence_theorem_note_2026-05-09",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "g_bare_canonical_convention_narrow_theorem_note_2026-05-02",
+        "g_bare_two_ward_rep_b_independence_theorem_note_2026-04-19",
+        "g_bare_two_ward_same_1pi_pinning_theorem_note_2026-04-19"
+      ],
+      "direct_in_degree": 2,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 7.392,
+      "note_path": "docs/G_BARE_FORCED_BY_WARD_REP_B_INDEPENDENCE_THEOREM_NOTE_2026-05-09.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/frontier_g_bare_canonical_convention_narrow.py",
+      "transitive_descendants": 83
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
       "claim_id": "dm_wilson_to_dweh_hermitian_source_family_target_note_2026-04-18",
       "claim_scope": null,
       "claim_type": "positive_theorem",
@@ -22266,32 +22345,6 @@
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_neutrino_source_surface_quartic_isotropy_and_u2_obstruction.py",
-      "transitive_descendants": 82
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "g_bare_forced_by_ward_rep_b_independence_theorem_note_2026-05-09",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "medium",
-      "criticality_rank": 1,
-      "cross_confirmation_status": null,
-      "deps": [
-        "g_bare_canonical_convention_narrow_theorem_note_2026-05-02",
-        "g_bare_two_ward_rep_b_independence_theorem_note_2026-04-19",
-        "g_bare_two_ward_same_1pi_pinning_theorem_note_2026-04-19"
-      ],
-      "direct_in_degree": 2,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 7.375,
-      "note_path": "docs/G_BARE_FORCED_BY_WARD_REP_B_INDEPENDENCE_THEOREM_NOTE_2026-05-09.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/frontier_g_bare_canonical_convention_narrow.py",
       "transitive_descendants": 82
     },
     {
@@ -25601,7 +25654,7 @@
       "claim_id": "dm_full_closure_64_to_1_channel_weight_bridge_narrow_theorem_note_2026-06-02",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "medium",
       "criticality_rank": 1,
       "cross_confirmation_status": null,
@@ -25653,7 +25706,7 @@
       "claim_id": "dm_full_closure_same_surface_thermal_bounding_theorem_note_2026-04-17",
       "claim_scope": null,
       "claim_type": "open_gate",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "medium",
       "criticality_rank": 1,
       "cross_confirmation_status": null,
@@ -25911,7 +25964,7 @@
       "claim_id": "plaquette_bootstrap_framework_integration_note_2026-05-03",
       "claim_scope": null,
       "claim_type": "positive_theorem",
-      "claim_type_provenance": "needs_reaudit_after_invalidation",
+      "claim_type_provenance": "default_positive_theorem",
       "criticality": "medium",
       "criticality_rank": 1,
       "cross_confirmation_status": null,
@@ -26543,7 +26596,7 @@
       "claim_id": "gellmann_completeness_theorem_note_2026-05-02",
       "claim_scope": null,
       "claim_type": "positive_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "medium",
       "criticality_rank": 1,
       "cross_confirmation_status": null,
@@ -27995,12 +28048,12 @@
       "direct_in_degree": 4,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 7.209,
+      "load_bearing_score": 7.248,
       "note_path": "docs/CORNER_FERMION_DETERMINANT_DOES_NOT_SELECT_KOIDE_R_HALF_NARROW_OBSTRUCTION_NOTE_2026-06-04.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/audit_companion_corner_fermion_determinant_not_r_half_exact.py",
-      "transitive_descendants": 36
+      "transitive_descendants": 37
     },
     {
       "audit_independence_required": "any_non_self",
@@ -28031,6 +28084,38 @@
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_koide_a1_brannen_plancherel_identity_support.py",
+      "transitive_descendants": 36
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "staggered_taste_is_the_qubit_no_separate_koide_multiplicity_narrow_obstruction_note_2026-06-04",
+      "claim_scope": null,
+      "claim_type": "no_go",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "koide_bae_probe_physical_extremization_bounded_obstruction_note_2026-05-09_probe25",
+        "koide_bae_probe_kappa_prediction_test_partial_falsification_note_2026-05-09_probe29",
+        "corner_fermion_determinant_does_not_select_koide_r_half_narrow_obstruction_note_2026-06-04",
+        "minimal_axioms",
+        "hierarchy_formula_honest_status_note_2026-05-10",
+        "koide_z3_scalar_potential_support_note_2026-04-19",
+        "staggered_dirac_realization_gate_note_2026-05-03",
+        "koide_r_half_not_symmetry_protected_dynamical_norm_balance_narrow_no_go_note_2026-06-04",
+        "koide_kappa_block_total_frobenius_measure_theorem_note_2026-04-19"
+      ],
+      "direct_in_degree": 4,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 7.209,
+      "note_path": "docs/STAGGERED_TASTE_IS_THE_QUBIT_NO_SEPARATE_KOIDE_MULTIPLICITY_NARROW_OBSTRUCTION_NOTE_2026-06-04.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/audit_companion_staggered_taste_is_qubit_no_koide_multiplicity_exact.py",
       "transitive_descendants": 36
     },
     {
@@ -28211,32 +28296,28 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
-      "claim_id": "staggered_taste_is_the_qubit_no_separate_koide_multiplicity_narrow_obstruction_note_2026-06-04",
+      "claim_id": "hypercharge_proof_walk_lattice_independence_bounded_note_2026-05-07",
       "claim_scope": null,
-      "claim_type": "no_go",
+      "claim_type": "bounded_theorem",
       "claim_type_provenance": "author_hint",
       "criticality": "medium",
       "criticality_rank": 1,
       "cross_confirmation_status": null,
       "deps": [
-        "koide_bae_probe_physical_extremization_bounded_obstruction_note_2026-05-09_probe25",
-        "koide_bae_probe_kappa_prediction_test_partial_falsification_note_2026-05-09_probe29",
-        "corner_fermion_determinant_does_not_select_koide_r_half_narrow_obstruction_note_2026-06-04",
-        "minimal_axioms",
-        "hierarchy_formula_honest_status_note_2026-05-10",
-        "koide_z3_scalar_potential_support_note_2026-04-19",
-        "staggered_dirac_realization_gate_note_2026-05-03",
-        "koide_r_half_not_symmetry_protected_dynamical_norm_balance_narrow_no_go_note_2026-06-04",
-        "koide_kappa_block_total_frobenius_measure_theorem_note_2026-04-19"
+        "standard_model_hypercharge_uniqueness_theorem_note_2026-04-24",
+        "left_handed_charge_matching_note",
+        "hypercharge_identification_note",
+        "anomaly_forces_time_theorem",
+        "lh_anomaly_trace_catalog_theorem_note_2026-04-25"
       ],
-      "direct_in_degree": 4,
+      "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 7.17,
-      "note_path": "docs/STAGGERED_TASTE_IS_THE_QUBIT_NO_SEPARATE_KOIDE_MULTIPLICITY_NARROW_OBSTRUCTION_NOTE_2026-06-04.md",
+      "load_bearing_score": 6.17,
+      "note_path": "docs/HYPERCHARGE_PROOF_WALK_LATTICE_INDEPENDENCE_BOUNDED_NOTE_2026-05-07.md",
       "queue_reason": "unaudited",
       "ready": false,
-      "runner_path": "scripts/audit_companion_staggered_taste_is_qubit_no_koide_multiplicity_exact.py",
+      "runner_path": "scripts/frontier_hypercharge_proof_walk_lattice_independence.py",
       "transitive_descendants": 35
     },
     {
@@ -28301,7 +28382,7 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
-      "claim_id": "hypercharge_proof_walk_lattice_independence_bounded_note_2026-05-07",
+      "claim_id": "gbare_wilson_action_internal_proof_walk_bounded_note_2026-05-08",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
       "claim_type_provenance": "author_hint",
@@ -28309,21 +28390,50 @@
       "criticality_rank": 1,
       "cross_confirmation_status": null,
       "deps": [
-        "standard_model_hypercharge_uniqueness_theorem_note_2026-04-24",
-        "left_handed_charge_matching_note",
-        "hypercharge_identification_note",
-        "anomaly_forces_time_theorem",
-        "lh_anomaly_trace_catalog_theorem_note_2026-04-25"
+        "g_bare_constraint_vs_convention_theorem_note_2026-05-03",
+        "hypercharge_proof_walk_lattice_independence_bounded_note_2026-05-07",
+        "g_bare_rescaling_freedom_removal_theorem_note_2026-05-03",
+        "g_bare_two_ward_closure_note_2026-04-18",
+        "g_bare_structural_normalization_theorem_note_2026-04-18",
+        "cl3_color_automorphism_theorem",
+        "g_bare_rigidity_theorem_note"
       ],
-      "direct_in_degree": 2,
+      "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 6.129,
-      "note_path": "docs/HYPERCHARGE_PROOF_WALK_LATTICE_INDEPENDENCE_BOUNDED_NOTE_2026-05-07.md",
+      "load_bearing_score": 5.587,
+      "note_path": "docs/GBARE_WILSON_ACTION_INTERNAL_PROOF_WALK_BOUNDED_NOTE_2026-05-08.md",
       "queue_reason": "unaudited",
       "ready": false,
-      "runner_path": "scripts/frontier_hypercharge_proof_walk_lattice_independence.py",
-      "transitive_descendants": 34
+      "runner_path": "scripts/frontier_gbare_wilson_action_internal_proof_walk.py",
+      "transitive_descendants": 33
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "cl3_normalization_i3_accepted_premise_bridge_bounded_note_2026-05-27",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "alpha_convention_i2_accepted_premise_bridge_bounded_note_2026-05-27",
+        "gbare_wilson_action_internal_proof_walk_bounded_note_2026-05-08",
+        "g_bare_derivation_note",
+        "g_bare_two_ward_h_unit_residue_accepted_premise_bridge_bounded_note_2026-05-26"
+      ],
+      "direct_in_degree": 4,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 7.044,
+      "note_path": "docs/CL3_NORMALIZATION_I3_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-27.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/cl3_normalization_i3_accepted_premise_runner.py",
+      "transitive_descendants": 32
     },
     {
       "audit_independence_required": "any_non_self",
@@ -28356,7 +28466,7 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
-      "claim_id": "gbare_wilson_action_internal_proof_walk_bounded_note_2026-05-08",
+      "claim_id": "axiom_first_lattice_wz_fujikawa_narrow_theorem_note_2026-05-26",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
       "claim_type_provenance": "author_hint",
@@ -28364,49 +28474,18 @@
       "criticality_rank": 1,
       "cross_confirmation_status": null,
       "deps": [
-        "g_bare_constraint_vs_convention_theorem_note_2026-05-03",
-        "hypercharge_proof_walk_lattice_independence_bounded_note_2026-05-07",
-        "g_bare_rescaling_freedom_removal_theorem_note_2026-05-03",
-        "g_bare_two_ward_closure_note_2026-04-18",
-        "g_bare_structural_normalization_theorem_note_2026-04-18",
-        "cl3_color_automorphism_theorem",
-        "g_bare_rigidity_theorem_note"
+        "minimal_axioms",
+        "no_per_site_chirality_theorem_note_2026-05-02",
+        "cpt_exact_note"
       ],
-      "direct_in_degree": 1,
+      "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 5.544,
-      "note_path": "docs/GBARE_WILSON_ACTION_INTERNAL_PROOF_WALK_BOUNDED_NOTE_2026-05-08.md",
+      "load_bearing_score": 6.0,
+      "note_path": "docs/AXIOM_FIRST_LATTICE_WZ_FUJIKAWA_NARROW_THEOREM_NOTE_2026-05-26.md",
       "queue_reason": "unaudited",
       "ready": false,
-      "runner_path": "scripts/frontier_gbare_wilson_action_internal_proof_walk.py",
-      "transitive_descendants": 32
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "cl3_normalization_i3_accepted_premise_bridge_bounded_note_2026-05-27",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "medium",
-      "criticality_rank": 1,
-      "cross_confirmation_status": null,
-      "deps": [
-        "alpha_convention_i2_accepted_premise_bridge_bounded_note_2026-05-27",
-        "gbare_wilson_action_internal_proof_walk_bounded_note_2026-05-08",
-        "g_bare_derivation_note",
-        "g_bare_two_ward_h_unit_residue_accepted_premise_bridge_bounded_note_2026-05-26"
-      ],
-      "direct_in_degree": 4,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 7.0,
-      "note_path": "docs/CL3_NORMALIZATION_I3_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-27.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/cl3_normalization_i3_accepted_premise_runner.py",
+      "runner_path": "scripts/frontier_lattice_wess_zumino_fujikawa_narrow_verifier.py",
       "transitive_descendants": 31
     },
     {
@@ -28445,32 +28524,6 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
-      "claim_id": "axiom_first_lattice_wz_fujikawa_narrow_theorem_note_2026-05-26",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "medium",
-      "criticality_rank": 1,
-      "cross_confirmation_status": null,
-      "deps": [
-        "minimal_axioms",
-        "no_per_site_chirality_theorem_note_2026-05-02",
-        "cpt_exact_note"
-      ],
-      "direct_in_degree": 2,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 5.954,
-      "note_path": "docs/AXIOM_FIRST_LATTICE_WZ_FUJIKAWA_NARROW_THEOREM_NOTE_2026-05-26.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/frontier_lattice_wess_zumino_fujikawa_narrow_verifier.py",
-      "transitive_descendants": 30
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
       "claim_id": "multifactor_connes_lott_purchases_not_derives_koide_multiplicity_narrow_obstruction_note_2026-06-04",
       "claim_scope": null,
       "claim_type": "no_go",
@@ -28493,12 +28546,12 @@
       "direct_in_degree": 2,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
-      "load_bearing_score": 5.907,
+      "load_bearing_score": 5.954,
       "note_path": "docs/MULTIFACTOR_CONNES_LOTT_PURCHASES_NOT_DERIVES_KOIDE_MULTIPLICITY_NARROW_OBSTRUCTION_NOTE_2026-06-04.md",
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/audit_companion_multifactor_cannot_cleanly_give_koide_multiplicity_exact.py",
-      "transitive_descendants": 29
+      "transitive_descendants": 30
     },
     {
       "audit_independence_required": "any_non_self",
@@ -29949,6 +30002,30 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
+      "claim_id": "wilson_real_positive_measure_bounded_premise_bridge_note_2026-06-03",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "cl3_normalization_i3_accepted_premise_bridge_bounded_note_2026-05-27"
+      ],
+      "direct_in_degree": 2,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 5.17,
+      "note_path": "docs/WILSON_REAL_POSITIVE_MEASURE_BOUNDED_PREMISE_BRIDGE_NOTE_2026-06-03.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/wilson_real_positive_measure_bounded_premise_runner.py",
+      "transitive_descendants": 17
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
       "claim_id": "work_history.atomic.hydrogen_helium_atomic_companion_note_2026-04-18",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
@@ -30032,30 +30109,6 @@
       "ready": false,
       "runner_path": "scripts/frontier_observable_principle_p1_bridge_free_cumulant_route.py",
       "transitive_descendants": 17
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "wilson_real_positive_measure_bounded_premise_bridge_note_2026-06-03",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "medium",
-      "criticality_rank": 1,
-      "cross_confirmation_status": null,
-      "deps": [
-        "cl3_normalization_i3_accepted_premise_bridge_bounded_note_2026-05-27"
-      ],
-      "direct_in_degree": 2,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 5.087,
-      "note_path": "docs/WILSON_REAL_POSITIVE_MEASURE_BOUNDED_PREMISE_BRIDGE_NOTE_2026-06-03.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/wilson_real_positive_measure_bounded_premise_runner.py",
-      "transitive_descendants": 16
     },
     {
       "audit_independence_required": "any_non_self",
@@ -30528,6 +30581,97 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
+      "claim_id": "a3_r2_review_confirms_exhaustion_note_2026-05-08_r2hr",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "a3_route2_single_clock_c3_obstruction_note_2026-05-08_r2",
+        "staggered_dirac_kawamoto_smit_forcing_theorem_note_2026-05-07",
+        "staggered_dirac_bz_corner_forcing_theorem_note_2026-05-07",
+        "axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03",
+        "axiom_first_microcausality_lieb_robinson_theorem_note_2026-05-01",
+        "cpt_exact_note",
+        "staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac",
+        "l3a_v3_trace_surface_bounded_obstruction_note_2026-05-07_l3a"
+      ],
+      "direct_in_degree": 1,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 4.2,
+      "note_path": "docs/A3_R2_REVIEW_CONFIRMS_EXHAUSTION_NOTE_2026-05-08_r2hr.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/cl3_a3_r2_hostile_review_2026_05_08_r2hr.py",
+      "transitive_descendants": 12
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "a3_r3_review_confirms_obstruction_note_2026-05-08_r3hr",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "a3_route3_anomaly_inflow_bounded_obstruction_note_2026-05-08_r3",
+        "staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac",
+        "axiom_first_reflection_positivity_theorem_note_2026-04-29",
+        "axiom_first_cluster_decomposition_theorem_note_2026-04-29",
+        "staggered_dirac_bz_corner_forcing_theorem_note_2026-05-07",
+        "three_generation_observable_theorem_note",
+        "su2_witten_z2_anomaly_theorem_note_2026-04-24",
+        "axiom_first_sm_anomaly_cancellation_complete_theorem_note_2026-05-03"
+      ],
+      "direct_in_degree": 1,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 4.2,
+      "note_path": "docs/A3_R3_REVIEW_CONFIRMS_OBSTRUCTION_NOTE_2026-05-08_r3hr.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/cl3_a3_r3_hostile_review_2026_05_08_r3hr.py",
+      "transitive_descendants": 12
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "a3_r4_review_confirmed_note_2026-05-08_r4hr",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "a3_route4_spin6_chain_bounded_obstruction_note_2026-05-08_r4",
+        "l3a_v3_trace_surface_bounded_obstruction_note_2026-05-07_l3a",
+        "staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac",
+        "cl3_color_automorphism_theorem",
+        "three_generation_observable_theorem_note",
+        "n_f_trace_space_bounded_obstruction_note_2026-05-07_w2binary"
+      ],
+      "direct_in_degree": 1,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 4.2,
+      "note_path": "docs/A3_R4_REVIEW_CONFIRMED_NOTE_2026-05-08_r4hr.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/cl3_a3_r4_hostile_review_2026_05_08_r4hr.py",
+      "transitive_descendants": 12
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
       "claim_id": "signed_gravity_naturally_hosted_orientation_line_note",
       "claim_scope": null,
       "claim_type": "positive_theorem",
@@ -30686,91 +30830,47 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
-      "claim_id": "a3_r2_review_confirms_exhaustion_note_2026-05-08_r2hr",
+      "claim_id": "ac_phi_lambda_preserved_c3_structural_foreclosure_bounded_theorem_note_2026-05-10",
       "claim_scope": null,
-      "claim_type": "bounded_theorem",
+      "claim_type": "no_go",
       "claim_type_provenance": "author_hint",
       "criticality": "medium",
       "criticality_rank": 1,
       "cross_confirmation_status": null,
       "deps": [
+        "c3_symmetry_preserved_interpretation_note_2026-05-08",
+        "koide_bae_30_probe_campaign_note_2026-05-09",
+        "staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac",
+        "a3_route1_higgs_yukawa_c3_breaking_bounded_obstruction_note_2026-05-08_r1",
         "a3_route2_single_clock_c3_obstruction_note_2026-05-08_r2",
-        "staggered_dirac_kawamoto_smit_forcing_theorem_note_2026-05-07",
-        "staggered_dirac_bz_corner_forcing_theorem_note_2026-05-07",
-        "axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03",
-        "axiom_first_microcausality_lieb_robinson_theorem_note_2026-05-01",
-        "cpt_exact_note",
-        "staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac",
-        "l3a_v3_trace_surface_bounded_obstruction_note_2026-05-07_l3a"
-      ],
-      "direct_in_degree": 1,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 4.085,
-      "note_path": "docs/A3_R2_REVIEW_CONFIRMS_EXHAUSTION_NOTE_2026-05-08_r2hr.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/cl3_a3_r2_hostile_review_2026_05_08_r2hr.py",
-      "transitive_descendants": 11
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "a3_r3_review_confirms_obstruction_note_2026-05-08_r3hr",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "medium",
-      "criticality_rank": 1,
-      "cross_confirmation_status": null,
-      "deps": [
         "a3_route3_anomaly_inflow_bounded_obstruction_note_2026-05-08_r3",
-        "staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac",
+        "a3_route4_spin6_chain_bounded_obstruction_note_2026-05-08_r4",
+        "a3_route5_no_proper_quotient_sharpened_obstruction_note_2026-05-08_r5",
+        "a3_r1_review_confirms_obstruction_note_2026-05-08_r1hr",
+        "a3_r2_review_confirms_exhaustion_note_2026-05-08_r2hr",
+        "a3_r3_review_confirms_obstruction_note_2026-05-08_r3hr",
+        "a3_r4_review_confirmed_note_2026-05-08_r4hr",
+        "a3_r5_review_confirms_obstruction_note_2026-05-08_r5hr",
+        "staggered_dirac_bz_corner_forcing_theorem_note_2026-05-07",
+        "minimal_axioms_2026-05-03",
         "axiom_first_reflection_positivity_theorem_note_2026-04-29",
         "axiom_first_cluster_decomposition_theorem_note_2026-04-29",
-        "staggered_dirac_bz_corner_forcing_theorem_note_2026-05-07",
+        "brannen_amplitude_equipartition_bae_rename_meta_note_2026-05-09",
+        "audit_backlog_note_2026-05-02",
+        "staggered_dirac_realization_gate_note_2026-05-03",
+        "a3_option_c_brannen_rivero_physical_lattice_bounded_obstruction_note_2026-05-08_optc",
+        "koide_circulant_character_derivation_note_2026-04-18",
         "three_generation_observable_theorem_note",
-        "su2_witten_z2_anomaly_theorem_note_2026-04-24",
-        "axiom_first_sm_anomaly_cancellation_complete_theorem_note_2026-05-03"
+        "three_generation_observable_no_proper_quotient_narrow_theorem_note_2026-05-02"
       ],
       "direct_in_degree": 1,
       "effective_status": "unaudited",
       "helper_runner_paths": [],
       "load_bearing_score": 4.085,
-      "note_path": "docs/A3_R3_REVIEW_CONFIRMS_OBSTRUCTION_NOTE_2026-05-08_r3hr.md",
+      "note_path": "docs/AC_PHI_LAMBDA_PRESERVED_C3_STRUCTURAL_FORECLOSURE_BOUNDED_THEOREM_NOTE_2026-05-10.md",
       "queue_reason": "unaudited",
       "ready": false,
-      "runner_path": "scripts/cl3_a3_r3_hostile_review_2026_05_08_r3hr.py",
-      "transitive_descendants": 11
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "a3_r4_review_confirmed_note_2026-05-08_r4hr",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "medium",
-      "criticality_rank": 1,
-      "cross_confirmation_status": null,
-      "deps": [
-        "a3_route4_spin6_chain_bounded_obstruction_note_2026-05-08_r4",
-        "l3a_v3_trace_surface_bounded_obstruction_note_2026-05-07_l3a",
-        "staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac",
-        "cl3_color_automorphism_theorem",
-        "three_generation_observable_theorem_note",
-        "n_f_trace_space_bounded_obstruction_note_2026-05-07_w2binary"
-      ],
-      "direct_in_degree": 1,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 4.085,
-      "note_path": "docs/A3_R4_REVIEW_CONFIRMED_NOTE_2026-05-08_r4hr.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/cl3_a3_r4_hostile_review_2026_05_08_r4hr.py",
+      "runner_path": "scripts/ac_phi_lambda_c3_equivariance_schur_diagnostic_2026_05_10.py",
       "transitive_descendants": 11
     },
     {
@@ -30853,6 +30953,35 @@
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_observable_principle_p1_bridge_wave11_route_c_doplicher_roberts_reconstruction_external_narrow.py",
+      "transitive_descendants": 11
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "strong_cp_joint_bridge_fails_holomorphic_residual_2026-06-04",
+      "claim_scope": null,
+      "claim_type": "no_go",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "koide_emergent_time_eta_conjugation_parity_bounded_note_2026-05-30",
+        "supertrace_index_holomorphic_route_to_koide_r_half_open_lead_note_2026-06-04",
+        "koide_generation_id_cl3_grade1_bridge_narrow_theorem_note_2026-06-02",
+        "strong_cp_rp_half_cannot_forbid_cp_odd_imaginary_no_go_note_2026-05-16",
+        "strong_cp_operator_basis_and_mass_orientation_theorem_note_2026-05-19",
+        "strong_cp_epsilon_pseudotensor_oh_sign_bridge_bounded_note_2026-05-26"
+      ],
+      "direct_in_degree": 1,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 4.085,
+      "note_path": "docs/STRONG_CP_JOINT_BRIDGE_FAILS_HOLOMORPHIC_RESIDUAL_2026-06-04.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/strong_cp_joint_bridge_holomorphic_residual_2026_06_04.py",
       "transitive_descendants": 11
     },
     {
@@ -30983,6 +31112,32 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
+      "claim_id": "strong_cp_theta_bar_structured_admission_2026-06-04",
+      "claim_scope": null,
+      "claim_type": "open_gate",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "strong_cp_theta_zero_note",
+        "strong_cp_joint_bridge_fails_holomorphic_residual_2026-06-04",
+        "ac_phi_lambda_preserved_c3_structural_foreclosure_bounded_theorem_note_2026-05-10"
+      ],
+      "direct_in_degree": 4,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 5.459,
+      "note_path": "docs/STRONG_CP_THETA_BAR_STRUCTURED_ADMISSION_2026-06-04.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/strong_cp_theta_bar_structured_admission_2026_06_04.py",
+      "transitive_descendants": 10
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
       "claim_id": "v_eff_total_njl_style_bounded_theorem_note_2026-05-10",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
@@ -31100,82 +31255,6 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
-      "claim_id": "ac_phi_lambda_preserved_c3_structural_foreclosure_bounded_theorem_note_2026-05-10",
-      "claim_scope": null,
-      "claim_type": "no_go",
-      "claim_type_provenance": "author_hint",
-      "criticality": "medium",
-      "criticality_rank": 1,
-      "cross_confirmation_status": null,
-      "deps": [
-        "c3_symmetry_preserved_interpretation_note_2026-05-08",
-        "koide_bae_30_probe_campaign_note_2026-05-09",
-        "staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac",
-        "a3_route1_higgs_yukawa_c3_breaking_bounded_obstruction_note_2026-05-08_r1",
-        "a3_route2_single_clock_c3_obstruction_note_2026-05-08_r2",
-        "a3_route3_anomaly_inflow_bounded_obstruction_note_2026-05-08_r3",
-        "a3_route4_spin6_chain_bounded_obstruction_note_2026-05-08_r4",
-        "a3_route5_no_proper_quotient_sharpened_obstruction_note_2026-05-08_r5",
-        "a3_r1_review_confirms_obstruction_note_2026-05-08_r1hr",
-        "a3_r2_review_confirms_exhaustion_note_2026-05-08_r2hr",
-        "a3_r3_review_confirms_obstruction_note_2026-05-08_r3hr",
-        "a3_r4_review_confirmed_note_2026-05-08_r4hr",
-        "a3_r5_review_confirms_obstruction_note_2026-05-08_r5hr",
-        "staggered_dirac_bz_corner_forcing_theorem_note_2026-05-07",
-        "minimal_axioms_2026-05-03",
-        "axiom_first_reflection_positivity_theorem_note_2026-04-29",
-        "axiom_first_cluster_decomposition_theorem_note_2026-04-29",
-        "brannen_amplitude_equipartition_bae_rename_meta_note_2026-05-09",
-        "audit_backlog_note_2026-05-02",
-        "staggered_dirac_realization_gate_note_2026-05-03",
-        "a3_option_c_brannen_rivero_physical_lattice_bounded_obstruction_note_2026-05-08_optc",
-        "koide_circulant_character_derivation_note_2026-04-18",
-        "three_generation_observable_theorem_note",
-        "three_generation_observable_no_proper_quotient_narrow_theorem_note_2026-05-02"
-      ],
-      "direct_in_degree": 1,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 3.959,
-      "note_path": "docs/AC_PHI_LAMBDA_PRESERVED_C3_STRUCTURAL_FORECLOSURE_BOUNDED_THEOREM_NOTE_2026-05-10.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/ac_phi_lambda_c3_equivariance_schur_diagnostic_2026_05_10.py",
-      "transitive_descendants": 10
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "strong_cp_joint_bridge_fails_holomorphic_residual_2026-06-04",
-      "claim_scope": null,
-      "claim_type": "no_go",
-      "claim_type_provenance": "author_hint",
-      "criticality": "medium",
-      "criticality_rank": 1,
-      "cross_confirmation_status": null,
-      "deps": [
-        "koide_emergent_time_eta_conjugation_parity_bounded_note_2026-05-30",
-        "supertrace_index_holomorphic_route_to_koide_r_half_open_lead_note_2026-06-04",
-        "koide_generation_id_cl3_grade1_bridge_narrow_theorem_note_2026-06-02",
-        "strong_cp_rp_half_cannot_forbid_cp_odd_imaginary_no_go_note_2026-05-16",
-        "strong_cp_operator_basis_and_mass_orientation_theorem_note_2026-05-19",
-        "strong_cp_epsilon_pseudotensor_oh_sign_bridge_bounded_note_2026-05-26"
-      ],
-      "direct_in_degree": 1,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 3.959,
-      "note_path": "docs/STRONG_CP_JOINT_BRIDGE_FAILS_HOLOMORPHIC_RESIDUAL_2026-06-04.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/strong_cp_joint_bridge_holomorphic_residual_2026_06_04.py",
-      "transitive_descendants": 10
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
       "claim_id": "fs_rotation_exchange_discrete_insufficiency_narrow_no_go_note_2026-05-28",
       "claim_scope": null,
       "claim_type": "no_go",
@@ -31221,32 +31300,6 @@
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_exercise_staggered_dirac_reassessment_2026_06_06.py",
-      "transitive_descendants": 9
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "strong_cp_theta_bar_structured_admission_2026-06-04",
-      "claim_scope": null,
-      "claim_type": "open_gate",
-      "claim_type_provenance": "author_hint",
-      "criticality": "medium",
-      "criticality_rank": 1,
-      "cross_confirmation_status": null,
-      "deps": [
-        "strong_cp_theta_zero_note",
-        "strong_cp_joint_bridge_fails_holomorphic_residual_2026-06-04",
-        "ac_phi_lambda_preserved_c3_structural_foreclosure_bounded_theorem_note_2026-05-10"
-      ],
-      "direct_in_degree": 4,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 5.322,
-      "note_path": "docs/STRONG_CP_THETA_BAR_STRUCTURED_ADMISSION_2026-06-04.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/strong_cp_theta_bar_structured_admission_2026_06_04.py",
       "transitive_descendants": 9
     },
     {
@@ -31832,6 +31885,34 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
+      "claim_id": "newphysics_np_strong_cp_theta_note_2026-05-10_npcp",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "strong_cp_theta_zero_note",
+        "strong_cp_theta_zero_audited_scope_narrow_bounded_note_2026-05-10",
+        "bridge_gap_action_form_uniqueness_no_go_note_2026-05-06",
+        "minimal_axioms_2026-05-03",
+        "g_bare_structural_normalization_theorem_note_2026-04-18"
+      ],
+      "direct_in_degree": 2,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 4.17,
+      "note_path": "docs/NEWPHYSICS_NP_STRONG_CP_THETA_NOTE_2026-05-10_npCP.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/frontier_np_strong_cp_theta_obstruction.py",
+      "transitive_descendants": 8
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
       "claim_id": "patched_stationary_system_pl_s3_theorem_note_2026-05-03",
       "claim_scope": null,
       "claim_type": "positive_theorem",
@@ -31969,6 +32050,35 @@
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/cl3_koide_x_l1_msbar_2026_05_08_probeX_L1_msbar.py",
+      "transitive_descendants": 7
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "strong_cp_gauge_theta_not_forced_by_reality_positivity_or_cpt_bounded_note_2026-06-07",
+      "claim_scope": null,
+      "claim_type": "no_go",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "strong_cp_theta_bar_structured_admission_2026-06-04",
+        "strong_cp_operator_basis_and_mass_orientation_theorem_note_2026-05-19",
+        "strong_cp_rp_half_cannot_forbid_cp_odd_imaginary_no_go_note_2026-05-16",
+        "newphysics_np_strong_cp_theta_note_2026-05-10_npcp",
+        "minimal_axioms",
+        "strong_cp_theta_zero_note"
+      ],
+      "direct_in_degree": 4,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 5.0,
+      "note_path": "docs/STRONG_CP_GAUGE_THETA_NOT_FORCED_BY_REALITY_POSITIVITY_OR_CPT_BOUNDED_NOTE_2026-06-07.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/audit_companion_strong_cp_gauge_theta_not_forced_by_reality_positivity_cpt_exact.py",
       "transitive_descendants": 7
     },
     {
@@ -32194,34 +32304,6 @@
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/free_sector_fs_level1_mechanism_reduction_2026-05-30.py",
-      "transitive_descendants": 7
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "newphysics_np_strong_cp_theta_note_2026-05-10_npcp",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "medium",
-      "criticality_rank": 1,
-      "cross_confirmation_status": null,
-      "deps": [
-        "strong_cp_theta_zero_note",
-        "strong_cp_theta_zero_audited_scope_narrow_bounded_note_2026-05-10",
-        "bridge_gap_action_form_uniqueness_no_go_note_2026-05-06",
-        "minimal_axioms_2026-05-03",
-        "g_bare_structural_normalization_theorem_note_2026-04-18"
-      ],
-      "direct_in_degree": 2,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 4.0,
-      "note_path": "docs/NEWPHYSICS_NP_STRONG_CP_THETA_NOTE_2026-05-10_npCP.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/frontier_np_strong_cp_theta_obstruction.py",
       "transitive_descendants": 7
     },
     {
@@ -32501,35 +32583,6 @@
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_dm_wilson_direct_descendant_constructive_transport_plateau_observable_affine_no_go_2026_04_19.py",
-      "transitive_descendants": 6
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "strong_cp_gauge_theta_not_forced_by_reality_positivity_or_cpt_bounded_note_2026-06-07",
-      "claim_scope": null,
-      "claim_type": "no_go",
-      "claim_type_provenance": "author_hint",
-      "criticality": "medium",
-      "criticality_rank": 1,
-      "cross_confirmation_status": null,
-      "deps": [
-        "strong_cp_theta_bar_structured_admission_2026-06-04",
-        "strong_cp_operator_basis_and_mass_orientation_theorem_note_2026-05-19",
-        "strong_cp_rp_half_cannot_forbid_cp_odd_imaginary_no_go_note_2026-05-16",
-        "newphysics_np_strong_cp_theta_note_2026-05-10_npcp",
-        "minimal_axioms",
-        "strong_cp_theta_zero_note"
-      ],
-      "direct_in_degree": 4,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 4.807,
-      "note_path": "docs/STRONG_CP_GAUGE_THETA_NOT_FORCED_BY_REALITY_POSITIVITY_OR_CPT_BOUNDED_NOTE_2026-06-07.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/audit_companion_strong_cp_gauge_theta_not_forced_by_reality_positivity_cpt_exact.py",
       "transitive_descendants": 6
     },
     {
@@ -33642,6 +33695,34 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
+      "claim_id": "strong_cp_gauge_theta_multiplaquette_ftf_is_admissible_not_clean_closeable_bounded_note_2026-06-07",
+      "claim_scope": null,
+      "claim_type": "no_go",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "newphysics_np_strong_cp_theta_note_2026-05-10_npcp",
+        "strong_cp_rp_half_cannot_forbid_cp_odd_imaginary_no_go_note_2026-05-16",
+        "strong_cp_gauge_theta_not_forced_by_reality_positivity_or_cpt_bounded_note_2026-06-07",
+        "minimal_axioms",
+        "strong_cp_theta_zero_note"
+      ],
+      "direct_in_degree": 2,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 3.585,
+      "note_path": "docs/STRONG_CP_GAUGE_THETA_MULTIPLAQUETTE_FTF_IS_ADMISSIBLE_NOT_CLEAN_CLOSEABLE_BOUNDED_NOTE_2026-06-07.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/audit_companion_strong_cp_multiplaquette_ftf_admissible_not_clean_closeable_exact.py",
+      "transitive_descendants": 5
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
       "claim_id": "supplied_readout_context_two_component_decomposition_bounded_note_2026-07-02",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
@@ -34727,34 +34808,6 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
-      "claim_id": "strong_cp_gauge_theta_multiplaquette_ftf_is_admissible_not_clean_closeable_bounded_note_2026-06-07",
-      "claim_scope": null,
-      "claim_type": "no_go",
-      "claim_type_provenance": "author_hint",
-      "criticality": "medium",
-      "criticality_rank": 1,
-      "cross_confirmation_status": null,
-      "deps": [
-        "newphysics_np_strong_cp_theta_note_2026-05-10_npcp",
-        "strong_cp_rp_half_cannot_forbid_cp_odd_imaginary_no_go_note_2026-05-16",
-        "strong_cp_gauge_theta_not_forced_by_reality_positivity_or_cpt_bounded_note_2026-06-07",
-        "minimal_axioms",
-        "strong_cp_theta_zero_note"
-      ],
-      "direct_in_degree": 2,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 3.322,
-      "note_path": "docs/STRONG_CP_GAUGE_THETA_MULTIPLAQUETTE_FTF_IS_ADMISSIBLE_NOT_CLEAN_CLOSEABLE_BOUNDED_NOTE_2026-06-07.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/audit_companion_strong_cp_multiplaquette_ftf_admissible_not_clean_closeable_exact.py",
-      "transitive_descendants": 4
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
       "claim_id": "wilson_bz_corner_hamming_staircase_closed_form_note_2026-05-09",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
@@ -35717,6 +35770,34 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
+      "claim_id": "theta_gauge_substrate_no_winding_carrier_emergent_q_bridge_bounded_theorem_note_2026-06-11",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "medium",
+      "criticality_rank": 1,
+      "cross_confirmation_status": null,
+      "deps": [
+        "strong_cp_theta_bar_structured_admission_2026-06-04",
+        "minimal_axioms",
+        "theta_cross_plane_term_absent_in_supplied_per_plaquette_class_bounded_theorem_note_2026-06-09",
+        "strong_cp_gauge_theta_multiplaquette_ftf_is_admissible_not_clean_closeable_bounded_note_2026-06-07",
+        "kinetic_isotropy_primitive"
+      ],
+      "direct_in_degree": 2,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 3.0,
+      "note_path": "docs/THETA_GAUGE_SUBSTRATE_NO_WINDING_CARRIER_EMERGENT_Q_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-11.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/frontier_theta_gauge_substrate_winding_vacuity_2026_06_11.py",
+      "transitive_descendants": 3
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
       "claim_id": "universal_gr_polarization_frame_bundle_attempt",
       "claim_scope": null,
       "claim_type": "open_gate",
@@ -36278,7 +36359,7 @@
       "claim_id": "interacting_transfer_matter_gap_and_gauge_reduction_bounded_note_2026-05-30",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "medium",
       "criticality_rank": 1,
       "cross_confirmation_status": null,
@@ -36719,34 +36800,6 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
-      "claim_id": "theta_gauge_substrate_no_winding_carrier_emergent_q_bridge_bounded_theorem_note_2026-06-11",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "medium",
-      "criticality_rank": 1,
-      "cross_confirmation_status": null,
-      "deps": [
-        "strong_cp_theta_bar_structured_admission_2026-06-04",
-        "minimal_axioms",
-        "theta_cross_plane_term_absent_in_supplied_per_plaquette_class_bounded_theorem_note_2026-06-09",
-        "strong_cp_gauge_theta_multiplaquette_ftf_is_admissible_not_clean_closeable_bounded_note_2026-06-07",
-        "kinetic_isotropy_primitive"
-      ],
-      "direct_in_degree": 2,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 2.585,
-      "note_path": "docs/THETA_GAUGE_SUBSTRATE_NO_WINDING_CARRIER_EMERGENT_Q_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-11.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/frontier_theta_gauge_substrate_winding_vacuity_2026_06_11.py",
-      "transitive_descendants": 2
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
       "claim_id": "universal_gr_metric_reparametrized_vertex_operator_lift_boundary_bounded_theorem_note_2026-06-08",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
@@ -36974,7 +37027,7 @@
       "claim_id": "lhcm_matter_assignment_su3_block_representation_narrow_theorem_note_2026-05-17",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -37038,6 +37091,32 @@
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/frontier_d3_checkerboard_step1_parity_lemma_2026_06_12.py",
+      "transitive_descendants": 2
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "gauge_center_sector_record_context_and_theta_q_character_grading_obstruction_bounded_theorem_note_2026-07-01",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "leaf",
+      "criticality_rank": 0,
+      "cross_confirmation_status": null,
+      "deps": [
+        "gauge_vacuum_plaquette_transfer_operator_character_recurrence_note",
+        "minimal_axioms",
+        "strong_cp_rp_half_cannot_forbid_cp_odd_imaginary_no_go_note_2026-05-16"
+      ],
+      "direct_in_degree": 1,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 2.085,
+      "note_path": "docs/GAUGE_CENTER_SECTOR_RECORD_CONTEXT_AND_THETA_Q_CHARACTER_GRADING_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-07-01.md",
+      "queue_reason": "unaudited",
+      "ready": true,
+      "runner_path": "scripts/gauge_center_sector_record_context_character_grading_obstruction_2026_07_01.py",
       "transitive_descendants": 2
     },
     {
@@ -37149,7 +37228,7 @@
       "claim_id": "fractional_instanton_action_core_from_topological_infrastructure_bounded_note_2026-06-18",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -37165,57 +37244,6 @@
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/fractional_instanton_action_core_split_2026_06_18.py",
-      "transitive_descendants": 1
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "gauge_center_sector_record_context_and_theta_q_character_grading_obstruction_bounded_theorem_note_2026-07-01",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "leaf",
-      "criticality_rank": 0,
-      "cross_confirmation_status": null,
-      "deps": [
-        "gauge_vacuum_plaquette_transfer_operator_character_recurrence_note",
-        "minimal_axioms",
-        "strong_cp_rp_half_cannot_forbid_cp_odd_imaginary_no_go_note_2026-05-16"
-      ],
-      "direct_in_degree": 1,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 1.5,
-      "note_path": "docs/GAUGE_CENTER_SECTOR_RECORD_CONTEXT_AND_THETA_Q_CHARACTER_GRADING_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-07-01.md",
-      "queue_reason": "unaudited",
-      "ready": true,
-      "runner_path": "scripts/gauge_center_sector_record_context_character_grading_obstruction_2026_07_01.py",
-      "transitive_descendants": 1
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "gauge_multiplaquette_character_gluing_emergent_integer_sector_record_context_and_action_pairing_residual_bounded_theorem_note_2026-07-02",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "leaf",
-      "criticality_rank": 0,
-      "cross_confirmation_status": null,
-      "deps": [
-        "minimal_axioms",
-        "gauge_vacuum_plaquette_transfer_operator_character_recurrence_note"
-      ],
-      "direct_in_degree": 1,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 1.5,
-      "note_path": "docs/GAUGE_MULTIPLAQUETTE_CHARACTER_GLUING_EMERGENT_INTEGER_SECTOR_RECORD_CONTEXT_AND_ACTION_PAIRING_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md",
-      "queue_reason": "unaudited",
-      "ready": true,
-      "runner_path": "scripts/gauge_multiplaquette_character_gluing_emergent_integer_sector_2026_07_02.py",
       "transitive_descendants": 1
     },
     {
@@ -37315,6 +37343,56 @@
       "queue_reason": "unaudited",
       "ready": true,
       "runner_path": "scripts/single_clock_axis_datum_s4_transportable_check_2026_06_17.py",
+      "transitive_descendants": 1
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "theta_link_star_gluing_frame_correlation_pair_composite_dagger_evenness_and_odd_branch_phase_residual_bounded_theorem_note_2026-07-02",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "leaf",
+      "criticality_rank": 0,
+      "cross_confirmation_status": null,
+      "deps": [
+        "minimal_axioms",
+        "strong_cp_rp_half_cannot_forbid_cp_odd_imaginary_no_go_note_2026-05-16"
+      ],
+      "direct_in_degree": 1,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 1.5,
+      "note_path": "docs/THETA_LINK_STAR_GLUING_FRAME_CORRELATION_PAIR_COMPOSITE_DAGGER_EVENNESS_AND_ODD_BRANCH_PHASE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md",
+      "queue_reason": "unaudited",
+      "ready": true,
+      "runner_path": "scripts/theta_link_star_frame_correlation_gluing_2026_07_02.py",
+      "transitive_descendants": 1
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "theta_mass_orientation_zero_branch_pairing_forced_on_k_real_surface_narrow_theorem_note_2026-07-01",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "leaf",
+      "criticality_rank": 0,
+      "cross_confirmation_status": null,
+      "deps": [
+        "staggered_only_det_positivity_case_a_note_2026-05-17",
+        "brannen_circulant_is_forced_c3_covariant_record_preserving_generation_form_bounded_theorem_note_2026-06-15"
+      ],
+      "direct_in_degree": 1,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 1.5,
+      "note_path": "docs/THETA_MASS_ORIENTATION_ZERO_BRANCH_PAIRING_FORCED_ON_K_REAL_SURFACE_NARROW_THEOREM_NOTE_2026-07-01.md",
+      "queue_reason": "unaudited",
+      "ready": true,
+      "runner_path": "scripts/theta_mass_orientation_zero_branch_pairing_forced_2026_07_01.py",
       "transitive_descendants": 1
     },
     {
@@ -37809,7 +37887,7 @@
       "claim_id": "post_record_character_path_channel_weight_prototype_2026-06-06",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -38025,10 +38103,58 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
+      "claim_id": "reading_note_claims_are_axiom_text_theorems_bounded_note_2026-07-02",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "leaf",
+      "criticality_rank": 0,
+      "cross_confirmation_status": null,
+      "deps": [
+        "minimal_axioms"
+      ],
+      "direct_in_degree": 0,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 0.0,
+      "note_path": "docs/READING_NOTE_CLAIMS_ARE_AXIOM_TEXT_THEOREMS_BOUNDED_NOTE_2026-07-02.md",
+      "queue_reason": "unaudited",
+      "ready": true,
+      "runner_path": "scripts/frontier_reading_note_derivations_2026_07_02.py",
+      "transitive_descendants": 0
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "reading_note_final_derivations_motion_closure_bounded_note_2026-07-02",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "leaf",
+      "criticality_rank": 0,
+      "cross_confirmation_status": null,
+      "deps": [
+        "minimal_axioms"
+      ],
+      "direct_in_degree": 0,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 0.0,
+      "note_path": "docs/READING_NOTE_FINAL_DERIVATIONS_MOTION_CLOSURE_BOUNDED_NOTE_2026-07-02.md",
+      "queue_reason": "unaudited",
+      "ready": true,
+      "runner_path": "scripts/frontier_answer_condition_motion_closure_2026_07_02.py",
+      "transitive_descendants": 0
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
       "claim_id": "record_axiom_audit_application_map_2026-06-06",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "needs_reaudit_after_invalidation",
+      "claim_type_provenance": "migration_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -38295,56 +38421,6 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
-      "claim_id": "theta_link_star_gluing_frame_correlation_pair_composite_dagger_evenness_and_odd_branch_phase_residual_bounded_theorem_note_2026-07-02",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "leaf",
-      "criticality_rank": 0,
-      "cross_confirmation_status": null,
-      "deps": [
-        "minimal_axioms",
-        "strong_cp_rp_half_cannot_forbid_cp_odd_imaginary_no_go_note_2026-05-16"
-      ],
-      "direct_in_degree": 0,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 0.0,
-      "note_path": "docs/THETA_LINK_STAR_GLUING_FRAME_CORRELATION_PAIR_COMPOSITE_DAGGER_EVENNESS_AND_ODD_BRANCH_PHASE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md",
-      "queue_reason": "unaudited",
-      "ready": true,
-      "runner_path": "scripts/theta_link_star_frame_correlation_gluing_2026_07_02.py",
-      "transitive_descendants": 0
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
-      "claim_id": "theta_mass_orientation_zero_branch_pairing_forced_on_k_real_surface_narrow_theorem_note_2026-07-01",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "leaf",
-      "criticality_rank": 0,
-      "cross_confirmation_status": null,
-      "deps": [
-        "staggered_only_det_positivity_case_a_note_2026-05-17",
-        "brannen_circulant_is_forced_c3_covariant_record_preserving_generation_form_bounded_theorem_note_2026-06-15"
-      ],
-      "direct_in_degree": 0,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 0.0,
-      "note_path": "docs/THETA_MASS_ORIENTATION_ZERO_BRANCH_PAIRING_FORCED_ON_K_REAL_SURFACE_NARROW_THEOREM_NOTE_2026-07-01.md",
-      "queue_reason": "unaudited",
-      "ready": true,
-      "runner_path": "scripts/theta_mass_orientation_zero_branch_pairing_forced_2026_07_01.py",
-      "transitive_descendants": 0
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
       "claim_id": "theta_supplier_flavored_grading_spectral_flow_registers_winding_2d_narrow_theorem_note_2026-07-02",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
@@ -38400,7 +38476,7 @@
       "claim_id": "three_family_card_missing_distance_live_bridge_note_2026-06-18",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -40118,7 +40194,7 @@
       "claim_id": "cl3_chiral_cube_wilson_hop_doubling_foreclosed_narrow_no_go_note_2026-05-27",
       "claim_scope": null,
       "claim_type": "no_go",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -41430,7 +41506,7 @@
       "claim_id": "interacting_rp_full_algebra_fixed_a_gauge_invariant_four_fermion_bounded_note_2026-06-05",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -42868,7 +42944,7 @@
       "claim_id": "su3_casimir_fundamental_algebraic_k1_k3_narrow_proof_walk_bounded_note_2026-05-10",
       "claim_scope": null,
       "claim_type": "positive_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -42943,6 +43019,34 @@
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/theta13_is_c3_doublet_breaking_sqrt2_charged_lepton_runner.py",
+      "transitive_descendants": 1
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "theta_4d_carrier_flux_cohomology_intersection_pairing_closed_branch_and_defect_closure_residual_bounded_theorem_note_2026-07-02",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "leaf",
+      "criticality_rank": 0,
+      "cross_confirmation_status": null,
+      "deps": [
+        "gauge_center_sector_record_context_and_theta_q_character_grading_obstruction_bounded_theorem_note_2026-07-01",
+        "gauge_multiplaquette_character_gluing_emergent_integer_sector_record_context_and_action_pairing_residual_bounded_theorem_note_2026-07-02",
+        "minimal_axioms",
+        "strong_cp_rp_half_cannot_forbid_cp_odd_imaginary_no_go_note_2026-05-16",
+        "theta_gauge_substrate_no_winding_carrier_emergent_q_bridge_bounded_theorem_note_2026-06-11"
+      ],
+      "direct_in_degree": 1,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 1.5,
+      "note_path": "docs/THETA_4D_CARRIER_FLUX_COHOMOLOGY_INTERSECTION_PAIRING_CLOSED_BRANCH_AND_DEFECT_CLOSURE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/theta_4d_carrier_flux_cohomology_intersection_pairing_2026_07_02.py",
       "transitive_descendants": 1
     },
     {
@@ -45460,7 +45564,7 @@
       "claim_id": "ew_current_matching_ozi_suppression_theorem_note_2026-04-27",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -45913,7 +46017,7 @@
       "claim_id": "fractional_instanton_dilute_gas_condensate_external_narrow_theorem_note_2026-05-16",
       "claim_scope": null,
       "claim_type": "open_gate",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -55165,7 +55269,7 @@
       "claim_id": "rp_gauge_half_wilson_temporal_bridge_narrow_theorem_note_2026-06-06",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -55195,7 +55299,7 @@
       "claim_id": "rp_two_step_transfer_matrix_singular_mode_c2_tightening_note_2026-06-02",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -55219,7 +55323,7 @@
       "claim_id": "rp_wilson_temporal_gauge_bridge_sign_and_positivity_repair_note_2026-06-06",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -56939,34 +57043,6 @@
       "audit_independence_required": "any_non_self",
       "audit_status": "unaudited",
       "blocker": null,
-      "claim_id": "theta_4d_carrier_flux_cohomology_intersection_pairing_closed_branch_and_defect_closure_residual_bounded_theorem_note_2026-07-02",
-      "claim_scope": null,
-      "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint",
-      "criticality": "leaf",
-      "criticality_rank": 0,
-      "cross_confirmation_status": null,
-      "deps": [
-        "gauge_center_sector_record_context_and_theta_q_character_grading_obstruction_bounded_theorem_note_2026-07-01",
-        "gauge_multiplaquette_character_gluing_emergent_integer_sector_record_context_and_action_pairing_residual_bounded_theorem_note_2026-07-02",
-        "minimal_axioms",
-        "strong_cp_rp_half_cannot_forbid_cp_odd_imaginary_no_go_note_2026-05-16",
-        "theta_gauge_substrate_no_winding_carrier_emergent_q_bridge_bounded_theorem_note_2026-06-11"
-      ],
-      "direct_in_degree": 0,
-      "effective_status": "unaudited",
-      "helper_runner_paths": [],
-      "load_bearing_score": 0.0,
-      "note_path": "docs/THETA_4D_CARRIER_FLUX_COHOMOLOGY_INTERSECTION_PAIRING_CLOSED_BRANCH_AND_DEFECT_CLOSURE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md",
-      "queue_reason": "unaudited",
-      "ready": false,
-      "runner_path": "scripts/theta_4d_carrier_flux_cohomology_intersection_pairing_2026_07_02.py",
-      "transitive_descendants": 0
-    },
-    {
-      "audit_independence_required": "any_non_self",
-      "audit_status": "unaudited",
-      "blocker": null,
       "claim_id": "theta_emergent_q_weighting_reality_rg_stable_bounded_theorem_note_2026-06-13",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
@@ -56990,6 +57066,34 @@
       "queue_reason": "unaudited",
       "ready": false,
       "runner_path": "scripts/frontier_theta_emergent_q_cp_rg_stability_2026_06_13.py",
+      "transitive_descendants": 0
+    },
+    {
+      "audit_independence_required": "any_non_self",
+      "audit_status": "unaudited",
+      "blocker": null,
+      "claim_id": "theta_gauge_z2_character_collapse_odd_support_and_positive_class_zero_branch_selection_bounded_theorem_note_2026-07-03",
+      "claim_scope": null,
+      "claim_type": "bounded_theorem",
+      "claim_type_provenance": "author_hint",
+      "criticality": "leaf",
+      "criticality_rank": 0,
+      "cross_confirmation_status": null,
+      "deps": [
+        "theta_mass_orientation_zero_branch_pairing_forced_on_k_real_surface_narrow_theorem_note_2026-07-01",
+        "theta_4d_carrier_flux_cohomology_intersection_pairing_closed_branch_and_defect_closure_residual_bounded_theorem_note_2026-07-02",
+        "gauge_multiplaquette_character_gluing_emergent_integer_sector_record_context_and_action_pairing_residual_bounded_theorem_note_2026-07-02",
+        "theta_link_star_gluing_frame_correlation_pair_composite_dagger_evenness_and_odd_branch_phase_residual_bounded_theorem_note_2026-07-02",
+        "minimal_axioms"
+      ],
+      "direct_in_degree": 0,
+      "effective_status": "unaudited",
+      "helper_runner_paths": [],
+      "load_bearing_score": 0.0,
+      "note_path": "docs/THETA_GAUGE_Z2_CHARACTER_COLLAPSE_ODD_SUPPORT_AND_POSITIVE_CLASS_ZERO_BRANCH_SELECTION_BOUNDED_THEOREM_NOTE_2026-07-03.md",
+      "queue_reason": "unaudited",
+      "ready": false,
+      "runner_path": "scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py",
       "transitive_descendants": 0
     },
     {
@@ -57828,7 +57932,7 @@
       "claim_id": "yt_ew_sin_sq_theta_w_preservation_bounded_note_2026-05-25",
       "claim_scope": null,
       "claim_type": "bounded_theorem",
-      "claim_type_provenance": "author_hint_after_invalidation",
+      "claim_type_provenance": "author_hint",
       "criticality": "leaf",
       "criticality_rank": 0,
       "cross_confirmation_status": null,
@@ -58302,6 +58406,6 @@
       "transitive_descendants": 0
     }
   ],
-  "ready_count": 139,
-  "total_pending": 1976
+  "ready_count": 142,
+  "total_pending": 1980
 }

--- a/docs/audit/data/auditor_reliability.json
+++ b/docs/audit/data/auditor_reliability.json
@@ -67,7 +67,7 @@
       "audits_with_runner_class": {
         "A": 626,
         "B": 23,
-        "C": 446,
+        "C": 445,
         "D": 7,
         "E": 14,
         "F": 6,
@@ -79,8 +79,8 @@
         "same_severity": 32
       },
       "criticality_counts": {
-        "critical": 207,
-        "high": 134,
+        "critical": 214,
+        "high": 126,
         "leaf": 462,
         "medium": 329
       },
@@ -100,10 +100,10 @@
       "third_pass_decisions_n": 110,
       "third_pass_overturn_rate": 0.5,
       "third_pass_overturn_rate_caveat": "Selection-biased: third auditor only runs on disputed cases. Expected value for a competent auditor is ~0.5. See script docstring.",
-      "total_audits": 1132,
-      "verdict_changed_after_re_audit": 919,
+      "total_audits": 1131,
+      "verdict_changed_after_re_audit": 918,
       "verdict_counts": {
-        "audited_clean": 1033,
+        "audited_clean": 1032,
         "audited_conditional": 25,
         "audited_decoration": 44,
         "audited_failed": 1,
@@ -134,7 +134,7 @@
   "totals": {
     "auditor_families_observed": 3,
     "overall_agreement_rate": 0.814,
-    "total_audits_recorded": 1346,
+    "total_audits_recorded": 1345,
     "total_cross_confirmation_family_participations": 387,
     "total_cross_confirmation_pairs": 344,
     "total_third_pass_decisions": 122

--- a/docs/audit/data/citation_graph.json
+++ b/docs/audit/data/citation_graph.json
@@ -35977,6 +35977,18 @@
       "to": "flavor_r_half_stable_under_thermalizing_arrow_2026-06-02"
     },
     {
+      "from": "reading_note_claims_are_axiom_text_theorems_bounded_note_2026-07-02",
+      "to": "minimal_axioms"
+    },
+    {
+      "from": "reading_note_final_derivations_motion_closure_bounded_note_2026-07-02",
+      "to": "minimal_axioms"
+    },
+    {
+      "from": "reading_note_final_derivations_motion_closure_bounded_note_2026-07-02",
+      "to": "ai_methodology.skills.audit-loop.skill"
+    },
+    {
       "from": "realization_row_sigma_reconciliation_bounded_theorem_note_2026-06-11",
       "to": "staggered_kernel_satisfies_z_point_cone_certificate_narrow_theorem_note_2026-06-11"
     },
@@ -41531,6 +41543,26 @@
     {
       "from": "theta_gauge_substrate_no_winding_carrier_emergent_q_bridge_bounded_theorem_note_2026-06-11",
       "to": "kinetic_isotropy_primitive"
+    },
+    {
+      "from": "theta_gauge_z2_character_collapse_odd_support_and_positive_class_zero_branch_selection_bounded_theorem_note_2026-07-03",
+      "to": "theta_mass_orientation_zero_branch_pairing_forced_on_k_real_surface_narrow_theorem_note_2026-07-01"
+    },
+    {
+      "from": "theta_gauge_z2_character_collapse_odd_support_and_positive_class_zero_branch_selection_bounded_theorem_note_2026-07-03",
+      "to": "theta_4d_carrier_flux_cohomology_intersection_pairing_closed_branch_and_defect_closure_residual_bounded_theorem_note_2026-07-02"
+    },
+    {
+      "from": "theta_gauge_z2_character_collapse_odd_support_and_positive_class_zero_branch_selection_bounded_theorem_note_2026-07-03",
+      "to": "gauge_multiplaquette_character_gluing_emergent_integer_sector_record_context_and_action_pairing_residual_bounded_theorem_note_2026-07-02"
+    },
+    {
+      "from": "theta_gauge_z2_character_collapse_odd_support_and_positive_class_zero_branch_selection_bounded_theorem_note_2026-07-03",
+      "to": "theta_link_star_gluing_frame_correlation_pair_composite_dagger_evenness_and_odd_branch_phase_residual_bounded_theorem_note_2026-07-02"
+    },
+    {
+      "from": "theta_gauge_z2_character_collapse_odd_support_and_positive_class_zero_branch_selection_bounded_theorem_note_2026-07-03",
+      "to": "minimal_axioms"
     },
     {
       "from": "theta_link_star_gluing_frame_correlation_pair_composite_dagger_evenness_and_odd_branch_phase_residual_bounded_theorem_note_2026-07-02",
@@ -56698,11 +56730,23 @@
     },
     {
       "from": "repo.front_door_status",
-      "to": "staggered_dirac_kinetic_class_forcing_narrow_theorem_note_2026-06-10"
+      "to": "no_per_site_chirality_theorem_note_2026-05-02"
+    },
+    {
+      "from": "repo.front_door_status",
+      "to": "tensor_product_translation_fermion_operator_bridge_narrow_theorem_note_2026-05-25"
+    },
+    {
+      "from": "repo.front_door_status",
+      "to": "real_diagonal_source_det_positivity_and_log_readout_lemma_note_2026-06-08"
     },
     {
       "from": "repo.front_door_status",
       "to": "staggered_dirac_substep1_grassmann_forcing_bridge_narrow_theorem_note_2026-05-16"
+    },
+    {
+      "from": "repo.front_door_status",
+      "to": "ew_current_matching_rule_open_gate_note_2026-05-03"
     },
     {
       "from": "repo.front_door_status",
@@ -56715,18 +56759,6 @@
     {
       "from": "repo.front_door_status",
       "to": "staggered_dirac_substep1_u4_conditional_single_module_narrow_bounded_note_2026-05-17"
-    },
-    {
-      "from": "repo.front_door_status",
-      "to": "axiom_first_fermionic_stefan_boltzmann_narrow_theorem_note_2026-05-26"
-    },
-    {
-      "from": "repo.front_door_status",
-      "to": "staggered_kernel_satisfies_z_point_cone_certificate_narrow_theorem_note_2026-06-11"
-    },
-    {
-      "from": "repo.front_door_status",
-      "to": "hopping_bilinear_hermiticity_theorem_note_2026-05-02"
     },
     {
       "from": "repo.repo_organization",
@@ -59267,7 +59299,7 @@
         "ai_methodology.skills.no-go-discipline.skill"
       ],
       "helper_runner_paths": [],
-      "note_hash": "bb08be69a2b5b64653057b2e9e045551435d4aedc4a94734ac4e86b81a4e4446",
+      "note_hash": "97d4b68275f649c82b5ddd08e0000fd4d0b8ad2e6c623a4a2008b7bb95fa92c7",
       "path": "docs/ai_methodology/skills/audit-loop/SKILL.md",
       "runner_path": "scripts/vocab_lint.py",
       "title": "Audit Loop"
@@ -59410,7 +59442,7 @@
         "ai_methodology.skills.physics-loop.references.long-running-execution"
       ],
       "helper_runner_paths": [],
-      "note_hash": "91dee267473a93a643a143c3c0867fec59525a25bee68b75c34e4012b5829b3a",
+      "note_hash": "6d0952390241e8e2c077ede3c809d7df3315fbc568bdc8c4ce22b90044cbf869",
       "path": "docs/ai_methodology/skills/physics-loop/SKILL.md",
       "runner_path": null,
       "title": "Physics Loop"
@@ -59437,7 +59469,7 @@
         "ai_methodology.skills.no-go-discipline.skill"
       ],
       "helper_runner_paths": [],
-      "note_hash": "9446729a42d5b7e808575e860aaf428bb34063a2a485c521a0537e733be69395",
+      "note_hash": "b98cb858e9c15f1a0499feee0fbe1ee82abe70910de587d2c8c0d8e56144b09c",
       "path": "docs/ai_methodology/skills/review-loop/SKILL.md",
       "runner_path": "scripts/vocab_lint.py",
       "title": "Review Loop"
@@ -93817,7 +93849,7 @@
       "claim_type_seed_hint": "meta",
       "deps": [],
       "helper_runner_paths": [],
-      "note_hash": "70324c45f8473c77118d68879e12618ff8366ecf9d4843ce91094a61dca6bc8a",
+      "note_hash": "7b581f9f475c7bf16a02e664ef48a271d20d0404d8b2b1f7e58bc41ab3d50a24",
       "path": "docs/MINIMAL_AXIOMS_2026-06-29.md",
       "runner_path": "scripts/audit_companion_minimal_axioms_clean_base_exact.py",
       "title": "Minimal Framework Axioms (Lattice, Qubit, Admissibility, Record)"
@@ -107933,6 +107965,35 @@
       "runner_path": "scripts/frontier_rd_fixedness_arrow_invariant_2026_06_12.py",
       "title": "R-D Fixedness Is Arrow-Invariant on the Retained Flow Family"
     },
+    "reading_note_claims_are_axiom_text_theorems_bounded_note_2026-07-02": {
+      "claim_id": "reading_note_claims_are_axiom_text_theorems_bounded_note_2026-07-02",
+      "claim_type_author_hint": "bounded_theorem",
+      "claim_type_author_hint_raw": "bounded_theorem",
+      "claim_type_seed_hint": "bounded_theorem",
+      "deps": [
+        "minimal_axioms"
+      ],
+      "helper_runner_paths": [],
+      "note_hash": "52b318d976d0f1e11eabce7f3e877c8509991627eaca579fafced71344c733e3",
+      "path": "docs/READING_NOTE_CLAIMS_ARE_AXIOM_TEXT_THEOREMS_BOUNDED_NOTE_2026-07-02.md",
+      "runner_path": "scripts/frontier_reading_note_derivations_2026_07_02.py",
+      "title": "Four Policy Reading-Note Claims Are Axiom-Text Theorems"
+    },
+    "reading_note_final_derivations_motion_closure_bounded_note_2026-07-02": {
+      "claim_id": "reading_note_final_derivations_motion_closure_bounded_note_2026-07-02",
+      "claim_type_author_hint": "bounded_theorem",
+      "claim_type_author_hint_raw": "bounded_theorem",
+      "claim_type_seed_hint": "bounded_theorem",
+      "deps": [
+        "minimal_axioms",
+        "ai_methodology.skills.audit-loop.skill"
+      ],
+      "helper_runner_paths": [],
+      "note_hash": "4eb37d1611184201b45c98d7576f34bfcdbf169274bb87cd000cdd69c3d1d266",
+      "path": "docs/READING_NOTE_FINAL_DERIVATIONS_MOTION_CLOSURE_BOUNDED_NOTE_2026-07-02.md",
+      "runner_path": "scripts/frontier_answer_condition_motion_closure_2026_07_02.py",
+      "title": "Final Reading-Note Derivations: Answer, Condition, Motion Closure, And Extensional Judgment"
+    },
     "real_diagonal_source_det_positivity_and_log_readout_lemma_note_2026-06-08": {
       "claim_id": "real_diagonal_source_det_positivity_and_log_readout_lemma_note_2026-06-08",
       "claim_type_author_hint": "bounded_theorem",
@@ -109232,7 +109293,7 @@
         "ai_methodology.ai_accountability_and_disclosure_note_2026-04-25"
       ],
       "helper_runner_paths": [],
-      "note_hash": "5bea212c62053a6c3e1edd5ae106d4a9764b7f1b7d3c4d8a03b4ea7257f81d07",
+      "note_hash": "70cce2d832dc0760771fa8406c340de004f3da08a371f8c75bc4c2ad8da4ef1b",
       "path": "docs/repo/CONTROLLED_VOCABULARY.md",
       "runner_path": null,
       "title": "Controlled Vocabulary"
@@ -109243,17 +109304,17 @@
       "claim_type_author_hint_raw": null,
       "claim_type_seed_hint": null,
       "deps": [
-        "staggered_dirac_kinetic_class_forcing_narrow_theorem_note_2026-06-10",
+        "no_per_site_chirality_theorem_note_2026-05-02",
+        "tensor_product_translation_fermion_operator_bridge_narrow_theorem_note_2026-05-25",
+        "real_diagonal_source_det_positivity_and_log_readout_lemma_note_2026-06-08",
         "staggered_dirac_substep1_grassmann_forcing_bridge_narrow_theorem_note_2026-05-16",
+        "ew_current_matching_rule_open_gate_note_2026-05-03",
         "cl3_taste_generation_theorem",
         "g_bare_parent_finite_link_wilson_beta6_bridge_note_2026-06-18",
-        "staggered_dirac_substep1_u4_conditional_single_module_narrow_bounded_note_2026-05-17",
-        "axiom_first_fermionic_stefan_boltzmann_narrow_theorem_note_2026-05-26",
-        "staggered_kernel_satisfies_z_point_cone_certificate_narrow_theorem_note_2026-06-11",
-        "hopping_bilinear_hermiticity_theorem_note_2026-05-02"
+        "staggered_dirac_substep1_u4_conditional_single_module_narrow_bounded_note_2026-05-17"
       ],
       "helper_runner_paths": [],
-      "note_hash": "761cc51e0463bfc9c5559ef45c040bb47287f1b18f5bec4ffe443461eb0913cc",
+      "note_hash": "66b7edf8996c4c086fefe4f1556455eb5ca816d66b7a486fe926da04cd10dab5",
       "path": "docs/repo/FRONT_DOOR_STATUS.md",
       "runner_path": null,
       "title": "Front Door Status Snapshot"
@@ -117113,6 +117174,24 @@
       "path": "docs/THETA_GAUGE_SUBSTRATE_NO_WINDING_CARRIER_EMERGENT_Q_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-11.md",
       "runner_path": "scripts/frontier_theta_gauge_substrate_winding_vacuity_2026_06_11.py",
       "title": "\u03b8_gauge Has No Carrier on the Substrate: the Lattice Gauge Group Is Connected and the Supplied Action Class Has No Topological Density \u2014 the Gauge-Side Admission Relocates to the Named Emergent-Q Bridge (Bounded Theorem)"
+    },
+    "theta_gauge_z2_character_collapse_odd_support_and_positive_class_zero_branch_selection_bounded_theorem_note_2026-07-03": {
+      "claim_id": "theta_gauge_z2_character_collapse_odd_support_and_positive_class_zero_branch_selection_bounded_theorem_note_2026-07-03",
+      "claim_type_author_hint": "bounded_theorem",
+      "claim_type_author_hint_raw": "bounded_theorem (exact character-collapse and class-selection",
+      "claim_type_seed_hint": "bounded_theorem",
+      "deps": [
+        "theta_mass_orientation_zero_branch_pairing_forced_on_k_real_surface_narrow_theorem_note_2026-07-01",
+        "theta_4d_carrier_flux_cohomology_intersection_pairing_closed_branch_and_defect_closure_residual_bounded_theorem_note_2026-07-02",
+        "gauge_multiplaquette_character_gluing_emergent_integer_sector_record_context_and_action_pairing_residual_bounded_theorem_note_2026-07-02",
+        "theta_link_star_gluing_frame_correlation_pair_composite_dagger_evenness_and_odd_branch_phase_residual_bounded_theorem_note_2026-07-02",
+        "minimal_axioms"
+      ],
+      "helper_runner_paths": [],
+      "note_hash": "446c1c752665c950bfa3f78d2dc735d8d547f07e83dc615c302865228db2fb00",
+      "path": "docs/THETA_GAUGE_Z2_CHARACTER_COLLAPSE_ODD_SUPPORT_AND_POSITIVE_CLASS_ZERO_BRANCH_SELECTION_BOUNDED_THEOREM_NOTE_2026-07-03.md",
+      "runner_path": "scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py",
+      "title": "The Gauge-Side Theta Dial Collapses to {0, pi} for Orientation-Even Character Weights on the Odd-Support Sector Lattice, and the Derived Positive Conjugation-Paired Weight Class Selects the Zero Branch \u2014 the Gauge Twin of the Mass-Side Pairing-Forced Zero Branch (Bounded Theorem)"
     },
     "theta_link_star_gluing_frame_correlation_pair_composite_dagger_evenness_and_odd_branch_phase_residual_bounded_theorem_note_2026-07-02": {
       "claim_id": "theta_link_star_gluing_frame_correlation_pair_composite_dagger_evenness_and_odd_branch_phase_residual_bounded_theorem_note_2026-07-02",
@@ -125242,7 +125321,7 @@
   "schema_version": 1,
   "stats": {
     "claim_type_author_hint_counts": {
-      "bounded_theorem": 1486,
+      "bounded_theorem": 1489,
       "decoration": 3,
       "meta": 293,
       "no_go": 283,
@@ -125251,7 +125330,7 @@
       "positive_theorem": 195
     },
     "claim_type_seed_hint_counts": {
-      "bounded_theorem": 1891,
+      "bounded_theorem": 1894,
       "decoration": 3,
       "meta": 293,
       "no_go": 387,
@@ -125259,10 +125338,10 @@
       "open_gate": 193,
       "positive_theorem": 580
     },
-    "edge_count": 14281,
+    "edge_count": 14289,
     "leaf_count": 1281,
-    "node_count": 3805,
+    "node_count": 3808,
     "root_count": 1098,
-    "runners_with_path": 3433
+    "runners_with_path": 3436
   }
 }

--- a/docs/audit/data/cycle_inventory.json
+++ b/docs/audit/data/cycle_inventory.json
@@ -19,7 +19,7 @@
         }
       ],
       "length": 3,
-      "max_transitive_descendants": 1000,
+      "max_transitive_descendants": 1001,
       "nodes": [
         {
           "audit_status": "unaudited",
@@ -28,7 +28,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md",
           "title": "Axiom-First Single-Clock Codimension-1 Unitary Evolution on the One-Qubit Cl(3) Pauli Factor over Z^3",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -37,7 +37,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/SINGLE_CLOCK_APBC_AXIS_LABEL_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-16.md",
           "title": "Single-Clock APBC Axis-Label Bridge",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -46,7 +46,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/SINGLE_CLOCK_AXIS_SELECTION_FROM_RECORD_DURABILITY_NARROW_NO_GO_NOTE_2026-06-11.md",
           "title": "Single-Clock Axis Selection From Record Durability: Every Retained Candidate Structure Is W-Transportable \u2014 Narrow No-Go With a Sharpened Pin",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         }
       ],
       "requires_lemma_extraction": false
@@ -197,7 +197,7 @@
         }
       ],
       "length": 35,
-      "max_transitive_descendants": 1000,
+      "max_transitive_descendants": 1001,
       "nodes": [
         {
           "audit_status": "unaudited",
@@ -206,7 +206,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md",
           "title": "Axiom-First Single-Clock Codimension-1 Unitary Evolution on the One-Qubit Cl(3) Pauli Factor over Z^3",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -215,7 +215,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/SINGLE_CLOCK_APBC_AXIS_LABEL_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-16.md",
           "title": "Single-Clock APBC Axis-Label Bridge",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -224,7 +224,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/SINGLE_CLOCK_AXIS_SELECTION_FROM_RECORD_DURABILITY_NARROW_NO_GO_NOTE_2026-06-11.md",
           "title": "Single-Clock Axis Selection From Record Durability: Every Retained Candidate Structure Is W-Transportable \u2014 Narrow No-Go With a Sharpened Pin",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -233,7 +233,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_CAP_K_FROM_FINITE_SPEED_REGISTRATION_NARROW_THEOREM_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 CAP-K From Finite-Speed Registration",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -242,7 +242,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_BR_LICENSE_FROM_RECORD_CAPACITY_NARROW_NO_GO_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 BR Record-Capacity Narrow No-Go",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -251,7 +251,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_NU_LICENSE_FROM_RETAINED_SURFACE_NARROW_NO_GO_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 NU License Narrowing No-Go",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -260,7 +260,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_EXPONENT_BARRIER_PARAMETER_SELECTOR_NARROW_THEOREM_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 Exponent \u2014 Barrier-Parameter Selector Narrow Theorem (+ Irreducible-Class Extension)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -269,7 +269,7 @@
           "effective_status": "meta",
           "note_path": "docs/RECORD_OUTCOME_OBSERVABLE_PRINCIPLE_CANONICAL_PROPOSAL_NOTE_2026-06-05.md",
           "title": "The Record-Outcome Observable Principle \u2014 Canonical Methodology (Proposal)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -278,7 +278,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_TM2_TRIMAXIMAL_COLUMN_FROM_RECORD_CENTRAL_SECTOR_NARROW_THEOREM_NOTE_2026-06-05.md",
           "title": "PMNS TM2 Trimaximal Column = the Recorded C3-Singlet Central Sector \u2014 Narrow Bridge Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -287,7 +287,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_TM2_MAGIC_RESIDUAL_DYNAMICAL_GENERATOR_NARROW_THEOREM_NOTE_2026-06-05.md",
           "title": "PMNS TM2 Magic Residual is a Native Dynamical Unitary \u2014 Narrow Bridge Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -296,7 +296,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_FROM_DM_NEUTRINO_SOURCE_H_DIAGONALIZATION_CLOSURE_THEOREM_NOTE_2026-04-17.md",
           "title": "PMNS as `f(H(m, delta, q_+))` \u2014 Bounded P3 Package",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -305,7 +305,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_P3_SYLVESTER_LINEAR_PATH_SIGNATURE_THEOREM_NOTE_2026-04-18.md",
           "title": "P3 Sylvester Linear-Path Signature Theorem on the DM Neutrino Source Surface",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -314,7 +314,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_ACTIVE_AFFINE_POINT_SELECTION_BOUNDARY_NOTE_2026-04-16.md",
           "title": "DM Neutrino Source-Surface Active Affine Point-Selection Boundary",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -323,7 +323,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_ACTIVE_HALF_PLANE_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Neutrino Source-Surface Active Half-Plane Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -332,7 +332,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_SHIFT_QUOTIENT_BUNDLE_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Neutrino Source-Surface Shift-Quotient Bundle Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -341,7 +341,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_EXACT_H_SOURCE_SURFACE_PREIMAGE_BUNDLE_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Neutrino Exact H-Side Source-Surface Preimage-Bundle Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -350,7 +350,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_LEPTOGENESIS_NE_PROJECTED_SOURCE_TRIPLET_SIGN_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Leptogenesis `N_e` Projected-Source Triplet Sign Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -359,7 +359,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_LEPTOGENESIS_NE_PROJECTED_SOURCE_LAW_DERIVATION_NOTE_2026-04-16.md",
           "title": "DM Leptogenesis `N_e` Projected-Source-Law Derivation",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -368,7 +368,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_LEPTOGENESIS_EXACT_KERNEL_CLOSURE_NOTE_2026-04-15.md",
           "title": "DM Leptogenesis Exact-Kernel Closure (claim narrowed 2026-05-01)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -377,7 +377,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_CODD_BOSONIC_NORMALIZATION_THEOREM_NOTE_2026-04-15.md",
           "title": "DM Neutrino `c_odd` Bosonic Normalization Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -386,7 +386,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_UNIQUE_AMPLITUDE_SLOT_NOTE.md",
           "title": "PMNS Selector Unique Amplitude Slot",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -395,7 +395,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_CLASS_SPACE_UNIQUENESS_NOTE.md",
           "title": "PMNS Selector Class-Space Uniqueness",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -404,7 +404,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_SECTOR_ODD_REDUCTION_NOTE.md",
           "title": "PMNS Selector Sector-Odd Reduction",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -413,7 +413,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SECTOR_EXCHANGE_NONFORCING_NOTE.md",
           "title": "PMNS Sector-Exchange Nonforcing",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -422,7 +422,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SECTOR_ORIENTATION_ORBIT_NOTE.md",
           "title": "PMNS Sector-Orientation Orbit Reduction",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -431,7 +431,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_BANK_NONREALIZATION_NOTE.md",
           "title": "PMNS Selector-Bank Nonrealization",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -440,7 +440,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/HIGGS_Z3_CHARGE_PMNS_GAUGE_REDUNDANCY_THEOREM_NOTE_2026-04-17.md",
           "title": "Higgs `Z_3` Charge Gauge-Redundancy Theorem for PMNS",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -449,7 +449,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/NEUTRINO_DIRAC_Z3_SUPPORT_TRICHOTOMY_NOTE.md",
           "title": "Neutrino Dirac `Z_3` Support Trichotomy",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -458,7 +458,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/NEUTRINO_MASS_REDUCTION_TO_DIRAC_NOTE.md",
           "title": "Neutrino Mass Reduction To The Dirac Lane",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -467,7 +467,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/HIGGS_VACUUM_EXPLICIT_SYSTEMATIC_NOTE.md",
           "title": "Higgs / Vacuum Authority",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -476,7 +476,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/HIGGS_MASS_DERIVED_NOTE.md",
           "title": "Higgs Mass: Canonical Authority Boundary",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -485,7 +485,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/YT_FLAGSHIP_BOUNDARY_NOTE.md",
           "title": "y_t Flagship Boundary Note",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -494,7 +494,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/YT_WARD_IDENTITY_DERIVATION_THEOREM.md",
           "title": "Staggered Vector Ward Identity on the Q_L Block: Lattice Noether Derivation, with the H_unit Matrix-Element Corollary y_t_bare = g_bare / sqrt(6)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -503,7 +503,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md",
           "title": "Staggered-Dirac Realization Gate Note \u2014 Bounded Synthesis Closure",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -512,7 +512,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/STAGGERED_DIRAC_GATE_CLOSURE_SYNTHESIS_THEOREM_NOTE_2026-05-17.md",
           "title": "Staggered-Dirac Realization Gate \u2014 Closure Synthesis (Block 01, 2026-05-17)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         }
       ],
       "requires_lemma_extraction": false
@@ -663,7 +663,7 @@
         }
       ],
       "length": 35,
-      "max_transitive_descendants": 1000,
+      "max_transitive_descendants": 1001,
       "nodes": [
         {
           "audit_status": "unaudited",
@@ -672,7 +672,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md",
           "title": "Axiom-First Single-Clock Codimension-1 Unitary Evolution on the One-Qubit Cl(3) Pauli Factor over Z^3",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -681,7 +681,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/SINGLE_CLOCK_APBC_AXIS_LABEL_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-16.md",
           "title": "Single-Clock APBC Axis-Label Bridge",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -690,7 +690,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/SINGLE_CLOCK_AXIS_SELECTION_FROM_RECORD_DURABILITY_NARROW_NO_GO_NOTE_2026-06-11.md",
           "title": "Single-Clock Axis Selection From Record Durability: Every Retained Candidate Structure Is W-Transportable \u2014 Narrow No-Go With a Sharpened Pin",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -699,7 +699,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_CAP_K_FROM_FINITE_SPEED_REGISTRATION_NARROW_THEOREM_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 CAP-K From Finite-Speed Registration",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -708,7 +708,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_BR_LICENSE_FROM_RECORD_CAPACITY_NARROW_NO_GO_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 BR Record-Capacity Narrow No-Go",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -717,7 +717,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_NU_LICENSE_FROM_RETAINED_SURFACE_NARROW_NO_GO_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 NU License Narrowing No-Go",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -726,7 +726,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_EXPONENT_BARRIER_PARAMETER_SELECTOR_NARROW_THEOREM_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 Exponent \u2014 Barrier-Parameter Selector Narrow Theorem (+ Irreducible-Class Extension)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -735,7 +735,7 @@
           "effective_status": "meta",
           "note_path": "docs/RECORD_OUTCOME_OBSERVABLE_PRINCIPLE_CANONICAL_PROPOSAL_NOTE_2026-06-05.md",
           "title": "The Record-Outcome Observable Principle \u2014 Canonical Methodology (Proposal)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -744,7 +744,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_TM2_TRIMAXIMAL_COLUMN_FROM_RECORD_CENTRAL_SECTOR_NARROW_THEOREM_NOTE_2026-06-05.md",
           "title": "PMNS TM2 Trimaximal Column = the Recorded C3-Singlet Central Sector \u2014 Narrow Bridge Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -753,7 +753,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_TM2_MAGIC_RESIDUAL_DYNAMICAL_GENERATOR_NARROW_THEOREM_NOTE_2026-06-05.md",
           "title": "PMNS TM2 Magic Residual is a Native Dynamical Unitary \u2014 Narrow Bridge Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -762,7 +762,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_FROM_DM_NEUTRINO_SOURCE_H_DIAGONALIZATION_CLOSURE_THEOREM_NOTE_2026-04-17.md",
           "title": "PMNS as `f(H(m, delta, q_+))` \u2014 Bounded P3 Package",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -771,7 +771,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_P3_SYLVESTER_LINEAR_PATH_SIGNATURE_THEOREM_NOTE_2026-04-18.md",
           "title": "P3 Sylvester Linear-Path Signature Theorem on the DM Neutrino Source Surface",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -780,7 +780,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_ACTIVE_AFFINE_POINT_SELECTION_BOUNDARY_NOTE_2026-04-16.md",
           "title": "DM Neutrino Source-Surface Active Affine Point-Selection Boundary",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -789,7 +789,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_ACTIVE_HALF_PLANE_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Neutrino Source-Surface Active Half-Plane Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -798,7 +798,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_SHIFT_QUOTIENT_BUNDLE_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Neutrino Source-Surface Shift-Quotient Bundle Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -807,7 +807,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_EXACT_H_SOURCE_SURFACE_PREIMAGE_BUNDLE_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Neutrino Exact H-Side Source-Surface Preimage-Bundle Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -816,7 +816,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_LEPTOGENESIS_NE_PROJECTED_SOURCE_TRIPLET_SIGN_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Leptogenesis `N_e` Projected-Source Triplet Sign Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -825,7 +825,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_LEPTOGENESIS_NE_PROJECTED_SOURCE_LAW_DERIVATION_NOTE_2026-04-16.md",
           "title": "DM Leptogenesis `N_e` Projected-Source-Law Derivation",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -834,7 +834,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_LEPTOGENESIS_EXACT_KERNEL_CLOSURE_NOTE_2026-04-15.md",
           "title": "DM Leptogenesis Exact-Kernel Closure (claim narrowed 2026-05-01)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -843,7 +843,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_CODD_BOSONIC_NORMALIZATION_THEOREM_NOTE_2026-04-15.md",
           "title": "DM Neutrino `c_odd` Bosonic Normalization Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -852,7 +852,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_UNIQUE_AMPLITUDE_SLOT_NOTE.md",
           "title": "PMNS Selector Unique Amplitude Slot",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -861,7 +861,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_CLASS_SPACE_UNIQUENESS_NOTE.md",
           "title": "PMNS Selector Class-Space Uniqueness",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -870,7 +870,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_SECTOR_ODD_REDUCTION_NOTE.md",
           "title": "PMNS Selector Sector-Odd Reduction",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -879,7 +879,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SECTOR_EXCHANGE_NONFORCING_NOTE.md",
           "title": "PMNS Sector-Exchange Nonforcing",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -888,7 +888,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SECTOR_ORIENTATION_ORBIT_NOTE.md",
           "title": "PMNS Sector-Orientation Orbit Reduction",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -897,7 +897,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_BANK_NONREALIZATION_NOTE.md",
           "title": "PMNS Selector-Bank Nonrealization",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -906,7 +906,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/HIGGS_Z3_CHARGE_PMNS_GAUGE_REDUNDANCY_THEOREM_NOTE_2026-04-17.md",
           "title": "Higgs `Z_3` Charge Gauge-Redundancy Theorem for PMNS",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -915,7 +915,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/NEUTRINO_DIRAC_Z3_SUPPORT_TRICHOTOMY_NOTE.md",
           "title": "Neutrino Dirac `Z_3` Support Trichotomy",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -924,7 +924,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/NEUTRINO_MASS_REDUCTION_TO_DIRAC_NOTE.md",
           "title": "Neutrino Mass Reduction To The Dirac Lane",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -933,7 +933,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/HIGGS_VACUUM_EXPLICIT_SYSTEMATIC_NOTE.md",
           "title": "Higgs / Vacuum Authority",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -942,7 +942,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/HIGGS_MASS_DERIVED_NOTE.md",
           "title": "Higgs Mass: Canonical Authority Boundary",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -951,7 +951,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/YT_FLAGSHIP_BOUNDARY_NOTE.md",
           "title": "y_t Flagship Boundary Note",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -960,7 +960,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/YT_WARD_IDENTITY_DERIVATION_THEOREM.md",
           "title": "Staggered Vector Ward Identity on the Q_L Block: Lattice Noether Derivation, with the H_unit Matrix-Element Corollary y_t_bare = g_bare / sqrt(6)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -969,7 +969,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md",
           "title": "Staggered-Dirac Realization Gate Note \u2014 Bounded Synthesis Closure",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -978,7 +978,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/STAGGERED_DIRAC_PHYSICAL_SPECIES_DIRECT_THEOREM_NOTE_2026-05-07.md",
           "title": "Staggered-Dirac Direct Three-State Algebraic Support",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         }
       ],
       "requires_lemma_extraction": false
@@ -1133,7 +1133,7 @@
         }
       ],
       "length": 36,
-      "max_transitive_descendants": 1000,
+      "max_transitive_descendants": 1001,
       "nodes": [
         {
           "audit_status": "unaudited",
@@ -1142,7 +1142,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/STAGGERED_DIRAC_SUBSTEP4_AC_NARROW_BOUNDED_NOTE_2026-05-07_substep4ac.md",
           "title": "Staggered-Dirac Substep 4 \u2014 AC Narrowing (Atomic Decomposition, Bounded)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1151,7 +1151,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md",
           "title": "Axiom-First Single-Clock Codimension-1 Unitary Evolution on the One-Qubit Cl(3) Pauli Factor over Z^3",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1160,7 +1160,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/SINGLE_CLOCK_APBC_AXIS_LABEL_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-16.md",
           "title": "Single-Clock APBC Axis-Label Bridge",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1169,7 +1169,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/SINGLE_CLOCK_AXIS_SELECTION_FROM_RECORD_DURABILITY_NARROW_NO_GO_NOTE_2026-06-11.md",
           "title": "Single-Clock Axis Selection From Record Durability: Every Retained Candidate Structure Is W-Transportable \u2014 Narrow No-Go With a Sharpened Pin",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1178,7 +1178,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_CAP_K_FROM_FINITE_SPEED_REGISTRATION_NARROW_THEOREM_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 CAP-K From Finite-Speed Registration",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1187,7 +1187,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_BR_LICENSE_FROM_RECORD_CAPACITY_NARROW_NO_GO_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 BR Record-Capacity Narrow No-Go",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1196,7 +1196,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_NU_LICENSE_FROM_RETAINED_SURFACE_NARROW_NO_GO_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 NU License Narrowing No-Go",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1205,7 +1205,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_EXPONENT_BARRIER_PARAMETER_SELECTOR_NARROW_THEOREM_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 Exponent \u2014 Barrier-Parameter Selector Narrow Theorem (+ Irreducible-Class Extension)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1214,7 +1214,7 @@
           "effective_status": "meta",
           "note_path": "docs/RECORD_OUTCOME_OBSERVABLE_PRINCIPLE_CANONICAL_PROPOSAL_NOTE_2026-06-05.md",
           "title": "The Record-Outcome Observable Principle \u2014 Canonical Methodology (Proposal)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1223,7 +1223,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_TM2_TRIMAXIMAL_COLUMN_FROM_RECORD_CENTRAL_SECTOR_NARROW_THEOREM_NOTE_2026-06-05.md",
           "title": "PMNS TM2 Trimaximal Column = the Recorded C3-Singlet Central Sector \u2014 Narrow Bridge Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1232,7 +1232,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_TM2_MAGIC_RESIDUAL_DYNAMICAL_GENERATOR_NARROW_THEOREM_NOTE_2026-06-05.md",
           "title": "PMNS TM2 Magic Residual is a Native Dynamical Unitary \u2014 Narrow Bridge Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1241,7 +1241,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_FROM_DM_NEUTRINO_SOURCE_H_DIAGONALIZATION_CLOSURE_THEOREM_NOTE_2026-04-17.md",
           "title": "PMNS as `f(H(m, delta, q_+))` \u2014 Bounded P3 Package",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1250,7 +1250,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_P3_SYLVESTER_LINEAR_PATH_SIGNATURE_THEOREM_NOTE_2026-04-18.md",
           "title": "P3 Sylvester Linear-Path Signature Theorem on the DM Neutrino Source Surface",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1259,7 +1259,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_ACTIVE_AFFINE_POINT_SELECTION_BOUNDARY_NOTE_2026-04-16.md",
           "title": "DM Neutrino Source-Surface Active Affine Point-Selection Boundary",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1268,7 +1268,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_ACTIVE_HALF_PLANE_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Neutrino Source-Surface Active Half-Plane Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1277,7 +1277,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_SHIFT_QUOTIENT_BUNDLE_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Neutrino Source-Surface Shift-Quotient Bundle Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1286,7 +1286,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_EXACT_H_SOURCE_SURFACE_PREIMAGE_BUNDLE_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Neutrino Exact H-Side Source-Surface Preimage-Bundle Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1295,7 +1295,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_LEPTOGENESIS_NE_PROJECTED_SOURCE_TRIPLET_SIGN_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Leptogenesis `N_e` Projected-Source Triplet Sign Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1304,7 +1304,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_LEPTOGENESIS_NE_PROJECTED_SOURCE_LAW_DERIVATION_NOTE_2026-04-16.md",
           "title": "DM Leptogenesis `N_e` Projected-Source-Law Derivation",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1313,7 +1313,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_LEPTOGENESIS_EXACT_KERNEL_CLOSURE_NOTE_2026-04-15.md",
           "title": "DM Leptogenesis Exact-Kernel Closure (claim narrowed 2026-05-01)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1322,7 +1322,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_CODD_BOSONIC_NORMALIZATION_THEOREM_NOTE_2026-04-15.md",
           "title": "DM Neutrino `c_odd` Bosonic Normalization Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1331,7 +1331,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_UNIQUE_AMPLITUDE_SLOT_NOTE.md",
           "title": "PMNS Selector Unique Amplitude Slot",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1340,7 +1340,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_CLASS_SPACE_UNIQUENESS_NOTE.md",
           "title": "PMNS Selector Class-Space Uniqueness",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1349,7 +1349,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_SECTOR_ODD_REDUCTION_NOTE.md",
           "title": "PMNS Selector Sector-Odd Reduction",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1358,7 +1358,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SECTOR_EXCHANGE_NONFORCING_NOTE.md",
           "title": "PMNS Sector-Exchange Nonforcing",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1367,7 +1367,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SECTOR_ORIENTATION_ORBIT_NOTE.md",
           "title": "PMNS Sector-Orientation Orbit Reduction",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1376,7 +1376,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_BANK_NONREALIZATION_NOTE.md",
           "title": "PMNS Selector-Bank Nonrealization",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1385,7 +1385,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/HIGGS_Z3_CHARGE_PMNS_GAUGE_REDUNDANCY_THEOREM_NOTE_2026-04-17.md",
           "title": "Higgs `Z_3` Charge Gauge-Redundancy Theorem for PMNS",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1394,7 +1394,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/NEUTRINO_DIRAC_Z3_SUPPORT_TRICHOTOMY_NOTE.md",
           "title": "Neutrino Dirac `Z_3` Support Trichotomy",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1403,7 +1403,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/NEUTRINO_MASS_REDUCTION_TO_DIRAC_NOTE.md",
           "title": "Neutrino Mass Reduction To The Dirac Lane",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1412,7 +1412,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/HIGGS_VACUUM_EXPLICIT_SYSTEMATIC_NOTE.md",
           "title": "Higgs / Vacuum Authority",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1421,7 +1421,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/HIGGS_MASS_DERIVED_NOTE.md",
           "title": "Higgs Mass: Canonical Authority Boundary",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1430,7 +1430,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/YT_FLAGSHIP_BOUNDARY_NOTE.md",
           "title": "y_t Flagship Boundary Note",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1439,7 +1439,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/YT_WARD_IDENTITY_DERIVATION_THEOREM.md",
           "title": "Staggered Vector Ward Identity on the Q_L Block: Lattice Noether Derivation, with the H_unit Matrix-Element Corollary y_t_bare = g_bare / sqrt(6)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1448,7 +1448,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md",
           "title": "Staggered-Dirac Realization Gate Note \u2014 Bounded Synthesis Closure",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1457,7 +1457,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/STAGGERED_DIRAC_GATE_CLOSURE_SYNTHESIS_THEOREM_NOTE_2026-05-17.md",
           "title": "Staggered-Dirac Realization Gate \u2014 Closure Synthesis (Block 01, 2026-05-17)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         }
       ],
       "requires_lemma_extraction": false
@@ -1612,7 +1612,7 @@
         }
       ],
       "length": 36,
-      "max_transitive_descendants": 1000,
+      "max_transitive_descendants": 1001,
       "nodes": [
         {
           "audit_status": "unaudited",
@@ -1621,7 +1621,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/STAGGERED_DIRAC_SUBSTEP4_AC_NARROW_BOUNDED_NOTE_2026-05-07_substep4ac.md",
           "title": "Staggered-Dirac Substep 4 \u2014 AC Narrowing (Atomic Decomposition, Bounded)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1630,7 +1630,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md",
           "title": "Axiom-First Single-Clock Codimension-1 Unitary Evolution on the One-Qubit Cl(3) Pauli Factor over Z^3",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1639,7 +1639,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/SINGLE_CLOCK_APBC_AXIS_LABEL_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-16.md",
           "title": "Single-Clock APBC Axis-Label Bridge",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1648,7 +1648,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/SINGLE_CLOCK_AXIS_SELECTION_FROM_RECORD_DURABILITY_NARROW_NO_GO_NOTE_2026-06-11.md",
           "title": "Single-Clock Axis Selection From Record Durability: Every Retained Candidate Structure Is W-Transportable \u2014 Narrow No-Go With a Sharpened Pin",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1657,7 +1657,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_CAP_K_FROM_FINITE_SPEED_REGISTRATION_NARROW_THEOREM_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 CAP-K From Finite-Speed Registration",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1666,7 +1666,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_BR_LICENSE_FROM_RECORD_CAPACITY_NARROW_NO_GO_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 BR Record-Capacity Narrow No-Go",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1675,7 +1675,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_NU_LICENSE_FROM_RETAINED_SURFACE_NARROW_NO_GO_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 NU License Narrowing No-Go",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1684,7 +1684,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/OBSERVABLE_PRINCIPLE_P1_EXPONENT_BARRIER_PARAMETER_SELECTOR_NARROW_THEOREM_NOTE_2026-06-10.md",
           "title": "Observable-Principle P1 Exponent \u2014 Barrier-Parameter Selector Narrow Theorem (+ Irreducible-Class Extension)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1693,7 +1693,7 @@
           "effective_status": "meta",
           "note_path": "docs/RECORD_OUTCOME_OBSERVABLE_PRINCIPLE_CANONICAL_PROPOSAL_NOTE_2026-06-05.md",
           "title": "The Record-Outcome Observable Principle \u2014 Canonical Methodology (Proposal)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1702,7 +1702,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_TM2_TRIMAXIMAL_COLUMN_FROM_RECORD_CENTRAL_SECTOR_NARROW_THEOREM_NOTE_2026-06-05.md",
           "title": "PMNS TM2 Trimaximal Column = the Recorded C3-Singlet Central Sector \u2014 Narrow Bridge Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1711,7 +1711,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_TM2_MAGIC_RESIDUAL_DYNAMICAL_GENERATOR_NARROW_THEOREM_NOTE_2026-06-05.md",
           "title": "PMNS TM2 Magic Residual is a Native Dynamical Unitary \u2014 Narrow Bridge Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1720,7 +1720,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_FROM_DM_NEUTRINO_SOURCE_H_DIAGONALIZATION_CLOSURE_THEOREM_NOTE_2026-04-17.md",
           "title": "PMNS as `f(H(m, delta, q_+))` \u2014 Bounded P3 Package",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1729,7 +1729,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_P3_SYLVESTER_LINEAR_PATH_SIGNATURE_THEOREM_NOTE_2026-04-18.md",
           "title": "P3 Sylvester Linear-Path Signature Theorem on the DM Neutrino Source Surface",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1738,7 +1738,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_ACTIVE_AFFINE_POINT_SELECTION_BOUNDARY_NOTE_2026-04-16.md",
           "title": "DM Neutrino Source-Surface Active Affine Point-Selection Boundary",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1747,7 +1747,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_ACTIVE_HALF_PLANE_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Neutrino Source-Surface Active Half-Plane Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1756,7 +1756,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_SOURCE_SURFACE_SHIFT_QUOTIENT_BUNDLE_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Neutrino Source-Surface Shift-Quotient Bundle Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1765,7 +1765,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_EXACT_H_SOURCE_SURFACE_PREIMAGE_BUNDLE_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Neutrino Exact H-Side Source-Surface Preimage-Bundle Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1774,7 +1774,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_LEPTOGENESIS_NE_PROJECTED_SOURCE_TRIPLET_SIGN_THEOREM_NOTE_2026-04-16.md",
           "title": "DM Leptogenesis `N_e` Projected-Source Triplet Sign Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1783,7 +1783,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_LEPTOGENESIS_NE_PROJECTED_SOURCE_LAW_DERIVATION_NOTE_2026-04-16.md",
           "title": "DM Leptogenesis `N_e` Projected-Source-Law Derivation",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1792,7 +1792,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_LEPTOGENESIS_EXACT_KERNEL_CLOSURE_NOTE_2026-04-15.md",
           "title": "DM Leptogenesis Exact-Kernel Closure (claim narrowed 2026-05-01)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1801,7 +1801,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/DM_NEUTRINO_CODD_BOSONIC_NORMALIZATION_THEOREM_NOTE_2026-04-15.md",
           "title": "DM Neutrino `c_odd` Bosonic Normalization Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1810,7 +1810,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_UNIQUE_AMPLITUDE_SLOT_NOTE.md",
           "title": "PMNS Selector Unique Amplitude Slot",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1819,7 +1819,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_CLASS_SPACE_UNIQUENESS_NOTE.md",
           "title": "PMNS Selector Class-Space Uniqueness",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1828,7 +1828,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_SECTOR_ODD_REDUCTION_NOTE.md",
           "title": "PMNS Selector Sector-Odd Reduction",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1837,7 +1837,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SECTOR_EXCHANGE_NONFORCING_NOTE.md",
           "title": "PMNS Sector-Exchange Nonforcing",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1846,7 +1846,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SECTOR_ORIENTATION_ORBIT_NOTE.md",
           "title": "PMNS Sector-Orientation Orbit Reduction",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1855,7 +1855,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/PMNS_SELECTOR_BANK_NONREALIZATION_NOTE.md",
           "title": "PMNS Selector-Bank Nonrealization",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1864,7 +1864,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/HIGGS_Z3_CHARGE_PMNS_GAUGE_REDUNDANCY_THEOREM_NOTE_2026-04-17.md",
           "title": "Higgs `Z_3` Charge Gauge-Redundancy Theorem for PMNS",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1873,7 +1873,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/NEUTRINO_DIRAC_Z3_SUPPORT_TRICHOTOMY_NOTE.md",
           "title": "Neutrino Dirac `Z_3` Support Trichotomy",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1882,7 +1882,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/NEUTRINO_MASS_REDUCTION_TO_DIRAC_NOTE.md",
           "title": "Neutrino Mass Reduction To The Dirac Lane",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1891,7 +1891,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/HIGGS_VACUUM_EXPLICIT_SYSTEMATIC_NOTE.md",
           "title": "Higgs / Vacuum Authority",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1900,7 +1900,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/HIGGS_MASS_DERIVED_NOTE.md",
           "title": "Higgs Mass: Canonical Authority Boundary",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1909,7 +1909,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/YT_FLAGSHIP_BOUNDARY_NOTE.md",
           "title": "y_t Flagship Boundary Note",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1918,7 +1918,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/YT_WARD_IDENTITY_DERIVATION_THEOREM.md",
           "title": "Staggered Vector Ward Identity on the Q_L Block: Lattice Noether Derivation, with the H_unit Matrix-Element Corollary y_t_bare = g_bare / sqrt(6)",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1927,7 +1927,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md",
           "title": "Staggered-Dirac Realization Gate Note \u2014 Bounded Synthesis Closure",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         },
         {
           "audit_status": "unaudited",
@@ -1936,7 +1936,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/STAGGERED_DIRAC_SUBSTEP4_LABELING_NO_GO_NOTE_2026-05-17.md",
           "title": "Staggered-Dirac Substep 4 \u2014 AC_\u03c6\u03bb Species-Labeling No-Go Theorem",
-          "transitive_descendants": 1000
+          "transitive_descendants": 1001
         }
       ],
       "requires_lemma_extraction": false
@@ -1955,7 +1955,7 @@
         }
       ],
       "length": 2,
-      "max_transitive_descendants": 377,
+      "max_transitive_descendants": 378,
       "nodes": [
         {
           "audit_status": "unaudited",
@@ -1964,7 +1964,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/QUARK_CP_CARRIER_COMPLETION_NOTE_2026-04-18.md",
           "title": "Quark CP-Carrier Completion on the Live Mass-Ratio Lane",
-          "transitive_descendants": 377
+          "transitive_descendants": 378
         },
         {
           "audit_status": "unaudited",
@@ -1973,7 +1973,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/QUARK_CP_CARRIER_SLOT_MINIMALITY_THEOREM_NOTE_2026-06-17.md",
           "title": "Quark CP Carrier Slot Minimality Theorem",
-          "transitive_descendants": 377
+          "transitive_descendants": 378
         }
       ],
       "requires_lemma_extraction": false
@@ -1992,7 +1992,7 @@
         }
       ],
       "length": 2,
-      "max_transitive_descendants": 285,
+      "max_transitive_descendants": 286,
       "nodes": [
         {
           "audit_status": "unaudited",
@@ -2001,7 +2001,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/BRIDGE_GAP_HK_THERMODYNAMIC_STRETCH_NOTE_2026-05-06.md",
           "title": "Bridge Gap \u2014 Heat-Kernel Thermodynamic \u27e8P\u27e9(6) Stretch Attempt (Block 03)",
-          "transitive_descendants": 285
+          "transitive_descendants": 286
         },
         {
           "audit_status": "unaudited",
@@ -2010,7 +2010,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md",
           "title": "Bridge Gap \u2014 HK Cube Perron L_s=2 (Block 06)",
-          "transitive_descendants": 285
+          "transitive_descendants": 286
         }
       ],
       "requires_lemma_extraction": false
@@ -2033,7 +2033,7 @@
         }
       ],
       "length": 3,
-      "max_transitive_descendants": 285,
+      "max_transitive_descendants": 286,
       "nodes": [
         {
           "audit_status": "unaudited",
@@ -2042,7 +2042,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/BRIDGE_GAP_ACTION_FORM_UNIQUENESS_NO_GO_NOTE_2026-05-06.md",
           "title": "Bridge Gap \u2014 Action-Form Uniqueness No-Go",
-          "transitive_descendants": 285
+          "transitive_descendants": 286
         },
         {
           "audit_status": "unaudited",
@@ -2051,7 +2051,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/BRIDGE_GAP_HK_THERMODYNAMIC_STRETCH_NOTE_2026-05-06.md",
           "title": "Bridge Gap \u2014 Heat-Kernel Thermodynamic \u27e8P\u27e9(6) Stretch Attempt (Block 03)",
-          "transitive_descendants": 285
+          "transitive_descendants": 286
         },
         {
           "audit_status": "unaudited",
@@ -2060,7 +2060,7 @@
           "effective_status": "unaudited",
           "note_path": "docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md",
           "title": "Bridge Gap \u2014 HK Cube Perron L_s=2 (Block 06)",
-          "transitive_descendants": 285
+          "transitive_descendants": 286
         }
       ],
       "requires_lemma_extraction": false

--- a/docs/audit/data/effective_status_summary.json
+++ b/docs/audit/data/effective_status_summary.json
@@ -1,11 +1,11 @@
 {
   "claim_type_counts": {
-    "bounded_theorem": 1920,
+    "bounded_theorem": 1922,
     "decoration": 50,
     "meta": 319,
     "no_go": 433,
     "open_gate": 171,
-    "positive_theorem": 742
+    "positive_theorem": 743
   },
   "cycle_examples": [
     [
@@ -203,7 +203,7 @@
     "retained_bounded": 849,
     "retained_no_go": 191,
     "retained_pending_chain": 4,
-    "unaudited": 1965
+    "unaudited": 1968
   },
   "retained_pending_chain_count": 4,
   "retained_pending_chain_examples": [

--- a/docs/audit/data/load_bearing_summary.json
+++ b/docs/audit/data/load_bearing_summary.json
@@ -1,12 +1,12 @@
 {
   "criticality_counts": {
-    "critical": 668,
-    "high": 468,
-    "leaf": 1698,
-    "medium": 971
+    "critical": 676,
+    "high": 460,
+    "leaf": 1700,
+    "medium": 972
   },
   "flagship_signal_used": false,
-  "node_count": 3805,
+  "node_count": 3808,
   "thresholds": {
     "critical_descendants": 250,
     "critical_in_degree": 15,
@@ -19,14 +19,14 @@
     {
       "claim_id": "minimal_axioms",
       "criticality": "critical",
-      "load_bearing_score": 184.862,
-      "transitive_descendants": 1860
+      "load_bearing_score": 186.364,
+      "transitive_descendants": 1863
     },
     {
       "claim_id": "three_generation_observable_theorem_note",
       "criticality": "critical",
-      "load_bearing_score": 67.166,
-      "transitive_descendants": 1148
+      "load_bearing_score": 67.167,
+      "transitive_descendants": 1149
     },
     {
       "claim_id": "quark_route2_exact_readout_map_note_2026-04-19",
@@ -37,98 +37,98 @@
     {
       "claim_id": "graph_first_su3_integration_note",
       "criticality": "critical",
-      "load_bearing_score": 65.125,
-      "transitive_descendants": 1578
+      "load_bearing_score": 65.126,
+      "transitive_descendants": 1579
     },
     {
       "claim_id": "observable_principle_from_axiom_note",
       "criticality": "critical",
-      "load_bearing_score": 64.231,
-      "transitive_descendants": 1201
+      "load_bearing_score": 64.232,
+      "transitive_descendants": 1202
     },
     {
       "claim_id": "plaquette_self_consistency_note",
       "criticality": "critical",
-      "load_bearing_score": 54.287,
-      "transitive_descendants": 1248
+      "load_bearing_score": 53.288,
+      "transitive_descendants": 1249
     },
     {
       "claim_id": "minimal_axioms_2026-05-03",
       "criticality": "critical",
-      "load_bearing_score": 48.172,
-      "transitive_descendants": 1153
+      "load_bearing_score": 48.174,
+      "transitive_descendants": 1154
     },
     {
       "claim_id": "key_terminology",
       "criticality": "critical",
-      "load_bearing_score": 46.791,
-      "transitive_descendants": 1252
+      "load_bearing_score": 46.793,
+      "transitive_descendants": 1254
     },
     {
       "claim_id": "staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac",
       "criticality": "critical",
-      "load_bearing_score": 44.467,
-      "transitive_descendants": 1000
+      "load_bearing_score": 44.469,
+      "transitive_descendants": 1001
     },
     {
       "claim_id": "yt_ward_identity_derivation_theorem",
       "criticality": "critical",
-      "load_bearing_score": 43.467,
-      "transitive_descendants": 1000
+      "load_bearing_score": 43.469,
+      "transitive_descendants": 1001
     },
     {
       "claim_id": "anomaly_forces_time_theorem",
       "criticality": "critical",
-      "load_bearing_score": 43.431,
-      "transitive_descendants": 1380
+      "load_bearing_score": 43.433,
+      "transitive_descendants": 1381
     },
     {
       "claim_id": "alpha_s_derived_note",
       "criticality": "critical",
-      "load_bearing_score": 42.152,
-      "transitive_descendants": 1137
-    },
-    {
-      "claim_id": "cl3_color_automorphism_theorem",
-      "criticality": "critical",
-      "load_bearing_score": 41.599,
-      "transitive_descendants": 1096
+      "load_bearing_score": 42.154,
+      "transitive_descendants": 1138
     },
     {
       "claim_id": "native_gauge_closure_note",
       "criticality": "critical",
-      "load_bearing_score": 41.59,
-      "transitive_descendants": 1540
+      "load_bearing_score": 41.591,
+      "transitive_descendants": 1541
+    },
+    {
+      "claim_id": "cl3_color_automorphism_theorem",
+      "criticality": "critical",
+      "load_bearing_score": 40.601,
+      "transitive_descendants": 1097
     },
     {
       "claim_id": "staggered_dirac_realization_gate_note_2026-05-03",
       "criticality": "critical",
-      "load_bearing_score": 39.467,
-      "transitive_descendants": 1000
+      "load_bearing_score": 39.469,
+      "transitive_descendants": 1001
     },
     {
       "claim_id": "yt_ew_color_projection_theorem",
       "criticality": "critical",
-      "load_bearing_score": 38.554,
-      "transitive_descendants": 1062
+      "load_bearing_score": 38.555,
+      "transitive_descendants": 1063
     },
     {
       "claim_id": "axiom_first_reflection_positivity_theorem_note_2026-04-29",
       "criticality": "critical",
-      "load_bearing_score": 38.528,
-      "transitive_descendants": 1043
+      "load_bearing_score": 37.529,
+      "transitive_descendants": 1044
     },
     {
       "claim_id": "cpt_exact_note",
       "criticality": "critical",
-      "load_bearing_score": 36.694,
-      "transitive_descendants": 1170
+      "load_bearing_score": 36.695,
+      "transitive_descendants": 1171
     },
     {
       "claim_id": "ckm_cp_phase_structural_identity_theorem_note_2026-04-24",
       "criticality": "critical",
-      "load_bearing_score": 36.57,
-      "transitive_descendants": 1074
+      "load_bearing_score": 36.571,
+      "transitive_descendants": 1075
     },
     {
       "claim_id": "s3_time_theta_to_slice_coupling_note",
@@ -139,32 +139,32 @@
     {
       "claim_id": "three_generation_structure_note",
       "criticality": "critical",
-      "load_bearing_score": 35.737,
-      "transitive_descendants": 1206
+      "load_bearing_score": 35.738,
+      "transitive_descendants": 1207
     },
     {
       "claim_id": "wolfenstein_lambda_a_structural_identities_theorem_note_2026-04-24",
       "criticality": "critical",
-      "load_bearing_score": 35.066,
-      "transitive_descendants": 1071
+      "load_bearing_score": 35.067,
+      "transitive_descendants": 1072
     },
     {
       "claim_id": "staggered_dirac_bz_corner_forcing_theorem_note_2026-05-07",
       "criticality": "critical",
-      "load_bearing_score": 34.97,
-      "transitive_descendants": 1002
+      "load_bearing_score": 34.972,
+      "transitive_descendants": 1003
     },
     {
       "claim_id": "koide_circulant_character_derivation_note_2026-04-18",
       "criticality": "critical",
-      "load_bearing_score": 34.7,
-      "transitive_descendants": 293
+      "load_bearing_score": 34.705,
+      "transitive_descendants": 294
     },
     {
       "claim_id": "s3_time_bilinear_tensor_primitive_note",
       "criticality": "critical",
-      "load_bearing_score": 34.174,
-      "transitive_descendants": 1154
+      "load_bearing_score": 34.175,
+      "transitive_descendants": 1155
     }
   ]
 }

--- a/docs/audit/data/runner_classification.json
+++ b/docs/audit/data/runner_classification.json
@@ -30252,6 +30252,30 @@
       "dominant_class": "A",
       "runner": "scripts/frontier_rd_fixedness_arrow_invariant_2026_06_12.py"
     },
+    "reading_note_claims_are_axiom_text_theorems_bounded_note_2026-07-02": {
+      "assert_count": 1,
+      "counts": {
+        "A": 0,
+        "B": 1,
+        "C": 0,
+        "D": 0
+      },
+      "decoration_candidate": true,
+      "dominant_class": "B",
+      "runner": "scripts/frontier_reading_note_derivations_2026_07_02.py"
+    },
+    "reading_note_final_derivations_motion_closure_bounded_note_2026-07-02": {
+      "assert_count": 3,
+      "counts": {
+        "A": 0,
+        "B": 2,
+        "C": 0,
+        "D": 0
+      },
+      "decoration_candidate": true,
+      "dominant_class": "B",
+      "runner": "scripts/frontier_answer_condition_motion_closure_2026_07_02.py"
+    },
     "real_diagonal_source_det_positivity_and_log_readout_lemma_note_2026-06-08": {
       "assert_count": 1,
       "counts": {
@@ -36491,6 +36515,18 @@
       "decoration_candidate": false,
       "dominant_class": "C",
       "runner": "scripts/frontier_theta_gauge_substrate_winding_vacuity_2026_06_11.py"
+    },
+    "theta_gauge_z2_character_collapse_odd_support_and_positive_class_zero_branch_selection_bounded_theorem_note_2026-07-03": {
+      "assert_count": 2,
+      "counts": {
+        "A": 0,
+        "B": 1,
+        "C": 6,
+        "D": 0
+      },
+      "decoration_candidate": false,
+      "dominant_class": "C",
+      "runner": "scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py"
     },
     "theta_link_star_gluing_frame_correlation_pair_composite_dagger_evenness_and_odd_branch_phase_residual_bounded_theorem_note_2026-07-02": {
       "assert_count": 2,
@@ -50904,6 +50940,21 @@
       "counts": {
         "A": 0,
         "B": 1,
+        "C": 0,
+        "D": 0
+      },
+      "decoration_candidate": true,
+      "dominant_class": "B",
+      "exists": true
+    },
+    "scripts/frontier_answer_condition_motion_closure_2026_07_02.py": {
+      "assert_count": 3,
+      "claims": [
+        "reading_note_final_derivations_motion_closure_bounded_note_2026-07-02"
+      ],
+      "counts": {
+        "A": 0,
+        "B": 2,
         "C": 0,
         "D": 0
       },
@@ -72560,6 +72611,21 @@
       "dominant_class": "A",
       "exists": true
     },
+    "scripts/frontier_reading_note_derivations_2026_07_02.py": {
+      "assert_count": 1,
+      "claims": [
+        "reading_note_claims_are_axiom_text_theorems_bounded_note_2026-07-02"
+      ],
+      "counts": {
+        "A": 0,
+        "B": 1,
+        "C": 0,
+        "D": 0
+      },
+      "decoration_candidate": true,
+      "dominant_class": "B",
+      "exists": true
+    },
     "scripts/frontier_record_asymptotic_reset_convergence_ledger_2026_06_05.py": {
       "assert_count": 1,
       "claims": [
@@ -89372,6 +89438,21 @@
       "dominant_class": "D",
       "exists": true
     },
+    "scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py": {
+      "assert_count": 2,
+      "claims": [
+        "theta_gauge_z2_character_collapse_odd_support_and_positive_class_zero_branch_selection_bounded_theorem_note_2026-07-03"
+      ],
+      "counts": {
+        "A": 0,
+        "B": 1,
+        "C": 6,
+        "D": 0
+      },
+      "decoration_candidate": false,
+      "dominant_class": "C",
+      "exists": true
+    },
     "scripts/theta_link_star_frame_correlation_gluing_2026_07_02.py": {
       "assert_count": 2,
       "claims": [
@@ -90599,16 +90680,16 @@
   },
   "schema_version": 1,
   "stats": {
-    "decoration_candidates": 688,
+    "decoration_candidates": 690,
     "dominant_class_distribution": {
       "A": 488,
-      "B": 632,
-      "C": 1272,
+      "B": 634,
+      "C": 1273,
       "D": 450,
       "none": 457
     },
-    "runners_classified": 3299,
-    "runners_with_C": 1729,
+    "runners_classified": 3302,
+    "runners_with_C": 1730,
     "runners_with_D": 1061
   }
 }

--- a/docs/repo/FRONT_DOOR_STATUS.md
+++ b/docs/repo/FRONT_DOOR_STATUS.md
@@ -11,15 +11,15 @@ It is not a physics claim surface and should not be edited by hand.
 
 | Metric | Value |
 |---|---:|
-| Ledger rows | 3635 |
-| Applied audit verdicts | 1346 |
+| Ledger rows | 3638 |
+| Applied audit verdicts | 1345 |
 | Retained-grade rows, including boxed decorations | 1274 |
 | Retained positive theorems | 189 |
 | Retained no-go rows | 191 |
 | Retained bounded rows | 849 |
 | Boxed decorations under retained parents | 45 |
 | Open gates | 24 |
-| Unaudited rows | 1965 |
+| Unaudited rows | 1968 |
 | Retained-pending-chain rows | 4 |
 | Audited conditional rows | 25 |
 | Audited renaming rows | 19 |
@@ -33,13 +33,13 @@ Source: [`docs/audit/AUDIT_LEDGER.md`](../audit/AUDIT_LEDGER.md) and
 
 | Metric | Value |
 |---|---:|
-| Total pending rows | 1976 |
-| Ready rows | 139 |
+| Total pending rows | 1980 |
+| Ready rows | 142 |
 | Cycle-break targets | 14 |
-| Critical pending | 420 |
+| Critical pending | 421 |
 | High pending | 292 |
-| Medium pending | 524 |
-| Leaf pending | 740 |
+| Medium pending | 525 |
+| Leaf pending | 742 |
 
 Next ready rows by queue order:
 
@@ -77,19 +77,19 @@ Source: [`docs/publication/ci3_z3/PUBLICATION_AUDIT_DIVERGENCE.md`](../publicati
 
 | Metric | Value |
 |---|---:|
-| Citation-graph nodes | 3805 |
-| Critical nodes | 668 |
-| High nodes | 468 |
-| Medium nodes | 971 |
-| Leaf nodes | 1698 |
+| Citation-graph nodes | 3808 |
+| Critical nodes | 676 |
+| High nodes | 460 |
+| Medium nodes | 972 |
+| Leaf nodes | 1700 |
 
 Top load-bearing rows by graph score:
 
-- `minimal_axioms` - critical; 1860 descendants; score 184.862
-- `three_generation_observable_theorem_note` - critical; 1148 descendants; score 67.166
+- `minimal_axioms` - critical; 1863 descendants; score 186.364
+- `three_generation_observable_theorem_note` - critical; 1149 descendants; score 67.167
 - `quark_route2_exact_readout_map_note_2026-04-19` - critical; 198 descendants; score 65.137
-- `graph_first_su3_integration_note` - critical; 1578 descendants; score 65.125
-- `observable_principle_from_axiom_note` - critical; 1201 descendants; score 64.231
-- `plaquette_self_consistency_note` - critical; 1248 descendants; score 54.287
-- `minimal_axioms_2026-05-03` - critical; 1153 descendants; score 48.172
-- `key_terminology` - critical; 1252 descendants; score 46.791
+- `graph_first_su3_integration_note` - critical; 1579 descendants; score 65.126
+- `observable_principle_from_axiom_note` - critical; 1202 descendants; score 64.232
+- `plaquette_self_consistency_note` - critical; 1249 descendants; score 53.288
+- `minimal_axioms_2026-05-03` - critical; 1154 descendants; score 48.174
+- `key_terminology` - critical; 1254 descendants; score 46.793

--- a/logs/runner-cache/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.txt
+++ b/logs/runner-cache/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py
-runner_sha256: 8b893054779cc287878d20d5aaa5057d8a2ef4fe778023523e254dc91c266627
+runner_sha256: 88384c0f620f9928535407ddd719f596b8addbd9f510bc11ae2944bbbe817689
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.24
+elapsed_sec: 0.20
 status: ok
 ----- stdout -----
 PASS: A1 Z2 character collapse with odd support :: z^Q = z^{-Q} for all Q with 1 in the support iff z^2 = 1; scan_count=2
@@ -22,7 +22,13 @@ PASS: B4 two-mechanism honesty for positive class selection :: orientation draws
 PASS: B5a mass-side mirror antisymmetric pairing :: min det(M+mI) on n=4,6,8 grid=8.995e+00
 PASS: B5b symmetric refutation leg loses sign guarantee :: m=-1.90, det=-2.349e-01
 PASS: B6 two-sided Z2 table zero branch :: (0,0)->0; (0,pi)->pi; (pi,0)->pi; (pi,pi)->0
-TOTAL: PASS=16 FAIL=0
+PASS: C1 note declares bounded_theorem Type header
+PASS: C2 note keeps branch-table result formal and scoped
+PASS: C3 note does not assert physical theta_bar value
+PASS: C4 note states class-to-action adjudication remains open
+PASS: C5 note keeps orientation evenness as a hypothesis
+PASS: C6 note has no landed/unconditional authority wording
+TOTAL: PASS=22 FAIL=0
 
 ----- stderr -----
 

--- a/logs/runner-cache/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.txt
+++ b/logs/runner-cache/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.txt
@@ -1,0 +1,28 @@
+===== runner cache v1 =====
+runner: scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py
+runner_sha256: 8b893054779cc287878d20d5aaa5057d8a2ef4fe778023523e254dc91c266627
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.24
+status: ok
+----- stdout -----
+PASS: A1 Z2 character collapse with odd support :: z^Q = z^{-Q} for all Q with 1 in the support iff z^2 = 1; scan_count=2
+PASS: A2 evenness alone is not multiplicative character input :: w(2)=0.825335614910, w(1)w(1)=0.912667807455
+PASS: A3 odd support is load-bearing :: even-support fixed count=4, odd-support fixed count=2
+PASS: A4a swap-closed evenness re-earned :: max alpha-odd paired residual=0.000e+00
+PASS: A4b pi branch is orientation-blind :: e.b flips under frame swap while (-1)^Q is unchanged on 100 draws
+PASS: B1 closed-surface positive matched labels A=4 (full tuple enumeration) :: 9^4 tuples filtered by matching; max |direct-product|=0.000e+00, min Z=1.870e-10
+PASS: B1 closed-surface positive matched labels A=16 (multiplicative scaling) :: Z_n(16) = Z_n(4)^4 cross-path; max diff=2.585e-26
+PASS: B2a SU(3) quadrature orthonormality gate :: <chi_F,chi_F>=1.000000000000+1.54e-19i
+PASS: B2b Wilson dual coefficients positive real :: min real=1.2548769, max relative imag=1.095e-16
+PASS: B2c Wilson conjugation pairing :: c00=3.4414404-2.7e-33i, c01=4.3623533-9.1e-17i, c02=2.8074251+6.1e-17i, c10=4.3623533-9.1e-17i, c11=4.4672594-3.6e-17i, c12=2.4927069-3.0e-17i, c20=2.8074251-1.8e-16i, c21=2.4927069-2.7e-16i, c22=1.2548769+3.0e-17i
+PASS: B3a positive class product weights on carrier sectors :: draws=200, unit-complementary Q values=[1, 1, 1, 1, 1, 1]
+PASS: B3b pi branch exits the positive class :: odd-Q draws=99, negative signed draws=99
+PASS: B4 two-mechanism honesty for positive class selection :: orientation draws=50, character pairs=50, negative witnesses=6
+PASS: B5a mass-side mirror antisymmetric pairing :: min det(M+mI) on n=4,6,8 grid=8.995e+00
+PASS: B5b symmetric refutation leg loses sign guarantee :: m=-1.90, det=-2.349e-01
+PASS: B6 two-sided Z2 table zero branch :: (0,0)->0; (0,pi)->pi; (pi,0)->pi; (pi,pi)->0
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py
+++ b/scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py
@@ -4,13 +4,19 @@ Sections:
 - A: Z2 character collapse with odd support.
 - B: positive class zero branch selection and mass-side mirror checks.
 
-Expected close: TOTAL: PASS=16 FAIL=0
+Expected close: TOTAL: PASS=22 FAIL=0
 """
 
 from itertools import permutations, product
+from pathlib import Path
 
 import numpy as np
 
+
+BASE = Path(__file__).resolve().parents[1]
+NOTE_PATH = BASE / "docs/THETA_GAUGE_Z2_CHARACTER_COLLAPSE_ODD_SUPPORT_AND_POSITIVE_CLASS_ZERO_BRANCH_SELECTION_BOUNDED_THEOREM_NOTE_2026-07-03.md"
+NOTE_TEXT = NOTE_PATH.read_text(encoding="utf-8")
+NOTE_FLAT = " ".join(NOTE_TEXT.split())
 
 rng = np.random.default_rng(7)
 PASS = 0
@@ -472,6 +478,34 @@ check(
     "B6 two-sided Z2 table zero branch",
     len(selected) == 1 and len(selected_zero) == 1 and len(zero_cells_under_selections) == 1,
     table_detail,
+)
+
+check(
+    "C1 note declares bounded_theorem Type header",
+    "**Type:** bounded_theorem" in NOTE_TEXT,
+)
+check(
+    "C2 note keeps branch-table result formal and scoped",
+    "formal branch table" in NOTE_TEXT
+    and "within the stated surfaces and classes only" in NOTE_TEXT,
+)
+check(
+    "C3 note does not assert physical theta_bar value",
+    "nothing here asserts the physical value of `theta_bar`" in NOTE_TEXT,
+)
+check(
+    "C4 note states class-to-action adjudication remains open",
+    "Whether the physical action class lies in (or reduces to) this class" in NOTE_FLAT
+    and "this note does not decide it" in NOTE_FLAT,
+)
+check(
+    "C5 note keeps orientation evenness as a hypothesis",
+    "orientation-evenness" in NOTE_TEXT
+    and "enters only as a named hypothesis" in NOTE_TEXT,
+)
+check(
+    "C6 note has no landed/unconditional authority wording",
+    "landed" not in NOTE_TEXT.lower() and "unconditional" not in NOTE_TEXT.lower(),
 )
 
 print(f"TOTAL: PASS={PASS} FAIL={FAIL}")

--- a/scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py
+++ b/scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py
@@ -1,0 +1,477 @@
+"""Gauge-side Z2 collapse and positive-class zero-branch runner.
+
+Sections:
+- A: Z2 character collapse with odd support.
+- B: positive class zero branch selection and mass-side mirror checks.
+
+Expected close: TOTAL: PASS=16 FAIL=0
+"""
+
+from itertools import permutations, product
+
+import numpy as np
+
+
+rng = np.random.default_rng(7)
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if bool(cond):
+        PASS += 1
+        status = "PASS"
+    else:
+        FAIL += 1
+        status = "FAIL"
+    suffix = f" :: {detail}" if detail else ""
+    print(f"{status}: {name}{suffix}")
+
+
+def permutation_sign(seq):
+    inversions = 0
+    vals = list(seq)
+    for i in range(len(vals)):
+        for j in range(i + 1, len(vals)):
+            if vals[i] > vals[j]:
+                inversions += 1
+    return -1 if inversions % 2 else 1
+
+
+PLANES = []
+PLANE_TO_INDEX = {}
+for a in range(4):
+    for b in range(a + 1, 4):
+        PLANE_TO_INDEX[(a, b)] = len(PLANES)
+        PLANES.append((a, b))
+
+
+def q_flux(m):
+    m = np.asarray(m, dtype=int)
+    m01, m02, m03, m12, m13, m23 = m
+    return int(m01 * m23 - m02 * m13 + m03 * m12)
+
+
+def oriented_complement(plane):
+    rest = [x for x in range(4) if x not in plane]
+    for comp in (tuple(rest), tuple(rest[::-1])):
+        if permutation_sign(tuple(plane) + comp) == 1:
+            return comp
+    return tuple(rest)
+
+
+def set_oriented_plane(m, plane, value):
+    a, b = plane
+    if a < b:
+        m[PLANE_TO_INDEX[(a, b)]] = value
+    else:
+        m[PLANE_TO_INDEX[(b, a)]] = -value
+
+
+def unit_complementary_configs():
+    configs = []
+    for plane in PLANES:
+        m = np.zeros(6, dtype=int)
+        set_oriented_plane(m, plane, 1)
+        set_oriented_plane(m, oriented_complement(plane), 1)
+        configs.append(m)
+    return configs
+
+
+def canonical_b(m):
+    m = np.asarray(m, dtype=int)
+    return np.array([m[5], -m[4], m[3]], dtype=int)
+
+
+def b_frame(m, frame):
+    return permutation_sign(frame) * canonical_b(m)
+
+
+def e_split(m):
+    m = np.asarray(m, dtype=int)
+    return np.array([m[0], m[1], m[2]], dtype=int)
+
+
+def z2_character(q):
+    return 1 if int(q) % 2 == 0 else -1
+
+
+def su3_sample():
+    z = rng.normal(size=(3, 3)) + 1j * rng.normal(size=(3, 3))
+    q, r = np.linalg.qr(z)
+    diag = np.diag(r)
+    phases = diag / np.abs(diag)
+    u = q * phases
+    det_u = np.linalg.det(u)
+    return u / det_u ** (1.0 / 3.0)
+
+
+def insertion_weight(u, alpha, c):
+    tr = np.trace(u)
+    return 1.0 + c * (np.exp(1j * alpha) * tr + np.exp(-1j * alpha) * np.conj(tr))
+
+
+def heat_coeff(n, t):
+    return float(np.exp(-t * n * n / 2.0))
+
+
+def direct_matched_closed_weight(sector, area, t, label_min=-4, label_max=4):
+    """Sum over ALL per-plaquette label tuples; the pairwise matching
+    constraint on the closed cycle does the selecting (nothing is imposed
+    by construction). Feasible only for small area."""
+    total = 0.0
+    for labels in product(range(label_min, label_max + 1), repeat=area):
+        matched = all(labels[(i + 1) % area] == labels[i] for i in range(area))
+        if matched and labels[0] == sector:
+            term = 1.0
+            for label in labels:
+                term *= heat_coeff(int(label), t)
+            total += term
+    return total
+
+
+def product_closed_weight(sector, area, t):
+    coeff = heat_coeff(sector, t)
+    out = 1.0
+    for _ in range(area):
+        out *= coeff
+    return out
+
+
+def antisym_det(lam, t1, t2):
+    avals = (t1, t2, -t1 - t2)
+    total = np.zeros_like(t1, dtype=complex)
+    for perm in permutations(range(3)):
+        term = np.ones_like(t1, dtype=complex)
+        for row in range(3):
+            term *= np.exp(1j * avals[row] * lam[perm[row]])
+        total += permutation_sign(perm) * term
+    return total
+
+
+def su3_lam(p, q):
+    return np.array([p + q + 2, q + 1, 0], dtype=int)
+
+
+def su3_quadrature_data(grid_n=200):
+    vals = (np.arange(grid_n) + 0.5) * (2.0 * np.pi / grid_n)
+    t1, t2 = np.meshgrid(vals, vals, indexing="ij")
+    ad = antisym_det(np.array([2, 1, 0], dtype=int), t1, t2)
+    den = np.mean(ad * np.conj(ad))
+    re_tr = np.cos(t1) + np.cos(t2) + np.cos(t1 + t2)
+    return t1, t2, ad, den, re_tr
+
+
+def wilson_coefficients(max_p=2, max_q=2, beta=6.0):
+    t1, t2, ad, den, re_tr = su3_quadrature_data()
+    boltz = np.exp((beta / 3.0) * re_tr)
+    coeffs = {}
+    for p in range(max_p + 1):
+        for q in range(max_q + 1):
+            al = antisym_det(su3_lam(p, q), t1, t2)
+            coeffs[(p, q)] = np.mean(boltz * ad * np.conj(al)) / den
+    return coeffs, (t1, t2, ad, den, re_tr)
+
+
+def plane_weight(n):
+    return float(np.exp(-n * n / 2.0))
+
+
+def base_sector_weight(m):
+    out = 1.0
+    for n in np.asarray(m, dtype=int):
+        out *= plane_weight(int(n))
+    return out
+
+
+def signed_sector_weight(m):
+    return z2_character(q_flux(m)) * base_sector_weight(m)
+
+
+def det_real(mat):
+    return float(np.real_if_close(np.linalg.det(mat), tol=1000))
+
+
+def spectrum_has_pm_i_pairs(vals):
+    vals = np.asarray(vals, dtype=complex)
+    nonzero = [v for v in vals if abs(v) > 1e-8]
+    for v in nonzero:
+        if abs(np.real(v)) > 1e-8:
+            return False
+        has_negative = np.any(np.abs(vals + v) < 1e-7)
+        has_conjugate = np.any(np.abs(vals - np.conj(v)) < 1e-7)
+        if not (has_negative and has_conjugate):
+            return False
+    return True
+
+
+# Section A
+grid = np.exp(2j * np.pi * np.arange(720) / 720.0)
+fixed_odd = [z for z in grid if abs(z - z ** -1) < 1e-12]
+a1_cond = (
+    len(fixed_odd) == 2
+    and any(abs(z - 1.0) < 1e-12 for z in fixed_odd)
+    and any(abs(z + 1.0) < 1e-12 for z in fixed_odd)
+)
+check(
+    "A1 Z2 character collapse with odd support",
+    a1_cond,
+    "z^Q = z^{-Q} for all Q with 1 in the support iff z^2 = 1; "
+    f"scan_count={len(fixed_odd)}",
+)
+
+qs = np.arange(-6, 7)
+wq = np.cos(0.3 * qs)
+even_alone = all(abs(np.cos(0.3 * q) - np.cos(0.3 * (-q))) < 1e-15 for q in qs)
+mult_left = float(np.cos(0.3 * (1 + 1)))
+mult_right = float(np.cos(0.3 * 1) * np.cos(0.3 * 1))
+check(
+    "A2 evenness alone is not multiplicative character input",
+    even_alone and abs(mult_left - mult_right) > 1e-12,
+    f"w(2)={mult_left:.12f}, w(1)w(1)={mult_right:.12f}",
+)
+
+fixed_even_support = [z for z in grid if abs(z**2 - z ** -2) < 1e-12]
+a3_cond = len(fixed_even_support) == 4 and len(fixed_even_support) > len(fixed_odd)
+check(
+    "A3 odd support is load-bearing",
+    a3_cond,
+    f"even-support fixed count={len(fixed_even_support)}, odd-support fixed count={len(fixed_odd)}",
+)
+
+alpha = 0.81
+c_insert = 0.37
+odd_residuals = []
+for _ in range(20):
+    u = su3_sample()
+    odd_u = 0.5 * (insertion_weight(u, alpha, c_insert) - insertion_weight(u, -alpha, c_insert))
+    uc = np.conj(u)
+    odd_uc = 0.5 * (insertion_weight(uc, alpha, c_insert) - insertion_weight(uc, -alpha, c_insert))
+    odd_residuals.append(abs(odd_u + odd_uc))
+max_odd_residual = max(odd_residuals)
+check(
+    "A4a swap-closed evenness re-earned",
+    max_odd_residual < 1e-12,
+    f"max alpha-odd paired residual={max_odd_residual:.3e}",
+)
+
+a4b_ok = True
+for _ in range(100):
+    m = rng.integers(-4, 5, size=6)
+    e = e_split(m)
+    q123 = int(np.dot(e, b_frame(m, (1, 2, 3))))
+    q213 = int(np.dot(e, b_frame(m, (2, 1, 3))))
+    if q123 != q_flux(m) or q213 != -q123 or z2_character(q123) != z2_character(q213):
+        a4b_ok = False
+        break
+check(
+    "A4b pi branch is orientation-blind",
+    a4b_ok,
+    "e.b flips under frame swap while (-1)^Q is unchanged on 100 draws",
+)
+
+
+# Section B
+b1_ok = True
+diffs = []
+values = []
+for n in range(-4, 5):
+    direct = direct_matched_closed_weight(n, 4, 0.7)
+    formula = product_closed_weight(n, 4, 0.7)
+    diffs.append(abs(direct - formula))
+    values.append(formula)
+    if abs(direct - formula) > 1e-12 or direct <= 0:
+        b1_ok = False
+for n in range(0, 5):
+    zp = product_closed_weight(n, 4, 0.7)
+    zm = product_closed_weight(-n, 4, 0.7)
+    if abs(zp - zm) > 1e-12:
+        b1_ok = False
+check(
+    "B1 closed-surface positive matched labels A=4 (full tuple enumeration)",
+    b1_ok,
+    f"9^4 tuples filtered by matching; max |direct-product|={max(diffs):.3e}, min Z={min(values):.3e}",
+)
+
+b1_scale_ok = True
+scale_diffs = []
+for n in range(-4, 5):
+    z4 = product_closed_weight(n, 4, 0.7)
+    z16 = product_closed_weight(n, 16, 0.7)
+    scale_diffs.append(abs(z16 - z4 ** 4))
+    if z16 <= 0 or abs(z16 - z4 ** 4) > 1e-12 * max(1.0, z16):
+        b1_scale_ok = False
+    if abs(product_closed_weight(n, 16, 0.7) - product_closed_weight(-n, 16, 0.7)) > 1e-15:
+        b1_scale_ok = False
+check(
+    "B1 closed-surface positive matched labels A=16 (multiplicative scaling)",
+    b1_scale_ok,
+    f"Z_n(16) = Z_n(4)^4 cross-path; max diff={max(scale_diffs):.3e}",
+)
+
+quad_t1, quad_t2, quad_ad, quad_den, quad_re_tr = su3_quadrature_data()
+af = antisym_det(su3_lam(1, 0), quad_t1, quad_t2)
+inner_ff = np.mean(af * np.conj(af)) / quad_den
+check(
+    "B2a SU(3) quadrature orthonormality gate",
+    abs(inner_ff.real - 1.0) < 1e-6 and abs(inner_ff.imag) < 1e-10,
+    f"<chi_F,chi_F>={inner_ff.real:.12f}{inner_ff.imag:+.2e}i",
+)
+
+coeffs, _quad_data = wilson_coefficients()
+b2b_ok = True
+for coeff in coeffs.values():
+    if coeff.real <= 0 or abs(coeff.imag) > 1e-7 * max(1.0, abs(coeff.real)):
+        b2b_ok = False
+        break
+check(
+    "B2b Wilson dual coefficients positive real",
+    b2b_ok,
+    "min real={:.8g}, max relative imag={:.3e}".format(
+        min(c.real for c in coeffs.values()),
+        max(abs(c.imag) / max(1.0, abs(c.real)) for c in coeffs.values()),
+    ),
+)
+
+b2c_ok = True
+for p in range(3):
+    for q in range(3):
+        if abs(coeffs[(p, q)] - coeffs[(q, p)]) > 1e-7:
+            b2c_ok = False
+values_detail = ", ".join(
+    f"c{p}{q}={coeffs[(p, q)].real:.8g}{coeffs[(p, q)].imag:+.1e}i"
+    for p in range(3)
+    for q in range(3)
+)
+check(
+    "B2c Wilson conjugation pairing",
+    b2c_ok,
+    values_detail,
+)
+
+b3_draws = rng.integers(-3, 4, size=(200, 6))
+unit_configs = unit_complementary_configs()
+b3a_draws_ok = all(base_sector_weight(m) > 0 for m in b3_draws)
+b3a_units_ok = all(base_sector_weight(m) > 0 and q_flux(m) == 1 for m in unit_configs)
+check(
+    "B3a positive class product weights on carrier sectors",
+    b3a_draws_ok and b3a_units_ok,
+    f"draws=200, unit-complementary Q values={[q_flux(m) for m in unit_configs]}",
+)
+
+odd_count = 0
+negative_count = 0
+b3b_ok = True
+for m in b3_draws:
+    base = base_sector_weight(m)
+    signed = signed_sector_weight(m)
+    expected = z2_character(q_flux(m))
+    ratio = int(np.sign(signed) / np.sign(base))
+    if ratio != expected:
+        b3b_ok = False
+    if q_flux(m) % 2:
+        odd_count += 1
+    if signed < 0:
+        negative_count += 1
+check(
+    "B3b pi branch exits the positive class",
+    b3b_ok and odd_count >= 30 and negative_count == odd_count,
+    f"odd-Q draws={odd_count}, negative signed draws={negative_count}",
+)
+
+b4_orientation_ok = True
+for _ in range(50):
+    m = rng.integers(-4, 5, size=6)
+    e = e_split(m)
+    q123 = int(np.dot(e, b_frame(m, (1, 2, 3))))
+    q213 = int(np.dot(e, b_frame(m, (2, 1, 3))))
+    if z2_character(q123) * base_sector_weight(m) != z2_character(q213) * base_sector_weight(m):
+        b4_orientation_ok = False
+        break
+b4_character_ok = True
+for _ in range(50):
+    m1 = rng.integers(-4, 5, size=6)
+    m2 = rng.integers(-4, 5, size=6)
+    q1 = q_flux(m1)
+    q2 = q_flux(m2)
+    if z2_character(q1 + q2) != z2_character(q1) * z2_character(q2):
+        b4_character_ok = False
+        break
+b4_negative_witnesses = sum(1 for m in unit_configs if signed_sector_weight(m) < 0)
+check(
+    "B4 two-mechanism honesty for positive class selection",
+    b4_orientation_ok and b4_character_ok and b4_negative_witnesses >= 1,
+    f"orientation draws=50, character pairs=50, negative witnesses={b4_negative_witnesses}",
+)
+
+m_grid = np.linspace(-3.0, 3.0, 13)
+b5a_ok = True
+min_det = None
+for n in (4, 6, 8):
+    a = rng.normal(size=(n, n))
+    mat = a - a.T
+    vals = np.linalg.eigvals(mat)
+    if not spectrum_has_pm_i_pairs(vals):
+        b5a_ok = False
+    for mass in m_grid:
+        det_val = det_real(mat + mass * np.eye(n))
+        min_det = det_val if min_det is None else min(min_det, det_val)
+        if det_val < -1e-9:
+            b5a_ok = False
+check(
+    "B5a mass-side mirror antisymmetric pairing",
+    b5a_ok,
+    f"min det(M+mI) on n=4,6,8 grid={min_det:.3e}",
+)
+
+s = np.diag(np.array([2.0, 1.0, 1.0, -1.0]))
+shift_grid = np.linspace(-3.0, 3.0, 61)
+found_shift = None
+found_det = None
+for shift in shift_grid:
+    det_val = det_real(s + shift * np.eye(4))
+    if det_val < 0:
+        found_shift = float(shift)
+        found_det = det_val
+        break
+check(
+    "B5b symmetric refutation leg loses sign guarantee",
+    found_shift is not None and found_det is not None and found_det < 0,
+    f"m={found_shift:.2f}, det={found_det:.3e}",
+)
+
+branches = (0.0, np.pi)
+table = []
+for theta_gauge, arg_det_m in product(branches, branches):
+    theta_bar = np.mod(theta_gauge + arg_det_m, 2.0 * np.pi)
+    if abs(theta_bar - 2.0 * np.pi) < 1e-12:
+        theta_bar = 0.0
+    table.append((theta_gauge, arg_det_m, theta_bar))
+selected_gauge = 0.0
+selected_mass = 0.0
+selected = [
+    cell
+    for cell in table
+    if abs(cell[0] - selected_gauge) < 1e-12 and abs(cell[1] - selected_mass) < 1e-12
+]
+selected_zero = [cell for cell in selected if abs(cell[2]) < 1e-12]
+zero_cells_under_selections = [
+    cell
+    for cell in table
+    if abs(cell[2]) < 1e-12
+    and abs(cell[0] - selected_gauge) < 1e-12
+    and abs(cell[1] - selected_mass) < 1e-12
+]
+table_detail = "; ".join(
+    f"({('0' if abs(g) < 1e-12 else 'pi')},{('0' if abs(m) < 1e-12 else 'pi')})->"
+    f"{('0' if abs(tb) < 1e-12 else 'pi')}"
+    for g, m, tb in table
+)
+check(
+    "B6 two-sided Z2 table zero branch",
+    len(selected) == 1 and len(selected_zero) == 1 and len(zero_cells_under_selections) == 1,
+    table_detail,
+)
+
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")


### PR DESCRIPTION
## Summary

Adds a bounded gauge-side theta branch-selection theorem, scoped to the stated current-main source surfaces and positive class. Review tightened the branch so it does not imply a physical theta value or retained authority before audit.

Review fix in `1571c7940`:

- replaces “landed/unconditional” authority wording with current-main/cited-source scoping
- makes the two-sided table a formal branch-table result within the stated surfaces/classes only
- names class-to-physical-action adjudication as open
- adds `minimal_axioms` as an explicit dependency edge
- adds runner guards that fail if the note drops the physical-action non-claim or reintroduces landed/unconditional wording
- refreshes audit surfaces with the row left `bounded_theorem / unaudited / unaudited`

No audit verdict, Tier-A registry edit, physical-action claim, measured-theta claim, or Strong-CP closure is landed here.

## Changes

- `docs/THETA_GAUGE_Z2_CHARACTER_COLLAPSE_ODD_SUPPORT_AND_POSITIVE_CLASS_ZERO_BRANCH_SELECTION_BOUNDED_THEOREM_NOTE_2026-07-03.md` — scoped bounded theorem note
- `scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py` — paired runner with scope guards
- `logs/runner-cache/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.txt` — refreshed cache, `TOTAL: PASS=22 FAIL=0`
- generated audit queue/ledger/status surfaces refreshed from current main

## Test Plan

- [x] `python3 -m py_compile scripts/theta_gauge_z2_collapse_positive_class_zero_branch_2026_07_03.py`
- [x] runner cache refresh via `scripts/runner_cache.py` -> `ok 0`, `TOTAL: PASS=22 FAIL=0`
- [x] `bash docs/audit/scripts/run_pipeline.sh` -> complete, no stale-audit invalidations
- [x] `python3 docs/audit/scripts/audit_lint.py --strict` -> OK, existing warnings only
- [x] `git diff --check`
