### PR TITLE
Make the AC R-eta unit obstruction self-contained

### DIFF
--- a/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -1,228 +1,183 @@
-# AC_phi_lambda R-eta Direct-License h-Class/h-Unit Non-Supply No-Go
+# Record Additivity Does Not Fix the R-eta Unit Calibration
 
-**Date:** 2026-07-04
+**Date:** 2026-07-04; countermodel repair 2026-07-11
 **Type:** no_go
 **Claim type:** no_go
-**Scope boundary:** bounded route no-go for the direct R-eta readout-license
-shortcut. The updated axioms say records form and that scalar readout is
-record-content additive, and the current support stack supplies fixed-locus
-arithmetic plus a Record-registrable finite context. Those ingredients do not
-derive the remaining `A_R-eta` license: the h-class statement that the physical
-charged-lepton angle is the fixed-locus density class, and the h-unit statement
-that this density is identity-read as the bare holonomy angle. This note does
-not derive, refute, re-grade, retire, or remove R-eta or AC_phi_lambda, and it
-does not edit any Tier-A registry, axiom, primitive, audit verdict, or
-publication-status surface.
-**Audit boundary:** independent audit lane only.
+**Status authority:** independent audit lane. This source proposal does not
+set or predict an audit verdict.
 **Primary runner:**
 [`scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py`](../scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py)
+**Runner cache:**
+[`logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt`](../logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt)
 
-## Target
+## Narrow no-go claim
 
-The live residual after the current R-eta surface is:
-
-```text
-A_R-eta:
-  h-class: the registered charged-lepton angle is a fixed-locus density
-           of the realized C3 cycle;
-  h-unit:  that density is identity-read as the bare cycle holonomy angle.
-```
-
-The direct-license shortcut tries to close this residual by saying:
+Grant the R-eta h-class hypothesis: a three-record charged-lepton cycle is to
+be read through a fixed local scalar `h`. Even with that grant, the
+[four axioms](MINIMAL_AXIOMS_2026-06-29.md) do not entail the identity
+calibration
 
 ```text
-Record forms + record-content additive readout
-+ supplied finite Record-registrable context
-+ fixed-locus arithmetic L = 2/9, S_sum = 2/3
-therefore the physical charged-lepton readout is Phi = S_sum = 2/3.
+Phi = 3h.
 ```
 
-This implication is invalid on the current surface. Record content and finite
-context make the readout domain available, but they do not choose the
-fixed-locus density as the physical observable, and they do not choose the
-identity conversion from dimensionless density to bare holonomy angle.
-
-## Retained Inputs And Context Handles
-
-- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
-  Record formation, single-record locking, permanence, record-content readout,
-  and finite scalar additivity. It keeps context selection, measurement basis,
-  formation rules, source/action, physical-observable identification, and
-  readout bridges outside axiom content.
-- [`ADMITTED_INPUT_REGISTRY_TIER_A_NOTE_2026-05-23.md`](ADMITTED_INPUT_REGISTRY_TIER_A_NOTE_2026-05-23.md)
-  and [`docs/audit/data/tier_a_admissions.json`](audit/data/tier_a_admissions.json)
-  still name `delta_readout_identification_R_eta` as a live AC_phi_lambda atom.
-- Context handles, not load-bearing retained inputs:
-  `ACPHILAMBDA_R_ETA_READOUT_IDENTIFICATION_NARROWING_BOUNDED_THEOREM_NOTE_2026-06-11.md`
-  is the lane source for the `A_R-eta` h-class/h-unit language;
-  `SUPPLIED_READOUT_CONTEXT_TWO_COMPONENT_DECOMPOSITION_BOUNDED_NOTE_2026-07-02.md`
-  and `ACPHILAMBDA_R_ETA_W2_REGISTRABILITY_CONTEXT_BRIDGE_NOTE_2026-06-18.md`
-  locate the context/frame versus scalar weighting split. This note recomputes
-  the finite independence witnesses below rather than importing those rows as
-  retained-grade proof.
-- [`KOIDE_APS_C3_FIXED_LOCUS_WEIGHTS_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md`](KOIDE_APS_C3_FIXED_LOCUS_WEIGHTS_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md)
-  supplies `L = L3(1,2) = 2/9` and `S_sum = 3L = 2/3` as fixed-locus
-  arithmetic, while excluding the physical readout bridge.
-- Additional context handles, not load-bearing inputs:
-  `ACPHILAMBDA_REGISTRABLE_CYCLE_HOLONOMY_NORMAL_FORM_2026-07-01.md`,
-  `ACPHILAMBDA_DEFECT_IDENTITY_UNIT_RESCALE_OBSTRUCTION_2026-07-01.md`,
-  `ACPHILAMBDA_R_ETA_ANGLE_NATIVE_FRONTIER_NO_GO_NOTE_2026-07-04.md`, and
-  `RECORD_CONTENT_READOUT_LICENSE_SPLIT_REGISTRATION_UNREACHABILITY_THEOREM_NOTE_2026-07-02.md`
-  name adjacent route vocabulary. The runner verifies the scalar-family and
-  additive-map witnesses directly.
-
-## Theorem
-
-On the current direct-license surface, the following implication is invalid:
+They admit a real one-parameter family of readouts
 
 ```text
-minimal Record axiom + supplied finite Record-registrable context
-+ fixed-locus arithmetic and holonomy normal form
-therefore the direct R-eta license is supplied.
+I_beta(R) = beta h N(R),
 ```
 
-There are two independent missing steps.
+where `N(R)` is the number of records in a finite pairwise-disjoint record
+collection. Every real `beta` satisfies empty-zero, record-content
+determination, and finite additivity. The target is `beta=1`; `beta=2` is an
+explicit countermodel with the same axiom structure and the same granted `h`.
 
-First, h-class is not supplied. Record additivity says that scalar readout is
-additive on record content. It does not say which additive scalar functional is
-the physical charged-lepton cycle holonomy. On the same finite record frame,
-the zero map, a count map, a fixed-locus single-density map, and the unaveraged
-fixed-locus sum are all record-content additive. They give different scalars.
-Only one of them is the R-eta target, and choosing it is exactly h-class
-content.
+This is a no-go for the direct inference from Record additivity to the R-eta
+h-unit. It is not a claim against a future same-observable holonomy theorem,
+an owner-approved calibration convention, or a stronger physical readout law.
 
-Second, h-unit is not supplied. Even after the fixed-locus class is selected,
-the identity conversion from dimensionless density to the bare holonomy angle
-is a separate scalar-normalization choice. The family
+## Countermodel family
+
+Keep the Lattice, Qubit, and Admissibility structures fixed. Let a state carry
+finite-support records, each locking one admissible local possibility as the
+Record axiom requires. For a finite record collection `R`, define `N(R)` as
+its cardinality. Because cardinality depends on record content and not on a
+site label, it is invariant under translations, proper cubic rotations, and
+permutations of the three cycle positions.
+
+For any real `beta`, set
 
 ```text
-Phi_beta = beta S_sum
+I_beta(empty) = 0,
+I_beta(R disjoint-union S) = I_beta(R)+I_beta(S),
+I_beta(R) = beta h N(R).
 ```
 
-is additive whenever the underlying fixed-locus readout is additive. The
-target is `beta = 1`; `beta = 2*pi`, `beta = 1/3`, `beta = 0`, and other
-dimensionless conversions are not excluded by Record additivity or supplied
-finite-context registrability. They may be wrong physical readouts, but ruling
-them out requires a readout-license theorem or explicit governance premise.
+The first two equations follow directly from cardinality. For a three-record
+cycle `C`,
 
-Thus the direct-license shortcut does not retire R-eta. It sharpens the
-remaining task: a successful proof must derive both h-class and h-unit, or
-owner governance must register a narrow readout primitive/premise explicitly.
+```text
+I_beta(C) = 3 beta h.
+```
 
-## Exact Checks
+When `h=2/9` is granted, `beta=1` gives `2/3` and `beta=2` gives `4/3`.
+Both models obey the stated axiom requirements. Therefore those requirements
+do not entail `beta=1`.
 
-The paired runner verifies:
+The countermodel is real and hence even under complex conjugation. Adding a
+K/CPT-evenness requirement does not remove the free coefficient.
 
-- the Tier-A registry keeps the live `AC_phi_lambda` target and keeps
-  `delta_readout_identification_R_eta` in its decomposition;
-- the minimal axioms include `Records form.` but leave formation rules,
-  context selection, and physical-observable identification outside axiom
-  content;
-- the R-eta narrowing source contains the h-class/h-unit decomposition and
-  says the atom remains admitted;
-- W2 closes only supplied finite-context registrability, not physical carrier
-  realization or `A_R-eta`;
-- supplied context decomposes into C1 frame data and C2 scalar
-  weighting/normalization data;
-- `L = 2/9`, `S_sum = 2/3`, and `Phi(c) = c S_sum`;
-- several distinct additive scalar readouts on the same finite record frame
-  satisfy empty-record and direct-sum additivity while yielding different
-  values;
-- selecting `Phi = S_sum` requires choosing the unaveraged fixed-locus class
-  and identity unit;
-- `Phi_beta = beta S_sum` hits the target only at `beta = 1`;
-- alternative h-class/h-unit combinations can be fitted to the same number,
-  showing that the number alone does not supply the license.
+## Scope
 
-No observed lepton masses, fitted selectors, Born rule, measurement semantics,
-event law, source/action bridge, new primitive, or owner decision enters the
-proof.
+The result grants the h-class association for the sake of the argument. It
+therefore proves a narrower and stronger residual statement than a joint
+h-class/h-unit discussion: h-unit remains unentailed after h-class has been
+supplied.
 
-## What This Moves
+The result does not derive or refute the physical R-eta identification. It
+does not set `h`, `delta`, `r`, or a charged-lepton mass, and it does not force
+`r=1/2`. It changes no axiom, approved primitive, owner-governed premise,
+registry, or audit verdict.
 
