### PR TITLE
physics-loop: classify intermittent record instrument normal form

### DIFF
--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/ARTIFACT_PLAN.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/ARTIFACT_PLAN.md
@@ -25,7 +25,7 @@
 - decisive same-carrier `I-SWAP` counterexample, with the label-to-Record
   realization kept open.
 
-## Effect selection and Born — current result
+## Effect selection and Born — delivered
 
 - exact depolarizing effect family surviving positivity, full POVM
   normalization/additivity, menu noncontextuality, and covariance;
@@ -35,11 +35,21 @@
   and derivation of `RC_i` retained as separate open bridges;
 - deterministic 51-check runner, full N1--N8 packet, and stacked review PR.
 
-## Full instrument, time, and probability — next
+## Full finite-carrier instrument normal form — current result
 
-- extend beyond the classified finite-edge completion to a local normalized
-  record-forming instrument family;
-- distinguish partial event order, integer tick count, and physical rate.
+- classify formation effects and the complementary no-record effect under
+  conditional cross-label exclusion;
+- expose event efficiencies and the arbitrary no-record CP operation as the
+  complete finite-cell normal-form coordinates;
+- construct one auxiliary-register CPTP countermodel with absorbing locked
+  sectors and uncalibrated blank-sector effects;
+- keep menu selection, physical readout, framework-Record realization, and
+  `Z^3` overlap composition open.
+
+## Event order, time, and rate — next
+
+- classify overlapping local-instrument schedules before adding a time metric;
+- distinguish event partial order, layer order, tick count, and rate.
 
 ## Continuum gateway
 

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/ASSUMPTIONS_AND_IMPORTS.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/ASSUMPTIONS_AND_IMPORTS.md
@@ -67,3 +67,19 @@ All listed effect-selection conditions carry zero framework-premise weight.
 The theorem does not derive a physical menu, probability semantics,
 framework-Record realization, repeat certainty, event order/rate, or a
 continuum law. No axiom or primitive change is implied.
+
+## Full finite-carrier instrument conditional/open interfaces
+
+- A finite system/register factorization with one blank label and a locked-label
+  direct sum.
+- A complete rank-one menu and the association of label `i` with `P_i`.
+- Finite CP/Kraus/trace semantics, with the reconciled Kraus--Choi theorem as
+  named retained mathematical authority.
+- Conditional cross-label exclusion and, separately, menu-neutral event
+  efficiency for the positive normal-form corollary.
+- Physical probability semantics, readout, and framework-Record realization
+  remain absent from the auxiliary-register countermodel.
+
+The approved minimal axioms chain-satisfy as foundation. These additional
+physical interfaces gain no premise authority here. The result is one abstract
+finite carrier, not a `Z^3` locality or overlapping-cell theorem.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/CLAIM_STATUS_CERTIFICATE.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/CLAIM_STATUS_CERTIFICATE.md
@@ -1,11 +1,11 @@
 ---
-target_claim_id: covariant_effect_map_nonselection_and_repeat_certainty_collapse_bounded_theorem_note_2026-07-11
+target_claim_id: autonomous_intermittent_record_instrument_calibration_nonselection_bounded_theorem_note_2026-07-11
 target_claim_type: bounded_theorem
-claim_type_reason: "Exact finite-dimensional depolarizing counterfamily for static effect selectors and an exact exhaustive-rank-one-menu collapse theorem under named zero-premise-weight hypotheses."
+claim_type_reason: "Exact finite-dimensional intermittent effect-surface and CP-instrument normal form, plus a narrow auxiliary-register CPTP countermodel to blank/locked calibration forcing."
 actual_current_surface_status: bounded-support
 trace_class: direct_blocker_closure
 reachability_to_target: partially_closes
-conditional_surface_status: "Static effect/POVM additivity, normalization, noncontextuality, and covariance leave a continuous depolarizing family. On a fixed exhaustive finite rank-one menu, joint normalization plus RC_i force E_i=P_i. Physical menu realization, probability semantics, framework Records, and derivation of RC_i remain open."
+conditional_surface_status: "On one abstract finite system/register carrier, cross-label exclusion gives E_i=e_iP_i and F=sum_i(1-e_i)P_i; neutral efficiencies give F=qI and conditional Born-form weights. Auxiliary absorption/reuse does not imply exclusion. Physical readout, framework Records, and overlapping Z3 composition remain open."
 hypothetical_axiom_status: null
 admitted_observation_status: none
 proposal_allowed: false
@@ -16,9 +16,9 @@ review_loop_disposition: iteration_3_pass_bounded
 
 # Claim Status Certificate
 
-The current source classifies an exact finite-dimensional effect-assignment
-counterfamily and the exact conditions that collapse a fixed exhaustive
-rank-one menu to projectors.
+The current source classifies the intermittent CP-instrument normal form on one
+abstract finite carrier and constructs an auxiliary-register calibration
+countermodel.
 The exact current status is:
 
 - the four axioms do not supply the required process law;
@@ -28,25 +28,26 @@ The exact current status is:
   by itself select a unique visible law;
 - the Clifford-vector conclusion remains conditional on a faithful spectral
   availability/formation-to-carrier bridge;
-- `T_a(A)=aA+(1-a)Tr(A)I/d` preserves effects, every normalized POVM,
-  noncontextuality, and unitary covariance while leaving `a` free;
-- trace representation can identify the depolarized density operator rather
-  than the input density operator;
-- for a fixed exhaustive rank-one menu, joint normalization plus
-  `RC_i: Tr(P_iE_i)=1` force `E_i=P_i`;
-- both conditions are named conditional hypotheses carrying zero
-  framework-premise weight;
-- the current runner reports `PASS=51 FAIL=0`; independent audit remains
+- cross-label exclusion and positivity force `E_i=e_iP_i`;
+- normalization fixes `F=sum_i(1-e_i)P_i`, while neutral efficiency gives
+  `F=qI` and conditional Born-form weights;
+- any CP no-record map with effect `F` completes the normal form, so channel
+  selection remains open;
+- one auxiliary-register CPTP family has absorbing consistent locked states
+  and uncalibrated blank-sector effects;
+- the construction has supplied-menu family equivariance, not one
+  menu-independent framework law;
+- the current runner reports `PASS=36 FAIL=0`; independent audit remains
   required.
 
 No axiom, primitive, or audit status is proposed or changed. The new claim
-depends on `minimal_axioms` and the record-outcome normal form; the new finite
-algebra is self-contained. Those edges remain subject to independent audit and
-dependency closure.
+depends on `minimal_axioms`, the record-outcome normal form, and the reconciled
+finite Kraus--Choi authority. Those edges remain subject to independent audit
+and dependency closure.
 
-The bounded nonselection/collapse result passed independent claim and code/math
-review after full-effect, claim-scope, and runner repairs. Its full N1--N8
-packet preserves physical menu realization, probability semantics,
-framework-Record realization, `RC_i`, event rate, and continuum control as
-separate walls. Because a local process/repeatability derivation remains live,
-this result does not trigger the campaign's axiom-update stop condition.
+The bounded normal form and auxiliary nonimplication passed independent claim,
+code/math, governance, and N1--N8 review after the arbitrary no-record CP
+parameter and finite-carrier scope were made explicit. One choice-free law,
+physical readout, framework-Record realization, overlap composition, event
+order/rate, and continuum control remain live. The result does not trigger the
+campaign's axiom-update stop condition.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
@@ -24,6 +24,11 @@ https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5202
 is open and mergeable against the minimal-dilation branch; its audit-lane
 workflow was running at the delivery checkpoint.
 
+Intermittent finite-carrier instrument normal-form review PR:
+https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5205
+is open and mergeable against the effect-selection branch; its audit-lane
+workflow was running at the delivery checkpoint.
+
 ## Central thesis
 
 The next move is not another sector Hamiltonian or continuum fit. It is to make

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
@@ -112,3 +112,26 @@ axioms. Runner/cache: `PASS=51 FAIL=0`; independent claim and code/math reviews
 passed after repairs. No axiom-update stop condition is triggered. The next
 campaign is the full normalized local record-forming instrument, beginning
 with the actual composition/repeatability/readout-to-formation science.
