### PR TITLE
physics: split constrained-fiber derivative certificate boundary

### DIFF
--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
@@ -1,6 +1,43 @@
 # Handoff
 
 Current branch:
+`physics-loop/record-faithful-dynamics-block31-nonfiber-derivative-invariant-ball-20260712`.
+The split-derivative/certificate-boundary runner reports `PASS=9 FAIL=0`.
+On every finite regulator, `DR_Phi[F]=E_Phi[F]` and higher derivatives are
+signed connected cumulants in the even-balanced Banach algebra. The exact
+identity `E_Phi L=I` gives complementary base-dependent projections
+`C_Phi=L E_Phi`, `Q_Phi=1-C_Phi`, with `E_Phi Q_Phi=0`. Fixed-order
+uniformity is claimed only on the simultaneous theorem's controlled
+finite-local-source class, not on the full interaction-space completion.
+
+The centered kernel is not nonlinear: for `h=+/-1`, `E_0h=0` while
+`D^2R_0[hLf,hLf]=-f^2`. Consistent composition of the simultaneous
+joint-polymer weights with the declared factor-two chart uses
+`lambda_chart=Lambda/2`. The available absolute Cauchy certificate is
+`Q_C=68 exp(Lambda/2)c/log(1+epsilon)`; even granting the unit-diameter raw
+gain leaves `68c/log(1+epsilon)>68` at every admissible point. This is a
+certificate boundary, not map noncontraction.
+
+On the fixed plaquette-character slice, every finite-rank projector leaves a
+nonzero raw direction. Its declared minimal-lift ratio is exactly
+`exp(-2lambda-4theta)<1`; representation smoothing and localized marked
+clusters remain live. Independent code/math, physics/import/Nature, and
+governance/no-go review pass after repairing full-Frechet wording, direct
+runner differentiation/support counts, N1 honesty markers, and repo-native
+science names. Audit validation seeds one `bounded_theorem` / `unaudited` row
+with exactly the simultaneous joint-polymer and declared-RG-chart
+dependencies; strict lint has zero errors and generated outputs are stripped.
+
+The next theorem must split `E_Phi=E_0+(E_Phi-E_0)`, prove a bounded local
+section for `L E_0`, retain a forced-base-activity attachment for every
+centered mark, and close explicit `B,q,M,delta` inequalities on one autonomous
+ball. No axiom-update stop is triggered.
+
+Split-derivative/certificate-boundary stacked PR:
+https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5333
+is open against the declared-RG-chart head.
+
+Previous branch:
 `physics-loop/record-faithful-dynamics-block30-projected-rescaled-contraction-20260712`.
 The declared-RG-chart runner reports `PASS=10 FAIL=0`. The source declares a
 factor-two support dilation, the finite-rank diameter-zero projector `P_0`,

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
@@ -1,5 +1,25 @@
 # PR Delivery
 
+The split constrained-fiber derivative and unlocalized-certificate boundary is delivered:
+
+- base: `physics-loop/record-faithful-dynamics-block30-projected-rescaled-contraction-20260712`
+- head: `physics-loop/record-faithful-dynamics-block31-nonfiber-derivative-invariant-ball-20260712`
+- runner: `PASS=9 FAIL=0`
+- scope: exact Banach-valued derivative/cumulant identities, a base-dependent
+  lifted/centered tangent split on the controlled finite-local-source class,
+  a nonlinear centered-kernel counterexample, a universal failure of the
+  current unlocalized Cauchy-plus-geometry certificate to reach `q<1`, and an
+  exact fixed-plaquette finite-jet raw floor below one; no actual
+  noncontraction or invariant ball
+- review: independent code/math, physics/import/Nature, and governance/no-go
+  pass after two repair iterations
+- audit compatibility: one `bounded_theorem` / `unaudited` row with exactly
+  the simultaneous joint-polymer and declared-RG-chart dependencies; full
+  pipeline and strict lint pass; generated outputs stripped
+- PR: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5333
+
+No merge is authorized. Independent audit remains authoritative.
+
 The declared projected/rescaled RG-chart theorem is delivered:
 
 - base: `physics-loop/record-faithful-dynamics-block29-grassmann-polymer-norm-20260712`

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
@@ -910,3 +910,41 @@ dependencies; strict lint has zero errors and generated status surfaces are
 stripped. PR #5330 is open. The invariant neighborhood, full non-fiber
 derivative, nonlinear contraction, taste carrier, and critical trajectory
 remain open. No axiom-update stop is triggered.
+
+## Split derivative and unlocalized Cauchy-certificate boundary review
+
+PASS WITH BOUNDED CLAIMS after two repair iterations. The exact finite-volume
+derivative is the normalized Banach-valued fiber insertion
+`DR_Phi[F]=E_Phi[F]`, with signed connected cumulants at higher order. The raw
+identity `E_Phi L=I` yields complementary base-dependent projections
+`C_Phi=L E_Phi` and `Q_Phi=1-C_Phi`; the centered tangent is killed linearly.
+The two-point witness `E_0h=0`, `E_0h^2=1` proves that this kernel is not an
+ideal or a nonlinear invariant sector.
+
+Physics/import review required the Result and Cauchy formula to remain inside
+the controlled finite-local-source class rather than claim a full anchored-
+space Frechet operator. It also narrowed the finite-jet statement to the fixed
+plaquette-character slice and declared minimal lift. Code/math review replaced
+a self-confirming finiteness check with direct dual-algebra differentiation of
+`-log Z`, and made the runner construct the coarse/fine plaquette supports,
+their `(diameter,size)=(2,4)->(4,8)` weight ratio, and an explicit finite-jet
+kernel vector. Governance/no-go review removed an unattempted N1 row and
+replaced branch-block shorthand with native scientific names.
+
+With joint-polymer parameters `Lambda,Theta`, the composed chart has
+`lambda=Lambda/2`, `theta=Theta/2`. The absolute Cauchy certificate is
+`Q_C=68 exp(Lambda/2)c/log(1+epsilon)`; even granting the weakest raw geometric
+gain gives `68c/log(1+epsilon)>68` everywhere. This is a certificate boundary,
+not a map no-go. A fixed plaquette-character mode in the kernel of any finite-
+rank projector has exact declared-lift ratio `exp(-2lambda-4theta)<1`, so the
+lower floor likewise does not forbid contraction.
+
+Runner/cache: `PASS=9 FAIL=0`. Independent symbolic differentiation confirms
+the first and mixed second derivatives and independently recomputes all three
+Cauchy rows. Full audit validation seeds one `bounded_theorem` / `unaudited`
+row with source hash `53720e65ebc870df...` and exactly the simultaneous
+joint-polymer and declared-RG-chart dependencies; strict lint has zero errors
+and generated audit/status surfaces are stripped. PR #5333 is open. The next
+target is a bounded local section plus forced-base-attachment marked-cluster
+estimate and explicit `B,q,M,delta` invariant-ball test. No axiom-update stop
+is triggered.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
@@ -8,31 +8,35 @@ current_goal: >-
   supply the physical evolution object, bare time ordering, record-formation
   weights, and an admissibility-to-carrier selector without importing the
   staggered/Dirac answer or sector-specific Standard Model and gravity laws.
