### PR TITLE
feat(gravity): transverse non-centrality structure of the emergent force at O(1/r^4)

### DIFF
--- a/docs/GRAVITY_EMERGENT_FORCE_TRANSVERSE_NONCENTRALITY_STRUCTURE_THEOREM_NOTE_2026-07-09.md
+++ b/docs/GRAVITY_EMERGENT_FORCE_TRANSVERSE_NONCENTRALITY_STRUCTURE_THEOREM_NOTE_2026-07-09.md
@@ -1,0 +1,154 @@
+# The Emergent Force Is Not Central: Exact Transverse Structure at O(1/r⁴) and the Three Central Orbits
+
+**Date:** 2026-07-09
+**Claim type:** theorem
+**Status authority:** independent audit lane only. This source note does not set or predict an audit outcome.
+**Primary runner:** [`scripts/frontier_gravity_transverse_noncentrality_structure.py`](../scripts/frontier_gravity_transverse_noncentrality_structure.py)
+**Cached output:** [`logs/runner-cache/frontier_gravity_transverse_noncentrality_structure.txt`](../logs/runner-cache/frontier_gravity_transverse_noncentrality_structure.txt)
+
+## Claim
+
+> **`−∇G = [1/(4π r²) + (15/(32π))·K₄(n̂)/r⁴]·n̂ − (5/(8π))·(n̂³ − S₄ n̂)/r⁴ + O(1/r⁶)`**
+
+The second correction term is exactly tangent to the sphere, so the emergent force is
+not central in a generic direction. It is asymptotically central precisely on the three
+cubic orbits `⟨100⟩`, `⟨110⟩`, and `⟨111⟩`, the stationary orbits of `S₄`. Its transverse
+magnitude is `(5/(8π))·√(S₆ − S₄²)/r⁴`, and relative to the Newtonian radial term it is
+at most `(5/2)·q_max/r²`, where `q²_max = (827 + 73√73)/18432` and the exact minimal
+polynomial is `9216·Q² − 827·Q + 8`.
+
+## Setting and dependencies
+
+The input expansion comes from the leading-correction theorem
+[`GRAVITY_LEADING_LATTICE_CORRECTION_CUBIC_ANISOTROPY_THEOREM_NOTE_2026-06-07`](GRAVITY_LEADING_LATTICE_CORRECTION_CUBIC_ANISOTROPY_THEOREM_NOTE_2026-06-07.md),
+which supplies `G(r) = 1/(4π r) + [5/(32π)]·K₄(n̂)/r³ + O(1/r⁵)`. This note is pure
+structure downstream of that expansion: exact gradient algebra plus an independent
+numeric certification of the remainder order against the exact Bessel-resolvent Green
+function. No new physical identification is introduced. “Force” means `−∇` of the same
+emergent potential named in that theorem.
+
+Write `r = |x|`, `n̂ = x/r`, `S₄ = Σ_μ n̂_μ⁴`, `S₆ = Σ_μ n̂_μ⁶`,
+`K₄ = S₄ − 3/5`, and `n̂³ = (n̂_x³,n̂_y³,n̂_z³)` componentwise. Define
+`t(n̂) = n̂³ − S₄n̂` and `q²(n̂) = S₆ − S₄²`.
+
+## Theorem
+
+- **T1 — gradient and remainder.** Exact differentiation of the supplied asymptotic form gives
+  `∇[1/(4πr) + (5/(32π))K₄/r³]`
+  `= −[1/(4πr²) + (15/(32π))K₄/r⁴]n̂ + (5/(8π))t/r⁴`.
+  Consequently the displayed force formula holds with remainder `O(1/r⁶)`. The
+  `O(1/r⁵)` potential term first contributes to its gradient at `O(1/r⁶)`.
+
+- **T2 — exact tangency and magnitude.** The identities
+  `n̂·t = n̂·n̂³ − S₄ = 0` and `t_μ = n̂_μ(n̂_μ² − S₄)` hold componentwise.
+  For the degree-zero homogeneous extension of `S₄`, `∇S₄ = 4t/r`, equivalently
+  `t = (1/4)∇_tan S₄`. Moreover, `|t|² = S₆ − S₄² = q²(n̂)` exactly.
+
+- **T3 — centrality classification.** `t = 0` if and only if every nonzero component
+  obeys `n̂_μ² = S₄`. The unit-norm condition then makes the `k` nonzero components
+  equal in magnitude, with `S₄ = 1/k` for `k = 1,2,3`. Thus the zero set is exactly
+  `⟨100⟩ ∪ ⟨110⟩ ∪ ⟨111⟩`, with `S₄ = 1,1/2,1/3`, respectively.
+
+- **T4 — stationary-orbit signatures.** These three orbits are precisely the stationary
+  orbits of `S₄` on the unit sphere. Its tangent-plane Hessian has eigenvalues
+  `{-4,-4}` at `⟨100⟩` (maximum), `{-2,+4}` at `⟨110⟩` (saddle), and
+  `{+8/3,+8/3}` at `⟨111⟩` (minimum). The equal eigenvalues at the first and third
+  orbits are forced by their `C₄` and `C₃` stabilizers.
+
+- **T5 — all-orders centrality on the three orbits.** The asymptotic gradient field is
+  equivariant under proper cubic rotations. At a fixed direction, any transverse term
+  must be a fixed vector of the stabilizer's tangent-plane action. The generators act
+  by rotation through `π/2` at `⟨100⟩`, `π` at `⟨110⟩`, and `2π/3` at `⟨111⟩`;
+  none has tangent-plane eigenvalue `1`. Every transverse term therefore vanishes there
+  at every asymptotic order. Conversely, T3 gives a nonzero `O(1/r⁴)` transverse term
+  in every other direction. The field is asymptotically central precisely on ⟨100⟩ ∪ ⟨110⟩ ∪ ⟨111⟩.
+
+- **T6 — transverse-to-radial ratio.** Dividing the leading transverse magnitude by
+  `1/(4πr²)` gives
+  `|transverse|/|radial| = (5/2)·q(n̂)/r² + O(1/r⁴)`.
+
+- **T7 — extremal anisotropy.** Stationarity of `q²` on the sphere is equivalent to
+  `n̂_μ(6n̂_μ⁴ − 8S₄n̂_μ² − 6S₆ + 8S₄²) = 0` for every `μ`. The bracketed factor is
+  quadratic in `n̂_μ²`, so at a stationary direction the nonzero components take at most
+  two distinct squared values; up to permutation and sign, every stationary direction
+  therefore lies in the planar family `n̂² = (v,1−v,0)` or the family
+  `n̂² = (u,u,1−2u)`. On the family
+  `n̂² = (u,u,1−2u)`,
+  `q²(u) = 2u³ + (1−2u)³ − [2u² + (1−2u)²]²` is maximized at
+  `u* = (13−√73)/48`. The global value is
+  `q²_max = (827 + 73√73)/18432 ≈ 0.0787061780`, and it obeys
+  `9216·Q² − 827·Q + 8 = 0`. The planar family has maximum `q² = 1/16` at
+  `n̂_x² = cos²(π/8)`, strictly below the global value. Hence the largest ratio
+  coefficient is `(5/2)q_max ≈ 0.70136553`. The lattice direction `(1,1,3)` has
+  `q² = 1152/14641 ≈ 0.0786832`, within `0.05%` of the global maximum.
+
+## Why the transverse term is the tangential gradient of S₄
+
+At this order the angular dependence enters through `S₄` alone. The derivative of
+`K₄/r³` therefore separates into a radial derivative and a sphere-tangential derivative.
+Projection onto the tangent plane gives the one-line identity
+`∇_tan S₄/4 = (n̂³ − S₄n̂) = t`.
+Thus the transverse component of `∇G` is parallel to the tangential gradient of `S₄`.
+Its gradient-field lines bend along the `S₄` gradient flow on the sphere, whose fixed
+points are the three orbits in T3 and whose local signatures are those in T4.
+
+## Numeric certification (runner)
+
+The `S1–S8` gates use exact SymPy algebra for the gradient, tangency, component factors,
+magnitude, classification, tangent Hessians, constrained stationarity, extrema, exact
+anchors, pair-response contrast, and stabilizer fixed-vector determinants. The runner
+does not infer any coefficient from numerical data. A deterministic simplex-grid scan
+over squared directions additionally certifies that no direction exceeds the
+two-equal-squares family maximum, at grid resolution `1/240`.
+
+The `N1–N5` gates evaluate the exact lattice Green function at `mp.dps = 24` using
+`G(x) = ∫₀^∞ e^{−6t} Π_μ I_{x_μ}(2t) dt`. They use the six lattice sites
+`(3,3,9)`, `(5,5,15)`, `(8,4,0)`, `(14,7,0)`, `(8,4,4)`, and `(12,6,6)`.
+The five-point stencil
+`D_ν = [−G(x+2e_ν)+8G(x+e_ν)−8G(x−e_ν)+G(x−2e_ν)]/12`
+has truncation `O(∂⁵G) = O(1/r⁶)`; the three-point stencil is insufficient because its
+`O(1/r⁴)` truncation is the same order as the transverse term.
+
+For each site the runner computes `ρ_num = n̂·D`, `t_num = D−ρ_num n̂`, and the radial
+and transverse predictions directly. The observed scaled transverse and radial residuals
+are bounded by the gates, the three direction pairs show the required relative
+`O(1/r²)` convergence, all six sites witness non-centrality, and the two largest-radius
+sites reproduce the ratio in T6 within `15%`. The exact direction anchors are
+`q²(1,1,3)=1152/14641`, `q²(2,1,0)=36/625`, `q²(2,1,1)=1/18`, and `q²=0` on
+`⟨100⟩`, `⟨110⟩`, and `⟨111⟩`.
+
+The `CTRL1–CTRL4` gates require rejection of a `10%`-inflated transverse coefficient,
+the nontangent substitution of `S₆` for `S₄`, the wrong minimal-polynomial coefficient
+`826`, and the wrong gradient coefficient `3/8`. These controls reuse the computed
+quantities and add no fitted parameter.
+
+## Conditional corollary (bounded bridge)
+
+Conditional on the weak-field source-response bridge
+[`GRAVITY_WEAK_FIELD_SOURCE_RESPONSE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-11`](GRAVITY_WEAK_FIELD_SOURCE_RESPONSE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-11.md),
+which converts `G` into a static pair response, two equal-source pairs at equal separation
+`r` along `⟨100⟩` and `⟨111⟩` differ in response magnitude by
+`(5/(32π))[K₄(⟨100⟩)−K₄(⟨111⟩)]/r³ = 5/(48π r³)` per unit coupling, since
+`K₄(⟨100⟩)=2/5`, `K₄(⟨110⟩)=−1/10`, and `K₄(⟨111⟩)=−4/15`. The equilibrium
+orientations of the induced torque, where the `O(1/r⁴)` transverse component vanishes,
+are exactly the three orbits of T3. This corollary is conditional on the bridge; the main
+theorem does not depend on it. Which response extremum is energetically preferred depends
+on the bridge's coupling-sign convention and is not assigned here.
+
+## Boundary / honest auditor read
+
+- The theorem gives the exact asymptotic structure of the supplied expansion together
+  with numerical certification of the remainder order; it does not derive new dynamics.
+- The `O(1/r⁶)` remainder is certified on six sites in three directions with `r ≤ 16.6`,
+  rather than proven symbolically here.
+- The conditional corollary inherits the bounded status of its cited bridge.
+- T5 is a symmetry theorem about the asymptotic series of an `O_h`-equivariant field,
+  certified by the stabilizer fixed-vector check.
+- The next natural step is the transverse structure at the next order: the `l=4,6,8`
+  content of the `O(1/r⁶)` transverse term.
+
+## Files
+
+- Source: this theorem note.
+- Executable runner: `scripts/frontier_gravity_transverse_noncentrality_structure.py`.
+- Reviewer cache target: `logs/runner-cache/frontier_gravity_transverse_noncentrality_structure.txt`.

