### PR TITLE
audit-infra: bind authenticated occurrence metadata

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -569,6 +569,13 @@ literal marker accepted for its `route_class`:
 - `topology_or_global_structure`: topology, global, bundle, homotopy, cohomology;
 - `dependency_or_registry_reclassification`: dependency, registry, reclassification, premise, authority.
 
+At least one of `mechanism`, `attempt`, or `outcome` itself must contain that
+literal class marker. If a live check label lacks the marker, use a nearby
+marker-bearing live section header as one of the three fields when that header
+genuinely names the same route. Do not duplicate `mechanism` into `attempt` or
+`outcome` unless the live stdout itself supplies the same text for those
+distinct semantic roles.
+
 When the gate is `FAIL`, list only the genuinely evidenced routes; fewer than
 five is valid and records the N1 failure. Do not fabricate extra routes merely
 to reach five.
@@ -615,6 +622,11 @@ its hit as `hidden_admission` with the matching N2 wall or as
 
 For every N3 hit and N5 statement, copy `phrase` byte-for-byte from the
 corresponding `full_phrase_groups[].phrase` value in the evidence manifest.
+Copy the complete authenticated tuple—`phrase`, `occurrence_group_id`,
+`occurrence_count`, `occurrence_locator_sha256`, and `evidence_locator`—from
+one and the same `full_phrase_groups[]` record. Never reuse a group id or
+locator digest under a different phrase, even when both occur on the same
+path.
 Never paraphrase a phrase, join two phrases with punctuation or a slash, or
 collapse distinct phrases into one object. For example, `boundary` and
 `primitive` require separate objects even when one source sentence contains

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -7116,6 +7116,54 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             m.validate_no_go_discipline(audit, evidence_manifest=manifest) or "",
         )
 
+    def test_n1_algebraic_route_uses_marker_bearing_live_header(self):
+        m = _import("no_go_discipline_gate")
+        manifest = self._manifest()
+        stdout_path = "audit-packet://runner-stdout/test_no_go"
+        header = "Part A: generic determinant identity"
+        check_one = "generic realification determinant is squared modulus"
+        check_two = "realified functional is twice complex functional on A"
+        manifest[stdout_path]["text"] += "\n" + "\n".join(
+            (header, check_one, check_two)
+        )
+        packet = _no_go_packet()
+        route = packet["N1_alternative_routes"][0]
+        route.update({
+            "route_id": "det_identity",
+            "route_class": "algebraic_rearrangement",
+            "mechanism": header,
+            "attempt": check_one,
+            "outcome": check_two,
+            "evidence_path": stdout_path,
+            "evidence_locator": header,
+        })
+        packet["N7_steelman"]["route_id"] = "det_identity"
+        n7_argument = (
+            "The strongest counter-route uses Part A: generic determinant identity "
+            "and attempts generic realification determinant is squared modulus; "
+            "its outcome is realified functional is twice complex functional on A."
+        )
+        packet["N7_steelman"]["argument"] = n7_argument
+        manifest[stdout_path]["text"] += "\n" + n7_argument
+        _set_no_go_scan_coverage(packet, manifest)
+        audit = {
+            "claim_type": "no_go", "verdict": "audited_clean",
+            "chain_closes": True, "no_go_discipline": packet,
+        }
+        self.assertIsNone(
+            m.validate_no_go_discipline(audit, evidence_manifest=manifest)
+        )
+        route.update({
+            "mechanism": check_one,
+            "attempt": check_one,
+            "outcome": check_two,
+            "evidence_locator": check_one,
+        })
+        self.assertIn(
+            "not supported by its evidenced",
+            m.validate_no_go_discipline(audit, evidence_manifest=manifest) or "",
+        )
+
     def test_n1_symmetry_route_accepts_invariance_vocabulary(self):
         m = _import("no_go_discipline_gate")
         manifest = self._manifest()
@@ -7809,6 +7857,18 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         )
         self.assertIn(
             "copied byte-for-byte as one contiguous substring",
+            template_flat,
+        )
+        self.assertIn(
+            "Copy the complete authenticated tuple",
+            template_flat,
+        )
+        self.assertIn(
+            "from one and the same `full_phrase_groups[]` record",
+            template_flat,
+        )
+        self.assertIn(
+            "use a nearby marker-bearing live section header",
             template_flat,
         )
 
