### PR TITLE
[physics-loop] registration-bar-block03 — the bar's shape is forced; its location is a d≥2 measurement, not a dial; campaign close

### DIFF
--- a/.claude/science/physics-loops/registration-bar/HANDOFF.md
+++ b/.claude/science/physics-loops/registration-bar/HANDOFF.md
@@ -1,0 +1,61 @@
+# registration-bar — campaign handoff (CLOSED 2026-07-09)
+
+## PRs, in review order
+
+1. **#5089** block01 — redundancy-onset criterion; BAR-NOT-PINNED with
+   the d=1 geometric obstruction measured. Base =
+   record-deposition-rate-block03.
+   Verify: `python3 scripts/registration_redundancy_onset_2026_07_09.py`
+   (exit 1) and
+   `python3 scripts/registration_bar_parameter_probes_2026_07_09.py`
+   (exit 0); diff both against their caches.
+2. **#5090** block02 — activity→information; necessity exhibited,
+   BOUND-PARTIAL.
+   Verify: `python3 scripts/activity_information_bound_2026_07_09.py`
+   (exit 1); diff against cache.
+3. **#5091** block03 — derivation synthesis (owner surface) + close.
+   Synthesis only; check against the two notes above and the cited
+   June notes.
+
+## One-paragraph result
+
+The registration bar's SHAPE is not free: reading "record" the way the
+dynamics-form chain already does, the Record axiom's clauses force
+registration to be redundancy onset (exactly-one → near-perfect
+discrimination; permanence → at least two independent registers;
+additivity → the plateau). The comparator exhibited the pieces it can:
+the lawful pointer is forced by pointer non-demolition (occupation
+fails measurably; cell charge with Gauss-law link registers works —
+the constraint structure is the copying mechanism); one register
+certifies at 88% of perfect; and no activity means no information,
+exactly. What d=1 cannot do — measured across two decades of coupling
+and an order of magnitude in mass — is host TWO independent registers:
+the two boundary links are a Markov blanket, so permanence-grade
+redundancy requires branching geometry. The Lattice axiom's Z^3
+supplies exactly what the Record axiom's permanence clause demands;
+the numerical bar location is now a d>=2 measurement waiting to be
+made, not a free dial.
+
+## Premise-ledger effect (the campaign's point)
+
+The season's bridge assumption ("activity is record-formation
+opportunity") is reduced to: (i) the one record-reading convention the
+whole framework already carries, (ii) exhibited necessity, (iii) the
+measured deposition constant as the rate normalization. One shared
+convention instead of an independent premise.
+
+## Named successor (not commissioned)
+
+Minimal d=2 registration comparator: smallest branching geometry;
+predicts redundancy onset occurs, the effective threshold is
+tolerance-insensitive, and its location can be checked against the
+deposition-sparse window. Each prediction falsifiable. Note the d=1
+negative also calibrates every d=1 record comparator in the repo:
+their records are supplied primitives, not formed registers, exactly
+as their notes declare.
+
+## Deliberately not done
+
+No formation rule chosen; no threshold value chosen; no axiom content
+or primitive registration proposed (owner standing instruction). The
+June no-go's wall respected throughout.

--- a/.claude/science/physics-loops/registration-bar/HANDOFF.md
+++ b/.claude/science/physics-loops/registration-bar/HANDOFF.md
@@ -46,13 +46,17 @@ convention instead of an independent premise.
 
 ## Named successor (not commissioned)
 
-Minimal d=2 registration comparator: smallest branching geometry;
-predicts redundancy onset occurs, the effective threshold is
-tolerance-insensitive, and its location can be checked against the
-deposition-sparse window. Each prediction falsifiable. Note the d=1
-negative also calibrates every d=1 record comparator in the repo:
-their records are supplied primitives, not formed registers, exactly
-as their notes declare.
+d=3 registration comparator — the framework's own Z^3 is the target
+(owner reminder 2026-07-09): the bar location can be
+dimension-dependent, so a d=2 measurement would import a fresh gap
+rather than close one. d=2 is admissible only as a declared stepping
+stone for method development, never as the bar's source. Predictions
+at d=3: redundancy onset occurs; the effective threshold is
+tolerance-insensitive; its location can be checked against the
+deposition-sparse window. Each falsifiable. Note the d=1 negative also
+calibrates every d=1 record comparator in the repo: their records are
+supplied primitives, not formed registers, exactly as their notes
+declare.
 
 ## Deliberately not done
 

