### PR TITLE
[physics-loop] universal-qg optional textbook meta closure — exact support

### DIFF
--- a/docs/UNIVERSAL_QG_OPTIONAL_TEXTBOOK_COMPARISON_NOTE.md
+++ b/docs/UNIVERSAL_QG_OPTIONAL_TEXTBOOK_COMPARISON_NOTE.md
@@ -61,8 +61,10 @@ geometric-action, or textbook-equivalence theorem.
 
 ### Finite closure certificate
 
-Let `N` be this source file and let `D` be the finite set of current markdown
-files under `docs/`, excluding audit-history artifacts. Define:
+Let `N` be this source file and let `D` be the finite set of current Markdown
+files under `docs/`, excluding `N` itself and the entire `docs/audit/` subtree.
+That subtree contains audit infrastructure, generated audit surfaces, and
+audit history rather than current dependent claim notes. Define:
 
 - `S(N)` to mean that `N` satisfies the source-local guards `Z0`-`Z4`;
 - `I(N,D)` to mean that every current inbound occurrence of this filename in

--- a/docs/UNIVERSAL_QG_OPTIONAL_TEXTBOOK_COMPARISON_NOTE.md
+++ b/docs/UNIVERSAL_QG_OPTIONAL_TEXTBOOK_COMPARISON_NOTE.md
@@ -1,7 +1,8 @@
 # Universal QG Optional Textbook Comparison Note
 
 **Date:** 2026-04-15 (originally); 2026-05-05 (meta retag for re-seed);
-2026-05-06 (zero-authority runner closure)
+2026-05-06 (zero-authority runner closure); 2026-07-10 (finite-predicate
+closure)
 **Type:** meta
 **Status:** audit-checkable packaging hub for optional textbook-comparison
 crosswalks against the universal-QG canonical textbook closure target.
@@ -9,6 +10,10 @@ crosswalks against the universal-QG canonical textbook closure target.
 **Authority role:** zero — this row exists only to anchor a citation hub
 for downstream universal-QG notes that need a stable target for "optional
 textbook comparison" callouts.
+**Audit target:** the finite repository predicate `Z := Z0 AND ... AND Z5`
+below, and no scientific proposition.
+**Status authority:** independent audit lane only; the runner supplies a
+repository-state certificate, not an audit verdict.
 **Primary runner:** `scripts/universal_qg_optional_textbook_comparison_meta_check.py`
 **Runner cache:** `logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt`
 
@@ -41,8 +46,11 @@ invariant, not a continuum theorem:
 - `Z3`: this note has no markdown links to other docs, so it registers no
   upstream theorem dependency edge for itself; cross-references below are
   code-span filenames for navigation only.
-- `Z4`: every substantive textbook-comparison result is forced out to its
-  own claim row with its own load-bearing step, runner, and audit.
+- `Z4`: the complete packaging-only source body is SHA-pinned by the runner;
+  in that pinned body every substantive textbook-comparison result is forced
+  out to its own claim row with its own load-bearing step, runner, and audit.
+  Any source change invalidates the pin until the source and runner are
+  reviewed together and the cache is refreshed.
 - `Z5`: current inbound mentions of this filename are guarded as optional
   packaging callouts rather than load-bearing theorem authority.
 
@@ -51,11 +59,35 @@ passing run certifies only this zero-authority metadata guard. It does not
 certify, import, or strengthen any universal-QG continuum, weak-measure,
 geometric-action, or textbook-equivalence theorem.
 
