### PR TITLE
frontier: repair yt p1 i_s re-audit packet bridge

### DIFF
--- a/docs/YT_P1_I_S_LATTICE_PT_CITATION_NOTE_2026-04-17.md
+++ b/docs/YT_P1_I_S_LATTICE_PT_CITATION_NOTE_2026-04-17.md
@@ -26,27 +26,30 @@ narrowed to a **conditional arithmetic lemma**: given a supplied bracket
 analogue, the associated P1 contribution is recomputed at
 `α_LM = 0.0907` and compared to the packaged `1.92%` nominal.
 
-The source-side repair surface for re-audit is more precise: the supplied
-bracket is not load-bearing for the framework-native candidate. The native
+The source-side repair surface for re-audit is now negative: the supplied
+bracket is not load-bearing for a framework-native value, and the native
 quadrature row
 [`YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md`](YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md)
-computes
-`I_S_native = 3.902217` on the exact `Cl(3) x Z^3` `H_unit` surface. If that
-quadrature row and the canonical alpha/plaquette value certificate
+now records the corrected full-BZ scalar value
+`I_S = 32.435`, not the old divided value `3.902`. The same correction packet
+also records that the fixed-regulator fermion channel is not a controlled
+matching constant. If that quadrature row and the canonical alpha/plaquette
+value certificate
 [`CANONICAL_PLAQUETTE_ALPHA_LM_VALUE_CERTIFICATE_BOUNDED_NOTE_2026-06-16.md`](CANONICAL_PLAQUETTE_ALPHA_LM_VALUE_CERTIFICATE_BOUNDED_NOTE_2026-06-16.md)
-are independently audited clean with retained-grade dependency closure, this
-row can be read as the native arithmetic bridge
+are independently audited clean, this row can be read only as the corrected
+diagnostic bridge
 
 ```
-    P1_native = (alpha_LM / (4 pi)) * C_F * I_S_native
-              = 3.754% central
-              = [3.566%, 3.942%] under the quadrature row's 5% scalar
-                systematic band.
+    P1_corrected_scalar_diagnostic
+      = (alpha_LM / (4 pi)) * C_F * 32.435
+      = 31.203% central
 ```
 
-The literature bracket remains parallel context only. It is not needed for the
-native candidate arithmetic, and no audit should treat the bracket as retained
-unless the bracket itself is separately accepted.
+That number is a diagnostic fallout of the corrected scalar channel, not a
+controlled native prediction. The corrected `Delta_R` diagnostic is O(50%) and
+uncontrolled until the scalar and fermion matching problems are re-derived. The
+literature bracket remains parallel context only, and no audit should treat the
+bracket as retained unless the bracket itself is separately accepted.
 
 The canonical numerical science lane is
 [`YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md`](YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md),
@@ -60,8 +63,9 @@ This citation row should be treated as:
 
 - a conditional arithmetic/literature-context witness for the supplied
   `I_S in [4,10]` bracket; and
-- a framework-native arithmetic bridge from the independently audited BZ
-  candidate value to `P1_native`.
+- a corrected BZ diagnostic bridge showing that the old native replacement
+  candidate is invalidated by the scalar `/N_TASTE` double-count and fermion
+  regulator-dependence findings.
 
 ## Authority notice
 
@@ -99,7 +103,7 @@ retained proof of that value. What the citation surface adds is narrower:
 
 Read it together with:
 
