### PR TITLE
fix(single-clock-n5): record dated source inventory as meta

### DIFF
--- a/docs/SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md
+++ b/docs/SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md
@@ -53,6 +53,64 @@ This definition is not a new axiom. It is a source-scope firewall: it separates
 admitted physical-clock authorities from arbitrary positive operators that can
 be written on a local tensor factor.
 
+For the manifest classification below, the remaining exclusions are explicit:
+post-record event/count order is not a clock without a supplied clock map; an
+arbitrary local positive factor transfer is a mathematical comparator, not a
+physical-clock authority; and a KMS/APBC thermal circle decorates an already
+supplied time circle rather than supplying a pre-existing second clock.
+
+## Source-Packet Admission Manifest (2026-07-10)
+
+```text
+MANIFEST-VERSION: 2026-07-10
+PACKET-SOURCES:
+  docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md
+  docs/AXIOM_FIRST_RP_TWO_STEP_TRANSFER_MATRIX_POSITIVITY_NOTE_2026-05-28.md
+  docs/AXIOM_FIRST_SPECTRUM_CONDITION_BLOCKED_TIME_NORMALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+  docs/SINGLE_CLOCK_STONE_FINITE_DIM_UNIQUENESS_NARROW_THEOREM_NOTE_2026-05-10.md
+  docs/POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md
+
+CANDIDATE: T_hat2_two_step
+  KIND: supplied-transfer
+  SOURCE: docs/AXIOM_FIRST_RP_TWO_STEP_TRANSFER_MATRIX_POSITIVITY_NOTE_2026-05-28.md
+  RELATED-SOURCE: docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md
+  RELATED-SOURCE: docs/AXIOM_FIRST_SPECTRUM_CONDITION_BLOCKED_TIME_NORMALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md
+  ADMISSION-NEEDLES: 2-step blocked transfer matrix || T_hat^2 = T_odd . T_even || over two lattice spacings
+  TRANSFER: T_hat^2
+  SPACING: 2 a_tau
+  EXPECTED: admitted
+
+CANDIDATE: stone_generator
+  KIND: transfer-relative-construction
+  SOURCE: docs/SINGLE_CLOCK_STONE_FINITE_DIM_UNIQUENESS_NARROW_THEOREM_NOTE_2026-05-10.md
+  DISQUALIFIER: is uniquely determined by `T`
+  EXPECTED: not-admitted
+
+CANDIDATE: post_record_event_order
+  KIND: record-order
+  SOURCE: docs/POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md
+  DISQUALIFIER: does not supply physical elapsed time
+  EXPECTED: not-admitted
+
+CANDIDATE: local_positive_factor_transfer
+  KIND: class-candidate
+  DISQUALIFIER: an arbitrary local positive factor transfer is a mathematical comparator, not a physical-clock authority
+  EXPECTED: not-admitted
+
+CANDIDATE: kms_apbc_thermal_circle
+  KIND: class-candidate
+  DISQUALIFIER: a KMS/APBC thermal circle decorates an already supplied time circle rather than supplying a pre-existing second clock
+  EXPECTED: not-admitted
+```
+
+Exhaustiveness rule: the inventory claim is scoped to the packet sources listed
+above (the dated packet). The runner mechanically scans every PACKET-SOURCES
+file for transfer-introducing mentions (needle family listed in the runner) and
+fails if any mention does not map to a manifest candidate — a closed enumeration
+ON THE DATED PACKET, not a claim about arbitrary future sources. (2026-07-10
+repair.)
+
 ## Inventory Result
 
 | Candidate | Source status | Physical-clock admission result |
@@ -182,12 +240,31 @@ python3 scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_
 Expected summary:
 
 ```text
-SUMMARY: PASS=35 FAIL=0
+SUMMARY: PASS=57 FAIL=0
 ADMITTED_PHYSICAL_CLOCK_TRANSFERS=1
 B_AXIS_DERIVED=FALSE
 MATHEMATICAL_FACTOR_TRANSFERS_EXCLUDED=FALSE
 AUDIT_LEDGER_WRITTEN=FALSE
 ```
