### PR TITLE
Make the AC occupancy-grain obstruction self-contained

### DIFF
--- a/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -48,8 +48,9 @@ future physical CAR/action theorem that derives a specific Gaussian measure.
 Take any model of Lattice, Qubit, Admissibility, and the record-locking clauses.
 Keep its lattice, one-site possibility algebra, admissibility rule, records,
 and record contents fixed. For a finite pairwise-disjoint record collection
-`C`, let `N(C)` be its cardinality, fix one real `lambda > 1`, and grant the
-same auxiliary carrier assignment in both extensions:
+`C`, let `N(C)` be its cardinality, set the exact mathematical witness
+`lambda=2`, and grant the same auxiliary carrier assignment in both
+extensions:
 
 ```text
 A(C) = lambda I_(N(C)),

--- a/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -1,147 +1,178 @@
-# AC_phi_lambda Record Outcome-Orbit Occupancy Non-Supply No-Go
+# The Axiom Surface Does Not Select a Complex-vs-Realified Occupancy Grain
 
-**Date:** 2026-07-04
+**Date:** 2026-07-04; countermodel repair 2026-07-11
 **Type:** no_go
 **Claim type:** no_go
-**Status:** source-side bounded no-go; independent audit required before any
-effective-status change. This note does not derive `r = 1/2`, does not choose
-the orbit/holomorphic horn, does not adopt the orbit-occupancy premise, does
-not introduce a K-real primitive, does not retire `AC_phi_lambda` or
-`AC_phi_lambda(i)`, and does not edit any Tier-A registry, axiom, primitive,
-audit verdict, or publication surface.
-**Current-main posture (2026-07-06):** live `main` now records Tier-A count
-zero: theta was retired 2026-07-05 by retained derivation, and
-`AC_phi_lambda` was retired by owner-governance adoption. This note banks the
-historical Record outcome-orbit non-supply no-go only; it does not reopen,
-modify, or re-grade either retirement record, `tier_a_admissions.json`, or
-owner-governed premise data.
+**Status authority:** independent audit lane. This source proposal does not
+set or predict an audit verdict.
 **Primary runner:**
 [`scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py`](../scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py)
+**Runner cache:**
+[`logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt`](../logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt)
 
-## Target
+## Narrow no-go claim
 
-After the axiom hygiene, a tempting shortcut remains:
+Grant an invertible complex matter block `A`. Even with that grant, the
+[four axioms](MINIMAL_AXIOMS_2026-06-29.md) do not entail whether its additive,
+K-even determinant readout uses one complex determinant grain or the
+realified two-power grain.
+
+Two functionals on the same carrier are
 
 ```text