-- [`YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md`](YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md) (native BZ quadrature candidate; independently audited on its own row)
+- [`YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md`](YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md) (corrected BZ diagnostic row; independently audited on its own row)
 - [`CANONICAL_PLAQUETTE_ALPHA_LM_VALUE_CERTIFICATE_BOUNDED_NOTE_2026-06-16.md`](CANONICAL_PLAQUETTE_ALPHA_LM_VALUE_CERTIFICATE_BOUNDED_NOTE_2026-06-16.md) (canonical arithmetic certificate for `P`, `u_0`, `alpha_LM`, and `alpha_LM/(4pi)`)
 - [`PLAQUETTE_SELF_CONSISTENCY_NOTE.md`](PLAQUETTE_SELF_CONSISTENCY_NOTE.md) (parent plaquette reuse surface)
 - [`YT_P1_COLOR_FACTOR_RETENTION_NOTE_2026-04-17.md`](YT_P1_COLOR_FACTOR_RETENTION_NOTE_2026-04-17.md) (retained `C_F`/`C_A`/`T_F n_f` decomposition)
@@ -525,8 +529,8 @@ audit lane to accept that bracket as a closed framework-native input.
 
 This section responds to the 2026-06-11 conditional audit request for a
 restricted packet that exposes the prior `I_1 = I_S` reduction, the `C_F`
-authority, and a citation/native certificate for the supplied `I_S in [4,10]`
-bracket. It is an audit-readiness bridge only. It does not update any audit
+authority, the conditional supplied-bracket arithmetic, and the corrected BZ
+diagnostic row. It is an audit-readiness bridge only. It does not update any audit
 verdict, does not promote this row, and does not treat any unaudited downstream
 quadrature note as an authority before independent review.
 
@@ -537,39 +541,34 @@ quadrature note as an authority before independent review.
 | `I_1 = I_S` reduction | `scripts/frontier_yt_p1_i1_lattice_pt_symbolic.py`; `logs/retained/yt_p1_i1_lattice_pt_symbolic_2026-04-17.log` | 21/21 symbolic checks: `I_1 = I_S - I_V`, `I_V = 0` on the conserved-current surface, hence `I_1 = I_S` | structural input exposed for audit; this bridge does not recertify its ledger status |
 | `C_F` color factor | `docs/YT_P1_COLOR_FACTOR_RETENTION_NOTE_2026-04-17.md`; `scripts/frontier_yt_p1_color_factor_retention.py`; `logs/runner-cache/frontier_yt_p1_color_factor_retention.txt` | exact `SU(3)` identities `C_F = 4/3`, `C_A = 3`, `T_F n_f = 3`, plus the three-channel decomposition | algebraic authority exposed for audit; per-channel integrals remain separate inputs |
 | conditional citation arithmetic | this note; `scripts/frontier_yt_p1_i_s_lattice_pt_citation.py`; `logs/runner-cache/frontier_yt_p1_i_s_lattice_pt_citation.txt` | supplied `I_S in [4,10]` maps to `P1 in [3.85%,9.62%]`, central `5.77%`, and `I_S = 2` maps back to the packaged `1.92%` reference | conditional arithmetic only; the bracket remains supplied unless accepted by audit or replaced by a native derivation |
-| native BZ arithmetic candidate | `docs/YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md`; `scripts/frontier_yt_p1_bz_quadrature_full_staggered_pt.py`; `logs/runner-cache/frontier_yt_p1_bz_quadrature_full_staggered_pt.txt` | full staggered-PT cache computes `I_v_scalar = +3.902217` with a quoted 5% systematic envelope and `I_v_gauge = 0`; this gives `P1_native = 3.754%` central and `[3.566%,3.942%]` under the scalar systematic | framework-native candidate arithmetic; if the quadrature lane is independently audited clean, this value replaces the supplied bracket as the load-bearing input for the native surface |
+| corrected BZ diagnostic bridge | `docs/YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md`; `scripts/frontier_yt_p1_bz_quadrature_full_staggered_pt.py`; `logs/runner-cache/frontier_yt_p1_bz_quadrature_full_staggered_pt.txt`; `docs/YT_P1_DELTA_R_FERMION_REGULATOR_DEPENDENCE_AND_SCALAR_NTASTE_RESOLUTION_NOTE_2026-06-16.md` | full staggered-PT cache computes corrected `I_v_scalar = +32.435`, positive `Delta_R = +51.129%`, and records that the old `-3.27%` / `-3.77%` P1 residual is invalidated | diagnostic correction only; the old native replacement candidate is not load-bearing, and the corrected row remains under separate audit |
 