+
+## Full finite-carrier instrument result
+
+The persistent-instrument, Kraus--Choi, controlled-copy, kernel, selective-atom,
+composition, and formation-rule lanes were read and their relevant runners
+replayed before this attack. No current row classifies a
+translation-covariant overlapping `Z^3` instrument.
+
+On one abstract finite system/register carrier, full normalization and
+conditional cross-label exclusion give `E_i=e_iP_i` and
+`F=sum_i(1-e_i)P_i`. Equal efficiencies give `F=qI` and Born-form conditional
+weights under named probability semantics. The remaining no-record operation
+is an arbitrary CP map with effect `F`; for scalar `q`, it is `q` times an
+arbitrary CPTP channel, with `sqrt(q)U` as the single-Kraus special case.
+
+An auxiliary blank-plus-locked-register CPTP family is absorbing on every
+consistent locked-register state and stable under same-map reuse, yet has
+cross-label blank formation for `a<1`. Its covariance is only supplied-menu
+family equivariance, not one menu-independent framework law. It proves a
+narrow auxiliary-register nonimplication, not a statement about framework
+Record permanence. Runner/cache: `PASS=36 FAIL=0`; claim and math reviews
+passed. No axiom-update stop condition is triggered. The next seam is
+overlapping local-instrument order, followed by physical time/rate.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/NO_GO_DISCIPLINE_CHECKLIST.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/NO_GO_DISCIPLINE_CHECKLIST.md
@@ -450,3 +450,158 @@ same-carrier probability/readout semantics, readout-to-formation calibration,
 event law, and continuum limit remain named. The result therefore advances the
 campaign without triggering its axiom-update stop condition. Independent
 review and audit remain required.
+
+---
+
+# No-Go Discipline: Autonomous Intermittent Instrument Calibration Nonselection
+
+**Status:** PASS for the narrow finite-dimensional statement that, for a
+supplied system/register decomposition and supplied rank-one menu, a normalized
+CPTP channel can have absorbing auxiliary locked-register sectors while its
+blank-sector formation effects violate cross-label exclusion.
+The exact positive classification under conditional repeat/exclusivity is
+proved alongside the countermodel. No lattice-wide process impossibility or
+axiom-update claim is made.
+
+## N1 — Alternative-route enumeration
+
+| Attack route | Marker | Attack and result |
+|---|---|---|
+| full normalization plus locked-output branches | `ATTEMPTED` | normalization fixes only `F+sum_iE_i=I`; without cross-label exclusion the depolarized blank-sector family survives |
+| conditional repeat/exclusivity on a nonempty event | `ATTEMPTED` | succeeds algebraically: positivity forces `E_i=e_iP_i`, while normalization fixes `F=sum_i(1-e_i)P_i` |
+| same autonomous map reused after formation | `ATTEMPTED` | the same channel is idempotent on every auxiliary locked-register sector while its blank effects remain depolarized |
+| supplied-menu family equivariance and label permutations | `ATTEMPTED` | the family survives simultaneous menu/system rotation for every `a`; this is not invariance of one menu-independent law |
+| permutation-neutral event efficiency | `ATTEMPTED` | equal `e_i=1-q` removes detection bias and gives `F=qI`, but does not select `q` or the no-record CPTP channel |
+| single-Kraus/minimal no-record branch | `ATTEMPTED` | reduces the no-record operation to `sqrt(q)U` but leaves arbitrary unitary freedom |
+| QND/controlled-copy/fresh-fragment formation | `ATTEMPTED` | remains a positive escape that calibrates projective formation under stronger named model conditions |
+
+No row is marked `RULED OUT BY PRIOR`: the prior sources are conditional or
+unaudited at the relevant physical scope, and the new finite algebra is proved
+self-containedly.
+
+## N2 — Wall-independence audit
+
+| Pair | First closes second? | Reverse? | Independent? |
+|---|---:|---:|---:|
+| blank-sector cross-label exclusion / menu-neutral no-record effect `F=qI` | no: unequal `e_iP_i` obey exclusion | no: the hostile `a<1` family has `F=qI` | yes |
+
+The exact negative residual is only blank/locked-sector calibration. Menu
+selection, event-efficiency choice, no-record channel selection, physical
+readout, framework-Record realization, overlapping composition, and time/rate
+are an out-of-scope interface inventory, not a claimed independent wall count;
+a stronger theorem may close several jointly.
+
+## N3 — Hidden-wall scan
+
+The new note, runner, cache, and campaign packet were scanned for `we assume`,
+`assum*`, `by construction`, `as is standard`, `framework provides`, `bridge
+context`, `background`, `naturally`, `obviously`, `standard QFT`, `registered`,
+`canonical`, `supplied`, and `adopted`.
+
+| Phrase hit | Classification |
+|---|---|
+| supplied `H_S tensor R` factorization | explicit mathematical carrier input |
+| blank/locked direct-sum register | explicit auxiliary decomposition, not a framework Record |
+| supplied complete rank-one menu | explicit input; not selected by the foundation |
+| association of register label `i` with `P_i` | explicit labeling map, not a physical readout theorem |
+| sector-conditioned Kraus blocks | explicit countermodel definition |
+| finite CP/Kraus/trace interpretation | named mathematical authority; physical probability semantics remain open |
+| supplied-menu group action | defines family equivariance, not one menu-independent framework law |
+| physical probability interpretation | absent from the auxiliary construction |
+| physical readout map | absent; register stability is not called readability |
+| `Z^3` locality and framework-Record realization | absent and explicitly out of scope |
+
+The earlier phrases `repeat-readable`, `wrong/contradictory label`, `local`,
+and `uses no preferred frame` were narrowed on the live source and runner.
+
+## N4 — Residual matching
+
+| Witness | Witness residual | Use here | Match? |
+|---|---|---|---:|
+| [rank-one locked-output source](../../../../docs/RECORD_OBSERVABLE_QUOTIENT_AND_RANK_ONE_FORMATION_OUTCOME_OPERATION_NORMAL_FORM_BOUNDED_THEOREM_NOTE_2026-07-11.md) | `J_i(rho)=Tr(E_i rho)P_i` with arbitrary `E_i` | exact starting residual | yes |
+| [minimal axioms](../../../../docs/MINIMAL_AXIOMS_2026-06-29.md) | approved foundation grants occurrence/permanence but no instrument or calibration | governance boundary only; not proof of the countermodel | authority context |
+| [minimal intermittent completion](../../../../docs/MINIMAL_RECORD_INSTRUMENT_DILATION_SCALAR_EXCHANGE_NONSELECTION_BOUNDED_THEOREM_NOTE_2026-07-11.md) | `E_empty=qI`, `E_i=(1-q)P_i`, single-Kraus `sqrt(q)U` freedom on one edge sector | recovered as the neutral/single-Kraus special case | exact adjacent case |
+| [raw exhaustive-menu collapse](../../../../docs/COVARIANT_EFFECT_MAP_NONSELECTION_AND_REPEAT_CERTAINTY_COLLAPSE_BOUNDED_THEOREM_NOTE_2026-07-11.md) | normalization plus raw `Tr(P_iE_i)=1` forces `E_i=P_i` | recovered as the `q=0` limit; not imported as the intermittent proof | exact adjacent limit |
+| [persistent-instrument construction](../../../../docs/PERSISTENT_RECORD_INSTRUMENT_CONSTRUCTION_NARROW_THEOREM_NOTE_2026-05-22.md) | any named complete Kraus family yields a block isometry, but the family is unselected | use the same finite algebra while classifying the family's effects | adjacent only |
+| [controlled-copy formation bridge](../../../../docs/RECORD_FORMATION_TO_KRAUS_ISOMETRY_BRIDGE_2026-06-06.md) | projective, repeat-stable instrument inside one named finite pointer model | positive `a=1` route, not framework-wide authority | adjacent only |
+| [formation-rule narrow no-go](../../../../docs/RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md) | occurrence is granted but process/site/state/weight/rate are not forced | preserves rather than broadens that boundary | context only |
+| [classical composition semigroup](../../../../docs/RECORD_COMPOSITION_BRIDGE_SEMIGROUP_POSITIVITY_SELECTION_BOUNDED_NOTE_2026-07-02.md) | named classical weight-convolution premises and finite candidates | different residual; not evidence about overlapping CP instruments | no |
+
+The new nonimplication is proved by its own CPTP countermodel and inherits no
+broader prior no-go.
+
+## N5 — Rhetoric and resolution matrix
+
+| Resolution | Proved/tested? | Honest scoped statement |
+|---|---:|---|
+| arbitrary fixed finite `d` rank-one menu | analytical | conditional repeat/exclusivity classifies every formation effect and complementary no-record effect; an arbitrary CP map with that effect parameterizes the remaining no-record operation |
+| arbitrary finite `d` autonomous hostile family | analytical | equations (14)--(17) give a CPTP blank-plus-locked channel for every `a,q` |
+| exact fixtures | runner `d=2,3`; hostile `d=2` | fixtures certify examples and mutations; universal scope comes from the source proof |
+| full `U(d)` supplied-menu family equivariance | analytical Kraus conjugation identity | corroborated by real/complex unitaries on blank and locked fixtures |
+| fixed-menu single-law invariance | no | explicitly not claimed |
+| framework qubit site or finite `Z^3` region | no | auxiliary register has no framework realization |
+| overlapping local instruments | no | explicitly deferred to the composition campaign |
+| lattice-wide QCA, continuum, probability, or physical time/rate | no | no extrapolation or physical interpretation is claimed |
+
+`Full CP-instrument normal form` means the complete parameterization on one
+abstract finite cell, including an explicitly arbitrary no-record CP map. It
+does not mean that a unique channel was selected or that `Z^3` overlapping-cell
+locality was proved.
+
+## N6 — Partial-closure and governance paths
+
+| Candidate path | Current status | What it could close |
+|---|---|---|
+| canonical `K=P` theorem | `retained_bounded` under named canonical apparatus preparation/readout and projector family | closes projective write only inside that calibrated apparatus surface |
+| controlled-copy/fresh-fragment write isometry | unaudited on current-main validation surface | positive finite-model calibration under pointer/fresh-fragment conditions |
+| formation-to-Kraus bridge and persistent-instrument construction | unaudited on current-main validation surface | build instruments from named isometry/Kraus data; do not select the physical data |
+| persistent Record as Kraus operator | audit in progress | exact isometry-to-instrument algebra while the isometry remains an input |
+| classical composition semigroup | unaudited and cache-hash stale | does not close overlapping CP-instrument composition |
+| one microscopic blank/locked coupling theorem | open | could tie formation blocks to deterministic completed-sector readout and derive conditional repeat/exclusivity |
+| overlapping-cell consistency or controlled coarse-graining | next live route | could reject autonomous block choices that cannot compose on `Z^3` |
+| explicit approved process primitive | governance-only route | presently neither proposed nor approved; carries zero weight without approval and registry update |
+| approved primitive registry | checked | `scale_reference`, `kinetic_isotropy`, and `realized_state` supply none of formation fidelity, event neutrality, instrument composition, or probability |
+
+Historical decisions are provenance only and cannot chain-satisfy. A labeling
+or register-basis convention cannot identify the blank-sector effect with a
+completed-sector readout effect.
+
+## N7 — Steelman
+
+The countermodel is not yet a framework countermodel. Its label register is
+not realized as Records on the qubit lattice; its family equivariance
+co-rotates a supplied menu rather than defining one choice-free law; and no
+overlapping-cell, Admissibility, QND, or common-dilation constraint is imposed.
+A physical Record-formation theorem could couple blank-sector formation to
+locked-sector stabilization and thereby force cross-label exclusion. The
+retained-bounded canonical `K=P` theorem and the controlled-copy model show
+that this route is substantive. Therefore the construction proves only the
+stated auxiliary-register nonimplication, not that framework Record permanence
+plus lawful local composition can never derive calibration.
+
+## N8 — Cross-cycle echo
+
+| Prior surface | Current status | Retirement/change mechanism and applicability |
+|---|---|---|
+| [minimal axioms](../../../../docs/MINIMAL_AXIOMS_2026-06-29.md) | approved axiom-premise node | grants occurrence and permanence, not a process or cross-sector calibration |
+| [finite isometry-to-Kraus algebra](../../../../docs/PERSISTENT_RECORD_AS_KRAUS_OPERATOR_NOTE_2026-05-20.md) | audit in progress | exact algebra after a normalized isometry is named; does not derive the physical isometry |
+| [controlled-copy write isometry](../../../../docs/RECORD_FORMATION_CONTROLLED_COPY_WRITE_ISOMETRY_THEOREM_NOTE_2026-06-18.md) | unaudited on current-main validation surface | closes calibration only inside a named finite model; no framework-wide retirement mechanism yet |
+| [effect-selection block](../../../../docs/COVARIANT_EFFECT_MAP_NONSELECTION_AND_REPEAT_CERTAINTY_COLLAPSE_BOUNDED_THEOREM_NOTE_2026-07-11.md) | bounded theorem, unaudited | raw repeat certainty is now identified as the `q=0` special case rather than silently applied to intermittent formation |
+| canonical `K=P` result | `retained_bounded` | demonstrates retirement through named apparatus calibration rather than auxiliary register stability |
+| [formation-rule narrow no-go](../../../../docs/RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md) and context/generator no-go | unaudited and broader/different | neither proves the present auxiliary countermodel or closes overlap composition |
+| persistent-instrument/Stinespring lanes | conditional/under audit | named isometry or Kraus data remain the positive construction route |
+| overlapping CP-instrument composition | open | next route; no current retirement mechanism |
+| current-main premise-decision history | provenance only | cannot supply or retire a physics premise; closure requires retained derivation or explicit approved primitive registration |
+
+## Autonomous-instrument gate conclusion
+
+All N1--N8 checks pass for the narrow classification and countermodel. The
+positive theorem identifies conditional repeat/exclusivity, event neutrality,
+and no-record channel selection as distinct coordinates. The hostile channel
+proves only that auxiliary locked-register absorption, same-map reuse, finite
+CPTP normalization, and supplied-menu family equivariance do not imply
+blank-sector cross-label exclusion. Physical Record realization, one
+choice-free law, and overlapping-lattice composition remain live
+stronger routes. The result therefore advances the campaign without
+triggering the axiom-update stop condition. Independent review and audit remain
+required.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/NO_GO_LEDGER.md
@@ -11,6 +11,7 @@
 | minimal outcome-forgotten-channel rank plus normalized rank-one outcome branches excludes `I-SWAP` coherence | falsified on one supplied one-excitation edge sector | `K_empty=sqrt(q)U` leaves a projective-unitary freedom; exchange choices have rank-three minimal channels and change eventual absorbing label weights |
 | positivity, full effect/POVM additivity and normalization, noncontextuality, and unitary covariance select `E_P=P` | falsified in every finite `d>1` | the continuous depolarizing family `T_a` survives and changes the representing density operator |
 | repeat certainty alone selects a normalized exhaustive effect menu | falsified | `E_i=I` has repeat certainty but violates joint normalization for `d>1` |
