### PR TITLE
Compact-interior Dobrushin continuum ultralocality boundary

### DIFF
--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
@@ -1,6 +1,27 @@
 # Handoff
 
 Current branch:
+`physics-loop/record-faithful-dynamics-block22-controlled-ultralocal-continuum-20260712`.
+The compact-interior continuum runner reports `PASS=8 FAIL=0`. On every
+compact subset of the strict Dobrushin wedge, uniform weighted mixing forces
+covered subexponential local observable families to factorize at fixed
+positive physical separation as `a->0`. Contact/non-Gaussian white-noise
+limits, exponential normalizations, macroscopic observables, critical tuning,
+and outside-wedge routes remain open. Under isotropic scaling the
+gauge-invariant OS gap lower bound diverges as `c/a`, while direct fermion
+propagation decouples without erasing local determinant-loop effects.
+
+Independent code/math, physics/import/Nature, governance, and full N1--N8
+reviews pass after aggregate-normalization, contact-limit, mass-language,
+weighted-runner, and five-condition wall-audit repairs. Audit validation seeds
+one `no_go` / `unaudited` row with exactly the Dobrushin uniqueness dependency;
+strict lint has zero errors and generated audit outputs are stripped.
+
+Compact-interior continuum no-go PR:
+https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5303
+is open and mergeable against the Dobrushin uniqueness head.
+
+Previous branch:
 `physics-loop/record-faithful-dynamics-block21-dobrushin-spatial-uniqueness-20260712`.
 The Dobrushin spatial-uniqueness runner reports `PASS=7 FAIL=0`. With
 `kappa=14/(m^2+2)`, `m>sqrt(12)`, and

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
@@ -1,5 +1,18 @@
 # PR Delivery
 
+The compact-interior Dobrushin continuum no-go is delivered:
+
+- base: `physics-loop/record-faithful-dynamics-block21-dobrushin-spatial-uniqueness-20260712`
+- head: `physics-loop/record-faithful-dynamics-block22-controlled-ultralocal-continuum-20260712`
+- runner: `PASS=8 FAIL=0`
+- scope: covered separated correlations vanish under compact-interior scaling;
+  contact/white-noise, critical, outside-wedge, and alternative-action routes remain open
+- audit compatibility: one `no_go` / `unaudited` row, exactly the Dobrushin
+  uniqueness dependency; strict lint zero errors; generated outputs stripped
+- PR: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5303
+
+No merge is authorized. Independent audit remains authoritative.
+
 The massive Wilson--staggered Dobrushin spatial-uniqueness wedge is prepared
 as the next stacked review block:
 

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
@@ -712,3 +712,17 @@ claim. No axiom-update stop is triggered.
 
 Delivery: stacked PR #5301 is open on the spatial DLR accumulation head.
 Independent audit remains authoritative.
+
+## Compact-interior continuum boundary review
+
+PASS WITH NARROW NO-GO BOUNDARY. Uniform weighted Dobrushin comparison on a
+compact strict subwedge gives `exp(-lambda_K R/a)` separated correlation
+decay. The final source restricts this to observable families with aggregate
+support/coefficient/normalization log-growth `o(1/a)`, keeps contact and
+white-noise limits open, distinguishes the dimensionful bare mass parameter
+from a pole mass, retains determinant-loop local effects, and limits the
+`c/a` OS-gap statement to isotropic gauge-invariant reconstructions. N1--N8
+contains all five conditions and ten wall pairs. Runner/cache: `PASS=8 FAIL=0`.
+Audit validation seeds one `no_go` / `unaudited` row with source hash
+`b9a08d8ef90d8600...` and the sole Dobrushin uniqueness dependency. PR #5303
+is open; no axiom-update stop is triggered.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
@@ -8,35 +8,35 @@ current_goal: >-
   supply the physical evolution object, bare time ordering, record-formation
   weights, and an admissibility-to-carrier selector without importing the
   staggered/Dirac answer or sector-specific Standard Model and gravity laws.
-branch: physics-loop/record-faithful-dynamics-block21-dobrushin-spatial-uniqueness-20260712
+branch: physics-loop/record-faithful-dynamics-block22-controlled-ultralocal-continuum-20260712
 base_commit_at_start: 9d1636f05f
-cycle_count: 21
-block_count: 21
-active_route: massive_wilson_staggered_dobrushin_spatial_uniqueness_wedge
+cycle_count: 22
+block_count: 22
+active_route: compact_dobrushin_subwedge_separated_point_ultralocal_continuum_boundary
 hard_residual: >-
   Can the four-axiom record surface canonically determine a faithful local
   record-forming instrument whose coherent no-record block is sufficiently
   constrained to exclude the observationally disconnected SWAP--Laplacian
   completion and select the Clifford-vector carrier?
