### PR TITLE
feat(ckm-bridge): derive 5/6 exponent and 12/25 transport as exact Fractions in the bridge-support runner

### DIFF
--- a/docs/CKM_FIVE_SIXTHS_BRIDGE_SUPPORT_NOTE.md
+++ b/docs/CKM_FIVE_SIXTHS_BRIDGE_SUPPORT_NOTE.md
@@ -175,13 +175,23 @@ python3 scripts/frontier_ckm_five_sixths_bridge_support.py
 
 Current expected result on `main`:
 
-- `EXACT PASS=5`
+- `EXACT PASS=15`
 - `BOUNDED PASS=7`
 - `FAIL=0`
 
 The runner checks:
 
 - exact `SU(3)` identity `C_F - T_F = 5/6`
+- exact Fraction derivation `C_F - T_F = (N^2-1)/(2N) - 1/2 = 5/6` at
+  `N = 3` from SU(3) representation data, with the float constants `C_F`, `T_F`
+  asserted equal to the exact values and the runner's compound float exponent
+  asserted within one ulp of the exact `5/6`
+- `N = 3` uniqueness in the scan window `N = 2..6` via the factorization
+  `3N^2 - 8N - 3 = (3N+1)(N-3)`
+- exact one-loop transport `gamma_0/(2 beta_0) = 12/25` at the threshold-local
+  `n_f = 4` point (convention `gamma_0 = 6 C_F`,
+  `beta_0 = 11 - 2 n_f/3`), with explicit `n_f = 3` (`4/9`) and `n_f = 5`
+  (`12/23`) rejectors and an `N = 2` (`1/4`) exponent rejector
 - exact promoted CKM input `|V_cb| = alpha_s(v)/sqrt(6)`
 - bounded `m_s/m_b` extraction from the `5/6` bridge
 - threshold-local self-scale transport from same-scale to PDG comparator

--- a/docs/CKM_FIVE_SIXTHS_BRIDGE_SUPPORT_NOTE.md
+++ b/docs/CKM_FIVE_SIXTHS_BRIDGE_SUPPORT_NOTE.md
@@ -2,6 +2,7 @@
 
 **Date:** 2026-04-16
 **Status:** bounded support tool for the down-type CKM-dual mass-ratio lane
+**Type:** bounded_theorem
 **Primary runner:** `scripts/frontier_ckm_five_sixths_bridge_support.py`
 
 ## Safe statement

--- a/logs/runner-cache/frontier_ckm_five_sixths_bridge_support.txt
+++ b/logs/runner-cache/frontier_ckm_five_sixths_bridge_support.txt
@@ -1,14 +1,28 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_ckm_five_sixths_bridge_support.py
-runner_sha256: d21d88ea3ed968239d23ca3df3850621eb18858dd2eda2dece0c8ec935989f8b
-timeout_sec: 120
+runner_sha256: 261772bf8b7406ab2347a47f7a6a590b494df6e74b067b5d0297a07478d135bb
+timeout_sec: 300
 exit_code: 0
-elapsed_sec: 0.04
+elapsed_sec: 0.05
 status: ok
 ----- stdout -----
 ========================================================================
   FRONTIER: CKM Five-Sixths Bridge Support
 ========================================================================
+
+========================================================================
+PART 0: Exact exponent and transport derivation
+========================================================================
+  [PASS] P0.1: C_F exact derivation
+  [PASS] P0.2: T_F exact input
+  [PASS] P0.3: exponent exact derivation
+  [PASS] P0.4: exact values reproduce existing float constants (exponent within 1 ulp)  (C_F,T_F exact; float(C_F-T_F) vs exact 5/6 gap = 1.11e-16)
+  [PASS] P0.5: N=3 is unique in the N=2..6 scan  (identity=True, matching ranks=[3])
+  [PASS] P0.6: exact one-loop inputs at N=3 and n_f=4
+  [PASS] P0.7: exact threshold-local transport power
+  [PASS] P0.8: n_f=3 transport rejector detected  (wrong-input value=4/9)
+  [PASS] P0.9: n_f=5 transport rejector detected  (wrong-input value=12/23)
+  [PASS] P0.10: N=2 exponent rejector detected  (wrong-input value=1/4)
 
 ========================================================================
 PART 1: Exact SU(3) and promoted CKM surface
@@ -70,7 +84,7 @@ PART 4: Exact multiplicative deviation decomposition
 ========================================================================
 SUMMARY
 ========================================================================
-  EXACT PASS=5
+  EXACT PASS=15
   BOUNDED PASS=7
   FAIL=0
   Status: bounded support tool for the down-type mass-ratio lane

--- a/scripts/frontier_ckm_five_sixths_bridge_support.py
+++ b/scripts/frontier_ckm_five_sixths_bridge_support.py
@@ -16,9 +16,37 @@ Safe claim:
 
 from __future__ import annotations
 
