### PR TITLE
audit-infra: dev-tier packet demand binds clean verdicts only (calibration)

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -86,8 +86,10 @@ Use this skill to audit one claim at a time from the repository audit queue and 
   source paths matching the no-go-name trigger (including obstruction,
   firewall, negative-boundary, no-uniform-sign, and stretch-attempt names),
   and `AUDIT_FORENSIC_MODE=1` certification runs. Development-tier rows supply
-  the N1-N8 packet as structured judgment with quoted evidence, validated
-  structurally. Negative-claim overclaims foreclose investigation paths
+  the N1-N8 packet as structured judgment with quoted evidence when the packet
+  is required or voluntarily included; otherwise non-clean verdicts record the
+  judgment in rationale prose. Any supplied packet is validated structurally.
+  Negative-claim overclaims foreclose investigation paths
   permanently and require the same scrutiny as positive-claim overclaims. If
   any N1-N8 check fails on the source note, choose the more conservative
   non-clean verdict whose `verdict_rationale` reflects the honest narrower
@@ -158,10 +160,11 @@ packet.
   runner, premise hashes) and survive unrelated repository growth.
   Independent cross-family re-derivation at xhigh and two-pass
   cross-confirmation on critical rows are unchanged and remain the heart of
-  the audit. When walls are named, answer N1-N8 as structured judgments with
-  quoted evidence; the packet is validated structurally (no
-  manifest-containment scans, no live-stdout precondition, no full-universe
-  dispositions, no transport envelope). The structured packet is MANDATORY
+  the audit. When walls are named, answer N1-N8 in the structured packet when
+  it is required or voluntarily included, and otherwise in rationale prose.
+  A supplied packet is validated structurally (no manifest-containment scans,
+  no live-stdout precondition, no full-universe dispositions, no transport
+  envelope). The structured packet is MANDATORY
   for `audited_clean` verdicts that name walls (and always on no-go rows);
   for non-clean verdicts on non-no-go rows it is optional — state the
   wall-naming judgment in `verdict_rationale` prose instead, since those

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -77,8 +77,10 @@ Use this skill to audit one claim at a time from the repository audit queue and 
   scope (owner-approved 2026-07-12):** the gate is always applied as auditor
   JUDGMENT, but the heavyweight evidence plumbing is tier-scoped -- see
   "Two-Tier Assurance" below. Every incoming audit still declares
-  `negative_assertion_classes`; a non-empty declaration requires N1-N8, and
-  an empty declaration never bypasses the mechanical source/output triggers.
+  `negative_assertion_classes`; a non-empty declaration requires the
+  structured N1-N8 packet on the same terms as the output trigger (clean
+  verdicts, no-go rows, forensic runs), and an empty declaration never
+  bypasses the mechanical source/output triggers.
   Forensic packets (manifest-backed containment, live runner-stdout citation,
   complete index dispositions) are mandatory for `claim_type: no_go` rows,
   source paths matching the no-go-name trigger (including obstruction,
@@ -159,7 +161,12 @@ packet.
   the audit. When walls are named, answer N1-N8 as structured judgments with
   quoted evidence; the packet is validated structurally (no
   manifest-containment scans, no live-stdout precondition, no full-universe
-  dispositions, no transport envelope).
+  dispositions, no transport envelope). The structured packet is MANDATORY
+  for `audited_clean` verdicts that name walls (and always on no-go rows);
+  for non-clean verdicts on non-no-go rows it is optional — state the
+  wall-naming judgment in `verdict_rationale` prose instead, since those
+  verdicts re-enter the repair queue and foreclose nothing. A supplied
+  packet is validated in full either way.
 - **Forensic tier.** Mandatory for `claim_type: no_go` rows and source paths
   matching the no-go-name trigger (including obstruction, firewall,
   negative-boundary, no-uniform-sign, and stretch-attempt names); forced

--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -191,10 +191,12 @@ empty declaration never bypasses a mechanical source or output trigger.
 - **Development tier:** for everything except `claim_type: no_go` rows,
   source paths matching the no-go-name trigger, and
   `AUDIT_FORENSIC_MODE=1` certification runs, supply N1-N8 as complete
