### PR TITLE
audit-infra: close two-tier assurance review gaps

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,19 +1,18 @@
 name: audit-lane
 
-# Run the mechanical audit pipeline on PRs that touch audit-relevant files,
-# plus a nightly cron pass on main. Public repo, free Actions minutes, but
-# we tighten triggers anyway because the repo has very high commit volume
-# (hundreds of pushes/day) and noisy workflow history is its own cost.
+# Run the mechanical audit pipeline nightly on main, with a manual trigger for
+# urgent refreshes. Pull requests are reviewed and landed through the
+# repo-native review-loop, which already runs the pipeline and strict lint in a
+# clean current-main worktree and strips generated audit outputs before landing.
 #
 # Drift-catching coverage:
-#   - PRs: advisory warning surface only (no auto-commit, no red failure)
 #   - main: caught within 24 hours by the nightly cron (auto-commits refresh)
 #   - manual: workflow_dispatch for urgent ad-hoc runs
 #
 # We deliberately do NOT trigger on every push to main, because:
 #   (a) the auto-commit-back-to-main creates a feedback loop concern, and
 #   (b) at hundreds of pushes/day the run count would be UI-noise excessive.
-# The nightly cron keeps main refreshed. Review-loop is the pre-merge gate:
+# The nightly cron keeps main refreshed. Review-loop is the landing gate:
 # it must inspect the PR, rebase/salvage against moving main, regenerate the
 # pipeline, and verify caches before landing.
 #
@@ -21,15 +20,6 @@ name: audit-lane
 # the configured independent auditor via apply_audit.py.
 
 on:
-  pull_request:
-    paths:
-      - 'docs/**/*.md'
-      - 'docs/audit/scripts/**'
-      - 'logs/runner-cache/**'
-      - 'scripts/**/*.py'
-      - 'scripts/**/*.sh'
-      - 'docs/audit/templates/audit_workflow.yml'
-      - '.github/workflows/audit.yml'
   schedule:
     - cron: "0 6 * * *"   # nightly 06:00 UTC pass on main
   workflow_dispatch:        # manual ad-hoc
@@ -38,10 +28,8 @@ permissions:
   contents: write          # required for auto-commit on cron runs
 
 concurrency:
-  # PR runs of the same branch supersede each other (only run latest);
-  # cron runs use a different group so they never get cancelled by PRs.
   group: audit-lane-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   audit_pipeline:
@@ -66,50 +54,10 @@ jobs:
             pip install -r requirements.txt
           fi
 
-      - name: Report missing dependency-edge repair candidates (PR only)
-        if: github.event_name == 'pull_request'
-        run: python3 docs/audit/scripts/repair_missing_dependency_edges.py
-
-      - name: Repair missing dependency edges (cron/manual only)
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      - name: Repair missing dependency edges
         run: python3 docs/audit/scripts/repair_missing_dependency_edges.py --apply
 
