### PR TITLE
fix(yt-zero-import): narrow claim surface to canonical-bare Ward ratio

### DIFF
--- a/docs/YT_ZERO_IMPORT_AUTHORITY_NOTE.md
+++ b/docs/YT_ZERO_IMPORT_AUTHORITY_NOTE.md
@@ -3,7 +3,10 @@
 **Date:** 2026-04-17
 **Type:** positive_theorem
 **Status:** supported canonical-bare Ward-ratio core (no fitted or observational
-SM inputs) + conditional Planck-surface and low-energy package
+SM inputs); the Planck-surface and low-energy package is excluded from this
+note's claim surface (2026-07-10 narrowing) and retained below as conditional
+context only, pending the shared-tadpole-dressing/physical-readout bridge
+theorem and the `kappa_Y = 0` selector theorem
 **Primary runner:** `scripts/frontier_yt_ward_identity_derivation.py` ([scripts/frontier_yt_ward_identity_derivation.py](../scripts/frontier_yt_ward_identity_derivation.py))
 **Additional primary runner:** `scripts/frontier_yt_color_projection_correction.py`
 **Supporting runners:** `scripts/frontier_yt_explicit_systematic_budget.py`,
@@ -41,7 +44,12 @@ Use this note together with:
 
 Do not treat older backward-Ward / route-history notes as competing authority.
 
-## Current strongest package read
+## Conditional context (excluded from claim surface): current strongest package read
+
+Nothing in this section is part of this note's citable claim surface
+(2026-07-10 narrowing; see the dated downstream-hygiene line in the Honest
+boundary section). The values are retained as conditional context for the
+record.
 
 | Observable | Framework result | Comparator | Deviation |
 |---|---|---|---|
@@ -57,10 +65,14 @@ under the selector condition stated below.
 
 ## Safe claim
 
-The current package can safely say:
+After the 2026-07-10 narrowing, this note's audited claim surface is exactly:
 
 - the canonical-bare matrix-element ratio is exact on the bounded Ward
   surface: `y_t_bare / g_bare = 1 / sqrt(6)`
+
+Everything below in this section is EXCLUDED from this note's claim surface
+and recorded as conditional context only:
+
 - conditional on an accepted shared-tadpole-dressing and physical-readout
   bridge, that bare ratio lifts to the Planck-surface statement
   `y_t(M_Pl) / g_s(M_Pl) = 1 / sqrt(6)`
@@ -171,13 +183,41 @@ The current package does **not** claim:
 - an unconditional derivation of the Yukawa-side selector `kappa_Y = 0` (the
   low-energy package is conditional on it)
 
+**2026-07-10 downstream hygiene.** This note's citable claim surface is
+exactly the canonical-bare Ward-ratio core
+`y_t_bare / g_bare = 1 / sqrt(6)` on the bounded Ward surface. Downstream
+notes must not cite this note as authority for the Planck-surface ratio
+`y_t(M_Pl) / g_s(M_Pl)`, the connected-trace factor `sqrt(8/9)`, the
+low-energy `y_t(v)` endpoint, either `m_t(pole)` central value, or any precision
+budget quoted here; those outputs are conditional context pending the
+shared-tadpole-dressing and physical-readout bridge theorem and the Yukawa-side
+selector theorem (`kappa_Y = 0`), and are to be audited separately once those
+authorities exist. This dated line itself moves the note hash so the row
+re-enters for re-audit.
+
 So the right read is:
 
 > the canonical-bare Ward ratio `y_t_bare/g_bare = 1/sqrt(6)` is the supported
-> core; its Planck-surface lift is conditional on shared dressing and physical
+> core and this note's only citable claim; everything else is conditional
+> context. Its Planck-surface lift is conditional on shared dressing and physical
 > readout, and the renormalized low-energy `y_t` / `m_t` package is additionally
 > conditional on the underived Yukawa-side selector `kappa_Y = 0`. No fitted or
 > observational SM input is used on the framework side. The current primary
 > precision caveat is a standard-method residual budget of order `~1.95%`, and
 > the older Schur bridge survives as an independent cross-check with its own
 > tighter but route-specific budget.
