### PR TITLE
fix(gate_b): retarget connectivity-tolerance boundary check to audited note + narrow to finite-replay scope

### DIFF
--- a/docs/GATE_B_CONNECTIVITY_TOLERANCE_NOTE.md
+++ b/docs/GATE_B_CONNECTIVITY_TOLERANCE_NOTE.md
@@ -5,13 +5,17 @@
 
 ## One-line read
 
-The replay supports a narrow but useful claim:
+Within this frozen finite replay, and under the supplied Gate B harness choices
+recorded below, the replay supports a narrow bounded reading:
 
-- position noise on a fixed connectivity backbone is tolerated
-- once connectivity is recomputed from geometry, the response becomes mixed
+- on this fixed connectivity backbone, the swept position noise is tolerated
+- once connectivity is recomputed from geometry, the sampled response becomes mixed
 
-That makes connectivity structure the real bottleneck in the current Gate B
-lane, but it does **not** close Gate B.
+Read strictly inside that finite harness, connectivity structure — not position
+noise — is where the sampled response first becomes mixed. That is a
+finite-replay observation under the supplied choices, not a derived theorem that
+connectivity is intrinsically the Gate B bottleneck, and it does **not** close
+Gate B.
 
 ## Primary artifact
 
@@ -54,14 +58,19 @@ The jitter sweep on fixed connectivity is the cleanest tolerance check:
 | `0.40` | `50.0%` | `-0.000003` | `0.50` |
 | `0.50` | `75.0%` | `+0.000005` | `0.75` |
 
-## Safe interpretation
+## Safe interpretation (finite replay only)
 
-- A fixed connectivity backbone survives substantial position noise.
-- Geometry-recomputed connectivity is the first place the response becomes
-  mixed.
-- The response does not show a cliff at jitter `0.5`; it degrades gradually.
-- The local response-slope probe stays in a bounded linear-response band rather
-  than collapsing.
+Read as frozen-replay observations under the supplied harness, not as general
+theorems:
+
+- On this fixed connectivity backbone, the sampled response survives the swept
+  position noise.
+- Geometry-recomputed connectivity is where the sampled response first becomes
+  mixed in this replay.
+- The response does not show a cliff at jitter `0.5`; it degrades gradually
+  across the swept points.
+- The local response-slope probe stays in a bounded linear-response band across
+  the swept points rather than collapsing.
 
 ## What this is not
 
@@ -72,11 +81,29 @@ The jitter sweep on fixed connectivity is the cleanest tolerance check:
 
 ## Why it matters
 
-This replay makes the remaining Gate B gap sharper:
+Within this finite replay the remaining Gate B gap looks sharper:
 
-- position noise is not the main failure mode
-- connectivity construction is
+- across the swept points, position noise is not what mixes the response first
+- recomputed connectivity is
 
-So the next useful growth rule is not “more jitter tolerance” but a rule that
-produces structured connectivity without turning the graph into a hand-imposed
-lattice.
+Read as a finite-replay signpost and not a general theorem, the next growth rule
+to try is not “more jitter tolerance” but a rule that produces structured
+connectivity without turning the graph into a hand-imposed lattice.
+
+## Audit scope firewall (2026-07-12)
+
+2026-07-12 audit scope: finite connectivity replay, not dynamics closure. This
+note cites the frozen replay numbers only inside the stated finite Gate B
+harness. The physical inputs behind those numbers remain supplied Gate-B data,
+tracked here with the shared supplied-residue vocabulary of
+`GATE_B_DYNAMICS_NOTE.md`:
+
+- `GB-S1b-b`: the physical scalar source/boundary/regulator/normalization remains supplied.
+- `GB-S2b`: the physical detector-window/TOWARD/`F~M` semantics remain supplied.
+- `GB-S3b`: the physical selection/dynamical generation of the connectivity stencil remains supplied.
+
+Because those inputs are supplied row-local premises rather than cited retained
+authorities, this note does not derive a Gate B dynamics theorem, supplies no
+physical gravity/readout bridge, and introduces no new axiom, Tier-A admission,
+or audit-status change. The "connectivity is the current bottleneck" reading is a
+finite-replay observation under those supplied choices, not a general theorem.

--- a/logs/runner-cache/gate_b_connectivity_tolerance.txt
+++ b/logs/runner-cache/gate_b_connectivity_tolerance.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/gate_b_connectivity_tolerance.py
-runner_sha256: bb89d656466f7d9cbb44a085f554cdfaac8587d1a1eb3905700127d4a67c0aed
-timeout_sec: 120
+runner_sha256: 571998caea2c9ab6f61db078e247e664c891aad9ecdb7ac41bf54f7ea4966aac
+timeout_sec: 180
 exit_code: 0
-elapsed_sec: 4.91
+elapsed_sec: 5.03
 status: ok
 ----- stdout -----
 ========================================================================================
@@ -42,8 +42,8 @@ Interpretation:
 
 Source-boundary checks
 ----------------------------------------
-[PASS] note claim type is open_gate and has 2026-06-12 source-index firewall
-[PASS] GB-S1b-b/GB-S2b/GB-S3b residues remain supplied row-local data
+[PASS] note declares bounded finite-replay status and 2026-07-12 audit-scope firewall
+[PASS] GB-S1b-b/GB-S2b/GB-S3b physical inputs remain supplied row-local premises
 [PASS] note forbids Gate B dynamics closure and axiom/admission/status changes
 BOUNDARY_CHECKS: PASS=3 FAIL=0
 

