### PR TITLE
test(ac): execute no-go rhetoric checks at five resolutions

### DIFF
--- a/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -225,4 +225,4 @@ Run:
 python3 scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
 ```
 
-Expected result: `PASS=54`, `FAIL=0`.
+Expected result: `PASS=59`, `FAIL=0`.

--- a/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -208,4 +208,4 @@ Run:
 python3 scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
 ```
 
-Expected result: `PASS=40`, `FAIL=0`.
+Expected result: `PASS=45`, `FAIL=0`.

--- a/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
@@ -1,6 +1,6 @@
 ===== runner cache v1 =====
 runner: scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
-runner_sha256: c0e6708a715a8539dadaf7c16a2831a9a37a06d6a5a892b845f43fded53ad2ab
+runner_sha256: 32f18b31492f765ff7b5ec35d3ccf138f5820a3cb9f2b439cd7a157cc9929fae
 timeout_sec: 120
 exit_code: 0
 elapsed_sec: 0.08
@@ -38,7 +38,15 @@ Part C: arbitrary finite additivity
   [PASS] cardinality formula holds at n=5
   [PASS] three-way disjoint additivity
 
-Part D: source and axiom guards
+Part D: rhetoric-resolution lifts
+---------------------------------
+  [PASS] per_element: singleton record indicator preserves distinct beta-one and beta-two readouts
+  [PASS] per_site: translated finite-site records preserve symmetry while leaving beta free
+  [PASS] per_mode: disjoint finite-mode decomposition preserves additivity while leaving beta free
+  [PASS] per_block: disjoint record blocks preserve additivity for both beta normalizations
+  [PASS] lattice_wide: finite lattice partition preserves both laws while beta remains unselected
+
+Part E: source and axiom guards
 -------------------------------
   [PASS] current Record axiom contains empty-zero
   [PASS] current Record axiom contains finite additivity
@@ -62,7 +70,7 @@ Part D: source and axiom guards
   [PASS] discipline gate records PASS
 
 ========================================================================
-TOTAL: PASS=40, FAIL=0
+TOTAL: PASS=45, FAIL=0
 
 ----- stderr -----
 

--- a/logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
-runner_sha256: ff4cd8e5d02e559634f900fa7b17658a0b97330795d203d2e6521dbd4e7ade8c
+runner_sha256: 0be6b226896e56c7248d78d019bd76b8385da1a01090634372821374d70106f6
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.73
+elapsed_sec: 0.58
 status: ok
 ----- stdout -----
 Complex-vs-realified determinant-power countermodels
@@ -60,7 +60,15 @@ Part E: exact finite witnesses
   [PASS] finite witness 2 has determinant-power split
   [PASS] finite witness 3 has determinant-power split
 
-Part F: source and axiom guards
+Part F: rhetoric-resolution lifts
+---------------------------------
+  [PASS] per_element: scalar complex carrier retains the factor-two determinant-power split
+  [PASS] per_site: translated singleton carriers retain both additive determinant readouts
+  [PASS] per_mode: diagonal finite-mode products retain the complex-versus-realified factor two
+  [PASS] per_block: direct-sum finite blocks preserve additivity for both determinant powers
+  [PASS] lattice_wide: finite lattice record union preserves both laws and their factor-two split
+
+Part G: source and axiom guards
 -------------------------------
   [PASS] axioms withhold K/CPT structure
   [PASS] axioms withhold source/action identification
@@ -82,7 +90,7 @@ Part F: source and axiom guards
   [PASS] discipline gate records PASS
 
 ====================================================================
-TOTAL: PASS=54, FAIL=0
+TOTAL: PASS=59, FAIL=0
 
 ----- stderr -----
 

--- a/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
@@ -94,7 +94,68 @@ def main() -> int:
         == readout(beta_counter, h, a) + readout(beta_counter, h, b) + readout(beta_counter, h, c),
     )
 