+| auxiliary locked-register absorption plus same-map reuse calibrates blank-sector formation | falsified on one supplied finite system/register class | an exact CPTP family has absorbing consistent locked states and cross-label blank formation for `a<1` |
 
 These negatives prune routes, not the full record-instrument program. The live
 escape is a separate classical record register coupled through a local
@@ -25,3 +26,7 @@ The effect-selection block supplies a positive conditional escape: on one
 fixed exhaustive finite rank-one menu, joint normalization plus `RC_i` forces
 `E_i=P_i`. Because a local process theorem may still derive both conditions,
 the negative rows do not prove that the axioms require amendment.
+
+The auxiliary-register result is not a framework-Record countermodel: it has no
+physical readout map, `Z^3` realization, one menu-independent law, or
+overlapping-cell composition. Those stronger routes remain live.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/OPPORTUNITY_QUEUE.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/OPPORTUNITY_QUEUE.md
@@ -7,8 +7,9 @@
 | 3 | exhaustive cubic neighbor-to-qubit intertwiner classification | 0.70 bounded | linearity and carrier faithfulness | high | high | derive scalar-sum plus vector-difference basis exactly |
 | 4 | eliminate the exchange branch by minimal outcome-forgotten-channel rank | falsified on supplied one-excitation sector | label-to-Record realization plus stronger effect/lattice/continuum selector | high | high | exchange angle changes eventual absorbing label weights despite rank-three minimality |
 | 5 | select formation effects from static covariance/additivity conditions | falsified; conditional selector isolated | physical menu plus `RC_i` derivation | high | high | depolarizing family survives; normalization plus `RC_i` forces projectors |
-| 6 | full normalized local record-instrument classification | 0.40 bounded | local composition, effect menu, repeatability, event gating | medium | medium | derive or refute `RC_i` and menu normalization from one local composition law |
-| 7 | controlled QCA-to-Hamiltonian continuum limit | 0.20 exact | scale/rate, RG control, universality | low | low | establish one microscopic carrier before testing Lorentz/QFT limits |
+| 6 | full finite-carrier record-instrument normal form | completed bounded candidate | physical menu/readout/Record realization and overlap composition | high | high | auxiliary absorption does not derive blank-sector calibration; normal form exposes `e_i` and no-record CP freedom |
+| 7 | overlapping local-instrument schedule and event order | 0.55 bounded | edge coloring/order or commuting-overlap/QCA rule | high | high | compare exact CPTP schedules on two overlapping edges |
+| 8 | controlled QCA-to-Hamiltonian continuum limit | 0.20 exact | scale/rate, RG control, universality | low | low | establish one microscopic carrier before testing Lorentz/QFT limits |
 
 The queue prioritizes the law/probability/time seam because every SM/GR
 continuum claim currently consumes a supplied kinetic/action surface. Closing

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
@@ -23,6 +23,18 @@ prepared for the next stacked review PR:
 
 No merge is authorized. Independent audit remains authoritative.
 
+The intermittent finite-carrier normal-form and auxiliary calibration
+nonselection result is prepared for the next stacked review PR:
+
+- base: `physics-loop/record-faithful-dynamics-block04-effect-selection-20260711`
+- head: `physics-loop/record-faithful-dynamics-block05-full-instrument-20260711`
+- source runner: `PASS=36 FAIL=0`
+- disposition: review-loop bounded PASS after independent claim, code/math,
+  governance, labeling/import, Nature-scope, and N1--N8 review; graph seeding
+  and strict lint validated, with generated status surfaces stripped
+
+No merge is authorized. Independent audit remains authoritative.
+
 The minimal-dilation exchange result was pushed and opened as the next stacked
 review PR:
 

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
@@ -26,12 +26,14 @@ No merge is authorized. Independent audit remains authoritative.
 The intermittent finite-carrier normal-form and auxiliary calibration
 nonselection result is prepared for the next stacked review PR:
 
