### PR TITLE
physics: repair KS/JW locality no-go evidence

### DIFF
--- a/docs/KS_ETA_VS_JW_STRING_CAR_LOCALITY_NO_GO_NOTE_2026-06-02.md
+++ b/docs/KS_ETA_VS_JW_STRING_CAR_LOCALITY_NO_GO_NOTE_2026-06-02.md
@@ -11,10 +11,10 @@ Dirac/taste c-number link coefficients. The Jordan-Wigner string is the
 operator-valued statistics object. They are orthogonal.
 
 The framework baseline is
-[`MINIMAL_AXIOMS_2026-06-04.md`](MINIMAL_AXIOMS_2026-06-04.md): Lattice supplies
-`Z^3`, Quantum supplies the one-qubit local algebra, and Record is irrelevant to
-this statistics question. The tested route does not add a new primitive,
-statistics rule, or owner-approved admission.
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md): Lattice supplies
+`Z^3`, Qubit supplies the one-qubit local algebra, and Record is irrelevant to
+this statistics question. The tested route does not add a new primitive or
+statistics rule.
 
 ## Result
 
@@ -34,35 +34,39 @@ keep eta, drop the string  -> CAR fails
 drop eta, keep the string  -> CAR holds
 ```
 
-So the staggered eta signs neither supply nor are needed for CAR. Locality also
-does not supply the string: the maximally local ladder has no string, while any
-Jordan-Wigner order on the patch has a nearest-neighbor link with a nontrivial
-tail.
+In the displayed finite operator construction, the staggered eta signs neither
+supply nor are needed for CAR. Locality also does not supply the string in the
+displayed ungraded Pauli-tensor
+representation: the maximally endpoint-local ladder has no string, while every
+Jordan-Wigner order on the patch has a nearest-neighbor link with a
+non-endpoint tail.
 
 ## Scope
 
 This is not a no-go against fermions on `Z^3`. The Jordan-Wigner frame exists.
-The claim is only that the tested locality-plus-KS route does not force it over
-the hard-core-boson frame. A future graded-locality rule, fermion-parity
-superselection principle, or lattice-native statistics derivation remains open
-and would need explicit owner approval or an independent derivation.
+The claim is that the tested locality-plus-KS route does not force it over
+the hard-core-boson frame. A future graded-locality/braiding rule or
+lattice-native statistics derivation remains open and would need explicit owner
+approval or an independent derivation. Fermion-parity superselection may
+accompany that structure, but parity alone is shared by both frames and does
+not select their cross-site braiding.
 
 ## No-Go Discipline Gate
 
-This gate applies only to the route above: deriving cross-site CAR from the
+This gate applies to the route above: deriving cross-site CAR from the
 staggered eta signs plus locality.
 
 ### N1 - Alternative Route Enumeration
 
-| Route | What it attempts | Result |
-| --- | --- | --- |
-| Eta-as-statistics | Treat `eta_mu(x)` as the CAR sign. | Counterfactuals show CAR rides the string, not eta. |
-| Locality-generates-string | Require matter operators to be local and infer the string. | The single-site hard-core boson is more local and is not CAR. |
-| Single-valuedness | Use single-valued fields to select the graded frame. | Both hard-core boson and Jordan-Wigner frames are single-valued. |
-| Per-site nilpotency | Upgrade `b_x^2=0` to cross-site anticommutation. | The hard-core boson has nilpotency without cross-site CAR. |
-| Same-algebra route | Use the shared ungraded matrix algebra to claim CAR is forced. | Same ungraded algebra means the graded frame is not selected. |
-| Order-choice route | Choose a total order that removes all strings on nearest-neighbor links. | The patch bandwidth check leaves a nontrivial tail. |
-| Graded-locality route | Add fermion-parity superselection. | This is a real external selector, not a consequence of KS eta signs. |
+| Route | Marker | What it attempts | Result |
+| --- | --- | --- | --- |
+| Eta-as-statistics | `ATTEMPTED` | Treat `eta_mu(x)` as the CAR sign. | C5 counterfactuals show CAR rides the string, not eta. |
+| Locality-generates-string | `ATTEMPTED` | Require matter operators to be local and infer the string. | C2 exhibits endpoint-local hard-core ladders without CAR. |
+| Single-valuedness | `ATTEMPTED` | Use single-valued fields to select the graded frame. | Both finite frames are single-valued. |
+| Per-site nilpotency | `ATTEMPTED` | Upgrade `b_x^2=0` to cross-site anticommutation. | C3 has nilpotency without cross-site CAR. |
+| Same-algebra route | `ATTEMPTED` | Use the shared ungraded matrix algebra to claim CAR is forced. | C6 finds the same full ungraded algebra in both frames. |
+| Order-choice route | `ATTEMPTED` | Choose a total order that removes all strings on nearest-neighbor links. | C7 enumerates all patch orderings and leaves a nontrivial tail. |
+| Parity-involution route | `ATTEMPTED` | Use the global parity involution to select the fermion frame. | C4 verifies that the same parity anticommutes with bare hard-core ladders and JW fermions, so parity does not select their braiding. |
 
 ### N2 - Wall Independence
 
@@ -72,47 +76,107 @@ statistics.
 
 ### N3 - Hidden-Wall Scan
 
-"Locality" means support on the tested lattice sites. "Eta" means a c-number
-coefficient in the hopping term. No graded locality, superselection rule, or
-total-order selection is hidden in those words.
+The trigger scan classifies each potentially load-bearing phrase:
+
+- "framework baseline" links the current axiom memo;
+- "canonical lexicographic order" is a non-load-bearing convenience because C7
+  enumerates all patch orderings;
+- "canonical KS pattern" is the explicitly defined finite sign table;
+- "standard finite linear algebra" is mathematical infrastructure;
+- "canonically supply" states the negative conclusion rather than assuming a
+  uniqueness premise.
+
+"Locality" means support in the tested ungraded tensor representation. "Eta"
+means a c-number coefficient in the hopping term. No graded locality,
+superselection rule, or physical total-order selection is hidden in those
+words.
 
 ### N4 - Residual Matching
 
 The residual is cross-site CAR selection. It is not the per-site nilpotency
 residual, the staggered Dirac/taste residual, or the existence of a compatible
-fermion representation.
+fermion representation. No prior no-go or campaign is used as the scientific
+witness. The retained rows listed in N6 and N8 are partial-path context; the
+runner's two finite realizations are the residual-matched witness.
 
 ### N5 - Rhetoric Audit
 
-The negative statement is route-local. It does not say CAR is impossible, only
-that KS eta plus locality does not force it.
+The negative statement is route-local: KS eta plus ungraded tensor locality
+does not force CAR. Its tested resolutions are:
+
+| Resolution | Exact tested surface |
+| --- | --- |
+| per mode | not tested and not claimed |
+| per site | all eight HCB and JW ladders: nilpotency, single-site HCB support, and shared parity oddness |
+| per distinct-site pair | all 28 pairs: HCB commutation and JW CAR |
+| per geometric link | all 12 links: HCB endpoint support and exact JW ordered-interval support |
+| per finite block | three-site full ungraded algebra and eight-site cube bandwidth |
+| lattice-wide | outside the finite-patch theorem domain |
 
 ### N6 - Partial-Closure Path Scan
 
-An owner-approved graded-locality primitive, a fermion-parity superselection
-admission, or a lattice-native statistics theorem could close the residual.
-This note leaves those paths open.
+Current partial paths are:
+
+- raw tensor locality, `retained_bounded`, supplies ungraded support control;
+- the parity involution, `retained`, supplies a grading operator but no braiding;
+- the Cl(4)-to-CAR equivalence, `retained`, derives CAR after Clifford relations
+  are supplied;
+- Cl(3) complexification, `retained`, supplies abstract algebraic structure;
+- the Pfaffian determinant-power theorem, `retained`, treats a supplied
+  Grassmann carrier;
+- approved primitives supply no odd-operator braiding or statistics selector.
+
+An owner-approved graded-locality/braiding primitive or a lattice-native
+statistics theorem could resolve the residual. Graded locality is substantive
+statistics structure, not a naming convention. Parity superselection alone
+cannot resolve the residual because both tested frames carry the same parity
+action.
 
 ### N7 - Steelman
 
 A hostile reviewer can argue that physical locality should be graded locality
 rather than ungraded tensor locality. That would supply CAR directly, but it is
-an added statistics rule; it is not derived from the eta coefficients.
+an added odd-operator braiding rule; it is not derived from the eta
+coefficients. The retained
+`fermion_parity_pauli_tensor_involution_narrow_theorem_note_2026-05-10`
+supplies the best ingredient, the involution `F`; it does not supply
+odd-operator braiding.
 
 ### N8 - Cross-Cycle Echo
 
-Other carrier notes separate the one-qubit state space from the cross-site
-statistics frame. This note adds the Kogut-Susskind eta-specific test of that
-split.
+Current-ledger context checked on 2026-07-12, without adding dependency edges:
 
-**Gate result:** pass for the narrow eta-versus-string route only.
+- `lieb_robinson_equal_time_tensor_locality_narrow_theorem_note_2026-05-10`
+  is `retained_bounded` for raw ungraded tensor locality;
+- `fermion_parity_pauli_tensor_involution_narrow_theorem_note_2026-05-10`
+  is `retained` for the parity involution, without a braiding selector;
+- `area_law_majorana_car_fock_equivalence_narrow_theorem_note_2026-05-09`
+  is `retained` after Clifford/CAR relations are supplied;
+- `cl3_complexification_split_narrow_theorem_note_2026-05-10` is `retained`
+  for abstract algebraic structure;
+- `acphilambda_fermionic_realification_pfaffian_power_identity_narrow_theorem_note_2026-07-12`
+  is `retained` for determinant-power identities on a supplied Grassmann
+  carrier.
+- `staggered_dirac_substep1_statistics_agnostic_no_forcing_note_2026-05-25`
+  is `unaudited` context; its statistics wall has not been retired and is not
+  cited as retained support.
+
+The Cl(4) result derives CAR from supplied Clifford relations; parity supplies
+grading algebra without braiding; raw tensor locality distinguishes the
+ungraded representation. None converts eta plus ungraded locality into CAR.
+The unaudited staggered-Dirac row echoes the same wall but contributes no
+retained authority here.
+
+**Gate result:** pass for the narrow eta-versus-string route.
 
 ## Validation
 
-The runner checks 23 exact finite-matrix facts:
+The runner checks 35 exact finite-matrix facts:
 
 - eta signs are c-number Kawamoto-Smit phases;
 - hard-core boson and Jordan-Wigner hopping use the same eta coefficients;
+- all hard-core link terms are endpoint-local while exactly `8/12` Jordan-Wigner
+  link terms carry non-endpoint string support in the displayed ordering;
 - hard-core boson ladders are nilpotent and local but not CAR;
 - Jordan-Wigner dressing gives CAR;
 - eta and the string pass the two counterfactual tests above;

--- a/logs/runner-cache/ks_eta_vs_jw_string_car_locality.txt
+++ b/logs/runner-cache/ks_eta_vs_jw_string_car_locality.txt
@@ -1,16 +1,16 @@
 ===== runner cache v1 =====
 runner: scripts/ks_eta_vs_jw_string_car_locality.py
-runner_sha256: c408dac49226d6d3958c270110cbbea2b44b4b02b7192f3771d7dba7ecef9e6e
+runner_sha256: b715831fd0e6239ee1d57f36d6d8d5fccc80fbf954024044cbc44f6ef471fde6
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.61
+elapsed_sec: 0.89
 status: ok
 ----- stdout -----
 [setup] L=2  N=8 sites  dim H = 256  nearest-neighbour links = 12
 [setup] lexicographic order pi: [(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)]
 
 C1  eta_mu(x) = Kawamoto-Smit phases (c-number Dirac-structure signs)
-  PASS  eta_from_spin_diag yields pure +-1 signs for every (mu,x)
+  PASS  eta_from_spin_diag equals the closed-form eta for every (mu,x)
   PASS  eta closed form matches canonical KS sign table (sample)
   PASS  eta_mu(x) is a c-number (int), carries NO operator content / no statistics
 
@@ -25,29 +25,41 @@ C4  JW-dressed c_x = S_x sigma_+^(x): cross-site CAR (the string supplies it)
   PASS  {c_x, c_y} = 0 for ALL x != y (CAR)
   PASS  {c_x, c_x^dag} = I for every x
   PASS  {c_x, c_y^dag} = 0 for x != y
+  PASS  the same global parity anticommutes with both HCB and JW ladders
 
-C2  staggered KS hopping carries eta in BOTH realizations; both nearest-neighbour LOCAL
+C2  same staggered eta in both realizations; endpoint locality differs by JW string
   PASS  HCB staggered hopping: every link term supported on its 2 endpoints (local)
-  PASS  HCB and JW staggered operators use the IDENTICAL eta sign on every link
-  PASS  H_hcb != H_jw (they differ ONLY by the JW string, not by eta)
+  PASS  JW link (0, 0, 0)-(1, 0, 0): tensor support equals its ordered endpoint interval
+  PASS  JW link (0, 0, 0)-(0, 1, 0): tensor support equals its ordered endpoint interval
+  PASS  JW link (0, 0, 0)-(0, 0, 1): tensor support equals its ordered endpoint interval
+  PASS  JW link (0, 0, 1)-(1, 0, 1): tensor support equals its ordered endpoint interval
+  PASS  JW link (0, 0, 1)-(0, 1, 1): tensor support equals its ordered endpoint interval
+  PASS  JW link (0, 1, 0)-(1, 1, 0): tensor support equals its ordered endpoint interval
+  PASS  JW link (0, 1, 0)-(0, 1, 1): tensor support equals its ordered endpoint interval
+  PASS  JW link (0, 1, 1)-(1, 1, 1): tensor support equals its ordered endpoint interval
+  PASS  JW link (1, 0, 0)-(1, 1, 0): tensor support equals its ordered endpoint interval
+  PASS  JW link (1, 0, 0)-(1, 0, 1): tensor support equals its ordered endpoint interval
+  PASS  JW link (1, 0, 1)-(1, 1, 1): tensor support equals its ordered endpoint interval
+  PASS  JW link (1, 1, 0)-(1, 1, 1): tensor support equals its ordered endpoint interval
+  PASS  isolated hopping-builder projections match the spin-diagonal eta table
+  PASS  JW hopping: exactly 8/12 geometric NN link terms carry non-endpoint string support
+  PASS  H_hcb != H_jw (they differ by the JW string, not by eta)
 
 C5  DECISIVE: the CAR sign rides the STRING, not eta (orthogonal objects)
   PASS  drop string, KEEP eta  ->  cross-site CAR FAILS (eta cannot supply CAR)
-  PASS  drop eta, KEEP string   ->  cross-site CAR STILL HOLDS (eta is not the CAR source)
-  PASS  the matter operator c_x is independent of eta (eta lives in the kinetic coefficient, the string lives in the operator)
+  PASS  drop eta, KEEP string   ->  kinetic operator changes and cross-site CAR holds
 
 C6  HCB and JW generators span the SAME M_{2^N}(C) on a three-site subpatch
   PASS  HCB algebra dim = 64 = 4^3 = 64 (full matrix algebra)
   PASS  JW  algebra dim = 64 = 4^3 = 64 (same full matrix algebra)
   PASS  on the subpatch, both frames generate the SAME ungraded algebra => operator-algebra data cannot select statistics
 
-C7  locality horn: JW string is genuinely NON-local on Z^3 (2x2x2 bandwidth > 1)
+C7  ungraded tensor locality horn: JW tails are non-endpoint-local on the 2x2x2 patch
   PASS  min grid-graph bandwidth over ALL orderings = 4 > 1 (no total order makes every NN link string-free)
   PASS  lexicographic slow-axis NN link (0, 0, 0)-(1, 0, 0) spans 4 positions => string non-trivial over intermediate sites [(0, 0, 1), (0, 1, 0), (0, 1, 1)]
-  PASS  a maximally-local matter operator (single-site b_x) carries NO string => locality does NOT force the JW string / CAR
 
 ========================================================================
-SCORECARD: PASS=23 FAIL=0
+SCORECARD: PASS=35 FAIL=0
 ========================================================================
 
 ----- stderr -----

--- a/scripts/ks_eta_vs_jw_string_car_locality.py
+++ b/scripts/ks_eta_vs_jw_string_car_locality.py
@@ -3,8 +3,8 @@ KS staggered eta-factor vs Jordan-Wigner string: does matter-attachment LOCALITY
 + the Kogut-Susskind staggered structure ALGEBRAICALLY FORCE cross-site CAR?
 
 Angle: NON-geometric / algebraic forcing of the cross-site CAR sign from the
-matter-attachment construction on Z^3 (Quantum = one qubit/Cl(3,0) spinor per
-site, Lattice = Z^3).
+matter-attachment construction on Z^3. Qubit supplies the one-site M_2(C)
+possibility algebra; the finite tensor realization below is the tested model.
 
 Central distinction under test (the two objects must NOT be conflated):
   * STAGGERED eta_mu(x) = (-1)^{x_1 + ... + x_{mu-1}}  -- a per-LINK c-number sign.
@@ -27,12 +27,13 @@ both carrying the IDENTICAL eta_mu(x) link signs, and check, exactly:
 
   C1  eta_mu(x) are the Kawamoto-Smit phases (c-number signs), eta independent of
       statistics realization.
-  C2  Both the HCB and JW staggered hopping operators are nearest-neighbour LOCAL
-      and both carry the SAME eta signs (eta does NOT discriminate statistics).
+  C2  Both staggered hopping constructions carry the SAME eta signs. HCB link
+      terms are endpoint-local, while JW link terms can carry the ordering string
+      outside their geometric endpoints (eta does NOT discriminate statistics).
   C3  The bare ladders are hard-core-bosonic: [b_x, b_y] = 0 for x != y, b_x^2 = 0.
       => a LOCAL, nilpotent, single-occupancy matter operator EXISTS that is NOT CAR.
       Hence locality + nilpotency + eta do NOT force CAR.
-  C4  CAR appears ONLY after the JW string dressing; {c_x, c_y}=0 needs the string,
+  C4  CAR appears after the JW string dressing; {c_x, c_y}=0 needs the string,
       which (a) is a DIFFERENT object from eta and (b) requires an ORDER choice.
   C5  Counterfactual: dropping the string but KEEPING eta leaves cross-site
       ANTIcommutators NON-zero (bosonic). Dropping eta but keeping the string still
@@ -40,12 +41,12 @@ both carrying the IDENTICAL eta_mu(x) link signs, and check, exactly:
   C6  On a three-site subpatch, the two algebras (HCB generators vs JW
       generators) generate the SAME full matrix algebra M_{2^N}(C). Statistics
       is a frame choice on one ungraded algebra.
-  C7  Locality horn: the JW string is genuinely NON-local on Z^3. No total order
-      makes every nearest-neighbour link string-free; the 2x2x2 grid graph has
-      bandwidth > 1, so the string is unavoidable for some local links. Locality
-      of the matter operator therefore does NOT canonically supply the string.
+  C7  Ungraded tensor-locality horn: no total order makes every nearest-neighbour
+      link string-free on the 2x2x2 patch. Its grid graph has bandwidth > 1, so
+      some geometric links carry non-endpoint tensor support. This representation
+      does not canonically supply the string from endpoint locality.
 
-VERDICT printed at the end. Uses the Lattice/Quantum baseline plus standard
+VERDICT printed at the end. Uses the Lattice/Qubit baseline plus standard
 finite linear algebra. No imports.
 """
 
@@ -162,7 +163,7 @@ def staggered_hopping(order, index, links, N, ladder, use_eta=True):
     return H
 
 # ----------------------------------------------------------------------------
-# Locality test: is an operator supported only on a nearest-neighbour link?
+# Locality test: is an operator supported on a nearest-neighbour link?
 # An operator O is "local on link (x,y)" if it commutes with sigma_z parity on
 # every site NOT in {x,y} ... but more robustly: O = (something on x) tensor
 # (something on y) tensor identity elsewhere. We test: does O act as identity on
@@ -306,12 +307,9 @@ def check():
         for mu in (1, 2, 3):
             e_def = eta(mu, x)
             e_spin = eta_from_spin_diag(mu, x)
-            # spin-diag returns +-1 (possibly times a global gamma convention sign).
-            # Kawamoto-Smit: eta from spin-diag equals the closed-form up to the
-            # global eta_1==1 gauge; compare magnitude-1 and that it is a pure sign.
-            if not (abs(abs(e_spin) - 1) < 1e-9):
+            if not np.allclose(e_spin, e_def, atol=1e-12):
                 c1 = False
-    ok("eta_from_spin_diag yields pure +-1 signs for every (mu,x)", c1)
+    ok("eta_from_spin_diag equals the closed-form eta for every (mu,x)", c1)
     # closed form sign table matches the canonical KS pattern
     ks_ref = {(1,(0,0,0)):1,(2,(1,0,0)):-1,(2,(0,0,0)):1,(3,(1,1,0)):1,(3,(0,1,0)):-1}
     ok("eta closed form matches canonical KS sign table (sample)",
@@ -348,28 +346,71 @@ def check():
        all(np.allclose(anticomm(cx[x], cx[x].conj().T), np.eye(D)) for x in order))
     ok("{c_x, c_y^dag} = 0 for x != y",
        all(np.allclose(anticomm(cx[x], cx[y].conj().T), 0) for (x, y) in pairs))
+    parity = kron_all([SZ] * N)
+    ok("the same global parity anticommutes with both HCB and JW ladders",
+       all(np.allclose(anticomm(parity, bx[x]), 0) for x in order)
+       and all(np.allclose(anticomm(parity, cx[x]), 0) for x in order))
     print()
 
-    # ---- C2: both staggered hopping operators carry the SAME eta and are LOCAL
-    print("C2  staggered KS hopping carries eta in BOTH realizations; both nearest-neighbour LOCAL")
+    # ---- C2: both constructions carry the SAME eta; locality differs by string
+    print("C2  same staggered eta in both realizations; endpoint locality differs by JW string")
     H_hcb = staggered_hopping(order, index, links, N, ladder_HCB, use_eta=True)
     H_jw  = staggered_hopping(order, index, links, N, ladder_JW,  use_eta=True)
     # Both are built from the SAME eta link signs. Confirm each link term in the HCB
     # operator is supported on exactly the 2 endpoint sites (nearest-neighbour local).
     hcb_local = True
-    for (mu, x, y) in links:
-        e = eta(mu, x)
-        ax, ay = bx[x], bx[y]
-        term = 0.5 * e * (ay.conj().T @ ax - ax.conj().T @ ay)
-        supp = set(support_sites(term, order, N))
+    eta_coeff_hcb = []
+    eta_coeff_jw = []
+    for link in links:
+        mu, x, y = link
+        signed_term = staggered_hopping(
+            order, index, [link], N, ladder_HCB, use_eta=True
+        )
+        unsigned_term = staggered_hopping(
+            order, index, [link], N, ladder_HCB, use_eta=False
+        )
+        supp = set(support_sites(signed_term, order, N))
         if not supp.issubset({x, y}):
             hcb_local = False
+        eta_coeff_hcb.append(
+            np.vdot(unsigned_term, signed_term)
+            / np.vdot(unsigned_term, unsigned_term)
+        )
     ok("HCB staggered hopping: every link term supported on its 2 endpoints (local)", hcb_local)
-    ok("HCB and JW staggered operators use the IDENTICAL eta sign on every link",
-       True)  # by construction both call eta(mu,x); shown explicitly here
-    # The eta enters identically; the ONLY difference between H_hcb and H_jw is the
+    jw_endpoint_local = []
+    jw_non_endpoint_local = []
+    for link in links:
+        mu, x, y = link
+        signed_term = staggered_hopping(
+            order, index, [link], N, ladder_JW, use_eta=True
+        )
+        unsigned_term = staggered_hopping(
+            order, index, [link], N, ladder_JW, use_eta=False
+        )
+        eta_coeff_jw.append(
+            np.vdot(unsigned_term, signed_term)
+            / np.vdot(unsigned_term, unsigned_term)
+        )
+        supp = set(support_sites(signed_term, order, N))
+        lo, hi = sorted((index[x], index[y]))
+        expected_support = {order[position] for position in range(lo, hi + 1)}
+        ok(f"JW link {x}-{y}: tensor support equals its ordered endpoint interval",
+           supp == expected_support)
+        if supp.issubset({x, y}):
+            jw_endpoint_local.append((mu, x, y))
+        else:
+            jw_non_endpoint_local.append((mu, x, y, tuple(sorted(supp))))
+    eta_reference = np.array(
+        [eta_from_spin_diag(mu, x) for (mu, x, _) in links], dtype=complex
+    )
+    ok("isolated hopping-builder projections match the spin-diagonal eta table",
+       np.allclose(eta_coeff_hcb, eta_reference)
+       and np.allclose(eta_coeff_jw, eta_reference))
+    ok("JW hopping: exactly 8/12 geometric NN link terms carry non-endpoint string support",
+       len(jw_non_endpoint_local) == 8 and len(jw_endpoint_local) == 4)
+    # The eta enters identically; the difference between H_hcb and H_jw is the
     # ladder dressing (the string), not eta.
-    ok("H_hcb != H_jw (they differ ONLY by the JW string, not by eta)",
+    ok("H_hcb != H_jw (they differ by the JW string, not by eta)",
        not np.allclose(H_hcb, H_jw))
     print()
 
@@ -381,18 +422,16 @@ def check():
         np.allclose(anticomm(cx_no_string[x], cx_no_string[y]), 0) for (x, y) in pairs)
     ok("drop string, KEEP eta  ->  cross-site CAR FAILS (eta cannot supply CAR)",
        not car_holds_without_string)
-    # (b) DROP eta (use_eta=False everywhere), KEEP the string -> CAR still holds
-    cx_no_eta = {x: ladder_JW(x, order, index, N) for x in order}  # string present, eta irrelevant to ladder
-    # the ladder operators themselves do not contain eta at all; eta is only in H.
+    # (b) DROP eta in the kinetic operator, KEEP the string -> H changes while
+    # the already constructed JW ladders continue to satisfy CAR.
+    H_jw_no_eta = staggered_hopping(
+        order, index, links, N, ladder_JW, use_eta=False
+    )
     car_holds_without_eta = all(
-        np.allclose(anticomm(cx_no_eta[x], cx_no_eta[y]), 0) for (x, y) in pairs)
-    ok("drop eta, KEEP string   ->  cross-site CAR STILL HOLDS (eta is not the CAR source)",
-       car_holds_without_eta)
-    # (c) eta sign and JW string-sign are different objects: eta is a c-number per link;
-    #     the string sign is an operator sigma_3^(y) on INTERMEDIATE sites.
-    #     Show eta(mu,x) does not appear in c_x at all (c_x is eta-independent):
-    ok("the matter operator c_x is independent of eta (eta lives in the kinetic coefficient, "
-       "the string lives in the operator)", True)
+        np.allclose(anticomm(cx[x], cx[y]), 0) for (x, y) in pairs
+    )
+    ok("drop eta, KEEP string   ->  kinetic operator changes and cross-site CAR holds",
+       not np.allclose(H_jw_no_eta, H_jw) and car_holds_without_eta)
     print()
 
     # ---- C6: same ungraded algebra on a subpatch (statistics is a frame choice)
@@ -424,7 +463,7 @@ def check():
     print()
 
     # ---- C7: locality horn -- the JW string is non-local; no order kills it
-    print("C7  locality horn: JW string is genuinely NON-local on Z^3 (2x2x2 bandwidth > 1)")
+    print("C7  ungraded tensor locality horn: JW tails are non-endpoint-local on the 2x2x2 patch")
     bw = grid_bandwidth_min(order, links)
     ok(f"min grid-graph bandwidth over ALL orderings = {bw} > 1 "
        "(no total order makes every NN link string-free)", bw > 1)
@@ -439,10 +478,6 @@ def check():
     ok(f"lexicographic slow-axis NN link {s_lo}-{s_hi} spans {span} positions "
        f"=> string non-trivial over intermediate sites {string_support}",
        span > 1 and len(string_support) > 0)
-    # the matter operator being LOCAL (single-site b_x) is consistent with NO string
-    # => locality does not force the string => does not force CAR.
-    ok("a maximally-local matter operator (single-site b_x) carries NO string => "
-       "locality does NOT force the JW string / CAR", True)
     print()
 
     print("="*72)


### PR DESCRIPTION
## Summary
- repair the KS/JW runner artifact identified by independent audit
- test every JW nearest-neighbor link against its exact ordered-interval tensor support
- make the eta coefficient check traverse the hopping builder and compare with the independent spin-diagonal construction
- add the complete N1-N8 scope packet and current-ledger retained-context bounds

## Validation
- runner: PASS=35, FAIL=0
- runner cache hash and stdout match
- Python compilation passes
- vocabulary lint passes
- audit pipeline and strict lint pass with no errors; changed claim requeues as no_go/unaudited
- independent Physics/Nature, CodeRunner/Governance, and No-Go Discipline reviews: PASS

## Audit repair target
The previous C2 headline asserted nearest-neighbor locality for both realizations while the runner established endpoint locality for HCB but did not assert the non-endpoint JW support carried by the ordering string. This PR tests the exact support of all 12 JW links and preserves the finite, ungraded-tensor scope.