### PR TITLE
Derive KS four-taste module on supplied OS0 action

### DIFF
--- a/docs/STAGGERED_DIRAC_SUBSTEP3_SPECIES_REDUCTION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-16.md
+++ b/docs/STAGGERED_DIRAC_SUBSTEP3_SPECIES_REDUCTION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-16.md
@@ -9,11 +9,11 @@ audit pipeline after independent review.
 audit verdict and downstream status are set only by the independent
 audit lane.
 **Primary runner:** [`scripts/audit_companion_staggered_dirac_substep3_species_reduction_bridge_2026_05_16.py`](../scripts/audit_companion_staggered_dirac_substep3_species_reduction_bridge_2026_05_16.py)
-**Authority role:** narrow algebraic bridge between two retained
-substrate primitives — the naive lattice fermion `2^d` species count
-on the hypercubic lattice and the `Cl(3,0) ⊗_R C ≅ M_2(C) ⊕ M_2(C)`
-complexification split — that isolates the substep-3 algebraic
-species-count vs. spinor-irrep content of the open
+**Authority role:** narrow algebraic bridge using the retained naive-lattice
+`2^d` species count, the retained `Cl(3,0) ⊗_R C ≅ M_2(C) ⊕ M_2(C)`
+complexification split, and the bounded supplied-action Kogut-Susskind
+blocking theorem. It isolates the substep-3 algebraic species-count versus
+spinor-irrep content of the open
 `STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md` gate.
 
 ## 1. Claim scope
@@ -32,12 +32,10 @@ spatial substrate. The following abstract-algebraic identities hold:
 
 - **(R2) Algebraic product decomposition.** The integer `16` admits
   the exact arithmetic factorization
-  `16 = 4 · 4 = 2^2 · 2^2`. The first factor "`4`" is the standard
-  algebraic taste-count `N_taste = 2^{d/2} = 4` at `d = 4`; the second
-  factor "`4`" is the standard algebraic spinor-count
-  `N_spinor = 2^{d/2} = 4` at `d = 4`. The factorization `16 = 4 · 4`
-  is an arithmetic identity in `Z`, not a derivation that the framework
-  must realize this specific factorization.
+  `16 = 4 · 4 = 2^2 · 2^2`. This arithmetic identity does not assign
+  physical roles to its factors. On the supplied one-component free OS0
+  staggered action, the cited action-level blocking theorem separately
+  derives a 4-dimensional irreducible spin module with multiplicity four.
 
 - **(R3) Spinor-count factor matches Cl(3,0) ⊗_R C dim.** The factor
   `N_spinor = 4` at `d = 4` matches the complex dimension of the
@@ -56,28 +54,26 @@ spatial substrate. The following abstract-algebraic identities hold:
   matches `N_spinor = 4`. This is an exact algebraic-dimensional
   identity, conditional on the cited complexification split.
 
-- **(R4) Taste-count factor decoupled from the Cl(3) algebra.** The
-  factor `N_taste = 4` at `d = 4` is an arithmetic count on the
-  hypercubic-lattice BZ corner structure (Hamming weights `0..d`),
-  not a Cl(3) algebra fact. The cited complexification split bounds
-  only the spinor-count factor (R3); the taste-count factor is **not**
-  forced by the cited upstream and remains an open structural
-  ingredient of the realization gate's substep 3.
+- **(R4) Action-derived taste multiplicity, distinct from Hamming
+  enumeration.** The Hamming-weight distribution `(1,4,6,4,1)` supplies
+  the 16 blocked components and their grading. It does not derive a taste
+  multiplicity. On the explicitly supplied one-component free OS0 staggered
+  action, the cited blocking theorem derives exact `Cl_4(C)` generators on
+  those 16 components and proves that the module is four copies of the unique
+  4-dimensional irreducible spin module. Thus `N_taste=4` is derived for that
+  supplied action. The cited `Cl(3,0)` complexification split contributes the
+  separate chirality-pair dimension match in (R3).
 
-- **(R5) Reduction-as-arithmetic-identity boundary.** The arithmetic
-  factorization `16 = 4 · 4` is **not** the same as a derivation that
-  the framework's specific staggered-Dirac realization implements a
-  Kogut-Susskind `4`-taste reduction. The naive operator carries the
-  full `2^d = 16` zero locus; the standard Kogut-Susskind staggered
-  reduction trades `2^d` doublers for `2^{d/2}` tastes via a
-  spin-diagonal projection, **inside** the staggered formalism. The
-  arithmetic identity `16 = 4 · 4` is necessary but **not sufficient**
-  to derive that the framework realizes that specific reduction.
+- **(R5) Supplied-action boundary.** The action-level theorem establishes
+  the Kogut-Susskind four-taste module conditional on its displayed free OS0
+  staggered action. It does not identify that action as the framework's
+  realized physical matter carrier. The remaining boundary is therefore
+  physical-carrier selection, rather than a missing taste derivation on the
+  supplied action.
 
-Facts (R1)-(R5) are abstract finite-dim lattice-field-theory and
-complex algebra statements. The final two items are explicit
-boundary disclaimers separating the **arithmetic identity** from a
-framework-realization claim.
+Facts (R1)-(R5) separate three layers: the naive-corner count, the exact
+Kogut-Susskind module on the supplied free OS0 action, and the unresolved
+framework physical-carrier identification.
 
 ## 2. Why this note exists
 
@@ -88,7 +84,10 @@ Hamming-weight-graded triplet `1 + 1 + 3 + 3 = 2^3` on `Z^3` (or the
 analogous structure on `Z^4` at `d = 4`), and whether the resulting
 species-count is forced to be the specific framework count.
 
-Two pieces of that chain have since landed retained narrow theorems:
+Two audited suppliers establish the naive count and the `Cl(3,0)` split.
+The supplied-action blocking theorem cited below now provides the missing
+action-level Kogut-Susskind module derivation. Ledger status for every row is
+set by the independent audit lane.
 
 - `NAIVE_LATTICE_FERMION_TWO_POWER_D_SPECIES_COUNT_NARROW_THEOREM_NOTE_2026-05-10.md`
   (retained / audited_clean per the 2026-05-16 ledger) — provides
@@ -100,15 +99,12 @@ Two pieces of that chain have since landed retained narrow theorems:
   which gives the spinor-rep dim `2 + 2 = 4` matching the `d = 4`
   spinor-count factor.
 
-This narrow theorem isolates the **abstract arithmetic factorization**
-`16 = 4 · 4` and the **spinor-count match** between `N_spinor = 4` at
-`d = 4` and the Cl(3) complexification split's chirality-pair dim
-`2 + 2 = 4`, plus the **explicit boundary** that the taste-count
-factor is **not** forced by the cited upstream. The boundary records
-that the substep-3 closure of the open gate — i.e., the framework's
-specific `4`-taste reduction on `Z^3` — is **not** retired by this
-note. The narrow theorem closes only the arithmetic-factorization +
-spinor-count-match half (R1)-(R3) and the explicit boundary (R4)-(R5).
+This revised narrow theorem keeps the arithmetic identity and the
+`Cl(3,0)` chirality-pair dimension match, and adds the independently
+checkable action-level result: the supplied free OS0 staggered action blocks
+to four copies of the 4-dimensional `Cl_4(C)` spin module. The remaining
+scope boundary is identification of that supplied action with the framework's
+realized physical matter carrier.
 
 ## 3. Cited authorities (one hop)
 
@@ -122,6 +118,10 @@ Load-bearing markdown-link upstream dependencies:
   — provides the `Cl(3,0) ⊗_R C ≅ M_2(C) ⊕ M_2(C)` split (R3). Status
   authority: independent audit lane only; effective status
   pipeline-derived.
+- [`STAGGERED_OS0_SUPPLIED_ACTION_KS_BLOCKING_FOUR_TASTE_MODULE_NARROW_THEOREM_NOTE_2026-07-11.md`](STAGGERED_OS0_SUPPLIED_ACTION_KS_BLOCKING_FOUR_TASTE_MODULE_NARROW_THEOREM_NOTE_2026-07-11.md)
+  — derives the exact blocked `Cl_4(C)` module and multiplicity four on the
+  explicitly supplied one-component free OS0 staggered action (R2, R4, R5).
+  Status authority: independent audit lane; effective status pipeline-derived.
 
 No other note's effective status is consumed.
 
