### PR TITLE
fix(gauge): narrow central-registration row to the positive Lueders subclass with exact negative-coefficient witnesses

### DIFF
--- a/docs/GAUGE_LINK_CENTRAL_REGISTRATION_INDUCED_BI_INVARIANT_STEP_KERNEL_THEOREM_NOTE_2026-07-02.md
+++ b/docs/GAUGE_LINK_CENTRAL_REGISTRATION_INDUCED_BI_INVARIANT_STEP_KERNEL_THEOREM_NOTE_2026-07-02.md
@@ -2,12 +2,14 @@
 
 **Date:** 2026-07-02
 **Claim type:** bounded_theorem
-**Claim scope:** Central-scalar record registration on a one-link `L^2(G)`
-carrier induces normalized convolutional, Ad-invariant, inversion-symmetric,
-representation-positive step kernels for the registration class, with exact
-finite `S3`/`Q8` witnesses and truncated `SU(3)` softness numerics; no
-record-step occurrence, position-classicality, rate-value, heat-kernel,
-continuum, or Wilson action-surface selection closure.
+**Claim scope:** Central-scalar record registration on a one-link `L^2(G)` carrier,
+restricted to the positive Lueders subclass with nonnegative square-root Kraus
+coefficients, induces normalized convolutional, Ad-invariant, inversion-symmetric,
+representation-positive step kernels for that registration subclass, with exact finite
+`S3`/`Q8` witnesses, exact negative-coefficient witnesses outside the subclass, and
+truncated `SU(3)` softness/per-step-variance numerics in a stated convention; no
+record-step occurrence, position-classicality, rate-value, per-unit-time rate,
+heat-kernel, continuum, or Wilson action-surface selection closure.
 **Status authority:** independent audit lane only. This source note does not
 set, predict, or apply an audit verdict.
 **Primary runner:** [`scripts/gauge_link_central_registration_induced_bi_invariant_step_kernel_2026_07_02.py`](../scripts/gauge_link_central_registration_induced_bi_invariant_step_kernel_2026_07_02.py)
@@ -22,12 +24,14 @@ surface
 `EMERGENT_GAUGE_HEAT_KERNEL_CLT_ATTRACTOR_CONDITIONAL_ON_BI_INVARIANT_DYNAMICS_NARROW_THEOREM_NOTE_2026-06-08.md`
 is named here only as prose context, not a citation-graph dependency.
 
-This note derives the premise from a different input. If a record step
-registers the gauge-central content of a link, the induced position-classical
-transition kernel is automatically normalized, convolutional,
-Ad-invariant, inversion-symmetric, and positive in the representation
-coefficients. The load-bearing input is registration-centrality, not
-kinematic covariance.
+This note derives the premise from a different input. If a record step registers the
+gauge-central content of a link through a positive Lueders channel (central Kraus
+blocks with nonnegative square-root coefficients), the induced position-classical
+transition kernel is automatically normalized, convolutional, Ad-invariant,
+inversion-symmetric, and positive in the representation coefficients. The load-bearing
+input is registration-centrality in the positive Lueders form, not kinematic
+covariance: centrality alone does not give representation positivity (Theorem 3
+exhibits exact central counterexamples), and kinematic covariance supplies neither.
 
 The canonical record partition discussion in
 `RECORD_OUTCOME_OBSERVABLE_PRINCIPLE_CANONICAL_PROPOSAL_NOTE_2026-06-05.md`
@@ -63,9 +67,12 @@ position basis `|g>`. The two-end gauge action is the two-sided regular
 action. The left end translates one side of the group argument, and the
 right end translates the other side.
 
