### PR TITLE
feat(bridge): 3D protocol-Admissibility realization + word dispersiveness (Wave B)

### DIFF
--- a/docs/PROTOCOL_ADMISSIBILITY_3D_REALIZATION_BRIDGE_AND_WORD_DISPERSIVENESS_NARROW_THEOREM_NOTE_2026-07-10.md
+++ b/docs/PROTOCOL_ADMISSIBILITY_3D_REALIZATION_BRIDGE_AND_WORD_DISPERSIVENESS_NARROW_THEOREM_NOTE_2026-07-10.md
@@ -1,0 +1,339 @@
+# Protocol--Admissibility 3D Realization Bridge And Word Dispersiveness
+
+**Date:** 2026-07-10
+**Type:** bounded_theorem
+**Claim type:** bounded_theorem
+**Claim scope note:** conditional theorem on the named availability-rule model
+`B`, the named `REAL3` realization predicate, the period-2 decorated-mover word
+class on the one-amplitude `Z^3` carrier, and the stated finite verifications.
+No inventory-completeness claim, no protocol-existence claim, and no claim that
+the physical tick realizes `REAL3` are made.
+**Status authority:** independent audit lane only. This source note does not set or predict an audit outcome.
+**Primary runner:**
+[`scripts/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.py`](../scripts/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.py)
+**Runner cache:**
+[`logs/runner-cache/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.txt`](../logs/runner-cache/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.txt)
+
+---
+
+## Why This Note Exists
+
+The protocol-selection note
+`KINETIC_ISOTROPY_3D_FACTORIZED_PROTOCOL_SELECTION_ON_ANALYZED_CLASSES_BOUNDED_THEOREM_NOTE_2026-07-09`
+reads its algebraic filter table as a physical filter only after two inputs are
+separately supplied. That note's "Supplied Conditional Physical Reading"
+section states them. The first input is that a realized sequential protocol is
+supplied with the constituent-factor semantics used there, and that
+
+> translation covariance of the fixed rule requires each constituent factor to be fully covariant modulo local `U(1)` frames and therefore to have zero site-modulus translation defect; nonvacuous variation together with proper cubic axis transitivity requires nonzero constituent-factor support on all three axes.
+
+The second input is that the realized composite word is supplied to be
+
+> dispersive in the characteristic-polynomial sense used by the runner.
+
+This note derives both supplied inputs as theorems from the two Admissibility
+clauses plus a named realization predicate `REAL3`, rather than leaving them as
+separately supplied physical readings. It does not claim to settle the selection
+question; it is the next derivation this step opens, and the residues the
+selection note keeps open stay open here.
+
+## Setting And Objects
+
+The carrier is the `Z^3` qubit lattice with one complex amplitude per site
+(one-component carrier). The period-2 cell `{0,1}^3` carries the 8-dimensional
+Bloch representation. The `L=4` site ring per axis (`4^3 = 64` sites) is used
+for exact site-level relation checks. The support law is measured on the `L=6`
+ring (`6^3 = 216` sites), where for words through length 5 every axis
+displacement satisfies `|net_i| <= 5 < 6` so no wraparound aliases a nonzero
+displacement to zero. The normal form is realized as an explicit operator
+product on the `L=12` ring (`12^3 = 1728` sites), large enough that a wrong
+central exponent `m_i` cannot alias to the identity the way `T_cell_i^2 = I`
+makes it on `L=4`. Nearest-neighbor license: every elementary factor
+is a nearest-neighbor-supported unitary. A local `U(1)` frame is a
+site-diagonal unitary. Whole-cell translation on axis `i` is translation by two
+sites on axis `i`, written `T_cell_i`; one-site translation on axis `i` is
+`T_i`.
+
+The decorated movers come from the landed parent chain. On the cell coordinate
+`p in {0,1}^3` (0-indexed), the eta pattern is
+
+- `eta_1(p) = 1`,
+- `eta_2(p) = (-1)^{p_0}`,
+- `eta_3(p) = (-1)^{p_0 + p_1}`.
+
+`S_i` is the eta-decorated one-site shift on axis `i` (Bloch form `S_axis(k, i)`;
+site form `site_shift(i, +1)`), and `S_i^{-1} = S_i^dagger`.
+
+The availability-rule model is abstract, following the one-axis bridge pattern.
+A rule table `B` assigns to each nearest-neighbor condition profile
+`c : N6 -> {0,1}`, where `N6` is the six offsets `{+-e_1, +-e_2, +-e_3}`, a
+nonempty subset `B(c)` of `{0,1}`. The variation offset set is
+`V(B) = { d in N6 : exists c, c' equal off slot d with B(c) != B(c') }`.
+
+## The Two Admissibility Clauses
+
+The two clause sentences, quoted verbatim from the linked axioms note, are:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations.
+
+> For each site, the available possibilities are determined by, and vary with, the nearest-neighbor conditions.
+
+Their formalizations on the availability-rule model are:
+
+- **Clause 1, translation part.** The table `B` is site-independent (one fixed
+  rule).
+- **Clause 1, rotation part.** `B(c o R) = B(c)` for every proper cubic
+  rotation `R`, where the 24-element rotation group acts on the `N6` slots.
+- **Clause 2, variation part.** `V(B)` is nonempty.
+
+## The Named 3D Realization Predicate
+
+For a sequential protocol `P = (F_1, ..., F_m)` with composite word
+`W = F_m ... F_1`, the predicate `REAL3(P; B)` bundles three conditions.
+
+- **(R1-factor)** Each constituent factor is built from the fixed rule data by
+  one site-independent assignment, modulo a local `U(1)` frame:
+  `F_j = g_j F_j^{(0)} g_j^dagger` with `g_j` diagonal and `F_j^{(0)}` exactly
+  translation covariant.
+- **(R2-factor)** Every variation offset `d in V(B)` is carried by some
+  constituent factor: some `F_j` has a nonzero matrix element at
+  nearest-neighbor displacement `d`.
+- **(R2-word)** For every axis `i` with `+e_i in V(B)` or `-e_i in V(B)`, the
+  composite `W` has a nonzero site-level matrix element `W[x,y]` whose
+  displacement `y - x` has nonzero axis-`i` component, at any displacement
+  length.
+
+R2-word is a genuine additional realization premise at the composite level. It
+is not a consequence of the factor-level conditions R1-factor and R2-factor;
+the `P_CANCEL` witness below satisfies both factor conditions while failing
+R2-word.
+
+## Theorem 3B1 (Factor Covariance And Zero Modulus Defect)
+
+**Statement.** Clause 1 (translation part) together with R1-factor implies that
+each constituent factor is fully covariant modulo local `U(1)` frames, meaning
+`T_a F_j T_a^dagger = h F_j h^dagger` for a diagonal `h` per axis generator, and
+therefore that each constituent factor has zero site-modulus translation
+defect.
+
+**Proof.** By R1-factor, `F_j = g_j F_j^{(0)} g_j^dagger` with `F_j^{(0)}`
+exactly translation covariant, so translating `F_j` conjugates it by the
+diagonal `h = T_a g_j T_a^dagger g_j^dagger`, which is a local frame. Frame
+conjugation multiplies each matrix element by unit-modulus diagonal phases, so
+it preserves entrywise moduli: `|F_j| = |F_j^{(0)}|` entrywise, and the
+right-hand side is translation invariant. Hence the site-modulus translation
+defect of `F_j` is zero. The runner realizes this with the bare undecorated
+one-site shift as `F_j^{(0)}`, which it checks is exactly translation covariant
+on all three axis generators. The decorated mover is then `g F_j^{(0)} g^dagger`
+for the explicit diagonal frame `g = diag((-1)^{x_0 x_1})` built from the eta
+pattern; the runner checks this reconstruction, checks that the decorated mover
+itself is not translation covariant (its translation gap is 2 on axis 0, taken
+as a maximum over axes so it cannot be masked by a covariant axis), and checks
+zero modulus defect for the decorated factor.
+
+**Strictness (necessary, not sufficient).** The alternating diagonal factor
+`D_alt = diag((-1)^{x_1})` has zero modulus defect, and every local frame `h`
+satisfies `h D_alt h^dagger = D_alt` because diagonals commute, while
+`T_1 D_alt T_1^dagger = -D_alt != D_alt`. So `D_alt` is not covariant modulo
+local frames although its defect is zero. Zero defect is only the derived
+necessary shadow of full covariance.
+
+**Rejector.** A site-dependent-amplitude factor built as a direct sum of
+`2x2` Givens rotations on axis-1 nearest-neighbor pairs with the fixed angle
+list `(0.3, 0.9)` along the ring is unitary and nearest-neighbor supported yet
+has modulus defect `> 0.05`. The defect functional therefore has teeth.
+
+The zero-defect filter of the selection note is the derived necessary shadow of
+this theorem.
+
+## Theorem 3B2 (Rotation Transport And All-Axis Factor Support)
+
+**Statement.** The 24 proper cubic rotations act transitively on the six
+nearest-neighbor offsets. Hence Clause 1 (rotation part) together with Clause 2
+(some variation offset `d0`) implies that `V(B)` contains all six offsets, and,
+combined with R2-factor, the constituent-factor support vector is `(1,1,1)`.
+
+**Transport proof.** Let `(c, c')` witness variation at slot `d0`, so they agree
+off slot `d0` and `B(c) != B(c')`. Fix a proper cubic rotation `R`. The rotated
+profiles `c o R^{-1}` and `c' o R^{-1}` agree off slot `R d0`, and by the
+rotation part `B(c o R^{-1}) = B(c) != B(c') = B(c' o R^{-1})`, so `R d0` is a
+variation slot. As `R` ranges over the group, `R d0` ranges over the full orbit
+of `d0`, which by transitivity is all six offsets. Thus `V(B) = N6`. R2-factor
+then forces some factor to carry nearest-neighbor support on each axis, so the
+support vector is `(1,1,1)`.
+
+**Covariant witness.** The parity table `B(c) = {0,1}` if `sum(c)` is even else
+`{0}` is invariant under every slot permutation, hence rotation covariant, and
+varies at every slot.
+
+**Non-covariant control.** The table `B'(c) = {0,1}` if `c(+e_1) = 1` else
+`{0}` varies only at slot `+e_1` and violates the rotation-covariance identity
+for some `R`. Its variation set misses axes 2 and 3, exactly the failure mode
+the transport argument rules out under covariance.
+
+The all-axis factor-support filter of the selection note is the derived
+necessary shadow of this theorem.
+
+## Theorem 3B3 (Word Reduction And The Dispersiveness Dichotomy)
+
+Consider finite words in the six letters
+`{S_1^{+1}, S_1^{-1}, S_2^{+1}, S_2^{-1}, S_3^{+1}, S_3^{-1}}`.
+
+**Relations (recomputed exactly at site level, `L=4`).** For `i != j`,
+`S_i S_j = - S_j S_i`, including with any inverse letters, because the
+staggered eta pattern contributes exactly one sign flip per cross-axis
+transposition. Same-axis letters commute. `S_i^2 = T_cell_i`, the whole-cell
+translation, which commutes with every letter. `S_i^{-1} = S_i^dagger` and
+`S_i S_i^{-1} = I` exactly.
+
+**Exact normal form.** Every word `w` reduces to
+`W = sigma * (prod_i T_cell_i^{m_i}) * S_1^{eps_1} S_2^{eps_2} S_3^{eps_3}`,
+where `net_i` is the net signed exponent of axis `i` in `w`,
+`eps_i = net_i mod 2 in {0,1}`, `m_i = (net_i - eps_i)/2`, and `sigma in {+1,-1}`
+is the parity of cross-axis adjacent transpositions used to sort the letters by
+axis. Same-axis letters commute, so they contribute no sign; the sign is the
+parity of the cross-axis inversions.
+
+**Support law.** `W` has site-level support at some displacement with nonzero
+axis-`i` component if and only if `net_i != 0`.
+
+**Dispersiveness dichotomy.** The Bloch characteristic-polynomial coefficients
+of `W` are momentum-independent if and only if `net = (0,0,0)`, i.e. exactly
+when `W = +-I`. If any `net_i != 0`, then either a residual mover
+(`eps_i = 1`) contributes momentum-dependent bands, or a pure central part
+(`eps_i = 0`, `m_i != 0`) contributes the momentum-dependent scalar phase
+`exp(-i m_i k_i)` through the determinant, so the characteristic polynomial
+depends on momentum.
+
+**Proof sketch.** Sort the letters by axis using adjacent transpositions. A
+cross-axis transposition flips a sign by pairwise anticommutation; a same-axis
+transposition is free. After sorting, each axis run is a power of `S_i`, and
+`S_i^2 = T_cell_i` splits that power into the central translation part `m_i` and
+the residual mover `eps_i`. The central factors commute through, giving the
+normal form. The support law reads off displacements: `S_i^{eps_i}` moves by one
+site on axis `i` when `eps_i = 1`, and `T_cell_i^{m_i}` moves by `2 m_i` sites,
+so axis-`i` displacement is nonzero exactly when `net_i != 0`. The dichotomy
+follows because `S_i^2 = e^{-i k_i} I` on the Bloch cell, so a pure central word
+is a momentum-dependent scalar and a residual mover has momentum-dependent
+eigenvalues, while `net = (0,0,0)` gives `+-I`. The runner verifies the
+reduction by building the normal form as an explicit operator product of central
+cell-translation and residual-mover operators on the `L=12` ring and matching it
+to the direct letter product, exhaustively for all words through length 5 (9330
+words) and on named length-6 witnesses; a rejector confirms that a wrong central
+exponent `m_i` is caught on `L=12` while it aliases to the identity on `L=4`, so
+the `m_i` are load-bearing. The support law is checked on the `L=6` ring, where
+words through length 5 never wrap. The induction is the prose argument above.
+
+**Bridge conclusion.** Under Clauses 1 and 2 and `REAL3`, Theorem 3B2 gives
+variation on all three axes; R2-word forces axis support on all three axes; the
+support law gives `net_i != 0` for all `i`; the dichotomy gives that the
+realized composite word is dispersive in the characteristic-polynomial sense.
+This derives, on the analyzed word class, the condition the selection note lists
+as its supplied input 2.
+
+**Separating witness (R2-word is load-bearing).** The cancelling word
+`P_CANCEL = S_1 S_1^{-1} S_2 S_2^{-1} S_3 S_3^{-1}` has zero constituent-factor
+modulus defect and factor support union `(1,1,1)`, so it satisfies R1-factor and
+R2-factor against the parity table, yet it composes to the identity:
+`net = (0,0,0)`, no off-site composite support, flat. It violates exactly
+R2-word. The unconditional claim that nonvacuous variation alone forces
+composite dispersiveness is therefore false and is not made; R2-word is the
+named extra realization premise.
+
+**Non-removal witness.** The weighted word `P_WEIGHT = S_1 S_1 S_2 S_3` has
+`net = (2,1,1)`, satisfies R2-word (axis-1 support at displacement 2 through
+`T_cell_1`, nearest-neighbor support on axes 2 and 3), and is dispersive. The
+bridge does not remove `P_WEIGHT`; the four-member candidate set of the
+selection note is kept intact.
+
+**Scope honesty.** The reduction and dichotomy are proved on words in the
+decorated movers. Non-word protocols, such as commuting pairing factors and
+diagonal-phase protocols, are outside 3B3's scope; in the analyzed ten-member
+inventory they are removed upstream by the 3B1 defect filter or the 3B2 support
+filter, not by 3B3.
+
+## Endpoint Corollary (Consistency With The Selection Note)
+
+Applying the three derived necessary conditions -- zero constituent-factor
+modulus defect, all-axis factor support, and R2-word (which on the word class
+implies composite dispersiveness) -- to the ten-member inventory of the
+selection note reproduces exactly the four-member candidate set
+`{P_SYM, P_SYM_OCT, P_REORDER, P_WEIGHT}`. Nothing is consumed: the four-member
+set is reproduced, not narrowed, and the octant, central-sign, and whole-cell
+translation residues stay open exactly as in the selection note.
+
+## Boundary And Honest Auditor Read
+
+- The availability-rule model `B` and the predicate `REAL3` are named
+  formalizations. The three theorems are conditional on them. Whether the
+  physical tick realizes `REAL3` is not derived here.
+- The 3B3 dichotomy is proved on the decorated-mover word class only, with
+  exhaustive machine verification through length 5 plus named longer witnesses,
+  and an algebraic induction argued in prose.
+- Nothing here selects among the four surviving protocols and nothing removes
+  `P_WEIGHT`.
+- The two derived factor conditions are necessary consequences of the bridge,
+  not equivalences. Their converses are false and are shown false by explicit
+  witnesses: `D_alt` has zero modulus defect without being covariant modulo
+  local frames, and a constant-rule uniform mover pattern shows that factor
+  support does not certify variation. Binary all-axis factor support is much
+  weaker than full protocol covariance.
+
+## Falsifiers
+
+- A word with `net != 0` whose Bloch characteristic polynomial is
+  momentum-independent across the fixed grid.
+- A frame-conjugated fixed-assignment factor with positive site-modulus
+  translation defect.
+- A rotation-covariant varying table whose variation set misses an axis.
+- A rebuild of the ten-member filter application yielding a survivor set other
+  than `{P_SYM, P_SYM_OCT, P_REORDER, P_WEIGHT}`.
+- A word whose direct site-level product disagrees with its predicted normal
+  form.
+
+## Dependencies
+
+- [MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md)
+  supplies the two Admissibility clause sentences and the explicit boundary that
+  Admissibility does not choose a transfer operator or kinetic branch.
+- [KINETIC_ISOTROPY_3D_SIMULTANEOUS_TICK_BOUNDED_THEOREM_NOTE_2026-06-10.md](KINETIC_ISOTROPY_3D_SIMULTANEOUS_TICK_BOUNDED_THEOREM_NOTE_2026-06-10.md)
+  supplies the 3D decorated-mover constructions, the factor identities, and the
+  bounded-class scope.
+- [LATTICE_NN_LIGHT_CONE_NOTE.md](LATTICE_NN_LIGHT_CONE_NOTE.md)
+  supplies the nearest-neighbor site-license as a finite forward-reachability
+  theorem.
+
+Context (no dependency edge):
+`KINETIC_ISOTROPY_3D_FACTORIZED_PROTOCOL_SELECTION_ON_ANALYZED_CLASSES_BOUNDED_THEOREM_NOTE_2026-07-09`,
+`TICK_CELL_SELECTION_BY_TRANSLATION_AND_VARIATION_CLAUSES_NARROW_THEOREM_NOTE_2026-07-09`,
+`STAGGERED_SITE_LICENSE_TICK_DICHOTOMY_BOUNDED_THEOREM_NOTE_2026-06-09`,
+`TICK_ADMISSIBILITY_REALIZATION_BRIDGE_CLAUSE_TO_PREDICATE_NARROW_THEOREM_NOTE_2026-07-10`.
+
+## Runner And Cache
+
+The runner recomputes the six decorated letters on the `L=4` ring and the Bloch
+cell, the cross-axis anticommutation and central-square relations, the 24 proper
+cubic rotations and their transitive action on the six offsets, the modulus
+defect functional with its Givens rejector and `D_alt` strictness witness, the
+parity availability table with its rotation-transport and non-covariant control,
+the exhaustive normal-form reduction and support law and dispersiveness
+dichotomy over all 9330 words through length 5, the named length-6 witnesses,
+and the ten-member endpoint reproduction. The check-group inventory is A
+(surface reconstruction), B (Theorem 3B1), C (Theorem 3B2), D (Theorem 3B3), and
+E (quote pins). The expected final line is `TOTAL: PASS=30 FAIL=0`. The runner
+is deterministic: it uses no randomness, a fixed momentum grid, and fixed word
+and phase lists, and it reads no audit metadata.
+
+Primary runner:
+[`scripts/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.py`](../scripts/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.py)
+
+Runner cache:
+[`logs/runner-cache/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.txt`](../logs/runner-cache/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.txt)
+
+Current local runner result is recorded in the SHA-pinned cache.
+
+## Changelog
+
+- **2026-07-10.** Initial bounded note and deterministic runner deriving the
+  two supplied inputs of the selection note as the theorems 3B1, 3B2, and 3B3
+  under the named availability-rule model and the `REAL3` realization predicate.