+- PR: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5205
 - base: `physics-loop/record-faithful-dynamics-block04-effect-selection-20260711`
 - head: `physics-loop/record-faithful-dynamics-block05-full-instrument-20260711`
 - source runner: `PASS=36 FAIL=0`
 - disposition: review-loop bounded PASS after independent claim, code/math,
   governance, labeling/import, Nature-scope, and N1--N8 review; graph seeding
   and strict lint validated, with generated status surfaces stripped
+- delivery check: open, mergeable, audit workflow running
 
 No merge is authorized. Independent audit remains authoritative.
 

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
@@ -135,3 +135,42 @@ duality, and provenance-only treatment of historical decisions. The citation
 graph seeded only `minimal_axioms` and the Block03 locked-output normal form;
 strict audit lint passed with no errors. Generated audit/effective-status
 surfaces are stripped before delivery. Independent audit remains required.
+
+## Full finite-carrier instrument internal result
+
+- Conditional cross-label exclusion gives `E_i=e_iP_i` and
+  `F=sum_i(1-e_i)P_i`.
+- Equal efficiencies remove detection bias; the no-record CP channel remains
+  an explicit free parameter.
+- An auxiliary blank-plus-locked-register CPTP family is absorbing on
+  consistent locked states but cross-label on blank input for `a<1`.
+- Menu-family equivariance is explicitly not one menu-independent law.
+- Runner/cache: `PASS=36 FAIL=0`.
+
+### Full-instrument review iteration 1
+
+Code/math review passed the effect classification, Kraus completeness,
+cross-label witness, locked-sector reuse, family equivariance, and no-record
+channel freedom. Claim review required narrowing from a unique/lattice
+classification to a complete abstract finite-carrier normal form parameterized
+by an arbitrary no-record CP map, plus a direct reconciled Kraus--Choi
+dependency. Those repairs passed re-review.
+
+### Full-instrument review iteration 2
+
+Governance/No-Go Discipline required the negative statement to remain an
+auxiliary-register result. The source and runner were narrowed, the exact
+menu-family equivariance identity was added, real and complex blank/locked
+fixtures were added, and the full N1--N8 packet was rewritten. Final
+governance re-review passed with no source blocker. Audit-compatibility
+validation remains required.
+
+### Full-instrument review iteration 3
+
+PASS WITH BOUNDED CLAIMS. Claim, code/math, labeling/import, Nature-scope,
+governance, and No-Go Discipline checks agree on the auxiliary finite-carrier
+boundary. The runner/cache agree at `PASS=36 FAIL=0`; vocabulary lint has zero
+violations. The audit pipeline seeded the bounded theorem as `unaudited` with
+exactly three dependencies: `minimal_axioms`, the locked-output normal form,
+and the reconciled Kraus--Choi theorem. Strict lint passed with no errors, and
+generated audit/effective-status surfaces were stripped before delivery.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/ROUTE_PORTFOLIO.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/ROUTE_PORTFOLIO.md
@@ -10,6 +10,8 @@ Scores are provisional `0..3`; risk is negative.
 | strict QCA as fundamental coherent block | 2 | 2 | 2 | 3 | -2 | useful constraint, but existing results leave quantized protocol freedom and no curved cone at current density |
 | graded-constraint/Born composition | 3 | 3 | 3 | 3 | -2 | static additivity/covariance leave a depolarizing family; exact closure is menu normalization plus physically derived `RC_i` |
 | strengthened exchange countermodel | 3 | 3 | 3 | 3 | -1 | completed on a supplied one-excitation sector: rank-three minimal outcome-forgotten `I-SWAP` channels change absorbing outcome-label weights |
+| intermittent finite-carrier instrument normal form | 3 | 3 | 3 | 3 | -1 | complete abstract parameterization; auxiliary absorption/reuse does not imply blank-sector calibration |
+| overlapping-instrument order | 3 | 3 | 3 | 2 | -2 | highest next discriminator: identical normalized edge rules can compose differently on overlapping supports |
 | unified continuum limit | 3 | 3 | 3 | 1 | -3 | deferred until the microscopic process object and carrier class are fixed |
 
 ## Route ordering
@@ -20,6 +22,8 @@ with strict-QCA and effect/Born work before the unified continuum limit. The
 countermodel succeeded at supplied-sector scope, so minimal
 outcome-forgotten-channel rank cannot discharge the exchange branch. The next
 leverage point was effect/Born selection: it isolated `RC_i` plus menu
-normalization as the exact conditional selector. The next route is to derive
-or refute those conditions inside a full local instrument, followed by
-simultaneous-QCA classification before continuum extrapolation.
+normalization as the exact conditional selector. The finite-carrier instrument
+normal form now exposes event efficiency and no-record channel freedom while
+the auxiliary-register countermodel leaves physical calibration open. The next
+route is overlapping-edge order/scheduling, followed by simultaneous-QCA
+classification before continuum extrapolation.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
@@ -8,30 +8,30 @@ current_goal: >-
   supply the physical evolution object, bare time ordering, record-formation
   weights, and an admissibility-to-carrier selector without importing the
   staggered/Dirac answer or sector-specific Standard Model and gravity laws.
-branch: physics-loop/record-faithful-dynamics-block04-effect-selection-20260711
+branch: physics-loop/record-faithful-dynamics-block05-full-instrument-20260711
 base_commit_at_start: 9d1636f05f
-cycle_count: 4
-block_count: 4
-active_route: full_local_instrument_and_readout_to_formation_calibration
+cycle_count: 5
+block_count: 5
+active_route: overlapping_local_instrument_schedule_and_event_order
 hard_residual: >-
   Can the four-axiom record surface canonically determine a faithful local
   record-forming instrument whose coherent no-record block is sufficiently
   constrained to exclude the observationally disconnected SWAP--Laplacian
   completion and select the Clifford-vector carrier?
-produced_claim_id: covariant_effect_map_nonselection_and_repeat_certainty_collapse_bounded_theorem_note_2026-07-11
+produced_claim_id: autonomous_intermittent_record_instrument_calibration_nonselection_bounded_theorem_note_2026-07-11
 actual_current_surface_status: bounded-support
 conditional_surface_status: >-
-  A depolarizing family survives positivity, full effect/POVM additivity and
-  normalization, menu noncontextuality, and unitary covariance. For one fixed
-  exhaustive finite rank-one menu, joint normalization plus the named
-  repeat-certainty condition RC_i force E_i=P_i. The physical effect menu,
-  probability semantics, framework-Record realization, and derivation of RC_i
-  remain open.
+  On one abstract finite system/register carrier, cross-label exclusion gives
+  E_i=e_i P_i and F=sum_i(1-e_i)P_i. Equal efficiencies give conditional
+  Born-form weights and F=qI, while the no-record CPTP channel remains
+  arbitrary. An auxiliary-register family proves absorption and same-map reuse
+  do not imply blank-sector calibration. Framework-Record realization and
+  overlapping Z^3 composition remain open.
 admitted_observation_status: none
 claim_type_reason: >-
-  The source proves an exact finite-dimensional counterfamily and collapse
-  theorem under named conditional hypotheses carrying zero framework-premise
-  weight, while leaving their physical process derivation open.
+  The source proves an exact finite-dimensional CP-instrument normal form and
+  an auxiliary-register countermodel while leaving physical readout, Record
+  realization, and lattice composition open.
 hypothetical_axiom_status: null
 proposal_allowed: false
 proposal_allowed_reason: >-
@@ -53,6 +53,9 @@ files_touched:
   - docs/COVARIANT_EFFECT_MAP_NONSELECTION_AND_REPEAT_CERTAINTY_COLLAPSE_BOUNDED_THEOREM_NOTE_2026-07-11.md
   - scripts/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.py
   - logs/runner-cache/covariant_effect_map_nonselection_repeat_certainty_collapse_2026_07_11.txt
+  - docs/AUTONOMOUS_INTERMITTENT_RECORD_INSTRUMENT_CALIBRATION_NONSELECTION_BOUNDED_THEOREM_NOTE_2026-07-11.md
+  - scripts/autonomous_intermittent_record_instrument_calibration_nonselection_2026_07_11.py
+  - logs/runner-cache/autonomous_intermittent_record_instrument_calibration_nonselection_2026_07_11.txt
 open_imports:
   - fundamental process object: Hamiltonian, strict tick, or record instrument
   - faithful law-to-record influence principle
@@ -66,19 +69,19 @@ no_go_routes:
   - direct preservation of every rank-one permanent record freezes the same carrier and also forbids unitary record formation
   - minimal outcome-forgotten-channel rank plus full normalization does not remove an outcome-label-sensitive I-SWAP no-record branch on the supplied one-excitation sector
   - positivity, effect/POVM additivity and normalization, noncontextuality, and unitary covariance do not identify E_P with P
