### PR TITLE
audit: standing restore lane for packet-missing and recovered-dep archives

### DIFF
--- a/docs/audit/scripts/invalidate_stale_audits.py
+++ b/docs/audit/scripts/invalidate_stale_audits.py
@@ -193,6 +193,7 @@ ARCHIVED_FIELDS = [
     "decoration_parent_claim_id",
     "auditor_confidence",
     "no_go_discipline",
+    "negative_assertion_classes",
     "runner_check_breakdown",
     "blocker",
     "audit_state_snapshot",
@@ -414,7 +415,9 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
         output_required = no_go_discipline_gate.output_requires_no_go_discipline(
             {**row, "verdict": audit_status}
         )
-        required = source_required or output_required
+        declared = row.get("negative_assertion_classes")
+        declared_requires = isinstance(declared, list) and bool(declared)
+        required = source_required or output_required or declared_requires
         if required and packet is None:
             return "no_go_discipline_packet_missing"
         if packet is not None and not isinstance(packet, dict):

--- a/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
+++ b/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
@@ -1,9 +1,30 @@
 #!/usr/bin/env python3
-"""One-shot restoration of audits over-aggressively invalidated before
-PR #907's policy refinement of `criticality_increased` and the
-soft-reset propagation rule in `compute_effective_status`.
+"""Restoration of audits over-aggressively invalidated by a since-refined
+policy. Originally the one-shot PR #907 pass for `criticality_increased`;
+now also the standing recovery lane for `no_go_discipline_packet_missing`
+archives whose gating was narrowed by the trigger-precision repair, and
+for `dep_weakened` archives whose dependency has recovered. Idempotent;
+safe to run on every pipeline pass.
 
-Two categories of archived audits are restored:
+Restored categories:
+
+  3. `no_go_discipline_packet_missing` invalidations whose archived audit
+     is restorable under the CURRENT no-go trigger. The restoration guard
+     re-runs the live source/output gate: a row that still asserts a
+     gated negative boundary without a packet, or whose archived packet
+     does not round-trip validation, stays invalidated for fresh audit.
+     Only rows the trigger-precision repair no longer gates (honest
+     scoping surfaces and misparse classes) become eligible.
+
+  4. `dep_weakened:dep_id:before->after` invalidations whose `dep_id`
+     has already recovered on the live ledger — through a landed
+     re-audit or an earlier restoration pass — to a tier at least as
+     strong as the archived audit's recorded `before` tier, with every
+     other still-live invalidation check clean. Chains recover one
+     dependency hop per pass; the pipeline's joint invalidate/restore
+     loop iterates passes to a fixed point within one run (ten-pass cap).
+
+Original PR #907 categories, retained verbatim:
 
   1. `criticality_increased:before->after` invalidations where PR #907's
      `_categorize_criticality_bump` would have returned `noop` or
@@ -39,7 +60,7 @@ Other invalidation reasons (`note_hash` drift handled by
 `runner_artifact_issue_resolved`) are NOT touched; those reflect real
 state changes that genuinely invalidated the audit.
 
-Both restoration categories also require the archived audit to satisfy
+Every restoration category also requires the archived audit to satisfy
 current audit-lane lint requirements (claim_type, claim_scope, repair
 class prefix for audited_conditional rows, and current auditor-family
 floor). Older archived audits that do not meet those requirements remain
@@ -55,15 +76,18 @@ is a no-op on the second run.
 
 Sequencing:
 
-  1. PR #907 must be merged (the policy code that holds soft-reset
-     deps at retained-grade and produces the new `criticality_soft_reset`
-     reason class).
-  2. Run this script (modifies the ledger).
-  3. Run `bash docs/audit/scripts/run_pipeline.sh` to propagate.
-     `invalidate_stale_audits.py` will see the restored audits and
-     soft-reset the criticality-bumped clean rows;
-     `compute_effective_status.py` will hold their effective_status at
-     retained-grade so downstream rows stay valid.
+  This script now runs inside `run_pipeline.sh` step 7, interleaved with
+  `invalidate_stale_audits.py` to a joint fixed point: invalidation
+  settles the gate state, restoration recovers eligible archives, and
+  `compute_effective_status.py` propagates between passes. Restoration
+  can expose a masked lower-ranked dependency verdict; the next
+  invalidation pass applies it with a fresh accurate reason, and the
+  before-tier comparison prevents re-restoration, so the loop is
+  monotone. Standalone invocation (with or without `--dry-run`) remains
+  supported and idempotent.
+
+  Historical PR #907 sequencing (one-shot): merge #907, run this script,
+  then run the pipeline to propagate.
 
 Usage:
   python3 docs/audit/scripts/restore_overaggressively_invalidated_audits.py [--dry-run] [--limit N]
@@ -71,8 +95,10 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import json
+import os
 import re
 import sys
 from datetime import datetime, timezone
