### PR TITLE
audit-infra: five-judge judicial panel orchestrator for disagreements

### DIFF
--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -606,7 +606,15 @@ def audit_summary_from_row(row: dict) -> dict:
         "audit_date": row.get("audit_date"),
         "claim_type": row.get("claim_type"),
         "claim_scope": row.get("claim_scope"),
+        "load_bearing_step": row.get("load_bearing_step"),
         "load_bearing_step_class": row.get("load_bearing_step_class"),
+        "chain_closes": row.get("chain_closes"),
+        "chain_closure_explanation": row.get("chain_closure_explanation"),
+        "verdict_rationale": row.get("verdict_rationale"),
+        "notes_for_re_audit_if_any": row.get("notes_for_re_audit_if_any"),
+        "runner_check_breakdown": row.get("runner_check_breakdown"),
+        "open_dependency_paths": row.get("open_dependency_paths"),
+        "decoration_parent_claim_id": row.get("decoration_parent_claim_id"),
         "negative_assertion_classes": list(
             normalized_negative_assertion_classes(row)
         ),
@@ -628,7 +636,15 @@ def audit_summary_from_blob(audit: dict) -> dict:
         "audit_date": audit.get("audit_date") or datetime.now(timezone.utc).isoformat(),
         "claim_type": audit.get("claim_type"),
         "claim_scope": audit.get("claim_scope"),
+        "load_bearing_step": audit.get("load_bearing_step"),
         "load_bearing_step_class": audit.get("load_bearing_step_class"),
+        "chain_closes": audit.get("chain_closes"),
+        "chain_closure_explanation": audit.get("chain_closure_explanation"),
+        "verdict_rationale": audit.get("verdict_rationale"),
+        "notes_for_re_audit_if_any": audit.get("notes_for_re_audit_if_any"),
+        "runner_check_breakdown": audit.get("runner_check_breakdown"),
+        "open_dependency_paths": audit.get("open_dependency_paths"),
+        "decoration_parent_claim_id": audit.get("decoration_parent_claim_id"),
         "negative_assertion_classes": list(
             normalized_negative_assertion_classes(audit)
         ),

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -20,11 +20,10 @@ rules:
     record a cross-confirmation comparison before any retraction can cascade
   - non-clean re-audits of confirmed legacy clean rows record a real
     disagreement instead of treating migration-only confirmation as authority
