### PR TITLE
fix(single-clock-n5): manifest-enumerated clock-admission inventory

### DIFF
--- a/docs/SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md
+++ b/docs/SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md
@@ -71,19 +71,222 @@ current admitted physical-clock transfers = { (T_hat^2, 2 a_tau) }
 
 No second physical-clock transfer is currently admitted.
 
+## Admission Manifest (2026-07-10)
+
+The inventory above is pinned to the explicit dated manifest below instead of
+a runner-preset list. The manifest is carried in this note as a fenced JSON
+block (fenced, so it adds no dependency edges), and the paired runner
+recomputes its content from source text:
+
+- **Packet.** `packet_notes` names the single-clock clock/evolution source
+  packet: the parent theorem note and this inventory note.
+- **Closed enumeration.** `entries` lists every document reachable by a
+  markdown dependency link from the two packet notes (targets `*.md`,
+  normalized to `docs/<basename>`). The runner recomputes this link union
+  live from both packet notes and fails on any divergence in either
+  direction, so the enumeration cannot silently go stale.
+- **Axiom authority.** The axiom leg reads the current 2026-06-29
+  minimal-axiom memo through the stable `minimal_axioms` premise node in
+  `docs/audit/data/axiom_premise_nodes.json`; the 2026-06-05 path cited by
+  the parent packet is a registered alias of the same node, not a second
+  authority.
+- **Computed admission.** `candidates` names each proposed physical-clock
+  transfer with per-criterion source evidence (file plus exact anchor) for
+  the four-part admission definition above. The runner evaluates the four
+  criteria against the named sources, requires every evidence file to lie
+  inside the enumerated packet surface, and computes the admitted list from
+  those checks; no preset `physical_clock_admitted` flags remain.
+  Counterfeit candidates (fabricated anchors, missing packet consumption,
+  evidence outside the enumerated surface) must evaluate to not-admitted.
+- **Honest auditor read.** For entries that are not clock-adjacent, the
+  negative disposition ("supplies no second physical clock") is carried by
+  the closed enumeration together with the parent packet's sole-pair
+  consumption grammar — every transfer/step pair the parent consumes
+  normalizes to the supplied `(T_hat^2, 2 a_tau)` pair — and by explicit
+  no-clock anchors in the clock-adjacent authorities (minimal axioms, Stone,
+  post-record). It is source-inventory support, not a semantic scan of every
+  linked document and not a mathematical exclusion.
+
+```json
+{
+  "manifest_date": "2026-07-10",
+  "surface": "single-clock clock/evolution source packet",
+  "packet_notes": [
+    "docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md",
+    "docs/SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md"
+  ],
+  "axiom_authority": {
+    "stable_id": "minimal_axioms",
+    "current_path": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "registry": "docs/audit/data/axiom_premise_nodes.json"
+  },
+  "entries": [
+    {
+      "path": "docs/AXIOM_FIRST_CL3_PER_SITE_UNIQUENESS_THEOREM_NOTE_2026-04-29.md",
+      "h1": "Axiom-First Per-Site Uniqueness of the Cl(3) Spinor Module",
+      "linked_by": ["parent"],
+      "role": "per-site Cl(3) module uniqueness input; supplies no transfer"
+    },
+    {
+      "path": "docs/AXIOM_FIRST_REFLECTION_POSITIVITY_THEOREM_NOTE_2026-04-29.md",
+      "h1": "Axiom-First Reflection Positivity: Staggered-Only, 2-Step Block Formulation",
+      "linked_by": ["parent"],
+      "role": "staggered-only two-step reflection-positivity groundwork on the same admitted transfer surface"
+    },
+    {
+      "path": "docs/AXIOM_FIRST_RP_TWO_STEP_TRANSFER_MATRIX_POSITIVITY_NOTE_2026-05-28.md",
+      "h1": "Free Staggered 2-Step Blocked Transfer-Matrix Positivity (In-Repo Derivation)",
+      "linked_by": ["n5"],
+      "role": "derives the positive Hermitian two-step blocked transfer T_hat^2; admitted-pair evidence source"
+    },
+    {
+      "path": "docs/AXIOM_FIRST_SPECTRUM_CONDITION_BLOCKED_TIME_NORMALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md",
+      "h1": "Spectrum-Condition Blocked-Time-Spacing Normalization Bridge Narrow Theorem",
+      "linked_by": ["n5"],
+      "role": "supplies the blocked clock denominator 2 a_tau and log normalization; admitted-pair evidence source"
+    },
+    {
+      "path": "docs/AXIOM_FIRST_SPECTRUM_CONDITION_THEOREM_NOTE_2026-04-29.md",
+      "h1": "Axiom-First Spectrum Condition (Lattice Analogue) on Cl(3) ⊗ Z^3",
+      "linked_by": ["parent"],
+      "role": "spectrum-condition groundwork for the supplied transfer; supplies no second transfer"
+    },
+    {
+      "path": "docs/EMERGENT_LORENTZ_INVARIANCE_NOTE.md",
+      "h1": "Emergent Lorentz Invariance from the Cubic Z³ Lattice (Conditional)",
+      "linked_by": ["parent"],
+      "role": "conditional emergent-Lorentz dispersion comparison; supplies no transfer"
+    },
+    {
+      "path": "docs/FREE_BILINEAR_QUASILOCAL_LR_BRIDGE_THEOREM_NOTE_2026-06-10.md",
+      "h1": "Free Bilinear Exact-Log Quasilocal Lieb-Robinson Bridge",
+      "linked_by": ["parent"],
+      "role": "quasilocal Lieb-Robinson bridge input; supplies no transfer"
+    },
+    {
+      "path": "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md",
+      "h1": "Kinetic-Isotropy Primitive",
+      "linked_by": ["parent"],
+      "role": "approved spatial kinetic-isotropy primitive; static spatial content only"
+    },
+    {
+      "path": "docs/LIEB_ROBINSON_EQUAL_TIME_TENSOR_LOCALITY_NARROW_THEOREM_NOTE_2026-05-10.md",
+      "h1": "Lieb-Robinson (M1) Equal-Time Tensor-Locality Narrow Theorem",
+      "linked_by": ["parent"],
+      "role": "equal-time tensor-locality input; supplies no transfer"
+    },
+    {
+      "path": "docs/MINIMAL_AXIOMS_2026-06-05.md",
+      "h1": "Minimal Framework Axioms (Lattice, Quantum, Record)",
+      "linked_by": ["parent"],
+      "role": "aliased historical path of the stable minimal_axioms premise node",
+      "alias_of": "minimal_axioms"
+    },
+    {
+      "path": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+      "h1": "Minimal Framework Axioms (Lattice, Qubit, Admissibility, Record)",
+      "linked_by": ["n5"],
+      "role": "current minimal-axiom memo; axiom authority for this manifest; supplies no clock",
+      "alias_of": "minimal_axioms"
+    },
+    {
+      "path": "docs/POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md",
+      "h1": "Post-Record Clock/Rate Interface",
+      "linked_by": ["n5"],
+      "role": "event/count order interface; physical rates require a supplied clock map"
+    },
+    {
+      "path": "docs/QUANTUM_LOCAL_ALGEBRA_DOES_NOT_FORCE_BOOST_ACTION_FAITH_NO_GO_NOTE_2026-06-02.md",
+      "h1": "Quantum Local Algebra Does Not Force Boost-Action Faith No-Go",
+      "linked_by": ["parent"],
+      "role": "boost-action no-go input; supplies no transfer"
+    },
+    {
+      "path": "docs/SINGLE_CLOCK_APBC_AXIS_LABEL_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-16.md",
+      "h1": "Single-Clock APBC Axis-Label Bridge",
+      "linked_by": ["parent"],
+      "role": "axis-label bridge decorating the already-supplied time circle"
+    },
+    {
+      "path": "docs/SINGLE_CLOCK_BLOCKED_TIME_UNIT_SPLIT_N2_SUPPORT_NOTE_2026-06-17.md",
+      "h1": "Single-Clock Blocked-Time Unit Split: N2 Internal Support Boundary",
+      "linked_by": ["parent"],
+      "role": "sibling blocked-time unit-split support boundary"
+    },
+    {
+      "path": "docs/SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md",
+      "h1": "Single-Clock Physical-Clock Admission Inventory N5 Support",
+      "linked_by": ["parent"],
+      "role": "this inventory note; linked back by the parent packet note"
+    },
+    {
+      "path": "docs/SINGLE_CLOCK_STONE_FINITE_DIM_UNIQUENESS_NARROW_THEOREM_NOTE_2026-05-10.md",
+      "h1": "Single-Clock Stone Finite-Dim Uniqueness Narrow Theorem",
+      "linked_by": ["parent", "n5"],
+      "role": "transfer-relative finite Stone/log uniqueness; constructs from a supplied transfer, adds none"
+    },
+    {
+      "path": "docs/SINGLE_CLOCK_UNIQUENESS_SCOPE_BOUNDARY_2026-06-06.md",
+      "h1": "Single-Clock Uniqueness Scope Boundary",
+      "linked_by": ["parent"],
+      "role": "single-clock uniqueness scope boundary; names what is not claimed"
+    },
+    {
+      "path": "docs/SPATIAL_CUBIC_TIME_ANISOTROPY_GATE_NO_GO_2026-06-06.md",
+      "h1": "Spatial Cubic Time-Anisotropy Gate No-Go",
+      "linked_by": ["parent"],
+      "role": "spatial cubic time-anisotropy gate no-go input; supplies no transfer"
+    }
+  ],
+  "candidates": [
+    {
+      "name": "T_hat^2",
+      "clock_denominator": "2 a_tau",
+      "criteria_evidence": {
+        "supplied_as_physical_transfer": {
+          "path": "docs/AXIOM_FIRST_RP_TWO_STEP_TRANSFER_MATRIX_POSITIVITY_NOTE_2026-05-28.md",
+          "anchor": "2-step blocked transfer matrix"
+        },
+        "positivity_trivial_kernel": {
+          "path": "docs/AXIOM_FIRST_RP_TWO_STEP_TRANSFER_MATRIX_POSITIVITY_NOTE_2026-05-28.md",
+          "anchor": "positive Hermitian"
+        },
+        "clock_denominator": {
+          "path": "docs/AXIOM_FIRST_SPECTRUM_CONDITION_BLOCKED_TIME_NORMALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md",
+          "anchor": "H  :=  -(1/(2 a_τ)) log(T_hat^2 / M_T)"
+        },
+        "packet_consumption": {
+          "path": "docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md",
+          "anchor": "inventory contains exactly the supplied `(T̂², 2a_τ)` transfer/step pair."
+        }
+      }
+    }
+  ]
+}
+```
+
 ## Proof
 
 ### 1. The minimal axioms do not admit a clock
 
