### PR TITLE
feat(admissibility): condition-alphabet identification — threshold met, no odd channel below vector triples, orientation-free at every size

### DIFF
--- a/docs/CONDITION_ALPHABET_IDENTIFICATION_COUPLED_CUBIC_ACTION_THRESHOLD_MET_NO_ODD_CHANNEL_BELOW_TRIPLES_BOUNDED_THEOREM_NOTE_2026-07-04.md
+++ b/docs/CONDITION_ALPHABET_IDENTIFICATION_COUPLED_CUBIC_ACTION_THRESHOLD_MET_NO_ODD_CHANNEL_BELOW_TRIPLES_BOUNDED_THEOREM_NOTE_2026-07-04.md
@@ -1,4 +1,4 @@
-# The Condition Alphabet Identified: Openness Plus Possibility Content Transforming as (Even Scalar, Pseudoscalar, Polar Vector, Axial Vector) Under the Coupled Cubic Action — the Alphabet Meets the Chirality Threshold (the Small-Alphabet Shortcut Is a Route No-Go) Yet Supplies No Odd Channel Below Vector Triples, and Every Chiral Channel Is the Same Single Orientation Bit (Bounded Theorem + Route No-Go)
+# The Condition Domain Identified: Openness Plus Possibility Content Transforming as (Even Scalar, Pseudoscalar, Polar Vector, Axial Vector) Under the Coupled Cubic Action — the DOMAIN-Level Alphabet Meets the Chirality Threshold (the Domain-Level Small-Alphabet Shortcut Is a Route No-Go; the REALIZED Record-Content Alphabet Is Rule-Generated and Remains Open) Yet No Odd Channel Exists Below Vector Triples, and Every Chiral Channel Is the Same Single Orientation Bit (Bounded Theorem + Route No-Go)
 
 **Date:** 2026-07-04
 **Type:** bounded_theorem
@@ -63,16 +63,25 @@ covariant structure is now exact:
    proper rotations an `SU(2)` element is built by axis-angle and its
    adjoint reproduces the spatial matrix exactly.
 
-2. **The alphabet meets the threshold — the small-alphabet shortcut is a
-   route no-go (Theorem 2).** The alignment invariant `v . d` (content
-   polar part against neighbor direction) is invariant under the joint
-   action of all 48 elements and separates arbitrarily many contents
-   (five witnesses reported). The covariant condition alphabet is
-   infinite, so the in-review classification's hoped-for shortcut — "the
-   physical alphabet stays below three values, hence the rule is
-   automatically achiral" — is **not available**. This is recorded as an
-   honest route no-go. At the same time, every such separating invariant
-   is even: alphabet size by itself supplies no chirality.
+2. **The domain-level alphabet meets the threshold — the domain-level
+   small-alphabet shortcut is a route no-go (Theorem 2).** The alignment
+   invariant `v . d` (content polar part against neighbor direction) is
+   invariant under the joint action of all 48 elements and separates
+   arbitrarily many contents (five witnesses reported). The covariant
+   condition DOMAIN — the space of conditions the fixed rule must be
+   defined over — supports a continuum of covariant distinctions, so the
+   shortcut "the rule's domain stays below three values, hence the rule
+   is automatically achiral" is **not available**. Recorded as an honest
+   route no-go, scoped to the domain level. **The realized alphabet is a
+   different object**: records are the only readable reality, a record
+   locks one *admissible* possibility (an element of the rule's
+   availability sets), and states are configurations of records generated
+   from the empty state — so the record contents that ever exist form a
+   rule-generated set that the axioms do not force to be infinite. Whether
+   the realized alphabet is small is an open, sharp question (see the
+   bootstrap residual below). At the same time, every separating
+   invariant above is even: alphabet size, at either level, supplies no
+   chirality.
 
 3. **No odd channel below vector triples (Theorem 3).** The exact sign-
    character multiplicities under the full cubic group are
@@ -106,13 +115,17 @@ covariant structure is now exact:
    data freely and absolute-orientation data never, and a chiral rule
    still costs exactly the one bit.
 
-**Identification summary.** The physical condition alphabet is
+**Identification summary.** The rule's condition DOMAIN is
 `{open} + state-geometry content` (even scalar + polar vector per
-content), infinite in covariant distinctions, orientation-free at every
-size. The chirality question for the fixed rule therefore cannot be
-settled by alphabet counting in either direction; it is settled, in both
-directions, by the same single orientation bit already localized on the
-gauge side — whose only content-level carriers are triple-product
+content), a continuum in covariant distinctions, orientation-free at
+every size. The REALIZED alphabet — the record contents that actually
+exist, which under the Record axiom are the only readable reality — is
+rule-generated from the empty state and is not identified here; its size
+is open. What is settled at every size, domain or realized: no odd
+channel exists below vector triples, relative orientation is free,
+absolute orientation is never supplied — so the chirality question for
+the fixed rule cannot be settled by alphabet counting in either
+direction, and its only content-level carriers are triple-product
 channels, now identified exactly.
 
 ## Authorities and premises
@@ -157,16 +170,21 @@ elements (A2). Hermiticity is preserved; pure states transform as polar
 vectors (A3); the pseudoscalar is the imaginary unit's coefficient and
 the readable scalar is even (A4).
 
-### Theorem 2 (threshold met; the small-alphabet shortcut is a route no-go)
+### Theorem 2 (domain-level threshold met; the domain-level shortcut is a route no-go)
 
 *Proof.* `(S v) . (S d) = v . d` for every signed permutation `S`
 (orthogonality), including improper ones — so alignment values are
 covariant, even, and separate a continuum of contents (five explicit
-witnesses, B1-B2). Any covariant rule may distinguish contents by these
+witnesses, B1-B2). Any covariant rule MAY distinguish contents by these
 values, so no finite bound — in particular the three-value chirality
