### PR TITLE
Make the AC occupancy determinant split self-contained

### DIFF
--- a/docs/ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md
@@ -1,152 +1,111 @@
-# AC_phi_lambda Occupancy Determinant-Power Split Exact Support
+# Complex Determinant and Realification Determinant Power
 
-**Date:** 2026-07-04
-**Claim type:** bounded_theorem
-**Status:** source-side exact support; independent audit required before any
-effective-status change. This note does not derive `r = 1/2`, does not choose
-the orbit/holomorphic horn, does not adopt the orbit-occupancy premise, does
-not introduce a K-real primitive, does not retire `AC_phi_lambda` or
-`AC_phi_lambda(i)`, and does not edit any Tier-A registry, axiom, primitive,
-audit verdict, or publication surface.
-**Current-main posture (2026-07-06):** live `main` now records Tier-A count
-zero: theta was retired 2026-07-05 by retained derivation, and
-`AC_phi_lambda` was retired by owner-governance adoption. This note banks the
-historical determinant-power split support only; it does not reopen, modify,
-or re-grade either retirement record, `tier_a_admissions.json`, or
-owner-governed premise data.
+**Date:** 2026-07-04; exact supplier repair 2026-07-11
+**Claim type:** positive_theorem
+**Status authority:** independent audit lane. This source proposal does not
+set or predict an audit verdict.
 **Primary runner:**
 [`scripts/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.py`](../scripts/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.py)
 **Runner cache:**
 [`logs/runner-cache/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.txt`](../logs/runner-cache/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.txt)
 
-## Target
+## Exact theorem
 
-The July 4 hygiene reclassified the per-lane `r` value of
-`AC_phi_lambda(i)` to realized-state registration. The live Tier-A residual is
-now narrower:
+Let `K=X+iY` be an `n x n` complex matrix, with `X` and `Y` real, and let
 
 ```text
-which grain/statistics the matter action implements:
-sector-tied/count-twice or orbit/holomorphic/count-once
+R(K) = [[X,-Y],
+        [Y, X]]
 ```
 
-The first-order staggered determinant theorem already shows that the
-one-component staggered matter measure gives a first-order holomorphic
-generation determinant and that count-twice behavior appears on the K-real
-restriction `c = conj(b)`. Current-main no-supply packets correctly block the
-shortcut from determinant or Record/axiom support to immediate retirement. This
-note adds the missing reusable algebraic support underneath the fork: for any
-complex kernel, the realified count is
-exactly the squared-modulus determinant, while the holomorphic Berezin count is
-the complex determinant to first power.
-
-## Exact Statement
-
-Let `K = X + iY` be an `n x n` complex matrix, with `X` and `Y` real. Its real
-linear representation is
+be its realification. Then
 
 ```text
-R(K) = [[X, -Y],
-        [Y,  X]].
+det_R R(K)
+  = det_C(K) det_C(conjugate(K))
+  = |det_C(K)|^2.
 ```
 
-Then
+With the displayed Berezin ordering convention, the holomorphic Gaussian on
+independent Grassmann variables satisfies
 
 ```text
-det_R R(K) = det_C(K) * conjugate(det_C(K)) = |det_C(K)|^2.
+integral d(chibar_n)d(chi_n)...d(chibar_1)d(chi_1)
+         exp(sum_ij chibar_i K_ij chi_j)
+  = det_C(K).
 ```
 
-The runner proves this symbolically for a generic `2 x 2` complex kernel and
-checks the scalar and scaling cases exactly. It also computes the holomorphic
-Berezin Gaussian directly by exterior algebra and obtains
+Thus a complex Gaussian determinant and the determinant of its realification
+carry first and second determinant powers, respectively.
+
+## Proof of the realification identity
+
+Complexify the real `2n`-dimensional representation. The invertible complex
+change of basis
 
 ```text
-Integral exp(chibar K chi) = det_C(K)
+S = [[I, iI],
+     [I,-iI]]
 ```
 
-to the first power. Therefore the count-once/count-twice binary is a
-determinant-power binary:
+intertwines `R(K)` with the block diagonal matrix
 
-| Reading | Kernel object | Determinant power | Slot interpretation |
-|---|---|---|---|
-| Holomorphic/orbit | `K` complex-linear | `det_C(K)` | one complex/K-orbit slot |
-| Realified/sector-tied | `R(K)` real-linear | `|det_C(K)|^2` | two real sector slots |
+```text
+diag(K,conjugate(K)).
+```
 
-The same identity is the abstract reason the C3 first-order theorem localizes
-count-twice to `c = conj(b)`: imposing the K-real/tied section turns the
-holomorphic independent variables into a conjugate pair and supplies the
-mixed `b*bbar` term. With `c` independent the determinant is holomorphic; on
-the tied section it is squared-modulus/count-twice data.
+Determinant is invariant under similarity, so
 
-## What Moves
+```text
+det_R R(K)
+  = det_C K det_C(conjugate(K))
+  = det_C K conjugate(det_C K).
+```
 
-This block strengthens the AC(i) route map:
+The result is real and nonnegative. No invertibility assumption is needed;
+the identity is polynomial and includes singular matrices.
 
-1. The remaining occupancy atom is not an unexplained phrase. It is exactly
-   the choice between a complex determinant counted once and its realified
-   determinant counted twice.
-2. The determinant-power split is source-side algebra, independent of fitted
-   lepton values or owner governance.
-3. The first-order staggered determinant theorem and the current-main
-   no-supply packets are reconciled: the first-order theorem supplies the
-   holomorphic branch as valid route material; the no-go boundary remains
-   correct because a physical theorem must still select that branch as the
-   matter action's readout.
+## Berezin determinant power
 
-## What Does Not Move
+Expand the Grassmann exponential. Terms beyond degree `2n` vanish. The top
+degree coefficient is the alternating sum over permutations of the matrix
+entries, which is `det_C(K)`. The displayed integration ordering extracts that
+coefficient with positive sign. The companion runner performs this exterior
+algebra calculation directly for a generic `2 x 2` kernel.
 
