### PR TITLE
feat(gauge-rp): heat-kernel weight gives native RP plane character positivity for all compact groups

### DIFF
--- a/docs/HEAT_KERNEL_GAUGE_ACTION_NATIVE_RP_PLANE_CHARACTER_POSITIVITY_ALL_COMPACT_GROUPS_NARROW_THEOREM_NOTE_2026-07-09.md
+++ b/docs/HEAT_KERNEL_GAUGE_ACTION_NATIVE_RP_PLANE_CHARACTER_POSITIVITY_ALL_COMPACT_GROUPS_NARROW_THEOREM_NOTE_2026-07-09.md
@@ -1,0 +1,284 @@
+# Heat-Kernel Gauge Action: The Reflection-Plane Character-Positivity Step Is Manifest for ALL Compact Groups (Native RP Mechanism, No Group-Dependent Certificate)
+
+**Date:** 2026-07-09
+**Claim type:** bounded_theorem
+**Status authority:** independent audit lane only. This source note does not set
+or predict an audit outcome.
+**Primary runner:**
+[`scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py`](../scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py)
+**Cached output:**
+[`logs/runner-cache/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.txt`](../logs/runner-cache/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.txt)
+
+## The gap this note addresses
+
+The retained-bounded Wilson temporal-gauge RP bridge
+([`AXIOM_FIRST_REFLECTION_POSITIVITY_WILSON_TEMPORAL_GAUGE_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05`](AXIOM_FIRST_REFLECTION_POSITIVITY_WILSON_TEMPORAL_GAUGE_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md),
+ledger `effective_status = retained_bounded`) runs a three-step mechanism on the
+Wilson plane weight: (W1) reflection split of the action across the temporal
+reflection plane, (W2) **nonnegativity of the character coefficients of the
+plane (straddling) factor**, (W3) the integrated reflected Gram matrix is PSD
+because the plane factor is a norm-square kernel. Step (W2) is the load-bearing
+positivity input, and on the **Wilson** weight it is **group-dependent**:
+
+- `Z_N`: exact finite DFT — coefficients computed and checked nonneg.
+- `U(1)`: modified Bessel `I_n(β) > 0` — positive-series certificate.
+- `SU(2)`: numeric/Monte-Carlo evidence only.
+- `SU(N≥3)`: **not derivable by that route.** Positivity of a class function
+  does not imply nonnegative character coefficients on a nonabelian group, and
+  the note's §4 conformance repair (PR #5050) rescoped its `SU(N≥3)` Wilson
+  positivity statement to the Osterwalder–Seiler **literature comparator**,
+  naming the heat-kernel action as the forward derivation path.
+
+This note takes exactly that named forward path.
+
+## Claim (narrow theorem, bounded)
+
+Let `G` be any compact group, `λ` its irreps with dimension `d_λ` and Casimir
+`C₂(λ)` (for the Lie cases, `C₂` in the retained trace-form normalization
+`Tr(T_a T_b) = δ_ab/2`; for finite/abelian testbeds, any nonnegative-spectrum
+group-Laplacian eigenvalue `λ_q ≥ 0` in place of `C₂`). Define the heat-kernel
+(HK) single-plaquette weight
+
+```
+K_t = Σ_λ c_λ(t) χ_λ ,   c_λ(t) = d_λ · exp(−t · C₂(λ)/2) ,   t > 0 ,
+```
+
+the same candidate object and convention as the HK candidate notes
+(`HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS_NARROW_THEOREM_NOTE_2026-06-08`,
+unaudited; the SU(3) fundamental coefficient there, `exp(−2/3)` at `t = 1`,
+is `exp(−t·C₂/2)` with `C₂(fund) = 4/3` — the runner cross-checks this
+convention alignment). Then:
+
+- **H1 (spectral positivity — manifest, all compact `G`).**
+  `c_λ(t) = d_λ e^{−t C₂(λ)/2} > 0` for **every** irrep of **every** compact
+  group and every `t > 0`. The (W2)-analog on the HK weight requires **no**
+  group-dependent certificate: no DFT, no Bessel positivity, no Monte-Carlo
+  estimate. In particular it holds for `SU(3)` and all `SU(N)` — exactly the
+  cases where the Wilson-weight route is not derivable.
+
+- **H2 (plane factor is a norm-square kernel).** `K_t` is real (the spectrum
+  is closed under conjugation with `d_λ̄ = d_λ`, `C₂(λ̄) = C₂(λ)`), and by the
+  cut factorization `χ_λ(AB†) = Σ_{ij} π_λ(A)_{ij} · conj(π_λ(B)_{ij})` the
+  per-link plane factor is
+
+  ```
+  K_t(U(0) U(1)†) = Σ_λ c_λ(t) Σ_{ij} π_λ(U(0))_{ij} · conj(π_λ(U(1))_{ij}) ,
+  ```
+
+  a positive combination (`c_λ > 0`) of manifest Gram products — a norm-square
+  kernel in matrix-element features, for every compact `G`.
+
+- **H3 (integrated two-slice RP Gram PSD, natively).** On the bridge note's
+  two-slice temporal-gauge carrier (temporal gauge `U_0 = 1`, periodic spatial
+  direction, `L_s` spatial links per slice, antilinear reflection
+  `Θ(F)(U) = conj(F(θU))`), replace the Wilson weight by the HK weight
+  `exp(−S_HK) = Π_p K_t(U_p)` (one spatial-loop factor per slice, one
+  straddling factor per spatial link). The half-slice weights are **real**
+  (H2 realness — the property the reflected-Gram argument actually consumes),
+  the plane factor is a norm-square kernel (H2), so the reflected Gram
+  `G_IJ = ⟨Θ(F_I) F_J⟩` over positive-half observables is PSD:
+  `G = W diag(κ) W†` with `κ ≥ 0`. This instantiates the retained gauge-half
+  Cauchy–Schwarz hypotheses
+  ([`REFLECTION_POSITIVITY_GAUGE_HALF_CAUCHY_SCHWARZ_NARROW_THEOREM_NOTE_2026-05-10`](REFLECTION_POSITIVITY_GAUGE_HALF_CAUCHY_SCHWARZ_NARROW_THEOREM_NOTE_2026-05-10.md),
+  ledger `effective_status = retained`) on the HK weight for **all** compact
+  `G` — including `SU(3)`, where the runner runs the integrated Gram check the
+  Wilson bridge could not derive.
+
+- **H4 (pointwise positivity — Boltzmann sensibility).** `K_t > 0` pointwise,
+  so `S_HK = −log K_t` is a real action and the HK weight is a genuine
+  Boltzmann factor. Certified per group: `Z_N` exact evaluation; `U(1)` via
+  the Poisson-summation (Jacobi theta) identity
+  `Σ_n e^{−tn²/2} e^{inθ} = √(2π/t) Σ_m e^{−(θ−2πm)²/(2t)}` — a sum of
+  manifestly positive Gaussian terms; `SU(2)` and `SU(3)` by a
+  grid-plus-Lipschitz-plus-truncation-tail certificate (margin strictly
+  exceeds the certified evaluation error), exercised at the runner's printed
+  `t` values. H4 is **not** needed for H3 (the
+  Gram argument uses realness and spectral positivity, not pointwise
+  positivity); it is stated because a candidate *action* must have one.
+
+**Bounded scope.** The theorem is about the HK **candidate** weight on the
+narrow two-slice carrier. It upgrades the RP *mechanism* from
+group-dependent-certificate to manifest **on that candidate**; it does not
+select the candidate (see boundary below).
+
+## Why this is the structurally honest fix
+
+The Wilson-weight (W2) obstruction is real mathematics: `exp(β·Re χ_fund)` has
+character coefficients given by group integrals that are not sign-definite
+term-by-term for nonabelian `G`, and no general positivity theorem applies.
+The HK weight **defines** the plane factor spectrally — positivity is not a
+property to be certified after the fact; it is the *definition's first line*.
+The group-dependence of (W2) is thereby located precisely: it is a property of
+the **Wilson parametrization** of the plane weight, not of the RP mechanism,
+the carrier, the reflection, or the gauge group. On the spectral (HK)
+parametrization the mechanism is uniform in `G`.
+
+Two structural bonuses, both re-proved in the runner rather than cited:
+
+- **Semigroup/normalization for free:** `c_λ(s)c_λ(t)/d_λ = c_λ(s+t)`
+  (character convolution `(f∗g)_λ = f_λ g_λ/d_λ`), and the trivial-rep
+  coefficient is `c_triv(t) = 1`, so `∫ K_t dHaar = 1` — the weight is
+  automatically Haar-normalized at every `t`.
+- **The antilinear reflection stays load-bearing:** dropping the conjugation
+  in `Θ` breaks PSD (the runner reproduces the bridge note's negative control
+  on the HK weight — the mechanism is not vacuously positive).
+
+## Carrier, observables, and conventions (mirrors the bridge note)
+
+- Two time slices `t ∈ {0, 1}`; one periodic spatial direction with `L_s = 2`
+  spatial links per slice; temporal gauge `U_0 = 1` on temporal links.
+- Reflection `θ` swaps the slices; `Θ` is **antilinear**:
+  `Θ(F)(U) = conj(F(θU))`.
+- Positive-half observable algebra `A_+`: functions of the `t = 1` slice
+  links. For the exact abelian Grams the runner uses the bridge note's
+  character-degree ≤ 2 monomial basis; for `SU(2)`/`SU(3)` Monte-Carlo Grams
+  it uses the bridge note's 6-element matrix-element/trace basis (for `SU(3)`,
+  `Tr U` is complex; the basis includes a conjugated trace — a legitimate
+  `A_+` element, the antifundamental character).
+- HK weight on the carrier:
+  `w(c₀, c₁) = K_t(loop(c₁)) · K_t(loop(c₀)) · Π_k K_t(U_k(0) U_k(1)†)`,
+  where `loop(c)` is the spatial plaquette (ordered product of the `L_s`
+  spatial links) of slice `c`. The straddling factor is the plane factor; the
+  two loop factors are the half weights. Plane symmetry (W1-analog): the
+  straddling factor is invariant under the slice swap because `K_t` is a real
+  class function and `K_t(V†) = K_t(V)`.
+- Groups exercised: `Z_N` (exact, finite testbed), `U(1)` (quadrature),
+  `SU(2)` (deterministic certificates + seeded MC Gram), `SU(3)` (the target:
+  deterministic certificates + seeded MC Gram).
+- `SU(3)` irrep data: Dynkin `(p, q)`, `d = (p+1)(q+1)(p+q+2)/2`,
+  `C₂ = (p² + q² + pq + 3p + 3q)/3`; characters evaluated as Schur polynomials
+  of the link eigenvalues via Newton/Jacobi–Trudi (no character table import —
+  computed from the matrices).
+
+## What is exact vs. numeric (honest inventory)
+
+| Group | H1 `c_λ > 0` | H2 factorization/realness | H3 Gram PSD | H4 pointwise |
+|---|---|---|---|---|
+| `Z_N` | manifest + enumerated | exact (1-dim reps) | **exact** double sum, all configs | exact evaluation |
+| `U(1)` | manifest | exact coefficient algebra | quadrature (trig-exact grid) | Poisson identity, term-positive |
+| `SU(2)` | manifest + tail bound | exact to 1e−12 (symmetric-power reps) | seeded MC, tolerance-gated | grid + Lipschitz + tail certificate |
+| `SU(3)` | manifest + tail bound | exact to 1e−11 (fund + adjoint) | seeded MC, tolerance-gated | grid + Lipschitz + tail certificate |
+
+The `SU(2)`/`SU(3)` integrated Grams are Monte-Carlo estimates (fixed seeds,
+printed tolerances) — same evidentiary class as the bridge note's Part E
+`SU(2)` check, now including the `SU(3)` case that the Wilson route had no
+derivable (W2) for. The deterministic content (H1, H2, semigroup,
+normalization, H4 certificates) is exact or certified with explicit error
+budgets, and is where the theorem's force lives: **the group-dependent step of
+the mechanism is gone by construction.**
+
+## What this note does NOT claim
+
+- **No claim that the HK weight is the framework's realized/selected action.**
+  HK is the Casimir-native *candidate*; the uniqueness-among-candidates note
+  (`HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS_NARROW_THEOREM_NOTE_2026-06-08`)
+  is **unaudited**, the semigroup-selection boundary
+  (`SEMIGROUP_CLOSURE_DOES_NOT_FORCE_HEAT_KERNEL_QUADRATIC_CONDITION_BOUNDED_NOTE_2026-07-02`)
+  is **unaudited**, the registration-induced step-kernel route
+  (`GAUGE_LINK_CENTRAL_REGISTRATION_INDUCED_BI_INVARIANT_STEP_KERNEL_THEOREM_NOTE_2026-07-02`)
+  is **unaudited**, and the dynamical premise boundary
+  (`RECORD_CLASSICAL_SEMIGROUP_BOUNDARY_2026-06-06`) is **audit_in_progress**
+  on the live ledger. Nothing here leans on any of them; they are context
+  pointers only.
+- **No modification of the Wilson bridge note.** Its Wilson-side scoping
+  (including the `SU(N≥3)` Osterwalder–Seiler comparator framing after
+  PR #5050) stands as audited. This note adds a parallel result on a different
+  weight; it does not edit, retire, or re-grade anything.
+- **No fermion factor, no full OS reconstruction.** Two-slice gauge-sector
+  Gram positivity on a narrow carrier — not multi-slice transfer-matrix
+  positivity (`AXIOM_FIRST_RP_TWO_STEP...` lineage), not a Hamiltonian, not a
+  continuum limit, and no coupling value is fixed (`t` is a free positive
+  parameter throughout; results are exercised at several `t`).
+- **No new axiom, no import.** The HK candidate, the carrier, the reflection,
+  the observable algebra, and the trace-form normalization are existing
+  framework content; character theory and Poisson summation are standard
+  mathematical methods re-verified numerically by the runner. The
+  Osterwalder–Seiler and textbook references below are **comparators only**
+  (already the bridge note's comparators — no new comparator is introduced);
+  every positivity statement used here is re-proved by the paired runner.
+- **No audit-status statement.** Grades are set exclusively by the independent
+  audit lane; this note predicts nothing.
+
+## Dependencies
+
+**Load-bearing (valid retained tiers on the live ledger):**
+
+- [`REFLECTION_POSITIVITY_GAUGE_HALF_CAUCHY_SCHWARZ_NARROW_THEOREM_NOTE_2026-05-10`](REFLECTION_POSITIVITY_GAUGE_HALF_CAUCHY_SCHWARZ_NARROW_THEOREM_NOTE_2026-05-10.md)
+  — `retained`. The abstract norm-square/Cauchy–Schwarz mechanism whose
+  hypotheses H2–H3 instantiate on the HK weight.
+- [`AXIOM_FIRST_REFLECTION_POSITIVITY_WILSON_TEMPORAL_GAUGE_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05`](AXIOM_FIRST_REFLECTION_POSITIVITY_WILSON_TEMPORAL_GAUGE_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md)
+  — `retained_bounded`. Supplies the carrier, the antilinear reflection, the
+  observable bases, the (W1)–(W3) decomposition, and the negative control
+  design; this note swaps its plane weight and re-proves everything on the
+  swap.
+
+**Context pointers (NOT load-bearing; unaudited / in-progress statuses stated
+above):** `HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS_NARROW_THEOREM_NOTE_2026-06-08`,
+`EMERGENT_GAUGE_HEAT_KERNEL_CLT_ATTRACTOR_CONDITIONAL_ON_BI_INVARIANT_DYNAMICS_NARROW_THEOREM_NOTE_2026-06-08`,
+`SEMIGROUP_CLOSURE_DOES_NOT_FORCE_HEAT_KERNEL_QUADRATIC_CONDITION_BOUNDED_NOTE_2026-07-02`,
+`GAUGE_LINK_CENTRAL_REGISTRATION_INDUCED_BI_INVARIANT_STEP_KERNEL_THEOREM_NOTE_2026-07-02`,
+`RECORD_CLASSICAL_SEMIGROUP_BOUNDARY_2026-06-06`,
+`RP_WILSON_TEMPORAL_GAUGE_BRIDGE_SIGN_AND_POSITIVITY_REPAIR_NOTE_2026-06-06`,
+`AXIOM_FIRST_REFLECTION_POSITIVITY_THEOREM_NOTE_2026-04-29` (the root RP row,
+`audited_conditional` — this note neither cites it as retained nor repairs it).
+
+## Runner test plan (Parts A–E ↔ claims)
+
+- **Part A — H1.** Enumerated strict positivity of `c_λ(t)` for `Z_N`
+  (`N ∈ {2,…,6}`), `U(1)` (`|n| ≤ 30`), `SU(2)` (`j ≤ 15`), `SU(3)`
+  (`p+q ≤ 10`), at several `t`; `SU(3)` dimension/Casimir spot checks
+  (`d(1,0)=3, C₂=4/3`; `d(1,1)=8, C₂=3`; `d(2,1)=15`; `d(2,2)=27`);
+  superexponential truncation-tail bounds with geometric-majorant guards.
+- **Part B — H2 algebra + conventions.** Exact coefficient-level semigroup
+  `c_λ(s)c_λ(t)/d_λ = c_λ(s+t)` (all four groups); `Z_N` kernel-level
+  convolution `K_s ∗ K_t = K_{s+t}` exact; trivial-coefficient normalization
+  `= 1`; realness of `K_t` (exact / grid / sampled); character orthonormality
+  on trig-exact quadrature grids (`SU(2)` Weyl `sin²` measure; `SU(3)` Weyl
+  2-torus measure `|Δ|²/6` — validates the Schur-polynomial character
+  machinery the `SU(3)` checks use); `U(1)` Poisson/Jacobi-theta identity to
+  1e−10.
+- **Part C — H4.** `Z_N` exact pointwise minima; `U(1)` term-positive Gaussian
+  representation + grid minimum; `SU(2)`/`SU(3)` certificates: grid minimum
+  − Lipschitz·(spacing/2) − truncation tail > 0, with the Lipschitz constant
+  from explicit character-derivative bounds (`|χ_j′| ≤ 2j(2j+1)`;
+  `SU(3)` weight-phase degree ≤ p+q per torus angle → `|∂χ| ≤ d_λ(p+q)`).
+- **Part D — H2 cut factorization.** `χ_λ(AB†) = Σ_{ij} π_λ(A)_{ij}
+  conj(π_λ(B)_{ij})` exact on seeded random pairs: `Z_N` (all reps), `SU(2)`
+  (symmetric-power reps `j ∈ {1/2, 1, 3/2, 2}`), `SU(3)` (fundamental and
+  adjoint `π_ad(U)_{ab} = 2 Tr(T_a U T_b U†)`, cross-checked against the
+  Schur-polynomial character and `χ_ad = |Tr U|² − 1`).
+- **Part E — H3.** Integrated reflected Gram PSD on the two-slice carrier
+  with the HK weight: `Z_N` exact over all configurations (`N ∈ {2,3,4,5}`,
+  `t ∈ {0.3, 1.0, 2.5}`), plus the manifest factorization `G = W diag(κ) W†`
+  with plane-kernel eigenvalues `κ ≥ 0` reproducing the direct Gram; the
+  **dropped-conjugation negative control** (non-PSD); `U(1)` quadrature Gram;
+  `SU(2)` seeded MC Gram; **`SU(3)` seeded MC Gram** — the check the Wilson
+  bridge could not derivably run.
+
+All checks are deterministic (fixed seeds); the runner prints
+`TOTAL: PASS=N FAIL=0` on success.
+
+## Standard methods and comparators (not imports)
+
+- Character theory of compact groups, Weyl integration, Schur polynomials /
+  Jacobi–Trudi, Poisson summation — standard mathematical methods; every
+  instance used is re-verified numerically inside the runner.
+- Heat-kernel lattice gauge actions and their character expansion appear in
+  the literature the bridge note already lists as comparators (Osterwalder &
+  Seiler, *Ann. Phys.* **110** (1978) 440; Montvay & Münster, *Quantum Fields
+  on a Lattice*, §3.4 role). **Comparator only**: no positivity statement is
+  imported from them; the runner re-proves each one it uses.
+
+## Closing
+
+The bridge note ends its `SU(N≥3)` discussion at a comparator because the
+Wilson plane weight's character positivity is not derivable there. On the
+spectral heat-kernel parametrization of the same plane weight, that entire
+step is manifest for every compact group, the retained gauge-half
+Cauchy–Schwarz mechanism runs natively (including the integrated `SU(3)` Gram
+exercised here), the weight is automatically Haar-normalized and pointwise
+positive, and the antilinear-reflection control still separates the mechanism
+from vacuous positivity. The next path this opens: connecting this native-RP
+property to the action-*selection* question (the unaudited HK-candidate lanes
+above), where RP-for-all-`G` is now a structural property the HK candidate
+carries and the Wilson parametrization does not derivably share.

--- a/docs/HEAT_KERNEL_GAUGE_ACTION_NATIVE_RP_PLANE_CHARACTER_POSITIVITY_ALL_COMPACT_GROUPS_NARROW_THEOREM_NOTE_2026-07-09.md
+++ b/docs/HEAT_KERNEL_GAUGE_ACTION_NATIVE_RP_PLANE_CHARACTER_POSITIVITY_ALL_COMPACT_GROUPS_NARROW_THEOREM_NOTE_2026-07-09.md
@@ -85,25 +85,25 @@ convention alignment). Then:
   numerically for `SU(2)` and `SU(3)` and exactly for the listed finite
   testbeds; those checks support the factorization but are not its proof.
 
-- **H4 (checked pointwise positivity — Boltzmann sensibility).** For the
-  groups and parameter values exercised by the runner, `K_t > 0` pointwise,
-  so `S_HK = −log K_t` is a real action and the HK weight is a genuine
-  Boltzmann factor on those checked surfaces. Certified per group: `Z_N` exact evaluation; `U(1)` via
+- **H4 (pointwise-positivity boundary — Boltzmann sensibility).** For `Z_N`
+  at the enumerated values and for `U(1)`, the runner establishes `K_t > 0`
+  pointwise: `Z_N` by exact evaluation and `U(1)` via
   the Poisson-summation (Jacobi theta) identity
   `Σ_n e^{−tn²/2} e^{inθ} = √(2π/t) Σ_m e^{−(θ−2πm)²/(2t)}` — a sum of
-  manifestly positive Gaussian terms; `SU(2)` and `SU(3)` by a
-  grid-plus-Lipschitz-plus-truncation-tail certificate (margin strictly
-  exceeds the certified evaluation error), exercised at the runner's printed
-  `t` values. H4 is **not** needed for H3 (the
+  manifestly positive Gaussian terms. For `SU(2)` and `SU(3)`, the finite
+  character truncations are positive on the sampled grids at the printed
+  `t` values, but this is numerical evidence only: no analytic infinite-tail
+  bound is proved here. H4 is **not** needed for H3 (the
   Gram argument uses realness and spectral positivity, not pointwise
-  positivity). No all-compact-group pointwise-positivity claim is inferred
-  from these finite testbeds.
+  positivity). Strict pointwise positivity for the full `SU(2)`/`SU(3)` heat
+  kernels remains a standard-theorem/import or analytic-tail gate outside the
+  runner's certified claim.
 
 **Bounded scope.** The theorem is about the HK **candidate** weight for a
 specified central heat semigroup on the narrow two-slice carrier. It makes
 the RP coefficient step manifest on that candidate; it does not select the
-candidate or establish pointwise positivity beyond the checked groups and
-parameters (see boundary below).
+candidate or establish full-kernel pointwise positivity for `SU(2)`/`SU(3)`
+(see boundary below).
 
 ## Why the heat-semigroup form is useful
 
@@ -155,13 +155,14 @@ Two structural bonuses, both re-proved in the runner rather than cited:
 |---|---|---|---|---|
 | `Z_N` | manifest + enumerated | exact (1-dim reps) | **exact** double sum, all configs | exact evaluation |
 | `U(1)` | manifest | exact coefficient algebra | quadrature (trig-exact grid) | Poisson identity, term-positive |
-| `SU(2)` | manifest + tail bound | exact to 1e−12 (symmetric-power reps) | seeded MC, tolerance-gated | grid + Lipschitz + tail certificate |
-| `SU(3)` | manifest + tail bound | exact to 1e−11 (fund + adjoint) | seeded MC, tolerance-gated | grid + Lipschitz + tail certificate |
+| `SU(2)` | manifest + enumerated | exact to 1e−12 (symmetric-power reps) | seeded MC, tolerance-gated | finite-truncation grid evidence |
+| `SU(3)` | manifest + enumerated | exact to 1e−11 (fund + adjoint) | seeded MC, tolerance-gated | finite-truncation grid evidence |
 
 The `SU(2)`/`SU(3)` integrated Grams are Monte-Carlo estimates (fixed seeds,
 printed tolerances). The deterministic H1/H2 coefficient algebra and
 semigroup/normalization identities are exact on their stated surface. H4 is
-certified only for the groups and parameter values listed in the table.
+proved for `Z_N`/`U(1)` as stated and is support-only for the sampled
+`SU(2)`/`SU(3)` truncations.
 
 ## What this note does NOT claim
 
@@ -225,8 +226,9 @@ above):** `HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS_NAR
 - **Part A — H1.** Enumerated strict positivity of `c_λ(t)` for `Z_N`
   (`N ∈ {2,…,6}`), `U(1)` (`|n| ≤ 30`), `SU(2)` (`j ≤ 15`), `SU(3)`
   (`p+q ≤ 10`), at several `t`; `SU(3)` dimension/Casimir spot checks
-  (`d(1,0)=3, C₂=4/3`; `d(1,1)=8, C₂=3`; `d(2,1)=15`; `d(2,2)=27`);
-  superexponential truncation-tail bounds with geometric-majorant guards.
+  (`d(1,0)=3, C₂=4/3`; `d(1,1)=8, C₂=3`; `d(2,1)=15`; `d(2,2)=27`).
+  Coefficient positivity itself is analytic from H1; these finite checks are
+  implementation sanity checks.
 - **Part B — H2 algebra + conventions.** Exact coefficient-level semigroup
   `c_λ(s)c_λ(t)/d_λ = c_λ(s+t)` (all four groups); `Z_N` kernel-level
   convolution `K_s ∗ K_t = K_{s+t}` exact; trivial-coefficient normalization
@@ -236,10 +238,9 @@ above):** `HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS_NAR
   machinery the `SU(3)` checks use); `U(1)` Poisson/Jacobi-theta identity to
   1e−10.
 - **Part C — H4.** `Z_N` exact pointwise minima; `U(1)` term-positive Gaussian
