### PR TITLE
fix(runners): repair stale Tier-A registry pins after the 2026-07-05 retirements

### DIFF
--- a/logs/runner-cache/acphilambda_occupancy_formation_append_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_occupancy_formation_append_non_supply_no_go_2026_07_04.txt
@@ -1,3 +1,11 @@
+===== runner cache v1 =====
+runner: scripts/acphilambda_occupancy_formation_append_non_supply_no_go_2026_07_04.py
+runner_sha256: 4b0f9874082efcb86374fc7f1a04a6ace6fe49965c02f96840f5693b59a10487
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 1.04
+status: ok
+----- stdout -----
 AC_phi_lambda occupancy formation-append non-supply verifier
 
 ================================================================================================
@@ -35,7 +43,9 @@ A. source presence, metadata, and no-overclaim firewall
 ================================================================================================
 B. Tier-A registry state on current main
 ================================================================================================
-[PASS] AC_phi_lambda remains the live Tier-A target
+[PASS] Tier-A live derivation targets are empty after the 2026-07-05 retirements
+[PASS] AC entry preserved intact under retired_derivation_targets
+[PASS] AC retirement mechanism is owner governance, not the formation append
 [PASS] AC minimum decomposition contains occupancy binary
 [PASS] AC minimum decomposition keeps R-eta separate
 [PASS] AC minimum decomposition keeps species bridge separate
@@ -151,4 +161,7 @@ G. note theorem and no-go discipline
 ================================================================================================
 TOTAL
 ================================================================================================
-TOTAL: PASS=120 FAIL=0 CHECKS=120
+TOTAL: PASS=122 FAIL=0 CHECKS=122
+
+----- stderr -----
+

--- a/logs/runner-cache/audit_companion_minimal_axioms_clean_base_exact.txt
+++ b/logs/runner-cache/audit_companion_minimal_axioms_clean_base_exact.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/audit_companion_minimal_axioms_clean_base_exact.py
-runner_sha256: efb20a41810c763fd7b4fcfb40a8995317d0084aa18557f21b05186e2b0cb57b
+runner_sha256: 3131e7297c563d671f6ba5991de56d6fdb2a49a88f5f6d0373e90c1ced946584
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.13
+elapsed_sec: 0.08
 status: ok
 ----- stdout -----
 PASS: Source note exists
@@ -48,6 +48,12 @@ PASS: Registry note records 2026-07-02/03 no-privilege/readout/state/law/record 
       
 PASS: Policy records 2026-07-02 foundation wording additions
       
+PASS: Memo Record axiom carries the 2026-07-04 formation sentence
+      occurrence is axiom content; formation rules stay downstream
+PASS: Registry note records the formation sentence
+      
+PASS: Policy records 2026-07-04 formation-sentence entry
+      
 PASS: Policy records 2026-07-03 Record permanence restoration
       
 PASS: Policy records 2026-07-03 Record section polish
@@ -56,8 +62,8 @@ PASS: Policy records 2026-06-29 foundation reset
       
 PASS: Policy no-laundering clause lists Admissibility and Record boundaries
       
-PASS: Tier-A genuine admitted input count remains two
-      2
+PASS: Tier-A genuine admitted input count is zero after the 2026-07-05 retirements
+      0
 PASS: minimal_axioms is not a Tier-A derivation target
       
 PASS: Tier-A registry records Record as reclassified primitive
@@ -104,7 +110,7 @@ PASS: Open gates outside axioms include staggered realization
       
 PASS: Open gates outside axioms include theta
       
-PASS: Open gates outside axioms include context selection and occurrence rules
+PASS: Open gates outside axioms include context selection and formation rules
       
 PASS: Open gates outside axioms include physical persistence dynamics
       
@@ -137,8 +143,8 @@ PASS: Qualification: supplied-condition law gives one answer where its condition
 PASS: Boundary: runner imports no context-selection/log-det/P2/measurement/dynamics/scale conclusion
       script checks only algebraic notation, graph adjacency, local availability bookkeeping, fixed record readout, and finite additivity
 
