### PR TITLE
audit-infra: preserve schema retry after locator repair rejection

### DIFF
--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -8112,6 +8112,26 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         self.assertNotIn("prior_secret", prompt)
         self.assertIn("not given its JSON or conclusion", prompt)
 
+    def test_failed_locator_repair_preserves_fresh_schema_eligibility(self):
+        m = _import_codex_audit_runner()
+        initial = "N1 route 1.outcome is not evidenced at evidence_path"
+        preservation = "validation repair changed preserved no-go judgment content"
+        self.assertEqual(
+            m.fresh_schema_retry_error(preservation, initial),
+            initial,
+        )
+        self.assertEqual(
+            m.fresh_schema_retry_error("N3 scan is incomplete", initial),
+            "N3 scan is incomplete",
+        )
+        self.assertEqual(
+            m.fresh_schema_retry_error("claim_id mismatch", None),
+            "claim_id mismatch",
+        )
+        self.assertIsNone(
+            m.fresh_schema_retry_error(None, initial),
+        )
+
     def test_oversized_validation_repair_is_detected_before_transport(self):
         m = _import_codex_audit_runner()
         original = "p" * (m.CODEX_INPUT_CHAR_LIMIT - 100)

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1571,6 +1571,26 @@ def fresh_schema_retry_code(validation_error: str) -> str:
     return "AUDIT_SCHEMA_REJECT"
 
 
+def fresh_schema_retry_error(
+    current_error: str | None,
+    initial_validation_error: str | None,
+) -> str | None:
+    """Keep a structured reject eligible after a failed locator repair.
+
+    Locator repair cannot change N1-N8 judgment content. A repair that
+    violates that rule, fails parsing, or fails operationally must not erase
+    the original structured validator reject and suppress the independent
+    fresh-schema retry.
+    """
+    if current_error is None:
+        return None
+    if fresh_schema_retry_eligible(current_error):
+        return current_error
+    if fresh_schema_retry_eligible(initial_validation_error):
+        return initial_validation_error
+    return current_error
+
+
 def render_fresh_schema_retry_prompt(
     original_prompt: str,
     validation_code: str,
@@ -2316,6 +2336,7 @@ def main() -> int:
                         )
                         break
                 elapsed += repair_elapsed
+            err = fresh_schema_retry_error(err, initial_validation_error)
             schema_retry_compute_required: str | None = None
             if (
                 err


### PR DESCRIPTION
Summary: preserve the original structured N1-N8 validator error when a locator-limited repair fails with a non-structured preservation, parse, or operational error; keep successful locator repair terminal; add regression coverage for success and failure paths. Verification: 273 audit-pipeline unit tests pass; the full audit pipeline and strict lint pass with no errors in a detached verification worktree. Independent review-loop judgment is requested separately. This PR changes no audit verdict.