### PR TITLE
fix(d3-landau-peierls): narrow derived scope to elliptic patches

### DIFF
--- a/docs/D3_LANDAU_PEIERLS_SINGLE_BAND_NORMALIZATION_BOUNDED_THEOREM_NOTE_2026-06-18.md
+++ b/docs/D3_LANDAU_PEIERLS_SINGLE_BAND_NORMALIZATION_BOUNDED_THEOREM_NOTE_2026-06-18.md
@@ -40,6 +40,15 @@ The literature name for the same object is the spinless single-band
 Landau-Peierls intraband term. That name is cited in parallel as context only:
 the source authority in this repo is the derivation and runner named above.
 
+**Derived scope (elliptic patches).** The derivation below establishes this
+normalization for elliptic (positive-determinant) quadratic patches, where the
+local canonical matrix has a real magnetic frequency and a discrete midpoint
+Landau ladder. Extending the same `-det(H_xy)/12` coefficient through the
+determinant-zero lines to saddle (negative-determinant) patches is an explicit
+open conjecture and is not part of the derived bounded claim; the full
+Brillouin-zone reference value is reported as a diagnostic that holds
+conditionally on that conjecture.
+
 ## Derivation
 
 1. **Peierls magnetic translations.** The plaquette convention has magnetic
@@ -71,13 +80,14 @@ the source authority in this repo is the derivation and runner named above.
    det(H) = a b - c^2.
    ```
 
-   Thus the local magnetic spacing is `B sqrt(det(H))` for elliptic patches,
-   and the analytic coefficient carried into the Brillouin-zone formula is the
-   determinant `E_xx E_yy - E_xy^2`. Saddle patches enter because the final
-   local response coefficient is the polynomial `-det(H)/12`, not a
-   square-root branch. The runner checks the exact rational coefficient on
-   both positive- and negative-determinant quadratic patches; the note does
-   not claim a separate discrete Landau-level spectrum for an isolated saddle.
+   Thus for elliptic (positive-determinant) patches the local magnetic spacing
+   is `B sqrt(det(H))`, a real frequency, and the analytic coefficient carried
+   into the Brillouin-zone formula is the determinant `E_xx E_yy - E_xy^2`. For
+   saddle (negative-determinant) patches the canonical matrix has real
+   eigenvalues, `sqrt(det(H))` is imaginary, and there is no discrete magnetic
+   ladder, so the midpoint derivation of the next step does not apply. The
+   derivation is therefore restricted to elliptic patches; the saddle patches
+   are held out of the derived scope as an explicit open conjecture.
 
 3. **Midpoint Euler-Maclaurin coefficient.** The local magnetic levels sample
    the transverse action by midpoint levels `(n + 1/2) h`, with
@@ -114,10 +124,14 @@ the source authority in this repo is the derivation and runner named above.
    Omega''(0) = -1/12 * integral f'(E(k)) det(H_xy(k)) d^3k/(2*pi)^3.
    ```
 
-   Since the local coefficient is polynomial in `det(H_xy)`, the full
-   Brillouin-zone patching does not require a separate sign branch at saddle
-   points. The cubic-band runner samples both signs of `det(H_xy)` and applies
-   the same exact coefficient.
+   This local coefficient is derived for elliptic patches, where the midpoint
+   magnetic ladder exists. Whether the same `-det(H_xy)/12` coefficient
+   continues unchanged across the determinant-zero lines into saddle patches is
+   an explicit open conjecture and is not part of the derived bounded claim.
+   The cubic-band runner samples both signs of `det(H_xy)` only to exhibit that
+   the Brillouin zone contains saddle regions held out of the derived elliptic
+   scope; the full-zone integral is reported as a diagnostic, conditional on
+   that conjecture.
 
 5. **Cubic-band substitution.** For the cubic nearest-neighbor band,
    `E_xx = 2 cos(kx)`, `E_yy = 2 cos(ky)`, and `E_xy = 0`, so the determinant
@@ -134,16 +148,23 @@ convention as the finite-torus comparison runner. The note is still bounded:
 - it does not derive an interacting or continuum-QFT response;
 - it does not assert a thermodynamic-limit theorem for the finite `L=32`
   comparison note;
+- the derived normalization is established only for elliptic
+  (positive-determinant) quadratic patches; the saddle (negative-determinant)
+  full-patch continuation is an explicit open conjecture, not part of the
+  derived bounded claim, and the full Brillouin-zone reference value is a
+  diagnostic conditional on it;
 - it leaves all status decisions to the audit lane.
 
 ## Runner Gates
 
 The runner verifies the finite magnetic-cell degeneracy density, the exact
 Bernoulli coefficients, the local symplectic determinant invariant, the
