### PR TITLE
science: K-symmetrized untied measure — records-only reconstruction test (rhalf block 16)

### DIFF
--- a/docs/KOIDE_K_SYMMETRIZED_UNTIED_MEASURE_RECORDS_ONLY_RECONSTRUCTION_BOUNDED_THEOREM_NOTE_2026-07-12.md
+++ b/docs/KOIDE_K_SYMMETRIZED_UNTIED_MEASURE_RECORDS_ONLY_RECONSTRUCTION_BOUNDED_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,589 @@
+# K-Symmetrized Untied Measure Records-Only Reconstruction — θ-Invariance Restores Hermiticity for Every Untied Coupling; Positivity Holds on a Nonempty Open Domain and Fails on Another; K-to-Measure Licensing and Many-Slice Transfer Remain Open; the Ordinary Doubled Gaussian Does Not Realize the Orbit Sum, and Uniform Doubling Preserves the Count-Once Comparator (Bounded Theorem, rhalf block 16)
+
+**Date:** 2026-07-12
+**Claim type:** `bounded_theorem` (exact two-slice Hermiticity theorem, exact
+mixed-domain signature certificates, and bounded licensing/transfer
+classification). This note adopts no premise, sets no audit status, and edits
+no registry or audit-lane data.
+**Primary runner:**
+[`scripts/frontier_k_symmetrized_untied_measure_2026_07_12.py`](../scripts/frontier_k_symmetrized_untied_measure_2026_07_12.py)
+**Runner cache:**
+[`logs/runner-cache/frontier_k_symmetrized_untied_measure_2026_07_12.txt`](../logs/runner-cache/frontier_k_symmetrized_untied_measure_2026_07_12.txt)
+(SCORECARD: PASS=19, FAIL=0)
+
+> **T2 SIGNATURE VERDICT FIRST — MIXED DOMAIN.** On the block-10 registrable
+> spanning set, the normalized K-symmetrized records-only Gram is exactly
+> **positive definite at both required genuinely complex untied probes**, so
+> positivity is not confined to the block-10 two-branch weight-reality set.
+> It is exactly **indefinite** at `W=iI` and at twice the first probe, with
+> strict negative rational principal minors; the second failure has
+> `Z_sym>0`. Strict signs give nonempty open PD and indefinite neighborhoods.
+> Thus the construction restores positivity **on a domain, not universally**.
+> The complete six-real-dimensional boundary is not classified here.
+
+> **Not claimed:** revival of the outcome-stage cell; licensing of K as an
+> input to the weight; a positive probability measure; a Gaussian/local or
+> many-slice transfer law; a global PSD-domain classification; a derivation or
+> adoption of either `r` endpoint; a resolution of the equipartition/dial or
+> formation-weight residues; a physical Krein reconstruction; or any premise,
+> registry, or audit-status change. **Claimed (bounded):** T1–T4 below at the
+> two-slice `C₃`-circulant and five-element registrable-spanning-set grade.
+
+## Role — the genuinely open block-10/11 escape tested here
+
+Block 10,
+[`RECORDS_ONLY_OS_RECONSTRUCTION_UNTIED_FIRST_ORDER_MEASURE_BOUNDED_THEOREM_NOTE_2026-07-11.md`](RECORDS_ONLY_OS_RECONSTRUCTION_UNTIED_FIRST_ORDER_MEASURE_BOUNDED_THEOREM_NOTE_2026-07-11.md),
+proved that the time-homogeneous **single Gaussian** untied measure has a
+Hermitian records-only OS Gram only on its two K-real branches: the K-tie and
+the all-real branch. It left a modified/non-OS emergent-time construction
+genuinely open and rejected the alternating `W,W†` measure because choosing
+which slice carries the conjugate needs an arrow and explicitly inserts K.
+
+Block 11 (source branch
+`origin/claude/science/rhalf-quasi-hermitian-escape-20260712`) closed a positive
+metric-operator weakening on `W` exactly to the tie. It left an indefinite
+Krein remainder on three transposition branches and a still coarser
+two-slice-factor `A₂` remainder. Neither block tested the arrow-free orbit
+average
+
+```text
+μ_sym(W) = 1/2 [ μ_W + μ_{W†} ]
+         = 1/2 [ exp(χ̄ K(W,W) χ) + exp(χ̄ K(W†,W†) χ) ].          (0.1)
+```
+
+The same time-homogeneous coupling occurs on both slices inside each summand.
+No choice assigns `W` to the future and `W†` to the past: (0.1) averages the
+whole two-slice weight over the K-orbit `{W,W†}`. The question is whether this
+conjugation-pairing move supplies a records-only positive form without paying
+the block-10 arrow cost, and whether it supplies an emergent-time transfer
+rather than only a two-slice functional.
+
+## Setup and notation — raw forms kept separate from normalized forms
+
+Use block 10's three-mode circulant and two-slice kernel,
+
+```text
+C = [[0,1,0], [0,0,1], [1,0,0]],       C³=I,
+W = aI+bC+cC²,
+K(W,W) = [[-W, -1/2 I], [+1/2 I, -W]].                       (0.2)
+```
+
+Let `B_W(O)` be the unnormalized Berezin functional with the first
+exponential in (0.1), and write
+
+```text
+Z_W                 = B_W(1),
+𝒢^W_ij               = B_W(θ(F_i) F_j),
+{F_i}                = {1, N, TCsym, e₂, e₃},
+B_sym(O)             = [B_W(O)+B_W†(O)]/2,
+Z_sym                = B_sym(1),
+𝒢^sym_ij             = B_sym(θ(F_i)F_j),
+G^sym                = 𝒢^sym/Z_sym,             only if Z_sym ≠ 0.       (0.3)
+```
+
+This raw/normalized distinction matters. The raw symmetrized Gram is the
+arithmetic average. The normalized `G^sym` is generally **not** the half-sum
+of the separately normalized component Grams, because their partition
+functions are complex conjugates rather than equal.
+
+## T1 — θ-invariance gives Hermiticity exactly for every untied W
+
+Block 10's reflection identity gives, before normalization,
+
+```text
+Z_{W†} = conjugate(Z_W),
+𝒢^{W†}_ij = conjugate(𝒢^W_ji).                              (1.1)
+```
+
+Equivalently, `θ` exchanges the two measures in (0.1). By linearity,
+
+```text
+θ μ_sym = μ_sym,
+𝒢^sym = [𝒢^W + (𝒢^W)†]/2 = (𝒢^sym)†,                       (1.2)
+Z_sym = [Z_W+conjugate(Z_W)]/2 = Re Z_W.                   (1.3)
+```
+
+Therefore the raw records-only form is Hermitian for **every** untied `W`.
+Where `Z_sym` is nonzero it is real, so division preserves Hermiticity. This
+is an exact sufficiency theorem; unlike block 10's single-Gaussian result, it
+does not require `W†∈{W,PWP}`.
+
+Checks 3–4 verify (1.1)–(1.3) entrywise with the reused exact Berezin engine at
+the two required probes:
+
+```text
+P1 = (a,b,c) = (4/5+i/10, 3/10+i/5, 1/2-i/10),
+     Z_sym = 442243/1000000;
+
+P2 = (a,b,c) = (1, 1/3+i/7, 1/3-i/5),
+     Z_sym = 118339871223181/85766121000000.
+```
+
+Both are genuinely off the block-10 K-tie/all-real union and both normalize.
+
+### The zero-mass locus is real and cannot be divided away
+
+Equation (1.3) defines the normalization domain:
+
+```text
+𝒟_norm = { (a,b,c) : Re det(W²+1/4 I) ≠ 0 }.               (1.4)
+```
+
+Its complement is nonempty even where `Z_W` itself is nonzero. At the exact
+scalar point
+
+```text
+W = (3/8+5i/8) I,
+W²+1/4 I = (15i/32) I,
+Z_W = (15i/32)³ = -3375i/32768 ≠ 0,
+Z_sym = 0.                                                  (1.5)
+```
+
+The raw symmetrized form remains Hermitian there, but there is no normalized
+expectation functional or normalized Gram. No assertion below crosses this
+locus.
+
+## T2 — decisive signature: positivity on a domain, failure on a domain
+
+For a Hermitian `5×5` matrix, nonnegativity of all 31 principal minors is an
+exact PSD criterion; strict positivity of the leading minors is Sylvester's
+PD criterion. The runner evaluates every minor over Gaussian rationals.
+
+### Exact PD at both required genuinely untied probes
+
+At both `P1` and `P2`, **all 31 principal minors are strictly positive exact
+rationals** (checks 6–7). In particular the full determinants are
+
+```text
+det G_sym(P1)
+ = 2481178078125000000000000000
+   /16916278917990800432294819443  > 0,
+
+det G_sym(P2)
+ = 41608903136082324823895797257801559519543346362471875000000000000000
+   /23208948333223840320190645259090098573336248968791134439568823789159901
+   > 0.                                                       (2.1)
+```
+
+Float minimum eigenvalues `≈0.0347416` and `≈0.00738361` are printed only as
+scan context; they do not decide either verdict.
+
+### Exact indefinite witnesses
+
+Symmetrization is not universally positive. Two exact witnesses isolate both
+the normalization-sign issue and a genuine positive-`Z_sym` failure:
+
+| point | `Z_sym` | exact negative principal minor | verdict |
+|---|---:|---:|---|
+| `W=iI` | `-27/64` | `G_sym[N,N] = -44/3` | indefinite |
+| `W=2P1` | `6467077/1000000` | `det G_sym[{TCsym,e₂}] = -7095906000000/41823084923929` | indefinite |
+
+The second row has positive normalization, so failure is not an artifact of
+dividing by a negative `Z_sym` (check 8).
+
+### The exact domain statement, and no stronger one
+
+Matrix entries are rational functions of the six real coupling coordinates
+away from (1.4)'s zero set. Exact strict PD at `P1,P2` therefore persists on
+open neighborhoods. Each strict negative minor likewise persists on open
+neighborhoods of `iI,2P1`. Hence:
+
+> **T2.** The K-symmetrized normalized records-only form is PD on a nonempty
+> open domain and indefinite on another nonempty open domain. It is neither a
+> universal positive reconstruction nor confined to the old K-real branches.
+
+The block-10 controls are recovered exactly (check 10): on the tie the two
+weights coincide; on the all-real branch the two components are related by
+`P`, so their P-even record Grams coincide. The known all-real inside-strip
+point remains PD and the known outside-strip point remains indefinite.
+
+The deterministic six-real-dimensional scan is labeled coverage only. Every
+coordinate component is sampled on a rational grid in `[-R,R]`; float
+eigenvalue **sign**, with no fitted or tolerance threshold, is used only to
+map the following pattern:
+
+| box radius `R` | PD | indefinite | `Z_sym=0` | samples |
+|---:|---:|---:|---:|---:|
+| `1/10` | 24 | 0 | 0 | 24 |
+| `1/5` | 19 | 5 | 0 | 24 |
+| `1/2` | 8 | 15 | 1 | 24 |
+| `3` | 0 | 48 | 0 | 48 |
+
+This supports a bounded-domain reading and warns against extrapolating the two
+favorable probes. It is **not** a theorem that failure is generic, that the
+domain is connected, or that a simple strip controls all six coordinates.
+The full semialgebraic boundary is a Residual Atom.
+
+## T3 — what kind of law/measure this is, and what remains unlicensed
+
+### (i) One answer versus an ensemble representation
+
+For supplied `(W,K)`, equation (0.1) returns exactly one fixed Grassmann
+integrand. On the extensional wording of the Qualification — a law gives one
+answer wherever its supplied condition holds — it therefore satisfies the
+**one-answer** clause. More precisely, it is:
+
+- a finite Grassmann/Berezin **weight**;
+- an unnormalized complex linear functional `B_sym`;
+- a normalized expectation functional only on `𝒟_norm`;
+- a θ-invariant Hermitian records-only form; and
+- on the T2 PD domain, a positive form on the stated registrable spanning set.
+
+It is **not** thereby:
+
+- a positive probability measure;
+- a normalized law on `Z_sym=0`;
+- a Gaussian or a single exponential weight;
+- the output of a landed single-step local bilinear rule;
+- a landed many-slice history law; or
+- a measure derived from the four Minimal Axioms.
+
+It also has an ensemble decomposition at the raw-weight level: it is the
+formal equal average of two component laws. That representation does not make
+it a positive probabilistic mixture. At `P1`, rewriting the normalized
+functional as a combination of the separately normalized component
+functionals gives
+
+```text
+alpha = Z_W/(Z_W+Z_W†) = 1/2 + (128413/442243)i,
+beta  = Z_W†/(Z_W+Z_W†) = 1/2 - (128413/442243)i,
+alpha+beta=1.                                                (3.1)
+```
+
+The coefficients are conjugate but nonreal (check 13). “One weight” and
+“formal ensemble representation” are therefore both correct at their stated
+levels; “positive ensemble of normalized laws” is false at this probe.
+
+### Non-Gaussianity is exact
+
+Let `S=χ̄K(W,W)χ` and `T=χ̄K(W†,W†)χ`. Any single bilinear exponential matching
+the constant and degree-two terms of (0.1) must have action `(S+T)/2`. At
+Grassmann degree four,
+
+```text
+1/2(e^S+e^T) - exp[(S+T)/2]
+    = (S-T)²/8 + higher Grassmann degree.                    (3.2)
+```
+
+At exact `P1`, `(S-T)²/8` is nonzero; the runner finds the first mismatch at
+degree four (723 coefficient masks differ overall, check 12). Thus the
+symmetrized construction is not a single three-mode Gaussian transfer rule at
+the required genuinely untied point. Exceptional fixed points such as the tie,
+where `S=T`, reduce to the original Gaussian as they must.
+
+### (ii) Does the construction pre-insert K?
+
+There are two honest readings.
+
+**Canonical supplied-context reading.** K is stipulated as supplied
+readout-context structure. Once it is supplied, the orbit `{W,W†}` and its
+equal average are canonical. No representative and no time arrow is chosen;
+`μ_sym(W)=μ_sym(W†)` exactly (check 14). This avoids the specific arrow defect
+of the alternating measure.
+
+**Measure-pre-insertion reading.** The construction explicitly applies that K
+involution to the unregistered Berezin weight. The Minimal Axioms memo places
+K/CPT orbit structure downstream of generic axiom content; it does not say
+that readout-context K may generate or modify the measure. On this reading,
+(0.1) promotes the very K structure sought at the outcome/record stage into
+the dynamics and therefore pre-inserts it.
+
+The algebra cannot choose between these readings. The question is retained as
+the first-class Residual Atom **K-ORBIT-AVERAGE LAW/MEASURE LICENSING**. No
+revival claim is available while it remains open.
+
+### (iii) Two-slice homogeneity does not land a many-slice law
+
+The average in (0.1) is global over the whole two-slice weight; it is not an
+independent average on each slice. Each summand is time-homogeneous, but there
+are at least two inequivalent extensions:
+
+```text
+quenched:  choose W or W† once for a complete N-step history,
+           then average the two complete-history weights;
+
+annealed:  average the orbit representative independently per step/link,
+           producing a sum over 2^N assignments.                          (3.3)
+```
+
+For commuting scalar step weights `x,y`, the two prescriptions already give
+`(x²+y²)/2=13/2` and `((x+y)/2)²=25/4` at `(x,y)=(2,3)` (check 15). Neither
+extension is landed. The two-slice construction therefore supplies no single
+transfer power or time-homogeneous many-slice law by itself.
+
+## T4 — doubled carrier: conjugation closure is real, realization fails
+
+### The six-mode carrier is Krein by construction
+
+Put
+
+```text
+D = W ⊕ W†,
+J = [[0,I₃],[I₃,0]].                                         (4.1)
+```
+
+Then exactly
+
+```text
+J D = D† J,      J²=I,      signature(J)=(3,3).              (4.2)
+```
+
+Thus `D` lies on block 11's any-signature conjugation-closed locus by
+construction. This is not a positive-metric escape: at generic nonreal `W`,
+the explicit carrier comes with three negative directions.
+
+There is also a natural doubled **antiunitary**. Let `P` be block 10's real
+generation inversion (`PCP=C²`) and put
+
+```text
+S = [[0,P],[P,0]],          K_D = S followed by scalar conjugation.
+```
+
+For the circulant, `W†=P conjugate(W) P`, so exactly
+
+```text
+S conjugate(D) S = D,       K_D²=1.                            (4.3)
+```
+
+The `K_D`-fixed real form is invariant under `D`. It must not be confused with
+the **linear** positive-eigenvalue half of the indefinite metric `J`. At `P1`,
+`[D,J]≠0`; with `P_J+=(I+J)/2`,
+
+```text
+(I-P_J+) D P_J+ ≠ 0.                                         (4.4)
+```
+
+Thus the K-real carrier is closed, but discarding the three negative `J`
+directions does not supply a closed positive three-complex-mode transfer system
+(check 16).
+
+### A Gaussian direct sum produces a product, not the orbit sum
+
+For Grassmann carriers,
+`Λ(V⊕V̄) ≅ Λ(V)⊗Λ(V̄)`. The Gaussian with coupling `D` consequently factorizes:
+
+```text
+Z_D = Z_W Z_W† = |Z_W|²,                                    (4.5)
+```
+
+not `Z_sym=(Z_W+Z_W†)/2`. For the P-even registrable basis, the natural
+K-paired additive lift of an already formed correlator `O` reduces to
+`O_+=(O_W+O_W†)/2`, gives
+
+```text
+B_D(O_+) = [B_W(O) Z_W† + Z_W B_W†(O)]/2.                   (4.6)
+```
+
+The spectator partition factors in (4.6) are absent from (0.3). At exact
+`P1`, the normalized doubled and symmetrized `5×5` forms differ in 24 entries;
+the first difference, at `(1,N)`, is
+
+```text
+1523664567517428 / 4626542220828959 ≠ 0.                    (4.7)
+```
+
+So the ordinary six-mode doubled Gaussian **does not reproduce** the
+K-symmetrized correlators, even on this natural K-paired additive lift
+(check 17).
+
+A direct-sum **superselection trace** with an exclusive one-of-two sector could
+produce the sum rather than the product, but that requires a sector label and
+a one-hot constraint. It is an ensemble realization added by hand, not the
+Gaussian on `W⊕W†`, and it inherits the T3 licensing and many-slice questions.
+
+### Counting: uniform doubling does not reinstate count-twice
+
+The undoubled `C₃` carrier has one complex singlet plus a two-complex-mode
+doublet: two and four real carrier degrees, respectively. The direct sum
+doubles **both**:
+
+```text
+                 singlet real degrees    doublet real degrees
+undoubled                 2                       4
+W ⊕ W†                    4                       8.             (4.8)
+```
+
+Applying block 10's fork arithmetic without changing its grain rule makes the
+uniform factor cancel. The count-once comparator is
+
+```text
+undoubled:       3 a² = eps,       6 b² = eps,
+doubled:         6 a² = 2 eps,    12 b² = 2 eps,
+both:            b²/a² = 1/2.                                  (4.9)
+```
+
+The doubled count-twice comparator would instead require
+
+```text
+6 a² = 2 eps,    12 b² = 4 eps       =>       b²/a² = 1.        (4.10)
+```
+
+Equation (4.10) does **not** follow from carrier doubling. It requires an extra
+doublet budget or an asymmetric quotient that removes/identifies the duplicated
+singlet without doing the same to the doublet. Either is a new
+formation/equipartition grain rule. The antiunitary K-fixed real form halves
+singlet and doublet uniformly, so it preserves the ratio; the linear `J=+1`
+projection also halves both but, by (4.4), is not transfer-invariant.
+
+> **T4.** Ordinary doubling pays a uniform factor-two carrier overhead and a
+> `(3,3)` Krein form. It neither realizes `μ_sym` nor automatically changes
+> the count-once fork comparator to count-twice. No physical `r` value is
+> inferred from (4.9)–(4.10).
+
+## Licensing consequence — algebraically live, not revived
+
+T1 removes the block-10 Hermiticity obstruction. T2 does more than a purely
+formal repair: there are exact genuinely untied complex points with a positive
+records-only form, and positivity persists on open neighborhoods. But the
+honesty gate for revival has two conjuncts: positivity **and** landed
+licensing. Only the first is met on the T2 PD domain.
+
+The outcome-stage cell is therefore **not revived**. Nor is the route closed
+by a count-twice-doubling no-go: the honest uniform doubled arithmetic leaves
+the count-once comparator unchanged. The bounded result is narrower and more
+useful:
+
+> the two-slice non-Gaussian orbit average is an algebraically viable positive
+> records-only functional on a real domain, while K-to-measure licensing,
+> law/ensemble status, and a many-slice transfer realization remain open; the
+> naive doubled Gaussian is not that realization.
+
+## Escape-table update relative to blocks 10 and 11
+
+| route | disposition after block 16 | exact reason / remaining cost |
+|---|---|---|
+| modified/non-OS emergent time via `μ_sym` | **PARTIALLY REALIZED ALGEBRAICALLY** | T1 Hermitian for every `W`; T2 PD on a nonempty open domain, indefinite on another |
+| K-orbit-average measure licensing | **OPEN — first-class Residual Atom** | supplied-context canonicality versus K-to-weight pre-insertion is not settled |
+| many-slice extension of `μ_sym` | **OPEN** | quenched two-term history average and annealed `2^N`-term average are inequivalent |
+| ordinary Gaussian on `W⊕W†` | **BLOCKED as a realization of `μ_sym`** | K-paired correlators still factor as a product; the K-real form is invariant but the positive `J` half is not; `(3,3)` Krein cost |
+| exclusive-sector/direct-sum trace | **OPEN, additional structure** | reproduces a sum only by adding a one-hot sector law |
+| alternating `W,W†` slice measure | **UNLICENSED (inherited)** | arrow-dependent placement and explicit K pre-insertion |
+| positive metric on `W` | **CLOSED to the tie (block 11)** | no non-tied positive-metric escape |
+| any-signature metric on `W` | **OPEN KREIN remainder (block 11)** | negative norms on the three non-tied transposition branches |
+| condition only on `A₂=W²+1/4I` | **OPEN, strictly coarser (block 11)** | factor condition does not reconstruct the records-only OS form |
+| `Z_sym=0` locus | **NO NORMALIZED CONSTRUCTION** | exact nonempty witness (1.5) |
+| full T2 PSD boundary | **OPEN** | exact open regions landed; no global six-dimensional classification |
+
+This table does not turn an open licensing question into a negative verdict and
+does not let exact two-slice positivity masquerade as a transfer construction.
+
+## Literature precedent — context only
+
+Conjugation/CT organization of complex-action sign problems is standard
+context; see P. N. Meisinger and M. C. Ogilvie,
+[*The Sign Problem, PT Symmetry and Abelian Lattice Duality*,
+arXiv:1306.1495](https://arxiv.org/abs/1306.1495). It is cited only as precedent
+for treating conjugation-paired complex weights. No orbit-average formula,
+Hermiticity statement, positivity domain, principal minor, doubled-carrier
+claim, or licensing conclusion is imported; all results above are proved
+repo-natively by the companion runner.
+
+## Residual Atoms
+
+1. **K-ORBIT-AVERAGE LAW/MEASURE LICENSING (first-class).** Whether supplied
+   readout-context K may canonically act on the unregistered weight or thereby
+   pre-inserts downstream structure. This is the load-bearing revival gate.
+2. **The complete T2 PSD domain.** Exact open PD and indefinite regions are
+   proved; connectedness, analytic boundary, and global genericity are not.
+3. **The `Z_sym=0` set.** Its defining equation is exact and one nontrivial
+   locus is witnessed; its full geometry is not classified.
+4. **Law versus ensemble ontology.** The prescription is extensionally one
+   answer and formally a raw orbit ensemble, but no positive probabilistic or
+   physical ensemble interpretation is supplied.
+5. **Many-slice time law.** Quenched and annealed extensions differ; neither is
+   landed, and no transfer semigroup/power is identified.
+6. **Exclusive-sector realization.** Reproducing a sum instead of the doubled
+   Gaussian product requires a one-hot sector rule and its history behavior.
+7. **Doubled-carrier grain.** Uniform doubling preserves the comparator;
+   changing it requires a new asymmetric quotient or equipartition budget.
+8. **Per-cell equipartition/dial and formation weight.** Entirely untouched;
+   no physical `r` endpoint is derived or adopted.
+9. **Finite spanning-set scope.** Positivity is established/falsified on
+   `{1,N,TCsym,e₂,e₃}` for the two-slice `C₃` circulant. Full record-algebra,
+   interacting, non-circulant, gauge, and higher-slice cases are not classified.
+10. **Inherited block-11 remainders.** Krein reconstruction and the coarser
+    `A₂` condition remain open at that note's stated costs and grades.
+
+## What This Note Does Not Claim
+
+- **Not** revival of the outcome-stage cell: T3 licensing is not landed.
+- **Not** a derivation, selection, prediction, or adoption of `r=1/2` or
+  `r=1`; equations (4.9)–(4.10) only compare the already named fork cells.
+- **Not** a global positivity theorem. Strict exact witnesses prove a mixed
+  domain; scans are labeled and never thresholded.
+- **Not** that Hermiticity implies positivity: T2 supplies exact counterexamples.
+- **Not** a positive probability measure or positive normalized component
+  mixture; (3.1) is an exact obstruction at `P1`.
+- **Not** a Gaussian or local transfer rule; (3.2) and T4 distinguish sum from
+  product.
+- **Not** that doubling restores count-twice. Uniform doubling doubles the
+  singlet and doublet alike.
+- **Not** that a superselection direct sum is forbidden. It is additional,
+  unlanded structure rather than the tested Gaussian carrier.
+- **Not** closure of the block-11 Krein or `A₂` remainders.
+- **Not** premise adoption, empirical comparison, registry change, or audit
+  verdict. No comparator is fitted or thresholded.
+
+## Consumed premises and supplied elements (claim scope)
+
+- **Block-10 two-slice construction and exact engine** —
+  [`RECORDS_ONLY_OS_RECONSTRUCTION_UNTIED_FIRST_ORDER_MEASURE_BOUNDED_THEOREM_NOTE_2026-07-11.md`](RECORDS_ONLY_OS_RECONSTRUCTION_UNTIED_FIRST_ORDER_MEASURE_BOUNDED_THEOREM_NOTE_2026-07-11.md)
+  and
+  [`scripts/frontier_records_only_os_reconstruction_2026_07_11.py`](../scripts/frontier_records_only_os_reconstruction_2026_07_11.py):
+  `W`, the two-slice staggered kernel, `θ`, reflection identity, registrable
+  spanning set, exact probes, all-real strip controls, alternating-measure
+  disposition, and the fork arithmetic. The engine is reused rather than
+  replaced.
+- **Block-11 metric-operator closure** — the note read once from
+  `origin/claude/science/rhalf-quasi-hermitian-escape-20260712`: positive
+  metrics close to the tie; any-signature conjugation closure has four loci;
+  the non-tied Krein and coarser-`A₂` remainders remain open. Those results are
+  cited at their declared grade and not reclassified here.
+- **Minimal Axioms and Qualification** —
+  [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md): a law gives
+  exactly one answer on its supplied condition; a law may not depend on an
+  unfixed choice unless admitted; K/CPT, probability, arrow, time metric, and
+  formation rules are downstream, not generic axiom content.
+- **Literature precedent only** — Meisinger–Ogilvie `arXiv:1306.1495`; no
+  theorem content imported.
+
+## Reprove-and-cite ledger
+
+- **Reproven exactly by the runner:** block-10 engine determinant and toy-Gram
+  controls; `Z_W†=conj Z_W`; raw Gram adjoint relation at both required probes;
+  direct integration of the orbit half-sum; Hermiticity before and after valid
+  normalization; exact zero-`Z_sym` witness; all 31 exact principal-minor signs
+  at `P1,P2`; exact negative minors at `iI,2P1`; inherited tie/all-real controls;
+  degree-four non-Gaussian obstruction; nonreal normalized component weights;
+  K-orbit invariance and tied reduction; annealed/quenched inequivalence;
+  doubled `J` intertwiner/signature, antiunitary K closure, and positive-`J`-half leakage; doubled
+  product-versus-sum correlator mismatch; real-dimension and fork arithmetic;
+  refined escape dispositions.
+- **Floats used only for labeled coverage:** minimum-eigenvalue context at the
+  exact probes and deterministic box scans. No float lies on a derivation path,
+  supplies a threshold, or changes an exact verdict.
+- **Cited at declared grade:** block 10 for the OS/reflection construction and
+  inherited fork/escape rows; block 11 for metric and `A₂` dispositions; the
+  Minimal Axioms memo for Qualification and downstream-structure scope;
+  Meisinger–Ogilvie for literature context only.
+
+## Verification
+
+```bash
+python3 scripts/frontier_k_symmetrized_untied_measure_2026_07_12.py
+```
+
+Expected: 19 numbered `[PASS]` lines, declared-open `RESIDUAL` lines, the T2
+signature verdict first in the final summary, one-sentence T1/T3/T4 outcomes,
+the doubled-carrier counting result, proposed claim scope, hostile-audit
+uncertainties, and `TOTAL: PASS=19 FAIL=0`. Exit code 0 iff `FAIL=0`.
+
+Regenerate the runner cache with
+
+```bash
+python3 scripts/precompute_audit_runners.py --push-mode none --force \
+  --runners scripts/frontier_k_symmetrized_untied_measure_2026_07_12.py
+```
+
+**Independent supervisor review required.** This note asserts no effective-
+status change.

--- a/logs/runner-cache/frontier_k_symmetrized_untied_measure_2026_07_12.txt
+++ b/logs/runner-cache/frontier_k_symmetrized_untied_measure_2026_07_12.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/frontier_k_symmetrized_untied_measure_2026_07_12.py
+runner_sha256: 79851427686ad8d202e648f0d8bfb7157d09a018408f0d55daa367bd57e6e75d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 15.55
+status: ok
+----- stdout -----
+============================================================================
+K-symmetrized untied measure -- records-only reconstruction (rhalf block 16)
+mu_sym = (mu_W + mu_{W^dag})/2; same registrable spanning set
+============================================================================
+[PASS] (01) reused block-10 Grassmann/Berezin engine: exact single-slice partition equals det K to the first power at a dense rational-complex point
+[PASS] (02) reused theta/two-slice engine reproduces block 10's inherited exact toy OS Gram
+[PASS] (03) T1 reflection identity at both required exact untied probes: Z(W^dag)=conj Z(W), G_raw(W^dag)=G_raw(W)^dag entrywise, and direct integration of the half-sum equals the arithmetic orbit average  [P1: Zsym=(442243/1000000+0i); P2: Zsym=(118339871223181/85766121000000+0i)]
+[PASS] (04) T1 exact consequence: theta preserves mu_sym and its raw records-only Gram is Hermitian; at both required probes Z_sym=Re Z_W is nonzero, so the normalized Gram is exactly Hermitian too
+[PASS] (05) normalization guard: Z_sym=Re Z_W is not automatically nonzero.  At W=(3/8+5i/8)I, Z_W=(15i/32)^3=-3375i/32768 is nonzero and purely imaginary, hence Z_sym=0 exactly; the raw symmetrized form remains Hermitian but no normalized Gram exists on this locus
+
+--- T2: exact signature and bounded domain structure ---
+[PASS] (06) required exact untied probe P1: the normalized K-symmetrized 5x5 Gram is POSITIVE DEFINITE -- all 31 principal minors are exact positive rationals (no threshold)  [smallest exact minor (0, 1, 2, 3, 4)=(2481178078125000000000000000/16916278917990800432294819443+0i); float context min-eig=0.0347416]
+[PASS] (07) required exact untied probe P2: the normalized K-symmetrized 5x5 Gram is POSITIVE DEFINITE -- all 31 principal minors are exact positive rationals (no threshold)  [smallest exact minor (0, 1, 2, 3, 4)=(41608903136082324823895797257801559519543346362471875000000000000000/23208948333223840320190645259090098573336248968791134439568823789159901+0i); float context min-eig=0.00738361]
+[PASS] (08) exact failure certificates on both signs/regions: W=iI and W=2P1 have nonzero Z_sym and exactly Hermitian normalized Grams, but each has a strictly negative rational principal minor; 2P1 has Z_sym>0, so failure is not an artifact of a negative normalization  [iI: Zsym=(-27/64+0i), minor(1,)=(-44/3+0i); 2P1: Zsym=(6467077/1000000+0i), minor(2, 3)=(-7095906000000/41823084923929+0i)]
+[PASS] (09) the exact T2 topology is MIXED-DOMAIN: strict PD at P1 and P2 and a strict negative minor at iI and 2P1 imply, by continuity away from Z_sym=0, nonempty open PD neighborhoods and nonempty open indefinite neighborhoods.  Thus symmetrization restores positivity on a domain, not universally
+[PASS] (10) block-10 controls are inherited exactly at records-only grade: mu_sym equals the tied weight on the tie; on the all-real branch its P-even record Gram equals the original Gram, positive inside the known strip and indefinite at the supplied outside point  [tie: PSD=True; real-inside: PSD=True; real-outside: PSD=False]
+[PASS] (11) labeled float-only six-real-dimensional coverage (eigenvalue sign, no threshold) sees the open PD core/tubes and failures as the box widens; this is domain evidence only, not a claimed analytic global boundary  [R=1/10: {'PD': 24, 'INDEF': 0, 'Z0': 0}, min-eig-range=[0.6985358701664226, 0.9997904979901552]; R=1/5: {'PD': 19, 'INDEF': 5, 'Z0': 0}, min-eig-range=[-1096.873178876457, 0.8942639014127854]; R=1/2: {'PD': 8, 'INDEF': 15, 'Z0': 1}, min-eig-range=[-377.667558380446, 0.6084816960975453]; R=3: {'PD': 0, 'INDEF': 48, 'Z0': 0}, min-eig-range=[-50.70872374489649, -0.0025409319670724366]]
+RESIDUAL (declared-open): the complete six-real-dimensional semialgebraic boundary of the PSD domain is NOT classified here.  Exact strict certificates establish open PD and indefinite regions; floats only map bounded coverage and are never promoted to a threshold or a global genericity theorem.
+
+--- T3: law/ensemble and licensing analysis ---
+[PASS] (12) mu_sym is one exact finite Grassmann weight but is NON-GAUSSIAN: its constant and bilinear coefficients force K_eff=(K_W+K_Wdag)/2, yet exp(chibar K_eff chi) first disagrees with the half-sum at Grassmann degree four.  Hence there is no single bilinear/3-mode local Gaussian rule producing this weight at P1  [first mismatch degree=4, mismatch masks=723]
+[PASS] (13) law versus ensemble, exact distinction: for supplied (W,K), the orbit-average prescription returns exactly one fixed raw integrand (so it satisfies the Qualification's extensional one-answer clause) and is a finite Berezin weight/linear functional.  It is formally a half-sum of two component weights, but after normalization at P1 the component coefficients are conjugate NONREAL numbers alpha,beta with alpha+beta=1 -- not a positive probabilistic mixture of two normalized laws  [alpha=(1/2+128413/442243i), beta=(1/2-128413/442243i)]
+[PASS] (14) K-orbit use is exact and explicit: mu_sym(W)=mu_sym(Wdag), it reduces to mu_W on the tie, and it differs from mu_W at generic P1.  Thus the construction is arrow-free once K is supplied, but it CONSUMES K to alter the unregistered weight; that physical licensing is not settled by the algebra
+RESIDUAL (declared-open): K-ORBIT-AVERAGE LAW/MEASURE LICENSING (first-class): pro -- supplied readout-context K canonically fixes the orbit and removes any arrow or representative choice; contra -- applying that downstream context to the Berezin weight promotes K into the dynamics/measure and can be read as pre-inserting the structure sought.  No authorized landed content resolves this choice, so neither side is adopted.
+[PASS] (15) time-homogeneity does not extend automatically: a quenched global orbit choice gives (x^N+y^N)/2, whereas an annealed per-step orbit average gives ((x+y)/2)^N; already at N=2, x=2, y=3 they are exactly 13/2 and 25/4.  The present half-sum is global over the supplied two-slice history and lands neither many-slice rule
+RESIDUAL (declared-open): the many-slice transfer rule is OPEN: quenched means one W/Wdag orbit representative fixed for a whole history before averaging histories; annealed means re-averaging orbit representatives per step/link and summing 2^N assignments.  Neither extension is supplied or licensed.
+
+--- T4: doubled-space realization and fork arithmetic ---
+[PASS] (16) the doubled one-slice carrier D=W direct-sum Wdag is conjugation-closed by construction in both relevant senses: J D=Ddag J for the copy-swap fundamental symmetry J, with J^2=I and signature (3,3); and the natural antiunitary K_D=S o conjugation obeys S conjugate(D) S=D and K_D^2=1 (S includes generation inversion P).  Its K-fixed real form is invariant.  Distinctly, the linear positive J=+1 half is NOT invariant: (I-P+)DP+ is nonzero at P1
+[PASS] (17) the ordinary doubled Gaussian does NOT reproduce mu_sym correlators even on the natural K-paired additive lift (the registrable basis is P-even, so this is the half-sum across copies): its partition is Z_D=Z_W Z_Wdag=|Z_W|^2 and spectator factors reweight every lifted correlator.  At exact P1 its normalized 5x5 form differs from the mu_sym form entrywise.  A direct-sum/superselection trace with an exclusive sector would reproduce the half-sum, but that one-hot sector structure is additional and is not the six-mode Gaussian  [first difference (0, 1)=(1523664567517428/4626542220828959+0i); mismatched entries=24]
+[PASS] (18) DOUBLED-CARRIER COUNTING: W direct-sum Wdag doubles BOTH the singlet and doublet carriers (real dimensions 2->4 and 4->8).  The honest uniform doubled equations 6 a^2=2 eps, 12 b^2=2 eps preserve the count-once comparator b^2/a^2=1/2; they do NOT produce the count-twice comparator 1.  Obtaining the latter needs 12 b^2=4 eps (or an asymmetric singlet quotient), an extra grain/equipartition rule
+RESIDUAL (declared-open): no physical r value is derived or adopted.  The equations in check 18 only compare the two already-landed fork cells.  Uniform direct-sum doubling pays a factor-two carrier overhead and a (3,3) Krein form.  The antiunitary K-fixed real form halves singlet and doublet uniformly; the linear positive J half is not transfer-invariant.  A different counting quotient would be new formation/equipartition content.
+[PASS] (19) escape-table update relative to blocks 10/11 is complete: the new arrow-free orbit average is algebraically live only on a PD domain, with licensing and many-slice transfer open; ordinary doubling does not realize its correlators; positive-metric closure, Krein, A2, and alternating-measure dispositions remain correctly separated
+RESIDUAL (declared-open): the per-cell equipartition/dial and formation-weight residues are untouched; no r endpoint, premise, probability rule, local transfer, or many-slice history law is adopted.  The exact construction is bounded to the two-slice C3 circulant and the registrable spanning set.
+
+T2 SIGNATURE VERDICT FIRST: PSD ON A NONEMPTY OPEN DOMAIN, INDEFINITE ON ANOTHER NONEMPTY OPEN DOMAIN (MIXED-DOMAIN BOUNDED THEOREM).  Both required exact complex untied probes are PD; iI and 2P1 have exact negative principal minors; no global six-dimensional boundary claimed.
+T1: theta exchanges mu_W and mu_Wdag, so mu_sym and its raw Gram are exactly reflection-invariant/Hermitian; normalization exists only where Z_sym=Re Z_W is nonzero.
+T3: the prescription is one fixed non-Gaussian Berezin weight and a formal orbit ensemble, but its K-to-measure licensing and annealed-versus-quenched many-slice law remain first-class open residuals.
+T4: W direct-sum Wdag is a (3,3)-signature conjugation-closed carrier, but its K-paired Gaussian gives product rather than sum correlators; the natural K-real form is closed while the linear positive J half is not.
+DOUBLED-CARRIER COUNTING RESULT: uniform doubling doubles singlet and doublet alike, preserves the count-once fork comparator, and does not reinstall count-twice without an extra asymmetric grain rule.
+CHECK COUNT: PASS=19 FAIL=0
+PROPOSED CLAIM_SCOPE: bounded_theorem -- two-slice C3 circulant, registrable 5-element spanning set, exact mixed signature, with K-orbit-average licensing and many-slice transfer explicitly open.
+HOSTILE-AUDIT UNCERTAINTIES: full PSD-domain boundary; whether supplied readout K may act on the weight; law-versus-ensemble physical status; annealed/quenched extension; exclusive-sector transfer realization; equipartition/formation grain.
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/frontier_k_symmetrized_untied_measure_2026_07_12.py
+++ b/scripts/frontier_k_symmetrized_untied_measure_2026_07_12.py
@@ -1,0 +1,819 @@
+#!/usr/bin/env python3
+"""K-symmetrized untied measure: records-only reconstruction (rhalf block 16).
+
+The two-slice weight tested here is
+
+    mu_sym(W) = (exp(chibar K(W,W) chi)
+                 + exp(chibar K(W^dag,W^dag) chi)) / 2.
+
+It is the K-orbit average of the time-homogeneous untied weight, not the
+arrow-dependent W,W^dag alternating weight.  All derivation-path arithmetic is
+exact over Gaussian rationals or SymPy rationals.  Floating eigenvalues are
+used only for labeled scans.  Numbered PASS/FAIL; exit 0 iff FAIL == 0.
+"""
+from fractions import Fraction as F
+from itertools import combinations
+import random
+
+import numpy as np
+import sympy as sp
+
+
+_pass = 0
+_fail = 0
+
+
+def check(num, desc, ok, detail=""):
+    global _pass, _fail
+    tag = "PASS" if ok else "FAIL"
+    if ok:
+        _pass += 1
+    else:
+        _fail += 1
+    line = f"[{tag}] ({num:02d}) {desc}"
+    if detail:
+        line += f"  [{detail}]"
+    print(line)
+
+
+def residual(msg):
+    print(f"RESIDUAL (declared-open): {msg}")
+
+
+# =====================================================================
+# Exact Gaussian-rational and Grassmann/Berezin engine (block 10 reused)
+# =====================================================================
+class CR:
+    __slots__ = ("re", "im")
+
+    def __init__(self, re=0, im=0):
+        self.re = re if isinstance(re, F) else F(re)
+        self.im = im if isinstance(im, F) else F(im)
+
+    def __add__(self, other):
+        other = asCR(other)
+        return CR(self.re + other.re, self.im + other.im)
+
+    __radd__ = __add__
+
+    def __sub__(self, other):
+        other = asCR(other)
+        return CR(self.re - other.re, self.im - other.im)
+
+    def __mul__(self, other):
+        other = asCR(other)
+        return CR(self.re * other.re - self.im * other.im,
+                  self.re * other.im + self.im * other.re)
+
+    __rmul__ = __mul__
+
+    def __truediv__(self, other):
+        other = asCR(other)
+        den = other.re * other.re + other.im * other.im
+        num = self * CR(other.re, -other.im)
+        return CR(num.re / den, num.im / den)
+
+    def __neg__(self):
+        return CR(-self.re, -self.im)
+
+    def conj(self):
+        return CR(self.re, -self.im)
+
+    def __eq__(self, other):
+        other = asCR(other)
+        return self.re == other.re and self.im == other.im
+
+    def __hash__(self):
+        return hash((self.re, self.im))
+
+    def is_zero(self):
+        return self.re == 0 and self.im == 0
+
+    def __repr__(self):
+        return f"({self.re}{'+' if self.im >= 0 else ''}{self.im}i)"
+
+    def __complex__(self):
+        return complex(float(self.re), float(self.im))
+
+
+def asCR(value):
+    if isinstance(value, CR):
+        return value
+    if isinstance(value, complex):
+        return CR(F(value.real), F(value.imag))
+    return CR(F(value), F(0))
+
+
+def gr_mul(p, q):
+    out = {}
+    for m1, c1 in p.items():
+        for m2, c2 in q.items():
+            if m1 & m2:
+                continue
+            sign = 1
+            remaining = m2
+            while remaining:
+                low = remaining & (-remaining)
+                bit = low.bit_length() - 1
+                if bin(m1 >> (bit + 1)).count("1") % 2:
+                    sign = -sign
+                remaining ^= low
+            mask = m1 | m2
+            value = c1 * c2 if sign > 0 else -(c1 * c2)
+            out[mask] = out.get(mask, CR(0)) + value
+    return {m: value for m, value in out.items() if not value.is_zero()}
+
+
+def gr_int(poly, generator):
+    out = {}
+    bit = 1 << generator
+    for mask, coeff in poly.items():
+        if not (mask & bit):
+            continue
+        below = bin(mask & (bit - 1)).count("1")
+        signed = -coeff if below % 2 else coeff
+        reduced = mask ^ bit
+        out[reduced] = out.get(reduced, CR(0)) + signed
+    return {m: value for m, value in out.items() if not value.is_zero()}
+
+
+def exp_bilinear(K, nmode):
+    action = {}
+    for i in range(nmode):
+        for j in range(nmode):
+            if K[i][j].is_zero():
+                continue
+            gi, gj = 2 * i, 2 * j + 1
+            mask = (1 << gi) | (1 << gj)
+            signed = K[i][j] if gi < gj else -K[i][j]
+            action[mask] = action.get(mask, CR(0)) + signed
+    expo = {0: CR(1)}
+    term = {0: CR(1)}
+    for order in range(1, nmode + 1):
+        term = gr_mul(term, action)
+        term = {m: value / order for m, value in term.items()}
+        for mask, value in term.items():
+            expo[mask] = expo.get(mask, CR(0)) + value
+    return {m: value for m, value in expo.items() if not value.is_zero()}
+
+
+def berezin_full(poly, nmode):
+    out = poly
+    for i in range(nmode):
+        out = gr_int(out, 2 * i + 1)
+        out = gr_int(out, 2 * i)
+    return out.get(0, CR(0))
+
+
+def expect(K, nmode, obs):
+    return berezin_full(gr_mul(obs, exp_bilinear(K, nmode)), nmode)
+
+
+def cb(i):
+    return {1 << (2 * i): CR(1)}
+
+
+def c(i):
+    return {1 << (2 * i + 1): CR(1)}
+
+
+def mul(*terms):
+    out = {0: CR(1)}
+    for term in terms:
+        out = gr_mul(out, term)
+    return out
+
+
+def scal(value, poly):
+    return {mask: asCR(value) * coeff for mask, coeff in poly.items()}
+
+
+def add(*polys):
+    out = {}
+    for poly in polys:
+        for mask, coeff in poly.items():
+            out[mask] = out.get(mask, CR(0)) + coeff
+    return {m: value for m, value in out.items() if not value.is_zero()}
+
+
+def theta(poly, ng=3):
+    out = {}
+    for mask, coeff in poly.items():
+        generators = [g for g in range(4 * ng) if (mask >> g) & 1]
+        sign = 1
+        reflected = []
+        for generator in reversed(generators):
+            mode = generator // 2
+            is_chi = generator % 2 == 1
+            slice_index = 0 if mode < ng else 1
+            generation = mode % ng
+            new_mode = generation if slice_index == 1 else ng + generation
+            reflected.append(2 * new_mode if is_chi else 2 * new_mode + 1)
+            sign = -sign
+        image = {0: CR(1)}
+        for generator in reflected:
+            image = gr_mul(image, {1 << generator: CR(1)})
+        out_coeff = coeff.conj() if sign > 0 else -coeff.conj()
+        for out_mask, value in scal(out_coeff, image).items():
+            out[out_mask] = out.get(out_mask, CR(0)) + value
+    return {m: value for m, value in out.items() if not value.is_zero()}
+
+
+Cm = [[CR(0), CR(1), CR(0)],
+      [CR(0), CR(0), CR(1)],
+      [CR(1), CR(0), CR(0)]]
+
+
+def matmul(A, B):
+    return [[sum((A[i][k] * B[k][j] for k in range(len(B))), CR(0))
+             for j in range(len(B[0]))] for i in range(len(A))]
+
+
+C2 = matmul(Cm, Cm)
+EYE = [[CR(1) if i == j else CR(0) for j in range(3)] for i in range(3)]
+
+
+def W_of(a, b, ccoef):
+    a, b, ccoef = asCR(a), asCR(b), asCR(ccoef)
+    return [[(a if i == j else CR(0)) + b * Cm[i][j] + ccoef * C2[i][j]
+             for j in range(3)] for i in range(3)]
+
+
+def dag(matrix):
+    return [[matrix[j][i].conj() for j in range(len(matrix))]
+            for i in range(len(matrix[0]))]
+
+
+def direct_sum(A, B):
+    na, nb = len(A), len(B)
+    return [[(A[i][j] if i < na and j < na else
+              B[i - na][j - na] if i >= na and j >= na else CR(0))
+             for j in range(na + nb)] for i in range(na + nb)]
+
+
+def cr_det(matrix):
+    size = len(matrix)
+    if size == 1:
+        return matrix[0][0]
+    total = CR(0)
+    for j in range(size):
+        sub = [row[:j] + row[j + 1:] for row in matrix[1:]]
+        term = matrix[0][j] * cr_det(sub)
+        total = total + (term if j % 2 == 0 else -term)
+    return total
+
+
+def build_K(W0, W1, ng=3):
+    K = [[CR(0)] * (2 * ng) for _ in range(2 * ng)]
+    for i in range(ng):
+        for j in range(ng):
+            K[i][j] = -W0[i][j]
+            K[ng + i][ng + j] = -W1[i][j]
+    for generation in range(ng):
+        K[generation][ng + generation] = CR(F(-1, 2))
+        K[ng + generation][generation] = CR(F(1, 2))
+    return K
+
+
+def n(generation):
+    return mul(cb(3 + generation), c(3 + generation))
+
+
+def bilin1(matrix):
+    out = {}
+    for i in range(3):
+        for j in range(3):
+            if matrix[i][j].is_zero():
+                continue
+            out = add(out, scal(matrix[i][j], mul(cb(3 + i), c(3 + j))))
+    return out
+
+
+one = {0: CR(1)}
+REG = {
+    "1": one,
+    "N": bilin1(EYE),
+    "TCsym": add(bilin1(Cm), bilin1(C2)),
+    "e2": add(mul(n(0), n(1)), mul(n(0), n(2)), mul(n(1), n(2))),
+    "e3": mul(n(0), n(1), n(2)),
+}
+RO = ["1", "N", "TCsym", "e2", "e3"]
+OBS_PAIR = {(i, j): gr_mul(theta(REG[name_i]), REG[name_j])
+            for i, name_i in enumerate(RO) for j, name_j in enumerate(RO)}
+
+
+def raw_gram_from_weight(weight):
+    Z = berezin_full(weight, 6)
+    G = [[berezin_full(gr_mul(OBS_PAIR[(i, j)], weight), 6)
+          for j in range(5)] for i in range(5)]
+    return G, Z
+
+
+def gaussian_weight(W):
+    return exp_bilinear(build_K(W, W), 6)
+
+
+def sym_weight(W):
+    return scal(F(1, 2), add(gaussian_weight(W), gaussian_weight(dag(W))))
+
+
+def reg_gram(W):
+    return raw_gram_from_weight(gaussian_weight(W))
+
+
+def sym_gram(W):
+    return raw_gram_from_weight(sym_weight(W))
+
+
+def norm_gram(G, Z):
+    return [[G[i][j] / Z for j in range(5)] for i in range(5)]
+
+
+def is_hermitian(G):
+    return all((G[i][j] - G[j][i].conj()).is_zero()
+               for i in range(len(G)) for j in range(len(G)))
+
+
+def principal_minors(G):
+    out = {}
+    for size in range(1, len(G) + 1):
+        for indices in combinations(range(len(G)), size):
+            out[indices] = cr_det([[G[i][j] for j in indices] for i in indices])
+    return out
+
+
+def exact_psd_status(G, Z):
+    if Z.is_zero():
+        return None, {}
+    normalized = norm_gram(G, Z)
+    minors = principal_minors(normalized)
+    psd = (is_hermitian(normalized)
+           and all(value.im == 0 and value.re >= 0 for value in minors.values()))
+    return psd, minors
+
+
+def gram_float(G, Z):
+    return np.array([[complex(G[i][j] / Z) for j in range(5)] for i in range(5)])
+
+
+def poly_equal(A, B):
+    masks = set(A) | set(B)
+    return all((A.get(mask, CR(0)) - B.get(mask, CR(0))).is_zero()
+               for mask in masks)
+
+
+print("=" * 76)
+print("K-symmetrized untied measure -- records-only reconstruction (rhalf block 16)")
+print("mu_sym = (mu_W + mu_{W^dag})/2; same registrable spanning set")
+print("=" * 76)
+
+
+# =====================================================================
+# Engine validation and T1
+# =====================================================================
+pt3 = [[CR(F(i - j, 3), F(i * j, 5)) for j in range(3)] for i in range(3)]
+check(1, "reused block-10 Grassmann/Berezin engine: exact single-slice "
+         "partition equals det K to the first power at a dense rational-complex "
+         "point", expect(pt3, 3, one) == cr_det(pt3))
+
+Wt1 = [[CR(1)]]
+Ktoy = build_K(Wt1, Wt1, ng=1)
+toy_basis = [one, cb(1), c(1), mul(cb(1), c(1))]
+toy = [[expect(Ktoy, 2, gr_mul(theta(toy_basis[i], 1), toy_basis[j]))
+        for j in range(4)] for i in range(4)]
+toy_target = [[CR(F(5, 4)), CR(0), CR(0), CR(-1)],
+              [CR(0), CR(F(1, 2)), CR(0), CR(0)],
+              [CR(0), CR(0), CR(F(1, 2)), CR(0)],
+              [CR(-1), CR(0), CR(0), CR(1)]]
+check(2, "reused theta/two-slice engine reproduces block 10's inherited exact "
+         "toy OS Gram", toy == toy_target)
+
+PROBES = [
+    ("P1", CR(F(4, 5), F(1, 10)), CR(F(3, 10), F(1, 5)),
+     CR(F(1, 2), F(-1, 10))),
+    ("P2", CR(1), CR(F(1, 3), F(1, 7)), CR(F(1, 3), F(-1, 5))),
+]
+
+orbit_ok = True
+orbit_details = []
+probe_data = {}
+for tag, a, b, ccoef in PROBES:
+    W = W_of(a, b, ccoef)
+    G, Z = reg_gram(W)
+    Gd, Zd = reg_gram(dag(W))
+    Gs, Zs = sym_gram(W)
+    relation = (Zd == Z.conj()
+                and all(Gd[j][i].conj() == G[i][j]
+                        for i in range(5) for j in range(5)))
+    averaged = (Zs == (Z + Zd) / 2
+                and all(Gs[i][j] == (G[i][j] + Gd[i][j]) / 2
+                        for i in range(5) for j in range(5)))
+    orbit_ok = orbit_ok and relation and averaged
+    orbit_details.append(f"{tag}: Zsym={Zs}")
+    probe_data[tag] = (W, G, Z, Gd, Zd, Gs, Zs)
+check(3, "T1 reflection identity at both required exact untied probes: "
+         "Z(W^dag)=conj Z(W), G_raw(W^dag)=G_raw(W)^dag entrywise, and direct "
+         "integration of the half-sum equals the arithmetic orbit average",
+      orbit_ok, "; ".join(orbit_details))
+
+herm_ok = all(not data[6].is_zero() and data[6].im == 0
+              and is_hermitian(data[5])
+              and is_hermitian(norm_gram(data[5], data[6]))
+              for data in probe_data.values())
+check(4, "T1 exact consequence: theta preserves mu_sym and its raw records-only "
+         "Gram is Hermitian; at both required probes Z_sym=Re Z_W is nonzero, "
+         "so the normalized Gram is exactly Hermitian too", herm_ok)
+
+azero = CR(F(3, 8), F(5, 8))
+Wzero = W_of(azero, 0, 0)
+Gzero_w, Zzero_w = reg_gram(Wzero)
+Gzero_s, Zzero_s = sym_gram(Wzero)
+check(5, "normalization guard: Z_sym=Re Z_W is not automatically nonzero.  "
+         "At W=(3/8+5i/8)I, Z_W=(15i/32)^3=-3375i/32768 is nonzero and purely "
+         "imaginary, hence Z_sym=0 exactly; the raw symmetrized form remains "
+         "Hermitian but no normalized Gram exists on this locus",
+      Zzero_w == CR(0, F(-3375, 32768)) and Zzero_s.is_zero()
+      and is_hermitian(Gzero_s))
+
+
+# =====================================================================
+# T2 -- the decisive exact signature and bounded domain structure
+# =====================================================================
+print("\n--- T2: exact signature and bounded domain structure ---")
+strict_probe_pd = {}
+for check_num, tag in [(6, "P1"), (7, "P2")]:
+    Gs, Zs = probe_data[tag][5], probe_data[tag][6]
+    psd, minors = exact_psd_status(Gs, Zs)
+    strict = (psd is True
+              and all(value.im == 0 and value.re > 0
+                      for value in minors.values()))
+    strict_probe_pd[tag] = strict
+    smallest = min(minors.items(), key=lambda item: float(item[1].re))
+    scan_mineig = float(np.linalg.eigvalsh(gram_float(Gs, Zs)).min())
+    check(check_num, f"required exact untied probe {tag}: the normalized "
+          "K-symmetrized 5x5 Gram is POSITIVE DEFINITE -- all 31 principal "
+          "minors are exact positive rationals (no threshold)", strict,
+          f"smallest exact minor {smallest[0]}={smallest[1]}; "
+          f"float context min-eig={scan_mineig:.6g}")
+
+failure_points = [
+    ("iI", CR(0, 1), CR(0), CR(0)),
+    ("2P1", PROBES[0][1] * 2, PROBES[0][2] * 2, PROBES[0][3] * 2),
+]
+failure_ok = True
+failure_details = []
+failure_minors = {}
+for tag, a, b, ccoef in failure_points:
+    Gs, Zs = sym_gram(W_of(a, b, ccoef))
+    psd, minors = exact_psd_status(Gs, Zs)
+    negatives = [(idx, value) for idx, value in minors.items()
+                 if value.im == 0 and value.re < 0]
+    first = min(negatives, key=lambda item: (len(item[0]), item[0]))
+    failure_minors[tag] = first
+    failure_ok = (failure_ok and psd is False and is_hermitian(norm_gram(Gs, Zs))
+                  and not Zs.is_zero() and bool(negatives))
+    failure_details.append(f"{tag}: Zsym={Zs}, minor{first[0]}={first[1]}")
+check(8, "exact failure certificates on both signs/regions: W=iI and W=2P1 "
+         "have nonzero Z_sym and exactly Hermitian normalized Grams, but each "
+         "has a strictly negative rational principal minor; 2P1 has Z_sym>0, "
+         "so failure is not an artifact of a negative normalization",
+      failure_ok and sym_gram(W_of(*failure_points[1][1:]))[1].re > 0,
+      "; ".join(failure_details))
+
+check(9, "the exact T2 topology is MIXED-DOMAIN: strict PD at P1 and P2 and a "
+         "strict negative minor at iI and 2P1 imply, by continuity away from "
+         "Z_sym=0, nonempty open PD neighborhoods and nonempty open indefinite "
+         "neighborhoods.  Thus symmetrization restores positivity on a domain, "
+         "not universally", all(strict_probe_pd.values())
+      and all(value.re < 0 for _, value in failure_minors.values()))
+
+# Exact inheritance controls relative to block 10: the tied weight itself is
+# unchanged; on P-even records the all-real branch agrees with its P-conjugate.
+W_tie = W_of(CR(F(4, 5)), CR(F(3, 10), F(1, 5)),
+             CR(F(3, 10), F(-1, 5)))
+W_real_in = W_of(F(4, 5), F(3, 10), F(1, 2))
+W_real_out = W_of(F(1, 2), F(-4, 5), F(3, 10))
+inherit_ok = True
+inherit_detail = []
+for tag, W, expected in [("tie", W_tie, True),
+                         ("real-inside", W_real_in, True),
+                         ("real-outside", W_real_out, False)]:
+    G, Z = reg_gram(W)
+    Gs, Zs = sym_gram(W)
+    status, _ = exact_psd_status(Gs, Zs)
+    same_records_form = (Z == Zs
+                         and all(G[i][j] == Gs[i][j]
+                                 for i in range(5) for j in range(5)))
+    inherit_ok = inherit_ok and same_records_form and status is expected
+    inherit_detail.append(f"{tag}: PSD={status}")
+check(10, "block-10 controls are inherited exactly at records-only grade: "
+          "mu_sym equals the tied weight on the tie; on the all-real branch its "
+          "P-even record Gram equals the original Gram, positive inside the "
+          "known strip and indefinite at the supplied outside point",
+      inherit_ok, "; ".join(inherit_detail))
+
+
+def scan_box(radius_tenths, samples, seed):
+    """Float-sign scan only: no threshold and no derivation-path use."""
+    rng = random.Random(seed)
+    counts = {"PD": 0, "INDEF": 0, "Z0": 0}
+    extrema = [float("inf"), float("-inf")]
+    for _ in range(samples):
+        vals = [F(rng.randint(-radius_tenths, radius_tenths), 10)
+                for _ in range(6)]
+        W = W_of(CR(vals[0], vals[1]), CR(vals[2], vals[3]),
+                 CR(vals[4], vals[5]))
+        Gs, Zs = sym_gram(W)
+        if Zs.is_zero():
+            counts["Z0"] += 1
+            continue
+        mineig = float(np.linalg.eigvalsh(gram_float(Gs, Zs)).min())
+        extrema[0], extrema[1] = min(extrema[0], mineig), max(extrema[1], mineig)
+        counts["PD" if mineig > 0 else "INDEF"] += 1
+    return counts, extrema
+
+
+scan_report = []
+for radius, samples in [(1, 24), (2, 24), (5, 24), (30, 48)]:
+    counts, extrema = scan_box(radius, samples, 20260712 + radius)
+    scan_report.append((F(radius, 10), counts, extrema))
+small_counts = scan_report[0][1]
+mid_counts = scan_report[1][1]
+wide_counts = scan_report[-1][1]
+check(11, "labeled float-only six-real-dimensional coverage (eigenvalue sign, "
+          "no threshold) sees the open PD core/tubes and failures as the box "
+          "widens; this is domain evidence only, not a claimed analytic global "
+          "boundary", small_counts["PD"] > 0 and mid_counts["INDEF"] > 0
+      and wide_counts["INDEF"] > 0,
+      "; ".join(f"R={radius}: {counts}, min-eig-range={extrema}"
+                for radius, counts, extrema in scan_report))
+residual("the complete six-real-dimensional semialgebraic boundary of the PSD "
+         "domain is NOT classified here.  Exact strict certificates establish "
+         "open PD and indefinite regions; floats only map bounded coverage and "
+         "are never promoted to a threshold or a global genericity theorem.")
+
+
+# =====================================================================
+# T3 -- law/ensemble status, K consumption, and many-slice extensions
+# =====================================================================
+print("\n--- T3: law/ensemble and licensing analysis ---")
+Wp1, Gp1, Zp1, Gdp1, Zdp1, Gsp1, Zsp1 = probe_data["P1"]
+Kp1 = build_K(Wp1, Wp1)
+Kdp1 = build_K(dag(Wp1), dag(Wp1))
+Kaverage = [[(Kp1[i][j] + Kdp1[i][j]) / 2 for j in range(6)]
+            for i in range(6)]
+single_gaussian_candidate = exp_bilinear(Kaverage, 6)
+symp1 = sym_weight(Wp1)
+all_masks = set(single_gaussian_candidate) | set(symp1)
+different_masks = [mask for mask in all_masks
+                   if single_gaussian_candidate.get(mask, CR(0))
+                   != symp1.get(mask, CR(0))]
+low_order_equal = all(single_gaussian_candidate.get(mask, CR(0))
+                      == symp1.get(mask, CR(0))
+                      for mask in all_masks if mask.bit_count() <= 2)
+first_degree = min(mask.bit_count() for mask in different_masks)
+check(12, "mu_sym is one exact finite Grassmann weight but is NON-GAUSSIAN: "
+          "its constant and bilinear coefficients force K_eff=(K_W+K_Wdag)/2, "
+          "yet exp(chibar K_eff chi) first disagrees with the half-sum at "
+          "Grassmann degree four.  Hence there is no single bilinear/3-mode "
+          "local Gaussian rule producing this weight at P1",
+      low_order_equal and first_degree == 4
+      and not poly_equal(single_gaussian_candidate, symp1),
+      f"first mismatch degree={first_degree}, mismatch masks={len(different_masks)}")
+
+alpha = Zp1 / (2 * Zsp1)
+beta = Zdp1 / (2 * Zsp1)
+check(13, "law versus ensemble, exact distinction: for supplied (W,K), the "
+          "orbit-average prescription returns exactly one fixed raw integrand "
+          "(so it satisfies the Qualification's extensional one-answer clause) "
+          "and is a finite Berezin weight/linear functional.  It is formally a "
+          "half-sum of two component weights, but after normalization at P1 the "
+          "component coefficients are conjugate NONREAL numbers alpha,beta "
+          "with alpha+beta=1 -- not a positive probabilistic mixture of two "
+          "normalized laws", alpha + beta == CR(1) and alpha.im != 0
+      and beta == alpha.conj(), f"alpha={alpha}, beta={beta}")
+
+Wgeneric = Wp1
+Wgeneric_dag = dag(Wgeneric)
+Wtied_weight = gaussian_weight(W_tie)
+check(14, "K-orbit use is exact and explicit: mu_sym(W)=mu_sym(Wdag), it reduces "
+          "to mu_W on the tie, and it differs from mu_W at generic P1.  Thus "
+          "the construction is arrow-free once K is supplied, but it CONSUMES "
+          "K to alter the unregistered weight; that physical licensing is not "
+          "settled by the algebra", poly_equal(sym_weight(Wgeneric),
+                                                sym_weight(Wgeneric_dag))
+      and poly_equal(sym_weight(W_tie), Wtied_weight)
+      and not poly_equal(sym_weight(Wgeneric), gaussian_weight(Wgeneric)))
+residual("K-ORBIT-AVERAGE LAW/MEASURE LICENSING (first-class): pro -- supplied "
+         "readout-context K canonically fixes the orbit and removes any arrow or "
+         "representative choice; contra -- applying that downstream context to "
+         "the Berezin weight promotes K into the dynamics/measure and can be "
+         "read as pre-inserting the structure sought.  No authorized landed "
+         "content resolves this choice, so neither side is adopted.")
+
+x_hist, y_hist = sp.Rational(2), sp.Rational(3)
+quenched_two = (x_hist ** 2 + y_hist ** 2) / 2
+annealed_two = ((x_hist + y_hist) / 2) ** 2
+check(15, "time-homogeneity does not extend automatically: a quenched global "
+          "orbit choice gives (x^N+y^N)/2, whereas an annealed per-step orbit "
+          "average gives ((x+y)/2)^N; already at N=2, x=2, y=3 they are exactly "
+          "13/2 and 25/4.  The present half-sum is global over the supplied "
+          "two-slice history and lands neither many-slice rule",
+      quenched_two == sp.Rational(13, 2)
+      and annealed_two == sp.Rational(25, 4)
+      and quenched_two != annealed_two)
+residual("the many-slice transfer rule is OPEN: quenched means one W/Wdag orbit "
+         "representative fixed for a whole history before averaging histories; "
+         "annealed means re-averaging orbit representatives per step/link and "
+         "summing 2^N assignments.  Neither extension is supplied or licensed.")
+
+
+# =====================================================================
+# T4 -- doubled carrier, correlator mismatch, and counting
+# =====================================================================
+print("\n--- T4: doubled-space realization and fork arithmetic ---")
+
+
+def identity(size):
+    return [[CR(1) if i == j else CR(0) for j in range(size)]
+            for i in range(size)]
+
+
+def matrix_add(A, B):
+    return [[A[i][j] + B[i][j] for j in range(len(A[0]))]
+            for i in range(len(A))]
+
+
+def matrix_sub(A, B):
+    return [[A[i][j] - B[i][j] for j in range(len(A[0]))]
+            for i in range(len(A))]
+
+
+def matrix_scale(value, A):
+    return [[asCR(value) * A[i][j] for j in range(len(A[0]))]
+            for i in range(len(A))]
+
+
+def matrix_equal(A, B):
+    return all(A[i][j] == B[i][j]
+               for i in range(len(A)) for j in range(len(A[0])))
+
+
+def matrix_nonzero(A):
+    return any(not value.is_zero() for row in A for value in row)
+
+
+D = direct_sum(Wp1, dag(Wp1))
+J = [[CR(1) if ((i < 3 and j == i + 3) or
+                (i >= 3 and j == i - 3)) else CR(0)
+      for j in range(6)] for i in range(6)]
+# The natural doubled antiunitary is K_D = S o complex-conjugation.  The
+# generation inversion P is needed because W^dag = P conjugate(W) P for the
+# C3 circulant.  This K-fixed real form is distinct from the linear J=+1 space.
+P3 = [[CR(1), CR(0), CR(0)],
+      [CR(0), CR(0), CR(1)],
+      [CR(0), CR(1), CR(0)]]
+Santi = [[(P3[i][j - 3] if i < 3 and j >= 3 else
+           P3[i - 3][j] if i >= 3 and j < 3 else CR(0))
+          for j in range(6)] for i in range(6)]
+Dbar = [[D[i][j].conj() for j in range(6)] for i in range(6)]
+Sbar = [[Santi[i][j].conj() for j in range(6)] for i in range(6)]
+I6 = identity(6)
+Pplus = matrix_scale(F(1, 2), matrix_add(I6, J))
+Pminus = matrix_sub(I6, Pplus)
+leak = matmul(matmul(Pminus, D), Pplus)
+Jsp = sp.Matrix([[int(J[i][j].re) for j in range(6)] for i in range(6)])
+signature = Jsp.eigenvals()
+check(16, "the doubled one-slice carrier D=W direct-sum Wdag is conjugation-"
+          "closed by construction in both relevant senses: J D=Ddag J for the "
+          "copy-swap fundamental symmetry J, with J^2=I and signature (3,3); "
+          "and the natural antiunitary K_D=S o conjugation obeys S conjugate(D) "
+          "S=D and K_D^2=1 (S includes generation inversion P).  Its K-fixed "
+          "real form is invariant.  Distinctly, the linear positive J=+1 half "
+          "is NOT invariant: (I-P+)DP+ is nonzero at P1",
+      matrix_equal(matmul(J, D), matmul(dag(D), J))
+      and matrix_equal(matmul(J, J), I6)
+      and signature == {sp.Integer(-1): 3, sp.Integer(1): 3}
+      and matrix_equal(matmul(matmul(Santi, Dbar), Santi), D)
+      and matrix_equal(matmul(Santi, Sbar), I6)
+      and matrix_nonzero(matrix_sub(matmul(D, J), matmul(J, D)))
+      and matrix_nonzero(leak))
+
+# A Grassmann Gaussian on a direct-sum carrier factorizes (exterior algebra of
+# a direct sum is a tensor product).  For the most charitable exchange-even
+# additive lift of an already-formed correlator O, spectator partitions give
+# B_D(O_+)=(B_W(O) Z_d + Z B_d(O))/2, not (B_W(O)+B_d(O))/2.
+Zdouble = Zp1 * Zdp1
+Gdouble_additive = [[(Gp1[i][j] * Zdp1 + Zp1 * Gdp1[i][j])
+                     / (2 * Zdouble) for j in range(5)] for i in range(5)]
+Gsym_normalized = norm_gram(Gsp1, Zsp1)
+mismatches = [((i, j), Gdouble_additive[i][j] - Gsym_normalized[i][j])
+              for i in range(5) for j in range(5)
+              if Gdouble_additive[i][j] != Gsym_normalized[i][j]]
+first_mismatch = mismatches[0]
+check(17, "the ordinary doubled Gaussian does NOT reproduce mu_sym correlators "
+          "even on the natural K-paired additive lift (the registrable basis is "
+          "P-even, so this is the half-sum across copies): its partition is "
+          "Z_D=Z_W Z_Wdag=|Z_W|^2 and spectator factors reweight every lifted "
+          "correlator.  At exact P1 its normalized 5x5 form differs from the "
+          "mu_sym form entrywise.  A direct-sum/superselection trace with an "
+          "exclusive sector would reproduce the half-sum, but that one-hot "
+          "sector structure is additional and is not the six-mode Gaussian",
+      Zdouble.im == 0 and Zdouble.re > 0 and Zdouble != Zsp1
+      and bool(mismatches),
+      f"first difference {first_mismatch[0]}={first_mismatch[1]}; "
+      f"mismatched entries={len(mismatches)}")
+
+# Fork arithmetic inherited from block 10, with no endpoint adopted.  Uniform
+# carrier doubling changes 3->6 diagonal slots and 6->12 doublet slots while
+# also doubling the corresponding budgets.  It therefore cancels from the
+# squared-amplitude ratio.  Count-twice would require a different budget rule.
+a2, b2, eps = sp.symbols("a2 b2 eps", positive=True)
+single_once = sp.solve([sp.Eq(3 * a2, eps), sp.Eq(6 * b2, eps)],
+                       [a2, b2], dict=True)[0]
+double_uniform = sp.solve([sp.Eq(6 * a2, 2 * eps),
+                           sp.Eq(12 * b2, 2 * eps)],
+                          [a2, b2], dict=True)[0]
+double_count_twice = sp.solve([sp.Eq(6 * a2, 2 * eps),
+                               sp.Eq(12 * b2, 4 * eps)],
+                              [a2, b2], dict=True)[0]
+ratio_single = sp.simplify(single_once[b2] / single_once[a2])
+ratio_double = sp.simplify(double_uniform[b2] / double_uniform[a2])
+ratio_twice = sp.simplify(double_count_twice[b2] /
+                          double_count_twice[a2])
+original_real_dims = {"singlet": 2, "doublet": 4}
+doubled_real_dims = {key: 2 * value for key, value in original_real_dims.items()}
+check(18, "DOUBLED-CARRIER COUNTING: W direct-sum Wdag doubles BOTH the singlet "
+          "and doublet carriers (real dimensions 2->4 and 4->8).  The honest "
+          "uniform doubled equations 6 a^2=2 eps, 12 b^2=2 eps preserve the "
+          "count-once comparator b^2/a^2=1/2; they do NOT produce the count-"
+          "twice comparator 1.  Obtaining the latter needs 12 b^2=4 eps (or an "
+          "asymmetric singlet quotient), an extra grain/equipartition rule",
+      doubled_real_dims == {"singlet": 4, "doublet": 8}
+      and ratio_single == sp.Rational(1, 2)
+      and ratio_double == ratio_single
+      and ratio_twice == 1)
+residual("no physical r value is derived or adopted.  The equations in check "
+         "18 only compare the two already-landed fork cells.  Uniform direct-"
+         "sum doubling pays a factor-two carrier overhead and a (3,3) Krein "
+         "form.  The antiunitary K-fixed real form halves singlet and doublet "
+         "uniformly; the linear positive J half is not transfer-invariant.  A "
+         "different counting quotient would be new formation/equipartition "
+         "content.")
+
+escape_table = {
+    "block10_non_OS": "PARTIALLY REALIZED algebraically by mu_sym",
+    "mu_sym_signature": "LIVE only on a nonempty PD domain; indefinite elsewhere",
+    "mu_sym_licensing": "OPEN first-class K-orbit-average residual",
+    "mu_sym_many_slice": "OPEN annealed-versus-quenched transfer residual",
+    "ordinary_doubling": "BLOCKED as a correlator realization; product not sum",
+    "positive_metric_W": "CLOSED to tie (block 11)",
+    "Krein_W": "OPEN on block-11 transposition loci",
+    "coarser_A2": "OPEN (block 11)",
+    "alternating_measure": "UNLICENSED inherited: arrow-dependent and K-preinserted",
+}
+check(19, "escape-table update relative to blocks 10/11 is complete: the new "
+          "arrow-free orbit average is algebraically live only on a PD domain, "
+          "with licensing and many-slice transfer open; ordinary doubling does "
+          "not realize its correlators; positive-metric closure, Krein, A2, and "
+          "alternating-measure dispositions remain correctly separated",
+      len(escape_table) == 9
+      and "OPEN" in escape_table["mu_sym_licensing"]
+      and "BLOCKED" in escape_table["ordinary_doubling"]
+      and "CLOSED" in escape_table["positive_metric_W"]
+      and "OPEN" in escape_table["Krein_W"]
+      and "OPEN" in escape_table["coarser_A2"]
+      and "UNLICENSED" in escape_table["alternating_measure"])
+residual("the per-cell equipartition/dial and formation-weight residues are "
+         "untouched; no r endpoint, premise, probability rule, local transfer, "
+         "or many-slice history law is adopted.  The exact construction is "
+         "bounded to the two-slice C3 circulant and the registrable spanning set.")
+
+
+print()
+print("T2 SIGNATURE VERDICT FIRST: PSD ON A NONEMPTY OPEN DOMAIN, INDEFINITE "
+      "ON ANOTHER NONEMPTY OPEN DOMAIN (MIXED-DOMAIN BOUNDED THEOREM).  Both "
+      "required exact complex untied probes are PD; iI and 2P1 have exact "
+      "negative principal minors; no global six-dimensional boundary claimed.")
+print("T1: theta exchanges mu_W and mu_Wdag, so mu_sym and its raw Gram are "
+      "exactly reflection-invariant/Hermitian; normalization exists only where "
+      "Z_sym=Re Z_W is nonzero.")
+print("T3: the prescription is one fixed non-Gaussian Berezin weight and a "
+      "formal orbit ensemble, but its K-to-measure licensing and annealed-versus-"
+      "quenched many-slice law remain first-class open residuals.")
+print("T4: W direct-sum Wdag is a (3,3)-signature conjugation-closed carrier, "
+      "but its K-paired Gaussian gives product rather than sum correlators; the "
+      "natural K-real form is closed while the linear positive J half is not.")
+print("DOUBLED-CARRIER COUNTING RESULT: uniform doubling doubles singlet and "
+      "doublet alike, preserves the count-once fork comparator, and does not "
+      "reinstall count-twice without an extra asymmetric grain rule.")
+print(f"CHECK COUNT: PASS={_pass} FAIL={_fail}")
+print("PROPOSED CLAIM_SCOPE: bounded_theorem -- two-slice C3 circulant, "
+      "registrable 5-element spanning set, exact mixed signature, with "
+      "K-orbit-average licensing and many-slice transfer explicitly open.")
+print("HOSTILE-AUDIT UNCERTAINTIES: full PSD-domain boundary; whether supplied "
+      "readout K may act on the weight; law-versus-ensemble physical status; "
+      "annealed/quenched extension; exclusive-sector transfer realization; "
+      "equipartition/formation grain.")
+print(f"TOTAL: PASS={_pass} FAIL={_fail}")
+raise SystemExit(0 if _fail == 0 else 1)


### PR DESCRIPTION
## Summary

**rhalf block 16 (exploratory, banked duality route): the arrow-free K-symmetrized untied measure μ_sym = (μ_W + μ_{W†})/2 restores Hermiticity for EVERY untied W and is positive definite on a nonempty open untied domain — but the revival gate has two conjuncts and only the first is met. The outcome-stage cell is NOT revived, and it is also not closed by a doubling no-go.** Stacked on #5193 (block 10 base). Bounded theorem; 19 checks, PASS=19 FAIL=0.

**T1 (exact, every W).** θ exchanges μ_W and μ_{W†}, so μ_sym is θ-invariant and its raw records-only Gram is Hermitian for every untied coupling — unlike block 10's single Gaussian, no K-real branch is needed. Normalization requires Z_sym = Re Z_W ≠ 0; exact nonzero-Z_W/zero-Z_sym witness at W = (3/8+5i/8)I.

**T2 (the decisive signature — MIXED DOMAIN).** At both required genuinely complex untied probes, all 31 principal minors of the normalized 5×5 Gram are strictly positive exact rationals — positivity escapes block 10's two-branch weight-reality set onto an open untied domain. Exact indefinite witnesses at W = iI and W = 2·P1 (the latter with Z_sym > 0, so failure is not a normalization-sign artifact). Strictness gives open neighborhoods on both sides. The full six-dimensional boundary is a declared Residual Atom; the labeled float scan (never thresholded) maps a bounded PD core.

**T3 (licensing — the load-bearing open gate).** μ_sym is one fixed non-Gaussian Berezin weight (exact: forcing the bilinear coefficients gives K_eff = (K_W+K_{W†})/2, which first disagrees at Grassmann degree four — the cosh obstruction), extensionally one answer per the Qualification, but formally an orbit average whose normalized component weights are conjugate NONREAL at P1 (not a positive mixture). The two readings — supplied-context canonicality (arrow-free, no representative chosen) vs. K-to-measure pre-insertion — cannot be separated by algebra; **K-ORBIT-AVERAGE LICENSING is the first-class residual and the revival gate**. Many-slice extension is also open (quenched vs annealed differ already at N=2: 13/2 vs 25/4).

**T4 (doubled carrier — realization fails, counting unchanged).** W⊕W† is conjugation-closed by construction in both senses (J-Krein with signature (3,3); antiunitary K_D via S = offdiag(P,P)), but the six-mode Gaussian's partition factorizes (Z_D = |Z_W|²) and its K-paired additive lift yields the average of *separately normalized* component expectations — not μ_sym's Z-weighted combination; 24 of 25 entries differ at P1. An exclusive-sector superselection trace would give the sum, but that one-hot rule is additional unlanded structure. **Counting: uniform doubling doubles singlet AND doublet alike (2→4, 4→8 real dims), so the count-once comparator b²/a² = 1/2 is preserved; count-twice would need an extra asymmetric grain rule.** No r value inferred.

**Escape table updated** relative to blocks 10/11: non-OS route PARTIALLY REALIZED algebraically; licensing OPEN (first-class); many-slice OPEN; ordinary doubling BLOCKED as a realization; alternating measure stays UNLICENSED; block 11 dispositions inherited unchanged.

## Honesty boundary

Not a revival (licensing unlanded), not a closure (the doubled arithmetic honestly refuses to reinstate count-twice), not a global positivity theorem, not a positive probability measure, no r endpoint touched. Literature (Meisinger–Ogilvie arXiv:1306.1495) cited as conjugation-pairing precedent only; everything proved repo-natively.

## Verification

```
python3 scripts/frontier_k_symmetrized_untied_measure_2026_07_12.py
```
Exact Gaussian-rational/SymPy on all derivation paths; floats only in the labeled scan; numbered [PASS]/[FAIL]; TOTAL: PASS=19 FAIL=0; exit 0. Runner cache committed (sha 79851427…). Supervisor hand-verified the Z_sym=0 witness, the cosh degree-four obstruction, the circulant antiunitary algebra (P·conj(W)·P = W†), and the T4 spectator-factor computation; independent re-run matches cache including the scan table.

Executor: codex gpt-5.6-sol (max reasoning) under supervisor review (Claude Fable 5, line-by-line); no premise adopted; no audit status set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
