### PR TITLE
governance: owner decision surface — Class B premise reversion options (proposal only)

### DIFF
--- a/docs/OWNER_DECISION_SURFACE_CLASS_B_PREMISE_REVERSION_2026-07-11.md
+++ b/docs/OWNER_DECISION_SURFACE_CLASS_B_PREMISE_REVERSION_2026-07-11.md
@@ -1,0 +1,73 @@
+# Owner Decision Surface: Reverting the Owner-Governed (Class B) Premises
+
+**Date:** 2026-07-11
+**Type:** PROPOSAL (Class D decision surface; cite only as proposed)
+**Status authority:** owner only. This document executes nothing. It records a
+pending owner decision with its options and blast radius, per the minimality
+policy's rule that unmade decisions are recorded, not acted on.
+
+## What is being decided
+
+On 2026-07-05 two premises were adopted into a then-new registry class,
+"owner-governed residual premises" (`docs/audit/data/owner_governed_premise_nodes.json`),
+retiring the last two Tier-A admissions and bringing the admitted-input count
+to zero:
+
+1. **The counting rule for the generation doublet** ("occupancy grain"): the
+   matched pair of generation modes counts once, as one pair, rather than once
+   per real component. It supplies only that counting rule — no value of the
+   mass-ratio dial, no weighting law.
+2. **The angle-readout license** ("R-eta h-class/h-unit"): permission to read a
+   specific registered angle functional identically in its natural units, with
+   no intervening conversion factor.
+
+Mechanically, a Class B premise lets downstream claims chain-complete without
+being marked conditional-on-an-admission, while staying inside an exact quoted
+boundary and remaining "not an axiom, not a primitive, not a derived theorem."
+
+On 2026-07-11 the owner stated: "we cannot have owner-governed class B
+premises." This surface records the reversal options.
+
+## Why the objection has force
+
+The adoption retired the Tier-A ledger without deriving anything. The
+"admitted-input count: zero" headline is doing rhetorical work the science has
+not paid for: the two premises are admissions with a different registry name.
+The framework's own audit vocabulary elsewhere insists that a supplied,
+underivable input bounds whatever consumes it.
+
+## Options
+
+**A. Full reversion.** Move both premises back to Tier-A admissions.
+- Admitted-input count returns to 2 (honest pre-2026-07-05 state).
+- Every row consuming them returns to the bounded tier (`retained_bounded`).
+- The theta closure is partially re-bounded: its mass-side reading was
+  relocated onto the counting-rule premise's boundary, so theta's "retired by
+  derivation" status becomes "retired by derivation, one leg bounded."
+- Registry edits (owner lane): `owner_governed_premise_nodes.json` emptied or
+  deleted; `tier_a_admissions.json` count and entries restored; minimality
+  policy §6 entry recording the reversal; effective-status recompute.
+
+**B. Keep the premises, rename the class.** If the objection is to the
+mechanism's presentation (a premise class that reads as "owner fiat clears the
+ledger"), the same two atoms can be re-filed as ordinary Tier-A admissions
+WITH their current exact boundaries, and the separate registry class deleted.
+Same science as A; differs only in whether the boundary texts survive as the
+admission wording.
+
+**C. Hold reversion behind the running derivation program.** The 2026-07-11
+r=1/2 program (five blocks: moment repair; permanence-forced double
+registration; the kappa flow-class localization; the graded-constraint
+boundary theorems; the dial-shape theorem) attacks exactly the content these
+premises supply. If the counting rule and the equal-weight-per-cell law become
+derived theorems, the premises retire by derivation and there is nothing left
+to revert; if the program dead-ends, revert per A with nothing lost meanwhile.
+Note: Class B premises already supply no values, so no numerical claim
+becomes true or false under any option — this is an honesty-labeling
+decision, not a physics decision.
+
+## What this surface does not do
+
+It does not edit any registry, does not change any claim's status, does not
+touch the two premises' boundary texts, and does not choose among A/B/C. The
+choice, and the recording of it in the minimality policy, are owner acts.


### PR DESCRIPTION
Records the 2026-07-11 owner statement ("we cannot have owner-governed Class B premises") as a Class D decision surface: what the two Class B premises are in plain terms, why the objection has force (the adoption retired the Tier-A ledger without deriving anything), and three options with blast radius — A: full reversion to Tier-A (count returns to 2; theta's mass-side leg re-bounded); B: same science, class renamed to ordinary admissions; C: hold reversion behind the running r=1/2 derivation program (PRs #5162–#5166), which attacks exactly the content these premises supply — if the counting rule and equal-weight law become theorems, there is nothing left to revert.

Executes nothing; registry edits and the choice among A/B/C are owner acts. Authored directly by the supervisor (no worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)