-  structured judgment with quoted evidence paths and locators. Structural
-  validation does not authenticate manifest containment, require live stdout,
-  require exhaustive N6/N8 index coverage, or require transport and snapshot
-  plumbing.
+  structured judgment with quoted evidence paths and locators when the packet
+  is required above or you voluntarily include it. For a non-clean verdict
+  where the packet is optional and omitted, record the judgment in rationale
+  prose. Structural validation of any supplied packet does not authenticate
+  manifest containment, require live stdout, require exhaustive N6/N8 index
+  coverage, or require transport and snapshot plumbing.
 - **Forensic tier:** the manifest-containment, live-stdout, complete-index,
   transport, and snapshot requirements below are mandatory. The no-go-name
   trigger includes no-go, obstruction, firewall, negative-boundary,
@@ -377,7 +379,8 @@ Return a single JSON object with exactly these fields. No other prose.
 }
 ```
 
-Use `null` only when the gate is not required. Otherwise replace it with:
+Use `null` when the structured packet is not required and you do not choose to
+supply it. Otherwise replace it with:
 
 ```json
 {

--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -167,19 +167,26 @@ row as `no_go`, or whenever your rationale would name walls, admissions,
 obstructions, "does not lift," "no route exists," "no retained primitive
 supplies this," or "requires a new axiom." A `false` value scopes only the
 orchestrated forensic evidence plumbing — it NEVER waives the gate when your
-own output names walls: in that case you MUST still include the structured
-`no_go_discipline` object (development tier: N1-N8 as structured judgments
-with quoted evidence), or the apply gate will reject your verdict outright.
-The restricted-input rule still applies: do not search the wider repository.
-For N8, judge only the source note, runner/helper sources, one-hop authorities,
-and premise registries supplied here. Missing cross-cycle evidence is a
-checklist failure, not permission to browse.
+own output names walls. For an `audited_clean` verdict (or any verdict on a
+`claim_type: no_go` row, or in a forensic run) you MUST include the
+structured `no_go_discipline` object (development tier: N1-N8 as structured
+judgments with quoted evidence), or the apply gate will reject your verdict
+outright. For a non-clean verdict on a non-no-go row in the development
+tier, the structured object is optional — state the same wall-naming
+judgment in your rationale prose; a supplied object is still validated in
+full. Non-clean verdicts re-enter the repair queue and foreclose nothing,
+which is why only claim-cementing clean verdicts carry the mandatory packet
+there. The restricted-input rule still applies: do not search the wider
+repository. For N8, judge only the source note, runner/helper sources,
+one-hop authorities, and premise registries supplied here. Missing
+cross-cycle evidence is a checklist failure, not permission to browse.
 
 Packet evidence requirements are tier-scoped (owner-approved 2026-07-12),
-but auditor judgment is not. Every triggered row must answer N1-N8, and every
-incoming audit must declare `negative_assertion_classes`; a non-empty
-declaration requires the packet, while an empty declaration never bypasses a
-mechanical source or output trigger.
+but auditor judgment is not. Every triggered row must answer N1-N8 at least
+in rationale prose, and every incoming audit must declare
+`negative_assertion_classes`; a non-empty declaration requires the packet on
+the same clean-verdict/no-go/forensic terms as the output trigger, while an
+empty declaration never bypasses a mechanical source or output trigger.
 
 - **Development tier:** for everything except `claim_type: no_go` rows,
   source paths matching the no-go-name trigger, and
@@ -361,7 +368,7 @@ Return a single JSON object with exactly these fields. No other prose.
   },
   "verdict": "<one of audited_clean, audited_renaming, audited_conditional, audited_decoration, audited_numerical_match, audited_failed>",
   "verdict_rationale": "<two to four sentences>",