-runner_check_breakdown = {A: 65, B: 0, C: 0, D: 0, total_pass: 65}
-TOTAL: PASS=65 FAIL=0
+runner_check_breakdown = {A: 68, B: 0, C: 0, D: 0, total_pass: 68}
+TOTAL: PASS=68 FAIL=0
 RESULT: PASS
 
 ----- stderr -----

--- a/logs/runner-cache/primitive_retirement_review_after_four_axiom_reset_2026_07_05.txt
+++ b/logs/runner-cache/primitive_retirement_review_after_four_axiom_reset_2026_07_05.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/primitive_retirement_review_after_four_axiom_reset_2026_07_05.py
-runner_sha256: 6ad9cfea2f648a02bc4875eb428fa9c11d1c85b3a8f6bd092ab4cce92f7bb7d9
+runner_sha256: ffb0d58b8ae35e060ea229bd618acfca707b83b2fcecb19f0bf01ac443392819
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.15
+elapsed_sec: 0.14
 status: ok
 ----- stdout -----
 ==============================================================================
@@ -42,8 +42,8 @@ Primitive source-boundary checks
 [PASS] scale source forbids dimensionless content
 [PASS] scale source does not derive a/l_P=1
 [PASS] kinetic source declares c_t=c_s
-[PASS] kinetic source says baseline does not fix ratio
-[PASS] kinetic source says scale fixes no dimensionless ratio
+[PASS] kinetic source says c_t = c_s is supplied rather than derived
+[PASS] kinetic source lists scale reference among structures not used as a derivation
 [PASS] realized source says laws do not pick state
 [PASS] realized source says pointwise evaluation only
 [PASS] realized source forbids state-selection content
@@ -83,8 +83,8 @@ Review-note conclusion checks
 [PASS] review note says premise registries are not reopened
 
 Hygiene diagnostic checks
-[PASS] scale boundary runner stale Tier-A count diagnostic is detected
-[PASS] primitive source notes still need four-axiom narrative scrub -- SCALE_REFERENCE_PRIMITIVE_NOTE.md, KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md, REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md
+[PASS] scale boundary runner carries the current Tier-A count gate
+[PASS] primitive source notes carry no pre-reset baseline narrative
 
 Verdicts
   scale_reference_primitive: KEEP -- no dimensionful derivation from current axioms

--- a/logs/runner-cache/scale_reference_primitive_boundary_check.txt
+++ b/logs/runner-cache/scale_reference_primitive_boundary_check.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/scale_reference_primitive_boundary_check.py
-runner_sha256: 995439520c351583d867dcfa0f4dd55fb5a8cf60119c8e51bcd9575836f94994
+runner_sha256: 8f32952c4dc78a9d4de99ce0042faaf37dd13a9b3cbe627cc442204d85a65d07
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.14
+elapsed_sec: 0.08
 status: ok
 ----- stdout -----
 ==============================================================================
@@ -29,7 +29,7 @@ Scope: primitive registry/source firewall only; no downstream theorem.
 [PASS] policy records dimensional irreducibility
 [PASS] policy records no-laundering boundary
 [PASS] policy keeps Planck-length self-consistency separate
-[PASS] Tier-A registry genuine count remains two -- 2
+[PASS] Tier-A registry genuine count is zero after the 2026-07-05 retirements -- 0
 [PASS] scale primitive is not a Tier-A derivation target
 [PASS] Tier-A registry records scale as reclassified primitive
 [PASS] Tier-A reclassification says not status-bounding
@@ -37,7 +37,7 @@ Scope: primitive registry/source firewall only; no downstream theorem.
 [PASS] note names Planck mass scale reference
 [PASS] note says units conversion not physics axiom
 [PASS] note says zero dimensionless content