--- a/docs/GRAVITY_EMERGENT_FORCE_TRANSVERSE_NONCENTRALITY_STRUCTURE_THEOREM_NOTE_2026-07-09.md
+++ b/docs/GRAVITY_EMERGENT_FORCE_TRANSVERSE_NONCENTRALITY_STRUCTURE_THEOREM_NOTE_2026-07-09.md
@@ -1,13 +1,14 @@
 # The Emergent Force Is Not Central: Exact Transverse Structure at O(1/r⁴) and the Three Central Orbits
 
 **Date:** 2026-07-09
-**Claim type:** theorem
-**Status authority:** independent audit lane only. This source note does not set or predict an audit outcome.
+**Claim type:** bounded_theorem
+**Status:** source-side bounded proposal; independent audit required.
 **Primary runner:** [`scripts/frontier_gravity_transverse_noncentrality_structure.py`](../scripts/frontier_gravity_transverse_noncentrality_structure.py)
 **Cached output:** [`logs/runner-cache/frontier_gravity_transverse_noncentrality_structure.txt`](../logs/runner-cache/frontier_gravity_transverse_noncentrality_structure.txt)
 
 ## Claim
 
+> **Conditional on the differentiable-remainder premise below,**
 > **`−∇G = [1/(4π r²) + (15/(32π))·K₄(n̂)/r⁴]·n̂ − (5/(8π))·(n̂³ − S₄ n̂)/r⁴ + O(1/r⁶)`**
 
 The second correction term is exactly tangent to the sphere, so the emergent force is
@@ -22,10 +23,10 @@ polynomial is `9216·Q² − 827·Q + 8`.
 The input expansion comes from the leading-correction theorem
 [`GRAVITY_LEADING_LATTICE_CORRECTION_CUBIC_ANISOTROPY_THEOREM_NOTE_2026-06-07`](GRAVITY_LEADING_LATTICE_CORRECTION_CUBIC_ANISOTROPY_THEOREM_NOTE_2026-06-07.md),
 which supplies `G(r) = 1/(4π r) + [5/(32π)]·K₄(n̂)/r³ + O(1/r⁵)`. This note is pure
-structure downstream of that expansion: exact gradient algebra plus an independent
-numeric certification of the remainder order against the exact Bessel-resolvent Green
-function. No new physical identification is introduced. “Force” means `−∇` of the same
-emergent potential named in that theorem.
+structure downstream of that expansion: exact gradient algebra plus independent
+finite-site numerical support for differentiating the remainder against the exact
+Bessel-resolvent Green function. No new physical identification is introduced. “Force”
+means `−∇` of the same emergent potential named in that theorem.
 
 Write `r = |x|`, `n̂ = x/r`, `S₄ = Σ_μ n̂_μ⁴`, `S₆ = Σ_μ n̂_μ⁶`,
 `K₄ = S₄ − 3/5`, and `n̂³ = (n̂_x³,n̂_y³,n̂_z³)` componentwise. Define