+### Finite closure certificate
+
+Let `N` be this source file and let `D` be the finite set of current markdown
+files under `docs/`, excluding audit-history artifacts. Define:
+
+- `S(N)` to mean that `N` satisfies the source-local guards `Z0`-`Z4`;
+- `I(N,D)` to mean that every current inbound occurrence of this filename in
+  `D` has both an optional-comparison marker and an explicit non-authority /
+  packaging guard; and
+- `Z(N,D) := S(N) AND I(N,D)`.
+
+The runner reads and SHA-pins all of `N`, enumerates `D`, and evaluates every
+conjunct in this definition. Therefore a passing run closes `Z(N,D)` for the
+checked checkout by finite inspection. This exhaustiveness is the entire
+derivation burden of this meta row. It neither assumes nor establishes the
+truth, completeness, or audit grade of any physics note named below.
+
+The certificate is falsified if any source-local guard fails, if this note
+acquires a markdown dependency edge, or if any current inbound occurrence is
+not explicitly optional and non-authoritative. Any edit to this source,
+including a substantive textbook comparison added here, invalidates the `Z4`
+source pin; such a comparison must be moved to its own claim row before a
+reviewer refreshes this metadata certificate.
+
 ## 2. What this note is for
 
-The canonical textbook continuum target for the universal-QG family is
-already handled on the project route by the theorem chain listed in §4 below.
-This note is a packaging hub providing a stable citation target for downstream
+The phrase "canonical textbook continuum target" is a navigation label here,
+not a statement about that target's truth, completeness, or audit grade. This
+note is a packaging hub providing a stable citation target for downstream
 universal-QG notes that need a named row to attach optional-comparison callouts
 to:
 
@@ -71,12 +103,12 @@ above. It is infrastructure metadata for the universal-QG citation graph.
 
 This note **must not** be used to:
 
-- reopen, weaken, or extend the closed universal-QG theorem stack;
+- assign, change, or extend the status of the universal-QG theorem stack;
 - introduce a new "comparison" claim that the audit lane would have to
   ratify;
 - act as a one-hop authority for any downstream theorem;
-- substitute for the actual closed canonical textbook continuum closure
-  parent.
+- substitute for the claim row that supplies the canonical textbook continuum
+  closure.
 
 If a universal-QG downstream note needs a *substantive* textbook-comparison
 result, that must live in its own claim row with its own load-bearing
@@ -84,9 +116,9 @@ step, runner, and independent audit review — not here.
 
 ## 4. Cross-references (informational only)
 
-The universal-QG canonical textbook closure parent and sibling theorems are
+The universal-QG canonical textbook closure parent and sibling claim rows are
 not load-bearing for this meta packaging note. They are listed here only so a
-reader landing on this row by citation can navigate to the actual derivations:
+reader landing on this row by citation can navigate to the substantive rows:
 
 - `UNIVERSAL_QG_CANONICAL_TEXTBOOK_CONTINUUM_GR_CLOSURE_NOTE.md`
 - `UNIVERSAL_QG_CANONICAL_SMOOTH_GRAVITATIONAL_WEAK_MEASURE_NOTE.md`
@@ -94,4 +126,5 @@ reader landing on this row by citation can navigate to the actual derivations:
 - `UNIVERSAL_QG_CANONICAL_TEXTBOOK_WEAK_MEASURE_EQUIVALENCE_NOTE.md`
 - `UNIVERSAL_QG_CONTINUUM_BRIDGE_REDUCTION_NOTE.md`
 
-These are the actual claim rows. This note is *not* one of them.
+These are the substantive claim rows. This note is *not* one of them, and its
+metadata certificate does not assign any grade to them.

--- a/logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt
+++ b/logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt
@@ -1,16 +1,16 @@
 ===== runner cache v1 =====
 runner: scripts/universal_qg_optional_textbook_comparison_meta_check.py
-runner_sha256: 286dfce08688326981e9cd56dac8ad23799f54ef2a1acb0f6a5e673d6269da44
+runner_sha256: 1277e3dcf94291d1c2ad5dc554f2f5ac20ff05ba66a85c71bae8fb46639df3aa
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.25
+elapsed_sec: 0.49
 status: ok
 ----- stdout -----
 ========================================================================
 UNIVERSAL QG OPTIONAL TEXTBOOK COMPARISON META CHECK
 ========================================================================
 [PASS (A)] note title is the expected optional textbook comparison note: docs/UNIVERSAL_QG_OPTIONAL_TEXTBOOK_COMPARISON_NOTE.md
