### PR TITLE
[physics-loop] per-plaquette-license block03 — exact support (subdomain completeness classification; stacked)

### DIFF
--- a/.claude/science/physics-loops/per-plaquette-license-20260712/CLAIM_STATUS_CERTIFICATE.md
+++ b/.claude/science/physics-loops/per-plaquette-license-20260712/CLAIM_STATUS_CERTIFICATE.md
@@ -45,3 +45,56 @@ function of tick-`t` data on that link's `C_1` set.
 Lemma A is an exact definition-unfolding. Lemma B and Corollary C are bounded
 by `(P-FUND-1TICK)`. The finite enumeration and falsifier certify the stated
 conditional consequence and boundary; they do not remove that premise.
+
+## Claim Status Certificate — Block 03
+
+**Date:** 2026-07-12  
+**Block:** covariant-subdomain completeness classification
+
+```yaml
+claim_id: per_plaquette_license_covariant_subdomain_classification_2026_07_12
+target_claim_id: per_plaquette_from_adjacency_license_2026_06_09
+target_claim_type: bounded_theorem
+actual_current_surface_status: exact-support
+conditional_surface_status: null
+hypothetical_axiom_status: null
+admitted_observation_status: null
+trace_class: upstream_support
+reachability_to_target: supports
+artifact_role: theorem
+target_blocker_text: "Block 01 named four domains but did not prove that they exhaust the endpoint-containing covariant one-step family."
+source_of_blocker_text: user_goal
+downstream_consumer: PER_PLAQUETTE_FROM_ADJACENCY_LICENSE_BOUNDED_THEOREM_NOTE_2026-06-09.md
+classification_domain: "endpoint-containing G_l-invariant subsets of C_1({0,e1})"
+enumerated_loop_lengths:
+  - 4
+  - 6
+computed_rows:
+  E: {size: 2, length4: 0/24, length6: 0/264, one_tick: true}
+  E_union_A: {size: 4, length4: 0/24, length6: 0/264, one_tick: true}
+  E_union_T: {size: 10, length4: 24/24, length6: 0/264, one_tick: true}
+  C_1: {size: 12, length4: 24/24, length6: 0/264, one_tick: true}
+  radius_2: {size: 38, length4: 24/24, length6: 264/264, one_tick: false}
+open_imports: []
+downstream_imports_not_retired:
+  - P-FUND-1TICK
+dependency_classes:
+  - exact finite signed-permutation construction of the order-eight undirected-link stabilizer
+  - exact exhaustive filter over all 1024 non-endpoint subsets
+  - block-01 rooted-loop convention and finite-graph C_1 definition
+review_loop_disposition: not_run_by_bounded_block_spec
+independent_audit_disposition: pending
+proposal_allowed: false
+proposal_allowed_reason: "This is upstream exact support for the parent row; it neither closes P-FUND-1TICK nor proves a per-plaquette action."
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+next_trace_action: "Independently audit the exact classification, then decide whether the downstream parent row should consume it without enlarging its bounded scope."
+```
+
+The exact-support status applies only to the finite group classification and
+the length-4/length-6 table. The order-eight group has orbit sizes `2/2/8`,
+and exhaustive filtering leaves exactly four endpoint-containing invariant
+domains. The computed `E∪A` row is `0/24` and `0/264`. The cubic Manhattan
+radius-2 link domain has 38 sites and lies outside `C_1`; the provisional size
+32 is not used. This certificate does not alter the conditional status of the
+block-01 derivation or the status authority of the downstream parent.

--- a/.claude/science/physics-loops/per-plaquette-license-20260712/HANDOFF.md
+++ b/.claude/science/physics-loops/per-plaquette-license-20260712/HANDOFF.md
@@ -96,3 +96,72 @@ acyclic — upstream note backticks the parent); dated Repair Note quotes the
 archived-verdict blocker. Parent runner +4 wiring pins (PASS 9->13); cache
 regenerated; vocab lint clean. Stacked on block 01 (uses its note file).
 Proposed weaving beyond this: none (publication surfaces untouched per skill).
+
+## Block 03 — Covariant-subdomain completeness classification
+
+**Date:** 2026-07-12  
+**Claim type:** bounded_theorem  
+**Actual current-surface status:** exact-support  
+**Trace class:** upstream_support  
+**Reachability to the parent row:** supports  
+**Independent audit:** pending
+
+### What landed
+
+- `docs/PER_PLAQUETTE_LICENSE_COVARIANT_SUBDOMAIN_CLASSIFICATION_NOTE_2026-07-12.md`
+  proves completeness of the endpoint-containing covariant one-step domain
+  lattice and states the enumerated-domain interval theorem.
+- `scripts/per_plaquette_license_covariant_subdomain_classification_2026_07_12.py`
+  constructs `G_l`, checks its group action, exhausts all 1024 candidate
+  subsets, recomputes the five-row loop table, and pins the note surface.
+- `logs/runner-cache/per_plaquette_license_covariant_subdomain_classification_2026_07_12.txt`
+  is the generated deterministic cache.
+- `STATE.yaml`, `CLAIM_STATUS_CERTIFICATE.md`, and this handoff record the
+  block-03 exact-support boundary and upstream-support trace.
+
+Blocks 01 and 02, the downstream parent, and all ledger/authority surfaces are
+unchanged in block 03.
+
+### Exact result
+
+- The proper-rotation stabilizer of `{0,e1}` has order 8, is closed under all
+  64 ordered products, fixes the undirected endpoint set, and splits into four
+  endpoint-preserving and four endpoint-swapping elements.
+- Its `C_1` orbits have sizes `2/2/8`: endpoints `E`, axial exterior `A`, and
+  transverse `T`. The ten non-endpoint sites have exactly the two orbits `A`
+  and `T`.
+- Exhaustive filtering of all `2^10 = 1024` non-endpoint subsets leaves
+  exactly `E`, `E∪A`, `E∪T`, and `C_1`, with sizes `2/4/10/12`.
+
+| domain | length 4 | length 6 | one-tick |
+| --- | ---: | ---: | :---: |
+| `E` | 0/24 | 0/264 | yes |
+| `E∪A` | 0/24 | 0/264 | yes |
+| `E∪T` | 24/24 | 0/264 | yes |
+| `C_1` | 24/24 | 0/264 | yes |
+| radius-2 | 24/24 | 264/264 | NO |
+
+The previously unchecked `E∪A` row is therefore empty at both lengths. The
+cubic Manhattan radius-2 link domain has 38 sites, not the provisional 32:
+its two 25-site endpoint balls have a 12-site intersection. The named point
+`-2e1=(-2,0,0)` is outside `C_1` and matches the block-01 radius-2
+source/target violation class.
+
+### Status firewall and stop point
+
+This exact support classifies covariant domains and the enumerated lengths 4
+and 6 only. It does not retire `(P-FUND-1TICK)`, prove a fundamental
+per-plaquette action, touch `theta_bare`, or change an axiom/primitive. It is
+upstream support toward the bounded parent row, not direct blocker closure.
+
+Verification at the block checkpoint:
+
+```text
+new runner: TOTAL: PASS=39 FAIL=0 (exit 0)
+cache: ok=1, nonzero_exit=0, timeout=0, error=0, missing=0
+block-01 runner: TOTAL: PASS=51 FAIL=0 (exit 0)
+parent runner: SUMMARY: PASS=13 FAIL=0 (exit 0)
+```
+
+Stop after the requested final verification. Do not commit, push, open a PR,
+or weave this support into the parent in block 03.