-### 8.2 What the native BZ certificate does and does not prove
+### 8.2 What the corrected BZ diagnostic does and does not prove
 
-The full-staggered quadrature cache supplies a directly inspectable native
-number near the low end of the cited bracket:
-
-```
-    I_S_native_candidate  =  I_v_scalar  =  3.902
-    5% systematic band    =  [3.707, 4.097]
-```
-
-Thus the native candidate is compatible with the low endpoint `I_S = 4` of the
-supplied bracket at the stated systematic level. More importantly, it is a
-framework-native number on the exact `Cl(3) x Z^3` `H_unit` quadrature surface,
-so it can replace the supplied bracket on the native arithmetic path once the
-quadrature row itself is audited. In the same normalization, using the
-canonical `alpha_LM` and `C_F = 4/3`,
+The full-staggered quadrature cache no longer supplies a native number near the
+low end of the cited bracket. It supplies a corrected diagnostic:
 
 ```
-    P1_native_candidate
-      = (alpha_LM / (4 pi)) * C_F * 3.902217
-      = 3.754%   (central, before the quadrature lane is audited)
-      = [3.566%, 3.942%] under the quadrature row's 5% scalar systematic
+    I_v_scalar corrected full-BZ  =  32.435
+    Delta_R full staggered-PT     =  +51.129%
 ```
 
-This is useful because it checks the scale and operator family against a
-framework-native full-staggered BZ computation rather than leaving the row as
-pure citation arithmetic. The native path does not prove the full supplied
-range `I_S in [4,10]` and does not prove the literature upper end `10`; it
-removes the need to import that range for the native candidate. The only
-remaining gate is independent audit of the quadrature row and this arithmetic
-bridge.
+Thus the old `I_S = 3.902` bridge is not available: it was the scalar
+`/N_TASTE` double-count surface. In the same normalization, using the canonical
+`alpha_LM` and `C_F = 4/3`, the corrected scalar diagnostic maps to
+
+```
+    P1_corrected_scalar_diagnostic
+      = (alpha_LM / (4 pi)) * C_F * 32.435
+      = 31.203%
+```
+
+That arithmetic is useful only as a correction diagnostic. It does not prove the
+supplied range `I_S in [4,10]`, does not replace the supplied bracket as a
+native input, and does not produce a controlled P1 prediction. The current
+corrected BZ row says the old small P1 residual is invalidated and that the
+scalar/fermion matching surface must be re-derived before it can carry native
+authority.
 
 ### 8.3 Re-audit verifier
 
@@ -577,18 +576,19 @@ The companion verifier
 `scripts/frontier_yt_p1_i_s_reaudit_packet_2026_06_12.py` checks the
 restricted packet above. Its PASS lines intentionally certify only:
 
-- source/cache presence for the prior symbolic, color-factor, citation, and
-  native-BZ candidate surfaces;
+- source/cache presence for the prior symbolic, color-factor, citation, BZ,
+  and correction surfaces;
 - exact recovery of `I_1 = I_S`, `C_F = 4/3`, and the conditional
   `P1 in [3.85%,9.62%]` arithmetic;
-- extraction of `I_v_scalar = +3.902217`, `P1_native = 3.754%`, and
-  `Delta_R = -3.769%` from the native full-staggered cache;
+- extraction of corrected `I_v_scalar = +32.435`, positive
+  `Delta_R = +51.129%`, and the invalidation of the old small residual from the
+  full-staggered cache;
 - explicit firewalls that this note does not claim audit closure, does not
-  prove or import the upper end of the supplied bracket for the native path,
+  prove or import the supplied bracket as a native path,
   and does not modify the master obstruction theorem.
 
 Independent audit remains required before this row or any downstream consumer
