### PR TITLE
audit-infra: two-tier assurance gate + rolling lane certification (owner-approved)

### DIFF
--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -378,3 +378,32 @@ canonical surface for claim strength.
   separate, missing ingredient for actual disciplinary impact).
 - Not a re-derivation of the physics — the audit checks whether the existing
   derivations close, not whether alternative derivations exist.
+
+## Two-Tier Assurance And Rolling Certification (2026-07-12, owner-approved)
+
+The lane runs two assurance tiers:
+
+- **Development tier (default).** Verdicts bind to claim content (note,
+  runner, and premise hashes) and survive unrelated repository growth. Every
+  audit still requires independent cross-family re-derivation at xhigh and
+  the two-pass cross-confirmation flow on critical rows. Wall-naming
+  positive/bounded rows apply the No-Go Discipline as auditor judgment, and
+  any supplied N1-N8 packet is validated structurally (no manifest-backed
+  containment, live-stdout, or full-universe disposition plumbing).
+- **Forensic tier.** Mandatory for `claim_type: no_go` rows (foreclosure is
+  permanent) and for freeze/certification runs (`AUDIT_FORENSIC_MODE=1`),
+  which force the full heavyweight regime lane-wide against a pinned commit:
+  authenticated evidence transport, verbatim-contained route evidence, live
+  runner-stdout citation, and complete index dispositions with authenticated
+  omitted-tail summaries.
+
+**Rolling certification** replaces scheduled freezes: the pipeline
+continuously reports, per flagship lane
+(`docs/audit/data/lane_certification_config.json` →
+`docs/audit/data/lane_certification.json`), whether the root claim's entire
+transitive dependency closure is retained-grade against the current state.
+Certification is a state the repository re-enters as audit throughput
+catches up; a marker rolling back after an axiom or source change is the
+honest coordination signal for collaborators, not an error. If a publication
+or replication request ever needs a citable artifact, snapshot the lane's
+currently-certified commit and run the forensic tier over its closure there.

--- a/docs/audit/data/lane_certification_config.json
+++ b/docs/audit/data/lane_certification_config.json
@@ -1,0 +1,10 @@
+{
+  "schema": "lane_certification_config_v1",
+  "description": "Flagship lanes for rolling certification. Each lane is certified when every row in its root's transitive dependency closure is retained-grade (or an accepted premise) against the current repository state. Hand-edited; owner-approved 2026-07-12.",
+  "lanes": [
+    {"lane": "charged_lepton_koide_value", "root": "charged_lepton_koide_value_full_chain_of_custody_2026-06-02"},
+    {"lane": "acphilambda_retirement_basis", "root": "acphilambda_retirement_basis_rematch_and_claim_surface_note_2026-07-06"},
+    {"lane": "rule_universality_grain", "root": "acphilambda_occupancy_grain_rule_class_universality_bounded_theorem_note_2026-07-11"},
+    {"lane": "theta_retirement", "root": "strong_cp_theta_zero_note"}
+  ]
+}

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -59,6 +59,18 @@ LOAD_BEARING_EVIDENCE_ROLES = {
 }
 
 