-The Lattice axiom supplies the `Z^3` site set and finite-range locality notion,
-but no dynamics, boundary condition, metric scale, lattice spacing, causal
-cone, or physical unit conversion. The Quantum axiom supplies the one-qubit
-local algebra at each site, but no dynamics or physical-observable bridge. The
-Record axiom supplies durable realized-outcome readout and finite additivity,
-but no time metric, dynamics, production process, or physical persistence
-dynamics.
+The current minimal-axiom memo (2026-06-29) names four axioms — Lattice,
+Qubit, Admissibility, Record — and none supplies a clock. The Lattice axiom
+supplies the `Z^3` site set with nearest-neighbor adjacency, translations,
+and proper cubic rotations; no dynamics and no time structure. The Qubit
+axiom supplies the one-site possibility domain with algebraic presentation
+`M_2(C)`; no dynamics. The memo states explicitly that Admissibility "is not
+a dynamics axiom" and that it does not "choose a Hamiltonian or transfer
+operator, supply transition probabilities or weights, select a scalar or
+nonzero kinetic branch, assert a Dirac-square carrier, define a time metric,
+or provide a record-production process or physical persistence dynamics."
+The Record axiom fixes records and finite scalar readout additivity, while
+the memo lists "time metric" among the open gates outside axiom content and
+keeps "Probability, dynamics, readout contexts, and physical observable
+bridges" downstream.
 
