### PR TITLE
audit-infra: backfill pre-contract seat rationales from bound envelopes

### DIFF
--- a/docs/audit/scripts/backfill_cross_seat_rationales.py
+++ b/docs/audit/scripts/backfill_cross_seat_rationales.py
@@ -14,14 +14,14 @@ disagreement row it scans the supplied delivery directories for envelopes
 whose ``audit.claim_id`` matches the row and whose
 ``audit.audit_invocation_id`` EQUALS the invocation id already recorded in
 the seat summary, then copies the envelope's ``verdict_rationale`` and
-``notes_for_re_audit_if_any`` into that summary. Every other summary field
-is cross-checked against the envelope first (verdict, claim_type,
-normalized claim_scope, load_bearing_step_class, auditor,
-negative_assertion_classes) and ANY mismatch refuses the row: an envelope
-that disagrees with the recorded seat is not evidence, whatever its
-invocation id says. Rows whose summaries already carry rationales are left
-untouched. Nothing is deleted and no verdict, status, or tuple field is
-modified.
+``notes_for_re_audit_if_any`` into that summary. Every recorded seat field
+other than those two backfill fields is cross-checked against the envelope
+first (with the same whitespace normalization for ``claim_scope`` and set
+normalization for ``negative_assertion_classes`` used by ``apply_audit.py``).
+ANY mismatch refuses that seat: an envelope that disagrees with the recorded
+seat is not evidence, whatever its invocation id says. Rows whose summaries
+already carry rationales are left untouched. Nothing is deleted and no
+verdict, status, or tuple field is modified.
 
 Run from a dedicated clean ``main`` checkout; commit the ledger change
 through the standard pipeline gates like any audit-data repair.
@@ -40,20 +40,38 @@ import orchestrate_audit_batch as batch  # noqa: E402
 
 LEDGER = batch.DATA / "audit_ledger.json"
 
-CHECKED_FIELDS = (
+REQUIRED_BINDING_FIELDS = (
     "verdict",
     "claim_type",
+    "claim_scope",
     "load_bearing_step_class",
+    "negative_assertion_classes",
     "auditor",
+    "auditor_family",
+    "auditor_model",
+    "auditor_reasoning_effort",
+    "independence",
+    "audit_date",
+    "audit_invocation_id",
 )
+BACKFILL_FIELDS = {"verdict_rationale", "notes_for_re_audit_if_any"}
 
 
 def norm(value: str) -> str:
-    return re.sub(r"\s+", " ", str(value or "").strip())
+    return re.sub(r"\s+", " ", value.strip())
+
+
+def normalized_classes(value: object) -> tuple[str, ...] | None:
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) for item in value
+    ):
+        return None
+    return tuple(sorted(set(value)))
 
 
 def envelope_index(delivery_dirs: list[Path]) -> dict[tuple[str, str], dict]:
     index: dict[tuple[str, str], dict] = {}
+    sources: dict[tuple[str, str], Path] = {}
     for directory in delivery_dirs:
         for path in sorted(directory.glob("delivery-*.json")):
             try:
@@ -66,26 +84,68 @@ def envelope_index(delivery_dirs: list[Path]) -> dict[tuple[str, str], dict]:
             cid = str(audit.get("claim_id") or "")
             invocation = str(audit.get("audit_invocation_id") or "")
             if cid and invocation:
-                index[(cid, invocation)] = audit
+                key = (cid, invocation)
+                if key in index:
+                    if index[key] != audit:
+                        raise ValueError(
+                            "conflicting delivery envelopes for "
+                            f"claim {cid!r}, invocation {invocation}: "
+                            f"{sources[key]} and {path}"
+                        )
+                    continue
+                index[key] = audit
+                sources[key] = path
     return index
 
 
