### PR TITLE
Born form via composite Gleason: bridge-conditional note (re-opened on main after #4915 direct-land)

### DIFF
--- a/docs/BORN_FORM_FROM_LAWFUL_GRADED_CONSTRAINT_COMPOSITE_GLEASON_BRIDGE_NOTE_2026-07-04.md
+++ b/docs/BORN_FORM_FROM_LAWFUL_GRADED_CONSTRAINT_COMPOSITE_GLEASON_BRIDGE_NOTE_2026-07-04.md
@@ -1,0 +1,186 @@
+---
+claim_id: born_form_from_lawful_graded_constraint_composite_gleason_bridge_note_2026-07-04
+claim_type: bounded_theorem
+claim_scope: "Bridge-conditional: if a lawful graded record-conditioned constraint exists and exposes full neighbor-composite projection menus, Gleason's theorem forces Born trace form on the composite and therefore on single-site restrictions. The grading primitive and entangled-menu eligibility are assumed here, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+bridge_inputs:
+  - gleason_theorem_1957
+runner: scripts/born_form_composite_gleason_bridge_2026_07_04.py
+---
+
+# Born Form From Lawful Graded Constraint via Composite Gleason (Bridge Note)
+
+**Date:** 2026-07-04
+**Type:** bounded_theorem
+**Claim type:** bounded_theorem, bridge-conditional
+**Audit-status authority:** independent audit lane only. This note sets no audit
+verdict and predicts none.
+**Primitive status:** no primitive is approved, registered, edited, or enlarged
+here. The graded-constraint premise is conditional input only.
+**Primary runner:**
+[`scripts/born_form_composite_gleason_bridge_2026_07_04.py`](../scripts/born_form_composite_gleason_bridge_2026_07_04.py)
+
+## Purpose
+
+The landed framework supplies a `Z^3` nearest-neighbor lattice, one-site
+possibility algebra `M_2(C)`, local admissibility by nearest-neighbor
+conditions, and Record content: Records form.; when present, a record locks
+exactly one admissible local possibility, records are permanent, one site
+carries at most one record, only records are readable, and finite scalar readout
+is additive over disjoint records. Those axioms do not supply probabilities,
+weights, dynamics, update rules, or record-production processes.
+
+This note isolates one conditional mathematical point in the graded-constraint
+program: if record influence on possibility menus is lawfully graded, and if
+the local lattice structure exposes the full projection lattice of a neighbor
+composite, then the form of that grading is forced. The note does not claim that
+the grading primitive exists.
+
+## Bridge Input
+
+**Bridge input:** Gleason's theorem (1957) - every non-negative frame function
+on the projection lattice of a Hilbert space of dimension >= 3 has the form
+`w(P) = Tr(rho P)` for a density operator `rho`.
+
+This is cited as classical mathematics, not re-proved. The framework-specific
+content is the lattice/composite use of that bridge: a one-site `M_2(C)` surface
+has the usual dimension-2 loophole, while a nearest-neighbor bonded pair has
+`M_2 tensor M_2 = M_4`, so the composite is inside Gleason's dimension range.
+
+## Hypotheses
+
+**H1 (grading exists).** There is a weight function `w >= 0` defined on every
+projection of the relevant algebra, with `w(0) = 0` and `w(identity) = 1`, and
+with menu-normalization `sum_i w(P_i) = 1` on every eligible menu (finite
+orthogonal resolution of the identity). This is the candidate primitive: it is
+assumed here, not claimed, derived, approved, or registered.
+
+**H2 (additivity).** For orthogonal projections `P` and `Q`, the grading is
+additive: `w(P + Q) = w(P) + w(Q)`.
+
+**H3 (non-contextuality).** The value `w(P)` does not depend on which admissible
+menu embeds `P`.
+
+**H4 (composite menus realized).** Menus range over neighbor-composite
+algebras: a bonded nearest-neighbor pair carries `M_2 tensor M_2 = M_4`, `w` is
+defined on the full projection lattice of the composite, and every finite
+orthogonal resolution of the composite identity - including resolutions that
+contain entangled projections - is menu-eligible, so H2 applies to all
+orthogonal pairs in `Proj(M_4)`. Without this full projection-measure strength
+a partial menu assignment is not a frame function and Gleason does not apply
+(refutation-seat finding, 2026-07-04).
+
+H4 is a substantive physical hypothesis, not axiom content. The minimal axioms
+supply site-local possibility domains with neighbor-dependent availability -
+not a pair-level possibility domain, not bonded-pair selection, not
+configuration-independent menu eligibility, and not records that lock composite
+entangled possibilities. Any registration of the graded-constraint primitive
+must therefore specify: which neighbor pairs carry composite menus; whether
+eligibility depends on the record configuration; how pair menus coexist with
+site-local admissibility; and in what sense entangled projections are
+alternatives. Those four items are the registration's specification burden,
+declared here rather than hidden.
+
+## Results
+
+**R1 (single-site exception, constructive).** On one `M_2(C)` site alone,
+H1-H3 do not force the Born form. Rank-1 one-site projections are indexed by
+Bloch directions `n`, with binary menus `{P(n), P(-n)}`. Any assignment
+`g(n) >= 0` with `g(n) + g(-n) = 1` is a normalized frame function on those
+menus. A non-quadratic example is the hemisphere/sign rule used by the runner:
+`g(n)=1` when `(n_z,n_y,n_x)` is lexicographically positive and `g(n)=0`
+otherwise, with the equator made well-defined by the same lexicographic tie
+rule. It normalizes every antipodal menu and is non-contextual on the one-site
+binary menus, and it extends to rank `0` and rank `2` by `g(0) = 0`,
+`g(I) = 1`. Its non-quadraticity is exact, not merely sampled: any trace form
+is affine in the Bloch direction, so `g(e_x) = g(e_z) = 1` with `g(I) = 1`
+forces the value `1/2` at the direction `(e_x - e_z)/sqrt(2)`, while the
+lexicographic rule assigns `0` there. Three directions plus normalization
+refute every `2x2` trace form at once; the sampled least-squares fit is kept
+only as a secondary bound and control.
+
+**R2 (composite rescue).** A bonded neighbor pair has Hilbert dimension `4`,
+which is `>= 3`, so Gleason applies to any `w` satisfying H1-H4 on the pair.
+There is a density operator `rho` on the pair such that `w(E) = Tr(rho E)` for
+composite projections `E`. For embedded single-site projections this gives
+`w(P tensor I) = Tr(rho (P tensor I)) = Tr(rho_1 P)`, where `rho_1` is the
+partial trace over the neighbor. Thus the single-site restriction is quadratic:
+it has Born form. The value of `rho` is determined by conditioning, here by
+records, but this note does not derive those values.
+
+**R3 (exception voided).** The R1 rogue functions do not extend to any grading
+that satisfies H1-H4 on the neighbor composite. If such an extension existed,
+R2 would force the embedded single-site restriction to have the quadratic Born
+form `Tr(rho_1 P)`, contradicting the explicit non-quadratic R1 assignment. The
+nearest-neighbor lattice is what makes a composite available; H4's full
+composite projection measure is what voids the dimension-2 loophole. The
+attribution matters: adjacency alone pays for nothing here without H4's
+strength.
+
+**R4 (zero-information limit).** Under an explicit additional premise -
+invariance of `w` under every unitary automorphism of the composite, whose
+commutant is scalar - `rho = I/d` follows. This full-symmetry premise is named
+here; it is not derived from H1-H4 or from the minimal axioms, and "no
+conditioning records" alone does not supply it. Under it, weights are uniform
+on symmetric menus: `1/2` on embedded one-site rank-1 binary alternatives in a
+pair, and `1/4` on the Bell-basis rank-1 composite menu. This is consistent
+with the landed uniform-on-orbits results and adds no new selection claim.
+
+## No-Go Discipline Gate
+
+- **N1 route inventory:** direct one-site Gleason is unavailable in dimension
+  `2`; imposing H1-H3 alone leaves the constructive rogue `g`; using the
+  neighbor composite invokes an explicit bridge input plus H4; deriving grading
+  values from records is downstream and not attempted.
+- **N2 primitive boundary:** H1 is the candidate primitive. The note assumes it
+  only to determine form; it does not approve, register, rename, or strengthen
+  any primitive.
+- **N3 hidden-wall scan:** H4 does not smuggle dynamics - no rates, histories,
+  updates, transition kernels, Hamiltonians, or record-production. It DOES
+  import pair-level menu ontology beyond the minimal axioms (pair possibility
+  domain, entangled alternatives, eligibility structure); that import is
+  declared inside H4 as the registration's specification burden rather than
+  hidden.
+- **N4 bridge-source honesty:** Gleason's theorem is imported as named
+  classical mathematics. The runner checks the finite-dimensional consequences
+  used here; it does not pretend to re-prove Gleason.
+- **N5 steelman:** "This is just textbook Gleason." Reply: the bridge input is
+  textbook, but the framework content is R1/R3 plus H4's declared specification
+  burden - one `M_2(C)` site admits rogue frame functions, and the neighbor
+  composite is where H4's projection-measure strength voids the loophole.
+- **N6 hidden-value scan:** The theorem fixes form, not values. Record
+  conditioning of `rho`, if admitted anywhere, is downstream content outside
+  this note.
+- **N7 scope guard:** The note does not touch orientation, scale, rate, time,
+  readout-context selection, record production, or physical persistence. It is
+  only a conditional bridge about menu weights.
+- **N8 audit hygiene:** No audit verdict is set, forecast, or implied; no axiom
+  or primitive file is changed; no claim is made that H4 follows from the
+  minimal axioms.
+
+## Non-Claims
+
+- Does **not** claim H1, the graded-constraint primitive, is approved or exists.
+- Does **not** derive weight values; record-conditioning of `rho` is downstream.
+- Does **not** touch orientation, rate, scale, record production, dynamics,
+  update rules, or persistence.
+- Does **not** set an audit verdict or close a wall.
+- Does **not** re-prove Gleason's theorem; Gleason is the named bridge input.
+
+## Verification
+
+The companion runner is a mechanical harness, not the proof: the load-bearing
+steps are the named bridge input and the exact R1 contradiction. It performs
+needle checks against the note and the minimal axiom memo; constructs the R1
+rogue frame function and verifies the exact three-direction contradiction
+against every `2x2` trace form, keeping the sampled least-squares
+Hermitian-trace-form fit (a superset of Born density forms) as a secondary
+bound with a Born-form control; verifies partial-trace bookkeeping identities
+for product, Bell, and maximally mixed states (implementation checks, not R2
+evidence); checks embedded and Bell menu normalization; checks the maximally
+mixed consequences for the separately-premised R4 limit; and exercises
+additivity and non-contextuality rejectors. R3 is carried as a corollary of
+the bridge input plus the exact R1 contradiction, and the runner labels it so.
+
+Measured runner total after final verification: `TOTAL: PASS=24 FAIL=0`.

--- a/scripts/born_form_composite_gleason_bridge_2026_07_04.py
+++ b/scripts/born_form_composite_gleason_bridge_2026_07_04.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Deterministic checks for the composite-Gleason Born-form bridge note."""
+
+from pathlib import Path
+import math
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "BORN_FORM_FROM_LAWFUL_GRADED_CONSTRAINT_COMPOSITE_GLEASON_BRIDGE_NOTE_2026-07-04.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+TOL = 1e-12
+
+
+def normalize(text):
+    return " ".join(text.split())
+
+
+def close(a, b, tol=TOL):
+    return abs(a - b) <= tol
+
+
+def cclose(a, b, tol=TOL):
+    return abs(a - b) <= tol
+
+
+def mat_zero(n):
+    return [[0j for _ in range(n)] for _ in range(n)]
+
+
+def mat_eye(n):
+    m = mat_zero(n)
+    for i in range(n):
+        m[i][i] = 1.0 + 0j
+    return m
+
+
+def mat_add(a, b):
+    n = len(a)
+    p = len(a[0])
+    return [[a[i][j] + b[i][j] for j in range(p)] for i in range(n)]
+
+
+def mat_sub(a, b):
+    n = len(a)
+    p = len(a[0])
+    return [[a[i][j] - b[i][j] for j in range(p)] for i in range(n)]
+
+
+def mat_scale(s, a):
+    return [[s * x for x in row] for row in a]
+
+
+def mat_trace(a):
+    return sum(a[i][i] for i in range(len(a)))
+
+
+def mat_mul(a, b):
+    n = len(a)
+    p = len(b[0])
+    inner = len(b)
+    out = mat_zero(n)
+    for i in range(n):
+        for j in range(p):
+            total = 0j
+            for k in range(inner):
+                total += a[i][k] * b[k][j]
+            out[i][j] = total
+    return out
+
+
+def trace_product(a, b):
+    return mat_trace(mat_mul(a, b))
+
+
+def max_abs_entry(a):
+    return max(abs(x) for row in a for x in row)
+
+
+def tensor(a, b):
+    n = len(a)
+    p = len(a[0])
+    q = len(b)
+    r = len(b[0])
+    out = [[0j for _ in range(p * r)] for _ in range(n * q)]
+    for i in range(n):
+        for j in range(p):
+            for k in range(q):
+                for l in range(r):
+                    out[i * q + k][j * r + l] = a[i][j] * b[k][l]
+    return out
+
+
+def rank1_projector_from_vector(v):
+    return [[v[i] * v[j].conjugate() for j in range(len(v))] for i in range(len(v))]
+
+
+def projection_from_direction(v):
+    a, b, c = v
+    norm = math.sqrt(a * a + b * b + c * c)
+    x = a / norm
+    y = b / norm
+    z = c / norm
+    return [
+        [(1.0 + z) / 2.0 + 0j, (x - 1j * y) / 2.0],
+        [(x + 1j * y) / 2.0, (1.0 - z) / 2.0 + 0j],
+    ]
+
+
+def gcd3(a, b, c):
+    return math.gcd(math.gcd(abs(a), abs(b)), abs(c))
+
+
+def reduced_direction(v):
+    g = gcd3(*v)
+    return (v[0] // g, v[1] // g, v[2] // g)
+
+
+def enumerate_bloch_sample():
+    seen = set()
+    for a in range(-2, 3):
+        for b in range(-2, 3):
+            for c in range(-2, 3):
+                if a == 0 and b == 0 and c == 0:
+                    continue
+                seen.add(reduced_direction((a, b, c)))
+    return sorted(seen)
+
+
+def rogue_weight(v):
+    a, b, c = v
+    return 1.0 if (c, b, a) > (0, 0, 0) else 0.0
+
+
+def projection_coefficients(p):
+    return [
+        p[0][0].real,
+        p[1][1].real,
+        (p[0][1] + p[1][0]).real,
+        (1j * p[1][0] - 1j * p[0][1]).real,
+    ]
+
+
+def solve_4x4(a, b):
+    aug = [list(a[i]) + [b[i]] for i in range(4)]
+    for col in range(4):
+        pivot = max(range(col, 4), key=lambda row: abs(aug[row][col]))
+        if abs(aug[pivot][col]) < 1e-14:
+            raise ValueError("singular normal equation")
+        if pivot != col:
+            aug[col], aug[pivot] = aug[pivot], aug[col]
+        scale = aug[col][col]
+        for j in range(col, 5):
+            aug[col][j] /= scale
+        for row in range(4):
+            if row == col:
+                continue
+            factor = aug[row][col]
+            for j in range(col, 5):
+                aug[row][j] -= factor * aug[col][j]
+    return [aug[i][4] for i in range(4)]
+
+
+def least_squares_rho_params(directions, values):
+    normal = [[0.0 for _ in range(4)] for _ in range(4)]
+    rhs = [0.0 for _ in range(4)]
+    rows = []
+    for v, value in zip(directions, values):
+        coeffs = projection_coefficients(projection_from_direction(v))
+        rows.append(coeffs)
+        for i in range(4):
+            rhs[i] += coeffs[i] * value
+            for j in range(4):
+                normal[i][j] += coeffs[i] * coeffs[j]
+    params = solve_4x4(normal, rhs)
+    residuals = []
+    for coeffs, value in zip(rows, values):
+        predicted = sum(coeffs[i] * params[i] for i in range(4))
+        residuals.append(abs(predicted - value))
+    return params, max(residuals), residuals
+
+
+def rho2_from_params(params):
+    a, b, c, d = params
+    return [[a + 0j, c + 1j * d], [c - 1j * d, b + 0j]]
+
+
+def partial_trace_second_qubit(rho4):
+    out = mat_zero(2)
+    for a in range(2):
+        for b in range(2):
+            out[a][b] = rho4[2 * a][2 * b] + rho4[2 * a + 1][2 * b + 1]
+    return out
+
+
+def bell_projectors():
+    inv = 1.0 / math.sqrt(2.0)
+    vectors = [
+        [inv + 0j, 0j, 0j, inv + 0j],
+        [inv + 0j, 0j, 0j, -inv + 0j],
+        [0j, inv + 0j, inv + 0j, 0j],
+        [0j, inv + 0j, -inv + 0j, 0j],
+    ]
+    return [rank1_projector_from_vector(v) for v in vectors]
+
+
+def density_matrices_4():
+    rho_zero = [[1 + 0j, 0j], [0j, 0j]]
+    rho_plus = [[0.5 + 0j, 0.5 + 0j], [0.5 + 0j, 0.5 + 0j]]
+    product = tensor(rho_zero, rho_plus)
+    entangled = bell_projectors()[0]
+    mixed = mat_scale(0.25, mat_eye(4))
+    return [("product", product), ("bell_pure", entangled), ("max_mixed", mixed)]
+
+
+def detect_bad_additivity(assignments):
+    return any(abs(sum(weights) - 1.0) > TOL for weights in assignments)
+
+
+def projection_key(p):
+    return tuple(
+        (round(x.real, 12), round(x.imag, 12))
+        for row in p
+        for x in row
+    )
+
+
+def detect_context_dependence(menu_assignments):
+    seen = {}
+    for _menu_name, p, value in menu_assignments:
+        key = projection_key(p)
+        if key in seen and abs(seen[key] - value) > TOL:
+            return True
+        seen[key] = value
+    return False
+
+
+class CheckRunner:
+    def __init__(self):
+        self.pass_count = 0
+        self.fail_count = 0
+        self.index = 1
+
+    def check(self, name, condition):
+        status = "PASS" if condition else "FAIL"
+        if condition:
+            self.pass_count += 1
+        else:
+            self.fail_count += 1
+        print(f"CHECK {self.index:02d}: {status} - {name}")
+        self.index += 1
+
+    def total(self):
+        print(f"TOTAL: PASS={self.pass_count} FAIL={self.fail_count}")
+        return self.fail_count
+
+
+def main():
+    runner = CheckRunner()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    note_norm = normalize(note)
+    axiom_norm = normalize(axiom)
+
+    runner.check(
+        "bridge input sentence names Gleason 1957 and the trace form",
+        "Gleason's theorem (1957)" in note
+        and "every non-negative frame function on the projection lattice of a Hilbert space of dimension >= 3 has the form `w(P) = Tr(rho P)`" in note_norm,
+    )
+    for label in ("H1 (grading exists)", "H2 (additivity)", "H3 (non-contextuality)", "H4 (composite menus realized)"):
+        runner.check(f"note contains hypothesis {label}", label in note)
+    runner.check(
+        "axiom file contains nearest-neighbor Z^3 adjacency sentence",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency" in axiom_norm,
+    )
+    runner.check(
+        "axiom file contains M_2(C) presentation sentence",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`." in axiom_norm,
+    )
+    runner.check(
+        "axiom file contains landed Record lock/permanence content",
+        "When present, a record locks exactly one admissible local possibility." in axiom_norm
+        and "records are permanent" in axiom_norm,
+    )
+    runner.check(
+        "axiom file contains the landed formation sentence",
+        "Records form." in axiom,
+    )
+
+    directions = enumerate_bloch_sample()
+    direction_set = set(directions)
+    runner.check(
+        "R1 sample is nonempty, antipodal, and deduplicated up to positive scaling",
+        len(directions) > 20
+        and all(tuple(-x for x in v) in direction_set for v in directions)
+        and len(directions) == len(direction_set),
+    )
+    menu_ok = True
+    additivity_ok = True
+    identity2 = mat_eye(2)
+    for v in directions:
+        neg = tuple(-x for x in v)
+        p = projection_from_direction(v)
+        q = projection_from_direction(neg)
+        if max_abs_entry(mat_sub(mat_add(p, q), identity2)) > 1e-12:
+            menu_ok = False
+        if abs(rogue_weight(v) + rogue_weight(neg) - 1.0) > TOL:
+            additivity_ok = False
+    runner.check("R1 antipodal M_2 menus resolve the identity", menu_ok)
+    runner.check("R1 rogue frame function normalizes and adds on every sampled menu", additivity_ok)
+
+    rogue_values = [rogue_weight(v) for v in directions]
+    _, rogue_max_residual, _ = least_squares_rho_params(directions, rogue_values)
+    runner.check(
+        "R1 secondary bound: sampled Hermitian trace-form fit (superset of Born forms) leaves residual > 0.05",
+        rogue_max_residual > 0.05,
+    )
+
+    g_ex = rogue_weight((1, 0, 0))
+    g_ez = rogue_weight((0, 0, 1))
+    g_u = rogue_weight((1, 0, -1))
+    m_ex = 2.0 * g_ex - 1.0
+    m_ez = 2.0 * g_ez - 1.0
+    m_u = (m_ex - m_ez) / math.sqrt(2.0)
+    predicted_u = 0.5 * (1.0 + m_u)
+    runner.check(
+        "R1 exact three-direction contradiction: trace form forces 1/2 at (e_x-e_z)/sqrt(2), rogue assigns 0",
+        g_ex == 1.0 and g_ez == 1.0 and g_u == 0.0
+        and close(predicted_u, 0.5) and abs(predicted_u - g_u) > 0.4,
+    )
+    runner.check(
+        "R1 rogue rank-0/rank-2 extension: g(0)=0, g(I)=1 completes every menu to w(I)",
+        0.0 == 0.0 and 1.0 == 1.0
+        and all(abs(rogue_weight(v) + rogue_weight(tuple(-x for x in v)) + 0.0 - 1.0) <= TOL for v in directions),
+    )
+
+    born_rho = [[0.65 + 0j, 0.10 + 0.15j], [0.10 - 0.15j, 0.35 + 0j]]
+    born_values = [trace_product(born_rho, projection_from_direction(v)).real for v in directions]
+    born_params, born_max_residual, _ = least_squares_rho_params(directions, born_values)
+    born_fit = rho2_from_params(born_params)
+    runner.check(
+        "R1 least-squares control recovers genuine 2x2 Born-form data",
+        born_max_residual < 1e-9 and max_abs_entry(mat_sub(born_rho, born_fit)) < 1e-9,
+    )
+
+    identity4 = mat_eye(4)
+    densities = density_matrices_4()
+    reduction_ok = True
+    embedded_menu_ok = True
+    bell_menu_ok = True
+    bells = bell_projectors()
+    bell_sum = mat_zero(4)
+    for bproj in bells:
+        bell_sum = mat_add(bell_sum, bproj)
+    bell_basis_resolves = max_abs_entry(mat_sub(bell_sum, identity4)) < 1e-12
+    for _name, rho4 in densities:
+        rho1 = partial_trace_second_qubit(rho4)
+        for v in directions:
+            p = projection_from_direction(v)
+            embedded = tensor(p, mat_eye(2))
+            left = trace_product(rho4, embedded).real
+            right = trace_product(rho1, p).real
+            if abs(left - right) > 1e-12:
+                reduction_ok = False
+            neg = projection_from_direction(tuple(-x for x in v))
+            w_menu = left + trace_product(rho4, tensor(neg, mat_eye(2))).real
+            if abs(w_menu - 1.0) > 1e-12:
+                embedded_menu_ok = False
+        bell_weights = [trace_product(rho4, bproj).real for bproj in bells]
+        if any(w < -1e-12 for w in bell_weights) or abs(sum(bell_weights) - 1.0) > 1e-12:
+            bell_menu_ok = False
+        if abs(
+            trace_product(rho4, mat_add(bells[0], bells[1])).real
+            - (bell_weights[0] + bell_weights[1])
+        ) > 1e-12:
+            bell_menu_ok = False
+    runner.check("R2 bookkeeping (implementation identity): embedded P tensor I weights equal partial-trace single-site weights", reduction_ok)
+    runner.check("R2 bookkeeping (implementation identity): embedded composite menus normalize for product, entangled, and mixed states", embedded_menu_ok)
+    runner.check("R2 bookkeeping (implementation identity): Bell entangled menu resolves identity and normalizes/adds", bell_basis_resolves and bell_menu_ok)
+    runner.check(
+        "R3 corollary support: exact R1 contradiction bars any composite Gleason extension (bridge input carries the corollary)",
+        abs(predicted_u - g_u) > 0.4,
+    )
+
+    mixed4 = mat_scale(0.25, mat_eye(4))
+    uniform_embedded = all(
+        abs(trace_product(mixed4, tensor(projection_from_direction(v), mat_eye(2))).real - 0.5) < 1e-12
+        for v in directions
+    )
+    uniform_bell = all(abs(trace_product(mixed4, bproj).real - 0.25) < 1e-12 for bproj in bells)
+    runner.check("R4 consequence check (full-symmetry premise supplied separately): maximally mixed gives 1/2 on embedded rank-1 site projections", uniform_embedded)
+    runner.check("R4 consequence check (full-symmetry premise supplied separately): maximally mixed gives 1/4 on every Bell-basis element", uniform_bell)
+
+    runner.check(
+        "rejector detects broken additivity on a binary menu",
+        detect_bad_additivity([[0.75, 0.75]]),
+    )
+    runner.check(
+        "rejector detects context-dependent weights on a shared projection",
+        detect_context_dependence([
+            ("bell_menu", bells[0], 0.25),
+            ("alternate_menu", bells[0], 0.30),
+        ]),
+    )
+
+    failures = runner.total()
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Re-opens the seat-repaired Born-form bridge note that closed unmerged when its stack base (#4915's branch) was closed in favor of the direct land. Content identical to the reviewed version; runner re-verified against main (the landed formation sentence needle now passes on main directly): **PASS=24 FAIL=0**.

Summary: IF grading is a full projection-lattice frame function on nearest-neighbor composites (H1-H4, with H4 declared as the substantive physical hypothesis carrying four specification obligations), THEN Gleason (named bridge input) forces Born trace form on single-site restrictions; the one-site M_2 rogue frame function is exhibited and refuted exactly (three directions + normalization). Attribution corrected per seats: adjacency makes the composite available; H4's projection-measure strength voids the dimension-2 loophole.

Cross-reference: the interface-consistency note (PR opening alongside) found the v1 pager core's menu-normalization wording defective and produced core v2 (conditioning form) — v2 supplies exactly the full-lattice frame-function strength this note's hypotheses need, so the two are consistent; H-block language keys to v2 at the next re-key wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)