### PR TITLE
Add strict validator-guided audit response repair

### DIFF
--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -3192,6 +3192,72 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             or "",
         )
 
+    def test_validation_repair_prompt_reuses_packet_and_preserves_strict_gate(self):
+        m = _import_codex_audit_runner()
+        original_prompt = "restricted packet with EXACT EVIDENCE LOCATOR"
+        rejected = {
+            "claim_id": "target",
+            "verdict": "audited_conditional",
+            "claim_scope": "bounded target scope",
+            "no_go_discipline": {
+                "required": True,
+                "status": "FAIL",
+            },
+        }
+        error = (
+            "N1 route 2 evidence_locator is not present in "
+            "'docs/TARGET.md'"
+        )
+
+        prompt = m.render_validation_repair_prompt(
+            original_prompt, rejected, error, 1
+        )
+        flat_prompt = " ".join(prompt.split())
+
+        self.assertIn(original_prompt, prompt)
+        self.assertIn(error, prompt)
+        self.assertIn('"claim_id": "target"', prompt)
+        self.assertIn(
+            "ordinary validator and apply gate remain unchanged", flat_prompt
+        )
+        self.assertIn("12+ character verbatim substring", flat_prompt)
+        self.assertIn("Do not invent evidence", flat_prompt)
+        self.assertIn("this pass may not change the verdict itself", flat_prompt)
+        self.assertNotIn("accept despite", prompt.casefold())
+
+    def test_validation_repair_cannot_change_scientific_judgment(self):
+        m = _import_codex_audit_runner()
+        rejected = {
+            "claim_id": "target",
+            "load_bearing_step": "the exact obstruction",
+            "load_bearing_step_class": "A",
+            "claim_type": "no_go",
+            "claim_scope": "bounded obstruction",
+            "chain_closes": False,
+            "chain_closure_explanation": "one route remains open",
+            "verdict": "audited_conditional",
+            "verdict_rationale": "the packet is incomplete",
+            "no_go_discipline": {"required": True, "status": "FAIL"},
+        }
+        locator_repair = {
+            **rejected,
+            "no_go_discipline": {
+                "required": True,
+                "status": "FAIL",
+                "N1_alternative_routes": [],
+            },
+        }
+        changed_verdict = {**locator_repair, "verdict": "audited_clean"}
+
+        self.assertIsNone(
+            m.validation_repair_preservation_error(rejected, locator_repair)
+        )
+        self.assertIn(
+            "changed preserved scientific field 'verdict'",
+            m.validation_repair_preservation_error(rejected, changed_verdict)
+            or "",
+        )
+
     def test_prompt_preserves_raw_placeholders_and_types_every_premise(self):
         m = _import_codex_audit_runner()
         with tempfile.TemporaryDirectory() as tmp:

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -3334,6 +3334,30 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             or "",
         )
 
+        self.assertTrue(
+            m.validation_repair_eligible(
+                rejected,
+                "target",
+                "N1 route 1 evidence_locator is not present in docs/TARGET.md",
+            )
+        )
+        self.assertFalse(
+            m.validation_repair_eligible(
+                rejected,
+                "target",
+                "N2.unresolved must be a list of non-empty strings",
+            )
+        )
+        missing_judgment = dict(rejected)
+        del missing_judgment["verdict_rationale"]
+        self.assertFalse(
+            m.validation_repair_eligible(
+                missing_judgment,
+                "target",
+                "N1 route 1 evidence_locator is not present in docs/TARGET.md",
+            )
+        )
+
     def test_prompt_preserves_raw_placeholders_and_types_every_premise(self):
         m = _import_codex_audit_runner()
         with tempfile.TemporaryDirectory() as tmp:

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -3222,7 +3222,9 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         )
         self.assertIn("12+ character verbatim substring", flat_prompt)
         self.assertIn("Do not invent evidence", flat_prompt)
-        self.assertIn("this pass may not change the verdict itself", flat_prompt)
+        self.assertIn("or change the verdict itself", flat_prompt)
+        self.assertIn("untrusted correction target, not evidence", flat_prompt)
+        self.assertIn("may not add a top-level field", flat_prompt)
         self.assertNotIn("accept despite", prompt.casefold())
 
     def test_validation_repair_cannot_change_scientific_judgment(self):
