### PR TITLE
[physics-loop] record-rate-gravity-block03 — bridge synthesis: the clock sector is derived; one link (energy→records) remains

### DIFF
--- a/.claude/science/physics-loops/record-rate-gravity/HANDOFF.md
+++ b/.claude/science/physics-loops/record-rate-gravity/HANDOFF.md
@@ -1,0 +1,51 @@
+# Handoff — record-rate-gravity
+
+Campaign 2026-07-08 (owner-commissioned: "the derivation that checks
+whether gravity was already in the axioms"). Owner mechanism insight:
+record crowding as the clock dial, saturation as the stop.
+
+CAMPAIGN VERDICT: the clock sector is DERIVED. Saturation stops
+formation (axiom corollary, rule-independent); the sign — crowding
+slows formation — is universal in the constraint reading of
+Admissibility (100% of the factorized class; non-generic over arbitrary
+covariant rules, so the reading does real work); the weak field carries
+exactly one constant (all lawful rate laws collapse; measured clock
+confirms at 21-146 sigma); the frozen-pocket exhibit realizes the
+owner's saturation mechanism live (termination at 65% occupancy with
+open sites permanently silenced). Combined with the prior campaigns,
+the remaining open link is the SOURCING half: records form where energy
+is (the formation rule's site/weight part — the axioms' named open
+gate). With it, the loop closes: energy -> records -> slow time ->
+universal fall.
+
+## PRs in review order
+
+1. #5076 block01 — saturation corollary + availability census +
+   constraint-class sign theorem.
+   `python3 -B scripts/record_saturation_availability_census_2026_07_08.py`
+2. #5077 block02 (stacked) — rate-law class reduction + measured clock
+   + frozen pockets.
+   `python3 scripts/formation_rate_law_class_reduction_2026_07_08.py`
+3. #5078 block03 (stacked) — bridge synthesis + close (meta; no runner).
+
+Nothing is landed; the review lane owns landing. Full campaign-season
+stack: #5061-#5078.
+
+## Owner surfaces left open (clarity options, in the synthesis note)
+
+- Constraint reading of Admissibility -> one-sentence axiom-intent
+  clarity (converts the sign theorem's premise from reading to text).
+- Lawful-rate-law existence -> optional primitive registration
+  (monotone local covariant rate rule exists; no rule chosen).
+
+## Next campaign (named)
+
+"Records form where energy is": derive the formation rule's site/weight
+correlation with local energy density from the dynamics-form theorem's
+record bridges (quantum-Darwinism premise ties records to interaction
+events). Closes the sourcing link. Also queued: d=3 lifts; DMRG engine;
+the June conformal-class input audits.
+
+## Resume
+
+Read STATE.yaml. Campaign closed. Follow-ups start fresh packs.

--- a/.claude/science/physics-loops/record-rate-gravity/STATE.yaml
+++ b/.claude/science/physics-loops/record-rate-gravity/STATE.yaml
@@ -41,7 +41,7 @@ success_bar: >
   realized-surface rule class is count-constant (no crowding response),
   that is the honest sign/mechanism obstruction — file it and surface to
   the owner rather than tuning.
-current_block: block01 + block02 workers in parallel
+current_block: CLOSED — blocks 01-03 shipped (PRs #5076-#5078)
 current_branch: physics-loop/record-rate-gravity-block01-20260708
 worktree: /Users/jonBridger/tp-matter-mass-wep
 imports: >
@@ -52,6 +52,13 @@ imports: >
   F(0) = 0 forced) — no specific rule is chosen; the toy simulation's
   process clock is a comparator device, not a time-metric claim.
 discipline: physics-loop standard. Plain language on any owner surface.
-next_exact_action: review worker drafts (block01 counting runner; block02
-  rate-law runner)
+next_exact_action: none — campaign closed; see HANDOFF.md; the sourcing
+  link (records form where energy is) is the named next campaign
 stop_condition_hit: none
+# block01 2026-07-08: run 1 fired ATTRACTION-NONGENERIC (raw ensemble —
+# expected in hindsight; enablement rules dominate); supervisor added the
+# constraint-class leg: factorized rules monotone by intersection, 100%
+# attraction-compatible; enablement witness exhibited. Saturation corollary
+# rule-independent over 27,012 configs. block02 2026-07-08: CLASS-REDUCED
+# single iteration; collapse 3e-11; clock contrast 21-146 sigma; frozen
+# pockets at 65% occupancy. Both supervisor-executed.

--- a/docs/RECORD_RATE_GRAVITY_BRIDGE_SYNTHESIS_2026-07-08.md
+++ b/docs/RECORD_RATE_GRAVITY_BRIDGE_SYNTHESIS_2026-07-08.md
@@ -1,0 +1,139 @@
+# Gravity From The Record Sector -- The Assembled Chain, What Each Link Rests On, And The One Link Still Open
+
+**Date:** 2026-07-08
+**Type:** meta (campaign synthesis; makes no new technical claim; every
+technical statement is carried by the cited runner-backed notes)
+**Claim type:** meta
+**Status authority:** none. Independent audit of every cited note is
+still required; nothing here is landed or promoted.
+
+## The chain, link by link
+
+The framework's gravity story now reads as follows. Each link names its
+authority and its status.
+
+1. **Geometry's shape comes from records.** Record order and structure
+   assemble the metric's causal/conformal class -- everything about
+   geometry except one number per point, the scale
+   (conditional assembly; June conformal-class note, pending audit of
+   two inputs).
+2. **That missing number is the clock rate, and record HISTORY cannot
+   supply it.** Retained no-go: count and order are invariant under
+   re-ticking; a finished history fixes no rate. (Retained.)
+3. **The candidate carrier of the scale is the record-formation RATE
+   -- forward dynamics, not history readout** -- which the retained
+   no-gos leave open. The global normalization stays conventional
+   (only rate CONTRASTS between regions are physical), matching both
+   the retained normalization gate and the forced background
+   subtraction of the classified static law (#5071).
+4. **The strong-field endpoint is an axiom corollary.** One record per
+   site plus permanence force zero formation at saturation --
+   rule-independently (#5076). In the freezing-capable rule class,
+   formation can stop in crowded pockets BEFORE space fills -- the
+   measured frozen-pocket exhibit (#5077): 65 percent terminal
+   occupancy with open sites permanently silenced.
+5. **The sign is the constraint character of Admissibility.** Over
+   arbitrary covariant rules the crowding response has no preferred
+   sign (census: non-generic); under the constraint reading -- records
+   restrict, never enable -- crowding slows formation automatically,
+   in 100 percent of the class (#5076). Antigravity would require an
+   enablement rule (a record creating possibilities its absence
+   forbade), exhibited explicitly as the complement's shape.
+6. **The weak field carries exactly one constant.** For every lawful
+   rate law (local, covariant, monotone, zero at zero availability --
+   the endpoint forced, not chosen), the linear response to crowding
+   factorizes through one dimensionless number; five laws collapse to
+   `3e-11` after rescaling, and a measured stochastic clock confirms
+   the collapse at 12-14 percent at finite contrast (#5077). The
+   rate-law freedom is a Newton-constant slot, nothing more.
+7. **The field dynamics is already derived.** Whatever modulates the
+   local evolution rate -- and a local event-rate field does exactly
+   that -- has the exactly massless, stable, Poisson-class induced
+   kernel, protected by energy conservation (#5073); the electric-
+   style alternative is closed by theorem (#5074); the static law and
+   its forced energy-contrast sourcing are classified (#5071); and the
+   source's species-blindness is derived (#5068). The matter side of
+   equal fall is #5061-#5067.
+
+## The one link still open (named plainly)
+
+The chain above derives: **record crowding slows local time**, with
+forced endpoint, universal sign in the constraint class, one-constant
+weak field, and the right field dynamics for the rate field. What it
+does NOT yet derive is the sourcing link: **that record crowding tracks
+energy density** -- that records form preferentially where energy is,
+so that the crowding contrasts which slow the clocks are the energy
+contrasts which the classified law says must source the field. This is
+exactly the still-downstream WEIGHT/SITE part of the formation rule
+(the axioms' open formation-rules gate: "which admissible possibility a
+new record locks, at which site, with what weight"). The rate part is
+now reduced (one constant); the where part is the next campaign:
+"records form where energy is" -- plausibly derivable from the
+dynamics-form theorem's record bridges (its quantum-Darwinism premise
+already ties record formation to interaction events), and falsifiable
+in-framework if not.
+
+With that link, the loop closes: energy -> records -> slow time ->
+(by #5061-#5067) matter falls along the time gradient, universally.
+Without it, the campaign has derived a complete and correctly-shaped
+clock sector awaiting its source coupling.
+
+## Owner surfaces (clarity options, no rulings made here)
+
+- **Constraint reading of Admissibility.** The sign theorem (#5076 T3)
+  rests on reading the admissibility rule as a constraint rule
+  (availability = intersection of per-neighbor restrictions; an open
+  neighbor imposes nothing). This is arguably the plain meaning of
+  "admissibility" and "locking"; a one-sentence clarity note on the
+  axiom's intent would convert "reading" into "text". Option, not
+  requirement: the census keeps both readings honest either way.
+- **Lawful-rate-law existence.** The Qualification clause ("a law...
+  gives exactly one answer") plus "Records form" arguably imply that
+  formation is governed by SOME lawful local covariant rate rule; a
+  primitive registration naming that (with monotonicity) would make
+  block02's class-wide results load-bearing without choosing any rule.
+  The alternative -- leaving it as a named premise on every downstream
+  note -- is also viable.
+
+## No-Go Compliance Table
+
+- Post-record clock-rate no-go (retained): respected -- the rate field
+  is forward dynamics, not history readout.
+- Record clock-rate normalization gate (retained): respected -- only
+  contrasts are physical; the global unit stays conventional.
+- Context-independence no-go (2026-06-17): respected -- nothing here is
+  Record-only; every leg uses Record + Admissibility + the reduced
+  rate-law class, exactly the "separate dynamics/source theorem" route
+  its N7 steelman left open.
+- Record-formation-not-forced no-go (2026-06-06): superseded in the
+  relevant respect by the owner-approved 2026-07-04 formation sentence
+  ("Records form."), which this campaign takes as axiom text.
+- Adaptive/coevolving-geometry no-go (2026-04-05, pre-reset): its
+  requested "single control law regulating the geometry observable" is
+  what the reduced rate-law class now provides; the old empirical
+  probe is unaffected and unrevived.
+
+## What would falsify this arc, in-framework
+
+- A derivation showing the realized admissibility rule is NOT of
+  constraint type (enablement witness realized) -- kills the sign.
+- The formation-weight campaign finding record placement anticorrelates
+  with energy density -- kills the sourcing link.
+- Audit failure of the June conformal-class inputs -- decouples the
+  geometry-shape half (the clock sector survives but the metric
+  assembly loses its other half).
+
+## The cited chain
+
+#5061-#5067 (matter/WEP), #5068 (source classification), #5071 (static
+law + subtraction), #5073/#5074 (induced kernel / obstruction), #5076
+(saturation + census + sign), #5077 (rate-law reduction + measured
+clock), and the June conformal-class, clock-rate, and firewall notes
+by their titles in the respective Dependencies sections.
+
+## Changelog
+
+- **2026-07-08.** Campaign synthesis. Owner-commissioned derivation ran
+  both structural legs to exact conclusions in one day; the sourcing
+  link (records form where energy is) is named as the next campaign;
+  two clarity options surfaced to the owner; campaign closed.


### PR DESCRIPTION
## What this PR contains

Campaign synthesis and close (stacked on #5077). Meta note — every technical claim carried by the cited runner-backed notes — plus pack close.

- `docs/RECORD_RATE_GRAVITY_BRIDGE_SYNTHESIS_2026-07-08.md`
- `.claude/science/physics-loops/record-rate-gravity/` (HANDOFF, STATE)

## The assembled chain

Geometry's shape from records (June conformal-class arc, conditional) → the missing scale is the clock rate (retained) → carried by the record-formation rate (forward dynamics; retained no-gos respected) → saturation endpoint axiom-forced (#5076) → sign universal in the constraint reading of Admissibility (#5076) → weak field = one constant (#5077) → field dynamics = the derived massless Poisson-class kernel with energy-contrast sourcing (#5068/#5071/#5073/#5074) → universal fall on the matter side (#5061–#5067).

**The one link still open, stated plainly:** that record crowding *tracks energy density* — records form where energy is. This is precisely the formation rule's site/weight part, the axioms' named open gate. With it: energy → records → slow time → universal fall. It is the named next campaign, with the dynamics-form theorem's quantum-Darwinism record bridge as the natural attack.

## Owner surfaces (clarity options, no rulings)

1. A one-sentence axiom-intent clarity fixing the constraint reading of Admissibility (records restrict, never enable) — converts the sign theorem's premise from reading to text.
2. An optional primitive registration for lawful-rate-law existence (monotone, local, covariant; no rule chosen — the class reduction makes any choice weak-field-equivalent).

Also included: the no-go compliance table (all four retained/relevant no-gos respected or superseded-by-owner-amendment) and the in-framework falsification list.

Review order for the campaign: #5076 → #5077 → this PR. Season stack: #5061–#5078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)