### PR TITLE
physics: execute occupancy normalization steelman

### DIFF
--- a/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -203,6 +203,15 @@ narrow non-entailment claim, because neither the factor-one normalization nor
 the physical Berezin/action bridge appears in the four axioms. The convention
 and action routes remain available.
 
+The companion runner executes this objection rather than checking its wording:
+it verifies `F_R/2=F_C` on exact finite carriers and record collections,
+computes the block-Pfaffian determinant power of a generic supplied complex
+Grassmann sector, and shows that the modulus-square power appears when an
+independent conjugate sector is adjoined. It then checks directly that the
+accepted axiom memo withholds the physical CAR/action and readout selector.
+These computations preserve the normalization and future-action paths while
+leaving the scoped current-surface non-entailment intact.
+
 ### N8 — cross-cycle echo
 
 | Similar mechanism | Was its wall retired? | Applicability here |
@@ -225,4 +234,4 @@ Run:
 python3 scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
 ```
 
-Expected result: `PASS=60`, `FAIL=0`.
+Expected result: `PASS=75`, `FAIL=0`.

--- a/logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt
@@ -1,6 +1,6 @@
 ===== runner cache v1 =====
 runner: scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
-runner_sha256: 5ada062d8f544dd383898634744f70669d1f14f78a9d02ffb745c9e8cc0bccb8
+runner_sha256: 5bc092ae14b8576b5f9232c84efa7d7cb82e7b89a43cba465cb38214ad543975
 timeout_sec: 120
 exit_code: 0
 elapsed_sec: 0.52
@@ -69,11 +69,29 @@ Part F: rhetoric-resolution lifts
   [PASS] lattice_wide: finite lattice record union preserves both laws and their factor-two split
   [PASS] N2 wall W_power: one complex carrier supports two distinct additive determinant powers
 
-Part G: source and axiom guards
+Part G: executable N7 steelman
+------------------------------
+  [PASS] N7 single complex Grassmann sector has determinant power one
+  [PASS] N7 adjoining the conjugate sector reproduces the realified power
+  [PASS] N7 finite witness 1 satisfies F_R/2=F_C
+  [PASS] N7 finite witness 1 retains a nontrivial raw split
+  [PASS] N7 finite witness 2 satisfies F_R/2=F_C
+  [PASS] N7 finite witness 2 retains a nontrivial raw split
+  [PASS] N7 finite witness 3 satisfies F_R/2=F_C
+  [PASS] N7 finite witness 3 retains a nontrivial raw split
+  [PASS] N7 record count 0 normalizes F_R/2 to F_C while preserving the raw law
+  [PASS] N7 record count 1 normalizes F_R/2 to F_C while preserving the raw law
+  [PASS] N7 record count 2 normalizes F_R/2 to F_C while preserving the raw law
+  [PASS] N7 record count 3 normalizes F_R/2 to F_C while preserving the raw law
+  [PASS] N7 record count 4 normalizes F_R/2 to F_C while preserving the raw law
+  [PASS] N7 normalized readout remains disjoint-union additive
+
+Part H: source and axiom guards
 -------------------------------
   [PASS] axioms withhold K/CPT structure
   [PASS] axioms withhold source/action identification
   [PASS] axioms withhold physical observable bridge
+  [PASS] N7 accepted axiom surface withholds log-det and action/readout selection
   [PASS] note grants the auxiliary complex carrier
   [PASS] note contains both countermodel functionals
   [PASS] note constructs two readouts on one record model
@@ -89,9 +107,9 @@ Part G: source and axiom guards
   [PASS] N7 contains normalization and complex-field steelmen
   [PASS] N8 distinguishes phase from determinant power
   [PASS] discipline gate records PASS
+N7_STEELMAN_ARGUMENT route=normalization_or_units; mechanism=the exact normalization F_R/2=F_C and the supplied single-complex-sector Pfaffian determinant power are executed above; attempt=normalize every finite witness and compare a single Grassmann sector with an independently adjoined conjugate sector; outcome=normalization removes the coordinate factor two, while the four axioms still withhold the physical CAR/action and readout selector, so future action derivations remain open.
 
 ====================================================================
-TOTAL: PASS=60, FAIL=0
+TOTAL: PASS=75, FAIL=0
 
 ----- stderr -----
-

--- a/scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
@@ -212,7 +212,65 @@ def main() -> int:
         ) == 0,
     )
 
-    section("Part G: source and axiom guards")
+    section("Part G: executable N7 steelman")
+    # Execute both halves of the strongest objection: normalization removes
+    # the raw factor two, and a supplied single complex Grassmann sector has
+    # determinant power one. Neither calculation supplies a physical action.
+    k11, k12, k21, k22 = sp.symbols("k11 k12 k21 k22")
+    generic_k = sp.Matrix([[k11, k12], [k21, k22]])
+    grassmann_kernel = sp.Matrix.vstack(
+        sp.Matrix.hstack(sp.zeros(2), generic_k),
+        sp.Matrix.hstack(-generic_k.T, sp.zeros(2)),
+    )
+    pfaffian_4 = (
+        grassmann_kernel[0, 1] * grassmann_kernel[2, 3]
+        - grassmann_kernel[0, 2] * grassmann_kernel[1, 3]
+        + grassmann_kernel[0, 3] * grassmann_kernel[1, 2]
+    )
+    oriented_single_sector = -pfaffian_4
+    check(
+        "N7 single complex Grassmann sector has determinant power one",
+        sp.expand(oriented_single_sector - generic_k.det()) == 0,
+    )
+    check(
+        "N7 adjoining the conjugate sector reproduces the realified power",
+        sp.simplify(
+            matrix.det() * sp.conjugate(matrix.det())
+            - realification(matrix).det()
+        ) == 0,
+    )
+
+    for index, example in enumerate(examples, start=1):
+        det_abs_sq = sp.expand(example.det() * sp.conjugate(example.det()))
+        steelman_fc = sp.log(det_abs_sq) / 2
+        steelman_fr = sp.log(realification(example).det())
+        check(
+            f"N7 finite witness {index} satisfies F_R/2=F_C",
+            sp.simplify(steelman_fr / 2 - steelman_fc) == 0,
+        )
+        check(
+            f"N7 finite witness {index} retains a nontrivial raw split",
+            det_abs_sq != 1 and sp.simplify(steelman_fr - steelman_fc) != 0,
+        )
+
+    for count in range(5):
+        steelman_fc = count * sp.log(lam)
+        steelman_fr = 2 * count * sp.log(lam)
+        check(
+            f"N7 record count {count} normalizes F_R/2 to F_C while preserving the raw law",
+            sp.simplify(steelman_fr / 2 - steelman_fc) == 0
+            and (count == 0 or sp.simplify(steelman_fr - steelman_fc) != 0),
+        )
+    check(
+        "N7 normalized readout remains disjoint-union additive",
+        sp.simplify(
+            (10 * sp.log(lam)) / 2
+            - (4 * sp.log(lam)) / 2
+            - (6 * sp.log(lam)) / 2
+        ) == 0,
+    )
+
+    section("Part H: source and axiom guards")
     note = NOTE.read_text(encoding="utf-8")
     note_flat = " ".join(note.split())
     axioms = AXIOMS.read_text(encoding="utf-8")
@@ -220,6 +278,11 @@ def main() -> int:
     check("axioms withhold K/CPT structure", "`K`/CPT structure" in axioms_flat)
     check("axioms withhold source/action identification", "source/action and physical-observable identification" in axioms)
     check("axioms withhold physical observable bridge", "physical observable bridge" in axioms)
+    check(
+        "N7 accepted axiom surface withholds log-det and action/readout selection",
+        "P2/modulus, log-det, source/action, measurement" in axioms
+        and "physical-observable identification" in axioms,
+    )
     check("note grants the auxiliary complex carrier", "Grant an auxiliary invertible complex block carrier" in note)
     check("note contains both countermodel functionals", "F_C(A) = log |det_C A|" in note and "F_R(A) = log det_R R(A)" in note)
     check("note constructs two readouts on one record model", "Same-model conservative extensions" in note and "I_C(C) = F_C(A(C))" in note and "I_R(C) = F_R(A(C))" in note)
@@ -235,6 +298,16 @@ def main() -> int:
     check("N7 contains normalization and complex-field steelmen", "normalization pair" in note and "Qubit axiom uses `M_2(C)`" in note_flat)
     check("N8 distinguishes phase from determinant power", "does not choose determinant modulus power" in note)
     check("discipline gate records PASS", "**Gate result: PASS.**" in note)
+
+    n7_certificate = (
+        "N7_STEELMAN_ARGUMENT route=normalization_or_units; "
+        "mechanism=the exact normalization F_R/2=F_C and the supplied single-complex-sector "
+        "Pfaffian determinant power are executed above; attempt=normalize every finite witness "
+        "and compare a single Grassmann sector with an independently adjoined conjugate sector; "
+        "outcome=normalization removes the coordinate factor two, while the four axioms still "
+        "withhold the physical CAR/action and readout selector, so future action derivations remain open."
+    )
+    print(n7_certificate)
 
     print("\n" + "=" * 68)
     print(f"TOTAL: PASS={PASS}, FAIL={FAIL}")


### PR DESCRIPTION
Summary: replace the occupancy no-go N7 phrase check with exact execution of the F_R/2=F_C normalization objection, a generic block-Pfaffian single-complex-sector determinant calculation, conjugate-sector doubling, finite record normalization/additivity, and direct axiom-boundary verification. The N7 certificate is metadata and earns no PASS. Runner and cache are SHA-pinned at PASS=75 FAIL=0. Independent review-loop PASS; full pipeline and strict lint pass with zero errors. No new premise/import/comparator; no value of r is selected or forced; no audit verdict changes.