### PR TITLE
review: repair koide native zero-section route guard

### DIFF
--- a/docs/KOIDE_NATIVE_ZERO_SECTION_NATURE_REVIEW_NOTE_2026-04-24.md
+++ b/docs/KOIDE_NATIVE_ZERO_SECTION_NATURE_REVIEW_NOTE_2026-04-24.md
@@ -1,25 +1,31 @@
-# Koide native zero-section Nature review
+# Koide native zero-section defined-route Nature review
 
 **Date:** 2026-04-24
 **Runner:** `scripts/frontier_koide_native_zero_section_nature_review.py`
-**Status:** passes as the next native route; fails as completed proposed_retained/native
-closure
+**Status:** passes as bounded defined-route support; fails as a retained physical
+Koide result
 
 ## Review Question
 
-Does the native zero-section route close the full dimensionless Koide lane as a
-retained/native theorem?
+Does the native zero-section route supply exact bounded algebraic support while
+leaving the physical Koide result unclaimed?
 
 ## Verdict
 
-Not yet.  It is the strongest native route found so far, but it still requires
-two identification theorems before it is retained closure.
+Yes as a defined-route algebra; no as a retained physical result. The repaired
+route proves the exact consequences of the defined zero-source, real
+`Z_3`-primitive, based endpoint object. It still requires three physical bridge
+theorems before it can be used as a physical Koide result:
+
+1. the charged-lepton scalar readout is the zero-source coefficient;
+2. the Brannen endpoint is the whole real nontrivial `Z_3` primitive;
+3. the open determinant-line endpoint readout is unit-preserving/based.
 
 ## What Is New
 
 The route stops trying to select a rank-one line inside the nontrivial `Z3`
-sector.  Instead it treats the physical Brannen endpoint as the whole real
-nontrivial `Z3` primitive.
+sector. Instead it defines a bounded route object whose endpoint is the whole
+real nontrivial `Z3` primitive.
 
 That matters because the real primitive has no nontrivial equivariant
 idempotents:
@@ -42,10 +48,10 @@ Then a unit-preserving determinant-line endpoint readout gives:
 c = 0.
 ```
 
-Together with the independent APS computation:
+Together with the finite `Z3` route scalar:
 
 ```text
-eta_APS = 2/9
+eta_Z3 = 2/9
 ```
 
 this gives:
@@ -54,13 +60,13 @@ this gives:
 delta_open = 2/9.
 ```
 
-The Q side is the already sharpened native zero-source source-response route:
+The Q side is the defined native zero-source source-response route:
 
 ```text
 z = 0 -> K_TL = 0 -> Q = 2/3.
 ```
 
-## Why This Is Not Yet Closure
+## Why This Is Not Yet A Physical Koide Result
 
 The retained Brannen corpus contains both:
 
@@ -74,10 +80,14 @@ and:
 selected-line / CP1 / rank-one language.
 ```
 
-The native route would imply the values only if the second is a coordinate
+The defined route implies the values only if the second is a coordinate
 presentation of the first, not an extra physical rank-one selector.
 
 A hostile reviewer can still ask:
+
+```text
+why is the physical charged-lepton scalar the zero-source coefficient?
+```
 
 ```text
 why is the physical Brannen endpoint the whole real primitive,
@@ -91,19 +101,22 @@ why is the open determinant endpoint readout unit-preserving/based,
 not an unbased torsor coordinate?
 ```
 
-Those are now the exact native closure obligations.
+Those are now the exact physical bridge obligations.
 
 ## Residual
 
 ```text
 NEXT_NATIVE_THEOREM =
-  derive_Brannen_endpoint_as_real_Z3_primitive_and_unit_determinant_readout
+  derive_zero_source_readout_Brannen_endpoint_as_real_Z3_primitive_and_unit_determinant_readout
 
 RESIDUAL_IDENTIFICATION_DELTA =
   rank_one_CP1_language_vs_real_primitive_endpoint
 
 RESIDUAL_TRIVIALIZATION =
   unit_preserving_open_determinant_line_readout
