### PR TITLE
audit-infra: bind no-go resolution text to live evidence

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -560,7 +560,7 @@ literal marker accepted for its `route_class`:
 - `symmetry_or_representation`: symmetry, invariant, representation, commutator, character, irrep, group;
 - `alternate_carrier_or_sector`: carrier, sector, module, space, irrep;
 - `boundary_or_initial_condition`: boundary, initial, background, state, pointwise;
-- `normalization_or_units`: normalization, unit, scale, dimensionful;
+- `normalization_or_units`: normalization, unit, `W_unit`, scale, dimensionful;
 - `dynamical_or_effective_action`: dynamic, effective, action, evolution, equivariant family;
 - `lattice_scale_or_limit`: lattice, continuum, limit, finite-size, asymptotic, approximate;
 - `numerical_or_finite_case`: numeric, finite, sample, scan, compute;
@@ -627,6 +627,10 @@ entry prefixed `per_element:`, `per_site:`, `per_mode:`, `per_block:`, and
 `lattice_wide:`. Put unexecuted classes in `untested_resolutions` as well; do
 not omit their prefixed `tested_resolutions` entry, which must state that the
 class was checked and not executed.
+Every complete `tested_resolutions[]` string—its class prefix and body—must be
+copied byte-for-byte as one contiguous substring from the cited live
+current-cycle `runner_stdout` at `resolution_evidence_path`. Do not summarize,
+shorten, or paraphrase a runner line.
 
 N6 must bind every indexed candidate to an exact quoted indexed basis, an N2
 wall, and a substantive closure mechanism. N7 must cite the N1 route surface

--- a/docs/audit/scripts/no_go_discipline_gate.py
+++ b/docs/audit/scripts/no_go_discipline_gate.py
@@ -41,7 +41,9 @@ ROUTE_CLASS_MARKERS = {
     "symmetry_or_representation": re.compile(r"\b(?:symmetr|invarian|represent|commut|character|irrep|group)\w*\b", re.I),
     "alternate_carrier_or_sector": re.compile(r"\b(?:alternate\s+)?(?:carrier|sector|module|space|irrep)\b", re.I),
     "boundary_or_initial_condition": re.compile(r"\b(?:boundary|initial|background|state|pointwise)\w*\b", re.I),
-    "normalization_or_units": re.compile(r"\b(?:normaliz|units?|scale|dimensionful)\w*\b", re.I),
+    "normalization_or_units": re.compile(
+        r"(?:\b(?:normaliz|units?|scale|dimensionful)\w*\b|\bW_unit\b)", re.I
+    ),
     "dynamical_or_effective_action": re.compile(r"\b(?:dynamic|effective|action|evolution|equivariant\s+family)\w*\b", re.I),
     "lattice_scale_or_limit": re.compile(r"\b(?:lattice|continuum|limit|finite[- ]size|asymptotic|approximate)\w*\b", re.I),
     "numerical_or_finite_case": re.compile(r"\b(?:numeric|finite|sample|scan|compute)\w*\b", re.I),
@@ -3602,8 +3604,17 @@ def _validate_n5(packet: dict, status: str, manifest: dict[str, dict] | None) ->
             resolution_entry = manifest[statement["resolution_evidence_path"]]
             if "runner_stdout" not in set(resolution_entry.get("roles") or []):
                 return f"N5 statement {index} resolution tests must cite current-cycle execution evidence"
+            resolution_text = str(resolution_entry.get("text") or "")
+            verified_resolutions = {
+                str(candidate)
+                for candidate in resolution_entry.get("verified_values") or []
+                if _text(candidate)
+            }
             for resolution in statement["tested_resolutions"]:
-                if not _entry_contains(resolution_entry, resolution):
+                if (
+                    resolution not in resolution_text
+                    and resolution not in verified_resolutions
+                ):
                     return f"N5 statement {index} tested resolution is not evidenced at resolution_evidence_path"
         if not isinstance(statement.get("occurrence_count"), int) or statement["occurrence_count"] <= 0:
             return f"N5 statement {index}.occurrence_count must be a positive integer"

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -7143,6 +7143,40 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             m.validate_no_go_discipline(audit, evidence_manifest=manifest)
         )
 
+    def test_n1_normalization_route_accepts_exact_w_unit_marker(self):
+        m = _import("no_go_discipline_gate")
+        marker = m.ROUTE_CLASS_MARKERS["normalization_or_units"]
+        self.assertIsNotNone(marker.search("W_unit"))
+        for non_marker in ("preW_unit", "W_unit_post", "W_unitary", "W__unit"):
+            with self.subTest(non_marker=non_marker):
+                self.assertIsNone(marker.search(non_marker))
+        manifest = self._manifest()
+        wall_line = (
+            "N2 wall W_unit: beta-one and beta-two singleton laws share h "
+            "but remain distinct"
+        )
+        stdout_path = "audit-packet://runner-stdout/test_no_go"
+        manifest[stdout_path]["text"] += "\n" + wall_line
+        packet = _no_go_packet()
+        route = packet["N1_alternative_routes"][4]
+        route.update({
+            "route_id": "unit_normalization",
+            "route_class": "normalization_or_units",
+            "mechanism": wall_line,
+            "attempt": wall_line,
+            "outcome": wall_line,
+            "evidence_path": stdout_path,
+            "evidence_locator": wall_line,
+        })
+        _set_no_go_scan_coverage(packet, manifest)
+        audit = {
+            "claim_type": "no_go", "verdict": "audited_clean",
+            "chain_closes": True, "no_go_discipline": packet,
+        }
+        self.assertIsNone(
+            m.validate_no_go_discipline(audit, evidence_manifest=manifest)
+        )
+
     def test_occurrence_scans_and_resolution_classes_fail_closed(self):
         m = _import("no_go_discipline_gate")
         manifest = self._manifest()