-For compact `G`, the same formulas are read in a Peter-Weyl truncation. The
-runner uses exact finite checks for `S3` and `Q8`, and a deterministic
-`SU(3)` character-grid truncation for the softness numerics.
+For compact `G`, the same formulas are read in a Peter-Weyl truncation: the
+finite-group count `|G| = sum_R d_R^2` is replaced by the truncated block count
+`N_trunc = sum_R d_R^2` over the kept irreps, and each truncated amplitude carries the
+normalized-Haar `N_trunc^(-1/2)` convention. The runner uses exact finite checks for
+`S3` and `Q8`, and a deterministic `SU(3)` character-grid truncation for the
+softness/per-step-variance numerics.
 
 A central registration channel has controlled-copy form
 
@@ -79,6 +86,12 @@ sum_j m_j(R) = 1  for each R.
 Here `P_R` is the Peter-Weyl isotypic projector for irrep `R`. Sharp
 partitions are indicator functions on the representation labels, and the
 full-resolution projective case is `m_j(R) = delta_{jR}`.
+
+More generally, a central-scalar channel has Kraus blocks `K_j = sum_R c_j(R) P_R`
+with complex scalars `c_j(R)` satisfying `sum_j |c_j(R)|^2 = 1` for each `R`. This
+note's theorems are restricted to the positive Lueders subclass
+`c_j(R) = sqrt(m_j(R)) >= 0` displayed above; Theorem 3 shows by exact witnesses that
+the restriction is load-bearing.
 
 For position-classical link states, the induced transition kernel is
 
@@ -126,9 +139,9 @@ which is not a citation-graph dependency. By contrast, on an irreducible
 carrier the central partition is trivial by Schur; the link/holonomy
 carrier is reducible, and that is where registration has content.
 
-## Theorem 2 (central registration induces bi-invariant positive step kernels)
+## Theorem 2 (positive Lueders central registration induces bi-invariant positive step kernels)
 
-Let
+Restrict to the positive Lueders subclass: let
 
 ```text
 K_j = sum_R sqrt(m_j(R)) P_R
@@ -166,13 +179,14 @@ characters with nonnegative Kronecker multiplicities. Therefore the
 character coefficients of `t(x) = T(x|e)` are nonnegative for every channel
 in this central registration class.
 
-Consequently, the bi-invariance and record-positivity premises of the
-gauge-dynamics lane are, for this class, derived, not assumed; the
-load-bearing input is registration-centrality, not kinematic covariance.
+Consequently, the bi-invariance and record-positivity premises of the gauge-dynamics
+lane are, for the positive Lueders registration subclass, derived, not assumed; the
+load-bearing input is registration-centrality in the positive Lueders form, not
+kinematic covariance.
 
 ## Theorem 3 (contrast witnesses)
 
-The central-scalar hypothesis is doing real work.
+The central-scalar hypothesis and the positive Lueders restriction are each doing real work.
 
 First, an intra-block non-scalar Kraus operator can preserve the
 representation label while picking a frame inside the `R` block. Such a
@@ -188,7 +202,26 @@ convolution kernel but not a registration kernel of the above kind. In the
 standard Fourier block is non-scalar. This matches the lane's drift witness:
 it is not the record-registration mechanism classified here.
 
-## Theorem 4 (registration softness sets the step size; derived rates)
+Third, centrality alone does not give representation positivity. The central unitary
+`K = P_triv + P_sign - P_std` on the `S3` regular carrier is a single-Kraus central
+trace-preserving channel (`K^2 = I` exactly), and its induced kernel `t(x)` with
+`kappa = (1/6)(chi_triv + chi_sign - 2 chi_std)` is an exact convolution with class
+values `t(e) = 1/9`, `t(transposition) = 0`, `t(3-cycle) = 4/9` and exact character
+coefficients `{triv: 1/6, sign: 1/6, std: -1/9}`: the standard coefficient is strictly
+negative. The channel is central-scalar with signed coefficient `c(std) = -1`, outside
+the positive Lueders subclass.
+
+Fourth, the failure survives genuine multi-outcome registration. The two-outcome
+central instrument with rational `5-12-13` weights,
+`K_1 = (12/13)(P_triv + P_sign - P_std)` and
+`K_2 = (5/13)(P_triv + P_sign + P_std)`, is exactly trace-preserving
+(`(12/13)^2 + (5/13)^2 = 1` per block), its induced kernel is an exact convolution,
+and its exact character coefficients are `{triv: 1/6, sign: 1/6, std: -23/507}`, again
+strictly negative in the standard block. Both witnesses are checked exactly in
+rational arithmetic by the runner. The positive Lueders hypothesis
+`c_j(R) = sqrt(m_j(R)) >= 0` is therefore on the load-bearing list, not a convenience.
+
+## Theorem 4 (registration softness sets the per-step variance in a stated convention)
 
 Registration softness controls the per-step size. Full-resolution
 projective registration resolves the representation label as sharply as the
@@ -203,10 +236,28 @@ strictly decreases as the registration is softened:
 projective > width 0.5 > width 2.0 > width 6.0 > width 15.0.
 ```
 