@@ -118,6 +144,7 @@ ARCHIVED_FIELDS = (
     "no_go_discipline",
     "audit_invocation_id",
     "audit_invocation_history",
+    "negative_assertion_classes",
 )
 
 RANK = {
@@ -465,6 +492,19 @@ def parse_dep_weakened(reason: str) -> tuple[str, str, str] | None:
     return dep_id, before, after
 
 
+@contextlib.contextmanager
+def _forensic_gate():
+    prior = os.environ.get("AUDIT_FORENSIC_MODE")
+    os.environ["AUDIT_FORENSIC_MODE"] = "1"
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop("AUDIT_FORENSIC_MODE", None)
+        else:
+            os.environ["AUDIT_FORENSIC_MODE"] = prior
+
+
 def restore_audit_from_previous(
     row: dict,
     rows: dict[str, dict] | None = None,
@@ -513,9 +553,14 @@ def restore_audit_from_previous(
         note_body = (REPO_ROOT / note_path).read_text(encoding="utf-8", errors="replace")
     except OSError:
         pass
-    source_required = no_go_discipline_gate.source_requires_no_go_discipline(
-        note_path, note_body, new_row.get("claim_type")
-    )
+    # Restoring archived clean authority is a certification-like act:
+    # evaluate the negative-boundary gate in the forensic tier so a
+    # packetless negative row cannot re-enter authority through a
+    # development-tier restoration pass (two-tier assurance, 2026-07-12).
+    with _forensic_gate():
+        source_required = no_go_discipline_gate.source_requires_no_go_discipline(
+            note_path, note_body, new_row.get("claim_type")
+        )
     gate_blob = {
         "claim_type": new_row.get("claim_type"),
         "claim_scope": new_row.get("claim_scope"),
@@ -527,12 +572,24 @@ def restore_audit_from_previous(
         "notes_for_re_audit_if_any": new_row.get("notes_for_re_audit_if_any"),
         "no_go_discipline": new_row.get("no_go_discipline"),
     }
-    output_required = no_go_discipline_gate.output_requires_no_go_discipline(
+    with _forensic_gate():
+        output_required = no_go_discipline_gate.output_requires_no_go_discipline(
         gate_blob
+    )
+    # Honor a non-empty declaration present on EITHER storage surface:
+    # the archived audit or the reset live row (legacy archives predate
+    # the field, but a surviving live declaration is still the auditor's
+    # semantic judgment). Absence of the key on genuinely old archives
+    # remains accepted.
+    declared_archived = archived.get("negative_assertion_classes")
+    declared_live = row.get("negative_assertion_classes")
+    declared_requires = any(
+        isinstance(d, list) and bool(d)
+        for d in (declared_archived, declared_live)
     )
     if (
         new_row.get("audit_status") == "audited_clean"
-        and (source_required or output_required)
+        and (source_required or output_required or declared_requires)
         and new_row.get("no_go_discipline") is None
     ):
         return None
@@ -555,26 +612,43 @@ def restore_audit_from_previous(
     if isinstance(cross, dict):
         for audit_key in ("first_audit", "second_audit", "third_audit"):
             summary = cross.get(audit_key)
-            if not isinstance(summary, dict) or summary.get("verdict") != "audited_clean":
+            if not isinstance(summary, dict) or not summary:
                 continue
+            verdict = summary.get("verdict") or summary.get("audit_status")
             summary_requires_packet = (
                 source_required
                 or no_go_discipline_gate.output_requires_no_go_discipline(summary)
             )
-            if not summary_requires_packet:
-                continue
             packet = summary.get("no_go_discipline")
+            if packet is None:
+                # A required clean seat without a packet is not restorable.
+                if summary_requires_packet and verdict == "audited_clean":
+                    return None
+                continue
+            # A PRESENT nested packet must round-trip validation even when
+            # the seat would not independently require one, mirroring the
+            # live invalidator's present-packet checks (restoration always
+            # evaluates in the forensic tier).
             manifest = no_go_discipline_gate.evidence_manifest_from_snapshot(
                 packet if isinstance(packet, dict) else {}
             )
-            if manifest is None:
-                return None
-            if no_go_discipline_gate.evidence_snapshot_current_error(
-                packet, current_manifest or {}
-            ):
-                return None
+            if verdict == "audited_clean":
+                if manifest is None:
+                    return None
+                if no_go_discipline_gate.evidence_snapshot_current_error(
+                    packet, current_manifest or {}
+                ):
+                    return None
+            elif manifest is None:
+                manifest = current_manifest
             if no_go_discipline_gate.validate_no_go_discipline(
-                {**summary, "chain_closes": True},
+                {
+                    **summary,
+                    "verdict": verdict,
+                    "chain_closes": summary.get(
+                        "chain_closes", verdict == "audited_clean"
+                    ),
+                },
                 source_required=source_required,
                 evidence_manifest=manifest,
             ):
@@ -600,21 +674,46 @@ def restore_audit_from_previous(
     return new_row
 
 
-def select_restore_candidates(rows: dict[str, dict]) -> tuple[dict[str, str], list[tuple[str, str, str]]]:
-    """First pass: find rows that should be restored under PR #907's policy.
+def select_restore_candidates(
+    rows: dict[str, dict],
+) -> tuple[dict[str, str], list[tuple[str, str, str]], dict[str, str], list[tuple[str, str, str]]]:
+    """First pass: find rows that should be restored.
 
     Returns:
       - `crit_set`: dict mapping `cid` -> archived `audit_status`
         (e.g. `audited_clean`, `audited_conditional`, ...) for rows whose
         most recent invalidation was a `criticality_increased:*` that
-        the new rule would have noop'd or soft_reset'd.
+        PR #907's rule would have noop'd or soft_reset'd.
       - `dep_weakened_set`: list of `(cid, dep_id, archived_status)`
         tuples for rows whose most recent invalidation was a
-        `dep_weakened:*` whose dep is in `crit_set` and whose restored
-        dep tier is no weaker than the archived audit's snapshot.
+        `dep_weakened:*` whose dep is restored in this same pass (via
+        `crit_set` or `packet_set`) and whose restored dep tier is no
+        weaker than the archived audit's snapshot.
+      - `packet_set`: dict mapping `cid` -> archived `audit_status` for
+        rows whose most recent invalidation was
+        `no_go_discipline_packet_missing` and whose archived audit is
+        restorable under the CURRENT no-go trigger: the restoration
+        guard in `restore_audit_from_previous` re-runs the live
+        source/output gate, so a row that still asserts a gated negative
+        boundary without a packet stays invalidated for fresh audit.
+        Only the trigger-precision repair makes rows eligible here.
+      - `recovered_dep_set`: list of `(cid, dep_id, archived_status)`
+        tuples for rows whose most recent invalidation was a
+        `dep_weakened:*` whose dep has ALREADY recovered on the live
+        ledger (a landed re-audit or a prior restoration pass) to a tier
+        no weaker than the one the archived audit closed against, and
+        which pass every other still-live invalidation check.
+
+    Rows further down a weakened chain become eligible on later passes as
+    their dependencies recover; each nightly pipeline run advances the
+    frontier by at least one dependency hop, so recovery converges without
+    any ordering logic here.
     """
     crit_set: dict[str, str] = {}
     crit_archived: dict[str, dict] = {}
+    packet_set: dict[str, str] = {}
+    packet_archived: dict[str, dict] = {}
+    recovered_dep_set: list[tuple[str, str, str]] = []
     dep_weakened_candidates: list[tuple[str, str, str, dict]] = []
 
     for cid, row in rows.items():
@@ -639,6 +738,16 @@ def select_restore_candidates(rows: dict[str, dict]) -> tuple[dict[str, str], li
                 crit_archived[cid] = archived
             continue
 
+        if reason == "no_go_discipline_packet_missing":
+            if (
+                archived_audit_is_lint_compatible(archived)
+                and restore_audit_from_previous(row, rows) is not None
+                and noncritical_invalidation_after_restore(row, rows) is None
+            ):
+                packet_set[cid] = archived.get("audit_status") or "?"
+                packet_archived[cid] = archived
+            continue
+
         dep = parse_dep_weakened(reason)
         if dep is not None:
             if not archived_audit_is_lint_compatible(archived):
@@ -646,19 +755,47 @@ def select_restore_candidates(rows: dict[str, dict]) -> tuple[dict[str, str], li
             if restore_audit_from_previous(row, rows) is None:
                 continue
             dep_id, before_status, _after_status = dep
+            dep_row = rows.get(dep_id)
+            if dep_row is None:
+                # A vanished dependency is never a recovered dependency.
+                dep_weakened_candidates.append(
+                    (cid, dep_id, before_status, archived)
+                )
+                continue
+            current_dep_status = dep_row.get("effective_status") or "unaudited"
+            if (
+                status_rank(current_dep_status) >= status_rank(before_status)
+                and noncritical_invalidation_after_restore(row, rows) is None
+            ):
+                recovered_dep_set.append(
+                    (cid, dep_id, archived.get("audit_status") or "?")
+                )
+                continue
             dep_weakened_candidates.append((cid, dep_id, before_status, archived))
             continue
 
+    restored_this_pass = {**crit_archived, **packet_archived}
     dep_weakened_set: list[tuple[str, str, str]] = []
     for cid, dep_id, before_status, archived in dep_weakened_candidates:
-        dep_archived = crit_archived.get(dep_id)
+        dep_archived = restored_this_pass.get(dep_id)
         if dep_archived is None:
             continue
         restored_dep_status = estimate_restored_effective_status(dep_archived)
-        if status_rank(restored_dep_status) >= status_rank(before_status):
-            dep_weakened_set.append((cid, dep_id, archived.get("audit_status") or "?"))
+        if status_rank(restored_dep_status) < status_rank(before_status):
+            continue
+        # Every other still-live invalidation check must also be clean;
+        # evaluate the blockers with the paired dependency virtually at
+        # its estimated restored tier so only the dependency being
+        # restored this pass is exempt from the comparison.
+        virtual_dep = dict(rows.get(dep_id) or {"claim_id": dep_id})
+        virtual_dep["effective_status"] = restored_dep_status
+        virtual_rows = dict(rows)
+        virtual_rows[dep_id] = virtual_dep
+        if noncritical_invalidation_after_restore(rows[cid], virtual_rows) is not None:
+            continue
+        dep_weakened_set.append((cid, dep_id, archived.get("audit_status") or "?"))
 
-    return crit_set, dep_weakened_set
+    return crit_set, dep_weakened_set, packet_set, recovered_dep_set
 
 
 def select_false_positive_no_go_candidates(rows: dict[str, dict]) -> dict[str, str]:
@@ -725,30 +862,53 @@ def main() -> int:
 
     if args.false_positive_no_go_only:
         crit_set, dep_weakened_set = {}, []
+        packet_set, recovered_dep_set = {}, []
     else:
-        crit_set, dep_weakened_set = select_restore_candidates(rows)
+        crit_set, dep_weakened_set, packet_set, recovered_dep_set = (
+            select_restore_candidates(rows)
+        )
     false_positive_set = select_false_positive_no_go_candidates(rows)
 
     if args.limit is not None:
-        crit_items = sorted(crit_set.items())[: args.limit]
-        crit_set = dict(crit_items)
-        dep_weakened_set = dep_weakened_set[: args.limit]
+        crit_set = dict(sorted(crit_set.items())[: args.limit])
         false_positive_set = dict(sorted(false_positive_set.items())[: args.limit])
+        packet_set = dict(sorted(packet_set.items())[: args.limit])
+        # Same-pass children whose parent was limited out must not restore
+        # ahead of their dependency.
+        surviving_parents = set(crit_set) | set(packet_set)
+        dep_weakened_set = [
+            entry for entry in dep_weakened_set if entry[1] in surviving_parents
+        ][: args.limit]
+        recovered_dep_set = recovered_dep_set[: args.limit]
+
+    def report(label: str, counts_from) -> None:
+        status_counts: dict[str, int] = {}
+        for prev_status in counts_from:
+            status_counts[prev_status] = status_counts.get(prev_status, 0) + 1
+        for status, n in sorted(status_counts.items(), key=lambda x: -x[1]):
+            print(f"    {n:5d}  was {status}")
 
     print(f"Identified {len(crit_set)} criticality_increased restore candidates:")
-    crit_status_counts: dict[str, int] = {}
-    for cid, prev_status in crit_set.items():
-        crit_status_counts[prev_status] = crit_status_counts.get(prev_status, 0) + 1
-    for status, n in sorted(crit_status_counts.items(), key=lambda x: -x[1]):
-        print(f"    {n:5d}  was {status}")
+    report("crit", crit_set.values())
 
     print(f"Identified {len(dep_weakened_set)} dep_weakened restore candidates"
-          f" (cascade from criticality_increased deps):")
-    dep_status_counts: dict[str, int] = {}
-    for _cid, _dep, prev_status in dep_weakened_set:
-        dep_status_counts[prev_status] = dep_status_counts.get(prev_status, 0) + 1
-    for status, n in sorted(dep_status_counts.items(), key=lambda x: -x[1]):
-        print(f"    {n:5d}  was {status}")
+          f" (cascade from deps restored in this pass):")
+    report("dep", [prev for _cid, _dep, prev in dep_weakened_set])
+
+    false_positive_ids = set(false_positive_set)
+    packet_set = {
+        cid: status
+        for cid, status in packet_set.items()
+        if cid not in false_positive_ids
+    }
+    print(f"Identified {len(packet_set)} no_go_discipline_packet_missing restore"
+          f" candidates (archived audit restorable under the current trigger,"
+          f" excluding rows the false-positive lane already selects):")
+    report("packet", packet_set.values())
+
+    print(f"Identified {len(recovered_dep_set)} dep_weakened restore candidates"
+          f" (dep already recovered on the live ledger):")
+    report("recovered", [prev for _cid, _dep, prev in recovered_dep_set])
 
     print(
         f"Identified {len(false_positive_set)} false-positive no-go trigger "
@@ -765,19 +925,24 @@ def main() -> int:
         return 0
 
     restored_count = 0
-    for cid in crit_set:
-        new_row = restore_audit_from_previous(rows[cid], rows)
-        if new_row is None:
+    restore_cids = list(crit_set)
+    restore_cids += [cid for cid, _dep, _prev in dep_weakened_set]
+    restore_cids += list(packet_set)
+    restore_cids += [cid for cid, _dep, _prev in recovered_dep_set]
+    seen: set[str] = set()
+    for cid in restore_cids:
+        if cid in seen:
             continue
-        rows[cid] = new_row
-        restored_count += 1
-    for cid, _dep, _prev in dep_weakened_set:
+        seen.add(cid)
         new_row = restore_audit_from_previous(rows[cid], rows)
         if new_row is None:
             continue
         rows[cid] = new_row
         restored_count += 1
     for cid in false_positive_set:
+        if cid in seen:
+            continue
+        seen.add(cid)
         new_row = restore_audit_from_previous(rows[cid], rows)
         if new_row is None:
             continue

--- a/docs/audit/scripts/run_pipeline.sh
+++ b/docs/audit/scripts/run_pipeline.sh
@@ -60,7 +60,14 @@ python3 docs/audit/scripts/compute_load_bearing.py
 echo "==> 6/16 compute_effective_status.py"
 python3 docs/audit/scripts/compute_effective_status.py
 
-echo "==> 7/16 invalidate_stale_audits.py"
+echo "==> 7/16 invalidate_stale_audits.py + restore loop"
+# Invalidation and restoration run to a JOINT fixed point. Restoration can
+# expose masked dependency verdicts when a chain recovers (a dep whose
+# effective status showed unaudited can re-expose a lower-ranked terminal
+# verdict), which the next invalidation pass then applies with an accurate
+# fresh reason; the restore selector's before-tier comparison cannot pick
+# such a row up again, so the loop is monotone and terminates. Weakened
+# chains recover one dependency hop per pass inside the same run.
 for attempt in 1 2 3 4 5 6 7 8 9 10; do
   python3 docs/audit/scripts/invalidate_stale_audits.py
   invalidated="$(
@@ -70,15 +77,20 @@ with open("docs/audit/data/audit_ledger.json", encoding="utf-8") as f:
     print(len(json.load(f).get("last_invalidations", [])))
 PY
   )"
-  if [[ "${invalidated}" == "0" ]]; then
+  restored="$(
+    python3 docs/audit/scripts/restore_overaggressively_invalidated_audits.py \
+      | sed -n 's/^Restored \([0-9][0-9]*\) audits.*/\1/p'
+  )"
+  restored="${restored:-0}"
+  if [[ "${invalidated}" == "0" && "${restored}" == "0" ]]; then
     break
   fi
-  echo "==> 7.${attempt}/16 compute_effective_status.py post-invalidation (${invalidated} invalidated)"
+  echo "==> 7.${attempt}/16 compute_effective_status.py post-invalidation/restore (${invalidated} invalidated, ${restored} restored)"
   python3 docs/audit/scripts/compute_effective_status.py
 done
 
-if [[ "${invalidated}" != "0" ]]; then
-  echo "invalidate_stale_audits.py did not reach a fixed point after 10 passes" >&2
+if [[ "${invalidated}" != "0" || "${restored}" != "0" ]]; then
+  echo "invalidate/restore did not reach a fixed point after 10 passes (joint invalidation/restoration)" >&2
   exit 1
 fi
 

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -8548,7 +8548,7 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
                 ),
             ),
         }
-        crit, dep_weak = m.select_restore_candidates(rows)
+        crit, dep_weak, _packet, _recovered = m.select_restore_candidates(rows)
         self.assertIn("ok_to_restore", crit)
         self.assertIn("soft_reset_target", crit)
         self.assertNotIn("weak_at_critical_skip", crit)
@@ -8579,7 +8579,7 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
                 ),
             ),
         }
-        crit, dep_weak = m.select_restore_candidates(rows)
+        crit, dep_weak, _packet, _recovered = m.select_restore_candidates(rows)
         self.assertIn("soft_reset_dep", crit)
         dep_weak_cids = {cid for cid, _, _ in dep_weak}
         self.assertEqual(dep_weak_cids, {"downstream_in_set"})
@@ -8606,7 +8606,7 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
                 ),
             ),
         }
-        crit, dep_weak = m.select_restore_candidates(rows)
+        crit, dep_weak, _packet, _recovered = m.select_restore_candidates(rows)
         self.assertIn("conditional_dep", crit)
         self.assertEqual(dep_weak, [])
 
@@ -8633,7 +8633,7 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
                 ),
             ),
         }
-        crit, dep_weak = m.select_restore_candidates(rows)
+        crit, dep_weak, _packet, _recovered = m.select_restore_candidates(rows)
         self.assertEqual(crit, {})
         self.assertEqual(dep_weak, [])
 
@@ -8659,7 +8659,7 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
         }
         rows["candidate"]["deps"] = ["weak_dep"]
 
-        crit, dep_weak = m.select_restore_candidates(rows)
+        crit, dep_weak, _packet, _recovered = m.select_restore_candidates(rows)
         self.assertEqual(crit, {})
         self.assertEqual(dep_weak, [])
 
@@ -8683,7 +8683,7 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
                 ),
             ),
         }
-        crit, dep_weak = m.select_restore_candidates(rows)
+        crit, dep_weak, _packet, _recovered = m.select_restore_candidates(rows)
         self.assertEqual(crit, {})
         self.assertEqual(dep_weak, [])
 
@@ -8768,9 +8768,374 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
                 )
             ),
         }
-        crit, dep_weak = m.select_restore_candidates(rows)
+        crit, dep_weak, _packet, _recovered = m.select_restore_candidates(rows)
         self.assertEqual(crit, {})
         self.assertEqual(dep_weak, [])
+
+    def test_packet_missing_restored_only_when_trigger_no_longer_gates(self):
+        m = self._import_and_patch()
+        ok_path = "docs/PACKET_OK.md"
+        self.fx.write_note(
+            ok_path,
+            "# Identity\n\nExact identity proof.\n\n"
+            "## What this does NOT claim\n"
+            "- Does not derive the parent coefficient; carried by separate rows.\n",
+        )
+        ok_row = self._seed_with_archived(
+            "packet_ok",
+            self._archived_audit(
+                invalidation_reason="no_go_discipline_packet_missing"
+            ),
+        )
+        ok_row["note_path"] = ok_path
+
+        neg_path = "docs/PACKET_NEG.md"
+        self.fx.write_note(
+            neg_path,
+            "# Boundary\n\n"
+            "No route exists to derive the selector from the four axioms.\n",
+        )
+        neg_row = self._seed_with_archived(
+            "packet_neg",
+            self._archived_audit(
+                invalidation_reason="no_go_discipline_packet_missing"
+            ),
+        )
+        neg_row["note_path"] = neg_path
+
+        nogo_row = self._seed_with_archived(
+            "packet_nogo",
+            self._archived_audit(
+                invalidation_reason="no_go_discipline_packet_missing",
+                claim_type="no_go",
+            ),
+        )
+        nogo_row["note_path"] = ok_path
+
+        low_floor_row = self._seed_with_archived(
+            "packet_low_floor",
+            self._archived_audit(
+                invalidation_reason="no_go_discipline_packet_missing",
+                auditor_family="codex-gpt-5",
+            ),
+        )
+        low_floor_row["note_path"] = ok_path
+
+        rows = {
+            "packet_ok": ok_row,
+            "packet_neg": neg_row,
+            "packet_nogo": nogo_row,
+            "packet_low_floor": low_floor_row,
+        }
+        crit, dep_weak, packet, recovered = m.select_restore_candidates(rows)
+        self.assertEqual(set(packet), {"packet_ok"})
+        self.assertEqual(crit, {})
+        self.assertEqual(dep_weak, [])
+        self.assertEqual(recovered, [])
+
+    def test_dep_weakened_restored_when_dep_already_recovered(self):
+        m = self._import_and_patch()
+        rows = {
+            "recovered_dep": {
+                "claim_id": "recovered_dep",
+                "note_path": "docs/RECOVERED_DEP.md",
+                "deps": [],
+                "audit_status": "audited_clean",
+                "effective_status": "retained_bounded",
+                "previous_audits": [],
+            },
+            "downstream_recovered": self._seed_with_archived(
+                "downstream_recovered",
+                self._archived_audit(
+                    invalidation_reason=(
+                        "dep_weakened:recovered_dep:retained_bounded->unaudited"
+                    ),
+                ),
+            ),
+            "weak_dep": {
+                "claim_id": "weak_dep",
+                "note_path": "docs/WEAK_DEP.md",
+                "deps": [],
+                "audit_status": "unaudited",
+                "effective_status": "unaudited",
+                "previous_audits": [],
+            },
+            "downstream_still_weak": self._seed_with_archived(
+                "downstream_still_weak",
+                self._archived_audit(
+                    invalidation_reason=(
+                        "dep_weakened:weak_dep:retained_bounded->unaudited"
+                    ),
+                ),
+            ),
+        }
+        crit, dep_weak, packet, recovered = m.select_restore_candidates(rows)
+        self.assertEqual({cid for cid, _, _ in recovered}, {"downstream_recovered"})
+        self.assertEqual(dep_weak, [])
+        self.assertEqual(packet, {})
+
+    def test_present_nested_seat_packet_always_round_trips(self):
+        """A malformed or stale optional packet on a positive-looking
+        cross-confirmation seat refuses restoration; symmetry with the
+        live invalidator's present-packet validation."""
+        m = self._import_and_patch()
+        archived = self._archived_audit(
+            invalidation_reason="no_go_discipline_packet_missing"
+        )
+        archived["cross_confirmation"] = {
+            "status": "confirmed",
+            "first_audit": {
+                "verdict": "audited_clean",
+                "claim_type": "positive_theorem",
+                "claim_scope": "an affirmative identity",
+                "verdict_rationale": "the identity closes",
+                "no_go_discipline": {"required": True, "status": "BROKEN"},
+            },
+            "second_audit": None,
+        }
+        row = self._seed_with_archived("nested_broken_packet", archived)
+        self.assertIsNone(
+            m.restore_audit_from_previous(
+                dict(row), {"nested_broken_packet": row}
+            )
+        )
+
+    def _positive_seat_with_packet(self, cid, runner_path,
+                                    resolution_path):
+        """Archived row whose positive-looking clean cross-confirmation seat
+        carries an optional (not independently required) N1-N8 packet.
+        The seat wording is affirmative so neither the source nor the
+        output trigger fires; the packet anchors to the runner only."""
+        m = self._import_and_patch()
+        archived = self._archived_audit(
+            invalidation_reason="no_go_discipline_packet_missing"
+        )
+        seat = {
+            "verdict": "audited_clean",
+            "auditor": "first-auditor",
+            "negative_assertion_classes": [],
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "claim_type": "positive_theorem",
+            "claim_scope": "an affirmative spectral identity",
+            "verdict_rationale": "the affirmative identity closes",
+            "load_bearing_step_class": "A",
+            "no_go_discipline": _no_go_packet(
+                evidence_path=runner_path,
+                source_path=runner_path,
+                claim_id=cid,
+            ),
+        }
+        archived["cross_confirmation"] = {
+            "status": "confirmed",
+            "first_audit": seat,
+            "second_audit": None,
+        }
+        row = self._seed_with_archived(cid, archived)
+        row["runner_path"] = runner_path
+        row["helper_runner_paths"] = [resolution_path]
+        manifest_row = dict(row)
+        manifest_row["previous_audits"] = []
+        manifest_row["claim_type"] = archived["claim_type"]
+        manifest_row["claim_scope"] = archived["claim_scope"]
+        manifest_row["audit_status"] = archived["audit_status"]
+        manifest = m.no_go_discipline_gate.build_evidence_manifest(
+            manifest_row, {cid: manifest_row}, self.tmp_root
+        )
+        _set_no_go_scan_coverage(seat["no_go_discipline"], manifest)
+        seat["no_go_discipline"]["evidence_snapshot"] = (
+            m.no_go_discipline_gate.build_evidence_snapshot(
+                seat["no_go_discipline"], manifest
+            )
+        )
+        return m, row
+
+    def test_stale_optional_nested_seat_packet_refuses_restoration(self):
+        """An optional nested packet whose authenticated evidence snapshot
+        no longer matches the current manifest refuses restoration even
+        though the positive-looking seat would not itself require one."""
+        cid = "stale_optional_seat"
+        runner_path = "scripts/STALE_OPTIONAL_SEAT.py"
+        resolution_path = "scripts/TEST_NO_GO_RESOLUTION.py"
+        self.fx.write_runner(runner_path, _no_go_evidence_text())
+        self.fx.write_runner(resolution_path, _no_go_resolution_text())
+        m, row = self._positive_seat_with_packet(
+            cid, runner_path, resolution_path
+        )
+        seat = row["previous_audits"][-1]["cross_confirmation"]["first_audit"]
+        # The seat itself must not gate: this exercises the optional-packet
+        # path, not the packet-required path.
+        self.assertFalse(
+            m.no_go_discipline_gate.output_requires_no_go_discipline(seat)
+        )
+        # Control: the intact snapshot round-trips and restores.
+        self.assertIsNotNone(
+            m.restore_audit_from_previous(dict(row), {cid: row})
+        )
+        # Rewrite the runner on disk after the snapshot was authenticated:
+        # the current manifest drifts and restoration must refuse.
+        self.fx.write_runner(
+            runner_path,
+            _no_go_evidence_text() + "\n# post-snapshot drift\n",
+        )
+        self.assertIsNone(
+            m.restore_audit_from_previous(dict(row), {cid: row})
+        )
+
+    def test_archived_declaration_binds_restoration(self):
+        """An archived clean audit that declared negative assertion
+        classes without a packet is never restorable, in any tier."""
+        m = self._import_and_patch()
+        archived = self._archived_audit(
+            invalidation_reason="no_go_discipline_packet_missing"
+        )
+        archived["negative_assertion_classes"] = ["no_go_result"]
+        row = self._seed_with_archived("declared_no_packet", archived)
+        self.assertIsNone(
+            m.restore_audit_from_previous(dict(row), {"declared_no_packet": row})
+        )
+        # A declaration surviving only on the reset live row binds too.
+        legacy = self._archived_audit(
+            invalidation_reason="no_go_discipline_packet_missing"
+        )
+        live_row = self._seed_with_archived("live_declared", legacy)
+        live_row["negative_assertion_classes"] = ["no_go_result"]
+        self.assertIsNone(
+            m.restore_audit_from_previous(dict(live_row), {"live_declared": live_row})
+        )
+        # And a genuinely old archive with no declaration anywhere restores.
+        old_row = self._seed_with_archived(
+            "legacy_plain",
+            self._archived_audit(
+                invalidation_reason="no_go_discipline_packet_missing"
+            ),
+        )
+        self.assertIsNotNone(
+            m.restore_audit_from_previous(dict(old_row), {"legacy_plain": old_row})
+        )
+        # And a declared-with-valid-packet archive round-trips the field.
+        ok = self._archived_audit(
+            invalidation_reason="no_go_discipline_packet_missing",
+            audit_status="audited_conditional",
+            notes_for_re_audit_if_any="other: conditional row round-trip",
+        )
+        ok["negative_assertion_classes"] = ["bounded_with_named_walls"]
+        row2 = self._seed_with_archived("declared_conditional", ok)
+        restored = m.restore_audit_from_previous(
+            dict(row2), {"declared_conditional": row2}
+        )
+        self.assertIsNotNone(restored)
+        self.assertEqual(
+            restored["negative_assertion_classes"], ["bounded_with_named_walls"]
+        )
+
+    def test_vanished_dependency_is_not_recovered(self):
+        m = self._import_and_patch()
+        row = self._seed_with_archived(
+            "ghost_downstream",
+            self._archived_audit(
+                invalidation_reason=(
+                    "dep_weakened:ghost_dep:audited_conditional->unaudited"
+                ),
+            ),
+        )
+        crit, dep_weak, packet, recovered = m.select_restore_candidates(
+            {"ghost_downstream": row}
+        )
+        self.assertEqual(recovered, [])
+        self.assertEqual(dep_weak, [])
+
+    def test_same_pass_pairing_refused_when_other_dep_still_weak(self):
+        m = self._import_and_patch()
+        ok_path = "docs/PACKET_DEP2.md"
+        self.fx.write_note(ok_path, "# Identity\n\nExact identity proof.\n")
+        dep_row = self._seed_with_archived(
+            "packet_dep2",
+            self._archived_audit(
+                invalidation_reason="no_go_discipline_packet_missing"
+            ),
+        )
+        dep_row["note_path"] = ok_path
+        dep_row["effective_status"] = "unaudited"
+        downstream = self._seed_with_archived(
+            "downstream_two_deps",
+            self._archived_audit(
+                invalidation_reason="dep_weakened:packet_dep2:retained->unaudited",
+            ),
+        )
+        downstream["deps"] = ["packet_dep2", "still_weak_dep"]
+        downstream["previous_audits"][-1]["audit_state_snapshot"] = {
+            "criticality": "leaf",
+            "deps": ["packet_dep2", "still_weak_dep"],
+            "dep_effective_status": {
+                "packet_dep2": "retained",
+                "still_weak_dep": "retained_bounded",
+            },
+        }
+        rows = {
+            "packet_dep2": dep_row,
+            "downstream_two_deps": downstream,
+            "still_weak_dep": {
+                "claim_id": "still_weak_dep",
+                "note_path": "docs/STILL_WEAK.md",
+                "deps": [],
+                "audit_status": "unaudited",
+                "effective_status": "unaudited",
+                "previous_audits": [],
+            },
+        }
+        crit, dep_weak, packet, recovered = m.select_restore_candidates(rows)
+        self.assertIn("packet_dep2", packet)
+        self.assertEqual(dep_weak, [])
+        self.assertEqual(recovered, [])
+
+    def test_false_positive_and_packet_lanes_restore_once(self):
+        m = self._import_and_patch()
+        m.DATA_DIR.mkdir(parents=True, exist_ok=True)
+        ok_path = "docs/PACKET_BOTH.md"
+        self.fx.write_note(ok_path, "# Identity\n\nExact identity proof.\n")
+        row = self._seed_with_archived(
+            "packet_both",
+            self._archived_audit(
+                invalidation_reason="no_go_discipline_packet_missing"
+            ),
+        )
+        row["note_path"] = ok_path
+        ledger = {"schema_version": 1, "rows": {"packet_both": row}}
+        m.LEDGER_PATH.write_text(json.dumps(ledger, indent=2, sort_keys=True))
+        with mock.patch.object(sys, "argv", ["restore"]):
+            rc = m.main()
+        self.assertEqual(rc, 0)
+        out = json.loads(m.LEDGER_PATH.read_text(encoding="utf-8"))
+        restored = out["rows"]["packet_both"]
+        self.assertEqual(restored["audit_status"], "audited_clean")
+        history = restored.get("restoration_history") or []
+        self.assertEqual(len(history), 1)
+
+    def test_dep_weakened_pairs_with_packet_restores_in_same_pass(self):
+        m = self._import_and_patch()
+        ok_path = "docs/PACKET_DEP.md"
+        self.fx.write_note(ok_path, "# Identity\n\nExact identity proof.\n")
+        dep_row = self._seed_with_archived(
+            "packet_dep",
+            self._archived_audit(
+                invalidation_reason="no_go_discipline_packet_missing"
+            ),
+        )
+        dep_row["note_path"] = ok_path
+        dep_row["effective_status"] = "unaudited"
+        downstream = self._seed_with_archived(
+            "downstream_of_packet",
+            self._archived_audit(
+                invalidation_reason="dep_weakened:packet_dep:retained->unaudited",
+            ),
+        )
+        rows = {"packet_dep": dep_row, "downstream_of_packet": downstream}
+        crit, dep_weak, packet, recovered = m.select_restore_candidates(rows)
+        self.assertEqual(set(packet), {"packet_dep"})
+        self.assertEqual({cid for cid, _, _ in dep_weak}, {"downstream_of_packet"})
+        self.assertEqual(recovered, [])
 
     def test_main_writes_restored_ledger(self):
         m = self._import_and_patch()


### PR DESCRIPTION
## Scope

Standing recovery lane for over-invalidated archives, wired into the pipeline. Stacked on #5238. Ships script, pipeline wiring, and tests only — no audit data, no verdicts, no row transitions.

## Source changes

- Two new restore categories alongside the #907 originals and main's false-positive-no-go lane (both preserved and merged):
  1. `no_go_discipline_packet_missing` archives restorable under the CURRENT trigger — the #5119 restoration guard re-runs the live gate, so still-gated negative authority stays invalidated; #5156's exact clean-provenance pin is honored, so pre-gpt-5.6 clean archives remain non-restorable by design and go to fresh audit instead.
  2. `dep_weakened` archives whose dependency has recovered on the live ledger (landed re-audit or earlier restoration) to at least the recorded before-tier, with every other still-live invalidation check clean; same-pass pairing extends the #907 category-2 mechanism to deps restored by category 1.
- `run_pipeline.sh` step 7 runs invalidation and restoration to a JOINT fixed point: restoration can expose masked lower-ranked dependency verdicts, the next pass applies them with fresh accurate reasons, and the before-tier comparison prevents re-restoration — monotone, terminating, one dependency hop per pass within a single run.

## Verification

- 272/272 tests on the current-main rebase (categories, refusals incl. provenance-pinned archives, lint floors, same-pass pairing, single-restore dedupe across lanes, and nested cross-confirmation seat packets: a required clean seat without a packet refuses, and any PRESENT seat packet — even one the seat would not independently require — must round-trip authenticated-snapshot, current-manifest, and full N1-N8 validation, mirroring the live invalidator; malformed-optional and stale-optional seat fixtures plus a valid-seat restore control).
- Dry-run against the current ledger (single selection pass; validation only): 0 packet-missing after deduplication against the pre-existing false-positive lane (which selects the same eligible row) + 6 recovered-dep + 1 false-positive candidate — the gpt-5.5-era archive population is intentionally non-restorable under #5156's ratchet, so today's direct recovery is small; the lane's standing value is automatic reversal of future over-invalidations and automatic dependent recovery as the parallel re-audit campaign lands upstream rows (multi-hop within each pipeline run).
- Churn simulation: restore-then-invalidate settles at the joint fixed point; no oscillation.
- Full pipeline pass; strict lint zero errors; generated outputs stripped.

## Boundary

The nightly audit-loop pipeline on main is the sole channel that lands resulting transitions; this PR supplies mechanism only. Restoration is append-only provenance: archives stay in previous_audits and each pass records a restoration_history entry; no verdict is re-authored. Restoration gates evaluate in the forensic tier regardless of ambient tier, archived negative_assertion_classes declarations bind restoration (declared classes without a packet never restore, and the declaration is preserved through the archive cycle on both the invalidate and restore sides), vanished dependencies never count as recovered, rows restore exactly once across all lanes including the false-positive lane, and --limit preserves same-pass parent/child consistency.

## Review requirement

/review-loop with GPT-5.6 Sol at max reasoning after #5238 lands and this branch rebases onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


