### PR TITLE
physics: prove two-layer KP source-polymer control

### DIFF
--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
@@ -1,6 +1,35 @@
 # Handoff
 
 Current branch:
+`physics-loop/record-faithful-dynamics-block28-gauge-body-source-polymer-20260712`.
+The two-layer source-polymer runner reports `PASS=14 FAIL=0`. For positive
+parameters satisfying `q<1` and `K_(theta,lambda)(c)<c`, the positive
+fermion-integrated gauge body has an absolutely convergent connected-polymer
+logarithm, a uniform complete Reinhardt source domain, all fixed-order local
+cumulants with factorial/tree-decay bounds, and a weighted connected `p=0`
+coarse interaction. Three explicit strict high-mass/small-coupling points are
+certified.
+
+Nature review found and the source repaired the cancellation edge case in
+which `A A^(-1)V` exposes a coarse-`V` factor independent of the hidden
+coordinate: every factor now carries a nonminimal syntactic footprint, and the
+runner tests exact regrouping with a dummy-supported hidden-independent
+factor. The first-layer rooted-tree recursion and final KP exclusion row are
+also explicit. Independent code/math, physics/import/Nature, governance, and
+positive-only N1--N8 reviews pass. Audit validation seeds one
+`bounded_theorem` / `unaudited` row with exactly Block27 as dependency; strict
+lint has zero errors and generated status surfaces are stripped.
+
+This closes the scalar gauge-body source/polymer rung only. The retained
+gauge--Grassmann Banach-algebra lift, simultaneous degree/path/end-point sum,
+projected/rescaled contraction, critical trajectory, and continuum limits
+remain open. No axiom-update stop is triggered.
+
+Two-layer source-polymer stacked PR:
+https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5322
+is open against the raw-action Hessian head.
+
+Previous branch:
 `physics-loop/record-faithful-dynamics-block27-raw-action-hessian-decay-20260712`.
 The raw-response runner reports `PASS=8 FAIL=0`. For the positive
 fermion-integrated gauge-body fiber action, `DR[F]=<F>` and

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
@@ -1,5 +1,24 @@
 # PR Delivery
 
+The two-layer constrained-fiber complex-source/polymer theorem is delivered:
+
+- base: `physics-loop/record-faithful-dynamics-block27-raw-action-hessian-decay-20260712`
+- head: `physics-loop/record-faithful-dynamics-block28-gauge-body-source-polymer-20260712`
+- runner: `PASS=14 FAIL=0`
+- scope: explicit two-layer KP convergence, a uniform gauge-body complex-source
+  domain, all fixed-order local cumulant/tree bounds, and weighted connected
+  coarse `p=0` membership; no retained gauge--Grassmann norm, projected RG
+  contraction, or continuum trajectory
+- review repair: nonminimal syntactic supports retain coarse-`V` factors after
+  hidden cancellation; the full rooted-tree recursion and final KP row are
+  explicit; the runner includes a dummy-supported hidden-independent factor
+- audit compatibility: one `bounded_theorem` / `unaudited` row with the sole
+  Block27 dependency; full pipeline and strict lint pass; generated outputs
+  stripped
+- PR: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5322
+
+No merge is authorized. Independent audit remains authoritative.
+
 The raw constrained-action response/Hessian theorem is delivered:
 
 - base: `physics-loop/record-faithful-dynamics-block26-coarse-gauge-gibbsianness-20260712`

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
@@ -830,3 +830,33 @@ Runner/cache: `PASS=8 FAIL=0`. Audit validation seeds one `bounded_theorem` /
 `unaudited` row with source hash `0bfb6dd97b50c569...` and the sole
 constrained-fiber dependency. PR #5317 is open; no negative theorem or
 axiom-update stop is triggered.
+
+## Two-layer gauge-body source-polymer review
+
+PASS WITH BOUNDED POSITIVE CLAIMS after one repair cycle. The explicit
+criterion `q<1`, `K_(theta,lambda)(c)<c` establishes a convergent two-layer
+hard-core polymer logarithm for the positive fermion-integrated gauge body,
+with three strict high-mass/small-coupling examples. Marked scalar sources
+give one uniform complete Reinhardt domain, all fixed-order connected
+cumulants, exponential connected-tree decay, and a weighted connected coarse
+`p=0` interaction.
+
+Physics/import review found that hidden-minimal supports could miss a
+coarse-`V`-dependent factor exposed by `A A^(-1)` cancellation. The repaired
+source declares a nonminimal syntactic footprint before simplification,
+charges both coarse endpoints, and verifies exact regrouping with a
+hidden-independent dummy-supported factor. The same review required the
+first-layer rooted-tree bridge to be written out; equations (2.6)--(2.10) now
+give the finite-truncation recursion, spanning-tree domination, pinned bound,
+and final KP exclusion inequality. Code/math independently checked all
+normalizations, factorials, incidence factors, source radii, and coarse
+multiplicity. Governance/no-go review passed the bounded label, sole Block27
+dependency, primitive discipline, and positive-only N1--N8 packet.
+
+Runner/cache: `PASS=14 FAIL=0`. Full audit validation seeds one
+`bounded_theorem` / `unaudited` row with source hash `f7791b8f1d0be585...`
+and exactly the raw-action Hessian dependency; strict lint has zero errors and
+generated audit/status surfaces are stripped. PR #5322 is open. The retained
+gauge--Grassmann simultaneous norm, projection/rescaling, physical critical
+trajectory, and continuum limits remain open. No negative theorem or
+axiom-update stop is triggered.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
@@ -8,31 +8,31 @@ current_goal: >-
   supply the physical evolution object, bare time ordering, record-formation
   weights, and an admissibility-to-carrier selector without importing the
   staggered/Dirac answer or sector-specific Standard Model and gravity laws.
-branch: physics-loop/record-faithful-dynamics-block27-raw-action-hessian-decay-20260712
+branch: physics-loop/record-faithful-dynamics-block28-gauge-body-source-polymer-20260712
 base_commit_at_start: 9d1636f05f