-[PASS (A)] Source note matches the reviewed byte-for-byte predicate surface: 3c80bb709d12151857e95375720b64f31f7977a14f8a1f98850c56ebecc2e591
+[PASS (A)] Source note matches the reviewed byte-for-byte predicate surface: c55da42c9bd275697d8d5cc94272b24efe28a9c3ae494ac07adcd7ad40afabee
 [PASS (A)] Type field is exactly meta: meta
 [PASS (A)] Status field negates theorem, claim, and new authority roles: audit-checkable packaging hub for optional textbook-comparison crosswalks against the universal-QG canonical textbook closure target. **Not** a theorem, claim, or new authority surface.
 [PASS (A)] Authority role is zero: zero — this row exists only to anchor a citation hub for downstream universal-QG notes that need a stable target for "optional textbook comparison" callouts.

--- a/logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt
+++ b/logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt
@@ -1,28 +1,35 @@
 ===== runner cache v1 =====
 runner: scripts/universal_qg_optional_textbook_comparison_meta_check.py
-runner_sha256: 3fbdece80a784fc3782f9ceb4c99d9fcf9ffdf6fc59feb051c482cdbfb0b31db
+runner_sha256: 286dfce08688326981e9cd56dac8ad23799f54ef2a1acb0f6a5e673d6269da44
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.61
+elapsed_sec: 0.25
 status: ok
 ----- stdout -----
 ========================================================================
 UNIVERSAL QG OPTIONAL TEXTBOOK COMPARISON META CHECK
 ========================================================================
 [PASS (A)] note title is the expected optional textbook comparison note: docs/UNIVERSAL_QG_OPTIONAL_TEXTBOOK_COMPARISON_NOTE.md
+[PASS (A)] Source note matches the reviewed byte-for-byte predicate surface: 3c80bb709d12151857e95375720b64f31f7977a14f8a1f98850c56ebecc2e591
 [PASS (A)] Type field is exactly meta: meta
 [PASS (A)] Status field negates theorem, claim, and new authority roles: audit-checkable packaging hub for optional textbook-comparison crosswalks against the universal-QG canonical textbook closure target. **Not** a theorem, claim, or new authority surface.
 [PASS (A)] Authority role is zero: zero — this row exists only to anchor a citation hub for downstream universal-QG notes that need a stable target for "optional textbook comparison" callouts.
+[PASS (A)] Audit target is the finite Z0-Z5 repository predicate only: the finite repository predicate `Z := Z0 AND ... AND Z5` below, and no scientific proposition.
+[PASS (A)] Status authority remains with the independent audit lane: independent audit lane only; the runner supplies a repository-state certificate, not an audit verdict.
 [PASS (A)] Primary runner points to this replay script: `scripts/universal_qg_optional_textbook_comparison_meta_check.py`
 [PASS (A)] Runner cache points to the cached replay transcript: `logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt`
 [PASS (A)] Audit-readiness metadata repair preserves zero-authority scope: source-side cache metadata is not a status promotion
+[PASS (A)] Z0-Z5 are each declared exactly once: 0,1,2,3,4,5
+[PASS (A)] Finite closure certificate defines source and inbound predicates: Z(N,D) source/inbound conjunction
+[PASS (A)] Finite certificate disclaims all physics-grade implications: physics and audit-grade firewall present
+[PASS (A)] Finite certificate states executable falsifiers: source pin, edge, inbound-context, and Z4 falsifiers present
 [PASS (A)] Source note has no markdown links to other docs: none
 [PASS (A)] Source note has no authority-style Citations section: Citations heading absent
 [PASS (A)] Informational cross-reference rows exist as separate claim files: all present as code spans
 [PASS (A)] Own-row substantive comparison firewall is explicit: claim-row firewall present
 [PASS (B)] Inbound mentions are guarded as optional packaging callouts: 21 mentions checked
 ------------------------------------------------------------------------