-  - third-auditor passes over cross-confirmation disagreements record the
-    tiebreaker and hard-stop on genuine three-way disagreement
-  - judicial third-auditor reviews over disagreements may ratify the first or
-    second prior audit after reading both prior rationales, or mark the
-    disagreement as irresolvable for human review
+  - ordinary single-auditor passes cannot resolve cross-confirmation
+    disagreements; those require the governed five-judge panel path
+  - judicial panel reviews may ratify an applyable first, second, or hybrid
+    tuple; a panel majority siding with neither is never applied
 """
 from __future__ import annotations
 
@@ -993,6 +992,11 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     side = judgment.get("sided_with")
     if side not in ALLOWED_JUDICIAL_SIDES:
         return False, f"sided_with {side!r} not in {sorted(ALLOWED_JUDICIAL_SIDES)}"
+    if side == "neither":
+        return False, (
+            "judicial side='neither' is a panel-escalation outcome and cannot "
+            "be applied; run a fresh five-judge panel with the prior votes"
+        )
     ratified_verdict = judgment.get("ratified_verdict")
     if ratified_verdict not in ALLOWED_VERDICTS:
         return False, f"ratified_verdict {ratified_verdict!r} not in {sorted(ALLOWED_VERDICTS)}"
@@ -1020,11 +1024,10 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     second = cross_confirmation.get("second_audit") or {}
     if not first or not second:
         return False, "judicial review requires first_audit and second_audit summaries"
-    if side != "neither":
-        for label, summary in (("first_audit", first), ("second_audit", second)):
-            tuple_error = legacy_tuple_upgrade_error(label, summary)
-            if tuple_error:
-                return False, tuple_error
+    for label, summary in (("first_audit", first), ("second_audit", second)):
+        tuple_error = legacy_tuple_upgrade_error(label, summary)
+        if tuple_error:
+            return False, tuple_error
 
     prior_auditors = {first.get("auditor"), second.get("auditor")}
     if judgment.get("third_auditor") in prior_auditors:
@@ -1085,8 +1088,6 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     )
     if ratified_verdict == "audited_decoration" and not ratified_decoration_parent:
         return False, "judicial audited_decoration requires decoration_parent_claim_id"
-    if side == "neither" and ratified_verdict == "audited_clean":
-        return False, "judicial side='neither' requires a conservative non-clean ratified_verdict"
     ratified_class = judgment.get("ratified_load_bearing_step_class")
     final_claim_type = ratified_claim_type or chosen_claim_type or row.get("claim_type")
     note_path = row.get("note_path") or ""
@@ -1104,7 +1105,7 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
             or chosen.get("claim_scope")
             or row.get("claim_scope")
         ),
-        "chain_closes": side != "neither" and ratified_verdict == "audited_clean",
+        "chain_closes": ratified_verdict == "audited_clean",
         "load_bearing_step": judgment.get("ratified_load_bearing_step"),
         "chain_closure_explanation": judgment.get("judgment_rationale"),
         "verdict_rationale": judgment.get("judgment_rationale"),
@@ -1201,23 +1202,13 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
         judgment["no_go_discipline"] = packet
 
     # All fallible checks above are transactional: only now may the judicial
-    # record mutate the live row. This also ensures a valid ``neither`` result
-    # runs the same No-Go Discipline gate before recording its blocker.
+    # record mutate the live row.
     third = judicial_summary_from_blob(judgment)
-    if side != "neither":
-        tuple_error = legacy_tuple_upgrade_error("third_audit", third)
-        if tuple_error:
-            return False, tuple_error
+    tuple_error = legacy_tuple_upgrade_error("third_audit", third)
+    if tuple_error:
+        return False, tuple_error
     row["cross_confirmation"]["third_audit"] = third
     row["cross_confirmation"]["mode"] = "judicial_third_pass"
-
-    if side == "neither":
-        row["cross_confirmation"]["status"] = "disagreement_irresolvable"
-        row["blocker"] = "judicial_review_irresolvable"
-        consume_audit_invocation(row, invocation_id)
-        rows[cid] = row
-        ledger["rows"] = rows
-        return True, "judicial review recorded that neither prior reading is sufficient"
 
     row["cross_confirmation"]["status"] = {
         "first": "third_confirmed_first",
@@ -1297,6 +1288,18 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         return False, invocation_error
     if audit_invocation_seen(row, invocation_id):
         return False, "audit_invocation_id has already been consumed for this claim"
+    prior_cross_confirmation = row.get("cross_confirmation")
+    prior_cross_confirmation_status = (
+        prior_cross_confirmation.get("status")
+        if isinstance(prior_cross_confirmation, dict)
+        else prior_cross_confirmation
+    )
+    if prior_cross_confirmation_status == "disagreement":
+        return False, (
+            "cross-confirmation disagreement cannot be resolved by an ordinary "
+            "single-auditor pass; run the governed five-judge judicial panel"
+        )
+
     def accept_row() -> None:
         """Commit the detached row and consume this invocation exactly once."""
         consume_audit_invocation(row, invocation_id)
@@ -1464,15 +1467,6 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
     terminal_second_pass_msg: str | None = None
     terminal_second_pass_error: str | None = None
     terminal_second_pass_blocker: str | None = None
-    third_pass_msg: str | None = None
-    third_pass_error: str | None = None
-    third_pass_blocker: str | None = None
-    prior_cross_confirmation = row.get("cross_confirmation")
-    prior_cross_confirmation_status = (
-        prior_cross_confirmation.get("status")
-        if isinstance(prior_cross_confirmation, dict)
-        else prior_cross_confirmation
-    )
     legacy_claim_type_reaudit = legacy_confirmed_clean_claim_type_reaudit(
         row, verdict, prior_cross_confirmation_status
     )
@@ -1504,7 +1498,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             f"{first.get('load_bearing_step_class')!r} vs "
             f"{second.get('verdict')!r}/{second.get('claim_type')!r}/"
             f"{second.get('load_bearing_step_class')!r}); "
-            "promote to third-auditor review"
+            "promote to the governed five-judge judicial panel"
         )
 
     first_terminal_verdict = row.get("audit_status")
@@ -1561,7 +1555,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
                 f"{first.get('load_bearing_step_class')!r} vs "
                 f"{second.get('verdict')!r}/{second.get('claim_type')!r}/"
                 f"{second.get('load_bearing_step_class')!r}); "
-                "promote to owner review"
+                "promote to the governed five-judge judicial panel"
             )
         accept_row()
         return True, "explicit second-seat cross-confirmation recorded"
@@ -1619,81 +1613,6 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
             accept_row()
             return True, terminal_second_pass_msg
 
-    third_pass = prior_cross_confirmation_status == "disagreement"
-    if third_pass:
-        if independence == "weak":
-            return False, "third-auditor confirmation requires independence != 'weak'"
-        err = third_confirmation_error(prior_cross_confirmation or {}, audit)
-        if err:
-            return False, err
-
-        first = (prior_cross_confirmation or {}).get("first_audit") or {}
-        second = (prior_cross_confirmation or {}).get("second_audit") or {}
-        for label, summary in (("first_audit", first), ("second_audit", second)):
-            tuple_error = legacy_tuple_upgrade_error(label, summary)
-            if tuple_error:
-                return False, tuple_error
-        for seat_name, seat in (("first", first), ("second", second)):
-            seat_gate_error = cross_summary_no_go_error(
-                seat,
-                source_required=source_requires_no_go,
-                current_evidence_manifest=evidence_manifest,
-            )
-            if seat_gate_error:
-                return False, (
-                    f"third-auditor confirmation cannot ratify an invalid {seat_name} "
-                    f"audit: {seat_gate_error}"
-                )
-        third = audit_summary_from_blob(audit)
-        tuple_error = legacy_tuple_upgrade_error("third_audit", third)
-        if tuple_error:
-            return False, tuple_error
-        first_verdict = first.get("verdict")
-        second_verdict = second.get("verdict")
-        third_verdict = third.get("verdict")
-        third_matches_first = audit_tuples_match(third, first)
-        third_matches_second = audit_tuples_match(third, second)
-        if third_matches_first:
-            row["cross_confirmation"]["third_audit"] = third
-            row["cross_confirmation"]["status"] = "third_confirmed_first"
-            row["cross_confirmation"]["mode"] = "terminal_third_pass"
-            row["cross_confirmation"]["agreement_schema"] = AUDIT_TUPLE_AGREEMENT_SCHEMA
-            third_pass_msg = "third auditor confirmed first verdict"
-            audit["verdict"] = first["verdict"]
-            audit["claim_type"] = first["claim_type"]
-            audit["load_bearing_step_class"] = first["load_bearing_step_class"]
-            audit["negative_assertion_classes"] = list(
-                normalized_negative_assertion_classes(first)
-            )
-        elif third_matches_second:
-            row["cross_confirmation"]["third_audit"] = third
-            row["cross_confirmation"]["status"] = "third_confirmed_second"
-            row["cross_confirmation"]["mode"] = "terminal_third_pass"
-            row["cross_confirmation"]["agreement_schema"] = AUDIT_TUPLE_AGREEMENT_SCHEMA
-            third_pass_msg = "third auditor confirmed second verdict"
-            audit["verdict"] = second["verdict"]
-            audit["claim_type"] = second["claim_type"]
-            audit["load_bearing_step_class"] = second["load_bearing_step_class"]
-            audit["negative_assertion_classes"] = list(
-                normalized_negative_assertion_classes(second)
-            )
-        else:
-            row["cross_confirmation"]["third_audit"] = third
-            row["cross_confirmation"]["status"] = "three_way_disagreement"
-            row["cross_confirmation"]["mode"] = "terminal_third_pass"
-            third_pass_msg = (
-                "third auditor introduced a third verdict or claim_type "
-                f"({first_verdict!r}/{first.get('claim_type')!r} vs "
-                f"{second_verdict!r}/{second.get('claim_type')!r} vs "
-                f"{third_verdict!r}/{third.get('claim_type')!r}); "
-                "escalate to human review"
-            )
-            third_pass_blocker = "third_auditor_disagreement"
-            row["audit_status"] = "audit_in_progress"
-            row["blocker"] = third_pass_blocker
-            accept_row()
-            return True, third_pass_msg
-
     critical_second_pass = (
         criticality == "critical"
         and prior_cross_confirmation_status == "awaiting_second"
@@ -1739,7 +1658,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
                 f"{first.get('load_bearing_step_class')!r} vs "
                 f"{second.get('verdict')!r}/{second.get('claim_type')!r}/"
                 f"{second.get('load_bearing_step_class')!r}); "
-                "promote to third-auditor review"
+                "promote to the governed five-judge judicial panel"
             )
 
     # Cross-confirmation flow for critical claims.
@@ -1750,7 +1669,6 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         verdict == "audited_clean"
         and criticality == "critical"
         and not critical_second_pass
-        and not third_pass
         and not legacy_claim_type_reaudit
     ):
         prior = row.get("cross_confirmation") or {}
@@ -1808,7 +1726,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
                 "negative_assertion_classes "
                 f"({first.get('claim_type')!r}/{first.get('load_bearing_step_class')!r} vs "
                 f"{claim_type!r}/{audit.get('load_bearing_step_class')!r}); "
-                "promote to third-auditor review"
+                "promote to the governed five-judge judicial panel"
             )
         # Concordant second audit: promote.
         row["cross_confirmation"]["second_audit"] = audit_summary_from_blob(audit)
@@ -1845,7 +1763,7 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         row["no_go_discipline"] = audit.get("no_go_discipline")
     if "runner_check_breakdown" in audit:
         row["runner_check_breakdown"] = audit["runner_check_breakdown"]
-    row["blocker"] = third_pass_blocker if third_pass else terminal_second_pass_blocker
+    row["blocker"] = terminal_second_pass_blocker
     if legacy_claim_type_reaudit:
         row.setdefault("cross_confirmation", {})["claim_type_reaudit"] = audit_summary_from_blob(audit)
         row["cross_confirmation"]["mode"] = "legacy_confirmed_clean_claim_type_reaudit"
@@ -1869,10 +1787,6 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         return False, terminal_second_pass_error
     if terminal_second_pass_msg:
         return True, terminal_second_pass_msg
-    if third_pass_error:
-        return False, third_pass_error
-    if third_pass_msg:
-        return True, third_pass_msg
     return True, "applied"
 
 

--- a/docs/audit/scripts/orchestrate_judicial_panel.py
+++ b/docs/audit/scripts/orchestrate_judicial_panel.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+"""Run the audit-loop five-judge panel over cross-confirmation disagreements.
+
+For each targeted disagreement row this renders the canonical restricted
+packet, appends both recorded seat positions (tuple summaries plus their
+archived full rationales), and launches five detached GPT-5.6-sol/xhigh
+judges with distinct identities. Each judge votes on the full tuple
+
+    (sided_with, ratified_verdict, ratified_claim_type,
+     ratified_claim_scope, ratified_load_bearing_step_class,
+     negative_assertion_classes)
+
+and must explain the error in the position it votes against. A majority is
+at least three matching full-tuple votes out of five (whitespace-only scope
+differences and assertion-class ordering are equivalent). On majority, a
+representative judicial JSON is applied through the standard serialized
+gates (apply -> pipeline -> strict lint -> diff/scope check -> commit ->
+push). Without a majority, the panel record is written to the workdir and
+the next invocation may pass it back via --prior-panel for a fresh panel
+with the earlier votes in context, per the audit-loop skill.
+
+Run only from a dedicated, clean ``main`` checkout.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import uuid
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS))
+import orchestrate_audit_batch as batch  # noqa: E402
+
+audit_runner = batch.audit_runner
+REPO_ROOT = batch.REPO_ROOT
+
+PANEL_SIZE = 5
+MAJORITY = 3
+MIN_VOTE_BYTES = 120
+
+VOTE_FIELDS = (
+    "sided_with",
+    "ratified_verdict",
+    "ratified_claim_type",
+    "ratified_claim_scope",
+    "ratified_load_bearing_step_class",
+    "negative_assertion_classes",
+    "judgment_rationale",
+    "first_auditor_error",
+    "second_auditor_error",
+)
+
+
+def norm_scope(value: str) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip())
+
+
+def vote_tuple(vote: dict) -> tuple:
+    classes = vote.get("negative_assertion_classes")
+    classes_key = tuple(sorted(classes)) if isinstance(classes, list) else ("<invalid>",)
+    return (
+        vote.get("sided_with"),
+        vote.get("ratified_verdict"),
+        vote.get("ratified_claim_type"),
+        norm_scope(vote.get("ratified_claim_scope") or ""),
+        vote.get("ratified_load_bearing_step_class"),
+        classes_key,
+    )
+
+
+def archived_rationale(row: dict, invocation_id: str) -> str:
+    for archived in reversed(row.get("previous_audits") or []):
+        if not isinstance(archived, dict):
+            continue
+        if invocation_id and archived.get("audit_invocation_id") == invocation_id:
+            rationale = str(archived.get("verdict_rationale") or "")
+            notes = str(archived.get("notes_for_re_audit_if_any") or "")
+            return rationale + (f"\n[re-audit notes] {notes}" if notes else "")
+    return "[no archived rationale found for this seat's invocation id]"
+
+
+def seat_block(label: str, summary: dict, row: dict) -> str:
+    lines = [f"=== BEGIN {label.upper()} POSITION ==="]
+    for field in (
+        "verdict", "claim_type", "claim_scope", "load_bearing_step_class",
+        "negative_assertion_classes", "independence", "auditor",
+    ):
+        lines.append(f"{field}: {json.dumps(summary.get(field))}")
+    lines.append("full rationale:")
+    lines.append(archived_rationale(row, str(summary.get("audit_invocation_id") or "")))
+    lines.append(f"=== END {label.upper()} POSITION ===")
+    return "\n".join(lines)
+
+
+def panel_instructions(judge_no: int, prior_panels: list[dict]) -> str:
+    prior_block = ""
+    if prior_panels:
+        prior_block = (
+            "\n### Prior panel outcomes (no majority yet)\n\n"
+            "Earlier five-judge panels on this disagreement produced the vote\n"
+            "breakdowns below. Weigh their arguments; you are not bound by\n"
+            "them.\n\n"
+            + json.dumps(prior_panels, indent=1, sort_keys=True)
+            + "\n"
+        )
+    return f"""
+### JUDICIAL PANEL SEAT {judge_no} OF {PANEL_SIZE}
+
+The two independent audit seats above DISAGREE. You are one judge on a
+five-judge panel resolving the disagreement. Judge ONLY from the restricted
+packet plus the two recorded positions. Do not search anything else.
+{prior_block}
+Return EXACTLY ONE JSON object and nothing else:
+
+{{
+  "sided_with": "<first|second|hybrid>",
+  "ratified_verdict": "<audited_clean|audited_renaming|audited_conditional|audited_decoration|audited_failed|audited_numerical_match>",
+  "ratified_claim_type": "<positive_theorem|bounded_theorem|no_go|open_gate|decoration|meta>",
+  "ratified_claim_scope": "<the exact scope sentence you ratify; reuse a seat's scope verbatim unless a hybrid correction is required>",
+  "ratified_load_bearing_step_class": "<(A)|(B)|(C)|(D)|(E)|(F)|(G) style class exactly as the seats use>",
+  "negative_assertion_classes": [],
+  "judgment_rationale": "<why the ratified tuple is correct, grounded in the packet>",
+  "first_auditor_error": "<the specific error in the first position, or 'none' if you side with it entirely>",
+  "second_auditor_error": "<the specific error in the second position, or 'none' if you side with it entirely>"
+}}
+
+Rules: vote the FULL tuple; a factual check against the packet (for
+example whether the runner computes a contested quantity) outweighs either
+seat's characterization; if you side with a seat, prefer that seat's
+claim_scope verbatim; declare negative_assertion_classes honestly for the
+tuple you ratify; never leave first_auditor_error and second_auditor_error
+both 'none' unless you ratify a hybrid that faults neither.
+"""
+
+
+def render_judge_prompt(
+    row: dict,
+    rows: dict[str, dict],
+    judge_no: int,
+    runner_timeout: int,
+    prior_panels: list[dict],
+) -> str:
+    template = audit_runner.PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
+    packet = audit_runner.render_prompt(
+        row,
+        rows,
+        template,
+        runner_timeout,
+        use_cache=False,
+        evidence_manifest_out={},
+        audit_invocation_id=uuid.uuid4().hex,
+    )
+    cross = row.get("cross_confirmation") or {}
+    first = cross.get("first_audit") or {}
+    second = cross.get("second_audit") or {}
+    return "\n\n".join(
+        [
+            packet,
+            seat_block("first_audit", first, row),
+            seat_block("second_audit", second, row),
+            panel_instructions(judge_no, prior_panels),
+        ]
+    )
+
+
+def launch_judge(
+    row: dict,
+    rows: dict[str, dict],
+    judge_no: int,
+    workdir: Path,
+    runner_timeout: int,
+    prior_panels: list[dict],
+) -> dict:
+    cid = row["claim_id"]
+    key = batch.artifact_key(cid)
+    prompt = render_judge_prompt(row, rows, judge_no, runner_timeout, prior_panels)
+    if len(prompt) > audit_runner.CODEX_INPUT_CHAR_LIMIT:
+        raise ValueError(
+            f"{cid}: judicial packet is {len(prompt)} characters; narrow the "
+            "packet rather than converting transport size into a verdict"
+        )
+    tag = f"{key}-judge{judge_no}"
+    isolated = workdir / f"isolated-{tag}"
+    isolated.mkdir(parents=True, exist_ok=False)
+    (isolated / "PANEL_TASK.md").write_text(prompt, encoding="utf-8")
+    raw_output = workdir / f"raw-{tag}.txt"
+    log_path = workdir / f"log-{tag}.txt"
+    log_handle = log_path.open("w", encoding="utf-8")
+    instruction = (
+        "Open PANEL_TASK.md in the current directory and follow it exactly. "
+        "It contains the complete restricted packet, both recorded audit "
+        "positions, and your panel-seat instructions. Do not inspect any "
+        "other file. Return only the single JSON vote object it requires."
+    )
+    import subprocess
+
+    proc = subprocess.Popen(
+        [
+            "codex", "exec", "--skip-git-repo-check", "--ignore-rules",
+            "--sandbox", "read-only", "--model", batch.MODEL,
+            "-c", f"model_reasoning_effort='{batch.REASONING}'",
+            "--output-last-message", str(raw_output), instruction,
+        ],
+        stdin=subprocess.DEVNULL,
+        stdout=log_handle,
+        stderr=log_handle,
+        cwd=isolated,
+        start_new_session=True,
+    )
+    now = time.monotonic()
+    return {
+        "cid": cid,
+        "pass": judge_no,
+        "judge": judge_no,
+        "proc": proc,
+        "raw_output": raw_output,
+        "log_path": log_path,
+        "log_handle": log_handle,
+        "isolated": isolated,
+        "auditor": (
+            f"codex-judicial-{judge_no}-"
+            f"{datetime.now(timezone.utc).strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
+        ),
+        "last_size": 0,
+        "last_progress": now,
+        "stalled": False,
+    }
+
+
+def collect_vote(job: dict) -> tuple[dict | None, str]:
+    if job["stalled"]:
+        return None, "stall_killed"
+    raw = job["raw_output"]
+    if job.get("returncode") != 0:
+        return None, f"judge_exit_{job.get('returncode')}"
+    if not raw.exists() or raw.stat().st_size <= MIN_VOTE_BYTES:
+        return None, "no_size_qualified_vote"
+    reply = audit_runner.extract_response(raw.read_text(encoding="utf-8"))
+    vote = audit_runner.parse_verdict_json(reply or "")
+    if vote is None:
+        return None, "malformed_vote_json"
+    missing = [field for field in VOTE_FIELDS if field not in vote]
+    if missing:
+        return None, f"vote_missing_fields:{','.join(missing)}"
+    return vote, "ok"
+
+
+def judicial_blob(
+    row: dict, representative: dict, votes: list[dict], majority: int
+) -> dict:
+    breakdown = [
+        {
+            "judge": index + 1,
+            "tuple": list(vote_tuple(vote)[:5]) + [list(vote_tuple(vote)[5])],
+            "rationale": str(vote.get("judgment_rationale") or "")[:600],
+        }
+        for index, vote in enumerate(votes)
+    ]
+    rationale = (
+        f"Five-judge panel majority ({majority}/{PANEL_SIZE} matching full "
+        "tuples) resolved the cross-confirmation disagreement. "
+        f"Representative rationale: {representative.get('judgment_rationale')}"
+        f"\n[panel breakdown] {json.dumps(breakdown, sort_keys=True)}"
+    )
+    return {
+        "claim_id": row["claim_id"],
+        "third_auditor": (
+            f"codex-judicial-panel-{datetime.now(timezone.utc).strftime('%Y%m%d')}-"
+            f"{uuid.uuid4().hex[:8]}"
+        ),
+        "auditor_family": batch.AUDITOR_FAMILY,
+        "auditor_model": batch.MODEL,
+        "auditor_reasoning_effort": batch.REASONING,
+        "independence": "judicial_review",
+        "audit_invocation_id": uuid.uuid4().hex,
+        "sided_with": representative.get("sided_with"),
+        "ratified_verdict": representative.get("ratified_verdict"),
+        "ratified_claim_type": representative.get("ratified_claim_type"),
+        "ratified_claim_scope": representative.get("ratified_claim_scope"),
+        "ratified_load_bearing_step_class": representative.get(
+            "ratified_load_bearing_step_class"
+        ),
+        "negative_assertion_classes": representative.get(
+            "negative_assertion_classes"
+        ),
+        "judgment_rationale": rationale,
+        "first_auditor_error": representative.get("first_auditor_error"),
+        "second_auditor_error": representative.get("second_auditor_error"),
+    }
+
+
+def apply_judgment(blob: dict, workdir: Path, retries: int) -> tuple[bool, dict]:
+    cid = blob["claim_id"]
+    judgment_path = workdir / f"judgment-{batch.artifact_key(cid)}.json"
+    judgment_path.write_text(
+        json.dumps(blob, indent=1, sort_keys=True), encoding="utf-8"
+    )
+    for attempt in range(1, retries + 1):
+        synced, detail = batch.sync_origin_main()
+        if not synced:
+            return False, {"cid": cid, "result": "sync_blocked", "detail": detail}
+        apply_result = batch.sh(
+            [
+                sys.executable,
+                str(SCRIPTS / "apply_audit.py"),
+                "--file",
+                str(judgment_path),
+            ]
+        )
+        if apply_result.returncode != 0:
+            return False, {
+                "cid": cid,
+                "result": "judicial_apply_rejected",
+                "detail": (apply_result.stderr or apply_result.stdout)[-400:],
+            }
+        pipeline = batch.sh(["bash", str(SCRIPTS / "run_pipeline.sh")], timeout=1800)
+        if pipeline.returncode != 0:
+            return False, {
+                "cid": cid,
+                "result": "pipeline_failed",
+                "detail": (pipeline.stderr or pipeline.stdout)[-400:],
+            }
+        lint = batch.sh(
+            [sys.executable, str(SCRIPTS / "audit_lint.py"), "--strict"], timeout=600
+        )
+        if lint.returncode != 0:
+            return False, {
+                "cid": cid,
+                "result": "strict_lint_failed",
+                "detail": (lint.stderr or lint.stdout)[-400:],
+            }
+        diff_check = batch.sh(["git", "diff", "--check"])
+        if diff_check.returncode != 0:
+            return False, {
+                "cid": cid,
+                "result": "diff_check_failed",
+                "detail": diff_check.stdout[-400:],
+            }
+        unexpected = [
+            path
+            for path in batch.changed_paths()
+            if not batch.allowed_generated_path(path)
+        ]
+        if unexpected:
+            return False, {
+                "cid": cid,
+                "result": "unexpected_generated_paths",
+                "detail": str(unexpected[:8]),
+            }
+        committed, detail = batch.stage_and_commit(
+            f"audit: {cid} judicial panel {blob['ratified_verdict']} "
+            f"(codex-cli, {batch.MODEL}, {batch.REASONING}, panel/batch)"
+        )
+        if not committed:
+            return False, {"cid": cid, "result": "commit_failed", "detail": detail}
+        local_commit = detail
+        push = batch.sh(["git", "push", "-q", "origin", "HEAD:main"])
+        if push.returncode == 0:
+            return True, {
+                "cid": cid,
+                "result": blob["ratified_verdict"],
+                "sided_with": blob["sided_with"],
+                "commit": local_commit,
+            }
+        fetch = batch.sh(["git", "fetch", "origin", "main", "-q"])
+        if fetch.returncode != 0:
+            return False, {"cid": cid, "result": "push_failed"}
+        landed = batch.sh(
+            ["git", "merge-base", "--is-ancestor", local_commit, "origin/main"]
+        )
+        if landed.returncode == 0:
+            return True, {
+                "cid": cid,
+                "result": blob["ratified_verdict"],
+                "sided_with": blob["sided_with"],
+                "commit": local_commit,
+            }
+        if attempt == retries:
+            return False, {"cid": cid, "result": "push_race_exhausted"}
+        error = batch.clean_main_error()
+        if error:
+            return False, {"cid": cid, "result": "race_retry_dirty", "detail": error}
+        reset = batch.sh(["git", "reset", "--hard", "origin/main"])
+        if reset.returncode != 0:
+            return False, {"cid": cid, "result": "race_reset_failed"}
+    return False, {"cid": cid, "result": "unreachable"}
+
+
+def run_panel(
+    row: dict,
+    rows: dict[str, dict],
+    workdir: Path,
+    stall_minutes: int,
+    runner_timeout: int,
+    retries: int,
+    prior_panels: list[dict],
+) -> dict:
+    cid = row["claim_id"]
+    jobs = []
+    try:
+        for judge_no in range(1, PANEL_SIZE + 1):
+            jobs.append(
+                launch_judge(
+                    row, rows, judge_no, workdir, runner_timeout, prior_panels
+                )
+            )
+    except BaseException:
+        batch.terminate_workers(jobs)
+        raise
+    print(f"   {cid}: launched {len(jobs)} panel judges; waiting")
+    batch.wait_workers(jobs, stall_minutes)
+    votes: list[dict] = []
+    failures: list[str] = []
+    for job in jobs:
+        vote, status = collect_vote(job)
+        if vote is None:
+            failures.append(f"judge{job['judge']}:{status}")
+        else:
+            votes.append(vote)
+    if len(votes) < MAJORITY:
+        return {
+            "cid": cid,
+            "result": "panel_delivery_short",
+            "detail": ";".join(failures),
+            "votes": votes,
+        }
+    tally = Counter(vote_tuple(vote) for vote in votes)
+    top_tuple, count = tally.most_common(1)[0]
+    record = {
+        "cid": cid,
+        "votes": [
+            {key: vote.get(key) for key in VOTE_FIELDS} for vote in votes
+        ],
+        "failures": failures,
+        "tally": [
+            {"tuple": [*key[:5], list(key[5])], "count": n}
+            for key, n in tally.most_common()
+        ],
+    }
+    (workdir / f"panel-{batch.artifact_key(cid)}.json").write_text(
+        json.dumps(record, indent=1, sort_keys=True), encoding="utf-8"
+    )
+    if count < MAJORITY:
+        return {
+            "cid": cid,
+            "result": "no_majority",
+            "detail": f"top tuple has {count}/{len(votes)} votes",
+            "votes": votes,
+        }
+    representative = next(
+        vote for vote in votes if vote_tuple(vote) == top_tuple
+    )
+    blob = judicial_blob(row, representative, votes, count)
+    ok, result = apply_judgment(blob, workdir, retries)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Five-judge panel drainer for cross-confirmation disagreements"
+    )
+    parser.add_argument(
+        "--claims",
+        help="comma-separated claim ids (default: every disagreement row)",
+    )
+    parser.add_argument(
+        "--prior-panel",
+        action="append",
+        default=[],
+        help="path to a prior panel-<key>.json record to give the judges",
+    )
+    parser.add_argument("--stall-minutes", type=int, default=45)
+    parser.add_argument("--runner-timeout-sec", type=int, default=120)
+    parser.add_argument("--push-retries", type=int, default=3)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if not args.dry_run:
+        error = batch.clean_main_error()
+        if error:
+            print(f"refusing to run: {error}. Use a dedicated clean main checkout.")
+            return 2
+
+    workdir = Path(
+        os.environ.get("AUDIT_PANEL_WORKDIR")
+        or f"/tmp/audit_panel_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}_{uuid.uuid4().hex[:8]}"
+    )
+    if not args.dry_run:
+        try:
+            workdir.mkdir(parents=True, exist_ok=False)
+        except FileExistsError:
+            print(
+                f"refusing to run: workdir {workdir} already exists. "
+                "Each run requires a fresh workdir; remove it or point "
+                "AUDIT_PANEL_WORKDIR at a new path."
+            )
+            return 2
+
+    rows = batch.load_rows()
+    if args.claims:
+        scope = [cid.strip() for cid in args.claims.split(",") if cid.strip()]
+    else:
+        scope = sorted(
+            cid
+            for cid, row in rows.items()
+            if (row.get("cross_confirmation") or {}).get("status") == "disagreement"
+        )
+    targets = []
+    for cid in scope:
+        row = rows.get(cid)
+        if not row:
+            print(f"   skip: {cid}: missing ledger row")
+            continue
+        if (row.get("cross_confirmation") or {}).get("status") != "disagreement":
+            print(f"   skip: {cid}: cross_confirmation is not a disagreement")
+            continue
+        targets.append(row)
+    print(f"== judicial panel targets: {len(targets)}")
+    if args.dry_run:
+        for row in targets:
+            print(f"   would panel: {row['claim_id']}")
+        return 0
+
+    prior_panels = []
+    for path in args.prior_panel:
+        prior_panels.append(json.loads(Path(path).read_text(encoding="utf-8")))
+
+    report = []
+    for row in targets:
+        result = run_panel(
+            row,
+            rows,
+            workdir,
+            args.stall_minutes,
+            args.runner_timeout_sec,
+            args.push_retries,
+            prior_panels,
+        )
+        report.append(result)
+        print(f"   {result['cid']}: {result['result']}")
+        rows = batch.load_rows()
+
+    (workdir / "report.jsonl").write_text(
+        "".join(
+            json.dumps(
+                {key: value for key, value in item.items() if key != "votes"},
+                sort_keys=True,
+            )
+            + "\n"
+            for item in report
+        ),
+        encoding="utf-8",
+    )
+    print(f"report: {workdir / 'report.jsonl'}")
+    applied = {
+        "audited_clean", "audited_renaming", "audited_conditional",
+        "audited_decoration", "audited_failed", "audited_numerical_match",
+    }
+    return 0 if all(item.get("result") in applied for item in report) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/audit/scripts/orchestrate_judicial_panel.py
+++ b/docs/audit/scripts/orchestrate_judicial_panel.py
@@ -657,6 +657,7 @@ HARD_APPLY_BLOCKER_PREFIXES = (
     "judicial review requires first_audit and second_audit summaries",
     "first_audit cannot be upgraded",
     "second_audit cannot be upgraded",
+    "third_audit cannot be upgraded",
     "judicial third auditor must differ",
     "trusted evidence manifest",
     "No-Go Discipline apply requires trusted orchestrator evidence transport",
@@ -1007,6 +1008,11 @@ def load_prior_panels(
             )
         if record.get("schema") != "judicial_panel_record_v1":
             return {}, f"prior panel {path} has an invalid schema"
+        invocation_id = record.get("invocation_id")
+        if not isinstance(invocation_id, str) or re.fullmatch(
+            r"[0-9a-f]{32}", invocation_id
+        ) is None:
+            return {}, f"prior panel {path} has an invalid invocation_id"
         panel_no = record.get("panel")
         if not isinstance(panel_no, int) or isinstance(panel_no, bool) or panel_no < 1:
             return {}, f"prior panel {path} has an invalid panel number"

--- a/docs/audit/scripts/orchestrate_judicial_panel.py
+++ b/docs/audit/scripts/orchestrate_judicial_panel.py
@@ -24,9 +24,11 @@ Run only from a dedicated, clean ``main`` checkout.
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import os
 import re
+import subprocess
 import sys
 import time
 import uuid
@@ -45,6 +47,24 @@ PANEL_SIZE = 5
 MAJORITY = 3
 MIN_VOTE_BYTES = 120
 
+ALLOWED_SIDES = {"first", "second", "hybrid"}
+ALLOWED_VERDICTS = {
+    "audited_clean",
+    "audited_renaming",
+    "audited_conditional",
+    "audited_decoration",
+    "audited_failed",
+    "audited_numerical_match",
+}
+ALLOWED_CLAIM_TYPES = {
+    "positive_theorem",
+    "bounded_theorem",
+    "no_go",
+    "open_gate",
+    "decoration",
+    "meta",
+}
+
 VOTE_FIELDS = (
     "sided_with",
     "ratified_verdict",
@@ -55,6 +75,27 @@ VOTE_FIELDS = (
     "judgment_rationale",
     "first_auditor_error",
     "second_auditor_error",
+)
+
+SEAT_ARGUMENT_FIELDS = (
+    "verdict",
+    "claim_type",
+    "claim_scope",
+    "load_bearing_step_class",
+    "negative_assertion_classes",
+    "load_bearing_step",
+    "chain_closes",
+    "chain_closure_explanation",
+    "runner_check_breakdown",
+    "open_dependency_paths",
+    "decoration_parent_claim_id",
+    "no_go_discipline",
+    "independence",
+    "auditor",
+    "auditor_family",
+    "auditor_model",
+    "auditor_reasoning_effort",
+    "audit_invocation_id",
 )
 
 
@@ -75,7 +116,52 @@ def vote_tuple(vote: dict) -> tuple:
     )
 
 
+def vote_schema_error(vote: object) -> str | None:
+    if not isinstance(vote, dict):
+        return "vote must be a JSON object"
+    missing = [field for field in VOTE_FIELDS if field not in vote]
+    if missing:
+        return f"vote_missing_fields:{','.join(missing)}"
+    if vote.get("sided_with") not in ALLOWED_SIDES:
+        return "vote has invalid sided_with"
+    if vote.get("ratified_verdict") not in ALLOWED_VERDICTS:
+        return "vote has invalid ratified_verdict"
+    if vote.get("ratified_claim_type") not in ALLOWED_CLAIM_TYPES:
+        return "vote has invalid ratified_claim_type"
+    for field in (
+        "ratified_claim_scope",
+        "ratified_load_bearing_step_class",
+        "judgment_rationale",
+        "first_auditor_error",
+        "second_auditor_error",
+    ):
+        if not isinstance(vote.get(field), str) or not vote[field].strip():
+            return f"vote field {field} must be a non-empty string"
+    declared = vote.get("negative_assertion_classes")
+    if not isinstance(declared, list) or not all(
+        isinstance(item, str) and item.strip() for item in declared
+    ):
+        return "negative_assertion_classes must be a list of non-empty strings"
+    for field in (
+        "hybrid_resolution_note",
+        "ratified_decoration_parent_claim_id",
+        "ratified_load_bearing_step",
+        "notes_for_re_audit_if_any",
+    ):
+        if field in vote and vote[field] is not None and not isinstance(vote[field], str):
+            return f"vote field {field} must be a string or null"
+    if "no_go_discipline" in vote and vote["no_go_discipline"] is not None:
+        if not isinstance(vote["no_go_discipline"], dict):
+            return "no_go_discipline must be an object or null"
+    return None
+
+
 def archived_rationale(row: dict, invocation_id: str) -> str:
+    if not invocation_id:
+        return (
+            "[seat summary has no audit_invocation_id; no invocation-bound "
+            "archived rationale is available]"
+        )
     for archived in reversed(row.get("previous_audits") or []):
         if not isinstance(archived, dict):
             continue
@@ -83,35 +169,80 @@ def archived_rationale(row: dict, invocation_id: str) -> str:
             rationale = str(archived.get("verdict_rationale") or "")
             notes = str(archived.get("notes_for_re_audit_if_any") or "")
             return rationale + (f"\n[re-audit notes] {notes}" if notes else "")
-    return "[no archived rationale found for this seat's invocation id]"
+    return (
+        "[no archived rationale found for this seat's invocation id "
+        f"{invocation_id}]"
+    )
+
+
+def seat_rationale(summary: dict, row: dict) -> str:
+    rationale = str(summary.get("verdict_rationale") or "")
+    notes = str(summary.get("notes_for_re_audit_if_any") or "")
+    if rationale:
+        return rationale + (f"\n[re-audit notes] {notes}" if notes else "")
+    return archived_rationale(row, str(summary.get("audit_invocation_id") or ""))
+
+
+def seat_context_error(row: dict) -> str | None:
+    cross = row.get("cross_confirmation") or {}
+    for label in ("first_audit", "second_audit"):
+        summary = cross.get(label) or {}
+        if not summary:
+            return f"{label} summary is missing"
+        if str(summary.get("verdict_rationale") or "").strip():
+            continue
+        invocation_id = str(summary.get("audit_invocation_id") or "")
+        matched = next(
+            (
+                archived
+                for archived in reversed(row.get("previous_audits") or [])
+                if isinstance(archived, dict)
+                and invocation_id
+                and archived.get("audit_invocation_id") == invocation_id
+                and str(archived.get("verdict_rationale") or "").strip()
+            ),
+            None,
+        )
+        if matched is None:
+            return (
+                f"{label} has no invocation-bound full rationale; rerun the "
+                "cross-confirmation seats under the rationale-preserving apply contract"
+            )
+    return None
 
 
 def seat_block(label: str, summary: dict, row: dict) -> str:
     lines = [f"=== BEGIN {label.upper()} POSITION ==="]
-    for field in (
-        "verdict", "claim_type", "claim_scope", "load_bearing_step_class",
-        "negative_assertion_classes", "independence", "auditor",
-    ):
-        lines.append(f"{field}: {json.dumps(summary.get(field))}")
+    for field in SEAT_ARGUMENT_FIELDS:
+        if field not in {"verdict_rationale", "notes_for_re_audit_if_any"}:
+            lines.append(f"{field}: {json.dumps(summary.get(field))}")
     lines.append("full rationale:")
-    lines.append(archived_rationale(row, str(summary.get("audit_invocation_id") or "")))
+    lines.append(seat_rationale(summary, row))
     lines.append(f"=== END {label.upper()} POSITION ===")
     return "\n".join(lines)
 
 
-def panel_instructions(judge_no: int, prior_panels: list[dict]) -> str:
+def panel_instructions(
+    judge_no: int,
+    judge_identity: str,
+    panel_no: int,
+    prior_panels: list[dict],
+) -> str:
     prior_block = ""
     if prior_panels:
         prior_block = (
-            "\n### Prior panel outcomes (no majority yet)\n\n"
-            "Earlier five-judge panels on this disagreement produced the vote\n"
-            "breakdowns below. Weigh their arguments; you are not bound by\n"
-            "them.\n\n"
+            "\n### Prior panel outcomes\n\n"
+            "Earlier five-judge panels on this same disagreement produced the\n"
+            "complete vote/rationale breakdowns below but no applyable majority.\n"
+            "Weigh their arguments; you are not bound by them.\n\n"
             + json.dumps(prior_panels, indent=1, sort_keys=True)
             + "\n"
         )
     return f"""
-### JUDICIAL PANEL SEAT {judge_no} OF {PANEL_SIZE}
+### JUDICIAL PANEL ROUND {panel_no}, SEAT {judge_no} OF {PANEL_SIZE}
+
+Your distinct judicial identity is `{judge_identity}`. It is unique to this
+seat and will be recorded with your vote.
 
 The two independent audit seats above DISAGREE. You are one judge on a
 five-judge panel resolving the disagreement. Judge ONLY from the restricted
@@ -123,40 +254,63 @@ Return EXACTLY ONE JSON object and nothing else:
   "sided_with": "<first|second|hybrid>",
   "ratified_verdict": "<audited_clean|audited_renaming|audited_conditional|audited_decoration|audited_failed|audited_numerical_match>",
   "ratified_claim_type": "<positive_theorem|bounded_theorem|no_go|open_gate|decoration|meta>",
-  "ratified_claim_scope": "<the exact scope sentence you ratify; reuse a seat's scope verbatim unless a hybrid correction is required>",
-  "ratified_load_bearing_step_class": "<(A)|(B)|(C)|(D)|(E)|(F)|(G) style class exactly as the seats use>",
+  "ratified_claim_scope": "<the exact scope sentence you ratify>",
+  "ratified_load_bearing_step": null,
+  "ratified_load_bearing_step_class": "<A|B|C|D|E|F|G exactly as the seats use>",
   "negative_assertion_classes": [],
   "judgment_rationale": "<why the ratified tuple is correct, grounded in the packet>",
   "first_auditor_error": "<the specific error in the first position, or 'none' if you side with it entirely>",
-  "second_auditor_error": "<the specific error in the second position, or 'none' if you side with it entirely>"
+  "second_auditor_error": "<the specific error in the second position, or 'none' if you side with it entirely>",
+  "hybrid_resolution_note": null,
+  "ratified_decoration_parent_claim_id": null,
+  "notes_for_re_audit_if_any": null,
+  "no_go_discipline": null
 }}
 
 Rules: vote the FULL tuple; a factual check against the packet (for
 example whether the runner computes a contested quantity) outweighs either
-seat's characterization; if you side with a seat, prefer that seat's
-claim_scope verbatim; declare negative_assertion_classes honestly for the
-tuple you ratify; never leave first_auditor_error and second_auditor_error
-both 'none' unless you ratify a hybrid that faults neither.
+seat's characterization. If sided_with is `first` or `second`, you MUST copy
+that seat's verdict, claim_type, claim_scope (character-for-character),
+load_bearing_step_class, negative_assertion_classes, decoration parent, and
+No-Go Discipline declaration/packet; any substantive correction MUST use
+`hybrid`. A hybrid MUST give a novel explicit scope and a non-empty
+hybrid_resolution_note. Replace the null optional values with the exact sided
+seat values when present. For a hybrid, supply the complete load-bearing step,
+decoration parent, repair note, and N1-N8 object whenever the chosen tuple
+requires them. Declare negative_assertion_classes honestly for the tuple you
+ratify. Never leave first_auditor_error and second_auditor_error both `none`
+unless a hybrid faults neither position.
 """
 
 
-def render_judge_prompt(
+def render_panel_packet(
     row: dict,
     rows: dict[str, dict],
-    judge_no: int,
     runner_timeout: int,
-    prior_panels: list[dict],
-) -> str:
+) -> tuple[str, dict[str, dict], str]:
     template = audit_runner.PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
+    evidence_manifest: dict[str, dict] = {}
+    invocation_id = uuid.uuid4().hex
     packet = audit_runner.render_prompt(
         row,
         rows,
         template,
         runner_timeout,
         use_cache=False,
-        evidence_manifest_out={},
-        audit_invocation_id=uuid.uuid4().hex,
+        evidence_manifest_out=evidence_manifest,
+        audit_invocation_id=invocation_id,
     )
+    return packet, evidence_manifest, invocation_id
+
+
+def render_judge_prompt(
+    packet: str,
+    row: dict,
+    judge_no: int,
+    judge_identity: str,
+    panel_no: int,
+    prior_panels: list[dict],
+) -> str:
     cross = row.get("cross_confirmation") or {}
     first = cross.get("first_audit") or {}
     second = cross.get("second_audit") or {}
@@ -165,28 +319,36 @@ def render_judge_prompt(
             packet,
             seat_block("first_audit", first, row),
             seat_block("second_audit", second, row),
-            panel_instructions(judge_no, prior_panels),
+            panel_instructions(judge_no, judge_identity, panel_no, prior_panels),
         ]
     )
 
 
 def launch_judge(
+    packet: str,
     row: dict,
-    rows: dict[str, dict],
     judge_no: int,
+    panel_no: int,
     workdir: Path,
-    runner_timeout: int,
     prior_panels: list[dict],
+    invocation_id: str,
+    evidence_manifest: dict[str, dict],
 ) -> dict:
     cid = row["claim_id"]
     key = batch.artifact_key(cid)