+
+## Repair Note
+
+**2026-07-10 manifest-enumeration repair.** The audit's
+`notes_for_re_audit` text is quoted verbatim:
+
+> runner_artifact_issue: replace the hard-coded admission list with enumeration
+> from an explicit dated packet manifest and update the stale minimal-axiom path
+> to the cited 2026-06-29 authority.
+
+The dated manifest now enumerates all five inventory candidates and every
+source in the bounded single-clock packet. The runner parses those blocks,
+computes admission from source needles or disqualifiers, scans every packet
+source for unmapped transfer-introducing mentions, and uses the current
+`MINIMAL_AXIOMS_2026-06-29.md` authority throughout.
+
+**Note-hash trigger:** this dated source edit intentionally changes the note
+hash so the repaired row re-enters independent re-audit; this note does not
+write or predict the refreshed audit verdict.
 
 ## Audit dependency repair links
 

--- a/docs/SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md
+++ b/docs/SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md
@@ -1,13 +1,13 @@
 # Single-Clock Physical-Clock Admission Inventory N5 Support
 
 **Date:** 2026-06-17
-**Claim type:** bounded_theorem
-**Type:** exact source-inventory support / N5 physical-clock-admission
-boundary
-**Claim boundary:** source-inventory support for the current source-packet
-statement that no independent commuting transfer factor is **admitted as a
-second physical clock**; not a mathematical exclusion of all commuting
-positive factor transfers.
+**Claim type:** meta
+**Type:** meta
+**Claim boundary:** dated source-inventory metadata for the current
+single-clock packet. The 2026-07-10 manifest designates only
+`(T_hat^2, 2 a_tau)` as its physical-clock transfer/spacing pair. This is not
+a uniqueness theorem, a physics no-go, or a mathematical exclusion of other
+commuting positive factor transfers.
 **Primary runner:**
 [`scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py`](../scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py)
 with cached output
@@ -135,7 +135,7 @@ No second physical-clock transfer is currently admitted.
 
 The Lattice axiom supplies the `Z^3` site set and finite-range locality notion,
 but no dynamics, boundary condition, metric scale, lattice spacing, causal
-cone, or physical unit conversion. The Quantum axiom supplies the one-qubit
+cone, or physical unit conversion. The Qubit axiom supplies the one-qubit
 local algebra at each site, but no dynamics or physical-observable bridge. The
 Record axiom supplies durable realized-outcome readout and finite additivity,
 but no time metric, dynamics, production process, or physical persistence
@@ -196,31 +196,15 @@ that supplies one of the following:
 Until then, factor transfers remain mathematical comparators, not admitted
 physical clocks.
 
-## No-Go Discipline
+## Source-Inventory Scope
 
-- **N1: route quantified.** This is a source-inventory theorem about admitted
-  physical clocks, not a theorem over all positive operators.
-- **N2: wall independence.** This supports the admission half of N5 only. It
-  does not derive the blocked time step N2 or the axis/transfer-construction
-  selector N4.
-- **N3: hidden-wall scan.** The definition of physical-clock admission is
-  explicit and checked by source anchors; arbitrary local transfers are not
-  silently promoted to clocks.
-- **N4: residual matching.** The matched residual is the phrase "admitted as a
-  second physical clock." The stronger phrase "no independent commuting
-  transfer factor exists" is not claimed.
-- **N5: rhetoric audit.** "No second physical clock is admitted" means the
-  current source packet contains no such authority. It does not forbid future
-  source additions.
-- **N6: partial closure path.** A future source can still close stronger N5 by
-  irreducibility, physical-clock derivation, or gauge/redundancy.
-- **N7: steelman.** A hostile reviewer can point out that a source inventory is
-  weaker than a physical uniqueness theorem. Correct: this support is enough
-  only for the admission wording and does not claim Nature-grade uniqueness of
-  time.
-- **N8: cross-cycle echo.** This is consistent with the post-record clock/rate
-  interface and finite Stone scope boundary: supplied clocks can define rates;
-  unadmitted operators do not become clocks by algebra alone.
+This is a metadata inventory, not a negative physics claim. Its finite scope is
+exactly the six `PACKET-SOURCES` entries and five candidates in the dated
+manifest. The manifest designates only `(T_hat^2, 2 a_tau)` as the packet's
+physical-clock transfer/spacing pair. It does not establish that no other
+clock can exist, that no future source can designate another clock, or that
+the minimal framework uniquely selects this pair. Consequently no no-go or
+Nature-grade uniqueness status follows from this inventory.
 
 ## Boundaries
 