+from fractions import Fraction
 import math
 
 from canonical_plaquette_surface import CANONICAL_ALPHA_S_V
+
+
+N_C = 3
+
+
+def casimir_fundamental(n: int) -> Fraction:
+    return Fraction(n * n - 1, 2 * n)
+
+
+T_F_EXACT = Fraction(1, 2)
+
+
+def exponent_exact(n: int) -> Fraction:
+    return casimir_fundamental(n) - T_F_EXACT
+
+
+def beta0_exact(n_f: int) -> Fraction:
+    return Fraction(11) - Fraction(2 * n_f, 3)
+
+
+def gamma0_exact(n: int) -> Fraction:
+    return 6 * casimir_fundamental(n)
+
+
+C_F_EXACT = casimir_fundamental(N_C)
+EXPONENT_EXACT = exponent_exact(N_C)
+TRANSPORT_EXACT = gamma0_exact(N_C) / (2 * beta0_exact(4))
 
 
 C_F = 4.0 / 3.0
@@ -55,6 +83,65 @@ def check(name: str, condition: bool, detail: str = "", kind: str = "EXACT") -> 
     if detail:
         line += f"  ({detail})"
     print(line)
+
+
+def part0_exact_derivation() -> None:
+    print("\n" + "=" * 72)
+    print("PART 0: Exact exponent and transport derivation")
+    print("=" * 72)
+
+    polynomial_identity = all(
+        3 * n * n - 8 * n - 3 == (3 * n + 1) * (n - 3)
+        for n in range(-2, 9)
+    )
+    matching_ranks = {
+        n for n in range(2, 7) if exponent_exact(n) == Fraction(5, 6)
+    }
+    transport_nf3 = gamma0_exact(3) / (2 * beta0_exact(3))
+    transport_nf5 = gamma0_exact(3) / (2 * beta0_exact(5))
+    exponent_n2 = exponent_exact(2)
+
+    check("P0.1: C_F exact derivation", C_F_EXACT == Fraction(4, 3))
+    check("P0.2: T_F exact input", T_F_EXACT == Fraction(1, 2))
+    check("P0.3: exponent exact derivation", EXPONENT_EXACT == Fraction(5, 6))
+    check(
+        "P0.4: exact values reproduce existing float constants (exponent within 1 ulp)",
+        C_F == float(C_F_EXACT)
+        and T_F == float(T_F_EXACT)
+        and abs(EXPONENT - float(EXPONENT_EXACT)) <= 2.0 ** -53,
+        f"C_F,T_F exact; float(C_F-T_F) vs exact 5/6 gap = "
+        f"{abs(EXPONENT - float(EXPONENT_EXACT)):.2e}",
+    )
+    check(
+        "P0.5: N=3 is unique in the N=2..6 scan",
+        polynomial_identity and matching_ranks == {3},
+        f"identity={polynomial_identity}, matching ranks={sorted(matching_ranks)}",
+    )
+    check(
+        "P0.6: exact one-loop inputs at N=3 and n_f=4",
+        gamma0_exact(3) == Fraction(8)
+        and beta0_exact(4) == Fraction(25, 3),
+    )
+    check(
+        "P0.7: exact threshold-local transport power",
+        TRANSPORT_EXACT == Fraction(12, 25)
+        and GAMMA0_OVER_2BETA0 == float(TRANSPORT_EXACT),
+    )
+    check(
+        "P0.8: n_f=3 transport rejector detected",
+        transport_nf3 == Fraction(4, 9) and transport_nf3 != TRANSPORT_EXACT,
+        f"wrong-input value={transport_nf3}",
+    )
+    check(
+        "P0.9: n_f=5 transport rejector detected",
+        transport_nf5 == Fraction(12, 23) and transport_nf5 != TRANSPORT_EXACT,
+        f"wrong-input value={transport_nf5}",
+    )
+    check(
+        "P0.10: N=2 exponent rejector detected",
+        exponent_n2 == Fraction(1, 4) and exponent_n2 != EXPONENT_EXACT,
+        f"wrong-input value={exponent_n2}",
+    )
 
 
 def part1_exact_surface() -> tuple[float, float]:
@@ -201,6 +288,7 @@ def main() -> int:
     print("  FRONTIER: CKM Five-Sixths Bridge Support")
     print("=" * 72)
 
+    part0_exact_derivation()
     v_cb, r_pred = part1_exact_surface()
     r_from_obs_vcb, r_pred = part2_bounded_bridge(v_cb, r_pred)
     part3_self_scale_transport(r_pred)


### PR DESCRIPTION
## Audit repair target

Ledger row `ckm_five_sixths_bridge_support_note`, currently `audited_conditional`. The auditor's `chain_closure_explanation` (verbatim):

> The arithmetic and runner checks close only after accepting the CKM-to-mass-ratio bridge and the threshold-local scale surface. The restricted packet does not derive either the bridge |V_cb| = (m_s/m_b)^(5/6) or the scale-selection rule from an axiom or retained input.