--- a/logs/runner-cache/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.txt
+++ b/logs/runner-cache/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.txt
@@ -1,0 +1,58 @@
+===== runner cache v1 =====
+runner: scripts/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.py
+runner_sha256: 4fa74f86feb57ae1c3a0f29ef56500d7e256380fa8580dedeccb6e7ab49a9b4c
+timeout_sec: 180
+exit_code: 0
+elapsed_sec: 3.32
+status: ok
+----- stdout -----
+
+Group A -- REAL3 realization surface: six decorated movers + cubic rotations
+================================================================================================
+  [PASS] A1 six decorated movers unitary at site (64) and across the Bloch grid  --  site=0.00e+00 bloch=2.22e-16
+  [PASS] A2 cross-axis letters anticommute at site level (including inverse letters)  --  max|{S_a,S_b}|=0.00e+00
+  [PASS] A3 S_i^2 equals the independently built cell translation, which is central  --  square=0.00e+00 central=0.00e+00
+  [PASS] A4 forward mover unitary and the inverse letter equals its adjoint  --  unit=0.00e+00 adjoint=0.00e+00
+  [PASS] A5 twenty-four proper cubic rotations, closed, transitive on the six NN offsets  --  |G|=24 orbit=[0, 1, 2, 3, 4, 5] distinct=24
+
+Group B -- Theorem 3B1: covariance modulo local frames => zero modulus defect
+================================================================================================
+  [PASS] B1 decorated mover = g F^{(0)} g^dag with F^{(0)} the exactly covariant bare shift; the decorated mover itself is not translation-covariant (gap>1); zero modulus defect  --  bare_cov=0.00e+00 recon=0.00e+00 dec_noncov_gap=2.00 modulus_defect=0.00e+00
+  [PASS] B2 an arbitrary local-frame decoration preserves zero modulus defect  --  defect=3.33e-16
+  [PASS] B3 the frame decoration is modulus-blind (|F| equals |F0| entrywise)  --  max||F|-|F0||=2.22e-16
+  [PASS] B4 a site-dependent axis-1 Givens rotation is unitary and NN-supported but has positive modulus defect  --  unit=1.11e-16 support=(0, 1, 0) defect=0.783
+  [PASS] B5 a covariant-modulus diagonal that translations sign-flip: zero defect, frame-invariant, not covariant  --  defect=0.00e+00 frame_inv=2.22e-16 flip=0.00e+00 gap=2.00
+  [PASS] B6 the undecorated bare shift also has zero modulus defect (the functional is not spuriously positive)  --  defect=0.00e+00
+
+Group C -- Theorem 3B2: rotation transitivity forces all-axis support
+================================================================================================
+  [PASS] C1 the parity availability rule B is rotation-covariant and varies at slot 0  --  covariant=True slot0_in_V=True
+  [PASS] C2 rotation transport carries slot 0 to all six NN directions, and the covariant parity rule varies on exactly that orbit  --  orbit0=[0, 1, 2, 3, 4, 5] V(B)=[0, 1, 2, 3, 4, 5]
+  [PASS] C3 control: a single-slot rule varies only at slot 0 and is NOT rotation-covariant  --  V(B')=[0] covariant=False
+  [PASS] C4 the all-axis mover set (S_1,S_2,S_3) has full constituent-factor support  --  support=(1, 1, 1)
+  [PASS] C5 a same-axis mover pair (S_1,S_1) supports only its own axis  --  support=(1, 0, 0)
+
+Group D -- Theorem 3B3: normal form, support law, dispersiveness dichotomy
+================================================================================================
+  [PASS] D1 exact normal form W = sigma * prod T_cell^m * residual movers (all 9330 words, len<=5)  --  words=9330 mismatches=0
+  [PASS] D1R a wrong central exponent m_i is caught on L=12 but aliases to identity on L=4 (m_i is load-bearing)  --  caught_on_L12=True aliases_on_L4=True
+  [PASS] D2 support law on the aliasing-free L=6 ring: axis-i occupied iff net_i != 0 (all 9330 words)  --  mismatches=0
+  [PASS] D3 dispersiveness dichotomy: Bloch char-poly flat (<1e-8) iff net displacement is (0,0,0) (all 9330 words)  --  anomalies=0
+  [PASS] D4 five named length-6 witnesses: exact normal form, net, sign, and +-I / dispersive value  --  failed_witnesses=0
+  [PASS] D5 P_CANCEL separates the filters: zero modulus defect, full support, composite identity, flat  --  defect=0.00e+00 support=(1, 1, 1) identity=0.00e+00 disp=2.84e-14
+  [PASS] D6 P_WEIGHT (net (2,1,1)) has full support, zero modulus defect, and is dispersive  --  support=(1, 1, 1) disp=1.05e+01 defect=0.00e+00
+  [PASS] D7 identity flat, single mover dispersive, and dropping the anticommutation sign is detectable  --  id=0.00e+00 s1=11.995 reorder_gap=2.00
+  [PASS] D8 the three filters jointly retain the four-member necessary-condition survivor set  --  survivors=['P_REORDER', 'P_SYM', 'P_SYM_OCT', 'P_WEIGHT']
+  [PASS] D9 ordered filters attribute each rejection to its first-failing stage (defect/support/dispersion)  --  defect=['P_MIX4', 'P_PAIRFLAT', 'P_STAIR'] support=['P_AXIS', 'P_DIAG'] dispersion=['P_CANCEL']
+
+Group E -- source-note quote pins (fabrication + framing gates)
+================================================================================================
+  [PASS] E1 both admissibility clause sentences are present verbatim in the axioms file  --  axiom clauses anchored
+  [PASS] E2 the note quotes both axiom clauses and frames its results as necessary consequences  --  note clauses + framing present
+  [PASS] E3 the two supplied-input fragments appear in the note and are anchored verbatim in the parent selection note  --  supplied inputs anchored in parent
+  [PASS] E4 the note is free of forbidden status/framing/nondeterminism language  --  clean
+
+TOTAL: PASS=30 FAIL=0
+
+----- stderr -----
+

--- a/scripts/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.py
+++ b/scripts/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.py
@@ -1,0 +1,1069 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+r"""
+Protocol--Admissibility 3D realization bridge and composite-word dispersiveness.
+
+Derives, on the named availability-rule model B and the named REAL3 realization
+predicate, the two conditions the 3D factorized-protocol selection note supplies
+as physical inputs, plus the word-reduction dichotomy behind the second:
+
+  * Theorem 3B1 -- factor covariance modulo local U(1) frames forces zero
+    site-modulus translation defect (a necessary, not sufficient, shadow);
+  * Theorem 3B2 -- the 24 proper cubic rotations act transitively on the six
+    nearest-neighbor offsets, so a single covariant variation forces all-axis
+    constituent-factor support;
+  * Theorem 3B3 -- exact normal form for words in the six decorated movers, the
+    support law, and the characteristic-polynomial dispersiveness dichotomy
+    (a word is char-poly flat iff its net displacement is (0,0,0)).
+
+Every construction is rebuilt locally (the sibling selection runner is NOT
+imported).  There is no randomness, no audit metadata is read, and there is no
+network or git access.  The check groups are A (surface reconstruction, 5),
+B (Theorem 3B1, 6), C (Theorem 3B2, 5), D (Theorem 3B3, 10), E (quote pins, 4).
+Final line: TOTAL: PASS=30 FAIL=0.
+
+Determinism note: this runner prints no git state (its stdout is SHA-pinned into
+a committed cache and must be reproducible); the human author runs
+`git diff --stat` / `git status --porcelain` separately during review.
+"""
+from __future__ import annotations
+
+import itertools
+import os
+import re
+import sys
+
+import numpy as np
+
+PASS, FAIL = 0, 0
+TOL = 1.0e-10
+L = 4
+
+
+def check(label, ok, detail=""):
+    """Record one computed boolean."""
+    global PASS, FAIL
+    verdict = bool(ok)
+    if verdict:
+        PASS += 1
+        tag = "PASS"
+    else:
+        FAIL += 1
+        tag = "FAIL"
+    print(f"  [{tag}] {label}" + (f"  --  {detail}" if detail else ""))
+
+
+def heading(text):
+    print(f"\n{text}")
+    print("=" * 96)
+
+
+# ---------------------------------------------------------------------------
+# Cell (2^3 Bloch) constructions -- copied conventions from the selection runner.
+comps = list(itertools.product((0, 1), repeat=3))
+idx = {p: i for i, p in enumerate(comps)}
+
+
+def eta_val(mu, p):
+    if mu == 0:
+        return 1
+    if mu == 1:
+        return (-1) ** p[0]
+    return (-1) ** (p[0] + p[1])
+
+
+def S_axis(kvec, axis, decorated=True):
+    S = np.zeros((8, 8), dtype=complex)
+    for p in comps:
+        ql = list(p)
+        ql[axis] ^= 1
+        q = tuple(ql)
+        phase = np.exp(-1j * kvec[axis]) if p[axis] == 0 else 1.0
+        S[idx[p], idx[q]] += (eta_val(axis, q) if decorated else 1.0) * phase
+    return S
+
+
+def S_axis_reverse(kvec, axis, decorated=True):
+    S = np.zeros((8, 8), dtype=complex)
+    for p in comps:
+        ql = list(p)
+        ql[axis] ^= 1
+        q = tuple(ql)
+        phase = np.exp(+1j * kvec[axis]) if p[axis] == 1 else 1.0
+        S[idx[p], idx[q]] += (eta_val(axis, q) if decorated else 1.0) * phase
+    return S
+
+
+THETA = np.pi / 5
+
+
+def mixed_cycle_tick(kvec):
+    Um = np.zeros((8, 8), dtype=complex)
+    cycle0 = [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)]
+    moves = ["across", "across", "within", "within"]
+    for i, move in enumerate(moves):
+        src, tgt = cycle0[i], cycle0[(i + 1) % 4]
+        axis = [a for a in range(3) if src[a] != tgt[a]][0]
+        sign = +1 if tgt[axis] == 1 else -1
+        phase = np.exp(1j * sign * kvec[axis]) if move == "across" else 1.0
+        Um[idx[tgt], idx[src]] = phase
+    cycle1 = [(0, 0, 1), (1, 0, 1), (1, 1, 1), (0, 1, 1)]
+    for i in range(4):
+        src, tgt = cycle1[i], cycle1[(i + 1) % 4]
+        Um[idx[tgt], idx[src]] = 1.0
+    return Um
+
+
+def staircase(kvec):
+    W = np.zeros((8, 8), dtype=complex)
+    for p in comps:
+        axis = 0 if (p[0] + p[1]) % 2 == 0 else 1
+        ql = list(p)
+        ql[axis] ^= 1
+        q = tuple(ql)
+        sign = +1 if q[axis] == 1 else -1
+        phase = np.exp(1j * sign * kvec[axis]) if q[axis] == 0 else 1.0
+        W[idx[q], idx[p]] = phase
+    return W
+
+
+def pairing_bloch(kvec, axis):
+    M = np.zeros((8, 8), dtype=complex)
+    for p in comps:
+        ql = list(p)
+        ql[axis] ^= 1
+        q = tuple(ql)
+        phase = np.exp(-1j * kvec[axis]) if p[axis] == 1 else np.exp(+1j * kvec[axis])
+        M[idx[q], idx[p]] = phase
+    return M
+
+
+def pairing_factor_bloch(axis):
+    """One nearest-neighbor pairing factor on `axis` (Bloch form)."""
+    return lambda kvec: (
+        np.cos(THETA) * np.eye(8) + 1j * np.sin(THETA) * pairing_bloch(kvec, axis)
+    )
+
+
+def diag_bloch(_kvec):
+    return np.diag([np.exp(1j * THETA * ((-1) ** sum(p))) for p in comps])
+
+
+# ---------------------------------------------------------------------------
+# Site (L=4 ring, 64 sites) constructions.
+coords = list(itertools.product(range(L), repeat=3))
+site_idx = {x: i for i, x in enumerate(coords)}
+coords_arr = np.array(coords, dtype=int)
+
+
+def shifted(x, axis, amount):
+    y = list(x)
+    y[axis] = (y[axis] + amount) % L
+    return tuple(y)
+
+
+def site_shift(axis, direction, decorated=True):
+    F = np.zeros((L**3, L**3), dtype=complex)
+    for source in coords:
+        target = shifted(source, axis, direction)
+        parity = tuple(v % 2 for v in source)
+        phase = eta_val(axis, parity) if decorated else 1.0
+        F[site_idx[target], site_idx[source]] = phase
+    return F
+
+
+def cell_translation(axis):
+    """Whole-cell (two-site) translation on `axis`, built independently."""
+    T = np.zeros((L**3, L**3), dtype=complex)
+    for source in coords:
+        target = shifted(source, axis, +2)
+        T[site_idx[target], site_idx[source]] = 1.0
+    return T
+
+
+T_cell = [cell_translation(a) for a in range(3)]
+
+
+def site_mixed_cycle():
+    F = np.zeros((L**3, L**3), dtype=complex)
+    cycles = {
+        0: [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)],
+        1: [(0, 0, 1), (1, 0, 1), (1, 1, 1), (0, 1, 1)],
+    }
+    for source in coords:
+        p = tuple(v % 2 for v in source)
+        cycle = cycles[p[2]]
+        i = cycle.index(p)
+        q = cycle[(i + 1) % 4]
+        axis = [a for a in range(3) if p[a] != q[a]][0]
+        amount = -1 if p[2] == 0 else q[axis] - p[axis]
+        target = shifted(source, axis, amount)
+        F[site_idx[target], site_idx[source]] = 1.0
+    return F
+
+
+def site_staircase():
+    F = np.zeros((L**3, L**3), dtype=complex)
+    for source in coords:
+        p = tuple(v % 2 for v in source)
+        axis = 0 if (p[0] + p[1]) % 2 == 0 else 1
+        target = shifted(source, axis, +1)
+        F[site_idx[target], site_idx[source]] = 1.0
+    return F
+
+
+def site_pairing(axis):
+    M = np.zeros((L**3, L**3), dtype=complex)
+    for source in coords:
+        amount = +1 if source[axis] % 2 == 1 else -1
+        target = shifted(source, axis, amount)
+        M[site_idx[target], site_idx[source]] = 1.0
+    return M
+
+
+def site_pairing_factor(axis):
+    """One nearest-neighbor pairing factor on `axis` (site form)."""
+    return np.cos(THETA) * np.eye(L**3) + 1j * np.sin(THETA) * site_pairing(axis)
+
+
+def site_diagonal():
+    return np.diag([
+        np.exp(1j * THETA * ((-1) ** sum(v % 2 for v in x))) for x in coords
+    ])
+
+
+def compose(matrices, dimension):
+    out = np.eye(dimension, dtype=complex)
+    for matrix in matrices:
+        out = out @ matrix
+    return out
+
+
+def forward(axis, decorated=True):
+    return lambda kvec: S_axis(kvec, axis, decorated)
+
+
+def reverse(axis, decorated=True):
+    return lambda kvec: S_axis_reverse(kvec, axis, decorated)
+
+
+site_forward = [site_shift(a, +1, decorated=True) for a in range(3)]
+site_reverse = [site_shift(a, -1, decorated=True) for a in range(3)]
+
+protocols = {
+    "P_SYM": {
+        "bloch_factors": [forward(0), forward(1), forward(2)],
+        "site_factors": [site_forward[0], site_forward[1], site_forward[2]],
+    },
+    "P_SYM_OCT": {
+        "bloch_factors": [reverse(0), forward(1), forward(2)],
+        "site_factors": [site_reverse[0], site_forward[1], site_forward[2]],
+    },
+    "P_REORDER": {
+        "bloch_factors": [forward(1), forward(0), forward(2)],
+        "site_factors": [site_forward[1], site_forward[0], site_forward[2]],
+    },
+    "P_WEIGHT": {
+        "bloch_factors": [forward(0), forward(0), forward(1), forward(2)],
+        "site_factors": [site_forward[0], site_forward[0], site_forward[1], site_forward[2]],
+    },
+    "P_AXIS": {
+        "bloch_factors": [forward(0)],
+        "site_factors": [site_forward[0]],
+    },
+    "P_MIX4": {
+        "bloch_factors": [mixed_cycle_tick],
+        "site_factors": [site_mixed_cycle()],
+    },
+    "P_STAIR": {
+        "bloch_factors": [staircase],
+        "site_factors": [site_staircase()],
+    },
+    "P_PAIRFLAT": {
+        "bloch_factors": [
+            pairing_factor_bloch(0),
+            pairing_factor_bloch(1),
+            pairing_factor_bloch(2),
+        ],
+        "site_factors": [
+            site_pairing_factor(0),
+            site_pairing_factor(1),
+            site_pairing_factor(2),
+        ],
+    },
+    "P_CANCEL": {
+        "bloch_factors": [forward(0), reverse(0), forward(1), reverse(1), forward(2), reverse(2)],
+        "site_factors": [site_forward[0], site_reverse[0], site_forward[1], site_reverse[1], site_forward[2], site_reverse[2]],
+    },
+    "P_DIAG": {
+        "bloch_factors": [diag_bloch],
+        "site_factors": [site_diagonal()],
+    },
+}
+
+
+def bloch_protocol(name, kvec):
+    return compose([f(kvec) for f in protocols[name]["bloch_factors"]], 8)
+
+
+def site_protocol(name):
+    return compose(protocols[name]["site_factors"], L**3)
+
+
+# ---------------------------------------------------------------------------
+# Filter functionals (copied semantics from the selection runner).
+translations = []
+for axis in range(3):
+    T = np.zeros((L**3, L**3), dtype=complex)
+    for source in coords:
+        T[site_idx[shifted(source, axis, +1)], site_idx[source]] = 1.0
+    translations.append(T)
+
+
+def factor_translation_defect(F):
+    return max(
+        np.max(np.abs(np.abs(T @ F @ T.conj().T) - np.abs(F)))
+        for T in translations
+    )
+
+
+def protocol_factor_modulus_defect(name):
+    return max(factor_translation_defect(F) for F in protocols[name]["site_factors"])
+
+
+def is_nearest_neighbor_pair(target, source, axis):
+    same_transverse = all(target[a] == source[a] for a in range(3) if a != axis)
+    delta = (target[axis] - source[axis]) % L
+    return same_transverse and delta in (1, L - 1)
+
+
+def factor_support_vector(factors):
+    vector = []
+    for axis in range(3):
+        occupied = any(
+            abs(F[site_idx[target], site_idx[source]]) > TOL
+            for F in factors
+            for source in coords
+            for target in coords
+            if is_nearest_neighbor_pair(target, source, axis)
+        )
+        vector.append(int(occupied))
+    return tuple(vector)
+
+
+# ---------------------------------------------------------------------------
+# Fixed momentum grid for the characteristic-polynomial dispersion measure.
+K = [
+    (0.3, 0.7, 1.1),
+    (1.9, 0.5, 2.3),
+    (0.9, 2.7, 1.7),
+    (2.9, 1.3, 0.7),
+    (0.1, 1.1, 2.1),
+    (1.3, 2.9, 0.3),
+]
+
+bloch_fn = {}
+for _a in range(3):
+    bloch_fn[(_a, +1)] = (lambda kvec, a=_a: S_axis(kvec, a, True))
+    bloch_fn[(_a, -1)] = (lambda kvec, a=_a: S_axis_reverse(kvec, a, True))
+
+
+def bloch_word(word, kvec):
+    mats = [bloch_fn[l](kvec) for l in word]
+    return compose(mats, 8) if mats else np.eye(8, dtype=complex)
+
+
+def word_dispersion(word):
+    polys = [np.poly(bloch_word(word, kvec)) for kvec in K]
+    return max(np.max(np.abs(p - polys[0])) for p in polys[1:])
+
+
+def protocol_dispersion(name):
+    polys = [np.poly(bloch_protocol(name, kvec)) for kvec in K]
+    return max(np.max(np.abs(p - polys[0])) for p in polys[1:])
+
+
+# ---------------------------------------------------------------------------
+# The six decorated-mover letters as exact real signed permutations on L=4 and
+# L=6.  L=4 gives the exact reduction identity; L=6 gives an aliasing-free
+# support law (|net_i| <= 5 < 6 so no torus wraparound).
+LETTERS = [(0, +1), (0, -1), (1, +1), (1, -1), (2, +1), (2, -1)]
+
+
+def _signed_perm(ring, axis, direction):
+    ring_coords = list(itertools.product(range(ring), repeat=3))
+    index = {x: i for i, x in enumerate(ring_coords)}
+    perm = np.empty(ring**3, dtype=np.int64)
+    sgn = np.empty(ring**3, dtype=np.int64)
+    for s, source in enumerate(ring_coords):
+        y = list(source)
+        y[axis] = (y[axis] + direction) % ring
+        perm[s] = index[tuple(y)]
+        sgn[s] = eta_val(axis, tuple(v % 2 for v in source))
+    return perm, sgn
+
+
+perm4 = {}
+sign4 = {}
+for _l in LETTERS:
+    perm4[_l], sign4[_l] = _signed_perm(L, _l[0], _l[1])
+
+L6 = 6
+coords6 = list(itertools.product(range(L6), repeat=3))
+coords6_arr = np.array(coords6, dtype=int)
+perm6 = {}
+for _l in LETTERS:
+    perm6[_l], _ = _signed_perm(L6, _l[0], _l[1])
+
+
+def net_of(word):
+    net = [0, 0, 0]
+    for axis, sign in word:
+        net[axis] += sign
+    return tuple(net)
+
+
+def sigma_of(word):
+    axes = [axis for axis, _ in word]
+    inversions = sum(
+        1
+        for i in range(len(axes))
+        for j in range(i + 1, len(axes))
+        if axes[i] > axes[j]
+    )
+    return -1 if inversions % 2 else 1
+
+
+def direct_signed(word):
+    """Exact signed permutation of the L=4 site product M(l1) @ ... @ M(ln)."""
+    P = np.arange(L**3)
+    Sg = np.ones(L**3, dtype=np.int64)
+    for l in reversed(word):
+        Sg = Sg * sign4[l][P]
+        P = perm4[l][P]
+    return P, Sg
+
+
+# L=12 makes the central exponents m_i load-bearing: T_cell_i^{m_i} shifts 2 m_i
+# sites, and for |net_i| <= 5 the residual shift 2 m_i in [-4, 4] never wraps on the
+# L=12 ring.  On the L=4 ring a wrong m_i is invisible because T_cell_i^2 = I aliases
+# every even shift to the identity; the normal form is therefore realized as an explicit
+# operator product on L=12 (not reconstructed from net displacement).
+L12 = 12
+coords12 = list(itertools.product(range(L12), repeat=3))
+idx12 = {x: i for i, x in enumerate(coords12)}
+perm12 = {}
+sign12 = {}
+for _l in LETTERS:
+    perm12[_l], sign12[_l] = _signed_perm(L12, _l[0], _l[1])
+
+
+_shift_cache = {}
+
+
+def cell_shift_perm(ring, idxmap, axis, twostep):
+    """Central cell translation T_cell_axis^{m} as a bare permutation (shift 2m sites)."""
+    key = (ring, axis, twostep % ring)
+    if key not in _shift_cache:
+        ring_coords = list(itertools.product(range(ring), repeat=3))
+        perm = np.empty(ring**3, dtype=np.int64)
+        for s, src in enumerate(ring_coords):
+            y = list(src)
+            y[axis] = (y[axis] + twostep) % ring
+            perm[s] = idxmap[tuple(y)]
+        _shift_cache[key] = perm
+    return _shift_cache[key]
+
+
+def _compose_signed(factors, ring):
+    """Compose an ordered list of (perm, sign) signed permutations, left-to-right."""
+    P = np.arange(ring**3)
+    Sg = np.ones(ring**3, dtype=np.int64)
+    for perm, sign in reversed(factors):
+        Sg = Sg * sign[P]
+        P = perm[P]
+    return P, Sg
+
+
+def direct_signed_12(word):
+    """Exact signed permutation of the L=12 site product M(l1) @ ... @ M(ln)."""
+    P = np.arange(L12**3)
+    Sg = np.ones(L12**3, dtype=np.int64)
+    for l in reversed(word):
+        Sg = Sg * sign12[l][P]
+        P = perm12[l][P]
+    return P, Sg
+
+
+def normal_form_op(word, ring, idxmap, permL, signL, m_override=None):
+    """Realize sigma * prod_i T_cell_i^{m_i} * S_0^{e0} S_1^{e1} S_2^{e2} as an explicit
+    operator product of central cell translations and residual movers on `ring`."""
+    net = net_of(word)
+    sigma = sigma_of(word)
+    eps = tuple(n % 2 for n in net)
+    if m_override is None:
+        m = tuple((net[i] - eps[i]) // 2 for i in range(3))
+    else:
+        m = m_override
+    ones_ring = np.ones(ring**3, dtype=np.int64)
+    factors = []
+    for i in range(3):
+        if m[i] != 0:
+            factors.append((cell_shift_perm(ring, idxmap, i, 2 * m[i]), ones_ring))
+    for i in range(3):
+        if eps[i] == 1:
+            factors.append((permL[(i, +1)], signL[(i, +1)]))
+    P, Sg = _compose_signed(factors, ring)
+    return P, sigma * Sg
+
+
+def measured_support6(word):
+    """Site-level per-axis support on the L=6 ring (aliasing-free)."""
+    cur = np.arange(L6**3)
+    for l in reversed(word):
+        cur = perm6[l][cur]
+    disp = (coords6_arr[cur] - coords6_arr) % L6
+    return tuple(int(np.any(disp[:, axis] != 0)) for axis in range(3))
+
+
+# ---------------------------------------------------------------------------
+# The 24 proper cubic rotations as 3x3 integer signed permutations (det +1).
+NN = [(1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)]
+nn_index = {o: i for i, o in enumerate(NN)}
+
+rotations = []
+for _perm in itertools.permutations(range(3)):
+    for _signs in itertools.product((1, -1), repeat=3):
+        R = np.zeros((3, 3), dtype=int)
+        for i in range(3):
+            R[i, _perm[i]] = _signs[i]
+        if round(float(np.linalg.det(R))) == 1:
+            rotations.append(R)
+
+
+def rotate_offset(R, offset):
+    return tuple(int(v) for v in (R @ np.array(offset)))
+
+
+rot_perms = [
+    tuple(nn_index[rotate_offset(R, o)] for o in NN) for R in rotations
+]
+
+
+def rotate_profile(profile, rperm):
+    """(c o R)[i] = c(R o_i): read the slot the rotation carries i into."""
+    return tuple(profile[rperm[i]] for i in range(6))
+
+
+PROFILES = list(itertools.product((0, 1), repeat=6))
+
+
+def variation_set(rule):
+    """Slots d where flipping only slot d can change the rule value."""
+    varied = set()
+    for c in PROFILES:
+        for d in range(6):
+            cp = list(c)
+            cp[d] ^= 1
+            if rule(c) != rule(tuple(cp)):
+                varied.add(d)
+    return varied
+
+
+# ---------------------------------------------------------------------------
+heading("Group A -- REAL3 realization surface: six decorated movers + cubic rotations")
+
+site_letter = {l: site_shift(l[0], l[1], decorated=True) for l in LETTERS}
+eye64 = np.eye(L**3)
+
+site_unit = max(
+    np.max(np.abs(site_letter[l] @ site_letter[l].conj().T - eye64)) for l in LETTERS
+)
+bloch_unit = max(
+    np.max(np.abs(bloch_fn[l](kvec) @ bloch_fn[l](kvec).conj().T - np.eye(8)))
+    for l in LETTERS
+    for kvec in K
+)
+check(
+    "A1 six decorated movers unitary at site (64) and across the Bloch grid",
+    site_unit < TOL and bloch_unit < 1e-10,
+    f"site={site_unit:.2e} bloch={bloch_unit:.2e}",
+)
+
+anti = 0.0
+for l in LETTERS:
+    for m in LETTERS:
+        if l[0] != m[0]:
+            anti = max(
+                anti,
+                np.max(np.abs(site_letter[l] @ site_letter[m] + site_letter[m] @ site_letter[l])),
+            )
+check(
+    "A2 cross-axis letters anticommute at site level (including inverse letters)",
+    anti < 1e-12,
+    f"max|{{S_a,S_b}}|={anti:.2e}",
+)
+
+sq_err = max(
+    np.max(np.abs(site_letter[(i, +1)] @ site_letter[(i, +1)] - T_cell[i])) for i in range(3)
+)
+central = 0.0
+for i in range(3):
+    for l in LETTERS:
+        central = max(
+            central, np.max(np.abs(T_cell[i] @ site_letter[l] - site_letter[l] @ T_cell[i]))
+        )
+check(
+    "A3 S_i^2 equals the independently built cell translation, which is central",
+    sq_err < TOL and central < TOL,
+    f"square={sq_err:.2e} central={central:.2e}",
+)
+
+inv_unit = max(
+    np.max(np.abs(site_letter[(i, +1)] @ site_letter[(i, +1)].conj().T - eye64)) for i in range(3)
+)
+inv_match = max(
+    np.max(np.abs(site_letter[(i, -1)] - site_letter[(i, +1)].conj().T)) for i in range(3)
+)
+check(
+    "A4 forward mover unitary and the inverse letter equals its adjoint",
+    inv_unit < TOL and inv_match < TOL,
+    f"unit={inv_unit:.2e} adjoint={inv_match:.2e}",
+)
+
+proper = all(
+    np.array_equal(R @ R.T, np.eye(3, dtype=int)) and round(float(np.linalg.det(R))) == 1
+    for R in rotations
+)
+orbit = {rperm[0] for rperm in rot_perms}
+products = set()
+closed = True
+for R1 in rotations:
+    for R2 in rotations:
+        Rp = R1 @ R2
+        if not (
+            np.array_equal(Rp @ Rp.T, np.eye(3, dtype=int))
+            and round(float(np.linalg.det(Rp))) == 1
+        ):
+            closed = False
+        products.add(tuple(int(v) for v in Rp.flatten()))
+distinct = len({tuple(int(v) for v in R.flatten()) for R in rotations})
+check(
+    "A5 twenty-four proper cubic rotations, closed, transitive on the six NN offsets",
+    len(rotations) == 24
+    and proper
+    and orbit == set(range(6))
+    and closed
+    and distinct == 24
+    and len(products) == 24,
+    f"|G|={len(rotations)} orbit={sorted(orbit)} distinct={distinct}",
+)
+
+# ---------------------------------------------------------------------------
+heading("Group B -- Theorem 3B1: covariance modulo local frames => zero modulus defect")
+
+F0 = site_shift(1, +1, decorated=True)  # decorated mover (kept for B2, B3)
+F0_bare = site_shift(1, +1, decorated=False)  # the exactly covariant bare shift F^{(0)}
+bare_cov_err = max(
+    np.max(np.abs(translations[a] @ F0_bare @ translations[a].conj().T - F0_bare))
+    for a in range(3)
+)
+g_frame = np.diag([(-1.0) ** (x[0] * x[1]) for x in coords]).astype(complex)
+recon_err = np.max(np.abs(g_frame @ F0_bare @ g_frame.conj().T - F0))
+dec_noncov_gap = max(
+    np.max(np.abs(translations[a] @ F0 @ translations[a].conj().T - F0))
+    for a in range(3)
+)
+mod_defect = factor_translation_defect(F0)
+check(
+    "B1 decorated mover = g F^{(0)} g^dag with F^{(0)} the exactly covariant bare shift; the decorated mover itself is not translation-covariant (gap>1); zero modulus defect",
+    bare_cov_err < 1e-12 and recon_err < 1e-12 and dec_noncov_gap > 1.0 and mod_defect < TOL,
+    f"bare_cov={bare_cov_err:.2e} recon={recon_err:.2e} dec_noncov_gap={dec_noncov_gap:.2f} modulus_defect={mod_defect:.2e}",
+)
+
+theta = np.array([(0.10 + 0.85 * rank) % np.pi for rank in range(L**3)])
+g = np.diag(np.exp(1j * theta))
+F_frame = g @ F0 @ g.conj().T
+frame_defect = factor_translation_defect(F_frame)
+check(
+    "B2 an arbitrary local-frame decoration preserves zero modulus defect",
+    frame_defect < 1e-12,
+    f"defect={frame_defect:.2e}",
+)
+
+mod_match = np.max(np.abs(np.abs(F_frame) - np.abs(F0)))
+check(
+    "B3 the frame decoration is modulus-blind (|F| equals |F0| entrywise)",
+    mod_match < 1e-12,
+    f"max||F|-|F0||={mod_match:.2e}",
+)
+
+givens = np.eye(L**3, dtype=complex)
+for x0 in range(L):
+    for x2 in range(L):
+        for lo, hi, angle in [(0, 1, 0.3), (2, 3, 0.9)]:
+            a = site_idx[(x0, lo, x2)]
+            b = site_idx[(x0, hi, x2)]
+            c, s = np.cos(angle), np.sin(angle)
+            givens[a, a] = c
+            givens[b, b] = c
+            givens[a, b] = -s
+            givens[b, a] = s
+giv_unit = np.max(np.abs(givens @ givens.conj().T - eye64))
+giv_support = factor_support_vector([givens])
+giv_defect = factor_translation_defect(givens)
+check(
+    "B4 a site-dependent axis-1 Givens rotation is unitary and NN-supported but has positive modulus defect",
+    giv_unit < TOL and giv_support == (0, 1, 0) and giv_defect > 0.05,
+    f"unit={giv_unit:.2e} support={giv_support} defect={giv_defect:.3f}",
+)
+
+D_alt = np.diag([(-1.0) ** x[1] for x in coords])
+dalt_defect = factor_translation_defect(D_alt)
+frame_inv = np.max(np.abs(g @ D_alt @ g.conj().T - D_alt))
+t1_conj = translations[1] @ D_alt @ translations[1].conj().T
+sign_flip = np.max(np.abs(t1_conj - (-D_alt)))
+gap = np.max(np.abs(-D_alt - D_alt))
+check(
+    "B5 a covariant-modulus diagonal that translations sign-flip: zero defect, frame-invariant, not covariant",
+    dalt_defect < TOL and frame_inv < 1e-12 and sign_flip < 1e-12 and gap > 1.0,
+    f"defect={dalt_defect:.2e} frame_inv={frame_inv:.2e} flip={sign_flip:.2e} gap={gap:.2f}",
+)
+
+bare = site_shift(1, +1, decorated=False)
+bare_defect = factor_translation_defect(bare)
+check(
+    "B6 the undecorated bare shift also has zero modulus defect (the functional is not spuriously positive)",
+    bare_defect < TOL,
+    f"defect={bare_defect:.2e}",
+)
+
+# ---------------------------------------------------------------------------
+heading("Group C -- Theorem 3B2: rotation transitivity forces all-axis support")
+
+
+def rule_parity(profile):
+    return frozenset({0, 1}) if sum(profile) % 2 == 0 else frozenset({0})
+
+
+def rule_slot0(profile):
+    return frozenset({0, 1}) if profile[0] == 1 else frozenset({0})
+
+
+def is_rotation_covariant(rule):
+    for c in PROFILES:
+        base = rule(c)
+        for rperm in rot_perms:
+            if rule(rotate_profile(c, rperm)) != base:
+                return False
+    return True
+
+
+cov_parity = is_rotation_covariant(rule_parity)
+var_parity = variation_set(rule_parity)
+check(
+    "C1 the parity availability rule B is rotation-covariant and varies at slot 0",
+    cov_parity and 0 in var_parity,
+    f"covariant={cov_parity} slot0_in_V={0 in var_parity}",
+)
+orbit0 = {rperm[0] for rperm in rot_perms}
+check(
+    "C2 rotation transport carries slot 0 to all six NN directions, and the covariant parity rule varies on exactly that orbit",
+    orbit0 == set(range(6)) and var_parity == orbit0,
+    f"orbit0={sorted(orbit0)} V(B)={sorted(var_parity)}",
+)
+
+cov_slot0 = is_rotation_covariant(rule_slot0)
+var_slot0 = variation_set(rule_slot0)
+check(
+    "C3 control: a single-slot rule varies only at slot 0 and is NOT rotation-covariant",
+    var_slot0 == {0} and not cov_slot0,
+    f"V(B')={sorted(var_slot0)} covariant={cov_slot0}",
+)
+
+support_all = factor_support_vector(
+    [site_letter[(0, +1)], site_letter[(1, +1)], site_letter[(2, +1)]]
+)
+check(
+    "C4 the all-axis mover set (S_1,S_2,S_3) has full constituent-factor support",
+    support_all == (1, 1, 1),
+    f"support={support_all}",
+)
+
+support_same = factor_support_vector([site_letter[(0, +1)], site_letter[(0, +1)]])
+check(
+    "C5 a same-axis mover pair (S_1,S_1) supports only its own axis",
+    support_same == (1, 0, 0),
+    f"support={support_same}",
+)
+
+# ---------------------------------------------------------------------------
+heading("Group D -- Theorem 3B3: normal form, support law, dispersiveness dichotomy")
+
+all_words = []
+for length in range(1, 6):
+    for w in itertools.product(LETTERS, repeat=length):
+        all_words.append(w)
+
+d1_bad = d2_bad = d3_bad = 0
+for w in all_words:
+    net = net_of(w)
+    perm_direct, sign_direct = direct_signed_12(w)
+    perm_normal, sign_normal = normal_form_op(w, L12, idx12, perm12, sign12)
+    if not (
+        np.array_equal(perm_direct, perm_normal)
+        and np.array_equal(sign_direct, sign_normal)
+    ):
+        d1_bad += 1
+    predicted = tuple(int(net[a] != 0) for a in range(3))
+    if measured_support6(w) != predicted:
+        d2_bad += 1
+    disp = word_dispersion(w)
+    should_be_flat = net == (0, 0, 0)
+    if should_be_flat:
+        if disp >= 1e-8:
+            d3_bad += 1
+    else:
+        if disp <= 1e-6:
+            d3_bad += 1
+
+check(
+    "D1 exact normal form W = sigma * prod T_cell^m * residual movers (all 9330 words, len<=5)",
+    len(all_words) == 9330 and d1_bad == 0,
+    f"words={len(all_words)} mismatches={d1_bad}",
+)
+
+w_reject = ((0, +1),) * 4  # S_0^4: net=(4,0,0), true m=(2,0,0)
+m_bad = (4, 0, 0)  # perturb m_0 by +2
+pd12, sd12 = direct_signed_12(w_reject)
+pb12, sb12 = normal_form_op(w_reject, L12, idx12, perm12, sign12, m_override=m_bad)
+caught_12 = not (np.array_equal(pd12, pb12) and np.array_equal(sd12, sb12))
+pd4, sd4 = direct_signed(w_reject)
+pb4, sb4 = normal_form_op(w_reject, L, site_idx, perm4, sign4, m_override=m_bad)
+aliases_4 = np.array_equal(pd4, pb4) and np.array_equal(sd4, sb4)
+check(
+    "D1R a wrong central exponent m_i is caught on L=12 but aliases to identity on L=4 (m_i is load-bearing)",
+    caught_12 and aliases_4,
+    f"caught_on_L12={caught_12} aliases_on_L4={aliases_4}",
+)
+check(
+    "D2 support law on the aliasing-free L=6 ring: axis-i occupied iff net_i != 0 (all 9330 words)",
+    d2_bad == 0,
+    f"mismatches={d2_bad}",
+)
+check(
+    "D3 dispersiveness dichotomy: Bloch char-poly flat (<1e-8) iff net displacement is (0,0,0) (all 9330 words)",
+    d3_bad == 0,
+    f"anomalies={d3_bad}",
+)
+
+witnesses = [
+    (((0, +1), (1, +1), (0, -1), (1, -1), (2, +1), (2, -1)), (0, 0, 0), -1, True),
+    (((0, +1), (0, -1), (1, +1), (1, -1), (2, +1), (2, -1)), (0, 0, 0), +1, True),
+    (((0, +1), (1, +1), (2, +1), (0, +1), (1, +1), (2, +1)), (2, 2, 2), -1, False),
+    (((0, +1), (0, +1), (1, +1), (1, +1), (2, +1), (2, +1)), (2, 2, 2), +1, False),
+    (((0, +1), (2, +1), (1, +1), (1, -1), (2, -1), (0, -1)), (0, 0, 0), +1, True),
+]
+d4_bad = 0
+for word, exp_net, exp_sigma, exp_flat in witnesses:
+    perm_direct, sign_direct = direct_signed_12(word)
+    perm_normal, sign_normal = normal_form_op(word, L12, idx12, perm12, sign12)
+    ok = (
+        net_of(word) == exp_net
+        and sigma_of(word) == exp_sigma
+        and np.array_equal(perm_direct, perm_normal)
+        and np.array_equal(sign_direct, sign_normal)
+    )
+    if exp_flat:
+        ok = (
+            ok
+            and np.array_equal(perm_direct, np.arange(L12**3))
+            and np.array_equal(sign_direct, exp_sigma * np.ones(L12**3, dtype=np.int64))
+        )
+        dense = max(
+            np.max(np.abs(bloch_word(word, kvec) - exp_sigma * np.eye(8))) for kvec in K
+        )
+        ok = ok and dense < 1e-12
+    else:
+        ok = ok and word_dispersion(word) > 1e-6
+    if not ok:
+        d4_bad += 1
+check(
+    "D4 five named length-6 witnesses: exact normal form, net, sign, and +-I / dispersive value",
+    d4_bad == 0,
+    f"failed_witnesses={d4_bad}",
+)
+
+pc_defect = protocol_factor_modulus_defect("P_CANCEL")
+pc_support = factor_support_vector(protocols["P_CANCEL"]["site_factors"])
+pc_identity = np.max(np.abs(site_protocol("P_CANCEL") - eye64))
+pc_disp = protocol_dispersion("P_CANCEL")
+check(
+    "D5 P_CANCEL separates the filters: zero modulus defect, full support, composite identity, flat",
+    pc_defect < TOL and pc_support == (1, 1, 1) and pc_identity < TOL and pc_disp < 1e-8,
+    f"defect={pc_defect:.2e} support={pc_support} identity={pc_identity:.2e} disp={pc_disp:.2e}",
+)
+
+pw_support = factor_support_vector(protocols["P_WEIGHT"]["site_factors"])
+pw_disp = protocol_dispersion("P_WEIGHT")
+pw_defect = protocol_factor_modulus_defect("P_WEIGHT")
+check(
+    "D6 P_WEIGHT (net (2,1,1)) has full support, zero modulus defect, and is dispersive",
+    pw_support == (1, 1, 1) and pw_disp > 1e-7 and pw_defect < TOL,
+    f"support={pw_support} disp={pw_disp:.2e} defect={pw_defect:.2e}",
+)
+
+id_disp = word_dispersion(())
+s1_disp = word_dispersion(((0, +1),))
+
+
+def signed_matrix(word):
+    perm, sign = direct_signed(word)
+    M = np.zeros((L**3, L**3))
+    for col in range(L**3):
+        M[perm[col], col] = sign[col]
+    return M
+
+
+reorder_gap = np.max(
+    np.abs(signed_matrix(((0, +1), (1, +1))) - signed_matrix(((1, +1), (0, +1))))
+)
+check(
+    "D7 identity flat, single mover dispersive, and dropping the anticommutation sign is detectable",
+    id_disp < 1e-8 and s1_disp > 1e-3 and reorder_gap > 1.0,
+    f"id={id_disp:.2e} s1={s1_disp:.3f} reorder_gap={reorder_gap:.2f}",
+)
+
+
+def first_failing_filter(name):
+    if protocol_factor_modulus_defect(name) >= TOL:
+        return "defect"
+    if factor_support_vector(protocols[name]["site_factors"]) != (1, 1, 1):
+        return "support"
+    if protocol_dispersion(name) <= 1e-7:
+        return "dispersion"
+    return "survivor"
+
+
+attribution = {}
+for name in protocols:
+    attribution.setdefault(first_failing_filter(name), set()).add(name)
+check(
+    "D8 the three filters jointly retain the four-member necessary-condition survivor set",
+    attribution.get("survivor") == {"P_SYM", "P_SYM_OCT", "P_REORDER", "P_WEIGHT"},
+    f"survivors={sorted(attribution.get('survivor', set()))}",
+)
+check(
+    "D9 ordered filters attribute each rejection to its first-failing stage (defect/support/dispersion)",
+    attribution.get("defect") == {"P_MIX4", "P_STAIR", "P_PAIRFLAT"}
+    and attribution.get("support") == {"P_AXIS", "P_DIAG"}
+    and attribution.get("dispersion") == {"P_CANCEL"},
+    f"defect={sorted(attribution.get('defect', set()))} "
+    f"support={sorted(attribution.get('support', set()))} "
+    f"dispersion={sorted(attribution.get('dispersion', set()))}",
+)
+
+# ---------------------------------------------------------------------------
+heading("Group E -- source-note quote pins (fabrication + framing gates)")
+
+repo = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+note_path = os.path.join(
+    repo,
+    "docs",
+    "PROTOCOL_ADMISSIBILITY_3D_REALIZATION_BRIDGE_AND_WORD_DISPERSIVENESS_NARROW_THEOREM_NOTE_2026-07-10.md",
+)
+axioms_path = os.path.join(repo, "docs", "MINIMAL_AXIOMS_2026-06-29.md")
+parent_path = os.path.join(
+    repo,
+    "docs",
+    "KINETIC_ISOTROPY_3D_FACTORIZED_PROTOCOL_SELECTION_ON_ANALYZED_CLASSES_BOUNDED_THEOREM_NOTE_2026-07-09.md",
+)
+
+
+def _norm(text):
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+note_norm = _norm(_read(note_path))
+axioms_norm = _norm(_read(axioms_path))
+parent_norm = _norm(_read(parent_path))
+
+CLAUSE_1 = (
+    "There is one fixed nearest-neighbor admissibility rule, covariant under "
+    "lattice translations and proper cubic rotations."
+)
+CLAUSE_2 = (
+    "For each site, the available possibilities are determined by, and vary "
+    "with, the nearest-neighbor conditions."
+)
+SUPPLIED_1 = (
+    "translation covariance of the fixed rule requires each constituent factor "
+    "to be fully covariant modulo local"
+)
+SUPPLIED_2 = "dispersive in the characteristic-polynomial sense used by the runner"
+
+e1 = _norm(CLAUSE_1) in axioms_norm and _norm(CLAUSE_2) in axioms_norm
+check(
+    "E1 both admissibility clause sentences are present verbatim in the axioms file",
+    e1,
+    "axiom clauses anchored" if e1 else "MISSING axiom clause",
+)
+
+e2 = (
+    _norm(CLAUSE_1) in note_norm
+    and _norm(CLAUSE_2) in note_norm
+    and "necessary consequences" in note_norm
+)
+check(
+    "E2 the note quotes both axiom clauses and frames its results as necessary consequences",
+    e2,
+    "note clauses + framing present" if e2 else "MISSING note clause/framing",
+)
+
+e3 = (
+    _norm(SUPPLIED_1) in note_norm
+    and _norm(SUPPLIED_2) in note_norm
+    and _norm(SUPPLIED_1) in parent_norm
+    and _norm(SUPPLIED_2) in parent_norm
+)
+check(
+    "E3 the two supplied-input fragments appear in the note and are anchored verbatim in the parent selection note",
+    e3,
+    "supplied inputs anchored in parent" if e3 else "MISSING supplied input",
+)
+
+FORBIDDEN = [
+    "only route",
+    "last route",
+    "exhausted",
+    "closes the route",
+    "owner-directed",
+    "retained",
+    "audited_clean",
+    "audited_conditional",
+    "unaudited",
+    "audit_ledger",
+    "is sufficient",
+    "sufficient for",
+    "clean grade",
+    "passes the audit",
+    "np.random",
+    "import random",
+    "datetime.now",
+    "time.time",
+]
+note_low = note_norm.lower()
+present = [token for token in FORBIDDEN if token.lower() in note_low]
+check(
+    "E4 the note is free of forbidden status/framing/nondeterminism language",
+    not present,
+    "clean" if not present else f"PRESENT: {present}",
+)
+
+print(f"\nTOTAL: PASS={PASS} FAIL={FAIL}")
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## What this responds to

The `audited_conditional` ledger row
`kinetic_isotropy_3d_factorized_protocol_selection_on_analyzed_classes_bounded_theorem_note_2026-07-09`
carries the recorded prescription:

> missing_bridge_theorem: derive and audit the supplied 3D protocol-Admissibility
> and composite-word-dispersiveness bridge, then re-audit after the direct
> unaudited theorem dependencies reach retained grade.

This PR supplies that bridge. It is **Wave B**; the Wave A tick-Admissibility
realization bridge (`TICK_ADMISSIBILITY_REALIZATION_BRIDGE_CLAUSE_TO_PREDICATE_NARROW_THEOREM_NOTE_2026-07-10`)
landed earlier.

## What changed

One note + one paired runner + one cache (source-only triple):

- `docs/PROTOCOL_ADMISSIBILITY_3D_REALIZATION_BRIDGE_AND_WORD_DISPERSIVENESS_NARROW_THEOREM_NOTE_2026-07-10.md`
- `scripts/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.py`
- `logs/runner-cache/protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_2026_07_10.txt`

The note derives both supplied inputs as theorems from the two Admissibility
clauses plus a named realization predicate `REAL3`, rather than leaving them as
separately supplied physical readings:

- **3B1** — factor covariance mod local U(1) frames ⟹ zero site-modulus
  translation defect. The exactly translation-covariant object is the bare
  one-site shift `F^(0)`; the decorated mover `g F^(0) g†` is itself **not**
  covariant (translation gap 2), so the covariance is a real, discriminating
  property.
- **3B2** — the 24 proper cubic rotations act transitively on the 6 NN offsets
  ⟹ all-axis factor support.
- **3B3** — exact operator normal form
  `W = σ · ∏_i T_cell_i^{m_i} · S_0^{e0} S_1^{e1} S_2^{e2}`, the support law
  (axis-i occupied ⟺ net_i ≠ 0), and the char-poly dispersiveness dichotomy
  (Bloch char-poly flat ⟺ net = (0,0,0), including the pure-central-phase branch).

## Runner

`TOTAL: PASS=30 FAIL=0` (elapsed ~3s). Load-bearing discriminating gates:

- **D1R** — a wrong central exponent `m_i` is caught on the aliasing-free L=12
  ring but aliases to identity on L=4 (`T_cell² = I` there), so `m_i` is
  load-bearing, not decorative.
- **D2** — support law verified on the L=6 ring, which is wraparound-free for
  length ≤ 5 words (`|net_i| ≤ 5 < 6`).
- **C3** — non-covariant single-slot control (complements the C2 all-axis
  transport check).
- **D9** — ordered first-failing-filter attribution (defect → support →
  dispersion) for each rejected candidate.

Went through an independent GPT-5.6-sol (max reasoning) adversarial review
before this PR was opened; all raised defects were fixed and re-verified.

## Downstream order

Per the prescription, re-audit of the selector/selection rows follows once the
direct unaudited theorem dependencies reach retained grade. Grades are set
exclusively by the independent audit lane on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
