### PR TITLE
science-fix: strong_cp_theta_zero_note cited-selection wiring + constructed action basis

### DIFF
--- a/docs/STRONG_CP_THETA_ZERO_NOTE.md
+++ b/docs/STRONG_CP_THETA_ZERO_NOTE.md
@@ -1,18 +1,18 @@
 # Strong CP / θ = 0 Conditional Action-Surface Closure
 
 **Date:** 2026-04-16 (status line narrowed 2026-04-28 per audit-lane verdict; action-surface firewall clarified 2026-05-26; cited-selection repair 2026-07-12)
-**Status:** `bounded_theorem` source-side boundary: conditional `θ_eff = 0` closure on the **cited-selected Wilson-plus-staggered / K-real Case-A mass surface** constructed by the runner. The decisive action-surface selection is now wired to the bounded authorities below rather than stipulated by the runner. Not a retained or tier-ratifiable strong-CP solution beyond those authorities' own conditions: the canonical real-positive Wilson class, the character/orientation-even/odd-support positive-class hypotheses, the supplied scalar-mass boundary and positive-mass convention, and the supplied K-real Case-A determinant-channel reading. An admitted CP-odd action term or complex mass phase re-opens the question.
+**Status:** `bounded_theorem` source-side boundary: conditional `θ_eff = 0` closure on the **bounded Wilson-plus-staggered / K-real Case-A selected action surface** constructed by the runner. The decisive action-surface selection is now wired to the bounded authorities below rather than stipulated by the runner. Not a retained or tier-ratifiable strong-CP solution beyond those authorities' own conditions: the canonical real-positive Wilson class, the character/orientation-even/odd-support positive-class hypotheses, the supplied scalar-mass boundary and positive-mass convention, and the supplied K-real Case-A determinant-channel reading. The sector-weight leg is additionally conditional on a supplied or separately derived integer-valued emergent `Q` with populated support; its existence, integrality, nonvacuity, and susceptibility remain open. An admitted CP-odd action term or complex mass phase re-opens the question.
 **Claim type:** bounded_theorem
 **Script:** `scripts/frontier_strong_cp_theta_zero.py`
 
 ## Load-bearing dependencies
 
-| Authority | Status authority | Consumed content |
+| Authority | Source claim boundary | Consumed content |
 |---|---|---|
-| [Native Positive-Class Adjudication (2026-07-04)](THETA_GAUGE_NATIVE_POSITIVE_CLASS_EMERGENT_SECTOR_WEIGHTING_NARROW_THEOREM_NOTE_2026-07-04.md) | `bounded_theorem` source-side boundary; independent audit lane only | In the canonical imported Wilson + staggered-Wilson class, non-negative native sector pushforwards make a positive relative emergent gauge-side theta weighting vacuous or zero; zero is selected on gcd-one populated support (adjacent populated sectors suffice). Existence, integrality, nonvacuity, and susceptibility of an emergent `Q` remain outside the authority. |
-| [Gauge Z2 Character Collapse and Positive-Class Zero-Branch Selection (2026-07-03)](THETA_GAUGE_Z2_CHARACTER_COLLAPSE_ODD_SUPPORT_AND_POSITIVE_CLASS_ZERO_BRANCH_SELECTION_BOUNDED_THEOREM_NOTE_2026-07-03.md) | `bounded_theorem` source-side boundary; independent audit lane only | For a multiplicative theta character, orientation-evenness plus odd support collapses the gauge branch to `{0, π}`; membership in the strictly positive conjugation-paired class excludes the odd-support `π` branch and selects zero. Character form, orientation-evenness, odd support, and positive-class membership are load-bearing, and physical-action-class membership is not supplied by this authority itself. |
-| [Single-Plaquette CP-Odd Slot Rejection and Quark-Mass Orientation (2026-05-19)](STRONG_CP_OPERATOR_BASIS_AND_MASS_ORIENTATION_THEOREM_NOTE_2026-05-19.md) | `bounded_theorem` supplied-premise source-side support; independent audit lane only | Under P1-P5 on the canonical real-positive Wilson surface, excludes the reviewed CP-odd single-plaquette action slot `i θ Σ_P Im Tr U_P`; under staggered anti-Hermiticity, the supplied real-positive determinant boundary, and the supplied scalar-mass class, excludes non-real scalar mass phases. It does not exclude clover or other multi-plaquette slots, and the positive mass sign is convention-aligned rather than derived. |
-| [Mass-Orientation Zero Branch on the K-Real Staggered Surface (2026-07-01)](THETA_MASS_ORIENTATION_ZERO_BRANCH_PAIRING_FORCED_ON_K_REAL_SURFACE_NARROW_THEOREM_NOTE_2026-07-01.md) | `bounded_theorem` source-side boundary; historical Tier-A/admission references supply no ready premise; independent audit lane only | On the supplied staggered-only Case-A K-real surface (real antisymmetric `M_KS`, bipartite `ε` grading, a reality-preserving background, and real scalar mass or a Hermitian flavor operator on the flavor tensor factor), exact `±iλ` pairing forces the determinant-orientation zero branch for either real sign. The determinant-channel K-real reading remains supplied; Wilson shifts, non-commuting flavor-kinetic couplings, and non-K-real flavor blocks are outside scope. |
+| [Native Positive-Class Adjudication (2026-07-04)](THETA_GAUGE_NATIVE_POSITIVE_CLASS_EMERGENT_SECTOR_WEIGHTING_NARROW_THEOREM_NOTE_2026-07-04.md) | `bounded_theorem` author-side classification; audit grade is not assigned here | In the canonical imported Wilson + staggered-Wilson class, non-negative native sector pushforwards make a positive relative emergent gauge-side theta weighting vacuous or zero; zero is selected on gcd-one populated support (adjacent populated sectors suffice). Existence, integrality, nonvacuity, and susceptibility of an emergent `Q` remain outside the authority. |
+| [Gauge Z2 Character Collapse and Positive-Class Zero-Branch Selection (2026-07-03)](THETA_GAUGE_Z2_CHARACTER_COLLAPSE_ODD_SUPPORT_AND_POSITIVE_CLASS_ZERO_BRANCH_SELECTION_BOUNDED_THEOREM_NOTE_2026-07-03.md) | `bounded_theorem` author-side classification; audit grade is not assigned here | For a multiplicative theta character, orientation-evenness plus odd support collapses the gauge branch to `{0, π}`; membership in the strictly positive conjugation-paired class excludes the odd-support `π` branch and selects zero. Character form, orientation-evenness, odd support, and positive-class membership are load-bearing, and physical-action-class membership is not supplied by this authority itself. |
+| [Single-Plaquette CP-Odd Slot Rejection and Quark-Mass Orientation (2026-05-19)](STRONG_CP_OPERATOR_BASIS_AND_MASS_ORIENTATION_THEOREM_NOTE_2026-05-19.md) | `bounded_theorem` author-side classification on a supplied-premise surface; audit grade is not assigned here | Under P1-P5 on the canonical real-positive Wilson surface, excludes the reviewed CP-odd single-plaquette action slot `i θ Σ_P Im Tr U_P`; under staggered anti-Hermiticity, the supplied real-positive determinant boundary, and the supplied scalar-mass class, excludes non-real scalar mass phases. It does not exclude clover or other multi-plaquette slots, and the positive mass sign is convention-aligned rather than derived. |
+| [Mass-Orientation Zero Branch on the K-Real Staggered Surface (2026-07-01)](THETA_MASS_ORIENTATION_ZERO_BRANCH_PAIRING_FORCED_ON_K_REAL_SURFACE_NARROW_THEOREM_NOTE_2026-07-01.md) | `bounded_theorem` author-side classification; historical Tier-A/admission references supply no ready premise; audit grade is not assigned here | On the supplied staggered-only Case-A K-real surface (real antisymmetric `M_KS`, bipartite `ε` grading, a reality-preserving background, and real scalar mass or a Hermitian flavor operator on the flavor tensor factor), exact `±iλ` pairing makes the determinant non-negative for either real sign; its orientation phase is zero on the nonzero-determinant locus. The determinant-channel K-real reading remains supplied; Wilson shifts, non-commuting flavor-kinetic couplings, and non-K-real flavor blocks are outside scope. |
 
 ## 2026-07-12 cited-selection correction
 
@@ -26,7 +26,7 @@ not enlarge any authority's claim boundary or predict an audit outcome.
 
 ## 2026-05-26 action-surface firewall
 
-This row is a bounded cited-selected-surface theorem, not an unconditional
+This row is a bounded selected-action-surface theorem, not an unconditional
 strong-CP solution. Its load-bearing premises are:
 
 1. the reviewed gauge action lies in the canonical real-positive Wilson class
@@ -36,11 +36,12 @@ strong-CP solution. Its load-bearing premises are:
    convention-aligned positive representative and on the K-real Case-A
    determinant-channel surface; and
 3. the topological-weight argument is applied only after the cited conditional
-   selectors have computed the zero gauge branch and zero determinant phase.
+   selectors have computed the zero gauge branch and the selected positive,
+   nonzero mass representatives lie on the zero-phase determinant locus.
 
 The note therefore licenses only the statement
 
-    θ_eff = 0 on the cited-selected Wilson-plus-staggered / K-real Case-A mass surface.
+    θ_eff = 0 on the bounded Wilson-plus-staggered / K-real Case-A selected action surface.
 
 It does not derive from the minimal axiom surface that every gauge action on
 the `Z^3` spatial substrate forbids all CP-odd topological discretizations.
@@ -54,8 +55,8 @@ such admitted data to zero.
 
 ## Theorem
 
-**Theorem (bounded cited-selected-surface `θ_eff = 0` closure).**
-On the cited-selected Wilson-plus-staggered / K-real Case-A mass surface
+**Theorem (bounded selected-action-surface `θ_eff = 0` closure).**
+On the bounded Wilson-plus-staggered / K-real Case-A selected action surface
 constructed and tested by the runner, conditional on every load-bearing
 dependency and condition in the table above,
 
@@ -69,7 +70,7 @@ with no surviving loophole from:
 3. strong-sector phase generation when the fermions are integrated out, or
 4. positive-weight topological-sector weighting away from `θ = 0`.
 
-This is a **bounded cited-selected-action-surface** closure theorem. It is not a
+This is a **bounded selected-action-surface** closure theorem. It is not a
 claim about every continuum formulation, every regulator, every possible
 CP-odd discretization on the `Z^3` spatial substrate, or axion-model exclusion
 beyond that selected surface.
@@ -151,13 +152,14 @@ Therefore:
 3. that rotated mass operator is no longer a real scalar mass term, so it
    exits the selected Wilson-plus-staggered scalar-mass action class.
 
-This closes the chiral/basis loophole on the selected surface. The framework
-does not have a continuous admissible axial freedom that can move phase between
-the mass term and a strong-sector `θ`.
+This closes the chiral/basis loophole on the selected surface. Within the
+supplied scalar-mass action class, no continuous admissible axial freedom can
+move phase between the mass term and a strong-sector `θ` while remaining in
+that class.
 
 ### Leg C: Gauge-sector radiative non-generation
 