--- a/.claude/science/physics-loops/per-plaquette-license-20260712/STATE.yaml
+++ b/.claude/science/physics-loops/per-plaquette-license-20260712/STATE.yaml
@@ -11,32 +11,33 @@ started: 2026-07-12T16:06-04:00
 deadline: 2026-07-12T22:06-04:00
 target_status: best-honest-status
 cycle: 1
-block: 02
-active_route: parent-consumption-wiring (block 02, stacked on block 01)
-active_route_status: conditional-support
+block: 03
+active_route: covariant-subdomain-completeness-classification (stacked on blocks 01/02)
+active_route_status: exact-support
+actual_current_surface_status: exact-support
 files_touched:
-  - docs/PER_PLAQUETTE_LICENSE_ONE_TICK_REACHABILITY_DERIVATION_NARROW_THEOREM_NOTE_2026-07-12.md
-  - scripts/per_plaquette_license_one_tick_reachability_derivation_2026_07_12.py
-  - logs/runner-cache/per_plaquette_license_one_tick_reachability_derivation_2026_07_12.txt
+  - docs/PER_PLAQUETTE_LICENSE_COVARIANT_SUBDOMAIN_CLASSIFICATION_NOTE_2026-07-12.md
+  - scripts/per_plaquette_license_covariant_subdomain_classification_2026_07_12.py
+  - logs/runner-cache/per_plaquette_license_covariant_subdomain_classification_2026_07_12.txt
   - .claude/science/physics-loops/per-plaquette-license-20260712/STATE.yaml
   - .claude/science/physics-loops/per-plaquette-license-20260712/CLAIM_STATUS_CERTIFICATE.md
   - .claude/science/physics-loops/per-plaquette-license-20260712/HANDOFF.md
 hard_residual: >
-  Lemma B fundamentality reading: a fundamental one-tick multi-link term's
-  availability is evaluable at each constituent link within that link's
-  one-tick dependency domain C_1. Close from Record/Admissibility +
-  joint-presentation surface, or name as the explicit thin premise
-  (P-FUND-1TICK).
-open_imports:
-  - none identified yet beyond the named-premise candidate (P-FUND-1TICK)
+  The finite covariant-domain completeness gap is closed. P-FUND-1TICK
+  remains load-bearing for the downstream derivation of the C_1 license and
+  is not retired by this classification; no per-plaquette action is derived.
+open_imports: []
+downstream_imports_not_retired:
+  - P-FUND-1TICK
 no_go_routes:
   - R1-minimal-nonempty-covariant-lift (pruned pre-execution; see NO_GO_LEDGER)
-trace_class: direct_blocker_closure
-pr_status: block01 PR #5274 open; block02 stacked PR pending
+trace_class: upstream_support
+reachability_to_target: supports
+pr_status: block 03 bounded execution; no commit, push, or PR by supervisor spec
 next_action: >
-  Independently audit the block-01 note, runner, cache, and conditional-status
-  certificate; if accepted, block 03 may wire the parent note to consume this
-  upstream result without enlarging its bounded claim.
-stop_condition: runtime 6h OR queue exhaustion per skill
+  After the requested verification stop, independently audit the block-03
+  exact finite classification and decide whether the downstream parent row
+  should consume this upstream support; perform no automatic weaving here.
+stop_condition: complete the requested runner/cache/regression/status verification, then stop
 lock_note: repo automation_lock.py errors on stale /Users/jonreilly path on
   this machine (infra N/A); branch-local supervisor discipline in force.