-Record names realized outcomes
-+ older Record wording used K/CPT orbits in a supplied readout context
-+ the determinant-power split identifies orbit/count-once versus sector/count-twice
-therefore AC_phi_lambda(i)'s occupancy realization binary is already in the axioms.
+F_C(A) = log |det_C A|,
+F_R(A) = log det_R R(A) = 2 F_C(A),
 ```
 
-The implication is invalid.
+where `R(A)` is the realification. Both are similarity invariant, invariant
+under complex conjugation, zero on the empty block, and additive under block
+direct sum. Under the positive scale deformation `A -> exp(t) A` on an
+`n`-dimensional complex block,
 
-The current public axiom memo,
-[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md), explicitly
-keeps `K`/CPT orbit structure, central-sector decomposition, Born weights,
-readout-context selection, measurement basis selection, probability rules, and
-formation rules outside the four axioms. The superseded June 5 Record wording
-did say that, once a readout context, finite central-sector decomposition, and
-fixed `K`/CPT conjugation were supplied, the realized outcome was the `K`/CPT
-orbit of the realized central sector. But even that older supplied-context
-sentence named the outcome object only. It did not attach a weight,
-normalization, occupancy rule, determinant power, or physical matter-statistics
-readout to that object.
+```text
+d/dt F_C(exp(t)A) at t=0 = n,
+d/dt F_R(exp(t)A) at t=0 = 2n.
+```
 
-## Finite Witness
+They therefore realize distinct occupancy grains while satisfying the same
+granted carrier symmetries and additive-readout requirements. The current
+axiom surface does not select between them.
 
-On the supplied two-outcome surface, let the registered outcome labels be
-`s` for the singlet and `d` for the doublet `K`/CPT orbit. Write
-`x = p_d / p_s` for the outcome-space weight ratio.
+This is a current-surface non-entailment result. It does not rule against a
+future physical CAR/action theorem that derives a specific Gaussian measure.
 
-The same outcome labels support both dictionaries already isolated in
-[`OCCUPANCY_ATOM_IS_THE_OUTCOME_DICTIONARY_FLOW_SELECTS_EQUIPARTITION_BOUNDED_NOTE_2026-06-12.md`](OCCUPANCY_ATOM_IS_THE_OUTCOME_DICTIONARY_FLOW_SELECTS_EQUIPARTITION_BOUNDED_NOTE_2026-06-12.md):
+## Exact countermodels
 
-| Dictionary | Outcome ratio | Interior fixed reading |
+The determinant identity
+
+```text
+det_R R(A)=det_C(A) conjugate(det_C(A))=|det_C(A)|^2
+```
+
+holds for every complex matrix. For invertible `A`, both logarithmic
+functionals are defined. If `A` and `B` are independent blocks, then
+
+```text
+F_C(A direct-sum B)=F_C(A)+F_C(B),
+F_R(A direct-sum B)=F_R(A)+F_R(B).
+```
+
+Complex conjugation leaves both values unchanged. Similarity
+`A -> S A S^(-1)` leaves both determinants unchanged. Thus neither basis
+invariance, K-evenness, nor additive composition distinguishes the
+functionals.
+
+The runner verifies the identities for generic symbolic `2 x 2` matrices and
+exact finite examples, then checks the scaling degrees `n` and `2n` for
+`n=1,2,3,4`.
+
+## Scope
+
+The result grants a complex carrier and a determinant-style readout. It does
+not derive a physical matter action, Berezin measure, K/CPT structure,
+determinant line, polarization, orbit quotient, or record-to-action map. It
+does not set `r`, `delta`, or any mass, and it does not force `r=1/2`.
+
+The live governance target is recorded in
+`docs/audit/data/owner_governed_premise_nodes.json` as AC(i), the matter-action
+occupancy grain. That registry identifies the target and is not a proof
+premise here.
+
+## No-Go Discipline Gate
+
+### N1 — alternative route enumeration
+
+| Route tested against the countermodel | Marker | Result and authority/check |
 |---|---|---|
-| Component dictionary `(1,2)` | `x = 2r` | `x = 1 -> r = 1/2` |
-| Slot dictionary `(1,1)` | `x = r` | `x = 1 -> r = 1` |
+| Complex carrier structure | ATTEMPTED | Both `F_C` and `F_R` are functorially constructed from the same complex block; runner Parts A–B. |
+| Complex-basis similarity invariance | ATTEMPTED | Both are unchanged by `S A S^(-1)`; runner Part B. |
+| K/conjugation evenness | ATTEMPTED | Both depend on `|det_C A|`; runner Part B. K/CPT is an extra grant because the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md) does not supply it. |
+| Empty-zero plus block additivity | ATTEMPTED | Both vanish on the empty determinant and add on direct sums; Record clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Part C. |
+| Positive scale response | ATTEMPTED | Both respond covariantly but with degrees `n` and `2n`; runner Part D. |
+| Pointwise realized-state evaluation | ATTEMPTED | Evaluating the same carrier at a realized state does not select the functional; [realized-state primitive](REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md) boundary. |
 
-The outcome object is identical in the two rows. Only the supplied dictionary
-changes. Therefore an axiom or context sentence saying "the outcome is a
-`K`/CPT orbit" cannot by itself determine which `r`-reading or determinant
-power is physical.
+No prior negative row is used as evidence.
 
-Block28 makes the same point in determinant language:
+### N2 — wall independence
 
-```text
-holomorphic/orbit count-once       -> det_C(K)
-realified/sector-tied count-twice  -> det_R R(K) = |det_C(K)|^2
-```
+The scoped claim has one wall: `W_grain`, the physical choice between the
+complex determinant line and its realification. Carrier existence is granted,
+so it is not counted as another wall.
 
-Record outcome naming supplies neither `det_C(K)` as the physical readout nor
-`det_R R(K)` as the physical readout. It supplies neither a measure nor a
-dictionary from outcome labels to determinant powers.
+### N3 — hidden-wall scan
 
-## No-Go Statement
+The proof text was scanned for `we assume`, `by construction`, `as is
+standard`, `the framework provides`, `bridge context`, `background`,
+`naturally`, `obviously`, `standard QFT`, `registered`, and `canonical`.
 
-Within the current axiom/primitive surface, Record outcome content does not
-retire `AC_phi_lambda(i)`. The current axioms explicitly keep the relevant
-`K`/CPT orbit and weighting structure downstream. The superseded
-supplied-context Record wording, even if quoted historically, names the
-outcome object but does not select the determinant-power dictionary. The live
-AC(i) survivor remains a physical measure/readout theorem: which grain or
-statistics the matter action implements.
-
-## What Moves
-
-| Surface | Movement |
+| Hit | Classification |
 |---|---|
-| "Orbit outcome is in the axioms" shortcut | pruned |
-| Current axiom/primitive review | K/CPT orbit structure and occupancy weights confirmed downstream |
-| AC(i) target | sharpened to dictionary/determinant-power selection, not outcome naming |
-| Tier-A registry | unchanged |
+| granted invertible complex block and determinant-style readout | explicit hypotheses that strengthen the countermodel |
+| `registered` in governance/coordinate discussion | non-load-bearing target or route description |
+| scan terms appearing in this checklist sentence | audit metadata, not proof steps |
 
-## What Does Not Move
+No hidden action, measure, polarization, or physical carrier selector is used.
 
-- `AC_phi_lambda` is not retired.
-- `AC_phi_lambda(i)` is not retired.
-- The orbit/holomorphic horn is not selected.
-- The sector/K-real horn is not selected.
-- `r = 1/2` is not derived, predicted, or preferred.
-- The orbit-occupancy premise candidate is not adopted.
-- No K-real primitive, readout-selection primitive, or occupancy primitive is
-  introduced.
-- No registry, primitive, axiom, audit status, or publication status is edited.
-- `AC_phi_lambda(ii)` / R-eta and theta are untouched.
+### N4 — residual matching
 
-## Relation To Existing Blocks
+| Prior negative witness | Witness residual | Current residual | Match/disposition |
+|---|---|---|---|
+| none | n/a | AC(i) complex-vs-realified physical occupancy grain | direct countermodels; no witness citation to drop |
 
-- [`ACPHILAMBDA_OCCUPANCY_SELECTION_REALIZED_STATE_REDUCTION_NOTE_2026-06-11.md`](ACPHILAMBDA_OCCUPANCY_SELECTION_REALIZED_STATE_REDUCTION_NOTE_2026-06-11.md)
-  names the measure-side realization binary as the live AC(i) survivor.
-- [`OCCUPANCY_ATOM_IS_THE_OUTCOME_DICTIONARY_FLOW_SELECTS_EQUIPARTITION_BOUNDED_NOTE_2026-06-12.md`](OCCUPANCY_ATOM_IS_THE_OUTCOME_DICTIONARY_FLOW_SELECTS_EQUIPARTITION_BOUNDED_NOTE_2026-06-12.md)
-  already states that Record names the outcome object, not the attached weight,
-  on the supplied two-outcome surface.
-- [`ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md`](ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md)
-  supplies the determinant-power split that the physical theorem still has to
-  select.
-- [`ACPHILAMBDA_MEASURE_BINARY_AXIOM_UPDATE_NO_GO_NOTE_2026-07-04.md`](ACPHILAMBDA_MEASURE_BINARY_AXIOM_UPDATE_NO_GO_NOTE_2026-07-04.md)
-  remains valid: axioms and approved primitives do not select the physical
-  matter-action statistics horn.
-- [`ACPHILAMBDA_OCCUPANCY_FORMATION_APPEND_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md`](ACPHILAMBDA_OCCUPANCY_FORMATION_APPEND_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md)
-  remains valid: Record formation/additivity does not identify the occupancy
-  dictionary or formation rule.
+The determinant identity is recomputed by the runner rather than inherited
+from a prior row.
 
-## Remaining Live Routes
+### N5 — rhetoric and resolution audit
 
-1. **Physical horn-selection theorem.** Derive the matter action's
-   holomorphic/K-orbit or realified/K-real readout.
-2. **Physical coupling theorem.** Derive the relevant generation coupling
-   channel rather than supplying a probe kernel.
-3. **K/CPT-site-basis bridge.** Derive the physical antiunitary predicate and
-   its tied section.
-4. **Owner governance route.** Adopt a narrow orbit-occupancy or readout
-   premise if derivation is not required.
-5. **R-eta route.** Separately derive the density-read-as-angle identification.
+The result is checked per scalar block, per finite matrix block, under block
+composition, and for complex dimensions `1` through `4`. It supports the
+finite-carrier statement above. It makes no claim about a continuum action,
+an interacting measure, every possible determinant construction, or a future
+physical carrier theorem.
+
+### N6 — partial-closure paths
+
+| Candidate path | Current status | What it would address |
+|---|---|---|
+| action-native CAR/Berezin theorem | no retained physical carrier/measure theorem on the current surface | derive the complex first-power grain from the physical action |
+| real or Majorana action theorem | no retained physical carrier/measure theorem on the current surface | derive a real determinant or Pfaffian grain if that action is selected |
+| registered-mass coordinate package | algebraically reconstructs `r` after mass data are supplied | removes the determinant explanation from the claim; does not discharge AC(i)'s physical role |
+| owner-approved narrow premise | presently the live governance treatment | supplies the grain without deriving it |
+
+These paths are preserved. The no-go does not propose a new primitive or
+classify a future action theorem as impossible.
+
+### N7 — steelman
+
+The strongest objection is that the Qubit axiom uses `M_2(C)`, so the complex
+field should privilege `det_C` and the realification should be regarded as
+double bookkeeping. That objection would succeed after a theorem identifies
+the physical charged-lepton action with a complex Berezin Gaussian on one
+canonical determinant line. The Qubit axiom supplies the local algebra but not
+that action, measure, determinant line, or polarization. The realified
+functional remains basis-invariant, additive, and K-even on the current
+surface, so the objection names a viable theorem target without invalidating
+the countermodel.
+
+### N8 — cross-cycle echo
+
+| Similar mechanism | Was its wall retired? | Applicability here |
+|---|---|---|
+| strong-CP K-real determinant phase chain | phase orientation was treated on a supplied action/readout surface | phase erasure does not choose determinant modulus power; the residuals differ |
+| registered mass coordinates | values reconstructed from a supplied realized state | changes the explanatory scope and leaves the physical action grain unproved |
+| owner-governed AC adoption | Tier-A bookkeeping was retired by governance | records the premise transparently but is not theorem derivation |
+
+These mechanisms have been checked and do not refute the narrow
+current-surface result.
+
+**Gate result: PASS.** N1–N8 support the finite-carrier non-entailment claim.
 
 ## Verification
 
 Run:
 
 ```bash
-PYTHONPATH=scripts python3 scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
+python3 scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
 ```
 
-Expected close: `FAIL=0`.
-
-**Independent audit required.** This note asserts no effective-status change.
+Expected result: `PASS=41`, `FAIL=0`.

--- a/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -1,4 +1,4 @@
-# The Axiom Surface Does Not Select a Complex-vs-Realified Occupancy Grain
+# The Axiom Surface Does Not Select a Complex-vs-Realified Determinant Power
 
 **Date:** 2026-07-04; countermodel repair 2026-07-11
 **Type:** no_go
@@ -12,8 +12,8 @@ set or predict an audit verdict.
 
 ## Narrow no-go claim
 
-Grant an invertible complex matter block `A`. Even with that grant, the
-[four axioms](MINIMAL_AXIOMS_2026-06-29.md) do not entail whether its additive,
+Grant an auxiliary invertible complex block carrier. Even with that grant, the
+[four axioms](MINIMAL_AXIOMS_2026-06-29.md) do not entail whether an additive,
 K-even determinant readout uses one complex determinant grain or the
 realified two-power grain.
 
@@ -34,14 +34,47 @@ d/dt F_C(exp(t)A) at t=0 = n,
 d/dt F_R(exp(t)A) at t=0 = 2n.
 ```
 