-[PASS] note says scale is irreducible by dimensional analysis
+[PASS] note disclaims deriving the chosen physical scale
 [PASS] note says it does not add or amend an axiom
 [PASS] note says it does not assert a/l_P = 1 as derived
 [PASS] note says it does not supply dimensionless quantity

--- a/scripts/acphilambda_occupancy_formation_append_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_occupancy_formation_append_non_supply_no_go_2026_07_04.py
@@ -120,10 +120,25 @@ def main() -> int:
 
     section("B. Tier-A registry state on current main")
     tier = json.loads(read(TIER_A))
-    ac = tier["derivation_targets"]["staggered_dirac_realization_gate_note_2026-05-03"]
+    ac = tier["retired_derivation_targets"]["staggered_dirac_realization_gate_note_2026-05-03"]
     decomp = ac["minimum_decomposition"]
     statement = ac["statement"]
-    check("AC_phi_lambda remains the live Tier-A target", tier["genuine_admitted_input_count"] >= 1)
+    check(
+        "Tier-A live derivation targets are empty after the 2026-07-05 retirements",
+        tier["genuine_admitted_input_count"] == 0
+        and tier["derivation_targets"] == {}
+        and tier["canonical_ids"] == [],
+        str(tier["genuine_admitted_input_count"]),
+    )
+    check(
+        "AC entry preserved intact under retired_derivation_targets",
+        bool(statement) and bool(decomp),
+    )
+    check(
+        "AC retirement mechanism is owner governance, not the formation append",
+        ac["retirement"]["mechanism"] == "retired_by_owner_governance_on_audited_surface",
+        ac["retirement"]["mechanism"],
+    )
     check("AC minimum decomposition contains occupancy binary", "reading_occupancy_selection" in decomp, decomp)
     check("AC minimum decomposition keeps R-eta separate", "delta_readout_identification_R_eta" in decomp, decomp)
     check("AC minimum decomposition keeps species bridge separate", "species_bridge" in decomp, decomp)

--- a/scripts/audit_companion_minimal_axioms_clean_base_exact.py
+++ b/scripts/audit_companion_minimal_axioms_clean_base_exact.py
@@ -215,7 +215,7 @@ def source_boundary_checks() -> list[Check]:
             and contains(policy, "Record does not supply readout-context selection, central decomposition, `K`/CPT structure"),
             "",
         ),
-        Check("Tier-A genuine admitted input count remains two", tier_a.get("genuine_admitted_input_count") == 2, str(tier_a.get("genuine_admitted_input_count"))),
+        Check("Tier-A genuine admitted input count is zero after the 2026-07-05 retirements", tier_a.get("genuine_admitted_input_count") == 0, str(tier_a.get("genuine_admitted_input_count"))),
         Check("minimal_axioms is not a Tier-A derivation target", CLAIM_ID not in derivation_targets, ""),
         Check("Tier-A registry records Record as reclassified primitive", bool(record_reclass), ""),
         Check("Tier-A Record reclassification source is current memo", record_reclass.get("source") == rel(NOTE), str(record_reclass.get("source"))),

--- a/scripts/primitive_retirement_review_after_four_axiom_reset_2026_07_05.py
+++ b/scripts/primitive_retirement_review_after_four_axiom_reset_2026_07_05.py
@@ -127,8 +127,12 @@ def main() -> int:
     check("scale source forbids dimensionless content", "zero dimensionless" in scale)
     check("scale source does not derive a/l_P=1", "It does not assert `a/l_P = 1` as a derived theorem." in scale)
     check("kinetic source declares c_t=c_s", "c_t = c_s" in kinetic)
