### PR TITLE
fix(activity-energy): withdraw unsupported thresholded-support prose, add note↔runner consistency gate

### DIFF
--- a/docs/ACTIVITY_ENERGY_BOUND_WITNESSES_BOUNDED_NOTE_2026-07-08.md
+++ b/docs/ACTIVITY_ENERGY_BOUND_WITNESSES_BOUNDED_NOTE_2026-07-08.md
@@ -59,11 +59,12 @@ threshold, or a deposition probability.
 
 - The exact inequality is finite-dimensional and uses the declared local-term
   decomposition.
-- The profile comparisons use absolute apportioned energy expectations,
-  thresholded supports, and finite time samples. They are diagnostics, not
-  identities.
+- The profile comparisons use normalized-profile overlap (a Bhattacharyya
+  coefficient over sum-normalized bond-activity and absolute bond-energy
+  profiles) and centroid separation, evaluated over their full support at
+  finite time samples. They are diagnostics, not identities.
 - The dense three-site model and one-particle chain, including their terms,
-  preparation choices, sizes, mass, thresholds, and finite times, are supplied.
+  preparation choices, sizes, mass, and finite times, are supplied.
 - No gravity conclusion or physical sourcing law is made.
 
 ## Dependencies
@@ -71,3 +72,19 @@ threshold, or a deposition probability.
 None. The operator inequality and toy comparators are self-contained; the
 optional record-opportunity reading uses the explicitly supplied `AO` premise
 rather than a derived dependency.
+
+## Repair Log
+
+- **2026-07-12** — Aligned the Boundaries prose to the runner's actual
+  profile-comparison diagnostics. The moving-packet comparison uses a
+  Bhattacharyya overlap over sum-normalized bond-activity and absolute
+  bond-energy profiles together with a centroid separation, evaluated over the
+  full support at the declared finite time samples. Removed the unsupported
+  thresholded-support characterization (the runner applies no support threshold)
+  and dropped `thresholds` from the supplied-parameter inventory of the dense
+  and one-particle models. Added a `METHODOLOGY-CONSISTENCY` runner check that
+  binds this prose to the `overlap` and `centroid` implementations, so the gate
+  fails if either the prose or those helpers drift. No numerical result changed:
+  the bound, stationary-witness, and finite-toy values are byte-identical.
+  Status authority: independent audit lane only. This repair sets no
+  `audit_status`, `effective_status`, ledger tag, or retained status.

--- a/logs/runner-cache/activity_energy_bound_witnesses_2026_07_08.txt
+++ b/logs/runner-cache/activity_energy_bound_witnesses_2026_07_08.txt
@@ -1,14 +1,15 @@
 ===== runner cache v1 =====
 runner: scripts/activity_energy_bound_witnesses_2026_07_08.py
-runner_sha256: a84f6a7e2a8e80234abbe4ade8b9b39e1c7244846594239468d829a8b6d15a8d
+runner_sha256: f91246325209109045acd6a95190426c2f10b97ca124438630bbdae07f4dd3c3
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.73
+elapsed_sec: 0.34
 status: ok
 ----- stdout -----
 BOUND: pass=True samples=40 max_activity_over_bound=0.546505 bound=2.2
 STATIONARY-WITNESS: pass=True activity=1.683e-17 touching-term-energy=-0.763742
 FINITE-TOY-WITNESSES: pass=True far_initial_activity=0.000e+00 overlaps=[0.986106, 0.863355, 0.942353, 0.921557] centroid_deltas=[1e-06, 1.106935, 0.071278, 0.234031]
+METHODOLOGY-CONSISTENCY: pass=True names_diagnostics=True lacks_withdrawn=True overlap_bc=True centroid_mean=True
 TOTAL: BOUNDED-TOY-SUPPORT-VALIDATED AO-bridge=supplied-premise finite-window-only
 
 ----- stderr -----

--- a/scripts/activity_energy_bound_witnesses_2026_07_08.py
+++ b/scripts/activity_energy_bound_witnesses_2026_07_08.py
@@ -16,10 +16,18 @@ from __future__ import annotations
 import math
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 import numpy as np
 import scipy.linalg as sla
 
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NOTE_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "ACTIVITY_ENERGY_BOUND_WITNESSES_BOUNDED_NOTE_2026-07-08.md"
+)
 
 RNG_SEED = 20260708
 BOUND_TOL = 1.0e-12
@@ -220,11 +228,61 @@ def check_empty_and_packet() -> tuple[bool, float, list[float], list[float]]:
     return ok, far_initial, overlaps, centroid_deltas
 
 
