### PR TITLE
fix(lorentz-so4): condition on (A-free); remove Wightman/CPT overreach

### DIFF
--- a/docs/LORENTZ_BOOST_FREE_STAGGERED_FERMION_2POINT_SO4_NARROW_THEOREM_NOTE_2026-05-29.md
+++ b/docs/LORENTZ_BOOST_FREE_STAGGERED_FERMION_2POINT_SO4_NARROW_THEOREM_NOTE_2026-05-29.md
@@ -9,17 +9,17 @@ audit pipeline after independent review.
 audit verdict and downstream status are set only by the independent
 audit lane.
 **Primary runner:** [`scripts/frontier_lorentz_boost_free_staggered_fermion_2point_so4.py`](../scripts/frontier_lorentz_boost_free_staggered_fermion_2point_so4.py)
-(SCORECARD: PASS=54, FAIL=0)
+(SCORECARD: PASS=57, FAIL=0)
 **Cached runner output:** [`logs/runner-cache/frontier_lorentz_boost_free_staggered_fermion_2point_so4.txt`](../logs/runner-cache/frontier_lorentz_boost_free_staggered_fermion_2point_so4.txt)
 
-This note is the **matter-sector (fermion) analogue** of the existing
-free-scalar boost result (`LORENTZ_BOOST_COVARIANCE_3PLUS1D_THEOREM_NOTE.md`,
-Step 6: the free-scalar Euclidean 2-point `G_E` is SO(4)-rotation
-invariant in the continuum limit, equivalent by Wick rotation to
-SO(3,1) covariance of the Wightman function). It establishes the same
-SO(4)/boost statement for the FREE staggered Dirac/Kähler-Dirac 2-point
-Schwinger function. It introduces no new vocabulary and makes no
-emergent-Lorentz claim for the interacting theory.
+This note is the **matter-sector (fermion) analogue** of the Euclidean
+free-scalar SO(4) result in
+`LORENTZ_BOOST_COVARIANCE_3PLUS1D_THEOREM_NOTE.md`, Step 6. It establishes
+the corresponding Euclidean SO(4) statement for the explicitly specified
+free staggered Dirac/Kähler-Dirac 2-point Schwinger function, conditional on
+the action premise named below. It does not inherit or assert the scalar
+note's Minkowski/Wightman extension. It introduces no new vocabulary and
+makes no emergent-Lorentz claim for the interacting theory.
 
 ## Claim
 
@@ -55,7 +55,16 @@ the free 2-point Euclidean Schwinger function
     Δ(p) = m² + (1/a²) Σ_μ sin²(p_μ a).
 ```
 
-**Theorem (free staggered-Dirac 2-point SO(4) covariance).** In the
+premise (A-free): the explicitly specified free (`U = 1`) staggered
+(Kogut-Susskind) Euclidean action with the framework's canonical phases, as
+displayed in the Claim section. This note's theorem is conditional on (A-free)
+as the analyzed action; whether (A-free) is the framework's physical carrier
+is NOT established here (the cited retained-bounded realization authority
+expressly disclaims that identification). The retained-bounded realization
+authority referred to here is
+`STAGGERED_DIRAC_SUBSTEP2_KAHLER_DIRAC_EQUIVALENCE_NARROW_THEOREM_NOTE_2026-05-17.md`.
+
+**Theorem (free staggered-Dirac 2-point SO(4) covariance, conditional on (A-free)).** In the
 continuum limit `a → 0` with physical separation held fixed,
 
 ```text
@@ -70,8 +79,10 @@ equivalently, at finite `a` taste does not enter the scalar spectrum
 taste-breaking corrections that vanish as `a → 0`). In position space
 this is the SO(4)-rotation-invariant kernel
 built from the scalar Euclidean propagator `m K_1(m R)/(4π² R)` and its
-derivative; equivalently (Wick rotation `t → -i τ`) the corresponding
-Wightman 2-point function is SO(3,1)-covariant in the continuum limit.
+derivative; the corresponding Minkowski/Wightman statement is NOT part of
+this note's claim surface: passing from the Euclidean Schwinger function to a
+Wightman function requires an OS-reconstruction step that this note neither
+performs nor cites at retained grade (see What stays open).
 
 **Leading correction — scope.** The O(a²) leading-correction statement
 below is made for the **taste-singlet scalar spectrum `Δ(p)` / displayed
@@ -90,8 +101,10 @@ taste-breaking lives in the non-spectator taste channels that `Δ(p)`
 does not resolve.
 
 Within the taste-singlet scalar spectrum `Δ(p)`, the leading lattice
-correction is a **dimension-6, parity-even, CPT-even, ℓ = 4
-cubic-harmonic anisotropy at O(a²)**, with the same angular family
+correction is a **dimension-6, operator-level parity-even and CPT-even,
+ℓ = 4 cubic-harmonic anisotropy at O(a²)**, where parity/CPT-evenness here
+is only the algebraic property of the displayed finite polynomial operator,
+with the same angular family
 `Σ_μ p_μ⁴` as the free-scalar result. As a 4D Euclidean
 hyperspherical decomposition on `S³`,
 
@@ -109,16 +122,17 @@ fixed-direction spatial 3-slice (`p_0 = 0`) the same scalar-spectrum
 operator reduces to the free-scalar boost note's 3D `K_4` (isotropic
 part `3/5`, axis/diagonal ratio `3`) — the explicit free-scalar bridge.
 
-Because the free theory is exactly solvable, the continuum limit of the
-free 2-point function is well-defined and the SO(4) statement is
-**unconditional for the free 2-point function**.
+Given (A-free), the free theory is exactly solvable, so the continuum limit of
+its free 2-point function is well-defined and the SO(4) conclusion follows for
+that analyzed action. This does not establish (A-free) as the framework's
+physical carrier.
 
 ## Construction
 
 ### Free staggered operator and the Kähler-Dirac spin/taste structure
 
-The framework's free staggered action in lattice units (`U = 1`, unit
-lattice spacing in the difference term) is
+The action analyzed under (A-free), in lattice units (`U = 1`, unit lattice
+spacing in the difference term), is
 
 ```text
     S_lat = Σ_{n} χ̄(n) [ M χ(n)
@@ -127,10 +141,11 @@ lattice spacing in the difference term) is
     η_0 = 1,   η_μ(n) = (-1)^{n_0 + ... + n_{μ-1}},
 ```
 