-may treat the native-BZ candidate or the P1 revision as retained authority.
+may treat any corrected BZ diagnostic or P1 revision as retained authority.
 
 ## 9. Validation
 

--- a/logs/runner-cache/frontier_yt_p1_i_s_reaudit_packet_2026_06_12.txt
+++ b/logs/runner-cache/frontier_yt_p1_i_s_reaudit_packet_2026_06_12.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_yt_p1_i_s_reaudit_packet_2026_06_12.py
-runner_sha256: 6f39a75787114288a6190793ce607a5d40dfbb6a13571693c2ad5c7d44de13ef
-timeout_sec: 120
+runner_sha256: df90512869e65759afd47c14099237722d5ee22d70e8272d84250ab405575b18
+timeout_sec: 300
 exit_code: 0
-elapsed_sec: 0.05
+elapsed_sec: 0.04
 status: ok
 ----- stdout -----
 ========================================================================
@@ -18,6 +18,7 @@ BLOCK 1: restricted-packet source/cache presence
   [PASS] docs/YT_P1_I_S_LATTICE_PT_CITATION_NOTE_2026-04-17.md exists  (present)
   [PASS] docs/YT_P1_COLOR_FACTOR_RETENTION_NOTE_2026-04-17.md exists  (present)
   [PASS] docs/YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md exists  (present)
+  [PASS] docs/YT_P1_DELTA_R_FERMION_REGULATOR_DEPENDENCE_AND_SCALAR_NTASTE_RESOLUTION_NOTE_2026-06-16.md exists  (present)
   [PASS] docs/CANONICAL_PLAQUETTE_ALPHA_LM_VALUE_CERTIFICATE_BOUNDED_NOTE_2026-06-16.md exists  (present)
   [PASS] docs/PLAQUETTE_SELF_CONSISTENCY_NOTE.md exists  (present)
   [PASS] docs/YT_UV_TO_IR_TRANSPORT_OBSTRUCTION_THEOREM_NOTE_2026-04-17.md exists  (present)
@@ -35,17 +36,17 @@ BLOCK 2: source-note status boundary
 ========================================================================
   [PASS] re-audit bridge section present
   [PASS] restricted packet table present
-  [PASS] native BZ candidate section present
+  [PASS] corrected BZ diagnostic section present
   [PASS] independent audit firewall present
   [PASS] no audit verdict update claimed
-  [PASS] native path does not use supplied bracket as load-bearing
-  [PASS] upper end not proved
-  [PASS] native candidate replacement gate explicit
+  [PASS] corrected path does not use supplied bracket as load-bearing
+  [PASS] supplied range not proved
+  [PASS] old native candidate invalidation explicit
   [PASS] master theorem not modified
   [PASS] old proposed-retained marker absent from citation note
   [PASS] citation note remains bounded theorem
   [PASS] citation note keeps legacy conditional arithmetic
-  [PASS] citation note names native arithmetic bridge
+  [PASS] citation note names corrected BZ diagnostic bridge
   [PASS] citation note links native BZ row as markdown dependency
   [PASS] citation note links canonical alpha certificate
   [PASS] citation note links parent plaquette surface
@@ -92,38 +93,39 @@ BLOCK 4: conditional I_S bracket arithmetic
   [PASS] central/standard revision factor is exactly 3
 
 ========================================================================
-BLOCK 5: native full-staggered BZ candidate
+BLOCK 5: corrected full-staggered BZ diagnostic
 ========================================================================
-  I_v_scalar candidate       = 3.902000
-  5% systematic scalar band  = [3.706900, 4.097100]
-  P1 native candidate        = 3.7538%
-  P1 native 5% band          = [3.5661%, 3.9415%]
-  Delta_R full staggered-PT  = -3.769%
+  I_v_scalar corrected       = 32.435000
+  5% systematic scalar band  = [30.813250, 34.056750]
+  P1 scalar diagnostic       = 31.2030%
+  P1 scalar 5% band          = [29.6428%, 32.7631%]
+  Delta_R full staggered-PT  = 51.129%
   [PASS] BZ cache records clean execution
