### PR TITLE
feat(chirality): domain-wall edge anomaly inflow via spectral flow (chiral-from-achiral step 3)

### DIFF
--- a/docs/DOMAIN_WALL_EDGE_ANOMALY_INFLOW_SPECTRAL_FLOW_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-05.md
+++ b/docs/DOMAIN_WALL_EDGE_ANOMALY_INFLOW_SPECTRAL_FLOW_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-05.md
@@ -1,0 +1,224 @@
+# Domain-Wall Edge Anomaly-Inflow Spectral Flow: Free-Field Bounded Theorem
+
+**Date:** 2026-07-05
+**Type:** bounded_theorem
+**Claim scope:** finite free-field linear algebra with a non-dynamical
+background `U(1)` field. The runner couples the record-time domain-wall
+Hamiltonian to Peierls-link phases, inserts one magnetic flux quantum through
+the transverse spatial torus, threads a twist through the remaining spatial
+cycle, diagonalizes `H(phi)` on a flux grid, and counts zero crossings of
+tracked localized edge levels. It checks Callan-Harvey anomaly-inflow
+consistency at the free-field spectral-flow level. It does not derive or
+resolve the ABJ anomaly premise.
+**Status authority:** independent audit lane only. This note does not set,
+predict, or request an audit status.
+**Primary runner:** [`scripts/domain_wall_edge_anomaly_inflow_spectral_flow_2026_07_05.py`](../scripts/domain_wall_edge_anomaly_inflow_spectral_flow_2026_07_05.py)
+**Runner cache:** [`logs/runner-cache/domain_wall_edge_anomaly_inflow_spectral_flow_2026_07_05.txt`](../logs/runner-cache/domain_wall_edge_anomaly_inflow_spectral_flow_2026_07_05.txt)
+
+## Source context
+
+This step builds on the Step 1 record-time domain-wall construction and uses
+the same four-component Wilson-domain-wall diagnostic:
+
+```text
+H =
+    K_x(A) Gamma_x + K_y(A) Gamma_y + sin(k_z) Gamma_z
+  + K_s Gamma_s
+  + [m(s) + L_x(A) + L_y(A) + L_s + (1 - cos(k_z))] Gamma_m.
+```
+
+The Step 1 note and runner were available in the source review worktree as
+`DOMAIN_WALL_CHIRAL_EDGE_FROM_ACHIRAL_CL3_BULK_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-04.md`
+and `scripts/domain_wall_chiral_edge_from_achiral_cl3_bulk_2026_07_04.py`.
+The Step 2 file
+`RECORD_FORMATION_FRONT_IS_THE_DOMAIN_WALL_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-05.md`
+was not present in the workspace at run time (it has since landed as its own
+PR). Accordingly this runner reuses the Step 1 chirality operator
+`chi_edge = i Gamma_s Gamma_m` and the mass-sign flip, and the tie to the Step 2
+formation arrow is stated conditionally on Step 2's identification of the
+mass/occupancy-gradient sign with the formation arrow (now available in the
+landed Step 2 note); the spectral-flow result of this note stands independently
+of that tie.
+
+The ABJ bridge
+`ANOMALY_FORCES_TIME_ABJ_INCONSISTENCY_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-26.md`
+is used only as an accepted-premise context: a consistent closed chiral gauge
+theory must have zero net anomaly. This Step 3 calculation supplies the
+free-field domain-wall consistency mechanism: local wall and anti-wall
+spectral flows are opposite, so the closed record-time torus has zero net
+flow.
+
+This is not a re-attack on
+`A3_ROUTE3_ANOMALY_INFLOW_BOUNDED_OBSTRUCTION_NOTE_2026-05-08_r3.md`.
+That note bounded anomaly inflow as a Brillouin-zone-corner distinguisher.
+Here the question is different: whether the already-constructed domain-wall
+edge has the expected local Callan-Harvey spectral flow under a background
+gauge field.
+
+The native anomaly-core notes
+`ABJ_SCALE_FREE_NATIVE_ABELIAN_ANOMALY_CORE_BOUNDARY_NOTE_2026-06-18.md`
+and `NATIVE_GAUGE_LEFT_HANDED_ABELIAN_SURFACE_BOUNDED_NOTE_2026-05-23.md`
+remain contextual only. They indicate where an abelian anomaly core would sit
+on the left-handed `6 + 2` surface, but no hypercharge or Standard Model
+content is assigned here.
+
+## Background gauge field
+
+For a three-dimensional Weyl edge, a pure twist of one spatial cycle gives
+paired Weyl-cone branches. The anomaly spectral-flow diagnostic requires the
+standard `E . B` handle: one background magnetic flux quantum through the
+transverse `x-y` torus and a threaded twist `phi` along the `z` cycle. The
+runner implements this with Peierls phases:
+
+```text
+U_y(x,y) = exp(i B x),
+U_x(L_x - 1,y) = exp(-i B L_x y),
+B = 2 pi / (L_x L_y).
+```
+
+The runner verifies that the summed plaquette phase is one flux quantum:
+
+```text
+sum_plaquette_phase = 6.283185307180 = 2 pi.
+```
+
+The threaded flux is represented by the shifted allowed momenta
+
+```text
+k_z(n, phi) = 2 pi (n + 0.31) / L_z - pi + phi / L_z  mod 2 pi,
+```
+
+with `phi in [0, 2 pi]`. For each `phi` and each `z` momentum, the runner
+diagonalizes the actual finite matrix. It then follows the wall-localized and
+anti-wall-localized edge states by eigenvector overlap, using the same
+site-window localization method as Step 1.
+
+## Computed checks
+
+With `L_x = L_y = 3`, `N_s = 14`, `L_z = 7`, `M = +0.8`, sharp front, and one
+magnetic flux quantum:
+
+```text
+wall flow      = +1
+anti-wall flow = -1
+net flow       = 0
+bulk_gap_min   = 0.590028989858
+```
+
+The measured zero-crossing intervals are:
+
+| sector | z | E(phi_j) -> E(phi_{j+1}) | k_z(phi_j) -> k_z(phi_{j+1}) | localization weight | edge chirality | sign |
+|---|---:|---:|---:|---:|---:|---:|
+| wall | 3 | `-0.042490753527 -> +0.022148477848` | `-0.042315329620 -> +0.021798806168` | `0.689764 -> 0.686201` | `+0.990621 -> +0.979238` | `+1` |
+| anti-wall | 3 | `+0.042490753527 -> -0.022148477848` | `-0.042315329620 -> +0.021798806168` | `0.860121 -> 0.855437` | `-0.990621 -> -0.979238` | `-1` |
+
+Thus the local wall and anti-wall flows are integer and opposite, and the
+closed record-time torus has zero net flow.
+
+The crossing states are edge states rather than bulk states:
+
+- minimum crossing localization weight: `0.686201`;
+- minimum crossing `|chi_edge|`: `0.979238`;
+- minimum non-edge bulk gap over the flux grid: `0.590028989858`.
+
+The near-zero tracked branch endpoints are printed by the runner. The branch
+that crosses on the wall has
+
+```text
+E0 = -0.169803467570
+Eend = +0.667991805447
+min |E| = 0.022148477848
+mean chi_edge = +0.992537
+```
+
+and the anti-wall partner has
+
+```text
+E0 = +0.169803467570
+Eend = -0.667991805447
+min |E| = 0.022148477848
+mean chi_edge = -0.992537
+```
+
+## Chirality flip
+
+The runner re-diagonalizes after flipping the mass orientation to `M = -0.8`.
+It does not reuse or sign-edit the positive-orientation trajectories. The
+measured flows reverse:
+
+```text
+M = +0.8: wall=+1, anti=-1
+M = -0.8: wall=-1, anti=+1
+```
+
+For the flipped run, the wall crossing has negative measured edge chirality
+and sign `-1`; the anti-wall crossing has positive measured edge chirality
+and sign `+1`. This is the finite-matrix check that the flow sign tracks the
+edge chirality. Conditional on Step 2's arrow identification, this is also
+the expected formation-arrow sign tracking.
+
+## Robustness
+
+The integer count is stable under the requested small changes of record-time
+lattice size and front width:
+
+| `N_s` | `L_z` | front width | wall flow | anti-wall flow | net | bulk gap |
+|---:|---:|---:|---:|---:|---:|---:|
+| 12 | 5 | 0.00 | `+1` | `-1` | `0` | `0.627870321803` |
+| 14 | 7 | 0.00 | `+1` | `-1` | `0` | `0.589795856227` |
+| 14 | 7 | 0.45 | `+1` | `-1` | `0` | `0.621469648907` |
+| 16 | 7 | 0.00 | `+1` | `-1` | `0` | `0.563638567662` |
+
+The count is therefore stable across this finite free-field sweep and is not
+a single-grid fine tuning.
+
+## What is shown
+
+At free-field level, with a non-dynamical background `U(1)` field:
+
+- the record-time domain-wall edge carries an integer local spectral flow
+  under one background flux quantum and a threaded twist;
+- the wall and anti-wall flows are opposite, so the record-time torus has
+  zero net flow;
+- the flow sign tracks the measured edge chirality and reverses when the
+  domain-wall chirality is flipped;
+- the crossing states are localized on the wall/anti-wall;
+- the non-edge bulk states remain gapped over the flux sweep.
+
+This is the Callan-Harvey anomaly-inflow consistency mechanism seen as
+finite-matrix spectral flow, given the framework's accepted ABJ premise.
+
+## What is not shown
+
+- The gauge field is a non-dynamical background. No gauge kinetic term,
+  gauge dynamics, or interaction is included.
+- This is not a derivation, resolution, weakening, or replacement of the
+  accepted ABJ anomaly premise.
+- This is not the A3 Route 3 BZ-corner-distinguisher question.
+- No hypercharge map, Standard Model content assignment, or completion
+  spectrum is supplied here; that is Step 4.
+- The dimensional interpretation of record-time as the domain-wall coordinate
+  versus physical time is not resolved.
+- No strong-CP or theta claim is made.
+- No import, axiom, audit status, closure, exhaustion claim, only-route claim,
+  or discharge claim is made.
+
+Finite-volume note: on a closed torus the wall and anti-wall are both present,
+so the global spectral flow is zero. The runner resolves the local wall and
+anti-wall branches by the Step 1 localization-window method after each
+diagonalization. The reported local flows are therefore local edge spectral
+flows; the global torus remains anomaly-neutral.
+
+## Validation
+
+Run:
+
+```bash
+python3 scripts/domain_wall_edge_anomaly_inflow_spectral_flow_2026_07_05.py
+```
+
+Observed terminal summary:
+
+```text
+TOTAL: PASS=12 FAIL=0
+```

