### PR TITLE
science: refresh axiom-first record-invariance companion

### DIFF
--- a/docs/AXIOM_FIRST_LATTICE_NOETHER_RECORD_INVARIANCE_COMPANION_NOTE_2026-06-04.md
+++ b/docs/AXIOM_FIRST_LATTICE_NOETHER_RECORD_INVARIANCE_COMPANION_NOTE_2026-06-04.md
@@ -25,10 +25,10 @@ new theorem claim, not a verdict change, and not independent review work.
 
 The parent surface is a bounded theorem on an admitted staggered/Grassmann
 carrier. Its load-bearing content is the finite lattice Noether chain: the
-symmetry condition `[T, M] = 0`, local-alpha promotion, the bilateral current
-specialization to the U(1) current, the on-shell divergence identity, the exact
-localized two-step Ward identity, and the `(2Z)^3` periodicity of the
-staggered phases.
+two-step translation symmetry condition, local-alpha promotion, the bilateral
+current specialization to the U(1) current, the on-shell divergence identity,
+the exact localized two-step Ward identity, and the `(2Z)^3` periodicity of
+the staggered phases.
 
 This companion does not derive the admitted carrier, the KS phase form, or a
 new current identity. It does not change the parent row. Axioms and primitives
@@ -36,14 +36,18 @@ are premise context here; they are not verdict-grade support for a bounded row.
 
 The narrow evidence recorded here is:
 
-1. the parent note hash, claim type, dependency list, and runner path match the
-   live ledger row;
-2. the parent runner exits with `PASSED: 7/7`;
-3. the parent load-bearing sections contain the symmetry condition, U(1)
+1. the parent row exists, its runner path still targets the parent runner, and
+   the parent note hash matches the live ledger hash while audit-owned fields
+   such as criticality, load, and status are printed informationally only;
+2. the parent dependency census contains the required source edges used by this
+   companion and has no record-specific source edge;
+3. the parent runner exits with all live exhibits passing (`PASSED: N/N`;
+   currently `PASSED: 9/9`);
+4. the parent load-bearing sections contain the symmetry condition, U(1)
    current specialization, on-shell divergence, exact two-step Ward identity,
    and one-site-shift caveat;
-4. the parent load-bearing sections do not use Record axiom content;
-5. the parent runner output is unchanged under counterfactual markers where
+5. the parent load-bearing sections do not use Record axiom content;
+6. the parent runner output is unchanged under counterfactual markers where
    Record is asserted or not asserted.
 
 ## What This Does Not Claim

--- a/logs/runner-cache/audit_companion_axiom_first_lattice_noether_record_invariance_2026_06_04.txt
+++ b/logs/runner-cache/audit_companion_axiom_first_lattice_noether_record_invariance_2026_06_04.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/audit_companion_axiom_first_lattice_noether_record_invariance_2026_06_04.py
-runner_sha256: 40027b1857cc63cbcbccbc49897f51b60a5ee76218280210e998fdfeb972dd9d
-timeout_sec: 120
+runner_sha256: 3126745723a6664392a286b1b60c575bbb289a16f65022c3d8ba7581a8316761
+timeout_sec: 300
 exit_code: 0
-elapsed_sec: 0.53
+elapsed_sec: 0.87
 status: ok
 ----- stdout -----
 ========================================================================
@@ -15,14 +15,17 @@ Parent runner: scripts/axiom_first_lattice_noether_check.py
 Scope: meta evidence only; no theorem claim and no verdict change.
 PASS parent_note_exists
 PASS parent_runner_exists
-PASS parent_claim_type_expected
+PASS parent_ledger_row_exists
+PASS parent_claim_type_field_present :: claim_type=bounded_theorem
 PASS parent_runner_path_expected
-PASS parent_current_criticality_expected
-PASS parent_current_load_expected :: load=13.443
-PASS parent_note_hash_expected
+PASS parent_current_criticality_present :: criticality=critical
+PASS parent_current_load_present :: load=19.518
+PASS parent_note_hash_field_present
 PASS parent_note_hash_matches_ledger
-PASS parent_deps_exact :: count=2
-PASS parent_current_row_unresolved
+PASS parent_deps_field_present :: count=8
+PASS parent_deps_include_required_sources :: missing=[]
+PASS parent_deps_omit_record_specific_sources :: count=8
+PASS parent_current_status_fields_present :: effective_status=unaudited, audit_status=unaudited
 PASS parent_load_bearing_block_present
 PASS parent_load_bearing_contains_noether_phrase_0
 PASS parent_load_bearing_contains_noether_phrase_1
