### PR TITLE
physics: adapt Berezin norm and extract quadratic center

### DIFF
--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
@@ -1,6 +1,37 @@
 # Handoff
 
 Current branch:
+`physics-loop/record-faithful-dynamics-block34-haar-berezin-running-center-20260712`.
+The Gaussian-adapted Berezin/quadratic-center runner reports `PASS=14 FAIL=0`.
+For every finite hidden set with `sigma_min(A_II)>=m`, covariance minors give
+Gaussian operator norm at most `max_p(m eta^2)^(-p)`; at
+`eta=m^(-1/2)` the norm and every tensor power are exactly one.
+
+Independent onsite-product Haar/Gaussian coordinates also admit a finite-
+horizon multi-index atom norm with algebra constant one at
+`r_*=1+sqrt(2)`. It repairs the prior one-index modulation counterexample and
+the explicit all-nonskeleton Wilson family, but full actual-range tagged
+membership is not yet proved.
+
+Every odd retained Schur path vanishes. The full `r=2` term is hidden-fiber
+constant and equals the positive gauge-covariant shortest quadratic kernel
+`S^(2)=mI+m^(-1)M_KI M_KI^dagger`. Exact extraction leaves the current bare
+residual row `K_res=2.747447e-11`, `q=exp(-1/2)`, and
+`B_res=3.080247e-9`; the conditional scalar ball diagnostic is feasible.
+These marked-attachment constants remain on the current product-Haar bare
+derivative and are not transferred to the correlated Gaussian reference.
+
+Independent code/math, physics/import/Nature, and governance/no-go reviews
+pass. Audit validation seeds one `bounded_theorem` / `unaudited` row with
+exactly five dependencies; strict lint has zero errors and generated outputs
+are stripped. No physical center/taste, autonomous RG, continuum, or
+axiom-update claim is made.
+
+Gaussian-adapted Berezin/quadratic-center stacked PR:
+https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5342
+is open against the current-chart handoff head.
+
+Previous branch:
 `physics-loop/record-faithful-dynamics-block33-autonomous-shadow-norm-20260712`.
 The current-chart autonomy/Grassmann-handoff runner reports `PASS=8 FAIL=0`.
 The exact straight dyadic support hierarchy composes and obeys the declared

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
@@ -1,5 +1,22 @@
 # PR Delivery
 
+The Gaussian-adapted Berezin handoff and shortest quadratic center is delivered:
+
+- base: `physics-loop/record-faithful-dynamics-block33-autonomous-shadow-norm-20260712`
+- head: `physics-loop/record-faithful-dynamics-block34-haar-berezin-running-center-20260712`
+- runner: `PASS=14 FAIL=0`
+- scope: exact fixed-gap Gaussian tensor norm one at `eta=m^(-1/2)`;
+  finite-horizon constant-one independent-factor atom algebra; exact odd-path
+  removal and fiber-constant positive `r=2` quadratic center; repaired current
+  bare residual/attachment constants; no correlated-Gaussian attachment,
+  actual-range tagged self-map, physical center, or invariant ball
+- review: independent code/math, physics/import/Nature, and governance/no-go pass
+- audit compatibility: one `bounded_theorem` / `unaudited` row with exactly
+  five dependencies; full pipeline and strict lint pass; generated outputs stripped
+- PR: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5342
+
+No merge is authorized. Independent audit remains authoritative.
+
 The current-chart autonomy and next-scale Grassmann-handoff boundary is delivered:
 
 - base: `physics-loop/record-faithful-dynamics-block32-localized-marked-invariant-ball-20260712`

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
@@ -1012,3 +1012,28 @@ generated outputs are stripped. PR #5340 is open. The next constructive target
 is a provenance-preserving multi-index Haar--Berezin norm with a running
 Gaussian/mass center, followed by a same-norm Hessian and invariant ball. No
 axiom-update stop is triggered.
+
+## Gaussian-adapted Berezin and shortest quadratic-center review
+
+PASS WITH BOUNDED CLAIMS after separating the product-Haar derivative from the
+correlated Gaussian reference. The covariance-minor proof gives norm one at
+`eta=m^(-1/2)` for every finite hidden set under a uniform singular gap. A
+finite-horizon tensor-factor Hoeffding atom norm has algebra constant one at
+`r_*=1+sqrt(2)` and repairs the explicit modulation-tag and Wilson-loop
+counterexamples, without claiming full actual-range membership.
+
+Independent path enumeration and staggered-sign checks prove that odd retained
+Schur lengths vanish and that all sixteen two-hop returns are backtracks or
+straight skeleton pairs. Their full sum is the hidden-independent positive
+kernel `S^(2)=mI+m^(-1)M_KI M_KI^dagger>=mI`. Extracting it exactly leaves
+`K_res=2.74744717327e-11`, `q=0.606530659713`, and
+`B_res=3.08024672439e-9` at the displayed point.
+
+Review rejected transferring forced attachment through the correlated
+Gaussian from contractivity alone. The repaired theorem keeps those constants
+on the current product-Haar bare derivative and names covariance locality,
+next-factor activity, running-gap persistence, spatial provenance, and the
+same-norm Hessian as open. Runner/cache are `PASS=14 FAIL=0`; audit validation
+seeds one `bounded_theorem` / `unaudited` row with exactly five dependencies;
+strict lint has zero errors and generated outputs are stripped. PR #5342 is
+open. No axiom-update stop is triggered.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
@@ -8,34 +8,34 @@ current_goal: >-
   supply the physical evolution object, bare time ordering, record-formation
   weights, and an admissibility-to-carrier selector without importing the
   staggered/Dirac answer or sector-specific Standard Model and gravity laws.
-branch: physics-loop/record-faithful-dynamics-block33-autonomous-shadow-norm-20260712
+branch: physics-loop/record-faithful-dynamics-block34-haar-berezin-running-center-20260712
 base_commit_at_start: 9d1636f05f
-cycle_count: 33
-block_count: 33
-active_route: wilson_staggered_current_chart_autonomy_grassmann_handoff
+cycle_count: 34
+block_count: 34
+active_route: wilson_staggered_gaussian_adapted_berezin_shortest_quadratic_center
 hard_residual: >-
   Can the four-axiom record surface canonically determine a faithful local
   record-forming instrument whose coherent no-record block is sufficiently
   constrained to exclude the observationally disconnected SWAP--Laplacian
   completion and select the Clifford-vector carrier?
-produced_claim_id: wilson_staggered_current_chart_autonomy_and_next_scale_grassmann_handoff_bounded_theorem_note_2026-07-12
+produced_claim_id: wilson_staggered_gaussian_adapted_berezin_handoff_and_shortest_quadratic_center_bounded_theorem_note_2026-07-12
 actual_current_surface_status: bounded-support
 conditional_surface_status: >-