+
+## Repair Note
+
+**2026-07-10 claim-surface narrowing.** The audit of this row returned
+`audited_conditional` with repair class `scope_too_broad`: the audited claim
+surface bundled the exact canonical-bare ratio with the conditional
+Planck-surface and low-energy `y_t`/`m_t` package and its precision
+qualifications, while the shared-dressing/physical-readout bridge and the
+`kappa_Y = 0` selector remain underived. Per the auditor's repair instruction,
+the claim surface is now narrowed to the canonical-bare Ward-ratio core; the
+Planck-surface and low-energy package (including all precision budgets) is
+excluded from this note's claim surface and retained as conditional context
+only, with a dated downstream-hygiene line in the Honest boundary section. No
+computational content changed; the primary runner's load-bearing blocks are
+untouched, with new note-surface checks pinning the narrowed wording.

--- a/logs/runner-cache/frontier_yt_ward_identity_derivation.txt
+++ b/logs/runner-cache/frontier_yt_ward_identity_derivation.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_yt_ward_identity_derivation.py
-runner_sha256: fa08cefaf4b1d968604e10cef1944041dca76a7eacbcf518dcbf4051ef6c6732
+runner_sha256: b65c944f5ee895becb24dffa6d46d916489d1a3274178e711fd885e852e2ab49
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 4.81
+elapsed_sec: 3.44
 status: ok
 ----- stdout -----
 ========================================================================
@@ -34,9 +34,9 @@ BLOCK W2: Propagator-level Ward identity (full Wick, contact terms)
   full Wick value <V F> = -Tr(J G) G + G J G  (disconnected + connected).
 
   [PASS (A)] Propagator is exactly iso-diagonal (U(2)_iso symmetry of M at fixed links)  --  max iso-offdiagonal |G| = 0.000e+00
-  [PASS (C)] Exact point-split Ward identity: max residual over all (x; y, z) at machine zero  --  max |D^-.<V psi psibar> - contact| = 2.040e-15 on random SU(3) background
-  [PASS (C)] Current conservation in expectation: sum_mu D^-_mu <V_mu(x)> = 0 at every site  --  max |div <V>| = 2.276e-15
-  [PASS (C)] Ward identity exact after a RANDOM local SU(3) gauge transformation of links  --  max residual = 6.727e-16 (gauge covariance of the point-split current)
+  [PASS (C)] Exact point-split Ward identity: max residual over all (x; y, z) at machine zero  --  max |D^-.<V psi psibar> - contact| = 2.046e-15 on random SU(3) background
+  [PASS (C)] Current conservation in expectation: sum_mu D^-_mu <V_mu(x)> = 0 at every site  --  max |div <V>| = 2.318e-15
+  [PASS (C)] Ward identity exact after a RANDOM local SU(3) gauge transformation of links  --  max residual = 6.524e-16 (gauge covariance of the point-split current)
 
 ========================================================================
 BLOCK W3: FALSIFICATION leg A: naive (link-stripped) current FAILS
@@ -48,7 +48,7 @@ BLOCK W3: FALSIFICATION leg A: naive (link-stripped) current FAILS
   is a property of the action's symmetry current, not of bookkeeping.
 
   [PASS (C)] Link-stripped current VIOLATES the kernel identity (residual >> 0)  --  max kernel residual = 0.9622 (vs < 1e-13 for the true current)
-  [PASS (C)] Link-stripped current VIOLATES the propagator-level Ward identity  --  max residual = 0.869859 (vs 2.040e-15 for the true current)
+  [PASS (C)] Link-stripped current VIOLATES the propagator-level Ward identity  --  max residual = 0.869859 (vs 2.046e-15 for the true current)
   [PASS (C)] With trivial links U = 1 the 'stripped' current is the true current: residual = 0  --  max residual = 0.000e+00 (failure is located in gauge covariance)
 
 ========================================================================
@@ -77,9 +77,9 @@ BLOCK W5: Iso-vector charged current: conserved at degenerate mass;
   explicit (m2 - m1) psibar tau+ psi insertion, nothing else.
 
   [PASS (A)] Breaking kernel identity: [tau+, diag(m1,m2) (x) 1_c] = (m2 - m1) (tau+ (x) 1_c)  --  (m2 - m1) = 0.4600; max |comm - (m2-m1) tau+| = 0.000e+00