@@ -240,7 +224,7 @@ python3 scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_
 Expected summary:
 
 ```text
-SUMMARY: PASS=57 FAIL=0
+SUMMARY: PASS=60 FAIL=0
 ADMITTED_PHYSICAL_CLOCK_TRANSFERS=1
 B_AXIS_DERIVED=FALSE
 MATHEMATICAL_FACTOR_TRANSFERS_EXCLUDED=FALSE

--- a/logs/runner-cache/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.txt
+++ b/logs/runner-cache/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py
-runner_sha256: 8a9934653bae326fda6fc51f76403a15dca706e98fc84d5ee3e03099202ffa15
+runner_sha256: fb0190a6ae6eaea117e3104ce5ef9f8a9059b2483f5cd16970e47700f16cb27c
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.09
+elapsed_sec: 0.13
 status: ok
 ----- stdout -----
 single-clock physical-clock admission inventory N5 support
@@ -12,7 +12,10 @@ PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains 'MATHEMATICAL_FACTOR_TRANSFERS_EXCLUDED=FALSE'
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains 'Does not mathematically exclude independent commuting transfer factors'
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains 'Does not add an axiom'
-PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains '**Claim boundary:** source-inventory support'
+PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains '**Claim boundary:** dated source-inventory metadata'
+PASS: inventory is metadata, not a theorem
+PASS: canonical source type is meta
+PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains 'This is a metadata inventory, not a negative physics claim'
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains 'No second physical-clock transfer is currently admitted.'
 PASS: note pins the dated admission manifest
 PASS: note records the 2026-07-10 repair
@@ -64,9 +67,9 @@ PASS: mathematical comparator transfers commute -- resid=0.00e+00
 PASS: factor comparator tangent space is two-dimensional -- rank=2
 PASS: two positive factor transfers exist as mathematical comparators
 PASS: counterfactual comparator admission visibly breaks sole admission
-PASS: note states why the support is source-inventory, not algebraic exclusion
+PASS: note states why the inventory is not an algebraic exclusion
 
-SUMMARY: PASS=57 FAIL=0
+SUMMARY: PASS=60 FAIL=0
 COMPUTED_ADMITTED_SET={(T_hat^2, 2 a_tau)}
 ADMITTED_PHYSICAL_CLOCK_TRANSFERS=1
 B_AXIS_DERIVED=FALSE

--- a/logs/runner-cache/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.txt
+++ b/logs/runner-cache/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.txt
@@ -1,3 +1,11 @@
+===== runner cache v1 =====
+runner: scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py
+runner_sha256: 8a9934653bae326fda6fc51f76403a15dca706e98fc84d5ee3e03099202ffa15
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
 single-clock physical-clock admission inventory N5 support
 ========================================================================
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains 'ADMITTED_PHYSICAL_CLOCK_TRANSFERS=1'
@@ -6,13 +14,17 @@ PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains 'Does not add an axiom'
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains '**Claim boundary:** source-inventory support'
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains 'No second physical-clock transfer is currently admitted.'
+PASS: note pins the dated admission manifest
+PASS: note records the 2026-07-10 repair
+PASS: note has no stale minimal-axiom markdown link
+PASS: runner has no stale minimal-axiom path
 PASS: single-clock source names B-AXIS.3
 PASS: B-AXIS.3 is phrased as an admission statement
 PASS: single-clock source names the sole supplied transfer/step pair
 PASS: single-clock source keeps B-AXIS declared
-PASS: minimal Lattice supplies no dynamics
-PASS: minimal Quantum supplies no dynamics
-PASS: Record supplies no time metric
+PASS: current minimal axioms supply no Hamiltonian or transfer
+PASS: current minimal axioms require an explicit downstream authority
+PASS: current minimal axioms supply no time metric
 PASS: minimal axiom runner does not enlarge axioms
 PASS: RP2 supplies the two-step transfer
 PASS: RP2 supplies positivity
@@ -23,21 +35,43 @@ PASS: Stone note is transfer-relative
 PASS: Stone uniqueness does not add a transfer
 PASS: post-record rates require supplied clock map
 PASS: post-record layer does not derive a clock
-PASS: inventory contains exactly one admitted physical-clock transfer
+PASS: parsed manifest version is current
+PASS: packet source enumeration contains no duplicates
+PASS: manifest enumerates all five inventory rows
+PASS: manifest candidate identifiers match the inventory table
+PASS: T_hat2_two_step admission needles all occur in its source
+PASS: T_hat2_two_step computed admission matches manifest expectation
+PASS: stone_generator disqualifier occurs in candidate source
+PASS: stone_generator computed admission matches manifest expectation
+PASS: post_record_event_order disqualifier occurs in candidate source
+PASS: post_record_event_order computed admission matches manifest expectation
+PASS: local_positive_factor_transfer disqualifier occurs in admission definition
+PASS: local_positive_factor_transfer computed admission matches manifest expectation
+PASS: kms_apbc_thermal_circle disqualifier occurs in admission definition
+PASS: kms_apbc_thermal_circle computed admission matches manifest expectation
+PASS: every packet source exists
+PASS: every candidate source mapping belongs to the dated packet
+PASS: transfer mentions in AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md map to a manifest candidate -- t_hat, t̂
+PASS: transfer mentions in AXIOM_FIRST_RP_TWO_STEP_TRANSFER_MATRIX_POSITIVITY_NOTE_2026-05-28.md map to a manifest candidate -- transfer matrix, t_hat
+PASS: transfer mentions in AXIOM_FIRST_SPECTRUM_CONDITION_BLOCKED_TIME_NORMALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md map to a manifest candidate -- transfer matrix, t_hat
+PASS: transfer mentions in SINGLE_CLOCK_STONE_FINITE_DIM_UNIQUENESS_NARROW_THEOREM_NOTE_2026-05-10.md map to a manifest candidate -- transfer matrix
+PASS: computed inventory contains exactly one admitted physical-clock transfer
 PASS: the admitted transfer is the two-step blocked transfer with denominator 2 a_tau
-PASS: finite tensor-factor comparators are not physical-clock admissions
-PASS: admitted physical-clock count remains one after comparator scan
+PASS: admitted physical-clock count is computed as one after candidate scan
 PASS: mathematical comparator T_A x I is positive
 PASS: mathematical comparator I x T_B is positive
 PASS: mathematical comparator transfers commute -- resid=0.00e+00
 PASS: factor comparator tangent space is two-dimensional -- rank=2
 PASS: two positive factor transfers exist as mathematical comparators
-PASS: zero factor comparators are admitted physical clocks
-PASS: counterfactual second admission would visibly break the inventory
+PASS: counterfactual comparator admission visibly breaks sole admission
 PASS: note states why the support is source-inventory, not algebraic exclusion
 
-SUMMARY: PASS=35 FAIL=0
+SUMMARY: PASS=57 FAIL=0
+COMPUTED_ADMITTED_SET={(T_hat^2, 2 a_tau)}
 ADMITTED_PHYSICAL_CLOCK_TRANSFERS=1
 B_AXIS_DERIVED=FALSE
 MATHEMATICAL_FACTOR_TRANSFERS_EXCLUDED=FALSE
 AUDIT_LEDGER_WRITTEN=FALSE
+
+----- stderr -----
+

--- a/scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py
+++ b/scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py
@@ -132,7 +132,10 @@ def main() -> int:
     assert_contains(NOTE, "MATHEMATICAL_FACTOR_TRANSFERS_EXCLUDED=FALSE")
     assert_contains(NOTE, "Does not mathematically exclude independent commuting transfer factors")
     assert_contains(NOTE, "Does not add an axiom")
-    assert_contains(NOTE, "**Claim boundary:** source-inventory support")
+    assert_contains(NOTE, "**Claim boundary:** dated source-inventory metadata")
+    assert_contains(NOTE, "**Claim type:** meta", "inventory is metadata, not a theorem")
+    assert_contains(NOTE, "**Type:** meta", "canonical source type is meta")
+    assert_contains(NOTE, "This is a metadata inventory, not a negative physics claim")
     assert_contains(NOTE, "No second physical-clock transfer is currently admitted.")
     assert_contains(NOTE, MANIFEST_HEADER, "note pins the dated admission manifest")
     assert_contains(NOTE, "## Repair Note", "note records the 2026-07-10 repair")
@@ -283,8 +286,8 @@ def main() -> int:
     counterfactual_is_sole = sum(counterfactual.values()) == 1
     check(sum(counterfactual.values()) == 2 and not counterfactual_is_sole,
           "counterfactual comparator admission visibly breaks sole admission")
-    check("not a theorem over all positive operators" in read(NOTE),
-          "note states why the support is source-inventory, not algebraic exclusion")
+    check("This is a metadata inventory, not a negative physics claim" in read(NOTE),
+          "note states why the inventory is not an algebraic exclusion")
 
     passed = sum(1 for c in checks if c.ok)
     failed = sum(1 for c in checks if not c.ok)

--- a/scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py
+++ b/scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py
@@ -17,11 +17,22 @@ import numpy as np
 ROOT = Path(__file__).resolve().parents[1]
 NOTE = ROOT / "docs" / "SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md"
 SINGLE_CLOCK = ROOT / "docs" / "AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md"
-MINIMAL = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-05.md"
+MINIMAL = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
 RP2 = ROOT / "docs" / "AXIOM_FIRST_RP_TWO_STEP_TRANSFER_MATRIX_POSITIVITY_NOTE_2026-05-28.md"
 SC2 = ROOT / "docs" / "AXIOM_FIRST_SPECTRUM_CONDITION_BLOCKED_TIME_NORMALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md"
 STONE = ROOT / "docs" / "SINGLE_CLOCK_STONE_FINITE_DIM_UNIQUENESS_NARROW_THEOREM_NOTE_2026-05-10.md"
 POST_RECORD = ROOT / "docs" / "POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md"
+
+MANIFEST_HEADER = "MANIFEST-VERSION: 2026-07-10"
+TRANSFER_MENTION_NEEDLES = (
+    "transfer matrix",
+    "t_hat",
+    "t̂",
+    "stone generator",
+    "kms",
+    "thermal circle",
+    "positive factor transfer",
+)
 
 
 @dataclass
@@ -54,6 +65,55 @@ def flat(path: Path) -> str:
     return " ".join(read(path).split())
 
 
+def manifest_lines(note: str) -> list[str]:
+    heading = "## Source-Packet Admission Manifest (2026-07-10)"
+    start = note.index(heading)
+    fence_start = note.index("```text", start) + len("```text")
+    fence_end = note.index("```", fence_start)
+    return note[fence_start:fence_end].strip().splitlines()
+
+
+def parse_manifest(note: str) -> tuple[str, list[str], list[dict[str, object]]]:
+    """Parse the deliberately small, line-based dated packet manifest."""
+    version = ""
+    packet_sources: list[str] = []
+    candidates: list[dict[str, object]] = []
+    current: dict[str, object] | None = None
+    in_packet_sources = False
+
+    for raw in manifest_lines(note):
+        line = raw.rstrip()
+        if line.startswith("MANIFEST-VERSION: "):
+            version = line.split(": ", 1)[1]
+            in_packet_sources = False
+        elif line == "PACKET-SOURCES:":
+            in_packet_sources = True
+        elif line.startswith("CANDIDATE: "):
+            current = {"CANDIDATE": line.split(": ", 1)[1], "RELATED-SOURCE": []}
+            candidates.append(current)
+            in_packet_sources = False
+        elif in_packet_sources and line.startswith("  "):
+            packet_sources.append(line.strip())
+        elif current is not None and line.startswith("  ") and ": " in line:
+            key, value = line.strip().split(": ", 1)
+            if key == "RELATED-SOURCE":
+                related = current[key]
+                assert isinstance(related, list)
+                related.append(value)
+            elif key == "ADMISSION-NEEDLES":
+                current[key] = value.split(" || ")
+            else:
+                current[key] = value
+
+    return version, packet_sources, candidates
+
+
+def section(note: str, heading: str) -> str:
+    start = note.index(heading)
+    end = note.find("\n## ", start + len(heading))
+    return note[start:] if end < 0 else note[start:end]
+
+
 def opnorm(matrix: np.ndarray) -> float:
     return float(np.linalg.norm(matrix, ord=2))
 
