### PR TITLE
[physics-loop] energy-sector-field-derivation-block02 — Route B: energy cannot be gauged abelianly; closure drags in the energy current

### DIFF
--- a/docs/ENERGY_GAUSS_CONSTRAINT_OBSTRUCTION_ROUTE_B_NOTE_2026-07-08.md
+++ b/docs/ENERGY_GAUSS_CONSTRAINT_OBSTRUCTION_ROUTE_B_NOTE_2026-07-08.md
@@ -1,0 +1,135 @@
+# Energy Cannot Be Gauged The Way Charge Is -- The Exact Abelian Obstruction, Its Current Closure, And The Route B Result
+
+**Date:** 2026-07-08
+**Type:** no_go (exact operator obstruction on the declared surface)
+with the constructive closure identification
+**Claim type:** no_go
+**Claim scope:** On the framework's matter surface, promoting energy
+conservation to an ABELIAN local constraint -- the exact move that
+gives the charge sector its Gauss law, its rotor field, and its
+long-range protected potential -- is obstructed, exactly: charge
+densities commute at all separations while adjacent energy densities do
+not, the obstruction is operator-valued (no central-extension escape),
+it is kinetic in origin (present in the free theory; absent for the
+density-only part of the energy), and the candidate constraint algebra
+closes only by importing the energy-current operator, which is
+orthogonal to the span of all conserved densities. Any local
+energy-constraint structure must therefore be field-dependent /
+non-abelian -- the lattice shadow of the hypersurface-deformation
+algebra of canonical gravity. The same current operator reappears
+constructively in Route A as the protector of the lapse channel's
+masslessness. No audit status set.
+**Status authority:** independent audit lane only, sets no audit status.
+**Primary runner:**
+[`scripts/energy_gauss_constraint_obstruction_2026_07_08.py`](../scripts/energy_gauss_constraint_obstruction_2026_07_08.py)
+**Runner cache:**
+[`logs/runner-cache/energy_gauss_constraint_obstruction_2026_07_08.txt`](../logs/runner-cache/energy_gauss_constraint_obstruction_2026_07_08.txt)
+
+## Why This Note Exists
+
+The charge sector's field exists because a global conservation law was
+promoted to a local constraint: `G_n = E_n - E_{n-1} - q_n = 0`. That
+promotion is consistent because the `q_n` commute -- the constraints
+are first-class as an abelian algebra. Route B asks whether the same
+move is available for energy. The answer is no, for an exact and
+structural reason, computed here rather than argued.
+
+## Statements (exact symbolic operator algebra, machinery inherited
+from the conserved-density classification runner; one dense
+verification at `1.8e-15`)
+
+**T1 -- charge is abelian.** `[q_n, q_m] = 0` for all site pairs,
+exactly (empty commutator). This is the licence behind the charge
+sector's Gauss law.
+
+**T2 -- energy is not.** For the cell energy densities `h_n` of the
+generic interacting family: `[h_n, h_{n+1}] != 0` with Hilbert-Schmidt
+norm `4.05e2` on the verification chain, vanishing exactly beyond
+adjacent cells (locality). The candidate abelian energy-Gauss
+generators `G^E_n = eta_n - eta_{n-1} - h_n` (auxiliary abelian field
+`eta`) therefore fail first-classness: `[G^E_n, G^E_m] = [h_n, h_m]`.
+
+**T3 -- no central-extension escape.** The obstruction is a nontrivial
+OPERATOR, not a c-number: its diagonal spread across the eigenbasis is
+`1.000` (a pure central extension would be proportional to the
+identity). Abelian closure cannot be restored by a phase/cocycle.
+
+**T4 -- what closure drags in.** The obstruction telescopes exactly
+into a local current: `D_n = -i sum_m [h_m, h_n] = j_n - j_{n+1}` with
+`j` constructed explicitly (crossing partial sums, width 3 cells,
+divergence identity exact). This `j` is genuinely new content: its
+principal angle to `span{translates of h, translates of q, identity}`
+is `1.571` (orthogonal), and including the species particle currents
+only reduces it to `1.244` -- it is the ENERGY current, not a
+recombination of anything conserved or of the charge currents. A
+constraint algebra containing local energy must therefore contain the
+energy-current sector: the minimal closure has the
+hypersurface-deformation shape (energy constraints closing on
+momentum-flux content), which is field-dependent, not abelian.
+
+**T5 -- the obstruction is kinetic.** Free-theory control: the
+obstruction persists with all interactions off (norm `1.72e2`) -- no
+choice of lawful interaction removes it. Density-only control: the
+diagonal part of the energy density IS abelian -- the obstruction
+comes entirely from the hopping (kinetic) part, i.e. exactly from the
+part of energy that moves things. Sitting still is gaugeable; motion
+is not -- abelianly.
+
+## No-Go Discipline
+
+- Routes enumerated: the abelian promotion (obstructed, T2/T3); the
+  central-extension repair (killed, T3); closure on the conserved set
+  (killed, T4's orthogonality); interaction engineering (killed, T5).
+- Steelman: "choose a different local energy density (apportioning
+  ambiguity) so the pieces commute." Response: the commutator's
+  telescoped divergence is apportioning-independent up to bounded
+  redefinitions, and T5 shows the diagonal-only choice that does
+  commute fails to be the energy (it omits the kinetic term entirely);
+  any density summing to `H` with local support contains the hopping
+  content that obstructs.
+- Escape named (and taken, constructively, by Route A): abandon the
+  abelian gauging; the energy-current operator this note exhibits is
+  precisely what protects the lapse channel's exact masslessness in
+  the induced-kernel route. The negative and the positive are the same
+  operator seen from two sides.
+- Boundedness: `d = 1` matter surface, the declared family, cell-level
+  densities; the hypersurface-deformation identification is a shape
+  statement about minimal closure, not a derivation of gravity's
+  constraint algebra.
+
+## Boundaries
+
+- Exact symbolic results on the declared two-species family (generic
+  draw, seed printed); one dense verification at `1.8e-15`.
+- No gravitational dynamics derived; no field constructed; the
+  companion Route A note carries the constructive half.
+- This note sets no audit status. Independent audit is required.
+
+## Dependencies
+
+- [`NOETHER_SOURCE_CURRENT_CLASSIFICATION_BOUNDED_NOTE_2026-07-08.md`](NOETHER_SOURCE_CURRENT_CLASSIFICATION_BOUNDED_NOTE_2026-07-08.md)
+  -- the algebra machinery and the conserved set the closure is tested
+  against.
+- [`ENERGY_CHANNEL_INDUCED_KERNEL_ROUTE_A_NOTE_2026-07-08.md`](ENERGY_CHANNEL_INDUCED_KERNEL_ROUTE_A_NOTE_2026-07-08.md)
+  -- the constructive reappearance of the obstruction operator.
+- [`SOURCE_FIELD_STATIC_LAW_CLASSIFICATION_BOUNDED_NOTE_2026-07-08.md`](SOURCE_FIELD_STATIC_LAW_CLASSIFICATION_BOUNDED_NOTE_2026-07-08.md)
+  -- the target-law frame.
+
+## Runner And Cache
+
+Supervisor-executed result:
+
+```text
+TOTAL ABELIAN-OBSTRUCTED elapsed=1.36s seed=20260708
+```
+
+Load-bearing residuals: charge abelianness exact; `||[h_n, h_{n+1}]|| =
+4.05e2` with locality exact beyond adjacent cells and dense
+verification `1.8e-15`; noncentral spread `1.000`; divergence identity
+exact with current width 3; principal angles `1.571 / 1.244`; free
+control `1.72e2`; density-only control abelian.
+
+## Changelog
+
+- **2026-07-08.** Initial note. Worker-drafted runner on the
+  classification machinery, supervisor-reviewed and supervisor-executed.

