### PR TITLE
feat(admissibility): bootstrap continuation — nonemptiness from 'Records form.', free-orbit reduction, and propagation closure

### DIFF
--- a/docs/BOOTSTRAP_CONTINUATION_AVAILABILITY_NONEMPTY_FREE_ORBIT_REDUCTION_PROPAGATION_CLOSURE_BOUNDED_THEOREM_NOTE_2026-07-04.md
+++ b/docs/BOOTSTRAP_CONTINUATION_AVAILABILITY_NONEMPTY_FREE_ORBIT_REDUCTION_PROPAGATION_CLOSURE_BOUNDED_THEOREM_NOTE_2026-07-04.md
@@ -1,0 +1,193 @@
+# The Bootstrap Continued: "Records Form" Makes the First Availability Set Nonempty, Every Orbit With Proper Symmetry Is Automatically Achiral (Chirality Requires a Free Off-Mirror Orbit), and Achirality Propagates — an Achiral Rule Keeps the Reachable Class Flip-Closed Inductively, While a Chiral Rule Breaks One-Step Closure at a Reachable Configuration (Bounded Theorem)
+
+**Date:** 2026-07-04
+**Type:** bounded_theorem
+**Claim type:** bounded_theorem (exact orbit/stabilizer classification,
+universal one-step closure statements, and explicit toy-model witnesses;
+the toy rules are named toys; not a determination of the framework's fixed
+rule).
+**Status authority:** independent audit lane only. This note does not set an
+audit verdict, edit registries, register primitives, change axioms, retire
+or re-grade any Tier-A admission, or claim Strong-CP closure.
+**Primary runner:**
+[`scripts/bootstrap_continuation_nonempty_free_orbit_propagation_closure_2026_07_04.py`](../scripts/bootstrap_continuation_nonempty_free_orbit_propagation_closure_2026_07_04.py)
+**Runner cache:**
+[`logs/runner-cache/bootstrap_continuation_nonempty_free_orbit_propagation_closure_2026_07_04.txt`](../logs/runner-cache/bootstrap_continuation_nonempty_free_orbit_propagation_closure_2026_07_04.txt)
+
+## Question
+
+The empty-state bootstrap left two named targets: the locus class of the
+first availability set `A0`, and whether achirality — if the rule has it —
+propagates past the first step. The premises are the Record axiom's
+sentences "Records form." and "When present, a record locks exactly one
+admissible local possibility"; the state definition ("A state is a
+configuration of records", `I(empty) = 0`); and the Admissibility
+covariance sentence
+([`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)).
+
+## Answer
+
+1. **Nonemptiness (Theorem 1 — the first derivation consuming "Records
+   form.").** Records occur; each locks an available possibility; the
+   first record's availability set is `A0`. Hence `A0` is **nonempty**,
+   and with proper-cubic invariance it **contains a full proper orbit**.
+   The bootstrap is not vacuous: the realized alphabet has at least one
+   orbit's worth of contents.
+
+2. **Free-orbit reduction (Theorem 2).** Every content orbit with a
+   nontrivial proper stabilizer lies on a rotation axis of the cubic
+   group (all 23 nontrivial proper elements' axes computed), every such
+   axis is improper-stabilized, and every such orbit is therefore
+   inversion-invariant — **automatically achiral**. Orbit size below 24
+   is equivalent to nontrivial proper stabilizer. So set-level chirality
+   of `A0` requires a **free (trivial-stabilizer) orbit off the mirror
+   loci**, unpaired with its twin: everything with any symmetry at all is
+   derivably safe, and the locus-class question reduces to the free
+   off-mirror part of `A0`.
+
+3. **Propagation closure (Theorem 3).** If the rule is achiral — its
+   availability function even under the improper flip — then **one-step
+   closure holds universally**: for every configuration `C` and site
+   `s`, `avail(flip C, s) = flip(avail(C, s))`. Since the empty state is
+   flip-fixed, induction gives: **the reachable configuration class is
+   closed under the flip at every record count** (endpoint witness: full
+   breadth-first enumeration to depth three on the `L = 2` quotient,
+   every layer flip-closed). Conversely, a chiral rule breaks one-step
+   closure **at a reachable configuration**: in the toy model, the odd
+   channel `J2 = sum det(d, e, c(e))` over recorded slot pairs drives a
+   threshold shift, and the explicit two-record witness has
+   `J2(C) = +2`, `J2(flip C) = -2`, with `avail(C)` equal to **all six**
+   candidates and `avail(flip C)` **empty** — the flipped configuration
+   is a dead end while the original is fully open, and the witness is
+   reachable in two verified formation steps. Chirality is not a
+   first-step artifact: it propagates as a class asymmetry exactly when
+   the rule spends the bit, and never otherwise.
+
+4. **Parity protection on the `L = 2` quotient, and spontaneous
+   registration (Theorem 4).** On the `L = 2` torus the two slots of
+   each axis read the same neighbor, so every slot pattern is
+   antipodally duplicated — and the `J2` channel **vanishes identically**
+   (direction-sensitive rule chirality needs `L >= 3`). Meanwhile, under
+   the achiral rule a single history can register a nonzero `J2`
+   (orientation registered in the configuration) while its flipped
+   history is equally reachable, step by verified step: class-level
+   symmetry with configuration-level breaking — the state-versus-law
+   separation, witnessed dynamically.
+
+**Continuation summary.** The realized alphabet starts nonempty by axiom;
+everything in it with any proper symmetry is derivably orientation-free;
+and the one bit, if the rule ever spends it, shows up as a reachability
+asymmetry that no achiral rule can produce and every chiral rule must.
+The remaining question is unchanged in kind but smaller in size: the free
+off-mirror part of the availability structure.
+
+## Authorities and premises
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) — quoted:
+  "Records form."; "When present, a record locks exactly one admissible
+  local possibility"; "A state is a configuration of records";
+  `I(empty) = 0`; the Admissibility sentences ("one fixed
+  nearest-neighbor admissibility rule, covariant under lattice
+  translations and proper cubic rotations"; "the available possibilities
+  are determined by, and vary with, the nearest-neighbor conditions");
+  the open-gates item placing formation rules downstream.
+- [`READING_NOTE_FINAL_DERIVATIONS_MOTION_CLOSURE_BOUNDED_NOTE_2026-07-02.md`](READING_NOTE_FINAL_DERIVATIONS_MOTION_CLOSURE_BOUNDED_NOTE_2026-07-02.md)
+  — condition typing (record absence included).
+- [`REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md`](REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md)
+  — the realized-state reading (contents as polar vectors; the toy's
+  axis-vector contents are its simplest instance).
+- The empty-state bootstrap (first availability set proper-invariant,
+  orbit dichotomy, degree-nine wall) and the coupled cubic action are
+  carried from in-review companions (prose references only, not
+  dependency edges); the pieces needed here are re-earned by the runner.
+
+## Theorem statements and proofs
+
+### Theorem 1 (nonemptiness from "Records form.")
+
+*Proof.* "Records form." puts occurrence at axiom strength: records are
+not merely possible but occur. Each record "locks exactly one admissible
+local possibility" — an element of the availability set at its formation
+step. The first record forms at the empty state, whose availability set
+at every site is `A0` (all-open conditions, translation covariance). A
+lock requires an element: `A0 != empty`. Proper-cubic invariance (the
+bootstrap constraint) then puts the full proper orbit of any member
+inside `A0` (A1, model-checked closure). No claim is made about which
+element the first record locks — formation selection is explicitly
+downstream.
+
+### Theorem 2 (free-orbit reduction)
+
+*Proof.* A point with nontrivial proper stabilizer is fixed by some
+nontrivial proper rotation, hence lies on its rotation axis; the 23
+nontrivial proper elements' axes are computed and each is
+improper-stabilized (A2); improper-stabilized points have
+inversion-invariant orbits (the bootstrap dichotomy, re-earned at A3
+together with the equivalence orbit-size `< 24` iff nontrivial
+stabilizer). Model unions witness the reduction: symmetric orbits plus
+mirror-plane orbits in any combination remain inversion-invariant;
+adding a single free off-mirror orbit breaks it; adding its twin
+restores it (A4). Hence chirality of any proper-invariant availability
+set is carried exclusively by unpaired free off-mirror orbits.
+
+### Theorem 3 (propagation closure and its converse witness)
+
+*Proof.* Let `Phi` be the improper flip on configurations. If the rule
+is achiral, `avail(Phi C, s) = Phi(avail(C, s))` for all `C, s` — in the
+toy, verified exactly on 200 random partial configurations (B3); the
+general statement is the definition of rule achirality applied
+configuration-wise. `Phi(empty) = empty`, so by induction every
+formation sequence maps to a valid formation sequence under `Phi`, and
+each reachable layer is `Phi`-closed — witnessed end-to-end by the full
+depth-three enumeration on the `L = 2` quotient (B4, layer sizes
+reported). For the converse, the chiral toy rule shifts its threshold on
+the sign of the proper-covariant, flip-odd channel `J2` (B1); the
+explicit witness configuration is reachable in two verified steps and
+has `avail(C)` all-six versus `avail(flip C)` empty (B5) — one-step
+closure fails at a reachable configuration, so the reachable class is
+flip-asymmetric from the third record onward. The chiral rule remains
+proper-covariant (B6): the asymmetry is precisely improper, the one bit.
+
+### Theorem 4 (parity protection at L = 2; spontaneous registration)
+
+*Proof.* On the `L = 2` torus, `+d` and `-d` neighbors coincide, so
+every readable slot pattern carries the same content at antipodal slots;
+`J2` then cancels pairwise in its `d`-sum — identically zero on 50
+random duplicated patterns (B2). So the quotient itself protects parity:
+no direction-sensitive odd channel can fire below `L = 3`. Separately, a
+three-record history under the achiral rule reaches a configuration with
+nonzero `J2` at a site — an orientation registered in the state — while
+the flipped history is verified reachable step-by-step (C1): the class
+is symmetric, the individual configuration is not, and nothing lawful
+distinguishes the pair.
+
+## What this note does and does not claim
+
+- **The toy rules are toys.** They witness the closure/violation
+  structure exactly; no claim is made that the framework's fixed rule is
+  either of them, or that it is achiral or chiral.
+- **Theorem 1 uses only occurrence.** "Records form." supplies that
+  records occur; which record, where, and with what weight remain
+  downstream, and nothing here constrains them.
+- **Theorem 3's converse is a witness, not a universal converse**: it
+  shows a chiral rule CAN break closure at a reachable configuration
+  (and the toy does, maximally); whether every chiral rule's
+  distinguishing condition is reachable depends on the rule and is not
+  claimed.
+- No fermion-sector claims; no measured quantities; no imports.
+
+## Residuals and next paths
+
+1. **The free off-mirror part of `A0`**: the locus-class question is now
+   exactly this — any derivation showing the all-open availability set
+   avoids unpaired free off-mirror orbits (or must contain them) settles
+   the realized-alphabet bootstrap. The safe/dangerous split is fully
+   classified; what remains is which side the fixed rule's `A0` sits on.
+2. **Quotient-size thresholds**: the `L = 2` parity protection suggests a
+   graded family — which odd channels first fire at which lattice
+   quotients — a possible tool for bounding rule chirality by locality
+   range.
+3. **Reachability-asymmetry as an audit target**: any proposal of a
+   chiral rule now predicts a concrete signature — a flip-asymmetric
+   reachable class from some finite record count onward — giving future
+   accounts a named, checkable consequence.

--- a/logs/runner-cache/bootstrap_continuation_nonempty_free_orbit_propagation_closure_2026_07_04.txt
+++ b/logs/runner-cache/bootstrap_continuation_nonempty_free_orbit_propagation_closure_2026_07_04.txt
@@ -1,0 +1,24 @@
+===== runner cache v1 =====
+runner: scripts/bootstrap_continuation_nonempty_free_orbit_propagation_closure_2026_07_04.py
+runner_sha256: 0b2ff4b9da43b3765afcbb7e99ed0e9609eda98d21d19c8580e5e14cd28381dd
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.32
+status: ok
+----- stdout -----
+PASS: S0 computed cubic group machinery | group=48 det_split=(24, 24) orbit_sizes=(6, 8, 12, 24, 24)
+PASS: A1 proper nonempty orbit containment | model_sizes=(6, 14, 30)
+PASS: A2 rotation axes improper stabilized | improper_fixed_axes=23 nonidentity_proper=23
+PASS: A3 small proper orbits and inversion | samples=25 small_orbits=3
+PASS: A4 free orbit reduction by inversion | base=50 plus_one_free=74 restored=98
+PASS: B1 J2 flip odd and proper covariant | nonzero_observed=True proper_tests=120
+PASS: B2 L2 duplicated slots zero J2 | patterns=50 values=(0,)
+PASS: B3 achiral toy one-step closure under flip | trials=200
+PASS: B4 achiral toy BFS endpoint flip closure | layer_sizes=(1, 48, 936, 9936)
+PASS: B5 chiral toy one-step closure violation witness | J2=2 flip_J2=-2 avail=(0, 1, 2, 3, 4, 5) flip_avail=() reachable=(True,True)
+PASS: B6 chiral toy proper torus covariance | proper_elements=24 random_configs_each=3
+PASS: C1 achiral toy spontaneous J2 registration | history_available=[True, True, True] flip_history_available=[True, True, True] first_nonzero=((0, 1, 0), 2)
+TOTAL: PASS=12 FAIL=0
+
+----- stderr -----
+

--- a/scripts/bootstrap_continuation_nonempty_free_orbit_propagation_closure_2026_07_04.py
+++ b/scripts/bootstrap_continuation_nonempty_free_orbit_propagation_closure_2026_07_04.py
@@ -1,0 +1,488 @@
+"""
+Sections:
+S/A - nonemptiness and the free-orbit reduction.
+B - the J2 channel and one-step closure / propagation tests.
+C - spontaneous registration under the achiral toy rule.
+
+Expected close: TOTAL: PASS=12 FAIL=0
+"""
+
+import itertools
+
+import numpy as np
+
+
+rng = np.random.default_rng(8)
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        prefix = "PASS"
+    else:
+        FAIL += 1
+        prefix = "FAIL"
+    print(f"{prefix}: {name}" + (f" | {detail}" if detail else ""))
+
+
+AX = np.array(
+    [
+        [1, 0, 0],
+        [-1, 0, 0],
+        [0, 1, 0],
+        [0, -1, 0],
+        [0, 0, 1],
+        [0, 0, -1],
+    ],
+    dtype=int,
+)
+DIRS = AX.copy()
+
+
+def axis_index(vec):
+    v = tuple(int(x) for x in np.asarray(vec, dtype=int))
+    for i, a in enumerate(AX):
+        if v == tuple(int(x) for x in a):
+            return i
+    raise ValueError(f"not an axis vector: {v}")
+
+
+NEG = tuple(axis_index(-AX[i]) for i in range(len(AX)))
+
+
+def det_int(M):
+    return int(round(float(np.linalg.det(M))))
+
+
+def mat_key(M):
+    return tuple(int(x) for x in M.reshape(-1))
+
+
+def signed_permutation_group():
+    mats = []
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            M = np.zeros((3, 3), dtype=int)
+            for row, col in enumerate(perm):
+                M[row, col] = signs[row]
+            mats.append(M)
+    mats.sort(key=mat_key)
+    return mats
+
+
+GROUP = signed_permutation_group()
+PROPER = [M for M in GROUP if det_int(M) == 1]
+IMPROPER = [M for M in GROUP if det_int(M) == -1]
+IDENTITY = np.eye(3, dtype=int)
+
+
+def point_key(v):
+    return tuple(int(x) for x in np.asarray(v, dtype=int))
+
+
+def proper_orbit_int(point):
+    p = np.asarray(point, dtype=int)
+    return {point_key(M @ p) for M in PROPER}
+
+
+def inverted_point_set(points):
+    return {tuple(-x for x in p) for p in points}
+
+
+def is_inversion_invariant(points):
+    return inverted_point_set(points) == set(points)
+
+
+def orbit_float(v):
+    return {tuple(float(x) for x in np.round(M @ v, 12)) for M in PROPER}
+
+
+def has_nontrivial_stabilizer(v):
+    return any(
+        not np.array_equal(M, IDENTITY) and np.allclose(M @ v, v, atol=1e-10)
+        for M in PROPER
+    )
+
+
+def inversion_in_float_orbit(v):
+    return any(np.allclose(M @ v, -v, atol=1e-10) for M in PROPER)
+
+
+def triple(a, b, c):
+    return int(np.dot(np.cross(a, b), c))
+
+
+def j2(slots):
+    total = 0
+    for d in slots:
+        for e in slots:
+            if d != e:
+                total += triple(DIRS[d], DIRS[e], AX[slots[e]])
+    return int(total)
+
+
+def flip_slots(slots):
+    return {NEG[d]: NEG[c] for d, c in slots.items()}
+
+
+def transform_slots(slots, M):
+    return {axis_index(M @ DIRS[d]): axis_index(M @ AX[c]) for d, c in slots.items()}
+
+
+def all_sites(L):
+    return tuple(itertools.product(range(L), repeat=3))
+
+
+def neighbor_site(site, direction, L):
+    raw = np.asarray(site, dtype=int) + DIRS[direction]
+    return tuple(int(x) for x in np.mod(raw, L))
+
+
+def slot_pattern(config, L, site):
+    slots = {}
+    for d in range(len(DIRS)):
+        nb = neighbor_site(site, d, L)
+        if nb in config:
+            slots[d] = config[nb]
+    return slots
+
+
+def available(config, L, site, odd_channel):
+    slots = slot_pattern(config, L, site)
+    threshold = 0.0
+    if odd_channel and len(slots) >= 2 and j2(slots) < -1e-9:
+        threshold = 1.0
+
+    out = []
+    for cand in range(len(AX)):
+        base = sum(int(np.dot(AX[cand], AX[c])) for c in slots.values())
+        if float(base) >= threshold:
+            out.append(cand)
+    return tuple(out)
+
+
+def flip_config(config):
+    return {site: NEG[c] for site, c in config.items()}
+
+
+def flip_availability(candidates):
+    return tuple(sorted(NEG[c] for c in candidates))
+
+
+def random_slot_pattern():
+    slots = {}
+    for d in range(len(DIRS)):
+        if rng.random() < 0.55:
+            slots[d] = int(rng.integers(0, len(AX)))
+    return slots
+
+
+def random_config_with_empty_target(L, max_records):
+    sites = all_sites(L)
+    target = sites[int(rng.integers(0, len(sites)))]
+    pool = [i for i, s in enumerate(sites) if s != target]
+    nrec = int(rng.integers(1, max_records + 1))
+    chosen = rng.choice(pool, size=nrec, replace=False)
+    config = {
+        sites[int(i)]: int(rng.integers(0, len(AX)))
+        for i in chosen
+    }
+    return config, target
+
+
+def state_to_config(state, sites):
+    return {sites[i]: c for i, c in enumerate(state) if c >= 0}
+
+
+def flip_state(state):
+    return tuple(-1 if c < 0 else NEG[c] for c in state)
+
+
+def transform_site(site, M, L):
+    raw = M @ np.asarray(site, dtype=int)
+    return tuple(int(x) for x in np.mod(raw, L))
+
+
+def transform_config(config, M, L):
+    return {
+        transform_site(site, M, L): axis_index(M @ AX[c])
+        for site, c in config.items()
+    }
+
+
+def transformed_candidates(candidates, M):
+    return tuple(sorted(axis_index(M @ AX[c]) for c in candidates))
+
+
+def history_reachable(history, L, odd_channel):
+    config = {}
+    trace = []
+    ok = True
+    for site, content in history:
+        avail = available(config, L, site, odd_channel)
+        trace.append((site, content, avail))
+        if site in config or content not in avail:
+            ok = False
+            break
+        config = dict(config)
+        config[site] = content
+    return ok, config, trace
+
+
+# Section S/A.
+axis_rep = np.array([1, 0, 0], dtype=int)
+corner_rep = np.array([1, 1, 1], dtype=int)
+edge_rep = np.array([1, 1, 0], dtype=int)
+mirror_rep = np.array([2, 1, 0], dtype=int)
+generic_rep = np.array([3, 2, 1], dtype=int)
+
+orbit_reps = (axis_rep, corner_rep, edge_rep, mirror_rep, generic_rep)
+orbit_sizes = tuple(len(proper_orbit_int(p)) for p in orbit_reps)
+det_counts = (len(PROPER), len(IMPROPER))
+check(
+    "S0 computed cubic group machinery",
+    len(GROUP) == 48 and det_counts == (24, 24) and orbit_sizes == (6, 8, 12, 24, 24),
+    f"group={len(GROUP)} det_split={det_counts} orbit_sizes={orbit_sizes}",
+)
+
+axis_orbit = proper_orbit_int(axis_rep)
+corner_orbit = proper_orbit_int(corner_rep)
+edge_orbit = proper_orbit_int(edge_rep)
+mirror_orbit = proper_orbit_int(mirror_rep)
+generic_orbit = proper_orbit_int(generic_rep)
+model_sets = (
+    axis_orbit,
+    axis_orbit | corner_orbit,
+    axis_orbit | generic_orbit,
+)
+a1_ok = all(
+    proper_orbit_int(np.array(p, dtype=int)).issubset(model_set)
+    for model_set in model_sets
+    for p in model_set
+)
+check(
+    "A1 proper nonempty orbit containment",
+    a1_ok,
+    f"model_sizes={tuple(len(s) for s in model_sets)}",
+)
+
+axis_count = 0
+axis_residual_ok = True
+for M in PROPER:
+    if np.array_equal(M, IDENTITY):
+        continue
+    vals, vecs = np.linalg.eig(M.astype(float))
+    idx = int(np.argmin(np.abs(vals - 1.0)))
+    axis = np.real(vecs[:, idx])
+    axis = axis / np.linalg.norm(axis)
+    axis_residual_ok = axis_residual_ok and np.allclose(M @ axis, axis, atol=1e-8)
+    if any(np.allclose(H @ axis, axis, atol=1e-8) for H in IMPROPER):
+        axis_count += 1
+check(
+    "A2 rotation axes improper stabilized",
+    axis_residual_ok and axis_count == len(PROPER) - 1,
+    f"improper_fixed_axes={axis_count} nonidentity_proper={len(PROPER) - 1}",
+)
+
+samples = [p.astype(float) for p in orbit_reps]
+for _ in range(20):
+    v = rng.normal(size=3)
+    samples.append(v / np.linalg.norm(v))
+
+a3_small = 0
+a3_ok = True
+for v in samples:
+    size = len(orbit_float(v))
+    nontrivial = has_nontrivial_stabilizer(v)
+    inv = inversion_in_float_orbit(v)
+    a3_ok = a3_ok and ((size < len(PROPER)) == nontrivial)
+    a3_ok = a3_ok and (size == len(PROPER) or inv)
+    if size < len(PROPER):
+        a3_small += 1
+check(
+    "A3 small proper orbits and inversion",
+    a3_ok,
+    f"samples={len(samples)} small_orbits={a3_small}",
+)
+
+base_union = axis_orbit | corner_orbit | edge_orbit | mirror_orbit
+with_generic = base_union | generic_orbit
+generic_twin = proper_orbit_int(-generic_rep)
+restored = with_generic | generic_twin
+a4_ok = (
+    is_inversion_invariant(base_union)
+    and not is_inversion_invariant(with_generic)
+    and is_inversion_invariant(restored)
+)
+check(
+    "A4 free orbit reduction by inversion",
+    a4_ok,
+    f"base={len(base_union)} plus_one_free={len(with_generic)} restored={len(restored)}",
+)
+
+
+# Section B.
+b1_flip_ok = True
+b1_nonzero = False
+for _ in range(200):
+    slots = random_slot_pattern()
+    val = j2(slots)
+    b1_nonzero = b1_nonzero or (val != 0)
+    b1_flip_ok = b1_flip_ok and (j2(flip_slots(slots)) == -val)
+
+b1_cov_ok = True
+for M in PROPER:
+    for _ in range(5):
+        slots = random_slot_pattern()
+        b1_cov_ok = b1_cov_ok and (j2(transform_slots(slots, M)) == j2(slots))
+check(
+    "B1 J2 flip odd and proper covariant",
+    b1_flip_ok and b1_nonzero and b1_cov_ok,
+    f"nonzero_observed={b1_nonzero} proper_tests={len(PROPER) * 5}",
+)
+
+pair_reps = tuple(i for i in range(len(AX)) if i < NEG[i])
+b2_values = []
+for _ in range(50):
+    slots = {}
+    for d in pair_reps:
+        if rng.random() < 0.85:
+            c = int(rng.integers(0, len(AX)))
+            slots[d] = c
+            slots[NEG[d]] = c
+    b2_values.append(j2(slots))
+check(
+    "B2 L2 duplicated slots zero J2",
+    all(v == 0 for v in b2_values),
+    f"patterns={len(b2_values)} values={tuple(sorted(set(b2_values)))}",
+)
+
+b3_ok = True
+for _ in range(200):
+    config, target = random_config_with_empty_target(3, 4)
+    lhs = tuple(sorted(available(flip_config(config), 3, target, False)))
+    rhs = flip_availability(available(config, 3, target, False))
+    b3_ok = b3_ok and (lhs == rhs)
+check(
+    "B3 achiral toy one-step closure under flip",
+    b3_ok,
+    "trials=200",
+)
+
+sites2 = all_sites(2)
+empty_state = tuple(-1 for _ in sites2)
+layers = [set([empty_state])]
+for _depth in range(3):
+    next_layer = set()
+    for state in layers[-1]:
+        config = state_to_config(state, sites2)
+        for i, site in enumerate(sites2):
+            if state[i] >= 0:
+                continue
+            for content in available(config, 2, site, False):
+                new_state = list(state)
+                new_state[i] = content
+                next_layer.add(tuple(new_state))
+    layers.append(next_layer)
+layer_sizes = tuple(len(layer) for layer in layers)
+b4_flip_ok = all(flip_state(state) in layer for layer in layers for state in layer)
+check(
+    "B4 achiral toy BFS endpoint flip closure",
+    b4_flip_ok and layer_sizes[0] == 1,
+    f"layer_sizes={layer_sizes}",
+)
+
+witness_first = ((1, 1, 0), 2)
+witness_second = ((0, 1, 1), 3)
+witness_target = (0, 1, 0)
+first_avail = available({}, 3, witness_first[0], True)
+config_after_first = {witness_first[0]: witness_first[1]}
+second_avail = available(config_after_first, 3, witness_second[0], True)
+witness_config = {
+    witness_first[0]: witness_first[1],
+    witness_second[0]: witness_second[1],
+}
+witness_slots = slot_pattern(witness_config, 3, witness_target)
+flipped_witness = flip_config(witness_config)
+flipped_witness_slots = slot_pattern(flipped_witness, 3, witness_target)
+witness_j2 = j2(witness_slots)
+flipped_witness_j2 = j2(flipped_witness_slots)
+witness_avail = available(witness_config, 3, witness_target, True)
+flipped_witness_avail = available(flipped_witness, 3, witness_target, True)
+all_candidates = tuple(range(len(AX)))
+b5_ok = (
+    witness_first[1] in first_avail
+    and witness_second[1] in second_avail
+    and witness_j2 == 2
+    and flipped_witness_j2 == -2
+    and witness_avail == all_candidates
+    and flipped_witness_avail == tuple()
+    and tuple(sorted(flipped_witness_avail)) != flip_availability(witness_avail)
+)
+check(
+    "B5 chiral toy one-step closure violation witness",
+    b5_ok,
+    (
+        f"J2={witness_j2} flip_J2={flipped_witness_j2} "
+        f"avail={witness_avail} flip_avail={flipped_witness_avail} "
+        f"reachable=({witness_first[1] in first_avail},{witness_second[1] in second_avail})"
+    ),
+)
+
+b6_ok = True
+sites3 = all_sites(3)
+for M in PROPER:
+    for _ in range(3):
+        target = sites3[int(rng.integers(0, len(sites3)))]
+        pool = [i for i, s in enumerate(sites3) if s != target]
+        nrec = int(rng.integers(0, 6))
+        chosen = rng.choice(pool, size=nrec, replace=False)
+        config = {
+            sites3[int(i)]: int(rng.integers(0, len(AX)))
+            for i in chosen
+        }
+        moved_config = transform_config(config, M, 3)
+        moved_target = transform_site(target, M, 3)
+        lhs = available(moved_config, 3, moved_target, True)
+        rhs = transformed_candidates(available(config, 3, target, True), M)
+        b6_ok = b6_ok and (tuple(sorted(lhs)) == rhs)
+check(
+    "B6 chiral toy proper torus covariance",
+    b6_ok,
+    f"proper_elements={len(PROPER)} random_configs_each=3",
+)
+
+
+# Section C.
+history = (
+    witness_first,
+    witness_second,
+    (witness_target, 0),
+)
+history_ok, history_config, history_trace = history_reachable(history, 3, False)
+flipped_history = tuple((site, NEG[content]) for site, content in history)
+flipped_history_ok, flipped_history_config, flipped_trace = history_reachable(
+    flipped_history, 3, False
+)
+nonzero_sites = []
+for site in sites3:
+    val = j2(slot_pattern(history_config, 3, site))
+    if val != 0:
+        nonzero_sites.append((site, val))
+c1_ok = history_ok and flipped_history_ok and bool(nonzero_sites)
+check(
+    "C1 achiral toy spontaneous J2 registration",
+    c1_ok,
+    (
+        f"history_available={[content in avail for _, content, avail in history_trace]} "
+        f"flip_history_available={[content in avail for _, content, avail in flipped_trace]} "
+        f"first_nonzero={nonzero_sites[0] if nonzero_sites else None}"
+    ),
+)
+
+
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")


### PR DESCRIPTION
## Summary

Bootstrap continuation — both named targets from the empty-state
bootstrap: the A0 locus-class question (narrowed by derivation) and
second-step propagation (settled by an inductive closure theorem with a
maximal converse witness).

- **Theorem 1 (nonemptiness — first derivation consuming the new
  "Records form." axiom sentence):** records occur; each locks an
  available possibility; the first record's availability set is A0 =>
  A0 is NONEMPTY and (with the bootstrap's proper-invariance) contains a
  full proper orbit. The realized alphabet starts with at least one
  orbit's worth of contents.
- **Theorem 2 (free-orbit reduction):** every orbit with a nontrivial
  proper stabilizer lies on a rotation axis (all 23 computed), every
  axis is improper-stabilized, hence every such orbit is AUTOMATICALLY
  achiral; orbit size < 24 iff nontrivial stabilizer. Set-level chirality
  requires an unpaired FREE off-mirror orbit — everything with any
  symmetry is derivably safe, and the locus-class question reduces to the
  free off-mirror part of A0.
- **Theorem 3 (propagation closure):** achiral rule => one-step closure
  holds universally (avail(flip C, s) = flip(avail(C, s)); 200 random
  configs exact) => by induction the reachable class is flip-closed at
  every record count (endpoint witness: full BFS to depth 3 on the L=2
  quotient, layers 1/48/936/9936 all closed). Converse witness: a chiral
  toy rule driven by the proper-covariant flip-odd channel
  J2 = sum det(d, e, c(e)) breaks one-step closure at a REACHABLE
  two-record configuration — maximally (avail(C) = all six,
  avail(flip C) = EMPTY; J2 = +-2), reachability verified step-by-step;
  the rule stays proper-covariant (all 24 checked): the asymmetry is
  precisely improper, the one bit.
- **Theorem 4 (L=2 parity protection + spontaneous registration):** on
  the L=2 quotient antipodal slot duplication kills J2 identically —
  direction-sensitive rule chirality needs L >= 3. And an achiral-rule
  history can register nonzero J2 (orientation in the state) while its
  flipped history is equally reachable: class symmetry, config-level
  breaking — the state-vs-law separation witnessed dynamically.

Honest scoping: toy rules are toys (no claim about the fixed rule);
Theorem 3's converse is a witness, not a universal converse; Theorem 1
uses occurrence only (formation selection stays downstream); in-review
companions in prose only.

## Changes

- 1 note: `docs/BOOTSTRAP_CONTINUATION_AVAILABILITY_NONEMPTY_FREE_ORBIT_REDUCTION_PROPAGATION_CLOSURE_BOUNDED_THEOREM_NOTE_2026-07-04.md`
- 1 runner: `scripts/bootstrap_continuation_nonempty_free_orbit_propagation_closure_2026_07_04.py`
- 1 cache: `logs/runner-cache/bootstrap_continuation_nonempty_free_orbit_propagation_closure_2026_07_04.txt`

## Test plan

- Runner re-run in a clean worktree off origin/main: `TOTAL: PASS=12 FAIL=0`
- Cache regenerated via `runner_cache.execute_runner`/`write_cache`
- Axiom quotes (including "Records form.") verified verbatim against the
  memo at the branch point; reviewer reconciles at landing as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