--- a/scripts/gate_b_connectivity_tolerance.py
+++ b/scripts/gate_b_connectivity_tolerance.py
@@ -37,7 +37,7 @@ SEEDS = (5, 18, 31, 44, 57, 70)
 JITTER_SWEEP = (0.0, 0.1, 0.2, 0.3, 0.4, 0.5)
 MASS_STRENGTHS = (0.75, 1.0, 1.25)
 ROOT = Path(__file__).resolve().parents[1]
-NOTE = ROOT / "docs" / "GATE_B_DYNAMICS_NOTE.md"
+NOTE = ROOT / "docs" / "GATE_B_CONNECTIVITY_TOLERANCE_NOTE.md"
 
 
 CHECK_PASS = 0
@@ -64,18 +64,18 @@ def _source_boundary_checks() -> None:
     print("Source-boundary checks")
     print("-" * 40)
     _check(
-        "note claim type is open_gate and has 2026-06-12 source-index firewall",
-        "**Claim type:** open_gate" in text
-        and "2026-06-12 audit firewall: source index, not dynamics closure" in text,
+        "note declares bounded finite-replay status and 2026-07-12 audit-scope firewall",
+        "bounded Gate B replay frozen on disk, not a dynamics theorem" in text
+        and "2026-07-12 audit scope: finite connectivity replay, not dynamics closure" in text,
     )
     _check(
-        "GB-S1b-b/GB-S2b/GB-S3b residues remain supplied row-local data",
+        "GB-S1b-b/GB-S2b/GB-S3b physical inputs remain supplied row-local premises",
         "`GB-S1b-b`" in flat
         and "`GB-S2b`" in flat
         and "`GB-S3b`" in flat
         and "physical scalar source/boundary/regulator/normalization remains supplied" in flat
         and "physical detector-window/TOWARD/`F~M` semantics remain supplied" in flat
-        and "physical selection/dynamical generation of that stencil remains supplied" in flat,
+        and "physical selection/dynamical generation of the connectivity stencil remains supplied" in flat,
     )
     _check(
         "note forbids Gate B dynamics closure and axiom/admission/status changes",


### PR DESCRIPTION
## What this responds to

Row `gate_b_connectivity_tolerance_note` (fan=29, `audited_conditional`, class C, lane `gate_b`). The audit verdict names two repair targets verbatim:

> Repair target: provide retained bridge theorems or explicit dependency edges deriving those supplied choices; **the runner boundary checks also inspect docs/GATE_B_DYNAMICS_NOTE.md rather than the audited note, so source-scope validation should be corrected.**

> Claim boundary until fixed: **cite the frozen replay numbers only inside the stated finite harness.**

This PR does the two things the verdict asks that do NOT require building the (still-missing) Gate B dynamics bridge: it (a) retargets the runner's source-scope validation to the audited note, and (b) conforms the note's prose to the stated finite-harness boundary. The bridge theorem itself is left open — the row requeues `unaudited` for the independent lane.

## What changed (source-only triple)

**`scripts/gate_b_connectivity_tolerance.py`** — the runner's `NOTE` pointer read `docs/GATE_B_DYNAMICS_NOTE.md` (a *different* note), so its three source-boundary checks were validating the wrong file. Repointed `NOTE` to the audited `GATE_B_CONNECTIVITY_TOLERANCE_NOTE.md` and rewrote the three checks to grep *this* note's own scope firewall:

- declares bounded finite-replay status + the `2026-07-12 audit scope: finite connectivity replay, not dynamics closure` firewall marker;
- carries the `GB-S1b-b`/`GB-S2b`/`GB-S3b` supplied-residue inventory (physical scalar source/boundary/regulator/normalization, detector-window/TOWARD/`F~M` semantics, and connectivity-stencil selection all remain **supplied** row-local premises);
- forbids Gate B dynamics closure and any axiom/admission/status change.

Each check discriminates — it fails if the disclaimers are removed or the frozen numbers are promoted to a theorem.

**`docs/GATE_B_CONNECTIVITY_TOLERANCE_NOTE.md`** — narrowed the "connectivity structure is the real bottleneck" reading to a *finite-replay observation under the supplied harness*, not a derived theorem; retitled "Safe interpretation" → "Safe interpretation (finite replay only)" and qualified its bullets to the swept points; added an "Audit scope firewall (2026-07-12)" section recording the supplied Gate-B inputs. `GATE_B_DYNAMICS_NOTE.md` is referenced in **backticks** (shared supplied-residue vocabulary), NOT a markdown link — so no new dependency edge is minted onto the `open_gate` dynamics row; the note's only link edges remain its own paired runner and dated log.

**`logs/runner-cache/gate_b_connectivity_tolerance.txt`** — regenerated; `BOUNDARY_CHECKS: PASS=3 FAIL=0`.

## Verification (reproduced personally)

- `python3 scripts/gate_b_connectivity_tolerance.py` → the frozen replay reproduces byte-identically (ordered `66.7%` / `+0.000012` / `0.66`, jittered `75.0%`, jitter sweep unchanged) and prints `BOUNDARY_CHECKS: PASS=3 FAIL=0`. No physics changed — only the source-scope pointer and the note prose.
- Diff vs current origin/main is exactly the three files above.
- Sibling check: no other runner greps this note's sentences. `scripts/gate_b_operator_cauchy.py` mentions the basename in a docstring comment only; `scripts/mesoscopic_surrogate_source_2d.py` / `_two_stage_2d.py` match only the generic phrase "Safe interpretation:" in their own docstrings; none reads this note.

Editing the note drifts its `note_hash`, requeuing the row for the independent audit lane — the intended unlock. No audit status is asserted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