-    prompt = render_judge_prompt(row, rows, judge_no, runner_timeout, prior_panels)
+    judge_identity = (
+        f"codex-judicial-{judge_no}-"
+        f"{datetime.now(timezone.utc).strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
+    )
+    prompt = render_judge_prompt(
+        packet, row, judge_no, judge_identity, panel_no, prior_panels
+    )
     if len(prompt) > audit_runner.CODEX_INPUT_CHAR_LIMIT:
         raise ValueError(
             f"{cid}: judicial packet is {len(prompt)} characters; narrow the "
             "packet rather than converting transport size into a verdict"
         )
-    tag = f"{key}-judge{judge_no}"
+    tag = f"{key}-panel{panel_no}-judge{judge_no}"
     isolated = workdir / f"isolated-{tag}"
     isolated.mkdir(parents=True, exist_ok=False)
     (isolated / "PANEL_TASK.md").write_text(prompt, encoding="utf-8")
@@ -199,21 +361,23 @@ def launch_judge(
         "positions, and your panel-seat instructions. Do not inspect any "
         "other file. Return only the single JSON vote object it requires."
     )
-    import subprocess
-
-    proc = subprocess.Popen(
-        [
-            "codex", "exec", "--skip-git-repo-check", "--ignore-rules",
-            "--sandbox", "read-only", "--model", batch.MODEL,
-            "-c", f"model_reasoning_effort='{batch.REASONING}'",
-            "--output-last-message", str(raw_output), instruction,
-        ],
-        stdin=subprocess.DEVNULL,
-        stdout=log_handle,
-        stderr=log_handle,
-        cwd=isolated,
-        start_new_session=True,
-    )
+    try:
+        proc = subprocess.Popen(
+            [
+                "codex", "exec", "--skip-git-repo-check", "--ignore-rules",
+                "--sandbox", "read-only", "--model", batch.MODEL,
+                "-c", f"model_reasoning_effort='{batch.REASONING}'",
+                "--output-last-message", str(raw_output), instruction,
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=log_handle,
+            stderr=log_handle,
+            cwd=isolated,
+            start_new_session=True,
+        )
+    except Exception:
+        log_handle.close()
+        raise
     now = time.monotonic()
     return {
         "cid": cid,
@@ -224,13 +388,14 @@ def launch_judge(
         "log_path": log_path,
         "log_handle": log_handle,
         "isolated": isolated,
-        "auditor": (
-            f"codex-judicial-{judge_no}-"
-            f"{datetime.now(timezone.utc).strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
-        ),
+        "auditor": judge_identity,
+        "panel": panel_no,
+        "invocation_id": invocation_id,
+        "evidence_manifest": evidence_manifest,
         "last_size": 0,
         "last_progress": now,
         "stalled": False,
+        "returncode": None,
     }
 
 
@@ -246,18 +411,31 @@ def collect_vote(job: dict) -> tuple[dict | None, str]:
     vote = audit_runner.parse_verdict_json(reply or "")
     if vote is None:
         return None, "malformed_vote_json"
-    missing = [field for field in VOTE_FIELDS if field not in vote]
-    if missing:
-        return None, f"vote_missing_fields:{','.join(missing)}"
+    schema_error = vote_schema_error(vote)
+    if schema_error:
+        return None, schema_error
     return vote, "ok"
 
 
+def public_vote(vote: dict) -> dict:
+    return {
+        "judge": vote.get("_panel_judge"),
+        "auditor": vote.get("_panel_auditor"),
+        **{key: value for key, value in vote.items() if not key.startswith("_")},
+    }
+
+
 def judicial_blob(
-    row: dict, representative: dict, votes: list[dict], majority: int
+    row: dict,
+    representative: dict,
+    votes: list[dict],
+    majority: int,
+    invocation_id: str | None = None,
 ) -> dict:
     breakdown = [
         {
-            "judge": index + 1,
+            "judge": vote.get("_panel_judge", index + 1),
+            "auditor": vote.get("_panel_auditor"),
             "tuple": list(vote_tuple(vote)[:5]) + [list(vote_tuple(vote)[5])],
             "rationale": str(vote.get("judgment_rationale") or "")[:600],
         }
@@ -269,34 +447,141 @@ def judicial_blob(
         f"Representative rationale: {representative.get('judgment_rationale')}"
         f"\n[panel breakdown] {json.dumps(breakdown, sort_keys=True)}"
     )
-    return {
+    side = representative.get("sided_with")
+    cross = row.get("cross_confirmation") or {}
+    chosen = cross.get(f"{side}_audit") or {} if side in {"first", "second"} else {}
+
+    if chosen:
+        ratified_verdict = chosen.get("verdict")
+        ratified_claim_type = chosen.get("claim_type")
+        ratified_scope = chosen.get("claim_scope")
+        ratified_class = chosen.get("load_bearing_step_class")
+        negative_classes = chosen.get("negative_assertion_classes")
+    else:
+        ratified_verdict = representative.get("ratified_verdict")
+        ratified_claim_type = representative.get("ratified_claim_type")
+        ratified_scope = representative.get("ratified_claim_scope")
+        ratified_class = representative.get("ratified_load_bearing_step_class")
+        negative_classes = representative.get("negative_assertion_classes")
+
+    blob = {
         "claim_id": row["claim_id"],
-        "third_auditor": (
-            f"codex-judicial-panel-{datetime.now(timezone.utc).strftime('%Y%m%d')}-"
-            f"{uuid.uuid4().hex[:8]}"
+        "third_auditor": representative.get("_panel_auditor") or (
+            f"codex-judicial-panel-"
+            f"{datetime.now(timezone.utc).strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
         ),
         "auditor_family": batch.AUDITOR_FAMILY,
         "auditor_model": batch.MODEL,
         "auditor_reasoning_effort": batch.REASONING,
         "independence": "judicial_review",
-        "audit_invocation_id": uuid.uuid4().hex,
-        "sided_with": representative.get("sided_with"),
-        "ratified_verdict": representative.get("ratified_verdict"),
-        "ratified_claim_type": representative.get("ratified_claim_type"),
-        "ratified_claim_scope": representative.get("ratified_claim_scope"),
-        "ratified_load_bearing_step_class": representative.get(
-            "ratified_load_bearing_step_class"
-        ),
-        "negative_assertion_classes": representative.get(
-            "negative_assertion_classes"
-        ),
+        "audit_invocation_id": invocation_id or uuid.uuid4().hex,
+        "sided_with": side,
+        "ratified_verdict": ratified_verdict,
+        "ratified_claim_type": ratified_claim_type,
+        "ratified_claim_scope": ratified_scope,
+        "ratified_load_bearing_step_class": ratified_class,
+        "negative_assertion_classes": negative_classes,
         "judgment_rationale": rationale,
         "first_auditor_error": representative.get("first_auditor_error"),
         "second_auditor_error": representative.get("second_auditor_error"),
     }
+    optional_sources = (chosen, representative) if chosen else (representative,)
+    for source in optional_sources:
+        if source.get("load_bearing_step"):
+            blob["ratified_load_bearing_step"] = source["load_bearing_step"]
+            break
+    for source in optional_sources:
+        if "notes_for_re_audit_if_any" in source:
+            blob["notes_for_re_audit_if_any"] = source.get(
+                "notes_for_re_audit_if_any"
+            )
+            break
+    for source in optional_sources:
+        parent = source.get("decoration_parent_claim_id") or source.get(
+            "ratified_decoration_parent_claim_id"
+        )
+        if parent:
+            blob["ratified_decoration_parent_claim_id"] = parent
+            break
+    for source in optional_sources:
+        if isinstance(source.get("no_go_discipline"), dict):
+            blob["no_go_discipline"] = copy.deepcopy(source["no_go_discipline"])
+            break
+    if side == "hybrid":
+        blob["hybrid_resolution_note"] = (
+            representative.get("hybrid_resolution_note")
+            or representative.get("judgment_rationale")
+        )
+    return blob
 
 
-def apply_judgment(blob: dict, workdir: Path, retries: int) -> tuple[bool, dict]:
+def judicial_applyability_error(
+    blob: dict,
+    rows: dict[str, dict],
+    evidence_manifest: dict[str, dict],
+    workdir: Path,
+) -> str | None:
+    """Run the exact apply validator on a detached ledger before writing JSON."""
+    import apply_audit as audit_apply
+
+    envelope_path = workdir / (
+        f"candidate-manifest-{batch.artifact_key(blob['claim_id'])}-"
+        f"{blob['audit_invocation_id']}.json"
+    )
+    envelope_path.write_text(
+        json.dumps(
+            {
+                "schema": "codex_audit_trusted_manifest_v1",
+                "claim_id": blob["claim_id"],
+                "audit_invocation_id": blob["audit_invocation_id"],
+                "issued_at": datetime.now(timezone.utc).isoformat(),
+                "entries": evidence_manifest,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    env_key = "CODEX_AUDIT_TRUSTED_EVIDENCE_MANIFEST"
+    old_manifest = os.environ.get(env_key)
+    os.environ[env_key] = str(envelope_path)
+    try:
+        ledger = {"schema_version": 1, "rows": copy.deepcopy(rows)}
+        ok, detail = audit_apply.apply_judicial_review(
+            ledger, copy.deepcopy(blob)
+        )
+    finally:
+        if old_manifest is None:
+            os.environ.pop(env_key, None)
+        else:
+            os.environ[env_key] = old_manifest
+    return None if ok else detail
+
+
+def restore_preapply_state() -> str | None:
+    reset = batch.sh(["git", "reset", "--hard", "HEAD"])
+    if reset.returncode != 0:
+        return f"reset failed: {(reset.stderr or reset.stdout).strip()[-240:]}"
+    clean = batch.sh(
+        ["git", "clean", "-fd", "--", *audit_runner.AUDIT_DATA_FILES]
+    )
+    if clean.returncode != 0:
+        return f"clean failed: {(clean.stderr or clean.stdout).strip()[-240:]}"
+    return None
+
+
+def failed_after_apply(cid: str, result: str, detail: str) -> tuple[bool, dict]:
+    restore_error = restore_preapply_state()
+    if restore_error:
+        detail = f"{detail}; restore failed: {restore_error}"
+    return False, {"cid": cid, "result": result, "detail": detail}
+
+
+def apply_judgment(
+    blob: dict,
+    evidence_manifest: dict[str, dict],
+    workdir: Path,
+    retries: int,
+) -> tuple[bool, dict]:
     cid = blob["claim_id"]
     judgment_path = workdir / f"judgment-{batch.artifact_key(cid)}.json"
     judgment_path.write_text(
@@ -306,60 +591,45 @@ def apply_judgment(blob: dict, workdir: Path, retries: int) -> tuple[bool, dict]
         synced, detail = batch.sync_origin_main()
         if not synced:
             return False, {"cid": cid, "result": "sync_blocked", "detail": detail}
-        apply_result = batch.sh(
-            [
-                sys.executable,
-                str(SCRIPTS / "apply_audit.py"),
-                "--file",
-                str(judgment_path),
-            ]
+        applied, apply_detail = audit_runner.apply_one(
+            blob, propagate=False, evidence_manifest=evidence_manifest
         )
-        if apply_result.returncode != 0:
-            return False, {
-                "cid": cid,
-                "result": "judicial_apply_rejected",
-                "detail": (apply_result.stderr or apply_result.stdout)[-400:],
-            }
+        if not applied:
+            return failed_after_apply(
+                cid, "judicial_apply_rejected", apply_detail[-400:]
+            )
         pipeline = batch.sh(["bash", str(SCRIPTS / "run_pipeline.sh")], timeout=1800)
         if pipeline.returncode != 0:
-            return False, {
-                "cid": cid,
-                "result": "pipeline_failed",
-                "detail": (pipeline.stderr or pipeline.stdout)[-400:],
-            }
+            return failed_after_apply(
+                cid, "pipeline_failed", (pipeline.stderr or pipeline.stdout)[-400:]
+            )
         lint = batch.sh(
             [sys.executable, str(SCRIPTS / "audit_lint.py"), "--strict"], timeout=600
         )
         if lint.returncode != 0:
-            return False, {
-                "cid": cid,
-                "result": "strict_lint_failed",
-                "detail": (lint.stderr or lint.stdout)[-400:],
-            }
+            return failed_after_apply(
+                cid, "strict_lint_failed", (lint.stderr or lint.stdout)[-400:]
+            )
         diff_check = batch.sh(["git", "diff", "--check"])
         if diff_check.returncode != 0:
-            return False, {
-                "cid": cid,
-                "result": "diff_check_failed",
-                "detail": diff_check.stdout[-400:],
-            }
+            return failed_after_apply(
+                cid, "diff_check_failed", diff_check.stdout[-400:]
+            )
         unexpected = [
             path
             for path in batch.changed_paths()
             if not batch.allowed_generated_path(path)
         ]
         if unexpected:
-            return False, {
-                "cid": cid,
-                "result": "unexpected_generated_paths",
-                "detail": str(unexpected[:8]),
-            }
+            return failed_after_apply(
+                cid, "unexpected_generated_paths", str(unexpected[:8])
+            )
         committed, detail = batch.stage_and_commit(
             f"audit: {cid} judicial panel {blob['ratified_verdict']} "
             f"(codex-cli, {batch.MODEL}, {batch.REASONING}, panel/batch)"
         )
         if not committed:
-            return False, {"cid": cid, "result": "commit_failed", "detail": detail}
+            return failed_after_apply(cid, "commit_failed", detail)
         local_commit = detail
         push = batch.sh(["git", "push", "-q", "origin", "HEAD:main"])
         if push.returncode == 0:
@@ -393,6 +663,15 @@ def apply_judgment(blob: dict, workdir: Path, retries: int) -> tuple[bool, dict]
     return False, {"cid": cid, "result": "unreachable"}
 
 
+def write_panel_record(workdir: Path, cid: str, panel_no: int, record: dict) -> None:
+    payload = json.dumps(record, indent=1, sort_keys=True)
+    key = batch.artifact_key(cid)
+    (workdir / f"panel-{key}-round{panel_no}.json").write_text(
+        payload, encoding="utf-8"
+    )
+    (workdir / f"panel-{key}.json").write_text(payload, encoding="utf-8")
+
+
 def run_panel(
     row: dict,
     rows: dict[str, dict],
@@ -403,63 +682,192 @@ def run_panel(
     prior_panels: list[dict],
 ) -> dict:
     cid = row["claim_id"]
-    jobs = []
+    context_error = seat_context_error(row)
+    if context_error:
+        return {"cid": cid, "result": "seat_context_blocked", "detail": context_error}
     try:
-        for judge_no in range(1, PANEL_SIZE + 1):
-            jobs.append(
-                launch_judge(
-                    row, rows, judge_no, workdir, runner_timeout, prior_panels
+        packet, evidence_manifest, invocation_id = render_panel_packet(
+            row, rows, runner_timeout
+        )
+    except Exception as exc:
+        return {"cid": cid, "result": "packet_render_blocked", "detail": str(exc)}
+
+    panel_history = copy.deepcopy(prior_panels)
+    panel_no = len(panel_history) + 1
+    while True:
+        jobs = []
+        try:
+            for judge_no in range(1, PANEL_SIZE + 1):
+                jobs.append(
+                    launch_judge(
+                        packet,
+                        row,
+                        judge_no,
+                        panel_no,
+                        workdir,
+                        panel_history,
+                        invocation_id,
+                        evidence_manifest,
+                    )
                 )
+        except Exception as exc:
+            batch.terminate_workers(jobs)
+            return {
+                "cid": cid,
+                "result": "panel_launch_blocked",
+                "detail": str(exc),
+            }
+        except BaseException:
+            batch.terminate_workers(jobs)
+            raise
+        identities = {job["auditor"] for job in jobs}
+        if len(identities) != PANEL_SIZE:
+            batch.terminate_workers(jobs)
+            return {
+                "cid": cid,
+                "result": "judge_identity_collision",
+                "detail": "panel judges did not receive five distinct identities",
+            }
+        print(
+            f"   {cid}: launched {len(jobs)} judges for panel {panel_no}; waiting"
+        )
+        try:
+            batch.wait_workers(jobs, stall_minutes)
+        except Exception as exc:
+            return {
+                "cid": cid,
+                "result": "panel_wait_blocked",
+                "detail": str(exc),
+            }
+        votes: list[dict] = []
+        failures: list[str] = []
+        for job in jobs:
+            vote, status = collect_vote(job)
+            if vote is None:
+                failures.append(f"judge{job['judge']}:{status}")
+            else:
+                vote["_panel_judge"] = job["judge"]
+                vote["_panel_auditor"] = job["auditor"]
+                votes.append(vote)
+
+        tally = Counter(vote_tuple(vote) for vote in votes)
+        record = {
+            "schema": "judicial_panel_record_v1",
+            "cid": cid,
+            "panel": panel_no,
+            "invocation_id": invocation_id,
+            "votes": [public_vote(vote) for vote in votes],
+            "failures": failures,
+            "tally": [
+                {"tuple": [*key[:5], list(key[5])], "count": n}
+                for key, n in tally.most_common()
+            ],
+        }
+        if len(votes) != PANEL_SIZE:
+            record["result"] = "panel_delivery_short"
+            write_panel_record(workdir, cid, panel_no, record)
+            return {
+                "cid": cid,
+                "result": "panel_delivery_short",
+                "detail": ";".join(failures),
+                "votes": record["votes"],
+            }
+
+        top_tuple, count = tally.most_common(1)[0]
+        if count < MAJORITY:
+            record["result"] = "no_majority"
+            write_panel_record(workdir, cid, panel_no, record)
+            panel_history.append(record)
+            print(
+                f"   {cid}: panel {panel_no} has no 3/5 majority; "
+                "launching a fresh five-judge panel with all prior votes"
             )
-    except BaseException:
-        batch.terminate_workers(jobs)
-        raise
-    print(f"   {cid}: launched {len(jobs)} panel judges; waiting")
-    batch.wait_workers(jobs, stall_minutes)
-    votes: list[dict] = []
-    failures: list[str] = []
-    for job in jobs:
-        vote, status = collect_vote(job)
-        if vote is None:
-            failures.append(f"judge{job['judge']}:{status}")
-        else:
-            votes.append(vote)
-    if len(votes) < MAJORITY:
-        return {
-            "cid": cid,
-            "result": "panel_delivery_short",
-            "detail": ";".join(failures),
-            "votes": votes,
-        }
-    tally = Counter(vote_tuple(vote) for vote in votes)
-    top_tuple, count = tally.most_common(1)[0]
-    record = {
-        "cid": cid,
-        "votes": [
-            {key: vote.get(key) for key in VOTE_FIELDS} for vote in votes
-        ],
-        "failures": failures,
-        "tally": [
-            {"tuple": [*key[:5], list(key[5])], "count": n}
-            for key, n in tally.most_common()
-        ],
-    }
-    (workdir / f"panel-{batch.artifact_key(cid)}.json").write_text(
-        json.dumps(record, indent=1, sort_keys=True), encoding="utf-8"
+            panel_no += 1
+            continue
+
+        apply_errors = []
+        blob = None
+        for representative in (
+            vote for vote in votes if vote_tuple(vote) == top_tuple
+        ):
+            candidate = judicial_blob(
+                row, representative, votes, count, invocation_id=invocation_id
+            )
+            error = judicial_applyability_error(
+                candidate, rows, evidence_manifest, workdir
+            )
+            if error is None:
+                blob = candidate
+                break
+            apply_errors.append(
+                {
+                    "judge": representative.get("_panel_judge"),
+                    "auditor": representative.get("_panel_auditor"),
+                    "error": error,
+                }
+            )
+        if blob is None:
+            record["result"] = "majority_unapplyable"
+            record["apply_errors"] = apply_errors
+            write_panel_record(workdir, cid, panel_no, record)
+            panel_history.append(record)
+            print(
+                f"   {cid}: panel {panel_no} majority is not applyable; "
+                "launching a fresh five-judge panel with all prior votes"
+            )
+            panel_no += 1
+            continue
+
+        record["result"] = "applyable_majority"
+        record["majority"] = count
+        write_panel_record(workdir, cid, panel_no, record)
+        _ok, result = apply_judgment(
+            blob, evidence_manifest, workdir, retries
+        )
+        return result
+
+
+def workdir_guard_error(workdir: Path) -> str | None:
+    resolved = workdir.expanduser().resolve(strict=False)
+    repo = REPO_ROOT.resolve()
+    try:
+        resolved.relative_to(repo)
+    except ValueError:
+        return None
+    return (
+        f"workdir {resolved} is inside the repository; use a fresh external "
+        "temporary directory so panel artifacts cannot dirty or hide inside main"
     )
-    if count < MAJORITY:
-        return {
-            "cid": cid,
-            "result": "no_majority",
-            "detail": f"top tuple has {count}/{len(votes)} votes",
-            "votes": votes,
-        }
-    representative = next(
-        vote for vote in votes if vote_tuple(vote) == top_tuple
-    )
-    blob = judicial_blob(row, representative, votes, count)
-    ok, result = apply_judgment(blob, workdir, retries)
-    return result
+
+
+def load_prior_panels(
+    paths: list[str], target_ids: set[str]
+) -> tuple[dict[str, list[dict]], str | None]:
+    grouped: dict[str, list[dict]] = {}
+    for path_text in paths:
+        path = Path(path_text)
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            return {}, f"cannot read prior panel {path}: {exc}"
+        if not isinstance(record, dict) or not isinstance(record.get("cid"), str):
+            return {}, f"prior panel {path} lacks a string cid"
+        cid = record["cid"]
+        if cid not in target_ids:
+            return {}, (
+                f"prior panel {path} is bound to {cid!r}, which is not one of "
+                "this invocation's targets"
+            )
+        votes = record.get("votes")
+        if not isinstance(votes, list) or len(votes) != PANEL_SIZE:
+            return {}, f"prior panel {path} does not contain five vote records"
+        for vote in votes:
+            if not isinstance(vote, dict) or not str(
+                vote.get("judgment_rationale") or ""
+            ).strip():
+                return {}, f"prior panel {path} contains a vote without rationale"
+        grouped.setdefault(cid, []).append(record)
+    return grouped, None
 
 
 def main() -> int:
@@ -493,6 +901,10 @@ def main() -> int:
         or f"/tmp/audit_panel_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}_{uuid.uuid4().hex[:8]}"
     )
     if not args.dry_run:
+        guard_error = workdir_guard_error(workdir)
+        if guard_error:
+            print(f"refusing to run: {guard_error}")
+            return 2
         try:
             workdir.mkdir(parents=True, exist_ok=False)
         except FileExistsError:
@@ -528,9 +940,12 @@ def main() -> int:
             print(f"   would panel: {row['claim_id']}")
         return 0
 
-    prior_panels = []
-    for path in args.prior_panel:
-        prior_panels.append(json.loads(Path(path).read_text(encoding="utf-8")))
+    prior_by_claim, prior_error = load_prior_panels(
+        args.prior_panel, {row["claim_id"] for row in targets}
+    )
+    if prior_error:
+        print(f"refusing to run: {prior_error}")
+        return 2
 
     report = []
     for row in targets:
@@ -541,7 +956,7 @@ def main() -> int:
             args.stall_minutes,
             args.runner_timeout_sec,
             args.push_retries,
-            prior_panels,
+            prior_by_claim.get(row["claim_id"], []),
         )
         report.append(result)
         print(f"   {result['cid']}: {result['result']}")
@@ -549,10 +964,7 @@ def main() -> int:
 
     (workdir / "report.jsonl").write_text(
         "".join(
-            json.dumps(
-                {key: value for key, value in item.items() if key != "votes"},
-                sort_keys=True,
-            )
+            json.dumps(item, sort_keys=True)
             + "\n"
             for item in report
         ),

--- a/docs/audit/scripts/orchestrate_judicial_panel.py
+++ b/docs/audit/scripts/orchestrate_judicial_panel.py
@@ -3,7 +3,7 @@
 
 For each targeted disagreement row this renders the canonical restricted
 packet, appends both recorded seat positions (tuple summaries plus their
-archived full rationales), and launches five detached GPT-5.6-sol/xhigh
+invocation-bound full rationales), and launches five detached GPT-5.6-sol/xhigh
 judges with distinct identities. Each judge votes on the full tuple
 
     (sided_with, ratified_verdict, ratified_claim_type,
@@ -15,9 +15,9 @@ at least three matching full-tuple votes out of five (whitespace-only scope
 differences and assertion-class ordering are equivalent). On majority, a
 representative judicial JSON is applied through the standard serialized
 gates (apply -> pipeline -> strict lint -> diff/scope check -> commit ->
-push). Without a majority, the panel record is written to the workdir and
-the next invocation may pass it back via --prior-panel for a fresh panel
-with the earlier votes in context, per the audit-loop skill.
+push). Without an applyable majority, the panel record is written to the
+workdir and a fresh five-judge panel is launched in the same loop with every
+earlier vote and rationale in context, per the audit-loop skill.
 
 Run only from a dedicated, clean ``main`` checkout.
 """
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import hashlib
 import json
 import os
 import re
@@ -47,7 +48,7 @@ PANEL_SIZE = 5
 MAJORITY = 3
 MIN_VOTE_BYTES = 120
 
-ALLOWED_SIDES = {"first", "second", "hybrid"}
+ALLOWED_SIDES = {"first", "second", "hybrid", "neither"}
 ALLOWED_VERDICTS = {
     "audited_clean",
     "audited_renaming",
@@ -116,6 +117,29 @@ def vote_tuple(vote: dict) -> tuple:
     )
 
 
+def disagreement_fingerprint(row: dict) -> dict:
+    """Bind panel history to the exact source and two recorded seats."""
+    cross = row.get("cross_confirmation") or {}
+    first = copy.deepcopy(cross.get("first_audit") or {})
+    second = copy.deepcopy(cross.get("second_audit") or {})
+    seat_payload = json.dumps(
+        {"first_audit": first, "second_audit": second},
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return {
+        "schema": "judicial_disagreement_fingerprint_v1",
+        "claim_id": row.get("claim_id"),
+        "note_hash": row.get("note_hash"),
+        "first_audit_invocation_id": first.get("audit_invocation_id"),
+        "second_audit_invocation_id": second.get("audit_invocation_id"),
+        "seat_summaries_sha256": hashlib.sha256(
+            seat_payload.encode("utf-8")
+        ).hexdigest(),
+    }
+
+
 def vote_schema_error(vote: object) -> str | None:
     if not isinstance(vote, dict):
         return "vote must be a JSON object"
@@ -153,6 +177,53 @@ def vote_schema_error(vote: object) -> str | None:
     if "no_go_discipline" in vote and vote["no_go_discipline"] is not None:
         if not isinstance(vote["no_go_discipline"], dict):
             return "no_go_discipline must be an object or null"
+    first_error = str(vote.get("first_auditor_error") or "").strip().lower()
+    second_error = str(vote.get("second_auditor_error") or "").strip().lower()
+    if vote.get("sided_with") == "first" and second_error == "none":
+        return "a first-sided vote must explain the second auditor's error"
+    if vote.get("sided_with") == "second" and first_error == "none":
+        return "a second-sided vote must explain the first auditor's error"
+    if vote.get("sided_with") in {"hybrid", "neither"} and (
+        first_error == "none" or second_error == "none"
+    ):
+        return (
+            f"a {vote.get('sided_with')}-sided vote must explain both "
+            "auditors' errors"
+        )
+    return None
+
+
+def sided_vote_context_error(row: dict, vote: dict) -> str | None:
+    """Reject a sided vote that changes the selected seat's full tuple."""
+    side = vote.get("sided_with")
+    if side not in {"first", "second"}:
+        return None
+    chosen = ((row.get("cross_confirmation") or {}).get(f"{side}_audit") or {})
+    comparisons = (
+        ("verdict", vote.get("ratified_verdict"), chosen.get("verdict")),
+        ("claim_type", vote.get("ratified_claim_type"), chosen.get("claim_type")),
+        (
+            "claim_scope",
+            norm_scope(vote.get("ratified_claim_scope") or ""),
+            norm_scope(chosen.get("claim_scope") or ""),
+        ),
+        (
+            "load_bearing_step_class",
+            vote.get("ratified_load_bearing_step_class"),
+            chosen.get("load_bearing_step_class"),
+        ),
+        (
+            "negative_assertion_classes",
+            tuple(sorted(vote.get("negative_assertion_classes") or [])),
+            tuple(sorted(chosen.get("negative_assertion_classes") or [])),
+        ),
+    )
+    mismatches = [name for name, actual, expected in comparisons if actual != expected]
+    if mismatches:
+        return (
+            f"{side}-sided vote changes selected seat tuple fields: "
+            f"{','.join(mismatches)}; use sided_with='hybrid' for corrections"
+        )
     return None
 
 
@@ -251,7 +322,7 @@ packet plus the two recorded positions. Do not search anything else.
 Return EXACTLY ONE JSON object and nothing else:
 
 {{
-  "sided_with": "<first|second|hybrid>",
+  "sided_with": "<first|second|hybrid|neither>",
   "ratified_verdict": "<audited_clean|audited_renaming|audited_conditional|audited_decoration|audited_failed|audited_numerical_match>",
   "ratified_claim_type": "<positive_theorem|bounded_theorem|no_go|open_gate|decoration|meta>",
   "ratified_claim_scope": "<the exact scope sentence you ratify>",
@@ -274,12 +345,15 @@ that seat's verdict, claim_type, claim_scope (character-for-character),
 load_bearing_step_class, negative_assertion_classes, decoration parent, and
 No-Go Discipline declaration/packet; any substantive correction MUST use
 `hybrid`. A hybrid MUST give a novel explicit scope and a non-empty
-hybrid_resolution_note. Replace the null optional values with the exact sided
-seat values when present. For a hybrid, supply the complete load-bearing step,
-decoration parent, repair note, and N1-N8 object whenever the chosen tuple
-requires them. Declare negative_assertion_classes honestly for the tuple you
-ratify. Never leave first_auditor_error and second_auditor_error both `none`
-unless a hybrid faults neither position.
+hybrid_resolution_note. Use `neither` only when neither original position nor
+an applyable hybrid is sufficient; still vote a complete conservative tuple.
+Replace the null optional values with the exact sided seat values when present.
+For a hybrid or neither vote, supply the complete load-bearing step, decoration
+parent, repair note, and N1-N8 object whenever the chosen tuple requires them.
+Declare negative_assertion_classes honestly for the tuple you ratify. A first-
+sided vote MUST explain the second auditor's error; a second-sided vote MUST
+explain the first auditor's error; a hybrid or neither vote MUST explain errors
+in both original positions.
 """
 
 
@@ -432,6 +506,14 @@ def judicial_blob(
     majority: int,
     invocation_id: str | None = None,
 ) -> dict:
+    context_error = sided_vote_context_error(row, representative)
+    if context_error:
+        raise ValueError(context_error)
+    if representative.get("sided_with") == "neither":
+        raise ValueError(
+            "a neither majority must be recorded and sent to a fresh panel, "
+            "not converted into judicial apply JSON"
+        )
     breakdown = [
         {
             "judge": vote.get("_panel_judge", index + 1),
@@ -449,7 +531,11 @@ def judicial_blob(
     )
     side = representative.get("sided_with")
     cross = row.get("cross_confirmation") or {}
-    chosen = cross.get(f"{side}_audit") or {} if side in {"first", "second"} else {}
+    chosen = (
+        (cross.get(f"{side}_audit") or {})
+        if side in {"first", "second"}
+        else {}
+    )
 
     if chosen:
         ratified_verdict = chosen.get("verdict")
@@ -555,6 +641,31 @@ def judicial_applyability_error(
         else:
             os.environ[env_key] = old_manifest
     return None if ok else detail
+
+
+HARD_APPLY_BLOCKER_PREFIXES = (
+    "missing required judicial fields:",
+    "unknown claim_id:",
+    "audit_invocation_id ",
+    "judicial third-auditor review requires independence=",
+    "auditor_family=",
+    "auditor_model=",
+    "auditor_reasoning_effort=",
+    "sided_with ",
+    "note_hash drift;",
+    "judicial review requires cross_confirmation.status",
+    "judicial review requires first_audit and second_audit summaries",
+    "first_audit cannot be upgraded",
+    "second_audit cannot be upgraded",
+    "judicial third auditor must differ",
+    "trusted evidence manifest",
+    "No-Go Discipline apply requires trusted orchestrator evidence transport",
+)
+
+
+def hard_apply_blocker(detail: str) -> bool:
+    """Separate persistent row/tool/policy failures from tuple rejections."""
+    return str(detail).startswith(HARD_APPLY_BLOCKER_PREFIXES)
 
 
 def restore_preapply_state() -> str | None:
@@ -746,9 +857,13 @@ def run_panel(
             if vote is None:
                 failures.append(f"judge{job['judge']}:{status}")
             else:
-                vote["_panel_judge"] = job["judge"]
-                vote["_panel_auditor"] = job["auditor"]
-                votes.append(vote)
+                context_error = sided_vote_context_error(row, vote)
+                if context_error:
+                    failures.append(f"judge{job['judge']}:{context_error}")
+                else:
+                    vote["_panel_judge"] = job["judge"]
+                    vote["_panel_auditor"] = job["auditor"]
+                    votes.append(vote)
 
         tally = Counter(vote_tuple(vote) for vote in votes)
         record = {
@@ -756,6 +871,7 @@ def run_panel(
             "cid": cid,
             "panel": panel_no,
             "invocation_id": invocation_id,
+            "disagreement_fingerprint": disagreement_fingerprint(row),
             "votes": [public_vote(vote) for vote in votes],
             "failures": failures,
             "tally": [
@@ -785,6 +901,22 @@ def run_panel(
             panel_no += 1
             continue
 
+        if top_tuple[0] == "neither":
+            record["result"] = "majority_neither"
+            record["majority"] = count
+            record["detail"] = (
+                "a neither majority is recorded but never applied; the "
+                "audit-loop skill requires a fresh five-judge panel"
+            )
+            write_panel_record(workdir, cid, panel_no, record)
+            panel_history.append(record)
+            print(
+                f"   {cid}: panel {panel_no} majority sides with neither; "
+                "launching a fresh five-judge panel with all prior votes"
+            )
+            panel_no += 1
+            continue
+
         apply_errors = []
         blob = None
         for representative in (
@@ -799,13 +931,24 @@ def run_panel(
             if error is None:
                 blob = candidate
                 break
-            apply_errors.append(
-                {
-                    "judge": representative.get("_panel_judge"),
-                    "auditor": representative.get("_panel_auditor"),
-                    "error": error,
+            rejection = {
+                "judge": representative.get("_panel_judge"),
+                "auditor": representative.get("_panel_auditor"),
+                "error": error,
+            }
+            apply_errors.append(rejection)
+            if hard_apply_blocker(error):
+                record["result"] = "applyability_blocked"
+                record["apply_errors"] = apply_errors
+                record["rejected_candidate"] = candidate
+                write_panel_record(workdir, cid, panel_no, record)
+                return {
+                    "cid": cid,
+                    "result": "applyability_blocked",
+                    "detail": error,
+                    "judgment": candidate,
+                    "votes": record["votes"],
                 }
-            )
         if blob is None:
             record["result"] = "majority_unapplyable"
             record["apply_errors"] = apply_errors
@@ -840,10 +983,14 @@ def workdir_guard_error(workdir: Path) -> str | None:
     )
 
 
+PRIOR_PANEL_RESULTS = {"no_majority", "majority_neither", "majority_unapplyable"}
+
+
 def load_prior_panels(
-    paths: list[str], target_ids: set[str]
+    paths: list[str], target_rows: dict[str, dict]
 ) -> tuple[dict[str, list[dict]], str | None]:
     grouped: dict[str, list[dict]] = {}
+    seen_rounds: set[tuple[str, int]] = set()
     for path_text in paths:
         path = Path(path_text)
         try:
@@ -853,21 +1000,72 @@ def load_prior_panels(
         if not isinstance(record, dict) or not isinstance(record.get("cid"), str):
             return {}, f"prior panel {path} lacks a string cid"
         cid = record["cid"]
-        if cid not in target_ids:
+        if cid not in target_rows:
             return {}, (
                 f"prior panel {path} is bound to {cid!r}, which is not one of "
                 "this invocation's targets"
             )
+        if record.get("schema") != "judicial_panel_record_v1":
+            return {}, f"prior panel {path} has an invalid schema"
+        panel_no = record.get("panel")
+        if not isinstance(panel_no, int) or isinstance(panel_no, bool) or panel_no < 1:
+            return {}, f"prior panel {path} has an invalid panel number"
+        round_key = (cid, panel_no)
+        if round_key in seen_rounds:
+            return {}, f"prior panel {path} duplicates {cid} panel {panel_no}"
+        seen_rounds.add(round_key)
+        expected_fingerprint = disagreement_fingerprint(target_rows[cid])
+        if record.get("disagreement_fingerprint") != expected_fingerprint:
+            return {}, (
+                f"prior panel {path} does not match the current source and "
+                "first/second audit-seat fingerprint"
+            )
+        if record.get("result") not in PRIOR_PANEL_RESULTS:
+            return {}, f"prior panel {path} has invalid result {record.get('result')!r}"
         votes = record.get("votes")
         if not isinstance(votes, list) or len(votes) != PANEL_SIZE:
             return {}, f"prior panel {path} does not contain five vote records"
         for vote in votes:
-            if not isinstance(vote, dict) or not str(
-                vote.get("judgment_rationale") or ""
-            ).strip():
-                return {}, f"prior panel {path} contains a vote without rationale"
+            schema_error = vote_schema_error(vote)
+            if schema_error:
+                return {}, f"prior panel {path} contains invalid vote: {schema_error}"
+            context_error = sided_vote_context_error(target_rows[cid], vote)
+            if context_error:
+                return {}, f"prior panel {path} contains invalid vote: {context_error}"
+        if len({vote.get("judge") for vote in votes}) != PANEL_SIZE:
+            return {}, f"prior panel {path} does not preserve five distinct judges"
+        if len({vote.get("auditor") for vote in votes}) != PANEL_SIZE:
+            return {}, f"prior panel {path} does not preserve five distinct identities"
+        tally = Counter(vote_tuple(vote) for vote in votes)
+        top_tuple, count = tally.most_common(1)[0]
+        result = record["result"]
+        if result == "no_majority" and count >= MAJORITY:
+            return {}, f"prior panel {path} labels a majority as no_majority"
+        if result == "majority_neither" and not (
+            count >= MAJORITY and top_tuple[0] == "neither"
+        ):
+            return {}, f"prior panel {path} has an inconsistent neither result"
+        if result == "majority_unapplyable" and not (
+            count >= MAJORITY and top_tuple[0] != "neither"
+        ):
+            return {}, f"prior panel {path} has an inconsistent unapplyable result"
         grouped.setdefault(cid, []).append(record)
+    for records in grouped.values():
+        records.sort(key=lambda record: record["panel"])
+        rounds = [record["panel"] for record in records]
+        if rounds != list(range(1, len(records) + 1)):
+            return {}, (
+                "prior panels must be a contiguous sequence beginning at round 1; "
+                f"got {rounds}"
+            )
     return grouped, None
+
+
+def runtime_arg_error(args: argparse.Namespace) -> str | None:
+    for name in ("stall_minutes", "runner_timeout_sec", "push_retries"):
+        if getattr(args, name) <= 0:
+            return f"--{name.replace('_', '-')} must be positive"
+    return None
 
 
 def main() -> int:
@@ -889,6 +1087,11 @@ def main() -> int:
     parser.add_argument("--push-retries", type=int, default=3)
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
+
+    arg_error = runtime_arg_error(args)
+    if arg_error:
+        print(f"refusing to run: {arg_error}")
+        return 2
 
     if not args.dry_run:
         error = batch.clean_main_error()
@@ -941,7 +1144,7 @@ def main() -> int:
         return 0
 
     prior_by_claim, prior_error = load_prior_panels(
-        args.prior_panel, {row["claim_id"] for row in targets}
+        args.prior_panel, {row["claim_id"]: row for row in targets}
     )
     if prior_error:
         print(f"refusing to run: {prior_error}")

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -12512,6 +12512,7 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
             "schema": "judicial_panel_record_v1",
             "cid": "claim-a",
             "panel": 1,
+            "invocation_id": "8" * 32,
             "result": "no_majority",
             "disagreement_fingerprint": m.disagreement_fingerprint(row),
             "votes": votes,

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -12023,12 +12023,8 @@ class SanitizeLegacyAuditArtifactsTest(unittest.TestCase):
         self.assertEqual(out["audit_status"], "unaudited")
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class JudicialPanelOrchestratorTest(unittest.TestCase):
-    """Pure-logic pins for the five-judge panel drainer."""
+    """Contract pins for the five-judge panel drainer."""
 
     def _vote(self, **overrides):
         vote = {
@@ -12036,14 +12032,74 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
             "ratified_verdict": "audited_clean",
             "ratified_claim_type": "bounded_theorem",
             "ratified_claim_scope": "an exact identity",
-            "ratified_load_bearing_step_class": "(C)",
+            "ratified_load_bearing_step": "check the exact identity",
+            "ratified_load_bearing_step_class": "C",
             "negative_assertion_classes": [],
             "judgment_rationale": "packet-grounded",
             "first_auditor_error": "none",
             "second_auditor_error": "missed the computed check",
+            "hybrid_resolution_note": None,
+            "ratified_decoration_parent_claim_id": None,
+            "notes_for_re_audit_if_any": None,
+            "no_go_discipline": None,
         }
         vote.update(overrides)
         return vote
+
+    def _row(self, claim_id="row"):
+        common = {
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "claim_type": "bounded_theorem",
+            "load_bearing_step": "check the exact identity",
+            "load_bearing_step_class": "C",
+            "negative_assertion_classes": [],
+            "chain_closes": True,
+            "chain_closure_explanation": "the exact algebra closes",
+            "notes_for_re_audit_if_any": None,
+            "runner_check_breakdown": {},
+            "open_dependency_paths": [],
+            "decoration_parent_claim_id": None,
+        }
+        first = {
+            **common,
+            "auditor": "first-auditor",
+            "audit_invocation_id": "a" * 32,
+            "verdict": "audited_clean",
+            "claim_scope": "an exact identity",
+            "verdict_rationale": "first full rationale",
+        }
+        second = {
+            **common,
+            "auditor": "second-auditor",
+            "audit_invocation_id": "b" * 32,
+            "verdict": "audited_conditional",
+            "claim_scope": "a conditional identity",
+            "chain_closes": False,
+            "verdict_rationale": "second full rationale",
+            "notes_for_re_audit_if_any": "other: check the stated condition",
+        }
+        return {
+            "claim_id": claim_id,
+            "note_path": "docs/audit/README.md",
+            "note_hash": hashlib.sha256(
+                (PROJECT_ROOT / "docs" / "audit" / "README.md")
+                .read_text(encoding="utf-8", errors="replace")
+                .encode("utf-8")
+            ).hexdigest(),
+            "audit_status": "audit_in_progress",
+            "claim_type": "bounded_theorem",
+            "criticality": "critical",
+            "blocker": "cross_confirmation_disagreement",
+            "cross_confirmation": {
+                "status": "disagreement",
+                "first_audit": first,
+                "second_audit": second,
+            },
+            "previous_audits": [],
+        }
 
     def test_vote_tuple_equivalence_rules(self):
         m = _import("orchestrate_judicial_panel")
@@ -12064,19 +12120,61 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
             m.vote_tuple(self._vote(ratified_verdict="audited_conditional")),
         )
 
-    def test_judicial_blob_satisfies_apply_contract(self):
+    def test_sided_blob_reuses_seat_scope_and_applies(self):
         m = _import("orchestrate_judicial_panel")
         apply_mod = _import("apply_audit")
-        votes = [self._vote(), self._vote(), self._vote()]
-        blob = m.judicial_blob({"claim_id": "row"}, votes[0], votes, 3)
+        row = self._row()
+        votes = [
+            self._vote(
+                ratified_claim_scope="an   exact identity",
+                _panel_judge=index,
+                _panel_auditor=f"judge-{index}",
+            )
+            for index in range(1, 6)
+        ]
+        blob = m.judicial_blob(
+            row, votes[0], votes, 5, invocation_id="c" * 32
+        )
         self.assertEqual(
             apply_mod.JUDICIAL_REQUIRED_FIELDS - set(blob), set()
         )
+        self.assertEqual(blob["ratified_claim_scope"], "an exact identity")
         self.assertEqual(blob["independence"], "judicial_review")
         self.assertEqual(blob["auditor_reasoning_effort"], "xhigh")
         self.assertEqual(len(blob["audit_invocation_id"]), 32)
-        self.assertIn("3/5 matching", blob["judgment_rationale"])
+        self.assertIn("5/5 matching", blob["judgment_rationale"])
         self.assertIn("panel breakdown", blob["judgment_rationale"])
+        ok, detail = apply_mod.apply_judicial_review(
+            {"schema_version": 1, "rows": {"row": row}}, blob
+        )
+        self.assertTrue(ok, detail)
+
+    def test_hybrid_blob_with_novel_scope_applies(self):
+        m = _import("orchestrate_judicial_panel")
+        apply_mod = _import("apply_audit")
+        row = self._row("hybrid-row")
+        votes = [
+            self._vote(
+                sided_with="hybrid",
+                ratified_claim_scope="a novel corrected identity",
+                hybrid_resolution_note="combine the correct bounded pieces",
+                first_auditor_error="scope was incomplete",
+                second_auditor_error="verdict was too conservative",
+                _panel_judge=index,
+                _panel_auditor=f"hybrid-judge-{index}",
+            )
+            for index in range(1, 6)
+        ]
+        blob = m.judicial_blob(
+            row, votes[0], votes, 5, invocation_id="d" * 32
+        )
+        self.assertEqual(blob["sided_with"], "hybrid")
+        self.assertEqual(blob["ratified_claim_scope"], "a novel corrected identity")
+        self.assertTrue(blob["hybrid_resolution_note"])
+        ok, detail = apply_mod.apply_judicial_review(
+            {"schema_version": 1, "rows": {"hybrid-row": row}}, blob
+        )
+        self.assertTrue(ok, detail)
 
     def test_collect_vote_rejects_incomplete_votes(self):
         m = _import("orchestrate_judicial_panel")
@@ -12093,7 +12191,205 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
         self.assertEqual(status, "ok")
         self.assertEqual(vote["sided_with"], "first")
 
+        invalid = self._vote(sided_with="neither")
+        raw.write_text(json.dumps(invalid) + " " * 200, encoding="utf-8")
+        vote, status = m.collect_vote(job)
+        self.assertIsNone(vote)
+        self.assertIn("invalid sided_with", status)
+
+    def test_rationale_is_invocation_bound_and_preserved_in_new_summaries(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row()
+        summary = dict(row["cross_confirmation"]["first_audit"])
+        summary.pop("verdict_rationale")
+        row["previous_audits"] = [
+            {
+                "audit_invocation_id": summary["audit_invocation_id"],
+                "verdict_rationale": "archived exact rationale",
+                "notes_for_re_audit_if_any": "archived note",
+            }
+        ]
+        self.assertIn("archived exact rationale", m.seat_rationale(summary, row))
+        self.assertIn("archived note", m.seat_rationale(summary, row))
+        self.assertIn(
+            "no archived rationale",
+            m.archived_rationale(row, "f" * 32),
+        )
+
+        apply_mod = _import("apply_audit")
+        audit = {
+            "auditor": "seat",
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "audit_invocation_id": "e" * 32,
+            "verdict": "audited_clean",
+            "claim_type": "positive_theorem",
+            "claim_scope": "scope",
+            "load_bearing_step": "step",
+            "load_bearing_step_class": "A",
+            "chain_closes": True,
+            "chain_closure_explanation": "closure",
+            "verdict_rationale": "full current argument",
+            "notes_for_re_audit_if_any": "note",
+            "negative_assertion_classes": [],
+        }
+        stored = apply_mod.audit_summary_from_blob(audit)
+        self.assertEqual(stored["verdict_rationale"], "full current argument")
+        self.assertEqual(stored["load_bearing_step"], "step")
+        self.assertEqual(stored["notes_for_re_audit_if_any"], "note")
+
+    def test_no_majority_runs_fresh_full_panel_with_prior_votes(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row()
+        launches = []
+
+        def fake_launch(
+            _packet, _row, judge_no, panel_no, _workdir, prior,
+            _invocation_id, _manifest,
+        ):
+            launches.append((panel_no, judge_no, len(prior)))
+            return {
+                "judge": judge_no,
+                "panel": panel_no,
+                "auditor": f"round-{panel_no}-judge-{judge_no}",
+            }
+
+        def fake_collect(job):
+            if job["panel"] == 1:
+                side = {1: "first", 2: "first", 3: "second", 4: "second", 5: "hybrid"}[
+                    job["judge"]
+                ]
+                if side == "second":
+                    return self._vote(
+                        sided_with="second",
+                        ratified_verdict="audited_conditional",
+                        ratified_claim_scope="a conditional identity",
+                        notes_for_re_audit_if_any="other: check the condition",
+                        first_auditor_error="missed the condition",
+                        second_auditor_error="none",
+                    ), "ok"
+                if side == "hybrid":
+                    return self._vote(
+                        sided_with="hybrid",
+                        ratified_claim_scope="a third scope",
+                        hybrid_resolution_note="third tuple",
+                    ), "ok"
+            return self._vote(), "ok"
+
+        with mock.patch.object(
+            m, "render_panel_packet", return_value=("packet", {}, "f" * 32)
+        ) as render, mock.patch.object(
+            m, "launch_judge", side_effect=fake_launch
+        ), mock.patch.object(
+            m.batch, "wait_workers", return_value=None
+        ), mock.patch.object(
+            m, "collect_vote", side_effect=fake_collect
+        ), mock.patch.object(
+            m, "judicial_applyability_error", return_value=None
+        ), mock.patch.object(
+            m,
+            "apply_judgment",
+            return_value=(
+                True,
+                {"cid": "row", "result": "audited_clean", "commit": "abc"},
+            ),
+        ):
+            result = m.run_panel(row, {"row": row}, self.tmp, 1, 1, 1, [])
+        self.assertEqual(result["result"], "audited_clean")
+        self.assertEqual(len(launches), 10)
+        self.assertTrue(all(prior == 0 for panel, _judge, prior in launches if panel == 1))
+        self.assertTrue(all(prior == 1 for panel, _judge, prior in launches if panel == 2))
+        render.assert_called_once()
+        first_record = json.loads(
+            next(self.tmp.glob("panel-*-round1.json")).read_text(encoding="utf-8")
+        )
+        self.assertEqual(len(first_record["votes"]), 5)
+        self.assertEqual(first_record["result"], "no_majority")
+
+    def test_panel_requires_all_five_deliveries(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row()
+
+        def fake_launch(
+            _packet, _row, judge_no, panel_no, _workdir, _prior,
+            _invocation_id, _manifest,
+        ):
+            return {
+                "judge": judge_no,
+                "panel": panel_no,
+                "auditor": f"judge-{judge_no}",
+            }
+
+        def fake_collect(job):
+            if job["judge"] == 5:
+                return None, "capacity_error"
+            return self._vote(), "ok"
+
+        with mock.patch.object(
+            m, "render_panel_packet", return_value=("packet", {}, "1" * 32)
+        ), mock.patch.object(
+            m, "launch_judge", side_effect=fake_launch
+        ), mock.patch.object(
+            m.batch, "wait_workers", return_value=None
+        ), mock.patch.object(
+            m, "collect_vote", side_effect=fake_collect
+        ), mock.patch.object(m, "apply_judgment") as apply_mock:
+            result = m.run_panel(row, {"row": row}, self.tmp, 1, 1, 1, [])
+        self.assertEqual(result["result"], "panel_delivery_short")
+        apply_mock.assert_not_called()
+        record = json.loads(
+            next(self.tmp.glob("panel-*-round1.json")).read_text(encoding="utf-8")
+        )
+        self.assertEqual(len(record["votes"]), 4)
+
+    def test_prior_panels_are_claim_bound_and_workdir_is_external(self):
+        m = _import("orchestrate_judicial_panel")
+        record = {
+            "cid": "claim-a",
+            "votes": [
+                {"judgment_rationale": f"reason {index}"}
+                for index in range(5)
+            ],
+        }
+        path = self.tmp / "prior.json"
+        path.write_text(json.dumps(record), encoding="utf-8")
+        grouped, error = m.load_prior_panels([str(path)], {"claim-a"})
+        self.assertIsNone(error)
+        self.assertEqual(grouped["claim-a"][0]["cid"], "claim-a")
+        _grouped, error = m.load_prior_panels([str(path)], {"claim-b"})
+        self.assertIn("not one of this invocation's targets", error)
+        self.assertIsNotNone(m.workdir_guard_error(m.REPO_ROOT / ".git" / "panel"))
+        self.assertIsNone(m.workdir_guard_error(self.tmp / "panel"))
+
+    def test_launch_failure_closes_new_log_handle(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row()
+        handles = []
+        original_open = Path.open
+
+        def tracked_open(path, *args, **kwargs):
+            handle = original_open(path, *args, **kwargs)
+            if path.name.startswith("log-"):
+                handles.append(handle)
+            return handle
+
+        with mock.patch.object(Path, "open", new=tracked_open), mock.patch.object(
+            m.subprocess, "Popen", side_effect=OSError("spawn failed")
+        ):
+            with self.assertRaises(OSError):
+                m.launch_judge(
+                    "packet", row, 1, 1, self.tmp, [], "2" * 32, {}
+                )
+        self.assertEqual(len(handles), 1)
+        self.assertTrue(handles[0].closed)
+
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmp.cleanup)
         self.tmp = Path(self._tmp.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -12025,3 +12025,75 @@ class SanitizeLegacyAuditArtifactsTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class JudicialPanelOrchestratorTest(unittest.TestCase):
+    """Pure-logic pins for the five-judge panel drainer."""
+
+    def _vote(self, **overrides):
+        vote = {
+            "sided_with": "first",
+            "ratified_verdict": "audited_clean",
+            "ratified_claim_type": "bounded_theorem",
+            "ratified_claim_scope": "an exact identity",
+            "ratified_load_bearing_step_class": "(C)",
+            "negative_assertion_classes": [],
+            "judgment_rationale": "packet-grounded",
+            "first_auditor_error": "none",
+            "second_auditor_error": "missed the computed check",
+        }
+        vote.update(overrides)
+        return vote
+
+    def test_vote_tuple_equivalence_rules(self):
+        m = _import("orchestrate_judicial_panel")
+        base = self._vote(
+            ratified_claim_scope="a  b\tc",
+            negative_assertion_classes=["x", "y"],
+        )
+        same = self._vote(
+            ratified_claim_scope="a b c",
+            negative_assertion_classes=["y", "x"],
+        )
+        different = self._vote(ratified_claim_scope="a b d")
+        self.assertEqual(m.vote_tuple(base), m.vote_tuple(same))
+        self.assertNotEqual(m.vote_tuple(base), m.vote_tuple(different))
+        # Substantive verdict differences always split the tuple.
+        self.assertNotEqual(
+            m.vote_tuple(base),
+            m.vote_tuple(self._vote(ratified_verdict="audited_conditional")),
+        )
+
+    def test_judicial_blob_satisfies_apply_contract(self):
+        m = _import("orchestrate_judicial_panel")
+        apply_mod = _import("apply_audit")
+        votes = [self._vote(), self._vote(), self._vote()]
+        blob = m.judicial_blob({"claim_id": "row"}, votes[0], votes, 3)
+        self.assertEqual(
+            apply_mod.JUDICIAL_REQUIRED_FIELDS - set(blob), set()
+        )
+        self.assertEqual(blob["independence"], "judicial_review")
+        self.assertEqual(blob["auditor_reasoning_effort"], "xhigh")
+        self.assertEqual(len(blob["audit_invocation_id"]), 32)
+        self.assertIn("3/5 matching", blob["judgment_rationale"])
+        self.assertIn("panel breakdown", blob["judgment_rationale"])
+
+    def test_collect_vote_rejects_incomplete_votes(self):
+        m = _import("orchestrate_judicial_panel")
+        incomplete = self._vote()
+        incomplete.pop("second_auditor_error")
+        raw = self.tmp / "raw.txt"
+        raw.write_text(json.dumps(incomplete) + " " * 200, encoding="utf-8")
+        job = {"stalled": False, "returncode": 0, "raw_output": raw, "judge": 1}
+        vote, status = m.collect_vote(job)
+        self.assertIsNone(vote)
+        self.assertIn("vote_missing_fields", status)
+        raw.write_text(json.dumps(self._vote()) + " " * 200, encoding="utf-8")
+        vote, status = m.collect_vote(job)
+        self.assertEqual(status, "ok")
+        self.assertEqual(vote["sided_with"], "first")
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name)

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -12,6 +12,7 @@ or:
 """
 from __future__ import annotations
 
+import argparse
 import contextlib
 import importlib
 import importlib.util
@@ -2335,7 +2336,7 @@ class ApplyAuditTest(unittest.TestCase):
             "PASS",
         )
 
-    def test_judicial_neither_validates_before_recording_blocker(self):
+    def test_judicial_neither_is_rejected_without_recording_blocker(self):
         m = _import("apply_audit")
         _patch_repo_root(m, self.tmp_root)
         self._seed_one_row(
@@ -2386,7 +2387,7 @@ class ApplyAuditTest(unittest.TestCase):
         before = json.dumps(led, sort_keys=True)
         ok, msg = m.apply_one(led, judgment)
         self.assertFalse(ok)
-        self.assertIn("N1-N8 packet is required", msg)
+        self.assertIn("panel-escalation outcome", msg)
         self.assertEqual(json.dumps(led, sort_keys=True), before)
 
 
@@ -12191,11 +12192,43 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
         self.assertEqual(status, "ok")
         self.assertEqual(vote["sided_with"], "first")
 
-        invalid = self._vote(sided_with="neither")
-        raw.write_text(json.dumps(invalid) + " " * 200, encoding="utf-8")
+        neither = self._vote(
+            sided_with="neither",
+            ratified_verdict="audited_conditional",
+            first_auditor_error="first scope is too broad",
+            second_auditor_error="second scope is too narrow",
+        )
+        raw.write_text(json.dumps(neither) + " " * 200, encoding="utf-8")
+        vote, status = m.collect_vote(job)
+        self.assertEqual(status, "ok")
+        self.assertEqual(vote["sided_with"], "neither")
+
+        no_opposing_error = self._vote(second_auditor_error="none")
+        raw.write_text(
+            json.dumps(no_opposing_error) + " " * 200, encoding="utf-8"
+        )
         vote, status = m.collect_vote(job)
         self.assertIsNone(vote)
-        self.assertIn("invalid sided_with", status)
+        self.assertIn("must explain the second auditor's error", status)
+
+    def test_sided_vote_must_match_selected_seat_before_blob(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row()
+        mismatch = self._vote(
+            ratified_verdict="audited_conditional",
+            ratified_claim_scope="a conditional identity",
+        )
+        error = m.sided_vote_context_error(row, mismatch)
+        self.assertIn("changes selected seat tuple fields", error)
+        with self.assertRaisesRegex(ValueError, "changes selected seat tuple"):
+            m.judicial_blob(row, mismatch, [mismatch] * 5, 5)
+
+        whitespace_equivalent = self._vote(
+            ratified_claim_scope="an   exact\tidentity"
+        )
+        self.assertIsNone(
+            m.sided_vote_context_error(row, whitespace_equivalent)
+        )
 
     def test_rationale_is_invocation_bound_and_preserved_in_new_summaries(self):
         m = _import("orchestrate_judicial_panel")
@@ -12344,24 +12377,196 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
         )
         self.assertEqual(len(record["votes"]), 4)
 
+    def test_neither_majority_runs_fresh_panel_without_building_blob(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row()
+        launches = []
+
+        def fake_launch(
+            _packet, _row, judge_no, panel_no, _workdir, prior,
+            _invocation_id, _manifest,
+        ):
+            launches.append((panel_no, judge_no, len(prior)))
+            return {
+                "judge": judge_no,
+                "panel": panel_no,
+                "auditor": f"round-{panel_no}-judge-{judge_no}",
+            }
+
+        def fake_collect(job):
+            if job["panel"] == 1:
+                return self._vote(
+                    sided_with="neither",
+                    ratified_verdict="audited_conditional",
+                    first_auditor_error="first tuple is unsound",
+                    second_auditor_error="second tuple is incomplete",
+                ), "ok"
+            return self._vote(), "ok"
+
+        with mock.patch.object(
+            m, "render_panel_packet", return_value=("packet", {}, "3" * 32)
+        ), mock.patch.object(
+            m, "launch_judge", side_effect=fake_launch
+        ), mock.patch.object(
+            m.batch, "wait_workers", return_value=None
+        ), mock.patch.object(
+            m, "collect_vote", side_effect=fake_collect
+        ), mock.patch.object(
+            m, "judicial_applyability_error", return_value=None
+        ), mock.patch.object(
+            m,
+            "apply_judgment",
+            return_value=(
+                True,
+                {"cid": "row", "result": "audited_clean", "commit": "abc"},
+            ),
+        ), mock.patch.object(m, "judicial_blob", wraps=m.judicial_blob) as build:
+            result = m.run_panel(row, {"row": row}, self.tmp, 1, 1, 1, [])
+        self.assertEqual(result["result"], "audited_clean")
+        self.assertEqual(len(launches), 10)
+        self.assertTrue(all(prior == 1 for panel, _judge, prior in launches if panel == 2))
+        self.assertEqual(build.call_count, 1)
+        record = json.loads(
+            next(self.tmp.glob("panel-*-round1.json")).read_text(encoding="utf-8")
+        )
+        self.assertEqual(record["result"], "majority_neither")
+
+    def test_hard_applyability_blocker_stops_with_candidate_and_error(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row()
+
+        def fake_launch(
+            _packet, _row, judge_no, panel_no, _workdir, _prior,
+            _invocation_id, _manifest,
+        ):
+            return {
+                "judge": judge_no,
+                "panel": panel_no,
+                "auditor": f"judge-{judge_no}",
+            }
+
+        with mock.patch.object(
+            m, "render_panel_packet", return_value=("packet", {}, "4" * 32)
+        ), mock.patch.object(
+            m, "launch_judge", side_effect=fake_launch
+        ), mock.patch.object(
+            m.batch, "wait_workers", return_value=None
+        ), mock.patch.object(
+            m, "collect_vote", return_value=(self._vote(), "ok")
+        ), mock.patch.object(
+            m,
+            "judicial_applyability_error",
+            return_value="note_hash drift; rerun seed before applying audit",
+        ), mock.patch.object(m, "apply_judgment") as apply_mock:
+            result = m.run_panel(row, {"row": row}, self.tmp, 1, 1, 1, [])
+        self.assertEqual(result["result"], "applyability_blocked")
+        self.assertIn("note_hash drift", result["detail"])
+        self.assertEqual(result["judgment"]["sided_with"], "first")
+        apply_mock.assert_not_called()
+        record = json.loads(
+            next(self.tmp.glob("panel-*-round1.json")).read_text(encoding="utf-8")
+        )
+        self.assertEqual(record["result"], "applyability_blocked")
+        self.assertIn("rejected_candidate", record)
+
+    def test_numeric_runtime_arguments_must_be_positive(self):
+        m = _import("orchestrate_judicial_panel")
+        valid = argparse.Namespace(
+            stall_minutes=1, runner_timeout_sec=1, push_retries=1
+        )
+        self.assertIsNone(m.runtime_arg_error(valid))
+        for field in ("stall_minutes", "runner_timeout_sec", "push_retries"):
+            invalid = argparse.Namespace(
+                stall_minutes=1, runner_timeout_sec=1, push_retries=1
+            )
+            setattr(invalid, field, 0)
+            self.assertIn("must be positive", m.runtime_arg_error(invalid))
+
     def test_prior_panels_are_claim_bound_and_workdir_is_external(self):
         m = _import("orchestrate_judicial_panel")
+        row = self._row("claim-a")
+        sides = ["first", "first", "second", "second", "hybrid"]
+        votes = []
+        for index, side in enumerate(sides, 1):
+            if side == "first":
+                vote = self._vote()
+            elif side == "second":
+                vote = self._vote(
+                    sided_with="second",
+                    ratified_verdict="audited_conditional",
+                    ratified_claim_scope="a conditional identity",
+                    first_auditor_error="missed the condition",
+                    second_auditor_error="none",
+                    notes_for_re_audit_if_any="other: check the stated condition",
+                )
+            else:
+                vote = self._vote(
+                    sided_with="hybrid",
+                    ratified_claim_scope="a third bounded identity",
+                    hybrid_resolution_note="correct both scopes",
+                    first_auditor_error="scope too broad",
+                    second_auditor_error="scope too narrow",
+                )
+            votes.append({"judge": index, "auditor": f"judge-{index}", **vote})
         record = {
+            "schema": "judicial_panel_record_v1",
             "cid": "claim-a",
-            "votes": [
-                {"judgment_rationale": f"reason {index}"}
-                for index in range(5)
-            ],
+            "panel": 1,
+            "result": "no_majority",
+            "disagreement_fingerprint": m.disagreement_fingerprint(row),
+            "votes": votes,
         }
         path = self.tmp / "prior.json"
         path.write_text(json.dumps(record), encoding="utf-8")
-        grouped, error = m.load_prior_panels([str(path)], {"claim-a"})
+        grouped, error = m.load_prior_panels([str(path)], {"claim-a": row})
         self.assertIsNone(error)
         self.assertEqual(grouped["claim-a"][0]["cid"], "claim-a")
-        _grouped, error = m.load_prior_panels([str(path)], {"claim-b"})
+        _grouped, error = m.load_prior_panels(
+            [str(path)], {"claim-b": self._row("claim-b")}
+        )
         self.assertIn("not one of this invocation's targets", error)
+
+        stale_row = self._row("claim-a")
+        stale_row["note_hash"] = "0" * 64
+        _grouped, error = m.load_prior_panels(
+            [str(path)], {"claim-a": stale_row}
+        )
+        self.assertIn("does not match the current source", error)
+
+        _grouped, error = m.load_prior_panels(
+            [str(path), str(path)], {"claim-a": row}
+        )
+        self.assertIn("duplicates claim-a panel 1", error)
         self.assertIsNotNone(m.workdir_guard_error(m.REPO_ROOT / ".git" / "panel"))
         self.assertIsNone(m.workdir_guard_error(self.tmp / "panel"))
+
+    def test_ordinary_auditor_cannot_resolve_a_disagreement(self):
+        apply_mod = _import("apply_audit")
+        row = self._row("ordinary-third")
+        audit = {
+            "claim_id": "ordinary-third",
+            "verdict": "audited_clean",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "an exact identity",
+            "auditor": "single-third-auditor",
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "audit_invocation_id": "9" * 32,
+            "load_bearing_step": "check the exact identity",
+            "load_bearing_step_class": "C",
+            "chain_closes": True,
+            "chain_closure_explanation": "the exact identity closes",
+            "verdict_rationale": "single vote is not panel authority",
+            "negative_assertion_classes": [],
+        }
+        ledger = {"schema_version": 1, "rows": {"ordinary-third": row}}
+        before = json.dumps(ledger, sort_keys=True)
+        ok, detail = apply_mod.apply_one(ledger, audit)
+        self.assertFalse(ok)
+        self.assertIn("five-judge judicial panel", detail)
+        self.assertEqual(json.dumps(ledger, sort_keys=True), before)
 
     def test_launch_failure_closes_new_log_handle(self):
         m = _import("orchestrate_judicial_panel")


### PR DESCRIPTION
## What

Implements the audit-loop skill's governed five-judge resolution step for cross-confirmation disagreements.

`orchestrate_judicial_panel.py` renders one canonical restricted packet per disagreement and appends both invocation-bound, rationale-preserving seat arguments. It launches five detached GPT-5.6-sol/xhigh judges with distinct identities, requires five valid full-tuple votes, and treats only whitespace-normalized scope and assertion-class ordering as equivalent. A 3/5 first- or second-sided majority must match that seat's tuple exactly; an applyable hybrid may use a novel scope.

No-majority, `neither`, and candidate-unapplyable majorities are recorded with all votes and automatically launch a fresh five-judge panel in the same loop. Persistent row/tool/policy blockers preserve the rejected candidate and exact error and stop as tooling blockers. Imported panel history is bound to the exact claim, note hash, and first/second seat summaries and invocation IDs.

`apply_audit.py` now persists the full seat arguments required by later panels, rejects ordinary single-auditor resolution once a disagreement exists, and rejects applying `neither`; only an applyable first, second, or hybrid panel result can become audit authority.

The implementation reuses the batch worker/job, cleanup, packet, apply, pipeline, strict-lint, diff/scope, commit, and race-retried push contracts.

## Verification

- `python3 docs/audit/scripts/tests/test_audit_pipeline.py` — 324 tests passed
- `bash docs/audit/scripts/run_pipeline.sh` — passed
- `python3 docs/audit/scripts/audit_lint.py --strict` — passed with no errors
- `python3 -m py_compile ...` and `git diff --check` — passed
- Judicial-panel focused tests — 14 passed
