### PR TITLE
fix(fsb): require nonempty Z(h); restrict FSB-X to explicit witnesses

### DIFF
--- a/docs/AXIOM_FIRST_FERMIONIC_STEFAN_BOLTZMANN_NARROW_THEOREM_NOTE_2026-05-26.md
+++ b/docs/AXIOM_FIRST_FERMIONIC_STEFAN_BOLTZMANN_NARROW_THEOREM_NOTE_2026-05-26.md
@@ -125,7 +125,7 @@ neither assumed nor derived.
 ## 2. Setup and definitions
 
 **Surface.** The `Z³` one-qubit single-ladder one-particle hopping
-surface: `MINIMAL_AXIOMS_2026-06-05.md` supplies the per-site
+surface: [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies the per-site
 one-qubit operator algebra, and the retained tensor-product fermion
 bridge supplies the finite periodic Fock/translation extension with
 local ladder operators.
@@ -271,8 +271,11 @@ numerically, boundary B-2.)
 ### 4.2 Step 1 (gapped remainder)
 
 Shrink each `r_j` so that `C_j r_j ≤ s_j/2` with `s_j` the smallest
-singular value of `V_jb`; the cone balls `B_j = B(p_j, r_j)` are
-finitely many and may be taken disjoint. Off `∪B_j`, every band obeys
+singular value of `V_jb`. Group the zero pairs `(p_j,b)` by distinct
+momentum point. Balls centered at distinct zero momenta may be taken
+disjoint; when several bands vanish at the same momentum, their branch
+contributions are summed inside the same ball. No disjointness between band
+labels at a shared momentum is assumed. Off the union of these balls, every band obeys
 `|E_b| ≥ Δ > 0` (compactness, §2), and `x n_F(x/T) ≤ x e^(−x/T)` is
 decreasing in `x ≥ Δ ≥ T`, so the off-cone contribution is at most
 `n_c · max|E_b| · e^(−Δ/T) = O(e^(−Δ/T))`, super-polynomially small.
@@ -350,7 +353,7 @@ certificates (boundary B-5).
 
 Load-bearing (markdown links):
 
-1. [`MINIMAL_AXIOMS_2026-06-05.md`](MINIMAL_AXIOMS_2026-06-05.md) —
+1. [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) —
    axiom premise node. License used: Lattice (`Z³`, translations, NN
    cubic adjacency) and Quantum (per-site qubit) for the kernel-class
    constructions. No dynamics drawn.

--- a/docs/AXIOM_FIRST_FERMIONIC_STEFAN_BOLTZMANN_NARROW_THEOREM_NOTE_2026-05-26.md
+++ b/docs/AXIOM_FIRST_FERMIONIC_STEFAN_BOLTZMANN_NARROW_THEOREM_NOTE_2026-05-26.md
@@ -8,7 +8,7 @@ retained tensor-product Fock/translation bridge, for **every** kinetic kernel in
 finite-range, sublattice-periodic, Hermitian hopping with analytic
 Bloch band family `{E_b(p)}` on the Brillouin torus — **whose massless
 set is point-like with linear cones** (hypothesis (Z): the zero set
-`Z(h) = {(p_j, b) : E_b(p_j) = 0}` is finite and each vanishing branch
+`Z(h) = {(p_j, b) : E_b(p_j) = 0}` is finite and nonempty, and each vanishing branch
 satisfies `|E_b(p_j + q)| = |V_jb q| + O(|q|²)` with invertible real
 `3×3` matrices `V_jb`), the half-filled free-Fermi thermal energy
 density per site obeys, as `T → 0`,
@@ -34,7 +34,7 @@ computed witnesses classified by their zero-set geometry.
 does not set or predict an audit outcome; audit verdict and effective
 status are set only by the independent audit lane.
 **Primary runner:** [`scripts/frontier_axiom_first_fermionic_stefan_boltzmann_narrow.py`](../scripts/frontier_axiom_first_fermionic_stefan_boltzmann_narrow.py)
