### PR TITLE
science: equipartition endpoints are registration-asymmetric on the tied section — r=1 forced degenerate, r=1/2 hosts an open Q=2/3 sector (rhalf block 12)

### DIFF
--- a/docs/KOIDE_EQUIPARTITION_ENDPOINT_REGISTRATION_ASYMMETRY_BOUNDED_THEOREM_NOTE_2026-07-12.md
+++ b/docs/KOIDE_EQUIPARTITION_ENDPOINT_REGISTRATION_ASYMMETRY_BOUNDED_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,427 @@
+# Equipartition Endpoints Are Registration-Asymmetric on the Tied First-Order Section — the `r = 1` Positive Branch Is Forced to `(3a,0,0)`, While `r = 1/2` Has an Open Three-Distinct Positive Sector with `Q = 2/3`; Allowing Signs Restores `r = 1` Non-Degeneracy but Unpins `Q` (Bounded Theorem, rhalf block 12)
+
+**Date:** 2026-07-12
+**Claim type:** bounded_theorem (exact tied-section positivity-window and
+endpoint registration-compatibility asymmetry, conditional on explicitly
+named unadopted identification elements). This source note does not set or
+predict an audit outcome, adopt any premise, derive either equipartition
+endpoint, or edit any audit-lane-owned registry or data file.
+**Primary runner:**
+[`scripts/frontier_equipartition_endpoint_registration_asymmetry_2026_07_12.py`](../scripts/frontier_equipartition_endpoint_registration_asymmetry_2026_07_12.py)
+**Runner cache:**
+[`logs/runner-cache/frontier_equipartition_endpoint_registration_asymmetry_2026_07_12.txt`](../logs/runner-cache/frontier_equipartition_endpoint_registration_asymmetry_2026_07_12.txt)
+(SCORECARD: PASS=23, FAIL=0)
+
+> **CLAIMED (bounded and conditional):** on block 10's K-tied circulant,
+> the nonnegative-spectrum phase set has nonempty interior exactly for
+> `r < 1`. At the two landed fork endpoints, the positive branch is
+> registration-asymmetric: `r = 1` permits only the phase points with
+> spectrum `(3a,0,0)`, hence violates the same named three-distinct-value
+> comparator used in block 10, whereas `r = 1/2` has the nonempty open sector
+> `0 < |theta| < pi/12 (mod 2pi/3)` with three distinct positive values and
+> `Q = 2/3` identically. If signs are instead allowed and
+> `sqrt(m_k) = |lambda_k|`, `r = 1` regains non-degenerate patterns but `Q`
+> becomes phase-dependent. Every record-facing statement is conditional on
+> the named identification and branch elements below.
+>
+> **NOT CLAIMED:** a derivation or adoption of `r = 1/2`, a rejection of the
+> `r = 1` algebraic endpoint outside the named registration conditions, a
+> discharge of the equipartition/dial residual, an empirical comparison, a
+> premise promotion, or an audit-status change.
+
+## Role and exact boundary
+
+Block 9 landed the two equipartition cells without choosing between them:
+per-real-mode equipartition gives `r = 1`, while per-outcome-cell
+equipartition gives `r = 1/2`. Block 10 forces K-reality into the measure at
+its declared bounded grade and selects the K-tied branch over its all-real
+competitor only after consuming a **named non-degeneracy element**: the
+registered pattern has three distinct values. That element is a
+comparator/premise, labeled and never thresholded.
+
+This block asks the next exact question: once on that tied section, can both
+equipartition endpoints support the registered pattern that block 10's branch
+selection requires?
+
+Take
+
+```text
+a > 0,        b = |b| exp(i theta),        r = |b|^2/a^2 >= 0,
+lambda_k = a + 2|b| cos(theta + 2pi k/3),  k = 0,1,2.
+```
+
+The spectrum is real on the tie. The readout interpretation is **not**
+supplied by the minimal Record axiom and is **not** supplied by the bounded
+R-D anatomy note. This note therefore declares, without adopting, its own
+bridge/modeling element
+
+```text
+B_sqrt:  sqrt(m_k) = lambda_k for each registered member,
+```
+
+together with the positive-branch convention
+
+```text
+B_plus:  lambda_k >= 0 for every k.
+```
+
+Only under `B_sqrt + B_plus` may the signed spectral sums below be read as
+the mass-ratio functional
+
+```text
+Q = (sum_k lambda_k^2)/(sum_k lambda_k)^2.
+```
+
+The sign-allowed alternative is treated separately in T4; it uses
+`m_k = lambda_k^2` and therefore `sqrt(m_k) = |lambda_k|`.
+
+## T1 — exact positivity window for general `r`
+
+Define the reduced phase distance
+
+```text
+delta(theta) = dist(theta, (2pi/3) Z),      0 <= delta <= pi/3.
+```
+
+Shifting `theta` by `2pi/3` only permutes the three eigenvalues, and reflection
+of the reduced phase also only permutes their ordering. For
+`0 <= delta <= pi/3`, the cosine multiset can be written as
+
+```text
+{ cos(delta), cos(2pi/3 + delta), cos(2pi/3 - delta) }.
+```
+
+The two gaps above `cos(2pi/3 + delta)` are exactly
+
+```text
+cos(delta)          - cos(2pi/3 + delta)
+  = (3/2)cos(delta) + (sqrt(3)/2)sin(delta) >= 0,
+
+cos(2pi/3 - delta) - cos(2pi/3 + delta)
+  = sqrt(3) sin(delta) >= 0.
+```
+
+Therefore (runner checks 5-8)
+
+```text
+min_k cos(theta + 2pi k/3)
+  = -cos(pi/3 - delta),
+
+lambda_min(theta)
+  = a - 2|b| cos(pi/3 - delta).
+```
+
+This decreases monotonically as `delta` runs from `0` to `pi/3`; its best and
+worst values are `a-|b|` and `a-2|b|`. For `r > 0`, the exact condition is
+
+```text
+lambda_k >= 0 for all k
+  iff min_k cos(theta + 2pi k/3) >= -1/(2sqrt(r))
+  iff 1 - 2sqrt(r) cos(pi/3-delta) >= 0.
+```
+
+For `1/4 <= r <= 1`, let
+
+```text
+alpha(r) = pi/3 - arccos(1/(2sqrt(r))).
+```
+
+The complete phase classification is:
+
+| range | nonnegative phase set | strictly positive phase set |
+|---|---|---|
+| `r = 0` | every phase | every phase |
+| `0 < r < 1/4` | every phase | every phase |
+| `r = 1/4` | every phase | `delta < pi/3` |
+| `1/4 < r < 1` | `delta <= alpha(r)` | `delta < alpha(r)` |
+| `r = 1` | `delta = 0` | empty |
+| `r > 1` | empty | empty |
+
+Equivalently in `(a,|b|)` coordinates:
+
+- `a >= 2|b|`: every phase is nonnegative;
+- `|b| < a < 2|b|`: closed windows of half-width
+  `pi/3 - arccos(a/(2|b|))` surround `theta = 0 (mod 2pi/3)`;
+- `a = |b|`: only those center points remain;
+- `a < |b|`: no phase is nonnegative.
+
+Thus the nonnegative phase set has **nonempty interior iff `r < 1`**. The
+separate non-degeneracy statement is also exact. For `|b| > 0`, the product
+of pairwise spectral differences is (runner check 16)
+
+```text
+(lambda_0-lambda_1)(lambda_0-lambda_2)(lambda_1-lambda_2)
+  = -6sqrt(3)|b|^3 sin(3theta).
+```
+
+Hence the three values are distinct exactly when
+`theta != 0 (mod pi/3)`. A strictly positive, three-distinct phase sector
+therefore exists **iff `0 < r < 1`**. At `r = 0` all three values equal `a`;
+at `r = 1` positivity leaves only a degenerate center point.
+
+### The two endpoint windows
+
+At `r = 1/2`, `|b| = a/sqrt(2)` and
+
+```text
+alpha(1/2) = pi/3 - arccos(1/sqrt(2)) = pi/12.
+```
+
+Thus nonnegativity holds exactly for
+`delta <= pi/12`; the boundary `delta = pi/12` has one exact zero. The open
+interior `delta < pi/12` is strictly positive, and deleting the collision
+point `delta = 0` leaves the nonempty open, three-distinct sector
+
+```text
+0 < delta(theta) < pi/12.
+```
+
+Choosing the representative nearest `theta = 0`, this is
+`0 < |theta| < pi/12 (mod 2pi/3)`.
+
+At `r = 1`, `|b| = a` and `alpha(1) = 0`: the window degenerates to the
+measure-zero point set `theta = 0 (mod 2pi/3)`.
+
+> **T1.** The tied circulant has a genuinely open nonnegative phase window
+> exactly for `r < 1`; it has a positive, non-degenerate window exactly for
+> `0 < r < 1`. The `r = 1/2` half-width is exactly `pi/12`, while the `r = 1`
+> phase set is zero-width.
+
+## T2 — the per-real-mode endpoint is registration-incompatible on the positive branch
+
+At `r = 1`, T1 forces `theta = 0 (mod 2pi/3)`. After the harmless spectral
+permutation induced by the phase representative,
+
+```text
+(lambda_0, lambda_1, lambda_2) = (3a, 0, 0),
+(m_0,      m_1,      m_2)      = (9a^2, 0, 0).
+```
+
+The two doublet members are equal, both before and after squaring. Therefore
+the registered pattern has at most two distinct values and fails block 10's
+same named element
+
+```text
+ND_3: the registered pattern has three distinct values.
+```
+
+`ND_3` is used only at its declared grade: a labeled comparator/premise, with
+no threshold and no numerical data comparison.
+
+> **T2.** Conditional on block 10's tied-section result, `B_sqrt`, `B_plus`,
+> and the same named `ND_3` element, the per-real-mode endpoint `r = 1`
+> cannot host a non-degenerate nonnegative registered spectrum at all. This
+> is a registration-compatibility result, not a derivation that algebraically
+> forbids `r = 1` outside those conditions.
+
+## T3 — the per-outcome-cell endpoint hosts a registrable sector
+
+The two trace identities are phase-free (runner checks 2-4):
+
+```text
+sum_k lambda_k   = 3a,
+sum_k lambda_k^2 = 3a^2 + 6|b|^2.
+```
+
+On `B_sqrt + B_plus`, they give
+
+```text
+Q = (sum_k m_k)/(sum_k sqrt(m_k))^2
+  = (sum_k lambda_k^2)/(sum_k lambda_k)^2
+  = (3a^2 + 6|b|^2)/(9a^2)
+  = (1 + 2r)/3.
+```
+
+At `r = 1/2`, this is identically
+
+```text
+Q = 2/3,
+```
+
+independently of `theta`. By T1, every phase in
+`0 < delta(theta) < pi/12` has three distinct positive `lambda_k`. Squaring
+preserves their distinctness because they are positive, so the registered
+`m_k` also satisfy `ND_3`. This is a nonempty open registrable sector, not a
+single fitted phase.
+
+> **T3.** Conditional on `B_sqrt`, `B_plus`, and `ND_3`, the
+> per-outcome-cell endpoint `r = 1/2` hosts a nonempty open non-degenerate
+> positive sector, and `Q = 2/3` everywhere on it. This **does not derive
+> `r = 1/2`**. It proves only that the already-landed `r = 1/2` fork endpoint
+> has a registrable non-degenerate sector while the `r = 1` endpoint has none
+> on the positive branch.
+
+## T4 — allowing signs restores `r = 1` non-degeneracy but unpins `Q`
+
+Consider instead the explicitly different branch
+
+```text
+B_abs:  m_k = lambda_k^2,       sqrt(m_k) = |lambda_k|,
+```
+
+with no requirement that every `lambda_k` be nonnegative. Then
+
+```text
+Q_abs(theta)
+  = (sum_k lambda_k^2)/(sum_k |lambda_k|)^2.
+```
+
+At `r = 1`, the numerator remains the phase-free value `9a^2`, but the
+absolute-value denominator is not the signed trace `3a`. Normalize `a = 1`,
+which leaves `Q_abs` unchanged. At the exact non-degenerate point
+`theta = pi/6`,
+
+```text
+lambda = (1+sqrt(3), 1-sqrt(3), 1),
+m      = (4+2sqrt(3), 4-2sqrt(3), 1),
+
+sum |lambda_k| = 1 + 2sqrt(3),
+Q_abs(pi/6)    = 9/(13+4sqrt(3)) ~= 0.4516.
+```
+
+All three `m_k` are distinct. A second exact non-degenerate point is
+`theta = pi/12`, where
+
+```text
+lambda = (
+  1 + (sqrt(6)+sqrt(2))/2,
+  1 - sqrt(2),
+  1 - (sqrt(6)-sqrt(2))/2
+),
+
+sign(lambda)       = (+,-,+),
+sum |lambda_k|     = 1 + 2sqrt(2),
+Q_abs(pi/12)       = 9/(9+4sqrt(2)).
+```
+
+The three squared values are again distinct, and
+
+```text
+9/(13+4sqrt(3)) != 9/(9+4sqrt(2)).
+```
+
+Thus fixing `r = 1` fixes the quadratic numerator but not the absolute-value
+denominator. The phase remains a live input, so the per-real-mode law alone
+selects no value of `Q` on `B_abs`.
+
+> **T4.** On the sign-allowed branch, the `r = 1` endpoint regains
+> non-degenerate registered spectra, but `Q` is phase-dependent. Within the
+> two endpoints of the landed equipartition fork, the per-real-mode law
+> therefore either violates `ND_3` (`B_plus`) or pins no `Q` (`B_abs`). The
+> per-outcome-cell endpoint is the unique fork endpoint compatible with both
+> a non-degenerate registered pattern and a pinned `Q`, **conditional on**
+> the tied-section result, the branch-appropriate identification
+> (`B_sqrt + B_plus` or `B_abs`), and `ND_3`. This conditional compatibility
+> does not choose or derive the endpoint.
+
+## Source grades and the R-D boundary
+
+Only the four bounded sources authorized for this block are used.
+
+- **Block 9 — bounded theorem, no adoption/status authority.**
+  [`KOIDE_FIRST_ORDER_SECTION_TIE_VS_OUTCOME_LABEL_RESIDUAL_LOCALIZATION_BOUNDED_THEOREM_NOTE_2026-07-11.md`](KOIDE_FIRST_ORDER_SECTION_TIE_VS_OUTCOME_LABEL_RESIDUAL_LOCALIZATION_BOUNDED_THEOREM_NOTE_2026-07-11.md)
+  supplies the landed two-cell equipartition arithmetic and the real tied
+  spectrum. It explicitly leaves the `r = 1` versus `r = 1/2` binary open.
+- **Block 10 — bounded theorem, no adoption/status authority.**
+  [`RECORDS_ONLY_OS_RECONSTRUCTION_UNTIED_FIRST_ORDER_MEASURE_BOUNDED_THEOREM_NOTE_2026-07-11.md`](RECORDS_ONLY_OS_RECONSTRUCTION_UNTIED_FIRST_ORDER_MEASURE_BOUNDED_THEOREM_NOTE_2026-07-11.md)
+  supplies the tied-section branch result at its declared grade and names
+  `ND_3` as a comparator/premise, labeled and never thresholded. It also says
+  the per-cell equipartition/dial law remains untouched.
+- **Minimal axioms — current axiom memo, not a spectral bridge.**
+  [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) says that
+  only records are readable and scalar readout is additive over disjoint
+  records. Its Qualification requires a derivation, bridge, admission, or
+  approved primitive registration for further structure. It does not map a
+  circulant eigenvalue to a registered mass.
+- **R-D anatomy — source proposal, independent audit required.** Read once
+  from
+  `origin/main:docs/RD_BRIDGE_ANATOMY_AGREEMENT_CONDITIONED_DOUBLE_REGISTRATION_BOUNDED_NOTE_2026-06-12.md`.
+  Its own status says **“source proposal; independent audit required”** and
+  that it does not adopt R-D, fix `r`, or provide status authority. What it
+  actually carries is the supplied singlet/doublet projector surface, the
+  conditional bookkeeping `(p_s,p_d) = (a^2,2|b|^2)`, idempotent pinching,
+  the agreement-conditioned map `r -> 2r^2`, its inverse, and the unresolved
+  independent-composition statistics atom. It **does not carry**
+  `sqrt(m_k) = lambda_k`, a per-member spectral-to-mass map, or the
+  nonnegative-eigenvalue branch. `B_sqrt`, `B_plus`, and the alternative
+  `B_abs` are therefore this note's own explicitly unadopted modeling
+  elements; they are not laundered through R-D or Record.
+
+## Residual Atoms
+
+1. **`B_sqrt`, the spectral square-root identification** —
+   `sqrt(m_k) = lambda_k` per registered member. This note's own declared
+   bridge/modeling element; unadopted and load-bearing for T2-T3.
+2. **The branch convention** — `B_plus` requires all `lambda_k >= 0` and
+   permits the signed trace in `Q`; `B_abs` instead registers
+   `m_k = lambda_k^2` and uses `|lambda_k|`. Neither branch is adopted here.
+3. **`ND_3`, the non-degeneracy element** — the registered pattern has three
+   distinct values. Inherited from block 10 at exactly its comparator/premise
+   grade, labeled and never thresholded; no numerical dataset is consumed.
+4. **The equipartition/dial-point law** — per-real-mode versus
+   per-outcome-cell equipartition remains the unresolved selector between
+   `r = 1` and `r = 1/2`. This note reshapes the endpoints' conditional
+   registration compatibility and does not discharge the selector.
+5. **The K-tied section** — consumed only at block 10's declared bounded
+   grade and conditional on that note's own supplied elements. This note does
+   not independently derive the tie or enlarge its scope.
+6. **The `C_3` circulant spectral model** — inherited from block 9 as the
+   declared probe coupling, not derived here as a physical mass operator.
+7. **The R-D statistics atom** — independent composition of repeated
+   registration on the conditional weight bookkeeping remains unresolved;
+   this note neither uses nor discharges it.
+
+## What This Does Not Claim
+
+- **Not** a derivation, adoption, or empirical selection of `r = 1/2` or
+  `r = 1`. The equipartition/dial residual survives intact.
+- **Not** an unconditional record-layer prediction. T2-T4 are conditional on
+  the explicitly named identification, branch, non-degeneracy, and tied-
+  section elements at their declared grades.
+- **Not** a claim that the minimal Record axiom or the R-D source supplies a
+  spectral-to-mass identification; neither does.
+- **Not** a thresholded notion of non-degeneracy and not a fitted phase. The
+  condition is exact pairwise inequality, and the T3 sector is open.
+- **Not** a universal exclusion of the per-real-mode endpoint. The theorem is
+  the branch dichotomy: it is incompatible with `ND_3` on `B_plus`, while on
+  `B_abs` it supports `ND_3` but does not determine `Q`.
+- **Not** a claim beyond the K-tied three-member circulant and the two landed
+  equipartition endpoints. Other spectral carriers, record maps, or endpoint
+  families are outside scope.
+- **Not** a premise promotion, registry edit, audit verdict, or effective-
+  status change. Independent audit remains required.
+
+## Reprove-and-cite ledger
+
+- **Reproven here (runner, exact SymPy):** phase permutation under
+  `theta -> theta+2pi/3`; the phase-free trace and squared-trace identities;
+  conditional `Q = (1+2r)/3`; the reduced-sector cosine ordering and exact
+  minimum envelope; its monotonicity and the best/worst minima; the complete
+  `(a,|b|)` and `r` positivity-window classification; the exact boundary
+  half-width and its endpoints; the `r = 0` special case; the `pi/12`
+  half-width and zero boundary at `r = 1/2`; the pairwise-difference product
+  and exact degeneracy locus; `Q = 2/3` at `r = 1/2`; the zero-width
+  `(3a,0,0)` spectrum and registered doublet degeneracy at `r = 1`; the
+  `theta = pi/6` sign-branch spectrum, squared pattern, and exact `Q`; the
+  second non-degenerate `theta = pi/12` sign-branch point and its different
+  exact `Q`.
+- **Cited at declared grade:** block 9's two equipartition cells and tied
+  spectrum; block 10's tied-section result, named `ND_3` element, and
+  surviving dial residual; the minimal Record/Qualification boundary; the
+  R-D anatomy note's proposed status, conditional bookkeeping, exact flow
+  anatomy, and unresolved statistics atom.
+- **Declared here, not cited as landed:** `B_sqrt`, `B_plus`, and `B_abs`.
+
+## Verification
+
+```bash
+python3 scripts/frontier_equipartition_endpoint_registration_asymmetry_2026_07_12.py
+python3 scripts/precompute_audit_runners.py --push-mode none --force \
+  --runners scripts/frontier_equipartition_endpoint_registration_asymmetry_2026_07_12.py
+```
+
+Expected: 23 numbered `[PASS]` lines, four declared-open `RESIDUAL` lines,
+then `TOTAL: PASS=23 FAIL=0` and the conditional verdict. Exit code 0 iff
+`FAIL=0`.
+
+**Independent audit required.** This note asserts no effective-status change.