-The corresponding values are checked against the validation references
-near `9.870`, `8.048`, `5.852`, `2.476`, and `1.861`. Each registration
-channel therefore has a derived rate: the lane's rate dial is relocated
-onto the registration resolution/softness of the step.
+The corresponding values are checked against the validation references near `9.870`,
+`8.048`, `5.852`, `2.476`, and `1.861`.
+
+Convention (stated, not selected). The truncation keeps the irreps with partitions
+`lam = (p+q, q, 0)` for `p, q >= 0` and `p + q <= 10`. The finite-group count is
+replaced by the truncated block count `N_trunc = sum_R d_R^2`, and the amplitudes
+carry the normalized-Haar convention
+`kappa_j(x) = N_trunc^(-1/2) sum_R sqrt(m_j(R)) d_R chi_R(x)` with
+`T = sum_j |kappa_j|^2`, normalized against the mass-one Haar class measure by
+truncated character orthonormality. The step-size functional is the squared
+principal-eigenphase distance `d^2 = t_1^2 + t_2^2 + t_3^2`, where `t_1, t_2` lie in
+`(-pi, pi)` on a midpoint grid and the third eigenphase `t_3 = -(t_1 + t_2)` is
+wrapped to `[-pi, pi)`; the reported quantity is the Haar-weighted mean of `d^2` under
+the kernel. This is one explicit convention among admissible bi-invariant step-size
+conventions (a traceless-log branch is a named alternative and is not implemented
+here); no canonical metric selection is claimed.
+
+Each registration channel therefore has a derived per-step variance in this stated
+convention: the lane's step-size dial is relocated onto the registration
+resolution/softness of the step. No per-unit-time rate is derived; converting a
+per-step variance into a rate requires the record-step count, which this row does not
+supply.
 
 Honest limit: the per-step kernel is not the heat kernel. For the width-6
 soft kernel, the runner computes
@@ -231,10 +282,17 @@ This note does not claim:
   semigroups live on the probability/ensemble".
 - It does not derive position-classicality between steps; that remains a
   named lane premise.
-- It does not derive the registration resolution or softness value. The
-  rate number, including `tau = 1/2` in
-  `GAUGE_LINK_PER_RECORD_STEP_RATE_DIAL_UNIT_VARIANCE_POINT_THEOREM_NOTE_2026-07-02.md`,
-  is not pinned here; that row is not a citation-graph dependency.
+- It does not derive the registration resolution or softness value, and no
+  per-unit-time rate is derived or pinned here, including `tau = 1/2` in
+  `GAUGE_LINK_PER_RECORD_STEP_RATE_DIAL_UNIT_VARIANCE_POINT_THEOREM_NOTE_2026-07-02.md`;
+  that row is not a citation-graph dependency, and this note's `SU(3)` numbers are
+  per-step variances in the stated convention, not rates.
+- It does not claim representation positivity for general central-scalar channels;
+  Theorem 3 exhibits exact central witnesses with strictly negative standard
+  coefficients outside the positive Lueders subclass.
+- It does not claim a canonical `SU(3)` metric or normalization; the stated convention
+  (normalized-Haar `N_trunc^(-1/2)` amplitudes and the principal-eigenphase distance)
+  is documented, alternatives are named, and none is adjudicated.
 - It does not claim the per-step kernel is the heat kernel; the per-step
   generator spread is gated in the runner.
 - It does not claim kinematic covariance supplies the step-measure premise;
