### PR TITLE
frontier: repair quark mass-ratio full-solve CP probe

### DIFF
--- a/docs/QUARK_MASS_RATIO_FULL_SOLVE_NOTE_2026-04-18.md
+++ b/docs/QUARK_MASS_RATIO_FULL_SOLVE_NOTE_2026-04-18.md
@@ -1,7 +1,7 @@
 # Quark Mass-Ratio Full Solve on the Minimal Schur-NNI Surface
 
 **Date:** 2026-04-18
-**Status:** bounded magnitude closure plus quantified CP-area ceiling
+**Status:** bounded magnitude result plus quantified phase-relaxed CP-area probe
 **Primary runner:** `scripts/frontier_quark_mass_ratio_full_solve.py`
 
 ## Safe statement
@@ -22,26 +22,27 @@ On that surface the magnitude solve is strong:
 - `m_u/m_c ~ 1.68 x 10^-3`
 - `m_c/m_t ~ 7.32 x 10^-3`
 
-both close to the usual observation comparators.
+both land near the usual observation comparators.
 
-But the same surface does **not** close the full CP sector. Its intrinsic
+But the same surface does **not** supply the full CP sector. Its intrinsic
 Jarlskog area stays near `~5 x 10^-6`, and even after relaxing the up/down
 `1-3` phases while keeping the CKM magnitudes close to the atlas values, the
-best current ceiling stays near `~6 x 10^-6`, still far below the atlas
-`J ~ 3.33 x 10^-5`.
+current deterministic probe reaches `8.46 x 10^-6`, about `25.4%` of the
+atlas `J ~ 3.33 x 10^-5`. That falsifies the older exact `25%` / `4x` pin but
+still leaves a multi-fold CP-area gap on the minimal surface.
 
 So the honest current endpoint is:
 
-- quark **magnitude** closure on the minimal Schur-NNI surface
-- no full CKM CP closure on that same surface
+- quark **magnitude** result on the minimal Schur-NNI surface
+- no full CKM CP result on that same surface
 - one extra CP-area primitive still missing
 
 A separate bounded completion note now exists:
 [QUARK_CP_CARRIER_COMPLETION_NOTE_2026-04-18.md](./QUARK_CP_CARRIER_COMPLETION_NOTE_2026-04-18.md).
 That new note does **not** change the verdict here. It adds one explicit
-complex `1-3` carrier per sector and closes the full quark package on a
-bounded extended surface. The present note remains the honest statement about
-the minimal Schur-NNI carrier by itself.
+complex `1-3` carrier per sector and gives a full numerical match on a bounded
+extended surface. The present note remains the honest statement about the
+minimal Schur-NNI carrier by itself.
 
 ## Inputs consumed
 
@@ -51,7 +52,7 @@ the minimal Schur-NNI carrier by itself.
 - historical bounded NNI support:
   [work_history/ckm/CKM_MASS_BASIS_NNI_NOTE.md](./work_history/ckm/CKM_MASS_BASIS_NNI_NOTE.md)
 
-## What closes
+## What This Supplies
 
 1. **Magnitude inversion.** The current down-type anchor plus the atlas CKM
    magnitude package is already strong enough to numerically invert the
@@ -61,14 +62,15 @@ the minimal Schur-NNI carrier by itself.
 3. **Full-lane diagnosis.** The remaining failure is sharply localized:
    not the magnitudes, but the CP area.
 
-## What does not close
+## What Remains Open
 
 1. **Intrinsic `J` on the minimal surface.** The current Schur-generated
    `1-3` structure still undershoots the atlas Jarlskog by a large factor.
 2. **Phase-only rescue.** Allowing independent up/down `1-3` phases while
-   keeping the CKM magnitudes near the atlas values does not repair the gap.
+   keeping the CKM magnitudes near the atlas values still leaves the current
+   deterministic probe at about `25.4%` of the atlas Jarlskog.
 3. **Retained full quark theorem.** This remains bounded support, not a
-   retained theorem-grade closure.
+   retained theorem-grade result.
 
 ## Interpretation
 

--- a/logs/runner-cache/frontier_quark_mass_ratio_full_solve.txt
+++ b/logs/runner-cache/frontier_quark_mass_ratio_full_solve.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_quark_mass_ratio_full_solve.py
-runner_sha256: 2b7fbdd80a1e5a28f5fe01b931f39d61329bd1854b230fe98304e8b07a0bc540
-timeout_sec: 120
+runner_sha256: b2a543126fb3cdf352cc246fa1ffa2f9a10e3da0e57b86c2cfc590d58a8a42d1
+timeout_sec: 300
 exit_code: 0
-elapsed_sec: 6.85
+elapsed_sec: 2.87
 status: ok
 ----- stdout -----
 ========================================================================
@@ -65,7 +65,7 @@ PART 3: Intrinsic CP Gap on the Magnitude-Solved Surface
   [PASS] The CP-area deficit is larger than a factor of 5  (factor = 6.53)
 
 ========================================================================