-the same single-Grassmann-component-per-site staggered action used in
-the framework's reflection-positivity and dispersion notes (see
-Dependencies). The physical-unit first-order operator used in the
-momentum-space theorem is the normalized matrix
+This is the same single-Grassmann-component-per-site staggered formula used in
+the framework's reflection-positivity and dispersion notes (see Dependencies),
+but that formula-level match is not an identification of (A-free) as the
+framework's physical carrier. The physical-unit first-order operator used in
+the momentum-space theorem is the normalized matrix
 
 ```text
     D_phys = a^{-1} D_lat,
@@ -329,14 +344,18 @@ As a 4D Euclidean hyperspherical harmonic decomposition on `S³`:
   confirms the corresponding `Δ(p)` anisotropy ratio is `3.987` and that
   the axis and body-diagonal anisotropies match `-(a²/3) p⁴ Σ_μ n_μ⁴`
   to within `0.5%` (Part 4 checks 4.2).
-- **Dimension-6, parity-even, CPT-even.** The operator is `O(a² p⁴)`
-  (two extra momentum powers beyond the dim-4 kinetic term → dimension
-  6) and `Δ(-p) = Δ(p)` exactly (only even powers of each `p_μ`; runner
-  residual `0`, Part 4 check 4.7), so there is no dim-3 (mass-like,
-  CPT-odd) or dim-5 (P-odd) lattice correction at this order. This is
-  the same protection structure as the scalar/dispersion notes; the
-  CPT-even support is consistent with the CPT note (see
-  Dependencies).
+- **Dimension-6, operator-level parity-even and CPT-even.** The displayed
+  correction polynomial `Q_4(p) = Σ_μ p_μ⁴` is `O(a² p⁴)` (two extra
+  momentum powers beyond the dim-4 kinetic term → dimension 6). Under the
+  explicit Euclidean parity map
+  `P: (p_1,p_2,p_3,p_τ) → (-p_1,-p_2,-p_3,p_τ)` and the scalar-operator
+  CPT momentum map `p → -p`, every displayed monomial is unchanged. The
+  runner verifies these finite coefficient transforms exactly (Part 4 check
+  4.6) and separately verifies `Δ(-p) = Δ(p)` for the full finite-`a` scalar
+  spectrum (Part 4 check 4.7). This is only an algebraic classification of the
+  displayed polynomial operator; it is not a Wick-rotation argument or a
+  broader CPT-classification theorem. `CPT_EXACT_NOTE.md` is a context
+  cross-reference, not support for this claim.
 
 This is the same ℓ = 4 cubic-harmonic angular family that appears in the
 free-scalar boost note — both are the unique lowest non-trivial
@@ -364,11 +383,11 @@ position-space SO(4) scalar Schwinger kernel is the same
 
 ```bash
 python3 scripts/frontier_lorentz_boost_free_staggered_fermion_2point_so4.py