-| Before | After |
-|---|---|
-| The direct-license route could be treated as a single missing sentence. | It is split into h-class plus h-unit. |
-| Record formation/additivity could be over-read as readout selection. | They supply readable record content, not the physical scalar functional. |
-| Supplied finite context could be over-read as scalar weighting closure. | It supplies a context/frame side only; scalar normalization remains separate. |
-| `Phi = S_sum` could be treated as a derivation because it hits `2/3`. | It is classified as the exact live R-eta license unless independently derived. |
-
-## What Does Not Move
-
-- AC_phi_lambda is not retired.
-- R-eta is not derived, refuted, re-graded, or removed from Tier-A.
-- No value of `delta`, `Phi`, h-class, h-unit, `c`, or `beta` is selected.
-- AC(i), theta, source/action gates, event laws, and owner primitive decisions
-  are untouched.
-- No registry, axiom, primitive, audit verdict, publication surface, or
-  downstream dependency status is edited.
-- A future direct readout-license theorem remains possible if it derives
-  h-class and h-unit without importing the target.
-
-## Remaining Live Routes
-
-1. **h-class theorem.** Derive that the physical charged-lepton readout is a
-   fixed-locus density of the realized `C3` cycle, not merely any additive
-   scalar on the supplied record content.
-2. **h-unit theorem.** Derive the identity conversion from that dimensionless
-   density to the bare holonomy angle, excluding `2*pi` packaging and other
-   scalar normalizations without fitting.
-3. **Combined direct-license theorem.** Derive `Phi = S_sum = 2/3` as the
-   physical charged-lepton cycle holonomy in one retained bridge.
-4. **Coherence-event/rate theorem.** Derive an event predicate and
-   normalization law that bypasses the direct-license path without importing
-   the target.
-5. **Owner governance.** Register a narrow readout primitive or premise
-   explicitly if derivation is intentionally bypassed; this would be
-   governance, not derivation.
+The live governance target is recorded in
+`docs/audit/data/owner_governed_premise_nodes.json` as AC(ii), the R-eta
+h-class/h-unit readout license. That registry identifies the target; it is not
+used as a proof premise here.
 
 ## No-Go Discipline Gate
 
-**N1 alternative route enumeration.** The block tests direct Record
-additivity, supplied finite context, C1 frame closure, C2 scalar weighting,
-fixed-locus arithmetic, holonomy normal form, h-class choice, h-unit choice,
-and numerical target fitting.
+### N1 — alternative route enumeration
 
-**N2 wall independence.** No new wall is introduced. The wall remains
-`A_R-eta`, now restated as h-class plus h-unit inside the already named
-`W_cycle_holonomy_value == W_defect_identity_unit == R-eta (ii)`.
+| Route tested against the countermodel | Marker | Result and authority/check |
+|---|---|---|
+| Record empty-zero | ATTEMPTED | `I_beta(empty)=0` for every real `beta`; Record clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Part A. |
+| Record finite additivity | ATTEMPTED | Cardinality is additive on disjoint unions, so every `I_beta` is additive; Record clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Parts A and C. |
+| Record-content determination | ATTEMPTED | `I_beta` depends on the finite record collection through `N(R)` and the granted scalar, with no site label; Record clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Part B. |
+| Lattice and cycle symmetry | ATTEMPTED | `N(R)` is invariant under translations, proper cubic rotations, and cycle-position permutations; Lattice clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Part B. |
+| K/CPT-even real readout | ATTEMPTED | Real `beta` and real `h` make `I_beta` unchanged by complex conjugation; this is an extra grant checked in runner Part B, not axiom content. |
+| Pointwise realized-state evaluation | ATTEMPTED | Evaluating the same realized record state leaves the law-level coefficient `beta` free; [realized-state primitive](REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md) boundary plus runner Parts A–C. |
 
-**N3 hidden-wall scan.** The proof imports no comparator masses, fitted
-selector, event law, Born/interface rule, physical carrier theorem,
-activation-rate premise, readout primitive, source/action bridge, or owner
-decision.
+The runner checks all six routes. Their authority boundary is the current
+minimal axiom memo plus the explicit family above; no prior negative row is
+used as a witness.
 
-**N4 residual matching.** The residual matches the Tier-A registry: the fixed
-number `2/9` is retained fixed-locus arithmetic conditional on R-eta; the
-surviving atom is the physical density-read-as-angle / holonomy-readout
-identification.
+### N2 — wall independence
 
-**N5 proven surface.** Proven here is a bounded no-go against using the
-updated axioms plus supplied finite-context support as the direct R-eta
-license. This is not a terminal no-go against future readout-license theorems.
+The scoped claim carries one wall: `W_unit`, the coefficient `beta=1`.
+h-class is granted, not counted as a second wall. No pairwise wall table is
+needed after this collapse.
 
-**N6 partial closure.** The result preserves useful support: fixed-locus
-arithmetic, finite-context registrability, and holonomy normal form remain
-valid. It only blocks overpromotion of that support into the physical license.
+### N3 — hidden-wall scan
 
-**N7 steelman.** A reviewer can say the exact value `2/3` is already on the
-right finite surface. Correct. The missing step is why Nature's charged-lepton
-cycle readout must use that surface with identity angle units.
+The proof text was scanned for `we assume`, `by construction`, `as is
+standard`, `the framework provides`, `bridge context`, `background`,
+`naturally`, `obviously`, `standard QFT`, `registered`, and `canonical`.
 
-**N8 cross-cycle echo.** This repeats the AC(i) and clock-route pattern: a
-realized readable slot and a correct finite value are not by themselves the
-selector/readout law needed for Tier-A retirement.
+| Hit | Classification |
+|---|---|
+| granted h-class and `h` | explicit hypothesis that strengthens the countermodel |
+| `registered` in the mass-coordinate and governance discussions | non-load-bearing route/target description |
+| scan terms appearing in this checklist sentence | audit metadata, not proof steps |
+
+No other scan hit is used in the proof.
+
+### N4 — residual matching
+
+No prior no-go row is cited as evidence.
+
+| Prior negative witness | Witness residual | Current residual | Match/disposition |
+|---|---|---|---|
+| none | n/a | h-unit face of AC(ii): identity reading of the fixed local scalar as cycle angle | direct countermodel; no witness citation to drop |
+
+### N5 — rhetoric and resolution audit
+
+The countermodel is checked for the empty collection, a single record, finite
+disjoint collections, a three-record cycle, and arbitrary finite cardinality.
+It supports the statement that the named finite-record axioms do not entail
+`beta=1`. It makes no claim about an added dynamical action, continuum limit,
+or future same-observable theorem.
+
+### N6 — partial-closure paths
+
+| Candidate path | Current status | What it would address |
+|---|---|---|
+| owner-approved `beta=1` coordinate calibration | not approved as a separate convention | h-unit by governance ratification, not axiom derivation |
+| same-observable determinant-line/holonomy theorem | no retained theorem on the current ledger surface | h-class and h-unit by physical derivation |
+| `ACPHILAMBDA_R_ETA_VALUE_FACE_REGISTERED_ANGLE_FUNCTIONAL_EXACTNESS_RELOCATION_NOTE_2026-07-05.md` | unaudited source context | registered value face; does not identify the physical fixed-locus observable |
+
+These paths remain compatible with the result. Neither is present in the four
+axioms or the approved primitive registry. This note does not classify them as
+impossible and does not propose a new primitive.
+
+### N7 — steelman
+
+The strongest objection is that angles are already measured in radians, so
+`beta=1` may be a coordinate convention rather than new physics. That
+objection succeeds after the fixed-locus scalar and the physical holonomy have
+been proved to be the same observable in the same coordinate. The current
+axioms name neither object and contain no such identity. Thus the objection
+identifies a viable ratification or theorem path while leaving the present
+non-entailment countermodel intact.
+
+### N8 — cross-cycle echo
+
+| Similar mechanism | Was its wall retired? | Applicability here |
+|---|---|---|
+| scale-reference primitive | calibration made explicit by owner approval | an analogous h-unit primitive would be a premise, not a derivation of `beta=1` |
+| registered mass-coordinate reconstruction | phase reconstructed after state data are supplied | does not establish the h-unit identity for the physical fixed-locus observable |
+
+Both mechanisms have been considered and do not refute the narrow
+current-surface claim.
+
+**Gate result: PASS.** N1–N8 support the finite-record, current-surface
+non-entailment statement above.
 
 ## Verification
 
 Run:
 
 ```bash
-PYTHONPATH=scripts python3 scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
+python3 scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
 ```
 
-Expected close:
-
-```text
-TOTAL: PASS>=120 FAIL=0
-```
+Expected result: `PASS=35`, `FAIL=0`.

--- a/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -12,13 +12,14 @@ set or predict an audit verdict.
 
 ## Narrow no-go claim
 
-Grant the R-eta h-class hypothesis: a three-record charged-lepton cycle is to
-be read through a fixed local scalar `h`. Even with that grant, the
-[four axioms](MINIMAL_AXIOMS_2026-06-29.md) do not entail the identity
-calibration
+Grant the R-eta h-class hypothesis: the charged-lepton eta readout lies in the
+fixed-locus density class represented by a nonzero local scalar `h`. This grants
+the class, not its identity calibration. Even with that grant, the
+[four axioms](MINIMAL_AXIOMS_2026-06-29.md) do not entail
 
 ```text
-Phi = 3h.
+|delta| = h,
+Phi = 3|delta| = 3h.
 ```
 
 They admit a real one-parameter family of readouts
@@ -31,6 +32,15 @@ where `N(R)` is the number of records in a finite pairwise-disjoint record
 collection. Every real `beta` satisfies empty-zero, record-content
 determination, and finite additivity. The target is `beta=1`; `beta=2` is an
 explicit countermodel with the same axiom structure and the same granted `h`.
+For a singleton record `x` and a three-record cycle `C`, respectively,
+
+```text
+|delta_beta| = I_beta({x}) = beta h,
+Phi_beta = I_beta(C) = 3 beta h.
+```
+
+Thus the same free coefficient changes the original AC(ii) eta-angle identity
+and its additive cycle-holonomy consequence.
 
 This is a no-go for the direct inference from Record additivity to the R-eta
 h-unit. It is not a claim against a future same-observable holonomy theorem,
