### PR TITLE
fix(yt): demote sqrt(8/9) to a conditional connected-trace specialization

### DIFF
--- a/docs/YT_ZERO_IMPORT_AUTHORITY_NOTE.md
+++ b/docs/YT_ZERO_IMPORT_AUTHORITY_NOTE.md
@@ -1,7 +1,7 @@
 # y_t Lane: Zero-Import Authority
 
 **Date:** 2026-04-17
-**Status:** DERIVED quantitative authority surface (zero external observables)
+**Status:** derived lattice-scale Ward-ratio core (zero external observables) + conditional low-energy package (conditional on the underived Yukawa-side selector `kappa_Y = 0`)
 **Primary runner:** `scripts/frontier_yt_ward_identity_derivation.py` ([scripts/frontier_yt_ward_identity_derivation.py](../scripts/frontier_yt_ward_identity_derivation.py))
 **Additional primary runner:** `scripts/frontier_yt_color_projection_correction.py`
 **Supporting runners:** `scripts/frontier_yt_explicit_systematic_budget.py`,
@@ -45,7 +45,9 @@ Do not treat older backward-Ward / route-history notes as competing authority.
 | `m_t(pole)` 3-loop | `173.10 GeV` | `172.69 GeV` | `+0.24%` |
 
 These are the current strongest zero-external-observable central values on the
-renormalized `y_t` lane.
+renormalized `y_t` lane. They are conditional central values: each one
+multiplies the exact Ward core by the connected-trace factor `sqrt(8/9)`,
+whose selector condition is stated below.
 
 ## Safe claim
 
@@ -53,10 +55,13 @@ The current package can safely say:
 
 - the lattice-scale Yukawa-to-gauge ratio is exact on the canonical surface:
   `y_t(M_Pl) / g_s(M_Pl) = 1 / sqrt(6)`
-- the physical low-energy Yukawa is the Ward value times the derived
-  color-projection factor `sqrt(8/9)`
-- the low-energy `y_t` endpoint and the current `m_t` values are derived
-  central values with zero external SM observables on the framework side
+- conditional on the underived Yukawa-side selector `kappa_Y = 0`, the
+  physical low-energy Yukawa is the Ward value times the connected-trace
+  color-projection factor `sqrt(8/9)` — a conditional connected-trace
+  specialization, not an unconditionally derived selector
+- conditional on that same selector, the low-energy `y_t` endpoint and the
+  current `m_t` values are conditional central values with zero external SM
+  observables on the framework side
 - the current precision caveat on the primary path is a standard-method
   residual budget, dominated by lattice-to-continuum 1-loop matching at the
   Planck interface plus standard SM RGE truncation, of order `~1.95%`
@@ -68,12 +73,35 @@ The current package can safely say:
 The package still cannot say that the renormalized `y_t` lane is a fully
 framework-internal retained theorem from `M_Pl` to `v`.
 
+## Conditionality of the low-energy package
+
+The color-projection factor `sqrt(8/9)` enters the low-energy package as a
+conditional connected-trace specialization, not as an unconditionally derived
+selector. Per
+[YT_COLOR_PROJECTION_CORRECTION_NOTE.md](./YT_COLOR_PROJECTION_CORRECTION_NOTE.md),
+the connected-trace value `K_Y(0) = 8/9` is the specialization of the color
+projection to the Yukawa-side selector `kappa_Y = 0`, and that selector is not
+derived in this packet: the cited SU(3) Fierz/channel-count authority plus
+color-blind scaling do not by themselves fix `kappa_Y = 0` or an unconditional
+`sqrt(8/9)` correction.
+
+Consequently:
+
+- the lattice-scale Ward ratio `y_t(M_Pl) / g_s(M_Pl) = 1 / sqrt(6)` is the
+  supported core of this note and does not depend on the selector
+- every low-energy quantity in this note that multiplies by `sqrt(8/9)` — the
+  `y_t(v)` endpoint and both `m_t(pole)` central values — is conditional on
+  `kappa_Y = 0`
+- deriving `kappa_Y = 0` on the framework side remains an open target; this
+  section records the current condition, not a closure of that derivation
+
 ## Why the lane is no longer carried by a framework-native explicit systematic
 
 The live primary path is now:
 
 1. exact lattice-scale Ward theorem on the retained theory