-polynomial saddle-continuation coefficient, the cubic-band Hessian determinant,
-and the parent d=3 reference Landau-Peierls value using this fixed
-normalization. The passing run reports:
+elliptic-versus-saddle canonical-eigenvalue dichotomy that restricts the
+derivation to elliptic patches, the cubic-band Hessian determinant, the
+saddle-scope boundary held as an explicit open conjecture, and the parent d=3
+reference Landau-Peierls value reported as a diagnostic conditional on that
+conjecture. The passing run reports:
 
 ```text
-TOTAL: PASS=13 FAIL=0
+TOTAL: PASS=14 FAIL=0
 ```

--- a/logs/runner-cache/frontier_d3_landau_peierls_single_band_normalization_2026_06_18.txt
+++ b/logs/runner-cache/frontier_d3_landau_peierls_single_band_normalization_2026_06_18.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_d3_landau_peierls_single_band_normalization_2026_06_18.py
-runner_sha256: 282b3e3b950161a5a35eb2812b7f13efa286dbad095188bd15affa060f92942b
-timeout_sec: 120
+runner_sha256: 7d0418b77f521e7f19798306f641c3957228f1d2017c9c36860e7cf41e6f0fc9
+timeout_sec: 180
 exit_code: 0
-elapsed_sec: 0.15
+elapsed_sec: 0.18
 status: ok
 ----- stdout -----
 d=3 single-band Landau-Peierls normalization source-boundary runner
@@ -14,14 +14,15 @@ PASS: midpoint Euler-Maclaurin has no linear endpoint term: B1(1/2)=0
 PASS: midpoint h^2 coefficient is exactly 1/24: -B2(1/2)/2=1/24
 PASS: grand-potential second-difference coefficient is exactly -1/12 after integration by parts: -2*(1/24)=-1/12
 PASS: local magnetic oscillator invariant is det(Hxy): (a,b,c)=(3/2,5/3,1/7) trace=0 det=243/98; (a,b,c)=(7/5,11/6,-2/9) trace=0 det=2039/810; (a,b,c)=(5/4,9/8,1/3) trace=0 det=373/288
-PASS: saddle continuation uses the exact polynomial coefficient -det(Hxy)/12: det=243/98 coeff=-81/392; det=-247/98 coeff=247/1176; det=358/405 coeff=-179/2430
+PASS: elliptic patches have a real magnetic frequency and saddle patches do not, so the midpoint ladder derivation is elliptic-only: elliptic det=243/98 lambda^2=-243/98<0; elliptic det=373/288 lambda^2=-373/288<0; saddle det=-247/98 lambda^2=247/98>0; saddle det=-398/405 lambda^2=398/405>0
 PASS: cubic band transverse Hessian determinant is 4 cos(kx) cos(ky): max finite-difference determinant error=7.513e-08
-PASS: cubic full-patch determinant includes elliptic and saddle signs without changing coefficient: det_min=-3.990369, det_max=+3.990369
-PASS: native normalization reproduces parent d=3 LP reference value without fitting: lp_ref=-3.949577202602e-03, expected=-3.949577202602e-03
+PASS: cubic Brillouin zone contains saddle (negative-determinant) patches held out of the derived elliptic scope: det_min=-3.990369, det_max=+3.990369
+PASS: full-zone integral under the conjectured saddle continuation reproduces the parent d=3 LP reference (diagnostic; saddle scope is an open conjecture): lp_ref=-3.949577202602e-03, expected=-3.949577202602e-03
 PASS: cubic particle-hole symmetry is preserved by the normalized LP integral: max |chi(mu)-chi(-mu)|=3.469e-18
 PASS: source note records bounded status and no-axiom boundary: all required source-boundary phrases present
+PASS: note restricts the derived claim to elliptic patches and marks the saddle continuation as an open conjecture: forbidden_present=[] required_absent=[]
 PASS: runner uses exact rational normalization, not a fitted float: CELL_NORMALIZATION_EXACT=-1/12
-TOTAL: PASS=13 FAIL=0
+TOTAL: PASS=14 FAIL=0
 
 ----- stderr -----
 

--- a/scripts/frontier_d3_landau_peierls_single_band_normalization_2026_06_18.py
+++ b/scripts/frontier_d3_landau_peierls_single_band_normalization_2026_06_18.py
@@ -103,11 +103,6 @@ def oscillator_characteristic_coefficients(a: Fraction, b: Fraction, c: Fraction
     return trace, determinant
 
 
-def local_response_coefficient(a: Fraction, b: Fraction, c: Fraction) -> Fraction:
-    """Local LP coefficient after midpoint and integration-by-parts reduction."""
-    return CELL_NORMALIZATION_EXACT * (a * b - c * c)
-
-
 def fermi_prime(energy: np.ndarray, mu: float, temperature: float) -> np.ndarray:
     x = (energy - mu) / temperature
     out = np.empty_like(x, dtype=np.float64)
@@ -231,25 +226,40 @@ def main() -> int:
         "; ".join(oscillator_details),
     )
 
