### PR TITLE
fix(poisson): surface helper via static import for audit packet

### DIFF
--- a/docs/POISSON_SELF_FIELD_SUPPLIED_BRANCH_CORE_BOUNDED_NOTE_2026-06-18.md
+++ b/docs/POISSON_SELF_FIELD_SUPPLIED_BRANCH_CORE_BOUNDED_NOTE_2026-06-18.md
@@ -10,7 +10,7 @@ new axiom.
 load-bearing authority for this bounded core.
 **Primary runner:** [`scripts/poisson_self_field_supplied_branch_core_2026_06_18.py`](../scripts/poisson_self_field_supplied_branch_core_2026_06_18.py)
 **Runner cache:** [`logs/runner-cache/poisson_self_field_supplied_branch_core_2026_06_18.txt`](../logs/runner-cache/poisson_self_field_supplied_branch_core_2026_06_18.txt)
-**Helper runners (audit packet must include):** [`scripts/poisson_self_field.py`](../scripts/poisson_self_field.py) — SHA-pinned cache [`logs/runner-cache/poisson_self_field.txt`](../logs/runner-cache/poisson_self_field.txt). The primary runner dynamically loads this helper via `importlib.util.spec_from_file_location("poisson_self_field", scripts/poisson_self_field.py)` (see `load_parent()`), so the load-bearing computation lives here. The primary runner calls the helper's `grow`, `_make_poisson_field` (which internally calls `_solve_poisson_2d`), `_prop_beam`, `_cz`, and `_dp`, plus the constants `H, K, NL, PW, MASS_Z, S, FAMILIES`. This helper source plus its cache must be in the restricted audit packet for the load-bearing calls to be verifiable.
+**Helper runners (audit packet must include):** [`scripts/poisson_self_field.py`](../scripts/poisson_self_field.py) — SHA-pinned cache [`logs/runner-cache/poisson_self_field.txt`](../logs/runner-cache/poisson_self_field.txt). The primary runner imports this helper statically via `from scripts import poisson_self_field` (see `load_parent()`, which returns the imported module), so the load-bearing computation lives here and the audit packet builder resolves the helper from that static import. The primary runner calls the helper's `grow`, `_make_poisson_field` (which internally calls `_solve_poisson_2d`), `_prop_beam`, `_cz`, and `_dp`, plus the constants `H, K, NL, PW, MASS_Z, S, FAMILIES`. This helper source plus its cache must be in the restricted audit packet for the load-bearing calls to be verifiable.
 
 ## Authority disclaimer
 
@@ -120,15 +120,39 @@ No derived value changed — the primary runner cache still reports
 `SUMMARY: PASS=18 FAIL=0`, and the helper cache still reports the same residual
 budget, TOWARD shifts, `F~M` slopes, Born ratio, and `s=0` null.
 
-The primary runner loads the helper via
+As of that repair the primary runner still loaded the helper via
 `importlib.util.spec_from_file_location` (a dynamic load inside
 `load_parent()`), not via `from scripts import poisson_self_field`. The
 import-form parser fix landed in PR #4424 targets the `from scripts import X`
-static form, so it does **not** auto-populate `helper_runner_paths` for this
-dynamic load. The audit packet must therefore include this helper via the
-note-side reference above (the same packaging convention used by other notes
-whose helpers are loaded dynamically).
+static form, so it did **not** auto-populate `helper_runner_paths` for that
+dynamic load; the 2026-06-20 repair therefore relied on the note-side reference
+above alone. See the 2026-07-12 entry below — that note-side reference did not
+populate the packet on its own, so the runner was subsequently converted to the
+static import form.
 
 Status authority: independent audit lane only. This repair sets no
 `audit_status`, `effective_status`, ledger tag, or retained status; it is the
 exact audit-named packaging repair and nothing more.