@@ -9407,6 +9467,155 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
                 )
             )
 
+    def test_authenticated_occurrence_metadata_binds_unique_tuple_only(self):
+        m = _import_codex_audit_runner()
+        group = {
+            "phrase": "axiom",
+            "occurrence_group_id": "3ec574c76f47c467",
+            "occurrence_count": 1,
+            "occurrence_locator_sha256": "9" * 64,
+            "evidence_locator": "the exact axiom occurrence locator",
+        }
+        manifest = {
+            "docs/SOURCE.md": {
+                "path": "docs/SOURCE.md",
+                "roles": ["source"],
+                "text": "the exact axiom occurrence locator",
+                "full_phrase_groups": [group],
+            }
+        }
+        hit = {
+            "phrase": "axiom",
+            "occurrence_group_id": "91368724cca5145",
+            "occurrence_count": 7,
+            "occurrence_locator_sha256": "8" * 64,
+            "classification": "non_load_bearing",
+            "rationale": "This occurrence carries no premise load in the scoped proof.",
+            "evidence_path": "docs/SOURCE.md",
+            "evidence_locator": "the exact axiom occurrence locator",
+        }
+        statement = {
+            **hit,
+            "phrase": "axiom",
+            "tested_resolutions": ["judgment content remains untouched"],
+        }
+        blob = {
+            "verdict": "audited_clean",
+            "no_go_discipline": {
+                "N3_hidden_wall_scan": {"hits": [hit]},
+                "N5_rhetoric_audit": {"statements": [statement]},
+            },
+        }
+        before_judgment = {
+            "verdict": blob["verdict"],
+            "classification": hit["classification"],
+            "rationale": hit["rationale"],
+            "tested_resolutions": list(statement["tested_resolutions"]),
+        }
+        changes = m.bind_authenticated_occurrence_metadata(blob, manifest)
+        self.assertEqual(len(changes), 6)
+        for item in (hit, statement):
+            self.assertEqual(item["occurrence_group_id"], group["occurrence_group_id"])
+            self.assertEqual(item["occurrence_count"], group["occurrence_count"])
+            self.assertEqual(
+                item["occurrence_locator_sha256"],
+                group["occurrence_locator_sha256"],
+            )
+        self.assertEqual(blob["verdict"], before_judgment["verdict"])
+        self.assertEqual(hit["classification"], before_judgment["classification"])
+        self.assertEqual(hit["rationale"], before_judgment["rationale"])
+        self.assertEqual(
+            statement["tested_resolutions"], before_judgment["tested_resolutions"]
+        )
+
+    def test_authenticated_occurrence_metadata_refuses_cross_label_and_ambiguity(self):
+        m = _import_codex_audit_runner()
+        groups = [
+            {
+                "phrase": "sector",
+                "occurrence_group_id": "29cbe9be0b190830",
+                "occurrence_count": 1,
+                "occurrence_locator_sha256": "1" * 64,
+                "evidence_locator": "first real sector locator",
+            },
+            {
+                "phrase": "canonical",
+                "occurrence_group_id": "b4db14624baf74e0",
+                "occurrence_count": 1,
+                "occurrence_locator_sha256": "2" * 64,
+                "evidence_locator": "shared rhetoric locator",
+            },
+        ]
+        manifest = {
+            "docs/SOURCE.md": {
+                "path": "docs/SOURCE.md", "roles": ["source"],
+                "text": "first real sector locator\nshared rhetoric locator",
+                "full_phrase_groups": groups,
+            }
+        }
+        cross_labeled = {
+            "phrase": "sector",
+            "occurrence_group_id": "b4db14624baf74e0",
+            "occurrence_count": 1,
+            "occurrence_locator_sha256": "2" * 64,
+            "classification": "non_load_bearing",
+            "rationale": "This cross-labeled test must remain fail-closed.",
+            "evidence_path": "docs/SOURCE.md",
+            "evidence_locator": "shared rhetoric locator",
+        }
+        blob = {"no_go_discipline": {"N3_hidden_wall_scan": {"hits": [cross_labeled]}}}
+        self.assertEqual(m.bind_authenticated_occurrence_metadata(blob, manifest), [])
+        self.assertEqual(cross_labeled["occurrence_group_id"], "b4db14624baf74e0")
+
+        ambiguous_manifest = json.loads(json.dumps(manifest))
+        ambiguous_manifest["docs/SOURCE.md"]["full_phrase_groups"] = [
+            groups[0],
+            {**groups[0], "occurrence_group_id": "90a40dc4ab7e0027"},
+        ]
+        cross_labeled["evidence_locator"] = "first real sector locator"
+        self.assertEqual(
+            m.bind_authenticated_occurrence_metadata(blob, ambiguous_manifest), []
+        )
+        self.assertEqual(cross_labeled["occurrence_group_id"], "b4db14624baf74e0")
+
+    def test_locator_repair_preservation_allows_bound_metadata_only(self):
+        m = _import_codex_audit_runner()
+        rejected = {
+            "verdict": "audited_clean",
+            "no_go_discipline": {
+                "N3_hidden_wall_scan": {
+                    "hits": [{
+                        "phrase": "axiom",
+                        "occurrence_group_id": "bad-id",
+                        "occurrence_count": 7,
+                        "occurrence_locator_sha256": "8" * 64,
+                        "classification": "non_load_bearing",
+                        "rationale": (
+                            "This exact occurrence carries no premise load in the proof."
+                        ),
+                        "evidence_path": "docs/SOURCE.md",
+                        "evidence_locator": "bad locator",
+                    }]
+                }
+            },
+        }
+        repaired = json.loads(json.dumps(rejected))
+        repaired_hit = repaired["no_go_discipline"]["N3_hidden_wall_scan"]["hits"][0]
+        repaired_hit.update({
+            "occurrence_group_id": "3ec574c76f47c467",
+            "occurrence_count": 1,
+            "occurrence_locator_sha256": "9" * 64,
+            "evidence_locator": "the exact axiom occurrence locator",
+        })
+        self.assertIsNone(
+            m.validation_repair_preservation_error(rejected, repaired)
+        )
+        repaired_hit["classification"] = "hidden_admission"
+        self.assertIn(
+            "changed preserved no-go judgment content",
+            m.validation_repair_preservation_error(rejected, repaired) or "",
+        )
+
     def test_fresh_schema_retry_exposes_error_not_rejected_conclusion(self):
         m = _import_codex_audit_runner()
         self.assertTrue(m.fresh_schema_retry_eligible(
@@ -9469,6 +9678,29 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         )
         self.assertIn("byte-for-byte as a contiguous line", n5_prompt)
         self.assertNotIn("statement 1", n5_prompt)
+        n3_tuple_code = m.fresh_schema_retry_code(
+            "N3 hit 2.occurrence_group_id must be a 16-hex context digest"
+        )
+        self.assertEqual(
+            n3_tuple_code, "N3_AUTHENTICATED_GROUP_TUPLE_MISMATCH"
+        )
+        n3_tuple_prompt = m.render_fresh_schema_retry_prompt(
+            "ORIGINAL RESTRICTED PACKET", n3_tuple_code, 1,
+        )
+        self.assertIn("from one same full_phrase_groups record", n3_tuple_prompt)
+        self.assertNotIn("hit 2", n3_tuple_prompt)
+        n3_scan_code = m.fresh_schema_retry_code(
+            "N3.hits must exactly disposition orchestrator phrase scan; "
+            "missing=[], extra=[('secret_path', 'sector', 'secret_id')]"
+        )
+        self.assertEqual(
+            n3_scan_code, "N3_AUTHENTICATED_GROUP_TUPLE_MISMATCH"
+        )
+        n3_scan_prompt = m.render_fresh_schema_retry_prompt(
+            "ORIGINAL RESTRICTED PACKET", n3_scan_code, 1,
+        )
+        self.assertNotIn("secret_path", n3_scan_prompt)
+        self.assertNotIn("secret_id", n3_scan_prompt)
 
     def test_failed_locator_repair_preserves_fresh_schema_eligibility(self):
         m = _import_codex_audit_runner()

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1534,6 +1534,78 @@ def validate_verdict(
     return None
 
 
+AUTHENTICATED_OCCURRENCE_FIELDS = (
+    "occurrence_group_id",
+    "occurrence_count",
+    "occurrence_locator_sha256",
+)
+
+
+def bind_authenticated_occurrence_metadata(
+    blob: dict,
+    evidence_manifest: dict[str, dict] | None,
+) -> list[dict[str, object]]:
+    """Bind orchestrator-owned N3/N5 occurrence metadata after a unique match.
+
+    The auditor owns classification, rationale, tested resolutions, walls, and
+    verdict content. The orchestrator owns the occurrence IDs/counts/digests.
+    Bind those three metadata fields only when the auditor's exact
+    (evidence_path, phrase, evidence_locator) selects one authenticated
+    full_phrase_groups record. Zero or multiple matches remain untouched and
+    fail closed in the ordinary validator.
+    """
+    if evidence_manifest is None:
+        return []
+    packet = blob.get("no_go_discipline")
+    if not isinstance(packet, dict):
+        return []
+    changes: list[dict[str, object]] = []
+    for section_name, collection_name in (
+        ("N3_hidden_wall_scan", "hits"),
+        ("N5_rhetoric_audit", "statements"),
+    ):
+        section = packet.get(section_name)
+        if not isinstance(section, dict):
+            continue
+        items = section.get(collection_name)
+        if not isinstance(items, list):
+            continue
+        for index, item in enumerate(items, 1):
+            if not isinstance(item, dict):
+                continue
+            path = item.get("evidence_path")
+            phrase = item.get("phrase")
+            locator = item.get("evidence_locator")
+            if not all(isinstance(value, str) and value for value in (path, phrase, locator)):
+                continue
+            entry = evidence_manifest.get(path)
+            if not isinstance(entry, dict):
+                continue
+            matches = [
+                group
+                for group in entry.get("full_phrase_groups") or []
+                if isinstance(group, dict)
+                and group.get("phrase") == phrase
+                and group.get("evidence_locator") == locator
+            ]
+            if len(matches) != 1:
+                continue
+            group = matches[0]
+            for field in AUTHENTICATED_OCCURRENCE_FIELDS:
+                expected = group.get(field)
+                if expected is None or item.get(field) == expected:
+                    continue
+                changes.append({
+                    "section": section_name,
+                    "index": index,
+                    "field": field,
+                    "from": item.get(field),
+                    "to": expected,
+                })
+                item[field] = expected
+    return changes
+
+
 def compute_required_reason(reply: str | None) -> str | None:
     """Accept only the exact one-line COMPUTE_REQUIRED escape protocol."""
     if not reply:
@@ -1597,6 +1669,20 @@ def fresh_schema_retry_eligible(validation_error: str | None) -> bool:
 
 def fresh_schema_retry_code(validation_error: str) -> str:
     """Reduce validator text to a conclusion-free control-plane code."""
+    if (
+        validation_error.startswith("N3 hit ")
+        and "occurrence_" in validation_error
+    ) or validation_error.startswith(
+        "N3.hits must exactly disposition orchestrator phrase scan"
+    ):
+        return "N3_AUTHENTICATED_GROUP_TUPLE_MISMATCH"
+    if (
+        validation_error.startswith("N5 statement ")
+        and "occurrence_" in validation_error
+    ) or validation_error.startswith(
+        "N5.statements must exactly disposition orchestrator rhetoric scan"
+    ):
+        return "N5_AUTHENTICATED_GROUP_TUPLE_MISMATCH"
     if validation_error.startswith("N3 retained_authority hit "):
         return "N3_RETAINED_AUTHORITY_PROVENANCE_MISMATCH"
     if validation_error.startswith("transport-bounded N8"):
@@ -1657,7 +1743,23 @@ def render_fresh_schema_retry_prompt(
         ),
         "N1_ROUTE_CLASS_MARKER_MISMATCH": (
             "Static N1 invariant: the joined mechanism, attempt, and outcome must "
-            "contain a documented literal marker for the selected route_class.\n"
+            "contain a documented literal marker for the selected route_class. "
+            "At least one of those fields must itself copy the marker. When a "
+            "check label lacks it, use an evidenced marker-bearing live section "
+            "header that genuinely names the same route; do not duplicate fields "
+            "unless stdout supplies the same text for distinct semantic roles.\n"
+        ),
+        "N3_AUTHENTICATED_GROUP_TUPLE_MISMATCH": (
+            "Static N3 invariant: copy phrase, occurrence_group_id, "
+            "occurrence_count, occurrence_locator_sha256, and evidence_locator "
+            "from one same full_phrase_groups record. Never cross-label a group "
+            "id, count, digest, or locator under another phrase.\n"
+        ),
+        "N5_AUTHENTICATED_GROUP_TUPLE_MISMATCH": (
+            "Static N5 invariant: copy phrase, occurrence_group_id, "
+            "occurrence_count, occurrence_locator_sha256, and evidence_locator "
+            "from one same full_phrase_groups record. Never cross-label a group "
+            "id, count, digest, or locator under another phrase.\n"
         ),
         "N5_TESTED_RESOLUTION_VERBATIM_MISMATCH": (
             "Static N5 invariant: copy every complete tested_resolutions entry, "
@@ -1708,7 +1810,10 @@ def validation_repair_preservation_error(
             return {
                 key: without_locator_fields(item)
                 for key, item in value.items()
-                if key not in VALIDATION_REPAIR_LOCATOR_FIELDS
+                if key not in (
+                    VALIDATION_REPAIR_LOCATOR_FIELDS
+                    | set(AUTHENTICATED_OCCURRENCE_FIELDS)
+                )
             }
         if isinstance(value, list):
             return [without_locator_fields(item) for item in value]
@@ -2318,6 +2423,17 @@ def main() -> int:
                     }) + "\n")
                 continue
 
+            occurrence_bindings = bind_authenticated_occurrence_metadata(
+                blob, exact_evidence_manifest
+            )
+            if occurrence_bindings:
+                with run_log.open("a", encoding="utf-8") as f:
+                    f.write(json.dumps({
+                        "claim_id": cid,
+                        "phase": "authenticated_occurrence_metadata_bound",
+                        "bindings": occurrence_bindings,
+                    }) + "\n")
+
             note_path = row.get("note_path") or full_led_row.get("note_path") or ""
             note_body = read_note_body(note_path) or ""
             source_requires_no_go = (
@@ -2398,6 +2514,20 @@ def main() -> int:
                                 "reply": (repair_reply or "")[:2000],
                             }) + "\n")
                         continue