-cycle_count: 27
-block_count: 27
-active_route: wilson_staggered_raw_constrained_action_hessian_decay
+cycle_count: 28
+block_count: 28
+active_route: wilson_staggered_constrained_fiber_two_layer_kp_source_polymer
 hard_residual: >-
   Can the four-axiom record surface canonically determine a faithful local
   record-forming instrument whose coherent no-record block is sufficiently
   constrained to exclude the observationally disconnected SWAP--Laplacian
   completion and select the Clifford-vector carrier?
-produced_claim_id: wilson_staggered_raw_constrained_action_hessian_decay_bounded_theorem_note_2026-07-12
+produced_claim_id: wilson_staggered_constrained_fiber_two_layer_kp_complex_source_polymer_bounded_theorem_note_2026-07-12
 actual_current_surface_status: bounded-support
 conditional_surface_status: >-
-  In the deep fiber wedge, the real positive gauge-body raw fiber action has
-  exact first response and a volume-uniform exponentially local Hessian on
-  bounded local hidden-gauge directions. Fixed local responses pass to the
-  infinite fiber. No higher-cumulant, complex-source, joint Grassmann polymer,
-  or projected/rescaled contraction theorem is proved.
+  In an explicit deep high-mass/small-coupling subwedge, the positive
+  fermion-integrated gauge body has a convergent two-layer polymer logarithm,
+  a uniform complete Reinhardt source domain, all fixed-order local
+  cumulant/tree bounds, and a weighted connected coarse p=0 interaction. No
+  simultaneous retained gauge--Grassmann norm, projected/rescaled
+  contraction, critical trajectory, or continuum theorem is proved.
 admitted_observation_status: none
 claim_type_reason: >-
-  The source proves positive coarse-gauge Gibbsianness and a sitewise
-  absolutely summable interaction representation in an explicit deep wedge.
-  It keeps the uniform connected joint-polymer norm, symmetry-adapted
-  coordinates, projected contraction, critical trajectory, and continuum
-  limit open.
+  The source proves an explicit sufficient two-layer KP region and uniform
+  gauge-body source/polymer bounds. It keeps the simultaneous all-degree
+  gauge--Grassmann norm, symmetry-adapted coordinates, projected contraction,
+  critical trajectory, and continuum limit open.
 hypothetical_axiom_status: null
 proposal_allowed: false
 proposal_allowed_reason: >-
@@ -123,6 +123,9 @@ files_touched:
   - docs/WILSON_STAGGERED_RAW_CONSTRAINED_ACTION_HESSIAN_DECAY_BOUNDED_THEOREM_NOTE_2026-07-12.md
   - scripts/wilson_staggered_raw_constrained_action_hessian_decay_2026_07_12.py
   - logs/runner-cache/wilson_staggered_raw_constrained_action_hessian_decay_2026_07_12.txt
+  - docs/WILSON_STAGGERED_CONSTRAINED_FIBER_TWO_LAYER_KP_COMPLEX_SOURCE_POLYMER_BOUNDED_THEOREM_NOTE_2026-07-12.md
+  - scripts/wilson_staggered_constrained_fiber_two_layer_kp_source_polymer_2026_07_12.py
+  - logs/runner-cache/wilson_staggered_constrained_fiber_two_layer_kp_source_polymer_2026_07_12.txt
 open_imports:
   - fundamental process object: Hamiltonian, strict tick, or record instrument
   - faithful law-to-record influence principle
@@ -167,10 +170,11 @@ no_go_routes:
   - exact factor-two gauge pushforward and fixed-background Schur locality do not close on the finite Wilson-staggered action family or supply an action-space RG contraction; taste-faithful and enlarged-polymer routes remain live
   - exact raw fiber integration cannot strictly contract its full unprojected action space in the common unrescaled coefficient norm because coarse-local lifted coordinates pass with unit ratio; relevant-coordinate projection, rescaling, and scale-weighted irrelevant norms remain live
   - coarse-gauge Gibbsianness does not by itself provide a uniform translation-adapted anchored interaction norm or the all-order source cumulants needed for the retained gauge--Grassmann action; complete-analyticity, cluster, and constructive RG routes remain live
+  - a scalar gauge-body source/polymer theorem does not by itself place the retained Grassmann coefficients in one simultaneous all-degree Banach norm or supply a projected/rescaled RG contraction
 trace_gate_classification: direct_blocker_closure
 reachability_to_target: partially_closes
-review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_bounded
-pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open
+review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_two_layer_source_polymer_pass_bounded
+pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open_two_layer_source_polymer_open
 block01_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5178
 block02_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5181
 block03_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5201
@@ -198,11 +202,12 @@ block24_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/
 block25_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5313
 block26_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5315
 block27_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5317
+block28_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5322
 next_exact_action: >-
-  Establish a uniform complex/source neighborhood for the constrained fibers
-  and factorial tree bounds for every connected cumulant of the exponentially
-  local Schur coefficients. Use it to place the retained gauge--Grassmann
-  logarithm in a uniform connected exponential polymer norm. Only then define
+  Lift the scalar two-layer KP estimate to one simultaneous
+  Banach-algebra-valued source for the exponentially local Schur coefficients.
+  Sum endpoints, paths, supports, and every balanced Grassmann degree in the
+  eta-weighted norm while preserving joint gauge covariance. Only then define
   symmetry-adapted coordinates, projection, and factor-two rescaling.
 stop_condition: >-
   Stop and discuss an axiom update only if an exact result proves that the

