### PR TITLE
physics: derive C3 resolvent determinant holonomy coupling

### DIFF
--- a/docs/ACPHILAMBDA_C3_RESOLVENT_DETERMINANT_HOLONOMY_COUPLING_NARROW_THEOREM_NOTE_2026-07-12.md
+++ b/docs/ACPHILAMBDA_C3_RESOLVENT_DETERMINANT_HOLONOMY_COUPLING_NARROW_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,191 @@
+# AC_phi_lambda C3 Resolvent Determinant-Holonomy Coupling
+
+**Date:** 2026-07-12
+**Claim type:** positive_theorem
+**Status authority:** independent audit lane. This source proposal does not
+set or predict an audit verdict.
+**Primary runner:**
+[`scripts/acphilambda_c3_resolvent_determinant_holonomy_coupling_2026_07_12.py`](../scripts/acphilambda_c3_resolvent_determinant_holonomy_coupling_2026_07_12.py)
+**Runner cache:**
+[`logs/runner-cache/acphilambda_c3_resolvent_determinant_holonomy_coupling_2026_07_12.txt`](../logs/runner-cache/acphilambda_c3_resolvent_determinant_holonomy_coupling_2026_07_12.txt)
+
+## Exact theorem
+
+On the real normal plane of the proper cubic `C3` body-diagonal rotation, use
+the basis in which the retained normal action is
+
+```text
+P_N = [[0,-1],
+       [1,-1]].
+```
+
+Define the two resolvents and their group-order-normalized nonidentity sum by
+
+```text
+R_1 = (I-P_N)^(-1),
+R_2 = (I-P_N^2)^(-1),
+B   = (R_1+R_2)/3.
+```
+
+Then
+
+```text
+R_1 = (1/3)[[2,-1],    R_2 = (1/3)[[ 1,1],
+              [1, 1]],                  [-1,2]],
+
+R_1+R_2 = I,
+B = I/3.
+```
+
+The inverse-normal-determinant density retained in
+[`KOIDE_APS_C3_FIXED_LOCUS_WEIGHTS_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md`](KOIDE_APS_C3_FIXED_LOCUS_WEIGHTS_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md)
+is
+
+```text
+h = (1/3) sum_(k=1)^2 det(I-P_N^k)^(-1) = 2/9.
+```
+
+The operator sum and the scalar density therefore obey the exact relation
+
+```text
+tr(B)=2/3=3h.
+```
+
+For real `beta`, define the finite unitary family
+
+```text
+U_beta = exp(i beta B).
+```
+
+Since `B=I/3`,
+
+```text
+U_beta = exp(i beta/3) I,
+det(U_beta)=exp(2 i beta/3).
+```
+
+At `beta=1`, the principal determinant phase is `2/3`. Choose the exponential
+root associated with the additive three-step lift:
+
+```text
+E = exp(i B/3).
+```
+
+It satisfies `E^3=U_1` and
+
+```text
+arg det(E)=2/9=h.
+```
+
+This is an exact coupling between the retained fixed-locus density and a
+constructed determinant-holonomy line. It is a finite algebra theorem; the
+physical identification boundary is stated below.
+
+## Fermionic determinant-power consequence
+
+Use `K=U_beta` as a supplied finite Grassmann kernel. The retained
+[`ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md`](ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md)
+gives, with its explicit Berezin orientation,
+
+```text
+Z_single(beta)=det_C(U_beta)=exp(2 i beta/3).
+```
+
+Writing this same single sector in Majorana-paired coordinates preserves its
+determinant power and phase. Adjoining an independent conjugate sector instead
+gives
+
+```text
+Z_pair(beta)
+  = det_C(U_beta) det_C(conjugate(U_beta))
+  = 1.
+```
+
+The ordinary realification determinant has the same phase-free scalar:
+
+```text
+det_R R(U_beta)=|det_C(U_beta)|^2=1.
+```
+
+Thus, at `beta=1`, the constructed nonzero determinant phase distinguishes the supplied
+single sector from the supplied conjugate-paired total determinant. A
+coordinate rewrite of the single sector does not erase it.
+
+## Determinant-character weights
+
+For the integer determinant-character family
+
+```text
+chi_k(z)=z^k,   k in Z,
+```
+
+the constructed line gives
+
+```text
+chi_k(det U_beta)=exp(2 i k beta/3).
+```
+
+Within this family, `chi_k` is faithful on `U(1)` exactly for `k=+1` or
+`k=-1`; `k=0` is trivial, and `|k|>1` has a nontrivial root-of-unity kernel.
+Complex conjugation exchanges the two faithful orientations. The
+conjugate-paired total line has net weight `k+(-k)=0` and hence trivial phase.
+Indeed, `chi_1` is the identity and `chi_-1` is inversion. For `|k|>1`, the
+nontrivial root `exp(2 pi i/|k|)` lies in the kernel of `chi_k`; for `k=0`,
+every point lies in the kernel.
+
+On the additive principal lift where `|2k beta/3|<pi`, the corresponding
+symmetric three-step phase is
+
+```text
+delta_(k,beta)=2 k beta/9.
+```
+
+The target magnitude `2/9` therefore corresponds algebraically to
+`|k beta|=1`. The displayed phase equation depends on the product `k beta`.
+Without a separately derived physical-faithfulness condition or connection
+normalization, that equation does not choose either factor.
+
+## Physical identification boundary
+
+The theorem constructs `B`, `U_beta`, and their determinant lines from the
+finite normal representation. It does not derive that:
+
+- `B` is the physical charged-lepton connection or action generator;
+- the physical fermionic kernel is `U_1`, `bC`, or another matrix carrying
+  this determinant line;
+- `beta=1` rather than another real normalization;
+- the physical Record character is faithful and therefore fundamental within
+  the displayed integer-character family;
+- the physical Record scalar is the folded principal determinant phase;
+- the cycle has three symmetry-equivalent physical Record contributions whose
+  additive lift is represented by `E`;
+- the physical Record reads the total determinant rather than factor-resolved
+  phases of a paired carrier.
+
+The normal rotation itself has `det(P_N)=1` and hence no determinant phase.
+The phase-bearing object here is the constructed resolvent exponential, not a
+relabeling of `P_N`.
+
+Consequently this theorem does not, by itself, discharge the physical
+charged-lepton occupancy-grain or R-eta readout obligations. It identifies a
+joint positive theorem target. A future theorem would need to derive that the
+physical total action determinant is built from the displayed `U_1` sector,
+with or without its independent conjugate; that Record reads the folded
+principal phase of that total determinant through a faithful character; and
+that three symmetry-equivalent physical contributions realize the displayed
+`E` lift. Under those derived conditions, the nonzero h readout rules out the
+conjugate-paired total determinant.
+
+No value or equation involving the registered-mass amplitude ratio `r` enters
+the construction. The theorem does not force `r=1/2`. It adds no axiom,
+primitive, imported value, comparator, or premise-registry entry.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/acphilambda_c3_resolvent_determinant_holonomy_coupling_2026_07_12.py
+```
+
+Expected result: `PASS=34`, `FAIL=0`.

--- a/logs/runner-cache/acphilambda_c3_resolvent_determinant_holonomy_coupling_2026_07_12.txt
+++ b/logs/runner-cache/acphilambda_c3_resolvent_determinant_holonomy_coupling_2026_07_12.txt
@@ -1,0 +1,60 @@
+===== runner cache v1 =====
+runner: scripts/acphilambda_c3_resolvent_determinant_holonomy_coupling_2026_07_12.py
+runner_sha256: d7b36ff5ab7848f490ccf51ed2333892d2169f3e1337eb15d4955250af72908f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.63
+status: ok
+----- stdout -----
+AC_phi_lambda C3 resolvent determinant-holonomy coupling
+
+Part A: normal representation and resolvents
+PASS  normal basis is P3-invariant with the displayed action
+PASS  normal action has order three
+PASS  normal action has determinant one
+PASS  first resolvent is exact
+PASS  second resolvent is exact
+PASS  the two resolvents sum to identity
+PASS  group-order-normalized nonidentity resolvent sum B equals I/3
+
+Part B: fixed-locus density and trace coupling
+PASS  both inverse-normal determinants have denominator three
+PASS  fixed-locus density h equals 2/9
+PASS  trace(B) equals 2/3
+PASS  trace(B) equals three times h
+PASS  B is unchanged under generator reversal
+
+Part C: determinant holonomy and symmetric three-step root
+PASS  exp(i beta B) reduces to a scalar unitary
+PASS  det U_beta is exp(2 i beta/3)
+PASS  symmetric edge root cubes to U1
+PASS  cycle determinant phase is 2/3
+PASS  edge determinant phase is h
+PASS  three edge phases add to the cycle phase
+PASS  U1 is unitary
+
+Part D: single sector, conjugate pair, and realification
+PASS  rank-two Pfaffian has the retained raw sign
+PASS  single-sector determinant carries the cycle phase
+PASS  independent conjugate-paired determinant equals one
+PASS  ordinary realification determinant equals one
+PASS  conjugate pairing cancels the determinant phase
+PASS  complex conjugation reverses the single-sector phase
+
+Part E: determinant-character weights and remaining normalization
+PASS  character formula at k=1,beta=1 gives cycle phase 2/3
+PASS  conjugate character k=-1 reverses orientation
+PASS  paired net weight k+(-k) is phase-trivial
+PASS  k=2 character has a nontrivial kernel witness z=-1
+PASS  k=1 is the identity and k=-1 inversion is bijective
+PASS  sample nonfundamental characters have nontrivial root kernels
+PASS  edge determinant character is derived from exp(i k beta B/3)
+PASS  edge lift at k=1,beta=1 equals h
+PASS  beta=2 remains a distinct exact normalization
+
+========================================================================
+SCORECARD: PASS=34 FAIL=0
+========================================================================
+
+----- stderr -----
+

--- a/scripts/acphilambda_c3_resolvent_determinant_holonomy_coupling_2026_07_12.py
+++ b/scripts/acphilambda_c3_resolvent_determinant_holonomy_coupling_2026_07_12.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Exact C3 resolvent and determinant-holonomy coupling checks."""
+
+from __future__ import annotations
+
+import sympy as sp
+
+
+PASS_COUNT = 0
+FAIL_COUNT = 0
+
+
+def check(label: str, condition: bool, detail: object = "") -> None:
+    global PASS_COUNT, FAIL_COUNT
+    if bool(condition):
+        PASS_COUNT += 1
+        print(f"PASS  {label}")
+    else:
+        FAIL_COUNT += 1
+        suffix = f" -- {detail}" if detail != "" else ""
+        print(f"FAIL  {label}{suffix}")
+
+
+def realification(matrix: sp.Matrix) -> sp.Matrix:
+    real = matrix.applyfunc(sp.re)
+    imag = matrix.applyfunc(sp.im)
+    return real.row_join(-imag).col_join(imag.row_join(real))
+
+
+def pfaffian4(matrix: sp.Matrix) -> sp.Expr:
+    return sp.expand(
+        matrix[0, 1] * matrix[2, 3]
+        - matrix[0, 2] * matrix[1, 3]
+        + matrix[0, 3] * matrix[1, 2]
+    )
+
+
+def main() -> int:
+    print("AC_phi_lambda C3 resolvent determinant-holonomy coupling")
+    print()
+
+    print("Part A: normal representation and resolvents")
+    P3 = sp.Matrix([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
+    basis = sp.Matrix([[1, 0], [-1, 1], [0, -1]])
+    normal = sp.Matrix([[0, -1], [1, -1]])
+    check("normal basis is P3-invariant with the displayed action",
+          P3 * basis == basis * normal)
+    check("normal action has order three", normal**3 == sp.eye(2))
+    check("normal action has determinant one", normal.det() == 1)
+    R1 = (sp.eye(2) - normal).inv()
+    R2 = (sp.eye(2) - normal**2).inv()
+    expected_R1 = sp.Rational(1, 3) * sp.Matrix([[2, -1], [1, 1]])
+    expected_R2 = sp.Rational(1, 3) * sp.Matrix([[1, 1], [-1, 2]])
+    check("first resolvent is exact", R1 == expected_R1, R1)
+    check("second resolvent is exact", R2 == expected_R2, R2)
+    check("the two resolvents sum to identity", R1 + R2 == sp.eye(2))
+    B = sp.Rational(1, 3) * (R1 + R2)
+    check("group-order-normalized nonidentity resolvent sum B equals I/3",
+          B == sp.eye(2) / 3, B)
+    print()
+
+    print("Part B: fixed-locus density and trace coupling")
+    d1 = (sp.eye(2) - normal).det()
+    d2 = (sp.eye(2) - normal**2).det()
+    h = sp.Rational(1, 3) * (1 / d1 + 1 / d2)
+    check("both inverse-normal determinants have denominator three",
+          d1 == 3 and d2 == 3, (d1, d2))
+    check("fixed-locus density h equals 2/9", h == sp.Rational(2, 9), h)
+    check("trace(B) equals 2/3", sp.trace(B) == sp.Rational(2, 3))
+    check("trace(B) equals three times h", sp.trace(B) == 3 * h)
+    check("B is unchanged under generator reversal",
+          sp.Rational(1, 3) * (R2 + R1) == B)
+    print()
+
+    print("Part C: determinant holonomy and symmetric three-step root")
+    beta = sp.symbols("beta", real=True)
+    U_beta = sp.exp(sp.I * beta / 3) * sp.eye(2)
+    check("exp(i beta B) reduces to a scalar unitary",
+          (sp.I * beta * B).exp() == U_beta)
+    check("det U_beta is exp(2 i beta/3)",
+          sp.simplify(U_beta.det() - sp.exp(2 * sp.I * beta / 3)) == 0)
+    U1 = U_beta.subs(beta, 1)
+    edge = sp.exp(sp.I / 9) * sp.eye(2)
+    check("symmetric edge root cubes to U1", sp.simplify(edge**3 - U1) == sp.zeros(2))
+    check("cycle determinant phase is 2/3",
+          sp.arg(U1.det()).equals(sp.Rational(2, 3)))
+    check("edge determinant phase is h",
+          sp.arg(edge.det()).equals(h))
+    check("three edge phases add to the cycle phase", 3 * h == sp.Rational(2, 3))
+    check("U1 is unitary", sp.simplify(U1.H * U1) == sp.eye(2))
+    print()
+
+    print("Part D: single sector, conjugate pair, and realification")
+    K = U1
+    A_K = sp.zeros(4)
+    A_K[:2, 2:] = K
+    A_K[2:, :2] = -K.T
+    pf = pfaffian4(A_K)
+    check("rank-two Pfaffian has the retained raw sign",
+          sp.simplify(pf + K.det()) == 0)
+    z_single = sp.simplify(K.det())
+    z_pair = sp.simplify(z_single * sp.conjugate(z_single))
+    check("single-sector determinant carries the cycle phase",
+          sp.arg(z_single).equals(sp.Rational(2, 3)))
+    check("independent conjugate-paired determinant equals one", z_pair == 1)
+    check("ordinary realification determinant equals one",
+          sp.simplify(realification(K).det()) == 1)
+    check("conjugate pairing cancels the determinant phase",
+          sp.arg(z_pair) == 0)
+    check("complex conjugation reverses the single-sector phase",
+          sp.simplify(sp.conjugate(z_single) - sp.exp(-2 * sp.I / 3)) == 0)
+    print()
+
+    print("Part E: determinant-character weights and remaining normalization")
+    k = sp.symbols("k", integer=True)
+    character = sp.exp(2 * sp.I * k * beta / 3)
+    check("character formula at k=1,beta=1 gives cycle phase 2/3",
+          sp.arg(character.subs({k: 1, beta: 1})).equals(sp.Rational(2, 3)))
+    check("conjugate character k=-1 reverses orientation",
+          sp.simplify(character.subs({k: -1, beta: 1})
+                      - sp.exp(-2 * sp.I / 3)) == 0)
+    check("paired net weight k+(-k) is phase-trivial",
+          sp.simplify(character * character.subs(k, -k)) == 1)
+    check("k=2 character has a nontrivial kernel witness z=-1",
+          (-sp.Integer(1))**2 == 1 and -sp.Integer(1) != 1)
+    z = sp.symbols("z", nonzero=True)
+    check("k=1 is the identity and k=-1 inversion is bijective",
+          sp.simplify(z**1 - z) == 0
+          and sp.simplify(1 / (1 / z) - z) == 0)
+    root_kernel_checks = []
+    for weight in (-4, -3, -2, 2, 3, 4):
+        root = sp.exp(2 * sp.pi * sp.I / abs(weight))
+        root_kernel_checks.append(
+            sp.simplify(root**weight - 1) == 0
+            and sp.simplify(root - 1) != 0
+        )
+    check("sample nonfundamental characters have nontrivial root kernels",
+          all(root_kernel_checks))
+    edge_character = (sp.I * k * beta * B / 3).exp().det()
+    check("edge determinant character is derived from exp(i k beta B/3)",
+          sp.simplify(edge_character - sp.exp(2 * sp.I * k * beta / 9)) == 0)
+    edge_lift = sp.Rational(2, 9) * k * beta
+    check("edge lift at k=1,beta=1 equals h",
+          edge_lift.subs({k: 1, beta: 1}) == h)
+    check("beta=2 remains a distinct exact normalization",
+          edge_lift.subs({k: 1, beta: 2}) == 2 * h)
+    print()
+
+    print("=" * 72)
+    print(f"SCORECARD: PASS={PASS_COUNT} FAIL={FAIL_COUNT}")
+    print("=" * 72)
+    return 0 if FAIL_COUNT == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- derive the exact normal-plane resolvent identity B=I/3 and tr(B)=2/3=3h
- construct U_beta=exp(i beta B), giving determinant cycle phase 2 beta/3 and the chosen three-step edge phase 2 beta/9
- prove that the single oriented Grassmann determinant carries the phase while an independent conjugate pair and ordinary realification cancel it
- characterize the determinant-character family chi_k and leave the physical faithfulness, beta normalization, action carrier, and Record map explicit outside the theorem
- keep the construction independent of the registered-mass ratio r

## Validation
- theorem runner: PASS=34, FAIL=0
- cache SHA and stdout reproduce
- independent pure-Python and three-seat formula reviews reproduce the resolvents, fixed-locus density, determinant phase, Pfaffian sign, and conjugate cancellation
- Python compilation and vocabulary lint pass
- audit compatibility pipeline and strict lint pass with no errors
- new row seeds as positive_theorem / unaudited with two retained dependencies
- Physics/Nature, CodeRunner/Governance, and scope-boundary reviews: PASS

## Scope
This PR lands finite algebra and an exact joint theorem target. It does not identify B as the physical charged-lepton action/connection, set beta=1, define the physical Record character, discharge AC(i) or AC(ii), or force r=1/2. Audit status remains the independent lane's decision.
