### PR TITLE
audit-infra: one audit attempt per claim per run + round-tagged artifacts

### DIFF
--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -209,6 +209,7 @@ def launch_worker(
     pass_no: int,
     workdir: Path,
     runner_timeout: int,
+    round_no: int = 1,
 ) -> dict:
     cid = row["claim_id"]
     key = artifact_key(cid)
@@ -232,13 +233,17 @@ def launch_worker(
             "packet must be narrowed without converting transport size into a verdict"
         )
 
-    isolated = workdir / f"isolated-{key}-p{pass_no}"
+    # Artifact names carry the round so a claim legitimately re-entering a
+    # later round (e.g. a critical row resuming at awaiting_second) never
+    # collides with this round's directories.
+    tag = f"{key}-r{round_no}-p{pass_no}"
+    isolated = workdir / f"isolated-{tag}"
     isolated.mkdir(parents=True, exist_ok=False)
     prompt_path = isolated / "AUDIT_TASK.md"
     prompt_path.write_text(prompt, encoding="utf-8")
-    raw_output = workdir / f"raw-{key}-p{pass_no}.txt"
-    delivery = workdir / f"delivery-{key}-p{pass_no}.json"
-    log_path = workdir / f"log-{key}-p{pass_no}.txt"
+    raw_output = workdir / f"raw-{tag}.txt"
+    delivery = workdir / f"delivery-{tag}.json"
+    log_path = workdir / f"log-{tag}.txt"
     log_handle = log_path.open("w", encoding="utf-8")
     instruction = (
         "Open AUDIT_TASK.md in the current directory and follow it exactly. "
@@ -829,7 +834,15 @@ def main() -> int:
     report: list[dict] = []
     session_skipped: set[str] = set()
     if not args.dry_run:
-        workdir.mkdir(parents=True, exist_ok=False)
+        try:
+            workdir.mkdir(parents=True, exist_ok=False)
+        except FileExistsError:
+            print(
+                f"refusing to run: workdir {workdir} already exists. "
+                "Each run requires a fresh workdir; remove it or point "
+                "AUDIT_BATCH_WORKDIR at a new path."
+            )
+            return 2
 
     for round_no in range(1, args.rounds + 1):
         rows = load_rows()
@@ -876,7 +889,10 @@ def main() -> int:
                 for pass_no in passes_for_row(row):
                     try:
                         jobs.append(
-                            launch_worker(row, rows, pass_no, workdir, args.runner_timeout_sec)
+                            launch_worker(
+                                row, rows, pass_no, workdir,
+                                args.runner_timeout_sec, round_no,
+                            )
                         )
                     except ValueError as exc:
                         launch_blocked = True
@@ -903,6 +919,12 @@ def main() -> int:
         wait_workers(jobs, args.stall_minutes)
         applied_ok, compute_skips = apply_serialized(jobs, report, args.push_retries)
         session_skipped.update(compute_skips)
+        # One audit attempt per claim per run. A non-terminal verdict
+        # (audited_conditional) re-enters the ledger as unaudited repair-queue
+        # work immediately, so without this a conditional row is re-targeted
+        # every remaining round and burns seats re-auditing an unchanged
+        # claim toward the same outcome. Repair, not repetition, moves it.
+        session_skipped.update(row["claim_id"] for row in batch)
         if not applied_ok or launch_blocked:
             break
         (workdir / "report.jsonl").write_text(

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -12,9 +12,11 @@ or:
 """
 from __future__ import annotations
 
+import contextlib
 import importlib
 import importlib.util
 import hashlib
+import io
 import json
 import os
 import sys
@@ -8510,6 +8512,102 @@ class ComputeLaneCertificationTest(unittest.TestCase):
             '("compute_lane_certification.py",      "refresh rolling lane certification")',
             apply_script,
         )
+
+
+class BatchOrchestratorRoundSemanticsTest(unittest.TestCase):
+    """Round semantics regression pins (theta canary, 2026-07-12): a
+    non-terminal verdict re-queues its row as unaudited immediately, so the
+    orchestrator must not re-target the unchanged claim in the same run, and
+    per-round artifact names must never collide."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def _row(self):
+        return {
+            "claim_id": "spin_row",
+            "claim_type": "bounded_theorem",
+            "audit_status": "unaudited",
+            "effective_status": "open",
+            "criticality": None,
+            "deps": [],
+        }
+
+    def test_one_audit_attempt_per_claim_per_run(self):
+        m = _import("orchestrate_audit_batch")
+        rows = {"spin_row": self._row()}
+        workdir = self.root / "wd"
+
+        def fake_apply(jobs, report, retries):
+            for job in jobs:
+                report.append(
+                    {"cid": job["cid"], "pass": 1, "result": "audited_conditional"}
+                )
+            return True, set()
+
+        launch = mock.Mock(
+            side_effect=lambda row, all_rows, pass_no, wd, timeout, round_no=1: {
+                "cid": row["claim_id"], "pass": pass_no, "round": round_no,
+            }
+        )
+        argv = [
+            "orchestrate_audit_batch.py", "--claims", "spin_row", "--rounds", "4",
+        ]
+        with mock.patch.dict(
+            os.environ, {"AUDIT_BATCH_WORKDIR": str(workdir)}
+        ), mock.patch.object(sys, "argv", argv), \
+                mock.patch.object(m, "clean_main_error", return_value=None), \
+                mock.patch.object(m, "load_rows", return_value=rows), \
+                mock.patch.object(m, "source_requires_forensic", return_value=False), \
+                mock.patch.object(m, "launch_worker", launch), \
+                mock.patch.object(m, "wait_workers", return_value=None), \
+                mock.patch.object(m, "apply_serialized", side_effect=fake_apply):
+            code = m.main()
+        # The row stays unaudited after its conditional verdict (repair
+        # queue), yet the run must audit it exactly once, not once per round.
+        self.assertEqual(code, 0)
+        self.assertEqual(launch.call_count, 1)
+
+    def test_round_tagged_artifacts_never_collide_across_rounds(self):
+        m = _import("orchestrate_audit_batch")
+        rows = {"spin_row": self._row()}
+        workdir = self.root / "wd2"
+        workdir.mkdir(parents=True)
+        proc = mock.Mock(pid=1234)
+        with mock.patch.object(
+            m.audit_runner, "render_prompt", return_value="packet"
+        ), mock.patch.object(
+            m.audit_runner, "PROMPT_TEMPLATE_PATH"
+        ) as template_path, mock.patch.object(
+            m.subprocess, "Popen", return_value=proc
+        ):
+            template_path.read_text.return_value = "template"
+            first = m.launch_worker(
+                rows["spin_row"], rows, 1, workdir, 120, 1
+            )
+            second = m.launch_worker(
+                rows["spin_row"], rows, 1, workdir, 120, 2
+            )
+        self.assertNotEqual(first["isolated"], second["isolated"])
+        self.assertIn("-r1-p1", str(first["isolated"]))
+        self.assertIn("-r2-p1", str(second["isolated"]))
+
+    def test_existing_workdir_refused_with_actionable_message(self):
+        m = _import("orchestrate_audit_batch")
+        workdir = self.root / "wd3"
+        workdir.mkdir(parents=True)
+        argv = ["orchestrate_audit_batch.py", "--claims", "spin_row"]
+        stdout = io.StringIO()
+        with mock.patch.dict(
+            os.environ, {"AUDIT_BATCH_WORKDIR": str(workdir)}
+        ), mock.patch.object(sys, "argv", argv), \
+                mock.patch.object(m, "clean_main_error", return_value=None), \
+                contextlib.redirect_stdout(stdout):
+            code = m.main()
+        self.assertEqual(code, 2)
+        self.assertIn("already exists", stdout.getvalue())
 
 
 class CodexAuditRunnerModelPolicyTest(unittest.TestCase):


### PR DESCRIPTION
## What

Fixes the round-2 spin found by θ-canary iteration 4 — the first run under the #5311 calibration, where both seats' `audited_conditional` verdicts **applied successfully** (the calibration works), and the new failure mode surfaced immediately behind it:

1. A conditional verdict re-queues its row as `unaudited` (non-terminal, standing rule), so `compute_targets` re-listed the same claim in round 2 of the same run — re-auditing an unchanged claim toward the same verdict, burning two seats per round.
2. The relaunch crashed anyway: worker artifact names (`isolated-<key>-p<pass>`) don't include the round, so round 2 hit round 1's directories (`FileExistsError` → `worker_launch_failed` → exit 1).

## Fixes

- **One audit attempt per claim per run:** after each round's serialized apply, all batch claims join `session_skipped`. Repair moves a conditional row; same-run repetition doesn't.
- **Round-tagged artifacts** (`isolated-<key>-r<N>-p<M>`, same for raw/delivery/log): the `awaiting_second` resume path is a legitimate same-claim multi-round re-entry and would hit the same collision.
- **Friendly workdir guard:** a pre-existing `AUDIT_BATCH_WORKDIR` now prints an actionable refusal instead of a raw `FileExistsError` traceback (operator hit this live).

## Tests

Three regression tests in a new `BatchOrchestratorRoundSemanticsTest` class: the one-attempt pin (mocked main loop, row stays unaudited across rounds, exactly one launch), round-tag collision-freedom (two launches of the same seat in different rounds), and the workdir refusal message. Suite 301/301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)