@@ -33,11 +34,14 @@ Write `r = |x|`, `n̂ = x/r`, `S₄ = Σ_μ n̂_μ⁴`, `S₆ = Σ_μ n̂_μ⁶`
 
 ## Theorem
 
-- **T1 — gradient and remainder.** Exact differentiation of the supplied asymptotic form gives
+- **T1 — gradient and conditional remainder.** Exact differentiation of the displayed
+  two-term truncation gives
   `∇[1/(4πr) + (5/(32π))K₄/r³]`
   `= −[1/(4πr²) + (15/(32π))K₄/r⁴]n̂ + (5/(8π))t/r⁴`.
-  Consequently the displayed force formula holds with remainder `O(1/r⁶)`. The
-  `O(1/r⁵)` potential term first contributes to its gradient at `O(1/r⁶)`.
+  If the supplied potential remainder `R_G(x)=O(r⁻⁵)` is differentiable with
+  `∇R_G(x)=O(r⁻⁶)` termwise in the lattice asymptotic expansion, then the full force
+  has the displayed `O(1/r⁶)` remainder. The six-site runner checks are finite-site
+  numerical support for this premise, not a proof of it.
 
 - **T2 — exact tangency and magnitude.** The identities
   `n̂·t = n̂·n̂³ − S₄ = 0` and `t_μ = n̂_μ(n̂_μ² − S₄)` hold componentwise.
@@ -63,7 +67,8 @@ Write `r = |x|`, `n̂ = x/r`, `S₄ = Σ_μ n̂_μ⁴`, `S₆ = Σ_μ n̂_μ⁶`
   at every asymptotic order. Conversely, T3 gives a nonzero `O(1/r⁴)` transverse term
   in every other direction. The field is asymptotically central precisely on ⟨100⟩ ∪ ⟨110⟩ ∪ ⟨111⟩.
 
-- **T6 — transverse-to-radial ratio.** Dividing the leading transverse magnitude by
+- **T6 — transverse-to-radial ratio.** Under the differentiable-remainder premise,
+  dividing the leading transverse magnitude by
   `1/(4πr²)` gives
   `|transverse|/|radial| = (5/2)·q(n̂)/r² + O(1/r⁴)`.
 
@@ -92,7 +97,7 @@ Thus the transverse component of `∇G` is parallel to the tangential gradient o
 Its gradient-field lines bend along the `S₄` gradient flow on the sphere, whose fixed
 points are the three orbits in T3 and whose local signatures are those in T4.
 
-## Numeric certification (runner)
+## Finite-site numerical support (runner)
 
 The `S1–S8` gates use exact SymPy algebra for the gradient, tangency, component factors,
 magnitude, classification, tangent Hessians, constrained stationarity, extrema, exact
@@ -111,9 +116,11 @@ has truncation `O(∂⁵G) = O(1/r⁶)`; the three-point stencil is insufficient
 
 For each site the runner computes `ρ_num = n̂·D`, `t_num = D−ρ_num n̂`, and the radial
 and transverse predictions directly. The observed scaled transverse and radial residuals
-are bounded by the gates, the three direction pairs show the required relative
-`O(1/r²)` convergence, all six sites witness non-centrality, and the two largest-radius
-sites reproduce the ratio in T6 within `15%`. The exact direction anchors are
+are compatible with the stated remainder at the sampled sites, the three direction pairs
+show the expected relative `O(1/r²)` convergence, all six sites witness non-centrality,
+and the two largest-radius sites reproduce the ratio in T6 within `15%`. These finite-site
+checks support but do not prove the differentiable-remainder premise. The exact direction
+anchors are
 `q²(1,1,3)=1152/14641`, `q²(2,1,0)=36/625`, `q²(2,1,1)=1/18`, and `q²=0` on
 `⟨100⟩`, `⟨110⟩`, and `⟨111⟩`.
 
@@ -137,10 +144,11 @@ on the bridge's coupling-sign convention and is not assigned here.
 
 ## Boundary / honest auditor read
 
-- The theorem gives the exact asymptotic structure of the supplied expansion together
-  with numerical certification of the remainder order; it does not derive new dynamics.
-- The `O(1/r⁶)` remainder is certified on six sites in three directions with `r ≤ 16.6`,
-  rather than proven symbolically here.
+- The theorem gives the exact gradient and orbit structure of the displayed two-term
+  truncation. The full-force `O(1/r⁶)` remainder is conditional on the named
+  differentiable-remainder premise; it does not derive new dynamics.
+- Six sites in three directions with `r ≤ 16.6` provide finite-site numerical support
+  for that premise. They do not prove an asymptotic derivative bound.
 - The conditional corollary inherits the bounded status of its cited bridge.
 - T5 is a symmetry theorem about the asymptotic series of an `O_h`-equivariant field,
   certified by the stabilizer fixed-vector check.