--- a/docs/WILSON_STAGGERED_CONSTRAINED_FIBER_TWO_LAYER_KP_COMPLEX_SOURCE_POLYMER_BOUNDED_THEOREM_NOTE_2026-07-12.md
+++ b/docs/WILSON_STAGGERED_CONSTRAINED_FIBER_TWO_LAYER_KP_COMPLEX_SOURCE_POLYMER_BOUNDED_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,511 @@
+# Two-layer source-polymer control for constrained Wilson--staggered gauge fibers
+
+**Date:** 2026-07-12
+**Type:** bounded_theorem
+**Status:** unaudited candidate; effective status is pipeline-derived only after independent audit.
+**Primary runner:** [`scripts/wilson_staggered_constrained_fiber_two_layer_kp_source_polymer_2026_07_12.py`](../scripts/wilson_staggered_constrained_fiber_two_layer_kp_source_polymer_2026_07_12.py)
+**Cached output:** [`logs/runner-cache/wilson_staggered_constrained_fiber_two_layer_kp_source_polymer_2026_07_12.txt`](../logs/runner-cache/wilson_staggered_constrained_fiber_two_layer_kp_source_polymer_2026_07_12.txt)
+
+## 0. Result
+
+The positive fermion-integrated gauge-body fiber now has an explicit
+all-order complex-source region and a connected coarse gauge-body polymer
+action.
+
+Use the same real constrained fiber and hidden-coordinate graph as the direct
+dependency,
+[raw constrained-action response and exponentially local Hessian](WILSON_STAGGERED_RAW_CONSTRAINED_ACTION_HESSIAN_DECAY_BOUNDED_THEOREM_NOTE_2026-07-12.md).
+For positive parameters `c,theta,lambda`, set
+
+```text
+kappa=14/(m^2+2),
+L=theta+2c+lambda,
+q=kappa exp(2L).                                                       (0.1)
+```
+
+Define `g(t)=(exp(t)-1)/t`, continuously extended by `g(0)=1`, and
+
+```text
+K_(theta,lambda)(c)
+ =12[exp(3 beta/4)-1] exp(4L)
+  +(3/2)sum_(n>=2) kappa^n
+       g(3 kappa^n/(2n)) exp(2nL).                                   (0.2)
+```
+
+Whenever
+
+```text
+q<1,                         K_(theta,lambda)(c)<c,                   (0.3)
+```
+
+the following hold uniformly in the finite regulator, hidden boundary, and
+complete coarse configuration `V`:
+
+1. the hidden partition function has an absolutely convergent two-layer
+   connected-polymer logarithm;
+2. bounded local complex gauge-body sources have a common zero-free domain,
+   hence a uniform complex-source domain,
+   controlled by the strict margin `epsilon=c-K_(theta,lambda)(c)`;
+3. every finite-order local connected cumulant is the derivative of that
+   common logarithm and obeys a factorial marked-cluster bound with
+   exponential connected-span decay;
+4. after hidden integration, the exact coarse gauge-body logarithm belongs to
+   the `p=0` sector of the generated coarse action space with positive size and
+   diameter weights.
+
+Three explicit points with `theta=lambda=0.001` are
+
+| `m` | `beta` | `c` | `K` | `epsilon` | `q` |
+|---:|---:|---:|---:|---:|---:|
+| 10 | 0.0005 | 0.12 | 0.1080982377 | 0.0119017623 | 0.2227031671 |
+| 12 | 0.0020 | 0.15 | 0.1164294085 | 0.0335705915 | 0.1754240151 |
+| 16 | 0.0035 | 0.14 | 0.1125456219 | 0.0274543781 | 0.0953784845 |
+
+This is a deliberately deep high-mass/small-coupling subwedge. It is not the
+whole `alpha(beta,m)<1/2` Dobrushin region.
+
+The theorem is gauge body only. It does not yet place the retained
+gauge--Grassmann logarithm in the simultaneous all-degree norm, define a
+projected/rescaled RG contraction, select a physical taste carrier, or produce
+a critical continuum trajectory.
+
+No negative theorem is shipped. No axiom-update stop is established.
+
+## 1. Exact interaction-factor expansion
+
+For fixed `V`, write the real hidden gauge-body energy, after extracting only
+`V`-independent scalar constants, as
+
+```text
+H_V(H)=sum_(a in I) psi_a^V(H_(S_a)).                                (1.1)
+```
+
+The label set contains fine Wilson plaquettes and the reverse-paired closed
+paths in the exact massive determinant logarithm. Each `S_a` is the declared
+**syntactic hidden footprint** of the label: every fine-link occurrence charges
+the hidden coordinate from whose one- or two-link block-map footprint that
+link is obtained. This support is deliberately not minimized after the
+substitution `U_1=A,U_2=A^(-1)V`. Thus an algebraic cancellation such as
+`A A^(-1)V=V` retains the `A` coordinate in `S_a`, even when the resulting
+factor is independent of `A`. Every nonconstant label consequently has a
+nonempty declared support, and any coarse link `V` exposed by cancellation is
+still charged to its skeleton coordinate and both coarse endpoints. With
+product hidden Haar measure,
+
+```text
+exp(-H_V)=product_a [1+f_a],
+f_a=exp(-psi_a^V)-1,              b_a=||f_a||_infinity.              (1.2)
+```
+
+Over-supporting a factor does not change the integral or the exact component
+factorization: dummy Haar coordinates integrate to one. It can only add
+overlaps to the polymer majorant. The incidence estimates below already count
+fine-link occurrences, so they apply to this syntactic footprint without
+change. Every bound is independent of `V`: substituting a skeleton pair
+`U_1=A,U_2=A^(-1)V` preserves unitarity and Haar measure.
+
+### 1.1 Wilson factors
+
+The exact `SU(3)` range is
+
+```text
+-3/2<=Re Tr U<=3.                                                     (1.3)
+```
+
+For `psi_p=-(beta/3)Re Tr U_p`, subtracting the midpoint `-beta/4`
+leaves
+
+```text
+||psi_p+beta/4||_infinity<=3 beta/4,
+b_p<=exp(3 beta/4)-1.                                                 (1.4)
+```
+
+The subtraction is an extractable vacuum constant. A hidden coordinate has a
+one- or two-link fine footprint; each fine link meets six four-dimensional
+plaquettes. Thus at most twelve plaquette labels meet one hidden coordinate.
+Each has `|S_p|<=4` and connected-tree span `ell(S_p)<=4`.
+
+### 1.2 Determinant path factors
+
+The nonbacktracking two-hop expansion has absolute row radius
+
+```text
+kappa=14/(m^2+2).                                                     (1.5)
+```
+
+At determinant order `n>=2`, the sum of potential norms incident on one fine
+link is at most `3 kappa^n/4`. Aggregating the at-most-two-link hidden
+footprint gives
+
+```text
+sup_h sum_(a: order n,h in S_a)||psi_a||_infinity
+ <=(3/2)kappa^n.                                                      (1.6)
+```
+
+An individual reverse-paired term is bounded by
+
+```text
+t_n=3 kappa^n/(2n).                                                   (1.7)
+```
+
+Therefore `exp(x)-1<=x g(t_n)` for `0<=x<=t_n` gives
+
+```text
+sup_h sum_(a: order n,h in S_a)b_a
+ <=(3/2)kappa^n g(t_n).                                              (1.8)
+```
+
+The path traverses `2n` fine-link occurrences, so
+`|S_a|<=2n` and `ell(S_a)<=2n`. The absolute word entropy is already included
+in `kappa`; no second lattice-animal factor is inserted.
+
+## 2. The two-layer cluster lemma
+
+Expanding (1.2) does not immediately give a hard-core gas of the original
+factors because overlapping factors can occur together. First group every
+finite factor set into connected components under hidden-support overlap.
+For a connected label set `Gamma`, put
+
+```text
+Y_Gamma=union_(a in Gamma) S_a,
+w_Gamma(V)=integral product_(a in Gamma) f_a dH_(Y_Gamma).            (2.1)
+```
+
+Disjoint components factor exactly under product Haar, and
+
+```text
+|w_Gamma(V)|<=product_(a in Gamma)b_a.                               (2.2)
+```
+
+The original partition function is therefore exactly a hard-core polymer gas
+of the connected `Gamma`, with incompatibility defined by overlap of
+`Y_Gamma`.
+
+Here is the model-independent sufficient condition used below:
+
+```text
+sup_h sum_(a:h in S_a)
+ b_a exp[(theta+2c)|S_a|+lambda ell(S_a)] < c.                       (2.3)
+```
+
+The first layer is a rooted-tree domination of connected factor collections.
+Give a factor the weight
+
+```text
+u_a=b_a exp[(theta+c)|S_a|+lambda ell(S_a)].                         (2.4)
+```
+
+For a root `a`, the sum of possible child weights with their remaining
+rooted-tree allowance is at most
+
+```text
+sum_(b:S_b intersects S_a)
+ b_b exp[(theta+2c)|S_b|+lambda ell(S_b)]
+ <=c|S_a|.                                                           (2.5)
+```
+
+For completeness, this implication can be obtained without a separate animal
+count. In a finite truncation let `T_a^(0)=u_a` and recursively majorize rooted
+labelled trees by
+
+```text
+T_a^(r+1)
+ =u_a exp[sum_(b:S_b intersects S_a) T_b^(r)].                      (2.6)
+```
+
+Induction using (2.5) gives
+
+```text
+T_a^(r)<=u_a exp[c|S_a|]
+ =b_a exp[(theta+2c)|S_a|+lambda ell(S_a)].                         (2.7)
+```
+
+Every finite overlap-connected factor set containing `a` has a spanning tree
+rooted at `a`, so its product weight occurs at least once in this nonnegative
+tree majorant. Moreover, for an overlap-connected collection,
+
+```text
+|union_a S_a|<=sum_a |S_a|,
+ell(union_a S_a)<=sum_a ell(S_a).                                  (2.8)
+```
+
+The second inequality follows by joining the support trees along the overlap
+tree. Rooting a collection that meets `h` at any one of its labels containing
+`h`, applying (2.7), and then (2.3) yields
+
+```text
+sum_(Gamma:h in Y_Gamma)
+ |w_Gamma| exp[(theta+c)|Y_Gamma|+lambda ell(Y_Gamma)] <=c.         (2.9)
+```
+
+The bounds are uniform in the finite truncation, so monotone convergence of
+the nonnegative majorant removes it. The second layer uses the remaining
+`c|Y|` as the exclusion function in the Kotecky--Preiss condition:
+
+```text
+sum_(Gamma' incompatible Gamma)
+ |w_(Gamma')| exp[theta|Y_(Gamma')|+lambda ell(Y_(Gamma'))]
+               exp[c|Y_(Gamma')|]
+ <=c|Y_Gamma|.                                                      (2.10)
+```
+
+Thus the hard-core polymer logarithm is absolutely convergent. The two copies
+of `c` in (2.3) are load-bearing: one pays for connected-factor grouping and
+one pays for the final polymer exclusion sum.
+
+The external abstract convergence theorem is R. Kotecky and D. Preiss,
+*Cluster expansion for abstract polymer models*, Communications in
+Mathematical Physics **103** (1986), 491--498, DOI
+`10.1007/BF01211762`. Equations (1.3)--(2.10), rather than that citation alone,
+verify its hypotheses for this continuous `SU(3)` fiber.
+
+## 3. Explicit model criterion and examples
+
+Substituting (1.4) and (1.8) into (2.3) gives exactly (0.2). Absolute
+convergence of its determinant series follows from `q=kappa exp(2L)<1`.
+A convenient closed upper envelope is
+
+```text
+K_F
+ <=(3/2)exp(3 kappa^2/4) q^2/(1-q).                                 (3.1)
+```
+
+The runner evaluates the actual series, not only (3.1), at the three displayed
+points. Their positive `theta,lambda` prove a genuine size- and distance-
+weighted domain rather than bare free-energy convergence.
+
+These constants are intentionally conservative. Reverse-pair trace centering,
+closed-loop cancellations, sharper incidence enumeration, or a
+Fernandez--Procacci criterion can enlarge the region; none is used.
+
+## 4. Uniform complex sources and all-order cumulants
+
+For bounded local real gauge-body observables `O_i` with hidden supports
+`T_i`, sizes `s_i`, spans `d_i`, and sup norms `M_i`, add complex sources
+`z_i O_i`. They enter (2.3) as marked factor activities. The same expansion is
+valid whenever
+
+```text
+S(z)=sup_h sum_(i:h in T_i)
+ [exp(|z_i|M_i)-1]
+ exp[(theta+2c)s_i+lambda d_i] < epsilon,                            (4.1)
+
+epsilon=c-K_(theta,lambda)(c)>0.                                    (4.2)
+```
+
+For one source this gives the explicit uniform radius
+
+```text
+r_O=M^(-1)log[1+epsilon exp(-(theta+2c)s-lambda d)].                 (4.3)
+```
+
+At the three points of Section 0, the norm-one radii for `(s,d)=(1,0)` are
+respectively `0.00930943`, `0.02454123`, and `0.02051691`; for `(4,2)` they
+are `0.00451961`, `0.01000061`, and `0.00886481`.
+
+Kotecky--Preiss convergence is uniform throughout the complete Reinhardt
+domain (4.1), so the partition function is zero-free there and its connected
+logarithm uses one common branch. Differentiation at the origin gives
+
+```text
+D^n R=(-1)^(n+1) kappa_n.                                           (4.4)
+```
+
+The marked connected-cluster series is absolutely convergent. For every
+fixed `n` it supplies a volume-, boundary-, and `V`-uniform factorial bound;
+because every cluster carrying all marks has connected hidden union, the
+`lambda` weight also gives
+
+```text
+|kappa_n(O_1,...,O_n)|
+ <=n! C_n product_i M_i
+       exp[-lambda tau(T_1,...,T_n)],                                (4.5)
+```
+
+where `tau` is the minimum hidden connected-tree span joining the marked
+supports and `C_n=C_n(c,theta,lambda;{s_i,d_i})<infinity` is the pinned
+marked-cluster majorant at any fixed strict sub-polydisc of (4.1). The theorem
+claims uniform finiteness and tree decay, not an optimized closed form for
+`C_n`.
+
+Equation (4.5) is an all-order extension of the prior real Hessian theorem in
+this stricter KP region. It is not obtained by renaming pair covariance decay
+as complete analyticity. The classic Dobrushin--Shlosman formulation is
+finite-spin and finite-range; it is method context, not an imported theorem
+for the present compact continuous, exponentially decaying fibers.
+
+## 5. Coarse gauge-body polymer norm
+
+Assign each positive fine-link hidden coordinate to the coarse cell containing
+its starting site. The two links of a skeleton coordinate have the same coarse
+anchor. Consecutive fine-path links map to equal or nearest-neighbor coarse
+cells. For a connected hidden polymer `Y`, let `X(Y)` contain every anchor and,
+for each skeleton coordinate in the declared syntactic footprints, both
+endpoints of its coarse link. This deliberately over-supports any factor that
+became hidden-independent after an `A A^(-1)` cancellation and therefore keeps
+every resulting `V` dependence inside `X(Y)`. Then
+
+```text
+X(Y) is connected,
+|X(Y)|<=2|Y|,
+diam X(Y)<=ell(Y)+1.                                                  (5.1)
+```
+
+There are at most `4*2^4=64` positive fine-link anchors in one factor-two
+coarse cell and at most four incoming skeleton endpoints. Hence at most 68
+hidden coordinates can charge one coarse anchor in the conversion.
+
+Group all hidden clusters with the same coarse support and use triangle
+inequality. The pinned two-layer bound then gives the `p=0` coarse interaction
+
+```text
+sup_z sum_(connected X contains z)
+ exp[(lambda/2)diam X+(theta/2)|X|] ||Phi_X^g||_infinity
+ <=68 exp(lambda/2)c.                                                (5.2)
+```
+
+Haar integration and the gauge-invariant plaquette/closed-loop factors make
+each coefficient coarse-gauge invariant. Thus (5.2) is genuine membership of
+the exact gauge body in the gauge-only sector of the generated action space,
+not merely quasilocality of the image measure.
+
+## 6. Runner contract
+
+Run:
+
+```bash
+python3 scripts/wilson_staggered_constrained_fiber_two_layer_kp_source_polymer_2026_07_12.py
+```
+
+The runner checks Wilson centering, hidden plaquette incidence, all three
+strict KP points, the determinant geometric envelope, source radii, an exact
+finite factor-to-polymer regrouping identity including a factor with an
+over-assigned dummy hidden coordinate, the coarse-anchor Lipschitz map, the
+68-coordinate multiplicity, and the source/dependency contract.
+The rooted-tree and marked KP bounds are analytic statements.
+
+## 7. Honest boundary and next theorem
+
+This theorem closes the complex-source and all-order connected-polymer problem
+for the positive gauge body in the explicit region (0.3). It does not close
+the retained gauge--Grassmann action.
+
+The next theorem must couple one simultaneous Banach-algebra-valued source to
+the exponentially local Schur coefficients, preserve balanced degree and
+joint gauge covariance, and prove that the sums over endpoints, paths,
+supports, and all Grassmann degrees fit the `eta`-weighted norm. Individual
+coefficient source disks are not enough.
+
+Only after that lift is it meaningful to define symmetry-adapted relevant
+coordinates and test a projected/rescaled irrelevant-map contraction. A
+failure of this particular KP inequality would be a limitation of the
+expansion, not evidence that the axioms require amendment.
+
+## 8. No-Go Discipline N1--N8
+
+No negative theorem or route foreclosure is shipped. The boundary sentences
+are scope disclaimers. The eight checks are retained conservatively and N1
+records proof routes actually executed for the positive theorem.
+
+### N1 — alternative-route enumeration
+
+| Route | Status | Executed test | Role |
+|---|---|---|---|
+| Interaction-factor decomposition | `ATTEMPTED` | Section 1 constructs Wilson and determinant factors. | Exact starting identity. |
+| Wilson midpoint centering | `ATTEMPTED` | Equation (1.4) and the runner verify `3 beta/4`. | Reduces the gauge activity without cancellation. |
+| Determinant loop incidence | `ATTEMPTED` | Equations (1.6)--(1.8) sum every path word. | Includes word entropy and footprint factor two. |
+| Two-layer connected regrouping | `ATTEMPTED` | Section 2 and a finite exact runner model verify factor-to-polymer equality. | Prevents treating overlapping factors as compatible. |
+| Rooted-tree majorant | `ATTEMPTED` | Equations (2.3)--(2.5) spend the first `c`. | Controls connected-factor entropy. |
+| Hard-core KP exclusion | `ATTEMPTED` | Equation (2.10) spends the second `c`. | Produces the zero-free log. |
+| Marked complex sources | `ATTEMPTED` | Section 4 derives and evaluates positive radii. | Supplies all-order cumulants. |
+| Hidden-to-coarse geometry | `ATTEMPTED` | Section 5 and the runner verify the anchor map and multiplicity. | Places the gauge body in the coarse norm. |
+
+### N2 — wall-independence audit
+
+The collapsed open conditions are `joint Grassmann projected/rescaled
+contraction theorem` and `physical critical trajectory/observable
+identification`.
+
+| Left | Right | Left closes right? | Right closes left? | Independent? |
+|---|---|---:|---:|---:|
+| joint Grassmann projected/rescaled contraction theorem | physical critical trajectory/observable identification | No | No | Yes |
+
+The simultaneous Grassmann norm is included in the first condition because a
+contraction theorem on that joint space presupposes that the map is defined
+there.
+
+### N3 — hidden-condition phrase scan
+
+| Mandated phrase | Classification |
+|---|---|
+| `we assume` | No load-bearing hit. |
+| `by construction` | No proof-substitute hit. |
+| `as is standard` | No hit. |
+| `the framework provides` | No hit. |
+| `bridge context` | No hit. |
+| `background` | Hidden boundary and fixed coarse configurations are mathematical variables. |
+| `naturally` | No hit. |
+| `obviously` | No hit. |
+| `standard QFT` | No hit. |
+| `registered` | No premise-granting hit. |
+| `canonical` | No unqualified use. |
+
+### N4 — citation/residual matching
+
+| Witness | Witness residual | Present residual | Match? | Disposition |
+|---|---|---|---:|---|
+| [Raw constrained-action Hessian](WILSON_STAGGERED_RAW_CONSTRAINED_ACTION_HESSIAN_DECAY_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Real second-order response only | Uniform complex/all-order gauge-body response | Yes | Sole direct repository dependency. |
+| Kotecky--Preiss 1986 | Abstract polymer convergence after an activity inequality | Verify the two-layer model-specific inequality | Yes | External mathematical theorem. |
+| Dobrushin--Shlosman 1987 | Complete analyticity in its declared framework | Continuous infinite-range constrained fiber | No | Context only; not imported. |
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Tested? | Permitted conclusion |
+|---|---:|---|
+| Every finite hidden regulator and boundary at the three points | Yes | Uniform zero-free source domain. |
+| Arbitrary finite local gauge-body source family satisfying (4.1) | Yes | Common connected logarithm and all-order cumulants. |
+| Infinite-volume fixed local gauge-body cumulants | Yes | Uniform limits of pinned clusters. |
+| Coarse gauge-body interaction | Yes | Weighted `p=0` polymer membership. |
+| Retained Grassmann coefficients, one at a time | No | Not claimed. |
+| Simultaneous all-degree gauge--Grassmann norm | No | Next theorem. |
+| Projected/rescaled joint RG map | No | No contraction claim. |
+| Physical critical trajectory | No | No existence or impossibility claim. |
+
+### N6 — partial-closure and primitive scan
+
+The parameters `c,theta,lambda` and source radii are mathematical convergence
+coordinates, not new physical premises. The Wilson--staggered regulator and
+factor-two block map were already declared. No action, probability, time,
+source, or RG axiom is added. The approved scale-reference,
+kinetic-isotropy, and realized-state primitives neither supply nor obstruct
+this cluster estimate.
+
+The remaining Grassmann and contraction steps are ordinary mathematical
+construction routes. No convention-only reframe or pending primitive proposal
+is being mislabeled as a physics wall.
+
+### N7 — hostile steelman
+
+A hostile reviewer should insist that the present wedge is grossly
+conservative: midpoint-centering the reverse-paired determinant traces gives
+another `3/4` improvement, and Fernandez--Procacci criteria improve the
+abstract polymer bound. Correct. Those routes can enlarge the region, so the
+paper makes no optimality or outside-wedge claim. They do not invalidate the
+positive strict points proved here.
+
+A second hostile reviewer should reject any statement that the scalar marked
+expansion automatically proves the retained Grassmann theorem. Correct. A
+Banach-algebra activity bound with simultaneous degree counting is still
+required and is the next target.
+
+### N8 — cross-cycle echo
+
+| Earlier surface | Earlier residual | Retired? | Mechanism applies here? | Present treatment |
+|---|---|---:|---:|---|
+| Constrained-fiber Dobrushin control | Pair comparison only | Yes, for real pair response | Partly | KP supplies the missing complex/all-order step only in a deeper region. |
+| Raw-action Hessian | Second derivative only | Yes, in (0.3) | Yes | Marked clusters extend it to all fixed orders. |
+| Coarse-gauge Gibbsianness | Sitewise summable, noncanonical potential | Yes, for gauge-body existence | Yes | The explicit expansion now supplies a weighted connected representative. |
+| Generated-action space | Finite-volume joint algebra only | No | Partly | Only its `p=0` gauge sector is closed here. |
+
+No prior partial closure is inflated into the simultaneous Grassmann or
+continuum theorem, and no axiom update is requested.

--- a/logs/runner-cache/wilson_staggered_constrained_fiber_two_layer_kp_source_polymer_2026_07_12.txt
+++ b/logs/runner-cache/wilson_staggered_constrained_fiber_two_layer_kp_source_polymer_2026_07_12.txt
@@ -1,0 +1,15 @@
+PASS wilson_midpoint_centering: centered_sup=0.150000000000, target=0.150000000000
+PASS hidden_plaquette_incidence: 2 footprints * 6 plaquettes=12
+PASS kp_point_m10: K=0.108098237701, c=0.120000, epsilon=0.011901762299, q=0.222703167050
+PASS kp_point_m12: K=0.116429408537, c=0.150000, epsilon=0.033570591463, q=0.175424015123
+PASS kp_point_m16: K=0.112545621909, c=0.140000, epsilon=0.027454378091, q=0.095378484501
+PASS determinant_geometric_envelope: series=0.056142085405, envelope=0.056368134832
+PASS source_radii_m10: r_(1,0)=0.009309432692, r_(4,2)=0.004519610534
+PASS source_radii_m12: r_(1,0)=0.024541233874, r_(4,2)=0.010000608670
+PASS source_radii_m16: r_(1,0)=0.020516914673, r_(4,2)=0.008864814082
+PASS two_layer_factor_to_polymer_identity: direct=1.044832880000000, polymer=1.044832880000000
+PASS fine_path_coarse_anchor_lipschitz: coarse_path=[(0, 0, 0, 0), (0, 0, 0, 0), (1, 0, 0, 0), (1, 0, 0, 0), (1, 1, 0, 0)]
+PASS coarse_anchor_multiplicity: 64 anchored fine links + 4 incoming skeleton endpoints=68
+PASS source_contract: missing=[], forbidden_hits=[]
+PASS sole_repository_dependency: markdown_dependency_set=['WILSON_STAGGERED_RAW_CONSTRAINED_ACTION_HESSIAN_DECAY_BOUNDED_THEOREM_NOTE_2026-07-12.md']
+SCORECARD PASS=14 FAIL=0

--- a/scripts/wilson_staggered_constrained_fiber_two_layer_kp_source_polymer_2026_07_12.py
+++ b/scripts/wilson_staggered_constrained_fiber_two_layer_kp_source_polymer_2026_07_12.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Checks the explicit two-layer KP source-polymer criterion."""
+
+from __future__ import annotations
+
+import itertools
+import math
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "WILSON_STAGGERED_CONSTRAINED_FIBER_TWO_LAYER_KP_COMPLEX_SOURCE_"
+    "POLYMER_BOUNDED_THEOREM_NOTE_2026-07-12.md"
+)
+
+
+def g(t: float) -> float:
+    return math.expm1(t) / t if t else 1.0
+
+
+def criterion(mass: float, beta: float, c: float, theta: float, lam: float) -> dict[str, float]:
+    kappa = 14.0 / (mass * mass + 2.0)
+    L = theta + 2.0 * c + lam
+    q = kappa * math.exp(2.0 * L)
+    wilson = 12.0 * math.expm1(3.0 * beta / 4.0) * math.exp(4.0 * L)
+    fermion = 0.0
+    for n in range(2, 100000):
+        t_n = 3.0 * kappa**n / (2.0 * n)
+        term = 1.5 * kappa**n * g(t_n) * math.exp(2.0 * n * L)
+        fermion += term
+        if term < 1.0e-18:
+            break
+    total = wilson + fermion
+    return {
+        "kappa": kappa,
+        "L": L,
+        "q": q,
+        "wilson": wilson,
+        "fermion": fermion,
+        "K": total,
+        "epsilon": c - total,
+    }
+
+
+def source_radius(epsilon: float, c: float, theta: float, lam: float, size: int, span: int, norm: float = 1.0) -> float:
+    return math.log1p(epsilon * math.exp(-(theta + 2.0 * c) * size - lam * span)) / norm
+
+
+def components(labels: tuple[int, ...], supports: list[set[int]]) -> list[tuple[int, ...]]:
+    unseen = set(labels)
+    out: list[tuple[int, ...]] = []
+    while unseen:
+        root = unseen.pop()
+        comp = {root}
+        frontier = [root]
+        while frontier:
+            a = frontier.pop()
+            linked = {b for b in unseen if supports[a] & supports[b]}
+            unseen -= linked
+            comp |= linked
+            frontier.extend(linked)
+        out.append(tuple(sorted(comp)))
+    return out
+
+
+def toy_two_layer_identity() -> tuple[float, float]:
+    # Label 3 is independent of every spin but deliberately carries the dummy
+    # syntactic support {0}. This models a coarse-V-dependent factor whose A
+    # variables cancel algebraically; over-supporting it must preserve the
+    # exact factor-to-polymer identity.
+    supports = [{0, 1}, {1, 2}, {2}, {0}]
+
+    def factor(label: int, spins: tuple[int, int, int]) -> float:
+        x = [2 * s - 1 for s in spins]
+        return [
+            0.04 + 0.07 * x[0] * x[1],
+            -0.02 - 0.05 * x[1] * x[2],
+            0.01 + 0.03 * x[2],
+            0.015,
+        ][label]
+
+    configs = list(itertools.product((0, 1), repeat=3))
+    direct = sum(math.prod(1.0 + factor(a, s) for a in range(4)) for s in configs) / len(configs)
+
+    polymer_weight: dict[tuple[int, ...], float] = {}
+    for r in range(1, 5):
+        for labels in itertools.combinations(range(4), r):
+            if len(components(labels, supports)) == 1:
+                polymer_weight[labels] = sum(
+                    math.prod(factor(a, s) for a in labels) for s in configs
+                ) / len(configs)
+
+    polymer_sum = 1.0
+    polymers = list(polymer_weight)
+    for r in range(1, len(polymers) + 1):
+        for family in itertools.combinations(polymers, r):
+            used_labels: set[int] = set()
+            used_sites: set[int] = set()
+            compatible = True
+            for gamma in family:
+                sites = set().union(*(supports[a] for a in gamma))
+                if used_labels & set(gamma) or used_sites & sites:
+                    compatible = False
+                    break
+                used_labels |= set(gamma)
+                used_sites |= sites
+            if compatible:
+                polymer_sum += math.prod(polymer_weight[gamma] for gamma in family)
+    return direct, polymer_sum
+
+
+def coarse_cells_for_path(path: list[tuple[int, int, int, int]]) -> list[tuple[int, int, int, int]]:
+    return [tuple(x // 2 for x in site) for site in path]
+
+
+def main() -> None:
+    checks: list[tuple[str, bool, str]] = []
+
+    # Exact SU(3) midpoint centering: Re Tr U in [-3/2,3] turns the Wilson
+    # exponent interval into length 3 beta/2 and centered sup norm 3 beta/4.
+    beta_probe = 0.2
+    wilson_values = [-beta_probe, beta_probe / 2.0]
+    midpoint = sum(wilson_values) / 2.0
+    centered = max(abs(x - midpoint) for x in wilson_values)
+    checks.append(
+        (
+            "wilson_midpoint_centering",
+            abs(centered - 3.0 * beta_probe / 4.0) < 1e-15,
+            f"centered_sup={centered:.12f}, target={3*beta_probe/4:.12f}",
+        )
+    )
+
+    # A two-link hidden footprint meets at most 12 fine plaquettes.
+    checks.append(("hidden_plaquette_incidence", 2 * 2 * (4 - 1) == 12, "2 footprints * 6 plaquettes=12"))
+
+    examples = [
+        (10.0, 0.0005, 0.12, 0.001, 0.001),
+        (12.0, 0.0020, 0.15, 0.001, 0.001),
+        (16.0, 0.0035, 0.14, 0.001, 0.001),
+    ]
+    results = []
+    for mass, beta, c, theta, lam in examples:
+        row = criterion(mass, beta, c, theta, lam)
+        results.append((mass, beta, c, theta, lam, row))
+        checks.append(
+            (
+                f"kp_point_m{mass:g}",
+                row["q"] < 1.0 and row["epsilon"] > 0.0,
+                f"K={row['K']:.12f}, c={c:.6f}, epsilon={row['epsilon']:.12f}, q={row['q']:.12f}",
+            )
+        )
+
+    # Check the closed geometric envelope used for tail diagnostics.
+    mass, beta, c, theta, lam, row = results[1]
+    envelope = 1.5 * math.exp(3.0 * row["kappa"] ** 2 / 4.0) * row["q"] ** 2 / (1.0 - row["q"])
+    checks.append(
+        (
+            "determinant_geometric_envelope",
+            row["fermion"] <= envelope + 1e-15,
+            f"series={row['fermion']:.12f}, envelope={envelope:.12f}",
+        )
+    )
+
+    # Explicit uniform radii for a norm-one one-coordinate source and a
+    # norm-one four-coordinate, span-two source.
+    for mass, beta, c, theta, lam, row in results:
+        r1 = source_radius(row["epsilon"], c, theta, lam, 1, 0)
+        r42 = source_radius(row["epsilon"], c, theta, lam, 4, 2)
+        checks.append(
+            (
+                f"source_radii_m{mass:g}",
+                r1 > 0.0 and r42 > 0.0 and r42 < r1,
+                f"r_(1,0)={r1:.12f}, r_(4,2)={r42:.12f}",
+            )
+        )
+
+    direct, polymer = toy_two_layer_identity()
+    checks.append(
+        (
+            "two_layer_factor_to_polymer_identity",
+            abs(direct - polymer) < 1e-14,
+            f"direct={direct:.15f}, polymer={polymer:.15f}",
+        )
+    )
+
+    fine_path = [(0, 0, 0, 0), (1, 0, 0, 0), (2, 0, 0, 0), (2, 1, 0, 0), (2, 2, 0, 0)]
+    coarse = coarse_cells_for_path(fine_path)
+    connected = all(sum(abs(a - b) for a, b in zip(x, y)) <= 1 for x, y in zip(coarse, coarse[1:]))
+    checks.append(
+        (
+            "fine_path_coarse_anchor_lipschitz",
+            connected and len(set(coarse)) <= len(fine_path),
+            f"coarse_path={coarse}",
+        )
+    )
+    checks.append(("coarse_anchor_multiplicity", 4 * 2**4 + 4 == 68, "64 anchored fine links + 4 incoming skeleton endpoints=68"))
+
+    text = NOTE.read_text()
+    required = [
+        "**Type:** bounded_theorem",
+        "L=theta+2c+lambda",
+        "K_(theta,lambda)(c)<c",
+        "q=kappa exp(2L)<1",
+        "two-layer",
+        "syntactic hidden footprint",
+        "uniform complex-source domain",
+        "D^n R=(-1)^(n+1) kappa_n",
+        "68 exp(lambda/2)c",
+        "No negative theorem is shipped.",
+        "No axiom-update stop is established.",
+        "### N1",
+        "### N2",
+        "### N3",
+        "### N4",
+        "### N5",
+        "### N6",
+        "### N7",
+        "### N8",
+    ]
+    missing = [x for x in required if x not in text]
+    forbidden = ["complete analyticity follows from Dobrushin", "retained-Grassmann theorem", "NOT_TESTED"]
+    hits = [x for x in forbidden if x in text]
+    checks.append(("source_contract", not missing and not hits, f"missing={missing}, forbidden_hits={hits}"))
+
+    dep = "WILSON_STAGGERED_RAW_CONSTRAINED_ACTION_HESSIAN_DECAY_BOUNDED_THEOREM_NOTE_2026-07-12.md"
+    note_links = re.findall(r"\]\(([^)#?]+\.md)\)", text)
+    dep_set = sorted(set(note_links))
+    checks.append(("sole_repository_dependency", dep_set == [dep], f"markdown_dependency_set={dep_set}"))
+
+    passed = sum(ok for _, ok, _ in checks)
+    failed = len(checks) - passed
+    for name, ok, detail in checks:
+        print(f"{'PASS' if ok else 'FAIL'} {name}: {detail}")
+    print(f"SCORECARD PASS={passed} FAIL={failed}")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Result

Proves a bounded positive theorem for the fermion-integrated constrained gauge body in an explicit high-mass/small-coupling subwedge:

- exact two-layer factor-to-hard-core-polymer regrouping;
- explicit KP criterion `q<1`, `K_(theta,lambda)(c)<c` with three strict parameter points;
- a uniform complete Reinhardt complex-source domain and all fixed-order connected-cumulant/tree-decay bounds;
- weighted `p=0` coarse gauge-body interaction membership;
- explicit syntactic support bookkeeping for coarse-`V` factors exposed by hidden-variable cancellation.

The scope remains gauge-body only. It does not claim the retained gauge–Grassmann norm, a projected/rescaled RG contraction, or a continuum trajectory, and it establishes no axiom-update stop.

## Review

Independent code/math, Nature/physics/import, and governance/no-go reviews passed after one repair cycle. The repair made the nonminimal syntactic footprint explicit, added the full rooted-tree recursion leading to the KP exclusion row, and extended the exact toy regrouping test to a hidden-independent factor with a dummy support.

## Checks

- runner/cache: `PASS=14 FAIL=0`
- `python3 -m py_compile ...`: pass
- controlled vocabulary lint: pass
- `git diff --check`: pass
- full audit pipeline: pass
- strict audit lint: no errors
- seeded row: `bounded_theorem`, `unaudited`, sole direct dependency Block 27

Stacked on #5317.