-  "negative_assertion_classes": ["<REQUIRED, possibly empty. After reading the full note, list every no-go-discipline policy class the artifact ASSERTS: no_go_result, stretch_attempt_negative, bounded_with_named_walls, derived_no_go_boundary, conditional_wall_rationale. This is your semantic judgment and is independent of any mechanical trigger; honest coverage routing (this note does not derive X - the parent row carries it) is not an assertion and declares nothing. Any non-empty declaration requires the full no_go_discipline packet.>"],
+  "negative_assertion_classes": ["<REQUIRED, possibly empty. After reading the full note, list every no-go-discipline policy class the artifact ASSERTS: no_go_result, stretch_attempt_negative, bounded_with_named_walls, derived_no_go_boundary, conditional_wall_rationale. This is your semantic judgment and is independent of any mechanical trigger; honest coverage routing (this note does not derive X - the parent row carries it) is not an assertion and declares nothing. A non-empty declaration requires the full no_go_discipline packet for an audited_clean verdict, any verdict on a no_go row, and forensic runs; on a development-tier non-clean verdict the declaration stands with the rationale prose.>"],
   "decoration_parent_claim_id": "<claim_id of the upstream parent if verdict = audited_decoration, else null>",
   "open_dependency_paths": ["<note path of any cited authority that is itself support / open / conditional>"],
   "auditor_confidence": "<low | medium | high>",

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -226,6 +226,8 @@ def cross_summary_no_go_error(
         source_required
         or no_go_discipline_gate.output_requires_no_go_discipline(summary)
         or bool(summary.get("negative_assertion_classes"))
+    ) and no_go_discipline_gate.packet_requirement_binds(
+        summary, source_required=source_required
     )
     if packet is None:
         return (

--- a/docs/audit/scripts/no_go_discipline_gate.py
+++ b/docs/audit/scripts/no_go_discipline_gate.py
@@ -2717,6 +2717,25 @@ def output_requires_no_go_discipline(audit: dict[str, Any]) -> bool:
     )
 
 
+def packet_requirement_binds(
+    audit: dict[str, Any], *, source_required: bool = False
+) -> bool:
+    """Whether a triggered structured-packet demand binds this verdict.
+
+    No-go artifacts (source-required rows, no_go claim-type judgments) and
+    forensic-tier runs carry the mandatory packet for every verdict. In the
+    development tier, the wall-naming output/declaration trigger binds only
+    claim-cementing `audited_clean` verdicts: non-clean verdicts are the
+    repair queue — they foreclose nothing and re-enter fresh audit — so the
+    wall-naming judgment stays in the verdict prose there, and a supplied
+    packet is still validated structurally.
+    """
+    if source_required or audit.get("claim_type") == "no_go" or forensic_mode():
+        return True
+    verdict = audit.get("verdict") or audit.get("audit_status")
+    return verdict == "audited_clean"
+
+
 def _text(value: Any) -> bool:
     return isinstance(value, str) and bool(value.strip())
 
@@ -4021,7 +4040,7 @@ def validate_no_go_discipline(
         source_required
         or output_requires_no_go_discipline(audit)
         or declared_requires
-    )
+    ) and packet_requirement_binds(audit, source_required=source_required)
     packet = audit.get("no_go_discipline")
     if not required:
         if packet is None:

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -1951,6 +1951,39 @@ class ApplyAuditTest(unittest.TestCase):
             ) or "",
         )
 
+    def test_dev_tier_prior_conditional_seat_packet_optional(self):
+        """A prior non-clean seat whose rationale names walls does not need
+        the structured packet in the development tier; a prior clean seat
+        with the same rationale still does."""
+        m = _import("apply_audit")
+        seat = {
+            "verdict": "audited_conditional",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "an affirmative identity",
+            "verdict_rationale": "A residual selector wall persists.",
+        }
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": ""}):
+            self.assertIsNone(
+                m.cross_summary_no_go_error(
+                    seat, source_required=False, current_evidence_manifest={}
+                )
+            )
+            self.assertIn(
+                "N1-N8 packet is required for the prior seat",
+                m.cross_summary_no_go_error(
+                    {**seat, "verdict": "audited_clean"},
+                    source_required=False,
+                    current_evidence_manifest={},
+                ) or "",
+            )
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
+            self.assertIn(
+                "N1-N8 packet is required for the prior seat",
+                m.cross_summary_no_go_error(
+                    seat, source_required=False, current_evidence_manifest={}
+                ) or "",
+            )
+
     def test_packeted_audit_archives_invalid_first_and_reuses_fresh_source_packet(self):
         m = _import("apply_audit")
         _patch_repo_root(m, self.tmp_root)
@@ -4718,6 +4751,80 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                     "claim_scope": "The exact positive identity closes.",
                     "negative_assertion_classes": [],
                 })
