### PR TITLE
koide: convention-invariant fixed-label scalar selectors are doublet-constant (bounded salvage)

### DIFF
--- a/docs/KOIDE_CONVENTION_INVARIANT_SCALAR_SELECTOR_DOUBLET_CONSTANCY_NARROW_THEOREM_NOTE_2026-07-12.md
+++ b/docs/KOIDE_CONVENTION_INVARIANT_SCALAR_SELECTOR_DOUBLET_CONSTANCY_NARROW_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,210 @@
+# Koide Convention-Invariant Scalar-Selector Doublet Constancy (Narrow Theorem)
+
+**Date:** 2026-07-12
+**Type:** bounded_theorem
+**Claim type:** bounded_theorem
+**Primary runner:**
+[`scripts/koide_convention_invariant_scalar_selector_doublet_constancy_2026_07_12.py`](../scripts/koide_convention_invariant_scalar_selector_doublet_constancy_2026_07_12.py)
+**Cache:**
+[`logs/runner-cache/koide_convention_invariant_scalar_selector_doublet_constancy_2026_07_12.txt`](../logs/runner-cache/koide_convention_invariant_scalar_selector_doublet_constancy_2026_07_12.txt)
+
+## Purpose
+
+The einselection-era calculation distinguished two facts. The Hermitian
+operator `C+C^2` is conjugation-even and resolves singlet from doublet, while
+the Hermitian operator `i(C-C^2)` resolves the two doublet sectors but changes
+sign under conjugation.
+
+This note proves the narrow statement supported by that algebra. On the
+supplied abstract `C_3` sector surface, a convention-invariant selector into a
+pointwise-fixed scalar-label space is constant on the conjugate doublet. The
+result is about fixed scalar labels. It does not say that the finest unlabeled
+sector partition has two blocks: an unordered three-atom spectral PVM is a
+decisive counterexample to that stronger claim.
+
+## Theorem (narrow)
+
+### T1 — The complex-unit orientation is not named content
+
+The argument is a positive-list one, not an exclusion one. The sentence
+"adds no further primitive structure" constrains what the real presentation
+contributes; by itself it does not exclude the complex structure of the
+`M_2(C)` presentation from the primitives. What decides the question is the
+memo's named-content burden. The live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) states:
+
+> These axioms state only their named primitive content. Further physical
+> structure requires a retained derivation or bridge, or explicit approved-
+> primitive registration, before use as a premise. A choice not fixed by the
+> supplied structure remains a named conditional or open dependency.
+
+The axioms do not name an orientation of the complex unit. The runner makes
+this mechanical with a two-model witness. The standard Pauli presentation and
+its entrywise-conjugate satisfy the same `Cl(3,0)` relations and the same
+abstract `M_2(C)` presentation, while their central pseudoscalars are `+iI`
+and `-iI`. Entrywise conjugation is multiplicative and real-linear on the full
+eight-monomial real spanning basis. Holding the Lattice, Admissibility, and
+Record data fixed therefore gives two presentations of the named content that
+differ only in complex-unit orientation. The label `M_2(C)` does not select
+between them: field conjugation maps the presentation to its conjugate.
+
+The real presentation reinforces this conclusion without supplying the
+positive-list burden. The memo also states:
+
+> A `Cl(3,0)`-compatible real-algebra presentation may be used equivalently and
+> adds no further primitive structure.
+
+There the complex unit is represented by the central pseudoscalar
+`omega_ps=e_1e_2e_3`, with `omega_ps^2=-1`. Reversing generator orientation
+changes its sign, and the canonical grade involution `e_i -> -e_i` sends
+`omega_ps -> -omega_ps`.
+
+Thus the complex-unit orientation is not fixed by the named supplied
+structure. Under the live Qualification it remains a named conditional or
+open dependency; it is not available to an `A_min`-only fixed-label selector.
+
+### T2 — Conjugation swaps the doublet sectors on the abstract sector surface
+
+On the supplied abstract `C_3` sector algebra, let `C` be the real cyclic
+matrix and define
+
+`P_chi=(1/3)(I+conjugate(chi)C+conjugate(chi^2)C^2)`
+
+for `chi` in `{1,w,conjugate(w)}`, where
+`w=-1/2+(sqrt(3)/2)i`. These character projectors resolve the identity.
+Entrywise conjugation fixes `C` and `P_1` and swaps
+`P_w <-> P_conjugate(w)`. The cyclic translation operator has a real
+permutation-matrix presentation; its two nonreal character labels are
+exchanged rather than individually fixed.
+
+This is a statement about the defined abstract sector algebra. It does not
+identify that algebra with a physical charged-lepton carrier.
+
+### T3 — Fixed-label scalar selectors are doublet-constant
+
+Let `tau` fix the singlet sector and exchange the two doublet sectors. Let
+`f` map the three sectors into a scalar-label space on which `tau` acts
+trivially. A selector derived without an orientation choice must satisfy
+
+`f(tau(x))=f(x)`.
+
+Therefore
+
+`f(w-sector)=f(conjugate(w)-sector)`.
+
+The exhaustive finite check evaluates all 27 functions from the three sectors
+to three fixed labels. Exactly 9 are invariant under domain pullback by `tau`,
+and every invariant function is doublet-constant. Their fiber partitions are
+only the one-block partition and `{singlet,doublet-orbit}`.
+
+The two-block scalar distinction is attained, not merely bounded above:
+`C+C^2` is conjugation-fixed and has eigenvalue `2` on the singlet projector
+and eigenvalue `-1` on the rank-two doublet projector. Hence the finest fiber
+partition available to a convention-invariant **fixed-label scalar selector**
+has the two blocks `{singlet,doublet-orbit}`.
+
+The bold qualifier is load-bearing. This theorem does not classify unlabeled
+partitions, equivariant labels, or PVMs whose atoms are permuted.
+
+## Decisive counterexample to the stronger partition claim
+
+Set
+
+`O=i(C-C^2)`.
+
+The runner verifies that `O` is Hermitian, has eigenvalues
+`{-sqrt(3),0,+sqrt(3)}`, and obeys `conjugate(O)=-O`. Choosing the signed
+observable `O` rather than `-O`, or attaching the fixed sign labels
+`+sqrt(3)` and `-sqrt(3)` to the two doublet sectors, requires an orientation.
+
+But the unordered spectral PVM is the same for either representative:
+
+`{P_1,P_w,P_conjugate(w)}`.
+
+Conjugation swaps two atoms and fixes the set. Thus the unlabeled three-block
+partition is convention-stable and resolves all three sectors without
+privileging either doublet member. Convention freeness alone does not derive
+ORBIT-INDEXING or identify the conjugate sectors as one record content.
+
+## Boundary consequence — the sibling partition is not discharged
+
+The landed sibling context
+`ACPHILAMBDA_OCCUPANCY_GRAIN_RULE_CLASS_UNIVERSALITY_BOUNDED_THEOREM_NOTE_2026-07-11.md`
+declares:
+
+> The charged-lepton 2-sector occupancy surface is the K/CPT-orbit partition
+> `{singlet sector, doublet orbit}` with occupancy distribution `(p_s,p_d)`,
+> `p_s+p_d=1`, where the equal-power-per-block grain reads `r=1/2` at
+> `p_s=p_d`.
+
+The fixed-label scalar-selector theorem does not derive that supplied
+occupancy partition. The existing context handle
+`KCPT_ORBIT_CONSTANCY_AND_DETERMINANT_CHARACTER_BOUNDARY_SUPPLIED_CONTEXT_BRIDGE_NOTE_2026-07-04.md`
+states explicitly that ORBIT-INDEXING is supplied and is not derived from
+Record. Distinct conjugate record contents with an unordered PVM remain
+compatible with the current axioms.
+
+Accordingly, no registry or bridge discharge is available from this theorem.
+Any future registry action remains owner-gated and requires a retained source
+for ORBIT-INDEXING or an equivalent physical identification.
+
+## What is not derived
+
+1. K-reality's value face is not derived: there is no claim that `delta=0`
+   and no claim about a registered phase magnitude.
+2. The K-odd monitor `i(C-C^2)` exists, is Hermitian, and resolves the
+   doublet. Its signed privileging is convention-dependent, while its
+   unordered three-atom PVM remains convention-stable. Existence, signed
+   privileging, and unlabeled partition structure are kept distinct.
+3. A complex-unit orientation is not derived. Under current main it can only
+   remain a named conditional/open dependency or follow a separately retained
+   bridge or owner-approved primitive registration. For provenance, the
+   superseded Qualification phrased the conditional escape as "unless that
+   choice is admitted." Current main has no admission class, so that historical
+   wording carries zero premise authority.
+4. The physical charged-lepton carrier identification and ORBIT-INDEXING are
+   not derived here.
+5. No normalized weights, probability simplex, measure, or occupancy/grain
+   selection is derived. The sibling's `p_s+p_d=1` and `r=1/2` readings remain
+   supplied conditions there.
+6. No R-eta bridge, mass content, comparator, threshold, record-formation
+   rule, process, state, site, weight, or rate is selected.
+
+## Scope boundary
+
+- This is a finite theorem about fixed-label scalar selectors on a supplied
+  abstract `C_3` sector algebra.
+- It proves doublet constancy only when the selector codomain is pointwise
+  fixed under the convention automorphism.
+- Equivariant selectors and unordered PVMs whose outputs are permuted are
+  explicitly allowed; their existence blocks the broader orbit-partition
+  discharge.
+- The K/CPT vocabulary, landed sibling declaration, and existing
+  ORBIT-INDEXING bridge are context handles only. They carry no load-bearing
+  citation-graph edge in this note.
+- Effective status and any downstream use remain owned by the independent
+  audit lane.
+
+## Load-bearing dependency
+
+| dependency | consumed content |
+|---|---|
+| [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | the Qubit algebra presentations, no-privilege clause, and live named-content/conditional-choice Qualification |
+
+## Runner verification map
+
+| check block | exact verification | result |
+|---|---|---:|
+| V1 | five whitespace-flattened current-memo clauses: Qubit real presentation, no privilege, live conditional/open choice clause, Record additivity as a boundary check, and the named-content burden | PASS (5) |
+| V2 | Pauli `Cl(3,0)` relations; `ps=+iI`, `ps^2=-I`; conjugated relations and `ps=-iI`; exact two-root center check and exchange; multiplicative and symbolic real-linear two-model witness | PASS (10) |
+| V3 | grade involution multiplicativity on all `8 x 8` basis-monomial products and `alpha(ps)=-ps` | PASS (2) |
+| V4 | projector resolution, idempotence, orthogonality, character equation, conjugation action, and fixed rank-two doublet block | PASS (8) |
+| V5 | exhaustive domain-swap action on 27 fixed-label selectors, exactly 9 invariant selectors, doublet constancy, and the two possible fiber partitions | PASS (4) |
+| V6 | K-odd Hermitian resolver, its conjugation-stable unordered three-atom PVM, K-even singlet/doublet scalar resolver, and character-`w` fixed-label flip | PASS (8) |
+| V7 | landed sibling declaration and existing bridge's supplied ORBIT-INDEXING framing, checked as non-load-bearing boundary context | PASS (3) |
+
+```text
+TOTAL: PASS=40 FAIL=0
+```
+
+**No check passes by literal stipulation.**

--- a/logs/runner-cache/koide_convention_invariant_scalar_selector_doublet_constancy_2026_07_12.txt
+++ b/logs/runner-cache/koide_convention_invariant_scalar_selector_doublet_constancy_2026_07_12.txt
@@ -1,0 +1,52 @@
+===== runner cache v1 =====
+runner: scripts/koide_convention_invariant_scalar_selector_doublet_constancy_2026_07_12.py
+runner_sha256: 5e8afefedf6b2440e48c5558e913550c9dfe29e6d38f53a9c6e7510d5534f7ce
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 1.45
+status: ok
+----- stdout -----
+PASS V1.1 Qubit real-presentation clause verbatim
+PASS V1.2 no-possibility-privileged clause verbatim
+PASS V1.3 Qualification choice clause verbatim
+PASS V1.4 Record additivity clause verbatim
+PASS V1.5 named-primitive-content burden clause verbatim
+PASS V2.1 Pauli generators satisfy Cl(3,0)
+PASS V2.2 pseudoscalar equals iI
+PASS V2.3 pseudoscalar squares to -I
+PASS V2.4 conjugated generators satisfy Cl(3,0)
+PASS V2.5 conjugated pseudoscalar equals -iI
+PASS V2.6 real-span central square roots are exactly +/-ps
+PASS V2.7 both roots are central and square to -I
+PASS V2.8 entrywise conjugation exchanges the two roots
+PASS V2.9 two-model witness: conjugation is multiplicative over all 64 monomial products
+PASS V2.10 two-model witness: conjugation is R-linear over the spanning basis
+PASS V3.1 grade involution multiplicative on all 8x8 basis products
+PASS V3.2 grade involution sends ps to -ps
+PASS V4.1 character projectors resolve identity
+PASS V4.2 character projectors are idempotent
+PASS V4.3 character projectors are pairwise orthogonal
+PASS V4.4 C Pw = w Pw
+PASS V4.5 C and P1 are conjugation-fixed
+PASS V4.6 conjugation swaps Pw and P_wbar
+PASS V4.7 doublet block is conjugation-fixed
+PASS V4.8 doublet block has rank 2
+PASS V5.1 exactly 9 of 27 selectors are swap-invariant
+PASS V5.2 fixed-label swap invariance forces doublet constancy
+PASS V5.3 invariant fixed-label selector fibers give exactly two partitions
+PASS V5.4 finest fixed-label scalar-selector fiber partition has 2 blocks
+PASS V6a.1 i(C-C^2) is Hermitian
+PASS V6a.2 i(C-C^2) is conjugation-odd
+PASS V6a.3 i(C-C^2) has the resolving spectrum
+PASS V6a.4 unordered three-atom PVM is conjugation-stable
+PASS V6b.1 C+C^2 is conjugation-even
+PASS V6b.2 C+C^2 has singlet-doublet spectrum
+PASS V6b.3 C+C^2 retains a rank-1/rank-2 distinction
+PASS V6c character-w selector flips under conjugation
+PASS V7.1 sibling supplied-context declaration verbatim
+PASS V7.2 bridge supplied ORBIT-INDEXING bullet verbatim
+PASS V7.3 bridge supplied-context framing verbatim
+TOTAL: PASS=40 FAIL=0
+
+----- stderr -----
+

--- a/scripts/koide_convention_invariant_scalar_selector_doublet_constancy_2026_07_12.py
+++ b/scripts/koide_convention_invariant_scalar_selector_doublet_constancy_2026_07_12.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Exact checks for convention-invariant fixed-label selector constancy."""
+
+from itertools import product
+from pathlib import Path
+import re
+import sys
+
+import sympy as sp
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MEMO = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+SIBLING = ROOT / "docs" / (
+    "ACPHILAMBDA_OCCUPANCY_GRAIN_RULE_CLASS_UNIVERSALITY_"
+    "BOUNDED_THEOREM_NOTE_2026-07-11.md"
+)
+BRIDGE = ROOT / "docs" / (
+    "KCPT_ORBIT_CONSTANCY_AND_DETERMINANT_CHARACTER_BOUNDARY_"
+    "SUPPLIED_CONTEXT_BRIDGE_NOTE_2026-07-04.md"
+)
+
+PASS = 0
+FAIL = 0
+
+
+def flat(text):
+    collapsed = re.sub(r"\s+", " ", text).strip()
+    return re.sub(r"(?<=\w)- (?=\w)", "-", collapsed)
+
+
+def matrix_zero(matrix):
+    return all(sp.simplify(entry) == 0 for entry in matrix)
+
+
+def matrix_equal(left, right):
+    return matrix_zero(left - right)
+
+
+def check(name, condition):
+    global PASS, FAIL
+    if bool(condition):
+        PASS += 1
+        print(f"PASS {name}")
+    else:
+        FAIL += 1
+        print(f"FAIL {name}")
+
+
+memo_text = flat(MEMO.read_text(encoding="utf-8"))
+sibling_source = SIBLING.read_text(encoding="utf-8")
+sibling_text = flat(re.sub(r"(?m)^> ?", "", sibling_source))
+bridge_text = flat(BRIDGE.read_text(encoding="utf-8"))
+
+# V1: exact memo text, matched only after whitespace flattening.
+real_presentation = (
+    "A `Cl(3,0)`-compatible real-algebra presentation may be used "
+    "equivalently and adds no further primitive structure."
+)
+no_privilege = "No possibility is privileged."
+qualification = (
+    "A choice not fixed by the supplied structure remains a named "
+    "conditional or open dependency."
+)
+record_additivity = (
+    "For any finite collection of pairwise-disjoint records, scalar readout "
+    "`I` is additive, with `I(empty)=0`."
+)
+check("V1.1 Qubit real-presentation clause verbatim", real_presentation in memo_text)
+check("V1.2 no-possibility-privileged clause verbatim", no_privilege in memo_text)
+check("V1.3 Qualification choice clause verbatim", qualification in memo_text)
+check("V1.4 Record additivity clause verbatim", record_additivity in memo_text)
+named_content = (
+    "These axioms state only their named primitive content. Further physical "
+    "structure requires a retained derivation or bridge, or explicit "
+    "approved-primitive registration, before use as a premise."
+)
+check("V1.5 named-primitive-content burden clause verbatim", named_content in memo_text)
+
+# V2: Pauli realization of Cl(3,0), its pseudoscalar, and conjugation.
+I = sp.I
+sqrt3 = sp.sqrt(3)
+eye2 = sp.eye(2)
+s1 = sp.Matrix([[0, 1], [1, 0]])
+s2 = sp.Matrix([[0, -I], [I, 0]])
+s3 = sp.Matrix([[1, 0], [0, -1]])
+sigmas = (s1, s2, s3)
+
+clifford = []
+for j, left in enumerate(sigmas):
+    for k, right in enumerate(sigmas):
+        target = 2 * eye2 if j == k else sp.zeros(2)
+        clifford.append(matrix_equal(left * right + right * left, target))
+check("V2.1 Pauli generators satisfy Cl(3,0)", all(clifford))
+
+ps = s1 * s2 * s3
+check("V2.2 pseudoscalar equals iI", matrix_equal(ps, I * eye2))
+check("V2.3 pseudoscalar squares to -I", matrix_equal(ps**2, -eye2))
+
+conjugated = tuple(s.conjugate() for s in sigmas)
+conjugated_clifford = []
+for j, left in enumerate(conjugated):
+    for k, right in enumerate(conjugated):
+        target = 2 * eye2 if j == k else sp.zeros(2)
+        conjugated_clifford.append(
+            matrix_equal(left * right + right * left, target)
+        )
+check(
+    "V2.4 conjugated generators satisfy Cl(3,0)",
+    all(conjugated_clifford),
+)
+conjugated_ps = conjugated[0] * conjugated[1] * conjugated[2]
+check("V2.5 conjugated pseudoscalar equals -iI", matrix_equal(conjugated_ps, -I * eye2))
+
+a, b = sp.symbols("a b", real=True)
+root_equations = (a**2 - b**2 + 1, 2 * a * b)
+real_roots = set(sp.solve(root_equations, (a, b), domain=sp.S.Reals))
+expected_roots = {(sp.Integer(0), sp.Integer(-1)), (sp.Integer(0), sp.Integer(1))}
+check("V2.6 real-span central square roots are exactly +/-ps", real_roots == expected_roots)
+
+x11, x12, x21, x22 = sp.symbols("x11 x12 x21 x22")
+generic_matrix = sp.Matrix([[x11, x12], [x21, x22]])
+central_checks = []
+root_checks = []
+for a_value, b_value in sorted(real_roots, key=str):
+    candidate = a_value * eye2 + b_value * ps
+    central_checks.append(matrix_zero(candidate * generic_matrix - generic_matrix * candidate))
+    root_checks.append(matrix_equal(candidate**2, -eye2))
+check("V2.7 both roots are central and square to -I", all(central_checks + root_checks))
+check("V2.8 entrywise conjugation exchanges the two roots", matrix_equal(ps.conjugate(), -ps))
+
+# Two-model witness: entrywise conjugation is a real-algebra automorphism --
+# multiplicative over the full 8-monomial spanning basis — so the standard
+# and conjugated presentations are two models of the named Qubit content
+# agreeing on every named clause and differing only in orientation.
+monomials = [eye2, s1, s2, s3, s1 * s2, s1 * s3, s2 * s3, s1 * s2 * s3]
+conj_mult = all(
+    matrix_equal((m1 * m2).conjugate(), m1.conjugate() * m2.conjugate())
+    for m1 in monomials
+    for m2 in monomials
+)
+check("V2.9 two-model witness: conjugation is multiplicative over all 64 monomial products", conj_mult)
+r_coeff, s_coeff = sp.symbols("r_coeff s_coeff", real=True)
+conj_rlinear = all(
+    matrix_equal(
+        (r_coeff * m1 + s_coeff * m2).conjugate(),
+        r_coeff * m1.conjugate() + s_coeff * m2.conjugate(),
+    )
+    for m1 in monomials
+    for m2 in monomials
+)
+check("V2.10 two-model witness: conjugation is R-linear over the spanning basis", conj_rlinear)
+
+# V3: grade involution on all 8x8 basis-monomial products.
+words = ((), (0,), (1,), (2,), (0, 1), (0, 2), (1, 2), (0, 1, 2))
+
+
+def rebuild(word, generators):
+    result = eye2
+    for index in word:
+        result = result * generators[index]
+    return result
+
+
+negative_sigmas = tuple(-s for s in sigmas)
+basis_matrices = tuple(rebuild(word, sigmas) for word in words)
+alpha_basis_matrices = tuple(rebuild(word, negative_sigmas) for word in words)
+
+
+def real_vector(matrix):
+    entries = []
+    for entry in matrix:
+        entries.extend((sp.re(entry), sp.im(entry)))
+    return sp.Matrix(entries)
+
+
+basis_coordinate_matrix = sp.Matrix.hstack(
+    *(real_vector(matrix) for matrix in basis_matrices)
+)
+basis_coordinate_inverse = basis_coordinate_matrix.inv()
+
+
+def alpha_linear(matrix):
+    coefficients = basis_coordinate_inverse * real_vector(matrix)
+    return sp.simplify(
+        sum(
+            (coefficient * image for coefficient, image in zip(
+                coefficients, alpha_basis_matrices
+            )),
+            sp.zeros(2),
+        )
+    )
+
+
+alpha_multiplicative = []
+for left_index, left_matrix in enumerate(basis_matrices):
+    for right_index, right_matrix in enumerate(basis_matrices):
+        alpha_of_product = alpha_linear(left_matrix * right_matrix)
+        product_of_alphas = (
+            alpha_basis_matrices[left_index]
+            * alpha_basis_matrices[right_index]
+        )
+        alpha_multiplicative.append(
+            matrix_equal(alpha_of_product, product_of_alphas)
+        )
+check("V3.1 grade involution multiplicative on all 8x8 basis products", all(alpha_multiplicative))
+alpha_ps = rebuild((0, 1, 2), negative_sigmas)
+check("V3.2 grade involution sends ps to -ps", matrix_equal(alpha_ps, -ps))
+
+# V4: exact C3 character projectors and conjugation action.
+C = sp.Matrix([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
+eye3 = sp.eye(3)
+w = -sp.Rational(1, 2) + sqrt3 * I / 2
+wbar = sp.conjugate(w)
+
+
+def character_projector(character):
+    return sp.simplify(
+        (eye3 + sp.conjugate(character) * C
+         + sp.conjugate(character**2) * C**2) / 3
+    )
+
+
+P1 = character_projector(sp.Integer(1))
+Pw = character_projector(w)
+Pwbar = character_projector(wbar)
+projectors = (P1, Pw, Pwbar)
+check("V4.1 character projectors resolve identity", matrix_equal(sum(projectors, sp.zeros(3)), eye3))
+check("V4.2 character projectors are idempotent", all(matrix_equal(P * P, P) for P in projectors))
+check(
+    "V4.3 character projectors are pairwise orthogonal",
+    all(matrix_zero(projectors[j] * projectors[k]) for j in range(3) for k in range(3) if j != k),
+)
+check("V4.4 C Pw = w Pw", matrix_equal(C * Pw, w * Pw))
+check("V4.5 C and P1 are conjugation-fixed", matrix_equal(C.conjugate(), C) and matrix_equal(P1.conjugate(), P1))
+check("V4.6 conjugation swaps Pw and P_wbar", matrix_equal(Pw.conjugate(), Pwbar))
+doublet = sp.simplify(Pw + Pwbar)
+check("V4.7 doublet block is conjugation-fixed", matrix_equal(doublet.conjugate(), doublet))
+check("V4.8 doublet block has rank 2", doublet.rank() == 2)
+
+# V5: exhaustive fixed-label selectors and their fiber partitions.
+selectors = list(product(range(3), repeat=3))
+sector_swap = (0, 2, 1)
+
+
+def pullback_by_sector_swap(selector):
+    return tuple(selector[sector_swap[index]] for index in range(3))
+
+
+invariant_selectors = [
+    selector
+    for selector in selectors
+    if pullback_by_sector_swap(selector) == selector
+]
+check("V5.1 exactly 9 of 27 selectors are swap-invariant", len(selectors) == 27 and len(invariant_selectors) == 9)
+check(
+    "V5.2 fixed-label swap invariance forces doublet constancy",
+    all(selector[1] == selector[2] for selector in invariant_selectors)
+    and any(selector[1] != selector[2] for selector in selectors),
+)
+
+
+def fiber_partition(selector):
+    blocks = []
+    for label in sorted(set(selector)):
+        blocks.append(tuple(index for index, value in enumerate(selector) if value == label))
+    return tuple(sorted(blocks))
+
+
+induced_partitions = {fiber_partition(f) for f in invariant_selectors}
+expected_partitions = {((0, 1, 2),), ((0,), (1, 2))}
+block_counts = {len(partition) for partition in induced_partitions}
+check("V5.3 invariant fixed-label selector fibers give exactly two partitions", induced_partitions == expected_partitions)
+check("V5.4 finest fixed-label scalar-selector fiber partition has 2 blocks", max(block_counts) == 2 and ((0,), (1, 2)) in induced_partitions)
+
+# V6: convention-odd resolver and convention-even surviving distinction.
+odd_observable = sp.simplify(I * (C - C**2))
+odd_eigenvalues = set(odd_observable.eigenvals())
+check("V6a.1 i(C-C^2) is Hermitian", matrix_equal(odd_observable.conjugate().T, odd_observable))
+check("V6a.2 i(C-C^2) is conjugation-odd", matrix_equal(odd_observable.conjugate(), -odd_observable))
+check("V6a.3 i(C-C^2) has the resolving spectrum", odd_eigenvalues == {-sqrt3, sp.Integer(0), sqrt3})
+
+
+def matrix_collection_equal(left, right):
+    return len(left) == len(right) and all(
+        any(matrix_equal(candidate, target) for target in right)
+        for candidate in left
+    )
+
+
+unordered_pvm = tuple(projectors)
+conjugated_unordered_pvm = tuple(P.conjugate() for P in projectors)
+check(
+    "V6a.4 unordered three-atom PVM is conjugation-stable",
+    matrix_collection_equal(unordered_pvm, conjugated_unordered_pvm)
+    and len(unordered_pvm) == 3,
+)
+
+even_observable = C + C**2
+even_eigenvalues = set(even_observable.eigenvals())
+check("V6b.1 C+C^2 is conjugation-even", matrix_equal(even_observable.conjugate(), even_observable))
+check("V6b.2 C+C^2 has singlet-doublet spectrum", even_eigenvalues == {sp.Integer(2), sp.Integer(-1)})
+check("V6b.3 C+C^2 retains a rank-1/rank-2 distinction", even_observable.eigenvals()[2] == 1 and even_observable.eigenvals()[-1] == 2)
+
+assignment = (sp.Integer(1), w, wbar)
+conjugated_assignment = tuple(sp.conjugate(value) for value in assignment)
+w_selector = tuple(int(sp.simplify(value - w) == 0) for value in assignment)
+conjugated_w_selector = tuple(int(sp.simplify(value - w) == 0) for value in conjugated_assignment)
+check("V6c character-w selector flips under conjugation", w_selector == (0, 1, 0) and conjugated_w_selector == (0, 0, 1))
+
+# V7: exact consumed-scope source text.
+sibling_declaration = (
+    "The charged-lepton 2-sector occupancy surface is the K/CPT-orbit "
+    "partition `{singlet sector, doublet orbit}` with occupancy distribution "
+    "`(p_s,p_d)`, `p_s+p_d=1`, where the equal-power-per-block grain reads "
+    "`r=1/2` at `p_s=p_d`."
+)
+orbit_indexing = (
+    "**ORBIT-INDEXING:** the context's record contents are indexed by "
+    "`K`-orbits, so `K`-conjugate outcomes carry the same record content;"
+)
+supplied_framing = (
+    "ORBIT-INDEXING and the determinant-character/log-character "
+    "homomorphism boundary are supplied context structure. They are not "
+    "derived from Record."
+)
+check("V7.1 sibling supplied-context declaration verbatim", sibling_declaration in sibling_text)
+check("V7.2 bridge supplied ORBIT-INDEXING bullet verbatim", orbit_indexing in bridge_text)
+check("V7.3 bridge supplied-context framing verbatim", supplied_framing in bridge_text)
+
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+sys.exit(int(FAIL != 0))


### PR DESCRIPTION
## Summary

This PR now carries the narrow theorem that survived review-loop. The originally advertised derivation of the full K/CPT orbit partition did not survive the No-Go Discipline steelman and has been removed.

- **T1 — positive-list route:** the current axiom memo supplies only its named primitive content and leaves an unfixed complex-unit orientation conditional/open. The proof explicitly rejects the invalid inference that “adds no further primitive structure” excludes the complex structure. Standard and conjugated Pauli presentations satisfy the named Qubit algebra identically while their pseudoscalars are `+iI` and `-iI`.
- **T2 — abstract sector algebra:** for real cyclic `C`, entrywise conjugation fixes `P_1` and swaps `P_w <-> P_wbar`.
- **T3 — narrow conclusion:** on the supplied abstract `C_3` surface, every convention-invariant selector into a pointwise-fixed scalar-label space is constant on the conjugate doublet. `C+C^2` constructively attains the singlet-versus-doublet fixed-label fiber partition.
- **Hostile control:** `i(C-C^2)` is Hermitian, conjugation-odd, and has spectrum `{-sqrt(3),0,+sqrt(3)}`. Its unordered three-atom spectral PVM is conjugation-stable, so convention freeness does **not** force the finest unlabeled partition to fuse the doublet.

## Claim boundary

The sibling occupancy theorem’s supplied K/CPT two-sector partition is **not discharged** here. ORBIT-INDEXING, the physical charged-lepton carrier, normalized weights, measure/grain selection, `delta=0` / the K-reality value face, and every formation rule/process/state/site/weight/rate remain open or conditional. No registry or bridge action is performed or made available by this theorem.

The historical phrase “unless that choice is admitted” remains recorded only as superseded provenance. Current main has no admission class; the live route is a named conditional/open dependency, a separately retained bridge, or owner-approved primitive registration.

## Verification

- Fresh runner and SHA-pinned cache: `TOTAL: PASS=40 FAIL=0`.
- Independent NumPy/DFT recomputation: Pauli signs, conjugated pseudoscalar `-iI`, projector conjugation, K-odd/K-even spectra, unordered PVM stability, and the 27-selector sweep all agree.
- `py_compile`, vocabulary lint, controlled-vocabulary render check, full audit pipeline validation, strict audit lint, portable-link scan, generated-output stripping, and `git diff --check` are required landing gates.
- New claim ID remains `unaudited`; the independent audit lane owns any later verdict.

Review-loop executor: Codex GPT-5.6-sol at maximum reasoning. Owner requested landing; no audit status set.