+
+### 2026-07-12 — static-import conversion
+
+The 2026-06-20 note-side reference alone did not place the helper in the
+restricted audit packet: the re-audit still returned `runner_artifact_issue`
+because the packet builder resolves helper sources from a runner's **static**
+`from scripts import X` imports (the PR #4424 parser), and the primary runner
+was still loading the helper through the dynamic
+`importlib.util.spec_from_file_location` form, which that parser does not follow.
+
+This repair converts the primary runner to the static form: it inserts the repo
+root on `sys.path` and imports the helper as `from scripts import
+poisson_self_field`, with `load_parent()` returning that imported module. The
+static import is exactly the form the packet builder resolves, so
+`scripts/poisson_self_field.py` is now shipped into the restricted packet and
+the load-bearing calls become verifiable in-packet.
+
+No derived value changed. The primary runner still reports
+`SUMMARY: PASS=18 FAIL=0`, with the same residual budget, TOWARD shifts, `F~M`
+slopes, Born ratio, and `s=0` null; only the helper import mechanism changed.
+
+Status authority: independent audit lane only. This repair sets no
+`audit_status`, `effective_status`, ledger tag, or retained status.

--- a/logs/runner-cache/poisson_self_field_supplied_branch_core_2026_06_18.txt
+++ b/logs/runner-cache/poisson_self_field_supplied_branch_core_2026_06_18.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/poisson_self_field_supplied_branch_core_2026_06_18.py
-runner_sha256: abe66b167f86d4468ee576f3123e39a1bab3e0fee10c960410f6683482ca21f9
+runner_sha256: c7ec1ee4c50326cd3d66fb750fabde937e5fc34d776bbb07e65303f1f84cdca8
 timeout_sec: 1800
 exit_code: 0
-elapsed_sec: 70.22
+elapsed_sec: 67.64
 status: ok
 ----- stdout -----
 ========================================================================

--- a/scripts/poisson_self_field_supplied_branch_core_2026_06_18.py
+++ b/scripts/poisson_self_field_supplied_branch_core_2026_06_18.py
@@ -10,12 +10,17 @@ from __future__ import annotations
 
 AUDIT_TIMEOUT_SEC = 1800
 
-import importlib.util
 import inspect
 import math
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import poisson_self_field as _poisson_self_field  # noqa: E402
+
 PARENT_RUNNER = REPO_ROOT / "scripts" / "poisson_self_field.py"
 PARENT_NOTE = REPO_ROOT / "docs" / "POISSON_SELF_FIELD_NOTE.md"
 CORE_NOTE = (
@@ -26,12 +31,7 @@ CORE_NOTE = (
 
 
 def load_parent():
-    spec = importlib.util.spec_from_file_location("poisson_self_field", PARENT_RUNNER)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"cannot import {PARENT_RUNNER}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    return _poisson_self_field
 
 
 class Score:


### PR DESCRIPTION
## Summary

Answers the historical `audited_conditional` / `runner_artifact_issue` verdict on row
`poisson_self_field_supplied_branch_core_bounded_note_2026-06-18` by converting its
primary runner to the canonical static helper-import form. No derived value changes.

Verdict repair target (verbatim):

> include scripts/poisson_self_field.py in the restricted packet and re-audit the primary runner's load-bearing calls.

## Root cause and current parser context

The primary runner's load-bearing computation lives in `scripts/poisson_self_field.py`
(functions `grow`, `_make_poisson_field` → `_solve_poisson_2d`, `_prop_beam`, `_cz`,
`_dp`; constants `H,K,NL,PW,MASS_Z,S,FAMILIES`). The 2026-06-21 re-audit predates
generic dynamic-loader detection: at that time the PR #4424 parser resolved helpers
from static `from scripts import X` imports, while this runner used
`importlib.util.spec_from_file_location`. The 2026-06-20 note-side reference did not
populate the packet on its own.

Current `main` also contains the later generic parser repair `f373596491`, which can
resolve this statically expressed dynamic-loader path. This PR nevertheless converts
the runner to the direct static form, removing reliance on that secondary inference
path and matching the established gate_b helper-surfacing pattern.

## Changes (source-only triple)

- `scripts/poisson_self_field_supplied_branch_core_2026_06_18.py` — dynamic
  `spec_from_file_location` load → static `from scripts import poisson_self_field`
  (insert repo root on `sys.path`; `load_parent()` returns the imported module; drop
  `import importlib.util`, add `import sys`). Call site `psf = load_parent()` unchanged.
- `docs/POISSON_SELF_FIELD_SUPPLIED_BRANCH_CORE_BOUNDED_NOTE_2026-06-18.md` — helper
  paragraph describes the static import; dated `2026-07-12` Repair Log records the
  conversion and the parser chronology. Sets no audit status.
- `logs/runner-cache/poisson_self_field_supplied_branch_core_2026_06_18.txt` — regenerated
  (new runner SHA; SUMMARY/VERDICT lines byte-identical).

## No physics change

Runner still reports `SUMMARY: PASS=18 FAIL=0` / `VERDICT: PASS -- bounded supplied-branch
core is audit-ready` — same residual budget (`max_residual=3.187e-05`), TOWARD shifts,
`F~M` slopes (0.9997 / 0.9993 / 0.9994), Born ratio (`9.84e-16`), and `s=0` null. Only the
helper import mechanism changed.

## Audit mechanics

Editing the runner and note drifts the row's source hashes, so the validation pipeline
requeues it `unaudited` for the independent audit lane. This PR asserts no audit status.
Precedent: commit `1552f0f3cc` (the gate_b helper-surfacing static-import fix).
