### PR TITLE
physics-loop: isolate repeat-certainty effect selector

### DIFF
--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/ARTIFACT_PLAN.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/ARTIFACT_PLAN.md
@@ -15,7 +15,7 @@
 - rank-one locked-output CP outcome-operation normal form;
 - mutation-sensitive runner, cache, N1--N8 packet, and stacked review PR.
 
-## Minimal dilation and exchange escape — current result
+## Minimal dilation and exchange escape — delivered
 
 - exact one-Kraus no-record completion classification `K_empty=sqrt(q)U`;
 - full normalization on a supplied one-excitation edge sector;
@@ -25,14 +25,17 @@
 - decisive same-carrier `I-SWAP` counterexample, with the label-to-Record
   realization kept open.
 
-## Effect selection and Born — next
+## Effect selection and Born — current result
 
-- test whether instrument composition plus exclusive-menu additivity yields a
-  frame function on neighbor composites;
-- derive or isolate effect selection, noncontextuality, and the exact remaining
-  premise behind the quadratic trace rule.
+- exact depolarizing effect family surviving positivity, full POVM
+  normalization/additivity, menu noncontextuality, and covariance;
+- exact theorem that a fixed exhaustive rank-one menu plus joint normalization
+  and `RC_i: Tr(P_i E_i)=1` forces `E_i=P_i`;
+- probability semantics, physical menu realization, framework-Record output,
+  and derivation of `RC_i` retained as separate open bridges;
+- deterministic 51-check runner, full N1--N8 packet, and stacked review PR.
 
-## Full instrument, time, and probability
+## Full instrument, time, and probability — next
 
 - extend beyond the classified finite-edge completion to a local normalized
   record-forming instrument family;

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/ASSUMPTIONS_AND_IMPORTS.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/ASSUMPTIONS_AND_IMPORTS.md
@@ -39,7 +39,7 @@
 | carrier selection | exhaust scalar and vector cubic intertwiners |
 | continuum generator | control the logarithm/coarse-graining branch and locality |
 
-## Minimal-dilation supplied hypotheses
+## Minimal-dilation named conditional inputs
 
 - A finite one-excitation sector on one unoriented nearest-neighbor edge.
 - A supplied complete rank-one `L/R` pointer menu and `0<q<1`.
@@ -52,3 +52,18 @@ These inputs make the exchange counterexample exact but bounded. The external
 outcome label is not derived as a framework Record. The block does not derive
 a physical lattice instrument, Born weights, event rate, simultaneous cubic
 composition, or continuum scaling from the four axioms.
+
+## Effect-selection named conditional inputs
+
+- Finite `d>1`, effects, and a fixed exhaustive rank-one projective menu.
+- Positivity, joint menu normalization, and the condition
+  `RC_i: Tr(P_i E_i)=1` for the collapse theorem.
+- Full effect/POVM additivity, normalization, menu noncontextuality, and
+  unitary covariance for comparison against structural-effect selectors.
+- CP/trace and probability interpretations only as named mathematical
+  hypotheses, not as approved framework premises.
+
+All listed effect-selection conditions carry zero framework-premise weight.
+The theorem does not derive a physical menu, probability semantics,
+framework-Record realization, repeat certainty, event order/rate, or a
+continuum law. No axiom or primitive change is implied.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/CLAIM_STATUS_CERTIFICATE.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/CLAIM_STATUS_CERTIFICATE.md
@@ -1,11 +1,11 @@
 ---
-target_claim_id: minimal_record_instrument_dilation_scalar_exchange_nonselection_bounded_theorem_note_2026-07-11
+target_claim_id: covariant_effect_map_nonselection_and_repeat_certainty_collapse_bounded_theorem_note_2026-07-11
 target_claim_type: bounded_theorem
-claim_type_reason: "Exact finite-dimensional classification of one-Kraus no-record completions on a supplied one-excitation sector, with two distinct outcome-forgotten channels of minimal Kraus/Choi rank three whose exchange angle changes absorbing outcome-label weights under named process hypotheses."
+claim_type_reason: "Exact finite-dimensional depolarizing counterfamily for static effect selectors and an exact exhaustive-rank-one-menu collapse theorem under named zero-premise-weight hypotheses."
 actual_current_surface_status: bounded-support
 trace_class: direct_blocker_closure
 reachability_to_target: partially_closes
-conditional_surface_status: "A fully normalized instrument on a supplied one-excitation edge sector has K_empty=sqrt(q)U freedom; rank-three minimal outcome-forgotten I-SWAP channels remain label-readout-visible. Label-to-Record realization, effect selection, process derivation, cubic composition, event rate, Born derivation, and continuum dynamics remain open."
+conditional_surface_status: "Static effect/POVM additivity, normalization, noncontextuality, and covariance leave a continuous depolarizing family. On a fixed exhaustive finite rank-one menu, joint normalization plus RC_i force E_i=P_i. Physical menu realization, probability semantics, framework Records, and derivation of RC_i remain open."
 hypothetical_axiom_status: null
 admitted_observation_status: none
 proposal_allowed: false
@@ -16,9 +16,9 @@ review_loop_disposition: iteration_3_pass_bounded
 
 # Claim Status Certificate
 
-The current source classifies the single-Kraus no-record completion of supplied
-rank-one outcome branches and constructs an outcome-label-sensitive exchange
-witness.
+The current source classifies an exact finite-dimensional effect-assignment
+counterfamily and the exact conditions that collapse a fixed exhaustive
+rank-one menu to projectors.
 The exact current status is:
 
 - the four axioms do not supply the required process law;
@@ -28,21 +28,25 @@ The exact current status is:
   by itself select a unique visible law;
 - the Clifford-vector conclusion remains conditional on a faithful spectral
   availability/formation-to-carrier bridge;
-- full normalization forces `K_empty=sqrt(q)U` but leaves `U` arbitrary;
-- two `I-SWAP` choices give outcome-forgotten channels of minimal Kraus/Choi
-  rank three and are not dilation gauge;
-- their eventual absorbing right-label weights are exactly `1/5` and `1/4`;
-- the current runner reports `PASS=44 FAIL=0`; independent source review and
-  independent audit remain required.
+- `T_a(A)=aA+(1-a)Tr(A)I/d` preserves effects, every normalized POVM,
+  noncontextuality, and unitary covariance while leaving `a` free;
+- trace representation can identify the depolarized density operator rather
+  than the input density operator;
+- for a fixed exhaustive rank-one menu, joint normalization plus
+  `RC_i: Tr(P_iE_i)=1` force `E_i=P_i`;
+- both conditions are named conditional hypotheses carrying zero
+  framework-premise weight;
+- the current runner reports `PASS=51 FAIL=0`; independent audit remains
+  required.
 
 No axiom, primitive, or audit status is proposed or changed. The new claim
-depends on `minimal_axioms`, the record-outcome normal form, and the reconciled
-Kraus/Choi theorem; those edges remain subject to independent audit and
+depends on `minimal_axioms` and the record-outcome normal form; the new finite
+algebra is self-contained. Those edges remain subject to independent audit and
 dependency closure.
 
-The bounded nonselection component passed N1--N8 and independent source review
-at supplied one-excitation-sector/minimal-rank-alone scope. The external
-outcome label is not identified as a framework Record. Effect-faithfulness,
-simultaneous cubic QCA, event-rate, and continuum-consistency selectors remain
-open. Because those routes remain live, this result does not trigger the
-campaign's axiom-update stop condition.
+The bounded nonselection/collapse result passed independent claim and code/math
+review after full-effect, claim-scope, and runner repairs. Its full N1--N8
+packet preserves physical menu realization, probability semantics,
+framework-Record realization, `RC_i`, event rate, and continuum control as
+separate walls. Because a local process/repeatability derivation remains live,
+this result does not trigger the campaign's axiom-update stop condition.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
@@ -19,6 +19,11 @@ https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5201
 is open and mergeable against the record-observable branch; its audit-lane
 workflow was queued at the delivery checkpoint.
 
+Covariant-effect nonselection and repeat-certainty collapse review PR:
+https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5202
+is open and mergeable against the minimal-dilation branch; its audit-lane
+workflow was running at the delivery checkpoint.
+
 ## Central thesis
 
 The next move is not another sector Hamiltonian or continuum fit. It is to make

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
@@ -87,3 +87,23 @@ framework Records and does not establish an axiom-update requirement: effect
 selection, full lattice instrument composition, strict-QCA classification,
 and continuum consistency remain live stronger routes. The next campaign is
 effect selection/Born, after reading the actual composite-menu and Born lanes.