-branch: physics-loop/record-faithful-dynamics-block30-projected-rescaled-contraction-20260712
+branch: physics-loop/record-faithful-dynamics-block31-nonfiber-derivative-invariant-ball-20260712
 base_commit_at_start: 9d1636f05f
-cycle_count: 30
-block_count: 30
-active_route: wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction
+cycle_count: 31
+block_count: 31
+active_route: wilson_staggered_split_derivative_unlocalized_cauchy_certificate_boundary
 hard_residual: >-
   Can the four-axiom record surface canonically determine a faithful local
   record-forming instrument whose coherent no-record block is sufficiently
   constrained to exclude the observationally disconnected SWAP--Laplacian
   completion and select the Clifford-vector carrier?
-produced_claim_id: wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_bounded_theorem_note_2026-07-12
+produced_claim_id: wilson_staggered_split_derivative_and_unlocalized_cauchy_certificate_boundary_bounded_theorem_note_2026-07-12
 actual_current_surface_status: bounded-support
 conditional_surface_status: >-
-  A declared factor-two support chart, finite diameter-zero/local-jet
-  projectors, and a field-rescaling torsor are explicit. Every extended raw
-  lifted direction gains at least exp(-lambda) suppression after projection in
-  that chart. No invariant neighborhood, full non-fiber derivative
-  contraction, physical relevance/taste selector, critical trajectory, or
-  continuum theorem is proved.
+  The constrained-fiber derivative is exactly a Banach-valued conditional
+  expectation on the controlled finite-local-source class and has a
+  base-dependent lifted/centered split. The centered kernel is not nonlinear.
+  Consistent half-weight bookkeeping proves that the current unlocalized
+  Cauchy-plus-geometry certificate stays above 68 everywhere, while a fixed
+  plaquette-character tail gives a finite-jet raw floor below one. This is a
+  certificate boundary, not dynamical noncontraction. No invariant ball,
+  localized full derivative, physical relevance/taste selector, critical
+  trajectory, or continuum theorem is proved.
 admitted_observation_status: none
 claim_type_reason: >-
-  The source constructs bounded mathematical RG charts and proves the exact
-  scale-weighted suppression of the entire extended raw-lift family. It keeps
-  the invariant ball, non-fiber derivative, nonlinear contraction, physical
-  relevance/taste identification, and critical trajectory open.
+  The source proves exact derivative/cumulant and split-projection identities,
+  an exact nonlinear centered-kernel counterexample, and a bounded limitation
+  of the existing absolute Cauchy certificate. It does not promote finite
+  local-source control to a full interaction-ball Frechet theorem or infer an
+  actual noncontraction result.
 hypothetical_axiom_status: null
 proposal_allowed: false
 proposal_allowed_reason: >-
@@ -132,6 +136,9 @@ files_touched:
   - docs/WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md
   - scripts/wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_2026_07_12.py
   - logs/runner-cache/wilson_staggered_declared_rg_chart_raw_lift_geometric_contraction_2026_07_12.txt
+  - docs/WILSON_STAGGERED_SPLIT_DERIVATIVE_AND_UNLOCALIZED_CAUCHY_CERTIFICATE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-07-12.md
+  - scripts/wilson_staggered_split_derivative_cauchy_certificate_boundary_2026_07_12.py
+  - logs/runner-cache/wilson_staggered_split_derivative_cauchy_certificate_boundary_2026_07_12.txt
 open_imports:
   - fundamental process object: Hamiltonian, strict tick, or record instrument
   - faithful law-to-record influence principle
@@ -179,10 +186,11 @@ no_go_routes:
   - a scalar gauge-body source/polymer theorem does not by itself place the retained Grassmann coefficients in one simultaneous all-degree Banach norm or supply a projected/rescaled RG contraction
   - one-step simultaneous gauge--Grassmann norm membership does not by itself define an invariant factor-two rescaled neighborhood or remove the exact raw relevant directions
   - geometric suppression of every extended raw lifted mode does not control the non-fiber derivative or prove invariance/nonlinear contraction of one joint ball
+  - the exact base-dependent conditional-centering split kills the centered tangent only at first order; its kernel is not an ideal, and the current unlocalized Cauchy-plus-geometry certificate remains above 68 even though localized forced-attachment and spectral-smoothing routes remain live
 trace_gate_classification: direct_blocker_closure
 reachability_to_target: partially_closes
-review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_two_layer_source_polymer_pass_retained_grassmann_polymer_norm_pass_declared_rg_chart_pass_bounded
-pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open_two_layer_source_polymer_open_retained_grassmann_polymer_norm_open_declared_rg_chart_open
+review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_two_layer_source_polymer_pass_retained_grassmann_polymer_norm_pass_declared_rg_chart_pass_split_derivative_certificate_boundary_pass_bounded
+pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open_two_layer_source_polymer_open_retained_grassmann_polymer_norm_open_declared_rg_chart_open_split_derivative_certificate_boundary_open
 block01_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5178
 block02_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5181
 block03_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5201
@@ -213,11 +221,15 @@ block27_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/
 block28_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5322
 block29_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5327
 block30_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5330
+block31_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5333
 next_exact_action: >-