-Thus the minimal axioms alone do not admit any physical-clock transfer.
+Thus the minimal axioms alone do not admit any physical-clock transfer; every
+admitted clock enters through a named downstream source authority, which is
+what the admission manifest above enumerates.
 
 ### 2. The two-step RP/SC packet admits one clock transfer
 
@@ -182,7 +385,7 @@ python3 scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_
 Expected summary:
 
 ```text
-SUMMARY: PASS=35 FAIL=0
+SUMMARY: PASS=53 FAIL=0
 ADMITTED_PHYSICAL_CLOCK_TRANSFERS=1
 B_AXIS_DERIVED=FALSE
 MATHEMATICAL_FACTOR_TRANSFERS_EXCLUDED=FALSE

--- a/logs/runner-cache/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.txt
+++ b/logs/runner-cache/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.txt
@@ -1,3 +1,11 @@
+===== runner cache v1 =====
+runner: scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py
+runner_sha256: 9266ae96c234db48ad0e759fa9896c4342ca948fbae5db048d2e2c294f9f5ed2
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.13
+status: ok
+----- stdout -----
 single-clock physical-clock admission inventory N5 support
 ========================================================================
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains 'ADMITTED_PHYSICAL_CLOCK_TRANSFERS=1'
@@ -6,14 +14,40 @@ PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains 'Does not add an axiom'
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains '**Claim boundary:** source-inventory support'
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains 'No second physical-clock transfer is currently admitted.'
+PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains '## Admission Manifest (2026-07-10)'
+PASS: note states why the support is source-inventory, not algebraic exclusion
 PASS: single-clock source names B-AXIS.3
 PASS: B-AXIS.3 is phrased as an admission statement
 PASS: single-clock source names the sole supplied transfer/step pair
 PASS: single-clock source keeps B-AXIS declared
-PASS: minimal Lattice supplies no dynamics
-PASS: minimal Quantum supplies no dynamics
-PASS: Record supplies no time metric
+PASS: minimal 2026-06-29 memo names the four axioms
+PASS: minimal 2026-06-29: Admissibility is not a dynamics axiom
+PASS: minimal 2026-06-29: dynamics-exclusion sentence covers transfer operator and time metric
+PASS: minimal 2026-06-29: time metric listed among open gates outside axiom content
+PASS: minimal 2026-06-29: probability/dynamics/bridges stay downstream
 PASS: minimal axiom runner does not enlarge axioms
+PASS: registry lists minimal_axioms as a canonical premise node
+PASS: registry current path for minimal_axioms is the 2026-06-29 memo
+PASS: registry aliases the 2026-06-05 path to the same premise node
+PASS: note carries exactly one fenced JSON manifest block -- found=1
+PASS: manifest is explicitly dated 2026-07-10
+PASS: manifest packet is the parent theorem note plus this inventory note
+PASS: manifest axiom authority matches the registry premise node
+PASS: manifest enumerates 19 packet documents -- got=19
+PASS: manifest entry paths are unique
+PASS: closed enumeration: manifest entries equal the live packet link union -- missing=[] stale=[]
+PASS: per-entry linked_by matches live link provenance and every role is stated -- mismatches=[]
+PASS: per-entry h1 titles match the live document headers -- mismatches=[]
+PASS: exactly the two minimal-axiom paths are marked as aliases of minimal_axioms
+PASS: every manifest alias row resolves inside the registry premise node
+PASS: manifest proposes exactly one physical-clock candidate
+PASS: candidate T_hat^2 evaluates as admitted from source evidence -- all four criteria evidenced in packet sources
+PASS: computed admitted physical-clock count is one -- got=1
+PASS: the computed admitted transfer is T_hat^2 with denominator 2 a_tau
+PASS: counterfeit rejector: fabricated anchor is not admitted -- positivity_trivial_kernel: anchor not found in source
+PASS: counterfeit rejector: missing packet-consumption criterion is not admitted -- criteria evidence does not cover exactly the four admission criteria
+PASS: counterfeit rejector: evidence outside the enumerated surface is not admitted -- supplied_as_physical_transfer: evidence path outside the enumerated packet surface
+PASS: parent grammar: every consumed T_hat^2 transfer/step pair normalizes to (T_hat^2, 2 a_tau) -- pairs=['T_hat^2,2a_tau']
 PASS: RP2 supplies the two-step transfer
 PASS: RP2 supplies positivity
 PASS: RP2 excludes the single-step object as the physical positive transfer
@@ -23,21 +57,16 @@ PASS: Stone note is transfer-relative
 PASS: Stone uniqueness does not add a transfer
 PASS: post-record rates require supplied clock map
 PASS: post-record layer does not derive a clock
-PASS: inventory contains exactly one admitted physical-clock transfer
-PASS: the admitted transfer is the two-step blocked transfer with denominator 2 a_tau
-PASS: finite tensor-factor comparators are not physical-clock admissions
-PASS: admitted physical-clock count remains one after comparator scan
 PASS: mathematical comparator T_A x I is positive
 PASS: mathematical comparator I x T_B is positive
 PASS: mathematical comparator transfers commute -- resid=0.00e+00
 PASS: factor comparator tangent space is two-dimensional -- rank=2
-PASS: two positive factor transfers exist as mathematical comparators
-PASS: zero factor comparators are admitted physical clocks
-PASS: counterfactual second admission would visibly break the inventory
-PASS: note states why the support is source-inventory, not algebraic exclusion
 
-SUMMARY: PASS=35 FAIL=0
+SUMMARY: PASS=53 FAIL=0
 ADMITTED_PHYSICAL_CLOCK_TRANSFERS=1
 B_AXIS_DERIVED=FALSE
 MATHEMATICAL_FACTOR_TRANSFERS_EXCLUDED=FALSE
 AUDIT_LEDGER_WRITTEN=FALSE
+
+----- stderr -----
+

--- a/scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py
+++ b/scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 """Source-inventory support for B-AXIS.3 physical-clock admission.
 
-This runner distinguishes admitted physical-clock transfers from arbitrary
-positive finite operators on tensor factors. It intentionally does not prove
-that commuting factor transfers are mathematically impossible.
+This runner enumerates the note's dated admission manifest live from the
+packet sources: it recomputes the packet link closure, reads the axiom leg
+through the stable minimal_axioms premise node (2026-06-29 memo), and computes
+the admitted physical-clock list from per-criterion source evidence instead of
+preset admission flags. It intentionally does not prove that commuting factor
+transfers are mathematically impossible.
 """
 
 from __future__ import annotations
 
+import copy
+import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -17,11 +23,19 @@ import numpy as np
 ROOT = Path(__file__).resolve().parents[1]
 NOTE = ROOT / "docs" / "SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md"
 SINGLE_CLOCK = ROOT / "docs" / "AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md"
-MINIMAL = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-05.md"
+MINIMAL = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+PREMISE_NODES = ROOT / "docs" / "audit" / "data" / "axiom_premise_nodes.json"
 RP2 = ROOT / "docs" / "AXIOM_FIRST_RP_TWO_STEP_TRANSFER_MATRIX_POSITIVITY_NOTE_2026-05-28.md"
 SC2 = ROOT / "docs" / "AXIOM_FIRST_SPECTRUM_CONDITION_BLOCKED_TIME_NORMALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md"
 STONE = ROOT / "docs" / "SINGLE_CLOCK_STONE_FINITE_DIM_UNIQUENESS_NARROW_THEOREM_NOTE_2026-05-10.md"
 POST_RECORD = ROOT / "docs" / "POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md"
+
+ADMISSION_CRITERIA = (
+    "supplied_as_physical_transfer",
+    "positivity_trivial_kernel",
+    "clock_denominator",
+    "packet_consumption",
+)
 
 
 @dataclass
@@ -54,6 +68,54 @@ def flat(path: Path) -> str:
     return " ".join(read(path).split())
 
 
+def strip_fences(text: str) -> str:
+    return re.sub(r"```.*?```", "", text, flags=re.S)
+
+
+def md_link_set(path: Path) -> set[str]:
+    """Markdown .md link targets outside fenced blocks, as docs/<basename>."""
+    targets = re.findall(r"\]\(([^)\s]+)\)", strip_fences(read(path)))
+    out: set[str] = set()
+    for target in targets:
+        target = target.split("#")[0]
+        if target.endswith(".md"):
+            out.add("docs/" + target.split("/")[-1])
+    return out
+
+
+def extract_manifest(path: Path) -> dict:
+    blocks = re.findall(r"```json\n(.*?)```", read(path), flags=re.S)
+    check(len(blocks) == 1, "note carries exactly one fenced JSON manifest block",
+          f"found={len(blocks)}")
+    return json.loads(blocks[0])
+
+
+def evaluate_candidate(candidate: dict, surface_paths: set[str]) -> tuple[bool, str]:
+    """Compute physical-clock admission from per-criterion source evidence."""
+    evidence = candidate.get("criteria_evidence", {})
+    if set(evidence.keys()) != set(ADMISSION_CRITERIA):
+        return False, "criteria evidence does not cover exactly the four admission criteria"
+    for criterion in ADMISSION_CRITERIA:
+        item = evidence[criterion]
+        rel = str(item.get("path", ""))
+        if rel not in surface_paths:
+            return False, f"{criterion}: evidence path outside the enumerated packet surface"
+        source = ROOT / rel
+        if not source.exists():
+            return False, f"{criterion}: evidence file missing"
+        anchor = " ".join(str(item.get("anchor", "")).split())
+        if not anchor or anchor not in flat(source):
+            return False, f"{criterion}: anchor not found in source"
+    return True, "all four criteria evidenced in packet sources"
+
+
+def normalize_pair(first: str, second: str) -> str:
+    s = f"{first},{second}".replace("`", "").replace(" ", "")
+    s = s.replace("T̂²", "T_hat^2").replace("T̂^2", "T_hat^2")
+    s = s.replace("τ", "tau").replace("²", "^2")
+    return s
+
+
 def opnorm(matrix: np.ndarray) -> float:
     return float(np.linalg.norm(matrix, ord=2))
 