+  - auxiliary locked-register absorption, same-map reuse, scalar no-record effect, and supplied-menu family equivariance do not imply blank-sector cross-label exclusion
 trace_gate_classification: direct_blocker_closure
 reachability_to_target: partially_closes
-review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_bounded
-pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_mergeable_checks_running
+review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_bounded
+pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_pending_delivery
 block01_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5178
 block02_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5181
 block03_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5201
 block04_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5202
 next_exact_action: >-
-  Read the actual full-instrument, persistent-record, local-composition,
-  repeatability, and readout-formation lanes; then classify a normalized local
-  record-forming instrument and test whether its composition derives the
-  effect menu and RC_i without importing probability semantics.
+  Read the actual event-order, history-time-rate, overlapping-instrument,
+  edge-coloring, and simultaneous-tick lanes; then classify overlapping-edge
+  schedules without importing a global clock or QCA answer.
 stop_condition: >-
   Stop and discuss an axiom update only if an exact result proves that the
   required bridge cannot be derived and an additional approved axiom or

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
@@ -73,11 +73,12 @@ no_go_routes:
 trace_gate_classification: direct_blocker_closure
 reachability_to_target: partially_closes
 review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_bounded
-pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_pending_delivery
+pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_mergeable_checks_running
 block01_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5178
 block02_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5181
 block03_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5201
 block04_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5202
+block05_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5205
 next_exact_action: >-
   Read the actual event-order, history-time-rate, overlapping-instrument,
   edge-coloring, and simultaneous-tick lanes; then classify overlapping-edge

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/TRACE_GATE.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/TRACE_GATE.md
@@ -1,11 +1,11 @@
 ---
 trace_class: direct_blocker_closure
-target_claim_id: covariant_effect_map_nonselection_and_repeat_certainty_collapse_bounded_theorem_note_2026-07-11
+target_claim_id: autonomous_intermittent_record_instrument_calibration_nonselection_bounded_theorem_note_2026-07-11
 target_blocker_text: "A unique or severely constrained dynamics/admissibility law, including time and the probability rule."
 source_of_blocker_text: user_goal
 reachability_to_target: partially_closes
 artifact_role: theorem
-next_trace_action: "Read the full-instrument/composition/repeatability lane and test whether one normalized local process derives the effect menu and RC_i without importing probability semantics."
+next_trace_action: "Read the event-order/time-rate and overlapping-instrument lanes, then classify two exact schedules on overlapping supports before importing a clock or QCA rule."
 ---
 
 # Trace Gate
@@ -32,3 +32,9 @@ It also proves that a fixed exhaustive rank-one menu, joint normalization, and
 the Born/effect blocker but does not derive probability semantics or `RC_i`.
 The next trace action is therefore the full local instrument rather than a
 second representation theorem.
+
+The finite-carrier instrument block now classifies the intermittent effect
+surface and remaining CP-instrument freedom on one abstract carrier. It also
+proves that auxiliary locked-register absorption and same-map reuse do not
+imply blank-sector calibration. The next trace action is the overlap-order seam,
+not a second single-cell instrument construction.

