### PR TITLE
physics: distinguish fermion coordinate change from determinant squaring

### DIFF
--- a/docs/ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md
+++ b/docs/ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,162 @@
+# Fermionic Realification and Pfaffian Determinant Power
+
+**Date:** 2026-07-12
+**Claim type:** positive_theorem
+**Status authority:** independent audit lane. This source proposal does not
+set or predict an audit verdict.
+**Primary runner:**
+[`scripts/acphilambda_fermionic_realification_pfaffian_power_identity_2026_07_12.py`](../scripts/acphilambda_fermionic_realification_pfaffian_power_identity_2026_07_12.py)
+**Cached output:**
+[`logs/runner-cache/acphilambda_fermionic_realification_pfaffian_power_identity_2026_07_12.txt`](../logs/runner-cache/acphilambda_fermionic_realification_pfaffian_power_identity_2026_07_12.txt)
+
+## Exact theorem
+
+Let `K` be an `n x n` complex matrix and introduce independent Grassmann
+columns `chibar` and `chi`. In the ordered column
+
+```text
+Psi = (chibar_1,...,chibar_n,chi_1,...,chi_n)^T
+```
+
+define the antisymmetric kernel
+
+```text
+A_K = [[0, K],
+       [-K^T, 0]].
+```
+
+Then
+
+```text
+(1/2) Psi^T A_K Psi = chibar^T K chi,
+
+Pf(A_K) = (-1)^(n(n-1)/2) det_C(K).
+```
+
+Let the left Berezin derivatives act from the rightmost differential first,
+and define the measure orientation explicitly by
+
+```text
+D(Psi) = (-1)^(n(n+1)/2) d(Psi_2n)...d(Psi_1).
+```
+
+The top coefficient of `exp(-(1/2)Psi^T A_K Psi)` in the ordered monomial
+`Psi_1...Psi_2n` is `(-1)^(n(n+1)/2) det_C(K)`. The displayed orientation
+therefore gives the complex-fermion Gaussian with determinant power one:
+
+```text
+integral D(Psi) exp(-(1/2) Psi^T A_K Psi) = det_C(K).
+```
+
+This remains true when `chibar,chi` are reorganized into Majorana-paired
+Grassmann coordinates: an invertible linear coordinate change transforms the
+kernel by congruence and the Berezin measure by the inverse Jacobian, leaving
+the Gaussian value unchanged. No physical Majorana reality condition is used.
+
+By contrast, adjoin an independent conjugate sector and order the direct-sum
+variables by concatenating the `A_K` block before the `A_conjugate(K)` block.
+Then Pfaffian direct-sum multiplicativity gives exactly
+
+```text
+Pf(A_K direct_sum A_conjugate(K))
+  = det_C(K) det_C(conjugate(K))
+  = |det_C(K)|^2
+```
+
+The same scalar equals
+`det_R R(K)` for the ordinary realification
+
+```text
+R(K) = [[Re K,-Im K],
+        [Im K, Re K]].
+```
+
+Therefore `det_R R(K)=|det_C(K)|^2` has the same scalar determinant as the
+displayed conjugate-paired Pfaffian product. This scalar equality does not
+identify the ordinary realification with that doubled Grassmann carrier. In
+particular, it is not the result of merely writing one complex fermionic
+Gaussian in real Grassmann coordinates. The matrix `R(K)` need not be
+antisymmetric and therefore need not itself be the quadratic kernel of the
+displayed single Majorana Gaussian.
+
+## Proof
+
+Grassmann anticommutation gives
+
+```text
+(1/2)(chibar^T K chi - chi^T K^T chibar)
+  = chibar^T K chi.
+```
+
+The standard block-Pfaffian identity
+
+```text
+Pf([[0,K],[-K^T,0]]) = (-1)^(n(n-1)/2) det(K)
+```
+
+follows by expanding the Pfaffian: every nonzero perfect matching pairs a
+`chibar` index with a `chi` index, and the resulting signed permutation sum
+is the determinant. It is a polynomial identity, so singular matrices are
+included.
+
+For an invertible coordinate change `Psi=M Xi`, the kernel becomes
+`M^T A_K M`. Pfaffians and Berezin measures transform as
+
+```text
+Pf(M^T A_K M) = det(M) Pf(A_K),
+D(Psi) = det(M)^(-1) D(Xi)
+```
+
+for the paired orientation convention. The factors cancel in the Gaussian.
+Thus a complex-to-Majorana coordinate change cannot alter the determinant
+power. A second power arises after the independent conjugate block is
+adjoined.
+
+The equality between the conjugate product and the realification determinant
+is the retained finite-matrix identity proved in
+[`ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md`](ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md).
+Its complexified similarity decomposition is
+`R(K) ~ diag(K,conjugate(K))`.
+
+## Exact checks
+
+The runner verifies:
+
+- antisymmetry and the block-Pfaffian identity for generic ranks 1, 2, and 3;
+- the Grassmann quadratic-form identity at generic rank 2;
+- covariance under generic congruence and cancellation with its Berezin
+  Jacobian;
+- direct exterior-algebra checks of the negative-exponent Gaussian and its
+  stated measure orientation at ranks 1, 2, and 3;
+- the direct-sum product with the conjugate block;
+- agreement of that product with the ordinary realification determinant;
+- phase sensitivity of the single-sector Pfaffian and phase cancellation in
+  the conjugate-paired construction;
+- a singular example and an explicit non-antisymmetric realification;
+- source guards preserving the charged-lepton scope boundary.
+
+## Charged-lepton scope boundary
+
+This theorem corrects the interpretation of the determinant-power fork. It
+shows that a Majorana-paired Grassmann presentation of a supplied single
+complex fermionic Gaussian preserves the first determinant power. The
+coordinate statement does not impose a physical reality condition. Within the
+displayed Grassmann-Gaussian construction, obtaining the modulus square instead
+uses a supplied conjugate sector or conjugate-paired readout.
+
+It does not derive from the four axioms that the charged-lepton carrier has
+the displayed Grassmann action, Berezin measure, global CAR structure, or a
+single-sector physical readout. It does not select a K/CPT-orbit occupancy
+grain, register or predict `r`, force `r=1/2`, derive `delta`, or supply the
+R-eta readout license. Those physical identifications require separately
+audited retained support.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/acphilambda_fermionic_realification_pfaffian_power_identity_2026_07_12.py
+```
+
+Expected result: `PASS=32`, `FAIL=0`.

--- a/logs/runner-cache/acphilambda_fermionic_realification_pfaffian_power_identity_2026_07_12.txt
+++ b/logs/runner-cache/acphilambda_fermionic_realification_pfaffian_power_identity_2026_07_12.txt
@@ -1,0 +1,49 @@
+Fermionic realification and Pfaffian determinant power
+================================================================
+
+Part A: block-Pfaffian identity
+-------------------------------
+  [PASS] rank-1 kernel is antisymmetric
+  [PASS] rank-1 Pfaffian has determinant power one
+  [PASS] rank-2 kernel is antisymmetric
+  [PASS] generic rank-2 block Pfaffian identity
+  [PASS] rank-3 kernel is antisymmetric
+  [PASS] generic rank-3 block Pfaffian identity
+
+Part B: quadratic form and coordinate covariance
+------------------------------------------------
+  [PASS] exterior-algebra quadratic is chibar K chi
+  [PASS] Pfaffian congruence carries det(M)
+  [PASS] exterior top form independently gives det(M)
+  [PASS] inverse top-form Jacobian cancels congruence factor
+  [PASS] rank-1 negative-exponent Gaussian top sign
+  [PASS] rank-1 oriented Gaussian equals det(K)
+  [PASS] rank-2 negative-exponent Gaussian top sign
+  [PASS] rank-2 oriented Gaussian equals det(K)
+  [PASS] rank-3 negative-exponent Gaussian top sign
+  [PASS] rank-3 oriented Gaussian equals det(K)
+
+Part C: conjugate sector and ordinary realification
+---------------------------------------------------
+  [PASS] single-sector Pfaffian equals z
+  [PASS] conjugate-sector Pfaffian equals conjugate(z)
+  [PASS] direct-sum Pfaffian is the product of sector Pfaffians
+  [PASS] paired Pfaffian is modulus square
+  [PASS] ordinary realification determinant matches paired sectors
+  [PASS] generic rank-2 realification is the conjugate determinant product
+  [PASS] generic rank-2 conjugate direct sum has no residual sign
+  [PASS] single sector retains complex phase
+  [PASS] paired sectors cancel complex phase
+  [PASS] ordinary realification need not be antisymmetric
+  [PASS] singular complex determinant vanishes
+  [PASS] singular block Pfaffian vanishes
+  [PASS] singular realification determinant vanishes
+
+Scope guards
+------------
+  [PASS] source states determinant-power preservation under coordinate change
+  [PASS] source excludes a derived charged-lepton action
+  [PASS] source does not force r=1/2
+
+================================================================
+TOTAL: PASS=32, FAIL=0

--- a/scripts/acphilambda_fermionic_realification_pfaffian_power_identity_2026_07_12.py
+++ b/scripts/acphilambda_fermionic_realification_pfaffian_power_identity_2026_07_12.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Exact checks for fermionic realification and Pfaffian determinant power."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sympy as sp
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_"
+    "NARROW_THEOREM_NOTE_2026-07-12.md"
+)
+
+PASS = 0
+FAIL = 0
+
+
+def check(label: str, ok: bool, detail: object = "") -> None:
+    global PASS, FAIL
+    if bool(ok):
+        PASS += 1
+        tag = "PASS"
+    else:
+        FAIL += 1
+        tag = "FAIL"
+    suffix = f"  ({detail})" if detail != "" else ""
+    print(f"  [{tag}] {label}{suffix}")
+
+
+def section(title: str) -> None:
+    print(f"\n{title}\n{'-' * len(title)}")
+
+
+def pfaffian(matrix: sp.Matrix) -> sp.Expr:
+    """Recursive Pfaffian for the small exact matrices used here."""
+    size = matrix.rows
+    if size == 0:
+        return sp.Integer(1)
+    if size % 2:
+        return sp.Integer(0)
+    total = sp.Integer(0)
+    for j in range(1, size):
+        keep = [index for index in range(size) if index not in (0, j)]
+        minor = matrix.extract(keep, keep)
+        total += (-1) ** (j + 1) * matrix[0, j] * pfaffian(minor)
+    return sp.expand(total)
+
+
+def fermion_kernel(matrix: sp.Matrix) -> sp.Matrix:
+    zeros = sp.zeros(matrix.rows)
+    return sp.Matrix.vstack(
+        sp.Matrix.hstack(zeros, matrix),
+        sp.Matrix.hstack(-matrix.T, zeros),
+    )
+
+
+def realification(matrix: sp.Matrix) -> sp.Matrix:
+    real = matrix.applyfunc(sp.re)
+    imag = matrix.applyfunc(sp.im)
+    return sp.Matrix.vstack(
+        sp.Matrix.hstack(real, -imag),
+        sp.Matrix.hstack(imag, real),
+    )
+
+
+def grassmann_mul(
+    left: dict[int, sp.Expr], right: dict[int, sp.Expr]
+) -> dict[int, sp.Expr]:
+    """Multiply sparse exterior polynomials in ascending generator order."""
+    out: dict[int, sp.Expr] = {}
+    for left_mask, left_coeff in left.items():
+        for right_mask, right_coeff in right.items():
+            if left_mask & right_mask:
+                continue
+            inversions = 0
+            bits = right_mask
+            while bits:
+                low = bits & -bits
+                index = low.bit_length() - 1
+                inversions += (left_mask >> (index + 1)).bit_count()
+                bits ^= low
+            sign = -1 if inversions % 2 else 1
+            mask = left_mask | right_mask
+            out[mask] = sp.simplify(
+                out.get(mask, 0) + sign * left_coeff * right_coeff
+            )
+    return {mask: coeff for mask, coeff in out.items() if coeff != 0}
+
+
+def grassmann_quadratic(matrix: sp.Matrix) -> dict[int, sp.Expr]:
+    """Return (1/2) Psi^T A_K Psi for Psi=(chibar,chi)."""
+    kernel = fermion_kernel(matrix)
+    variables = [{1 << index: sp.Integer(1)} for index in range(kernel.rows)]
+    out: dict[int, sp.Expr] = {}
+    for row in range(kernel.rows):
+        for col in range(kernel.cols):
+            term = grassmann_mul(variables[row], variables[col])
+            for mask, coeff in term.items():
+                out[mask] = sp.simplify(
+                    out.get(mask, 0)
+                    + sp.Rational(1, 2) * kernel[row, col] * coeff
+                )
+    return {mask: coeff for mask, coeff in out.items() if coeff != 0}
+
+
+def grassmann_gaussian_top(matrix: sp.Matrix) -> sp.Expr:
+    """Top coefficient of exp(-(1/2) Psi^T A_K Psi)."""
+    action = {
+        mask: -coeff for mask, coeff in grassmann_quadratic(matrix).items()
+    }
+    exponential: dict[int, sp.Expr] = {0: sp.Integer(1)}
+    power: dict[int, sp.Expr] = {0: sp.Integer(1)}
+    factorial = sp.Integer(1)
+    for degree in range(1, matrix.rows + 1):
+        power = grassmann_mul(power, action)
+        factorial *= degree
+        for mask, coeff in power.items():
+            exponential[mask] = sp.simplify(
+                exponential.get(mask, 0) + coeff / factorial
+            )
+    top_mask = (1 << (2 * matrix.rows)) - 1
+    return sp.simplify(exponential.get(top_mask, 0))
+
+
+def exterior_top_jacobian(matrix: sp.Matrix) -> sp.Expr:
+    """Coefficient of Xi_1...Xi_m in wedge_i sum_j M_ij Xi_j."""
+    product: dict[int, sp.Expr] = {0: sp.Integer(1)}
+    for row in range(matrix.rows):
+        linear_form = {
+            1 << col: matrix[row, col]
+            for col in range(matrix.cols)
+            if matrix[row, col] != 0
+        }
+        product = grassmann_mul(product, linear_form)
+    return sp.simplify(product.get((1 << matrix.rows) - 1, 0))
+
+
+def main() -> int:
+    print("Fermionic realification and Pfaffian determinant power")
+    print("=" * 64)
+
+    section("Part A: block-Pfaffian identity")
+    k1 = sp.Symbol("k1")
+    kernel1 = fermion_kernel(sp.Matrix([[k1]]))
+    check("rank-1 kernel is antisymmetric", kernel1.T == -kernel1)
+    check("rank-1 Pfaffian has determinant power one", pfaffian(kernel1) == k1)
+
+    a, b, c, d = sp.symbols("a b c d")
+    matrix2 = sp.Matrix([[a, b], [c, d]])
+    kernel2 = fermion_kernel(matrix2)
+    sign2 = (-1) ** (2 * 1 // 2)
+    check("rank-2 kernel is antisymmetric", kernel2.T == -kernel2)
+    check(
+        "generic rank-2 block Pfaffian identity",
+        sp.simplify(pfaffian(kernel2) - sign2 * matrix2.det()) == 0,
+    )
+
+    entries3 = sp.symbols("q00:03 q10:13 q20:23")
+    matrix3 = sp.Matrix(3, 3, entries3)
+    kernel3 = fermion_kernel(matrix3)
+    sign3 = (-1) ** (3 * 2 // 2)
+    check("rank-3 kernel is antisymmetric", kernel3.T == -kernel3)
+    check(
+        "generic rank-3 block Pfaffian identity",
+        sp.simplify(pfaffian(kernel3) - sign3 * matrix3.det()) == 0,
+    )
+
+    section("Part B: quadratic form and coordinate covariance")
+    expected_quadratic = {
+        (1 << i) | (1 << (2 + j)): matrix2[i, j]
+        for i in range(2)
+        for j in range(2)
+    }
+    check(
+        "exterior-algebra quadratic is chibar K chi",
+        grassmann_quadratic(matrix2) == expected_quadratic,
+    )
+
+    p, q, r, s = sp.symbols("p q r s")
+    transform = sp.Matrix([[p, q], [r, s]])
+    congruent = transform.T * kernel1 * transform
+    check(
+        "Pfaffian congruence carries det(M)",
+        sp.simplify(pfaffian(congruent) - transform.det() * pfaffian(kernel1)) == 0,
+    )
+    check(
+        "exterior top form independently gives det(M)",
+        sp.simplify(exterior_top_jacobian(transform) - transform.det()) == 0,
+    )
+    check(
+        "inverse top-form Jacobian cancels congruence factor",
+        sp.simplify(pfaffian(congruent) / transform.det() - pfaffian(kernel1)) == 0,
+    )
+
+    for rank, matrix in ((1, sp.Matrix([[k1]])), (2, matrix2), (3, matrix3)):
+        orientation = (-1) ** (rank * (rank + 1) // 2)
+        gaussian_top = grassmann_gaussian_top(matrix)
+        check(
+            f"rank-{rank} negative-exponent Gaussian top sign",
+            sp.simplify(gaussian_top - orientation * matrix.det()) == 0,
+        )
+        check(
+            f"rank-{rank} oriented Gaussian equals det(K)",
+            sp.simplify(orientation * gaussian_top - matrix.det()) == 0,
+        )
+
+    section("Part C: conjugate sector and ordinary realification")
+    u, v = sp.symbols("u v", real=True)
+    z = u + sp.I * v
+    complex_scalar = sp.Matrix([[z]])
+    conjugate_scalar = sp.conjugate(complex_scalar)
+    paired_kernel = sp.diag(
+        fermion_kernel(complex_scalar), fermion_kernel(conjugate_scalar)
+    )
+    single_pf = pfaffian(fermion_kernel(complex_scalar))
+    conjugate_pf = pfaffian(fermion_kernel(conjugate_scalar))
+    paired_pf = pfaffian(paired_kernel)
+    modulus_square = sp.expand(z * sp.conjugate(z))
+    check("single-sector Pfaffian equals z", sp.simplify(single_pf - z) == 0)
+    check(
+        "conjugate-sector Pfaffian equals conjugate(z)",
+        sp.simplify(conjugate_pf - sp.conjugate(z)) == 0,
+    )
+    check(
+        "direct-sum Pfaffian is the product of sector Pfaffians",
+        sp.simplify(paired_pf - single_pf * conjugate_pf) == 0,
+    )
+    check("paired Pfaffian is modulus square", sp.simplify(paired_pf - modulus_square) == 0)
+    check(
+        "ordinary realification determinant matches paired sectors",
+        sp.simplify(realification(complex_scalar).det() - paired_pf) == 0,
+    )
+    x0, x1, x2, x3, y0, y1, y2, y3 = sp.symbols(
+        "x0 x1 x2 x3 y0 y1 y2 y3", real=True
+    )
+    complex_matrix2 = sp.Matrix(
+        [[x0 + sp.I * y0, x1 + sp.I * y1],
+         [x2 + sp.I * y2, x3 + sp.I * y3]]
+    )
+    check(
+        "generic rank-2 realification is the conjugate determinant product",
+        sp.simplify(
+            realification(complex_matrix2).det()
+            - complex_matrix2.det() * sp.conjugate(complex_matrix2.det())
+        )
+        == 0,
+    )
+    paired_kernel2 = sp.diag(
+        fermion_kernel(complex_matrix2),
+        fermion_kernel(sp.conjugate(complex_matrix2)),
+    )
+    check(
+        "generic rank-2 conjugate direct sum has no residual sign",
+        sp.simplify(
+            pfaffian(paired_kernel2)
+            - complex_matrix2.det() * sp.conjugate(complex_matrix2.det())
+        )
+        == 0,
+    )
+    check("single sector retains complex phase", sp.simplify(sp.im(single_pf) - v) == 0)
+    check("paired sectors cancel complex phase", sp.simplify(sp.im(paired_pf)) == 0)
+
+    generic_realification = realification(
+        sp.Matrix([[u + sp.I * v, 2], [3 * sp.I, 1 - sp.I]])
+    )
+    check(
+        "ordinary realification need not be antisymmetric",
+        generic_realification.T != -generic_realification,
+    )
+
+    singular = sp.Matrix([[1 + sp.I, 2], [2 + 2 * sp.I, 4]])
+    check("singular complex determinant vanishes", singular.det() == 0)
+    check("singular block Pfaffian vanishes", pfaffian(fermion_kernel(singular)) == 0)
+    check("singular realification determinant vanishes", realification(singular).det() == 0)
+
+    section("Scope guards")
+    note = NOTE.read_text(encoding="utf-8")
+    check(
+        "source states determinant-power preservation under coordinate change",
+        "coordinate change cannot alter the determinant\npower" in note,
+    )
+    check(
+        "source excludes a derived charged-lepton action",
+        "does not derive from the four axioms that the charged-lepton carrier has" in note,
+    )
+    check("source does not force r=1/2", "force `r=1/2`" in note)
+
+    print("\n" + "=" * 64)
+    print(f"TOTAL: PASS={PASS}, FAIL={FAIL}")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- proves the block-Pfaffian identity for a supplied complex fermionic Gaussian
- fixes the grouped Berezin orientation and checks ranks 1, 2, and 3 exactly
- distinguishes Majorana-paired coordinate rewriting from adjoining a conjugate sector
- keeps the physical charged-lepton action, CAR carrier, occupancy grain, r, delta, and R-eta readout outside the claim

## Verification

- runner: PASS=32, FAIL=0
- cached output matches fresh stdout
- independent review-loop formula check: PASS
- audit compatibility pipeline: no errors
- strict audit lint: no errors
- vocabulary lint and git diff check: pass

## Audit handoff

Proposed claim id: acphilambda_fermionic_realification_pfaffian_power_identity_narrow_theorem_note_2026-07-12

Audit status and effective status remain owned by the independent audit lane. This theorem narrows AC(i); it does not discharge the physical occupancy obligation.