### PR TITLE
[physics-loop] per-plaquette-license block04 — exact support (length-8 extension; convention unification; stacked)

### DIFF
--- a/.claude/science/physics-loops/per-plaquette-license-20260712/HANDOFF.md
+++ b/.claude/science/physics-loops/per-plaquette-license-20260712/HANDOFF.md
@@ -165,3 +165,28 @@ parent runner: SUMMARY: PASS=13 FAIL=0 (exit 0)
 
 Stop after the requested final verification. Do not commit, push, open a PR,
 or weave this support into the parent in block 03.
+
+## Block 04 (2026-07-12, supervisor-executed) + campaign close-out
+
+Length-8 extension of the classification: all one-tick domains reject the
+entire rooted simple length-8 class (0/3312, incl. full C_1 — the
+plaquette-only selection extends beyond the parent's tested {4,6}); radius-2
+admits exactly 96/3312 (strict subclass, unlike full 264/264 at length 6).
+Supervisor pre-probed every cell independently before editing.
+
+FINDING (convention): the shared loop generator (parent convention) enforced
+no-backtrack + no-repeated-edge but NOT vertex-simplicity — vacuous at
+lengths 4/6, load-bearing at 8 (4272 closed walks vs 3312 simple loops).
+Both campaign runners now enforce the stated rooted-SIMPLE domain (block-01
+results unchanged, 51/0; caches regenerated). The parent runner
+(frontier_per_plaquette..., lengths 4/6 only) is unaffected but inherits the
+same latent gap if ever extended — flagged for the review lane in the
+block-04 PR.
+
+Campaign residual (owner-gated / future lanes):
+- (P-FUND-1TICK) closure: needs either an owner registration decision or
+  future ticked-update-law content; the R4 boundary analysis in block 01 is
+  the recorded stretch attempt.
+- Lengths > 8 and non-loop link sets: open frontier, not claimed.
+Proposed weaving: parent note could later also cite the classification note
+(block 03/04) next to the derivation edge; deferred to review.

--- a/docs/PER_PLAQUETTE_LICENSE_COVARIANT_SUBDOMAIN_CLASSIFICATION_NOTE_2026-07-12.md
+++ b/docs/PER_PLAQUETTE_LICENSE_COVARIANT_SUBDOMAIN_CLASSIFICATION_NOTE_2026-07-12.md
@@ -18,7 +18,7 @@ block exhibited four named one-step domains and a radius-2 falsifier, but it
 did not prove that the four domains exhaust the covariant one-step family or
 place radius 2 in the same computed table. Here the order-eight undirected-link
 stabilizer is constructed explicitly, its orbits are exhausted, and every
-cell of the resulting length-4/length-6 classification is recomputed.
+cell of the resulting length-4/length-6/length-8 classification is recomputed.
 
 This exact finite classification neither changes block 01's conditional
 derivation status nor changes the block-02-wired parent. Its role is upstream
@@ -111,29 +111,38 @@ the per-domain one-tick / `R`-locality upper-bound test `D subseteq C_1`; it
 does not separately assert that an update law has been established as
 `R`-local.
 
-| domain | size | length-4 family | length-6 family | one-tick / `R`-local bound (`D subseteq C_1`) |
-| --- | ---: | ---: | ---: | :---: |
-| `E` (endpoints) | 2 | empty (0/24) | 0/264 | yes |
-| `E∪A` | 4 | empty (0/24) | 0/264 | yes |
-| `E∪T` | 10 | all plaquettes (24/24) | 0/264 | yes |
-| `C_1` | 12 | all plaquettes (24/24) | 0/264 | yes |
-| radius-2 | 38 | 24/24 | 264/264 | NO |
+| domain | size | length-4 family | length-6 family | length-8 family | one-tick / `R`-local bound (`D subseteq C_1`) |
+| --- | ---: | ---: | ---: | ---: | :---: |
+| `E` (endpoints) | 2 | empty (0/24) | 0/264 | 0/3312 | yes |
+| `E∪A` | 4 | empty (0/24) | 0/264 | 0/3312 | yes |
+| `E∪T` | 10 | all plaquettes (24/24) | 0/264 | 0/3312 | yes |
+| `C_1` | 12 | all plaquettes (24/24) | 0/264 | 0/3312 | yes |
+| radius-2 | 38 | 24/24 | 264/264 | 96/3312 | NO |
 
 The radius-2 cardinality is computed rather than assumed. Each endpoint's
 cubic Manhattan radius-2 ball has 25 sites, their intersection has 12 sites,
 and their union therefore has `25 + 25 - 12 = 38` sites.
 
-The previously unchecked `E∪A` row is empty at both enumerated lengths:
-`0/24` and `0/264`. The radius-2 row admits the full length-6 enumeration.
+The previously unchecked `E∪A` row is empty at all three enumerated lengths:
+`0/24`, `0/264`, and `0/3312`. The radius-2 row admits the full length-6
+enumeration.
+
+**Length-8 extension (2026-07-12, block 04).** All 3312 rooted simple
+length-8 loops are rejected by every one-tick domain, including full `C_1`:
+the license's plaquette-only selection extends unchanged from the parent's
+tested {4, 6} domain to length 8. Radius-2, by contrast, admits exactly 96 of
+the 3312 length-8 loops — a strict subclass, unlike its full admission of
+the length-6 class — so the one-tick bound remains the operative exclusion
+mechanism at every tested length.
 Its named exterior point is also the block-01 falsifier instance: source `(-2,0,0)` and target `(0,0,0)`
 are at graph distance 2, so allowing that
 dependency is the witnessed violation class of one-tick confinement.
 
 ## Theorem (enumerated-domain interval classification)
 
-On the enumerated lengths 4 and 6, every domain in the four-element lattice
+On the enumerated lengths 4, 6, and 8, every domain in the four-element lattice
 that contains the transverse orbit lies in the interval `[E∪T,C_1]` and gives
-the same selection: all 24 plaquettes and no length-6 loop. Both domains that
+the same selection: all 24 plaquettes and no length-6 or length-8 loop. Both domains that
 omit the transverse orbit lie in `[E,E∪A]` and give the constant-empty family.
 Equivalently,
 
@@ -161,7 +170,7 @@ not the enumeration outcomes, pins the full `C_1` bound.
 
 ## Boundaries
 
-- This theorem concerns the enumerated lengths 4 and 6 only; no other loop
+- This theorem concerns the enumerated lengths 4, 6, and 8 only; no other loop
   length is classified.
 - This is a classification of covariant domains, not a classification of
   licenses beyond the endpoint-containing, stabilizer-invariant one-step
@@ -202,5 +211,5 @@ git status --short
 
 ```yaml
 claim_type_author_hint: bounded_theorem
-claim_scope: "The order-eight stabilizer exhausts endpoint-containing covariant one-step domains, and the length-4/length-6 table classifies those four domains plus radius 2."
+claim_scope: "The order-eight stabilizer exhausts endpoint-containing covariant one-step domains, and the length-4/length-6/length-8 table classifies those four domains plus radius 2."
 ```

--- a/logs/runner-cache/per_plaquette_license_covariant_subdomain_classification_2026_07_12.txt
+++ b/logs/runner-cache/per_plaquette_license_covariant_subdomain_classification_2026_07_12.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/per_plaquette_license_covariant_subdomain_classification_2026_07_12.py
-runner_sha256: 33e6b93969b4f6041526a03c00c8575fbf2e0822d2161ec4e6d3a94e53576d89
+runner_sha256: 0ca4adaec367f1c5fd0639c3d3b8e5fdb35c37fb23745db65cdd0bd1812f62b6
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.30
+elapsed_sec: 5.32
 status: ok
 ----- stdout -----
 ========================================================================================
@@ -32,24 +32,27 @@ BLOCK B — exhaustive invariant-subset lattice
   INVARIANT_SUBSETS: tested=1024 invariant=4 sizes=[2, 4, 10, 12]
 
 ----------------------------------------------------------------------------------------
-BLOCK C — computed length-4/length-6 classification table
+BLOCK C — computed length-4/length-6/length-8 classification table
 ----------------------------------------------------------------------------------------
   [PASS] all five domain builders are undirected-link definitions
   [PASS] all five domain builders are translation/proper-rotation covariant  --  comparisons=130
   [PASS] rooted length-4 count  --  found=24
   [PASS] all rooted length-4 loops are plaquettes
   [PASS] rooted length-6 count  --  found=264
-  [PASS] the complete five-row classification matches the computed theorem table  --  {'E': (2, 0, 0, True), 'E+A': (4, 0, 0, True), 'E+T': (10, 24, 0, True), 'C_1': (12, 24, 0, True), 'radius-2': (38, 24, 264, False)}
+  [PASS] rooted length-8 count  --  found=3312
+  [PASS] the complete five-row classification matches the computed theorem table  --  {'E': (2, 0, 0, 0, True), 'E+A': (4, 0, 0, 0, True), 'E+T': (10, 24, 0, 0, True), 'C_1': (12, 24, 0, 0, True), 'radius-2': (38, 24, 264, 96, False)}
   [PASS] domains missing T give the constant-empty family
-  [PASS] domains containing T give the constant 24/0 family
+  [PASS] domains containing T give the constant 24/0/0 family
   [PASS] radius-2 admits the entire enumerated length-6 class
+  [PASS] one-tick domains reject the entire enumerated length-8 class
+  [PASS] radius-2 admits only a strict length-8 subclass (96 of 3312)  --  radius-2 length-8 pass=96
   COMPUTED_CLASSIFICATION_TABLE:
-  domain       size   length-4   length-6   one-tick-subset-C_1
-  E (endpoints)    2     0/24       0/264    yes
-  E union A       4     0/24       0/264    yes
-  E union T      10    24/24       0/264    yes
-  C_1            12    24/24       0/264    yes
-  radius-2       38    24/24     264/264    NO
+  domain       size   length-4   length-6   length-8    one-tick-subset-C_1
+  E (endpoints)    2     0/24       0/264       0/3312    yes
+  E union A       4     0/24       0/264       0/3312    yes
+  E union T      10    24/24       0/264       0/3312    yes
+  C_1            12    24/24       0/264       0/3312    yes
+  radius-2       38    24/24     264/264      96/3312    NO
 
 ----------------------------------------------------------------------------------------
 BLOCK D — one-tick column and named radius-2 witness
@@ -82,7 +85,7 @@ BLOCK E — paired-note surface pins
 SHORT STDOUT SUMMARY
 E union A row: size=4 length4=0/24 length6=0/264
 radius-2 domain size: 38
-TOTAL: PASS=39 FAIL=0
+TOTAL: PASS=42 FAIL=0
 ========================================================================================
 
 ----- stderr -----

--- a/logs/runner-cache/per_plaquette_license_one_tick_reachability_derivation_2026_07_12.txt
+++ b/logs/runner-cache/per_plaquette_license_one_tick_reachability_derivation_2026_07_12.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/per_plaquette_license_one_tick_reachability_derivation_2026_07_12.py
-runner_sha256: bea0586ccb98c5cc5d3de8c4cb7756eabdad1da552a8b099a7e147a0baa693bf
+runner_sha256: 2187339062813d6183773bf60048f301ebf18bf83d9620a40799a69b0aed23e8
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.26
+elapsed_sec: 0.25
 status: ok
 ----- stdout -----
 ========================================================================================

--- a/scripts/per_plaquette_license_covariant_subdomain_classification_2026_07_12.py
+++ b/scripts/per_plaquette_license_covariant_subdomain_classification_2026_07_12.py
@@ -3,7 +3,7 @@
 
 This deterministic runner constructs the order-eight stabilizer of the
 undirected reference link, exhausts all endpoint-containing subsets of its
-one-step domain, and computes the length-4/length-6 mutual-containment table.
+one-step domain, and computes the length-4/length-6/length-8 mutual-containment table.
 It also checks the paired note's theorem, status, table, and boundary pins.
 """
 from __future__ import annotations
@@ -203,6 +203,13 @@ def closed_loops(length: int) -> list[Loop]:
             points.append(position)
         if not admissible or points[-1] != ZERO:
             continue
+        interior = points[:-1]
+        if len(set(interior)) != len(interior):
+            # rooted SIMPLE loops: no vertex revisit before the closing
+            # return to the root (the stated parent/block-01 domain; the
+            # distinction is vacuous at lengths 4 and 6 and load-bearing at
+            # length 8, where non-simple closed walks exist).
+            continue
         links = tuple((points[index], points[index + 1]) for index in range(length))
         if len({frozenset(link) for link in links}) == length:
             loops.append(links)
@@ -365,7 +372,7 @@ def block_b(
 
 
 def block_c() -> tuple[list[dict[str, object]], list[Loop], list[Loop]]:
-    section("BLOCK C — computed length-4/length-6 classification table")
+    section("BLOCK C — computed length-4/length-6/length-8 classification table")
     rotations = proper_cubic_rotations()
     translations: tuple[Point, ...] = ((2, -1, 3), (-3, 0, 1))
     covariance_checks = []
@@ -395,9 +402,11 @@ def block_c() -> tuple[list[dict[str, object]], list[Loop], list[Loop]]:
 
     length4 = closed_loops(4)
     length6 = closed_loops(6)
+    length8 = closed_loops(8)
     check("rooted length-4 count", len(length4) == 24, f"found={len(length4)}")
     check("all rooted length-4 loops are plaquettes", all(map(is_plaquette, length4)))
     check("rooted length-6 count", len(length6) == 264, f"found={len(length6)}")
+    check("rooted length-8 count", len(length8) == 3312, f"found={len(length8)}")
 
     reference_c1 = c1_domain(REFERENCE_LINK)
     rows: list[dict[str, object]] = []
@@ -410,22 +419,24 @@ def block_c() -> tuple[list[dict[str, object]], list[Loop], list[Loop]]:
                 "size": len(reference),
                 "length4": sum(passes_domain(loop, builder) for loop in length4),
                 "length6": sum(passes_domain(loop, builder) for loop in length6),
+                "length8": sum(passes_domain(loop, builder) for loop in length8),
                 "one_tick": reference <= reference_c1,
             }
         )
 
     expected = {
-        "E": (2, 0, 0, True),
-        "E+A": (4, 0, 0, True),
-        "E+T": (10, 24, 0, True),
-        "C_1": (12, 24, 0, True),
-        "radius-2": (38, 24, 264, False),
+        "E": (2, 0, 0, 0, True),
+        "E+A": (4, 0, 0, 0, True),
+        "E+T": (10, 24, 0, 0, True),
+        "C_1": (12, 24, 0, 0, True),
+        "radius-2": (38, 24, 264, 96, False),
     }
     actual = {
         str(row["key"]): (
             row["size"],
             row["length4"],
             row["length6"],
+            row["length8"],
             row["one_tick"],
         )
         for row in rows
@@ -437,24 +448,34 @@ def block_c() -> tuple[list[dict[str, object]], list[Loop], list[Loop]]:
     )
     check(
         "domains missing T give the constant-empty family",
-        actual["E"][1:3] == actual["E+A"][1:3] == (0, 0),
+        actual["E"][1:4] == actual["E+A"][1:4] == (0, 0, 0),
     )
     check(
-        "domains containing T give the constant 24/0 family",
-        actual["E+T"][1:3] == actual["C_1"][1:3] == (24, 0),
+        "domains containing T give the constant 24/0/0 family",
+        actual["E+T"][1:4] == actual["C_1"][1:4] == (24, 0, 0),
     )
     check(
         "radius-2 admits the entire enumerated length-6 class",
         actual["radius-2"][2] == len(length6) == 264,
     )
+    check(
+        "one-tick domains reject the entire enumerated length-8 class",
+        all(actual[k][3] == 0 for k in ("E", "E+A", "E+T", "C_1")),
+    )
+    check(
+        "radius-2 admits only a strict length-8 subclass (96 of 3312)",
+        actual["radius-2"][3] == 96 and 0 < 96 < len(length8),
+        f"radius-2 length-8 pass={actual['radius-2'][3]}",
+    )
 
     print("  COMPUTED_CLASSIFICATION_TABLE:")
-    print("  domain       size   length-4   length-6   one-tick-subset-C_1")
+    print("  domain       size   length-4   length-6   length-8    one-tick-subset-C_1")
     for row in rows:
         print(
             f"  {str(row['label']):<12} {int(row['size']):>4}   "
             f"{int(row['length4']):>3}/{len(length4):<3}    "
             f"{int(row['length6']):>3}/{len(length6):<3}    "
+            f"{int(row['length8']):>4}/{len(length8):<4}    "
             f"{'yes' if row['one_tick'] else 'NO'}"
         )
     return rows, length4, length6
@@ -507,11 +528,11 @@ def block_d(rows: list[dict[str, object]]) -> None:
 def table_row_needles(rows: list[dict[str, object]]) -> tuple[str, ...]:
     by_key = {str(row["key"]): row for row in rows}
     return (
-        f"| `E` (endpoints) | {by_key['E']['size']} | empty ({by_key['E']['length4']}/24) | {by_key['E']['length6']}/264 | yes |",
-        f"| `E∪A` | {by_key['E+A']['size']} | empty ({by_key['E+A']['length4']}/24) | {by_key['E+A']['length6']}/264 | yes |",
-        f"| `E∪T` | {by_key['E+T']['size']} | all plaquettes ({by_key['E+T']['length4']}/24) | {by_key['E+T']['length6']}/264 | yes |",
-        f"| `C_1` | {by_key['C_1']['size']} | all plaquettes ({by_key['C_1']['length4']}/24) | {by_key['C_1']['length6']}/264 | yes |",
-        f"| radius-2 | {by_key['radius-2']['size']} | {by_key['radius-2']['length4']}/24 | {by_key['radius-2']['length6']}/264 | NO |",
+        f"| `E` (endpoints) | {by_key['E']['size']} | empty ({by_key['E']['length4']}/24) | {by_key['E']['length6']}/264 | {by_key['E']['length8']}/3312 | yes |",
+        f"| `E∪A` | {by_key['E+A']['size']} | empty ({by_key['E+A']['length4']}/24) | {by_key['E+A']['length6']}/264 | {by_key['E+A']['length8']}/3312 | yes |",
+        f"| `E∪T` | {by_key['E+T']['size']} | all plaquettes ({by_key['E+T']['length4']}/24) | {by_key['E+T']['length6']}/264 | {by_key['E+T']['length8']}/3312 | yes |",
+        f"| `C_1` | {by_key['C_1']['size']} | all plaquettes ({by_key['C_1']['length4']}/24) | {by_key['C_1']['length6']}/264 | {by_key['C_1']['length8']}/3312 | yes |",
+        f"| radius-2 | {by_key['radius-2']['size']} | {by_key['radius-2']['length4']}/24 | {by_key['radius-2']['length6']}/264 | {by_key['radius-2']['length8']}/3312 | NO |",
     )
 
 
@@ -547,7 +568,7 @@ def block_e(rows: list[dict[str, object]]) -> None:
     )
     boundary_needles = (
         "## Boundaries",
-        "enumerated lengths 4 and 6 only",
+        "enumerated lengths 4, 6, and 8 only",
         "classification of covariant domains",
         "does **not** prove that the fundamental action is per-plaquette",
         "`theta_bare` is untouched",

--- a/scripts/per_plaquette_license_one_tick_reachability_derivation_2026_07_12.py
+++ b/scripts/per_plaquette_license_one_tick_reachability_derivation_2026_07_12.py
@@ -129,6 +129,11 @@ def closed_loops(length: int) -> list[tuple[Link, ...]]:
             points.append(position)
         if not admissible or points[-1] != ZERO:
             continue
+        interior = points[:-1]
+        if len(set(interior)) != len(interior):
+            # rooted SIMPLE loops (block-04 convention unification): vacuous
+            # at the lengths 4/6 used here; load-bearing at length 8.
+            continue
         links = tuple((points[index], points[index + 1]) for index in range(length))
         if len({frozenset(link) for link in links}) == length:
             loops.append(links)


### PR DESCRIPTION
## Summary

`[physics-loop]` per-plaquette-license **block 04** — **exact support (length-8 extension + convention unification; stacked, final block)**.

**Stacked PR: base = `physics-loop/per-plaquette-license-block03-20260712`** (chain: #5274 → #5275 → #5279 → this).

Two results:

1. **Length-8 extension.** Every one-tick domain — including full `C₁` — rejects the entire rooted simple length-8 class (**0/3312**); the license's plaquette-only selection extends beyond the parent's tested {4, 6}. Radius-2 admits exactly **96/3312** — a strict subclass, unlike its full 264/264 admission at length 6 — so the one-tick bound remains the operative exclusion mechanism at every tested length. Classification table and interval theorem updated to three lengths; runner `PASS=42 FAIL=0`.

2. **Convention finding (load-bearing at length 8 only).** The inherited parent loop-generator convention enforced no-backtracking and no-repeated-edge but **not vertex-simplicity** — vacuous at lengths 4/6 (24/264 unchanged either way), but at length 8 there are 4272 closed walks vs **3312 rooted simple loops**. Both campaign runners now enforce the stated rooted-**simple** domain (block-01 runner re-verified unchanged at `51/0`; both caches regenerated). The parent enumeration runner (lengths 4/6 only) is unaffected but inherits the same latent gap if ever extended — flagged here for the review lane.

## Verification

- Classification runner `PASS=42 FAIL=0`; block-01 runner `51/0`; parent runner `13/0` — all supervisor-rerun; caches SHA-pinned; `vocab_lint` clean.
- Every new table cell (E∪A, E∪T, C₁, radius-2 at length 8; the 3312 count; the 96 subclass) was **independently pre-computed by the supervisor in a separate implementation** before the edits.
- Review note: one pin failure (stale 5-column table needles) was caught by the supervisor's post-commit re-verification and fixed in the amended commit — the shipped branch is the verified state.

Campaign close-out is recorded in the pack (`HANDOFF.md`): residual `(P-FUND-1TICK)` closure is owner-gated (registration decision) or awaits future ticked-update-law content; lengths > 8 and non-loop link sets remain open frontier, not claimed. Independent audit remains required for all four blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
