### PR TITLE
audit-infra: expose N4 residual IDs to auditors

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -448,10 +448,14 @@ supply it. Otherwise replace it with:
         "witness_id": "<unique id referenced by a prior-ruled N1 route>",
         "route_id": "<matching N1 route_id>",
         "witness_residual": "<residual in cited witness>",
+        "witness_residual_id": "<stable residual:<id> string present in the cited authority>",
         "claim_residual": "<residual asserted here>",
+        "claim_residual_id": "<stable residual:<id> string present in the audited source>",
         "match": true,
-        "evidence_path": "<manifest path>",
-        "evidence_locator": "<actual locator>"
+        "evidence_path": "<manifest authority path containing witness_residual and witness_residual_id>",
+        "evidence_locator": "<actual authority locator>",
+        "claim_evidence_path": "<manifest source path containing claim_residual and claim_residual_id>",
+        "claim_evidence_locator": "<actual source locator>"
       }
     ],
     "none_found_reason": "<required when witnesses is empty; forbidden as a substitute for prior-route evidence>",
@@ -610,6 +614,15 @@ axiom/approved-primitive vocabulary is explicit accepted premise content and
 is separately guarded by premise-purity checks; it is not a hidden admission
 inside the audited claim. The authenticated manifest remains available for N1,
 N2, N4, N6, and N7 authority checks.
+
+For N4, emit `witnesses: []` with a substantive `none_found_reason` when no
+N1 route is marked `RULED OUT BY PRIOR`; do not create a placeholder witness.
+When such a route exists, every witness object must include both stable
+`residual:<id>` fields and both evidence surfaces. Copy `witness_residual_id`
+from the cited authority and `claim_residual_id` from the audited source; each
+ID and residual text must occur verbatim at its own cited path. The authority
+goes in `evidence_path`, while the audited source goes in
+`claim_evidence_path`.
 
 For an N3 hit, `retained_authority` classifies the provenance of the hit's
 whole `evidence_path`, not the semantics of a word such as `axiom` inside that

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -7864,6 +7864,26 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             template_flat,
         )
         self.assertIn(
+            '"witness_residual_id": "<stable residual:<id> string present in the cited authority>"',
+            template_flat,
+        )
+        self.assertIn(
+            '"claim_residual_id": "<stable residual:<id> string present in the audited source>"',
+            template_flat,
+        )
+        self.assertIn(
+            '"claim_evidence_path": "<manifest source path containing claim_residual and claim_residual_id>"',
+            template_flat,
+        )
+        self.assertIn(
+            '"claim_evidence_locator": "<actual source locator>"',
+            template_flat,
+        )
+        self.assertIn(
+            "emit `witnesses: []` with a substantive `none_found_reason`",
+            template_flat,
+        )
+        self.assertIn(
             "from one and the same `full_phrase_groups[]` record",
             template_flat,
         )
@@ -9701,6 +9721,32 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         )
         self.assertNotIn("secret_path", n3_scan_prompt)
         self.assertNotIn("secret_id", n3_scan_prompt)
+        n4_errors = [
+            "N4 witness 1.witness_residual_id must be non-empty",
+            "N4 witness 1.claim_residual_id must be a stable residual:<id>",
+            "N4 witness 1 witness residual must cite an authority at secret/path",
+            "N4 witness 1 claim residual must cite the source secret_claim_id",
+            "N4 witness 1 requires non-empty evidence_path and evidence_locator",
+            "N4 witness 1 claim residual requires non-empty evidence_path and evidence_locator",
+        ]
+        for n4_error in n4_errors:
+            with self.subTest(n4_error=n4_error):
+                n4_code = m.fresh_schema_retry_code(n4_error)
+                self.assertEqual(n4_code, "N4_WITNESS_SCHEMA_MISMATCH")
+                n4_prompt = m.render_fresh_schema_retry_prompt(
+                    "ORIGINAL RESTRICTED PACKET", n4_code, 1,
+                )
+                self.assertIn("when no N1 route is RULED OUT BY PRIOR", n4_prompt)
+                self.assertIn("stable residual:<id> strings", n4_prompt)
+                self.assertIn("authority evidence_path and evidence_locator", n4_prompt)
+                self.assertIn(
+                    "source claim_evidence_path and claim_evidence_locator",
+                    n4_prompt,
+                )
+                self.assertIn("witness surface must have the authority role", n4_prompt)
+                self.assertNotIn("witness 1", n4_prompt)
+                self.assertNotIn("secret/path", n4_prompt)
+                self.assertNotIn("secret_claim_id", n4_prompt)
 
     def test_failed_locator_repair_preserves_fresh_schema_eligibility(self):
         m = _import_codex_audit_runner()

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1699,6 +1699,8 @@ def fresh_schema_retry_code(validation_error: str) -> str:
         and "is not supported by its evidenced" in validation_error
     ):
         return "N1_ROUTE_CLASS_MARKER_MISMATCH"
+    if validation_error.startswith("N4 witness "):
+        return "N4_WITNESS_SCHEMA_MISMATCH"
     return "AUDIT_SCHEMA_REJECT"
 
 
@@ -1766,6 +1768,17 @@ def render_fresh_schema_retry_prompt(
             "including its canonical class prefix and body, byte-for-byte as a "
             "contiguous line from the cited live current-cycle runner_stdout. "
             "Do not summarize, shorten, or paraphrase those five lines.\n"
+        ),
+        "N4_WITNESS_SCHEMA_MISMATCH": (
+            "Static N4 invariant: when no N1 route is RULED OUT BY PRIOR, emit "
+            "witnesses as an empty list with a substantive none_found_reason; "
+            "never fabricate a placeholder witness. Otherwise every witness "
+            "must include witness_residual_id and claim_residual_id as stable "
+            "residual:<id> strings, plus separate authority evidence_path and "
+            "evidence_locator fields and separate source claim_evidence_path and "
+            "claim_evidence_locator fields. The witness surface must have the "
+            "authority role and the claim surface must have the source role. Copy "
+            "each residual text and ID verbatim from its own cited packet surface.\n"
         ),
     }.get(validation_code, "")
     return (


### PR DESCRIPTION
Repairs prompt/validator drift exposed by the AC occupancy re-audit. The prompt now includes every validator-required N4 witness residual ID, authority/source evidence path, and locator field, with correct empty-witness guidance. All N4 witness validator failures receive a conclusion-blind typed retry that leaks no rejected IDs or paths; the validator is unchanged. Verification: 309 audit-pipeline tests, full pipeline, strict lint, py_compile, vocabulary lint, and diff check. Independent review-loop PASS on exact head d8e694e68283c495de9dacc0ee014dac628aa326. No audit verdicts or generated audit files.