-def seat_mismatch(summary: dict, audit: dict) -> str | None:
-    for field in CHECKED_FIELDS:
-        if summary.get(field) != audit.get(field):
-            return (
-                f"{field} mismatch: summary={summary.get(field)!r} "
-                f"envelope={audit.get(field)!r}"
-            )
-    if norm(summary.get("claim_scope")) != norm(audit.get("claim_scope")):
+def seat_mismatch(
+    summary: dict,
+    audit: dict,
+    expected_claim_id: str,
+    expected_invocation_id: str,
+) -> str | None:
+    if audit.get("claim_id") != expected_claim_id:
+        return (
+            f"claim_id mismatch: row={expected_claim_id!r} "
+            f"envelope={audit.get('claim_id')!r}"
+        )
+    if audit.get("audit_invocation_id") != expected_invocation_id:
+        return (
+            "audit_invocation_id mismatch: "
+            f"summary={expected_invocation_id!r} "
+            f"envelope={audit.get('audit_invocation_id')!r}"
+        )
+    missing = [field for field in REQUIRED_BINDING_FIELDS if field not in summary]
+    if missing:
+        return f"summary missing recorded binding fields: {missing}"
+
+    summary_scope = summary.get("claim_scope")
+    audit_scope = audit.get("claim_scope")
+    if not isinstance(summary_scope, str) or not isinstance(audit_scope, str):
+        return "claim_scope mismatch: both values must be strings"
+    if norm(summary_scope) != norm(audit_scope):
         return "claim_scope mismatch after whitespace normalization"
-    summary_classes = sorted(summary.get("negative_assertion_classes") or [])
-    audit_classes = sorted(audit.get("negative_assertion_classes") or [])
+
+    summary_classes = normalized_classes(summary.get("negative_assertion_classes"))
+    audit_classes = normalized_classes(audit.get("negative_assertion_classes"))
+    if summary_classes is None or audit_classes is None:
+        return (
+            "negative_assertion_classes mismatch: both values must be "
+            "lists of strings"
+        )
     if summary_classes != audit_classes:
         return (
             f"negative_assertion_classes mismatch: summary={summary_classes} "
             f"envelope={audit_classes}"
         )
+
+    special_fields = {"claim_scope", "negative_assertion_classes"}
+    for field in sorted(set(summary) - BACKFILL_FIELDS - special_fields):
+        if summary.get(field) != audit.get(field):
+            return (
+                f"{field} mismatch: summary={summary.get(field)!r} "
+                f"envelope={audit.get(field)!r}"
+            )
     return None
 
 