-      - name: Report runner cache freshness (PR only, advisory)
-        if: github.event_name == 'pull_request'
-        run: |
-          # Every runner under scripts/ must have a SHA-pinned cache at
-          # logs/runner-cache/<stem>.txt whose header sha matches the
-          # current runner. The audit lane consumes this cache; stale
-          # caches mean the auditor sees outdated evidence.
-          #
-          # PRs check ONLY runners changed in this branch vs the base
-          # ref, so an unrelated PR doesn't inherit pre-existing drift
-          # on main. The nightly cron step below catches main-branch
-          # drift separately. (--pr-diff escalates to the full ledger
-          # if a cache-invalidator helper changed.)
-          base="origin/${{ github.base_ref }}"
-          git fetch --no-tags origin "+${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
-          if ! python3 scripts/precompute_audit_runners.py --pr-diff "$base" --check-only; then
-            echo
-            echo "::warning::Runner cache is stale for one or more runners changed in this PR."
-            echo "::warning::This is advisory because main moves continuously; review-loop must regenerate caches before landing."
-            echo "::warning::Local repair command:"
-            echo "::warning::  python3 scripts/precompute_audit_runners.py --pr-diff $base"
-            {
-              echo "### Runner Cache Advisory"
-              echo
-              echo "One or more runner caches changed in this PR are stale."
-              echo
-              echo "This PR check is advisory only because audit/review work keeps \`main\` moving. The landing reviewer must regenerate caches from current \`main\` before pushing."
-              echo
-              echo "\`\`\`bash"
-              echo "python3 scripts/precompute_audit_runners.py --pr-diff $base"
-              echo "\`\`\`"
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Report main-branch cache drift (cron/manual, warning only)
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      - name: Report main-branch cache drift (warning only)
         run: |
           # Full-ledger freshness check on main. Emits a warning if
           # drift exists; the cron's refresh step below will fix it.
@@ -120,94 +68,14 @@ jobs:
       - name: Run audit pipeline
         run: bash docs/audit/scripts/run_pipeline.sh
 
-      - name: Report vocabulary drift (PR only, advisory)
-        if: github.event_name == 'pull_request'
-        run: |
-          # vocab_lint reads docs/repo/controlled_vocabulary.yaml and flags
-          # routine local drift plus deferred link-aware migrations
-          # (forbidden filename suffixes, F-letter codes). Advisory only: at baseline
-          # the repo carries ~208 files with violations from the pre-Cleanup-2
-          # emergent-suffix wave; those are tracked for the Cleanup-2 sweep.
-          # The gate exists so NEW drift on this PR is visible.
-          mkdir -p /tmp/vocab-lint
-          if ! python3 scripts/vocab_lint.py --report-only --report-path /tmp/vocab-lint/report.json docs/; then
-            echo
-            echo "::warning::vocab_lint reports vocabulary drift in this branch."
-            echo "::warning::See vocab-lint-${{ github.run_id }} artifact for the per-file report."
-            echo "::warning::Cleanup-2 owns the baseline sweep; a new violation introduced by THIS PR should be fixed before landing."
-            {
-              echo "### Vocabulary Drift Advisory"
-              echo
-              echo "vocab_lint flagged vocabulary drift in this branch."
-              echo
-              echo "Run locally to inspect:"
-              echo "\`\`\`bash"
-              echo "python3 scripts/vocab_lint.py --report-only docs/"
-              echo "\`\`\`"
-              echo
-              echo "Auto-correctable routine drift can be applied with:"
-              echo "\`\`\`bash"
-              echo "python3 scripts/vocab_lint.py --fix docs/"
-              echo "\`\`\`"
-              echo
-              echo "Filename renames (forbidden suffixes) require the Cleanup-2 link-aware tooling."
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Upload vocab_lint report
-        if: github.event_name == 'pull_request' && always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: vocab-lint-${{ github.run_id }}
-          path: /tmp/vocab-lint/report.json
-          if-no-files-found: ignore
-          retention-days: 14
-
-      - name: Check vocabulary doc render (PR only, hard gate)
-        if: github.event_name == 'pull_request'
-        run: |
-          # Render --check fails if docs/repo/CONTROLLED_VOCABULARY.md or
-          # docs/KEY_TERMINOLOGY.md drift from the canonical YAML +
-          # templates. Change either the YAML or the templates, then run
-          # `python3 scripts/render_controlled_vocabulary.py` to regenerate.
-          python3 scripts/render_controlled_vocabulary.py --check
-
-      - name: Regenerate conditional-prompt snapshot (cron/manual only)
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      - name: Regenerate conditional-prompt snapshot
         # MISSING_DERIVATION_PROMPTS.md is the static snapshot the
         # science-fix-loop reads. Without this refresh it drifts from the
         # live ledger, causing wasted attempts on rows that have already
-        # been re-audited. PR runs deliberately skip this step so they
-        # don't produce extra generated-file advisories below.
+        # been re-audited.
         run: python3 docs/audit/scripts/generate_conditional_prompts.py
 
-      - name: Report pipeline diff (PR only, advisory)
-        if: github.event_name == 'pull_request'
-        run: |
-          git status --short docs/audit docs/publication/ci3_z3
-          if [[ -n "$(git status --porcelain docs/audit docs/publication/ci3_z3)" ]]; then
-            echo
-            echo "::warning::Audit-data files changed during pipeline run on this PR."
-            echo "::warning::This can be a real missing-regeneration issue, or normal drift"
-            echo "::warning::from main moving while the PR stays open."
-            echo "::warning::Review-loop must rerun the pipeline from current main before landing."
-            git diff --stat docs/audit docs/publication/ci3_z3 || true
-            {
-              echo "### Audit Pipeline Diff Advisory"
-              echo
-              echo "The audit pipeline produced generated-file diffs on this PR."
-              echo
-              echo "This PR check is advisory only. Open PRs may sit while \`main\` moves; review-loop is responsible for applying source-only deltas to current \`main\`, rerunning the pipeline, and landing only if the regenerated audit data is clean."
-              echo
-              echo "\`\`\`bash"
-              echo "bash docs/audit/scripts/run_pipeline.sh"
-              echo "python3 docs/audit/scripts/generate_conditional_prompts.py"
-              echo "\`\`\`"
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Commit refreshed ledger / queue (cron only)
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      - name: Commit refreshed ledger / queue
         run: |
           set -e
           git config user.name  "audit-bot"

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -564,8 +564,11 @@ five-judge panel in the same loop using the restricted source packet plus the
 full first-audit and second-audit arguments as explicit context. Each judge
 must run at the required audit model/reasoning level with a distinct auditor
 identity, vote on the full tuple `(sided_with, ratified_verdict,
-ratified_claim_type, ratified_load_bearing_step_class)`, and explain errors in
-the other position. A majority is at least three matching votes out of five.
+ratified_claim_type, ratified_claim_scope, ratified_load_bearing_step_class,
+negative_assertion_classes)`, and explain errors in the other position. Treat
+whitespace-only scope differences and assertion-class ordering as equivalent,
+but require substantive scope and declaration agreement. A majority is at
+least three matching full-tuple votes out of five.
 
 After a panel majority, go with the majority only if the majority tuple is
 applyable by the audit tooling and the normal gates pass. Apply a representative

--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -390,8 +390,9 @@ The lane runs two assurance tiers:
   positive/bounded rows apply the No-Go Discipline as auditor judgment, and
   any supplied N1-N8 packet is validated structurally (no manifest-backed
   containment, live-stdout, or full-universe disposition plumbing).
-- **Forensic tier.** Mandatory for `claim_type: no_go` rows (foreclosure is
-  permanent) and for freeze/certification runs (`AUDIT_FORENSIC_MODE=1`),
+- **Forensic tier.** Mandatory for `claim_type: no_go` rows and no-go-named
+  source files (foreclosure is permanent), and for freeze/certification runs
+  (`AUDIT_FORENSIC_MODE=1`),
   which force the full heavyweight regime lane-wide against a pinned commit:
   authenticated evidence transport, verbatim-contained route evidence, live
   runner-stdout citation, and complete index dispositions with authenticated
@@ -400,11 +401,10 @@ The lane runs two assurance tiers:
 **Rolling certification** replaces scheduled freezes: the pipeline
 continuously reports, per flagship lane
 (`docs/audit/data/lane_certification_config.json` →
-`docs/audit/data/lane_certification.json`), whether the root claim's entire
-transitive dependency closure is chain-satisfying against the current state:
-retained-grade rows, decorations of retained parents, registered accepted
-premises, and permitted metadata context all satisfy the marker; metadata
-registered as non-evidence context does not.
+`docs/audit/data/lane_certification.json`), whether every configured scientific
+root claim and their combined transitive dependency closure are chain-satisfying
+against the current state. Retained-grade rows, decorations of retained parents,
+and registered accepted premises satisfy the marker; metadata does not.
 Certification is a state the repository re-enters as audit throughput
 catches up; a marker rolling back after an axiom or source change is the
 honest coordination signal for collaborators, not an error. If a publication

--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -410,3 +410,7 @@ catches up; a marker rolling back after an axiom or source change is the
 honest coordination signal for collaborators, not an error. If a publication
 or replication request ever needs a citable artifact, snapshot the lane's
 currently-certified commit and run the forensic tier over its closure there.
+Some configured roots intentionally name unresolved scientific `open_gate`
+obligations. Those lanes remain uncertified until source-level science retires
+or replaces the open root; audit throughput alone cannot certify an open gate,
+and substituting an already-retained surrogate would hide the live obligation.

--- a/docs/audit/data/lane_certification_config.json
+++ b/docs/audit/data/lane_certification_config.json
@@ -1,6 +1,6 @@
 {
   "schema": "lane_certification_config_v2",
-  "description": "Flagship lanes for rolling certification. Each lane is certified when every configured scientific root and every row in their combined transitive dependency closure is chain-satisfying against the current repository state: retained-grade rows, decorations of retained parents, and registered accepted premises satisfy. Metadata does not. Hand-edited; owner-approved 2026-07-12.",
+  "description": "Flagship lanes for rolling certification. Each lane is certified when every configured scientific root and every row in their combined transitive dependency closure is chain-satisfying against the current repository state: retained-grade rows, decorations of retained parents, and registered accepted premises satisfy. Metadata does not. A configured open-gate root intentionally keeps its lane uncertified until source-level science retires or replaces that obligation; audit throughput alone cannot certify it. Hand-edited; owner-approved 2026-07-12.",
   "lanes": [
     {"lane": "charged_lepton_koide_value", "root": "charged_lepton_koide_value_full_chain_of_custody_2026-06-02"},
     {"lane": "acphilambda_retirement_basis", "roots": ["ac_orbit_occupancy_statistical_grain_derivation_obligation", "ac_reta_hclass_hunit_readout_derivation_obligation"]},

--- a/docs/audit/data/lane_certification_config.json
+++ b/docs/audit/data/lane_certification_config.json
@@ -1,9 +1,9 @@
 {
-  "schema": "lane_certification_config_v1",
-  "description": "Flagship lanes for rolling certification. Each lane is certified when every row in its root's transitive dependency closure is chain-satisfying against the current repository state: retained-grade rows, decorations of retained parents, registered accepted premises, and permitted metadata context satisfy; registered non-evidence context does not. Hand-edited; owner-approved 2026-07-12.",
+  "schema": "lane_certification_config_v2",
+  "description": "Flagship lanes for rolling certification. Each lane is certified when every configured scientific root and every row in their combined transitive dependency closure is chain-satisfying against the current repository state: retained-grade rows, decorations of retained parents, and registered accepted premises satisfy. Metadata does not. Hand-edited; owner-approved 2026-07-12.",
   "lanes": [
     {"lane": "charged_lepton_koide_value", "root": "charged_lepton_koide_value_full_chain_of_custody_2026-06-02"},
-    {"lane": "acphilambda_retirement_basis", "root": "acphilambda_retirement_basis_rematch_and_claim_surface_note_2026-07-06"},
+    {"lane": "acphilambda_retirement_basis", "roots": ["ac_orbit_occupancy_statistical_grain_derivation_obligation", "ac_reta_hclass_hunit_readout_derivation_obligation"]},
     {"lane": "rule_universality_grain", "root": "acphilambda_occupancy_grain_rule_class_universality_bounded_theorem_note_2026-07-11"},
     {"lane": "theta_retirement", "root": "strong_cp_theta_zero_note"}
   ]

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -958,6 +958,9 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
             return False, "hybrid judicial review requires hybrid_resolution_note"
         if ratified_claim_type is None:
             return False, "hybrid judicial review requires ratified_claim_type"
+        ratified_scope = judgment.get("ratified_claim_scope")
+        if not isinstance(ratified_scope, str) or not ratified_scope.strip():
+            return False, "hybrid judicial review requires ratified_claim_scope"
     if side in {"first", "second"}:
         chosen = first if side == "first" else second
         chosen_label = "first" if side == "first" else "second"

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -191,8 +191,10 @@ def trusted_manifest_current_error(
     trusted_manifest: dict[str, dict],
     row: dict,
     rows: dict[str, dict],
+    *,
+    dynamic_index_drift_invalidates: bool = True,
 ) -> str | None:
-    """Reject replayed prompt evidence after source or dynamic-index drift."""
+    """Reject replayed evidence after stable-content or governed index drift."""
     probe_packet = dict(packet)
     probe_packet["evidence_snapshot"] = (
         no_go_discipline_gate.build_evidence_snapshot(
@@ -206,7 +208,9 @@ def trusted_manifest_current_error(
         current_row, rows, REPO_ROOT
     )
     return no_go_discipline_gate.evidence_snapshot_current_error(
-        probe_packet, current_manifest, dynamic_index_drift_invalidates=True
+        probe_packet,
+        current_manifest,
+        dynamic_index_drift_invalidates=dynamic_index_drift_invalidates,
     )
 
 
@@ -484,6 +488,14 @@ def normalized_negative_assertion_classes(blob: dict) -> tuple[str, ...]:
     return tuple(sorted({item for item in declared if isinstance(item, str)}))
 
 
+def normalized_claim_scope(blob: dict) -> str:
+    """Normalize insignificant whitespace without weakening scoped agreement."""
+    scope = blob.get("claim_scope")
+    if not isinstance(scope, str):
+        return ""
+    return " ".join(scope.split())
+
+
 def audit_tuples_match(first: dict, second: dict) -> bool:
     """Compare every field whose disagreement requires governed resolution."""
     return (
@@ -491,6 +503,7 @@ def audit_tuples_match(first: dict, second: dict) -> bool:
         and first.get("claim_type") == second.get("claim_type")
         and first.get("load_bearing_step_class")
         == second.get("load_bearing_step_class")
+        and normalized_claim_scope(first) == normalized_claim_scope(second)
         and normalized_negative_assertion_classes(first)
         == normalized_negative_assertion_classes(second)
     )
@@ -971,6 +984,25 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
                 "negative_assertion_classes does not match the ratified "
                 f"{chosen_label}_audit declaration"
             )
+        if (
+            judgment.get("ratified_load_bearing_step_class")
+            != chosen.get("load_bearing_step_class")
+        ):
+            return False, (
+                "ratified_load_bearing_step_class does not match the ratified "
+                f"{chosen_label}_audit class"
+            )
+        ratified_scope = judgment.get("ratified_claim_scope")
+        if (
+            ratified_scope is not None
+            and normalized_claim_scope({"claim_scope": ratified_scope})
+            != normalized_claim_scope(chosen)
+        ):
+            return False, (
+                "ratified_claim_scope does not match the ratified "
+                f"{chosen_label}_audit scope; use sided_with='hybrid' to "
+                "ratify a different scope"
+            )
     ratified_decoration_parent = (
         judgment.get("ratified_decoration_parent_claim_id")
         or judgment.get("decoration_parent_claim_id")
@@ -1034,13 +1066,17 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
         evidence_manifest = no_go_discipline_gate.build_evidence_manifest(
             row, rows, REPO_ROOT
         )
-    if ratified_verdict == "audited_clean" and forensic_probe:
+    if ratified_verdict == "audited_clean":
         clipped_error = clipped_clean_evidence_error(evidence_manifest)
         if clipped_error:
             return False, clipped_error
-    if trusted_transport and forensic_probe:
+    if trusted_transport:
         manifest_error = trusted_manifest_current_error(
-            judgment.get("no_go_discipline") or {}, evidence_manifest, row, rows
+            judgment.get("no_go_discipline") or {},
+            evidence_manifest,
+            row,
+            rows,
+            dynamic_index_drift_invalidates=forensic_probe,
         )
         if manifest_error:
             return False, f"trusted evidence manifest is stale: {manifest_error}"
@@ -1234,13 +1270,17 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         evidence_manifest = no_go_discipline_gate.build_evidence_manifest(
             row, rows, REPO_ROOT
         )
-    if verdict == "audited_clean" and _forensic:
+    if verdict == "audited_clean":
         clipped_error = clipped_clean_evidence_error(evidence_manifest)
         if clipped_error:
             return False, clipped_error
-    if trusted_transport and _forensic:
+    if trusted_transport:
         manifest_error = trusted_manifest_current_error(
-            audit.get("no_go_discipline") or {}, evidence_manifest, row, rows
+            audit.get("no_go_discipline") or {},
+            evidence_manifest,
+            row,
+            rows,
+            dynamic_index_drift_invalidates=_forensic,
         )
         if manifest_error:
             return False, f"trusted evidence manifest is stale: {manifest_error}"
@@ -1637,20 +1677,17 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         err = cross_confirmation_error(first, audit)
         if err:
             return False, err
-        if (
-            first.get("load_bearing_step_class") != audit.get("load_bearing_step_class")
-            or first.get("claim_type") != claim_type
-            or normalized_negative_assertion_classes(first)
-            != normalized_negative_assertion_classes(audit)
-        ):
-            row["cross_confirmation"]["second_audit"] = audit_summary_from_blob(audit)
+        second = audit_summary_from_blob(audit)
+        if not audit_tuples_match(first, second):
+            row["cross_confirmation"]["second_audit"] = second
             row["cross_confirmation"]["status"] = "disagreement"
             row["audit_status"] = "audit_in_progress"
             row["blocker"] = "cross_confirmation_disagreement"
             accept_row()
             return True, (
                 "first and second audits disagree on claim_type, "
-                "load_bearing_step_class, or negative_assertion_classes "
+                "claim_scope, load_bearing_step_class, or "
+                "negative_assertion_classes "
                 f"({first.get('claim_type')!r}/{first.get('load_bearing_step_class')!r} vs "
                 f"{claim_type!r}/{audit.get('load_bearing_step_class')!r}); "
                 "promote to third-auditor review"

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -291,6 +291,7 @@ def archive_invalid_first_and_require_fresh_packet(row: dict, first: dict) -> No
     archive_replaced_cross_confirmation_first(row, first)
     row.pop("cross_confirmation", None)
     row.pop("no_go_discipline", None)
+    row.pop("negative_assertion_classes", None)
     row["audit_status"] = "unaudited"
     row["blocker"] = "invalid_cross_confirmation_first_archived_reaudit_required"
 
@@ -470,6 +471,31 @@ def cross_confirmation_error(first: dict, audit: dict) -> str | None:
     return None
 
 
+def normalized_negative_assertion_classes(blob: dict) -> tuple[str, ...]:
+    """Return the declaration as a stable component of the audit tuple.
+
+    Missing legacy declarations are treated as the historical equivalent of an
+    empty declaration. New audit inputs are separately required to carry an
+    explicit validated list before they reach any comparison path.
+    """
+    declared = blob.get("negative_assertion_classes")
+    if not isinstance(declared, list):
+        return ()
+    return tuple(sorted({item for item in declared if isinstance(item, str)}))
+
+
+def audit_tuples_match(first: dict, second: dict) -> bool:
+    """Compare every field whose disagreement requires governed resolution."""
+    return (
+        first.get("verdict") == second.get("verdict")
+        and first.get("claim_type") == second.get("claim_type")
+        and first.get("load_bearing_step_class")
+        == second.get("load_bearing_step_class")
+        and normalized_negative_assertion_classes(first)
+        == normalized_negative_assertion_classes(second)
+    )
+
+
 def third_confirmation_error(cross_confirmation: dict, audit: dict) -> str | None:
     """Return a rejection reason when the third audit is not independent."""
     prior_auditors = {
@@ -513,6 +539,9 @@ def audit_summary_from_row(row: dict) -> dict:
         "claim_type": row.get("claim_type"),
         "claim_scope": row.get("claim_scope"),
         "load_bearing_step_class": row.get("load_bearing_step_class"),
+        "negative_assertion_classes": list(
+            normalized_negative_assertion_classes(row)
+        ),
         "verdict": row.get("audit_status"),
         "audit_invocation_id": row.get("audit_invocation_id"),
     }
@@ -532,6 +561,9 @@ def audit_summary_from_blob(audit: dict) -> dict:
         "claim_type": audit.get("claim_type"),
         "claim_scope": audit.get("claim_scope"),
         "load_bearing_step_class": audit.get("load_bearing_step_class"),
+        "negative_assertion_classes": list(
+            normalized_negative_assertion_classes(audit)
+        ),
         "verdict": audit.get("verdict"),
         "audit_invocation_id": audit.get("audit_invocation_id"),
     }
@@ -551,6 +583,9 @@ def judicial_summary_from_blob(judgment: dict) -> dict:
         "claim_type": judgment.get("ratified_claim_type"),
         "claim_scope": judgment.get("ratified_claim_scope"),
         "load_bearing_step_class": judgment.get("ratified_load_bearing_step_class"),
+        "negative_assertion_classes": list(
+            normalized_negative_assertion_classes(judgment)
+        ),
         "verdict": judgment.get("ratified_verdict"),
         "audit_invocation_id": judgment.get("audit_invocation_id"),
         "sided_with": judgment.get("sided_with"),
@@ -928,6 +963,14 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
                 f"ratified_claim_type {ratified_claim_type!r} does not match "
                 f"{chosen_label}_audit claim_type {chosen_claim_type!r}"
             )
+        if (
+            normalized_negative_assertion_classes(judgment)
+            != normalized_negative_assertion_classes(chosen)
+        ):
+            return False, (
+                "negative_assertion_classes does not match the ratified "
+                f"{chosen_label}_audit declaration"
+            )
     ratified_decoration_parent = (
         judgment.get("ratified_decoration_parent_claim_id")
         or judgment.get("decoration_parent_claim_id")
@@ -1095,6 +1138,11 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     else:
         row["decoration_parent_claim_id"] = judgment.get("decoration_parent_claim_id")
     row["auditor_confidence"] = judgment.get("auditor_confidence", "judicial")
+    row["negative_assertion_classes"] = list(
+        normalized_negative_assertion_classes(
+            chosen if side in {"first", "second"} else judgment
+        )
+    )
     if judgment.get("no_go_discipline") is None:
         row.pop("no_go_discipline", None)
     else:
@@ -1369,11 +1417,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             return False, "explicit second-seat cross-confirmation requires independence != 'weak'"
 
         second = audit_summary_from_blob(audit)
-        matches = (
-            first.get("verdict") == second.get("verdict")
-            and first.get("claim_type") == second.get("claim_type")
-            and first.get("load_bearing_step_class") == second.get("load_bearing_step_class")
-        )
+        matches = audit_tuples_match(first, second)
         row["cross_confirmation"] = {
             "first_audit": first,
             "second_audit": second,
@@ -1419,11 +1463,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             return False, "terminal cross-confirmation requires independence != 'weak'"
 
         second = audit_summary_from_blob(audit)
-        matches = (
-            first.get("verdict") == second.get("verdict")
-            and first.get("claim_type") == second.get("claim_type")
-            and first.get("load_bearing_step_class") == second.get("load_bearing_step_class")
-        )
+        matches = audit_tuples_match(first, second)
         row["cross_confirmation"] = {
             "first_audit": first,
             "second_audit": second,
@@ -1472,16 +1512,8 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         first_verdict = first.get("verdict")
         second_verdict = second.get("verdict")
         third_verdict = third.get("verdict")
-        third_matches_first = (
-            third_verdict == first_verdict
-            and third.get("claim_type") == first.get("claim_type")
-            and third.get("load_bearing_step_class") == first.get("load_bearing_step_class")
-        )
-        third_matches_second = (
-            third_verdict == second_verdict
-            and third.get("claim_type") == second.get("claim_type")
-            and third.get("load_bearing_step_class") == second.get("load_bearing_step_class")
-        )
+        third_matches_first = audit_tuples_match(third, first)
+        third_matches_second = audit_tuples_match(third, second)
         if third_matches_first:
             row["cross_confirmation"]["third_audit"] = third
             row["cross_confirmation"]["status"] = "third_confirmed_first"
@@ -1490,6 +1522,9 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             audit["verdict"] = first["verdict"]
             audit["claim_type"] = first["claim_type"]
             audit["load_bearing_step_class"] = first["load_bearing_step_class"]
+            audit["negative_assertion_classes"] = list(
+                normalized_negative_assertion_classes(first)
+            )
         elif third_matches_second:
             row["cross_confirmation"]["third_audit"] = third
             row["cross_confirmation"]["status"] = "third_confirmed_second"
@@ -1498,6 +1533,9 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             audit["verdict"] = second["verdict"]
             audit["claim_type"] = second["claim_type"]
             audit["load_bearing_step_class"] = second["load_bearing_step_class"]
+            audit["negative_assertion_classes"] = list(
+                normalized_negative_assertion_classes(second)
+            )
         else:
             row["cross_confirmation"]["third_audit"] = third
             row["cross_confirmation"]["status"] = "three_way_disagreement"
@@ -1539,11 +1577,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
 
         second = audit_summary_from_blob(audit)
         row["cross_confirmation"]["second_audit"] = second
-        matches = (
-            first.get("verdict") == second.get("verdict")
-            and first.get("claim_type") == second.get("claim_type")
-            and first.get("load_bearing_step_class") == second.get("load_bearing_step_class")
-        )
+        matches = audit_tuples_match(first, second)
         if matches:
             row["cross_confirmation"]["status"] = "confirmed"
         else:
@@ -1606,6 +1640,8 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         if (
             first.get("load_bearing_step_class") != audit.get("load_bearing_step_class")
             or first.get("claim_type") != claim_type
+            or normalized_negative_assertion_classes(first)
+            != normalized_negative_assertion_classes(audit)
         ):
             row["cross_confirmation"]["second_audit"] = audit_summary_from_blob(audit)
             row["cross_confirmation"]["status"] = "disagreement"
@@ -1613,7 +1649,8 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             row["blocker"] = "cross_confirmation_disagreement"
             accept_row()
             return True, (
-                "first and second audits disagree on claim_type or load_bearing_step_class "
+                "first and second audits disagree on claim_type, "
+                "load_bearing_step_class, or negative_assertion_classes "
                 f"({first.get('claim_type')!r}/{first.get('load_bearing_step_class')!r} vs "
                 f"{claim_type!r}/{audit.get('load_bearing_step_class')!r}); "
                 "promote to third-auditor review"
@@ -1643,6 +1680,9 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
     row["open_dependency_paths"] = audit.get("open_dependency_paths", [])
     row["decoration_parent_claim_id"] = audit.get("decoration_parent_claim_id")
     row["auditor_confidence"] = audit.get("auditor_confidence")
+    row["negative_assertion_classes"] = list(
+        normalized_negative_assertion_classes(audit)
+    )
     if audit.get("no_go_discipline") is None:
         row.pop("no_go_discipline", None)
     else:

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -218,8 +218,10 @@ def cross_summary_no_go_error(
 ) -> str | None:
     """Validate a prior cross-confirmation seat before it can be ratified."""
     packet = summary.get("no_go_discipline")
-    required = source_required or no_go_discipline_gate.output_requires_no_go_discipline(
-        summary
+    required = (
+        source_required
+        or no_go_discipline_gate.output_requires_no_go_discipline(summary)
+        or bool(summary.get("negative_assertion_classes"))
     )
     if packet is None:
         return (
@@ -241,6 +243,7 @@ def cross_summary_no_go_error(
             },
             source_required=source_required,
             evidence_manifest=None,
+            structural_only=True,
         )
     if snapshot_manifest is None:
         return "authenticated evidence_snapshot is required"
@@ -972,9 +975,17 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     )
     if (
         evidence_manifest is None
-        and judgment.get("no_go_discipline") is not None
         and forensic_probe
     ):
+        if judgment.get("no_go_discipline") is None:
+            preliminary_error = no_go_discipline_gate.validate_no_go_discipline(
+                gate_blob,
+                source_required=source_required_probe,
+                structural_only=True,
+                require_declaration=True,
+            )
+            if preliminary_error:
+                return False, preliminary_error
         return False, "No-Go Discipline apply requires trusted orchestrator evidence transport"
     if evidence_manifest is None:
         evidence_manifest = no_go_discipline_gate.build_evidence_manifest(
@@ -1021,6 +1032,7 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
         source_required=source_requires_no_go,
         evidence_manifest=evidence_manifest if _forensic else None,
         prior_claim_scope=prior_claim_scope_for_row(row),
+        structural_only=not _forensic,
         require_declaration=True,
     )
     if no_go_error:
@@ -1158,9 +1170,17 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
     )
     if (
         evidence_manifest is None
-        and audit.get("no_go_discipline") is not None
         and _forensic
     ):
+        if audit.get("no_go_discipline") is None:
+            preliminary_error = no_go_discipline_gate.validate_no_go_discipline(
+                audit,
+                source_required=_source_req_probe,
+                structural_only=True,
+                require_declaration=True,
+            )
+            if preliminary_error:
+                return False, preliminary_error
         return False, "No-Go Discipline apply requires trusted orchestrator evidence transport"
     if evidence_manifest is None:
         evidence_manifest = no_go_discipline_gate.build_evidence_manifest(
@@ -1198,6 +1218,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         source_required=source_requires_no_go,
         evidence_manifest=evidence_manifest if _forensic else None,
         prior_claim_scope=prior_claim_scope_for_row(row),
+        structural_only=not _forensic,
         require_declaration=True,
     )
     if no_go_error:

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -331,6 +331,7 @@ JUDICIAL_REQUIRED_FIELDS = {
     "independence",
     "sided_with",
     "ratified_verdict",
+    "ratified_claim_type",
     "ratified_claim_scope",
     "ratified_load_bearing_step_class",
     "judgment_rationale",
@@ -508,6 +509,56 @@ def audit_tuples_match(first: dict, second: dict) -> bool:
         and normalized_claim_scope(first) == normalized_claim_scope(second)
         and normalized_negative_assertion_classes(first)
         == normalized_negative_assertion_classes(second)
+    )
+
+
+def audit_summary_tuple_schema_error(summary: object) -> str | None:
+    """Require a complete typed tuple before minting ``audit_tuple_v2``."""
+    if not isinstance(summary, dict) or not summary:
+        return "audit summary must be a non-empty object"
+    required = {
+        "verdict",
+        "claim_type",
+        "claim_scope",
+        "load_bearing_step_class",
+        "negative_assertion_classes",
+    }
+    missing = required - set(summary)
+    if missing:
+        return f"audit summary missing tuple fields: {sorted(missing)}"
+    verdict = summary.get("verdict")
+    if verdict not in ALLOWED_VERDICTS:
+        return f"audit summary has non-terminal verdict {verdict!r}"
+    claim_type = summary.get("claim_type")
+    if claim_type not in ALLOWED_CLAIM_TYPES:
+        return f"audit summary has invalid claim_type {claim_type!r}"
+    scope = summary.get("claim_scope")
+    if not isinstance(scope, str) or not scope.strip():
+        return "audit summary claim_scope must be a non-empty string"
+    step_class = summary.get("load_bearing_step_class")
+    if not isinstance(step_class, str) or not step_class.strip():
+        return "audit summary load_bearing_step_class must be a non-empty string"
+    declared = summary.get("negative_assertion_classes")
+    if not isinstance(declared, list) or not all(
+        isinstance(item, str) for item in declared
+    ):
+        return "audit summary negative_assertion_classes must be a list of strings"
+    unknown = sorted(
+        set(declared) - no_go_discipline_gate.POLICY_NEGATIVE_CLASSES
+    )
+    if unknown:
+        return f"audit summary has unknown negative_assertion_classes: {unknown}"
+    return None
+
+
+def legacy_tuple_upgrade_error(label: str, summary: object) -> str | None:
+    """Explain why an old seat cannot be relabeled as exact v2 agreement."""
+    error = audit_summary_tuple_schema_error(summary)
+    if error is None:
+        return None
+    return (
+        f"{label} cannot be upgraded to {AUDIT_TUPLE_AGREEMENT_SCHEMA}: "
+        f"{error}; fresh re-audit required"
     )
 
 
@@ -928,7 +979,7 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     if ratified_verdict not in ALLOWED_VERDICTS:
         return False, f"ratified_verdict {ratified_verdict!r} not in {sorted(ALLOWED_VERDICTS)}"
     ratified_claim_type = judgment.get("ratified_claim_type")
-    if ratified_claim_type is not None and ratified_claim_type not in ALLOWED_CLAIM_TYPES:
+    if ratified_claim_type not in ALLOWED_CLAIM_TYPES:
         return False, f"ratified_claim_type {ratified_claim_type!r} not in {sorted(ALLOWED_CLAIM_TYPES)}"
     ratified_claim_scope = judgment.get("ratified_claim_scope")
     if not isinstance(ratified_claim_scope, str) or not ratified_claim_scope.strip():
@@ -951,6 +1002,11 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     second = cross_confirmation.get("second_audit") or {}
     if not first or not second:
         return False, "judicial review requires first_audit and second_audit summaries"
+    if side != "neither":
+        for label, summary in (("first_audit", first), ("second_audit", second)):
+            tuple_error = legacy_tuple_upgrade_error(label, summary)
+            if tuple_error:
+                return False, tuple_error
 
     prior_auditors = {first.get("auditor"), second.get("auditor")}
     if judgment.get("third_auditor") in prior_auditors:
@@ -961,8 +1017,6 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     if side == "hybrid":
         if not judgment.get("hybrid_resolution_note"):
             return False, "hybrid judicial review requires hybrid_resolution_note"
-        if ratified_claim_type is None:
-            return False, "hybrid judicial review requires ratified_claim_type"
         ratified_scope = ratified_claim_scope
     if side in {"first", "second"}:
         chosen = first if side == "first" else second
@@ -1132,6 +1186,10 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     # record mutate the live row. This also ensures a valid ``neither`` result
     # runs the same No-Go Discipline gate before recording its blocker.
     third = judicial_summary_from_blob(judgment)
+    if side != "neither":
+        tuple_error = legacy_tuple_upgrade_error("third_audit", third)
+        if tuple_error:
+            return False, tuple_error
     row["cross_confirmation"]["third_audit"] = third
     row["cross_confirmation"]["mode"] = "judicial_third_pass"
 
@@ -1462,6 +1520,10 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             return False, "explicit second-seat cross-confirmation requires independence != 'weak'"
 
         second = audit_summary_from_blob(audit)
+        for label, summary in (("first_audit", first), ("second_audit", second)):
+            tuple_error = legacy_tuple_upgrade_error(label, summary)
+            if tuple_error:
+                return False, tuple_error
         matches = audit_tuples_match(first, second)
         row["cross_confirmation"] = {
             "first_audit": first,
@@ -1510,6 +1572,10 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             return False, "terminal cross-confirmation requires independence != 'weak'"
 
         second = audit_summary_from_blob(audit)
+        for label, summary in (("first_audit", first), ("second_audit", second)):
+            tuple_error = legacy_tuple_upgrade_error(label, summary)
+            if tuple_error:
+                return False, tuple_error
         matches = audit_tuples_match(first, second)
         row["cross_confirmation"] = {
             "first_audit": first,
@@ -1545,6 +1611,10 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
 
         first = (prior_cross_confirmation or {}).get("first_audit") or {}
         second = (prior_cross_confirmation or {}).get("second_audit") or {}
+        for label, summary in (("first_audit", first), ("second_audit", second)):
+            tuple_error = legacy_tuple_upgrade_error(label, summary)
+            if tuple_error:
+                return False, tuple_error
         for seat_name, seat in (("first", first), ("second", second)):
             seat_gate_error = cross_summary_no_go_error(
                 seat,
@@ -1557,6 +1627,9 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
                     f"audit: {seat_gate_error}"
                 )
         third = audit_summary_from_blob(audit)
+        tuple_error = legacy_tuple_upgrade_error("third_audit", third)
+        if tuple_error:
+            return False, tuple_error
         first_verdict = first.get("verdict")
         second_verdict = second.get("verdict")
         third_verdict = third.get("verdict")
@@ -1609,6 +1682,9 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
     )
     if critical_second_pass:
         first = (prior_cross_confirmation or {}).get("first_audit") or {}
+        tuple_error = legacy_tuple_upgrade_error("first_audit", first)
+        if tuple_error:
+            return False, tuple_error
         first_gate_error = cross_summary_no_go_error(
             first,
             source_required=source_requires_no_go,
@@ -1626,6 +1702,9 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             return False, err
 
         second = audit_summary_from_blob(audit)
+        tuple_error = legacy_tuple_upgrade_error("second_audit", second)
+        if tuple_error:
+            return False, tuple_error
         row["cross_confirmation"]["second_audit"] = second
         matches = audit_tuples_match(first, second)
         if matches:
@@ -1659,8 +1738,12 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         prior = row.get("cross_confirmation") or {}
         first = prior.get("first_audit")
         if first is None:
+            first_summary = audit_summary_from_blob(audit)
+            tuple_error = legacy_tuple_upgrade_error("first_audit", first_summary)
+            if tuple_error:
+                return False, tuple_error
             row["cross_confirmation"] = {
-                "first_audit": audit_summary_from_blob(audit),
+                "first_audit": first_summary,
                 "second_audit": None,
                 "status": "awaiting_second",
             }
@@ -1672,6 +1755,9 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             row["claim_type_last_reviewed"] = audit.get("audit_date") or datetime.now(timezone.utc).isoformat()
             accept_row()
             return True, "first audit recorded; awaiting independent second auditor"
+        tuple_error = legacy_tuple_upgrade_error("first_audit", first)
+        if tuple_error:
+            return False, tuple_error
         first_gate_error = cross_summary_no_go_error(
             first,
             source_required=source_requires_no_go,
@@ -1689,6 +1775,9 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         if err:
             return False, err
         second = audit_summary_from_blob(audit)
+        tuple_error = legacy_tuple_upgrade_error("second_audit", second)
+        if tuple_error:
+            return False, tuple_error
         if not audit_tuples_match(first, second):
             row["cross_confirmation"]["second_audit"] = second
             row["cross_confirmation"]["status"] = "disagreement"

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -331,6 +331,7 @@ JUDICIAL_REQUIRED_FIELDS = {
     "independence",
     "sided_with",
     "ratified_verdict",
+    "ratified_claim_scope",
     "ratified_load_bearing_step_class",
     "judgment_rationale",
     "first_auditor_error",
@@ -928,6 +929,9 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     ratified_claim_type = judgment.get("ratified_claim_type")
     if ratified_claim_type is not None and ratified_claim_type not in ALLOWED_CLAIM_TYPES:
         return False, f"ratified_claim_type {ratified_claim_type!r} not in {sorted(ALLOWED_CLAIM_TYPES)}"
+    ratified_claim_scope = judgment.get("ratified_claim_scope")
+    if not isinstance(ratified_claim_scope, str) or not ratified_claim_scope.strip():
+        return False, "ratified_claim_scope must be a non-empty string"
 
     err = note_hash_drift_error(row)
     if err:
@@ -958,9 +962,7 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
             return False, "hybrid judicial review requires hybrid_resolution_note"
         if ratified_claim_type is None:
             return False, "hybrid judicial review requires ratified_claim_type"
-        ratified_scope = judgment.get("ratified_claim_scope")
-        if not isinstance(ratified_scope, str) or not ratified_scope.strip():
-            return False, "hybrid judicial review requires ratified_claim_scope"
+        ratified_scope = ratified_claim_scope
     if side in {"first", "second"}:
         chosen = first if side == "first" else second
         chosen_label = "first" if side == "first" else "second"
@@ -995,10 +997,8 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
                 "ratified_load_bearing_step_class does not match the ratified "
                 f"{chosen_label}_audit class"
             )
-        ratified_scope = judgment.get("ratified_claim_scope")
         if (
-            ratified_scope is not None
-            and normalized_claim_scope({"claim_scope": ratified_scope})
+            normalized_claim_scope({"claim_scope": ratified_claim_scope})
             != normalized_claim_scope(chosen)
         ):
             return False, (
@@ -1800,17 +1800,40 @@ def run_propagation() -> int:
                 print(f"     stderr: {result.stderr.strip()[:400]}", file=sys.stderr)
             return 1
         if script == "invalidate_stale_audits.py":
+            converged = False
             for attempt in range(1, 11):
                 invalidated = len(
                     json.loads(LEDGER_PATH.read_text(encoding="utf-8")).get(
                         "last_invalidations", []
                     )
                 )
-                if invalidated == 0:
+                restore = subprocess.run(
+                    [
+                        sys.executable,
+                        str(scripts_dir / "restore_overaggressively_invalidated_audits.py"),
+                    ],
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    text=True,
+                )
+                if restore.returncode != 0:
+                    print(
+                        "     FAIL restore_overaggressively_invalidated_audits.py",
+                        file=sys.stderr,
+                    )
+                    return 1
+                restored_match = re.search(
+                    r"^Restored (\d+) audits",
+                    restore.stdout or "",
+                    re.MULTILINE,
+                )
+                restored = int(restored_match.group(1)) if restored_match else 0
+                if invalidated == 0 and restored == 0:
+                    converged = True
                     break
                 print(
-                    f"     fixed-point pass {attempt}: {invalidated} invalidation(s); "
-                    "recomputing effective status"
+                    f"     fixed-point pass {attempt}: {invalidated} invalidation(s), "
+                    f"{restored} restoration(s); recomputing effective status"
                 )
                 compute = subprocess.run(
                     [sys.executable, str(scripts_dir / "compute_effective_status.py")],
@@ -1826,13 +1849,10 @@ def run_propagation() -> int:
                 if repeat.returncode != 0:
                     print("     FAIL invalidate_stale_audits.py", file=sys.stderr)
                     return 1
-            if len(
-                json.loads(LEDGER_PATH.read_text(encoding="utf-8")).get(
-                    "last_invalidations", []
-                )
-            ) != 0:
+            if not converged:
                 print(
-                    "     FAIL invalidation did not reach a fixed point after 10 passes",
+                    "     FAIL invalidation/restoration did not reach a fixed point "
+                    "after 10 passes",
                     file=sys.stderr,
                 )
                 return 1

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -436,6 +436,7 @@ def _canonicalize_existing_auditor_family(family: str | None) -> str | None:
 
 
 ALLOWED_JUDICIAL_SIDES = {"first", "second", "hybrid", "neither"}
+AUDIT_TUPLE_AGREEMENT_SCHEMA = "audit_tuple_v2"
 JUDICIAL_REVIEWABLE_STATUSES = {
     "disagreement",
     "third_confirmed_first",
@@ -1147,6 +1148,7 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
         "second": "third_confirmed_second",
         "hybrid": "third_confirmed_hybrid",
     }[side]
+    row["cross_confirmation"]["agreement_schema"] = AUDIT_TUPLE_AGREEMENT_SCHEMA
     row["audit_status"] = ratified_verdict
     row["auditor"] = judgment["third_auditor"]
     row["auditor_family"] = judgment["auditor_family"]
@@ -1467,6 +1469,8 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             "status": "confirmed" if matches else "disagreement",
             "mode": "explicit_second_seat",
         }
+        if matches:
+            row["cross_confirmation"]["agreement_schema"] = AUDIT_TUPLE_AGREEMENT_SCHEMA
         if not matches:
             row["audit_status"] = "audit_in_progress"
             row["blocker"] = "cross_confirmation_disagreement"
@@ -1514,6 +1518,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             "mode": "terminal_second_pass",
         }
         if matches:
+            row["cross_confirmation"]["agreement_schema"] = AUDIT_TUPLE_AGREEMENT_SCHEMA
             terminal_second_pass_msg = "terminal verdict cross-confirmed"
         else:
             terminal_second_pass_msg = (
@@ -1561,6 +1566,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             row["cross_confirmation"]["third_audit"] = third
             row["cross_confirmation"]["status"] = "third_confirmed_first"
             row["cross_confirmation"]["mode"] = "terminal_third_pass"
+            row["cross_confirmation"]["agreement_schema"] = AUDIT_TUPLE_AGREEMENT_SCHEMA
             third_pass_msg = "third auditor confirmed first verdict"
             audit["verdict"] = first["verdict"]
             audit["claim_type"] = first["claim_type"]
@@ -1572,6 +1578,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             row["cross_confirmation"]["third_audit"] = third
             row["cross_confirmation"]["status"] = "third_confirmed_second"
             row["cross_confirmation"]["mode"] = "terminal_third_pass"
+            row["cross_confirmation"]["agreement_schema"] = AUDIT_TUPLE_AGREEMENT_SCHEMA
             third_pass_msg = "third auditor confirmed second verdict"
             audit["verdict"] = second["verdict"]
             audit["claim_type"] = second["claim_type"]
@@ -1623,6 +1630,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         matches = audit_tuples_match(first, second)
         if matches:
             row["cross_confirmation"]["status"] = "confirmed"
+            row["cross_confirmation"]["agreement_schema"] = AUDIT_TUPLE_AGREEMENT_SCHEMA
         else:
             row["cross_confirmation"]["status"] = "disagreement"
             row["audit_status"] = "audit_in_progress"
@@ -1698,6 +1706,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         # Concordant second audit: promote.
         row["cross_confirmation"]["second_audit"] = audit_summary_from_blob(audit)
         row["cross_confirmation"]["status"] = "confirmed"
+        row["cross_confirmation"]["agreement_schema"] = AUDIT_TUPLE_AGREEMENT_SCHEMA
 
     # Apply the audit fields.
     row["audit_status"] = verdict

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -980,11 +980,11 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
         evidence_manifest = no_go_discipline_gate.build_evidence_manifest(
             row, rows, REPO_ROOT
         )
-    if ratified_verdict == "audited_clean":
+    if ratified_verdict == "audited_clean" and forensic_probe:
         clipped_error = clipped_clean_evidence_error(evidence_manifest)
         if clipped_error:
             return False, clipped_error
-    if trusted_transport:
+    if trusted_transport and forensic_probe:
         manifest_error = trusted_manifest_current_error(
             judgment.get("no_go_discipline") or {}, evidence_manifest, row, rows
         )
@@ -1166,11 +1166,11 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         evidence_manifest = no_go_discipline_gate.build_evidence_manifest(
             row, rows, REPO_ROOT
         )
-    if verdict == "audited_clean":
+    if verdict == "audited_clean" and _forensic:
         clipped_error = clipped_clean_evidence_error(evidence_manifest)
         if clipped_error:
             return False, clipped_error
-    if trusted_transport:
+    if trusted_transport and _forensic:
         manifest_error = trusted_manifest_current_error(
             audit.get("no_go_discipline") or {}, evidence_manifest, row, rows
         )
@@ -1666,6 +1666,7 @@ PROPAGATION_STEPS = (
     ("compute_effective_status.py",        "post-apply effective_status pass"),
     ("invalidate_stale_audits.py",         "invalidate audits whose deps shifted"),
     ("compute_effective_status.py",        "post-invalidation effective_status pass"),
+    ("compute_lane_certification.py",      "refresh rolling lane certification"),
     ("compute_audit_queue.py",             "refresh audit queue"),
     ("compute_reaudit_candidates.py",      "refresh re-audit candidates"),
     ("render_audit_ledger.py",             "render AUDIT_LEDGER.md"),

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -81,6 +81,7 @@ ALLOWED_CLAIM_TYPES = {
     None,
 }
 RETAINED_GRADES = {"retained", "retained_no_go", "retained_bounded"}
+AUDIT_TUPLE_AGREEMENT_SCHEMA = "audit_tuple_v2"
 
 
 def normalized_claim_scope(audit_like: dict) -> str:
@@ -935,8 +936,28 @@ def main() -> int:
                     )
 
         xc = row.get("cross_confirmation") or {}
-        if isinstance(xc, dict) and xc.get("status") in {"third_confirmed_first", "third_confirmed_second", "third_confirmed_hybrid"}:
-            xc_status = xc.get("status")
+        xc_status = xc.get("status") if isinstance(xc, dict) else None
+        exact_tuple_schema = (
+            isinstance(xc, dict)
+            and xc.get("agreement_schema") == AUDIT_TUPLE_AGREEMENT_SCHEMA
+        )
+        if isinstance(xc, dict) and xc_status == "confirmed":
+            first = xc.get("first_audit") or {}
+            second = xc.get("second_audit") or {}
+            if not audit_summary_tuples_match(first, second):
+                message = (
+                    f"{cid}: confirmed cross-confirmation full audit tuple mismatch "
+                    "(verdict, claim_type, normalized claim_scope, "
+                    "load_bearing_step_class, negative_assertion_classes)"
+                )
+                if exact_tuple_schema:
+                    errors.append(message)
+                else:
+                    add_notice(
+                        "legacy_cross_confirmation_tuple_mismatch",
+                        message + "; legacy confirmation requires fresh re-audit",
+                    )
+        if isinstance(xc, dict) and xc_status in {"third_confirmed_first", "third_confirmed_second", "third_confirmed_hybrid"}:
             expected_side = {
                 "third_confirmed_first": "first",
                 "third_confirmed_second": "second",
@@ -954,16 +975,20 @@ def main() -> int:
                     errors.append(
                         f"{cid}: {xc_status} conflicts with third_audit.sided_with={side!r}"
                     )
-                if (
-                    expected_side != "hybrid"
-                    and third.get("verdict")
-                    and winning.get("verdict")
-                    and third.get("verdict") != winning.get("verdict")
+                if expected_side != "hybrid" and not audit_summary_tuples_match(
+                    third, winning
                 ):
-                    errors.append(
-                        f"{cid}: {xc_status} third_audit verdict={third.get('verdict')!r} "
-                        f"does not match winning audit {winning.get('verdict')!r}"
+                    message = (
+                        f"{cid}: {xc_status} third_audit full audit tuple does not "
+                        "match the winning audit"
                     )
+                    if exact_tuple_schema:
+                        errors.append(message)
+                    else:
+                        add_notice(
+                            "legacy_cross_confirmation_tuple_mismatch",
+                            message + "; legacy confirmation requires fresh re-audit",
+                        )
                 if row.get("claim_type_provenance") == "judicial_review":
                     for key in ("verdict", "claim_type", "load_bearing_step_class"):
                         row_key = "audit_status" if key == "verdict" else key
@@ -1054,13 +1079,6 @@ def main() -> int:
                             f"{cid}: same-family critical cross-confirmation requires "
                             "second_audit.independence='fresh_context'"
                         )
-                    if xc_status == "confirmed":
-                        if not audit_summary_tuples_match(first, second):
-                            errors.append(
-                                f"{cid}: critical cross-confirmation full audit tuple mismatch "
-                                "(verdict, claim_type, normalized claim_scope, "
-                                "load_bearing_step_class, negative_assertion_classes)"
-                            )
                     if xc_status in {"third_confirmed_first", "third_confirmed_second", "third_confirmed_hybrid"}:
                         third = xc.get("third_audit") or {}
                         if not third:
@@ -1086,13 +1104,6 @@ def main() -> int:
                                     errors.append(
                                         f"{cid}: third_confirmed_hybrid requires "
                                         f"third_audit.sided_with='hybrid'"
-                                    )
-                            else:
-                                winning = first if xc_status == "third_confirmed_first" else second
-                                if not audit_summary_tuples_match(third, winning):
-                                    errors.append(
-                                        f"{cid}: {xc_status} third_audit full audit tuple "
-                                        "does not match the winning audit"
                                     )
 
         if a == "audited_decoration":

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -83,6 +83,35 @@ ALLOWED_CLAIM_TYPES = {
 RETAINED_GRADES = {"retained", "retained_no_go", "retained_bounded"}
 
 
+def normalized_claim_scope(audit_like: dict) -> str:
+    """Normalize insignificant whitespace without weakening scoped agreement."""
+    scope = audit_like.get("claim_scope")
+    if not isinstance(scope, str):
+        return ""
+    return " ".join(scope.split())
+
+
+def normalized_negative_assertion_classes(audit_like: dict) -> tuple[str, ...]:
+    """Return the declared negative-assertion classes as a stable tuple."""
+    declared = audit_like.get("negative_assertion_classes")
+    if not isinstance(declared, list):
+        return ()
+    return tuple(sorted({item for item in declared if isinstance(item, str)}))
+
+
+def audit_summary_tuples_match(first: dict, second: dict) -> bool:
+    """Mirror apply_audit's full cross-confirmation agreement tuple."""
+    return (
+        first.get("verdict") == second.get("verdict")
+        and first.get("claim_type") == second.get("claim_type")
+        and normalized_claim_scope(first) == normalized_claim_scope(second)
+        and first.get("load_bearing_step_class")
+        == second.get("load_bearing_step_class")
+        and normalized_negative_assertion_classes(first)
+        == normalized_negative_assertion_classes(second)
+    )
+
+
 def is_retained_grade(status):
     """Mirror compute_effective_status.is_retained_grade: literal retained-grade
     keywords plus `decoration_under_<parent>` (which is only assigned when the
@@ -1026,16 +1055,11 @@ def main() -> int:
                             "second_audit.independence='fresh_context'"
                         )
                     if xc_status == "confirmed":
-                        if first.get("claim_type") != second.get("claim_type"):
+                        if not audit_summary_tuples_match(first, second):
                             errors.append(
-                                f"{cid}: critical cross-confirmation claim_type mismatch "
-                                f"{first.get('claim_type')!r} vs {second.get('claim_type')!r}"
-                            )
-                        if first.get("load_bearing_step_class") != second.get("load_bearing_step_class"):
-                            errors.append(
-                                f"{cid}: critical cross-confirmation load_bearing_step_class mismatch "
-                                f"{first.get('load_bearing_step_class')!r} vs "
-                                f"{second.get('load_bearing_step_class')!r}"
+                                f"{cid}: critical cross-confirmation full audit tuple mismatch "
+                                "(verdict, claim_type, normalized claim_scope, "
+                                "load_bearing_step_class, negative_assertion_classes)"
                             )
                     if xc_status in {"third_confirmed_first", "third_confirmed_second", "third_confirmed_hybrid"}:
                         third = xc.get("third_audit") or {}
@@ -1065,12 +1089,11 @@ def main() -> int:
                                     )
                             else:
                                 winning = first if xc_status == "third_confirmed_first" else second
-                                for key in ("verdict", "claim_type", "load_bearing_step_class"):
-                                    if third.get(key) != winning.get(key):
-                                        errors.append(
-                                            f"{cid}: {xc_status} third_audit {key}={third.get(key)!r} "
-                                            f"does not match winning audit {winning.get(key)!r}"
-                                        )
+                                if not audit_summary_tuples_match(third, winning):
+                                    errors.append(
+                                        f"{cid}: {xc_status} third_audit full audit tuple "
+                                        "does not match the winning audit"
+                                    )
 
         if a == "audited_decoration":
             parent = row.get("decoration_parent_claim_id")

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -115,6 +115,17 @@ def audit_summary_tuples_match(first: dict, second: dict) -> bool:
     )
 
 
+def live_row_audit_tuple(row: dict) -> dict:
+    """Project the authoritative live row onto the v2 agreement tuple."""
+    return {
+        "verdict": row.get("audit_status"),
+        "claim_type": row.get("claim_type"),
+        "claim_scope": row.get("claim_scope"),
+        "load_bearing_step_class": row.get("load_bearing_step_class"),
+        "negative_assertion_classes": row.get("negative_assertion_classes"),
+    }
+
+
 def audit_summary_tuple_schema_error(summary: object) -> str | None:
     """Require a complete, typed v2 agreement tuple before comparison."""
     if not isinstance(summary, dict) or not summary:
@@ -1037,6 +1048,16 @@ def main() -> int:
                     "legacy_cross_confirmation_tuple_mismatch",
                     message + "; legacy confirmation requires fresh re-audit",
                 )
+            if (
+                exact_tuple_schema
+                and tuple_schema_valid
+                and tuples_match is True
+                and not audit_summary_tuples_match(live_row_audit_tuple(row), second)
+            ):
+                errors.append(
+                    f"{cid}: authoritative live row full audit tuple does not "
+                    "match the confirmed consensus"
+                )
         if isinstance(xc, dict) and xc_status in {"third_confirmed_first", "third_confirmed_second", "third_confirmed_hybrid"}:
             expected_side = {
                 "third_confirmed_first": "first",
@@ -1105,6 +1126,17 @@ def main() -> int:
                     add_notice(
                         "legacy_cross_confirmation_tuple_mismatch",
                         message + "; legacy confirmation requires fresh re-audit",
+                    )
+                if (
+                    exact_tuple_schema
+                    and tuple_schema_valid
+                    and not audit_summary_tuples_match(
+                        live_row_audit_tuple(row), third_dict
+                    )
+                ):
+                    errors.append(
+                        f"{cid}: authoritative live row full audit tuple does not "
+                        f"match {xc_status} consensus"
                     )
                 if (
                     summary_access_allowed

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -113,6 +113,45 @@ def audit_summary_tuples_match(first: dict, second: dict) -> bool:
     )
 
 
+def audit_summary_tuple_schema_error(summary: object) -> str | None:
+    """Require a complete, typed v2 agreement tuple before comparison."""
+    if not isinstance(summary, dict) or not summary:
+        return "audit summary must be a non-empty object"
+    required = {
+        "verdict",
+        "claim_type",
+        "claim_scope",
+        "load_bearing_step_class",
+        "negative_assertion_classes",
+    }
+    missing = required - set(summary)
+    if missing:
+        return f"audit summary missing tuple fields: {sorted(missing)}"
+    verdict = summary.get("verdict")
+    if verdict not in ALLOWED_AUDIT_STATUSES or verdict in {
+        "unaudited", "audit_in_progress"
+    }:
+        return f"audit summary has non-terminal verdict {verdict!r}"
+    claim_type = summary.get("claim_type")
+    if claim_type not in ALLOWED_CLAIM_TYPES or claim_type is None:
+        return f"audit summary has invalid claim_type {claim_type!r}"
+    scope = summary.get("claim_scope")
+    if not isinstance(scope, str) or not scope.strip():
+        return "audit summary claim_scope must be a non-empty string"
+    step_class = summary.get("load_bearing_step_class")
+    if not isinstance(step_class, str) or not step_class.strip():
+        return "audit summary load_bearing_step_class must be a non-empty string"
+    declared = summary.get("negative_assertion_classes")
+    if not isinstance(declared, list) or not all(
+        isinstance(item, str) for item in declared
+    ):
+        return "audit summary negative_assertion_classes must be a list of strings"
+    unknown = sorted(set(declared) - no_go_discipline_gate.POLICY_NEGATIVE_CLASSES)
+    if unknown:
+        return f"audit summary has unknown negative_assertion_classes: {unknown}"
+    return None
+
+
 def is_retained_grade(status):
     """Mirror compute_effective_status.is_retained_grade: literal retained-grade
     keywords plus `decoration_under_<parent>` (which is only assigned when the
@@ -937,13 +976,26 @@ def main() -> int:
 
         xc = row.get("cross_confirmation") or {}
         xc_status = xc.get("status") if isinstance(xc, dict) else None
+        agreement_schema = xc.get("agreement_schema") if isinstance(xc, dict) else None
+        if agreement_schema not in {None, AUDIT_TUPLE_AGREEMENT_SCHEMA}:
+            errors.append(
+                f"{cid}: unsupported cross_confirmation.agreement_schema "
+                f"{agreement_schema!r}"
+            )
         exact_tuple_schema = (
             isinstance(xc, dict)
-            and xc.get("agreement_schema") == AUDIT_TUPLE_AGREEMENT_SCHEMA
+            and agreement_schema == AUDIT_TUPLE_AGREEMENT_SCHEMA
         )
         if isinstance(xc, dict) and xc_status == "confirmed":
             first = xc.get("first_audit") or {}
             second = xc.get("second_audit") or {}
+            if exact_tuple_schema:
+                for label, summary in (("first_audit", first), ("second_audit", second)):
+                    schema_error = audit_summary_tuple_schema_error(summary)
+                    if schema_error:
+                        errors.append(
+                            f"{cid}: versioned cross_confirmation.{label} {schema_error}"
+                        )
             if not audit_summary_tuples_match(first, second):
                 message = (
                     f"{cid}: confirmed cross-confirmation full audit tuple mismatch "
@@ -970,6 +1022,18 @@ def main() -> int:
             if not third:
                 errors.append(f"{cid}: {xc_status} requires third_audit")
             else:
+                if exact_tuple_schema:
+                    for label, summary in (
+                        ("first_audit", first),
+                        ("second_audit", second),
+                        ("third_audit", third),
+                    ):
+                        schema_error = audit_summary_tuple_schema_error(summary)
+                        if schema_error:
+                            errors.append(
+                                f"{cid}: versioned cross_confirmation.{label} "
+                                f"{schema_error}"
+                            )
                 side = third.get("sided_with")
                 if side is not None and side != expected_side:
                     errors.append(

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -995,6 +995,7 @@ def main() -> int:
             isinstance(xc, dict)
             and agreement_schema == AUDIT_TUPLE_AGREEMENT_SCHEMA
         )
+        summary_access_allowed = agreement_schema is None
         if isinstance(xc, dict) and xc_status == "confirmed":
             first = xc.get("first_audit") or {}
             second = xc.get("second_audit") or {}
@@ -1012,6 +1013,10 @@ def main() -> int:
                 if agreement_schema is None
                 or (exact_tuple_schema and tuple_schema_valid)
                 else None
+            )
+            summary_access_allowed = (
+                agreement_schema is None
+                or (exact_tuple_schema and tuple_schema_valid)
             )
             if exact_tuple_schema and tuple_schema_valid and tuples_match is False:
                 errors.append(
@@ -1167,14 +1172,15 @@ def main() -> int:
                     f"{cid}: criticality={criticality} requires independence != 'weak' for audited_clean"
                 )
             if criticality == "critical":
-                xc = row.get("cross_confirmation") or {}
+                xc_value = row.get("cross_confirmation")
+                xc = xc_value if isinstance(xc_value, dict) else {}
                 xc_status = xc.get("status")
                 if xc_status not in {"confirmed", "third_confirmed_first", "third_confirmed_second", "third_confirmed_hybrid"}:
                     errors.append(
                         f"{cid}: critical claim requires confirmed cross-confirmation; "
                         f"got {xc_status!r}"
                     )
-                else:
+                elif summary_access_allowed:
                     first_value = xc.get("first_audit")
                     second_value = xc.get("second_audit")
                     first = first_value if isinstance(first_value, dict) else {}

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -490,6 +490,12 @@ def main() -> int:
         if verdict in {None, "unaudited"}:
             return
         packet = audit_like.get("no_go_discipline")
+        forensic_tier = bool(
+            source_required
+            or audit_like.get("claim_type") == "no_go"
+            or row.get("claim_type") == "no_go"
+            or no_go_discipline_gate.forensic_mode()
+        )
         required = source_required or no_go_discipline_gate.output_requires_no_go_discipline(
             audit_like
         )
@@ -520,19 +526,23 @@ def main() -> int:
                 "chain_closes", verdict == "audited_clean"
             ),
         }
-        evidence_manifest = no_go_discipline_gate.evidence_manifest_from_snapshot(packet)
-        current_manifest = no_go_discipline_gate.build_evidence_manifest(
-            row, rows, REPO_ROOT
-        )
-        if evidence_manifest is None:
-            report_invalid("authenticated evidence_snapshot is required")
-            return
-        snapshot_error = no_go_discipline_gate.evidence_snapshot_current_error(
-            packet, current_manifest
-        )
-        if snapshot_error:
-            report_invalid(snapshot_error)
-            return
+        evidence_manifest = None
+        if forensic_tier:
+            evidence_manifest = no_go_discipline_gate.evidence_manifest_from_snapshot(
+                packet
+            )
+            current_manifest = no_go_discipline_gate.build_evidence_manifest(
+                row, rows, REPO_ROOT
+            )
+            if evidence_manifest is None:
+                report_invalid("authenticated evidence_snapshot is required")
+                return
+            snapshot_error = no_go_discipline_gate.evidence_snapshot_current_error(
+                packet, current_manifest
+            )
+            if snapshot_error:
+                report_invalid(snapshot_error)
+                return
         error = no_go_discipline_gate.validate_no_go_discipline(
             normalized,
             source_required=source_required,

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -102,6 +102,8 @@ def normalized_negative_assertion_classes(audit_like: dict) -> tuple[str, ...]:
 
 def audit_summary_tuples_match(first: dict, second: dict) -> bool:
     """Mirror apply_audit's full cross-confirmation agreement tuple."""
+    if not isinstance(first, dict) or not isinstance(second, dict):
+        return False
     return (
         first.get("verdict") == second.get("verdict")
         and first.get("claim_type") == second.get("claim_type")
@@ -128,12 +130,15 @@ def audit_summary_tuple_schema_error(summary: object) -> str | None:
     if missing:
         return f"audit summary missing tuple fields: {sorted(missing)}"
     verdict = summary.get("verdict")
-    if verdict not in ALLOWED_AUDIT_STATUSES or verdict in {
+    if not isinstance(verdict, str) or verdict not in ALLOWED_AUDIT_STATUSES or verdict in {
         "unaudited", "audit_in_progress"
     }:
         return f"audit summary has non-terminal verdict {verdict!r}"
     claim_type = summary.get("claim_type")
-    if claim_type not in ALLOWED_CLAIM_TYPES or claim_type is None:
+    if (
+        not isinstance(claim_type, str)
+        or claim_type not in ALLOWED_CLAIM_TYPES
+    ):
         return f"audit summary has invalid claim_type {claim_type!r}"
     scope = summary.get("claim_scope")
     if not isinstance(scope, str) or not scope.strip():
@@ -989,26 +994,32 @@ def main() -> int:
         if isinstance(xc, dict) and xc_status == "confirmed":
             first = xc.get("first_audit") or {}
             second = xc.get("second_audit") or {}
+            tuple_schema_valid = True
             if exact_tuple_schema:
                 for label, summary in (("first_audit", first), ("second_audit", second)):
                     schema_error = audit_summary_tuple_schema_error(summary)
                     if schema_error:
+                        tuple_schema_valid = False
                         errors.append(
                             f"{cid}: versioned cross_confirmation.{label} {schema_error}"
                         )
-            if not audit_summary_tuples_match(first, second):
+            tuples_match = audit_summary_tuples_match(first, second)
+            if exact_tuple_schema and tuple_schema_valid and not tuples_match:
+                errors.append(
+                    f"{cid}: confirmed cross-confirmation full audit tuple mismatch "
+                    "(verdict, claim_type, normalized claim_scope, "
+                    "load_bearing_step_class, negative_assertion_classes)"
+                )
+            elif agreement_schema is None and not tuples_match:
                 message = (
                     f"{cid}: confirmed cross-confirmation full audit tuple mismatch "
                     "(verdict, claim_type, normalized claim_scope, "
                     "load_bearing_step_class, negative_assertion_classes)"
                 )
-                if exact_tuple_schema:
-                    errors.append(message)
-                else:
-                    add_notice(
-                        "legacy_cross_confirmation_tuple_mismatch",
-                        message + "; legacy confirmation requires fresh re-audit",
-                    )
+                add_notice(
+                    "legacy_cross_confirmation_tuple_mismatch",
+                    message + "; legacy confirmation requires fresh re-audit",
+                )
         if isinstance(xc, dict) and xc_status in {"third_confirmed_first", "third_confirmed_second", "third_confirmed_hybrid"}:
             expected_side = {
                 "third_confirmed_first": "first",
@@ -1022,6 +1033,7 @@ def main() -> int:
             if not third:
                 errors.append(f"{cid}: {xc_status} requires third_audit")
             else:
+                tuple_schema_valid = True
                 if exact_tuple_schema:
                     for label, summary in (
                         ("first_audit", first),
@@ -1030,6 +1042,7 @@ def main() -> int:
                     ):
                         schema_error = audit_summary_tuple_schema_error(summary)
                         if schema_error:
+                            tuple_schema_valid = False
                             errors.append(
                                 f"{cid}: versioned cross_confirmation.{label} "
                                 f"{schema_error}"
@@ -1039,20 +1052,30 @@ def main() -> int:
                     errors.append(
                         f"{cid}: {xc_status} conflicts with third_audit.sided_with={side!r}"
                     )
-                if expected_side != "hybrid" and not audit_summary_tuples_match(
-                    third, winning
+                tuples_match = audit_summary_tuples_match(third, winning)
+                if (
+                    expected_side != "hybrid"
+                    and exact_tuple_schema
+                    and tuple_schema_valid
+                    and not tuples_match
+                ):
+                    errors.append(
+                        f"{cid}: {xc_status} third_audit full audit tuple does not "
+                        "match the winning audit"
+                    )
+                elif (
+                    expected_side != "hybrid"
+                    and agreement_schema is None
+                    and not tuples_match
                 ):
                     message = (
                         f"{cid}: {xc_status} third_audit full audit tuple does not "
                         "match the winning audit"
                     )
-                    if exact_tuple_schema:
-                        errors.append(message)
-                    else:
-                        add_notice(
-                            "legacy_cross_confirmation_tuple_mismatch",
-                            message + "; legacy confirmation requires fresh re-audit",
-                        )
+                    add_notice(
+                        "legacy_cross_confirmation_tuple_mismatch",
+                        message + "; legacy confirmation requires fresh re-audit",
+                    )
                 if row.get("claim_type_provenance") == "judicial_review":
                     for key in ("verdict", "claim_type", "load_bearing_step_class"):
                         row_key = "audit_status" if key == "verdict" else key
@@ -1127,8 +1150,10 @@ def main() -> int:
                         f"got {xc_status!r}"
                     )
                 else:
-                    first = xc.get("first_audit") or {}
-                    second = xc.get("second_audit") or {}
+                    first_value = xc.get("first_audit")
+                    second_value = xc.get("second_audit")
+                    first = first_value if isinstance(first_value, dict) else {}
+                    second = second_value if isinstance(second_value, dict) else {}
                     if first.get("auditor") and first.get("auditor") == second.get("auditor"):
                         errors.append(
                             f"{cid}: critical cross-confirmation reused auditor identity/session "
@@ -1144,7 +1169,8 @@ def main() -> int:
                             "second_audit.independence='fresh_context'"
                         )
                     if xc_status in {"third_confirmed_first", "third_confirmed_second", "third_confirmed_hybrid"}:
-                        third = xc.get("third_audit") or {}
+                        third_value = xc.get("third_audit")
+                        third = third_value if isinstance(third_value, dict) else {}
                         if not third:
                             errors.append(f"{cid}: {xc_status} requires third_audit")
                         elif third.get("auditor") in {first.get("auditor"), second.get("auditor")}:

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -498,7 +498,7 @@ def main() -> int:
         )
         required = source_required or no_go_discipline_gate.output_requires_no_go_discipline(
             audit_like
-        )
+        ) or bool(audit_like.get("negative_assertion_classes"))
         if required and packet is None:
             message = (
                 f"{cid}: {label} lacks structured No-Go Discipline and "
@@ -547,6 +547,7 @@ def main() -> int:
             normalized,
             source_required=source_required,
             evidence_manifest=evidence_manifest,
+            structural_only=not forensic_tier,
         )
         if error:
             report_invalid(error)
@@ -726,6 +727,7 @@ def main() -> int:
             archived_error = no_go_discipline_gate.validate_no_go_discipline(
                 archived_blob,
                 evidence_manifest=None,
+                structural_only=True,
             )
             if archived_error:
                 message = (

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -982,7 +982,10 @@ def main() -> int:
         xc = row.get("cross_confirmation") or {}
         xc_status = xc.get("status") if isinstance(xc, dict) else None
         agreement_schema = xc.get("agreement_schema") if isinstance(xc, dict) else None
-        if agreement_schema not in {None, AUDIT_TUPLE_AGREEMENT_SCHEMA}:
+        if (
+            agreement_schema is not None
+            and agreement_schema != AUDIT_TUPLE_AGREEMENT_SCHEMA
+        ):
             errors.append(
                 f"{cid}: unsupported cross_confirmation.agreement_schema "
                 f"{agreement_schema!r}"
@@ -1003,14 +1006,19 @@ def main() -> int:
                         errors.append(
                             f"{cid}: versioned cross_confirmation.{label} {schema_error}"
                         )
-            tuples_match = audit_summary_tuples_match(first, second)
-            if exact_tuple_schema and tuple_schema_valid and not tuples_match:
+            tuples_match = (
+                audit_summary_tuples_match(first, second)
+                if agreement_schema is None
+                or (exact_tuple_schema and tuple_schema_valid)
+                else None
+            )
+            if exact_tuple_schema and tuple_schema_valid and tuples_match is False:
                 errors.append(
                     f"{cid}: confirmed cross-confirmation full audit tuple mismatch "
                     "(verdict, claim_type, normalized claim_scope, "
                     "load_bearing_step_class, negative_assertion_classes)"
                 )
-            elif agreement_schema is None and not tuples_match:
+            elif agreement_schema is None and tuples_match is False:
                 message = (
                     f"{cid}: confirmed cross-confirmation full audit tuple mismatch "
                     "(verdict, claim_type, normalized claim_scope, "
@@ -1029,7 +1037,8 @@ def main() -> int:
             first = xc.get("first_audit") or {}
             second = xc.get("second_audit") or {}
             winning = first if expected_side == "first" else second
-            third = xc.get("third_audit") or {}
+            third_value = xc.get("third_audit")
+            third = third_value if isinstance(third_value, dict) else third_value or {}
             if not third:
                 errors.append(f"{cid}: {xc_status} requires third_audit")
             else:
@@ -1047,17 +1056,23 @@ def main() -> int:
                                 f"{cid}: versioned cross_confirmation.{label} "
                                 f"{schema_error}"
                             )
-                side = third.get("sided_with")
+                third_dict = third if isinstance(third, dict) else {}
+                side = third_dict.get("sided_with")
                 if side is not None and side != expected_side:
                     errors.append(
                         f"{cid}: {xc_status} conflicts with third_audit.sided_with={side!r}"
                     )
-                tuples_match = audit_summary_tuples_match(third, winning)
+                tuples_match = (
+                    audit_summary_tuples_match(third, winning)
+                    if agreement_schema is None
+                    or (exact_tuple_schema and tuple_schema_valid)
+                    else None
+                )
                 if (
                     expected_side != "hybrid"
                     and exact_tuple_schema
                     and tuple_schema_valid
-                    and not tuples_match
+                    and tuples_match is False
                 ):
                     errors.append(
                         f"{cid}: {xc_status} third_audit full audit tuple does not "
@@ -1066,7 +1081,7 @@ def main() -> int:
                 elif (
                     expected_side != "hybrid"
                     and agreement_schema is None
-                    and not tuples_match
+                    and tuples_match is False
                 ):
                     message = (
                         f"{cid}: {xc_status} third_audit full audit tuple does not "
@@ -1079,10 +1094,10 @@ def main() -> int:
                 if row.get("claim_type_provenance") == "judicial_review":
                     for key in ("verdict", "claim_type", "load_bearing_step_class"):
                         row_key = "audit_status" if key == "verdict" else key
-                        if third.get(key) is not None and row.get(row_key) != third.get(key):
+                        if third_dict.get(key) is not None and row.get(row_key) != third_dict.get(key):
                             errors.append(
                                 f"{cid}: judicial_review row {row_key}={row.get(row_key)!r} "
-                                f"does not match third_audit {key}={third.get(key)!r}"
+                                f"does not match third_audit {key}={third_dict.get(key)!r}"
                             )
 
         if a == "audited_clean":

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -965,7 +965,8 @@ def main() -> int:
                 other_side_non_claude = False
                 if xc_status in {"confirmed", "third_confirmed_first", "third_confirmed_second", "third_confirmed_hybrid"}:
                     for key in ("first_audit", "second_audit", "third_audit"):
-                        side = (xc.get(key) or {}) if isinstance(xc, dict) else {}
+                        side_value = xc.get(key) if isinstance(xc, dict) else None
+                        side = side_value if isinstance(side_value, dict) else {}
                         side_fam = side.get("auditor_family") or ""
                         if side_fam and not side_fam.startswith("claude-"):
                             other_side_non_claude = True
@@ -1057,11 +1058,17 @@ def main() -> int:
                                 f"{schema_error}"
                             )
                 third_dict = third if isinstance(third, dict) else {}
-                side = third_dict.get("sided_with")
-                if side is not None and side != expected_side:
-                    errors.append(
-                        f"{cid}: {xc_status} conflicts with third_audit.sided_with={side!r}"
-                    )
+                summary_access_allowed = (
+                    agreement_schema is None
+                    or (exact_tuple_schema and tuple_schema_valid)
+                )
+                if summary_access_allowed:
+                    side = third_dict.get("sided_with")
+                    if side is not None and side != expected_side:
+                        errors.append(
+                            f"{cid}: {xc_status} conflicts with "
+                            f"third_audit.sided_with={side!r}"
+                        )
                 tuples_match = (
                     audit_summary_tuples_match(third, winning)
                     if agreement_schema is None
@@ -1091,7 +1098,10 @@ def main() -> int:
                         "legacy_cross_confirmation_tuple_mismatch",
                         message + "; legacy confirmation requires fresh re-audit",
                     )
-                if row.get("claim_type_provenance") == "judicial_review":
+                if (
+                    summary_access_allowed
+                    and row.get("claim_type_provenance") == "judicial_review"
+                ):
                     for key in ("verdict", "claim_type", "load_bearing_step_class"):
                         row_key = "audit_status" if key == "verdict" else key
                         if third_dict.get(key) is not None and row.get(row_key) != third_dict.get(key):

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -982,9 +982,12 @@ def main() -> int:
 
         xc = row.get("cross_confirmation") or {}
         xc_status = xc.get("status") if isinstance(xc, dict) else None
-        agreement_schema = xc.get("agreement_schema") if isinstance(xc, dict) else None
+        agreement_schema_present = (
+            isinstance(xc, dict) and "agreement_schema" in xc
+        )
+        agreement_schema = xc.get("agreement_schema") if agreement_schema_present else None
         if (
-            agreement_schema is not None
+            agreement_schema_present
             and agreement_schema != AUDIT_TUPLE_AGREEMENT_SCHEMA
         ):
             errors.append(
@@ -995,7 +998,7 @@ def main() -> int:
             isinstance(xc, dict)
             and agreement_schema == AUDIT_TUPLE_AGREEMENT_SCHEMA
         )
-        summary_access_allowed = agreement_schema is None
+        summary_access_allowed = not agreement_schema_present
         if isinstance(xc, dict) and xc_status == "confirmed":
             first = xc.get("first_audit") or {}
             second = xc.get("second_audit") or {}
@@ -1010,12 +1013,12 @@ def main() -> int:
                         )
             tuples_match = (
                 audit_summary_tuples_match(first, second)
-                if agreement_schema is None
+                if not agreement_schema_present
                 or (exact_tuple_schema and tuple_schema_valid)
                 else None
             )
             summary_access_allowed = (
-                agreement_schema is None
+                not agreement_schema_present
                 or (exact_tuple_schema and tuple_schema_valid)
             )
             if exact_tuple_schema and tuple_schema_valid and tuples_match is False:
@@ -1024,7 +1027,7 @@ def main() -> int:
                     "(verdict, claim_type, normalized claim_scope, "
                     "load_bearing_step_class, negative_assertion_classes)"
                 )
-            elif agreement_schema is None and tuples_match is False:
+            elif not agreement_schema_present and tuples_match is False:
                 message = (
                     f"{cid}: confirmed cross-confirmation full audit tuple mismatch "
                     "(verdict, claim_type, normalized claim_scope, "
@@ -1064,7 +1067,7 @@ def main() -> int:
                             )
                 third_dict = third if isinstance(third, dict) else {}
                 summary_access_allowed = (
-                    agreement_schema is None
+                    not agreement_schema_present
                     or (exact_tuple_schema and tuple_schema_valid)
                 )
                 if summary_access_allowed:
@@ -1076,7 +1079,7 @@ def main() -> int:
                         )
                 tuples_match = (
                     audit_summary_tuples_match(third, winning)
-                    if agreement_schema is None
+                    if not agreement_schema_present
                     or (exact_tuple_schema and tuple_schema_valid)
                     else None
                 )
@@ -1092,7 +1095,7 @@ def main() -> int:
                     )
                 elif (
                     expected_side != "hybrid"
-                    and agreement_schema is None
+                    and not agreement_schema_present
                     and tuples_match is False
                 ):
                     message = (

--- a/docs/audit/scripts/compute_lane_certification.py
+++ b/docs/audit/scripts/compute_lane_certification.py
@@ -6,9 +6,10 @@ scientific root claim or claims and their transitive dependency closure and
 report whether every row is currently chain-satisfying: retained-grade, a
 decoration of a retained parent, or an accepted premise.
 Certification is a state the repository re-enters continuously as audit
-throughput catches up with landings — never a scheduled event. A lane's
-marker rolling back (after an axiom edit or source change) is the honest
-coordination signal, not an error.
+throughput and source-level science catch up with landings — never a scheduled
+event. A configured open-gate root intentionally remains uncertified until the
+obligation is retired or replaced. A lane's marker rolling back (after an axiom
+edit or source change) is the honest coordination signal, not an error.
 """
 from __future__ import annotations
 

--- a/docs/audit/scripts/compute_lane_certification.py
+++ b/docs/audit/scripts/compute_lane_certification.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Rolling lane certification (two-tier assurance, owner-approved 2026-07-12).
 
-For each flagship lane in lane_certification_config.json, walk the root
-claim's transitive dependency closure in the citation graph and report
-whether every row is currently chain-satisfying: retained-grade, a decoration
-of a retained parent, permitted metadata context, or an accepted premise.
+For each flagship lane in lane_certification_config.json, walk the configured
+scientific root claim or claims and their transitive dependency closure and
+report whether every row is currently chain-satisfying: retained-grade, a
+decoration of a retained parent, or an accepted premise.
 Certification is a state the repository re-enters continuously as audit
 throughput catches up with landings — never a scheduled event. A lane's
 marker rolling back (after an axiom edit or source change) is the honest
@@ -37,8 +37,6 @@ def status_satisfies_certification(claim_id: str, status: object) -> bool:
         return True
     if isinstance(status, str) and status.startswith("decoration_under_"):
         return True
-    if status == "meta":
-        return not premise_nodes.is_non_evidence_context_dep(claim_id)
     return False
 
 
@@ -56,20 +54,50 @@ def main() -> int:
 
     lanes_out = []
     for lane in config.get("lanes", []):
-        root = lane.get("root")
+        configured_roots = lane.get("roots")
+        roots = (
+            [str(value) for value in configured_roots if value]
+            if isinstance(configured_roots, list)
+            else [str(lane.get("root"))] if lane.get("root") else []
+        )
         name = lane.get("lane")
-        if root not in rows:
-            missing = {"claim_id": root, "effective_status": "not_in_ledger"}
+        missing_roots = [root for root in roots if root not in rows]
+        if not roots or missing_roots:
+            missing = [
+                {"claim_id": root, "effective_status": "not_in_ledger"}
+                for root in missing_roots
+            ]
             lanes_out.append({
-                "lane": name, "root": root, "certified": False,
-                "closure_size": 1, "uncertified_count": 1,
-                "blocking": [missing],
-                "note": "root claim not in ledger",
+                "lane": name,
+                "root": roots[0] if len(roots) == 1 else None,
+                "roots": roots,
+                "certified": False,
+                "closure_size": len(roots),
+                "uncertified_count": len(missing) if roots else 1,
+                "blocking": missing,
+                "note": (
+                    "no root claims configured"
+                    if not roots
+                    else f"root claims not in ledger: {missing_roots}"
+                ),
             })
             continue
         seen: set[str] = set()
-        frontier = [root]
+        frontier = list(roots)
         blocking: list[dict] = []
+        invalid_roots: set[str] = set()
+        for root in roots:
+            root_row = rows[root]
+            if not (
+                root_row.get("claim_type") not in {"meta", "decoration"}
+                and root_row.get("effective_status") in RETAINED_GRADE
+            ):
+                invalid_roots.add(root)
+                blocking.append({
+                    "claim_id": root,
+                    "effective_status": root_row.get("effective_status"),
+                    "reason": "root_not_retained_science",
+                })
         while frontier:
             cid = frontier.pop()
             if cid in seen:
@@ -82,14 +110,15 @@ def main() -> int:
                 blocking.append({"claim_id": cid, "effective_status": "not_in_ledger"})
                 continue
             status = row.get("effective_status")
-            if not status_satisfies_certification(cid, status):
+            if cid not in invalid_roots and not status_satisfies_certification(cid, status):
                 blocking.append({"claim_id": cid, "effective_status": status})
             for dep in row.get("deps") or []:
                 if dep not in seen:
                     frontier.append(dep)
         lanes_out.append({
             "lane": name,
-            "root": root,
+            "root": roots[0] if len(roots) == 1 else None,
+            "roots": roots,
             "closure_size": len(seen),
             "uncertified_count": len(blocking),
             "certified": not blocking,
@@ -99,7 +128,7 @@ def main() -> int:
         })
 
     OUT.write_text(json.dumps({
-        "schema": "lane_certification_v1",
+        "schema": "lane_certification_v2",
         "repo_head": head,
         "lanes": lanes_out,
     }, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/docs/audit/scripts/invalidate_stale_audits.py
+++ b/docs/audit/scripts/invalidate_stale_audits.py
@@ -339,6 +339,7 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
             },
             source_required=source_required,
             evidence_manifest=evidence_manifest if _forensic else None,
+            structural_only=not _forensic,
         )
         if packet_error:
             if audit_status == "audited_clean":
@@ -361,6 +362,7 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
             required = (
                 source_required
                 or no_go_discipline_gate.output_requires_no_go_discipline(summary)
+                or bool(summary.get("negative_assertion_classes"))
             )
             if nested_packet is None:
                 if required and verdict == "audited_clean":
@@ -403,6 +405,7 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
                     evidence_manifest=(
                         evidence_manifest if nested_forensic else None
                     ),
+                    structural_only=not nested_forensic,
                 )
             if packet_error:
                 digest = hashlib.sha256(packet_error.encode("utf-8")).hexdigest()[:12]

--- a/docs/audit/scripts/invalidate_stale_audits.py
+++ b/docs/audit/scripts/invalidate_stale_audits.py
@@ -414,6 +414,13 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
     if audit_status == "audit_in_progress":
         return None
 
+    if (
+        audit_status not in {None, "unaudited"}
+        and bool(row.get("negative_assertion_classes"))
+        and packet is None
+    ):
+        return "no_go_discipline_packet_missing"
+
     if audit_status == "audited_clean":
         output_required = no_go_discipline_gate.output_requires_no_go_discipline(
             {**row, "verdict": audit_status}
@@ -718,6 +725,7 @@ def archive_and_reset(row: dict, reason: str) -> dict:
         else:
             new_row[k] = v
     new_row.pop("no_go_discipline", None)
+    new_row.pop("negative_assertion_classes", None)
     source_hint = row.get("claim_type_author_hint")
     if source_hint in CLAIM_TYPES:
         new_row["claim_type"] = source_hint
@@ -755,6 +763,9 @@ def soft_reset_to_cross_confirmation_pending(row: dict, reason: str) -> dict:
         "claim_type": row.get("claim_type"),
         "claim_scope": row.get("claim_scope"),
         "load_bearing_step_class": row.get("load_bearing_step_class"),
+        "negative_assertion_classes": list(
+            row.get("negative_assertion_classes") or []
+        ),
         "verdict": row.get("audit_status"),
     }
     if row.get("no_go_discipline") is not None:

--- a/docs/audit/scripts/no_go_discipline_gate.py
+++ b/docs/audit/scripts/no_go_discipline_gate.py
@@ -4000,6 +4000,7 @@ def validate_no_go_discipline(
     evidence_manifest: dict[str, dict] | None = None,
     prior_claim_scope: str | None = None,
     require_declaration: bool = False,
+    structural_only: bool = False,
 ) -> str | None:
     declared = audit.get("negative_assertion_classes")
     if require_declaration:
@@ -4033,7 +4034,9 @@ def validate_no_go_discipline(
         return "No-Go Discipline N1-N8 packet is required for this audit"
     if packet is None:
         return None
-    if evidence_manifest is None:
+    if structural_only:
+        evidence_manifest = None
+    elif evidence_manifest is None:
         evidence_manifest = evidence_manifest_from_snapshot(packet)
     error = _unknown_fields(
         packet,

--- a/docs/audit/scripts/no_go_discipline_gate.py
+++ b/docs/audit/scripts/no_go_discipline_gate.py
@@ -2709,8 +2709,6 @@ def source_requires_no_go_discipline(
 def output_requires_no_go_discipline(audit: dict[str, Any]) -> bool:
     if audit.get("claim_type") == "no_go":
         return True
-    if not forensic_mode():
-        return False
     boundary = "\n".join(str(audit.get(field) or "") for field in OUTPUT_BOUNDARY_FIELDS)
     if _has_negative_boundary_assertion(boundary):
         return True

--- a/docs/audit/scripts/no_go_discipline_gate.py
+++ b/docs/audit/scripts/no_go_discipline_gate.py
@@ -2709,6 +2709,8 @@ def source_requires_no_go_discipline(
 def output_requires_no_go_discipline(audit: dict[str, Any]) -> bool:
     if audit.get("claim_type") == "no_go":
         return True
+    if not forensic_mode():
+        return False
     boundary = "\n".join(str(audit.get(field) or "") for field in OUTPUT_BOUNDARY_FIELDS)
     if _has_negative_boundary_assertion(boundary):
         return True

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -774,10 +774,24 @@ def selected_batch(targets: list[dict], max_workers: int) -> list[dict]:
 def scope_for_args(args: argparse.Namespace, rows: dict[str, dict]) -> set[str]:
     if args.lane:
         config = json.loads((DATA / "lane_certification_config.json").read_text(encoding="utf-8"))
-        roots = [lane["root"] for lane in config.get("lanes", []) if lane.get("lane") == args.lane]
+        roots: list[str] = []
+        for lane in config.get("lanes", []):
+            if lane.get("lane") != args.lane:
+                continue
+            configured_roots = lane.get("roots")
+            if isinstance(configured_roots, list):
+                roots.extend(
+                    root for root in configured_roots
+                    if isinstance(root, str) and root
+                )
+            elif isinstance(lane.get("root"), str) and lane["root"]:
+                roots.append(lane["root"])
         if not roots:
             raise ValueError(f"unknown lane {args.lane!r}")
-        return lane_closure(roots[0], rows)
+        scope: set[str] = set()
+        for root in roots:
+            scope.update(lane_closure(root, rows))
+        return scope
     return {claim.strip() for claim in args.claims.split(",") if claim.strip()}
 
 

--- a/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
+++ b/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
@@ -586,6 +586,7 @@ def restore_audit_from_previous(
         "verdict_rationale": new_row.get("verdict_rationale"),
         "notes_for_re_audit_if_any": new_row.get("notes_for_re_audit_if_any"),
         "no_go_discipline": new_row.get("no_go_discipline"),
+        "negative_assertion_classes": new_row.get("negative_assertion_classes"),
     }
     with _forensic_gate():
         output_required = no_go_discipline_gate.output_requires_no_go_discipline(
@@ -633,6 +634,7 @@ def restore_audit_from_previous(
             summary_requires_packet = (
                 source_required
                 or no_go_discipline_gate.output_requires_no_go_discipline(summary)
+                or bool(summary.get("negative_assertion_classes"))
             )
             packet = summary.get("no_go_discipline")
             if packet is None:
@@ -668,8 +670,8 @@ def restore_audit_from_previous(
                 evidence_manifest=manifest,
             ):
                 return None
-    # A present packet must round-trip and validate. Packetless negative clean
-    # authority is deliberately not restorable under the current gate.
+    # Restoration is a certification-like act: a present packet must
+    # round-trip through its authenticated snapshot and validate forensically.
     if new_row.get("no_go_discipline") is not None:
         evidence_manifest = no_go_discipline_gate.evidence_manifest_from_snapshot(
             new_row["no_go_discipline"]

--- a/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
+++ b/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
@@ -142,6 +142,7 @@ ARCHIVED_FIELDS = (
     "claim_type_last_reviewed",
     "notes_for_re_audit_if_any",
     "no_go_discipline",
+    "negative_assertion_classes",
     "audit_invocation_id",
     "audit_invocation_history",
     "negative_assertion_classes",
@@ -603,6 +604,11 @@ def restore_audit_from_previous(
         isinstance(d, list) and bool(d)
         for d in (declared_archived, declared_live)
     )
+    if (
+        bool(new_row.get("negative_assertion_classes"))
+        and new_row.get("no_go_discipline") is None
+    ):
+        return None
     if (
         new_row.get("audit_status") == "audited_clean"
         and (source_required or output_required or declared_requires)

--- a/docs/audit/scripts/seed_audit_ledger.py
+++ b/docs/audit/scripts/seed_audit_ledger.py
@@ -109,7 +109,10 @@ EMPTY_AUDIT = {
 
 # Audit fields that are preserved across re-seeds when the note hash is
 # unchanged. If the hash changes, these are archived and reset.
-AUDIT_FIELDS = list(EMPTY_AUDIT.keys()) + ["no_go_discipline"]
+AUDIT_FIELDS = list(EMPTY_AUDIT.keys()) + [
+    "no_go_discipline",
+    "negative_assertion_classes",
+]
 
 DEFAULT_PROSE_STATUS = "not_evaluated_pre_vocab_lint"
 
@@ -186,6 +189,7 @@ def reset_unaudited_audit_fields(row: dict) -> None:
     # replayable merely because the live audit-owned fields were cleared.
     row["audit_invocation_history"] = invocation_history
     row.pop("no_go_discipline", None)
+    row.pop("negative_assertion_classes", None)
 
 
 def is_excluded_source_path(path: str) -> bool:
@@ -480,6 +484,7 @@ def archive_prior_audit(row: dict) -> dict:
     for k, v in EMPTY_AUDIT.items():
         new_row[k] = v if not isinstance(v, (list, dict)) else (list(v) if isinstance(v, list) else dict(v))
     new_row.pop("no_go_discipline", None)
+    new_row.pop("negative_assertion_classes", None)
     return new_row
 
 

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -1055,6 +1055,40 @@ class ApplyAuditTest(unittest.TestCase):
             self.assertEqual(m.run_propagation(), 0)
         self.assertEqual(invalidation_calls, 2)
 
+    def test_propagation_runs_restoration_to_joint_fixed_point(self):
+        m = _import("apply_audit")
+        _patch_repo_root(m, self.tmp_root)
+        m.LEDGER_PATH.parent.mkdir(parents=True, exist_ok=True)
+        m.LEDGER_PATH.write_text(
+            json.dumps({"rows": {}, "last_invalidations": []}),
+            encoding="utf-8",
+        )
+        invalidation_calls = 0
+        restoration_calls = 0
+
+        def fake_run(cmd, **_kwargs):
+            nonlocal invalidation_calls, restoration_calls
+            name = Path(cmd[1]).name
+            if name == "invalidate_stale_audits.py":
+                invalidation_calls += 1
+                payload = json.loads(m.LEDGER_PATH.read_text(encoding="utf-8"))
+                payload["last_invalidations"] = []
+                m.LEDGER_PATH.write_text(json.dumps(payload), encoding="utf-8")
+            if name == "restore_overaggressively_invalidated_audits.py":
+                restoration_calls += 1
+                restored = 1 if restoration_calls == 1 else 0
+                return mock.Mock(
+                    returncode=0,
+                    stdout=f"Restored {restored} audits across ledger\n",
+                    stderr="",
+                )
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch("subprocess.run", side_effect=fake_run):
+            self.assertEqual(m.run_propagation(), 0)
+        self.assertEqual(invalidation_calls, 2)
+        self.assertEqual(restoration_calls, 2)
+
     def test_audit_invocation_history_rejects_replay_after_newer_audit(self):
         m = _import("apply_audit")
         _patch_repo_root(m, self.tmp_root)
@@ -2192,6 +2226,7 @@ class ApplyAuditTest(unittest.TestCase):
             "negative_assertion_classes": [],
             "ratified_verdict": "audited_clean",
             "ratified_claim_type": "no_go",
+            "ratified_claim_scope": "the obstruction",
             "ratified_load_bearing_step_class": "A",
             "judgment_rationale": "the scoped obstruction closes",
             "first_auditor_error": "none on the scoped result",
@@ -8686,6 +8721,21 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             transport_bounded_n8=True,
         )
         self.assertEqual(error, "transport-bounded N8 evidence forbids audited_clean")
+
+        declared_negative = {
+            **blob,
+            "claim_type": "bounded_theorem",
+            "negative_assertion_classes": ["bounded_with_named_walls"],
+        }
+        self.assertEqual(
+            m.validate_verdict(
+                declared_negative,
+                "target",
+                expected_invocation_id="a" * 32,
+                transport_bounded_n8=True,
+            ),
+            "transport-bounded N8 evidence forbids audited_clean",
+        )
 
     def test_development_runner_validation_ignores_locator_containment(self):
         m = _import_codex_audit_runner()

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -3466,6 +3466,14 @@ class AuditLintTest(unittest.TestCase):
 
         ledger = self.fx.read_ledger()
         cross = ledger["rows"]["critical_claim"]["cross_confirmation"]
+        cross["agreement_schema"] = "audit_tuple_v999"
+        self.fx.write_ledger(ledger)
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = m.main()
+        self.assertEqual(rc, 1, output.getvalue())
+        self.assertIn("unsupported cross_confirmation.agreement_schema", output.getvalue())
+
         cross.pop("agreement_schema")
         self.fx.write_ledger(ledger)
         output = io.StringIO()
@@ -3485,6 +3493,32 @@ class AuditLintTest(unittest.TestCase):
             rc = m.main()
         self.assertEqual(rc, 1, output.getvalue())
         self.assertIn("full audit tuple mismatch", output.getvalue())
+
+        cross["first_audit"]["claim_scope"] = " normalized   scoped\ntheorem "
+        cross["second_audit"]["claim_scope"] = "normalized scoped theorem"
+        cross["first_audit"]["negative_assertion_classes"] = [
+            "conditional_wall_rationale",
+            "bounded_with_named_walls",
+        ]
+        cross["second_audit"]["negative_assertion_classes"] = [
+            "bounded_with_named_walls",
+            "conditional_wall_rationale",
+            "bounded_with_named_walls",
+        ]
+        self.fx.write_ledger(ledger)
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = m.main()
+        self.assertEqual(rc, 0, output.getvalue())
+
+        cross["first_audit"] = {}
+        cross["second_audit"] = {}
+        self.fx.write_ledger(ledger)
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = m.main()
+        self.assertEqual(rc, 1, output.getvalue())
+        self.assertIn("audit summary must be a non-empty object", output.getvalue())
 
     def test_lint_enforces_versioned_tuple_for_all_confirmed_paths(self):
         m = _import("audit_lint")

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -3375,6 +3375,85 @@ class AuditLintTest(unittest.TestCase):
             row.setdefault("deps", [])
         self.fx.write_ledger({"schema_version": 1, "rows": rows})
 
+    def test_cross_confirmation_tuple_normalization_matches_apply_gate(self):
+        m = _import("audit_lint")
+        first = {
+            "verdict": "audited_clean",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "bounded structural scope",
+            "load_bearing_step_class": "A",
+            "negative_assertion_classes": [
+                "conditional_wall_rationale",
+                "bounded_with_named_walls",
+            ],
+        }
+        equivalent = {
+            **first,
+            "claim_scope": " bounded   structural\nscope ",
+            "negative_assertion_classes": [
+                "bounded_with_named_walls",
+                "conditional_wall_rationale",
+                "bounded_with_named_walls",
+            ],
+        }
+        self.assertTrue(m.audit_summary_tuples_match(first, equivalent))
+        self.assertFalse(m.audit_summary_tuples_match(
+            first, {**equivalent, "claim_scope": "different scope"}
+        ))
+        self.assertFalse(m.audit_summary_tuples_match(
+            first, {**equivalent, "negative_assertion_classes": []}
+        ))
+
+    def test_lint_rejects_confirmed_scope_mismatch(self):
+        m = _import("audit_lint")
+        _patch_repo_root(m, self.tmp_root)
+        first = {
+            "auditor": "first-auditor",
+            "auditor_family": "codex-gpt-5.6",
+            "independence": "cross_family",
+            "verdict": "audited_clean",
+            "claim_type": "positive_theorem",
+            "claim_scope": "first scoped theorem",
+            "load_bearing_step_class": "A",
+            "negative_assertion_classes": [],
+        }
+        second = {
+            **first,
+            "auditor": "second-auditor",
+            "independence": "fresh_context",
+            "claim_scope": "substantively different theorem",
+        }
+        rows = {
+            "critical_claim": {
+                "claim_id": "critical_claim",
+                "audit_status": "audited_clean",
+                "effective_status": "retained",
+                "claim_type": "positive_theorem",
+                "claim_scope": second["claim_scope"],
+                "chain_closes": True,
+                "auditor": second["auditor"],
+                "auditor_family": second["auditor_family"],
+                "auditor_model": "gpt-5.6-sol",
+                "auditor_reasoning_effort": "xhigh",
+                "independence": "fresh_context",
+                "criticality": "critical",
+                "load_bearing_step_class": "A",
+                "negative_assertion_classes": [],
+                "cross_confirmation": {
+                    "status": "confirmed",
+                    "first_audit": first,
+                    "second_audit": second,
+                },
+            }
+        }
+        self._write_minimal_ledger(rows)
+        import contextlib, io
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = m.main()
+        self.assertEqual(rc, 1, output.getvalue())
+        self.assertIn("full audit tuple mismatch", output.getvalue())
+
     def test_front_door_current_markdown_link_passes(self):
         m = _import("audit_lint")
         errors = m.front_door_axiom_pointer_errors(

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -3466,14 +3466,22 @@ class AuditLintTest(unittest.TestCase):
 
         ledger = self.fx.read_ledger()
         cross = ledger["rows"]["critical_claim"]["cross_confirmation"]
-        cross["agreement_schema"] = "audit_tuple_v999"
-        self.fx.write_ledger(ledger)
-        output = io.StringIO()
-        with contextlib.redirect_stdout(output):
-            rc = m.main()
-        self.assertEqual(rc, 1, output.getvalue())
-        self.assertIn("unsupported cross_confirmation.agreement_schema", output.getvalue())
-        self.assertNotIn("legacy_cross_confirmation_tuple_mismatch", output.getvalue())
+        for unsupported_schema in ("audit_tuple_v999", [], {}):
+            with self.subTest(unsupported_schema=unsupported_schema):
+                cross["agreement_schema"] = unsupported_schema
+                self.fx.write_ledger(ledger)
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    rc = m.main()
+                self.assertEqual(rc, 1, output.getvalue())
+                self.assertIn(
+                    "unsupported cross_confirmation.agreement_schema",
+                    output.getvalue(),
+                )
+                self.assertNotIn(
+                    "legacy_cross_confirmation_tuple_mismatch",
+                    output.getvalue(),
+                )
 
         cross.pop("agreement_schema")
         self.fx.write_ledger(ledger)
@@ -3609,6 +3617,17 @@ class AuditLintTest(unittest.TestCase):
                     rc = m.main()
                 self.assertEqual(rc, 1, output.getvalue())
                 self.assertIn("full audit tuple", output.getvalue())
+                if winner:
+                    cross["third_audit"] = "malformed-third-summary"
+                    self._write_minimal_ledger(rows)
+                    output = io.StringIO()
+                    with contextlib.redirect_stdout(output):
+                        rc = m.main()
+                    self.assertEqual(rc, 1, output.getvalue())
+                    self.assertIn(
+                        "audit summary must be a non-empty object",
+                        output.getvalue(),
+                    )
 
     def test_front_door_current_markdown_link_passes(self):
         m = _import("audit_lint")

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -1140,7 +1140,7 @@ class ApplyAuditTest(unittest.TestCase):
         }
         with mock.patch.object(
             m, "trusted_evidence_manifest", return_value=manifest
-        ):
+        ), mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
             ok, msg = m.apply_one(led, audit)
         self.assertFalse(ok)
         self.assertIn("clipped evidence", msg)
@@ -1171,7 +1171,9 @@ class ApplyAuditTest(unittest.TestCase):
             m,
             "trusted_manifest_current_error",
             return_value="source drifted",
-        ) as reauth:
+        ) as reauth, mock.patch.dict(
+            os.environ, {"AUDIT_FORENSIC_MODE": "1"}
+        ):
             ok, msg = m.apply_one(led, audit)
         self.assertFalse(ok)
         self.assertIn("source drifted", msg)
@@ -3118,6 +3120,44 @@ class AuditLintTest(unittest.TestCase):
             rc = m.main()
         self.assertEqual(rc, 1)
         self.assertIn("cross_confirmation.first_audit invalid", buf.getvalue())
+
+    def test_lint_tier_gates_snapshot_requirement_for_bounded_packet(self):
+        m = _import("audit_lint")
+        _patch_repo_root(m, self.tmp_root)
+        rows = {
+            "bounded": {
+                "claim_id": "bounded",
+                "_body": "# Exact bounded source\n",
+                "audit_status": "audited_clean",
+                "effective_status": "retained_bounded",
+                "claim_type": "bounded_theorem",
+                "claim_scope": "the scoped obstruction",
+                "chain_closes": True,
+                "auditor": "lint-auditor",
+                "auditor_family": "codex-gpt-5.6",
+                "auditor_model": "gpt-5.6-sol",
+                "auditor_reasoning_effort": "xhigh",
+                "independence": "cross_family",
+                "criticality": "leaf",
+                "load_bearing_step_class": "A",
+                "negative_assertion_classes": [],
+                "no_go_discipline": _no_go_packet(),
+            }
+        }
+        self._write_minimal_ledger(rows)
+        import contextlib, io
+        buf = io.StringIO()
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": ""}), \
+             contextlib.redirect_stdout(buf):
+            rc = m.main()
+        self.assertEqual(rc, 0, buf.getvalue())
+
+        buf = io.StringIO()
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}), \
+             contextlib.redirect_stdout(buf):
+            rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("authenticated evidence_snapshot is required", buf.getvalue())
 
     def test_lint_allows_schema_old_no_go_packet_in_non_authoritative_history(self):
         m = _import("audit_lint")
@@ -7435,6 +7475,7 @@ class ComputeLaneCertificationTest(unittest.TestCase):
         missing = [f"missing_{index:02d}" for index in range(16)]
         rows = {
             "root": {
+                "claim_type": "positive_theorem",
                 "effective_status": "retained",
                 "deps": [
                     "minimal_axioms",
@@ -7478,9 +7519,36 @@ class ComputeLaneCertificationTest(unittest.TestCase):
             [{"claim_id": "absent_root", "effective_status": "not_in_ledger"}],
         )
 
-    def test_meta_context_respects_non_evidence_registry(self):
+    def test_multiple_scientific_roots_share_one_combined_closure(self):
+        rows = {
+            "first": {
+                "claim_type": "positive_theorem",
+                "effective_status": "retained",
+                "deps": ["shared"],
+            },
+            "second": {
+                "claim_type": "bounded_theorem",
+                "effective_status": "retained_bounded",
+                "deps": ["shared"],
+            },
+            "shared": {
+                "claim_type": "positive_theorem",
+                "effective_status": "retained",
+                "deps": [],
+            },
+        }
+        payload, _ = self._run(
+            [{"lane": "multi", "roots": ["first", "second"]}], rows
+        )
+        lane = payload["lanes"][0]
+        self.assertTrue(lane["certified"])
+        self.assertEqual(lane["roots"], ["first", "second"])
+        self.assertEqual(lane["closure_size"], 3)
+
+    def test_metadata_never_satisfies_scientific_certification(self):
         rows = {
             "root": {
+                "claim_type": "positive_theorem",
                 "effective_status": "retained",
                 "deps": ["permitted_meta", "non_evidence_meta"],
             },
@@ -7495,11 +7563,18 @@ class ComputeLaneCertificationTest(unittest.TestCase):
         lane = payload["lanes"][0]
         self.assertEqual(
             lane["blocking"],
-            [{"claim_id": "non_evidence_meta", "effective_status": "meta"}],
+            [
+                {"claim_id": "non_evidence_meta", "effective_status": "meta"},
+                {"claim_id": "permitted_meta", "effective_status": "meta"},
+            ],
         )
 
     def test_output_is_deterministic_and_pipeline_recomputes_after_invalidation(self):
-        rows = {"root": {"effective_status": "retained", "deps": []}}
+        rows = {"root": {
+            "claim_type": "positive_theorem",
+            "effective_status": "retained",
+            "deps": [],
+        }}
         lanes = [{"lane": "stable", "root": "root"}]
         _, first = self._run(lanes, rows)
         _, second = self._run(lanes, rows)
@@ -7513,6 +7588,13 @@ class ComputeLaneCertificationTest(unittest.TestCase):
         self.assertGreater(
             script.index(invocation),
             script.index("did not reach a fixed point after 10 passes"),
+        )
+        apply_script = (
+            PROJECT_ROOT / "docs" / "audit" / "scripts" / "apply_audit.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            '("compute_lane_certification.py",      "refresh rolling lane certification")',
+            apply_script,
         )
 
 
@@ -8114,6 +8196,7 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         blob.update({
             "claim_id": "target",
             "verdict": "audited_clean",
+            "claim_type": "no_go",
             "audit_invocation_id": "a" * 32,
             "no_go_discipline": {
                 "status": "PASS",
@@ -8127,6 +8210,39 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             transport_bounded_n8=True,
         )
         self.assertEqual(error, "transport-bounded N8 evidence forbids audited_clean")
+
+    def test_development_runner_validation_ignores_locator_containment(self):
+        m = _import_codex_audit_runner()
+        blob = {field: "x" for field in m.REQUIRED_VERDICT_FIELDS}
+        blob.update({
+            "claim_id": "bounded",
+            "verdict": "audited_clean",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "the scoped obstruction",
+            "chain_closes": True,
+            "no_go_discipline": _no_go_packet(),
+        })
+        unrelated_manifest = {
+            "docs/UNRELATED.md": {
+                "roles": ["source"],
+                "text": "no packet locator appears here",
+            }
+        }
+        self.assertIsNone(
+            m.validate_verdict(
+                blob,
+                "bounded",
+                evidence_manifest=unrelated_manifest,
+            )
+        )
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
+            self.assertIsNotNone(
+                m.validate_verdict(
+                    blob,
+                    "bounded",
+                    evidence_manifest=unrelated_manifest,
+                )
+            )
 
     def test_fresh_schema_retry_exposes_error_not_rejected_conclusion(self):
         m = _import_codex_audit_runner()
@@ -8653,7 +8769,7 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
 
         self.assertIsNotNone(m.restore_audit_from_previous(row, {cid: row}))
 
-    def test_restore_refuses_packetless_clean_output_negative_authority(self):
+    def test_restore_tier_gates_packetless_clean_output_negative_authority(self):
         m = self._import_and_patch()
         cid = "packetless_output_negative"
         note_path = "docs/POSITIVE_SOURCE.md"
@@ -8674,14 +8790,24 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
                 archived["claim_type"],
             )
         )
-        self.assertTrue(
+        self.assertFalse(
             m.no_go_discipline_gate.output_requires_no_go_discipline(
                 {**archived, "verdict": archived["audit_status"]}
             )
         )
-        self.assertIsNone(
-            m.restore_audit_from_previous(row, {cid: row})
-        )
+        self.assertIsNotNone(m.restore_audit_from_previous(row, {cid: row}))
+
+        row = self._seed_with_archived(cid, archived)
+        row["note_path"] = note_path
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
+            self.assertTrue(
+                m.no_go_discipline_gate.output_requires_no_go_discipline(
+                    {**archived, "verdict": archived["audit_status"]}
+                )
+            )
+            self.assertIsNone(
+                m.restore_audit_from_previous(row, {cid: row})
+            )
 
     def test_select_restore_candidates_picks_criticality_increased(self):
         m = self._import_and_patch()

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -9307,7 +9307,7 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
         )
         self.assertIsNone(m.restore_audit_from_previous(row, {cid: row}))
 
-    def test_restore_tier_gates_packet_snapshot_currency(self):
+    def test_restore_requires_packet_snapshot_currency(self):
         m = self._import_and_patch()
         cid = "bounded_packet_restore"
         note_path = "docs/POSITIVE_PACKET_SOURCE.md"
@@ -9323,17 +9323,9 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
         })
         row = self._seed_with_archived(cid, archived)
         row["note_path"] = note_path
-        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": ""}):
-            self.assertIsNotNone(
-                m.restore_audit_from_previous(row, {cid: row})
-            )
-
-        row = self._seed_with_archived(cid, archived)
-        row["note_path"] = note_path
-        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
-            self.assertIsNone(
-                m.restore_audit_from_previous(row, {cid: row})
-            )
+        self.assertIsNone(
+            m.restore_audit_from_previous(row, {cid: row})
+        )
 
     def test_select_restore_candidates_picks_criticality_increased(self):
         m = self._import_and_patch()
@@ -9830,10 +9822,24 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
             notes_for_re_audit_if_any="other: conditional row round-trip",
         )
         ok["negative_assertion_classes"] = ["bounded_with_named_walls"]
+        ok["no_go_discipline"] = {"status": "PASS"}
         row2 = self._seed_with_archived("declared_conditional", ok)
-        restored = m.restore_audit_from_previous(
-            dict(row2), {"declared_conditional": row2}
-        )
+        with mock.patch.object(
+            m.no_go_discipline_gate,
+            "evidence_manifest_from_snapshot",
+            return_value={"authenticated": {}},
+        ), mock.patch.object(
+            m.no_go_discipline_gate,
+            "evidence_snapshot_current_error",
+            return_value=None,
+        ), mock.patch.object(
+            m.no_go_discipline_gate,
+            "validate_no_go_discipline",
+            return_value=None,
+        ):
+            restored = m.restore_audit_from_previous(
+                dict(row2), {"declared_conditional": row2}
+            )
         self.assertIsNotNone(restored)
         self.assertEqual(
             restored["negative_assertion_classes"], ["bounded_with_named_walls"]

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -1250,6 +1250,20 @@ class ApplyAuditTest(unittest.TestCase):
             )
         self.assertIsNone(validate.call_args.kwargs["evidence_manifest"])
 
+        declared_without_packet = {
+            **summary,
+            "no_go_discipline": None,
+            "negative_assertion_classes": ["bounded_with_named_walls"],
+        }
+        self.assertIn(
+            "N1-N8 packet is required",
+            m.cross_summary_no_go_error(
+                declared_without_packet,
+                source_required=False,
+                current_evidence_manifest=None,
+            ) or "",
+        )
+
         with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
             self.assertIn(
                 "authenticated evidence_snapshot",
@@ -1309,6 +1323,7 @@ class ApplyAuditTest(unittest.TestCase):
             "no_go_discipline": {"status": "PASS"},
         }
         forensic_led = json.loads(json.dumps(led))
+        packetless_led = json.loads(json.dumps(led))
         with mock.patch.object(
             m.no_go_discipline_gate,
             "validate_no_go_discipline",
@@ -1323,6 +1338,18 @@ class ApplyAuditTest(unittest.TestCase):
 
         with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
             ok, msg = m.apply_one(forensic_led, dict(judgment))
+        self.assertFalse(ok)
+        self.assertIn("trusted orchestrator evidence transport", msg)
+
+        packetless_judgment = {
+            **judgment,
+            "no_go_discipline": None,
+            "negative_assertion_classes": [],
+            "judgment_rationale": "the exact structural result closes",
+            "notes_for_re_audit_if_any": None,
+        }
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
+            ok, msg = m.apply_one(packetless_led, packetless_judgment)
         self.assertFalse(ok)
         self.assertIn("trusted orchestrator evidence transport", msg)
 
@@ -1363,6 +1390,33 @@ class ApplyAuditTest(unittest.TestCase):
         ):
             ok, msg = m.apply_one(led, audit)
         self.assertTrue(ok, msg)
+
+    def test_packetless_reclassification_of_stored_no_go_requires_transport(self):
+        m = _import("apply_audit")
+        _patch_repo_root(m, self.tmp_root)
+        self._seed_one_row(
+            "test_stored_foreclosure",
+            claim_type="no_go",
+            note_body="Exact positive source identity.\n",
+        )
+        led = self.fx.read_ledger()
+        audit = {
+            "claim_id": "test_stored_foreclosure",
+            "verdict": "audited_conditional",
+            "claim_type": "positive_theorem",
+            "claim_scope": "exact positive source identity",
+            "auditor": "fresh-auditor",
+            "negative_assertion_classes": [],
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "load_bearing_step_class": "C",
+            "no_go_discipline": None,
+        }
+        ok, msg = m.apply_one(led, audit)
+        self.assertFalse(ok)
+        self.assertIn("trusted orchestrator evidence transport", msg)
 
     def test_terminal_disagreement_preserves_live_authority(self):
         m = _import("apply_audit")
@@ -3152,6 +3206,22 @@ class AuditLintTest(unittest.TestCase):
             rc = m.main()
         self.assertEqual(rc, 0, buf.getvalue())
 
+        original_ledger = self.fx.read_ledger()
+        packetless_ledger = json.loads(json.dumps(original_ledger))
+        packetless_row = packetless_ledger["rows"]["bounded"]
+        packetless_row.pop("no_go_discipline", None)
+        packetless_row["negative_assertion_classes"] = [
+            "bounded_with_named_walls"
+        ]
+        self.fx.write_ledger(packetless_ledger)
+        buf = io.StringIO()
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": ""}), \
+             contextlib.redirect_stdout(buf):
+            rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("lacks structured No-Go Discipline", buf.getvalue())
+
+        self.fx.write_ledger(original_ledger)
         buf = io.StringIO()
         with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}), \
              contextlib.redirect_stdout(buf):
@@ -4018,6 +4088,31 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         self.assertIsNone(
             m.validate_no_go_discipline(audit, evidence_manifest=manifest)
         )
+
+    def test_structural_only_ignores_embedded_snapshot_locators(self):
+        m = _import("no_go_discipline_gate")
+        packet = _no_go_packet()
+        unrelated_manifest = {
+            "docs/UNRELATED.md": {
+                "path": "docs/UNRELATED.md",
+                "roles": ["source"],
+                "text": "unrelated source text",
+            }
+        }
+        packet["evidence_snapshot"] = m.build_evidence_snapshot(
+            packet, unrelated_manifest
+        )
+        audit = {
+            "claim_type": "bounded_theorem",
+            "verdict": "audited_clean",
+            "claim_scope": "the scoped obstruction",
+            "chain_closes": True,
+            "no_go_discipline": packet,
+        }
+        self.assertIsNone(
+            m.validate_no_go_discipline(audit, structural_only=True)
+        )
+        self.assertIsNotNone(m.validate_no_go_discipline(audit))
 
     def test_no_go_output_candidate_caps_are_declared(self):
         m = _import("no_go_discipline_gate")
@@ -8169,6 +8264,21 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         self.assertIn("N8 TRANSPORT BOUND", fitted)
         self.assertIn("do not return audited_clean", fitted)
 
+        development_manifest = {
+            path: {"text": full, "roles": ["cross_cycle_index"]}
+        }
+        development_fitted, _ = m.fit_prompt_to_transport_limit(
+            prompt,
+            development_manifest,
+            cid,
+            max_chars=2500,
+            forensic_bound=False,
+        )
+        self.assertNotIn("do not return audited_clean", development_fitted)
+        self.assertIn(
+            "does not force a verdict or No-Go status", development_fitted
+        )
+
         snapshot = m.no_go_discipline_gate.build_evidence_snapshot({}, manifest)
         packet = {"evidence_snapshot": snapshot}
         current = {path: {"text": full, "roles": ["cross_cycle_index"]}}
@@ -8220,6 +8330,7 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             "claim_type": "bounded_theorem",
             "claim_scope": "the scoped obstruction",
             "chain_closes": True,
+            "negative_assertion_classes": [],
             "no_go_discipline": _no_go_packet(),
         })
         unrelated_manifest = {
@@ -8805,6 +8916,34 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
                     {**archived, "verdict": archived["audit_status"]}
                 )
             )
+            self.assertIsNone(
+                m.restore_audit_from_previous(row, {cid: row})
+            )
+
+    def test_restore_tier_gates_packet_snapshot_currency(self):
+        m = self._import_and_patch()
+        cid = "bounded_packet_restore"
+        note_path = "docs/POSITIVE_PACKET_SOURCE.md"
+        self.fx.write_note(note_path, "# Positive source theorem\n")
+        archived = self._archived_audit(
+            claim_type="bounded_theorem",
+            invalidation_reason="criticality_increased:leaf->medium",
+        )
+        archived.update({
+            "claim_scope": "the scoped obstruction",
+            "chain_closes": True,
+            "no_go_discipline": _no_go_packet(),
+        })
+        row = self._seed_with_archived(cid, archived)
+        row["note_path"] = note_path
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": ""}):
+            self.assertIsNotNone(
+                m.restore_audit_from_previous(row, {cid: row})
+            )
+
+        row = self._seed_with_archived(cid, archived)
+        row["note_path"] = note_path
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
             self.assertIsNone(
                 m.restore_audit_from_previous(row, {cid: row})
             )

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -3618,7 +3618,14 @@ class AuditLintTest(unittest.TestCase):
                 self.assertEqual(rc, 1, output.getvalue())
                 self.assertIn("full audit tuple", output.getvalue())
                 if winner:
+                    valid_third = cross["third_audit"]
                     cross["third_audit"] = "malformed-third-summary"
+                    rows["terminal_claim"].update({
+                        "audit_status": "audited_clean",
+                        "effective_status": "retained_bounded",
+                        "chain_closes": True,
+                        "auditor_family": "claude-opus",
+                    })
                     self._write_minimal_ledger(rows)
                     output = io.StringIO()
                     with contextlib.redirect_stdout(output):
@@ -3628,6 +3635,26 @@ class AuditLintTest(unittest.TestCase):
                         "audit summary must be a non-empty object",
                         output.getvalue(),
                     )
+                    cross["third_audit"] = valid_third
+                    for unsupported_schema in ([], {}):
+                        with self.subTest(
+                            status=status,
+                            unsupported_schema=unsupported_schema,
+                        ):
+                            cross["agreement_schema"] = unsupported_schema
+                            self._write_minimal_ledger(rows)
+                            output = io.StringIO()
+                            with contextlib.redirect_stdout(output):
+                                rc = m.main()
+                            self.assertEqual(rc, 1, output.getvalue())
+                            self.assertIn(
+                                "unsupported cross_confirmation.agreement_schema",
+                                output.getvalue(),
+                            )
+                            self.assertNotIn(
+                                "legacy_cross_confirmation_tuple_mismatch",
+                                output.getvalue(),
+                            )
 
     def test_front_door_current_markdown_link_passes(self):
         m = _import("audit_lint")

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -2095,6 +2095,55 @@ class ApplyAuditTest(unittest.TestCase):
         self.assertEqual(row["load_bearing_step_class"], "C")
         self.assertIsNone(row["blocker"])
 
+    def test_hybrid_judicial_review_requires_explicit_scope(self):
+        m = _import("apply_audit")
+        _patch_repo_root(m, self.tmp_root)
+        self._seed_one_row(
+            "test_hybrid_scope",
+            audit_status="audit_in_progress",
+            claim_type="positive_theorem",
+            criticality="critical",
+        )
+        led = self.fx.read_ledger()
+        seat = {
+            "auditor": "first-auditor",
+            "auditor_family": "codex-gpt-5.6",
+            "verdict": "audited_clean",
+            "claim_type": "positive_theorem",
+            "claim_scope": "first scope",
+            "load_bearing_step_class": "C",
+            "negative_assertion_classes": [],
+        }
+        led["rows"]["test_hybrid_scope"]["cross_confirmation"] = {
+            "status": "disagreement",
+            "first_audit": seat,
+            "second_audit": {
+                **seat,
+                "auditor": "second-auditor",
+                "claim_type": "bounded_theorem",
+            },
+        }
+        judgment = {
+            "claim_id": "test_hybrid_scope",
+            "third_auditor": "judicial-panel",
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "judicial_review",
+            "sided_with": "hybrid",
+            "negative_assertion_classes": [],
+            "ratified_verdict": "audited_clean",
+            "ratified_claim_type": "bounded_theorem",
+            "ratified_load_bearing_step_class": "C",
+            "judgment_rationale": "ratify a third tuple",
+            "first_auditor_error": "scope too narrow",
+            "second_auditor_error": "class too narrow",
+            "hybrid_resolution_note": "panel selected a hybrid",
+        }
+        ok, msg = m.apply_one(led, judgment)
+        self.assertFalse(ok)
+        self.assertIn("ratified_claim_scope", msg)
+
     def test_judicial_no_go_requires_discipline_packet(self):
         m = _import("apply_audit")
         _patch_repo_root(m, self.tmp_root)
@@ -7936,6 +7985,26 @@ class ComputeLaneCertificationTest(unittest.TestCase):
         self.assertTrue(lane["certified"])
         self.assertEqual(lane["roots"], ["first", "second"])
         self.assertEqual(lane["closure_size"], 3)
+
+    def test_batch_orchestrator_unions_multi_root_lane_scope(self):
+        m = _import("orchestrate_audit_batch")
+        config = self.data / "lane_certification_config.json"
+        config.write_text(json.dumps({
+            "lanes": [{"lane": "multi", "roots": ["first", "second"]}]
+        }), encoding="utf-8")
+        rows = {
+            "first": {"deps": ["shared"]},
+            "second": {"deps": ["other"]},
+            "shared": {"deps": []},
+            "other": {"deps": []},
+        }
+        with mock.patch.object(m, "DATA", self.data), mock.patch.object(
+            m, "accepted", return_value=False
+        ):
+            scope = m.scope_for_args(
+                mock.Mock(lane="multi", claims=""), rows
+            )
+        self.assertEqual(scope, {"first", "second", "shared", "other"})
 
     def test_metadata_never_satisfies_scientific_certification(self):
         rows = {

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -3466,7 +3466,7 @@ class AuditLintTest(unittest.TestCase):
 
         ledger = self.fx.read_ledger()
         cross = ledger["rows"]["critical_claim"]["cross_confirmation"]
-        for unsupported_schema in ("audit_tuple_v999", [], {}):
+        for unsupported_schema in ("audit_tuple_v999", None, [], {}):
             with self.subTest(unsupported_schema=unsupported_schema):
                 cross["agreement_schema"] = unsupported_schema
                 self.fx.write_ledger(ledger)
@@ -3636,7 +3636,7 @@ class AuditLintTest(unittest.TestCase):
                         output.getvalue(),
                     )
                     cross["third_audit"] = valid_third
-                    for unsupported_schema in ([], {}):
+                    for unsupported_schema in (None, [], {}):
                         with self.subTest(
                             status=status,
                             unsupported_schema=unsupported_schema,

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -1274,6 +1274,119 @@ class ApplyAuditTest(unittest.TestCase):
                 ) or "",
             )
 
+    def test_negative_assertion_declaration_is_persisted_and_cleared(self):
+        m = _import("apply_audit")
+        _patch_repo_root(m, self.tmp_root)
+        self._seed_one_row("test_declared_negative")
+        led = self.fx.read_ledger()
+        declared = {
+            "claim_id": "test_declared_negative",
+            "verdict": "audited_conditional",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "bounded structural scope",
+            "auditor": "declaration-auditor",
+            "negative_assertion_classes": ["bounded_with_named_walls"],
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "load_bearing_step_class": "A",
+            "no_go_discipline": {"status": "PASS"},
+        }
+        with mock.patch.object(
+            m.no_go_discipline_gate,
+            "validate_no_go_discipline",
+            return_value=None,
+        ):
+            ok, msg = m.apply_one(led, declared)
+        self.assertTrue(ok, msg)
+        self.assertEqual(
+            led["rows"]["test_declared_negative"]["negative_assertion_classes"],
+            ["bounded_with_named_walls"],
+        )
+
+        self._seed_one_row("test_cleared_negative")
+        clear_led = self.fx.read_ledger()
+        clear_led["rows"]["test_cleared_negative"][
+            "negative_assertion_classes"
+        ] = ["bounded_with_named_walls"]
+        cleared = {
+            "claim_id": "test_cleared_negative",
+            "verdict": "audited_conditional",
+            "claim_type": "positive_theorem",
+            "claim_scope": "positive structural scope",
+            "auditor": "clearing-auditor",
+            "negative_assertion_classes": [],
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "load_bearing_step_class": "C",
+        }
+        ok, msg = m.apply_one(clear_led, cleared)
+        self.assertTrue(ok, msg)
+        self.assertEqual(
+            clear_led["rows"]["test_cleared_negative"][
+                "negative_assertion_classes"
+            ],
+            [],
+        )
+
+    def test_cross_confirmation_disagrees_when_negative_declaration_changes(self):
+        m = _import("apply_audit")
+        _patch_repo_root(m, self.tmp_root)
+        self._seed_one_row(
+            "test_negative_tuple",
+            criticality="critical",
+        )
+        led = self.fx.read_ledger()
+        first = {
+            "claim_id": "test_negative_tuple",
+            "verdict": "audited_clean",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "bounded structural scope",
+            "auditor": "first-declaration-auditor",
+            "negative_assertion_classes": ["bounded_with_named_walls"],
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "cross_family",
+            "load_bearing_step_class": "A",
+            "no_go_discipline": {"status": "PASS"},
+        }
+        with mock.patch.object(
+            m.no_go_discipline_gate,
+            "validate_no_go_discipline",
+            return_value=None,
+        ):
+            ok, msg = m.apply_one(led, first)
+        self.assertTrue(ok, msg)
+        self.assertEqual(
+            led["rows"]["test_negative_tuple"]["cross_confirmation"][
+                "first_audit"
+            ]["negative_assertion_classes"],
+            ["bounded_with_named_walls"],
+        )
+
+        second = {
+            **first,
+            "auditor": "second-declaration-auditor",
+            "independence": "fresh_context",
+            "negative_assertion_classes": [],
+            "no_go_discipline": None,
+        }
+        with mock.patch.object(
+            m.no_go_discipline_gate,
+            "validate_no_go_discipline",
+            return_value=None,
+        ):
+            ok, msg = m.apply_one(led, second)
+        self.assertTrue(ok, msg)
+        row = led["rows"]["test_negative_tuple"]
+        self.assertEqual(row["audit_status"], "audit_in_progress")
+        self.assertEqual(row["cross_confirmation"]["status"], "disagreement")
+        self.assertEqual(row["blocker"], "cross_confirmation_disagreement")
+
     def test_judicial_packet_transport_is_tier_gated(self):
         m = _import("apply_audit")
         _patch_repo_root(m, self.tmp_root)
@@ -1767,7 +1880,7 @@ class ApplyAuditTest(unittest.TestCase):
         second_audit = {
             **fresh_audit,
             "auditor": "fresh-packeted-second",
-            "negative_assertion_classes": [],
+            "negative_assertion_classes": ["no_go_result"],
             "independence": "fresh_context",
             "audit_invocation_id": "f" * 32,
         }
@@ -7346,11 +7459,17 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             "claim_type": "no_go",
             "claim_type_author_hint": "no_go",
             "no_go_discipline": packet,
+            "negative_assertion_classes": ["no_go_result"],
             "previous_audits": [],
         }
         reset = m.archive_and_reset(row, "test invalidation")
         self.assertEqual(reset["previous_audits"][0]["no_go_discipline"], packet)
+        self.assertEqual(
+            reset["previous_audits"][0]["negative_assertion_classes"],
+            ["no_go_result"],
+        )
         self.assertNotIn("no_go_discipline", reset)
+        self.assertNotIn("negative_assertion_classes", reset)
 
     def test_packetless_clean_no_go_is_invalidated(self):
         m = _import("invalidate_stale_audits")
@@ -7375,6 +7494,20 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 m.detect_invalidation(row, {"legacy_no_go": row}),
                 "no_go_discipline_packet_missing",
             )
+
+    def test_packetless_declared_negative_conditional_is_invalidated(self):
+        m = _import("invalidate_stale_audits")
+        row = {
+            "claim_id": "declared_negative_conditional",
+            "note_path": "docs/POSITIVE_SOURCE.md",
+            "audit_status": "audited_conditional",
+            "claim_type": "bounded_theorem",
+            "negative_assertion_classes": ["bounded_with_named_walls"],
+        }
+        self.assertEqual(
+            m.detect_invalidation(row, {"declared_negative_conditional": row}),
+            "no_go_discipline_packet_missing",
+        )
 
     def test_live_packet_invalid_under_current_policy_is_invalidated(self):
         m = _import("invalidate_stale_audits")
@@ -8793,6 +8926,25 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
             invalidation_reason="criticality_increased:leaf->medium",
         )
         archived["chain_closes"] = True
+        row = self._seed_with_archived(cid, archived)
+        row["note_path"] = note_path
+        self.assertIsNone(
+            m.restore_audit_from_previous(row, {cid: row})
+        )
+
+    def test_restore_refuses_packetless_declared_negative_conditional(self):
+        m = self._import_and_patch()
+        cid = "packetless_declared_conditional"
+        note_path = "docs/POSITIVE_CONDITIONAL.md"
+        self.fx.write_note(note_path, "# Positive bounded source\n")
+        archived = self._archived_audit(
+            audit_status="audited_conditional",
+            claim_type="bounded_theorem",
+            invalidation_reason="criticality_increased:leaf->medium",
+        )
+        archived["negative_assertion_classes"] = [
+            "bounded_with_named_walls"
+        ]
         row = self._seed_with_archived(cid, archived)
         row["note_path"] = note_path
         self.assertIsNone(

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -1387,6 +1387,152 @@ class ApplyAuditTest(unittest.TestCase):
         self.assertEqual(row["cross_confirmation"]["status"], "disagreement")
         self.assertEqual(row["blocker"], "cross_confirmation_disagreement")
 
+    def test_cross_confirmation_disagrees_when_claim_scope_changes(self):
+        m = _import("apply_audit")
+        _patch_repo_root(m, self.tmp_root)
+        self._seed_one_row("test_scope_tuple", criticality="critical")
+        led = self.fx.read_ledger()
+        first = {
+            "claim_id": "test_scope_tuple",
+            "verdict": "audited_clean",
+            "claim_type": "positive_theorem",
+            "claim_scope": "the identity for n = 2",
+            "auditor": "first-scope-auditor",
+            "negative_assertion_classes": [],
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "cross_family",
+            "load_bearing_step_class": "C",
+        }
+        ok, msg = m.apply_one(led, first)
+        self.assertTrue(ok, msg)
+        second = {
+            **first,
+            "auditor": "second-scope-auditor",
+            "independence": "fresh_context",
+            "claim_scope": "the identity for every n",
+        }
+        ok, msg = m.apply_one(led, second)
+        self.assertTrue(ok, msg)
+        row = led["rows"]["test_scope_tuple"]
+        self.assertEqual(row["audit_status"], "audit_in_progress")
+        self.assertEqual(row["cross_confirmation"]["status"], "disagreement")
+
+    def test_development_apply_preserves_core_evidence_gates(self):
+        m = _import("apply_audit")
+        _patch_repo_root(m, self.tmp_root)
+        self._seed_one_row("test_stale_development_transport")
+        stale_led = self.fx.read_ledger()
+        audit = {
+            "claim_id": "test_stale_development_transport",
+            "verdict": "audited_clean",
+            "claim_type": "positive_theorem",
+            "claim_scope": "the exact positive identity",
+            "auditor": "development-auditor",
+            "negative_assertion_classes": [],
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "load_bearing_step_class": "C",
+        }
+        manifest = {
+            "docs/TEST.md": {"roles": ["source"], "text": "old source"}
+        }
+        with mock.patch.object(
+            m, "trusted_evidence_manifest", return_value=manifest
+        ), mock.patch.object(
+            m, "trusted_manifest_current_error", return_value="source drifted"
+        ) as current_check:
+            ok, msg = m.apply_one(stale_led, audit)
+        self.assertFalse(ok)
+        self.assertIn("trusted evidence manifest is stale", msg)
+        self.assertFalse(
+            current_check.call_args.kwargs["dynamic_index_drift_invalidates"]
+        )
+
+        self._seed_one_row("test_clipped_development_transport")
+        clipped_led = self.fx.read_ledger()
+        clipped_audit = {
+            **audit,
+            "claim_id": "test_clipped_development_transport",
+            "auditor": "clipped-development-auditor",
+        }
+        clipped_manifest = {
+            "docs/TEST.md": {
+                "roles": ["source"],
+                "text": "... [packet-clipped docs/TEST.md; 999 chars total] ...",
+            }
+        }
+        with mock.patch.object(
+            m, "trusted_evidence_manifest", return_value=clipped_manifest
+        ):
+            ok, msg = m.apply_one(clipped_led, clipped_audit)
+        self.assertFalse(ok)
+        self.assertIn("complete load-bearing packet surfaces", msg)
+
+    def test_judicial_side_must_preserve_chosen_scope_and_class(self):
+        m = _import("apply_audit")
+        _patch_repo_root(m, self.tmp_root)
+        self._seed_one_row(
+            "test_judicial_tuple",
+            audit_status="audit_in_progress",
+            claim_type="positive_theorem",
+            criticality="critical",
+        )
+        led = self.fx.read_ledger()
+        seat = {
+            "auditor": "first-auditor",
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "verdict": "audited_clean",
+            "claim_type": "positive_theorem",
+            "claim_scope": "the identity for n = 2",
+            "load_bearing_step_class": "C",
+            "negative_assertion_classes": [],
+        }
+        led["rows"]["test_judicial_tuple"]["cross_confirmation"] = {
+            "status": "disagreement",
+            "first_audit": seat,
+            "second_audit": {
+                **seat,
+                "auditor": "second-auditor",
+                "verdict": "audited_conditional",
+            },
+        }
+        judgment = {
+            "claim_id": "test_judicial_tuple",
+            "third_auditor": "judicial-panel",
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "judicial_review",
+            "sided_with": "first",
+            "negative_assertion_classes": [],
+            "ratified_verdict": "audited_clean",
+            "ratified_claim_type": "positive_theorem",
+            "ratified_claim_scope": "the identity for n = 2",
+            "ratified_load_bearing_step_class": "D",
+            "judgment_rationale": "confirm the first seat",
+            "first_auditor_error": "none",
+            "second_auditor_error": "overstated the blocker",
+        }
+        ok, msg = m.apply_one(json.loads(json.dumps(led)), judgment)
+        self.assertFalse(ok)
+        self.assertIn("ratified_load_bearing_step_class", msg)
+
+        scope_judgment = {
+            **judgment,
+            "ratified_load_bearing_step_class": "C",
+            "ratified_claim_scope": "the identity for every n",
+        }
+        ok, msg = m.apply_one(json.loads(json.dumps(led)), scope_judgment)
+        self.assertFalse(ok)
+        self.assertIn("ratified_claim_scope", msg)
+
     def test_judicial_packet_transport_is_tier_gated(self):
         m = _import("apply_audit")
         _patch_repo_root(m, self.tmp_root)
@@ -4159,6 +4305,24 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 m.source_requires_no_go_discipline(
                     "docs/BOUNDED_ROW.md", wall_body, "bounded_theorem"
                 )
+            )
+
+    def test_development_output_trigger_cannot_be_bypassed_by_empty_declaration(self):
+        m = _import("no_go_discipline_gate")
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": ""}):
+            self.assertTrue(
+                m.output_requires_no_go_discipline({
+                    "claim_type": "bounded_theorem",
+                    "claim_scope": "No retained primitive supplies the wall.",
+                    "negative_assertion_classes": [],
+                })
+            )
+            self.assertFalse(
+                m.output_requires_no_go_discipline({
+                    "claim_type": "positive_theorem",
+                    "claim_scope": "The exact positive identity closes.",
+                    "negative_assertion_classes": [],
+                })
             )
 
     def test_n3_excludes_explicit_accepted_premise_vocabulary(self):
@@ -8479,6 +8643,20 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
                 evidence_manifest=unrelated_manifest,
             )
         )
+        clipped_manifest = {
+            "docs/BOUNDED.md": {
+                "roles": ["source"],
+                "text": "... [packet-clipped docs/BOUNDED.md; 999 chars total] ...",
+            }
+        }
+        self.assertIn(
+            "complete load-bearing packet surfaces",
+            m.validate_verdict(
+                blob,
+                "bounded",
+                evidence_manifest=clipped_manifest,
+            ) or "",
+        )
         with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
             self.assertIsNotNone(
                 m.validate_verdict(
@@ -9032,7 +9210,7 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
 
         self.assertIsNotNone(m.restore_audit_from_previous(row, {cid: row}))
 
-    def test_restore_tier_gates_packetless_clean_output_negative_authority(self):
+    def test_restore_refuses_packetless_clean_output_negative_authority(self):
         m = self._import_and_patch()
         cid = "packetless_output_negative"
         note_path = "docs/POSITIVE_SOURCE.md"
@@ -9053,24 +9231,12 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
                 archived["claim_type"],
             )
         )
-        self.assertFalse(
+        self.assertTrue(
             m.no_go_discipline_gate.output_requires_no_go_discipline(
                 {**archived, "verdict": archived["audit_status"]}
             )
         )
-        self.assertIsNotNone(m.restore_audit_from_previous(row, {cid: row}))
-
-        row = self._seed_with_archived(cid, archived)
-        row["note_path"] = note_path
-        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
-            self.assertTrue(
-                m.no_go_discipline_gate.output_requires_no_go_discipline(
-                    {**archived, "verdict": archived["audit_status"]}
-                )
-            )
-            self.assertIsNone(
-                m.restore_audit_from_previous(row, {cid: row})
-            )
+        self.assertIsNone(m.restore_audit_from_previous(row, {cid: row}))
 
     def test_restore_tier_gates_packet_snapshot_currency(self):
         m = self._import_and_patch()

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -3473,6 +3473,7 @@ class AuditLintTest(unittest.TestCase):
             rc = m.main()
         self.assertEqual(rc, 1, output.getvalue())
         self.assertIn("unsupported cross_confirmation.agreement_schema", output.getvalue())
+        self.assertNotIn("legacy_cross_confirmation_tuple_mismatch", output.getvalue())
 
         cross.pop("agreement_schema")
         self.fx.write_ledger(ledger)
@@ -3519,6 +3520,26 @@ class AuditLintTest(unittest.TestCase):
             rc = m.main()
         self.assertEqual(rc, 1, output.getvalue())
         self.assertIn("audit summary must be a non-empty object", output.getvalue())
+
+        cross["first_audit"] = "malformed-summary"
+        cross["second_audit"] = {}
+        self.fx.write_ledger(ledger)
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = m.main()
+        self.assertEqual(rc, 1, output.getvalue())
+        self.assertIn("audit summary must be a non-empty object", output.getvalue())
+
+        malformed = dict(first)
+        malformed["verdict"] = []
+        cross["first_audit"] = malformed
+        cross["second_audit"] = dict(malformed)
+        self.fx.write_ledger(ledger)
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = m.main()
+        self.assertEqual(rc, 1, output.getvalue())
+        self.assertIn("non-terminal verdict []", output.getvalue())
 
     def test_lint_enforces_versioned_tuple_for_all_confirmed_paths(self):
         m = _import("audit_lint")

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -1554,6 +1554,12 @@ class ApplyAuditTest(unittest.TestCase):
             "first_auditor_error": "none",
             "second_auditor_error": "overstated the blocker",
         }
+        missing_type = dict(judgment)
+        missing_type.pop("ratified_claim_type")
+        ok, msg = m.apply_one(json.loads(json.dumps(led)), missing_type)
+        self.assertFalse(ok)
+        self.assertIn("ratified_claim_type", msg)
+
         ok, msg = m.apply_one(json.loads(json.dumps(led)), judgment)
         self.assertFalse(ok)
         self.assertIn("ratified_load_bearing_step_class", msg)
@@ -1586,6 +1592,7 @@ class ApplyAuditTest(unittest.TestCase):
                 "claim_type": "positive_theorem",
                 "claim_scope": "positive scope",
                 "load_bearing_step_class": "C",
+                "negative_assertion_classes": [],
             },
             "second_audit": {
                 "auditor": "second-auditor",
@@ -1594,6 +1601,7 @@ class ApplyAuditTest(unittest.TestCase):
                 "claim_type": "bounded_theorem",
                 "claim_scope": "bounded scope",
                 "load_bearing_step_class": "A",
+                "negative_assertion_classes": [],
             },
         }
         judgment = {
@@ -2095,6 +2103,7 @@ class ApplyAuditTest(unittest.TestCase):
                 "auditor_family": "codex-gpt-5",
                 "verdict": "audited_clean",
                 "claim_type": "positive_theorem",
+                "claim_scope": "first exact scope",
                 "load_bearing_step_class": "C",
             },
             "second_audit": {
@@ -2103,6 +2112,7 @@ class ApplyAuditTest(unittest.TestCase):
                 "auditor_family": "codex-gpt-5.5",
                 "verdict": "audited_clean",
                 "claim_type": "bounded_theorem",
+                "claim_scope": "second bounded scope",
                 "load_bearing_step_class": "A",
             },
         }
@@ -2125,6 +2135,14 @@ class ApplyAuditTest(unittest.TestCase):
             "second_auditor_error": "understated load-bearing class",
             "hybrid_resolution_note": "human-authorized second-stage panel",
         }
+        legacy_led = json.loads(json.dumps(led))
+        legacy_led["rows"]["test_hybrid"]["cross_confirmation"][
+            "first_audit"
+        ].pop("claim_scope")
+        ok, msg = m.apply_one(legacy_led, audit)
+        self.assertFalse(ok)
+        self.assertIn("cannot be upgraded to audit_tuple_v2", msg)
+
         ok, msg = m.apply_one(led, audit)
         self.assertTrue(ok, msg)
         row = led["rows"]["test_hybrid"]
@@ -3505,20 +3523,32 @@ class AuditLintTest(unittest.TestCase):
 
         cross["first_audit"]["claim_scope"] = " normalized   scoped\ntheorem "
         cross["second_audit"]["claim_scope"] = "normalized scoped theorem"
-        cross["first_audit"]["negative_assertion_classes"] = [
-            "conditional_wall_rationale",
-            "bounded_with_named_walls",
-        ]
-        cross["second_audit"]["negative_assertion_classes"] = [
-            "bounded_with_named_walls",
-            "conditional_wall_rationale",
-            "bounded_with_named_walls",
-        ]
+        cross["first_audit"]["negative_assertion_classes"] = []
+        cross["second_audit"]["negative_assertion_classes"] = []
+        self.fx.write_ledger(ledger)
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = m.main()
+        self.assertEqual(rc, 1, output.getvalue())
+        self.assertIn("authoritative live row full audit tuple", output.getvalue())
+
+        live = ledger["rows"]["critical_claim"]
+        live["claim_scope"] = "normalized scoped theorem"
+        live["negative_assertion_classes"] = []
         self.fx.write_ledger(ledger)
         output = io.StringIO()
         with contextlib.redirect_stdout(output):
             rc = m.main()
         self.assertEqual(rc, 0, output.getvalue())
+
+        live["negative_assertion_classes"] = ["bounded_with_named_walls"]
+        self.fx.write_ledger(ledger)
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = m.main()
+        self.assertEqual(rc, 1, output.getvalue())
+        self.assertIn("authoritative live row full audit tuple", output.getvalue())
+        live["negative_assertion_classes"] = []
 
         cross["first_audit"] = {}
         cross["second_audit"] = {}
@@ -8956,10 +8986,13 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             max_chars=2500,
             forensic_bound=False,
         )
-        self.assertNotIn("do not return audited_clean", development_fitted)
+        self.assertIn("do not return audited_clean", development_fitted)
         self.assertIn(
-            "does not force a verdict or No-Go status", development_fitted
+            "does not force a verdict when the final classification carries no "
+            "negative assertion",
+            development_fitted,
         )
+        self.assertIn("classify claim_type=no_go", development_fitted)
 
         snapshot = m.no_go_discipline_gate.build_evidence_snapshot({}, manifest)
         packet = {"evidence_snapshot": snapshot}
@@ -9074,6 +9107,12 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         self.assertTrue(m.fresh_schema_retry_eligible(
             "no_go_discipline.status must be PASS or FAIL"
         ))
+        transport_error = "transport-bounded N8 evidence forbids audited_clean"
+        self.assertTrue(m.fresh_schema_retry_eligible(transport_error))
+        self.assertEqual(
+            m.fresh_schema_retry_code(transport_error),
+            "N8_TRANSPORT_BOUND_DISPOSITION_MISMATCH",
+        )
         self.assertFalse(m.fresh_schema_retry_eligible("claim_id mismatch"))
         code = m.fresh_schema_retry_code(
             "N1 route prior_secret.route_class exposes prior content"

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -2070,6 +2070,12 @@ class ApplyAuditTest(unittest.TestCase):
             ok, msg = m.apply_one(led, second_audit)
         self.assertTrue(ok, msg)
         self.assertEqual(msg, "applied")
+        self.assertEqual(
+            led["rows"]["legacy_pending_no_go"]["cross_confirmation"][
+                "agreement_schema"
+            ],
+            "audit_tuple_v2",
+        )
 
     def test_hybrid_judicial_review_records_applyable_third_tuple(self):
         m = _import("apply_audit")
@@ -2123,6 +2129,9 @@ class ApplyAuditTest(unittest.TestCase):
         self.assertTrue(ok, msg)
         row = led["rows"]["test_hybrid"]
         self.assertEqual(row["cross_confirmation"]["status"], "third_confirmed_hybrid")
+        self.assertEqual(
+            row["cross_confirmation"]["agreement_schema"], "audit_tuple_v2"
+        )
         self.assertEqual(row["cross_confirmation"]["third_audit"]["sided_with"], "hybrid")
         self.assertEqual(row["audit_status"], "audited_clean")
         self.assertEqual(row["claim_type"], "bounded_theorem")
@@ -3441,6 +3450,7 @@ class AuditLintTest(unittest.TestCase):
                 "negative_assertion_classes": [],
                 "cross_confirmation": {
                     "status": "confirmed",
+                    "agreement_schema": "audit_tuple_v2",
                     "first_audit": first,
                     "second_audit": second,
                 },
@@ -3453,6 +3463,97 @@ class AuditLintTest(unittest.TestCase):
             rc = m.main()
         self.assertEqual(rc, 1, output.getvalue())
         self.assertIn("full audit tuple mismatch", output.getvalue())
+
+        ledger = self.fx.read_ledger()
+        cross = ledger["rows"]["critical_claim"]["cross_confirmation"]
+        cross.pop("agreement_schema")
+        self.fx.write_ledger(ledger)
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = m.main()
+        self.assertEqual(rc, 0, output.getvalue())
+        self.assertIn("legacy_cross_confirmation_tuple_mismatch", output.getvalue())
+
+        cross["agreement_schema"] = "audit_tuple_v2"
+        cross["second_audit"]["claim_scope"] = cross["first_audit"]["claim_scope"]
+        cross["second_audit"]["negative_assertion_classes"] = [
+            "bounded_with_named_walls"
+        ]
+        self.fx.write_ledger(ledger)
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = m.main()
+        self.assertEqual(rc, 1, output.getvalue())
+        self.assertIn("full audit tuple mismatch", output.getvalue())
+
+    def test_lint_enforces_versioned_tuple_for_all_confirmed_paths(self):
+        m = _import("audit_lint")
+        _patch_repo_root(m, self.tmp_root)
+        base = {
+            "auditor": "first-auditor",
+            "auditor_family": "codex-gpt-5.6",
+            "independence": "cross_family",
+            "verdict": "audited_conditional",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "first bounded scope",
+            "load_bearing_step_class": "A",
+            "negative_assertion_classes": [],
+        }
+        for status, winner in (
+            ("confirmed", None),
+            ("third_confirmed_first", "first"),
+            ("third_confirmed_second", "second"),
+        ):
+            with self.subTest(status=status):
+                first = dict(base)
+                second = {
+                    **base,
+                    "auditor": "second-auditor",
+                    "independence": "fresh_context",
+                    "claim_scope": "second bounded scope",
+                }
+                cross = {
+                    "status": status,
+                    "agreement_schema": "audit_tuple_v2",
+                    "first_audit": first,
+                    "second_audit": second,
+                }
+                if winner:
+                    chosen = first if winner == "first" else second
+                    cross["third_audit"] = {
+                        **chosen,
+                        "auditor": "third-auditor",
+                        "independence": "judicial_review",
+                        "claim_scope": "third mismatched scope",
+                        "sided_with": winner,
+                    }
+                rows = {
+                    "terminal_claim": {
+                        "claim_id": "terminal_claim",
+                        "audit_status": "audited_conditional",
+                        "effective_status": "audited_conditional",
+                        "claim_type": "bounded_theorem",
+                        "claim_scope": "terminal bounded scope",
+                        "chain_closes": False,
+                        "auditor": "terminal-auditor",
+                        "auditor_family": "codex-gpt-5.6",
+                        "auditor_model": "gpt-5.6-sol",
+                        "auditor_reasoning_effort": "xhigh",
+                        "independence": "fresh_context",
+                        "criticality": "leaf",
+                        "load_bearing_step_class": "A",
+                        "negative_assertion_classes": [],
+                        "notes_for_re_audit_if_any": "other: tuple test",
+                        "cross_confirmation": cross,
+                    }
+                }
+                self._write_minimal_ledger(rows)
+                import contextlib, io
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    rc = m.main()
+                self.assertEqual(rc, 1, output.getvalue())
+                self.assertIn("full audit tuple", output.getvalue())
 
     def test_front_door_current_markdown_link_passes(self):
         m = _import("audit_lint")

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1480,7 +1480,10 @@ def validate_verdict(
         or blob.get("claim_type") == "no_go"
         or no_go_discipline_gate.forensic_mode()
     )
-    if transport_bounded_n8 and forensic_tier:
+    transport_bound_is_dispositive = bool(
+        forensic_tier or blob.get("negative_assertion_classes")
+    )
+    if transport_bounded_n8 and transport_bound_is_dispositive:
         packet = blob.get("no_go_discipline")
         n8 = packet.get("N8_cross_cycle_echo") if isinstance(packet, dict) else None
         if blob.get("verdict") == "audited_clean":

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1196,7 +1196,13 @@ def fit_prompt_to_transport_limit(
             if forensic_bound
             else
             "This development-tier transport bound does not force a verdict "
-            "or No-Go status; scope any N8 judgment to the rendered records. "
+            "when the final classification carries no negative assertion. If "
+            "you classify claim_type=no_go or declare any nonempty "
+            "negative_assertion_classes, set "
+            "N8_cross_cycle_echo.packet_complete=false, keep its unresolved "
+            "list nonempty, set no_go_discipline.status=FAIL, and do not return "
+            "audited_clean. Otherwise, scope any N8 judgment to the rendered "
+            "records. "
         )
         notice = (
             "\n\n---\n"
@@ -1579,11 +1585,11 @@ def render_validation_repair_prompt(
 
 
 def fresh_schema_retry_eligible(validation_error: str | None) -> bool:
-    """Allow a new isolated audit only for structured N1-N8 schema rejects."""
+    """Allow a new isolated audit for structured N1-N8 disposition rejects."""
     if not validation_error:
         return False
     return bool(re.match(
-        r"^(?:N[1-8]\b|No-Go Discipline\b|no_go_discipline\b)",
+        r"^(?:N[1-8]\b|No-Go Discipline\b|no_go_discipline\b|transport-bounded N8\b)",
         validation_error,
     ))
 
@@ -1592,6 +1598,8 @@ def fresh_schema_retry_code(validation_error: str) -> str:
     """Reduce validator text to a conclusion-free control-plane code."""
     if validation_error.startswith("N3 retained_authority hit "):
         return "N3_RETAINED_AUTHORITY_PROVENANCE_MISMATCH"
+    if validation_error.startswith("transport-bounded N8"):
+        return "N8_TRANSPORT_BOUND_DISPOSITION_MISMATCH"
     if (
         validation_error.startswith("N1 route ")
         and ".route_class=" in validation_error

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1493,8 +1493,7 @@ def validate_verdict(
         if not isinstance(unresolved, list) or not unresolved:
             return "transport-bounded N8 evidence requires a nonempty unresolved list"
     if (
-        forensic_tier
-        and blob.get("verdict") == "audited_clean"
+        blob.get("verdict") == "audited_clean"
         and evidence_manifest is not None
     ):
         clipped_paths = sorted(

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1155,14 +1155,16 @@ def fit_prompt_to_transport_limit(
     claim_id: str,
     *,
     max_chars: int = CODEX_INPUT_CHAR_LIMIT,
+    forensic_bound: bool = True,
 ) -> tuple[str, dict[str, int] | None]:
     """Fit an oversized no-go prompt by bounding only rendered N8 records.
 
     Validation and apply receive the exact rendered subset plus a digest/count
-    commitment to the complete orchestrator index. Because the auditor cannot
-    inspect every N8 candidate, the inserted binding notice requires an
-    incomplete N8 FAIL packet and forbids ``audited_clean``. If even an empty
-    rendered candidate list cannot fit, fail closed instead of clipping
+    commitment to the complete orchestrator index. In the forensic tier, the
+    inserted binding notice requires an incomplete N8 FAIL packet and forbids
+    ``audited_clean``. In the development tier it only forbids exhaustive N8
+    claims from the omitted records and does not force a verdict. If even an
+    empty rendered candidate list cannot fit, fail closed instead of clipping
     source/runner evidence.
     """
     if len(prompt) <= max_chars:
@@ -1187,6 +1189,15 @@ def fit_prompt_to_transport_limit(
         bounded = dict(payload)
         bounded["candidates"] = candidates[:candidate_count]
         bounded_text = json.dumps(bounded, indent=2, sort_keys=True)
+        forensic_notice = (
+            "Therefore set N8_cross_cycle_echo.packet_complete=false, keep "
+            "N8_cross_cycle_echo.unresolved nonempty, set the overall "
+            "no_go_discipline.status=FAIL, and do not return audited_clean. "
+            if forensic_bound
+            else
+            "This development-tier transport bound does not force a verdict "
+            "or No-Go status; scope any N8 judgment to the rendered records. "
+        )
         notice = (
             "\n\n---\n"
             "N8 TRANSPORT BOUND (binding; transport metadata, not evidence):\n"
@@ -1194,9 +1205,7 @@ def fit_prompt_to_transport_limit(
             f"cross-cycle candidates; this transport renders the first "
             f"{candidate_count} in the orchestrator's relevance order while "
             "retaining the complete no-go-row universe count and digest. "
-            "Therefore set N8_cross_cycle_echo.packet_complete=false, keep "
-            "N8_cross_cycle_echo.unresolved nonempty, set the overall "
-            "no_go_discipline.status=FAIL, and do not return audited_clean. "
+            f"{forensic_notice}"
             "Use only verbatim locators from rendered authenticated records.\n"
         )
         fitted = prompt.replace(full_text, bounded_text, 1)
@@ -1508,6 +1517,8 @@ def validate_verdict(
         source_required=source_requires_no_go,
         evidence_manifest=evidence_manifest if forensic_tier else None,
         prior_claim_scope=prior_claim_scope,
+        structural_only=not forensic_tier,
+        require_declaration=True,
     )
     if no_go_error:
         return no_go_error
@@ -2164,9 +2175,36 @@ def main() -> int:
                                        evidence_manifest_out=exact_evidence_manifest,
                                        audit_invocation_id=audit_invocation_id)
 
+            transport_note_path = (
+                row.get("note_path") or full_led_row.get("note_path") or ""
+            )
+            transport_note_body = read_note_body(transport_note_path) or ""
+            transport_source_required = (
+                no_go_discipline_gate.source_requires_no_go_discipline(
+                    transport_note_path,
+                    transport_note_body,
+                    (
+                        ""
+                        if args.from_dispatch
+                        else row.get("claim_type") or full_led_row.get("claim_type")
+                    ),
+                )
+            )
+            transport_forensic = bool(
+                transport_source_required
+                or (
+                    not args.from_dispatch
+                    and (row.get("claim_type") or full_led_row.get("claim_type"))
+                    == "no_go"
+                )
+                or no_go_discipline_gate.forensic_mode()
+            )
             try:
                 prompt, transport_bound = fit_prompt_to_transport_limit(
-                    prompt, exact_evidence_manifest, cid
+                    prompt,
+                    exact_evidence_manifest,
+                    cid,
+                    forensic_bound=transport_forensic,
                 )
             except ValueError as exc:
                 print(f"  SKIP prompt transport: {exc}")

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -2217,12 +2217,18 @@ def main() -> int:
                     }) + "\n")
                 continue
             if transport_bound:
+                transport_disposition = (
+                    "clean forbidden"
+                    if transport_forensic
+                    else "development-tier structural bound; verdict not forced"
+                )
                 print(
                     "  N8 transport-bound: "
                     f"{transport_bound['rendered_candidates']}/"
                     f"{transport_bound['authenticated_candidates']} candidates, "
                     f"{transport_bound['prompt_chars_before']} -> "
-                    f"{transport_bound['prompt_chars_after']} chars; clean forbidden"
+                    f"{transport_bound['prompt_chars_after']} chars; "
+                    f"{transport_disposition}"
                 )
 
             if args.dry_run:

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1466,7 +1466,12 @@ def validate_verdict(
         return invocation_error
     if expected_invocation_id is not None and blob.get("audit_invocation_id") != expected_invocation_id:
         return "audit_invocation_id is absent or does not match the prompt-bound invocation"
-    if transport_bounded_n8:
+    forensic_tier = bool(
+        source_requires_no_go
+        or blob.get("claim_type") == "no_go"
+        or no_go_discipline_gate.forensic_mode()
+    )
+    if transport_bounded_n8 and forensic_tier:
         packet = blob.get("no_go_discipline")
         n8 = packet.get("N8_cross_cycle_echo") if isinstance(packet, dict) else None
         if blob.get("verdict") == "audited_clean":
@@ -1478,7 +1483,11 @@ def validate_verdict(
         unresolved = n8.get("unresolved") if isinstance(n8, dict) else None
         if not isinstance(unresolved, list) or not unresolved:
             return "transport-bounded N8 evidence requires a nonempty unresolved list"
-    if blob.get("verdict") == "audited_clean" and evidence_manifest is not None:
+    if (
+        forensic_tier
+        and blob.get("verdict") == "audited_clean"
+        and evidence_manifest is not None
+    ):
         clipped_paths = sorted(
             path
             for path, entry in evidence_manifest.items()
@@ -1497,7 +1506,7 @@ def validate_verdict(
     no_go_error = no_go_discipline_gate.validate_no_go_discipline(
         blob,
         source_required=source_requires_no_go,
-        evidence_manifest=evidence_manifest,
+        evidence_manifest=evidence_manifest if forensic_tier else None,
         prior_claim_scope=prior_claim_scope,
     )
     if no_go_error:


### PR DESCRIPTION
## Context

PR #5280 was closed after its two-tier audit-assurance content landed directly on main. An exact gpt-5.6-sol / xhigh review of the landed tooling found transport and enforcement gaps that could incorrectly force development-tier bounded theorems through forensic locator containment, or allow materially different cross-confirmation payloads to agree.

## Repairs

- preserve core evidence completeness, freshness, and clipping checks across both assurance tiers while reserving dynamic N6/N8 index-drift containment for forensic audits
- keep real no-go claims and output-shaped negative assertions fail-closed; use structural N1-N8 validation for development-tier bounded/positive wall packets
- persist and compare normalized claim scope, load-bearing class, and negative assertion declarations through cross-confirmation, judicial review, archive, reset, and restoration
- version new five-field cross-confirmation agreement records; reject malformed/unknown schemas while surfacing pre-version legacy scope/declaration mismatches as re-audit notices without mutating generated verdict state
- require judicial passes to ratify the same scope/class/declaration tuple
- support multi-root lane certification and multi-root batch orchestration
- run invalidation/restoration to a joint fixed point after verdict application
- preserve forensic restoration semantics and current-main certification policy
- stop audit-lane GitHub Actions from running on pull requests; review-loop owns local PR validation, while nightly and manual main refreshes remain

## Validation

- 296/296 audit-pipeline tests pass
- full 16-stage audit pipeline passes on current main
- strict audit lint: 3,751 rows, zero errors
- YAML parse and git diff --check pass
- generated ledger, queue, certification, and publication-status outputs are not included

The migration-safe lint reports 88 pre-versioned cross-confirmation scope/declaration mismatches as legacy re-audit notices. This PR does not rewrite or invalidate those generated audit records; they are evidence for the independent older-science audit backlog.

This PR changes audit infrastructure and methodology only; it applies no science verdict. It is intended to unblock a fresh audit-loop retry of lorentz_violation_derived_note after landing. The validation run also surfaced existing generated audit-lane work (including the packetless Koide row and cascade invalidations); those outputs are intentionally not committed.