### PR TITLE
physics: reatomize residuals across two horizons

### DIFF
--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
@@ -1,6 +1,42 @@
 # Handoff
 
 Current branch:
+`physics-loop/record-faithful-dynamics-block36-two-horizon-reatomization-20260712`.
+The two-horizon skeleton-pullback/re-Hoeffding runner reports
+`PASS=14 FAIL=0`. It retains full coefficients, substitutes the next straight
+skeleton, and proves exact commuting re-atomization and cluster evaluation to
+canonical future atoms. The complete future coordinate group includes
+skeleton and nonskeleton hidden gauge links plus fixed-`m` endpoint Gaussian
+factors.
+
+The actual safe factor counts are Wilson `(4,4)`, determinant `(r,0)`, and
+residual Schur `(r,4)`. At `m=15000,beta=0,c=.001,Theta=10^-6,Lambda=1`,
+`K_2=6.67199105118e-6<c`. The converted base defect is
+`B_2=7.48017242352e-4<c` only at weak coarse spatial weights. The marked row
+`q=0.606530659713` maps a double-decorated strong source mark to the canonical-
+future-atom weak output norm.
+
+The explicit `V` and `V_1V_2=W` witnesses show future-tag creation and
+erasure. Consequently this theorem does not restore the next strong spatial
+weights, prove a three-level cocycle, perform a second RG integration, or
+control a generated ball. Correlated-Gaussian attachment and running-gap
+control also remain open.
+
+Independent code/math, physics/import/Nature, and governance/no-go reviews
+pass. Audit validation seeds one `bounded_theorem` / `unaudited` row with
+exactly three dependencies; the full pipeline and strict lint have zero
+errors and generated outputs are stripped. No axiom-update stop is triggered.
+
+Two-horizon canonical re-atomization stacked PR:
+https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5344
+is open against the one-horizon lineage-cluster head.
+
+Next exact action: split nonempty future atoms from the genuine empty-atom/raw-
+lift sector, then combine atom downshift and raw geometric suppression to test
+the full strong spatial handoff. Correlated covariance locality/attachment is
+the parallel analytic wall.
+
+Previous branch:
 `physics-loop/record-faithful-dynamics-block35-tagged-residual-cluster-20260712`.
 The one-horizon Haar--Berezin Hoeffding lineage-cluster runner reports
 `PASS=13 FAIL=0`. For the complete current bare residual factor family, every

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
@@ -1,5 +1,22 @@
 # PR Delivery
 
+The two-horizon skeleton-pullback/re-Hoeffding intertwining is delivered:
+
+- base: `physics-loop/record-faithful-dynamics-block35-tagged-residual-cluster-20260712`
+- head: `physics-loop/record-faithful-dynamics-block36-two-horizon-reatomization-20260712`
+- runner: `PASS=14 FAIL=0`
+- scope: exact next-skeleton pullback, complete future gauge/endpoint atom
+  chart, contractive decorated evaluation, actual-factor `(4,4)/(r,0)/(r,4)`
+  counts, strict two-level activity/base rows, and explicit tag creation/
+  erasure; weak spatial output only, with no strong handoff, second RG step,
+  all-scale cocycle, correlated-Gaussian attachment, or invariant ball
+- review: independent code/math, physics/import/Nature, and governance/no-go pass
+- audit compatibility: one `bounded_theorem` / `unaudited` row with exactly
+  three dependencies; full pipeline and strict lint pass; generated outputs stripped
+- PR: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5344
+
+No merge is authorized. Independent audit remains authoritative.
+
 The one-horizon Haar--Berezin Hoeffding lineage-cluster lift is delivered:
 
 - base: `physics-loop/record-faithful-dynamics-block34-haar-berezin-running-center-20260712`

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
@@ -1068,6 +1068,35 @@ tag routes and the exact residual-match check.
 Runner/cache: `PASS=13 FAIL=0`. Audit validation seeds one `bounded_theorem` /
 `unaudited` row with exactly four dependencies; the full pipeline and strict
 lint have zero errors and generated outputs are stripped. PR #5343 is open.
-The next target is a two-level evaluation-commuting re-atomization cocycle,
+The next target is a two-level evaluation-commuting re-atomization identity,
 then correlated-covariance locality and attachment. No axiom-update stop is
+triggered.
+
+## Two-horizon skeleton-pullback/re-Hoeffding review
+
+PASS WITH BOUNDED CLAIMS after two theorem-critical scope repairs. The first
+repair expands the future coordinate group to every next hidden gauge link,
+including nonskeleton links, plus the two fixed-`m` endpoint Gaussian factors.
+The resulting safe counts are Wilson `(4,4)`, determinant `(r,0)`, and Schur
+`(r,4)`. The second repair keeps the converted spatial weights weak: canonical
+future atoms do not themselves restore the missing strong reserve.
+
+The exact two-level projections commute, current integration commutes with
+future projections, and the evaluated double-lineage algebra maps
+contractively to genuine canonical future atoms. The `V` witness creates a
+future tag from an empty current tag, while `V_1V_2=W` erases two individual
+future tags. These examples validate full-coefficient re-atomization and rule
+out Boolean tag propagation without implying an all-scale no-go.
+
+At the displayed point, `K_2=6.67199105118e-6<c` and the weak output base row
+is `B_2=7.48017242352e-4<c`. The marked number `q=0.606530659713` is only a
+one-step double-decorated-strong to future-atom-weak estimate. Independent
+code/math, physics/import/Nature, and governance/no-go review pass the final
+surface. Runner/cache are `PASS=14 FAIL=0`; audit validation seeds one
+`bounded_theorem` / `unaudited` row with exactly three dependencies; strict
+lint has zero errors and generated outputs are stripped. PR #5344 is open.
+
+The next target splits nonempty future atoms from extended empty atoms and
+combines atom downshift with raw-lift geometry for the strong spatial handoff;
+correlated covariance attachment remains independent. No axiom-update stop is
 triggered.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
@@ -8,36 +8,34 @@ current_goal: >-
   supply the physical evolution object, bare time ordering, record-formation
   weights, and an admissibility-to-carrier selector without importing the
   staggered/Dirac answer or sector-specific Standard Model and gravity laws.
-branch: physics-loop/record-faithful-dynamics-block35-tagged-residual-cluster-20260712
+branch: physics-loop/record-faithful-dynamics-block36-two-horizon-reatomization-20260712
 base_commit_at_start: 9d1636f05f
-cycle_count: 35
-block_count: 35
-active_route: wilson_staggered_one_horizon_haar_berezin_hoeffding_lineage_cluster_lift
+cycle_count: 36
+block_count: 36
+active_route: wilson_staggered_two_horizon_skeleton_pullback_canonical_rehoeffding_intertwining
 hard_residual: >-
   Can the four-axiom record surface canonically determine a faithful local
   record-forming instrument whose coherent no-record block is sufficiently
   constrained to exclude the observationally disconnected SWAP--Laplacian
   completion and select the Clifford-vector carrier?
-produced_claim_id: wilson_staggered_one_horizon_haar_berezin_hoeffding_lineage_cluster_lift_bounded_theorem_note_2026-07-12
+produced_claim_id: wilson_staggered_two_horizon_skeleton_pullback_canonical_rehoeffding_intertwining_bounded_theorem_note_2026-07-12
 actual_current_surface_status: bounded-support
 conditional_surface_status: >-