--- a/logs/runner-cache/frontier_gravity_transverse_noncentrality_structure.txt
+++ b/logs/runner-cache/frontier_gravity_transverse_noncentrality_structure.txt
@@ -1,0 +1,70 @@
+===== runner cache v1 =====
+runner: scripts/frontier_gravity_transverse_noncentrality_structure.py
+runner_sha256: 781372d68ed7bbba81c7eb8f1345a0cdc8528afb13bf7e1ca13ab8b89aee9c6e
+timeout_sec: 360
+exit_code: 0
+elapsed_sec: 33.18
+status: ok
+----- stdout -----
+PASS S1 gradient identity, x component
+PASS S1 gradient identity, y component
+PASS S1 gradient identity, z component
+PASS S2a transverse vector is exactly tangent
+PASS S2b component factor t_mu=nhat_mu(nhat_mu^2-S4)
+PASS S2c degree-zero gradient is 4t/r componentwise
+PASS S3 magnitude identity |t|^2=S6-S4^2
+PASS S4 central orbit <100> has t=0 and S4=1
+PASS S4 central orbit <110> has t=0 and S4=1/2
+PASS S4 central orbit <111> has t=0 and S4=1/3
+PASS S4 converse factor forces each nonzero square to equal S4
+PASS S4 k equal nonzero squares imply S4=1/k for k=1,2,3
+PASS S5 sphere Hessian spectrum at <100>
+PASS S5 sphere Hessian spectrum at <110>
+PASS S5 sphere Hessian spectrum at <111>
+PASS S6 constrained stationarity equation from lambda=n dot grad(q2)
+PASS S6 two-equal-square extremum u_star solves dq2/du
+PASS S6 exact global q2 maximum on the extremal family
+PASS S6 q2 maximum obeys 9216 Q^2-827 Q+8=0
+PASS S6 planar maximum q2=1/16 at v=cos^2(pi/8)
+PASS S6 global maximum is strictly above planar maximum
+PASS S6 simplex grid finds no direction above the family maximum
+PASS S6 simplex grid attains the family maximum to grid resolution
+PASS S7 exact q2 anchor (1,1,3)
+PASS S7 exact q2 anchor (2,1,0)
+PASS S7 exact q2 anchor (2,1,1)
+PASS S7 conditional pair-response contrast coefficient
+PASS S8 stabilizer has no tangent fixed vector at <100>
+PASS S8 stabilizer has no tangent fixed vector at <110>
+PASS S8 stabilizer has no tangent fixed vector at <111>
+PASS N1 transverse relative remainder at (3, 3, 9): e_t*r^2=1.01404911 < 8
+PASS N1 transverse relative remainder at (5, 5, 15): e_t*r^2=0.776289874 < 8
+PASS N1 transverse relative remainder at (8, 4, 0): e_t*r^2=2.18980574 < 8
+PASS N1 transverse relative remainder at (14, 7, 0): e_t*r^2=2.24725288 < 8
+PASS N1 transverse relative remainder at (8, 4, 4): e_t*r^2=4.71870185 < 8
+PASS N1 transverse relative remainder at (12, 6, 6): e_t*r^2=4.77927043 < 8
+PASS N2 radial remainder at (3, 3, 9): abs(error)*r^6=0.177493544 < 1
+PASS N2 radial remainder at (5, 5, 15): abs(error)*r^6=0.175610197 < 1
+PASS N2 radial remainder at (8, 4, 0): abs(error)*r^6=0.00811264485 < 1
+PASS N2 radial remainder at (14, 7, 0): abs(error)*r^6=0.0119890992 < 1
+PASS N2 radial remainder at (8, 4, 4): abs(error)*r^6=0.0887271447 < 1
+PASS N2 radial remainder at (12, 6, 6): abs(error)*r^6=0.0910416839 < 1
+PASS N3 O(1/r^2) relative convergence (3, 3, 9) to (5, 5, 15): ratio=3.62854544 expected=2.77777778
+PASS N3 O(1/r^2) relative convergence (8, 4, 0) to (14, 7, 0): ratio=2.98421248 expected=3.0625
+PASS N3 O(1/r^2) relative convergence (8, 4, 4) to (12, 6, 6): ratio=2.22148533 expected=2.25
+PASS N4 non-centrality witness at (3, 3, 9): measured/predicted=0.98975708 > 0.5
+PASS N4 non-centrality witness at (5, 5, 15): measured/predicted=0.997177128 > 0.5
+PASS N4 non-centrality witness at (8, 4, 0): measured/predicted=0.972627428 > 0.5
+PASS N4 non-centrality witness at (14, 7, 0): measured/predicted=0.990827539 > 0.5
+PASS N4 non-centrality witness at (8, 4, 4): measured/predicted=0.950846856 > 0.5
+PASS N4 non-centrality witness at (12, 6, 6): measured/predicted=0.977873748 > 0.5
+PASS N5 transverse/radial ratio at (14, 7, 0): relative error=0.00977623477 < 0.15
+PASS N5 transverse/radial ratio at (5, 5, 15): relative error=0.00337783628 < 0.15
+PASS CTRL1 10 percent inflated transverse coefficient is rejected: e_t*r^2=25.7057181 > 8
+PASS CTRL2 S6-in-place-of-S4 transverse form is rejected: e_t*r^2=120.502671 > 8
+PASS CTRL3 wrong minimal-polynomial coefficient 826 is rejected
+PASS CTRL4 wrong 3/8 transverse gradient coefficient is rejected
+RESULT: -grad G = [1/(4 pi r^2) + (15/32 pi) K4/r^4] nhat - (5/8 pi)(nhat^3 - S4 nhat)/r^4 + O(1/r^6); central orbits <100>,<110>,<111>; q2_max=(827+73*sqrt(73))/18432=0.078706178; ratio_coeff=(5/2)*q_max=0.701365534
+TOTAL: PASS=57 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/frontier_gravity_transverse_noncentrality_structure.txt
+++ b/logs/runner-cache/frontier_gravity_transverse_noncentrality_structure.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_gravity_transverse_noncentrality_structure.py
-runner_sha256: 781372d68ed7bbba81c7eb8f1345a0cdc8528afb13bf7e1ca13ab8b89aee9c6e
+runner_sha256: f8c7f788aa2e109416841e5e43d190f8987610da561e4b6efb4bfb40b6255501
 timeout_sec: 360
 exit_code: 0
-elapsed_sec: 33.18
+elapsed_sec: 24.15
 status: ok
 ----- stdout -----
 PASS S1 gradient identity, x component
@@ -36,21 +36,21 @@ PASS S7 conditional pair-response contrast coefficient
 PASS S8 stabilizer has no tangent fixed vector at <100>
 PASS S8 stabilizer has no tangent fixed vector at <110>
 PASS S8 stabilizer has no tangent fixed vector at <111>
-PASS N1 transverse relative remainder at (3, 3, 9): e_t*r^2=1.01404911 < 8
-PASS N1 transverse relative remainder at (5, 5, 15): e_t*r^2=0.776289874 < 8
-PASS N1 transverse relative remainder at (8, 4, 0): e_t*r^2=2.18980574 < 8
-PASS N1 transverse relative remainder at (14, 7, 0): e_t*r^2=2.24725288 < 8
-PASS N1 transverse relative remainder at (8, 4, 4): e_t*r^2=4.71870185 < 8
-PASS N1 transverse relative remainder at (12, 6, 6): e_t*r^2=4.77927043 < 8
-PASS N2 radial remainder at (3, 3, 9): abs(error)*r^6=0.177493544 < 1
-PASS N2 radial remainder at (5, 5, 15): abs(error)*r^6=0.175610197 < 1
-PASS N2 radial remainder at (8, 4, 0): abs(error)*r^6=0.00811264485 < 1
-PASS N2 radial remainder at (14, 7, 0): abs(error)*r^6=0.0119890992 < 1
-PASS N2 radial remainder at (8, 4, 4): abs(error)*r^6=0.0887271447 < 1
-PASS N2 radial remainder at (12, 6, 6): abs(error)*r^6=0.0910416839 < 1
-PASS N3 O(1/r^2) relative convergence (3, 3, 9) to (5, 5, 15): ratio=3.62854544 expected=2.77777778
-PASS N3 O(1/r^2) relative convergence (8, 4, 0) to (14, 7, 0): ratio=2.98421248 expected=3.0625
-PASS N3 O(1/r^2) relative convergence (8, 4, 4) to (12, 6, 6): ratio=2.22148533 expected=2.25
+PASS N1 finite-site transverse remainder compatibility at (3, 3, 9): e_t*r^2=1.01404911 < 8
+PASS N1 finite-site transverse remainder compatibility at (5, 5, 15): e_t*r^2=0.776289874 < 8
+PASS N1 finite-site transverse remainder compatibility at (8, 4, 0): e_t*r^2=2.18980574 < 8
+PASS N1 finite-site transverse remainder compatibility at (14, 7, 0): e_t*r^2=2.24725288 < 8
+PASS N1 finite-site transverse remainder compatibility at (8, 4, 4): e_t*r^2=4.71870185 < 8
+PASS N1 finite-site transverse remainder compatibility at (12, 6, 6): e_t*r^2=4.77927043 < 8
+PASS N2 finite-site radial remainder compatibility at (3, 3, 9): abs(error)*r^6=0.177493544 < 1
+PASS N2 finite-site radial remainder compatibility at (5, 5, 15): abs(error)*r^6=0.175610197 < 1
+PASS N2 finite-site radial remainder compatibility at (8, 4, 0): abs(error)*r^6=0.00811264485 < 1
+PASS N2 finite-site radial remainder compatibility at (14, 7, 0): abs(error)*r^6=0.0119890992 < 1
+PASS N2 finite-site radial remainder compatibility at (8, 4, 4): abs(error)*r^6=0.0887271447 < 1
+PASS N2 finite-site radial remainder compatibility at (12, 6, 6): abs(error)*r^6=0.0910416839 < 1
+PASS N3 finite-site O(1/r^2) relative convergence (3, 3, 9) to (5, 5, 15): ratio=3.62854544 expected=2.77777778
+PASS N3 finite-site O(1/r^2) relative convergence (8, 4, 0) to (14, 7, 0): ratio=2.98421248 expected=3.0625
+PASS N3 finite-site O(1/r^2) relative convergence (8, 4, 4) to (12, 6, 6): ratio=2.22148533 expected=2.25
 PASS N4 non-centrality witness at (3, 3, 9): measured/predicted=0.98975708 > 0.5
 PASS N4 non-centrality witness at (5, 5, 15): measured/predicted=0.997177128 > 0.5
 PASS N4 non-centrality witness at (8, 4, 0): measured/predicted=0.972627428 > 0.5