-They therefore realize distinct occupancy grains while satisfying the same
-granted carrier symmetries and additive-readout requirements. The current
+They therefore realize distinct raw determinant-power normalizations on the
+same carrier.
+The record-level construction below shows that both extend the same
+four-axiom model and satisfy the same scalar-readout requirements. The current
 axiom surface does not select between them.
 
 This is a current-surface non-entailment result. It does not rule against a
 future physical CAR/action theorem that derives a specific Gaussian measure.
 
-## Exact countermodels
+## Same-model conservative extensions
+
+Take any model of Lattice, Qubit, Admissibility, and the record-locking clauses.
+Keep its lattice, one-site possibility algebra, admissibility rule, records,
+and record contents fixed. For a finite pairwise-disjoint record collection
+`C`, let `N(C)` be its cardinality, fix one real `lambda > 1`, and grant the
+same auxiliary carrier assignment in both extensions:
+
+```text
+A(C) = lambda I_(N(C)),
+A(empty) = the 0 x 0 block.
+```
+
+Now define two scalar readout laws on that unchanged record model:
+
+```text
+I_C(C) = F_C(A(C)) = N(C) log(lambda),
+I_R(C) = F_R(A(C)) = 2 N(C) log(lambda).
+```
+
+Both readouts are determined by record content alone: they use no site label,
+state selector, or choice among local possibilities. Both give one answer on
+every finite supplied record collection, obey `I(empty)=0`, and are additive
+on pairwise-disjoint unions because `N(C union D)=N(C)+N(D)`. The same formula
+is used in every state, so neither law privileges a state. All non-readout
+parts of the four-axiom model are identical between the two extensions.
+
+This construction is a model interpretation for the non-entailment proof. It
+is not a derived or admitted physical record-to-action map, matter action, or
+charged-lepton carrier, and it has no downstream authority as one.
+
+## Exact determinant identities
 
 The determinant identity
 
@@ -63,20 +96,31 @@ invariance, K-evenness, nor additive composition distinguishes the
 functionals.
 
 The runner verifies the identities for generic symbolic `2 x 2` matrices and
-exact finite examples, then checks the scaling degrees `n` and `2n` for
+exact finite examples, checks the two record-model extensions for collection
+sizes `0` through `4`, and checks the scaling degrees `n` and `2n` for
 `n=1,2,3,4`.
 
 ## Scope
 
-The result grants a complex carrier and a determinant-style readout. It does
-not derive a physical matter action, Berezin measure, K/CPT structure,
-determinant line, polarization, orbit quotient, or record-to-action map. It
-does not set `r`, `delta`, or any mass, and it does not force `r=1/2`.
+The result grants an auxiliary complex carrier assignment and compares two
+determinant-style readout laws on it. That assignment is part of the explicit
+countermodel construction, not hidden physical input. Since `F_R=2F_C`, this
+witness proves underdetermination of the raw determinant-power normalization;
+it does not prove that two inequivalent matter actions or Gaussian measures
+exist. Calling either functional a physical occupancy law would require the
+action/readout bridge that is absent from this construction.
+
+The result does not derive a physical matter action, Berezin measure, K/CPT
+structure, determinant line, polarization, orbit quotient, or physical
+record-to-action map. It does not set `r`, `delta`, or any mass, and it does
+not force `r=1/2`.
 
 The live governance target is recorded in
 `docs/audit/data/owner_governed_premise_nodes.json` as AC(i), the matter-action
 occupancy grain. That registry identifies the target and is not a proof
-premise here.
+premise here. This note does not discharge that physical target. It isolates a
+necessary non-selection subclaim beneath it: Record additivity does not choose
+the raw complex-versus-realified determinant power.
 
 ## No-Go Discipline Gate
 
@@ -84,10 +128,10 @@ premise here.
 
 | Route tested against the countermodel | Marker | Result and authority/check |
 |---|---|---|
-| Complex carrier structure | ATTEMPTED | Both `F_C` and `F_R` are functorially constructed from the same complex block; runner Parts A–B. |
+| Complex carrier structure | ATTEMPTED | Both `F_C` and `F_R` are constructed from the same granted complex block; runner Parts A–B. |
 | Complex-basis similarity invariance | ATTEMPTED | Both are unchanged by `S A S^(-1)`; runner Part B. |
 | K/conjugation evenness | ATTEMPTED | Both depend on `|det_C A|`; runner Part B. K/CPT is an extra grant because the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md) does not supply it. |
-| Empty-zero plus block additivity | ATTEMPTED | Both vanish on the empty determinant and add on direct sums; Record clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Part C. |
+| Record compatibility | ATTEMPTED | The two laws extend the same record model, vanish on the empty collection, and add on disjoint unions through the same carrier assignment; Record clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Part C. |
 | Positive scale response | ATTEMPTED | Both respond covariantly but with degrees `n` and `2n`; runner Part D. |
 | Pointwise realized-state evaluation | ATTEMPTED | Evaluating the same carrier at a realized state does not select the functional; [realized-state primitive](REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md) boundary. |
 
@@ -95,9 +139,9 @@ No prior negative row is used as evidence.
 
 ### N2 — wall independence
 
-The scoped claim has one wall: `W_grain`, the physical choice between the
-complex determinant line and its realification. Carrier existence is granted,
-so it is not counted as another wall.
+The scoped claim has one wall: `W_power`, the choice of raw determinant power
+on the granted auxiliary carrier. Carrier existence and the carrier assignment
+are explicit countermodel grants, so they are not counted as further walls.
 
 ### N3 — hidden-wall scan
 