--- a/docs/PER_PLAQUETTE_LICENSE_COVARIANT_SUBDOMAIN_CLASSIFICATION_NOTE_2026-07-12.md
+++ b/docs/PER_PLAQUETTE_LICENSE_COVARIANT_SUBDOMAIN_CLASSIFICATION_NOTE_2026-07-12.md
@@ -1,0 +1,206 @@
+# Covariant One-Step Link-Subdomain Completeness Classification
+
+**Date:** 2026-07-12  
+**Claim type:** bounded_theorem  
+**Type:** bounded_theorem  
+**Status:** exact finite classification support on the enumerated domains  
+**Status authority:** independent audit lane only. This source note does not
+set or predict an audit outcome.  
+**Primary runner:**
+[`scripts/per_plaquette_license_covariant_subdomain_classification_2026_07_12.py`](../scripts/per_plaquette_license_covariant_subdomain_classification_2026_07_12.py)  
+**Cached output:**
+[`logs/runner-cache/per_plaquette_license_covariant_subdomain_classification_2026_07_12.txt`](../logs/runner-cache/per_plaquette_license_covariant_subdomain_classification_2026_07_12.txt)
+
+## Role
+
+This note closes the finite completeness question left open by block 01. That
+block exhibited four named one-step domains and a radius-2 falsifier, but it
+did not prove that the four domains exhaust the covariant one-step family or
+place radius 2 in the same computed table. Here the order-eight undirected-link
+stabilizer is constructed explicitly, its orbits are exhausted, and every
+cell of the resulting length-4/length-6 classification is recomputed.
+
+This exact finite classification neither changes block 01's conditional
+derivation status nor changes the block-02-wired parent. Its role is upstream
+support for that parent's bounded enumeration row.
+
+## Definitions
+
+Let `e1=(1,0,0)`, `e2=(0,1,0)`, and `e3=(0,0,1)`, and fix the undirected
+reference link `l={0,e1}`. With the self-plus-nearest-neighbor relation `R`,
+
+```text
+C_1(l) = {p : min(d(p,0),d(p,e1)) <= 1}.
+```
+
+Inside this 12-point set define the three disjoint sets
+
+```text
+E = {0,e1},
+A = {-e1,2e1},
+T = {+e2,-e2,+e3,-e3,e1+e2,e1-e2,e1+e3,e1-e3}.
+```
+
+Thus `C_1(l)=E∪A∪T`. Let `G_l` be the subgroup of proper cubic rotations that
+stabilizes the axis of `l`, acting affinely about the midpoint `e1/2`. A
+rotation that preserves `e1` fixes the endpoints individually; one that sends
+`e1` to `-e1` swaps them.
+
+A covariant domain assignment containing its carrier endpoints is determined
+at the reference link by a set `D` with `E subseteq D`. Choice-independent
+transport to every other undirected link requires `D` to be `G_l`-invariant;
+conversely, stabilizer invariance makes that transport well defined. A
+one-step domain additionally obeys `D subseteq C_1(l)`.
+
+## Theorem (completeness)
+
+Under the undirected-link stabilizer `G_l` of the reference link `{0,e1}`
+(order 8), the ten-point complement `C_1({0,e1}) minus {0,e1}` decomposes into
+exactly two orbits:
+
+```text
+A = {-e1,2e1}                                      (size 2),
+T = {+e2,-e2,+e3,-e3,e1+e2,e1-e2,e1+e3,e1-e3}    (size 8).
+```
+
+Hence the `G_l`-invariant subsets of `C_1({0,e1})` that contain the endpoints
+form exactly the four-element lattice
+
+```text
+E,  E∪A,  E∪T,  E∪A∪T = C_1.
+```
+
+Therefore every covariant one-step license domain in the stated family is one
+of those four domains. Graph-radius-2 and larger covariant domains exceed
+one-step reachability.
+
+### Proof
+
+The proper cubic rotations are the 24 determinant-`+1` signed permutation
+matrices. Exactly eight send `e1` to `+e1` or `-e1`. Acting about `e1/2`, all
+eight fix `{0,e1}` as a set; four preserve the endpoints and four swap them.
+Direct multiplication of all 64 ordered pairs is closed in the same set, so
+these eight transformations form `G_l`.
+
+Axial rotations and the endpoint swap exchange the two points of `A`. The
+four transverse directions at one endpoint are exchanged by axial rotations,
+and the endpoint swap connects them to the four transverse points at the
+other endpoint. Thus `A` and `T` are orbits. They are disjoint, have sizes 2
+and 8, and exhaust the ten non-endpoint sites, so there are no other orbits.
+The endpoint set `E` is itself the remaining size-2 orbit.
+
+An invariant subset is a union of whole orbits. Requiring `E` leaves an
+independent include/exclude choice for `A` and for `T`, giving exactly `2^2 = 4`
+orbit unions. The runner independently filters all `2^10 = 1024` subsets
+of the non-endpoint sites and finds only those four. Stabilizer
+invariance is precisely what removes dependence on the choice of cubic
+rotation used to transport the reference domain, proving the covariance
+claim in both directions.
+
+Finally, `-2e1 = (-2,0,0)` belongs to the radius-2 domain of `{0,e1}` but not
+to `C_1({0,e1})`. Every graph-radius-`r` domain with `r >= 2` contains this
+same witness, so none is a one-step domain.
+
+## Computed classification table
+
+For each rooted loop, the tested license requires the full loop support to be
+contained in the transported domain of every constituent link. The loop
+generator uses the block-01/parent convention: root at the origin, no
+immediate backtracking, and no repeated undirected edge. The last column is
+the per-domain one-tick / `R`-locality upper-bound test `D subseteq C_1`; it
+does not separately assert that an update law has been established as
+`R`-local.
+
+| domain | size | length-4 family | length-6 family | one-tick / `R`-local bound (`D subseteq C_1`) |
+| --- | ---: | ---: | ---: | :---: |
+| `E` (endpoints) | 2 | empty (0/24) | 0/264 | yes |
+| `E∪A` | 4 | empty (0/24) | 0/264 | yes |
+| `E∪T` | 10 | all plaquettes (24/24) | 0/264 | yes |
+| `C_1` | 12 | all plaquettes (24/24) | 0/264 | yes |
+| radius-2 | 38 | 24/24 | 264/264 | NO |
+
+The radius-2 cardinality is computed rather than assumed. Each endpoint's
+cubic Manhattan radius-2 ball has 25 sites, their intersection has 12 sites,
+and their union therefore has `25 + 25 - 12 = 38` sites.
+
+The previously unchecked `E∪A` row is empty at both enumerated lengths:
+`0/24` and `0/264`. The radius-2 row admits the full length-6 enumeration.
+Its named exterior point is also the block-01 falsifier instance: source `(-2,0,0)` and target `(0,0,0)`
+are at graph distance 2, so allowing that
+dependency is the witnessed violation class of one-tick confinement.
+
+## Theorem (enumerated-domain interval classification)
+
+On the enumerated lengths 4 and 6, every domain in the four-element lattice
+that contains the transverse orbit lies in the interval `[E∪T,C_1]` and gives
+the same selection: all 24 plaquettes and no length-6 loop. Both domains that
+omit the transverse orbit lie in `[E,E∪A]` and give the constant-empty family.
+Equivalently,
+
+```text
+E, E∪A       -> 0/24 and 0/264;
+E∪T, C_1     -> 24/24 and 0/264.
+```
+
+The radius-2 domain is covariant but lies outside the one-step interval; it
+gives `24/24` and `264/264`.
+
+### Proof
+
+Completeness leaves exactly the four one-step rows in the table. The two rows
+containing `T` have the identical computed vector `(24,0)`, while the two rows
+missing `T` have `(0,0)`. This exhausts the lattice, so the statement is a
+theorem on the enumerated domains rather than an extrapolation from selected
+examples. The independently computed radius-2 row fails the one-tick
+containment test and has vector `(24,264)`.
+
+The classification therefore isolates exactly what these finite enumerations
+can and cannot distinguish. In particular, they cannot select `C_1` over its
+strict `E∪T` subdomain. As block 01 states, the permissive one-tick derivation,
+not the enumeration outcomes, pins the full `C_1` bound.
+
+## Boundaries
+
+- This theorem concerns the enumerated lengths 4 and 6 only; no other loop
+  length is classified.
+- This is a classification of covariant domains, not a classification of
+  licenses beyond the endpoint-containing, stabilizer-invariant one-step
+  family.
+- This does **not** prove that the fundamental action is per-plaquette and
+  makes no per-plaquette-action claim.
+- The table checks domain containment in `C_1`; it does not derive the
+  block-01 `(P-FUND-1TICK)` premise or enlarge the finite-graph theorem into a
+  physical-spacetime statement.
+- `theta_bare` is untouched.
+- This block does not amend an axiom or approved primitive.
+- Blocks 01 and 02 and their artifacts are not modified by this classification.
+
+## Dependencies and context
+
+- [PER_PLAQUETTE_LICENSE_ONE_TICK_REACHABILITY_DERIVATION_NARROW_THEOREM_NOTE_2026-07-12.md](PER_PLAQUETTE_LICENSE_ONE_TICK_REACHABILITY_DERIVATION_NARROW_THEOREM_NOTE_2026-07-12.md)
+  — supplies the four named domains, enumeration convention, radius-2
+  falsifier instance, and the statement that the derivation rather than the
+  finite outcomes pins `C_1`; its conditional boundary is unchanged.
+- [LATTICE_NN_LIGHT_CONE_NOTE.md](LATTICE_NN_LIGHT_CONE_NOTE.md) — supplies
+  only the finite-graph definition of `C_t` and the `R`-local reachability
+  scope.
+- The block-02-wired parent enumeration note
+  `PER_PLAQUETTE_FROM_ADJACENCY_LICENSE_BOUNDED_THEOREM_NOTE_2026-06-09.md`
+  is downstream context under the same rooted-loop convention. It remains
+  backticked rather than linked here, preserving the acyclic citation
+  direction.
+
+## Verification
+
+```bash
+python3 scripts/per_plaquette_license_covariant_subdomain_classification_2026_07_12.py
+python3 scripts/precompute_audit_runners.py --runners scripts/per_plaquette_license_covariant_subdomain_classification_2026_07_12.py --force --allow-non-main --push-mode none
+python3 scripts/per_plaquette_license_one_tick_reachability_derivation_2026_07_12.py | tail -5
+python3 scripts/frontier_per_plaquette_from_adjacency_license_2026_06_09.py | tail -3
+git status --short
+```
+
+```yaml
+claim_type_author_hint: bounded_theorem
+claim_scope: "The order-eight stabilizer exhausts endpoint-containing covariant one-step domains, and the length-4/length-6 table classifies those four domains plus radius 2."
+```