@@ -63,7 +63,7 @@ PASS CTRL1 10 percent inflated transverse coefficient is rejected: e_t*r^2=25.70
 PASS CTRL2 S6-in-place-of-S4 transverse form is rejected: e_t*r^2=120.502671 > 8
 PASS CTRL3 wrong minimal-polynomial coefficient 826 is rejected
 PASS CTRL4 wrong 3/8 transverse gradient coefficient is rejected
-RESULT: -grad G = [1/(4 pi r^2) + (15/32 pi) K4/r^4] nhat - (5/8 pi)(nhat^3 - S4 nhat)/r^4 + O(1/r^6); central orbits <100>,<110>,<111>; q2_max=(827+73*sqrt(73))/18432=0.078706178; ratio_coeff=(5/2)*q_max=0.701365534
+RESULT: exact gradient of the displayed truncation is [1/(4 pi r^2) + (15/32 pi) K4/r^4] nhat - (5/8 pi)(nhat^3 - S4 nhat)/r^4; an O(1/r^6) full-force remainder is conditional on termwise differentiability and has finite-site support; central orbits <100>,<110>,<111>; q2_max=(827+73*sqrt(73))/18432=0.078706178; ratio_coeff=(5/2)*q_max=0.701365534
 TOTAL: PASS=57 FAIL=0
 
 ----- stderr -----

