### PR TITLE
science: bound neutrino source amplitude carrier premise

### DIFF
--- a/docs/DM_NEUTRINO_SOURCE_AMPLITUDE_THEOREM_NOTE_2026-04-15.md
+++ b/docs/DM_NEUTRINO_SOURCE_AMPLITUDE_THEOREM_NOTE_2026-04-15.md
@@ -1,10 +1,10 @@
 # DM Neutrino Source-Amplitude Theorem
 
-**Claim type:** positive_theorem
+**Claim type:** bounded_theorem
 
 **Date:** 2026-04-15  
-**Status:** exact sharp-branch source-amplitude theorem on the refreshed
-`main`-derived DM lane  
+**Status:** bounded conditional sharp-branch source-amplitude result on the
+named-input `K_R` carrier definition
 **Script:** `scripts/frontier_dm_neutrino_source_amplitude_theorem.py`
 
 ## Framework sentence
@@ -19,11 +19,11 @@ left on the source side?
 
 Can the selector amplitude `a_sel` and the symmetric weak source amplitude
 `tau_+ = tau_E + tau_T` be fixed canonically on the sharp source-oriented
-branch?
+branch, inside the named-input `K_R` carrier definition?
 
 ## Bottom line
 
-Yes.
+Yes, inside that bounded carrier context.
 
 On the sharp source-oriented branch:
 
@@ -31,14 +31,29 @@ On the sharp source-oriented branch:
 - `tau_E = tau_T = 1/2`
 - `tau_+ = 1`
 
-Therefore, using the already-derived transfer coefficients,
+Therefore, using the already-derived transfer coefficients inside the same
+bounded source package,
 
 - `gamma = c_odd a_sel = 1/2`
 - `E1 = sqrt(8/3) tau_+ = sqrt(8/3)`
 - `E2 = (sqrt(8)/3) tau_+ = sqrt(8)/3`
 
 So on the refreshed `main`-derived branch, the source side is no longer a
-floating pair of amplitudes on the sharp branch. It is canonically fixed.
+floating pair of amplitudes on the sharp branch once the named-input `K_R`
+carrier definition is supplied. This does not derive that carrier as a
+physical primitive.
+
+## 2026-07-04 scope repair
+
+The upstream `S3_TIME_BILINEAR_TENSOR_PRIMITIVE_NOTE.md` now records `K_R` as a
+class-A definition under named admitted inputs `(delta_A1, u_E, u_T)`. It
+explicitly does not derive those inputs, the decoupling fact, the
+aligned-bright coordinates, or a physical tensor-primitive interpretation.
+
+This note is therefore not an exact physical weak-carrier theorem. Its
+load-bearing result is conditional: given the named-input `K_R` row factor and
+the sharp source-oriented projection, the source amplitudes are fixed as
+`a_sel = 1/2`, `tau_E = tau_T = 1/2`, and `tau_+ = 1`.
 
 ## Selector amplitude
 
@@ -71,7 +86,7 @@ So the canonical sharp selector amplitude is
 
 ## Symmetric weak source amplitude
 
-The exact weak source carrier is the two-column bright bundle
+The named-input weak source carrier definition is the two-column bright bundle
 
 `K_R(q) = [[u_E(q), u_T(q)], [delta_A1(q)u_E(q), delta_A1(q)u_T(q)]]`.
 
@@ -100,23 +115,26 @@ The coefficient theorems already gave:
 - `c_odd = +1`
 - `v_even = (sqrt(8/3), sqrt(8)/3)`.
 
-Substituting the sharp source amplitudes gives the exact triplet-side source
+Substituting the sharp source amplitudes gives the bounded triplet-side source
 data
 
 - `gamma = 1/2`
 - `E1 = sqrt(8/3)`
 - `E2 = sqrt(8)/3`.
 
-That is the strongest exact source-side closure point reached so far on the
-refreshed `main`-derived DM branch.
+That is the current bounded source-amplitude point on the refreshed
+`main`-derived DM branch, conditional on the named-input `K_R` carrier
+definition.
 
-## What this does not close
+## What remains open
 
-This note does **not** yet rewrite the full leptogenesis benchmark in terms of
-these sharp source amplitudes. The existing benchmark runner still uses the
-older reduced kernel.
+This note does **not** derive the `K_R` carrier as a physical weak tensor
+primitive. It also does **not** yet rewrite the full leptogenesis benchmark in
+terms of these sharp source amplitudes. The existing benchmark runner still
+uses the older reduced kernel.
 
-So this is a source-amplitude theorem, not yet the final `eta` closure note.
+So this is a bounded source-amplitude result inside a supplied carrier
+definition, not yet the final `eta` note.
 
 ## Command
 

