### PR TITLE
fix(runners): platform-stable witness prints in domain-wall 07-04 runner

### DIFF
--- a/logs/runner-cache/domain_wall_chiral_edge_from_achiral_cl3_bulk_2026_07_04.txt
+++ b/logs/runner-cache/domain_wall_chiral_edge_from_achiral_cl3_bulk_2026_07_04.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/domain_wall_chiral_edge_from_achiral_cl3_bulk_2026_07_04.py
-runner_sha256: 4b9ea98fddf65db2c620d3e555ff274b2b7fbbde7d73e70d74b267817944bb61
+runner_sha256: 0cd9e9e17c8ec3fa3b363b1da4066ba235753f5a326168f545e80e3dc532f434
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.18
+elapsed_sec: 0.29
 status: ok
 ----- stdout -----
 
@@ -17,30 +17,30 @@ PASS - naive BZ-corner chiralities sum to zero  (plus=4 minus=4 sum=0)
 2. Direct Wilson removal lifts doublers but breaks chiral anticommutation
 ========================================================================================
 PASS - Wilson scalar lifts seven of the eight naive corner zeros  (corner_min_singular=[0.0, 2.0, 2.0, 4.0, 2.0, 4.0, 4.0, 6.0])
-PASS - massless embedded operator anticommutes with gamma_5  (||{gamma_5,D}||=0.000e+00)
+PASS - massless embedded operator anticommutes with gamma_5  (||{gamma_5,D}|| < 1e-12: True)
 PASS - Wilson term breaks the gamma_5 anticommutation  (||{gamma_5,D+W}||=4.000000)
 
 ========================================================================================
 3. Record-time domain wall localizes one chiral Weyl species per wall
 ========================================================================================
 PASS - domain-wall Hamiltonian is Hermitian
-PASS - periodic wall/anti-wall has four light spinor states at p=0  (light=4 max|E_light|=4.557e-09 next_gap=0.801204)
-PASS - wall-localized light rank is two spin components, i.e. one Weyl species  (window_eigs=[0.798565653441 0.798565653441 0.             0.            ])
-PASS - anti-wall-localized light rank is two spin components, i.e. one Weyl species  (window_eigs=[ 0.880610823077  0.880610823077 -0.             -0.            ])
-PASS - wall profile has exponential one-sided localization tails  (peak=15 xi_left=0.621335 xi_right=1.701298 r2=(1.000000000000,1.000000000000) antiwall_leak=9.012e-19)
-PASS - anti-wall profile has exponential one-sided localization tails  (peak=48 xi_left=1.701298 xi_right=0.621335 r2=(1.000000000000,1.000000000000) wall_leak=2.253e-17)
+PASS - periodic wall/anti-wall has four light spinor states at p=0  (light=4 max|E_light| < 1e-06: True next_gap=0.801204)
+PASS - wall-localized light rank is two spin components, i.e. one Weyl species  (window_top2=[0.798565653 0.798565653] max|window_rest| < 1e-10: True)
+PASS - anti-wall-localized light rank is two spin components, i.e. one Weyl species  (window_top2=[0.880610823 0.880610823] max|window_rest| < 1e-10: True)
+PASS - wall profile has exponential one-sided localization tails  (peak=15 xi_left=0.621335 xi_right=1.701298 min_r2 > 0.999999: True antiwall_leak < 1e-12: True)
+PASS - anti-wall profile has exponential one-sided localization tails  (peak=48 xi_left=1.701298 xi_right=0.621335 min_r2 > 0.999999: True wall_leak < 1e-12: True)
 PASS - wall chirality is a definite eigenvalue fixed by sign(M)  (<chi_edge>=1.000000000000, sign(M)=1)
 PASS - anti-wall chirality is opposite  (<chi_edge>=-1.000000000000)