--- a/.claude/science/physics-loops/registration-bar/STATE.yaml
+++ b/.claude/science/physics-loops/registration-bar/STATE.yaml
@@ -36,18 +36,41 @@ success_bar: >
   does not pin the bar (which sharpens the no-go), filed with N1-N8.
   No new axiom content; no primitive registration (owner standing
   instruction).
-current_block: block01+block02 workers launching in parallel (pinned
-  shared conventions: pointer = site occupation/charge basis; fragments
-  = contiguous disjoint site blocks; Holevo content per the 2026-06-05
-  record-formation note)
-current_branch: physics-loop/registration-bar-block01-20260709
-  (base = record-deposition-rate-block03, which carries the kappa
-  runner and its lineage)
+current_block: CLOSED (block03 derivation synthesis shipped with the
+  close, PR #5091)
+current_branch: physics-loop/registration-bar-block03-20260709
 worktree: /Users/jonBridger/tp-matter-mass-wep
 imports: the QD record reading + pointer-non-demolition (standing
   bounded conventions of the dynamics-form chain — cited, not
   re-derived); gauged comparator + activity conventions by citation.
 discipline: physics-loop standard; vocab_lint before commits; stop and
   write up on any axiom trigger.
-next_exact_action: review both worker drafts line-by-line
+block01_result: >
+  PR #5089. BAR-NOT-PINNED (physics outcome, exit 1): the criterion
+  SHAPE is forced (redundancy onset; R>=2 from permanence; small delta
+  from exactly-one); occupation pointer demolished (v1, confirms the
+  2026-06-05 necessity theorem in situ); lawful pointer = cell charge
+  with Gauss-law link registers (constraint structure = copying
+  mechanism); single-register certification I/H=0.88; R>=2
+  geometrically impossible in d=1 (two-boundary Markov blanket +
+  zero-mode noise; xi_reg<=1 across g 0.05-1.0, m 0.3/3.0 probes).
+block02_result: >
+  PR #5090. BOUND-PARTIAL (honest): necessity direction exhibited with
+  exact controls (stationary floor 1e-15; Fannes-Audenaert envelope
+  zero violations; excess grows from exactly zero) — no activity, no
+  opportunity. Findings kept: pointer flow rides coherence (no linear
+  activity gate exists; measured counterexample); d=1 Markov blanket
+  saturates attribution (r=0.63).
+block03_result: >
+  PR #5091. Derivation synthesis (owner surface):
+  docs/REGISTRATION_BAR_DERIVATION_SYNTHESIS_2026-07-09.md — the bar's
+  shape is forced by the Record axiom's clauses through the one shared
+  record-reading convention; necessity exhibited; rate normalization =
+  measured kappa; bar LOCATION deferred to d>=2 (named successor:
+  minimal d=2 comparator). Lattice/Record consistency exhibit: the
+  permanence clause demands the branching geometry the Z^3 axiom
+  supplies; d=1 worlds cannot host permanence-grade records.
+next_exact_action: none — campaign closed. Named successor (not
+  commissioned): minimal d=2 registration comparator (redundancy onset,
+  delta-insensitivity, bar location vs the sparse window).
 stop_condition_hit: none

--- a/.claude/science/physics-loops/registration-bar/STATE.yaml
+++ b/.claude/science/physics-loops/registration-bar/STATE.yaml
@@ -71,6 +71,9 @@ block03_result: >
   permanence clause demands the branching geometry the Z^3 axiom
   supplies; d=1 worlds cannot host permanence-grade records.
 next_exact_action: none — campaign closed. Named successor (not
-  commissioned): minimal d=2 registration comparator (redundancy onset,
-  delta-insensitivity, bar location vs the sparse window).
+  commissioned): d=3 registration comparator — the framework's Z^3 is
+  the target (owner reminder 2026-07-09; the bar location can be
+  dimension-dependent, so d=2 is a method stepping stone at most, never
+  the bar's source). Measures: redundancy onset, delta-insensitivity,
+  bar location vs the sparse window.
 stop_condition_hit: none

--- a/docs/REGISTRATION_BAR_DERIVATION_SYNTHESIS_2026-07-09.md
+++ b/docs/REGISTRATION_BAR_DERIVATION_SYNTHESIS_2026-07-09.md
@@ -87,16 +87,20 @@ free dial.
 
 ## What would settle the rest
 
-A minimal two-dimensional comparator (the smallest branching
-geometry). There, the derived criterion predicts: redundancy onset
-occurs; its effective threshold is insensitive to the tolerance choice
-(a property, not a dial); and its location can be checked against the
-deposition-sparse window that the gravity chain needs. Each of these
-is falsifiable. One dimension has already shown it cannot host the
-measurement -- that negative is load-bearing for interpreting every
-d = 1 record comparator in the repository, including this season's
-coupled toys, whose "records" are supplied primitives rather than
-formed registers, exactly as their notes declare.
+A three-dimensional comparator -- the framework's own lattice. The
+derived criterion predicts: redundancy onset occurs; its effective
+threshold is insensitive to the tolerance choice (a property, not a
+dial); and its location can be checked against the deposition-sparse
+window that the gravity chain needs. Each of these is falsifiable.
+The measurement belongs at d = 3 because the bar's location can
+depend on dimension -- a two-dimensional stand-in would trade the
+supplied threshold for a supplied dimension and close nothing; two
+dimensions are admissible only as a declared method stepping stone.
+One dimension has already shown it cannot host the measurement at
+all -- that negative is load-bearing for interpreting every d = 1
+record comparator in the repository, including this season's coupled
+toys, whose "records" are supplied primitives rather than formed
+registers, exactly as their notes declare.
 
 ## Boundaries
 

--- a/docs/REGISTRATION_BAR_DERIVATION_SYNTHESIS_2026-07-09.md
+++ b/docs/REGISTRATION_BAR_DERIVATION_SYNTHESIS_2026-07-09.md
@@ -1,0 +1,106 @@
+# The Registration Bar -- What The Axioms Force, What The Comparator Shows, What Remains
+
+**Date:** 2026-07-09
+**Type:** derivation synthesis (composes cited results; no new measurement)
+**Claim type:** synthesis
+**Status authority:** independent audit lane only, sets no audit status.
+**Sources:**
+[`docs/REGISTRATION_REDUNDANCY_ONSET_BOUNDED_NOTE_2026-07-09.md`](REGISTRATION_REDUNDANCY_ONSET_BOUNDED_NOTE_2026-07-09.md),
+[`docs/ACTIVITY_INFORMATION_BOUND_BOUNDED_NOTE_2026-07-09.md`](ACTIVITY_INFORMATION_BOUND_BOUNDED_NOTE_2026-07-09.md),
+[`docs/RECORD_FORMATION_POINTER_NON_DEMOLITION_DYNAMICS_CONSTRAINT_BOUNDED_THEOREM_NOTE_2026-06-05.md`](RECORD_FORMATION_POINTER_NON_DEMOLITION_DYNAMICS_CONSTRAINT_BOUNDED_THEOREM_NOTE_2026-06-05.md),
+[`docs/RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md`](RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md),
+[`docs/DEPOSITION_CONSTANT_CONSTRAINT_MAP_2026-07-08.md`](DEPOSITION_CONSTANT_CONSTRAINT_MAP_2026-07-08.md)
+
+## The question
+
+The gravity chain runs from the axioms to universal fall with one
+substantive assumption left: that local activity is record-formation
+opportunity, with the registration threshold swept rather than
+supplied. This campaign asked whether the threshold is actually free.
+
+## The answer in one paragraph
+
+It is not free -- its SHAPE is forced. Reading "record" the way the
+framework's dynamics work already reads it (a record is information
+about a local possibility, recoverably written into surroundings), the
+Record axiom's own clauses dictate what registration must be: the
+surroundings must discriminate EXACTLY ONE admissible possibility
+(near-perfectly, because the axiom says one, not mostly-one); the
+imprint must be held by AT LEAST TWO independent registers (because
+the axiom says permanent, and a single copy is erasable -- that
+erasure was measured in June); and the registers must add up over
+disjoint pieces (the axiom's additivity clause -- which is exactly the
+redundancy-plateau structure). Registration is redundancy onset. What
+the axioms do not supply -- and what remains honestly open -- is the
+numerical location of that onset in any particular dynamics, and the
+comparator study returned a sharp, unexpected structural reason why:
+one-dimensional worlds cannot hold permanence-grade records at all.
+
+## What the measurements established
+
+1. **The pointer is not a choice.** Try to record a quantity the
+   dynamics scrambles, and nothing registers -- measured first
+   (occupation: nothing anywhere), then explained by the June theorem
+   (a record's target must be conserved by the local dynamics while
+   the copy is written). The comparator's lawful pointer is the
+   gauge-invariant local charge, and its registers are the gauge
+   field's links: by the Gauss constraint every link registers its
+   enclosed charge. The framework's constraint structure IS the
+   copying mechanism.
+2. **One register certifies; two never do -- for a geometric reason.**
+   Certification of one register reaches 88% of perfect across every
+   probed coupling and mass. A second independent register never
+   crosses the bar, because in one dimension everything the outside
+   world knows about a local charge passes through its two boundary
+   links: distant registers are copies of the boundary registers, not
+   independent copies of the charge. Permanence-grade redundancy needs
+   branching geometry. The framework's Lattice axiom supplies three
+   dimensions; the one-dimensional comparator structurally cannot.
+   That the Record axiom's permanence clause DEMANDS the branching
+   geometry the Lattice axiom PROVIDES is, at comparator level, a
+   consistency exhibit between the two axioms -- records and the
+   lattice fit together in a way one-dimensional worlds do not permit.
+3. **No activity, no opportunity -- exactly.** On a stationary state,
+   no register anywhere gains anything (measured at numerical floor);
+   every information change respects the rigorous envelope of the
+   local state change; and information appears only after, and only
+   where, energy acts. The chain's sourcing statement -- records form
+   only where energy acts -- now has its information-theoretic half
+   exhibited with exact controls, not assumed.
+
+## The premise ledger, before and after
+
+Before: one named bridge assumption -- "activity is record-formation
+opportunity" -- carrying both a necessity claim and an implicit rate
+claim, plus a free registration threshold.
+
+After: the necessity half is exhibited (exact controls); the
+threshold's SHAPE is forced by the Record axiom's clauses through the
+same record-reading convention the dynamics-form theorem already
+carries (one shared convention for the whole framework, not two
+independent assumptions); the rate normalization is the measured
+deposition constant, not an assumption. What remains supplied: the
+record-reading convention itself (unchanged in status, load-bearing
+for dynamics and gravity alike), and the numerical bar location,
+which is now a d >= 2 measurement waiting to be made rather than a
+free dial.
+
+## What would settle the rest
+
+A minimal two-dimensional comparator (the smallest branching
+geometry). There, the derived criterion predicts: redundancy onset
+occurs; its effective threshold is insensitive to the tolerance choice
+(a property, not a dial); and its location can be checked against the
+deposition-sparse window that the gravity chain needs. Each of these
+is falsifiable. One dimension has already shown it cannot host the
+measurement -- that negative is load-bearing for interpreting every
+d = 1 record comparator in the repository, including this season's
+coupled toys, whose "records" are supplied primitives rather than
+formed registers, exactly as their notes declare.
+
+## Boundaries
+
+No formation rule chosen; no axiom content proposed; the June no-go's
+wall (the bare axioms force no formation rule) is respected -- every
+statement here is conditional on the declared record-reading
+convention, and says so.


