### PR TITLE
fix(record-front): platform-stable witnesses via basis-invariant marginal

### DIFF
--- a/docs/RECORD_FORMATION_FRONT_IS_THE_DOMAIN_WALL_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-05.md
+++ b/docs/RECORD_FORMATION_FRONT_IS_THE_DOMAIN_WALL_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-05.md
@@ -48,20 +48,31 @@ The runner verifies:
 
 The runner first builds the same finite operator in two independent ways:
 one vectorized construction and one explicit block assembly. They agree at
-the operator level:
+the operator level; the agreement magnitudes are pure rounding noise, so the
+runner reports them as bound checks:
 
-- `max|theta_A-theta_B| = 2.220e-16`
-- `||H_A-H_B||_F = 2.683e-15`
+- `max|theta_A-theta_B| < 1e-14` (satisfied)
+- `||H_A-H_B||_F < 1e-12` (satisfied)
+
+At the spatial momentum used, the finite operator is exactly
+sigma-degenerate, so the eigensolver's basis inside the low edge doublet is
+BLAS/LAPACK-build-dependent. All localization witnesses below are therefore
+computed from the basis-invariant two-state subspace marginal (the site
+diagonal of the rank-2 low-subspace projector): peak sites are reported
+tie-aware (every site within relative margin `1e-10` of the marginal
+maximum; measured ties sit at `<= 5e-14` and resolved neighbors at
+`>= 1.8e-8`), and the exponential tail is fitted from the deterministic
+anchor site (the tie site nearest the occupancy midpoint).
 
 The measured front-width table is:
 
-| width `w` | gradient at front | midpoint site | peak sites | chirality | probability `xi` | fit `R^2` |
+| width `w` | gradient at front | midpoint site | peak sites (tie-aware) | chirality | probability `xi` | fit `R^2` |
 |---:|---:|---:|---|---|---:|---:|
-| 0.75 | +0.870062 | 32 | `[31, 31]` | `[-1, -1]` | 0.750973 | 0.995061 |
-| 1.5 | +0.582783 | 32 | `[31, 32]` | `[-1, -1]` | 0.771490 | 0.991982 |
-| 3 | +0.321513 | 32 | `[32, 32]` | `[-1, -1]` | 0.780902 | 0.994960 |
-| 5 | +0.197375 | 32 | `[32, 32]` | `[-1, -1]` | 0.785808 | 0.994213 |
-| 8 | +0.124350 | 32 | `[32, 32]` | `[-1, -1]` | 0.818263 | 0.991020 |
+| 0.75 | +0.870062 | 32 | `[31, 32]` | `[-1, -1]` | 0.723996 | 0.999958 |
+| 1.5 | +0.582783 | 32 | `[31, 32]` | `[-1, -1]` | 0.736150 | 0.999235 |
+| 3 | +0.321513 | 32 | `[31, 32]` | `[-1, -1]` | 0.780902 | 0.994960 |
+| 5 | +0.197375 | 32 | `[32]` | `[-1, -1]` | 0.785808 | 0.994213 |
+| 8 | +0.124350 | 32 | `[32]` | `[-1, -1]` | 0.818263 | 0.991020 |
 
 The chirality flip check at `w=3` gives:
 
@@ -81,14 +92,17 @@ gap_full  = 1.000000000000
 The projected Weyl-cone check gives:
 
 ```text
-max projected-velocity Clifford anticommutator error = 1.256e-15
+max projected-velocity Clifford anticommutator error < 1e-10 (bound check)
 projected velocity eigenvalues = [-1,+1] for each of the three Cl(3,0) axes
 ```
 
 All quantities above are computed from diagonalizing the finite operator and
 projecting inside the measured low eigenspace. The chirality is measured as an
 expectation value of the record-time extended chirality operator; it is not
-inserted as a per-site Cl(3,0) chirality.
+inserted as a per-site Cl(3,0) chirality. Rounding-noise magnitudes (the
+construction agreements and the projected anticommutator error) are reported
+as satisfied bounds rather than digits because their trailing digits are
+BLAS-build-dependent.
 
 ## What Is Shown
 

