### PR TITLE
physics: define projected RG chart and raw suppression

### DIFF
--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
@@ -1,6 +1,34 @@
 # Handoff
 
 Current branch:
+`physics-loop/record-faithful-dynamics-block30-projected-rescaled-contraction-20260712`.
+The declared-RG-chart runner reports `PASS=10 FAIL=0`. The source declares a
+factor-two support dilation, the finite-rank diameter-zero projector `P_0`,
+finite Berezin/Peter--Weyl jet projectors, and the field-coordinate torsor
+`||D_rho Phi||_eta=||Phi||_(eta/rho)`. It extends the exact raw lift identity
+to even balanced retained polynomials.
+
+In this declared chart, every extended raw lifted direction remaining after
+`P_0` is suppressed by at least `exp(-lambda)`. This retires the concern that
+the infinite raw unit-direction family automatically defeats all rescaled
+contraction attempts. Fixed-background Schur mass/hopping tangent bounds are
+also explicit after `rho` rescaling.
+
+Independent code/math, physics/import/Nature, and governance/no-go review pass
+after correcting the per-mode scale factor to an upper bound. Audit validation
+seeds one `bounded_theorem` / `unaudited` row with exactly Block25 and Block29
+dependencies; strict lint has zero errors and generated outputs are stripped.
+
+The theorem does not establish a unique physical relevant sector, invariant
+ball, full non-fiber derivative contraction, nonlinear iteration, physical
+beta function, taste carrier, or critical trajectory. No axiom-update stop is
+triggered.
+
+Declared-RG-chart stacked PR:
+https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5330
+is open against the retained-Grassmann polymer head.
+
+Previous branch:
 `physics-loop/record-faithful-dynamics-block29-grassmann-polymer-norm-20260712`.
 The retained-Grassmann joint-polymer runner reports `PASS=14 FAIL=0`. The
 retained weight's correct positive body is `det D_II`, not the full `det D`.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
@@ -1,5 +1,21 @@
 # PR Delivery
 
+The declared projected/rescaled RG-chart theorem is delivered:
+
+- base: `physics-loop/record-faithful-dynamics-block29-grassmann-polymer-norm-20260712`
+- head: `physics-loop/record-faithful-dynamics-block30-projected-rescaled-contraction-20260712`
+- runner: `PASS=10 FAIL=0`
+- scope: finite diameter-zero and declared local-jet projectors, exact field-
+  rescaling torsor, joint raw-lift identity, and `exp(-lambda)` suppression of
+  every extended raw lifted mode in the declared support chart; no invariant
+  ball or full derivative contraction
+- audit compatibility: one `bounded_theorem` / `unaudited` row with exactly
+  Block25 and Block29 dependencies; pipeline/strict lint pass; generated
+  outputs stripped
+- PR: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5330
+
+No merge is authorized. Independent audit remains authoritative.
+
 The simultaneous retained gauge--Grassmann polymer-norm theorem is delivered:
 
 - base: `physics-loop/record-faithful-dynamics-block28-gauge-body-source-polymer-20260712`

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
@@ -887,3 +887,26 @@ repair. Audit validation seeds one `bounded_theorem` / `unaudited` row with
 source hash `ccd263928a7d0c58...` and exactly three intended dependencies;
 strict lint has zero errors and generated audit/status surfaces are stripped.
 PR #5327 is open. No negative theorem or axiom-update stop is triggered.
+
+## Declared projected/rescaled RG-chart review
+
+PASS WITH BOUNDED POSITIVE CLAIMS. The chart declares `H_2`, the full
+diameter-zero projector `P_0`, finite Berezin/Peter--Weyl jet projectors, and a
+field coordinate `rho`; none is promoted as a physical relevance or
+normalization selector. The exact raw factorization extends to even balanced
+retained polynomials. After doubled-support comparison, every extended raw
+lift left by `P_0` gains at least `exp(-lambda)` suppression.
+
+Code/math review verified the doubled-anchor comparison, finite rank and
+contractivity of `P_0`, the field norm identity, the Grassmann factorization,
+and the fixed-background Schur tangent signs/constants. It required equation
+(0.3) to be an upper bound rather than an exact ratio; the repair passed.
+Nature and governance review pass the declared-chart language, four-wall
+N1--N8 packet, and physical import firewall. Runner/cache: `PASS=10 FAIL=0`.
+
+Audit validation seeds one `bounded_theorem` / `unaudited` row with source
+hash `364153b46a3e6cbb...` and exactly the raw-unit and joint-polymer
+dependencies; strict lint has zero errors and generated status surfaces are
+stripped. PR #5330 is open. The invariant neighborhood, full non-fiber
+derivative, nonlinear contraction, taste carrier, and critical trajectory
+remain open. No axiom-update stop is triggered.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
@@ -8,32 +8,31 @@ current_goal: >-
   supply the physical evolution object, bare time ordering, record-formation
   weights, and an admissibility-to-carrier selector without importing the
   staggered/Dirac answer or sector-specific Standard Model and gravity laws.