--- a/docs/AUTONOMOUS_INTERMITTENT_RECORD_INSTRUMENT_CALIBRATION_NONSELECTION_BOUNDED_THEOREM_NOTE_2026-07-11.md
+++ b/docs/AUTONOMOUS_INTERMITTENT_RECORD_INSTRUMENT_CALIBRATION_NONSELECTION_BOUNDED_THEOREM_NOTE_2026-07-11.md
@@ -1,0 +1,337 @@
+---
+claim_id: autonomous_intermittent_record_instrument_calibration_nonselection_bounded_theorem_note_2026-07-11
+claim_type: bounded_theorem
+claim_scope: "Exact finite-dimensional effect-surface classification and full CP-instrument normal form for normalized rank-one locked-output instruments with a no-record outcome under conditional repeat/exclusivity: the remaining no-record CP operation is an explicit free parameter. Also an auxiliary-register CPTP countermodel proving that, for a supplied finite system/register decomposition and supplied rank-one menu, absorbing locked-register sectors, reuse of the same map, and menu-family equivariance do not imply blank-sector cross-label exclusion. The approved minimal_axioms dependency chain-satisfies; every additional physical interface remains conditional/open and gains no premise authority here."
+upstream_dependencies:
+  - minimal_axioms
+  - record_observable_quotient_and_rank_one_formation_outcome_operation_normal_form_bounded_theorem_note_2026-07-11
+  - kraus_choi_representation_normalization_reconciled_narrow_theorem_note_2026-06-05
+runner: scripts/autonomous_intermittent_record_instrument_calibration_nonselection_2026_07_11.py
+---
+
+# Autonomous Intermittent Record Instrument: Classification And Calibration Nonselection
+
+**Date:** 2026-07-11
+
+**Type:** bounded theorem
+
+**Status authority:** independent audit only. This source changes no axiom,
+approved primitive, framework rule, or audit verdict.
+
+**Primary runner:**
+[`scripts/autonomous_intermittent_record_instrument_calibration_nonselection_2026_07_11.py`](../scripts/autonomous_intermittent_record_instrument_calibration_nonselection_2026_07_11.py)
+
+**Cached output:**
+[`logs/runner-cache/autonomous_intermittent_record_instrument_calibration_nonselection_2026_07_11.txt`](../logs/runner-cache/autonomous_intermittent_record_instrument_calibration_nonselection_2026_07_11.txt)
+
+## Question
+
+The previous finite-carrier results leave an apparent conflict. Raw exhaustive-menu
+repeat certainty gives `E_i=P_i`, but an intermittent normalized instrument
+with a no-record outcome has formation effects `(1-q)P_i` and empty effect
+`qI`. The correct full-instrument question is therefore:
+
+```text
+what does cross-label exclusion select conditional on a formation event,
+when the mathematical no-record outcome occurs on an attempt?
+```
+
+This note gives the exact finite answer and then tests whether autonomous reuse
+and absorbing auxiliary locked-register sectors derive the needed calibration.
+
+## Existing-science reading gate
+
+The actual instrument stack was read and its runners replayed before this
+attack:
+
+- the approved
+  [`minimal axioms`](MINIMAL_AXIOMS_2026-06-29.md) supply Lattice, Qubit,
+  Admissibility, generic Record occurrence, permanence, readability, and finite
+  scalar readout additivity, but no formation rule, instrument, probability,
+  update, context, time, or rate;
+
+- finite normalized isometry implies Kraus completeness, a CPTP unconditional
+  map, and positive normalized selective branches; the relevant rows are still
+  in independent-audit processing;
+- the reconciled finite-dimensional
+  [`Kraus--Choi authority`](KRAUS_CHOI_REPRESENTATION_NORMALIZATION_RECONCILED_NARROW_THEOREM_NOTE_2026-06-05.md)
+  supplies existence of a Kraus representation for a named CP map with the
+  normalization convention kept explicit; current-main validation records the
+  row as `audited_clean` / effective `retained`, with status remaining
+  pipeline-derived;
+- any named normalized Kraus family gives an explicit block-column Stinespring
+  isometry (`29/0`), but the physical family is not selected;
+- the controlled-copy/fresh-fragment model gives projective `K_i=P_i`,
+  dephasing, and repeat-stable one-hot labels (`75/0`) inside its named pointer,
+  Darwinism, fresh-fragment, time, and calibration conditions;
+- the kernel (`48/0`), pre-record (`38/0`), and selective-atom (`33/0`)
+  interfaces correctly keep possible-outcome weights, realized atoms, and
+  post-record histories as different object types;
+- the composition-semigroup runner still passes `28/0`, but its cache wrapper
+  carries an older runner hash and the theorem concerns classical weight
+  convolution, not overlapping CP instruments;
+- the live narrow no-go grants generic occurrence from Record but leaves the
+  formation process, site, state, weight, and rate open (`6/0`).
+
+The rank-one locked-output input used here is
+[`RECORD_OBSERVABLE_QUOTIENT_AND_RANK_ONE_FORMATION_OUTCOME_OPERATION_NORMAL_FORM_BOUNDED_THEOREM_NOTE_2026-07-11.md`](RECORD_OBSERVABLE_QUOTIENT_AND_RANK_ONE_FORMATION_OUTCOME_OPERATION_NORMAL_FORM_BOUNDED_THEOREM_NOTE_2026-07-11.md):
+
+```text
+J_i(rho)=Tr(E_i rho) P_i,       E_i>=0.                    (1)
+```
+
+Apart from the named finite Kraus-representation authority, all algebra below
+is proved directly. Earlier intermittent and raw-menu campaign blocks are
+comparators, not additional proof authority.
+
+## 1. Full intermittent effect classification
+
+Let `H=C^d`, and fix a complete rank-one menu
+`P_i=|i><i|`, `sum_i P_i=I`. Consider a finite CP instrument with outcomes
+`{empty,1,...,d}`. Let the nonempty branches have the locked-output form (1),
+and let
+
+```text
+F := J_empty^*(I) >= 0                                      (2)
+```
+
+be the no-record effect. Full normalization is
+
+```text
+F + sum_i E_i = I.                                          (3)
+```
+
+Impose **conditional repeat/exclusivity** only:
+
+```text
+Tr(P_j E_i)=0        for i!=j.                              (4)
+```
+
+Equation (4) says that if the input already occupies locked possibility `j`,
+a nonempty outcome cannot produce a cross-label outcome `i`. It does not demand
+that a nonempty event occur on every attempt.
+
+### Theorem
+
+Equations (1)--(4) imply, for unique `0<=e_i<=1`,
+
+```text
+E_i = e_i P_i,
+F   = sum_i (1-e_i)P_i.                                    (5)
+```
+
+**Proof.** For fixed `i`, equation (4) makes every diagonal entry of positive
+`E_i` vanish except possibly the `i`th. For a positive semidefinite matrix,
+
+```text
+|(E_i)_(jk)|^2 <= (E_i)_(jj)(E_i)_(kk),                    (6)
+```
+
+so each zero diagonal kills its full row and column. Hence `E_i=e_iP_i` with
+`e_i>=0`. Equation (3) gives the second formula in (5), and `F>=0` gives
+`e_i<=1`. QED.
+
+For input `P_j`, the no-record probability is `q_j=1-e_j`; conditional on a
+nonempty outcome, the label is exactly `j` whenever `e_j>0`. Thus conditional
+cross-label exclusion fixes the direction of each formation effect but not its
+event efficiency.
+
+If the no-record event is permutation-neutral on the fixed menu,
+
+```text
+q_i=q  for every i,                                         (7)
+```
+
+then
+
+```text
+E_i=(1-q)P_i,       F=qI.                                  (8)
+```
+
+For an arbitrary input density operator,
+
+```text
+p(empty)=q,
+p(i)=(1-q)Tr(P_i rho),
+p(i | nonempty)=Tr(P_i rho).                               (9)
+```
+
+The last equality is Born-form conditional weighting under the named CP/trace
+and probability interpretation. This note does not derive probability
+semantics from the four axioms.
+
+Without (7), conditional selection is detection-biased:
+
+```text
+p(i | nonempty)
+  = e_i Tr(P_i rho) / sum_j e_j Tr(P_j rho).                (10)
+```
+
+Permutation-neutral event gating, not normalization alone, removes that bias.
+
+## 2. Complete CP-instrument normal form; channel selection remains free
+
+Conversely, choose any numbers `0<=e_i<=1` and any CP map `J_empty`
+whose effect is `F=sum_i(1-e_i)P_i`. Together with
+
+```text
+J_i(rho)=e_i Tr(P_i rho)P_i,                                (11)
+```
+
+these maps form a normalized instrument by equation (3). Thus equations
+(5) and (11), plus the explicitly arbitrary CP map with complementary effect
+`F`, are the complete abstract finite-cell normal form within the named
+rank-one locked-output/conditional-repeat class. This parameterizes every
+member; it does not select a unique instrument.
+
+Let `{L_alpha}` be Kraus operators for `J_empty`. Equation (8) fixes only
+
+```text
+sum_alpha L_alpha^dag L_alpha = qI.                         (12)
+```
+
+For `q>0`, `J_empty/q` is an arbitrary CPTP channel. If the no-record
+operation has one Kraus operator, polar decomposition gives
+
+```text
+L=sqrt(q)U,       U unitary.                                (13)
+```
+
+Thus the earlier one-Kraus unitary freedom is the rank-one special case of the
+full classification. A unitary channel and a dephasing channel can have the
+same effect `qI` while acting differently on coherence.
+
+An explicit Stinespring isometry for the classified instrument is
+
+```text
+V|psi>
+  = sum_alpha |empty,alpha> tensor L_alpha|psi>
+    + sum_i |i> tensor sqrt(e_i)P_i|psi>,                   (14)
+```
+
+because `V^dag V=F+sum_iE_i=I`. The labels in (14) are mathematical outcome
+registers. This note does not identify the external labels as framework
+Records.
+
+## 3. Autonomous auxiliary-register countermodel
+
+The remaining auxiliary question is whether absorption plus reuse of one
+CPTP channel on a supplied finite system/register decomposition forces (4). It
+does not.
+
+Let the register have basis `{|empty>,|1>,...,|d>}`. For `0<=a<=1` define
+
+```text
+w_(ij) = a delta_(ij) + (1-a)/d.                            (15)
+```
+
+Fix `0<=q<1`. On the blank register use the Kraus operators
+
+```text
+N       = sqrt(q) I tensor |empty><empty|,
+B_(ij)  = sqrt((1-q)w_(ij)) |i><j| tensor |i><empty|.       (16)
+```
+
+On every already locked register sector use
+
+```text
+R_(ij) = |i><j| tensor |i><i|.                              (17)
+```
+
+The complete family `{N,B_(ij),R_(ij)}` obeys
+
+```text
+sum K^dag K
+ = I tensor |empty><empty|
+   + sum_i I tensor |i><i|
+ = I.                                                       (18)
+```
+
+It is therefore one autonomous CPTP channel on the full blank-plus-locked
+carrier. Its blank-sector formation effects are
+
+```text
+E_i=(1-q)[aP_i+(1-a)I/d],       F=qI.                       (19)
+```
+
+For every locked label `i`, equation (17) resets the system to `P_i`, keeps
+the auxiliary register in `|i>`, and is idempotent under reuse. These are
+absorbing register-label/system-reset statements; no physical readout map or
+framework-Record realization has been constructed. Yet for `a<1`, a blank
+input `P_j` has nonzero cross-label formation weight for `i!=j`.
+
+The construction is equivariant as a supplied-menu family. If `C_P` denotes
+the channel built from menu `{P_i}` and `W_U=U tensor I_register`, then direct
+conjugation of every system matrix unit in (16)--(17) gives
+
+```text
+C_(UPU^dag)[ W_U X W_U^dag ]
+  = W_U C_P[X] W_U^dag.                                   (20)
+```
+
+This is equivariance of a menu-parameterized family, not invariance of one
+menu-independent framework law. The construction is finite on one supplied
+system/register carrier, normalized, and stable under sequential reuse. It is
+not yet framework-local on `Z^3`.
+
+Therefore:
+
+```text
+absorbing locked-register sectors + same-map reuse + menu-family equivariance
+  do not imply blank-sector cross-label exclusion.          (21)
+```
+
+The exact missing cross-sector condition is that blank-sector formation be
+calibrated to locked-register stabilization. Calling that stabilization a
+physical readout or Record permanence requires a separate framework
+realization; the auxiliary construction supplies neither.
+
+This is a narrow auxiliary-register countermodel, not a no-go against deriving
+calibration from a stronger process theorem. A coupling law tying blank-sector
+formation to locked-sector stabilization, overlapping-cell consistency, or a physical
+coarse-graining theorem remains a live route.
+
+## 4. Physical residuals
+
+The theorem gives the complete effect surface and CP-instrument normal form on
+one abstract finite cell, with the no-record CP operation left as an explicit
+parameter. It is not a `Z^3` locality or overlapping-cell classification. The
+following remain separate:
+
+1. selecting the physical rank-one readout context;
+2. realizing the mathematical locked register and a readout map as a framework Record on `Z^3`;
+3. deriving conditional repeat/exclusivity across blank and locked sectors;
+4. deriving permutation-neutral event gating rather than unequal `e_i`;
+5. selecting `q`, the conditional no-record CPTP channel, and a stopping rule;
+6. composing overlapping local instruments into one simultaneous lattice law;
+7. selecting event order, physical time, and rate.
+
+The last two items are the next campaign seams. Disjoint tensor composition is
+exact, but overlapping instruments need not commute and are not classified by
+the classical record-composition semigroup lane.
+
+## 5. Boundaries
+
+- The approved `minimal_axioms` dependency chain-satisfies. Finite
+  CP-instrument interpretation, the supplied rank-one menu, system/register
+  decomposition, label/menu association, probability semantics, physical
+  readout, conditional repeat/exclusivity, event neutrality, and
+  framework-Record realization remain conditional/open interfaces and acquire
+  no chain-satisfying premise authority here.
+- The autonomous countermodel is a finite mathematical register construction;
+  it does not identify the external labels as framework Records.
+- The theorem does not derive probability semantics, outcome realization, or
+  a Born rule from empirical counts.
+- It does not derive a pointer, Darwinism bridge, controlled-copy Hamiltonian,
+  fresh-fragment supply, or register calibration from Record.
+- It does not select event order, rate, or the no-record channel.
+- It does not construct a translation-covariant overlapping-edge instrument,
+  simultaneous cubic QCA, continuum limit, Standard Model, or GR sector.
+- It does not establish that the axioms require amendment. The exact hostile
+  channel leaves stronger process/composition derivations open.
+
+## Reproduction
+
+```bash
+python3 scripts/autonomous_intermittent_record_instrument_calibration_nonselection_2026_07_11.py
+```