-SUMMARY: PASS A=11 B=1 C=0 D=0 total_pass=12
+SUMMARY: PASS A=18 B=1 C=0 D=0 total_pass=19
 
 ----- stderr -----
 

--- a/scripts/universal_qg_optional_textbook_comparison_meta_check.py
+++ b/scripts/universal_qg_optional_textbook_comparison_meta_check.py
@@ -8,6 +8,7 @@ elsewhere only in explicitly optional/packaging contexts.
 """
 from __future__ import annotations
 
+import hashlib
 import math
 import re
 import sys
@@ -21,6 +22,7 @@ NOTE_PATH = REPO_ROOT / NOTE_REL
 RUNNER_REL = Path("scripts/universal_qg_optional_textbook_comparison_meta_check.py")
 CACHE_REL = Path("logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt")
 TARGET_NAME = NOTE_REL.name
+EXPECTED_NOTE_SHA256 = "3c80bb709d12151857e95375720b64f31f7977a14f8a1f98850c56ebecc2e591"
 DOC_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)\s#]+\.md)(?:#[^)]*)?\)")
 
 
@@ -35,6 +37,10 @@ class CheckResult:
 def read(path: Path) -> str:
     with path.open(encoding="utf-8") as handle:
         return handle.read()
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def field(body: str, name: str) -> str:
@@ -96,10 +102,13 @@ def inbound_optional_contexts() -> tuple[bool, int, list[str]]:
 def main() -> int:
     body = read(NOTE_PATH)
     normalized_body = " ".join(body.split())
+    predicate_text = normalized_body.replace("`", "")
     results: list[CheckResult] = []
 
     status = field(body, "Status")
     authority = field(body, "Authority role")
+    audit_target = field(body, "Audit target")
+    status_authority = field(body, "Status authority")
     primary_runner = field(body, "Primary runner")
     runner_cache = field(body, "Runner cache")
 
@@ -109,6 +118,14 @@ def main() -> int:
         "A",
         body.startswith("# Universal QG Optional Textbook Comparison Note\n"),
         str(NOTE_REL),
+    )
+    note_sha = sha256(NOTE_PATH)
+    add(
+        results,
+        "Source note matches the reviewed byte-for-byte predicate surface",
+        "A",
+        note_sha == EXPECTED_NOTE_SHA256,
+        note_sha,
     )
     add(
         results,
@@ -121,7 +138,12 @@ def main() -> int:
         results,
         "Status field negates theorem, claim, and new authority roles",
         "A",
-        all(token in status.lower() for token in ("not", "theorem", "claim", "new authority surface")),
+        re.search(
+            r"\*\*not\*\*\s+a theorem,\s*claim,\s*or new authority surface",
+            status,
+            re.IGNORECASE,
+        )
+        is not None,
         status or "missing",
     )
     add(
@@ -130,6 +152,24 @@ def main() -> int:
         "A",
         authority.lower().startswith("zero"),
         authority or "missing",
+    )
+    add(
+        results,
+        "Audit target is the finite Z0-Z5 repository predicate only",
+        "A",
+        "finite repository predicate" in audit_target.lower()
+        and "z := z0 and ... and z5" in audit_target.lower()
+        and "no scientific proposition" in audit_target.lower(),
+        audit_target or "missing",
+    )
+    add(
+        results,
+        "Status authority remains with the independent audit lane",
+        "A",
+        "independent audit lane only" in status_authority.lower()
+        and "repository-state certificate" in status_authority.lower()
+        and "not an audit verdict" in status_authority.lower(),
+        status_authority or "missing",
     )
     add(
         results,
@@ -152,6 +192,48 @@ def main() -> int:
         "does not change this row's zero-authority role" in normalized_body
         and "does not assert an audit outcome" in normalized_body,
         "source-side cache metadata is not a status promotion",
+    )
+    z_labels = re.findall(r"^- `Z([0-5])`:", body, re.MULTILINE)
+    add(
+        results,
+        "Z0-Z5 are each declared exactly once",
+        "A",
+        z_labels == ["0", "1", "2", "3", "4", "5"],
+        ",".join(z_labels) or "missing",
+    )
+    add(
+        results,
+        "Finite closure certificate defines source and inbound predicates",
+        "A",
+        all(
+            marker in predicate_text
+            for marker in (
+                "S(N) to mean that N satisfies the source-local guards Z0-Z4",
+                "I(N,D) to mean that every current inbound occurrence",
+                "Z(N,D) := S(N) AND I(N,D)",
+                "a passing run closes Z(N,D) for the checked checkout by finite inspection",
+            )
+        ),
+        "Z(N,D) source/inbound conjunction",
+    )
+    add(
+        results,
+        "Finite certificate disclaims all physics-grade implications",
+        "A",
+        "neither assumes nor establishes the truth, completeness, or audit grade"
+        in predicate_text
+        and "metadata certificate does not assign any grade" in predicate_text,
+        "physics and audit-grade firewall present",
+    )
+    add(
+        results,
+        "Finite certificate states executable falsifiers",
+        "A",
+        "certificate is falsified if any source-local guard fails" in predicate_text
+        and "acquires a markdown dependency edge" in predicate_text
+        and "Any edit to this source" in predicate_text
+        and "invalidates the Z4 source pin" in predicate_text,
+        "source pin, edge, inbound-context, and Z4 falsifiers present",
     )
     add(
         results,

--- a/scripts/universal_qg_optional_textbook_comparison_meta_check.py
+++ b/scripts/universal_qg_optional_textbook_comparison_meta_check.py
@@ -22,7 +22,7 @@ NOTE_PATH = REPO_ROOT / NOTE_REL
 RUNNER_REL = Path("scripts/universal_qg_optional_textbook_comparison_meta_check.py")
 CACHE_REL = Path("logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt")
 TARGET_NAME = NOTE_REL.name
-EXPECTED_NOTE_SHA256 = "3c80bb709d12151857e95375720b64f31f7977a14f8a1f98850c56ebecc2e591"
+EXPECTED_NOTE_SHA256 = "c55da42c9bd275697d8d5cc94272b24efe28a9c3ae494ac07adcd7ad40afabee"
 DOC_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)\s#]+\.md)(?:#[^)]*)?\)")
 
 
@@ -211,6 +211,7 @@ def main() -> int:
                 "S(N) to mean that N satisfies the source-local guards Z0-Z4",
                 "I(N,D) to mean that every current inbound occurrence",
                 "Z(N,D) := S(N) AND I(N,D)",
+                "excluding N itself and the entire docs/audit/ subtree",
                 "a passing run closes Z(N,D) for the checked checkout by finite inspection",
             )
         ),


### PR DESCRIPTION
## Scope

This PR hardens a standalone zero-authority metadata predicate. It does not repair, requeue, grade, or apply a verdict for a scientific audit row, and it does not derive or import the underlying universal-QG continuum physics.

## Source triple

- `docs/UNIVERSAL_QG_OPTIONAL_TEXTBOOK_COMPARISON_NOTE.md` defines the finite repository predicate `Z(N,D)` and explicit falsifiers.
- `scripts/universal_qg_optional_textbook_comparison_meta_check.py` SHA-pins the complete source body, enforces `Z0`-`Z5`, verifies zero outbound dependency edges, and checks every current inbound occurrence for optional/non-authority guards.
- `logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt` is the fresh paired cache.

Branch-local physics-loop state, handoff, and planning artifacts were stripped from the landing delta.

## Verification

- Metadata runner: `SUMMARY: PASS A=18 B=1 C=0 D=0 total_pass=19`, exit 0.
- Cache freshness check: PASS; runner SHA and stdout match.
- `py_compile`, vocabulary lint, and `git diff --check`: PASS.
- Pipeline/strict-lint validation: zero errors; generated audit/effective-status outputs are not submitted.

## Boundary

The target remains `Type: meta` with authority role zero. A passing run certifies only the checked checkout packaging invariant; it does not establish the truth, completeness, or grade of any substantive physics row named for navigation.