### PR TITLE
fix(record-atom): restate availability theorem on the live four-axiom surface with declared admissibility-instance premise

### DIFF
--- a/docs/RECORD_LOCAL_FINITE_ATOM_AVAILABILITY_NARROW_THEOREM_NOTE_2026-06-17.md
+++ b/docs/RECORD_LOCAL_FINITE_ATOM_AVAILABILITY_NARROW_THEOREM_NOTE_2026-06-17.md
@@ -1,6 +1,7 @@
 # Record Local Finite Atom Availability Narrow Theorem
 
 **Date:** 2026-06-17
+**Surface update:** 2026-07-09 — restated on the live four-axiom memo (`Lattice`/`Qubit`/`Admissibility`/`Record`, 2026-06-29): the availability claim now names its declared admissibility-instance premise, the presence-conditional layer cites the live Record wording, and the legacy axiom name and 2026-06-05 memo citation are replaced. Finite-algebra content unchanged.
 **Claim type:** positive_theorem
 **Type:** positive_theorem
 **Status authority:** independent audit lane only. This source note does not
@@ -13,13 +14,16 @@ with cache
 
 **Depends on:**
 
-- [`MINIMAL_AXIOMS_2026-06-05.md`](MINIMAL_AXIOMS_2026-06-05.md)
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+- [`RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md`](RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md)
 
 ## Result
 
-For every finite `n`, the Lattice and Quantum axioms admit a concrete finite
-local readout context with `n` pairwise support-disjoint nonzero
-record-eligible readout atoms.
+For every finite `n`, the Lattice and Qubit axioms admit a concrete finite
+local readout context with `n` pairwise support-disjoint nonzero readout
+atoms. Under the declared admissibility instance named below — an instance
+premise, not axiom content — each chosen atom is available at its site, so
+the collection is record-eligible in the sense of the live Record axiom.
 
 Choose the lattice sites
 
@@ -27,7 +31,7 @@ Choose the lattice sites
 x_k = (k,0,0),    k = 0, ..., n-1.
 ```
 
-At each site, Quantum supplies a one-site copy of `M_2(C)`. In a declared local
+At each site, Qubit supplies a one-site copy of `M_2(C)`. In a declared local
 diagonal readout context choose
 
 ```text
@@ -54,14 +58,42 @@ record-eligible readout atoms is framework-native:
 - `Z^3` supplies arbitrary finite lists of distinct sites.
 - `M_2(C)` supplies nonzero orthogonal rank-one projectors in any declared
   one-site diagonal context.
-- Entrywise conjugation fixes the chosen projectors, so the Record axiom's
-  fixed `K`/CPT-orbit wording has a concrete finite model.
+- Entrywise conjugation fixes the chosen projectors inside the declared
+  context. On the live memo, `K`/CPT orbit structure is downstream
+  readout-context content, not generic axiom content; the `K`-fixedness here
+  is a property of this declared context, not an axiom-level requirement.
 - The finite Boolean count functional on the declared context can be declared
   additively unit-normalized.
 
 The repair does **not** say that this context is physically selected. It only
 proves that the source packet no longer has to import arbitrary finite nonzero
 readout atoms as mathematical objects.