-PART 4: Phase-Relaxed J Ceiling at Fixed CKM Magnitude Corridor
+PART 4: Phase-Relaxed J Probe at Fixed CKM Magnitude Corridor
 ========================================================================
 
   Corridor:
@@ -73,37 +73,37 @@ PART 4: Phase-Relaxed J Ceiling at Fixed CKM Magnitude Corridor
     |V_cb - target| <= 0.0020
     |V_ub - target| <= 0.0010
 
-  best relaxed m_u/m_c  = 1.776950e-03
-  best relaxed m_c/m_t  = 4.559336e-02
-  delta_u               = 62.394 deg
-  delta_d               = 91.462 deg
-  |V_us|                = 0.225348
-  |V_cb|                = 0.043048
-  |V_ub|                = 0.004688
-  J_ceiling             = 6.459890e-06
-  [PASS] Phase relaxation keeps the CKM magnitudes inside the declared corridor  (dv = (-1.9224e-03, +8.7421e-04, +7.7540e-04))
-  [PASS] The phase-relaxed J ceiling still stays below 25% of the atlas J  (J_ceiling/J_atlas = 0.1939)
-  [PASS] Even the relaxed surface still misses the atlas J by more than 4x  (factor = 5.16)
+  best relaxed m_u/m_c  = 1.638341e-03
+  best relaxed m_c/m_t  = 4.608915e-02
+  delta_u               = 85.074 deg
+  delta_d               = 272.732 deg
+  |V_us|                = 0.229025
+  |V_cb|                = 0.043848
+  |V_ub|                = 0.004709
+  J_probe               = 8.460641e-06
+  [PASS] Phase relaxation keeps the CKM magnitudes inside the declared corridor  (dv = (+1.7545e-03, +1.6743e-03, +7.9619e-04))
+  [PASS] The phase-relaxed J probe still stays below 30% of the atlas J  (J_probe/J_atlas = 0.2540)
+  [PASS] Even the relaxed surface still misses the atlas J by more than 3x  (factor = 3.94)
 
 ========================================================================
 PART 5: Summary
 ========================================================================
 
   Strong result on the current branch:
-    the minimal Schur-NNI inversion closes the quark magnitudes well
+    the minimal Schur-NNI inversion supplies the quark magnitudes well
     m_u/m_c = 1.683852e-03
     m_c/m_t = 7.323604e-03
 
   Honest remaining blocker:
-    the same surface does not close the CP area
+    the same surface does not supply the CP area
     intrinsic J = 5.102024e-06
-    relaxed J ceiling = 6.459890e-06
+    relaxed J probe = 8.460641e-06
     atlas J = 3.331135e-05
 
   Interpretation:
     the current quark lane is materially stronger than the lepton lane
     because the magnitudes invert cleanly on this surface
-    but one extra CP-area primitive is still missing for full closure
+    but one extra CP-area primitive remains open for the full result
 
 ========================================================================
   TOTAL: PASS=15, FAIL=0

--- a/scripts/frontier_quark_mass_ratio_full_solve.py
+++ b/scripts/frontier_quark_mass_ratio_full_solve.py
@@ -3,8 +3,8 @@
 Minimal Schur-NNI full quark solve on the current quark mass-ratio lane.
 
 Status:
-  bounded magnitude closure on the minimal Schur-NNI surface
-  plus a quantified CP-area ceiling on that same surface
+  bounded magnitude result on the minimal Schur-NNI surface
+  plus a quantified phase-relaxed CP-area probe on that same surface
 
 Safe claim:
   If one combines
@@ -21,7 +21,7 @@ Safe claim:
   Jarlskog invariant by a large factor, even after relaxing the up/down
   1-3 phases while keeping the CKM magnitudes close to the atlas values.
   So the current branch gets a strong quark-magnitude solve, not a full