--- a/logs/runner-cache/frontier_equipartition_endpoint_registration_asymmetry_2026_07_12.txt
+++ b/logs/runner-cache/frontier_equipartition_endpoint_registration_asymmetry_2026_07_12.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/frontier_equipartition_endpoint_registration_asymmetry_2026_07_12.py
+runner_sha256: d89b141eeff9dad964674e9d4af5a6a7b7d9a7362e15c6f8d7f13269bb39cd9d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.44
+status: ok
+----- stdout -----
+[01] [PASS] theta -> theta + 2*pi/3 only permutes the tied spectrum
+[02] [PASS] sum_k lambda_k = 3*a is theta-free
+[03] [PASS] sum_k lambda_k**2 = 3*a**2 + 6*|b|**2 is theta-free
+[04] [PASS] on sqrt(m)=lambda, Q=(1+2*r)/3
+[05] [PASS] reduced-sector cosine gaps have manifest nonnegative forms
+[06] [PASS] min_k cos(theta+2*pi*k/3) = -cos(pi/3-delta)
+[07] [PASS] the spectral minimum decreases monotonically across 0<=delta<=pi/3
+[08] [PASS] the best and worst phase minima are a-|b| and a-2|b|
+[09] [PASS] for |b|<a<2|b|, delta=alpha is the exact zero boundary
+[10] [PASS] the intermediate half-width runs from pi/3 to 0
+[11] [PASS] the worst-phase zero is a=2|b| (the all-phase threshold)
+[12] [PASS] the best-phase zero is a=|b| (the open-window threshold)
+[13] [PASS] r=0 is the all-positive but fully degenerate special case
+[14] [PASS] r=1/2 has exact half-width pi/12
+[15] [PASS] the r=1/2 boundary has one exact zero and no negative eigenvalue
+[16] [PASS] the spectrum is distinct iff |b|>0 and sin(3*theta)!=0
+[17] [PASS] r=1/2 pins Q=2/3 on the positive branch
+[18] [PASS] r=1 has only the zero-width phase set and spectrum (3*a,0,0)
+[19] [PASS] r=1 positive-branch registration is doublet-degenerate
+[20] [PASS] sign branch at theta=pi/6 gives the exact supervisor spectrum
+[21] [PASS] theta=pi/6 is non-degenerate and Q=9/(13+4*sqrt(3))
+[22] [PASS] theta=pi/12 is a second exact non-degenerate sign-branch point
+[23] [PASS] the two non-degenerate sign-branch points have different exact Q
+RESIDUAL (declared-open): sqrt(m_k)=lambda_k is this note's unadopted bridge element.
+RESIDUAL (declared-open): lambda_k>=0 is the positive-branch convention.
+RESIDUAL (declared-open): the three-distinct-value comparator is named, not thresholded.
+RESIDUAL (declared-open): the equipartition/dial law still selects neither endpoint.
+TOTAL: PASS=23 FAIL=0
+VERDICT: exact tied-section asymmetry verified conditionally: r=1 has no non-degenerate positive-branch registration, r=1/2 has an open one with Q=2/3, and the sign branch restores non-degeneracy at r=1 only by making Q phase-dependent. No premise is adopted and no audit status is set.
+
+----- stderr -----
+

