### PR TITLE
physics: state Pfaffian theorem domain positively

### DIFF
--- a/docs/ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md
+++ b/docs/ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md
@@ -144,12 +144,13 @@ coordinate statement does not impose a physical reality condition. Within the
 displayed Grassmann-Gaussian construction, obtaining the modulus square instead
 uses a supplied conjugate sector or conjugate-paired readout.
 
-It does not derive from the four axioms that the charged-lepton carrier has
-the displayed Grassmann action, Berezin measure, global CAR structure, or a
-single-sector physical readout. It does not select a K/CPT-orbit occupancy
-grain, register or predict `r`, force `r=1/2`, derive `delta`, or supply the
-R-eta readout license. Those physical identifications require separately
-audited retained support.
+The theorem domain is a supplied Grassmann action, Berezin measure, and
+determinant carrier. Framework derivation of the charged-lepton carrier,
+global CAR structure, physical single-sector readout, K/CPT-orbit occupancy
+grain, registered `r`, `delta`, and R-eta readout lies outside this theorem.
+Its outputs are limited to determinant-power identities and coordinate
+covariance. Physical charged-lepton identification requires separately audited
+retained support.
 
 ## Verification
 

--- a/logs/runner-cache/acphilambda_fermionic_realification_pfaffian_power_identity_2026_07_12.txt
+++ b/logs/runner-cache/acphilambda_fermionic_realification_pfaffian_power_identity_2026_07_12.txt
@@ -42,8 +42,8 @@ Part C: conjugate sector and ordinary realification
 Scope guards
 ------------
   [PASS] source states determinant-power preservation under coordinate change
-  [PASS] source excludes a derived charged-lepton action
-  [PASS] source does not force r=1/2
+  [PASS] source limits the theorem to a supplied algebraic domain
+  [PASS] source leaves registered r outside the theorem domain
 
 ================================================================
 TOTAL: PASS=32, FAIL=0

--- a/scripts/acphilambda_fermionic_realification_pfaffian_power_identity_2026_07_12.py
+++ b/scripts/acphilambda_fermionic_realification_pfaffian_power_identity_2026_07_12.py
@@ -283,10 +283,13 @@ def main() -> int:
         "coordinate change cannot alter the determinant\npower" in note,
     )
     check(
-        "source excludes a derived charged-lepton action",
-        "does not derive from the four axioms that the charged-lepton carrier has" in note,
+        "source limits the theorem to a supplied algebraic domain",
+        "The theorem domain is a supplied Grassmann action" in note,
     )
-    check("source does not force r=1/2", "force `r=1/2`" in note)
+    check(
+        "source leaves registered r outside the theorem domain",
+        "grain, registered `r`, `delta`, and R-eta readout lies outside" in note,
+    )
 
     print("\n" + "=" * 64)
     print(f"TOTAL: PASS={PASS}, FAIL={FAIL}")


### PR DESCRIPTION
## Summary

- rewrites the theorem boundary as a positive supplied-domain statement
- preserves the charged-lepton carrier, CAR, occupancy, r, delta, and R-eta exclusions
- updates paired scope guards and cached output
- prevents a positive algebraic theorem from being misrouted into the broad no-go evidence index

## Verification

- independent review-loop: PASS
- runner/cache: PASS=32, FAIL=0
- source no-go trigger: true before, false after
- full audit compatibility pipeline and strict lint: no errors
- vocabulary lint, py_compile, and diff check: pass

## Audit handoff

The claim remains unaudited. Audit status and effective status are set by the independent audit lane.