--- a/logs/runner-cache/domain_wall_edge_anomaly_inflow_spectral_flow_2026_07_05.txt
+++ b/logs/runner-cache/domain_wall_edge_anomaly_inflow_spectral_flow_2026_07_05.txt
@@ -1,0 +1,73 @@
+===== runner cache v1 =====
+runner: scripts/domain_wall_edge_anomaly_inflow_spectral_flow_2026_07_05.py
+runner_sha256: a75af0c9c66bd27a0854f4497f75a177dc702638bed4b4c454b1041ddbdb6dcc
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 49.63
+status: ok
+----- stdout -----
+
+============================================================================================
+1. Background U(1) flux and Hermiticity
+============================================================================================
+PASS - magnetic Peierls links carry one total U(1) flux quantum  (sum_plaquette_phase=6.283185307180 expected=6.283185307180)
+PASS - gauge-coupled domain-wall Hamiltonian is Hermitian  (||H-H^dagger||=0.000e+00)
+
+============================================================================================
+2. Spectral flow of localized wall and anti-wall edge branches
+============================================================================================
+
+positive mass orientation
+config: Lx=3 Ly=3 Ns=14 Lz=7 M=+0.800 width=0.000 phi_steps=15 flux=1
+flow: wall=+1 anti=-1 net=+0
+bulk_gap_min=0.590028989858
+  wall crossings:
+    z=3 phi_step=2->3 E=-0.042490753527->+0.022148477848 k=-0.042315329620->+0.021798806168 weight=0.689764->0.686201 chi=+0.990621->+0.979238 sign=+1
+  anti crossings:
+    z=3 phi_step=2->3 E=+0.042490753527->-0.022148477848 k=-0.042315329620->+0.021798806168 weight=0.860121->0.855437 chi=-0.990621->-0.979238 sign=-1
+  near-zero tracked branch endpoints:
+    wall z=2: E0=-0.906332189719 Eend=-0.169803467570 min|E|=0.169803467570 min_weight=0.318276 mean_chi=+0.987854
+    wall z=3: E0=-0.169803467570 Eend=+0.667991805447 min|E|=0.022148477848 min_weight=0.496995 mean_chi=+0.992537
+    anti z=2: E0=+0.906332189719 Eend=+0.169803467570 min|E|=0.169803467570 min_weight=0.514318 mean_chi=-0.987854
+    anti z=3: E0=+0.169803467570 Eend=-0.667991805447 min|E|=0.022148477848 min_weight=0.704985 mean_chi=-0.992537
+PASS - wall spectral flow is the integer +1  (wall_flow=1 crossings=1)
+PASS - anti-wall spectral flow is the integer -1  (anti_flow=-1 crossings=1)
+PASS - record-time torus has zero net spectral flow  (net=0)
+PASS - crossing states are localized edge states  (min_crossing_weight=0.686201 min|chi|=0.979238)
+PASS - bulk states stay gapped while edge levels cross  (min_bulk_gap=0.590028989858)
+PASS - flow sign tracks measured edge chirality  (wall sign/chi=+1/+0.984930; anti sign/chi=-1/-0.984930)
+
+============================================================================================
+3. Chirality flip re-diagonalizes and reverses the flow
+============================================================================================
+
+flipped mass orientation
+config: Lx=3 Ly=3 Ns=14 Lz=7 M=-0.800 width=0.000 phi_steps=15 flux=1
+flow: wall=-1 anti=+1 net=+0
+bulk_gap_min=0.590028989858
+  wall crossings:
+    z=3 phi_step=2->3 E=+0.042490753527->-0.022148477848 k=-0.042315329620->+0.021798806168 weight=0.860121->0.855437 chi=-0.990621->-0.979238 sign=-1
+  anti crossings:
+    z=3 phi_step=2->3 E=-0.042490753527->+0.022148477848 k=-0.042315329620->+0.021798806168 weight=0.689764->0.686201 chi=+0.990621->+0.979238 sign=+1
+  near-zero tracked branch endpoints:
+    wall z=2: E0=+0.906332189719 Eend=+0.169803467570 min|E|=0.169803467570 min_weight=0.514318 mean_chi=-0.987854
+    wall z=3: E0=+0.169803467570 Eend=-0.667991805447 min|E|=0.022148477848 min_weight=0.704985 mean_chi=-0.992537
+    anti z=2: E0=-0.906332189719 Eend=-0.169803467570 min|E|=0.169803467570 min_weight=0.318276 mean_chi=+0.987854
+    anti z=3: E0=-0.169803467570 Eend=+0.667991805447 min|E|=0.022148477848 min_weight=0.496995 mean_chi=+0.992537
+PASS - flipping the wall chirality reverses wall and anti-wall flow  (M=+ flow=(+1,-1); M=- flow=(-1,+1))
+PASS - flipped flow sign tracks flipped measured chirality  (wall sign/chi=-1/-0.984930; anti sign/chi=+1/+0.984930)
+
+============================================================================================
+4. Quantization and robustness
+============================================================================================
+robust row: Ns=12 Lz= 5 width=0.00 wall=+1 anti=-1 net=+0 bulk_gap=0.627870321803
+robust row: Ns=14 Lz= 7 width=0.00 wall=+1 anti=-1 net=+0 bulk_gap=0.589795856227
+robust row: Ns=14 Lz= 7 width=0.45 wall=+1 anti=-1 net=+0 bulk_gap=0.621469648907
+robust row: Ns=16 Lz= 7 width=0.00 wall=+1 anti=-1 net=+0 bulk_gap=0.563638567662
+PASS - integer flow is stable under lattice-size and front-width changes  (rows=(+1,-1), (+1,-1), (+1,-1), (+1,-1))
+PASS - robustness rows keep the bulk gapped  (min_bulk_gap=0.563638567662)
+
+TOTAL: PASS=12 FAIL=0
+
+----- stderr -----
+