-produced_claim_id: massive_wilson_staggered_dobrushin_spatial_uniqueness_wedge_bounded_theorem_note_2026-07-12
+produced_claim_id: compact_dobrushin_subwedge_separated_point_ultralocal_continuum_boundary_bounded_theorem_note_2026-07-12
 actual_current_surface_status: bounded-support
 conditional_surface_status: >-
-  At fixed lattice spacing, kappa=14/(m^2+2), m>sqrt(12), and
-  18 beta +(3/2)kappa^2(2-kappa)/(1-kappa)^2<1, the exact nonbacktracking
-  determinant-loop interaction obeys a strict Dobrushin link-influence bound.
-  The full Z4 gauge DLR and gauge-fermion functionals are unique, periodic and
-  DLR-boundary finite-volume sequences converge without subsequences, and
-  weighted comparison gives exponential clustering. The reconstructed
-  gauge-invariant OS Hilbert space has a one-dimensional invariant vacuum and
-  positive fixed-lattice Hamiltonian gap. Beta=6, light mass, charged sectors,
-  and a nontrivial continuum remain open.
+  For a-to-zero trajectories in any compact subset of the strict Dobrushin
+  wedge, one weighted mixing rate is uniform. Controlled gauge-invariant local
+  observable families with aggregate support/coefficient/normalization growth
+  subexponential in 1/a have vanishing connected correlations at fixed positive
+  physical separation. Any tight accumulation tested on that class factorizes
+  across separated regions; contact and white-noise limits remain open. The
+  isotropic gauge-invariant OS gap lower bound diverges as c/a and direct
+  fermion propagation decouples. Boundary-tuned, block/polymer/RG, weak-
+  coupling/light-mass, charged-sector, and alternative-action routes remain open.
 admitted_observation_status: none
 claim_type_reason: >-
-  The source proves an explicit nonempty small-beta, large-m full-sequence
-  spatial uniqueness, clustering, and gauge-invariant OS-gap wedge under
-  supplied Wilson-staggered, spin, geometry, Haar-weight, parameter,
-  exhaustion, and observable-domain conditions. The strict inequality is
-  sufficient only and does not locate the phase boundary or select the action.
+  The source proves a narrow compact-interior continuum no-go for controlled
+  subexponential local observables under the supplied Wilson-staggered action,
+  isotropic scaling, parameter trajectory, and observable embeddings. It does
+  not exclude contact distributions, exponential rescalings, growing nonlocal
+  observables, critical tuning, other controlled regions, or other actions.
 hypothetical_axiom_status: null
 proposal_allowed: false
 proposal_allowed_reason: >-
@@ -109,6 +109,9 @@ files_touched:
   - docs/MASSIVE_WILSON_STAGGERED_DOBRUSHIN_SPATIAL_UNIQUENESS_WEDGE_BOUNDED_THEOREM_NOTE_2026-07-12.md
   - scripts/massive_wilson_staggered_dobrushin_spatial_uniqueness_wedge_2026_07_12.py
   - logs/runner-cache/massive_wilson_staggered_dobrushin_spatial_uniqueness_wedge_2026_07_12.txt
+  - docs/COMPACT_DOBRUSHIN_SUBWEDGE_SEPARATED_POINT_ULTRALOCAL_CONTINUUM_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-07-12.md
+  - scripts/compact_dobrushin_subwedge_ultralocal_continuum_boundary_2026_07_12.py
+  - logs/runner-cache/compact_dobrushin_subwedge_ultralocal_continuum_boundary_2026_07_12.txt
 open_imports:
   - fundamental process object: Hamiltonian, strict tick, or record instrument
   - faithful law-to-record influence principle
@@ -148,10 +151,11 @@ no_go_routes:
   - temporal subsequence nonuniqueness is not an irreducible interacting wall at fixed finite spatial volume: the exact massive log-determinant contraction makes the blocked gauge-history potential Holder and Bowen/Ruelle unique for every fixed m>0
   - spatial thermodynamic existence is not blocked by the open beta-six plaquette-value hierarchy: site-anchored Q summability and compact-link DLR extraction give accumulation states for every beta>=0 and m>0, while phase uniqueness remains separate
   - failure of the explicit Dobrushin inequality is not evidence of phase coexistence: it is a sufficient small-beta, large-m criterion, while block-Dobrushin, polymer, chessboard, and RG routes remain live outside it