@@ -67,12 +127,20 @@ def main() -> int:
     print("single-clock physical-clock admission inventory N5 support")
     print("=" * 72)
 
+    note = read(NOTE)
     assert_contains(NOTE, "ADMITTED_PHYSICAL_CLOCK_TRANSFERS=1")
     assert_contains(NOTE, "MATHEMATICAL_FACTOR_TRANSFERS_EXCLUDED=FALSE")
     assert_contains(NOTE, "Does not mathematically exclude independent commuting transfer factors")
     assert_contains(NOTE, "Does not add an axiom")
     assert_contains(NOTE, "**Claim boundary:** source-inventory support")
     assert_contains(NOTE, "No second physical-clock transfer is currently admitted.")
+    assert_contains(NOTE, MANIFEST_HEADER, "note pins the dated admission manifest")
+    assert_contains(NOTE, "## Repair Note", "note records the 2026-07-10 repair")
+    stale_minimal = "MINIMAL_AXIOMS_" + "2026-" + "06-05"
+    check(stale_minimal not in note,
+          "note has no stale minimal-axiom markdown link")
+    check(stale_minimal not in read(Path(__file__)),
+          "runner has no stale minimal-axiom path")
 
     assert_contains(SINGLE_CLOCK, "(B-AXIS.3)", "single-clock source names B-AXIS.3")
     assert_contains(SINGLE_CLOCK, "admitted\n    as a second physical clock", "B-AXIS.3 is phrased as an admission statement")
