### PR TITLE
fix(shapiro): narrow static-discriminator note per audited_conditional verdict

### DIFF
--- a/docs/SHAPIRO_STATIC_DISCRIMINATOR_NOTE.md
+++ b/docs/SHAPIRO_STATIC_DISCRIMINATOR_NOTE.md
@@ -1,7 +1,13 @@
 # Shapiro Static Discriminator
 
-**Date:** 2026-04-06  
-**Status:** boundary result - static cone shape can mimic the proposed_retained c-dependent phase lag exactly; static scheduling cannot
+**Date:** 2026-04-06 (interpretation narrowed 2026-07-12 per audit-lane verdict)  
+**Status:** bounded finite-model card. Within the supplied runner the `static_cone`
+and `causal` field builders are algebraically identical (same spatial cone law, no
+delay), so their detector phase curves coincide **by construction**; the completed
+finite sweep over fixed delays `0` through `3` gives a near-flat `static_schedule`
+curve that does not track the c-dependent curve. This note asserts neither an
+identification of the runner's in-file `causal` comparator with the retained causal
+propagating-field lane nor an evaluated zero-strength control.
 
 ## Artifact Chain
 
@@ -11,57 +17,77 @@
 
 ## Question
 
-Can any static field shape or static scheduling proxy mimic the retained
-c-dependent phase lag from the causal propagating-field lane?
+Within this finite runner, how do a frozen spatial-cone field and a frozen
+scheduling proxy compare, on the detector-line phase response, against the
+runner's in-file cone comparator?
 
-## Control Results
+## Measured curves
 
-The control gate is clean:
-
-- exact zero control stays exact
-- the retained causal phase curve is portable across the three grown families
-
-Measured mean curves:
+The runner prints these per-mode mean detector phase curves (three grown
+families, 16 seeds each):
 
 | Mode | c=2.0 | c=1.0 | c=0.5 | c=0.25 |
 | --- | ---: | ---: | ---: | ---: |
-| causal dynamic cone | +0.0372 | +0.0446 | +0.0569 | +0.0662 |
-| static cone shape | +0.0372 | +0.0446 | +0.0569 | +0.0662 |
-| static scheduling | +0.0446 | +0.0445 | +0.0446 | +0.0450 |
+| in-file cone comparator (`causal`) | +0.0372 | +0.0446 | +0.0569 | +0.0662 |
+| static cone shape (`static_cone`) | +0.0372 | +0.0446 | +0.0569 | +0.0662 |
+| static scheduling (`static_schedule`) | +0.0446 | +0.0445 | +0.0446 | +0.0450 |
 
-## Discriminator Read
+## What the runner actually establishes
 
-1. **Static cone shape is a perfect mimic.**
-   - The frozen cone-shape proxy reproduces the full c-dependent causal
-     phase curve to numerical precision on all three families.
-   - This means the Shapiro-style phase lag is **not** a unique
-     discriminator against static field-shape effects in this model.
+1. **The static-cone row equals the comparator row by construction.**
+   `_static_cone_field` and `_causal_field` have identical bodies — the same
+   `cone_radius = c * det_radius * max(dx, 0) / x_span` support and `strength / r`
+   fill, with no temporal delay in either — and the sweep evaluates them at the
+   same `c`. The exact agreement of the two rows is therefore an internal identity
+   of the runner (the comparator is compared against a verbatim copy of itself),
+   not an empirical demonstration that a physically distinct static field shape
+   mimics a causal propagating field.
 
-2. **Static scheduling is not enough.**
-   - A frozen activation delay produces only a near-flat phase response.
-   - It does not reproduce the causal c-dependence.
+2. **The scheduling proxy does not track the c-curve.**
+   `_static_schedule_field` adds a genuine fixed layer delay
+   (`layer < SOURCE_LAYER + delay_layers` gate). Sampled at delays `0` through `3`
+   it produces only a near-flat phase response, so on this finite model a fixed
+   activation schedule does not reproduce the c-dependence of the cone comparator.
+   This mismatch is the retained finite-model content of the lane.
 
-## Conclusion
+## What this note does NOT claim
 
-The strongest honest statement is:
+- That the runner's `causal` mode represents the retained **causal
+  propagating-field lane**. The `causal` mode is an in-file spatial-cone
+  construct; a one-hop retained theorem constructing this comparator from that
+  lane is not supplied, so no such identification is asserted here.
+- That a physically distinct static field-shape family mimics a causal
+  propagating field. The static-cone/comparator agreement is an identity by
+  construction (§1), not a degeneracy between distinct hypotheses.
+- An evaluated exact zero-strength control. The runner's null slot is a
+  `zero_ok = max(zero_ok, 0.0)` placeholder that performs no zero-strength
+  propagation; it is a no-op, not an evaluated null check.
+- That the detector-line phase lag is a unique causal-propagation discriminator.
+  On the current packet the only genuine separation shown is against the
+  fixed-schedule proxy.
 