-  The exact straight dyadic support hierarchy composes, but the full certified
-  weak completion does not embed into the same next-step strong marked norm by
-  support-only retagging: an explicit all-nonskeleton Wilson-loop family has a
-  divergent norm quotient. The next-step fifteen-site Gaussian Berezin map has
-  current-eta operator norm 10^720 at the ultra-deep witness. These are present-
-  chart boundaries only; actual RG-range provenance, a Gaussian-adapted
-  multi-index norm, running center, invariant ball, taste selection, and the
-  critical continuum remain open.
+  A uniform singular gap and eta=m^(-1/2) make normalized Gaussian Berezin
+  expectation contractive at every finite tensor depth. Independent product
+  coordinates admit a finite-horizon constant-one multi-index atom algebra.
+  The exact fiber-constant r=2 Schur kernel is extracted into a positive
+  gauge-covariant quadratic center; odd paths vanish, leaving a bare residual
+  row 2.747e-11 and q=exp(-1/2). Correlated-Gaussian attachment, actual-range
+  tagged membership, running-gap persistence, and same-norm iteration remain
+  open.
 admitted_observation_status: none
 claim_type_reason: >-
-  The source proves an exact dyadic support hierarchy and three narrowly scoped
-  present-chart boundaries: support-only weak-to-strong nonembedding on an
-  explicit Wilson family, the current-eta Gaussian Berezin norm, and the
-  ambient one-index Haar martingale algebra obstruction. It leaves the actual
-  RG range and constructive multi-index Haar--Berezin norms open.
+  The source proves exact fixed-gap Gaussian coefficient control, a finite-
+  horizon independent-factor atom algebra, the shortest quadratic Schur
+  kernel and parity extraction, and the repaired current bare residual row.
+  It explicitly does not transfer product-Haar marked attachment to a
+  correlated Gaussian or claim an autonomous RG self-map.
 hypothetical_axiom_status: null
 proposal_allowed: false
 proposal_allowed_reason: >-
@@ -144,6 +144,9 @@ files_touched:
   - docs/WILSON_STAGGERED_CURRENT_CHART_AUTONOMY_AND_NEXT_SCALE_GRASSMANN_HANDOFF_BOUNDED_THEOREM_NOTE_2026-07-12.md
   - scripts/wilson_staggered_current_chart_autonomy_grassmann_handoff_2026_07_12.py
   - logs/runner-cache/wilson_staggered_current_chart_autonomy_grassmann_handoff_2026_07_12.txt
+  - docs/WILSON_STAGGERED_GAUSSIAN_ADAPTED_BEREZIN_HANDOFF_AND_SHORTEST_QUADRATIC_CENTER_BOUNDED_THEOREM_NOTE_2026-07-12.md
+  - scripts/wilson_staggered_gaussian_adapted_berezin_quadratic_center_2026_07_12.py
+  - logs/runner-cache/wilson_staggered_gaussian_adapted_berezin_quadratic_center_2026_07_12.txt
 open_imports:
   - fundamental process object: Hamiltonian, strict tick, or record instrument
   - faithful law-to-record influence principle
@@ -194,10 +197,11 @@ no_go_routes:
   - the exact base-dependent conditional-centering split kills the centered tangent only at first order; its kernel is not an ideal, and the current unlocalized Cauchy-plus-geometry certificate remains above 68 even though localized forced-attachment and spectral-smoothing routes remain live
   - a strict one-step strong-to-weak derivative contraction does not by itself return the coarse action to the same strong split norm or control a running center and nonlinear invariant ball
   - the full certified weak completion has no support-only embedding into the present next-step strong norm, and the present ultra-small eta makes the next Gaussian Berezin conditioning enormous; this does not rule out actual-range provenance, running Gaussian centers, or multi-index Haar--Berezin norms
+  - Gaussian adaptation and shortest-quadratic extraction repair the fixed-gap tensor norm and current bare residual constants, but do not by themselves supply correlated-reference forced attachment, full actual-range tag membership, or a persistent running gap
 trace_gate_classification: direct_blocker_closure
 reachability_to_target: partially_closes
-review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_two_layer_source_polymer_pass_retained_grassmann_polymer_norm_pass_declared_rg_chart_pass_split_derivative_certificate_boundary_pass_marked_attachment_strong_weak_contraction_pass_current_chart_autonomy_handoff_pass_bounded
-pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open_two_layer_source_polymer_open_retained_grassmann_polymer_norm_open_declared_rg_chart_open_split_derivative_certificate_boundary_open_marked_attachment_strong_weak_contraction_open_current_chart_autonomy_handoff_open
+review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_two_layer_source_polymer_pass_retained_grassmann_polymer_norm_pass_declared_rg_chart_pass_split_derivative_certificate_boundary_pass_marked_attachment_strong_weak_contraction_pass_current_chart_autonomy_handoff_pass_gaussian_berezin_quadratic_center_pass_bounded
+pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open_two_layer_source_polymer_open_retained_grassmann_polymer_norm_open_declared_rg_chart_open_split_derivative_certificate_boundary_open_marked_attachment_strong_weak_contraction_open_current_chart_autonomy_handoff_open_gaussian_berezin_quadratic_center_open
 block01_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5178
 block02_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5181
 block03_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5201
@@ -231,13 +235,15 @@ block30_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/
 block31_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5333
 block32_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5338
 block33_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5340
+block34_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5342
 next_exact_action: >-
-  Construct a provenance-preserving multi-index Haar--Berezin atom norm with
-  Grassmann weights tied to a running onsite Gaussian/mass center. Prove the
-  actual RG range lands in it, its algebra and conditional expectations are
-  scale-uniform, and its one-step image returns to the same norm. Then derive
-  the same-norm two-mark Hessian and close the already-feasible invariant-ball
-  inequality, keeping the ultra-massive basin distinct from criticality.
+  Prove a tagged cluster expansion for the complete current residual factor
+  family, including non-pure Haar words, Grassmann endpoint contractions, and
+  skeleton-cancellation transfer into future coarse-link tags. Then extend
+  forced attachment through the correlated running covariance with an explicit
+  locality/cluster bound and prove the resulting actual RG range returns to a
+  uniform strong provenance norm. Only then derive the same-norm Hessian and
+  invariant ball.
 stop_condition: >-
   Stop and discuss an axiom update only if an exact result proves that the
   required bridge cannot be derived and an additional approved axiom or