--- a/logs/runner-cache/record_formation_front_chiral_edge_2026_07_05.txt
+++ b/logs/runner-cache/record_formation_front_chiral_edge_2026_07_05.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/record_formation_front_chiral_edge_2026_07_05.py
-runner_sha256: 4e837e9b9f1a2e278b37e9b6a378ba96c054533bb7ec5b80f415aa2d2ba09656
+runner_sha256: 764430bfb0d8b406052f1fe9ba022dbbfc775fcfde5bab18284e1018d8ff2e27
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.31
+elapsed_sec: 0.46
 status: ok
 ----- stdout -----
 
@@ -11,18 +11,18 @@ status: ok
 0. Cl(3,0) and independent construction cross-check
 ========================================================================================
 PASS: Pauli generators realize the Cl(3,0) spatial algebra
-PASS: two independent occupancy constructions agree  (max|theta_A-theta_B|=2.220e-16)
-PASS: two independent Hamiltonian constructions agree  (||H_A-H_B||_F=2.683e-15)
+PASS: two independent occupancy constructions agree  (max|theta_A-theta_B| < 1e-14: True)
+PASS: two independent Hamiltonian constructions agree  (||H_A-H_B||_F < 1e-12: True)
 
 ========================================================================================
 1. Formation front localizes a chiral edge across front widths
 ========================================================================================
-PASS: front width w=0.75: edge is light, localized at occupancy midpoint, and chiral  (grad=+0.870062, midpoint_s=32, peaks=[31, 31], chi=[-1.0, -1.0], prob_xi=0.750973, R2=0.995061)
-PASS: front width w=1.5: edge is light, localized at occupancy midpoint, and chiral  (grad=+0.582783, midpoint_s=32, peaks=[32, 31], chi=[-1.0, -1.0], prob_xi=0.736150, R2=0.999235)
-PASS: front width w=3: edge is light, localized at occupancy midpoint, and chiral  (grad=+0.321513, midpoint_s=32, peaks=[32, 32], chi=[-1.0, -1.0], prob_xi=0.780902, R2=0.994960)
-PASS: front width w=5: edge is light, localized at occupancy midpoint, and chiral  (grad=+0.197375, midpoint_s=32, peaks=[32, 32], chi=[-1.0, -1.0], prob_xi=0.785808, R2=0.994213)
-PASS: front width w=8: edge is light, localized at occupancy midpoint, and chiral  (grad=+0.124350, midpoint_s=32, peaks=[32, 32], chi=[-1.0, -1.0], prob_xi=0.818263, R2=0.991020)
-PASS: localization length is measured for a range of front widths  (xi_prob(w)=0.75:0.750973, 1.5:0.736150, 3:0.780902, 5:0.785808, 8:0.818263)
+PASS: front width w=0.75: edge is light, localized at occupancy midpoint, and chiral  (grad=+0.870062, midpoint_s=32, peaks=[31, 32], chi=[-1.0, -1.0], prob_xi=0.723996, R2=0.999958)
+PASS: front width w=1.5: edge is light, localized at occupancy midpoint, and chiral  (grad=+0.582783, midpoint_s=32, peaks=[31, 32], chi=[-1.0, -1.0], prob_xi=0.736150, R2=0.999235)
+PASS: front width w=3: edge is light, localized at occupancy midpoint, and chiral  (grad=+0.321513, midpoint_s=32, peaks=[31, 32], chi=[-1.0, -1.0], prob_xi=0.780902, R2=0.994960)
+PASS: front width w=5: edge is light, localized at occupancy midpoint, and chiral  (grad=+0.197375, midpoint_s=32, peaks=[32], chi=[-1.0, -1.0], prob_xi=0.785808, R2=0.994213)
+PASS: front width w=8: edge is light, localized at occupancy midpoint, and chiral  (grad=+0.124350, midpoint_s=32, peaks=[32], chi=[-1.0, -1.0], prob_xi=0.818263, R2=0.991020)
+PASS: localization length is measured for a range of front widths  (xi_prob(w)=0.75:0.723996, 1.5:0.736150, 3:0.780902, 5:0.785808, 8:0.818263)
 
 ========================================================================================
 2. Formation-arrow sign flip