+
+RESIDUAL_SOURCE_READOUT =
+  zero_source_coefficient_vs_physical_charged_lepton_scalar
 ```
 
 ## Falsifiers
@@ -132,7 +145,10 @@ Expected closeout:
 KOIDE_NATIVE_ZERO_SECTION_NATURE_REVIEW=PASS_AS_ROUTE
 KOIDE_NATIVE_ZERO_SECTION_RETAINED_CLOSURE=FALSE
 NATIVE_ROUTE_IMPLIES_VALUES_CONDITIONALLY=TRUE
-NEXT_NATIVE_THEOREM=derive_Brannen_endpoint_as_real_Z3_primitive_and_unit_determinant_readout
+NATIVE_ROUTE_DEFINED_ALGEBRA=TRUE
+PHYSICAL_KOIDE_CLOSURE_CLAIMED=FALSE
+PHYSICAL_BRIDGE_IDENTIFICATIONS_CLAIMED=FALSE
+NEXT_NATIVE_THEOREM=derive_zero_source_readout_Brannen_endpoint_as_real_Z3_primitive_and_unit_determinant_readout
 ```
 
 ## Audit dependency repair links

--- a/logs/runner-cache/frontier_koide_native_zero_section_nature_review.txt
+++ b/logs/runner-cache/frontier_koide_native_zero_section_nature_review.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_koide_native_zero_section_nature_review.py
-runner_sha256: 62df282e619cf0ae10d5921742dcba47fdc849d49873c768ba74f95c776dca2a
-timeout_sec: 120
+runner_sha256: 2f334cf6898ba38740e9cb2293dda4823fe763f999e01bf4d3d7cb2e8f580a76
+timeout_sec: 300
 exit_code: 0
-elapsed_sec: 1.00
+elapsed_sec: 0.58
 status: ok
 ----- stdout -----
 
@@ -15,16 +15,16 @@ A. Route packet
        docs/KOIDE_NATIVE_ZERO_SECTION_CLOSURE_ROUTE_NOTE_2026-04-24.md
 [PASS] A.2 native route runner passes
        runner closeout verified.
-[PASS] A.3 route does not claim retained-only closure
-       Conditional route is not promoted beyond its proof boundary.
+[PASS] A.3 route does not claim the physical Koide result
+       Defined-route algebra is not promoted beyond its proof boundary.
 
 ========================================================================================
 B. Positive content
 ========================================================================================
-[PASS] B.1 Q is implied under native zero-source source-response
+[PASS] B.1 Q is implied inside the defined zero-source route
        The source-label zero section gives K_TL=0 and Q=2/3.
-[PASS] B.2 delta is implied under real primitive plus unit endpoint
-       Real Z3 primitive removes spectator; unit endpoint removes c.
+[PASS] B.2 delta is implied inside the defined real primitive plus unit endpoint
+       Real Z3 primitive removes spectator; based endpoint removes c.
 [PASS] B.3 the route is not numerological
        Load-bearing checks are representation idempotents and unit preservation.
 
@@ -40,20 +40,20 @@ C. Compatibility with retained Brannen support
 D. Remaining objections
 ========================================================================================
 [PASS] D.1 all remaining objections are identification theorems, not arithmetic gaps
+       Is zero-source source-response already the charged-lepton scalar readout?
        Does the physical Brannen endpoint mean the whole real primitive or a rank-one CP1 line?
        Is the CP1 line a coordinate presentation of the real primitive, or an extra physical selector?
        Is the open determinant endpoint a based unit-preserving functor, or an unbased torsor?
-       Is zero-source source-response already the charged-lepton scalar readout?
-[PASS] D.2 retained-only closure is not yet reviewer-proof
-       A hostile reviewer can reject the real-primitive reinterpretation until it is derived from the Brannen construction itself.
+[PASS] D.2 physical Koide result remains unclaimed
+       A hostile reviewer can reject the three physical identifications until they are derived from retained sources.
 
 ========================================================================================
 E. Verdict
 ========================================================================================
