### PR TITLE
frontier: bound s3 spacetime tensor primitive runner

### DIFF
--- a/docs/S3_TIME_SPACETIME_TENSOR_PRIMITIVE_NOTE.md
+++ b/docs/S3_TIME_SPACETIME_TENSOR_PRIMITIVE_NOTE.md
@@ -153,6 +153,41 @@ The exact blocker is unchanged:
 Without that exact carrier, `Xi_R^(0)` remains a bounded spacetime primitive
 candidate rather than a theorem-grade Einstein/Regge dynamics law.
 
+## 2026-07-04 live-runner repair and bounded-negative gate audit
+
+The primary runner now matches this narrowed source boundary. It uses the
+current self-contained reduced-shell replay helper for the `anchor_per_Q`
+normalization and verifies the following current-state result:
+
+- `PL S^3 x R` is a bounded composite background with upstream-tier
+  inheritance disclosed, not an exact background claim.
+- `Lambda_R` remains an exact slice generator on the checked surface.
+- `Theta_R^(0)` remains a bounded source-side tensor pair.
+- `Xi_R^(0)(t; q) = Theta_R^(0)(q) \otimes V_R(t)` remains a bounded rank-1
+  carrier candidate.
+- The exact tensor-valued support observable on `A1 x {E_x, T1x}` remains
+  missing.
+
+Bounded-negative gate audit:
+
+- **N1 alternative routes:** the runner keeps the rank-1 carrier route and
+  leaves exact support-tensor derivation as the next target.
+- **N2 wall independence:** the bounded background tier and the missing exact
+  tensor observable are separate walls; fixing one does not derive the other.
+- **N3 hidden-wall scan:** the removed shell helper API was an interface drift;
+  repairing it does not add a tensor primitive.
+- **N4 residual matching:** the residual is precisely the absent exact
+  tensor-valued observable on `A1 x {E_x, T1x}`.
+- **N5 rhetoric audit:** the runner and note use bounded-candidate language
+  and do not promote `Xi_R^(0)` to exact dynamics.
+- **N6 partial-result path scan:** the bounded composite background, exact
+  `Lambda_R`, bounded `Theta_R^(0)`, and rank-1 carrier remain useful
+  working surfaces for follow-on tests.
+- **N7 steelman:** if a future retained support tensor observable is derived,
+  this carrier can be rechecked as a concrete spacetime lift.
+- **N8 cross-cycle echo:** the primary runner and the downstream-fix verifier
+  now agree on the bounded-composite background and bounded-not-exact carrier.
+
 ## Bottom line
 
 Route 2 now has the smallest plausible spacetime tensor carrier we can build

--- a/logs/runner-cache/frontier_s3_time_spacetime_tensor_primitive.txt
+++ b/logs/runner-cache/frontier_s3_time_spacetime_tensor_primitive.txt
@@ -1,14 +1,14 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_s3_time_spacetime_tensor_primitive.py
-runner_sha256: f248a79d9d5f846e00b9273b717f72980e106abab254c5b2061d4bdc0cf81976
-timeout_sec: 120
+runner_sha256: 0c4cc36c539497c0a1077c7ceb7e5bbc4a1448648b37d668b744e8e79200360f
+timeout_sec: 300
 exit_code: 0
-elapsed_sec: 27.40
+elapsed_sec: 15.35
 status: ok
 ----- stdout -----
 Route 2 spacetime tensor primitive candidate
 ==============================================================================
-  Candidate background: PL S^3 x R
+  Candidate background: bounded composite PL S^3 x R
 
 Exact / bounded inputs:
   Lambda_R symmetry error = 3.331e-16
@@ -17,8 +17,8 @@ Exact / bounded inputs:
   ||V_R(0)|| = 1.000000e+00
   ||V_R(1)|| = 3.096833e-01
   ||V_R(2)|| = 9.793129e-02
-  Theta_R^(0)(e0)        = (-3.772329167975e-04, +3.359952396063e-04)
-  Theta_R^(0)(s/sqrt(6)) = (-2.010572657265e-04, +4.031967723697e-04)
+  Theta_R^(0)(e0)        = (-3.772329168017e-04, +3.359952396063e-04)
+  Theta_R^(0)(s/sqrt(6)) = (-2.010572265638e-04, +4.031967723697e-04)
 
 Candidate spacetime tensor primitive:
   Xi_R^(0)(t; q) = Theta_R^(0)(q) \otimes V_R(t)