+def check_note_methodology_consistency() -> tuple[bool, str]:
+    """Bind the paired note's profile-comparison prose to what the runner computes.
+
+    The note must name the runner's real diagnostics -- a Bhattacharyya overlap
+    over sum-normalized profiles and a centroid separation evaluated over the full
+    support -- and must not carry the withdrawn thresholded-support
+    characterization. The `overlap`/`centroid` helpers are probed to confirm they
+    genuinely have the normalized-profile behavior the note claims, so the gate
+    fails if either the prose or the implementation drifts.
+    """
+    if not NOTE_PATH.exists():
+        return False, "note-missing"
+    flat = " ".join(NOTE_PATH.read_text(encoding="utf-8").split())
+
+    required_present = (
+        "Bhattacharyya coefficient over sum-normalized",
+        "centroid separation",
+        "over their full support",
+    )
+    required_absent = (
+        "thresholded supports",
+        "mass, thresholds,",
+    )
+    names_diagnostics = all(phrase in flat for phrase in required_present)
+    lacks_withdrawn = all(phrase not in flat for phrase in required_absent)
+
+    probe_a = np.array([0.2, 0.5, 0.3, 0.1], dtype=np.float64)
+    probe_b = np.array([0.1, 0.4, 0.4, 0.6], dtype=np.float64)
+    self_overlap = overlap(probe_a, probe_a)
+    scale_gap_overlap = abs(overlap(3.0 * probe_a, probe_b) - overlap(probe_a, probe_b))
+    scale_gap_centroid = abs(centroid(5.0 * probe_a) - centroid(probe_a))
+    overlap_is_bhattacharyya = (
+        abs(self_overlap - 1.0) <= 1.0e-12 and scale_gap_overlap <= 1.0e-12
+    )
+    centroid_is_normalized_mean = scale_gap_centroid <= 1.0e-12
+
+    ok = (
+        names_diagnostics
+        and lacks_withdrawn
+        and overlap_is_bhattacharyya
+        and centroid_is_normalized_mean
+    )
+    detail = (
+        f"names_diagnostics={names_diagnostics} lacks_withdrawn={lacks_withdrawn} "
+        f"overlap_bc={overlap_is_bhattacharyya} centroid_mean={centroid_is_normalized_mean}"
+    )
+    return ok, detail
+
+
 def run() -> tuple[list[str], int]:
     bound_ok, max_ratio, bound = check_bound()
     stationary_ok, stationary_activity, local_energy = check_stationary_witness()
     toy_ok, far_initial, overlaps, centroid_deltas = check_empty_and_packet()
-    passed = bound_ok and stationary_ok and toy_ok
+    method_ok, method_detail = check_note_methodology_consistency()
+    passed = bound_ok and stationary_ok and toy_ok and method_ok
 
     lines = [
         (
@@ -240,6 +298,7 @@ def run() -> tuple[list[str], int]:
             f"overlaps={[round(value, 6) for value in overlaps]} "
             f"centroid_deltas={[round(value, 6) for value in centroid_deltas]}"
         ),
+        f"METHODOLOGY-CONSISTENCY: pass={method_ok} {method_detail}",
         (
             "TOTAL: BOUNDED-TOY-SUPPORT-VALIDATED "
             "AO-bridge=supplied-premise finite-window-only"


### PR DESCRIPTION
## What this responds to

Audit verdict on row `activity_energy_bound_witnesses_bounded_note_2026-07-08`
(`audited_conditional`, `runner_artifact_issue`), verbatim:

> remove the unsupported thresholded-support characterization, or add an
> explicit thresholded-support computation and refreshed cached output, then
> re-audit.

The row's `claim_scope` characterizes the diagnostics as *"including the note's
thresholded-support characterization"*, but the paired runner
(`scripts/activity_energy_bound_witnesses_2026_07_08.py`) applies **no support
threshold**. Its profile comparisons are a Bhattacharyya `overlap` over
sum-normalized bond-activity/bond-energy profiles and a `centroid` separation,
both evaluated over the full support. The note's "thresholded supports" prose
described a computation the runner never performs.

## Branch taken: remove (Branch 1 of the verdict)

Branch 2 (add a threshold computation) would change the runner's overlap/centroid
numbers and advances no physics — "thresholded support" is surplus prose, not a
science target. So this PR removes it and pins the corrected prose to the code.

## Changes (source-only triple)

1. **`docs/ACTIVITY_ENERGY_BOUND_WITNESSES_BOUNDED_NOTE_2026-07-08.md`**
   - Boundaries: replace the "absolute apportioned energy expectations,
     thresholded supports" characterization with the runner's actual method —
     "normalized-profile overlap (a Bhattacharyya coefficient over sum-normalized
     bond-activity and absolute bond-energy profiles) and centroid separation,
     evaluated over their full support at finite time samples."
   - Boundaries: drop `thresholds` from the supplied-parameter inventory of the
     dense and one-particle models.
   - Add a dated `## Repair Log` entry recording the withdrawal, carrying the
     status-authority disclaimer.
2. **`scripts/activity_energy_bound_witnesses_2026_07_08.py`**
   - Add `check_note_methodology_consistency()`: a discriminating note↔runner
     gate. It (a) requires the corrected diagnostic phrases present and the
     withdrawn phrases absent in the note, and (b) probes the `overlap`/`centroid`
     helpers to confirm they genuinely have the normalized-profile behavior the
     note claims (self-overlap = 1, scale-invariance). Wired into `run()` and a
     new `METHODOLOGY-CONSISTENCY:` output line.
3. **`logs/runner-cache/activity_energy_bound_witnesses_2026_07_08.txt`**
   - Regenerated; new `runner_sha256: f91246...`, `exit_code: 0`.

## No physics change

All prior numbers byte-identical:
`BOUND: pass=True samples=40 max_activity_over_bound=0.546505 bound=2.2`;
`STATIONARY-WITNESS: pass=True activity=1.683e-17 touching-term-energy=-0.763742`;
`FINITE-TOY-WITNESSES: pass=True far_initial_activity=0.000e+00 overlaps=[0.986106, 0.863355, 0.942353, 0.921557] centroid_deltas=[1e-06, 1.106935, 0.071278, 0.234031]`;
`TOTAL: BOUNDED-TOY-SUPPORT-VALIDATED AO-bridge=supplied-premise finite-window-only`.
New line: `METHODOLOGY-CONSISTENCY: pass=True names_diagnostics=True lacks_withdrawn=True overlap_bc=True centroid_mean=True`.

The gate is verified discriminating: reverting the bullet-2 prose, reintroducing
"mass, thresholds,", or dropping "over their full support" each flips it to FAIL;
the numeric probes stay bound to the helper behavior.

## Audit mechanics

Editing the note and runner drifts the row's `note_hash`, so the row requeues
`unaudited` for the independent audit lane. **No `audit_status`,
`effective_status`, ledger tag, or retained status is asserted anywhere in this
PR** — status authority is the independent audit lane only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