+
+## Admissibility layer (declared instance premise)
+
+The live memo adds Admissibility: one fixed nearest-neighbor rule, covariant
+under lattice translations and proper cubic rotations, under which the
+available possibilities at each site are determined by, and vary with, the
+nearest-neighbor conditions. The axioms name this rule but do not supply its
+content. Whether the atom `P_1` is available at a given site therefore
+depends on the unspecified fixed rule and the neighbor conditions: it is
+instance content, and this note does not derive it.
+
+**Declared admissibility-instance premise.** The availability-side claim is
+stated under a declared instance: an admissibility rule and neighbor
+condition under which the chosen atom `P_1` lies in the available set at each
+chosen site `x_k`. The paired runner exhibits covariant toy instances in
+which the premise holds at every site, a covariant toy instance in which it
+fails (so the premise does real selective work and is not vacuous), and a
+toy instance whose available set varies with the neighbor conditions
+(matching the live memo's wording). None of these toy instances is claimed
+to be the framework's fixed rule.
+
+**Presence-conditional layer (axiom-native).** No instance premise is needed
+to read a realized stack: by the live Record axiom, when present, a record
+locks exactly one admissible local possibility. Realized records carry their
+admissibility by axiom. The declared instance premise is load-bearing only
+for the pre-record availability/eligibility claim above.
 
 ## Proof
 
@@ -105,13 +137,20 @@ This theorem does not derive:
 - a physical `K`/CPT bridge beyond the declared finite context;
 - a canonical normalization rule for all readout contexts;
 - a clock/rate, persistence dynamics, occupancy rule, or dial selector;
+- the content of the fixed admissibility rule, or that any particular atom
+  is admissible at any particular site (instance content; the declared
+  admissibility-instance premise above is named, not derived);
+- any claim that the toy admissibility instances in the runner are the
+  framework's fixed rule.
 - a completed infinite record.
 
 The retained no-go
 `RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md`
-is respected: Lattice, Quantum, and Record alone still do not force any
-particular atom to be produced. This theorem only supplies the finite local
-availability/readout-context side of later conditional production claims.
+is respected on its current narrowed text: occurrence is axiom-forced by
+"Records form.", and the axioms still do not supply the formation
+rule/process/state/site/weight/rate. This theorem only supplies the finite
+local availability/readout-context side of later conditional production
+claims; it does not supply a formation rule.
 
 ## Runner Summary
 
@@ -125,5 +164,10 @@ The runner verifies:
 - the finite Boolean unit-count functional is additive;
 - for any proposed finite bound `B`, the construction has `B+1` finite
   nonzero record-eligible readout atoms;
-- production, probability, physical context selection, clock/rate, and dial
-  selection remain open gates.
+- covariant toy admissibility instances: one under which the declared
+  premise holds at every chosen site, one under which it fails (rejector),
+  and one whose available set varies with the neighbor conditions;
+- the presence-conditional reading: the live Record axiom's admissible-lock
+  wording is pinned from the memo text;
+- production, probability, physical context selection, clock/rate, dial
+  selection, and admissibility-instance selection remain open gates.

--- a/docs/RECORD_LOCAL_FINITE_ATOM_AVAILABILITY_NARROW_THEOREM_NOTE_2026-06-17.md
+++ b/docs/RECORD_LOCAL_FINITE_ATOM_AVAILABILITY_NARROW_THEOREM_NOTE_2026-06-17.md
@@ -2,8 +2,8 @@
 
 **Date:** 2026-06-17
 **Surface update:** 2026-07-09 — restated on the live four-axiom memo (`Lattice`/`Qubit`/`Admissibility`/`Record`, 2026-06-29): the availability claim now names its declared admissibility-instance premise, the presence-conditional layer cites the live Record wording, and the legacy axiom name and 2026-06-05 memo citation are replaced. Finite-algebra content unchanged.
-**Claim type:** positive_theorem
-**Type:** positive_theorem
+**Claim type:** bounded_theorem
+**Type:** bounded_theorem
 **Status authority:** independent audit lane only. This source note does not
 apply audit verdicts, does not edit audit data, and does not assert package
 promotion.
@@ -51,9 +51,10 @@ readout functional on the finite Boolean context, that sum is exactly `n`.
 
 ## What This Repairs
 
-This note removes a hidden source-side import in the unbounded finite-record
-schemas. The existence of arbitrary finite local sites and nonzero local
-record-eligible readout atoms is framework-native:
+This note makes the source-side inputs in the unbounded finite-record schemas
+explicit. Arbitrary finite local sites and one-site projectors are
+framework-native; their readout and record-eligibility roles are conditional
+on the declared input surface below:
 
 - `Z^3` supplies arbitrary finite lists of distinct sites.
 - `M_2(C)` supplies nonzero orthogonal rank-one projectors in any declared
@@ -68,6 +69,22 @@ record-eligible readout atoms is framework-native:
 The repair does **not** say that this context is physically selected. It only
 proves that the source packet no longer has to import arbitrary finite nonzero
 readout atoms as mathematical objects.
+
+## Declared inputs and remaining selection walls
+
+The bounded theorem is conditional on four independently named inputs:
+
+- an **admissibility instance** under which `P_1` is available at the chosen
+  sites;
+- the **diagonal readout context** `span{P_0,P_1}`;
+- the **`K`/conjugation context** given by entrywise conjugation in that
+  declared basis; and
+- the **unit-count normalization** assigning weight `1` to each chosen atom.
+
+The Lattice and Qubit axioms supply the sites and matrices, but the framework
+does not select any of those four inputs. The exact finite-algebra conclusion
+therefore closes only under this declared instance/context/normalization
+surface. Selecting that surface remains open.
 
 ## Admissibility layer (declared instance premise)
 

--- a/logs/runner-cache/frontier_record_local_finite_atom_availability_2026_06_17.txt
+++ b/logs/runner-cache/frontier_record_local_finite_atom_availability_2026_06_17.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_record_local_finite_atom_availability_2026_06_17.py
-runner_sha256: 970fea5b752a83b4c4a20599d616361c37f030791bcd84167566949768a5906a
-timeout_sec: 120
+runner_sha256: 2824c826e50148a5951381b693ca77f2e9983217ad134b3cf2fe5fee783b7cc0
+timeout_sec: 300
 exit_code: 0
-elapsed_sec: 0.37
+elapsed_sec: 0.60
 status: ok
 ----- stdout -----
 Record local finite readout-atom availability theorem
@@ -12,13 +12,16 @@ audit_required_before_effective_retained: true
 proposal_allowed: false
 
 A. source authority and boundary text
-[PASS] A1 minimal axioms expose Lattice Z^3
-[PASS] A2 minimal axioms expose one-site M_2(C)
-[PASS] A3 minimal Record requires a supplied readout context
-[PASS] A4 minimal Record excludes production/probability/context selection
-[PASS] A5 retained no-go boundary keeps record formation unforced
-[PASS] A6 theorem boundary explicitly does not derive production
-[PASS] A7 theorem names record-eligible readout atoms, not produced records
+[PASS] A1 live Lattice axiom exposes cubic Z^3 sites
+[PASS] A2 live Qubit axiom exposes one-site M_2(C)
+[PASS] A3 live Admissibility axiom names one fixed covariant NN rule
+[PASS] A4 live Admissibility axiom requires neighbor-varying availability
+[PASS] A5 live Record axiom locks one admissible possibility
+[PASS] A6 live memo leaves formation-rule details downstream
+[PASS] A7 live memo keeps downstream bridges open
+[PASS] A8 narrowed no-go withholds the formation rule/process/state/site/weight/rate
+[PASS] A9 theorem boundary explicitly does not derive production
+[PASS] A10 theorem names the declared availability premise and record eligibility
 
 B. one-site diagonal readout context
 [PASS] B1 P0 is idempotent
@@ -29,6 +32,14 @@ B. one-site diagonal readout context
 [PASS] B6 both atoms are fixed by entrywise K
 [PASS] B7 atoms commute inside the declared readout algebra
 [PASS] B8 atoms are not central in all M_2(C)
+
+AD. declared toy admissibility instances
+[PASS] AD1 each toy NN-multiset rule is invariant under all neighbor permutations -- permutation invariance implies translation/proper-cubic-rotation covariance
+[PASS] AD2 R_all makes the declared P1 premise hold at every constructed site
+[PASS] AD3 R_p0only rejector detects failure of the declared P1 premise at every site -- the availability premise is selective, not vacuous
+[PASS] AD4 R_varying makes P1 availability vary with the neighbor condition
+[PASS] AD5 toy realized stack locks only possibilities available at lock time under R_all
+[NAMED] AD5 live presence-conditional layer: by the Record wording, a present record locks an admissible local possibility
 
 C. arbitrary finite disjoint supports on Z^3
 [PASS] C1 n=0: distinct line supports and one atom per support
@@ -63,8 +74,9 @@ E. boundary classifier
 [PASS] E6 physical context selection remains open
 [PASS] E7 clock/rate remains open
 [PASS] E8 dial selection remains open
+[PASS] E9 admissibility-instance selection remains open
 
-SCORECARD: PASS=43 FAIL=0
+SCORECARD: PASS=52 FAIL=0
 VERDICT: exact finite local readout-atom/context availability closes; production, probability, physical context selection, clock/rate, and dial selection remain open.
 
 ----- stderr -----

--- a/logs/runner-cache/frontier_record_local_finite_atom_availability_2026_06_17.txt
+++ b/logs/runner-cache/frontier_record_local_finite_atom_availability_2026_06_17.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_record_local_finite_atom_availability_2026_06_17.py
-runner_sha256: 2824c826e50148a5951381b693ca77f2e9983217ad134b3cf2fe5fee783b7cc0
-timeout_sec: 300
+runner_sha256: b669d1447af6b84f67a2ebb5fc7b355176ae204d8b730049b29702fa50d18450
+timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.60
+elapsed_sec: 0.21
 status: ok
 ----- stdout -----
 Record local finite readout-atom availability theorem
@@ -66,7 +66,7 @@ D. finite Boolean unit-count readout
 [PASS] D5 finite prefixes remain bounded by their chosen length
 
 E. boundary classifier
-[PASS] E1 local readout-atom availability is the closed part
+[PASS] E1 local readout-atom availability closes only under the declared instance
 [PASS] E2 declared unit-count context is the closed finite algebra part
 [PASS] E3 record production remains open
 [PASS] E4 measurement/decoherence instrument remains open
@@ -77,7 +77,7 @@ E. boundary classifier
 [PASS] E9 admissibility-instance selection remains open
 
 SCORECARD: PASS=52 FAIL=0
-VERDICT: exact finite local readout-atom/context availability closes; production, probability, physical context selection, clock/rate, and dial selection remain open.
+VERDICT: exact finite local readout-atom/context availability closes only under the declared admissibility instance, diagonal readout context, K/conjugation context, and unit-count normalization; selection of those inputs, production, probability, clock/rate, and dial selection remain open.
 
 ----- stderr -----
 

--- a/scripts/frontier_record_local_finite_atom_availability_2026_06_17.py
+++ b/scripts/frontier_record_local_finite_atom_availability_2026_06_17.py
@@ -6,6 +6,9 @@ This runner checks the exact finite algebra behind the source-side repair:
 * Z^3 supplies arbitrary finite lists of distinct supports;
 * a declared one-site diagonal context inside M_2(C) has two nonzero
   K-fixed orthogonal readout atoms;
+* a declared covariant admissibility instance makes the chosen atom available
+  at each site; a contrasting covariant instance defeats it (the premise is
+  selective, not vacuous);
 * the finite Boolean unit-count functional is additive on disjoint support
   tags;
 * the result is availability/readout-context algebra only, not production,
@@ -15,6 +18,7 @@ This runner checks the exact finite algebra behind the source-side repair:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from itertools import permutations
 from pathlib import Path
 
 import sympy as sp
@@ -82,6 +86,39 @@ def commutator(a: sp.Matrix, b: sp.Matrix) -> sp.Matrix:
     return a * b - b * a
 
 
+NeighborCondition = tuple[str | None, str | None, str | None, str | None, str | None, str | None]
+AvailableSet = frozenset[str]
+
+
+def r_all(condition: NeighborCondition) -> AvailableSet:
+    del condition
+    return frozenset({"P0", "P1"})
+
+
+def r_p0only(condition: NeighborCondition) -> AvailableSet:
+    del condition
+    return frozenset({"P0"})
+
+
+def r_varying(condition: NeighborCondition) -> AvailableSet:
+    return frozenset({"P0", "P1"}) if all(label is None for label in condition) else frozenset({"P0"})
+
+
+def neighbor_condition(
+    site: tuple[int, int, int], locked: dict[tuple[int, int, int], str]
+) -> NeighborCondition:
+    x, y, z = site
+    neighbors = (
+        (x + 1, y, z),
+        (x - 1, y, z),
+        (x, y + 1, z),
+        (x, y - 1, z),
+        (x, y, z + 1),
+        (x, y, z - 1),
+    )
+    return tuple(locked.get(neighbor) for neighbor in neighbors)  # type: ignore[return-value]
+
+
 def read_text(rel: str) -> str:
     return (ROOT / rel).read_text(encoding="utf-8")
 
@@ -94,17 +131,22 @@ def main() -> int:
     print()
 
     print("A. source authority and boundary text")
-    minimal = read_text("docs/MINIMAL_AXIOMS_2026-06-05.md")
+    minimal = read_text("docs/MINIMAL_AXIOMS_2026-06-29.md")
     nogo = read_text("docs/RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md")
     note = read_text("docs/RECORD_LOCAL_FINITE_ATOM_AVAILABILITY_NARROW_THEOREM_NOTE_2026-06-17.md")
     minimal_flat = " ".join(minimal.split())
-    check("A1 minimal axioms expose Lattice Z^3", "The site set is `Z^3`" in minimal)
-    check("A2 minimal axioms expose one-site M_2(C)", "M_2(C)" in minimal)
-    check("A3 minimal Record requires a supplied readout context", "Given a readout context" in minimal)
-    check("A4 minimal Record excludes production/probability/context selection", "A record supplies no readout context" in minimal_flat and "probability" in minimal)
-    check("A5 retained no-go boundary keeps record formation unforced", "does not unconditionally force record formation" in nogo)
-    check("A6 theorem boundary explicitly does not derive production", "record production or realization dynamics" in note)
-    check("A7 theorem names record-eligible readout atoms, not produced records", "record-eligible readout atoms" in note)
+    nogo_flat = " ".join(nogo.split())
+    note_flat = " ".join(note.split())
+    check("A1 live Lattice axiom exposes cubic Z^3 sites", "Physical sites are the points of the cubic lattice `Z^3`" in minimal_flat)
+    check("A2 live Qubit axiom exposes one-site M_2(C)", "The full one-site possibility domain has algebraic presentation `M_2(C)`." in minimal_flat)
+    check("A3 live Admissibility axiom names one fixed covariant NN rule", "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations." in minimal_flat)
+    check("A4 live Admissibility axiom requires neighbor-varying availability", "the available possibilities are determined by, and vary with, the nearest-neighbor conditions" in minimal_flat)
+    check("A5 live Record axiom locks one admissible possibility", "a record locks exactly one admissible local possibility" in minimal_flat)
+    check("A6 live memo leaves formation-rule details downstream", "formation rules (which admissible possibility a new record locks, at which site, with what weight, or at what rate)" in minimal_flat)
+    check("A7 live memo keeps downstream bridges open", "Probability, dynamics, readout contexts, and physical observable bridges remain downstream." in minimal_flat)
+    check("A8 narrowed no-go withholds the formation rule/process/state/site/weight/rate", "It does not supply the formation rule/process/state/site/weight/rate." in nogo_flat)
+    check("A9 theorem boundary explicitly does not derive production", "record production or realization dynamics" in note)
+    check("A10 theorem names the declared availability premise and record eligibility", "declared admissibility-instance premise" in note_flat and "record-eligible" in note)
 
     print("\nB. one-site diagonal readout context")
     check("B1 P0 is idempotent", P0 * P0 == P0)
@@ -115,6 +157,54 @@ def main() -> int:
     check("B6 both atoms are fixed by entrywise K", k_fixed(P0) and k_fixed(P1))
     check("B7 atoms commute inside the declared readout algebra", commutator(P0, P1) == sp.zeros(2))
     check("B8 atoms are not central in all M_2(C)", commutator(P0, X) != sp.zeros(2) and commutator(P1, X) != sp.zeros(2))
+
+    print("\nAD. declared toy admissibility instances")
+    rules = (r_all, r_p0only, r_varying)
+    representative_conditions: tuple[NeighborCondition, ...] = (
+        (None, None, None, None, None, None),
+        ("P1", None, None, None, None, None),
+        ("P0", "P1", None, None, None, None),
+        ("P0", "P0", "P1", "P1", None, None),
+    )
+    neighbor_permutations = tuple(permutations(range(6)))
+    check(
+        "AD1 each toy NN-multiset rule is invariant under all neighbor permutations",
+        all(
+            rule(tuple(condition[index] for index in permutation)) == rule(condition)
+            for rule in rules
+            for condition in representative_conditions
+            for permutation in neighbor_permutations
+        ),
+        "permutation invariance implies translation/proper-cubic-rotation covariance",
+    )
+    empty_condition: NeighborCondition = (None, None, None, None, None, None)
+    check(
+        "AD2 R_all makes the declared P1 premise hold at every constructed site",
+        all("P1" in r_all(empty_condition) for n in (1, 3, 8) for _site in line_sites(n)),
+    )
+    check(
+        "AD3 R_p0only rejector detects failure of the declared P1 premise at every site",
+        all("P1" not in r_p0only(empty_condition) for n in (1, 3, 8) for _site in line_sites(n)),
+        "the availability premise is selective, not vacuous",
+    )
+    recorded_neighbor: NeighborCondition = ("P0", None, None, None, None, None)
+    check(
+        "AD4 R_varying makes P1 availability vary with the neighbor condition",
+        "P1" in r_varying(empty_condition) and "P1" not in r_varying(recorded_neighbor),
+    )
+    locked: dict[tuple[int, int, int], str] = {}
+    realized_stack: list[LocalReadoutAtom] = []
+    admissible_at_lock: list[bool] = []
+    for record in atoms(8):
+        condition_at_lock = neighbor_condition(record.site, locked)
+        admissible_at_lock.append(record.label in r_all(condition_at_lock))
+        locked[record.site] = record.label
+        realized_stack.append(record)
+    check(
+        "AD5 toy realized stack locks only possibilities available at lock time under R_all",
+        len(realized_stack) == 8 and all(admissible_at_lock),
+    )
+    print("[NAMED] AD5 live presence-conditional layer: by the Record wording, a present record locks an admissible local possibility")
 
     print("\nC. arbitrary finite disjoint supports on Z^3")
     tested_lengths = [0, 1, 2, 3, 5, 8, 13, 21, 55]
@@ -161,6 +251,7 @@ def main() -> int:
         "physical_context_selection": "open",
         "clock_rate": "open",
         "dial_selection": "open",
+        "admissibility_instance_selection": "open",
     }
     check("E1 local readout-atom availability is the closed part", gates["local_readout_atom_availability"] == "closed")
     check("E2 declared unit-count context is the closed finite algebra part", gates["declared_unit_count_context"] == "closed")
