### PR TITLE
science: stabilize Wilson descendant Schur entropy witness

### DIFF
--- a/docs/DM_WILSON_DIRECT_DESCENDANT_CANONICAL_FIBER_SCHUR_ENTROPY_CANDIDATE_NO_GO_NOTE_2026-04-19.md
+++ b/docs/DM_WILSON_DIRECT_DESCENDANT_CANONICAL_FIBER_SCHUR_ENTROPY_CANDIDATE_NO_GO_NOTE_2026-04-19.md
@@ -1,7 +1,7 @@
 # DM Wilson Direct-Descendant Canonical-Fiber Schur-Entropy Candidate / No-Go
 
 **Date:** 2026-04-19  
-**Status:** proposed_no_go — exact follow-on no-go on the DM source-fiber
+**Status:** proposed_no_go — bounded follow-on no-go on the DM source-fiber
 lane (canonical-fiber Schur-entropy candidate)
 
 ### Detailed status
@@ -15,12 +15,11 @@ choose the most isotropic normalized Schur spectrum
 ```
 
 does **not** extend canonically. Standard coefficient-free normalized
-Schur-spectral laws disagree on exact positive-fiber points. If one adds a
+Schur-spectral laws disagree on live positive-fiber witnesses. If one adds a
 Shannon-entropy selector assumption, that does produce an explicit endpoint
 candidate on the canonical fiber, but the resulting aligned-seed -> endpoint
-exact crossing leaves the constructive chamber. So the physical selector is
-still open. This note does not add a repo-wide axiom or promote any upstream
-lane.
+crossing leaves the constructive chamber. So the physical selector remains
+unsupplied. This note does not add a repo-wide axiom or promote any upstream lane.
 
 **Primary runner:**  
 `scripts/frontier_dm_wilson_direct_descendant_canonical_fiber_schur_entropy_candidate_no_go_2026_04_19.py`
@@ -53,13 +52,14 @@ Does that slogan actually define a unique law on the full canonical fiber?
 No, not by itself.
 
 On the orbit-level canonical fiber, the normalized Schur spectra are no longer
-totally ordered by majorization. The runner certifies two exact positive-fiber
+totally ordered by majorization. The runner certifies two live positive-fiber
 points:
 
 - a **Shannon point** `S_H`,
 - and a **Renyi-2 / participation point** `S_R`,
 
-both satisfying the exact canonical orbit constraints and the retained
+both satisfying the canonical orbit constraints to measured numerical residual
+and the retained
 positive-branch conditions
 
 ```text
@@ -82,8 +82,8 @@ There is also one honest conditional positive result:
   unique continuous symmetric additive entropy, then Shannon is selected;
 - that picks an explicit canonical-fiber endpoint candidate `S_H`.
 
-But even then the source problem is not closed physically, because the unique
-exact `eta_1 = 1` crossing on the aligned-seed -> `S_H` segment already has
+But even then the source problem is not supplied physically, because the unique
+`eta_1 = 1` crossing on the aligned-seed -> `S_H` segment already has
 `E1 < 0`, so it leaves the constructive chamber.
 
 So the remaining gap is sharper again:
@@ -127,27 +127,27 @@ symmetric normalized spectral laws agreed there and selected `W1`.
 
 That agreement does **not** survive promotion to the full canonical fiber.
 
-The runner constructs two exact positive-fiber points:
+The runner constructs two positive-fiber witnesses:
 
 ### Shannon point `S_H`
 
 Direct-descendant source in source-5 coordinates:
 
 ```text
-S_H = (0.68897954, 0.63297204, 0.11110204, 0.23146031, 1.43769822)
+S_H = (0.687984, 0.633083, 0.111299, 0.230527, 1.436475)
 ```
 
 with normalized Schur spectrum
 
 ```text
-p_H = (0.63244590, 0.32076736, 0.04678674)
+p_H = (0.632499, 0.320566, 0.046936)
 ```
 
 and projected-source pack
 
 ```text
 (gamma, E1, E2, Delta_src)
-= (0.39432401, 0.00143109, 0.00184739, 0.02661580).
+= (0.394192, 0.000366, 0.000359, 0.026680).
 ```
 
 ### Renyi-2 / participation point `S_R`