-    section("Part D: source and axiom guards")
+    section("Part D: rhetoric-resolution lifts")
+    check(
+        "per_element: singleton record indicator preserves distinct beta-one and beta-two readouts",
+        readout(beta_target, h, singleton) == h
+        and readout(beta_counter, h, singleton) == 2 * h,
+    )
+
+    site_family = frozenset({(-2, 1, 0), (0, 0, 0), (3, -1, 2), (4, 4, -3)})
+    translated_family = frozenset((x + 9, y - 6, z + 5) for x, y, z in site_family)
+    check(
+        "per_site: translated finite-site records preserve symmetry while leaving beta free",
+        all(
+            readout(beta, h, translated_family) == readout(beta, h, site_family)
+            for beta in (beta_target, beta_counter)
+        )
+        and readout(beta_target, h, site_family) != readout(beta_counter, h, site_family),
+    )
+
+    mode_records = frozenset((0, 0, mode) for mode in range(5))
+    low_modes = frozenset((0, 0, mode) for mode in range(2))
+    high_modes = mode_records - low_modes
+    check(
+        "per_mode: disjoint finite-mode decomposition preserves additivity while leaving beta free",
+        low_modes.isdisjoint(high_modes)
+        and all(
+            readout(beta, h, mode_records)
+            == readout(beta, h, low_modes) + readout(beta, h, high_modes)
+            for beta in (beta_target, beta_counter)
+        )
+        and readout(beta_target, h, mode_records) != readout(beta_counter, h, mode_records),
+    )
+
+    check(
+        "per_block: disjoint record blocks preserve additivity for both beta normalizations",
+        all(
+            readout(beta, h, r | s) == readout(beta, h, r) + readout(beta, h, s)
+            for beta in (beta_target, beta_counter)
+        )
+        and readout(beta_target, h, r | s) != readout(beta_counter, h, r | s),
+    )
+
+    lattice_records = frozenset(
+        (x, y, z)
+        for x in range(2)
+        for y in range(2)
+        for z in range(2)
+    )
+    even_sites = frozenset(site for site in lattice_records if sum(site) % 2 == 0)
+    odd_sites = lattice_records - even_sites
+    check(
+        "lattice_wide: finite lattice partition preserves both laws while beta remains unselected",
+        even_sites.isdisjoint(odd_sites)
+        and all(
+            readout(beta, h, lattice_records)
+            == readout(beta, h, even_sites) + readout(beta, h, odd_sites)
+            for beta in (beta_target, beta_counter)
+        )
+        and readout(beta_target, h, lattice_records)
+        != readout(beta_counter, h, lattice_records),
+    )
+
+    section("Part E: source and axiom guards")
     note = NOTE.read_text(encoding="utf-8")
     axioms = AXIOMS.read_text(encoding="utf-8")
     scale_reference = SCALE_REFERENCE.read_text(encoding="utf-8")

--- a/scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
@@ -120,7 +120,91 @@ def main() -> int:
             sp.simplify(realification(example).det() - example.det() * sp.conjugate(example.det())) == 0,
         )
 