+            )
+
+    def test_dev_tier_packet_demand_binds_clean_verdicts_only(self):
+        """Development-tier calibration (2026-07-12): the wall-naming
+        output/declaration trigger mandates the structured packet only for
+        claim-cementing audited_clean verdicts. Non-clean verdicts are the
+        repair queue — the wall-naming judgment stays in prose there — while
+        no-go judgments, source-required rows, and the forensic tier bind
+        every verdict, and a supplied packet is always validated."""
+        m = _import("no_go_discipline_gate")
+        packet_required = "No-Go Discipline N1-N8 packet is required for this audit"
+        wall = {
+            "claim_type": "bounded_theorem",
+            "claim_scope": "an affirmative identity",
+            "verdict_rationale": "A residual selector wall persists.",
+        }
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": ""}):
+            for verdict in ("audited_conditional", "audited_failed"):
+                with self.subTest(verdict=verdict):
+                    self.assertIsNone(
+                        m.validate_no_go_discipline(
+                            {
+                                **wall,
+                                "verdict": verdict,
+                                "negative_assertion_classes": [
+                                    "conditional_wall_rationale"
+                                ],
+                            },
+                            require_declaration=True,
+                        )
+                    )
+            self.assertEqual(
+                m.validate_no_go_discipline(
+                    {
+                        **wall,
+                        "verdict": "audited_clean",
+                        "negative_assertion_classes": [
+                            "conditional_wall_rationale"
+                        ],
+                    },
+                    require_declaration=True,
+                ),
+                packet_required,
+            )
+            self.assertEqual(
+                m.validate_no_go_discipline(
+                    {**wall, "claim_type": "no_go", "verdict": "audited_conditional"}
+                ),
+                packet_required,
+            )
+            self.assertEqual(
+                m.validate_no_go_discipline(
+                    {**wall, "verdict": "audited_conditional"},
+                    source_required=True,
+                ),
+                packet_required,
+            )
+            # A packet supplied alongside a non-clean verdict is still
+            # validated structurally rather than waved through.
+            self.assertIsNotNone(
+                m.validate_no_go_discipline(
+                    {
+                        **wall,
+                        "verdict": "audited_conditional",
+                        "no_go_discipline": {"required": True},
+                    }
+                )
+            )
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
+            self.assertEqual(
+                m.validate_no_go_discipline(
+                    {**wall, "verdict": "audited_conditional"}
+                ),
+                packet_required,
             )
 
     def test_n3_excludes_explicit_accepted_premise_vocabulary(self):


### PR DESCRIPTION
## What

Calibration under the owner-approved two-tier assurance regime (2026-07-12): the wall-naming output/declaration trigger for the structured N1-N8 `no_go_discipline` object binds **claim-cementing `audited_clean` verdicts** in the development tier. Non-clean verdicts (`audited_conditional`, `audited_failed`, …) are the repair queue — they foreclose nothing and re-enter fresh audit — so the wall-naming judgment stays in `verdict_rationale` prose there, and a supplied packet is still validated in full.

**Always binding, unchanged:** source-required rows (no-go artifacts), `claim_type: no_go` judgments at any verdict, and `AUDIT_FORENSIC_MODE=1` certification runs. The restore lane evaluates under its `_forensic_gate()` and is untouched.

## Why now (canary evidence)

θ-lane canary, 2026-07-12: six conditional seat-verdicts across three orchestrator iterations, **zero applied** — each blocked on packet-schema perfection for a non-terminal verdict (N2 pairwise rationale wording, N1 `route_class` vocabulary) while the verdicts' repair content was sound. Demanding the full packet schema on repair-queue verdicts recreates the unattainable-packet regime one tier down: it blocks the queue that exists to fix the very defects the verdicts name.

## Mechanics

- New gate helper `packet_requirement_binds(audit, *, source_required)`: binds when source-required, `claim_type == no_go`, forensic mode, or `verdict == audited_clean`.
- Threaded into the only two consumers that hard-required packets on non-clean verdicts: `validate_no_go_discipline` (the `required` computation) and `apply_audit.cross_summary_no_go_error` (prior-seat check). All gate call sites already normalize `verdict` into the dict.
- Surveyed the remaining trigger consumers: `audit_lint` already errors only on clean live rows (notices otherwise); `invalidate_stale_audits` packet-absence checks are already `audited_clean`-scoped at both the live-row and nested-seat sites; the restore lane runs forensically by design.
- Template + audit-loop skill wording aligned (structured packet mandatory for clean/no-go/forensic; prose judgment for dev-tier non-clean; supplied packets always validated).
- Two new tests pin the calibration from the gate side and the apply side (clean still demands; conditional/failed do not; no-go/source/forensic bind at any verdict; supplied malformed packet on a conditional still rejects). Suite 275/275 OK; vocab_lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)