--- a/scripts/domain_wall_edge_anomaly_inflow_spectral_flow_2026_07_05.py
+++ b/scripts/domain_wall_edge_anomaly_inflow_spectral_flow_2026_07_05.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+"""Domain-wall edge anomaly-inflow spectral-flow check.
+
+This runner is the Step 3 free-field diagnostic:
+
+* start from the Step 1 record-time Wilson-domain-wall Hamiltonian;
+* couple a non-dynamical U(1) background gauge field by Peierls phases;
+* put one magnetic flux quantum through the transverse x-y torus;
+* thread a twist phi through the z cycle;
+* diagonalize H(phi) on a phi grid and follow localized edge levels by
+  eigenvector overlap;
+* count zero crossings of the tracked wall and anti-wall edge branches.
+
+The calculation is deterministic and uses only numpy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+import numpy as np
+
+np.set_printoptions(precision=12, suppress=True, linewidth=160)
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        tag = "PASS"
+    else:
+        FAIL += 1
+        tag = "FAIL"
+    suffix = f"  ({detail})" if detail else ""
+    print(f"{tag} - {name}{suffix}")
+
+
+def section(title: str) -> None:
+    print("\n" + "=" * 92)
+    print(title)
+    print("=" * 92)
+
+
+def wrap_to_pi(k: float) -> float:
+    return float((k + math.pi) % (2.0 * math.pi) - math.pi)
+
+
+def sign_int(x: float, tol: float = 1.0e-9) -> int:
+    if x > tol:
+        return 1
+    if x < -tol:
+        return -1
+    return 0
+
+
+def norm(A: np.ndarray) -> float:
+    return float(np.linalg.norm(A))
+
+
+def periodic_distance(n: int, center: int) -> np.ndarray:
+    x = np.arange(n)
+    d = np.abs(x - center)
+    return np.minimum(d, n - d)
+
+
+# Step 1 gamma matrices.
+I2 = np.eye(2, dtype=complex)
+sigma_1 = np.array([[0, 1], [1, 0]], dtype=complex)
+sigma_2 = np.array([[0, -1j], [1j, 0]], dtype=complex)
+sigma_3 = np.array([[1, 0], [0, -1]], dtype=complex)
+tau_1 = sigma_1.copy()
+tau_2 = sigma_2.copy()
+tau_3 = sigma_3.copy()
+
+G_x = np.kron(tau_1, sigma_1)
+G_y = np.kron(tau_1, sigma_2)
+G_z = np.kron(tau_1, sigma_3)
+G_s = np.kron(tau_2, I2)
+G_m = np.kron(tau_3, I2)
+edge_chirality = 1j * G_s @ G_m
+
+
+def covariant_xy_operators(
+    Lx: int,
+    Ly: int,
+    n_flux: int = 1,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Magnetic translations on a two-torus with n_flux U(1) flux quanta.
+
+    Landau gauge:
+        U_y(x,y) = exp(i B x)
+        U_x(Lx-1,y) = exp(-i B Lx y)
+    with B = 2 pi n_flux / (Lx Ly). This gives periodic links with uniform
+    plaquette flux modulo the boundary convention.
+    """
+    n_xy = Lx * Ly
+    B = 2.0 * math.pi * n_flux / n_xy
+    Ux = np.ones((Lx, Ly), dtype=complex)
+    Uy = np.ones((Lx, Ly), dtype=complex)
+    for x in range(Lx):
+        for y in range(Ly):
+            Uy[x, y] = np.exp(1j * B * x)
+            if x == Lx - 1:
+                Ux[x, y] = np.exp(-1j * B * Lx * y)
+
+    Kx = np.zeros((n_xy, n_xy), dtype=complex)
+    Ky = np.zeros((n_xy, n_xy), dtype=complex)
+    Lxy = np.zeros((n_xy, n_xy), dtype=complex)
+
+    def idx(x: int, y: int) -> int:
+        return (x % Lx) * Ly + (y % Ly)
+
+    for x in range(Lx):
+        for y in range(Ly):
+            i = idx(x, y)
+            for j, u, K in (
+                (idx(x + 1, y), Ux[x, y], Kx),
+                (idx(x, y + 1), Uy[x, y], Ky),
+            ):
+                K[i, j] += -0.5j * u
+                K[j, i] += 0.5j * np.conj(u)
+                Lxy[i, i] += 0.5
+                Lxy[j, j] += 0.5
+                Lxy[i, j] += -0.5 * u
+                Lxy[j, i] += -0.5 * np.conj(u)
+
+    return Kx, Ky, Lxy, Ux, Uy
+
+
+def plaquette_fluxes(Ux: np.ndarray, Uy: np.ndarray) -> np.ndarray:
+    Lx, Ly = Ux.shape
+    phases = []
+    for x in range(Lx):
+        for y in range(Ly):
+            loop = (
+                Ux[x, y]
+                * Uy[(x + 1) % Lx, y]
+                * np.conj(Ux[x, (y + 1) % Ly])
+                * np.conj(Uy[x, y])
+            )
+            phases.append(math.atan2(loop.imag, loop.real))
+    return np.array(phases, dtype=float)
+
+
+def record_time_operators(n_s: int) -> tuple[np.ndarray, np.ndarray]:
+    K = np.zeros((n_s, n_s), dtype=complex)
+    L = np.zeros((n_s, n_s), dtype=complex)
+    for s in range(n_s):
+        K[s, (s + 1) % n_s] += -0.5j
+        K[s, (s - 1) % n_s] += 0.5j
+        L[s, s] += 1.0
+        L[s, (s + 1) % n_s] += -0.5
+        L[s, (s - 1) % n_s] += -0.5
+    return K, L
+
+
+def mass_profile(n_s: int, M: float, front_width: float = 0.0) -> tuple[np.ndarray, int, int]:
+    wall = n_s // 4
+    anti_wall = wall + n_s // 2
+    if front_width <= 0.0:
+        m = -M * np.ones(n_s, dtype=float)
+        m[wall:anti_wall] = M
+    else:
+        x = np.arange(n_s)
+        phase = np.sin(2.0 * math.pi * (x - wall) / n_s)
+        m = M * np.tanh(phase / front_width)
+    return m, wall, anti_wall
+
+
+@dataclass(frozen=True)
+class FlowConfig:
+    Lx: int = 3
+    Ly: int = 3
+    Ns: int = 14
+    Lz: int = 7
+    M: float = 0.8
+    front_width: float = 0.0
+    phi_steps: int = 15
+    n_flux: int = 1
+    twist_offset: float = 0.31
+    window_width: float = 2.0
+    edge_weight_cut: float = 0.10
+    chirality_cut: float = 0.40
+    crossing_energy_cut: float = 0.30
+
+
+class DomainWallFluxModel:
+    def __init__(self, cfg: FlowConfig):
+        self.cfg = cfg
+        self.n_xy = cfg.Lx * cfg.Ly
+        self.n_sites = self.n_xy * cfg.Ns
+
+        Kx, Ky, Lxy, Ux, Uy = covariant_xy_operators(cfg.Lx, cfg.Ly, cfg.n_flux)
+        Ks, Ls = record_time_operators(cfg.Ns)
+        m, self.wall, self.anti_wall = mass_profile(cfg.Ns, cfg.M, cfg.front_width)
+
+        Ixy = np.eye(self.n_xy, dtype=complex)
+        Is = np.eye(cfg.Ns, dtype=complex)
+        In = np.eye(self.n_sites, dtype=complex)
+
+        kinetic = (
+            np.kron(np.kron(Kx, Is), G_x)
+            + np.kron(np.kron(Ky, Is), G_y)
+            + np.kron(np.kron(Ixy, Ks), G_s)
+        )
+        mass_base = np.kron(Lxy, Is) + np.kron(Ixy, np.diag(m) + Ls)
+        self.H_base = kinetic + np.kron(mass_base, G_m)
+        self.H_z_wilson = np.kron(In, G_m)
+        self.H_z_kinetic = np.kron(In, G_z)
+        self.chirality_operator = np.kron(In, edge_chirality)
+        self.plaquette_phases = plaquette_fluxes(Ux, Uy)
+
+        self.windows: dict[str, np.ndarray] = {}
+        for name, center in (("wall", self.wall), ("anti", self.anti_wall)):
+            d = periodic_distance(cfg.Ns, center)
+            self.windows[name] = np.exp(-((d / cfg.window_width) ** 2))
+
+    def H(self, kz: float) -> np.ndarray:
+        return self.H_base + (1.0 - math.cos(kz)) * self.H_z_wilson + math.sin(kz) * self.H_z_kinetic
+
+    def localization_weights(self, evecs: np.ndarray, center_name: str) -> np.ndarray:
+        arr = evecs.reshape(self.n_xy, self.cfg.Ns, 4, -1)
+        window = self.windows[center_name]
+        return np.sum(np.abs(arr) ** 2 * window[None, :, None, None], axis=(0, 1, 2)).real
+
+    def chirality_expectations(self, evecs: np.ndarray) -> np.ndarray:
+        return np.einsum("ij,ij->j", evecs.conj(), self.chirality_operator @ evecs).real
+
+
+@dataclass
+class Branch:
+    z_index: int
+    energies: list[float]
+    momenta: list[float]
+    weights: list[float]
+    chiralities: list[float]
+
+    @property
+    def min_abs_energy(self) -> float:
+        return min(abs(e) for e in self.energies)
+
+    @property
+    def min_weight(self) -> float:
+        return min(self.weights)
+
+    @property
+    def mean_chirality(self) -> float:
+        return float(np.mean(self.chiralities))
+
+
+@dataclass
+class Crossing:
+    z_index: int
+    phi_index: int
+    e0: float
+    e1: float
+    k0: float
+    k1: float
+    w0: float
+    w1: float
+    chi0: float
+    chi1: float
+
+    @property
+    def sign(self) -> int:
+        if self.e0 < 0.0 < self.e1:
+            return 1
+        if self.e0 > 0.0 > self.e1:
+            return -1
+        return 0
+
+
+@dataclass
+class FlowResult:
+    cfg: FlowConfig
+    flow: dict[str, int]
+    crossings: dict[str, list[Crossing]]
+    branches: dict[str, list[Branch]]
+    min_bulk_gap: float
+    min_edge_crossing_weight: float
+    min_abs_crossing_chirality: float
+
+
+def allowed_kz(cfg: FlowConfig, z_index: int, phi: float) -> float:
+    return wrap_to_pi(2.0 * math.pi * (z_index + cfg.twist_offset) / cfg.Lz - math.pi + phi / cfg.Lz)
+
+
+def select_edge_state(
+    model: DomainWallFluxModel,
+    evals: np.ndarray,
+    evecs: np.ndarray,
+    center_name: str,
+    previous: np.ndarray | None,
+) -> tuple[int, float, float]:
+    weights = model.localization_weights(evecs, center_name)
+    chiralities = model.chirality_expectations(evecs)
+    cfg = model.cfg
+    candidates = np.where((weights > cfg.edge_weight_cut) & (np.abs(chiralities) > cfg.chirality_cut))[0]
+    if candidates.size == 0:
+        scores = weights * np.abs(chiralities) / (1.0 + np.abs(evals))
+        candidates = np.argsort(scores)[-12:]
+
+    if previous is None:
+        score = weights[candidates] * np.abs(chiralities[candidates]) / (1.0 + np.abs(evals[candidates]))
+    else:
+        overlap = np.abs(evecs[:, candidates].conj().T @ previous)
+        tie_break = 1.0e-3 * weights[candidates] * np.abs(chiralities[candidates]) / (1.0 + np.abs(evals[candidates]))
+        score = overlap + tie_break
+
+    i = int(candidates[int(np.argmax(score))])
+    return i, float(weights[i]), float(chiralities[i])
+
+
+def count_crossings(branch: Branch, energy_cut: float) -> list[Crossing]:
+    crossings: list[Crossing] = []
+    for j in range(len(branch.energies) - 1):
+        e0 = branch.energies[j]
+        e1 = branch.energies[j + 1]
+        near_zero = max(abs(e0), abs(e1)) < energy_cut
+        if not near_zero:
+            continue
+        if e0 < 0.0 < e1 or e0 > 0.0 > e1:
+            crossings.append(
+                Crossing(
+                    z_index=branch.z_index,
+                    phi_index=j,
+                    e0=e0,
+                    e1=e1,
+                    k0=branch.momenta[j],
+                    k1=branch.momenta[j + 1],
+                    w0=branch.weights[j],
+                    w1=branch.weights[j + 1],
+                    chi0=branch.chiralities[j],
+                    chi1=branch.chiralities[j + 1],
+                )
+            )
+    return crossings
+
+
+def run_flow(cfg: FlowConfig) -> FlowResult:
+    model = DomainWallFluxModel(cfg)
+    phis = np.linspace(0.0, 2.0 * math.pi, cfg.phi_steps)
+    tracked: dict[str, list[Branch]] = {"wall": [], "anti": []}
+    min_bulk_gap = float("inf")
+
+    for z_index in range(cfg.Lz):
+        previous: dict[str, np.ndarray | None] = {"wall": None, "anti": None}
+        data = {
+            "wall": {"energies": [], "momenta": [], "weights": [], "chiralities": []},
+            "anti": {"energies": [], "momenta": [], "weights": [], "chiralities": []},
+        }
+
+        for phi in phis:
+            kz = allowed_kz(cfg, z_index, float(phi))
+            evals, evecs = np.linalg.eigh(model.H(kz))
+            wall_weights = model.localization_weights(evecs, "wall")
+            anti_weights = model.localization_weights(evecs, "anti")
+            chiralities = model.chirality_expectations(evecs)
+            edge_like = (
+                (np.maximum(wall_weights, anti_weights) > cfg.edge_weight_cut)
+                & (np.abs(chiralities) > cfg.chirality_cut)
+                & (np.abs(evals) < 1.2)
+            )
+            bulk_abs = np.abs(evals[~edge_like])
+            min_bulk_gap = min(min_bulk_gap, float(np.min(bulk_abs)))
+
+            for center_name in ("wall", "anti"):
+                i, weight, chirality = select_edge_state(model, evals, evecs, center_name, previous[center_name])
+                previous[center_name] = evecs[:, i]
+                data[center_name]["energies"].append(float(evals[i]))
+                data[center_name]["momenta"].append(kz)
+                data[center_name]["weights"].append(weight)
+                data[center_name]["chiralities"].append(chirality)
+
+        for center_name in ("wall", "anti"):
+            tracked[center_name].append(
+                Branch(
+                    z_index=z_index,
+                    energies=data[center_name]["energies"],
+                    momenta=data[center_name]["momenta"],
+                    weights=data[center_name]["weights"],
+                    chiralities=data[center_name]["chiralities"],
+                )
+            )
+
+    crossings: dict[str, list[Crossing]] = {
+        center_name: [
+            crossing
+            for branch in tracked[center_name]
+            for crossing in count_crossings(branch, cfg.crossing_energy_cut)
+        ]
+        for center_name in ("wall", "anti")
+    }
+    flow = {
+        center_name: sum(crossing.sign for crossing in crossings[center_name])
+        for center_name in ("wall", "anti")
+    }
+
+    all_crossings = crossings["wall"] + crossings["anti"]
+    min_edge_crossing_weight = min(
+        [min(c.w0, c.w1) for c in all_crossings],
+        default=0.0,
+    )
+    min_abs_crossing_chirality = min(
+        [min(abs(c.chi0), abs(c.chi1)) for c in all_crossings],
+        default=0.0,
+    )
+
+    return FlowResult(
+        cfg=cfg,
+        flow=flow,
+        crossings=crossings,
+        branches=tracked,
+        min_bulk_gap=min_bulk_gap,
+        min_edge_crossing_weight=min_edge_crossing_weight,
+        min_abs_crossing_chirality=min_abs_crossing_chirality,
+    )
+
+
+def print_crossing_summary(label: str, result: FlowResult) -> None:
+    print(f"\n{label}")
+    print(
+        "config: "
+        f"Lx={result.cfg.Lx} Ly={result.cfg.Ly} Ns={result.cfg.Ns} Lz={result.cfg.Lz} "
+        f"M={result.cfg.M:+.3f} width={result.cfg.front_width:.3f} "
+        f"phi_steps={result.cfg.phi_steps} flux={result.cfg.n_flux}"
+    )
+    print(f"flow: wall={result.flow['wall']:+d} anti={result.flow['anti']:+d} net={result.flow['wall'] + result.flow['anti']:+d}")
+    print(f"bulk_gap_min={result.min_bulk_gap:.12f}")
+    for center_name in ("wall", "anti"):
+        print(f"  {center_name} crossings:")
+        for c in result.crossings[center_name]:
+            print(
+                "    "
+                f"z={c.z_index} phi_step={c.phi_index}->{c.phi_index + 1} "
+                f"E={c.e0:+.12f}->{c.e1:+.12f} "
+                f"k={c.k0:+.12f}->{c.k1:+.12f} "
+                f"weight={c.w0:.6f}->{c.w1:.6f} "
+                f"chi={c.chi0:+.6f}->{c.chi1:+.6f} "
+                f"sign={c.sign:+d}"
+            )
+    print("  near-zero tracked branch endpoints:")
+    for center_name in ("wall", "anti"):
+        for branch in result.branches[center_name]:
+            if branch.min_abs_energy < 0.25:
+                print(
+                    "    "
+                    f"{center_name} z={branch.z_index}: "
+                    f"E0={branch.energies[0]:+.12f} Eend={branch.energies[-1]:+.12f} "
+                    f"min|E|={branch.min_abs_energy:.12f} "
+                    f"min_weight={branch.min_weight:.6f} "
+                    f"mean_chi={branch.mean_chirality:+.6f}"
+                )
+
+
+def verify_background_flux() -> None:
+    section("1. Background U(1) flux and Hermiticity")
+    cfg = FlowConfig()
+    model = DomainWallFluxModel(cfg)
+    flux_total = float(np.sum(model.plaquette_phases))
+    expected_total = 2.0 * math.pi * cfg.n_flux
+    H0 = model.H(0.123)
+    check(
+        "magnetic Peierls links carry one total U(1) flux quantum",
+        abs(flux_total - expected_total) < 1.0e-12,
+        f"sum_plaquette_phase={flux_total:.12f} expected={expected_total:.12f}",
+    )
+    check(
+        "gauge-coupled domain-wall Hamiltonian is Hermitian",
+        norm(H0 - H0.conj().T) < 1.0e-12,
+        f"||H-H^dagger||={norm(H0 - H0.conj().T):.3e}",
+    )
+
+
+def main() -> None:
+    verify_background_flux()
+
+    section("2. Spectral flow of localized wall and anti-wall edge branches")
+    main_cfg = FlowConfig(M=0.8, front_width=0.0, Ns=14, Lz=7, phi_steps=15)
+    main_result = run_flow(main_cfg)
+    print_crossing_summary("positive mass orientation", main_result)
+    wall_cross = main_result.crossings["wall"][0]
+    anti_cross = main_result.crossings["anti"][0]
+    check(
+        "wall spectral flow is the integer +1",
+        main_result.flow["wall"] == 1 and len(main_result.crossings["wall"]) == 1,
+        f"wall_flow={main_result.flow['wall']} crossings={len(main_result.crossings['wall'])}",
+    )
+    check(
+        "anti-wall spectral flow is the integer -1",
+        main_result.flow["anti"] == -1 and len(main_result.crossings["anti"]) == 1,
+        f"anti_flow={main_result.flow['anti']} crossings={len(main_result.crossings['anti'])}",
+    )
+    check(
+        "record-time torus has zero net spectral flow",
+        main_result.flow["wall"] + main_result.flow["anti"] == 0,
+        f"net={main_result.flow['wall'] + main_result.flow['anti']}",
+    )
+    check(
+        "crossing states are localized edge states",
+        main_result.min_edge_crossing_weight > 0.45 and main_result.min_abs_crossing_chirality > 0.97,
+        f"min_crossing_weight={main_result.min_edge_crossing_weight:.6f} min|chi|={main_result.min_abs_crossing_chirality:.6f}",
+    )
+    check(
+        "bulk states stay gapped while edge levels cross",
+        main_result.min_bulk_gap > 0.55,
+        f"min_bulk_gap={main_result.min_bulk_gap:.12f}",
+    )
+    check(
+        "flow sign tracks measured edge chirality",
+        wall_cross.sign == sign_int(0.5 * (wall_cross.chi0 + wall_cross.chi1))
+        and anti_cross.sign == sign_int(0.5 * (anti_cross.chi0 + anti_cross.chi1)),
+        (
+            f"wall sign/chi={wall_cross.sign:+d}/{0.5 * (wall_cross.chi0 + wall_cross.chi1):+.6f}; "
+            f"anti sign/chi={anti_cross.sign:+d}/{0.5 * (anti_cross.chi0 + anti_cross.chi1):+.6f}"
+        ),
+    )
+
+    section("3. Chirality flip re-diagonalizes and reverses the flow")
+    flip_cfg = FlowConfig(M=-0.8, front_width=0.0, Ns=14, Lz=7, phi_steps=15)
+    flip_result = run_flow(flip_cfg)
+    print_crossing_summary("flipped mass orientation", flip_result)
+    flip_wall_cross = flip_result.crossings["wall"][0]
+    flip_anti_cross = flip_result.crossings["anti"][0]
+    check(
+        "flipping the wall chirality reverses wall and anti-wall flow",
+        flip_result.flow["wall"] == -main_result.flow["wall"]
+        and flip_result.flow["anti"] == -main_result.flow["anti"],
+        (
+            f"M=+ flow=({main_result.flow['wall']:+d},{main_result.flow['anti']:+d}); "
+            f"M=- flow=({flip_result.flow['wall']:+d},{flip_result.flow['anti']:+d})"
+        ),
+    )
+    check(
+        "flipped flow sign tracks flipped measured chirality",
+        flip_wall_cross.sign == sign_int(0.5 * (flip_wall_cross.chi0 + flip_wall_cross.chi1))
+        and flip_anti_cross.sign == sign_int(0.5 * (flip_anti_cross.chi0 + flip_anti_cross.chi1)),
+        (
+            f"wall sign/chi={flip_wall_cross.sign:+d}/{0.5 * (flip_wall_cross.chi0 + flip_wall_cross.chi1):+.6f}; "
+            f"anti sign/chi={flip_anti_cross.sign:+d}/{0.5 * (flip_anti_cross.chi0 + flip_anti_cross.chi1):+.6f}"
+        ),
+    )
+
+    section("4. Quantization and robustness")
+    robust_configs = [
+        FlowConfig(M=0.8, front_width=0.0, Ns=12, Lz=5, phi_steps=11),
+        FlowConfig(M=0.8, front_width=0.0, Ns=14, Lz=7, phi_steps=11),
+        FlowConfig(M=0.8, front_width=0.45, Ns=14, Lz=7, phi_steps=11),
+        FlowConfig(M=0.8, front_width=0.0, Ns=16, Lz=7, phi_steps=11),
+    ]
+    robust_rows = []
+    for cfg in robust_configs:
+        result = run_flow(cfg)
+        robust_rows.append(result)
+        print(
+            f"robust row: Ns={cfg.Ns:2d} Lz={cfg.Lz:2d} width={cfg.front_width:.2f} "
+            f"wall={result.flow['wall']:+d} anti={result.flow['anti']:+d} "
+            f"net={result.flow['wall'] + result.flow['anti']:+d} "
+            f"bulk_gap={result.min_bulk_gap:.12f}"
+        )
+    check(
+        "integer flow is stable under lattice-size and front-width changes",
+        all(r.flow["wall"] == 1 and r.flow["anti"] == -1 for r in robust_rows),
+        "rows=" + ", ".join(f"({r.flow['wall']:+d},{r.flow['anti']:+d})" for r in robust_rows),
+    )
+    check(
+        "robustness rows keep the bulk gapped",
+        all(r.min_bulk_gap > 0.55 for r in robust_rows),
+        "min_bulk_gap=" + f"{min(r.min_bulk_gap for r in robust_rows):.12f}",
+    )
+
+    print(f"\nTOTAL: PASS={PASS} FAIL={FAIL}")
+    if FAIL:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Step 3 of the chiral-from-achiral program: couple the record-time domain-wall
chiral edge (Steps 1-2) to a **non-dynamical background U(1) field** and verify
the Callan-Harvey anomaly-inflow consistency via **spectral flow**. Result
(free-field): under one magnetic flux quantum (Peierls links) through the
transverse spatial torus and a threaded twist through the remaining cycle, the
wall edge carries integer spectral flow **+1** and the anti-wall **−1**, so the
record-time torus has **net zero** — the local Callan-Harvey inflow with a
globally anomaly-neutral closed system, consistent with the framework's
**accepted** ABJ premise (which this uses, not resolves).