+
+## Effect-selection and repeat-certainty result
+
+The actual Gleason, Busch, graded-interface, readout-frame, count-firewall, and
+finite-record Born lanes were replayed before the new attack. The resulting
+hostile family
+`T_a(A)=aA+(1-a)Tr(A)I/d` preserves every effect, normalized POVM,
+noncontextual assignment, and unitary covariance while leaving `a` free. Its
+trace weights are represented by the depolarized density operator rather than
+the input density operator. Structural trace form therefore does not identify
+the formation effects.
+
+For any fixed exhaustive finite rank-one menu, positivity, joint normalization,
+and the named condition `RC_i: Tr(P_i E_i)=1` force `E_i=P_i`. Both conditions
+are load-bearing. The result is conditional and does not derive probability
+semantics, the physical menu, framework-Record realization, or `RC_i` from the
+axioms. Runner/cache: `PASS=51 FAIL=0`; independent claim and code/math reviews
+passed after repairs. No axiom-update stop condition is triggered. The next
+campaign is the full normalized local record-forming instrument, beginning
+with the actual composition/repeatability/readout-to-formation science.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/NO_GO_DISCIPLINE_CHECKLIST.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/NO_GO_DISCIPLINE_CHECKLIST.md
@@ -295,3 +295,158 @@ outcome-forgotten channels, non-gauge distinction, and absorbing label-sensitive
 witness close every promotion condition for the narrow nonselection statement.
 The label-to-Record, effect, cubic-QCA, event-rate, and continuum routes remain
 named and live. Independent review and audit remain required.
