### PR TITLE
fix(runners): repair two stale sibling-interface references (mechanical)

### DIFF
--- a/logs/runner-cache/frontier_dm_leptogenesis_pmns_selector_bank_cp_sheet_blindness_theorem.txt
+++ b/logs/runner-cache/frontier_dm_leptogenesis_pmns_selector_bank_cp_sheet_blindness_theorem.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_dm_leptogenesis_pmns_selector_bank_cp_sheet_blindness_theorem.py
-runner_sha256: efd2cace1340bcd4e73aa0d503c5c5c51ea736fae135457c09b571d65fb23bd4
-timeout_sec: 120
+runner_sha256: efefef2c830ed90d58fd4ce9cda8f43815f62ddbb983c8be2d8000ba7818a508
+timeout_sec: 300
 exit_code: 0
-elapsed_sec: 17.26
+elapsed_sec: 5.39
 status: ok
 ----- stdout -----
 ========================================================================================
@@ -18,9 +18,9 @@ Question:
 PART 1: CURRENT EXACT CLOSURE LAWS ARE CP-SHEET BLIND
 ========================================================================================
   [PASS] The minimum-information closure law keeps exact closure and information cost under delta -> -delta  (eta_flip=1.000000000000, ΔI=0.000e+00)
-  [PASS] Its displayed representative therefore has an equally selected opposite-CP partner  (rep=(gamma,E1,E2)=(-2.874e-09,-0.192115,-0.419208))
+  [PASS] Its displayed representative therefore has an equally selected opposite-CP partner  (rep=(gamma,E1,E2)=(-2.253e-09,-0.192115,-0.419208))
   [PASS] The observable-relative-action closure law also keeps exact closure and relative action under delta -> -delta  (eta_flip=1.000000000000, ΔS=0.000e+00)
-  [PASS] Its displayed representative likewise has an equally selected opposite-CP partner  (rep=(gamma,E1,E2)=(-1.435e-07,0.008979,-0.439435))
+  [PASS] Its displayed representative likewise has an equally selected opposite-CP partner  (rep=(gamma,E1,E2)=(-3.049e-09,0.008977,-0.439435))
 
 ========================================================================================
 PART 2: TRANSPORT-POSITIVE CANDIDATES ARE STILL CP-SHEET BLIND

--- a/logs/runner-cache/frontier_gr_class_expansion_finite_rank_target.txt
+++ b/logs/runner-cache/frontier_gr_class_expansion_finite_rank_target.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_gr_class_expansion_finite_rank_target.py
-runner_sha256: f6e37590b1c22de23917ee5e7a7d4a19f173cbce45e986afd9567c9a36e95bc4
-timeout_sec: 120
+runner_sha256: dac4ee96af37b1cd4b3aecf87e1b96f2d502c9e238d0edb8e15ef557bddd604e
+timeout_sec: 300
 exit_code: 0
-elapsed_sec: 3.35
+elapsed_sec: 1.70
 status: ok
 ----- stdout -----
 GR CLASS EXPANSION AUDIT
@@ -12,25 +12,18 @@ GR CLASS EXPANSION AUDIT
   Candidate: exact finite-rank source-to-metric theorem
 
 [EXACT] PASS: finite-rank column identity
-    max column error=3.886e-16, support size=7
+    max column error=3.331e-16, support size=7
 [EXACT] PASS: finite-rank compressed source
-    max field error=9.992e-16
+    max field error=7.772e-16, q_eff_sum=9.53220124
 [EXACT] PASS: finite-rank exterior harmonicity outside support