-- `AC_phi_lambda` is not retired.
-- `AC_phi_lambda(i)` is not retired.
-- The orbit/holomorphic horn is not selected.
-- The sector/K-real horn is not selected.
-- `r = 1/2` is not derived, predicted, or preferred.
-- The orbit-occupancy premise candidate is not adopted.
-- No physical generation Yukawa coupling form is derived.
-- No K/CPT-site-basis physical predicate is derived.
-- No registry, primitive, axiom, audit status, or publication status is edited.
-- `AC_phi_lambda(ii)` / R-eta and theta are untouched.
+## Exact checks
 
-## Relation To Existing Blocks
+The runner verifies:
 
-- [`ACPHILAMBDA_OCCUPANCY_SELECTION_REALIZED_STATE_REDUCTION_NOTE_2026-06-11.md`](ACPHILAMBDA_OCCUPANCY_SELECTION_REALIZED_STATE_REDUCTION_NOTE_2026-06-11.md)
-  reclassifies the value face and names the measure-side realization binary as
-  the survivor. This note supplies exact determinant-power support for that
-  survivor.
-- [`KOIDE_STAGGERED_FIRST_ORDER_GENERATION_DETERMINANT_BOUNDED_THEOREM_NOTE_2026-06-11.md`](KOIDE_STAGGERED_FIRST_ORDER_GENERATION_DETERMINANT_BOUNDED_THEOREM_NOTE_2026-06-11.md)
-  computes the staggered surface and localizes the count-twice term to
-  `c = conj(b)`. This note abstracts the same fork as
-  `det_C` versus `det_R(realification)`.
-- [`ACPHILAMBDA_MEASURE_BINARY_AXIOM_UPDATE_NO_GO_NOTE_2026-07-04.md`](ACPHILAMBDA_MEASURE_BINARY_AXIOM_UPDATE_NO_GO_NOTE_2026-07-04.md)
-  remains valid: axioms and approved primitives do not select the physical
-  matter-action statistics horn.
-- [`ACPHILAMBDA_OCCUPANCY_FORMATION_APPEND_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md`](ACPHILAMBDA_OCCUPANCY_FORMATION_APPEND_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md)
-  remains valid: Record formation/additivity does not identify the occupancy
-  dictionary or formation rule.
-- [`CHARGED_LEPTON_VALUE_REDUCES_TO_ONE_COUNTING_BIT_SYNTHESIS_NOTE_2026-06-05.md`](CHARGED_LEPTON_VALUE_REDUCES_TO_ONE_COUNTING_BIT_SYNTHESIS_NOTE_2026-06-05.md)
-  and [`GENERATION_WEIGHT_DIAL_STRUCTURE_2026-06-05.md`](GENERATION_WEIGHT_DIAL_STRUCTURE_2026-06-05.md)
-  already identify the value-facing fork as `det_C`/block-count versus
-  `det_R`/dimension. This note makes the determinant-power identity explicit.
+- the generic symbolic `2 x 2` realification identity;
+- scalar, diagonal, singular, and exact `3 x 3` instances;
+- first-power versus second-power scaling;
+- the generic `2 x 2` Berezin Gaussian coefficient;
+- the phase sensitivity of `det_C(K)` and phase blindness of
+  `det_R R(K)`;
+- source guards that keep the physical AC(i) selector and `r` outside this
+  theorem.
 
-## Remaining Live Routes
+## Charged-lepton scope boundary
 
-1. **Physical horn-selection theorem.** Derive that the actual matter action
-   implements the holomorphic/K-orbit readout or the realified/K-real readout.
-2. **Physical coupling theorem.** Derive the relevant generation coupling
-   channel rather than supplying a probe kernel.
-3. **K/CPT-site-basis bridge.** Derive the physical antiunitary predicate whose
-   tied section is being read.
-4. **Durability or governance route.** Adopt a narrow owner-ratified premise if
-   derivation is not required.
-5. **R-eta route.** Separately derive the density-read-as-angle identification.
+This theorem supplies the determinant-power fork used to state AC(i)
+precisely. It does not identify the physical charged-lepton matter carrier
+with the complex Gaussian or its realification. It does not select a
+K/CPT-orbit occupancy grain, establish a path-integral measure, choose a
+physical action, register or predict `r`, force `r=1/2`, derive `delta`, or
+supply the R-eta readout license.
+
+The two mathematical determinant constructions are both present in the
+theorem. A separate physical carrier theorem or an explicitly governed premise
+is required before either construction can be used as the charged-lepton
+occupancy rule.
 
 ## Verification
 
 Run:
 
 ```bash
-PYTHONPATH=scripts python3 scripts/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.py
+python3 scripts/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.py
 ```
 
-Expected close: `FAIL=0`.
-
-**Independent audit required.** This note asserts no effective-status change.
+Expected result: `PASS=16`, `FAIL=0`.

--- a/docs/ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md
@@ -31,9 +31,12 @@ independent Grassmann variables satisfies
 
 ```text
 integral d(chibar_n)d(chi_n)...d(chibar_1)d(chi_1)
-         exp(sum_ij chibar_i K_ij chi_j)
+         exp(-sum_ij chibar_i K_ij chi_j)
   = det_C(K).
 ```
+
+Here integration is the standard left Berezin derivative, normalized by
+`integral d(theta) theta = 1`, with the rightmost differential acting first.
 
 Thus a complex Gaussian determinant and the determinant of its realification
 carry first and second determinant powers, respectively.
@@ -67,11 +70,13 @@ the identity is polynomial and includes singular matrices.
 
 ## Berezin determinant power
 
-Expand the Grassmann exponential. Terms beyond degree `2n` vanish. The top
+Expand the Grassmann exponential. Terms beyond degree `2n` vanish. With the
+displayed differential ordering and the minus sign in the exponent, the top
 degree coefficient is the alternating sum over permutations of the matrix
-entries, which is `det_C(K)`. The displayed integration ordering extracts that
-coefficient with positive sign. The companion runner performs this exterior
-algebra calculation directly for a generic `2 x 2` kernel.
+entries, which is `det_C(K)`. The companion runner performs this exterior
+algebra calculation directly for generic `1 x 1`, `2 x 2`, and `3 x 3`
+kernels. The odd-dimensional checks guard the sign convention that an even
+dimension alone would not detect.
 
 ## Exact checks
 
