### PR TITLE
physics: lift residual clusters with Hoeffding lineage

### DIFF
--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
@@ -1,6 +1,44 @@
 # Handoff
 
 Current branch:
+`physics-loop/record-faithful-dynamics-block35-tagged-residual-cluster-20260712`.
+The one-horizon Haar--Berezin Hoeffding lineage-cluster runner reports
+`PASS=13 FAIL=0`. For the complete current bare residual factor family, every
+factor has a canonical product-coordinate Hoeffding decomposition and the
+decorated hard-core logarithm evaluates exactly to the original residual
+cluster logarithm.
+
+The conservative factor activities charge Wilson factors by at most four
+hidden Haar coordinates, determinant paths of length `r` by at most `r`, and
+Schur paths by at most `r+2`, with `C_*=3+2sqrt(2)`. At the displayed witness,
+`K_tag=9.967013e-7<c`; marked-lineage attachment gives
+`A_att=7.342847e-4` and a finite `B_tag=1.117432e-4`. This is not yet an
+invariant-ball row.
+
+The actual factor audit is explicit: retained determinant loops use only
+nonskeleton interior links, Schur paths have exactly two skeleton boundary
+links, repeated-coordinate Haar projection is included, and a length-four
+Schur witness reduces to a coarse `V` while its current Haar tag is empty.
+Current atom tags can also disappear under products or integration. Formal
+lineage is therefore retained only as metadata; it is not identified with
+geometric support or assumed to survive the next blocking step.
+
+Independent code/math, physics/import/Nature, and governance/no-go reviews
+pass. Audit validation seeds one `bounded_theorem` / `unaudited` row with
+exactly four dependencies; the full pipeline and strict lint have zero errors
+and generated outputs are stripped. No tag-density, multiscale autonomy,
+correlated-Gaussian attachment, continuum, or axiom-update claim is made.
+
+One-horizon decorated lineage-cluster stacked PR:
+https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5343
+is open against the Gaussian-adapted quadratic-center head.
+
+Next exact action: retain full decorated coefficients, substitute the next
+skeleton, re-Hoeffding-atomize in the new hidden variables, and prove an
+evaluation-commuting two-level tag-update bound. Then attack correlated-
+covariance locality/attachment and same-norm return.
+
+Previous branch:
 `physics-loop/record-faithful-dynamics-block34-haar-berezin-running-center-20260712`.
 The Gaussian-adapted Berezin/quadratic-center runner reports `PASS=14 FAIL=0`.
 For every finite hidden set with `sigma_min(A_II)>=m`, covariance minors give

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
@@ -1,5 +1,22 @@
 # PR Delivery
 
+The one-horizon Haar--Berezin Hoeffding lineage-cluster lift is delivered:
+
+- base: `physics-loop/record-faithful-dynamics-block34-haar-berezin-running-center-20260712`
+- head: `physics-loop/record-faithful-dynamics-block35-tagged-residual-cluster-20260712`
+- runner: `PASS=13 FAIL=0`
+- scope: exact decorated-factor evaluation to the complete current residual
+  cluster system; conservative tagged KP and marked-lineage bounds; explicit
+  actual-factor, repeated-coordinate, empty-tag, and SU(3) singlet witnesses;
+  no tag density, tag survival, multiscale autonomy, correlated-Gaussian
+  attachment, or invariant ball
+- review: independent code/math, physics/import/Nature, and governance/no-go pass
+- audit compatibility: one `bounded_theorem` / `unaudited` row with exactly
+  four dependencies; full pipeline and strict lint pass; generated outputs stripped
+- PR: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5343
+
+No merge is authorized. Independent audit remains authoritative.
+
 The Gaussian-adapted Berezin handoff and shortest quadratic center is delivered:
 
 - base: `physics-loop/record-faithful-dynamics-block33-autonomous-shadow-norm-20260712`

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
@@ -1037,3 +1037,37 @@ same-norm Hessian as open. Runner/cache are `PASS=14 FAIL=0`; audit validation
 seeds one `bounded_theorem` / `unaudited` row with exactly five dependencies;
 strict lint has zero errors and generated outputs are stripped. PR #5342 is
 open. No axiom-update stop is triggered.
+
+## One-horizon Haar--Berezin Hoeffding lineage-cluster review
+
+PASS WITH BOUNDED CLAIMS after the factor grammar, tag semantics, and marked-
+reuse proofs were made explicit. On the current independent hidden Haar and
+onsite Gaussian coordinates, the canonical multi-index Hoeffding atoms obey
+the finite-horizon algebra estimate with `r_*=1+sqrt(2)` and
+`C_*=3+2sqrt(2)`. Decorating each residual factor by its atom subset and
+running the hard-core logarithm without merging lineages gives an exact
+evaluation identity back to the original complete residual cluster system.
+
+Physics/import review checked the actual Wilson, determinant, and Schur factor
+grammar. Determinant loops in `det D_II` use nonskeleton interior links, while
+Schur paths carry two skeleton boundary links. The repeated-coordinate Haar
+identity and an explicit length-four path show why syntactic support is not a
+genuine tag: the path reduces to coarse `V` with an empty current Haar atom.
+The SU(3) epsilon singlet and the nonmultiplicativity of centered projections
+likewise prevent any tag-survival shortcut. The future rule must retain the
+full coefficient, substitute the next skeleton, and re-atomize.
+
+Code/math review independently reconstructed the atom bound, evaluation map,
+finite decorated logarithm, all conservative activities, and marked-lineage
+constants. At the witness, `K_tag=9.96701305855e-7<c`,
+`A_att=7.34284716321e-4`, and `B_tag=1.11743219758e-4`; the safe old Cauchy
+row does not yield an invariant ball. Governance/no-go review passes the full
+N1--N8 packet, including the attempted direct-survival and genuine-syntactic-
+tag routes and the exact residual-match check.
+
+Runner/cache: `PASS=13 FAIL=0`. Audit validation seeds one `bounded_theorem` /
+`unaudited` row with exactly four dependencies; the full pipeline and strict
+lint have zero errors and generated outputs are stripped. PR #5343 is open.
+The next target is a two-level evaluation-commuting re-atomization cocycle,
+then correlated-covariance locality and attachment. No axiom-update stop is
+triggered.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
@@ -8,34 +8,36 @@ current_goal: >-
   supply the physical evolution object, bare time ordering, record-formation
   weights, and an admissibility-to-carrier selector without importing the
   staggered/Dirac answer or sector-specific Standard Model and gravity laws.
-branch: physics-loop/record-faithful-dynamics-block34-haar-berezin-running-center-20260712
+branch: physics-loop/record-faithful-dynamics-block35-tagged-residual-cluster-20260712
 base_commit_at_start: 9d1636f05f