@@ -130,13 +130,16 @@ No other note's effective status is consumed.
 - **Standard integer arithmetic.** The factorization `16 = 4 · 4 = 2^2
   · 2^2 = 2^{d/2} · 2^{d/2}` at `d = 4`. Admitted-context
   mathematical infrastructure.
-- **Standard finite-dim complex linear algebra.**
+- **Standard finite-dim complex linear algebra and complex Clifford
+  classification.**
   `dim_C (V ⊕ W) = dim_C V + dim_C W` for finite-dim complex vector
-  spaces. Admitted-context.
+  spaces and `Cl_4(C)=M_4(C)`. Admitted-context mathematical infrastructure.
+- **Supplied free OS0 staggered action.** The one-component action and its
+  canonical eta phases are the disclosed physical premise of the bounded
+  action-level theorem.
 
-No physics conventions admitted beyond the abstract integer
-arithmetic. No PDG value consumed. No staggered-Dirac-on-specific-
-lattice-substrate / `g_bare` / framework-instance-specific input.
+No PDG value, `g_bare`, generation identification, or framework physical-
+carrier selection is consumed.
 
 ## 5. Proof
 
@@ -151,9 +154,11 @@ At `d = 4`, the count is `2^4 = 16`. ∎
 ### 5.2 (R2) Algebraic product decomposition
 
 By integer arithmetic, `16 = 4 · 4 = 2^2 · 2^2 = 2^{d/2} · 2^{d/2}`
-at `d = 4`. The two factors are the standard algebraic taste-count
-and spinor-count at `d = 4`. The factorization is an integer
-identity. ∎
+at `d = 4`. This establishes the product identity but does not name either
+factor. The cited supplied-action blocking theorem derives the factor roles
+from the action: `Cl_4(C)=M_4(C)` acts irreducibly on a 4-dimensional spin
+module, and its exact 16-component blocked representation has multiplicity
+four. ∎
 
 ### 5.3 (R3) Spinor-count factor matches Cl(3,0) ⊗_R C chirality-pair dim
 
@@ -172,58 +177,44 @@ narrow's (K4)). The chirality pair of complex-dim values is
 `dim_C V_+ + dim_C V_- = 2 + 2 = 4` matches the algebraic
 `N_spinor = 2^{d/2} = 4` at `d = 4`. ∎
 
-### 5.4 (R4) Taste-count factor decoupled from Cl(3) algebra
+### 5.4 (R4) Action-derived taste multiplicity
 
-The factor `N_taste = 4` at `d = 4` arises from the hypercubic-lattice
-BZ corner Hamming-weight grading on `Z^d`:
+The hypercubic block labels have Hamming-weight grading
 
 ```text
 (Hamming-weight count on {0, π}^d)  =  binomial(d, k),  k = 0..d.
 ```
 
-At `d = 4`, the Hamming-weight count is `binom(4, k) = (1, 4, 6, 4, 1)`,
-summing to `2^4 = 16`. The Kogut-Susskind reduction at even `d`
-identifies pairs of opposite-chirality corner clusters via a
-spin-diagonal projection, producing `2^{d/2}` tastes. The cited
-upstream `Cl(3,0) ⊗_R C` split provides only the chirality-pair
-dimensional content `(2, 2)`, not the lattice-block taste structure.
-The taste-count factor is therefore decoupled from the cited Cl(3)
-algebra at the level of the narrow theorem's claim. ∎
+At `d = 4`, this gives `(1,4,6,4,1)`, summing to 16. This enumeration
+establishes the blocked-component count and grading, not the taste
+multiplicity.
 
-### 5.5 (R5) Reduction-as-arithmetic-identity boundary
+The cited supplied-action theorem starts from the displayed canonical
+staggered finite difference, blocks `n=2y+b`, and rephases it to
 
-The arithmetic identity `16 = 4 · 4` is exact. It says only that
-the integer `16` has the factorization `4 · 4`; it does **not**
-prove that the framework's lattice realization implements a specific
-Kogut-Susskind `4`-taste reduction. Three structurally distinct
-ingredients enter such a reduction, none of which is forced by the
-arithmetic identity:
+```text
+D_red(p)=mI_16+i sum_mu alpha_mu sin(p_mu a)/a.
+```
 
-(i) **Specific lattice substrate.** Whether the framework lives on
-    `Z^3` (spatial), `Z^4` (space-time), or another lattice substrate
-    determines `d` and changes the BZ corner count. The cited upstream
-    `2^d` theorem records the count for any `d ≥ 1` but does not
-    select a specific framework substrate.
+It proves `{alpha_mu,alpha_nu}=2 delta_(mu nu) I_16`, exact rank 16 for
+the Clifford-word span, and character `(16,0,...,0)`. Since
+`Cl_4(C)=M_4(C)` has a unique 4-dimensional irreducible module, the
+16-dimensional block module is four copies of that spin module. Therefore
+`N_taste=4` is derived on the supplied action. The `Cl(3,0)` split remains
+the separate chirality-pair dimensional match of (R3). ∎
 
-(ii) **Specific regulator (naive / staggered / Wilson / etc.).** The
-    `2^d` count is for the **naive** operator (per the cited upstream
-    boundary, §"Boundary"). The staggered (Kogut-Susskind) reduction
-    is a **different** regulator with a **different** count
-    (`2^{d/2}` tastes at even `d`). The framework's regulator choice
-    is **not** forced by the cited upstream.
+### 5.5 (R5) Supplied-action boundary
 
-(iii) **Specific spin-diagonal projection.** The Kogut-Susskind
-    reduction requires a specific spin-diagonal staggered phase
-    structure (Kawamoto-Smit form), which is the substep-2 content
-    of the open gate. The arithmetic identity `16 = 4 · 4` does not
-    derive the Kawamoto-Smit form.
+The arithmetic identity does not establish the Kogut-Susskind module. The
+cited action-level theorem now supplies that missing derivation for its
+explicitly displayed free OS0 staggered action and canonical phases.
 
-None of (i)-(iii) is closed by the arithmetic identity. The boundary
-records that this narrow theorem closes only the **arithmetic
-factorization + spinor-count match** half. The full substep-3
-closure of the open gate — i.e., the framework's specific
-`4`-taste reduction on its specific lattice substrate — remains
-open work. ∎
+That theorem is conditional on the action. Neither it nor the present note
+derives the action from the four framework axioms or identifies it as the
+realized physical charged-lepton matter carrier. Consequently the algebraic
+species-reduction step is established on the supplied action, while the
+framework physical-carrier selection remains a distinct realization
+obligation. ∎
 
 ## 6. What this note does NOT claim
 
@@ -235,16 +226,16 @@ open work. ∎
 - Does **not** force the framework's regulator to be naive or
   staggered. The cited upstream explicitly disclaims regulator
   independence; this narrow theorem inherits that disclaimer.
-- Does **not** derive the Kogut-Susskind staggered reduction or the
-  Kawamoto-Smit phase form. Those are downstream substep-2 substep-3
-  content carried by separate notes.
+- Does **not** derive the supplied free OS0 staggered action or its canonical
+  phase form from the four framework axioms. Conditional on that displayed
+  action, the cited blocking theorem does derive the Kogut-Susskind
+  four-taste module.
 - Does **not** identify the `2^{d/2} = 4` algebraic spinor-count with
   the framework's physical-spinor-content on its specific substrate.
   The match is at the level of the abstract algebraic factorization,
   not the framework's physical-spinor identification.