-  [PASS (C)] Degenerate mass: charged-current Ward identity EXACT (no breaking term needed)  --  max residual = 1.395e-15 ([tau+, m 1] = 0)
+  [PASS (C)] Degenerate mass: charged-current Ward identity EXACT (no breaking term needed)  --  max residual = 1.393e-15 ([tau+, m 1] = 0)
   [PASS (C)] Split mass m1 != m2: charged current NOT conserved (residual >> 0 w/o insertion)  --  max residual without insertion = 0.199313
-  [PASS (C)] Split mass: residual equals the EXACT (m2-m1) psibar tau+ psi insertion  --  max residual WITH exact mass insertion = 7.615e-16
+  [PASS (C)] Split mass: residual equals the EXACT (m2-m1) psibar tau+ psi insertion  --  max residual WITH exact mass insertion = 7.312e-16
 
 ========================================================================
 BLOCK W6: EXACT-arithmetic certificate: Ward residual is EXACTLY zero
@@ -321,9 +321,20 @@ identification surface; it documents SU(N_c) algebraic facts.
   -- context only, no PASS/FAIL attached, no precision claim.
 
 ========================================================================
+BLOCK 13: note claim-surface checks (2026-07-10 narrowing repair)
+These note-surface checks pin the dated narrowing to the canonical-bare
+Ward-ratio core; the runner's computational blocks are unchanged.
+========================================================================
+
+  [PASS (A)] Authority note carries the dated downstream-hygiene line  --  pins the 2026-07-10 claim-surface narrowing
+  [PASS (A)] Authority note states its narrowed audited claim surface exactly  --  canonical-bare claim surface is explicit
+  [PASS (A)] Authority note fences the package section as excluded conditional context  --  Planck/IR package is outside this note's claim surface
+  [PASS (A)] Authority note retains the exact canonical-bare ratio claim  --  bounded Ward-ratio core remains present
+
+========================================================================
 SUMMARY
 ========================================================================
-  PASS: 58
+  PASS: 62
   FAIL: 0
 
   WARD-IDENTITY THEOREM (load-bearing, Blocks W1-W6):
@@ -357,7 +368,7 @@ SUMMARY
     (W1)  exact point-split vector Ward identity of the staggered Q_L action
     (T1)  y_t_bare = g_bare / sqrt(6)   (g_bare-flat form factor)
 
-TOTAL: PASS=58 FAIL=0
+TOTAL: PASS=62 FAIL=0
   See docs/YT_WARD_IDENTITY_DERIVATION_THEOREM.md for the source note.
 
 ----- stderr -----

--- a/scripts/frontier_yt_ward_identity_derivation.py
+++ b/scripts/frontier_yt_ward_identity_derivation.py
@@ -75,6 +75,7 @@ to any helper-imported plaquette constant):
              where helper constants enter; algebra-only checks kept).
   Block 12:  Two-gluon color-trace algebra (exact SU(3) facts kept as
              checks; topology-counting and NNLO-magnitude lines log-only).