-  representation + grid minimum; `SU(2)`/`SU(3)` certificates: grid minimum
-  − Lipschitz·(spacing/2) − truncation tail > 0, with the Lipschitz constant
-  from explicit character-derivative bounds (`|χ_j′| ≤ 2j(2j+1)`;
-  `SU(3)` weight-phase degree ≤ p+q per torus angle → `|∂χ| ≤ d_λ(p+q)`).
+  representation + grid minimum; `SU(2)`/`SU(3)` finite-truncation grid
+  minima as numerical evidence only. No sampled finite-ratio estimate is used
+  as an infinite-tail bound.
 - **Part D — H2 cut factorization.** `χ_λ(AB†) = Σ_{ij} π_λ(A)_{ij}
   conj(π_λ(B)_{ij})` exact on seeded random pairs: `Z_N` (all reps), `SU(2)`
   (symmetric-power reps `j ∈ {1/2, 1, 3/2, 2}`), `SU(3)` (fundamental and
@@ -272,6 +273,7 @@ On the spectral heat-semigroup parametrization, coefficient positivity is
 manifest, the retained gauge-half Cauchy–Schwarz mechanism runs natively, and
 the antilinear-reflection control still separates the mechanism from vacuous
 positivity. The runner checks the integrated `SU(3)` Gram as a numerical
-instance and certifies pointwise positivity only on its enumerated group and
-parameter surfaces. The remaining open path is action selection; this note
+instance. It proves pointwise positivity for the stated `Z_N`/`U(1)` surfaces
+and reports only finite-truncation evidence for `SU(2)`/`SU(3)`. The remaining
+open paths are the full-kernel positivity authority and action selection; this note
 does not choose the heat-kernel candidate or rule out the Wilson route.

--- a/docs/HEAT_KERNEL_GAUGE_ACTION_NATIVE_RP_PLANE_CHARACTER_POSITIVITY_ALL_COMPACT_GROUPS_NARROW_THEOREM_NOTE_2026-07-09.md
+++ b/docs/HEAT_KERNEL_GAUGE_ACTION_NATIVE_RP_PLANE_CHARACTER_POSITIVITY_ALL_COMPACT_GROUPS_NARROW_THEOREM_NOTE_2026-07-09.md
@@ -10,9 +10,9 @@
 
 ## Comparison boundary
 
-The retained-bounded Wilson temporal-gauge RP bridge
+The Wilson temporal-gauge RP bridge
 ([`AXIOM_FIRST_REFLECTION_POSITIVITY_WILSON_TEMPORAL_GAUGE_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05`](AXIOM_FIRST_REFLECTION_POSITIVITY_WILSON_TEMPORAL_GAUGE_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md),
-ledger `effective_status = retained_bounded`) runs a three-step mechanism on the
+whose current standing is recorded in the live audit ledger) runs a three-step mechanism on the
 Wilson plane weight: (W1) reflection split of the action across the temporal
 reflection plane, (W2) **nonnegativity of the character coefficients of the
 plane (straddling) factor**, (W3) the integrated reflected Gram matrix is PSD
@@ -34,7 +34,7 @@ manifest from the spectral definition.
 Let `G` be a compact Lie group equipped with a specified positive
 bi-invariant Laplacian, and let `λ` label its irreducible representations with
 dimension `d_λ` and nonnegative Laplacian eigenvalue `C₂(λ)`. For the `SU(N)`
-cases, `C₂` uses the retained trace-form normalization
+cases, `C₂` uses the specified trace-form normalization
 `Tr(T_a T_b) = δ_ab/2`. The finite and abelian runner testbeds use the explicitly
 specified nonnegative central generators stated below. Define the heat-kernel
 (HK) single-plaquette weight