-(`TOTAL: PASS=18 FAIL=0`, deterministic, runtime well under one
+(`TOTAL: PASS=20 FAIL=0`, deterministic, runtime well under one
 minute)
 **Runner cache:** [`logs/runner-cache/frontier_axiom_first_fermionic_stefan_boltzmann_narrow.txt`](../logs/runner-cache/frontier_axiom_first_fermionic_stefan_boltzmann_narrow.txt)
 **Authority role:** source-note proposal. If retained, this row
@@ -79,6 +79,20 @@ row's status and performs no selection itself.
   (specialization to a supplied isotropic dispersion), so downstream
   citations of the per-Dirac-species law and the `7/8` per-dof ratio
   are unaffected.
+
+## Repair Note
+
+**2026-07-10.** The audit's notes for re-audit were:
+
+> scope_too_broad: Require Z(h) to be nonempty or replace
+> g_eff in (0,infinity) by g_eff in [0,infinity), and restrict FSB-X to the
+> explicit witnesses or add hypotheses globally controlling every zero
+> component; then re-audit.
+
+The chosen arms are the NONEMPTY arm for hypothesis (Z), preserving
+the existing `g_eff ∈ (0, ∞)` claim surface, and the
+RESTRICT-TO-WITNESSES arm for FSB-X. No computational content changed;
+the runner gains an empty-set discriminator and note-surface pins.
 
 ## 1. Question and method
 
@@ -147,7 +161,7 @@ is NOT derived here.
 per-dof normalization as denominator.
 
 **Hypothesis (Z) (point-like linear-cone zero set).** The massless
-set `Z(h) = {(p_j, b) : E_b(p_j) = 0}` is finite, and for each
+set `Z(h) = {(p_j, b) : E_b(p_j) = 0}` is finite and nonempty, and for each
 `(p_j, b) ∈ Z(h)` there are an invertible real `3×3` matrix `V_jb`,
 a radius `r_j > 0`, and a constant `C_j < ∞` with
 
@@ -160,6 +174,12 @@ a radius `r_j > 0`, and a constant `C_j < ∞` with
 finiteness of `Z(h)` plus the local cone bounds already imply a
 uniform gap `Δ > 0` off the cone neighborhoods; no separate gap
 hypothesis is needed.)
+
+(2026-07-10 scope repair: nonemptiness is load-bearing for
+`g_eff ∈ (0, ∞)`. The empty-`Z(h)` fully gapped case is excluded from
+FSB-K's claim surface: there `u(T) = O(e^{-Δ/T})` and
+`g_eff(T) → 0`, so the `T⁴` normalization is not the natural currency
+and no FSB-K claim is made.)
 
 ## 3. Statements
 
@@ -197,19 +217,22 @@ whether a given realized kernel satisfies (Z) is a separate,
 external, computable kernel-geometry fact, not certified here
 (boundary B-3). ∎
 
-### 3.3 Proposition FSB-X (both clauses of (Z) are load-bearing; certificate grade)
+### 3.3 Proposition FSB-X (both clauses of (Z) are load-bearing on explicit witness kernels; certificate grade)
 
-(a) **Extended zero set.** If a band's zero set contains a regular
-codim-1 surface piece with nonvanishing normal gradient, then
-`u(T) ≍ T²` (Sommerfeld; tubular-neighborhood/coarea sketch in §4.6),
-so `g_eff(T) ≍ T⁻²` diverges — the `T⁴` law fails structurally.
-(b) **Point-like but quadratic.** If a zero is an isolated point with
-nondegenerate quadratic dispersion `|E| ≍ |q|²`, then
+(a) **Extended zero set.** For the explicit extended-zero witness
+kernel (§4.6; runner checks 12–13), `u(T) ≍ T²` (Sommerfeld), so
+`g_eff(T) ≍ T⁻²` diverges — the `T⁴` law fails structurally.
+(b) **Point-like but quadratic.** For the explicit isolated
+quadratic-point witness kernel (runner checks 14–15),
 `u(T) ≍ T^(5/2)` and `g_eff(T) ≍ T^(−3/2)` diverges — point-likeness
 alone is insufficient; the linear-cone clause is load-bearing
-separately. Both behaviors are computed on explicit kernels (runner
-checks 12–15); FSB-X is certificate + sketch grade, not the
-theorem-grade core (boundary B-5). ∎
+separately. FSB-X is certificate + sketch grade, not the theorem-grade
+core (boundary B-5). No sufficient-condition claim is made for kernels
+with additional uncontrolled zero components: a flatter additional
+component (`|E| ≍ |q|^α`, `α > 2`) dominates the low-`T` asymptotics
+(`u ≍ T^{1+3/α}`), so the two-sided rates above are witness-specific;
+only the per-witness divergence of `g_eff(T)` is certified.
+(2026-07-10 scope repair.) ∎
 
 ### 3.4 Corollary FSB-C (continuum specialization; the 2026-05-26 content, preserved)
 