@@ -245,7 +303,7 @@ This note does not claim:
   promotion.
 
 Forward surface: the native finite-carrier registration kernel is
-parameter-free at full resolution. Computing its rate against the
+parameter-free at full resolution. Computing its per-step variance against the
 unit-variance point is the next concrete calculation. That calculation is
 outside this row.
 
@@ -271,6 +329,12 @@ The row fails if any runner-checkable surface below fails.
 - The deterministic drift witness must be convolutional but must have a
   negative nontrivial character coefficient and a non-scalar standard
   Fourier block.
+- The exact central witnesses outside the positive Lueders subclass must have exactly
+  the computed negative standard coefficients: `-1/9` for the central unitary witness
+  and `-23/507` for the two-outcome `5-12-13` witness, each strictly negative.
+- The `SU(3)` principal-eigenphase wrap region `|t_1 + t_2| > pi` must carry strictly
+  positive Haar class measure, so the stated wrap convention is engaged rather than
+  vacuous.
 - The `SU(3)` character machinery must pass scalar Jacobi-Trudi dimension
   checks and sampled orthonormality checks.
 - The `SU(3)` soft kernels must normalize, have real sampled character
@@ -298,5 +362,5 @@ python3 scripts/gauge_link_central_registration_induced_bi_invariant_step_kernel
 Expected:
 
 ```text
-TOTAL: PASS=103 FAIL=0
+TOTAL: PASS=117 FAIL=0
 ```

--- a/logs/runner-cache/gauge_link_central_registration_induced_bi_invariant_step_kernel_2026_07_02.txt
+++ b/logs/runner-cache/gauge_link_central_registration_induced_bi_invariant_step_kernel_2026_07_02.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/gauge_link_central_registration_induced_bi_invariant_step_kernel_2026_07_02.py
-runner_sha256: 7f9d03973a7e811d88fcc9f6741341d5c85fe22dee693cd185ae20585ccd3f9a
-timeout_sec: 120
+runner_sha256: bda9d6e41f80c810f6857f5ce5ae9677949ae585f4df14289cdd30205c422853
+timeout_sec: 600
 exit_code: 0
-elapsed_sec: 0.37
+elapsed_sec: 0.49
 status: ok
 ----- stdout -----
 PASS: A1 S3 projectors idempotent 
@@ -35,11 +35,19 @@ PASS: B3 Q8 full-resolution two-sided invariance exactly
 PASS: B3 Q8 full-resolution inversion symmetry exactly 
 PASS: B3 Q8 full-resolution character coefficients nonnegative [('triv', Fraction(1, 8)), ('chi_i', Fraction(1, 16)), ('chi_j', Fraction(1, 16)), ('chi_k', Fraction(1, 16)), ('quat', Fraction(0, 1))]
 B3 Q8 full-resolution character coefficients: [('triv', Fraction(1, 8)), ('chi_i', Fraction(1, 16)), ('chi_j', Fraction(1, 16)), ('chi_k', Fraction(1, 16)), ('quat', Fraction(0, 1))]
-PASS: C1 intra-block channel column validity 1.5543122344752192e-15
-PASS: C1 intra-block non-scalar Kraus is non-convolution max=0.0029069998035762268
+PASS: C1 intra-block channel column validity 1.2212453270876722e-15
+PASS: C1 intra-block non-scalar Kraus is non-convolution max=0.0029069998035760047
 PASS: C2 drift witness is a convolution kernel 
 PASS: C2 drift has negative nontrivial character coefficient [('triv', np.float64(0.16666666666666666)), ('sign', np.float64(0.16666666666666666)), ('std', np.float64(-0.16666666666666666))]
 PASS: C2 drift standard Fourier block is non-scalar 0.8660254037844387