@@ -44,8 +44,8 @@ K_t = Σ_λ c_λ(t) χ_λ ,   c_λ(t) = d_λ · exp(−t · C₂(λ)/2) ,   t > 
 ```
 
 the same candidate object and convention as the HK candidate notes
-(`HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS_NARROW_THEOREM_NOTE_2026-06-08`,
-unaudited; the SU(3) fundamental coefficient there, `exp(−2/3)` at `t = 1`,
+(`HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS_NARROW_THEOREM_NOTE_2026-06-08`;
+the SU(3) fundamental coefficient there, `exp(−2/3)` at `t = 1`,
 is `exp(−t·C₂/2)` with `C₂(fund) = 4/3` — the runner cross-checks this
 convention alignment). Then:
 
@@ -77,10 +77,10 @@ convention alignment). Then:
   (H2 realness — the property the reflected-Gram argument actually consumes),
   the plane factor is a norm-square kernel (H2), so the reflected Gram
   `G_IJ = ⟨Θ(F_I) F_J⟩` over positive-half observables is PSD:
-  `G = W diag(κ) W†` with `κ ≥ 0`. This instantiates the retained gauge-half
+  `G = W diag(κ) W†` with `κ ≥ 0`. This instantiates the gauge-half
   Cauchy–Schwarz hypotheses
-  ([`REFLECTION_POSITIVITY_GAUGE_HALF_CAUCHY_SCHWARZ_NARROW_THEOREM_NOTE_2026-05-10`](REFLECTION_POSITIVITY_GAUGE_HALF_CAUCHY_SCHWARZ_NARROW_THEOREM_NOTE_2026-05-10.md),
-  ledger `effective_status = retained`) on the HK weight for compact Lie `G`
+  ([`REFLECTION_POSITIVITY_GAUGE_HALF_CAUCHY_SCHWARZ_NARROW_THEOREM_NOTE_2026-05-10`](REFLECTION_POSITIVITY_GAUGE_HALF_CAUCHY_SCHWARZ_NARROW_THEOREM_NOTE_2026-05-10.md);
+  consult the live audit ledger for current standing) on the HK weight for compact Lie `G`
   with the specified heat semigroup. The runner exercises the integrated Gram
   numerically for `SU(2)` and `SU(3)` and exactly for the listed finite
   testbeds; those checks support the factorization but are not its proof.
@@ -169,14 +169,14 @@ proved for `Z_N`/`U(1)` as stated and is support-only for the sampled
 - **No claim that the HK weight is the framework's realized/selected action.**
   HK is the Casimir-native *candidate*; the uniqueness-among-candidates note
   (`HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS_NARROW_THEOREM_NOTE_2026-06-08`)
-  is **unaudited**, the semigroup-selection boundary
+  is a context pointer, as are the semigroup-selection boundary
   (`SEMIGROUP_CLOSURE_DOES_NOT_FORCE_HEAT_KERNEL_QUADRATIC_CONDITION_BOUNDED_NOTE_2026-07-02`)
-  is **unaudited**, the registration-induced step-kernel route
+  and the registration-induced step-kernel route
   (`GAUGE_LINK_CENTRAL_REGISTRATION_INDUCED_BI_INVARIANT_STEP_KERNEL_THEOREM_NOTE_2026-07-02`)
-  is **unaudited**, and the dynamical premise boundary
-  (`RECORD_CLASSICAL_SEMIGROUP_BOUNDARY_2026-06-06`) is **audit_in_progress**
-  on the live ledger. Nothing here leans on any of them; they are context
-  pointers only.
+  and the dynamical premise boundary
+  (`RECORD_CLASSICAL_SEMIGROUP_BOUNDARY_2026-06-06`). Nothing here leans on
+  any of them; consult the live audit ledger for current standing. They are
+  context pointers only.
 - **No Wilson obstruction claim.** This note adds a parallel result on a
   different weight. It neither endorses nor depends on the Wilson bridge's
   `SU(N≥3)` comparator framing; the representation-ring route above shows
@@ -200,26 +200,27 @@ proved for `Z_N`/`U(1)` as stated and is support-only for the sampled
 
 ## Dependencies
 
-**Load-bearing (valid retained tiers on the live ledger):**
+**Load-bearing dependencies** (current standing is audit-lane-owned; consult
+the live audit ledger):
 
 - [`REFLECTION_POSITIVITY_GAUGE_HALF_CAUCHY_SCHWARZ_NARROW_THEOREM_NOTE_2026-05-10`](REFLECTION_POSITIVITY_GAUGE_HALF_CAUCHY_SCHWARZ_NARROW_THEOREM_NOTE_2026-05-10.md)
-  — `retained`. The abstract norm-square/Cauchy–Schwarz mechanism whose
+  — the abstract norm-square/Cauchy–Schwarz mechanism whose
   hypotheses H2–H3 instantiate on the HK weight.
 - [`AXIOM_FIRST_REFLECTION_POSITIVITY_WILSON_TEMPORAL_GAUGE_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05`](AXIOM_FIRST_REFLECTION_POSITIVITY_WILSON_TEMPORAL_GAUGE_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md)
-  — `retained_bounded`. Supplies the carrier, the antilinear reflection, the
+  — supplies the carrier, the antilinear reflection, the
   observable bases, the (W1)–(W3) decomposition, and the negative control
   design; this note swaps its plane weight and re-proves everything on the
   swap.
 
-**Context pointers (NOT load-bearing; unaudited / in-progress statuses stated
-above):** `HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS_NARROW_THEOREM_NOTE_2026-06-08`,
+**Context pointers (NOT load-bearing; consult the live audit ledger for current
+standing):** `HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS_NARROW_THEOREM_NOTE_2026-06-08`,
 `EMERGENT_GAUGE_HEAT_KERNEL_CLT_ATTRACTOR_CONDITIONAL_ON_BI_INVARIANT_DYNAMICS_NARROW_THEOREM_NOTE_2026-06-08`,
 `SEMIGROUP_CLOSURE_DOES_NOT_FORCE_HEAT_KERNEL_QUADRATIC_CONDITION_BOUNDED_NOTE_2026-07-02`,
 `GAUGE_LINK_CENTRAL_REGISTRATION_INDUCED_BI_INVARIANT_STEP_KERNEL_THEOREM_NOTE_2026-07-02`,
 `RECORD_CLASSICAL_SEMIGROUP_BOUNDARY_2026-06-06`,
 `RP_WILSON_TEMPORAL_GAUGE_BRIDGE_SIGN_AND_POSITIVITY_REPAIR_NOTE_2026-06-06`,
-`AXIOM_FIRST_REFLECTION_POSITIVITY_THEOREM_NOTE_2026-04-29` (the root RP row,
-`audited_conditional` — this note neither cites it as retained nor repairs it).
+`AXIOM_FIRST_REFLECTION_POSITIVITY_THEOREM_NOTE_2026-04-29` (the root RP row;
+this note neither uses it as load-bearing authority nor repairs it).
 
 ## Runner test plan (Parts A–E ↔ claims)
 
@@ -270,7 +271,7 @@ All checks are deterministic (fixed seeds); the runner prints
 ## Closing
 
 On the spectral heat-semigroup parametrization, coefficient positivity is
-manifest, the retained gauge-half Cauchy–Schwarz mechanism runs natively, and
+manifest, the gauge-half Cauchy–Schwarz mechanism runs natively, and
 the antilinear-reflection control still separates the mechanism from vacuous
 positivity. The runner checks the integrated `SU(3)` Gram as a numerical
 instance. It proves pointwise positivity for the stated `Z_N`/`U(1)` surfaces

--- a/docs/HEAT_KERNEL_GAUGE_ACTION_NATIVE_RP_PLANE_CHARACTER_POSITIVITY_ALL_COMPACT_GROUPS_NARROW_THEOREM_NOTE_2026-07-09.md
+++ b/docs/HEAT_KERNEL_GAUGE_ACTION_NATIVE_RP_PLANE_CHARACTER_POSITIVITY_ALL_COMPACT_GROUPS_NARROW_THEOREM_NOTE_2026-07-09.md
@@ -1,15 +1,14 @@
-# Heat-Kernel Gauge Action: The Reflection-Plane Character-Positivity Step Is Manifest for ALL Compact Groups (Native RP Mechanism, No Group-Dependent Certificate)
+# Heat-Kernel Gauge Action: Manifest Reflection-Plane Character Positivity for a Specified Central Heat Semigroup
 
 **Date:** 2026-07-09
 **Claim type:** bounded_theorem
-**Status authority:** independent audit lane only. This source note does not set
-or predict an audit outcome.
+**Status:** source-side bounded proposal; independent audit required.
 **Primary runner:**
 [`scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py`](../scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py)
 **Cached output:**
 [`logs/runner-cache/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.txt`](../logs/runner-cache/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.txt)
 
-## The gap this note addresses
+## Comparison boundary
 
 The retained-bounded Wilson temporal-gauge RP bridge
 ([`AXIOM_FIRST_REFLECTION_POSITIVITY_WILSON_TEMPORAL_GAUGE_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05`](AXIOM_FIRST_REFLECTION_POSITIVITY_WILSON_TEMPORAL_GAUGE_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md),
@@ -17,26 +16,27 @@ ledger `effective_status = retained_bounded`) runs a three-step mechanism on the
 Wilson plane weight: (W1) reflection split of the action across the temporal
 reflection plane, (W2) **nonnegativity of the character coefficients of the
 plane (straddling) factor**, (W3) the integrated reflected Gram matrix is PSD
-because the plane factor is a norm-square kernel. Step (W2) is the load-bearing
-positivity input, and on the **Wilson** weight it is **group-dependent**:
+because the plane factor is a norm-square kernel. Step (W2) is load-bearing.
 
-- `Z_N`: exact finite DFT — coefficients computed and checked nonneg.
-- `U(1)`: modified Bessel `I_n(β) > 0` — positive-series certificate.
-- `SU(2)`: numeric/Monte-Carlo evidence only.
-- `SU(N≥3)`: **not derivable by that route.** Positivity of a class function
-  does not imply nonnegative character coefficients on a nonabelian group, and
-  the note's §4 conformance repair (PR #5050) rescoped its `SU(N≥3)` Wilson
-  positivity statement to the Osterwalder–Seiler **literature comparator**,
-  naming the heat-kernel action as the forward derivation path.
-
-This note takes exactly that named forward path.
+This note does **not** claim that the Wilson weight lacks a general positivity
+route. For a finite-dimensional unitary representation `R`,
+`exp[(β/2N)(χ_R+χ_R̄)]` expands as a positive power series in tensor-product
+characters, and every tensor product decomposes into irreducible characters
+with nonnegative integer multiplicities. That representation-ring route gives
+nonnegative Wilson character coefficients for compact `G`. The earlier
+group-dependent obstruction framing is therefore not an authority used here
+and requires separate source repair. This note instead proves the parallel
+heat-semigroup construction, whose coefficients and semigroup law are
+manifest from the spectral definition.
 
 ## Claim (narrow theorem, bounded)
 
-Let `G` be any compact group, `λ` its irreps with dimension `d_λ` and Casimir
-`C₂(λ)` (for the Lie cases, `C₂` in the retained trace-form normalization
-`Tr(T_a T_b) = δ_ab/2`; for finite/abelian testbeds, any nonnegative-spectrum
-group-Laplacian eigenvalue `λ_q ≥ 0` in place of `C₂`). Define the heat-kernel
+Let `G` be a compact Lie group equipped with a specified positive
+bi-invariant Laplacian, and let `λ` label its irreducible representations with
+dimension `d_λ` and nonnegative Laplacian eigenvalue `C₂(λ)`. For the `SU(N)`
+cases, `C₂` uses the retained trace-form normalization
+`Tr(T_a T_b) = δ_ab/2`. The finite and abelian runner testbeds use the explicitly
+specified nonnegative central generators stated below. Define the heat-kernel
 (HK) single-plaquette weight
 
 ```
@@ -49,12 +49,12 @@ unaudited; the SU(3) fundamental coefficient there, `exp(−2/3)` at `t = 1`,
 is `exp(−t·C₂/2)` with `C₂(fund) = 4/3` — the runner cross-checks this
 convention alignment). Then:
 
-- **H1 (spectral positivity — manifest, all compact `G`).**
-  `c_λ(t) = d_λ e^{−t C₂(λ)/2} > 0` for **every** irrep of **every** compact
-  group and every `t > 0`. The (W2)-analog on the HK weight requires **no**
-  group-dependent certificate: no DFT, no Bessel positivity, no Monte-Carlo
-  estimate. In particular it holds for `SU(3)` and all `SU(N)` — exactly the
-  cases where the Wilson-weight route is not derivable.
+- **H1 (spectral positivity — manifest for the specified heat semigroup).**
+  `c_λ(t) = d_λ e^{−t C₂(λ)/2} > 0` for **every** irrep of every compact Lie
+  group carrying the specified positive bi-invariant Laplacian and every
+  `t > 0`. The (W2)-analog on the HK weight follows directly from the spectral
+  definition. In particular it holds for `SU(3)` and all `SU(N)` with the
+  displayed Casimir convention.
 
 - **H2 (plane factor is a norm-square kernel).** `K_t` is real (the spectrum
   is closed under conjugation with `d_λ̄ = d_λ`, `C₂(λ̄) = C₂(λ)`), and by the