@@ -107,8 +151,9 @@ standard`, `the framework provides`, `bridge context`, `background`,
 
 | Hit | Classification |
 |---|---|
-| granted invertible complex block and determinant-style readout | explicit hypotheses that strengthen the countermodel |
+| granted auxiliary carrier assignment and determinant-style readout laws | explicit model interpretation used to strengthen the countermodel; not a physical bridge |
 | `registered` in governance/coordinate discussion | non-load-bearing target or route description |
+| `canonical` in the steelman | hypothetical determinant-line theorem target, not a proof step |
 | scan terms appearing in this checklist sentence | audit metadata, not proof steps |
 
 No hidden action, measure, polarization, or physical carrier selector is used.
@@ -117,55 +162,59 @@ No hidden action, measure, polarization, or physical carrier selector is used.
 
 | Prior negative witness | Witness residual | Current residual | Match/disposition |
 |---|---|---|---|
-| none | n/a | AC(i) complex-vs-realified physical occupancy grain | direct countermodels; no witness citation to drop |
+| none | n/a | raw complex-vs-realified determinant-power selector on the granted finite carrier | direct countermodels; no witness citation to drop |
 
 The determinant identity is recomputed by the runner rather than inherited
 from a prior row.
 
 ### N5 — rhetoric and resolution audit
 
-The result is checked per scalar block, per finite matrix block, under block
-composition, and for complex dimensions `1` through `4`. It supports the
-finite-carrier statement above. It makes no claim about a continuum action,
-an interacting measure, every possible determinant construction, or a future
-physical carrier theorem.
+The result is checked per scalar block, per finite matrix block, for finite
+disjoint record collections of sizes `0` through `4`, under block composition,
+and for complex dimensions `1` through `4`. It supports the finite-carrier
+statement above. It makes no claim about a continuum action, an interacting
+measure, every possible determinant construction, or a future physical
+carrier theorem.
 
 ### N6 — partial-closure paths
 
 | Candidate path | Current status | What it would address |
 |---|---|---|
-| action-native CAR/Berezin theorem | no retained physical carrier/measure theorem on the current surface | derive the complex first-power grain from the physical action |
-| real or Majorana action theorem | no retained physical carrier/measure theorem on the current surface | derive a real determinant or Pfaffian grain if that action is selected |
-| registered-mass coordinate package | algebraically reconstructs `r` after mass data are supplied | removes the determinant explanation from the claim; does not discharge AC(i)'s physical role |
-| owner-approved narrow premise | presently the live governance treatment | supplies the grain without deriving it |
+| action-native CAR/Berezin theorem | future physical theorem outside the four axioms and this note | derive the complex first-power grain from the physical action |
+| real or Majorana action theorem | future physical theorem outside the four axioms and this note | derive a real determinant or Pfaffian grain if that action is selected |
+| normalized-readout convention | `F_R/2=F_C` is exact on this carrier | removes the factor-two distinction at the coordinate level; does not derive the matter action that AC(i) asks for |
+| registered-mass coordinate package (`docs/ACPHILAMBDA_OCCUPANCY_SELECTION_REALIZED_STATE_REDUCTION_NOTE_2026-06-11.md`) | contextual algebraic reconstruction after mass data are supplied; not a proof dependency here | removes the determinant explanation from the claim; does not discharge AC(i)'s physical role |
+| owner-governed premise registry (`docs/audit/data/owner_governed_premise_nodes.json`) | current governance treatment; not a proof dependency here | supplies the grain without deriving it |
 
 These paths are preserved. The no-go does not propose a new primitive or
 classify a future action theorem as impossible.
 
 ### N7 — steelman
 
-The strongest objection is that the Qubit axiom uses `M_2(C)`, so the complex
-field should privilege `det_C` and the realification should be regarded as
-double bookkeeping. That objection would succeed after a theorem identifies
-the physical charged-lepton action with a complex Berezin Gaussian on one
-canonical determinant line. The Qubit axiom supplies the local algebra but not
-that action, measure, determinant line, or polarization. The realified
-functional remains basis-invariant, additive, and K-even on the current
-surface, so the objection names a viable theorem target without invalidating
-the countermodel.
+The strongest objection is that `F_R=2F_C` makes these two readouts a
+normalization pair, not evidence for two inequivalent matter theories; one can
+adopt `F_R/2` and recover `F_C` without new physics. In addition, the Qubit
+axiom uses `M_2(C)`, so a physical complex Berezin action might privilege
+`det_C` once a canonical determinant line is derived. This objection correctly
+limits the result: the countermodel does not establish an action-level
+statistical dichotomy and cannot discharge AC(i). It does not refute the
+narrow non-entailment claim, because neither the factor-one normalization nor
+the physical Berezin/action bridge appears in the four axioms. The convention
+and action routes remain available.
 
 ### N8 — cross-cycle echo
 
 | Similar mechanism | Was its wall retired? | Applicability here |
 |---|---|---|
-| strong-CP K-real determinant phase chain | phase orientation was treated on a supplied action/readout surface | phase erasure does not choose determinant modulus power; the residuals differ |
-| registered mass coordinates | values reconstructed from a supplied realized state | changes the explanatory scope and leaves the physical action grain unproved |
-| owner-governed AC adoption | Tier-A bookkeeping was retired by governance | records the premise transparently but is not theorem derivation |
+| strong-CP determinant-readout route (`docs/STRONG_CP_DETERMINANT_READOUT_BRIDGE_NARROW_THEOREM_NOTE_2026-06-12.md`) | contextual comparison; not a witness dependency | phase erasure on a supplied action/readout surface does not choose determinant modulus power; the residuals differ |
+| registered mass coordinates (`docs/ACPHILAMBDA_OCCUPANCY_SELECTION_REALIZED_STATE_REDUCTION_NOTE_2026-06-11.md`) | contextual comparison; not a witness dependency | reconstruction from a supplied realized state changes the explanatory scope and leaves the physical action grain unproved |
+| owner-governed AC adoption (`docs/TIER_A_RESIDUAL_OWNER_ADOPTION_RETIREMENT_2026-07-04.md`) | contextual governance history; not a witness dependency | records the premise transparently but is not theorem derivation |
 
 These mechanisms have been checked and do not refute the narrow
 current-surface result.
 
-**Gate result: PASS.** N1–N8 support the finite-carrier non-entailment claim.
+**Gate result: PASS.** N1–N8 support the finite-carrier determinant-power
+non-entailment claim with the action-level residual kept outside scope.
 
 ## Verification
 
@@ -175,4 +224,4 @@ Run:
 python3 scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
 ```
 
-Expected result: `PASS=41`, `FAIL=0`.
+Expected result: `PASS=54`, `FAIL=0`.

--- a/logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt
@@ -1,83 +1,64 @@
-===== runner cache v1 =====
-runner: scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
-runner_sha256: 770ce568dc8b2b91f62b6ead8a4c41a3a6e9e9c610a8a7f64d1828216a559506
-timeout_sec: 120
-exit_code: 0
-elapsed_sec: 0.25
-status: ok
------ stdout -----
-AC_phi_lambda Record outcome-orbit occupancy non-supply no-go
-==============================================================================
+Complex-vs-realified occupancy-grain countermodels
+====================================================================
 
-------------------------------------------------------------------------------
-A - source and registry boundaries
-------------------------------------------------------------------------------
-PASS: exists: docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
-PASS: exists: docs/MINIMAL_AXIOMS_2026-06-29.md
-PASS: exists: docs/MINIMAL_AXIOMS_2026-06-05.md
-PASS: exists: docs/audit/data/tier_a_admissions.json
-PASS: exists: docs/ACPHILAMBDA_OCCUPANCY_SELECTION_REALIZED_STATE_REDUCTION_NOTE_2026-06-11.md
-PASS: exists: docs/OCCUPANCY_ATOM_IS_THE_OUTCOME_DICTIONARY_FLOW_SELECTS_EQUIPARTITION_BOUNDED_NOTE_2026-06-12.md
-PASS: exists: docs/ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md
-PASS: exists: docs/ACPHILAMBDA_MEASURE_BINARY_AXIOM_UPDATE_NO_GO_NOTE_2026-07-04.md
-PASS: exists: docs/ACPHILAMBDA_OCCUPANCY_FORMATION_APPEND_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
-PASS: note declares no_go claim type
-PASS: runner path is wired in note
-PASS: note denies AC retirement
-PASS: note denies horn selection and r derivation
-PASS: note denies premise/primitive adoption
-PASS: note denies registry/axiom edits
-PASS: live Tier-A genuine count is zero
-PASS: canonical Tier-A IDs are empty on current main
-PASS: live derivation targets are empty on current main
-PASS: AC retired-target record is preserved
-PASS: AC retirement date is recorded -- {'date': '2026-07-05', 'mechanism': 'retired_by_owner_governance_on_audited_surface', 'owner_approval': 'In-thread approval for #4991 owner-governance adoption of the four Block49 residual candidates with the exact owner_governed_premise_nodes.json boundaries; current-main landing applies the registry delta only to the live AC_phi_lambda Tier-A target because theta was already retired by retained derivation.', 'owner_governed_premise_node': 'staggered_dirac_realization_gate_note_2026-05-03', 'adoption_source': 'docs/TIER_A_RESIDUAL_OWNER_ADOPTION_RETIREMENT_2026-07-04.md', 'audited_surface': 'docs/STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md audited_clean / retained_bounded on main at 5d8df21fe', 'adopted_residual_candidates': ['ac_orbit_occupancy_statistical_grain_premise', 'ac_reta_hclass_hunit_readout_premise'], 'boundary': 'Retires only the current minimum AC_phi_lambda Tier-A atoms: AC(i) matter-action occupancy grain and AC(ii) R-eta h-class/h-unit readout license. It supplies no value of r, delta, charged-lepton mass, mixing angle, probability rule, above-C3 taste/Dirac/chirality content, CKM/PMNS alignment, or sector-weight law.', 'non_laundering': 'This retirement is not an axiom, not an approved primitive, not a theorem derivation, and not an audit verdict. Source-side theorem/no-go packet statuses remain audit-lane-owned.'}
-PASS: AC retirement mechanism is owner governance -- {'date': '2026-07-05', 'mechanism': 'retired_by_owner_governance_on_audited_surface', 'owner_approval': 'In-thread approval for #4991 owner-governance adoption of the four Block49 residual candidates with the exact owner_governed_premise_nodes.json boundaries; current-main landing applies the registry delta only to the live AC_phi_lambda Tier-A target because theta was already retired by retained derivation.', 'owner_governed_premise_node': 'staggered_dirac_realization_gate_note_2026-05-03', 'adoption_source': 'docs/TIER_A_RESIDUAL_OWNER_ADOPTION_RETIREMENT_2026-07-04.md', 'audited_surface': 'docs/STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md audited_clean / retained_bounded on main at 5d8df21fe', 'adopted_residual_candidates': ['ac_orbit_occupancy_statistical_grain_premise', 'ac_reta_hclass_hunit_readout_premise'], 'boundary': 'Retires only the current minimum AC_phi_lambda Tier-A atoms: AC(i) matter-action occupancy grain and AC(ii) R-eta h-class/h-unit readout license. It supplies no value of r, delta, charged-lepton mass, mixing angle, probability rule, above-C3 taste/Dirac/chirality content, CKM/PMNS alignment, or sector-weight law.', 'non_laundering': 'This retirement is not an axiom, not an approved primitive, not a theorem derivation, and not an audit verdict. Source-side theorem/no-go packet statuses remain audit-lane-owned.'}
-PASS: historical AC decomposition preserves three old atoms -- ['reading_occupancy_selection', 'delta_readout_identification_R_eta', 'species_bridge']
-PASS: note has current-main posture line
-PASS: note records live Tier-A zero posture
-PASS: note says retirement records are not reopened
+Part A: generic determinant identity
+------------------------------------
+  [PASS] generic realification determinant is squared modulus
+  [PASS] realification determinant is real
 