@@ -38,7 +38,7 @@ PASS: uniform empty/full occupancy has no light edge and stays gapped  (gap_empt
 ========================================================================================
 4. Projected Cl(3,0) Weyl cone at the front
 ========================================================================================
-PASS: projected edge velocities obey the Pauli Clifford algebra  (max_anticommutator_error=1.308e-15, velocity_eigs=[array([-1.,  1.]), array([-1.,  1.]), array([-1.,  1.])])
+PASS: projected edge velocities obey the Pauli Clifford algebra  (max_anticommutator_error < 1e-10: True, velocity_eigs=[array([-1.,  1.]), array([-1.,  1.]), array([-1.,  1.])])
 
 TOTAL: PASS=13 FAIL=0
 

--- a/scripts/record_formation_front_chiral_edge_2026_07_05.py
+++ b/scripts/record_formation_front_chiral_edge_2026_07_05.py
@@ -12,6 +12,15 @@ anti-front as an opposite-chirality contrast.
 
 All physical claims are measured from diagonalizing the finite operator.
 No randomness; numpy only.
+
+Printed witness values are restricted to platform-stable quantities. At the
+spatial momentum used here the operator is exactly sigma-degenerate, so the
+eigensolver's basis inside the low doublet — and the argmax of a two-site
+peak tie — are BLAS/LAPACK-build-dependent. Localization witnesses are
+therefore computed from the basis-invariant two-state subspace marginal with
+tie-aware peak reporting and a deterministic tail-fit anchor (the tie site
+nearest the occupancy midpoint), and pure rounding-noise magnitudes are
+printed as bound checks rather than digits.
 """
 
 from __future__ import annotations
@@ -203,32 +212,46 @@ def localize_in_low_subspace(
     return out
 
 
-def fit_tail(profile: np.ndarray, peak: int, max_steps: int) -> tuple[float, float, float, int]:
+def tie_peak_sites(profile: np.ndarray, rel_tol: float = 1e-10) -> list[int]:
+    """Sites within rel_tol of the profile maximum.
+
+    Measured on the marginals used here: exact-degeneracy ties sit at
+    relative margins <= 5e-14 while genuinely resolved neighbors sit at
+    >= 1.8e-8, so 1e-10 sits over three orders above the former and over
+    two orders below the latter.
+    """
+    peak_value = float(np.max(profile))
+    return [int(s) for s in np.nonzero(profile >= (1.0 - rel_tol) * peak_value)[0]]
+
+
+def fit_tail(profile: np.ndarray, anchors: list[int], max_steps: int) -> tuple[float, float, float, int, int]:
+    """Best-R^2 exponential tail fit over the deterministic anchor candidates."""
     best = None
     length = len(profile)
-    for direction in (+1, -1):
-        xs = []
-        ys = []
-        for d in range(0, max_steps + 1):
-            value = float(profile[(peak + direction * d) % length])
-            if value > 1e-14:
-                xs.append(float(d))
-                ys.append(np.log(value))
-        if len(xs) < 6:
-            continue
-        slope, intercept = np.polyfit(xs, ys, 1)
-        fitted = slope * np.array(xs) + intercept
-        denom = float(np.sum((np.array(ys) - np.mean(ys)) ** 2))
-        r2 = 1.0 if denom < 1e-30 else 1.0 - float(np.sum((np.array(ys) - fitted) ** 2)) / denom
-        candidate = (r2, len(xs), slope, direction)
-        if best is None or candidate[0] > best[0]:
-            best = candidate
+    for anchor in sorted(anchors):
+        for direction in (+1, -1):
+            xs = []
+            ys = []
+            for d in range(0, max_steps + 1):
+                value = float(profile[(anchor + direction * d) % length])
+                if value > 1e-14:
+                    xs.append(float(d))
+                    ys.append(np.log(value))
+            if len(xs) < 6:
+                continue
+            slope, intercept = np.polyfit(xs, ys, 1)
+            fitted = slope * np.array(xs) + intercept
+            denom = float(np.sum((np.array(ys) - np.mean(ys)) ** 2))
+            r2 = 1.0 if denom < 1e-30 else 1.0 - float(np.sum((np.array(ys) - fitted) ** 2)) / denom
+            candidate = (r2, slope, anchor, direction)
+            if best is None or candidate[0] > best[0]:
+                best = candidate
     if best is None:
-        return float("nan"), float("nan"), float("nan"), 0
-    r2, _count, slope, direction = best
+        return float("nan"), float("nan"), float("nan"), -1, 0
+    r2, slope, anchor, direction = best
     probability_xi = -1.0 / slope if slope < 0.0 else float("inf")
     amplitude_xi = 2.0 * probability_xi
-    return probability_xi, amplitude_xi, r2, direction
+    return probability_xi, amplitude_xi, r2, anchor, direction
 
 
 def analyze_front(
@@ -251,12 +274,15 @@ def analyze_front(
     localized = localize_in_low_subspace(evecs, low_indices, sites, 2)
     chirality_operator = np.kron(np.eye(length, dtype=complex), np.kron(TAU_Z, I2))
     chiralities = [float(np.vdot(psi, chirality_operator @ psi).real) for _w, psi in localized]
-    profiles = [site_profile(psi, length) for _w, psi in localized]
-    peaks = [int(np.argmax(profile)) for profile in profiles]
+    # Basis-invariant witness: the summed two-state site marginal (the diagonal
+    # of the rank-2 subspace projector), not either individual eigenvector.
+    marginal = np.sum([site_profile(psi, length) for _w, psi in localized], axis=0)
+    peaks = tie_peak_sites(marginal)
     midpoint = midpoint_near(theta, center, radius)
     gradient = float(theta[(center + 1) % length] - theta[(center - 1) % length])
-    probability_xi, amplitude_xi, r2, tail_dir = fit_tail(
-        profiles[0], peaks[0], max(12, int(np.ceil(4.0 * width)))
+    anchor = min(peaks, key=lambda s: (abs(s - midpoint), s))
+    probability_xi, amplitude_xi, r2, _fit_anchor, tail_dir = fit_tail(
+        marginal, [anchor], max(12, int(np.ceil(4.0 * width)))
     )
     return {
         "theta": theta,
@@ -266,6 +292,7 @@ def analyze_front(
         "support": [w for w, _psi in localized],
         "chiralities": chiralities,
         "peaks": peaks,
+        "anchor": anchor,
         "midpoint": midpoint,
         "gradient": gradient,
         "probability_xi": probability_xi,
@@ -308,15 +335,17 @@ def main() -> int:
     theta_b = occupancy_profile_b(length, front, anti_front, 3.0)
     h_a = hamiltonian_a(theta_a, p=(0.17, 0.11, -0.07))
     h_b = hamiltonian_b(theta_b, p=(0.17, 0.11, -0.07))
+    theta_diff = float(np.max(np.abs(theta_a - theta_b)))
+    h_diff = fro_norm(h_a - h_b)
     check(
         "two independent occupancy constructions agree",
-        float(np.max(np.abs(theta_a - theta_b))) < 1e-14,
-        f"max|theta_A-theta_B|={float(np.max(np.abs(theta_a - theta_b))):.3e}",
+        theta_diff < 1e-14,
+        f"max|theta_A-theta_B| < 1e-14: {theta_diff < 1e-14}",
     )
     check(
         "two independent Hamiltonian constructions agree",
-        fro_norm(h_a - h_b) < 1e-12,
-        f"||H_A-H_B||_F={fro_norm(h_a - h_b):.3e}",
+        h_diff < 1e-12,
+        f"||H_A-H_B||_F < 1e-12: {h_diff < 1e-12}",
     )
 
     section("1. Formation front localizes a chiral edge across front widths")
@@ -344,7 +373,7 @@ def main() -> int:
                 result["gradient"],
                 result["midpoint"],
                 result["peaks"],
-                [round(c, 12) for c in result["chiralities"]],
+                [round(c, 6) for c in result["chiralities"]],
                 result["probability_xi"],
                 result["r2"],
             ),
@@ -413,11 +442,14 @@ def main() -> int:
     section("4. Projected Cl(3,0) Weyl cone at the front")
     max_velocity_error, velocities = projected_velocity_errors(forward["states"], length)
     velocity_eigs = [np.linalg.eigvalsh(v) for v in velocities]
+    algebra_ok = max_velocity_error < 1e-10 and all(
+        np.allclose(eigs, [-1.0, 1.0], atol=1e-10) for eigs in velocity_eigs
+    )
+    printed_eigs = [np.round(eigs, 9) for eigs in velocity_eigs]
     check(
         "projected edge velocities obey the Pauli Clifford algebra",
-        max_velocity_error < 1e-10
-        and all(np.allclose(eigs, [-1.0, 1.0], atol=1e-10) for eigs in velocity_eigs),
-        f"max_anticommutator_error={max_velocity_error:.3e}, velocity_eigs={velocity_eigs}",
+        algebra_ok,
+        f"max_anticommutator_error < 1e-10: {max_velocity_error < 1e-10}, velocity_eigs={printed_eigs}",
     )
 
     print(f"\nTOTAL: PASS={PASS} FAIL={FAIL}")


### PR DESCRIPTION
## Summary

Conformance repair for the `audited_failed` row `record_formation_front_is_the_domain_wall_free_field_bounded_theorem_note_2026-07-05` (audit 2026-07-09T06:52). The audit lane's exact finding:

> The finite-model runner completes and supports the qualitative edge/localization/chirality checks, but the source note's computed witness table is stale relative to the current runner output. In particular, the w=1.5 localization row and the projected-velocity anticommutator error no longer match the executed runner.

## Diagnosis

The mismatch is not a transcription slip — the flagged witnesses are **platform-nondeterministic**. At the spatial momentum used, the finite operator is exactly sigma-degenerate, so the eigensolver's basis inside the low edge doublet is arbitrary, and the two-site peak is an exact tie: measured relative margins between sites 31/32 are <= 5e-14 for w=0.75, 1.5, **and 3** (the w=3 cross-build agreement in the old table was luck), while resolved neighbors sit at >= 1.8e-8. The per-state argmax peaks, the per-state tail-fit xi/R^2, and the ~1e-15 anticommutator digits are therefore BLAS/LAPACK-build-dependent; the note and the committed cache were computed on different builds.

## Changes

- `scripts/record_formation_front_chiral_edge_2026_07_05.py` — witnesses restricted to platform-stable quantities: localization computed from the basis-invariant two-state subspace marginal (site diagonal of the rank-2 low-subspace projector); tie-aware peak reporting (rel margin 1e-10, sitting >3 orders above measured ties and >2 orders below measured resolved margins); deterministic tail-fit anchor (tie site nearest the occupancy midpoint); rounding-noise magnitudes (construction agreements, anticommutator error) printed as bound checks rather than digits.
- `logs/runner-cache/record_formation_front_chiral_edge_2026_07_05.txt` — regenerated via `scripts/runner_cache.py` (new runner SHA pinned, exit 0).
- `docs/RECORD_FORMATION_FRONT_IS_THE_DOMAIN_WALL_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-05.md` — witness table conformed to the hardened deterministic output; determinism discipline stated above the table; anticommutator line in bound form. Claim scope, What Is Shown/Not Shown, and dependencies unchanged.

## What is and is not claimed

Science conclusions are unchanged: light chiral edge localized at the occupancy midpoint across all five widths, chirality flips with the formation-gradient sign, uniform bulk stays gapped, projected Cl(3,0) Weyl cone. The w=3/5/8 xi values are identical to the old table (their anchor was already the midpoint site); w=0.75/1.5 xi values changed because the anchor is now deterministic rather than eigensolver-dependent. This PR sets no audit status; re-grading belongs to the independent audit lane. Ledger dependents (`domain_wall_edge_anomaly_inflow...` and `domain_wall_edge_content_vs_sm...`) quote none of the changed digits.

## Test Plan

- [x] Own runner re-run on this machine: `TOTAL: PASS=13 FAIL=0`
- [x] Cache regenerated through the canonical `runner_cache.py` mechanism; header SHA matches the hardened runner
- [x] Tie/resolved margins measured per width (probe) to justify the 1e-10 tolerance
- [x] Repo swept for other quotes of the stale digits: only the audit-lane-owned `AUDIT_LEDGER.md` carries them (not touched, per lane ownership); other grep hits are coincidental same-magnitude noise in unrelated caches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit repair target (verbatim)

> After refreshing the computed witness table/cache or aligning the runner, re-check only the supplied-map finite free-field diagnostic boundary; do not treat the repaired row as deriving record-production dynamics, the occupancy-to-mass bridge, gauge coupling, anomaly inflow, or Standard Model content.