-cycle_count: 34
-block_count: 34
-active_route: wilson_staggered_gaussian_adapted_berezin_shortest_quadratic_center
+cycle_count: 35
+block_count: 35
+active_route: wilson_staggered_one_horizon_haar_berezin_hoeffding_lineage_cluster_lift
 hard_residual: >-
   Can the four-axiom record surface canonically determine a faithful local
   record-forming instrument whose coherent no-record block is sufficiently
   constrained to exclude the observationally disconnected SWAP--Laplacian
   completion and select the Clifford-vector carrier?
-produced_claim_id: wilson_staggered_gaussian_adapted_berezin_handoff_and_shortest_quadratic_center_bounded_theorem_note_2026-07-12
+produced_claim_id: wilson_staggered_one_horizon_haar_berezin_hoeffding_lineage_cluster_lift_bounded_theorem_note_2026-07-12
 actual_current_surface_status: bounded-support
 conditional_surface_status: >-
-  A uniform singular gap and eta=m^(-1/2) make normalized Gaussian Berezin
-  expectation contractive at every finite tensor depth. Independent product
-  coordinates admit a finite-horizon constant-one multi-index atom algebra.
-  The exact fiber-constant r=2 Schur kernel is extracted into a positive
-  gauge-covariant quadratic center; odd paths vanish, leaving a bare residual
-  row 2.747e-11 and q=exp(-1/2). Correlated-Gaussian attachment, actual-range
-  tagged membership, running-gap persistence, and same-norm iteration remain
+  The complete current bare residual factor family has an exact one-horizon
+  decorated Haar--Berezin Hoeffding lift whose evaluation recovers the
+  original residual cluster logarithm. Safe tagged activities satisfy
+  K_tag=9.967013e-7<c at the displayed witness and give a finite marked
+  attachment row. The construction retains formal lineages without asserting
+  physical tag survival: next-skeleton substitution can erase current tags.
+  A future-coordinate re-atomization cocycle, correlated-Gaussian attachment,
+  running-gap persistence, same-norm iteration, and an invariant ball remain
   open.
 admitted_observation_status: none
 claim_type_reason: >-
-  The source proves exact fixed-gap Gaussian coefficient control, a finite-
-  horizon independent-factor atom algebra, the shortest quadratic Schur
-  kernel and parity extraction, and the repaired current bare residual row.
-  It explicitly does not transfer product-Haar marked attachment to a
-  correlated Gaussian or claim an autonomous RG self-map.
+  The source proves an exact finite-horizon decorated-factor evaluation map,
+  controls the complete present residual factor grammar with conservative
+  Hoeffding activities, and verifies marked-cluster reuse on formal lineages.
+  It explicitly distinguishes syntactic carriers, nonzero atom tags, formal
+  lineages, and geometric tree span, and does not claim tag density, tag
+  survival, correlated-Gaussian attachment, or an autonomous RG self-map.
 hypothetical_axiom_status: null
 proposal_allowed: false
 proposal_allowed_reason: >-
@@ -147,6 +149,9 @@ files_touched:
   - docs/WILSON_STAGGERED_GAUSSIAN_ADAPTED_BEREZIN_HANDOFF_AND_SHORTEST_QUADRATIC_CENTER_BOUNDED_THEOREM_NOTE_2026-07-12.md
   - scripts/wilson_staggered_gaussian_adapted_berezin_quadratic_center_2026_07_12.py
   - logs/runner-cache/wilson_staggered_gaussian_adapted_berezin_quadratic_center_2026_07_12.txt
+  - docs/WILSON_STAGGERED_ONE_HORIZON_HAAR_BEREZIN_HOEFFDING_LINEAGE_CLUSTER_LIFT_BOUNDED_THEOREM_NOTE_2026-07-12.md
+  - scripts/wilson_staggered_one_horizon_hoeffding_lineage_cluster_lift_2026_07_12.py
+  - logs/runner-cache/wilson_staggered_one_horizon_hoeffding_lineage_cluster_lift_2026_07_12.txt
 open_imports:
   - fundamental process object: Hamiltonian, strict tick, or record instrument
   - faithful law-to-record influence principle
@@ -198,10 +203,11 @@ no_go_routes:
   - a strict one-step strong-to-weak derivative contraction does not by itself return the coarse action to the same strong split norm or control a running center and nonlinear invariant ball
   - the full certified weak completion has no support-only embedding into the present next-step strong norm, and the present ultra-small eta makes the next Gaussian Berezin conditioning enormous; this does not rule out actual-range provenance, running Gaussian centers, or multi-index Haar--Berezin norms
   - Gaussian adaptation and shortest-quadratic extraction repair the fixed-gap tensor norm and current bare residual constants, but do not by themselves supply correlated-reference forced attachment, full actual-range tag membership, or a persistent running gap
+  - the one-horizon decorated Hoeffding lift exactly evaluates to the current residual cluster system, but current Haar tags can disappear after integration or next-skeleton substitution; formal lineage therefore cannot be propagated as physical multiscale support without re-atomization
 trace_gate_classification: direct_blocker_closure
 reachability_to_target: partially_closes
-review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_two_layer_source_polymer_pass_retained_grassmann_polymer_norm_pass_declared_rg_chart_pass_split_derivative_certificate_boundary_pass_marked_attachment_strong_weak_contraction_pass_current_chart_autonomy_handoff_pass_gaussian_berezin_quadratic_center_pass_bounded
-pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open_two_layer_source_polymer_open_retained_grassmann_polymer_norm_open_declared_rg_chart_open_split_derivative_certificate_boundary_open_marked_attachment_strong_weak_contraction_open_current_chart_autonomy_handoff_open_gaussian_berezin_quadratic_center_open
+review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_two_layer_source_polymer_pass_retained_grassmann_polymer_norm_pass_declared_rg_chart_pass_split_derivative_certificate_boundary_pass_marked_attachment_strong_weak_contraction_pass_current_chart_autonomy_handoff_pass_gaussian_berezin_quadratic_center_pass_one_horizon_lineage_cluster_lift_pass_bounded
+pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open_two_layer_source_polymer_open_retained_grassmann_polymer_norm_open_declared_rg_chart_open_split_derivative_certificate_boundary_open_marked_attachment_strong_weak_contraction_open_current_chart_autonomy_handoff_open_gaussian_berezin_quadratic_center_open_one_horizon_lineage_cluster_lift_open
 block01_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5178
 block02_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5181
 block03_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5201
@@ -236,14 +242,15 @@ block31_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/
 block32_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5338
 block33_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5340
 block34_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5342
+block35_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5343
 next_exact_action: >-
