### PR TITLE
audit-infra: bind no-go classes to packet provenance

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -547,7 +547,7 @@ verbatim at the single cited `evidence_path`. The combined text must contain a
 literal marker accepted for its `route_class`:
 
 - `algebraic_rearrangement`: algebra, identity, rearrange, factor, cancel, solve;
-- `symmetry_or_representation`: symmetry, representation, commutator, character, irrep, group;
+- `symmetry_or_representation`: symmetry, invariant, representation, commutator, character, irrep, group;
 - `alternate_carrier_or_sector`: carrier, sector, module, space, irrep;
 - `boundary_or_initial_condition`: boundary, initial, background, state, pointwise;
 - `normalization_or_units`: normalization, unit, scale, dimensionful;
@@ -593,6 +593,15 @@ axiom/approved-primitive vocabulary is explicit accepted premise content and
 is separately guarded by premise-purity checks; it is not a hidden admission
 inside the audited claim. The authenticated manifest remains available for N1,
 N2, N4, N6, and N7 authority checks.
+
+For an N3 hit, `retained_authority` classifies the provenance of the hit's
+whole `evidence_path`, not the semantics of a word such as `axiom` inside that
+path. It is legal exactly when the manifest entry has an `authority`,
+`framework_premise`, or `premise_registry` role and also has retained-grade
+`effective_status` or `accepted_premise_type: axiom_or_approved_primitive`.
+A path whose manifest role is `source` cannot be `retained_authority`; classify
+its hit as `hidden_admission` with the matching N2 wall or as
+`non_load_bearing` with the required substantive rationale.
 
 For every N3 hit and N5 statement, copy `phrase` byte-for-byte from the
 corresponding `full_phrase_groups[].phrase` value in the evidence manifest.

--- a/docs/audit/scripts/no_go_discipline_gate.py
+++ b/docs/audit/scripts/no_go_discipline_gate.py
@@ -38,7 +38,7 @@ ROUTE_CLASSES = {
 }
 ROUTE_CLASS_MARKERS = {
     "algebraic_rearrangement": re.compile(r"\b(?:algebra|identity|rearrang|factor|cancel|solve)\w*\b", re.I),
-    "symmetry_or_representation": re.compile(r"\b(?:symmetr|represent|commut|character|irrep|group)\w*\b", re.I),
+    "symmetry_or_representation": re.compile(r"\b(?:symmetr|invarian|represent|commut|character|irrep|group)\w*\b", re.I),
     "alternate_carrier_or_sector": re.compile(r"\b(?:alternate\s+)?(?:carrier|sector|module|space|irrep)\b", re.I),
     "boundary_or_initial_condition": re.compile(r"\b(?:boundary|initial|background|state|pointwise)\w*\b", re.I),
     "normalization_or_units": re.compile(r"\b(?:normaliz|units?|scale|dimensionful)\w*\b", re.I),

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -6199,6 +6199,36 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             m.validate_no_go_discipline(audit, evidence_manifest=manifest) or "",
         )
 
+    def test_n1_symmetry_route_accepts_invariance_vocabulary(self):
+        m = _import("no_go_discipline_gate")
+        manifest = self._manifest()
+        route_text = (
+            "readout is translation invariant\n"
+            "readout is proper-cubic-rotation invariant\n"
+            "readout is cycle-position permutation invariant\n"
+        )
+        stdout_path = "audit-packet://runner-stdout/test_no_go"
+        manifest[stdout_path]["text"] += "\n" + route_text
+        packet = _no_go_packet()
+        route = packet["N1_alternative_routes"][1]
+        route.update({
+            "route_id": "lattice_symmetry",
+            "route_class": "symmetry_or_representation",
+            "mechanism": "readout is translation invariant",
+            "attempt": "readout is proper-cubic-rotation invariant",
+            "outcome": "readout is cycle-position permutation invariant",
+            "evidence_path": stdout_path,
+            "evidence_locator": "readout is translation invariant",
+        })
+        _set_no_go_scan_coverage(packet, manifest)
+        audit = {
+            "claim_type": "no_go", "verdict": "audited_clean",
+            "chain_closes": True, "no_go_discipline": packet,
+        }
+        self.assertIsNone(
+            m.validate_no_go_discipline(audit, evidence_manifest=manifest)
+        )
+
     def test_occurrence_scans_and_resolution_classes_fail_closed(self):
         m = _import("no_go_discipline_gate")
         manifest = self._manifest()