@@ -170,6 +261,7 @@ def main() -> int:
     check("E6 physical context selection remains open", gates["physical_context_selection"] == "open")
     check("E7 clock/rate remains open", gates["clock_rate"] == "open")
     check("E8 dial selection remains open", gates["dial_selection"] == "open")
+    check("E9 admissibility-instance selection remains open", gates["admissibility_instance_selection"] == "open")
 
     print()
     print(f"SCORECARD: PASS={PASS} FAIL={FAIL}")

--- a/scripts/frontier_record_local_finite_atom_availability_2026_06_17.py
+++ b/scripts/frontier_record_local_finite_atom_availability_2026_06_17.py
@@ -243,7 +243,7 @@ def main() -> int:
 
     print("\nE. boundary classifier")
     gates = {
-        "local_readout_atom_availability": "closed",
+        "local_readout_atom_availability": "closed_under_declared_instance",
         "declared_unit_count_context": "closed",
         "record_production": "open",
         "measurement_decoherence_instrument": "open",
@@ -253,7 +253,10 @@ def main() -> int:
         "dial_selection": "open",
         "admissibility_instance_selection": "open",
     }
-    check("E1 local readout-atom availability is the closed part", gates["local_readout_atom_availability"] == "closed")
+    check(
+        "E1 local readout-atom availability closes only under the declared instance",
+        gates["local_readout_atom_availability"] == "closed_under_declared_instance",
+    )
     check("E2 declared unit-count context is the closed finite algebra part", gates["declared_unit_count_context"] == "closed")
     check("E3 record production remains open", gates["record_production"] == "open")
     check("E4 measurement/decoherence instrument remains open", gates["measurement_decoherence_instrument"] == "open")
