### PR TITLE
physics: close retained Grassmann polymer norm

### DIFF
--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
@@ -1,6 +1,37 @@
 # Handoff
 
 Current branch:
+`physics-loop/record-faithful-dynamics-block29-grassmann-polymer-norm-20260712`.
+The retained-Grassmann joint-polymer runner reports `PASS=14 FAIL=0`. The
+retained weight's correct positive body is `det D_II`, not the full `det D`.
+A new `m>4` induced-graph hopping expansion controls that body, while the
+Schur inverse expansion gives retained-to-retained even balanced path
+activities. Their combined Banach-valued two-layer row closes whenever
+`q=(4/m)exp(L)<1` and `K_W+K_I+K_S<c`.
+
+At three strict points (`m=12,16,20`), the exact one-step joint logarithm has
+one uniform connected decomposition satisfying
+`||Gamma_c||<=68 exp(lambda/2)c+3m eta^2 exp(theta/2)`. This pays all
+endpoints, paths, colors, supports, and every balanced Grassmann degree
+simultaneously. The executable witness checks coefficient-exact
+Banach-valued regrouping and a nonzero connected quartic logarithm.
+
+Independent code/math, physics/import/Nature, and governance/no-go review
+pass after separating the three downstream N2 walls. Audit validation seeds
+one `bounded_theorem` / `unaudited` row with exactly the Schur-block,
+generated-action-space, and two-layer-KP dependencies; strict lint has zero
+errors and generated status surfaces are stripped.
+
+This is one-step joint-norm closure only. It does not supply an invariant
+rescaled neighborhood, relevant-coordinate projection, contraction, physical
+taste carrier, retained-fermion OS/CAR reconstruction, or critical continuum
+trajectory. No axiom-update stop is triggered.
+
+Retained-Grassmann joint-polymer stacked PR:
+https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5327
+is open against the gauge-body source-polymer head.
+
+Previous branch:
 `physics-loop/record-faithful-dynamics-block28-gauge-body-source-polymer-20260712`.
 The two-layer source-polymer runner reports `PASS=14 FAIL=0`. For positive
 parameters satisfying `q<1` and `K_(theta,lambda)(c)<c`, the positive

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
@@ -1,5 +1,23 @@
 # PR Delivery
 
+The simultaneous retained gauge--Grassmann polymer-norm theorem is delivered:
+
+- base: `physics-loop/record-faithful-dynamics-block28-gauge-body-source-polymer-20260712`
+- head: `physics-loop/record-faithful-dynamics-block29-grassmann-polymer-norm-20260712`
+- runner: `PASS=14 FAIL=0`
+- scope: a direct `det D_II` positive-body hopping expansion plus Schur-path
+  Banach activities closes one uniform all-degree connected norm at three
+  explicit points; no invariant rescaled map, contraction, taste selection,
+  retained-fermion OS/CAR reconstruction, or continuum trajectory
+- review: independent code/math, physics/import/Nature, and governance/no-go
+  pass after the N2 wall-separation repair
+- audit compatibility: one `bounded_theorem` / `unaudited` row with exactly
+  the Schur-block, generated-action-space, and two-layer-KP dependencies; full
+  pipeline and strict lint pass; generated outputs stripped
+- PR: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5327
+
+No merge is authorized. Independent audit remains authoritative.
+
 The two-layer constrained-fiber complex-source/polymer theorem is delivered:
 
 - base: `physics-loop/record-faithful-dynamics-block27-raw-action-hessian-decay-20260712`

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
@@ -860,3 +860,30 @@ generated audit/status surfaces are stripped. PR #5322 is open. The retained
 gauge--Grassmann simultaneous norm, projection/rescaling, physical critical
 trajectory, and continuum limits remain open. No negative theorem or
 axiom-update stop is triggered.
+
+## Simultaneous retained-Grassmann polymer-norm review
+
+PASS WITH BOUNDED POSITIVE CLAIMS. Physics/import review first isolated the
+load-bearing measure mismatch: the retained Schur weight has positive body
+`det D_II`, while the previous gauge-body theorem controls the full `det D`.
+The final source does not reweight by the uncontrolled `(det S)^(-1)`.
+Instead, a direct `m>4` induced-graph hopping expansion gives the eliminated-
+determinant path row, and the Schur inverse expansion gives jointly
+gauge-invariant retained-to-retained even balanced path factors.
+
+The `eta`-weighted coefficient norm is submultiplicative, the even sector is
+commutative, and Haar integration is contractive. The prior two-layer
+rooted-tree/KP proof therefore lifts to the Banach-valued activities. Code/math
+review independently reproduced every fixed-link, path-position, orientation,
+color, hidden-footprint, envelope, mass-term, and 68-anchor factor. The runner
+checks three strict points, exact coefficient regrouping, and a nonzero
+balanced quartic connected logarithm: `PASS=14 FAIL=0`.
+
+Nature review passes the correct-body repair, gauge covariance, balanced
+degree, local coefficient limit, and taste/CAR/OS/continuum boundaries.
+Governance review required three independent N2 walls—projected/rescaled
+invariant RG, physical taste carrier, and critical trajectory—and passed the
+repair. Audit validation seeds one `bounded_theorem` / `unaudited` row with
+source hash `ccd263928a7d0c58...` and exactly three intended dependencies;
+strict lint has zero errors and generated audit/status surfaces are stripped.
+PR #5327 is open. No negative theorem or axiom-update stop is triggered.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
@@ -8,31 +8,32 @@ current_goal: >-
   supply the physical evolution object, bare time ordering, record-formation
   weights, and an admissibility-to-carrier selector without importing the
   staggered/Dirac answer or sector-specific Standard Model and gravity laws.
-branch: physics-loop/record-faithful-dynamics-block28-gauge-body-source-polymer-20260712
+branch: physics-loop/record-faithful-dynamics-block29-grassmann-polymer-norm-20260712
 base_commit_at_start: 9d1636f05f
-cycle_count: 28
-block_count: 28
-active_route: wilson_staggered_constrained_fiber_two_layer_kp_source_polymer
+cycle_count: 29
+block_count: 29
+active_route: wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm
 hard_residual: >-
   Can the four-axiom record surface canonically determine a faithful local
   record-forming instrument whose coherent no-record block is sufficiently
   constrained to exclude the observationally disconnected SWAP--Laplacian
   completion and select the Clifford-vector carrier?
-produced_claim_id: wilson_staggered_constrained_fiber_two_layer_kp_complex_source_polymer_bounded_theorem_note_2026-07-12
+produced_claim_id: wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_bounded_theorem_note_2026-07-12
 actual_current_surface_status: bounded-support
 conditional_surface_status: >-