--- a/logs/runner-cache/frontier_dm_neutrino_source_amplitude_theorem.txt
+++ b/logs/runner-cache/frontier_dm_neutrino_source_amplitude_theorem.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_dm_neutrino_source_amplitude_theorem.py
-runner_sha256: e69845697fe62c81659eb4ab3029f6ada57f9fc340adbcab6952455b542e7da3
-timeout_sec: 120
+runner_sha256: acb8046906783e28ce014d5a31af97a00e7a65d73d968e108eef418dcc4b7545
+timeout_sec: 300
 exit_code: 0
-elapsed_sec: 0.08
+elapsed_sec: 0.13
 status: ok
 ----- stdout -----
 ========================================================================================
@@ -22,20 +22,20 @@ PART 1: SHARP SELECTOR PROJECTION FIXES A_SEL
 ========================================================================================
 PART 2: SHARP SYMMETRIC SOURCE PROJECTION FIXES TAU_PLUS
 ========================================================================================
-  [PASS] The exact weak carrier is the two-column bright bundle K_R(q) = [[u_E,u_T],[delta_A1 u_E,delta_A1 u_T]]
+  [PASS] The weak carrier premise is the named-input K_R definition, not a physical-primitive theorem
   [PASS] The hierarchy selector theorem again supplies sharp bosonic-even projection rather than soft weighting
   [PASS] The weak even reduction note fixes that only the swap-even source mode survives
   [PASS] The canonical sharp swap-even projector is P_+ = (I + P_swap)/2  (idempotence err=0.00e+00)
   [PASS] Its source-oriented coordinate vector is exactly (tau_E,tau_T) = (1/2,1/2)  (vec=[0.5, 0.5])
-  [PASS] Therefore the symmetric source amplitude is canonically tau_+ = 1  (tau_+=1.000000)
+  [PASS] Therefore the bounded symmetric source amplitude is canonically tau_+ = 1 inside that carrier definition  (tau_+=1.000000)
 
 ========================================================================================
-PART 3: THE EXACT TRIPLET SOURCE DATA FOLLOW IMMEDIATELY
+PART 3: THE BOUNDED TRIPLET SOURCE DATA FOLLOW INSIDE THE CARRIER DEFINITION
 ========================================================================================
   [PASS] The odd transfer coefficient is already fixed as c_odd = +1
   [PASS] The even transfer coefficients are already fixed as v_even = (sqrt(8/3), sqrt(8)/3)
-  [PASS] So the exact odd triplet source is gamma = a_sel = 1/2  (gamma=0.500000)
-  [PASS] The exact even triplet responses are E1 = sqrt(8/3) and E2 = sqrt(8)/3  ((E1,E2)=(1.632993161855,0.942809041582))
+  [PASS] So the bounded odd triplet source is gamma = a_sel = 1/2  (gamma=0.500000)
+  [PASS] The bounded even triplet responses are E1 = sqrt(8/3) and E2 = sqrt(8)/3  ((E1,E2)=(1.632993161855,0.942809041582))
 
 ========================================================================================
 SUMMARY: PASS=15 FAIL=0

--- a/scripts/frontier_dm_neutrino_source_amplitude_theorem.py
+++ b/scripts/frontier_dm_neutrino_source_amplitude_theorem.py
@@ -7,16 +7,17 @@ Framework convention:
 
 Question:
   Once the transfer coefficients are fixed, can the source amplitudes on the
-  source-oriented sharp branch be fixed canonically as well?
+  source-oriented sharp branch be fixed canonically inside the named-input
+  K_R carrier definition?
 
 Answer:
-  Yes, on the sharp source-oriented branch:
+  Yes, conditionally on that named-input carrier definition:
 
     a_sel = 1/2
     tau_E = tau_T = 1/2
     tau_+ = 1
 
-  Therefore the exact transfer law becomes
+  Therefore the bounded source package becomes
 
     gamma = 1/2
     E1 = sqrt(8/3)
@@ -53,6 +54,10 @@ def check(name: str, condition: bool, detail: str = "") -> bool:
 
 def read(rel: str) -> str:
     return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def compact(text: str) -> str:
+    return "".join(text.split())
 
 
 S_CLS = np.diag([0.0, 0.0, 1.0, -1.0])
@@ -110,10 +115,15 @@ def part2_sharp_symmetric_source_projection_fixes_tau_plus() -> None:
     source_vec = np.array([0.5, 0.5], dtype=float)
     tau_plus = float(np.sum(source_vec))
 