-    check("kinetic source says baseline does not fix ratio", "does **not** fix the kinetic\nisotropy `c_t = c_s`" in kinetic)
-    check("kinetic source says scale fixes no dimensionless ratio", "the scale reference fixes no\ndimensionless ratio" in kinetic)
+    check("kinetic source says c_t = c_s is supplied rather than derived", "`c_t = c_s` is supplied rather than derived" in kinetic)
+    check(
+        "kinetic source lists scale reference among structures not used as a derivation",
+        "scale reference, and records' causal order" in kinetic
+        and "are not used here as a derivation of that equality" in kinetic,
+    )
     check("realized source says laws do not pick state", "The laws do not pick the state; the world does" in realized)
     check("realized source says pointwise evaluation only", "Derivations may evaluate at the realized state, pointwise." in realized)
     check("realized source forbids state-selection content", "It does not supply a state, state-selection rule" in realized)
@@ -166,12 +170,16 @@ def main() -> int:
 
     print("Hygiene diagnostic checks")
     stale_count_check = "Tier-A registry genuine count remains two" in scale_runner
-    check("scale boundary runner stale Tier-A count diagnostic is detected", stale_count_check)
+    current_count_check = "Tier-A registry genuine count is zero after the 2026-07-05 retirements" in scale_runner
+    check(
+        "scale boundary runner carries the current Tier-A count gate",
+        current_count_check and not stale_count_check,
+    )
     old_baseline_refs = [
         p.name for p, text in [(SCALE, scale), (KINETIC, kinetic), (REALIZED, realized)]
         if re.search(r"three named axioms|Lattice \+ Quantum \+ Record|MINIMAL_AXIOMS_2026-06-0[45]", text)
     ]
-    check("primitive source notes still need four-axiom narrative scrub", bool(old_baseline_refs), ", ".join(old_baseline_refs))
+    check("primitive source notes carry no pre-reset baseline narrative", not old_baseline_refs, ", ".join(old_baseline_refs))
     print()
 
     print("Verdicts")

--- a/scripts/scale_reference_primitive_boundary_check.py
+++ b/scripts/scale_reference_primitive_boundary_check.py
@@ -118,8 +118,8 @@ def main() -> int:
     )
 
     check(
-        "Tier-A registry genuine count remains two",
-        tier_a.get("genuine_admitted_input_count") == 2,
+        "Tier-A registry genuine count is zero after the 2026-07-05 retirements",
+        tier_a.get("genuine_admitted_input_count") == 0,
         str(tier_a.get("genuine_admitted_input_count")),
     )
     check("scale primitive is not a Tier-A derivation target", CLAIM_ID not in derivation_targets)
@@ -133,7 +133,7 @@ def main() -> int:
     check("note names Planck mass scale reference", "a^{-1} = M_Pl" in note)
     check("note says units conversion not physics axiom", "This is a units conversion, not a physics axiom." in note)
     check("note says zero dimensionless content", "It carries zero dimensionless\ncontent" in note)
-    check("note says scale is irreducible by dimensional analysis", "irreducible by dimensional analysis" in note)
+    check("note disclaims deriving the chosen physical scale", "No derivation of the chosen\nphysical scale is claimed here" in note)
     check("note says it does not add or amend an axiom", "It does not add or amend an axiom." in note)
     check("note says it does not assert a/l_P = 1 as derived", "It does not assert `a/l_P = 1` as a derived theorem." in note)
     check("note says it does not supply dimensionless quantity", "It does not supply any dimensionless quantity." in note)


### PR DESCRIPTION
## Summary

`scripts/acphilambda_occupancy_formation_append_non_supply_no_go_2026_07_04.py` crashed on current main with `KeyError: 'staggered_dirac_realization_gate_note_2026-05-03'` and never printed its TOTAL line. Root cause: `docs/audit/data/tier_a_admissions.json` was reshaped by the 2026-07-05 retirements — and the reshape is bigger than "2 -> 1": the live registry now has `genuine_admitted_input_count: 0`, `canonical_ids: []`, `derivation_targets: {}`, with BOTH former entries (theta, retired by retained derivation; AC_phi_lambda, retired by owner governance) preserved intact under `retired_derivation_targets`.

This PR repairs the four runners whose failures trace to stale structural pins on that registry, regenerates their caches, and reports (without repairing) the runners whose failures are genuine live-content drift.