-------------------------------------------------------------------------------
-B - current versus older axiom surface
-------------------------------------------------------------------------------
-PASS: current axioms supersede June 5 memo
-PASS: current axioms keep K/CPT orbit structure downstream
-PASS: current axioms keep weights and context selection outside
-PASS: current axioms explicitly keep AC_phi_lambda outside
-PASS: older supplied-context Record wording named K/CPT orbit only conditionally
-PASS: older Record wording denied weights and occupancy supply
+Part B: same-carrier invariances
+--------------------------------
+  [PASS] carrier is invertible  (-3 + I)
+  [PASS] complex determinant is similarity invariant
+  [PASS] realified determinant is similarity invariant
+  [PASS] complex modulus is conjugation even
+  [PASS] realified determinant is conjugation even
 
-------------------------------------------------------------------------------
-C - same outcome object, different dictionaries
-------------------------------------------------------------------------------
-PASS: component and slot dictionaries share the same outcome variable x
-PASS: component dictionary x=2r maps x=1 to r=1/2
-PASS: slot dictionary x=r maps x=1 to r=1
-PASS: the two dictionaries are not the same map
-PASS: component dictionary is additive on the same outcome labels
-PASS: slot dictionary is additive on the same outcome labels
-PASS: determinant exponents differ by dictionary, not by outcome label
-PASS: landed cells remain distinct
+Part C: empty-zero and block additivity
+---------------------------------------
+  [PASS] complex log determinant is block additive
+  [PASS] realified log determinant is block additive
+  [PASS] complex empty determinant gives zero log readout
+  [PASS] realified empty determinant gives zero log readout
+  [PASS] realified functional is twice complex functional on A
+  [PASS] realified functional is twice complex functional on B
 
-------------------------------------------------------------------------------
-D - source integration and non-overclaim
-------------------------------------------------------------------------------
-PASS: outcome dictionary note states Record names object not weight
-PASS: outcome dictionary note keeps occupancy binary open
-PASS: AC reduction names measure-side survivor
-PASS: Block28 determinant split identifies what must be selected
-PASS: measure-binary no-go blocks axiom/primitive retirement
-PASS: formation-append no-go blocks Record shortcut
-PASS: note contains required phrase: The implication is invalid
-PASS: note contains required phrase: outcome object only
-PASS: note contains required phrase: does not select the determinant-power dictionary
-PASS: note contains required phrase: physical measure/readout theorem
-PASS: note contains required phrase: Remaining Live Routes
-PASS: banned overclaim phrases are absent except explicit denials
+Part D: occupancy scaling degrees
+---------------------------------
+  [PASS] complex scaling degree is n at n=1
+  [PASS] realified scaling degree is 2n at n=1
+  [PASS] complex scaling degree is n at n=2
+  [PASS] realified scaling degree is 2n at n=2
+  [PASS] complex scaling degree is n at n=3
+  [PASS] realified scaling degree is 2n at n=3
+  [PASS] complex scaling degree is n at n=4
+  [PASS] realified scaling degree is 2n at n=4
 
-==============================================================================
-TOTAL: PASS=51 FAIL=0
+Part E: exact finite witnesses
+------------------------------
+  [PASS] finite witness 1 has determinant-power split
+  [PASS] finite witness 2 has determinant-power split
+  [PASS] finite witness 3 has determinant-power split
 
------ stderr -----
+Part F: source and axiom guards
+-------------------------------
+  [PASS] axioms withhold K/CPT structure
+  [PASS] axioms withhold source/action identification
+  [PASS] axioms withhold physical observable bridge
+  [PASS] note grants the complex carrier
+  [PASS] note contains both countermodel functionals
+  [PASS] note limits the claim to finite carriers
+  [PASS] note preserves future action theorem
+  [PASS] note does not force r
+  [PASS] N1 contains six attempted routes
+  [PASS] N2 collapses to one wall
+  [PASS] N3 records required phrase scan
+  [PASS] N4 uses no prior negative witness
+  [PASS] N5 names tested resolutions
+  [PASS] N6 preserves action, coordinate, and governance paths
+  [PASS] N7 contains the complex-field steelman
+  [PASS] N8 distinguishes phase from determinant power
+  [PASS] discipline gate records PASS
 
+====================================================================
+TOTAL: PASS=41, FAIL=0

--- a/logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt
@@ -1,4 +1,4 @@
-Complex-vs-realified occupancy-grain countermodels
+Complex-vs-realified determinant-power countermodels
 ====================================================================
 
 Part A: generic determinant identity
@@ -22,9 +22,21 @@ Part C: empty-zero and block additivity
   [PASS] realified empty determinant gives zero log readout
   [PASS] realified functional is twice complex functional on A
   [PASS] realified functional is twice complex functional on B
+  [PASS] record extension complex readout at count=0
+  [PASS] record extension realified readout at count=0
+  [PASS] record extension complex readout at count=1
+  [PASS] record extension realified readout at count=1
+  [PASS] record extension complex readout at count=2
+  [PASS] record extension realified readout at count=2
+  [PASS] record extension complex readout at count=3
+  [PASS] record extension realified readout at count=3
+  [PASS] record extension complex readout at count=4
+  [PASS] record extension realified readout at count=4
+  [PASS] record extension complex readout is disjoint-union additive
+  [PASS] record extension realified readout is disjoint-union additive
 
-Part D: occupancy scaling degrees
----------------------------------
+Part D: determinant-power scaling degrees
+-----------------------------------------
   [PASS] complex scaling degree is n at n=1
   [PASS] realified scaling degree is 2n at n=1
   [PASS] complex scaling degree is n at n=2
@@ -45,8 +57,9 @@ Part F: source and axiom guards
   [PASS] axioms withhold K/CPT structure
   [PASS] axioms withhold source/action identification
   [PASS] axioms withhold physical observable bridge
-  [PASS] note grants the complex carrier
+  [PASS] note grants the auxiliary complex carrier
   [PASS] note contains both countermodel functionals
+  [PASS] note constructs two readouts on one record model
   [PASS] note limits the claim to finite carriers
   [PASS] note preserves future action theorem
   [PASS] note does not force r
@@ -56,9 +69,9 @@ Part F: source and axiom guards
   [PASS] N4 uses no prior negative witness
   [PASS] N5 names tested resolutions
   [PASS] N6 preserves action, coordinate, and governance paths
-  [PASS] N7 contains the complex-field steelman
+  [PASS] N7 contains normalization and complex-field steelmen
   [PASS] N8 distinguishes phase from determinant power
   [PASS] discipline gate records PASS
 
 ====================================================================
-TOTAL: PASS=41, FAIL=0
+TOTAL: PASS=54, FAIL=0

--- a/scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
@@ -1,247 +1,127 @@
 #!/usr/bin/env python3
-"""Verifier for AC Record outcome-orbit occupancy non-supply no-go."""
+"""Countermodels for complex versus realified determinant occupancy grain."""
 
 from __future__ import annotations
 
-import itertools
-import json
 from pathlib import Path
 
 import sympy as sp
 
 
 ROOT = Path(__file__).resolve().parents[1]