@@ -37,7 +40,7 @@ PASS parent_load_bearing_contains_noether_phrase_9
 PASS parent_load_bearing_omits_record_axiom_terms
 PASS parent_runner_exit_zero :: returncode=0
 PASS parent_runner_summary_present
-PASS parent_runner_passed_all_seven :: passed=7/7
+PASS parent_runner_passed_all_live_exhibits :: passed=9/9
 PASS record_marker_true_exit_zero :: returncode=0
 PASS record_marker_does_not_change_parent_output
 PASS companion_declares_meta_type
@@ -46,7 +49,7 @@ PASS companion_disclaims_verdict_change
 PASS companion_keeps_dependency_boundary
 PASS companion_marks_axioms_not_support
 ========================================================================
-SUMMARY: PASS=32 FAIL=0
+SUMMARY: PASS=35 FAIL=0
 ========================================================================
 
 ----- stderr -----

--- a/scripts/audit_companion_axiom_first_lattice_noether_record_invariance_2026_06_04.py
+++ b/scripts/audit_companion_axiom_first_lattice_noether_record_invariance_2026_06_04.py
@@ -23,17 +23,12 @@ COMPANION_NOTE = REPO_ROOT / "docs" / "AXIOM_FIRST_LATTICE_NOETHER_RECORD_INVARI
 LEDGER = REPO_ROOT / "docs" / "audit" / "data" / "audit_ledger.json"
 
 PARENT_ID = "axiom_first_lattice_noether_theorem_note_2026-04-29"
-EXPECTED_NOTE_HASH = "a30fd6532a3fa61a5a83654a52f965cad74c0aa0a6ba48ee30801465578423c2"
 EXPECTED_RUNNER_PATH = "scripts/axiom_first_lattice_noether_check.py"