-The runner constructs the cited-selected action surface by starting from a
+The runner constructs the bounded selected action surface by starting from a
 candidate gauge slot `θ` and one scalar phase `α_f` per staggered flavor. It
 then applies the bounded selectors in the dependency table before any closure
 check. The background package inputs remain:
@@ -210,8 +212,9 @@ selected Wilson-plus-staggered action class.
 
 ### Leg D: Topological-sector positivity and the `θ = 0` minimum
 
-The topological charge exists on the selected `3+1` surface, and the selected
-partition function can be written formally as
+Conditional on a supplied or separately derived integer-valued emergent sector
+functional `Q` with populated support, the selected partition function can be
+written formally as
 
     Z = Σ_Q Z_Q
 
@@ -238,13 +241,15 @@ so the selected-surface free energy
 
 is minimized at `θ = 0`.
 
-This is the exact topological closure needed here. It does **not** require a
-closed-form first-principles expression for the detailed lattice measure
-`Z_Q`. Positivity of the sector weights is enough.
+This is the exact conditional sector-weight inequality needed here. It does
+**not** derive the existence, integrality, nonvacuity, or susceptibility of an
+emergent `Q`, and it does not require a closed-form first-principles expression
+for the detailed lattice measure `Z_Q`. Positivity of the sector weights is
+enough once that sector functional and populated support are supplied.
 
 The runner mirrors this mechanism with a sampled selected-surface `3+1`
-positive-weight `Q`-weighted family rather than a literal computed exact
-sector decomposition:
+positive-weight clover-style `Q` proxy rather than a derived emergent `Q` or a
+literal computed exact sector decomposition:
 
 - sampled selected-surface positive weights are strictly positive,
 - the sampled `θ`-sum obeys `|Z(θ)| <= Z(0)`,
@@ -252,9 +257,9 @@ sector decomposition:
 
 ## Relation to CKM CP Violation
 
-The framework does contain CP violation, but only in the weak sector. The
-`Z_3` source acts through the electroweak `1+2` split and produces the CKM
-phase
+Within this bounded selected-action-surface package, the explicit CP-violating datum
+carried by the runner is the weak-sector CKM phase. The separate `Z_3` source
+acts through the electroweak `1+2` split and produces
 
     δ_std = arctan(√5) = 65.905°.
 
@@ -268,7 +273,9 @@ discrete weak-sector source. The runner keeps the exact finite checks:
 - `|det V_CKM| = 1`,
 - explicit positive-mass `arg det(M_u M_d) = 0`.
 
-So CKM CP remains weak-sector only and does not leak into `θ_eff`.
+Thus the runner finds no CKM-to-`θ_eff` leakage on this bounded selected
+surface. This does not exclude a strong-sector phase after admitting a CP-odd
+action term or complex mass phase outside that surface.
 
 ## Combined Result
 
@@ -281,14 +288,14 @@ The four legs now close together:
 4. positive topological-sector weights force the free-energy minimum to
    `θ = 0`.
 
-Therefore, on the cited-selected Wilson-plus-staggered / K-real Case-A mass
-surface,
+Therefore, on the bounded Wilson-plus-staggered / K-real Case-A selected
+action surface,
 
     θ_bare = 0,
     arg det(M_u M_d) = 0,
     θ_eff = 0.
 
-This is a **bounded cited-selected-surface strong-CP closure package**.
+This is a **bounded selected-action-surface strong-CP closure package**.
 
 ## What Is Actually Proved
 
@@ -322,7 +329,8 @@ This is a **bounded cited-selected-surface strong-CP closure package**.
    canonical real-positive P1-P5 surface;
 5. operator-basis reality reduces each scalar mass phase to `{0, π}`;
 6. exact K-real `±iλ` pairing makes the determinant non-negative for both real
-   mass signs on the supplied Case-A surface; and
+   mass signs on the supplied Case-A surface, with zero phase only on the
+   nonzero-determinant locus; and
 7. the convention-aligned positive-real representative is `α_f = 0` for every
    constructed flavor slot.
 
@@ -344,7 +352,8 @@ by zero.
 5. free-field and gauged `Z^3` staggered determinant positivity,
 6. `3+1` APBC determinant positivity on sampled selected-surface `SU(3)`
    configurations,
-7. sampled nontrivial topological charge without determinant phase generation,
+7. sampled nontrivial clover-style topological-charge proxy without determinant
+   phase generation,
 8. `εD + Dε = 0` on the selected `3+1` APBC surface,
 9. sampled exact `±λ` pairing of `iD`,
 10. sampled `Im Γ_f = 0`,
@@ -360,7 +369,7 @@ by zero.
 16. sampled selected-surface effective action is real,
 17. linkwise complex conjugation preserves the full selected-surface effective
     action,
-18. sampled selected-surface positive-weight `Q`-weighted family obeys
+18. sampled selected-surface positive-weight `Q`-proxy family obeys
     `|Z(θ)| <= Z(0)`,
 19. the sampled selected-surface free energy is minimized at `θ = 0`.
 
@@ -375,13 +384,15 @@ These support items are not counted as theorem-grade closure.
 ## What Is Not Claimed
 
 1. **Unrestricted all-formulations closure.**
-   The theorem is only about the cited-selected Wilson-plus-staggered / K-real
-   Case-A mass surface on the `Z^3` spatial substrate, with every cited
+   The theorem is only about the bounded Wilson-plus-staggered / K-real Case-A
+   selected action surface on the `Z^3` spatial substrate, with every cited
    condition inherited.
 
-2. **Closed-form `Z_Q` measure on the selected lattice surface.**
-   The closure uses positivity and the `θ`-sum bound, not a closed-form
-   instanton measure.
+2. **Emergent-`Q` existence or a closed-form `Z_Q` measure.**
+   The conditional closure uses positivity and the `θ`-sum bound after an
+   integer-valued sector functional with populated support is supplied; it does
+   not derive that functional, its nonvacuity or susceptibility, or a
+   closed-form instanton measure.
 
 3. **Axion exclusion beyond the selected action surface.**
    The theorem does not exclude axion models or other regulators outside the
@@ -401,7 +412,7 @@ These support items are not counted as theorem-grade closure.
 
 ## How This Changes The Paper
 
-The strong-CP lane has a bounded cited-selected-surface closure package:
+The strong-CP lane has a bounded selected-action-surface closure package:
 
 - fermion phase closure,
 - axial/chiral non-generation,
@@ -415,12 +426,13 @@ The safe paper sentence is:
 > determinant-channel conditions, the runner constructs the zero-branch action
 > surface and finds no additional generated strong-sector phase: the
 > determinant phase vanishes, admissible axial rotations do not move phase into
-> `θ`, exact fermion integration stays real, and positive sampled topological
-> weights place the selected-surface free-energy minimum at `θ = 0`.
+> `θ`, exact fermion integration stays real, and, conditional on a supplied
+> populated integer-sector functional, positive sampled proxy weights place the
+> selected-surface free-energy minimum at `θ = 0`.
 
 ## Experimental Predictions
 
-1. **`θ_eff = 0` exactly on the cited-selected action surface, conditional on
+1. **`θ_eff = 0` exactly on the bounded selected action surface, conditional on
    all cited surface and channel conditions.**
 2. **`d_n(QCD) = 0` on that selected surface, conditional on the same surface
    premises.**
@@ -491,9 +503,10 @@ status.
    Q-structure existence and nonvacuity open.
 2. Mass-side selection retains the supplied scalar-mass boundary, the
    convention-aligned positive representative, and the K-real Case-A
-   determinant-channel identification. The K-real pairing theorem fixes the
-   determinant phase for both real signs; it does not independently derive the
-   positive sign.
+   determinant-channel identification. The K-real pairing theorem makes the
+   determinant non-negative for both real signs and fixes its phase only on the
+   nonzero-determinant locus; it does not independently derive the positive
+   sign. The runner's selected positive nonzero masses lie on that locus.
 3. An ADMITTED CP-odd action term or complex mass phase is outside the
    constructed selected surface and re-opens the strong-CP question. A choice
    to admit such data is not fixed by the supplied structure and remains a

--- a/docs/STRONG_CP_THETA_ZERO_NOTE.md
+++ b/docs/STRONG_CP_THETA_ZERO_NOTE.md
@@ -1,36 +1,63 @@
 # Strong CP / θ = 0 Conditional Action-Surface Closure
 
-**Date:** 2026-04-16 (status line narrowed 2026-04-28 per audit-lane verdict; action-surface firewall clarified 2026-05-26)
-**Status:** `bounded_theorem` source-side boundary: conditional `θ_eff = 0` closure on the **explicitly θ-free Wilson-plus-staggered scalar-mass surface** that the runner restricts to. The decisive step is action-surface selection (no bare θ slot, real positive mass orientation), not a derived dynamical θ = 0 result. Not a retained or tier-ratifiable strong-CP solution beyond that selected surface.
+**Date:** 2026-04-16 (status line narrowed 2026-04-28 per audit-lane verdict; action-surface firewall clarified 2026-05-26; cited-selection repair 2026-07-12)
+**Status:** `bounded_theorem` source-side boundary: conditional `θ_eff = 0` closure on the **cited-selected Wilson-plus-staggered / K-real Case-A mass surface** constructed by the runner. The decisive action-surface selection is now wired to the bounded authorities below rather than stipulated by the runner. Not a retained or tier-ratifiable strong-CP solution beyond those authorities' own conditions: the canonical real-positive Wilson class, the character/orientation-even/odd-support positive-class hypotheses, the supplied scalar-mass boundary and positive-mass convention, and the supplied K-real Case-A determinant-channel reading. An admitted CP-odd action term or complex mass phase re-opens the question.
 **Claim type:** bounded_theorem
 **Script:** `scripts/frontier_strong_cp_theta_zero.py`
 