--- a/logs/runner-cache/per_plaquette_license_covariant_subdomain_classification_2026_07_12.txt
+++ b/logs/runner-cache/per_plaquette_license_covariant_subdomain_classification_2026_07_12.txt
@@ -1,0 +1,89 @@
+===== runner cache v1 =====
+runner: scripts/per_plaquette_license_covariant_subdomain_classification_2026_07_12.py
+runner_sha256: 33e6b93969b4f6041526a03c00c8575fbf2e0822d2161ec4e6d3a94e53576d89
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.30
+status: ok
+----- stdout -----
+========================================================================================
+COVARIANT ONE-STEP LINK-SUBDOMAIN COMPLETENESS CLASSIFICATION
+========================================================================================
+
+----------------------------------------------------------------------------------------
+BLOCK A — explicit undirected-link stabilizer and orbit decomposition
+----------------------------------------------------------------------------------------
+  [PASS] proper cubic rotation group has order 24
+  [PASS] G_l has order 8 = four axial rotations times endpoint swap  --  preserve=4 swap=4
+  [PASS] G_l is closed under composition  --  64 products checked
+  [PASS] every G_l element fixes {0,e1} as an undirected set
+  [PASS] C_1({0,e1}) has size 12
+  [PASS] the stated endpoint, axial, and transverse sets partition C_1  --  sizes=2/2/8
+  [PASS] the full orbit decomposition is exactly E, A, T with sizes 2/2/8  --  sizes=[2, 2, 8]
+  [PASS] the 10 non-endpoint points decompose into exactly A and T  --  orbit_count=2
+
+----------------------------------------------------------------------------------------
+BLOCK B — exhaustive invariant-subset lattice
+----------------------------------------------------------------------------------------
+  [PASS] all 2^10 endpoint-containing subsets were tested  --  tested=1024
+  [PASS] exactly four subsets are G_l-invariant  --  invariant=4
+  [PASS] the invariant-subset lattice is exactly E, E union A, E union T, C_1  --  sizes=[2, 4, 10, 12]
+  [PASS] the four domains are closed under union and intersection
+  INVARIANT_SUBSETS: tested=1024 invariant=4 sizes=[2, 4, 10, 12]
+
+----------------------------------------------------------------------------------------
+BLOCK C — computed length-4/length-6 classification table
+----------------------------------------------------------------------------------------
+  [PASS] all five domain builders are undirected-link definitions
+  [PASS] all five domain builders are translation/proper-rotation covariant  --  comparisons=130
+  [PASS] rooted length-4 count  --  found=24
+  [PASS] all rooted length-4 loops are plaquettes
+  [PASS] rooted length-6 count  --  found=264
+  [PASS] the complete five-row classification matches the computed theorem table  --  {'E': (2, 0, 0, True), 'E+A': (4, 0, 0, True), 'E+T': (10, 24, 0, True), 'C_1': (12, 24, 0, True), 'radius-2': (38, 24, 264, False)}
+  [PASS] domains missing T give the constant-empty family
+  [PASS] domains containing T give the constant 24/0 family
+  [PASS] radius-2 admits the entire enumerated length-6 class
+  COMPUTED_CLASSIFICATION_TABLE:
+  domain       size   length-4   length-6   one-tick-subset-C_1
+  E (endpoints)    2     0/24       0/264    yes
+  E union A       4     0/24       0/264    yes
+  E union T      10    24/24       0/264    yes
+  C_1            12    24/24       0/264    yes
+  radius-2       38    24/24     264/264    NO
+
+----------------------------------------------------------------------------------------
+BLOCK D — one-tick column and named radius-2 witness
+----------------------------------------------------------------------------------------
+  [PASS] the four lattice domains are subsets of C_1
+  [PASS] radius-2 is not a subset of C_1  --  radius2=38 C_1=12
+  [PASS] radius-2 size is 25 + 25 - 12 = 38  --  balls=25/25 intersection=12
+  [PASS] -2e1 is a named radius-2 point outside C_1  --  witness=(-2, 0, 0)
+  [PASS] the witness is the block-01 radius-2 source/target violation class  --  source=(-2,0,0) target=(0,0,0)
+  ONE_TICK_WITNESS: point=(-2, 0, 0) in_radius2=True in_C_1=False block01_target=(0, 0, 0)
+
+----------------------------------------------------------------------------------------
+BLOCK E — paired-note surface pins
+----------------------------------------------------------------------------------------
+  [PASS] paired classification note exists  --  docs/PER_PLAQUETTE_LICENSE_COVARIANT_SUBDOMAIN_CLASSIFICATION_NOTE_2026-07-12.md
+  [PASS] note is dated 2026-07-12
+  [PASS] note claim type is bounded_theorem
+  [PASS] note has the exact finite-classification status
+  [PASS] canonical status-authority firewall is present
+  [PASS] completeness theorem tag and exhaustive count are pinned
+  [PASS] classification table contains every computed cell
+  [PASS] enumerated-domain interval theorem tag is pinned
+  [PASS] all required boundary pins are present
+  [PASS] radius-2 witness and block-01 falsifier class are named
+  [PASS] authorized dependencies and backticked parent context are pinned
+  [PASS] the parent context is not a markdown dependency edge
+  [PASS] yaml tail supplies bounded-theorem author hint and one-line scope
+
+========================================================================================
+SHORT STDOUT SUMMARY
+E union A row: size=4 length4=0/24 length6=0/264
+radius-2 domain size: 38
+TOTAL: PASS=39 FAIL=0
+========================================================================================
+
+----- stderr -----
+