-EXPECTED_CLAIM_TYPE = "bounded_theorem"
-EXPECTED_CRITICALITY = "high"
-EXPECTED_LOAD = 13.443
-EXPECTED_DEPS = {
+REQUIRED_DEPS = {
     "minimal_axioms",
     "staggered_dirac_substep1_grassmann_forcing_bridge_narrow_theorem_note_2026-05-16",
 }
-STATUS_FIELD = "effective" + "_status"
-PENDING_STATUS = "un" + "audited"
+STATUS_FIELDS = ("effective" + "_status", "audit" + "_status")
 
 PASS = 0
 FAIL = 0
@@ -89,21 +84,45 @@ def main() -> int:
     print("Scope: meta evidence only; no theorem claim and no verdict change.")
 
     ledger = json.loads(LEDGER.read_text(encoding="utf-8"))["rows"]
-    row = ledger[PARENT_ID]
+    row = ledger.get(PARENT_ID, {})
+    deps = row.get("deps", [])
+    deps_set = set(deps) if isinstance(deps, list) else set()
     record("parent_note_exists", PARENT_NOTE.is_file())
     record("parent_runner_exists", PARENT_RUNNER.is_file())
-    record("parent_claim_type_expected", row.get("claim_type") == EXPECTED_CLAIM_TYPE)
+    record("parent_ledger_row_exists", bool(row))
+    record("parent_claim_type_field_present", bool(row.get("claim_type")), f"claim_type={row.get('claim_type')}")
     record("parent_runner_path_expected", row.get("runner_path") == EXPECTED_RUNNER_PATH)
-    record("parent_current_criticality_expected", row.get("criticality") == EXPECTED_CRITICALITY)
     record(
-        "parent_current_load_expected",
-        abs(float(row.get("load_bearing_score")) - EXPECTED_LOAD) < 1e-12,
-        f"load={row.get('load_bearing_score')}",
+        "parent_current_criticality_present",
+        bool(row.get("criticality")),
+        f"criticality={row.get('criticality')}",
     )
-    record("parent_note_hash_expected", sha256(PARENT_NOTE) == EXPECTED_NOTE_HASH)
+    try:
+        load_value = float(row.get("load_bearing_score"))
+        load_present = True
+    except (TypeError, ValueError):
+        load_value = row.get("load_bearing_score")
+        load_present = False
+    record("parent_current_load_present", load_present, f"load={load_value}")
+    row_note_hash = row.get("note_hash")
+    record("parent_note_hash_field_present", isinstance(row_note_hash, str) and len(row_note_hash) == 64)
     record("parent_note_hash_matches_ledger", sha256(PARENT_NOTE) == row.get("note_hash"))
-    record("parent_deps_exact", set(row.get("deps", [])) == EXPECTED_DEPS, f"count={len(row.get('deps', []))}")
-    record("parent_current_row_unresolved", row.get(STATUS_FIELD) == PENDING_STATUS)
+    record("parent_deps_field_present", bool(deps_set), f"count={len(deps_set)}")
+    record(
+        "parent_deps_include_required_sources",
+        REQUIRED_DEPS.issubset(deps_set),
+        f"missing={sorted(REQUIRED_DEPS - deps_set)}",
+    )
+    record(
+        "parent_deps_omit_record_specific_sources",
+        all("record" not in dep.lower() for dep in deps_set),
+        f"count={len(deps_set)}",
+    )
+    record(
+        "parent_current_status_fields_present",
+        all(bool(row.get(field)) for field in STATUS_FIELDS),
+        ", ".join(f"{field}={row.get(field)}" for field in STATUS_FIELDS),
+    )
 
     parent_text = PARENT_NOTE.read_text(encoding="utf-8")
     start = parent_text.find("## Statement")
@@ -116,7 +135,7 @@ def main() -> int:
             "`(2Z)^3` sublattice two-step Ward identity",
             "Fermion-number current",
             "Symmetry condition",
-            "[ T^A , M ]",
+            "commutes with `M_KS`",
             "bilateral form (5)",
             "on shell",
             "central two-step generator",
@@ -135,9 +154,13 @@ def main() -> int:
     record("parent_runner_exit_zero", parent_false.returncode == 0, f"returncode={parent_false.returncode}")
     record("parent_runner_summary_present", summary is not None)
     if summary:
-        record("parent_runner_passed_all_seven", summary == (7, 7), f"passed={summary[0]}/{summary[1]}")
+        record(
+            "parent_runner_passed_all_live_exhibits",
+            summary[0] == summary[1] and summary[1] >= 7,
+            f"passed={summary[0]}/{summary[1]}",
+        )
     else:
-        record("parent_runner_passed_all_seven", False)
+        record("parent_runner_passed_all_live_exhibits", False)
     record("record_marker_true_exit_zero", parent_true.returncode == 0, f"returncode={parent_true.returncode}")
     record(
         "record_marker_does_not_change_parent_output",


### PR DESCRIPTION
## Item

1. `audit_companion_axiom_first_lattice_noether_record_invariance_2026_06_04`

## Reconfirmed live signature

Fresh worktree live run initially exited with `SUMMARY: PASS=26 FAIL=6`. The failing gates were stale companion expectations for criticality/load, note hash, exact dependency count, a narrowed Noether phrase, and the parent runner exhibit count (`passed=9/9` vs old `7/7`).

## Diagnosis

Resolution class (a): source-preserving hygiene repair. The parent note and parent runner had moved through later source repairs, while the companion still pinned audit-owned values and an old exact ledger census. The record-invariance content was still intact: the parent load-bearing block omits Record axiom terms and the parent runner output is unchanged when `CL3_RECORD_ASSERTED` is toggled.

## Repair

- Convert criticality/load/status value pins to field-presence checks with informational output.
- Keep row existence, parent runner path, note-hash-to-ledger agreement, required source dependency presence, and no record-specific dependency edge.
- Update the stale parent-runner count gate to require all live exhibits pass with at least the original seven exhibits.
- Refresh the companion note to describe the live-row contract and current `PASSED: 9/9` parent runner surface.

## Verification

- `PYTHONPATH=scripts python3 scripts/audit_companion_axiom_first_lattice_noether_record_invariance_2026_06_04.py` -> `SUMMARY: PASS=35 FAIL=0`
- `python3 -m py_compile scripts/audit_companion_axiom_first_lattice_noether_record_invariance_2026_06_04.py`
- `git diff --check`
- refreshed `logs/runner-cache/audit_companion_axiom_first_lattice_noether_record_invariance_2026_06_04.txt` with the required cache writer command

🤖 Generated with [Claude Code](https://claude.com/claude-code)