@@ -103,19 +163,26 @@ def backfill_row(row: dict, index: dict[tuple[str, str], dict]) -> tuple[int, li
             continue
         invocation = str(summary.get("audit_invocation_id") or "")
         if not invocation:
-            problems.append(f"{label}: summary has no invocation id")
+            problems.append(
+                f"{label}: summary has no invocation id; fresh seat rerun required"
+            )
             continue
         audit = index.get((cid, invocation))
         if audit is None:
-            problems.append(f"{label}: no envelope bound to invocation {invocation[:12]}")
+            problems.append(
+                f"{label}: no envelope bound to invocation {invocation[:12]}; "
+                "fresh seat rerun required if the original envelope is unavailable"
+            )
             continue
-        mismatch = seat_mismatch(summary, audit)
+        mismatch = seat_mismatch(summary, audit, cid, invocation)
         if mismatch:
             problems.append(f"{label}: {mismatch}")
             continue
-        rationale = str(audit.get("verdict_rationale") or "").strip()
-        if not rationale:
-            problems.append(f"{label}: bound envelope has an empty rationale")
+        rationale = audit.get("verdict_rationale")
+        if not isinstance(rationale, str) or not rationale.strip():
+            problems.append(
+                f"{label}: bound envelope rationale must be a non-empty string"
+            )
             continue
         summary["verdict_rationale"] = rationale
         notes = audit.get("notes_for_re_audit_if_any")
@@ -156,7 +223,11 @@ def main() -> int:
         if not directory.is_dir():
             print(f"refusing to run: {directory} is not a directory")
             return 2
-    index = envelope_index(delivery_dirs)
+    try:
+        index = envelope_index(delivery_dirs)
+    except ValueError as exc:
+        print(f"refusing to run: {exc}")
+        return 2
     print(f"indexed {len(index)} invocation-bound envelopes")
 
     ledger = json.loads(LEDGER.read_text(encoding="utf-8"))

--- a/docs/audit/scripts/backfill_cross_seat_rationales.py
+++ b/docs/audit/scripts/backfill_cross_seat_rationales.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Backfill pre-contract cross-confirmation seat summaries from envelopes.
+
+The rationale-preserving apply contract (2026-07-13) records each seat's
+``verdict_rationale`` and ``notes_for_re_audit_if_any`` inside its
+``cross_confirmation`` summary, and the judicial panel refuses to seat a
+disagreement whose recorded positions lack an invocation-bound full
+rationale. Disagreements recorded BEFORE the contract carry tuple-only
+summaries, so their panels are blocked even though the seats' full audits
+still exist as orchestrator delivery envelopes on disk.
+
+This tool completes exactly that gap and nothing else. For each targeted
+disagreement row it scans the supplied delivery directories for envelopes
+whose ``audit.claim_id`` matches the row and whose
+``audit.audit_invocation_id`` EQUALS the invocation id already recorded in
+the seat summary, then copies the envelope's ``verdict_rationale`` and
+``notes_for_re_audit_if_any`` into that summary. Every other summary field
+is cross-checked against the envelope first (verdict, claim_type,
+normalized claim_scope, load_bearing_step_class, auditor,
+negative_assertion_classes) and ANY mismatch refuses the row: an envelope
+that disagrees with the recorded seat is not evidence, whatever its
+invocation id says. Rows whose summaries already carry rationales are left
+untouched. Nothing is deleted and no verdict, status, or tuple field is
+modified.
+
+Run from a dedicated clean ``main`` checkout; commit the ledger change
+through the standard pipeline gates like any audit-data repair.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS))
+import orchestrate_audit_batch as batch  # noqa: E402
+
+LEDGER = batch.DATA / "audit_ledger.json"
+
+CHECKED_FIELDS = (
+    "verdict",
+    "claim_type",
+    "load_bearing_step_class",
+    "auditor",
+)
+
+
+def norm(value: str) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip())
+
+
+def envelope_index(delivery_dirs: list[Path]) -> dict[tuple[str, str], dict]:
+    index: dict[tuple[str, str], dict] = {}
+    for directory in delivery_dirs:
+        for path in sorted(directory.glob("delivery-*.json")):
+            try:
+                envelope = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            audit = envelope.get("audit")
+            if not isinstance(audit, dict):
+                continue
+            cid = str(audit.get("claim_id") or "")
+            invocation = str(audit.get("audit_invocation_id") or "")
+            if cid and invocation:
+                index[(cid, invocation)] = audit
+    return index
+
+
+def seat_mismatch(summary: dict, audit: dict) -> str | None:
+    for field in CHECKED_FIELDS:
+        if summary.get(field) != audit.get(field):
+            return (
+                f"{field} mismatch: summary={summary.get(field)!r} "
+                f"envelope={audit.get(field)!r}"
+            )
+    if norm(summary.get("claim_scope")) != norm(audit.get("claim_scope")):
+        return "claim_scope mismatch after whitespace normalization"
+    summary_classes = sorted(summary.get("negative_assertion_classes") or [])
+    audit_classes = sorted(audit.get("negative_assertion_classes") or [])
+    if summary_classes != audit_classes:
+        return (
+            f"negative_assertion_classes mismatch: summary={summary_classes} "
+            f"envelope={audit_classes}"
+        )
+    return None
+
+
+def backfill_row(row: dict, index: dict[tuple[str, str], dict]) -> tuple[int, list[str]]:
+    cid = str(row.get("claim_id") or "")
+    cross = row.get("cross_confirmation") or {}
+    filled = 0
+    problems: list[str] = []
+    for label in ("first_audit", "second_audit"):
+        summary = cross.get(label)
+        if not isinstance(summary, dict) or not summary:
+            problems.append(f"{label}: summary missing")
+            continue
+        if str(summary.get("verdict_rationale") or "").strip():
+            continue
+        invocation = str(summary.get("audit_invocation_id") or "")
+        if not invocation:
+            problems.append(f"{label}: summary has no invocation id")
+            continue
+        audit = index.get((cid, invocation))
+        if audit is None:
+            problems.append(f"{label}: no envelope bound to invocation {invocation[:12]}")
+            continue
+        mismatch = seat_mismatch(summary, audit)
+        if mismatch:
+            problems.append(f"{label}: {mismatch}")
+            continue
+        rationale = str(audit.get("verdict_rationale") or "").strip()
+        if not rationale:
+            problems.append(f"{label}: bound envelope has an empty rationale")
+            continue
+        summary["verdict_rationale"] = rationale
+        notes = audit.get("notes_for_re_audit_if_any")
+        if isinstance(notes, str) and notes.strip():
+            summary["notes_for_re_audit_if_any"] = notes
+        filled += 1
+    return filled, problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill pre-contract disagreement seat rationales from "
+            "invocation-bound orchestrator delivery envelopes"
+        )
+    )
+    parser.add_argument(
+        "--deliveries",
+        action="append",
+        required=True,
+        help="directory of delivery-*.json envelopes (repeatable)",
+    )
+    parser.add_argument(
+        "--claims",
+        help="comma-separated claim ids (default: every disagreement row)",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if not args.dry_run:
+        error = batch.clean_main_error()
+        if error:
+            print(f"refusing to run: {error}. Use a dedicated clean main checkout.")
+            return 2
+
+    delivery_dirs = [Path(entry) for entry in args.deliveries]
+    for directory in delivery_dirs:
+        if not directory.is_dir():
+            print(f"refusing to run: {directory} is not a directory")
+            return 2
+    index = envelope_index(delivery_dirs)
+    print(f"indexed {len(index)} invocation-bound envelopes")
+
+    ledger = json.loads(LEDGER.read_text(encoding="utf-8"))
+    rows = ledger.get("rows", {})
+    if args.claims:
+        scope = [cid.strip() for cid in args.claims.split(",") if cid.strip()]
+    else:
+        scope = sorted(
+            cid
+            for cid, row in rows.items()
+            if (row.get("cross_confirmation") or {}).get("status") == "disagreement"
+        )
+
+    total_filled = 0
+    for cid in scope:
+        row = rows.get(cid)
+        if not row:
+            print(f"   skip: {cid}: missing ledger row")
+            continue
+        if (row.get("cross_confirmation") or {}).get("status") != "disagreement":
+            print(f"   skip: {cid}: not a disagreement")
+            continue
+        filled, problems = backfill_row(row, index)
+        total_filled += filled
+        state = f"filled {filled} seat rationale(s)"
+        if problems:
+            state += "; unresolved: " + " | ".join(problems)
+        print(f"   {cid}: {state}")
+
+    if total_filled == 0:
+        print("nothing to backfill")
+        return 0
+    if args.dry_run:
+        print(f"dry run: would fill {total_filled} seat rationale(s)")
+        return 0
+    # Match apply_audit.py's canonical ledger serialization exactly.
+    LEDGER.write_text(json.dumps(ledger, indent=2, sort_keys=True) + "\n")
+    print(f"wrote {LEDGER} with {total_filled} backfilled seat rationale(s)")
+    print(
+        "NEXT: bash docs/audit/scripts/run_pipeline.sh && "
+        "python3 docs/audit/scripts/audit_lint.py --strict, then commit the "
+        "generated audit surfaces per the standard audit-data flow."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -12599,3 +12599,89 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class BackfillCrossSeatRationalesTest(unittest.TestCase):
+    """The backfill completes pre-contract seat summaries ONLY from
+    envelopes bound by (claim_id, audit_invocation_id) whose recorded tuple
+    matches the summary exactly; any mismatch refuses the seat."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name)
+
+    def _summary(self, invocation, verdict="audited_clean"):
+        return {
+            "verdict": verdict,
+            "claim_type": "bounded_theorem",
+            "claim_scope": "an exact identity",
+            "load_bearing_step_class": "(C)",
+            "negative_assertion_classes": [],
+            "auditor": f"codex-audit-batch-A-{invocation[:8]}",
+            "audit_invocation_id": invocation,
+        }
+
+    def _audit(self, cid, invocation, verdict="audited_clean", scope="an  exact identity"):
+        return {
+            "claim_id": cid,
+            "audit_invocation_id": invocation,
+            "verdict": verdict,
+            "claim_type": "bounded_theorem",
+            "claim_scope": scope,
+            "load_bearing_step_class": "(C)",
+            "negative_assertion_classes": [],
+            "auditor": f"codex-audit-batch-A-{invocation[:8]}",
+            "verdict_rationale": "the full recorded seat argument",
+            "notes_for_re_audit_if_any": "none needed",
+        }
+
+    def test_backfills_bound_matching_seat_and_refuses_mismatch(self):
+        m = _import("backfill_cross_seat_rationales")
+        inv_a, inv_b = "a" * 32, "b" * 32
+        row = {
+            "claim_id": "row1",
+            "cross_confirmation": {
+                "status": "disagreement",
+                "first_audit": self._summary(inv_a),
+                "second_audit": self._summary(inv_b, verdict="audited_conditional"),
+            },
+        }
+        # first seat's envelope matches (whitespace-only scope difference is
+        # tolerated); second seat's envelope disagrees on the verdict.
+        index = {
+            ("row1", inv_a): self._audit("row1", inv_a),
+            ("row1", inv_b): self._audit("row1", inv_b, verdict="audited_clean"),
+        }
+        filled, problems = m.backfill_row(row, index)
+        self.assertEqual(filled, 1)
+        first = row["cross_confirmation"]["first_audit"]
+        self.assertEqual(
+            first["verdict_rationale"], "the full recorded seat argument"
+        )
+        self.assertEqual(first["notes_for_re_audit_if_any"], "none needed")
+        second = row["cross_confirmation"]["second_audit"]
+        self.assertNotIn("verdict_rationale", second)
+        self.assertTrue(any("verdict mismatch" in p for p in problems))
+        # Idempotent: a filled seat is not touched again.
+        filled_again, _ = m.backfill_row(row, index)
+        self.assertEqual(filled_again, 0)
+
+    def test_unbound_or_empty_envelopes_never_fill(self):
+        m = _import("backfill_cross_seat_rationales")
+        inv = "c" * 32
+        row = {
+            "claim_id": "row2",
+            "cross_confirmation": {
+                "status": "disagreement",
+                "first_audit": self._summary(inv),
+                "second_audit": self._summary("d" * 32),
+            },
+        }
+        empty = self._audit("row2", inv)
+        empty["verdict_rationale"] = "   "
+        index = {("row2", inv): empty}
+        filled, problems = m.backfill_row(row, index)
+        self.assertEqual(filled, 0)
+        self.assertTrue(any("empty rationale" in p for p in problems))
+        self.assertTrue(any("no envelope bound" in p for p in problems))

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -13,6 +13,7 @@ or:
 from __future__ import annotations
 
 import argparse
+import copy
 import contextlib
 import importlib
 import importlib.util
@@ -12597,14 +12598,10 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
         self.tmp = Path(self._tmp.name)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class BackfillCrossSeatRationalesTest(unittest.TestCase):
     """The backfill completes pre-contract seat summaries ONLY from
-    envelopes bound by (claim_id, audit_invocation_id) whose recorded tuple
-    matches the summary exactly; any mismatch refuses the seat."""
+    envelopes bound by (claim_id, audit_invocation_id) whose recorded fields
+    match the summary exactly; any mismatch refuses the seat."""
 
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
@@ -12619,6 +12616,11 @@ class BackfillCrossSeatRationalesTest(unittest.TestCase):
             "load_bearing_step_class": "(C)",
             "negative_assertion_classes": [],
             "auditor": f"codex-audit-batch-A-{invocation[:8]}",
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "audit_date": "2026-07-13T00:00:00+00:00",
             "audit_invocation_id": invocation,
         }
 
@@ -12632,6 +12634,11 @@ class BackfillCrossSeatRationalesTest(unittest.TestCase):
             "load_bearing_step_class": "(C)",
             "negative_assertion_classes": [],
             "auditor": f"codex-audit-batch-A-{invocation[:8]}",
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "audit_date": "2026-07-13T00:00:00+00:00",
             "verdict_rationale": "the full recorded seat argument",
             "notes_for_re_audit_if_any": "none needed",
         }