--- a/scripts/frontier_gravity_transverse_noncentrality_structure.py
+++ b/scripts/frontier_gravity_transverse_noncentrality_structure.py
@@ -1,0 +1,475 @@
+"""Class-A finite runner for transverse non-centrality of the emergent force.
+
+The symbolic gates verify the exact gradient, tangency, central-orbit,
+sphere-Hessian, extremal, and stabilizer identities.  The numeric gates use
+the exact Bessel-resolvent lattice Green function and a five-point gradient
+stencil at six lattice sites to certify the O(1/r^6) gradient remainder.
+Four controls require specified wrong coefficients or structures to fail.
+
+Prints PASS/FAIL gate lines, a RESULT line, and TOTAL: PASS=N FAIL=M.
+"""
+
+AUDIT_TIMEOUT_SEC = 360
+
+import sys
+
+import mpmath as mp
+import sympy as sp
+
+
+results = []
+
+
+def check(name, ok):
+    results.append((name, bool(ok)))
+
+
+def all_zero(expressions):
+    return all(sp.simplify(expression) == 0 for expression in expressions)
+
+
+# ---------------------------------------------------------------------------
+# Exact symbolic structure
+# ---------------------------------------------------------------------------
+x, y, z = sp.symbols("x y z", real=True)
+xyz = sp.Matrix([x, y, z])
+r = sp.sqrt(x**2 + y**2 + z**2)
+nhat = xyz / r
+S4 = sum(component**4 for component in nhat)
+S6 = sum(component**6 for component in nhat)
+K4 = S4 - sp.Rational(3, 5)
+tangent = sp.Matrix([component**3 - S4 * component for component in nhat])
+
+potential = 1 / (4 * sp.pi * r) + sp.Rational(5, 32) * K4 / (sp.pi * r**3)
+gradient_claim = (
+    -(1 / (4 * sp.pi * r**2) + sp.Rational(15, 32) * K4 / (sp.pi * r**4)) * nhat
+    + sp.Rational(5, 8) * tangent / (sp.pi * r**4)
+)
+gradient_exact = sp.Matrix([sp.diff(potential, variable) for variable in xyz])
+for index, label in enumerate(("x", "y", "z")):
+    check(
+        "S1 gradient identity, %s component" % label,
+        sp.simplify(gradient_exact[index] - gradient_claim[index]) == 0,
+    )
+
+check("S2a transverse vector is exactly tangent", sp.simplify(nhat.dot(tangent)) == 0)
+check(
+    "S2b component factor t_mu=nhat_mu(nhat_mu^2-S4)",
+    all_zero(
+        tangent[index] - nhat[index] * (nhat[index] ** 2 - S4)
+        for index in range(3)
+    ),
+)
+homogeneous_gradient = sp.Matrix([sp.diff(S4, variable) for variable in xyz])
+check(
+    "S2c degree-zero gradient is 4t/r componentwise",
+    all_zero(homogeneous_gradient[index] - 4 * tangent[index] / r for index in range(3)),
+)
+check(
+    "S3 magnitude identity |t|^2=S6-S4^2",
+    sp.simplify(tangent.dot(tangent) - (S6 - S4**2)) == 0,
+)
+
+
+def direction_invariants(direction):
+    norm = sp.sqrt(sum(component**2 for component in direction))
+    unit = sp.Matrix([sp.sympify(component) / norm for component in direction])
+    s4 = sp.simplify(sum(component**4 for component in unit))
+    vector = sp.Matrix([sp.simplify(component**3 - s4 * component) for component in unit])
+    return unit, s4, vector
+
+
+for label, direction, expected_s4 in (
+    ("<100>", (1, 0, 0), sp.Integer(1)),
+    ("<110>", (1, 1, 0), sp.Rational(1, 2)),
+    ("<111>", (1, 1, 1), sp.Rational(1, 3)),
+):
+    _, orbit_s4, orbit_tangent = direction_invariants(direction)
+    check(
+        "S4 central orbit %s has t=0 and S4=%s" % (label, expected_s4),
+        orbit_s4 == expected_s4 and all(component == 0 for component in orbit_tangent),
+    )
+
+a, b, c = sp.symbols("a b c", real=True)
+abstract_n = sp.Matrix([a, b, c])
+abstract_s4 = sum(component**4 for component in abstract_n)
+abstract_tangent = sp.Matrix(
+    [component**3 - abstract_s4 * component for component in abstract_n]
+)
+check(
+    "S4 converse factor forces each nonzero square to equal S4",
+    all(
+        sp.simplify(
+            sp.factor(abstract_tangent[index])
+            - sp.factor(abstract_n[index] * (abstract_n[index] ** 2 - abstract_s4))
+        )
+        == 0
+        for index in range(3)
+    ),
+)
+check(
+    "S4 k equal nonzero squares imply S4=1/k for k=1,2,3",
+    all(
+        sp.simplify(sp.Integer(k) * (sp.Rational(1, k)) ** 2 - sp.Rational(1, k)) == 0
+        for k in (1, 2, 3)
+    ),
+)
+
+homogeneous_hessian = sp.hessian(S4, (x, y, z))
+orbit_hessian_data = (
+    (
+        "<100>",
+        sp.Matrix([1, 0, 0]),
+        sp.Matrix([[0, 0], [1, 0], [0, 1]]),
+        {-sp.Integer(4): 2},
+    ),
+    (
+        "<110>",
+        sp.Matrix([1 / sp.sqrt(2), 1 / sp.sqrt(2), 0]),
+        sp.Matrix([[1 / sp.sqrt(2), 0], [-1 / sp.sqrt(2), 0], [0, 1]]),
+        {-sp.Integer(2): 1, sp.Integer(4): 1},
+    ),
+    (
+        "<111>",
+        sp.Matrix([1 / sp.sqrt(3), 1 / sp.sqrt(3), 1 / sp.sqrt(3)]),
+        sp.Matrix(
+            [
+                [1 / sp.sqrt(2), 1 / sp.sqrt(6)],
+                [-1 / sp.sqrt(2), 1 / sp.sqrt(6)],
+                [0, -2 / sp.sqrt(6)],
+            ]
+        ),
+        {sp.Rational(8, 3): 2},
+    ),
+)
+for label, point, frame, expected_eigenvalues in orbit_hessian_data:
+    substitutions = dict(zip((x, y, z), point))
+    tangent_hessian = sp.simplify(frame.T * homogeneous_hessian.subs(substitutions) * frame)
+    eigenvalues = {sp.simplify(value): multiplicity for value, multiplicity in tangent_hessian.eigenvals().items()}
+    check("S5 sphere Hessian spectrum at %s" % label, eigenvalues == expected_eigenvalues)
+
+q2_abstract = sum(component**6 for component in abstract_n) - abstract_s4**2
+q2_gradient = sp.Matrix([sp.diff(q2_abstract, component) for component in abstract_n])
+lagrange_lambda = sp.expand(abstract_n.dot(q2_gradient))
+stationarity_claim = sp.Matrix(
+    [
+        component
+        * (
+            6 * component**4
+            - 8 * abstract_s4 * component**2
+            - 6 * sum(entry**6 for entry in abstract_n)
+            + 8 * abstract_s4**2
+        )
+        for component in abstract_n
+    ]
+)
+check(
+    "S6 constrained stationarity equation from lambda=n dot grad(q2)",
+    sp.simplify(lagrange_lambda - (6 * sum(entry**6 for entry in abstract_n) - 8 * abstract_s4**2))
+    == 0
+    and all_zero(q2_gradient[index] - lagrange_lambda * abstract_n[index] - stationarity_claim[index] for index in range(3)),
+)
+
+u = sp.symbols("u", real=True)
+q2_u = sp.expand(
+    2 * u**3 + (1 - 2 * u) ** 3 - (2 * u**2 + (1 - 2 * u) ** 2) ** 2
+)
+u_star = (13 - sp.sqrt(73)) / 48
+q2_max = (827 + 73 * sp.sqrt(73)) / 18432
+check("S6 two-equal-square extremum u_star solves dq2/du", sp.simplify(sp.diff(q2_u, u).subs(u, u_star)) == 0)
+check("S6 exact global q2 maximum on the extremal family", sp.simplify(q2_u.subs(u, u_star) - q2_max) == 0)
+check(
+    "S6 q2 maximum obeys 9216 Q^2-827 Q+8=0",
+    sp.expand(9216 * q2_max**2 - 827 * q2_max + 8) == 0,
+)
+
+v = sp.symbols("v", real=True)
+q2_planar = sp.expand(v**3 + (1 - v) ** 3 - (v**2 + (1 - v) ** 2) ** 2)
+v_star = sp.cos(sp.pi / 8) ** 2
+planar_gap = sp.simplify(q2_max - sp.Rational(1, 16))
+check(
+    "S6 planar maximum q2=1/16 at v=cos^2(pi/8)",
+    sp.simplify(sp.diff(q2_planar, v).subs(v, v_star)) == 0
+    and sp.simplify(q2_planar.subs(v, v_star) - sp.Rational(1, 16)) == 0
+    and sp.simplify(sp.diff(q2_planar, v, 2).subs(v, v_star)) < 0,
+)
+check("S6 global maximum is strictly above planar maximum", planar_gap.is_positive)
+
+GRID_N = 240
+q2_max_float = float(q2_max)
+grid_max = -1.0
+for i in range(GRID_N + 1):
+    w1 = i / GRID_N
+    for j in range(GRID_N + 1 - i):
+        w2 = j / GRID_N
+        w3 = 1.0 - w1 - w2
+        s4_grid = w1 * w1 + w2 * w2 + w3 * w3
+        s6_grid = w1 * w1 * w1 + w2 * w2 * w2 + w3 * w3 * w3
+        q2_grid = s6_grid - s4_grid * s4_grid
+        if q2_grid > grid_max:
+            grid_max = q2_grid
+check(
+    "S6 simplex grid finds no direction above the family maximum",
+    grid_max <= q2_max_float + 1.0e-12,
+)
+check(
+    "S6 simplex grid attains the family maximum to grid resolution",
+    grid_max >= q2_max_float - 5.0e-4,
+)
+
+
+def exact_q2(direction):
+    norm2 = sum(sp.Integer(component) ** 2 for component in direction)
+    s4 = sum(sp.Integer(component) ** 4 for component in direction) / norm2**2
+    s6 = sum(sp.Integer(component) ** 6 for component in direction) / norm2**3
+    return sp.factor(s6 - s4**2)
+
+
+for label, direction, expected in (
+    ("(1,1,3)", (1, 1, 3), sp.Rational(1152, 14641)),
+    ("(2,1,0)", (2, 1, 0), sp.Rational(36, 625)),
+    ("(2,1,1)", (2, 1, 1), sp.Rational(1, 18)),
+):
+    check("S7 exact q2 anchor %s" % label, exact_q2(direction) == expected)
+
+k4_100 = sp.Rational(2, 5)
+k4_111 = -sp.Rational(4, 15)
+check(
+    "S7 conditional pair-response contrast coefficient",
+    sp.simplify(
+        sp.Rational(5, 32) * (k4_100 - k4_111) / sp.pi
+        - sp.Rational(5, 48) / sp.pi
+    )
+    == 0,
+)
+
+rotation_data = (
+    (
+        "<100>",
+        sp.Matrix([[1, 0, 0], [0, 0, -1], [0, 1, 0]]),
+        sp.Matrix([[0, 0], [1, 0], [0, 1]]),
+    ),
+    (
+        "<110>",
+        sp.Matrix([[0, 1, 0], [1, 0, 0], [0, 0, -1]]),
+        sp.Matrix([[1 / sp.sqrt(2), 0], [-1 / sp.sqrt(2), 0], [0, 1]]),
+    ),
+    (
+        "<111>",
+        sp.Matrix([[0, 0, 1], [1, 0, 0], [0, 1, 0]]),
+        sp.Matrix(
+            [
+                [1 / sp.sqrt(2), 1 / sp.sqrt(6)],
+                [-1 / sp.sqrt(2), 1 / sp.sqrt(6)],
+                [0, -2 / sp.sqrt(6)],
+            ]
+        ),
+    ),
+)
+for label, rotation, frame in rotation_data:
+    tangent_rotation = sp.simplify(frame.T * rotation * frame)
+    fixed_vector_determinant = sp.simplify((sp.eye(2) - tangent_rotation).det())
+    check(
+        "S8 stabilizer has no tangent fixed vector at %s" % label,
+        fixed_vector_determinant != 0,
+    )
+
+# ---------------------------------------------------------------------------
+# Bessel-resolvent values and five-point finite-difference gradients
+# ---------------------------------------------------------------------------
+mp.mp.dps = 24
+mpexp = mp.exp
+besseli = mp.besseli
+mpf = mp.mpf
+mpinf = mp.inf
+mpquad = mp.quad
+
+
+def G_num(x, y, z):
+    x, y, z = abs(x), abs(y), abs(z)
+    r2 = x*x + y*y + z*z
+    def integrand(t):
+        return mpexp(-6*t) * besseli(x, 2*t) * besseli(y, 2*t) * besseli(z, 2*t)
+    pts = [0, mpf(r2)/12 + 1, mpf(r2)/6 + 2, mpf(r2)/2 + 4, 4*mpf(r2) + 20, mpinf]
+    return mpquad(integrand, pts)
+
+
+green_cache = {}
+
+
+def cached_G(site):
+    key = tuple(sorted(abs(coordinate) for coordinate in site))
+    if key not in green_cache:
+        green_cache[key] = G_num(*key)
+    return green_cache[key]
+
+
+def vector_dot(left, right):
+    return sum(a_value * b_value for a_value, b_value in zip(left, right))
+
+
+def vector_norm(vector):
+    return mp.sqrt(vector_dot(vector, vector))
+
+
+def gradient_num(site):
+    gradient = []
+    for axis in range(3):
+        values = {}
+        for offset in (-2, -1, 1, 2):
+            shifted = list(site)
+            shifted[axis] += offset
+            values[offset] = cached_G(tuple(shifted))
+        gradient.append(
+            (-values[2] + 8 * values[1] - 8 * values[-1] + values[-2]) / 12
+        )
+    return gradient
+
+
+sites = ((3, 3, 9), (5, 5, 15), (8, 4, 0), (14, 7, 0), (8, 4, 4), (12, 6, 6))
+numeric = {}
+for site in sites:
+    r2_num = mpf(sum(coordinate * coordinate for coordinate in site))
+    radius = mp.sqrt(r2_num)
+    unit = [mpf(coordinate) / radius for coordinate in site]
+    s4_num = sum(component**4 for component in unit)
+    s6_num = sum(component**6 for component in unit)
+    k4_num = s4_num - mpf(3) / 5
+    angular_tangent = [component**3 - s4_num * component for component in unit]
+    derivative = gradient_num(site)
+    rho_num = vector_dot(unit, derivative)
+    transverse_num = [derivative[index] - rho_num * unit[index] for index in range(3)]
+    rho_pred = -(
+        1 / (4 * mp.pi * radius**2)
+        + mpf(15) / (32 * mp.pi) * k4_num / radius**4
+    )
+    transverse_pred = [
+        mpf(5) / (8 * mp.pi) * component / radius**4 for component in angular_tangent
+    ]
+    transverse_error = vector_norm(
+        [transverse_num[index] - transverse_pred[index] for index in range(3)]
+    ) / vector_norm(transverse_pred)
+    numeric[site] = {
+        "r": radius,
+        "unit": unit,
+        "s4": s4_num,
+        "s6": s6_num,
+        "q2": s6_num - s4_num**2,
+        "rho_num": rho_num,
+        "rho_pred": rho_pred,
+        "transverse_num": transverse_num,
+        "transverse_pred": transverse_pred,
+        "e_t": transverse_error,
+    }
+
+for site in sites:
+    data = numeric[site]
+    scaled_error = data["e_t"] * data["r"] ** 2
+    check(
+        "N1 transverse relative remainder at %s: e_t*r^2=%.9g < 8"
+        % (site, float(scaled_error)),
+        scaled_error < 8,
+    )
+
+for site in sites:
+    data = numeric[site]
+    scaled_error = abs(data["rho_num"] - data["rho_pred"]) * data["r"] ** 6
+    check(
+        "N2 radial remainder at %s: abs(error)*r^6=%.9g < 1"
+        % (site, float(scaled_error)),
+        scaled_error < 1,
+    )
+
+site_pairs = (((3, 3, 9), (5, 5, 15)), ((8, 4, 0), (14, 7, 0)), ((8, 4, 4), (12, 6, 6)))
+for small_site, large_site in site_pairs:
+    small = numeric[small_site]
+    large = numeric[large_site]
+    measured = small["e_t"] / large["e_t"]
+    expected = (large["r"] / small["r"]) ** 2
+    check(
+        "N3 O(1/r^2) relative convergence %s to %s: ratio=%.9g expected=%.9g"
+        % (small_site, large_site, float(measured), float(expected)),
+        mpf("0.5") * expected <= measured <= 2 * expected,
+    )
+
+for site in sites:
+    data = numeric[site]
+    measured = vector_norm(data["transverse_num"])
+    threshold = mpf("0.5") * vector_norm(data["transverse_pred"])
+    check(
+        "N4 non-centrality witness at %s: measured/predicted=%.9g > 0.5"
+        % (site, float(measured / vector_norm(data["transverse_pred"]))),
+        measured > threshold,
+    )
+
+for site in ((14, 7, 0), (5, 5, 15)):
+    data = numeric[site]
+    measured = vector_norm(data["transverse_num"]) / abs(data["rho_num"])
+    predicted = mpf(5) / 2 * mp.sqrt(data["q2"]) / data["r"] ** 2
+    relative_error = abs(measured / predicted - 1)
+    check(
+        "N5 transverse/radial ratio at %s: relative error=%.9g < 0.15"
+        % (site, float(relative_error)),
+        relative_error < mpf("0.15"),
+    )
+
+# Specified wrong-value rejectors reuse the symbolic objects and numeric values above.
+control_site = (5, 5, 15)
+control_data = numeric[control_site]
+inflated_prediction = [mpf("1.10") * value for value in control_data["transverse_pred"]]
+inflated_error = vector_norm(
+    [control_data["transverse_num"][index] - inflated_prediction[index] for index in range(3)]
+) / vector_norm(inflated_prediction)
+check(
+    "CTRL1 10 percent inflated transverse coefficient is rejected: e_t*r^2=%.9g > 8"
+    % float(inflated_error * control_data["r"] ** 2),
+    inflated_error * control_data["r"] ** 2 > 8,
+)
+
+wrong_angular_tangent = [
+    component**3 - control_data["s6"] * component for component in control_data["unit"]
+]
+wrong_prediction = [
+    mpf(5) / (8 * mp.pi) * component / control_data["r"] ** 4
+    for component in wrong_angular_tangent
+]
+wrong_form_error = vector_norm(
+    [control_data["transverse_num"][index] - wrong_prediction[index] for index in range(3)]
+) / vector_norm(wrong_prediction)
+check(
+    "CTRL2 S6-in-place-of-S4 transverse form is rejected: e_t*r^2=%.9g > 8"
+    % float(wrong_form_error * control_data["r"] ** 2),
+    wrong_form_error * control_data["r"] ** 2 > 8,
+)
+
+check(
+    "CTRL3 wrong minimal-polynomial coefficient 826 is rejected",
+    sp.expand(9216 * q2_max**2 - 826 * q2_max + 8) != 0,
+)
+wrong_gradient_claim = (
+    -(1 / (4 * sp.pi * r**2) + sp.Rational(15, 32) * K4 / (sp.pi * r**4)) * nhat
+    + sp.Rational(3, 8) * tangent / (sp.pi * r**4)
+)
+check(
+    "CTRL4 wrong 3/8 transverse gradient coefficient is rejected",
+    any(
+        sp.simplify(gradient_exact[index] - wrong_gradient_claim[index]) != 0
+        for index in range(3)
+    ),
+)
+
+n_pass = sum(1 for _, ok in results if ok)
+n_fail = sum(1 for _, ok in results if not ok)
+for name, ok in results:
+    print(("PASS" if ok else "FAIL"), name)
+q2_max_num = mpf(827 + 73 * mp.sqrt(73)) / 18432
+ratio_coefficient = mpf(5) / 2 * mp.sqrt(q2_max_num)
+print(
+    "RESULT: -grad G = [1/(4 pi r^2) + (15/32 pi) K4/r^4] nhat - "
+    "(5/8 pi)(nhat^3 - S4 nhat)/r^4 + O(1/r^6); central orbits "
+    "<100>,<110>,<111>; q2_max=(827+73*sqrt(73))/18432=%.9g; "
+    "ratio_coeff=(5/2)*q_max=%.9g"
+    % (float(q2_max_num), float(ratio_coefficient))
+)
+print("TOTAL: PASS=%d FAIL=%d" % (n_pass, n_fail))
+sys.exit(1 if n_fail else 0)