+## Load-bearing dependencies
+
+| Authority | Status authority | Consumed content |
+|---|---|---|
+| [Native Positive-Class Adjudication (2026-07-04)](THETA_GAUGE_NATIVE_POSITIVE_CLASS_EMERGENT_SECTOR_WEIGHTING_NARROW_THEOREM_NOTE_2026-07-04.md) | `bounded_theorem` source-side boundary; independent audit lane only | In the canonical imported Wilson + staggered-Wilson class, non-negative native sector pushforwards make a positive relative emergent gauge-side theta weighting vacuous or zero; zero is selected on gcd-one populated support (adjacent populated sectors suffice). Existence, integrality, nonvacuity, and susceptibility of an emergent `Q` remain outside the authority. |
+| [Gauge Z2 Character Collapse and Positive-Class Zero-Branch Selection (2026-07-03)](THETA_GAUGE_Z2_CHARACTER_COLLAPSE_ODD_SUPPORT_AND_POSITIVE_CLASS_ZERO_BRANCH_SELECTION_BOUNDED_THEOREM_NOTE_2026-07-03.md) | `bounded_theorem` source-side boundary; independent audit lane only | For a multiplicative theta character, orientation-evenness plus odd support collapses the gauge branch to `{0, π}`; membership in the strictly positive conjugation-paired class excludes the odd-support `π` branch and selects zero. Character form, orientation-evenness, odd support, and positive-class membership are load-bearing, and physical-action-class membership is not supplied by this authority itself. |
+| [Single-Plaquette CP-Odd Slot Rejection and Quark-Mass Orientation (2026-05-19)](STRONG_CP_OPERATOR_BASIS_AND_MASS_ORIENTATION_THEOREM_NOTE_2026-05-19.md) | `bounded_theorem` supplied-premise source-side support; independent audit lane only | Under P1-P5 on the canonical real-positive Wilson surface, excludes the reviewed CP-odd single-plaquette action slot `i θ Σ_P Im Tr U_P`; under staggered anti-Hermiticity, the supplied real-positive determinant boundary, and the supplied scalar-mass class, excludes non-real scalar mass phases. It does not exclude clover or other multi-plaquette slots, and the positive mass sign is convention-aligned rather than derived. |
+| [Mass-Orientation Zero Branch on the K-Real Staggered Surface (2026-07-01)](THETA_MASS_ORIENTATION_ZERO_BRANCH_PAIRING_FORCED_ON_K_REAL_SURFACE_NARROW_THEOREM_NOTE_2026-07-01.md) | `bounded_theorem` source-side boundary; historical Tier-A/admission references supply no ready premise; independent audit lane only | On the supplied staggered-only Case-A K-real surface (real antisymmetric `M_KS`, bipartite `ε` grading, a reality-preserving background, and real scalar mass or a Hermitian flavor operator on the flavor tensor factor), exact `±iλ` pairing forces the determinant-orientation zero branch for either real sign. The determinant-channel K-real reading remains supplied; Wilson shifts, non-commuting flavor-kinetic couplings, and non-K-real flavor blocks are outside scope. |
+
+## 2026-07-12 cited-selection correction
+
+The action-surface dependencies were previously uncited, and the runner
+previously hard-coded `θ_bare = 0` and positive-real masses before checking
+closure. This repair wires the four bounded authorities above and makes the
+runner construct candidate gauge and per-flavor mass-phase slots, compute the
+allowed conditional basis, and only then run the unchanged determinant,
+axial, effective-action, and topological-sector closure legs. The repair does
+not enlarge any authority's claim boundary or predict an audit outcome.
+
 ## 2026-05-26 action-surface firewall
 
-This row is a bounded selected-surface theorem, not an unconditional strong-CP
-solution. Its load-bearing premises are:
+This row is a bounded cited-selected-surface theorem, not an unconditional
+strong-CP solution. Its load-bearing premises are:
 
-1. the Wilson-plus-staggered action is restricted to the explicitly
-   `θ`-free real-positive scalar-mass surface used by the runner,
-2. the positive real quark-mass orientation is part of that selected surface,
-   and
-3. the topological-weight argument is only applied after those two premises
-   have already removed the bare `θ` slot and determinant phase.
+1. the reviewed gauge action lies in the canonical real-positive Wilson class
+   and, where the sector-character result is used, satisfies character form,
+   orientation-evenness, odd support, and positive-class membership;
+2. the reviewed fermion action lies in the supplied scalar-mass class with the
+   convention-aligned positive representative and on the K-real Case-A
+   determinant-channel surface; and
+3. the topological-weight argument is applied only after the cited conditional
+   selectors have computed the zero gauge branch and zero determinant phase.
 
 The note therefore licenses only the statement
 
-    θ_eff = 0 on the explicitly θ-free Wilson-plus-staggered scalar-mass surface.
+    θ_eff = 0 on the cited-selected Wilson-plus-staggered / K-real Case-A mass surface.
 
 It does not derive from the minimal axiom surface that every gauge action on
-the `Z^3` spatial substrate forbids all CP-odd topological discretizations,
-nor does it derive the scalar positive mass orientation from primitives.
-Downstream use must inherit those selected surface premises explicitly.
+the `Z^3` spatial substrate forbids all CP-odd topological discretizations.
+The single-plaquette exclusion, positive-class branch selection, scalar-mass
+boundary, positive-mass convention, and K-real determinant-channel reading
+retain their cited conditions. Downstream use must inherit them explicitly.
+
+**Named conditional:** an ADMITTED CP-odd action term or complex mass phase
+re-opens the strong-CP question; the supplied structure does not silently set
+such admitted data to zero.
 
 ## Theorem
 
-**Theorem (bounded selected-surface `θ_eff = 0` closure).**
-On the explicitly `θ`-free Wilson-plus-staggered scalar-mass surface tested by
-the runner,
+**Theorem (bounded cited-selected-surface `θ_eff = 0` closure).**
+On the cited-selected Wilson-plus-staggered / K-real Case-A mass surface
+constructed and tested by the runner, conditional on every load-bearing
+dependency and condition in the table above,
 
     θ_eff = θ_QCD + arg det(M_u M_d) = 0
 
@@ -42,7 +69,7 @@ with no surviving loophole from:
 3. strong-sector phase generation when the fermions are integrated out, or
 4. positive-weight topological-sector weighting away from `θ = 0`.
 
-This is a **bounded selected-action-surface** closure theorem. It is not a
+This is a **bounded cited-selected-action-surface** closure theorem. It is not a
 claim about every continuum formulation, every regulator, every possible
 CP-odd discretization on the `Z^3` spatial substrate, or axion-model exclusion
 beyond that selected surface.
@@ -130,7 +157,10 @@ the mass term and a strong-sector `θ`.
 
 ### Leg C: Gauge-sector radiative non-generation
 
-The selected action surface used here is fixed by the bounded package boundary:
+The runner constructs the cited-selected action surface by starting from a
+candidate gauge slot `θ` and one scalar phase `α_f` per staggered flavor. It
+then applies the bounded selectors in the dependency table before any closure
+check. The background package inputs remain:
 
 1. one-qubit operator algebra,
 2. `Z^3` spatial substrate,
@@ -142,11 +172,15 @@ Canonical normalization fixes the Wilson gauge coupling at
 
     β = 6.
 
-So the selected action class is exactly:
+Within the authorities' stated conditions, the computed gauge branch is zero
+and every convention-aligned positive-real mass representative has
+`α_f = 0`. The resulting conditional action class is:
 
     S_sel[U, ψ, ψ̄] = S_Wilson[U] + ψ̄(D[U] + m)ψ
 
-with no bare `θ` slot.
+The absence of the reviewed CP-odd slot here is a computed result of the cited
+conditional selectors. It is not a claim that every clover, multi-plaquette,
+higher-trace, axion-coupled, or signed action is excluded.
 
 Integrating out the fermions is exact on this surface:
 
@@ -247,14 +281,14 @@ The four legs now close together:
 4. positive topological-sector weights force the free-energy minimum to
    `θ = 0`.
 
-Therefore, on the explicitly `θ`-free Wilson-plus-staggered scalar-mass
+Therefore, on the cited-selected Wilson-plus-staggered / K-real Case-A mass
 surface,
 
     θ_bare = 0,
     arg det(M_u M_d) = 0,
     θ_eff = 0.
 
-This is a **bounded selected-surface strong-CP closure package**.
+This is a **bounded cited-selected-surface strong-CP closure package**.
 
 ## What Is Actually Proved
 
@@ -276,39 +310,59 @@ This is a **bounded selected-surface strong-CP closure package**.
 13. positive selected-surface sector weights imply `|Z(θ)| <= Z(0)`, hence
     `F(θ)` is minimized at `θ = 0`.
 
-### Accepted-surface definitions used by the closure
+### Cited conditional selection statements re-verified by the runner
 
-1. no bare `θ` slot appears in the selected Wilson-plus-staggered action
-   class,
-2. therefore `θ_bare = 0` on that selected action surface.
+1. a multiplicative orientation-even theta character on odd support collapses
+   to `{0, π}`;
+2. strictly positive weights on odd support exclude `π` and select the zero
+   branch;
+3. an exact positive native-history pushforward with gcd-one populated support
+   likewise leaves only the zero relative branch;
+4. the reviewed single-plaquette CP-odd Wilson slot is rejected on the
+   canonical real-positive P1-P5 surface;
+5. operator-basis reality reduces each scalar mass phase to `{0, π}`;
+6. exact K-real `±iλ` pairing makes the determinant non-negative for both real
+   mass signs on the supplied Case-A surface; and
+7. the convention-aligned positive-real representative is `α_f = 0` for every
+   constructed flavor slot.
 
-These are part of the accepted action-surface definition. They are load-bearing
-for the closure claim, but the runner counts them as support/definition items
-rather than standalone theorem passes.
+The runner also admits one nonzero gauge theta probe and one nonzero complex
+mass-phase probe as data. Each check passes only by detecting the out-of-surface
+datum and printing the named conditional; neither probe is silently replaced
+by zero.
 
 ### Selected-surface compute checks
 
-1. free-field and gauged `Z^3` staggered determinant positivity,
-2. `3+1` APBC determinant positivity on sampled selected-surface `SU(3)`
+1. exact toy-scale construction of the candidate gauge and per-flavor mass
+   slots,
+2. exact algebraic Z2 collapse, positive-class zero-branch selection, and native
+   positive pushforward selection,
+3. exact operator-basis reality, K-real pairing, and positive-real
+   representative selection,
+4. detection and naming of deliberately admitted nonzero gauge and mass-phase
+   data,
+5. free-field and gauged `Z^3` staggered determinant positivity,
+6. `3+1` APBC determinant positivity on sampled selected-surface `SU(3)`
    configurations,
-3. sampled nontrivial topological charge without determinant phase generation,
-4. `εD + Dε = 0` on the selected `3+1` APBC surface,
-5. sampled exact `±λ` pairing of `iD`,
-6. sampled `Im Γ_f = 0`,
-7. sampled agreement between the spectral phase and the determinant phase,
-8. sampled axial-grid audit matches the exact statement that only `α ∈ πZ`
+7. sampled nontrivial topological charge without determinant phase generation,
+8. `εD + Dε = 0` on the selected `3+1` APBC surface,
+9. sampled exact `±λ` pairing of `iD`,
+10. sampled `Im Γ_f = 0`,
+11. sampled agreement between the spectral phase and the determinant phase,
+12. sampled axial-grid audit matches the exact statement that only `α ∈ πZ`
    preserves a real mass operator,
-9. explicit nontrivial axial rotation exits the selected scalar-mass action
+13. explicit nontrivial axial rotation exits the selected scalar-mass action
    class,
-10. the only admissible selected-surface axial endpoints keep zero determinant
+14. the only admissible selected-surface axial endpoints keep zero determinant
     phase,
-11. explicit positive-mass quark-surface audit gives `arg det(M_u M_d)=0`,
-12. sampled selected-surface effective action is real,
-13. linkwise complex conjugation preserves the full selected-surface effective
+15. the constructed positive-mass quark surface gives
+    `arg det(M_u M_d)=0`,
+16. sampled selected-surface effective action is real,
+17. linkwise complex conjugation preserves the full selected-surface effective
     action,
-14. sampled selected-surface positive-weight `Q`-weighted family obeys
+18. sampled selected-surface positive-weight `Q`-weighted family obeys
     `|Z(θ)| <= Z(0)`,
-15. the sampled selected-surface free energy is minimized at `θ = 0`.
+19. the sampled selected-surface free energy is minimized at `θ = 0`.
 
 ### Support only
 
@@ -321,8 +375,9 @@ These support items are not counted as theorem-grade closure.
 ## What Is Not Claimed
 
 1. **Unrestricted all-formulations closure.**