-  [PASS] BZ cache records PASS=45 FAIL=0
-  [PASS] BZ cache gives I_v_scalar near 3.902
-  [PASS] 5% scalar systematic overlaps I_S = 4
-  [PASS] native P1 candidate equals framework-native arithmetic bridge
-  [PASS] native P1 systematic band recorded
-  [PASS] BZ cache gives negative Delta_R three-channel assembly
-  [PASS] note records native lower-end candidate
-  [PASS] note records native P1 central value
-  [PASS] note records native P1 systematic band
-  [PASS] note says native candidate removes bracket import for native path
+  [PASS] BZ cache records PASS=44 FAIL=0
+  [PASS] BZ cache gives corrected I_v_scalar near 32.435
+  [PASS] 5% scalar systematic is far outside supplied I_S bracket
+  [PASS] corrected scalar diagnostic maps to about 31.2%
+  [PASS] corrected scalar 5% band recorded arithmetically
+  [PASS] BZ cache gives positive Delta_R three-channel diagnostic
+  [PASS] BZ cache records old small residual invalidated
+  [PASS] note records corrected scalar diagnostic
+  [PASS] note records corrected P1 scalar diagnostic
+  [PASS] note says old native replacement candidate is invalidated
+  [PASS] note says corrected BZ row remains diagnostic only
 
 ========================================================================
 BLOCK 6: audit/status firewall
 ========================================================================
   [PASS] citation note says legacy bracket is not retained by default
   [PASS] citation note keeps master obstruction unchanged
-  [PASS] new bridge calls BZ surface a native candidate
+  [PASS] new bridge calls BZ surface a corrected diagnostic
   [PASS] new bridge requires separate BZ audit
   [PASS] new bridge does not treat literature bracket as native authority
-  [PASS] bridge keeps BZ candidate under separate audit
+  [PASS] bridge keeps corrected BZ diagnostic under separate audit
   [PASS] this runner does not edit audit ledger  (source/cache verifier only)
 
 ========================================================================
-SUMMARY: PASS=72  FAIL=0
+SUMMARY: PASS=74  FAIL=0
 ========================================================================
 
 RESULT:

--- a/scripts/frontier_yt_p1_i_s_reaudit_packet_2026_06_12.py
+++ b/scripts/frontier_yt_p1_i_s_reaudit_packet_2026_06_12.py
@@ -11,9 +11,9 @@ packet exposes:
   * the `SU(3)` color-factor authority `C_F = 4/3`;
   * the conditional citation arithmetic `I_S in [4,10] -> P1 in
     [3.85%,9.62%]`;