@@ -67,71 +129,176 @@ def main() -> int:
     print("single-clock physical-clock admission inventory N5 support")
     print("=" * 72)
 
+    # --- note scope anchors ---
     assert_contains(NOTE, "ADMITTED_PHYSICAL_CLOCK_TRANSFERS=1")
     assert_contains(NOTE, "MATHEMATICAL_FACTOR_TRANSFERS_EXCLUDED=FALSE")
     assert_contains(NOTE, "Does not mathematically exclude independent commuting transfer factors")
     assert_contains(NOTE, "Does not add an axiom")
     assert_contains(NOTE, "**Claim boundary:** source-inventory support")
     assert_contains(NOTE, "No second physical-clock transfer is currently admitted.")
+    assert_contains(NOTE, "## Admission Manifest (2026-07-10)")
+    check("not a theorem over all positive operators" in read(NOTE),
+          "note states why the support is source-inventory, not algebraic exclusion")
 
+    # --- parent packet anchors ---
     assert_contains(SINGLE_CLOCK, "(B-AXIS.3)", "single-clock source names B-AXIS.3")
-    assert_contains(SINGLE_CLOCK, "admitted\n    as a second physical clock", "B-AXIS.3 is phrased as an admission statement")
-    assert_contains(SINGLE_CLOCK, "(T̂², 2a_τ)", "single-clock source names the sole supplied transfer/step pair")
+    assert_contains(SINGLE_CLOCK, "admitted\n    as a second physical clock",
+                    "B-AXIS.3 is phrased as an admission statement")
+    assert_contains(SINGLE_CLOCK, "(T̂², 2a_τ)",
+                    "single-clock source names the sole supplied transfer/step pair")
     check("This note **complies** by declaring those clauses as (B-AXIS)" in flat(SINGLE_CLOCK),
           "single-clock source keeps B-AXIS declared")
 
