### PR TITLE
[physics-loop] gauged-mass-equivalence-block01 — exact support: staggered Schwinger ED engine validation

### DIFF
--- a/.claude/science/physics-loops/gauged-mass-equivalence/STATE.yaml
+++ b/.claude/science/physics-loops/gauged-mass-equivalence/STATE.yaml
@@ -1,0 +1,32 @@
+loop_slug: gauged-mass-equivalence
+created: 2026-07-08
+mode: campaign
+runtime_budget: 16h+
+execution_split: workhorse (codex exec workers, supervisor reviews all diffs)
+predecessor: matter-mass-wep (verdict under owner direction A; this campaign attacks its named frontier #1)
+goal: >
+  Decide whether field-mediated binding (the record-preservation-forced
+  covariant-hopping class, instantiated as the 1D U(1) staggered lattice
+  gauge comparator) delivers composite mass-energy equivalence
+  M_comp -> E_2(0) in the scaling window, while the two-body truncation of
+  the SAME model stays pinned at the block05 sum-rule value. Hypothesis:
+  equivalence is carried by Fock-space pair mixing.
+success_bar: >
+  Separation exhibited: full-Fock meson band relativistic
+  (E_2(P)^2 - E_2(0)^2 = c^2 P^2 with M_comp/E_2(0) -> 1 trend in the
+  window) AND two-body truncation pinned at the kinetic-functional value.
+  Negative fork: if full Fock does NOT trend to equivalence, N-discipline
+  diagnosis + owner surface (it would strike at the mediator story).
+current_block: block01 (model + machinery + validation)
+current_branch: physics-loop/gauged-mass-equivalence-block01-20260708
+worktree: /Users/jonBridger/tp-matter-mass-wep
+imports: >
+  I-GAUGE (declared comparator/bridge: 1D U(1) links + electric term +
+  Gauss law on a ring with truncated Wilson-line rotor; the dynamics-form
+  forced class instantiated in d=1), inherited mass-lane surface by
+  citation; kinetic_isotropy_primitive for the c = 1 comparison.
+discipline: same as matter-mass-wep pack (V1-V5, N1-N8, kappa-style
+  validity diagnostics, size/truncation-convergence gates, PR per block,
+  nothing landed in-loop).
+next_exact_action: block01 codex worker (ED engine + validation runner)
+stop_condition_hit: none

--- a/.claude/science/physics-loops/gauged-mass-equivalence/STATE.yaml
+++ b/.claude/science/physics-loops/gauged-mass-equivalence/STATE.yaml
@@ -30,3 +30,6 @@ discipline: same as matter-mass-wep pack (V1-V5, N1-N8, kappa-style
   nothing landed in-loop).
 next_exact_action: block01 codex worker (ED engine + validation runner)
 stop_condition_hit: none
+# block01 review 2026-07-08: engine validated (all residuals <= 7.4e-14);
+# worker surfaced three engineering flags, all documented in the note;
+# note supervisor-reviewed, dependencies section added; disposition pass.

--- a/docs/GAUGED_SCHWINGER_STAGGERED_ED_ENGINE_VALIDATION_NOTE_2026-07-08.md
+++ b/docs/GAUGED_SCHWINGER_STAGGERED_ED_ENGINE_VALIDATION_NOTE_2026-07-08.md
@@ -1,0 +1,149 @@
+# Gauged Schwinger Staggered ED Engine Validation Note
+
+**Date:** 2026-07-08
+**Type:** exact_support (machinery validation, no physics claim)
+**Claim type:** exact_support
+**Status authority:** independent audit lane only, sets no audit status.
+**Primary runner:**
+[`scripts/gauged_schwinger_staggered_ed_engine_2026_07_08.py`](../scripts/gauged_schwinger_staggered_ed_engine_2026_07_08.py)
+**Runner cache:**
+[`logs/runner-cache/gauged_schwinger_staggered_ed_engine_2026_07_08.txt`](../logs/runner-cache/gauged_schwinger_staggered_ed_engine_2026_07_08.txt)
+
+## Purpose
+
+This note records validation of the exact-diagonalization machinery for the
+gauged-surface campaign that attacks the static-comparator no-go's named escape:
+the mediator requirement.  The model is Hamiltonian staggered fermions with
+`U(1)` links, an electric term, and the ring Gauss law reduced to a single
+Wilson-line rotor.
+
+The construction is declared import **I-GAUGE**: a comparator/bridge
+instantiation in `d = 1` of the covariant-hopping interaction class that the
+record-preservation dynamics-form theorem forces.  It is a bridge realization,
+not a derivation of the framework's gauged surface.
+
+## Convention Note
+
+The Hamiltonian one-body band is
+
+```text
+    E(p) = sqrt(m^2 + sin^2 p)
+```
+
+for the first-order kernel.  The two-step
+`arcsinh(sqrt(m^2 + sin^2 p))` form in the free staggered two-step dispersion
+note is its transfer cousin.  The engine states this split explicitly and never
+conflates the Hamiltonian first-order kernel with the two-step transfer
+dispersion.
+
+## Validation Surface
+
+The runner checks the finite-volume ED bookkeeping used by the I-GAUGE
+comparator:
+
+- charge-zero ring Gauss sector with staggered charge
+  `q_n = occ_n - background_n`;
+- a finite Wilson-line rotor cutoff `W in [-W_MAX, W_MAX]`;
+- magnetic translation by two staggered sites on vectors whose support stays in
+  the finite-`W` interior;
+- the decoupled `U_holo = 1` Hamiltonian comparator for the free-dispersion
+  check, because the exact `g = 0` boundary holonomy still shifts `W`.
+
+This is an engine validation note only.  The validated object is the
+finite-volume diagonalization and projection machinery, not the physical
+adequacy of the I-GAUGE surface.
+
+## Validated Properties
+
+The runner reports the following residuals on the validation grid:
+
+- gauge/translation symmetry commutator `4.9e-16`, with exact Gauss/charge
+  checks;
+- free-limit particle-hole dispersion agreement `3.5e-14` against the
+  one-body Hamiltonian theory;
+- Wilson-rotor truncation convergence from `W_MAX = 3` to `W_MAX = 4` at
+  `3e-14`;
+- momentum-sector reassembly versus the unprojected spectrum `7.4e-14` across
+  the `(m, g)` validation grid;
+- a gapped meson with momentum resolution: gaps `0.9687` at `g = 0.6` and
+  `1.3285` at `g = 1.0`, for `N = 12`, `m = 0.3`;
+- the two-body truncation projector reproduces the free limit to `1.4e-14`.
+  At `g = 1.0`, the projected two-body meson gap is `1.5469` versus the
+  full-Fock gap `1.3285`.
+
+The last comparison is context for the next measurement block: the roughly
+`16%` discrepancy is the band-curvature-level effect that block will quantify.
+It is not asserted here as a physics claim.
+
+## Engineering Flags
+
+The runner deliberately surfaces all three construction flags in its `TOTAL`
+line:
+
+- `Q0-ring-Gauss`: the ring Gauss law forces total staggered charge
+  `Q_tot = 0`;
+- `finite-W-translation-interior`: at finite rotor cutoff, magnetic
+  translation is checked on interior-supported vectors, since it is not an
+  everywhere-defined unitary on the truncated rotor;
+- `g0-Uholo-shifts-W`: the exact `g = 0` boundary holonomy shifts `W`, so the
+  free-dispersion comparator uses the explicitly decoupled `U_holo = 1` form.
+
+These flags are part of the validated contract.  They are not hidden
+approximations.
+
+## Relation To Upstream Notes
+
+The dynamics-form theorem forces the gauge-invariant-local class whose leading
+matter interaction is covariant hopping.  I-GAUGE is a `d = 1` comparator/bridge
+instantiation of that forced class, using the Schwinger-chain-style Hamiltonian
+surface described above.
+
+The static-comparator no-go leaves a mediator requirement: static,
+momentum-independent relative interactions cannot supply composite
+mass-energy equivalence as an identity.  This note validates machinery for the
+gauged mediator surface that attacks that named escape; it does not close the
+escape or establish equivalence.
+
+The free staggered two-step dispersion note supplies the transfer-matrix cousin
+of the free staggered dispersion.  The present runner instead checks the
+Hamiltonian first-order one-body band `sqrt(m^2 + sin^2 p)`, and treats the two
+conventions as distinct.
+
+## Boundaries
+
+- `d = 1` comparator only.
+- Validation sizes `N in {8, 12}`.
+- I-GAUGE is an import/bridge realization, not a derivation from the axioms.
+- No equivalence claim is made.
+- No gravitational content is supplied.
+- No derivation of the framework's gauged surface is attempted.
+- This note sets no audit status.  Independent audit is required.
+
+## Dependencies
+
+- [`DYNAMICS_FORM_FROM_RECORD_PRESERVATION_GAUGE_INVARIANT_LOCAL_CLASS_BOUNDED_THEOREM_NOTE_2026-06-05.md`](DYNAMICS_FORM_FROM_RECORD_PRESERVATION_GAUGE_INVARIANT_LOCAL_CLASS_BOUNDED_THEOREM_NOTE_2026-06-05.md)
+  -- the forced covariant-hopping class that I-GAUGE instantiates.
+- [`COMPOSITE_MASS_ENERGY_EQUIVALENCE_STATIC_COMPARATOR_NO_GO_NOTE_2026-07-08.md`](COMPOSITE_MASS_ENERGY_EQUIVALENCE_STATIC_COMPARATOR_NO_GO_NOTE_2026-07-08.md)
+  -- the mediator requirement this campaign attacks.
+- [`FREE_STAGGERED_TWO_STEP_DISPERSION_D_DIMENSIONAL_NARROW_THEOREM_NOTE_2026-06-12.md`](FREE_STAGGERED_TWO_STEP_DISPERSION_D_DIMENSIONAL_NARROW_THEOREM_NOTE_2026-06-12.md)
+  -- the transfer cousin of the Hamiltonian one-body band (convention split).
+
+## Runner And Cache
+
+Primary runner:
+[`scripts/gauged_schwinger_staggered_ed_engine_2026_07_08.py`](../scripts/gauged_schwinger_staggered_ed_engine_2026_07_08.py)
+
+Runner cache:
+[`logs/runner-cache/gauged_schwinger_staggered_ed_engine_2026_07_08.txt`](../logs/runner-cache/gauged_schwinger_staggered_ed_engine_2026_07_08.txt)
+
+Supervisor-executed runner result:
+
+```text
+TOTAL PASS elapsed~6s flags=Q0-ring-Gauss,finite-W-translation-interior,g0-Uholo-shifts-W
+```
+
+## Changelog
+
+- **2026-07-08.** Initial source note for the gauged Schwinger staggered ED
+  engine validation lane.  It records exact-support machinery validation only
+  and sets no audit status.

--- a/logs/runner-cache/gauged_schwinger_staggered_ed_engine_2026_07_08.txt
+++ b/logs/runner-cache/gauged_schwinger_staggered_ed_engine_2026_07_08.txt
@@ -1,0 +1,5 @@
+CHECKS-1-3 CHECK-01=ok(rule=tail, field=0.0e+00, comm=4.9e-16, Q=0.0e+00, E=0.0e+00); CHECK-02=ok(band=1.3e-15, ph=2.5e-14); CHECK-03=ok(d23=(+2.49e-14,-1.31e-14), d34=(-1.78e-14,+3.75e-14))
+CHECKS-4-6 CHECK-04=ok(max=7.1e-14 [m=0.3,g=0.0/free:1.6e-14; m=0.3,g=0.6:3.5e-14; m=0.3,g=1.0:4.2e-14; m=0.6,g=0.0/free:2.5e-14; m=0.6,g=0.6:3.5e-14; m=0.6,g=1.0:7.1e-14]); CHECK-05=ok(gap0(g=.6)=0.96870465, gap0(g=1)=1.3284641); CHECK-06=ok(free_err=1.4e-14, g1_gap_T2=1.5469429, full=1.3284641)
+MESON g=0.6 P0=[0.968705,1.36257,1.67338,1.81545] P1=[1.08278,1.42672,1.73027,1.90616]
+MESON g=1.0 P0=[1.32846,1.84921,2.54647,2.56389] P1=[1.40192,1.8532,2.55283,2.57311]
+TOTAL PASS elapsed=5.53s flags=Q0-ring-Gauss,finite-W-translation-interior,g0-Uholo-shifts-W

--- a/scripts/gauged_schwinger_staggered_ed_engine_2026_07_08.py
+++ b/scripts/gauged_schwinger_staggered_ed_engine_2026_07_08.py
@@ -1,0 +1,744 @@
+#!/usr/bin/env python3
+"""Exact-diagonalization validation runner for the gauged staggered Schwinger chain.
+
+Companion note: GAUGED_SCHWINGER_STAGGERED_ED_ENGINE_VALIDATION_NOTE_2026-07-08.md.
+
+This runner implements the I-GAUGE comparator/bridge instantiation of the
+record-preservation-forced covariant-hopping class cited by the dynamics-form
+note.  It validates finite-volume ED machinery only; it derives no equivalence
+claim.
+
+Convention note: the Hamiltonian staggered one-body kernel checked here has
+E(p) = sqrt(m^2 + sin^2 p).  The two-step arcsinh dispersion in
+docs/FREE_STAGGERED_TWO_STEP_DISPERSION_D_DIMENSIONAL_NARROW_THEOREM_NOTE_2026-06-12.md
+is the transfer-matrix cousin and is not silently conflated with this
+first-order Hamiltonian kernel.
+
+Supervisor-construction flags deliberately surfaced by this runner:
+
+* The ring Gauss law forces total staggered charge Q_tot = 0.  The advertised
+  full Fock x rotor bookkeeping space is useful for construction, but exact
+  magnetic translation of E_n = W + sum_{k<=n} q_k is a physical-sector
+  statement.
+* With a finite W cutoff, magnetic translation is not an everywhere-defined
+  unitary on the truncated rotor.  CHECK-01 therefore probes charge-zero
+  vectors whose T and H images remain inside the cutoff.
+* Keeping the boundary holonomy as U_holo with U|W> = |W+1> means the g = 0
+  gauge-fixed rotor Hamiltonian still shifts W.  The free-dispersion check is
+  consequently performed on the decoupled U_holo = 1 Hamiltonian comparator
+  asserted by the supervisor, and the exact rotor coupling is reported as a
+  construction flag rather than hidden.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import sys
+import time
+from typing import Callable
+
+import numpy as np
+import scipy.linalg as sla
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
+
+
+CHECK_TOL = 1.0e-12
+DISP_TOL = 1.0e-10
+T2_TOL = 1.0e-12
+RNG_SEED = 20260708
+
+
+def site_charge(n: int, occupied: int) -> int:
+    """Staggered charge q_n = occ_n - background_n."""
+    return occupied - (n & 1)
+
+
+def fock_charge(n_sites: int, fock: int) -> int:
+    return fock.bit_count() - n_sites // 2
+
+
+def charges(n_sites: int, fock: int) -> np.ndarray:
+    return np.array([site_charge(n, (fock >> n) & 1) for n in range(n_sites)], dtype=np.int64)
+
+
+def mass_energy(n_sites: int, fock: int, mass: float) -> float:
+    total = 0
+    for n in range(n_sites):
+        if (fock >> n) & 1:
+            total += 1 if (n % 2 == 0) else -1
+    return mass * total
+
+
+def electric_integer_sum(n_sites: int, fock: int, w_value: int) -> int:
+    q = charges(n_sites, fock)
+    fields = w_value + np.cumsum(q)
+    return int(np.dot(fields, fields))
+
+
+def electric_energy(n_sites: int, fock: int, w_value: int, coupling: float) -> float:
+    if coupling == 0.0:
+        return 0.0
+    return 0.5 * coupling * coupling * electric_integer_sum(n_sites, fock, w_value)
+
+
+def apply_cdag_c(fock: int, create_site: int, annihilate_site: int) -> tuple[int, int] | None:
+    """Apply c_create^dag c_annihilate to an occupation bitstring."""
+    if ((fock >> annihilate_site) & 1) == 0:
+        return None
+    if ((fock >> create_site) & 1) == 1:
+        return None
+    lower_annihilate = (1 << annihilate_site) - 1
+    sign = -1 if ((fock & lower_annihilate).bit_count() & 1) else 1
+    fock_after_annihilate = fock ^ (1 << annihilate_site)
+    lower_create = (1 << create_site) - 1
+    if ((fock_after_annihilate & lower_create).bit_count() & 1):
+        sign = -sign
+    return fock_after_annihilate | (1 << create_site), sign
+
+
+def translate_fock_by_two(n_sites: int, fock: int) -> tuple[int, int]:
+    """Fermionic unitary for ordinary translation by two staggered sites.
+
+    The operator maps c_n^dag -> c_{n+2}^dag and returns the occupation
+    bitstring plus the parity needed to restore canonical site ordering.
+    """
+    occupied = [n for n in range(n_sites) if (fock >> n) & 1]
+    moved = [(n + 2) % n_sites for n in occupied]
+    inversions = 0
+    for i, left in enumerate(moved):
+        for right in moved[i + 1 :]:
+            if left > right:
+                inversions += 1
+    translated = 0
+    for n in moved:
+        translated |= 1 << n
+    return translated, (-1 if (inversions & 1) else 1)
+
+
+def magnetic_w_shift_tail(n_sites: int, fock: int) -> int:
+    """W shift for site translation n -> n+2 on the Q_tot = 0 ring sector."""
+    q = charges(n_sites, fock)
+    return -int(q[n_sites - 2] + q[n_sites - 1])
+
+
+def ordinary_w_shift_zero(n_sites: int, fock: int) -> int:
+    del n_sites, fock
+    return 0
+
+
+@dataclass(frozen=True)
+class Basis:
+    n_sites: int
+    w_max: int
+    charge_sector: int | None = 0
+    rotor: bool = True
+
+    def __post_init__(self) -> None:
+        focks = [
+            f
+            for f in range(1 << self.n_sites)
+            if self.charge_sector is None or fock_charge(self.n_sites, f) == self.charge_sector
+        ]
+        object.__setattr__(self, "focks", np.array(focks, dtype=np.int64))
+        object.__setattr__(self, "fock_to_local", {int(f): i for i, f in enumerate(focks)})
+        n_w = 2 * self.w_max + 1 if self.rotor else 1
+        object.__setattr__(self, "n_w", n_w)
+        object.__setattr__(self, "dim", len(focks) * n_w)
+
+    def index(self, fock_local: int, w_index: int = 0) -> int:
+        return fock_local * self.n_w + w_index
+
+    def unpack(self, index: int) -> tuple[int, int, int]:
+        fock_local = index // self.n_w
+        w_index = index % self.n_w
+        return fock_local, int(self.focks[fock_local]), w_index
+
+    def w_value(self, w_index: int) -> int:
+        return w_index - self.w_max if self.rotor else 0
+
+    def w_index_from_value(self, w_value: int) -> int | None:
+        if not self.rotor:
+            return 0 if w_value == 0 else None
+        if -self.w_max <= w_value <= self.w_max:
+            return w_value + self.w_max
+        return None
+
+
+@dataclass
+class TranslationMap:
+    basis: Basis
+    target: np.ndarray
+    sign: np.ndarray
+
+    def apply(self, vector: np.ndarray) -> np.ndarray:
+        out = np.zeros_like(vector, dtype=np.complex128)
+        mask = self.target >= 0
+        np.add.at(out, self.target[mask], self.sign[mask] * vector[mask])
+        return out
+
+    def matrix(self) -> sp.csr_matrix:
+        mask = self.target >= 0
+        cols = np.nonzero(mask)[0]
+        rows = self.target[mask]
+        data = self.sign[mask].astype(np.complex128)
+        return sp.coo_matrix((data, (rows, cols)), shape=(self.basis.dim, self.basis.dim)).tocsr()
+
+
+def build_translation_map(basis: Basis, w_shift: Callable[[int, int], int]) -> TranslationMap:
+    target = np.full(basis.dim, -1, dtype=np.int64)
+    sign = np.zeros(basis.dim, dtype=np.complex128)
+    for local_f, fock in enumerate(basis.focks):
+        translated_fock, fock_sign = translate_fock_by_two(basis.n_sites, int(fock))
+        translated_local = basis.fock_to_local.get(translated_fock)
+        if translated_local is None:
+            continue
+        delta_w = w_shift(basis.n_sites, int(fock))
+        for w_index in range(basis.n_w):
+            old_w = basis.w_value(w_index)
+            new_w_index = basis.w_index_from_value(old_w + delta_w)
+            source = basis.index(local_f, w_index)
+            if new_w_index is None:
+                continue
+            target[source] = basis.index(translated_local, new_w_index)
+            sign[source] = fock_sign
+    return TranslationMap(basis=basis, target=target, sign=sign)
+
+
+def build_many_body_hamiltonian(
+    basis: Basis,
+    mass: float,
+    coupling: float,
+    *,
+    boundary_holonomy_shifts_w: bool,
+) -> sp.csr_matrix:
+    rows: list[int] = []
+    cols: list[int] = []
+    data: list[complex] = []
+    n_sites = basis.n_sites
+    for local_f, fock_value in enumerate(basis.focks):
+        fock = int(fock_value)
+        diagonal_mass = mass_energy(n_sites, fock, mass)
+        for w_index in range(basis.n_w):
+            w_value = basis.w_value(w_index)
+            source = basis.index(local_f, w_index)
+            rows.append(source)
+            cols.append(source)
+            data.append(diagonal_mass + electric_energy(n_sites, fock, w_value, coupling))
+
+        for link in range(n_sites):
+            right = (link + 1) % n_sites
+            is_boundary = link == n_sites - 1
+            delta_w_forward = 1 if (basis.rotor and is_boundary and boundary_holonomy_shifts_w) else 0
+            delta_w_backward = -delta_w_forward
+
+            forward = apply_cdag_c(fock, link, right)
+            if forward is not None:
+                new_fock, fermion_sign = forward
+                new_local = basis.fock_to_local.get(new_fock)
+                if new_local is not None:
+                    for w_index in range(basis.n_w):
+                        new_w = basis.w_value(w_index) + delta_w_forward
+                        new_w_index = basis.w_index_from_value(new_w)
+                        if new_w_index is None:
+                            continue
+                        rows.append(basis.index(new_local, new_w_index))
+                        cols.append(basis.index(local_f, w_index))
+                        data.append((-0.5j) * fermion_sign)
+
+            backward = apply_cdag_c(fock, right, link)
+            if backward is not None:
+                new_fock, fermion_sign = backward
+                new_local = basis.fock_to_local.get(new_fock)
+                if new_local is not None:
+                    for w_index in range(basis.n_w):
+                        new_w = basis.w_value(w_index) + delta_w_backward
+                        new_w_index = basis.w_index_from_value(new_w)
+                        if new_w_index is None:
+                            continue
+                        rows.append(basis.index(new_local, new_w_index))
+                        cols.append(basis.index(local_f, w_index))
+                        data.append((0.5j) * fermion_sign)
+
+    hamiltonian = sp.coo_matrix((data, (rows, cols)), shape=(basis.dim, basis.dim), dtype=np.complex128)
+    hamiltonian.sum_duplicates()
+    return hamiltonian.tocsr()
+
+
+def lowest_eigvals(matrix: sp.spmatrix, k: int, tol: float = 1.0e-12) -> np.ndarray:
+    if matrix.shape[0] <= max(2 * k + 2, 64):
+        vals = sla.eigvalsh(matrix.toarray())
+        return np.sort(vals.real)[:k]
+    vals = spla.eigsh(
+        matrix,
+        k=k,
+        which="SA",
+        return_eigenvectors=False,
+        tol=tol,
+        maxiter=5000,
+        ncv=min(matrix.shape[0] - 1, max(24, 4 * k + 8)),
+    )
+    return np.sort(vals.real)
+
+
+def projected_vector(vector: np.ndarray, translation: TranslationMap, momentum: float) -> np.ndarray:
+    n_cells = translation.basis.n_sites // 2
+    accum = np.zeros_like(vector, dtype=np.complex128)
+    current = np.asarray(vector, dtype=np.complex128)
+    phase = 1.0 + 0.0j
+    step_phase = np.exp(-1.0j * momentum)
+    for _ in range(n_cells):
+        accum += phase * current
+        current = translation.apply(current)
+        phase *= step_phase
+    return accum / n_cells
+
+
+def projected_lowest_eigvals(
+    hamiltonian: sp.csr_matrix,
+    translation: TranslationMap,
+    momentum: float,
+    k: int,
+    tol: float = 1.0e-11,
+) -> np.ndarray:
+    dim = hamiltonian.shape[0]
+
+    def matvec(vector: np.ndarray) -> np.ndarray:
+        pv = projected_vector(vector, translation, momentum)
+        return projected_vector(hamiltonian @ pv, translation, momentum)
+
+    operator = spla.LinearOperator((dim, dim), matvec=matvec, dtype=np.complex128)
+    vals = spla.eigsh(
+        operator,
+        k=k,
+        which="SA",
+        return_eigenvectors=False,
+        tol=tol,
+        maxiter=6000,
+        ncv=min(dim - 1, max(32, 5 * k + 16)),
+    )
+    return np.sort(vals.real)
+
+
+def sector_lowest_table(
+    hamiltonian: sp.csr_matrix,
+    translation: TranslationMap,
+    k: int,
+    tol: float = 1.0e-11,
+) -> list[np.ndarray]:
+    n_cells = translation.basis.n_sites // 2
+    table: list[np.ndarray] = []
+    for p_index in range(n_cells):
+        momentum = 2.0 * np.pi * p_index / n_cells
+        table.append(projected_lowest_eigvals(hamiltonian, translation, momentum, k, tol=tol))
+    return table
+
+
+def ground_sector_index(sector_table: list[np.ndarray]) -> int:
+    lows = np.array([vals[0] for vals in sector_table], dtype=np.float64)
+    return int(np.argmin(lows))
+
+
+def safe_random_vector(basis: Basis, rng: np.random.Generator, samples: int = 96) -> np.ndarray:
+    """Random charge-zero vector with enough W margin for CHECK-01 commutators."""
+    vec = np.zeros(basis.dim, dtype=np.complex128)
+    candidates: list[int] = []
+    for idx in range(basis.dim):
+        _, fock, w_index = basis.unpack(idx)
+        w = basis.w_value(w_index)
+        if abs(w) <= max(0, basis.w_max - 3):
+            shifted = w + magnetic_w_shift_tail(basis.n_sites, fock)
+            if -basis.w_max + 1 <= shifted <= basis.w_max - 1:
+                candidates.append(idx)
+    chosen = rng.choice(candidates, size=min(samples, len(candidates)), replace=False)
+    vec[chosen] = rng.normal(size=len(chosen)) + 1.0j * rng.normal(size=len(chosen))
+    norm = np.linalg.norm(vec)
+    if norm == 0.0:
+        raise RuntimeError("empty safe-vector support")
+    return vec / norm
+
+
+def check_magnetic_translation_rule(n_sites: int, rng: np.random.Generator) -> tuple[str, float]:
+    candidates: dict[str, Callable[[int, int], int]] = {
+        "tail": magnetic_w_shift_tail,
+        "minus_tail": lambda n, f: -magnetic_w_shift_tail(n, f),
+        "head": lambda n, f: int(charges(n, f)[0] + charges(n, f)[1]),
+        "minus_head": lambda n, f: -int(charges(n, f)[0] + charges(n, f)[1]),
+        "zero": ordinary_w_shift_zero,
+    }
+    focks = [f for f in range(1 << n_sites) if fock_charge(n_sites, f) == 0]
+    worst_by_name: dict[str, float] = {}
+    for name, shift in candidates.items():
+        worst = 0.0
+        for _ in range(200):
+            fock = int(rng.choice(focks))
+            w = int(rng.integers(-2, 3))
+            translated_fock, _ = translate_fock_by_two(n_sites, fock)
+            old_fields = w + np.cumsum(charges(n_sites, fock))
+            new_w = w + shift(n_sites, fock)
+            new_fields = new_w + np.cumsum(charges(n_sites, translated_fock))
+            rotated_old_fields = np.roll(old_fields, 2)
+            worst = max(worst, float(np.max(np.abs(new_fields - rotated_old_fields))))
+        worst_by_name[name] = worst
+    best = min(worst_by_name, key=worst_by_name.get)
+    return best, worst_by_name[best]
+
+
+def check_01(rng: np.random.Generator) -> tuple[bool, str]:
+    best_rule, electric_field_error = check_magnetic_translation_rule(8, rng)
+    worst_comm = 0.0
+    worst_q_comm = 0.0
+    worst_electric = 0.0
+    for n_sites in (8, 12):
+        basis = Basis(n_sites=n_sites, w_max=4, charge_sector=0, rotor=True)
+        translation = build_translation_map(basis, magnetic_w_shift_tail)
+        for mass in (0.3, 0.6):
+            for coupling in (0.0, 0.6, 1.0):
+                hamiltonian = build_many_body_hamiltonian(
+                    basis,
+                    mass,
+                    coupling,
+                    boundary_holonomy_shifts_w=True,
+                )
+                for _ in range(20):
+                    v = safe_random_vector(basis, rng)
+                    comm = hamiltonian @ translation.apply(v) - translation.apply(hamiltonian @ v)
+                    worst_comm = max(worst_comm, float(np.linalg.norm(comm)))
+
+                coo = hamiltonian.tocoo()
+                charges_by_index = np.empty(basis.dim, dtype=np.int64)
+                for idx in range(basis.dim):
+                    _, fock, _ = basis.unpack(idx)
+                    charges_by_index[idx] = fock_charge(n_sites, fock)
+                if coo.nnz:
+                    q_delta = charges_by_index[coo.row] - charges_by_index[coo.col]
+                    worst_q_comm = max(worst_q_comm, float(np.max(np.abs(q_delta * coo.data))))
+
+                for _ in range(20):
+                    local_f = int(rng.integers(0, len(basis.focks)))
+                    fock = int(basis.focks[local_f])
+                    w_index = int(rng.integers(0, basis.n_w))
+                    w = basis.w_value(w_index)
+                    exact_sum = electric_integer_sum(n_sites, fock, w)
+                    q = charges(n_sites, fock)
+                    direct_sum = int(np.dot(w + np.cumsum(q), w + np.cumsum(q)))
+                    worst_electric = max(worst_electric, abs(exact_sum - direct_sum))
+
+    passed = (
+        best_rule == "tail"
+        and electric_field_error <= CHECK_TOL
+        and worst_comm <= CHECK_TOL
+        and worst_q_comm <= CHECK_TOL
+        and worst_electric <= CHECK_TOL
+    )
+    detail = (
+        f"rule={best_rule}, field={electric_field_error:.1e}, "
+        f"comm={worst_comm:.1e}, Q={worst_q_comm:.1e}, E={worst_electric:.1e}"
+    )
+    return passed, detail
+
+
+def free_one_body_matrix(n_sites: int, mass: float) -> np.ndarray:
+    h = np.zeros((n_sites, n_sites), dtype=np.complex128)
+    for n in range(n_sites):
+        h[n, n] += mass * (1 if n % 2 == 0 else -1)
+        right = (n + 1) % n_sites
+        h[n, right] += -0.5j
+        h[right, n] += 0.5j
+    return h
+
+
+def analytic_cell_band(n_sites: int, mass: float) -> np.ndarray:
+    n_cells = n_sites // 2
+    cell_momenta = 2.0 * np.pi * np.arange(n_cells) / n_cells
+    return np.sqrt(mass * mass + np.sin(0.5 * cell_momenta) ** 2)
+
+
+def free_particle_hole_gaps(n_sites: int, mass: float) -> np.ndarray:
+    band = analytic_cell_band(n_sites, mass)
+    n_cells = n_sites // 2
+    gaps = np.empty(n_cells, dtype=np.float64)
+    for p_index in range(n_cells):
+        gaps[p_index] = min(band[(k + p_index) % n_cells] + band[k] for k in range(n_cells))
+    return gaps
+
+
+def build_free_fermion_hamiltonian(n_sites: int, mass: float) -> tuple[Basis, sp.csr_matrix, TranslationMap]:
+    basis = Basis(n_sites=n_sites, w_max=0, charge_sector=0, rotor=False)
+    hamiltonian = build_many_body_hamiltonian(
+        basis,
+        mass,
+        0.0,
+        boundary_holonomy_shifts_w=False,
+    )
+    translation = build_translation_map(basis, ordinary_w_shift_zero)
+    return basis, hamiltonian, translation
+
+
+def check_02() -> tuple[bool, str, dict[tuple[int, float], np.ndarray]]:
+    ph_cache: dict[tuple[int, float], np.ndarray] = {}
+    worst_band = 0.0
+    worst_sector = 0.0
+    for n_sites in (8, 12):
+        n_cells = n_sites // 2
+        for mass in (0.3, 0.6):
+            one_body = free_one_body_matrix(n_sites, mass)
+            one_body_eigs = np.sort(sla.eigvalsh(one_body).real)
+            band = analytic_cell_band(n_sites, mass)
+            expected = np.sort(np.concatenate([-band, band]))
+            worst_band = max(worst_band, float(np.max(np.abs(one_body_eigs - expected))))
+
+            ph = free_particle_hole_gaps(n_sites, mass)
+            ph_cache[(n_sites, mass)] = ph
+            _, hamiltonian, translation = build_free_fermion_hamiltonian(n_sites, mass)
+            sector_table = sector_lowest_table(hamiltonian, translation, 3)
+            ground_index = ground_sector_index(sector_table)
+            ground = sector_table[ground_index][0]
+            for p_index in range(n_cells):
+                vals = sector_table[(ground_index + p_index) % n_cells]
+                excitation = vals[1] - ground if p_index == 0 else vals[0] - ground
+                worst_sector = max(worst_sector, abs(float(excitation - ph[p_index])))
+    passed = worst_band <= DISP_TOL and worst_sector <= DISP_TOL
+    return passed, f"band={worst_band:.1e}, ph={worst_sector:.1e}", ph_cache
+
+
+def check_exact_rotor_g0_couples_w() -> bool:
+    basis = Basis(n_sites=8, w_max=2, charge_sector=0, rotor=True)
+    hamiltonian = build_many_body_hamiltonian(
+        basis,
+        0.3,
+        0.0,
+        boundary_holonomy_shifts_w=True,
+    )
+    coo = hamiltonian.tocoo()
+    for row, col, value in zip(coo.row, coo.col, coo.data):
+        if abs(value) == 0.0:
+            continue
+        _, _, row_w = basis.unpack(int(row))
+        _, _, col_w = basis.unpack(int(col))
+        if row_w != col_w:
+            return True
+    return False
+
+
+def check_03() -> tuple[bool, str]:
+    energies: dict[int, np.ndarray] = {}
+    for w_max in (2, 3, 4):
+        basis = Basis(n_sites=8, w_max=w_max, charge_sector=0, rotor=True)
+        hamiltonian = build_many_body_hamiltonian(
+            basis,
+            0.3,
+            1.0,
+            boundary_holonomy_shifts_w=True,
+        )
+        energies[w_max] = lowest_eigvals(hamiltonian, 2)
+    diff_23 = energies[2] - energies[3]
+    diff_34 = energies[3] - energies[4]
+    passed = bool(np.max(np.abs(diff_34)) <= 1.0e-10)
+    detail = (
+        f"d23=({diff_23[0]:+.2e},{diff_23[1]:+.2e}), "
+        f"d34=({diff_34[0]:+.2e},{diff_34[1]:+.2e})"
+    )
+    return passed, detail
+
+
+def check_04() -> tuple[bool, str]:
+    n_sites = 8
+    n_cells = n_sites // 2
+    basis = Basis(n_sites=n_sites, w_max=4, charge_sector=0, rotor=True)
+    translation = build_translation_map(basis, magnetic_w_shift_tail)
+    worst = 0.0
+    summaries: list[str] = []
+    for mass in (0.3, 0.6):
+        # The g = 0 supervisor check is the decoupled U_holo = 1 comparator:
+        # exact rotor g = 0 still hops in W and is flagged in TOTAL.
+        free_basis, free_h, free_t = build_free_fermion_hamiltonian(n_sites, mass)
+        full = lowest_eigvals(free_h, 8)
+        sector_vals = []
+        for vals in sector_lowest_table(free_h, free_t, 8):
+            sector_vals.extend(vals)
+        reassembled = np.sort(np.array(sector_vals, dtype=np.float64))[:8]
+        err = float(np.max(np.abs(full - reassembled)))
+        worst = max(worst, err)
+        summaries.append(f"m={mass},g=0.0/free:{err:.1e}")
+
+        for coupling in (0.6, 1.0):
+            hamiltonian = build_many_body_hamiltonian(basis, mass, coupling, boundary_holonomy_shifts_w=True)
+            full = lowest_eigvals(hamiltonian, 8)
+            sector_vals: list[float] = []
+            for p_index in range(n_cells):
+                momentum = 2.0 * np.pi * p_index / n_cells
+                sector_vals.extend(projected_lowest_eigvals(hamiltonian, translation, momentum, 8))
+            reassembled = np.sort(np.array(sector_vals, dtype=np.float64))[:8]
+            err = float(np.max(np.abs(full - reassembled)))
+            worst = max(worst, err)
+            summaries.append(f"m={mass},g={coupling}:{err:.1e}")
+    return worst <= 1.0e-10, "max=" + f"{worst:.1e}" + " [" + "; ".join(summaries) + "]"
+
+
+def check_05() -> tuple[bool, str, dict[float, dict[str, np.ndarray]]]:
+    n_sites = 12
+    n_cells = n_sites // 2
+    mass = 0.3
+    basis = Basis(n_sites=n_sites, w_max=4, charge_sector=0, rotor=True)
+    translation = build_translation_map(basis, magnetic_w_shift_tail)
+    results: dict[float, dict[str, np.ndarray]] = {}
+    gaps: list[float] = []
+    ok = True
+    for coupling in (0.6, 1.0):
+        hamiltonian = build_many_body_hamiltonian(
+            basis,
+            mass,
+            coupling,
+            boundary_holonomy_shifts_w=True,
+        )
+        sector_table = sector_lowest_table(hamiltonian, translation, 5)
+        ground_index = ground_sector_index(sector_table)
+        p0 = sector_table[ground_index]
+        p1 = sector_table[(ground_index + 1) % n_cells][:4]
+        gap = float(p0[1] - p0[0])
+        gaps.append(gap)
+        ok = ok and gap > 1.0e-10
+        results[coupling] = {
+            "P0_excitations": p0[1:5] - p0[0],
+            "P1_excitations": p1[:4] - p0[0],
+        }
+    ok = ok and gaps[1] > gaps[0]
+    detail = f"gap0(g=.6)={gaps[0]:.8g}, gap0(g=1)={gaps[1]:.8g}"
+    return ok, detail, results
+
+
+def slater_state_columns(
+    fock_basis: Basis,
+    one_body_modes: np.ndarray,
+    occupied_mode_columns: list[int],
+) -> np.ndarray:
+    n_particles = len(occupied_mode_columns)
+    state = np.zeros(fock_basis.dim, dtype=np.complex128)
+    mode_block = one_body_modes[:, occupied_mode_columns]
+    for local_f, fock_value in enumerate(fock_basis.focks):
+        fock = int(fock_value)
+        if fock.bit_count() != n_particles:
+            continue
+        occupied_sites = [n for n in range(fock_basis.n_sites) if (fock >> n) & 1]
+        state[local_f] = np.linalg.det(mode_block[occupied_sites, :])
+    return state
+
+
+def build_t2_free_basis(n_sites: int, mass: float) -> tuple[Basis, np.ndarray, float]:
+    fock_basis, _, _ = build_free_fermion_hamiltonian(n_sites, mass)
+    one_body = free_one_body_matrix(n_sites, mass)
+    eigvals, eigvecs = sla.eigh(one_body)
+    order = np.argsort(eigvals.real)
+    eigvals = eigvals[order].real
+    eigvecs = eigvecs[:, order]
+    n_cells = n_sites // 2
+    lower = list(range(n_cells))
+    upper = list(range(n_cells, n_sites))
+    columns: list[np.ndarray] = [slater_state_columns(fock_basis, eigvecs, lower)]
+    for hole_position, _hole_mode in enumerate(lower):
+        for particle_mode in upper:
+            occupied = lower.copy()
+            occupied[hole_position] = particle_mode
+            columns.append(slater_state_columns(fock_basis, eigvecs, occupied))
+    basis_matrix = np.column_stack(columns)
+    gram = basis_matrix.conj().T @ basis_matrix
+    gram_error = float(np.linalg.norm(gram - np.eye(gram.shape[0]), ord=2))
+    if gram_error > 1.0e-10:
+        q_matrix, _ = np.linalg.qr(basis_matrix)
+        basis_matrix = q_matrix[:, : len(columns)]
+    free_ground = float(np.sum(eigvals[:n_cells]))
+    return fock_basis, basis_matrix, free_ground
+
+
+def embed_t2_in_rotor(t2_fermion_basis: Basis, t2_matrix: np.ndarray, rotor_basis: Basis, w_value: int = 0) -> np.ndarray:
+    w_index = rotor_basis.w_index_from_value(w_value)
+    if w_index is None:
+        raise ValueError("requested W value is outside rotor basis")
+    embedded = np.zeros((rotor_basis.dim, t2_matrix.shape[1]), dtype=np.complex128)
+    for local_f, fock in enumerate(t2_fermion_basis.focks):
+        rotor_local = rotor_basis.fock_to_local[int(fock)]
+        embedded[rotor_basis.index(rotor_local, w_index), :] = t2_matrix[local_f, :]
+    return embedded
+
+
+def check_06(ph_cache: dict[tuple[int, float], np.ndarray]) -> tuple[bool, str]:
+    n_sites = 12
+    mass = 0.3
+    fock_basis, t2_matrix, _ = build_t2_free_basis(n_sites, mass)
+    _, free_hamiltonian, _ = build_free_fermion_hamiltonian(n_sites, mass)
+    t2_free_h = t2_matrix.conj().T @ (free_hamiltonian @ t2_matrix)
+    t2_free_vals = np.sort(sla.eigvalsh(t2_free_h).real)
+    t2_free_gap = float(t2_free_vals[1] - t2_free_vals[0])
+    expected_gap = float(np.min(ph_cache[(n_sites, mass)]))
+    free_error = abs(t2_free_gap - expected_gap)
+
+    rotor_basis = Basis(n_sites=n_sites, w_max=4, charge_sector=0, rotor=True)
+    t2_rotor = embed_t2_in_rotor(fock_basis, t2_matrix, rotor_basis, 0)
+    full_h = build_many_body_hamiltonian(
+        rotor_basis,
+        mass,
+        1.0,
+        boundary_holonomy_shifts_w=True,
+    )
+    t2_h = t2_rotor.conj().T @ (full_h @ t2_rotor)
+    t2_vals = np.sort(sla.eigvalsh(t2_h).real)
+    t2_gap = float(t2_vals[1] - t2_vals[0])
+    full_vals = lowest_eigvals(full_h, 2)
+    full_gap = float(full_vals[1] - full_vals[0])
+    passed = free_error <= T2_TOL
+    detail = f"free_err={free_error:.1e}, g1_gap_T2={t2_gap:.8g}, full={full_gap:.8g}"
+    return passed, detail
+
+
+def main() -> int:
+    started = time.time()
+    rng = np.random.default_rng(RNG_SEED)
+    flags: list[str] = [
+        "Q0-ring-Gauss",
+        "finite-W-translation-interior",
+    ]
+    if check_exact_rotor_g0_couples_w():
+        flags.append("g0-Uholo-shifts-W")
+
+    check_results: list[tuple[str, bool, str]] = []
+    ok01, detail01 = check_01(rng)
+    check_results.append(("CHECK-01", ok01, detail01))
+
+    ok02, detail02, ph_cache = check_02()
+    check_results.append(("CHECK-02", ok02, detail02))
+
+    ok03, detail03 = check_03()
+    check_results.append(("CHECK-03", ok03, detail03))
+
+    ok04, detail04 = check_04()
+    check_results.append(("CHECK-04", ok04, detail04))
+
+    ok05, detail05, meson_results = check_05()
+    check_results.append(("CHECK-05", ok05, detail05))
+
+    ok06, detail06 = check_06(ph_cache)
+    check_results.append(("CHECK-06", ok06, detail06))
+
+    passed_all = all(ok for _, ok, _ in check_results)
+    elapsed = time.time() - started
+    status = "PASS" if passed_all else "FAIL"
+
+    c01_c03 = "; ".join(f"{name}={'ok' if ok else 'FAIL'}({detail})" for name, ok, detail in check_results[:3])
+    c04_c06 = "; ".join(f"{name}={'ok' if ok else 'FAIL'}({detail})" for name, ok, detail in check_results[3:])
+    p0_g06 = ",".join(f"{x:.6g}" for x in meson_results[0.6]["P0_excitations"])
+    p1_g06 = ",".join(f"{x:.6g}" for x in meson_results[0.6]["P1_excitations"])
+    p0_g10 = ",".join(f"{x:.6g}" for x in meson_results[1.0]["P0_excitations"])
+    p1_g10 = ",".join(f"{x:.6g}" for x in meson_results[1.0]["P1_excitations"])
+
+    print(f"CHECKS-1-3 {c01_c03}")
+    print(f"CHECKS-4-6 {c04_c06}")
+    print(f"MESON g=0.6 P0=[{p0_g06}] P1=[{p1_g06}]")
+    print(f"MESON g=1.0 P0=[{p0_g10}] P1=[{p1_g10}]")
+    print(f"TOTAL {status} elapsed={elapsed:.2f}s flags={','.join(flags)}")
+    return 0 if passed_all else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

STACKED on #5065 (mass-lane block05). Opens the gauged-mass-equivalence campaign: does field-mediated binding — the covariant-hopping class the record-preservation theorem forces — deliver the composite mass-energy equivalence that every static interaction provably cannot?

This block is machinery only (exact_support, no physics claim): Hamiltonian staggered Schwinger comparator (declared import I-GAUGE, a d=1 bridge instantiation of the forced class), ring Gauss law reduced to a single Wilson-line rotor, magnetic-translation momentum sectors.

Validation: gauge/translation commutator 4.9e-16; free-limit dispersion 3.5e-14; rotor truncation converged (3e-14); momentum-sector reassembly 7.4e-14; gapped meson with momentum resolution; two-body truncation projector exact in the free limit. Context for the measurement block: at g=1.0 the truncated meson gap (1.5469) already differs from the full-Fock gap (1.3285) by 16%.

Three engineering flags surfaced by the worker are documented as part of the validated contract (charge-zero ring sector; interior-supported translation checks at finite rotor cutoff; the g=0 holonomy W-shift handled by an explicitly decoupled comparator).

## Artifacts

- Note: `docs/GAUGED_SCHWINGER_STAGGERED_ED_ENGINE_VALIDATION_NOTE_2026-07-08.md`
- Runner: `scripts/gauged_schwinger_staggered_ed_engine_2026_07_08.py`
- Cache: `logs/runner-cache/gauged_schwinger_staggered_ed_engine_2026_07_08.txt`
- Loop pack: `.claude/science/physics-loops/gauged-mass-equivalence/`

## Verification

```
python3 scripts/gauged_schwinger_staggered_ed_engine_2026_07_08.py
# expect TOTAL PASS
```

## Trace

upstream_support → the measurement block (separation experiment: full Fock vs two-body truncation of the same model). Independent audit still required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)