-2. derived color projection `sqrt(8/9)`
+2. conditional connected-trace color projection `sqrt(8/9)` (conditional on
+   the underived selector `kappa_Y = 0`; see the conditionality section above)
 3. standard lattice-to-continuum matching at the `M_Pl` interface
 4. standard SM RGE running from `M_Pl` to `v`
 5. standard pole-mass conversion
@@ -89,8 +117,9 @@ continuum:
 - standard lattice 1-loop matching at the `M_Pl` interface, which dominates
   the current budget
 
-That leaves the lane as a **derived quantitative lane** rather than a
-retained theorem-grade UV-to-IR closure.
+That leaves the lane as an exact Ward-ratio core plus a **conditional
+quantitative low-energy package** rather than a retained theorem-grade
+UV-to-IR closure.
 
 ## What the Schur-bridge stack becomes
 
@@ -116,12 +145,15 @@ The current package does **not** claim:
 - a theorem-grade elimination of all UV-to-IR transport residuals
 - a practical direct-lattice bypass that measures `y_t(v)` on accessible
   lattices
+- an unconditional derivation of the Yukawa-side selector `kappa_Y = 0` (the
+  low-energy package is conditional on it)
 
 So the right read is:
 
 > the exact lattice-scale Yukawa/gauge normalization is retained, the
-> renormalized low-energy `y_t` / `m_t` lane is derived with zero external SM
-> observables on the framework side, the current primary precision caveat is a
-> standard-method residual budget of order `~1.95%`, and the older Schur
-> bridge survives as an independent cross-check with its own tighter but
+> renormalized low-energy `y_t` / `m_t` lane is a conditional package —
+> conditional on the underived Yukawa-side selector `kappa_Y = 0` — with zero
+> external SM observables on the framework side, the current primary precision
+> caveat is a standard-method residual budget of order `~1.95%`, and the older
+> Schur bridge survives as an independent cross-check with its own tighter but
 > route-specific budget.

--- a/logs/runner-cache/frontier_yt_flagship_boundary_contract.txt
+++ b/logs/runner-cache/frontier_yt_flagship_boundary_contract.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_yt_flagship_boundary_contract.py
-runner_sha256: 9852c60d991a5258082717f055e447a802b9cd6fceb3e6b688b3fc448fed743f
-timeout_sec: 120
+runner_sha256: c04e0cc9a187a1d857e07284fd4e63530e11259ddd30015e1032ee22d1c041b2
+timeout_sec: 600
 exit_code: 0
-elapsed_sec: 0.05
+elapsed_sec: 0.04
 status: ok
 ----- stdout -----
 ==============================================================================
@@ -49,6 +49,9 @@ Part 4: limitation and non-claim firewall
 [PASS] cannot-claim section forbids direct-lattice y_t(v) bypass claim
 [PASS] cannot-claim section preserves Schur bridge rather than discarding it
 [PASS] zero-import authority also refuses fully retained theorem-grade UV-to-IR closure
+[PASS] zero-import authority demotes sqrt(8/9) to a conditional connected-trace specialization
+[PASS] zero-import authority conditions the low-energy package on the underived selector
+[PASS] zero-import authority carries a conditionality section for the low-energy package
 
 Part 5: bridge cross-check budget alignment
 [PASS] flagship note preserves conservative Schur budget 1.2147511%
@@ -71,7 +74,7 @@ Part 7: no hidden observed-input promotion
 [PASS] paper-safe wording calls current values central values, not retained closure
 
 ==============================================================================
-RESULT: PASS=46 FAIL=0
+RESULT: PASS=49 FAIL=0
 ==============================================================================
 
 ----- stderr -----

--- a/scripts/frontier_yt_flagship_boundary_contract.py
+++ b/scripts/frontier_yt_flagship_boundary_contract.py
@@ -11,7 +11,9 @@ authority contract:
 * the positive statements stay scoped to derived central values and exact
   lattice-scale support;
 * the note explicitly forbids fully-retained UV-to-IR closure, a native
-  continuum-limit theorem, and a direct-lattice low-energy bypass claim.
+  continuum-limit theorem, and a direct-lattice low-energy bypass claim;
+* the zero-import authority conditions its low-energy package on the underived
+  ``kappa_Y = 0`` selector (conditional connected-trace specialization).
 
 It deliberately does not certify effective retained status.  Independent
 audit owns that decision.