-branch: physics-loop/record-faithful-dynamics-block29-grassmann-polymer-norm-20260712
+branch: physics-loop/record-faithful-dynamics-block30-projected-rescaled-contraction-20260712
 base_commit_at_start: 9d1636f05f
-cycle_count: 29
-block_count: 29
-active_route: wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm
+cycle_count: 30
+block_count: 30
+active_route: wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction
 hard_residual: >-
   Can the four-axiom record surface canonically determine a faithful local
   record-forming instrument whose coherent no-record block is sufficiently
   constrained to exclude the observationally disconnected SWAP--Laplacian
   completion and select the Clifford-vector carrier?
-produced_claim_id: wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_bounded_theorem_note_2026-07-12
+produced_claim_id: wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_bounded_theorem_note_2026-07-12
 actual_current_surface_status: bounded-support
 conditional_surface_status: >-
-  In an explicit deeper m>4 subwedge, the exact retained gauge--Grassmann
-  one-step logarithm has a uniform connected decomposition in one simultaneous
-  eta-weighted all-degree norm. No invariant rescaled neighborhood,
-  relevant-coordinate projection, contraction, physical taste carrier,
-  retained-fermion OS/CAR reconstruction, critical trajectory, or continuum
-  theorem is proved.
+  A declared factor-two support chart, finite diameter-zero/local-jet
+  projectors, and a field-rescaling torsor are explicit. Every extended raw
+  lifted direction gains at least exp(-lambda) suppression after projection in
+  that chart. No invariant neighborhood, full non-fiber derivative
+  contraction, physical relevance/taste selector, critical trajectory, or
+  continuum theorem is proved.
 admitted_observation_status: none
 claim_type_reason: >-
-  The source proves a direct eliminated-determinant hopping row and a
-  simultaneous Banach-valued Schur-path KP bound with explicit nonempty
-  points. It keeps symmetry-adapted coordinates, projected/rescaled
-  contraction, physical taste identification, critical trajectory, and
-  continuum limits open.
+  The source constructs bounded mathematical RG charts and proves the exact
+  scale-weighted suppression of the entire extended raw-lift family. It keeps
+  the invariant ball, non-fiber derivative, nonlinear contraction, physical
+  relevance/taste identification, and critical trajectory open.
 hypothetical_axiom_status: null
 proposal_allowed: false
 proposal_allowed_reason: >-
@@ -130,6 +129,9 @@ files_touched:
   - docs/WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md
   - scripts/wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_2026_07_12.py
   - logs/runner-cache/wilson_staggered_retained_grassmann_two_layer_kp_polymer_norm_2026_07_12.txt
+  - docs/WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md
+  - scripts/wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_2026_07_12.py
+  - logs/runner-cache/wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_2026_07_12.txt
 open_imports:
   - fundamental process object: Hamiltonian, strict tick, or record instrument
   - faithful law-to-record influence principle
@@ -176,10 +178,11 @@ no_go_routes:
   - coarse-gauge Gibbsianness does not by itself provide a uniform translation-adapted anchored interaction norm or the all-order source cumulants needed for the retained gauge--Grassmann action; complete-analyticity, cluster, and constructive RG routes remain live
   - a scalar gauge-body source/polymer theorem does not by itself place the retained Grassmann coefficients in one simultaneous all-degree Banach norm or supply a projected/rescaled RG contraction
   - one-step simultaneous gauge--Grassmann norm membership does not by itself define an invariant factor-two rescaled neighborhood or remove the exact raw relevant directions
+  - geometric suppression of every extended raw lifted mode does not control the non-fiber derivative or prove invariance/nonlinear contraction of one joint ball
 trace_gate_classification: direct_blocker_closure
 reachability_to_target: partially_closes
-review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_two_layer_source_polymer_pass_retained_grassmann_polymer_norm_pass_bounded
-pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open_two_layer_source_polymer_open_retained_grassmann_polymer_norm_open
+review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_two_layer_source_polymer_pass_retained_grassmann_polymer_norm_pass_declared_rg_chart_pass_bounded
+pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open_two_layer_source_polymer_open_retained_grassmann_polymer_norm_open_declared_rg_chart_open
 block01_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5178
 block02_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5181
 block03_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5201
@@ -209,11 +212,12 @@ block26_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/
 block27_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5317
 block28_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5322
 block29_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5327
+block30_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5330
 next_exact_action: >-
