### PR TITLE
Reconciliation Block 4: heat-trace live-guard re-pin (PASS=81 FAIL=0 restored)

### DIFF
--- a/docs/ACPHILAMBDA_AMBIENT_EQUIVARIANT_HEAT_TRACE_FACE_2026-07-02.md
+++ b/docs/ACPHILAMBDA_AMBIENT_EQUIVARIANT_HEAT_TRACE_FACE_2026-07-02.md
@@ -43,8 +43,11 @@ And nothing here derives the physical normalization or the phase value.
 ## Frame And Retained Inputs
 The dependency source is
 [KOIDE_APS_C3_FIXED_LOCUS_WEIGHTS_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05](KOIDE_APS_C3_FIXED_LOCUS_WEIGHTS_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md).
-It supplies the pinned local row: "**(B) The weight `(1,2)` is forced and gives local density `2/9`.**"
-It also pins the scope exclusion: "It does **not** supply the physical single-summand readout".
+It supplies the pinned local value: "L_C_3(N) = (1/3)(1/3+1/3) = 2/9."
+It also pins the scope exclusion: "No physical single-summand readout is derived."
+(The supplier note was made self-contained after this note was written; the
+pinned sentences above quote its current text, which derives the same `2/9`
+density with the same readout exclusion.)
 The axiom memo `docs/MINIMAL_AXIOMS_2026-06-29.md` supplies the lattice objects:
 "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
 adjacency, standard translations, and proper cubic rotations about each site."

--- a/logs/runner-cache/acphilambda_ambient_equivariant_heat_trace_face_2026_07_02.txt
+++ b/logs/runner-cache/acphilambda_ambient_equivariant_heat_trace_face_2026_07_02.txt
@@ -1,11 +1,3 @@
-===== runner cache v1 =====
-runner: scripts/acphilambda_ambient_equivariant_heat_trace_face_2026_07_02.py
-runner_sha256: 1e840f22691f1f049fa9618c18a5f94dd6bd9730fe471fd1ddb9c51ae66aec0b
-timeout_sec: 120
-exit_code: 0
-elapsed_sec: 0.32
-status: ok
------ stdout -----
 
 -- Source and note pins --
 [PASS] note exists
@@ -101,6 +93,3 @@ status: ok
 [PASS] verification close is recorded
 
 TOTAL: PASS=81 FAIL=0
-
------ stderr -----
-

--- a/scripts/acphilambda_ambient_equivariant_heat_trace_face_2026_07_02.py
+++ b/scripts/acphilambda_ambient_equivariant_heat_trace_face_2026_07_02.py
@@ -143,11 +143,11 @@ def source_checks() -> None:
     check("note exists", NOTE.exists())
     check("fixed-locus source exists", FIXED.exists())
     check("axioms memo exists", AXIOMS.exists())
-    check("fixed-locus local density pin exists", "forced and gives local density `2/9`" in fixed)
-    check("fixed-locus readout exclusion pin exists", "does **not** supply the physical single-summand readout" in fixed)
+    check("fixed-locus local density pin exists", "L_C_3(N) = (1/3)(1/3+1/3) = 2/9." in fixed)
+    check("fixed-locus readout exclusion pin exists", "No physical single-summand readout is derived." in fixed)
     check("axioms lattice sentence exists", landed_lattice_sentence in axioms_flat)
-    check("note quotes local density pin", "forced and gives local density `2/9`" in note)
-    check("note quotes readout exclusion pin", "does **not**" in note and "supply the physical single-summand readout" in note)
+    check("note quotes local density pin", "L_C_3(N) = (1/3)(1/3+1/3) = 2/9." in note)
+    check("note quotes readout exclusion pin", "No physical single-summand readout is derived." in note)
     check("note quotes lattice sentence", landed_lattice_sentence in flat(note))
 
 def exact_reduction_checks() -> None:


### PR DESCRIPTION
## Campaign context

Fourth block of the axiom-reconciliation campaign; stacked on the Block 3 index PR. This is the Wave 1 live-guard repair the index queued: `scripts/acphilambda_ambient_equivariant_heat_trace_face_2026_07_02.py` was failing on main (PASS=79 FAIL=2) because PR #5184 rewrote its supplier note and dropped the two exact sentences the runner pins.

## Changes

- Runner: both fixed-locus pins re-keyed to the rewritten supplier's current sentences — the derived value line `L_C_3(N) = (1/3)(1/3+1/3) = 2/9.` and the boundary line `No physical single-summand readout is derived.` The paired note-quote checks re-keyed to the same sentences.
- Note `ACPHILAMBDA_AMBIENT_EQUIVARIANT_HEAT_TRACE_FACE_2026-07-02.md`: its quoted supplier pins updated to the current supplier text, with a one-sentence provenance remark that the supplier was made self-contained after this note was written. The old pinned sentence claimed the `(1,2)` weight is "forced"; the consumer's argument uses only the `2/9` value and the readout exclusion (verified: no other use of the forcing claim in the note), both of which the rewritten supplier still derives/states.
- Cache regenerated: `TOTAL: PASS=81 FAIL=0` (was 79/2 on main).

## Verification

- `python3 scripts/acphilambda_ambient_equivariant_heat_trace_face_2026_07_02.py` → PASS=81 FAIL=0; diff against the committed cache.
- `git diff main -- scripts/... docs/...` — the full change is 4 needle strings, 2 quote lines, 1 provenance sentence, 1 cache.

## Boundaries

Mechanical re-pin only; no claim, verdict, status, or axiom content changed. Sets no audit status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)