@@ -66,7 +66,7 @@ convention alignment). Then:
   ```
 
   a positive combination (`c_λ > 0`) of manifest Gram products — a norm-square
-  kernel in matrix-element features, for every compact `G`.
+  kernel in matrix-element features on this heat-semigroup surface.
 
 - **H3 (integrated two-slice RP Gram PSD, natively).** On the bridge note's
   two-slice temporal-gauge carrier (temporal gauge `U_0 = 1`, periodic spatial
@@ -80,13 +80,15 @@ convention alignment). Then:
   `G = W diag(κ) W†` with `κ ≥ 0`. This instantiates the retained gauge-half
   Cauchy–Schwarz hypotheses
   ([`REFLECTION_POSITIVITY_GAUGE_HALF_CAUCHY_SCHWARZ_NARROW_THEOREM_NOTE_2026-05-10`](REFLECTION_POSITIVITY_GAUGE_HALF_CAUCHY_SCHWARZ_NARROW_THEOREM_NOTE_2026-05-10.md),
-  ledger `effective_status = retained`) on the HK weight for **all** compact
-  `G` — including `SU(3)`, where the runner runs the integrated Gram check the
-  Wilson bridge could not derive.
+  ledger `effective_status = retained`) on the HK weight for compact Lie `G`
+  with the specified heat semigroup. The runner exercises the integrated Gram
+  numerically for `SU(2)` and `SU(3)` and exactly for the listed finite
+  testbeds; those checks support the factorization but are not its proof.
 
-- **H4 (pointwise positivity — Boltzmann sensibility).** `K_t > 0` pointwise,
+- **H4 (checked pointwise positivity — Boltzmann sensibility).** For the
+  groups and parameter values exercised by the runner, `K_t > 0` pointwise,
   so `S_HK = −log K_t` is a real action and the HK weight is a genuine
-  Boltzmann factor. Certified per group: `Z_N` exact evaluation; `U(1)` via
+  Boltzmann factor on those checked surfaces. Certified per group: `Z_N` exact evaluation; `U(1)` via
   the Poisson-summation (Jacobi theta) identity
   `Σ_n e^{−tn²/2} e^{inθ} = √(2π/t) Σ_m e^{−(θ−2πm)²/(2t)}` — a sum of
   manifestly positive Gaussian terms; `SU(2)` and `SU(3)` by a
@@ -94,24 +96,21 @@ convention alignment). Then:
   exceeds the certified evaluation error), exercised at the runner's printed
   `t` values. H4 is **not** needed for H3 (the
   Gram argument uses realness and spectral positivity, not pointwise
-  positivity); it is stated because a candidate *action* must have one.
+  positivity). No all-compact-group pointwise-positivity claim is inferred
+  from these finite testbeds.
 
-**Bounded scope.** The theorem is about the HK **candidate** weight on the
-narrow two-slice carrier. It upgrades the RP *mechanism* from
-group-dependent-certificate to manifest **on that candidate**; it does not
-select the candidate (see boundary below).
+**Bounded scope.** The theorem is about the HK **candidate** weight for a
+specified central heat semigroup on the narrow two-slice carrier. It makes
+the RP coefficient step manifest on that candidate; it does not select the
+candidate or establish pointwise positivity beyond the checked groups and
+parameters (see boundary below).
 
-## Why this is the structurally honest fix
+## Why the heat-semigroup form is useful
 
-The Wilson-weight (W2) obstruction is real mathematics: `exp(β·Re χ_fund)` has
-character coefficients given by group integrals that are not sign-definite
-term-by-term for nonabelian `G`, and no general positivity theorem applies.
-The HK weight **defines** the plane factor spectrally — positivity is not a
-property to be certified after the fact; it is the *definition's first line*.
-The group-dependence of (W2) is thereby located precisely: it is a property of
-the **Wilson parametrization** of the plane weight, not of the RP mechanism,
-the carrier, the reflection, or the gauge group. On the spectral (HK)
-parametrization the mechanism is uniform in `G`.
+The HK weight defines the plane factor spectrally, so coefficient positivity
+is the definition's first line and the semigroup law is explicit. This is a
+clean construction in its own right. It is not evidence for a Wilson-side
+obstruction, and the theorem's value does not depend on such an obstruction.
 
 Two structural bonuses, both re-proved in the runner rather than cited:
 
@@ -160,12 +159,9 @@ Two structural bonuses, both re-proved in the runner rather than cited:
 | `SU(3)` | manifest + tail bound | exact to 1e−11 (fund + adjoint) | seeded MC, tolerance-gated | grid + Lipschitz + tail certificate |
 
 The `SU(2)`/`SU(3)` integrated Grams are Monte-Carlo estimates (fixed seeds,
-printed tolerances) — same evidentiary class as the bridge note's Part E
-`SU(2)` check, now including the `SU(3)` case that the Wilson route had no
-derivable (W2) for. The deterministic content (H1, H2, semigroup,
-normalization, H4 certificates) is exact or certified with explicit error
-budgets, and is where the theorem's force lives: **the group-dependent step of
-the mechanism is gone by construction.**
+printed tolerances). The deterministic H1/H2 coefficient algebra and
+semigroup/normalization identities are exact on their stated surface. H4 is
+certified only for the groups and parameter values listed in the table.
 
 ## What this note does NOT claim
 
@@ -180,22 +176,24 @@ the mechanism is gone by construction.**
   (`RECORD_CLASSICAL_SEMIGROUP_BOUNDARY_2026-06-06`) is **audit_in_progress**
   on the live ledger. Nothing here leans on any of them; they are context
   pointers only.
-- **No modification of the Wilson bridge note.** Its Wilson-side scoping
-  (including the `SU(N≥3)` Osterwalder–Seiler comparator framing after
-  PR #5050) stands as audited. This note adds a parallel result on a different
-  weight; it does not edit, retire, or re-grade anything.
+- **No Wilson obstruction claim.** This note adds a parallel result on a
+  different weight. It neither endorses nor depends on the Wilson bridge's
+  `SU(N≥3)` comparator framing; the representation-ring route above shows
+  that framing requires separate source repair.
 - **No fermion factor, no full OS reconstruction.** Two-slice gauge-sector
   Gram positivity on a narrow carrier — not multi-slice transfer-matrix
   positivity (`AXIOM_FIRST_RP_TWO_STEP...` lineage), not a Hamiltonian, not a
   continuum limit, and no coupling value is fixed (`t` is a free positive
   parameter throughout; results are exercised at several `t`).
-- **No new axiom, no import.** The HK candidate, the carrier, the reflection,
+- **No new axiom.** The HK candidate, the carrier, the reflection,
   the observable algebra, and the trace-form normalization are existing
   framework content; character theory and Poisson summation are standard
   mathematical methods re-verified numerically by the runner. The
   Osterwalder–Seiler and textbook references below are **comparators only**
-  (already the bridge note's comparators — no new comparator is introduced);
-  every positivity statement used here is re-proved by the paired runner.
+  (already the bridge note's comparators — no new comparator is introduced).
+  The broad H1/H2 statement follows from the specified spectral definition;
+  the paired runner verifies its listed finite, abelian, and `SU(2)`/`SU(3)`
+  instances rather than exhaustively testing every compact Lie group.
 - **No audit-status statement.** Grades are set exclusively by the independent
   audit lane; this note predicts nothing.
 
@@ -252,8 +250,7 @@ above):** `HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS_NAR
   `t ∈ {0.3, 1.0, 2.5}`), plus the manifest factorization `G = W diag(κ) W†`
   with plane-kernel eigenvalues `κ ≥ 0` reproducing the direct Gram; the
   **dropped-conjugation negative control** (non-PSD); `U(1)` quadrature Gram;
-  `SU(2)` seeded MC Gram; **`SU(3)` seeded MC Gram** — the check the Wilson
-  bridge could not derivably run.
+  `SU(2)` seeded MC Gram; **`SU(3)` seeded MC Gram**.
 
 All checks are deterministic (fixed seeds); the runner prints
 `TOTAL: PASS=N FAIL=0` on success.
@@ -271,14 +268,10 @@ All checks are deterministic (fixed seeds); the runner prints
 
 ## Closing
 
-The bridge note ends its `SU(N≥3)` discussion at a comparator because the
-Wilson plane weight's character positivity is not derivable there. On the
-spectral heat-kernel parametrization of the same plane weight, that entire
-step is manifest for every compact group, the retained gauge-half
-Cauchy–Schwarz mechanism runs natively (including the integrated `SU(3)` Gram
-exercised here), the weight is automatically Haar-normalized and pointwise
-positive, and the antilinear-reflection control still separates the mechanism
-from vacuous positivity. The next path this opens: connecting this native-RP
-property to the action-*selection* question (the unaudited HK-candidate lanes
-above), where RP-for-all-`G` is now a structural property the HK candidate
-carries and the Wilson parametrization does not derivably share.
+On the spectral heat-semigroup parametrization, coefficient positivity is
+manifest, the retained gauge-half Cauchy–Schwarz mechanism runs natively, and
+the antilinear-reflection control still separates the mechanism from vacuous
+positivity. The runner checks the integrated `SU(3)` Gram as a numerical
+instance and certifies pointwise positivity only on its enumerated group and
+parameter surfaces. The remaining open path is action selection; this note
+does not choose the heat-kernel candidate or rule out the Wilson route.

--- a/logs/runner-cache/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.txt
+++ b/logs/runner-cache/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.txt
@@ -1,13 +1,13 @@
 ===== runner cache v1 =====
 runner: scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py
-runner_sha256: 40d28bec8b8351ebe3c4facb3bfeb9b9c59e785a2c7378b2bd1e158084fc205c
+runner_sha256: c936168f6122a4480b8335f1762503644c60f349044a38c82a515a70374157c0
 timeout_sec: 900
 exit_code: 0
-elapsed_sec: 14.20
+elapsed_sec: 10.62
 status: ok
 ----- stdout -----
 ========================================================================================
-Heat-kernel gauge action: native RP plane character positivity, all compact groups
+Heat-kernel gauge action: native RP plane character positivity on specified heat semigroups
 companion runner for the 2026-07-09 narrow theorem note
 ========================================================================================
 
@@ -46,13 +46,13 @@ Part D -- H2 cut factorization: chi(AB^dag) = sum_ij pi(A)_ij conj(pi(B)_ij)
   [PASS] D1: Z_5 factorization exact for all reps and group pairs  (max dev=1.6e-16)
   [PASS] D2: SU(2) symmetric-power reps: homomorphism, unitarity, trace = character  (hom=5.8e-16, unit=8.9e-16, tr=2.0e-15)
   [PASS] D3: SU(2) factorization chi_j(AB^dag) = sum_ij pi_j(A)_ij conj(pi_j(B)_ij)  (max dev=1.3e-15)
-  [PASS] D4: SU(3) adjoint: real, orthogonal, homomorphism, trace = |TrU|^2-1 = s_(1,1)  (im=5.6e-17, orth=6.7e-16, hom=3.4e-16, tr=2.8e-16, schur=5.1e-16)
-  [PASS] D5: SU(3) factorization, fundamental and adjoint  (fund=1.1e-16, adj=6.7e-16)
+  [PASS] D4: SU(3) adjoint: real, orthogonal, homomorphism, trace = |TrU|^2-1 = s_(1,1)  (im=5.6e-17, orth=2.6e-16, hom=2.5e-16, tr=1.4e-16, schur=7.2e-16)
+  [PASS] D5: SU(3) factorization, fundamental and adjoint  (fund=2.5e-16, adj=8.9e-16)
 
 ----------------------------------------------------------------------------------------
 Part E -- H3: integrated reflected Gram PSD with the HK weight
 ----------------------------------------------------------------------------------------
-  [PASS] E1: Z_N exact Gram PSD (N in {2,3,4,5}, t in {0.3,1.0,2.5})  (Z_2(t=0.3): min=-5.4e-16; Z_2(t=1.0): min=-5.3e-17; Z_2(t=2.5): min=-2.3e-18; Z_5(t=0.3): min=+1.1e-02 ...)
+  [PASS] E1: Z_N exact Gram PSD (N in {2,3,4,5}, t in {0.3,1.0,2.5})  (Z_2(t=0.3): min=-3.9e-16; Z_2(t=1.0): min=-4.6e-17; Z_2(t=2.5): min=-3.1e-18; Z_5(t=0.3): min=+1.1e-02 ...)
   [PASS] E2: dropped-conjugation control is NOT PSD (Z_4)  (min eig=-1.7253)
   [PASS] E3: manifest factorization G = W diag(kappa) W^dag, kappa >= 0 (Z_4, t=1.0)  (match dev=1.4e-13, kappa_min=+2.9e-01)
   [PASS] E4: U(1) quadrature Gram PSD (24-point grid, t in {0.5,1.5})  (t=0.5: min=+4.6e-03; t=1.5: min=+4.3e-02)

--- a/logs/runner-cache/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.txt
+++ b/logs/runner-cache/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.txt
@@ -1,0 +1,67 @@
+===== runner cache v1 =====
+runner: scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py
+runner_sha256: 40d28bec8b8351ebe3c4facb3bfeb9b9c59e785a2c7378b2bd1e158084fc205c
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 14.20
+status: ok
+----- stdout -----
+========================================================================================
+Heat-kernel gauge action: native RP plane character positivity, all compact groups
+companion runner for the 2026-07-09 narrow theorem note
+========================================================================================
+
+----------------------------------------------------------------------------------------
+Part A -- H1: manifest strict positivity of c_lambda(t), with tail bounds
+----------------------------------------------------------------------------------------
+  [PASS] A1: Z_N coefficients strictly positive (N=2..6, t in {0.3,1.0,2.5})
+  [PASS] A2: U(1) coefficients strictly positive (|n|<=30, t in {0.5,1.5})
+  [PASS] A3: SU(2) coefficients strictly positive (2j<=30) + tail(t=1, 2j>24) tiny  (tail<= 1.538e-34)
+  [PASS] A4: SU(3) dimension/Casimir spot checks + c_fund(1)/d = exp(-2/3) alignment  (|c_fund(1)/d - e^(-2/3)|=0.0e+00)
+  [PASS] A5: SU(3) coefficients strictly positive (p+q<=10, t in {1,2,3,4,6})
+  [PASS] A6: SU(3) truncation tails < 1e-10 at every (t, cut) used below  (t=1.0:cut16:1.3e-13; t=2.0:cut12:5.3e-19; t=3.0:cut10:2.4e-22; t=4.0:cut8:2.2e-21; t=6.0:cut8:3.7e-34)
+
+----------------------------------------------------------------------------------------
+Part B -- H2 algebra: semigroup, normalization, realness, orthonormality
+----------------------------------------------------------------------------------------
+  [PASS] B1: coefficient semigroup c(s)c(t)/d = c(s+t) on Z_N, U(1), SU(2), SU(3)  (max dev=1.1e-16)
+  [PASS] B2: Z_5 kernel-level convolution (K_0.4 * K_0.9) = K_1.3 exact  (max dev=2.2e-16)
+  [PASS] B3: Haar normalization: c_triv=1; mean_Z4 K=1; SU(2)/SU(3) Weyl integrals = 1  (max dev=1.1e-16)
+  [PASS] B4: realness of K_t (Z_5 exact; SU(3) torus grid; SU(2) m-sum is real by construction)  (Z_5 im=2.8e-16, SU(3) im=9.3e-15)
+  [PASS] B5: character orthonormality (SU(2) sin^2 measure; SU(3) Weyl 2-torus measure)  (max dev=3.3e-16)
+  [PASS] B6: U(1) Poisson/Jacobi-theta identity (character sum = Gaussian image sum)  (max dev=1.8e-15)
+  [PASS] B7: Schur machinery at identity: s_(p,q)(1,1,1) = d_(p,q) for p+q<=6  (max dev=0.0e+00)
+
+----------------------------------------------------------------------------------------
+Part C -- H4: pointwise positivity of K_t (certificates at printed t)
+----------------------------------------------------------------------------------------
+  [PASS] C1: Z_N pointwise positivity, exact (N=2..6, t in {0.3,1.0,2.5})  (Z_2(t=0.3):4.512e-01; Z_4(t=0.3):6.718e-02)
+  [PASS] C2: U(1) pointwise positivity (term-positive Gaussian rep; grid min > 0)  (t=0.5: min=3.667e-04; t=1.5: min=1.525e-01)
+  [PASS] C3: SU(2) strict-positivity certificate (grid + Lipschitz + tail)  (t=3.0: min=0.0948, err=1.87e-04; t=4.0: min=0.2636, err=9.81e-05)
+  [PASS] C4: SU(3) strict-positivity certificate (torus grid + Lipschitz + tail)  (t=4.0: min=0.4835, err=2.80e-02; t=6.0: min=0.8414, err=5.52e-03)
+
+----------------------------------------------------------------------------------------
+Part D -- H2 cut factorization: chi(AB^dag) = sum_ij pi(A)_ij conj(pi(B)_ij)
+----------------------------------------------------------------------------------------
+  [PASS] D1: Z_5 factorization exact for all reps and group pairs  (max dev=1.6e-16)
+  [PASS] D2: SU(2) symmetric-power reps: homomorphism, unitarity, trace = character  (hom=5.8e-16, unit=8.9e-16, tr=2.0e-15)
+  [PASS] D3: SU(2) factorization chi_j(AB^dag) = sum_ij pi_j(A)_ij conj(pi_j(B)_ij)  (max dev=1.3e-15)
+  [PASS] D4: SU(3) adjoint: real, orthogonal, homomorphism, trace = |TrU|^2-1 = s_(1,1)  (im=5.6e-17, orth=6.7e-16, hom=3.4e-16, tr=2.8e-16, schur=5.1e-16)
+  [PASS] D5: SU(3) factorization, fundamental and adjoint  (fund=1.1e-16, adj=6.7e-16)
+
+----------------------------------------------------------------------------------------
+Part E -- H3: integrated reflected Gram PSD with the HK weight
+----------------------------------------------------------------------------------------
+  [PASS] E1: Z_N exact Gram PSD (N in {2,3,4,5}, t in {0.3,1.0,2.5})  (Z_2(t=0.3): min=-5.4e-16; Z_2(t=1.0): min=-5.3e-17; Z_2(t=2.5): min=-2.3e-18; Z_5(t=0.3): min=+1.1e-02 ...)
+  [PASS] E2: dropped-conjugation control is NOT PSD (Z_4)  (min eig=-1.7253)
+  [PASS] E3: manifest factorization G = W diag(kappa) W^dag, kappa >= 0 (Z_4, t=1.0)  (match dev=1.4e-13, kappa_min=+2.9e-01)
+  [PASS] E4: U(1) quadrature Gram PSD (24-point grid, t in {0.5,1.5})  (t=0.5: min=+4.6e-03; t=1.5: min=+4.3e-02)
+  [PASS] E5: SU(2) MC Gram PSD within MC tolerance (t=3.0, n=200k, seed 0)  (min eig=+3.45e-02, tol=3.5e-02, herm=1.2e-02, w_min=1.49e-04, ESS=38756)
+  [PASS] E6: SU(3) MC Gram PSD within MC tolerance (t=3.0, n=400k, seed 1)  (min eig=+1.43e-02, tol=2.2e-02, herm=7.3e-03, w_min=1.25e-02, ESS=114246)
+
+========================================================================================
+TOTAL: PASS=28 FAIL=0
+========================================================================================
+
+----- stderr -----
+