@@ -53,16 +63,19 @@ I_beta(R disjoint-union S) = I_beta(R)+I_beta(S),
 I_beta(R) = beta h N(R).
 ```
 
-The first two equations follow directly from cardinality. For a three-record
-cycle `C`,
+The first two equations follow directly from cardinality. For a singleton
+record `x` and a three-record cycle `C`,
 
 ```text
+I_beta({x}) = beta h,
 I_beta(C) = 3 beta h.
 ```
 
-When `h=2/9` is granted, `beta=1` gives `2/3` and `beta=2` gives `4/3`.
-Both models obey the stated axiom requirements. Therefore those requirements
-do not entail `beta=1`.
+When `h=2/9` is granted, `beta=1` gives the eta angle `2/9` and cycle
+holonomy `2/3`, while `beta=2` gives `4/9` and `4/3`. Both models obey the
+stated axiom requirements. Therefore those requirements do not entail
+`beta=1` at either the singleton eta-angle resolution or the three-record
+cycle resolution.
 
 The countermodel is real and hence even under complex conjugation. Adding a
 K/CPT-evenness requirement does not remove the free coefficient.
@@ -90,22 +103,26 @@ used as a proof premise here.
 
 | Route tested against the countermodel | Marker | Result and authority/check |
 |---|---|---|
-| Record empty-zero | ATTEMPTED | `I_beta(empty)=0` for every real `beta`; Record clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Part A. |
-| Record finite additivity | ATTEMPTED | Cardinality is additive on disjoint unions, so every `I_beta` is additive; Record clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Parts A and C. |
-| Record-content determination | ATTEMPTED | `I_beta` depends on the finite record collection through `N(R)` and the granted scalar, with no site label; Record clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Part B. |
+| Full Record readout route | ATTEMPTED | Empty-zero, record-content determination, and finite disjoint additivity all hold for every real `beta`; Record clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Parts A--C. |
 | Lattice and cycle symmetry | ATTEMPTED | `N(R)` is invariant under translations, proper cubic rotations, and cycle-position permutations; Lattice clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Part B. |
 | K/CPT-even real readout | ATTEMPTED | Real `beta` and real `h` make `I_beta` unchanged by complex conjugation; this is an extra grant checked in runner Part B, not axiom content. |
-| Pointwise realized-state evaluation | ATTEMPTED | Evaluating the same realized record state leaves the law-level coefficient `beta` free; [realized-state primitive](REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md) boundary plus runner Parts A–C. |
+| Pointwise realized-state evaluation | ATTEMPTED | Evaluating the same realized record state leaves the law-level coefficient `beta` free; [realized-state primitive](REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md) boundary plus runner Parts A--C. |
+| Dimensionful scale reference | ATTEMPTED | The [scale-reference primitive](SCALE_REFERENCE_PRIMITIVE_NOTE.md) supplies units conversion and no dimensionless phase, selector, or readout bridge; `beta` is dimensionless, runner Part D. |
+| Kinetic-form isotropy | ATTEMPTED | The [kinetic-isotropy primitive](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md) supplies `c_t=c_s` and no phase, selector, or readout bridge; the family is unchanged, runner Part D. |
+| Exact fixed-locus value | ATTEMPTED | Granting the nonzero value `h=2/9` leaves both `beta=1` and `beta=2`; runner Part A checks the singleton and cycle values separately. |
 
-The runner checks all six routes. Their authority boundary is the current
-minimal axiom memo plus the explicit family above; no prior negative row is
-used as a witness.
+The runner checks all seven routes. Their authority boundary is the current
+minimal axiom memo, the approved primitive boundary notes, and the explicit
+family above; no prior negative row is used as a witness.
 
 ### N2 — wall independence
 
-The scoped claim carries one wall: `W_unit`, the coefficient `beta=1`.
-h-class is granted, not counted as a second wall. No pairwise wall table is
-needed after this collapse.
+The scoped claim carries one wall: `W_unit`, the coefficient `beta=1` in
+`|delta|=beta h`. The h-class face of AC(ii) is an explicit hypothesis, not a
+second unresolved wall in this theorem. The three-record relation
+`Phi=3|delta|` is an additive consequence of the same coefficient, not an
+independent normalization wall. No pairwise wall table is needed after this
+collapse.
 
 ### N3 — hidden-wall scan
 
@@ -116,57 +133,71 @@ standard`, `the framework provides`, `bridge context`, `background`,
 | Hit | Classification |
 |---|---|
 | granted h-class and `h` | explicit hypothesis that strengthens the countermodel |
-| `registered` in the mass-coordinate and governance discussions | non-load-bearing route/target description |
+| `registered` / `governance target` in the AC(ii) boundary discussion | non-load-bearing identification of the theorem target |
+| `registered` in the mass-coordinate path | non-load-bearing description of a partial route |
 | scan terms appearing in this checklist sentence | audit metadata, not proof steps |
 
 No other scan hit is used in the proof.
 
 ### N4 — residual matching
 
-No prior no-go row is cited as evidence.
+No prior no-go row is cited as evidence. The target itself is matched against
+`docs/TIER_A_RESIDUAL_OWNER_ADOPTION_RETIREMENT_2026-07-04.md:77-85`, whose
+adopted AC(ii) text says that the physical readout is the fixed-locus density
+class `h`, identity-read in h-units as the eta angle, with no intervening
+normalization factor.
 
-| Prior negative witness | Witness residual | Current residual | Match/disposition |
+| Target or prior negative witness | Residual there | Current residual | Match/disposition |
 |---|---|---|---|
-| none | n/a | h-unit face of AC(ii): identity reading of the fixed local scalar as cycle angle | direct countermodel; no witness citation to drop |
+| adopted AC(ii) text at the locator above | h-class plus identity h-unit for the eta angle | h-class granted; identity h-unit `|delta|=h` tested | exact match to the h-unit face |
+| prior negative witness: none | n/a | the same h-unit face, with `Phi=3|delta|` kept as a consequence | direct countermodel; no witness citation to drop |
 
 ### N5 — rhetoric and resolution audit
 
-The countermodel is checked for the empty collection, a single record, finite
-disjoint collections, a three-record cycle, and arbitrary finite cardinality.
-It supports the statement that the named finite-record axioms do not entail
-`beta=1`. It makes no claim about an added dynamical action, continuum limit,
-or future same-observable theorem.
+The countermodel is checked for the empty collection, a singleton eta-angle
+readout, finite disjoint collections, a three-record cycle holonomy, and
+arbitrary finite cardinality. It supports the statement that the named
+finite-record axioms do not entail `beta=1` at those resolutions. It makes no
+per-mode, per-action-block, continuum, or lattice-wide dynamical claim, and no
+claim against a future same-observable theorem.
 
 ### N6 — partial-closure paths
 
 | Candidate path | Current status | What it would address |
 |---|---|---|
-| owner-approved `beta=1` coordinate calibration | not approved as a separate convention | h-unit by governance ratification, not axiom derivation |
+| existing Class B AC(ii) owner premise | approved as a governance premise, not a theorem or convention | currently supplies h-class and h-unit inside its recorded boundary; it is the target to retire, not evidence of derivation |
+| convention-only coordinate ratification | not adopted as a separate convention | could dispose of h-unit only after the physical fixed-locus scalar and eta angle are shown to be the same observable |
 | same-observable determinant-line/holonomy theorem | no retained theorem on the current ledger surface | h-class and h-unit by physical derivation |
 | `ACPHILAMBDA_R_ETA_VALUE_FACE_REGISTERED_ANGLE_FUNCTIONAL_EXACTNESS_RELOCATION_NOTE_2026-07-05.md` | unaudited source context | registered value face; does not identify the physical fixed-locus observable |
 
-These paths remain compatible with the result. Neither is present in the four
-axioms or the approved primitive registry. This note does not classify them as
-impossible and does not propose a new primitive.
+These paths remain compatible with the result. The existing owner premise is
+present precisely as governance content; the derivational and convention-only
+paths are not supplied by the four axioms or approved primitive registry. This
+note does not classify them as impossible and does not propose a new primitive.
 
 ### N7 — steelman
 
-The strongest objection is that angles are already measured in radians, so
-`beta=1` may be a coordinate convention rather than new physics. That
-objection succeeds after the fixed-locus scalar and the physical holonomy have
-been proved to be the same observable in the same coordinate. The current
-axioms name neither object and contain no such identity. Thus the objection
-identifies a viable ratification or theorem path while leaving the present
-non-entailment countermodel intact.
+The strongest objection is that the current Class B AC(ii) premise already
+licenses `beta=1`, and that radians then make the identity coefficient a
+coordinate statement rather than new physics. The first point is correct on
+the owner-governed lane: the premise supplies the result, but does not derive
+it from the axioms. The coordinate objection succeeds if the fixed-locus scalar
+and the physical eta angle are first proved to be the same observable in the
+same coordinate. The current axioms name neither object and contain no such
+identity. Thus the objection identifies the governance and same-observable
+paths while leaving the present derivational non-entailment intact.
 
 ### N8 — cross-cycle echo
 
 | Similar mechanism | Was its wall retired? | Applicability here |
 |---|---|---|
-| scale-reference primitive | calibration made explicit by owner approval | an analogous h-unit primitive would be a premise, not a derivation of `beta=1` |
-| registered mass-coordinate reconstruction | phase reconstructed after state data are supplied | does not establish the h-unit identity for the physical fixed-locus observable |
+| AC(ii) Tier-A-to-Class-B adoption | removed from live Tier-A by owner governance; the two owner atoms remain premise content | records the present license but does not retire it by derivation |
+| theta retirement | the registry records a retained-derivation retirement mechanism at adoption; no theta theorem is used here | the analogous mechanism here is a retained same-observable/readout theorem that makes AC(ii) redundant |
+| scale-reference primitive | calibration made explicit by owner approval | an analogous h-unit primitive would relocate the premise, not derive `beta=1` |
+| registered mass-coordinate reconstruction | reconstructs phase after state data are supplied; current source row is unaudited | does not establish the h-unit identity for the physical fixed-locus observable |
+| identity-unit/radian-convention source routes | current relevant source rows are unaudited, so they are not used as authority here | they motivate convention tests but do not refute this direct countermodel |
 
