### PR TITLE
audit-infra: bind N6 dispositions to wall IDs

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -503,7 +503,7 @@ supply it. Otherwise replace it with:
         "closure_mechanism": "<include indexed_basis verbatim, then use 40+ normalized characters to explain how the candidate could close that wall>",
         "could_close_wall": false,
         "addressed": true,
-        "disposition": "<why the candidate does or does not close the scoped wall>",
+        "disposition": "<include affected_wall verbatim, then explain why the candidate does or does not close it>",
         "evidence_path": "<manifest path>",
         "evidence_locator": "<actual locator>"
       }
@@ -654,8 +654,10 @@ place any of them on the `N5_rhetoric_audit` section object itself.
 For every N6 candidate, copy `indexed_basis` exactly from its orchestrator
 candidate record and include that complete `indexed_basis` text verbatim
 inside `closure_mechanism` before explaining how the candidate could affect
-the named wall. A paraphrase or merely related explanation does not satisfy
-the authenticated-basis binding.
+the named wall. Also include the complete `affected_wall` text verbatim inside
+that candidate's `disposition` before explaining why the wall does or does not
+close. A paraphrase or merely related explanation does not satisfy either
+authenticated binding.
 
 For each N5 statement, `resolution_classes_checked` must equal the five canonical classes exactly,
 and `tested_resolutions` must contain exactly five entries: one and only one

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -7868,6 +7868,10 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             template_flat,
         )
         self.assertIn(
+            "include the complete `affected_wall` text verbatim inside that candidate's `disposition`",
+            template_flat,
+        )
+        self.assertIn(
             "Copy the complete authenticated tuple",
             template_flat,
         )
@@ -9781,6 +9785,20 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         self.assertIn("copy indexed_basis exactly", n6_basis_prompt)
         self.assertIn("complete text verbatim", n6_basis_prompt)
         self.assertNotIn("candidate 1", n6_basis_prompt)
+        n6_wall_error = (
+            "N6 candidate 1.disposition must name its affected_wall secret_wall"
+        )
+        n6_wall_code = m.fresh_schema_retry_code(n6_wall_error)
+        self.assertEqual(
+            n6_wall_code, "N6_AFFECTED_WALL_VERBATIM_MISMATCH"
+        )
+        n6_wall_prompt = m.render_fresh_schema_retry_prompt(
+            "ORIGINAL RESTRICTED PACKET", n6_wall_code, 1,
+        )
+        self.assertIn("copy affected_wall exactly", n6_wall_prompt)
+        self.assertIn("complete text verbatim inside its disposition", n6_wall_prompt)
+        self.assertNotIn("candidate 1", n6_wall_prompt)
+        self.assertNotIn("secret_wall", n6_wall_prompt)
 
     def test_failed_locator_repair_preserves_fresh_schema_eligibility(self):
         m = _import_codex_audit_runner()

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1717,6 +1717,11 @@ def fresh_schema_retry_code(validation_error: str) -> str:
         and ".closure_mechanism must use its indexed_basis" in validation_error
     ):
         return "N6_INDEXED_BASIS_VERBATIM_MISMATCH"
+    if (
+        validation_error.startswith("N6 candidate ")
+        and ".disposition must name its affected_wall" in validation_error
+    ):
+        return "N6_AFFECTED_WALL_VERBATIM_MISMATCH"
     return "AUDIT_SCHEMA_REJECT"
 
 
@@ -1808,6 +1813,12 @@ def render_fresh_schema_retry_prompt(
             "record and include that complete text verbatim inside the same "
             "candidate's closure_mechanism before the explanation of how it could "
             "affect the named wall. Do not paraphrase or shorten indexed_basis.\n"
+        ),
+        "N6_AFFECTED_WALL_VERBATIM_MISMATCH": (
+            "Static N6 invariant: copy affected_wall exactly from the same "
+            "candidate and include that complete text verbatim inside its "
+            "disposition before explaining why the candidate does or does not "
+            "close the wall. Do not paraphrase or shorten affected_wall.\n"
         ),
     }.get(validation_code, "")
     return (


### PR DESCRIPTION
## Summary
- align the N6 prompt contract with the existing affected-wall validator
- add conclusion-blind typed retry guidance for wall-binding failures
- add regression coverage without exposing rejected candidate content

## Verification
- independent review-loop PASS at `9dc1cdcfbb56f2215f93eef3226fba6c44c43466`
- 309 tests passed
- audit pipeline passed
- strict audit lint passed
- no audit verdicts or generated status files changed