-threshold — constrains the physical alphabet from below. The shortcut
-"alphabet below three, hence achiral" is a route no-go; the classification
-must run, and does run, through the channel structure instead.
+threshold — constrains the rule's condition domain from below. The
+domain-level shortcut "the domain has fewer than three values, hence
+achiral" is a route no-go; the classification must run, and does run,
+through the channel structure instead. **Scope**: this theorem bounds the
+domain, not the realized record-content set — the realized alphabet is
+generated by the fixed rule's availability sets from the empty state, and
+a small realized alphabet remains possible; nothing here forecloses a
+realized-level achirality argument.
 
 ### Theorem 3 (no odd channel below vector triples; uniqueness at triples)
 
@@ -194,9 +212,15 @@ and the mass-side determinant phase.
 
 ## What this note does and does not claim
 
-- **It does not determine the framework's fixed rule.** The alphabet is
-  identified; whether the rule uses a chiral channel remains the rule's
-  own property. What is now exact: the alphabet cannot settle the
+- **It does not determine the framework's fixed rule.** The condition
+  domain is identified; whether the rule uses a chiral channel remains
+  the rule's own property.
+- **It does not identify the realized alphabet.** Under the Record axiom
+  records are the only readable reality; realized contents are locked
+  admissible possibilities, generated by the fixed rule from the empty
+  state. Theorem 2's continuum is the rule's domain, not the realized
+  content set, and this note makes no claim that the realized alphabet is
+  infinite. What is now exact: the alphabet cannot settle the
   question by size (in either direction), the only content-level chiral
   carriers are triple-product channels, and their cost is the one
   already-localized orientation bit.
@@ -215,16 +239,26 @@ and the mass-side determinant phase.
 
 ## Residuals and next paths
 
-1. **Rule-dependence structure**: with the alphabet identified, the
-   remaining question about the fixed rule is which covariant channels
-   its dependence actually uses — openness pattern, alignment values,
+1. **Realized-alphabet bootstrap**: the empty state's all-open condition
+   pattern is invariant under the full cubic group, so the rule's first
+   availability set is proper-cubic-invariant as a set; proper-cubic
+   orbits on the content sphere are inversion-invariant exactly when the
+   orbit point is stabilized by an improper element (axes, corners, edge
+   midpoints, mirror-plane points), while generic 24-point orbits are
+   chiral and come in inversion-paired twins. So realized-alphabet
+   chirality at the first step reduces to whether the all-open
+   availability set contains an unpaired generic orbit — the same single
+   bit, now at the bootstrap level. Deriving the availability set's locus
+   class is the sharp next question the records-only reading opens.
+2. **Rule-dependence structure**: which covariant channels the fixed
+   rule's dependence actually uses — openness pattern, alignment values,
    relative orientations (all achiral-compatible), or a triple-product
    channel (chiral, costing the bit). Any derivation pinning the rule's
-   dependence class now grades the chirality question directly.
-2. **Coupled-action adjudication**: formal audit-lane treatment of the
+   dependence class grades the chirality question directly.
+3. **Coupled-action adjudication**: formal audit-lane treatment of the
    induced rotation action on contents as the presentation-supplied
    action (the named-model caveat above).
-3. **Theta-chain wiring**: with the in-review companions, this note's
+4. **Theta-chain wiring**: with the in-review companions, this note's
    Theorems 3-4 give the content-side face of the one-bit localization —
    the same bit from the rule side, the carrier side, and now the
    alphabet side.

