### PR TITLE
audit-infra: axiom-premise pre-check in the restore lane (non-oscillating restoration)

### DIFF
--- a/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
+++ b/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
@@ -519,6 +519,21 @@ def restore_audit_from_previous(
     if not history:
         return None
     archived = history[-1]
+    # Axiom-premise pre-check (mirrors invalidate_stale_audits.py's
+    # axiom_premise_changed trigger exactly, including its tolerance for
+    # snapshots that predate the hash map): an audit performed under
+    # different axiom-premise text is re-audit material, never restore
+    # material. Without this, a restored stale-premise verdict is briefly
+    # LIVE in the ledger until the next sweep re-invalidates it — a window
+    # in which dispatch producers, lane certification, or a collaborator
+    # can read a verdict audited under different axioms as current.
+    if rows is not None:
+        snap = archived.get("audit_state_snapshot") or {}
+        snap_axiom_hash = snap.get("dep_axiom_premise_note_hash") or {}
+        for dep, before in snap_axiom_hash.items():
+            after = (rows.get(dep) or {}).get("note_hash")
+            if before is not None and after is not None and before != after:
+                return None
     new_row = dict(row)
     new_row["previous_audits"] = history
     archived_reference = hashlib.sha256(

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -8292,6 +8292,63 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
         m.LEDGER_PATH = m.DATA_DIR / "audit_ledger.json"
         return m
 
+    def test_restore_refuses_stale_axiom_premise_hash(self):
+        m = self._import_and_patch()
+        archived = self._archived_audit()
+        archived["audit_state_snapshot"] = {
+            "criticality": "leaf",
+            "deps": ["minimal_axioms"],
+            "dep_axiom_premise_note_hash": {"minimal_axioms": "c8201cb1" + "0" * 56},
+        }
+        row = self._seed_with_archived("stale_premise_row", archived)
+        row["deps"] = ["minimal_axioms"]
+        rows = {
+            "stale_premise_row": row,
+            "minimal_axioms": {
+                "claim_id": "minimal_axioms",
+                "note_hash": "fc4d60cc" + "0" * 56,
+            },
+        }
+        # Mismatching recorded vs current premise hash: re-audit material,
+        # never restore material (mirrors invalidate's axiom_premise_changed).
+        self.assertIsNone(m.restore_audit_from_previous(row, rows))
+
+    def test_restore_proceeds_on_matching_or_absent_axiom_premise_hash(self):
+        m = self._import_and_patch()
+        matching_hash = "c8201cb1" + "0" * 56
+        archived = self._archived_audit()
+        archived["audit_state_snapshot"] = {
+            "criticality": "leaf",
+            "deps": ["minimal_axioms"],
+            "dep_axiom_premise_note_hash": {"minimal_axioms": matching_hash},
+        }
+        row = self._seed_with_archived("matching_premise_row", archived)
+        rows = {
+            "matching_premise_row": row,
+            "minimal_axioms": {
+                "claim_id": "minimal_axioms",
+                "note_hash": matching_hash,
+            },
+        }
+        self.assertIsNotNone(m.restore_audit_from_previous(row, rows))
+        # Snapshots that predate the hash map restore exactly as the
+        # invalidation sweep tolerates them (mirror semantics, both ways).
+        archived_legacy = self._archived_audit()
+        archived_legacy["audit_state_snapshot"] = {
+            "criticality": "leaf", "deps": ["minimal_axioms"],
+        }
+        row_legacy = self._seed_with_archived("legacy_snapshot_row", archived_legacy)
+        rows_legacy = {
+            "legacy_snapshot_row": row_legacy,
+            "minimal_axioms": {
+                "claim_id": "minimal_axioms",
+                "note_hash": "fc4d60cc" + "0" * 56,
+            },
+        }
+        self.assertIsNotNone(
+            m.restore_audit_from_previous(row_legacy, rows_legacy)
+        )
+
     def test_categorize_archived_mirrors_invalidate_policy(self):
         m = self._import_and_patch()
         # leaf/medium: any audit qualifies

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -8294,33 +8294,46 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
 
     def test_restore_refuses_stale_axiom_premise_hash(self):
         m = self._import_and_patch()
+        matching_hash = "c8201cb1" + "0" * 56
         archived = self._archived_audit()
         archived["audit_state_snapshot"] = {
             "criticality": "leaf",
-            "deps": ["minimal_axioms"],
-            "dep_axiom_premise_note_hash": {"minimal_axioms": "c8201cb1" + "0" * 56},
+            "deps": ["minimal_axioms", "scale_reference_primitive"],
+            "dep_axiom_premise_note_hash": {
+                "minimal_axioms": matching_hash,
+                "scale_reference_primitive": "9a2f106e" + "0" * 56,
+            },
         }
         row = self._seed_with_archived("stale_premise_row", archived)
-        row["deps"] = ["minimal_axioms"]
+        row["deps"] = ["minimal_axioms", "scale_reference_primitive"]
         rows = {
             "stale_premise_row": row,
             "minimal_axioms": {
                 "claim_id": "minimal_axioms",
+                "note_hash": matching_hash,
+            },
+            "scale_reference_primitive": {
+                "claim_id": "scale_reference_primitive",
                 "note_hash": "fc4d60cc" + "0" * 56,
             },
         }
-        # Mismatching recorded vs current premise hash: re-audit material,
+        # The axiom matches but a later primitive map entry does not. Every
+        # recorded premise key is checked: the mismatch is re-audit material,
         # never restore material (mirrors invalidate's axiom_premise_changed).
         self.assertIsNone(m.restore_audit_from_previous(row, rows))
 
     def test_restore_proceeds_on_matching_or_absent_axiom_premise_hash(self):
         m = self._import_and_patch()
         matching_hash = "c8201cb1" + "0" * 56
+        matching_primitive_hash = "9a2f106e" + "0" * 56
         archived = self._archived_audit()
         archived["audit_state_snapshot"] = {
             "criticality": "leaf",
-            "deps": ["minimal_axioms"],
-            "dep_axiom_premise_note_hash": {"minimal_axioms": matching_hash},
+            "deps": ["minimal_axioms", "scale_reference_primitive"],
+            "dep_axiom_premise_note_hash": {
+                "minimal_axioms": matching_hash,
+                "scale_reference_primitive": matching_primitive_hash,
+            },
         }
         row = self._seed_with_archived("matching_premise_row", archived)
         rows = {
@@ -8328,6 +8341,10 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
             "minimal_axioms": {
                 "claim_id": "minimal_axioms",
                 "note_hash": matching_hash,
+            },
+            "scale_reference_primitive": {
+                "claim_id": "scale_reference_primitive",
+                "note_hash": matching_primitive_hash,
             },
         }
         self.assertIsNotNone(m.restore_audit_from_previous(row, rows))


### PR DESCRIPTION
## Summary

Ships the sibling-worktree proposal, reviewed and verified against live code: `invalidate_stale_audits.py` re-invalidates on `axiom_premise_changed` (snapshot `dep_axiom_premise_note_hash` vs current note hash), but `restore_audit_from_previous` never consulted that map — so a stale-premise archive restores in joint-loop pass 1 and re-invalidates in pass 2 (observed on `i1_native_quadratic_static_source_normalization_bridge_2026-06-08`, `c8201cb1→fc4d60cc`, fixed point at pass 3).

**The exposure this closes is stronger than non-oscillation:** between passes, a verdict audited under *different axioms* is briefly live in the ledger — dispatch producers, lane certification, or a collaborator can read it as current.

**Review notes applied:**
- Mirrors the invalidator **exactly**, including tolerance for legacy snapshots that predate the hash map (refusal only when both hashes present and differ) — stricter-than-invalidate would strand archives the sweep itself accepts.
- Iterates **all** keys of the snapshot map (primitives included), not just `minimal_axioms`.
- Chokepoint placement (`restore_audit_from_previous` → None) covers every restore category lane at once.
- Fixtures pin the mirror **from both sides**: stale → refused; matching → restores; absent map → restores.

Consistency: makes explicit what the 230-row restore analysis concluded from the other direction — different-premise-era archives are re-audit material. Verdicts bind to claim content including premise hashes; restore now honors that binding symmetrically with invalidation.

## Verification
- Suite 275/275; vocab_lint clean on changed files; source-only (no generated surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)