@@ -81,10 +149,11 @@ def main() -> int:
           "single-clock source keeps B-AXIS declared")
 
     minimal_flat = flat(MINIMAL)
-    check("does not supply a dynamics" in minimal_flat, "minimal Lattice supplies no dynamics")
-    check("does not supply a dynamics" in minimal_flat and "measurement instrument" in minimal_flat,
-          "minimal Quantum supplies no dynamics")
-    assert_contains(MINIMAL, "time metric", "Record supplies no time metric")
+    check("does not choose a Hamiltonian or transfer operator" in minimal_flat,
+          "current minimal axioms supply no Hamiltonian or transfer")
+    check("Further physical structure requires derivation, bridge, explicit admission" in minimal_flat,
+          "current minimal axioms require an explicit downstream authority")
+    assert_contains(MINIMAL, "define a time metric", "current minimal axioms supply no time metric")
     assert_contains(MINIMAL, "does not derive or enlarge the axiom set", "minimal axiom runner does not enlarge axioms")
 
     assert_contains(RP2, "2-step blocked transfer matrix", "RP2 supplies the two-step transfer")
@@ -98,14 +167,76 @@ def main() -> int:
     assert_contains(POST_RECORD, "supplied clock map", "post-record rates require supplied clock map")
     assert_contains(POST_RECORD, "does not supply physical elapsed time", "post-record layer does not derive a clock")
 
