### PR TITLE
fix(ac): restrict R-eta magnitude countermodel to positive beta

### DIFF
--- a/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -13,7 +13,7 @@ set or predict an audit verdict.
 ## Narrow no-go claim
 
 Grant the R-eta h-class hypothesis: the charged-lepton eta readout lies in the
-fixed-locus density class represented by a nonzero local scalar `h`. This grants
+fixed-locus density class represented by a positive local scalar `h`. This grants
 the class, not its identity calibration. Even with that grant, the
 [four axioms](MINIMAL_AXIOMS_2026-06-29.md) do not entail
 
@@ -22,14 +22,14 @@ the class, not its identity calibration. Even with that grant, the
 Phi = 3|delta| = 3h.
 ```
 
-They admit a real one-parameter family of readouts
+They admit a positive-real one-parameter family of readouts
 
 ```text
 I_beta(R) = beta h N(R),
 ```
 
 where `N(R)` is the number of records in a finite pairwise-disjoint record
-collection. Every real `beta` satisfies empty-zero, record-content
+collection. Every positive real `beta` satisfies empty-zero, record-content
 determination, and finite additivity. The target is `beta=1`; `beta=2` is an
 explicit countermodel with the same axiom structure and the same granted `h`.
 For a singleton record `x` and a three-record cycle `C`, respectively,
@@ -56,7 +56,7 @@ its cardinality. Because cardinality depends on record content and not on a
 site label, it is invariant under translations, proper cubic rotations, and
 permutations of the three cycle positions.
 
-For any real `beta`, set
+For any positive real `beta`, set
 
 ```text
 I_beta(empty) = 0,
@@ -104,9 +104,9 @@ Historical decision text identifies provenance only and is not used as proof.
 
 | Route tested against the countermodel | Marker | Result and authority/check |
 |---|---|---|
-| Full Record readout route | ATTEMPTED | Empty-zero, record-content determination, and finite disjoint additivity all hold for every real `beta`; Record clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Parts A--C. |
+| Full Record readout route | ATTEMPTED | Empty-zero, record-content determination, and finite disjoint additivity all hold for every positive real `beta`; Record clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Parts A--C. |
 | Lattice and cycle symmetry | ATTEMPTED | `N(R)` is invariant under translations, proper cubic rotations, and cycle-position permutations; Lattice clause in the [axiom memo](MINIMAL_AXIOMS_2026-06-29.md), runner Part B. |
-| K/CPT-even real readout | ATTEMPTED | Real `beta` and real `h` make `I_beta` unchanged by complex conjugation; this is an extra grant checked in runner Part B, not axiom content. |
+| K/CPT-even real readout | ATTEMPTED | Positive real `beta` and real `h` make `I_beta` unchanged by complex conjugation; this is an extra grant checked in runner Part B, not axiom content. |
 | Pointwise realized-state evaluation | ATTEMPTED | Evaluating the same realized record state leaves the law-level coefficient `beta` free; [realized-state primitive](REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md) boundary plus runner Parts A--C. |
 | Dimensionful scale reference | ATTEMPTED | The [scale-reference primitive](SCALE_REFERENCE_PRIMITIVE_NOTE.md) supplies units conversion and no dimensionless phase, selector, or readout bridge; `beta` is dimensionless, runner Part D. |
 | Kinetic-form isotropy | ATTEMPTED | The [kinetic-isotropy primitive](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md) supplies `c_t=c_s` and no phase, selector, or readout bridge; the family is unchanged, runner Part D. |
@@ -208,4 +208,4 @@ Run:
 python3 scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
 ```
 
-Expected result: `PASS=46`, `FAIL=0`.
+Expected result: `PASS=47`, `FAIL=0`.

--- a/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
-runner_sha256: 44a70a4d553b49d998b10369de1a2496228ccc09afa785bb05a41a7796183ff7
+runner_sha256: b9211c0318c1110acc3e2b06a5d638bd6e55100fcc8ac5fc27dfc3245b8c4b95
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.04
+elapsed_sec: 0.10
 status: ok
 ----- stdout -----
 Record additivity and the R-eta unit-calibration countermodel
@@ -11,6 +11,7 @@ Record additivity and the R-eta unit-calibration countermodel
 
 Part A: exact beta family
 -------------------------
+  [PASS] tested beta family is strictly positive
   [PASS] empty record reads zero for every tested beta
   [PASS] finite disjoint additivity holds for every tested beta
   [PASS] target singleton eta angle is 2/9
@@ -55,7 +56,7 @@ Part E: source and axiom guards
   [PASS] scale reference withholds dimensionless readout content
   [PASS] kinetic isotropy withholds phase and readout bridge
   [PASS] note grants h-class explicitly
-  [PASS] note states the beta countermodel
+  [PASS] note states the positive beta countermodel
   [PASS] note matches singleton eta angle and cycle holonomy
   [PASS] note limits claim to current finite-record surface
   [PASS] note preserves a future same-observable theorem
@@ -71,7 +72,7 @@ Part E: source and axiom guards
   [PASS] discipline gate records PASS
 
 ========================================================================
-TOTAL: PASS=46, FAIL=0
+TOTAL: PASS=47, FAIL=0
 
 ----- stderr -----
 

--- a/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
@@ -52,7 +52,8 @@ def main() -> int:
     cycle = frozenset({(0, 0, 0), (1, 0, 0), (0, 1, 0)})
 
     section("Part A: exact beta family")
-    betas = [Fraction(-1), Fraction(0), Fraction(1, 3), beta_target, beta_counter]
+    betas = [Fraction(1, 3), Fraction(1, 2), beta_target, Fraction(3, 2), beta_counter]
+    check("tested beta family is strictly positive", all(beta > 0 for beta in betas))
     check("empty record reads zero for every tested beta", all(readout(beta, h, empty) == 0 for beta in betas))
     check(
         "finite disjoint additivity holds for every tested beta",
@@ -175,7 +176,10 @@ def main() -> int:
     check("scale reference withholds dimensionless readout content", "no mass ratio, coupling, mixing angle, phase, selector, readout bridge" in scale_flat)
     check("kinetic isotropy withholds phase and readout bridge", "No mass ratio, coupling, mixing angle, phase, or selector is supplied" in kinetic_flat and "readout bridge" in kinetic_flat)
     check("note grants h-class explicitly", "Grant the R-eta h-class hypothesis" in note)
-    check("note states the beta countermodel", "I_beta(R) = beta h N(R)" in note)
+    check(
+        "note states the positive beta countermodel",
+        "Every positive real `beta`" in note and "I_beta(R) = beta h N(R)" in note,
+    )
     check("note matches singleton eta angle and cycle holonomy", "|delta_beta| = I_beta({x}) = beta h" in note and "Phi_beta = I_beta(C) = 3 beta h" in note)
     check("note limits claim to current finite-record surface", "finite-record, current-surface" in note)
     check("note preserves a future same-observable theorem", "future same-observable holonomy theorem" in note)


### PR DESCRIPTION
## Summary
- repair the sign inconsistency between every-real-beta language and the magnitude equation
- restrict the countermodel family to positive h and positive real beta, which contains beta=1 and beta=2
- make the runner enforce positive samples and refresh its cache/expected total

## Scope
The beta=2 countermodel still proves direct Record-additivity non-entailment. No axiom, primitive, premise, import, comparator, or r constraint is added.

## Validation
- independent review-loop PASS
- runner PASS=47 FAIL=0 and fresh cache
- full pipeline and strict lint PASS
- vocabulary, links, and diff hygiene PASS
