### PR TITLE
[physics-loop] universal-QG optional textbook meta closure — exact-support

### DIFF
--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/ARTIFACT_PLAN.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/ARTIFACT_PLAN.md
@@ -1,0 +1,9 @@
+# Artifact Plan
+
+1. State the exact audit target as `Z0`-`Z5`, not a physics theorem.
+2. Define `Z(N,D) = S(N) AND I(N,D)` and list executable falsifiers.
+3. Tighten the runner to check the target, status-authority firewall,
+   predicate definition, six labels, disclaimers, and falsifiers.
+4. Refresh the SHA-pinned runner cache.
+5. Run the review milestone and audit compatibility checks.
+

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/ASSUMPTIONS_AND_IMPORTS.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/ASSUMPTIONS_AND_IMPORTS.md
@@ -1,0 +1,26 @@
+# Assumptions And Imports
+
+| Item | Role in claim | Current class | Source surface | Load-bearing? | Needed for target status? | Retirement path | Disposition |
+|---|---|---|---|:---:|:---:|---|---|
+| Target note text | Defines the finite source-local predicate | zero-input structural | `docs/UNIVERSAL_QG_OPTIONAL_TEXTBOOK_COMPARISON_NOTE.md` | yes | yes | Direct finite inspection | checked by runner |
+| Current markdown corpus under `docs/` | Finite domain for inbound-reference enumeration | zero-input structural | current checkout | yes | yes | Exhaustive filesystem enumeration | checked by runner |
+| Audit-history exclusion | Prevents archived audit prose from being treated as a current dependent | admitted normalization | runner scope | yes | yes | Keep exclusion explicit and narrow | accepted for metadata-only scope |
+| Canonical textbook physics rows | Navigation names only | support-only | code-span filenames in target note | no | no | None required; they carry no edge here | excluded from proof inputs |
+| External literature or observed values | No role | unsupported import | none | no | no | not applicable | absent |
+
+No physics theorem, fitted value, observation, or literature statement is a
+proof input to the finite metadata predicate.
+
+## Counterfactual pass
+
+| Implicit choice | What if it is wrong? | Direction opened | Effect on this block |
+|---|---|---|---|
+| `docs/` is the current dependent-note domain | A consumer outside `docs/` could exist | Widen a future repository-policy scanner | No current audit dependency edge is hidden; the audit graph is built from markdown notes under `docs/` |
+| `docs/audit/` is history rather than a current dependent | Archived prompts necessarily repeat the filename without packaging guards | Treat audit history as evidence input | Rejected for this predicate because it would make history self-referential; the exclusion is explicit |
+| Optional/non-authority context can be recognized syntactically | A future citation could use novel wording | Extend `context_guard` with the new native phrase before landing that citation | Runner fails closed on unrecognized current contexts |
+| Code-span filenames are navigation, not dependency edges | The graph builder could later change its link semantics | Revisit `Z3` against the updated parser | Current graph policy treats markdown links as edges; the runner directly enforces the present syntax |
+| The named comparison rows exist | One could be renamed or removed | Update the navigation inventory without granting authority | Runner fails until the informational list and files agree |
+
+None of these counterfactuals opens a physics theorem route or requires a new
+axiom/primitive. They only change the finite repository domain or parser
+contract and therefore remain tooling-level maintenance paths.

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/CLAIM_STATUS_CERTIFICATE.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/CLAIM_STATUS_CERTIFICATE.md
@@ -1,0 +1,39 @@
+---
+actual_current_surface_status: exact-support
+target_claim_type: meta
+trace_class: direct_blocker_closure
+reachability_to_target: closes
+conditional_surface_status: null
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "The artifact certifies a zero-authority metadata predicate and carries no scientific proposition a dependent may consume as evidence."
+audit_required_before_effective_retained: false
+bare_retained_allowed: false
+dependency_classes:
+  - zero-input structural
+  - admitted normalization
+open_imports: []
+review_loop_disposition: pass
+---
+
+# Claim Status Certificate
+
+The exact-support label applies only to `Z(N,D)`, the finite metadata
+predicate. The correct repo-facing class remains `meta`; meta rows are
+non-claim infrastructure and do not acquire a physics effective status.
+
+There are no load-bearing physics dependencies, fitted inputs, observed
+targets, literature values, or admitted unit conventions. Independent audit
+or re-seeding still owns the ledger classification; this certificate does not
+pre-fill an audit result.
+
+The `admitted normalization` dependency class above refers only to excluding
+audit-history markdown from the current-dependent corpus. It is not a physics
+premise, convention, or source of bounded scientific status.
+
+Pipeline validation re-seeds the row with claim type `meta`, leaves its audit
+field unaudited, derives effective status `meta`, and records `deps: []`. The
+row is correctly absent from the audit queue because repository policy does
+not queue meta rows.
+Accordingly, no retained-grade physics outcome is available or requested by
+this certificate.

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/GOAL.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/GOAL.md
@@ -1,0 +1,10 @@
+# Goal
+
+Close the auditor-quoted packaging boundary for
+`universal_qg_optional_textbook_comparison_note` as a finite repository-state
+predicate. The block must make the source-local and inbound-reference guards
+explicit, executable, and falsifiable without turning the row into a physics
+theorem or assigning an audit verdict.
+
+The underlying canonical textbook continuum closure is outside this block.
+

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/HANDOFF.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/HANDOFF.md
@@ -35,10 +35,13 @@ its content and the auditor's quoted scope.
 ## Delivery
 
 - Branch: `claude/science-fix/universal_qg_optional_textbook_comparison_note-447cbd9f`