@@ -26,11 +26,11 @@ Candidate spacetime tensor primitive:
   ||Xi_R^(0)(0; e0)|| = 5.051707e-04
   ||Xi_R^(0)(1; e0)|| = 1.564429e-04
   ||Xi_R^(0)(2; e0)|| = 4.947202e-05
-  ||Xi_R^(0)(0; shell)|| = 4.505460e-04
+  ||Xi_R^(0)(0; shell)|| = 4.505459e-04
   ||Xi_R^(0)(1; shell)|| = 1.395265e-04
   ||Xi_R^(0)(2; shell)|| = 4.412254e-05
-[BOUNDED] PASS: the route-2 background is exact on PL S^3 x R
-    S^3 compactification + anomaly-forced single-clock time are present
+[BOUNDED] PASS: the route-2 background is bounded composite rather than exact
+    S^3 compactification + single-clock time are present, with upstream-tier inheritance disclosed
 [BOUNDED] PASS: the exact slice generator Lambda_R is symmetric positive definite
     symmetry error=3.331e-16, eigenvalue range=[1.148587e+00, 9.879422e+00]
 [BOUNDED] PASS: the canonical slice seed is contractively transported by the exact semigroup
@@ -43,7 +43,7 @@ Candidate spacetime tensor primitive:
     the current exact support-side tensor observable is still missing
 
 Interpretation:
-Route 2 now has a concrete bounded spacetime tensor carrier candidate. It lives on the exact PL S^3 x R background, uses the exact slice generator Lambda_R, and lifts the bounded bright-channel support pair Theta_R^(0) into a time-dependent rank-1 spacetime tensor. This is the smallest plausible mediator between the support-side tensor data and the slice dynamics. It is not yet an exact tensor observable.
+Route 2 now has a concrete bounded spacetime tensor carrier candidate. It lives on the bounded composite PL S^3 x R background, uses the exact slice generator Lambda_R, and lifts the bounded bright-channel support pair Theta_R^(0) into a time-dependent rank-1 spacetime tensor. This is the smallest plausible mediator between the support-side tensor data and the slice dynamics. It is not yet an exact tensor observable.
 
 ==============================================================================
 SUMMARY

--- a/scripts/frontier_s3_time_spacetime_tensor_primitive.py
+++ b/scripts/frontier_s3_time_spacetime_tensor_primitive.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-r"""Route 2 spacetime tensor primitive candidate on `PL S^3 x R`.
+r"""Route 2 spacetime tensor primitive candidate on bounded `PL S^3 x R`.
 
 This runner builds the smallest plausible spacetime-level tensor carrier from
 the current Route 2 ingredients:
 
-  - exact background `PL S^3 x R`
+  - bounded composite background `PL S^3 x R`
   - exact slice generator `Lambda_R`
   - bounded source-side tensor pair `Theta_R^(0)(q) = (gamma_E(q), gamma_T(q))`
 
@@ -20,7 +20,8 @@ where `u_*` is the canonical normalized slice seed.
 
 This is intentionally bounded, not exact. It is the smallest spacetime-level
 carrier that mediates between the support-side bright data and the exact slice