-  Define symmetry-adapted vacuum, mass, kinetic, gauge, and remaining
-  relevant/marginal coordinates on the joint action space. Extract them,
-  apply factor-two geometric and field rescaling, and test whether the
-  irrelevant derivative is strictly contractive on one invariant neighborhood.
+  Bound the non-fiber derivative in the declared factor-two chart, including
+  determinant scalar loops and every Grassmann degree, then prove or delimit
+  an invariant joint ball with nonlinear irrelevant Lipschitz constant below
+  one. Keep any contraction in this deep wedge distinct from criticality.
 stop_condition: >-
   Stop and discuss an axiom update only if an exact result proves that the
   required bridge cannot be derived and an additional approved axiom or

--- a/docs/WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md
+++ b/docs/WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,342 @@
+# Declared factor-two RG chart and geometric suppression of raw lifted directions
+
+**Date:** 2026-07-12
+**Type:** bounded_theorem
+**Status:** unaudited candidate; effective status is pipeline-derived only after independent audit.
+**Primary runner:** [`scripts/wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_2026_07_12.py`](../scripts/wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_2026_07_12.py)
+**Cached output:** [`logs/runner-cache/wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_2026_07_12.txt`](../logs/runner-cache/wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_2026_07_12.txt)
+
+## 0. Result
+
+The exact one-step joint action now has an explicit family of mathematical RG
+charts. In those charts, the raw unit directions identified previously split
+cleanly into a finite zero-diameter sector and geometrically suppressed
+extended directions.
+
+Use the joint action space and analytic one-step neighborhood from the
+[simultaneous retained-Grassmann polymer theorem](WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md),
+and the exact raw lift identity from the
+[constrained-fiber raw unit-direction theorem](WILSON_STAGGERED_CONSTRAINED_FIBER_DOBRUSHIN_AND_RAW_RG_UNIT_DIRECTIONS_BOUNDED_THEOREM_NOTE_2026-07-12.md).
+
+This note declares, rather than physically selects, three chart ingredients:
+
+1. a factor-two dilation support `H_2(X)` containing the doubled sites and
+   straight two-link representatives of every link in `X`;
+2. the projector `P_0` onto translation/symmetry-invariant diameter-zero
+   interaction coordinates;
+3. a positive field-coordinate parameter `rho` with
+   `bar psi'=rho bar psi`, `psi'=rho psi`.
+
+They obey the exact norm identity
+
+```text
+||D_rho Phi||_(lambda,theta,eta)=||Phi||_(lambda,theta,eta/rho),     (0.1)
+```
+
+and, at `rho=1`, every raw lifted interaction in `(1-P_0)` obeys
+
+```text
+||(1-P_0) D_(2,1) R L Phi||_(lambda,theta,eta)
+ <=exp(-lambda)||(1-P_0)L Phi||_(lambda,theta,eta).                 (0.2)
+```
+
+Here `R L Phi=Phi` is the exact fiber-constant identity and `D_(2,rho)` means
+factor-two support relabeling followed by `D_rho`. More generally, the norm
+ratio of a pure balanced pair-degree `p` term on `X` is bounded by
+
+```text
+ratio_(X,p)<=rho^(-2p) exp[-lambda diam X]
+              exp[-theta(|H_2(X)|-|X|)].                            (0.3)
+```
+
+for the declared support representative. Equation (0.2) retires the concern
+that the infinite family of raw unit directions automatically forbids every
+rescaled contraction. It proves contraction only on the extended
+fiber-constant lifted subspace, not on the full derivative.
+
+Any finite set of local Berezin/Peter--Weyl coefficient modes also defines a
+bounded finite-rank coordinate projector. Different finite jet sets and every
+`rho>0` give legitimate, generally inequivalent charts for the same exact
+coarse functional. The existing science does not select one as the physical
+relevant/marginal sector or choose a physical field normalization.
+
+The theorem does not establish an invariant neighborhood, a full irrelevant
+Lipschitz constant below one, nonlinear stability, a fixed point, a physical
+beta function, taste selection, or a critical continuum trajectory.
+
+No axiom-update stop is established.
+
+## 1. Joint interaction space and local coordinate projectors
+
+An element is a chosen connected interaction decomposition
+
+```text
+Phi={Phi_X},
+||Phi||_(lambda,theta,eta)
+ =sup_z sum_(X contains z)
+   exp[lambda diam X+theta|X|]||Phi_X||_eta.                         (1.1)
+```
+
+For the translation- and supplied-symmetry-invariant subspace, retain every
+diameter-zero coefficient in
+
+```text
+P_0 Phi={Phi_X:diam X=0}.                                           (1.2)
+```
+
+There are no link variables internal to a one-site polymer. With three color
+components and balanced even Grassmann degree, the invariant local algebra is
+finite-dimensional. Therefore `P_0` is a finite-rank idempotent on the
+symmetry-invariant interaction space and
+
+```text
+||P_0||<=1,                    ||1-P_0||<=1                          (1.3)
+```
+
+for the fixed coefficient decomposition.
+
+More elaborate declared jets are also available. Choose finitely many local
+jointly gauge-invariant basis elements `e_j`, such as an onsite bilinear, a
+symmetry-averaged shortest covariant bilinear, or a plaquette character. Their
+Berezin coefficient and normalized Haar/Peter--Weyl coefficient maps are
+bounded linear functionals `ell_j` in the sup/projective norm. After replacing
+the basis by its finite Gram-dual if necessary,
+
+```text
+P_J Phi=sum_(j in J) ell_j(Phi)e_j,
+P_J^2=P_J,                  rank P_J<infinity.                       (1.4)
+```
+
+This is coordinate extraction, not a relevance theorem. Vacuum, onsite,
+short-bilinear, and plaquette labels acquire physical meanings only after a
+fixed point, normalization condition, carrier, and observable bridge are
+supplied.
+
+One useful fixed-background tangent check is already explicit. Introduce a
+declared hopping coordinate `t` in the Schur kernel,
+
+```text
+S_t=mI-t^2 A(mI+tM_II)^(-1)B.                                      (1.5)
+```
+
+With `||A||,||B||,||M_II||<=4` and `m>4`, differentiation at `t=1` gives
+
+```text
+||partial_m S||<=1+16/m^2,
+||partial_t S||<=32/m+64/m^2.                                      (1.6)
+```
+
+After `D_rho`, both bilinear bounds acquire `rho^(-2)`. These are bounded
+coordinate tangents, not RG eigenvalues. The eliminated-determinant response
+also produces scalar loop coordinates and is not hidden inside (1.6).
+
+## 2. Declared factor-two support chart
+
+For each connected coarse polymer `X`, declare `H_2(X)` on the fine lattice to
+contain the doubled sites `2X` and the straight fine paths representing its
+coarse links. Then
+
+```text
+diam H_2(X)>=2 diam X,
+|H_2(X)|>=|X|.                                                       (2.1)
+```
+
+The first inequality is exact because the two doubled endpoints realizing a
+diameter pair remain in the support. The second follows from the injection
+`x->2x`. This declaration fixes a common fine/coarse support convention that
+the preceding notes intentionally had not selected.
+
+Let `L Phi` be the fiber-constant lift to `H_2(X)`. The exact factorization
+argument extends coefficient-wise to every even balanced retained polynomial:
+
+```text
+R(Psi+t L Phi)=R(Psi)+t Phi,
+DR_Psi[L Phi]=Phi,                                                   (2.2)
+```
+
+and all mixed higher derivatives containing `L Phi` vanish. The original raw
+unit ratio was measured before comparing the fine and coarse support weights.
+
+For an anchored output term, use the doubled anchor `2z` in the input norm.
+Equations (2.1)--(2.2) give
+
+```text
+exp[lambda diam X+theta|X|]
+ /exp[lambda diam H_2(X)+theta|H_2(X)|]
+ <=exp[-lambda diam X].                                             (2.3)
+```
+
+Every term in `(1-P_0)` has integer graph diameter at least one. Summing at the
+anchor proves (0.2). Thus a finite projector is not being claimed to remove
+the infinite raw-lift family; all extended members are paid by the declared
+geometric weight.
+
+## 3. Field-rescaling torsor
+
+For `rho>0`, define
+
+```text
+(D_rho Phi)(V,bar psi',psi')
+ =Phi(V,rho^(-1)bar psi',rho^(-1)psi').                             (3.1)
+```
+
+A balanced pair-degree `p` coefficient is multiplied by `rho^(-2p)`.
+Substitution in (1.1) proves (0.1) exactly. Consequently `D_rho` is an
+isometry from the `eta/rho` chart to the `eta` chart. If `rho>=1`, it is also
+nonexpansive at fixed `eta`; for `rho<1`, no volume-uniform fixed-`eta` bound
+over unbounded degree is asserted.
+
+Combining (2.3) with the degree factor gives (0.3). The onsite mass coordinate,
+for example, changes by `rho^(-2)`. Choices `rho=1` and `rho=2` therefore give
+different numerical mass coordinates while representing the same polynomial
+after the corresponding variable change.
+
+No condition in the direct dependencies fixes `rho`. The convergence weight
+`eta` is not a physical field normalization. The kinetic-isotropy primitive
+would equate declared temporal and spatial kinetic forms only; it does not
+choose their common coefficient, a taste carrier, or `rho`.
+
+## 4. What remains for a full contraction
+
+For a declared finite jet projector `P_J`, the desired map would be
+
+```text
+T_(J,rho)= (1-P_J)D_(2,rho)R.                                      (4.1)
+```
+
+A full theorem still requires all three of the following on one explicit ball:
+
+```text
+T_(J,rho)(B_delta) subset B_delta,
+sup_(Phi in B_delta)||DT_(J,rho)(Phi)||<1,
+uniform nonlinear remainder control.                               (4.2)
+```
+
+The prior complex joint source domain proves that derivatives exist and have
+cluster bounds. It does not compare every non-fiber input support with its
+rescaled output support, prove (4.2), or show that the output returns to the
+same ball. Equation (0.2) verifies the complete raw lifted part of that test;
+the non-fiber directions remain open.
+
+A contraction proved in the present high-mass/small-coupling domain would
+most naturally describe a massive ultralocal basin. It would not by itself
+provide the boundary-tuned critical trajectory required for a propagating
+continuum.
+
+## 5. Runner contract
+
+Run:
+
+```bash
+python3 scripts/wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_2026_07_12.py
+```
+
+The runner checks `P_0` idempotence, factor-two diameter/size inequalities,
+the anchored `exp(-lambda)` suppression on a nontrivial interaction, the exact
+field-rescaling norm identity, two inequivalent `rho` charts, coefficient-wise
+joint raw factorization, a nested finite-jet family, and the source/dependency
+contract. The general anchor comparison and bounded finite Gram-dual
+construction are analytic statements.
+
+## 6. No-Go Discipline N1--N8
+
+The note contains a narrow nonselection statement—existing science does not
+choose `P_J` or `rho`—but no impossibility theorem. The full N1--N8 packet is
+therefore load-bearing.
+
+### N1 — alternative-route enumeration
+
+| Route | Status | Executed test | Outcome |
+|---|---|---|---|
+| Zero-diameter coefficient projection | `ATTEMPTED` | Equations (1.2)--(1.3) and runner. | Exact finite-rank chart component. |
+| Finite Berezin/Peter--Weyl jets | `ATTEMPTED` | Equation (1.4) constructs bounded finite Gram-dual projectors. | Many finite choices exist; none is promoted physically. |
+| Taylor/background jets | `ATTEMPTED` | Compared with Haar coefficient extraction. | Requires a declared background and is not used. |
+| Factor-two support dilation | `ATTEMPTED` | Equations (2.1)--(2.3) and runner. | Extended raw lifts contract by `exp(-lambda)`. |
+| Field normalization | `ATTEMPTED` | Equations (3.1) and (0.1). | Exact `rho>0` torsor; no selector found in dependencies. |
+| Direct derivative from joint analyticity | `ATTEMPTED` | Section 4 separates existence from a scale-weighted operator bound. | Does not yet prove the non-fiber part of (4.2). |
+| Enlarged finite jet space | `ATTEMPTED` | Runner compares nested jet sets. | Changes coordinates but does not select one. |
+| Alternative norm/block kernel | `ATTEMPTED` | The direct dependencies were scanned for an autonomous support norm or selected block; neither supplies one. | Remains live for the full derivative. |
+
+### N2 — wall-independence audit
+
+The downstream conditions are `declared projected/rescaled chart`, `invariant
+self-map neighborhood with q<1`, `physical taste-carrier identification`, and
+`critical trajectory/observable identification`.
+
+| Left | Right | Left closes right? | Right closes left? | Independent? |
+|---|---|---:|---:|---:|
+| declared projected/rescaled chart | invariant self-map neighborhood with q<1 | No | No | Yes |
+| declared projected/rescaled chart | physical taste-carrier identification | No | No | Yes |
+| declared projected/rescaled chart | critical trajectory/observable identification | No | No | Yes |
+| invariant self-map neighborhood with q<1 | physical taste-carrier identification | No | No | Yes |
+| invariant self-map neighborhood with q<1 | critical trajectory/observable identification | No | No | Yes |
+| physical taste-carrier identification | critical trajectory/observable identification | No | No | Yes |
+
+The derivative, ball invariance, and nonlinear remainder are components of the
+second condition rather than inflated separate walls.
+
+### N3 — hidden-condition phrase scan
+
+| Phrase | Classification |
+|---|---|
+| `canonical` | No physical canonicality claim; the support and chart are declared. |
+| `physical mass` | No hit. |
+| `kinetic term` | Short-bilinear coordinate is not identified physically. |
+| `gauge coupling` | Plaquette mode is not identified with a renormalized coupling. |
+| `standard RG` | No hit. |
+| `field normalization` | Explicitly a nonselected chart parameter. |
+| `engineering dimension` | No imported dimension assignment. |
+| `by construction` | No proof-substitute hit. |
+| `we assume` | No hidden premise. |
+
+### N4 — citation/residual matching
+
+| Witness | Witness residual | Present use | Match? |
+|---|---|---|---:|
+| [Raw unit directions](WILSON_STAGGERED_CONSTRAINED_FIBER_DOBRUSHIN_AND_RAW_RG_UNIT_DIRECTIONS_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Unit ratio before projection/rescaling | Exact factorization in the declared support chart | Yes |
+| [Joint polymer norm](WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md) | One-step membership, no self-map | Domain for coordinate projectors and analytic derivatives | Yes |
+| Abstract Banach contraction theorem | Consequences after a self-map and `q<1` | Neither hypothesis is imported | No; context only |
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Tested? | Permitted conclusion |
+|---|---:|---|
+| Coordinate projector existence | Yes | Declared finite-rank charts exist. |
+| Field-rescaling family | Yes | Exact norm transformation and nonselection. |
+| Raw lifted extended directions | Yes | `exp(-lambda)` contraction in the declared chart. |
+| Full derivative at one action | Partly | Exists; no operator norm below one. |
+| Invariant neighborhood/nonlinear iteration | No | No contraction theorem. |
+| Physical relevance/taste/beta function | No | No physical RG identification. |
+| Critical continuum trajectory | No | No existence or impossibility claim. |
+
+### N6 — partial-closure and primitive scan
+
+The support dilation, finite jets, and `rho` are mathematical chart data. They
+do not add an action, probability, time, taste, scale, state, or field-
+normalization premise. The registered primitives neither supply nor obstruct
+the full estimate. The nonselection of a chart is not an axiom contradiction.
+
+### N7 — hostile steelman
+
+A hostile reviewer should object that a finite projector cannot remove the
+infinite raw unit-direction family. Correct; equation (2.3) pays every extended
+member geometrically and removes only diameter zero.
+
+A second should object that `exp(-lambda)` depends on a support convention.
+Correct; `H_2` is declared explicitly here. The theorem does not pretend that
+the earlier notes had already fixed a common autonomous fine/coarse norm.
+
+A third should say that another `rho`, jet set, norm, or taste-faithful block
+could close the full derivative. Correct; all remain live.
+
+### N8 — cross-cycle echo
+
+| Earlier surface | Earlier residual | Present treatment |
+|---|---|---|
+| Raw unit directions | Full unrescaled contraction impossible | Extended lifts gain the exact declared geometric factor; onsite terms are projected. |
+| Joint polymer membership | No RG chart | Finite jets, support dilation, and field torsor are now explicit. |
+| Compact deep-wedge continuum boundary | Massive interior is ultralocal | Any future contraction here is not mislabeled critical. |
+| Taste-blocking bridge attempts | Imported contraction constants lacked a map/norm | No external constant is imported; the remaining inequality is displayed. |
+
+No route is closed by relabeling, no physical beta function is claimed, and no
+axiom update is requested.

--- a/logs/runner-cache/wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_2026_07_12.txt
+++ b/logs/runner-cache/wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_2026_07_12.txt
@@ -1,0 +1,11 @@
+PASS zero_diameter_projector: rank_fixture=1, complement_terms=3
+PASS extended_raw_lift_geometric_suppression: coarse=0.387258788964, fine_lift=0.568890092245, ratio=0.680726900052, exp(-lambda)=0.794533602503
+PASS factor_two_support_inequalities: checked_supports=3
+PASS field_rescaling_norm_identity: norm_Dz_eta=0.403774047537, norm_eta_over_z=0.403774047537
+PASS field_chart_nonselection: z1_mass=3.000000, z2_mass=0.750000
+PASS joint_raw_lift_identity: action_shift=-0.085100000000, expected=-0.085100000000
+PASS finite_jet_chart_family: jet_A=['onsite', 'vacuum'], jet_B=['onsite', 'plaquette', 'short_bilinear', 'vacuum']
+PASS schur_coordinate_tangent_bounds: m=12:dm=0.138889,dt=0.388889; m=16:dm=0.132812,dt=0.281250; m=20:dm=0.130000,dt=0.220000
+PASS source_contract: missing=[], forbidden_hits=[]
+PASS repository_dependency_set: markdown_dependency_set=['WILSON_STAGGERED_CONSTRAINED_FIBER_DOBRUSHIN_AND_RAW_RG_UNIT_DIRECTIONS_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md']
+SCORECARD PASS=10 FAIL=0

--- a/scripts/wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_2026_07_12.py
+++ b/scripts/wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_2026_07_12.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Checks a declared factor-two RG chart and raw-lift suppression."""
+
+from __future__ import annotations
+
+import math
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_"
+    "CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md"
+)
+
+
+def diameter(support: frozenset[int]) -> int:
+    return max(support) - min(support) if support else 0
+
+
+def anchored_norm(
+    interaction: dict[frozenset[int], float], lam: float, theta: float
+) -> float:
+    anchors = set().union(*interaction) if interaction else set()
+    return max(
+        (
+            sum(
+                math.exp(lam * diameter(support) + theta * len(support)) * abs(value)
+                for support, value in interaction.items()
+                if anchor in support
+            )
+            for anchor in anchors
+        ),
+        default=0.0,
+    )
+
+
+def zero_diameter_projector(
+    interaction: dict[frozenset[int], float]
+) -> dict[frozenset[int], float]:
+    return {support: value for support, value in interaction.items() if diameter(support) == 0}
+
+
+def complement(
+    interaction: dict[frozenset[int], float]
+) -> dict[frozenset[int], float]:
+    return {support: value for support, value in interaction.items() if diameter(support) >= 1}
+
+
+def straight_factor_two_lift(
+    interaction: dict[frozenset[int], float]
+) -> dict[frozenset[int], float]:
+    lifted: dict[frozenset[int], float] = {}
+    for support, value in interaction.items():
+        if len(support) == 1:
+            site = next(iter(support))
+            fine_support = frozenset({2 * site})
+        else:
+            fine_support = frozenset(range(2 * min(support), 2 * max(support) + 1))
+        lifted[fine_support] = value
+    return lifted
+
+
+def grassmann_norm(coefficients: dict[int, float], eta: float) -> float:
+    return sum(abs(value) * eta ** degree for degree, value in coefficients.items())
+
+
+def field_rescale(coefficients: dict[int, float], z: float) -> dict[int, float]:
+    return {degree: value * z ** (-degree) for degree, value in coefficients.items()}
+
+
+def main() -> None:
+    checks: list[tuple[str, bool, str]] = []
+
+    interaction = {
+        frozenset({0}): 0.31,
+        frozenset({0, 1}): -0.12,
+        frozenset({1, 2}): 0.08,
+        frozenset({0, 1, 2}): 0.05,
+    }
+    p0 = zero_diameter_projector(interaction)
+    p0_twice = zero_diameter_projector(p0)
+    irrel = complement(interaction)
+    checks.append(
+        (
+            "zero_diameter_projector",
+            p0 == p0_twice
+            and set(p0) == {frozenset({0})}
+            and set(p0).isdisjoint(irrel),
+            f"rank_fixture={len(p0)}, complement_terms={len(irrel)}",
+        )
+    )
+
+    lam, theta = 0.23, 0.07
+    lifted = straight_factor_two_lift(irrel)
+    coarse_norm = anchored_norm(irrel, lam, theta)
+    fine_norm = anchored_norm(lifted, lam, theta)
+    ratio = coarse_norm / fine_norm
+    checks.append(
+        (
+            "extended_raw_lift_geometric_suppression",
+            ratio <= math.exp(-lam) + 1.0e-14,
+            f"coarse={coarse_norm:.12f}, fine_lift={fine_norm:.12f}, ratio={ratio:.12f}, exp(-lambda)={math.exp(-lam):.12f}",
+        )
+    )
+
+    # Every lifted extended support contains doubled endpoint separation and
+    # at least the original number of sites.
+    support_checks = []
+    for support in irrel:
+        lifted_support = next(
+            candidate
+            for candidate, value in straight_factor_two_lift({support: interaction[support]}).items()
+            if value == interaction[support]
+        )
+        support_checks.append(
+            diameter(lifted_support) >= 2 * diameter(support)
+            and len(lifted_support) >= len(support)
+        )
+    checks.append(
+        (
+            "factor_two_support_inequalities",
+            all(support_checks),
+            f"checked_supports={len(support_checks)}",
+        )
+    )
+
+    coefficients = {0: 0.4, 2: -0.3, 4: 0.17, 6: -0.06}
+    eta, z = 0.19, 1.7
+    rescaled = field_rescale(coefficients, z)
+    lhs = grassmann_norm(rescaled, eta)
+    rhs = grassmann_norm(coefficients, eta / z)
+    checks.append(
+        (
+            "field_rescaling_norm_identity",
+            abs(lhs - rhs) < 1.0e-15,
+            f"norm_Dz_eta={lhs:.12f}, norm_eta_over_z={rhs:.12f}",
+        )
+    )
+
+    # Two equally admissible chart parameters give different coefficient
+    # coordinates for the same polynomial functional.
+    z1, z2 = 1.0, 2.0
+    mass1 = field_rescale({2: 3.0}, z1)[2]
+    mass2 = field_rescale({2: 3.0}, z2)[2]
+    checks.append(
+        (
+            "field_chart_nonselection",
+            mass1 != mass2 and mass1 == 3.0 and mass2 == 0.75,
+            f"z1_mass={mass1:.6f}, z2_mass={mass2:.6f}",
+        )
+    )
+
+    # Exact fiber-constant factorization with one retained square-zero
+    # bilinear coefficient: -log[Z(1-t a xi)]+log Z=t a xi.
+    hidden_weights = [0.4, 1.1, 0.7, 0.9]
+    t, a = 0.37, -0.23
+    body = sum(hidden_weights)
+    nilpotent_weight = -t * a * body
+    normalized_nilpotent = nilpotent_weight / body
+    action_shift = -normalized_nilpotent
+    checks.append(
+        (
+            "joint_raw_lift_identity",
+            abs(action_shift - t * a) < 1.0e-15,
+            f"action_shift={action_shift:.12f}, expected={t*a:.12f}",
+        )
+    )
+
+    # A declared finite jet is an ordinary finite coordinate projection; two
+    # different declared jet sets are both idempotent and inequivalent.
+    coordinates = {"vacuum": 0.2, "onsite": 0.4, "short_bilinear": -0.1, "plaquette": 0.07, "long_loop": 0.03}
+    jet_a = {key: coordinates[key] for key in ("vacuum", "onsite")}
+    jet_b = {key: coordinates[key] for key in ("vacuum", "onsite", "short_bilinear", "plaquette")}
+    checks.append(
+        (
+            "finite_jet_chart_family",
+            set(jet_a) < set(jet_b) and jet_a != jet_b,
+            f"jet_A={sorted(jet_a)}, jet_B={sorted(jet_b)}",
+        )
+    )
+
+    # Fixed-background Schur tangent bounds for declared microscopic mass and
+    # hopping coordinates, after the common rho=2^(3/2) field chart.
+    rho_tangent = 2.0 ** 1.5
+    tangent_rows = []
+    for mass in (12.0, 16.0, 20.0):
+        mass_bound = (1.0 + 16.0 / mass**2) / rho_tangent**2
+        hopping_bound = (32.0 / mass + 64.0 / mass**2) / rho_tangent**2
+        tangent_rows.append((mass, mass_bound, hopping_bound))
+    checks.append(
+        (
+            "schur_coordinate_tangent_bounds",
+            all(mass_bound < 0.14 and hopping_bound < 0.39 for _, mass_bound, hopping_bound in tangent_rows),
+            "; ".join(
+                f"m={mass:g}:dm={mass_bound:.6f},dt={hopping_bound:.6f}"
+                for mass, mass_bound, hopping_bound in tangent_rows
+            ),
+        )
+    )
+
+    text = NOTE.read_text()
+    required = [
+        "**Type:** bounded_theorem",
+        "P_0",
+        "exp(-lambda)",
+        "||D_rho Phi||_(lambda,theta,eta)=||Phi||_(lambda,theta,eta/rho)",
+        "not a physical field normalization",
+        "does not establish an invariant neighborhood",
+        "No axiom-update stop is established.",
+        "### N1",
+        "### N2",
+        "### N3",
+        "### N4",
+        "### N5",
+        "### N6",
+        "### N7",
+        "### N8",
+    ]
+    missing = [item for item in required if item not in text]
+    forbidden = ["the unique relevant sector", "is the physical beta function", "NOT_TESTED"]
+    hits = [item for item in forbidden if item in text]
+    checks.append(("source_contract", not missing and not hits, f"missing={missing}, forbidden_hits={hits}"))
+
+    expected_dependencies = sorted(
+        [
+            "WILSON_STAGGERED_CONSTRAINED_FIBER_DOBRUSHIN_AND_RAW_RG_UNIT_DIRECTIONS_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+        ]
+    )
+    dependencies = sorted(set(re.findall(r"\]\(([^)#?]+\.md)\)", text)))
+    checks.append(
+        (
+            "repository_dependency_set",
+            dependencies == expected_dependencies,
+            f"markdown_dependency_set={dependencies}",
+        )
+    )
+
+    passed = sum(ok for _, ok, _ in checks)
+    failed = len(checks) - passed
+    for name, ok, detail in checks:
+        print(f"{'PASS' if ok else 'FAIL'} {name}: {detail}")
+    print(f"SCORECARD PASS={passed} FAIL={failed}")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Result

Constructs the first explicit mathematical projected/rescaled RG chart on the exact joint action space.

- declares the factor-two support dilation `H_2`;
- constructs the finite-rank diameter-zero projector `P_0` and general finite Berezin/Peter–Weyl jet projectors;
- proves the exact field-coordinate torsor `||D_rho Phi||_(lambda,theta,eta)=||Phi||_(lambda,theta,eta/rho)`;
- extends the raw lift identity coefficientwise to even balanced retained polynomials;
- proves that every extended raw lifted direction left after `P_0` is geometrically suppressed by at least `exp(-lambda)` in the declared chart;
- gives fixed-background Schur mass/hopping tangent bounds after field rescaling.

The theorem also proves narrow chart nonselection: different finite jets and `rho>0` are legitimate coordinate systems for the same exact functional. It does not claim a unique physical relevant sector, invariant ball, full irrelevant derivative contraction, nonlinear iteration, physical beta function, taste carrier, or critical continuum trajectory.

## Review

Independent code/math, physics/import/Nature, and governance/no-go reviews pass after correcting the per-mode scale factor from an exact ratio to the supported upper bound.

## Checks

- runner/cache: `PASS=10 FAIL=0`
- Python compilation: pass
- controlled vocabulary lint: pass
- `git diff --check`: pass
- full audit pipeline: pass
- strict audit lint: no errors
- seeded row: `bounded_theorem`, `unaudited`, exactly Block25 + Block29 dependencies

Stacked on #5327.
