### PR TITLE
audit-infra: bind exact phrase groups and AC wall evidence

### DIFF
--- a/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -225,4 +225,4 @@ Run:
 python3 scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
 ```
 
-Expected result: `PASS=59`, `FAIL=0`.
+Expected result: `PASS=60`, `FAIL=0`.

--- a/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -208,4 +208,4 @@ Run:
 python3 scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
 ```
 
-Expected result: `PASS=45`, `FAIL=0`.
+Expected result: `PASS=46`, `FAIL=0`.

--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -557,8 +557,17 @@ occurrences of `absent`, `cannot`, `does not`, `fails`, `impossible`,
 `no nonzero`, `no-go`, `obstruction`, `requires a new axiom`, `rule out`,
 `rules out`, `structurally undecidable`, `unavailable`, `is not`, and `are not`,
 and must test all five resolution classes substantively against cited live
-current-cycle runner stdout evidence. For each N5 statement,
-`resolution_classes_checked` must equal the five canonical classes exactly,
+current-cycle runner stdout evidence.
+
+For every N3 hit and N5 statement, copy `phrase` byte-for-byte from the
+corresponding `full_phrase_groups[].phrase` value in the evidence manifest.
+Never paraphrase a phrase, join two phrases with punctuation or a slash, or
+collapse distinct phrases into one object. For example, `boundary` and
+`primitive` require separate objects even when one source sentence contains
+both. The path, phrase, and occurrence-group id must identify the same single
+authenticated group.
+
+For each N5 statement, `resolution_classes_checked` must equal the five canonical classes exactly,
 and `tested_resolutions` must contain exactly five entries: one and only one
 entry prefixed `per_element:`, `per_site:`, `per_mode:`, `per_block:`, and
 `lattice_wide:`. Put unexecuted classes in `untested_resolutions` as well; do

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -6705,6 +6705,25 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         self.assertIn("prior=archived unrestricted scope", prompt)
         self.assertNotIn("{{PRIOR_CLAIM_SCOPE}}", prompt)
 
+    def test_no_go_prompt_requires_exact_unjoined_phrase_groups(self):
+        template = (
+            PROJECT_ROOT / "docs" / "audit" / "AUDIT_AGENT_PROMPT_TEMPLATE.md"
+        ).read_text(encoding="utf-8")
+        template_flat = " ".join(template.split())
+        self.assertIn(
+            "copy `phrase` byte-for-byte from the corresponding "
+            "`full_phrase_groups[].phrase`",
+            template_flat,
+        )
+        self.assertIn(
+            "Never paraphrase a phrase, join two phrases with punctuation or a slash",
+            template_flat,
+        )
+        self.assertIn(
+            "`boundary` and `primitive` require separate objects",
+            template_flat,
+        )
+
     def test_prompt_uses_neutral_dispatch_task_without_raw_question(self):
         m = _import_codex_audit_runner()
         with tempfile.TemporaryDirectory() as tmp:

--- a/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
-runner_sha256: 32f18b31492f765ff7b5ec35d3ccf138f5820a3cb9f2b439cd7a157cc9929fae
+runner_sha256: 44a70a4d553b49d998b10369de1a2496228ccc09afa785bb05a41a7796183ff7
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.08
+elapsed_sec: 0.04
 status: ok
 ----- stdout -----
 Record additivity and the R-eta unit-calibration countermodel
@@ -45,6 +45,7 @@ Part D: rhetoric-resolution lifts
   [PASS] per_mode: disjoint finite-mode decomposition preserves additivity while leaving beta free
   [PASS] per_block: disjoint record blocks preserve additivity for both beta normalizations
   [PASS] lattice_wide: finite lattice partition preserves both laws while beta remains unselected
+  [PASS] N2 wall W_unit: beta-one and beta-two singleton laws share h but remain distinct
 
 Part E: source and axiom guards
 -------------------------------
@@ -70,7 +71,7 @@ Part E: source and axiom guards
   [PASS] discipline gate records PASS
 
 ========================================================================
-TOTAL: PASS=45, FAIL=0
+TOTAL: PASS=46, FAIL=0
 
 ----- stderr -----
 

--- a/logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
-runner_sha256: 0be6b226896e56c7248d78d019bd76b8385da1a01090634372821374d70106f6
+runner_sha256: 5ada062d8f544dd383898634744f70669d1f14f78a9d02ffb745c9e8cc0bccb8
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.58
+elapsed_sec: 0.52
 status: ok
 ----- stdout -----
 Complex-vs-realified determinant-power countermodels
@@ -67,6 +67,7 @@ Part F: rhetoric-resolution lifts
   [PASS] per_mode: diagonal finite-mode products retain the complex-versus-realified factor two
   [PASS] per_block: direct-sum finite blocks preserve additivity for both determinant powers
   [PASS] lattice_wide: finite lattice record union preserves both laws and their factor-two split
+  [PASS] N2 wall W_power: one complex carrier supports two distinct additive determinant powers
 
 Part G: source and axiom guards
 -------------------------------
@@ -90,7 +91,7 @@ Part G: source and axiom guards
   [PASS] discipline gate records PASS
 
 ====================================================================
-TOTAL: PASS=59, FAIL=0
+TOTAL: PASS=60, FAIL=0
 
 ----- stderr -----
 

--- a/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
@@ -154,6 +154,13 @@ def main() -> int:
         and readout(beta_target, h, lattice_records)
         != readout(beta_counter, h, lattice_records),
     )
+    check(
+        "N2 wall W_unit: beta-one and beta-two singleton laws share h but remain distinct",
+        readout(beta_target, h, singleton) == h
+        and readout(beta_counter, h, singleton) == 2 * h
+        and readout(beta_target, h, singleton)
+        != readout(beta_counter, h, singleton),
+    )
 
     section("Part E: source and axiom guards")
     note = NOTE.read_text(encoding="utf-8")

--- a/scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
@@ -203,6 +203,14 @@ def main() -> int:
             - 2 * sp.expand_log(lattice_fc, force=True)
         ) == 0,
     )
+    check(
+        "N2 wall W_power: one complex carrier supports two distinct additive determinant powers",
+        sp.simplify(scalar_det_r - scalar_det_c * sp.conjugate(scalar_det_c)) == 0
+        and sp.simplify(
+            sp.expand_log(mode_fr, force=True)
+            - 2 * sp.expand_log(mode_fc, force=True)
+        ) == 0,
+    )
 
     section("Part G: source and axiom guards")
     note = NOTE.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- require N3/N5 phrase fields to copy one authenticated phrase group byte-for-byte and forbid joined phrases
- add a regression for the observed boundary / primitive schema defect
- expose the existing W_power and W_unit one-wall countermodels in live runner stdout
- refresh runner caches and expected totals

## Scope
This repairs authenticated audit evidence. It adds no axiom, primitive, premise, import, comparator, physical bridge, or mass constraint; r remains free.

## Validation
- independent review-loop PASS
- full audit test suite 261/261
- full pipeline PASS; strict lint zero errors
- occupancy 60/0; R-eta 46/0
- caches fresh and vocabulary clean
