### PR TITLE
audit-infra: bound N8 bulk-scan candidates + verdict durability under index growth (fixes same-day audit-decay regression)

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -223,7 +223,14 @@ historical dispositions, open derivation obligations, similar `no_go` rows in th
 audit ledger, and every tracked
 `.claude/science/physics-loops/**/NO_GO_LEDGER.md` file. The index metadata
 states the exact glob, scanned file count and paths, similarity threshold, and
-candidate limit. You must disposition every listed `candidate_id`;
+per-kind candidate limits. High-signal kinds (prior audit cycles, open gates,
+loop ledgers) are listed in full; the bulk similarity/scan kinds are capped by
+the declared relevance order with an authenticated omitted-tail summary
+(`candidate_truncation`: total hits, omitted count, omitted-id hash), so the
+corpus cannot be hidden while the disposition set stays reviewable. Index
+universes that grow after your packet is authenticated are re-audit signal
+for the dispatch stream, never retroactive invalidation of your verdict. You
+must disposition every listed `candidate_id`;
 `packet_complete` is valid only when the N8 evidence path names this index.
 
 ```json

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -191,7 +191,7 @@ def trusted_manifest_current_error(
         row, rows, REPO_ROOT
     )
     return no_go_discipline_gate.evidence_snapshot_current_error(
-        probe_packet, current_manifest
+        probe_packet, current_manifest, dynamic_index_drift_invalidates=True
     )
 
 

--- a/docs/audit/scripts/invalidate_stale_audits.py
+++ b/docs/audit/scripts/invalidate_stale_audits.py
@@ -269,6 +269,13 @@ def clean_auditor_provenance_is_valid(value: dict) -> bool:
     return independence in {"strong", "external", "judicial_review"}
 
 
+# Dynamic-index growth observed on otherwise-valid authenticated packets.
+# Growth is re-audit signal for the dispatch stream, never retroactive
+# invalidation; main() persists it as a generated artifact.
+INDEX_GROWTH_TARGETS: list[dict] = []
+GROWTH_TARGETS_PATH = REPO_ROOT / "docs" / "audit" / "data" / "no_go_index_growth_targets.json"
+
+
 def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
     audit_status = row.get("audit_status")
     if audit_status == "audited_clean" and not clean_auditor_provenance_is_valid(row):
@@ -304,6 +311,16 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
                 packet, current_manifest
             ):
                 return "no_go_discipline_packet_invalid"
+            growth = no_go_discipline_gate.evidence_snapshot_index_growth(
+                packet, current_manifest
+            )
+            if growth:
+                INDEX_GROWTH_TARGETS.append(
+                    {
+                        "claim_id": str(row.get("claim_id") or ""),
+                        "new_candidates": growth,
+                    }
+                )
         elif evidence_manifest is None:
             evidence_manifest = current_manifest
         packet_error = no_go_discipline_gate.validate_no_go_discipline(
@@ -779,7 +796,25 @@ def main() -> int:
 
     LEDGER_PATH.write_text(json.dumps(ledger, indent=2, sort_keys=True) + "\n")
 
+    GROWTH_TARGETS_PATH.write_text(
+        json.dumps(
+            {
+                "schema": "no_go_index_growth_targets_v1",
+                "description": (
+                    "Rows whose authenticated N6/N8 index universes grew "
+                    "after their packet was authenticated. Re-audit signal "
+                    "for the targeted dispatch stream; verdicts stay valid."
+                ),
+                "targets": INDEX_GROWTH_TARGETS,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
     print(f"invalidate_stale_audits: scanned {len(rows)} rows")
+    print(f"  index-growth re-audit targets: {len(INDEX_GROWTH_TARGETS)}")
     print(f"  invalidated (hard reset): {len(invalidated)}")
     for cid, reason in invalidated[:10]:
         print(f"    {cid}: {reason}")

--- a/docs/audit/scripts/no_go_discipline_gate.py
+++ b/docs/audit/scripts/no_go_discipline_gate.py
@@ -498,6 +498,24 @@ def set_packet_evidence(
             manifest[path]["invocation_bound_rendered_text"] = True
 
 
+# Per-kind N8 candidate caps. High-signal kinds are uncapped (None) and must
+# be dispositioned in full. The two bulk similarity/scan kinds are capped by
+# the declared relevance order (kind priority, shared-term count descending)
+# with an authenticated omitted-tail summary in the index, so corpus hiding
+# remains impossible while the disposition set stays reviewable at audit
+# scale. 2026-07-12 repair: uncapped scan kinds produced ~1,700-candidate
+# packets on common-vocabulary foundational rows (infeasible to disposition
+# honestly in one session), and together with snapshot set-identity
+# invalidation they decayed every clean audit within hours of landing.
+N8_KIND_CANDIDATE_LIMITS: dict[str, int | None] = {
+    "prior_audit_cycle": None,
+    "open_gate": None,
+    "similar_negative_boundary": 40,
+    "repo_negative_phrase_hit": 60,
+    "physics_loop_no_go_ledger": None,
+}
+
+
 def cross_cycle_index_path(claim_id: str) -> str:
     return f"audit-packet://cross-cycle-index/{claim_id}"
 
@@ -739,10 +757,39 @@ def build_cross_cycle_index(
             str(candidate.get("candidate_id") or ""),
         ),
     )
-    # Every relevant candidate must be dispositioned. The authenticated
-    # no-go universe prevents corpus hiding, and leaving the relevance set
-    # uncapped prevents a large same-kind family from escaping N8 review.
-    candidates = ordered_candidates
+    # Every LISTED candidate must be dispositioned. High-signal kinds are
+    # listed in full; the bulk scan kinds are capped by the declared
+    # relevance order with an authenticated omitted-tail summary below, so
+    # the corpus remains un-hideable (counts + omitted-id hash are part of
+    # the authenticated index) while the disposition set stays reviewable.
+    listed_candidates: list[dict[str, Any]] = []
+    kind_totals: dict[str, int] = {}
+    omitted_by_kind: dict[str, list[str]] = {}
+    for candidate in ordered_candidates:
+        kind = str(candidate.get("kind"))
+        kind_totals[kind] = kind_totals.get(kind, 0) + 1
+        limit = N8_KIND_CANDIDATE_LIMITS.get(kind)
+        if limit is not None and kind_totals[kind] > limit:
+            omitted_by_kind.setdefault(kind, []).append(
+                str(candidate.get("candidate_id") or "")
+            )
+            continue
+        listed_candidates.append(candidate)
+    candidate_truncation = {
+        kind: {
+            "limit": N8_KIND_CANDIDATE_LIMITS.get(kind),
+            "total_hits": total,
+            "listed": total - len(omitted_by_kind.get(kind, [])),
+            "omitted_count": len(omitted_by_kind.get(kind, [])),
+            "omitted_candidate_ids_sha256": hashlib.sha256(
+                json.dumps(
+                    omitted_by_kind.get(kind, []), separators=(",", ":")
+                ).encode("utf-8")
+            ).hexdigest(),
+        }
+        for kind, total in sorted(kind_totals.items())
+    }
+    candidates = listed_candidates
     return json.dumps(
         {
             "schema": "no_go_cross_cycle_index_v1",
@@ -752,7 +799,14 @@ def build_cross_cycle_index(
                 "one_hop_authority_audit_history": True,
                 "historical_dispositions": True,
                 "open_gates": True,
-                "candidate_limit": None,
+                "candidate_limit": {
+                    "per_kind": N8_KIND_CANDIDATE_LIMITS,
+                    "policy": (
+                        "high-signal kinds listed in full; bulk scan kinds "
+                        "capped by declared relevance order with an "
+                        "authenticated omitted-tail summary"
+                    ),
+                },
                 "candidate_order": (
                     "kind priority, shared-term count descending, candidate_id"
                 ),
@@ -766,7 +820,9 @@ def build_cross_cycle_index(
                         "with explicit no-go/boundary triggers"
                     ),
                     "minimum_shared_terms": 2,
-                    "candidate_limit": None,
+                    "candidate_limit": N8_KIND_CANDIDATE_LIMITS[
+                        "similar_negative_boundary"
+                    ],
                 },
                 "physics_loop_no_go_ledgers": {
                     "glob": loop_ledger_glob,
@@ -783,6 +839,7 @@ def build_cross_cycle_index(
             "no_go_row_universe": no_go_universe,
             "no_go_row_universe_count": len(no_go_universe),
             "no_go_row_universe_sha256": no_go_universe_sha256,
+            "candidate_truncation": candidate_truncation,
             "candidates": candidates,
         },
         indent=2,
@@ -1422,9 +1479,23 @@ def evidence_manifest_from_snapshot(packet: dict[str, Any]) -> dict[str, dict] |
 
 
 def evidence_snapshot_current_error(
-    packet: dict[str, Any], current_manifest: dict[str, dict]
+    packet: dict[str, Any],
+    current_manifest: dict[str, dict],
+    *,
+    dynamic_index_drift_invalidates: bool = False,
 ) -> str | None:
-    """Reauthenticate stable file-backed snapshot entries against current bytes."""
+    """Reauthenticate stable file-backed snapshot entries against current bytes.
+
+    Dynamic-index (N6/N8) universes grow with every landed note, loop ledger,
+    and vocabulary row, so by default their drift is NOT an invalidation —
+    growth is re-audit signal (see evidence_snapshot_index_growth), never
+    retroactive deletion of an authenticated verdict. Apply-time REPLAY
+    rejection is the one caller that opts back in with
+    dynamic_index_drift_invalidates=True: a stale replayed prompt manifest is
+    rejected there precisely because the live indexes have moved on.
+    2026-07-12 repair: the unconditional set-identity comparison decayed
+    every clean audit within hours in an active repo, including
+    doubly-confirmed cross-family cleans."""
     stored_manifest = evidence_manifest_from_snapshot(packet)
     if stored_manifest is None:
         return "evidence_snapshot is malformed or predates the current authenticated schema"
@@ -1454,13 +1525,14 @@ def evidence_snapshot_current_error(
         current = current_manifest.get(path)
         if current is None:
             return f"evidence_snapshot path {path!r} is absent from the current packet"
-        if dynamic_index or not stored.get("invocation_bound_rendered_text"):
+        if dynamic_index and not dynamic_index_drift_invalidates:
+            continue
+        if dynamic_index:
             current_text_hash = hashlib.sha256(
                 str(current.get("text") or "").encode("utf-8")
             ).hexdigest()
             if current_text_hash != stored.get("content_sha256"):
                 return f"evidence_snapshot rendered content drifted for {path!r}"
-        if dynamic_index:
             if "cross_cycle_index" in roles:
                 current_candidates = _index_candidates(
                     current, schema="no_go_cross_cycle_index_v1",
@@ -1478,6 +1550,12 @@ def evidence_snapshot_current_error(
             if current_candidates != stored_candidates:
                 return f"evidence_snapshot candidate set drifted for {path!r}"
             continue
+        if not stored.get("invocation_bound_rendered_text"):
+            current_text_hash = hashlib.sha256(
+                str(current.get("text") or "").encode("utf-8")
+            ).hexdigest()
+            if current_text_hash != stored.get("content_sha256"):
+                return f"evidence_snapshot rendered content drifted for {path!r}"
         if not stable_roles.intersection(roles):
             continue
         if stored.get("full_content_sha256") is not None:
@@ -1489,6 +1567,46 @@ def evidence_snapshot_current_error(
             if current.get(field) != stored.get(field):
                 return f"evidence_snapshot {field} drifted for {path!r}"
     return None
+
+
+def evidence_snapshot_index_growth(
+    packet: dict[str, Any], current_manifest: dict[str, dict]
+) -> dict[str, list[str]]:
+    """Dynamic-index candidates that appeared after this packet was
+    authenticated. Growth is re-audit signal for the dispatch stream, never
+    retroactive invalidation of the authenticated verdict."""
+    stored_manifest = evidence_manifest_from_snapshot(packet)
+    growth: dict[str, list[str]] = {}
+    if stored_manifest is None:
+        return growth
+    for path, stored in stored_manifest.items():
+        roles = set(stored.get("roles") or [])
+        if "cross_cycle_index" in roles:
+            current_candidates = _index_candidates(
+                current_manifest.get(path) or {},
+                schema="no_go_cross_cycle_index_v1",
+                stored_field="cross_cycle_candidate_ids",
+                stored_records_field="cross_cycle_candidates",
+            )
+            stored_candidates = _index_candidates(
+                stored,
+                schema="no_go_cross_cycle_index_v1",
+                stored_field="cross_cycle_candidate_ids",
+                stored_records_field="cross_cycle_candidates",
+            )
+        elif "partial_closure_index" in roles:
+            current_candidates = _partial_closure_candidates(
+                current_manifest.get(path) or {}
+            )
+            stored_candidates = _partial_closure_candidates(stored)
+        else:
+            continue
+        new_ids = sorted(
+            set(current_candidates or set()) - set(stored_candidates or set())
+        )
+        if new_ids:
+            growth[path] = new_ids
+    return growth
 
 
 def _has_governed_no_existence(text: str) -> bool:

--- a/docs/audit/scripts/no_go_discipline_gate.py
+++ b/docs/audit/scripts/no_go_discipline_gate.py
@@ -789,6 +789,10 @@ def build_cross_cycle_index(
         }
         for kind, total in sorted(kind_totals.items())
     }
+    candidate_id_universe = sorted(
+        str(candidate.get("candidate_id") or "")
+        for candidate in ordered_candidates
+    )
     candidates = listed_candidates
     return json.dumps(
         {
@@ -839,6 +843,10 @@ def build_cross_cycle_index(
             "no_go_row_universe": no_go_universe,
             "no_go_row_universe_count": len(no_go_universe),
             "no_go_row_universe_sha256": no_go_universe_sha256,
+            # Full IDs are lightweight authenticated metadata, not disposition
+            # records. They let the durability sweep report capped-tail growth
+            # exactly without restoring the infeasible uncapped packet.
+            "candidate_id_universe": candidate_id_universe,
             "candidate_truncation": candidate_truncation,
             "candidates": candidates,
         },
@@ -857,6 +865,7 @@ def build_partial_closure_index(
     cid = str(row.get("claim_id") or "")
     current_terms = _row_search_terms(row, root)
     candidates: list[dict[str, Any]] = []
+    candidate_id_universe: set[str] = set()
 
     def add_candidate(
         *,
@@ -868,6 +877,7 @@ def build_partial_closure_index(
         accepted_premise_type: str | None = None,
         content_sha256: str | None = None,
     ) -> None:
+        candidate_id_universe.add(candidate_id)
         candidates.append(
             {
                 "candidate_id": candidate_id,
@@ -933,9 +943,14 @@ def build_partial_closure_index(
         overlap = sorted(current_terms.intersection(_search_terms(line)))
         if overlap and keyword_re.search(line):
             vocabulary_hits.append((len(overlap), line_number, line, overlap))
-    for _score, line_number, line, overlap in sorted(
+    ordered_vocabulary_hits = sorted(
         vocabulary_hits, key=lambda item: (-item[0], item[1])
-    )[:10]:
+    )
+    candidate_id_universe.update(
+        f"controlled_vocabulary:{line_number}"
+        for _score, line_number, _line, _overlap in ordered_vocabulary_hits
+    )
+    for _score, line_number, line, overlap in ordered_vocabulary_hits[:10]:
         add_candidate(
             candidate_id=f"controlled_vocabulary:{line_number}",
             kind="definition_refactor",
@@ -957,9 +972,12 @@ def build_partial_closure_index(
         overlap = sorted(current_terms.intersection(_search_terms(content)))
         if len(overlap) >= 2 and keyword_re.search(content):
             meta_hits.append((len(overlap), path, content, overlap))
-    for _score, path, content, overlap in sorted(
-        meta_hits, key=lambda item: (-item[0], item[1])
-    )[:10]:
+    ordered_meta_hits = sorted(meta_hits, key=lambda item: (-item[0], item[1]))
+    candidate_id_universe.update(
+        f"meta_reframe:{path}"
+        for _score, path, _content, _overlap in ordered_meta_hits
+    )
+    for _score, path, content, overlap in ordered_meta_hits[:10]:
         add_candidate(
             candidate_id=f"meta_reframe:{path}",
             kind="definition_refactor",
@@ -989,9 +1007,12 @@ def build_partial_closure_index(
         overlap = sorted(current_terms.intersection(_search_terms(content)))
         if len(overlap) >= 2 and keyword_re.search(content):
             claim_hits.append((len(overlap), path, content, overlap))
-    for _score, path, content, overlap in sorted(
-        claim_hits, key=lambda item: (-item[0], item[1])
-    )[:20]:
+    ordered_claim_hits = sorted(claim_hits, key=lambda item: (-item[0], item[1]))
+    candidate_id_universe.update(
+        f"claim_reframe:{path}"
+        for _score, path, _content, _overlap in ordered_claim_hits
+    )
+    for _score, path, content, overlap in ordered_claim_hits[:20]:
         add_candidate(
             candidate_id=f"claim_reframe:{path}",
             kind="claim_scope_reframe",
@@ -1015,9 +1036,14 @@ def build_partial_closure_index(
         overlap = sorted(current_terms.intersection(_search_terms(content)))
         if len(overlap) >= 2 and keyword_re.search(content):
             reframe_hits.append((len(overlap), path, content, overlap))
-    for _score, path, content, overlap in sorted(
+    ordered_reframe_hits = sorted(
         reframe_hits, key=lambda item: (-item[0], item[1])
-    )[:10]:
+    )
+    candidate_id_universe.update(
+        f"in_flight_reframe:{path}"
+        for _score, path, _content, _overlap in ordered_reframe_hits
+    )
+    for _score, path, content, overlap in ordered_reframe_hits[:10]:
         add_candidate(
             candidate_id=f"in_flight_reframe:{path}",
             kind="definition_refactor",
@@ -1070,6 +1096,9 @@ def build_partial_closure_index(
                     "evidence_line_limit_per_candidate": 5,
                 },
             },
+            # Candidate records remain capped above; full IDs are authenticated
+            # solely so post-authentication growth is observable exactly.
+            "candidate_id_universe": sorted(candidate_id_universe),
             "candidates": candidates,
         },
         indent=2,
@@ -1260,6 +1289,59 @@ def _index_candidates(
     return mapped
 
 
+def _index_candidate_id_universe(
+    entry: dict[str, Any], *, schema: str, universe_field: str,
+    stored_field: str, stored_records_field: str,
+) -> set[str] | None:
+    """Return every candidate ID, including IDs omitted from capped records.
+
+    Legacy snapshots predate ``candidate_id_universe``. Their listed IDs are
+    the best available fallback (and legacy N8 snapshots were uncapped).
+    """
+    stored_universe = entry.get(universe_field)
+    stored_set: set[str] | None = None
+    if stored_universe is not None:
+        if (
+            not isinstance(stored_universe, list)
+            or not all(_text(item) for item in stored_universe)
+        ):
+            return None
+        stored_set = {str(item) for item in stored_universe}
+        if len(stored_set) != len(stored_universe):
+            return None
+    rendered_text = str(entry.get("text") or "")
+    parsed = None
+    if rendered_text:
+        try:
+            parsed = json.loads(rendered_text)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(parsed, dict) or parsed.get("schema") != schema:
+            return None
+    if isinstance(parsed, dict):
+        rendered_universe = parsed.get("candidate_id_universe")
+        if "candidate_id_universe" in parsed:
+            if not isinstance(rendered_universe, list):
+                return None
+            if not all(_text(item) for item in rendered_universe):
+                return None
+            universe = {str(item) for item in rendered_universe}
+            if len(universe) != len(rendered_universe):
+                return None
+            if stored_set is not None and stored_set != universe:
+                return None
+            return universe
+    if not rendered_text and stored_set is not None:
+        return stored_set
+    candidates = _index_candidates(
+        entry,
+        schema=schema,
+        stored_field=stored_field,
+        stored_records_field=stored_records_field,
+    )
+    return set(candidates) if candidates is not None else None
+
+
 def _cross_cycle_candidate_ids(entry: dict[str, Any]) -> set[str] | None:
     candidates = _index_candidates(
         entry,
@@ -1355,6 +1437,23 @@ def build_evidence_snapshot(
             snapshot_entry["cross_cycle_candidates"] = [
                 candidates[candidate_id] for candidate_id in sorted(candidates)
             ]
+            candidate_id_universe = _index_candidate_id_universe(
+                entry,
+                schema="no_go_cross_cycle_index_v1",
+                universe_field="cross_cycle_candidate_id_universe",
+                stored_field="cross_cycle_candidate_ids",
+                stored_records_field="cross_cycle_candidates",
+            )
+            if (
+                candidate_id_universe is None
+                or not set(candidates).issubset(candidate_id_universe)
+            ):
+                raise ValueError(
+                    "cross-cycle candidate-ID universe is not orchestrator-authenticated"
+                )
+            snapshot_entry["cross_cycle_candidate_id_universe"] = sorted(
+                candidate_id_universe
+            )
             try:
                 cross_payload = json.loads(text)
             except json.JSONDecodeError as exc:
@@ -1373,6 +1472,23 @@ def build_evidence_snapshot(
             snapshot_entry["partial_closure_candidates"] = [
                 candidates[candidate_id] for candidate_id in sorted(candidates)
             ]
+            candidate_id_universe = _index_candidate_id_universe(
+                entry,
+                schema="no_go_partial_closure_index_v1",
+                universe_field="partial_closure_candidate_id_universe",
+                stored_field="partial_closure_candidate_ids",
+                stored_records_field="partial_closure_candidates",
+            )
+            if (
+                candidate_id_universe is None
+                or not set(candidates).issubset(candidate_id_universe)
+            ):
+                raise ValueError(
+                    "partial-closure candidate-ID universe is not orchestrator-authenticated"
+                )
+            snapshot_entry["partial_closure_candidate_id_universe"] = sorted(
+                candidate_id_universe
+            )
         entries[path] = snapshot_entry
     return {"schema": "no_go_evidence_snapshot_v1", "entries": entries}
 
@@ -1446,6 +1562,48 @@ def evidence_manifest_from_snapshot(packet: dict[str, Any]) -> dict[str, dict] |
         for field in ("cross_cycle_candidates", "partial_closure_candidates"):
             if stored.get(field) is not None and not isinstance(stored[field], list):
                 return None
+        for field in (
+            "cross_cycle_candidate_id_universe",
+            "partial_closure_candidate_id_universe",
+        ):
+            universe_values = stored.get(field)
+            if universe_values is not None and (
+                not isinstance(universe_values, list)
+                or not all(_text(item) for item in universe_values)
+                or len(set(universe_values)) != len(universe_values)
+            ):
+                return None
+        role_set = set(roles)
+        for role, universe_field, schema, listed_field, records_field in (
+            (
+                "cross_cycle_index",
+                "cross_cycle_candidate_id_universe",
+                "no_go_cross_cycle_index_v1",
+                "cross_cycle_candidate_ids",
+                "cross_cycle_candidates",
+            ),
+            (
+                "partial_closure_index",
+                "partial_closure_candidate_id_universe",
+                "no_go_partial_closure_index_v1",
+                "partial_closure_candidate_ids",
+                "partial_closure_candidates",
+            ),
+        ):
+            stored_universe = stored.get(universe_field)
+            if role not in role_set or stored_universe is None:
+                continue
+            listed_candidates = _index_candidates(
+                stored,
+                schema=schema,
+                stored_field=listed_field,
+                stored_records_field=records_field,
+            )
+            if (
+                listed_candidates is None
+                or not set(listed_candidates).issubset(set(stored_universe))
+            ):
+                return None
         universe_count = stored.get("no_go_row_universe_count")
         universe_sha256 = stored.get("no_go_row_universe_sha256")
         if "cross_cycle_index" in set(roles):
@@ -1469,10 +1627,16 @@ def evidence_manifest_from_snapshot(packet: dict[str, Any]) -> dict[str, dict] |
             "invocation_bound_rendered_text": invocation_bound_rendered_text,
             "cross_cycle_candidate_ids": stored.get("cross_cycle_candidate_ids"),
             "cross_cycle_candidates": stored.get("cross_cycle_candidates"),
+            "cross_cycle_candidate_id_universe": stored.get(
+                "cross_cycle_candidate_id_universe"
+            ),
             "no_go_row_universe_count": universe_count,
             "no_go_row_universe_sha256": universe_sha256,
             "partial_closure_candidate_ids": stored.get("partial_closure_candidate_ids"),
             "partial_closure_candidates": stored.get("partial_closure_candidates"),
+            "partial_closure_candidate_id_universe": stored.get(
+                "partial_closure_candidate_id_universe"
+            ),
             "phrase_occurrences": phrase_occurrences,
         }
     return manifest
@@ -1582,23 +1746,35 @@ def evidence_snapshot_index_growth(
     for path, stored in stored_manifest.items():
         roles = set(stored.get("roles") or [])
         if "cross_cycle_index" in roles:
-            current_candidates = _index_candidates(
+            current_candidates = _index_candidate_id_universe(
                 current_manifest.get(path) or {},
                 schema="no_go_cross_cycle_index_v1",
+                universe_field="cross_cycle_candidate_id_universe",
                 stored_field="cross_cycle_candidate_ids",
                 stored_records_field="cross_cycle_candidates",
             )
-            stored_candidates = _index_candidates(
+            stored_candidates = _index_candidate_id_universe(
                 stored,
                 schema="no_go_cross_cycle_index_v1",
+                universe_field="cross_cycle_candidate_id_universe",
                 stored_field="cross_cycle_candidate_ids",
                 stored_records_field="cross_cycle_candidates",
             )
         elif "partial_closure_index" in roles:
-            current_candidates = _partial_closure_candidates(
-                current_manifest.get(path) or {}
+            current_candidates = _index_candidate_id_universe(
+                current_manifest.get(path) or {},
+                schema="no_go_partial_closure_index_v1",
+                universe_field="partial_closure_candidate_id_universe",
+                stored_field="partial_closure_candidate_ids",
+                stored_records_field="partial_closure_candidates",
             )
-            stored_candidates = _partial_closure_candidates(stored)
+            stored_candidates = _index_candidate_id_universe(
+                stored,
+                schema="no_go_partial_closure_index_v1",
+                universe_field="partial_closure_candidate_id_universe",
+                stored_field="partial_closure_candidate_ids",
+                stored_records_field="partial_closure_candidates",
+            )
         else:
             continue
         new_ids = sorted(

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -4217,7 +4217,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         self.assertEqual([path.name for path in paths], ["SOURCE_NO_GO.md"])
         self.assertEqual([record["path"].name for record in records], ["SOURCE_NO_GO.md"])
 
-    def test_cross_cycle_index_is_complete_and_ignores_mutable_peer_audit_state(self):
+    def test_cross_cycle_index_caps_bulk_kinds_with_authenticated_tail_and_ignores_mutable_peer_audit_state(self):
         m = _import("no_go_discipline_gate")
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -4253,7 +4253,15 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 candidate for candidate in parsed["candidates"]
                 if candidate["kind"] == "similar_negative_boundary"
             ]
-            self.assertEqual(len(similar), 100)
+            cap = m.N8_KIND_CANDIDATE_LIMITS["similar_negative_boundary"]
+            self.assertEqual(len(similar), cap)
+            truncation = parsed["candidate_truncation"]["similar_negative_boundary"]
+            self.assertEqual(truncation["total_hits"], 100)
+            self.assertEqual(truncation["listed"], cap)
+            self.assertEqual(truncation["omitted_count"], 100 - cap)
+            self.assertEqual(len(truncation["omitted_candidate_ids_sha256"]), 64)
+            # the universe itself stays complete: capping the disposition
+            # list never hides the corpus
             self.assertEqual(parsed["no_go_row_universe_count"], 100)
             self.assertEqual(
                 {item["claim_id"] for item in parsed["no_go_row_universe"]},
@@ -4274,6 +4282,110 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             target_row["claim_scope"] = "different mutable target scope"
             target_row["verdict_rationale"] = "different mutable target verdict"
             self.assertNotEqual(first, m.build_cross_cycle_index(target_row, rows, root))
+
+    def test_dynamic_index_growth_never_invalidates_but_is_reported(self):
+        m = _import("no_go_discipline_gate")
+        index_uri = m.cross_cycle_index_path("target_claim")
+        universe_sha = "0" * 64
+        stored_index_text = json.dumps(
+            {
+                "schema": "no_go_cross_cycle_index_v1",
+                "claim_id": "target_claim",
+                "no_go_row_universe_count": 1,
+                "no_go_row_universe_sha256": universe_sha,
+                "candidates": [
+                    {"candidate_id": "open_gate:alpha", "kind": "open_gate"}
+                ],
+            }
+        )
+        manifest = {
+            index_uri: {
+                "path": index_uri,
+                "roles": ["cross_cycle_index"],
+                "text": stored_index_text,
+                "effective_status": None,
+                "accepted_premise_type": None,
+            }
+        }
+        packet = {
+            "required": True,
+            "status": "PASS",
+            "N8_cross_cycle_echo": {
+                "packet_complete": True,
+                "echoes": [
+                    {
+                        "candidate_id": "open_gate:alpha",
+                        "mechanism": "synthetic",
+                        "retired": False,
+                        "applicable": False,
+                        "addressed": True,
+                        "evidence_path": index_uri,
+                        "evidence_locator": "open_gate:alpha",
+                    }
+                ],
+                "unresolved": [],
+                "evidence_path": index_uri,
+                "evidence_locator": "open_gate:alpha",
+            },
+        }
+        packet["evidence_snapshot"] = m.build_evidence_snapshot(packet, manifest)
+        grown_index_text = json.dumps(
+            {
+                "schema": "no_go_cross_cycle_index_v1",
+                "claim_id": "target_claim",
+                "no_go_row_universe_count": 2,
+                "no_go_row_universe_sha256": universe_sha,
+                "candidates": [
+                    {"candidate_id": "open_gate:alpha", "kind": "open_gate"},
+                    {"candidate_id": "open_gate:beta", "kind": "open_gate"},
+                ],
+            }
+        )
+        current_manifest = {
+            index_uri: dict(manifest[index_uri], text=grown_index_text)
+        }
+        self.assertIsNone(
+            m.evidence_snapshot_current_error(packet, current_manifest)
+        )
+        growth = m.evidence_snapshot_index_growth(packet, current_manifest)
+        self.assertEqual(growth, {index_uri: ["open_gate:beta"]})
+
+    def test_stable_role_content_drift_still_invalidates(self):
+        m = _import("no_go_discipline_gate")
+        manifest = {
+            "docs/SOURCE.md": {
+                "path": "docs/SOURCE.md",
+                "roles": ["source"],
+                "text": "original source text with a stable locator sentence.",
+                "effective_status": None,
+                "accepted_premise_type": None,
+            }
+        }
+        packet = {
+            "required": True,
+            "status": "PASS",
+            "N3_hidden_wall_scan": {
+                "hits": [
+                    {
+                        "phrase": "stable locator sentence",
+                        "resolution": "synthetic",
+                        "evidence_path": "docs/SOURCE.md",
+                        "evidence_locator": "stable locator sentence",
+                    }
+                ],
+                "unresolved": [],
+            },
+        }
+        packet["evidence_snapshot"] = m.build_evidence_snapshot(packet, manifest)
+        drifted = {
+            "docs/SOURCE.md": dict(
+                manifest["docs/SOURCE.md"],
+                text="rewritten source text, locator gone.",
+            )
+        }
+        self.assertIsNotNone(
+            m.evidence_snapshot_current_error(packet, drifted)
+        )
 
     def test_previous_audit_candidates_are_live_unless_explicitly_retired(self):
         m = _import("no_go_discipline_gate")
@@ -4694,17 +4806,26 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             "schema": "no_go_cross_cycle_index_v1", "claim_id": "test_no_go",
             "candidates": [{"candidate_id": "new:cycle", "kind": "prior_audit_cycle"}],
         })
+        # Verdict durability (default): dynamic-index drift never
+        # retroactively invalidates an authenticated packet.
+        self.assertIsNone(m.evidence_snapshot_current_error(packet, changed))
+        # Apply-time replay rejection opts back in and still catches it.
         self.assertIn(
             "rendered content drifted",
-            m.evidence_snapshot_current_error(packet, changed) or "",
+            m.evidence_snapshot_current_error(
+                packet, changed, dynamic_index_drift_invalidates=True
+            ) or "",
         )
         changed = json.loads(json.dumps(manifest))
         cross_payload = json.loads(changed[cross_path]["text"])
         cross_payload["search_scope"] = {"scanned_count": 9999}
         changed[cross_path]["text"] = json.dumps(cross_payload)
+        self.assertIsNone(m.evidence_snapshot_current_error(packet, changed))
         self.assertIn(
             "rendered content drifted",
-            m.evidence_snapshot_current_error(packet, changed) or "",
+            m.evidence_snapshot_current_error(
+                packet, changed, dynamic_index_drift_invalidates=True
+            ) or "",
         )
 
     def test_snapshot_reauthenticates_authority_metadata_and_path_universe(self):

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -4259,7 +4259,24 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             self.assertEqual(truncation["total_hits"], 100)
             self.assertEqual(truncation["listed"], cap)
             self.assertEqual(truncation["omitted_count"], 100 - cap)
-            self.assertEqual(len(truncation["omitted_candidate_ids_sha256"]), 64)
+            full_similar_ids = sorted(
+                f"similar_negative_boundary:peer_{index}"
+                for index in range(100)
+            )
+            self.assertEqual(
+                [candidate["candidate_id"] for candidate in similar],
+                full_similar_ids[:cap],
+            )
+            omitted_ids = full_similar_ids[cap:]
+            self.assertEqual(
+                truncation["omitted_candidate_ids_sha256"],
+                hashlib.sha256(
+                    json.dumps(omitted_ids, separators=(",", ":")).encode()
+                ).hexdigest(),
+            )
+            self.assertTrue(
+                set(full_similar_ids).issubset(parsed["candidate_id_universe"])
+            )
             # the universe itself stays complete: capping the disposition
             # list never hides the corpus
             self.assertEqual(parsed["no_go_row_universe_count"], 100)
@@ -4349,6 +4366,108 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         )
         growth = m.evidence_snapshot_index_growth(packet, current_manifest)
         self.assertEqual(growth, {index_uri: ["open_gate:beta"]})
+
+    def test_dynamic_index_growth_reports_capped_tail_and_partial_closure_ids(self):
+        m = _import("no_go_discipline_gate")
+        cross_uri = m.cross_cycle_index_path("target_claim")
+        partial_uri = m.partial_closure_index_path("target_claim")
+        cross_listed = [f"similar:{index:02d}" for index in range(40)]
+        cross_stored_universe = [*cross_listed, "similar:omitted"]
+        partial_stored_universe = ["partial:listed", "partial:removed"]
+
+        def cross_text(universe):
+            return json.dumps(
+                {
+                    "schema": "no_go_cross_cycle_index_v1",
+                    "claim_id": "target_claim",
+                    "no_go_row_universe_count": 0,
+                    "no_go_row_universe_sha256": "0" * 64,
+                    "candidate_id_universe": universe,
+                    "candidates": [
+                        {"candidate_id": candidate_id}
+                        for candidate_id in cross_listed
+                    ],
+                }
+            )
+
+        def partial_text(universe):
+            return json.dumps(
+                {
+                    "schema": "no_go_partial_closure_index_v1",
+                    "claim_id": "target_claim",
+                    "candidate_id_universe": universe,
+                    "candidates": [{"candidate_id": "partial:listed"}],
+                }
+            )
+
+        manifest = {
+            cross_uri: {
+                "path": cross_uri,
+                "roles": ["cross_cycle_index"],
+                "text": cross_text(cross_stored_universe),
+            },
+            partial_uri: {
+                "path": partial_uri,
+                "roles": ["partial_closure_index"],
+                "text": partial_text(partial_stored_universe),
+            },
+        }
+        packet = {"evidence_snapshot": m.build_evidence_snapshot({}, manifest)}
+        mismatched_manifest = json.loads(json.dumps(manifest))
+        mismatched_manifest[cross_uri][
+            "cross_cycle_candidate_id_universe"
+        ] = cross_listed
+        with self.assertRaisesRegex(ValueError, "candidate-ID universe"):
+            m.build_evidence_snapshot({}, mismatched_manifest)
+
+        malformed_manifest = json.loads(json.dumps(manifest))
+        malformed_cross = json.loads(malformed_manifest[cross_uri]["text"])
+        malformed_cross["candidate_id_universe"] = "not-a-list"
+        malformed_manifest[cross_uri]["text"] = json.dumps(malformed_cross)
+        with self.assertRaisesRegex(ValueError, "candidate-ID universe"):
+            m.build_evidence_snapshot({}, malformed_manifest)
+
+        subset_invalid_packet = json.loads(json.dumps(packet))
+        subset_invalid_packet["evidence_snapshot"]["entries"][cross_uri][
+            "cross_cycle_candidate_id_universe"
+        ] = cross_listed[1:]
+        self.assertIsNone(
+            m.evidence_manifest_from_snapshot(subset_invalid_packet)
+        )
+
+        current_manifest = {
+            cross_uri: dict(
+                manifest[cross_uri],
+                text=cross_text([*cross_stored_universe, "similar:new-tail"]),
+            ),
+            partial_uri: dict(
+                manifest[partial_uri],
+                text=partial_text(["partial:listed", "partial:new"]),
+            ),
+        }
+        self.assertEqual(
+            m.evidence_snapshot_index_growth(packet, current_manifest),
+            {
+                cross_uri: ["similar:new-tail"],
+                partial_uri: ["partial:new"],
+            },
+        )
+
+        # Persisted snapshots from before this field existed remain readable.
+        # N8 was uncapped then; if a synthetic legacy snapshot was capped, the
+        # fallback safely over-targets its previously omitted IDs once.
+        legacy_packet = json.loads(json.dumps(packet))
+        legacy_entries = legacy_packet["evidence_snapshot"]["entries"]
+        legacy_entries[cross_uri].pop("cross_cycle_candidate_id_universe")
+        legacy_entries[partial_uri].pop("partial_closure_candidate_id_universe")
+        self.assertIsNotNone(m.evidence_manifest_from_snapshot(legacy_packet))
+        self.assertEqual(
+            m.evidence_snapshot_index_growth(legacy_packet, current_manifest),
+            {
+                cross_uri: ["similar:new-tail", "similar:omitted"],
+                partial_uri: ["partial:new"],
+            },
+        )
 
     def test_stable_role_content_drift_still_invalidates(self):
         m = _import("no_go_discipline_gate")


### PR DESCRIPTION
## Incident

Today's audit-authority hardening introduced a same-day regression with two coupled defects, verified live:

1. **Infeasible packets**: the new N8 bulk scan kinds are uncapped (`candidate_limit: null`) — `repo_negative_phrase_hit` scans 3,964 docs and `similar_negative_boundary` all no-go rows — producing **~1,700-candidate** indexes on common-vocabulary foundational rows (cl3_pauli: 1,711). No auditor can disposition that honestly in a session; nothing gate-required can land.
2. **Verdict decay**: the invalidation sweep's snapshot set-identity check treats ANY index growth as `no_go_discipline_packet_invalid`. Since every landed note/loop-ledger/vocab row grows the universes, **every clean audit decays within hours**: a doubly-confirmed cross-family clean landed at 09:00 today was wiped by afternoon; the owner lane's own 07-11 cleans (69-echo packets, valid at the time) were retro-invalidated.

## Fix (three parts, intent-preserving)

- **Builder caps with authenticated tails**: per-kind `N8_KIND_CANDIDATE_LIMITS` — high-signal kinds (prior audit cycles, open gates, loop ledgers) listed in full; bulk scan kinds capped 60/40 by the already-declared relevance order, with a `candidate_truncation` block (total hits, omitted count, omitted-id sha256) inside the authenticated index. The anti-corpus-hiding intent survives: the full universe count/hash is part of the index; only the *disposition list* is bounded — mirroring the N6 builder's existing 10/20 caps. cl3_pauli: 1,711 → **172 listed**.
- **Durability by default**: `evidence_snapshot_current_error` no longer invalidates on dynamic-index drift; new `evidence_snapshot_index_growth` reports post-authentication growth, and the sweep persists it to `docs/audit/data/no_go_index_growth_targets.json` (generated) as **re-audit signal for the dispatch stream** — new candidates get looked at without deleting the authenticated verdict.
- **Replay defense preserved**: `trusted_manifest_current_error` (apply-time replayed-prompt rejection) opts back in via `dynamic_index_drift_invalidates=True`; the one-use invocation guard is untouched. The failing-then-fixed test triple demonstrates the split semantics precisely.

## Verification
- **220/220 tests** (was 217 + 3 new/updated): the old uncapped-by-design test now asserts cap + authenticated tail; byte-drift roundtrip asserts durability-by-default and replay-rejection-with-flag; new growth-never-invalidates and stable-drift-still-invalidates tests.
- Full `run_pipeline.sh` + `audit_lint.py --strict` green end-to-end on this branch; growth artifact generates.
- No `docs/audit/data` staged (generated surfaces regenerate post-merge).

## Post-merge (owner lane)
Run `restore_overaggressively_invalidated_audits.py` (or targeted re-application) for rows invalidated solely by `no_go_discipline_packet_invalid` under the old rule whose packets re-validate under this one — the 07-11/07-12 cleans (incl. persistent_record_as_kraus_operator) are the known set; their index growth then lands in the growth-targets artifact instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)