--- a/docs/CONDITION_ALPHABET_IDENTIFICATION_COUPLED_CUBIC_ACTION_THRESHOLD_MET_NO_ODD_CHANNEL_BELOW_TRIPLES_BOUNDED_THEOREM_NOTE_2026-07-04.md
+++ b/docs/CONDITION_ALPHABET_IDENTIFICATION_COUPLED_CUBIC_ACTION_THRESHOLD_MET_NO_ODD_CHANNEL_BELOW_TRIPLES_BOUNDED_THEOREM_NOTE_2026-07-04.md
@@ -1,0 +1,230 @@
+# The Condition Alphabet Identified: Openness Plus Possibility Content Transforming as (Even Scalar, Pseudoscalar, Polar Vector, Axial Vector) Under the Coupled Cubic Action — the Alphabet Meets the Chirality Threshold (the Small-Alphabet Shortcut Is a Route No-Go) Yet Supplies No Odd Channel Below Vector Triples, and Every Chiral Channel Is the Same Single Orientation Bit (Bounded Theorem + Route No-Go)
+
+**Date:** 2026-07-04
+**Type:** bounded_theorem
+**Claim type:** bounded_theorem (exact transformation-law, separation, and
+character-multiplicity statements for the condition space assembled from
+named premises; one honest route no-go; not a determination of the
+framework's fixed rule, and no import is introduced).
+**Status authority:** independent audit lane only. This note does not set an
+audit verdict, edit registries, register primitives, change axioms, retire
+or re-grade any Tier-A admission, or claim Strong-CP closure.
+**Primary runner:**
+[`scripts/condition_alphabet_identification_orientation_free_2026_07_04.py`](../scripts/condition_alphabet_identification_orientation_free_2026_07_04.py)
+**Runner cache:**
+[`logs/runner-cache/condition_alphabet_identification_orientation_free_2026_07_04.txt`](../logs/runner-cache/condition_alphabet_identification_orientation_free_2026_07_04.txt)
+
+## Question
+
+An in-review classification of the admissibility rule's covariance
+extension showed that, over a finite condition alphabet, a chiral
+nearest-neighbor rule is impossible at two condition values
+(recorded/open) and first becomes possible at three, and that a chiral
+rule costs exactly one orientation-odd bit. The open item it named was
+**physical alphabet identification**: what condition space do the axioms
+actually supply, and does it reach the chirality threshold?
+
+The premises that fix the answer are all named. Conditions are each
+neighbor's record content or openness — the condition is a predicate on
+states with record absence included
+([`READING_NOTE_FINAL_DERIVATIONS_MOTION_CLOSURE_BOUNDED_NOTE_2026-07-02.md`](READING_NOTE_FINAL_DERIVATIONS_MOTION_CLOSURE_BOUNDED_NOTE_2026-07-02.md)).
+A record "locks exactly one admissible local possibility"; the one-site
+domain "has algebraic presentation `M_2(C)`" with "a `Cl(3,0)`-compatible
+real-algebra presentation ... equivalently" — the presentation whose
+generators are the three spatial directions
+([`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)); and a
+registered primitive fixes the realized-state (pointwise evaluation)
+reading of what a physical history locks
+([`REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md`](REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md)).
+Under the `Cl(3,0)` tie, the cubic rotations act on the one-site domain:
+complex-linearly for proper elements (the `SU(2)` adjoint matching the
+spatial rotation) and complex-antilinearly for improper ones — the coupled
+cubic action this note works under (named model; the presentation clause
+is what licenses it).
+
+## Answer
+
+The condition space is `{open}` together with possibility content whose
+covariant structure is now exact:
+
+1. **Content law (Theorem 1).** On the real basis
+   `X = a 1 + b (i1) + v . sigma + w . (i sigma)`, every cubic element `S`
+   (proper or improper) acts by
+
+   ```text
+   a -> a,   b -> det(S) b,   v -> S v,   w -> det(S) S w :
+   ```
+
+   an even scalar, a **pseudoscalar** (the imaginary unit's coefficient),
+   a **polar vector**, and an axial vector. Self-adjoint content — the
+   state reading of a locked possibility — has `b = w = 0` exactly, and a
+   pure state `(1 + n.sigma)/2` transforms as the polar vector
+   `n -> S n`. The lift is constructed, not assumed: for each of the 24
+   proper rotations an `SU(2)` element is built by axis-angle and its
+   adjoint reproduces the spatial matrix exactly.
+
+2. **The alphabet meets the threshold — the small-alphabet shortcut is a
+   route no-go (Theorem 2).** The alignment invariant `v . d` (content
+   polar part against neighbor direction) is invariant under the joint
+   action of all 48 elements and separates arbitrarily many contents
+   (five witnesses reported). The covariant condition alphabet is
+   infinite, so the in-review classification's hoped-for shortcut — "the
+   physical alphabet stays below three values, hence the rule is
+   automatically achiral" — is **not available**. This is recorded as an
+   honest route no-go. At the same time, every such separating invariant
+   is even: alphabet size by itself supplies no chirality.
+
+3. **No odd channel below vector triples (Theorem 3).** The exact sign-
+   character multiplicities under the full cubic group are
+
+   ```text
+   m(V) = 0,   m(V x V) = 0,   m(V x V x V) = 1,
+   m(dir6) = 0,   m(dir6 x V) = 0,   m(dir6 x V x V) = 1,
+   ```
+
+   so there is **no** parity-odd covariant of fewer than three vector
+   slots (directions or polar contents in any mix), and at three slots
+   the odd channel is unique — the sign-isotype projection of a generic
+   trilinear form is exactly proportional to the triple product
+   `epsilon`. The finite-alphabet threshold ("three condition values")
+   recurs on the continuum as a **vector-count threshold of three**. The
+   only single-content odd channel is the pseudoscalar `b`, and it is
+   doubly excluded: state content has `b = 0`, and real scalar readout is
+   blind to it (the readable scalar of a content is even under all 48).
+
+4. **One bit at every alphabet size (Theorem 4).** The unique odd content
+   channel — the triple product `det(v1, v2, v3)` — flips under every
+   improper element (it is conjugation-odd, the same class as the theta
+   seed and the mass-side determinant phase). Its paired realization
+   `i x det(v1, v2, v3)` is fully covariant under the antilinear value
+   twist (achiral) with identically zero readable part. The **relative**
+   orientation `det(d-triple) x det(v-triple)` is even — freely available
+   to achiral rules. Flipping contents alone or directions alone flips
+   the odd channels; flipping both restores them. So enlarging the
+   condition alphabet to its full physical size manufactures no
+   orientation datum: the condition space supplies relative-orientation
+   data freely and absolute-orientation data never, and a chiral rule
+   still costs exactly the one bit.
+
+**Identification summary.** The physical condition alphabet is
+`{open} + state-geometry content` (even scalar + polar vector per
+content), infinite in covariant distinctions, orientation-free at every
+size. The chirality question for the fixed rule therefore cannot be
+settled by alphabet counting in either direction; it is settled, in both
+directions, by the same single orientation bit already localized on the
+gauge side — whose only content-level carriers are triple-product
+channels, now identified exactly.
+
+## Authorities and premises
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) — quoted:
+  the Record sentences ("When present, a record locks exactly one
+  admissible local possibility"; "Only records are readable. A readout
+  value is determined by record content alone", scalar additive readout);
+  the Qubit sentences ("The full one-site possibility domain has algebraic
+  presentation `M_2(C)`"; the `Cl(3,0)` equivalence clause; "No
+  possibility is privileged. Possibilities are distinguished by the
+  supplied algebraic structure alone."); the Admissibility covariance
+  sentence; the Lattice proper rotations.
+- [`READING_NOTE_FINAL_DERIVATIONS_MOTION_CLOSURE_BOUNDED_NOTE_2026-07-02.md`](READING_NOTE_FINAL_DERIVATIONS_MOTION_CLOSURE_BOUNDED_NOTE_2026-07-02.md)
+  — condition typing (predicate on states, record absence included).
+- [`REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md`](REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md)
+  — the realized-state (pointwise evaluation) reading of locked content:
+  the state (self-adjoint) reading used in Theorem 1's `b = w = 0`
+  restriction.
+- [`THETA_LINK_STAR_GLUING_FRAME_CORRELATION_PAIR_COMPOSITE_DAGGER_EVENNESS_AND_ODD_BRANCH_PHASE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md`](THETA_LINK_STAR_GLUING_FRAME_CORRELATION_PAIR_COMPOSITE_DAGGER_EVENNESS_AND_ODD_BRANCH_PHASE_RESIDUAL_BOUNDED_THEOREM_NOTE_2026-07-02.md)
+  — evenness of supplied reads (the readout-blindness face used in
+  Theorems 3-4).
+- The coupled cubic action (proper linear / improper antilinear on the
+  one-site domain) and the finite-alphabet covariance classification are
+  carried from in-review companions (prose references only, not
+  dependency edges); the pieces this note needs are re-earned by the
+  runner (the `SU(2)` lift construction, the antilinear improper action,
+  and the threshold statement as a named comparison).
+
+## Theorem statements and proofs
+
+### Theorem 1 (content law under the coupled cubic action)
+
+*Proof sketch and runner anchoring.* Proper rotations preserve the
+Clifford relations of `sigma_i` tied to the axes, so they act by the
+`SU(2)` adjoint with `Ad(u) sigma_i = sum_j R_{ji} sigma_j` — the lift is
+constructed by axis-angle for each of the 24 rotations and verified
+exactly (A1). Improper elements compose that with the antilinear
+`sigma_2`-conjugation. On the real basis the induced law is
+`(a, b, v, w) -> (a, det(S) b, S v, det(S) S w)`, verified over all 48
+elements (A2). Hermiticity is preserved; pure states transform as polar
+vectors (A3); the pseudoscalar is the imaginary unit's coefficient and
+the readable scalar is even (A4).
+
+### Theorem 2 (threshold met; the small-alphabet shortcut is a route no-go)
+
+*Proof.* `(S v) . (S d) = v . d` for every signed permutation `S`
+(orthogonality), including improper ones — so alignment values are
+covariant, even, and separate a continuum of contents (five explicit
+witnesses, B1-B2). Any covariant rule may distinguish contents by these
+values, so no finite bound — in particular the three-value chirality
+threshold — constrains the physical alphabet from below. The shortcut
+"alphabet below three, hence achiral" is a route no-go; the classification
+must run, and does run, through the channel structure instead.
+
+### Theorem 3 (no odd channel below vector triples; uniqueness at triples)
+
+*Proof.* Exact sign-character sums over the 48-element group: for tensor
+powers of the vector representation, `(1/48) sum det(g) tr(g)^n` gives
+`0, 0, 1` for `n = 1, 2, 3`; with the 6-direction permutation character
+(fixed-direction count), `0, 0, 1` for `dir6`, `dir6 x V`,
+`dir6 x V x V` (C1-C3, integrality asserted). The sign-isotype projection
+of a generic trilinear form equals `c epsilon`, `c != 0` (C4): the unique
+odd channel at the threshold is the triple product. The pseudoscalar `b`
+is the only single-content odd channel and is excluded twice over —
+state content carries none, and scalar readout cannot see it (C5).
+
+### Theorem 4 (one bit at every alphabet size)
+
+*Proof.* `det(v1, v2, v3)` is proper-invariant and improper-odd under the
+joint action (D1); `i x det` is fully covariant under the antilinear
+value twist with zero readable part (D2); the relative orientation
+`det(d) x det(v)` is even under all 48 (D3); and the four-way flip
+bookkeeping shows content-side and direction-side orientation flips are
+the same single bit — flipping both restores every product (D4). The
+content space's improper action is conjugation, so content-side
+chirality is conjugation-oddness: the same class as the theta-slot seed
+and the mass-side determinant phase.
+
+## What this note does and does not claim
+
+- **It does not determine the framework's fixed rule.** The alphabet is
+  identified; whether the rule uses a chiral channel remains the rule's
+  own property. What is now exact: the alphabet cannot settle the
+  question by size (in either direction), the only content-level chiral
+  carriers are triple-product channels, and their cost is the one
+  already-localized orientation bit.
+- **The coupled action is the named model** licensed by the `Cl(3,0)`
+  presentation clause; a reading in which rotations act trivially on
+  contents would make fixed content values covariant constants — in
+  tension with "No possibility is privileged. Possibilities are
+  distinguished by the supplied algebraic structure alone" — but its
+  formal adjudication belongs to the audit lane, not this note.
+- **The state (self-adjoint) reading of locked content** is carried on
+  the registered realized-state primitive; if a future account supplied
+  non-self-adjoint content, the pseudoscalar channel would open — and
+  would still be readout-blind (Theorem 1/3), so the readable alphabet
+  remains orientation-free even then.
+- No fermion-sector claims; no measured quantities; no imports.
+
+## Residuals and next paths
+
+1. **Rule-dependence structure**: with the alphabet identified, the
+   remaining question about the fixed rule is which covariant channels
+   its dependence actually uses — openness pattern, alignment values,
+   relative orientations (all achiral-compatible), or a triple-product
+   channel (chiral, costing the bit). Any derivation pinning the rule's
+   dependence class now grades the chirality question directly.
+2. **Coupled-action adjudication**: formal audit-lane treatment of the
+   induced rotation action on contents as the presentation-supplied
+   action (the named-model caveat above).
+3. **Theta-chain wiring**: with the in-review companions, this note's
+   Theorems 3-4 give the content-side face of the one-bit localization —
+   the same bit from the rule side, the carrier side, and now the
+   alphabet side.

--- a/logs/runner-cache/condition_alphabet_identification_orientation_free_2026_07_04.txt
+++ b/logs/runner-cache/condition_alphabet_identification_orientation_free_2026_07_04.txt
@@ -1,0 +1,28 @@
+===== runner cache v1 =====
+runner: scripts/condition_alphabet_identification_orientation_free_2026_07_04.py
+runner_sha256: 9f65f72163144c40de651da1d3ceebfe4f65e7343e2495541c894650ecb60ead
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.14
+status: ok
+----- stdout -----
+PASS: S0 generated group and real-basis extraction | unique=48, proper=24, improper=24, basis_max=2.220e-16
+PASS: A1 axis-angle SU(2) lift reproduces spatial adjoint | proper_count=24, max_err=3.140e-16
+PASS: A2 content law: even scalar, pseudoscalar, polar vector, axial vector | elements=48, draws_per_element=3, max_err=1.221e-15
+PASS: A3 self-adjoint state content preserves the polar vector law | hermitian_max=4.965e-16, pure_state_max=3.377e-16, state_b_w_max=2.220e-16
+PASS: A4 pseudoscalar coefficient is readout-invisible | readout_max=4.441e-16, b_law_max=4.441e-16, improper_flips=72
+PASS: B1 covariant alphabet exceeds the chirality threshold | joint_invariance_max=1.776e-15, values=[0.1, 0.2, 0.3, 0.4, 0.5]
+PASS: B2 separating values are even under inversion | P_invariance_max=0.000e+00, P_values=[0.1, 0.2, 0.3, 0.4, 0.5]
+PASS: C1 no sign character below vector pairs | mV=0 (sum=0), mVV=0 (sum=0)
+PASS: C2 vector triple has one sign character | mVVV=1 (sum=48)
+PASS: C3 direction alphabet channels first appear at vector pairs | mDir=0 (sum=0), mDirV=0 (sum=0), mDirVV=1 (sum=48)
+PASS: C4 epsilon uniqueness from projector and permutation signs | c=-0.06266910642791916, max_err=1.388e-16
+PASS: C5 pseudoscalar odd channel is excluded from state readout | b_channel_max=2.220e-16, hermitian_b_w_max=2.220e-16, readout_even_max=4.441e-16
+PASS: D1 content triple product is conjugation-odd | proper_max=0.000e+00, improper_flip_max=0.000e+00
+PASS: D2 imaginary triple product is invariant and readout-blind | twisted_invariance_max=0.000e+00, real_part_max=0.000e+00
+PASS: D3 relative orientation is invariant under all signed permutations | relative_orientation_max=0.000e+00
+PASS: D4 absolute orientation is one bit | four_combinations=20, max_err=0.000e+00, min_abs_triple=1.453e-02
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/condition_alphabet_identification_orientation_free_2026_07_04.py
+++ b/scripts/condition_alphabet_identification_orientation_free_2026_07_04.py
@@ -1,0 +1,473 @@
+"""
+Condition-alphabet identification runner.
+
+Sections:
+- S0: shared signed-permutation and real-basis machinery
+- A: the coupled action and the content law
+- B: alphabet size: chirality threshold met, shortcut closed
+- C: chiral channels: none below vector triples
+- D: transport: one bit at every alphabet size
+
+Expected close: TOTAL: PASS=16 FAIL=0
+"""
+
+import itertools
+
+import numpy as np
+
+
+PASS = 0
+FAIL = 0
+TOL = 1.0e-10
+rng = np.random.default_rng(2)
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        status = "PASS"
+    else:
+        FAIL += 1
+        status = "FAIL"
+    suffix = f" | {detail}" if detail else ""
+    print(f"{status}: {name}{suffix}")
+
+
+def det3_int(A):
+    return int(
+        A[0, 0] * (A[1, 1] * A[2, 2] - A[1, 2] * A[2, 1])
+        - A[0, 1] * (A[1, 0] * A[2, 2] - A[1, 2] * A[2, 0])
+        + A[0, 2] * (A[1, 0] * A[2, 1] - A[1, 1] * A[2, 0])
+    )
+
+
+def perm_sign(p):
+    inversions = 0
+    for i in range(len(p)):
+        for j in range(i + 1, len(p)):
+            if p[i] > p[j]:
+                inversions += 1
+    return -1 if inversions % 2 else 1
+
+
+def all_signed_permutation_matrices():
+    out = []
+    for p in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            S = np.zeros((3, 3), dtype=int)
+            for row, col in enumerate(p):
+                S[row, col] = signs[row]
+            out.append(S)
+    return out
+
+
+mats = all_signed_permutation_matrices()
+proper = [S for S in mats if det3_int(S) == 1]
+improper = [S for S in mats if det3_int(S) == -1]
+P = -np.eye(3, dtype=int)
+
+I2 = np.eye(2, dtype=complex)
+sigma1 = np.array([[0, 1], [1, 0]], dtype=complex)
+sigma2 = np.array([[0, -1j], [1j, 0]], dtype=complex)
+sigma3 = np.array([[1, 0], [0, -1]], dtype=complex)
+sigmas = [sigma1, sigma2, sigma3]
+
+
+def sigma_dot(v):
+    return v[0] * sigma1 + v[1] * sigma2 + v[2] * sigma3
+
+
+def su2_lift(R):
+    R = np.asarray(R, dtype=float)
+    cos_t = np.clip((np.trace(R) - 1.0) / 2.0, -1.0, 1.0)
+    t = np.arccos(cos_t)
+    if abs(t) < 1.0e-12:
+        n = np.array([1.0, 0.0, 0.0])
+    elif abs(np.pi - t) < 1.0e-8:
+        B = R + np.eye(3)
+        col = int(np.argmax(np.sum(B * B, axis=0)))
+        n = B[:, col]
+        n_norm = np.linalg.norm(n)
+        assert n_norm > TOL, "axis-angle pi branch produced a zero axis"
+        n = n / n_norm
+    else:
+        n = np.array(
+            [
+                R[2, 1] - R[1, 2],
+                R[0, 2] - R[2, 0],
+                R[1, 0] - R[0, 1],
+            ]
+        ) / (2.0 * np.sin(t))
+        n = n / np.linalg.norm(n)
+    return np.cos(t / 2.0) * I2 - 1j * np.sin(t / 2.0) * sigma_dot(n)
+
+
+def compose(a, b, v, w):
+    X = (a + 1j * b) * I2.copy()
+    for i in range(3):
+        X = X + (v[i] + 1j * w[i]) * sigmas[i]
+    return X
+
+
+def decompose(X):
+    scalar = np.trace(X) / 2.0
+    a = float(np.real(scalar))
+    b = float(np.imag(scalar))
+    v = np.zeros(3)
+    w = np.zeros(3)
+    for i in range(3):
+        coeff = np.trace(sigmas[i] @ X) / 2.0
+        v[i] = float(np.real(coeff))
+        w[i] = float(np.imag(coeff))
+    return a, b, v, w
+
+
+def full_action(S, X):
+    d = det3_int(S)
+    if d == 1:
+        u = su2_lift(S)
+        return u @ X @ u.conj().T
+    u = su2_lift(-S)
+    return u @ (sigma2 @ np.conjugate(X) @ sigma2) @ u.conj().T
+
+
+def fixed_axis_directions(S):
+    count = 0
+    for i in range(3):
+        e = np.zeros(3, dtype=int)
+        e[i] = 1
+        if np.array_equal(S @ e, e):
+            count += 1
+        if np.array_equal(S @ (-e), -e):
+            count += 1
+    return count
+
+
+def sign_multiplicity(chars, label):
+    total = 0
+    for S, chi in zip(mats, chars):
+        total += det3_int(S) * int(chi)
+    assert total % len(mats) == 0, f"{label} sign multiplicity is not integral"
+    return total // len(mats), total
+
+
+def vector_power_chars(n):
+    return [int(np.trace(S)) ** n for S in mats]
+
+
+def dir6_vector_power_chars(n):
+    return [fixed_axis_directions(S) * (int(np.trace(S)) ** n) for S in mats]
+
+
+def triple_det(v1, v2, v3):
+    return float(np.linalg.det(np.column_stack((v1, v2, v3))))
+
+
+def epsilon_tensor():
+    eps = np.zeros((3, 3, 3))
+    for p in itertools.permutations(range(3)):
+        eps[p[0], p[1], p[2]] = perm_sign(p)
+    return eps
+
+
+def run():
+    unique_count = len({tuple(S.reshape(-1).tolist()) for S in mats})
+    basis_max = 0.0
+    for _ in range(10):
+        a, b = rng.normal(size=2)
+        v = rng.normal(size=3)
+        w = rng.normal(size=3)
+        X = compose(a, b, v, w)
+        aa, bb, vv, ww = decompose(X)
+        X2 = compose(aa, bb, vv, ww)
+        basis_max = max(
+            basis_max,
+            abs(aa - a),
+            abs(bb - b),
+            float(np.max(np.abs(vv - v))),
+            float(np.max(np.abs(ww - w))),
+            float(np.max(np.abs(X2 - X))),
+        )
+    check(
+        "S0 generated group and real-basis extraction",
+        unique_count == 48
+        and len(proper) == 24
+        and len(improper) == 24
+        and any(np.array_equal(S, P) for S in mats)
+        and basis_max < TOL,
+        f"unique={unique_count}, proper={len(proper)}, improper={len(improper)}, "
+        f"basis_max={basis_max:.3e}",
+    )
+
+    a1_max = 0.0
+    for R in proper:
+        u = su2_lift(R)
+        for i in range(3):
+            lhs = u @ sigmas[i] @ u.conj().T
+            rhs = sum(R[j, i] * sigmas[j] for j in range(3))
+            a1_max = max(a1_max, float(np.max(np.abs(lhs - rhs))))
+    check(
+        "A1 axis-angle SU(2) lift reproduces spatial adjoint",
+        a1_max < TOL,
+        f"proper_count={len(proper)}, max_err={a1_max:.3e}",
+    )
+
+    a2_max = 0.0
+    for S in mats:
+        d = det3_int(S)
+        for _ in range(3):
+            a, b = rng.normal(size=2)
+            v = rng.normal(size=3)
+            w = rng.normal(size=3)
+            aa, bb, vv, ww = decompose(full_action(S, compose(a, b, v, w)))
+            a2_max = max(
+                a2_max,
+                abs(aa - a),
+                abs(bb - d * b),
+                float(np.max(np.abs(vv - S @ v))),
+                float(np.max(np.abs(ww - d * (S @ w)))),
+            )
+    check(
+        "A2 content law: even scalar, pseudoscalar, polar vector, axial vector",
+        a2_max < TOL,
+        f"elements={len(mats)}, draws_per_element=3, max_err={a2_max:.3e}",
+    )
+
+    herm_max = 0.0
+    pure_max = 0.0
+    state_bw_max = 0.0
+    for S in mats:
+        for _ in range(3):
+            a = rng.normal()
+            v = rng.normal(size=3)
+            X = compose(a, 0.0, v, np.zeros(3))
+            Y = full_action(S, X)
+            aa, bb, vv, ww = decompose(Y)
+            herm_max = max(herm_max, float(np.max(np.abs(Y - Y.conj().T))))
+            state_bw_max = max(state_bw_max, abs(bb), float(np.max(np.abs(ww))))
+
+            n = rng.normal(size=3)
+            n = n / np.linalg.norm(n)
+            rho = (I2 + sigma_dot(n)) / 2.0
+            rho2 = full_action(S, rho)
+            aa2, bb2, vv2, ww2 = decompose(rho2)
+            expected = (I2 + sigma_dot(S @ n)) / 2.0
+            pure_max = max(
+                pure_max,
+                float(np.max(np.abs(rho2 - expected))),
+                abs(aa2 - 0.5),
+                abs(bb2),
+                float(np.max(np.abs(vv2 - (S @ n) / 2.0))),
+                float(np.max(np.abs(ww2))),
+            )
+    check(
+        "A3 self-adjoint state content preserves the polar vector law",
+        herm_max < TOL and pure_max < TOL and state_bw_max < TOL,
+        f"hermitian_max={herm_max:.3e}, pure_state_max={pure_max:.3e}, "
+        f"state_b_w_max={state_bw_max:.3e}",
+    )
+
+    readout_max = 0.0
+    b_flip_max = 0.0
+    b_improper_flips = 0
+    for S in mats:
+        d = det3_int(S)
+        for _ in range(3):
+            a, b = rng.normal(size=2)
+            aa, bb, vv, ww = decompose(
+                full_action(S, compose(a, b, np.zeros(3), np.zeros(3)))
+            )
+            readout = float(np.real(np.trace(compose(aa, bb, vv, ww))) / 2.0)
+            readout_max = max(readout_max, abs(readout - a))
+            b_flip_max = max(b_flip_max, abs(bb - d * b))
+            if d == -1 and abs(bb + b) < TOL:
+                b_improper_flips += 1
+    readout_even = readout_max < TOL
+    check(
+        "A4 pseudoscalar coefficient is readout-invisible",
+        readout_even and b_flip_max < TOL and b_improper_flips == 3 * len(improper),
+        f"readout_max={readout_max:.3e}, b_law_max={b_flip_max:.3e}, "
+        f"improper_flips={b_improper_flips}",
+    )
+
+    b1_inv_max = 0.0
+    for S in mats:
+        for _ in range(3):
+            v = rng.normal(size=3)
+            dvec = rng.normal(size=3)
+            before = float(v @ dvec)
+            after = float((S @ v) @ (S @ dvec))
+            b1_inv_max = max(b1_inv_max, abs(after - before))
+    ts = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
+    z_dir = np.array([0.0, 0.0, 1.0])
+    separating_values = []
+    for t in ts:
+        v = np.array([0.0, np.sqrt(1.0 - t * t), t])
+        separating_values.append(float(v @ z_dir))
+    distinct_values = len({round(x, 12) for x in separating_values})
+    check(
+        "B1 covariant alphabet exceeds the chirality threshold",
+        b1_inv_max < TOL and distinct_values == len(separating_values),
+        f"joint_invariance_max={b1_inv_max:.3e}, values={separating_values}",
+    )
+
+    b2_max = 0.0
+    p_values = []
+    for t in ts:
+        v = np.array([0.0, np.sqrt(1.0 - t * t), t])
+        before = float(v @ z_dir)
+        after = float((P @ v) @ (P @ z_dir))
+        p_values.append(after)
+        b2_max = max(b2_max, abs(after - before))
+    check(
+        "B2 separating values are even under inversion",
+        b2_max < TOL and np.allclose(p_values, separating_values, atol=TOL, rtol=0.0),
+        f"P_invariance_max={b2_max:.3e}, P_values={p_values}",
+    )
+
+    m_v, total_v = sign_multiplicity(vector_power_chars(1), "V")
+    m_vv, total_vv = sign_multiplicity(vector_power_chars(2), "V tensor V")
+    check(
+        "C1 no sign character below vector pairs",
+        m_v == 0 and m_vv == 0,
+        f"mV={m_v} (sum={total_v}), mVV={m_vv} (sum={total_vv})",
+    )
+
+    m_vvv, total_vvv = sign_multiplicity(vector_power_chars(3), "V tensor V tensor V")
+    check(
+        "C2 vector triple has one sign character",
+        m_vvv == 1,
+        f"mVVV={m_vvv} (sum={total_vvv})",
+    )
+
+    m_dir, total_dir = sign_multiplicity(dir6_vector_power_chars(0), "dir6")
+    m_dir_v, total_dir_v = sign_multiplicity(
+        dir6_vector_power_chars(1), "dir6 tensor V"
+    )
+    m_dir_vv, total_dir_vv = sign_multiplicity(
+        dir6_vector_power_chars(2), "dir6 tensor V tensor V"
+    )
+    check(
+        "C3 direction alphabet channels first appear at vector pairs",
+        m_dir == 0 and m_dir_v == 0 and m_dir_vv == 1,
+        f"mDir={m_dir} (sum={total_dir}), mDirV={m_dir_v} "
+        f"(sum={total_dir_v}), mDirVV={m_dir_vv} (sum={total_dir_vv})",
+    )
+
+    T = rng.normal(size=(3, 3, 3))
+    projected = np.zeros((3, 3, 3))
+    for S in mats:
+        projected += det3_int(S) * np.einsum("ia,jb,kc,abc->ijk", S, S, S, T)
+    projected = projected / len(mats)
+    eps = epsilon_tensor()
+    c = float(np.sum(projected * eps) / np.sum(eps * eps))
+    c_err = float(np.max(np.abs(projected - c * eps)))
+    check(
+        "C4 epsilon uniqueness from projector and permutation signs",
+        c_err < TOL and abs(c) > TOL,
+        f"c={c:.16g}, max_err={c_err:.3e}",
+    )
+
+    b_basis_max = 0.0
+    for S in mats:
+        aa, bb, vv, ww = decompose(full_action(S, compose(0.0, 1.0, np.zeros(3), np.zeros(3))))
+        b_basis_max = max(
+            b_basis_max,
+            abs(aa),
+            abs(bb - det3_int(S)),
+            float(np.max(np.abs(vv))),
+            float(np.max(np.abs(ww))),
+        )
+    b_channel_odd = b_basis_max < TOL
+    hermitian_b_zero = state_bw_max < TOL
+    check(
+        "C5 pseudoscalar odd channel is excluded from state readout",
+        b_channel_odd and hermitian_b_zero and readout_even,
+        f"b_channel_max={b_basis_max:.3e}, hermitian_b_w_max={state_bw_max:.3e}, "
+        f"readout_even_max={readout_max:.3e}",
+    )
+
+    d1_proper_max = 0.0
+    d1_improper_max = 0.0
+    for S in mats:
+        d = det3_int(S)
+        for _ in range(20):
+            v1, v2, v3 = rng.normal(size=(3, 3))
+            before = triple_det(v1, v2, v3)
+            after = triple_det(S @ v1, S @ v2, S @ v3)
+            if d == 1:
+                d1_proper_max = max(d1_proper_max, abs(after - before))
+            else:
+                d1_improper_max = max(d1_improper_max, abs(after + before))
+    check(
+        "D1 content triple product is conjugation-odd",
+        d1_proper_max < TOL and d1_improper_max < TOL,
+        f"proper_max={d1_proper_max:.3e}, improper_flip_max={d1_improper_max:.3e}",
+    )
+
+    d2_invariance_max = 0.0
+    d2_real_max = 0.0
+    for S in mats:
+        d = det3_int(S)
+        for _ in range(20):
+            v1, v2, v3 = rng.normal(size=(3, 3))
+            before = 1j * triple_det(v1, v2, v3)
+            raw_after = 1j * triple_det(S @ v1, S @ v2, S @ v3)
+            after = np.conjugate(raw_after) if d == -1 else raw_after
+            d2_invariance_max = max(d2_invariance_max, abs(after - before))
+            d2_real_max = max(d2_real_max, abs(float(np.real(after))))
+    check(
+        "D2 imaginary triple product is invariant and readout-blind",
+        d2_invariance_max < TOL and d2_real_max < TOL,
+        f"twisted_invariance_max={d2_invariance_max:.3e}, real_part_max={d2_real_max:.3e}",
+    )
+
+    d3_max = 0.0
+    e1 = np.array([1.0, 0.0, 0.0])
+    e2 = np.array([0.0, 1.0, 0.0])
+    e3 = np.array([0.0, 0.0, 1.0])
+    for S in mats:
+        for _ in range(20):
+            v1, v2, v3 = rng.normal(size=(3, 3))
+            before = triple_det(e1, e2, e3) * triple_det(v1, v2, v3)
+            after = triple_det(S @ e1, S @ e2, S @ e3) * triple_det(
+                S @ v1, S @ v2, S @ v3
+            )
+            d3_max = max(d3_max, abs(after - before))
+    check(
+        "D3 relative orientation is invariant under all signed permutations",
+        d3_max < TOL,
+        f"relative_orientation_max={d3_max:.3e}",
+    )
+
+    d4_max = 0.0
+    d4_min_abs = np.inf
+    for _ in range(20):
+        v1, v2, v3 = rng.normal(size=(3, 3))
+        base_content = triple_det(v1, v2, v3)
+        d4_min_abs = min(d4_min_abs, abs(base_content))
+        for content_flip, direction_flip in itertools.product((1.0, -1.0), repeat=2):
+            content_det = triple_det(content_flip * v1, content_flip * v2, content_flip * v3)
+            direction_det = triple_det(direction_flip * e1, direction_flip * e2, direction_flip * e3)
+            product_value = content_det * direction_det
+            expected_content = content_flip * base_content
+            expected_direction = direction_flip
+            expected_product = content_flip * direction_flip * base_content
+            d4_max = max(
+                d4_max,
+                abs(content_det - expected_content),
+                abs(direction_det - expected_direction),
+                abs(product_value - expected_product),
+            )
+    check(
+        "D4 absolute orientation is one bit",
+        d4_max < TOL and d4_min_abs > TOL,
+        f"four_combinations=20, max_err={d4_max:.3e}, min_abs_triple={d4_min_abs:.3e}",
+    )
+
+    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary

Physical condition-alphabet identification for the admissibility rule —
the open item named by the covariance-extension classification. The
alphabet is identified from named premises and its chiral structure is
classified exactly.

- **Theorem 1 (content law):** under the coupled cubic action (proper =
  constructed SU(2) adjoint via the Cl(3,0) tie of sigma_i to the axes;
  improper = antilinear sigma_2-conjugation composed with a proper
  adjoint), the one-site content decomposes exactly as
  a -> a, b -> det(S) b, v -> S v, w -> det(S) S w: even scalar,
  PSEUDOSCALAR (the imaginary unit's coefficient), POLAR VECTOR, axial
  vector. State (self-adjoint) content — the registered realized-state
  reading — has b = w = 0; pure states transform as polar vectors.
- **Theorem 2 (threshold met — honest route no-go):** alignment
  invariants v.d are jointly invariant under all 48 elements and separate
  a continuum of contents. The covariant alphabet is INFINITE, so the
  hoped-for shortcut "alphabet < 3 values => rule automatically achiral"
  is NOT available. Recorded as a route no-go. Every separating invariant
  is even: size supplies no chirality.
- **Theorem 3 (no odd channel below vector triples):** exact
  sign-character multiplicities: m(V) = 0, m(VxV) = 0, m(VxVxV) = 1;
  m(dir6) = 0, m(dir6xV) = 0, m(dir6xVxV) = 1. The finite-alphabet
  threshold (3 condition values) recurs on the continuum as a
  vector-count threshold of 3, and the unique odd channel at the
  threshold is the triple product (sign-isotype projection of a generic
  trilinear = c*epsilon). The single-content pseudoscalar channel is
  doubly excluded: state content carries none AND scalar readout is blind
  to it.
- **Theorem 4 (one bit at every alphabet size):** the content triple
  product is conjugation-odd (same class as the theta seed and the
  mass-side determinant phase); i*det is achiral under the antilinear
  twist with zero readable part; RELATIVE orientation det(d)*det(v) is
  even and freely available to achiral rules; four-way flip bookkeeping
  shows content-side and direction-side orientation are the SAME single
  bit. Enlarging the alphabet to full physical size manufactures no
  orientation datum.

Honest scoping: does NOT determine the fixed rule's chirality; the
coupled action is the named model licensed by the Cl(3,0) clause (formal
adjudication flagged for the audit lane); the state reading rides the
registered realized-state primitive; in-review companions referenced in
prose only with needed pieces re-earned.

## Changes

- 1 note: `docs/CONDITION_ALPHABET_IDENTIFICATION_COUPLED_CUBIC_ACTION_THRESHOLD_MET_NO_ODD_CHANNEL_BELOW_TRIPLES_BOUNDED_THEOREM_NOTE_2026-07-04.md`
- 1 runner: `scripts/condition_alphabet_identification_orientation_free_2026_07_04.py`
- 1 cache: `logs/runner-cache/condition_alphabet_identification_orientation_free_2026_07_04.txt`

## Test plan

- Runner re-run in a clean worktree off origin/main: `TOTAL: PASS=16 FAIL=0`
- Cache regenerated via `runner_cache.execute_runner`/`write_cache`
- Axiom quotes verified against the memo at branch time; reviewer
  reconciles at landing as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