-   The theorem is only about the explicitly selected Wilson-plus-staggered
-   action surface on the `Z^3` spatial substrate.
+   The theorem is only about the cited-selected Wilson-plus-staggered / K-real
+   Case-A mass surface on the `Z^3` spatial substrate, with every cited
+   condition inherited.
 
 2. **Closed-form `Z_Q` measure on the selected lattice surface.**
    The closure uses positivity and the `θ`-sum bound, not a closed-form
@@ -339,9 +394,14 @@ These support items are not counted as theorem-grade closure.
    theorem and the relevant CKM package premises are both admitted, while
    the numerical `d_n(CKM)` scale remains EFT-bridged.
 
+5. **Closure after admitting excluded data.**
+   An admitted CP-odd action term, including an unreviewed topological slot, or
+   an admitted complex mass phase re-opens the question. The runner detects
+   those inputs; it does not remove them by definition.
+
 ## How This Changes The Paper
 
-The strong-CP lane has a bounded selected-surface closure package:
+The strong-CP lane has a bounded cited-selected-surface closure package:
 
 - fermion phase closure,
 - axial/chiral non-generation,
@@ -350,16 +410,18 @@ The strong-CP lane has a bounded selected-surface closure package:
 
 The safe paper sentence is:
 
-> On the explicitly `θ`-free Wilson-plus-staggered scalar-mass surface tested by
-> the runner, no additional strong-sector phase is generated: the determinant
-> phase vanishes, axial rotations preserving the scalar-mass surface do not move
-> phase into `θ`, exact fermion integration stays real, and positive sampled
-> topological weights place the selected-surface free-energy minimum at
-> `θ = 0`.
+> Conditional on the cited canonical positive gauge class, its character and
+> support hypotheses, and the supplied scalar-mass / K-real Case-A
+> determinant-channel conditions, the runner constructs the zero-branch action
+> surface and finds no additional generated strong-sector phase: the
+> determinant phase vanishes, admissible axial rotations do not move phase into
+> `θ`, exact fermion integration stays real, and positive sampled topological
+> weights place the selected-surface free-energy minimum at `θ = 0`.
 
 ## Experimental Predictions
 
-1. **`θ_eff = 0` exactly on the selected action surface.**
+1. **`θ_eff = 0` exactly on the cited-selected action surface, conditional on
+   all cited surface and channel conditions.**
 2. **`d_n(QCD) = 0` on that selected surface, conditional on the same surface
    premises.**
    The surviving observable neutron-EDM estimate is the separate CKM-only
@@ -384,11 +446,12 @@ The safe paper sentence is:
 python3 scripts/frontier_strong_cp_theta_zero.py
 # Exit code: 0
 # THEOREM PASS=13  FAIL=0
-# SELECTED-SURFACE COMPUTE PASS=30  FAIL=0
+# SELECTED-SURFACE COMPUTE PASS=42  FAIL=0
 # SUPPORT=4