-[PASS] E.1 passes as the next native route to pursue
-       It is the first route that kills the delta spectator by retained real-representation irreducibility.
-[PASS] E.2 fails as completed retained/native closure today
-       It still needs the real-primitive Brannen identification and determinant-line unit theorem.
+[PASS] E.1 passes as a bounded defined-route review
+       It supplies exact route algebra for the zero-source, real-primitive, based-endpoint pattern.
+[PASS] E.2 fails as a retained physical Koide result today
+       It still needs the zero-source readout, real-primitive Brannen endpoint, and determinant-line unit theorems.
 
 ========================================================================================
 Summary
@@ -61,23 +61,27 @@ Summary
 PASSED: 12/12
   [PASS] A.1 native zero-section route artifacts exist
   [PASS] A.2 native route runner passes
-  [PASS] A.3 route does not claim retained-only closure
-  [PASS] B.1 Q is implied under native zero-source source-response
-  [PASS] B.2 delta is implied under real primitive plus unit endpoint
+  [PASS] A.3 route does not claim the physical Koide result
+  [PASS] B.1 Q is implied inside the defined zero-source route
+  [PASS] B.2 delta is implied inside the defined real primitive plus unit endpoint
   [PASS] B.3 the route is not numerological
   [PASS] C.1 retained Brannen geometry supports a real-doublet primitive reading
   [PASS] C.2 retained Brannen corpus also contains rank-one/CP1 language
   [PASS] D.1 all remaining objections are identification theorems, not arithmetic gaps
-  [PASS] D.2 retained-only closure is not yet reviewer-proof
-  [PASS] E.1 passes as the next native route to pursue
-  [PASS] E.2 fails as completed retained/native closure today
+  [PASS] D.2 physical Koide result remains unclaimed
+  [PASS] E.1 passes as a bounded defined-route review
+  [PASS] E.2 fails as a retained physical Koide result today
 
 KOIDE_NATIVE_ZERO_SECTION_NATURE_REVIEW=PASS_AS_ROUTE
 KOIDE_NATIVE_ZERO_SECTION_RETAINED_CLOSURE=FALSE
 NATIVE_ROUTE_IMPLIES_VALUES_CONDITIONALLY=TRUE
-NEXT_NATIVE_THEOREM=derive_Brannen_endpoint_as_real_Z3_primitive_and_unit_determinant_readout
+NATIVE_ROUTE_DEFINED_ALGEBRA=TRUE
+PHYSICAL_KOIDE_CLOSURE_CLAIMED=FALSE
+PHYSICAL_BRIDGE_IDENTIFICATIONS_CLAIMED=FALSE
+NEXT_NATIVE_THEOREM=derive_zero_source_readout_Brannen_endpoint_as_real_Z3_primitive_and_unit_determinant_readout
 RESIDUAL_IDENTIFICATION_DELTA=rank_one_CP1_language_vs_real_primitive_endpoint
 RESIDUAL_TRIVIALIZATION=unit_preserving_open_determinant_line_readout
+RESIDUAL_SOURCE_READOUT=zero_source_coefficient_vs_physical_charged_lepton_scalar
 
 ----- stderr -----
 

--- a/scripts/frontier_koide_native_zero_section_nature_review.py
+++ b/scripts/frontier_koide_native_zero_section_nature_review.py
@@ -1,26 +1,27 @@
 #!/usr/bin/env python3
 """
-Nature-grade review of the Koide native zero-section closure route.
+Nature-grade review of the Koide native zero-section defined-route algebra.
 
 Review question:
-  Does the native zero-section route close the dimensionless Koide lane as a
-  retained/native theorem, and if not, what exact work remains?
+  Does the current native zero-section route supply exact bounded algebraic
+  support while leaving the physical Koide result unclaimed, and if not, what
+  exact work remains?
 
 Verdict:
-  The route is the strongest native closure path found so far.  It is exact,
-  non-numerological, and it removes the delta spectator obstruction if the
-  physical Brannen endpoint is the whole real nontrivial Z3 primitive.
+  The repaired route is an exact, non-numerological defined-route algebra. It
+  gives Q and delta inside the defined zero-source, real Z3 primitive, based
+  endpoint object.
 
-  It does not yet pass as retained-only closure, because the repository still
-  contains two competing descriptions of the Brannen object:
+  It does not yet pass as a retained physical result, because the repository
+  still contains two competing descriptions of the Brannen object:
 
     - older selected-line/CP1 language, where a rank-one line is physical;
     - the native real-primitive route, where the real Z3 doublet is physical
       and rank-one lines are coordinate/gauge choices.
 
-  Native closure requires a retained identification theorem resolving that
-  conflict in favor of the real primitive, plus a determinant-line unit theorem
-  for the open endpoint.
+  The physical result requires three retained identification theorems: the
+  charged-lepton scalar is the zero-source coefficient, the Brannen endpoint is
+  the whole real primitive, and the determinant-line readout is based.
 """
 
 from __future__ import annotations