@@ -388,7 +411,7 @@ axioms.
 
 [`scripts/frontier_axiom_first_fermionic_stefan_boltzmann_narrow.py`](../scripts/frontier_axiom_first_fermionic_stefan_boltzmann_narrow.py)
 — deterministic, no network, no randomness; numpy + sympy + mpmath;
-runtime well under one minute. 18 checks in four sections:
+runtime well under one minute. 20 checks in five sections:
 
 - **[A]** (4 checks) the exact currency: `η/ζ` arithmetic (symbolic),
   the Fermi-Dirac integral `Γ(4)η(4) = 7π⁴/120` and `I_F/I_B = 7/8`
@@ -422,16 +445,21 @@ runtime well under one minute. 18 checks in four sections:
   branch-blindness sentence present); branch-blindness of the
   computation (both branch symbols through the same code path,
   separated only by computed geometry).
+- **[E]** (2 checks) the 2026-07-10 scope repair: an explicitly gapped
+  empty-zero-set kernel has decreasing `u(T)/T⁴ → 0` on three
+  decreasing temperatures, and note-surface pins require the
+  nonempty-(Z), explicit-witness FSB-X, witness-specific, dated repair,
+  and Repair Note wording.
 
 Four `RESIDUAL (declared-open): ...` lines mark boundaries B-1, B-2,
 B-3, B-5 where they are load-bearing (B-4 is recorded inside check
 11's message).
 
-Runner check classes per the audit rubric: checks 1–15 and 18 are
+Runner check classes per the audit rubric: checks 1–15 and 18–19 are
 class (A) (exact symbolic arithmetic and algebraic/spectral/
 quadrature computations on constructed finite objects); checks 16–17
-conjoin class (B) components (cross-note text/ledger verification)
-with class (A) arithmetic.
+and 20 conjoin class (B) components (cross-note or source-note text/
+ledger verification) with class (A) arithmetic where applicable.
 
 ## 8. What this does NOT close
 
@@ -458,8 +486,8 @@ with class (A) arithmetic.
 python3 scripts/frontier_axiom_first_fermionic_stefan_boltzmann_narrow.py
 ```
 
-Expected output (deterministic): 18 numbered `[PASS]` lines in
-sections `[A]`/`[B]`/`[C]`/`[D]` as described in §7, including
+Expected output (deterministic): 20 numbered `[PASS]` lines in
+sections `[A]`/`[B]`/`[C]`/`[D]`/`[E]` as described in §7, including
 `g_eff(T) at L=128 = 0.979, 1.026, 1.144, 1.508 at T=0.05..0.4`,
 `W2 ... g_eff = 0.472, 0.507 ... plateau at sum |det V|^-1 = 8/16 =
 1/2`, `g_eff = 323, 81, 20.4, 5.0 ... T-halving ratios 3.97, 3.99`,
@@ -467,7 +495,7 @@ sections `[A]`/`[B]`/`[C]`/`[D]` as described in §7, including
 four `RESIDUAL (declared-open): ...` lines; then exactly:
 
 ```text
-TOTAL: PASS=18 FAIL=0
+TOTAL: PASS=20 FAIL=0
 ```
 
 followed by the VERDICT block stating the conditional `T⁴` law with
@@ -479,7 +507,7 @@ derived. Exit code 0 iff `FAIL=0`.
 
 ```yaml
 claim_type_author_hint: bounded_theorem
-claim_scope: "On the Z^3 one-qubit single-ladder one-particle hopping surface supplied by the current minimal axiom memo and the retained tensor-product Fock/translation bridge: for every realized-class kinetic kernel (finite-range, sublattice-periodic, Hermitian hopping with analytic Bloch bands) satisfying hypothesis (Z) — the massless set is a finite set of points with linear cones, |E_b(p_j+q)| = |V_jb q| + O(|q|^2), V_jb invertible — the half-filled free-Fermi thermal energy density per site obeys u(T) = g_eff (7/8)(pi^2/30) T^4 + O(T^5) as T -> 0, with g_eff = sum |det V_jb|^{-1} finite = the cone-weighted massless species count; equivalently g_eff(T) = u(T)/[(7/8)(pi^2/30)T^4] has a finite plateau (the massless species density is finite, in the retained SB bridge row's per-dof currency), conditionally on (Z). Error control: off-cone O(e^{-Delta/T}), cone-window O(T^5) absolute / O(T) relative, constants explicit in the kernel's cone data, gap, band number, bandwidth. The hypothesis is demonstrably load-bearing in both clauses (computed certificates: extended zero surface gives g_eff ~ T^-2 Sommerfeld; quadratic point zero gives g_eff ~ T^-3/2). Bounded by: the probe currency (free-Fermi half-filled integrand, equilibrium not derived); thermodynamic-limit statement with numerically certified finite-L control; (Z) verified only for the runner's witnesses, never for 'the realized kernel'; FSB-X at certificate grade. Branch-blind: phi = -1 is neither assumed nor derived, and no flux, branch, or inventory input is consumed. Continuum specialization preserved: u_F = (7 pi^2/60) T^4 per Dirac species; u_F/u_B = 7/8 per dof."
+claim_scope: "On the Z^3 one-qubit single-ladder one-particle hopping surface supplied by the current minimal axiom memo and the retained tensor-product Fock/translation bridge: for every realized-class kinetic kernel (finite-range, sublattice-periodic, Hermitian hopping with analytic Bloch bands) satisfying hypothesis (Z) — the massless set is a finite nonempty set of points with linear cones, |E_b(p_j+q)| = |V_jb q| + O(|q|^2), V_jb invertible — the half-filled free-Fermi thermal energy density per site obeys u(T) = g_eff (7/8)(pi^2/30) T^4 + O(T^5) as T -> 0, with g_eff = sum |det V_jb|^{-1} finite = the cone-weighted massless species count; equivalently g_eff(T) = u(T)/[(7/8)(pi^2/30)T^4] has a finite plateau (the massless species density is finite, in the retained SB bridge row's per-dof currency), conditionally on (Z). Error control: off-cone O(e^{-Delta/T}), cone-window O(T^5) absolute / O(T) relative, constants explicit in the kernel's cone data, gap, band number, bandwidth. The hypothesis is demonstrably load-bearing on the explicit witness kernels in both clauses (computed certificates: the extended-zero witness gives g_eff ~ T^-2 Sommerfeld; the quadratic-point witness gives g_eff ~ T^-3/2); no sufficient-condition claim is made for kernels with additional uncontrolled zero components. Bounded by: the probe currency (free-Fermi half-filled integrand, equilibrium not derived); thermodynamic-limit statement with numerically certified finite-L control; (Z) verified only for the runner's witnesses, never for 'the realized kernel'; FSB-X at certificate grade. Branch-blind: phi = -1 is neither assumed nor derived, and no flux, branch, or inventory input is consumed. Continuum specialization preserved: u_F = (7 pi^2/60) T^4 per Dirac species; u_F/u_B = 7/8 per dof."
 upstream_dependencies:
   - minimal_axioms
   - tensor_product_translation_fermion_operator_bridge_narrow_theorem_note_2026-05-25

--- a/logs/runner-cache/frontier_axiom_first_fermionic_stefan_boltzmann_narrow.txt
+++ b/logs/runner-cache/frontier_axiom_first_fermionic_stefan_boltzmann_narrow.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_axiom_first_fermionic_stefan_boltzmann_narrow.py
-runner_sha256: c759c026987cbab59fe8aa92e19b478290daaabda9053ae218b126c74b591d47
+runner_sha256: 5e8d947f6cf05f6b77bc2f973bbd0849a486f86d3332ec53522ea76418ae06b1
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 1.90
+elapsed_sec: 0.96
 status: ok
 ----- stdout -----
 ========================================================================
@@ -50,8 +50,14 @@ RESIDUAL (declared-open): u(T) is the half-filled free-Fermi probe in the retain
 RESIDUAL (declared-open): hypothesis (Z) is a CONDITION: this row verifies it for its explicit witnesses only and does NOT certify it for the realized kernel; which kernel is realized (the P-FLUX bit) is neither assumed nor derived here (boundary B-3)
 RESIDUAL (declared-open): the falsification legs [C] are computed certificates with proof sketches, not the theorem-grade core; they establish only that (Z) is load-bearing (boundary B-5)
 
-TOTAL: PASS=18 FAIL=0
-VERDICT: on the licensed realized kernel class, for every kinetic kernel whose massless set is point-like with
+========================================================================
+[E] 2026-07-10 hypothesis-scope repair
+========================================================================
+[PASS] 19. [E] empty-set discriminator: the explicitly gapped W3 kernel has min|E| = 1.0 and empty Z(h); u(T)/T^4 = 5.541209e-02, 1.347272e-03, 2.833632e-07 at decreasing T = 0.2, 0.1, 0.05, with successive ratios 2.431e-02, 2.103e-04 < 0.5 -- the normalization tends to zero, so nonemptiness is load-bearing for the g_eff in (0, infinity) claim surface
+[PASS] 20. [E] note-surface pins: hypothesis (Z) says 'finite and nonempty'; both dated scope-repair parentheticals, the explicit-witness FSB-X title, the 'witness-specific' closing needle, and the Repair Note are present
+
+TOTAL: PASS=20 FAIL=0
+VERDICT: on the licensed realized kernel class, for every kinetic kernel whose massless set is nonempty, point-like with
          linear cones (hypothesis (Z)), the low-T thermal energy density obeys u(T) = g_eff (7/8)(pi^2/30) T^4
          + O(T^5) with g_eff = sum |det V|^-1 finite = the cone-weighted massless species count, in the retained
          Stefan-Boltzmann bridge row's own per-dof currency (clause (CL), supplied CONDITIONALLY on (Z)).

--- a/scripts/frontier_axiom_first_fermionic_stefan_boltzmann_narrow.py
+++ b/scripts/frontier_axiom_first_fermionic_stefan_boltzmann_narrow.py
@@ -10,10 +10,10 @@ kernel class, not a supplied continuum dispersion).
 Theorem computed here (FSB-K).  For every kinetic kernel in the
 licensed realized class -- finite-range, sublattice-periodic, Hermitian
 hopping on the Z^3 single-mode-per-site one-particle surface -- whose