Runner-verified (12 checks, exact/numerical linear algebra):
- One U(1) flux quantum through x-y (summed plaquette phase = 2π); H Hermitian.
- **Spectral flow found by diagonalization + level-tracking**, not asserted:
  H(φ) diagonalized across a φ-grid, wall/anti-wall edge levels followed by
  eigenvector overlap, zero-crossings counted. Wall = +1, anti-wall = −1, net 0.
- Crossing states are edge-localized (weight > 0.68, |χ| > 0.97); bulk stays
  gapped (min gap ≈ 0.59) across the flux sweep.
- **Flow sign tracks chirality, and flipping M re-diagonalizes and reverses it**
  (M=+ → (+1,−1); M=− → (−1,+1)) — the can't-hard-code discriminator.
- Integer flow stable across a lattice-size / front-width robustness table.

## Honest scope (in the note)

Shown: at free-field level the domain-wall edge carries the expected integer
Callan-Harvey spectral flow, wall/anti-wall opposite (net-zero closed torus),
sign tracking the edge chirality. **Not** shown, stated plainly: the gauge field
is a non-dynamical background (no gauge kinetic term, no interactions); this is
the consistency mechanism **given** the accepted ABJ premise, **not** a
derivation/resolution of it; it is **not** the bounded A3-Route-3 BZ-corner
distinguisher (different question); no hypercharge/SM content (that's Step 4);
the record-time-vs-physical-time dimensional interpretation is left open; no
strong-CP/theta, no import/axiom, no audit status.

## Verification provenance

Codex 5.5 xhigh ran this step **once** (the second independent run was not
produced). To substitute for the missing cross-run, I re-extracted the spectral
flow **independently** — my own edge-selection and crossing-count, at a finer
φ-grid, on a different config — and it reproduces codex's result exactly
(M=+0.8: wall +1, anti −1, net 0; M=−0.8: reversed), confirming the integer is
not a coarse-grid tracking artifact. Reviewed line-by-line; the note honestly
flags that the Step-2 file was absent in codex's environment (Step-2 arrow tie
stated conditionally; Step 2 has since landed), and the spectral-flow result
stands independently of that tie.

## Changes

- 1 note: `docs/DOMAIN_WALL_EDGE_ANOMALY_INFLOW_SPECTRAL_FLOW_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-05.md`
- 1 runner: `scripts/domain_wall_edge_anomaly_inflow_spectral_flow_2026_07_05.py`
- 1 cache: `logs/runner-cache/domain_wall_edge_anomaly_inflow_spectral_flow_2026_07_05.txt`

## Test plan

- Runner re-run in a clean worktree off origin/main: `TOTAL: PASS=12 FAIL=0`
- Independent fine-grid re-extraction agrees (+1/−1/net-0 and the M-flip).
- Cache generated via `runner_cache.execute_runner`/`write_cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