@@ -267,8 +270,10 @@ def main() -> int:
     print(f"SCORECARD: PASS={PASS} FAIL={FAIL}")
     if FAIL == 0:
         print(
-            "VERDICT: exact finite local readout-atom/context availability closes; "
-            "production, probability, physical context selection, clock/rate, and dial selection remain open."
+            "VERDICT: exact finite local readout-atom/context availability closes only under the "
+            "declared admissibility instance, diagonal readout context, K/conjugation context, "
+            "and unit-count normalization; selection of those inputs, production, probability, "
+            "clock/rate, and dial selection remain open."
         )
         return 0
     print("VERDICT: local atom availability repair failed; do not use this artifact.")


### PR DESCRIPTION
## Audit repair target

Ledger row `record_local_finite_atom_availability_narrow_theorem_note_2026-06-17`, currently `audited_conditional`. The auditor's `chain_closure_explanation` (verbatim):

> The finite projector algebra inside a declared M2(C) context closes, but the live 2026-06-29 axiom surface adds admissibility and only lets records lock admissible local possibilities. The source does not derive that the chosen P1 atoms are admissible for arbitrary finite supports, and its runner is stale against the current formation no-go text.

## What this PR does

Restates the note on the live four-axiom memo (`Lattice`/`Qubit`/`Admissibility`/`Record`, 2026-06-29) and supplies exactly the two missing pieces the auditor named:

**Admissibility of the chosen atoms.** The Admissibility axiom fixes one covariant NN rule but leaves instance content unspecified (declared, not derived). The note now carries a "Admissibility layer (declared instance premise)" section: the availability claim names its declared admissibility-instance premise explicitly (an instance premise, not axiom content), and a presence-conditional paragraph cites the live Record wording ("a record locks exactly one admissible local possibility"). The Result section states availability under that declared instance. The framework cannot derive instance content from the axioms — so the honest repair is a named declared premise plus a new open gate (`admissibility-instance selection`), not a fabricated derivation.

**Runner staleness against the formation no-go.** Dependencies swapped from the legacy 2026-06-05 memo to [MINIMAL_AXIOMS_2026-06-29.md](docs/MINIMAL_AXIOMS_2026-06-29.md) plus the live [RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md](docs/RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md) as second dep. The runner's axiom-surface block now pins ten needles to the live memo and the narrowed no-go text (including the no-go's own "It does not supply the formation rule/process/state/site/weight/rate." and the axiom-forced "Records form." occurrence clause). K/CPT wording moved to downstream readout-context content per the live Record axiom.

**New runner AD block (real checks, with rejector).** Three toy admissibility instances as multiset functions of the 6-neighbor label tuple: `R_all` (premise holds; covariance checked over all 720 label permutations x 4 representative conditions), `R_p0only` (explicit rejector — premise fails everywhere), `R_varying` (condition-dependent availability: P1 available on the empty condition, not with a recorded neighbor). AD5 runs a real lock-time presence-conditional check over `atoms(8)` with a growing locked dict — each lock is validated against the instance at its actual neighbor condition at lock time.