@@ -12653,6 +12660,7 @@ class BackfillCrossSeatRationalesTest(unittest.TestCase):
             ("row1", inv_a): self._audit("row1", inv_a),
             ("row1", inv_b): self._audit("row1", inv_b, verdict="audited_clean"),
         }
+        before = copy.deepcopy(row)
         filled, problems = m.backfill_row(row, index)
         self.assertEqual(filled, 1)
         first = row["cross_confirmation"]["first_audit"]
@@ -12663,9 +12671,95 @@ class BackfillCrossSeatRationalesTest(unittest.TestCase):
         second = row["cross_confirmation"]["second_audit"]
         self.assertNotIn("verdict_rationale", second)
         self.assertTrue(any("verdict mismatch" in p for p in problems))
+        expected = copy.deepcopy(before)
+        expected_first = expected["cross_confirmation"]["first_audit"]
+        expected_first["verdict_rationale"] = "the full recorded seat argument"
+        expected_first["notes_for_re_audit_if_any"] = "none needed"
+        self.assertEqual(row, expected)
         # Idempotent: a filled seat is not touched again.
         filled_again, _ = m.backfill_row(row, index)
         self.assertEqual(filled_again, 0)
+
+    def test_refuses_tuple_provenance_and_binding_mismatches(self):
+        m = _import("backfill_cross_seat_rationales")
+        invocation = "e" * 32
+        cases = {
+            "verdict": "audited_failed",
+            "claim_type": "positive_theorem",
+            "claim_scope": "a different identity",
+            "load_bearing_step_class": "(B)",
+            "negative_assertion_classes": ["derived_no_go_boundary"],
+            "auditor": "a-different-seat",
+            "auditor_family": "a-different-family",
+            "auditor_model": "a-different-model",
+            "auditor_reasoning_effort": "low",
+            "independence": "weak",
+            "audit_date": "2099-01-01T00:00:00+00:00",
+            "audit_invocation_id": "f" * 32,
+        }
+        for field, value in cases.items():
+            with self.subTest(field=field):
+                summary = self._summary(invocation)
+                audit = self._audit("row3", invocation)
+                audit[field] = value
+                row = {
+                    "claim_id": "row3",
+                    "cross_confirmation": {
+                        "status": "disagreement",
+                        "first_audit": summary,
+                        "second_audit": self._summary("a" * 32),
+                    },
+                }
+                before = copy.deepcopy(row)
+                index = {("row3", invocation): audit}
+                filled, problems = m.backfill_row(row, index)
+                self.assertEqual(filled, 0)
+                self.assertEqual(row, before)
+                self.assertTrue(any(field in problem for problem in problems))
+
+        row = {
+            "claim_id": "row3",
+            "cross_confirmation": {
+                "status": "disagreement",
+                "first_audit": self._summary(invocation),
+                "second_audit": self._summary("a" * 32),
+            },
+        }
+        wrong_claim = self._audit("other-row", invocation)
+        filled, problems = m.backfill_row(
+            row, {("row3", invocation): wrong_claim}
+        )
+        self.assertEqual(filled, 0)
+        self.assertTrue(
+            any("claim_id mismatch" in problem for problem in problems)
+        )
+
+    def test_envelope_index_refuses_conflicts_but_isolates_claims(self):
+        m = _import("backfill_cross_seat_rationales")
+        invocation = "b" * 32
+        first_dir = self.tmp / "first"
+        second_dir = self.tmp / "second"
+        first_dir.mkdir()
+        second_dir.mkdir()
+        first = self._audit("row4", invocation)
+        conflicting = copy.deepcopy(first)
+        conflicting["verdict_rationale"] = "a different seat argument"
+        (first_dir / "delivery-first.json").write_text(
+            json.dumps({"audit": first}), encoding="utf-8"
+        )
+        (second_dir / "delivery-conflict.json").write_text(
+            json.dumps({"audit": conflicting}), encoding="utf-8"
+        )
+        with self.assertRaisesRegex(ValueError, "conflicting delivery envelopes"):
+            m.envelope_index([first_dir, second_dir])
+
+        other_claim = self._audit("row5", invocation)
+        (second_dir / "delivery-conflict.json").write_text(
+            json.dumps({"audit": other_claim}), encoding="utf-8"
+        )
+        index = m.envelope_index([first_dir, second_dir, first_dir])
+        self.assertEqual(index[("row4", invocation)], first)
+        self.assertEqual(index[("row5", invocation)], other_claim)
 
     def test_unbound_or_empty_envelopes_never_fill(self):
         m = _import("backfill_cross_seat_rationales")