-# SCORECARD: PASS=54  FAIL=0
+# SCORECARD: PASS=57  FAIL=0
 # Exit code: 0
 ```
 
-The 54 checks span 9 parts (self-contained: numpy + scipy.special +
+The 57 checks span 9 parts (self-contained: numpy + scipy.special +
 optional sympy):
 
 | Part | Coverage                                                            | PASS |
@@ -381,9 +400,9 @@ optional sympy):
 | 4    | Scalar-spectrum leading anisotropy = dim-6 ℓ=4 cubic harmonic (4D; c₄=-1/3; no ℓ=2,6) | 8  |
 | 5    | Free-scalar bridge consistency (3-slice, coefficient, kernel)      | 4    |
 | 6    | Position-space SO(4) isotropy of the lattice trace 2-point (even sublattice) | 4 |
-| 7    | Combined SO(4)/SO(3,1) statement + relation to the scalar note     | 9    |
+| 7    | Conditional Euclidean theorem surface, note pins, and scalar-note context | 12   |
 
-Total: 54/54 PASS.
+Total: 57/57 PASS.
 
 A noted structural feature (Part 6): the trace (taste-summed) 2-point
 `tr G~ = 4m/Δ(p)` is invariant under the staggered taste shift
@@ -423,6 +442,10 @@ statement, which is the load-bearing content.
   function is treated. No Osterwalder-Schrader reconstruction, no
   continuum-existence (Wightman) claim, and no emergent-Lorentz claim
   for the interacting theory are made.
+- **Framework physical-carrier identification.** Premise (A-free) selects the
+  action analyzed here. This note does not establish that (A-free) is the
+  framework's realized or physical fermion carrier; the cited retained-bounded
+  realization authority expressly disclaims that identification.
 - **Taste-symmetry restoration at finite `a`.** The taste-spectator
   `1_taste` factorisation holds in the continuum limit (`a → 0`); at
   finite `a` the free theory already carries `O(a)` non-spectator
@@ -441,15 +464,27 @@ statement, which is the load-bearing content.
   is the structural continuum-limit covariance and the taste-singlet
   scalar-sector ℓ = 4 angular structure, with no physical-unit readout.
 
+**2026-07-10 downstream hygiene.** This note's citable surface is the
+Euclidean free staggered-Dirac 2-point continuum-limit SO(4) statement and the
+taste-singlet O(a²) anisotropy scope, conditional on the explicitly specified
+free action (A-free). Downstream notes must not cite this note as authority
+for: the identification of (A-free) as the framework's physical carrier; any
+Wightman/SO(3,1) covariance statement; or any CPT classification beyond the
+displayed operator-level parity/CPT-evenness algebra. Those extensions require
+separate retained support. This dated line itself moves the note hash so the
+row re-enters for re-audit.
+
 ## Honest status
 
-The continuum limit of the FREE staggered-Dirac 2-point Schwinger
-function is well-defined (the free theory is exactly solvable, the
-momentum-space propagator is the explicit closed form above), so the
+Conditional on (A-free), the continuum limit of the explicitly specified FREE
+staggered-Dirac 2-point Schwinger function is well-defined (the free theory is
+exactly solvable, and the momentum-space propagator is the explicit closed
+form above), so the
 SO(4)-covariance statement and the dim-6 ℓ = 4 cubic-harmonic
 characterisation of the leading O(a²) correction **of the taste-singlet
 scalar spectrum `Δ(p)` / displayed taste-spectator `D~` sector** are
-**unconditional for the free 2-point function**. The O(a²)
+theorems for that analyzed action. Whether (A-free) is the framework's
+physical carrier is not established here. The O(a²)
 leading-correction statement is confined to that taste-singlet scalar
 sector; for the FULL free staggered spin⊗taste propagator the leading
 finite-`a` correction is the `O(a)` non-spectator taste-mixing admitted
@@ -461,8 +496,9 @@ of the continuum propagator; closed-form inverse; `c_4 = -1/3`; pure 4D
 ℓ = 4 with no ℓ = 0/2/6) and at the expected O(a²) rate for the displayed
 taste-spectator block (lattice → continuum convergence; SO(4)-orbit
 residual scaling). This note makes no interacting-theory, n-point,
-OS-reconstruction, continuum-existence, full-spin⊗taste-propagator
-leading-order, or physical-unit claim, and introduces no new vocabulary:
+OS-reconstruction, Minkowski/Wightman, full-spin⊗taste-propagator
+leading-order, physical-carrier-identification, or physical-unit claim, and
+introduces no new vocabulary:
 it is one concrete sub-step, the matter-sector analogue of the
 free-scalar SO(4)/boost result. Status authority for this row is the
 independent audit lane.
@@ -482,16 +518,15 @@ is ledger-derived):
   `a → 0` form; at finite `a` the reconstruction carries the standard
   `O(a)` staggered taste-breaking, and what is exact is the scalar
   spectrum `Δ(p)` with its 4-fold taste multiplicity).
-- [CPT_EXACT_NOTE.md](CPT_EXACT_NOTE.md) — exact CPT on the
-  even periodic lattice. Supports the parity-even / CPT-even
-  classification of the leading O(a²) correction **of the taste-singlet
-  scalar spectrum `Δ(p)`** (no dim-3 / dim-5 operators); the present note
-  verifies `Δ(-p) = Δ(p)` directly on its own scalar-spectrum operator
-  family in the runner (Part 4 check 4.7).
-
 Context notes (plain-text / backticked per the citation-graph
 convention; not load-bearing one-hop dependencies of this row, cited for
 provenance of the conventions and as the sibling scalar result):
+
+- `CPT_EXACT_NOTE.md` — context only, not support. The present runner's
+  retained claim is limited to exact parity/CPT sign-transform invariance of
+  the displayed finite polynomial `Σ_μ p_μ⁴` and the separate inversion
+  evenness `Δ(-p) = Δ(p)`; no Wick-rotated or broader CPT classification is
+  imported from this note.
 
 - `LORENTZ_BOOST_COVARIANCE_3PLUS1D_THEOREM_NOTE.md` — the free-SCALAR
   SO(4)/boost result (Step 6) that this note is the matter-sector
@@ -509,3 +544,34 @@ provenance of the conventions and as the sibling scalar result):
   `η_μ(n) = (-1)^{Σ_{ν<μ} n_ν}`, action, exact free staggered
   dispersion `sinh² E = m² + sin² p` in 1+1d) against which the
   conventions used here are matched.
+
+## Repair Note
+
+**Date:** 2026-07-10
+
+Audit `notes_for_re_audit` (verbatim):
+
+> scope_too_broad: Narrow the claim to a theorem conditional on the explicitly specified free staggered action, remove or separately support the framework-carrier and Wightman/CPT extensions, and add a dated downstream-hygiene line to this note's own boundary so its hash drift re-enters the row into the audit queue.
+
+Narrowing applied:
+
+1. Named premise (A-free), made the theorem and honest-status language
+   conditional on that explicitly specified action, and disclaimed any
+   framework physical-carrier identification using the retained-bounded
+   realization authority's own boundary.
+2. Removed the claimed Euclidean-to-Wightman equivalence and replaced every
+   Wightman reference with an OS-reconstruction non-claim pointer or boundary.
+3. Confined parity/CPT-evenness to the displayed polynomial operator and moved
+   `CPT_EXACT_NOTE.md` to a backticked context-only cross-reference.
+4. Preserved the Euclidean continuum-limit statement and the existing
+   taste-singlet O(a²) versus full-spin⊗taste O(a) correction scopes.
+5. Added the dated downstream-hygiene boundary above and runner pins for the
+   narrowed note surface.
+
+Runner disposition: the assertion-only Wick-rotation PASS was demoted to a
+context log because no OS reconstruction is performed or retained-grade
+authority cited. The assertion-only CPT PASS was replaced by an exact
+coefficient-map verification of the displayed `Σ_μ p_μ⁴` polynomial under
+explicit parity and CPT momentum-sign transformations; the existing numerical
+`Δ(-p) = Δ(p)` check remains as a separate finite-`a` scalar-spectrum
+evenness check without broader classification language.

--- a/docs/LORENTZ_BOOST_FREE_STAGGERED_FERMION_2POINT_SO4_NARROW_THEOREM_NOTE_2026-05-29.md
+++ b/docs/LORENTZ_BOOST_FREE_STAGGERED_FERMION_2POINT_SO4_NARROW_THEOREM_NOTE_2026-05-29.md
@@ -43,9 +43,10 @@ with Euclidean `γ_μ` Hermitian, `{γ_μ, γ_ν} = 2 δ_{μν}`. The clean
 `1_taste` spin⊗taste factorisation written here is the `a → 0` form;
 what is exact at finite `a` is the **scalar spectrum**
 `Δ(p) = m² + (1/a²) Σ_μ sin²(p_μ a)`, with taste entering not the
-eigenvalue but as a **4-fold spectral multiplicity** (the genuine
-finite-`a` taste-breaking is the `O(a)` non-spectator mixing of standard
-staggered fermions, vanishing as `a → 0`; see Construction). Its inverse —
+eigenvalue but as a **4-fold spectral multiplicity**. In a local hypercube
+spin⊗taste basis there is `O(a)` non-spectator spin-taste mixing, but the free
+spectrum remains exactly fourfold degenerate: this is not physical taste
+splitting. The local-basis mixing vanishes as `a → 0`; see Construction. Its inverse —
 the free 2-point Euclidean Schwinger function
 `G_E(τ, x⃗) = ⟨χ(τ,x) χ̄(0,0)⟩` in momentum space — is
 
@@ -75,8 +76,9 @@ continuum limit `a → 0` with physical separation held fixed,
 the standard SO(4)-covariant Euclidean Dirac/Kähler-Dirac propagator
 (in this `a → 0` limit the taste factor is a spectator `1_taste`;
 equivalently, at finite `a` taste does not enter the scalar spectrum
-`Δ(p)` and appears only as a 4-fold spectral multiplicity, with `O(a)`
-taste-breaking corrections that vanish as `a → 0`). In position space
+`Δ(p)` and appears only as a 4-fold spectral multiplicity; the local-basis
+`O(a)` spin-taste mixing vanishes as `a → 0` and never splits that free
+spectrum). In position space
 this is the SO(4)-rotation-invariant kernel
 built from the scalar Euclidean propagator `m K_1(m R)/(4π² R)` and its
 derivative; the corresponding Minkowski/Wightman statement is NOT part of
@@ -89,16 +91,17 @@ below is made for the **taste-singlet scalar spectrum `Δ(p)` / displayed
 taste-spectator `D~` sector** (the taste-spectral-multiplicity sector
 verified in Part 1a), NOT for the full free staggered spin⊗taste
 propagator. For the FULL free staggered spin⊗taste propagator the leading
-finite-`a` correction is the **`O(a)` non-spectator taste-mixing** of the
-hypercube spin⊗taste reconstruction (standard staggered taste-breaking;
-e.g. `γ_S ⊗ ξ_5` channels), as the Construction admits; that `O(a)`
-taste-mixing vanishes as `a → 0`, recovering the displayed `D~(p)`. The
+finite-`a` correction in a local hypercube basis is the **`O(a)`
+non-spectator spin-taste mixing** of the hypercube reconstruction (e.g.
+`γ_S ⊗ ξ_5` channels), as the Construction admits; that basis-dependent
+mixing vanishes as `a → 0`, recovering the displayed `D~(p)`. The
 two statements are consistent: the taste-singlet scalar spectrum `Δ(p)`
 is exactly the sector in which taste does not enter the eigenvalue (it
 appears only as a 4-fold spectral multiplicity), so its leading
 anisotropy is the `O(a²)` cubic harmonic, while the genuine `O(a)`
-taste-breaking lives in the non-spectator taste channels that `Δ(p)`
-does not resolve.
+spin-taste mixing lives in channels that `Δ(p)` does not resolve. The free
+fourfold degeneracy remains exact; interacting taste violation is the
+separate `O(a²)` effect named below.
 
 Within the taste-singlet scalar spectrum `Δ(p)`, the leading lattice
 correction is a **dimension-6, operator-level parity-even and CPT-even,
@@ -170,8 +173,9 @@ only as the spectator factor `1_taste` — is the **continuum-limit**
 (`a → 0`) form of the operator, NOT an exact finite-`a` reduced-BZ
 lattice-operator identity. At finite `a` the honest hypercube spin⊗taste
 reconstruction (Kawamoto-Smit / Kluberg-Stern) carries `O(a)`
-non-spectator taste-mixing channels (e.g. `γ_S ⊗ ξ_5`) at generic
-momenta — the standard staggered taste-breaking — and a dimension count
+non-spectator spin-taste mixing channels (e.g. `γ_S ⊗ ξ_5`) at generic
+momenta. This is a local-basis mixing, not physical splitting of the exactly
+fourfold-degenerate free spectrum. A dimension count
 confirms the factorisation cannot be a single-spacing identity: the 16
 spin⊗taste components carrying one Grassmann dof per site live on the
 block lattice `(L/2)^4` at spacing `2a` (`16 · (L/2)^4 = L^4`), so a
@@ -181,8 +185,9 @@ spectrum** `Δ(p) = m² + (1/a²) Σ_μ sin²(p_μ a)`: taste does not enter the
 eigenvalue but appears as a **4-fold spectral multiplicity** (every
 eigenvalue multiplicity is divisible by 4). The taste-spectator `1_taste`
 statement is therefore a continuum-limit / 4-fold-spectral-multiplicity
-statement; the genuine finite-`a` taste-breaking is `O(a)` and vanishes
-as `a → 0`, recovering the displayed spin⊗taste `D~(p)`.
+statement; the local-basis finite-`a` spin-taste mixing is `O(a)` and vanishes
+as `a → 0`, recovering the displayed spin⊗taste `D~(p)`. Interacting taste
+violation is a separate `O(a²)` effect.
 
 #### Canonical phase-to-spin/taste derivation inside this packet
 
@@ -449,13 +454,14 @@ statement, which is the load-bearing content.
 - **Taste-symmetry restoration at finite `a`.** The taste-spectator
   `1_taste` factorisation holds in the continuum limit (`a → 0`); at
   finite `a` the free theory already carries `O(a)` non-spectator
-  taste-breaking in the spin⊗taste reconstruction (standard staggered
-  taste-breaking), vanishing as `a → 0`. What is exact at finite `a` is
+  non-spectator spin-taste mixing in a local hypercube reconstruction,
+  vanishing as `a → 0`. This is not physical taste splitting: what is exact
+  at finite `a` is
   the scalar spectrum `Δ(p)` (taste enters only as a 4-fold multiplicity,
   not the eigenvalue). The additional interacting-theory taste-breaking
   (`O(a²)` taste-violating four-fermion operators) is a separate effect
   and is out of scope; the magnitude and continuum extrapolation of free
-  finite-`a` taste-breaking are likewise out of scope here.
+  finite-`a` local-basis mixing are likewise out of scope here.
 - **Physical-unit conversion.** Any conversion of the O(a²)
   scalar-spectrum anisotropy to physical Lorentz-violation magnitude
   requires the Planck-pin / unit-map premise `a ~ 1/M_Pl`, which is NOT
@@ -487,8 +493,9 @@ theorems for that analyzed action. Whether (A-free) is the framework's
 physical carrier is not established here. The O(a²)
 leading-correction statement is confined to that taste-singlet scalar
 sector; for the FULL free staggered spin⊗taste propagator the leading
-finite-`a` correction is the `O(a)` non-spectator taste-mixing admitted
-in the Construction (vanishing as `a → 0`), so no O(a²) leading-correction
+finite-`a` correction in a local hypercube basis is the `O(a)` non-spectator
+spin-taste mixing admitted in the Construction (vanishing as `a → 0` while
+the free spectrum remains exactly fourfold degenerate), so no O(a²) leading-correction
 claim is made for the full spin⊗taste propagator. The scalar-sector
 statements are exact algebraic / continuum-limit facts, verified by the
 registered runner at machine precision (exact SO(4) bispinor covariance
@@ -515,9 +522,10 @@ is ledger-derived):
   load-bearing algebraic spin/taste structure whose continuum limit is
   the spin⊗taste momentum-space operator `D~(p) = m 1 + (i/a) Σ γ_μ ⊗
   1_taste sin(p_μ a)` used here (the clean `1_taste` factorisation is the
-  `a → 0` form; at finite `a` the reconstruction carries the standard
-  `O(a)` staggered taste-breaking, and what is exact is the scalar
-  spectrum `Δ(p)` with its 4-fold taste multiplicity).
+  `a → 0` form; at finite `a` the local reconstruction carries `O(a)`
+  non-spectator spin-taste mixing without splitting the exactly fourfold-
+  degenerate free spectrum, and what is exact is the scalar spectrum `Δ(p)`
+  with its 4-fold taste multiplicity).
 Context notes (plain-text / backticked per the citation-graph
 convention; not load-bearing one-hop dependencies of this row, cited for
 provenance of the conventions and as the sibling scalar result):

--- a/logs/runner-cache/frontier_lorentz_boost_free_staggered_fermion_2point_so4.txt
+++ b/logs/runner-cache/frontier_lorentz_boost_free_staggered_fermion_2point_so4.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_lorentz_boost_free_staggered_fermion_2point_so4.py
-runner_sha256: cc4f729dc0d9a85b071630beeda27d7316f2ec5d9f2d5d5637d26a32e0d99d11
+runner_sha256: 7710d3f9767f90db16cbed90b43c2a0bab727b0572906b1e4048dd202ee1c224
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 18.56
+elapsed_sec: 19.13
 status: ok
 ----- stdout -----
 ==============================================================================
@@ -14,7 +14,8 @@ THEOREM (conditional on (A-free)):
          lim_{a->0} G~_lat(p) = (m - i gamma.p)/(p^2 + m^2),
          the SO(4)-covariant Euclidean Dirac/Kahler-Dirac propagator;
          taste-singlet scalar-spectrum leading correction = dim-6 ell=4
-         cubic harmonic, O(a^2) (full spin x taste leading corr is O(a)).
+         cubic harmonic, O(a^2) (local-basis spin-taste mixing is O(a);
+         the free spectrum remains exactly fourfold degenerate).
 
 
 === Part 0: canonical staggered phases -> reduced-BZ spin/taste operator ===
@@ -109,7 +110,7 @@ THEOREM (conditional on (A-free)):
   [PASS] Z^3 x Z_tau has hypercubic point symmetry, NOT SO(4)  (SO(4) is non-compact-completion of the cubic group; emergent only)
   [PASS] Continuum-limit D~(p) = m 1 + (i/a) sum gamma_mu sin(p_mu a) (KS basis)  (phases eta_0=1, eta_mu=(-1)^{sum_{nu<mu} n_nu}; 1_taste spectator is the a->0 form, finite-a taste enters as 4-fold spectral mult (Part 1a))
   [PASS] THEOREM: lim_{a->0} G~_lat(p) = (m - i gamma.p)/(p^2+m^2)  (standard SO(4) Euclidean Dirac/Kahler-Dirac propagator)
-  [PASS] Scalar-spectrum leading lattice correction: dim-6, ell=4 cubic harmonic, O(a^2)  (sum_mu p_mu^4; iso 1/2, axis/diag ratio 4 (4D); no ell=2,6 (taste-singlet Delta(p)/D~ sector; full spin x taste leading corr is O(a)))
+  [PASS] Scalar-spectrum leading lattice correction: dim-6, ell=4 cubic harmonic, O(a^2)  (sum_mu p_mu^4; iso 1/2, axis/diag ratio 4 (4D); no ell=2,6 (taste-singlet Delta(p)/D~ sector; local-basis spin-taste mixing is O(a), free spectrum exactly fourfold degenerate))
   [CONTEXT] Displayed-polynomial P/CPT classification  (real algebraic check is Part 4.6; CPT_EXACT_NOTE is context, not support)
   [CONTEXT] Minkowski/Wightman extension excluded  (no Wick-rotation PASS: OS reconstruction is outside this claim surface)
   [PASS] MATTER-SECTOR ANALOGUE of free-scalar boost note Step 6 (SO(4))  (same mechanism: cubic dispersion -> isotropic continuum limit)
@@ -124,7 +125,8 @@ All checks passed. Conditional on (A-free), the explicitly specified
 FREE staggered-Dirac 2-point Schwinger function becomes SO(4)-covariant
 in the continuum limit, with the
 taste-singlet scalar spectrum's leading anisotropy a dim-6 ell=4
-cubic harmonic at O(a^2) (full spin x taste leading corr is O(a)).
+cubic harmonic at O(a^2) (local-basis spin-taste mixing is O(a);
+the free spectrum remains exactly fourfold degenerate).
 Matter-sector analogue of the free-scalar boost note.
 
 ----- stderr -----

--- a/logs/runner-cache/frontier_lorentz_boost_free_staggered_fermion_2point_so4.txt
+++ b/logs/runner-cache/frontier_lorentz_boost_free_staggered_fermion_2point_so4.txt
@@ -1,16 +1,17 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_lorentz_boost_free_staggered_fermion_2point_so4.py
-runner_sha256: c5caa0e09a30f24e369d89a9dda5038114ab105e014003c94f422a57bd136699
+runner_sha256: cc4f729dc0d9a85b071630beeda27d7316f2ec5d9f2d5d5637d26a32e0d99d11
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 18.30
+elapsed_sec: 18.56
 status: ok
 ----- stdout -----
 ==============================================================================
 SO(4) Covariance of the FREE Staggered-Dirac 2-Point Schwinger Function
 ==============================================================================
 
-THEOREM: lim_{a->0} G~_lat(p) = (m - i gamma.p)/(p^2 + m^2),
+THEOREM (conditional on (A-free)):
+         lim_{a->0} G~_lat(p) = (m - i gamma.p)/(p^2 + m^2),
          the SO(4)-covariant Euclidean Dirac/Kahler-Dirac propagator;
          taste-singlet scalar-spectrum leading correction = dim-6 ell=4
          cubic harmonic, O(a^2) (full spin x taste leading corr is O(a)).
@@ -74,8 +75,8 @@ THEOREM: lim_{a->0} G~_lat(p) = (m - i gamma.p)/(p^2 + m^2),
   [PASS] 4D isotropic average <sum n_mu^4>_{S^3} = 1/2  (numeric = 0.50026, exact 3/(d+2) = 1/2 at d=4)
   [PASS] No ell=2 contamination: <f * (n_a n_b - delta/4)>_{S^3} ~ 0  (max ell=2 projection = 1.81e-04 (pure ell=4))
   [PASS] Sympy: H4 = sum x_mu^4 - (1/2) r^4 is harmonic (pure 4D ell=4)  (Laplacian(H4) = 0 (=> no ell=0,2,6 admixture))
-  [PASS] Scalar-spectrum leading LV operator is dimension-6 (O(a^2 p^4), two extra momenta)  (sum_mu p_mu^4 with coeff a^2/3; CPT-even, parity-even (even powers); taste-singlet Delta(p) sector (full spin x taste leading corr is O(a)))
-  [PASS] Parity-even: Delta(-p) = Delta(p) (no dim-5 / CPT-odd dispersion term)  (max|Delta(-p)-Delta(p)| = 0.0e+00)
+  [PASS] Displayed Q4=sum_mu p_mu^4 is degree-4 and exactly P/CPT-even  (exact coefficient maps under P:(p1,p2,p3,ptau)->(-p1,-p2,-p3,ptau) and scalar-operator CPT:p->-p)
+  [PASS] Finite-a scalar spectrum is momentum-inversion even: Delta(-p)=Delta(p)  (max|Delta(-p)-Delta(p)| = 0.0e+00)
 
 === Part 5: free-scalar bridge consistency ===
 
@@ -98,24 +99,30 @@ THEOREM: lim_{a->0} G~_lat(p) = (m - i gamma.p)/(p^2 + m^2),
   [PASS] Axis vs body-diagonal (all-even, equal physical R=2.0) anisotropy shrinks with a  (rel anisotropy: a=0.5 -> 5.814e-01, a=0.25 -> 2.620e-01 (dim-6 ell=4, O(a^2)))
   [PASS] Trace Euclidean Schwinger function real (Im~0) and positive (even sep)  (tr G_E(2,0,0,0) = 7.2004e-02, |Im| = 1.1e-15)
 
-=== Part 7: combined SO(4) statement + relation to scalar note ===
+=== Part 7: conditional Euclidean theorem surface + context ===
 
+  [PASS] Note pin: premise (A-free) is present
+  [PASS] Note pin: theorem header is conditional on (A-free)
+  [PASS] Note pin: Minkowski/Wightman sentence is an OS-reconstruction non-claim
+  [PASS] Note pin: 2026-07-10 downstream-hygiene boundary is present
+  [PASS] Note pin: old unconditional Wick-rotation equivalence is absent
   [PASS] Z^3 x Z_tau has hypercubic point symmetry, NOT SO(4)  (SO(4) is non-compact-completion of the cubic group; emergent only)
   [PASS] Continuum-limit D~(p) = m 1 + (i/a) sum gamma_mu sin(p_mu a) (KS basis)  (phases eta_0=1, eta_mu=(-1)^{sum_{nu<mu} n_nu}; 1_taste spectator is the a->0 form, finite-a taste enters as 4-fold spectral mult (Part 1a))
   [PASS] THEOREM: lim_{a->0} G~_lat(p) = (m - i gamma.p)/(p^2+m^2)  (standard SO(4) Euclidean Dirac/Kahler-Dirac propagator)
   [PASS] Scalar-spectrum leading lattice correction: dim-6, ell=4 cubic harmonic, O(a^2)  (sum_mu p_mu^4; iso 1/2, axis/diag ratio 4 (4D); no ell=2,6 (taste-singlet Delta(p)/D~ sector; full spin x taste leading corr is O(a)))
-  [PASS] Parity-even + CPT-even: only even powers of p (no dim-3, dim-5)  (Delta(-p)=Delta(p); matches scalar/dispersion-note structure)
-  [PASS] Wick rotation: continuum Wightman 2-pt is SO(3,1)-covariant  (SO(4) Euclidean invariance <=> SO(3,1) boost covariance (t=-i tau))
+  [CONTEXT] Displayed-polynomial P/CPT classification  (real algebraic check is Part 4.6; CPT_EXACT_NOTE is context, not support)
+  [CONTEXT] Minkowski/Wightman extension excluded  (no Wick-rotation PASS: OS reconstruction is outside this claim surface)
   [PASS] MATTER-SECTOR ANALOGUE of free-scalar boost note Step 6 (SO(4))  (same mechanism: cubic dispersion -> isotropic continuum limit)
   [PASS] Free-scalar bridge: spatial 3-slice reduces to scalar note's 3D K_4  (iso 3/5, ratio 3 on the slice; full 4D is iso 1/2, ratio 4)
-  [PASS] Unconditional for the FREE 2-point function (free theory limit exists)  (NOT interacting, NOT n-point, NOT OS reconstruction, NOT FS)
+  [PASS] Conditional on (A-free): free 2-point Euclidean limit exists  (NOT a framework-carrier, interacting, n-point, OS, or Minkowski claim)
 
 ==============================================================================
-SCORECARD: PASS=54  FAIL=0
+SCORECARD: PASS=57  FAIL=0
 ==============================================================================
 
-All checks passed. The FREE staggered-Dirac 2-point Schwinger
-function becomes SO(4)-covariant in the continuum limit, with the
+All checks passed. Conditional on (A-free), the explicitly specified
+FREE staggered-Dirac 2-point Schwinger function becomes SO(4)-covariant
+in the continuum limit, with the
 taste-singlet scalar spectrum's leading anisotropy a dim-6 ell=4
 cubic harmonic at O(a^2) (full spin x taste leading corr is O(a)).
 Matter-sector analogue of the free-scalar boost note.

--- a/scripts/frontier_lorentz_boost_free_staggered_fermion_2point_so4.py
+++ b/scripts/frontier_lorentz_boost_free_staggered_fermion_2point_so4.py
@@ -9,8 +9,9 @@ STATUS: bounded theorem, conditional on premise (A-free), on the continuum
         of the leading dim-6, ell=4 cubic-harmonic anisotropy at O(a^2) OF THE
         TASTE-SINGLET SCALAR SPECTRUM Delta(p) / displayed taste-spectator D~
         sector. (For the full free staggered spin x taste propagator the
-        leading finite-a correction is the O(a) non-spectator taste-mixing
-        admitted below, vanishing as a->0; no O(a^2) leading-correction claim
+        leading finite-a correction in a local hypercube basis is O(a)
+        non-spectator spin-taste mixing, vanishing as a->0 while the free
+        spectrum stays exactly fourfold degenerate; no O(a^2) leading-correction claim
         is made for the full spin x taste propagator.)
         Status authority: independent audit lane only.
 
@@ -44,15 +45,17 @@ THEOREM (free staggered-Dirac 2-point SO(4) covariance, conditional on
   The clean 1_taste spin(x)taste factorisation is the a -> 0 form, NOT an
   exact finite-a reduced-BZ lattice-operator identity: at finite a the honest
   hypercube spin(x)taste reconstruction (Kawamoto-Smit / Kluberg-Stern) carries
-  O(a) non-spectator taste-mixing channels (e.g. gamma_S (x) xi_5), the standard
-  staggered taste-breaking, and a dimension count forbids the factorisation as
+  O(a) non-spectator spin-taste mixing channels (e.g. gamma_S (x) xi_5).
+  This is local-basis mixing, not physical splitting of the exactly
+  fourfold-degenerate free spectrum. A dimension count forbids the factorisation as
   a single-spacing identity (16 spin(x)taste components carrying one dof/site
   live on the block lattice (L/2)^4 at spacing 2a: 16*(L/2)^4 = L^4). What IS
   exact at finite a is the SCALAR SPECTRUM Delta(p) = m^2 + (1/a^2) sum_mu
   sin^2(p_mu a): taste does not enter the eigenvalue but appears as a 4-FOLD
   SPECTRAL MULTIPLICITY (every eigenvalue multiplicity divisible by 4). The
   taste-spectator statement is therefore a continuum-limit / 4-fold-spectral-
-  multiplicity statement; finite-a taste-breaking is O(a) and vanishes as a->0.
+  multiplicity statement; local-basis spin-taste mixing is O(a) and vanishes
+  as a->0. Interacting taste violation is a separate O(a^2) effect.
   (Part 1a verifies the exact spectrum + 4-fold multiplicity on the genuine
   position-space staggered operator.)
   Its inverse (the 2-point Schwinger function in momentum space) is
@@ -72,7 +75,8 @@ THEOREM (free staggered-Dirac 2-point SO(4) covariance, conditional on
   the STANDARD SO(4)-COVARIANT Euclidean Dirac/Kahler-Dirac propagator
   (in this a -> 0 limit taste is a spectator 1_taste; at finite a taste does
   not enter the scalar spectrum Delta(p) and appears only as a 4-fold spectral
-  multiplicity, with O(a) taste-breaking that vanishes as a -> 0). In position
+  multiplicity, with O(a) local-basis spin-taste mixing that vanishes as
+  a -> 0 without splitting the free spectrum). In position
   space this is the SO(4)-rotation-invariant kernel built from the scalar
   Euclidean propagator G_E^scal(R) = m K_1(m R)/(4 pi^2 R) and its
   derivative. A corresponding Minkowski/Wightman statement is outside this
@@ -83,7 +87,7 @@ THEOREM (free staggered-Dirac 2-point SO(4) covariance, conditional on
   displayed taste-spectator D~ sector: O(a^2), dimension-6, parity-even,
   CPT-even, ell=4 CUBIC HARMONIC. (For the FULL free staggered spin x taste
   propagator the leading finite-a correction is the O(a) non-spectator
-  taste-mixing above, not this O(a^2) term.) It enters through
+  spin-taste mixing above, not this O(a^2) term.) It enters through
       sin(p_mu a)/a = p_mu - (a^2/6) p_mu^3 + O(a^4)              (numerator)
       Delta(p) = m^2 + |p|^2 - (a^2/3) sum_mu p_mu^4 + O(a^4)     (denominator)
   The unique anisotropic structure is sum_mu p_mu^4. As a 4D Euclidean
@@ -1071,7 +1075,8 @@ def test_part7_combined():
 
     check("Scalar-spectrum leading lattice correction: dim-6, ell=4 cubic harmonic, O(a^2)",
           True, "sum_mu p_mu^4; iso 1/2, axis/diag ratio 4 (4D); no ell=2,6 "
-          "(taste-singlet Delta(p)/D~ sector; full spin x taste leading corr is O(a))")
+          "(taste-singlet Delta(p)/D~ sector; local-basis spin-taste mixing is O(a), "
+          "free spectrum exactly fourfold degenerate)")
 
     context_log("Displayed-polynomial P/CPT classification",
                 "real algebraic check is Part 4.6; CPT_EXACT_NOTE is context, not support")
@@ -1123,7 +1128,8 @@ def main():
     print("         lim_{a->0} G~_lat(p) = (m - i gamma.p)/(p^2 + m^2),")
     print("         the SO(4)-covariant Euclidean Dirac/Kahler-Dirac propagator;")
     print("         taste-singlet scalar-spectrum leading correction = dim-6 ell=4")
-    print("         cubic harmonic, O(a^2) (full spin x taste leading corr is O(a)).")
+    print("         cubic harmonic, O(a^2) (local-basis spin-taste mixing is O(a);")
+    print("         the free spectrum remains exactly fourfold degenerate).")
     print()
 
     test_part0_canonical_staggered_to_spin_taste()
@@ -1149,7 +1155,8 @@ def main():
         print("FREE staggered-Dirac 2-point Schwinger function becomes SO(4)-covariant")
         print("in the continuum limit, with the")
         print("taste-singlet scalar spectrum's leading anisotropy a dim-6 ell=4")
-        print("cubic harmonic at O(a^2) (full spin x taste leading corr is O(a)).")
+        print("cubic harmonic at O(a^2) (local-basis spin-taste mixing is O(a);")
+        print("the free spectrum remains exactly fourfold degenerate).")
         print("Matter-sector analogue of the free-scalar boost note.")
         sys.exit(0)
 

--- a/scripts/frontier_lorentz_boost_free_staggered_fermion_2point_so4.py
+++ b/scripts/frontier_lorentz_boost_free_staggered_fermion_2point_so4.py
@@ -3,7 +3,8 @@
 SO(4) Covariance of the FREE Staggered-Dirac 2-Point Schwinger Function
 =======================================================================
 
-STATUS: bounded theorem on the continuum limit of the FREE (U=1) staggered
+STATUS: bounded theorem, conditional on premise (A-free), on the continuum
+        limit of the explicitly specified FREE (U=1) staggered
         2-point Euclidean Schwinger function, with explicit characterisation
         of the leading dim-6, ell=4 cubic-harmonic anisotropy at O(a^2) OF THE
         TASTE-SINGLET SCALAR SPECTRUM Delta(p) / displayed taste-spectator D~
@@ -18,7 +19,13 @@ boost note:
   docs/LORENTZ_BOOST_COVARIANCE_3PLUS1D_THEOREM_NOTE.md
   scripts/frontier_lorentz_boost_3plus1d.py  (free scalar; Step 6 SO(4)).
 
-THEOREM (free staggered-Dirac 2-point SO(4) covariance):
+PREMISE (A-free): the explicitly specified free (U=1) staggered
+  (Kogut-Susskind) Euclidean action with the framework's canonical phases.
+  This runner analyzes that action; it does not identify (A-free) as the
+  framework's physical carrier.
+
+THEOREM (free staggered-Dirac 2-point SO(4) covariance, conditional on
+(A-free)):
   On the free (U=1) staggered (Kogut-Susskind) lattice with the framework's
   canonical phases eta_0 = 1, eta_mu(n) = (-1)^{n_0 + ... + n_{mu-1}}, the
   CONTINUUM-LIMIT (a -> 0) spin(x)taste form of the free staggered Dirac
@@ -68,8 +75,9 @@ THEOREM (free staggered-Dirac 2-point SO(4) covariance):
   multiplicity, with O(a) taste-breaking that vanishes as a -> 0). In position
   space this is the SO(4)-rotation-invariant kernel built from the scalar
   Euclidean propagator G_E^scal(R) = m K_1(m R)/(4 pi^2 R) and its
-  derivative; equivalently (Wick rotation t -> -i tau) the Wightman
-  2-point function is SO(3,1)-covariant in the continuum limit.
+  derivative. A corresponding Minkowski/Wightman statement is outside this
+  runner's claim surface: OS reconstruction is neither performed nor cited at
+  retained grade.
 
   Leading lattice correction OF THE TASTE-SINGLET SCALAR SPECTRUM Delta(p) /
   displayed taste-spectator D~ sector: O(a^2), dimension-6, parity-even,
@@ -92,8 +100,8 @@ SCOPE (deliberately narrow; the audit lane is harsh):
   * FREE (U=1) fermion 2-POINT function ONLY.
   * NOT the interacting theory, NOT n-point, NOT full OS reconstruction,
     NOT a continuum-existence claim. The continuum LIMIT of the free 2-pt
-    function is well-defined (free theory), so the result is UNCONDITIONAL
-    for the free 2-pt.
+    function is well-defined for the analyzed action, so the result follows
+    conditional on (A-free), without a framework physical-carrier claim.
   * Matter-sector analogue of the existing free-scalar SO(4)/boost result;
     NO new vocabulary, NO emergent-Lorentz claim for the interacting theory.
 
@@ -109,12 +117,13 @@ CONVENTIONS verified against the repo:
     STAGGERED_DIRAC_SUBSTEP2_KAHLER_DIRAC_EQUIVALENCE_NARROW_THEOREM_NOTE
     _2026-05-17.md.
 
-This runner verifies the theorem with >= 30 PASS checks across 8 parts.
+This runner verifies the theorem with >= 30 PASS checks across 9 parts.
 Self-contained: numpy + scipy.special (+ optional sympy).
 """
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 import numpy as np
 import scipy.special as sp
 
@@ -137,6 +146,14 @@ def check(name, condition, detail="", kind="EXACT"):
         msg += f"  ({detail})"
     print(msg)
     return condition
+
+
+def context_log(name, detail=""):
+    """Print non-verdict context without changing PASS/FAIL accounting."""
+    msg = f"  [CONTEXT] {name}"
+    if detail:
+        msg += f"  ({detail})"
+    print(msg)
 
 
 # =============================================================================
@@ -845,22 +862,36 @@ def test_part4_l4_cubic_harmonic():
               np.max(np.abs(lap)) < 1e-9,
               "sympy not installed; pointwise Laplacian check used")
 
-    # 4.6 dimension-6 classification: the scalar-spectrum LV operator is
-    #     O(a^2 p^4), i.e. two extra powers of momentum beyond the dim-4
-    #     kinetic term -> dimension 6.
-    check("Scalar-spectrum leading LV operator is dimension-6 (O(a^2 p^4), two extra momenta)",
-          True,
-          "sum_mu p_mu^4 with coeff a^2/3; CPT-even, parity-even (even powers); "
-          "taste-singlet Delta(p) sector (full spin x taste leading corr is O(a))")
+    # 4.6 Exact finite-polynomial classification of the DISPLAYED dim-6 term.
+    #     P flips the three spatial momenta and CPT reverses all four momenta;
+    #     charge conjugation acts trivially on this real scalar coefficient.
+    q4_terms = {
+        tuple(4 if nu == mu else 0 for nu in range(4)): -1
+        for mu in range(4)
+    }
 
-    # 4.7 parity-even / CPT-even: Delta(-p) = Delta(p) (no odd-power terms).
+    def sign_transform(terms, signs):
+        return {
+            powers: coeff * np.prod([sign ** power for sign, power in zip(signs, powers)])
+            for powers, coeff in terms.items()
+        }
+
+    parity_image = sign_transform(q4_terms, (-1, -1, -1, 1))
+    cpt_image = sign_transform(q4_terms, (-1, -1, -1, -1))
+    degree_four = all(sum(powers) == 4 for powers in q4_terms)
+    check("Displayed Q4=sum_mu p_mu^4 is degree-4 and exactly P/CPT-even",
+          degree_four and parity_image == q4_terms and cpt_image == q4_terms,
+          "exact coefficient maps under P:(p1,p2,p3,ptau)->(-p1,-p2,-p3,ptau) "
+          "and scalar-operator CPT:p->-p")
+
+    # 4.7 Separate finite-a scalar-spectrum inversion evenness check.
     rng3 = np.random.default_rng(9)
     max_par = 0.0
     a = 0.3
     for _ in range(50):
         p = rng3.uniform(-2, 2, 4)
         max_par = max(max_par, abs(Delta_lat(p, a, m) - Delta_lat(-p, a, m)))
-    check("Parity-even: Delta(-p) = Delta(p) (no dim-5 / CPT-odd dispersion term)",
+    check("Finite-a scalar spectrum is momentum-inversion even: Delta(-p)=Delta(p)",
           max_par < 1e-13, f"max|Delta(-p)-Delta(p)| = {max_par:.1e}")
 
     return True
@@ -1001,11 +1032,32 @@ def test_part6_position_space_so4():
 
 
 # =============================================================================
-# Part 7: combined statement + relation to existing notes
+# Part 7: conditional Euclidean statement, note-surface pins, and context
 # =============================================================================
 
 def test_part7_combined():
-    print("\n=== Part 7: combined SO(4) statement + relation to scalar note ===\n")
+    print("\n=== Part 7: conditional Euclidean theorem surface + context ===\n")
+
+    note_path = (Path(__file__).resolve().parents[1] / "docs" /
+                 "LORENTZ_BOOST_FREE_STAGGERED_FERMION_2POINT_SO4_NARROW_THEOREM_NOTE_2026-05-29.md")
+    note_text = note_path.read_text(encoding="utf-8")
+    note_surface = " ".join(note_text.split())
+    wightman_nonclaim = (
+        "the corresponding Minkowski/Wightman statement is NOT part of this "
+        "note's claim surface: passing from the Euclidean Schwinger function "
+        "to a Wightman function requires an OS-reconstruction step that this "
+        "note neither performs nor cites at retained grade (see What stays open)."
+    )
+    check("Note pin: premise (A-free) is present", "(A-free)" in note_text)
+    check("Note pin: theorem header is conditional on (A-free)",
+          "Theorem (free staggered-Dirac 2-point SO(4) covariance, conditional on (A-free))"
+          in note_surface)
+    check("Note pin: Minkowski/Wightman sentence is an OS-reconstruction non-claim",
+          wightman_nonclaim in note_surface)
+    check("Note pin: 2026-07-10 downstream-hygiene boundary is present",
+          "**2026-07-10 downstream hygiene.**" in note_text)
+    check("Note pin: old unconditional Wick-rotation equivalence is absent",
+          "equivalently (Wick rotation" not in note_text)
 
     check("Z^3 x Z_tau has hypercubic point symmetry, NOT SO(4)",
           True, "SO(4) is non-compact-completion of the cubic group; emergent only")
@@ -1021,11 +1073,11 @@ def test_part7_combined():
           True, "sum_mu p_mu^4; iso 1/2, axis/diag ratio 4 (4D); no ell=2,6 "
           "(taste-singlet Delta(p)/D~ sector; full spin x taste leading corr is O(a))")
 
-    check("Parity-even + CPT-even: only even powers of p (no dim-3, dim-5)",
-          True, "Delta(-p)=Delta(p); matches scalar/dispersion-note structure")
+    context_log("Displayed-polynomial P/CPT classification",
+                "real algebraic check is Part 4.6; CPT_EXACT_NOTE is context, not support")
 
-    check("Wick rotation: continuum Wightman 2-pt is SO(3,1)-covariant",
-          True, "SO(4) Euclidean invariance <=> SO(3,1) boost covariance (t=-i tau)")
+    context_log("Minkowski/Wightman extension excluded",
+                "no Wick-rotation PASS: OS reconstruction is outside this claim surface")
 
     check("MATTER-SECTOR ANALOGUE of free-scalar boost note Step 6 (SO(4))",
           True, "same mechanism: cubic dispersion -> isotropic continuum limit")
@@ -1033,8 +1085,8 @@ def test_part7_combined():
     check("Free-scalar bridge: spatial 3-slice reduces to scalar note's 3D K_4",
           True, "iso 3/5, ratio 3 on the slice; full 4D is iso 1/2, ratio 4")
 
-    check("Unconditional for the FREE 2-point function (free theory limit exists)",
-          True, "NOT interacting, NOT n-point, NOT OS reconstruction, NOT FS")
+    check("Conditional on (A-free): free 2-point Euclidean limit exists",
+          True, "NOT a framework-carrier, interacting, n-point, OS, or Minkowski claim")
 
     return True
 
@@ -1067,7 +1119,8 @@ def main():
     print("SO(4) Covariance of the FREE Staggered-Dirac 2-Point Schwinger Function")
     print("=" * 78)
     print()
-    print("THEOREM: lim_{a->0} G~_lat(p) = (m - i gamma.p)/(p^2 + m^2),")
+    print("THEOREM (conditional on (A-free)):")
+    print("         lim_{a->0} G~_lat(p) = (m - i gamma.p)/(p^2 + m^2),")
     print("         the SO(4)-covariant Euclidean Dirac/Kahler-Dirac propagator;")
     print("         taste-singlet scalar-spectrum leading correction = dim-6 ell=4")
     print("         cubic harmonic, O(a^2) (full spin x taste leading corr is O(a)).")
@@ -1092,8 +1145,9 @@ def main():
         print("\n*** FAILURES DETECTED ***")
         sys.exit(1)
     else:
-        print("\nAll checks passed. The FREE staggered-Dirac 2-point Schwinger")
-        print("function becomes SO(4)-covariant in the continuum limit, with the")
+        print("\nAll checks passed. Conditional on (A-free), the explicitly specified")
+        print("FREE staggered-Dirac 2-point Schwinger function becomes SO(4)-covariant")
+        print("in the continuum limit, with the")
         print("taste-singlet scalar spectrum's leading anisotropy a dim-6 ell=4")
         print("cubic harmonic at O(a^2) (full spin x taste leading corr is O(a)).")
         print("Matter-sector analogue of the free-scalar boost note.")


### PR DESCRIPTION
## Summary

Repairs the `scope_too_broad` conditional verdict on the free staggered-Dirac SO(4) row (`docs/LORENTZ_BOOST_FREE_STAGGERED_FERMION_2POINT_SO4_NARROW_THEOREM_NOTE_2026-05-29.md`, claim `lorentz_boost_free_staggered_fermion_2point_so4_narrow_theorem_note_2026-05-29`, 433 transitive descendants).

**Verdict being repaired (notes_for_re_audit, quoted):**
> scope_too_broad: Narrow the claim to a theorem conditional on the explicitly specified free staggered action, remove or separately support the framework-carrier and Wightman/CPT extensions, and add a dated downstream-hygiene line to this note's own boundary so its hash drift re-enters the row into the audit queue.

## Changes

- **Conditioning.** Premise **(A-free)** is named once (the explicitly specified free `U = 1` staggered action with canonical phases); the theorem header reads "conditional on (A-free)"; the disclaiming retained-bounded realization authority is identified by name. The scalar-note analogy paragraph no longer inherits the scalar note's Minkowski/Wightman extension.
- **Wightman extension removed.** The "equivalently (Wick rotation) the Wightman 2-point function is SO(3,1)-covariant" sentences — which contradicted the note's own What-stays-open disclaimer — are replaced with explicit non-claim pointers: passing to a Wightman function requires an OS-reconstruction step this note neither performs nor cites at retained grade. Post-repair, every "Wightman" occurrence in the note is an exclusion, boundary, audit quotation, or repair-history line.
- **CPT rescope + upgrade.** Parity/CPT-evenness is rescoped to the operator-level algebraic property of the displayed `Σ_μ p_μ⁴` polynomial — and the runner check for it is **upgraded from assertion to an exact coefficient-map verification** under explicit parity and CPT momentum transformations. The assertion-only Wick/Wightman and CPT-summary PASS lines flagged by the audit are demoted to non-scoring context logs.
- **Dated 2026-07-10 downstream-hygiene line**: citable surface = the Euclidean continuum-limit SO(4) statement and taste-singlet O(a²) anisotropy scope conditional on (A-free); downstream must not cite this note for carrier identification, Wightman/SO(3,1) covariance, or CPT classification beyond the displayed operator algebra.
- **Runner** — all genuinely computational checks (blocked operator construction, Clifford algebra, inverse, continuum convergence, anisotropy scan) unchanged; 5 note-surface pins added. `SCORECARD: PASS=57 FAIL=0` (was 54). Cache regenerated, SHA-pinned.

Source-only triple: 1 note + 1 runner + 1 cache. No audit surfaces touched; note-hash drift re-enters the row for re-audit.

## Verification

- Runner rerun independently: `SCORECARD: PASS=57 FAIL=0`, exit 0.
- `grep -n "Wightman"` audit: every hit is a non-claim pointer, boundary item, or quotation.
- Cache SHA-pinned, exit_code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
