### PR TITLE
audit-infra: align N5 and N6 schema guidance

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -500,7 +500,7 @@ supply it. Otherwise replace it with:
         "kind": "<approved_primitive | open_gate | convention_reframe | definition_refactor>",
         "indexed_basis": "<20+ character exact quote from this candidate record>",
         "affected_wall": "<exact N2 wall tested by this candidate>",
-        "closure_mechanism": "<40+ normalized characters explaining how the candidate could close that wall>",
+        "closure_mechanism": "<include indexed_basis verbatim, then use 40+ normalized characters to explain how the candidate could close that wall>",
         "could_close_wall": false,
         "addressed": true,
         "disposition": "<why the candidate does or does not close the scoped wall>",
@@ -645,6 +645,17 @@ collapse distinct phrases into one object. For example, `boundary` and
 `primitive` require separate objects even when one source sentence contains
 both. The path, phrase, and occurrence-group id must identify the same single
 authenticated group.
+
+For N5, the fields `resolution_classes_checked`, `tested_resolutions`,
+`untested_resolutions`, `resolution_evidence_path`, and
+`resolution_evidence_locator` belong inside each `statements[]` object. Do not
+place any of them on the `N5_rhetoric_audit` section object itself.
+
+For every N6 candidate, copy `indexed_basis` exactly from its orchestrator
+candidate record and include that complete `indexed_basis` text verbatim
+inside `closure_mechanism` before explaining how the candidate could affect
+the named wall. A paraphrase or merely related explanation does not satisfy
+the authenticated-basis binding.
 
 For each N5 statement, `resolution_classes_checked` must equal the five canonical classes exactly,
 and `tested_resolutions` must contain exactly five entries: one and only one

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -7860,6 +7860,14 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             template_flat,
         )
         self.assertIn(
+            "belong inside each `statements[]` object",
+            template_flat,
+        )
+        self.assertIn(
+            "include that complete `indexed_basis` text verbatim inside `closure_mechanism`",
+            template_flat,
+        )
+        self.assertIn(
             "Copy the complete authenticated tuple",
             template_flat,
         )
@@ -9747,6 +9755,32 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
                 self.assertNotIn("witness 1", n4_prompt)
                 self.assertNotIn("secret/path", n4_prompt)
                 self.assertNotIn("secret_claim_id", n4_prompt)
+        n5_nesting_error = (
+            "N5 contains unknown fields ['resolution_classes_checked', "
+            "'tested_resolutions', 'secret_field_value']"
+        )
+        n5_nesting_code = m.fresh_schema_retry_code(n5_nesting_error)
+        self.assertEqual(
+            n5_nesting_code, "N5_STATEMENT_FIELD_NESTING_MISMATCH"
+        )
+        n5_nesting_prompt = m.render_fresh_schema_retry_prompt(
+            "ORIGINAL RESTRICTED PACKET", n5_nesting_code, 1,
+        )
+        self.assertIn("belong inside each statements[] object", n5_nesting_prompt)
+        self.assertNotIn("secret_field_value", n5_nesting_prompt)
+        n6_basis_error = (
+            "N6 candidate 1.closure_mechanism must use its indexed_basis"
+        )
+        n6_basis_code = m.fresh_schema_retry_code(n6_basis_error)
+        self.assertEqual(
+            n6_basis_code, "N6_INDEXED_BASIS_VERBATIM_MISMATCH"
+        )
+        n6_basis_prompt = m.render_fresh_schema_retry_prompt(
+            "ORIGINAL RESTRICTED PACKET", n6_basis_code, 1,
+        )
+        self.assertIn("copy indexed_basis exactly", n6_basis_prompt)
+        self.assertIn("complete text verbatim", n6_basis_prompt)
+        self.assertNotIn("candidate 1", n6_basis_prompt)
 
     def test_failed_locator_repair_preserves_fresh_schema_eligibility(self):
         m = _import_codex_audit_runner()

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1701,6 +1701,22 @@ def fresh_schema_retry_code(validation_error: str) -> str:
         return "N1_ROUTE_CLASS_MARKER_MISMATCH"
     if validation_error.startswith("N4 witness "):
         return "N4_WITNESS_SCHEMA_MISMATCH"
+    if validation_error.startswith("N5 contains unknown fields") and any(
+        field in validation_error
+        for field in (
+            "resolution_classes_checked",
+            "tested_resolutions",
+            "untested_resolutions",
+            "resolution_evidence_path",
+            "resolution_evidence_locator",
+        )
+    ):
+        return "N5_STATEMENT_FIELD_NESTING_MISMATCH"
+    if (
+        validation_error.startswith("N6 candidate ")
+        and ".closure_mechanism must use its indexed_basis" in validation_error
+    ):
+        return "N6_INDEXED_BASIS_VERBATIM_MISMATCH"
     return "AUDIT_SCHEMA_REJECT"
 
 
@@ -1779,6 +1795,19 @@ def render_fresh_schema_retry_prompt(
             "claim_evidence_locator fields. The witness surface must have the "
             "authority role and the claim surface must have the source role. Copy "
             "each residual text and ID verbatim from its own cited packet surface.\n"
+        ),
+        "N5_STATEMENT_FIELD_NESTING_MISMATCH": (
+            "Static N5 invariant: resolution_classes_checked, "
+            "tested_resolutions, untested_resolutions, resolution_evidence_path, "
+            "and resolution_evidence_locator belong inside each statements[] "
+            "object, never on the N5_rhetoric_audit section object. Preserve all "
+            "statement content while placing each field at that documented level.\n"
+        ),
+        "N6_INDEXED_BASIS_VERBATIM_MISMATCH": (
+            "Static N6 invariant: copy indexed_basis exactly from the candidate "
+            "record and include that complete text verbatim inside the same "
+            "candidate's closure_mechanism before the explanation of how it could "
+            "affect the named wall. Do not paraphrase or shorten indexed_basis.\n"
         ),
     }.get(validation_code, "")
     return (


### PR DESCRIPTION
Repairs prompt/validator parity exposed by the R-eta re-audit. N5 resolution fields are explicitly confined to statements entries; N6 closure mechanisms must include the authenticated indexed basis verbatim. Adds conclusion-blind typed retries for both shapes without relaxing validators or leaking rejected content. Verification: 309 audit-pipeline tests, full pipeline, strict lint, py_compile, vocabulary lint, diff check, and sanitization probes. Independent review-loop PASS on exact head e0b007030a419667d6eb63ff589b6fe586a5caae. No audit verdicts, science changes, or generated audit files.