+# TOTAL PASS=55  FAIL=0
 ```
 
-## Audit boundary (2026-04-28)
+## Historical audit boundary (2026-04-28)
 
 Audit verdict (`audited_conditional`, high criticality, 124 transitive
 descendants):
@@ -413,24 +476,25 @@ descendants):
 > is not yet an audited solution of strong CP beyond that selected
 > action surface.
 
-## What this note does NOT claim
+The 2026-07-12 repair responds to that historical wiring defect by citing the
+four bounded selection authorities and constructing the conditional basis in
+the runner. This source note does not set or predict the resulting audit
+status.
 
-- A derivation that the framework action surface forbids the CP-odd `F̃F`
-  term.
-- A derivation of the positive real quark-mass orientation
-  (`arg det(M_u M_d) = 0`) from the framework primitives.
-- A dynamical selection of θ = 0; the runner evaluates a θ-free
-  surface and finds no generated phase, but does not derive the
-  surface's exclusion of CP-odd terms.
+## Remaining conditional boundary
 
-## What would close this lane (Path A future work)
-
-Promoting from bounded conditional to a retained-grade proposal would require:
-
-1. A retained operator-basis / action-surface theorem deriving from
-   framework primitives and canonical normalization that no
-   gauge-invariant CP-odd θ term is an admissible slot.
-2. A registered positive real quark-mass orientation /
-   `arg det(M_u M_d) = 0` theorem as a dependency.
-3. An updated runner that constructs the allowed action basis and
-   fails if an `F̃F` term or complex mass phase is admitted.
+1. Gauge-side exclusion is no broader than the cited authorities: the
+   single-plaquette Wilson-slot theorem requires P1-P5; the character theorem
+   requires character form, orientation-evenness, odd support, and
+   positive-class membership; and the native theorem remains inside the
+   canonical imported Wilson + staggered-Wilson positive class while leaving
+   Q-structure existence and nonvacuity open.
+2. Mass-side selection retains the supplied scalar-mass boundary, the
+   convention-aligned positive representative, and the K-real Case-A
+   determinant-channel identification. The K-real pairing theorem fixes the
+   determinant phase for both real signs; it does not independently derive the
+   positive sign.
+3. An ADMITTED CP-odd action term or complex mass phase is outside the
+   constructed selected surface and re-opens the strong-CP question. A choice
+   to admit such data is not fixed by the supplied structure and remains a
+   named conditional or open dependency.

--- a/logs/runner-cache/frontier_strong_cp_theta_zero.txt
+++ b/logs/runner-cache/frontier_strong_cp_theta_zero.txt
@@ -1,51 +1,68 @@
-===== runner cache v1 =====
-runner: scripts/frontier_strong_cp_theta_zero.py
-runner_sha256: ccdff72e07c79e685e162b708e3ebfe9aadb137490f8836134b30b4babaa55f1
-timeout_sec: 120
-exit_code: 0
-elapsed_sec: 2.46
-status: ok
------ stdout -----
 ==============================================================================
-Strong CP / θ = 0 Bounded Selected-Surface Closure
+Strong CP / θ = 0 Bounded Cited-Selected-Surface Closure
 ==============================================================================
 
-CLAIM: On the explicitly θ-free Wilson-plus-staggered scalar-mass surface,
-       θ_eff = 0 with no surviving loophole from axial rephasing,
-       exact fermion integration, or positive-weight topological sectors.
+CLAIM: Conditional on the cited selectors' own surfaces and classes,
+       the constructed Wilson-plus-staggered / K-real Case-A mass surface
+       has θ_eff = 0 with no generated strong-sector phase.
+
+=== ACTION-BASIS CONSTRUCTION FROM CITED CONDITIONAL SELECTORS ===
+
+  [PASS] [COMPUTE] Candidate basis parameterizes the CP-even and CP-odd gauge slots  (gauge candidates = ('Wilson plaquette', 'i theta sum_P Im Tr U_P'))
+  [PASS] [COMPUTE] P1-P5 real-positive single-plaquette selector computes theta=0 for the reviewed CP-odd slot  (computed theta/pi branches = (Fraction(0, 1),))
+  [PASS] [COMPUTE] Exact Z2-character equation on odd support computes theta/pi in {0, 1}  (roots of z^2-1 mapped to theta/pi = (Fraction(0, 1), Fraction(1, 1)))
+  [PASS] [COMPUTE] Strict positivity on conjugation-paired odd support computes the zero branch  (computed theta/pi branches = (Fraction(0, 1),))
+  [PASS] [COMPUTE] Exact positive native pushforward with gcd-one support computes zero weighting  (m(q) = {-1: Fraction(3, 8), 0: Fraction(1, 3), 1: Fraction(3, 8)}; Delta = 1; branches = (Fraction(0, 1),))
+  [PASS] [COMPUTE] Candidate mass basis parameterizes alpha_f for every staggered flavor  (flavors = u, d, s, c, b, t)
+  [PASS] [COMPUTE] Operator-basis reality computes alpha_f/pi in {0, 1}  (computed real scalar phases = (Fraction(0, 1), Fraction(1, 1)))
+  [PASS] [COMPUTE] K-real +/-i lambda pairing computes zero determinant phase for both real signs  (exact det = m_f^2 + (3/2)^2 > 0 for every +/-m_f)
+  [PASS] [COMPUTE] Reality plus K-real zero-branch pairing constructs alpha_f=0 positive-real representatives  (pairing fixes arg det for both signs; supplied positive-mass convention fixes the representative)
+  [PASS] [COMPUTE] Constructed action basis contains no selected CP-odd or complex-mass slot  (theta/pi = 0; alpha_f/pi = [Fraction(0, 1), Fraction(0, 1), Fraction(0, 1), Fraction(0, 1), Fraction(0, 1), Fraction(0, 1)])
+  NAMED CONDITIONAL: an ADMITTED CP-odd action term or complex mass phase re-opens the strong-CP question.
+    detected admitted datum: theta/pi=1/3
+  [PASS] [COMPUTE] ADMITTED theta != 0 is detected and named without being zeroed  (retained admitted probe theta/pi = 1/3)
+  NAMED CONDITIONAL: an ADMITTED CP-odd action term or complex mass phase re-opens the strong-CP question.
+    detected admitted datum: alpha_u/pi=1/3
+  [PASS] [COMPUTE] ADMITTED alpha_f != 0 is detected and named without being zeroed  (retained admitted probe alpha_u/pi = 1/3)
+
+Constructed action conditions:
+  - canonical real-positive Wilson P1-P5 surface
+  - character form + orientation-evenness + odd support + positive class
+  - supplied scalar-mass class + positive-mass convention
+  - supplied K-real Case-A determinant-channel reading
 
 === LEG A: Fermion phase closure ===
 
   [PASS] [COMPUTE] Free staggered D is anti-Hermitian  (max |D + D†| = 0.00e+00)
-  [PASS] [COMPUTE] Free staggered D has purely imaginary eigenvalues  (max |Re eig| = 1.78e-15)
+  [PASS] [COMPUTE] Free staggered D has purely imaginary eigenvalues  (max |Re eig| = 2.00e-15)
   [PASS] [COMPUTE] Free det(D+mI) is real positive  (phase = 0.00e+00)
-  cfg 0: max|D+D†| = 0.00e+00, |phase| = 3.01e-15
-  cfg 1: max|D+D†| = 0.00e+00, |phase| = 7.53e-17
+  cfg 0: max|D+D†| = 0.00e+00, |phase| = 6.91e-15
+  cfg 1: max|D+D†| = 0.00e+00, |phase| = 5.58e-15
   [PASS] [COMPUTE] Gauged Z^3 staggered D[U] stays anti-Hermitian  (max |D + D†| = 0.00e+00)
-  [PASS] [COMPUTE] Gauged Z^3 det(D[U]+mI) stays real positive  (max |phase| = 3.01e-15)
-  [PASS] [COMPUTE] Complex mass control produces a determinant phase  (|phase| = 1.2422)
-  3+1 cfg 0: max|D+D†| = 0.00e+00, |phase| = 8.84e-15, Q = 0.0292
-  3+1 cfg 1: max|D+D†| = 0.00e+00, |phase| = 2.13e-14, Q = 0.0011
+  [PASS] [COMPUTE] Gauged Z^3 det(D[U]+mI) stays real positive  (max |phase| = 6.91e-15)
+  [PASS] [COMPUTE] Complex mass control produces a determinant phase  (|phase| = 1.2168)
+  3+1 cfg 0: max|D+D†| = 0.00e+00, |phase| = 7.12e-15, Q = 0.0292
+  3+1 cfg 1: max|D+D†| = 0.00e+00, |phase| = 7.24e-15, Q = 0.0011
   [PASS] [COMPUTE] 3+1 APBC staggered D[U] stays anti-Hermitian  (max |D + D†| = 0.00e+00)
-  [PASS] [COMPUTE] 3+1 APBC det(D+mI) stays real positive  (max |phase| = 2.13e-14)
+  [PASS] [COMPUTE] 3+1 APBC det(D+mI) stays real positive  (max |phase| = 1.70e-14)
   [PASS] [COMPUTE] Nontrivial 3+1 topological-charge samples do not induce a determinant phase  (Q range = [-0.038, 0.029])
   [PASS] [COMPUTE] εD + Dε = 0 on the selected 3+1 APBC surface  (max |εD + Dε| = 0.00e+00)
-  spectral cfg 0: pair=1.07e-14, ImΓ=-1.14e-13, det phase=3.16e-16
-  spectral cfg 1: pair=1.15e-14, ImΓ=1.14e-13, det phase=8.27e-15
-  [PASS] [COMPUTE] ±λ spectral pairing holds on sampled 3+1 APBC configurations  (max |λ_k + λ_(N-1-k)| = 2.04e-14)
-  [PASS] [COMPUTE] Im Γ_f vanishes on sampled 3+1 APBC configurations  (max |Im Γ_f| = 1.14e-13)
-  [PASS] [COMPUTE] Spectral phase matches the determinant phase of det(D+mI)  (max wrapped |arg det + Im Γ_f| = 1.22e-13)
+  spectral cfg 0: pair=1.33e-14, ImΓ=2.27e-13, det phase=-8.46e-16
+  spectral cfg 1: pair=1.38e-14, ImΓ=1.14e-13, det phase=-8.55e-15
+  [PASS] [COMPUTE] ±λ spectral pairing holds on sampled 3+1 APBC configurations  (max |λ_k + λ_(N-1-k)| = 1.82e-14)
+  [PASS] [COMPUTE] Im Γ_f vanishes on sampled 3+1 APBC configurations  (max |Im Γ_f| = 2.27e-13)
+  [PASS] [COMPUTE] Spectral phase matches the determinant phase of det(D+mI)  (max wrapped |arg det + Im Γ_f| = 2.27e-13)
 
 === LEG B: Axial / chiral non-generation ===
 
   [PASS] [THEOREM] Sublattice generator obeys ε² = I  (max |ε²-I| = 0.00e+00)
   [PASS] [THEOREM] Axial rotation U_α is unitary  (max |U U† - I| = 0.00e+00)
   [PASS] [THEOREM] Axial rotation leaves the selected kinetic operator invariant  (max |U_α D U_α - D| = 1.16e-16)
-  [PASS] [THEOREM] Rotated mass operator is exactly m(cos α I + i sin α ε)  (max residual = 1.96e-17)
+  [PASS] [THEOREM] Rotated mass operator is exactly m(cos α I + i sin α ε)  (max residual = 1.39e-17)
   [PASS] [COMPUTE] Sampled axial grid only preserves a real mass operator at α ∈ {0, π}  (grid audit matches the exact m(cos α I + i sin α ε) formula)
-  [PASS] [COMPUTE] Nontrivial axial rotation generates an imaginary pseudoscalar mass component  (max |Im M_α| = 7.071e-02)
-  [PASS] [COMPUTE] Nontrivial axial rotation exits the selected scalar-mass action class  (max |M_α - m cos(α) I| = 7.071e-02; |arg det| = 5.32e-15)
-  [PASS] [COMPUTE] The only admissible selected-surface axial endpoints keep the determinant phase zero  (max endpoint |phase| = 1.22e-14)
+  [PASS] [COMPUTE] Nontrivial axial rotation generates an imaginary pseudoscalar mass component  (max |Im M_α| = 6.788e-02)
+  [PASS] [COMPUTE] Nontrivial axial rotation exits the selected scalar-mass action class  (max |M_α - m cos(α) I| = 6.788e-02; |arg det| = 1.89e-14)
+  [PASS] [COMPUTE] The only admissible selected-surface axial endpoints keep the determinant phase zero  (max endpoint |phase| = 9.35e-15)
 
 === Weak-sector-only CP source ===
 
@@ -63,26 +80,26 @@ CLAIM: On the explicitly θ-free Wilson-plus-staggered scalar-mass surface,
 
   [PASS] [THEOREM] Selected action surface has 5 explicit inputs  ((1) one-qubit operator algebra; (2) Z^3 spatial substrate; (3) finite Grassmann / staggered-Dirac partition; (4) physical lattice reading; (5) canonical normalization: g_bare = 1, plaquette / u₀ surface)
   [PASS] [THEOREM] Canonical normalization fixes Wilson β = 6  (β = 6.000000000000)
-  [INFO] [SUPPORT] No bare θ slot is present in the selected action-class definition  (slots = ['beta', 'fermion', 'gauge', 'mass'])
-  cfg 0: Im S_eff = -1.49e-14, S_eff(U)-S_eff(U*) = 2.97e-14
-  cfg 1: Im S_eff = -5.97e-15, S_eff(U)-S_eff(U*) = 1.19e-14
+  [INFO] [SUPPORT] The cited selectors construct no admitted bare theta slot  (theta/pi = 0; gauge slots = ('Wilson plaquette',))
+  cfg 0: Im S_eff = -1.47e-15, S_eff(U)-S_eff(U*) = 2.95e-15
+  cfg 1: Im S_eff = -7.53e-15, S_eff(U)-S_eff(U*) = 1.51e-14
   [PASS] [COMPUTE] Wilson gauge action is real on sampled selected 3+1 configurations  (max |Im S_gauge| = 0.00e+00)
-  [PASS] [COMPUTE] Exact selected effective action is real on sampled selected 3+1 configurations  (max |Im S_eff| = 1.90e-14)
+  [PASS] [COMPUTE] Exact selected effective action is real on sampled selected 3+1 configurations  (max |Im S_eff| = 1.62e-14)
   [PASS] [COMPUTE] Linkwise complex conjugation preserves the Wilson gauge action  (max |S_gauge(U)-S_gauge(U*)| = 0.00e+00)
   [PASS] [COMPUTE] Linkwise complex conjugation preserves the exact fermion effective action  (max |log|det|(U)-log|det|(U*)| = 0.00e+00)
-  [PASS] [COMPUTE] Linkwise complex conjugation preserves the full selected effective action  (max |S_eff(U)-S_eff(U*)| = 3.80e-14)
+  [PASS] [COMPUTE] Linkwise complex conjugation preserves the full selected effective action  (max |S_eff(U)-S_eff(U*)| = 3.24e-14)
 
 === LEG D: Topological-sector positivity and θ = 0 minimum ===
 
-  sample 0: Q = -0.0030, log weight = 27.854
-  sample 1: Q = -0.0214, log weight = -85.001
-  [PASS] [COMPUTE] Sampled positive-weight Q-weighted family is strictly positive  (min shifted weight = 1.659e-60)
+  sample 0: Q = -0.0030, log weight = 25.882
+  sample 1: Q = -0.0214, log weight = -86.985
+  [PASS] [COMPUTE] Sampled positive-weight Q-weighted family is strictly positive  (min shifted weight = 1.685e-60)
   [PASS] [COMPUTE] Sampled positive-weight θ-sum obeys |Z(θ)| <= Z(0)  (max (|Z|-Z0) = 0.00e+00)
   [PASS] [COMPUTE] Sampled θ-sum free energy is minimized at θ = 0  (min(F(θ)-F(0)) = 0.00e+00)
 
 === COMBINED RESULT: θ_eff = 0 ===
 
-  [INFO] [SUPPORT] θ_bare = 0 is taken from the selected action-class definition  (no bare θ slot appears in the selected Wilson-plus-staggered scalar-mass action)
+  [INFO] [SUPPORT] theta_bare = 0 is read from the constructed cited-selected basis  (computed theta/pi = 0)
   [PASS] [COMPUTE] Explicit positive-mass quark surface gives arg det(M_u M_d) = 0  (|arg det| = 0.00e+00)
   [PASS] [COMPUTE] Combined selected-surface synthesis gives θ_eff = 0  (0.0 + 0.0 = 0.0)
   [PASS] [COMPUTE] Selected-surface closure is consistent with the neutron-EDM bound  (|θ_eff| = 0.0e+00 < 1.0e-10)
@@ -94,14 +111,12 @@ CLAIM: On the explicitly θ-free Wilson-plus-staggered scalar-mass surface,
 
 ==============================================================================
 THEOREM PASS=13  FAIL=0
-SELECTED-SURFACE COMPUTE PASS=30  FAIL=0
+SELECTED-SURFACE COMPUTE PASS=42  FAIL=0
 SUPPORT=4
+TOTAL PASS=55  FAIL=0
 ==============================================================================
 
-All selected action-surface closure checks passed. The strong sector closes at
-θ_eff = 0 on the selected Wilson-plus-staggered scalar-mass surface, while
-CKM CP remains weak-sector only and the surviving neutron-EDM signal
+All cited-selected action-surface closure checks passed. Conditional on
+the printed surfaces and classes, the strong sector closes at θ_eff = 0,
+while CKM CP remains weak-sector only and the surviving neutron-EDM signal
 stays in the separate bounded CKM lane.
-
------ stderr -----
-

--- a/logs/runner-cache/frontier_strong_cp_theta_zero.txt
+++ b/logs/runner-cache/frontier_strong_cp_theta_zero.txt
@@ -1,5 +1,5 @@
 ==============================================================================
-Strong CP / θ = 0 Bounded Cited-Selected-Surface Closure
+Strong CP / θ = 0 Bounded Selected-Action-Surface Closure
 ==============================================================================
 
 CLAIM: Conditional on the cited selectors' own surfaces and classes,
@@ -99,7 +99,7 @@ Constructed action conditions:
 
 === COMBINED RESULT: θ_eff = 0 ===
 
-  [INFO] [SUPPORT] theta_bare = 0 is read from the constructed cited-selected basis  (computed theta/pi = 0)
+  [INFO] [SUPPORT] theta_bare = 0 is read from the constructed bounded selected basis  (computed theta/pi = 0)
   [PASS] [COMPUTE] Explicit positive-mass quark surface gives arg det(M_u M_d) = 0  (|arg det| = 0.00e+00)
   [PASS] [COMPUTE] Combined selected-surface synthesis gives θ_eff = 0  (0.0 + 0.0 = 0.0)
   [PASS] [COMPUTE] Selected-surface closure is consistent with the neutron-EDM bound  (|θ_eff| = 0.0e+00 < 1.0e-10)
@@ -116,7 +116,7 @@ SUPPORT=4
 TOTAL PASS=55  FAIL=0
 ==============================================================================
 
-All cited-selected action-surface closure checks passed. Conditional on
+All bounded selected action-surface closure checks passed. Conditional on
 the printed surfaces and classes, the strong sector closes at θ_eff = 0,
 while CKM CP remains weak-sector only and the surviving neutron-EDM signal
 stays in the separate bounded CKM lane.

--- a/scripts/frontier_strong_cp_theta_zero.py
+++ b/scripts/frontier_strong_cp_theta_zero.py
@@ -3,12 +3,12 @@
 Strong CP / θ = 0 Bounded Selected-Surface Closure
 ==================================================
 
-STATUS: bounded selected-surface closure on the explicitly θ-free
-Wilson-plus-staggered scalar-mass action surface
+STATUS: bounded cited-selected-surface closure on the conditional
+Wilson-plus-staggered / K-real Case-A mass action surface
 
 TARGET CLAIM:
-  On the explicitly θ-free Wilson-plus-staggered scalar-mass surface on the
-  Z^3 spatial substrate,
+  On the cited-selected Wilson-plus-staggered / K-real Case-A mass surface on
+  the Z^3 spatial substrate,
   θ_eff = 0 with no surviving loophole from:
 
     (A) fermion determinant / effective-action phase,
@@ -17,12 +17,18 @@ TARGET CLAIM:
     (D) positive-weight topological-sector weighting away from θ = 0.
 
 SCOPE:
-  This is a bounded selected-surface closure package, not a universal
-  all-formulations strong-CP theorem and not a retained-status claim.
+  This is a bounded cited-selected-surface closure package, conditional on
+  the cited authorities' own positive-class, character/support,
+  single-plaquette, scalar-mass, and K-real Case-A conditions. It is not a
+  universal all-formulations strong-CP theorem or an audit-status claim.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass, replace
+from fractions import Fraction
+from functools import reduce
+from math import gcd, isqrt
 import sys
 import numpy as np
 
@@ -37,6 +43,369 @@ COUNTS = {
     "SELECTED-SURFACE COMPUTE FAIL": 0,
     "SUPPORT": 0,
 }
+
+NAMED_CONDITIONAL_LINE = (
+    "NAMED CONDITIONAL: an ADMITTED CP-odd action term or complex mass phase "
+    "re-opens the strong-CP question."
+)
+
+
+@dataclass(frozen=True)
+class FlavorMassSlot:
+    """One candidate staggered-flavor scalar mass m_f exp(i pi alpha_f)."""
+
+    flavor: str
+    magnitude: Fraction
+    alpha_over_pi: Fraction
+
+
+@dataclass(frozen=True)
+class CandidateSlotSpace:
+    """Candidate action slots before the cited conditional selectors act."""
+
+    cp_even_gauge_slots: tuple[str, ...]
+    cp_odd_gauge_slot: str
+    theta_probe_values_over_pi: tuple[Fraction, ...]
+    alpha_probe_values_over_pi: tuple[Fraction, ...]
+    flavor_magnitudes: tuple[tuple[str, Fraction], ...]
+
+
+@dataclass(frozen=True)
+class ConstructedActionBasis:
+    """Action basis returned by, rather than supplied to, the selection checks."""
+
+    gauge_slots: tuple[str, ...]
+    theta_over_pi: Fraction
+    mass_slots: tuple[FlavorMassSlot, ...]
+    conditions: tuple[str, ...]
+
+
+def phase_mod_two(phase_over_pi):
+    """Canonical exact representative of a phase measured in units of pi."""
+    return phase_over_pi % 2
+
+
+def solve_linear_zero(slope, intercept=Fraction(0)):
+    """Solve slope*x + intercept = 0 in exact rational arithmetic."""
+    if slope == 0:
+        raise ValueError("linear selector has zero slope")
+    return -intercept / slope
+
+
+def exact_z2_phase_branches():
+    """Solve z^2 - 1 = 0 exactly and map z=exp(i theta) to theta/pi."""
+    a, b, c = Fraction(1), Fraction(0), Fraction(-1)
+    discriminant = b * b - 4 * a * c
+    if discriminant.denominator != 1:
+        raise ValueError("Z2 character discriminant is not integral")
+    sqrt_discriminant = isqrt(discriminant.numerator)
+    if sqrt_discriminant**2 != discriminant.numerator:
+        raise ValueError("Z2 character discriminant is not a perfect square")
+    roots = (
+        (-b + sqrt_discriminant) / (2 * a),
+        (-b - sqrt_discriminant) / (2 * a),
+    )
+    phase_by_root = {Fraction(1): Fraction(0), Fraction(-1): Fraction(1)}
+    return tuple(sorted(phase_by_root[root] for root in roots))
+
+
+def character_is_orientation_even(theta_over_pi, support):
+    """Exact test of exp(i theta Q) = exp(-i theta Q) on integer support."""
+    return all((theta_over_pi * q).denominator == 1 for q in support)
+
+
+def integer_character_sign(theta_over_pi, q):
+    """Exact +/-1 value after the orientation-even character collapse."""
+    exponent = theta_over_pi * q
+    if exponent.denominator != 1:
+        raise ValueError("character has not collapsed to the real Z2 branches")
+    return 1 if exponent.numerator % 2 == 0 else -1
+
+
+def positive_character_branches(branches, sector_masses):
+    """Keep only collapsed characters preserving every populated positive mass."""
+    return tuple(
+        theta
+        for theta in branches
+        if all(
+            mass > 0 and integer_character_sign(theta, q) * mass > 0
+            for q, mass in sector_masses.items()
+            if mass > 0
+        )
+    )
+
+
+def exact_sector_pushforward(histories):
+    """Push exact positive native-history weights to integer-sector masses."""
+    masses = {}
+    for q, weight in histories:
+        if weight < 0:
+            raise ValueError("native positive-class toy history has negative weight")
+        masses[q] = masses.get(q, Fraction(0)) + weight
+    return masses
+
+
+def support_gcd(sector_masses):
+    """GCD of differences on populated integer support."""
+    support = sorted(q for q, mass in sector_masses.items() if mass > 0)
+    if len(support) < 2:
+        return 0
+    q0 = support[0]
+    return reduce(gcd, (abs(q - q0) for q in support[1:]))
+
+
+def positive_relative_zero_branches(sector_masses):
+    """Solve the native positive relative-phase condition on gcd-one support."""
+    populated = {q: mass for q, mass in sector_masses.items() if mass > 0}
+    if any(mass < 0 for mass in sector_masses.values()) or support_gcd(populated) != 1:
+        return tuple()
+    # For gcd-one support the relative unit character z must itself be a
+    # positive real unit. The exact linear equation is z - 1 = 0.
+    z = solve_linear_zero(Fraction(1), Fraction(-1))
+    return (Fraction(0),) if z == 1 else tuple()
+
+
+def scalar_phase_is_real(alpha_over_pi):
+    """Exact reality test for m exp(i pi alpha), m > 0."""
+    return phase_mod_two(alpha_over_pi).denominator == 1
+
+
+def scalar_phase_is_positive_real(alpha_over_pi):
+    """Exact supplied/convention-aligned positive-real representative test."""
+    return phase_mod_two(alpha_over_pi) == 0
+
+
+def mass_slot_value(slot):
+    """Numerical coefficient used only after exact phase selection."""
+    return float(slot.magnitude) * np.exp(1j * np.pi * float(slot.alpha_over_pi))
+
+
+def mass_slot(action_basis, flavor):
+    """Look up a constructed flavor slot."""
+    return next(slot for slot in action_basis.mass_slots if slot.flavor == flavor)
+
+
+def selected_real_mass(action_basis, flavor="s"):
+    """Return a real mass from the constructed positive-real surface."""
+    slot = mass_slot(action_basis, flavor)
+    value = mass_slot_value(slot)
+    if slot.alpha_over_pi != 0 or abs(value.imag) > 1e-15 or value.real <= 0:
+        raise ValueError("closure leg received a mass outside the constructed surface")
+    return float(value.real)
+
+
+def quark_mass_matrices(action_basis):
+    """Build the up/down mass matrices from the constructed flavor slots."""
+    values = {slot.flavor: mass_slot_value(slot) for slot in action_basis.mass_slots}
+    return (
+        np.diag([values["u"], values["c"], values["t"]]),
+        np.diag([values["d"], values["s"], values["b"]]),
+    )
+
+
+def candidate_slot_space():
+    """Parameterize, rather than pre-delete, the theta and alpha_f slots."""
+    rational_phase_grid = tuple(Fraction(k, 4) for k in range(8))
+    return CandidateSlotSpace(
+        cp_even_gauge_slots=("Wilson plaquette",),
+        cp_odd_gauge_slot="i theta sum_P Im Tr U_P",
+        theta_probe_values_over_pi=rational_phase_grid,
+        alpha_probe_values_over_pi=rational_phase_grid,
+        flavor_magnitudes=(
+            ("u", Fraction(11, 5000)),
+            ("d", Fraction(47, 10000)),
+            ("s", Fraction(12, 125)),
+            ("c", Fraction(127, 100)),
+            ("b", Fraction(209, 50)),
+            ("t", Fraction(1731, 10)),
+        ),
+    )
+
+
+def detect_admitted_named_conditional(action_basis):
+    """Detect admitted out-of-surface data without modifying it."""
+    reasons = []
+    if action_basis.theta_over_pi != 0:
+        reasons.append(f"theta/pi={action_basis.theta_over_pi}")
+    reasons.extend(
+        f"alpha_{slot.flavor}/pi={slot.alpha_over_pi}"
+        for slot in action_basis.mass_slots
+        if slot.alpha_over_pi != 0
+    )
+    if reasons:
+        print(f"  {NAMED_CONDITIONAL_LINE}")
+        print(f"    detected admitted datum: {', '.join(reasons)}")
+    return tuple(reasons)
+
+
+def construct_allowed_action_basis():
+    """Compute the bounded allowed basis from the cited selection statements."""
+    print("\n=== ACTION-BASIS CONSTRUCTION FROM CITED CONDITIONAL SELECTORS ===\n")
+
+    candidates = candidate_slot_space()
+    check(
+        "Candidate basis parameterizes the CP-even and CP-odd gauge slots",
+        candidates.cp_even_gauge_slots == ("Wilson plaquette",)
+        and "theta" in candidates.cp_odd_gauge_slot
+        and len(candidates.theta_probe_values_over_pi) > 2,
+        f"gauge candidates = {candidates.cp_even_gauge_slots + (candidates.cp_odd_gauge_slot,)}",
+        bucket="COMPUTE",
+    )
+
+    # On generic real Q_lat, Im(i theta Q_lat) has exact linear coefficient
+    # theta. P4 therefore solves theta=0; no finite phase grid is used here.
+    real_positive_single_plaquette = (solve_linear_zero(Fraction(1)),)
+    check(
+        "P1-P5 real-positive single-plaquette selector computes theta=0 for the reviewed CP-odd slot",
+        real_positive_single_plaquette == (Fraction(0),),
+        f"computed theta/pi branches = {real_positive_single_plaquette}",
+        bucket="COMPUTE",
+    )
+
+    odd_support = (-1, 0, 1)
+    collapsed = (
+        exact_z2_phase_branches()
+        if any(abs(q) % 2 == 1 for q in odd_support)
+        else tuple()
+    )
+    check(
+        "Exact Z2-character equation on odd support computes theta/pi in {0, 1}",
+        collapsed == (Fraction(0), Fraction(1))
+        and all(character_is_orientation_even(theta, odd_support) for theta in collapsed),
+        f"roots of z^2-1 mapped to theta/pi = {collapsed}",
+        bucket="COMPUTE",
+    )
+
+    conjugation_paired_positive_masses = {
+        -1: Fraction(3, 8),
+        0: Fraction(5, 4),
+        1: Fraction(3, 8),
+    }
+    positive_selected = positive_character_branches(
+        collapsed, conjugation_paired_positive_masses
+    )
+    check(
+        "Strict positivity on conjugation-paired odd support computes the zero branch",
+        positive_selected == (Fraction(0),),
+        f"computed theta/pi branches = {positive_selected}",
+        bucket="COMPUTE",
+    )
+
+    native_histories = (
+        (-1, Fraction(1, 8)),
+        (-1, Fraction(1, 4)),
+        (0, Fraction(1, 3)),
+        (1, Fraction(3, 8)),
+    )
+    native_sector_masses = exact_sector_pushforward(native_histories)
+    native_gcd = support_gcd(native_sector_masses)
+    native_selected = positive_relative_zero_branches(native_sector_masses)
+    check(
+        "Exact positive native pushforward with gcd-one support computes zero weighting",
+        native_gcd == 1 and native_selected == (Fraction(0),),
+        f"m(q) = {native_sector_masses}; Delta = {native_gcd}; branches = {native_selected}",
+        bucket="COMPUTE",
+    )
+
+    check(
+        "Candidate mass basis parameterizes alpha_f for every staggered flavor",
+        len(candidates.flavor_magnitudes) == 6
+        and all(magnitude > 0 for _, magnitude in candidates.flavor_magnitudes)
+        and len(candidates.alpha_probe_values_over_pi) > 2,
+        "flavors = " + ", ".join(flavor for flavor, _ in candidates.flavor_magnitudes),
+        bucket="COMPUTE",
+    )
+
+    # A unit scalar phase is real iff z=conj(z), hence z^2=1. Solve that
+    # equation exactly rather than filtering the toy probe grid.
+    real_scalar_phases = exact_z2_phase_branches()
+    check(
+        "Operator-basis reality computes alpha_f/pi in {0, 1}",
+        real_scalar_phases == (Fraction(0), Fraction(1)),
+        f"computed real scalar phases = {real_scalar_phases}",
+        bucket="COMPUTE",
+    )
+
+    pairing_lambda = Fraction(3, 2)
+    k_real_determinants = {}
+    for flavor, magnitude in candidates.flavor_magnitudes:
+        k_real_determinants[(flavor, "+")] = magnitude**2 + pairing_lambda**2
+        k_real_determinants[(flavor, "-")] = (-magnitude) ** 2 + pairing_lambda**2
+    pairing_forces_zero = all(det > 0 for det in k_real_determinants.values()) and all(
+        k_real_determinants[(flavor, "+")] == k_real_determinants[(flavor, "-")]
+        for flavor, _ in candidates.flavor_magnitudes
+    )
+    check(
+        "K-real +/-i lambda pairing computes zero determinant phase for both real signs",
+        pairing_forces_zero,
+        "exact det = m_f^2 + (3/2)^2 > 0 for every +/-m_f",
+        bucket="COMPUTE",
+    )
+
+    positive_real_phases = tuple(
+        alpha for alpha in real_scalar_phases if scalar_phase_is_positive_real(alpha)
+    )
+    check(
+        "Reality plus K-real zero-branch pairing constructs alpha_f=0 positive-real representatives",
+        pairing_forces_zero and positive_real_phases == (Fraction(0),),
+        "pairing fixes arg det for both signs; supplied positive-mass convention fixes the representative",
+        bucket="COMPUTE",
+    )
+
+    selected_gauge_branches = tuple(
+        theta for theta in positive_selected if theta in real_positive_single_plaquette
+    )
+    selected_theta = selected_gauge_branches[0]
+    selected_alpha = positive_real_phases[0]
+    selected = ConstructedActionBasis(
+        gauge_slots=candidates.cp_even_gauge_slots,
+        theta_over_pi=selected_theta,
+        mass_slots=tuple(
+            FlavorMassSlot(flavor, magnitude, selected_alpha)
+            for flavor, magnitude in candidates.flavor_magnitudes
+        ),
+        conditions=(
+            "canonical real-positive Wilson P1-P5 surface",
+            "character form + orientation-evenness + odd support + positive class",
+            "supplied scalar-mass class + positive-mass convention",
+            "supplied K-real Case-A determinant-channel reading",
+        ),
+    )
+    check(
+        "Constructed action basis contains no selected CP-odd or complex-mass slot",
+        selected.theta_over_pi == 0
+        and candidates.cp_odd_gauge_slot not in selected.gauge_slots
+        and all(slot.alpha_over_pi == 0 for slot in selected.mass_slots),
+        f"theta/pi = {selected.theta_over_pi}; alpha_f/pi = {[slot.alpha_over_pi for slot in selected.mass_slots]}",
+        bucket="COMPUTE",
+    )
+
+    theta_probe = replace(
+        selected,
+        gauge_slots=selected.gauge_slots + (candidates.cp_odd_gauge_slot,),
+        theta_over_pi=Fraction(1, 3),
+    )
+    theta_reasons = detect_admitted_named_conditional(theta_probe)
+    check(
+        "ADMITTED theta != 0 is detected and named without being zeroed",
+        theta_probe.theta_over_pi == Fraction(1, 3)
+        and theta_reasons == ("theta/pi=1/3",),
+        f"retained admitted probe theta/pi = {theta_probe.theta_over_pi}",
+        bucket="COMPUTE",
+    )
+
+    complex_u = replace(selected.mass_slots[0], alpha_over_pi=Fraction(1, 3))
+    alpha_probe = replace(selected, mass_slots=(complex_u,) + selected.mass_slots[1:])
+    alpha_reasons = detect_admitted_named_conditional(alpha_probe)
+    check(
+        "ADMITTED alpha_f != 0 is detected and named without being zeroed",
+        complex_u.alpha_over_pi == Fraction(1, 3)
+        and alpha_reasons == ("alpha_u/pi=1/3",),
+        f"retained admitted probe alpha_u/pi = {complex_u.alpha_over_pi}",
+        bucket="COMPUTE",
+    )
+
+    return selected
 
 
 def safe_slogdet(M):
@@ -314,11 +683,11 @@ def effective_action_3p1(U_links, L_s, L_t, mass, beta=None):
     }
 
 
-def test_leg_a_fermion_phase_closure():
+def test_leg_a_fermion_phase_closure(action_basis):
     print("\n=== LEG A: Fermion phase closure ===\n")
 
     rng = np.random.default_rng(42)
-    mass = 0.1
+    mass = selected_real_mass(action_basis)
     L = 4
     N = L ** 3 * 3
 
@@ -419,12 +788,12 @@ def test_leg_a_fermion_phase_closure():
     check("Spectral phase matches the determinant phase of det(D+mI)", max_phase_match < 1e-10, f"max wrapped |arg det + Im Γ_f| = {max_phase_match:.2e}", bucket="COMPUTE")
 
 
-def test_leg_b_chiral_basis_non_generation():
+def test_leg_b_chiral_basis_non_generation(action_basis):
     print("\n=== LEG B: Axial / chiral non-generation ===\n")
 
     L_s = 4
     L_t = 4
-    mass = 0.1
+    mass = selected_real_mass(action_basis)
     rng = np.random.default_rng(314159)
     U = random_gauge_config_3p1(L_s, L_t, rng)
     D = build_staggered_dirac_3p1(L_s, L_t, U)
@@ -489,7 +858,7 @@ def test_leg_b_chiral_basis_non_generation():
     check("The only admissible selected-surface axial endpoints keep the determinant phase zero", max(phase_endpoints) < 1e-10, f"max endpoint |phase| = {max(phase_endpoints):.2e}", bucket="COMPUTE")
 
 
-def test_weak_sector_separation():
+def test_weak_sector_separation(action_basis):
     print("\n=== Weak-sector-only CP source ===\n")
 
     vertices = [(a1, a2, a3) for a1 in (0, 1) for a2 in (0, 1) for a3 in (0, 1)]
@@ -565,13 +934,12 @@ def test_weak_sector_separation():
 
     y_t = 0.9176
     check("Selected Yukawa/top lane keeps the quark masses real and positive", y_t > 0 and np.isreal(y_t), f"y_t = {y_t}", bucket="COMPUTE")
-    M_u = np.diag([2.2e-3, 1.27, 173.10])
-    M_d = np.diag([4.7e-3, 9.6e-2, 4.18])
+    M_u, M_d = quark_mass_matrices(action_basis)
     arg_det_md = abs(float(np.angle(np.linalg.det(M_u @ M_d))))
     check("arg det(M_u M_d) = 0 on an explicit positive-mass quark surface", arg_det_md < 1e-12, f"|arg det| = {arg_det_md:.2e}", bucket="COMPUTE")
 
 
-def test_leg_c_effective_action_cp_even():
+def test_leg_c_effective_action_cp_even(action_basis):
     print("\n=== LEG C: Gauge-sector radiative non-generation ===\n")
 
     axioms = [
@@ -582,15 +950,24 @@ def test_leg_c_effective_action_cp_even():
         "canonical normalization: g_bare = 1, plaquette / u₀ surface",
     ]
     beta = 6.0 / (4.0 * np.pi * CANONICAL_ALPHA_BARE)
-    action_slots = {"gauge": "Wilson plaquette", "fermion": "staggered Dirac", "beta": beta, "mass": "real"}
+    action_slots = {
+        "gauge": action_basis.gauge_slots,
+        "fermion": "staggered Dirac",
+        "beta": beta,
+        "theta_over_pi": action_basis.theta_over_pi,
+        "mass_slots": action_basis.mass_slots,
+    }
 
     check(f"Selected action surface has {len(axioms)} explicit inputs", len(axioms) == 5, "; ".join(f"({i+1}) {a}" for i, a in enumerate(axioms)))
     check("Canonical normalization fixes Wilson β = 6", abs(beta - 6.0) < 1e-12, f"β = {beta:.12f}")
-    support("No bare θ slot is present in the selected action-class definition", f"slots = {sorted(action_slots)}")
+    support(
+        "The cited selectors construct no admitted bare theta slot",
+        f"theta/pi = {action_basis.theta_over_pi}; gauge slots = {action_basis.gauge_slots}",
+    )
 
     L_s = 4
     L_t = 4
-    mass = 0.1
+    mass = selected_real_mass(action_basis)
     rng = np.random.default_rng(12345)
     n_configs = 4
 
@@ -626,12 +1003,12 @@ def test_leg_c_effective_action_cp_even():
     check("Linkwise complex conjugation preserves the full selected effective action", max_seff_cp < 1e-10, f"max |S_eff(U)-S_eff(U*)| = {max_seff_cp:.2e}", bucket="COMPUTE")
 
 
-def test_leg_d_topological_sector_positivity():
+def test_leg_d_topological_sector_positivity(action_basis):
     print("\n=== LEG D: Topological-sector positivity and θ = 0 minimum ===\n")
 
     L_s = 4
     L_t = 4
-    mass = 0.1
+    mass = selected_real_mass(action_basis)
     beta = 6.0 / (4.0 * np.pi * CANONICAL_ALPHA_BARE)
     rng = np.random.default_rng(20260417)
     n_samples = 8
@@ -668,17 +1045,19 @@ def test_leg_d_topological_sector_positivity():
     check("Sampled θ-sum free energy is minimized at θ = 0", min_residual > -1e-10, f"min(F(θ)-F(0)) = {min_residual:.2e}", bucket="COMPUTE")
 
 
-def test_combined_theta_eff():
+def test_combined_theta_eff(action_basis):
     print("\n=== COMBINED RESULT: θ_eff = 0 ===\n")
 
-    theta_bare = 0.0
-    M_u = np.diag([2.2e-3, 1.27, 173.10])
-    M_d = np.diag([4.7e-3, 9.6e-2, 4.18])
+    theta_bare = np.pi * float(action_basis.theta_over_pi)
+    M_u, M_d = quark_mass_matrices(action_basis)
     arg_det_M = float(np.angle(np.linalg.det(M_u @ M_d)))
     theta_eff = theta_bare + arg_det_M
     theta_exp_bound = 1e-10
 
-    support("θ_bare = 0 is taken from the selected action-class definition", "no bare θ slot appears in the selected Wilson-plus-staggered scalar-mass action")
+    support(
+        "theta_bare = 0 is read from the constructed cited-selected basis",
+        f"computed theta/pi = {action_basis.theta_over_pi}",
+    )
     check("Explicit positive-mass quark surface gives arg det(M_u M_d) = 0", abs(arg_det_M) < 1e-12, f"|arg det| = {abs(arg_det_M):.2e}", bucket="COMPUTE")
     check("Combined selected-surface synthesis gives θ_eff = 0", abs(theta_eff) < 1e-12, f"{theta_bare} + {arg_det_M} = {theta_eff}", bucket="COMPUTE")
     check("Selected-surface closure is consistent with the neutron-EDM bound", abs(theta_eff) < theta_exp_bound, f"|θ_eff| = {abs(theta_eff):.1e} < {theta_exp_bound:.1e}", bucket="COMPUTE")
@@ -686,19 +1065,24 @@ def test_combined_theta_eff():
 
 def main():
     print("=" * 78)
-    print("Strong CP / θ = 0 Bounded Selected-Surface Closure")
+    print("Strong CP / θ = 0 Bounded Cited-Selected-Surface Closure")
     print("=" * 78)
     print()
-    print("CLAIM: On the explicitly θ-free Wilson-plus-staggered scalar-mass surface,")
-    print("       θ_eff = 0 with no surviving loophole from axial rephasing,")
-    print("       exact fermion integration, or positive-weight topological sectors.")
+    print("CLAIM: Conditional on the cited selectors' own surfaces and classes,")
+    print("       the constructed Wilson-plus-staggered / K-real Case-A mass surface")
+    print("       has θ_eff = 0 with no generated strong-sector phase.")
 
-    test_leg_a_fermion_phase_closure()
-    test_leg_b_chiral_basis_non_generation()
-    test_weak_sector_separation()
-    test_leg_c_effective_action_cp_even()
-    test_leg_d_topological_sector_positivity()
-    test_combined_theta_eff()
+    action_basis = construct_allowed_action_basis()
+    print("\nConstructed action conditions:")
+    for condition in action_basis.conditions:
+        print(f"  - {condition}")
+
+    test_leg_a_fermion_phase_closure(action_basis)
+    test_leg_b_chiral_basis_non_generation(action_basis)
+    test_weak_sector_separation(action_basis)
+    test_leg_c_effective_action_cp_even(action_basis)
+    test_leg_d_topological_sector_positivity(action_basis)
+    test_combined_theta_eff(action_basis)
 
     print("\n=== SUPPORT CONTEXT ===\n")
     support("Vafa-Witten sign discipline is consistent with the selected positive-weight closure", "external consistency only; not counted as theorem-grade")
@@ -713,17 +1097,19 @@ def main():
         f"FAIL={COUNTS['SELECTED-SURFACE COMPUTE FAIL']}"
     )
     print(f"SUPPORT={COUNTS['SUPPORT']}")
+    total_pass = COUNTS["THEOREM PASS"] + COUNTS["SELECTED-SURFACE COMPUTE PASS"]
+    total_fail = COUNTS["THEOREM FAIL"] + COUNTS["SELECTED-SURFACE COMPUTE FAIL"]
+    print(f"TOTAL PASS={total_pass}  FAIL={total_fail}")
     print("=" * 78)
 
-    total_fail = COUNTS["THEOREM FAIL"] + COUNTS["SELECTED-SURFACE COMPUTE FAIL"]
     if total_fail != 0:
-        print("\nOne or more selected-surface strong-CP closure checks failed.")
+        print("\nOne or more cited-selected-surface strong-CP closure checks failed.")
         return 1
 
     print()
-    print("All selected action-surface closure checks passed. The strong sector closes at")
-    print("θ_eff = 0 on the selected Wilson-plus-staggered scalar-mass surface, while")
-    print("CKM CP remains weak-sector only and the surviving neutron-EDM signal")
+    print("All cited-selected action-surface closure checks passed. Conditional on")
+    print("the printed surfaces and classes, the strong sector closes at θ_eff = 0,")
+    print("while CKM CP remains weak-sector only and the surviving neutron-EDM signal")
     print("stays in the separate bounded CKM lane.")
     return 0
 

--- a/scripts/frontier_strong_cp_theta_zero.py
+++ b/scripts/frontier_strong_cp_theta_zero.py
@@ -3,11 +3,11 @@
 Strong CP / θ = 0 Bounded Selected-Surface Closure
 ==================================================
 
-STATUS: bounded cited-selected-surface closure on the conditional
+STATUS: bounded selected-action-surface closure on the conditional
 Wilson-plus-staggered / K-real Case-A mass action surface
 
 TARGET CLAIM:
-  On the cited-selected Wilson-plus-staggered / K-real Case-A mass surface on
+  On the bounded Wilson-plus-staggered / K-real Case-A selected action surface on
   the Z^3 spatial substrate,
   θ_eff = 0 with no surviving loophole from:
 
@@ -17,7 +17,7 @@ TARGET CLAIM:
     (D) positive-weight topological-sector weighting away from θ = 0.
 
 SCOPE:
-  This is a bounded cited-selected-surface closure package, conditional on
+  This is a bounded selected-action-surface closure package, conditional on
   the cited authorities' own positive-class, character/support,
   single-plaquette, scalar-mass, and K-real Case-A conditions. It is not a
   universal all-formulations strong-CP theorem or an audit-status claim.
@@ -1055,7 +1055,7 @@ def test_combined_theta_eff(action_basis):
     theta_exp_bound = 1e-10
 
     support(
-        "theta_bare = 0 is read from the constructed cited-selected basis",
+        "theta_bare = 0 is read from the constructed bounded selected basis",
         f"computed theta/pi = {action_basis.theta_over_pi}",
     )
     check("Explicit positive-mass quark surface gives arg det(M_u M_d) = 0", abs(arg_det_M) < 1e-12, f"|arg det| = {abs(arg_det_M):.2e}", bucket="COMPUTE")
@@ -1065,7 +1065,7 @@ def test_combined_theta_eff(action_basis):
 
 def main():
     print("=" * 78)
-    print("Strong CP / θ = 0 Bounded Cited-Selected-Surface Closure")
+    print("Strong CP / θ = 0 Bounded Selected-Action-Surface Closure")
     print("=" * 78)
     print()
     print("CLAIM: Conditional on the cited selectors' own surfaces and classes,")
@@ -1103,11 +1103,11 @@ def main():
     print("=" * 78)
 
     if total_fail != 0:
-        print("\nOne or more cited-selected-surface strong-CP closure checks failed.")
+        print("\nOne or more bounded selected-action-surface strong-CP closure checks failed.")
         return 1
 
     print()
-    print("All cited-selected action-surface closure checks passed. Conditional on")
+    print("All bounded selected action-surface closure checks passed. Conditional on")
     print("the printed surfaces and classes, the strong sector closes at θ_eff = 0,")
     print("while CKM CP remains weak-sector only and the surviving neutron-EDM signal")
     print("stays in the separate bounded CKM lane.")


### PR DESCRIPTION
## What

Repairs the theta lane's two independent `missing_bridge_theorem` handoffs by wiring four bounded source authorities into the strong-CP selected-action-surface note and making the runner construct the conditional gauge/mass basis before executing the existing closure legs.

## Audit repair targets (verbatim)

Seat A:

> missing_bridge_theorem: add retained dependencies deriving exclusion of a CP-odd topological action slot and selection of the positive-real quark-mass orientation, then update the runner to construct and test the allowed action basis.

Seat B:

> missing_bridge_theorem: add retained operator-basis/action-surface and positive-real quark-mass-orientation dependencies, then update the runner to construct the allowed action basis and reject an admitted CP-odd term or complex mass phase.

## Reviewed repair

- The dependency table stays inside all four authorities' scopes: single-plaquette-only exclusion; emergent-Q existence/integrality/nonvacuity/susceptibility remains open; the positive mass sign is convention-aligned rather than derived; the K-real Case-A determinant-channel reading remains supplied, with zero phase stated only on the nonzero-determinant locus.
- The Status and theorem remain bounded to the selected action surface. An admitted CP-odd action term or complex mass phase re-opens the question.
- The runner computes the Z2 roots, positive-class filter, exact P4 linear solution, positive native-sector pushforward and gcd-one condition, then constructs per-flavor positive-real representatives.
- The two `1/3` admitted-data probes pass by detection, print the named conditional, and retain their immutable input data.
- The determinant, axial, effective-action and sector-weight closure algorithms are unchanged; their literal masses/theta are replaced by values consumed from the constructed basis.

## Review-loop result

Two iterations. Initial findings were fixed narrowly: emergent-Q existence overclaim, determinant-zero phase domain, framework-wide weak-sector wording, overbroad axial wording, and noncanonical authority/vocabulary framing.

No-Go Discipline: PASS.

- N1: seven distinct escape routes were checked; clover/multi-plaquette, non-positive weights, missing/noninteger Q, complex masses, non-K-real/Wilson-shifted blocks, and determinant-zero cases are explicitly outside or reopen the bounded claim.
- N2: the collapsed independent wall set is the P1-P5 single-plaquette class, character/positive class, supplied integer-Q populated carrier, and scalar-mass K-real Case-A channel.
- N3-N5: all canonical/supplied conditions are explicit; prior residuals and negative rhetoric are resolution-matched.
- N6: no new axiom or primitive is introduced; the four sources form a bounded import-bearing path.
- N7: the strongest naturalness/clover/complex-mass steelman defeats an unconditional theorem but not this explicitly bounded theorem.
- N8: prior theta gauge/mass echoes remain open or supplied and are not silently retired.

Validation: runner `55/0` in under two seconds; live stdout matches the committed cache byte-for-byte; independent selector recomputation passed; `vocab_lint` clean; audit pipeline and strict lint exit zero; the row seeds exactly four dependencies and queues as `unaudited`; no generated audit, ledger, effective-status, or verdict surface is included.

Review disposition: `PASS WITH BOUNDED CLAIMS`. Independent audit remains the only status authority.