## Repair precedent

The gate shape used here (count == 0, live targets empty, entries preserved under `retired_derivation_targets`, exact retirement-mechanism string) is the shape already carried by the landed post-retirement runners on main. Repointing a stale structural pin to the current registry truth is the TIMELESS-GATES repair class; it is not a gate weakening — every replacement below is an exact-value equality or exact-phrase pin that fails if the registry or notes regress.

## Repaired (4 runners, 6 edit sites, honest re-runs)

1. **`acphilambda_occupancy_formation_append_non_supply_no_go_2026_07_04.py`** — was: crash (KeyError), no summary. Repointed the `ac` lookup to `retired_derivation_targets[...]` and replaced the single now-false liveness gate (`genuine_admitted_input_count >= 1`, "AC_phi_lambda remains the live Tier-A target") with three discriminating gates: live targets empty (`count == 0` AND `derivation_targets == {}` AND `canonical_ids == []`), AC entry preserved intact, and retirement mechanism exactly `retired_by_owner_governance_on_audited_surface`. The mechanism gate is consistent with the note's no-go claim (the July 4 formation append does not retire AC_phi_lambda(i) — owner governance did). All other section-B gates kept verbatim against the preserved entry; sections C–G untouched. Now: `TOTAL: PASS=122 FAIL=0 CHECKS=122`, exit 0.
2. **`scale_reference_primitive_boundary_check.py`** — was: `FAIL=2`. (a) count pin `== 2` -> `== 0` with honest label; (b) note-phrase pin "irreducible by dimensional analysis" -> the note's current review-approved sentence "No derivation of the chosen physical scale is claimed here" (review commit 5e9fa2b580 rewrote the note; the irreducibility concept remains gated by this runner's separate AXIOM_MINIMALITY_POLICY.md check, which still passes). Now: `SUMMARY: ... PASS=43 FAIL=0`.
3. **`audit_companion_minimal_axioms_clean_base_exact.py`** — was: `FAIL=1`. Count pin `== 2` -> `== 0` with honest label. Now: `TOTAL: PASS=68 FAIL=0`. The `audit_companion_three_axiom_clean_base_exact.py` compatibility wrapper runpy-executes this file and inherits the repair (re-run green, no edit needed).
4. **`primitive_retirement_review_after_four_axiom_reset_2026_07_05.py`** — was: `FAIL=4`. (a) Two kinetic-note phrase pins repointed to the current review-approved sentences ("`c_t = c_s` is supplied rather than derived"; "scale reference, and records' causal order" + "are not used here as a derivation of that equality") — same review commit 5e9fa2b580 rewrote that note. (b) Two hygiene diagnostics flipped: this runner is a debt tracker that asserted known drift STILL EXISTS (that the scale runner still carried its stale `== 2` pin; that primitive notes still carried pre-reset baseline narrative). Repairing the tracked files inverts the tracker, so the same PR flips both checks to assert the repaired state — still discriminating (stale count string must be ABSENT and current gate PRESENT in the scale runner; the pre-reset-narrative regex still runs and must match nothing). Now: `TOTAL: PASS=61 FAIL=0`.

Caches for all four regenerated via `scripts/runner_cache.py` (`execute_runner` + `write_cache`).

## Reported, deliberately NOT repaired (genuine drift — repairing would weaken content gates)