--- a/docs/WILSON_STAGGERED_GAUSSIAN_ADAPTED_BEREZIN_HANDOFF_AND_SHORTEST_QUADRATIC_CENTER_BOUNDED_THEOREM_NOTE_2026-07-12.md
+++ b/docs/WILSON_STAGGERED_GAUSSIAN_ADAPTED_BEREZIN_HANDOFF_AND_SHORTEST_QUADRATIC_CENTER_BOUNDED_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,443 @@
+# Gaussian-adapted Berezin handoff and shortest quadratic center
+
+**Date:** 2026-07-12
+**Type:** bounded_theorem
+**Status:** unaudited candidate; effective status is pipeline-derived only after independent audit.
+**Primary runner:** [`scripts/wilson_staggered_gaussian_adapted_berezin_quadratic_center_2026_07_12.py`](../scripts/wilson_staggered_gaussian_adapted_berezin_quadratic_center_2026_07_12.py)
+**Cached output:** [`logs/runner-cache/wilson_staggered_gaussian_adapted_berezin_quadratic_center_2026_07_12.txt`](../logs/runner-cache/wilson_staggered_gaussian_adapted_berezin_quadratic_center_2026_07_12.txt)
+
+## 0. Result
+
+The fixed-gap Gaussian-reference coefficient-norm explosion has an exact
+positive repair. Independently, the shortest Schur activity can be extracted
+as a running quadratic center rather than treated as an irrelevant interaction;
+it is the dominant Schur activity at the displayed witness.
+
+Use the exact factor-two block and Schur identity from the
+[gauge-block theorem](MASSIVE_WILSON_STAGGERED_FACTOR_TWO_GAUGE_BLOCK_SCHUR_OS_SEMIGROUP_BOUNDED_THEOREM_NOTE_2026-07-12.md),
+the simultaneous coefficient norm and path row from the
+[retained-Grassmann polymer theorem](WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md),
+the field-coordinate torsor from the
+[declared RG chart](WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md),
+the forced-base response formulas from the
+[K-retaining marked-attachment theorem](WILSON_STAGGERED_K_RETAINING_MARKED_ATTACHMENT_STRONG_WEAK_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md),
+and the current-`eta` boundary from the
+[next-scale handoff theorem](WILSON_STAGGERED_CURRENT_CHART_AUTONOMY_AND_NEXT_SCALE_GRASSMANN_HANDOFF_BOUNDED_THEOREM_NOTE_2026-07-12.md).
+
+For an invertible quadratic hidden block with
+`sigma_min(A_II)>=m>0`, normalized Gaussian
+Berezin expectation contracts a balanced hidden `p`-pair monomial by a
+`p`-by-`p` covariance minor. Since `||A_II^(-1)||_2<=m^(-1)`, every such minor
+has magnitude at most `m^(-p)`. Therefore in the coefficient `l1` norm,
+
+```text
+||G_(A_II)||_(eta -> eta)
+ <=max_(0<=p<=3|I|)(m eta^2)^(-p).                                 (0.1)
+```
+
+At the Gaussian-adapted value
+
+```text
+eta_m=m^(-1/2),                                                     (0.2)
+```
+
+the operator norm is exactly one for any number of eliminated sites. In
+particular, the fifteen-site norm is `1`, not the `10^720` obtained in the
+old `eta=10^(-10)` chart. Product hidden-Haar averaging remains contractive,
+so the combined Haar--Berezin reference expectation is contractive as well.
+
+There is also an exact finite-horizon provenance algebra. For independent
+tensor-factor Haar expectations and onsite-product Gaussian pair expectations
+`E_i`, put
+`Q_i=1-E_i` and
+
+```text
+r_*=1+sqrt(2),
+Delta_S=product_(i in S)Q_i product_(i not in S)E_i,
+||F||_prov=sum_S r_*^|S| ||Delta_S F||_pi.                         (0.2a)
+```
+
+Because `r_*^2=1+2r_*`, this is a Banach-algebra norm with constant one.
+Partial conditional expectations and their atom-complements have norm at most
+one. With level weights `r_a=r_*R^a`, a downshift of every nonempty
+cancellation tag gains at most `R^(-1)`. This finite-horizon multi-index
+construction removes the algebraic one-index martingale counterexample: a
+fine detail modulated by a coarse atom retains both tags. It does not yet prove
+that the complete Wilson--staggered RG range has a uniformly bounded tagged
+decomposition at every scale. A general coupled covariance satisfying (0.1)
+is a separate contractive reference; it is not claimed to factor into these
+local coordinate expectations.
+
+The Schur paths have another exact simplification. Both retained endpoints
+lie in `K=(2Z)^4`; nearest-neighbor hopping flips bipartite parity, so every
+odd total path length vanishes. At total length two, the only paths are a
+backtrack or two straight steps along one axis. The former is the identity and
+the latter is exactly the declared coarse link `V`. Consequently the complete
+length-two kernel is hidden-fiber constant:
+
+```text
+S^(2)(V)
+ =(m+2/m)I
+  -(1/(4m))sum_mu[V_(X,mu) shift_(+mu)
+                  +V_(X-mu,mu)^dagger shift_(-mu)].                (0.3)
+```
+
+Equivalently,
+
+```text
+S^(2)=mI-m^(-1)M_KI M_IK=mI+m^(-1)M_KI M_KI^dagger>=mI.           (0.4)
+```
+
+It is a gauge-covariant, blocked-translation/proper-cubic/reflection-
+compatible finite-range quadratic coordinate. Because all even Grassmann
+bilinears commute, its exponential can be extracted exactly from the Schur
+factor product. This is declared running-center data, not a selected physical
+mass or kinetic term.
+
+After extracting (0.3), the Schur interaction row begins at even `r=4`:
+
+```text
+K_res
+ =K_W+K_I
+  +18 eta_m^2 sum_(even r>=4)
+     r h^(r-1)g(9 eta_m^2 2^(-r)m^(-(r-1))) exp(rL),               (0.5)
+```
+
+with `h=4/m`, `L=Theta+2c+Lambda`, and the earlier definitions of `K_W,K_I`.
+At
+
+```text
+m=10000, beta=0, c=0.001, Theta=10^(-6), Lambda=1,
+eta_m=0.01,                                                         (0.6)
+```
+
+For the current bare one-step factor family after exact `r=2` extraction, the
+exact rows are
+
+```text
+K_(S,2)=1.068290846710377... 10^(-5),
+K_(S,even>=4)=2.536105198800462... 10^(-11),
+K_I=2.113419744695058... 10^(-12),
+K_res=2.747447173269967... 10^(-11).                               (0.7)
+```
+
+The marked-attachment formulas applied to the residual row give
+
+```text
+A_att=2.021458733802326... 10^(-8),
+q_centered=2.266318968338462... 10^(-6),
+q_split=max{exp(-1/2),q_centered}=0.606530659712633...,
+B_res<=3.080246724392693... 10^(-9).                               (0.8)
+```
+
+The old scalar Cauchy diagnostic is now feasible without an ultra-small
+Grassmann weight: at `delta=10^(-8)` its left side is
+`9.156776063580995... 10^(-9)<delta`.
+
+This closes the fixed-gap Gaussian-reference tensor-norm explosion and
+extracts the leading quadratic center. It does not prove that the exact next RG range returns to a
+strong spatial provenance norm, that the running quadratic gap persists on a
+ball, or that the same-norm Hessian estimate holds. Hence (0.8) is not yet an
+autonomous invariant ball. No axiom-update stop is established.
+
+## 1. Covariance-adapted Gaussian expectation and provenance atoms
+
+Let `I` be any finite set of hidden sites with three colors per site and let
+
+```text
+Q_I=bar zeta A_II zeta,          sigma_min(A_II)>=m>0.             (1.1)
+```
+
+Normalized Berezin expectation is
+
+```text
+G_(A_II)[F]
+ =(det A_II)^(-1) integral dbar zeta dzeta exp(-Q_I)F.             (1.2)
+```
+
+On an ordered balanced monomial with hidden barred indices `P` and unbarred
+indices `Q`, `|P|=|Q|=p`, Wick expansion gives, up to the ordering sign,
+
+```text
+G_(A_II)[bar zeta_P zeta_Q]
+ =det[(A_II^(-1))_(Q,P)].                                         (1.3)
+```
+
+Every singular value of a submatrix is at most `||A_II^(-1)||_2`; Hadamard's
+inequality therefore bounds (1.3) by `m^(-p)`. The input monomial pays
+`eta^(2p)` and its retained part has the same remaining weight, proving
+(0.1). The constant term shows the operator norm is at least one, so it is
+exactly one whenever `m eta^2>=1`.
+
+The choice (0.2) is the smallest coefficient weight with that property and
+therefore the most favorable one for the Schur activity row. Tensoring over
+fifteen sites does not multiply a constant greater than one. If the quadratic
+block depends on hidden Haar variables but retains the uniform gap (1.1), the
+bound is pointwise in those variables; normalized Haar averaging preserves it.
+
+With the unital embedding `L` of retained coefficients, put
+
+```text
+E_m=E_H G_(A_II),       C_m=L E_m,       Q_m=1-C_m.                (1.4)
+```
+
+Then `E_m L=1` and `E_m Q_m=0`. For one coordinate use the weighted split norm
+
+```text
+N_(m,r)(F)=||E_mF||+r||Q_mF||.                                    (1.5)
+```
+
+The bimodule property, coefficient-norm submultiplicativity, and
+`||Q_m(F^oG^o)||<=2||F^o||||G^o||` give
+
+```text
+N_(m,r)(FG)<=N_(m,r)(F)N_(m,r)(G)
+whenever r^2>=1+2r.                                                (1.6)
+```
+
+The smallest positive solution is `r_*`. For the atom construction, specialize
+to independent product-Haar coordinates and independent onsite scalar Gaussian
+pair expectations at `eta_m`; these even tensor-factor maps commute. Iterating
+(1.6) over any finite family of them gives (0.2a) in the
+tensor-projective coefficient norm. Coordinate integrations remove all atoms
+containing their `Q_i`, while leaving the others unchanged, hence have norm at
+most one. A level downshift changes `r_a` to `r_(a-1)=r_a/R`, so an atom with
+nonempty tag set `S` gains `R^(-|S|)`.
+
+For the current-chart martingale witness, `h_j` carries tag `{j}` and
+`conj(h_j)g_k` carries `{j,k}`. The coarse component `a_hg_k` therefore obeys
+
+```text
+||a_hg_k||_prov
+ /( ||h_j||_prov ||conj(h_j)g_k||_prov )
+ <=a_h/r_j^2,                                                       (1.7)
+```
+
+independently of the modulation level `k`. The missing modulation tag was the
+one-index defect. For the explicit all-nonskeleton Wilson family, every
+contour coordinate is genuinely tagged. Taking `R=2`, its former per-site
+weak-to-strong growth is replaced by
+
+```text
+q_loop<=[exp(Lambda/2+Theta/2+2c)/2]^|X|
+       =(0.826011419447...)^|X|                                   (1.8)
+```
+
+at (0.6). General actual-range membership is stronger: a large polymer with
+only one genuine cancellation tag need not satisfy (1.8). That tagged cluster
+theorem remains open.
+
+## 2. Exact shortest quadratic center
+
+Write the exact Schur complement as
+
+```text
+S=mI-M_KI(mI+M_II)^(-1)M_IK.                                     (2.1)
+```
+
+For `m>4`, expanding the inverse gives paths of total length `r=n+2`.
+Staggered nearest-neighbor hopping changes site parity at every step. Since
+both endpoints belong to `(2Z)^4`, every odd `r` coefficient is identically
+zero. This is stronger than the safe all-`r` majorant used previously.
+
+At `r=2`, a cross-axis second step leaves two odd coordinates and cannot land
+in `K`. There are eight backtracks and eight straight two-step paths. The
+staggered sign is unchanged along a straight direction. A backtrack has
+`M_(x,z)M_(z,x)=-1/4`, while a straight pair has transporter `V` and product
+coefficient `+1/4` before the Schur minus. Summing gives (0.3).
+
+The coordinate-free expression (0.4) proves positivity and the uniform gap.
+It also proves gauge covariance directly. Straight coarse links intertwine
+the declared blocked translations, proper cubic rotations, and compatible
+time reflection. No hidden Haar coordinate occurs in (0.3), so extracting it
+does not consume a cancellation estimate.
+
+Let `P_2` denote coefficient extraction of the vacuum and the full kernel
+(0.3), not merely its onsite scalar part. The centered interaction is
+
+```text
+V^o=(1-P_2)Gamma.                                                   (2.2)
+```
+
+Calling only `m+2/m` the center would leave the nearest-neighbor coarse
+quadratic term in the interaction and would not achieve (0.5). The full
+gauge-covariant shortest kernel is load-bearing.
+
+## 3. Field and running-center chart
+
+For two positive gap coordinates `m,m'`, the exact field torsor obeys
+
+```text
+||D_rho Phi||_(eta(m'))=||Phi||_(eta(m')/rho),
+rho=eta(m')/eta(m)=sqrt(m/m').                                    (3.1)
+```
+
+Hence `D_rho` is an isometry from the `m`-adapted coefficient chart to the
+`m'`-adapted chart, and an onsite coefficient `m` transforms to
+`rho^(-2)m=m'`. This is a chart identity, not a dynamical equation selecting
+`m'`.
+
+Without applying `D_rho`, the identity map between two mass-adapted charts on
+a polymer `X` obeys
+
+```text
+||Phi_X||_(eta(m'))
+ <=exp[3|X|(log(m/m'))_+]||Phi_X||_(eta(m)).                       (3.2)
+```
+
+There are at most three balanced pairs per site, so a controlled relative
+mass decrease can be paid by an explicit size-weight reserve. A future
+autonomous theorem must derive the center update, prove its gap and reserve,
+and fix `rho` by a declared normalization condition.
+
+## 4. Residual activity and conditional ball diagnostic
+
+The even-length restriction applies to both determinant loops and Schur paths;
+`K_I` already sums even `r>=4`. Extraction of the commuting `r=2` bilinear
+factors changes the Schur row to (0.5). It is exact factor regrouping, not a
+subtraction from a norm bound.
+
+The current bare constrained-fiber derivative still uses the product-Haar
+reference while leaving retained Grassmann variables external. For that map,
+the complete `r=2` kernel is fiber constant and its exact extraction changes
+the base activity to (0.5). The K-retaining forced-attachment formulas
+therefore apply to this current bare residual row, giving (0.7)--(0.8).
+
+This does not extend those marked-attachment constants to the combined
+expectation (1.4). A general covariance Gaussian can couple hidden sites;
+contractivity and `E_mQ_m=0` alone do not provide the local product
+factorization used by the marked-tree proof. A covariance locality/cluster
+theorem and a next-factor activity row are still required.
+
+For the source radius `r_src=log(1+c-K_res)`, retain the prior Cauchy envelope
+
+```text
+M_delta=2[68 exp(Lambda/2)c]/(r_src-delta)^2.                      (4.1)
+```
+
+The runner evaluates
+
+```text
+B_res+q_split delta+(M_delta/2)delta^2<delta                        (4.2)
+```
+
+at `delta=10^(-8)`. Equation (4.2) is conditional scalar feasibility. The
+spatial strong-norm handoff, actual-range factor row, running gap, and same-
+norm two-mark bound are still required before Banach contraction applies.
+This is not yet an autonomous invariant ball.
+
+## 5. Runner contract
+
+Run:
+
+```bash
+python3 scripts/wilson_staggered_gaussian_adapted_berezin_quadratic_center_2026_07_12.py
+```
+
+The runner checks exact Gaussian monomial contractions, old versus adapted
+fifteen-site norms, the `r_*` split-algebra inequality on a finite exterior
+algebra, multi-index shift and modulation-tag bounds,
+the dyadic two-hop classification and parity rule, the shortest-kernel gap,
+field-chart identities, the exact residual activity/attachment constants,
+the conditional scalar ball inequality, and the source/dependency contract.
+The arbitrary-volume covariance-minor bound and infinite factor rows are
+analytic.
+
+## 6. No-Go Discipline N1--N8
+
+The theorem is positive. Its boundary statements remain narrow because it
+repairs one half of a prior no-go-sensitive autonomy problem.
+
+### N1 — alternative-route enumeration
+
+| Route | Status | Executed result |
+|---|---|---|
+| Keep `eta=10^(-10)` | `ATTEMPTED` | The prior exact fifteen-site norm is `10^720`. |
+| Onsite Gaussian adaptation | `ATTEMPTED` | Equations (0.1)--(0.2) make every tensor depth contractive. |
+| Leave all Schur paths in the interaction | `ATTEMPTED` | At (0.6), `K_(S,2)` dominates and the base defect exceeds the old source radius. |
+| Extract only the onsite scalar | `ATTEMPTED` | Does not achieve (0.5): the straight `r=2` coarse-link bilinear is equally fiber constant. |
+| Extract the full shortest quadratic kernel | `ATTEMPTED` | Equations (0.3)--(0.8) give the exact residual row and feasible scalar diagnostic. |
+| Odd Schur paths | `ATTEMPTED` | Bipartite parity makes them identically zero between retained endpoints. |
+| Finite-horizon multi-index Haar--Berezin atoms | `ATTEMPTED` | Equations (0.2a), (1.6)--(1.8) give the algebra, expectation, shift, and explicit Wilson-family handoff constants. |
+
+Full covariance centers, multiscale provenance atoms, Peter--Weyl smoothing,
+taste-faithful hypercube blocks, and small/large-field decompositions remain
+live; they are not labeled attempted here.
+
+### N2 — wall-independence audit
+
+The four remaining conditions are `spatial actual-range provenance handoff`,
+`running quadratic gap/normalization`, `physical taste/chart identification`,
+and `critical trajectory/observable identification`.
+
+| Left | Right | Left closes right? | Right closes left? | Independent? |
+|---|---|---:|---:|---:|
+| spatial provenance handoff | running quadratic gap | No | No | Yes |
+| spatial provenance handoff | physical taste/chart | No | No | Yes |
+| spatial provenance handoff | critical trajectory/observable | No | No | Yes |
+| running quadratic gap | physical taste/chart | No | No | Yes |
+| running quadratic gap | critical trajectory/observable | No | No | Yes |
+| physical taste/chart | critical trajectory/observable | No | No | Yes |
+
+### N3 — hidden-condition phrase scan
+
+| Phrase | Classification |
+|---|---|
+| `Gaussian-adapted` | Exact norm condition (0.2), not a physical vacuum claim. |
+| `running center` | Declared extracted coordinate; no selected flow equation. |
+| `mass` | Gap/chart coordinate, not a derived physical mass. |
+| `kinetic` | No physical kinetic normalization is assigned to (0.3). |
+| `same norm` | Explicitly still absent spatially. |
+| `autonomous` | Explicitly not established. |
+| `by construction` | No proof-substitute use. |
+| `standard RG` | No hit. |
+
+### N4 — citation/residual matching
+
+| Dependency | Exact use | Match? |
+|---|---|---:|
+| [Factor-two Schur theorem](MASSIVE_WILSON_STAGGERED_FACTOR_TWO_GAUGE_BLOCK_SCHUR_OS_SEMIGROUP_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Block geometry, hopping signs, exact Schur identity, covariance | Yes |
+| [Retained-Grassmann polymer theorem](WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Coefficient norm and determinant/Schur activity rows | Yes |
+| [Declared RG chart](WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Exact field-coordinate torsor | Yes |
+| [K-retaining marked attachment](WILSON_STAGGERED_K_RETAINING_MARKED_ATTACHMENT_STRONG_WEAK_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Residual-row attachment and scalar Cauchy formulas | Yes |
+| [Current-chart handoff boundary](WILSON_STAGGERED_CURRENT_CHART_AUTONOMY_AND_NEXT_SCALE_GRASSMANN_HANDOFF_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Fifteen-site problem and running-center route | Yes |
+
+### N5 — rhetoric and resolution audit
+
+The Gaussian operator theorem holds for every finite hidden set under the
+explicit quadratic gap. The local atom factorization separately uses the
+onsite-product Gaussian reference. The numerical residual row is one bare ultra-massive
+factor family after exact `r=2` extraction. It is not the factor row of every
+action in a ball or every later scale. The atom algebra is finite-horizon and
+the Wilson calculation uses one tag per contour coordinate; neither proves a
+uniform tagged decomposition of the full actual RG range. The scalar inequality is not an
+invariant-ball theorem. No fixed point, criticality, or continuum claim is
+made. Extending forced attachment to the correlated Gaussian reference needs
+a separate covariance-locality/cluster theorem and remains open.
+
+### N6 — partial-closure and primitive scan
+
+Quadratic coefficient extraction, covariance-weighted Berezin integration,
+and field coordinates are regulator mathematics. The registered primitives
+do not select the center, `rho`, physical mass, or taste. No missing
+constructive estimate is reclassified as an axiom.
+
+### N7 — hostile steelman
+
+A hostile reviewer should insist that the next exact action is not purely
+quadratic and that its quadratic center need not retain the gap (0.4). Correct;
+the full interaction is retained, and persistence of a chosen running center
+is open. Another should insist that Gaussian adaptation does not repair the
+Wilson-loop support counterfamily. Correct; the spatial provenance handoff is
+the next independent target. These live routes defeat any broader autonomy
+claim.
+
+### N8 — cross-cycle echo
+
+Raw lifted unit directions were repaired by geometric rescaling; the
+unlocalized derivative certificate was repaired by forced attachment. Here
+the Grassmann tensor explosion is repaired by its covariance norm and the
+dominant apparent interaction is moved to its exact quadratic coordinate.
+The remaining spatial handoff is not an axiom-update signal.
+
+**No-Go Discipline status: PASS.**

--- a/logs/runner-cache/wilson_staggered_gaussian_adapted_berezin_quadratic_center_2026_07_12.txt
+++ b/logs/runner-cache/wilson_staggered_gaussian_adapted_berezin_quadratic_center_2026_07_12.txt
@@ -1,0 +1,15 @@
+PASS gaussian_adapted_tensor_norm: old_one_site=1.0e+48, old_fifteen_site=1e720, eta_m=0.01, adapted_fifteen_site=1
+PASS three_color_covariance_minor_bound: contractions=[1.0, 0.0001, 1e-08, 1e-12], adapted_ratios=[1.0, 1.0, 1.0, 0.9999999999999998]
+PASS interaction_updates_quadratic_center: G[(bar_zeta zeta)(bar_psi psi)]={(2, 3): 0.0001}
+PASS multi_index_local_split_algebra: r*=1+sqrt(2)=2.414213562373, fixtures=18, worst_ratio=1.000000000000<=1
+PASS multi_index_modulation_and_shift: ratios=[0.0011914783003736799, 0.0011914783003736799, 0.0011914783003736799], nonempty_tag_shift<=0.5, Wilson_per_tag=0.826011419447
+PASS shortest_path_classification: returning_two_step=16, backtracks=8, straight=8
+PASS odd_schur_path_parity: odd_return_counts=[0, 0, 0], even_return_counts=[16, 640, 34816]
+PASS shortest_quadratic_center_gap: U=1 momentum spectrum min=10000.000000000000, max=10000.000400000001, gap>=10000
+PASS running_mass_chart_torsor: m'=9900, rho=1.005037815259, transformed_mass=9900.000000000004, one_site_identity_cost=1.030610152128
+PASS quadratic_center_residual_activity: K_S2=1.068290846710377e-05, K_S_even>=4=2.536105198800461e-11, K_I=2.113419744695058e-12, K_res=2.747447173269967e-11, old_B=1.197696492987366e-03>old_r_src=9.888280124566245e-04
+PASS residual_marked_attachment: tau=1.010729358519869e-08, A_att=2.021458733802326e-08, q_centered=2.266318968338462e-06, q_split=0.606530659713, B_res=3.080246724392692e-09
+PASS conditional_ball_scalar_feasibility: r_src=9.995003056365085e-04, delta=1.0e-08, M_delta=224454.841239342, lhs=9.156776063580995e-09
+PASS source_contract: missing=[], forbidden_hits=[]
+PASS repository_dependency_set: markdown_dependency_set=['MASSIVE_WILSON_STAGGERED_FACTOR_TWO_GAUGE_BLOCK_SCHUR_OS_SEMIGROUP_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_CURRENT_CHART_AUTONOMY_AND_NEXT_SCALE_GRASSMANN_HANDOFF_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_K_RETAINING_MARKED_ATTACHMENT_STRONG_WEAK_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md']
+SCORECARD PASS=14 FAIL=0

--- a/scripts/wilson_staggered_gaussian_adapted_berezin_quadratic_center_2026_07_12.py
+++ b/scripts/wilson_staggered_gaussian_adapted_berezin_quadratic_center_2026_07_12.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Checks Gaussian-adapted Berezin handoff and shortest-center extraction."""
+
+from __future__ import annotations
+
+import itertools
+import math
+import re
+from collections import defaultdict
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "WILSON_STAGGERED_GAUSSIAN_ADAPTED_BEREZIN_HANDOFF_AND_"
+    "SHORTEST_QUADRATIC_CENTER_BOUNDED_THEOREM_NOTE_2026-07-12.md"
+)
+Exterior = dict[tuple[int, ...], float]
+
+
+def g(value: float) -> float:
+    return math.expm1(value) / value if value else 1.0
+
+
+def ext_mul(left: Exterior, right: Exterior) -> Exterior:
+    out: dict[tuple[int, ...], float] = defaultdict(float)
+    for left_monomial, left_value in left.items():
+        for right_monomial, right_value in right.items():
+            if set(left_monomial) & set(right_monomial):
+                continue
+            inversions = sum(a > b for a in left_monomial for b in right_monomial)
+            monomial = tuple(sorted(left_monomial + right_monomial))
+            out[monomial] += (-1) ** inversions * left_value * right_value
+    return {key: value for key, value in out.items() if abs(value) > 1.0e-15}
+
+
+def ext_norm(value: Exterior, eta: float) -> float:
+    return sum(abs(coefficient) * eta ** len(monomial) for monomial, coefficient in value.items())
+
+
+def gaussian_project(value: Exterior, mass: float) -> Exterior:
+    """Normalize-integrate hidden ordered pair (0,1), retaining indices >=2."""
+    out: dict[tuple[int, ...], float] = defaultdict(float)
+    for monomial, coefficient in value.items():
+        hidden = set(monomial) & {0, 1}
+        if not hidden:
+            out[monomial] += coefficient
+        elif hidden == {0, 1}:
+            retained = tuple(index for index in monomial if index >= 2)
+            out[retained] += coefficient / mass
+    return dict(out)
+
+
+def lift(value: Exterior) -> Exterior:
+    return dict(value)
+
+
+def centered(value: Exterior, mass: float) -> Exterior:
+    coarse = lift(gaussian_project(value, mass))
+    keys = set(value) | set(coarse)
+    return {key: value.get(key, 0.0) - coarse.get(key, 0.0) for key in keys if abs(value.get(key, 0.0) - coarse.get(key, 0.0)) > 1.0e-15}
+
+
+def split_norm(value: Exterior, mass: float, eta: float, split_weight: float) -> float:
+    return ext_norm(gaussian_project(value, mass), eta) + split_weight * ext_norm(
+        centered(value, mass), eta
+    )
+
+
+def integer_sup_n_exp(slack: float) -> tuple[int, float]:
+    critical = 1.0 / slack
+    candidates = {max(1, math.floor(critical)), max(1, math.ceil(critical))}
+    return max(((int(n), n * math.exp(-slack * n)) for n in candidates), key=lambda row: row[1])
+
+
+def integer_sup_attachment(k_value: float, c: float) -> tuple[int, float]:
+    critical = -math.log1p(-k_value / c) / k_value
+    candidates = {max(1, math.floor(critical)), max(1, math.ceil(critical))}
+    return max(
+        ((int(n), math.exp(-c * n) * math.expm1(k_value * n)) for n in candidates),
+        key=lambda row: row[1],
+    )
+
+
+def attachment_constants(k_value: float, c: float) -> dict[str, float]:
+    n_d, d_slack = integer_sup_n_exp(c - k_value)
+    n_a, a_zero = integer_sup_attachment(k_value, c)
+    tau = k_value * d_slack
+    anchored = (a_zero + tau / (1.0 - tau)) / (1.0 - tau)
+    return {
+        "n_d": float(n_d),
+        "d_slack": d_slack,
+        "n_a": float(n_a),
+        "a_zero": a_zero,
+        "tau": tau,
+        "A_att": anchored,
+    }
+
+
+def residual_rows(mass: float, c: float, theta: float, lam: float, eta: float) -> dict[str, float]:
+    h = 4.0 / mass
+    total_weight = theta + 2.0 * c + lam
+    x_two = 9.0 * eta**2 * 2.0**-2 * mass**-1
+    schur_two = 18.0 * eta**2 * 2.0 * h * g(x_two) * math.exp(2.0 * total_weight)
+    determinant = 0.0
+    schur_residual = 0.0
+    for length in range(4, 10000, 2):
+        determinant_term = (
+            1.5
+            * h**length
+            * g(3.0 * h**length / length)
+            * math.exp(length * total_weight)
+        )
+        determinant += determinant_term
+        x_length = 9.0 * eta**2 * 2.0 ** (-length) * mass ** (-(length - 1))
+        schur_term = (
+            18.0
+            * eta**2
+            * length
+            * h ** (length - 1)
+            * g(x_length)
+            * math.exp(length * total_weight)
+        )
+        schur_residual += schur_term
+        if max(determinant_term, schur_term) < 1.0e-22:
+            break
+    return {
+        "x_two": x_two,
+        "K_S_two": schur_two,
+        "K_I": determinant,
+        "K_S_residual": schur_residual,
+        "K_residual": determinant + schur_residual,
+    }
+
+
+def main() -> None:
+    checks: list[tuple[str, bool, str]] = []
+
+    mass = 1.0e4
+    old_eta = 1.0e-10
+    adapted_eta = mass**-0.5
+    old_one_site = max((mass * old_eta**2) ** (-pairs) for pairs in range(4))
+    adapted_one_site = max((mass * adapted_eta**2) ** (-pairs) for pairs in range(4))
+    checks.append(
+        (
+            "gaussian_adapted_tensor_norm",
+            math.isclose(old_one_site, 1.0e48, rel_tol=1.0e-14)
+            and math.isclose(15.0 * math.log10(old_one_site), 720.0, abs_tol=1.0e-12)
+            and adapted_one_site == 1.0,
+            f"old_one_site={old_one_site:.1e}, old_fifteen_site=1e{15*math.log10(old_one_site):.0f}, eta_m={adapted_eta:g}, adapted_fifteen_site=1",
+        )
+    )
+
+    # Direct three-color scalar covariance minors m^{-p}.
+    contractions = [mass ** (-pairs) for pairs in range(4)]
+    ratios = [value / adapted_eta ** (2 * pairs) for pairs, value in enumerate(contractions)]
+    checks.append(
+        (
+            "three_color_covariance_minor_bound",
+            all(math.isclose(value, 1.0, abs_tol=1.0e-14) for value in ratios),
+            f"contractions={contractions}, adapted_ratios={ratios}",
+        )
+    )
+
+    # Mixed quartic contracts into a retained quadratic coefficient.
+    mixed = {(0, 1, 2, 3): 1.0}
+    projected = gaussian_project(mixed, mass)
+    checks.append(
+        (
+            "interaction_updates_quadratic_center",
+            projected == {(2, 3): 1.0 / mass},
+            f"G[(bar_zeta zeta)(bar_psi psi)]={projected}",
+        )
+    )
+
+    # Exhaust a small integer coefficient family for the exact weighted split
+    # algebra bound. Analytically, r^2 >= 1+2r pays the centered product.
+    split_weight = 1.0 + math.sqrt(2.0)
+    basis = [(), (0,), (1,), (2,), (3,), (0, 1), (2, 3), (0, 1, 2, 3)]
+    fixtures = []
+    for first, second in itertools.product((-1.0, 0.0, 1.0), repeat=2):
+        fixtures.append({basis[0]: first, basis[5]: second})
+        fixtures.append({basis[6]: first, basis[7]: second})
+    worst_ratio = 0.0
+    algebra_ok = True
+    for left, right in itertools.product(fixtures, repeat=2):
+        denominator = split_norm(left, mass, adapted_eta, split_weight) * split_norm(
+            right, mass, adapted_eta, split_weight
+        )
+        if not denominator:
+            continue
+        ratio = split_norm(ext_mul(left, right), mass, adapted_eta, split_weight) / denominator
+        worst_ratio = max(worst_ratio, ratio)
+        algebra_ok &= ratio <= 1.0 + 1.0e-12
+    checks.append(
+        (
+            "multi_index_local_split_algebra",
+            algebra_ok
+            and math.isclose(split_weight**2, 1.0 + 2.0 * split_weight, abs_tol=1.0e-14),
+            f"r*=1+sqrt(2)={split_weight:.12f}, fixtures={len(fixtures)}, worst_ratio={worst_ratio:.12f}<=1",
+        )
+    )
+
+    scale_ratio = 2.0
+    detail_level = 2
+    modulation_levels = (4, 8, 12)
+    a_h = 1.0 / 9.0
+    r_j = split_weight * scale_ratio**detail_level
+    tagged_ratios = []
+    for modulation_level in modulation_levels:
+        r_k = split_weight * scale_ratio**modulation_level
+        tagged_ratios.append((a_h * r_k) / (r_j * (r_j * r_k)))
+    loop_base = math.exp(0.5 + 0.5e-6 + 0.002) / scale_ratio
+    checks.append(
+        (
+            "multi_index_modulation_and_shift",
+            max(tagged_ratios) - min(tagged_ratios) < 1.0e-18
+            and math.isclose(tagged_ratios[0], a_h / r_j**2, rel_tol=1.0e-14)
+            and scale_ratio**-1 < 1.0
+            and loop_base < 1.0,
+            f"ratios={tagged_ratios}, nonempty_tag_shift<={scale_ratio**-1:g}, Wilson_per_tag={loop_base:.12f}",
+        )
+    )
+
+    # A K site has all coordinates even. Two steps return to K iff they
+    # backtrack or continue straight along the same axis; odd lengths cannot
+    # connect equal bipartite parity.
+    directions = [(axis, sign) for axis in range(4) for sign in (-1, 1)]
+    two_step = []
+    for first, second in itertools.product(directions, repeat=2):
+        endpoint = [0, 0, 0, 0]
+        endpoint[first[0]] += first[1]
+        endpoint[second[0]] += second[1]
+        if all(coordinate % 2 == 0 for coordinate in endpoint):
+            two_step.append((first, second, tuple(endpoint)))
+    backtracks = sum(first[0] == second[0] and first[1] == -second[1] for first, second, _ in two_step)
+    straight = sum(first == second for first, second, _ in two_step)
+    checks.append(
+        (
+            "shortest_path_classification",
+            len(two_step) == 16 and backtracks == 8 and straight == 8,
+            f"returning_two_step={len(two_step)}, backtracks={backtracks}, straight={straight}",
+        )
+    )
+    endpoint_counts = {(0, 0, 0, 0): 1}
+    odd_returns = []
+    even_returns = []
+    for length in range(1, 7):
+        updated: dict[tuple[int, ...], int] = defaultdict(int)
+        for endpoint, count in endpoint_counts.items():
+            for axis, sign in directions:
+                target = list(endpoint)
+                target[axis] += sign
+                updated[tuple(target)] += count
+        endpoint_counts = updated
+        returns = sum(
+            count
+            for endpoint, count in endpoint_counts.items()
+            if all(value % 2 == 0 for value in endpoint)
+        )
+        (odd_returns if length % 2 else even_returns).append(returns)
+    checks.append(
+        (
+            "odd_schur_path_parity",
+            odd_returns == [0, 0, 0] and all(value > 0 for value in even_returns),
+            f"odd_return_counts={odd_returns}, even_return_counts={even_returns}",
+        )
+    )
+
+    # Coordinate-free shortest center S2=mI+m^{-1}BB^dagger has gap m.
+    momenta = tuple(2.0 * math.pi * index / 8.0 for index in range(8))
+    center_eigenvalues = [
+        mass + 2.0 / mass - sum(math.cos(momentum) for momentum in row) / (2.0 * mass)
+        for row in itertools.product(momenta, repeat=4)
+    ]
+    checks.append(
+        (
+            "shortest_quadratic_center_gap",
+            min(center_eigenvalues) >= mass - 1.0e-12
+            and max(center_eigenvalues) <= mass + 4.0 / mass + 1.0e-12,
+            f"U=1 momentum spectrum min={min(center_eigenvalues):.12f}, max={max(center_eigenvalues):.12f}, gap>={mass:g}",
+        )
+    )
+
+    # Exact field torsor between mass-adapted charts.
+    mass_prime = 0.99 * mass
+    eta_prime = mass_prime**-0.5
+    rho = eta_prime / adapted_eta
+    torsor_rows = []
+    for pairs in range(4):
+        lhs = eta_prime ** (2 * pairs) * rho ** (-2 * pairs)
+        rhs = adapted_eta ** (2 * pairs)
+        torsor_rows.append(math.isclose(lhs, rhs, rel_tol=1.0e-14, abs_tol=1.0e-30))
+    size_cost = math.exp(3.0 * math.log(mass / mass_prime))
+    checks.append(
+        (
+            "running_mass_chart_torsor",
+            all(torsor_rows)
+            and math.isclose(rho**-2 * mass, mass_prime, rel_tol=1.0e-14)
+            and size_cost > 1.0,
+            f"m'={mass_prime:g}, rho={rho:.12f}, transformed_mass={rho**-2*mass:.12f}, one_site_identity_cost={size_cost:.12f}",
+        )
+    )
+
+    c, theta, lam = 0.001, 1.0e-6, 1.0
+    rows = residual_rows(mass, c, theta, lam, adapted_eta)
+    residual = rows["K_residual"]
+    attachment = attachment_constants(residual, c)
+    conversion = 68.0 * math.exp(lam / 2.0)
+    old_activity = rows["K_S_two"] + residual
+    old_base_defect = conversion * old_activity
+    old_source_radius = math.log1p(c - old_activity)
+    q_centered = conversion * attachment["A_att"]
+    q_split = max(math.exp(-lam / 2.0), q_centered)
+    base_residual = conversion * residual
+    checks.append(
+        (
+            "quadratic_center_residual_activity",
+            rows["K_S_two"] > 1.0e-5
+            and rows["K_S_residual"] < 2.6e-11
+            and residual < 2.8e-11
+            and old_base_defect > old_source_radius,
+            "K_S2={:.15e}, K_S_even>=4={:.15e}, K_I={:.15e}, K_res={:.15e}, old_B={:.15e}>old_r_src={:.15e}".format(
+                rows["K_S_two"],
+                rows["K_S_residual"],
+                rows["K_I"],
+                residual,
+                old_base_defect,
+                old_source_radius,
+            ),
+        )
+    )
+    checks.append(
+        (
+            "residual_marked_attachment",
+            attachment["tau"] < 2.0e-8
+            and q_centered < 3.0e-6
+            and math.isclose(q_split, math.exp(-0.5), rel_tol=1.0e-14)
+            and base_residual < 3.1e-9,
+            "tau={:.15e}, A_att={:.15e}, q_centered={:.15e}, q_split={:.12f}, B_res={:.15e}".format(
+                attachment["tau"], attachment["A_att"], q_centered, q_split, base_residual
+            ),
+        )
+    )
+
+    source_radius = math.log1p(c - residual)
+    delta = 1.0e-8
+    hessian = 2.0 * conversion * c / (source_radius - delta) ** 2
+    ball_left = base_residual + q_split * delta + 0.5 * hessian * delta**2
+    checks.append(
+        (
+            "conditional_ball_scalar_feasibility",
+            ball_left < delta,
+            f"r_src={source_radius:.15e}, delta={delta:.1e}, M_delta={hessian:.9f}, lhs={ball_left:.15e}",
+        )
+    )
+
+    text = NOTE.read_text()
+    required = [
+        "**Type:** bounded_theorem",
+        "eta_m=m^(-1/2)",
+        "S^(2)",
+        "not yet an autonomous invariant ball",
+        "No axiom-update stop",
+        "### N1",
+        "### N2",
+        "### N3",
+        "### N4",
+        "### N5",
+        "### N6",
+        "### N7",
+        "### N8",
+    ]
+    missing = [item for item in required if item not in text]
+    forbidden = ["physical running mass is selected", "proves a critical trajectory", "NOT_TESTED"]
+    hits = [item for item in forbidden if item in text]
+    checks.append(("source_contract", not missing and not hits, f"missing={missing}, forbidden_hits={hits}"))
+
+    expected_dependencies = sorted(
+        [
+            "MASSIVE_WILSON_STAGGERED_FACTOR_TWO_GAUGE_BLOCK_SCHUR_OS_SEMIGROUP_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_CURRENT_CHART_AUTONOMY_AND_NEXT_SCALE_GRASSMANN_HANDOFF_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_K_RETAINING_MARKED_ATTACHMENT_STRONG_WEAK_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+        ]
+    )
+    dependencies = sorted(set(re.findall(r"\]\(([^)#?]+\.md)\)", text)))
+    checks.append(
+        (
+            "repository_dependency_set",
+            dependencies == expected_dependencies,
+            f"markdown_dependency_set={dependencies}",
+        )
+    )
+
+    passed = sum(ok for _, ok, _ in checks)
+    failed = len(checks) - passed
+    for name, ok, detail in checks:
+        print(f"{'PASS' if ok else 'FAIL'} {name}: {detail}")
+    print(f"SCORECARD PASS={passed} FAIL={failed}")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Result

This block repairs the Gaussian-reference side of the next-scale handoff and extracts the leading shortest Schur term into the running quadratic center.

- proves a finite-set covariance-minor bound for normalized Gaussian Berezin expectation; eta=m^(-1/2) makes the fifteen-site tensor norm exactly one rather than 10^720
- constructs a finite-horizon multi-index Haar/on-site-Gaussian atom algebra with constant one and a contractive nonempty-tag scale shift
- classifies all retained two-hop paths and proves every odd Schur length vanishes by bipartite parity
- extracts the exact hidden-fiber-constant quadratic kernel S^(2)=mI+m^(-1)M_KI M_KI^dagger, including its coarse-link form, gauge covariance, and gap at least m
- reduces the current bare residual activity at the displayed point to 2.747447e-11, with the current product-Haar split bound returning to q=exp(-1/2)
- makes the prior scalar ball inequality feasible, while explicitly leaving correlated-Gaussian forced attachment, actual-range tagged membership, running-gap persistence, and the same-norm Hessian open

The marked-attachment constants are not transferred through a correlated Gaussian reference. No autonomous RG, fixed-point, critical-continuum, physical taste/mass, or axiom-update claim is made.

## Verification

- runner: PASS=14 FAIL=0
- independent code/math review: PASS WITH BOUNDED CLAIMS
- independent physics/import/Nature review: PASS WITH BOUNDED CLAIMS
- independent governance and No-Go Discipline review: PASS
- vocabulary lint: zero violations
- audit pipeline and strict lint: zero errors
- seeded row: bounded_theorem / unaudited with exactly five declared dependencies
- generated audit/effective-status outputs stripped

Independent audit remains authoritative.