-massless set is point-like with linear cones (hypothesis (Z): finitely
-many zero branches (p_j, b), each |E_b(p_j + q)| = |V_jb q| + O(|q|^2)
-with invertible V_jb), the half-filled free-Fermi thermal energy
-density per site obeys
+massless set is point-like with linear cones (hypothesis (Z): a finite,
+nonempty set of zero branches (p_j, b), each
+|E_b(p_j + q)| = |V_jb q| + O(|q|^2) with invertible V_jb), the
+half-filled free-Fermi thermal energy density per site obeys
 
     u(T) = g_eff * (7/8)(pi^2/30) T^4 + O(T^5),
     g_eff = sum_(j,b) |det V_jb|^(-1)  (finite),
@@ -54,6 +54,10 @@ Load-bearing content COMPUTED (not just continuum arithmetic):
       phi = -1 is neither assumed nor derived (branch-blind quantifier;
       both licensed branch symbols enter only as computed witnesses
       classified by their zero-set geometry).
+  [E] the 2026-07-10 scope repair: an explicitly gapped empty-zero-set
+      kernel has u(T)/T^4 decreasing toward zero at three decreasing
+      temperatures, and note-surface pins enforce the nonempty-(Z) and
+      explicit-witness FSB-X wording.
 
 Deterministic, no network, no randomness; numpy + sympy + mpmath.
 Exit code 0 iff FAIL = 0.