--- a/scripts/frontier_equipartition_endpoint_registration_asymmetry_2026_07_12.py
+++ b/scripts/frontier_equipartition_endpoint_registration_asymmetry_2026_07_12.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Exact checks for the tied-section equipartition endpoint asymmetry.
+
+This runner proves only finite algebra and trigonometric identities.  The
+spectral-to-record identification and either branch convention are declared
+modeling elements; running these checks does not adopt either element or set
+an audit status.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import sympy as sp
+
+
+PASS = 0
+FAIL = 0
+CHECK = 0
+
+
+def exact_zero(expr: sp.Expr) -> bool:
+    """Return whether SymPy reduces an exact expression to zero."""
+
+    reduced = sp.trigsimp(sp.expand_trig(expr), method="fu")
+    return sp.simplify(reduced) == 0
+
+
+def report(label: str, condition: bool, detail: str = "") -> None:
+    """Print one numbered exact check and update the scorecard."""
+
+    global PASS, FAIL, CHECK
+    CHECK += 1
+    if bool(condition):
+        PASS += 1
+        print(f"[{CHECK:02d}] [PASS] {label}")
+    else:
+        FAIL += 1
+        suffix = f" :: {detail}" if detail else ""
+        print(f"[{CHECK:02d}] [FAIL] {label}{suffix}")
+
+
+def all_zero(expressions: list[sp.Expr]) -> bool:
+    return all(exact_zero(expr) for expr in expressions)
+
+
+def all_distinct(values: list[sp.Expr]) -> bool:
+    return all(
+        not exact_zero(values[i] - values[j])
+        for i in range(len(values))
+        for j in range(i + 1, len(values))
+    )
+
+
+# Structural symbols.  The theorem assumes a > 0, rho = |b| >= 0, and
+# r = rho**2/a**2.  No empirical values enter the runner.
+a = sp.symbols("a", positive=True, real=True)
+rho = sp.symbols("rho", nonnegative=True, real=True)
+r = sp.symbols("r", nonnegative=True, real=True)
+theta = sp.symbols("theta", real=True)
+d = sp.symbols("d", nonnegative=True, real=True)
+pi = sp.pi
+
+
+def lam(k: int, angle: sp.Expr = theta, radius: sp.Expr = rho) -> sp.Expr:
+    return a + 2 * radius * sp.cos(angle + 2 * pi * k / 3)
+
+
+lams = [lam(k) for k in range(3)]
+
+
+# 1--4: phase covariance, theta-free traces, and the conditional Q identity.
+shifted = [lam(k, theta + 2 * pi / 3) for k in range(3)]
+rotated = [lams[1], lams[2], lams[0]]
+report(
+    "theta -> theta + 2*pi/3 only permutes the tied spectrum",
+    all_zero([shifted[k] - rotated[k] for k in range(3)]),
+)
+
+sum_lam = sp.trigsimp(sum(lams), method="fu")
+report("sum_k lambda_k = 3*a is theta-free", exact_zero(sum_lam - 3 * a))
+
+sum_lam_sq = sp.trigsimp(sum(value**2 for value in lams), method="fu")
+report(
+    "sum_k lambda_k**2 = 3*a**2 + 6*|b|**2 is theta-free",
+    exact_zero(sum_lam_sq - (3 * a**2 + 6 * rho**2)),
+)
+
+q_signed = sp.simplify(sum_lam_sq / sum_lam**2)
+q_in_r = sp.simplify(q_signed.subs(rho, a * sp.sqrt(r)))
+report(
+    "on sqrt(m)=lambda, Q=(1+2*r)/3",
+    exact_zero(q_in_r - (1 + 2 * r) / 3),
+)
+
+
+# 5--13: exact reduced-sector minimum and complete general-r window.
+# Reduce theta modulo 2*pi/3 and reflect so 0 <= d <= pi/3.  The three
+# cosines are then the following set.  The displayed gaps are nonnegative on
+# that interval, proving c_min is the minimum without numerical sampling.
+c0 = sp.cos(d)
+c_plus = sp.cos(2 * pi / 3 + d)
+c_minus = sp.cos(2 * pi / 3 - d)
+gap_0 = sp.Rational(3, 2) * sp.cos(d) + sp.sqrt(3) * sp.sin(d) / 2
+gap_minus = sp.sqrt(3) * sp.sin(d)
+report(
+    "reduced-sector cosine gaps have manifest nonnegative forms",
+    all_zero([c0 - c_plus - gap_0, c_minus - c_plus - gap_minus]),
+)
+
+c_envelope = -sp.cos(pi / 3 - d)
+report(
+    "min_k cos(theta+2*pi*k/3) = -cos(pi/3-delta)",
+    exact_zero(c_plus - c_envelope),
+)
+
+lambda_min = sp.simplify(a + 2 * rho * c_envelope)
+report(
+    "the spectral minimum decreases monotonically across 0<=delta<=pi/3",
+    exact_zero(sp.diff(lambda_min, d) + 2 * rho * sp.sin(pi / 3 - d)),
+)
+
+report(
+    "the best and worst phase minima are a-|b| and a-2|b|",
+    all_zero(
+        [
+            lambda_min.subs(d, 0) - (a - rho),
+            lambda_min.subs(d, pi / 3) - (a - 2 * rho),
+        ]
+    ),
+)
+
+alpha = pi / 3 - sp.acos(a / (2 * rho))
+report(
+    "for |b|<a<2|b|, delta=alpha is the exact zero boundary",
+    exact_zero(lambda_min.subs(d, alpha)),
+)
+
+report(
+    "the intermediate half-width runs from pi/3 to 0",
+    exact_zero(alpha.subs(a, 2 * rho) - pi / 3)
+    and exact_zero(alpha.subs(a, rho)),
+)
+
+report(
+    "the worst-phase zero is a=2|b| (the all-phase threshold)",
+    exact_zero(lambda_min.subs(d, pi / 3) - (a - 2 * rho)),
+)
+
+report(
+    "the best-phase zero is a=|b| (the open-window threshold)",
+    exact_zero(lambda_min.subs(d, 0) - (a - rho))
+    and exact_zero(lambda_min.subs(d, pi / 3) - (a - 2 * rho)),
+    "The equivalence follows from the monotone envelope on 0<=delta<=pi/3.",
+)
+
+rho_zero_lams = [sp.simplify(value.subs(rho, 0)) for value in lams]
+report(
+    "r=0 is the all-positive but fully degenerate special case",
+    all_zero([value - a for value in rho_zero_lams]),
+)
+
+
+# 14--19: the r=1/2 and r=1 endpoint comparison, including degeneracy.
+alpha_r = pi / 3 - sp.acos(1 / (2 * sp.sqrt(r)))
+report(
+    "r=1/2 has exact half-width pi/12",
+    exact_zero(alpha_r.subs(r, sp.Rational(1, 2)) - pi / 12),
+)
+
+rhalf_radius = a / sp.sqrt(2)
+rhalf_boundary = [lam(k, pi / 12, rhalf_radius) for k in range(3)]
+report(
+    "the r=1/2 boundary has one exact zero and no negative eigenvalue",
+    any(exact_zero(value) for value in rhalf_boundary)
+    and all(bool(sp.simplify(value >= 0)) for value in rhalf_boundary),
+)
+
+pair_difference_product = (
+    (lams[0] - lams[1])
+    * (lams[0] - lams[2])
+    * (lams[1] - lams[2])
+)
+disc_target = -6 * sp.sqrt(3) * rho**3 * sp.sin(3 * theta)
+report(
+    "the spectrum is distinct iff |b|>0 and sin(3*theta)!=0",
+    exact_zero(pair_difference_product - disc_target),
+)
+
+rhalf_q = sp.simplify(q_in_r.subs(r, sp.Rational(1, 2)))
+report("r=1/2 pins Q=2/3 on the positive branch", rhalf_q == sp.Rational(2, 3))
+
+rone_radius = a
+rone_center = [sp.trigsimp(lam(k, 0, rone_radius)) for k in range(3)]
+report(
+    "r=1 has only the zero-width phase set and spectrum (3*a,0,0)",
+    exact_zero(alpha_r.subs(r, 1))
+    and all_zero(
+        [
+            rone_center[0] - 3 * a,
+            rone_center[1],
+            rone_center[2],
+        ]
+    ),
+)
+
+rone_registered = [sp.expand(value**2) for value in rone_center]
+report(
+    "r=1 positive-branch registration is doublet-degenerate",
+    exact_zero(rone_registered[1] - rone_registered[2])
+    and exact_zero(rone_registered[1]),
+)
+
+
+# 20--23: sign-allowed branch at r=1.  Normalize a=1; scale cancels from Q.
+def normalized_rone(angle: sp.Expr) -> list[sp.Expr]:
+    return [sp.trigsimp(1 + 2 * sp.cos(angle + 2 * pi * k / 3)) for k in range(3)]
+
+
+pi6_lam = normalized_rone(pi / 6)
+pi6_expected = [1 + sp.sqrt(3), 1 - sp.sqrt(3), 1]
+pi6_m = [sp.expand(value**2) for value in pi6_lam]
+pi6_m_expected = [4 + 2 * sp.sqrt(3), 4 - 2 * sp.sqrt(3), 1]
+report(
+    "sign branch at theta=pi/6 gives the exact supervisor spectrum",
+    all_zero([pi6_lam[k] - pi6_expected[k] for k in range(3)])
+    and all_zero([pi6_m[k] - pi6_m_expected[k] for k in range(3)]),
+)
+
+pi6_abs_sum = sp.simplify(sum(sp.Abs(value) for value in pi6_lam))
+pi6_q = sp.simplify(sum(pi6_m) / pi6_abs_sum**2)
+report(
+    "theta=pi/6 is non-degenerate and Q=9/(13+4*sqrt(3))",
+    all_distinct(pi6_m)
+    and exact_zero(pi6_abs_sum - (1 + 2 * sp.sqrt(3)))
+    and exact_zero(pi6_q - 9 / (13 + 4 * sp.sqrt(3))),
+)
+
+pi12_lam = normalized_rone(pi / 12)
+pi12_m = [sp.expand(value**2) for value in pi12_lam]
+pi12_abs_sum = sp.simplify(sum(sp.Abs(value) for value in pi12_lam))
+pi12_q = sp.simplify(sum(pi12_m) / pi12_abs_sum**2)
+report(
+    "theta=pi/12 is a second exact non-degenerate sign-branch point",
+    bool(sp.simplify(pi12_lam[0] > 0))
+    and bool(sp.simplify(pi12_lam[1] < 0))
+    and bool(sp.simplify(pi12_lam[2] > 0))
+    and all_distinct(pi12_m),
+)
+
+report(
+    "the two non-degenerate sign-branch points have different exact Q",
+    exact_zero(pi12_abs_sum - (1 + 2 * sp.sqrt(2)))
+    and exact_zero(pi12_q - 9 / (9 + 4 * sp.sqrt(2)))
+    and not exact_zero(pi12_q - pi6_q),
+)
+
+
+print("RESIDUAL (declared-open): sqrt(m_k)=lambda_k is this note's unadopted bridge element.")
+print("RESIDUAL (declared-open): lambda_k>=0 is the positive-branch convention.")
+print("RESIDUAL (declared-open): the three-distinct-value comparator is named, not thresholded.")
+print("RESIDUAL (declared-open): the equipartition/dial law still selects neither endpoint.")
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+if FAIL == 0:
+    print(
+        "VERDICT: exact tied-section asymmetry verified conditionally: r=1 has no "
+        "non-degenerate positive-branch registration, r=1/2 has an open one with "
+        "Q=2/3, and the sign branch restores non-degeneracy at r=1 only by making "
+        "Q phase-dependent. No premise is adopted and no audit status is set."
+    )
+else:
+    print("VERDICT: verification failed; no theorem verdict is available.")
+
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## rhalf block 12 — equipartition endpoints are registration-asymmetric on the tied section (BOUNDED_THEOREM)

