### PR TITLE
repair: remove inherited rho-map r-attribution from the T2 locked-record-outcomes surface

### DIFF
--- a/docs/KOIDE_OCCUPANCY_FROM_LOCKED_RECORD_OUTCOMES_BOUNDED_NOTE_2026-07-03.md
+++ b/docs/KOIDE_OCCUPANCY_FROM_LOCKED_RECORD_OUTCOMES_BOUNDED_NOTE_2026-07-03.md
@@ -10,10 +10,71 @@ zero on main. This note is banked only as bounded historical/supporting science
 for the flavor occupancy bridge; it does not reopen, modify, or supply
 authority for any admission or retirement record.
 
+**Repair update:** 2026-07-11 — an independent audit (2026-07-10) failed the
+companion orbit-occupancy note for an arithmetic error in its `rho`-map. This
+note **inherited** the same contaminated arithmetic in its T2 negative control
+(the Result T2 negative-control passage and runner CHECK 13). The `rho`-map r-attribution is
+withdrawn and replaced by the equipartition-granularity framing;
+`Z_sector/Z_orbit = 2` is retained as a normalization / determinant-power fact
+**decoupled from `r`**. Companion to PR #5162 (the 2026-06-09 note's source-side
+repair). The T1 localization and the T2 slot-counting collision exhibit are a
+separate, uncontested argument and are unchanged. See the
+**Repair (2026-07-11)** section below.
+
 **Primary runner:**
 [`scripts/frontier_koide_occupancy_locked_record_outcomes_2026_07_03.py`](../scripts/frontier_koide_occupancy_locked_record_outcomes_2026_07_03.py)
 **Runner cache:**
 [`logs/runner-cache/frontier_koide_occupancy_locked_record_outcomes_2026_07_03.txt`](../logs/runner-cache/frontier_koide_occupancy_locked_record_outcomes_2026_07_03.txt)