-- Commit: pending.
-- Pull request: pending.
+- Science block commit: `9c43bce4677d3fbb474166be52ebad88d14d3c13`.
+- Pull request: [#5118](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5118).
+- PR verification: open, non-draft, mergeable; audit-lane CI queued at the
+  delivery checkpoint.
 
 ## Next exact action
 
-Commit the reviewed block, push the dedicated branch, and open/verify its
-review PR. Independent audit authority remains unchanged.
+Allow PR #5118 CI and independent reviewers to evaluate the exact metadata-
+support block. Independent audit authority remains unchanged; do not apply a
+verdict from this branch.

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/HANDOFF.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/HANDOFF.md
@@ -1,0 +1,44 @@
+# Handoff
+
+## Current result
+
+The target note now expresses its only auditable burden as the finite
+predicate `Z(N,D)`. The paired runner checks the complete declared predicate
+and its falsifiers while preserving the physics and audit-status firewalls.
+
+## Honest boundary
+
+This closes only the packaging invariant quoted by the auditor. It says
+nothing about whether the universal-QG canonical textbook continuum chain is
+true, complete, or independently clean.
+
+## Verification
+
+- Direct runner: `SUMMARY: PASS A=18 B=1 C=0 D=0 total_pass=19`.
+- Independent replay: source SHA matches; labels `Z0`-`Z5` occur once; zero
+  outbound markdown edges; 12 inbound-reference lines guarded.
+- SHA-pinned cache: fresh, runner SHA
+  `286dfce08688326981e9cd56dac8ad23799f54ef2a1acb0f6a5e673d6269da44`.
+- Audit compatibility pipeline: pass. Target re-seeds as `meta / unaudited /
+  meta`, with `deps: []` and no audit-queue entry.
+- Strict audit lint: no errors (pre-existing unrelated warnings/notices only).
+- Review-loop disposition: `pass` after one source-pin fix and clean re-review.
+
+## Audit-policy consequence
+
+Meta rows are non-claim infrastructure and are not queued for audit. The
+honest closed state for this block is therefore exact support for `Z(N,D)` plus
+`effective_status: meta`, not a source-authored or retained-grade physics
+verdict. Retyping this row merely to obtain a theorem verdict would contradict
+its content and the auditor's quoted scope.
+
+## Delivery
+
+- Branch: `claude/science-fix/universal_qg_optional_textbook_comparison_note-447cbd9f`
+- Commit: pending.
+- Pull request: pending.
+
+## Next exact action
+
+Commit the reviewed block, push the dedicated branch, and open/verify its
+review PR. Independent audit authority remains unchanged.

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/HANDOFF.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/HANDOFF.md
@@ -37,8 +37,8 @@ its content and the auditor's quoted scope.
 - Branch: `claude/science-fix/universal_qg_optional_textbook_comparison_note-447cbd9f`
 - Science block commit: `9c43bce4677d3fbb474166be52ebad88d14d3c13`.
 - Pull request: [#5118](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5118).
-- PR verification: open, non-draft, mergeable; audit-lane CI queued at the
-  delivery checkpoint.
+- PR verification after the delivery-metadata push: open, non-draft,
+  mergeable, and GitHub merge state `CLEAN`.
 
 ## Next exact action
 

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/LITERATURE_BRIDGES.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/LITERATURE_BRIDGES.md
@@ -1,0 +1,6 @@
+# Literature Bridges
+
+Literature review was not requested and is unnecessary. The target is a
+finite repository-state predicate, so there are no external theorem,
+normalization, or observational imports.
+

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/NO_GO_LEDGER.md
@@ -1,0 +1,10 @@
+# No-Go Ledger
+
+These are rejected packaging routes, not scientific no-go claims.
+
+| Route | Obstruction | Scope of obstruction | Consequence |
+|---|---|---|---|
+| Theorem retag | The source carries no scientific proposition and no physics derivation | this packaging row only | Retagging would launder metadata into authority |
+| One-hop physics citations | Markdown links would create dependencies and contradict the zero-authority invariant | this packaging row only | Keep navigation filenames as code spans |
+| Claiming continuum closure here | The auditor's scope excludes the underlying canonical closure | this block only | Physics grades remain wholly outside `Z(N,D)` |
+| Author-assigned audit result | Audit status belongs to an independent lane | all source-side edits | Runner pass is evidence, never a verdict |

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/OPPORTUNITY_QUEUE.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/OPPORTUNITY_QUEUE.md
@@ -1,0 +1,14 @@
+# Opportunity Queue
+
+This is a single-target, short science-fix block rather than a campaign.
+
+| Rank | Opportunity | Expected movement | Missing imports | Runner | Review landability | State |
+|---:|---|---|---:|:---:|:---:|---|
+| 1 | Finite `Z(N,D)` packaging-boundary certificate | direct closure of the quoted meta blocker | 0 | yes | high | executed |
+
+No unrelated science target is authorized by this prompt.
+
+The promotion value gate is not applicable: this block proposes no bounded-to-
+retained movement and no physics `claim_type`. Its value is the exact finite
+certificate requested by the quoted meta blocker, not a re-verification of a
+scientific identity.

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/PR_BACKLOG.md
@@ -2,5 +2,5 @@
 
 No delivery backlog remains. The reviewed branch is pushed and PR
 [#5118](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5118)
-is open and mergeable. Its audit-lane CI check was queued at the delivery
-checkpoint.
+is open, non-draft, mergeable, and reported GitHub merge state `CLEAN` after
+the delivery-metadata push.

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/PR_BACKLOG.md
@@ -1,4 +1,6 @@
 # PR Backlog
 
-No delivery failure has occurred. Branch push and PR creation are pending the
-reviewed block commit.
+No delivery backlog remains. The reviewed branch is pushed and PR
+[#5118](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5118)
+is open and mergeable. Its audit-lane CI check was queued at the delivery
+checkpoint.

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/PR_BACKLOG.md
@@ -1,0 +1,4 @@
+# PR Backlog
+
+No delivery failure has occurred. Branch push and PR creation are pending the
+reviewed block commit.

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/REVIEW_HISTORY.md
@@ -1,0 +1,54 @@
+# Review History
+
+## 2026-07-10 — iteration 1
+
+- `CodeRunnerReviewer`: **RISK**. The runner checked that the `Z4` firewall
+  sentence existed but an arbitrary source edit could add substantive content
+  without necessarily failing that semantic guard.
+- `PhysicsClaimReviewer`: **SUPPORT**. Correctly scoped as a meta predicate;
+  no physics theorem or continuum grade is supported.
+- `ImportSupportReviewer`: **CLEAN**. No measured, fitted, literature,
+  observational, normalization, or physics-convention imports.
+- `NatureRetentionReviewer`: **OPEN / not applicable to physics retention**.
+  The finite predicate is exact support for metadata only.
+- `NoGoDisciplineReviewer`: not applicable; rejected packaging routes are not
+  scientific no-go claims.
+- `LabelingConventionReviewer`: **PASS**. The row is already `meta`; no
+  labeling content is presented as a bounded theorem.
+- `RepoGovernanceReviewer`: **PASS after fix**. No authority edge or authored
+  verdict; the independent audit lane remains sovereign.
+
+Fix: SHA-pin the complete reviewed source note in the runner. Any source edit
+now fails closed until source, runner, and cache are reviewed together.
+
+## 2026-07-10 — iteration 2
+
+- `PhysicsClaimReviewer`: **FIX**. Section 3 still used legacy phrases
+  describing the external theorem stack and closure parent as already closed,
+  which exceeded this row's declared zero-authority scope.
+
+Fix: replace those phrases with status-neutral prohibitions against assigning
+or changing the stack's status and against substituting for the substantive
+claim row.
+
+## 2026-07-10 — iteration 3
+
+- `CodeRunnerReviewer`: **PASS**. Direct runner reports `PASS A=18 B=1`, and
+  an independent implementation confirms the SHA, six labels, zero outbound
+  markdown edges, and 12 guarded inbound-reference lines.
+- `PhysicsClaimReviewer`: **SUPPORT**. Scope remains exactly the packaging
+  invariant; the note explicitly disclaims grades for named physics rows.
+- `ImportSupportReviewer`: **CLEAN**.
+- `NatureRetentionReviewer`: **OPEN / not applicable to physics retention**.
+- `NoGoDisciplineReviewer`: **NOT APPLICABLE**.
+- `LabelingConventionReviewer`: **PASS**.
+- `RepoGovernanceReviewer`: **PASS**.
+- `Audit Compatibility`: **PASS**. Validation pipeline gives `claim_type:
+  meta`, leaves the audit field unaudited, derives effective status `meta`,
+  records `deps: []`, and attaches the fresh runner path and expected note
+  hash, with no target audit-queue entry.
+  Strict lint reports no errors; existing repository warnings/notices are
+  unrelated.
+
+Final local disposition: **pass**, with exact support limited to the finite
+metadata predicate.

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/ROUTE_PORTFOLIO.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/ROUTE_PORTFOLIO.md
@@ -1,0 +1,13 @@
+# Route Portfolio
+
+| Route | Claim-state movement | Trace | Import retirement | Review closure | Artifactability | Overclaim risk | Decision |
+|---|---:|---:|---:|---:|---:|---:|---|
+| Retag the row as a theorem and cite continuum authorities | 0 | 0 | 0 | 0 | 1 | -3 | rejected: contradicts the row's actual role |
+| Leave the disclaimer as prose only | 1 | 1 | 0 | 0 | 3 | -1 | rejected: repeats the audited definition-only state |
+| Define `Z(N,D)` and exhaustively replay it | 3 | 3 | 3 | 3 | 3 | 0 | selected |
+| Delete the row and rewrite all inbound navigation | 1 | 1 | 1 | 1 | 1 | -1 | rejected: unnecessary blast radius |
+
+The selected route converts the whole declared burden into a finite predicate
+with direct falsifiers. It does not attempt a hard physics residual because
+the audited scope explicitly excludes one.
+

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/STATE.yaml
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/STATE.yaml
@@ -20,6 +20,6 @@ no_go_routes:
   - physics-authority-import
 trace_gate_classification: direct_blocker_closure
 review_disposition: pass
-pr_status: pending
-next_exact_action: "Commit the reviewed block, push the dedicated branch, and open/verify its review PR."
+pr_status: "open: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5118"
+next_exact_action: "Allow PR #5118 CI and independent reviewers to evaluate the exact metadata-support block; do not apply an audit verdict from this branch."
 stop_condition: "The finite metadata predicate and cache pass, review disposition is pass, and delivery is packaged without a physics-status promotion."

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/STATE.yaml
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/STATE.yaml
@@ -1,0 +1,25 @@
+loop_slug: universal-qg-optional-textbook-meta-closure-20260710
+mode: run
+target_status: best-honest-status
+runtime_budget: "approximately 15 minutes, supplied by the science-fix prompt"
+cycle_count: 1
+block_count: 1
+active_route: finite-repository-predicate
+hard_residual: null
+actual_current_surface_status: exact-support
+trace_class: direct_blocker_closure
+reachability_to_target: closes
+files_touched:
+  - docs/UNIVERSAL_QG_OPTIONAL_TEXTBOOK_COMPARISON_NOTE.md
+  - scripts/universal_qg_optional_textbook_comparison_meta_check.py
+  - logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt
+  - .claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/
+open_imports: []
+no_go_routes:
+  - theorem-retag
+  - physics-authority-import
+trace_gate_classification: direct_blocker_closure
+review_disposition: pass
+pr_status: pending
+next_exact_action: "Commit the reviewed block, push the dedicated branch, and open/verify its review PR."
+stop_condition: "The finite metadata predicate and cache pass, review disposition is pass, and delivery is packaged without a physics-status promotion."

--- a/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/TRACE_GATE.md
+++ b/.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/TRACE_GATE.md
@@ -1,0 +1,18 @@
+---
+trace_class: direct_blocker_closure
+target_claim_id: universal_qg_optional_textbook_comparison_note
+target_blocker_text: "The load-bearing step is a definitional scope statement, not a first-principles computation or algebraic theorem. The note explicitly disclaims being a theorem, claim, or new authority surface, so the audit cannot ratify the seeded positive-theorem hint. With no cited authorities or runner, the only closed item is the packaging boundary itself."
+source_of_blocker_text: audit_ledger
+reachability_to_target: closes
+artifact_role: runner_certificate
+next_trace_action: "Re-seed the graph to confirm claim_type meta, deps=[], and the fresh runner attachment; no physics status is proposed."
+---
+
+The artifact reaches the exact audited object: the packaging boundary itself.
+It closes that narrow object by replacing a bare definition with an exhaustive
+finite predicate and a SHA-pinned replay. It does not reach, support, or grade
+the canonical textbook continuum closure.
+
+Pipeline validation performs that next trace action successfully. The meta row
+does not enter the audit queue; if a future auditor challenges its
+classification, only the independent audit lane may change it.

--- a/docs/UNIVERSAL_QG_OPTIONAL_TEXTBOOK_COMPARISON_NOTE.md
+++ b/docs/UNIVERSAL_QG_OPTIONAL_TEXTBOOK_COMPARISON_NOTE.md
@@ -1,7 +1,8 @@
 # Universal QG Optional Textbook Comparison Note
 
 **Date:** 2026-04-15 (originally); 2026-05-05 (meta retag for re-seed);
-2026-05-06 (zero-authority runner closure)
+2026-05-06 (zero-authority runner closure); 2026-07-10 (finite-predicate
+closure)
 **Type:** meta
 **Status:** audit-checkable packaging hub for optional textbook-comparison
 crosswalks against the universal-QG canonical textbook closure target.
@@ -9,6 +10,10 @@ crosswalks against the universal-QG canonical textbook closure target.
 **Authority role:** zero — this row exists only to anchor a citation hub
 for downstream universal-QG notes that need a stable target for "optional
 textbook comparison" callouts.
+**Audit target:** the finite repository predicate `Z := Z0 AND ... AND Z5`
+below, and no scientific proposition.
+**Status authority:** independent audit lane only; the runner supplies a
+repository-state certificate, not an audit verdict.
 **Primary runner:** `scripts/universal_qg_optional_textbook_comparison_meta_check.py`
 **Runner cache:** `logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt`
 
@@ -41,8 +46,11 @@ invariant, not a continuum theorem:
 - `Z3`: this note has no markdown links to other docs, so it registers no
   upstream theorem dependency edge for itself; cross-references below are
   code-span filenames for navigation only.
-- `Z4`: every substantive textbook-comparison result is forced out to its
-  own claim row with its own load-bearing step, runner, and audit.
+- `Z4`: the complete packaging-only source body is SHA-pinned by the runner;
+  in that pinned body every substantive textbook-comparison result is forced
+  out to its own claim row with its own load-bearing step, runner, and audit.
+  Any source change invalidates the pin until the source and runner are
+  reviewed together and the cache is refreshed.
 - `Z5`: current inbound mentions of this filename are guarded as optional
   packaging callouts rather than load-bearing theorem authority.
 
@@ -51,11 +59,35 @@ passing run certifies only this zero-authority metadata guard. It does not
 certify, import, or strengthen any universal-QG continuum, weak-measure,
 geometric-action, or textbook-equivalence theorem.
 
+### Finite closure certificate
+
+Let `N` be this source file and let `D` be the finite set of current markdown
+files under `docs/`, excluding audit-history artifacts. Define:
+
+- `S(N)` to mean that `N` satisfies the source-local guards `Z0`-`Z4`;
+- `I(N,D)` to mean that every current inbound occurrence of this filename in
+  `D` has both an optional-comparison marker and an explicit non-authority /
+  packaging guard; and
+- `Z(N,D) := S(N) AND I(N,D)`.
+
+The runner reads and SHA-pins all of `N`, enumerates `D`, and evaluates every
+conjunct in this definition. Therefore a passing run closes `Z(N,D)` for the
+checked checkout by finite inspection. This exhaustiveness is the entire
+derivation burden of this meta row. It neither assumes nor establishes the
+truth, completeness, or audit grade of any physics note named below.
+
+The certificate is falsified if any source-local guard fails, if this note
+acquires a markdown dependency edge, or if any current inbound occurrence is
+not explicitly optional and non-authoritative. Any edit to this source,
+including a substantive textbook comparison added here, invalidates the `Z4`
+source pin; such a comparison must be moved to its own claim row before a
+reviewer refreshes this metadata certificate.
+
 ## 2. What this note is for
 
-The canonical textbook continuum target for the universal-QG family is
-already handled on the project route by the theorem chain listed in §4 below.
-This note is a packaging hub providing a stable citation target for downstream
+The phrase "canonical textbook continuum target" is a navigation label here,
+not a statement about that target's truth, completeness, or audit grade. This
+note is a packaging hub providing a stable citation target for downstream
 universal-QG notes that need a named row to attach optional-comparison callouts
 to:
 
@@ -71,12 +103,12 @@ above. It is infrastructure metadata for the universal-QG citation graph.
 
 This note **must not** be used to:
 
-- reopen, weaken, or extend the closed universal-QG theorem stack;
+- assign, change, or extend the status of the universal-QG theorem stack;
 - introduce a new "comparison" claim that the audit lane would have to
   ratify;
 - act as a one-hop authority for any downstream theorem;
-- substitute for the actual closed canonical textbook continuum closure
-  parent.
+- substitute for the claim row that supplies the canonical textbook continuum
+  closure.
 
 If a universal-QG downstream note needs a *substantive* textbook-comparison
 result, that must live in its own claim row with its own load-bearing
@@ -84,9 +116,9 @@ step, runner, and independent audit review — not here.
 
 ## 4. Cross-references (informational only)
 
-The universal-QG canonical textbook closure parent and sibling theorems are
+The universal-QG canonical textbook closure parent and sibling claim rows are
 not load-bearing for this meta packaging note. They are listed here only so a
-reader landing on this row by citation can navigate to the actual derivations:
+reader landing on this row by citation can navigate to the substantive rows:
 
 - `UNIVERSAL_QG_CANONICAL_TEXTBOOK_CONTINUUM_GR_CLOSURE_NOTE.md`
 - `UNIVERSAL_QG_CANONICAL_SMOOTH_GRAVITATIONAL_WEAK_MEASURE_NOTE.md`
@@ -94,4 +126,5 @@ reader landing on this row by citation can navigate to the actual derivations:
 - `UNIVERSAL_QG_CANONICAL_TEXTBOOK_WEAK_MEASURE_EQUIVALENCE_NOTE.md`
 - `UNIVERSAL_QG_CONTINUUM_BRIDGE_REDUCTION_NOTE.md`
 
-These are the actual claim rows. This note is *not* one of them.
+These are the substantive claim rows. This note is *not* one of them, and its
+metadata certificate does not assign any grade to them.

--- a/logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt
+++ b/logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt
@@ -1,28 +1,35 @@
 ===== runner cache v1 =====
 runner: scripts/universal_qg_optional_textbook_comparison_meta_check.py
-runner_sha256: 3fbdece80a784fc3782f9ceb4c99d9fcf9ffdf6fc59feb051c482cdbfb0b31db
+runner_sha256: 286dfce08688326981e9cd56dac8ad23799f54ef2a1acb0f6a5e673d6269da44
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.61
+elapsed_sec: 0.25
 status: ok
 ----- stdout -----
 ========================================================================
 UNIVERSAL QG OPTIONAL TEXTBOOK COMPARISON META CHECK
 ========================================================================
 [PASS (A)] note title is the expected optional textbook comparison note: docs/UNIVERSAL_QG_OPTIONAL_TEXTBOOK_COMPARISON_NOTE.md
+[PASS (A)] Source note matches the reviewed byte-for-byte predicate surface: 3c80bb709d12151857e95375720b64f31f7977a14f8a1f98850c56ebecc2e591
 [PASS (A)] Type field is exactly meta: meta
 [PASS (A)] Status field negates theorem, claim, and new authority roles: audit-checkable packaging hub for optional textbook-comparison crosswalks against the universal-QG canonical textbook closure target. **Not** a theorem, claim, or new authority surface.
 [PASS (A)] Authority role is zero: zero — this row exists only to anchor a citation hub for downstream universal-QG notes that need a stable target for "optional textbook comparison" callouts.
+[PASS (A)] Audit target is the finite Z0-Z5 repository predicate only: the finite repository predicate `Z := Z0 AND ... AND Z5` below, and no scientific proposition.
+[PASS (A)] Status authority remains with the independent audit lane: independent audit lane only; the runner supplies a repository-state certificate, not an audit verdict.
 [PASS (A)] Primary runner points to this replay script: `scripts/universal_qg_optional_textbook_comparison_meta_check.py`
 [PASS (A)] Runner cache points to the cached replay transcript: `logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt`
 [PASS (A)] Audit-readiness metadata repair preserves zero-authority scope: source-side cache metadata is not a status promotion
+[PASS (A)] Z0-Z5 are each declared exactly once: 0,1,2,3,4,5
+[PASS (A)] Finite closure certificate defines source and inbound predicates: Z(N,D) source/inbound conjunction
+[PASS (A)] Finite certificate disclaims all physics-grade implications: physics and audit-grade firewall present
+[PASS (A)] Finite certificate states executable falsifiers: source pin, edge, inbound-context, and Z4 falsifiers present
 [PASS (A)] Source note has no markdown links to other docs: none
 [PASS (A)] Source note has no authority-style Citations section: Citations heading absent
 [PASS (A)] Informational cross-reference rows exist as separate claim files: all present as code spans
 [PASS (A)] Own-row substantive comparison firewall is explicit: claim-row firewall present
 [PASS (B)] Inbound mentions are guarded as optional packaging callouts: 21 mentions checked
 ------------------------------------------------------------------------
-SUMMARY: PASS A=11 B=1 C=0 D=0 total_pass=12
+SUMMARY: PASS A=18 B=1 C=0 D=0 total_pass=19
 
 ----- stderr -----
 

--- a/scripts/universal_qg_optional_textbook_comparison_meta_check.py
+++ b/scripts/universal_qg_optional_textbook_comparison_meta_check.py
@@ -8,6 +8,7 @@ elsewhere only in explicitly optional/packaging contexts.
 """
 from __future__ import annotations
 
+import hashlib
 import math
 import re
 import sys
@@ -21,6 +22,7 @@ NOTE_PATH = REPO_ROOT / NOTE_REL
 RUNNER_REL = Path("scripts/universal_qg_optional_textbook_comparison_meta_check.py")
 CACHE_REL = Path("logs/runner-cache/universal_qg_optional_textbook_comparison_meta_check.txt")
 TARGET_NAME = NOTE_REL.name
+EXPECTED_NOTE_SHA256 = "3c80bb709d12151857e95375720b64f31f7977a14f8a1f98850c56ebecc2e591"
 DOC_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)\s#]+\.md)(?:#[^)]*)?\)")
 
 
@@ -35,6 +37,10 @@ class CheckResult:
 def read(path: Path) -> str:
     with path.open(encoding="utf-8") as handle:
         return handle.read()
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def field(body: str, name: str) -> str:
@@ -96,10 +102,13 @@ def inbound_optional_contexts() -> tuple[bool, int, list[str]]:
 def main() -> int:
     body = read(NOTE_PATH)
     normalized_body = " ".join(body.split())
+    predicate_text = normalized_body.replace("`", "")
     results: list[CheckResult] = []
 
     status = field(body, "Status")
     authority = field(body, "Authority role")
+    audit_target = field(body, "Audit target")
+    status_authority = field(body, "Status authority")
     primary_runner = field(body, "Primary runner")
     runner_cache = field(body, "Runner cache")
 
@@ -109,6 +118,14 @@ def main() -> int:
         "A",
         body.startswith("# Universal QG Optional Textbook Comparison Note\n"),
         str(NOTE_REL),
+    )
+    note_sha = sha256(NOTE_PATH)
+    add(
+        results,
+        "Source note matches the reviewed byte-for-byte predicate surface",
+        "A",
+        note_sha == EXPECTED_NOTE_SHA256,
+        note_sha,
     )
     add(
         results,
@@ -121,7 +138,12 @@ def main() -> int:
         results,
         "Status field negates theorem, claim, and new authority roles",
         "A",
-        all(token in status.lower() for token in ("not", "theorem", "claim", "new authority surface")),
+        re.search(
+            r"\*\*not\*\*\s+a theorem,\s*claim,\s*or new authority surface",
+            status,
+            re.IGNORECASE,
+        )
+        is not None,
         status or "missing",
     )
     add(
@@ -130,6 +152,24 @@ def main() -> int:
         "A",
         authority.lower().startswith("zero"),
         authority or "missing",
+    )
+    add(
+        results,
+        "Audit target is the finite Z0-Z5 repository predicate only",
+        "A",
+        "finite repository predicate" in audit_target.lower()
+        and "z := z0 and ... and z5" in audit_target.lower()
+        and "no scientific proposition" in audit_target.lower(),
+        audit_target or "missing",
+    )
+    add(
+        results,
+        "Status authority remains with the independent audit lane",
+        "A",
+        "independent audit lane only" in status_authority.lower()
+        and "repository-state certificate" in status_authority.lower()
+        and "not an audit verdict" in status_authority.lower(),
+        status_authority or "missing",
     )
     add(
         results,
@@ -152,6 +192,48 @@ def main() -> int:
         "does not change this row's zero-authority role" in normalized_body
         and "does not assert an audit outcome" in normalized_body,
         "source-side cache metadata is not a status promotion",
+    )
+    z_labels = re.findall(r"^- `Z([0-5])`:", body, re.MULTILINE)
+    add(
+        results,
+        "Z0-Z5 are each declared exactly once",
+        "A",
+        z_labels == ["0", "1", "2", "3", "4", "5"],
+        ",".join(z_labels) or "missing",
+    )
+    add(
+        results,
+        "Finite closure certificate defines source and inbound predicates",
+        "A",
+        all(
+            marker in predicate_text
+            for marker in (
+                "S(N) to mean that N satisfies the source-local guards Z0-Z4",
+                "I(N,D) to mean that every current inbound occurrence",
+                "Z(N,D) := S(N) AND I(N,D)",
+                "a passing run closes Z(N,D) for the checked checkout by finite inspection",
+            )
+        ),
+        "Z(N,D) source/inbound conjunction",
+    )
+    add(
+        results,
+        "Finite certificate disclaims all physics-grade implications",
+        "A",
+        "neither assumes nor establishes the truth, completeness, or audit grade"
+        in predicate_text
+        and "metadata certificate does not assign any grade" in predicate_text,
+        "physics and audit-grade firewall present",
+    )
+    add(
+        results,
+        "Finite certificate states executable falsifiers",
+        "A",
+        "certificate is falsified if any source-local guard fails" in predicate_text
+        and "acquires a markdown dependency edge" in predicate_text
+        and "Any edit to this source" in predicate_text
+        and "invalidates the Z4 source pin" in predicate_text,
+        "source pin, edge, inbound-context, and Z4 falsifiers present",
     )
     add(
         results,


### PR DESCRIPTION
## Summary

Closes the audited packaging/meta-predicate mismatch without retyping the row as a physics theorem. The source remains `claim_type: meta`, `effective_status: meta`, and dependency-free.

- strengthens the exact meta checker with source-byte and inbound-reference guards
- refreshes the paired runner cache
- records the physics-loop assumptions, trace gate, status certificate, review history, and handoff

## Verification

- checker: `PASS A=18 B=1` (19 checks)
- audit pipeline: passed
- strict audit lint: passed with no errors
- review-loop disposition: pass after three iterations

See `.claude/science/physics-loops/universal-qg-optional-textbook-meta-closure-20260710/HANDOFF.md`.

This is exact support for a meta packaging invariant, not a retained physics claim.