@@ -508,10 +512,48 @@ def main():
              "establish only that (Z) is load-bearing (boundary B-5)")
 
     print()
+    print("=" * 72)
+    print("[E] 2026-07-10 hypothesis-scope repair")
+    print("=" * 72)
+
+    empty_zero_vals = sym_gapped(Lbig)
+    empty_T = (0.2, 0.1, 0.05)
+    empty_u_T4 = [u_density(empty_zero_vals, T) / T ** 4
+                  for T in empty_T]
+    empty_ratios = [empty_u_T4[i + 1] / empty_u_T4[i]
+                    for i in range(len(empty_u_T4) - 1)]
+    report(count_zeros(empty_zero_vals) == 0
+           and float(np.min(np.abs(empty_zero_vals))) >= 1.0
+           and all(r < 0.5 for r in empty_ratios),
+           f"[E] empty-set discriminator: the explicitly gapped W3 "
+           f"kernel has min|E| = {np.min(np.abs(empty_zero_vals)):.1f} "
+           f"and empty Z(h); u(T)/T^4 = {empty_u_T4[0]:.6e}, "
+           f"{empty_u_T4[1]:.6e}, {empty_u_T4[2]:.6e} at decreasing "
+           f"T = {empty_T[0]}, {empty_T[1]}, {empty_T[2]}, with "
+           f"successive ratios {empty_ratios[0]:.3e}, "
+           f"{empty_ratios[1]:.3e} < 0.5 -- the normalization tends "
+           f"to zero, so nonemptiness is load-bearing for the "
+           f"g_eff in (0, infinity) claim surface")
+
+    z_start = self_txt.index("**Hypothesis (Z)")
+    z_end = self_txt.index("## 3. Statements", z_start)
+    z_block = self_txt[z_start:z_end]
+    report("finite and nonempty" in z_block
+           and self_txt.count("(2026-07-10 scope repair") >= 2
+           and "Proposition FSB-X (both clauses of (Z) are load-bearing "
+               "on explicit witness kernels; certificate grade)" in self_txt
+           and "witness-specific" in self_txt
+           and "## Repair Note" in self_txt,
+           "[E] note-surface pins: hypothesis (Z) says 'finite and "
+           "nonempty'; both dated scope-repair parentheticals, the "
+           "explicit-witness FSB-X title, the 'witness-specific' "
+           "closing needle, and the Repair Note are present")
+
+    print()
     print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
     if FAIL == 0:
         print("VERDICT: on the licensed realized kernel class, for every "
-              "kinetic kernel whose massless set is point-like with")
+              "kinetic kernel whose massless set is nonempty, point-like with")
         print("         linear cones (hypothesis (Z)), the low-T thermal "
               "energy density obeys u(T) = g_eff (7/8)(pi^2/30) T^4")
         print("         + O(T^5) with g_eff = sum |det V|^-1 finite = the "


### PR DESCRIPTION
## Summary

Repairs the `scope_too_broad` conditional verdict on the fermionic Stefan-Boltzmann row (`docs/AXIOM_FIRST_FERMIONIC_STEFAN_BOLTZMANN_NARROW_THEOREM_NOTE_2026-05-26.md`, claim `axiom_first_fermionic_stefan_boltzmann_narrow_theorem_note_2026-05-26`, 512 transitive descendants).

**Verdict being repaired (notes_for_re_audit, quoted):**
> scope_too_broad: Require Z(h) to be nonempty or replace g_eff in (0,infinity) by g_eff in [0,infinity), and restrict FSB-X to the explicit witnesses or add hypotheses globally controlling every zero component; then re-audit.

Both offered arms are taken in their minimal-diff form:

1. **Nonempty arm for (Z).** The empty massless set satisfies the old "finite" wording but gives `g_eff = 0 ∉ (0, ∞)` — the theorem as stated was false for fully gapped kernels. Hypothesis (Z) now reads "finite and nonempty" (both statements: abstract and §2), keeping every `g_eff ∈ (0, ∞)` display unchanged, with a dated remark recording the excluded gapped case (`u(T) = O(e^{−Δ/T})`, `g_eff(T) → 0`).
2. **Witness-restriction arm for FSB-X.** Both clauses are now claims about the explicit witness kernels (runner checks 12–15), with the mathematical reason no broader sufficient-condition claim is safe: an additional flatter zero component (`|E| ≍ |q|^α`, `α > 2`) dominates the low-T asymptotics (`u ≍ T^{1+3/α}`), so the two-sided rates are witness-specific; only the per-witness divergence of `g_eff(T)` is certified.

## Changes

- **Note** — (Z) nonemptiness in both statements; dated scope-repair remark in the (Z) block; FSB-X retitled and restricted to the explicit witnesses with the flatter-component caveat; `## Repair Note` quoting the verdict; runner-section list updated (18→20, new section [E]).
- **Runner** — all existing checks 1–18 unchanged; new section [E]: (i) an explicitly gapped (empty-`Z(h)`) kernel's `u(T)/T⁴` decreases toward 0 across three decreasing temperatures — a computational discriminator against the old wording's implicit claim; (ii) note-surface pins (nonempty-(Z), explicit-witness FSB-X title, "witness-specific" caveat, dated repair remarks, Repair Note). `TOTAL: PASS=20 FAIL=0`.
- **Cache** — regenerated, SHA-pinned.

Source-only triple: 1 note + 1 runner + 1 cache. No audit surfaces touched; note-hash drift re-enters the row for re-audit.

## Verification

- Runner rerun independently: `TOTAL: PASS=20 FAIL=0`, exit 0.
- `grep -c "finite and nonempty"` → 2 (abstract + §2 hypothesis block).
- Cache SHA-pinned, exit_code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
