### PR TITLE
audit-infra: AUDIT_DISPATCH_QUEUE.md is a pipeline-generated audit surface

### DIFF
--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -19,6 +19,7 @@ import hashlib
 import io
 import json
 import os
+import re
 import sys
 import tempfile
 import unittest
@@ -8579,6 +8580,38 @@ class ComputeLaneCertificationTest(unittest.TestCase):
         self.assertIn(
             '("compute_lane_certification.py",      "refresh rolling lane certification")',
             apply_script,
+        )
+
+
+class AuditDataFilesCoverPipelineSurfacesTest(unittest.TestCase):
+    """Every generated surface the pipeline announces must be covered by
+    AUDIT_DATA_FILES, or verdict applies fail the unexpected-generated-paths
+    gate the first time that surface actually changes (grain drain,
+    2026-07-12: AUDIT_DISPATCH_QUEUE.md)."""
+
+    def test_pipeline_announced_surfaces_are_allowlisted(self):
+        runner = _import_codex_audit_runner()
+        script = (
+            PROJECT_ROOT / "docs" / "audit" / "scripts" / "run_pipeline.sh"
+        ).read_text(encoding="utf-8")
+        announced = {
+            match
+            for match in re.findall(r"Read (docs/[^\s]+)", script)
+            if "<" not in match
+        }
+        self.assertIn("docs/audit/AUDIT_DISPATCH_QUEUE.md", announced)
+
+        def covered(path: str) -> bool:
+            return any(
+                path == allowed or path.startswith(allowed + "/")
+                for allowed in runner.AUDIT_DATA_FILES
+            )
+
+        uncovered = sorted(path for path in announced if not covered(path))
+        self.assertEqual(
+            uncovered, [],
+            "pipeline-generated surfaces missing from AUDIT_DATA_FILES "
+            f"(apply gate will reject verdicts when they change): {uncovered}",
         )
 
 

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1314,6 +1314,7 @@ def run_codex(prompt: str, isolated_dir: Path, timeout_sec: int,
 # alongside any verdict-write to keep main internally consistent.
 AUDIT_DATA_FILES = [
     "docs/audit/AUDIT_LEDGER.md",
+    "docs/audit/AUDIT_DISPATCH_QUEUE.md",
     "docs/audit/AUDIT_QUEUE.md",
     "docs/audit/data",
     "docs/publication/ci3_z3/CLAIMS_TABLE_EFFECTIVE_STATUS.md",


### PR DESCRIPTION
## What

Grain-drain round 1 hit the next latent defect: the first verdict apply regenerated `docs/audit/AUDIT_DISPATCH_QUEUE.md` (a standard pipeline output — `run_pipeline.sh` announces it, and historical audit commits include it), but `AUDIT_DATA_FILES` in `scripts/codex_audit_runner.py` predates that surface, so the orchestrator's unexpected-generated-paths gate rejected the commit (`apply_or_gate_failed`), leaving six validated seat deliveries unapplied on disk (they'll be salvage-applied after this lands — no re-audit needed).

## Fix

- Add `docs/audit/AUDIT_DISPATCH_QUEUE.md` to `AUDIT_DATA_FILES` (this is both the allowlist for the gate and the staging list for the audit commit, so the file lands with the verdict as intended).
- New drift-invariant test `AuditDataFilesCoverPipelineSurfacesTest`: extracts every `Read docs/...` surface `run_pipeline.sh` announces and asserts each is covered by `AUDIT_DATA_FILES` — the next time the pipeline grows a surface, the suite fails at PR time instead of the live apply gate failing mid-drain.

Suite 304/304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)