--- a/logs/runner-cache/energy_gauss_constraint_obstruction_2026_07_08.txt
+++ b/logs/runner-cache/energy_gauss_constraint_obstruction_2026_07_08.txt
@@ -1,0 +1,6 @@
+CHARGE q_abelian=ok qh_l2_nonzero=8 qh_l2_minmax=(9.171e-01,1.297e+00)
+ENERGY-OBSTRUCTION C01_hs8=4.049983e+02 locality_d>=2=ok self=ok dense_err=1.8e-15 G01_hs8=4.049983e+02 noncentral_spread=1.000
+CURRENT-CLOSURE j_hs8=4.049983e+02 div_exact=ok width=3 angle_hq=1.571 angle_hqJ=1.244 drop=0.327 curr_dominated=no
+CONTROLS free_C01_hs8=1.718835e+02 single_C01_hs8=(6.349e+01,1.966e+02) diag_abelian=ok obstruction-is-kinetic
+SPEC-NOTE eta-auxiliary-only; current=crossing-partial-sum; projection=8site-degree<=6-coeff-basis
+TOTAL ABELIAN-OBSTRUCTED elapsed=1.36s seed=20260708

--- a/scripts/energy_gauss_constraint_obstruction_2026_07_08.py
+++ b/scripts/energy_gauss_constraint_obstruction_2026_07_08.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Route B energy-sector obstruction to an abelian local Gauss constraint.
+
+Can energy conservation be promoted to an ABELIAN local constraint the way
+charge is?  In the charge sector, local charge densities commute at all
+separations; that abelian Gauss algebra is the algebraic source of the
+long-range field.  Energy densities do not commute.  This runner computes that
+local obstruction exactly in the same normal-ordered fermionic algebra used by
+scripts/noether_source_current_classification_2026_07_08.py, then identifies
+the sector pulled in by the candidate constraint algebra: the energy-current
+sector, the lattice shadow of the hypersurface-deformation algebra.
+
+Companion note:
+ENERGY_GAUSS_CONSTRAINT_OBSTRUCTION_ROUTE_B_NOTE_2026-07-08.md.
+
+No gravitational dynamics are derived here; no audit status is set.
+
+Design concerns are explicit rather than hidden:
+- The auxiliary eta bookkeeping is algebraically inert because
+  [eta_k, matter] = [eta_k, eta_l] = 0, so [G_n, G_m] = [h_n, h_m].
+- The current construction uses the standard crossing-current partial sum
+  j_n = -i sum_{a <= n-1, b >= n} [h_a, h_b], truncated only by locality.
+- The projection check is a finite 8-site, degree <= 6 coefficient-basis
+  check over the imported monomial/operator conventions; it is not used as an
+  exact identity proof.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+from pathlib import Path
+import sys
+import time
+
+import numpy as np
+import scipy.linalg as sla
+import scipy.sparse as sp
+
+
+sys.dont_write_bytecode = True
+
+RNG_SEED = 20260708
+CELL_SITES = 2
+DENSE_SITES = 8
+CHECK_TOL = 1.0e-12
+CLEAN_TOL = 1.0e-14
+ANGLE_GATE = 0.3
+NONCENTRAL_GATE = 0.1
+PROJECTION_WINDOW = 8
+PROJECTION_DEGREE = 6
+
+
+def import_classification_runner():
+    path = Path(__file__).with_name("noether_source_current_classification_2026_07_08.py")
+    spec = importlib.util.spec_from_file_location("noether_source_current_classification_2026_07_08", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load noether source/current classification runner")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+eng = import_classification_runner()
+
+
+def add_scaled(accum, op, scale: complex) -> None:
+    eng.op_add_scaled(accum, op, scale)
+
+
+def translate_op(op, delta_sites: int):
+    out = {}
+    for key, coeff in op.items():
+        eng.op_add(out, eng.translate_key(key, delta_sites), coeff)
+    return out
+
+
+def h_cell(c, n: int, *, part: str = "total"):
+    return translate_op(eng.build_h_density(c, part=part), CELL_SITES * n)
+
+
+def q_site(n: int):
+    out = {}
+    eng.add_number(out, eng.mode(n, "a"), 1.0)
+    eng.add_number(out, eng.mode(n, "b"), 1.0)
+    return out
+
+
+def identity_op():
+    return {eng.identity_key(): 1.0 + 0.0j}
+
+
+def density_only(op):
+    return {key: coeff for key, coeff in op.items() if key[0] == key[1]}
+
+
+def commutator(left, right):
+    out = {}
+    for l_key, l_coeff in left.items():
+        if abs(l_coeff) <= CLEAN_TOL:
+            continue
+        for r_key, r_coeff in right.items():
+            if abs(r_coeff) <= CLEAN_TOL:
+                continue
+            scale = l_coeff * r_coeff
+            for key, coeff in eng.commutator_key_items(l_key, r_key):
+                eng.op_add(out, key, scale * coeff)
+    return out
+
+
+def op_difference(left, right):
+    out = {}
+    add_scaled(out, left, 1.0)
+    add_scaled(out, right, -1.0)
+    return out
+
+
+def op_linear(terms):
+    out = {}
+    for scale, op in terms:
+        add_scaled(out, op, scale)
+    return out
+
+
+def coeff_l2(op) -> float:
+    return math.sqrt(sum(float(abs(coeff) ** 2) for coeff in op.values()))
+
+
+def op_sites(op) -> list[int]:
+    sites: set[int] = set()
+    for key in op:
+        if key == eng.identity_key():
+            continue
+        sites.update(eng.key_sites(key))
+    return sorted(sites)
+
+
+def op_width(op) -> int:
+    sites = op_sites(op)
+    return 0 if not sites else max(sites) - min(sites) + 1
+
+
+def shift_min_site_to_zero(op):
+    sites = op_sites(op)
+    if not sites:
+        return op
+    return translate_op(op, -min(sites))
+
+
+def sparse_max_abs(matrix: sp.spmatrix) -> float:
+    coo = matrix.tocoo()
+    return float(np.max(np.abs(coo.data))) if coo.nnz else 0.0
+
+
+def sparse_frobenius(matrix: sp.spmatrix) -> float:
+    csr = matrix.tocsr()
+    return float(np.linalg.norm(csr.data)) if csr.nnz else 0.0
+
+
+def hs_norm_8(op, cache) -> float:
+    return sparse_frobenius(eng.operator_sparse(op, DENSE_SITES, cache))
+
+
+def dense_vs_symbolic_commutator_error(left, right, symbolic, cache) -> float:
+    left_mat = eng.operator_sparse(left, DENSE_SITES, cache)
+    right_mat = eng.operator_sparse(right, DENSE_SITES, cache)
+    sym_mat = eng.operator_sparse(symbolic, DENSE_SITES, cache)
+    diff = left_mat @ right_mat - right_mat @ left_mat - sym_mat
+    diff.eliminate_zeros()
+    return sparse_max_abs(diff)
+
+
+def noncentral_eigen_spread(op) -> float:
+    local = shift_min_site_to_zero(op)
+    sites = op_sites(local)
+    if not sites:
+        return 0.0
+    n_sites = max(sites) + 1
+    mat = eng.operator_sparse(local, n_sites, {})
+    hermitian = (-1.0j * mat).toarray()
+    hermitian = (hermitian + hermitian.conjugate().T) * 0.5
+    evals = sla.eigvalsh(hermitian, check_finite=False).real
+    centered = evals - float(np.mean(evals))
+    rms = math.sqrt(float(np.mean(evals * evals)))
+    return math.sqrt(float(np.mean(centered * centered))) / max(rms, np.finfo(float).tiny)
+
+
+def crossing_current(c, n: int):
+    out = {}
+    for a in range(n - 3, n):
+        for b in range(n, n + 4):
+            add_scaled(out, commutator(h_cell(c, a), h_cell(c, b)), -1.0j)
+    return out
+
+
+def energy_divergence(c, n: int):
+    out = {}
+    hn = h_cell(c, n)
+    for m in range(n - 3, n + 4):
+        add_scaled(out, commutator(h_cell(c, m), hn), -1.0j)
+    return out
+
+
+def finite_window_ok(op, *, window: int = PROJECTION_WINDOW, degree: int = PROJECTION_DEGREE) -> bool:
+    for key in op:
+        if key == eng.identity_key():
+            continue
+        sites = eng.key_sites(key)
+        if not sites:
+            continue
+        if min(sites) < 0 or max(sites) >= window:
+            return False
+        if eng.key_degree(key) > degree:
+            return False
+    return True
+
+
+def coefficient_angle(vector_op, span_ops) -> tuple[float, bool]:
+    all_ops = [vector_op, *span_ops]
+    window_ok = all(finite_window_ok(op) for op in all_ops)
+    keys = sorted({key for op in all_ops for key, coeff in op.items() if abs(coeff) > CLEAN_TOL})
+    if not keys:
+        return math.pi / 2.0, window_ok
+    index = {key: idx for idx, key in enumerate(keys)}
+    vec = np.zeros(len(keys), dtype=np.complex128)
+    for key, coeff in vector_op.items():
+        if abs(coeff) > CLEAN_TOL:
+            vec[index[key]] = coeff
+    cols = []
+    for op in span_ops:
+        col = np.zeros(len(keys), dtype=np.complex128)
+        for key, coeff in op.items():
+            if abs(coeff) > CLEAN_TOL:
+                col[index[key]] = coeff
+        if np.linalg.norm(col) > CLEAN_TOL:
+            cols.append(col)
+    norm = float(np.linalg.norm(vec))
+    if norm <= CLEAN_TOL or not cols:
+        return math.pi / 2.0, window_ok
+    mat = np.column_stack(cols)
+    q, singular, _ = sla.svd(mat, full_matrices=False, check_finite=False)
+    rank = int(np.count_nonzero(singular > 1.0e-12))
+    if rank == 0:
+        return math.pi / 2.0, window_ok
+    q = q[:, :rank]
+    residual = vec - q @ (q.conjugate().T @ vec)
+    sin_theta = float(np.linalg.norm(residual) / norm)
+    return float(math.asin(np.clip(sin_theta, 0.0, 1.0))), window_ok
+
+
+def local_projection_report(c, j_op):
+    h_base = eng.build_h_density(c)
+    span_hq = [identity_op()]
+    span_hq.extend(q_site(site) for site in range(PROJECTION_WINDOW))
+    for cell in range(3):
+        span_hq.append(translate_op(h_base, CELL_SITES * cell))
+
+    angle_hq, basis_ok_hq = coefficient_angle(j_op, span_hq)
+
+    span_with_currents = list(span_hq)
+    for species in ("a", "b"):
+        current_base = eng.build_current_operator(species, c)
+        for cell in range(3):
+            span_with_currents.append(translate_op(current_base, CELL_SITES * cell))
+    angle_current, basis_ok_current = coefficient_angle(j_op, span_with_currents)
+    return angle_hq, angle_current, angle_hq - angle_current, basis_ok_hq and basis_ok_current
+
+
+def check_charge(c):
+    q_ops = [q_site(n) for n in range(6)]
+    charge_abelian = True
+    for n in range(6):
+        for m in range(6):
+            if commutator(q_ops[n], q_ops[m]):
+                charge_abelian = False
+
+    qh_norms = []
+    for site in range(6):
+        for cell in range(3):
+            qh_norms.append(coeff_l2(commutator(q_site(site), h_cell(c, cell))))
+    nonzero = [norm for norm in qh_norms if norm > CLEAN_TOL]
+    return charge_abelian, len(nonzero), (min(nonzero) if nonzero else 0.0), max(qh_norms)
+
+
+def check_energy(c, cache):
+    c01 = commutator(h_cell(c, 0), h_cell(c, 1))
+    locality_ok = True
+    self_ok = True
+    for n in range(6):
+        for m in range(6):
+            if abs(n - m) > 3:
+                continue
+            cnm = commutator(h_cell(c, n), h_cell(c, m))
+            if n == m and cnm:
+                self_ok = False
+            if abs(n - m) >= 2 and cnm:
+                locality_ok = False
+    norm = hs_norm_8(c01, cache)
+    dense_error = dense_vs_symbolic_commutator_error(h_cell(c, 0), h_cell(c, 1), c01, cache)
+    spread = noncentral_eigen_spread(c01)
+    return c01, norm, locality_ok, self_ok, dense_error, spread
+
+
+def check_current(c, cache):
+    j1 = crossing_current(c, 1)
+    j2 = crossing_current(c, 2)
+    d1 = energy_divergence(c, 1)
+    continuity_error = op_linear([(1.0, d1), (-1.0, j1), (1.0, j2)])
+    j_norm = hs_norm_8(j1, cache)
+    angle_hq, angle_current, angle_drop, basis_ok = local_projection_report(c, j1)
+    return j1, j_norm, not continuity_error, op_width(j1), angle_hq, angle_current, angle_drop, basis_ok
+
+
+def check_controls(c, cache):
+    free_c = eng.free_like(c)
+    free_c01 = commutator(h_cell(free_c, 0), h_cell(free_c, 1))
+    free_norm = hs_norm_8(free_c01, cache)
+
+    single_a = commutator(h_cell(c, 0, part="a"), h_cell(c, 1, part="a"))
+    single_b = commutator(h_cell(c, 0, part="b"), h_cell(c, 1, part="b"))
+    single_a_norm = hs_norm_8(single_a, cache)
+    single_b_norm = hs_norm_8(single_b, cache)
+
+    diag_base = density_only(eng.build_h_density(c))
+    diag_abelian = True
+    for n in range(6):
+        for m in range(6):
+            if abs(n - m) <= 3 and commutator(translate_op(diag_base, CELL_SITES * n), translate_op(diag_base, CELL_SITES * m)):
+                diag_abelian = False
+    return free_norm, single_a_norm, single_b_norm, diag_abelian
+
+
+def main() -> int:
+    started = time.time()
+    verdict = "MACHINERY-FAIL"
+    notes: list[str] = []
+    cache = {}
+
+    try:
+        rng = np.random.default_rng(RNG_SEED)
+        c = eng.random_couplings(rng)
+
+        charge_ok, qh_nonzero, qh_min, qh_max = check_charge(c)
+        c01, c01_norm, locality_ok, self_ok, dense_error, spread = check_energy(c, cache)
+        j1, j_norm, continuity_ok, j_width, angle_hq, angle_current, angle_drop, projection_ok = check_current(c, cache)
+        free_norm, single_a_norm, single_b_norm, diag_abelian = check_controls(c, cache)
+
+        machinery_ok = (
+            charge_ok
+            and locality_ok
+            and self_ok
+            and dense_error <= CHECK_TOL
+            and continuity_ok
+            and projection_ok
+            and diag_abelian
+        )
+        unexpected = (
+            c01_norm <= CHECK_TOL
+            or spread <= NONCENTRAL_GATE
+            or angle_hq <= ANGLE_GATE
+            or free_norm <= CHECK_TOL
+            or j_norm <= CHECK_TOL
+        )
+
+        if machinery_ok and not unexpected:
+            verdict = "ABELIAN-OBSTRUCTED"
+        elif machinery_ok and unexpected:
+            verdict = "UNEXPECTED-CLOSURE"
+
+        curr_dominated = angle_current < ANGLE_GATE
+        print(f"CHARGE q_abelian={'ok' if charge_ok else 'FAIL'} qh_l2_nonzero={qh_nonzero} qh_l2_minmax=({qh_min:.3e},{qh_max:.3e})")
+        print(
+            "ENERGY-OBSTRUCTION "
+            f"C01_hs8={c01_norm:.6e} locality_d>=2={'ok' if locality_ok else 'FAIL'} self={'ok' if self_ok else 'FAIL'} "
+            f"dense_err={dense_error:.1e} G01_hs8={c01_norm:.6e} noncentral_spread={spread:.3f}"
+        )
+        print(
+            "CURRENT-CLOSURE "
+            f"j_hs8={j_norm:.6e} div_exact={'ok' if continuity_ok else 'FAIL'} width={j_width} "
+            f"angle_hq={angle_hq:.3f} angle_hqJ={angle_current:.3f} drop={angle_drop:.3f} "
+            f"curr_dominated={'yes' if curr_dominated else 'no'}"
+        )
+        print(
+            "CONTROLS "
+            f"free_C01_hs8={free_norm:.6e} single_C01_hs8=({single_a_norm:.3e},{single_b_norm:.3e}) "
+            f"diag_abelian={'ok' if diag_abelian else 'FAIL'} obstruction-is-kinetic"
+        )
+        print("SPEC-NOTE eta-auxiliary-only; current=crossing-partial-sum; projection=8site-degree<=6-coeff-basis")
+        print(f"TOTAL {verdict} elapsed={time.time() - started:.2f}s seed={RNG_SEED}")
+        return 0 if verdict == "ABELIAN-OBSTRUCTED" else 1
+    except Exception as exc:
+        notes.append(f"{type(exc).__name__}:{exc}")
+        print("CHARGE blocked")
+        print("ENERGY-OBSTRUCTION blocked")
+        print("CURRENT-CLOSURE blocked")
+        print("CONTROLS blocked")
+        print("SPEC-NOTE " + "|".join(notes))
+        print(f"TOTAL MACHINERY-FAIL elapsed={time.time() - started:.2f}s seed={RNG_SEED}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What this PR contains

Route B of the decisive campaign (stacked on #5073). One runner (exact symbolic operator algebra on the classification machinery), supervisor-authored no-go note, cache.

- `docs/ENERGY_GAUSS_CONSTRAINT_OBSTRUCTION_ROUTE_B_NOTE_2026-07-08.md`
- `scripts/energy_gauss_constraint_obstruction_2026_07_08.py`
- `logs/runner-cache/energy_gauss_constraint_obstruction_2026_07_08.txt`

## The result (supervisor-executed, ABELIAN-OBSTRUCTED, 1.4s)

The charge sector's field exists because charge conservation was promoted to a local constraint, and that promotion is licensed by an exact fact: **charge densities commute everywhere** (verified symbolically exact). The same move for energy is obstructed, exactly:

- Adjacent energy densities do not commute (HS norm 4.05e2; locality exact beyond adjacent cells; dense verification 1.8e-15) → the candidate abelian energy-Gauss constraints are not first-class.
- **No central-extension escape:** the obstruction is operator-valued (diagonal spread 1.000), not a c-number cocycle.
- **Kinetic in origin:** persists in the free theory (1.72e2) — no interaction choice fixes it; the density-only part of the energy IS abelian — the obstruction is exactly the part of energy that moves things.
- **What closure drags in:** the obstruction telescopes exactly into a local current (divergence identity exact, width 3 cells) that is orthogonal to the span of every conserved density (principal angle 1.571 = π/2) and is not the particle current (1.244). Minimal closure must contain the energy-current sector — the lattice shadow of the hypersurface-deformation algebra: any local energy-constraint structure is field-dependent, non-abelian.

The constructive twist: this same current operator is what *protects* the lapse channel's exact masslessness in Route A (#5073) — the obstruction and the protection are one operator seen from two sides.

## Verification

```
python3 scripts/energy_gauss_constraint_obstruction_2026_07_08.py   # ~2s, TOTAL ABELIAN-OBSTRUCTED
```

Block03 (synthesis + campaign halt for the owner conversation) follows stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)