-    section("Part F: source and axiom guards")
+    section("Part F: rhetoric-resolution lifts")
+    scalar = sp.Matrix([[2 + sp.I]])
+    scalar_det_c = scalar.det()
+    scalar_det_r = realification(scalar).det()
+    check(
+        "per_element: scalar complex carrier retains the factor-two determinant-power split",
+        sp.simplify(scalar_det_r - scalar_det_c * sp.conjugate(scalar_det_c)) == 0
+        and scalar_det_r != abs(scalar_det_c),
+    )
+
+    site_records = frozenset({(0, 0, 0), (2, -1, 3), (4, 2, -2)})
+    translated_sites = frozenset((x + 5, y - 7, z + 11) for x, y, z in site_records)
+    site_count = len(site_records)
+    site_carrier = sp.eye(site_count) * lam
+    translated_carrier = sp.eye(len(translated_sites)) * lam
+    site_fc = sp.log(abs(site_carrier.det()))
+    site_fr = sp.log(realification(site_carrier).det())
+    check(
+        "per_site: translated singleton carriers retain both additive determinant readouts",
+        len(translated_sites) == site_count
+        and translated_carrier == site_carrier
+        and sp.simplify(
+            realification(translated_carrier).det()
+            - translated_carrier.det() * sp.conjugate(translated_carrier.det())
+        ) == 0
+        and sp.simplify(
+            sp.expand_log(site_fr, force=True)
+            - 2 * sp.expand_log(site_fc, force=True)
+        ) == 0,
+    )
+
+    mode_carrier = sp.diag(2, 3, 5, 7)
+    mode_fc = sp.log(abs(mode_carrier.det()))
+    mode_fr = sp.log(realification(mode_carrier).det())
+    check(
+        "per_mode: diagonal finite-mode products retain the complex-versus-realified factor two",
+        sp.simplify(sp.expand_log(mode_fr, force=True) - 2 * sp.expand_log(mode_fc, force=True)) == 0,
+    )
+
+    combined_blocks = sp.diag(2, 3, 5)
+    combined_fc = sp.log(abs(combined_blocks.det()))
+    combined_fr = sp.log(realification(combined_blocks).det())
+    check(
+        "per_block: direct-sum finite blocks preserve additivity for both determinant powers",
+        sp.simplify(sp.expand_log(combined_fc, force=True) - sp.expand_log(fc_a, force=True) - sp.expand_log(fc_b, force=True)) == 0
+        and sp.simplify(sp.expand_log(combined_fr, force=True) - sp.expand_log(fr_a, force=True) - sp.expand_log(fr_b, force=True)) == 0,
+    )
+
+    lattice_sites = frozenset(
+        (x, y, z)
+        for x in range(2)
+        for y in range(2)
+        for z in range(2)
+    )
+    left_half = frozenset(site for site in lattice_sites if site[0] == 0)
+    right_half = lattice_sites - left_half
+    lattice_carrier = sp.eye(len(lattice_sites)) * lam
+    left_carrier = sp.eye(len(left_half)) * lam
+    right_carrier = sp.eye(len(right_half)) * lam
+    lattice_fc = sp.log(abs(lattice_carrier.det()))
+    lattice_fr = sp.log(realification(lattice_carrier).det())
+    halves_fc = sp.log(abs(left_carrier.det())) + sp.log(abs(right_carrier.det()))
+    halves_fr = (
+        sp.log(realification(left_carrier).det())
+        + sp.log(realification(right_carrier).det())
+    )
+    check(
+        "lattice_wide: finite lattice record union preserves both laws and their factor-two split",
+        left_half.isdisjoint(right_half)
+        and len(left_half) + len(right_half) == len(lattice_sites)
+        and sp.simplify(
+            sp.expand_log(lattice_fc, force=True)
+            - sp.expand_log(halves_fc, force=True)
+        ) == 0
+        and sp.simplify(
+            sp.expand_log(lattice_fr, force=True)
+            - sp.expand_log(halves_fr, force=True)
+        ) == 0
+        and sp.simplify(
+            sp.expand_log(lattice_fr, force=True)
+            - 2 * sp.expand_log(lattice_fc, force=True)
+        ) == 0,
+    )
+
+    section("Part G: source and axiom guards")
     note = NOTE.read_text(encoding="utf-8")
     note_flat = " ".join(note.split())
     axioms = AXIOMS.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- execute AC(i) determinant-power countermodel checks at element, site, mode, block, and finite-lattice resolutions
- execute AC(ii) beta-family checks at the same five finite resolutions
- construct and realify carriers and verify genuine disjoint decompositions rather than formula echoes
- refresh both runner caches and source expected counts

## Scope
No axiom, primitive, premise, import, comparator, or physical bridge is added. The claims remain narrow current-surface non-entailment results and r remains free.

## Validation
- occupancy runner PASS=59 FAIL=0
- R-eta runner PASS=45 FAIL=0
- cache check fresh for both changed runners
- full audit pipeline PASS
- strict audit lint zero errors
- independent review-loop PASS after three substantive-check repairs