+
+## Repair (2026-07-11): inherited `rho`-map r-attribution withdrawn
+
+An independent audit (2026-07-10) failed the companion orbit-occupancy note
+[`KOIDE_ORBIT_OCCUPANCY_INDEPENDENCE_AND_PREMISE_CANDIDATE_NOTE_2026-06-09.md`](KOIDE_ORBIT_OCCUPANCY_INDEPENDENCE_AND_PREMISE_CANDIDATE_NOTE_2026-06-09.md)
+for an arithmetic error in its `rho`-map. Verbatim finding:
+
+> "The holomorphic Gaussian integral does not yield the claimed one-slot
+> equipartition moment: with Z=pi/g and g=6 beta, it gives &lt;|b|^2&gt;=1/(6 beta),
+> hence r=1, not 1/2. The runner obtains r=1/2 by hard-coding a per-slot quantum
+> rather than deriving it from that integral."
+
+**The inheritance.** This note reproduced the same withdrawn `rho` arithmetic in
+its T2 negative control. The passage revised below, and the runner's CHECK 13,
+carried the `rho`-map `r = 1/(2ρ)` with `ρ = (π/g)/Z_d`, reading `r = 1` and
+`r = 1/2` off the partition-normalization ratio `Z_sector/Z_orbit = 2`. That
+attribution is withdrawn here for the same reason the audit gave on the source
+side: the honest Gaussian moment is **normalization-independent** — the `Z`
+ratio cancels in the moment ratio — and gives `r = 1` for *both* bookkeepings,
+so `Z_d` does not set `r`.
+
+**What changed, and what did not.**
+
+- **Withdrawn:** the `rho`-map `r = 1/(2ρ)` and every statement that the
+  `Z`-ratio *sets* the `r`-ratio (runner CHECK 13 rewritten; the lines below
+  rewritten).
+- **Retained as a true fact, relabeled:** `Z_sector/Z_orbit = 2` is a
+  normalization / determinant-power fact only, decoupled from `r` (runner
+  CHECK 12, now paired with an honest `sympy` moment check confirming the
+  second moment `⟨|b|²⟩` is the same under both bookkeepings, so the moment
+  `r` is invariant to that choice — mirroring the companion runner's O3A).
+- **Corrected r-attribution:** the two `r`-endpoints are exact solutions of two
+  realized-state equipartition **laws** differing only in granularity — per
+  **real mode** (sector cell: `E_s = ε`, `E_d = 2ε` ⟹ `r = 1`) versus per
+  **outcome cell** (orbit cell: `E_s = E_d` ⟹ `r = 1/2`, and `Q = 2/3` via
+  `Q = (1+2r)/3`). The quantum `ε` cancels in `r`; nothing is hard-coded on a
+  derivation path.
+- **Untouched:** the T1 K-real-section localization (Result T1) and the T2
+  slot-counting collision exhibit against the two Record sentences (Result T2's
+  collision passage). That collision argument — one locked complex outcome
+  assigned two slots by the Re/Im split versus one slot by the locked outcome —
+  is a separate argument, is not contested by the audit, and is not weakened,
+  expanded, or re-editorialized here. Only the downstream `r`-attribution step
+  was contaminated.
+
+This repair is the companion to the 2026-06-09 note's **Repair (2026-07-11)**
+section (in-flight as PR #5162), which withdrew the `rho`-map on the source side
+and recharacterized the two witnesses as realized-state equipartition laws
+differing only in granularity. This note sets no audit status; the audit lane
+owns the re-check. Runner after repair: `TOTAL: PASS=13 FAIL=0`.
 
 ## Question
 
@@ -79,9 +140,18 @@ and the slot multiplicity is changed by the real-coordinate split rather than
 by record content alone. The orbit grading assigns one slot to the locked
 outcome and respects both sentences under the same reading.
 
-The runner's T2 negative control shows the difference is load-bearing:
-`Z_sector / Z_orbit = 2`, giving exactly `r = 1` for sector slotting and
-`r = 1/2` for orbit slotting through the landed `rho` arithmetic.
+The runner's T2 negative control separates a true partition-normalization fact
+from the `r`-attribution. `Z_sector / Z_orbit = 2` is a genuine normalization /
+determinant-power fact (the two-registered-data bookkeeping changes the doublet
+partition by the fiber-count factor 2), but it does **not**, by itself, set the
+doublet `r`: the honest Gaussian moment is normalization-independent — the `Z`
+ratio cancels — and gives `r = 1` for both bookkeepings. The two `r`-endpoints
+arise instead as exact solutions of two realized-state equipartition laws
+differing only in granularity: per real mode (sector cell: `E_s = ε`,
+`E_d = 2ε` ⟹ `r = 1`) versus per outcome cell (orbit cell: `E_s = E_d` ⟹
+`r = 1/2`, and `Q = 2/3` via `Q = (1+2r)/3`). See the **Repair (2026-07-11)**
+section above and the companion 2026-06-09 note's Repair section (in-flight as
+PR #5162).
 
 The honesty boundary is sharp. T2 is not a full derivation unless the
 one-record-one-slot identification is supplied. The remaining bridge is:

--- a/logs/runner-cache/frontier_koide_occupancy_locked_record_outcomes_2026_07_03.txt
+++ b/logs/runner-cache/frontier_koide_occupancy_locked_record_outcomes_2026_07_03.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_koide_occupancy_locked_record_outcomes_2026_07_03.py
-runner_sha256: 4d7432857eb6fbbd3682b88bff1a4af3a353caf13f85cedf8482872900251340
+runner_sha256: 0148f7551343c471b947a9b6f2ac865ee65f4eb0130b67eaae8d9e7e47032d93
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.27
+elapsed_sec: 0.50
 status: ok
 ----- stdout -----
 CHECK 01: PASS -- live quote guard: record locks exactly one admissible local possibility
@@ -17,12 +17,12 @@ CHECK 08: PASS -- T1 negative control: conjugate contamination before K-reality 
 CHECK 09: PASS -- T2 orbit grading assigns one slot to one locked record-outcome
 CHECK 10: PASS -- T2 sector grading makes one locked complex outcome into two registered data
 CHECK 11: PASS -- T2 sector grading changes the slot count by the Re/Im split rather than record content alone
-CHECK 12: PASS -- T2 negative control: two registered data change the doublet weight by factor 2
-CHECK 13: PASS -- T2 factor-2 slot change reproduces r=1 versus r=1/2 exactly
+CHECK 12: PASS -- T2 normalization fact DECOUPLED from r: Z_sector/Z_orbit=2 is a true normalization/det-power fact, but the honest Gaussian moment gives the same <|b|^2> and r=1 for both bookkeepings, so Z_d does NOT set r (rho-map withdrawn; companion PR #5162)
+CHECK 13: PASS -- T2 r-endpoints from equipartition-law GRANULARITY (not the Z-ratio): per-real-mode law (sector cell) solves exactly to r=1, Q=1; per-outcome-cell law E_s=E_d (orbit cell) solves exactly to r=1/2, Q=2/3 -- quantum eps cancels, nothing hard-coded
 SUMMARY files written: docs/KOIDE_OCCUPANCY_FROM_LOCKED_RECORD_OUTCOMES_BOUNDED_NOTE_2026-07-03.md; scripts/frontier_koide_occupancy_locked_record_outcomes_2026_07_03.py
 SUMMARY sharpest remaining bridge sentence: one record locking one admissible local possibility is one statistical slot, and the relevant locked possibilities for the generation doublet are the K/CPT record-outcome orbits rather than the real components of the fluctuation coordinate.
 SUMMARY walls dodged: category-slip by counting record-outcomes only; measure-neutrality by not using J_cs as selector.
-SUMMARY uncertainty for supervisor: T2 remains a collision exhibit under the supplied one-record-one-slot reading.
+SUMMARY repair 2026-07-11 (companion PR #5162): inherited rho-map r-attribution removed; Z_sector/Z_orbit=2 relabeled a normalization/det-power fact decoupled from r; r-endpoints now from equipartition-law granularity (per real mode r=1 / per outcome cell r=1/2). T2 remains a collision exhibit under the supplied one-record-one-slot reading.
 TOTAL: PASS=13 FAIL=0
 
 ----- stderr -----

--- a/scripts/frontier_koide_occupancy_locked_record_outcomes_2026_07_03.py
+++ b/scripts/frontier_koide_occupancy_locked_record_outcomes_2026_07_03.py
@@ -6,6 +6,36 @@ docs/KOIDE_OCCUPANCY_FROM_LOCKED_RECORD_OUTCOMES_BOUNDED_NOTE_2026-07-03.md.
 
 The checks are deterministic symbolic checks. They do not consume empirical
 numbers, fits, random draws, or floating tolerances.
+
+REPAIR 2026-07-11 (companion to PR #5162)
+-----------------------------------------
+An independent audit (2026-07-10) failed the companion orbit-occupancy note
+(KOIDE_ORBIT_OCCUPANCY_INDEPENDENCE_..._2026-06-09) for an arithmetic error in
+its rho-map. Verbatim finding:
+
+  "The holomorphic Gaussian integral does not yield the claimed one-slot
+   equipartition moment: with Z=pi/g and g=6 beta, it gives <|b|^2>=1/(6 beta),
+   hence r=1, not 1/2. The runner obtains r=1/2 by hard-coding a per-slot
+   quantum rather than deriving it from that integral."
+
+This T2 runner INHERITED that contaminated arithmetic: its former CHECK 13 read
+r off a rho-map r = 1/(2 rho) with rho = (pi/g)/Z_d, letting the partition
+normalization Z_d SET r. That is withdrawn. The honest Gaussian moment is
+normalization-INDEPENDENT (Z_d cancels in the moment ratio) and gives r = 1 for
+BOTH bookkeepings, not r = 1/2. What survives:
+
+  * CHECK 12 (relabeled): Z_sector/Z_orbit = 2 is a true normalization /
+    determinant-power fact, DECOUPLED from r. Now paired with an honest sympy
+    moment check confirming <|b|^2> is the same under both bookkeepings, so the
+    moment r is normalization-independent (mirrors the companion runner's O3A).
+  * CHECK 13 (rewritten): the two r-endpoints are exact solutions of two
+    realized-state equipartition LAWS differing only in granularity -- per REAL
+    MODE (sector cell: E_s = eps, E_d = 2 eps => r = 1) versus per OUTCOME CELL
+    (orbit cell: E_s = E_d => r = 1/2, Q = 2/3 via Q = (1+2 r)/3). The quantum
+    eps cancels in r; nothing is hard-coded on a derivation path.
+
+The T1 localization checks and the T2 slot-counting collision exhibit (CHECKS
+1-11) are a separate argument, uncontested by the audit, and are unchanged.
 """
 
 from pathlib import Path
@@ -103,17 +133,93 @@ def main() -> int:
     check(10, sector_collides_with_lock, "T2 sector grading makes one locked complex outcome into two registered data")
     check(11, sector_depends_on_split, "T2 sector grading changes the slot count by the Re/Im split rather than record content alone")
 
+    # -----------------------------------------------------------------------
+    # T2 normalization fact vs the r-endpoints. REPAIR 2026-07-11 (companion to
+    # PR #5162; see the module docstring and the 2026-06-09 note's
+    # "Repair (2026-07-11)" section). The prior CHECK 13 read r off a rho-map
+    # r = 1/(2 rho), rho = (pi/g)/Z_d, letting the doublet partition
+    # normalization Z_d SET r. The 2026-07-10 audit showed that is an
+    # arithmetic error: the honest Gaussian moment is normalization-independent
+    # (Z_d cancels) and gives r = 1 for both bookkeepings. The rho-map and every
+    # "Z-ratio sets the r-ratio" statement are withdrawn. What survives is (a)
+    # the normalization fact Z_sector/Z_orbit = 2, DECOUPLED from r, and (b) the
+    # r-endpoints as exact solutions of two equipartition laws differing only in
+    # granularity.
     g = sp.symbols("g", positive=True)
-    z_orbit = sp.pi / g
-    z_sector = 2 * sp.pi / g
-    weight_factor = sp.simplify(z_sector / z_orbit)
-    rho_orbit = sp.simplify((sp.pi / g) / z_orbit)
-    rho_sector = sp.simplify((sp.pi / g) / z_sector)
-    r_orbit = sp.simplify(1 / (2 * rho_orbit))
-    r_sector = sp.simplify(1 / (2 * rho_sector))
+    beta = sp.symbols("beta", positive=True)
 
-    check(12, weight_factor == 2, "T2 negative control: two registered data change the doublet weight by factor 2")
-    check(13, r_sector == 1 and r_orbit == sp.Rational(1, 2), "T2 factor-2 slot change reproduces r=1 versus r=1/2 exactly")
+    # (a) Normalization / determinant-power fact, decoupled from r. The two
+    # doublet partition bookkeepings of the SAME physical weight exp(-6 beta
+    # |b|^2) -- holomorphic one-complex-slot (Z = pi/g) and realified
+    # two-real-slot (Z = 2 pi/g), with g = 6 beta -- differ by the fiber-count
+    # factor 2. An honest sympy moment check (mirroring the companion runner's
+    # O3A) confirms the second moment <|b|^2> is the SAME under both, so the
+    # Gaussian moment r = <|b|^2>/<a^2> is normalization-independent: Z_d does
+    # NOT set r.
+    z_orbit = sp.pi / g          # holomorphic one-complex-slot bookkeeping
+    z_sector = 2 * sp.pi / g     # realified two-real-slot bookkeeping
+    weight_factor = sp.simplify(z_sector / z_orbit)
+
+    a_s = sp.symbols("a", real=True)
+    x_s, y_s = sp.symbols("x y", real=True)
+    rho_r = sp.symbols("rho_r", positive=True)  # radial coordinate |b|
+    w_singlet = sp.exp(-beta * 3 * a_s ** 2)
+    mean_a2 = sp.simplify(
+        sp.integrate(a_s ** 2 * w_singlet, (a_s, -sp.oo, sp.oo))
+        / sp.integrate(w_singlet, (a_s, -sp.oo, sp.oo)))
+    w_holo = sp.exp(-beta * 6 * rho_r ** 2)
+    mean_b2_holo = sp.simplify(
+        sp.integrate(2 * sp.pi * rho_r * rho_r ** 2 * w_holo, (rho_r, 0, sp.oo))
+        / sp.integrate(2 * sp.pi * rho_r * w_holo, (rho_r, 0, sp.oo)))
+    w_real = sp.exp(-beta * 6 * (x_s ** 2 + y_s ** 2))
+    mean_b2_real = sp.simplify(
+        sp.integrate(sp.integrate((x_s ** 2 + y_s ** 2) * w_real, (x_s, -sp.oo, sp.oo)),
+                     (y_s, -sp.oo, sp.oo))
+        / sp.integrate(sp.integrate(w_real, (x_s, -sp.oo, sp.oo)), (y_s, -sp.oo, sp.oo)))
+    r_moment_holo = sp.simplify(mean_b2_holo / mean_a2)
+    r_moment_real = sp.simplify(mean_b2_real / mean_a2)
+
+    check(12,
+          weight_factor == 2
+          and sp.simplify(mean_b2_holo - mean_b2_real) == 0
+          and r_moment_holo == r_moment_real == 1,
+          "T2 normalization fact DECOUPLED from r: Z_sector/Z_orbit=2 is a true "
+          "normalization/det-power fact, but the honest Gaussian moment gives the "
+          "same <|b|^2> and r=1 for both bookkeepings, so Z_d does NOT set r "
+          "(rho-map withdrawn; companion PR #5162)")
+
+    # (b) The two r-endpoints as exact solutions of two realized-state
+    # equipartition LAWS differing only in granularity. Landed circulant lever:
+    # E_s = 3 a^2, E_d = 6 |b|^2. One quantum eps per counting unit; eps cancels
+    # in r, so nothing is hard-coded on a derivation path.
+    a_v = sp.symbols("a_v", positive=True)
+    bmag2 = sp.symbols("bmag2", positive=True)
+    eps = sp.symbols("eps", positive=True)
+    E_s = 3 * a_v ** 2
+    E_d = 6 * bmag2
+    # sector cell = per-REAL-MODE equipartition (three real modes a; x; y):
+    #   E_s = eps, E_d = 2 eps  =>  |b|^2 = a^2, r = 1.
+    sol_sector = sp.solve([sp.Eq(E_s, eps), sp.Eq(E_d, 2 * eps)], [eps, bmag2], dict=True)[0]
+    r_sector = sp.simplify(sol_sector[bmag2] / a_v ** 2)
+    # orbit cell = per-OUTCOME-CELL equipartition (two cells {e0}; {e1,e2}):
+    #   E_s = eps, E_d = eps (E_s = E_d)  =>  |b|^2 = a^2/2, r = 1/2.
+    sol_orbit = sp.solve([sp.Eq(E_s, eps), sp.Eq(E_d, eps)], [eps, bmag2], dict=True)[0]
+    r_orbit = sp.simplify(sol_orbit[bmag2] / a_v ** 2)
+    Q_sector = sp.simplify((1 + 2 * r_sector) / 3)
+    Q_orbit = sp.simplify((1 + 2 * r_orbit) / 3)
+
+    check(13,
+          r_sector == 1 and r_orbit == sp.Rational(1, 2)
+          and Q_sector == 1 and Q_orbit == sp.Rational(2, 3)
+          # eps is SOLVED from each law (eps = 3 a^2), not assumed, and cancels:
+          # r_sector, r_orbit are pure numbers with no residual eps dependence.
+          and sp.simplify(sol_sector[eps] - 3 * a_v ** 2) == 0
+          and sp.simplify(sol_orbit[eps] - 3 * a_v ** 2) == 0
+          and eps not in r_sector.free_symbols and eps not in r_orbit.free_symbols,
+          "T2 r-endpoints from equipartition-law GRANULARITY (not the Z-ratio): "
+          "per-real-mode law (sector cell) solves exactly to r=1, Q=1; "
+          "per-outcome-cell law E_s=E_d (orbit cell) solves exactly to r=1/2, "
+          "Q=2/3 -- quantum eps cancels, nothing hard-coded")
 
     remaining_bridge = (
         "one record locking one admissible local possibility is one statistical "
@@ -129,7 +235,7 @@ def main() -> int:
     )
     print(f"SUMMARY sharpest remaining bridge sentence: {remaining_bridge}.")
     print("SUMMARY walls dodged: category-slip by counting record-outcomes only; measure-neutrality by not using J_cs as selector.")
-    print("SUMMARY uncertainty for supervisor: T2 remains a collision exhibit under the supplied one-record-one-slot reading.")
+    print("SUMMARY repair 2026-07-11 (companion PR #5162): inherited rho-map r-attribution removed; Z_sector/Z_orbit=2 relabeled a normalization/det-power fact decoupled from r; r-endpoints now from equipartition-law granularity (per real mode r=1 / per outcome cell r=1/2). T2 remains a collision exhibit under the supplied one-record-one-slot reading.")
     print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
     return 0 if FAIL == 0 else 1
 


### PR DESCRIPTION
Companion to PR #5162. The T2 surface reproduced the withdrawn ρ-map arithmetic in its "negative control": the runner's r_orbit/r_sector = 1/(2ρ) block and CHECK 13, and the note's "Z_sector/Z_orbit = 2, giving exactly r=1 ... r=1/2 through the landed rho arithmetic" passage.

Repair: the ρ-map block is deleted; CHECK 12 keeps Z_sector/Z_orbit = 2 as a true normalization/determinant-power fact now DECOUPLED from r (with an honest sympy moment check proving Z_d does not set r); CHECK 13 re-derives the two endpoints as exact solves of the per-real-mode (r=1) vs per-outcome-cell (r=1/2) equipartition laws. The core T1 K-real-section localization and the T2 slot-counting collision exhibit are byte-for-byte untouched — only the r-attribution step changed. Dated repair section quotes the 2026-07-10 audit finding verbatim.

Runner: PASS=13 FAIL=0 (rewritten in place, no renumbering). Cache refreshed and check-only clean.

Execution disclosure: drafted by a Claude Opus 4.8 executor under Claude Fable 5 supervision (workhorse split; codex was usage-limited); supervisor reviewed line-by-line and re-ran the runner. Independent audit remains codex-owned; no status asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)