-PASS - wall projected spatial velocities form one Cl(3,0) Weyl cone  (square_err=1.256e-15 anticomm_err=9.421e-16 handedness=-1)
+PASS - wall projected spatial velocities form one Cl(3,0) Weyl cone  (square_err < 1e-10: True anticomm_err < 1e-10: True handedness=-1)
 PASS - anti-wall projected Weyl cone has opposite handedness  (wall_hand=-1 anti_hand=1)
 PASS - flipping M flips wall and anti-wall chiralities  (M=-0.8: wall_chi=-1.000000000000 anti_chi=1.000000000000)
 
 ========================================================================================
 4. Bulk gap and index/count contrasts
 ========================================================================================
-PASS - only the physical p=0 corner carries light domain-wall modes  (light_counts=[4, 0, 0, 0, 0, 0, 0, 0] min_gaps=[4.556685656800885e-09, 1.2076871085066714, 1.2076871085066743, 3.205673785991848, 1.2076871085066743, 3.2056737859918476, 3.2056737859918485, 5.205188287678513])
-PASS - uniform record-time bulk is gapped by |M| with no edge light modes  (uniform_gaps=[0.7999999999999995, 0.7999999999999988])
-PASS - wall/anti-wall pair has one species per wall and net zero chirality on the torus  (species_count=2 walls=2 net_edge_chi=-4.441e-16 net_handedness=2.665e-15)
+PASS - only the physical p=0 corner carries light domain-wall modes  (light_counts=[4, 0, 0, 0, 0, 0, 0, 0] min_gap_p0 < 1e-06: True heavy_min_gaps=[1.207687109 1.207687109 3.205673786 1.207687109 3.205673786 3.205673786 5.205188288])
+PASS - uniform record-time bulk is gapped by |M| with no edge light modes  (uniform_gaps=[0.8 0.8] max|gap - |M|| < 1e-10: True)
+PASS - wall/anti-wall pair has one species per wall and net zero chirality on the torus  (species_count=2 walls=2 |net_edge_chi| < 1e-10: True |net_handedness| < 1e-10: True)
 
 TOTAL: PASS=19 FAIL=0
 