-  In an explicit deep high-mass/small-coupling subwedge, the positive
-  fermion-integrated gauge body has a convergent two-layer polymer logarithm,
-  a uniform complete Reinhardt source domain, all fixed-order local
-  cumulant/tree bounds, and a weighted connected coarse p=0 interaction. No
-  simultaneous retained gauge--Grassmann norm, projected/rescaled
-  contraction, critical trajectory, or continuum theorem is proved.
+  In an explicit deeper m>4 subwedge, the exact retained gauge--Grassmann
+  one-step logarithm has a uniform connected decomposition in one simultaneous
+  eta-weighted all-degree norm. No invariant rescaled neighborhood,
+  relevant-coordinate projection, contraction, physical taste carrier,
+  retained-fermion OS/CAR reconstruction, critical trajectory, or continuum
+  theorem is proved.
 admitted_observation_status: none
 claim_type_reason: >-
-  The source proves an explicit sufficient two-layer KP region and uniform
-  gauge-body source/polymer bounds. It keeps the simultaneous all-degree
-  gauge--Grassmann norm, symmetry-adapted coordinates, projected contraction,
-  critical trajectory, and continuum limit open.
+  The source proves a direct eliminated-determinant hopping row and a
+  simultaneous Banach-valued Schur-path KP bound with explicit nonempty
+  points. It keeps symmetry-adapted coordinates, projected/rescaled
+  contraction, physical taste identification, critical trajectory, and
+  continuum limits open.
 hypothetical_axiom_status: null
 proposal_allowed: false
 proposal_allowed_reason: >-
@@ -126,6 +127,9 @@ files_touched:
   - docs/WILSON_STAGGERED_CONSTRAINED_FIBER_TWO_LAYER_KP_COMPLEX_SOURCE_POLYMER_BOUNDED_THEOREM_NOTE_2026-07-12.md
   - scripts/wilson_staggered_constrained_fiber_two_layer_kp_source_polymer_2026_07_12.py
   - logs/runner-cache/wilson_staggered_constrained_fiber_two_layer_kp_source_polymer_2026_07_12.txt
+  - docs/WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md
+  - scripts/wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_2026_07_12.py
+  - logs/runner-cache/wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_2026_07_12.txt
 open_imports:
   - fundamental process object: Hamiltonian, strict tick, or record instrument
   - faithful law-to-record influence principle
@@ -171,10 +175,11 @@ no_go_routes:
   - exact raw fiber integration cannot strictly contract its full unprojected action space in the common unrescaled coefficient norm because coarse-local lifted coordinates pass with unit ratio; relevant-coordinate projection, rescaling, and scale-weighted irrelevant norms remain live
   - coarse-gauge Gibbsianness does not by itself provide a uniform translation-adapted anchored interaction norm or the all-order source cumulants needed for the retained gauge--Grassmann action; complete-analyticity, cluster, and constructive RG routes remain live
   - a scalar gauge-body source/polymer theorem does not by itself place the retained Grassmann coefficients in one simultaneous all-degree Banach norm or supply a projected/rescaled RG contraction
+  - one-step simultaneous gauge--Grassmann norm membership does not by itself define an invariant factor-two rescaled neighborhood or remove the exact raw relevant directions
 trace_gate_classification: direct_blocker_closure
 reachability_to_target: partially_closes
-review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_two_layer_source_polymer_pass_bounded
-pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open_two_layer_source_polymer_open
+review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_two_layer_source_polymer_pass_retained_grassmann_polymer_norm_pass_bounded
+pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open_two_layer_source_polymer_open_retained_grassmann_polymer_norm_open
 block01_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5178
 block02_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5181
 block03_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5201
@@ -203,12 +208,12 @@ block25_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/
 block26_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5315
 block27_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5317
 block28_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5322
+block29_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5327
 next_exact_action: >-
-  Lift the scalar two-layer KP estimate to one simultaneous
-  Banach-algebra-valued source for the exponentially local Schur coefficients.
-  Sum endpoints, paths, supports, and every balanced Grassmann degree in the
-  eta-weighted norm while preserving joint gauge covariance. Only then define
-  symmetry-adapted coordinates, projection, and factor-two rescaling.
+  Define symmetry-adapted vacuum, mass, kinetic, gauge, and remaining
+  relevant/marginal coordinates on the joint action space. Extract them,
+  apply factor-two geometric and field rescaling, and test whether the
+  irrelevant derivative is strictly contractive on one invariant neighborhood.
 stop_condition: >-
   Stop and discuss an axiom update only if an exact result proves that the
   required bridge cannot be derived and an additional approved axiom or

