### PR TITLE
[physics-loop] ckm-composite-typed-bridge block02 — exact support/boundary

### DIFF
--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/ARTIFACT_PLAN.md
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/ARTIFACT_PLAN.md
@@ -1,0 +1,16 @@
+# Artifact plan
+
+Source artifacts:
+
+- `docs/CKM_MASS_OPERATOR_PROJECTOR_OVERLAP_TYPING_THEOREM_NOTE_2026-07-12.md`
+- `scripts/frontier_ckm_mass_operator_projector_overlap_typing.py`
+- `logs/runner-cache/frontier_ckm_mass_operator_projector_overlap_typing.txt`
+- this loop pack
+
+The runner must verify exact projector identities, weak-basis covariance, the
+rank-`(1+5)` determinant exponent, the two-family commutator form, and explicit
+down-only countermodels. It must contain no observed target values.
+
+Generated audit authority files are validation outputs and must not ship.
+This block does not edit the primitive registry, lane registry, claim-status
+registry, or retained audit verdicts.

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/ASSUMPTIONS_AND_IMPORTS.md
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/ASSUMPTIONS_AND_IMPORTS.md
@@ -1,0 +1,19 @@
+# Assumptions and imports
+
+| Item | Role | Status | Consequence if removed |
+|---|---|---|---|
+| Supplied complex `3 x 3` quark mass operators `M_u,M_d` with their standard left-handed physical meaning | Load-bearing physical typing | Open framework derivation | The theorem remains algebra but loses its CKM interpretation |
+| `H_u=M_uM_u^dagger`, `H_d=M_dM_d^dagger` | Definition | Exact | No left spectral projectors |
+| Simple positive spectra, ordered and named by quark generation | Explicit theorem condition and labeling convention | Not derived here | Degenerate eigenspaces require a block-projector version and individual CKM entries are not selected |
+| Finite-dimensional spectral theorem and Lagrange spectral projectors | Standard/literature theorem | Exact mathematical import | Projector formula unavailable |
+| Standard definition `V=U_u^dagger U_d` | Supplied physical semantics | Standard, not a new framework primitive | Projector overlaps are merely relative eigenline overlaps |
+| `R=m_s/m_b=sqrt(d_s/d_b)` | Supplied spectral ratio | Exact conditional on typing | No five-sixths comparison |
+| Abstract six-state `X_R=Q+R(I-Q)` with rank-one `Q` | Algebraic packaging | Exact but not a physical lift | The exponent packaging disappears; the physical overlap theorem is unchanged |
+| `Tr(P_c^uP_b^d)=R^(5/3)` | Desired alignment law | Open; not assumed in the result | The five-sixths physical bridge remains unproved |
+| Unitary invariance of a positive six-state scalar readout | New/open premise used only by the unselected determinant-character route | Not consumed by the source theorem | Conditional uniqueness of `det^(1/6)` is unavailable |
+| Multiplicativity on commuting same-space positive operators | New/open premise used only by the unselected determinant-character route | Not supplied by Record and not consumed by the source theorem | Conditional uniqueness of `det^(1/6)` is unavailable |
+| Degree-one scale covariance of that scalar readout | New/open premise used only by the unselected determinant-character route | Not consumed by the source theorem | Conditional uniqueness of `det^(1/6)` is unavailable |
+
+No observed mass value, fitted texture parameter, CKM target, or RG datum is
+used. The scale-reference, kinetic-isotropy, and realized-state primitives do
+not supply a quark mass pair, a relative eigenbasis, or a mixing readout.

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/CLAIM_STATUS_CERTIFICATE.md
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/CLAIM_STATUS_CERTIFICATE.md
@@ -1,0 +1,149 @@
+# Claim-status certificate
+
+```yaml
+actual_current_surface_status: exact support/boundary theorem
+claim_type: bounded_theorem
+trace_class: upstream_support
+reachability_to_target: supports
+retirement_claimed: false
+registry_edited: false
+primitive_edited: false
+axiom_edited: false
+audit_status_set: false
+publication_status_set: false
+proposal_allowed: false
+proposal_allowed_reason: physical mass-operator origin and invariant alignment remain open
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+Bounded claim: for a supplied nondegenerate quark mass-operator pair with the
+standard CKM semantics, spectral-projector overlaps exactly equal CKM moduli
+squared. The desired five-sixths relation is exactly equivalent to one scalar
+relative-alignment law. No universal equivariant/invariant down-only scalar
+construction can recover CKM mixing on the full stated domain. The positive
+identity and negative boundary are one mixed-role bounded row; no separate
+`no_go` row is proposed.
+
+Excluded claims:
+
+- the framework derives `M_u` or `M_d`;
+- the five-sixths alignment law is derived;
+- the atlas six-state carrier is identified with generation flavor;
+- an absolute mass, CKM value, RG law, or empirical agreement is predicted;
+- the entire CKM closure target is retired.
+
+## N1 — Alternative-route enumeration
+
+The tested negative claim is only the universal factorization through data
+from `H_d` alone, with equivariant operator construction and invariant scalar
+readout. Routes that change that input domain remain live.
+
+| Attack route | What it attempts | Why it does not defeat the scoped claim | Marker | Evidence |
+|---|---|---|---|---|
+| Arbitrary down-spectrum scalar | Set `|V_cb|=f(spec H_d)` without the six-state packaging | Fixed `H_d` supports continuously varying up-sector orientations and hence varying `|V_cb|` | ATTEMPTED | source note §5, equations (5.1)-(5.2) |
+| Down-equivariant operator followed by invariant readout | Let eigenvectors or nonlinear functions inside `Phi(H_d)` restore orientation information | Equivariance plus conjugacy-invariant scalar output still gives a class function of the unchanged `H_d` | ATTEMPTED | source note Theorem 2 |
+| Rank-`(1+5)` normalized determinant | Encode `R` as `X_R=Q+R(I-Q)` and read `det(X_R)^(1/6)` | It fixes the exponent but remains identical for two pairs with the same `H_d` and different relative orientation | ATTEMPTED | source note §§4-5; paired runner down-only countermodels |
+| `C3` circulant carrier reuse | Use a cyclic generation carrier to select both a hierarchy and CKM orientation | The retained carrier boundary leaves sector phases, relative scales, and quark readout open; it does not supply this alignment | RULED OUT BY PRIOR | [`QUARK_C3_CIRCULANT_SOURCE_LAW_BOUNDARY_NOTE_2026-04-28.md`](../../../../docs/QUARK_C3_CIRCULANT_SOURCE_LAW_BOUNDARY_NOTE_2026-04-28.md), lines 122-145 |
+| Fixed external reference projector | Supply `P_ref` and read an overlap with a down-sector eigenspace | This can work only after adding an orientation carrier; the input is `(H_d,P_ref)`, not down-only | ATTEMPTED | source note §5 boundary paragraph |
+| Supplied pair projectors | Consume `(H_u,H_d)` and read `Tr(P_c^uP_b^d)` | This succeeds and is the strongest escape, but changes the theorem's input domain rather than refuting it | ATTEMPTED | source note Theorem 1 |
+| Paired texture or source/action dynamics | Derive both sectors and their relative eigenbasis jointly | This remains a positive route outside the down-only class; no claim here rules it out | ATTEMPTED | source note §§5 and 7 |
+
+Seven distinct attacks were considered. Four are direct constructions within
+the class; three are domain-changing escapes used to check that the theorem's
+rhetoric does not foreclose viable paired routes.
+
+## N2 — Wall-independence audit
+
+The positive bridge has the collapsed wall set below.
+
+| Pair | Closing first closes second? | Closing second closes first? | Independent? |
+|---|---|---|---|
+| `W1`: derive and physically type `M_u,M_d`; `W2`: derive `Tr(P_c^uP_b^d)=R^(5/3)` | No: derived operators need not obey the alignment law | No: a conditional alignment law does not derive the operators | Yes |
+
+The generation-flavor to six-state lift is route-specific. It is not counted
+as a universal third wall because the direct projector-overlap route does not
+need it.
+
+## N3 — Hidden-wall scan
+
+| Trigger hit | Location | Classification | Treatment |
+|---|---|---|---|
+| “supplied” mass operators | source note §§1-2 | Explicit supplied condition; already `W1` in the collapsed set | Listed in theorem conditions and import ledger |
+| “Assume simple positive ordered spectra” | source note equation (2.2) | Explicit algebraic condition | Degenerate case and naming consequence stated |
+| “standard CKM definition” | source note equation (2.4) | Explicit supplied physical semantics | Not described as a framework-derived fact |
+| ordered `u,c,t` and `d,s,b` names | source note equation (2.2) | Non-load-bearing labeling convention | The general `i,j` theorem is algebraic before names are attached |
+| abstract six-state `Q` | source note §4 | Explicit nonphysical packaging condition | No generation-to-six-state lift is claimed |
+| atlas/STRC carrier context | source note §6 | Genuine non-load-bearing context | Explicitly not consumed as a dependency |
+
+The scan found no remaining hidden condition and did not change the collapsed
+two-wall set.
+
+## N4 — Residual matching
+
+| Witness | Witness residual | Current residual | Match? | Use |
+|---|---|---|---|---|
+| Parent loop [`NO_GO_LEDGER.md`](../ckm-down-scale-covariance-20260712/NO_GO_LEDGER.md), lines 3-12 | Casimir-identity, QCD, and scale-rescue routes do not supply the bridge | Universal down-only equivariant/invariant scalar readout | Partial/No; its orientation countermodel is evidence inside a narrower route row, not a proof of this class theorem | Target handoff only; dropped as proof witness |
+| [`QUARK_C3_CIRCULANT_SOURCE_LAW_BOUNDARY_NOTE_2026-04-28.md`](../../../../docs/QUARK_C3_CIRCULANT_SOURCE_LAW_BOUNDARY_NOTE_2026-04-28.md), lines 122-145 | A `C3` carrier does not supply sector phases/scales and quark readout | Universal down-only orientation readout | No | Dropped as proof witness; retained only as route-specific N1 pruning |
+| [`OBSERVABLE_PRINCIPLE_T1D_DETERMINANT_READOUT_INDEPENDENCE_NO_GO_NOTE_2026-06-16.md`](../../../../docs/OBSERVABLE_PRINCIPLE_T1D_DETERMINANT_READOUT_INDEPENDENCE_NO_GO_NOTE_2026-06-16.md), lines 33-56 | Record plus determinant algebra does not force determinant-only readout | Universal down-only orientation readout | No | Dropped as proof witness; informs readout-premise disclosure only |
+| [`QUARK_GENERATION_STRATIFIED_WARD_FREE_MATRIX_NO_GO_NOTE_2026-04-28.md`](../../../../docs/QUARK_GENERATION_STRATIFIED_WARD_FREE_MATRIX_NO_GO_NOTE_2026-04-28.md), lines 108-150 | Fixed CKM data do not determine Yukawa singular values | Fixed down data do not determine relative CKM orientation | No; converse information direction | Dropped as proof witness |
+
+After nonmatching witnesses are dropped, the current theorem stands on its own
+fixed-`H_d`, varying-`H_u` countermodel and does not require a witness count.
+
+## N5 — Rhetoric and resolution audit
+
+| Resolution | Tested? | Result allowed here |
+|---|---|---|
+| Individual spectral element/eigenvalue | Yes | The full down spectrum is fixed in the countermodel |
+| Down-sector `3 x 3` operator | Yes | The whole operator `H_d` is fixed exactly |
+| Equivariant operator image `Phi(H_d)` | Yes, abstractly | It is fixed/equivalent whenever `H_d` is fixed |
+| Invariant scalar readout | Yes, abstractly | It cannot distinguish the two mass pairs |
+| Pair-based mass-operator map | No; explicit escape | No negative claim |
+| Source/action dynamics or lattice-wide construction | No | No negative claim |
+| Global CKM closure or all textures | No | No negative claim |
+
+The source uses only “universal down-only equivariant/invariant class.” It does
+not promote the finite operator-pair result to a per-site, action-level,
+lattice-wide, or global CKM no-go.
+
+## N6 — Partial-closure paths
+
+| Candidate path | Current status | What it could close | Classification |
+|---|---|---|---|
+| Pair spectral-projector overlap in the new source note, §§2-3 | Exact supplied-context result; independent audit pending | Physical CKM readout once the pair is supplied | Positive theorem path, already executed |
+| Fixed `P_ref` orientation carrier | Open and not framework-typed | Down-sector readout relative to a supplied ray | Explicit bounded bridge path |
+| Paired NNI or broken-`C3` source/action | Open; coefficients/source law not derived | `W2`, the relative alignment law | Future source/action theorem path |
+| [`OBSERVABLE_PRINCIPLE_T1D_DETERMINANT_CONTEXT_QUOTIENT_BRIDGE_NOTE_2026-06-18.md`](../../../../docs/OBSERVABLE_PRINCIPLE_T1D_DETERMINANT_CONTEXT_QUOTIENT_BRIDGE_NOTE_2026-06-18.md) | Source proposal; current effective status unaudited; not consumed | Readout selection in its stated Record context, not CKM orientation | Candidate reframe/context path with nonmatching residual |
+| Scale-reference, kinetic-isotropy, realized-state primitives | Approved but non-supplying for this residual | Units, kinetic form, pointwise state evaluation only | Not walls and not CKM closure paths |
+
+No convention-only reframe, meta-ratification, or in-flight convention proposal
+was found that closes relative up/down orientation. The negative claim does not
+say a new axiom is required; theorem, source/action, or explicit bounded-bridge
+retirement paths remain open.
+
+## N7 — Hostile steelman
+
+A hostile reviewer should reject any suggestion that the down-only obstruction
+blocks the physics: the mass problem is relational, so the correct input is the
+pair `(H_u,H_d)`, or a source/action object that generates both. The strongest
+authority is the new source note's Theorem 1, which gives the exact escape
+`Tr(P_i^uP_j^d)=|V_ij|^2`. A derived reference projector could also carry the
+missing orientation. This steelman succeeds against an overbroad CKM no-go but
+does not touch the stated theorem, because every successful route changes the
+input from `H_d` alone to orientation-carrying relational data. The claim is
+therefore kept at the narrow down-only class.
+
+## N8 — Cross-cycle echo
+
+| Prior wall | Status/mechanism | Could the mechanism apply here? | Incorporation |
+|---|---|---|---|
+| Parent CKM down-scale loop [`NO_GO_LEDGER.md`](../ckm-down-scale-covariance-20260712/NO_GO_LEDGER.md), lines 3-12 | Kept typed determinant/source-action routes open after scale-only failures | Yes; replace down-only data with a relational pair | Executed as Theorem 1 |
+| T1-d determinant-context source proposal [`OBSERVABLE_PRINCIPLE_T1D_DETERMINANT_CONTEXT_QUOTIENT_BRIDGE_NOTE_2026-06-18.md`](../../../../docs/OBSERVABLE_PRINCIPLE_T1D_DETERMINANT_CONTEXT_QUOTIENT_BRIDGE_NOTE_2026-06-18.md) | Current effective status unaudited; proposes richer supplied context for a determinant-readout independence wall | Only at the readout layer; it cannot manufacture CKM orientation | Recorded as an unaudited candidate mechanism, not authority or a proof witness |
+| Retained `C3` carrier boundary [`QUARK_C3_CIRCULANT_SOURCE_LAW_BOUNDARY_NOTE_2026-04-28.md`](../../../../docs/QUARK_C3_CIRCULANT_SOURCE_LAW_BOUNDARY_NOTE_2026-04-28.md), lines 122-167 | Leaves species source/readout theorem as the retirement path | Yes, a sector-specific paired source law could close `W2` | Kept live in the opportunity queue |
+
+The recurring retirement mechanism is richer, explicitly typed relational
+context. This block applies that mechanism to the readout while preserving the
+remaining source/action alignment target.
+
+No-go discipline status: `PASS`.

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/GOAL.md
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/GOAL.md
@@ -1,0 +1,19 @@
+# Goal
+
+Close as much as possible of the parent block's composite typed bridge
+
+```text
+down-mass data -> rank-(1+5) operator X_R -> |V_cb|
+```
+
+without importing observed targets or mistaking determinant packaging for a
+physical mixing theorem. The best honest outcome is an exact, basis-covariant
+readout from a supplied quark mass-operator pair, together with a precise
+statement of the one scalar alignment law that remains dynamical.
+
+Success means:
+
+1. type the physical readout directly on generation flavor;
+2. prove or falsify the down-only route on its stated domain;
+3. isolate the residual needed to obtain the five-sixths relation;
+4. keep all framework-origin, carrier-lift, and empirical gates explicit.

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/HANDOFF.md
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/HANDOFF.md
@@ -1,0 +1,16 @@
+# Handoff
+
+The exact source-side result is complete: supplied mass pairs give a typed CKM
+readout through spectral-projector overlap, and the universal down-only route
+is ruled out on its stated class. The five-sixths claim is not derived.
+
+Next exact science action:
+
+```text
+derive from framework source/action data a paired relation equivalent to
+Tr(P_c^u P_b^d) = (m_s/m_b)^(5/3)
+```
+
+Independent review, vocabulary lint, exact runner/cache freshness checks, and
+the audit pipeline have passed. Keep the branch stacked on block 01; do not
+spend cycles rebasing either PR merely because `main` moved.

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/LITERATURE_BRIDGES.md
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/LITERATURE_BRIDGES.md
@@ -1,0 +1,10 @@
+# Literature bridges
+
+No external literature is load-bearing in this block. The argument uses only
+finite-dimensional spectral projectors, trace cyclicity, and the standard
+definition of the CKM matrix from the two left diagonalizers.
+
+Future literature work should be limited to candidate paired texture or
+source/action mechanisms after their assumptions are stated in repo-native
+form. Literature cannot substitute for the missing framework derivation or
+alignment theorem.

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/NO_GO_LEDGER.md
@@ -1,0 +1,39 @@
+# No-go ledger
+
+## Universal down-only route
+
+Fix nondegenerate `H_d` and the up-sector eigenvalues. Rotating only the
+up-sector `2-3` eigenbasis changes
+`Tr(P_c^uP_b^d)=|V_cb|^2` continuously while every unitarily equivariant
+construction from `H_d`, followed by a conjugacy-invariant scalar readout,
+remains fixed. Therefore that whole down-only factorization class cannot be a
+universal CKM readout.
+
+Scope: finite-dimensional nondegenerate mass pairs and the stated
+equivariant/invariant map class. This is not a no-go for paired source/action
+dynamics, an externally supplied orientation projector, NNI textures, or a
+broken-symmetry construction.
+
+## Determinant-character route
+
+A positive, unitarily invariant, degree-one readout on positive six-state
+operators that is multiplicative on commuting same-space operators is
+uniquely `det^(1/6)`. The uniqueness is conditional: commuting
+multiplicativity is not supplied by the minimal Record surface, and the
+result still contains no relative up/down orientation.
+
+## Carrier reuse
+
+The atlas `1+5` carrier and generation-flavor mass carrier are different
+spaces. The reduced STRC two-axis carrier does not turn its five-channel axis
+into five independent mass eigenvalues. Reuse without a lift is a typing
+error, not a theorem.
+
+## Prior retained boundaries
+
+The retained
+[`C3` circulant source-law boundary](../../../../docs/QUARK_C3_CIRCULANT_SOURCE_LAW_BOUNDARY_NOTE_2026-04-28.md)
+shows that the carrier does not by itself supply sector phases, relative
+scales, or quark readout. The present pair theorem supplies a relative-basis
+readout after the mass pair is given; it does not overturn or close that
+source-law boundary.

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/OPPORTUNITY_QUEUE.md
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/OPPORTUNITY_QUEUE.md
@@ -1,0 +1,13 @@
+# Opportunity queue
+
+1. Derive a paired source/action constraint equivalent to
+   `Tr(P_c^uP_b^d)=(m_s/m_b)^(5/3)`.
+2. Derive and physically type `M_u,M_d` from framework data before making any
+   phenomenological claim.
+3. Test whether a coefficient-closed paired NNI or broken-`C3` construction
+   fixes the required projector overlap without target fitting.
+4. If the atlas determinant route remains desired, construct a theorem-level
+   generation-flavor to six-state lift and show why its rank-one direction is
+   physical.
+5. Only after the source-side bridge closes, add RG transport and empirical
+   comparison as a separate block.

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/PR_BACKLOG.md
@@ -1,0 +1,13 @@
+# PR backlog
+
+- Parent/base PR: #5235, branch
+  `physics-loop/ckm-down-scale-closure-block01-20260712`.
+- This block: open one stacked PR from
+  `physics-loop/ckm-composite-typed-bridge-block02-20260712` onto the parent
+  branch.
+- Do not refresh either PR onto fast-moving `main` solely to change its
+  clean/behind status. The reviewer lane owns later integration and useful
+  cherry-picks.
+- PR title should identify the composite typing bridge and its exact
+  support/boundary role.
+- PR body should state the two open walls and the exact runner result.

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/PR_BACKLOG.md
@@ -2,9 +2,10 @@
 
 - Parent/base PR: #5235, branch
   `physics-loop/ckm-down-scale-closure-block01-20260712`.
-- This block: open one stacked PR from
-  `physics-loop/ckm-composite-typed-bridge-block02-20260712` onto the parent
-  branch.
+- This block: PR
+  [#5272](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5272)
+  is open from `physics-loop/ckm-composite-typed-bridge-block02-20260712` onto
+  the parent branch.
 - Do not refresh either PR onto fast-moving `main` solely to change its
   clean/behind status. The reviewer lane owns later integration and useful
   cherry-picks.

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/REVIEW_HISTORY.md
@@ -1,0 +1,52 @@
+# Review history
+
+## Pre-review fanout — 2026-07-12
+
+Three independent route checks converged:
+
+1. Relative-basis route: derived
+   `Tr(P_i^uP_j^d)=|V_ij|^2`, the two-family commutator form, and the fixed-`H_d`
+   orientation countermodel.
+2. Atlas-reuse route: found no existing authority supplying a
+   generation-flavor to six-state lift or the relative alignment law; shared
+   circulants and current NNI prose do not close it.
+3. Spectral-character route: proved conditional uniqueness of `det^(1/6)`
+   under added readout axioms and confirmed that it remains orientation-blind.
+
+Initial exact runner result:
+`SUMMARY: EXACT_PASS=18 BOUNDARY_PASS=14 FAIL=0`.
+
+## Review-loop iteration 1
+
+- Code/runner: PASS; independent random-unitary recomputation gave projector
+  overlap and weak-basis covariance errors below `5e-16`.
+- Physics/Nature/labeling: BOUNDED / BOUNDED / PASS. Findings: narrow the trace
+  movement, remove unproved minimality, use the native mixed-role status, and
+  remove branch-local source prose.
+- Imports/governance/no-go discipline: fixes required for determinant-character
+  premise disclosure, retained-authority links, and tabular N1-N8 evidence.
+
+## Review-loop iterations 2-3
+
+All verified findings were fixed and only changed files were re-reviewed.
+Final dispositions:
+
+- Code/runner: PASS.
+- Physics claim: BOUNDED; parent physical bridge OPEN.
+- Nature retention: BOUNDED; no Nature-readiness claim.
+- Import support: PASS.
+- Labeling convention: PASS.
+- Repository governance: PASS.
+- No-go discipline: PASS after the full N1-N8 evidence walk.
+
+No reviewer applied an audit verdict. Independent audit remains required.
+
+## Audit compatibility validation
+
+The audit pipeline seeded one new leaf row,
+`ckm_mass_operator_projector_overlap_typing_theorem_note_2026-07-12`, with
+`claim_type=bounded_theorem`, `audit_status=unaudited`, the parent-note
+dependency, and the paired runner. Strict lint passed with no errors (31
+pre-existing warnings and 248 notices). All regenerated audit, publication,
+and front-door outputs were restored from the intended stacked base and are
+absent from the source diff.

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/ROUTE_PORTFOLIO.md
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/ROUTE_PORTFOLIO.md
@@ -1,0 +1,16 @@
+# Route portfolio
+
+| Route | Verdict | Reason |
+|---|---|---|
+| Pair spectral-projector overlap | Selected; exact support | `Tr(P_i^uP_j^d)=|V_ij|^2` is phase-free and weak-basis invariant |
+| Down-only spectral/determinant map | Ruled out on the universal equivariant/invariant class | Fixed `H_d` and varying `H_u` orientation leave every down-only class function fixed while `|V_cb|` varies |
+| Commuting positive-operator character | Conditional uniqueness only | Natural readout axioms select `det^(1/6)`, but those readout axioms are new and the result is orientation-blind |
+| Atlas/STRC `1+5` reuse | Type-blocked | The atlas carrier is weak-isospin times color; the mass operators act on generation flavor; the reduced STRC carrier is two-dimensional |
+| Paired NNI/Schur texture | Live future route | It can carry relative orientation, but current texture coefficients are not fixed |
+| `C3` circulant carrier reuse | Ruled out by retained prior for source-law closure | The retained [`C3` carrier boundary](../../../../docs/QUARK_C3_CIRCULANT_SOURCE_LAW_BOUNDARY_NOTE_2026-04-28.md) leaves sector phases, relative scales, and quark readout open |
+| Broken-`C3` paired source/action | Live future route | Could select a relative eigenbasis, but no source/action theorem presently forces the alignment law |
+| Record/log-determinant readout | Context-limited | Existing Record axioms do not derive determinant-only multiplicative readout |
+
+The pair route wins because it supplies the exact semantic bridge with the
+fewest added inputs. It deliberately does not claim to derive the residual
+alignment law.

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/STATE.yaml
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/STATE.yaml
@@ -7,7 +7,9 @@ cycle_count: 1
 branch: physics-loop/ckm-composite-typed-bridge-block02-20260712
 base_branch: physics-loop/ckm-down-scale-closure-block01-20260712
 base_pr: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5235
-status: ready_to_publish
+status: pr_open
+source_commit: 1b7a41bbc
+pr: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5272
 claim_type: bounded_theorem
 actual_current_surface_status: exact support/boundary theorem
 trace_class: upstream_support

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/STATE.yaml
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/STATE.yaml
@@ -1,0 +1,33 @@
+loop_slug: ckm-composite-typed-bridge-20260712
+date: 2026-07-12
+mode: run
+target: best-honest-status
+science_block: 02
+cycle_count: 1
+branch: physics-loop/ckm-composite-typed-bridge-block02-20260712
+base_branch: physics-loop/ckm-down-scale-closure-block01-20260712
+base_pr: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5235
+status: ready_to_publish
+claim_type: bounded_theorem
+actual_current_surface_status: exact support/boundary theorem
+trace_class: upstream_support
+reachability_to_target: supports
+active_route: pair_spectral_projector_overlap
+hard_residual: derive_the_invariant_alignment_law_Tr_Pc_Pb_equals_ms_over_mb_to_the_five_thirds
+registry_edits: false
+retirement_claimed: false
+proposal_allowed: false
+proposal_allowed_reason: the physical mass-operator origin and invariant alignment law remain open
+open_imports:
+  - framework derivation and physical typing of the quark mass-operator pair
+  - source/action theorem fixing the relative up/down spectral-projector alignment
+  - generation-flavor to six-state carrier lift if the atlas determinant route is retained
+verification:
+  runner: "EXACT_PASS=18 BOUNDARY_PASS=14 FAIL=0"
+  py_compile: pass
+  independent_review: "PASS WITH BOUNDED CLAIMS; 3 iterations"
+  audit_pipeline: "pass; newly seeded rows=1"
+  audit_lint_strict: "pass with 31 existing warnings and 248 notices; no errors"
+  pipeline_outputs_stripped: pass
+next_exact_action: independently review the pair-projector theorem and then seek a source/action alignment law
+main_refresh_policy: do not refresh this stacked block or its parent merely because fast-moving main is ahead

--- a/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/TRACE_GATE.md
+++ b/.claude/science/physics-loops/ckm-composite-typed-bridge-20260712/TRACE_GATE.md
@@ -1,0 +1,20 @@
+# Trace gate
+
+Parent blocker:
+
+> derive a composite typed bridge from down-sector mass data through a
+> rank-`(1+5)` operator to physical `|V_cb|`, while respecting the fact that
+> mass spectra alone do not determine mixing orientation.
+
+Target claim ID:
+`ckm_down_type_scale_convention_support_note_2026-04-22`.
+
+Classification: `upstream_support` with reachability `supports`. The scoped
+down-only theorem also contributes `negative_route_pruning`, but no separate
+no-go claim row is proposed.
+
+The block directly types the physical readout as
+`|V_cb|^2=Tr(P_c^uP_b^d)`, proves the down-only obstruction, and rewrites the
+five-sixths target as the invariant alignment law
+`Tr(P_c^uP_b^d)=R^(5/3)`. It does not derive that law or the physical mass
+operators, so the parent target remains open.

--- a/docs/CKM_MASS_OPERATOR_PROJECTOR_OVERLAP_TYPING_THEOREM_NOTE_2026-07-12.md
+++ b/docs/CKM_MASS_OPERATOR_PROJECTOR_OVERLAP_TYPING_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,284 @@
+# CKM Mass-Operator Projector-Overlap Typing Theorem
+
+**Date:** 2026-07-12
+
+**Claim type:** bounded_theorem
+
+**Actual current-surface status:** exact support/boundary theorem
+
+**Trace class:** upstream_support
+
+**Reachability to target:** supports
+
+**Status authority:** independent audit lane only. This source note does not
+set or predict an audit outcome.
+
+**Primary runner:**
+[`scripts/frontier_ckm_mass_operator_projector_overlap_typing.py`](../scripts/frontier_ckm_mass_operator_projector_overlap_typing.py)
+
+## 1. Target and result
+
+The parent theorem note
+[`CKM_DOWN_TYPE_SCALE_CONVENTION_SUPPORT_NOTE_2026-04-22.md`](CKM_DOWN_TYPE_SCALE_CONVENTION_SUPPORT_NOTE_2026-04-22.md)
+isolated a composite typed bridge,
+
+```text
+down-mass data -> rank-(1+5) operator X_R -> |V_cb|,
+```
+
+but also proved that fixed mass spectra do not determine CKM orientation.
+This note separates the exact typing result from the remaining dynamical
+alignment law.
+
+The positive result is a basis-covariant CKM readout from a supplied *pair* of
+quark mass operators:
+
+```text
+|V_cb|^2 = Tr(P_c^u P_b^d).                              (1.1)
+```
+
+Here `P_c^u` and `P_b^d` are spectral projectors of the left-handed up- and
+down-sector mass-squared operators. No diagonalizer phases, observed masses,
+or fitted CKM entries enter (1.1).
+
+The five-sixths bridge is therefore equivalent to one explicit invariant
+alignment law,
+
+```text
+Tr(P_c^u P_b^d) = (m_s/m_b)^(5/3).                       (1.2)
+```
+
+Equation (1.2), not the determinant power, is the remaining dynamical target.
+The negative result is correspondingly narrow: no universal down-only,
+unitarily equivariant map followed by a conjugacy-invariant scalar readout can
+produce physical `|V_cb|` on the full nondegenerate mass-pair domain.
+
+## 2. Explicit theorem conditions
+
+Let `M_u` and `M_d` be supplied complex `3 x 3` quark mass operators acting
+between the usual right- and left-handed generation spaces. Define their
+left-handed positive operators
+
+```text
+H_u = M_u M_u^dagger,
+H_d = M_d M_d^dagger.                                    (2.1)
+```
+
+Assume simple positive ordered spectra
+
+```text
+spec(H_u) = {u_u < u_c < u_t} = {m_u^2,m_c^2,m_t^2},
+spec(H_d) = {d_d < d_s < d_b} = {m_d^2,m_s^2,m_b^2}.     (2.2)
+```
+
+The ordering labels are an explicit quark-name convention on already supplied
+mass operators. This note does not derive the operators, their spectra, or
+their identification with physical quarks from the framework axioms.
+
+For a simple eigenvalue, define the spectral projector without choosing an
+eigenvector phase:
+
+```text
+P_i^u = product_(k != i) (H_u-u_k I)/(u_i-u_k),
+P_j^d = product_(l != j) (H_d-d_l I)/(d_j-d_l).          (2.3)
+```
+
+Let `U_u` and `U_d` be any unitary left diagonalizers and use the standard CKM
+definition
+
+```text
+V = U_u^dagger U_d.                                      (2.4)
+```
+
+Equation (2.4) is the supplied physical meaning of the quark mass operators;
+it is not a new framework axiom or primitive.
+
+## 3. Spectral-projector overlap theorem
+
+**Theorem 1.** Under (2.1)-(2.4),
+
+```text
+Tr(P_i^u P_j^d) = |V_ij|^2.                              (3.1)
+```
+
+**Proof.** Simple spectra give rank-one projectors
+
+```text
+P_i^u = |u_i><u_i|,
+P_j^d = |d_j><d_j|.
+```
+
+Therefore
+
+```text
+Tr(P_i^u P_j^d)
+  = <u_i|d_j><d_j|u_i>
+  = |<u_i|d_j>|^2
+  = |V_ij|^2.
+```
+
+The expression is invariant under eigenvector rephasing. Under a simultaneous
+weak-basis change `W`, both projectors transform as `P -> W P W^dagger`, and
+cyclicity of trace leaves (3.1) unchanged. Thus
+
+```text
+|V_cb| = sqrt(Tr(P_c^u P_b^d))                           (3.2)
+```
+
+is a target-free, basis-covariant typed readout. Beyond `H_d`, a sufficient
+extra relational datum is the up-sector charm projector `P_c^u`; the full
+operator `H_u` is sufficient but not logically necessary.
+
+The compressed overlap operator supplies an equivalent one-dimensional
+determinant form:
+
+```text
+O_cb := P_c^u P_b^d P_c^u
+      = |V_cb|^2 P_c^u,
+det_(Ran P_c^u)(O_cb) = |V_cb|^2.                        (3.3)
+```
+
+This determinant is on the physical overlap line. It is not the six-state
+normalized determinant of the parent construction.
+
+## 4. Exact reformulation of the five-sixths target
+
+Define the supplied down-spectrum ratio
+
+```text
+R := m_s/m_b = sqrt(d_s/d_b).                            (4.1)
+```
+
+For any rank-one projector `Q` on an abstract six-dimensional space, let
+`P=I-Q` and
+
+```text
+X_R = Q + R P.
+```
+
+Then
+
+```text
+det(X_R) = R^5,
+Delta_6(X_R) := det(X_R)^(1/6) = R^(5/6).                (4.2)
+```
+
+Combining (3.2) and (4.2) gives the exact equivalences
+
+```text
+|V_cb| = Delta_6(X_R)
+<=> Tr(P_c^u P_b^d) = R^(5/3)
+<=> |V_cb|^6 = det(X_R) = R^5.                          (4.3)
+```
+
+Thus (4.2) packages the exponent but does not imply (4.3). The remaining
+physical content is the scalar alignment law (1.2), relating one up-sector
+eigenline, one down-sector eigenline, and the down-sector spectrum.
+
+On a strict two-family `2-3` restriction there is an equivalent commutator
+falsifier. With spectral gaps `Delta_u`, `Delta_d`, define
+
+```text
+chi := 2 ||[H_u,H_d]||_F^2/(Delta_u^2 Delta_d^2).
+```
+
+For a real relative rotation with `t=|V_cb|^2`,
+
+```text
+chi = 4 t(1-t).                                          (4.4)
+```
+
+The five-sixths law would require
+
+```text
+chi(R) = 4 R^(5/3) (1-R^(5/3)).                         (4.5)
+```
+
+The direct overlap trace is the primary readout because (4.4) alone has the
+branch ambiguity `t <-> 1-t`.
+
+## 5. Exact down-only boundary
+
+**Theorem 2.** Let `Phi(H_d)` be any unitarily equivariant construction and
+let `rho(Phi(H_d))` be any conjugacy-invariant scalar readout. Then the
+composition is a class function of `H_d`; it cannot equal physical `|V_cb|`
+for every nondegenerate pair `(H_u,H_d)`.
+
+**Proof.** Fix a positive diagonal `H_d=D_d` and distinct positive up-sector
+eigenvalues. Vary only the relative up-sector orientation,
+
+```text
+H_u(theta) = R_23(theta) D_u R_23(theta)^dagger.         (5.1)
+```
+
+The input `H_d`, its spectrum, every down-only spectral invariant, and hence
+`rho(Phi(H_d))` remain fixed. But the projector theorem gives
+
+```text
+Tr(P_c^u(theta) P_b^d) = sin(theta)^2,
+|V_cb| = |sin(theta)|,                                  (5.2)
+```
+
+which varies continuously. This contradicts a universal down-only
+factorization.
+
+A fixed external projector can evade the proof only by supplying an
+orientation reference. The input is then `(H_d,P_ref)`, not down-only, and the
+origin and physical typing of `P_ref` become separate theorem obligations.
+
+This theorem does not rule out pair-based source/action dynamics, a derived
+up-sector projector, paired NNI textures, or another orientation-carrying
+construction. It rules out only the universal equivariant/invariant
+down-only class.
+
+## 6. Carrier-type audit
+
+The parent's six-state `rank-(1+5)` determinant is an abstract conjugacy-class
+construction. Nearby CKM atlas prose places a `1+5` split on the six states of
+the weak-isospin by color block `Q_L=(2,3)`. In contrast, `H_u` and `H_d` act
+on three-dimensional generation flavor. No theorem cited here identifies
+those spaces or lifts `m_s/m_b` into the fivefold gauge complement.
+
+The reduced STRC carrier also does not provide that lift: its displayed
+`H_(1+5)=span{e_1,e_5}` is two-dimensional, with the five-channel represented
+by one reduced axis. Treating that reduced axis as five independent mass
+eigenvalues would add the missing lift by hand.
+
+Accordingly, this note does not consume the atlas or STRC surfaces as
+load-bearing dependencies; their carrier types do not supply (1.2).
+
+## 7. What moved and what remains open
+
+Established exactly here:
+
+1. the phase-free, basis-covariant map from a supplied mass-operator pair to
+   every CKM modulus;
+2. the exact invariant statement of the five-sixths alignment target;
+3. the universal down-only equivariant/invariant route obstruction;
+4. the distinction between the generation-flavor overlap determinant and the
+   abstract six-state normalized determinant.
+
+Still open:
+
+1. derivation of physical `M_u` and `M_d` from framework source/action data;
+2. a dynamical theorem forcing (1.2) or (4.5);
+3. a derived generation-to-six-state carrier lift, if that route is retained;
+4. absolute quark masses, RG transport, and empirical comparison.
+
+The current claim is one bounded row with an exact support result and an exact
+scoped boundary. Theorem 2 is not proposed as a separate `no_go` claim row.
+This is not the physical five-sixths bridge and does not permit retained-grade
+proposal language.
+
+## 8. Verification
+
+Run:
+
+```bash
+python3 scripts/frontier_ckm_mass_operator_projector_overlap_typing.py
+```
+
+The runner verifies the Lagrange projectors, overlap identity, weak-basis
+covariance, compressed determinant, five-sixths equivalence, two-family
+commutator formula, and explicit down-only countermodels using exact symbolic
+or rational algebra. It contains no observed mass or CKM target value.

--- a/logs/runner-cache/frontier_ckm_mass_operator_projector_overlap_typing.txt
+++ b/logs/runner-cache/frontier_ckm_mass_operator_projector_overlap_typing.txt
@@ -1,0 +1,58 @@
+===== runner cache v1 =====
+runner: scripts/frontier_ckm_mass_operator_projector_overlap_typing.py
+runner_sha256: 6b013501e6518151faa09e7dde9028849c6473658da5ede3a5037063c5c64929
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.57
+status: ok
+----- stdout -----
+CKM MASS-OPERATOR PROJECTOR-OVERLAP TYPING THEOREM
+
+1. SPECTRAL-PROJECTOR OVERLAP
+[EXACT_PASS] P_c is an exact Lagrange spectral projector
+[EXACT_PASS] P_b is idempotent
+[EXACT_PASS] P_b has trace one
+[EXACT_PASS] projector overlap is sin(theta)^2
+[EXACT_PASS] compressed overlap is |V_cb|^2 P_c
+[EXACT_PASS] compressed one-line determinant equals overlap
+
+2. PHASE AND WEAK-BASIS CONTROLS
+[EXACT_PASS] complex 2-3 control is unitary
+[EXACT_PASS] complex-phase overlap is |V_cb|^2=9/25
+[EXACT_PASS] simultaneous weak-basis rotation preserves overlap
+[EXACT_PASS] simultaneous rephasing preserves overlap
+
+3. SIX-STATE DETERMINANT AND ALIGNMENT RESIDUAL
+[EXACT_PASS] rank-(1+5) determinant is R^5
+[EXACT_PASS] normalized determinant exponent is 5/6
+[EXACT_PASS] mass ratio is invariant under common down-sector scale
+[EXACT_PASS] squared five-sixths target is (h_s/h_b)^(5/6)
+[EXACT_PASS] exact selected-orientation witness has R^(5/6)=1/32
+[EXACT_PASS] exact alignment witness has overlap R^(5/3)
+[EXACT_PASS] bridge sixth-power form is |V_cb|^6=R^5
+
+4. TWO-FAMILY COMMUTATOR FALSIFIER
+[EXACT_PASS] commutator invariant is 4t(1-t)
+[BOUNDARY_PASS] commutator readout has t<->1-t ambiguity
+
+5. UNIVERSAL DOWN-ONLY COUNTERMODEL
+[BOUNDARY_PASS] fixed H_d has unchanged trace
+[BOUNDARY_PASS] fixed H_d has unchanged determinant
+[BOUNDARY_PASS] first up orientation gives zero overlap
+[BOUNDARY_PASS] second up orientation gives 9/25 overlap
+[BOUNDARY_PASS] same down input supports distinct |V_cb| readouts
+[BOUNDARY_PASS] down-only X_R is identical in both orientations
+[BOUNDARY_PASS] down-only determinant cannot distinguish orientations
+
+6. CLAIM-BOUNDARY FIREWALLS
+[BOUNDARY_PASS] source note declares bounded_theorem
+[BOUNDARY_PASS] source note declares exact support/boundary theorem status
+[BOUNDARY_PASS] source note keeps the invariant alignment law open
+[BOUNDARY_PASS] source note narrows the down-only theorem class
+[BOUNDARY_PASS] source note forbids retained-grade proposal language
+[BOUNDARY_PASS] runner-facing theorem note contains no observed target values
+
+SUMMARY: EXACT_PASS=18 BOUNDARY_PASS=14 FAIL=0
+
+----- stderr -----
+

--- a/scripts/frontier_ckm_mass_operator_projector_overlap_typing.py
+++ b/scripts/frontier_ckm_mass_operator_projector_overlap_typing.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Exact CKM mass-operator projector-overlap typing checks.
+
+No observed quark mass, fitted texture coefficient, or CKM comparator enters
+the proof.  The runner checks a pair-based typed readout and the exact boundary
+against universal down-only determinant/spectral constructions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sympy as sp
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / "CKM_MASS_OPERATOR_PROJECTOR_OVERLAP_TYPING_THEOREM_NOTE_2026-07-12.md"
+EXACT_PASS = 0
+BOUNDARY_PASS = 0
+FAIL = 0
+
+
+def check(label: str, condition: bool, detail: str = "", *, boundary: bool = False) -> None:
+    global EXACT_PASS, BOUNDARY_PASS, FAIL
+    ok = bool(condition)
+    if ok:
+        if boundary:
+            BOUNDARY_PASS += 1
+            tag = "BOUNDARY_PASS"
+        else:
+            EXACT_PASS += 1
+            tag = "EXACT_PASS"
+    else:
+        FAIL += 1
+        tag = "FAIL"
+    print(f"[{tag}] {label}")
+    if detail:
+        print(f"             {detail}")
+
+
+def lagrange_projector(operator: sp.Matrix, eigenvalue: sp.Expr, others: tuple[sp.Expr, ...]) -> sp.Matrix:
+    identity = sp.eye(operator.rows)
+    result = identity
+    for other in others:
+        result = result * (operator - other * identity) / (eigenvalue - other)
+    return sp.simplify(result)
+
+
+def symbolic_projector_overlap() -> None:
+    print("\n1. SPECTRAL-PROJECTOR OVERLAP")
+    u, c, t = sp.symbols("u c t", positive=True, real=True)
+    d, s, b = sp.symbols("d s b", positive=True, real=True)
+    theta = sp.symbols("theta", real=True)
+    rotation = sp.Matrix(
+        [
+            [1, 0, 0],
+            [0, sp.cos(theta), sp.sin(theta)],
+            [0, -sp.sin(theta), sp.cos(theta)],
+        ]
+    )
+    h_u = sp.diag(u, c, t)
+    h_d = sp.simplify(rotation * sp.diag(d, s, b) * rotation.T)
+    p_c = lagrange_projector(h_u, c, (u, t))
+    p_b = lagrange_projector(h_d, b, (d, s))
+    overlap = sp.trigsimp(sp.trace(p_c * p_b))
+
+    check("P_c is an exact Lagrange spectral projector", p_c == sp.diag(0, 1, 0))
+    check("P_b is idempotent", sp.simplify(p_b * p_b - p_b) == sp.zeros(3))
+    check("P_b has trace one", sp.trigsimp(sp.trace(p_b)) == 1)
+    check("projector overlap is sin(theta)^2", sp.trigsimp(overlap - sp.sin(theta) ** 2) == 0)
+    compressed = sp.simplify(p_c * p_b * p_c)
+    check("compressed overlap is |V_cb|^2 P_c", sp.trigsimp(compressed - sp.sin(theta) ** 2 * p_c) == sp.zeros(3))
+    check("compressed one-line determinant equals overlap", sp.trigsimp(compressed[1, 1] - overlap) == 0)
+
+
+def exact_complex_and_basis_controls() -> None:
+    print("\n2. PHASE AND WEAK-BASIS CONTROLS")
+    c23 = sp.Rational(4, 5)
+    s23 = sp.Rational(3, 5)
+    phase = sp.I
+    v = sp.Matrix(
+        [
+            [1, 0, 0],
+            [0, c23, phase * s23],
+            [0, phase * s23, c23],
+        ]
+    )
+    h_u = sp.diag(1, 4, 9)
+    h_d = sp.simplify(v * sp.diag(16, 25, 36) * v.conjugate().T)
+    p_c = lagrange_projector(h_u, sp.Integer(4), (sp.Integer(1), sp.Integer(9)))
+    p_b = lagrange_projector(h_d, sp.Integer(36), (sp.Integer(16), sp.Integer(25)))
+    overlap = sp.simplify(sp.trace(p_c * p_b))
+
+    check("complex 2-3 control is unitary", sp.simplify(v.conjugate().T * v) == sp.eye(3))
+    check("complex-phase overlap is |V_cb|^2=9/25", overlap == sp.Rational(9, 25))
+
+    w = sp.Matrix(
+        [
+            [sp.Rational(4, 5), sp.Rational(3, 5), 0],
+            [-sp.Rational(3, 5), sp.Rational(4, 5), 0],
+            [0, 0, 1],
+        ]
+    )
+    transformed = sp.simplify(sp.trace((w * p_c * w.T) * (w * p_b * w.T)))
+    check("simultaneous weak-basis rotation preserves overlap", transformed == overlap)
+
+    rephase = sp.diag(1, sp.I, -1)
+    rephased = sp.simplify(
+        sp.trace(
+            (rephase * p_c * rephase.conjugate().T)
+            * (rephase * p_b * rephase.conjugate().T)
+        )
+    )
+    check("simultaneous rephasing preserves overlap", rephased == overlap)
+
+
+def determinant_and_alignment() -> None:
+    print("\n3. SIX-STATE DETERMINANT AND ALIGNMENT RESIDUAL")
+    r = sp.symbols("R", positive=True)
+    q = sp.diag(1, 0, 0, 0, 0, 0)
+    p = sp.eye(6) - q
+    x_r = q + r * p
+    check("rank-(1+5) determinant is R^5", sp.factor(x_r.det()) == r**5)
+    check(
+        "normalized determinant exponent is 5/6",
+        sp.expand_log(sp.log(x_r.det()), force=True) / 6 == sp.Rational(5, 6) * sp.log(r),
+    )
+
+    h_s, h_b, scale = sp.symbols("h_s h_b scale", positive=True)
+    mass_ratio = sp.sqrt(h_s / h_b)
+    check(
+        "mass ratio is invariant under common down-sector scale",
+        sp.simplify(sp.sqrt((scale * h_s) / (scale * h_b)) - mass_ratio) == 0,
+    )
+    check(
+        "squared five-sixths target is (h_s/h_b)^(5/6)",
+        sp.simplify(mass_ratio ** sp.Rational(5, 3) - (h_s / h_b) ** sp.Rational(5, 6)) == 0,
+    )
+
+    q0 = sp.Rational(1, 2)
+    r0 = q0**6
+    target_amplitude = q0**5
+    target_overlap = target_amplitude**2
+    check("exact selected-orientation witness has R^(5/6)=1/32", r0 ** sp.Rational(5, 6) == target_amplitude)
+    check("exact alignment witness has overlap R^(5/3)", r0 ** sp.Rational(5, 3) == target_overlap)
+    check("bridge sixth-power form is |V_cb|^6=R^5", target_amplitude**6 == r0**5)
+
+
+def commutator_control() -> None:
+    print("\n4. TWO-FAMILY COMMUTATOR FALSIFIER")
+    a1, a2, b1, b2 = sp.symbols("a1 a2 b1 b2", real=True)
+    cosine = sp.Rational(4, 5)
+    sine = sp.Rational(3, 5)
+    rotation = sp.Matrix([[cosine, sine], [-sine, cosine]])
+    a = sp.simplify(rotation * sp.diag(a1, a2) * rotation.T)
+    b = sp.diag(b1, b2)
+    commutator = sp.simplify(a * b - b * a)
+    frob_sq = sp.simplify(sp.trace(commutator.conjugate().T * commutator))
+    gap_sq = (a2 - a1) ** 2 * (b2 - b1) ** 2
+    chi = sp.factor(2 * frob_sq / gap_sq)
+    expected = 4 * sine**2 * cosine**2
+    check("commutator invariant is 4t(1-t)", sp.simplify(chi - expected) == 0)
+    check("commutator readout has t<->1-t ambiguity", sp.simplify(expected - 4 * cosine**2 * sine**2) == 0, boundary=True)
+
+
+def down_only_countermodel() -> None:
+    print("\n5. UNIVERSAL DOWN-ONLY COUNTERMODEL")
+    d, s, b = sp.symbols("d s b", positive=True, real=True)
+    h_d = sp.diag(d, s, b)
+    p_b = sp.diag(0, 0, 1)
+    p_c_zero = sp.diag(0, 1, 0)
+    rotation = sp.Matrix(
+        [
+            [1, 0, 0],
+            [0, sp.Rational(4, 5), sp.Rational(3, 5)],
+            [0, -sp.Rational(3, 5), sp.Rational(4, 5)],
+        ]
+    )
+    p_c_rotated = sp.simplify(rotation * p_c_zero * rotation.T)
+    overlap_zero = sp.trace(p_c_zero * p_b)
+    overlap_rotated = sp.simplify(sp.trace(p_c_rotated * p_b))
+
+    check("fixed H_d has unchanged trace", sp.trace(h_d) == d + s + b, boundary=True)
+    check("fixed H_d has unchanged determinant", h_d.det() == d * s * b, boundary=True)
+    check("first up orientation gives zero overlap", overlap_zero == 0, boundary=True)
+    check("second up orientation gives 9/25 overlap", overlap_rotated == sp.Rational(9, 25), boundary=True)
+    check("same down input supports distinct |V_cb| readouts", overlap_zero != overlap_rotated, boundary=True)
+
+    ratio = sp.sqrt(s / b)
+    x_a = sp.diag(1, ratio, ratio, ratio, ratio, ratio)
+    x_b = sp.diag(1, ratio, ratio, ratio, ratio, ratio)
+    check("down-only X_R is identical in both orientations", x_a == x_b, boundary=True)
+    check("down-only determinant cannot distinguish orientations", x_a.det() == x_b.det(), boundary=True)
+
+
+def textual_firewalls() -> None:
+    print("\n6. CLAIM-BOUNDARY FIREWALLS")
+    note = NOTE.read_text(encoding="utf-8")
+    normalized = " ".join(note.split())
+    check("source note declares bounded_theorem", "**Claim type:** bounded_theorem" in note, boundary=True)
+    check(
+        "source note declares exact support/boundary theorem status",
+        "**Actual current-surface status:** exact support/boundary theorem" in note,
+        boundary=True,
+    )
+    check("source note keeps the invariant alignment law open", "dynamical theorem forcing (1.2)" in normalized, boundary=True)
+    check("source note narrows the down-only theorem class", "universal equivariant/invariant down-only class" in normalized, boundary=True)
+    check("source note forbids retained-grade proposal language", "does not permit retained-grade proposal language" in normalized, boundary=True)
+    forbidden_targets = ["0.0422", "93.4", "81.0", "4.180", "0.022"]
+    check("runner-facing theorem note contains no observed target values", not any(x in note for x in forbidden_targets), boundary=True)
+
+
+def main() -> int:
+    print("CKM MASS-OPERATOR PROJECTOR-OVERLAP TYPING THEOREM")
+    symbolic_projector_overlap()
+    exact_complex_and_basis_controls()
+    determinant_and_alignment()
+    commutator_control()
+    down_only_countermodel()
+    textual_firewalls()
+    print(f"\nSUMMARY: EXACT_PASS={EXACT_PASS} BOUNDARY_PASS={BOUNDARY_PASS} FAIL={FAIL}")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Stacked scope

This is block 02, stacked directly on PR #5235. It intentionally does not refresh either branch against fast-moving main.

## Result

- For supplied nondegenerate quark mass operators, proves Tr(P_i^u P_j^d) = |V_ij|^2.
- Rewrites the five-sixths target exactly as Tr(P_c^u P_b^d) = (m_s/m_b)^(5/3).
- Proves a scoped boundary: no universal down-only equivariant construction followed by an invariant scalar readout can reproduce physical |V_cb| on the full stated mass-pair domain.
- Keeps the physical mass-operator origin and invariant alignment law open.

Claim type: bounded_theorem. Current source role: exact support/boundary theorem. Trace: upstream_support / supports. No audit verdict is authored.

## No-Go Discipline N1-N8

- N1: seven distinct attacks recorded: spectrum scalar, equivariant operator, rank-(1+5) determinant, C3 carrier reuse, external reference projector, supplied pair projectors, and paired source/action dynamics.
- N2: two independent walls remain: physical mass-pair derivation and relative alignment law.
- N3: supplied mass pair, ordered-spectrum convention, CKM semantics, abstract six-state carrier, and nearby carrier context are explicitly classified.
- N4: only exact residual matches are retained; parent, C3, T1-d, and free-matrix witnesses are marked partial or nonmatching where appropriate.
- N5: the negative result is limited to finite nondegenerate down-only operator/readout maps, not pair dynamics, actions, lattices, or global CKM closure.
- N6: pair, reference-projector, paired-texture, and source/action retirement paths remain live; no new-axiom requirement is asserted.
- N7: the hostile steelman is the successful pair-projector route, which changes the input domain and therefore does not refute the narrow down-only theorem.
- N8: prior CKM scale, determinant-context, and C3 carrier walls were checked for richer-context retirement mechanisms.

No-Go Discipline status: PASS.

## Verification

- runner: EXACT_PASS=18 BOUNDARY_PASS=14 FAIL=0
- independent random-unitary recomputation: overlap/covariance errors below 5e-16
- cache freshness: PASS
- py_compile: PASS
- vocabulary lint: PASS
- audit pipeline: PASS, one new unaudited bounded theorem row
- strict audit lint: PASS with no errors; existing warnings/notices only
- pipeline-generated audit/status outputs stripped from the PR

## Open walls

1. Derive and physically type M_u and M_d from framework source/action data.
2. Derive Tr(P_c^u P_b^d) = (m_s/m_b)^(5/3) without target fitting.