@@ -155,23 +155,24 @@ and projected-source pack
 Direct-descendant source in source-5 coordinates:
 
 ```text
-S_R = (0.81041468, 0.64850569, 0.07186022, 0.58457279, 2.88995859)
+S_R = (0.814878, 0.638842, 0.059148, 0.651241, 2.334017)
 ```
 
 with normalized Schur spectrum
 
 ```text
-p_R = (0.51180785, 0.47455234, 0.01363981)
+p_R = (0.542688, 0.443272, 0.014040)
 ```
 
 and projected-source pack
 
 ```text
 (gamma, E1, E2, Delta_src)
-= (0.05318324, 0.44644652, 0.00414285, 0.01226713).
+= (0.123428, 0.444163, 0.007508, 0.013822).
 ```
 
-Both lie on the exact same canonical orbit-level fiber and both satisfy
+Both lie on the same canonical orbit-level fiber to measured residual and both
+satisfy
 
 ```text
 gamma > 0, E1 > 0, E2 > 0, Delta_src > 0.
@@ -212,7 +213,7 @@ witness `W1` in their respective laws:
 So the plateau selector does not simply transplant unchanged to the full
 canonical fiber.
 
-That matters because it closes a tempting but false shortcut:
+That matters because it rules out a tempting but false shortcut:
 
 > prove something on the four certified plateau witnesses, then treat that as
 > the law on the whole fiber.
@@ -242,16 +243,16 @@ candidate:
 That is a real scientific sharpening, because it identifies exactly what extra
 axiom would be load-bearing if one wanted a single scalar law here.
 
-## Why this still does not close the physical selector
+## Why this still does not supply the physical selector
 
 Even the Shannon endpoint is not enough to finish.
 
-The aligned-seed -> `S_H` affine segment still has a unique exact
+The aligned-seed -> `S_H` affine segment still has a unique
 `eta_1 = 1` crossing, but the runner certifies that the crossing pack is
 
 ```text
 (eta_1, gamma, E1, E2, Delta_src)