--- a/scripts/domain_wall_chiral_edge_from_achiral_cl3_bulk_2026_07_04.py
+++ b/scripts/domain_wall_chiral_edge_from_achiral_cl3_bulk_2026_07_04.py
@@ -266,12 +266,12 @@ wilson_anticom_norm = norm(anticommutator(gamma_5, Dw_test))
 check(
     "Wilson scalar lifts seven of the eight naive corner zeros",
     zero_after_wilson == 1 and corner_singular_mins[0] < 1.0e-12 and min(corner_singular_mins[1:]) > 1.9,
-    f"corner_min_singular={corner_singular_mins}",
+    f"corner_min_singular={[float(np.round(x, 9)) for x in corner_singular_mins]}",
 )
 check(
     "massless embedded operator anticommutes with gamma_5",
     naive_anticom_norm < 1.0e-12,
-    f"||{{gamma_5,D}}||={naive_anticom_norm:.3e}",
+    f"||{{gamma_5,D}}|| < 1e-12: {naive_anticom_norm < 1.0e-12}",
 )
 check(
     "Wilson term breaks the gamma_5 anticommutation",
@@ -292,7 +292,7 @@ check("domain-wall Hamiltonian is Hermitian", norm(H0 - H0.conj().T) < 1.0e-12)
 check(
     "periodic wall/anti-wall has four light spinor states at p=0",
     len(light) == 4 and next_gap > 0.5,
-    f"light={len(light)} max|E_light|={np.max(np.abs(evals[light])):.3e} next_gap={next_gap:.6f}",
+    f"light={len(light)} max|E_light| < 1e-06: {np.max(np.abs(evals[light])) < 1.0e-6} next_gap={next_gap:.6f}",
 )
 
 wall_evals, wall_light, wall_window, wall_basis = localized_light_basis(H0, N_S, wall)
@@ -301,12 +301,12 @@ anti_evals, anti_light, anti_window, anti_basis = localized_light_basis(H0, N_S,
 check(
     "wall-localized light rank is two spin components, i.e. one Weyl species",
     wall_light.size == 4 and np.all(wall_window[:2] > 0.5) and np.all(wall_window[2:] < 1.0e-10),
-    f"window_eigs={wall_window}",
+    f"window_top2={np.round(wall_window[:2], 9)} max|window_rest| < 1e-10: {np.max(np.abs(wall_window[2:])) < 1.0e-10}",
 )
 check(
     "anti-wall-localized light rank is two spin components, i.e. one Weyl species",
     anti_light.size == 4 and np.all(anti_window[:2] > 0.5) and np.all(anti_window[2:] < 1.0e-10),
-    f"window_eigs={anti_window}",
+    f"window_top2={np.round(anti_window[:2], 9)} max|window_rest| < 1e-10: {np.max(np.abs(anti_window[2:])) < 1.0e-10}",
 )
 
 wall_profile = subspace_profile(wall_basis, N_S)
@@ -332,7 +332,8 @@ check(
     and wall_leak < 1.0e-12,
     (
         f"peak={wall_peak} xi_left={wall_left_xi:.6f} xi_right={wall_right_xi:.6f} "
-        f"r2=({wall_left_r2:.12f},{wall_right_r2:.12f}) antiwall_leak={wall_leak:.3e}"
+        f"min_r2 > 0.999999: {min(wall_left_r2, wall_right_r2) > 0.999999} "
+        f"antiwall_leak < 1e-12: {wall_leak < 1.0e-12}"
     ),
 )
 check(
@@ -345,7 +346,8 @@ check(
     and anti_leak < 1.0e-12,
     (
         f"peak={anti_peak} xi_left={anti_left_xi:.6f} xi_right={anti_right_xi:.6f} "
-        f"r2=({anti_left_r2:.12f},{anti_right_r2:.12f}) wall_leak={anti_leak:.3e}"
+        f"min_r2 > 0.999999: {min(anti_left_r2, anti_right_r2) > 0.999999} "
+        f"wall_leak < 1e-12: {anti_leak < 1.0e-12}"
     ),
 )
 
@@ -367,7 +369,8 @@ check(
 check(
     "wall projected spatial velocities form one Cl(3,0) Weyl cone",
     wall_sqerr < 1.0e-10 and wall_antierr < 1.0e-10 and abs(abs(wall_hand) - 1.0) < 1.0e-10,
-    f"square_err={wall_sqerr:.3e} anticomm_err={wall_antierr:.3e} handedness={wall_hand:.0f}",
+    f"square_err < 1e-10: {wall_sqerr < 1.0e-10} anticomm_err < 1e-10: {wall_antierr < 1.0e-10} "
+    f"handedness={wall_hand:.0f}",
 )
 check(
     "anti-wall projected Weyl cone has opposite handedness",
@@ -409,17 +412,20 @@ for sign in (-1.0, 1.0):
 check(
     "only the physical p=0 corner carries light domain-wall modes",
     corner_light_counts[0] == 4 and sum(corner_light_counts[1:]) == 0 and min(corner_min_gaps[1:]) > 0.7,
-    f"light_counts={corner_light_counts} min_gaps={corner_min_gaps}",
+    f"light_counts={corner_light_counts} min_gap_p0 < 1e-06: {corner_min_gaps[0] < 1.0e-6} "
+    f"heavy_min_gaps={np.round(np.array(corner_min_gaps[1:]), 9)}",
 )
 check(
     "uniform record-time bulk is gapped by |M| with no edge light modes",
     min(uniform_gaps) > 0.7 and all(abs(g - abs(M)) < 1.0e-10 for g in uniform_gaps),
-    f"uniform_gaps={uniform_gaps}",
+    f"uniform_gaps={np.round(np.array(uniform_gaps), 9)} "
+    f"max|gap - |M|| < 1e-10: {max(abs(g - abs(M)) for g in uniform_gaps) < 1.0e-10}",
 )
 check(
     "wall/anti-wall pair has one species per wall and net zero chirality on the torus",
     abs(wall_chi + anti_chi) < 1.0e-10 and abs(wall_hand + anti_hand) < 1.0e-10,
-    f"species_count=2 walls=2 net_edge_chi={wall_chi + anti_chi:.3e} net_handedness={wall_hand + anti_hand:.3e}",
+    f"species_count=2 walls=2 |net_edge_chi| < 1e-10: {abs(wall_chi + anti_chi) < 1.0e-10} "
+    f"|net_handedness| < 1e-10: {abs(wall_hand + anti_hand) < 1.0e-10}",
 )
 
 print(f"\nTOTAL: PASS={PASS} FAIL={FAIL}")


### PR DESCRIPTION
## Summary

Applies the PR #5088 hardening pattern (now landed on main) to its 2026-07-04 sibling, `scripts/domain_wall_chiral_edge_from_achiral_cl3_bulk_2026_07_04.py`. The runner printed exact rounding-noise digits in PASS-line details — the platform-nondeterminism class where a different BLAS/LAPACK build changes the committed cache text and re-breaks a pinned row.

## What was leaking noise digits (old cache)

- `||{gamma_5,D}||=0.000e+00` — exact-zero residual printed as digits
- `max|E_light|=4.557e-09` — the finite-size wall/anti-wall splitting sits ~2e-13 from its print-rounding boundary, within eigensolver cross-build noise
- `window_eigs=[... 0. 0.]` / `[... -0. -0.]` — signed-zero tails of the degenerate window pair (sign is build-dependent)
- `r2=(1.000000000000,...)`, `antiwall_leak=9.012e-19`, `wall_leak=2.253e-17`, `square_err=1.256e-15`, `anticomm_err=9.421e-16`, `net_edge_chi=-4.441e-16`, `net_handedness=2.665e-15`
- `min_gaps=[4.556685656800885e-09, 1.2076871085066714, 1.2076871085066743, ...]` — full-precision floats; the old cache already shows the noise scatter in-run (symmetry-equivalent corners differing in the last two digits)
- `uniform_gaps=[0.7999999999999995, 0.7999999999999988]`

## Fix

- Noise-class quantities now print bound checks at the **same tolerances the pass conditions already use** (e.g. `antiwall_leak < 1e-12: True`, `max|window_rest| < 1e-10: True`).
- Genuine O(1) witnesses print `np.round(..., 9)` copies (`window_top2`, `heavy_min_gaps`, `uniform_gaps`); validity is still computed on raw values.
- **No science-logic change**: all 19 pass conditions and tolerances are untouched; check count stays 19; `TOTAL: PASS=19 FAIL=0`.

## Argmax witnesses probed — no tie machinery needed

The localization/tail-fit witnesses already run on the basis-invariant rank-2 subspace marginal (`subspace_profile`). A margin probe measured the peak-site margins at **6.9e-1 relative** on both walls (vs ~1e-15 cross-build profile noise) — no ties, unlike the 07-05 sibling whose marginal had exact 5e-14 adjacent-site ties. The existing `argmax` peak selection is therefore already platform-stable and is deliberately left unchanged. Frobenius/trace witnesses (velocity errors, handedness, chirality) were verified basis-invariant under intra-doublet rotations.

## Re-audit tradeoff (owner-accepted)

This row is currently `retained_bounded` on the audit ledger (audited 2026-07-09). Editing its runner/cache re-opens the audit — this proactive hardening was requested with that tradeoff stated. The paired note (`docs/DOMAIN_WALL_CHIRAL_EDGE_FROM_ACHIRAL_CL3_BULK_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-04.md`) quotes no changed content (only `TOTAL: PASS=19 FAIL=0` and parameters) and is untouched. No audit files or grades are touched.

## Test plan

- [x] Runner re-run in the worktree: `TOTAL: PASS=19 FAIL=0`
- [x] Two consecutive runs byte-identical
- [x] Cache regenerated via `scripts/runner_cache.py` (SHA-pinned, `status: ok`)
- [x] Diff limited to the runner + its cache (source-only pair; note unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)