@@ -190,6 +192,18 @@ def main() -> int:
             or "fully framework-internal continuum-limit theorem" in zero_n
         )
         and "from `M_Pl` to `v`" in zero_n,
+    )
+    check(
+        "zero-import authority demotes sqrt(8/9) to a conditional connected-trace specialization",
+        "conditional connected-trace specialization" in zero_n,
+    )
+    check(
+        "zero-import authority conditions the low-energy package on the underived selector",
+        "conditional on the underived Yukawa-side selector `kappa_Y = 0`" in zero_n,
+    )
+    check(
+        "zero-import authority carries a conditionality section for the low-energy package",
+        "## Conditionality of the low-energy package" in zero,
     )
 
     print("\nPart 5: bridge cross-check budget alignment")


### PR DESCRIPTION
## Summary

Responds to the `audited_conditional` verdict on ledger row `yt_zero_import_authority_note`, whose `notes_for_re_audit_if_any` says, verbatim:

> missing_bridge_theorem: derive the physical Yukawa-side kappa_Y=0 selector, or demote sqrt(8/9) to a conditional connected-trace specialization before re-auditing the low-energy package.

This PR takes the second branch: it demotes `sqrt(8/9)` throughout `docs/YT_ZERO_IMPORT_AUTHORITY_NOTE.md` to a conditional connected-trace specialization, conditional on the underived Yukawa-side selector `kappa_Y = 0`. The lattice-scale Ward ratio `y_t(M_Pl) / g_s(M_Pl) = 1 / sqrt(6)` stays as the supported, selector-independent core. Deriving `kappa_Y = 0` on the framework side remains an open target; the note now records the condition explicitly instead of asserting an unconditional low-energy derivation.

## Changes

- `docs/YT_ZERO_IMPORT_AUTHORITY_NOTE.md`:
  - Status line: split into the derived lattice-scale Ward-ratio core + a conditional low-energy package.
  - Strongest-package table: central values labeled conditional, with the selector condition pointed to below.
  - Safe-claim bullets 2–3: low-energy Yukawa and `y_t`/`m_t` central values now conditional on `kappa_Y = 0`; `sqrt(8/9)` named a conditional connected-trace specialization, not an unconditionally derived selector.
  - New section "Conditionality of the low-energy package": states `K_Y(0) = 8/9` is the specialization to `kappa_Y = 0`, that the selector is not derived in this packet, and that every `sqrt(8/9)`-multiplied quantity is conditional. Cites the already-linked color-projection note; no new dependency edges.
  - Primary-path step 2, the closing classification paragraph, the Honest-boundary non-claim list, and the final blockquote made consistent with the conditional package. The pre-existing lattice-scale-normalization clause, the `~1.95%` residual-budget text, and the Schur cross-check clause are preserved verbatim.
- `scripts/frontier_yt_flagship_boundary_contract.py`: three new Part-4 firewall checks pin the demotion (conditional connected-trace specialization phrase, the `kappa_Y = 0` selector condition, and the conditionality section heading) so the conditional phrasing cannot silently regress; docstring bullet added. This runner pairs with `yt_flagship_boundary_note` (unaudited), so no clean row is invalidated.
- `logs/runner-cache/frontier_yt_flagship_boundary_contract.txt`: regenerated (PASS=49 FAIL=0, was 46).

## Verification

- `scripts/frontier_yt_flagship_boundary_contract.py`: PASS=49 FAIL=0 (the runner that gates the zero note's text).
- `scripts/frontier_yt_ward_identity_derivation.py` (the row's paired runner, untouched — also paired with the retained_bounded `yt_ward_identity_derivation_theorem` row, deliberately not edited): TOTAL: PASS=58 FAIL=0.
- Sibling runners all pass: `frontier_yt_zero_import_ratio_authority`, `frontier_yt_boundary_consistency` (14/14), `frontier_yt_eft_bridge`, `frontier_yt_2loop_chain` (2/2), `frontier_direct_yt_extraction` (8/8).
- Blast radius: the zero note's 9 ledger dependents are all unaudited (plus one meta catalog row); the retained_bounded ward-theorem row does not carry this note as a dep edge. No retained-grade row is invalidated.

Re-audit of `yt_zero_import_authority_note` is for the independent audit lane; this PR authors no status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