-  The complete current bare residual factor family has an exact one-horizon
-  decorated Haar--Berezin Hoeffding lift whose evaluation recovers the
-  original residual cluster logarithm. Safe tagged activities satisfy
-  K_tag=9.967013e-7<c at the displayed witness and give a finite marked
-  attachment row. The construction retains formal lineages without asserting
-  physical tag survival: next-skeleton substitution can erase current tags.
-  A future-coordinate re-atomization cocycle, correlated-Gaussian attachment,
-  running-gap persistence, same-norm iteration, and an invariant ball remain
-  open.
+  The complete current bare residual admits an exact two-level next-skeleton
+  pullback and canonical re-Hoeffding intertwining. All next hidden gauge
+  links and fixed-m endpoint factors are included, and evaluated lineages give
+  genuine future atoms despite exact tag creation/erasure. At the displayed
+  point K_2=6.671991e-6<c and B_2=7.480172e-4<c, but only in the weak coarse
+  spatial norm. Strong-spatial empty-atom handoff, correlated-Gaussian
+  attachment, running-gap persistence, same-norm iteration, and an invariant
+  ball remain open.
 admitted_observation_status: none
 claim_type_reason: >-
-  The source proves an exact finite-horizon decorated-factor evaluation map,
-  controls the complete present residual factor grammar with conservative
-  Hoeffding activities, and verifies marked-cluster reuse on formal lineages.
-  It explicitly distinguishes syntactic carriers, nonzero atom tags, formal
-  lineages, and geometric tree span, and does not claim tag density, tag
-  survival, correlated-Gaussian attachment, or an autonomous RG self-map.
+  The source proves the exact two-level projection/evaluation identities,
+  controls the complete present residual grammar in a canonical future-atom
+  weak output norm, and gives a double-decorated-source to future-atom-weak
+  one-mark row. It explicitly does not claim a three-level cocycle, spatial
+  strong return, correlated-Gaussian attachment, or an autonomous RG self-map.
 hypothetical_axiom_status: null
 proposal_allowed: false
 proposal_allowed_reason: >-
@@ -152,6 +150,9 @@ files_touched:
   - docs/WILSON_STAGGERED_ONE_HORIZON_HAAR_BEREZIN_HOEFFDING_LINEAGE_CLUSTER_LIFT_BOUNDED_THEOREM_NOTE_2026-07-12.md
   - scripts/wilson_staggered_one_horizon_hoeffding_lineage_cluster_lift_2026_07_12.py
   - logs/runner-cache/wilson_staggered_one_horizon_hoeffding_lineage_cluster_lift_2026_07_12.txt
+  - docs/WILSON_STAGGERED_TWO_HORIZON_SKELETON_PULLBACK_CANONICAL_REHOEFFDING_INTERTWINING_BOUNDED_THEOREM_NOTE_2026-07-12.md
+  - scripts/wilson_staggered_two_horizon_skeleton_pullback_reatomization_2026_07_12.py
+  - logs/runner-cache/wilson_staggered_two_horizon_skeleton_pullback_reatomization_2026_07_12.txt
 open_imports:
   - fundamental process object: Hamiltonian, strict tick, or record instrument
   - faithful law-to-record influence principle
@@ -204,10 +205,11 @@ no_go_routes:
   - the full certified weak completion has no support-only embedding into the present next-step strong norm, and the present ultra-small eta makes the next Gaussian Berezin conditioning enormous; this does not rule out actual-range provenance, running Gaussian centers, or multi-index Haar--Berezin norms
   - Gaussian adaptation and shortest-quadratic extraction repair the fixed-gap tensor norm and current bare residual constants, but do not by themselves supply correlated-reference forced attachment, full actual-range tag membership, or a persistent running gap
   - the one-horizon decorated Hoeffding lift exactly evaluates to the current residual cluster system, but current Haar tags can disappear after integration or next-skeleton substitution; formal lineage therefore cannot be propagated as physical multiscale support without re-atomization
+  - exact two-level re-atomization produces genuine future atoms in the weak output norm, but tag fusion leaves extended empty future atoms and does not restore the missing strong spatial weights
 trace_gate_classification: direct_blocker_closure
 reachability_to_target: partially_closes
-review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_two_layer_source_polymer_pass_retained_grassmann_polymer_norm_pass_declared_rg_chart_pass_split_derivative_certificate_boundary_pass_marked_attachment_strong_weak_contraction_pass_current_chart_autonomy_handoff_pass_gaussian_berezin_quadratic_center_pass_one_horizon_lineage_cluster_lift_pass_bounded
-pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open_two_layer_source_polymer_open_retained_grassmann_polymer_norm_open_declared_rg_chart_open_split_derivative_certificate_boundary_open_marked_attachment_strong_weak_contraction_open_current_chart_autonomy_handoff_open_gaussian_berezin_quadratic_center_open_one_horizon_lineage_cluster_lift_open
+review_disposition: cubic_response_pass_outcome_operation_pass_minimal_dilation_pass_effect_selection_pass_full_instrument_pass_event_order_pass_scalar_car_qca_pass_matching_qca_pass_symmetric_clifford_pass_common_hamiltonian_pass_charge_dichotomy_pass_bdg_pass_free_scalar_spectral_continuum_pass_free_os_car_fock_representation_pass_circle_boundary_pass_two_seam_holonomy_pass_coupled_circle_gram_pass_os_interior_descent_subsequential_transfer_pass_massive_infinite_time_uniqueness_pass_spatial_dlr_accumulation_pass_dobrushin_spatial_uniqueness_gap_pass_compact_subwedge_ultralocal_continuum_no_go_pass_sharp_certificate_boundary_critical_scaling_no_go_pass_factor_two_block_schur_os_semigroup_pass_constrained_fiber_raw_rg_unit_directions_pass_coarse_gauge_gibbsianness_pass_raw_action_hessian_pass_two_layer_source_polymer_pass_retained_grassmann_polymer_norm_pass_declared_rg_chart_pass_split_derivative_certificate_boundary_pass_marked_attachment_strong_weak_contraction_pass_current_chart_autonomy_handoff_pass_gaussian_berezin_quadratic_center_pass_one_horizon_lineage_cluster_lift_pass_two_horizon_reatomization_intertwining_pass_bounded
+pr_status: cubic_response_open_outcome_operation_open_minimal_dilation_open_effect_selection_open_full_instrument_open_event_order_open_scalar_car_qca_open_matching_qca_open_symmetric_clifford_open_common_hamiltonian_open_charge_dichotomy_open_bdg_open_continuum_open_residue_open_circle_boundary_mergeable_two_seam_holonomy_open_coupled_circle_gram_open_os_interior_descent_subsequential_transfer_open_massive_infinite_time_uniqueness_open_spatial_dlr_accumulation_open_dobrushin_spatial_uniqueness_gap_open_compact_subwedge_ultralocal_continuum_no_go_open_sharp_certificate_boundary_critical_scaling_no_go_open_factor_two_block_schur_os_semigroup_open_constrained_fiber_raw_rg_unit_directions_open_coarse_gauge_gibbsianness_open_raw_action_hessian_open_two_layer_source_polymer_open_retained_grassmann_polymer_norm_open_declared_rg_chart_open_split_derivative_certificate_boundary_open_marked_attachment_strong_weak_contraction_open_current_chart_autonomy_handoff_open_gaussian_berezin_quadratic_center_open_one_horizon_lineage_cluster_lift_open_two_horizon_reatomization_intertwining_open
 block01_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5178
 block02_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5181
 block03_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5201
@@ -243,14 +245,15 @@ block32_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/
 block33_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5340
 block34_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5342
 block35_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5343