--- a/docs/WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md
+++ b/docs/WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,493 @@
+# Simultaneous retained-Grassmann polymer control for constrained Wilson--staggered fibers
+
+**Date:** 2026-07-12
+**Type:** bounded_theorem
+**Status:** unaudited candidate; effective status is pipeline-derived only after independent audit.
+**Primary runner:** [`scripts/wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_2026_07_12.py`](../scripts/wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_2026_07_12.py)
+**Cached output:** [`logs/runner-cache/wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_2026_07_12.txt`](../logs/runner-cache/wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_2026_07_12.txt)
+
+## 0. Result
+
+The exact one-step retained gauge--Grassmann logarithm now belongs to one
+simultaneous all-degree connected polymer norm in an explicit high-mass,
+small-coupling region.
+
+Three prior surfaces are used without changing their scope:
+
+- the [exact retained Schur weight and fixed-background locality](MASSIVE_WILSON_STAGGERED_FACTOR_TWO_GAUGE_BLOCK_SCHUR_OS_SEMIGROUP_BOUNDED_THEOREM_NOTE_2026-07-12.md);
+- the [joint generated-action coefficient space and anchored norm](WILSON_STAGGERED_CONSTRAINED_FIBER_DOBRUSHIN_AND_RAW_RG_UNIT_DIRECTIONS_BOUNDED_THEOREM_NOTE_2026-07-12.md);
+- the [two-layer rooted-tree/Kotecky--Preiss lemma and syntactic support map](WILSON_STAGGERED_CONSTRAINED_FIBER_TWO_LAYER_KP_COMPLEX_SOURCE_POLYMER_BOUNDED_THEOREM_NOTE_2026-07-12.md).
+
+The positive body of the retained weight is `det D_II`, not the full
+determinant controlled in the last dependency. The proof therefore derives a
+new anchored hopping expansion for `det D_II`; it does not insert an
+uncontrolled `(det S)^(-1)` reweighting.
+
+Let
+
+```text
+h=4/m,
+L=theta+2c+lambda,
+q=h exp(L),                                                          (0.1)
+```
+
+where `c,theta,lambda,eta>0` and `m>4`. Put
+`g(t)=(exp(t)-1)/t`, with `g(0)=1`, and define
+
+```text
+K_W=12[exp(3 beta/4)-1]exp(4L),                                     (0.2)
+
+K_I=(3/2)sum_(even r>=4)
+       h^r g(3h^r/r) exp(rL),                                      (0.3)
+
+K_S=18 eta^2 sum_(r>=2)
+       r h^(r-1)
+       g(9 eta^2 2^(-r)m^(-(r-1))) exp(rL),                         (0.4)
+
+K_joint=K_W+K_I+K_S.                                                (0.5)
+```
+
+Whenever
+
+```text
+q=h exp(L)<1,                    K_joint=K_W+K_I+K_S<c,              (0.6)
+```
+
+on the declared reflection-compatible periodic regulators with every fine
+extent at least four, the finite-volume exact action
+
+```text
+Gamma_c(V,bar psi,psi)=-log W_c(V,bar psi,psi)                       (0.7)
+```
+
+has a regulator-, hidden-boundary-, and coarse-`V`-uniform connected
+decomposition in the generated coefficient space. After removing the
+`V,bar psi,psi`-independent vacuum constant,
+
+```text
+||Gamma_c||_(lambda/2,theta/2,eta)
+ <=68 exp(lambda/2)c+3m eta^2 exp(theta/2).                          (0.8)
+```
+
+The bound sums all endpoints, paths, connected supports, color components,
+and every balanced Grassmann degree at once. It implies local coefficient
+limits and one common complete Reinhardt source domain around the exact
+one-step action. The coefficients remain jointly coarse-gauge invariant.
+
+Three strict points with `theta=lambda=0.001` are
+
+| `m` | `beta` | `c` | `eta` | `K_W` | `K_I` | `K_S` | `K_joint` | `c-K_joint` | `q` |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 12 | 0.0005 | 0.120 | 0.020 | 0.0118493 | 0.0597052 | 0.0185296 | 0.0900840 | 0.0299160 | 0.4245981 |
+| 16 | 0.0010 | 0.120 | 0.050 | 0.0237030 | 0.0171894 | 0.0660856 | 0.1069779 | 0.0130221 | 0.3184485 |
+| 20 | 0.0025 | 0.125 | 0.040 | 0.0617104 | 0.0070465 | 0.0301263 | 0.0988832 | 0.0261168 | 0.2573192 |
+
+This is one-step mathematical closure for the declared form-migrating
+retained variables. `eta` is a convergence coordinate; it is not a physical field normalization. The theorem does not prove an invariant RG neighborhood,
+projected/rescaled contraction, taste selection, retained-fermion OS
+reconstruction, a critical trajectory, or any Lorentz/QFT/Standard Model/GR
+limit.
+
+No negative theorem is shipped. No axiom-update stop is established.
+
+## 1. The correct positive body
+
+The exact retained weight is
+
+```text
+W_c(V,bar psi,psi)
+ =integral dH exp[-S_W(U)] det D_II(U)
+             exp[-bar psi S(U)psi],                                 (1.1)
+```
+
+with `S=mI-D_KI D_II^(-1)D_IK`. Its scalar body at zero retained
+Grassmann field is
+
+```text
+Z_II(V)=integral dH exp[-S_W(U)]det D_II(U)>0.                       (1.2)
+```
+
+By contrast, full fermion integration produces the body with
+`det D=det D_II det S`. Passing from that measure to (1.2) would require the
+factor `(det S)^(-1)`. No volume-uniform local bound for that factor has been
+proved, so it is not used.
+
+The eliminated induced graph `I` is bipartite. Its staggered hop `M_II` has at
+most eight oriented blocks of norm `1/2` in each row. For `m>4`, the exact
+absolutely path-convergent expansion is
+
+```text
+log det D_II
+ =3|I|log m
+  +sum_(r>=1)(-1)^(r+1)Tr[(M_II/m)^r]/r.                             (1.3)
+```
+
+Odd `r` vanish by bipartite parity. At fine extent at least four, every closed
+length-two word is an immediate reversal, and its transporter is
+`U U^dagger=1`; these terms join the extracted vacuum constant. Reverse-pair
+the remaining even closed paths at `r>=4`. The excluded extent-two wrap is a
+finite-size alias, not part of the theorem.
+
+For a fixed positive fine link, choose its orientation and one of `r` path
+positions. The remaining `r-1` steps have at most eight choices. With the
+color-trace factor three and the coefficient in (1.3),
+
+```text
+sum_(order r paths through fine link e)||psi_gamma^I||_infinity
+ <=(3/r)[2r 8^(r-1)]2^(-r)m^(-r)
+ =(3/4)h^r.                                                         (1.4)
+```
+
+A hidden coordinate has a one- or two-link syntactic footprint. Therefore
+
+```text
+sup_a sum_(gamma:a in S_gamma, order r)||psi_gamma^I||_infinity
+ <=(3/2)h^r.                                                        (1.5)
+```
+
+An individual reverse-paired potential has the safe bound
+
+```text
+t_r^I=3h^r/r.                                                       (1.6)
+```
+
+The actual individual path coefficient is much smaller; (1.6) is chosen so
+that no root, color, or reverse-pair convention is hidden. Since
+`exp(x)-1<=x g(t_r^I)` for `0<=x<=t_r^I`, and each syntactic support has
+`|S_gamma|,ell(S_gamma)<=r`, equations (1.5)--(1.6) give exactly (0.3).
+The Wilson midpoint factors give (0.2) as before.
+
+## 2. Schur paths in the even balanced Banach algebra
+
+For `m>4`, use the direct hopping series
+
+```text
+D_II^(-1)
+ =m^(-1)sum_(n>=0)(-M_II/m)^n.                                     (2.1)
+```
+
+After the two outer hops in the Schur complement, a term with `n` internal
+hops is a retained-to-retained path of length `r=n+2`. Its transporter is
+unitary and its scalar coefficient obeys
+
+```text
+|a_gamma|<=2^(-r)m^(-(r-1)).                                       (2.2)
+```
+
+Write the corresponding jointly gauge-invariant even bilinear as
+
+```text
+B_gamma
+ =a_gamma bar psi_(x_gamma) U_gamma psi_(y_gamma).                  (2.3)
+```
+
+The entrywise color sum of a `3 by 3` unitary is at most nine. In the
+coefficient norm with weight `eta`,
+
+```text
+||B_gamma||_eta
+ <=x_r=9 eta^2 2^(-r)m^(-(r-1)).                                   (2.4)
+```
+
+Even Grassmann elements commute. Hence the exact Schur exponential factors as
+
+```text
+exp[-bar psi(S-mI)psi]=product_gamma exp(B_gamma),                  (2.5)
+```
+
+with the path signs absorbed into `a_gamma`. No bilinear truncation is made:
+each factor and products of distinct factors contain the balanced quartic and
+higher terms allowed by the generated action space. Submultiplicativity gives
+
+```text
+||exp(B_gamma)-1||_eta
+ <=exp(x_r)-1=x_r g(x_r).                                           (2.6)
+```
+
+The same fixed-link word count as in (1.4), now without the trace coefficient,
+gives
+
+```text
+sum_(length r Schur paths through fine link e)||B_gamma||_eta
+ <=9 eta^2 r h^(r-1).                                               (2.7)
+```
+
+The hidden footprint factor two and (2.6) give
+
+```text
+sup_a sum_(gamma:a in S_gamma, length r)
+ ||exp(B_gamma)-1||_eta
+ <=18 eta^2 r h^(r-1)g(x_r).                                       (2.8)
+```
+
+Again `|S_gamma|,ell(S_gamma)<=r`; weighting (2.8) produces exactly (0.4).
+This is the load-bearing simultaneous sum. It counts all retained endpoints
+because fixing the traversed fine link and the word position determines the
+start once the other steps are chosen.
+
+The hidden-independent onsite mass factor is extracted from (2.5):
+
+```text
+Phi_mass=m sum_(X,a) bar psi_X^a psi_X^a.                            (2.9)
+```
+
+It contributes `3m eta^2 exp(theta/2)` to (0.8) and requires no KP smallness.
+
+## 3. Banach-algebra two-layer expansion
+
+Use the coefficient algebra
+
+```text
+A_X=[C(SU(3)^(E_X)) tensor
+     Lambda_even,balanced(bar psi_X,psi_X)]^(G_X),                  (3.1)
+```
+
+with
+
+```text
+||Phi_X||_eta
+ =sum_(p,P,Q;|P|=|Q|=p)
+   eta^(2p)||phi_(X;P,Q)||_infinity.                                (3.2)
+```
+
+This weighted coefficient `l1` norm is submultiplicative. The even sector is
+commutative, and coefficient-wise Haar integration is contractive. Thus the
+interaction factors from Sections 1--2 can be grouped by hidden-support
+overlap exactly as scalar factors were grouped in the prior two-layer lemma.
+
+For a connected factor collection `Gamma`, its activity is now an element of
+the even balanced Banach algebra:
+
+```text
+w_Gamma(V,bar psi,psi)
+ =integral product_(a in Gamma) f_a dH_(Y_Gamma),
+||w_Gamma||_eta<=product_(a in Gamma)||f_a||_eta.                   (3.3)
+```
+
+The rooted-tree recursion and the final hard-core exclusion proof use only
+nonnegative norm majorants. Replacing absolute value by `||.||_eta` therefore
+gives the same sufficient condition
+
+```text
+sup_h sum_(a:h in S_a)
+ ||f_a||_eta exp[(theta+2c)|S_a|+lambda ell(S_a)]<c.                (3.4)
+```
+
+Equations (0.2)--(0.5) are the three contributions to its left side. Under
+(0.6), the hard-core connected logarithm converges absolutely in the Banach
+algebra. Its body is positive, so this convergent branch equals the exact
+finite Grassmann logarithm in (0.7).
+
+The same norm proof remains valid after multiplying any finite local family of
+additional even balanced sources whose total weighted activity fits inside
+the strict margin `c-K_joint`. Hence the logarithm has a common complete
+Reinhardt source domain and every finite-order coefficient derivative is a
+connected marked cluster. Unlike coefficient-by-coefficient scalar disks,
+this one estimate sums every Grassmann degree simultaneously.
+
+Useful closed envelopes are
+
+```text
+K_I<=(3/2)exp(3h^4/4) q^4/(1-q^2),                                 (3.5)
+
+K_S<=18 eta^2 exp(9eta^2/(4m))
+       exp(L) q(2-q)/(1-q)^2.                                      (3.6)
+```
+
+The runner evaluates the actual series at the three displayed points and
+checks both envelopes.
+
+The abstract scalar polymer theorem is R. Kotecky and D. Preiss,
+*Cluster expansion for abstract polymer models*, Communications in
+Mathematical Physics **103** (1986), 491--498, DOI
+`10.1007/BF01211762`. The Banach-algebra extension used here is proved by the
+same displayed norm majorant and absolutely convergent combinatorial series;
+no separate model theorem is imported.
+
+## 4. Hidden-to-coarse joint norm
+
+Use the nonminimal syntactic supports before any `A A^(-1)V` cancellation.
+Every retained-to-retained Schur path begins and ends with a fine link in an
+outgoing or incoming skeleton pair. Adding both endpoints of each charged
+skeleton coordinate therefore includes both fermion endpoints as well as
+every exposed coarse link.
+
+For a connected hidden polymer `Y`, the resulting coarse support `X(Y)` obeys
+
+```text
+X(Y) connected,
+|X(Y)|<=2|Y|,
+diam X(Y)<=ell(Y)+1.                                                 (4.1)
+```
+
+At most 64 positive fine-link anchors and four incoming skeleton endpoints
+charge one coarse cell, so the safe conversion multiplicity remains 68.
+Grouping all joint clusters with the same coarse support and using (4.1)
+gives
+
+```text
+sup_z sum_(connected X contains z)
+ exp[(lambda/2)diam X+(theta/2)|X|] ||Phi_X||_eta
+ <=68 exp(lambda/2)c                                                 (4.2)
+```
+
+for the cluster part. Adding (2.9) proves (0.8).
+
+Every scalar determinant path is gauge invariant. Every Schur path factor
+contracts its open transporter with retained endpoint fields and is jointly
+gauge invariant. Haar integration, multiplication, and the connected
+logarithm preserve that invariance. Balanced degree is likewise preserved
+term by term.
+
+The uniform pinned expansion also constructs local infinite-volume
+coefficients: every finite cluster stabilizes once the regulator contains it,
+while the omitted diameter tail is uniformly summable. This is a local
+coefficient limit, not an iterated critical RG trajectory.
+
+## 5. Runner contract
+
+Run:
+
+```bash
+python3 scripts/wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_2026_07_12.py
+```
+
+The runner checks the three strict joint KP points, both closed envelopes, the
+fixed-link determinant and Schur word-incidence factors, the bipartite
+length-two constant floor, coefficient-norm submultiplicativity, and a
+coefficient-exact two-hidden-coordinate Banach-valued factor-to-polymer
+identity. The latter has overlapping bilinear path factors and a nonzero
+balanced quartic connected logarithm. It also checks coarse support and the
+source/dependency contract. The infinite rooted-tree and thermodynamic-limit
+steps are analytic statements.
+
+## 6. Honest boundary and next theorem
+
+This theorem closes membership of the exact one-step form-migrating retained
+action in the declared joint norm at the displayed points. It does not say
+that the norm ball maps into itself after field/geometric rescaling, or that
+the same `eta` is a physical normalization.
+
+The next theorem must define symmetry-adapted vacuum, mass, kinetic, gauge,
+and other relevant/marginal coordinates; extract them; apply factor-two
+geometric and field rescaling; and bound the derivative of the remaining map
+strictly below one on an invariant neighborhood. The exact raw unit directions
+make that projection load-bearing.
+
+Taste-faithful hypercube variables, auxiliary-field reorganizations, and
+alternative block kernels remain live. Failure of this sufficient inequality
+outside the displayed region would not establish failure of joint locality.
+
+## 7. No-Go Discipline N1--N8
+
+No negative theorem or route foreclosure is shipped. The boundary statements
+are scope limits. The checks are retained conservatively because the theorem
+advances a prior no-go-sensitive RG campaign.
+
+### N1 — alternative-route enumeration
+
+| Route | Status | Executed test | Result |
+|---|---|---|---|
+| Full-determinant reweighting | `ATTEMPTED` | Section 1 compares the exact bodies. | Rejected as an input because `(det S)^(-1)` has no local bound. |
+| Direct eliminated-determinant hopping expansion | `ATTEMPTED` | Equations (1.3)--(1.6). | Supplies the correct positive-body activity row for `m>4`. |
+| Schur path expansion | `ATTEMPTED` | Equations (2.1)--(2.8). | Sums endpoints, paths, colors, and supports. |
+| Banach-valued two-layer KP | `ATTEMPTED` | Section 3 replaces scalar absolute values by the submultiplicative norm. | Sums all balanced degrees simultaneously. |
+| Coefficientwise complex disks | `ATTEMPTED` | Compared with the common margin after (3.4). | Strictly weaker than the simultaneous algebra estimate. |
+| Direct exterior-algebra regrouping | `ATTEMPTED` | Runner evaluates the exact finite identity and logarithm. | Confirms higher connected degree generation. |
+| Hidden-to-coarse support conversion | `ATTEMPTED` | Section 4 and runner. | Preserves endpoints and the safe 68 multiplicity. |
+| Auxiliary-field/taste-faithful reorganizations | `ATTEMPTED` | Not used in the positive proof. | Remain live routes to larger or more physical regions. |
+
+### N2 — wall-independence audit
+
+The collapsed downstream conditions are `projected/rescaled invariant RG
+neighborhood`, `physical taste-carrier identification`, and `critical
+trajectory/observable identification`.
+
+| Left | Right | Left closes right? | Right closes left? | Independent? |
+|---|---|---:|---:|---:|
+| projected/rescaled invariant RG neighborhood | physical taste-carrier identification | No | No | Yes |
+| projected/rescaled invariant RG neighborhood | critical trajectory/observable identification | No | No | Yes |
+| physical taste-carrier identification | critical trajectory/observable identification | No | No | Yes |
+
+Joint norm membership is now an input to the first condition, not a separate
+remaining wall.
+
+### N3 — hidden-condition phrase scan
+
+| Mandated phrase | Classification |
+|---|---|
+| `we assume` | No load-bearing hit. |
+| `by construction` | No proof-substitute hit. |
+| `as is standard` | No hit. |
+| `the framework provides` | No hit. |
+| `bridge context` | No hit. |
+| `background` | Fixed gauge background is an explicit Schur variable. |
+| `naturally` | No hit. |
+| `obviously` | No hit. |
+| `standard QFT` | No hit. |
+| `registered` | No premise-granting hit. |
+| `canonical Grassmann` | Ordering is algebraic bookkeeping only. |
+| `standard CAR` | No CAR/Fock import occurs. |
+
+### N4 — citation/residual matching
+
+| Witness | Witness residual | Present use | Match? |
+|---|---|---|---:|
+| [Exact Schur block](MASSIVE_WILSON_STAGGERED_FACTOR_TWO_GAUGE_BLOCK_SCHUR_OS_SEMIGROUP_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Fixed-background locality; no joint norm | Exact weight, positivity, covariance, and hopping matrices | Yes |
+| [Generated-action space](WILSON_STAGGERED_CONSTRAINED_FIBER_DOBRUSHIN_AND_RAW_RG_UNIT_DIRECTIONS_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Finite-volume membership only | Target algebra and norm | Yes |
+| [Scalar two-layer KP](WILSON_STAGGERED_CONSTRAINED_FIBER_TWO_LAYER_KP_COMPLEX_SOURCE_POLYMER_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Full-determinant gauge body only | Abstract two-layer lemma and support conversion, not its body | Yes |
+| Kotecky--Preiss 1986 | Abstract scalar hard-core convergence | Norm-majorized combinatorial series | Yes |
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Tested? | Permitted conclusion |
+|---|---:|---|
+| Every finite regulator at the three points | Yes | Exact joint connected logarithm and uniform norm. |
+| Local infinite-volume coefficients | Yes | Pinned cluster limits. |
+| Every balanced Grassmann degree simultaneously | Yes | One `eta`-weighted sum is finite. |
+| All `m>4` or the whole Block28 region | No | Only points/parameters satisfying (0.6). |
+| One rescaled RG self-map | No | Next theorem. |
+| Iterated critical trajectory | No | No existence or impossibility claim. |
+| Retained-fermion OS/CAR/QFT reconstruction | No | Not inferred from Euclidean polynomial closure. |
+
+### N6 — partial-closure and primitive scan
+
+The Wilson--staggered action, formal Grassmann variables, and straight
+factor-two block are previously declared regulator data. Haar/Gibbs
+integration is mathematical measure machinery, not a Born probability or
+record-formation law. `eta` is a convergence coordinate. No action, time,
+probability, CAR, field-normalization, taste, scale, or state primitive is
+added.
+
+The registered scale-reference, kinetic-isotropy, and realized-state
+primitives neither supply nor obstruct this estimate. The remaining
+projection/rescaling problem is ordinary constructive mathematics.
+
+### N7 — hostile steelman
+
+A hostile reviewer should first reject importing the full-determinant fiber
+measure. Correct; Section 1 builds the correct `det D_II` expansion instead.
+The price is the stricter `m>4` hopping region.
+
+A second hostile reviewer should demand that every endpoint, path position,
+orientation, color coefficient, support, and Grassmann degree be paid once.
+Correct; equations (1.4), (2.4), (2.7), and (2.8) expose those factors, while
+the Banach exponential pays all powers of each bilinear.
+
+A third should object that small `eta` may hide a physical field rescaling.
+Correct as a physical criticism; the theorem claims Banach membership for a
+declared convergence coordinate, not a selected normalization or invariant
+RG domain.
+
+### N8 — cross-cycle echo
+
+| Earlier surface | Earlier residual | Retired here? | Treatment |
+|---|---|---:|---|
+| Fixed-background Schur locality | No hidden cumulants or joint norm | Yes, in (0.6) | Direct path activities enter one algebra-valued cluster expansion. |
+| Generated-action space | Finite-volume algebra only | Yes, at the displayed points | Exact action has a uniform connected decomposition. |
+| Full-determinant gauge-body KP | Wrong positive body for retained fields | No, as a body | Its two-layer lemma is reused after a new `det D_II` row. |
+| Raw action unit directions | No unprojected contraction | No | Projection/rescaling remains the next theorem. |
+| One-even-site Schur block | Not taste faithful | No | No physical taste label is promoted. |
+
+No partial closure is relabeled as contraction or continuum physics, and no
+axiom update is requested.

--- a/logs/runner-cache/wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_2026_07_12.txt
+++ b/logs/runner-cache/wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_2026_07_12.txt
@@ -1,0 +1,15 @@
+PASS joint_kp_point_m12: K_W=0.011849253889, K_I=0.059705177822, K_S=0.018529578488, K=0.090084010199, epsilon=0.029915989801, q=0.424598064272
+PASS closed_envelopes_m12: K_I=0.059705177822<=0.060028967755, K_S=0.018529578488<=0.018530668232
+PASS joint_kp_point_m16: K_W=0.023702952081, K_I=0.017189402625, K_S=0.066085584459, K=0.106977939166, epsilon=0.013022060834, q=0.318448548204
+PASS closed_envelopes_m16: K_I=0.017189402625<=0.017217054958, K_S=0.066085584459<=0.066102304315
+PASS joint_kp_point_m20: K_W=0.061710429711, K_I=0.007046543214, K_S=0.030126268784, K=0.098883241708, epsilon=0.026116758292, q=0.257319207457
+PASS closed_envelopes_m20: K_I=0.007046543214<=0.007051045068, K_S=0.030126268784<=0.030129958636
+PASS fixed_link_path_incidence: words=4096, determinant=0.009259259259, schur=1.333333333333
+PASS induced_bipartite_constant_floor: odd closed words forbidden; length-two reversals=8
+PASS eta_norm_submultiplicative: product=0.342015700000, bound=0.344746352577
+PASS banach_factor_to_polymer_identity: body=0.999976000000, regrouping=1.110e-16, log=0.000e+00
+PASS balanced_quartic_connected_log: quartic=0.000029662824, monomials=[(0, 1, 2, 3), (0, 3), (1, 2)]
+PASS schur_path_coarse_support: coarse_path=[(0, 0, 0, 0), (0, 0, 0, 0), (1, 0, 0, 0), (1, 1, 0, 0)], anchor_multiplicity=68
+PASS source_contract: missing=[], forbidden_hits=[]
+PASS repository_dependency_set: markdown_dependency_set=['MASSIVE_WILSON_STAGGERED_FACTOR_TWO_GAUGE_BLOCK_SCHUR_OS_SEMIGROUP_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_CONSTRAINED_FIBER_DOBRUSHIN_AND_RAW_RG_UNIT_DIRECTIONS_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_CONSTRAINED_FIBER_TWO_LAYER_KP_COMPLEX_SOURCE_POLYMER_BOUNDED_THEOREM_NOTE_2026-07-12.md']
+SCORECARD PASS=14 FAIL=0

--- a/scripts/wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_2026_07_12.py
+++ b/scripts/wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_2026_07_12.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Checks simultaneous retained-Grassmann two-layer KP control."""
+
+from __future__ import annotations
+
+import itertools
+import math
+import re
+from collections import defaultdict
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_"
+    "NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md"
+)
+Monomial = tuple[int, ...]
+Exterior = dict[Monomial, float]
+
+
+def g(t: float) -> float:
+    return math.expm1(t) / t if t else 1.0
+
+
+def criterion(
+    mass: float, beta: float, c: float, theta: float, lam: float, eta: float
+) -> dict[str, float]:
+    h = 4.0 / mass
+    L = theta + 2.0 * c + lam
+    q = h * math.exp(L)
+    wilson = 12.0 * math.expm1(3.0 * beta / 4.0) * math.exp(4.0 * L)
+    determinant = 0.0
+    for r in range(4, 10000, 2):
+        term = 1.5 * h**r * g(3.0 * h**r / r) * math.exp(r * L)
+        determinant += term
+        if term < 1.0e-18:
+            break
+    schur = 0.0
+    for r in range(2, 10000):
+        x_r = 9.0 * eta**2 * 2.0 ** (-r) * mass ** (-(r - 1))
+        term = 18.0 * eta**2 * r * h ** (r - 1) * g(x_r) * math.exp(r * L)
+        schur += term
+        if term < 1.0e-18:
+            break
+    total = wilson + determinant + schur
+    det_envelope = 1.5 * math.exp(3.0 * h**4 / 4.0) * q**4 / (1.0 - q**2)
+    schur_envelope = (
+        18.0
+        * eta**2
+        * math.exp(9.0 * eta**2 / (4.0 * mass))
+        * math.exp(L)
+        * q
+        * (2.0 - q)
+        / (1.0 - q) ** 2
+    )
+    return {
+        "h": h,
+        "L": L,
+        "q": q,
+        "wilson": wilson,
+        "determinant": determinant,
+        "schur": schur,
+        "K": total,
+        "epsilon": c - total,
+        "det_envelope": det_envelope,
+        "schur_envelope": schur_envelope,
+    }
+
+
+def ext_add(left: Exterior, right: Exterior, scale: float = 1.0) -> Exterior:
+    out: dict[Monomial, float] = defaultdict(float, left)
+    for monomial, coefficient in right.items():
+        out[monomial] += scale * coefficient
+    return {key: value for key, value in out.items() if abs(value) > 1.0e-15}
+
+
+def ext_mul(left: Exterior, right: Exterior) -> Exterior:
+    out: dict[Monomial, float] = defaultdict(float)
+    for monomial_left, coefficient_left in left.items():
+        for monomial_right, coefficient_right in right.items():
+            if set(monomial_left) & set(monomial_right):
+                continue
+            inversions = sum(a > b for a in monomial_left for b in monomial_right)
+            monomial = tuple(sorted(monomial_left + monomial_right))
+            out[monomial] += ((-1) ** inversions) * coefficient_left * coefficient_right
+    return {key: value for key, value in out.items() if abs(value) > 1.0e-15}
+
+
+def ext_scale(value: Exterior, scalar: float) -> Exterior:
+    return {key: scalar * coefficient for key, coefficient in value.items()}
+
+
+def ext_norm(value: Exterior, eta: float) -> float:
+    return sum(abs(coefficient) * eta ** len(monomial) for monomial, coefficient in value.items())
+
+
+def ext_log_one_plus(nilpotent: Exterior, max_degree: int) -> Exterior:
+    out: Exterior = {}
+    power = dict(nilpotent)
+    for order in range(1, max_degree + 1):
+        out = ext_add(out, power, ((-1) ** (order + 1)) / order)
+        power = ext_mul(power, nilpotent)
+        if not power:
+            break
+    return out
+
+
+def components(labels: tuple[int, ...], supports: list[set[int]]) -> list[tuple[int, ...]]:
+    unseen = set(labels)
+    out: list[tuple[int, ...]] = []
+    while unseen:
+        root = unseen.pop()
+        component = {root}
+        frontier = [root]
+        while frontier:
+            label = frontier.pop()
+            linked = {other for other in unseen if supports[label] & supports[other]}
+            unseen -= linked
+            component |= linked
+            frontier.extend(linked)
+        out.append(tuple(sorted(component)))
+    return out
+
+
+def average_activity_product(labels: tuple[int, ...], activities: list[list[Exterior]]) -> Exterior:
+    out: Exterior = {}
+    for config_index in range(len(activities[0])):
+        product: Exterior = {(): 1.0}
+        for label in labels:
+            product = ext_mul(product, activities[label][config_index])
+        out = ext_add(out, product, 1.0 / len(activities[0]))
+    return out
+
+
+def banach_polymer_identity() -> tuple[float, Exterior, Exterior, Exterior]:
+    hidden_configs = list(itertools.product((-1.0, 1.0), repeat=2))
+    supports = [{0}, {1}, {0, 1}, {0, 1}, {0, 1}]
+    activities: list[list[Exterior]] = [[] for _ in supports]
+    for x, y in hidden_configs:
+        activities[0].append({(): 0.03 * x})
+        activities[1].append({(): -0.02 * y})
+        activities[2].append({(): 0.04 * x * y})
+        # Even balanced path factors. The two bilinears overlap in hidden
+        # support and their product fills all four Grassmann generators.
+        activities[3].append({(0, 3): 0.11 * (1.0 + 0.25 * x)})
+        activities[4].append({(1, 2): -0.09 * (1.0 - 0.30 * y)})
+
+    one: Exterior = {(): 1.0}
+    direct: Exterior = {}
+    for config_index in range(len(hidden_configs)):
+        product = one
+        for label in range(len(supports)):
+            product = ext_mul(product, ext_add(one, activities[label][config_index]))
+        direct = ext_add(direct, product, 1.0 / len(hidden_configs))
+
+    polymer_weight: dict[tuple[int, ...], Exterior] = {}
+    labels_all = range(len(supports))
+    for size in range(1, len(supports) + 1):
+        for labels in itertools.combinations(labels_all, size):
+            if len(components(labels, supports)) == 1:
+                polymer_weight[labels] = average_activity_product(labels, activities)
+
+    polymer_sum: Exterior = {(): 1.0}
+    polymers = list(polymer_weight)
+    # At most one nonempty-support polymer per hidden coordinate can occur in
+    # a compatible family; this two-coordinate witness therefore stops at two.
+    for size in range(1, len(hidden_configs[0]) + 1):
+        for family in itertools.combinations(polymers, size):
+            used_labels: set[int] = set()
+            used_hidden: set[int] = set()
+            compatible = True
+            for gamma in family:
+                hidden = set().union(*(supports[label] for label in gamma))
+                if used_labels & set(gamma) or used_hidden & hidden:
+                    compatible = False
+                    break
+                used_labels |= set(gamma)
+                used_hidden |= hidden
+            if compatible:
+                product: Exterior = {(): 1.0}
+                for gamma in family:
+                    product = ext_mul(product, polymer_weight[gamma])
+                polymer_sum = ext_add(polymer_sum, product)
+
+    body = direct.get((), 0.0)
+    normalized_nilpotent = ext_add(ext_scale(direct, 1.0 / body), {(): 1.0}, -1.0)
+    direct_log = ext_log_one_plus(normalized_nilpotent, 4)
+    polymer_nilpotent = ext_add(ext_scale(polymer_sum, 1.0 / body), {(): 1.0}, -1.0)
+    polymer_log = ext_log_one_plus(polymer_nilpotent, 4)
+    return body, direct, polymer_sum, ext_add(direct_log, polymer_log, -1.0)
+
+
+def max_coefficient_difference(left: Exterior, right: Exterior) -> float:
+    keys = set(left) | set(right)
+    return max((abs(left.get(key, 0.0) - right.get(key, 0.0)) for key in keys), default=0.0)
+
+
+def main() -> None:
+    checks: list[tuple[str, bool, str]] = []
+    examples = [
+        (12.0, 0.0005, 0.12, 0.001, 0.001, 0.02),
+        (16.0, 0.0010, 0.12, 0.001, 0.001, 0.05),
+        (20.0, 0.0025, 0.125, 0.001, 0.001, 0.04),
+    ]
+    for mass, beta, c, theta, lam, eta in examples:
+        row = criterion(mass, beta, c, theta, lam, eta)
+        checks.append(
+            (
+                f"joint_kp_point_m{mass:g}",
+                row["q"] < 1.0 and row["epsilon"] > 0.0,
+                "K_W={:.12f}, K_I={:.12f}, K_S={:.12f}, "
+                "K={:.12f}, epsilon={:.12f}, q={:.12f}".format(
+                    row["wilson"],
+                    row["determinant"],
+                    row["schur"],
+                    row["K"],
+                    row["epsilon"],
+                    row["q"],
+                ),
+            )
+        )
+        checks.append(
+            (
+                f"closed_envelopes_m{mass:g}",
+                row["determinant"] <= row["det_envelope"] + 1.0e-15
+                and row["schur"] <= row["schur_envelope"] + 1.0e-15,
+                "K_I={:.12f}<={:.12f}, K_S={:.12f}<={:.12f}".format(
+                    row["determinant"],
+                    row["det_envelope"],
+                    row["schur"],
+                    row["schur_envelope"],
+                ),
+            )
+        )
+
+    # A fixed positive fine link can occur at any of r positions and in either
+    # orientation; the other r-1 steps have eight safe choices.
+    r = 4
+    fixed_link_words = 2 * r * 8 ** (r - 1)
+    h = 4.0 / 12.0
+    det_incidence = (3.0 / r) * fixed_link_words * 2.0 ** (-r) * 12.0 ** (-r)
+    schur_incidence = 9.0 * fixed_link_words * 2.0 ** (-r) * 12.0 ** (-(r - 1))
+    checks.append(
+        (
+            "fixed_link_path_incidence",
+            fixed_link_words == 4096
+            and abs(det_incidence - 0.75 * h**r) < 1.0e-15
+            and abs(schur_incidence - 9.0 * r * h ** (r - 1)) < 1.0e-15,
+            f"words={fixed_link_words}, determinant={det_incidence:.12f}, schur={schur_incidence:.12f}",
+        )
+    )
+
+    # Odd closed nearest-neighbor words are excluded by parity; every length-2
+    # closed word is an immediate reversal and hence has U U^dagger=1.
+    directions = [(axis, sign) for axis in range(4) for sign in (-1, 1)]
+    two_step_closed = [
+        (first, second)
+        for first in directions
+        for second in directions
+        if first[0] == second[0] and first[1] == -second[1]
+    ]
+    checks.append(
+        (
+            "induced_bipartite_constant_floor",
+            len(two_step_closed) == 8,
+            f"odd closed words forbidden; length-two reversals={len(two_step_closed)}",
+        )
+    )
+
+    eta_probe = 0.37
+    left: Exterior = {(): 0.7, (0, 1): -0.2, (2, 3): 0.11}
+    right: Exterior = {(): -0.4, (0, 3): 0.3, (1, 2): -0.17}
+    product = ext_mul(left, right)
+    checks.append(
+        (
+            "eta_norm_submultiplicative",
+            ext_norm(product, eta_probe) <= ext_norm(left, eta_probe) * ext_norm(right, eta_probe) + 1.0e-15,
+            "product={:.12f}, bound={:.12f}".format(
+                ext_norm(product, eta_probe), ext_norm(left, eta_probe) * ext_norm(right, eta_probe)
+            ),
+        )
+    )
+
+    body, direct, polymer, log_residual = banach_polymer_identity()
+    regrouping_residual = max_coefficient_difference(direct, polymer)
+    logarithm_residual = max((abs(value) for value in log_residual.values()), default=0.0)
+    normalized_nilpotent = ext_add(ext_scale(direct, 1.0 / body), {(): 1.0}, -1.0)
+    logarithm = ext_log_one_plus(normalized_nilpotent, 4)
+    quartic = logarithm.get((0, 1, 2, 3), 0.0)
+    checks.append(
+        (
+            "banach_factor_to_polymer_identity",
+            body > 0.0 and regrouping_residual < 1.0e-14 and logarithm_residual < 1.0e-14,
+            f"body={body:.12f}, regrouping={regrouping_residual:.3e}, log={logarithm_residual:.3e}",
+        )
+    )
+    checks.append(
+        (
+            "balanced_quartic_connected_log",
+            abs(quartic) > 1.0e-8 and all(len(monomial) % 2 == 0 for monomial in logarithm),
+            f"quartic={quartic:.12f}, monomials={sorted(logarithm)}",
+        )
+    )
+
+    # The first and last fine links of a retained-to-retained Schur path belong
+    # to outgoing or incoming skeleton pairs, so the endpoint coarse cells are
+    # already charged by the syntactic support convention.
+    coarse_path = [(0, 0, 0, 0), (0, 0, 0, 0), (1, 0, 0, 0), (1, 1, 0, 0)]
+    connected = all(sum(abs(a - b) for a, b in zip(x, y)) <= 1 for x, y in zip(coarse_path, coarse_path[1:]))
+    checks.append(
+        (
+            "schur_path_coarse_support",
+            connected and coarse_path[0] == (0, 0, 0, 0) and coarse_path[-1] == (1, 1, 0, 0),
+            f"coarse_path={coarse_path}, anchor_multiplicity=68",
+        )
+    )
+
+    text = NOTE.read_text()
+    required = [
+        "**Type:** bounded_theorem",
+        "det D_II",
+        "K_joint=K_W+K_I+K_S<c",
+        "q=h exp(L)<1",
+        "complete Reinhardt",
+        "every fine\nextent at least four",
+        "68 exp(lambda/2)c+3m eta^2 exp(theta/2)",
+        "not a physical field normalization",
+        "No axiom-update stop is established.",
+        "### N1",
+        "### N2",
+        "### N3",
+        "### N4",
+        "### N5",
+        "### N6",
+        "### N7",
+        "### N8",
+    ]
+    missing = [item for item in required if item not in text]
+    forbidden = ["Block 28's full-determinant measure applies unchanged", "NOT_TESTED"]
+    hits = [item for item in forbidden if item in text]
+    checks.append(("source_contract", not missing and not hits, f"missing={missing}, forbidden_hits={hits}"))
+
+    expected_dependencies = sorted(
+        [
+            "MASSIVE_WILSON_STAGGERED_FACTOR_TWO_GAUGE_BLOCK_SCHUR_OS_SEMIGROUP_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_CONSTRAINED_FIBER_DOBRUSHIN_AND_RAW_RG_UNIT_DIRECTIONS_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_CONSTRAINED_FIBER_TWO_LAYER_KP_COMPLEX_SOURCE_POLYMER_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+        ]
+    )
+    note_links = re.findall(r"\]\(([^)#?]+\.md)\)", text)
+    dependency_set = sorted(set(note_links))
+    checks.append(
+        (
+            "repository_dependency_set",
+            dependency_set == expected_dependencies,
+            f"markdown_dependency_set={dependency_set}",
+        )
+    )
+
+    passed = sum(ok for _, ok, _ in checks)
+    failed = len(checks) - passed
+    for name, ok, detail in checks:
+        print(f"{'PASS' if ok else 'FAIL'} {name}: {detail}")
+    print(f"SCORECARD PASS={passed} FAIL={failed}")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Result

Closes the exact one-step retained gauge–Grassmann action in one simultaneous all-degree connected polymer norm in an explicit deeper high-mass/small-coupling region.

The load-bearing correction is the positive body: the retained weight uses `det D_II`, not Block 28's full `det D`. This PR derives a separate `m>4` hopping/path activity row for `det D_II`, then adds the Schur retained-to-retained paths as even balanced Grassmann-valued activities in the declared `eta`-weighted Banach algebra.

Under `q=(4/m)exp(L)<1` and `K_W+K_I+K_S<c`, it proves a uniform connected decomposition with

`||Gamma_c||_(lambda/2,theta/2,eta) <= 68 exp(lambda/2)c + 3m eta^2 exp(theta/2)`.

Three strict witnesses are provided at `m=12,16,20`. The theorem sums endpoints, paths, supports, colors, and every balanced Grassmann degree simultaneously. It does not claim an invariant rescaled RG neighborhood, contraction, taste selection, retained-fermion OS/CAR reconstruction, or a continuum trajectory.

## Review

Independent code/math, physics/import/Nature, and governance/no-go reviews passed after one N2 repair separating projected RG, physical taste-carrier identification, and critical-trajectory identification.

## Checks

- runner/cache: `PASS=14 FAIL=0`
- exact Banach-valued factor/polymer regrouping and nonzero connected quartic witness
- Python compilation: pass
- controlled vocabulary lint: pass
- `git diff --check`: pass
- full audit pipeline: pass
- strict audit lint: no errors
- seeded row: `bounded_theorem`, `unaudited`, with exactly the three intended Block24/25/28 dependencies

Stacked on #5322.