-  * the full-staggered BZ candidate cache giving a framework-native scalar
-    candidate and native P1 arithmetic that can replace the supplied bracket
-    if the BZ row is independently audited clean;
+  * the corrected full-staggered BZ cache showing the old small native
+    candidate was a scalar taste-normalization bug and that the corrected
+    diagnostic is large and uncontrolled;
   * explicit firewalls against treating either surface as an audit-closed
     retained value before independent review.
 """
@@ -33,6 +33,7 @@ ROOT = Path(__file__).resolve().parents[1]
 NOTE = ROOT / "docs" / "YT_P1_I_S_LATTICE_PT_CITATION_NOTE_2026-04-17.md"
 COLOR_NOTE = ROOT / "docs" / "YT_P1_COLOR_FACTOR_RETENTION_NOTE_2026-04-17.md"
 BZ_NOTE = ROOT / "docs" / "YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md"
+CORRECTION_NOTE = ROOT / "docs" / "YT_P1_DELTA_R_FERMION_REGULATOR_DEPENDENCE_AND_SCALAR_NTASTE_RESOLUTION_NOTE_2026-06-16.md"
 CANONICAL_CERT_NOTE = ROOT / "docs" / "CANONICAL_PLAQUETTE_ALPHA_LM_VALUE_CERTIFICATE_BOUNDED_NOTE_2026-06-16.md"
 PLAQUETTE_NOTE = ROOT / "docs" / "PLAQUETTE_SELF_CONSISTENCY_NOTE.md"
 MASTER_NOTE = ROOT / "docs" / "YT_UV_TO_IR_TRANSPORT_OBSTRUCTION_THEOREM_NOTE_2026-04-17.md"
@@ -96,6 +97,7 @@ def block_1_packet_presence() -> None:
         NOTE,
         COLOR_NOTE,
         BZ_NOTE,
+        CORRECTION_NOTE,
         CANONICAL_CERT_NOTE,
         PLAQUETTE_NOTE,
         MASTER_NOTE,
@@ -125,17 +127,17 @@ def block_2_source_boundary() -> None:
     note_flat = compact(note)
     check("re-audit bridge section present", "2026-06-12 restricted-packet re-audit bridge" in note)
     check("restricted packet table present", "Packet authorities exposed for re-audit" in note)
-    check("native BZ candidate section present", "What the native BZ certificate does and does not prove" in note)
+    check("corrected BZ diagnostic section present", "What the corrected BZ diagnostic does and does not prove" in note)
     check("independent audit firewall present", "Independent audit remains required" in note)
     check("no audit verdict update claimed", "does not update any audit verdict" in note_flat)
-    check("native path does not use supplied bracket as load-bearing", "supplied bracket is not load-bearing for the framework-native candidate" in note_flat)
-    check("upper end not proved", "does not prove the full supplied range" in note_flat)
-    check("native candidate replacement gate explicit", "can replace the supplied bracket on the native arithmetic path once the quadrature row itself is audited" in note_flat)
+    check("corrected path does not use supplied bracket as load-bearing", "supplied bracket is not load-bearing for a framework-native value" in note_flat)
+    check("supplied range not proved", "does not prove the supplied range" in note_flat)
+    check("old native candidate invalidation explicit", "old native replacement candidate is invalidated" in note_flat)
     check("master theorem not modified", "does not modify the master obstruction theorem" in note_flat)
     check("old proposed-retained marker absent from citation note", ("proposed_" + "retained") not in note)
     check("citation note remains bounded theorem", "**Claim type:** bounded_theorem" in note)
     check("citation note keeps legacy conditional arithmetic", "conditional arithmetic lemma" in note)
-    check("citation note names native arithmetic bridge", "framework-native arithmetic bridge" in note)
+    check("citation note names corrected BZ diagnostic bridge", "corrected BZ diagnostic bridge" in note)
     check("citation note links native BZ row as markdown dependency", "](YT_P1_BZ_QUADRATURE_FULL_STAGGERED_PT_NOTE_2026-04-18.md)" in note)
     check("citation note links canonical alpha certificate", "](CANONICAL_PLAQUETTE_ALPHA_LM_VALUE_CERTIFICATE_BOUNDED_NOTE_2026-06-16.md)" in note)
     check("citation note links parent plaquette surface", "](PLAQUETTE_SELF_CONSISTENCY_NOTE.md)" in note)
@@ -178,7 +180,11 @@ def block_3b_canonical_alpha_certificate() -> None:
     check("canonical certificate links plaquette parent", "](PLAQUETTE_SELF_CONSISTENCY_NOTE.md)" in cert)
     check("canonical certificate displays alpha_LM/(4pi)", "alpha_LM/(4pi)" in cert)
     check("BZ note links canonical certificate", "](CANONICAL_PLAQUETTE_ALPHA_LM_VALUE_CERTIFICATE_BOUNDED_NOTE_2026-06-16.md)" in bz)
-    check("P1 note consumes canonical certificate only after audit", "canonical alpha/plaquette value certificate" in p1 and "independently audited clean" in p1)
+    p1_flat = compact(p1)
+    check(
+        "P1 note consumes canonical certificate only after audit",
+        "canonical alpha/plaquette value certificate" in p1_flat and "independently audited clean" in p1_flat,
+    )
 
 
 def block_4_conditional_arithmetic() -> None:
@@ -219,11 +225,12 @@ def block_4_conditional_arithmetic() -> None:
 
 def block_5_native_bz_candidate() -> None:
     print("\n" + "=" * 72)
-    print("BLOCK 5: native full-staggered BZ candidate")
+    print("BLOCK 5: corrected full-staggered BZ diagnostic")
     print("=" * 72)
 
     cache = text(BZ_CACHE)
     note = text(NOTE)
+    note_flat = compact(note)
 
     i_v_scalar = require_float(r"I_v_scalar\s+= \+([0-9.]+) \+/-", cache, "I_v_scalar")
     delta_r = require_float(r"Delta_R full staggered-PT:\s+([-+0-9.]+) %", cache, "Delta_R")
@@ -236,23 +243,24 @@ def block_5_native_bz_candidate() -> None:
     p1_native_low = alpha_over_4pi * cf * syst_low
     p1_native_high = alpha_over_4pi * cf * syst_high
 
-    print(f"  I_v_scalar candidate       = {i_v_scalar:.6f}")
+    print(f"  I_v_scalar corrected       = {i_v_scalar:.6f}")
     print(f"  5% systematic scalar band  = [{syst_low:.6f}, {syst_high:.6f}]")
-    print(f"  P1 native candidate        = {100.0 * p1_native:.4f}%")
-    print(f"  P1 native 5% band          = [{100.0 * p1_native_low:.4f}%, {100.0 * p1_native_high:.4f}%]")
+    print(f"  P1 scalar diagnostic       = {100.0 * p1_native:.4f}%")
+    print(f"  P1 scalar 5% band          = [{100.0 * p1_native_low:.4f}%, {100.0 * p1_native_high:.4f}%]")
     print(f"  Delta_R full staggered-PT  = {delta_r:.3f}%")
 
     check("BZ cache records clean execution", "status: ok" in cache and "exit_code: 0" in cache)
-    check("BZ cache records PASS=45 FAIL=0", "SUMMARY: PASS=45  FAIL=0" in cache)
-    check("BZ cache gives I_v_scalar near 3.902", abs(i_v_scalar - 3.902) < 0.005)
-    check("5% scalar systematic overlaps I_S = 4", syst_low <= 4.0 <= syst_high)
-    check("native P1 candidate equals framework-native arithmetic bridge", abs(100.0 * p1_native - 3.754) < 0.03)
-    check("native P1 systematic band recorded", abs(100.0 * p1_native_low - 3.566) < 0.03 and abs(100.0 * p1_native_high - 3.942) < 0.03)
-    check("BZ cache gives negative Delta_R three-channel assembly", delta_r < 0.0)
-    check("note records native lower-end candidate", "I_S_native_candidate" in note and "3.902" in note)
-    check("note records native P1 central value", "3.754%" in note)
-    check("note records native P1 systematic band", "[3.566%, 3.942%]" in note)
-    check("note says native candidate removes bracket import for native path", "removes the need to import that range for the native candidate" in note)
+    check("BZ cache records PASS=44 FAIL=0", "SUMMARY: PASS=44  FAIL=0" in cache)
+    check("BZ cache gives corrected I_v_scalar near 32.435", abs(i_v_scalar - 32.435) < 0.01)
+    check("5% scalar systematic is far outside supplied I_S bracket", syst_low > 10.0)
+    check("corrected scalar diagnostic maps to about 31.2%", abs(100.0 * p1_native - 31.203) < 0.05)
+    check("corrected scalar 5% band recorded arithmetically", abs(100.0 * p1_native_low - 29.643) < 0.05 and abs(100.0 * p1_native_high - 32.763) < 0.05)
+    check("BZ cache gives positive Delta_R three-channel diagnostic", delta_r > 0.0)
+    check("BZ cache records old small residual invalidated", "old -3.27% / -3.77% P1 residual is invalidated" in cache)
+    check("note records corrected scalar diagnostic", "I_v_scalar corrected full-BZ  =  32.435" in note)
+    check("note records corrected P1 scalar diagnostic", "31.203%" in note)
+    check("note says old native replacement candidate is invalidated", "old native replacement candidate is invalidated" in note_flat)
+    check("note says corrected BZ row remains diagnostic only", "diagnostic correction only" in note_flat)
 
 
 def block_6_scope_firewall() -> None:
@@ -265,16 +273,16 @@ def block_6_scope_firewall() -> None:
 
     check("citation note says legacy bracket is not retained by default", "no audit should treat the bracket as retained unless the bracket itself is separately accepted" in note_flat)
     check("citation note keeps master obstruction unchanged", "Do not modify the master obstruction theorem" in note)
-    check("new bridge calls BZ surface a native candidate", "native-BZ candidate" in note or "native BZ candidate" in note)
+    check("new bridge calls BZ surface a corrected diagnostic", "corrected BZ diagnostic" in note)
     check("new bridge requires separate BZ audit", "Independent audit remains required" in note)
     check(
         "new bridge does not treat literature bracket as native authority",
         "literature bracket remains parallel context only" in note_flat,
     )
     check(
-        "bridge keeps BZ candidate under separate audit",
+        "bridge keeps corrected BZ diagnostic under separate audit",
         "Independent audit remains required" in note
-        and "native-BZ candidate or the P1 revision as retained authority" in note,
+        and "corrected BZ diagnostic or P1 revision as retained authority" in note,
     )
     check("this runner does not edit audit ledger", True, "source/cache verifier only")
 


### PR DESCRIPTION
## Summary
- Repairs item 21: `frontier_yt_p1_i_s_reaudit_packet_2026_06_12`.
- Reconfirmed live starting signature: `SUMMARY: PASS=66  FAIL=6`, all in the old Block 5 native-BZ bridge.
- Root cause: the packet still gated the stale BZ native replacement candidate: `PASS=45 FAIL=0`, `I_v_scalar ~= 3.902`, a low-end scalar band, `P1_native ~= 3.754%`, and negative `Delta_R`. The current BZ cache records corrected `I_v_scalar = 32.435`, corrected scalar diagnostic `P1 = 31.203%`, positive `Delta_R = +51.129%`, and invalidates the old small residual after the scalar `/N_TASTE` and fermion-regulator correction note.
- Resolution class: (c) honest bounded result / bridge narrowing. The note now treats the BZ row as a corrected diagnostic only, not a controlled native P1 prediction or replacement for the supplied bracket.

## Verification
- `PYTHONPATH=scripts python3 scripts/frontier_yt_p1_i_s_reaudit_packet_2026_06_12.py` -> `SUMMARY: PASS=74  FAIL=0`.
- Regenerated `logs/runner-cache/frontier_yt_p1_i_s_reaudit_packet_2026_06_12.txt` with the required cache helper.
- `python3 -m py_compile scripts/frontier_yt_p1_i_s_reaudit_packet_2026_06_12.py scripts/frontier_yt_p1_bz_quadrature_full_staggered_pt.py`.
- `git diff --check`.
- Targeted stale-wording scan for the old native replacement candidate phrases returned no hits in the changed note/runner/cache.

## Audit boundary
- This PR does not edit or predict audit-status grades.
- The runner verifies row/source/cache presence and corrected diagnostic content only.
- Independent audit remains required before treating any corrected BZ diagnostic or P1 revision as retained authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)