--- a/logs/runner-cache/autonomous_intermittent_record_instrument_calibration_nonselection_2026_07_11.txt
+++ b/logs/runner-cache/autonomous_intermittent_record_instrument_calibration_nonselection_2026_07_11.txt
@@ -1,0 +1,39 @@
+PASS C01: PSD plus a zero cross-label diagonal kills the complex off-diagonal
+PASS C02: the first repeat-exclusive effect is e_0 P_0
+PASS C03: normalization fixes the diagonal no-record effect
+PASS C04: the classified effects form a normalized intermittent menu
+PASS C05: dimension-three efficiencies leave the complementary no-record effect
+PASS C06: classified formation effects obey cross-label exclusion
+PASS C07: unequal formation efficiencies bias the conditional nonempty distribution
+PASS C08: normalization and repeat exclusivity alone do not recover Born-form conditional weights
+PASS C09: permutation-neutral event efficiency restores Born-form conditional weights
+PASS C10: permutation neutrality makes the no-record effect scalar
+PASS A01: the autonomous blank-plus-locked Kraus family is exactly CPTP
+PASS A02: the blank-sector no-record effect is q I
+PASS A03i0: blank formation effect is the scaled depolarized hostile effect
+PASS A03i1: blank formation effect is the scaled depolarized hostile effect
+PASS A04: the hostile blank sector has nonzero cross-label formation weight
+PASS A05i0: the consistent locked-register state is fixed by one channel use
+PASS A06i0: same-map reuse preserves locked-register-sector absorption
+PASS A05i1: the consistent locked-register state is fixed by one channel use
+PASS A06i1: same-map reuse preserves locked-register-sector absorption
+PASS A07: the calibrated a=1 positive control is also CPTP
+PASS A08: a=1 removes cross-label formation
+PASS A09: auxiliary register absorption and same-map reuse do not imply blank-sector cross-label exclusion
+PASS V01: hadamard_blank corroborates supplied-menu family equivariance
+PASS V02: hadamard_locked corroborates supplied-menu family equivariance
+PASS V03: complex_blank corroborates supplied-menu family equivariance
+PASS V04: complex_locked corroborates supplied-menu family equivariance
+PASS V05: a one-Kraus no-record map has scalar effect q I
+PASS V06: a multi-Kraus no-record map can have the same scalar effect
+PASS V07: the scalar no-record effect does not select the conditional no-record channel
+PASS V08: the one-Kraus special case is sqrt(q) times a unitary
+PASS S01: source note exists
+PASS S02: source contains boundary marker: conditional repeat/exclusivity
+PASS S03: source contains boundary marker: does not identify the external labels as framework Records
+PASS S04: source contains boundary marker: does not derive probability semantics
+PASS S05: source contains boundary marker: does not select event order, rate, or the no-record channel
+PASS S06: source contains boundary marker: does not establish that the axioms require amendment
+BOUNDARY: finite Kraus representation is named mathematical authority; physical CP-instrument applicability, the supplied menu, probability semantics, cross-label exclusion, and event neutrality remain conditional/open and gain no chain-satisfying premise authority.
+BOUNDARY: auxiliary locked-register absorption and same-map reuse do not imply blank-sector cross-label exclusion.
+TOTAL: PASS=36 FAIL=0