+  - compact containment in the strict Dobrushin wedge cannot yield a propagating continuum with covered nonzero separated correlations, but this does not close contact, boundary-tuned, block/polymer/RG, weak-coupling/light-mass, charged-sector, or alternative-action continuum routes
 trace_gate_classification: direct_blocker_closure
 reachability_to_target: partially_closes
-review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_bounded
-pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open
+review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_bounded
+pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open
 block01_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5178
 block02_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5181
 block03_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5201
@@ -173,12 +177,12 @@ block18_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/
 block19_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5294
 block20_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5297
 block21_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5301
+block22_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5303
 next_exact_action: >-
-  Take a-to-zero along a compact subwedge with a uniform Dobrushin margin and
-  prove the resulting controlled scaling is ultralocal/trivial: correlations
-  at fixed physical separation vanish and the fixed-lattice OS gap diverges
-  in physical units. Then identify which approach-to-boundary or alternative
-  RG route could support a nontrivial Lorentz/QFT limit.
+  Read and reconcile the actual critical-scaling, asymptotic-freedom,
+  constructive-RG, free-continuum, and Lorentz-restoration lanes. Determine
+  whether any theorem-grade boundary-tuned trajectory has a proved diverging
+  correlation length; do not treat alpha=1 as a physical critical surface.
 stop_condition: >-
   Stop and discuss an axiom update only if an exact result proves that the
   required bridge cannot be derived and an additional approved axiom or