@@ -6782,6 +6812,18 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         )
         self.assertIn(
             "`boundary` and `primitive` require separate objects",
+            template_flat,
+        )
+        self.assertIn(
+            "`retained_authority` classifies the provenance of the hit's whole",
+            template_flat,
+        )
+        self.assertIn(
+            "A path whose manifest role is `source` cannot be `retained_authority`",
+            template_flat,
+        )
+        self.assertIn(
+            "symmetry_or_representation`: symmetry, invariant, representation",
             template_flat,
         )
 
@@ -8111,6 +8153,27 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         self.assertNotIn("Recheck every N1-N8", prompt)
         self.assertNotIn("prior_secret", prompt)
         self.assertIn("not given its JSON or conclusion", prompt)
+        n3_code = m.fresh_schema_retry_code(
+            "N3 retained_authority hit 1 is not retained or accepted in the manifest"
+        )
+        self.assertEqual(
+            n3_code, "N3_RETAINED_AUTHORITY_PROVENANCE_MISMATCH"
+        )
+        n3_prompt = m.render_fresh_schema_retry_prompt(
+            "ORIGINAL RESTRICTED PACKET", n3_code, 1,
+        )
+        self.assertIn("describes path provenance", n3_prompt)
+        self.assertNotIn("hit 1", n3_prompt)
+        n1_code = m.fresh_schema_retry_code(
+            "N1 route 2.route_class='symmetry_or_representation' "
+            "is not supported by its evidenced mechanism/attempt/outcome vocabulary"
+        )
+        self.assertEqual(n1_code, "N1_ROUTE_CLASS_MARKER_MISMATCH")
+        n1_prompt = m.render_fresh_schema_retry_prompt(
+            "ORIGINAL RESTRICTED PACKET", n1_code, 1,
+        )
+        self.assertIn("joined mechanism, attempt, and outcome", n1_prompt)
+        self.assertNotIn("route 2", n1_prompt)
 
     def test_failed_locator_repair_preserves_fresh_schema_eligibility(self):
         m = _import_codex_audit_runner()

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1568,6 +1568,14 @@ def fresh_schema_retry_eligible(validation_error: str | None) -> bool:
 
 def fresh_schema_retry_code(validation_error: str) -> str:
     """Reduce validator text to a conclusion-free control-plane code."""
+    if validation_error.startswith("N3 retained_authority hit "):
+        return "N3_RETAINED_AUTHORITY_PROVENANCE_MISMATCH"
+    if (
+        validation_error.startswith("N1 route ")
+        and ".route_class=" in validation_error
+        and "is not supported by its evidenced" in validation_error
+    ):
+        return "N1_ROUTE_CLASS_MARKER_MISMATCH"
     return "AUDIT_SCHEMA_REJECT"
 
 
@@ -1602,6 +1610,19 @@ def render_fresh_schema_retry_prompt(
     discards the prior object completely. The generic validator code reveals
     no failed section, scientific framing, or prior conclusion.
     """
+    guidance = {
+        "N3_RETAINED_AUTHORITY_PROVENANCE_MISMATCH": (
+            "Static N3 invariant: retained_authority describes path provenance, "
+            "not phrase semantics. Use it exactly when the hit path has an "
+            "authority/framework_premise/premise_registry role and retained-grade "
+            "status or accepted axiom/approved-primitive type. A source-role path "
+            "must instead be classified from its actual load-bearing use.\n"
+        ),
+        "N1_ROUTE_CLASS_MARKER_MISMATCH": (
+            "Static N1 invariant: the joined mechanism, attempt, and outcome must "
+            "contain a documented literal marker for the selected route_class.\n"
+        ),
+    }.get(validation_code, "")
     return (
         f"{original_prompt}\n\n"
         "---\n"
@@ -1615,6 +1636,7 @@ def render_fresh_schema_retry_prompt(
         "output schema and every invariant already stated in the original "
         "restricted packet before responding.\n\n"
         f"VALIDATOR CODE:\n{validation_code}\n"
+        f"{guidance}"
     )
 
 


### PR DESCRIPTION
Summary: mirror the existing fail-closed N3 retained-authority provenance rule in the model-facing prompt; accept invariant/invariance as symmetry-route vocabulary; give fresh isolated schema retries conclusion-blind typed control codes and static schema guidance; add regressions reproducing both charged-lepton audit failures. Verification: 274 audit-pipeline tests pass; full pipeline and strict lint pass with zero errors; vocabulary lint and diff checks pass. Independent review-loop PASS at exact rebased head. No science claims or audit verdicts change.