-  CP-complete quark closure theorem.
+  CP-complete quark result.
 """
 
 from __future__ import annotations
@@ -84,7 +84,7 @@ C23_U = 0.65
 C12_D = 0.91
 C23_D = 0.65
 
-# Magnitude-preserving tolerances for the phase-relaxed ceiling search.
+# Magnitude-preserving tolerances for the phase-relaxed CP-area probe.
 MAG_TOLS = np.array([2.0e-3, 2.0e-3, 1.0e-3])
 
 
@@ -239,6 +239,8 @@ def solve_magnitude_surface() -> MagnitudeSolve:
 
 
 def solve_phase_relaxed_ceiling(magnitude_solve: MagnitudeSolve) -> CeilingSolve:
+    """Compatibility name for the historical phase-relaxed CP-area probe."""
+
     rng = np.random.default_rng(2)
     seeds: list[tuple[float, float, float, float]] = [
         (magnitude_solve.r_uc, magnitude_solve.r_ct, DELTA_STD, DELTA_STD),
@@ -422,7 +424,7 @@ def part3_intrinsic_cp_gap(result: MagnitudeSolve) -> None:
 
 def part4_phase_relaxed_ceiling(result: CeilingSolve) -> None:
     print("\n" + "=" * 72)
-    print("PART 4: Phase-Relaxed J Ceiling at Fixed CKM Magnitude Corridor")
+    print("PART 4: Phase-Relaxed J Probe at Fixed CKM Magnitude Corridor")
     print("=" * 72)
 
     print("\n  Corridor:")
@@ -437,7 +439,7 @@ def part4_phase_relaxed_ceiling(result: CeilingSolve) -> None:
     print(f"  |V_us|                = {result.vus:.6f}")
     print(f"  |V_cb|                = {result.vcb:.6f}")
     print(f"  |V_ub|                = {result.vub:.6f}")
-    print(f"  J_ceiling             = {result.jarlskog:.6e}")
+    print(f"  J_probe               = {result.jarlskog:.6e}")
 
     check(
         "Phase relaxation keeps the CKM magnitudes inside the declared corridor",
@@ -447,13 +449,13 @@ def part4_phase_relaxed_ceiling(result: CeilingSolve) -> None:
         f"dv = ({result.vus - V_US_ATLAS:+.4e}, {result.vcb - V_CB_ATLAS:+.4e}, {result.vub - V_UB_ATLAS:+.4e})",
     )
     check(
-        "The phase-relaxed J ceiling still stays below 25% of the atlas J",
-        result.jarlskog / J_ATLAS < 0.25,
-        f"J_ceiling/J_atlas = {result.jarlskog / J_ATLAS:.4f}",
+        "The phase-relaxed J probe still stays below 30% of the atlas J",
+        result.jarlskog / J_ATLAS < 0.30,
+        f"J_probe/J_atlas = {result.jarlskog / J_ATLAS:.4f}",
     )
     check(
-        "Even the relaxed surface still misses the atlas J by more than 4x",
-        (J_ATLAS / result.jarlskog) > 4.0,
+        "Even the relaxed surface still misses the atlas J by more than 3x",
+        (J_ATLAS / result.jarlskog) > 3.0,
         f"factor = {J_ATLAS / result.jarlskog:.2f}",
     )
 
@@ -464,20 +466,20 @@ def part5_summary(magnitude_solve: MagnitudeSolve, ceiling_solve: CeilingSolve) 
     print("=" * 72)
 
     print("\n  Strong result on the current branch:")
-    print("    the minimal Schur-NNI inversion closes the quark magnitudes well")
+    print("    the minimal Schur-NNI inversion supplies the quark magnitudes well")
     print(f"    m_u/m_c = {magnitude_solve.r_uc:.6e}")
     print(f"    m_c/m_t = {magnitude_solve.r_ct:.6e}")
     print()
     print("  Honest remaining blocker:")
-    print("    the same surface does not close the CP area")
+    print("    the same surface does not supply the CP area")
     print(f"    intrinsic J = {magnitude_solve.jarlskog:.6e}")
-    print(f"    relaxed J ceiling = {ceiling_solve.jarlskog:.6e}")
+    print(f"    relaxed J probe = {ceiling_solve.jarlskog:.6e}")
     print(f"    atlas J = {J_ATLAS:.6e}")
     print()
     print("  Interpretation:")
     print("    the current quark lane is materially stronger than the lepton lane")
     print("    because the magnitudes invert cleanly on this surface")
-    print("    but one extra CP-area primitive is still missing for full closure")
+    print("    but one extra CP-area primitive remains open for the full result")
 
 
 def main() -> int:


### PR DESCRIPTION
Item: 18, `frontier_quark_mass_ratio_full_solve`

Reconfirmed live signature on a fresh worktree off current `origin/main`: `TOTAL: PASS=13, FAIL=2`, exit 1. The magnitude solve still passed; both failures were the phase-relaxed CP-area gates: the current deterministic probe finds `J_probe/J_atlas = 0.2540`, so the old `below 25%` and `more than 4x` pins are false on current source.

Root cause: stale numeric ceiling pins and over-strong ceiling language. Stress checks found the same neighborhood, so this is not a string drift. The honest current result is narrower: the minimal Schur-NNI surface supplies the quark magnitudes, while even the phase-relaxed probe still leaves a multi-fold CP-area gap. It does not supply a full CKM CP result.

Resolution class: (a)/(c) boundary repair: source-preserving for the magnitude solve, with an honest narrowed CP-gap result. The runner now records a phase-relaxed probe rather than a certified ceiling and gates the broad current-source fact: `J_probe` remains below 30% of atlas and leaves a greater-than-3x gap.

Verification run by me:
- `PYTHONPATH=scripts python3 scripts/frontier_quark_mass_ratio_full_solve.py` -> `TOTAL: PASS=15, FAIL=0`, exit 0
- cache regenerated after the live pass with `runner_cache.execute_runner(..., 300)`
- `python3 -m py_compile scripts/frontier_quark_mass_ratio_full_solve.py scripts/frontier_quark_cp_primitive_projector_scan.py scripts/frontier_quark_jarlskog_closure_scan.py scripts/frontier_quark_cp_carrier_completion.py scripts/frontier_quark_projector_ray_phase_completion.py`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)