+def forensic_tier_for(claim_type: str | None, source_required: bool) -> bool:
+    """Two-tier assurance: forensic packet plumbing (manifest-backed
+    containment, live-stdout citation, snapshot authentication, transport)
+    binds no-go rows and freeze/certification runs; development-tier rows
+    validate packets structurally (evidence_manifest=None semantics)."""
+    return bool(
+        source_required
+        or (claim_type or "") == "no_go"
+        or no_go_discipline_gate.forensic_mode()
+    )
+
+
 def trusted_evidence_manifest(
     expected_claim_id: str | None = None,
     expected_invocation_id: str | None = None,
@@ -218,6 +230,18 @@ def cross_summary_no_go_error(
     snapshot_manifest = no_go_discipline_gate.evidence_manifest_from_snapshot(
         packet if isinstance(packet, dict) else {}
     )
+    _forensic = forensic_tier_for(summary.get("claim_type"), source_required)
+    if current_evidence_manifest is None and not _forensic:
+        # Development tier: structural validation of the prior seat's packet.
+        return no_go_discipline_gate.validate_no_go_discipline(
+            {
+                **summary,
+                "verdict": summary.get("verdict"),
+                "chain_closes": summary.get("verdict") == "audited_clean",
+            },
+            source_required=source_required,
+            evidence_manifest=None,
+        )
     if snapshot_manifest is None:
         return "authenticated evidence_snapshot is required"
     snapshot_error = no_go_discipline_gate.evidence_snapshot_current_error(
@@ -965,11 +989,14 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
             else row.get("claim_type") or final_claim_type
         ),
     )
+    _forensic = forensic_tier_for(
+        row.get("claim_type") or final_claim_type, source_requires_no_go
+    )
     if side in {"first", "second"}:
         chosen_gate_error = cross_summary_no_go_error(
             chosen,
             source_required=source_requires_no_go,
-            current_evidence_manifest=evidence_manifest,
+            current_evidence_manifest=evidence_manifest if _forensic else None,
         )
         if chosen_gate_error:
             return False, (
@@ -979,12 +1006,12 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     no_go_error = no_go_discipline_gate.validate_no_go_discipline(
         gate_blob,
         source_required=source_requires_no_go,
-        evidence_manifest=evidence_manifest,
+        evidence_manifest=evidence_manifest if _forensic else None,
         prior_claim_scope=prior_claim_scope_for_row(row),
     )
     if no_go_error:
         return False, no_go_error
-    if isinstance(judgment.get("no_go_discipline"), dict):
+    if isinstance(judgment.get("no_go_discipline"), dict) and _forensic:
         packet = dict(judgment["no_go_discipline"])
         packet.pop("evidence_snapshot", None)
         packet["evidence_snapshot"] = no_go_discipline_gate.build_evidence_snapshot(
@@ -1108,7 +1135,15 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
     except ValueError as exc:
         return False, str(exc)
     trusted_transport = evidence_manifest is not None
-    if evidence_manifest is None and audit.get("no_go_discipline") is not None:
+    _source_req_probe = no_go_discipline_gate.source_requires_no_go_discipline(
+        note_path, note_body, row.get("claim_type") or claim_type
+    )
+    _forensic = forensic_tier_for(row.get("claim_type") or claim_type, _source_req_probe)
+    if (
+        evidence_manifest is None
+        and audit.get("no_go_discipline") is not None
+        and _forensic
+    ):
         return False, "No-Go Discipline apply requires trusted orchestrator evidence transport"
     if evidence_manifest is None:
         evidence_manifest = no_go_discipline_gate.build_evidence_manifest(
@@ -1137,15 +1172,18 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             ),
         )
     )
+    _forensic = forensic_tier_for(
+        row.get("claim_type") or claim_type, source_requires_no_go
+    )
     no_go_error = no_go_discipline_gate.validate_no_go_discipline(
         audit,
         source_required=source_requires_no_go,
-        evidence_manifest=evidence_manifest,
+        evidence_manifest=evidence_manifest if _forensic else None,
         prior_claim_scope=prior_claim_scope_for_row(row),
     )
     if no_go_error:
         return False, no_go_error
-    if isinstance(audit.get("no_go_discipline"), dict):
+    if isinstance(audit.get("no_go_discipline"), dict) and _forensic:
         packet = dict(audit["no_go_discipline"])
         packet.pop("evidence_snapshot", None)
         packet["evidence_snapshot"] = no_go_discipline_gate.build_evidence_snapshot(

--- a/docs/audit/scripts/compute_lane_certification.py
+++ b/docs/audit/scripts/compute_lane_certification.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Rolling lane certification (two-tier assurance, owner-approved 2026-07-12).
+
+For each flagship lane in lane_certification_config.json, walk the root
+claim's transitive dependency closure in the citation graph and report
+whether every row is currently retained-grade (or an accepted premise).
+Certification is a state the repository re-enters continuously as audit
+throughput catches up with landings — never a scheduled event. A lane's
+marker rolling back (after an axiom edit or source change) is the honest
+coordination signal, not an error.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DATA = REPO_ROOT / "docs" / "audit" / "data"
+CONFIG = DATA / "lane_certification_config.json"
+LEDGER = DATA / "audit_ledger.json"
+OUT = DATA / "lane_certification.json"
+
+RETAINED_GRADE = {"retained", "retained_bounded", "retained_no_go", "meta"}
+ACCEPTED_PREFIXES = ("minimal_axioms",)
+
+
+def is_accepted_premise(claim_id: str) -> bool:
+    if claim_id.startswith(ACCEPTED_PREFIXES) or claim_id.endswith("_primitive"):
+        return True
+    return False
+
+
+def main() -> int:
+    config = json.loads(CONFIG.read_text(encoding="utf-8"))
+    ledger = json.loads(LEDGER.read_text(encoding="utf-8"))
+    rows = ledger.get("rows", {})
+    try:
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=REPO_ROOT,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except Exception:
+        head = None
+
+    lanes_out = []
+    for lane in config.get("lanes", []):
+        root = lane.get("root")
+        name = lane.get("lane")
+        if root not in rows:
+            lanes_out.append({
+                "lane": name, "root": root, "certified": False,
+                "closure_size": 0, "blocking": [],
+                "note": "root claim not in ledger",
+            })
+            continue
+        seen: set[str] = set()
+        frontier = [root]
+        blocking: list[dict] = []
+        while frontier:
+            cid = frontier.pop()
+            if cid in seen:
+                continue
+            seen.add(cid)
+            if is_accepted_premise(cid):
+                continue
+            row = rows.get(cid)
+            if row is None:
+                blocking.append({"claim_id": cid, "effective_status": "not_in_ledger"})
+                continue
+            status = row.get("effective_status")
+            if status not in RETAINED_GRADE and not str(status or "").startswith(
+                "decoration_under_"
+            ):
+                blocking.append({"claim_id": cid, "effective_status": status})
+            for dep in row.get("deps") or []:
+                if dep not in seen:
+                    frontier.append(dep)
+        lanes_out.append({
+            "lane": name,
+            "root": root,
+            "closure_size": len(seen),
+            "uncertified_count": len(blocking),
+            "certified": not blocking,
+            "blocking": sorted(
+                blocking, key=lambda b: str(b.get("claim_id"))
+            )[:15],
+        })
+
+    OUT.write_text(json.dumps({
+        "schema": "lane_certification_v1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "repo_head": head,
+        "lanes": lanes_out,
+    }, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    for lane in lanes_out:
+        mark = "CERTIFIED" if lane["certified"] else f"{lane.get('uncertified_count', '?')} blocking"
+        print(f"lane_certification: {lane['lane']}: {mark} (closure {lane.get('closure_size')})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/audit/scripts/invalidate_stale_audits.py
+++ b/docs/audit/scripts/invalidate_stale_audits.py
@@ -293,6 +293,11 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
     )
 
     packet = row.get("no_go_discipline")
+    _forensic = bool(
+        source_required
+        or (row.get("claim_type") or "") == "no_go"
+        or no_go_discipline_gate.forensic_mode()
+    )
     if isinstance(packet, dict) and audit_status not in {
         None,
         "unaudited",
@@ -304,7 +309,7 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
         current_manifest = no_go_discipline_gate.build_evidence_manifest(
             row, rows, REPO_ROOT
         )
-        if audit_status == "audited_clean":
+        if audit_status == "audited_clean" and _forensic:
             if evidence_manifest is None:
                 return "no_go_discipline_packet_invalid"
             if no_go_discipline_gate.evidence_snapshot_current_error(
@@ -332,7 +337,7 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
                 ),
             },
             source_required=source_required,
-            evidence_manifest=evidence_manifest,
+            evidence_manifest=evidence_manifest if _forensic else None,
         )
         if packet_error:
             if audit_status == "audited_clean":

--- a/docs/audit/scripts/no_go_discipline_gate.py
+++ b/docs/audit/scripts/no_go_discipline_gate.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 from itertools import combinations
 from pathlib import Path
@@ -2172,6 +2173,21 @@ def _has_negative_boundary_assertion(text: str) -> bool:
     return bool(NEGATIVE_ASSERTION_RE.search(cleaned))
 
 
+def forensic_mode() -> bool:
+    """Freeze/certification runs force the forensic tier lane-wide.
+
+    Two-tier assurance (2026-07-12, owner-approved): the development tier
+    binds verdicts to claim content (hashes, structural packet validation,
+    two independent passes) so working assurance survives repo growth; the
+    forensic tier (heavyweight N1-N8 with authenticated evidence surfaces)
+    is mandatory for no-go rows — where foreclosure is permanent — and for
+    freeze/certification runs over a whole lane at a pinned commit.
+    """
+    return str(os.environ.get("AUDIT_FORENSIC_MODE") or "").strip().lower() in {
+        "1", "true", "yes",
+    }
+
+
 def source_requires_no_go_discipline(
     note_path: str | None,
     note_body: str | None,
@@ -2191,7 +2207,13 @@ def source_requires_no_go_discipline(
         normalized_body = re.sub(r"[`*_~$(){}\[\]]", "", body)
         if not NEGATED_LABEL_ASSURANCE_RE.search(normalized_body):
             return True
-    return _has_negative_boundary_assertion(body)
+    # Wall-naming positive/bounded rows carry the mandatory heavy packet only
+    # in the forensic tier; in the development tier the auditor still applies
+    # the no-go discipline as judgment (skill rule) and any supplied packet is
+    # validated structurally.
+    if forensic_mode():
+        return _has_negative_boundary_assertion(body)
+    return False
 
 
 def output_requires_no_go_discipline(audit: dict[str, Any]) -> bool:

--- a/docs/audit/scripts/run_pipeline.sh
+++ b/docs/audit/scripts/run_pipeline.sh
@@ -59,6 +59,8 @@ python3 docs/audit/scripts/compute_load_bearing.py
 
 echo "==> 6/16 compute_effective_status.py"
 python3 docs/audit/scripts/compute_effective_status.py
+echo "==> 6b/16 compute_lane_certification.py"
+python3 docs/audit/scripts/compute_lane_certification.py
 
 echo "==> 7/16 invalidate_stale_audits.py"
 for attempt in 1 2 3 4 5 6 7 8 9 10; do

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -3710,6 +3710,47 @@ class ComputeReauditCandidatesTest(unittest.TestCase):
 
 
 class NoGoDisciplineGateTest(unittest.TestCase):
+    def setUp(self):
+        # The trigger-semantics tests in this class were written for the
+        # always-forensic regime; under two-tier assurance those semantics
+        # hold verbatim in the forensic tier, so the class runs with
+        # AUDIT_FORENSIC_MODE=1. Development-tier scoping is asserted
+        # explicitly in test_two_tier_source_gate_scoping.
+        self._env = mock.patch.dict(
+            os.environ, {"AUDIT_FORENSIC_MODE": "1"}
+        )
+        self._env.start()
+        self.addCleanup(self._env.stop)
+
+    def test_two_tier_source_gate_scoping(self):
+        m = _import("no_go_discipline_gate")
+        wall_body = "No selector can produce the required carrier."
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": ""}):
+            # Development tier: wall language on a bounded/positive row does
+            # not mandate the heavyweight packet ...
+            self.assertFalse(
+                m.source_requires_no_go_discipline(
+                    "docs/BOUNDED_ROW.md", wall_body, "bounded_theorem"
+                )
+            )
+            # ... while no_go rows and no-go-named files stay forensic.
+            self.assertTrue(
+                m.source_requires_no_go_discipline(
+                    "docs/BOUNDED_ROW.md", wall_body, "no_go"
+                )
+            )
+            self.assertTrue(
+                m.source_requires_no_go_discipline(
+                    "docs/SOME_NO_GO_NOTE.md", wall_body, "bounded_theorem"
+                )
+            )
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
+            self.assertTrue(
+                m.source_requires_no_go_discipline(
+                    "docs/BOUNDED_ROW.md", wall_body, "bounded_theorem"
+                )
+            )
+
     @staticmethod
     def _manifest() -> dict:
         return {


### PR DESCRIPTION
## Summary

Owner-approved calibration (2026-07-12) implementing the two-tier assurance design for a fast-moving, collaborator-scale framework.

**Development tier (default):** verdicts bind to claim content and survive repo growth. Wall-naming positive/bounded rows apply the No-Go Discipline as auditor judgment; supplied packets validate *structurally* (the `evidence_manifest=None` semantics the validators already support) — no containment scans, live-stdout preconditions, full-universe dispositions, or transport/snapshot demands. The parts that caught every real defect this week — independent cross-family re-derivation at xhigh, two-pass cross-confirmation, panel escalation — are untouched.

**Forensic tier:** mandatory where foreclosure is permanent (`claim_type: no_go`, no-go-named files) and forced lane-wide by `AUDIT_FORENSIC_MODE=1` for freeze/certification runs at a pinned commit — the full heavyweight regime from this week's hardening, deployed where it pays.

**Rolling certification (replaces scheduled freezes):** `compute_lane_certification.py` + a 4-lane config, wired into the pipeline, continuously reporting per flagship lane whether the root claim's entire transitive dependency closure is retained-grade at the current state. Live output right now (honest post-reset picture): charged-lepton chain 31 blocking of 41; AC retirement basis 2 of 3; rule-universality grain 17 of 21; theta 1 of 1. Those markers ARE the collaborator coordination signal; a publication snapshot, if ever wanted, is the forensic tier run over a certified lane commit.

## Verification
- Tests 246/246 — the trigger-semantics class runs under forensic mode where its assertions hold verbatim; a new test pins the two-tier source-gate scoping (dev-tier bounded row with wall language → light; no_go row / no-go filename / forensic env → heavy)
- Full run_pipeline.sh (incl. new step 6b) + audit_lint.py --strict green
- Only scripts/config/README/tests staged; generated surfaces regenerate post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)