## What this PR does (and does not do)

The bridge `|V_cb| = (m_s/m_b)^(5/6)` and the scale-selection rule **stay named premises** — that boundary is honest and preserved verbatim ("full scale-choice closure is not yet theorem-grade."; the entire "What is not claimed" list is untouched). What this PR derives is the packet's arithmetic **inputs**, which previously entered as bare float literals the runner never checked:

- **The exponent 5/6** as exact SU(3) representation arithmetic: `C_F = (N^2-1)/(2N)`, `T_F = 1/2`, `C_F - T_F = 5/6` at `N = 3`, all as `fractions.Fraction` with no float rounding — plus an **N=3 uniqueness gate**: `3N^2 - 8N - 3 = (3N+1)(N-3)` as an integer polynomial identity (checked at n = -2..8), and the scan `{N in 2..6 : exponent(N) = 5/6} = {3}`.
- **The transport power 12/25** as exact one-loop data at the threshold-local point: `gamma_0 = 6 C_F = 8`, `beta_0(n_f=4) = 25/3`, `gamma_0/(2 beta_0) = 12/25` — the convention the runner already used, now derived rather than asserted.
- **Rejectors** (each passes iff the wrong-input exact value is reproduced AND differs from the n_f=4 / N=3 value): `n_f=3 -> 4/9`, `n_f=5 -> 12/23`, `N=2 -> 1/4`.

New `part0_exact_derivation()` runs first in main(); Parts 1–4, all float constants, tolerances, and the SUMMARY block are byte-for-byte unchanged (verified against the diff and by grep).

## Reviewer catch (1-ulp float fact)

The executor's draft resolved an impossibility in my spec by redefining `EXPONENT = float(EXPONENT_EXACT)` — changing the landed constant by 1 ulp and making that clause of the float-bridge gate true by construction. The floating-point fact: `4.0/3.0 - 0.5 = 0x1.aaaaaaaaaaaaap-1` while `float(Fraction(5,6)) = 0x1.aaaaaaaaaaaabp-1` — exactly 1 ulp apart (the compound float subtraction of two correctly-rounded constants is not the correctly-rounded exact value). I reverted `EXPONENT = C_F - T_F` byte-for-byte and made P0.4 state the truth: `C_F`, `T_F` reproduce their exact values exactly; the compound float exponent sits within 1 ulp (`<= 2^-53`) of exact 5/6, with the measured gap (1.11e-16) printed in the check detail. The gate stays discriminating — a wrong exact value (e.g. the N=2 rejector's 1/4) misses by ~10^14 ulp. The note bullet states the same distinction.

## Runner numbers (my own re-runs, not log echoes)

- `scripts/frontier_ckm_five_sixths_bridge_support.py`: `EXACT PASS=15`, `BOUNDED PASS=7`, `FAIL=0`, exit 0 (acceptance: EXACT >= 15, BOUNDED = 7 unchanged)
- Note expected-count lines updated `EXACT PASS=5` -> `EXACT PASS=15` and match the actual output
- All five sibling runners referencing this note/runner re-run clean: `frontier_quark_five_sixths_scale_selection_boundary` (PASS=34 FAIL=0), `frontier_ckm_down_type_scale_convention_support` (prose-summary runner, exit 0), `source_cycle_false_edge_hygiene_2026_06_17` (PASS=11 FAIL=0), `frontier_koide_color_sector_correction` (PASS=24 FAIL=0), `ckm_down_type_scale_convention_cycle_edge_hygiene_2026_06_17` (PASS=11 FAIL=0)
- Cache regenerated via `runner_cache.execute_runner`/`write_cache`: `exit_code: 0`
- Link inventory identical to main (no .md links added or removed); backticked peers (`CKM_FROM_MASS_HIERARCHY_NOTE.md`, `DOWN_TYPE_MASS_RATIO_CKM_DUAL_NOTE.md`) stay backticked non-deps; forbidden strings 0 hits

## Landing order

None — standalone. No other open PR touches these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-loop landing checklist

**Audit repair target (`notes_for_re_audit_if_any`, verbatim):**

> missing_bridge_theorem: derive the 5/6 CKM-to-mass-ratio bridge and the threshold-local scale-selection rule from approved premises, then update the runner to compute rather than assume those steps.

- Source-side requeue: the target note changed; validation confirms its source hash drifts for ordinary re-audit.
- Sibling-runner pin sweep: `rg -l --fixed-strings CKM_FIVE_SIXTHS_BRIDGE_SUPPORT_NOTE.md scripts` identified five siblings; all five were reviewed and rerun before landing.
- Claim boundary: this is bounded arithmetic hardening only. It does not satisfy the physical bridge or scale-selection target.
- Audit-generated outputs: none are submitted; pipeline-regenerated audit/data and effective-status files are validation-only and stripped before landing.
- Status authority: independent audit lane only.