### PR TITLE
fix(single-clock-n2): wire minimal-axioms dependency edge

### DIFF
--- a/docs/SINGLE_CLOCK_BLOCKED_TIME_UNIT_SPLIT_N2_SUPPORT_NOTE_2026-06-17.md
+++ b/docs/SINGLE_CLOCK_BLOCKED_TIME_UNIT_SPLIT_N2_SUPPORT_NOTE_2026-06-17.md
@@ -13,7 +13,7 @@ undischarged absolute-unit premise.
 effective-status files, or publication status surfaces. Independent audit
 owns any effective verdict.
 **Primary runner:** [`scripts/single_clock_blocked_time_unit_split_n2_support_2026_06_17.py`](../scripts/single_clock_blocked_time_unit_split_n2_support_2026_06_17.py)
-(`TOTAL: PASS=35 FAIL=0`).
+(`TOTAL: PASS=37 FAIL=0`).
 
 ## Result
 
@@ -58,9 +58,16 @@ minimal axioms and outside Record alone.
   keeps Stone uniqueness transfer-relative and tau-relative; it does not let
   the transfer alone derive an absolute clock unit, axis uniqueness, or
   no-second-clock result.
-- **Minimal framework axioms.** `MINIMAL_AXIOMS_2026-06-05.md` states that
+- **Minimal framework axioms.**
+  [`MINIMAL_AXIOMS_2026-06-05.md`](MINIMAL_AXIOMS_2026-06-05.md) states that
   Lattice supplies no metric scale, lattice spacing, or physical unit
-  conversion, and Record supplies no time metric or dynamics.
+  conversion, and Record supplies no time metric or dynamics. This markdown
+  link is a load-bearing dependency edge (added 2026-07-10): the `2026-06-05`
+  path is an aliased path of the canonical `minimal_axioms` premise node in
+  `docs/audit/data/axiom_premise_nodes.json` (current path
+  `MINIMAL_AXIOMS_2026-06-29.md`), so the edge resolves to the live
+  minimal-axioms authority and its full text and effective status enter this
+  note's dependency packet.
 - **Post-record clock/rate boundary.**
   [`POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md`](POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md)
   proves that finite record histories determine event order and counts, not a
@@ -185,12 +192,14 @@ The runner checks:
 - tau-rescaling and dimensionless-transfer invariance;
 - post-record histories preserving words and counts under inequivalent clocks;
 - minimal-axiom and Record clock/rate no-go anchors;
+- the minimal-axioms markdown dependency edge and its aliased-path mapping to
+  the canonical `minimal_axioms` premise node;
 - no audit-ledger, audit-queue, effective-status, or publication-surface
   edits in the branch;
 - explicit boundaries that keep this support from becoming a status or audit
   verdict.
 
-Expected output: `TOTAL: PASS=35 FAIL=0`.
+Expected output: `TOTAL: PASS=37 FAIL=0`.
 
 ## Boundaries
 

--- a/logs/runner-cache/single_clock_blocked_time_unit_split_n2_support_2026_06_17.txt
+++ b/logs/runner-cache/single_clock_blocked_time_unit_split_n2_support_2026_06_17.txt
@@ -1,3 +1,11 @@
+===== runner cache v1 =====
+runner: scripts/single_clock_blocked_time_unit_split_n2_support_2026_06_17.py
+runner_sha256: 4b54bb3dc73e6337b2d73cce17ea9b7708441ccfdf1998994604ff8f796a0c61
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
 ==============================================================================
 SINGLE-CLOCK B-AXIS.1 BLOCKED-TIME UNIT SPLIT CHECK
 ==============================================================================
@@ -13,6 +21,8 @@ SINGLE-CLOCK B-AXIS.1 BLOCKED-TIME UNIT SPLIT CHECK
   [PASS] SC2 bridge forbids physical mass/unit overread
   [PASS] minimal Lattice excludes metric scale/lattice spacing/unit conversion
   [PASS] minimal Record excludes time metric/dynamics/probability
+  [PASS] note wires MINIMAL_AXIOMS_2026-06-05 as a markdown dependency edge
+  [PASS] linked 2026-06-05 path aliases the canonical minimal_axioms premise node
   [PASS] post-record interface says counts do not supply clock metric
   [PASS] post-record interface supports rates only with supplied clock map
   [PASS] record rate gate separates stable dial from physical rate unit
@@ -48,5 +58,8 @@ SINGLE-CLOCK B-AXIS.1 BLOCKED-TIME UNIT SPLIT CHECK
   [PASS] note explicitly says no audit-surface update
 
 ==============================================================================
-TOTAL: PASS=35 FAIL=0
+TOTAL: PASS=37 FAIL=0
 ==============================================================================
+
+----- stderr -----
+

--- a/scripts/single_clock_blocked_time_unit_split_n2_support_2026_06_17.py
+++ b/scripts/single_clock_blocked_time_unit_split_n2_support_2026_06_17.py
@@ -8,11 +8,16 @@ This runner certifies a narrow source-side repair:
 * The absolute physical clock/rate unit carried by a_tau is still not derived
   by minimal Lattice/Quantum/Record, by Record counts, or by the transfer
   spectrum alone.