--- a/logs/runner-cache/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.txt
+++ b/logs/runner-cache/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py
-runner_sha256: c936168f6122a4480b8335f1762503644c60f349044a38c82a515a70374157c0
+runner_sha256: ae41b968fb1c8f631412e7a2e68753ed319c4c0dee5ec704547fb45f23bfe5e6
 timeout_sec: 900
 exit_code: 0
-elapsed_sec: 10.62
+elapsed_sec: 10.51
 status: ok
 ----- stdout -----
 ========================================================================================
@@ -12,14 +12,13 @@ companion runner for the 2026-07-09 narrow theorem note
 ========================================================================================
 
 ----------------------------------------------------------------------------------------
-Part A -- H1: manifest strict positivity of c_lambda(t), with tail bounds
+Part A -- H1: manifest strict positivity of c_lambda(t)
 ----------------------------------------------------------------------------------------
   [PASS] A1: Z_N coefficients strictly positive (N=2..6, t in {0.3,1.0,2.5})
   [PASS] A2: U(1) coefficients strictly positive (|n|<=30, t in {0.5,1.5})
-  [PASS] A3: SU(2) coefficients strictly positive (2j<=30) + tail(t=1, 2j>24) tiny  (tail<= 1.538e-34)
+  [PASS] A3: SU(2) sampled coefficients strictly positive (2j<=30)
   [PASS] A4: SU(3) dimension/Casimir spot checks + c_fund(1)/d = exp(-2/3) alignment  (|c_fund(1)/d - e^(-2/3)|=0.0e+00)
   [PASS] A5: SU(3) coefficients strictly positive (p+q<=10, t in {1,2,3,4,6})
-  [PASS] A6: SU(3) truncation tails < 1e-10 at every (t, cut) used below  (t=1.0:cut16:1.3e-13; t=2.0:cut12:5.3e-19; t=3.0:cut10:2.4e-22; t=4.0:cut8:2.2e-21; t=6.0:cut8:3.7e-34)
 
 ----------------------------------------------------------------------------------------
 Part B -- H2 algebra: semigroup, normalization, realness, orthonormality
@@ -33,12 +32,12 @@ Part B -- H2 algebra: semigroup, normalization, realness, orthonormality
   [PASS] B7: Schur machinery at identity: s_(p,q)(1,1,1) = d_(p,q) for p+q<=6  (max dev=0.0e+00)
 
 ----------------------------------------------------------------------------------------
-Part C -- H4: pointwise positivity of K_t (certificates at printed t)
+Part C -- H4: pointwise-positivity boundary at printed t
 ----------------------------------------------------------------------------------------
   [PASS] C1: Z_N pointwise positivity, exact (N=2..6, t in {0.3,1.0,2.5})  (Z_2(t=0.3):4.512e-01; Z_4(t=0.3):6.718e-02)
   [PASS] C2: U(1) pointwise positivity (term-positive Gaussian rep; grid min > 0)  (t=0.5: min=3.667e-04; t=1.5: min=1.525e-01)
-  [PASS] C3: SU(2) strict-positivity certificate (grid + Lipschitz + tail)  (t=3.0: min=0.0948, err=1.87e-04; t=4.0: min=0.2636, err=9.81e-05)
-  [PASS] C4: SU(3) strict-positivity certificate (torus grid + Lipschitz + tail)  (t=4.0: min=0.4835, err=2.80e-02; t=6.0: min=0.8414, err=5.52e-03)
+  [PASS] C3: SU(2) finite-truncation grid is positive (support only)  (t=3.0: truncated-grid min=0.0948; t=4.0: truncated-grid min=0.2636)
+  [PASS] C4: SU(3) finite-truncation torus grid is positive (support only)  (t=4.0: truncated-grid min=0.4835; t=6.0: truncated-grid min=0.8414)
 
 ----------------------------------------------------------------------------------------
 Part D -- H2 cut factorization: chi(AB^dag) = sum_ij pi(A)_ij conj(pi(B)_ij)
@@ -60,7 +59,7 @@ Part E -- H3: integrated reflected Gram PSD with the HK weight
   [PASS] E6: SU(3) MC Gram PSD within MC tolerance (t=3.0, n=400k, seed 1)  (min eig=+1.43e-02, tol=2.2e-02, herm=7.3e-03, w_min=1.25e-02, ESS=114246)
 
 ========================================================================================
-TOTAL: PASS=28 FAIL=0
+TOTAL: PASS=27 FAIL=0
 ========================================================================================
 
 ----- stderr -----

--- a/logs/runner-cache/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.txt
+++ b/logs/runner-cache/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.txt
@@ -3,7 +3,7 @@ runner: scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity
 runner_sha256: ae41b968fb1c8f631412e7a2e68753ed319c4c0dee5ec704547fb45f23bfe5e6
 timeout_sec: 900
 exit_code: 0
-elapsed_sec: 10.51
+elapsed_sec: 10.34
 status: ok
 ----- stdout -----
 ========================================================================================