### PR DESCRIPTION
## What this PR contains

Block03 (final) of the registration-bar campaign: the derivation synthesis (owner surface, plain language) plus the campaign close.

- `docs/REGISTRATION_BAR_DERIVATION_SYNTHESIS_2026-07-09.md` — composes the two measurement blocks with the June record-formation theorem and no-go
- Pack STATE (CLOSED) + HANDOFF with review order and verification commands

## The synthesis in one paragraph

The registration threshold the kappa campaign had to sweep is not free: under the record-reading the dynamics-form chain already carries, the Record axiom's own clauses force registration to be redundancy onset — "exactly one" forces near-perfect discrimination, "permanent" forces at least two independent registers (single copies are erasable, measured in June), "additive" is the plateau. The comparator exhibited what d=1 permits: the lawful pointer is forced by non-demolition (the constraint structure is the copying mechanism), one register certifies at 88% of perfect, and no activity means no information, exactly. What d=1 cannot host — measured, not assumed — is the second independent register: boundary links are a Markov blanket, so permanence-grade redundancy requires branching geometry. The Lattice axiom's Z³ supplies precisely what the Record axiom's permanence clause demands.

## Premise-ledger effect

The season's bridge assumption reduces to: the one shared record-reading convention + exhibited necessity + the measured deposition constant. The bar's numerical location is now a **d=3 measurement** waiting to be made — the framework's own Z³ is the target, since the bar location can be dimension-dependent and a d=2 stand-in would trade a supplied threshold for a supplied dimension (d=2 admissible only as a declared method stepping stone). Named successor, not commissioned, with three falsifiable predictions attached.

Sets no audit status; independent audit still required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)