+                    repair_bindings = bind_authenticated_occurrence_metadata(
+                        repair_blob, exact_evidence_manifest
+                    )
+                    if repair_bindings:
+                        with run_log.open("a", encoding="utf-8") as f:
+                            f.write(json.dumps({
+                                "claim_id": cid,
+                                "phase": (
+                                    "validation_repair_authenticated_"
+                                    "occurrence_metadata_bound"
+                                ),
+                                "attempt": repair_attempt,
+                                "bindings": repair_bindings,
+                            }) + "\n")
                     preservation_error = validation_repair_preservation_error(
                         initial_rejected_blob, repair_blob
                     )
@@ -2481,6 +2611,20 @@ def main() -> int:
                     if schema_blob is None:
                         err = "fresh schema retry reply not valid JSON"
                         continue
+                    schema_bindings = bind_authenticated_occurrence_metadata(
+                        schema_blob, exact_evidence_manifest
+                    )
+                    if schema_bindings:
+                        with run_log.open("a", encoding="utf-8") as f:
+                            f.write(json.dumps({
+                                "claim_id": cid,
+                                "phase": (
+                                    "fresh_schema_retry_authenticated_"
+                                    "occurrence_metadata_bound"
+                                ),
+                                "attempt": schema_attempt,
+                                "bindings": schema_bindings,
+                            }) + "\n")
                     schema_error = validate_verdict(
                         schema_blob,
                         cid,


### PR DESCRIPTION
Deterministically binds N3/N5 occurrence authentication metadata after a unique exact evidence-manifest match, while preserving all scientific judgment fields and failing closed on zero, ambiguous, or cross-labeled matches. Strengthens prompt and typed-retry guidance for authenticated tuples and N1 route markers. Verification: 308 audit-pipeline tests; full repository pipeline; strict audit lint with no errors; Python compilation; diff check. Independent review-loop PASS on exact patch-equivalent head. No audit verdicts applied.