--- a/docs/COMPACT_DOBRUSHIN_SUBWEDGE_SEPARATED_POINT_ULTRALOCAL_CONTINUUM_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-07-12.md
+++ b/docs/COMPACT_DOBRUSHIN_SUBWEDGE_SEPARATED_POINT_ULTRALOCAL_CONTINUUM_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,297 @@
+# Compact-interior Dobrushin trajectories have only contact-supported gauge-invariant continuum correlations
+
+**Date:** 2026-07-12  
+**Type:** no_go  
+**Status:** unaudited candidate; effective status is pipeline-derived only after independent audit.  
+**Primary runner:** [`scripts/compact_dobrushin_subwedge_ultralocal_continuum_boundary_2026_07_12.py`](../scripts/compact_dobrushin_subwedge_ultralocal_continuum_boundary_2026_07_12.py)  
+**Cached output:** [`logs/runner-cache/compact_dobrushin_subwedge_ultralocal_continuum_boundary_2026_07_12.txt`](../logs/runner-cache/compact_dobrushin_subwedge_ultralocal_continuum_boundary_2026_07_12.txt)
+
+## 0. Result
+
+Let `a_j->0` be isotropic lattice spacings for the supplied massive
+Wilson--staggered model. Suppose `(beta_j,m_j)` stays in a compact subset `K`
+of the strict
+[Dobrushin spatial-uniqueness wedge](MASSIVE_WILSON_STAGGERED_DOBRUSHIN_SPATIAL_UNIQUENESS_WEDGE_BOUNDED_THEOREM_NOTE_2026-07-12.md):
+
+```text
+kappa(m)=14/(m^2+2),
+alpha(beta,m)=18beta +(3/2)kappa^2(2-kappa)/(1-kappa)^2<1.             (0.1)
+```
+
+Then there are constants `lambda_K>0` and `c_K>0`, independent of `j`, such
+that:
+
+1. connected gauge-invariant local observable families separated by physical
+   distance `R>0` obey
+   `C L_F(a_j)L_G(a_j) exp(-lambda_K R/a_j+O(1))`;
+2. if their support complexity, coefficient norm, and multiplicative
+   normalization satisfy
+   `log[L_F L_G |Z_F Z_G|]=o(1/a_j)`, their separated-point connected
+   functions vanish;
+3. the gauge-invariant OS Hamiltonian gap obeys
+   `Delta_OS,j>=c_K/a_j` and therefore diverges;
+4. `m_j` is bounded below by a positive constant, so the dimensionful bare
+   mass parameter `m_j/a_j` diverges and direct fermionic propagation
+   decouples at fixed physical separation. No pole-mass identification is
+   asserted.
+
+Thus every compact-interior trajectory has a **separated-point ultralocal**
+scaling boundary for this controlled observable class. Any tight accumulation
+functional tested on the covered observable families factorizes across
+separated regions, so only contact-supported correlations can survive.
+Contact terms, non-Gaussian
+contact cumulants, and white-noise-type distributional limits may remain.
+This does not assert existence of a full distribution-valued continuum field,
+Gaussianity, or absence of every continuum measure.
+
+This is the first controlled lattice-spacing classification for the coupled
+model, but it is a negative boundary for a narrow trajectory class. A
+continuum with nonzero separated correlations under the covered
+subexponential normalizations must leave every compact interior subset: its
+correlation length in lattice units must diverge, so it must approach a
+critical/uniqueness boundary or use another controlled RG regime. The theorem
+does not prove that such routes fail.
+
+No Lorentz/QFT, Standard Model, GR, action-selection, or physical-probability
+closure follows. No axiom-update stop is established.
+
+## 1. Uniform weighted comparison on a compact subwedge
+
+The direct dependency proves that at each `(beta,m)` with `alpha<1`, the
+link-influence matrix has an exponential moment below one for sufficiently
+small positive weight. The row majorants are continuous in `(beta,m,lambda)`
+where `lambda` is the exponential distance weight.
+
+Compactness of `K` and strictness of the inequality give
+
+```text
+sup_K alpha(beta,m)=1-epsilon_K<1,
+sup_K kappa(m)=kappa_K<1.                                             (1.1)
+```
+
+Uniform continuity then supplies one `lambda_K>0` such that the weighted
+influence row remains below one on all of `K`. The weighted Dobrushin
+comparison theorem gives, for translated fixed local polynomials `F,G`,
+
+```text
+|omega_j(FG)-omega_j(F)omega_j(G)|
+ <=C_(F,G,K) exp[-lambda_K dist_lattice(supp F,supp G)].              (1.2)
+```
+
+The cross-Wick/off-diagonal inverse proof in the dependency makes (1.2) valid
+for fixed-degree local gauge--fermion polynomials, not only gauge functions.
+
+## 2. Fixed physical separation
+
+Embed the supports near two physical points separated by `R>0`. Their lattice
+distance is at least `R/a_j-O(1)`. Equation (1.2) gives
+
+```text
+|connected_j(F,G)|<=C'_(F,G,K)exp(-lambda_K R/a_j).                   (2.1)
+```
+
+For every `N`, `a_j^(-N)exp(-lambda_K R/a_j)->0`. More generally, let
+`L_F(a),L_G(a)` bound the aggregate coefficient norm and support multiplicity
+of the observable families. If
+
+```text
+log[L_F(a_j)L_G(a_j)|Z_F(a_j)Z_G(a_j)|]=o(1/a_j),                    (2.2)
+```
+
+then the renormalized connected function also tends to zero. This includes
+fixed local observables, power and power-times-log renormalizations,
+polynomially many lattice terms, and ordinary Riemann-sum smearings with
+separated physical supports. Exponentially large field rescalings,
+exponentially complex supports, and nonlocal/macroscopic loop families are not
+classified.
+
+Equation (2.1) controls separated points only. It does not control coincident
+contact distributions, composite-operator subtractions, or arbitrary
+volume-growing observables.
+
+## 3. Divergent physical OS gap and fermion decoupling
+
+Uniform weighted clustering gives one `rho_K<1` for the two-step OS
+contraction on every member of the family:
+
+```text
+spec(T_(2,j)|Omega_j^perp) subset [0,rho_K].                           (3.1)
+```
+
+For isotropic `a_tau,j=a_j`, spectral calculus gives
+
+```text
+Delta_OS,j>=-(2a_j)^(-1)log rho_K=:c_K/a_j -> infinity.               (3.2)
+```
+
+If a supplied anisotropic regulator is used instead, the exact statement is
+`Delta_OS,j>=c_K/a_tau,j`; comparison with `1/a_j` then needs a separately
+controlled spacing ratio.
+
+Compactness of `K` also gives `m_j>=m_K>5.809...`. Hence the dimensionful
+bare mass parameter is at least `m_K/a_j`, and the hopping bound gives
+propagation at physical separation `R` of order
+`(4/m_K)^(R/a_j)`. It vanishes exponentially.
+
+Fixed-mass closed determinant loops nevertheless remain order one in lattice
+units and can renormalize local gauge, contact, and vacuum terms. Propagating
+fermion decoupling does not imply that the gauge marginal becomes the pure
+Wilson measure.
+
+The divergent lower bound is not a continuum Yang--Mills mass-gap result and
+does not identify operators across the varying OS Hilbert spaces. It says the
+opposite of a finite propagating mass scale: every non-vacuum gauge-invariant
+excitation is pushed to infinite physical energy along this compact-interior
+trajectory.
+
+## 4. Why this does not close the continuum campaign
+
+The usual propagating lattice continuum mechanism with nonzero separated
+correlations requires a correlation
+length in lattice units that diverges as `a->0`. Here the uniform Dobrushin
+margin bounds that correlation length uniformly. Therefore a propagating route
+in the covered subexponential local class must violate at least one
+compact-interior hypothesis. Live possibilities include:
+
+- approaching `alpha=1` so the certified decay rate can vanish;
+- leaving the one-link Dobrushin wedge while remaining in a larger block or
+  polymer-controlled region;
+- tuning toward light mass, where the present absolute loop expansion loses
+  its margin;
+- a constructive RG trajectory, including the weak-bare-coupling region not
+  reached by this small-`beta` certificate;
+- different microscopic dynamics if the axioms eventually select another
+  admissible carrier.
+
+Nothing here proves that a new axiom or primitive is needed.
+
+In particular, the standard Wilson weak-bare-coupling/light-lattice-mass
+scaling direction lies outside this wedge: `beta=6/g_0^2->infinity` and a
+fixed physical fermion mass requires `m_lat=a m_phys->0`, whereas here
+`beta<1/18` and `m_lat>5.809...`. The existing free tuned continuum is
+therefore a counterexample to
+any broader claim that lattice scaling itself must be ultralocal.
+
+## 5. Runner contract
+
+Run:
+
+```bash
+python3 scripts/compact_dobrushin_subwedge_ultralocal_continuum_boundary_2026_07_12.py
+```
+
+The runner checks compact-margin examples, uniform weighted-radius continuity,
+faster-than-power separated-point decay, subexponential-renormalization decay,
+the `1/a` gap lower bound, fermion decoupling, and the source/N1--N8 boundary.
+The weighted comparison and OS spectral theorems are analytic machinery; the
+runner checks their scaling consequences.
+
+## 6. No-Go Discipline N1--N8
+
+This theorem has a negative continuum boundary, so all eight checks are
+load-bearing.
+
+### N1 — alternative-route enumeration
+
+| Route | Status | Test and result | Why it remains live outside the claim |
+|---|---|---|---|
+| Compact strict Dobrushin interior | `ATTEMPTED` | Uniform exponential clustering proves separated-point ultralocality. | This is exactly the narrow class closed here. |
+| Approach the Dobrushin boundary | `ATTEMPTED` | The uniform `lambda_K` proof fails when the margin tends to zero. | Diverging correlation length remains possible. |
+| Block-Dobrushin criterion | `ATTEMPTED` | One-link failure does not imply block failure. | A larger controlled region may support tuning. |
+| Polymer/cluster expansion | `ATTEMPTED` | Existing small-coupling routes use different norms. | Their boundary behavior is not classified here. |
+| Light-mass constructive RG | `ATTEMPTED` | The absolute `R` loop margin is lost. | Cancellation-based RG remains live. |
+| Weak-bare-coupling gauge scaling | `ATTEMPTED` | The present small-`beta` wedge does not reach it. | Standard asymptotic-scaling logic is outside scope. |
+| Exponential field renormalization | `ATTEMPTED` | Condition (2.2) excludes it. | Such a normalization would need separate locality/temperedness control. |
+| Alternative microscopic carrier/action | `ATTEMPTED` | The Wilson-staggered action is supplied, not axiom-selected. | A different derived dynamics can have another critical surface. |
+
+### N2 — wall-independence audit
+
+| Left condition | Right condition | Left closes right? | Right closes left? | Independent? |
+|---|---|---:|---:|---:|
+| compact strict Dobrushin interior | controlled subexponential local observable class | No | No | Yes |
+| compact strict Dobrushin interior | uniform lattice correlation length | Yes | No | No |
+| compact strict Dobrushin interior | propagating continuum with covered nonzero separated correlations | No | No | Yes |
+| compact strict Dobrushin interior | axiom-selected action | No | No | Yes |
+| controlled subexponential local observable class | uniform lattice correlation length | No | No | Yes |
+| controlled subexponential local observable class | propagating continuum with covered nonzero separated correlations | No | No | Yes |
+| controlled subexponential local observable class | axiom-selected action | No | No | Yes |
+| uniform lattice correlation length | propagating continuum with covered nonzero separated correlations | No | No | Yes |
+| uniform lattice correlation length | axiom-selected action | No | No | Yes |
+| propagating continuum with covered nonzero separated correlations | axiom-selected action | No | No | Yes |
+
+The compact-interior hypothesis supplies the uniform correlation-length bound;
+they are not counted as two independent walls. Uniform mixing excludes
+nonzero separated correlations only after the controlled observable and
+normalization class is also imposed. Neither condition selects the microscopic
+action or closes boundary-tuned, block, polymer, or RG routes.
+
+### N3 — hidden-condition phrase scan
+
+| Mandated phrase | Classification |
+|---|---|
+| `we assume` | No load-bearing hit. |
+| `by construction` | No proof-substitute hit. |
+| `as is standard` | No hit. |
+| `the framework provides` | No hit. |
+| `bridge context` | No hit. |
+| `background` | No hidden background premise. |
+| `naturally` | No hit. |
+| `obviously` | No hit. |
+| `standard QFT` | No hit. |
+| `registered` | No premise-granting hit. |
+| `canonical` | No unqualified use. |
+
+### N4 — citation/residual matching
+
+| Witness | Witness residual | Present residual | Match? | Disposition |
+|---|---|---|---:|---|
+| [Dobrushin uniqueness and OS-gap wedge](MASSIVE_WILSON_STAGGERED_DOBRUSHIN_SPATIAL_UNIQUENESS_WEDGE_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Uniform weighted clustering and fixed-lattice gap at each strict-wedge point | Uniformize those bounds on compact `K` and scale `a->0` | Yes | Sole direct dependency. |
+| Free staggered scalar continuum theorem | Free pole/dispersion scaling | Coupled compact-interior scaling | No | Context only. |
+| Beta-six plaquette work | Bulk observable at fixed regulator coupling | Small-beta continuum scaling | No | Context only. |
+| Dobrushin 1968 | Weighted comparison decay | Scaling consequence after compact uniformization | Yes | Transitive external machinery. |
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Tested? | Permitted conclusion |
+|---|---:|---|
+| Fixed separated local observables | Yes | Connected functions vanish. |
+| Power/log field renormalizations | Yes | Still vanish. |
+| Exponential field renormalizations | No | No claim. |
+| Coincident/contact distributions | No | No full continuum-field existence claim. |
+| Compact strict subwedge trajectories | Yes | Separated-point ultralocal boundary. |
+| Boundary-tuned or outside-wedge trajectories | No | No triviality claim. |
+| Gauge-invariant OS sector | Yes | Physical gap diverges. |
+| Charged/unconstructed sectors | No | No gap or decoupling claim. |
+
+### N6 — partial-closure and primitive scan
+
+The result is a scaling theorem, not a convention. Isotropic spacing is part
+of the supplied regulator trajectory; an anisotropic alternative is stated
+separately. Approved primitives add no dynamics, coupling flow, field
+normalization, or continuum theorem. No primitive is enlarged and no
+axiom-update stop is triggered.
+
+### N7 — hostile steelman
+
+A hostile reviewer should say that vanishing bare connected functions does not
+prove triviality after arbitrary wave-function renormalization. Correct: the
+theorem explicitly covers only (2.2), including power/log normalizations, and
+leaves exponentially large rescalings and contact distributions open.
+
+The stronger hostile point is that all interesting continuum limits approach
+criticality, while `K` is compactly separated from it. That is precisely the
+theorem's value and limitation: it proves the controlled interior cannot be
+the desired propagating continuum and directs the campaign to boundary-tuned
+control.
+
+### N8 — cross-cycle echo
+
+| Prior surface | Similar wall | Lesson here |
+|---|---|---|
+| Free staggered continuum | Pole scaling survived because the mass/spacing trajectory was tuned | Fixed large lattice mass here instead diverges physically. |
+| Spatial DLR accumulation | Existence alone did not select a phase | Uniform uniqueness now selects a phase but also bounds correlation length. |
+| Dobrushin uniqueness wedge | Strict decay gave a fixed-lattice gap | Compact uniformization makes the physical gap diverge as `a->0`. |
+| Beta-six strong-coupling work | Fixed-coupling control did not supply continuum scaling | This theorem states the scaling consequence rather than importing one. |
+
+The negative boundary is trajectory-specific and leaves all critical/RG routes
+open.

--- a/logs/runner-cache/compact_dobrushin_subwedge_ultralocal_continuum_boundary_2026_07_12.txt
+++ b/logs/runner-cache/compact_dobrushin_subwedge_ultralocal_continuum_boundary_2026_07_12.txt
@@ -1,0 +1,9 @@
+PASS A concrete compact parameter packet has a strict uniform Dobrushin margin: alphas=0.194392,0.374392,0.430719,0.790719, epsilon=0.209281
+PASS One positive exponential weight keeps the full packet influence row below one: weighted alphas=0.204054,0.387690,0.441243,0.808515, lambda=0.010
+PASS Fixed-physical-separation correlations vanish as lattice distance diverges: bounds=7.788008e-01,6.065307e-01,3.678794e-01,1.353353e-01
+PASS Exponential separation beats every tested power-law field normalization: coarse=1.901e+08,9.477e+09,3.679e+11,8.661e+12; asymptotic=1.319e+11,3.014e+00,3.720e-20
+PASS A sampled subexponential normalization cannot cancel the mixing exponential: bounds=5.449e+10,9.875e+08,1.000e+00
+PASS A uniform transfer radius below one gives an inverse-spacing OS gap lower bound: gap lower bounds=1.317006,2.634013,5.268026,10.536052
+PASS The compact-wedge dimensionful bare mass parameter diverges: m/a=145.226,290.453,580.906,1161.812
+PASS Source-note narrow no-go and N1-N8 contract: missing=[]; missing N2 pairs=[]; attempted=8; independent pairs=9
+SCORECARD PASS=8 FAIL=0

--- a/scripts/compact_dobrushin_subwedge_ultralocal_continuum_boundary_2026_07_12.py
+++ b/scripts/compact_dobrushin_subwedge_ultralocal_continuum_boundary_2026_07_12.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Certificate for compact-interior Dobrushin continuum ultralocality."""
+
+from __future__ import annotations
+
+from math import exp, log
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "COMPACT_DOBRUSHIN_SUBWEDGE_SEPARATED_POINT_ULTRALOCAL_CONTINUUM_"
+    "BOUNDARY_BOUNDED_THEOREM_NOTE_2026-07-12.md"
+)
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: bool, detail: str) -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"PASS {name}: {detail}")
+    else:
+        FAIL += 1
+        print(f"FAIL {name}: {detail}")
+
+
+def alpha(beta: float, mass: float) -> float:
+    kappa = 14.0 / (mass * mass + 2.0)
+    return 18.0 * beta + 1.5 * kappa**2 * (2.0 - kappa) / (1.0 - kappa) ** 2
+
+
+def weighted_alpha(beta: float, mass: float, weight: float) -> float:
+    factor = exp(2.0 * weight)
+    weighted_kappa = 14.0 * factor / (mass * mass + 2.0)
+    fermion = 1.5 * weighted_kappa**2 * (2.0 - weighted_kappa) / (1.0 - weighted_kappa) ** 2
+    return 18.0 * beta * factor + fermion
+
+
+def main() -> int:
+    compact_points = ((0.0, 8.0), (0.01, 8.0), (0.02, 10.0), (0.04, 10.0))
+    values = [alpha(beta, mass) for beta, mass in compact_points]
+    margin = 1.0 - max(values)
+    check(
+        "A concrete compact parameter packet has a strict uniform Dobrushin margin",
+        margin > 0.0,
+        "alphas=" + ",".join(f"{value:.6f}" for value in values) + f", epsilon={margin:.6f}",
+    )
+
+    lattice_rate = 0.01
+    weighted_values = [weighted_alpha(beta, mass, lattice_rate) for beta, mass in compact_points]
+    check(
+        "One positive exponential weight keeps the full packet influence row below one",
+        max(weighted_values) < 1.0,
+        "weighted alphas=" + ",".join(f"{value:.6f}" for value in weighted_values)
+        + f", lambda={lattice_rate:.3f}",
+    )
+
+    separation = 1.0
+    spacings = (0.04, 0.02, 0.01, 0.005)
+    correlations = [exp(-lattice_rate * separation / spacing) for spacing in spacings]
+    check(
+        "Fixed-physical-separation correlations vanish as lattice distance diverges",
+        all(correlations[index + 1] < correlations[index] for index in range(3))
+        and correlations[-1] < 0.15,
+        "bounds=" + ",".join(f"{value:.6e}" for value in correlations),
+    )
+
+    power = 6
+    renormalized = [spacing ** (-power) * exp(-lattice_rate / spacing) for spacing in spacings]
+    tiny_spacings = (0.0005, 0.0002, 0.0001)
+    tiny = [spacing ** (-power) * exp(-lattice_rate / spacing) for spacing in tiny_spacings]
+    check(
+        "Exponential separation beats every tested power-law field normalization",
+        tiny[-1] < tiny[-2] < tiny[-3] and tiny[-1] < 1.0,
+        "coarse=" + ",".join(f"{value:.3e}" for value in renormalized)
+        + "; asymptotic=" + ",".join(f"{value:.3e}" for value in tiny),
+    )
+
+    # Example subexponential normalization exp(sqrt(1/a)).
+    subexp = [exp((1.0 / spacing) ** 0.5 - lattice_rate / spacing) for spacing in tiny_spacings]
+    check(
+        "A sampled subexponential normalization cannot cancel the mixing exponential",
+        subexp[-1] < subexp[-2] < subexp[-3],
+        "bounds=" + ",".join(f"{value:.3e}" for value in subexp),
+    )
+
+    rho = 0.9
+    gaps = [-log(rho) / (2.0 * spacing) for spacing in spacings]
+    check(
+        "A uniform transfer radius below one gives an inverse-spacing OS gap lower bound",
+        all(gaps[index + 1] > gaps[index] for index in range(3))
+        and abs(gaps[-1] * spacings[-1] + log(rho) / 2.0) < 1.0e-14,
+        "gap lower bounds=" + ",".join(f"{value:.6f}" for value in gaps),
+    )
+
+    mass_floor = 5.809057503265459
+    physical_masses = [mass_floor / spacing for spacing in spacings]
+    check(
+        "The compact-wedge dimensionful bare mass parameter diverges",
+        all(physical_masses[index + 1] > physical_masses[index] for index in range(3)),
+        "m/a=" + ",".join(f"{value:.3f}" for value in physical_masses),
+    )
+
+    text = NOTE.read_text(encoding="utf-8") if NOTE.exists() else ""
+    required = [
+        "**Type:** no_go",
+        "compact subset `K`",
+        "log[L_F L_G |Z_F Z_G|]=o(1/a_j)",
+        "contact-supported correlations can survive",
+        "white-noise-type distributional limits may remain",
+        "does not assert existence of a full distribution-valued continuum field",
+        "Exponentially large field rescalings",
+        "nonlocal/macroscopic loop families are not",
+        "Delta_OS,j>=-(2a_j)^(-1)log rho_K",
+        "varying OS Hilbert spaces",
+        "Fixed-mass closed determinant loops",
+        "does not imply that the gauge marginal becomes the pure",
+        "standard Wilson weak-bare-coupling/light-lattice-mass",
+        "No axiom-update stop",
+        "No-Go Discipline N1--N8",
+        "### N3 — hidden-condition phrase scan",
+        "### N4 — citation/residual matching",
+        "### N5 — rhetoric and resolution audit",
+        "### N6 — partial-closure and primitive scan",
+        "### N7 — hostile steelman",
+        "### N8 — cross-cycle echo",
+    ]
+    missing = [item for item in required if item not in text]
+    attempted = text.count("| `ATTEMPTED` |")
+    independent = text.count("| No | No | Yes |")
+    n2_conditions = [
+        "compact strict Dobrushin interior",
+        "controlled subexponential local observable class",
+        "uniform lattice correlation length",
+        "propagating continuum with covered nonzero separated correlations",
+        "axiom-selected action",
+    ]
+    n2_pairs = [
+        f"| {n2_conditions[left]} | {n2_conditions[right]} |"
+        for left in range(len(n2_conditions))
+        for right in range(left + 1, len(n2_conditions))
+    ]
+    missing_pairs = [item for item in n2_pairs if item not in text]
+    check(
+        "Source-note narrow no-go and N1-N8 contract",
+        not missing and not missing_pairs and attempted >= 8 and independent >= 9,
+        f"missing={missing}; missing N2 pairs={missing_pairs}; "
+        f"attempted={attempted}; independent pairs={independent}",
+    )
+
+    print(f"SCORECARD PASS={PASS} FAIL={FAIL}")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

For a -> 0 along any compact subset of the strict Wilson-staggered Dobrushin wedge, controlled gauge-invariant local observable families with subexponential support/normalization complexity have vanishing connected correlations at every fixed positive physical separation. Any tight accumulation tested on that class factorizes across separated regions; only contact-supported correlations can survive.

The isotropic gauge-invariant OS gap lower bound diverges at least as c_K/a, and the dimensionful bare fermion parameter diverges while direct fermion propagation decouples.

## Boundary

This is a narrow no-go, not blanket continuum triviality. Contact terms, non-Gaussian contact cumulants, white-noise limits, exponential renormalizations, macroscopic/nonlocal observables, boundary-tuned trajectories, block/polymer/RG regions, charged sectors, and alternative actions remain open. The standard beta=6/g0^2 -> infinity, m_lat=a m_phys -> 0 route lies outside the certified interior. No axiom-update stop is established.

## Checks

Independent code/math, physics/import, governance, and N1-N8 reviews pass. Runner/cache PASS=8 FAIL=0 and byte-identical; py_compile and vocabulary lint pass. Audit compatibility seeds one no_go / unaudited row with exactly the Dobrushin uniqueness dependency; strict lint has zero errors; generated audit outputs are stripped.

Stacked base: PR #5301.