-- the Shapiro-style phase lag is a real, portable observable
-- but it is **not** stronger than all static field-shape effects
-- it is only stronger than the static scheduling proxy
+## Retained finite-model boundary
 
-So this lane gives us a **boundary**, not a clean uniqueness proof:
-the observable is compatible with causal propagation, but a static cone-shape
-field family can reproduce the same detector phase curve exactly.
+- `static_cone` equals the in-file `causal` comparator exactly, by construction.
+- the fixed-schedule proxy (delays `0` through `3`) is near-flat and does not
+  track the c-curve.
 
-## Claim Boundary
+Reinstating a unique causal-propagation discriminator, or a physical
+static-shape degeneracy claim, would each require additional retained structure:
+(i) a one-hop bridge theorem tying the in-file comparator to the causal
+propagating-field lane, (ii) a genuinely distinct static field-shape comparator,
+and (iii) an evaluated zero-strength control.
 
-This does **not** claim:
+## Audit boundary (2026-07-12)
 
-- that the retained phase lag is falsified
-- that the causal propagating-field lane is invalid
-- that the static scheduling proxy is a full match
+Audit verdict (`audited_conditional`, 89 transitive descendants):
 
-It **does** say:
-
-- if we want a unique causal-propagation discriminator, we need a different
-  observable than the detector-line phase lag alone
+> Issue: `_causal_field` and `_static_cone_field` implement the same spatial
+> field law, so their exact match is an algebraic consequence of the runner
+> definitions rather than an independent causal-versus-static comparison. Why
+> this blocks: no cited authority or construction establishes that the runner's
+> so-called causal branch represents the retained propagating-field lane. Repair
+> target: supply a retained bridge deriving this causal comparator from that lane
+> and verify an actual zero-strength control rather than assigning `zero_ok` to
+> zero. Claim boundary until fixed: the internal equality and the sampled
+> delay-0-through-3 scheduling mismatch remain valid finite-model results.


### PR DESCRIPTION
## What this responds to

Row `shapiro_static_discriminator_note` (fan=89, `audited_conditional`, class `missing_bridge_theorem`). The audit verdict's demote branch names exactly what stays valid:

> Claim boundary until fixed: the internal equality and the sampled delay-0-through-3 scheduling mismatch remain valid finite-model results.

This PR conforms the note's prose to that boundary. It is a **note-only** change — `scripts/shapiro_static_discriminator.py` and its cache are byte-unchanged.

## What changed (`docs/SHAPIRO_STATIC_DISCRIMINATOR_NOTE.md` only)

Withdrawn / qualified (the parts the verdict flagged as unsupported):

- The framing that a *physically distinct* static field shape "perfectly mimics" a causal propagating field. `_static_cone_field` and `_causal_field` have identical bodies (same `cone_radius`/`strength/r` law, no delay) evaluated at the same `c`, so their exact agreement is an **identity by construction** — the comparator compared against a verbatim copy of itself — not an empirical degeneracy between distinct hypotheses.
- The identification of the runner's in-file `causal` mode with the **retained causal propagating-field lane**. No one-hop bridge theorem supplies that identification, so the note no longer asserts it (the lane is referenced in backticks only, never as a dependency link).
- "Exact zero control stays exact" — the runner's null slot is a `zero_ok = max(zero_ok, 0.0)` no-op placeholder, not an evaluated zero-strength field. The note now states this.

Retained as valid finite-model results (the verdict's demote branch):

- `static_cone` equals the in-file `causal` comparator exactly, by construction.
- The fixed-schedule proxy (delays 0–3) is near-flat and does not track the c-curve.

Added: "What this note does NOT claim", "Retained finite-model boundary", and an "Audit boundary (2026-07-12)" section quoting the verdict verbatim. No audit grade is authored or predicted.

## Verification (reproduced personally)

- `python3 scripts/shapiro_static_discriminator.py` → exit 0; curves reproduce the note's table (causal / static_cone identical `+0.0372 / +0.0446 / +0.0569 / +0.0662`; static_schedule near-flat `+0.0446 / +0.0445 / +0.0446 / +0.0450`).
- Only `docs/SHAPIRO_STATIC_DISCRIMINATOR_NOTE.md` changed; runner + cache byte-unchanged (`git diff` shows no `scripts/`/`logs/` shapiro paths).
- Sibling `scripts/shapiro_phase_lag_probe.py` reads `SHAPIRO_DELAY_NOTE.md` (line 39) and only *writes an outbound link* to this note (line 385); it greps none of this note's sentences, so the edit cannot affect it.

Editing the note drifts its `note_hash`, re-queuing the row for the independent audit lane — the intended unlock. No status is asserted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