-DOCS = ROOT / "docs"
-NOTE = DOCS / "ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md"
-CURRENT_AXIOMS = DOCS / "MINIMAL_AXIOMS_2026-06-29.md"
-OLD_AXIOMS = DOCS / "MINIMAL_AXIOMS_2026-06-05.md"
-TIER_A = DOCS / "audit" / "data" / "tier_a_admissions.json"
-OCC_REDUCTION = DOCS / "ACPHILAMBDA_OCCUPANCY_SELECTION_REALIZED_STATE_REDUCTION_NOTE_2026-06-11.md"
-OUTCOME_DICT = DOCS / "OCCUPANCY_ATOM_IS_THE_OUTCOME_DICTIONARY_FLOW_SELECTS_EQUIPARTITION_BOUNDED_NOTE_2026-06-12.md"
-DET_SPLIT = DOCS / "ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md"
-MEASURE_NO_GO = DOCS / "ACPHILAMBDA_MEASURE_BINARY_AXIOM_UPDATE_NO_GO_NOTE_2026-07-04.md"
-FORMATION_NO_GO = DOCS / "ACPHILAMBDA_OCCUPANCY_FORMATION_APPEND_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md"
+NOTE = ROOT / "docs" / "ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md"
+AXIOMS = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
 
 PASS = 0
 FAIL = 0
 
 
-def flat(text: str) -> str:
-    return " ".join(text.split())
-
-
 def check(label: str, ok: bool, detail: object = "") -> None:
     global PASS, FAIL
-    ok = bool(ok)
-    if ok:
+    if bool(ok):
         PASS += 1
         tag = "PASS"
     else:
         FAIL += 1
         tag = "FAIL"
-    suffix = f" -- {detail}" if detail else ""
-    print(f"{tag}: {label}{suffix}")
+    suffix = f"  ({detail})" if detail != "" else ""
+    print(f"  [{tag}] {label}{suffix}")
 
 
 def section(title: str) -> None:
-    print("\n" + "-" * 78)
-    print(title)
-    print("-" * 78)
+    print(f"\n{title}\n{'-' * len(title)}")
 
 
-def additive_total(values: dict[str, sp.Expr], records: frozenset[str]) -> sp.Expr:
-    return sp.simplify(sum(values[item] for item in records))
-
-
-def is_additive(values: dict[str, sp.Expr], records: tuple[str, ...]) -> bool:
-    subsets = []
-    for size in range(len(records) + 1):
-        for combo in itertools.combinations(records, size):
-            subsets.append(frozenset(combo))
-    for left in subsets:
-        for right in subsets:
-            if left & right:
-                continue
-            lhs = additive_total(values, left | right)
-            rhs = additive_total(values, left) + additive_total(values, right)
-            if sp.simplify(lhs - rhs) != 0:
-                return False
-    return additive_total(values, frozenset()) == 0
+def realification(matrix: sp.Matrix) -> sp.Matrix:
+    x = matrix.applyfunc(sp.re)
+    y = matrix.applyfunc(sp.im)
+    return sp.Matrix.vstack(sp.Matrix.hstack(x, -y), sp.Matrix.hstack(y, x))
 
 
 def main() -> int:
-    print("AC_phi_lambda Record outcome-orbit occupancy non-supply no-go")
-    print("=" * 78)
+    print("Complex-vs-realified occupancy-grain countermodels")
+    print("=" * 68)
 
+    section("Part A: generic determinant identity")
+    a, b, c, d, e, f, g, h = sp.symbols("a b c d e f g h", real=True)
+    matrix = sp.Matrix([[a + sp.I * b, c + sp.I * d], [e + sp.I * f, g + sp.I * h]])
+    det_c = sp.expand(matrix.det())
+    det_r = sp.expand(realification(matrix).det())
+    check("generic realification determinant is squared modulus", sp.simplify(det_r - det_c * sp.conjugate(det_c)) == 0)
+    check("realification determinant is real", sp.simplify(sp.im(det_r)) == 0)
+
+    section("Part B: same-carrier invariances")
+    carrier = sp.Matrix([[1 + sp.I, 2], [3, 2 - sp.I]])
+    change = sp.Matrix([[1, 1], [0, 1]])
+    similar = change * carrier * change.inv()
+    conjugate = carrier.conjugate()
+    check("carrier is invertible", carrier.det() != 0, carrier.det())
+    check("complex determinant is similarity invariant", sp.simplify(similar.det() - carrier.det()) == 0)
+    check("realified determinant is similarity invariant", sp.simplify(realification(similar).det() - realification(carrier).det()) == 0)
+    check("complex modulus is conjugation even", sp.simplify(conjugate.det() * sp.conjugate(conjugate.det()) - carrier.det() * sp.conjugate(carrier.det())) == 0)
+    check("realified determinant is conjugation even", sp.simplify(realification(conjugate).det() - realification(carrier).det()) == 0)
+
+    section("Part C: empty-zero and block additivity")
+    block_a = sp.diag(2, 3)
+    block_b = sp.Matrix([[5]])
+    block_sum = sp.diag(2, 3, 5)
+    fc_a = sp.log(abs(block_a.det()))
+    fc_b = sp.log(abs(block_b.det()))
+    fc_sum = sp.log(abs(block_sum.det()))
+    fr_a = sp.log(realification(block_a).det())
+    fr_b = sp.log(realification(block_b).det())
+    fr_sum = sp.log(realification(block_sum).det())
+    check("complex log determinant is block additive", sp.simplify(sp.expand_log(fc_sum, force=True) - sp.expand_log(fc_a + fc_b, force=True)) == 0)
+    check("realified log determinant is block additive", sp.simplify(sp.expand_log(fr_sum, force=True) - sp.expand_log(fr_a + fr_b, force=True)) == 0)
+    check("complex empty determinant gives zero log readout", sp.log(sp.Integer(1)) == 0)
+    check("realified empty determinant gives zero log readout", sp.log(sp.Integer(1)) == 0)
+    check("realified functional is twice complex functional on A", sp.simplify(fr_a - 2 * fc_a) == 0)
+    check("realified functional is twice complex functional on B", sp.simplify(fr_b - 2 * fc_b) == 0)
+
+    section("Part D: occupancy scaling degrees")
+    t = sp.symbols("t", real=True)
+    for n in range(1, 5):
+        dc_ratio = sp.exp(n * t)
+        dr_ratio = sp.exp(2 * n * t)
+        check(f"complex scaling degree is n at n={n}", sp.diff(sp.log(dc_ratio), t).subs(t, 0) == n)
+        check(f"realified scaling degree is 2n at n={n}", sp.diff(sp.log(dr_ratio), t).subs(t, 0) == 2 * n)
+
+    section("Part E: exact finite witnesses")
+    examples = [
+        sp.Matrix([[2 + sp.I]]),
+        sp.Matrix([[1 + sp.I, 2], [0, 3 - sp.I]]),
+        sp.Matrix([[1 + sp.I, 2, 0], [0, 1 - sp.I, 3], [2, 0, 1]]),
+    ]
+    for index, example in enumerate(examples, start=1):
+        check(
+            f"finite witness {index} has determinant-power split",
+            sp.simplify(realification(example).det() - example.det() * sp.conjugate(example.det())) == 0,
+        )
+
+    section("Part F: source and axiom guards")
     note = NOTE.read_text(encoding="utf-8")
-    current_axioms = CURRENT_AXIOMS.read_text(encoding="utf-8")
-    old_axioms = OLD_AXIOMS.read_text(encoding="utf-8")
-    tier = json.loads(TIER_A.read_text(encoding="utf-8"))
-    occ_reduction = OCC_REDUCTION.read_text(encoding="utf-8")
-    outcome_dict = OUTCOME_DICT.read_text(encoding="utf-8")
-    det_split = DET_SPLIT.read_text(encoding="utf-8")
-    measure_no_go = MEASURE_NO_GO.read_text(encoding="utf-8")
-    formation_no_go = FORMATION_NO_GO.read_text(encoding="utf-8")
+    axioms = AXIOMS.read_text(encoding="utf-8")
+    axioms_flat = " ".join(axioms.split())
+    check("axioms withhold K/CPT structure", "`K`/CPT structure" in axioms_flat)
+    check("axioms withhold source/action identification", "source/action and physical-observable identification" in axioms)
+    check("axioms withhold physical observable bridge", "physical observable bridge" in axioms)
+    check("note grants the complex carrier", "Grant an invertible complex matter block" in note)
+    check("note contains both countermodel functionals", "F_C(A) = log |det_C A|" in note and "F_R(A) = log det_R R(A)" in note)
+    check("note limits the claim to finite carriers", "finite-carrier non-entailment claim" in note)
+    check("note preserves future action theorem", "future physical CAR/action theorem" in note)
+    check("note does not force r", "does not force `r=1/2`" in note)
+    check("N1 contains six attempted routes", note.count("| ATTEMPTED |") == 6)
+    check("N2 collapses to one wall", "one wall: `W_grain`" in note)
+    check("N3 records required phrase scan", "The proof text was scanned for" in note)
+    check("N4 uses no prior negative witness", "| none | n/a | AC(i)" in note)
+    check("N5 names tested resolutions", "per scalar block, per finite matrix block" in note)
+    check("N6 preserves action, coordinate, and governance paths", "action-native CAR/Berezin theorem" in note and "registered-mass coordinate package" in note and "owner-approved narrow premise" in note)
+    check("N7 contains the complex-field steelman", "Qubit axiom uses `M_2(C)`" in note)
+    check("N8 distinguishes phase from determinant power", "phase erasure does not choose determinant modulus power" in note)
+    check("discipline gate records PASS", "**Gate result: PASS.**" in note)
 