+PASS: C3 central unitary witness squares to identity exactly 
+PASS: C3 central unitary induced kernel is an exact convolution 
+PASS: C3 central unitary kernel class values exact [((0, 1, 2), '1/9'), ((0, 2, 1), '0'), ((1, 0, 2), '0'), ((1, 2, 0), '4/9'), ((2, 0, 1), '4/9'), ((2, 1, 0), '0')]
+PASS: C3 central unitary character coefficients exact with negative std block {'triv': Fraction(1, 6), 'sign': Fraction(1, 6), 'std': Fraction(-1, 9)}
+PASS: C4 two-outcome 5-12-13 instrument is exactly trace-preserving 
+PASS: C4 two-outcome induced kernel is an exact convolution 
+PASS: C4 two-outcome character coefficients exact {'triv': Fraction(1, 6), 'sign': Fraction(1, 6), 'std': Fraction(-23, 507)}
+PASS: C4 two-outcome std coefficient strictly negative -23/507
 PASS: D0 SU3 Haar class density normalizes 1.0
 PASS: D1 SU3 scalar Jacobi-Trudi dimensions match Weyl dimensions reps=66
 PASS: D1 SU3 sampled character orthonormality [((1, 0, 0), (1, 0, 0), (1+2.1821677345877545e-20j)), ((2, 1, 0), (2, 1, 0), (1+1.8485267540907658e-35j)), ((1, 0, 0), (2, 1, 0), (4.163336342344337e-17+1.3877787807814457e-17j)), ((2, 0, 0), (1, 1, 0), (-7.28583859910259e-17+6.938893903907228e-18j))]
@@ -66,6 +74,7 @@ PASS: D3 SU3 w=6.0 variance near validation reference value=2.4877727520125266 r
 PASS: D3 SU3 w=15.0 variance near validation reference value=1.8861389013174228 ref=1.861
 PASS: D4 SU3 width-6 per-block generator spread exceeds heat-form floor 0.43827942136673814
 PASS: D4 SU3 width-6 per-block generator spread remains bounded 0.43827942136673814
+PASS: D5 SU3 principal-eigenphase wrap region has positive Haar measure 0.024328943366910404
 PASS: E1 S3 dimension-square sum is group order 6
 PASS: E1 Q8 dimension-square sum is group order 8
 PASS: E2 S3 full-resolution spectral data exact {'triv': Fraction(1, 6), 'sign': Fraction(1, 9), 'std': Fraction(1, 9)}
@@ -93,6 +102,11 @@ PASS: F note preserve marker needle='an audit verdict or any effective-status pr
 PASS: F note preserve marker needle='Kronecker'
 PASS: F note preserve marker needle='intra-block'
 PASS: F note preserve marker needle='the per-step kernel is not the heat kernel'
+PASS: F note preserve marker needle='positive Lueders subclass'
+PASS: F note preserve marker needle='centrality alone does not give representation positivity'
+PASS: F note preserve marker needle='per-step variance'
+PASS: F note preserve marker needle='N_trunc^(-1/2)'
+PASS: F note preserve marker needle='principal-eigenphase distance'
 PASS: F canonical source metadata needle='**Claim type:** bounded_theorem'
 PASS: F canonical source metadata needle='**Claim scope:** Central-scalar record registration'
 PASS: F canonical source metadata needle='**Status authority:** independent audit lane only.'
@@ -112,7 +126,7 @@ PASS: F note forbidden string absent needle='closes the route'
 PASS: F runner forbidden string absent needle='closes the route'
 PASS: F note forbidden string absent needle='covariance implies the step-measure premise'
 PASS: F runner forbidden string absent needle='covariance implies the step-measure premise'