+* The note wires MINIMAL_AXIOMS_2026-06-05.md as a markdown dependency edge
+  (2026-07-10 repair); that path is an aliased path of the canonical
+  minimal_axioms premise node, so the edge resolves to the live axiom
+  authority.
 
 It intentionally does not apply audit verdicts or edit audit surfaces.
 """
 from __future__ import annotations
 
+import json
 import math
 from pathlib import Path
 
@@ -26,6 +31,7 @@ SC2 = ROOT / "docs" / "AXIOM_FIRST_SPECTRUM_CONDITION_BLOCKED_TIME_NORMALIZATION
 MIN_AX = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-05.md"
 POST_RECORD = ROOT / "docs" / "POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md"
 RECORD_GATE = ROOT / "docs" / "RECORD_CLOCK_RATE_NORMALIZATION_GATE_2026-06-06.md"
+PREMISE_NODES = ROOT / "docs" / "audit" / "data" / "axiom_premise_nodes.json"
 
 PASS = 0
 FAIL = 0
@@ -77,6 +83,9 @@ def block_text_anchors() -> None:
     record("SC2 bridge forbids physical mass/unit overread", "No physical mass" in sc2 and "free construction parameters" in sc2)
     record("minimal Lattice excludes metric scale/lattice spacing/unit conversion", "metric scale" in min_ax and "lattice spacing" in min_ax and "physical unit conversion" in min_ax)
     record("minimal Record excludes time metric/dynamics/probability", "time metric" in min_ax and "dynamics" in min_ax and "probability" in min_ax)
+    record("note wires MINIMAL_AXIOMS_2026-06-05 as a markdown dependency edge", "[`MINIMAL_AXIOMS_2026-06-05.md`](MINIMAL_AXIOMS_2026-06-05.md)" in note)
+    min_ax_node = json.loads(read(PREMISE_NODES))["nodes"]["minimal_axioms"]
+    record("linked 2026-06-05 path aliases the canonical minimal_axioms premise node", MIN_AX.relative_to(ROOT).as_posix() in min_ax_node["aliased_paths"] and (ROOT / min_ax_node["current_path"]).exists())
     record("post-record interface says counts do not supply clock metric", "does not supply physical elapsed time" in post and "clock metric" in post)
     record("post-record interface supports rates only with supplied clock map", "supplied clock map" in post and "conditional on the clock map" in post)
     record("record rate gate separates stable dial from physical rate unit", "physical rate claim" in gate and "clock/rate unit" in gate)


### PR DESCRIPTION
## Summary

Repairs the `missing_dependency_edge` verdict on the single-clock n2 support row (`docs/SINGLE_CLOCK_BLOCKED_TIME_UNIT_SPLIT_N2_SUPPORT_NOTE_2026-06-17.md`).

**Verdict being repaired (notes_for_re_audit, quoted):**
> missing_dependency_edge: add a load-bearing dependency edge to docs/MINIMAL_AXIOMS_2026-06-05.md so its full text and effective status enter the restricted packet, then re-audit the framework-wide N2b conclusion.

The verdict's issue: the note's framework-wide N2b conclusion consumes `MINIMAL_AXIOMS_2026-06-05.md` exclusion clauses, but the Inputs reference was backticked — context only, no ledger dependency edge — so the minimal-axioms authority never entered the row's restricted packet.

## Changes

- **Note** — the Inputs reference to `MINIMAL_AXIOMS_2026-06-05.md` is converted from a backticked name to a markdown link (= a load-bearing ledger dependency edge), with an explanation of the alias mechanism: per `docs/audit/data/axiom_premise_nodes.json`, the `2026-06-05` path is an aliased path of the canonical `minimal_axioms` premise node (current path `MINIMAL_AXIOMS_2026-06-29.md`), so `build_citation_graph.py` canonicalizes the edge to the live axiom authority and its full text and effective status enter the packet. Exactly one new edge is added; `MINIMAL_AXIOMS_2026-06-29.md` stays backticked. Runner totals updated 35→37 in both places; one new Validation bullet.
- **Runner** (`scripts/single_clock_blocked_time_unit_split_n2_support_2026_06_17.py`) — two new discriminating checks: (a) the markdown-link edge is present in the note (fails on the old backticked form); (b) the linked `2026-06-05` path appears in the `aliased_paths` of the canonical `minimal_axioms` node and the node's `current_path` exists. `MIN_AX` deliberately stays pinned to the 06-05 text because the runner's exact exclusion-phrase anchors ("metric scale", "lattice spacing", "physical unit conversion") live only there; the alias check certifies that this path resolves to the live authority.
- **Cache** (`logs/runner-cache/single_clock_blocked_time_unit_split_n2_support_2026_06_17.txt`) — regenerated via `scripts/runner_cache.py`.

Source-only triple: 1 note + 1 runner + 1 cache. No audit surfaces touched; the note-hash drift re-enters the row for independent re-audit, which is the verdict's own repair mechanism.

## Verification

- Paired runner re-run: `TOTAL: PASS=37 FAIL=0` (was 35), exit 0.
- Parent sibling runner `scripts/axiom_first_single_clock_codimension1_evolution_check.py` re-run: `TOTAL: PASS=47 FAIL=0` (unchanged).
- Sibling-runner grep for the note basename: only the paired runner and the parent runner reference it; both pass post-edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)