@@ -80,7 +85,7 @@ The runner verifies:
 - the generic symbolic `2 x 2` realification identity;
 - scalar, diagonal, singular, and exact `3 x 3` instances;
 - first-power versus second-power scaling;
-- the generic `2 x 2` Berezin Gaussian coefficient;
+- generic `1 x 1`, `2 x 2`, and `3 x 3` Berezin Gaussian coefficients;
 - the phase sensitivity of `det_C(K)` and phase blindness of
   `det_R R(K)`;
 - source guards that keep the physical AC(i) selector and `r` outside this
@@ -108,4 +113,4 @@ Run:
 python3 scripts/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.py
 ```
 
-Expected result: `PASS=16`, `FAIL=0`.
+Expected result: `PASS=18`, `FAIL=0`.

--- a/logs/runner-cache/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.py
-runner_sha256: c387a1736dabda11c3b04cc665bc701b679be7628bd8cf9cf2304634649bb324
+runner_sha256: 9459b8f7f3c643cde45696675e4b0986c4d0ec334ba65cc859abcad04863667c
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.40
+elapsed_sec: 0.68
 status: ok
 ----- stdout -----
 Complex determinant and realification determinant power
@@ -28,8 +28,10 @@ Part B: exact finite examples
 
 Part C: Berezin first power
 ---------------------------
+  [PASS] generic 1x1 top coefficient is det_C(K)  (k0)
   [PASS] generic 2x2 top coefficient is det_C(K)  (k00*k11 - k01*k10)
   [PASS] Berezin result has first determinant power
+  [PASS] generic 3x3 top coefficient is det_C(K)
 
 Scope guards
 ------------
@@ -38,6 +40,7 @@ Scope guards
   [PASS] source does not force r=1/2
 
 ================================================================
-TOTAL: PASS=16, FAIL=0
+TOTAL: PASS=18, FAIL=0
 
 ----- stderr -----
+

--- a/logs/runner-cache/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.txt
@@ -1,84 +1,43 @@
 ===== runner cache v1 =====
 runner: scripts/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.py
-runner_sha256: 42557c7048d6b28e6a0896d58c25e665693f9c521dd39633f3a486a7a7a1e866
+runner_sha256: c387a1736dabda11c3b04cc665bc701b679be7628bd8cf9cf2304634649bb324
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.51
+elapsed_sec: 0.40
 status: ok
 ----- stdout -----
-AC_phi_lambda occupancy determinant-power split exact support
-==============================================================================
+Complex determinant and realification determinant power
+================================================================
 
-------------------------------------------------------------------------------
-A - source and registry boundaries
-------------------------------------------------------------------------------
-PASS: exists: docs/ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md
-PASS: exists: docs/audit/data/tier_a_admissions.json
-PASS: exists: docs/ACPHILAMBDA_OCCUPANCY_SELECTION_REALIZED_STATE_REDUCTION_NOTE_2026-06-11.md
-PASS: exists: docs/KOIDE_STAGGERED_FIRST_ORDER_GENERATION_DETERMINANT_BOUNDED_THEOREM_NOTE_2026-06-11.md
-PASS: exists: docs/ACPHILAMBDA_MEASURE_BINARY_AXIOM_UPDATE_NO_GO_NOTE_2026-07-04.md
-PASS: exists: docs/ACPHILAMBDA_OCCUPANCY_FORMATION_APPEND_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
-PASS: exists: docs/CHARGED_LEPTON_VALUE_REDUCES_TO_ONE_COUNTING_BIT_SYNTHESIS_NOTE_2026-06-05.md
-PASS: exists: docs/GENERATION_WEIGHT_DIAL_STRUCTURE_2026-06-05.md
-PASS: exists: docs/MINIMAL_AXIOMS_2026-06-29.md
-PASS: exists: docs/REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md
-PASS: note declares bounded_theorem claim type
-PASS: runner path is wired in note
-PASS: note denies AC retirement
-PASS: note denies horn selection
-PASS: note denies premise and primitive adoption
-PASS: note denies registry/axiom/primitive/audit edits
-PASS: live Tier-A genuine count is zero
-PASS: canonical Tier-A IDs are empty on current main
-PASS: live derivation targets are empty on current main
-PASS: AC retired-target record is preserved
-PASS: AC retirement date is recorded -- {'date': '2026-07-05', 'mechanism': 'retired_by_owner_governance_on_audited_surface', 'owner_approval': 'In-thread approval for #4991 owner-governance adoption of the four Block49 residual candidates with the exact owner_governed_premise_nodes.json boundaries; current-main landing applies the registry delta only to the live AC_phi_lambda Tier-A target because theta was already retired by retained derivation.', 'owner_governed_premise_node': 'staggered_dirac_realization_gate_note_2026-05-03', 'adoption_source': 'docs/TIER_A_RESIDUAL_OWNER_ADOPTION_RETIREMENT_2026-07-04.md', 'audited_surface': 'docs/STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md audited_clean / retained_bounded on main at 5d8df21fe', 'adopted_residual_candidates': ['ac_orbit_occupancy_statistical_grain_premise', 'ac_reta_hclass_hunit_readout_premise'], 'boundary': 'Retires only the current minimum AC_phi_lambda Tier-A atoms: AC(i) matter-action occupancy grain and AC(ii) R-eta h-class/h-unit readout license. It supplies no value of r, delta, charged-lepton mass, mixing angle, probability rule, above-C3 taste/Dirac/chirality content, CKM/PMNS alignment, or sector-weight law.', 'non_laundering': 'This retirement is not an axiom, not an approved primitive, not a theorem derivation, and not an audit verdict. Source-side theorem/no-go packet statuses remain audit-lane-owned.'}
-PASS: AC retirement mechanism is owner governance -- {'date': '2026-07-05', 'mechanism': 'retired_by_owner_governance_on_audited_surface', 'owner_approval': 'In-thread approval for #4991 owner-governance adoption of the four Block49 residual candidates with the exact owner_governed_premise_nodes.json boundaries; current-main landing applies the registry delta only to the live AC_phi_lambda Tier-A target because theta was already retired by retained derivation.', 'owner_governed_premise_node': 'staggered_dirac_realization_gate_note_2026-05-03', 'adoption_source': 'docs/TIER_A_RESIDUAL_OWNER_ADOPTION_RETIREMENT_2026-07-04.md', 'audited_surface': 'docs/STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md audited_clean / retained_bounded on main at 5d8df21fe', 'adopted_residual_candidates': ['ac_orbit_occupancy_statistical_grain_premise', 'ac_reta_hclass_hunit_readout_premise'], 'boundary': 'Retires only the current minimum AC_phi_lambda Tier-A atoms: AC(i) matter-action occupancy grain and AC(ii) R-eta h-class/h-unit readout license. It supplies no value of r, delta, charged-lepton mass, mixing angle, probability rule, above-C3 taste/Dirac/chirality content, CKM/PMNS alignment, or sector-weight law.', 'non_laundering': 'This retirement is not an axiom, not an approved primitive, not a theorem derivation, and not an audit verdict. Source-side theorem/no-go packet statuses remain audit-lane-owned.'}
-PASS: historical AC decomposition preserves three old atoms -- ['reading_occupancy_selection', 'delta_readout_identification_R_eta', 'species_bridge']
-PASS: AC retired registry names reading/occupancy selection
-PASS: AC retirement boundary names occupancy grain
-PASS: note has current-main posture line
-PASS: note records live Tier-A zero posture
-PASS: note says retirement records are not reopened
+Part A: generic realification identity
+--------------------------------------
+  [PASS] generic 2x2 determinant identity
+  [PASS] realified determinant is real
+  [PASS] scalar realification gives x^2+y^2
+  [PASS] singular scalar is included
+  [PASS] complex determinant scales to first power per complex mode
+  [PASS] realified determinant scales to second power per complex mode
 
-------------------------------------------------------------------------------
-B - determinant power algebra
-------------------------------------------------------------------------------
-PASS: generic 2x2 realification determinant equals squared complex determinant
-PASS: scalar realification gives z*zbar
-PASS: multiplication by i changes det_C phase but not det_R
-PASS: complex count scales once for one complex mode
-PASS: realified count scales twice for one complex mode
-PASS: explicit Berezin Gaussian gives det_C(K) to first power -- k00*k11 - k01*k10
+Part B: exact finite examples
+-----------------------------
+  [PASS] diagonal 2x2 example
+  [PASS] exact 3x3 example
+  [PASS] singular 2x2 example has both determinants zero
+  [PASS] multiplication by i changes the complex determinant phase in odd size
+  [PASS] multiplication by i leaves the realified determinant unchanged
 
-------------------------------------------------------------------------------
-C - AC occupancy fork localization
-------------------------------------------------------------------------------
-PASS: independent C3 channel determinant is holomorphic in beta,gamma
-PASS: tied section supplies mixed beta*betabar term
-PASS: K-real substitution produces |beta|^2 dependence -- alpha**3 - 3*alpha*u**2 - 3*alpha*v**2 + 2*u**3 - 6*u*v**2
-PASS: landed cells remain distinct
-PASS: note keeps both determinant horns live
+Part C: Berezin first power
+---------------------------
+  [PASS] generic 2x2 top coefficient is det_C(K)  (k00*k11 - k01*k10)
+  [PASS] Berezin result has first determinant power
 
-------------------------------------------------------------------------------
-D - source integration and non-overclaim
-------------------------------------------------------------------------------
-PASS: realized-state reduction names survivor as measure-side realization
-PASS: first-order theorem already localizes count-twice to K-real restriction
-PASS: measure-binary no-go blocks axiom/primitive retirement
-PASS: formation-append no-go blocks Record shortcut
-PASS: counting-bit synthesis names det_C versus det_R fork
-PASS: dial note identifies block-count and dimension endpoints
-PASS: axiom and primitive surfaces do not supply measure/weight selection
-PASS: note contains required phrase: det_R R(K) = det_C(K) * conjugate(det_C(K))
-PASS: note contains required phrase: determinant-power binary
-PASS: note contains required phrase: matter action implements
-PASS: note contains required phrase: Remaining Live Routes
-PASS: note contains required phrase: Independent audit required
-PASS: banned overclaim phrases are absent except explicit denials
+Scope guards
+------------
+  [PASS] source note has no load-bearing links to former context stack
+  [PASS] source excludes a physical occupancy selector
+  [PASS] source does not force r=1/2
 
-==============================================================================
-TOTAL: PASS=52 FAIL=0
+================================================================
+TOTAL: PASS=16, FAIL=0
 
 ----- stderr -----
-

--- a/scripts/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.py
+++ b/scripts/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.py
@@ -1,58 +1,40 @@
 #!/usr/bin/env python3
-"""Verifier for AC occupancy determinant-power split exact support."""
+"""Exact checks for complex versus realified determinant power."""
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import sympy as sp
 
 
 ROOT = Path(__file__).resolve().parents[1]
-DOCS = ROOT / "docs"
-NOTE = DOCS / "ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md"
-TIER_A = DOCS / "audit" / "data" / "tier_a_admissions.json"
-OCC_REDUCTION = DOCS / "ACPHILAMBDA_OCCUPANCY_SELECTION_REALIZED_STATE_REDUCTION_NOTE_2026-06-11.md"
-FIRST_ORDER = DOCS / "KOIDE_STAGGERED_FIRST_ORDER_GENERATION_DETERMINANT_BOUNDED_THEOREM_NOTE_2026-06-11.md"
-MEASURE_NO_GO = DOCS / "ACPHILAMBDA_MEASURE_BINARY_AXIOM_UPDATE_NO_GO_NOTE_2026-07-04.md"
-FORMATION_NO_GO = DOCS / "ACPHILAMBDA_OCCUPANCY_FORMATION_APPEND_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md"
-COUNTING_BIT = DOCS / "CHARGED_LEPTON_VALUE_REDUCES_TO_ONE_COUNTING_BIT_SYNTHESIS_NOTE_2026-06-05.md"
-DIAL = DOCS / "GENERATION_WEIGHT_DIAL_STRUCTURE_2026-06-05.md"
-MINIMAL = DOCS / "MINIMAL_AXIOMS_2026-06-29.md"
-REALIZED_PRIMITIVE = DOCS / "REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md"
+NOTE = ROOT / "docs" / "ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md"
 
 PASS = 0
 FAIL = 0
 
 
-def flat(text: str) -> str:
-    return " ".join(text.split())
-
-
 def check(label: str, ok: bool, detail: object = "") -> None:
     global PASS, FAIL
-    ok = bool(ok)
-    if ok:
+    if bool(ok):
         PASS += 1
         tag = "PASS"
     else:
         FAIL += 1
         tag = "FAIL"
-    suffix = f" -- {detail}" if detail else ""
-    print(f"{tag}: {label}{suffix}")
+    suffix = f"  ({detail})" if detail != "" else ""
+    print(f"  [{tag}] {label}{suffix}")
 
 
 def section(title: str) -> None:
-    print("\n" + "-" * 78)
-    print(title)
-    print("-" * 78)
+    print(f"\n{title}\n{'-' * len(title)}")
 
 
-def realification(x_mat: sp.Matrix, y_mat: sp.Matrix) -> sp.Matrix:
-    top = sp.Matrix.hstack(x_mat, -y_mat)
-    bottom = sp.Matrix.hstack(y_mat, x_mat)
-    return sp.Matrix.vstack(top, bottom)
+def realification(matrix: sp.Matrix) -> sp.Matrix:
+    x = matrix.applyfunc(sp.re)
+    y = matrix.applyfunc(sp.im)
+    return sp.Matrix.vstack(sp.Matrix.hstack(x, -y), sp.Matrix.hstack(y, x))
 
 
 def gr_mul(p: dict[int, sp.Expr], q: dict[int, sp.Expr]) -> dict[int, sp.Expr]:
@@ -61,237 +43,123 @@ def gr_mul(p: dict[int, sp.Expr], q: dict[int, sp.Expr]) -> dict[int, sp.Expr]:
         for m2, c2 in q.items():
             if m1 & m2:
                 continue
-            sign = 1
-            g = m2
-            while g:
-                low = g & -g
+            inversions = 0
+            bits = m2
+            while bits:
+                low = bits & -bits
                 bit = low.bit_length() - 1
-                if bin(m1 >> (bit + 1)).count("1") % 2:
-                    sign = -sign
-                g ^= low
-            m = m1 | m2
-            out[m] = out.get(m, 0) + sign * c1 * c2
-    return {m: sp.simplify(c) for m, c in out.items() if sp.simplify(c) != 0}
+                inversions += (m1 >> (bit + 1)).bit_count()
+                bits ^= low
+            sign = -1 if inversions % 2 else 1
+            mask = m1 | m2
+            out[mask] = sp.simplify(out.get(mask, 0) + sign * c1 * c2)
+    return {mask: value for mask, value in out.items() if value != 0}
 
 
-def gr_int(p: dict[int, sp.Expr], g: int) -> dict[int, sp.Expr]:
-    out: dict[int, sp.Expr] = {}
-    bit = 1 << g
-    for m, c in p.items():
-        if not (m & bit):
-            continue
-        below = bin(m & (bit - 1)).count("1")
-        sign = -1 if below % 2 else 1
-        m2 = m ^ bit
-        out[m2] = out.get(m2, 0) + sign * c
-    return {m: sp.simplify(c) for m, c in out.items() if sp.simplify(c) != 0}
-
-
-def berezin_partition(k_mat: list[list[sp.Expr]], n: int) -> sp.Expr:
-    """Compute int dchibar dchi exp(chibar K chi) by exterior algebra."""
-
+def berezin_top_coefficient(k_mat: list[list[sp.Expr]]) -> sp.Expr:
+    n = len(k_mat)
     action: dict[int, sp.Expr] = {}
     for i in range(n):
         for j in range(n):
-            coeff = k_mat[i][j]
-            if coeff == 0:
-                continue
-            gi, gj = 2 * i, 2 * j + 1
-            monomial = (1 << gi) | (1 << gj)
-            sign = 1 if gi < gj else -1
-            action[monomial] = action.get(monomial, 0) + sign * coeff
+            # Generator order is chi_1,chibar_1,...,chi_n,chibar_n.
+            chi = 2 * j
+            chibar = 2 * i + 1
+            mask = (1 << chi) | (1 << chibar)
+            sign = -1 if chibar > chi else 1
+            action[mask] = sp.simplify(action.get(mask, 0) + sign * k_mat[i][j])
 
-    expo: dict[int, sp.Expr] = {0: sp.Integer(1)}
-    term: dict[int, sp.Expr] = {0: sp.Integer(1)}
-    for k in range(1, n + 1):
-        term = gr_mul(term, action)
-        term = {m: sp.simplify(c / k) for m, c in term.items() if sp.simplify(c) != 0}
-        for m, c in term.items():
-            expo[m] = expo.get(m, 0) + c
-
-    out = expo
-    for i in range(n):
-        out = gr_int(out, 2 * i)
-        out = gr_int(out, 2 * i + 1)
-    return sp.simplify(out.get(0, 0))
+    exponential: dict[int, sp.Expr] = {0: sp.Integer(1)}
+    power: dict[int, sp.Expr] = {0: sp.Integer(1)}
+    factorial = sp.Integer(1)
+    for degree in range(1, n + 1):
+        power = gr_mul(power, action)
+        factorial *= degree
+        for mask, value in power.items():
+            exponential[mask] = sp.simplify(
+                exponential.get(mask, 0) + value / factorial
+            )
+    return sp.simplify(exponential.get((1 << (2 * n)) - 1, 0))
 
 
 def main() -> int:
-    print("AC_phi_lambda occupancy determinant-power split exact support")
-    print("=" * 78)
+    print("Complex determinant and realification determinant power")
+    print("=" * 64)
 
-    note = NOTE.read_text(encoding="utf-8")
-    tier = json.loads(TIER_A.read_text(encoding="utf-8"))
-    occ_reduction = OCC_REDUCTION.read_text(encoding="utf-8")
-    first_order = FIRST_ORDER.read_text(encoding="utf-8")
-    measure_no_go = MEASURE_NO_GO.read_text(encoding="utf-8")
-    formation_no_go = FORMATION_NO_GO.read_text(encoding="utf-8")
-    counting_bit = COUNTING_BIT.read_text(encoding="utf-8")
-    dial = DIAL.read_text(encoding="utf-8")
-    minimal = MINIMAL.read_text(encoding="utf-8")
-    realized = REALIZED_PRIMITIVE.read_text(encoding="utf-8")
-
-    note_flat = flat(note)
-    occ_flat = flat(occ_reduction)
-    first_flat = flat(first_order)
-    measure_no_go_flat = flat(measure_no_go)
-    formation_no_go_flat = flat(formation_no_go)
-    counting_flat = flat(counting_bit)
-    dial_flat = flat(dial)
-    minimal_flat = flat(minimal)
-    realized_flat = flat(realized)
-
-    section("A - source and registry boundaries")
-
-    for path in [NOTE, TIER_A, OCC_REDUCTION, FIRST_ORDER, MEASURE_NO_GO, FORMATION_NO_GO, COUNTING_BIT, DIAL, MINIMAL, REALIZED_PRIMITIVE]:
-        check(f"exists: {path.relative_to(ROOT)}", path.exists())
-
-    check("note declares bounded_theorem claim type", "**Claim type:** bounded_theorem" in note)
-    check("runner path is wired in note", Path(__file__).name in note)
-    check("note denies AC retirement", "does not retire `AC_phi_lambda`" in note and "`AC_phi_lambda(i)` is not retired" in note)
-    check("note denies horn selection", "does not choose the orbit/holomorphic horn" in note_flat and "The sector/K-real horn is not selected" in note)
-    check("note denies premise and primitive adoption", "does not adopt the orbit-occupancy premise" in note_flat and "does not introduce a K-real primitive" in note_flat)
-    check("note denies registry/axiom/primitive/audit edits", "does not edit any Tier-A registry" in note_flat and "No registry, primitive, axiom" in note)
-
-    ac = tier["retired_derivation_targets"]["staggered_dirac_realization_gate_note_2026-05-03"]
-    check("live Tier-A genuine count is zero", tier["genuine_admitted_input_count"] == 0, tier["genuine_admitted_input_count"])
-    check("canonical Tier-A IDs are empty on current main", tier["canonical_ids"] == [], tier["canonical_ids"])
-    check("live derivation targets are empty on current main", tier.get("derivation_targets", {}) == {}, tier.get("derivation_targets"))
-    retirement = ac.get("retirement", {})
-    check("AC retired-target record is preserved", bool(ac))
-    check("AC retirement date is recorded", retirement.get("date") == "2026-07-05", retirement)
-    check("AC retirement mechanism is owner governance", retirement.get("mechanism") == "retired_by_owner_governance_on_audited_surface", retirement)
-    check(
-        "historical AC decomposition preserves three old atoms",
-        ac["minimum_decomposition"] == [
-            "reading_occupancy_selection",
-            "delta_readout_identification_R_eta",
-            "species_bridge",
-        ],
-        ac["minimum_decomposition"],
-    )
-    ac_flat = flat(json.dumps(ac))
-    check("AC retired registry names reading/occupancy selection", "reading/occupancy selection" in ac_flat and "reading_occupancy_selection" in ac_flat)
-    check("AC retirement boundary names occupancy grain", "matter-action occupancy grain" in ac_flat)
-    check("note has current-main posture line", "Current-main posture (2026-07-06)" in note)
-    check("note records live Tier-A zero posture", "Tier-A count\nzero" in note or "Tier-A count zero" in note)
-    check("note says retirement records are not reopened", "does not reopen, modify,\nor re-grade either retirement record" in note)
-
-    section("B - determinant power algebra")
-
+    section("Part A: generic realification identity")
     a, b, c, d, e, f, g, h = sp.symbols("a b c d e f g h", real=True)
-    x_mat = sp.Matrix([[a, c], [e, g]])
-    y_mat = sp.Matrix([[b, d], [f, h]])
-    k_complex = x_mat + sp.I * y_mat
-    r_complex = realification(x_mat, y_mat)
-    det_c = sp.factor(k_complex.det())
-    det_r = sp.factor(r_complex.det())
-    abs_sq = sp.factor(det_c * sp.conjugate(det_c))
-    check("generic 2x2 realification determinant equals squared complex determinant", sp.simplify(det_r - abs_sq) == 0)
+    k = sp.Matrix([[a + sp.I * b, c + sp.I * d], [e + sp.I * f, g + sp.I * h]])
+    rk = realification(k)
+    det_c = sp.expand(k.det())
+    det_r = sp.expand(rk.det())
+    abs_sq = sp.expand(det_c * sp.conjugate(det_c))
+    check("generic 2x2 determinant identity", sp.simplify(det_r - abs_sq) == 0)
+    check("realified determinant is real", sp.simplify(sp.im(det_r)) == 0)
 
-    x, y, lam = sp.symbols("x y lam", real=True, positive=True)
+    x, y, lam = sp.symbols("x y lam", real=True)
     z = x + sp.I * y
-    scalar_r = sp.Matrix([[x, -y], [y, x]])
-    check("scalar realification gives z*zbar", sp.simplify(scalar_r.det() - z * sp.conjugate(z)) == 0)
-    check("multiplication by i changes det_C phase but not det_R", sp.simplify((sp.I * z) - z) != 0 and sp.simplify(((-y) ** 2 + x**2) - (x**2 + y**2)) == 0)
-    check("complex count scales once for one complex mode", sp.simplify((lam * z) / z - lam) == 0)
-    scaled_scalar_r = sp.Matrix([[lam * x, -lam * y], [lam * y, lam * x]])
-    check("realified count scales twice for one complex mode", sp.simplify(scaled_scalar_r.det() / scalar_r.det() - lam**2) == 0)
-
-    k_symbols = [[sp.Symbol(f"k{i}{j}") for j in range(2)] for i in range(2)]
-    z_berezin = berezin_partition(k_symbols, 2)
-    det_berezin = sp.Matrix(k_symbols).det()
-    check("explicit Berezin Gaussian gives det_C(K) to first power", sp.simplify(z_berezin - det_berezin) == 0, z_berezin)
-
-    section("C - AC occupancy fork localization")
-
-    alpha, beta, gamma, betabar = sp.symbols("alpha beta gamma betabar")
-    det3 = alpha**3 + beta**3 + gamma**3 - 3 * alpha * beta * gamma
-    check("independent C3 channel determinant is holomorphic in beta,gamma", betabar not in det3.free_symbols and gamma in det3.free_symbols)
-    det_tied = alpha**3 + beta**3 + betabar**3 - 3 * alpha * beta * betabar
-    check("tied section supplies mixed beta*betabar term", sp.diff(det_tied, beta, betabar) == -3 * alpha)
-    u, v = sp.symbols("u v", real=True)
-    det_tied_uv = sp.expand(det_tied.subs({beta: u + sp.I * v, betabar: u - sp.I * v}))
-    expected_uv = sp.expand(alpha**3 + 2 * u**3 - 6 * u * v**2 - 3 * alpha * (u**2 + v**2))
-    check("K-real substitution produces |beta|^2 dependence", sp.simplify(det_tied_uv - expected_uv) == 0, det_tied_uv)
-
-    q = lambda r: sp.Rational(1, 3) + sp.Rational(2, 3) * r
-    check("landed cells remain distinct", q(sp.Integer(1)) == 1 and q(sp.Rational(1, 2)) == sp.Rational(2, 3))
-    check("note keeps both determinant horns live", "Holomorphic/orbit" in note and "Realified/sector-tied" in note)
-
-    section("D - source integration and non-overclaim")
-
+    rz = realification(sp.Matrix([[z]]))
+    check("scalar realification gives x^2+y^2", sp.simplify(rz.det() - x**2 - y**2) == 0)
+    check("singular scalar is included", realification(sp.Matrix([[0]])).det() == 0)
     check(
-        "realized-state reduction names survivor as measure-side realization",
-        "measure-side binary itself" in occ_flat and "matter action's statistics implements" in occ_flat,
+        "complex determinant scales to first power per complex mode",
+        sp.simplify((lam * sp.Matrix([[z]])).det() - lam * z) == 0,
     )
     check(
-        "first-order theorem already localizes count-twice to K-real restriction",
-        "measure side is first-order" in first_flat and "c = conj(b)" in first_flat and "which horn is physical is not decided" in first_flat,
-    )
-    check(
-        "measure-binary no-go blocks axiom/primitive retirement",
-        "does not supply the AC(i) reading/occupancy binary" in measure_no_go_flat
-        and "No value of `r` is derived, selected, or preferred." in measure_no_go,
-    )
-    check(
-        "formation-append no-go blocks Record shortcut",
-        "The July 4 formation append does not retire AC_phi_lambda(i)." in formation_no_go
-        and "measure-side doublet occupancy realization binary" in formation_no_go_flat,
-    )
-    check(
-        "counting-bit synthesis names det_C versus det_R fork",
-        "det_C" in counting_bit and "det_R" in counting_bit and "one binary counting-measure bit" in counting_flat,
-    )
-    check(
-        "dial note identifies block-count and dimension endpoints",
-        "block-count / det_C" in dial and "Born / dimension / det_R" in dial,
-    )
-    check(
-        "axiom and primitive surfaces do not supply measure/weight selection",
-        "readout-context selection" in minimal_flat
-        and "Born weights" in minimal_flat
-        and "measure, weighting, probability rule" in realized_flat,
+        "realified determinant scales to second power per complex mode",
+        sp.simplify(realification(lam * sp.Matrix([[z]])).det() - lam**2 * rz.det()) == 0,
     )
 
-    required_note_phrases = [
-        "det_R R(K) = det_C(K) * conjugate(det_C(K))",
-        "determinant-power binary",
-        "matter action implements",
-        "Remaining Live Routes",
-        "Independent audit required",
-    ]
-    for phrase in required_note_phrases:
-        check(f"note contains required phrase: {phrase}", phrase in note)
+    section("Part B: exact finite examples")
+    diagonal = sp.diag(1 + sp.I, 2 - sp.I)
+    check(
+        "diagonal 2x2 example",
+        realification(diagonal).det()
+        == sp.simplify(diagonal.det() * sp.conjugate(diagonal.det())),
+    )
+    exact3 = sp.Matrix([[1 + sp.I, 2, 0], [0, 1 - sp.I, 3], [2, 0, 1]])
+    check(
+        "exact 3x3 example",
+        sp.simplify(
+            realification(exact3).det()
+            - exact3.det() * sp.conjugate(exact3.det())
+        )
+        == 0,
+    )
+    singular2 = sp.Matrix([[1 + sp.I, 2], [2 + 2 * sp.I, 4]])
+    check("singular 2x2 example has both determinants zero", singular2.det() == 0 and realification(singular2).det() == 0)
+    check(
+        "multiplication by i changes the complex determinant phase in odd size",
+        sp.det(sp.I * exact3) == -sp.I * exact3.det(),
+    )
+    check(
+        "multiplication by i leaves the realified determinant unchanged",
+        sp.simplify(realification(sp.I * exact3).det() - realification(exact3).det()) == 0,
+    )
 
-    banned = [
-        "derives `r = 1/2`",
-        "chooses the orbit/holomorphic horn",
-        "adopts the orbit-occupancy premise",
-        "introduces a K-real primitive",
-        "retires `AC_phi_lambda`",
-        "edits the Tier-A registry",
-        "R-eta is derived",
-        "theta is derived",
-        "retained_no_go",
-        "audited_clean",
-    ]
-    false_positive_context = {
-        "derives `r = 1/2`": "does not derive `r = 1/2`",
-        "chooses the orbit/holomorphic horn": "does not choose the orbit/holomorphic horn",
-        "adopts the orbit-occupancy premise": "does not adopt the orbit-occupancy premise",
-        "introduces a K-real primitive": "does not introduce a K-real primitive",
-        "retires `AC_phi_lambda`": "does not retire `AC_phi_lambda`",
-        "edits the Tier-A registry": "does not edit the Tier-A registry",
-    }
-    found = []
-    for phrase in banned:
-        if phrase in note and false_positive_context.get(phrase) not in note:
-            found.append(phrase)
-    check("banned overclaim phrases are absent except explicit denials", not found, found)
+    section("Part C: Berezin first power")
+    k00, k01, k10, k11 = sp.symbols("k00 k01 k10 k11")
+    entries = [[k00, k01], [k10, k11]]
+    top = berezin_top_coefficient(entries)
+    expected = sp.Matrix(entries).det()
+    check("generic 2x2 top coefficient is det_C(K)", sp.simplify(top - expected) == 0, top)
+    check("Berezin result has first determinant power", sp.Poly(top, k00, k01, k10, k11).total_degree() == 2)
 
-    print("\n" + "=" * 78)
-    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+    section("Scope guards")
+    note = NOTE.read_text(encoding="utf-8")
+    former_links = (
+        "ACPHILAMBDA_OCCUPANCY_SELECTION_REALIZED_STATE_REDUCTION_NOTE_2026-06-11.md",
+        "KOIDE_STAGGERED_FIRST_ORDER_GENERATION_DETERMINANT_BOUNDED_THEOREM_NOTE_2026-06-11.md",
+        "ACPHILAMBDA_MEASURE_BINARY_AXIOM_UPDATE_NO_GO_NOTE_2026-07-04.md",
+        "ACPHILAMBDA_OCCUPANCY_FORMATION_APPEND_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md",
+        "CHARGED_LEPTON_VALUE_REDUCES_TO_ONE_COUNTING_BIT_SYNTHESIS_NOTE_2026-06-05.md",
+        "GENERATION_WEIGHT_DIAL_STRUCTURE_2026-06-05.md",
+    )
+    check("source note has no load-bearing links to former context stack", all(link not in note for link in former_links))
+    check("source excludes a physical occupancy selector", "does not select a\nK/CPT-orbit occupancy grain" in note)
+    check("source does not force r=1/2", "force `r=1/2`" in note)
+
+    print("\n" + "=" * 64)
+    print(f"TOTAL: PASS={PASS}, FAIL={FAIL}")
     return 0 if FAIL == 0 else 1
 
 

--- a/scripts/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.py
+++ b/scripts/acphilambda_occupancy_determinant_power_split_exact_support_2026_07_04.py
@@ -57,6 +57,7 @@ def gr_mul(p: dict[int, sp.Expr], q: dict[int, sp.Expr]) -> dict[int, sp.Expr]:
 
 
 def berezin_top_coefficient(k_mat: list[list[sp.Expr]]) -> sp.Expr:
+    """Coefficient for exp(-chibar K chi) in chi_1,chibar_1,... order."""
     n = len(k_mat)
     action: dict[int, sp.Expr] = {}
     for i in range(n):
@@ -66,7 +67,7 @@ def berezin_top_coefficient(k_mat: list[list[sp.Expr]]) -> sp.Expr:
             chibar = 2 * i + 1
             mask = (1 << chi) | (1 << chibar)
             sign = -1 if chibar > chi else 1
-            action[mask] = sp.simplify(action.get(mask, 0) + sign * k_mat[i][j])
+            action[mask] = sp.simplify(action.get(mask, 0) - sign * k_mat[i][j])
 
     exponential: dict[int, sp.Expr] = {0: sp.Integer(1)}
     power: dict[int, sp.Expr] = {0: sp.Integer(1)}
@@ -137,12 +138,24 @@ def main() -> int:
     )
 
     section("Part C: Berezin first power")
+    k0 = sp.Symbol("k0")
+    scalar_top = berezin_top_coefficient([[k0]])
+    check("generic 1x1 top coefficient is det_C(K)", scalar_top == k0, scalar_top)
+
     k00, k01, k10, k11 = sp.symbols("k00 k01 k10 k11")
     entries = [[k00, k01], [k10, k11]]
     top = berezin_top_coefficient(entries)
     expected = sp.Matrix(entries).det()
     check("generic 2x2 top coefficient is det_C(K)", sp.simplify(top - expected) == 0, top)
     check("Berezin result has first determinant power", sp.Poly(top, k00, k01, k10, k11).total_degree() == 2)
+
+    entries3 = [
+        [sp.Symbol(f"q{i}{j}") for j in range(3)]
+        for i in range(3)
+    ]
+    top3 = berezin_top_coefficient(entries3)
+    expected3 = sp.Matrix(entries3).det()
+    check("generic 3x3 top coefficient is det_C(K)", sp.simplify(top3 - expected3) == 0)
 
     section("Scope guards")
     note = NOTE.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- prove `det_R R(K) = |det_C K|^2` without the six-row contextual dependency stack
- compute the holomorphic Berezin Gaussian determinant to first power by exterior algebra with an explicit standard left-derivative sign/order convention
- cover generic symbolic, scalar, singular, diagonal, and exact 3x3 cases
- keep physical matter-carrier selection, K/CPT occupancy grain, action/measure choice, R-eta, and the value of `r` outside the theorem

## Review repair
- correct the Gaussian exponent sign for the displayed Berezin measure ordering
- add generic 1x1 and 3x3 checks so an even-dimensional test cannot mask a parity sign error

## Verification
- exact runner: 18 PASS / 0 FAIL
- runner cache matches and hashes the revised runner
- Python compilation passes
- changed files have no vocabulary-lint findings
- validation pipeline and strict audit lint pass; generated audit outputs are intentionally stripped from the framework PR
- git diff check passes

Audit status remains exclusively for the independent audit lane.