+  Block 13:  Note claim-surface checks pinning the 2026-07-10 narrowing.
 
 Every PASS is a computed check.  The Ward residuals are computed on explicit
 lattice constructions whose link backgrounds are random (not present in any
@@ -87,6 +88,7 @@ from __future__ import annotations
 import math
 import sys
 from itertools import product
+from pathlib import Path
 
 import numpy as np
 
@@ -1392,6 +1394,49 @@ alpha_LM_sq_C_F_sq = (ALPHA_LM * C_F / PI) ** 2
 delta_NNLO_nonplanar = alpha_LM_sq_C_F_sq / (N_c ** 2)
 log(f"    delta_NNLO_NP = (alpha_LM * C_F / pi)^2 / N_c^2 = {delta_NNLO_nonplanar*100:.4f}%")
 log("  -- context only, no PASS/FAIL attached, no precision claim.")
+
+
+# ============================================================
+# BLOCK 13: note claim-surface checks (2026-07-10 narrowing repair)
+# ============================================================
+log()
+log("=" * 72)
+log("BLOCK 13: note claim-surface checks (2026-07-10 narrowing repair)")
+log("These note-surface checks pin the dated narrowing to the canonical-bare")
+log("Ward-ratio core; the runner's computational blocks are unchanged.")
+log("=" * 72)
+log()
+
+repo_root = Path(__file__).resolve().parents[1]
+authority_note = (repo_root / "docs" / "YT_ZERO_IMPORT_AUTHORITY_NOTE.md").read_text(
+    encoding="utf-8"
+)
+
+check(
+    "Authority note carries the dated downstream-hygiene line",
+    "2026-07-10 downstream hygiene." in authority_note,
+    "pins the 2026-07-10 claim-surface narrowing",
+    cls="A",
+)
+check(
+    "Authority note states its narrowed audited claim surface exactly",
+    "this note's audited claim surface is exactly:" in authority_note,
+    "canonical-bare claim surface is explicit",
+    cls="A",
+)
+check(
+    "Authority note fences the package section as excluded conditional context",
+    "Conditional context (excluded from claim surface): current strongest package read"
+    in authority_note,
+    "Planck/IR package is outside this note's claim surface",
+    cls="A",
+)
+check(
+    "Authority note retains the exact canonical-bare ratio claim",
+    "y_t_bare / g_bare = 1 / sqrt(6)" in authority_note,
+    "bounded Ward-ratio core remains present",
+    cls="A",
+)
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

Repairs the `scope_too_broad` conditional verdict on the y_t zero-import authority row (`docs/YT_ZERO_IMPORT_AUTHORITY_NOTE.md`, claim `yt_zero_import_authority_note`, 936 transitive descendants — the largest single defective blocker in the audit queue).

**Verdict being repaired (notes_for_re_audit, quoted):**
> scope_too_broad: Narrow this note's audited claim surface to the canonical-bare ratio and add a dated downstream-hygiene line to this note's own boundary explicitly excluding the Planck/IR values and precision budgets; audit those outputs separately after the bridge and selector theorems exist.

The verdict's issue: the audited claim surface bundled the exact canonical-bare ratio `y_t_bare / g_bare = 1/sqrt(6)` (which the audit found supported, class C) with the conditional Planck-surface and low-energy `y_t`/`m_t` package, while the shared-dressing/physical-readout bridge is not certified and the retained color-projection no-go establishes the `kappa_Y = 0` selector remains underived.

## Changes

- **Note** — claim surface narrowed exactly as instructed: Status header states the exclusion; the package-read section is retitled `Conditional context (excluded from claim surface)` with a lead-in fencing it out of the citable surface (table values kept verbatim for the record and for external needle stability); the Safe claim section now states the audited claim surface is exactly the canonical-bare ratio, with all conditional items explicitly excluded; a dated **2026-07-10 downstream hygiene** line in the Honest boundary section bars downstream citation of the Planck-surface ratio, `sqrt(8/9)`, `y_t(v)`, `m_t(pole)`, and precision budgets pending the bridge and selector theorems; canonical `## Repair Note` section added. No computational content changed.
- **Runner** (`scripts/frontier_yt_ward_identity_derivation.py`) — new Block 13 with 4 discriminating class-A note-surface checks pinning the narrowed wording (fails on the pre-repair note). All computational blocks untouched. PASS total 58→62.
- **Cache** (`logs/runner-cache/frontier_yt_ward_identity_derivation.txt`) — regenerated, SHA-pinned to the new runner, exit 0.

Source-only triple: 1 note + 1 runner + 1 cache. No audit surfaces touched; the note-hash drift re-enters the row for independent re-audit, which is the verdict's own repair mechanism.

## Verification

- Primary runner: `TOTAL: PASS=62 FAIL=0`, exit 0.
- External needle stability: `scripts/frontier_yt_flagship_boundary_contract.py` (needles `0.9176`, `172.57 GeV`, `173.10 GeV`, `~1.95%` in this note) still `PASS=56 FAIL=0`; `scripts/frontier_yt_zero_import_ratio_authority.py` still passes.
- Deliberate cycle-break backtick/link structure in the "Use this note together with" list is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