-    continuation_examples = (
+    # Elliptic patches (det(H)>0) give a purely imaginary JH spectrum, i.e. a
+    # real magnetic frequency sqrt(det) and a discrete midpoint Landau ladder,
+    # so the midpoint Euler-Maclaurin derivation applies. Saddle patches
+    # (det(H)<0) give a real JH spectrum: sqrt(det) is imaginary, there is no
+    # oscillator ladder, and the derivation does not apply. This dichotomy is
+    # why the derived scope is elliptic-only and the saddle continuation is held
+    # as an explicit open conjecture. JH eigenvalues solve lambda^2 + det(H)=0.
+    elliptic_examples = (
         (Fraction(3, 2), Fraction(5, 3), Fraction(1, 7)),
-        (Fraction(3, 2), Fraction(-5, 3), Fraction(1, 7)),
-        (Fraction(-4, 5), Fraction(-7, 6), Fraction(2, 9)),
+        (Fraction(5, 4), Fraction(9, 8), Fraction(1, 3)),
     )
-    signs = set()
-    continuation_ok = True
-    continuation_details: list[str] = []
-    for a, b, c in continuation_examples:
-        det_h = a * b - c * c
-        coeff = local_response_coefficient(a, b, c)
-        continuation_ok = continuation_ok and coeff == -det_h / 12
-        signs.add(1 if det_h > 0 else -1 if det_h < 0 else 0)
-        continuation_details.append(f"det={det_h} coeff={coeff}")
-    continuation_ok = continuation_ok and {1, -1}.issubset(signs)
+    saddle_examples = (
+        (Fraction(3, 2), Fraction(-5, 3), Fraction(1, 7)),
+        (Fraction(-4, 5), Fraction(7, 6), Fraction(2, 9)),
+    )
+    dichotomy_ok = True
+    dichotomy_details: list[str] = []
+    for a, b, c in elliptic_examples:
+        _, det_jh = oscillator_characteristic_coefficients(a, b, c)
+        eigen_sq = -det_jh
+        # elliptic: det(H)>0 and lambda^2<0 (purely imaginary -> real frequency).
+        dichotomy_ok = dichotomy_ok and det_jh > 0 and eigen_sq < 0
+        dichotomy_details.append(f"elliptic det={det_jh} lambda^2={eigen_sq}<0")
+    for a, b, c in saddle_examples:
+        _, det_jh = oscillator_characteristic_coefficients(a, b, c)
+        eigen_sq = -det_jh
+        # saddle: det(H)<0 and lambda^2>0 (real eigenvalues -> no oscillator).
+        dichotomy_ok = dichotomy_ok and det_jh < 0 and eigen_sq > 0
+        dichotomy_details.append(f"saddle det={det_jh} lambda^2={eigen_sq}>0")
     gates.check(
-        "saddle continuation uses the exact polynomial coefficient -det(Hxy)/12",
-        continuation_ok,
-        "; ".join(continuation_details),
+        "elliptic patches have a real magnetic frequency and saddle patches do "
+        "not, so the midpoint ladder derivation is elliptic-only",
+        dichotomy_ok,
+        "; ".join(dichotomy_details),
     )
 
     sample_points = (
@@ -272,14 +282,14 @@ def main() -> int:
     k = 2.0 * math.pi * (np.arange(64, dtype=np.float64) + 0.5) / 64.0
     det_grid = 4.0 * np.cos(k[:, None]) * np.cos(k[None, :])
     gates.check(
-        "cubic full-patch determinant includes elliptic and saddle signs without changing coefficient",
+        "cubic Brillouin zone contains saddle (negative-determinant) patches held out of the derived elliptic scope",
         float(np.min(det_grid)) < 0.0 and float(np.max(det_grid)) > 0.0,
         f"det_min={float(np.min(det_grid)):+.6f}, det_max={float(np.max(det_grid)):+.6f}",
     )
 
     lp_ref = landau_peierls_chi_from_native_normalization(REFERENCE_MU, TEMPERATURE, LP_GRID_N)
     gates.check(
-        "native normalization reproduces parent d=3 LP reference value without fitting",
+        "full-zone integral under the conjectured saddle continuation reproduces the parent d=3 LP reference (diagnostic; saddle scope is an open conjecture)",
         abs(lp_ref - EXPECTED_PARENT_LP_REFERENCE) <= PARENT_REFERENCE_TOL,
         f"lp_ref={lp_ref:+.12e}, expected={EXPECTED_PARENT_LP_REFERENCE:+.12e}",
     )
@@ -299,7 +309,6 @@ def main() -> int:
     note_text = NOTE_PATH.read_text()
     required_phrases = (
         "finite-torus `B/(2*pi)` magnetic-cell",
-        "polynomial `-det(H)/12`",
         "does not introduce a new axiom",
         "midpoint Euler-Maclaurin coefficient",
         "`-1/12`",
@@ -311,6 +320,26 @@ def main() -> int:
         "source note records bounded status and no-axiom boundary",
         not missing,
         "all required source-boundary phrases present" if not missing else f"missing={missing}",
+    )
+
+    # Discriminating scope gate: the note must confine the derived claim to
+    # elliptic patches and mark the saddle continuation as an open conjecture.
+    # It FLIPS to FAIL if the withdrawn overclaim is re-added or the boundary
+    # language is removed.
+    scope_forbidden = (
+        "does not require a separate sign branch",
+        "polynomial `-det(H)/12`",
+    )
+    scope_required = (
+        "explicit open conjecture",
+        "not part of the derived bounded claim",
+    )
+    present_forbidden = [phrase for phrase in scope_forbidden if phrase in note_text]
+    absent_required = [phrase for phrase in scope_required if phrase not in note_text]
+    gates.check(
+        "note restricts the derived claim to elliptic patches and marks the saddle continuation as an open conjecture",
+        not present_forbidden and not absent_required,
+        f"forbidden_present={present_forbidden} required_absent={absent_required}",
     )
 
     gates.check(


### PR DESCRIPTION
## What verdict this responds to

The independent audit lane graded the `d3_landau_peierls` bounded-theorem row
`audited_conditional` with a `missing_bridge_theorem` finding: the note derives
the `-1/12 · det(H_xy)` single-band Landau-Peierls normalization from the
midpoint Euler-Maclaurin coefficient, but that derivation only supplies a
discrete magnetic ladder where the local canonical matrix has a **real magnetic
frequency**. The extension of the same coefficient across the determinant-zero
lines into saddle patches was asserted without a bridging theorem. The verdict's
own repair options were "narrow the note to elliptic patches" / "split the clean
elliptic bounded core from the conditional full-patch extension."

## What changed

This takes the **narrow** option. Editing the note + runner re-drifts their
hashes so the row re-enters the queue for independent re-audit.

**Note** (`docs/D3_LANDAU_PEIERLS_..._NOTE_2026-06-18.md`)
- Adds a "Derived scope (elliptic patches)" paragraph: the derivation
  establishes the normalization for elliptic (positive-determinant) patches
  only; the `-det(H_xy)/12` continuation to saddle patches is an **explicit open
  conjecture**, not part of the derived bounded claim.
- Rewrites Step 2 and Step 4 to withdraw the "does not require a separate sign
  branch" / "polynomial `-det(H)/12`" overclaim and state the elliptic
  restriction. For saddle patches the JH spectrum is real, `sqrt(det(H))` is
  imaginary, there is no ladder, so the midpoint step does not apply.
- Adds a Source Boundary bullet and reports the full-Brillouin-zone value as a
  diagnostic conditional on the conjecture.

**Runner** (`scripts/frontier_d3_landau_peierls_..._2026_06_18.py`)
- Removes the tautological continuation gate. It asserted
  `local_response_coefficient(a,b,c) == -det/12`, but the helper returns
  `-1/12 · (a·b − c·c) = -det/12` — an `x == x` identity that could not fail.
  The dead helper is removed.
- Adds a **discriminating** elliptic/saddle gate computed from the real
  characteristic-polynomial machinery: elliptic examples must have `det(H) > 0`
  with `λ² = −det(H) < 0` (real frequency); saddle examples `det(H) < 0` with
  `λ² > 0` (no oscillator ladder).
- Adds a **discriminating** prose scope-consistency gate that flips to FAIL if
  the withdrawn overclaim is re-added or the open-conjecture boundary language
  is removed (verified: re-injecting the overclaim yields `PASS=13 FAIL=1`).
- Relabels the full-patch determinant and full-zone reference gates as
  diagnostics held out of the derived elliptic scope (conditions unchanged).

## Runner numbers

`TOTAL: PASS=14 FAIL=0` (was 13; −1 tautological gate, +1 dichotomy gate,
+1 scope gate). Cache regenerated via `scripts/runner_cache.py`, `status: ok`,
`exit_code: 0`.

## Scope / boundary

- Source-only triple: 1 note + 1 runner + 1 cache. No audit-owned surface
  touched; the note authors no status and predicts no grade.
- No new axiom, primitive, import, or fitted scalar. The change only *narrows*
  the derived claim; the full-zone diagnostic value is unchanged.
- The sole dependent (the d=3 orbital-response parent runner) greps only
  preserved phrases; its pre-existing failing `PASS=9` cache pin is an
  independent unaudited-row issue untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