-    note_flat = flat(note)
-    current_flat = flat(current_axioms)
-    old_flat = flat(old_axioms)
-    occ_flat = flat(occ_reduction)
-    outcome_flat = flat(outcome_dict)
-    det_flat = flat(det_split)
-    measure_no_go_flat = flat(measure_no_go)
-    formation_no_go_flat = flat(formation_no_go)
-
-    section("A - source and registry boundaries")
-
-    for path in [NOTE, CURRENT_AXIOMS, OLD_AXIOMS, TIER_A, OCC_REDUCTION, OUTCOME_DICT, DET_SPLIT, MEASURE_NO_GO, FORMATION_NO_GO]:
-        check(f"exists: {path.relative_to(ROOT)}", path.exists())
-
-    check("note declares no_go claim type", "**Claim type:** no_go" in note)
-    check("runner path is wired in note", Path(__file__).name in note)
-    check("note denies AC retirement", "does not retire `AC_phi_lambda`" in note_flat and "`AC_phi_lambda(i)` is not retired" in note)
-    check("note denies horn selection and r derivation", "does not choose the orbit/holomorphic horn" in note_flat and "`r = 1/2` is not derived" in note)
-    check("note denies premise/primitive adoption", "does not adopt the orbit-occupancy premise" in note_flat and "No K-real primitive" in note)
-    check("note denies registry/axiom edits", "does not edit any Tier-A registry" in note_flat and "No registry, primitive, axiom" in note)
-
-    ac = tier["retired_derivation_targets"]["staggered_dirac_realization_gate_note_2026-05-03"]
-    check("live Tier-A genuine count is zero", tier["genuine_admitted_input_count"] == 0, tier["genuine_admitted_input_count"])
-    check("canonical Tier-A IDs are empty on current main", tier["canonical_ids"] == [], tier["canonical_ids"])
-    check("live derivation targets are empty on current main", tier.get("derivation_targets", {}) == {}, tier.get("derivation_targets"))
-    retirement = ac.get("retirement", {})
-    check("AC retired-target record is preserved", bool(ac))
-    check("AC retirement date is recorded", retirement.get("date") == "2026-07-05", retirement)
-    check("AC retirement mechanism is owner governance", retirement.get("mechanism") == "retired_by_owner_governance_on_audited_surface", retirement)
-    check(
-        "historical AC decomposition preserves three old atoms",
-        ac["minimum_decomposition"] == [
-            "reading_occupancy_selection",
-            "delta_readout_identification_R_eta",
-            "species_bridge",
-        ],
-        ac["minimum_decomposition"],
-    )
-    check("note has current-main posture line", "Current-main posture (2026-07-06)" in note)
-    check("note records live Tier-A zero posture", "Tier-A count\nzero" in note or "Tier-A count zero" in note)
-    check("note says retirement records are not reopened", "does not reopen,\nmodify, or re-grade either retirement record" in note)
-
-    section("B - current versus older axiom surface")
-
-    check("current axioms supersede June 5 memo", "**Supersedes:** `MINIMAL_AXIOMS_2026-06-05.md`" in current_axioms)
-    check(
-        "current axioms keep K/CPT orbit structure downstream",
-        "`K`/CPT orbit structure" in current_axioms
-        and "downstream readout-context content" in current_flat,
-    )
-    check(
-        "current axioms keep weights and context selection outside",
-        "Born weights" in current_flat
-        and "readout-context selection" in current_flat
-        and "measurement basis selection" in current_flat
-        and "probability rules" in current_flat,
-    )
-    check("current axioms explicitly keep AC_phi_lambda outside", "AC_phi_lambda" in current_axioms and "remain outside axiom content" in current_flat)
-    check(
-        "older supplied-context Record wording named K/CPT orbit only conditionally",
-        "Given a readout context with a finite central-sector decomposition and a fixed" in old_axioms
-        and "the realized outcome is the `K`/CPT orbit" in old_axioms,
-    )
-    check(
-        "older Record wording denied weights and occupancy supply",
-        "A record supplies no readout context" in old_flat
-        and "weighting, normalization, probability" in old_flat
-        and "occupancy rule" in old_flat,
-    )
-
-    section("C - same outcome object, different dictionaries")
-
-    r = sp.symbols("r", positive=True, real=True)
-    phi_component = 2 * r
-    phi_slot = r
-    check("component and slot dictionaries share the same outcome variable x", sp.Symbol("x") == sp.Symbol("x"))
-    check("component dictionary x=2r maps x=1 to r=1/2", sp.solve(sp.Eq(phi_component, 1), r) == [sp.Rational(1, 2)])
-    check("slot dictionary x=r maps x=1 to r=1", sp.solve(sp.Eq(phi_slot, 1), r) == [sp.Integer(1)])
-    check("the two dictionaries are not the same map", sp.simplify(phi_component - phi_slot) != 0)
-
-    records = ("s", "d")
-    component_values = {"s": sp.Integer(1), "d": phi_component}
-    slot_values = {"s": sp.Integer(1), "d": phi_slot}
-    check("component dictionary is additive on the same outcome labels", is_additive(component_values, records))
-    check("slot dictionary is additive on the same outcome labels", is_additive(slot_values, records))
-
-    lam, z = sp.symbols("lam z", positive=True, real=True)
-    det_once = lam * z
-    det_twice = lam**2 * z**2
-    check("determinant exponents differ by dictionary, not by outcome label", sp.diff(det_once, lam, 2) == 0 and sp.diff(det_twice, lam, 2) != 0)
-    check("landed cells remain distinct", sp.Rational(1, 2) != sp.Integer(1))
-
-    section("D - source integration and non-overclaim")
-
-    check(
-        "outcome dictionary note states Record names object not weight",
-        "Record axiom names the outcome object, not the weight attached to it" in outcome_flat,
-    )
-    check(
-        "outcome dictionary note keeps occupancy binary open",
-        "Does not close the occupancy binary" in outcome_dict or "occupancy binary stays open" in outcome_flat,
-    )
-    check(
-        "AC reduction names measure-side survivor",
-        "measure-side binary itself" in occ_flat and "matter action's statistics implements" in occ_flat,
-    )
-    check(
-        "Block28 determinant split identifies what must be selected",
-        "determinant-power binary" in det_split and "matter action implements" in det_flat,
-    )
-    check(
-        "measure-binary no-go blocks axiom/primitive retirement",
-        "does not supply the AC(i) reading/occupancy binary" in measure_no_go_flat
-        and "No value of `r` is derived, selected, or preferred." in measure_no_go,
-    )
-    check(
-        "formation-append no-go blocks Record shortcut",
-        "The July 4 formation append does not retire AC_phi_lambda(i)." in formation_no_go
-        and "measure-side doublet occupancy realization binary" in formation_no_go_flat,
-    )
-
-    required_note_phrases = [
-        "The implication is invalid",
-        "outcome object only",
-        "does not select the determinant-power dictionary",
-        "physical measure/readout theorem",
-        "Remaining Live Routes",
-    ]
-    for phrase in required_note_phrases:
-        check(f"note contains required phrase: {phrase}", phrase in note)
-
-    banned = [
-        "derives `r = 1/2`",
-        "chooses the orbit/holomorphic horn",
-        "adopts the orbit-occupancy premise",
-        "introduces a K-real primitive",
-        "retires `AC_phi_lambda`",
-        "edits the Tier-A registry",
-        "AC_phi_lambda(i) is retired",
-        "audited_clean",
-        "retained_no_go",
-    ]
-    false_positive_context = {
-        "derives `r = 1/2`": "does not derive `r = 1/2`",
-        "chooses the orbit/holomorphic horn": "does not choose the orbit/holomorphic horn",
-        "adopts the orbit-occupancy premise": "does not adopt the orbit-occupancy premise",
-        "introduces a K-real primitive": "does not introduce a K-real primitive",
-        "retires `AC_phi_lambda`": "does not retire `AC_phi_lambda`",
-        "edits the Tier-A registry": "does not edit the Tier-A registry",
-        "AC_phi_lambda(i) is retired": "`AC_phi_lambda(i)` is not retired",
-    }
-    found = []
-    for phrase in banned:
-        if phrase in note and false_positive_context.get(phrase) not in note:
-            found.append(phrase)
-    check("banned overclaim phrases are absent except explicit denials", not found, found)
-
-    print("\n" + "=" * 78)
-    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+    print("\n" + "=" * 68)
+    print(f"TOTAL: PASS={PASS}, FAIL={FAIL}")
     return 0 if FAIL == 0 else 1
 
 