--- a/scripts/autonomous_intermittent_record_instrument_calibration_nonselection_2026_07_11.py
+++ b/scripts/autonomous_intermittent_record_instrument_calibration_nonselection_2026_07_11.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Exact finite checks for the autonomous intermittent Record-instrument theorem."""
+
+from pathlib import Path
+
+import sympy as sp
+
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: bool, detail: str) -> None:
+    global PASS, FAIL
+    if bool(condition):
+        PASS += 1
+        print(f"PASS {name}: {detail}")
+    else:
+        FAIL += 1
+        print(f"FAIL {name}: {detail}")
+
+
+def ket(dimension: int, index: int) -> sp.Matrix:
+    return sp.eye(dimension)[:, index]
+
+
+def projector(vector: sp.Matrix) -> sp.Matrix:
+    return sp.simplify(vector * vector.H)
+
+
+def matrix_unit(dimension: int, row: int, column: int) -> sp.Matrix:
+    return ket(dimension, row) * ket(dimension, column).H
+
+
+def channel(kraus: list[sp.Matrix], rho: sp.Matrix) -> sp.Matrix:
+    return sp.simplify(sum((item * rho * item.H for item in kraus), sp.zeros(rho.rows)))
+
+
+def autonomous_kraus(
+    dimension: int,
+    mixing: sp.Expr,
+    empty_weight: sp.Expr,
+    frame: sp.Matrix | None = None,
+) -> tuple[list[sp.Matrix], sp.Matrix, list[list[sp.Matrix]], list[list[sp.Matrix]]]:
+    """Kraus family on system tensor (blank direct-sum locked labels)."""
+    frame = sp.eye(dimension) if frame is None else frame
+    register_dimension = dimension + 1
+    blank = matrix_unit(register_dimension, 0, 0)
+
+    no_record = sp.sqrt(empty_weight) * sp.kronecker_product(sp.eye(dimension), blank)
+    formation: list[list[sp.Matrix]] = []
+    locked: list[list[sp.Matrix]] = []
+
+    for outcome in range(dimension):
+        formation_row: list[sp.Matrix] = []
+        locked_row: list[sp.Matrix] = []
+        for source in range(dimension):
+            weight = mixing * int(outcome == source) + (1 - mixing) / dimension
+            system_write = frame * matrix_unit(dimension, outcome, source) * frame.H
+            record_write = matrix_unit(register_dimension, outcome + 1, 0)
+            formation_row.append(
+                sp.sqrt((1 - empty_weight) * weight)
+                * sp.kronecker_product(system_write, record_write)
+            )
+            locked_register = matrix_unit(register_dimension, outcome + 1, outcome + 1)
+            locked_row.append(sp.kronecker_product(system_write, locked_register))
+        formation.append(formation_row)
+        locked.append(locked_row)
+
+    all_kraus = [no_record]
+    all_kraus.extend(item for row in formation for item in row)
+    all_kraus.extend(item for row in locked for item in row)
+    return all_kraus, no_record, formation, locked
+
+
+def classification_checks() -> None:
+    x, y, e0, e1 = sp.symbols("x y e0 e1", real=True)
+    effect0 = sp.Matrix([[e0, x + sp.I * y], [x - sp.I * y, 0]])
+    check("C01", sp.expand(effect0.det()) == -(x**2 + y**2), "PSD plus a zero cross-label diagonal kills the complex off-diagonal")
+    check("C02", effect0.subs({x: 0, y: 0}) == e0 * projector(ket(2, 0)), "the first repeat-exclusive effect is e_0 P_0")
+
+    p0, p1 = (projector(ket(2, i)) for i in range(2))
+    effects = [e0 * p0, e1 * p1]
+    empty = sp.simplify(sp.eye(2) - sum(effects, sp.zeros(2)))
+    check("C03", empty == sp.diag(1 - e0, 1 - e1), "normalization fixes the diagonal no-record effect")
+    check("C04", empty + sum(effects, sp.zeros(2)) == sp.eye(2), "the classified effects form a normalized intermittent menu")
+
+    dimension = 3
+    efficiencies = (sp.Rational(1, 2), sp.Rational(2, 3), sp.Rational(3, 4))
+    menu = [projector(ket(dimension, i)) for i in range(dimension)]
+    effects3 = [efficiencies[i] * menu[i] for i in range(dimension)]
+    empty3 = sp.eye(dimension) - sum(effects3, sp.zeros(dimension))
+    check("C05", empty3 == sp.diag(sp.Rational(1, 2), sp.Rational(1, 3), sp.Rational(1, 4)), "dimension-three efficiencies leave the complementary no-record effect")
+    check("C06", all(sp.trace(effects3[i] * menu[j]) == 0 for i in range(dimension) for j in range(dimension) if i != j), "classified formation effects obey cross-label exclusion")
+
+    rho = sp.diag(sp.Rational(1, 3), sp.Rational(2, 3))
+    biased_effects = [sp.Rational(1, 2) * p0, sp.Rational(3, 4) * p1]
+    biased_weights = [sp.trace(item * rho) for item in biased_effects]
+    biased_conditional = sp.simplify(biased_weights[0] / sum(biased_weights))
+    check("C07", biased_conditional == sp.Rational(1, 4), "unequal formation efficiencies bias the conditional nonempty distribution")
+    check("C08", biased_conditional != sp.trace(p0 * rho), "normalization and repeat exclusivity alone do not recover Born-form conditional weights")
+
+    efficiency = sp.Rational(2, 3)
+    neutral_effects = [efficiency * p0, efficiency * p1]
+    neutral_weights = [sp.trace(item * rho) for item in neutral_effects]
+    check("C09", sp.simplify(neutral_weights[0] / sum(neutral_weights)) == sp.trace(p0 * rho), "permutation-neutral event efficiency restores Born-form conditional weights")
+    check("C10", sp.eye(2) - sum(neutral_effects, sp.zeros(2)) == sp.Rational(1, 3) * sp.eye(2), "permutation neutrality makes the no-record effect scalar")
+
+
+def autonomous_hostile_checks() -> None:
+    dimension = 2
+    mixing = sp.Rational(1, 3)
+    empty_weight = sp.Rational(1, 4)
+    kraus, no_record, formation, _ = autonomous_kraus(dimension, mixing, empty_weight)
+    extended_dimension = dimension * (dimension + 1)
+    completeness = sum((item.H * item for item in kraus), sp.zeros(extended_dimension))
+    check("A01", sp.simplify(completeness) == sp.eye(extended_dimension), "the autonomous blank-plus-locked Kraus family is exactly CPTP")
+
+    blank = projector(ket(dimension + 1, 0))
+    locked_registers = [projector(ket(dimension + 1, i + 1)) for i in range(dimension)]
+    menu = [projector(ket(dimension, i)) for i in range(dimension)]
+
+    no_record_effect = sp.zeros(dimension)
+    blank_projector = sp.kronecker_product(sp.eye(dimension), blank)
+    no_record_effect_full = sp.simplify(blank_projector * no_record.H * no_record * blank_projector)
+    for row in range(dimension):
+        for column in range(dimension):
+            no_record_effect[row, column] = no_record_effect_full[row * (dimension + 1), column * (dimension + 1)]
+    check("A02", no_record_effect == empty_weight * sp.eye(dimension), "the blank-sector no-record effect is q I")
+
+    for outcome in range(dimension):
+        effect = sp.zeros(dimension)
+        for item in formation[outcome]:
+            full_effect = sp.simplify(blank_projector * item.H * item * blank_projector)
+            for row in range(dimension):
+                for column in range(dimension):
+                    effect[row, column] += full_effect[row * (dimension + 1), column * (dimension + 1)]
+        expected = (1 - empty_weight) * (
+            mixing * menu[outcome] + (1 - mixing) * sp.eye(dimension) / dimension
+        )
+        check(f"A03i{outcome}", sp.simplify(effect - expected) == sp.zeros(dimension), "blank formation effect is the scaled depolarized hostile effect")
+
+    cross_probability = sp.simplify(
+        sum(sp.trace(item * sp.kronecker_product(menu[1], blank) * item.H) for item in formation[0])
+    )
+    check("A04", cross_probability == sp.Rational(1, 4), "the hostile blank sector has nonzero cross-label formation weight")
+
+    for label in range(dimension):
+        locked_state = sp.kronecker_product(menu[label], locked_registers[label])
+        once = channel(kraus, locked_state)
+        twice = channel(kraus, once)
+        check(f"A05i{label}", once == locked_state, "the consistent locked-register state is fixed by one channel use")
+        check(f"A06i{label}", twice == once, "same-map reuse preserves locked-register-sector absorption")
+
+    calibrated, _, calibrated_formation, _ = autonomous_kraus(dimension, sp.Integer(1), empty_weight)
+    calibrated_complete = sum((item.H * item for item in calibrated), sp.zeros(extended_dimension))
+    check("A07", calibrated_complete == sp.eye(extended_dimension), "the calibrated a=1 positive control is also CPTP")
+    calibrated_cross = sp.simplify(
+        sum(sp.trace(item * sp.kronecker_product(menu[1], blank) * item.H) for item in calibrated_formation[0])
+    )
+    check("A08", calibrated_cross == 0, "a=1 removes cross-label formation")
+    check("A09", mixing != 1 and cross_probability > 0, "auxiliary register absorption and same-map reuse do not imply blank-sector cross-label exclusion")
+
+
+def covariance_and_dilation_checks() -> None:
+    dimension = 2
+    mixing = sp.Rational(1, 3)
+    empty_weight = sp.Rational(1, 4)
+    hadamard = sp.Matrix([[1, 1], [1, -1]]) / sp.sqrt(2)
+    complex_unitary = sp.Matrix([[1, sp.I], [sp.I, 1]]) / sp.sqrt(2)
+    base, _, _, _ = autonomous_kraus(dimension, mixing, empty_weight)
+    register_identity = sp.eye(dimension + 1)
+    rho_system = sp.Matrix([[sp.Rational(2, 3), sp.sqrt(2) / 3], [sp.sqrt(2) / 3, sp.Rational(1, 3)]])
+    blank = projector(ket(dimension + 1, 0))
+    locked_zero = projector(ket(dimension + 1, 1))
+    fixtures = (
+        ("hadamard_blank", hadamard, sp.kronecker_product(rho_system, blank)),
+        ("hadamard_locked", hadamard, sp.kronecker_product(rho_system, locked_zero)),
+        ("complex_blank", complex_unitary, sp.kronecker_product(rho_system, blank)),
+        ("complex_locked", complex_unitary, sp.kronecker_product(rho_system, locked_zero)),
+    )
+    for index, (label, unitary, rho) in enumerate(fixtures, 1):
+        rotated, _, _, _ = autonomous_kraus(dimension, mixing, empty_weight, unitary)
+        intertwiner = sp.kronecker_product(unitary, register_identity)
+        left = channel(rotated, intertwiner * rho * intertwiner.H)
+        right = sp.simplify(intertwiner * channel(base, rho) * intertwiner.H)
+        check(f"V{index:02d}", sp.simplify(left - right) == sp.zeros(left.rows), f"{label} corroborates supplied-menu family equivariance")
+
+    q = sp.Rational(1, 3)
+    p0, p1 = (projector(ket(2, i)) for i in range(2))
+    x_gate = sp.sqrt(q) * sp.Matrix([[0, 1], [1, 0]])
+    dephasing = [sp.sqrt(q) * p0, sp.sqrt(q) * p1]
+    check("V05", x_gate.H * x_gate == q * sp.eye(2), "a one-Kraus no-record map has scalar effect q I")
+    check("V06", sum((item.H * item for item in dephasing), sp.zeros(2)) == q * sp.eye(2), "a multi-Kraus no-record map can have the same scalar effect")
+    plus = projector(sp.Matrix([1, 1]) / sp.sqrt(2))
+    check("V07", channel([x_gate], plus) != channel(dephasing, plus), "the scalar no-record effect does not select the conditional no-record channel")
+    unitary_part = sp.simplify(x_gate / sp.sqrt(q))
+    check("V08", unitary_part.H * unitary_part == sp.eye(2), "the one-Kraus special case is sqrt(q) times a unitary")
+
+
+def source_checks() -> None:
+    path = Path("docs/AUTONOMOUS_INTERMITTENT_RECORD_INSTRUMENT_CALIBRATION_NONSELECTION_BOUNDED_THEOREM_NOTE_2026-07-11.md")
+    check("S01", path.exists(), "source note exists")
+    text = path.read_text() if path.exists() else ""
+    markers = (
+        "conditional repeat/exclusivity",
+        "does not identify the external labels as framework Records",
+        "does not derive probability semantics",
+        "does not select event order, rate, or the no-record channel",
+        "does not establish that the axioms require amendment",
+    )
+    for index, marker in enumerate(markers, 2):
+        check(f"S{index:02d}", marker in text, f"source contains boundary marker: {marker}")
+
+
+def main() -> int:
+    classification_checks()
+    autonomous_hostile_checks()
+    covariance_and_dilation_checks()
+    source_checks()
+    print("BOUNDARY: finite Kraus representation is named mathematical authority; physical CP-instrument applicability, the supplied menu, probability semantics, cross-label exclusion, and event neutrality remain conditional/open and gain no chain-satisfying premise authority.")
+    print("BOUNDARY: auxiliary locked-register absorption and same-map reuse do not imply blank-sector cross-label exclusion.")
+    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

- classifies the complete finite-carrier effect surface under conditional cross-label exclusion: E_i=e_iP_i and F=sum_i(1-e_i)P_i
- gives the full CP-instrument normal form, explicitly parameterized by the arbitrary no-record CP operation
- isolates menu-neutral event efficiency as the condition removing detection bias and yielding conditional Born-form weights
- constructs an exact auxiliary blank-plus-locked-register CPTP family showing absorption and same-map reuse do not imply blank-sector calibration
- distinguishes supplied-menu family equivariance from one menu-independent framework law

This is one abstract finite system/register carrier, not a framework-Record or Z^3 locality theorem. No axiom or primitive change is proposed.

## Verification

- runner/cache: PASS=36 FAIL=0, byte-identical
- independent claim and code/math review: PASS
- No-Go Discipline/current-main governance: PASS
- vocabulary lint: 0 violations
- audit pipeline: PASS; deps are minimal_axioms + locked-output normal form + reconciled Kraus-Choi
- strict audit lint: no errors
- generated audit/effective-status surfaces stripped before delivery