### PR TITLE
audit: evidence finite R-eta singleton route

### DIFF
--- a/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -110,7 +110,7 @@ Historical decision text identifies provenance only and is not used as proof.
 | Pointwise realized-state evaluation | ATTEMPTED | Evaluating the same realized record state leaves the law-level coefficient `beta` free; [realized-state primitive](REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md) boundary plus runner Parts A--C. |
 | Dimensionful scale reference | ATTEMPTED | The [scale-reference primitive](SCALE_REFERENCE_PRIMITIVE_NOTE.md) supplies units conversion and no dimensionless phase, selector, or readout bridge; `beta` is dimensionless, runner Part D. |
 | Kinetic-form isotropy | ATTEMPTED | The [kinetic-isotropy primitive](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md) supplies `c_t=c_s` and no phase, selector, or readout bridge; the family is unchanged, runner Part D. |
-| Exact fixed-locus value | ATTEMPTED | Granting the nonzero value `h=2/9` leaves both `beta=1` and `beta=2`; runner Part A checks the singleton and cycle values separately. |
+| Exact fixed-locus value | ATTEMPTED | Granting the nonzero value `h=2/9` leaves both `beta=1` and `beta=2`; runner Part A checks the singleton and cycle values separately, including the live `N1 numerical_or_finite_case` finite singleton point-evaluation marker. |
 | Coordinate-convention steelman | ATTEMPTED | N7 convention mechanism: same-observable common-unit rescaling. N7 convention attempt: multiply `h` and `abs(delta_beta)` by the same positive unit factor. N7 convention outcome: `beta=abs(delta_beta)/h` remains invariant and the `W_unit` readout bridge is not selected. Runner Part E verifies the symbolic identity and finite exact examples. |
 
 The runner checks all eight routes. Their authority boundary is the current
@@ -228,4 +228,4 @@ Run:
 python3 scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
 ```
 
-Expected result: `PASS=55`, `FAIL=0`.
+Expected result: `PASS=56`, `FAIL=0`.

--- a/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
-runner_sha256: 05459bf60276df17189636d471996081a4afc6f59b3cd988f1963558199f8e30
+runner_sha256: 86cf54b9a9f3f6e4c4d76b9d9e232d2950e76f8b22f0daed479f5ecc705ca5e4
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.33
+elapsed_sec: 0.27
 status: ok
 ----- stdout -----
 Record additivity and the R-eta unit-calibration countermodel
@@ -16,6 +16,7 @@ Part A: exact beta family
   [PASS] finite disjoint additivity holds for every tested beta
   [PASS] target singleton eta angle is 2/9
   [PASS] countermodel singleton eta angle is 4/9
+  [PASS] N1 numerical_or_finite_case mechanism: finite singleton point evaluation; N1 numerical_or_finite_case attempt: finite cardinality formula at n=1; N1 numerical_or_finite_case outcome: finite beta-one and beta-two singleton readouts remain distinct
   [PASS] target cycle holonomy is 2/3
   [PASS] countermodel cycle holonomy is 4/3
   [PASS] target and countermodel share the same h
@@ -88,7 +89,7 @@ Part F: source and axiom guards
   [PASS] discipline gate records PASS
 
 ========================================================================
-TOTAL: PASS=55, FAIL=0
+TOTAL: PASS=56, FAIL=0
 
 ----- stderr -----
 

--- a/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
@@ -63,6 +63,15 @@ def main() -> int:
     )
     check("target singleton eta angle is 2/9", readout(beta_target, h, singleton) == Fraction(2, 9))
     check("countermodel singleton eta angle is 4/9", readout(beta_counter, h, singleton) == Fraction(4, 9))
+    check(
+        "N1 numerical_or_finite_case mechanism: finite singleton point evaluation; "
+        "N1 numerical_or_finite_case attempt: finite cardinality formula at n=1; "
+        "N1 numerical_or_finite_case outcome: finite beta-one and beta-two singleton readouts remain distinct",
+        len(singleton) == 1
+        and readout(beta_target, h, singleton) == h
+        and readout(beta_counter, h, singleton) == 2 * h
+        and readout(beta_target, h, singleton) != readout(beta_counter, h, singleton),
+    )
     check("target cycle holonomy is 2/3", readout(beta_target, h, cycle) == Fraction(2, 3))
     check("countermodel cycle holonomy is 4/3", readout(beta_counter, h, cycle) == Fraction(4, 3))
     check("target and countermodel share the same h", h == Fraction(2, 9))


### PR DESCRIPTION
## Summary
- add an assertion-backed finite-singleton marker for the existing `numerical_or_finite_case` N1 route
- point the no-go note at the live marker and refresh its expected runner count
- refresh the deterministic runner cache

This is evidence repair only: it does not change theorem scope, select `beta=1`, add a premise, or force `r=1/2`.

## Verification
- independent review-loop PASS at `0dde6a743d020f535e2d62b99eb94ef87ecae362`
- focused runner: `PASS=56`, `FAIL=0`
- cache freshness/live-output check passed
- audit pipeline passed
- strict audit lint passed with zero errors
- no audit verdict or generated status file changed