+
+---
+
+# No-Go Discipline: Covariant Effect Nonselection And Repeat-Certainty Collapse
+
+**Status:** PASS for the narrow finite-dimensional statement that effect/POVM
+additivity, normalization, noncontextuality, and unitary covariance do not by
+themselves identify the locked-output formation effect with the matching
+rank-one projector. Exhaustive menu normalization plus named conditional repeat
+certainty does make that identification. Probability semantics, framework-
+Record realization, and the physical calibration bridge remain open; no axiom
+update is claimed.
+
+## N1 — Alternative-route enumeration
+
+| Attack route | Marker | Attack and result |
+|---|---|---|
+| projective-menu/Gleason representation | `ATTEMPTED` | the hostile family `E_P=T_a(P)` is positive, normalized, additive, noncontextual, and covariant while `a` remains free; equations (1)--(4) of the [source](../../../../docs/COVARIANT_EFFECT_MAP_NONSELECTION_AND_REPEAT_CERTAINTY_COLLAPSE_BOUNDED_THEOREM_NOTE_2026-07-11.md#L78) show that trace form can return the depolarized representative rather than the input state |
+| composite `M_4` Gleason menus including entangled resolutions | `ATTEMPTED` | `T_a` is defined in every finite dimension and commutes with unitary conjugation, so enlarging named conditional projective menus does not select `a`; the imported composite-menu theorem still requires its grading/additivity/noncontextuality surface |
+| full effect/POVM Busch route | `ATTEMPTED` | extending `T_a` to every effect preserves effect bounds and every normalized POVM, so M1--M3 still leave the continuous family; see [lines 80--108](../../../../docs/COVARIANT_EFFECT_MAP_NONSELECTION_AND_REPEAT_CERTAINTY_COLLAPSE_BOUNDED_THEOREM_NOTE_2026-07-11.md#L80) |
+| covariance or menu noncontextuality as the missing selector | `ATTEMPTED` | `T_a(UAU^dag)=U T_a(A)U^dag` identically and depends only on `A`, not its menu, so neither condition selects `a` |
+| exhaustive menu normalization without repeat certainty | `ATTEMPTED` | the same `T_a` family survives for every `0<=a<=1`; this route fails to identify `E_i=P_i` |
+| repeat certainty without joint normalization | `ATTEMPTED` | the hostile assignment `E_i=I` satisfies `Tr(E_iP_i)=1` for every rank-one `P_i` but fails `sum_i E_i=I` for `d>1` |
+| exhaustive menu normalization plus repeat certainty | `ATTEMPTED` | succeeds: positivity, zero-diagonal row/column control, and normalization force `E_i=P_i` for every outcome; see [lines 151--185](../../../../docs/COVARIANT_EFFECT_MAP_NONSELECTION_AND_REPEAT_CERTAINTY_COLLAPSE_BOUNDED_THEOREM_NOTE_2026-07-11.md#L151) |
+
+The successful last route is conditional. The campaign has not derived the
+effect menu, its probability meaning, or repeat certainty from the four
+axioms. This is why the result is a bounded collapse theorem rather than a
+Born-rule derivation or a broad no-go.
+
+## N2 — Wall-independence audit
+
+The collapsed wall set internal to this finite effect-selection theorem has
+one independent pair:
+
+| Pair | First closes second? | Reverse? | Independent? |
+|---|---:|---:|---:|
+| finite exhaustive normalized effect menu / `RC_i: Tr(P_iE_i)=1` | no: the depolarizing family remains | no: `E_i=I` has `RC_i` but fails normalization | yes |
+
+The physical application has a dependency chain, not five independent walls:
+
+```text
+framework-Record realization
+  -> readout probability semantics
+  -> deterministic repeat readout
+  -> readout/formation calibration
+  -> RC_i for the formation effects.
+```
+
+Event order/rate and continuum control remain downstream out-of-scope
+campaign gates. Neither algebraic wall is derived by this theorem.
+
+## N3 — Hidden-wall scan
+
+The source, runner, and campaign packet were scanned for `we assume`,
+`assum*`, `by construction`, `as is standard`, `framework provides`, `bridge
+context`, `background`, `naturally`, `obviously`, `standard QFT`, `registered`,
+and `canonical`.
+
+All load-bearing conditions are explicit: finite `d>1`; effects and named
+conditional CP/trace semantics; an exhaustive rank-one projective menu; positivity and
+joint normalization; full effect/POVM additivity and noncontextuality only when
+comparing with Busch; and repeat certainty only for the collapse theorem. The
+runner's finite exact fixtures certify examples and reject mutations; the
+analytical proofs, not the fixture count, carry the universal claims. No label
+is promoted to a framework Record, and no empirical count is promoted to a
+predictive probability.
+
+| Phrase hit | Classification |
+|---|---|
+| `it assumes grading` in the replay paragraph | non-load-bearing comparator description |
+| `candidate and unregistered` | non-load-bearing status context; grants no premise weight |
+| the quoted scan vocabulary in this checklist | scan metadata, not a theorem premise |
+| `named conditional hypotheses` | explicit open conditions carrying zero framework-premise weight |
+
+## N4 — Residual matching
+
+| Witness | Witness residual | Residual used here | Match? |
+|---|---|---|---:|
+| [rank-one locked-output source, lines 192--219](../../../../docs/RECORD_OBSERVABLE_QUOTIENT_AND_RANK_ONE_FORMATION_OUTCOME_OPERATION_NORMAL_FORM_BOUNDED_THEOREM_NOTE_2026-07-11.md#L192) | `J_P(rho)=Tr(E_P rho)P` with `E_P` unselected | attack precisely the identification of `E_P` | yes |
+| [composite Gleason bridge](../../../../docs/BORN_FORM_FROM_LAWFUL_GRADED_CONSTRAINT_COMPOSITE_GLEASON_BRIDGE_NOTE_2026-07-04.md) | trace representation after named conditional grading, frame additivity, noncontextuality, and full composite menus | same-shape representation-versus-identification comparator, not an exact prior closure | adjacent only |
+| [qubit Busch/effect bridge](../../../../docs/BUSCH_POVM_EFFECT_GLEASON_QUBIT_AUTHORITY_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md) | trace representation after named conditional POVM-effect M1--M3 | same-shape representation-versus-identification comparator, not proof authority | adjacent only |
+| [readout frame-extension bridge](../../../../docs/READOUT_BRIDGE_FRAME_EXTENSION_UNIFIES_MARGINAL_READ_AND_REGISTERED_FACTOR_CONDITIONAL_BOUNDED_THEOREM_NOTE_2026-07-06.md) | realized disjoint Records do not automatically provide all projection-menu frame relations | adjacent physical-menu realization residual | adjacent only |
+| [post-record probability firewall](../../../../docs/POST_RECORD_COUNT_PROBABILITY_FIREWALL_2026-06-06.md) | counts do not derive predictive weights | different residual; context only, not witness support | no |
+
+The effect-identification residual is not substituted for the distinct
+probability, event-rate, or continuum residuals.
+
+## N5 — Rhetoric and resolution matrix
+
+| Resolution | Tested/proved? | Honest scoped statement |
+|---|---:|---|
+| arbitrary finite-dimensional effect/POVM | analytical | `T_a` maps every effect to an effect and every POVM to a POVM |
+| arbitrary fixed finite rank-one menu under named conditions | analytical | normalization plus repeat certainty forces `E_i=P_i` |
+| exact low-dimensional fixtures | runner: `d=2,4` plus a rational nonprojective POVM | fixtures corroborate algebra and catch context/collapse mutations; they are not called a universal numerical proof |
+| per lattice site or simultaneous QCA | no | open physical realization/composition problem |
+| infinite lattice, momentum mode, or continuum | no | no extrapolation is claimed |
+| Standard Model or gravity sector | no | no sector recovery is claimed |
+
+The phrase `Born-form trace weights` is therefore used only for equation (10)
+under named conditional CP/trace and probability semantics. The source does not say
+that the four axioms derive the Born probability rule.
+
+## N6 — Partial-closure and governance paths
+
+| Candidate path | Current status | What it could close |
+|---|---|---|
+| [composite Gleason bridge](../../../../docs/BORN_FORM_FROM_LAWFUL_GRADED_CONSTRAINT_COMPOSITE_GLEASON_BRIDGE_NOTE_2026-07-04.md) | `audited_conditional` | representation form after its grading/menu premises; cannot identify `sigma=rho` by itself |
+| [graded-constraint interface](../../../../docs/GRADED_CONSTRAINT_INTERFACE_CONSISTENCY_BOUNDED_NOTE_2026-07-04.md) | `audited_conditional` consistency result; proposed v2 is candidate/unregistered | presently supplies nothing; could close only after retained-grade derivation or explicit approval and registry update |
+| [readout frame extension](../../../../docs/READOUT_BRIDGE_FRAME_EXTENSION_UNIFIES_MARGINAL_READ_AND_REGISTERED_FACTOR_CONDITIONAL_BOUNDED_THEOREM_NOTE_2026-07-06.md) | bounded conditional bridge | could connect realized readouts to full frame menus if its hypotheses are discharged |
+| local instrument composition/coarse-graining | current next campaign route | could derive menu normalization, repeat readout, and formation/readout calibration together |
+| explicitly approved probability/process primitive | governance route only | presently neither proposed nor approved and carrying zero premise weight; approval and registry update would be required |
+| approved primitive registry | checked | `scale_reference`, `kinetic_isotropy`, and `realized_state` close none of menu, probability, repeat-certainty, or calibration walls |
+
+These routes remain live. Their existence prevents the hostile family from
+being advertised as proof that the axioms must be amended.
+
+## N7 — Steelman
+
+A hostile reviewer can accept the finite collapse algebra and still reject its
+physical use: framework Record permanence concerns an already realized record,
+whereas `E_i` governs formation of a candidate future record. A local
+instrument may use one channel to read the former and a different covariant
+channel `T_a` to form the latter. Nothing in the four axioms presently says
+those operational families coincide, and repeat certainty for the readout does
+not transfer to formation without calibration. This steelman is accepted. It
+does not refute the conditional theorem; it exactly identifies the next
+full-instrument/readout-to-formation attack.
+
+## N8 — Cross-cycle echo
+
+| Prior surface | Current status | Retirement/change mechanism and applicability |
+|---|---|---|
+| [finite ideal-record Born parent](../../../../docs/BORN_RULE_FROM_GLEASON_BUSCH_DERIVATION_NOTE_2026-05-20.md) | unaudited conditional source | takes ideal sharp projectors, a reference state, and Lüders structure as named conditional inputs; current result does not inherit those as axioms |
+| [composite Gleason bridge](../../../../docs/BORN_FORM_FROM_LAWFUL_GRADED_CONSTRAINT_COMPOSITE_GLEASON_BRIDGE_NOTE_2026-07-04.md) | `audited_conditional` | closed representation form, not grading/menu derivation or representative-state identification |
+| [post-record probability firewall](../../../../docs/POST_RECORD_COUNT_PROBABILITY_FIREWALL_2026-06-06.md) | unaudited no-go source | its count-to-prediction wall is neither retired nor reused as a broader impossibility theorem |
+| [minimal axioms](../../../../docs/MINIMAL_AXIOMS_2026-06-29.md) | approved axiom-premise node | Record says that Records form but supplies no formation rule, weights, or rate; this result adds none |
+| [minimal-dilation exchange result](../../../../docs/MINIMAL_RECORD_INSTRUMENT_DILATION_SCALAR_EXCHANGE_NONSELECTION_BOUNDED_THEOREM_NOTE_2026-07-11.md) | bounded theorem, unaudited | effect selection was a named residual; the current theorem narrows it to explicit menu/readout/calibration bridges but does not close lattice composition |
+
+Current-main `premise_decision_history.json` is provenance only and cannot
+chain-satisfy a claim. Prior probability walls can close only through a
+retained-grade derivation or an explicitly approved primitive recorded in the
+registry. No historical governance entry or relabeling convention retires
+them here.
+
+## Effect-selection gate conclusion
+
+All N1--N8 checks pass for the bounded theorem. The depolarizing family is an
+exact counterexample to structural-effect uniqueness, while the exhaustive
+menu collapse theorem gives a precise positive closure route after named
+conditional repeat certainty. The physical effect menu, framework-Record realization,
+same-carrier probability/readout semantics, readout-to-formation calibration,
+event law, and continuum limit remain named. The result therefore advances the
+campaign without triggering its axiom-update stop condition. Independent
+review and audit remain required.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/NO_GO_LEDGER.md
@@ -9,6 +9,8 @@
 | unitary evolution alone forms permanent records | rejected in finite blank/record split | an invariant record subspace is reducing, so blank-to-record transitions vanish |
 | availability variation equals kinetic-coefficient variation | falsified on current text | the top-eigenspace availability rule varies while remaining independent of the kinetic law |
 | minimal outcome-forgotten-channel rank plus normalized rank-one outcome branches excludes `I-SWAP` coherence | falsified on one supplied one-excitation edge sector | `K_empty=sqrt(q)U` leaves a projective-unitary freedom; exchange choices have rank-three minimal channels and change eventual absorbing label weights |
+| positivity, full effect/POVM additivity and normalization, noncontextuality, and unitary covariance select `E_P=P` | falsified in every finite `d>1` | the continuous depolarizing family `T_a` survives and changes the representing density operator |
+| repeat certainty alone selects a normalized exhaustive effect menu | falsified | `E_i=I` has repeat certainty but violates joint normalization for `d>1` |
 
 These negatives prune routes, not the full record-instrument program. The live
 escape is a separate classical record register coupled through a local
@@ -18,3 +20,8 @@ The new one-excitation-sector counterexample closes only the minimal-rank
 selector. It does not realize its external labels as framework Records or
 close direction-resolving effect selection, simultaneous cubic QCA
 composition, or continuum-consistency selectors.
+
+The effect-selection block supplies a positive conditional escape: on one
+fixed exhaustive finite rank-one menu, joint normalization plus `RC_i` forces
+`E_i=P_i`. Because a local process theorem may still derive both conditions,
+the negative rows do not prove that the axioms require amendment.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/OPPORTUNITY_QUEUE.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/OPPORTUNITY_QUEUE.md
@@ -6,8 +6,8 @@
 | 2 | absorbing rank-one formation-outcome normal form | completed bounded candidate | CP-process physical identification | high | high | classify a full normalized instrument and its minimal dilation |
 | 3 | exhaustive cubic neighbor-to-qubit intertwiner classification | 0.70 bounded | linearity and carrier faithfulness | high | high | derive scalar-sum plus vector-difference basis exactly |
 | 4 | eliminate the exchange branch by minimal outcome-forgotten-channel rank | falsified on supplied one-excitation sector | label-to-Record realization plus stronger effect/lattice/continuum selector | high | high | exchange angle changes eventual absorbing label weights despite rank-three minimality |
-| 5 | derive Born form on composite record menus | 0.35 bounded | grade additivity and menu noncontextuality | medium | medium | close the `M_2` loophole on neighboring composites without assuming probabilities |
-| 6 | full normalized local record-instrument classification | 0.30 bounded | local composition, pointer/effect menu, event gating | medium | medium | classify beyond the finite-edge single-no-record-Kraus family |
+| 5 | select formation effects from static covariance/additivity conditions | falsified; conditional selector isolated | physical menu plus `RC_i` derivation | high | high | depolarizing family survives; normalization plus `RC_i` forces projectors |
+| 6 | full normalized local record-instrument classification | 0.40 bounded | local composition, effect menu, repeatability, event gating | medium | medium | derive or refute `RC_i` and menu normalization from one local composition law |
 | 7 | controlled QCA-to-Hamiltonian continuum limit | 0.20 exact | scale/rate, RG control, universality | low | low | establish one microscopic carrier before testing Lorentz/QFT limits |
 
 The queue prioritizes the law/probability/time seam because every SM/GR

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
@@ -12,12 +12,14 @@ No merge was performed. Independent audit remains authoritative.
 The covariant-effect nonselection and repeat-certainty collapse result is
 prepared for the next stacked review PR:
 
+- PR: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5202
 - base: `physics-loop/record-faithful-dynamics-block03-20260711`
 - head: `physics-loop/record-faithful-dynamics-block04-effect-selection-20260711`
 - source runner: `PASS=51 FAIL=0`
 - disposition: review-loop bounded PASS after independent claim, code/math,
   governance, and full N1--N8 review; audit seeding and strict lint validated,
   with generated status surfaces stripped before delivery
+- delivery check: open, mergeable, audit workflow running
 
 No merge is authorized. Independent audit remains authoritative.
 

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
@@ -9,6 +9,18 @@ The cubic neighbor-response result was pushed and opened for review:
 
 No merge was performed. Independent audit remains authoritative.
 
+The covariant-effect nonselection and repeat-certainty collapse result is
+prepared for the next stacked review PR:
+
+- base: `physics-loop/record-faithful-dynamics-block03-20260711`
+- head: `physics-loop/record-faithful-dynamics-block04-effect-selection-20260711`
+- source runner: `PASS=51 FAIL=0`
+- disposition: review-loop bounded PASS after independent claim, code/math,
+  governance, and full N1--N8 review; audit seeding and strict lint validated,
+  with generated status surfaces stripped before delivery
+
+No merge is authorized. Independent audit remains authoritative.
+
 The minimal-dilation exchange result was pushed and opened as the next stacked
 review PR:
 

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
@@ -98,3 +98,40 @@ were stripped before delivery.
   labels from framework Records, scoping minimality to the outcome-forgotten
   channel, defining common-frame exchange, and disclosing every supplied
   process input. Independent audit remains required.
+
+## Effect-selection and repeat-certainty internal result
+
+- The full-effect depolarizing family preserves effect bounds, normalized
+  POVMs, menu noncontextuality, and unitary covariance while remaining
+  nonprojective for `a<1`.
+- Its trace dual represents weights with the depolarized density operator,
+  exposing why representation form does not identify the physical input.
+- Joint menu normalization plus `RC_i` exactly force every formation effect in
+  a fixed exhaustive finite rank-one menu to equal its projector.
+- Runner/cache: `PASS=51 FAIL=0`.
+
+### Effect-selection review iteration 1
+
+Review found four material blockers: projection-only versus full-POVM scope,
+Born-instrument overstatement, compressed physical walls, and tautological or
+overbroad runner claims. Governance review also required a full N1--N8 packet,
+current-main zero-premise-weight terminology, an exact `RC_i` definition, and
+a genuine shared-projection context mutation.
+
+### Effect-selection review iteration 2
+
+PASS from independent claim and code/math review. The source now covers every
+effect/POVM analytically, scopes fixture claims honestly, separates all
+physical interfaces, and contains a generic `d=2` symbolic certificate plus a
+general-`d` proof. Final governance/no-go re-review and independent audit remain
+required.
+
+### Effect-selection review iteration 3
+
+PASS WITH BOUNDED CLAIMS. Governance re-review confirmed the exact two-wall
+menu/`RC_i` independence table, the physical dependency chain, corrected
+residual matching, current-main zero-premise-weight language, full-effect
+duality, and provenance-only treatment of historical decisions. The citation
+graph seeded only `minimal_axioms` and the Block03 locked-output normal form;
+strict audit lint passed with no errors. Generated audit/effective-status
+surfaces are stripped before delivery. Independent audit remains required.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/ROUTE_PORTFOLIO.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/ROUTE_PORTFOLIO.md
@@ -8,7 +8,7 @@ Scores are provisional `0..3`; risk is negative.
 | rank-one formation-outcome normal form | 3 | 3 | 2 | 3 | -1 | separates an individual irreversible formation outcome from the coherent carrier and prevents a frozen-carrier category error |
 | cubic-equivariant faithful carrier | 3 | 3 | 3 | 2 | -2 | promising: scalar sum plus vector difference is the full linear intertwiner space; faithfulness must remove scalar without fiat |
 | strict QCA as fundamental coherent block | 2 | 2 | 2 | 3 | -2 | useful constraint, but existing results leave quantized protocol freedom and no curved cone at current density |
-| graded-constraint/Born composition | 3 | 3 | 3 | 2 | -3 | can unify formation weights and interference if additivity/menu-independence are derived rather than inserted |
+| graded-constraint/Born composition | 3 | 3 | 3 | 3 | -2 | static additivity/covariance leave a depolarizing family; exact closure is menu normalization plus physically derived `RC_i` |
 | strengthened exchange countermodel | 3 | 3 | 3 | 3 | -1 | completed on a supplied one-excitation sector: rank-three minimal outcome-forgotten `I-SWAP` channels change absorbing outcome-label weights |
 | unified continuum limit | 3 | 3 | 3 | 1 | -3 | deferred until the microscopic process object and carrier class are fixed |
 
@@ -19,5 +19,7 @@ then the cubic classifier and hostile exchange countermodel together. Follow
 with strict-QCA and effect/Born work before the unified continuum limit. The
 countermodel succeeded at supplied-sector scope, so minimal
 outcome-forgotten-channel rank cannot discharge the exchange branch. The next
-leverage point is effect/Born selection, followed by full-instrument and
+leverage point was effect/Born selection: it isolated `RC_i` plus menu
+normalization as the exact conditional selector. The next route is to derive
+or refute those conditions inside a full local instrument, followed by
 simultaneous-QCA classification before continuum extrapolation.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
@@ -69,10 +69,11 @@ no_go_routes:
 trace_gate_classification: direct_blocker_closure
 reachability_to_target: partially_closes
 review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_bounded
-pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_pending_delivery
+pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_mergeable_checks_running
 block01_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5178
 block02_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5181
 block03_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5201
+block04_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5202
 next_exact_action: >-
   Read the actual full-instrument, persistent-record, local-composition,
   repeatability, and readout-formation lanes; then classify a normalized local

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
@@ -8,29 +8,30 @@ current_goal: >-
   supply the physical evolution object, bare time ordering, record-formation
   weights, and an admissibility-to-carrier selector without importing the
   staggered/Dirac answer or sector-specific Standard Model and gravity laws.
-branch: physics-loop/record-faithful-dynamics-block03-20260711
+branch: physics-loop/record-faithful-dynamics-block04-effect-selection-20260711
 base_commit_at_start: 9d1636f05f
-cycle_count: 3
-block_count: 3
-active_route: composite_menu_effect_selection_and_born_rule
+cycle_count: 4
+block_count: 4
+active_route: full_local_instrument_and_readout_to_formation_calibration
 hard_residual: >-
   Can the four-axiom record surface canonically determine a faithful local
   record-forming instrument whose coherent no-record block is sufficiently
   constrained to exclude the observationally disconnected SWAP--Laplacian
   completion and select the Clifford-vector carrier?
-produced_claim_id: minimal_record_instrument_dilation_scalar_exchange_nonselection_bounded_theorem_note_2026-07-11
+produced_claim_id: covariant_effect_map_nonselection_and_repeat_certainty_collapse_bounded_theorem_note_2026-07-11
 actual_current_surface_status: bounded-support
 conditional_surface_status: >-
-  For supplied rank-one outcome branches and a single no-record Kraus operator,
-  full normalization gives K_empty=sqrt(q)U. On one finite edge, minimal
-  outcome-forgotten I-SWAP channels change eventual absorbing outcome-label
-  weights. Label-to-Record realization, effect selection, lattice composition,
-  event rate, Born derivation, and continuum dynamics remain open.
+  A depolarizing family survives positivity, full effect/POVM additivity and
+  normalization, menu noncontextuality, and unitary covariance. For one fixed
+  exhaustive finite rank-one menu, joint normalization plus the named
+  repeat-certainty condition RC_i force E_i=P_i. The physical effect menu,
+  probability semantics, framework-Record realization, and derivation of RC_i
+  remain open.
 admitted_observation_status: none
 claim_type_reason: >-
-  The source proves exact algebraic and operational statements under named
-  finite-dimensional and CP hypotheses while leaving the physical process
-  identification and downstream selectors open.
+  The source proves an exact finite-dimensional counterfamily and collapse
+  theorem under named conditional hypotheses carrying zero framework-premise
+  weight, while leaving their physical process derivation open.
 hypothetical_axiom_status: null
 proposal_allowed: false
 proposal_allowed_reason: >-
@@ -49,6 +50,9 @@ files_touched:
   - docs/MINIMAL_RECORD_INSTRUMENT_DILATION_SCALAR_EXCHANGE_NONSELECTION_BOUNDED_THEOREM_NOTE_2026-07-11.md
   - scripts/minimal_record_instrument_dilation_scalar_exchange_nonselection_2026_07_11.py
   - logs/runner-cache/minimal_record_instrument_dilation_scalar_exchange_nonselection_2026_07_11.txt
+  - docs/COVARIANT_EFFECT_MAP_NONSELECTION_AND_REPEAT_CERTAINTY_COLLAPSE_BOUNDED_THEOREM_NOTE_2026-07-11.md
+  - scripts/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.py
+  - logs/runner-cache/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.txt
 open_imports:
   - fundamental process object: Hamiltonian, strict tick, or record instrument
   - faithful law-to-record influence principle
@@ -61,18 +65,21 @@ no_go_routes:
   - strict local unitary ticks alone leave multiple drift protocols and no curved cone at the analyzed carrier density
   - direct preservation of every rank-one permanent record freezes the same carrier and also forbids unitary record formation
   - minimal outcome-forgotten-channel rank plus full normalization does not remove an outcome-label-sensitive I-SWAP no-record branch on the supplied one-excitation sector
+  - positivity, effect/POVM additivity and normalization, noncontextuality, and unitary covariance do not identify E_P with P
 trace_gate_classification: direct_blocker_closure
 reachability_to_target: partially_closes
-review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_bounded
-pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_mergeable_checks_queued
+review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_bounded
+pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_pending_delivery
 block01_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5178
 block02_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5181
 block03_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5201
 next_exact_action: >-
-  Read and reconcile the composite-menu, Gleason-Busch, grade-additivity,
-  record-frequency, and Born/scattering lanes; then classify effect selection
-  without importing a preferred pointer frame or probability measure.
+  Read the actual full-instrument, persistent-record, local-composition,
+  repeatability, and readout-formation lanes; then classify a normalized local
+  record-forming instrument and test whether its composition derives the
+  effect menu and RC_i without importing probability semantics.
 stop_condition: >-
-  Stop the campaign only after either (a) an exact selector theorem
-  with every new premise isolated, or (b) a strengthened faithful countermodel
-  proving that an additional process primitive is unavoidable.
+  Stop and discuss an axiom update only if an exact result proves that the
+  required bridge cannot be derived and an additional approved axiom or
+  primitive is necessary. Conditional theorems and underdetermination results
+  do not trigger this condition while live derivation routes remain.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/TRACE_GATE.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/TRACE_GATE.md
@@ -1,11 +1,11 @@
 ---
 trace_class: direct_blocker_closure
-target_claim_id: minimal_record_instrument_dilation_scalar_exchange_nonselection_bounded_theorem_note_2026-07-11
+target_claim_id: covariant_effect_map_nonselection_and_repeat_certainty_collapse_bounded_theorem_note_2026-07-11
 target_blocker_text: "A unique or severely constrained dynamics/admissibility law, including time and the probability rule."
 source_of_blocker_text: user_goal
 reachability_to_target: partially_closes
 artifact_role: theorem
-next_trace_action: "Read the composite-menu/Born lane and attack effect selection without importing a probability measure or preferred pointer frame."
+next_trace_action: "Read the full-instrument/composition/repeatability lane and test whether one normalized local process derives the effect menu and RC_i without importing probability semantics."
 ---
 
 # Trace Gate
@@ -24,3 +24,11 @@ normalization and minimal outcome-forgotten-channel rank do not select away an
 weights on a supplied one-excitation sector. A label-to-Record realization,
 effect selection, full lattice composition, event rate, and continuum control
 remain open.
+
+The effect-selection block now proves that the static structural conditions
+normally used for trace representation leave an exact depolarizing freedom.
+It also proves that a fixed exhaustive rank-one menu, joint normalization, and
+`RC_i` force the locked-output effects to be projectors. This directly narrows
+the Born/effect blocker but does not derive probability semantics or `RC_i`.
+The next trace action is therefore the full local instrument rather than a
+second representation theorem.

--- a/docs/COVARIANT_EFFECT_MAP_NONSELECTION_AND_REPEAT_CERTAINTY_COLLAPSE_BOUNDED_THEOREM_NOTE_2026-07-11.md
+++ b/docs/COVARIANT_EFFECT_MAP_NONSELECTION_AND_REPEAT_CERTAINTY_COLLAPSE_BOUNDED_THEOREM_NOTE_2026-07-11.md
@@ -1,0 +1,275 @@
+---
+claim_id: covariant_effect_map_nonselection_and_repeat_certainty_collapse_bounded_theorem_note_2026-07-11
+claim_type: bounded_theorem
+claim_scope: "Exact finite-dimensional nonselection family for normalized, positive, orthogonally additive, noncontextual, unitary-covariant effect assignments, plus the theorem that exhaustive rank-one menu normalization and repeat certainty force E_i=P_i. POVM additivity and repeat certainty are named conditional hypotheses with zero premise weight and are not derived from the four axioms."
+upstream_dependencies:
+  - minimal_axioms
+  - record_observable_quotient_and_rank_one_formation_outcome_operation_normal_form_bounded_theorem_note_2026-07-11
+runner: scripts/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.py
+---
+
+# Covariant Effect Nonselection And Repeat-Certainty Collapse
+
+**Date:** 2026-07-11
+
+**Type:** bounded theorem
+
+**Status authority:** independent audit only. This source changes no axiom,
+primitive, framework rule, or audit verdict.
+
+**Primary runner:**
+[`scripts/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.py`](../scripts/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.py)
+
+**Cached output:**
+[`logs/runner-cache/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.txt`](../logs/runner-cache/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.txt)
+
+## Question
+
+The rank-one locked-output theorem leaves each formation outcome in the form
+
+```text
+J_P(rho) = Tr(E_P rho) P,       0 <= E_P <= I.
+```
+
+What selects `E_P=P`?
+
+The existing Gleason and Busch lanes answer a different question. They show
+that an already named conditional additive, normalized, nonnegative,
+noncontextual
+weight functional has trace form. They do not identify its representing
+density operator with the input density operator, and they do not select the
+projection-indexed formation-effect assignment.
+
+This note proves two exact facts:
+
+1. positivity, normalization, orthogonal additivity, noncontextuality, and
+   unitary covariance still leave a continuous depolarizing freedom;
+2. exhaustive rank-one menu normalization plus repeat certainty collapses the
+   effect menu to `E_i=P_i`.
+
+Within a named conditional effect/probability surface, the final algebraic selector is
+readout-to-formation calibration. Framework-Record realization, readout
+probability semantics, and repeat certainty remain separate physical bridges.
+
+## Existing-science reading gate
+
+The actual current lane was replayed before this theorem:
+
+- the composite Gleason bridge reports `PASS=24 FAIL=0` and is
+  `audited_conditional`; it assumes grading, orthogonal additivity,
+  noncontextuality, full `M_4` projection menus including entangled
+  resolutions, and the named Gleason theorem;
+- the graded-interface v2 runner reports `PASS=7 FAIL=0` and is
+  `audited_conditional`; v2 is candidate and unregistered;
+- the qubit Busch/effect runner reports `40 PASS / 0 FAIL` and correctly proves
+  trace form from named conditional POVM-effect axioms M1--M3, but its row is unaudited
+  and it does not derive M1--M3;
+- the post-record count firewall (`56/0`) and finite-frequency boundary
+  (`35/0`) show that realized counts do not supply predictive weights, IID
+  structure, or convergence;
+- the finite ideal-record Born parent is unaudited and still conditionally
+  identifies a pre-record reference state.
+
+These replayed rows are non-load-bearing comparators whose statuses may change;
+the present nonselection, duality, and collapse proofs are self-contained.
+The Busch comparator is
+`BUSCH_POVM_EFFECT_GLEASON_QUBIT_AUTHORITY_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md`.
+The arbitrary locked-output effect is derived under Block03's named conditions in
+[`RECORD_OBSERVABLE_QUOTIENT_AND_RANK_ONE_FORMATION_OUTCOME_OPERATION_NORMAL_FORM_BOUNDED_THEOREM_NOTE_2026-07-11.md`](RECORD_OBSERVABLE_QUOTIENT_AND_RANK_ONE_FORMATION_OUTCOME_OPERATION_NORMAL_FORM_BOUNDED_THEOREM_NOTE_2026-07-11.md).
+
+## 1. Exact covariant nonselection family
+
+Let `H=C^d`. For every effect `0<=A<=I`, define, for `0<=a<=1`,
+
+```text
+T_a(A) = a A + (1-a) Tr(A) I/d.                         (1)
+```
+
+For a projection `P`, write `E_P^(a)=T_a(P)`, so
+`Tr(P)=rank(P)`.
+
+This family obeys:
+
+```text
+T_a(0)=0,       T_a(I)=I,
+0 <= E_P^(a) <= I,
+E_(P+Q)^(a)=E_P^(a)+E_Q^(a)       when PQ=0,
+E_(UPU^dag)^(a)=U E_P^(a) U^dag.
+```
+
+For every projective resolution `sum_i P_i=I`, equation (1) gives
+
+```text
+sum_i E_(P_i)^(a)=I.                                      (2)
+```
+
+More generally, if `{A_i}` is any POVM, linearity and
+`sum_i Tr(A_i)=Tr(I)=d` give `sum_i T_a(A_i)=I`. If `lambda` is an
+eigenvalue of `A`, the corresponding eigenvalue of `T_a(A)` is
+`a lambda+(1-a)Tr(A)/d`, which lies in `[0,1]`. Thus the family survives
+the full effect/POVM M1--M3 surface, not only projective menus.
+
+The assignment is a function of `A`, not of its embedding menu, so it is
+noncontextual. Positivity, full effect/POVM additivity and normalization,
+menu noncontextuality, and unitary covariance therefore do not select `a`.
+
+For any density operator `rho` and any effect `A`,
+
+```text
+m_(rho,a)(A) := Tr(rho T_a(A))
+  = Tr([a rho + (1-a)I/d] A).                             (3)
+```
+
+In particular, set `A=P` for a projection-indexed formation effect.
+Accordingly, applying a scalar trace-representation theorem to the functional
+on the left returns the depolarized representative
+
+```text
+sigma_a(rho)=a rho+(1-a)I/d,                              (4)
+```
+
+not the identification `sigma=rho`. Trace form alone does not close effect
+selection.
+
+## 2. Repeat certainty collapses the hostile family
+
+For rank-one `P`, the self-weight is
+
+```text
+Tr(P E_P^(a)) = a + (1-a)/d.                              (5)
+```
+
+At finite `d>1`, imposing repeat certainty
+
+```text
+Tr(P E_P)=1                                               (6)
+```
+
+selects `a=1` inside (1), so `E_P=P`.
+
+Equation (6) is not silently attributed to Record permanence. Permanence says
+an existing framework Record remains locked. It does not say that the
+formation effect for a future outcome is the same operational functional as a
+deterministic readout of the existing record.
+
+## 3. General exhaustive-menu collapse theorem
+
+Let `{P_i=|i><i|}_{i=1}^d` be a complete rank-one projective menu. Let
+`{E_i}` be effects satisfying
+
+```text
+E_i >= 0,        sum_i E_i=I,        Tr(E_i P_i)=1.        (7)
+```
+
+Then
+
+```text
+E_i=P_i  for every i.                                     (8)
+```
+
+**Proof.** In the basis defined by the menu, positivity gives
+`<j|E_i|j>>=0`. Normalization and the last clause of (7) give
+
+```text
+sum_i <j|E_i|j>=1,       <j|E_j|j>=1,
+```
+
+so `<j|E_i|j>=0` for every `i!=j`. For a positive semidefinite matrix,
+
+```text
+|(E_i)_(jk)|^2 <= (E_i)_(jj) (E_i)_(kk).                  (9)
+```
+
+Every zero diagonal entry therefore kills its full row and column. `E_i`
+annihilates every `|j>` with `j!=i`, while normalization and repeat certainty
+give `E_i|i> = |i>`. Hence `E_i=P_i`. QED.
+
+Both clauses are load-bearing. Repeat certainty alone admits `E_i=I` for all
+`i`; joint normalization rules that family out. Joint normalization without
+repeat certainty admits the continuous family (1).
+
+Combining (8) with the locked-output normal form gives
+
+```text
+J_i(rho)=Tr(P_i rho)P_i.                                  (10)
+```
+
+This is the rank-one projective measure-and-prepare/Lueders instrument with
+Born-form trace weights, conditional on the named CP/trace interpretation,
+menu normalization, repeat certainty, and calibration hypotheses. Those
+hypotheses carry zero framework-premise weight here. This is not a derivation
+of probability semantics from the framework axioms.
+
+## 4. Physical residual
+
+The theorem does not derive the physical applicability of POVM additivity from
+the four axioms. It also does not derive repeat certainty from Record
+permanence. For the algebraic theorem the exact missing condition is simply
+
+```text
+RC_i: Tr(P_i E_i)=1  for every i.                           (11)
+```
+
+Call a physical derivation of (11) for the formation effects the
+**readout-to-formation calibration bridge**. The name records one gap; it is
+not an approved primitive, and it carries zero premise weight. Before equation
+(10) can be framework-native, three additional interfaces remain explicit: realize the
+output as a framework Record on `Z^3`, identify a same-carrier readout as an
+effect/probability functional, and derive deterministic repeat readout. Record
+permanence alone supplies none of those identifications and does not prove
+`RC_i` for formation.
+
+If a candidate local instrument plus controlled coarse-graining derives
+`RC_i` and the effect-menu hypotheses, equation (10) follows without a
+preferred rank-one projective readout context: the argument applies
+covariantly to every fixed rank-one menu under the theorem hypotheses. If not,
+the depolarizing family (1) remains a hostile alternative.
+
+## 5. Boundaries
+
+- Effects, the rank-one menu, positivity, joint normalization, POVM/effect
+  additivity, and repeat certainty are named conditional hypotheses carrying
+  zero framework-premise weight.
+- The theorem does not derive POVM additivity, noncontextuality, composite-menu
+  eligibility, or the physical menu from Admissibility or Record.
+- The theorem does not derive repeat certainty from Record permanence.
+- The theorem does not identify an outcome label as a framework Record.
+- The theorem fixes the formation-effect assignment after calibration; it does not derive event
+  occurrence, site/order/rate, reset/IID structure, a clock, or a continuum
+  law.
+- Counts and empirical frequencies are not used as predictive probabilities.
+- The theorem does not establish that the axioms require amendment. The
+  [`minimal axioms`](MINIMAL_AXIOMS_2026-06-29.md) leave the process surface
+  downstream; a local process theorem could still derive the named bridge. An
+  explicit primitive would carry zero premise weight until approval and a
+  registry update.
+
+## 6. No-Go Discipline summary
+
+- **N1:** projective-only Gleason, composite Gleason, qubit POVM/Busch,
+  covariance, and repeat-calibration routes are separated.
+- **N2:** the exhaustive normalized menu and `RC_i` are the two independent
+  algebraic walls. Record realization, readout probability semantics,
+  deterministic repeat readout, calibration, and `RC_i` form a physical
+  dependency chain; event/rate and continuum are downstream out-of-scope gates.
+- **N3:** every effect, menu, normalization, covariance, and calibration
+  hypothesis is explicit.
+- **N4:** the result attacks effect identification, not the different count,
+  frequency, reference-state, event-rate, or continuum residuals.
+- **N5:** the collapse is per fixed finite rank-one menu under the theorem
+  hypotheses; no lattice-wide or continuum statement is made.
+- **N6:** composite-menu derivation and local-instrument coarse-graining remain
+  live derivation routes; explicit primitive approval and registry update are
+  a governance-only route with zero premise weight beforehand.
+- **N7:** a hostile reviewer can reject `RC_i` as physically underived; the
+  theorem agrees and leaves its process derivation as the next target.
+- **N8:** prior Gleason/Busch work repeatedly closed representation form while
+  leaving probability/additivity and identification of the representing
+  density operator with the input density operator open; this theorem does not
+  relabel those residuals as solved.
+
+## Reproduction
+
+```bash
+python3 scripts/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.py
+```

--- a/logs/runner-cache/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.txt
+++ b/logs/runner-cache/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.txt
@@ -1,0 +1,54 @@
+PASS F01basisd2m0: rank-one menu effects normalize
+PASS F02basisd2m0: all transformed menu elements obey 0<=E<=I
+PASS F01basisd2m1_3: rank-one menu effects normalize
+PASS F02basisd2m1_3: all transformed menu elements obey 0<=E<=I
+PASS F01basisd2m1: rank-one menu effects normalize
+PASS F02basisd2m1: all transformed menu elements obey 0<=E<=I
+PASS F01basisd4m0: rank-one menu effects normalize
+PASS F02basisd4m0: all transformed menu elements obey 0<=E<=I
+PASS F01basisd4m1_3: rank-one menu effects normalize
+PASS F02basisd4m1_3: all transformed menu elements obey 0<=E<=I
+PASS F01basisd4m1: rank-one menu effects normalize
+PASS F02basisd4m1: all transformed menu elements obey 0<=E<=I
+PASS F01belld4m0: rank-one menu effects normalize
+PASS F02belld4m0: all transformed menu elements obey 0<=E<=I
+PASS F01belld4m1_3: rank-one menu effects normalize
+PASS F02belld4m1_3: all transformed menu elements obey 0<=E<=I
+PASS F01belld4m1: rank-one menu effects normalize
+PASS F02belld4m1: all transformed menu elements obey 0<=E<=I
+PASS F03d2: E_0=0
+PASS F04d2: E_I=I
+PASS F05d2: orthogonal additivity holds on every coordinate-projector pair
+PASS F03d4: E_0=0
+PASS F04d4: E_I=I
+PASS F05d4: orthogonal additivity holds on every coordinate-projector pair
+PASS F06: two exact noncommuting witnesses satisfy unitary covariance
+PASS F07: the rational three-outcome input is a nonprojective POVM
+PASS F08: the hostile map preserves full POVM normalization
+PASS F09: transformed nonprojective POVM elements remain effects
+PASS F10: rejector detects a menu-length-dependent mutation on one shared projection
+PASS N01: a=1/3 gives a nonprojective effect
+PASS N02: noisy self-weight is 1/2 rather than one
+PASS N03: eight exact fixtures show trace form can return the depolarized state instead of the input state
+PASS N04: rank-one repeat weight has the exact affine form
+PASS N05: repeat certainty selects a=1 inside the hostile family
+PASS C01: a PSD zero-diagonal 2x2 principal minor forces its off-diagonal entry to vanish
+PASS C02: finite exact control agrees that a real sum of two squares vanishes only at zero
+PASS C03: generic d=2 Hermitian menu is jointly normalized
+PASS C04: the two repeat weights isolate the remaining diagonal b
+PASS C05: second repeat certainty forces b=0
+PASS C06: PSD of the repeat-calibrated E0 forces its off-diagonal to zero
+PASS C07: the generic d=2 menu collapses to P0,P1
+PASS C08d2: repeat certainty alone admits E_i=I
+PASS C09d2: the repeat-only hostile family fails joint normalization
+PASS C08d4: repeat certainty alone admits E_i=I
+PASS C09d4: the repeat-only hostile family fails joint normalization
+PASS S01: source note exists
+PASS S02: source contains boundary marker: readout-to-formation calibration
+PASS S03: source contains boundary marker: does not derive POVM additivity
+PASS S04: source contains boundary marker: does not derive repeat certainty from Record permanence
+PASS S05: source contains boundary marker: does not identify an outcome label as a framework Record
+PASS S06: source contains boundary marker: does not establish that the axioms require amendment
+BOUNDARY: additivity, menu normalization, effects, and repeat certainty are named conditional hypotheses with zero premise weight.
+BOUNDARY: the collapse theorem selects E_i=P_i only after the named condition RC_i=Tr(P_i E_i)=1.
+TOTAL: PASS=51 FAIL=0

--- a/scripts/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.py
+++ b/scripts/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Exact checks for covariant effect nonselection and repeat certainty."""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+
+import sympy as sp
+
+
+PASS = 0
+FAIL = 0
+
+
+def check(label: str, condition: bool, detail: str) -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"PASS {label}: {detail}")
+    else:
+        FAIL += 1
+        print(f"FAIL {label}: {detail}")
+
+
+def projector(vector: sp.Matrix) -> sp.Matrix:
+    return sp.simplify(vector * vector.H)
+
+
+def basis_menu(dimension: int) -> list[sp.Matrix]:
+    result = []
+    for index in range(dimension):
+        vector = sp.zeros(dimension, 1)
+        vector[index] = 1
+        result.append(projector(vector))
+    return result
+
+
+def bell_menu() -> list[sp.Matrix]:
+    root = sp.sqrt(2)
+    vectors = (
+        sp.Matrix([1, 0, 0, 1]) / root,
+        sp.Matrix([1, 0, 0, -1]) / root,
+        sp.Matrix([0, 1, 1, 0]) / root,
+        sp.Matrix([0, 1, -1, 0]) / root,
+    )
+    return [projector(vector) for vector in vectors]
+
+
+def depolarized_effect(effect_input: sp.Matrix, mixing: sp.Expr) -> sp.Matrix:
+    dimension = effect_input.rows
+    return sp.simplify(
+        mixing * effect_input
+        + (1 - mixing) * sp.trace(effect_input) * sp.eye(dimension) / dimension
+    )
+
+
+def structural_family_checks() -> None:
+    for menu_name, dimension, menu in (
+        ("basis", 2, basis_menu(2)),
+        ("basis", 4, basis_menu(4)),
+        ("bell", 4, bell_menu()),
+    ):
+        for mixing in (sp.Integer(0), sp.Rational(1, 3), sp.Integer(1)):
+            effects = [depolarized_effect(item, mixing) for item in menu]
+            suffix = f"{menu_name}d{dimension}m{str(mixing).replace('/', '_')}"
+            check(f"F01{suffix}", sum(effects, sp.zeros(dimension)) == sp.eye(dimension), "rank-one menu effects normalize")
+            check(f"F02{suffix}", all(effect.is_positive_semidefinite and (sp.eye(dimension) - effect).is_positive_semidefinite for effect in effects), "all transformed menu elements obey 0<=E<=I")
+
+    for dimension in (2, 4):
+        zero = sp.zeros(dimension)
+        identity = sp.eye(dimension)
+        mixing = sp.Rational(2, 5)
+        check(f"F03d{dimension}", depolarized_effect(zero, mixing) == zero, "E_0=0")
+        check(f"F04d{dimension}", depolarized_effect(identity, mixing) == identity, "E_I=I")
+
+        menu = basis_menu(dimension)
+        additive = True
+        indices = range(dimension)
+        for mask_left in range(1 << dimension):
+            for mask_right in range(1 << dimension):
+                if mask_left & mask_right:
+                    continue
+                left = sum((menu[i] for i in indices if mask_left & (1 << i)), zero)
+                right = sum((menu[i] for i in indices if mask_right & (1 << i)), zero)
+                additive &= depolarized_effect(left + right, mixing) == (
+                    depolarized_effect(left, mixing) + depolarized_effect(right, mixing)
+                )
+        check(f"F05d{dimension}", additive, "orthogonal additivity holds on every coordinate-projector pair")
+
+    hadamard = sp.Matrix([[1, 1], [1, -1]]) / sp.sqrt(2)
+    swap = sp.Matrix(
+        [[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]]
+    )
+    unitaries = (sp.kronecker_product(hadamard, sp.eye(2)), swap)
+    projection = bell_menu()[0]
+    mixing = sp.Rational(1, 3)
+    covariant = all(
+        sp.simplify(
+            depolarized_effect(unitary * projection * unitary.H, mixing)
+            - unitary * depolarized_effect(projection, mixing) * unitary.H
+        )
+        == sp.zeros(4)
+        for unitary in unitaries
+    )
+    check("F06", covariant, "two exact noncommuting witnesses satisfy unitary covariance")
+
+    povm = (
+        sp.diag(sp.Rational(1, 2), 0),
+        sp.diag(sp.Rational(1, 2), sp.Rational(1, 3)),
+        sp.diag(0, sp.Rational(2, 3)),
+    )
+    transformed = [depolarized_effect(item, sp.Rational(1, 3)) for item in povm]
+    check("F07", sum(povm, sp.zeros(2)) == sp.eye(2), "the rational three-outcome input is a nonprojective POVM")
+    check("F08", sum(transformed, sp.zeros(2)) == sp.eye(2), "the hostile map preserves full POVM normalization")
+    check("F09", all(item.is_positive_semidefinite and (sp.eye(2) - item).is_positive_semidefinite for item in transformed), "transformed nonprojective POVM elements remain effects")
+    shared_projection = basis_menu(2)[0]
+    two_outcome_context = (shared_projection, basis_menu(2)[1])
+    three_outcome_context = (
+        shared_projection,
+        basis_menu(2)[1] / 2,
+        basis_menu(2)[1] / 2,
+    )
+    context_mutation = (
+        two_outcome_context[0] == three_outcome_context[0]
+        and sum(two_outcome_context, sp.zeros(2)) == sp.eye(2)
+        and sum(three_outcome_context, sp.zeros(2)) == sp.eye(2)
+        and depolarized_effect(two_outcome_context[0], sp.Rational(1, 3))
+        != depolarized_effect(three_outcome_context[0], sp.Rational(2, 3))
+    )
+    check("F10", context_mutation, "rejector detects a menu-length-dependent mutation on one shared projection")
+
+
+def nonselection_and_duality_checks() -> None:
+    dimension = 4
+    mixing = sp.Rational(1, 3)
+    projection = basis_menu(dimension)[0]
+    effect = depolarized_effect(projection, mixing)
+    check("N01", effect != projection, "a=1/3 gives a nonprojective effect")
+    check("N02", sp.trace(effect * projection) == sp.Rational(1, 2), "noisy self-weight is 1/2 rather than one")
+
+    vector = sp.Matrix([1, 1, 0, 0]) / sp.sqrt(2)
+    rho = projector(vector)
+    depolarized_state = sp.simplify(mixing * rho + (1 - mixing) * sp.eye(dimension) / dimension)
+    duality = all(
+        sp.simplify(
+            sp.trace(rho * depolarized_effect(candidate, mixing))
+            - sp.trace(depolarized_state * candidate)
+        )
+        == 0
+        for candidate in bell_menu() + basis_menu(dimension)
+    )
+    check("N03", duality, "eight exact fixtures show trace form can return the depolarized state instead of the input state")
+
+    parameter = sp.symbols("a", real=True)
+    self_weight = sp.simplify(sp.trace(projection * depolarized_effect(projection, parameter)))
+    check("N04", self_weight == parameter + (1 - parameter) / dimension, "rank-one repeat weight has the exact affine form")
+    check("N05", sp.solve(sp.Eq(self_weight, 1), parameter) == [1], "repeat certainty selects a=1 inside the hostile family")
+
+
+def general_collapse_checks() -> None:
+    # Proof certificate for the general finite-dimensional lemma.  In a
+    # normalized rank-one menu, repeat certainty fixes diagonal entry i of E_i
+    # to one.  Positivity and normalization make every other effect's i-th
+    # diagonal zero.  The PSD 2x2-minor inequality
+    # |E_j[k,i]|^2 <= E_j[k,k] E_j[i,i] then kills row/column i of E_j.
+    # Applying this for every i leaves E_j=P_j.
+    u, v, diagonal = sp.symbols("u v diagonal", real=True, nonnegative=True)
+    principal_minor = sp.Matrix([[0, u + sp.I * v], [u - sp.I * v, diagonal]])
+    check("C01", sp.expand(principal_minor.det()) == -(u**2 + v**2), "a PSD zero-diagonal 2x2 principal minor forces its off-diagonal entry to vanish")
+    rational_grid = range(-5, 6)
+    check("C02", all((x, y) == (0, 0) for x, y in itertools.product(rational_grid, repeat=2) if x * x + y * y == 0), "finite exact control agrees that a real sum of two squares vanishes only at zero")
+
+    # Generic d=2 Hermitian certificate. Repeat certainty for E0 fixes its
+    # first diagonal to one. With E1=I-E0, repeat certainty for E1 fixes the
+    # remaining E0 diagonal to zero. PSD then kills the complex off-diagonal.
+    x, y, b = sp.symbols("x y b", real=True)
+    e0 = sp.Matrix([[1, x + sp.I * y], [x - sp.I * y, b]])
+    e1 = sp.eye(2) - e0
+    p0, p1 = basis_menu(2)
+    check("C03", sp.simplify(e0 + e1) == sp.eye(2), "generic d=2 Hermitian menu is jointly normalized")
+    check("C04", sp.trace(e0 * p0) == 1 and sp.trace(e1 * p1) == 1 - b, "the two repeat weights isolate the remaining diagonal b")
+    check("C05", sp.solve(sp.Eq(sp.trace(e1 * p1), 1), b) == [0], "second repeat certainty forces b=0")
+    check("C06", sp.expand(e0.det().subs(b, 0)) == -(x**2 + y**2), "PSD of the repeat-calibrated E0 forces its off-diagonal to zero")
+    check("C07", e0.subs({b: 0, x: 0, y: 0}) == p0 and e1.subs({b: 0, x: 0, y: 0}) == p1, "the generic d=2 menu collapses to P0,P1")
+
+    # Hostile controls show both hypotheses are load-bearing.
+    for dimension in (2, 4):
+        menu = basis_menu(dimension)
+        identity_effects = [sp.eye(dimension) for _ in menu]
+        check(f"C08d{dimension}", all(sp.trace(effect * menu[i]) == 1 for i, effect in enumerate(identity_effects)), "repeat certainty alone admits E_i=I")
+        check(f"C09d{dimension}", sum(identity_effects, sp.zeros(dimension)) != sp.eye(dimension), "the repeat-only hostile family fails joint normalization")
+
+
+def source_checks() -> None:
+    path = Path("docs/COVARIANT_EFFECT_MAP_NONSELECTION_AND_REPEAT_CERTAINTY_COLLAPSE_BOUNDED_THEOREM_NOTE_2026-07-11.md")
+    check("S01", path.exists(), "source note exists")
+    text = path.read_text() if path.exists() else ""
+    markers = (
+        "readout-to-formation calibration",
+        "does not derive POVM additivity",
+        "does not derive repeat certainty from Record permanence",
+        "does not identify an outcome label as a framework Record",
+        "does not establish that the axioms require amendment",
+    )
+    for index, marker in enumerate(markers, 2):
+        check(f"S{index:02d}", marker in text, f"source contains boundary marker: {marker}")
+
+
+def main() -> int:
+    structural_family_checks()
+    nonselection_and_duality_checks()
+    general_collapse_checks()
+    source_checks()
+    print("BOUNDARY: additivity, menu normalization, effects, and repeat certainty are named conditional hypotheses with zero premise weight.")
+    print("BOUNDARY: the collapse theorem selects E_i=P_i only after the named condition RC_i=Tr(P_i E_i)=1.")
+    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

- constructs the exact finite-dimensional depolarizing effect family that survives positivity, full POVM normalization/additivity, menu noncontextuality, and unitary covariance
- proves that a fixed exhaustive rank-one menu plus joint normalization and RC_i = Tr(P_i E_i) = 1 forces E_i = P_i
- keeps probability semantics, physical menu realization, framework-Record realization, and derivation of RC_i explicit and open
- adds the full N1-N8 packet and advances the campaign to the normalized local-instrument attack

No axiom or primitive change is proposed. Independent audit remains authoritative.

## Verification

- runner/cache: PASS=51 FAIL=0, byte-identical
- independent claim and code/math review: PASS
- No-Go Discipline and current-main governance review: PASS
- vocabulary lint: 0 violations
- audit pipeline: PASS; intended deps are minimal_axioms + Block03 locked-output normal form
- strict audit lint: no errors
- generated audit/effective-status surfaces stripped before delivery