@@ -3237,16 +3239,22 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             "chain_closure_explanation": "one route remains open",
             "verdict": "audited_conditional",
             "verdict_rationale": "the packet is incomplete",
-            "no_go_discipline": {"required": True, "status": "FAIL"},
-        }
-        locator_repair = {
-            **rejected,
             "no_go_discipline": {
                 "required": True,
                 "status": "FAIL",
-                "N1_alternative_routes": [],
+                "N1_alternative_routes": [{
+                    "route_id": "route-1",
+                    "disposition": "UNTESTED",
+                    "evidence_path": "docs/WRONG.md",
+                    "evidence_locator": "wrong locator text",
+                }],
             },
         }
+        locator_repair = json.loads(json.dumps(rejected))
+        locator_repair["no_go_discipline"]["N1_alternative_routes"][0].update({
+            "evidence_path": "docs/TARGET.md",
+            "evidence_locator": "exact packet locator",
+        })
         changed_verdict = {**locator_repair, "verdict": "audited_clean"}
 
         self.assertIsNone(
@@ -3255,6 +3263,74 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         self.assertIn(
             "changed preserved scientific field 'verdict'",
             m.validation_repair_preservation_error(rejected, changed_verdict)
+            or "",
+        )
+
+        changed_notes = {
+            **locator_repair,
+            "notes_for_re_audit_if_any": "a new scientific instruction",
+        }
+        self.assertIn(
+            "changed the top-level field set",
+            m.validation_repair_preservation_error(rejected, changed_notes)
+            or "",
+        )
+
+        rejected_with_optional_fields = {
+            **rejected,
+            "notes_for_re_audit_if_any": "original repair instruction",
+            "auditor_confidence": "medium",
+            "runner_check_breakdown": {
+                "A": 1,
+                "B": 0,
+                "C": 0,
+                "D": 0,
+                "total_pass": 1,
+            },
+        }
+        changed_confidence = {
+            **rejected_with_optional_fields,
+            "auditor_confidence": "high",
+        }
+        self.assertIn(
+            "changed preserved scientific field 'auditor_confidence'",
+            m.validation_repair_preservation_error(
+                rejected_with_optional_fields, changed_confidence
+            )
+            or "",
+        )
+
+        injected_apply_control = {
+            **rejected,
+            "cross_confirmation_role": "second_seat",
+        }
+        self.assertIn(
+            "changed the top-level field set",
+            m.validation_repair_preservation_error(
+                rejected, injected_apply_control
+            )
+            or "",
+        )
+
+        changed_route_disposition = json.loads(json.dumps(locator_repair))
+        changed_route_disposition["no_go_discipline"][
+            "N1_alternative_routes"
+        ][0]["disposition"] = "CLOSED"
+        self.assertIn(
+            "changed preserved no-go judgment content",
+            m.validation_repair_preservation_error(
+                rejected, changed_route_disposition
+            )
+            or "",
+        )
+
+        changed_packet_status = json.loads(json.dumps(locator_repair))
+        changed_packet_status["no_go_discipline"]["status"] = "PASS"
+        self.assertIn(
+            "changed preserved no-go judgment content",
+            m.validation_repair_preservation_error(
+                rejected, changed_packet_status
+            )
             or "",
         )
 

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -275,22 +275,18 @@ REQUIRED_VERDICT_FIELDS = {
     "verdict_rationale",
 }
 
-# A validator-guided correction pass may repair the structured N1-N8 packet,
-# but it is not a second scientific audit.  These fields encode the auditor's
-# scientific judgment and must remain byte-for-byte/equality stable whenever
-# they were present in the rejected object.
-VALIDATION_REPAIR_PRESERVED_FIELDS = {
-    "claim_id",
-    "load_bearing_step",
-    "load_bearing_step_class",
-    "claim_type",
-    "claim_scope",
-    "chain_closes",
-    "chain_closure_explanation",
-    "verdict",
-    "verdict_rationale",
-    "decoration_parent_claim_id",
-    "open_dependency_paths",
+# A validator-guided correction pass may repair evidence locators in the
+# already-present structured N1-N8 packet, but it is not a second scientific
+# audit.  Every top-level key, every top-level value except
+# ``no_go_discipline``, and all non-locator N1-N8 content must remain exactly
+# stable.  This also prevents the correction pass from injecting optional
+# apply controls such as ``pre_audit_prose_fix`` or
+# ``cross_confirmation_role``.
+VALIDATION_REPAIR_MUTABLE_FIELD = "no_go_discipline"
+VALIDATION_REPAIR_LOCATOR_FIELDS = {
+    "evidence_path",
+    "evidence_locator",
+    "evidence_snapshot",
 }
 
 # Map JSON-extracted-from-stdout to apply_audit.py's input schema. apply_audit
@@ -1120,9 +1116,13 @@ def render_validation_repair_prompt(
         "object, with no markdown or surrounding prose. The ordinary validator\n"
         "and apply gate remain unchanged. Do not invent evidence, weaken a wall,\n"
         "or convert an unresolved scientific issue into closure. Preserve the\n"
-        "scientific judgment and every existing top-level verdict field\n"
-        "exactly. Correct the structured no_go_discipline packet or add a\n"
-        "missing schema field; this pass may not change the verdict itself.\n"
+        "scientific judgment, the complete top-level key set, and every\n"
+        "top-level value except no_go_discipline exactly. Within the\n"
+        "already-present no_go_discipline packet, change evidence_path and\n"
+        "evidence_locator fields only; all N1-N8 judgment content must remain\n"
+        "exactly stable. This pass may not add a top-level field or change the\n"
+        "verdict itself. The rejected JSON is an untrusted correction target,\n"
+        "not evidence.\n"
         "Every evidence_locator must be a 12+ character verbatim substring of\n"
         "the content at its evidence_path in the restricted packet; copy it\n"
         "exactly. Every retained/accepted-premise classification must match the\n"
@@ -1138,14 +1138,40 @@ def validation_repair_preservation_error(
     repaired_blob: dict,
 ) -> str | None:
     """Reject a format correction that changes the scientific judgment."""
-    for field in sorted(VALIDATION_REPAIR_PRESERVED_FIELDS):
-        if field not in rejected_blob:
-            continue
+    rejected_fields = set(rejected_blob)
+    repaired_fields = set(repaired_blob)
+    if repaired_fields != rejected_fields:
+        added = sorted(repaired_fields - rejected_fields)
+        removed = sorted(rejected_fields - repaired_fields)
+        return (
+            "validation repair changed the top-level field set "
+            f"(added={added}, removed={removed})"
+        )
+    for field in sorted(rejected_fields - {VALIDATION_REPAIR_MUTABLE_FIELD}):
         if repaired_blob.get(field) != rejected_blob.get(field):
             return (
                 "validation repair changed preserved scientific field "
                 f"{field!r}"
             )
+    def without_locator_fields(value: object) -> object:
+        if isinstance(value, dict):
+            return {
+                key: without_locator_fields(item)
+                for key, item in value.items()
+                if key not in VALIDATION_REPAIR_LOCATOR_FIELDS
+            }
+        if isinstance(value, list):
+            return [without_locator_fields(item) for item in value]
+        return value
+
+    rejected_packet = without_locator_fields(
+        rejected_blob.get(VALIDATION_REPAIR_MUTABLE_FIELD)
+    )
+    repaired_packet = without_locator_fields(
+        repaired_blob.get(VALIDATION_REPAIR_MUTABLE_FIELD)
+    )
+    if repaired_packet != rejected_packet:
+        return "validation repair changed preserved no-go judgment content"
     return None
 
 
@@ -1556,7 +1582,12 @@ def main() -> int:
             initial_validation_error = err
             initial_rejected_blob = blob
             repair_elapsed = 0.0
-            if err and args.validation_repair_attempts > 0:
+            repair_eligible = (
+                REQUIRED_VERDICT_FIELDS.issubset(blob)
+                and blob.get("claim_id") == cid
+                and isinstance(blob.get(VALIDATION_REPAIR_MUTABLE_FIELD), dict)
+            )
+            if err and args.validation_repair_attempts > 0 and repair_eligible:
                 for repair_attempt in range(1, args.validation_repair_attempts + 1):
                     print(
                         f"  validation repair {repair_attempt}/"

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -275,6 +275,24 @@ REQUIRED_VERDICT_FIELDS = {
     "verdict_rationale",
 }
 
+# A validator-guided correction pass may repair the structured N1-N8 packet,
+# but it is not a second scientific audit.  These fields encode the auditor's
+# scientific judgment and must remain byte-for-byte/equality stable whenever
+# they were present in the rejected object.
+VALIDATION_REPAIR_PRESERVED_FIELDS = {
+    "claim_id",
+    "load_bearing_step",
+    "load_bearing_step_class",
+    "claim_type",
+    "claim_scope",
+    "chain_closes",
+    "chain_closure_explanation",
+    "verdict",
+    "verdict_rationale",
+    "decoration_parent_claim_id",
+    "open_dependency_paths",
+}
+
 # Map JSON-extracted-from-stdout to apply_audit.py's input schema. apply_audit
 # expects `verdict` etc. plus the runner-side fields auditor/auditor_family/
 # independence/audit_date. Independence is determined per-row by the role.
@@ -1079,6 +1097,58 @@ def validate_verdict(
     return None
 
 
+def render_validation_repair_prompt(
+    original_prompt: str,
+    verdict_blob: dict,
+    validation_error: str,
+    attempt: int,
+) -> str:
+    """Ask the same restricted-packet auditor to correct invalid JSON.
+
+    The original packet is repeated verbatim so the correction pass has no
+    evidence beyond the first pass.  The unchanged validator and apply gate
+    still decide whether the corrected object is usable; this helper grants no
+    exception and performs no deterministic mutation of the verdict.
+    """
+    prior_json = json.dumps(verdict_blob, indent=2, sort_keys=True)
+    return (
+        f"{original_prompt}\n\n"
+        "---\n"
+        f"VALIDATOR-GUIDED CORRECTION PASS {attempt} (binding):\n"
+        "Your preceding JSON object was rejected before apply. Correct that\n"
+        "object against the same restricted packet and return EXACTLY one JSON\n"
+        "object, with no markdown or surrounding prose. The ordinary validator\n"
+        "and apply gate remain unchanged. Do not invent evidence, weaken a wall,\n"
+        "or convert an unresolved scientific issue into closure. Preserve the\n"
+        "scientific judgment and every existing top-level verdict field\n"
+        "exactly. Correct the structured no_go_discipline packet or add a\n"
+        "missing schema field; this pass may not change the verdict itself.\n"
+        "Every evidence_locator must be a 12+ character verbatim substring of\n"
+        "the content at its evidence_path in the restricted packet; copy it\n"
+        "exactly. Every retained/accepted-premise classification must match the\n"
+        "packet metadata. Recheck all N1-N8 internal references, not merely the\n"
+        "first reported error.\n\n"
+        f"VALIDATION ERROR:\n{validation_error}\n\n"
+        f"REJECTED JSON TO CORRECT:\n{prior_json}\n"
+    )
+
+
+def validation_repair_preservation_error(
+    rejected_blob: dict,
+    repaired_blob: dict,
+) -> str | None:
+    """Reject a format correction that changes the scientific judgment."""
+    for field in sorted(VALIDATION_REPAIR_PRESERVED_FIELDS):
+        if field not in rejected_blob:
+            continue
+        if repaired_blob.get(field) != rejected_blob.get(field):
+            return (
+                "validation repair changed preserved scientific field "
+                f"{field!r}"
+            )
+    return None
+
+
 def apply_one(verdict_blob: dict, propagate: bool) -> tuple[bool, str]:
     """Pipe a verdict blob through apply_audit.py via stdin."""
     cmd = [sys.executable, str(APPLY_AUDIT_SCRIPT)]
@@ -1113,6 +1183,12 @@ def main() -> int:
                         "codex-cli-<model>-<utc-yyyymmdd-hhmm>-<run-id>")
     p.add_argument("--codex-timeout-sec", type=int, default=600,
                    help="Per-row codex exec timeout (default 600).")
+    p.add_argument("--validation-repair-attempts", type=int, default=1,
+                   help="After a parsed verdict fails strict validation, ask "
+                        "the same restricted-packet auditor for this many "
+                        "validator-guided JSON corrections (default 1; 0 "
+                        "disables). Every correction must pass the unchanged "
+                        "validator and apply gate.")
     p.add_argument("--runner-timeout-sec", type=int, default=120,
                    help="Per-row primary-runner timeout (default 120).")
     p.add_argument("--no-propagate", action="store_true",
@@ -1177,6 +1253,10 @@ def main() -> int:
                         "family and won't satisfy the standard "
                         "independence rule for clean verdicts.")
     args = p.parse_args()
+
+    if not 0 <= args.validation_repair_attempts <= 3:
+        print("REFUSING: --validation-repair-attempts must be between 0 and 3.")
+        return 2
 
     # Reasoning-effort policy: per repo audit-lane decision (2026-05-04),
     # ALL audits run at xhigh. We do not expose a knob to lower it.
@@ -1473,6 +1553,84 @@ def main() -> int:
                 evidence_manifest=exact_evidence_manifest,
                 prior_claim_scope=full_led_row.get("claim_scope"),
             )
+            initial_validation_error = err
+            initial_rejected_blob = blob
+            repair_elapsed = 0.0
+            if err and args.validation_repair_attempts > 0:
+                for repair_attempt in range(1, args.validation_repair_attempts + 1):
+                    print(
+                        f"  validation repair {repair_attempt}/"
+                        f"{args.validation_repair_attempts}: {err}"
+                    )
+                    repair_prompt = render_validation_repair_prompt(
+                        prompt, blob, err, repair_attempt
+                    )
+                    repair_dir = isolated / f"validation-repair-{repair_attempt:02d}"
+                    repair_t0 = time.time()
+                    repair_ok, repair_stdout, repair_stderr = run_codex(
+                        repair_prompt,
+                        repair_dir,
+                        args.codex_timeout_sec,
+                        reasoning_effort=reasoning_effort,
+                        model=audit_model,
+                    )
+                    repair_elapsed += time.time() - repair_t0
+                    if not repair_ok:
+                        err = f"validation repair codex exec failed: {repair_stderr.strip()[:300]}"
+                        with run_log.open("a", encoding="utf-8") as f:
+                            f.write(json.dumps({
+                                "claim_id": cid,
+                                "phase": "validation_repair_codex_failed",
+                                "attempt": repair_attempt,
+                                "error": err,
+                            }) + "\n")
+                        continue
+                    repair_reply = extract_response(repair_stdout)
+                    repair_blob = parse_verdict_json(repair_reply or "")
+                    if repair_blob is None:
+                        err = "validation repair reply not valid JSON"
+                        with run_log.open("a", encoding="utf-8") as f:
+                            f.write(json.dumps({
+                                "claim_id": cid,
+                                "phase": "validation_repair_json_parse_failed",
+                                "attempt": repair_attempt,
+                                "reply": (repair_reply or "")[:2000],
+                            }) + "\n")
+                        continue
+                    preservation_error = validation_repair_preservation_error(
+                        initial_rejected_blob, repair_blob
+                    )
+                    repair_error = preservation_error
+                    if repair_error is None:
+                        repair_error = validate_verdict(
+                            repair_blob,
+                            cid,
+                            source_requires_no_go=source_requires_no_go,
+                            evidence_manifest=exact_evidence_manifest,
+                            prior_claim_scope=full_led_row.get("claim_scope"),
+                        )
+                    with run_log.open("a", encoding="utf-8") as f:
+                        f.write(json.dumps({
+                            "claim_id": cid,
+                            "phase": (
+                                "validation_repair_passed"
+                                if repair_error is None
+                                else "validation_repair_failed"
+                            ),
+                            "attempt": repair_attempt,
+                            "initial_error": initial_validation_error,
+                            "error": repair_error,
+                        }) + "\n")
+                    if preservation_error is None:
+                        blob = repair_blob
+                    err = repair_error
+                    if err is None:
+                        print(
+                            f"  validation repair passed "
+                            f"({repair_elapsed:.1f}s cumulative)"
+                        )
+                        break
+                elapsed += repair_elapsed
             if err:
                 print(f"  FAIL validate: {err}")
                 failed += 1

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -286,7 +286,6 @@ VALIDATION_REPAIR_MUTABLE_FIELD = "no_go_discipline"
 VALIDATION_REPAIR_LOCATOR_FIELDS = {
     "evidence_path",
     "evidence_locator",
-    "evidence_snapshot",
 }
 
 # Map JSON-extracted-from-stdout to apply_audit.py's input schema. apply_audit
@@ -1125,9 +1124,8 @@ def render_validation_repair_prompt(
         "not evidence.\n"
         "Every evidence_locator must be a 12+ character verbatim substring of\n"
         "the content at its evidence_path in the restricted packet; copy it\n"
-        "exactly. Every retained/accepted-premise classification must match the\n"
-        "packet metadata. Recheck all N1-N8 internal references, not merely the\n"
-        "first reported error.\n\n"
+        "exactly. Do not revise any classification or internal N1-N8\n"
+        "reference.\n\n"
         f"VALIDATION ERROR:\n{validation_error}\n\n"
         f"REJECTED JSON TO CORRECT:\n{prior_json}\n"
     )
@@ -1175,6 +1173,27 @@ def validation_repair_preservation_error(
     return None
 
 
+def validation_repair_eligible(
+    rejected_blob: dict,
+    expected_cid: str,
+    validation_error: str | None,
+) -> bool:
+    """True only for a complete verdict with an N1-N8 locator failure."""
+    if not validation_error:
+        return False
+    locator_error = validation_error.casefold()
+    if not any(
+        marker in locator_error
+        for marker in ("evidence_path", "evidence path", "evidence_locator")
+    ):
+        return False
+    return (
+        REQUIRED_VERDICT_FIELDS.issubset(rejected_blob)
+        and rejected_blob.get("claim_id") == expected_cid
+        and isinstance(rejected_blob.get(VALIDATION_REPAIR_MUTABLE_FIELD), dict)
+    )
+
+
 def apply_one(verdict_blob: dict, propagate: bool) -> tuple[bool, str]:
     """Pipe a verdict blob through apply_audit.py via stdin."""
     cmd = [sys.executable, str(APPLY_AUDIT_SCRIPT)]
@@ -1210,7 +1229,8 @@ def main() -> int:
     p.add_argument("--codex-timeout-sec", type=int, default=600,
                    help="Per-row codex exec timeout (default 600).")
     p.add_argument("--validation-repair-attempts", type=int, default=1,
-                   help="After a parsed verdict fails strict validation, ask "
+                   help="After a complete parsed verdict fails strict N1-N8 "
+                        "evidence-locator validation, ask "
                         "the same restricted-packet auditor for this many "
                         "validator-guided JSON corrections (default 1; 0 "
                         "disables). Every correction must pass the unchanged "
@@ -1582,11 +1602,7 @@ def main() -> int:
             initial_validation_error = err
             initial_rejected_blob = blob
             repair_elapsed = 0.0
-            repair_eligible = (
-                REQUIRED_VERDICT_FIELDS.issubset(blob)
-                and blob.get("claim_id") == cid
-                and isinstance(blob.get(VALIDATION_REPAIR_MUTABLE_FIELD), dict)
-            )
+            repair_eligible = validation_repair_eligible(blob, cid, err)
             if err and args.validation_repair_attempts > 0 and repair_eligible:
                 for repair_attempt in range(1, args.validation_repair_attempts + 1):
                     print(


### PR DESCRIPTION
Adds a bounded validator-guided correction pass when a parsed independent audit verdict fails strict N1-N8 evidence-locator validation. The correction receives the identical restricted packet, the rejected JSON marked as an untrusted correction target rather than evidence, and the exact validator error. It runs in the same isolated Codex environment and may change only evidence_path/evidence_locator fields inside an already-present no_go_discipline packet. The complete top-level key set, every other top-level value, packet status, routes, walls, residuals, dispositions, and all other N1-N8 judgment content are equality-frozen against the initially rejected object. Missing top-level judgment fields and absent packets are ineligible for repair. The existing no-go validator and apply gate remain unchanged and must accept the corrected object against the original exact evidence manifest. Set --validation-repair-attempts 0 to disable; accepted range is 0 through 3, default 1. Every failed correction attempt is logged and cannot apply a verdict. Verification: 140 audit pipeline unit tests pass; py_compile passes; full audit pipeline and strict lint pass with existing warnings and no errors.