-  Prove a tagged cluster expansion for the complete current residual factor
-  family, including non-pure Haar words, Grassmann endpoint contractions, and
-  skeleton-cancellation transfer into future coarse-link tags. Then extend
-  forced attachment through the correlated running covariance with an explicit
-  locality/cluster bound and prove the resulting actual RG range returns to a
-  uniform strong provenance norm. Only then derive the same-norm Hessian and
-  invariant ball.
+  Construct the two-level future-coordinate tag-update cocycle: retain every
+  full decorated coefficient, substitute the next skeleton exactly, and
+  re-Hoeffding-atomize in the new hidden variables. Prove an evaluation-
+  commuting bound that survives current-tag erasure. Then extend forced
+  attachment through the correlated running covariance with an explicit
+  locality/cluster bound and return the actual RG range to a uniform strong
+  provenance norm. Only then derive the same-norm Hessian and invariant ball.
 stop_condition: >-
   Stop and discuss an axiom update only if an exact result proves that the
   required bridge cannot be derived and an additional approved axiom or

--- a/docs/WILSON_STAGGERED_ONE_HORIZON_HAAR_BEREZIN_HOEFFDING_LINEAGE_CLUSTER_LIFT_BOUNDED_THEOREM_NOTE_2026-07-12.md
+++ b/docs/WILSON_STAGGERED_ONE_HORIZON_HAAR_BEREZIN_HOEFFDING_LINEAGE_CLUSTER_LIFT_BOUNDED_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,403 @@
+# One-horizon Haar--Berezin Hoeffding lineage cluster lift
+
+**Date:** 2026-07-12
+**Type:** bounded_theorem
+**Status:** unaudited candidate; effective status is pipeline-derived only after independent audit.
+**Primary runner:** [`scripts/wilson_staggered_one_horizon_hoeffding_lineage_cluster_lift_2026_07_12.py`](../scripts/wilson_staggered_one_horizon_hoeffding_lineage_cluster_lift_2026_07_12.py)
+**Cached output:** [`logs/runner-cache/wilson_staggered_one_horizon_hoeffding_lineage_cluster_lift_2026_07_12.txt`](../logs/runner-cache/wilson_staggered_one_horizon_hoeffding_lineage_cluster_lift_2026_07_12.txt)
+
+## 0. Result
+
+The complete current bare residual factor family has an exact, regulator-
+uniform, one-horizon decorated Haar--Berezin cluster lift. Forgetting the
+decoration evaluates exactly to the ordinary residual action. This supplies
+genuine factor/cluster provenance, but not yet a scale-to-scale tag-density or
+autonomous-norm theorem.
+
+Use the exact residual Wilson/determinant/Schur factor grammar and two-layer
+cluster lemma from the
+[simultaneous retained-Grassmann theorem](WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md),
+including its
+[syntactic-support source theorem](WILSON_STAGGERED_CONSTRAINED_FIBER_TWO_LAYER_KP_COMPLEX_SOURCE_POLYMER_BOUNDED_THEOREM_NOTE_2026-07-12.md),
+the K-retaining output conversion from the
+[marked-attachment theorem](WILSON_STAGGERED_K_RETAINING_MARKED_ATTACHMENT_STRONG_WEAK_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md),
+and the shortest-center/atom algebra from the
+[Gaussian-adapted quadratic-center theorem](WILSON_STAGGERED_GAUSSIAN_ADAPTED_BEREZIN_HANDOFF_AND_SHORTEST_QUADRATIC_CENTER_BOUNDED_THEOREM_NOTE_2026-07-12.md).
+
+For each independent hidden Haar coordinate and each retained endpoint site,
+use respectively its normalized Haar expectation and the onsite three-color
+Gaussian expectation at `eta=m^(-1/2)`. Put
+
+```text
+r_*=1+sqrt(2),                 C_*=r_*^2=3+2sqrt(2).                (0.1)
+```
+
+If a factor `f_a` depends on `n_a` such product coordinates, its canonical
+Hoeffding components obey
+
+```text
+f_a=sum_(T subset J_a) Delta_T f_a,
+sum_T r_*^|T| ||Delta_T f_a||
+ <=C_*^n_a ||f_a||.                                                (0.2)
+```
+
+After extracting the full shortest quadratic center, every residual Schur
+length is even and at least four. The safe coordinate counts are
+
+```text
+n_a<=4                  for a Wilson plaquette,
+n_a<=r                  for an eliminated-determinant word of length r,
+n_a<=r+2                for a Schur word of length r.              (0.3)
+```
+
+The last two coordinates are the two retained endpoint sites; treating all
+three colors at one site as one Gaussian tensor factor avoids a spurious
+color-multiplicity charge.
+
+Let `h=4/m`, `L=Theta+2c+Lambda`,
+`x_r=9 eta^2 2^(-r)m^(-(r-1))`, and `g(x)=(exp(x)-1)/x`. A safe black-box
+tagged activity majorant is
+
+```text
+K_W^tag=12 [exp((3 beta/4)C_*^4)-1] exp(4L),                      (0.4)
+
+K_I^tag=(3/2)sum_(even r>=4)
+          C_*^r h^r g(3C_*^r h^r/r) exp(rL),                      (0.5)
+
+K_S^tag=18 eta^2 sum_(even r>=4)
+          C_*^(r+2) r h^(r-1) g(C_*^(r+2)x_r) exp(rL),            (0.6)
+
+K_tag=K_W^tag+K_I^tag+K_S^tag.                                   (0.7)
+```
+
+At
+
+```text
+m=10000, beta=0, c=0.001, Theta=10^(-6), Lambda=1,
+eta=0.01,                                                           (0.8)
+```
+
+the exact series give
+
+```text
+q_hop^tag=h C_* exp(L)=0.006350016695825...,
+K_I^tag=2.438980005374... 10^(-9),
+K_S^tag=9.942623258493... 10^(-7),
+K_tag=9.967013058547... 10^(-7)<c.                                 (0.9)
+```
+
+Thus both factor-to-polymer grouping and the hard-core logarithm converge in
+the decorated coefficient algebra. Their K-retaining coarse conversion gives
+
+```text
+||Gamma_hat_res||_(Lambda/2,Theta/2,eta;lineage)
+ <=68 exp(Lambda/2)K_tag
+ =1.11743219758... 10^(-4).                                       (0.10)
+```
+
+The residual marked-source formulas remain below one:
+
+```text
+q_centered^tag=0.082322896477...,
+q_split^tag=max{exp(-1/2),q_centered^tag}=0.606530659713... .       (0.11)
+```
+
+The base defect in (0.10) is too large for the old scalar Cauchy ball
+certificate at this point. More importantly, (0.11) is still a one-horizon
+decorated estimate. It does not prove that lineage tags become next-scale
+canonical atoms or occur with density proportional to coarse support.
+
+## 1. Canonical factor atoms
+
+Let `J_a` contain the declared hidden Haar coordinates in the syntactic
+support of `f_a` and, for a Schur factor, its at-most-two retained endpoint
+sites. For `i in J_a`, let `E_i` be the corresponding tensor-factor
+expectation and `Q_i=1-E_i`. Define
+
+```text
+Delta_T=product_(i in T)Q_i product_(i in J_a minus T)E_i.          (1.1)
+```
+
+Three labels remain distinct throughout:
+
+- `Sigma_a=J_a` is the nonminimal syntactic carrier used for overlap geometry;
+- `T_a` is a genuine nonzero canonical atom subset;
+- `mathcal L` is the formal nonquotient list of original factor/atom choices.
+
+The previously declared `ell(Sigma_a)` is the support-tree span and is never a
+lineage label.
+
+The even coordinate maps commute, so
+
+```text
+sum_(T subset J_a)Delta_T=product_i(E_i+Q_i)=1.                    (1.2)
+```
+
+Every `E_i` is contractive and `||Q_i||<=2`. Therefore
+
+```text
+||Delta_T f_a||<=2^|T| ||f_a||,
+sum_T r_*^|T| ||Delta_T f_a||
+ <=sum_T(2r_*)^|T| ||f_a||
+ =(1+2r_*)^n_a ||f_a||
+ =C_*^n_a ||f_a||.                                                 (1.3)
+```
+
+This is a black-box upper bound. If a syntactic coordinate is dummy after an
+`A A^(-1)V` cancellation, its `Q_i` component is exactly zero. Charging it by
+`C_*` is safe overcount, not evidence of a genuine tag.
+
+The retained-body geometry is sharper than the black-box count. A determinant
+word lies entirely in the eliminated `I-I` graph. No skeleton fine link can
+occur because every skeleton link has a retained `K=(2Z)^4` endpoint. A Schur
+word has exactly two skeleton boundary links; all internal `I-I` links are
+nonskeleton. Thus skeleton-to-future-`V` transfer is a Wilson/Schur issue, not
+an eliminated-determinant issue.
+
+If the two Schur boundary occurrences use the same skeleton coordinate, the
+exact Haar split is
+
+```text
+E_A[A M A^(-1)V]=(Tr M/3)V,
+Q_A[A M A^(-1)V]=[A M A^(-1)-(Tr M/3)I]V.                         (1.4)
+```
+
+For `M=I`, only the empty atom remains; for `Tr M=0`, the word is pure `Q_A`;
+generically both sectors occur. Atomization must be applied to the actual
+activity, not merely its primitive transporter. For example, if
+`B=bar psi A psi`, the factor `exp(B)-1` has `E_A B=E_A B^2=0` but a generally
+nonzero `E_A B^3`, because the `SU(3)` three-fundamental Haar integral contains
+the epsilon--epsilon singlet. Determinant exponentials likewise acquire empty
+atoms from invariant channels in their powers. This is why (0.4)--(0.6) use
+the black-box potential-level algebra bound rather than a pure-`Q` shortcut.
+
+An explicit residual `r=4` Schur path makes the distinction unavoidable:
+
+```text
+K0 --A--> z --H--> w --H^(-1)--> z --A^(-1)V--> K1.               (1.5)
+```
+
+Its transporter reduces to `V`. Its declared syntactic carrier contains
+`{A,H}`, but its genuine current Haar atom is empty. The evaluated extended
+quadratic must be extracted into a fuller center or atomized after the next
+coarse-link pullback; current dummy charges cannot provide a downshift gain.
+
+The evaluated split/Hoeffding algebra has constant one because
+`r_*^2=1+2r_*` pays the local fusion `Q_iQ_i -> E_i+Q_i`. Separately, the
+decorated coefficient algebra is the weighted `l1` free direct sum of atom
+lineages. A lineage records the original factor label and its actual nonzero
+subset `T`; multiplication concatenates lineages rather than quotienting equal
+evaluated coefficients. Its tensor-projective `l1` product has constant one
+directly. Evaluation performs all fusion only after summing the exact
+coefficients.
+
+## 2. Exact decorated cluster lift and evaluation
+
+For an overlap-connected original factor set `Gamma`, choose one atom subset
+`T_a subset J_a` for every `a in Gamma` and define
+
+```text
+w_hat_(Gamma,{T_a})
+ =integral product_(a in Gamma) Delta_(T_a)f_a dH_(Y_Gamma).        (2.1)
+```
+
+The retained Gaussian expectations in (1.1) are formal coefficient
+decompositions only; the physical current bare fiber integral in (2.1) is the
+same product Haar integral as before. Finite reconstruction and linearity give
+
+```text
+sum_({T_a}) w_hat_(Gamma,{T_a})
+ =integral product_(a in Gamma)f_a dH_(Y_Gamma)
+ =w_Gamma.                                                         (2.2)
+```
+
+Run the second hard-core logarithm without merging decorated labels. A
+decorated logarithmic cluster consists of its original hard-core cluster,
+every original factor label, and every selected atom subset. Let `ev` forget
+those subsets and sum their coefficients. Absolute convergence permits
+Fubini/reconstruction term by term, proving
+
+```text
+ev(Gamma_hat_res)=Gamma_res.                                       (2.3)
+```
+
+Equation (2.3) is load-bearing. Ordinary nonempty Hoeffding atoms do not
+survive full expectation:
+
+```text
+E_all Delta_T=0,                   T nonempty.                      (2.4)
+```
+
+Products of centered atoms can nevertheless have nonzero expectation. The
+decoration that survives is therefore formal cluster lineage with the exact
+evaluation map (2.3), not the ordinary Hoeffding decomposition of the coarse
+output.
+
+Normalized Haar expectations and the onsite color-scalar Gaussian expectation
+intertwine coarse gauge transformations. Blocked translations and proper
+cubic rotations permute coordinate slots; the compatible reflection permutes
+or dualizes them. Therefore atom subsets and lineages transform in symmetry
+orbits, while every evaluated coefficient in (2.3) remains jointly gauge
+invariant, even-balanced, and compatible with the declared symmetries.
+
+## 3. Tagged activity criterion
+
+The residual factors have the coordinate counts (0.3). For the safest
+potential-level bound, first apply (1.3) to each Wilson potential,
+determinant potential, or Schur bilinear, then use submultiplicativity of the
+constant-one atom algebra to exponentiate. This gives (0.4)--(0.6). No claim
+that a general determinant or Schur activity is pure centered in every
+coordinate is used.
+
+The tagged first-layer rooted-tree recursion is the same nonnegative
+majorant, with each scalar/Banach activity norm replaced by its decorated
+`l1` norm. If `K_tag<c`, the actual tagged root row remains `K_tag`, while the
+two copies of `c` still pay connected grouping and hard-core exclusion. This
+proves regulator-uniform convergence and (0.10).
+
+For a decorated mark whose evaluated coefficient is `Q_0`-centered, every
+formal endpoint-atom projection remains Haar-centered because the coordinate
+maps commute. Its mark-only first-layer coefficient therefore vanishes under
+the physical product-Haar integral. The free-lineage `l1` norm is
+submultiplicative, so both marked-path rerooting arguments apply with `K`
+replaced by `K_tag`, proving (0.11).
+
+At beta zero, the Wilson row vanishes. Solving `K_tag<c` with (0.4) gives the
+strict nonzero interval
+
+```text
+0<=beta<1.7476907... 10^(-9)                                      (3.1)
+```
+
+at the other parameters in (0.8). This is a mathematical neighborhood, not a
+phenomenological gauge-coupling region.
+
+## 4. What the lineage does not yet do
+
+The lift is exact for the complete current bare residual action and uniform in
+the finite regulator. It is one RG horizon only.
+
+- A nonempty current hidden tag can disappear under Haar integration; its
+  formal lineage does not automatically become a next-scale cancellation tag.
+- Empty-tag lineages and extended coefficients are not automatically vacuum,
+  center, or raw lifted coordinates; every lineage still records its original
+  factor label.
+- Dummy syntactic support may be charged in (1.3), but cannot supply tag
+  density or a scale-shift gain.
+- The theorem does not decompose dependence on future coarse links into
+  canonical future atoms or prove a tag-update cocycle.
+- The correlated running Gaussian still needs its own covariance-locality and
+  marked-attachment theorem.
+
+Consequently there is no same-norm self-map, invariant ball, fixed point,
+critical trajectory, or continuum result. No axiom-update stop is established.
+
+The exact next-horizon algebraic rule is nevertheless clear: retain and
+evaluate the full coarse coefficient, substitute the next skeleton chart
+`V_1=A'`, `V_2=A'^(-1)W`, and only then perform the next product-Haar
+Hoeffding decomposition. A coarse support is an upper carrier, not a tag:
+`V_1V_2=W` can erase the next `A'` atom. Boolean lineage metadata without the
+full evaluated coefficient is therefore insufficient for iteration.
+
+## 5. Runner contract
+
+Run:
+
+```bash
+python3 scripts/wilson_staggered_one_horizon_hoeffding_lineage_cluster_lift_2026_07_12.py
+```
+
+The runner checks the exact `r_*` identities, canonical finite-product
+Hoeffding reconstruction, the black-box atom bound, dummy-coordinate
+annihilation, nonzero products of centered atoms, decorated factor-collection
+evaluation, the tagged activity series and beta interval, marked constants,
+and the source/dependency contract. The two infinite cluster recursions use
+the displayed analytic KP majorant.
+
+## 6. No-Go Discipline N1--N8
+
+The result is constructive. The boundary packet prevents formal provenance
+from being mislabeled as autonomy.
+
+### N1 — alternative-route enumeration
+
+| Route | Status | Executed result |
+|---|---|---|
+| Canonical product-coordinate Hoeffding atoms | `ATTEMPTED` | Equations (1.1)--(1.3) instantiate the actual factor grammar. |
+| Black-box `C_*` charging | `ATTEMPTED` | Equations (0.4)--(0.9) give a strict tagged KP row. |
+| Direct survival of nonempty atoms | `ATTEMPTED` | Equation (2.4) shows individual nonempty atoms are annihilated. |
+| Decorated lineage lift | `ATTEMPTED` | Equations (2.1)--(2.3) give exact evaluation equality. |
+| Syntactic supports as genuine tags | `ATTEMPTED` | The dummy and `r=4` cancellation witnesses have zero `Q_i` components despite nonempty carriers. |
+
+Essential-support atomization, future-coordinate tags, tag-update cocycles,
+correlated-Gaussian clusters, Peter--Weyl smoothing, and taste-faithful blocks
+remain live and are not labeled attempted.
+
+### N2 — wall-independence audit
+
+The four conditions are `future-tag update/spatial handoff`, `correlated
+Gaussian attachment/running gap`, `physical taste/chart identification`, and
+`critical trajectory/observable identification`.
+
+| Left | Right | Left closes right? | Right closes left? | Independent? |
+|---|---|---:|---:|---:|
+| future-tag update | correlated Gaussian attachment | No | No | Yes |
+| future-tag update | physical taste/chart | No | No | Yes |
+| future-tag update | critical trajectory/observable | No | No | Yes |
+| correlated Gaussian attachment | physical taste/chart | No | No | Yes |
+| correlated Gaussian attachment | critical trajectory/observable | No | No | Yes |
+| physical taste/chart | critical trajectory/observable | No | No | Yes |
+
+### N3 — hidden-condition phrase scan
+
+| Phrase | Classification |
+|---|---|
+| `canonical atoms` | Canonical only relative to the declared product reference. |
+| `lineage` | Formal nonquotient metadata with evaluation (2.3). |
+| `actual residual action` | The current bare one-step residual only. |
+| `uniform` | Regulator-uniform at one horizon, not horizon-uniform. |
+| `support` | Syntactic support is an overcount and never promoted to genuine tag density. |
+| `same norm` | Explicitly absent. |
+| `autonomous` | Explicitly absent. |
+| `by construction` | No proof-substitute use. |
+
+### N4 — citation/residual matching
+
+| Dependency | Exact use | Match? |
+|---|---|---:|
+| [Retained-Grassmann theorem](WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Residual factors, Banach coefficient norm, incidence rows | Yes |
+| [Syntactic-support source theorem](WILSON_STAGGERED_CONSTRAINED_FIBER_TWO_LAYER_KP_COMPLEX_SOURCE_POLYMER_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Two-layer lemma, dummy-support and coarse conversion | Yes |
+| [Marked attachment](WILSON_STAGGERED_K_RETAINING_MARKED_ATTACHMENT_STRONG_WEAK_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md) | K-retaining output and optional marked constants | Yes |
+| [Gaussian-adapted center](WILSON_STAGGERED_GAUSSIAN_ADAPTED_BEREZIN_HANDOFF_AND_SHORTEST_QUADRATIC_CENTER_BOUNDED_THEOREM_NOTE_2026-07-12.md) | `r=2`/odd extraction and product-coordinate atom algebra | Yes |
+
+### N5 — rhetoric and resolution audit
+
+The factor grammar is complete for the current bare one-step action after
+shortest-center extraction. The decorated convergence is uniform in regulator
+size. Neither statement covers a ball of generated actions, multiple RG
+horizons, correlated covariance integration, or physical continuum scaling.
+
+### N6 — partial-closure and primitive scan
+
+Hoeffding projections, direct-sum lineage, and cluster evaluation are
+mathematical bookkeeping on declared regulator variables. They neither add
+nor require a physical action, probability, time, scale, taste, or state
+primitive. The missing tag-update/covariance theorem is not an axiom issue.
+
+### N7 — hostile steelman
+
+A hostile reviewer should object that formal tags can persist even when their
+evaluated coefficient loses all dependence on the tagged coordinate. Correct;
+that is why no shift contraction follows. Another should demand future coarse-
+coordinate atomization and correlated-covariance locality before iteration.
+Correct; both are the next live routes.
+
+### N8 — cross-cycle echo
+
+Earlier syntactic supports were safe for convergence but unsafe as genuine
+minimal supports. This theorem preserves that distinction: they bound the
+black-box atom cost, while only nonzero canonical components enter lineage.
+The resulting one-horizon lift is progress toward, not a relabeling of, an
+autonomous RG norm.
+
+**No-Go Discipline status: PASS.**

--- a/logs/runner-cache/wilson_staggered_one_horizon_hoeffding_lineage_cluster_lift_2026_07_12.txt
+++ b/logs/runner-cache/wilson_staggered_one_horizon_hoeffding_lineage_cluster_lift_2026_07_12.txt
@@ -1,0 +1,14 @@
+PASS hoeffding_weight_identity: r*=2.414213562373095, C*=r*^2=1+2r*=5.828427124746190
+PASS canonical_atom_reconstruction_and_bound: atoms=8, reconstruction_error=2.220e-16, atom_norm=2.548233764909<=black_box=259.373383669613
+PASS dummy_coordinate_has_no_tag: nonzero_tag_sets=[(), (0,)]
+PASS skeleton_cancellation_has_empty_current_atom: V-only transporter with syntactic A,H carrier has nonzero_tag_sets=[()]
+PASS centered_tags_do_not_survive_expectation: E[x]=0.0, E[x*x]=1.0
+PASS center_charge_allows_cubic_haar_singlet: SU3-center moments E[z],E[z^2],E[z^3]=[(3.700743415417188e-17+0j), (3.700743415417188e-17-7.401486830834377e-17j), (0.9999999999999997+1.060642464147365e-16j)]; Haar U11 U22 U33 epsilon coefficient=0.166667
+PASS decorated_factor_collection_evaluation: decorated_sum=0.023500000000000, direct_weight=0.023500000000000
+PASS decorated_hard_core_log_evaluation: nonzero_decorations=3, power_errors=[3.469446951953614e-18, 1.0842021724855044e-19, 6.776263578034403e-21, 1.5881867761018131e-22], log_partial=0.023228124713318
+PASS tagged_residual_activity_point: q_hop=6.350016695825048e-03, K_I=2.438980005374748e-09, K_S=9.942623258493337e-07, K=9.967013058547084e-07, margin=9.990032986941454e-04
+PASS strict_nonzero_beta_interval: beta_ceiling=1.747690723278375e-09, beta_probe=1.730213816045591e-09, K_probe=9.900099595330247e-04<c
+PASS tagged_marked_constants: tau=3.670317404266788e-04, A_att=7.342847163210340e-04, q_centered=8.232289647729789e-02, q_split=0.606530659713, B_tag=1.117432197578131e-04
+PASS source_contract: missing=[], forbidden_hits=[]
+PASS repository_dependency_set: markdown_dependency_set=['WILSON_STAGGERED_CONSTRAINED_FIBER_TWO_LAYER_KP_COMPLEX_SOURCE_POLYMER_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_GAUSSIAN_ADAPTED_BEREZIN_HANDOFF_AND_SHORTEST_QUADRATIC_CENTER_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_K_RETAINING_MARKED_ATTACHMENT_STRONG_WEAK_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md']
+SCORECARD PASS=13 FAIL=0

--- a/scripts/wilson_staggered_one_horizon_hoeffding_lineage_cluster_lift_2026_07_12.py
+++ b/scripts/wilson_staggered_one_horizon_hoeffding_lineage_cluster_lift_2026_07_12.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Checks the one-horizon Haar--Berezin Hoeffding lineage cluster lift."""
+
+from __future__ import annotations
+
+import itertools
+import math
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "WILSON_STAGGERED_ONE_HORIZON_HAAR_BEREZIN_HOEFFDING_"
+    "LINEAGE_CLUSTER_LIFT_BOUNDED_THEOREM_NOTE_2026-07-12.md"
+)
+
+
+def g(value: float) -> float:
+    return math.expm1(value) / value if value else 1.0
+
+
+def expectation(function: dict[tuple[int, ...], float], axes: set[int]) -> dict[tuple[int, ...], float]:
+    dimension = len(next(iter(function)))
+    out = {}
+    for point in function:
+        total = 0.0
+        for values in itertools.product((-1, 1), repeat=len(axes)):
+            source = list(point)
+            for axis, value in zip(sorted(axes), values):
+                source[axis] = value
+            total += function[tuple(source)]
+        out[point] = total / (2 ** len(axes))
+    assert all(len(point) == dimension for point in out)
+    return out
+
+
+def subtract(left: dict[tuple[int, ...], float], right: dict[tuple[int, ...], float]) -> dict[tuple[int, ...], float]:
+    return {point: left[point] - right[point] for point in left}
+
+
+def hoeffding_component(
+    function: dict[tuple[int, ...], float], tagged: set[int]
+) -> dict[tuple[int, ...], float]:
+    dimension = len(next(iter(function)))
+    component = expectation(function, set(range(dimension)) - tagged)
+    for axis in sorted(tagged):
+        component = subtract(component, expectation(component, {axis}))
+    return component
+
+
+def add_functions(functions: list[dict[tuple[int, ...], float]]) -> dict[tuple[int, ...], float]:
+    points = functions[0]
+    return {point: sum(function[point] for function in functions) for point in points}
+
+
+def multiply(*functions: dict[tuple[int, ...], float]) -> dict[tuple[int, ...], float]:
+    return {point: math.prod(function[point] for function in functions) for point in functions[0]}
+
+
+def sup_norm(function: dict[tuple[int, ...], float]) -> float:
+    return max(abs(value) for value in function.values())
+
+
+def mean(function: dict[tuple[int, ...], float]) -> float:
+    return sum(function.values()) / len(function)
+
+
+def atomize(function: dict[tuple[int, ...], float]) -> dict[tuple[int, ...], dict[tuple[int, ...], float]]:
+    dimension = len(next(iter(function)))
+    out = {}
+    for size in range(dimension + 1):
+        for tagged in itertools.combinations(range(dimension), size):
+            out[tagged] = hoeffding_component(function, set(tagged))
+    return out
+
+
+def atom_norm(function: dict[tuple[int, ...], float], weight: float) -> float:
+    return sum(weight ** len(tagged) * sup_norm(component) for tagged, component in atomize(function).items())
+
+
+def integer_sup_n_exp(slack: float) -> tuple[int, float]:
+    critical = 1.0 / slack
+    candidates = {max(1, math.floor(critical)), max(1, math.ceil(critical))}
+    return max(((int(n), n * math.exp(-slack * n)) for n in candidates), key=lambda row: row[1])
+
+
+def integer_sup_attachment(k_value: float, c: float) -> tuple[int, float]:
+    critical = -math.log1p(-k_value / c) / k_value
+    candidates = {max(1, math.floor(critical)), max(1, math.ceil(critical))}
+    return max(
+        ((int(n), math.exp(-c * n) * math.expm1(k_value * n)) for n in candidates),
+        key=lambda row: row[1],
+    )
+
+
+def attachment_constants(k_value: float, c: float) -> dict[str, float]:
+    n_d, d_slack = integer_sup_n_exp(c - k_value)
+    n_a, a_zero = integer_sup_attachment(k_value, c)
+    tau = k_value * d_slack
+    anchored = (a_zero + tau / (1.0 - tau)) / (1.0 - tau)
+    return {
+        "n_d": float(n_d),
+        "d_slack": d_slack,
+        "n_a": float(n_a),
+        "a_zero": a_zero,
+        "tau": tau,
+        "A_att": anchored,
+    }
+
+
+def tagged_rows(
+    mass: float, beta: float, c: float, theta: float, lam: float, eta: float
+) -> dict[str, float]:
+    r_star = 1.0 + math.sqrt(2.0)
+    coordinate_cost = r_star**2
+    h = 4.0 / mass
+    total_weight = theta + 2.0 * c + lam
+    wilson = (
+        12.0
+        * math.expm1((3.0 * beta / 4.0) * coordinate_cost**4)
+        * math.exp(4.0 * total_weight)
+    )
+    determinant = 0.0
+    schur = 0.0
+    for length in range(4, 10000, 2):
+        det_term = (
+            1.5
+            * coordinate_cost**length
+            * h**length
+            * g(3.0 * coordinate_cost**length * h**length / length)
+            * math.exp(length * total_weight)
+        )
+        determinant += det_term
+        x_length = 9.0 * eta**2 * 2.0 ** (-length) * mass ** (-(length - 1))
+        schur_term = (
+            18.0
+            * eta**2
+            * coordinate_cost ** (length + 2)
+            * length
+            * h ** (length - 1)
+            * g(coordinate_cost ** (length + 2) * x_length)
+            * math.exp(length * total_weight)
+        )
+        schur += schur_term
+        if max(det_term, schur_term) < 1.0e-22:
+            break
+    return {
+        "C": coordinate_cost,
+        "q_hop": h * coordinate_cost * math.exp(total_weight),
+        "K_W": wilson,
+        "K_I": determinant,
+        "K_S": schur,
+        "K": wilson + determinant + schur,
+    }
+
+
+def main() -> None:
+    checks: list[tuple[str, bool, str]] = []
+    r_star = 1.0 + math.sqrt(2.0)
+    coordinate_cost = r_star**2
+    checks.append(
+        (
+            "hoeffding_weight_identity",
+            math.isclose(coordinate_cost, 1.0 + 2.0 * r_star, abs_tol=1.0e-14)
+            and math.isclose(coordinate_cost, 3.0 + 2.0 * math.sqrt(2.0), abs_tol=1.0e-14),
+            f"r*={r_star:.15f}, C*=r*^2=1+2r*={coordinate_cost:.15f}",
+        )
+    )
+
+    points = tuple(itertools.product((-1, 1), repeat=3))
+    function = {
+        point: 0.7 + 0.2 * point[0] - 0.3 * point[1] + 0.11 * point[0] * point[2]
+        for point in points
+    }
+    atoms = atomize(function)
+    reconstructed = add_functions(list(atoms.values()))
+    max_error = max(abs(function[point] - reconstructed[point]) for point in points)
+    black_box = coordinate_cost**3 * sup_norm(function)
+    checks.append(
+        (
+            "canonical_atom_reconstruction_and_bound",
+            max_error < 1.0e-14 and atom_norm(function, r_star) <= black_box + 1.0e-14,
+            f"atoms={len(atoms)}, reconstruction_error={max_error:.3e}, atom_norm={atom_norm(function,r_star):.12f}<=black_box={black_box:.12f}",
+        )
+    )
+
+    dummy_function = {point: 1.0 + 0.25 * point[0] for point in points}
+    dummy_atoms = atomize(dummy_function)
+    dummy_nonzero = [tagged for tagged, component in dummy_atoms.items() if sup_norm(component) > 1.0e-14]
+    checks.append(
+        (
+            "dummy_coordinate_has_no_tag",
+            dummy_nonzero == [(), (0,)],
+            f"nonzero_tag_sets={dummy_nonzero}",
+        )
+    )
+
+    fully_dummy = {point: 0.375 for point in points}
+    fully_dummy_nonzero = [
+        tagged for tagged, component in atomize(fully_dummy).items() if sup_norm(component) > 1.0e-14
+    ]
+    checks.append(
+        (
+            "skeleton_cancellation_has_empty_current_atom",
+            fully_dummy_nonzero == [()],
+            f"V-only transporter with syntactic A,H carrier has nonzero_tag_sets={fully_dummy_nonzero}",
+        )
+    )
+
+    centered_x = {point: float(point[0]) for point in points}
+    checks.append(
+        (
+            "centered_tags_do_not_survive_expectation",
+            abs(mean(centered_x)) < 1.0e-15 and math.isclose(mean(multiply(centered_x, centered_x)), 1.0),
+            f"E[x]={mean(centered_x):.1f}, E[x*x]={mean(multiply(centered_x,centered_x)):.1f}",
+        )
+    )
+
+    omega = complex(-0.5, math.sqrt(3.0) / 2.0)
+    center_moments = [sum(omega ** (power * moment) for power in range(3)) / 3.0 for moment in range(1, 4)]
+    epsilon_component = 1.0 / 6.0
+    checks.append(
+        (
+            "center_charge_allows_cubic_haar_singlet",
+            abs(center_moments[0]) < 1.0e-15
+            and abs(center_moments[1]) < 1.0e-15
+            and abs(center_moments[2] - 1.0) < 1.0e-15
+            and epsilon_component > 0.0,
+            f"SU3-center moments E[z],E[z^2],E[z^3]={center_moments}; Haar U11 U22 U33 epsilon coefficient={epsilon_component:g}",
+        )
+    )
+
+    factor_one = {point: 0.1 + 0.2 * point[0] - 0.05 * point[1] for point in points}
+    factor_two = {
+        point: -0.03 + 0.15 * point[0] + 0.07 * point[1] + 0.04 * point[2]
+        for point in points
+    }
+    decorated_sum = 0.0
+    decorated_weights = []
+    for atom_one, atom_two in itertools.product(atomize(factor_one).values(), atomize(factor_two).values()):
+        weight = mean(multiply(atom_one, atom_two))
+        decorated_sum += weight
+        if abs(weight) > 1.0e-15:
+            decorated_weights.append(weight)
+    direct_weight = mean(multiply(factor_one, factor_two))
+    checks.append(
+        (
+            "decorated_factor_collection_evaluation",
+            math.isclose(decorated_sum, direct_weight, abs_tol=1.0e-14),
+            f"decorated_sum={decorated_sum:.15f}, direct_weight={direct_weight:.15f}",
+        )
+    )
+
+    direct_log_partial = 0.0
+    decorated_log_partial = 0.0
+    power_errors = []
+    for order in range(1, 5):
+        direct_power = direct_weight**order
+        decorated_power = sum(
+            math.prod(choice) for choice in itertools.product(decorated_weights, repeat=order)
+        )
+        power_errors.append(abs(direct_power - decorated_power))
+        coefficient = ((-1) ** (order + 1)) / order
+        direct_log_partial += coefficient * direct_power
+        decorated_log_partial += coefficient * decorated_power
+    checks.append(
+        (
+            "decorated_hard_core_log_evaluation",
+            max(power_errors) < 1.0e-14
+            and math.isclose(decorated_log_partial, direct_log_partial, abs_tol=1.0e-14),
+            f"nonzero_decorations={len(decorated_weights)}, power_errors={power_errors}, log_partial={decorated_log_partial:.15f}",
+        )
+    )
+
+    mass, beta, c, theta, lam = 1.0e4, 0.0, 0.001, 1.0e-6, 1.0
+    eta = mass**-0.5
+    rows = tagged_rows(mass, beta, c, theta, lam, eta)
+    checks.append(
+        (
+            "tagged_residual_activity_point",
+            rows["q_hop"] < 0.00636
+            and rows["K_I"] < 2.44e-9
+            and rows["K_S"] < 9.95e-7
+            and rows["K"] < c,
+            "q_hop={:.15e}, K_I={:.15e}, K_S={:.15e}, K={:.15e}, margin={:.15e}".format(
+                rows["q_hop"], rows["K_I"], rows["K_S"], rows["K"], c - rows["K"]
+            ),
+        )
+    )
+
+    beta_ceiling = (4.0 / 3.0) * math.log1p(
+        (c - rows["K_I"] - rows["K_S"])
+        / (12.0 * math.exp(4.0 * (theta + 2.0 * c + lam)))
+    )
+    beta_ceiling /= coordinate_cost**4
+    beta_probe = 0.99 * beta_ceiling
+    probe_rows = tagged_rows(mass, beta_probe, c, theta, lam, eta)
+    checks.append(
+        (
+            "strict_nonzero_beta_interval",
+            1.7e-9 < beta_ceiling < 1.8e-9 and probe_rows["K"] < c,
+            f"beta_ceiling={beta_ceiling:.15e}, beta_probe={beta_probe:.15e}, K_probe={probe_rows['K']:.15e}<c",
+        )
+    )
+
+    attachment = attachment_constants(rows["K"], c)
+    conversion = 68.0 * math.exp(lam / 2.0)
+    q_centered = conversion * attachment["A_att"]
+    q_split = max(math.exp(-lam / 2.0), q_centered)
+    base_defect = conversion * rows["K"]
+    checks.append(
+        (
+            "tagged_marked_constants",
+            q_centered < 0.083 and q_split < 1.0 and base_defect < 1.12e-4,
+            "tau={:.15e}, A_att={:.15e}, q_centered={:.15e}, q_split={:.12f}, B_tag={:.15e}".format(
+                attachment["tau"], attachment["A_att"], q_centered, q_split, base_defect
+            ),
+        )
+    )
+
+    text = NOTE.read_text()
+    required = [
+        "**Type:** bounded_theorem",
+        "ev(Gamma_hat_res)=Gamma_res",
+        "one RG horizon only",
+        "No axiom-update stop",
+        "### N1",
+        "### N2",
+        "### N3",
+        "### N4",
+        "### N5",
+        "### N6",
+        "### N7",
+        "### N8",
+    ]
+    missing = [item for item in required if item not in text]
+    forbidden = ["proves an autonomous RG", "tags survive integration", "NOT_TESTED"]
+    hits = [item for item in forbidden if item in text]
+    checks.append(("source_contract", not missing and not hits, f"missing={missing}, forbidden_hits={hits}"))
+
+    expected_dependencies = sorted(
+        [
+            "WILSON_STAGGERED_CONSTRAINED_FIBER_TWO_LAYER_KP_COMPLEX_SOURCE_POLYMER_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_GAUSSIAN_ADAPTED_BEREZIN_HANDOFF_AND_SHORTEST_QUADRATIC_CENTER_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_K_RETAINING_MARKED_ATTACHMENT_STRONG_WEAK_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_RETAINED_GRASSMANN_TWO_LAYER_KP_POLYMER_NORM_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+        ]
+    )
+    dependencies = sorted(set(re.findall(r"\]\(([^)#?]+\.md)\)", text)))
+    checks.append(
+        (
+            "repository_dependency_set",
+            dependencies == expected_dependencies,
+            f"markdown_dependency_set={dependencies}",
+        )
+    )
+
+    passed = sum(ok for _, ok, _ in checks)
+    failed = len(checks) - passed
+    for name, ok, detail in checks:
+        print(f"{'PASS' if ok else 'FAIL'} {name}: {detail}")
+    print(f"SCORECARD PASS={passed} FAIL={failed}")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Result

- constructs an exact one-horizon decorated Haar–Berezin Hoeffding lift whose evaluation recovers the complete current bare residual factor system
- proves safe tagged KP activity and marked-attachment bounds at the witness point
- audits the actual retained determinant/Schur factor grammar, repeated-coordinate Haar projection, the explicit length-four empty-tag witness, and gauge covariance
- keeps syntactic carrier, nonzero atom tag, formal lineage, and geometric tree span distinct

## Boundary

This does not prove tag density, tag survival after physical integration, multiscale autonomy, a correlated-Gaussian lift, or an invariant ball. The next block must substitute the next skeleton, retain full coefficients, and re-atomize rather than propagate tags as physical support.

## Verification

- runner: PASS=13, FAIL=0; cache reproduced byte-for-byte
- independent code/math, physics/import, and governance/no-go reviews: pass with bounded claims
- full audit pipeline and strict lint: zero errors
- seeded as bounded_theorem / unaudited with the four intended dependencies
- vocabulary lint: clean; py_compile and git diff --check: clean