+    # --- axiom authority: cited 2026-06-29 memo supplies no clock ---
     minimal_flat = flat(MINIMAL)
-    check("does not supply a dynamics" in minimal_flat, "minimal Lattice supplies no dynamics")
-    check("does not supply a dynamics" in minimal_flat and "measurement instrument" in minimal_flat,
-          "minimal Quantum supplies no dynamics")
-    assert_contains(MINIMAL, "time metric", "Record supplies no time metric")
-    assert_contains(MINIMAL, "does not derive or enlarge the axiom set", "minimal axiom runner does not enlarge axioms")
+    check("### Lattice / Physical Locality" in minimal_flat
+          and "### Qubit / Site Possibility" in minimal_flat
+          and "### Admissibility / Local Constraint" in minimal_flat
+          and "### Record / Fixed Reality" in minimal_flat,
+          "minimal 2026-06-29 memo names the four axioms")
+    check("Admissibility is not a dynamics axiom." in minimal_flat,
+          "minimal 2026-06-29: Admissibility is not a dynamics axiom")
+    exclusion = ("choose a Hamiltonian or transfer operator, supply transition "
+                 "probabilities or weights, select a scalar or nonzero kinetic branch, "
+                 "assert a Dirac-square carrier, define a time metric, or provide a "
+                 "record-production process or physical persistence dynamics.")
+    check(exclusion in minimal_flat,
+          "minimal 2026-06-29: dynamics-exclusion sentence covers transfer operator and time metric")
+    check("time metric, and local observability of records" in minimal_flat,
+          "minimal 2026-06-29: time metric listed among open gates outside axiom content")
+    check("Probability, dynamics, readout contexts, and physical observable bridges remain downstream."
+          in minimal_flat,
+          "minimal 2026-06-29: probability/dynamics/bridges stay downstream")
+    check("does not derive or enlarge the axiom set" in minimal_flat,
+          "minimal axiom runner does not enlarge axioms")
 