--- a/scripts/frontier_gravity_transverse_noncentrality_structure.py
+++ b/scripts/frontier_gravity_transverse_noncentrality_structure.py
@@ -3,7 +3,8 @@
 The symbolic gates verify the exact gradient, tangency, central-orbit,
 sphere-Hessian, extremal, and stabilizer identities.  The numeric gates use
 the exact Bessel-resolvent lattice Green function and a five-point gradient
-stencil at six lattice sites to certify the O(1/r^6) gradient remainder.
+stencil at six lattice sites as finite-site support for compatibility with an
+O(1/r^6) gradient remainder; they do not prove the asymptotic derivative bound.
 Four controls require specified wrong coefficients or structures to fail.
 
 Prints PASS/FAIL gate lines, a RESULT line, and TOTAL: PASS=N FAIL=M.
@@ -366,7 +367,7 @@ for site in sites:
     data = numeric[site]
     scaled_error = data["e_t"] * data["r"] ** 2
     check(
-        "N1 transverse relative remainder at %s: e_t*r^2=%.9g < 8"
+        "N1 finite-site transverse remainder compatibility at %s: e_t*r^2=%.9g < 8"
         % (site, float(scaled_error)),
         scaled_error < 8,
     )
@@ -375,7 +376,7 @@ for site in sites:
     data = numeric[site]
     scaled_error = abs(data["rho_num"] - data["rho_pred"]) * data["r"] ** 6
     check(
-        "N2 radial remainder at %s: abs(error)*r^6=%.9g < 1"
+        "N2 finite-site radial remainder compatibility at %s: abs(error)*r^6=%.9g < 1"
         % (site, float(scaled_error)),
         scaled_error < 1,
     )