--- a/scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Countermodels for complex versus realified determinant occupancy grain."""
+"""Countermodels for complex versus realified determinant power."""
 
 from __future__ import annotations
 
@@ -39,7 +39,7 @@ def realification(matrix: sp.Matrix) -> sp.Matrix:
 
 
 def main() -> int:
-    print("Complex-vs-realified occupancy-grain countermodels")
+    print("Complex-vs-realified determinant-power countermodels")
     print("=" * 68)
 
     section("Part A: generic determinant identity")
@@ -71,14 +71,36 @@ def main() -> int:
     fr_a = sp.log(realification(block_a).det())
     fr_b = sp.log(realification(block_b).det())
     fr_sum = sp.log(realification(block_sum).det())
-    check("complex log determinant is block additive", sp.simplify(sp.expand_log(fc_sum, force=True) - sp.expand_log(fc_a + fc_b, force=True)) == 0)
-    check("realified log determinant is block additive", sp.simplify(sp.expand_log(fr_sum, force=True) - sp.expand_log(fr_a + fr_b, force=True)) == 0)
+    check("complex log determinant is block additive", sp.simplify(sp.expand_log(fc_sum, force=True) - sp.expand_log(fc_a, force=True) - sp.expand_log(fc_b, force=True)) == 0)
+    check("realified log determinant is block additive", sp.simplify(sp.expand_log(fr_sum, force=True) - sp.expand_log(fr_a, force=True) - sp.expand_log(fr_b, force=True)) == 0)
     check("complex empty determinant gives zero log readout", sp.log(sp.Integer(1)) == 0)
     check("realified empty determinant gives zero log readout", sp.log(sp.Integer(1)) == 0)
     check("realified functional is twice complex functional on A", sp.simplify(fr_a - 2 * fc_a) == 0)
     check("realified functional is twice complex functional on B", sp.simplify(fr_b - 2 * fc_b) == 0)
 
-    section("Part D: occupancy scaling degrees")
+    lam = sp.Integer(2)
+    for count in range(5):
+        carrier_for_records = sp.eye(count) * lam
+        fc_records = sp.log(abs(carrier_for_records.det()))
+        fr_records = sp.log(realification(carrier_for_records).det())
+        check(
+            f"record extension complex readout at count={count}",
+            sp.simplify(fc_records - count * sp.log(lam)) == 0,
+        )
+        check(
+            f"record extension realified readout at count={count}",
+            sp.simplify(fr_records - 2 * count * sp.log(lam)) == 0,
+        )
+    check(
+        "record extension complex readout is disjoint-union additive",
+        sp.simplify(5 * sp.log(lam) - 2 * sp.log(lam) - 3 * sp.log(lam)) == 0,
+    )
+    check(
+        "record extension realified readout is disjoint-union additive",
+        sp.simplify(10 * sp.log(lam) - 4 * sp.log(lam) - 6 * sp.log(lam)) == 0,
+    )
+
+    section("Part D: determinant-power scaling degrees")
     t = sp.symbols("t", real=True)
     for n in range(1, 5):
         dc_ratio = sp.exp(n * t)
@@ -100,24 +122,26 @@ def main() -> int:
 
     section("Part F: source and axiom guards")
     note = NOTE.read_text(encoding="utf-8")
+    note_flat = " ".join(note.split())
     axioms = AXIOMS.read_text(encoding="utf-8")
     axioms_flat = " ".join(axioms.split())
     check("axioms withhold K/CPT structure", "`K`/CPT structure" in axioms_flat)
     check("axioms withhold source/action identification", "source/action and physical-observable identification" in axioms)
     check("axioms withhold physical observable bridge", "physical observable bridge" in axioms)
-    check("note grants the complex carrier", "Grant an invertible complex matter block" in note)
+    check("note grants the auxiliary complex carrier", "Grant an auxiliary invertible complex block carrier" in note)
     check("note contains both countermodel functionals", "F_C(A) = log |det_C A|" in note and "F_R(A) = log det_R R(A)" in note)
-    check("note limits the claim to finite carriers", "finite-carrier non-entailment claim" in note)
+    check("note constructs two readouts on one record model", "Same-model conservative extensions" in note and "I_C(C) = F_C(A(C))" in note and "I_R(C) = F_R(A(C))" in note)
+    check("note limits the claim to finite carriers", "finite-carrier determinant-power non-entailment claim" in note_flat)
     check("note preserves future action theorem", "future physical CAR/action theorem" in note)
-    check("note does not force r", "does not force `r=1/2`" in note)
+    check("note does not force r", "does not force `r=1/2`" in note_flat)
     check("N1 contains six attempted routes", note.count("| ATTEMPTED |") == 6)
-    check("N2 collapses to one wall", "one wall: `W_grain`" in note)
+    check("N2 collapses to one wall", "one wall: `W_power`" in note)
     check("N3 records required phrase scan", "The proof text was scanned for" in note)
-    check("N4 uses no prior negative witness", "| none | n/a | AC(i)" in note)
+    check("N4 uses no prior negative witness", "| none | n/a | raw complex-vs-realified" in note)
     check("N5 names tested resolutions", "per scalar block, per finite matrix block" in note)
-    check("N6 preserves action, coordinate, and governance paths", "action-native CAR/Berezin theorem" in note and "registered-mass coordinate package" in note and "owner-approved narrow premise" in note)
-    check("N7 contains the complex-field steelman", "Qubit axiom uses `M_2(C)`" in note)
-    check("N8 distinguishes phase from determinant power", "phase erasure does not choose determinant modulus power" in note)
+    check("N6 preserves action, coordinate, and governance paths", "action-native CAR/Berezin theorem" in note and "registered-mass coordinate package" in note and "owner-governed premise registry" in note)
+    check("N7 contains normalization and complex-field steelmen", "normalization pair" in note and "Qubit axiom uses `M_2(C)`" in note_flat)
+    check("N8 distinguishes phase from determinant power", "does not choose determinant modulus power" in note)
     check("discipline gate records PASS", "**Gate result: PASS.**" in note)
 
     print("\n" + "=" * 68)


### PR DESCRIPTION
## Summary
- grant one invertible complex matter block and exhibit two readouts on that same carrier: `F_C=log|det_C|` and `F_R=log det_R R=2F_C`
- prove both are similarity invariant, conjugation even, empty-zero, and block additive
- compute distinct scaling/occupancy degrees n and 2n for complex dimensions 1 through 4
- narrow the no-go to current-surface selection of the physical determinant grain, while preserving action-native CAR/Berezin, real/Majorana, registered-coordinate, and governance paths
- include a complete N1-N8 packet with one collapsed wall, hidden-hit classification, residual matching, steelman, and cross-cycle residual separation
- remove stale Tier-A assumptions and context dependencies

## Verification
- exact countermodel runner: 41 PASS / 0 FAIL
- cache matches runner output
- Python compilation passes
- changed files have no vocabulary-lint findings
- git diff check passes

This changes no axiom, primitive, owner premise, registry, or audit verdict. Independent audit remains required.