+    # --- stable premise-node registry: 06-05 path is an alias, not a second authority ---
+    registry = json.loads(read(PREMISE_NODES))
+    node = registry.get("nodes", {}).get("minimal_axioms", {})
+    check("minimal_axioms" in registry.get("canonical_ids", []),
+          "registry lists minimal_axioms as a canonical premise node")
+    check(node.get("current_path") == "docs/MINIMAL_AXIOMS_2026-06-29.md",
+          "registry current path for minimal_axioms is the 2026-06-29 memo")
+    check("docs/MINIMAL_AXIOMS_2026-06-05.md" in node.get("aliased_paths", []),
+          "registry aliases the 2026-06-05 path to the same premise node")
+
+    # --- manifest: structure ---
+    manifest = extract_manifest(NOTE)
+    note_rel = "docs/" + NOTE.name
+    parent_rel = "docs/" + SINGLE_CLOCK.name
+    check(manifest.get("manifest_date") == "2026-07-10", "manifest is explicitly dated 2026-07-10")
+    check(manifest.get("packet_notes") == [parent_rel, note_rel],
+          "manifest packet is the parent theorem note plus this inventory note")
+    authority = manifest.get("axiom_authority", {})
+    check(authority.get("stable_id") == "minimal_axioms"
+          and authority.get("current_path") == node.get("current_path")
+          and authority.get("registry") == "docs/audit/data/axiom_premise_nodes.json",
+          "manifest axiom authority matches the registry premise node")
+
+    # --- manifest: closed enumeration recomputed live from the packet notes ---
+    entries = manifest.get("entries", [])
+    entry_paths = [e.get("path", "") for e in entries]
+    parent_links = md_link_set(SINGLE_CLOCK)
+    note_links = md_link_set(NOTE)
+    union = parent_links | note_links
+    check(len(entries) == 19, "manifest enumerates 19 packet documents", f"got={len(entries)}")
+    check(len(entry_paths) == len(set(entry_paths)), "manifest entry paths are unique")
+    missing = sorted(union - set(entry_paths))
+    stale = sorted(set(entry_paths) - union)
+    check(not missing and not stale,
+          "closed enumeration: manifest entries equal the live packet link union",
+          f"missing={missing} stale={stale}")
+
+    provenance_mismatches = []
+    title_mismatches = []
+    for entry in entries:
+        path = entry.get("path", "")
+        want = set()
+        if path in parent_links:
+            want.add("parent")
+        if path in note_links:
+            want.add("n5")
+        if set(entry.get("linked_by", [])) != want or not want:
+            provenance_mismatches.append(path)
+        source = ROOT / path
+        first_line = read(source).splitlines()[0] if source.exists() else ""
+        if first_line != "# " + str(entry.get("h1", "")):
+            title_mismatches.append(path)
+        if not str(entry.get("role", "")).strip():
+            provenance_mismatches.append(path + " (empty role)")
+    check(not provenance_mismatches,
+          "per-entry linked_by matches live link provenance and every role is stated",
+          f"mismatches={provenance_mismatches}")
+    check(not title_mismatches,
+          "per-entry h1 titles match the live document headers",
+          f"mismatches={title_mismatches}")
+    alias_rows = {e["path"]: e.get("alias_of") for e in entries if "alias_of" in e}
+    check(set(alias_rows) == {"docs/MINIMAL_AXIOMS_2026-06-05.md", "docs/MINIMAL_AXIOMS_2026-06-29.md"}
+          and set(alias_rows.values()) == {"minimal_axioms"},
+          "exactly the two minimal-axiom paths are marked as aliases of minimal_axioms")
+    aliased_ok = all(
+        path == node.get("current_path") or path in node.get("aliased_paths", [])
+        for path in alias_rows
+    )
+    check(aliased_ok, "every manifest alias row resolves inside the registry premise node")
+
+    # --- computed admission: evaluate candidates against packet sources ---
+    surface = set(entry_paths) | set(manifest.get("packet_notes", []))
+    candidates = manifest.get("candidates", [])
+    check(len(candidates) == 1, "manifest proposes exactly one physical-clock candidate")
+    admitted = []
+    for candidate in candidates:
+        ok, why = evaluate_candidate(candidate, surface)
+        check(ok, f"candidate {candidate.get('name')} evaluates as admitted from source evidence", why)
+        if ok:
+            admitted.append(candidate)
+    check(len(admitted) == 1, "computed admitted physical-clock count is one", f"got={len(admitted)}")
+    check(bool(admitted) and admitted[0].get("name") == "T_hat^2"
+          and admitted[0].get("clock_denominator") == "2 a_tau",
+          "the computed admitted transfer is T_hat^2 with denominator 2 a_tau")
+
+    # --- counterfeit rejectors: the same evaluator must refuse broken candidates ---
+    real = candidates[0]
+    fake_anchor = copy.deepcopy(real)
+    fake_anchor["criteria_evidence"]["positivity_trivial_kernel"]["anchor"] = (
+        "counterfeit anchor text absent from every packet source")
+    ok_fake, why_fake = evaluate_candidate(fake_anchor, surface)
+    check(not ok_fake, "counterfeit rejector: fabricated anchor is not admitted", why_fake)
+    fake_missing = copy.deepcopy(real)
+    del fake_missing["criteria_evidence"]["packet_consumption"]
+    ok_fake, why_fake = evaluate_candidate(fake_missing, surface)
+    check(not ok_fake, "counterfeit rejector: missing packet-consumption criterion is not admitted",
+          why_fake)
+    fake_outside = copy.deepcopy(real)
+    fake_outside["criteria_evidence"]["supplied_as_physical_transfer"]["path"] = (
+        "docs/NOT_IN_PACKET_SURFACE_NOTE.md")
+    ok_fake, why_fake = evaluate_candidate(fake_outside, surface)
+    check(not ok_fake, "counterfeit rejector: evidence outside the enumerated surface is not admitted",
+          why_fake)
+
+    # --- sole-pair consumption grammar in the parent packet ---
+    pair_pat = re.compile(r"\(([^(),]+),([^()]*a_(?:τ|tau)[^()]*)\)")
+    pairs = [normalize_pair(a, b) for a, b in pair_pat.findall(read(SINGLE_CLOCK))]
+    transfer_pairs = sorted({p for p in pairs if p.startswith("T_hat^2,")})
+    check(transfer_pairs == ["T_hat^2,2a_tau"],
+          "parent grammar: every consumed T_hat^2 transfer/step pair normalizes to (T_hat^2, 2 a_tau)",
+          f"pairs={transfer_pairs}")
+
+    # --- admitted-pair evidence sources keep their independent anchors ---
     assert_contains(RP2, "2-step blocked transfer matrix", "RP2 supplies the two-step transfer")
     assert_contains(RP2, "positive Hermitian", "RP2 supplies positivity")