@@ -387,7 +388,7 @@ for small_site, large_site in site_pairs:
     measured = small["e_t"] / large["e_t"]
     expected = (large["r"] / small["r"]) ** 2
     check(
-        "N3 O(1/r^2) relative convergence %s to %s: ratio=%.9g expected=%.9g"
+        "N3 finite-site O(1/r^2) relative convergence %s to %s: ratio=%.9g expected=%.9g"
         % (small_site, large_site, float(measured), float(expected)),
         mpf("0.5") * expected <= measured <= 2 * expected,
     )
@@ -465,8 +466,10 @@ for name, ok in results:
 q2_max_num = mpf(827 + 73 * mp.sqrt(73)) / 18432
 ratio_coefficient = mpf(5) / 2 * mp.sqrt(q2_max_num)
 print(
-    "RESULT: -grad G = [1/(4 pi r^2) + (15/32 pi) K4/r^4] nhat - "
-    "(5/8 pi)(nhat^3 - S4 nhat)/r^4 + O(1/r^6); central orbits "
+    "RESULT: exact gradient of the displayed truncation is "
+    "[1/(4 pi r^2) + (15/32 pi) K4/r^4] nhat - "
+    "(5/8 pi)(nhat^3 - S4 nhat)/r^4; an O(1/r^6) full-force remainder "
+    "is conditional on termwise differentiability and has finite-site support; central orbits "
     "<100>,<110>,<111>; q2_max=(827+73*sqrt(73))/18432=%.9g; "
     "ratio_coeff=(5/2)*q_max=%.9g"
     % (float(q2_max_num), float(ratio_coefficient))


### PR DESCRIPTION
## Summary

Force-structure follow-on to the landed leading-correction theorem (`GRAVITY_LEADING_LATTICE_CORRECTION_CUBIC_ANISOTROPY_THEOREM_NOTE_2026-06-07`). That note gives the potential; this note gives the exact structure of the force field it generates — and shows the emergent force is **not central**:

> `−∇G = [1/(4π r²) + (15/(32π))·K₄(n̂)/r⁴]·n̂ − (5/(8π))·(n̂³ − S₄ n̂)/r⁴ + O(1/r⁶)`

- The correction's second term is **exactly tangent** to the sphere: `t = n̂³ − S₄n̂ = (1/4)∇_tan S₄`, with `|t|² = S₆ − S₄²`.
- The force is asymptotically central **precisely** on `⟨100⟩ ∪ ⟨110⟩ ∪ ⟨111⟩` — the stationary orbits of S₄ — and centrality there holds at **all asymptotic orders** by a stabilizer fixed-vector argument (tangent rotations by π/2, π, 2π/3 have no +1 eigenvalue).
- Sphere Hessian signatures: `{−4,−4}` max at ⟨100⟩, `{−2,+4}` saddle at ⟨110⟩, `{+8/3,+8/3}` min at ⟨111⟩.
- Largest transverse/radial ratio: `(5/2)·q_max/r²` with `q²_max = (827 + 73√73)/18432`, minimal polynomial `9216·Q² − 827·Q + 8`; the reduction to the two-equal-squares family is derived (stationarity factor is quadratic in `n̂_μ²`) and additionally certified by a deterministic simplex-grid scan.
- Conditional corollary (cites the retained_bounded source-response bridge, status inherited): equal pairs along ⟨100⟩ vs ⟨111⟩ differ in static response by `5/(48π r³)` per unit coupling; sign/preference not assigned (bridge coupling-sign convention).

No new physical identification: "force" = −∇ of the same emergent potential named in the upstream theorem note.

## Changes

- `docs/GRAVITY_EMERGENT_FORCE_TRANSVERSE_NONCENTRALITY_STRUCTURE_THEOREM_NOTE_2026-07-09.md` — theorem note (deps: leading-correction theorem note, source-response bridge note).
- `scripts/frontier_gravity_transverse_noncentrality_structure.py` — paired class-A runner: exact SymPy gates (gradient identity, tangency, component factorization, |t|², centrality classification, tangent-plane Hessian spectra, derived constrained stationarity, extremal family + minpoly + planar comparison + simplex-grid global certificate, exact anchors, contrast coefficient, stabilizer fixed-vector determinants) + Bessel-resolvent numerics at mp.dps=24 with a five-point stencil at six sites (residual bounds, O(1/r²) convergence ratios, non-centrality witnesses, ratio check) + 4 wrong-value controls.
- `logs/runner-cache/frontier_gravity_transverse_noncentrality_structure.txt` — fresh cache.

## Runner

`TOTAL: PASS=57 FAIL=0` (32s). Controls reject a 10%-inflated coefficient (margin 25.7 vs pass bound 8), the S₆-for-S₄ form, minpoly coefficient 826, and gradient coefficient 3/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Superseding review-loop correction

The source is now `bounded_theorem`. Differentiating the asymptotic remainder is explicitly conditional on the named premise `nabla R = O(r^-6)`; six-site numerical checks are compatibility support only, not a proof of that premise. The exact gradient, tangent-orbit, Hessian, and extremal algebra is unchanged. Final runner: 57/0, exit 0. No-Go N1-N8: PASS at this conditional bounded scope.