-Both mechanisms have been considered and do not refute the narrow
+All listed mechanisms have been considered and do not refute the narrow
 current-surface claim.
 
 **Gate result: PASS.** N1–N8 support the finite-record, current-surface
@@ -180,4 +211,4 @@ Run:
 python3 scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
 ```
 
-Expected result: `PASS=35`, `FAIL=0`.
+Expected result: `PASS=40`, `FAIL=0`.

--- a/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
@@ -5,8 +5,10 @@ Part A: exact beta family
 -------------------------
   [PASS] empty record reads zero for every tested beta
   [PASS] finite disjoint additivity holds for every tested beta
-  [PASS] target cycle value is 2/3
-  [PASS] countermodel cycle value is 4/3
+  [PASS] target singleton eta angle is 2/9
+  [PASS] countermodel singleton eta angle is 4/9
+  [PASS] target cycle holonomy is 2/3
+  [PASS] countermodel cycle holonomy is 4/3
   [PASS] target and countermodel share the same h
   [PASS] target and countermodel are distinct
 
@@ -33,20 +35,23 @@ Part D: source and axiom guards
   [PASS] current Record axiom contains empty-zero
   [PASS] current Record axiom contains finite additivity
   [PASS] current axioms withhold physical-observable identification
+  [PASS] scale reference withholds dimensionless readout content
+  [PASS] kinetic isotropy withholds phase and readout bridge
   [PASS] note grants h-class explicitly
   [PASS] note states the beta countermodel
+  [PASS] note matches singleton eta angle and cycle holonomy
   [PASS] note limits claim to current finite-record surface
   [PASS] note preserves a future same-observable theorem
   [PASS] note does not force r
-  [PASS] N1 contains six attempted routes
+  [PASS] N1 contains seven attempted routes
   [PASS] N2 collapses to one wall
   [PASS] N3 records the required phrase scan
   [PASS] N4 uses no prior negative witness
   [PASS] N5 names tested resolutions
   [PASS] N6 records convention and theorem paths
-  [PASS] N7 contains the radian steelman
-  [PASS] N8 considers the primitive and coordinate mechanisms
+  [PASS] N7 contains the owner-premise and coordinate steelman
+  [PASS] N8 considers governance, derivation, primitive, and coordinate mechanisms
   [PASS] discipline gate records PASS
 
 ========================================================================
-TOTAL: PASS=35, FAIL=0
+TOTAL: PASS=40, FAIL=0

--- a/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
@@ -1,216 +1,52 @@
-AC_phi_lambda R-eta direct-license h-class/h-unit non-supply no-go verifier
+Record additivity and the R-eta unit-calibration countermodel
+========================================================================
 
-========================================================================================
-A. source presence and Tier-A boundary
-========================================================================================
-[PASS] exists: docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
-[PASS] exists: docs/audit/data/tier_a_admissions.json
-[PASS] exists: docs/audit/data/audit_ledger.json
-[PASS] exists: docs/MINIMAL_AXIOMS_2026-06-29.md
-[PASS] exists: docs/audit/data/axiom_premise_nodes.json
-[PASS] exists: docs/ADMITTED_INPUT_REGISTRY_TIER_A_NOTE_2026-05-23.md
-[PASS] exists: docs/ACPHILAMBDA_R_ETA_READOUT_IDENTIFICATION_NARROWING_BOUNDED_THEOREM_NOTE_2026-06-11.md
-[PASS] exists: docs/SUPPLIED_READOUT_CONTEXT_TWO_COMPONENT_DECOMPOSITION_BOUNDED_NOTE_2026-07-02.md
-[PASS] exists: docs/ACPHILAMBDA_R_ETA_W2_REGISTRABILITY_CONTEXT_BRIDGE_NOTE_2026-06-18.md
-[PASS] exists: docs/KOIDE_APS_C3_FIXED_LOCUS_WEIGHTS_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md
-[PASS] exists: docs/ACPHILAMBDA_REGISTRABLE_CYCLE_HOLONOMY_NORMAL_FORM_2026-07-01.md
-[PASS] exists: docs/ACPHILAMBDA_DEFECT_IDENTITY_UNIT_RESCALE_OBSTRUCTION_2026-07-01.md
-[PASS] exists: docs/ACPHILAMBDA_R_ETA_ANGLE_NATIVE_FRONTIER_NO_GO_NOTE_2026-07-04.md
-[PASS] exists: docs/RECORD_CONTENT_READOUT_LICENSE_SPLIT_REGISTRATION_UNREACHABILITY_THEOREM_NOTE_2026-07-02.md
-[PASS] exists: docs/REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md
-[PASS] AC_phi_lambda remains the live Tier-A target
-[PASS] AC minimum decomposition keeps R-eta
-[PASS] AC minimum decomposition keeps occupancy separate
-[PASS] AC statement names density-read-as-angle R-eta
-[PASS] human registry names R-eta
-[PASS] note declares Type no_go
-[PASS] note declares Claim type no_go
-[PASS] note declares independent audit boundary
-[PASS] note says R-eta is not retired
-[PASS] note says AC_phi_lambda is not retired
-[PASS] note says no registry/axiom/primitive edit
-[PASS] forbidden overclaim absent: R-eta is retired
-[PASS] forbidden overclaim absent: AC_phi_lambda is retired
-[PASS] forbidden overclaim absent: A_R-eta is derived.
-[PASS] forbidden overclaim absent: therefore R-eta closes
-[PASS] forbidden overclaim absent: audit_status: audited_clean
-[PASS] forbidden overclaim absent: effective_status: retained
-[PASS] forbidden overclaim absent: promoted to retained
+Part A: exact beta family
+-------------------------
+  [PASS] empty record reads zero for every tested beta
+  [PASS] finite disjoint additivity holds for every tested beta
+  [PASS] target cycle value is 2/3
+  [PASS] countermodel cycle value is 4/3
+  [PASS] target and countermodel share the same h
+  [PASS] target and countermodel are distinct
 
-========================================================================================
-B. axiom and primitive boundary pins
-========================================================================================
-[PASS] approved premise registry has minimal axioms
-[PASS] approved premise registry excludes R-eta
-[PASS] minimal axioms contain boundary phrase: Records form.
-[PASS] minimal axioms contain boundary phrase: A readout value is determined by record content alone
-[PASS] minimal axioms contain boundary phrase: scalar readout `I` is additive
-[PASS] minimal axioms contain boundary phrase: context selection
-[PASS] minimal axioms contain boundary phrase: measurement basis selection
-[PASS] minimal axioms contain boundary phrase: formation rules
-[PASS] minimal axioms contain boundary phrase: source/action and physical-observable identification
-[PASS] minimal axioms name AC_phi_lambda as outside axioms
-[PASS] realized-state primitive withholds no state
-[PASS] realized-state primitive withholds measure
-[PASS] realized-state primitive withholds weighting
-[PASS] realized-state primitive withholds probability rule
-[PASS] realized-state primitive withholds normalization rule
-[PASS] realized-state primitive withholds value
+Part B: content and symmetry
+----------------------------
+  [PASS] readout is translation invariant
+  [PASS] readout is proper-cubic-rotation invariant
+  [PASS] readout is cycle-position permutation invariant
+  [PASS] real readout is conjugation even
+  [PASS] readout depends on record collection through cardinality
 
-========================================================================================
-C. source-surface h-class/h-unit pins
-========================================================================================
-[PASS] narrowing source contains A_R-eta
-[PASS] narrowing source contains **(h-class)** class membership
-[PASS] narrowing source contains **(h-unit)** identity reading
-[PASS] narrowing source contains The surviving atom
-[PASS] narrowing source contains remains admitted
-[PASS] supplied-context source contains C1 (FRAME)
-[PASS] supplied-context source contains C2 (WEIGHTING)
-[PASS] supplied-context source contains C1 Does Not Supply C2
-[PASS] supplied-context source contains C2 Does Not Supply C1
-[PASS] supplied-context source contains No C1 supplier is derived here
-[PASS] W2 source contains supplied finite context algebra
-[PASS] W2 source contains physical carrier realization
-[PASS] W2 source contains The value atom `A_R-eta` remains admitted
-[PASS] W2 source contains not a value derivation and not an admission retirement
-[PASS] fixed-locus source contains L₃(1,2)
-[PASS] fixed-locus source contains 2/9
-[PASS] fixed-locus source excludes physical readout bridge
-[PASS] normal-form source contains Phi = S_sum = 2/3
-[PASS] normal-form source contains W_cycle_holonomy_value
-[PASS] normal-form source contains physical charged-lepton readout
-[PASS] normal-form source contains No derivation is supplied
-[PASS] defect source contains W_defect_identity_unit
-[PASS] defect source contains identity-unit member
-[PASS] defect source contains rescale-breaking
-[PASS] angle frontier source contains Phi = S_sum
-[PASS] angle frontier source contains live R-eta license
-[PASS] angle frontier source contains license target
-[PASS] record split source contains record-determined content
-[PASS] record split source contains readout-construction
-[PASS] record split source contains license split
+Part C: arbitrary finite additivity
+-----------------------------------
+  [PASS] cardinality formula holds at n=0
+  [PASS] cardinality formula holds at n=1
+  [PASS] cardinality formula holds at n=2
+  [PASS] cardinality formula holds at n=3
+  [PASS] cardinality formula holds at n=4
+  [PASS] cardinality formula holds at n=5
+  [PASS] three-way disjoint additivity
 
-========================================================================================
-D. dependency row status checks
-========================================================================================
-[PASS] ledger row exists for ACPHILAMBDA_R_ETA_READOUT_IDENTIFICATION_NARROWING_BOUNDED_THEOREM_NOTE_2026-06-11.md
-[PASS] ACPHILAMBDA_R_ETA_READOUT_IDENTIFICATION_NARROWING_BOUNDED_THEOREM_NOTE_2026-06-11.md is not unbounded retained
-[PASS] ACPHILAMBDA_R_ETA_READOUT_IDENTIFICATION_NARROWING_BOUNDED_THEOREM_NOTE_2026-06-11.md has claim type
-[PASS] ledger row exists for SUPPLIED_READOUT_CONTEXT_TWO_COMPONENT_DECOMPOSITION_BOUNDED_NOTE_2026-07-02.md
-[PASS] SUPPLIED_READOUT_CONTEXT_TWO_COMPONENT_DECOMPOSITION_BOUNDED_NOTE_2026-07-02.md is not unbounded retained
-[PASS] SUPPLIED_READOUT_CONTEXT_TWO_COMPONENT_DECOMPOSITION_BOUNDED_NOTE_2026-07-02.md has claim type
-[PASS] ledger row exists for ACPHILAMBDA_R_ETA_W2_REGISTRABILITY_CONTEXT_BRIDGE_NOTE_2026-06-18.md
-[PASS] ACPHILAMBDA_R_ETA_W2_REGISTRABILITY_CONTEXT_BRIDGE_NOTE_2026-06-18.md is not unbounded retained
-[PASS] ACPHILAMBDA_R_ETA_W2_REGISTRABILITY_CONTEXT_BRIDGE_NOTE_2026-06-18.md has claim type
-[PASS] ledger row exists for KOIDE_APS_C3_FIXED_LOCUS_WEIGHTS_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md
-[PASS] KOIDE_APS_C3_FIXED_LOCUS_WEIGHTS_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md is not unbounded retained
-[PASS] KOIDE_APS_C3_FIXED_LOCUS_WEIGHTS_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md has claim type
-[PASS] ledger row exists for ACPHILAMBDA_REGISTRABLE_CYCLE_HOLONOMY_NORMAL_FORM_2026-07-01.md
-[PASS] ACPHILAMBDA_REGISTRABLE_CYCLE_HOLONOMY_NORMAL_FORM_2026-07-01.md is not unbounded retained
-[PASS] ACPHILAMBDA_REGISTRABLE_CYCLE_HOLONOMY_NORMAL_FORM_2026-07-01.md has claim type
-[PASS] ledger row exists for ACPHILAMBDA_DEFECT_IDENTITY_UNIT_RESCALE_OBSTRUCTION_2026-07-01.md
-[PASS] ACPHILAMBDA_DEFECT_IDENTITY_UNIT_RESCALE_OBSTRUCTION_2026-07-01.md is not unbounded retained
-[PASS] ACPHILAMBDA_DEFECT_IDENTITY_UNIT_RESCALE_OBSTRUCTION_2026-07-01.md has claim type
-[PASS] ledger row exists for ACPHILAMBDA_R_ETA_ANGLE_NATIVE_FRONTIER_NO_GO_NOTE_2026-07-04.md
-[PASS] ACPHILAMBDA_R_ETA_ANGLE_NATIVE_FRONTIER_NO_GO_NOTE_2026-07-04.md is not unbounded retained
-[PASS] ACPHILAMBDA_R_ETA_ANGLE_NATIVE_FRONTIER_NO_GO_NOTE_2026-07-04.md has claim type
-[PASS] ledger row exists for RECORD_CONTENT_READOUT_LICENSE_SPLIT_REGISTRATION_UNREACHABILITY_THEOREM_NOTE_2026-07-02.md
-[PASS] RECORD_CONTENT_READOUT_LICENSE_SPLIT_REGISTRATION_UNREACHABILITY_THEOREM_NOTE_2026-07-02.md is not unbounded retained
-[PASS] RECORD_CONTENT_READOUT_LICENSE_SPLIT_REGISTRATION_UNREACHABILITY_THEOREM_NOTE_2026-07-02.md has claim type
-[PASS] new row not required before audit pipeline seeding
+Part D: source and axiom guards
+-------------------------------
+  [PASS] current Record axiom contains empty-zero
+  [PASS] current Record axiom contains finite additivity
+  [PASS] current axioms withhold physical-observable identification
+  [PASS] note grants h-class explicitly
+  [PASS] note states the beta countermodel
+  [PASS] note limits claim to current finite-record surface
+  [PASS] note preserves a future same-observable theorem
+  [PASS] note does not force r
+  [PASS] N1 contains six attempted routes
+  [PASS] N2 collapses to one wall
+  [PASS] N3 records the required phrase scan
+  [PASS] N4 uses no prior negative witness
+  [PASS] N5 names tested resolutions
+  [PASS] N6 records convention and theorem paths
+  [PASS] N7 contains the radian steelman
+  [PASS] N8 considers the primitive and coordinate mechanisms
+  [PASS] discipline gate records PASS
 
-========================================================================================
-E. fixed-locus and holonomy algebra
-========================================================================================
-[PASS] L = 2/9
-[PASS] S_sum = 3L = 2/3
-[PASS] Phi(c) = c S_sum hits target at c=1
-[PASS] Phi_beta hits target at beta=1
-[PASS] target is not the single density L
-[PASS] target is not count normalization 1
-[PASS] target is not zero
-[PASS] 2*pi packaging misses target
-[PASS] 1/3 unit maps S_sum back to L
-[PASS] 3 unit maps single density L to target
-[PASS] same target can be fit by different class/unit pairs
-[PASS] target below pi
-[PASS] target nonzero bare angle
-
-========================================================================================
-F. record-additive h-class witnesses
-========================================================================================
-[PASS] zero empty-record readout is zero
-[PASS] zero is additive on disjoint sample records
-[PASS] zero depends only on record content
-[PASS] count empty-record readout is zero
-[PASS] count is additive on disjoint sample records
-[PASS] count depends only on record content
-[PASS] single_density empty-record readout is zero
-[PASS] single_density is additive on disjoint sample records
-[PASS] single_density depends only on record content
-[PASS] unaveraged_fixed_locus_sum empty-record readout is zero
-[PASS] unaveraged_fixed_locus_sum is additive on disjoint sample records
-[PASS] unaveraged_fixed_locus_sum depends only on record content
-[PASS] double_sum empty-record readout is zero
-[PASS] double_sum is additive on disjoint sample records
-[PASS] double_sum depends only on record content
-[PASS] zero map misses target
-[PASS] count map misses target
-[PASS] single-density map gives L
-[PASS] unaveraged fixed-locus sum gives target
-[PASS] double sum misses target
-[PASS] same record frame admits multiple additive scalar values
-[PASS] Record additivity alone does not select the target member
-
-========================================================================================
-G. h-unit and C1/C2 independence witnesses
-========================================================================================
-[PASS] beta=0 gives an additive scalar multiple
-[PASS] beta=1/3 gives an additive scalar multiple
-[PASS] beta=1 gives an additive scalar multiple
-[PASS] beta=2*pi gives an additive scalar multiple
-[PASS] beta=3 gives an additive scalar multiple
-[PASS] only beta=1 in tested set hits target
-[PASS] beta=2*pi is not identity unit
-[PASS] beta=0 is zero readout
-[PASS] beta=1/3 recovers single-density value
-[PASS] C1 fixed frame with w=1 is additive
-[PASS] C1 fixed frame with w=2 is additive
-[PASS] same frame different C2 weights yield different values
-[PASS] Hadamard mixed frame has equal squared weights
-[PASS] Hadamard mixed first cell is not original unit cell
-[PASS] equal weighting alone does not recover original frame
-
-========================================================================================
-H. note discipline and no-overclaim checks
-========================================================================================
-[PASS] note contains required boundary: bounded route no-go
-[PASS] note contains required boundary: h-class
-[PASS] note contains required boundary: h-unit
-[PASS] note contains required boundary: A_R-eta
-[PASS] note contains required boundary: This implication is invalid
-[PASS] note contains required boundary: a successful proof must derive both h-class and h-unit
-[PASS] note contains required boundary: A future direct readout-license theorem remains possible
-[PASS] note contains required boundary: h-class theorem
-[PASS] note contains required boundary: h-unit theorem
-[PASS] note contains required boundary: Combined direct-license theorem
-[PASS] note contains required boundary: Owner governance
-[PASS] note contains N1 no-go gate
-[PASS] note contains N2 no-go gate
-[PASS] note contains N3 no-go gate
-[PASS] note contains N4 no-go gate
-[PASS] note contains N5 no-go gate
-[PASS] note contains N6 no-go gate
-[PASS] note contains N7 no-go gate
-[PASS] note contains N8 no-go gate
-[PASS] note links Tier-A residual atom
-[PASS] note links minimal axioms
-[PASS] note names narrowing source as context
-[PASS] note does not use generated audit ledger as authority
-[PASS] angle frontier classifies Phi=S_sum as target
-[PASS] W2 context leaves physical carrier realization open
-[PASS] supplied context says frame does not supply weighting
-[PASS] defect rescale leaves c=1 open
-
-TOTAL: PASS=181 FAIL=0 CHECKS=181
+========================================================================
+TOTAL: PASS=35, FAIL=0

--- a/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
@@ -11,6 +11,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 NOTE = ROOT / "docs" / "ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md"
 AXIOMS = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+SCALE_REFERENCE = ROOT / "docs" / "SCALE_REFERENCE_PRIMITIVE_NOTE.md"
+KINETIC_ISOTROPY = ROOT / "docs" / "KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md"
 
 PASS = 0
 FAIL = 0
@@ -46,6 +48,7 @@ def main() -> int:
     empty: frozenset[tuple[int, int, int]] = frozenset()
     r = frozenset({(0, 0, 0), (1, 0, 0)})
     s = frozenset({(0, 1, 0), (0, 0, 1), (1, 1, 0)})
+    singleton = frozenset({(0, 0, 0)})
     cycle = frozenset({(0, 0, 0), (1, 0, 0), (0, 1, 0)})
 
     section("Part A: exact beta family")
@@ -55,8 +58,10 @@ def main() -> int:
         "finite disjoint additivity holds for every tested beta",
         all(readout(beta, h, r | s) == readout(beta, h, r) + readout(beta, h, s) for beta in betas),
     )
-    check("target cycle value is 2/3", readout(beta_target, h, cycle) == Fraction(2, 3))
-    check("countermodel cycle value is 4/3", readout(beta_counter, h, cycle) == Fraction(4, 3))
+    check("target singleton eta angle is 2/9", readout(beta_target, h, singleton) == Fraction(2, 9))
+    check("countermodel singleton eta angle is 4/9", readout(beta_counter, h, singleton) == Fraction(4, 9))
+    check("target cycle holonomy is 2/3", readout(beta_target, h, cycle) == Fraction(2, 3))
+    check("countermodel cycle holonomy is 4/3", readout(beta_counter, h, cycle) == Fraction(4, 3))
     check("target and countermodel share the same h", h == Fraction(2, 9))
     check("target and countermodel are distinct", readout(beta_target, h, cycle) != readout(beta_counter, h, cycle))
 
@@ -92,22 +97,29 @@ def main() -> int:
     section("Part D: source and axiom guards")
     note = NOTE.read_text(encoding="utf-8")
     axioms = AXIOMS.read_text(encoding="utf-8")
+    scale_reference = SCALE_REFERENCE.read_text(encoding="utf-8")
+    kinetic_isotropy = KINETIC_ISOTROPY.read_text(encoding="utf-8")
+    scale_flat = " ".join(scale_reference.split())
+    kinetic_flat = " ".join(kinetic_isotropy.split())
     check("current Record axiom contains empty-zero", "I(empty)=0" in axioms)
     check("current Record axiom contains finite additivity", "scalar readout `I` is additive" in " ".join(axioms.split()))
     check("current axioms withhold physical-observable identification", "source/action and physical-observable identification" in axioms)
+    check("scale reference withholds dimensionless readout content", "no mass ratio, coupling, mixing angle, phase, selector, readout bridge" in scale_flat)
+    check("kinetic isotropy withholds phase and readout bridge", "No mass ratio, coupling, mixing angle, phase, or selector is supplied" in kinetic_flat and "readout bridge" in kinetic_flat)
     check("note grants h-class explicitly", "Grant the R-eta h-class hypothesis" in note)
     check("note states the beta countermodel", "I_beta(R) = beta h N(R)" in note)
+    check("note matches singleton eta angle and cycle holonomy", "|delta_beta| = I_beta({x}) = beta h" in note and "Phi_beta = I_beta(C) = 3 beta h" in note)
     check("note limits claim to current finite-record surface", "finite-record, current-surface" in note)
     check("note preserves a future same-observable theorem", "future same-observable holonomy theorem" in note)
     check("note does not force r", "does not force\n`r=1/2`" in note)
-    check("N1 contains six attempted routes", note.count("| ATTEMPTED |") == 6)
+    check("N1 contains seven attempted routes", note.count("| ATTEMPTED |") == 7)
     check("N2 collapses to one wall", "one wall: `W_unit`" in note)
     check("N3 records the required phrase scan", "The proof text was scanned for" in note)
     check("N4 uses no prior negative witness", "No prior no-go row is cited as evidence" in note)
-    check("N5 names tested resolutions", "empty collection, a single record, finite" in note)
-    check("N6 records convention and theorem paths", "owner-approved `beta=1` coordinate calibration" in note and "same-observable determinant-line/holonomy theorem" in note)
-    check("N7 contains the radian steelman", "angles are already measured in radians" in note)
-    check("N8 considers the primitive and coordinate mechanisms", "scale-reference primitive" in note and "registered mass-coordinate reconstruction" in note)
+    check("N5 names tested resolutions", "empty collection, a singleton eta-angle" in note and "three-record cycle holonomy" in note)
+    check("N6 records convention and theorem paths", "convention-only coordinate ratification" in note and "same-observable determinant-line/holonomy theorem" in note)
+    check("N7 contains the owner-premise and coordinate steelman", "current Class B AC(ii) premise already" in note and "same observable" in note)
+    check("N8 considers governance, derivation, primitive, and coordinate mechanisms", "Tier-A-to-Class-B adoption" in note and "theta retirement" in note and "scale-reference primitive" in note and "registered mass-coordinate reconstruction" in note)
     check("discipline gate records PASS", "**Gate result: PASS.**" in note)
 
     print("\n" + "=" * 72)

--- a/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
@@ -1,31 +1,16 @@
 #!/usr/bin/env python3
+"""Countermodels showing Record additivity leaves the R-eta unit free."""
+
 from __future__ import annotations
 
-import json
-import math
-import re
+import itertools
+from fractions import Fraction
 from pathlib import Path
-
-import sympy as sp
 
 
 ROOT = Path(__file__).resolve().parents[1]
-DOCS = ROOT / "docs"
-NOTE = DOCS / "ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md"
-TIER_A = DOCS / "audit" / "data" / "tier_a_admissions.json"
-LEDGER = DOCS / "audit" / "data" / "audit_ledger.json"
-AXIOMS = DOCS / "MINIMAL_AXIOMS_2026-06-29.md"
-AXIOM_PREMISES = DOCS / "audit" / "data" / "axiom_premise_nodes.json"
-REGISTRY = DOCS / "ADMITTED_INPUT_REGISTRY_TIER_A_NOTE_2026-05-23.md"
-NARROWING = DOCS / "ACPHILAMBDA_R_ETA_READOUT_IDENTIFICATION_NARROWING_BOUNDED_THEOREM_NOTE_2026-06-11.md"
-SUPPLIED_CONTEXT = DOCS / "SUPPLIED_READOUT_CONTEXT_TWO_COMPONENT_DECOMPOSITION_BOUNDED_NOTE_2026-07-02.md"
-W2_CONTEXT = DOCS / "ACPHILAMBDA_R_ETA_W2_REGISTRABILITY_CONTEXT_BRIDGE_NOTE_2026-06-18.md"
-FIXED_LOCUS = DOCS / "KOIDE_APS_C3_FIXED_LOCUS_WEIGHTS_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md"
-NORMAL_FORM = DOCS / "ACPHILAMBDA_REGISTRABLE_CYCLE_HOLONOMY_NORMAL_FORM_2026-07-01.md"
-DEFECT = DOCS / "ACPHILAMBDA_DEFECT_IDENTITY_UNIT_RESCALE_OBSTRUCTION_2026-07-01.md"
-ANGLE_FRONTIER = DOCS / "ACPHILAMBDA_R_ETA_ANGLE_NATIVE_FRONTIER_NO_GO_NOTE_2026-07-04.md"
-RECORD_SPLIT = DOCS / "RECORD_CONTENT_READOUT_LICENSE_SPLIT_REGISTRATION_UNREACHABILITY_THEOREM_NOTE_2026-07-02.md"
-REALIZED = DOCS / "REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md"
+NOTE = ROOT / "docs" / "ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md"
+AXIOMS = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
 
 PASS = 0
 FAIL = 0
@@ -33,323 +18,100 @@ FAIL = 0
 
 def check(label: str, ok: bool, detail: object = "") -> None:
     global PASS, FAIL
-    if ok:
+    if bool(ok):
         PASS += 1
-        print(f"[PASS] {label}")
+        tag = "PASS"
     else:
         FAIL += 1
-        suffix = f" :: {detail}" if detail else ""
-        print(f"[FAIL] {label}{suffix}")
+        tag = "FAIL"
+    suffix = f"  ({detail})" if detail != "" else ""
+    print(f"  [{tag}] {label}{suffix}")
 
 
 def section(title: str) -> None:
-    print("\n" + "=" * 88)
-    print(title)
-    print("=" * 88)
+    print(f"\n{title}\n{'-' * len(title)}")
 
 
-def read(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
-
-
-def flat(text: str) -> str:
-    return re.sub(r"\s+", " ", text)
-
-
-def ledger_row_by_path(path: str) -> dict | None:
-    rows = json.loads(read(LEDGER))["rows"]
-    matches = [row for row in rows.values() if row.get("note_path") == path]
-    if not matches:
-        return None
-    if len(matches) != 1:
-        raise AssertionError(f"ledger matches for {path}: {len(matches)}")
-    return matches[0]
-
-
-def lin(coeffs: tuple[sp.Expr, ...], vec: tuple[sp.Expr, ...]) -> sp.Expr:
-    return sp.simplify(sum(c * v for c, v in zip(coeffs, vec)))
-
-
-def additive(coeffs: tuple[sp.Expr, ...], x: tuple[sp.Expr, ...], y: tuple[sp.Expr, ...]) -> bool:
-    xy = tuple(a + b for a, b in zip(x, y))
-    return sp.simplify(lin(coeffs, xy) - lin(coeffs, x) - lin(coeffs, y)) == 0
+def readout(beta: Fraction, h: Fraction, records: frozenset[tuple[int, int, int]]) -> Fraction:
+    return beta * h * len(records)
 
 
 def main() -> int:
-    print("AC_phi_lambda R-eta direct-license h-class/h-unit non-supply no-go verifier")
+    print("Record additivity and the R-eta unit-calibration countermodel")
+    print("=" * 72)
 
-    paths = [
-        NOTE,
-        TIER_A,
-        LEDGER,
-        AXIOMS,
-        AXIOM_PREMISES,
-        REGISTRY,
-        NARROWING,
-        SUPPLIED_CONTEXT,
-        W2_CONTEXT,
-        FIXED_LOCUS,
-        NORMAL_FORM,
-        DEFECT,
-        ANGLE_FRONTIER,
-        RECORD_SPLIT,
-        REALIZED,
-    ]
+    h = Fraction(2, 9)
+    beta_target = Fraction(1, 1)
+    beta_counter = Fraction(2, 1)
+    empty: frozenset[tuple[int, int, int]] = frozenset()
+    r = frozenset({(0, 0, 0), (1, 0, 0)})
+    s = frozenset({(0, 1, 0), (0, 0, 1), (1, 1, 0)})
+    cycle = frozenset({(0, 0, 0), (1, 0, 0), (0, 1, 0)})
 
-    section("A. source presence and Tier-A boundary")
-    for path in paths:
-        check(f"exists: {path.relative_to(ROOT)}", path.exists())
+    section("Part A: exact beta family")
+    betas = [Fraction(-1), Fraction(0), Fraction(1, 3), beta_target, beta_counter]
+    check("empty record reads zero for every tested beta", all(readout(beta, h, empty) == 0 for beta in betas))
+    check(
+        "finite disjoint additivity holds for every tested beta",
+        all(readout(beta, h, r | s) == readout(beta, h, r) + readout(beta, h, s) for beta in betas),
+    )
+    check("target cycle value is 2/3", readout(beta_target, h, cycle) == Fraction(2, 3))
+    check("countermodel cycle value is 4/3", readout(beta_counter, h, cycle) == Fraction(4, 3))
+    check("target and countermodel share the same h", h == Fraction(2, 9))
+    check("target and countermodel are distinct", readout(beta_target, h, cycle) != readout(beta_counter, h, cycle))
 
-    note = read(NOTE)
-    note_flat = flat(note)
-    tier = json.loads(read(TIER_A))
-    axioms = read(AXIOMS)
-    premises = json.loads(read(AXIOM_PREMISES))
-    registry = read(REGISTRY)
-    narrowing = read(NARROWING)
-    supplied_context = read(SUPPLIED_CONTEXT)
-    w2_context = read(W2_CONTEXT)
-    fixed_locus = read(FIXED_LOCUS)
-    normal_form = read(NORMAL_FORM)
-    defect = read(DEFECT)
-    angle_frontier = read(ANGLE_FRONTIER)
-    record_split = read(RECORD_SPLIT)
-    realized = read(REALIZED)
+    section("Part B: content and symmetry")
+    translated = frozenset((x + 7, y - 4, z + 2) for x, y, z in cycle)
+    rotated = frozenset((-y, x, z) for x, y, z in cycle)
+    check("readout is translation invariant", all(readout(beta, h, translated) == readout(beta, h, cycle) for beta in betas))
+    check("readout is proper-cubic-rotation invariant", all(readout(beta, h, rotated) == readout(beta, h, cycle) for beta in betas))
+    check(
+        "readout is cycle-position permutation invariant",
+        all(
+            readout(beta, h, frozenset(order)) == readout(beta, h, cycle)
+            for beta in betas
+            for order in itertools.permutations(cycle)
+        ),
+    )
+    check("real readout is conjugation even", all(complex(readout(beta, h, cycle)).conjugate() == complex(readout(beta, h, cycle)) for beta in betas))
+    check("readout depends on record collection through cardinality", readout(beta_target, h, r) == 2 * h and readout(beta_target, h, s) == 3 * h)
 
-    axioms_flat = flat(axioms)
-    registry_flat = flat(registry)
-    narrowing_flat = flat(narrowing)
-    supplied_flat = flat(supplied_context)
-    w2_flat = flat(w2_context)
-    fixed_flat = flat(fixed_locus)
-    normal_flat = flat(normal_form)
-    defect_flat = flat(defect)
-    angle_flat = flat(angle_frontier)
-    record_split_flat = flat(record_split)
-    realized_flat = flat(realized)
+    section("Part C: arbitrary finite additivity")
+    for n in range(6):
+        records = frozenset((i, 0, 0) for i in range(n))
+        check(f"cardinality formula holds at n={n}", readout(beta_counter, h, records) == beta_counter * h * n)
+    a = frozenset({(10, 0, 0)})
+    b = frozenset({(11, 0, 0), (12, 0, 0)})
+    c = frozenset({(13, 0, 0), (14, 0, 0), (15, 0, 0)})
+    check(
+        "three-way disjoint additivity",
+        readout(beta_counter, h, a | b | c)
+        == readout(beta_counter, h, a) + readout(beta_counter, h, b) + readout(beta_counter, h, c),
+    )
 
-    ac = tier["derivation_targets"]["staggered_dirac_realization_gate_note_2026-05-03"]
-    decomp = ac["minimum_decomposition"]
-    check("AC_phi_lambda remains the live Tier-A target", tier["genuine_admitted_input_count"] >= 1)
-    check("AC minimum decomposition keeps R-eta", "delta_readout_identification_R_eta" in decomp, decomp)
-    check("AC minimum decomposition keeps occupancy separate", "reading_occupancy_selection" in decomp, decomp)
-    check("AC statement names density-read-as-angle R-eta", "density-read-as-angle" in ac["statement"] and "R-eta" in ac["statement"])
-    check("human registry names R-eta", ("R-eta" in registry_flat or "R-\u03b7" in registry) and "density-read-as-angle" in registry_flat)
-    check("note declares Type no_go", "**Type:** no_go" in note)
-    check("note declares Claim type no_go", "**Claim type:** no_go" in note)
-    check("note declares independent audit boundary", "independent audit lane only" in note)
-    check("note says R-eta is not retired", "R-eta is not derived, refuted, re-graded, or removed from Tier-A" in note)
-    check("note says AC_phi_lambda is not retired", "AC_phi_lambda is not retired." in note)
-    check("note says no registry/axiom/primitive edit", "No registry, axiom, primitive, audit verdict, publication surface" in note)
-    for forbidden in [
-        "R-eta is retired",
-        "AC_phi_lambda is retired",
-        "A_R-eta is derived.",
-        "therefore R-eta closes",
-        "audit_status: audited_clean",
-        "effective_status: retained",
-        "promoted to retained",
-    ]:
-        check(f"forbidden overclaim absent: {forbidden}", forbidden not in note)
+    section("Part D: source and axiom guards")
+    note = NOTE.read_text(encoding="utf-8")
+    axioms = AXIOMS.read_text(encoding="utf-8")
+    check("current Record axiom contains empty-zero", "I(empty)=0" in axioms)
+    check("current Record axiom contains finite additivity", "scalar readout `I` is additive" in " ".join(axioms.split()))
+    check("current axioms withhold physical-observable identification", "source/action and physical-observable identification" in axioms)
+    check("note grants h-class explicitly", "Grant the R-eta h-class hypothesis" in note)
+    check("note states the beta countermodel", "I_beta(R) = beta h N(R)" in note)
+    check("note limits claim to current finite-record surface", "finite-record, current-surface" in note)
+    check("note preserves a future same-observable theorem", "future same-observable holonomy theorem" in note)
+    check("note does not force r", "does not force\n`r=1/2`" in note)
+    check("N1 contains six attempted routes", note.count("| ATTEMPTED |") == 6)
+    check("N2 collapses to one wall", "one wall: `W_unit`" in note)
+    check("N3 records the required phrase scan", "The proof text was scanned for" in note)
+    check("N4 uses no prior negative witness", "No prior no-go row is cited as evidence" in note)
+    check("N5 names tested resolutions", "empty collection, a single record, finite" in note)
+    check("N6 records convention and theorem paths", "owner-approved `beta=1` coordinate calibration" in note and "same-observable determinant-line/holonomy theorem" in note)
+    check("N7 contains the radian steelman", "angles are already measured in radians" in note)
+    check("N8 considers the primitive and coordinate mechanisms", "scale-reference primitive" in note and "registered mass-coordinate reconstruction" in note)
+    check("discipline gate records PASS", "**Gate result: PASS.**" in note)
 
-    section("B. axiom and primitive boundary pins")
-    check("approved premise registry has minimal axioms", "minimal_axioms" in premises["canonical_ids"])
-    check("approved premise registry excludes R-eta", all("R" not in cid and "eta" not in cid for cid in premises["canonical_ids"]))
-    for phrase in [
-        "Records form.",
-        "A readout value is determined by record content alone",
-        "scalar readout `I` is additive",
-        "context selection",
-        "measurement basis selection",
-        "formation rules",
-        "source/action and physical-observable identification",
-    ]:
-        check(f"minimal axioms contain boundary phrase: {phrase}", phrase in axioms_flat)
-    check("minimal axioms name AC_phi_lambda as outside axioms", "AC_phi_lambda" in axioms and "outside axiom content" in axioms_flat)
-    for phrase in ["no state", "measure", "weighting", "probability rule", "normalization rule", "value"]:
-        check(f"realized-state primitive withholds {phrase}", phrase in realized_flat)
-
-    section("C. source-surface h-class/h-unit pins")
-    for phrase in [
-        "A_R-eta",
-        "**(h-class)** class membership",
-        "**(h-unit)** identity reading",
-        "The surviving atom",
-        "remains admitted",
-    ]:
-        check(f"narrowing source contains {phrase}", phrase in narrowing)
-    for phrase in [
-        "C1 (FRAME)",
-        "C2 (WEIGHTING)",
-        "C1 Does Not Supply C2",
-        "C2 Does Not Supply C1",
-        "No C1 supplier is derived here",
-    ]:
-        check(f"supplied-context source contains {phrase}", phrase in supplied_context)
-    for phrase in [
-        "supplied finite context algebra",
-        "physical carrier realization",
-        "The value atom `A_R-eta` remains admitted",
-        "not a value derivation and not an admission retirement",
-    ]:
-        check(f"W2 source contains {phrase}", phrase in w2_flat)
-    for phrase in [
-        "L\u2083(1,2)",
-        "2/9",
-    ]:
-        check(f"fixed-locus source contains {phrase}", phrase in fixed_locus)
-    fixed_lower = fixed_flat.lower()
-    check("fixed-locus source excludes physical readout bridge", "physical readout" in fixed_lower or "physical single-summand" in fixed_lower)
-    for phrase in [
-        "Phi = S_sum = 2/3",
-        "W_cycle_holonomy_value",
-        "physical charged-lepton readout",
-        "No derivation is supplied",
-    ]:
-        check(f"normal-form source contains {phrase}", phrase in normal_form)
-    for phrase in [
-        "W_defect_identity_unit",
-        "identity-unit member",
-        "rescale-breaking",
-    ]:
-        check(f"defect source contains {phrase}", phrase in defect)
-    for phrase in [
-        "Phi = S_sum",
-        "live R-eta license",
-        "license target",
-    ]:
-        check(f"angle frontier source contains {phrase}", phrase in angle_frontier)
-    for phrase in [
-        "record-determined content",
-        "readout-construction",
-        "license split",
-    ]:
-        check(f"record split source contains {phrase}", phrase in record_split_flat)
-
-    section("D. dependency row status checks")
-    expected_paths = [
-        "docs/ACPHILAMBDA_R_ETA_READOUT_IDENTIFICATION_NARROWING_BOUNDED_THEOREM_NOTE_2026-06-11.md",
-        "docs/SUPPLIED_READOUT_CONTEXT_TWO_COMPONENT_DECOMPOSITION_BOUNDED_NOTE_2026-07-02.md",
-        "docs/ACPHILAMBDA_R_ETA_W2_REGISTRABILITY_CONTEXT_BRIDGE_NOTE_2026-06-18.md",
-        "docs/KOIDE_APS_C3_FIXED_LOCUS_WEIGHTS_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md",
-        "docs/ACPHILAMBDA_REGISTRABLE_CYCLE_HOLONOMY_NORMAL_FORM_2026-07-01.md",
-        "docs/ACPHILAMBDA_DEFECT_IDENTITY_UNIT_RESCALE_OBSTRUCTION_2026-07-01.md",
-        "docs/ACPHILAMBDA_R_ETA_ANGLE_NATIVE_FRONTIER_NO_GO_NOTE_2026-07-04.md",
-        "docs/RECORD_CONTENT_READOUT_LICENSE_SPLIT_REGISTRATION_UNREACHABILITY_THEOREM_NOTE_2026-07-02.md",
-    ]
-    for path in expected_paths:
-        row = ledger_row_by_path(path)
-        check(f"ledger row exists for {Path(path).name}", row is not None)
-        if row is not None:
-            check(f"{Path(path).name} is not unbounded retained", row.get("effective_status") != "retained", row.get("effective_status"))
-            check(f"{Path(path).name} has claim type", bool(row.get("claim_type")), row.get("claim_type"))
-    new_row = ledger_row_by_path("docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md")
-    if new_row is None:
-        check("new row not required before audit pipeline seeding", True)
-    else:
-        check("new row claim_type is no_go", new_row.get("claim_type") == "no_go", new_row.get("claim_type"))
-        check("new row audit status remains unaudited", new_row.get("audit_status") == "unaudited", new_row.get("audit_status"))
-        check("new row effective status remains unaudited", new_row.get("effective_status") == "unaudited", new_row.get("effective_status"))
-
-    section("E. fixed-locus and holonomy algebra")
-    L = sp.Rational(2, 9)
-    S_sum = 3 * L
-    c, beta = sp.symbols("c beta", real=True)
-    phi_c = c * S_sum
-    phi_beta = beta * S_sum
-    target = sp.Rational(2, 3)
-    check("L = 2/9", L == sp.Rational(2, 9))
-    check("S_sum = 3L = 2/3", S_sum == target)
-    check("Phi(c) = c S_sum hits target at c=1", sp.solve(sp.Eq(phi_c, target), c) == [1])
-    check("Phi_beta hits target at beta=1", sp.solve(sp.Eq(phi_beta, target), beta) == [1])
-    check("target is not the single density L", target != L)
-    check("target is not count normalization 1", target != 1)
-    check("target is not zero", target != 0)
-    check("2*pi packaging misses target", not math.isclose(float(2 * math.pi * float(S_sum)), float(target)))
-    check("1/3 unit maps S_sum back to L", sp.simplify(sp.Rational(1, 3) * S_sum - L) == 0)
-    check("3 unit maps single density L to target", sp.simplify(3 * L - target) == 0)
-    check("same target can be fit by different class/unit pairs", sp.simplify(1 * S_sum - 3 * L) == 0)
-    check("target below pi", float(target) < math.pi)
-    check("target nonzero bare angle", target > 0)
-
-    section("F. record-additive h-class witnesses")
-    x3 = (sp.Integer(1), sp.Integer(0), sp.Integer(2))
-    y3 = (sp.Integer(0), sp.Integer(3), sp.Integer(1))
-    state = (sp.Integer(1), sp.Integer(1), sp.Integer(1))
-    readouts = {
-        "zero": (sp.Integer(0), sp.Integer(0), sp.Integer(0)),
-        "count": (sp.Integer(1), sp.Integer(1), sp.Integer(1)),
-        "single_density": (L / 3, L / 3, L / 3),
-        "unaveraged_fixed_locus_sum": (L, L, L),
-        "double_sum": (2 * L, 2 * L, 2 * L),
-    }
-    values = {}
-    for name, coeffs in readouts.items():
-        check(f"{name} empty-record readout is zero", lin(coeffs, (0, 0, 0)) == 0)
-        check(f"{name} is additive on disjoint sample records", additive(coeffs, x3, y3))
-        values[name] = lin(coeffs, state)
-        check(f"{name} depends only on record content", all(c in coeffs for c in coeffs))
-    check("zero map misses target", values["zero"] != target)
-    check("count map misses target", values["count"] != target)
-    check("single-density map gives L", values["single_density"] == L)
-    check("unaveraged fixed-locus sum gives target", values["unaveraged_fixed_locus_sum"] == target)
-    check("double sum misses target", values["double_sum"] != target)
-    distinct_values = {sp.sstr(v) for v in values.values()}
-    check("same record frame admits multiple additive scalar values", len(distinct_values) == len(values), values)
-    check("Record additivity alone does not select the target member", sum(1 for v in values.values() if v == target) == 1)
-
-    section("G. h-unit and C1/C2 independence witnesses")
-    beta_values = [sp.Integer(0), sp.Rational(1, 3), sp.Integer(1), 2 * sp.pi, sp.Integer(3)]
-    beta_outputs = [sp.simplify(b * S_sum) for b in beta_values]
-    for b, out in zip(beta_values, beta_outputs):
-        check(f"beta={b} gives an additive scalar multiple", sp.simplify(out - b * S_sum) == 0)
-    check("only beta=1 in tested set hits target", sum(1 for out in beta_outputs if sp.simplify(out - target) == 0) == 1)
-    check("beta=2*pi is not identity unit", sp.simplify(2 * sp.pi * S_sum - target) != 0)
-    check("beta=0 is zero readout", beta_outputs[0] == 0)
-    check("beta=1/3 recovers single-density value", beta_outputs[1] == L)
-
-    x2 = (sp.Integer(1), sp.Integer(2))
-    y2 = (sp.Integer(3), sp.Integer(4))
-    coeff_w1 = (sp.Integer(1), sp.Integer(1))
-    coeff_w2 = (sp.Integer(1), sp.Integer(2))
-    check("C1 fixed frame with w=1 is additive", additive(coeff_w1, x2, y2))
-    check("C1 fixed frame with w=2 is additive", additive(coeff_w2, x2, y2))
-    check("same frame different C2 weights yield different values", lin(coeff_w1, x2) != lin(coeff_w2, x2))
-    H = sp.Matrix([[1, 1], [1, -1]]) / sp.sqrt(2)
-    unit = sp.Matrix([1, 0])
-    mixed = H * unit
-    check("Hadamard mixed frame has equal squared weights", sp.simplify(mixed[0] ** 2 - mixed[1] ** 2) == 0)
-    check("Hadamard mixed first cell is not original unit cell", sp.simplify(mixed[0] - 1) != 0)
-    check("equal weighting alone does not recover original frame", sp.simplify(mixed[1]) != 0)
-
-    section("H. note discipline and no-overclaim checks")
-    required = [
-        "bounded route no-go",
-        "h-class",
-        "h-unit",
-        "A_R-eta",
-        "This implication is invalid",
-        "a successful proof must derive both h-class and h-unit",
-        "A future direct readout-license theorem remains possible",
-        "h-class theorem",
-        "h-unit theorem",
-        "Combined direct-license theorem",
-        "Owner governance",
-    ]
-    for phrase in required:
-        check(f"note contains required boundary: {phrase}", phrase in note_flat)
-    for n in range(1, 9):
-        check(f"note contains N{n} no-go gate", f"**N{n}" in note)
-    check("note links Tier-A residual atom", "delta_readout_identification_R_eta" in note)
-    check("note links minimal axioms", "MINIMAL_AXIOMS_2026-06-29.md" in note)
-    check("note names narrowing source as context", "ACPHILAMBDA_R_ETA_READOUT_IDENTIFICATION_NARROWING_BOUNDED_THEOREM_NOTE_2026-06-11.md" in note)
-    check("note does not use generated audit ledger as authority", "AUDIT_LEDGER.md](" not in note)
-    check("angle frontier classifies Phi=S_sum as target", "live R-eta license" in angle_flat)
-    check("W2 context leaves physical carrier realization open", "physical charged-lepton carrier must be shown to realize this context" in w2_flat)
-    check("supplied context says frame does not supply weighting", "C1 Does Not Supply C2" in supplied_context)
-    check("defect rescale leaves c=1 open", "identity-unit member `c = 1`" in defect_flat)
-
-    print(f"\nTOTAL: PASS={PASS} FAIL={FAIL} CHECKS={PASS + FAIL}")
+    print("\n" + "=" * 72)
+    print(f"TOTAL: PASS={PASS}, FAIL={FAIL}")
     return 0 if FAIL == 0 else 1
 
 


### PR DESCRIPTION
## Summary
- replace the stale Tier-A-dependent R-eta verifier with the exact family `I_beta(R)=beta h N(R)`
- grant the h-class face and test the original AC(ii) h-unit at both resolutions: `|delta_beta|=beta h` for a singleton and `Phi_beta=3 beta h` for the three-record cycle
- exhibit `beta=1` and `beta=2` on the same granted `h=2/9` surface, giving `2/9` vs `4/9` locally and `2/3` vs `4/3` on the cycle
- verify empty-zero, finite additivity, content determination, translation/proper-cubic/cycle symmetry, conjugation evenness, and arbitrary finite cardinalities
- narrow the no-go to current finite-record direct inference while preserving the existing Class B premise, convention-ratification, and same-observable theorem paths
- include a full N1-N8 no-go-discipline packet with seven distinct attacks, one-wall collapse, hidden-hit classifications, exact AC(ii) residual matching, steelman, partial paths, and cross-cycle mechanisms
- remove stale live-Tier-A assumptions and the corrupt cache path

## Review fix
- match the countermodel directly to the adopted AC(ii) eta-angle identity `|delta|=h`; the cycle holonomy is retained as its additive consequence
- acknowledge that AC(ii) is already owner-approved Class B premise content while keeping governance distinct from axiom derivation
- distinguish historical/adoption mechanisms from current retained-grade proof authority

## Verification
- exact countermodel runner: 40 PASS / 0 FAIL
- independent symbolic check: `beta h(n+m)-beta hn-beta hm = 0`
- cache matches live runner output
- Python compilation passes
- changed files have no vocabulary-lint findings
- audit compatibility pipeline and strict lint pass with no errors
- GitHub `audit_pipeline` check passes

This changes no axiom, primitive, owner premise, registry, or audit verdict. Independent audit remains required.