@@ -12683,5 +12777,24 @@ class BackfillCrossSeatRationalesTest(unittest.TestCase):
         index = {("row2", inv): empty}
         filled, problems = m.backfill_row(row, index)
         self.assertEqual(filled, 0)
-        self.assertTrue(any("empty rationale" in p for p in problems))
+        self.assertTrue(any("non-empty string" in p for p in problems))
         self.assertTrue(any("no envelope bound" in p for p in problems))
+
+    def test_missing_invocation_requires_fresh_seat_rerun(self):
+        m = _import("backfill_cross_seat_rationales")
+        row = {
+            "claim_id": "s3-row",
+            "cross_confirmation": {
+                "status": "disagreement",
+                "first_audit": {"audit_invocation_id": None},
+                "second_audit": {"audit_invocation_id": None},
+            },
+        }
+        filled, problems = m.backfill_row(row, {})
+        self.assertEqual(filled, 0)
+        self.assertEqual(len(problems), 2)
+        self.assertTrue(all("fresh seat rerun required" in p for p in problems))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

#5337's rationale-preserving apply contract correctly blocks judicial panels on disagreements whose seat summaries lack invocation-bound full rationales. Four live disagreements predate the contract; three (cl3_complexification, persistent_record_kraus, cpt_exact) still have their seats' complete audits as orchestrator delivery envelopes on disk, bound to the recorded summaries by exact `(claim_id, audit_invocation_id)` — verified before writing this.

`backfill_cross_seat_rationales.py` completes exactly that gap:

- Fills `verdict_rationale` (+ `notes_for_re_audit_if_any`) into a seat summary **only** from an envelope whose invocation id equals the summary's, and **only** after cross-checking every recorded tuple field (verdict, claim_type, whitespace-normalized claim_scope, load_bearing_step_class, auditor, negative_assertion_classes). Any mismatch refuses the seat — an envelope that disagrees with the recorded seat is not evidence, whatever its id says.
- Never re-touches filled seats, never modifies verdicts/statuses/tuple fields, serializes the ledger in apply_audit's canonical form, and runs under the standard clean-main guard with the normal pipeline/lint/audit-data commit flow.
- Rows with no surviving envelopes (s3_mass_matrix) stay blocked pending a genuine seat rerun — the tool never invents evidence.

## Tests

Bound-match fill with whitespace-tolerant scope + verdict-mismatch refusal + idempotence; unbound and empty-rationale refusals. Suite 326/326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)