-    max exterior residual=1.277e-15
-
-exact finite-rank family:
-  R_match=3.0  a=0.357088  shell_rms=0.126  shell_max_rel=0.841  direct=9.851e-02  coarse=7.393e-05
-  R_match=3.5  a=0.315750  shell_rms=0.125  shell_max_rel=0.628  direct=9.650e-02  coarse=3.848e-05
-  R_match=4.0  a=0.297284  shell_rms=0.125  shell_max_rel=0.533  direct=9.638e-03  coarse=2.125e-05
-  R_match=4.5  a=0.259967  shell_rms=0.111  shell_max_rel=0.340  direct=2.793e-02  coarse=1.188e-05
-  R_match=5.0  a=0.239107  shell_rms=0.094  shell_max_rel=0.233  direct=1.039e-02  coarse=7.028e-06
+    max exterior residual=1.055e-15
 support size=7, q_eff_sum=9.53220124
 best coarse row: R_match=5.0, a=0.239107, shell_rms=0.094, direct=1.039e-02, coarse=7.028e-06
 
 [EXACT] PASS: finite-rank source renormalization is exact
-    boundary reconstruction error=6.939e-17
+    boundary reconstruction error=6.245e-17
 [EXACT] PASS: the microscopic boundary action is stationary on the finite-rank class
-    flux_err=4.163e-16, stationary_grad=4.163e-16
+    flux_err=3.331e-16, stationary_grad=3.331e-16
 [BOUNDED] PASS: the finite-rank class admits a vacuum-close coarse-grained scalar exterior metric
     R_match=5.0, direct=1.039e-02, coarse=7.028e-06
 [BOUNDED] PASS: the direct `3+1` metric residual remains nonzero

--- a/scripts/frontier_dm_leptogenesis_pmns_selector_bank_cp_sheet_blindness_theorem.py
+++ b/scripts/frontier_dm_leptogenesis_pmns_selector_bank_cp_sheet_blindness_theorem.py
@@ -137,9 +137,9 @@ def part2_transport_positive_candidates_are_still_cp_sheet_blind() -> None:
     print("PART 2: TRANSPORT-POSITIVE CANDIDATES ARE STILL CP-SHEET BLIND")
     print("=" * 88)
 
-    x_opt, y_opt, delta_opt, _packet_opt, etas_opt = quiet_call(cand.part2_transport_extremality_selects_a_positive_off_seed_candidate)
+    x_opt, y_opt, delta_opt, _packet_opt, etas_opt = quiet_call(cand.part2_transport_search_finds_an_off_seed_overshoot_witness)
     x_close, y_close, delta_close, _packet_close, etas_close = quiet_call(
-        cand.part3_continuity_gives_an_exact_full_closure_point, x_opt, y_opt, delta_opt
+        cand.part3_continuity_gives_an_interpolated_closure_witness, x_opt, y_opt, delta_opt
     )
 
     _packet_opt_flip, etas_opt_flip = cand.eta_columns_from_active(x_opt, y_opt, -delta_opt)

--- a/scripts/frontier_gr_class_expansion_finite_rank_target.py
+++ b/scripts/frontier_gr_class_expansion_finite_rank_target.py
@@ -56,8 +56,7 @@ def main() -> int:
 
     phi_full, support, interior, q_eff = finite_rank.exact_finite_rank_field()
     boundary = finite_rank.boundary_stationarity_report(phi_full)
