### PR TITLE
audit-infra: skip note-hash-drifted rows at targeting time

### DIFF
--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -93,6 +93,28 @@ def dep_ready(row: dict, effective: dict[str, str]) -> bool:
     return True
 
 
+def note_hash_drifted(row: dict) -> bool:
+    """Whether the ledger row's note_hash lags the note file on disk.
+
+    A science-fix landing changes the note before seed_audit_ledger.py
+    refreshes the row, and apply_audit refuses drifted rows AFTER the seats
+    have already run (grain wave 2, 2026-07-13: two fresh seats audited the
+    repaired note and their applies were rejected). Refusing at targeting
+    time saves the seats and tells the operator the exact remedy.
+    """
+    note_path = row.get("note_path") or ""
+    if not note_path or not (REPO_ROOT / note_path).exists():
+        return False
+    import hashlib
+
+    on_disk = hashlib.sha256(
+        (REPO_ROOT / note_path)
+        .read_text(encoding="utf-8", errors="replace")
+        .encode("utf-8")
+    ).hexdigest()
+    return on_disk != row.get("note_hash")
+
+
 def source_requires_forensic(row: dict) -> bool:
     note_path = row.get("note_path") or ""
     try:
@@ -268,6 +290,12 @@ def compute_targets(
             continue
         if not dep_ready(row, effective):
             skipped.append(f"{cid}: dependencies are not retained-grade")
+            continue
+        if note_hash_drifted(row):
+            skipped.append(
+                f"{cid}: ledger note_hash lags the note file; run "
+                "seed_audit_ledger.py + pipeline and commit before auditing"
+            )
             continue
         if audit_status == "unaudited" and awaiting_repair_since_conditional(
             row, effective, rows

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -12798,3 +12798,46 @@ class BackfillCrossSeatRationalesTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class BatchOrchestratorHashDriftPreflightTest(unittest.TestCase):
+    """A row whose ledger note_hash lags the note file is skipped at
+    targeting time (grain wave 2, 2026-07-13: two seats audited a repaired
+    note and their applies were refused by the drift gate)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name)
+
+    def test_drifted_row_skips_with_remedy_message(self):
+        m = _import("orchestrate_audit_batch")
+        import hashlib as _hashlib
+        note = self.tmp / "docs" / "NOTE.md"
+        note.parent.mkdir(parents=True)
+        note.write_text("repaired body\n", encoding="utf-8")
+        current = _hashlib.sha256(
+            note.read_text(encoding="utf-8").encode("utf-8")
+        ).hexdigest()
+        row = {
+            "claim_id": "drift_row",
+            "claim_type": "bounded_theorem",
+            "audit_status": "unaudited",
+            "effective_status": "open_gate",
+            "criticality": None,
+            "deps": [],
+            "note_path": "docs/NOTE.md",
+            "note_hash": "0" * 64,
+        }
+        with mock.patch.object(m, "REPO_ROOT", self.tmp), mock.patch.object(
+            m, "source_requires_forensic", return_value=False
+        ):
+            targets, skipped = m.compute_targets({"drift_row"}, {"drift_row": row})
+            self.assertEqual(targets, [])
+            self.assertTrue(
+                any("note_hash lags the note file" in line for line in skipped)
+            )
+            # Aligned hash targets normally.
+            row["note_hash"] = current
+            targets, skipped = m.compute_targets({"drift_row"}, {"drift_row": row})
+            self.assertEqual([r["claim_id"] for r in targets], ["drift_row"])


### PR DESCRIPTION
Grain wave 2 burned two seats auditing a freshly-repaired note whose ledger row still carried the pre-repair `note_hash` — apply refused on drift *after* the audits ran, and the subsequent reseed moved the evidence universe, correctly staling the delivered envelopes under the #5265 replay defense. `compute_targets` now refuses drifted rows at targeting time with the exact remedy message (reseed + pipeline + commit), mirroring `apply_audit.note_hash_drift_error`. One test pins both directions. Suite 330/330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)