+    carrier_compact = compact(carrier)
+    kr_definition = compact("K_R(q) := [[u_E(q), u_T(q)], [delta_A1(q) u_E(q), delta_A1(q) u_T(q)]]")
+
     check(
-        "The exact weak carrier is the two-column bright bundle K_R(q) = [[u_E,u_T],[delta_A1 u_E,delta_A1 u_T]]",
-        "K_R(q) = [[u_E(q), u_T(q)], [delta_A1(q)u_E(q), delta_A1(q)u_T(q)]]".replace(" ", "")
-        in carrier.replace(" ", ""),
+        "The weak carrier premise is the named-input K_R definition, not a physical-primitive theorem",
+        kr_definition in carrier_compact
+        and "class-A definition" in carrier
+        and ("**does not derive**" in carrier or "does **not** derive" in carrier)
+        and "physical tensor primitive" in carrier,
     )
     check(
         "The hierarchy selector theorem again supplies sharp bosonic-even projection rather than soft weighting",
@@ -134,15 +144,15 @@ def part2_sharp_symmetric_source_projection_fixes_tau_plus() -> None:
         f"vec={source_vec.tolist()}",
     )
     check(
-        "Therefore the symmetric source amplitude is canonically tau_+ = 1",
+        "Therefore the bounded symmetric source amplitude is canonically tau_+ = 1 inside that carrier definition",
         abs(tau_plus - 1.0) < 1e-12,
         f"tau_+={tau_plus:.6f}",
     )
 
 
-def part3_the_exact_triplet_source_data_follow_immediately() -> None:
+def part3_the_bounded_triplet_source_data_follow_immediately() -> None:
     print("\n" + "=" * 88)
-    print("PART 3: THE EXACT TRIPLET SOURCE DATA FOLLOW IMMEDIATELY")
+    print("PART 3: THE BOUNDED TRIPLET SOURCE DATA FOLLOW INSIDE THE CARRIER DEFINITION")
     print("=" * 88)
 
     codd = read("docs/DM_NEUTRINO_CODD_BOSONIC_NORMALIZATION_THEOREM_NOTE_2026-04-15.md")
@@ -163,12 +173,12 @@ def part3_the_exact_triplet_source_data_follow_immediately() -> None:
         "v_even = (sqrt(8/3), sqrt(8)/3)" in veven,
     )
     check(
-        "So the exact odd triplet source is gamma = a_sel = 1/2",
+        "So the bounded odd triplet source is gamma = a_sel = 1/2",
         abs(gamma - 0.5) < 1e-12,
         f"gamma={gamma:.6f}",
     )
     check(
-        "The exact even triplet responses are E1 = sqrt(8/3) and E2 = sqrt(8)/3",
+        "The bounded even triplet responses are E1 = sqrt(8/3) and E2 = sqrt(8)/3",
         abs(e1 - math.sqrt(8.0 / 3.0)) < 1e-12 and abs(e2 - math.sqrt(8.0) / 3.0) < 1e-12,
         f"(E1,E2)=({e1:.12f},{e2:.12f})",
     )
@@ -181,7 +191,7 @@ def main() -> int:
 
     part1_sharp_selector_projection_fixes_a_sel()
     part2_sharp_symmetric_source_projection_fixes_tau_plus()
-    part3_the_exact_triplet_source_data_follow_immediately()
+    part3_the_bounded_triplet_source_data_follow_immediately()
 
     print("\n" + "=" * 88)
     print(f"SUMMARY: PASS={PASS_COUNT} FAIL={FAIL_COUNT}")


### PR DESCRIPTION
## Item

12 `frontier_dm_neutrino_source_amplitude_theorem`

## Reconfirmed live signature

Initial live rerun on a fresh worktree:

- `SUMMARY: PASS=14 FAIL=1`
- failing gate: `The exact weak carrier is the two-column bright bundle K_R(q) = [[u_E,u_T],[delta_A1 u_E,delta_A1 u_T]]`

## Diagnosis

The paired upstream `S3_TIME_BILINEAR_TENSOR_PRIMITIVE_NOTE.md` no longer supports the runner's exact-weak-carrier premise. It records `K_R` as a class-A named-input definition under `(delta_A1, u_E, u_T)` and explicitly does not derive the inputs, decoupling fact, aligned-bright coordinates, or a physical tensor-primitive interpretation.

The old source-amplitude note/runner therefore overclaimed. The amplitude algebra still holds inside the supplied `K_R` carrier definition, but it is not an exact physical weak-carrier theorem.

## Resolution class

(c) honest bounded result / named wall. The result is narrowed to the bounded carrier context: given the named-input `K_R` row factor and the sharp source-oriented projection, `a_sel = 1/2`, `tau_E = tau_T = 1/2`, `tau_+ = 1`, and the bounded source package gives `(gamma, E1, E2) = (1/2, sqrt(8/3), sqrt(8)/3)`.

Open boundary retained: derivation of `K_R` as a physical weak tensor primitive and full benchmark rewrite remain open.

## Verification

- Live runner after repair: `SUMMARY: PASS=15 FAIL=0`
- Fresh cache regenerated with the required cache writer: `SUMMARY: PASS=15 FAIL=0`
- `python3 -m py_compile scripts/frontier_dm_neutrino_source_amplitude_theorem.py`
- `git diff --check`
- wording scan for stale exact weak/source/triplet and closing rhetoric on the edited note/runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