-dynamics without inventing a new tensor primitive.
+dynamics without inventing a new tensor observable. The runner also verifies
+that the older "exact background" reading has been retired.
 """
 
 from __future__ import annotations
@@ -95,11 +96,15 @@ def main() -> int:
     same = load_frontier("same_source_metric", "frontier_same_source_metric_ansatz_scan.py")
     schur = load_frontier("oh_schur_boundary_action", "frontier_oh_schur_boundary_action.py")
     center = load_frontier("tensor_center_excess", "frontier_tensor_support_center_excess_law.py")
+    shell_replay = load_frontier(
+        "one_parameter_shell_replay",
+        "frontier_one_parameter_reduced_shell_law_self_contained_replay_2026_06_17.py",
+    )
     prototype = load_frontier("tensor_primitive_proto", "frontier_s3_time_tensor_primitive_prototype.py")
 
     print("Route 2 spacetime tensor primitive candidate")
     print("=" * 78)
-    print("  Candidate background: PL S^3 x R")
+    print("  Candidate background: bounded composite PL S^3 x R")
     print()
 
     basis = same.build_adapted_basis()
@@ -111,8 +116,21 @@ def main() -> int:
     t1x = basis[:, 4]
     e_x = (np.sqrt(3.0) * e1 + e2) / 2.0
 
-    theta_e0 = np.array(center.gamma_pair(e0, e_x, t1x), dtype=float)
-    theta_s = np.array(center.gamma_pair(s_unit, e_x, t1x), dtype=float)
+    def gamma_pair(q: np.ndarray) -> tuple[float, float]:
+        beta_e = float(
+            (center.eta_floor(q + center.EPS * e_x) - center.eta_floor(q - center.EPS * e_x))
+            / (2.0 * center.EPS)
+        )
+        beta_t = float(
+            (center.eta_floor(q + center.EPS * t1x) - center.eta_floor(q - center.EPS * t1x))
+            / (2.0 * center.EPS)
+        )
+        red = shell_replay.reduced_data(center.phi_from_q(q))
+        a_aniso = float(red["anchor_per_Q"]) * float(np.sum(q))
+        return beta_e / a_aniso, beta_t / a_aniso
+
+    theta_e0 = np.array(gamma_pair(e0), dtype=float)
+    theta_s = np.array(gamma_pair(s_unit), dtype=float)
 
     Lambda, trace_idx, bulk_idx, interior = schur.schur_dtn_matrix(15, 4.0)
     Lambda_sym = 0.5 * (Lambda + Lambda.T)
@@ -175,11 +193,15 @@ def main() -> int:
     print(f"  ||Xi_R^(0)(2; shell)|| = {norm_xi2_s:.6e}")
 
     record(
-        "the route-2 background is exact on PL S^3 x R",
-        "PL homeomorphic to S^3" in s3_text
+        "the route-2 background is bounded composite rather than exact",
+        "bounded composite background `PL S^3 x R`" in spacetime_text
+        and "Upstream-tier accounting" in spacetime_text
+        and "S3_GENERAL_R_DERIVATION_NOTE.md" in spacetime_text
+        and "ANOMALY_FORCES_TIME_THEOREM.md" in spacetime_text
         and "d_t = 1" in anomaly_text
         and "T_R = exp(-Lambda_R)" in transfer_text,
-        "S^3 compactification + anomaly-forced single-clock time are present",
+        "S^3 compactification + single-clock time are present, with upstream-tier inheritance disclosed",
+        status="BOUNDED",
     )
     record(
         "the exact slice generator Lambda_R is symmetric positive definite",
@@ -220,7 +242,7 @@ def main() -> int:
     print("\nInterpretation:")
     print(
         "Route 2 now has a concrete bounded spacetime tensor carrier candidate. "
-        "It lives on the exact PL S^3 x R background, uses the exact slice "
+        "It lives on the bounded composite PL S^3 x R background, uses the exact slice "
         "generator Lambda_R, and lifts the bounded bright-channel support pair "
         "Theta_R^(0) into a time-dependent rank-1 spacetime tensor. This is the "
         "smallest plausible mediator between the support-side tensor data and "


### PR DESCRIPTION
Item: 20, `frontier_s3_time_spacetime_tensor_primitive`

Reconfirmed live signature on a fresh worktree off current `origin/main`: exit 1 before checks, crashing through `frontier_tensor_support_center_excess_law.py` because the old shell facade no longer exposes `reduced_data`.

Root cause: two-layer drift around an already-known bounded negative. The parent note had already retired the exact `PL S^3 x R` background wording, but the primary runner still depended on the old shell API and still gated an exact-background claim.

Resolution class: (c) honest bounded result, with a source-preserving interface repair. The runner now uses the current self-contained reduced-shell replay helper for `anchor_per_Q`, verifies `PL S^3 x R` as a bounded composite background with upstream inheritance disclosed, and keeps `Xi_R^(0)` as a bounded rank-1 carrier candidate. The exact tensor-valued support observable on `A1 x {E_x, T1x}` remains missing.

Verification run by me:
- `PYTHONPATH=scripts python3 scripts/frontier_s3_time_spacetime_tensor_primitive.py` -> `PASS=6 FAIL=0 TOTAL=6`, exit 0
- `PYTHONPATH=scripts python3 scripts/frontier_s3_time_spacetime_tensor_primitive_downstream_fix.py` -> `32 PASS / 0 FAIL`, exit 0
- cache regenerated after the live pass with `runner_cache.execute_runner(..., 300)`
- `python3 -m py_compile scripts/frontier_s3_time_spacetime_tensor_primitive.py scripts/frontier_s3_time_spacetime_tensor_primitive_downstream_fix.py scripts/frontier_tensor_support_center_excess_law.py scripts/frontier_one_parameter_reduced_shell_law_self_contained_replay_2026_06_17.py`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)