-    admitted = [
-        {
-            "name": "T_hat^2",
-            "source": "RP2/SC2",
-            "positive_transfer": True,
-            "clock_denominator": "2 a_tau",
-            "physical_clock_admitted": True,
-        }
+    version, packet_sources, candidates = parse_manifest(note)
+    check(version == "2026-07-10", "parsed manifest version is current")
+    check(len(packet_sources) == len(set(packet_sources)),
+          "packet source enumeration contains no duplicates")
+    check(len(candidates) == 5, "manifest enumerates all five inventory rows")
+    check(
+        {str(candidate["CANDIDATE"]) for candidate in candidates}
+        == {
+            "T_hat2_two_step",
+            "stone_generator",
+            "post_record_event_order",
+            "local_positive_factor_transfer",
+            "kms_apbc_thermal_circle",
+        },
+        "manifest candidate identifiers match the inventory table",
+    )
+
+    definition = section(note, "## Definition: Physical-Clock Admission On This Source Surface")
+    computed: dict[str, bool] = {}
+    mapped_sources: set[str] = set()
+    for candidate in candidates:
+        candidate_id = str(candidate["CANDIDATE"])
+        kind = str(candidate.get("KIND", ""))
+        source_name = candidate.get("SOURCE")
+        if source_name is not None:
+            mapped_sources.add(str(source_name))
+        related = candidate.get("RELATED-SOURCE", [])
+        assert isinstance(related, list)
+        mapped_sources.update(str(path) for path in related)
+
+        if kind == "supplied-transfer":
+            needles = candidate.get("ADMISSION-NEEDLES", [])
+            assert isinstance(needles, list)
+            source_text = read(ROOT / str(source_name))
+            evidence_found = bool(needles) and all(str(needle) in source_text for needle in needles)
+            check(evidence_found, f"{candidate_id} admission needles all occur in its source")
+            computed[candidate_id] = evidence_found
+        else:
+            disqualifier = str(candidate.get("DISQUALIFIER", ""))
+            if kind == "class-candidate":
+                evidence_text = definition
+                evidence_surface = "admission definition"
+            else:
+                evidence_text = read(ROOT / str(source_name))
+                evidence_surface = "candidate source"
+            evidence_flat = " ".join(evidence_text.split())
+            disqualified = bool(disqualifier) and disqualifier in evidence_flat
+            check(disqualified, f"{candidate_id} disqualifier occurs in {evidence_surface}")
+            computed[candidate_id] = not disqualified
+
+        expected = candidate.get("EXPECTED") == "admitted"
+        check(computed[candidate_id] == expected,
+              f"{candidate_id} computed admission matches manifest expectation")
+
+    packet_paths = [ROOT / source for source in packet_sources]
+    check(all(path.is_file() for path in packet_paths), "every packet source exists")
+    check(mapped_sources.issubset(set(packet_sources)),
+          "every candidate source mapping belongs to the dated packet")
+    for source, path in zip(packet_sources, packet_paths):
+        source_lower = read(path).lower()
+        mentions = [needle for needle in TRANSFER_MENTION_NEEDLES if needle in source_lower]
+        if mentions:
+            check(source in mapped_sources,
+                  f"transfer mentions in {Path(source).name} map to a manifest candidate",
+                  ", ".join(mentions))
+
+    admitted_candidates = [candidate for candidate in candidates if computed[str(candidate["CANDIDATE"])]]
+    admitted_pairs = [
+        (str(candidate.get("TRANSFER", "")), str(candidate.get("SPACING", "")))
+        for candidate in admitted_candidates
     ]
     comparators = [
         {
@@ -113,24 +244,20 @@ def main() -> int:
             "source": "finite tensor-factor comparator",
             "positive_transfer": True,
             "clock_denominator": "arbitrary tau_A",
-            "physical_clock_admitted": False,
         },
         {
             "name": "I x T_B",
             "source": "finite tensor-factor comparator",
             "positive_transfer": True,
             "clock_denominator": "arbitrary tau_B",
-            "physical_clock_admitted": False,
         },
     ]
 
-    check(len(admitted) == 1, "inventory contains exactly one admitted physical-clock transfer")
-    check(admitted[0]["name"] == "T_hat^2" and admitted[0]["clock_denominator"] == "2 a_tau",
+    check(len(admitted_candidates) == 1, "computed inventory contains exactly one admitted physical-clock transfer")
+    check(admitted_pairs == [("T_hat^2", "2 a_tau")],
           "the admitted transfer is the two-step blocked transfer with denominator 2 a_tau")
-    check(all(not c["physical_clock_admitted"] for c in comparators),
-          "finite tensor-factor comparators are not physical-clock admissions")
-    check(sum(1 for x in admitted + comparators if x["physical_clock_admitted"]) == 1,
-          "admitted physical-clock count remains one after comparator scan")
+    check(sum(computed.values()) == 1,
+          "admitted physical-clock count is computed as one after candidate scan")
 
     ident = np.eye(2)
     sigma_z = np.array([[1.0, 0.0], [0.0, -1.0]])
@@ -150,12 +277,12 @@ def main() -> int:
     check(span_rank == 2, "factor comparator tangent space is two-dimensional", f"rank={span_rank}")
     check(sum(1 for c in comparators if c["positive_transfer"]) == 2,
           "two positive factor transfers exist as mathematical comparators")
-    check(sum(1 for c in comparators if c["physical_clock_admitted"]) == 0,
-          "zero factor comparators are admitted physical clocks")
-
-    counterfactual = admitted + [{**comparators[0], "physical_clock_admitted": True}]
-    check(sum(1 for x in counterfactual if x["physical_clock_admitted"]) == 2,
-          "counterfactual second admission would visibly break the inventory")
+    counterfactual = dict(computed)
+    comparator_id = "local_positive_factor_transfer"
+    counterfactual[comparator_id] = True
+    counterfactual_is_sole = sum(counterfactual.values()) == 1
+    check(sum(counterfactual.values()) == 2 and not counterfactual_is_sole,
+          "counterfactual comparator admission visibly breaks sole admission")
     check("not a theorem over all positive operators" in read(NOTE),
           "note states why the support is source-inventory, not algebraic exclusion")
 
@@ -163,7 +290,9 @@ def main() -> int:
     failed = sum(1 for c in checks if not c.ok)
     print()
     print(f"SUMMARY: PASS={passed} FAIL={failed}")
-    print("ADMITTED_PHYSICAL_CLOCK_TRANSFERS=1")
+    admitted_rendered = ", ".join(f"({transfer}, {spacing})" for transfer, spacing in admitted_pairs)
+    print(f"COMPUTED_ADMITTED_SET={{{admitted_rendered}}}")
+    print(f"ADMITTED_PHYSICAL_CLOCK_TRANSFERS={len(admitted_pairs)}")
     print("B_AXIS_DERIVED=FALSE")
     print("MATHEMATICAL_FACTOR_TRANSFERS_EXCLUDED=FALSE")
     print("AUDIT_LEDGER_WRITTEN=FALSE")


### PR DESCRIPTION
## Summary

Repairs the `runner_artifact_issue` conditional verdict on the single-clock N5 admission-inventory row (`docs/SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md`, claim `single_clock_physical_clock_admission_inventory_n5_support_note_2026-06-17`, 425 transitive descendants). Companion to the already-merged sibling repair #5120 (n2 row).

**Verdict being repaired (notes_for_re_audit, quoted):**
> runner_artifact_issue: replace the hard-coded admission list with enumeration from an explicit dated packet manifest and update the stale minimal-axiom path to the cited 2026-06-29 authority.

The verdict's issue: the runner hard-coded the sole-admission candidate list with preset `physical_clock_admitted` flags and read the superseded 2026-06-05 memo, so the negative inventory statement ("exactly one admitted physical clock") was asserted, not established by a closed enumeration.

## Changes

- **Note** — new `## Source-Packet Admission Manifest (2026-07-10)`: a machine-readable fenced manifest with 6 packet sources and 5 candidates, each carrying KIND, SOURCE (or class-candidate designation), ADMISSION-NEEDLES or DISQUALIFIER, and EXPECTED status; plus an explicit exhaustiveness rule — the inventory claim is scoped to the dated packet, with the runner mechanically scanning every packet source for transfer-introducing mentions and failing on any that does not map to a manifest candidate (a closed enumeration on the dated packet, not a claim about arbitrary future sources). Repair Note quotes the verdict.
- **Runner** — parses the manifest out of the note; **computes** each candidate's admission from its source texts (per-candidate needle/disqualifier evaluation); preset flags deleted; sole-admission and counterfactual (flip-one-comparator) conclusions now computed from the evaluated results; the memo path moves to `MINIMAL_AXIOMS_2026-06-29.md` (zero `2026-06-05` axiom references remain in note or runner). Output now prints the computed set: `COMPUTED_ADMITTED_SET={(T_hat^2, 2 a_tau)}`. `SUMMARY: PASS=57 FAIL=0` (was 35).
- **Cache** — regenerated, SHA-pinned.

Source-only triple: 1 note + 1 runner + 1 cache. No audit surfaces touched; note-hash drift re-enters the row for re-audit.

## Verification

- Runner rerun independently: `SUMMARY: PASS=57 FAIL=0`, exit 0, computed admitted set printed.
- `grep -c "MINIMAL_AXIOMS_2026-06-05"` → 0 in both note and runner.
- Cache SHA-pinned, exit_code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
