### PR TITLE
repair: sanitizer must not rewrite current-schema lifecycle_state enum values (audit infrastructure)

### DIFF
--- a/docs/audit/scripts/sanitize_legacy_audit_artifacts.py
+++ b/docs/audit/scripts/sanitize_legacy_audit_artifacts.py
@@ -37,6 +37,13 @@ TEXT_REPLACEMENTS = (
     ("proposed-promoted", "candidate promoted-grade"),
 )
 
+# Current-schema enum fields whose value sets legitimately contain strings that
+# collide with legacy status vocabulary. The no-go discipline gate requires
+# lifecycle_state in {active, retired, unknown}; rewriting its "unknown" to
+# "unaudited" corrupts authenticated evidence snapshots and makes the gate
+# reject otherwise valid packets.
+CURRENT_SCHEMA_ENUM_KEYS = frozenset({"lifecycle_state"})
+
 
 def sanitize_string(value: str) -> str:
     mapped = EXACT_STATUS_VALUE_MAP.get(value)
@@ -48,16 +55,18 @@ def sanitize_string(value: str) -> str:
     return out
 
 
-def sanitize_obj(value):
+def sanitize_obj(value, key=None):
     if isinstance(value, dict):
         return {
-            k: sanitize_obj(v)
+            k: sanitize_obj(v, k)
             for k, v in value.items()
             if k not in DEPRECATED_KEYS
         }
     if isinstance(value, list):
-        return [sanitize_obj(v) for v in value]
+        return [sanitize_obj(v, key) for v in value]
     if isinstance(value, str):
+        if key in CURRENT_SCHEMA_ENUM_KEYS:
+            return value
         return sanitize_string(value)
     return value
 

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -11695,6 +11695,26 @@ class SanitizeLegacyAuditArtifactsTest(unittest.TestCase):
             "cl3_complexification_split_narrow_theorem_note_2026-05-10",
         )
 
+    def test_lifecycle_state_unknown_survives_the_exact_status_map(self):
+        # The no-go discipline gate requires lifecycle_state in
+        # {active, retired, unknown}; the legacy map must not rewrite that
+        # enum's "unknown" while it still rewrites legacy status values.
+        m = _import("sanitize_legacy_audit_artifacts")
+        snapshot = {
+            "audit_status": "unknown",
+            "cross_cycle_candidates": [
+                {
+                    "candidate": "similar_negative_boundary:example_note",
+                    "lifecycle_state": "unknown",
+                }
+            ],
+        }
+        out = m.sanitize_obj(snapshot)
+        self.assertEqual(
+            out["cross_cycle_candidates"][0]["lifecycle_state"], "unknown"
+        )
+        self.assertEqual(out["audit_status"], "unaudited")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Audit-infrastructure repair, routed through review per the audit-loop skill's no-smuggling rule.

**Defect (observed, blocking a live audit):** `sanitize_legacy_audit_artifacts.py` recursively maps the exact string `"unknown"` → `"unaudited"` in every string field of generated audit artifacts. The no-go discipline gate's authenticated evidence snapshots legitimately carry `lifecycle_state ∈ {active, retired, unknown}`; the blanket rewrite corrupts that enum inside `cross_cycle_candidates`, and the gate then rejects otherwise valid forensic packets. Observed on the G3 outcome-factorization no-go row: `apply_audit.py` accepted, pipeline invalidated with `no_go_discipline_packet_invalid`, validator error "lacks valid lifecycle_state". The full rejection record, manifest, and rejected JSON are preserved from the audit session.

**Fix (minimal, key-aware):** `sanitize_obj` now passes the enclosing key and preserves string values under `CURRENT_SCHEMA_ENUM_KEYS = {"lifecycle_state"}`. Legacy status vocabulary elsewhere is still rewritten (regression test asserts both directions).

**Test note:** the test module defines `SanitizeLegacyAuditArtifactsTest` twice; the second definition shadows the first, so the new test is added to the collectable (second) class. The shadowing itself is pre-existing and left for a separate cleanup. Full audit-pipeline test module: 309 tests, OK.

**Flagged for reviewer (not changed here):** the sanitizer's exact-status map is key-blind by design; other current-schema enums whose values collide with legacy vocabulary (e.g. a field legitimately valued `"open"`) would be corrupted the same way. If the reviewer prefers, the fix generalizes by extending `CURRENT_SCHEMA_ENUM_KEYS`.

No audit verdict, generated surface, or science content is touched.

Authored by Claude Fable 5 (supervisor) from the audit agent's preserved rejection record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)