-    assert_contains(RP2, "single-step transfer operator is NOT positive", "RP2 excludes the single-step object as the physical positive transfer")
+    assert_contains(RP2, "single-step transfer operator is NOT positive",
+                    "RP2 excludes the single-step object as the physical positive transfer")
     assert_contains(SC2, "2 a_τ", "SC2 supplies the blocked time denominator")
-    assert_contains(SC2, "H  :=  -(1/(2 a_τ)) log(T_hat^2 / M_T)", "SC2 supplies corrected log normalization")
-
+    assert_contains(SC2, "H  :=  -(1/(2 a_τ)) log(T_hat^2 / M_T)",
+                    "SC2 supplies corrected log normalization")
     assert_contains(STONE, "given", "Stone note is transfer-relative")
     check("uniquely determined by `T`" in read(STONE), "Stone uniqueness does not add a transfer")
     assert_contains(POST_RECORD, "supplied clock map", "post-record rates require supplied clock map")
-    assert_contains(POST_RECORD, "does not supply physical elapsed time", "post-record layer does not derive a clock")
+    assert_contains(POST_RECORD, "does not supply physical elapsed time",
+                    "post-record layer does not derive a clock")
 
-    admitted = [
-        {
-            "name": "T_hat^2",
-            "source": "RP2/SC2",
-            "positive_transfer": True,
-            "clock_denominator": "2 a_tau",
-            "physical_clock_admitted": True,
-        }
-    ]
-    comparators = [
-        {
-            "name": "T_A x I",
-            "source": "finite tensor-factor comparator",
-            "positive_transfer": True,
-            "clock_denominator": "arbitrary tau_A",
-            "physical_clock_admitted": False,
-        },
-        {
-            "name": "I x T_B",
-            "source": "finite tensor-factor comparator",
-            "positive_transfer": True,
-            "clock_denominator": "arbitrary tau_B",
-            "physical_clock_admitted": False,
-        },
-    ]
-
-    check(len(admitted) == 1, "inventory contains exactly one admitted physical-clock transfer")
-    check(admitted[0]["name"] == "T_hat^2" and admitted[0]["clock_denominator"] == "2 a_tau",
-          "the admitted transfer is the two-step blocked transfer with denominator 2 a_tau")
-    check(all(not c["physical_clock_admitted"] for c in comparators),
-          "finite tensor-factor comparators are not physical-clock admissions")
-    check(sum(1 for x in admitted + comparators if x["physical_clock_admitted"]) == 1,
-          "admitted physical-clock count remains one after comparator scan")
-
+    # --- mathematical comparators exist (why the exclusion claim is NOT made) ---
     ident = np.eye(2)
     sigma_z = np.array([[1.0, 0.0], [0.0, -1.0]])
     h_a = 1.1 * ident + 0.2 * sigma_z