-TOTAL: PASS=103 FAIL=0
+TOTAL: PASS=117 FAIL=0
 
 ----- stderr -----
 

--- a/scripts/gauge_link_central_registration_induced_bi_invariant_step_kernel_2026_07_02.py
+++ b/scripts/gauge_link_central_registration_induced_bi_invariant_step_kernel_2026_07_02.py
@@ -6,12 +6,13 @@ and independent algebra/numerics for the row.
 
 T1: the two-ended link carrier has gauge-central pointer content given by the
 Peter-Weyl isotypic projectors.
-T2: scalar central registration Kraus blocks induce normalized, convolutional,
-Ad-invariant, inversion-symmetric, positive step kernels.
-T3: intra-block frame-picking and deterministic drift witnesses show what the
-central scalar registration hypothesis supplies.
-T4: registration softness controls step size, while the per-step soft kernel is
-not asserted to be a heat kernel.
+T2: positive Lueders scalar central registration Kraus blocks induce normalized,
+convolutional, Ad-invariant, inversion-symmetric, positive step kernels.
+T3: intra-block frame-picking, deterministic drift, and exact negative-coefficient
+central witnesses show what the positive Lueders central scalar registration
+hypothesis supplies and what centrality alone does not.
+T4: registration softness controls the per-step variance in a stated convention,
+while the per-step soft kernel is not asserted to be a heat kernel.
 """
 
 import numpy as np
@@ -445,6 +446,109 @@ def run_s3_contrast(elems, idx, mul, inv, projectors, chars):
     nonscalar_norm = np.linalg.norm(rho_g0 - (np.trace(rho_g0) / 2.0) * np.eye(2), 2)
     check("C2 drift standard Fourier block is non-scalar", nonscalar_norm > 0.5, str(nonscalar_norm))
 
+    p_triv = projectors["triv"]
+    p_sign = projectors["sign"]
+    p_std_frac = projectors["std"]
+    k_central = [
+        [p_triv[i][j] + p_sign[i][j] - p_std_frac[i][j] for j in range(6)]
+        for i in range(6)
+    ]
+    check(
+        "C3 central unitary witness squares to identity exactly",
+        frac_matrix_mul(k_central, k_central) == frac_matrix_identity(6),
+    )
+
+    t_central = [[k_central[i][j] ** 2 for j in range(6)] for i in range(6)]
+    by_delta_exact = {}
+    conv_exact = True
+    for g in elems:
+        for h in elems:
+            x = mul(g, inv(h))
+            val = t_central[idx[g]][idx[h]]
+            if x in by_delta_exact and by_delta_exact[x] != val:
+                conv_exact = False
+            by_delta_exact[x] = val
+    check("C3 central unitary induced kernel is an exact convolution", conv_exact)
+
+    class_expected = {3: Fraction(1, 9), 1: Fraction(0), 0: Fraction(4, 9)}
+    class_ok = True
+    for x, val in by_delta_exact.items():
+        fixed = sum(1 for i in range(3) if x[i] == i)
+        class_ok = class_ok and (val == class_expected[fixed])
+    check(
+        "C3 central unitary kernel class values exact",
+        class_ok,
+        str(sorted((x, str(v)) for x, v in by_delta_exact.items())),
+    )
+
+    e_id = elems[0]
+    coeff_map_central = {}
+    for name, dim, ch in chars:
+        coeff = Fraction(0)
+        for x in elems:
+            coeff += t_central[idx[x]][idx[e_id]] * ch[inv(x)]
+        coeff_map_central[name] = coeff / 6
+    expected_central = {"triv": Fraction(1, 6), "sign": Fraction(1, 6), "std": Fraction(-1, 9)}
+    check(
+        "C3 central unitary character coefficients exact with negative std block",
+        coeff_map_central == expected_central and coeff_map_central["std"] < 0,
+        str(coeff_map_central),
+    )
+
+    w_big = Fraction(12, 13)
+    w_small = Fraction(5, 13)
+    k_one = [
+        [w_big * (p_triv[i][j] + p_sign[i][j] - p_std_frac[i][j]) for j in range(6)]
+        for i in range(6)
+    ]
+    k_two = [
+        [w_small * (p_triv[i][j] + p_sign[i][j] + p_std_frac[i][j]) for j in range(6)]
+        for i in range(6)
+    ]
+    k_one_t = [[k_one[j][i] for j in range(6)] for i in range(6)]
+    k_two_t = [[k_two[j][i] for j in range(6)] for i in range(6)]
+    kraus_sum = frac_matrix_add([
+        frac_matrix_mul(k_one_t, k_one),
+        frac_matrix_mul(k_two_t, k_two),
+    ])
+    check(
+        "C4 two-outcome 5-12-13 instrument is exactly trace-preserving",
+        kraus_sum == frac_matrix_identity(6),
+    )
+
+    t_two = [
+        [k_one[i][j] ** 2 + k_two[i][j] ** 2 for j in range(6)]
+        for i in range(6)
+    ]
+    by_delta_two = {}
+    conv_two = True
+    for g in elems:
+        for h in elems:
+            x = mul(g, inv(h))
+            val = t_two[idx[g]][idx[h]]
+            if x in by_delta_two and by_delta_two[x] != val:
+                conv_two = False
+            by_delta_two[x] = val
+    check("C4 two-outcome induced kernel is an exact convolution", conv_two)
+
+    coeff_map_two = {}
+    for name, dim, ch in chars:
+        coeff = Fraction(0)
+        for x in elems:
+            coeff += t_two[idx[x]][idx[e_id]] * ch[inv(x)]
+        coeff_map_two[name] = coeff / 6
+    expected_two = {"triv": Fraction(1, 6), "sign": Fraction(1, 6), "std": Fraction(-23, 507)}
+    check(
+        "C4 two-outcome character coefficients exact",
+        coeff_map_two == expected_two,
+        str(coeff_map_two),
+    )
+    check(
+        "C4 two-outcome std coefficient strictly negative",
+        coeff_map_two["std"] < 0,
+        str(coeff_map_two["std"]),
+    )
+
 
 def det3_arrays(a00, a01, a02, a10, a11, a12, a20, a21, a22):
     return (
@@ -670,6 +774,13 @@ def run_su3_numerics():
     check("D4 SU3 width-6 per-block generator spread exceeds heat-form floor", spread > 0.2, str(spread))
     check("D4 SU3 width-6 per-block generator spread remains bounded", spread < 1.0, str(spread))
 
+    wrap_engaged = integral(np.where(np.abs(t1g + t2g) > np.pi, 1.0, 0.0))
+    check(
+        "D5 SU3 principal-eigenphase wrap region has positive Haar measure",
+        float(np.real(wrap_engaged)) > 1e-3,
+        str(wrap_engaged),
+    )
+
 
 def run_exact_summary(s3_chars, s3_coeffs):
     s3_dim_sum = sum(Fraction(dim * dim) for _, dim, _ in s3_chars)
@@ -736,6 +847,11 @@ def run_source_guards():
         "Kronecker",
         "intra-block",
         "the per-step kernel is not the heat kernel",
+        "positive Lueders subclass",
+        "centrality alone does not give representation positivity",
+        "per-step variance",
+        "N_trunc^(-1/2)",
+        "principal-eigenphase distance",
     ]
     for marker in preserve:
         require_contains("F note preserve marker", note_text, marker)


### PR DESCRIPTION
## Summary

Fix-class edit to an existing packet (1 note + 1 paired runner + regenerated cache) responding to the `audited_conditional` verdict on ledger row `gauge_link_central_registration_induced_bi_invariant_step_kernel_theorem_note_2026-07-02`. The `notes_for_re_audit_if_any` says, verbatim:

> scope_too_broad: Narrow 'central-scalar registration' to the positive Lueders subclass, repair and document the compact normalization and SU(3) metric, rename the computed quantity as per-step variance, then rerun after the semigroup dependency is retained-grade.

Every item of the verdict except the external dependency condition is addressed in-packet:

- **Positive Lueders narrowing (scope):** the claim scope, premise paragraph, Theorem 2, and Theorem 4 header now state the positive Lueders channel subclass explicitly; the premise records that centrality alone does not give representation positivity (Theorem 3 now exhibits exact central counterexamples) and that kinematic covariance supplies neither.
- **Compact normalization documented:** N_trunc = sum_R d_R^2 with the normalized-Haar N_trunc^(-1/2) convention stated where the truncation is introduced, and the general central-scalar c_j(R) form recorded.
- **SU(3) metric documented as a stated convention:** squared principal-eigenphase distance d^2 = t1^2 + t2^2 + t3^2 with t3 = -(t1+t2) wrapped to [-pi, pi), explicitly labeled "Convention (stated, not selected)." with the traceless-log alternative named and no canonical-metric selection claimed.
- **Per-step variance rename:** the computed quantity is named per-step variance throughout; the note states no per-unit-time rate is derived (converting a per-step variance into a rate requires the record-step count, which this row does not supply). The backticked `GAUGE_LINK_PER_RECORD_STEP_RATE_DIAL` basename stays context-only, not a citation-graph dependency.
- **Exact negative-coefficient witnesses (Theorem 3 upgraded):** two new exact witnesses, each doing real work:
  - Third witness (central unitary): K = P_triv + P_sign - P_std on the S3 regular representation, K^2 = I exact; entrywise-squared kernel has exact class values t(e)=1/9, t(transposition)=0, t(3-cycle)=4/9 and central coefficients {triv: 1/6, sign: 1/6, std: **-1/9**}.
  - Fourth witness (two-outcome isometric family, 5-12-13): K1 = (12/13)K, K2 = (5/13)(P_triv+P_sign+P_std), sum K_j^dag K_j = I exact; coefficient map {triv: 1/6, sign: 1/6, std: **-23/507**}.
- **Runner upgrades (discriminating gates):** C3/C4 blocks verify both witnesses with exact `Fraction` arithmetic (Kraus-sum identity, exact convolution, exact class values, exact negative std coefficients — 8 checks); D5 verifies the wrap region |t1+t2| > pi is engaged with positive Haar measure (falsifier for the wrap convention); 5 new forbidden-string guards pin the narrowed language. New falsifier bullets pin the exact -1/9 and -23/507 values.

## Runner

`python3 scripts/gauge_link_central_registration_induced_bi_invariant_step_kernel_2026_07_02.py` → `TOTAL: PASS=117 FAIL=0` (103 existing + C3(4) + C4(4) + D5(1) + 5 forbidden-string guards), exit 0. Cache regenerated via `runner_cache.py`.

## Re-audit dependency note

The verdict's final clause ("rerun after the semigroup dependency is retained-grade") is external to this packet: the row's re-audit additionally waits on `record_classical_semigroup_boundary_2026-06-06` reaching retained grade (currently `audit_in_progress` in another lane). This PR discharges the in-packet portion of the verdict so the row is re-audit-ready the moment that dependency lands.

## Test plan

- [x] Paired runner re-run by reviewer-of-record: PASS=117 FAIL=0, exit 0
- [x] All 20 preserve-verbatim pins present; all 8 forbidden strings absent; no non-ASCII characters
- [x] Markdown-link inventory identical to origin/main (no new dependency edges)
- [x] Sibling grep: no other script references the note or runner basename
- [x] Cache regenerated from the worktree; triple is exactly 1 note + 1 runner + 1 cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)