--- a/scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py
+++ b/scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py
@@ -1,0 +1,770 @@
+#!/usr/bin/env python3
+"""Audit-companion runner for
+HEAT_KERNEL_GAUGE_ACTION_NATIVE_RP_PLANE_CHARACTER_POSITIVITY_ALL_COMPACT_GROUPS_NARROW_THEOREM_NOTE_2026-07-09.
+
+Everything below is REPROVED from finite-dimensional computation inside this
+file; nothing is cited as an input. The heat-kernel (HK) plane weight is
+
+    K_t = sum_lambda c_lambda(t) chi_lambda ,   c_lambda(t) = d_lambda * exp(-t*C2(lambda)/2)
+
+with C2 in the retained trace-form normalization Tr(T_a T_b) = delta_ab/2 for
+the Lie cases (SU(3) fundamental C2 = 4/3, so c_fund(1)/d = exp(-2/3), the
+same convention as the HK candidate notes), and a nonnegative-spectrum group
+Laplacian for the finite/abelian testbeds (Z_N cycle Cayley set {+-1}:
+lambda_q = 2(1-cos(2*pi*q/N)); U(1): lambda_n = n^2).
+
+Setup (mirrors the Wilson temporal-gauge RP bridge note's carrier):
+  * two time slices t in {0,1}; one periodic spatial direction; L_s = 2
+    spatial links per slice; temporal gauge U_0 = 1;
+  * reflection theta swaps the slices; Theta is ANTILINEAR:
+    Theta(F)(U) = conj(F(theta U));
+  * HK weight w(c0,c1) = K_t(loop(c1)) * K_t(loop(c0)) * prod_k K_t(U_k(0) U_k(1)^dag);
+  * positive-half observables: abelian character-degree<=2 monomials /
+    the bridge note's 6-element matrix-element basis.
+
+Parts:
+  A (H1): manifest strict positivity of c_lambda(t) for Z_N, U(1), SU(2),
+     SU(3); SU(3) dimension/Casimir spot checks incl. the exp(-2/3)
+     convention alignment; superexponential truncation-tail bounds with
+     geometric-majorant guards.
+  B (H2 algebra): coefficient-level semigroup c(s)c(t)/d = c(s+t) on all
+     four groups; exact Z_N kernel-level convolution; Haar normalization
+     (trivial coefficient = 1; quadrature integrals = 1); realness of K_t;
+     character orthonormality on trig-exact Weyl quadrature grids (validates
+     the Schur-polynomial character machinery); U(1) Poisson/Jacobi-theta
+     identity; Schur(identity) = dimension.
+  C (H4): pointwise positivity. Z_N exact; U(1) via the term-positive
+     Gaussian image sum; SU(2)/SU(3) grid + Lipschitz + truncation-tail
+     certificates at printed t values (H4 is not consumed by H3).
+  D (H2 cut factorization): chi_lambda(A B^dag) = sum_ij pi_lambda(A)_ij *
+     conj(pi_lambda(B)_ij) exactly, on seeded random pairs: Z_N all reps;
+     SU(2) unitary symmetric-power reps j in {1/2,1,3/2,2}; SU(3)
+     fundamental and adjoint (pi_ad(U)_ab = 2 Tr(T_a U T_b U^dag)).
+  E (H3): integrated reflected Gram PSD on the two-slice carrier with the
+     HK weight: Z_N exact over all configurations; dropped-conjugation
+     negative control (non-PSD); manifest factorization G = W diag(kappa)
+     W^dag with plane-kernel eigenvalues kappa >= 0; U(1) quadrature Gram;
+     SU(2) and SU(3) seeded Monte-Carlo Grams (the SU(3) case is the one
+     the Wilson-weight route had no derivable coefficient-positivity for).
+
+Literature disclaimer: Osterwalder & Seiler, Ann. Phys. 110 (1978) 440, and
+Montvay & Munster, "Quantum Fields on a Lattice" Sec. 3.4, are comparators
+only; every positivity statement above is reproved here. No PDG / fitted /
+measured / lattice-MC-input / beta=6 / g_bare value is used as a derivation
+input. This runner is an audit companion for a bounded theorem note: not a
+new claim row beyond its note, not a status promotion; audit grades are set
+exclusively by the independent audit lane.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+
+import numpy as np
+
+AUDIT_TIMEOUT_SEC = 900
+
+PASS = 0
+FAIL = 0
+
+
+def check(label: str, ok: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if ok:
+        PASS += 1
+        print(f"  [PASS] {label}" + (f"  ({detail})" if detail else ""))
+    else:
+        FAIL += 1
+        print(f"  [FAIL] {label}" + (f"  ({detail})" if detail else ""))
+
+
+def section(title: str) -> None:
+    print()
+    print("-" * 88)
+    print(title)
+    print("-" * 88)
+
+
+# ----------------------------------------------------------------------------
+# Group spectral data and kernels
+# ----------------------------------------------------------------------------
+
+def zn_coeffs(N: int, t: float) -> np.ndarray:
+    q = np.arange(N)
+    lam = 2.0 * (1.0 - np.cos(2.0 * np.pi * q / N))
+    return np.exp(-t * lam / 2.0)
+
+
+def zn_kernel(N: int, t: float) -> np.ndarray:
+    """K_t(n) for n = 0..N-1 (exact finite character sum; real)."""
+    c = zn_coeffs(N, t)
+    n = np.arange(N)
+    phases = np.exp(2j * np.pi * np.outer(q_ := np.arange(N), n) / N)
+    K = (c[:, None] * phases).sum(axis=0)
+    assert np.abs(K.imag).max() < 1e-12
+    return K.real
+
+
+def u1_kernel_on_grid(theta: np.ndarray, t: float, nmax: int = 60) -> np.ndarray:
+    n = np.arange(-nmax, nmax + 1)
+    c = np.exp(-t * n.astype(float) ** 2 / 2.0)
+    K = (c[:, None] * np.exp(1j * np.outer(n, theta))).sum(axis=0)
+    return K.real
+
+
+def u1_gaussian_image_sum(theta: np.ndarray, t: float, mmax: int = 8) -> np.ndarray:
+    out = np.zeros_like(theta)
+    for m in range(-mmax, mmax + 1):
+        out += np.exp(-(theta - 2.0 * np.pi * m) ** 2 / (2.0 * t))
+    return math.sqrt(2.0 * np.pi / t) * out
+
+
+def su2_irreps(jmax_twice: int):
+    """[(j, d, C2)] for 2j = 0..jmax_twice."""
+    out = []
+    for tw in range(jmax_twice + 1):
+        j = tw / 2.0
+        out.append((j, tw + 1, j * (j + 1.0)))
+    return out
+
+
+def su2_char_grid(j: float, theta: np.ndarray) -> np.ndarray:
+    """chi_j(theta) = sum_m exp(2 i m theta) via the everywhere-stable m-sum."""
+    ms = -j + np.arange(int(2 * j) + 1)
+    return np.cos(2.0 * np.outer(ms, theta)).sum(axis=0)
+
+
+def su2_kernel_grid(theta: np.ndarray, t: float, jmax_twice: int) -> np.ndarray:
+    K = np.zeros_like(theta)
+    for j, d, C2 in su2_irreps(jmax_twice):
+        K += d * math.exp(-t * C2 / 2.0) * su2_char_grid(j, theta)
+    return K
+
+
+def su2_theta_of(U: np.ndarray) -> np.ndarray:
+    """Conjugacy angle theta in [0, pi] from stacked SU(2) matrices."""
+    tr = np.einsum("...ii->...", U).real
+    return np.arccos(np.clip(tr / 2.0, -1.0, 1.0))
+
+
+def su3_irreps(cut: int):
+    """[(p, q, d, C2)] for p+q <= cut."""
+    out = []
+    for p in range(cut + 1):
+        for q in range(cut + 1 - p):
+            d = (p + 1) * (q + 1) * (p + q + 2) // 2
+            C2 = (p * p + q * q + p * q + 3 * p + 3 * q) / 3.0
+            out.append((p, q, d, C2))
+    return out
+
+
+def su3_h_polys(x: np.ndarray, kmax: int) -> dict:
+    """Complete homogeneous h_k(x1,x2,x3) via Newton identities, vectorized.
+
+    x: (..., 3) complex eigenvalues. Returns {k: (...) array}, h_{-2}=h_{-1}=0.
+    """
+    shape = x.shape[:-1]
+    p = {k: (x ** k).sum(axis=-1) for k in range(1, kmax + 1)}
+    h = {-2: np.zeros(shape, dtype=complex), -1: np.zeros(shape, dtype=complex),
+         0: np.ones(shape, dtype=complex)}
+    for k in range(1, kmax + 1):
+        acc = np.zeros(shape, dtype=complex)
+        for i in range(1, k + 1):
+            acc = acc + p[i] * h[k - i]
+        h[k] = acc / k
+    return h
+
+
+def su3_schur(h: dict, p: int, q: int) -> np.ndarray:
+    """s_lambda for partition (p+q, q, 0) via 3x3 Jacobi-Trudi in h."""
+    l1, l2 = p + q, q
+    a, b, c = h[l1], h[l1 + 1], h[l1 + 2]
+    d_, e, f = h[l2 - 1], h[l2], h[l2 + 1]
+    g, i_, jj = h[-2], h[-1], h[0]
+    return (a * (e * jj - f * i_)
+            - b * (d_ * jj - f * g)
+            + c * (d_ * i_ - e * g))
+
+
+def su3_kernel_from_eigs(x: np.ndarray, t: float, cut: int,
+                         return_imag: bool = False):
+    """K_t from eigenvalues x (..., 3), truncated at p+q <= cut."""
+    irreps = su3_irreps(cut)
+    h = su3_h_polys(x, cut + 2)
+    K = np.zeros(x.shape[:-1], dtype=complex)
+    for p, q, d, C2 in irreps:
+        K = K + d * math.exp(-t * C2 / 2.0) * su3_schur(h, p, q)
+    if return_imag:
+        return K.real, np.abs(K.imag).max()
+    return K.real
+
+
+def su3_torus_eigs(t1: np.ndarray, t2: np.ndarray) -> np.ndarray:
+    x = np.empty(t1.shape + (3,), dtype=complex)
+    x[..., 0] = np.exp(1j * t1)
+    x[..., 1] = np.exp(1j * t2)
+    x[..., 2] = np.exp(-1j * (t1 + t2))
+    return x
+
+
+def su2_tail_bound(t: float, jmax_twice_cut: int, extra: int = 40):
+    """Bound sum_{2j > cut} d^2 exp(-t C2/2) with a geometric-majorant guard."""
+    terms = []
+    for tw in range(jmax_twice_cut + 1, jmax_twice_cut + 1 + extra):
+        j = tw / 2.0
+        terms.append((tw + 1) ** 2 * math.exp(-t * j * (j + 1) / 2.0))
+    ratios_ok = all(terms[i + 1] < 0.5 * terms[i] for i in range(len(terms) - 1)
+                    if terms[i] > 0)
+    return sum(terms) + terms[-1], ratios_ok
+
+
+def su3_tail_bound(t: float, cut: int, extra: int = 30):
+    """Bound sum_{p+q > cut} d^2 exp(-t C2/2) with a geometric-majorant guard."""
+    level = []
+    for s in range(cut + 1, cut + 1 + extra):
+        tot = 0.0
+        for p in range(s + 1):
+            q = s - p
+            d = (p + 1) * (q + 1) * (p + q + 2) / 2.0
+            C2 = (p * p + q * q + p * q + 3 * p + 3 * q) / 3.0
+            tot += d * d * math.exp(-t * C2 / 2.0)
+        level.append(tot)
+    ratios_ok = all(level[i + 1] < 0.5 * level[i] for i in range(len(level) - 1)
+                    if level[i] > 0)
+    return sum(level) + level[-1], ratios_ok
+
+
+# ----------------------------------------------------------------------------
+# Haar sampling
+# ----------------------------------------------------------------------------
+
+def rand_su2(rng: np.random.Generator, n: int) -> np.ndarray:
+    v = rng.standard_normal((n, 4))
+    v /= np.linalg.norm(v, axis=1, keepdims=True)
+    a, b, c, d = v[:, 0], v[:, 1], v[:, 2], v[:, 3]
+    U = np.empty((n, 2, 2), dtype=complex)
+    U[:, 0, 0] = a + 1j * b
+    U[:, 0, 1] = c + 1j * d
+    U[:, 1, 0] = -c + 1j * d
+    U[:, 1, 1] = a - 1j * b
+    return U
+
+
+def rand_su3(rng: np.random.Generator, n: int) -> np.ndarray:
+    Z = (rng.standard_normal((n, 3, 3)) + 1j * rng.standard_normal((n, 3, 3)))
+    Q, R = np.linalg.qr(Z)
+    diag = np.einsum("...ii->...i", R)
+    ph = diag / np.abs(diag)
+    Q = Q * ph[:, None, :]
+    det = np.linalg.det(Q)
+    Q = Q * np.exp(-1j * np.angle(det) / 3.0)[:, None, None]
+    return Q
+
+
+def dagger(U: np.ndarray) -> np.ndarray:
+    return np.conj(np.swapaxes(U, -1, -2))
+
+
+# ----------------------------------------------------------------------------
+# Abelian exact/quadrature integrated Gram (Z_N and U(1)-grid), L_s = 2
+# ----------------------------------------------------------------------------
+
+def abelian_basis(Ls: int = 2):
+    qs = [(0,) * Ls]
+    for q in itertools.product((-1, 0, 1), repeat=Ls):
+        if 1 <= sum(abs(x) for x in q) <= 2:
+            qs.append(q)
+    return np.array(qs)
+
+
+def abelian_gram(Kvals: np.ndarray, conj_first: bool = True, Ls: int = 2):
+    """Reflected Gram over all slice configs on the N-point group/grid.
+
+    Kvals[d] = K_t at group element d (real). Weight:
+    w(c0,c1) = K(loop(c1)) K(loop(c0)) prod_k K(c0_k - c1_k).
+    G_ij = (1/Z) sum_{c0,c1} w * conj(F_i(c0)) * F_j(c1)   (conj dropped when
+    conj_first=False -- the negative control).
+    """
+    N = len(Kvals)
+    idx = np.indices((N,) * Ls).reshape(Ls, -1)          # (Ls, M)
+    M = idx.shape[1]
+    hvec = Kvals[idx.sum(axis=0) % N]                    # (M,) half weights
+    D = (idx[:, :, None] - idx[:, None, :]) % N          # (Ls, M, M)
+    Kplane = Kvals[D].prod(axis=0)                       # (M, M)
+    qs = abelian_basis(Ls)
+    phases = (2.0 * np.pi / N) * (qs @ idx)              # (B, M)
+    F = np.exp(1j * phases)
+    row = (np.conj(F) if conj_first else F) * hvec
+    col = F * hvec
+    Gu = row @ Kplane @ col.T
+    Z = float(hvec @ Kplane @ hvec)
+    return Gu, Z, Kplane, hvec, F
+
+
+def psd_report(G: np.ndarray):
+    herm = np.abs(G - G.conj().T).max()
+    ev = np.linalg.eigvalsh((G + G.conj().T) / 2.0)
+    return ev.min(), herm
+
+
+# ----------------------------------------------------------------------------
+# SU(2) symmetric-power representation (Part D)
+# ----------------------------------------------------------------------------
+
+def su2_sym_power(U: np.ndarray, n: int) -> np.ndarray:
+    """Unitary irrep of SU(2) on degree-n Bargmann monomials e_ab = z1^a z2^b /
+    sqrt(a! b!), via (pi(U) f)(z) = f(U^{-1} z). Dimension n+1."""
+    Minv = U.conj().T
+    dim = n + 1
+    pi = np.zeros((dim, dim), dtype=complex)
+    fact = [math.factorial(k) for k in range(n + 1)]
+    for col, (a, b) in enumerate((n - k, k) for k in range(dim)):
+        # expand (M11 z1 + M12 z2)^a (M21 z1 + M22 z2)^b
+        coeff = {}
+        for i in range(a + 1):
+            for k in range(b + 1):
+                c1 = i + k
+                w = (math.comb(a, i) * Minv[0, 0] ** i * Minv[0, 1] ** (a - i)
+                     * math.comb(b, k) * Minv[1, 0] ** k * Minv[1, 1] ** (b - k))
+                coeff[c1] = coeff.get(c1, 0.0) + w
+        for c1, w in coeff.items():
+            d1 = n - c1
+            rowi = n - c1
+            pi[rowi, col] = (w * math.sqrt(fact[c1] * fact[d1])
+                             / math.sqrt(fact[a] * fact[b]))
+    return pi
+
+
+GELL_MANN = [
+    np.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]], dtype=complex),
+    np.array([[0, -1j, 0], [1j, 0, 0], [0, 0, 0]], dtype=complex),
+    np.array([[1, 0, 0], [0, -1, 0], [0, 0, 0]], dtype=complex),
+    np.array([[0, 0, 1], [0, 0, 0], [1, 0, 0]], dtype=complex),
+    np.array([[0, 0, -1j], [0, 0, 0], [1j, 0, 0]], dtype=complex),
+    np.array([[0, 0, 0], [0, 0, 1], [0, 1, 0]], dtype=complex),
+    np.array([[0, 0, 0], [0, 0, -1j], [0, 1j, 0]], dtype=complex),
+    np.array([[1, 0, 0], [0, 1, 0], [0, 0, -2]], dtype=complex) / math.sqrt(3.0),
+]
+
+
+def su3_adjoint(U: np.ndarray) -> np.ndarray:
+    """pi_ad(U)_ab = 2 Tr(T_a U T_b U^dag), T_a = lambda_a/2."""
+    Ud = U.conj().T
+    pi = np.empty((8, 8), dtype=complex)
+    for a in range(8):
+        for b in range(8):
+            pi[a, b] = 0.5 * np.trace(GELL_MANN[a] @ U @ GELL_MANN[b] @ Ud)
+    return pi
+
+
+# ----------------------------------------------------------------------------
+# Monte-Carlo integrated Gram (SU(2)/SU(3)), L_s = 2
+# ----------------------------------------------------------------------------
+
+def mc_gram(group: str, t: float, n: int, seed: int, cut: int):
+    rng = np.random.default_rng(seed)
+    sampler = rand_su2 if group == "su2" else rand_su3
+    L = [[sampler(rng, n) for _s in (0, 1)] for _k in (0, 1)]
+
+    loop0 = L[0][0] @ L[1][0]
+    loop1 = L[0][1] @ L[1][1]
+    str0 = L[0][0] @ dagger(L[0][1])
+    str1 = L[1][0] @ dagger(L[1][1])
+
+    if group == "su2":
+        def kern(V):
+            th = su2_theta_of(V)
+            K = np.zeros(n)
+            for j, d, C2 in su2_irreps(cut):
+                K += d * math.exp(-t * C2 / 2.0) * su2_char_grid(j, th)
+            return K, 0.0
+    else:
+        def kern(V):
+            x = np.linalg.eigvals(V)
+            return su3_kernel_from_eigs(x, t, cut, return_imag=True)
+
+    kvals, imags = [], []
+    for V in (loop0, loop1, str0, str1):
+        K, im = kern(V)
+        kvals.append(K)
+        imags.append(im)
+    w = kvals[0] * kvals[1] * kvals[2] * kvals[3]
+
+    def obs(A, B):
+        trA = np.einsum("nii->n", A)
+        trB = np.einsum("nii->n", B)
+        trAB = np.einsum("nij,nji->n", A, B)
+        one = np.ones(n, dtype=complex)
+        if group == "su2":
+            fifth = A[:, 0, 0]
+        else:
+            fifth = np.conj(trA)
+        return np.stack([one, trA, trB, trAB, fifth, B[:, 0, 1]])
+
+    Fpos = obs(L[0][1], L[1][1])
+    Fneg = obs(L[0][0], L[1][0])
+    G = np.einsum("s,is,js->ij", w, np.conj(Fneg), Fpos) / w.sum()
+    ess = float(w.sum() ** 2 / (w * w).sum())
+    return G, w, max(imags), ess
+
+
+# ----------------------------------------------------------------------------
+# Parts
+# ----------------------------------------------------------------------------
+
+def part_a():
+    section("Part A -- H1: manifest strict positivity of c_lambda(t), with tail bounds")
+
+    ok = True
+    detail = []
+    for N in range(2, 7):
+        for t in (0.3, 1.0, 2.5):
+            c = zn_coeffs(N, t)
+            ok = ok and bool(c.min() > 0.0)
+    check("A1: Z_N coefficients strictly positive (N=2..6, t in {0.3,1.0,2.5})", ok)
+
+    # |n| <= 30 keeps exp(-t n^2/2) inside float64 range at t=1.5 (exp(-675));
+    # positivity of exp(real) is manifest, the check certifies the computed values.
+    n = np.arange(-30, 31)
+    ok = True
+    for t in (0.5, 1.5):
+        c = np.exp(-t * n.astype(float) ** 2 / 2.0)
+        ok = ok and bool(c.min() > 0.0)
+    check("A2: U(1) coefficients strictly positive (|n|<=30, t in {0.5,1.5})", ok)
+
+    ok = True
+    for t in (1.0, 1.5, 3.0, 4.0):
+        cs = [d * math.exp(-t * C2 / 2.0) for _j, d, C2 in su2_irreps(30)]
+        ok = ok and min(cs) > 0.0
+    tail, guard = su2_tail_bound(1.0, 24)
+    check("A3: SU(2) coefficients strictly positive (2j<=30) + tail(t=1, 2j>24) tiny",
+          ok and guard and tail < 1e-12, f"tail<= {tail:.3e}")
+
+    spot = {(1, 0): (3, 4.0 / 3.0), (0, 1): (3, 4.0 / 3.0), (1, 1): (8, 3.0),
+            (2, 0): (6, 10.0 / 3.0), (3, 0): (10, 6.0), (2, 1): (15, 16.0 / 3.0),
+            (2, 2): (27, 8.0)}
+    ok = True
+    c2_fund = None
+    for (p, q, d, C2) in su3_irreps(10):
+        if (p, q) == (1, 0):
+            c2_fund = C2
+        if (p, q) in spot:
+            d0, C20 = spot[(p, q)]
+            ok = ok and d == d0 and abs(C2 - C20) < 1e-12
+    align = abs(math.exp(-1.0 * c2_fund / 2.0) - math.exp(-2.0 / 3.0))
+    check("A4: SU(3) dimension/Casimir spot checks + c_fund(1)/d = exp(-2/3) alignment",
+          ok and align < 1e-15, f"|c_fund(1)/d - e^(-2/3)|={align:.1e}")
+
+    ok = True
+    for t in (1.0, 2.0, 3.0, 4.0, 6.0):
+        cs = [d * math.exp(-t * C2 / 2.0) for _p, _q, d, C2 in su3_irreps(10)]
+        ok = ok and min(cs) > 0.0
+    check("A5: SU(3) coefficients strictly positive (p+q<=10, t in {1,2,3,4,6})", ok)
+
+    ok = True
+    details = []
+    for t, cut in ((1.0, 16), (2.0, 12), (3.0, 10), (4.0, 8), (6.0, 8)):
+        tail, guard = su3_tail_bound(t, cut)
+        ok = ok and guard and tail < 1e-10
+        details.append(f"t={t}:cut{cut}:{tail:.1e}")
+    check("A6: SU(3) truncation tails < 1e-10 at every (t, cut) used below",
+          ok, "; ".join(details))
+
+
+def part_b():
+    section("Part B -- H2 algebra: semigroup, normalization, realness, orthonormality")
+
+    s, t = 0.7, 1.3
+    worst = 0.0
+    for N in range(2, 7):
+        lhs = zn_coeffs(N, s) * zn_coeffs(N, t)
+        rhs = zn_coeffs(N, s + t)
+        worst = max(worst, float(np.abs(lhs - rhs).max()))
+    n = np.arange(-40, 41).astype(float)
+    worst = max(worst, float(np.abs(np.exp(-s * n * n / 2) * np.exp(-t * n * n / 2)
+                                    - np.exp(-(s + t) * n * n / 2)).max()))
+    for _j, d, C2 in su2_irreps(30):
+        cs_, ct_, cst = (d * math.exp(-u * C2 / 2.0) for u in (s, t, s + t))
+        worst = max(worst, abs(cs_ * ct_ / d - cst))
+    for _p, _q, d, C2 in su3_irreps(10):
+        cs_, ct_, cst = (d * math.exp(-u * C2 / 2.0) for u in (s, t, s + t))
+        worst = max(worst, abs(cs_ * ct_ / d - cst))
+    check("B1: coefficient semigroup c(s)c(t)/d = c(s+t) on Z_N, U(1), SU(2), SU(3)",
+          worst < 1e-12, f"max dev={worst:.1e}")
+
+    N = 5
+    Ks, Kt, Kst = zn_kernel(N, 0.4), zn_kernel(N, 0.9), zn_kernel(N, 1.3)
+    conv = np.array([(Ks * np.roll(Kt[::-1], nn + 1)).sum() / N for nn in range(N)])
+    dev = float(np.abs(conv - Kst).max())
+    check("B2: Z_5 kernel-level convolution (K_0.4 * K_0.9) = K_1.3 exact",
+          dev < 1e-12, f"max dev={dev:.1e}")
+
+    devs = []
+    devs.append(abs(zn_coeffs(4, 1.0)[0] - 1.0))
+    devs.append(abs(zn_kernel(4, 1.0).mean() - 1.0))
+    th = np.linspace(0.0, np.pi, 4096, endpoint=False) + np.pi / 8192
+    K2 = su2_kernel_grid(th, 1.5, 24)
+    devs.append(abs((2.0 / np.pi) * np.mean(np.sin(th) ** 2 * K2) * np.pi - 1.0))
+    g = 72
+    t1, t2 = np.meshgrid(2 * np.pi * np.arange(g) / g, 2 * np.pi * np.arange(g) / g,
+                         indexing="ij")
+    x = su3_torus_eigs(t1, t2)
+    delta2 = (np.abs(x[..., 0] - x[..., 1]) ** 2 * np.abs(x[..., 0] - x[..., 2]) ** 2
+              * np.abs(x[..., 1] - x[..., 2]) ** 2)
+    K3 = su3_kernel_from_eigs(x, 2.0, 12)
+    devs.append(abs(np.mean(delta2 * K3) / 6.0 - 1.0))
+    check("B3: Haar normalization: c_triv=1; mean_Z4 K=1; SU(2)/SU(3) Weyl integrals = 1",
+          max(devs) < 1e-10, f"max dev={max(devs):.1e}")
+
+    im_zn = 0.0  # zn_kernel asserts internally; recompute explicitly
+    c = zn_coeffs(5, 0.7)
+    q = np.arange(5)
+    Kc = (c[:, None] * np.exp(2j * np.pi * np.outer(q, q) / 5)).sum(axis=0)
+    im_zn = float(np.abs(Kc.imag).max())
+    _, im_su3 = su3_kernel_from_eigs(x, 2.0, 12, return_imag=True)
+    check("B4: realness of K_t (Z_5 exact; SU(3) torus grid; SU(2) m-sum is real by construction)",
+          im_zn < 1e-12 and im_su3 < 1e-9, f"Z_5 im={im_zn:.1e}, SU(3) im={im_su3:.1e}")
+
+    thq = np.linspace(0.0, np.pi, 4096, endpoint=False) + np.pi / 8192
+    worst = 0.0
+    for tja in range(0, 7):
+        for tjb in range(0, 7):
+            ja, jb = tja / 2.0, tjb / 2.0
+            val = (2.0 / np.pi) * np.mean(np.sin(thq) ** 2
+                                          * su2_char_grid(ja, thq)
+                                          * su2_char_grid(jb, thq)) * np.pi
+            worst = max(worst, abs(val - (1.0 if tja == tjb else 0.0)))
+    hh = su3_h_polys(x, 8)
+    reps = [(0, 0), (1, 0), (0, 1), (1, 1), (2, 0), (2, 1)]
+    for (pa, qa) in reps:
+        for (pb, qb) in reps:
+            sa = su3_schur(hh, pa, qa)
+            sb = su3_schur(hh, pb, qb)
+            val = np.mean(delta2 * sa * np.conj(sb)) / 6.0
+            tgt = 1.0 if (pa, qa) == (pb, qb) else 0.0
+            worst = max(worst, abs(val - tgt))
+    check("B5: character orthonormality (SU(2) sin^2 measure; SU(3) Weyl 2-torus measure)",
+          worst < 1e-9, f"max dev={worst:.1e}")
+
+    thg = np.linspace(-np.pi, np.pi, 1001)
+    worst = 0.0
+    for tt in (0.5, 1.5):
+        worst = max(worst, float(np.abs(u1_kernel_on_grid(thg, tt)
+                                        - u1_gaussian_image_sum(thg, tt)).max()))
+    check("B6: U(1) Poisson/Jacobi-theta identity (character sum = Gaussian image sum)",
+          worst < 1e-10, f"max dev={worst:.1e}")
+
+    idx = su3_torus_eigs(np.zeros(1), np.zeros(1))
+    hid = su3_h_polys(idx, 8)
+    worst = 0.0
+    for (p, q, d, _C2) in su3_irreps(6):
+        worst = max(worst, abs(complex(su3_schur(hid, p, q)[0]) - d))
+    check("B7: Schur machinery at identity: s_(p,q)(1,1,1) = d_(p,q) for p+q<=6",
+          worst < 1e-9, f"max dev={worst:.1e}")
+
+
+def part_c():
+    section("Part C -- H4: pointwise positivity of K_t (certificates at printed t)")
+
+    ok = True
+    mins = []
+    for N in range(2, 7):
+        for t in (0.3, 1.0, 2.5):
+            K = zn_kernel(N, t)
+            ok = ok and bool(K.min() > 0.0)
+            if N in (2, 4) and t == 0.3:
+                mins.append(f"Z_{N}(t={t}):{K.min():.3e}")
+    check("C1: Z_N pointwise positivity, exact (N=2..6, t in {0.3,1.0,2.5})",
+          ok, "; ".join(mins))
+
+    thg = np.linspace(-np.pi, np.pi, 2001)
+    ok = True
+    detail = []
+    for tt in (0.5, 1.5):
+        Kg = u1_gaussian_image_sum(thg, tt)
+        Kc = u1_kernel_on_grid(thg, tt)
+        ok = ok and bool(Kg.min() > 0.0) and bool(Kc.min() > 0.0)
+        detail.append(f"t={tt}: min={Kc.min():.3e}")
+    check("C2: U(1) pointwise positivity (term-positive Gaussian rep; grid min > 0)",
+          ok, "; ".join(detail))
+
+    ok = True
+    detail = []
+    for tt in (3.0, 4.0):
+        npts = 20001
+        th = np.linspace(0.0, np.pi, npts)
+        cut = 24
+        K = su2_kernel_grid(th, tt, cut)
+        margin = float(K.min())
+        L = sum(d * math.exp(-tt * C2 / 2.0) * (2 * j) * (2 * j + 1)
+                for j, d, C2 in su2_irreps(cut))
+        h = np.pi / (npts - 1)
+        tail, guard = su2_tail_bound(tt, cut)
+        err = L * h / 2.0 + tail
+        ok = ok and guard and margin - err > 0.0
+        detail.append(f"t={tt}: min={margin:.4f}, err={err:.2e}")
+    check("C3: SU(2) strict-positivity certificate (grid + Lipschitz + tail)",
+          ok, "; ".join(detail))
+
+    ok = True
+    detail = []
+    for tt, cut in ((4.0, 8), (6.0, 8)):
+        g = 401
+        ax = np.linspace(-np.pi, np.pi, g, endpoint=False)
+        t1, t2 = np.meshgrid(ax, ax, indexing="ij")
+        x = su3_torus_eigs(t1, t2)
+        K = su3_kernel_from_eigs(x, tt, cut)
+        margin = float(K.min())
+        Lang = sum(d * d * (p + q) * math.exp(-tt * C2 / 2.0)
+                   for p, q, d, C2 in su3_irreps(cut))
+        h = 2.0 * np.pi / g
+        tail, guard = su3_tail_bound(tt, cut)
+        err = 2.0 * Lang * h / 2.0 + tail
+        ok = ok and guard and margin - err > 0.0
+        detail.append(f"t={tt}: min={margin:.4f}, err={err:.2e}")
+    check("C4: SU(3) strict-positivity certificate (torus grid + Lipschitz + tail)",
+          ok, "; ".join(detail))
+
+
+def part_d():
+    section("Part D -- H2 cut factorization: chi(AB^dag) = sum_ij pi(A)_ij conj(pi(B)_ij)")
+
+    N = 5
+    worst = 0.0
+    for qq in range(N):
+        for a in range(N):
+            for b in range(N):
+                lhs = np.exp(2j * np.pi * qq * (a - b) / N)
+                rhs = np.exp(2j * np.pi * qq * a / N) * np.conj(np.exp(2j * np.pi * qq * b / N))
+                worst = max(worst, abs(lhs - rhs))
+    check("D1: Z_5 factorization exact for all reps and group pairs",
+          worst < 1e-14, f"max dev={worst:.1e}")
+
+    rng = np.random.default_rng(11)
+    pairs = [(rand_su2(rng, 1)[0], rand_su2(rng, 1)[0]) for _ in range(5)]
+    worst_h = worst_u = worst_tr = 0.0
+    for A, B in pairs:
+        for tw in (1, 2, 3, 4):
+            pa, pb, pab = (su2_sym_power(M, tw) for M in (A, B, A @ B))
+            worst_h = max(worst_h, float(np.abs(pa @ pb - pab).max()))
+            worst_u = max(worst_u, float(np.abs(pa @ pa.conj().T - np.eye(tw + 1)).max()))
+            th = su2_theta_of(A[None])[0]
+            worst_tr = max(worst_tr, abs(np.trace(pa)
+                                         - complex(su2_char_grid(tw / 2.0, np.array([th]))[0])))
+    check("D2: SU(2) symmetric-power reps: homomorphism, unitarity, trace = character",
+          max(worst_h, worst_u, worst_tr) < 1e-12,
+          f"hom={worst_h:.1e}, unit={worst_u:.1e}, tr={worst_tr:.1e}")
+
+    worst = 0.0
+    for A, B in pairs:
+        V = A @ B.conj().T
+        thv = su2_theta_of(V[None])[0]
+        for tw in (1, 2, 3, 4):
+            lhs = complex(su2_char_grid(tw / 2.0, np.array([thv]))[0])
+            pa, pb = su2_sym_power(A, tw), su2_sym_power(B, tw)
+            rhs = (pa * np.conj(pb)).sum()
+            worst = max(worst, abs(lhs - rhs))
+    check("D3: SU(2) factorization chi_j(AB^dag) = sum_ij pi_j(A)_ij conj(pi_j(B)_ij)",
+          worst < 1e-12, f"max dev={worst:.1e}")
+
+    rng3 = np.random.default_rng(12)
+    A3, B3 = rand_su3(rng3, 1)[0], rand_su3(rng3, 1)[0]
+    piA, piB, piAB = su3_adjoint(A3), su3_adjoint(B3), su3_adjoint(A3 @ B3)
+    im = max(float(np.abs(piA.imag).max()), float(np.abs(piB.imag).max()))
+    orth = float(np.abs(piA @ piA.conj().T - np.eye(8)).max())
+    hom = float(np.abs(piA @ piB - piAB).max())
+    trdev = abs(np.trace(piA) - (abs(np.trace(A3)) ** 2 - 1.0))
+    hA = su3_h_polys(np.linalg.eigvals(A3)[None], 6)
+    schur_dev = abs(complex(su3_schur(hA, 1, 1)[0]) - (abs(np.trace(A3)) ** 2 - 1.0))
+    check("D4: SU(3) adjoint: real, orthogonal, homomorphism, trace = |TrU|^2-1 = s_(1,1)",
+          max(im, orth, hom, trdev, schur_dev) < 1e-11,
+          f"im={im:.1e}, orth={orth:.1e}, hom={hom:.1e}, tr={trdev:.1e}, schur={schur_dev:.1e}")
+
+    V = A3 @ B3.conj().T
+    fund = abs(np.trace(V) - (A3 * np.conj(B3)).sum())
+    adj = abs((abs(np.trace(V)) ** 2 - 1.0) - (piA * np.conj(piB)).sum())
+    check("D5: SU(3) factorization, fundamental and adjoint",
+          max(fund, abs(adj)) < 1e-11, f"fund={fund:.1e}, adj={abs(adj):.1e}")
+
+
+def part_e():
+    section("Part E -- H3: integrated reflected Gram PSD with the HK weight")
+
+    ok = True
+    details = []
+    for N in (2, 3, 4, 5):
+        for t in (0.3, 1.0, 2.5):
+            Gu, Z, _, _, _ = abelian_gram(zn_kernel(N, t))
+            mineig, herm = psd_report(Gu / Z)
+            ok = ok and mineig > -1e-11 and herm < 1e-11
+            if N in (2, 5):
+                details.append(f"Z_{N}(t={t}): min={mineig:+.1e}")
+    check("E1: Z_N exact Gram PSD (N in {2,3,4,5}, t in {0.3,1.0,2.5})",
+          ok, "; ".join(details[:4]) + " ...")
+
+    worst_ctrl = 0.0
+    for t in (0.3, 1.0):
+        Gu, Z, _, _, _ = abelian_gram(zn_kernel(4, t), conj_first=False)
+        mineig, _ = psd_report(Gu / Z)
+        worst_ctrl = min(worst_ctrl, mineig)
+    check("E2: dropped-conjugation control is NOT PSD (Z_4)",
+          worst_ctrl < -1e-3, f"min eig={worst_ctrl:+.4f}")
+
+    Gu, Z, Kplane, hvec, F = abelian_gram(zn_kernel(4, 1.0))
+    kap, phi = np.linalg.eigh((Kplane + Kplane.T) / 2.0)
+    W = (hvec * np.conj(F)) @ phi
+    Gfac = (W * kap) @ W.conj().T
+    dev = float(np.abs(Gfac - Gu).max())
+    check("E3: manifest factorization G = W diag(kappa) W^dag, kappa >= 0 (Z_4, t=1.0)",
+          dev < 1e-9 and kap.min() > -1e-12,
+          f"match dev={dev:.1e}, kappa_min={kap.min():+.1e}")
+
+    ok = True
+    details = []
+    for t in (0.5, 1.5):
+        grid = 24
+        Kvals = u1_kernel_on_grid(2.0 * np.pi * np.arange(grid) / grid, t)
+        Gu, Z, _, _, _ = abelian_gram(Kvals)
+        mineig, herm = psd_report(Gu / Z)
+        ok = ok and mineig > -1e-9 and herm < 1e-9
+        details.append(f"t={t}: min={mineig:+.1e}")
+    check("E4: U(1) quadrature Gram PSD (24-point grid, t in {0.5,1.5})",
+          ok, "; ".join(details))
+
+    # t=3.0 matches a C3-certified kernel: w_min is then bounded below by a
+    # certified strictly positive kernel minimum, and the weight is light-tailed.
+    G, w, im, ess = mc_gram("su2", 3.0, 200_000, 0, 24)
+    mineig, herm = psd_report(G)
+    tol = max(3.0 * herm, 5e-3)
+    check("E5: SU(2) MC Gram PSD within MC tolerance (t=3.0, n=200k, seed 0)",
+          mineig > -tol and w.min() > 0.0 and im < 1e-8,
+          f"min eig={mineig:+.2e}, tol={tol:.1e}, herm={herm:.1e}, w_min={w.min():.2e}, ESS={ess:.0f}")
+
+    G, w, im, ess = mc_gram("su3", 3.0, 400_000, 1, 10)
+    mineig, herm = psd_report(G)
+    tol = max(3.0 * herm, 5e-3)
+    check("E6: SU(3) MC Gram PSD within MC tolerance (t=3.0, n=400k, seed 1)",
+          mineig > -tol and w.min() > 0.0 and im < 1e-6,
+          f"min eig={mineig:+.2e}, tol={tol:.1e}, herm={herm:.1e}, w_min={w.min():.2e}, ESS={ess:.0f}")
+
+
+def main() -> int:
+    print("=" * 88)
+    print("Heat-kernel gauge action: native RP plane character positivity, all compact groups")
+    print("companion runner for the 2026-07-09 narrow theorem note")
+    print("=" * 88)
+    part_a()
+    part_b()
+    part_c()
+    part_d()
+    part_e()
+    print()
+    print("=" * 88)
+    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+    print("=" * 88)
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py
+++ b/scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py
@@ -25,8 +25,8 @@ Setup (mirrors the Wilson temporal-gauge RP bridge note's carrier):
 Parts:
   A (H1): manifest strict positivity of c_lambda(t) for Z_N, U(1), SU(2),
      SU(3); SU(3) dimension/Casimir spot checks incl. the exp(-2/3)
-     convention alignment; superexponential truncation-tail bounds with
-     geometric-majorant guards.
+     convention alignment. These are implementation sanity checks; analytic
+     coefficient positivity follows from the displayed exponential formula.
   B (H2 algebra): coefficient-level semigroup c(s)c(t)/d = c(s+t) on all
      four groups; exact Z_N kernel-level convolution; Haar normalization
      (trivial coefficient = 1; quadrature integrals = 1); realness of K_t;
@@ -34,8 +34,8 @@ Parts:
      the Schur-polynomial character machinery); U(1) Poisson/Jacobi-theta
      identity; Schur(identity) = dimension.
   C (H4): pointwise positivity. Z_N exact; U(1) via the term-positive
-     Gaussian image sum; SU(2)/SU(3) grid + Lipschitz + truncation-tail
-     certificates at printed t values (H4 is not consumed by H3).
+     Gaussian image sum; SU(2)/SU(3) finite-truncation grid evidence at
+     printed t values (support only; H4 is not consumed by H3).
   D (H2 cut factorization): chi_lambda(A B^dag) = sum_ij pi_lambda(A)_ij *
      conj(pi_lambda(B)_ij) exactly, on seeded random pairs: Z_N all reps;
      SU(2) unitary symmetric-power reps j in {1/2,1,3/2,2}; SU(3)
@@ -205,33 +205,6 @@ def su3_torus_eigs(t1: np.ndarray, t2: np.ndarray) -> np.ndarray:
     x[..., 1] = np.exp(1j * t2)
     x[..., 2] = np.exp(-1j * (t1 + t2))
     return x
-
-
-def su2_tail_bound(t: float, jmax_twice_cut: int, extra: int = 40):
-    """Bound sum_{2j > cut} d^2 exp(-t C2/2) with a geometric-majorant guard."""
-    terms = []
-    for tw in range(jmax_twice_cut + 1, jmax_twice_cut + 1 + extra):
-        j = tw / 2.0
-        terms.append((tw + 1) ** 2 * math.exp(-t * j * (j + 1) / 2.0))
-    ratios_ok = all(terms[i + 1] < 0.5 * terms[i] for i in range(len(terms) - 1)
-                    if terms[i] > 0)
-    return sum(terms) + terms[-1], ratios_ok
-
-
-def su3_tail_bound(t: float, cut: int, extra: int = 30):
-    """Bound sum_{p+q > cut} d^2 exp(-t C2/2) with a geometric-majorant guard."""
-    level = []
-    for s in range(cut + 1, cut + 1 + extra):
-        tot = 0.0
-        for p in range(s + 1):
-            q = s - p
-            d = (p + 1) * (q + 1) * (p + q + 2) / 2.0
-            C2 = (p * p + q * q + p * q + 3 * p + 3 * q) / 3.0
-            tot += d * d * math.exp(-t * C2 / 2.0)
-        level.append(tot)
-    ratios_ok = all(level[i + 1] < 0.5 * level[i] for i in range(len(level) - 1)
-                    if level[i] > 0)
-    return sum(level) + level[-1], ratios_ok
 
 
 # ----------------------------------------------------------------------------
@@ -413,7 +386,7 @@ def mc_gram(group: str, t: float, n: int, seed: int, cut: int):
 # ----------------------------------------------------------------------------
 
 def part_a():
-    section("Part A -- H1: manifest strict positivity of c_lambda(t), with tail bounds")
+    section("Part A -- H1: manifest strict positivity of c_lambda(t)")
 
     ok = True
     detail = []
@@ -436,9 +409,7 @@ def part_a():
     for t in (1.0, 1.5, 3.0, 4.0):
         cs = [d * math.exp(-t * C2 / 2.0) for _j, d, C2 in su2_irreps(30)]
         ok = ok and min(cs) > 0.0
-    tail, guard = su2_tail_bound(1.0, 24)
-    check("A3: SU(2) coefficients strictly positive (2j<=30) + tail(t=1, 2j>24) tiny",
-          ok and guard and tail < 1e-12, f"tail<= {tail:.3e}")
+    check("A3: SU(2) sampled coefficients strictly positive (2j<=30)", ok)
 
     spot = {(1, 0): (3, 4.0 / 3.0), (0, 1): (3, 4.0 / 3.0), (1, 1): (8, 3.0),
             (2, 0): (6, 10.0 / 3.0), (3, 0): (10, 6.0), (2, 1): (15, 16.0 / 3.0),
@@ -460,16 +431,6 @@ def part_a():
         cs = [d * math.exp(-t * C2 / 2.0) for _p, _q, d, C2 in su3_irreps(10)]
         ok = ok and min(cs) > 0.0
     check("A5: SU(3) coefficients strictly positive (p+q<=10, t in {1,2,3,4,6})", ok)
-
-    ok = True
-    details = []
-    for t, cut in ((1.0, 16), (2.0, 12), (3.0, 10), (4.0, 8), (6.0, 8)):
-        tail, guard = su3_tail_bound(t, cut)
-        ok = ok and guard and tail < 1e-10
-        details.append(f"t={t}:cut{cut}:{tail:.1e}")
-    check("A6: SU(3) truncation tails < 1e-10 at every (t, cut) used below",
-          ok, "; ".join(details))
-
 
 def part_b():
     section("Part B -- H2 algebra: semigroup, normalization, realness, orthonormality")
@@ -564,7 +525,7 @@ def part_b():
 
 
 def part_c():
-    section("Part C -- H4: pointwise positivity of K_t (certificates at printed t)")
+    section("Part C -- H4: pointwise-positivity boundary at printed t")
 
     ok = True
     mins = []
@@ -596,14 +557,9 @@ def part_c():
         cut = 24
         K = su2_kernel_grid(th, tt, cut)
         margin = float(K.min())
-        L = sum(d * math.exp(-tt * C2 / 2.0) * (2 * j) * (2 * j + 1)
-                for j, d, C2 in su2_irreps(cut))
-        h = np.pi / (npts - 1)
-        tail, guard = su2_tail_bound(tt, cut)
-        err = L * h / 2.0 + tail
-        ok = ok and guard and margin - err > 0.0
-        detail.append(f"t={tt}: min={margin:.4f}, err={err:.2e}")
-    check("C3: SU(2) strict-positivity certificate (grid + Lipschitz + tail)",
+        ok = ok and margin > 0.0
+        detail.append(f"t={tt}: truncated-grid min={margin:.4f}")
+    check("C3: SU(2) finite-truncation grid is positive (support only)",
           ok, "; ".join(detail))
 
     ok = True
@@ -615,14 +571,9 @@ def part_c():
         x = su3_torus_eigs(t1, t2)
         K = su3_kernel_from_eigs(x, tt, cut)
         margin = float(K.min())
-        Lang = sum(d * d * (p + q) * math.exp(-tt * C2 / 2.0)
-                   for p, q, d, C2 in su3_irreps(cut))
-        h = 2.0 * np.pi / g
-        tail, guard = su3_tail_bound(tt, cut)
-        err = 2.0 * Lang * h / 2.0 + tail
-        ok = ok and guard and margin - err > 0.0
-        detail.append(f"t={tt}: min={margin:.4f}, err={err:.2e}")
-    check("C4: SU(3) strict-positivity certificate (torus grid + Lipschitz + tail)",
+        ok = ok and margin > 0.0
+        detail.append(f"t={tt}: truncated-grid min={margin:.4f}")
+    check("C4: SU(3) finite-truncation torus grid is positive (support only)",
           ok, "; ".join(detail))
 
 
@@ -731,8 +682,8 @@ def part_e():
     check("E4: U(1) quadrature Gram PSD (24-point grid, t in {0.5,1.5})",
           ok, "; ".join(details))
 
-    # t=3.0 matches a C3-certified kernel: w_min is then bounded below by a
-    # certified strictly positive kernel minimum, and the weight is light-tailed.
+    # The sampled Monte-Carlo weights remain positive at t=3.0. This is a
+    # finite-sample diagnostic, not a full-kernel pointwise-positivity proof.
     G, w, im, ess = mc_gram("su2", 3.0, 200_000, 0, 24)
     mineig, herm = psd_report(G)
     tol = max(3.0 * herm, 5e-3)

--- a/scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py
+++ b/scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py
@@ -44,8 +44,7 @@ Parts:
      HK weight: Z_N exact over all configurations; dropped-conjugation
      negative control (non-PSD); manifest factorization G = W diag(kappa)
      W^dag with plane-kernel eigenvalues kappa >= 0; U(1) quadrature Gram;
-     SU(2) and SU(3) seeded Monte-Carlo Grams (the SU(3) case is the one
-     the Wilson-weight route had no derivable coefficient-positivity for).
+     SU(2) and SU(3) seeded Monte-Carlo Grams.
 
 Literature disclaimer: Osterwalder & Seiler, Ann. Phys. 110 (1978) 440, and
 Montvay & Munster, "Quantum Fields on a Lattice" Sec. 3.4, are comparators
@@ -751,7 +750,7 @@ def part_e():
 
 def main() -> int:
     print("=" * 88)
-    print("Heat-kernel gauge action: native RP plane character positivity, all compact groups")
+    print("Heat-kernel gauge action: native RP plane character positivity on specified heat semigroups")
     print("companion runner for the 2026-07-09 narrow theorem note")
     print("=" * 88)
     part_a()


### PR DESCRIPTION
## The wall

Row `axiom_first_reflection_positivity_wilson_temporal_gauge_bridge_narrow_theorem_note_2026-06-05` (`retained_bounded`) proves two-slice temporal-gauge RP for the **Wilson** weight via plane-factor character-coefficient nonnegativity (W2) — a step that is **group-dependent**: exact on `Z_N`, Bessel on `U(1)`, numeric-only on `SU(2)`, and **not derivable on `SU(N≥3)`** (positivity of a class function does not imply nonnegative character coefficients on a nonabelian group). PR #5050 rescoped the `SU(N≥3)` Wilson case to the Osterwalder–Seiler **comparator** and named the heat-kernel action as the forward derivation path.

## What this PR derives

On the heat-kernel single-plaquette weight `K_t = Σ_λ d_λ e^{−t·C₂(λ)/2} χ_λ` (the existing HK candidate, same convention as the HK candidate notes — `exp(−2/3)` fundamental coefficient at `t=1` cross-checked):

- **H1** — the (W2)-analog `c_λ(t) > 0` is **manifest for every compact group**, every `t > 0`. No DFT, no Bessel positivity, no MC estimate, no group-dependent certificate. In particular `SU(3)`.
- **H2** — `K_t` is real, and the cut factorization `χ_λ(AB†) = Σ_ij π_λ(A)_ij·conj(π_λ(B)_ij)` makes the straddling plane factor a manifest norm-square kernel.
- **H3** — the integrated two-slice reflected Gram is PSD **natively** on the bridge note's carrier, instantiating the retained gauge-half Cauchy–Schwarz hypotheses (`reflection_positivity_gauge_half_cauchy_schwarz_narrow_theorem_note_2026-05-10`, `retained`) for all compact `G` — including the integrated `SU(3)` Gram the Wilson route could not derivably run.
- **H4** — `K_t > 0` pointwise (Boltzmann sensibility), certified with explicit grid+Lipschitz+truncation-tail error budgets at the runner's printed `t` values. Not consumed by H3.

The group-dependence of (W2) is thereby located precisely: it is a property of the **Wilson parametrization** of the plane weight, not of the RP mechanism, the carrier, the reflection, or the gauge group.

## Honest evidentiary inventory

- **Exact/manifest:** H1 all groups; H2 factorization (`Z_N` exact; `SU(2)` symmetric-power reps to 1e−12; `SU(3)` fundamental + adjoint to 1e−11); coefficient semigroup, Haar normalization, realness, character orthonormality; `Z_N` Grams summed over **all** configurations; manifest `G = W diag(κ) W†` factorization; H4 certificates with margins strictly above certified error.
- **Seeded Monte-Carlo (evidence, not proof):** the `SU(2)`/`SU(3)` **integrated** Grams (E5: `t=3.0`, n=200k, ESS≈39k; E6: `t=3.0`, n=400k, ESS≈114k; min eigenvalues strictly positive, tolerances printed). Same evidentiary class as the bridge note's own Part E `SU(2)` check.
- **Negative control:** dropping the antilinear conjugation in `Θ` breaks PSD (min eig ≈ −1.7) — the mechanism is not vacuously positive.

## Scope and non-claims

- Narrow two-slice carrier; **no** action selection (HK-candidate/uniqueness lanes are unaudited and cited as context only), no modification of the Wilson bridge note, no fermions, no OS reconstruction, no continuum limit, no coupling value (`t` free throughout).
- No new axiom, no import: carrier/reflection/bases are row ④'s; OS + Montvay–Münster remain **comparators only** (already the bridge note's); every positivity statement used is re-proved inside the runner.
- No audit-status statement — grades belong to the independent audit lane.

## Triple

- Note: `docs/HEAT_KERNEL_GAUGE_ACTION_NATIVE_RP_PLANE_CHARACTER_POSITIVITY_ALL_COMPACT_GROUPS_NARROW_THEOREM_NOTE_2026-07-09.md`
- Runner: `scripts/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.py` (numpy-only, 14 s, `AUDIT_TIMEOUT_SEC = 900`)
- Cache: `logs/runner-cache/audit_companion_heat_kernel_native_rp_plane_character_positivity_2026_07_09.txt` — `TOTAL: PASS=28 FAIL=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Superseding review-loop correction

This section supersedes the original Wall, H4, and evidentiary-inventory wording above. The Wilson weight does have a general representation-ring route: the positive exponential series in `chi_R + chi_Rbar` decomposes tensor powers with nonnegative integer irrep multiplicities. No Wilson `SU(N>=3)` obstruction is claimed. H1-H3 are scoped to compact Lie groups with a specified positive bi-invariant heat semigroup (plus the explicit finite/abelian testbeds). For H4, Z_N/U(1) positivity is analytic on the stated surface; SU(2)/SU(3) finite-truncation grids are support-only, with no claimed infinite-tail certificate. Final runner: 27/0, exit 0. No-Go N1-N8: PASS at this narrowed bounded scope. Audit status remains independent-audit-owned.