### PR TITLE
[physics-loop] record-deposition-rate-block03 — constraint map: one free number, bracketed from both sides; campaign close

### DIFF
--- a/.claude/science/physics-loops/record-deposition-rate/HANDOFF.md
+++ b/.claude/science/physics-loops/record-deposition-rate/HANDOFF.md
@@ -1,0 +1,51 @@
+# record-deposition-rate — campaign handoff (CLOSED 2026-07-09)
+
+## PRs, in review order
+
+1. **#5082** block01 — kappa(theta) measured in the gauged comparator.
+   Verify: `python3 scripts/deposition_per_activity_kappa_2026_07_08.py`
+   (KAPPA-MEASURED, exit 0; diff against
+   `logs/runner-cache/deposition_per_activity_kappa_2026_07_08.txt`).
+2. **#5085** block02 — kappa translated (trail / mobility /
+   ossification), mobility forces sparsity. Base = the
+   collapse-merger-comparator-block01 branch (it holds the engine and
+   its Poisson deposition fix).
+   Verify: `python3 scripts/ossification_mobility_translation_2026_07_08.py`
+   (WINDOW-MAPPED, exit 0; diff against its cache).
+3. **#5087** block03 — constraint map, owner surface
+   (`docs/DEPOSITION_CONSTANT_CONSTRAINT_MAP_2026-07-08.md`). Synthesis
+   only; verify by reading against the two cited notes.
+
+## One-paragraph result
+
+The gravity chain's one remaining free number — how readily records
+form per unit of activity — is now a measured decreasing power of the
+registration bar (exponent about -0.8 above the comparator's
+registration floor at threshold 0.2), and it is bracketed from two
+sides by phenomenology in the coupled toy: large values fossilize and
+pin everything (nothing could move), small values leave no trail; the
+two scales sit four decades apart, so the window is wide open and the
+requirement that bodies move FORCES sparse deposition — the sparsity
+assumption of the season synthesis is now exhibited, not assumed.
+
+## Deliberately not done
+
+No formation rule chosen; no registration threshold chosen; no axiom
+or primitive proposals (owner instruction: clarity items only if
+absolutely blocking). The block01/block02 kappas are the same dial in
+two devices, cited for meaning, not numerically bridged.
+
+## Named successor (not commissioned)
+
+Derive the registration bar from the dynamics-form record-formation
+mechanism (redundant-imprint records). That is the last substantive
+assumption in the gravity chain; if it falls, the chain runs from the
+axioms to universal fall with only declared comparator devices left.
+
+## Weaving proposals (for review lane, not applied)
+
+- The season synthesis (#5081) could cite the constraint map as the
+  quantitative closure of its sparsity discussion.
+- The frozen-star and merger notes (#5084, #5086) could cite the
+  mobility bound as the reason astrophysical bodies sit in the sparse
+  regime.

--- a/.claude/science/physics-loops/record-deposition-rate/STATE.yaml
+++ b/.claude/science/physics-loops/record-deposition-rate/STATE.yaml
@@ -22,10 +22,8 @@ success_bar: >
   kappa(threshold) measured with declared proxies; both phenomenological
   handles expressed as bounds on one constant; honest statement of what
   remains free. No formation rule chosen.
-current_block: block02 shipped (PR #5085); block03 (constraint note +
-  close) remains
-current_branch: physics-loop/record-deposition-rate-block02-20260708
-  (base = collapse-merger-comparator-block01, which holds the engine)
+current_block: CLOSED (block03 constraint map shipped, PR #5087)
+current_branch: physics-loop/record-deposition-rate-block03-20260708
 worktree: /Users/jonBridger/tp-matter-mass-wep
 imports: activity/distinguishability proxies as declared readout devices
   (QD bridge remains a named premise); comparators by citation.
@@ -44,7 +42,14 @@ block02_result: >
   deposit-displace ratchet mode declared. Worker drafts failed closed on
   the engine's bare-product deposition probability; engine fixed
   (Poisson conversion) on the collapse-merger-comparator-block01 branch.
-next_exact_action: block03 — constraint note tying kappa(theta), the
-  sparse window, and the mobility bound into one owner-readable
-  statement; then campaign close + handoff.
+block03_result: >
+  PR #5087. Constraint map (owner surface, plain language):
+  docs/DEPOSITION_CONSTANT_CONSTRAINT_MAP_2026-07-08.md — the one free
+  number, the measured curve above the registration floor, the
+  four-decade two-sided bracket, what would pin it (derive the
+  registration bar from the dynamics-form record mechanism, or anchor
+  one number empirically and predict the rest).
+next_exact_action: none — campaign closed. Named successor: derive the
+  registration bar (the record-formation bridge) from the dynamics-form
+  mechanism; not commissioned.
 stop_condition_hit: none

--- a/docs/DEPOSITION_CONSTANT_CONSTRAINT_MAP_2026-07-08.md
+++ b/docs/DEPOSITION_CONSTANT_CONSTRAINT_MAP_2026-07-08.md
@@ -1,0 +1,89 @@
+# The Deposition Constant -- What Is Now Measured, What Brackets It, What Would Pin It
+
+**Date:** 2026-07-08 (closing 2026-07-09)
+**Type:** constraint map (synthesis of cited results; no new measurement)
+**Claim type:** synthesis
+**Status authority:** independent audit lane only, sets no audit status.
+**Sources:**
+[`docs/DEPOSITION_PER_ACTIVITY_KAPPA_BOUNDED_NOTE_2026-07-08.md`](DEPOSITION_PER_ACTIVITY_KAPPA_BOUNDED_NOTE_2026-07-08.md),
+[`docs/OSSIFICATION_MOBILITY_TRANSLATION_BOUNDED_NOTE_2026-07-08.md`](OSSIFICATION_MOBILITY_TRANSLATION_BOUNDED_NOTE_2026-07-08.md),
+[`docs/GRAVITY_CHAIN_CLOSURE_SEASON_SYNTHESIS_2026-07-08.md`](GRAVITY_CHAIN_CLOSURE_SEASON_SYNTHESIS_2026-07-08.md)
+
+## The one free number
+
+The gravity chain (energy makes records, records slow clocks, slow
+clocks make things fall) is closed as derivation up to the formation
+rate: HOW OFTEN a record forms per unit of local activity. The axioms
+say records form, one per site, permanently; they do not say how
+readily. Everything about gravity's strength in this framework now
+hangs on that single number -- the deposition constant. This campaign
+measured what can be measured about it without choosing a formation
+rule, and mapped what brackets it.
+
+## What is measured
+
+1. **The constant as a function of the registration bar.** If
+   registration means "a site's local state has become distinguishable
+   from the background by at least some threshold", then the deposition
+   constant is a measured, decreasing power of that threshold (exponent
+   about -0.8 in the comparator), once the background entanglement the
+   interacting ground state already carries is subtracted. Below a
+   threshold of about 0.2 the comparator never goes quiet -- everything
+   registers everywhere, endlessly. At and above 0.2 registration is a
+   sparse, transient event. So the registration bar has a floor, and
+   above that floor the constant is a lawful measured curve, not a free
+   function.
+2. **The two-sided bracket from phenomenology.** In the coupled toy,
+   sweeping the constant across five decades:
+   - Too large, and nothing can move: a body pins itself by its own
+     deposits (at 1e-3 in toy units a driven body travels 13 sites of a
+     200-site course) and a stationary body fossilizes.
+   - Small enough, and bodies cross freely leaving no permanent trail
+     (at 1e-6: full crossing, zero trail).
+   - The two scales are FOUR DECADES apart: the largest
+     mobility-compatible value sits at 1e-6, the smallest value that
+     visibly fossilizes a resting body within the run sits at 1e-2.
+   The window between "the universe's bodies can move" and "gravity's
+   records accumulate at all" is wide open, and the requirement that
+   bodies move FORCES sparse deposition -- the sparsity the season's
+   synthesis had to assume is now exhibited as the mobile regime of the
+   same constant.
+3. **The extremes are the right ones.** The same toy, at the same
+   constant, collapses a dense blob into a frozen star (husk + bound
+   shell + slowed boundary clocks), merges two of them by bridging with
+   an exact never-shrinking-husk law, and leaves permanent sparse
+   record shells with permanent clock offsets in the far field -- the
+   gravitational-memory-like imprint. None of that required tuning the
+   constant to a special value; it required only being inside the
+   window.
+
+## What is NOT chosen
+
+No formation rule. No registration threshold. No new axiom content and
+no primitive registration (per the owner's standing instruction:
+clarity items only if absolutely blocking -- nothing here blocks). The
+constant's absolute value in physical units is open.
+
+## What would pin the number
+
+- **Derive the registration bar.** The dynamics-form work already
+  contains a record-formation mechanism (states become records when
+  their imprint on the surroundings is redundant). Deriving the
+  threshold from that mechanism -- rather than sweeping it -- is the
+  named next campaign, and it is the last substantive assumption in
+  the gravity chain.
+- **Or anchor it empirically.** One number (for instance matching the
+  observed strength of gravity) fixes the constant; the framework then
+  PREDICTS the trail/memory amplitudes and the fossilization scale with
+  nothing left to adjust. The falsifiable branch stays falsifiable:
+  heavy deposition means scalar-memory-like trails that current
+  observation does not see.
+
+## Boundaries
+
+Comparator units throughout; the block01 threshold-sweep constant and
+the block02 toy-sweep constant are the same physical dial measured in
+two different devices, cited for meaning and not numerically bridged.
+The d = 1 wall caveat (one record blocks a line completely) makes the
+toy's mobility bound the harshest case; more dimensions widen the
+window, they do not close it.


### PR DESCRIPTION
## What this PR contains

Block03 (final) of the record-deposition-rate campaign: the owner-readable constraint map plus the campaign close.

- `docs/DEPOSITION_CONSTANT_CONSTRAINT_MAP_2026-07-08.md` — synthesis of the two measurement blocks, plain language, no new measurement
- Pack STATE (CLOSED) + HANDOFF with review order and verification commands

## The map in one paragraph

The gravity chain's one remaining free number — how readily records form per unit of activity — is now a measured decreasing power of the registration bar (exponent ~ -0.8 above the registration floor at threshold 0.2, block01), and it is bracketed from two sides by phenomenology (block02): large values fossilize and pin everything, small values leave no trail, and the two scales sit four decades apart. The window is wide open, and the requirement that bodies move forces sparse deposition — the season synthesis's sparsity assumption is exhibited, not assumed.

## Deliberately not done

No formation rule chosen; no registration threshold chosen; no axiom or primitive proposals (owner instruction: clarity items only if absolutely blocking). The named successor campaign — derive the registration bar from the dynamics-form record-formation mechanism — is banked in the HANDOFF, not commissioned.

## Verify

Synthesis only: check the numbers against `docs/DEPOSITION_PER_ACTIVITY_KAPPA_BOUNDED_NOTE_2026-07-08.md` (#5082) and `docs/OSSIFICATION_MOBILITY_TRANSLATION_BOUNDED_NOTE_2026-07-08.md` (#5085).

Sets no audit status; independent audit still required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)