## Runner numbers (my own re-runs, not log echoes)

- `scripts/frontier_record_local_finite_atom_availability_2026_06_17.py`: `SCORECARD: PASS=52 FAIL=0`, exit 0 (acceptance was N>=45)
- Sibling `scripts/frontier_record_formation_not_unconditionally_forced_by_minimal_axioms.py`: `TOTAL: PASS=6 FAIL=0`, exit 0 (the no-go's own runner still passes with the new dep edge pointing at it)
- Cache regenerated via `runner_cache.execute_runner`/`write_cache`: `exit_code: 0`

Forbidden-string checks: "Quantum" (legacy axiom name) 0 hits in the note; no audit-grade or status-prediction language; preserve needle "record-eligible readout atoms" intact (x2).

## Landing order

None — standalone. Both dependency targets (the 2026-06-29 memo and the formation no-go note) are already on main; no other open PR touches these files.

Finite-algebra content of the theorem is unchanged; this is a surface restatement plus the declared-premise layer the auditor asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-loop landing checklist

**Audit repair target (`notes_for_re_audit_if_any`, verbatim):**

> missing_bridge_theorem: add a current-axiom bridge proving the chosen local projector atoms are admissible record-eligible possibilities for arbitrary finite supports, then refresh the runner against MINIMAL_AXIOMS_2026-06-29 and add the formation no-go as a direct dependency or remove the dependency on it.

- Source-side requeue: the target note and paired runner changed; validation confirms source-side hash drift.
- Sibling-runner pin sweep: `rg -l --fixed-strings RECORD_LOCAL_FINITE_ATOM_AVAILABILITY_NARROW_THEOREM_NOTE_2026-06-17.md scripts` identified the paired runner and the unbounded-additivity consumer; their pins were reviewed before landing.
- Claim boundary: the honest bounded alternative was selected. The admissibility instance, diagonal readout context, K/conjugation context, and unit-count normalization remain supplied inputs.
- Audit-generated outputs: none are submitted; pipeline-regenerated audit/data and effective-status files are validation-only and stripped before landing.
- Status authority: independent audit lane only.