-= (1.0, 0.34109295..., -0.01679389..., 0.03008909..., 0.02972000...)
+= (1.0, 0.340874..., -0.017698..., 0.028874..., 0.029772...)
 ```
 
 So the crossing leaves the constructive chamber because `E1 < 0`.
@@ -262,7 +263,7 @@ That means:
 - but it still would **not** supply the physical point required by the older
   constructive/positive route.
 
-## What this closes
+## What this establishes
 
 - the vague hope that the full canonical fiber is already canonically ordered
   by generic normalized Schur-spectral isotropy;
@@ -271,7 +272,7 @@ That means:
 - the idea that "most isotropic spectrum" is already a theorem-grade law
   without specifying the isotropy functional.
 
-## What this does not close
+## What remains open
 
 - a retained derivation of the entropy-additivity axiom from `Cl(3)` on `Z^3`;
 - a theorem that the Shannon endpoint is the physical direct-descendant source;
@@ -289,7 +290,7 @@ It must at least:
 1. specify the microscopic scalar itself, not just the slogan "isotropy";
 2. be compatible with the direct-descendant canonical orbit-level fiber;
 3. connect back to the constructive physical route rather than sending the
-   exact crossing out of the chamber.
+   `eta_1 = 1` crossing out of the chamber.
 
 That is the sharpest honest post-fiber statement now available.
 
@@ -309,9 +310,9 @@ PYTHONPATH=scripts python3 scripts/frontier_dm_wilson_direct_descendant_canonica
 
 Expected:
 
-- exact positive-fiber Shannon point `S_H`;
-- exact positive-fiber Renyi-2 / participation point `S_R`;
+- positive-fiber Shannon witness `S_H`;
+- positive-fiber Renyi-2 / participation witness `S_R`;
 - opposite Shannon / Renyi-2 ordering;
 - majorization incomparability of `p_H` and `p_R`;
-- unique aligned-seed -> `S_H` exact crossing with `E1 < 0`;
+- unique aligned-seed -> `S_H` crossing with `E1 < 0`;
 - `PASS` with `FAIL=0`.

--- a/logs/runner-cache/frontier_dm_wilson_direct_descendant_canonical_fiber_schur_entropy_candidate_no_go_2026_04_19.txt
+++ b/logs/runner-cache/frontier_dm_wilson_direct_descendant_canonical_fiber_schur_entropy_candidate_no_go_2026_04_19.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_dm_wilson_direct_descendant_canonical_fiber_schur_entropy_candidate_no_go_2026_04_19.py
-runner_sha256: f43fcb8e118f425a6263db27585d469d02a7c27e0e544f40c7ded6b717886389
-timeout_sec: 120
+runner_sha256: bb08d43c8474ff6203f82d3f917002f24f8f999ddd5ecff80c661e7c0df2f6cf
+timeout_sec: 300
 exit_code: 0
-elapsed_sec: 33.28
+elapsed_sec: 14.15
 status: ok
 ----- stdout -----
 ========================================================================================
@@ -14,40 +14,40 @@ DM WILSON DIRECT-DESCENDANT CANONICAL-FIBER SCHUR-ENTROPY CANDIDATE / NO-GO
 PART 1: THE ORBIT-LEVEL CANONICAL FIBER AND POSITIVE BRANCH ARE EXACTLY REPRESENTABLE
 ========================================================================================
   [PASS] The canonical favored-column orbit is fixed exactly by the two permutation-invariant moments (sum c_i^2, sum c_i^3)  ((p2,p3)=(0.865045876015,0.801108643551))
-  [PASS] The Shannon and Renyi-2 constructions both land exactly on that orbit-level fiber and inside gamma > 0, E1 > 0, E2 > 0, Delta_src > 0  (Shannon pack=[0.39432401 0.00143109 0.00184739 0.0266158 ], Renyi2 pack=[0.05318324 0.44644652 0.00414284 0.01226713])
+  [PASS] The Shannon and Renyi-2 constructions both land on that orbit-level fiber and inside gamma > 0, E1 > 0, E2 > 0, Delta_src > 0  (Shannon pack=[0.394192 0.000366 0.000359 0.02668 ], Renyi2 pack=[0.123428 0.444163 0.007508 0.013822], fiber residuals=(1.34e-14,6.66e-16))
 
 ========================================================================================
 PART 2: THE PLATEAU SCHUR-ISOTROPY SLOGAN DOES NOT EXTEND CANONICALLY TO THE FULL FIBER
 ========================================================================================
-  [PASS] The Shannon construction beats the certified plateau witness W1 in Shannon entropy  ((S_H,W1)=(0.797755102040,0.510071681521))
-  [PASS] The Renyi-2 / participation construction beats W1 in Renyi-2 entropy  ((S_R,W1)=(0.718807116688,0.311764655074))
-  [PASS] Shannon and Renyi-2 rank the two exact positive-fiber points oppositely  (H(S_H,S_R)=(0.797755102040,0.755115148545), R2(S_H,S_R)=(0.683061178595,0.718807116688))
-  [PASS] Their normalized Schur spectra are majorization-incomparable, so 'most isotropic spectrum' is not a well-defined law on the full fiber  (S_H=[0.6324459  0.32076736 0.04678674], S_R=[0.51180785 0.47455234 0.01363981])
+  [PASS] The Shannon construction beats the certified plateau witness W1 in Shannon entropy  ((S_H,W1)=(0.798006059761,0.510071681521))
+  [PASS] The Renyi-2 / participation construction beats W1 in Renyi-2 entropy  ((S_R,W1)=(0.710909098609,0.311764655074))
+  [PASS] Shannon and Renyi-2 rank the two positive-fiber witnesses oppositely  (H(S_H,S_R)=(0.798006059761,0.752228252538), R2(S_H,S_R)=(0.683157784562,0.710909098609))
+  [PASS] Their normalized Schur spectra are majorization-incomparable, so 'most isotropic spectrum' is not a well-defined law on the full fiber  (S_H=[0.632499 0.320566 0.046936], S_R=[0.542688 0.443272 0.01404 ])
 
 ========================================================================================
 PART 3: THE EXTRA AXIOM THAT PICKS SHANNON DOES GIVE AN EXPLICIT ENDPOINT CANDIDATE
 ========================================================================================
-  [PASS] The Shannon point is an explicit positive source on the canonical orbit-level fiber  (source5=[0.68897954 0.63297204 0.11110204 0.23146031 1.43769822], spectrum=[0.6324459  0.32076736 0.04678674])
-  [PASS] That candidate keeps the exact transport-maximal favored-column value eta_1 = 1.052220313052...  (etas=[0.85539487 1.05222031 0.85257098])
+  [PASS] The Shannon point is an explicit positive source on the canonical orbit-level fiber  (source5=[0.687984 0.633083 0.111299 0.230527 1.436475], spectrum=[0.632499 0.320566 0.046936])
+  [PASS] That candidate keeps the exact transport-maximal favored-column value eta_1 = 1.052220313052...  (etas=[0.855532 1.05222  0.852846])
 
 ========================================================================================
-PART 4: EVEN THE SHANNON ENDPOINT DOES NOT YET CLOSE THE PHYSICAL SELECTOR
+PART 4: EVEN THE SHANNON ENDPOINT DOES NOT YET SUPPLY THE PHYSICAL SELECTOR
 ========================================================================================
-  [PASS] The aligned-seed -> Shannon-endpoint segment still has a unique exact eta_1 = 1 crossing  (lambda=0.857349816848)
-  [PASS] That exact crossing is locally full-rank but it leaves the constructive chamber because E1 < 0  (root pack=[ 1.          0.34109294 -0.01679389  0.03008909  0.02972   ])
+  [PASS] The aligned-seed -> Shannon-endpoint segment still has a unique exact eta_1 = 1 crossing  (lambda=0.857207025945)
+  [PASS] That exact crossing is locally full-rank but it leaves the constructive chamber because E1 < 0  (root pack=[ 1.        0.340874 -0.017698  0.028874  0.029772])
 
 ========================================================================================
 PART 5: BOTTOM LINE
 ========================================================================================
-  [PASS] The full canonical source fiber therefore does not carry a canonical coefficient-free Schur-spectral isotropy law on the current branch  (Shannon and Renyi-2 / participation disagree on exact positive-fiber points)
-  [PASS] What the branch now has is a sharper conditional candidate: if one adds the entropy-additivity axiom, Shannon selects an explicit endpoint, but constructive physical closure still remains open  (the remaining gap is not generic spectral isotropy but the extra physical law beyond it)
+  [PASS] The full canonical source fiber therefore does not carry a canonical coefficient-free Schur-spectral isotropy law on the current branch  (Shannon and Renyi-2 / participation disagree on positive-fiber witnesses)
+  [PASS] What the branch now has is a sharper conditional candidate: if one adds the entropy-additivity axiom, Shannon selects an explicit endpoint, but the constructive physical selector remains open  (the remaining gap is not generic spectral isotropy but the extra physical law beyond it)
 
-  canonical orbit targets (p2,p3) = [0.86504588 0.80110864]
-  Shannon source5                 = [0.68897954 0.63297204 0.11110204 0.23146031 1.43769822]
-  Shannon spectrum                = [0.6324459  0.32076736 0.04678674]
-  Renyi2 source5                  = [0.81041467 0.64850569 0.07186022 0.58457279 2.88995859]
-  Renyi2 spectrum                 = [0.51180785 0.47455234 0.01363981]
-  Shannon root pack               = [ 1.          0.34109294 -0.01679389  0.03008909  0.02972   ]
+  canonical orbit targets (p2,p3) = [0.865046 0.801109]
+  Shannon source5                 = [0.687984 0.633083 0.111299 0.230527 1.436475]
+  Shannon spectrum                = [0.632499 0.320566 0.046936]
+  Renyi2 source5                  = [0.814878 0.638842 0.059148 0.651241 2.334017]
+  Renyi2 spectrum                 = [0.542688 0.443272 0.01404 ]
+  Shannon root pack               = [ 1.        0.340874 -0.017698  0.028874  0.029772]
 
 ========================================================================================
 SUMMARY: PASS=12 FAIL=0

--- a/scripts/frontier_dm_wilson_direct_descendant_canonical_fiber_schur_entropy_candidate_no_go_2026_04_19.py
+++ b/scripts/frontier_dm_wilson_direct_descendant_canonical_fiber_schur_entropy_candidate_no_go_2026_04_19.py
@@ -11,13 +11,14 @@ Purpose:
        Schur-spectral isotropy laws do not canonically extend the plateau
        selector;
     2. an explicit Shannon-entropy point and an explicit Renyi-2 /
-       participation point both lie on the same exact positive fiber, but the
+       participation point both hit the same positive fiber to measured
+       residual, but the
        two laws rank them oppositely;
     3. their normalized Schur spectra are majorization-incomparable, so the
        phrase "most isotropic spectrum" is not well-defined on the full fiber;
     4. if one nevertheless adds the extra entropy-additivity axiom that picks
        Shannon, the resulting endpoint is explicit, but the aligned-seed ->
-       endpoint exact eta_1 = 1 crossing leaves the constructive chamber.
+       endpoint eta_1 = 1 crossing leaves the constructive chamber.
 """
 
 from __future__ import annotations
@@ -215,17 +216,18 @@ def main() -> int:
         plateau_targets_ok,
         f"(p2,p3)=({TARGET_P2_P3[0]:.12f},{TARGET_P2_P3[1]:.12f})",
     )
+    shannon_fiber_resid = float(np.max(np.abs(canonical_fiber_invariants(shannon_params) - TARGET_P2_P3)))
+    renyi_fiber_resid = float(np.max(np.abs(canonical_fiber_invariants(renyi_params) - TARGET_P2_P3)))
     check(
-        "The Shannon and Renyi-2 constructions both land exactly on that orbit-level fiber and inside gamma > 0, E1 > 0, E2 > 0, Delta_src > 0",
-        shannon_result.success
-        and renyi_result.success
-        and np.max(np.abs(canonical_fiber_invariants(shannon_params) - TARGET_P2_P3)) < 1.0e-12
-        and np.max(np.abs(canonical_fiber_invariants(renyi_params) - TARGET_P2_P3)) < 1.0e-12
+        "The Shannon and Renyi-2 constructions both land on that orbit-level fiber and inside gamma > 0, E1 > 0, E2 > 0, Delta_src > 0",
+        shannon_fiber_resid < 1.0e-12
+        and renyi_fiber_resid < 1.0e-12
         and np.min(shannon_pack4) > 0.0
         and np.min(renyi_pack4) > 0.0,
         (
             f"Shannon pack={np.round(shannon_pack4, 12)}, "
-            f"Renyi2 pack={np.round(renyi_pack4, 12)}"
+            f"Renyi2 pack={np.round(renyi_pack4, 12)}, "
+            f"fiber residuals=({shannon_fiber_resid:.2e},{renyi_fiber_resid:.2e})"
         ),
     )
 
@@ -243,7 +245,7 @@ def main() -> int:
         f"(S_R,W1)=({renyi2_entropy(renyi_params):.12f},{renyi2_entropy(w1_params):.12f})",
     )
     check(
-        "Shannon and Renyi-2 rank the two exact positive-fiber points oppositely",
+        "Shannon and Renyi-2 rank the two positive-fiber witnesses oppositely",
         shannon_entropy(shannon_params) > shannon_entropy(renyi_params) + 1.0e-6
         and renyi2_entropy(renyi_params) > renyi2_entropy(shannon_params) + 1.0e-6
         and participation_ratio(renyi_params) > participation_ratio(shannon_params) + 1.0e-6,
@@ -276,7 +278,7 @@ def main() -> int:
     )
 
     print("\n" + "=" * 88)
-    print("PART 4: EVEN THE SHANNON ENDPOINT DOES NOT YET CLOSE THE PHYSICAL SELECTOR")
+    print("PART 4: EVEN THE SHANNON ENDPOINT DOES NOT YET SUPPLY THE PHYSICAL SELECTOR")
     print("=" * 88)
     root_count = eta_root_count(SEED_SOURCE5, shannon_source5)
     root_lambda = float(brentq(lambda lam: eta1(segment(SEED_SOURCE5, shannon_source5, lam)) - 1.0, 0.0, 1.0))
@@ -306,10 +308,10 @@ def main() -> int:
     check(
         "The full canonical source fiber therefore does not carry a canonical coefficient-free Schur-spectral isotropy law on the current branch",
         True,
-        "Shannon and Renyi-2 / participation disagree on exact positive-fiber points",
+        "Shannon and Renyi-2 / participation disagree on positive-fiber witnesses",
     )
     check(
-        "What the branch now has is a sharper conditional candidate: if one adds the entropy-additivity axiom, Shannon selects an explicit endpoint, but constructive physical closure still remains open",
+        "What the branch now has is a sharper conditional candidate: if one adds the entropy-additivity axiom, Shannon selects an explicit endpoint, but the constructive physical selector remains open",
         True,
         "the remaining gap is not generic spectral isotropy but the extra physical law beyond it",
     )


### PR DESCRIPTION
## Item

14. `frontier_dm_wilson_direct_descendant_canonical_fiber_schur_entropy_candidate_no_go_2026_04_19`

## Reconfirmed live signature

Before repair, the live runner exited with `SUMMARY: PASS=11 FAIL=1`. The failing gate required both optimizer success flags even though the Renyi-2 witness still landed on the canonical fiber with measured residual `6.66e-16` and positive branch margins.

## Diagnosis

This was a numerical-interface regression, not a science-content failure. `trust-constr` can stop on its evaluation/status surface while still returning a witness whose checked physics quantities satisfy the fiber and positivity conditions. The old gate mixed optimizer bookkeeping with the actual invariant it intended to certify.

## Resolution class

(a) genuine source-preserving repair. The gate now checks measured canonical-fiber residuals plus `gamma > 0`, `E1 > 0`, `E2 > 0`, and `Delta_src > 0`. The note/cache were refreshed to the current live witness values and the physical-selector wording was narrowed to avoid closing-style rhetoric.

## Verification

- `PYTHONPATH=scripts python3 scripts/frontier_dm_wilson_direct_descendant_canonical_fiber_schur_entropy_candidate_no_go_2026_04_19.py` -> `SUMMARY: PASS=12 FAIL=0`
- `python3 -m py_compile scripts/frontier_dm_wilson_direct_descendant_canonical_fiber_schur_entropy_candidate_no_go_2026_04_19.py`
- `git diff --check`
- refreshed `logs/runner-cache/frontier_dm_wilson_direct_descendant_canonical_fiber_schur_entropy_candidate_no_go_2026_04_19.txt` with the required cache writer command

🤖 Generated with [Claude Code](https://claude.com/claude-code)