- **`frontier_record_p1_dependency_audit_verifier.py` — `FAIL=7`.** It recomputes the live dependency graph against the frozen 2026-06-04 note claim. The graph moved: dependents 92 -> 101, pre-existing 91 -> 100, unaudited 81 -> 79, meta 10 -> 13; 3 dependents named in the note are no longer in the graph (`OBSERVABLE_PRINCIPLE_CONSUMED_SECTOR_BOUNDED_BY_AC_PHI_LAMBDA_NARROW_THEOREM_NOTE_2026-06-05.md`, `OBSERVABLE_PRINCIPLE_P1_BR_LICENSE_FROM_RECORD_CAPACITY_NARROW_NO_GO_NOTE_2026-06-10.md`, `OBSERVABLE_PRINCIPLE_P1_EXPONENT_BARRIER_PARAMETER_SELECTOR_NARROW_THEOREM_NOTE_2026-06-10.md`); 3 are new (`HIERARCHY_FORMULA_HONEST_STATUS_NOTE_2026-05-10.md`, `STAGGERED_DIRAC_GATE_CLOSURE_SYNTHESIS_THEOREM_NOTE_2026-05-17.md`, `docs/ai_methodology/raw/repo_audit.md`); REWRITE+SPLIT+LEAVE totals 91 vs n_direct = 100. These failures are the runner doing its job on a stale note claim. Runner and cache left untouched; reconciling the note is content work for the review/audit lanes.
- **`acphilambda_retirement_basis_rematch_claim_surface_2026_07_06.py` — `FAIL=2`.** Its gate "all 16 basis rows are retained-grade" is genuinely false on the live ledger: 7 rows are now non-retained (`acphilambda_occupancy_selection_realized_state_reduction_note_2026-06-11` unaudited, `koide_orbit_occupancy_independence_and_premise_candidate_note_2026-06-09` audited_failed, `acphilambda_r_eta_value_face_registered_angle_functional_exactness_relocation_note_2026-07-05` unaudited, `acphilambda_r_eta_readout_identification_narrowing_bounded_theorem_note_2026-06-11` unaudited, `acphilambda_r_eta_w2_registrability_context_bridge_note_2026-06-18` unaudited, `acphilambda_species_bridge_realized_state_decomposition_note_2026-06-11` unaudited, `charged_lepton_koide_value_full_chain_of_custody_2026-06-02` open_gate); the second failing gate is the custody-capstone structure/value split. Left failing per instruction ("if a gate genuinely fails now, let it fail"). Note: its cache in `logs/runner-cache/` is stale-green relative to this live FAIL=2 — flagged here, not regenerated, since regenerating a red cache for an unrepaired runner would change the recorded state without a repair.
- **`tier_a_residual_owner_adoption_retirement_2026_07_04.py` — false alarm.** It is green (`RESULT: PASS=68 FAIL=0 CHECKS=68`); the original sweep grepped only for "TOTAL" and missed its `RESULT:` summary format.

## Note-staleness observations (report only — no note edited here)

- The acphilambda append note's N4 sentence says `reading_occupancy_selection` "remains in the live minimum decomposition" — stale against the reshaped registry (the decomposition is preserved under the retired entry, not live).
- The primitive-retirement review note's "Current-main posture (2026-07-06)" section describes the pre-repair hygiene state (it records the scale-runner stale pin as open debt); after this PR that recorded debt is discharged. Both are dated content matters for the review/audit lanes.

## Blast radius

- `acphilambda_occupancy_formation_append...` pairs row `acphilambda_occupancy_formation_append_non_supply_no_go_note_2026-07-04` (audited_conditional, no_go, zero reverse deps). This runner edit re-opens that one row via deps_changed — disclosed and unavoidable: the runner crashed outright.
- `scale_reference_primitive_boundary_check.py` pairs no ledger row (zero audit blast radius).
- `audit_companion_minimal_axioms...` pairs `minimal_axioms` (meta); `primitive_retirement_review...` pairs its note row (unaudited, meta); the untouched rematch runner pairs its note row (unaudited, meta).

## Boundary

No note's audit-status language was edited; no audit grade authored or predicted. No gate weakened: every repaired check is an exact-value/exact-phrase pin against current truth, and genuinely failing runners were left failing and reported. Sibling re-runs in the edited tree: `admitted_input_registry_tier_a_boundary_check.py` PASS=59 FAIL=0, `tier_a_residual_owner_adoption_retirement_2026_07_04.py` PASS=68 FAIL=0, three-axiom wrapper PASS=68 FAIL=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
