### PR TITLE
feat(admissibility): rule covariance-extension classification — openness-level achirality, oriented-frame chiral channel, one shared orientation bit with the theta seed

### DIFF
--- a/docs/ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md
+++ b/docs/ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md
@@ -1,0 +1,243 @@
+# The Admissibility-Rule Covariance Extension Classified: Openness-Level Patterns Are Automatically Achiral, Chirality Requires Three Condition Values (One Chiral Pair at k = 3; Canonical Carrier the Oriented Frame), the Antilinear Value Twist Pairs Odd With Odd, and a Chiral Fixed Rule Is the Same Single Orientation Bit as the Theta Seed (Bounded Theorem + Classification)
+
+**Date:** 2026-07-03
+**Type:** bounded_theorem
+**Claim type:** bounded_theorem (exact finite classification of
+nearest-neighbor rule spaces under the proper-to-full cubic covariance
+extension, on explicitly named condition-alphabet models; not a
+determination of the framework's physical rule, and no import is introduced
+— what an import would be is what gets classified).
+**Status authority:** independent audit lane only. This note does not set an
+audit verdict, edit registries, register primitives, change axioms, retire
+or re-grade any Tier-A admission, or claim Strong-CP closure.
+**Primary runner:**
+[`scripts/admissibility_rule_covariance_extension_classification_2026_07_03.py`](../scripts/admissibility_rule_covariance_extension_classification_2026_07_03.py)
+**Runner cache:**
+[`logs/runner-cache/admissibility_rule_covariance_extension_classification_2026_07_03.txt`](../logs/runner-cache/admissibility_rule_covariance_extension_classification_2026_07_03.txt)
+
+## Question
+
+The Admissibility axiom supplies "one fixed nearest-neighbor admissibility
+rule, covariant under lattice translations and proper cubic rotations", with
+"the available possibilities ... determined by, and vary[ing] with, the
+nearest-neighbor conditions"
+([`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)). The
+axiom names **proper** covariance; its behavior under improper elements
+(spatial inversion, reflections) is an unstated property. A neighbor's
+condition is its record content or openness — the condition is a predicate
+on states with record absence included
+([`READING_NOTE_FINAL_DERIVATIONS_MOTION_CLOSURE_BOUNDED_NOTE_2026-07-02.md`](READING_NOTE_FINAL_DERIVATIONS_MOTION_CLOSURE_BOUNDED_NOTE_2026-07-02.md)).
+
+Questions answered here, by exact finite classification on named
+condition-alphabet models (colorings of the six nearest-neighbor directions
+by a `k`-letter alphabet, with rule values acted on complex-antilinearly by
+improper elements — the conjugation action of the one-site algebra's
+`Cl(3,0)` presentation, re-earned in miniature by the runner):
+
+1. When is proper covariance automatically full-cubic covariance
+   (achirality)?
+2. If not automatic, what is the minimal chiral channel, and what would a
+   chiral fixed rule cost?
+3. How does rule chirality relate to the theta-slot orientation
+   structure?
+
+## Answer
+
+Five exact results:
+
+1. **Structure (Theorem 1).** The full cubic group is `G = G+ x {1, P}`
+   with the inversion `P` central; the direction action is faithful (48
+   distinct permutations of the six axis directions), and the antipodal
+   permutation is not realized by any proper element. So the improper
+   question is exactly the action of the single central element `P`.
+
+2. **Openness-level patterns are automatically achiral (Theorem 2).** For
+   the two-letter alphabet (recorded/open — content-blind conditions),
+   every coloring of the six directions is proper-equivalent to its
+   `P`-image (all 64, exhaustively; Burnside orbit counts agree at 10 and
+   10). Every proper-covariant rule depending only on the openness
+   pattern is therefore automatically covariant under the full cubic
+   group. **A chiral admissibility rule cannot live at the openness
+   level**; chirality requires distinguishable record contents.
+
+3. **Chirality requires three condition values, and at exactly three it
+   is unique (Theorem 3).** At `k = 3` the proper/full orbit counts are
+   57 and 56: exactly **one** chiral pair, whose members are the handed
+   fully-mixed patterns — every axis bi-colored with two distinct values,
+   every value used exactly twice, the value-to-axis incidence encoding a
+   handedness (runner-anchored representative reported). At `k = 4`
+   (three record contents plus openness) the count grows to 20 pairs and
+   includes the **canonical carrier**: the oriented-frame coloring
+   (`+x, +y, +z` carrying the three distinct contents, the rest open),
+   verified chiral directly. The invariant carrying the canonical channel
+   is the frame sign — the determinant sign of the labeled direction
+   triple — which is proper-invariant and `P`-odd, and spans the
+   one-dimensional `P`-odd part of the proper-invariant function space on
+   the chiral orbit.
+
+4. **The antilinear value twist pairs odd with odd (Theorem 4).** With
+   rule values acted on antilinearly under improper elements (conjugation
+   — the `Cl(3,0)` presentation's improper action), the rule
+   `R0 = i x frame_sign` is fully `G`-covariant: an achiral rule may use
+   the odd pattern channel, paired with the odd value direction. The
+   bare-sign rule `R1 = frame_sign` transforms by the determinant
+   character (chiral). The twist is load-bearing: under the untwisted
+   action `R0` is chiral too. And the **readable scalar part of the
+   achiral odd channel vanishes identically** (`Re R0 = 0` on the whole
+   orbit): achiral rules can carry the oriented-frame structure only in
+   the direction that scalar readout cannot see.
+
+5. **Dichotomy and theta-seed equivalence (Theorem 5).** A chiral rule
+   comes in a supplied-structure-indistinguishable pair `{R1, -R1}` (both
+   fixed by every proper element, exchanged by `P`): fixing one is a
+   one-bit selection no supplied structure determines. That bit is the
+   theta-seed bit: the chiral rule's sign makes the frame-dependent
+   density of the theta slot frame-invariant and nonzero (seed
+   constructible), flipping the frame alone or the rule alone flips it,
+   and flipping both restores it — **one orientation bit total**, shared
+   between the rule and the seed. Conversely, an achiral rule supplies no
+   seed sign: its readable odd part is identically zero and swap-closed
+   pattern ensembles sum the chiral channel to zero exactly.
+
+**Classification summary.** Either the framework's fixed rule is achiral —
+in which case full-cubic covariance is derived, no orientation exists at
+rule level, and the theta-slot conclusions proceed import-free — or the
+rule is chiral, in which case it necessarily carries an
+orientation-encoding content channel — impossible at openness level,
+minimally the handed bi-coloring at three condition values, canonically
+the oriented frame at three contents plus openness — and the choice
+within its pair is exactly one orientation-odd import, the same single
+bit the theta seed needs. One bit is in question anywhere in this sector,
+and this note locates where it can live.
+
+## Authorities and premises
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) — quoted:
+  the Admissibility sentences ("one fixed nearest-neighbor admissibility
+  rule, covariant under lattice translations and proper cubic rotations";
+  "For each site, the available possibilities are determined by, and vary
+  with, the nearest-neighbor conditions"); the Lattice axiom's proper
+  cubic rotations; the Qubit `Cl(3,0)` equivalence clause; the Record
+  readout sentence ("Only records are readable. A readout value is
+  determined by record content alone", scalar additive readout); the
+  Qualification's law sentence ("A law privileges no states. Its domain is
+  a supplied condition...").
+- [`READING_NOTE_FINAL_DERIVATIONS_MOTION_CLOSURE_BOUNDED_NOTE_2026-07-02.md`](READING_NOTE_FINAL_DERIVATIONS_MOTION_CLOSURE_BOUNDED_NOTE_2026-07-02.md)
+  — condition typing: the condition as a predicate on states with record
+  absence included (openness is a condition value).
+- [`THETA_4D_CARRIER_FLUX_COHOMOLOGY_INTERSECTION_PAIRING_CLOSED_BRANCH_AND_DEFECT_CLOSURE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md`](THETA_4D_CARRIER_FLUX_COHOMOLOGY_INTERSECTION_PAIRING_CLOSED_BRANCH_AND_DEFECT_CLOSURE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md)
+  — the theta-slot pairing whose frame-dependent density Theorem 5
+  transports to.
+- [`THETA_LINK_STAR_GLUING_FRAME_CORRELATION_PAIR_COMPOSITE_DAGGER_EVENNESS_AND_ODD_BRANCH_PHASE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md`](THETA_LINK_STAR_GLUING_FRAME_CORRELATION_PAIR_COMPOSITE_DAGGER_EVENNESS_AND_ODD_BRANCH_PHASE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md)
+  — evenness of supplied pair reads (the readable-sector face of
+  Theorem 4's vanishing).
+- The antilinear improper action on the one-site algebra is carried from
+  the in-review native orientation analysis (prose reference only, not a
+  dependency edge); its use here is confined to the value-twist
+  definition, re-earned in miniature by the runner (`sigma_2`-conjugation
+  sends each Clifford generator to its negative and is antilinear).
+
+## Theorem statements and proofs
+
+### Theorem 1 (the improper question is one central bit)
+
+`O_h = G+ x {1, P}` with `P = -I` central; the action on the six axis
+directions is faithful; the antipodal permutation is not proper-realizable.
+
+*Proof.* `P` commutes with every signed permutation; the direction action
+is faithful because an orthogonal map fixing all six axis vectors is the
+identity; if a proper `g` induced the antipodal permutation then `g P`
+would induce the identity, forcing `g = P`, a contradiction. Runner:
+A1-A4, including the unique factorization `g = g+ P^eps`.
+
+### Theorem 2 (openness achirality)
+
+Every proper-covariant rule depending only on the recorded/open pattern of
+the six neighbors is covariant under the full cubic group.
+
+*Proof.* Exhaustive: each of the 64 two-letter colorings is
+proper-equivalent to its `P`-image (B1; Burnside cross-check 10 = 10). A
+`G+`-invariant function on a set where `P` preserves every `G+`-orbit is
+`G`-invariant. Content-blind conditions cannot carry chirality.
+
+### Theorem 3 (chirality threshold and the minimal/canonical channels)
+
+At `k = 2` there is no chiral pair (Theorem 2); at `k = 3` there is
+exactly one, whose members are the handed fully-mixed patterns (every
+axis bi-colored, every value used twice); at `k = 4` the sector grows
+(difference 20) and contains the oriented-frame coloring as the canonical
+carrier; the frame sign spans the `P`-odd proper-invariant functions on
+the canonical chiral orbit.
+
+*Proof.* Burnside differences 57 - 56 = 1 and 240 - 220 = 20, each
+cross-checked by direct orbit enumeration, with the `k = 3`
+representative's structure gated (every axis bi-colored, value counts
+2/2/2) (B2-B3); the oriented-frame witness lies in a `k = 4` chiral pair
+and its `P`-image is not reached by any of the 24 proper elements
+(B4-B5); the frame sign is proper-invariant, `P`-odd, and the odd
+projector on the two-dimensional proper-invariant function space of the
+canonical orbit has rank one with the sign as its image (C1-C2).
+
+### Theorem 4 (antilinear pairing law)
+
+With improper elements acting on values by conjugation:
+`R0 = i x frame_sign` is `G`-covariant (achiral); `R1 = frame_sign`
+transforms by the determinant character (chiral); under the untwisted
+action `R0` is chiral (the twist is load-bearing); and `Re R0 = 0`
+identically — the achiral realization of the oriented-frame channel is
+invisible to scalar readout.
+
+*Proof.* Direct computation over the full 48-element group on the whole
+chiral orbit (D0-D4). Odd pattern times odd value direction is even
+because conjugation flips `i`; that flip is exactly what the improper
+action supplies.
+
+### Theorem 5 (one bit, shared)
+
+A chiral fixed rule is a selection within the `P`-exchanged pair
+`{R1, -R1}` that no supplied transformation determines (E1). The selected
+sign transports to the theta slot: `s x D(frame)` is invariant under the
+simultaneous `P`-flip of rule witness and frame, and nonzero on generic
+fluxes (E2); flipping either alone flips it, flipping both restores it —
+one bit total (E4). An achiral rule supplies no such sign: readable odd
+part identically zero, swap-closed ensembles sum the channel to zero (E3).
+
+## What this note does and does not claim
+
+- **It does not determine the framework's physical rule.** The axiom fixes
+  one rule; whether that rule is achiral or chiral is a property this
+  note classifies but does not decide. What it derives: where chirality
+  could live (only in content-level structure, minimally the
+  oriented-frame channel), and what it would cost (one orientation-odd
+  bit, identical to the theta-seed bit).
+- **The condition-alphabet models are named models.** Identifying the
+  physical condition alphabet (how many record contents the admissibility
+  rule distinguishes) is downstream content; the classification is exact
+  for each `k` and the structural conclusions (openness achirality,
+  oriented-frame minimality, the pairing law) are alphabet-graded
+  statements.
+- **No fermion-sector claim.** That any derived rule chirality would also
+  surface in fermion-sector structure is left entirely to that sector's
+  own lane; nothing here asserts or constrains it beyond the shared-bit
+  bookkeeping at rule level.
+- The antilinear twist premise is carried from the in-review companion
+  (prose only) and re-earned in miniature; Theorem 4's pairing statement
+  is unconditional for the stated value action.
+
+## Residuals and next paths
+
+1. **Physical alphabet identification**: how many neighbor contents the
+   fixed rule distinguishes — the classification says nothing chiral can
+   happen below three; a derivation pinning the alphabet would immediately
+   grade the rule's chirality question.
+2. **Achirality derivation route**: if the rule's dependence is derivably
+   openness-graded (content-blind at the covariance level), Theorem 2
+   would upgrade "proper covariance" to full-cubic covariance as a
+   theorem — the next path this opens on the covariance side.
+3. **Chirality route accounting**: any future proposal of a chiral rule
+   now has a named price — the oriented-frame channel and one
+   orientation-odd bit shared with the theta seed — so proposals can be
+   audited against exactly that carrier.
+4. **Theta-chain wiring**: when the in-review orientation and Z2 companions
+   land, Theorem 5's transport statement connects the rule-level bit to
+   the theta branch table on cited premises.

--- a/logs/runner-cache/admissibility_rule_covariance_extension_classification_2026_07_03.txt
+++ b/logs/runner-cache/admissibility_rule_covariance_extension_classification_2026_07_03.txt
@@ -1,0 +1,32 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_rule_covariance_extension_classification_2026_07_03.py
+runner_sha256: d1ca040d6fa52483e20b695d20ec42e9d9d77361ba89f39f79431c6ad90e587d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.33
+status: ok
+----- stdout -----
+PASS: A1 inversion central | generated=48; det(P)=-1
+PASS: A2 direction action faithful | distinct direction permutations=48
+PASS: A3 inversion outside proper image | proper image size=24; P_perm=(1, 0, 3, 2, 5, 4)
+PASS: A4 proper-times-inversion factorization | factorized=48; proper=24
+PASS: B1 openness patterns achiral | Burnside proper/full=10/10; direct proper/full=10/10; p-related=64
+PASS: B2 ternary chiral pair count | Burnside proper/full=57/56; difference=1; direct chiral orbit sizes=[24, 24]; representative=(0, 1, 0, 2, 1, 2) (every axis bi-colored, every color used twice)
+PASS: B3 quaternary chiral pair count | Burnside proper/full=240/220; difference=20; direct chiral pairs=20
+PASS: B4 oriented frame witness membership | witness=(1, 0, 2, 0, 3, 0); k=4 orbit pair=(65, 72)
+PASS: B5 witness P-image separation | proper maps found=0
+PASS: C1 frame_sign proper split | full orbit=48; proper split=24/24
+PASS: C2 chiral orbit odd channel dimension | proper-invariant rank=2; P-odd factors=0.5,-0.5
+PASS: D0 antilinear value premise | Pauli generators map to their negatives; scalar coefficients conjugate
+PASS: D1 twisted imaginary sign invariant | group elements checked=48; orbit size=48
+PASS: D2 real sign determinant character | group elements checked=48; orbit size=48
+PASS: D3 achiral scalar readout zero | nonzero imaginary example=(0, 1, 0, 2, 0, 3)
+PASS: D4 twist load-bearing | P under untwisted action sends R0 to -R0 on 48 colorings
+PASS: E1 chiral rule pair exchange | proper-fixed pair is distinct and exchanged by inversion
+PASS: E2 theta seed transport | draws=50; nonzero D=49; signs=1/-1
+PASS: E3 scalar and pair cancellation | pair sum=0; readable real zero=True
+PASS: E4 one orientation bit | draws=20; base sign=1; flipped sign=-1
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_rule_covariance_extension_classification_2026_07_03.py
+++ b/scripts/admissibility_rule_covariance_extension_classification_2026_07_03.py
@@ -1,0 +1,515 @@
+"""Class-A runner for admissibility-rule covariance-extension classification.
+
+Sections:
+A. group structure
+B. Burnside classification of condition patterns
+C. sign channel on the chiral orbit
+D. antilinear value twist and pairing law
+E. dichotomy and theta-seed transport
+
+Expected close: TOTAL: PASS=20 FAIL=0
+"""
+
+import itertools
+import numpy as np
+
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if bool(cond):
+        PASS += 1
+        status = "PASS"
+    else:
+        FAIL += 1
+        status = "FAIL"
+    suffix = f" | {detail}" if detail else ""
+    print(f"{status}: {name}{suffix}")
+
+
+def det3(M):
+    return int(
+        M[0, 0] * (M[1, 1] * M[2, 2] - M[1, 2] * M[2, 1])
+        - M[0, 1] * (M[1, 0] * M[2, 2] - M[1, 2] * M[2, 0])
+        + M[0, 2] * (M[1, 0] * M[2, 1] - M[1, 1] * M[2, 0])
+    )
+
+
+def mat_key(M):
+    return tuple(int(x) for x in M.reshape(-1))
+
+
+DIRS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {d: i for i, d in enumerate(DIRS)}
+
+
+def dperm(M):
+    perm = []
+    for d in DIRS:
+        image = tuple(int(x) for x in M @ np.array(d, dtype=int))
+        perm.append(DIR_INDEX[image])
+    return tuple(perm)
+
+
+def act_col(perm, col):
+    out = [None] * len(col)
+    for i, j in enumerate(perm):
+        out[j] = col[i]
+    return tuple(out)
+
+
+def inv_perm(perm):
+    out = [None] * len(perm)
+    for i, j in enumerate(perm):
+        out[j] = i
+    return tuple(out)
+
+
+records = []
+seen_mats = set()
+for perm in itertools.permutations(range(3)):
+    for signs in itertools.product((-1, 1), repeat=3):
+        M = np.zeros((3, 3), dtype=int)
+        for row, col in enumerate(perm):
+            M[row, col] = signs[row]
+        key = mat_key(M)
+        if key not in seen_mats:
+            seen_mats.add(key)
+            records.append({"M": M, "key": key, "det": det3(M), "perm": dperm(M)})
+
+mats = [r["M"] for r in records]
+proper_records = [r for r in records if r["det"] == 1]
+full_perms = [r["perm"] for r in records]
+proper_perms = [r["perm"] for r in proper_records]
+I = np.eye(3, dtype=int)
+P = -I
+P_key = mat_key(P)
+P_perm = dperm(P)
+
+
+def cycle_count(perm):
+    seen = [False] * len(perm)
+    cycles = 0
+    for start in range(len(perm)):
+        if not seen[start]:
+            cycles += 1
+            here = start
+            while not seen[here]:
+                seen[here] = True
+                here = perm[here]
+    return cycles
+
+
+def burnside_orbits(perms, k):
+    total = sum(k ** cycle_count(perm) for perm in perms)
+    assert total % len(perms) == 0
+    return total // len(perms)
+
+
+def all_colorings(k):
+    return list(itertools.product(range(k), repeat=len(DIRS)))
+
+
+def direct_orbits(perms, k):
+    unseen = set(all_colorings(k))
+    orbits = []
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in perms}
+        orbits.append(orbit)
+        unseen -= orbit
+    return orbits
+
+
+def orbit_ids(orbits):
+    return {col: i for i, orbit in enumerate(orbits) for col in orbit}
+
+
+def proper_equiv_to_p_image(col):
+    p_col = act_col(P_perm, col)
+    return any(act_col(perm, col) == p_col for perm in proper_perms)
+
+
+def chiral_pairs(proper_orbits):
+    ids = orbit_ids(proper_orbits)
+    pairs = []
+    seen = set()
+    for i, orbit in enumerate(proper_orbits):
+        image_id = ids[act_col(P_perm, next(iter(orbit)))]
+        if image_id != i:
+            pair = tuple(sorted((i, image_id)))
+            if pair not in seen:
+                seen.add(pair)
+                pairs.append(pair)
+    return pairs
+
+
+def frame_sign(col):
+    rows = []
+    for color in (1, 2, 3):
+        positions = [i for i, value in enumerate(col) if value == color]
+        if len(positions) != 1:
+            return 0
+        rows.append(DIRS[positions[0]])
+    return det3(np.array(rows, dtype=int))
+
+
+def frame_from_col(col):
+    rows = []
+    for color in (1, 2, 3):
+        positions = [i for i, value in enumerate(col) if value == color]
+        assert len(positions) == 1
+        rows.append(DIRS[positions[0]])
+    return tuple(rows)
+
+
+def transform_value(R, perm, det, col, twisted=True):
+    value = R(act_col(inv_perm(perm), col))
+    if twisted and det == -1:
+        value = np.conjugate(value)
+    return value
+
+
+central = all(np.array_equal(P @ M, M @ P) for M in mats)
+check(
+    "A1 inversion central",
+    len(records) == len(seen_mats) and P_key in seen_mats and central,
+    f"generated={len(records)}; det(P)={det3(P)}",
+)
+
+check(
+    "A2 direction action faithful",
+    len(set(full_perms)) == len(records),
+    f"distinct direction permutations={len(set(full_perms))}",
+)
+
+check(
+    "A3 inversion outside proper image",
+    P_perm not in set(proper_perms),
+    f"proper image size={len(set(proper_perms))}; P_perm={P_perm}",
+)
+
+factorizations = {}
+for g_plus in proper_records:
+    for eps in (0, 1):
+        factor = g_plus["M"] @ (P if eps else I)
+        key = mat_key(factor)
+        if key not in factorizations:
+            factorizations[key] = []
+        factorizations[key].append((g_plus["key"], eps))
+
+check(
+    "A4 proper-times-inversion factorization",
+    set(factorizations) == seen_mats and all(len(v) == 1 for v in factorizations.values()),
+    f"factorized={len(factorizations)}; proper={len(proper_records)}",
+)
+
+b2_proper = burnside_orbits(proper_perms, 2)
+b2_full = burnside_orbits(full_perms, 2)
+d2_proper = direct_orbits(proper_perms, 2)
+d2_full = direct_orbits(full_perms, 2)
+all_binary_p_related = all(proper_equiv_to_p_image(col) for col in all_colorings(2))
+check(
+    "B1 openness patterns achiral",
+    b2_proper == b2_full
+    and len(d2_proper) == b2_proper
+    and len(d2_full) == b2_full
+    and all_binary_p_related,
+    (
+        f"Burnside proper/full={b2_proper}/{b2_full}; "
+        f"direct proper/full={len(d2_proper)}/{len(d2_full)}; "
+        f"p-related={sum(1 for col in all_colorings(2) if proper_equiv_to_p_image(col))}"
+    ),
+)
+
+b3_proper = burnside_orbits(proper_perms, 3)
+b3_full = burnside_orbits(full_perms, 3)
+diff3 = b3_proper - b3_full
+d3_proper = direct_orbits(proper_perms, 3)
+d3_full = direct_orbits(full_perms, 3)
+ids3 = orbit_ids(d3_proper)
+not_p_related3 = [col for col in all_colorings(3) if not proper_equiv_to_p_image(col)]
+not_p_orbits3 = sorted({ids3[col] for col in not_p_related3})
+pairs3 = chiral_pairs(d3_proper)
+sizes3 = [len(d3_proper[i]) for i in not_p_orbits3]
+rep3 = min(d3_proper[not_p_orbits3[0]])
+rep3_axis_mixed = all(rep3[2 * axis] != rep3[2 * axis + 1] for axis in range(3))
+rep3_color_counts = sorted(rep3.count(color) for color in range(3))
+check(
+    "B2 ternary chiral pair count",
+    diff3 == 1
+    and len(d3_proper) == b3_proper
+    and len(d3_full) == b3_full
+    and len(not_p_related3) > 0
+    and len(not_p_orbits3) == 2
+    and len(pairs3) == diff3
+    and rep3_axis_mixed
+    and rep3_color_counts == [2, 2, 2],
+    (
+        f"Burnside proper/full={b3_proper}/{b3_full}; "
+        f"difference={diff3}; direct chiral orbit sizes={sizes3}; "
+        f"representative={rep3} (every axis bi-colored, every color used twice)"
+    ),
+)
+
+b4_proper = burnside_orbits(proper_perms, 4)
+b4_full = burnside_orbits(full_perms, 4)
+diff4 = b4_proper - b4_full
+d4_proper = direct_orbits(proper_perms, 4)
+d4_full = direct_orbits(full_perms, 4)
+ids4 = orbit_ids(d4_proper)
+pairs4 = chiral_pairs(d4_proper)
+check(
+    "B3 quaternary chiral pair count",
+    diff4 > 1
+    and len(d4_proper) == b4_proper
+    and len(d4_full) == b4_full
+    and len(pairs4) == diff4,
+    (
+        f"Burnside proper/full={b4_proper}/{b4_full}; "
+        f"difference={diff4}; direct chiral pairs={len(pairs4)}"
+    ),
+)
+
+witness = (1, 0, 2, 0, 3, 0)
+p_witness = act_col(P_perm, witness)
+witness_orbit_id = ids4[witness]
+witness_pair = [pair for pair in pairs4 if witness_orbit_id in pair]
+check(
+    "B4 oriented frame witness membership",
+    len(witness_pair) == 1 and frame_sign(witness) == 1,
+    f"witness={witness}; k=4 orbit pair={witness_pair[0] if witness_pair else None}",
+)
+
+proper_maps_witness_to_p = [perm for perm in proper_perms if act_col(perm, witness) == p_witness]
+check(
+    "B5 witness P-image separation",
+    len(proper_maps_witness_to_p) == 0,
+    f"proper maps found={len(proper_maps_witness_to_p)}",
+)
+
+full_witness_orbit = {act_col(perm, witness) for perm in full_perms}
+proper_witness_orbit = {act_col(perm, witness) for perm in proper_perms}
+proper_p_witness_orbit = {act_col(perm, p_witness) for perm in proper_perms}
+frame_sign_proper_fixed = all(
+    frame_sign(act_col(perm, col)) == frame_sign(col)
+    for perm in proper_perms
+    for col in full_witness_orbit
+)
+check(
+    "C1 frame_sign proper split",
+    len(full_witness_orbit) == len(full_perms)
+    and proper_witness_orbit.isdisjoint(proper_p_witness_orbit)
+    and proper_witness_orbit | proper_p_witness_orbit == full_witness_orbit
+    and all(frame_sign(col) == 1 for col in proper_witness_orbit)
+    and all(frame_sign(col) == -1 for col in proper_p_witness_orbit)
+    and frame_sign_proper_fixed,
+    (
+        f"full orbit={len(full_witness_orbit)}; "
+        f"proper split={len(proper_witness_orbit)}/{len(proper_p_witness_orbit)}"
+    ),
+)
+
+orbit_list = sorted(full_witness_orbit)
+orbit_index = {col: i for i, col in enumerate(orbit_list)}
+
+
+def transform_function_vector(vec, perm):
+    inv = inv_perm(perm)
+    return np.array([vec[orbit_index[act_col(inv, col)]] for col in orbit_list], dtype=float)
+
+
+def average_under_proper(vec):
+    out = np.zeros(len(orbit_list), dtype=float)
+    for perm in proper_perms:
+        out += transform_function_vector(vec, perm)
+    return out / len(proper_perms)
+
+
+projector_columns = []
+for col_index in range(len(orbit_list)):
+    basis = np.zeros(len(orbit_list), dtype=float)
+    basis[col_index] = 1.0
+    projector_columns.append(average_under_proper(basis))
+proper_projector = np.column_stack(projector_columns)
+projector_rank = np.linalg.matrix_rank(proper_projector, tol=1e-9)
+ind_witness = np.array([1.0 if col in proper_witness_orbit else 0.0 for col in orbit_list])
+ind_p_witness = np.array([1.0 if col in proper_p_witness_orbit else 0.0 for col in orbit_list])
+sign_vec = np.array([float(frame_sign(col)) for col in orbit_list])
+odd_witness = 0.5 * (ind_witness - transform_function_vector(ind_witness, P_perm))
+odd_p_witness = 0.5 * (ind_p_witness - transform_function_vector(ind_p_witness, P_perm))
+avg_odd_witness = average_under_proper(odd_witness)
+avg_odd_p_witness = average_under_proper(odd_p_witness)
+sign_norm = float(np.dot(sign_vec, sign_vec))
+factor_witness = float(np.dot(avg_odd_witness, sign_vec) / sign_norm)
+factor_p_witness = float(np.dot(avg_odd_p_witness, sign_vec) / sign_norm)
+check(
+    "C2 chiral orbit odd channel dimension",
+    projector_rank == 2
+    and np.allclose(average_under_proper(ind_witness), ind_witness)
+    and np.allclose(average_under_proper(ind_p_witness), ind_p_witness)
+    and np.allclose(avg_odd_witness, factor_witness * sign_vec)
+    and np.allclose(avg_odd_p_witness, factor_p_witness * sign_vec)
+    and factor_witness != 0.0
+    and factor_witness == -factor_p_witness,
+    f"proper-invariant rank={projector_rank}; P-odd factors={factor_witness},{factor_p_witness}",
+)
+
+sigma1 = np.array([[0, 1], [1, 0]], dtype=complex)
+sigma2 = np.array([[0, -1j], [1j, 0]], dtype=complex)
+sigma3 = np.array([[1, 0], [0, -1]], dtype=complex)
+
+
+def spin_flip(X):
+    return sigma2 @ np.conjugate(X) @ sigma2
+
+
+alpha = 1 + 2j
+beta = -3 + 1j
+X = sigma1 + 2 * sigma2
+Y = sigma3 - sigma1
+check(
+    "D0 antilinear value premise",
+    all(np.allclose(spin_flip(sigma), -sigma) for sigma in (sigma1, sigma2, sigma3))
+    and np.allclose(spin_flip(alpha * X + beta * Y), np.conjugate(alpha) * spin_flip(X) + np.conjugate(beta) * spin_flip(Y)),
+    "Pauli generators map to their negatives; scalar coefficients conjugate",
+)
+
+
+def R0(col):
+    return 1j * frame_sign(col)
+
+
+def R1(col):
+    return frame_sign(col)
+
+
+check(
+    "D1 twisted imaginary sign invariant",
+    all(
+        np.allclose(transform_value(R0, rec["perm"], rec["det"], col, twisted=True), R0(col))
+        for rec in records
+        for col in full_witness_orbit
+    ),
+    f"group elements checked={len(records)}; orbit size={len(full_witness_orbit)}",
+)
+
+check(
+    "D2 real sign determinant character",
+    all(
+        np.allclose(transform_value(R1, rec["perm"], rec["det"], col, twisted=True), rec["det"] * R1(col))
+        for rec in records
+        for col in full_witness_orbit
+    ),
+    f"group elements checked={len(records)}; orbit size={len(full_witness_orbit)}",
+)
+
+r0_real_zero = all(np.real(R0(col)) == 0 for col in full_witness_orbit)
+r0_imag_nonzero = [col for col in orbit_list if np.imag(R0(col)) != 0]
+check(
+    "D3 achiral scalar readout zero",
+    r0_real_zero and len(r0_imag_nonzero) > 0,
+    f"nonzero imaginary example={r0_imag_nonzero[0] if r0_imag_nonzero else None}",
+)
+
+check(
+    "D4 twist load-bearing",
+    all(np.allclose(transform_value(R0, P_perm, det3(P), col, twisted=False), -R0(col)) for col in full_witness_orbit)
+    and any(not np.allclose(transform_value(R0, P_perm, det3(P), col, twisted=False), R0(col)) for col in full_witness_orbit),
+    f"P under untwisted action sends R0 to -R0 on {len(full_witness_orbit)} colorings",
+)
+
+
+def P_R1(col):
+    return transform_value(R1, P_perm, det3(P), col, twisted=True)
+
+
+check(
+    "E1 chiral rule pair exchange",
+    all(
+        np.allclose(transform_value(R1, rec["perm"], rec["det"], col, twisted=True), R1(col))
+        for rec in proper_records
+        for col in full_witness_orbit
+    )
+    and all(
+        np.allclose(transform_value(P_R1, rec["perm"], rec["det"], col, twisted=True), P_R1(col))
+        for rec in proper_records
+        for col in full_witness_orbit
+    )
+    and any(not np.allclose(R1(col), P_R1(col)) for col in full_witness_orbit)
+    and all(np.allclose(P_R1(col), -R1(col)) for col in full_witness_orbit)
+    and all(
+        np.allclose(transform_value(P_R1, P_perm, det3(P), col, twisted=True), R1(col))
+        for col in full_witness_orbit
+    ),
+    "proper-fixed pair is distinct and exchanged by inversion",
+)
+
+
+def frame_orientation(frame):
+    return det3(np.array(frame, dtype=int))
+
+
+def density_for_frame(draw, frame):
+    e = np.array(draw[:3], dtype=int)
+    raw_b = np.array(draw[3:], dtype=int)
+    b_frame = frame_orientation(frame) * raw_b
+    return int(np.dot(e, b_frame))
+
+
+witness_frame = frame_from_col(witness)
+p_witness_frame = frame_from_col(p_witness)
+s_witness = R1(witness)
+s_p_witness = R1(p_witness)
+rng = np.random.default_rng(3)
+draws50 = rng.integers(-5, 6, size=(50, 6))
+base_D50 = [density_for_frame(draw, witness_frame) for draw in draws50]
+p_D50 = [density_for_frame(draw, p_witness_frame) for draw in draws50]
+nonzero_D50 = sum(1 for value in base_D50 if value != 0)
+check(
+    "E2 theta seed transport",
+    frame_orientation(witness_frame) == s_witness
+    and frame_orientation(p_witness_frame) == s_p_witness
+    and all(s_witness * d0 == s_p_witness * d1 for d0, d1 in zip(base_D50, p_D50))
+    and nonzero_D50 >= 35,
+    f"draws={len(draws50)}; nonzero D={nonzero_D50}; signs={s_witness}/{s_p_witness}",
+)
+
+check(
+    "E3 scalar and pair cancellation",
+    R1(witness) + R1(p_witness) == 0 and r0_real_zero,
+    f"pair sum={R1(witness) + R1(p_witness)}; readable real zero={r0_real_zero}",
+)
+
+draws20 = rng.integers(-5, 6, size=(20, 6))
+four_way_ok = True
+for draw in draws20:
+    d_base = density_for_frame(draw, witness_frame)
+    d_frame_flip = density_for_frame(draw, p_witness_frame)
+    prod_base = s_witness * d_base
+    prod_frame_flip = s_witness * d_frame_flip
+    prod_witness_flip = s_p_witness * d_base
+    prod_both_flip = s_p_witness * d_frame_flip
+    four_way_ok = four_way_ok and d_frame_flip == -d_base
+    four_way_ok = four_way_ok and s_p_witness == -s_witness
+    four_way_ok = four_way_ok and prod_frame_flip == -prod_base
+    four_way_ok = four_way_ok and prod_witness_flip == -prod_base
+    four_way_ok = four_way_ok and prod_both_flip == prod_base
+
+check(
+    "E4 one orientation bit",
+    four_way_ok,
+    f"draws={len(draws20)}; base sign={s_witness}; flipped sign={s_p_witness}",
+)
+
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")


### PR DESCRIPTION
## Summary

Consolidation block: the Admissibility axiom names PROPER covariance only —
whether the fixed rule is also improper-covariant (achiral) is an unstated
property. This triple classifies that property exactly on named
condition-alphabet models and prices both branches.

- **Theorem 1 (structure):** O_h = G+ x {1, P} with inversion P central,
  faithful on the 6 directions, antipodal permutation not
  proper-realizable — the improper question is one central bit.
- **Theorem 2 (openness achirality):** with content-blind conditions
  (recorded/open), EVERY coloring of the 6 neighbor directions is
  proper-equivalent to its P-image (exhaustive over 64; Burnside 10 = 10).
  A chiral rule cannot live at the openness level — chirality requires
  distinguishable record contents.
- **Theorem 3 (chirality threshold):** at k = 3 condition values there is
  EXACTLY ONE chiral pair (Burnside 57 vs 56, direct-enumeration
  cross-check) — the handed fully-mixed patterns (every axis bi-colored,
  every value used twice; representative runner-anchored). At k = 4
  (three contents + openness): 20 pairs, including the CANONICAL carrier —
  the oriented frame (+x,+y,+z distinctly colored, rest open), verified
  chiral directly. The frame sign (det of the labeled direction triple) is
  proper-invariant, P-odd, and spans the P-odd invariants on the canonical
  chiral orbit.
- **Theorem 4 (antilinear pairing law):** with improper elements acting on
  values by conjugation (the Cl(3,0) action, re-earned in miniature),
  i x frame_sign is fully G-covariant — achiral rules CAN carry the
  oriented-frame channel, but only in the direction scalar readout cannot
  see (Re part identically zero). Bare frame_sign transforms by the
  determinant character (chiral). The twist is load-bearing (discriminating
  check: untwisted action makes both chiral).
- **Theorem 5 (one bit, shared):** a chiral fixed rule = a selection within
  the P-exchanged pair {R, -R} that no supplied structure determines; the
  selected sign makes the theta-slot frame density frame-invariant and
  nonzero (seed constructible); flipping rule or frame alone flips it,
  both restores it — the rule-level bit and the theta-seed bit are the
  SAME single orientation bit. Achiral rules supply no seed sign.

Honest scoping: classification only — does NOT determine the physical
rule's chirality; condition alphabets are named models (physical alphabet
identification is downstream); no fermion-sector claims; antilinear twist
premise carried from the in-review companion (prose only, re-earned in
miniature).

## Changes

- 1 note: `docs/ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`
- 1 runner: `scripts/admissibility_rule_covariance_extension_classification_2026_07_03.py`
- 1 cache: `logs/runner-cache/admissibility_rule_covariance_extension_classification_2026_07_03.txt`

## Test plan

- Runner re-run in a clean worktree off origin/main: `TOTAL: PASS=20 FAIL=0`
- Cache regenerated via `runner_cache.execute_runner`/`write_cache`
- Axiom quotes verified against the memo at branch time; reviewer
  reconciles at landing as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