--- a/scripts/per_plaquette_license_covariant_subdomain_classification_2026_07_12.py
+++ b/scripts/per_plaquette_license_covariant_subdomain_classification_2026_07_12.py
@@ -1,0 +1,613 @@
+#!/usr/bin/env python3
+"""Exact finite certificate for the covariant link-subdomain classification.
+
+This deterministic runner constructs the order-eight stabilizer of the
+undirected reference link, exhausts all endpoint-containing subsets of its
+one-step domain, and computes the length-4/length-6 mutual-containment table.
+It also checks the paired note's theorem, status, table, and boundary pins.
+"""
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+from typing import Callable, Iterable
+
+Point = tuple[int, int, int]
+Link = tuple[Point, Point]
+Loop = tuple[Link, ...]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+DomainBuilder = Callable[[Link], set[Point]]
+
+ROOT = Path(__file__).resolve().parent.parent
+NOTE = (
+    ROOT
+    / "docs"
+    / "PER_PLAQUETTE_LICENSE_COVARIANT_SUBDOMAIN_CLASSIFICATION_"
+    "NOTE_2026-07-12.md"
+)
+
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+NEG_E1: Point = (-1, 0, 0)
+DIRS: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+REFERENCE_LINK: Link = (ZERO, E1)
+RADIUS2_WITNESS: Point = (-2, 0, 0)
+
+PASS = 0
+FAIL = 0
+
+
+def section(title: str) -> None:
+    print("\n" + "-" * 88)
+    print(title)
+    print("-" * 88)
+
+
+def check(label: str, condition: bool, detail: str = "") -> bool:
+    global PASS, FAIL
+    ok = bool(condition)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    suffix = f"  --  {detail}" if detail else ""
+    print(f"  [{'PASS' if ok else 'FAIL'}] {label}{suffix}")
+    return ok
+
+
+def add(a: Point, b: Point) -> Point:
+    return tuple(x + y for x, y in zip(a, b))  # type: ignore[return-value]
+
+
+def sub(a: Point, b: Point) -> Point:
+    return tuple(x - y for x, y in zip(a, b))  # type: ignore[return-value]
+
+
+def dot(a: Point, b: Point) -> int:
+    return sum(x * y for x, y in zip(a, b))
+
+
+def distance(a: Point, b: Point) -> int:
+    return sum(abs(x - y) for x, y in zip(a, b))
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+def proper_cubic_rotations() -> tuple[Matrix, ...]:
+    matrices: list[Matrix] = []
+    for permutation in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] != 1:
+                continue
+            rows = []
+            for row in range(3):
+                entries = [0, 0, 0]
+                entries[permutation[row]] = signs[row]
+                rows.append(tuple(entries))
+            matrices.append(tuple(rows))  # type: ignore[arg-type]
+    return tuple(matrices)
+
+
+def mat_vec(matrix: Matrix, vector: Point) -> Point:
+    return tuple(dot(row, vector) for row in matrix)  # type: ignore[return-value]
+
+
+def mat_mul(left: Matrix, right: Matrix) -> Matrix:
+    columns = tuple(tuple(right[row][column] for row in range(3)) for column in range(3))
+    return tuple(
+        tuple(dot(row, column) for column in columns) for row in left
+    )  # type: ignore[return-value]
+
+
+def reference_link_action(matrix: Matrix, point: Point) -> Point:
+    """Act about the midpoint e1/2, so axis reversal swaps the endpoints."""
+    doubled_centered = (2 * point[0] - 1, 2 * point[1], 2 * point[2])
+    rotated = mat_vec(matrix, doubled_centered)
+    numerators = (rotated[0] + 1, rotated[1], rotated[2])
+    if any(value % 2 for value in numerators):
+        raise ValueError("reference-link action did not preserve the lattice")
+    return tuple(value // 2 for value in numerators)  # type: ignore[return-value]
+
+
+def undirected_link_stabilizer(rotations: Iterable[Matrix]) -> tuple[Matrix, ...]:
+    return tuple(matrix for matrix in rotations if mat_vec(matrix, E1) in (E1, NEG_E1))
+
+
+def orbit(point: Point, group: tuple[Matrix, ...]) -> frozenset[Point]:
+    return frozenset(reference_link_action(matrix, point) for matrix in group)
+
+
+def orbit_partition(
+    points: set[Point], group: tuple[Matrix, ...]
+) -> set[frozenset[Point]]:
+    remaining = set(points)
+    parts: set[frozenset[Point]] = set()
+    while remaining:
+        part = orbit(min(remaining), group)
+        parts.add(part)
+        remaining -= part
+    return parts
+
+
+def l1_ball(center: Point, radius: int) -> set[Point]:
+    offsets = itertools.product(range(-radius, radius + 1), repeat=3)
+    return {
+        add(center, offset)
+        for offset in offsets
+        if sum(abs(coordinate) for coordinate in offset) <= radius
+    }
+
+
+def endpoint_domain(link: Link) -> set[Point]:
+    return set(link)
+
+
+def endpoint_axial_domain(link: Link) -> set[Point]:
+    a, b = link
+    axis = sub(b, a)
+    return {a, b, sub(a, axis), add(b, axis)}
+
+
+def endpoint_transverse_domain(link: Link) -> set[Point]:
+    a, b = link
+    axis = sub(b, a)
+    domain = {a, b}
+    for endpoint in link:
+        domain.update(add(endpoint, step) for step in DIRS if dot(step, axis) == 0)
+    return domain
+
+
+def c1_domain(link: Link) -> set[Point]:
+    return set().union(*(l1_ball(endpoint, 1) for endpoint in link))
+
+
+def radius2_domain(link: Link) -> set[Point]:
+    return set().union(*(l1_ball(endpoint, 2) for endpoint in link))
+
+
+DOMAIN_BUILDERS: tuple[tuple[str, str, DomainBuilder], ...] = (
+    ("E", "E (endpoints)", endpoint_domain),
+    ("E+A", "E union A", endpoint_axial_domain),
+    ("E+T", "E union T", endpoint_transverse_domain),
+    ("C_1", "C_1", c1_domain),
+    ("radius-2", "radius-2", radius2_domain),
+)
+
+
+def closed_loops(length: int) -> list[Loop]:
+    """Use the block-01/parent rooted-loop convention exactly."""
+    loops: list[Loop] = []
+    for steps in itertools.product(DIRS, repeat=length):
+        position = ZERO
+        points = [position]
+        admissible = True
+        for index, step in enumerate(steps):
+            if index > 0 and add(steps[index - 1], step) == ZERO:
+                admissible = False
+                break
+            position = add(position, step)
+            points.append(position)
+        if not admissible or points[-1] != ZERO:
+            continue
+        links = tuple((points[index], points[index + 1]) for index in range(length))
+        if len({frozenset(link) for link in links}) == length:
+            loops.append(links)
+    return loops
+
+
+def loop_support(loop: Loop) -> set[Point]:
+    return {point for link in loop for point in link}
+
+
+def is_plaquette(loop: Loop) -> bool:
+    return len(loop_support(loop)) == 4
+
+
+def passes_domain(loop: Loop, builder: DomainBuilder) -> bool:
+    support = loop_support(loop)
+    return all(support <= builder(link) for link in loop)
+
+
+def block_a() -> tuple[
+    tuple[Matrix, ...], set[Point], frozenset[Point], frozenset[Point], frozenset[Point]
+]:
+    section("BLOCK A — explicit undirected-link stabilizer and orbit decomposition")
+    rotations = proper_cubic_rotations()
+    group = undirected_link_stabilizer(rotations)
+    group_set = set(group)
+    endpoint_preserving = tuple(
+        matrix
+        for matrix in group
+        if reference_link_action(matrix, ZERO) == ZERO
+        and reference_link_action(matrix, E1) == E1
+    )
+    endpoint_swapping = tuple(
+        matrix
+        for matrix in group
+        if reference_link_action(matrix, ZERO) == E1
+        and reference_link_action(matrix, E1) == ZERO
+    )
+
+    check("proper cubic rotation group has order 24", len(rotations) == len(set(rotations)) == 24)
+    check(
+        "G_l has order 8 = four axial rotations times endpoint swap",
+        len(group) == len(group_set) == 8
+        and len(endpoint_preserving) == len(endpoint_swapping) == 4,
+        f"preserve={len(endpoint_preserving)} swap={len(endpoint_swapping)}",
+    )
+    check(
+        "G_l is closed under composition",
+        all(mat_mul(left, right) in group_set for left in group for right in group),
+        "64 products checked",
+    )
+    check(
+        "every G_l element fixes {0,e1} as an undirected set",
+        all(
+            {
+                reference_link_action(matrix, ZERO),
+                reference_link_action(matrix, E1),
+            }
+            == {ZERO, E1}
+            for matrix in group
+        ),
+    )
+
+    reference_c1 = c1_domain(REFERENCE_LINK)
+    endpoints = frozenset((ZERO, E1))
+    axial = frozenset((NEG_E1, (2, 0, 0)))
+    transverse = frozenset(
+        (
+            (0, 1, 0),
+            (0, -1, 0),
+            (0, 0, 1),
+            (0, 0, -1),
+            (1, 1, 0),
+            (1, -1, 0),
+            (1, 0, 1),
+            (1, 0, -1),
+        )
+    )
+    full_partition = orbit_partition(reference_c1, group)
+    nonendpoint_partition = orbit_partition(reference_c1 - set(endpoints), group)
+    check("C_1({0,e1}) has size 12", len(reference_c1) == 12)
+    check(
+        "the stated endpoint, axial, and transverse sets partition C_1",
+        set(endpoints) | set(axial) | set(transverse) == reference_c1
+        and not (set(endpoints) & set(axial))
+        and not (set(endpoints) & set(transverse))
+        and not (set(axial) & set(transverse)),
+        f"sizes={len(endpoints)}/{len(axial)}/{len(transverse)}",
+    )
+    check(
+        "the full orbit decomposition is exactly E, A, T with sizes 2/2/8",
+        full_partition == {endpoints, axial, transverse},
+        f"sizes={sorted(map(len, full_partition))}",
+    )
+    check(
+        "the 10 non-endpoint points decompose into exactly A and T",
+        nonendpoint_partition == {axial, transverse},
+        f"orbit_count={len(nonendpoint_partition)}",
+    )
+    return group, reference_c1, endpoints, axial, transverse
+
+
+def block_b(
+    group: tuple[Matrix, ...],
+    reference_c1: set[Point],
+    endpoints: frozenset[Point],
+    axial: frozenset[Point],
+    transverse: frozenset[Point],
+) -> None:
+    section("BLOCK B — exhaustive invariant-subset lattice")
+    nonendpoints = tuple(sorted(reference_c1 - set(endpoints)))
+    invariant_domains: set[frozenset[Point]] = set()
+    tested = 0
+    for mask in range(1 << len(nonendpoints)):
+        tested += 1
+        candidate = set(endpoints)
+        candidate.update(
+            point for index, point in enumerate(nonendpoints) if mask & (1 << index)
+        )
+        if all(
+            {reference_link_action(matrix, point) for point in candidate} == candidate
+            for matrix in group
+        ):
+            invariant_domains.add(frozenset(candidate))
+
+    expected_domains = {
+        endpoints,
+        endpoints | axial,
+        endpoints | transverse,
+        endpoints | axial | transverse,
+    }
+    check(
+        "all 2^10 endpoint-containing subsets were tested",
+        tested == 1024,
+        f"tested={tested}",
+    )
+    check(
+        "exactly four subsets are G_l-invariant",
+        len(invariant_domains) == 4,
+        f"invariant={len(invariant_domains)}",
+    )
+    check(
+        "the invariant-subset lattice is exactly E, E union A, E union T, C_1",
+        invariant_domains == expected_domains,
+        f"sizes={sorted(map(len, invariant_domains))}",
+    )
+    check(
+        "the four domains are closed under union and intersection",
+        all(
+            (left | right) in invariant_domains and (left & right) in invariant_domains
+            for left in invariant_domains
+            for right in invariant_domains
+        ),
+    )
+    print(
+        "  INVARIANT_SUBSETS: "
+        f"tested={tested} invariant={len(invariant_domains)} sizes="
+        f"{sorted(map(len, invariant_domains))}"
+    )
+
+
+def block_c() -> tuple[list[dict[str, object]], list[Loop], list[Loop]]:
+    section("BLOCK C — computed length-4/length-6 classification table")
+    rotations = proper_cubic_rotations()
+    translations: tuple[Point, ...] = ((2, -1, 3), (-3, 0, 1))
+    covariance_checks = []
+    reversal_checks = []
+    for _, _, builder in DOMAIN_BUILDERS:
+        reference = builder(REFERENCE_LINK)
+        reversal_checks.append(reference == builder((E1, ZERO)))
+        covariance_checks.extend(
+            {mat_vec(matrix, point) for point in reference}
+            == builder((ZERO, mat_vec(matrix, E1)))
+            for matrix in rotations
+        )
+        covariance_checks.extend(
+            {add(point, translation) for point in reference}
+            == builder((translation, add(translation, E1)))
+            for translation in translations
+        )
+    check(
+        "all five domain builders are undirected-link definitions",
+        all(reversal_checks),
+    )
+    check(
+        "all five domain builders are translation/proper-rotation covariant",
+        all(covariance_checks),
+        f"comparisons={len(covariance_checks)}",
+    )
+
+    length4 = closed_loops(4)
+    length6 = closed_loops(6)
+    check("rooted length-4 count", len(length4) == 24, f"found={len(length4)}")
+    check("all rooted length-4 loops are plaquettes", all(map(is_plaquette, length4)))
+    check("rooted length-6 count", len(length6) == 264, f"found={len(length6)}")
+
+    reference_c1 = c1_domain(REFERENCE_LINK)
+    rows: list[dict[str, object]] = []
+    for key, label, builder in DOMAIN_BUILDERS:
+        reference = builder(REFERENCE_LINK)
+        rows.append(
+            {
+                "key": key,
+                "label": label,
+                "size": len(reference),
+                "length4": sum(passes_domain(loop, builder) for loop in length4),
+                "length6": sum(passes_domain(loop, builder) for loop in length6),
+                "one_tick": reference <= reference_c1,
+            }
+        )
+
+    expected = {
+        "E": (2, 0, 0, True),
+        "E+A": (4, 0, 0, True),
+        "E+T": (10, 24, 0, True),
+        "C_1": (12, 24, 0, True),
+        "radius-2": (38, 24, 264, False),
+    }
+    actual = {
+        str(row["key"]): (
+            row["size"],
+            row["length4"],
+            row["length6"],
+            row["one_tick"],
+        )
+        for row in rows
+    }
+    check(
+        "the complete five-row classification matches the computed theorem table",
+        actual == expected,
+        str(actual),
+    )
+    check(
+        "domains missing T give the constant-empty family",
+        actual["E"][1:3] == actual["E+A"][1:3] == (0, 0),
+    )
+    check(
+        "domains containing T give the constant 24/0 family",
+        actual["E+T"][1:3] == actual["C_1"][1:3] == (24, 0),
+    )
+    check(
+        "radius-2 admits the entire enumerated length-6 class",
+        actual["radius-2"][2] == len(length6) == 264,
+    )
+
+    print("  COMPUTED_CLASSIFICATION_TABLE:")
+    print("  domain       size   length-4   length-6   one-tick-subset-C_1")
+    for row in rows:
+        print(
+            f"  {str(row['label']):<12} {int(row['size']):>4}   "
+            f"{int(row['length4']):>3}/{len(length4):<3}    "
+            f"{int(row['length6']):>3}/{len(length6):<3}    "
+            f"{'yes' if row['one_tick'] else 'NO'}"
+        )
+    return rows, length4, length6
+
+
+def block_d(rows: list[dict[str, object]]) -> None:
+    section("BLOCK D — one-tick column and named radius-2 witness")
+    by_key = {str(row["key"]): row for row in rows}
+    reference_c1 = c1_domain(REFERENCE_LINK)
+    reference_radius2 = radius2_domain(REFERENCE_LINK)
+    left_ball = l1_ball(ZERO, 2)
+    right_ball = l1_ball(E1, 2)
+    check(
+        "the four lattice domains are subsets of C_1",
+        all(bool(by_key[key]["one_tick"]) for key in ("E", "E+A", "E+T", "C_1")),
+    )
+    check(
+        "radius-2 is not a subset of C_1",
+        not bool(by_key["radius-2"]["one_tick"]),
+        f"radius2={len(reference_radius2)} C_1={len(reference_c1)}",
+    )
+    check(
+        "radius-2 size is 25 + 25 - 12 = 38",
+        len(left_ball) == len(right_ball) == 25
+        and len(left_ball & right_ball) == 12
+        and len(reference_radius2) == 38,
+        f"balls={len(left_ball)}/{len(right_ball)} intersection={len(left_ball & right_ball)}",
+    )
+    check(
+        "-2e1 is a named radius-2 point outside C_1",
+        RADIUS2_WITNESS in reference_radius2
+        and RADIUS2_WITNESS not in reference_c1
+        and distance(RADIUS2_WITNESS, ZERO) == 2,
+        f"witness={RADIUS2_WITNESS}",
+    )
+    check(
+        "the witness is the block-01 radius-2 source/target violation class",
+        RADIUS2_WITNESS == (-2, 0, 0)
+        and ZERO == (0, 0, 0)
+        and distance(RADIUS2_WITNESS, ZERO) == 2,
+        "source=(-2,0,0) target=(0,0,0)",
+    )
+    print(
+        "  ONE_TICK_WITNESS: "
+        f"point={RADIUS2_WITNESS} in_radius2=True in_C_1=False "
+        "block01_target=(0, 0, 0)"
+    )
+
+
+def table_row_needles(rows: list[dict[str, object]]) -> tuple[str, ...]:
+    by_key = {str(row["key"]): row for row in rows}
+    return (
+        f"| `E` (endpoints) | {by_key['E']['size']} | empty ({by_key['E']['length4']}/24) | {by_key['E']['length6']}/264 | yes |",
+        f"| `E∪A` | {by_key['E+A']['size']} | empty ({by_key['E+A']['length4']}/24) | {by_key['E+A']['length6']}/264 | yes |",
+        f"| `E∪T` | {by_key['E+T']['size']} | all plaquettes ({by_key['E+T']['length4']}/24) | {by_key['E+T']['length6']}/264 | yes |",
+        f"| `C_1` | {by_key['C_1']['size']} | all plaquettes ({by_key['C_1']['length4']}/24) | {by_key['C_1']['length6']}/264 | yes |",
+        f"| radius-2 | {by_key['radius-2']['size']} | {by_key['radius-2']['length4']}/24 | {by_key['radius-2']['length6']}/264 | NO |",
+    )
+
+
+def block_e(rows: list[dict[str, object]]) -> None:
+    section("BLOCK E — paired-note surface pins")
+    exists = NOTE.is_file()
+    check("paired classification note exists", exists, str(NOTE.relative_to(ROOT)))
+    note = NOTE.read_text(encoding="utf-8") if exists else ""
+    check("note is dated 2026-07-12", "**Date:** 2026-07-12" in note)
+    check("note claim type is bounded_theorem", "**Claim type:** bounded_theorem" in note)
+    check(
+        "note has the exact finite-classification status",
+        "**Status:** exact finite classification support on the enumerated domains" in note,
+    )
+    check(
+        "canonical status-authority firewall is present",
+        "**Status authority:** independent audit lane only." in note,
+    )
+    check(
+        "completeness theorem tag and exhaustive count are pinned",
+        "## Theorem (completeness)" in note
+        and "all `2^10 = 1024` subsets" in note
+        and "exactly `2^2 = 4`" in note,
+    )
+    check(
+        "classification table contains every computed cell",
+        "## Computed classification table" in note
+        and all(row in note for row in table_row_needles(rows)),
+    )
+    check(
+        "enumerated-domain interval theorem tag is pinned",
+        "## Theorem (enumerated-domain interval classification)" in note,
+    )
+    boundary_needles = (
+        "## Boundaries",
+        "enumerated lengths 4 and 6 only",
+        "classification of covariant domains",
+        "does **not** prove that the fundamental action is per-plaquette",
+        "`theta_bare` is untouched",
+        "does not amend an axiom or approved primitive",
+    )
+    check(
+        "all required boundary pins are present",
+        all(needle in note for needle in boundary_needles),
+    )
+    check(
+        "radius-2 witness and block-01 falsifier class are named",
+        "`-2e1 = (-2,0,0)`" in note
+        and "source `(-2,0,0)` and target `(0,0,0)`" in note,
+    )
+    dependency_needles = (
+        "[PER_PLAQUETTE_LICENSE_ONE_TICK_REACHABILITY_DERIVATION_NARROW_THEOREM_NOTE_2026-07-12.md](PER_PLAQUETTE_LICENSE_ONE_TICK_REACHABILITY_DERIVATION_NARROW_THEOREM_NOTE_2026-07-12.md)",
+        "[LATTICE_NN_LIGHT_CONE_NOTE.md](LATTICE_NN_LIGHT_CONE_NOTE.md)",
+        "`PER_PLAQUETTE_FROM_ADJACENCY_LICENSE_BOUNDED_THEOREM_NOTE_2026-06-09.md`",
+    )
+    check(
+        "authorized dependencies and backticked parent context are pinned",
+        all(needle in note for needle in dependency_needles),
+    )
+    check(
+        "the parent context is not a markdown dependency edge",
+        "[PER_PLAQUETTE_FROM_ADJACENCY_LICENSE_BOUNDED_THEOREM_NOTE_2026-06-09.md]"
+        not in note,
+    )
+    check(
+        "yaml tail supplies bounded-theorem author hint and one-line scope",
+        "claim_type_author_hint: bounded_theorem" in note
+        and "claim_scope:" in note,
+    )
+
+
+def main() -> int:
+    print("=" * 88)
+    print("COVARIANT ONE-STEP LINK-SUBDOMAIN COMPLETENESS CLASSIFICATION")
+    print("=" * 88)
+
+    group, reference_c1, endpoints, axial, transverse = block_a()
+    block_b(group, reference_c1, endpoints, axial, transverse)
+    rows, _, _ = block_c()
+    block_d(rows)
+    block_e(rows)
+
+    by_key = {str(row["key"]): row for row in rows}
+    print("\n" + "=" * 88)
+    print("SHORT STDOUT SUMMARY")
+    print(
+        "E union A row: "
+        f"size={by_key['E+A']['size']} "
+        f"length4={by_key['E+A']['length4']}/24 "
+        f"length6={by_key['E+A']['length6']}/264"
+    )
+    print(f"radius-2 domain size: {by_key['radius-2']['size']}")
+    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+    print("=" * 88)
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`[physics-loop]` per-plaquette-license **block 03** — **exact support (finite classification; stacked)**.

**Stacked PR: base = `physics-loop/per-plaquette-license-block02-20260712`** (chain: #5274 → #5275 → this).

Completes the campaign's classification leg. New load-bearing content beyond block 01 (corollary-churn guard recorded in the pack): **completeness** — under the order-8 undirected-link stabilizer, the invariant one-step license domains containing the endpoints are *exactly* the 4-element orbit-union lattice `{E, E∪A, E∪T, C₁}` (proven by exhaustive filter over all 2¹⁰ subsets, matching the orbit argument), plus the full computed classification:

| domain | size | length-4 | length-6 | one-tick |
|---|---|---|---|---|
| E (endpoints) | 2 | 0/24 | 0/264 | yes |
| E∪A (axial) | 4 | 0/24 | 0/264 | yes |
| E∪T (transverse) | 10 | 24/24 | 0/264 | yes |
| C₁ (full) | 12 | 24/24 | 0/264 | yes |
| radius-2 | **38** | 24/24 | 264/264 | **no** |

**Interval theorem:** the enumerated consequences are constant on `{E∪T, C₁}` and constant-empty on `{E, E∪A}` — a theorem-grade record of exactly which distinctions the finite enumerations cannot make, supporting block 01's statement that the **derivation** (permissive one-tick bound), not the enumeration, pins `C₁`. The radius-2 row shows the one-tick bound is precisely what excludes the length-6 class.

Honesty note: the spec carried a provisional radius-2 size of 32 with instructions to compute and report the true value; the worker computed **38** (= 25+25−12), independently matching the supervisor's own pre-review probe.

## Status discipline

`actual_current_surface_status: exact-support`; trace `upstream_support / supports` toward the parent row; no license-selection claim beyond the stabilizer-invariant one-step family; lengths 4/6 only; independent audit remains required.

## Verification

- New runner `PASS=39 FAIL=0` (supervisor-rerun); block-01 runner `51/0` and parent runner `13/0` untouched and passing; `vocab_lint` clean; cache SHA-pinned.
- Every table cell was independently reproduced by the supervisor in a separate implementation (E∪A rows and the radius-2 size precomputed before the worker ran).

Process: `/workhorse` canonical recipe (`gpt-5.6-sol`, `effort=max`); pack checkpoints (`STATE`, `HANDOFF`, block-03 certificate) committed with the block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