@@ -79,31 +80,36 @@ def main() -> int:
     code, output = run(route_script)
     record(
         "A.2 native route runner passes",
-        code == 0 and "PASSED: 17/17" in output,
+        code == 0
+        and "PASSED: 18/18" in output
+        and "KOIDE_NATIVE_ZERO_SECTION_DEFINED_ROUTE_ALGEBRA=TRUE" in output,
         "runner closeout verified.",
     )
     record(
-        "A.3 route does not claim retained-only closure",
-        "RETAINED_ONLY_NATIVE_CLOSURE_CLAIMED=FALSE" in output,
-        "Conditional route is not promoted beyond its proof boundary.",
+        "A.3 route does not claim the physical Koide result",
+        "PHYSICAL_KOIDE_CLOSURE_CLAIMED=FALSE" in output
+        and "PHYSICAL_BRIDGE_IDENTIFICATIONS_CLAIMED=FALSE" in output,
+        "Defined-route algebra is not promoted beyond its proof boundary.",
     )
 
     section("B. Positive content")
 
     record(
-        "B.1 Q is implied under native zero-source source-response",
-        "CONDITIONAL_NATIVE_ZERO_SECTION_IMPLIES_Q=TRUE" in output,
+        "B.1 Q is implied inside the defined zero-source route",
+        "DEFINED_ROUTE_ZERO_SECTION_IMPLIES_Q=TRUE" in output,
         "The source-label zero section gives K_TL=0 and Q=2/3.",
     )
     record(
-        "B.2 delta is implied under real primitive plus unit endpoint",
-        "CONDITIONAL_NATIVE_ZERO_SECTION_IMPLIES_DELTA=TRUE" in output,
-        "Real Z3 primitive removes spectator; unit endpoint removes c.",
+        "B.2 delta is implied inside the defined real primitive plus unit endpoint",
+        "DEFINED_ROUTE_REAL_Z3_PRIMITIVE_HAS_NO_SPECTATOR_IDEMPOTENT=TRUE" in output
+        and "DEFINED_ROUTE_UNIT_ENDPOINT_IMPLIES_C_ZERO=TRUE" in output
+        and "DEFINED_ROUTE_ENDPOINT_IMPLIES_DELTA=TRUE" in output,
+        "Real Z3 primitive removes spectator; based endpoint removes c.",
     )
     record(
         "B.3 the route is not numerological",
         "no hidden target import" in output.lower()
-        and "eta_APS=2/9" in output
+        and "eta_Z3=2/9" in output
         and "idempotents=[{a: 0, b: 0}, {a: 1, b: 0}]" in output,
         "Load-bearing checks are representation idempotents and unit preservation.",
     )