@@ -7175,6 +7209,28 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             "lacks a substantive",
             m.validate_no_go_discipline(audit, evidence_manifest=manifest) or "",
         )
+
+    def test_n5_tested_resolution_must_be_verbatim_runner_stdout(self):
+        m = _import("no_go_discipline_gate")
+        manifest = self._manifest()
+        for replacement in (
+            "per_element: summarized the complete route inventory without copying it",
+            NO_GO_N5_TESTED_RESOLUTIONS[0].replace("tested", "TESTED", 1),
+            NO_GO_N5_TESTED_RESOLUTIONS[0].replace("rhetoric against", "rhetoric  against", 1),
+            NO_GO_N5_TESTED_RESOLUTIONS[0].replace("rhetoric against", "rhetoric\nagainst", 1),
+        ):
+            with self.subTest(replacement=replacement):
+                packet = _no_go_packet()
+                _set_no_go_scan_coverage(packet, manifest)
+                packet["N5_rhetoric_audit"]["statements"][0]["tested_resolutions"][0] = replacement
+                audit = {
+                    "claim_type": "no_go", "verdict": "audited_clean",
+                    "chain_closes": True, "no_go_discipline": packet,
+                }
+                self.assertIn(
+                    "tested resolution is not evidenced at resolution_evidence_path",
+                    m.validate_no_go_discipline(audit, evidence_manifest=manifest) or "",
+                )
 
     def test_n8_mechanism_is_bound_to_exact_candidate_record(self):
         m = _import("no_go_discipline_gate")
@@ -7738,6 +7794,18 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         )
         self.assertIn(
             "symmetry_or_representation`: symmetry, invariant, representation",
+            template_flat,
+        )
+        self.assertIn(
+            "normalization_or_units`: normalization, unit, `W_unit`, scale",
+            template_flat,
+        )
+        self.assertIn(
+            "Every complete `tested_resolutions[]` string",
+            template_flat,
+        )
+        self.assertIn(
+            "copied byte-for-byte as one contiguous substring",
             template_flat,
         )
 
@@ -9258,6 +9326,16 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         )
         self.assertIn("joined mechanism, attempt, and outcome", n1_prompt)
         self.assertNotIn("route 2", n1_prompt)
+        n5_code = m.fresh_schema_retry_code(
+            "N5 statement 1 tested resolution is not evidenced at "
+            "resolution_evidence_path"
+        )
+        self.assertEqual(n5_code, "N5_TESTED_RESOLUTION_VERBATIM_MISMATCH")
+        n5_prompt = m.render_fresh_schema_retry_prompt(
+            "ORIGINAL RESTRICTED PACKET", n5_code, 1,
+        )
+        self.assertIn("byte-for-byte as a contiguous line", n5_prompt)
+        self.assertNotIn("statement 1", n5_prompt)
 
     def test_failed_locator_repair_preserves_fresh_schema_eligibility(self):
         m = _import_codex_audit_runner()

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1601,6 +1601,12 @@ def fresh_schema_retry_code(validation_error: str) -> str:
     if validation_error.startswith("transport-bounded N8"):
         return "N8_TRANSPORT_BOUND_DISPOSITION_MISMATCH"
     if (
+        validation_error.startswith("N5 statement ")
+        and "tested resolution is not evidenced at resolution_evidence_path"
+        in validation_error
+    ):
+        return "N5_TESTED_RESOLUTION_VERBATIM_MISMATCH"
+    if (
         validation_error.startswith("N1 route ")
         and ".route_class=" in validation_error
         and "is not supported by its evidenced" in validation_error
@@ -1651,6 +1657,12 @@ def render_fresh_schema_retry_prompt(
         "N1_ROUTE_CLASS_MARKER_MISMATCH": (
             "Static N1 invariant: the joined mechanism, attempt, and outcome must "
             "contain a documented literal marker for the selected route_class.\n"
+        ),
+        "N5_TESTED_RESOLUTION_VERBATIM_MISMATCH": (
+            "Static N5 invariant: copy every complete tested_resolutions entry, "
+            "including its canonical class prefix and body, byte-for-byte as a "
+            "contiguous line from the cited live current-cycle runner_stdout. "
+            "Do not summarize, shorten, or paraphrase those five lines.\n"
         ),
     }.get(validation_code, "")
     return (


### PR DESCRIPTION
Summary: require every N5 tested-resolution entry to match byte-exact current runner stdout or exact authenticated snapshot values; add conclusion-blind typed retry guidance; accept the exact W_unit identifier as normalization-route vocabulary with strict token boundaries; add regressions for paraphrase, case, whitespace, newline, snapshot replay, and identifier boundaries. Verification: 300 audit-pipeline tests pass; full pipeline and strict lint pass with zero errors; vocabulary lint and diff checks pass. Independent review-loop PASS. No science claims or audit verdicts change.