+block36_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5344
 next_exact_action: >-
-  Construct the two-level future-coordinate tag-update cocycle: retain every
-  full decorated coefficient, substitute the next skeleton exactly, and
-  re-Hoeffding-atomize in the new hidden variables. Prove an evaluation-
-  commuting bound that survives current-tag erasure. Then extend forced
-  attachment through the correlated running covariance with an explicit
-  locality/cluster bound and return the actual RG range to a uniform strong
-  provenance norm. Only then derive the same-norm Hessian and invariant ball.
+  Split the evaluated future output into its nonempty canonical-atom sector
+  and genuine empty-atom/future-fiber-constant sector. Combine atom-level
+  downshift for the former with the declared raw-lift geometric mechanism for
+  the latter, and test whether the actual bare range restores the full strong
+  spatial weights. In parallel, extend forced attachment through the
+  correlated running covariance with an explicit locality/cluster bound.
+  Only then derive the same-norm Hessian and invariant ball.
 stop_condition: >-
   Stop and discuss an axiom update only if an exact result proves that the
   required bridge cannot be derived and an additional approved axiom or

--- a/docs/WILSON_STAGGERED_TWO_HORIZON_SKELETON_PULLBACK_CANONICAL_REHOEFFDING_INTERTWINING_BOUNDED_THEOREM_NOTE_2026-07-12.md
+++ b/docs/WILSON_STAGGERED_TWO_HORIZON_SKELETON_PULLBACK_CANONICAL_REHOEFFDING_INTERTWINING_BOUNDED_THEOREM_NOTE_2026-07-12.md
@@ -1,0 +1,450 @@
+# Two-horizon skeleton pullback with canonical re-Hoeffding intertwining
+
+**Date:** 2026-07-12
+**Type:** bounded_theorem
+**Status:** unaudited candidate; effective status is pipeline-derived only after independent audit.
+**Primary runner:** [`scripts/wilson_staggered_two_horizon_skeleton_pullback_reatomization_2026_07_12.py`](../scripts/wilson_staggered_two_horizon_skeleton_pullback_reatomization_2026_07_12.py)
+**Cached output:** [`logs/runner-cache/wilson_staggered_two_horizon_skeleton_pullback_reatomization_2026_07_12.txt`](../logs/runner-cache/wilson_staggered_two_horizon_skeleton_pullback_reatomization_2026_07_12.txt)
+
+## 0. Result
+
+The complete present Wilson--staggered bare residual factor system has an
+exact two-horizon skeleton-pullback/re-Hoeffding lift. The construction keeps
+the full factor coefficients, substitutes the next straight skeleton, and
+only then forms canonical atoms in the future gauge/endpoint provenance
+coordinates. Future-tag
+creation and erasure relative to current coefficients are both handled by an
+evaluation-commuting two-level intertwining identity; no Boolean tag-survival
+rule is assumed.
+
+Use the exact straight factor-two disintegration from the
+[gauge-block/Schur theorem](MASSIVE_WILSON_STAGGERED_FACTOR_TWO_GAUGE_BLOCK_SCHUR_OS_SEMIGROUP_BOUNDED_THEOREM_NOTE_2026-07-12.md),
+the support and field chart from the
+[declared RG-chart theorem](WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md),
+and the full current residual factor grammar and decorated cluster algebra
+from the
+[one-horizon lineage theorem](WILSON_STAGGERED_ONE_HORIZON_HAAR_BEREZIN_HOEFFDING_LINEAGE_CLUSTER_LIFT_BOUNDED_THEOREM_NOTE_2026-07-12.md).
+
+Write the current and next skeleton substitutions as
+
+```text
+U_1=A,       U_2=A^(-1)V,
+V_1=B,       V_2=B^(-1)W.                                         (0.1)
+```
+
+The current integration coordinates `J_a^0` are hidden fine Haar links. The
+future provenance coordinates `J_a^1` include the first members `B` of future
+skeleton pairs, every coarse `V` link outside those pairs, and the at-most-two
+fixed-`m` onsite Gaussian endpoint factors of a Schur word. Moving the endpoint
+projections from the current decoration to the future decoration is permitted
+because they remain external to current Haar integration; they are not
+duplicated as a second Gaussian layer. All distinct coordinate expectations
+commute. With
+
+```text
+r_*=1+sqrt(2),                   C_*=r_*^2=3+2sqrt(2),              (0.2)
+```
+
+define the exact two-level factor atoms
+
+```text
+Delta_(T,S)^(0->1) f_a
+ =Delta_S^1 Delta_T^0 [f_a(A,R_2(Y_1,W))].                          (0.3)
+```
+
+Then
+
+```text
+f_a(A,R_2(Y_1,W))=sum_(T,S) Delta_(T,S)^(0->1)f_a,                 (0.4)
+
+sum_(T,S) r_*^(|T|+|S|)||Delta_(T,S)^(0->1)f_a||
+ <=C_*^(n_a^0+n_a^1)||f_a||.                                      (0.5)
+```
+
+The safe actual-factor coordinate counts after shortest-center extraction are
+
+```text
+(n_a^0,n_a^1)<=(4,4)       for a Wilson plaquette,
+(n_a^0,n_a^1)<=(r,0)       for a determinant word of length r,
+(n_a^0,n_a^1)<=(r,4)       for a residual Schur word of length r.  (0.6)
+```
+
+The zero in the determinant row is exact: an eliminated `I-I` word contains
+no current skeleton fine link. A Schur word has only its two skeleton boundary
+links available to carry future `V` dependence.
+
+Let `h=4/m`, `L=Theta+2c+Lambda`,
+`x_r=9 eta^2 2^(-r)m^(-(r-1))`, and `g(x)=(exp(x)-1)/x`. Applying (0.5) at
+the factor level before either cluster grouping gives
+
+```text
+K_W^(2)=12[exp((3beta/4)C_*^8)-1]exp(4L),                          (0.7)
+
+K_I^(2)=(3/2)sum_(even r>=4)
+          C_*^r h^r g(3C_*^r h^r/r)exp(rL),                       (0.8)
+
+K_S^(2)=18eta^2 sum_(even r>=4)
+          C_*^(r+4)r h^(r-1)g(C_*^(r+4)x_r)exp(rL),               (0.9)
+
+K_2=K_W^(2)+K_I^(2)+K_S^(2).                                     (0.10)
+```
+
+At
+
+```text
+m=15000, beta=0, c=0.001, Theta=10^(-6), Lambda=1,
+eta=m^(-1/2),                                                       (0.11)
+```
+
+the exact series give
+
+```text
+q_hop=0.004233344463883...,
+K_I^(2)=4.817630355648... 10^(-10),
+K_S^(2)=6.671509288145... 10^(-6),
+K_2=6.671991051180... 10^(-6)<c.                                  (0.12)
+```
+
+The two-layer cluster conversion lands the pulled-back base residual in the
+weak coarse spatial norm with canonical future provenance atoms:
+
+```text
+||Gamma_res after R_2||_(Lambda/2,Theta/2,eta;future-atoms)
+ <=B_2:=68exp(Lambda/2)K_2
+ =7.480172423521... 10^(-4)<c.                                    (0.13)
+```
+
+For a current-product-Haar-centered input mark normalized in the double-
+decorated strong source norm, the same algebra gives
+
+```text
+q_centered^(2)=0.555188304219...,
+q_split^(2)=max{exp(-1/2),q_centered^(2)}
+           =0.606530659713...<1.                                  (0.14)
+```
+
+There is also a strict interval
+
+```text
+0<=beta<1.505860908679... 10^(-12)                                (0.15)
+```
+
+with all other parameters fixed as in (0.11). Equations (0.13)--(0.14) are a
+two-horizon canonical-atom weak membership and one-mark strong-to-weak
+estimate, not a return to the next strong spatial weights, an invariant ball,
+or an autonomous RG contraction.
+
+## 1. Exact pullback and commuting atom projections
+
+For each coarse link, the second equality in (0.1) is the same exact Haar
+coordinate change as at the first scale:
+
+```text
+dB d(B^(-1)W)=dB dW.                                               (1.1)
+```
+
+The current and future skeleton paths are link-disjoint within their own
+scales, and the exact blocking semigroup identifies the second pullback with
+straight path concatenation. Coarse links outside the future skeleton remain
+future hidden Haar coordinates unchanged. The complete coordinate change is
+surjective, so it preserves the factor sup norm.
+
+For `i in J_a^k`, put `Q_i^k=1-E_i^k` and
+
+```text
+Delta_T^k=product_(i in T)Q_i^k product_(i in J_a^k minus T)E_i^k.
+                                                                         (1.2)
+```
+
+The current Haar coordinates and the future gauge/endpoint provenance
+coordinates act on distinct variables. The fixed-`m` endpoint atom is
+projected once, at the future level, rather than projected twice.
+Consequently
+
+```text
+Delta_S^1 Delta_T^0=Delta_T^0 Delta_S^1,                           (1.3)
+sum_(T,S)Delta_S^1 Delta_T^0=1.                                   (1.4)
+```
+
+For each level, `||Q_i^k||<=2`. Applying the one-level bound twice gives
+(0.5). Equivalently, the two-level re-atomization intertwining is the exact
+identity
+
+```text
+Delta_S^1 [sum_T Delta_T^0(f_a after R_2)]
+ =sum_T Delta_S^1 Delta_T^0(f_a after R_2).                        (1.5)
+```
+
+Here `R_2(Y_1,W)` includes unchanged future nonskeleton links as well as the
+skeleton substitutions in (0.1). Let `E_0` denote the physical current
+hidden-link Haar integration. It leaves
+all future hidden links and retained endpoint variables external, hence
+
+```text
+E_0 Delta_S^1=Delta_S^1 E_0.                                     (1.6)
+```
+
+Equations (1.5)--(1.6), rather than inherited Boolean labels, are the
+tag-update law.
+
+Two opposite exact witnesses explain why the full coefficient is necessary.
+The residual length-four path from the previous theorem can reduce to `V` and
+have only the empty current atom. After (0.1), either `V=B` or
+`V=B^(-1)W`; its fundamental `B` dependence has a nonempty future atom. Thus
+an empty current tag can become a future tag. Conversely,
+
+```text
+V_1V_2=B B^(-1)W=W,                                                (1.7)
+```
+
+so two individually future-tagged coefficients can multiply to an empty
+future atom. The evaluated Hoeffding algebra performs both fusions exactly.
+
+## 2. Two-horizon decorated cluster evaluation
+
+For an overlap-connected current factor collection `Gamma`, choose current
+and future atom subsets `(T_a,S_a)` for every factor and define
+
+```text
+w_hat_Gamma^(2)({T_a,S_a};Y_1,W)
+ =integral dH_0 product_(a in Gamma)
+   Delta_(T_a,S_a)^(0->1)f_a.                                    (2.1)
+```
+
+Here `dH_0` is exactly the current physical hidden Haar integration, and
+`Y_1` comprises future skeleton-first and nonskeleton hidden links together
+with the retained endpoint variables. The fixed-`m` endpoint atoms are part
+of the future coefficient provenance. Future atoms are coefficient
+decompositions, not an early integration over `Y_1`.
+Finite reconstruction, (1.6), and Fubini give
+
+```text
+sum_({T_a,S_a})w_hat_Gamma^(2)
+ =w_Gamma after R_2.                                               (2.2)
+```
+
+Run both the connected factor grouping and the hard-core logarithm in the
+free two-level lineage algebra. Its product concatenates original factor
+labels and both atom subsets. Let `ev_1` multiply and fuse future atoms in the
+actual Hoeffding algebra, sum all decorations, and forget the formal lineage.
+The coordinatewise `r_*` split algebra has product constant one, so `ev_1` is
+contractive from the free double-lineage projective `l1` norm to the evaluated
+canonical future-atom norm. Absolute convergence under (0.10) permits
+evaluation term by term:
+
+```text
+ev_1(Gamma_hat_res^(2))=Gamma_res after R_2.                        (2.3)
+```
+
+Applying an actual future projection after evaluation gives the genuine
+canonical output atoms:
+
+```text
+Delta_S^1(Gamma_res after R_2)
+ =Delta_S^1 ev_1(Gamma_hat_res^(2)).                               (2.4)
+```
+
+No individual formal lineage is identified with the left side of (2.4).
+Lineages may fuse into a different atom subset, including the empty subset.
+
+Normalized Haar expectations and the fixed-`m` onsite color-scalar Gaussian
+expectations intertwine gauge transformations, while blocked translations,
+proper cubic rotations, and the compatible reflection permute or dualize
+coordinate slots. Therefore the two-level atom algebra is equivariant and
+(2.3) remains jointly gauge invariant and compatible with the declared
+lattice symmetries.
+
+## 3. Actual-factor activity and canonical future-weak output
+
+The Wilson row in (0.6) pays at most four current and four future hidden link
+coordinates. A coarse `V` occurrence costs one future coordinate whether it
+is a skeleton-first/second link or a nonskeleton hidden link. Determinant paths
+pay only their current `r` eliminated-link coordinates. Residual Schur paths
+pay `r` current link coordinates; their future provenance pays two retained
+endpoint-site factors and at most two hidden gauge coordinates inherited from
+their boundary `V` links.
+For each primitive potential or bilinear `psi`, the constant-one double-atom
+algebra gives
+
+```text
+||exp(psi)-1||_(2atom)
+ <=exp(||psi||_(2atom))-1
+ <=exp(C_*^(n_a^0+n_a^1)||psi||)-1.                               (3.1)
+```
+
+Applying this safe potential-level majorant before the two cluster groupings
+gives the black-box factors in (0.7)--(0.9).
+
+Because the double-lineage coefficient algebra has a projective weighted
+`l1` product with constant one, the existing rooted-tree and hard-core
+recursions apply with scalar activity replaced by the double-decorated
+activity. If `K_2<c`, they yield (0.13). This is an actual-range atomization
+statement for the complete present bare residual factor grammar pulled back
+through the next skeleton, but its spatial weights remain the weak output
+weights `(Lambda/2,Theta/2)`.
+
+For a mark `O` centered under the full current hidden product-Haar expectation,
+`E_0 O=0`, every future atom projection commutes with `E_0`. Thus
+`E_0 Delta_S^1 O=0`, and its mark-only current fiber integral still vanishes.
+When `O` is measured in the double-decorated strong source norm, the two
+marked-path rerootings apply with `K=K_2`, giving (0.14) into the canonical-
+future-atom weak output norm. No uncharged embedding of a generic undecorated
+strong mark is asserted. This statement also does not replace current product
+Haar centering by the correlated Gaussian center.
+
+The strict inequalities `K_2<c`, `B_2<c`, and `q_split^(2)<1` at (0.11) show
+that the base residual has controlled canonical future atoms in the weak
+coarse norm and give a one-step double-decorated-strong to future-atom-weak
+marked estimate represented in the two-adjacent-horizon atom packet. Upgrading
+to the next strong spatial
+weights would require a density/downshift estimate for nonempty future atoms
+and a separate treatment of the empty future atom. Equation (1.7) proves that
+empty future atoms really occur. A ball additionally requires the perturbation
+factor grammar, a two-mark/same-norm Hessian, center-update and gap control,
+and the correlated-reference attachment theorem.
+
+## 4. Scope and remaining wall
+
+This theorem closes the exact algebraic gauge-tag update route for the
+complete current bare residual and one next skeleton pullback. It does not
+establish a horizon-uniform factor grammar for arbitrary generated actions or
+a new correlated-Gaussian endpoint chart.
+
+- The cost `C_*^(n_a^0+n_a^1)` is a two-level black-box cost; no all-scale
+  bound is inferred.
+- Current and future atom labels are canonical only relative to the declared
+  product references and skeleton chart.
+- The fixed-`m` onsite endpoint atoms are projected in `J_a^1` and inherited
+  through the gauge pullback; changing the Gaussian center requires a separate
+  covariance/chart theorem and is not hidden in this fixed reference.
+- Equation (0.13) controls the base residual, not every perturbation in a
+  radius-`c` ball, and does so only at weak coarse spatial weights.
+- Equation (0.14) uses a current product-Haar-centered mark. The correlated
+  Gaussian `G_(A_II)` still couples sites and lacks a local marked-cluster
+  attachment theorem in this campaign.
+- The extracted quadratic center has not yet been proved to update with a
+  uniform gap, and no normalization condition selects its running coordinate.
+
+Thus there is no invariant ball, fixed point, tuned critical trajectory,
+Lorentz/QFT continuum, Standard Model limit, gravity limit, or axiom-update
+conclusion. No axiom-update stop is established.
+
+The next exact targets are (i) a strong-spatial handoff splitting nonempty
+future atoms from the genuine empty-atom/raw-lift sector and (ii) a covariance-
+local cluster representation for the normalized correlated Berezin
+expectation, with a marked-source estimate uniform under the displayed gap.
+
+## 5. Runner contract
+
+Run:
+
+```bash
+python3 scripts/wilson_staggered_two_horizon_skeleton_pullback_reatomization_2026_07_12.py
+```
+
+The runner checks nested atom reconstruction and the double `C_*` bound,
+projection commutation, current-integration/future-atom commutation, exact tag
+creation and erasure witnesses, finite decorated factor/logarithm evaluation,
+representative grammar-derived coordinate-count fixtures, the activity and
+marked rows, the strict beta interval, and the source/dependency contract. The
+general coordinate-count proof and infinite cluster convergence use the
+displayed analytic grammar and nonnegative KP majorant.
+
+## 6. No-Go Discipline N1--N8
+
+The theorem is constructive. This packet prevents a two-level identity from
+being advertised as all-scale autonomy.
+
+### N1 — alternative-route enumeration
+
+| Route | Status | Executed result |
+|---|---|---|
+| Propagate current Boolean tags | `ATTEMPTED` | The `V` and `V_1V_2=W` witnesses show both tag creation and erasure, so this route fails exactly. |
+| Substitute the next skeleton and re-atomize full coefficients | `ATTEMPTED` | Equations (1.3)--(1.6) prove the exact two-level intertwining. |
+| Re-atomize only after current cluster evaluation | `ATTEMPTED` | Equations (2.3)--(2.4) give the exact output atoms, while the pre-integration lift supplies the activity bound. |
+| Charge syntactic support as genuine tag density | `ATTEMPTED` | Equation (1.7) again gives an empty future atom despite two nonempty carriers. |
+| Double-decorated KP output | `ATTEMPTED` | Equations (0.7)--(0.15) give a strict canonical-future-atom weak base row and one double-decorated-strong to future-atom-weak mark row. |
+
+Strong-spatial tag-density/empty-atom handoff, correlated-Gaussian clusters,
+all-generated-factor closure, center-update normalization, same-norm two-mark
+bounds, Peter--Weyl smoothing, and taste-faithful blocking remain live and are
+not labeled attempted.
+
+### N2 — wall-independence audit
+
+The five remaining conditions are `strong-spatial tag-density/empty-atom
+handoff`, `correlated Gaussian attachment/running gap`, `generated-ball
+Hessian/invariance`, `physical taste/chart identification`, and `critical
+trajectory/observable identification`.
+
+| Left | Right | Left closes right? | Right closes left? | Independent? |
+|---|---|---:|---:|---:|
+| strong-spatial handoff | correlated Gaussian attachment | No | No | Yes |
+| strong-spatial handoff | generated-ball invariance | No | No | Yes |
+| strong-spatial handoff | physical taste/chart | No | No | Yes |
+| strong-spatial handoff | critical trajectory/observable | No | No | Yes |
+| correlated Gaussian attachment | generated-ball invariance | No | No | Yes |
+| correlated Gaussian attachment | physical taste/chart | No | No | Yes |
+| correlated Gaussian attachment | critical trajectory/observable | No | No | Yes |
+| generated-ball invariance | physical taste/chart | No | No | Yes |
+| generated-ball invariance | critical trajectory/observable | No | No | Yes |
+| physical taste/chart | critical trajectory/observable | No | No | Yes |
+
+### N3 — hidden-condition phrase scan
+
+| Phrase | Classification |
+|---|---|
+| `canonical re-Hoeffding` | Canonical only for the declared product reference and skeleton chart. |
+| `intertwining` | The exact two-level projection identity (1.5), not a three-level composition or dynamical cocycle. |
+| `actual range` | The complete present bare residual after one future pullback, canonically atomized only at weak spatial weights. |
+| `future atoms` | Canonical coefficient atoms at the second horizon; they do not restore the next strong spatial weights. |
+| `uniform` | Regulator-uniform for two horizons; never horizon-uniform. |
+| `membership` | Base-point weak norm membership (0.13), not return to the next strong norm or invariance of a neighborhood. |
+| `contraction` | Used only for the one-step double-decorated-strong to future-atom-weak mark number (0.14); no generic-source, same-norm, or autonomous-map claim. |
+| `by construction` | No proof-substitute use. |
+
+### N4 — citation/residual matching
+
+| Dependency | Exact use | Match? |
+|---|---|---:|
+| [Gauge block/Schur theorem](MASSIVE_WILSON_STAGGERED_FACTOR_TWO_GAUGE_BLOCK_SCHUR_OS_SEMIGROUP_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Exact straight skeleton, Haar disintegration, semigroup, and determinant/Schur grammar | Yes |
+| [Declared RG chart](WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Fine/coarse support chart used with the half-weight output; the one-horizon dependency supplies the strong/weak boundary | Yes |
+| [One-horizon lineage theorem](WILSON_STAGGERED_ONE_HORIZON_HAAR_BEREZIN_HOEFFDING_LINEAGE_CLUSTER_LIFT_BOUNDED_THEOREM_NOTE_2026-07-12.md) | Complete residual factors, atom algebra, KP conversion, marked reuse, and current-tag witnesses | Yes |
+
+### N5 — rhetoric and resolution audit
+
+The factor grammar is complete only for the present bare residual after the
+already extracted shortest center. The exact intertwining spans two adjacent
+coordinate layers, while the converted spatial norm remains weak. The theorem
+does not say that all generated perturbations have the same grammar, that the
+strong-spatial handoff closes, that the center remains gapped, or that the
+displayed massive point lies on a critical continuum trajectory.
+
+### N6 — partial-closure and primitive scan
+
+The result closes the two-level coefficient tag-update wall, but not the
+strong-spatial handoff wall. It uses the already declared skeleton and product
+expectations and adds no physical action, time, probability, carrier, taste,
+scale, or state primitive. The remaining spatial, covariance, and invariant-
+ball work is constructive analysis, not evidence that an axiom is missing.
+
+### N7 — hostile steelman
+
+A hostile reviewer should demand an example where current tags fail to predict
+future tags; both directions are explicit in (1.7) and its preceding `V`
+witness. They should also object that a finite two-level factor bound may grow
+under further iteration and says nothing about perturbation closure. Correct;
+the theorem claims neither horizon uniformity nor a ball. Finally, they should
+demand the missing spatial half-weight restoration before calling (0.13) a
+strong return, and correlated-Gaussian attachment before calling (0.14) a
+running-center result. Correct; neither claim is made.
+
+### N8 — cross-cycle echo
+
+The prior block proved that formal lineage survives while ordinary tags need
+not. This block does not rename lineage as support. It evaluates the full
+coefficient through the next skeleton and recomputes canonical atoms. The
+result repairs the coefficient tag-update wall while preserving the strong-
+spatial, covariance, center, invariant-ball, and continuum walls.
+
+**No-Go Discipline status: PASS.**

--- a/logs/runner-cache/wilson_staggered_two_horizon_skeleton_pullback_reatomization_2026_07_12.txt
+++ b/logs/runner-cache/wilson_staggered_two_horizon_skeleton_pullback_reatomization_2026_07_12.txt
@@ -1,0 +1,15 @@
+PASS two_level_atom_constant: r*=2.414213562373095, C*=5.828427124746190
+PASS nested_reatomization_reconstruction_and_bound: atoms=16, reconstruction_error=1.110e-16, nested_norm=3.264213562373<=black_box=1350.178986134421
+PASS independent_horizon_projections_commute: max_commutator=1.735e-17
+PASS future_atoms_commute_with_current_integration: max_commutator=0.000e+00
+PASS empty_current_tag_can_become_future_tag: current_nonempty=0.0, current_empty=1.0, future_empty=0.0, future_nonempty=1.0
+PASS future_skeleton_pair_can_erase_tags: V1=B and V2=B^-1 W are tagged separately, while V1V2=W has future atoms empty-only
+PASS two_horizon_decorated_factor_evaluation: decorations=16, evaluation_error=1.735e-18
+PASS two_horizon_logarithm_evaluation: order_three_partial_log_error=1.735e-18
+PASS actual_factor_coordinate_count_fixtures: fixtures=[('Wilson', 4, 4), ('determinant_r4', 4, 0), ('Schur_r4', 4, 4), ('determinant_r6', 6, 0), ('Schur_r6', 6, 4), ('determinant_r8', 8, 0), ('Schur_r8', 8, 4)]
+PASS two_horizon_actual_range_activity: q_hop=4.233344463883365e-03, K_I=4.817630355648377e-10, K_S=6.671509288144902e-06, K_2=6.671991051180467e-06<c
+PASS two_horizon_future_atom_weak_and_marked_constants: tau=2.470974562481002e-03, A_att=4.952040123867673e-03, q_centered=5.551883042195168e-01, q_split=0.606530659713, B_2_weak=7.480172423521457e-04<c
+PASS strict_two_horizon_beta_interval: beta_ceiling=1.505860908679052e-12, K(0.99 beta_ceiling)=9.900667125152236e-04<c
+PASS source_contract: missing=[], forbidden_hits=[]
+PASS repository_dependency_set: markdown_dependency_set=['MASSIVE_WILSON_STAGGERED_FACTOR_TWO_GAUGE_BLOCK_SCHUR_OS_SEMIGROUP_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_ONE_HORIZON_HAAR_BEREZIN_HOEFFDING_LINEAGE_CLUSTER_LIFT_BOUNDED_THEOREM_NOTE_2026-07-12.md']
+SCORECARD PASS=14 FAIL=0

--- a/scripts/wilson_staggered_two_horizon_skeleton_pullback_reatomization_2026_07_12.py
+++ b/scripts/wilson_staggered_two_horizon_skeleton_pullback_reatomization_2026_07_12.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Checks the two-horizon skeleton-pullback/re-Hoeffding theorem."""
+
+from __future__ import annotations
+
+import itertools
+import math
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "WILSON_STAGGERED_TWO_HORIZON_SKELETON_PULLBACK_CANONICAL_"
+    "REHOEFFDING_INTERTWINING_BOUNDED_THEOREM_NOTE_2026-07-12.md"
+)
+
+
+Function = dict[tuple[int, ...], float]
+
+
+def expectation(function: Function, axes: set[int]) -> Function:
+    out: Function = {}
+    for point in function:
+        total = 0.0
+        for values in itertools.product((-1, 1), repeat=len(axes)):
+            source = list(point)
+            for axis, value in zip(sorted(axes), values):
+                source[axis] = value
+            total += function[tuple(source)]
+        out[point] = total / (2 ** len(axes))
+    return out
+
+
+def subtract(left: Function, right: Function) -> Function:
+    return {point: left[point] - right[point] for point in left}
+
+
+def add(functions: list[Function]) -> Function:
+    return {point: sum(function[point] for function in functions) for point in functions[0]}
+
+
+def multiply(*functions: Function) -> Function:
+    return {point: math.prod(function[point] for function in functions) for point in functions[0]}
+
+
+def scale(function: Function, scalar: float) -> Function:
+    return {point: scalar * value for point, value in function.items()}
+
+
+def sup_norm(function: Function) -> float:
+    return max(abs(value) for value in function.values())
+
+
+def component(function: Function, group: set[int], tagged: set[int]) -> Function:
+    out = expectation(function, group - tagged)
+    for axis in sorted(tagged):
+        out = subtract(out, expectation(out, {axis}))
+    return out
+
+
+def atomize(function: Function, group: set[int]) -> dict[tuple[int, ...], Function]:
+    axes = sorted(group)
+    return {
+        tagged: component(function, group, set(tagged))
+        for size in range(len(axes) + 1)
+        for tagged in itertools.combinations(axes, size)
+    }
+
+
+def nested_atoms(
+    function: Function, current: set[int], future: set[int]
+) -> dict[tuple[tuple[int, ...], tuple[int, ...]], Function]:
+    out = {}
+    for current_tag, current_atom in atomize(function, current).items():
+        for future_tag, future_atom in atomize(current_atom, future).items():
+            out[(current_tag, future_tag)] = future_atom
+    return out
+
+
+def nested_norm(function: Function, current: set[int], future: set[int], weight: float) -> float:
+    return sum(
+        weight ** (len(current_tag) + len(future_tag)) * sup_norm(atom)
+        for (current_tag, future_tag), atom in nested_atoms(function, current, future).items()
+    )
+
+
+def max_error(left: Function, right: Function) -> float:
+    return max(abs(left[point] - right[point]) for point in left)
+
+
+def g(value: float) -> float:
+    return math.expm1(value) / value if value else 1.0
+
+
+def integer_sup_n_exp(slack: float) -> tuple[int, float]:
+    critical = 1.0 / slack
+    candidates = {max(1, math.floor(critical)), max(1, math.ceil(critical))}
+    return max(((int(n), n * math.exp(-slack * n)) for n in candidates), key=lambda row: row[1])
+
+
+def integer_sup_attachment(k_value: float, c: float) -> tuple[int, float]:
+    critical = -math.log1p(-k_value / c) / k_value
+    candidates = {max(1, math.floor(critical)), max(1, math.ceil(critical))}
+    return max(
+        ((int(n), math.exp(-c * n) * math.expm1(k_value * n)) for n in candidates),
+        key=lambda row: row[1],
+    )
+
+
+def attachment_constants(k_value: float, c: float) -> dict[str, float]:
+    n_d, d_slack = integer_sup_n_exp(c - k_value)
+    n_a, a_zero = integer_sup_attachment(k_value, c)
+    tau = k_value * d_slack
+    anchored = (a_zero + tau / (1.0 - tau)) / (1.0 - tau)
+    return {
+        "n_d": float(n_d),
+        "d_slack": d_slack,
+        "n_a": float(n_a),
+        "a_zero": a_zero,
+        "tau": tau,
+        "A_att": anchored,
+    }
+
+
+def two_horizon_rows(
+    mass: float, beta: float, c: float, theta: float, lam: float, eta: float
+) -> dict[str, float]:
+    coordinate_cost = 3.0 + 2.0 * math.sqrt(2.0)
+    h = 4.0 / mass
+    total_weight = theta + 2.0 * c + lam
+    wilson = (
+        12.0
+        * math.expm1((3.0 * beta / 4.0) * coordinate_cost**8)
+        * math.exp(4.0 * total_weight)
+    )
+    determinant = 0.0
+    schur = 0.0
+    for length in range(4, 10000, 2):
+        det_term = (
+            1.5
+            * coordinate_cost**length
+            * h**length
+            * g(3.0 * coordinate_cost**length * h**length / length)
+            * math.exp(length * total_weight)
+        )
+        determinant += det_term
+        x_length = 9.0 * eta**2 * 2.0 ** (-length) * mass ** (-(length - 1))
+        schur_term = (
+            18.0
+            * eta**2
+            * coordinate_cost ** (length + 4)
+            * length
+            * h ** (length - 1)
+            * g(coordinate_cost ** (length + 4) * x_length)
+            * math.exp(length * total_weight)
+        )
+        schur += schur_term
+        if max(det_term, schur_term) < 1.0e-24:
+            break
+    return {
+        "C": coordinate_cost,
+        "q_hop": h * coordinate_cost * math.exp(total_weight),
+        "K_W": wilson,
+        "K_I": determinant,
+        "K_S": schur,
+        "K": wilson + determinant + schur,
+    }
+
+
+def main() -> None:
+    checks: list[tuple[str, bool, str]] = []
+    r_star = 1.0 + math.sqrt(2.0)
+    coordinate_cost = r_star**2
+    checks.append(
+        (
+            "two_level_atom_constant",
+            math.isclose(coordinate_cost, 3.0 + 2.0 * math.sqrt(2.0), abs_tol=1.0e-14),
+            f"r*={r_star:.15f}, C*={coordinate_cost:.15f}",
+        )
+    )
+
+    points = tuple(itertools.product((-1, 1), repeat=4))
+    current = {0, 1}
+    future = {2, 3}
+    function = {
+        point: (
+            0.6
+            + 0.13 * point[0]
+            - 0.17 * point[1]
+            + 0.11 * point[2]
+            + 0.07 * point[0] * point[3]
+            - 0.09 * point[1] * point[2] * point[3]
+        )
+        for point in points
+    }
+    atoms = nested_atoms(function, current, future)
+    reconstructed = add(list(atoms.values()))
+    bound = coordinate_cost ** (len(current) + len(future)) * sup_norm(function)
+    checks.append(
+        (
+            "nested_reatomization_reconstruction_and_bound",
+            max_error(function, reconstructed) < 1.0e-14
+            and nested_norm(function, current, future, r_star) <= bound + 1.0e-12,
+            "atoms={}, reconstruction_error={:.3e}, nested_norm={:.12f}<=black_box={:.12f}".format(
+                len(atoms), max_error(function, reconstructed), nested_norm(function, current, future, r_star), bound
+            ),
+        )
+    )
+
+    current_tag, future_tag = {0}, {2, 3}
+    current_then_future = component(component(function, current, current_tag), future, future_tag)
+    future_then_current = component(component(function, future, future_tag), current, current_tag)
+    checks.append(
+        (
+            "independent_horizon_projections_commute",
+            max_error(current_then_future, future_then_current) < 1.0e-14,
+            f"max_commutator={max_error(current_then_future, future_then_current):.3e}",
+        )
+    )
+
+    integrated_after = expectation(component(function, future, {2}), current)
+    projected_after = component(expectation(function, current), future, {2})
+    checks.append(
+        (
+            "future_atoms_commute_with_current_integration",
+            max_error(integrated_after, projected_after) < 1.0e-14,
+            f"max_commutator={max_error(integrated_after, projected_after):.3e}",
+        )
+    )
+
+    two_points = tuple(itertools.product((-1, 1), repeat=2))
+    current_dummy_future_live = {point: float(point[1]) for point in two_points}
+    current_atoms = atomize(current_dummy_future_live, {0})
+    future_atoms = atomize(current_dummy_future_live, {1})
+    checks.append(
+        (
+            "empty_current_tag_can_become_future_tag",
+            sup_norm(current_atoms[(0,)]) < 1.0e-14
+            and sup_norm(current_atoms[()]) > 0.9
+            and sup_norm(future_atoms[()]) < 1.0e-14
+            and sup_norm(future_atoms[(1,)]) > 0.9,
+            "current_nonempty={:.1f}, current_empty={:.1f}, future_empty={:.1f}, future_nonempty={:.1f}".format(
+                sup_norm(current_atoms[(0,)]),
+                sup_norm(current_atoms[()]),
+                sup_norm(future_atoms[()]),
+                sup_norm(future_atoms[(1,)]),
+            ),
+        )
+    )
+
+    w_value = -1.0
+    first_half = {point: float(point[1]) for point in two_points}
+    second_half = {point: float(point[1]) * w_value for point in two_points}
+    product = multiply(first_half, second_half)
+    checks.append(
+        (
+            "future_skeleton_pair_can_erase_tags",
+            sup_norm(atomize(first_half, {1})[(1,)]) > 0.9
+            and sup_norm(atomize(second_half, {1})[(1,)]) > 0.9
+            and sup_norm(atomize(product, {1})[(1,)]) < 1.0e-14
+            and math.isclose(sup_norm(atomize(product, {1})[()]), 1.0),
+            "V1=B and V2=B^-1 W are tagged separately, while V1V2=W has future atoms empty-only",
+        )
+    )
+
+    factor_one = {
+        point: 0.08 + 0.12 * point[0] - 0.05 * point[2] + 0.03 * point[0] * point[2]
+        for point in points
+    }
+    factor_two = {
+        point: -0.04 + 0.09 * point[0] + 0.06 * point[2] - 0.02 * point[0] * point[2]
+        for point in points
+    }
+    test_current = {0}
+    test_future = {2}
+    direct_output = expectation(multiply(factor_one, factor_two), test_current)
+    decorated_outputs: list[Function] = []
+    for atom_one, atom_two in itertools.product(
+        nested_atoms(factor_one, test_current, test_future).values(),
+        nested_atoms(factor_two, test_current, test_future).values(),
+    ):
+        decorated_outputs.append(expectation(multiply(atom_one, atom_two), test_current))
+    evaluated_output = add(decorated_outputs)
+    checks.append(
+        (
+            "two_horizon_decorated_factor_evaluation",
+            max_error(direct_output, evaluated_output) < 1.0e-14,
+            f"decorations={len(decorated_outputs)}, evaluation_error={max_error(direct_output,evaluated_output):.3e}",
+        )
+    )
+
+    direct_log = {point: 0.0 for point in points}
+    decorated_log = {point: 0.0 for point in points}
+    for order in range(1, 4):
+        coefficient = ((-1) ** (order + 1)) / order
+        direct_log = add([direct_log, scale(multiply(*([direct_output] * order)), coefficient)])
+        decorated_power = add(
+            [multiply(*choice) for choice in itertools.product(decorated_outputs, repeat=order)]
+        )
+        decorated_log = add([decorated_log, scale(decorated_power, coefficient)])
+    checks.append(
+        (
+            "two_horizon_logarithm_evaluation",
+            max_error(direct_log, decorated_log) < 1.0e-13,
+            f"order_three_partial_log_error={max_error(direct_log,decorated_log):.3e}",
+        )
+    )
+
+    wilson_current = {f"fine_hidden_link_{index}" for index in range(4)}
+    wilson_future = {f"exposed_coarse_link_{index}" for index in range(4)}
+    count_fixtures = []
+    count_fixtures.append(("Wilson", len(wilson_current), len(wilson_future), 4, 4))
+    for length in (4, 6, 8):
+        determinant_current = {f"II_link_{index}" for index in range(length)}
+        determinant_future: set[str] = set()
+        schur_current = {f"Schur_link_{index}" for index in range(length)}
+        schur_future = {"left_boundary_V", "right_boundary_V", "left_endpoint", "right_endpoint"}
+        count_fixtures.append(
+            (f"determinant_r{length}", len(determinant_current), len(determinant_future), length, 0)
+        )
+        count_fixtures.append((f"Schur_r{length}", len(schur_current), len(schur_future), length, 4))
+    count_ok = all((n0, n1) == (bound0, bound1) for _, n0, n1, bound0, bound1 in count_fixtures)
+    checks.append(
+        (
+            "actual_factor_coordinate_count_fixtures",
+            count_ok,
+            "fixtures=" + str([(name, n0, n1) for name, n0, n1, _, _ in count_fixtures]),
+        )
+    )
+
+    mass, beta, c, theta, lam = 1.5e4, 0.0, 0.001, 1.0e-6, 1.0
+    eta = mass**-0.5
+    rows = two_horizon_rows(mass, beta, c, theta, lam, eta)
+    checks.append(
+        (
+            "two_horizon_actual_range_activity",
+            rows["q_hop"] < 0.00424
+            and rows["K_I"] < 4.82e-10
+            and rows["K_S"] < 6.672e-6
+            and rows["K"] < c,
+            "q_hop={:.15e}, K_I={:.15e}, K_S={:.15e}, K_2={:.15e}<c".format(
+                rows["q_hop"], rows["K_I"], rows["K_S"], rows["K"]
+            ),
+        )
+    )
+
+    attachment = attachment_constants(rows["K"], c)
+    conversion = 68.0 * math.exp(lam / 2.0)
+    q_centered = conversion * attachment["A_att"]
+    q_split = max(math.exp(-lam / 2.0), q_centered)
+    base_defect = conversion * rows["K"]
+    checks.append(
+        (
+            "two_horizon_future_atom_weak_and_marked_constants",
+            q_centered < 0.556 and q_split < 0.607 and base_defect < c,
+            "tau={:.15e}, A_att={:.15e}, q_centered={:.15e}, q_split={:.12f}, B_2_weak={:.15e}<c".format(
+                attachment["tau"], attachment["A_att"], q_centered, q_split, base_defect
+            ),
+        )
+    )
+
+    beta_ceiling = (4.0 / 3.0) * math.log1p(
+        (c - rows["K_I"] - rows["K_S"])
+        / (12.0 * math.exp(4.0 * (theta + 2.0 * c + lam)))
+    )
+    beta_ceiling /= coordinate_cost**8
+    probe = two_horizon_rows(mass, 0.99 * beta_ceiling, c, theta, lam, eta)
+    checks.append(
+        (
+            "strict_two_horizon_beta_interval",
+            1.50e-12 < beta_ceiling < 1.51e-12 and probe["K"] < c,
+            f"beta_ceiling={beta_ceiling:.15e}, K(0.99 beta_ceiling)={probe['K']:.15e}<c",
+        )
+    )
+
+    text = NOTE.read_text()
+    required = [
+        "**Type:** bounded_theorem",
+        "Delta_S^1 Delta_T^0",
+        "ev_1(Gamma_hat_res^(2))",
+        "two-adjacent-horizon atom packet",
+        "No axiom-update stop",
+        "### N1",
+        "### N2",
+        "### N3",
+        "### N4",
+        "### N5",
+        "### N6",
+        "### N7",
+        "### N8",
+    ]
+    missing = [item for item in required if item not in text]
+    forbidden = [
+        "proves an autonomous RG",
+        "lineage is physical support",
+        "future strong provenance chart",
+        "strict future-strong",
+        "NOT_TESTED",
+    ]
+    hits = [item for item in forbidden if item in text]
+    checks.append(("source_contract", not missing and not hits, f"missing={missing}, forbidden_hits={hits}"))
+
+    expected_dependencies = sorted(
+        [
+            "MASSIVE_WILSON_STAGGERED_FACTOR_TWO_GAUGE_BLOCK_SCHUR_OS_SEMIGROUP_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_DECLARED_RG_CHART_RAW_LIFT_GEOMETRIC_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_ONE_HORIZON_HAAR_BEREZIN_HOEFFDING_LINEAGE_CLUSTER_LIFT_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+        ]
+    )
+    dependencies = sorted(set(re.findall(r"\]\(([^)#?]+\.md)\)", text)))
+    checks.append(
+        (
+            "repository_dependency_set",
+            dependencies == expected_dependencies,
+            f"markdown_dependency_set={dependencies}",
+        )
+    )
+
+    passed = sum(ok for _, ok, _ in checks)
+    failed = len(checks) - passed
+    for name, ok, detail in checks:
+        print(f"{'PASS' if ok else 'FAIL'} {name}: {detail}")
+    print(f"SCORECARD PASS={passed} FAIL={failed}")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Result

- retains complete factor coefficients, performs the exact next-skeleton pullback, and proves a two-level re-Hoeffding intertwining identity
- includes every future hidden gauge coordinate, including nonskeleton links, plus fixed-m endpoint Gaussian provenance
- proves exact decorated cluster/log evaluation to genuine canonical future atoms, with explicit future-tag creation and erasure witnesses
- gives safe two-level activities for the actual Wilson/determinant/Schur grammar and a strict fixed-m witness

## Honest boundary

The converted base row is controlled only at weak coarse spatial weights: B2_weak=7.480172423521e-4<c. The marked number is a one-step double-decorated-strong to future-atom-weak estimate, q=0.606530659713. This PR does not prove next-strong spatial handoff, tag density, empty-atom control, a second RG integration, an all-scale cocycle, correlated-Gaussian attachment, an invariant ball, or a continuum result.

## Verification

- runner/cache: PASS=14 FAIL=0, byte-exact
- independent code/math, physics/import/Nature, and governance/no-go: pass with bounded claims
- full audit pipeline and strict lint: zero errors
- seeded bounded_theorem / unaudited with exactly three dependencies
- vocabulary lint, py_compile, and git diff --check: clean