@@ -137,10 +143,10 @@ def main() -> int:
     section("D. Remaining objections")
 
     objections = [
+        "Is zero-source source-response already the charged-lepton scalar readout?",
         "Does the physical Brannen endpoint mean the whole real primitive or a rank-one CP1 line?",
         "Is the CP1 line a coordinate presentation of the real primitive, or an extra physical selector?",
         "Is the open determinant endpoint a based unit-preserving functor, or an unbased torsor?",
-        "Is zero-source source-response already the charged-lepton scalar readout?",
     ]
     record(
         "D.1 all remaining objections are identification theorems, not arithmetic gaps",
@@ -148,22 +154,22 @@ def main() -> int:
         "\n".join(objections),
     )
     record(
-        "D.2 retained-only closure is not yet reviewer-proof",
+        "D.2 physical Koide result remains unclaimed",
         True,
-        "A hostile reviewer can reject the real-primitive reinterpretation until it is derived from the Brannen construction itself.",
+        "A hostile reviewer can reject the three physical identifications until they are derived from retained sources.",
     )
 
     section("E. Verdict")
 
     record(
-        "E.1 passes as the next native route to pursue",
+        "E.1 passes as a bounded defined-route review",
         True,
-        "It is the first route that kills the delta spectator by retained real-representation irreducibility.",
+        "It supplies exact route algebra for the zero-source, real-primitive, based-endpoint pattern.",
     )
     record(
-        "E.2 fails as completed retained/native closure today",
+        "E.2 fails as a retained physical Koide result today",
         True,
-        "It still needs the real-primitive Brannen identification and determinant-line unit theorem.",
+        "It still needs the zero-source readout, real-primitive Brannen endpoint, and determinant-line unit theorems.",
     )
 
     print()
@@ -181,13 +187,18 @@ def main() -> int:
         print("KOIDE_NATIVE_ZERO_SECTION_NATURE_REVIEW=PASS_AS_ROUTE")
         print("KOIDE_NATIVE_ZERO_SECTION_RETAINED_CLOSURE=FALSE")
         print("NATIVE_ROUTE_IMPLIES_VALUES_CONDITIONALLY=TRUE")
-        print("NEXT_NATIVE_THEOREM=derive_Brannen_endpoint_as_real_Z3_primitive_and_unit_determinant_readout")
+        print("NATIVE_ROUTE_DEFINED_ALGEBRA=TRUE")
+        print("PHYSICAL_KOIDE_CLOSURE_CLAIMED=FALSE")
+        print("PHYSICAL_BRIDGE_IDENTIFICATIONS_CLAIMED=FALSE")
+        print("NEXT_NATIVE_THEOREM=derive_zero_source_readout_Brannen_endpoint_as_real_Z3_primitive_and_unit_determinant_readout")
         print("RESIDUAL_IDENTIFICATION_DELTA=rank_one_CP1_language_vs_real_primitive_endpoint")
         print("RESIDUAL_TRIVIALIZATION=unit_preserving_open_determinant_line_readout")
+        print("RESIDUAL_SOURCE_READOUT=zero_source_coefficient_vs_physical_charged_lepton_scalar")
         return 0
 
     print("KOIDE_NATIVE_ZERO_SECTION_NATURE_REVIEW=FAIL")
     print("KOIDE_NATIVE_ZERO_SECTION_RETAINED_CLOSURE=FALSE")
+    print("PHYSICAL_KOIDE_CLOSURE_CLAIMED=FALSE")
     return 1
 
 


### PR DESCRIPTION
Item: 17, `frontier_koide_native_zero_section_nature_review`

Reconfirmed live signature on a fresh worktree off current `origin/main`: `PASSED: 7/12`, `KOIDE_NATIVE_ZERO_SECTION_NATURE_REVIEW=FAIL`, exit 1.

Root cause: the review runner was pinned to the pre-repair sibling route surface: `PASSED: 17/17`, old conditional-output tokens, and two remaining bridge obligations. The sibling route now honestly passes as a repaired defined-route algebra object with `PASSED: 18/18`, `KOIDE_NATIVE_ZERO_SECTION_DEFINED_ROUTE_ALGEBRA=TRUE`, and explicit non-promotion tokens for the physical Koide result.

Resolution class: (a) source-preserving repair. This updates the review runner and note to verify the current defined-route algebra surface while preserving the physical boundary: the route supplies bounded route support, and the physical Koide result remains unclaimed pending three bridge identifications: zero-source readout, real-primitive Brannen endpoint, and based determinant-line readout.

Verification run by me:
- `PYTHONPATH=scripts python3 scripts/frontier_koide_native_zero_section_nature_review.py` -> `PASSED: 12/12`, exit 0
- cache regenerated after the live pass with `runner_cache.execute_runner(..., 300)`
- `python3 -m py_compile scripts/frontier_koide_native_zero_section_nature_review.py scripts/frontier_koide_native_zero_section_closure_route.py`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)