**Stacked on #5193** (base = block 10's branch). Origin: the 2026-07-12 exercise-skill run against the r=1/2 wall; this block hardens supervisor probe P2.

### Result

On block 10's K-tied circulant (`λ_k = a + 2|b|cos(θ + 2πk/3)`, real spectrum), exact positivity-window classification: a genuinely open nonnegative phase window exists **iff r < 1** (all phases valid for r ≤ 1/4; half-width `π/3 − arccos(1/(2√r))` for 1/4 < r < 1; zero width at r = 1). Consequences for the two landed fork endpoints:

- **Per-real-mode endpoint (r = 1): registration-incompatible on the positive branch.** Positivity forces the spectrum to exactly `(3a, 0, 0)` — the doublet degenerate at zero — violating the same named three-distinct-value element (ND₃) block 10's branch selection consumes.
- **Per-outcome-cell endpoint (r = 1/2): hosts an open registrable sector.** `0 < |θ| < π/12` gives three distinct positive values with `Q = 2/3` identically — an open sector, not a fitted phase.
- **Sign-allowed branch dichotomy:** allowing negative λ (registered m = λ², √m = |λ|) restores r = 1 non-degeneracy but unpins Q entirely (two exact points: `Q = 9/(13+4√3)` at θ = π/6 vs `Q = 9/(9+4√2)` at θ = π/12). So within the tied measure the per-real-mode law either violates ND₃ or pins no Q; **the per-cell law is the unique fork endpoint compatible with both a non-degenerate registered pattern and a pinned Q** — conditional on the named elements.

### Honesty boundary

The spectral identification `√m_k = λ_k` (B_sqrt) and the branch conventions (B_plus / B_abs) are this note's **own declared, unadopted** modeling elements — the R-D anatomy note was read and provably does *not* carry them (it carries projector bookkeeping, the agreement-conditioned r → 2r² flow, and the unresolved statistics atom). ND₃ is inherited at exactly its comparator/premise grade, labeled, never thresholded; no PDG values, no fitted phase consumed. **This does not derive r = 1/2** — the equipartition/dial residual survives; the theorem reshapes the endpoints' registration-compatibility only.

### Runner

`scripts/frontier_equipartition_endpoint_registration_asymmetry_2026_07_12.py` — exact sympy (trig identities via manifest nonnegative gap forms, no numerics on derivation paths). **PASS=23 FAIL=0**, exit 0, cache regenerated. Supervisor re-ran independently.

**Executor disclosure:** executor = codex gpt-5.6-sol (max reasoning) under supervisor review (Claude Fable 5: spec, probe verification, line-by-line review, independent re-run). No premise adopted; no audit status set. Independent audit required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