-    coarse_report = finite_rank.coarse_metric_report(phi_full)
-    best = coarse_report["best"]
+    _coarse_rows, best, _coarse_ratio = finite_rank.coarse_metric_report(phi_full)
 
     print(f"support size={len(support)}, q_eff_sum={np.sum(q_eff):.8f}")
     print(


### PR DESCRIPTION
## What this responds to

Follow-up to the stale-green sweep (PR #4943), which diagnosed 30 Class-D
stale-green runners in its body without committing fixes. The umbrella directive
was to correctly fix the *mechanically-fixable* Class-D items — stale
sibling-reference / indexing / exit-path bugs — while routing anything that turns
out to be a masked science failure to the science loop instead of papering over it.

Three items were queued as "mechanical." Each was **investigated first** to confirm
it is genuinely a stale-reference bug and not a masked science failure (the
must-fail-if-wrong test), *before* any edit. Result: **two are genuine mechanical
fixes (landed here); one is a masked science regression (escalated, untouched).**

## The two mechanical fixes (this PR)

**1. `frontier_gr_class_expansion_finite_rank_target`** — tuple/dict interface drift.
The sibling `frontier_finite_rank_source_to_metric_theorem.coarse_metric_report`
now returns a 3-tuple `(rows, best, ratio)`; the runner still indexed it as a dict
(`coarse_report["best"]` → `TypeError`). Repointed to tuple-unpack. `best` is still
`min(rows, key=lambda row: row[5])`, a 6-tuple, and the runner's reads `best[0,1,2,4,5]`
remain consistent with it. The discriminating `BOUNDED` checks (`best[5] < 1e-5`
vacuum-close coarse residual; `best[4] > 0` nonzero direct residual) and the
exact source-renormalization / boundary-stationarity gates are untouched.
Live re-run: `PASS=4 FAIL=0`, exit 0.

**2. `frontier_dm_leptogenesis_pmns_selector_bank_cp_sheet_blindness_theorem`** —
sibling function rename. The sibling
`frontier_dm_leptogenesis_pmns_transport_extremal_source_candidate` renamed its
`part2`/`part3` entry points; the runner still called the removed names
(`AttributeError`). Repointed to the current names
(`part2_transport_search_finds_an_off_seed_overshoot_witness`,
`part3_continuity_gives_an_interpolated_closure_witness`). Semantics preserved:
part2 still yields an `eta > 1` overshoot witness and part3 still yields the
`eta = 1` closure to 1e-10, so the runner's own opposite-CP-symmetry and
off-mainline-landing gates (which do the actual science discrimination) are
unchanged and still pass. Live re-run: `PASS=13 FAIL=0`, exit 0.

Both caches were regenerated **only after** each genuinely passed live
(`exit_code: 0` in each cache header). No note edits, no gate weakening, no
verdict changes.

## The third item is NOT mechanical — escalated, not touched here

**`frontier_g_bare_two_ward_closure`** was queued as a mechanical "verdict/exit
reconcile," but investigation shows it is a **genuine science regression**, so it
is deliberately left honestly red (`PASS=17 FAIL=1`, exit 1) and routed to the
science loop instead.

The runner's Block 5 gates on the authority note
`docs/YT_WARD_IDENTITY_DERIVATION_THEOREM.md` asserting the two representations
of `Γ⁴(q²)` *"must agree"* as a **forcing** identity, and Block 6 then **solves**
`g_bare² = 2 N_c y_t_bare² = 1` and prints `VERDICT: CLOSED` (g_bare = 1 *derived*
via the two-Ward closure). But that note was repaired upstream (commit `2fc3c1c3b4`,
"Repair YT Ward identity derivation") to **retract the forcing claim**: it now
evaluates Representation A *"at canonical g_bare = 1"* and states *"the agreement
… confirms internal consistency of the framework **but is not the source of the
value**,"* tracing g_bare = 1 to the *"algebraic g_bare = 1 rescaling convention"*
(an input), not a derivation.

Re-pinning the runner's needle to the note's new "…values agree at the canonical
surface" phrasing would let it keep printing `VERDICT: CLOSED` / "Therefore →
g_bare = 1" while the authority note has conceded exactly that derivation is only a
consistency check. That fails the must-fail-if-wrong test, so it is **not** a
mechanical re-pin. Block 5 is a correctly discriminating gate doing its job; the
honest `FAIL=1` is the right signal. Resolution (downgrade the runner's CLOSED
framing to match the repaired note, or adjudicate whether the closure genuinely
pins g_bare) is science-loop work, reported here only — not committed to `docs/`.

## Files
- `scripts/frontier_gr_class_expansion_finite_rank_target.py`
- `scripts/frontier_dm_leptogenesis_pmns_selector_bank_cp_sheet_blindness_theorem.py`
- `logs/runner-cache/` caches for both (regenerated post-pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)