@@ -142,28 +309,19 @@ def main() -> int:
     check(np.min(np.linalg.eigvalsh(t_a)) > 0, "mathematical comparator T_A x I is positive")
     check(np.min(np.linalg.eigvalsh(t_b)) > 0, "mathematical comparator I x T_B is positive")
     check(opnorm(t_a @ t_b - t_b @ t_a) < 1e-13,
-          "mathematical comparator transfers commute", f"resid={opnorm(t_a @ t_b - t_b @ t_a):.2e}")
+          "mathematical comparator transfers commute",
+          f"resid={opnorm(t_a @ t_b - t_b @ t_a):.2e}")
 
     h_a_lift = np.kron(h_a, ident)
     h_b_lift = np.kron(ident, h_b)
     span_rank = np.linalg.matrix_rank(np.stack([h_a_lift.ravel(), h_b_lift.ravel()]), tol=1e-12)
     check(span_rank == 2, "factor comparator tangent space is two-dimensional", f"rank={span_rank}")
-    check(sum(1 for c in comparators if c["positive_transfer"]) == 2,
-          "two positive factor transfers exist as mathematical comparators")
-    check(sum(1 for c in comparators if c["physical_clock_admitted"]) == 0,
-          "zero factor comparators are admitted physical clocks")
-
-    counterfactual = admitted + [{**comparators[0], "physical_clock_admitted": True}]
-    check(sum(1 for x in counterfactual if x["physical_clock_admitted"]) == 2,
-          "counterfactual second admission would visibly break the inventory")
-    check("not a theorem over all positive operators" in read(NOTE),
-          "note states why the support is source-inventory, not algebraic exclusion")
 
     passed = sum(1 for c in checks if c.ok)
     failed = sum(1 for c in checks if not c.ok)
     print()
     print(f"SUMMARY: PASS={passed} FAIL={failed}")
-    print("ADMITTED_PHYSICAL_CLOCK_TRANSFERS=1")
+    print(f"ADMITTED_PHYSICAL_CLOCK_TRANSFERS={len(admitted)}")
     print("B_AXIS_DERIVED=FALSE")
     print("MATHEMATICAL_FACTOR_TRANSFERS_EXCLUDED=FALSE")
     print("AUDIT_LEDGER_WRITTEN=FALSE")


### PR DESCRIPTION
## What this responds to

Row `single_clock_physical_clock_admission_inventory_n5_support_note_2026-06-17`
was `audited_conditional` with the verdict:

> supply an explicit dated source-packet or admission manifest and make the runner enumerate it using the cited 2026-06-29 axiom memo rather than preset physical_clock_admitted flags.

This PR satisfies that verdict in its own vocabulary. No axiom is added; the note's
dependency edges are unchanged.

## What changed (source-only triple)

- **Note** — adds a dated `## Admission Manifest (2026-07-10)` section: prose bullets plus a
  single fenced JSON manifest enumerating the 19-document packet, the axiom-authority block
  (stable id `minimal_axioms`), and exactly one physical-clock candidate (`T_hat^2`, clock
  denominator `2 a_tau`) with per-criterion source evidence over the four admission criteria.
  The manifest is fenced, so it adds **no** ledger dependency edges — the note's markdown-link
  inventory stays exactly the 5 Audit-dependency-repair links (verified identical to
  `origin/main`).
- **Runner** — replaces the old preset `admitted`/`comparators` dicts (which carried
  `physical_clock_admitted` booleans) with a live recompute:
  - **Closed enumeration** — the manifest entries must equal the live markdown-link union of
    the parent theorem note and this support note (`missing=[] stale=[]`, 19 unique entries);
    per-entry `linked_by` provenance and `h1` titles are checked against the live document
    headers.
  - **Axiom authority via the registry alias** — read through the stable `minimal_axioms`
    premise node in `docs/audit/data/axiom_premise_nodes.json`; current path is
    `MINIMAL_AXIOMS_2026-06-29.md`, and `MINIMAL_AXIOMS_2026-06-05.md` resolves as an alias of
    the same node (not a second authority). The 06-29 memo's dynamics-exclusion sentence
    (transfer operator, time metric, weights) is grepped verbatim.
  - **Computed admission** — physical-clock admission is evaluated from per-criterion source
    evidence, not a preset flag; the sole candidate is admitted only because each of the four
    criteria resolves to an anchor found in an enumerated packet source. Three counterfeit
    candidates (fabricated anchor, deleted criterion, evidence outside the enumerated surface)
    are refused **through the same evaluator**.
  - **Sole-pair grammar** — a scan of the parent packet confirms every consumed `T_hat^2`
    transfer/step pair normalizes to `(T_hat^2, 2 a_tau)`.
- **Cache** — regenerated via `scripts/runner_cache.py`.

## Boundary (unchanged)

The support remains **source-inventory**, not an algebraic exclusion. The runner constructs
explicit commuting positive factor transfers (`resid=0.00e+00`, tangent rank 2) to show why
`MATHEMATICAL_FACTOR_TRANSFERS_EXCLUDED=FALSE` — the note does **not** claim independent
commuting transfer factors are mathematically impossible, only that none is currently admitted.

## Runner result

```
SUMMARY: PASS=53 FAIL=0
ADMITTED_PHYSICAL_CLOCK_TRANSFERS=1
B_AXIS_DERIVED=FALSE
MATHEMATICAL_FACTOR_TRANSFERS_EXCLUDED=FALSE
AUDIT_LEDGER_WRITTEN=FALSE
```

Discriminating-gate checked: corrupting a manifest `h1` drives the runner to `PASS=52 FAIL=1`
with a precise mismatch report; the counterfeit rejectors fire on each broken candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