-- Does **not** make any physical / observational claim, consume any
-  PDG value, fitted constant, or admit any lattice convention beyond
-  the cited upstream narrow theorems and standard integer arithmetic.
+- Does **not** make an observational claim or consume a PDG value or fitted
+  constant. The supplied free OS0 staggered action is disclosed explicitly.
 - Does **not** assert that the three physical SM matter generations
   correspond to a specific subset of the `16` corner states. That
   identification is in substep 4 (the AC_φλ residual carried by the
@@ -260,29 +251,19 @@ open work. ∎
 - No same-surface family arguments.
 - No staggered-Dirac realization gate output consumed.
 - No `g_bare = 1` derivation output consumed.
-- No lattice-action carrier (Wilson plaquette, staggered phases,
-  per-site Hilbert-space-on-physical-lattice) load-bearing.
+- The explicitly displayed free OS0 staggered action is load-bearing and is
+  disclosed as the supplied-action premise of the bounded theorem.
 - No new foundational premise beyond the baseline physical Cl(3) local
   algebra on the Z^3 spatial substrate.
 
-## 8. Open derivation gap
+## 8. Remaining derivation gap
 
-The step from "abstract arithmetic factorization `16 = 4 · 4` plus
-spinor-dim match `2 + 2 = 4`" (R2-R3) to "the framework's specific
-staggered-Dirac realization implements the Kogut-Susskind `4`-taste
-reduction with the spinor-count factor identified with the Cl(3,0)
-chirality pair" is **not** in scope of this note. That step
-requires (a) selection of the specific framework lattice substrate
-and dimension, (b) selection of the specific regulator (staggered
-over naive / Wilson / overlap / etc.), and (c) the substep-2
-Kawamoto-Smit phase-form forcing argument. None of (a)-(c) is
-closed here.
-
-Closing the gap is the open work of the parent realization gate's
-substep 3, with substep-2 (Kawamoto-Smit forcing) as a load-bearing
-input. This narrow theorem closes only the arithmetic-factorization
-+ spinor-count-match content within the abstract upstream narrow
-theorems, and explicitly records the boundary.
+The supplied-action theorem derives the Kogut-Susskind four-taste module and
+therefore repairs the prior action-level algebra gap. It does not derive the
+free OS0 staggered action from Lattice, Qubit, Admissibility, and Record, or
+show that this action is the framework's realized charged-lepton matter
+carrier. That physical-carrier identification remains the realization
+obligation upstream of charged-lepton use.
 
 ## 9. Validation
 
@@ -309,30 +290,25 @@ verifies via sympy exact symbolic arithmetic:
 5. **(R4) Hamming-weight count on `{0, π}^4`.** The Hamming-weight
    distribution `binom(4, k)` for `k = 0..4` is `(1, 4, 6, 4, 1)`,
    summing to `16`. Verified by exhaustive corner enumeration.
-6. **(R4) Taste-count not forced by Cl(3) algebra.** The taste-count
-   factor `N_taste = 4` is recorded as a lattice-block fact (Hamming-
-   weight count) decoupled from the cited Cl(3) complexification
-   split dim. Verified by structural enumeration.
-7. **(R5) Regulator-dependence disclosure.** The `2^d = 16` naive
-   count is recorded alongside the Wilson `1`-fermion count, the
-   staggered-`d=4` `4`-taste count, and overlap/domain-wall
-   `1`-fermion counts as **different** regulator counts. The
-   arithmetic identity `16 = 4 · 4` does **not** force any specific
-   regulator on the framework.
-8. **(R5) Counterfactual: at `d = 6`, `2^6 = 64 = 8 · 8`.** The same
-   arithmetic factorization `2^d = 2^{d/2} · 2^{d/2}` holds at any
-   even `d`; at `d = 6`, `N_spinor = N_taste = 8`. This confirms the
-   `d = 4` factorization is not specific to a `(4, 4)` choice; it is
-   the generic even-`d` algebraic identity.
+6. **(R4) Action-level taste multiplicity.** The companion constructs the
+   canonical eta-weighted flip matrices, verifies the exact Clifford
+   relations, proves rank 16 for their word span, and checks character
+   `(16,0,...,0)`, giving four irreducible spin modules.
+7. **(R5) Supplied-action boundary.** Source pins verify that the action is
+   disclosed as a premise and that no framework physical-carrier selection is
+   claimed.
+8. **Arithmetic counterfactual.** At `d=6`, the identity becomes
+   `64=8*8`, confirming that arithmetic alone does not assign factor roles.
 
 Expected output: `PASS=N FAIL=0` with `N ≥ 12`.
 
 ## 10. Cross-references
 
-Load-bearing markdown-link upstream (two one-hop dependencies):
+Load-bearing markdown-link upstream (three one-hop dependencies):
 
 - [`NAIVE_LATTICE_FERMION_TWO_POWER_D_SPECIES_COUNT_NARROW_THEOREM_NOTE_2026-05-10.md`](NAIVE_LATTICE_FERMION_TWO_POWER_D_SPECIES_COUNT_NARROW_THEOREM_NOTE_2026-05-10.md)
 - [`CL3_COMPLEXIFICATION_SPLIT_NARROW_THEOREM_NOTE_2026-05-10.md`](CL3_COMPLEXIFICATION_SPLIT_NARROW_THEOREM_NOTE_2026-05-10.md)
+- [`STAGGERED_OS0_SUPPLIED_ACTION_KS_BLOCKING_FOUR_TASTE_MODULE_NARROW_THEOREM_NOTE_2026-07-11.md`](STAGGERED_OS0_SUPPLIED_ACTION_KS_BLOCKING_FOUR_TASTE_MODULE_NARROW_THEOREM_NOTE_2026-07-11.md)
 
 Plain-text (non-load-bearing) reader pointers; following the PR #306
 cleanup pattern, these are written without markdown links so the
@@ -346,24 +322,22 @@ edges:
   — pre-existing bounded-support packaging of the BZ corner
   Hamming-weight grading on `Z^3`.
 - `STAGGERED_DIRAC_KAWAMOTO_SMIT_FORCING_THEOREM_NOTE_2026-05-07.md`
-  — substep-2 note carrying the Kawamoto-Smit phase-form forcing
-  that would be needed to close substep-3 on the framework's
-  specific lattice substrate.
+  — substep-2 context for the canonical phase form.
 - `STAGGERED_DIRAC_PHYSICAL_SPECIES_DIRECT_THEOREM_NOTE_2026-05-07.md`
   — substep-4 note carrying the SM-matter-generation reading of the
   Hamming-weight triplet (out of scope here).
 - `CL3_FAITHFUL_IRREP_DIM_TWO_NARROW_THEOREM_NOTE_2026-05-10.md`
   — sister narrow theorem one hop downstream of the cited
   complexification split.
-- `MINIMAL_AXIOMS_2026-05-03.md`
+- `MINIMAL_AXIOMS_2026-06-29.md`
   — framework baseline memo for the physical Cl(3) local algebra and
   Z^3 spatial substrate; the narrow theorem does not consume its
   effective status.
 
 ## 11. Citation-graph note
 
-Load-bearing markdown-link upstream consists of exactly the two narrow
-sibling theorems listed in Section 3. Cross-references to the open
+Load-bearing markdown-link upstream consists of the three narrow
+theorems listed in Section 3. Cross-references to the open
 gate, substep-2/3/4 in-flight notes, the Cl(3) faithful-irrep
 sister narrow, and the minimal-axioms memo are plain-text reader
 pointers (not markdown links); the theorem does not consume their

--- a/docs/STAGGERED_DIRAC_SUBSTEP3_SPECIES_REDUCTION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-16.md
+++ b/docs/STAGGERED_DIRAC_SUBSTEP3_SPECIES_REDUCTION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-16.md
@@ -84,17 +84,17 @@ Hamming-weight-graded triplet `1 + 1 + 3 + 3 = 2^3` on `Z^3` (or the
 analogous structure on `Z^4` at `d = 4`), and whether the resulting
 species-count is forced to be the specific framework count.
 
-Two audited suppliers establish the naive count and the `Cl(3,0)` split.
+Two supplier theorems establish the naive count and the `Cl(3,0)` split.
 The supplied-action blocking theorem cited below now provides the missing
 action-level Kogut-Susskind module derivation. Ledger status for every row is
 set by the independent audit lane.
 
 - `NAIVE_LATTICE_FERMION_TWO_POWER_D_SPECIES_COUNT_NARROW_THEOREM_NOTE_2026-05-10.md`
-  (retained / audited_clean per the 2026-05-16 ledger) — provides
+  — provides
   the abstract `2^d` corner-cardinality readout for the naive lattice
   Dirac operator.
 - `CL3_COMPLEXIFICATION_SPLIT_NARROW_THEOREM_NOTE_2026-05-10.md`
-  (retained / audited_clean per the 2026-05-16 ledger) — provides
+  — provides
   the `Cl(3,0) ⊗_R C ≅ M_2(C) ⊕ M_2(C)` chirality-summand split,
   which gives the spinor-rep dim `2 + 2 = 4` matching the `d = 4`
   spinor-count factor.
@@ -220,9 +220,9 @@ obligation. ∎
 
 - Does **not** identify the framework's specific lattice substrate
   with `Z^4` or any other dimension-`d` lattice. The cited upstream
-  naive lattice theorem is regulator-independent and substrate-
-  independent on its own terms; this narrow theorem records only the
-  `d = 4` instance to exhibit the `16 = 4 · 4` factorization.
+  theorem concerns the naive lattice operator on its stated comparison
+  surface; this narrow theorem records only the `d = 4` instance to
+  exhibit the `16 = 4 · 4` factorization.
 - Does **not** force the framework's regulator to be naive or
   staggered. The cited upstream explicitly disclaims regulator
   independence; this narrow theorem inherits that disclaimer.

--- a/docs/STAGGERED_OS0_SUPPLIED_ACTION_KS_BLOCKING_FOUR_TASTE_MODULE_NARROW_THEOREM_NOTE_2026-07-11.md
+++ b/docs/STAGGERED_OS0_SUPPLIED_ACTION_KS_BLOCKING_FOUR_TASTE_MODULE_NARROW_THEOREM_NOTE_2026-07-11.md
@@ -1,0 +1,194 @@
+# Supplied OS0 Staggered Action: KS Blocking and Four-Taste Module Narrow Theorem
+
+**Date:** 2026-07-11
+**Claim type:** bounded_theorem
+**Status authority:** independent audit lane. This source proposal does not
+set or predict an audit verdict.
+**Primary runner:**
+[`scripts/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.py`](../scripts/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.py)
+**Cached runner output:**
+[`logs/runner-cache/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.txt`](../logs/runner-cache/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.txt)
+
+## Claim
+
+Supply the one-component free Kogut-Susskind action on the OS0
+`Z^3 x Z_tau` kinetic block,
+
+```text
+S = sum_n chi_bar(n) [m chi(n)
+    + (1/(2a)) sum_mu eta_mu(n)
+      (chi(n+e_mu)-chi(n-e_mu))],
+
+eta_mu(n)=(-1)^(sum_{nu<mu} n_nu),   mu=0,1,2,3.
+```
+
+For this supplied action, the block decomposition `n=2y+b`,
+`b in {0,1}^4`, and a momentum-local rephasing derive the exact reduced
+operator
+
+```text
+D_red(p) = m I_16 + i sum_mu alpha_mu sin(p_mu a)/a,
+(alpha_mu)_(b xor e_mu,b) = eta_mu(b).
+```
+
+The four matrices `alpha_mu` furnish a 16-dimensional complex module for
+`Cl_4(C) = M_4(C)`. Their character is four times the character of the
+unique 4-dimensional irreducible module. Therefore the blocked carrier is
+the direct sum of four Dirac-spin modules,
+
+```text
+C^16 = C^4_spin tensor C^4_taste,
+alpha_mu = gamma_mu tensor I_4,
+N_taste = 4,
+```
+
+after a choice of module isomorphism. The multiplicity four follows from the
+action and its canonical phases; it is not inferred from the integer identity
+`16=4*4` or from Hamming-weight enumeration by itself.
+
+## Supplied-action boundary
+
+The action displayed above is the premise of this bounded theorem. The theorem
+does not derive that action from Lattice, Qubit, Admissibility, and Record, and
+does not identify it as the realized charged-lepton matter carrier. It derives
+the Kogut-Susskind blocking and module multiplicity once that action is
+supplied. It supplies no generation identification, occupancy/readout rule,
+value of `r`, phase `delta`, mass, coupling, probability rule, or outcome
+dictionary.
+
+This boundary is load-bearing. The theorem repairs an algebraic supplier gap
+in the species-reduction row; it does not discharge the physical-carrier or
+charged-lepton occupancy-grain questions.
+
+## Exact derivation
+
+### Blocked finite difference
+
+Write `n=2y+b` with `b in {0,1}^4`, and Fourier transform the coarse cell
+coordinate `y`. Set
+
+```text
+t_mu = exp(i p_mu a),   K_mu = 2 p_mu a.
+```
+
+For a fixed direction `mu`, the blocked finite-difference matrix has one
+nonzero entry in row `b`, column `b xor e_mu`. Its coefficient is
+
+```text
+eta_mu(b) (1-t_mu^(-2))/(2a),  b_mu=0,
+eta_mu(b) (t_mu^2-1)/(2a),     b_mu=1.
+```
+
+Let `P_b=product_mu t_mu^(b_mu)`. In both cases,
+
+```text
+(P^(-1) D_mu P)_(b,b xor e_mu)
+  = eta_mu(b) (t_mu-t_mu^(-1))/(2a)
+  = i eta_mu(b) sin(p_mu a)/a.
+```
+
+Summing the four directions and the mass term gives the displayed
+`D_red(p)` exactly. No small-`a` expansion is used.
+
+### Clifford relations
+
+For every block label `b`, `alpha_mu` flips bit `b_mu` with sign
+`eta_mu(b)`. Flipping the same bit twice gives `alpha_mu^2=I_16`.
+For `mu<nu`, flipping `b_mu` changes the exponent in `eta_nu` once, while
+flipping `b_nu` does not change the exponent in `eta_mu`. Hence
+
+```text
+alpha_mu alpha_nu = - alpha_nu alpha_mu,
+{alpha_mu,alpha_nu}=2 delta_(mu nu) I_16.
+```
+
+Thus the action supplies a representation of `Cl_4(C)` on the 16 blocked
+components.
+
+### Four-module multiplicity
+
+The 16 ordered Clifford words
+
+```text
+alpha_0^(epsilon_0) ... alpha_3^(epsilon_3),
+epsilon_mu in {0,1},
+```
+
+are linearly independent, so the represented algebra has complex dimension
+16. Their traces are
+
+```text
+Tr(I_16)=16,
+Tr(alpha_0^(epsilon_0)...alpha_3^(epsilon_3))=0
+for nonzero epsilon.
+```
+
+Complex Clifford classification gives `Cl_4(C)=M_4(C)`, with a unique
+irreducible module of complex dimension four. A 16-dimensional module is
+therefore four copies of that irrep. The trace character confirms the
+multiplicity: it is four times the irreducible character. Equivalently, the
+commutant is `M_4(C)`, the taste factor.
+
+The same Clifford relations give
+
+```text
+(sum_mu s_mu alpha_mu)^2 = (sum_mu s_mu^2) I_16,
+
+[m I_16+i sum_mu s_mu alpha_mu]^(-1)
+  = [m I_16-i sum_mu s_mu alpha_mu]
+    /(m^2+sum_mu s_mu^2),
+
+s_mu=sin(p_mu a)/a.
+```
+
+The spectrum consequently consists of four identical Dirac-spin spectra.
+
+## Relation to Hamming-weight enumeration
+
+The block labels have multiplicities `(1,4,6,4,1)` by Hamming weight and sum
+to 16. That enumeration establishes the blocked-component count and grading.
+The multiplicity `N_taste=4` is established separately by the Clifford-module
+decomposition above. This distinction prevents the arithmetic factorization
+`16=4*4` from being used as a surrogate for the action-level taste derivation.
+
+## Inputs and non-import statement
+
+The load-bearing physical input is the explicitly supplied one-component free
+OS0 staggered action and its displayed canonical phases. Mathematical
+infrastructure consists of finite-dimensional complex linear algebra,
+Laurent-polynomial identities, and the standard complex Clifford-algebra
+classification `Cl_4(C)=M_4(C)`.
+
+No observational number, fitted selector, external numerical comparator,
+physical-species identification, charged-lepton readout rule, or additional
+framework axiom or primitive is used.
+
+## Validation
+
+The exact SymPy runner checks:
+
+1. the 16 block labels and their Hamming-weight multiplicities;
+2. each Laurent-polynomial rephasing identity in four directions;
+3. the full blocked operator identity;
+4. the exact Clifford anticommutators;
+5. exact rank 16 for the Clifford-word span;
+6. the character `(16,0,...,0)`;
+7. fourfold irreducible-module multiplicity; and
+8. the exact scalar-denominator inverse.
+
+Expected result: `TOTAL: PASS=15, FAIL=0`.
+
+## Dependency and downstream routing
+
+This derivation is self-contained conditional on the displayed action; it
+consumes no source-note effective status. The following are plain-text routing
+pointers rather than load-bearing citation edges:
+
+- `STAGGERED_DIRAC_SUBSTEP3_SPECIES_REDUCTION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-16.md`
+  should cite this theorem when separating Hamming enumeration from the
+  action-derived taste multiplicity.
+- `LORENTZ_BOOST_FREE_STAGGERED_FERMION_2POINT_SO4_NARROW_THEOREM_NOTE_2026-05-29.md`
+  contains a broader numerical implementation of the same blocked-action
+  algebra as part of a continuum two-point-function packet.
+- `STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md` retains the separate
+  physical-carrier identification question.

--- a/docs/STAGGERED_OS0_SUPPLIED_ACTION_KS_BLOCKING_FOUR_TASTE_MODULE_NARROW_THEOREM_NOTE_2026-07-11.md
+++ b/docs/STAGGERED_OS0_SUPPLIED_ACTION_KS_BLOCKING_FOUR_TASTE_MODULE_NARROW_THEOREM_NOTE_2026-07-11.md
@@ -138,8 +138,12 @@ The same Clifford relations give
   = [m I_16-i sum_mu s_mu alpha_mu]
     /(m^2+sum_mu s_mu^2),
 
-s_mu=sin(p_mu a)/a.
+s_mu=sin(p_mu a)/a,
+m^2+sum_mu s_mu^2 != 0.
 ```
+
+At the excluded point `m=0` and `s_mu=0` for every `mu`, the operator is
+zero and has no inverse.
 
 The spectrum consequently consists of four identical Dirac-spin spectra.
 
@@ -174,9 +178,11 @@ The exact SymPy runner checks:
 5. exact rank 16 for the Clifford-word span;
 6. the character `(16,0,...,0)`;
 7. fourfold irreducible-module multiplicity; and
-8. the exact scalar-denominator inverse.
+8. the exact scalar-denominator numerator identity and inverse on its declared
+   nonzero-denominator domain; and
+9. exclusion of the singular point `m=s_0=s_1=s_2=s_3=0`.
 
-Expected result: `TOTAL: PASS=15, FAIL=0`.
+Expected result: `TOTAL: PASS=17, FAIL=0`.
 
 ## Dependency and downstream routing
 

--- a/logs/runner-cache/audit_companion_staggered_dirac_substep3_species_reduction_bridge_2026_05_16.txt
+++ b/logs/runner-cache/audit_companion_staggered_dirac_substep3_species_reduction_bridge_2026_05_16.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/audit_companion_staggered_dirac_substep3_species_reduction_bridge_2026_05_16.py
-runner_sha256: 46a705a8dab78b873861e997a54cd1bd1cf6849017bbd8c1d38ba01e06014a6c
+runner_sha256: 74be305caed298a8c634c2ffa10cfc1e6bdd817d3e01500099f788544b76138c
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.55
+elapsed_sec: 0.41
 status: ok
 ----- stdout -----
 ========================================================================================
@@ -24,7 +24,7 @@ Part 1: (R1) d = 4 corner cardinality = 16 (cited upstream)
 Part 2: (R2) arithmetic factorization 16 = 4 * 4 = 2^2 * 2^2
 ----------------------------------------------------------------------------------------
   [PASS (A)] (R2) 16 = 4 * 4 (integer arithmetic)
-  [PASS (A)] (R2) 4 = 2^(d/2) at d = 4 (taste-count factor)  (2^(d/2) = 4)
+  [PASS (A)] (R2) each arithmetic factor is 4 = 2^(d/2) at d = 4  (2^(d/2) = 4)
   [PASS (A)] (R2) factorization 2^d = 2^(d/2) * 2^(d/2) at d = 4
 
 ----------------------------------------------------------------------------------------
@@ -49,16 +49,20 @@ Part 5: (R4) Hamming-weight count on {0, π}^4
   [PASS (A)] (R4) Hamming-weight counts sum to 2^d = 16  (sum binom(4, k) = 16)
 
 ----------------------------------------------------------------------------------------
-Part 6: (R4) Taste-count factor decoupled from Cl(3) algebra
+Part 6: (R4) supplied-action Clifford module gives four tastes
 ----------------------------------------------------------------------------------------
-  [PASS (A)] (R4) Cl(3) chirality-pair sum 2+2=4 matches N_spinor (not N_taste)  (chirality sum = 4; N_taste = N_spinor = 4)
-  [PASS (A)] (R4) taste-count factor is the lattice-block Hamming-weight count = 4
+  [PASS (A)] (R4) Cl(3) chirality-pair sum 2+2=4 matches the spin-module dimension  (chirality sum = 4)
+  [PASS (A)] (R4) canonical eta flip matrices satisfy the exact Cl_4 relations
+  [PASS (A)] (R4) Clifford-word span has exact dimension 16  (rank=16)
+  [PASS (A)] (R4) blocked-module character is four times the 4-spinor character  (character=(16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+  [PASS (A)] (R4) 16-dimensional Cl_4(C)=M_4(C) module has multiplicity four
 
 ----------------------------------------------------------------------------------------
-Part 7: (R5) Regulator dependence disclosure
+Part 7: (R5) supplied-action scope pins
 ----------------------------------------------------------------------------------------
-  [PASS (A)] (R5) naive count 16 is distinct from staggered/wilson/overlap/DW counts  (counts = {'naive': 16, 'wilson': 1, 'staggered': 4, 'domain_wall': 1, 'overlap': 1})
-  [PASS (A)] (R5) arithmetic 16 = 4 * 4 does NOT force any specific regulator
+  [PASS (C)] (R5) target cites the supplied-action blocking theorem
+  [PASS (C)] (R5) supplier disclaims framework physical-carrier identification
+  [PASS (C)] (R5) target records physical-carrier selection as a separate obligation
 
 ----------------------------------------------------------------------------------------
 Part 8: (R5) Counterfactual at d = 6 (factorization generalizes)
@@ -76,12 +80,12 @@ Summary
     (R3) Cl(3,0) ⊗_R C chirality-pair dim (2, 2), sum = 4
     (R3) match to N_spinor = 2^(d/2) = 4 at d = 4
     (R4) Hamming-weight distribution = binom(4, k) summing to 16
-    (R4) taste-count factor 4 is lattice-block fact, not Cl(3) algebra fact
-    (R5) regulator-dependence disclosed: naive 16 != staggered 4, etc.
+    (R4) supplied-action Cl_4 module is four copies of the spin irrep
+    (R5) supplied-action and physical-carrier scopes are separated
     (R5) factorization generalizes to even d (d = 6 gives 8 * 8)
 
 ========================================================================================
-TOTAL: PASS=22, FAIL=0
+TOTAL: PASS=26, FAIL=0
 ========================================================================================
 
 ----- stderr -----

--- a/logs/runner-cache/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.txt
+++ b/logs/runner-cache/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.txt
@@ -1,0 +1,48 @@
+===== runner cache v1 =====
+runner: scripts/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.py
+runner_sha256: 33a5a791252dbb62cf9b1887cff27410ef028031ed7a0f069d488051296d6bea
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.66
+status: ok
+----- stdout -----
+========================================================================================
+Supplied-action KS blocking and four-taste module: exact companion
+========================================================================================
+
+Part 1: exact block carrier and canonical staggered phases
+----------------------------------------------------------
+  [PASS (A)] b in {0,1}^4 gives 16 blocked components
+  [PASS (A)] Hamming-weight multiplicities are (1,4,6,4,1)  (observed=(1, 4, 6, 4, 1))
+  [PASS (A)] canonical eta signs depend on preceding block bits
+
+Part 2: exact Laurent-polynomial blocking identity
+--------------------------------------------------
+  [PASS (A)] rephasing turns every blocked direction into alpha_mu (t_mu-t_mu^-1)/(2a)  (directions=[True, True, True, True])
+  [PASS (A)] the full blocked operator has the exact reduced Laurent-polynomial form
+  [PASS (A)] on t_mu=exp(i p_mu a), the Laurent coefficient is i sin(p_mu a)/a
+
+Part 3: exact Cl_4(C) representation
+------------------------------------
+  [PASS (A)] each alpha_mu is a real symmetric involution  (squares=[True, True, True, True])
+  [PASS (A)] distinct alpha generators anticommute  (pairs=[True, True, True, True, True, True])
+  [PASS (A)] the 16 Clifford words are linearly independent  (exact rank=16)
+  [PASS (A)] the block-module character is 16 on the identity and 0 on 15 nonidentity words  (character=(16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+
+Part 4: module multiplicity and inverse
+---------------------------------------
+  [PASS (A)] Cl_4(C)=M_4(C) gives four irreducible spin modules in the 16-component carrier  (16=4*4)
+  [PASS (A)] the exact character equals four times the irreducible Cl_4(C) character
+  [PASS (A)] the Clifford kinetic square is (sum_mu s_mu^2) I_16
+  [PASS (A)] the blocked operator has the exact scalar-denominator inverse identity
+
+Scope guard
+-----------
+  [PASS (C)] source note discloses the action premise and disclaims physical-carrier selection
+
+========================================================================================
+TOTAL: PASS=15, FAIL=0
+========================================================================================
+
+----- stderr -----
+

--- a/logs/runner-cache/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.txt
+++ b/logs/runner-cache/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.py
-runner_sha256: 33a5a791252dbb62cf9b1887cff27410ef028031ed7a0f069d488051296d6bea
+runner_sha256: 8fe31813c9ab93e38504a42abd824bb23116e0240f207aea77eeae740b2cf359
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.66
+elapsed_sec: 0.63
 status: ok
 ----- stdout -----
 ========================================================================================
@@ -34,14 +34,16 @@ Part 4: module multiplicity and inverse
   [PASS (A)] Cl_4(C)=M_4(C) gives four irreducible spin modules in the 16-component carrier  (16=4*4)
   [PASS (A)] the exact character equals four times the irreducible Cl_4(C) character
   [PASS (A)] the Clifford kinetic square is (sum_mu s_mu^2) I_16
-  [PASS (A)] the blocked operator has the exact scalar-denominator inverse identity
+  [PASS (A)] the blocked operator has the exact scalar-denominator numerator identity
+  [PASS (A)] the displayed inverse is exact on the declared nonzero-denominator domain
+  [PASS (A)] the zero-mass zero-momentum singular point is excluded from the inverse domain
 
 Scope guard
 -----------
   [PASS (C)] source note discloses the action premise and disclaims physical-carrier selection
 
 ========================================================================================
-TOTAL: PASS=15, FAIL=0
+TOTAL: PASS=17, FAIL=0
 ========================================================================================
 
 ----- stderr -----

--- a/scripts/audit_companion_staggered_dirac_substep3_species_reduction_bridge_2026_05_16.py
+++ b/scripts/audit_companion_staggered_dirac_substep3_species_reduction_bridge_2026_05_16.py
@@ -6,8 +6,9 @@ The narrow theorem's load-bearing content is the abstract arithmetic
 factorization 2^d = 2^(d/2) * 2^(d/2) at even d (with d = 4 giving
 16 = 4 * 4), and the explicit dimensional match between the spinor-
 count factor 2^(d/2) = 4 at d = 4 and the Cl(3,0) ⊗_R C chirality-
-pair dim 2 + 2 = 4. The taste-count factor and the framework-specific
-Kogut-Susskind reduction are decoupled by an explicit boundary.
+pair dim 2 + 2 = 4. A separate supplied-action theorem now derives the
+Kogut-Susskind four-taste module from exact blocking and Clifford character
+data. Physical-carrier identification remains outside this row.
 
 Given the cited upstream narrow theorems
 
@@ -30,6 +31,7 @@ from __future__ import annotations
 
 from itertools import product
 import math
+from pathlib import Path
 import sys
 
 try:
@@ -57,14 +59,14 @@ PASS = 0
 FAIL = 0
 
 
-def check(label: str, ok: bool, detail: str = "") -> None:
+def check(label: str, ok: bool, detail: str = "", kind: str = "A") -> None:
     global PASS, FAIL
     if ok:
         PASS += 1
-        tag = "PASS (A)"
+        tag = f"PASS ({kind})"
     else:
         FAIL += 1
-        tag = "FAIL (A)"
+        tag = f"FAIL ({kind})"
     suffix = f"  ({detail})" if detail else ""
     print(f"  [{tag}] {label}{suffix}")
 
@@ -79,6 +81,33 @@ def section(title: str) -> None:
 def mat_eq(A: Matrix, B: Matrix) -> bool:
     diff = simplify(A - B)
     return all(diff[i, j] == 0 for i in range(diff.rows) for j in range(diff.cols))
+
+
+def block_bits(index: int) -> tuple[int, ...]:
+    return tuple((index >> mu) & 1 for mu in range(4))
+
+
+def block_index(bit_tuple: tuple[int, ...] | list[int]) -> int:
+    return sum((int(bit) & 1) << mu for mu, bit in enumerate(bit_tuple))
+
+
+def staggered_alpha(mu: int) -> Matrix:
+    matrix = zeros(16, 16)
+    for column in range(16):
+        bit_tuple = block_bits(column)
+        flipped = list(bit_tuple)
+        flipped[mu] ^= 1
+        sign = -1 if sum(bit_tuple[:mu]) % 2 else 1
+        matrix[block_index(flipped), column] = sign
+    return matrix
+
+
+def clifford_word(alphas: tuple[Matrix, ...], mask: int) -> Matrix:
+    word = eye(16)
+    for mu in range(4):
+        if mask & (1 << mu):
+            word *= alphas[mu]
+    return word
 
 
 def main() -> int:
@@ -127,7 +156,7 @@ def main() -> int:
         16 == 4 * 4,
     )
     check(
-        "(R2) 4 = 2^(d/2) at d = 4 (taste-count factor)",
+        "(R2) each arithmetic factor is 4 = 2^(d/2) at d = 4",
         4 == 2 ** (d // 2),
         detail=f"2^(d/2) = {2 ** (d // 2)}",
     )
@@ -229,45 +258,67 @@ def main() -> int:
     )
 
     # =========================================================================
-    section("Part 6: (R4) Taste-count factor decoupled from Cl(3) algebra")
+    section("Part 6: (R4) supplied-action Clifford module gives four tastes")
     # =========================================================================
-    # Taste count is a lattice-block fact (Hamming-weight count), not a
-    # Cl(3) algebra fact. The Cl(3) complexification split provides only
-    # the chirality pair (V_+, V_-) of complex dim (2, 2).
+    # Hamming enumeration supplies 16 blocked components.  The factor roles
+    # come from the canonical eta-weighted Clifford representation.
     cl3_chirality_pair_dim = (2, 2)
     cl3_chirality_pair_sum = sum(cl3_chirality_pair_dim)
-    taste_count_d4 = 2 ** (d // 2)
     check(
-        "(R4) Cl(3) chirality-pair sum 2+2=4 matches N_spinor (not N_taste)",
-        cl3_chirality_pair_sum == taste_count_d4,
-        detail=f"chirality sum = {cl3_chirality_pair_sum}; N_taste = N_spinor = {taste_count_d4}",
+        "(R4) Cl(3) chirality-pair sum 2+2=4 matches the spin-module dimension",
+        cl3_chirality_pair_sum == 4,
+        detail=f"chirality sum = {cl3_chirality_pair_sum}",
+    )
+
+    alphas = tuple(staggered_alpha(mu) for mu in range(4))
+    clifford_ok = True
+    for mu, A in enumerate(alphas):
+        for nu, B in enumerate(alphas):
+            target = 2 * eye(16) if mu == nu else zeros(16, 16)
+            clifford_ok = clifford_ok and mat_eq(A * B + B * A, target)
+    check(
+        "(R4) canonical eta flip matrices satisfy the exact Cl_4 relations",
+        clifford_ok,
+    )
+
+    words = tuple(clifford_word(alphas, mask) for mask in range(16))
+    flattened = Matrix.hstack(*[word.reshape(256, 1) for word in words])
+    traces = tuple(word.trace() for word in words)
+    check(
+        "(R4) Clifford-word span has exact dimension 16",
+        flattened.rank() == 16,
+        detail=f"rank={flattened.rank()}",
     )
     check(
-        "(R4) taste-count factor is the lattice-block Hamming-weight count = 4",
-        taste_count_d4 == 2 ** (d // 2),
+        "(R4) blocked-module character is four times the 4-spinor character",
+        traces[0] == 16 and all(value == 0 for value in traces[1:]),
+        detail=f"character={traces}",
+    )
+    check(
+        "(R4) 16-dimensional Cl_4(C)=M_4(C) module has multiplicity four",
+        16 == 4 * 4,
     )
 
     # =========================================================================
-    section("Part 7: (R5) Regulator dependence disclosure")
+    section("Part 7: (R5) supplied-action scope pins")
     # =========================================================================
-    regulator_counts_d4 = {
-        "naive": 16,           # cited upstream T1 (2^d)
-        "wilson": 1,           # standard SLAC/Wilson lift to 1 physical
-        "staggered": 4,        # Kogut-Susskind 4-taste at d=4
-        "domain_wall": 1,
-        "overlap": 1,
-    }
+    repo = Path(__file__).resolve().parents[1]
+    target_note = (repo / "docs/STAGGERED_DIRAC_SUBSTEP3_SPECIES_REDUCTION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-16.md").read_text()
+    supplier_note = (repo / "docs/STAGGERED_OS0_SUPPLIED_ACTION_KS_BLOCKING_FOUR_TASTE_MODULE_NARROW_THEOREM_NOTE_2026-07-11.md").read_text()
     check(
-        "(R5) naive count 16 is distinct from staggered/wilson/overlap/DW counts",
-        regulator_counts_d4["naive"] != regulator_counts_d4["staggered"]
-        and regulator_counts_d4["naive"] != regulator_counts_d4["wilson"]
-        and regulator_counts_d4["naive"] != regulator_counts_d4["overlap"]
-        and regulator_counts_d4["naive"] != regulator_counts_d4["domain_wall"],
-        detail=f"counts = {regulator_counts_d4}",
+        "(R5) target cites the supplied-action blocking theorem",
+        "STAGGERED_OS0_SUPPLIED_ACTION_KS_BLOCKING_FOUR_TASTE_MODULE_NARROW_THEOREM_NOTE_2026-07-11.md" in target_note,
+        kind="C",
     )
     check(
-        "(R5) arithmetic 16 = 4 * 4 does NOT force any specific regulator",
-        len(set(regulator_counts_d4.values())) > 1,
+        "(R5) supplier disclaims framework physical-carrier identification",
+        "does not identify it as the realized charged-lepton matter carrier" in supplier_note,
+        kind="C",
+    )
+    check(
+        "(R5) target records physical-carrier selection as a separate obligation",
+        "physical-carrier selection remains a distinct realization" in target_note,
+        kind="C",
     )
 
     # =========================================================================
@@ -300,8 +351,8 @@ def main() -> int:
     print("    (R3) Cl(3,0) ⊗_R C chirality-pair dim (2, 2), sum = 4")
     print("    (R3) match to N_spinor = 2^(d/2) = 4 at d = 4")
     print("    (R4) Hamming-weight distribution = binom(4, k) summing to 16")
-    print("    (R4) taste-count factor 4 is lattice-block fact, not Cl(3) algebra fact")
-    print("    (R5) regulator-dependence disclosed: naive 16 != staggered 4, etc.")
+    print("    (R4) supplied-action Cl_4 module is four copies of the spin irrep")
+    print("    (R5) supplied-action and physical-carrier scopes are separated")
     print("    (R5) factorization generalizes to even d (d = 6 gives 8 * 8)")
 
     print()

--- a/scripts/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.py
+++ b/scripts/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.py
@@ -239,8 +239,19 @@ def main() -> int:
     operator = m * identity + sp.I * kinetic
     numerator = m * identity - sp.I * kinetic
     check(
-        "the blocked operator has the exact scalar-denominator inverse identity",
+        "the blocked operator has the exact scalar-denominator numerator identity",
         matrix_is_zero(operator * numerator - denominator * identity),
+    )
+    inverse_on_domain = numerator / denominator
+    check(
+        "the displayed inverse is exact on the declared nonzero-denominator domain",
+        matrix_is_zero(operator * inverse_on_domain - identity),
+    )
+    singular_substitution = {m: 0, **{value: 0 for value in s_symbols}}
+    check(
+        "the zero-mass zero-momentum singular point is excluded from the inverse domain",
+        denominator.subs(singular_substitution) == 0
+        and operator.subs(singular_substitution) == sp.zeros(16),
     )
 
     section("Scope guard")

--- a/scripts/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.py
+++ b/scripts/frontier_staggered_os0_supplied_action_ks_blocking_four_taste_module_2026_07_11.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Exact companion for the supplied-action KS blocking theorem.
+
+Starting from the explicitly supplied one-component free OS0 staggered action
+in four Euclidean directions, this runner verifies at exact symbolic precision:
+
+* the block decomposition n = 2y + b with b in {0,1}^4;
+* the momentum-local rephasing of the blocked finite difference;
+* the resulting four Clifford generators on the 16-component block carrier;
+* the character and rank that identify four copies of the unique 4-dimensional
+  irreducible Cl_4(C) module.
+
+The runner analyzes the supplied action.  It does not identify that action as
+the framework's physical charged-lepton carrier.
+"""
+
+from __future__ import annotations
+
+from itertools import product
+from pathlib import Path
+import sys
+
+try:
+    import sympy as sp
+except ImportError:
+    print("FAIL: sympy is required for exact algebra")
+    raise SystemExit(1)
+
+
+PASS = 0
+FAIL = 0
+
+
+def check(label: str, condition: bool, detail: str = "", kind: str = "A") -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        mark = f"PASS ({kind})"
+    else:
+        FAIL += 1
+        mark = f"FAIL ({kind})"
+    suffix = f"  ({detail})" if detail else ""
+    print(f"  [{mark}] {label}{suffix}")
+
+
+def section(label: str) -> None:
+    print()
+    print(label)
+    print("-" * len(label))
+
+
+def bits(index: int) -> tuple[int, ...]:
+    return tuple((index >> mu) & 1 for mu in range(4))
+
+
+def index(bit_tuple: tuple[int, ...] | list[int]) -> int:
+    return sum((int(bit) & 1) << mu for mu, bit in enumerate(bit_tuple))
+
+
+BLOCK_BITS = tuple(bits(i) for i in range(16))
+
+
+def eta(mu: int, bit_tuple: tuple[int, ...]) -> int:
+    return -1 if sum(bit_tuple[:mu]) % 2 else 1
+
+
+def alpha(mu: int) -> sp.Matrix:
+    matrix = sp.zeros(16)
+    for column, bit_tuple in enumerate(BLOCK_BITS):
+        flipped = list(bit_tuple)
+        flipped[mu] ^= 1
+        matrix[index(flipped), column] = eta(mu, bit_tuple)
+    return matrix
+
+
+ALPHAS = tuple(alpha(mu) for mu in range(4))
+
+
+def raw_blocked_direction(mu: int, t: sp.Symbol, a: sp.Symbol) -> sp.Matrix:
+    """Blocked one-direction difference before rephasing.
+
+    t = exp(i p_mu a), so a coarse-cell boundary hop carries t^(+/-2).
+    Rows are output block labels b and columns are input labels b xor e_mu.
+    """
+    matrix = sp.zeros(16)
+    for row, bit_tuple in enumerate(BLOCK_BITS):
+        flipped = list(bit_tuple)
+        flipped[mu] ^= 1
+        column = index(flipped)
+        sign = eta(mu, bit_tuple)
+        if bit_tuple[mu] == 0:
+            coefficient = sign * (1 - t**-2) / (2 * a)
+        else:
+            coefficient = sign * (t**2 - 1) / (2 * a)
+        matrix[row, column] = coefficient
+    return matrix
+
+
+def rephasing(t_symbols: tuple[sp.Symbol, ...]) -> sp.Matrix:
+    diagonal = []
+    for bit_tuple in BLOCK_BITS:
+        phase = sp.Integer(1)
+        for mu, bit in enumerate(bit_tuple):
+            phase *= t_symbols[mu] ** bit
+        diagonal.append(phase)
+    return sp.diag(*diagonal)
+
+
+def clifford_word(mask: int) -> sp.Matrix:
+    word = sp.eye(16)
+    for mu in range(4):
+        if mask & (1 << mu):
+            word *= ALPHAS[mu]
+    return word
+
+
+def matrix_is_zero(matrix: sp.Matrix) -> bool:
+    return all(sp.simplify(entry) == 0 for entry in matrix)
+
+
+def main() -> int:
+    print("=" * 88)
+    print("Supplied-action KS blocking and four-taste module: exact companion")
+    print("=" * 88)
+
+    section("Part 1: exact block carrier and canonical staggered phases")
+    check(
+        "b in {0,1}^4 gives 16 blocked components",
+        len(BLOCK_BITS) == 16 and len(set(BLOCK_BITS)) == 16,
+    )
+    expected_counts = (1, 4, 6, 4, 1)
+    observed_counts = tuple(
+        sum(1 for bit_tuple in BLOCK_BITS if sum(bit_tuple) == weight)
+        for weight in range(5)
+    )
+    check(
+        "Hamming-weight multiplicities are (1,4,6,4,1)",
+        observed_counts == expected_counts,
+        detail=f"observed={observed_counts}",
+    )
+    check(
+        "canonical eta signs depend on preceding block bits",
+        all(eta(mu, bit_tuple) == (-1) ** sum(bit_tuple[:mu])
+            for mu in range(4) for bit_tuple in BLOCK_BITS),
+    )
+
+    section("Part 2: exact Laurent-polynomial blocking identity")
+    a = sp.symbols("a", nonzero=True)
+    t_symbols = sp.symbols("t0:4", nonzero=True)
+    phase = rephasing(t_symbols)
+    phase_inverse = sp.diag(*[entry**-1 for entry in phase.diagonal()])
+    direction_residuals = []
+    for mu in range(4):
+        raw = raw_blocked_direction(mu, t_symbols[mu], a)
+        reduced = phase_inverse * raw * phase
+        expected = ((t_symbols[mu] - t_symbols[mu]**-1) / (2 * a)) * ALPHAS[mu]
+        direction_residuals.append(matrix_is_zero(reduced - expected))
+    check(
+        "rephasing turns every blocked direction into alpha_mu (t_mu-t_mu^-1)/(2a)",
+        all(direction_residuals),
+        detail=f"directions={direction_residuals}",
+    )
+
+    m = sp.symbols("m")
+    raw_full = m * sp.eye(16)
+    expected_full = m * sp.eye(16)
+    for mu in range(4):
+        raw_full += raw_blocked_direction(mu, t_symbols[mu], a)
+        expected_full += ((t_symbols[mu] - t_symbols[mu]**-1) / (2 * a)) * ALPHAS[mu]
+    check(
+        "the full blocked operator has the exact reduced Laurent-polynomial form",
+        matrix_is_zero(phase_inverse * raw_full * phase - expected_full),
+    )
+    check(
+        "on t_mu=exp(i p_mu a), the Laurent coefficient is i sin(p_mu a)/a",
+        sp.simplify((sp.exp(sp.I * sp.Symbol("x"))
+                     - sp.exp(-sp.I * sp.Symbol("x"))) / 2
+                    - sp.I * sp.sin(sp.Symbol("x"))) == 0,
+    )
+
+    section("Part 3: exact Cl_4(C) representation")
+    identity = sp.eye(16)
+    zero = sp.zeros(16)
+    square_checks = [matrix_is_zero(A * A - identity) for A in ALPHAS]
+    check(
+        "each alpha_mu is a real symmetric involution",
+        all(A == A.T for A in ALPHAS) and all(square_checks),
+        detail=f"squares={square_checks}",
+    )
+    anticomm_checks = []
+    for mu in range(4):
+        for nu in range(mu + 1, 4):
+            anticomm_checks.append(matrix_is_zero(ALPHAS[mu] * ALPHAS[nu]
+                                                   + ALPHAS[nu] * ALPHAS[mu]))
+    check(
+        "distinct alpha generators anticommute",
+        all(anticomm_checks),
+        detail=f"pairs={anticomm_checks}",
+    )
+
+    words = tuple(clifford_word(mask) for mask in range(16))
+    flattened = sp.Matrix.hstack(*[word.reshape(256, 1) for word in words])
+    word_rank = flattened.rank()
+    check(
+        "the 16 Clifford words are linearly independent",
+        word_rank == 16,
+        detail=f"exact rank={word_rank}",
+    )
+    traces = tuple(sp.trace(word) for word in words)
+    check(
+        "the block-module character is 16 on the identity and 0 on 15 nonidentity words",
+        traces[0] == 16 and all(value == 0 for value in traces[1:]),
+        detail=f"character={traces}",
+    )
+
+    section("Part 4: module multiplicity and inverse")
+    spin_dimension = 4
+    multiplicity = 16 // spin_dimension
+    check(
+        "Cl_4(C)=M_4(C) gives four irreducible spin modules in the 16-component carrier",
+        16 == spin_dimension * multiplicity and multiplicity == 4,
+        detail=f"16={spin_dimension}*{multiplicity}",
+    )
+    check(
+        "the exact character equals four times the irreducible Cl_4(C) character",
+        traces[0] == 4 * spin_dimension and all(value == 4 * 0 for value in traces[1:]),
+    )
+
+    s_symbols = sp.symbols("s0:4", real=True)
+    kinetic = sp.zeros(16)
+    for mu in range(4):
+        kinetic += s_symbols[mu] * ALPHAS[mu]
+    kinetic_square = sum(value**2 for value in s_symbols) * identity
+    check(
+        "the Clifford kinetic square is (sum_mu s_mu^2) I_16",
+        matrix_is_zero(kinetic * kinetic - kinetic_square),
+    )
+    denominator = m**2 + sum(value**2 for value in s_symbols)
+    operator = m * identity + sp.I * kinetic
+    numerator = m * identity - sp.I * kinetic
+    check(
+        "the blocked operator has the exact scalar-denominator inverse identity",
+        matrix_is_zero(operator * numerator - denominator * identity),
+    )
+
+    section("Scope guard")
+    note = (Path(__file__).resolve().parents[1]
+            / "docs/STAGGERED_OS0_SUPPLIED_ACTION_KS_BLOCKING_FOUR_TASTE_MODULE_NARROW_THEOREM_NOTE_2026-07-11.md").read_text()
+    check(
+        "source note discloses the action premise and disclaims physical-carrier selection",
+        "The action displayed above is the premise of this bounded theorem" in note
+        and "does not identify it as the realized charged-lepton matter carrier" in note,
+        kind="C",
+    )
+
+    print()
+    print("=" * 88)
+    print(f"TOTAL: PASS={PASS}, FAIL={FAIL}")
+    print("=" * 88)
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds an exact bounded theorem for Kogut-Susskind blocking on the explicitly supplied one-component free OS0 staggered action. The new SymPy runner proves the Laurent-polynomial blocking identity, exact Cl_4(C) relations, rank-16 Clifford algebra, character multiplicity four, and the scalar inverse on its declared nonzero-denominator domain. Revises the species-reduction consumer so Hamming weights provide the 16-component grading while the action-level Clifford module provides four tastes.\n\nThe physical-carrier selection remains explicit and out of scope; no audit verdict, axiom, primitive, comparator, generation identification, r value, or charged-lepton readout is added.\n\nExact independent-audit repair target:\n\n> missing_bridge_theorem — add a retained one-hop theorem deriving the Kogut-Susskind spin-diagonal blocking and four-taste count on the supplied OS0 matter carrier, revise R4 so Hamming-weight enumeration is not itself presented as the taste derivation, and rerun this row.\n\nVerification: new runner PASS=17 FAIL=0, including the singular-locus exclusion; repaired consumer PASS=26 FAIL=0; caches SHA-fresh; vocabulary lint clean; staged claim typing clean.