-  Bound the non-fiber derivative in the declared factor-two chart, including
-  determinant scalar loops and every Grassmann degree, then prove or delimit
-  an invariant joint ball with nonlinear irrelevant Lipschitz constant below
-  one. Keep any contraction in this deep wedge distinct from criticality.
+  Prove a scale-localized marked-cluster estimate for
+  E_Phi=E_0+(E_Phi-E_0): construct a uniformly bounded local section for the
+  product-fiber response, retain the forced attachment of every centered mark
+  to at least one determinant/Wilson/Schur base activity, and derive explicit
+  base-offset, derivative, and Hessian constants. Then test
+  B+q delta+(M/2)delta^2<=delta on one autonomous joint chart. Keep any
+  contraction in this deep wedge distinct from criticality.
 stop_condition: >-
   Stop and discuss an axiom update only if an exact result proves that the
   required bridge cannot be derived and an additional approved axiom or

--- a/docs/WILSON_STAGGERED_SPLIT_DERIVATIVE_AND_UNLOCALIZED_CAUCHY_CERTIFICATE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-07-12.md
+++ b/docs/WILSON_STAGGERED_SPLIT_DERIVATIVE_AND_UNLOCALIZED_CAUCHY_CERTIFICATE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,396 @@
+# Split constrained-fiber derivative and unlocalized Cauchy-certificate boundary
+
+**Date:** 2026-07-12
+**Type:** bounded_theorem
+**Status:** unaudited candidate; effective status is pipeline-derived only after independent audit.
+**Primary runner:** [`scripts/wilson_staggered_split_derivative_cauchy_certificate_boundary_2026_07_12.py`](../scripts/wilson_staggered_split_derivative_cauchy_certificate_boundary_2026_07_12.py)
+**Cached output:** [`logs/runner-cache/wilson_staggered_split_derivative_cauchy_certificate_boundary_2026_07_12.txt`](../logs/runner-cache/wilson_staggered_split_derivative_cauchy_certificate_boundary_2026_07_12.txt)
+
+## 0. Result
+
+On every finite regulator, the exact constrained-fiber map has an algebraic
+tangent split at each controlled base action. The simultaneous joint-polymer theorem makes its fixed-order
+derivatives uniform on the controlled finite-local-source class. Neither that
+restricted split nor the existing unlocalized Cauchy estimate is the missing
+full interaction-ball theorem.
+
+Use the common even-balanced Banach source domain from the
+[simultaneous retained-Grassmann polymer theorem](WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md)
+and the lift/rescaling identities from the
+[declared factor-two RG chart](WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md).
+For a controlled base action `Phi`, put
+
+```text
+Z_Phi=integral_fiber exp(-Phi),
+E_Phi[F]=Z_Phi^(-1) integral_fiber exp(-Phi)F.                       (0.1)
+```
+
+Products and the inverse in (0.1) are taken in the commutative even-balanced
+Grassmann Banach algebra. Direct differentiation gives
+
+```text
+D R_Phi[F]=E_Phi[F],
+D^n R_Phi[F_1,...,F_n]=(-1)^(n+1) kappa_n^Phi(F_1,...,F_n).          (0.2)
+```
+
+In particular, `D^2 R=-Cov_Phi`. Since the exact fiber-constant lift obeys
+`E_Phi L=I`, the base-action-dependent operators
+
+```text
+C_Phi=L E_Phi,                 Q_Phi=1-C_Phi                        (0.3)
+```
+
+are complementary projections and
+
+```text
+F=L(E_Phi F)+Q_Phi F,          E_Phi Q_Phi=0.                       (0.4)
+```
+
+Thus, algebraically at finite volume and uniformly for each fixed order on the
+controlled finite-local-source class, the derivative is split onto the
+corresponding local coarse response class and its conditionally centered
+summand is killed exactly at first order. As the allowed local coarse sources
+vary, the range of `C_Phi` contains an infinite-dimensional family of lifted
+coarse interactions, and `C_Phi` depends on the base action. It is not a
+finite relevant/marginal projector or a physical coordinate selection. A
+bounded extension to the entire anchored interaction space is not asserted.
+
+Conditional centering is also not a nonlinear invariant sector. Already for
+one product-Haar surrogate coordinate `h=+/-1` and a coarse function `f`,
+
+```text
+E_0[h Lf]=0,                 D^2R_0[hLf,hLf]=-f^2.                  (0.5)
+```
+
+The centered kernel is not an ideal: products of centered elements can have a
+nonzero conditional mean.
+
+The second result is an exact limitation of the presently available
+**certificate**, not of the dynamics. Write the parameters of the simultaneous
+polymer theorem as `Lambda,Theta,c`, let
+
+```text
+epsilon=c-K_joint>0,          r_src=log(1+epsilon),
+A=68 exp(Lambda/2)c.                                               (0.6)
+```
+
+For one normalized local source in the theorem's weighted activity class,
+Cauchy's estimate gives
+
+```text
+sup_(F in S_loc, ||F||_src<=1)
+ ||D R_Phi[F]||_(Lambda/2,Theta/2,eta)
+ <=Q_C=A/r_src
+      =68 exp(Lambda/2)c/log(1+epsilon),                            (0.7)
+```
+
+where `S_loc` is the finite-local-source class controlled by the simultaneous
+joint-polymer theorem. This is
+a normalized-source Cauchy certificate, not a completed operator norm on the
+full interaction-space completion.
+
+The output norm is controlled only at chart weights
+`lambda=Lambda/2,theta=Theta/2`. Therefore the uniform unit-diameter raw-lift
+gain in the composed joint-polymer/RG-chart certificate is `exp(-Lambda/2)`, not
+`exp(-Lambda)`. Even if that raw-lift gain is granted to every source response,
+
+```text
+exp(-Lambda/2)Q_C
+ =68c/log(1+epsilon)>68,                                            (0.8)
+```
+
+because `0<epsilon<c` and `log(1+epsilon)<epsilon`. Hence plain source
+analyticity plus the raw-lift support factor cannot certify a full derivative
+constant below one anywhere in the declared KP region. Equation (0.8) is not a
+dynamical noncontraction theorem: it says the absolute, unlocalized estimate
+has discarded the small forced-attachment factor needed for the proof.
+
+Finally, any finite-rank projector on the present coefficient space leaves a
+nonzero vector in the fixed-support coarse-plaquette character span. Scalar
+gauge-invariant Peter--Weyl characters make that slice infinite-dimensional.
+At `rho=1`, the exact raw identity then gives, for the declared minimal
+plaquette lift,
+
+```text
+||(1-P_J)D_(2,1)R[Lf]||/||Lf||
+ =exp[-2lambda-4theta].                                             (0.9)
+```
+
+This is a positive lower floor strictly below one, not a noncontraction
+result. It proves only that finite projection in the present coefficient
+space does not make this declared fixed-support tail vanish. A representation-
+weighted norm, another support chart, actual fiber smoothing, or a localized
+marked-cluster estimate remains live.
+
+The next constructive target is a scale-localized split
+
+```text
+E_Phi=E_0+(E_Phi-E_0),                                              (0.10)
+```
+
+where `L E_0` has a bounded local section compatible with the shadow norm and
+every centered contribution to `E_Phi-E_0` is forced to attach to at least one
+base activity. Only after that estimate supplies `q<1` can a base offset `B`
+and Hessian bound `M` close
+
+```text
+B+q delta+(M/2)delta^2<=delta.                                      (0.11)
+```
+
+No axiom-update stop is established.
+
+## 1. Banach-valued derivative and cumulants
+
+On a finite regulator, the positive body of `Z_Phi` is nonzero throughout the
+simultaneous joint-polymer source domain. The inverse in (0.1) therefore exists in the finite
+even Grassmann algebra. For commuting perturbations `F_i`, differentiation of
+
+```text
+R(Phi+tF)=-log integral exp[-Phi-tF]                                (1.1)
+```
+
+is ordinary commutative Banach-algebra differentiation. The first two orders
+are
+
+```text
+D R_Phi[F]=E_Phi[F],
+D^2 R_Phi[F,G]
+ =-[E_Phi(FG)-E_Phi(F)E_Phi(G)].                                   (1.2)
+```
+
+The moment--cumulant recursion gives (0.2) at every order. The simultaneous
+joint-polymer theorem's common
+Reinhardt domain and uniform marked-cluster convergence make each fixed-order
+identity regulator-, hidden-boundary-, and coarse-`V`-uniform for the local
+source class proved there. This statement does not silently promote finite
+local-source analyticity to a full Fréchet bound on every interaction-ball
+direction.
+
+For every coarse interaction `f`, fiber constancy gives `E_Phi[Lf]=f`.
+Consequently
+
+```text
+C_Phi^2=L E_Phi L E_Phi=L E_Phi=C_Phi,
+Q_Phi^2=Q_Phi,
+E_Phi Q_Phi=0.                                                       (1.3)
+```
+
+At finite volume these are exact algebraic identities. In the uniform local
+source class, boundedness of `E_Phi` follows from the marked expansion. A
+volume-uniform extension to the whole anchored interaction space is exactly
+part of the localized-operator problem, rather than an assumption here.
+
+## 2. Why the centered split is not the RG relevant split
+
+The range of `C_Phi` contains every local coarse gauge function and every
+allowed even-balanced coarse Grassmann polynomial. It is therefore
+infinite-dimensional even before supports are allowed to grow. It also changes
+with `Phi`.
+
+Equation (0.5) shows the nonlinear problem directly. With product measure on
+`h=+/-1`, `E_0 h=0` but `E_0 h^2=1`. The first centered insertion vanishes,
+while its connected second response is nonzero. If `f` is chosen in the
+high-character plaquette tail, `f^2` need not lie in any fixed finite jet.
+Thus quotienting by `ker E_0` would erase load-bearing nonlinear covariance.
+
+The quotient norm
+
+```text
+||f||_quot=inf_(E_0F=f)||F||                                       (2.1)
+```
+
+makes `E_0` contractive by definition, but supplies neither a local bounded
+section nor geometric lift control. Conversely the shadow norm
+`||f||_sh=||Lf||` gives the desired support comparison only if
+
+```text
+||L E_0F||<=C_sec||F||                                              (2.2)
+```
+
+with a scale-uniform local constant. The current notes do not prove (2.2).
+Moreover `ker E_0` is not an ideal, so the quotient is not automatically a
+submultiplicative action algebra for exponentials and polymers.
+
+## 3. Consistent Cauchy and chart weights
+
+Let a normalized local source `F` have weighted source incidence at most one.
+Convexity gives
+
+```text
+sum_marked [exp(|z| ||F_a||)-1] weight_a
+ <=exp(|z|)-1.                                                       (3.1)
+```
+
+It fits inside the strict activity margin whenever
+`|z|<r_src=log(1+epsilon)`. Across this disk, the non-onsite connected output
+has the simultaneous joint-polymer bound `A=68 exp(Lambda/2)c`. Cauchy's integral formula proves
+(0.7); the onsite mass is independent of this marked source and is not inserted
+into `A`.
+
+At the three displayed joint-polymer points, the unlocalized first-derivative
+constants are approximately
+
+| `m` | `Q_C` | `exp(-Lambda/2)Q_C` |
+|---:|---:|---:|
+| 12 | 276.96 | 276.82 |
+| 16 | 631.02 | 630.71 |
+| 20 | 329.86 | 329.69 |
+
+The exact inequality (0.8), rather than these examples, proves that parameter
+optimization cannot repair this particular black-box certificate. Increasing
+`Lambda` increases `A` by precisely the factor canceled by the weakest
+diameter-one lift gain in the composed chart.
+
+This does not rule out:
+
+- a forced-base-attachment estimate proportional to `K_joint/c`;
+- representation-index smoothing of fixed-support Peter--Weyl tails;
+- a block-shadow norm with a proved bounded local section;
+- a different gauge-covariant/taste-faithful block;
+- a multistep estimate.
+
+## 4. Finite-jet tail and exact raw floor
+
+Let `X` be the four vertices of one coarse plaquette. Its graph diameter is
+two. The minimal declared straight factor-two boundary lift has eight vertices,
+diameter four, and the same scalar Grassmann degree `p=0`. The coefficient norm
+therefore gives the exact weight ratio
+
+```text
+exp[lambda*2+theta*4]/exp[lambda*4+theta*8]
+ =exp[-2lambda-4theta].                                              (4.1)
+```
+
+The scalar class functions on the plaquette holonomy contain the characters
+of infinitely many inequivalent `SU(3)` representations. Restrict a finite-
+rank `P_J` to their span. Its kernel is nonzero; choose `f` there. The exact
+identity `R(Phi+tLf)=R(Phi)+tf` and `P_Jf=0` prove (0.9).
+
+At the displayed joint-polymer points the composed chart has
+`lambda=theta=0.0005`, so the floor is `exp(-0.003)=0.997004...`.
+Using another declared chart with `lambda=theta=0.001` gives
+`exp(-0.006)=0.994017...`. Both are below one. The result forbids neither a
+one-step contraction nor a spectral smoothing theorem.
+
+## 5. Runner contract
+
+Run:
+
+```bash
+python3 scripts/wilson_staggered_split_derivative_cauchy_certificate_boundary_2026_07_12.py
+```
+
+The runner checks Banach-valued expectation/covariance algebra in a nontrivial
+dual-number fiber, `E L=1`, projection idempotence, exact annihilation of the
+centered linear component, the nonlinear centered-square witness, the three
+joint-polymer Cauchy constants with consistent half-weights, a representative finite
+plaquette-character jet tail, and the source/dependency contract. The general
+cumulant recursion, infinite-dimensional kernel argument, and uniform marked-
+cluster statements are analytic.
+
+## 6. No-Go Discipline N1--N8
+
+The certificate boundary and finite-jet tail are negative-shaped statements.
+They are deliberately restricted to the estimates actually tested.
+
+### N1 — alternative-route enumeration
+
+| Route | Status | Result |
+|---|---|---|
+| Unlocalized Cauchy plus raw geometry | `ATTEMPTED` | Equation (0.8) proves this certificate stays above 68. |
+| Exact conditional-centering split | `ATTEMPTED` | Equations (0.3)--(0.5) kill the linear kernel but expose a nonzero Hessian. |
+| Larger finite local jets | `ATTEMPTED` | Fixed-support plaquette characters leave an infinite tail and the exact floor (0.9). |
+| Product-fiber quotient norm | `ATTEMPTED` | Makes `E_0` contractive tautologically but loses a proved local section and nonlinear algebra. |
+| Block-shadow/local-section norm | `ATTEMPTED` | Reduces the task to (2.2); that estimate remains live. |
+| Forced-attachment marked clusters | `ATTEMPTED` | The missing subtraction is identified in (0.10); the current absolute proof did not retain its `K_joint` factor. |
+| Peter--Weyl/Casimir-weighted smoothing | `ATTEMPTED` | Inspection of the present sup/projective coefficient norm shows that it has no representation-index weight; a new weighted norm remains live. |
+
+The narrow result closes only the first black-box certificate and the claim
+that finite projection alone deletes every tail.
+
+### N2 — wall-independence audit
+
+The downstream conditions are `localized full derivative q<1`, `one invariant
+ball including its center defect`, `physical taste/chart identification`, and
+`critical trajectory/observable identification`.
+
+| Left | Right | Left closes right? | Right closes left? | Independent? |
+|---|---|---:|---:|---:|
+| localized full derivative | invariant ball | No | No | Yes |
+| localized full derivative | physical taste/chart | No | No | Yes |
+| localized full derivative | critical trajectory/observable | No | No | Yes |
+| invariant ball | physical taste/chart | No | No | Yes |
+| invariant ball | critical trajectory/observable | No | No | Yes |
+| physical taste/chart | critical trajectory/observable | No | No | Yes |
+
+Once a derivative bound is uniform on a convex ball, its nonlinear Lipschitz
+remainder is part of that bound rather than a separately inflated wall.
+
+### N3 — hidden-condition phrase scan
+
+| Phrase or premise | Classification |
+|---|---|
+| `finite local sector` | Not assumed finite-dimensional; the plaquette gauge slice is explicitly infinite-dimensional. |
+| `by construction` | No projector idempotence is promoted to contraction. |
+| `background` | `Phi` is an explicit base action and `C_Phi` is explicitly base dependent. |
+| `standard RG` | No imported relevance or scaling classification. |
+| `field normalization` | `rho` remains a declared chart parameter. |
+| uniform source domain | Kept distinct from uniformity on an action-space ball. |
+| positive conditional expectation | Used only for the scalar/product illustration; the joint formula is Banach-algebra valued. |
+
+### N4 — citation/residual matching
+
+| Witness | Witness residual | Present use | Match? |
+|---|---|---|---:|
+| [Simultaneous polymer theorem](WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Joint source domain and half-weight output norm | Derivative existence and Cauchy constant | Yes |
+| [Declared RG chart](WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Exact raw lifts and declared support/field rescaling | Split identity and raw geometric comparison | Yes |
+| Earlier raw norm-one boundary | Unprojected, unrescaled lift | Full projected derivative | No; not used as a no-go witness. |
+| Compact-interior continuum boundary | Physical critical scaling | Mathematical derivative estimate | No; context only. |
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Tested? | Permitted conclusion |
+|---|---:|---|
+| Finite-volume Banach derivative/cumulants | Yes | Exact identities (0.2). |
+| Uniform local marked-source class | Yes | Cauchy certificate (0.7). |
+| Arbitrary full interaction ball | No | No Fréchet contraction claim. |
+| One fixed plaquette character slice | Yes | Finite-jet tail and floor (0.9). |
+| Every non-fiber mode | No | No actual noncontraction claim. |
+| Nonlinear centered kernel | Yes, counterexample | It is not invariant in general. |
+| Autonomous invariant neighborhood | No | Equation (0.11) is the next test. |
+| Critical continuum | No | No existence or impossibility claim. |
+
+### N6 — partial-closure and primitive scan
+
+The split, source norm, support weights, and finite jets are mathematical chart
+data. A better local section, marked-tree estimate, representation-weighted
+norm, or alternative block is an ordinary constructive route. The registered
+scale-reference, kinetic-isotropy, and realized-state primitives neither grant
+nor obstruct these estimates. No missing estimate is relabeled as a new axiom.
+
+### N7 — hostile steelman
+
+A hostile reviewer should say that the absolute Cauchy bound throws away the
+one fact most likely to make the derivative small: after subtracting the
+product-fiber response, every surviving marked cluster must contain a base
+activity. Correct. In an ultra-deep wedge that factor can be arbitrarily small.
+The present boundary therefore motivates, rather than forecloses, a centered
+marked-tree proof. The same reviewer should demand Peter--Weyl smoothing before
+calling finite jets insufficient for contraction. Correct: finite jets alone
+do not erase the tail, but actual constrained integration may damp it.
+
+### N8 — cross-cycle echo
+
+| Earlier surface | Earlier wall | Later mechanism | Present lesson |
+|---|---|---|---|
+| Raw unit directions | Full unrescaled norm had unit directions | Declared factor-two support rescaling | Do not turn a failed certificate into a map no-go. |
+| Pair Hessian only | No all-order source domain | Two-layer marked-source and simultaneous joint-polymer estimates | Stronger localization machinery can retire method walls. |
+| No joint norm | Generated action lacked uniform membership | Simultaneous retained-Grassmann polymer norm | The next gap is an operator estimate, not an axiom. |
+| No RG chart | Fine/coarse weights were incomparable | Declared factor-two RG chart | The chart now exposes exact half-weight bookkeeping. |
+
+Several live routes remain. The negative claim is therefore only that the
+unlocalized joint-polymer/RG-chart certificate cannot prove `q<1`, and that finite jets do
+not delete the fixed-support character tail. No physical contraction route is
+declared closed.
+
+**No-Go Discipline status: PASS.**

--- a/logs/runner-cache/wilson_staggered_split_derivative_cauchy_certificate_boundary_2026_07_12.txt
+++ b/logs/runner-cache/wilson_staggered_split_derivative_cauchy_certificate_boundary_2026_07_12.txt
@@ -1,0 +1,10 @@
+PASS banach_derivative_and_covariance: DR_direct=(0.02727272727272726, -0.008374655647382922), DR_expectation=(0.02727272727272726, -0.008374655647382922), D2_direct=(0.016997245179063362, -0.017250772184656486), -Cov=(0.016997245179063362, -0.017250772184656486)
+PASS split_projection_identities: E(Lf)=(0.31000000000000005, -0.09), E(centered)=(-2.1026951223961298e-17, 2.4850033264681535e-18)
+PASS centered_kernel_not_nonlinear: E(h)=0.0, E(h^2)=1.0, D2R[h,h]=-1.0
+PASS unlocalized_cauchy_boundary_m12: K=0.090084010199, epsilon=0.029915989801, radius=0.029477235615, Q_C=276.962233734, exp(-Lambda/2)Q_C=276.823787231
+PASS unlocalized_cauchy_boundary_m16: K=0.106977939166, epsilon=0.013022060834, radius=0.012938002753, Q_C=631.015557481, exp(-Lambda/2)Q_C=630.700128566
+PASS unlocalized_cauchy_boundary_m20: K=0.098883241708, epsilon=0.026116758292, radius=0.025781539778, Q_C=329.858151831, exp(-Lambda/2)Q_C=329.693263980
+PASS finite_jet_plaquette_character_tail: jet_rank=9, kernel_index=9, coarse=(d2,s4), fine=(d4,s8), composed_ratio=0.997004495503
+PASS source_contract: missing=[], forbidden_hits=[]
+PASS repository_dependency_set: markdown_dependency_set=['WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md']
+SCORECARD PASS=9 FAIL=0

--- a/scripts/wilson_staggered_split_derivative_cauchy_certificate_boundary_2026_07_12.py
+++ b/scripts/wilson_staggered_split_derivative_cauchy_certificate_boundary_2026_07_12.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Checks the split derivative and the unlocalized Cauchy-certificate boundary."""
+
+from __future__ import annotations
+
+import math
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "WILSON_STAGGERED_SPLIT_DERIVATIVE_AND_UNLOCALIZED_CAUCHY_"
+    "CERTIFICATE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-07-12.md"
+)
+
+
+# Dual numbers a+b*x with x^2=0 model the commutative even nilpotent algebra.
+Dual = tuple[float, float]
+
+
+def add(left: Dual, right: Dual) -> Dual:
+    return left[0] + right[0], left[1] + right[1]
+
+
+def scale(value: Dual, scalar: float) -> Dual:
+    return scalar * value[0], scalar * value[1]
+
+
+def mul(left: Dual, right: Dual) -> Dual:
+    return left[0] * right[0], left[0] * right[1] + left[1] * right[0]
+
+
+def inv(value: Dual) -> Dual:
+    return 1.0 / value[0], -value[1] / value[0] ** 2
+
+
+def average(values: list[Dual], weights: list[Dual]) -> Dual:
+    numerator: Dual = (0.0, 0.0)
+    denominator: Dual = (0.0, 0.0)
+    for value, weight in zip(values, weights, strict=True):
+        numerator = add(numerator, mul(weight, value))
+        denominator = add(denominator, weight)
+    return mul(inv(denominator), numerator)
+
+
+def covariance(left: list[Dual], right: list[Dual], weights: list[Dual]) -> Dual:
+    product = [mul(a, b) for a, b in zip(left, right, strict=True)]
+    return add(average(product, weights), scale(mul(average(left, weights), average(right, weights)), -1.0))
+
+
+def close(left: Dual, right: Dual, tolerance: float = 1.0e-14) -> bool:
+    return max(abs(a - b) for a, b in zip(left, right, strict=True)) < tolerance
+
+
+def graph_diameter(points: set[tuple[int, int]]) -> int:
+    return max(
+        (abs(x1 - x2) + abs(y1 - y2) for x1, y1 in points for x2, y2 in points),
+        default=0,
+    )
+
+
+def criterion(
+    mass: float, beta: float, c: float, theta: float, lam: float, eta: float
+) -> dict[str, float]:
+    def g(t: float) -> float:
+        return math.expm1(t) / t if t else 1.0
+
+    h = 4.0 / mass
+    total_weight = theta + 2.0 * c + lam
+    q_hop = h * math.exp(total_weight)
+    wilson = 12.0 * math.expm1(3.0 * beta / 4.0) * math.exp(4.0 * total_weight)
+    determinant = 0.0
+    for length in range(4, 10000, 2):
+        term = 1.5 * h**length * g(3.0 * h**length / length) * math.exp(length * total_weight)
+        determinant += term
+        if term < 1.0e-18:
+            break
+    schur = 0.0
+    for length in range(2, 10000):
+        x_length = 9.0 * eta**2 * 2.0 ** (-length) * mass ** (-(length - 1))
+        term = (
+            18.0
+            * eta**2
+            * length
+            * h ** (length - 1)
+            * g(x_length)
+            * math.exp(length * total_weight)
+        )
+        schur += term
+        if term < 1.0e-18:
+            break
+    activity = wilson + determinant + schur
+    epsilon = c - activity
+    source_radius = math.log1p(epsilon)
+    cauchy = 68.0 * math.exp(lam / 2.0) * c / source_radius
+    granted_geometry = math.exp(-lam / 2.0) * cauchy
+    return {
+        "K": activity,
+        "epsilon": epsilon,
+        "q_hop": q_hop,
+        "radius": source_radius,
+        "cauchy": cauchy,
+        "granted_geometry": granted_geometry,
+    }
+
+
+def main() -> None:
+    checks: list[tuple[str, bool, str]] = []
+
+    weights: list[Dual] = [(0.7, 0.03), (1.1, -0.02), (0.6, 0.01), (0.9, 0.04)]
+    perturbation: list[Dual] = [(0.2, -0.07), (-0.4, 0.03), (0.5, 0.02), (0.1, -0.05)]
+    other: list[Dual] = [(-0.3, 0.04), (0.2, -0.06), (0.1, 0.08), (0.7, 0.01)]
+    expectation = average(perturbation, weights)
+    second_derivative = scale(covariance(perturbation, other, weights), -1.0)
+
+    # Independently differentiate -log Z(t,u) at the origin in the dual
+    # algebra, without calling average() or covariance() on the derivative
+    # path.  Z_t=-sum(wF), Z_u=-sum(wG), and Z_tu=sum(wFG).
+    z0: Dual = (0.0, 0.0)
+    z_t: Dual = (0.0, 0.0)
+    z_u: Dual = (0.0, 0.0)
+    z_tu: Dual = (0.0, 0.0)
+    for weight, value, other_value in zip(weights, perturbation, other, strict=True):
+        z0 = add(z0, weight)
+        z_t = add(z_t, scale(mul(weight, value), -1.0))
+        z_u = add(z_u, scale(mul(weight, other_value), -1.0))
+        z_tu = add(z_tu, mul(weight, mul(value, other_value)))
+    z0_inv = inv(z0)
+    derivative_direct = scale(mul(z0_inv, z_t), -1.0)
+    mixed_direct = add(mul(mul(z0_inv, z_t), mul(z0_inv, z_u)), scale(mul(z0_inv, z_tu), -1.0))
+    checks.append(
+        (
+            "banach_derivative_and_covariance",
+            close(derivative_direct, expectation) and close(mixed_direct, second_derivative),
+            f"DR_direct={derivative_direct}, DR_expectation={expectation}, D2_direct={mixed_direct}, -Cov={second_derivative}",
+        )
+    )
+
+    # E L=I and Pi=L E are checked on a nonconstant hidden perturbation.
+    lifted = [(0.31, -0.09)] * len(weights)
+    e_lifted = average(lifted, weights)
+    projected = [expectation] * len(weights)
+    projected_twice = [average(projected, weights)] * len(weights)
+    centered = [add(value, scale(expectation, -1.0)) for value in perturbation]
+    e_centered = average(centered, weights)
+    checks.append(
+        (
+            "split_projection_identities",
+            max(abs(a - b) for a, b in zip(e_lifted, lifted[0], strict=True)) < 1.0e-14
+            and max(
+                abs(a - b)
+                for first, second in zip(projected, projected_twice, strict=True)
+                for a, b in zip(first, second, strict=True)
+            )
+            < 1.0e-14
+            and max(abs(value) for value in e_centered) < 1.0e-14,
+            f"E(Lf)={e_lifted}, E(centered)={e_centered}",
+        )
+    )
+
+    # Conditional centering is linear, not nonlinear: E h=0 but E h^2=1.
+    hidden = [-1.0, 1.0]
+    mean = sum(hidden) / 2.0
+    square_mean = sum(value * value for value in hidden) / 2.0
+    checks.append(
+        (
+            "centered_kernel_not_nonlinear",
+            mean == 0.0 and square_mean == 1.0,
+            f"E(h)={mean:.1f}, E(h^2)={square_mean:.1f}, D2R[h,h]={-square_mean:.1f}",
+        )
+    )
+
+    examples = [
+        (12.0, 0.0005, 0.12, 0.001, 0.001, 0.02),
+        (16.0, 0.0010, 0.12, 0.001, 0.001, 0.05),
+        (20.0, 0.0025, 0.125, 0.001, 0.001, 0.04),
+    ]
+    for mass, beta, c, theta, lam, eta in examples:
+        row = criterion(mass, beta, c, theta, lam, eta)
+        checks.append(
+            (
+                f"unlocalized_cauchy_boundary_m{mass:g}",
+                row["epsilon"] > 0.0
+                and row["q_hop"] < 1.0
+                and row["cauchy"] > 68.0 * math.exp(lam / 2.0)
+                and row["granted_geometry"] > 68.0,
+                "K={:.12f}, epsilon={:.12f}, radius={:.12f}, "
+                "Q_C={:.9f}, exp(-Lambda/2)Q_C={:.9f}".format(
+                    row["K"],
+                    row["epsilon"],
+                    row["radius"],
+                    row["cauchy"],
+                    row["granted_geometry"],
+                ),
+            )
+        )
+
+    # A fixed plaquette support has infinitely many character coordinates. A
+    # representative rank-nine coordinate projection has an explicit kernel
+    # vector. Independently construct the declared minimal H2 perimeter and
+    # compare the two one-term anchored weights.
+    jet_rank = 9
+    coordinate_dimension = jet_rank + 3
+    kernel_vector = [0.0] * coordinate_dimension
+    kernel_vector[jet_rank] = 1.0
+    projected_vector = [value if index < jet_rank else 0.0 for index, value in enumerate(kernel_vector)]
+    coarse_support = {(0, 0), (1, 0), (1, 1), (0, 1)}
+    fine_support = {
+        (0, 0),
+        (1, 0),
+        (2, 0),
+        (2, 1),
+        (2, 2),
+        (1, 2),
+        (0, 2),
+        (0, 1),
+    }
+    chart_lam = 0.001 / 2.0
+    chart_theta = 0.001 / 2.0
+    coarse_weight = math.exp(
+        chart_lam * graph_diameter(coarse_support) + chart_theta * len(coarse_support)
+    )
+    fine_weight = math.exp(
+        chart_lam * graph_diameter(fine_support) + chart_theta * len(fine_support)
+    )
+    plaquette_ratio = coarse_weight / fine_weight
+    checks.append(
+        (
+            "finite_jet_plaquette_character_tail",
+            all(value == 0.0 for value in projected_vector)
+            and graph_diameter(coarse_support) == 2
+            and len(coarse_support) == 4
+            and graph_diameter(fine_support) == 4
+            and len(fine_support) == 8
+            and abs(plaquette_ratio - math.exp(-2.0 * chart_lam - 4.0 * chart_theta)) < 1.0e-15,
+            "jet_rank={}, kernel_index={}, coarse=(d{},s{}), fine=(d{},s{}), composed_ratio={:.12f}".format(
+                jet_rank,
+                jet_rank,
+                graph_diameter(coarse_support),
+                len(coarse_support),
+                graph_diameter(fine_support),
+                len(fine_support),
+                plaquette_ratio,
+            ),
+        )
+    )
+
+    text = NOTE.read_text()
+    required = [
+        "**Type:** bounded_theorem",
+        "D R_Phi[F]=E_Phi[F]",
+        "68c/log(1+epsilon)>68",
+        "dynamical noncontraction theorem",
+        "not a nonlinear invariant sector",
+        "No axiom-update stop is established.",
+        "### N1",
+        "### N2",
+        "### N3",
+        "### N4",
+        "### N5",
+        "### N6",
+        "### N7",
+        "### N8",
+    ]
+    missing = [item for item in required if item not in text]
+    forbidden = ["finite projectors can never contract", "requires a new axiom", "NOT_TESTED"]
+    hits = [item for item in forbidden if item in text]
+    checks.append(("source_contract", not missing and not hits, f"missing={missing}, forbidden_hits={hits}"))
+
+    expected_dependencies = sorted(
+        [
+            "WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+        ]
+    )
+    dependencies = sorted(set(re.findall(r"\]\(([^)#?]+\.md)\)", text)))
+    checks.append(
+        (
+            "repository_dependency_set",
+            dependencies == expected_dependencies,
+            f"markdown_dependency_set={dependencies}",
+        )
+    )
+
+    passed = sum(ok for _, ok, _ in checks)
+    failed = len(checks) - passed
+    for name, ok, detail in checks:
+        print(f"{'PASS' if ok else 'FAIL'} {name}: {detail}")
+    print(f"SCORECARD PASS={passed} FAIL={failed}")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Result

Adds a bounded theorem for the exact constrained-fiber derivative on the controlled finite-local-source class.

- derives `DR_Phi[F]=E_Phi[F]` and the all-order cumulant signs in the even-balanced Banach algebra;
- proves the exact base-dependent split `C_Phi=L E_Phi`, `Q_Phi=1-C_Phi`, with `E_Phi Q_Phi=0`;
- gives an exact two-point witness that the centered kernel is not a nonlinear invariant sector;
- reconciles the joint-polymer half-weights with the declared RG chart;
- proves the current unlocalized Cauchy-plus-geometry certificate remains above 68 everywhere in its admissible region, without asserting dynamical noncontraction;
- proves a fixed-support plaquette-character tail survives every finite-rank projector in the present coefficient space, with exact declared-lift floor `exp(-2 lambda-4 theta)<1`.

Runner/cache: `PASS=9 FAIL=0`.

## Boundary

This does not prove or disprove full non-fiber contraction. The missing positive estimate is a scale-localized split `E_Phi=E_0+(E_Phi-E_0)` with a bounded local section for `L E_0` and a forced-base-attachment factor for centered marked clusters, followed by the affine ball test `B+q delta+(M/2)delta^2<=delta`.

No physical relevant sector, field normalization, taste carrier, critical trajectory, continuum limit, or axiom update is claimed.

## No-Go Discipline N1--N8

- **N1:** seven executed routes are recorded: unlocalized Cauchy/geometry, conditional centering, finite jets, quotient norm, block-shadow/local-section norm, forced-attachment clusters, and inspection of the current norm for Peter--Weyl weights.
- **N2:** the collapsed independent conditions are localized `q<1`, an invariant ball, physical taste/chart identification, and a critical trajectory/observable identification; all six pairs are tabulated.
- **N3:** finite-local-source versus full Frechet scope, base dependence, nonlinearity, field normalization, and fixed-support infinite-dimensionality are explicit.
- **N4:** the joint-polymer theorem and declared factor-two RG chart match the two residuals used; older raw and compact-continuum boundaries are not used as full-contraction witnesses.
- **N5:** the certificate result is restricted to the normalized local-source class and one declared plaquette slice; no arbitrary interaction-ball or critical claim is made.
- **N6:** local sections, marked-cluster localization, weighted norms, and alternative blocks are ordinary constructive mathematics, not missing axioms or primitives.
- **N7:** the strongest steelman is the small forced-attachment factor discarded by the absolute estimate, plus possible representation smoothing.
- **N8:** earlier certificate walls were repeatedly retired by stronger mathematics; this result does not foreclose the same pattern.

No-Go Discipline status: PASS for the narrow certificate boundary only.

## Review and audit compatibility

Independent code/math, physics/import/Nature, and governance/no-go review pass after two repair iterations. Full validation pipeline and strict lint pass. The seeded row is `bounded_theorem / unaudited` with exactly the simultaneous joint-polymer and declared-RG-chart dependencies. Generated audit/status outputs are stripped; the independent audit lane remains authoritative.
