### PR TITLE
audit-infra: bind N6 candidate evidence locators

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -505,7 +505,7 @@ supply it. Otherwise replace it with:
         "addressed": true,
         "disposition": "<include affected_wall verbatim, then explain why the candidate does or does not close it>",
         "evidence_path": "<manifest path>",
-        "evidence_locator": "<actual locator>"
+        "evidence_locator": "<copy candidate_id verbatim; it is the stable locator in the serialized partial-closure index>"
       }
     ],
     "none_found_reason": "<required when candidates is empty>",
@@ -656,8 +656,11 @@ candidate record and include that complete `indexed_basis` text verbatim
 inside `closure_mechanism` before explaining how the candidate could affect
 the named wall. Also include the complete `affected_wall` text verbatim inside
 that candidate's `disposition` before explaining why the wall does or does not
-close. A paraphrase or merely related explanation does not satisfy either
-authenticated binding.
+close. Set `evidence_path` to the orchestrator partial-closure-index path and
+set `evidence_locator` to that candidate's complete `candidate_id` verbatim;
+the candidate id is the stable unique locator in the serialized index, whereas
+a quote-bearing `indexed_basis` prefix may be JSON-escaped there. A paraphrase
+or merely related explanation does not satisfy either authenticated binding.
 
 For each N5 statement, `resolution_classes_checked` must equal the five canonical classes exactly,
 and `tested_resolutions` must contain exactly five entries: one and only one

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -9821,6 +9821,111 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         )
         self.assertEqual(cross_labeled["occurrence_group_id"], "b4db14624baf74e0")
 
+    def test_authenticated_n6_candidate_locator_binds_unique_candidate_id_only(self):
+        m = _import_codex_audit_runner()
+        path = "audit-packet://partial-closure-index/test_no_go"
+        candidate_id = "controlled_vocabulary:246"
+        indexed_basis = (
+            'definition: "First-principles compute from the approved premise '
+            'surface producing a number not present in any input."'
+        )
+        indexed_candidate = {
+            "candidate_id": candidate_id,
+            "kind": "definition_refactor",
+            "basis": indexed_basis,
+        }
+        manifest = {
+            path: {
+                "path": path,
+                "roles": ["partial_closure_index"],
+                "text": json.dumps(
+                    {"candidates": [indexed_candidate]},
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+            }
+        }
+        candidate = {
+            "candidate_id": candidate_id,
+            "kind": "definition_refactor",
+            "indexed_basis": indexed_basis,
+            "affected_wall": "W_unit",
+            "closure_mechanism": (
+                f"{indexed_basis} It does not supply the W_unit theorem."
+            ),
+            "could_close_wall": False,
+            "addressed": True,
+            "disposition": "W_unit remains unproved by this definition.",
+            "evidence_path": path,
+            "evidence_locator": 'definition: "First-p',
+        }
+        blob = {
+            "verdict": "audited_clean",
+            "no_go_discipline": {
+                "N6_partial_closure_scan": {"candidates": [candidate]}
+            },
+        }
+        before = {
+            key: json.loads(json.dumps(value))
+            for key, value in candidate.items()
+            if key != "evidence_locator"
+        }
+        changes = m.bind_authenticated_n6_candidate_locators(blob, manifest)
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(candidate["evidence_locator"], candidate_id)
+        self.assertEqual(
+            {
+                key: value
+                for key, value in candidate.items()
+                if key != "evidence_locator"
+            },
+            before,
+        )
+        self.assertEqual(blob["verdict"], "audited_clean")
+
+    def test_authenticated_n6_candidate_locator_refuses_ambiguity_and_wrong_role(self):
+        m = _import_codex_audit_runner()
+        path = "audit-packet://partial-closure-index/test_no_go"
+        candidate_id = "controlled_vocabulary:246"
+        indexed = {"candidate_id": candidate_id, "kind": "definition_refactor"}
+        candidate = {
+            "candidate_id": candidate_id,
+            "evidence_path": path,
+            "evidence_locator": "absent quoted basis prefix",
+        }
+        blob = {
+            "no_go_discipline": {
+                "N6_partial_closure_scan": {"candidates": [candidate]}
+            }
+        }
+        ambiguous = {
+            path: {
+                "roles": ["partial_closure_index"],
+                "text": json.dumps({"candidates": [indexed, indexed]}),
+            }
+        }
+        self.assertEqual(
+            m.bind_authenticated_n6_candidate_locators(blob, ambiguous), []
+        )
+        self.assertEqual(candidate["evidence_locator"], "absent quoted basis prefix")
+        wrong_role = json.loads(json.dumps(ambiguous))
+        wrong_role[path]["roles"] = ["cross_cycle_index"]
+        wrong_role[path]["text"] = json.dumps({"candidates": [indexed]})
+        self.assertEqual(
+            m.bind_authenticated_n6_candidate_locators(blob, wrong_role), []
+        )
+        self.assertEqual(candidate["evidence_locator"], "absent quoted basis prefix")
+        non_object = {
+            path: {
+                "roles": ["partial_closure_index"],
+                "text": "[]",
+            }
+        }
+        self.assertEqual(
+            m.bind_authenticated_n6_candidate_locators(blob, non_object), []
+        )
+        self.assertEqual(candidate["evidence_locator"], "absent quoted basis prefix")
+
     def test_locator_repair_preservation_allows_bound_metadata_only(self):
         m = _import_codex_audit_runner()
         rejected = {

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1606,6 +1606,75 @@ def bind_authenticated_occurrence_metadata(
     return changes
 
 
+def bind_authenticated_n6_candidate_locators(
+    blob: dict,
+    evidence_manifest: dict[str, dict] | None,
+) -> list[dict[str, object]]:
+    """Bind an invalid N6 locator to its unique authenticated candidate id.
+
+    The auditor owns candidate selection, indexed basis, wall mapping,
+    mechanism, disposition, and verdict content. The orchestrator owns the
+    serialized partial-closure index. When an N6 object already names one
+    exact candidate id from that index but supplies a locator that is absent
+    from the serialized text (commonly because quoted basis text is JSON
+    escaped), replace only ``evidence_locator`` with the unique candidate id.
+    Ambiguous, missing, cross-index, or already valid locators remain untouched
+    and fail closed in the ordinary validator.
+    """
+    if evidence_manifest is None:
+        return []
+    packet = blob.get("no_go_discipline")
+    n6 = packet.get("N6_partial_closure_scan") if isinstance(packet, dict) else None
+    candidates = n6.get("candidates") if isinstance(n6, dict) else None
+    if not isinstance(candidates, list):
+        return []
+    changes: list[dict[str, object]] = []
+    for index, candidate in enumerate(candidates, 1):
+        if not isinstance(candidate, dict):
+            continue
+        path = candidate.get("evidence_path")
+        candidate_id = candidate.get("candidate_id")
+        locator = candidate.get("evidence_locator")
+        if not all(
+            isinstance(value, str) and value
+            for value in (path, candidate_id, locator)
+        ):
+            continue
+        entry = evidence_manifest.get(path)
+        if not isinstance(entry, dict):
+            continue
+        if "partial_closure_index" not in set(entry.get("roles") or []):
+            continue
+        text = str(entry.get("text") or "")
+        if locator in text:
+            continue
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        indexed = payload.get("candidates")
+        if not isinstance(indexed, list):
+            continue
+        matches = [
+            item
+            for item in indexed
+            if isinstance(item, dict) and item.get("candidate_id") == candidate_id
+        ]
+        if len(matches) != 1 or candidate_id not in text:
+            continue
+        changes.append({
+            "section": "N6_partial_closure_scan",
+            "index": index,
+            "field": "evidence_locator",
+            "from": locator,
+            "to": candidate_id,
+        })
+        candidate["evidence_locator"] = candidate_id
+    return changes
+
+
 def compute_required_reason(reply: str | None) -> str | None:
     """Accept only the exact one-line COMPUTE_REQUIRED escape protocol."""
     if not reply:
@@ -2486,6 +2555,16 @@ def main() -> int:
                         "phase": "authenticated_occurrence_metadata_bound",
                         "bindings": occurrence_bindings,
                     }) + "\n")
+            n6_locator_bindings = bind_authenticated_n6_candidate_locators(
+                blob, exact_evidence_manifest
+            )
+            if n6_locator_bindings:
+                with run_log.open("a", encoding="utf-8") as f:
+                    f.write(json.dumps({
+                        "claim_id": cid,
+                        "phase": "authenticated_n6_candidate_locators_bound",
+                        "bindings": n6_locator_bindings,
+                    }) + "\n")
 
             note_path = row.get("note_path") or full_led_row.get("note_path") or ""
             note_body = read_note_body(note_path) or ""
@@ -2580,6 +2659,22 @@ def main() -> int:
                                 ),
                                 "attempt": repair_attempt,
                                 "bindings": repair_bindings,
+                            }) + "\n")
+                    repair_n6_locator_bindings = (
+                        bind_authenticated_n6_candidate_locators(
+                            repair_blob, exact_evidence_manifest
+                        )
+                    )
+                    if repair_n6_locator_bindings:
+                        with run_log.open("a", encoding="utf-8") as f:
+                            f.write(json.dumps({
+                                "claim_id": cid,
+                                "phase": (
+                                    "validation_repair_authenticated_n6_"
+                                    "candidate_locators_bound"
+                                ),
+                                "attempt": repair_attempt,
+                                "bindings": repair_n6_locator_bindings,
                             }) + "\n")
                     preservation_error = validation_repair_preservation_error(
                         initial_rejected_blob, repair_blob
@@ -2677,6 +2772,22 @@ def main() -> int:
                                 ),
                                 "attempt": schema_attempt,
                                 "bindings": schema_bindings,
+                            }) + "\n")
+                    schema_n6_locator_bindings = (
+                        bind_authenticated_n6_candidate_locators(
+                            schema_blob, exact_evidence_manifest
+                        )
+                    )
+                    if schema_n6_locator_bindings:
+                        with run_log.open("a", encoding="utf-8") as f:
+                            f.write(json.dumps({
+                                "claim_id": cid,
+                                "phase": (
+                                    "fresh_schema_retry_authenticated_n6_"
+                                    "candidate_locators_bound"
+                                ),
+                                "attempt": schema_attempt,
+                                "bindings": schema_n6_locator_bindings,
                             }) + "\n")
                     schema_error = validate_verdict(
                         schema_blob,


### PR DESCRIPTION
## Summary
- instruct N6 packets to use the authenticated candidate ID as the stable serialized-index locator
- bind an invalid N6 locator to that already-selected unique candidate ID across initial, repair, and fresh-schema paths
- fail closed on missing, malformed, ambiguous, wrong-role, or cross-index metadata
- add regression coverage, including quote-escaped basis text and non-object JSON

The binder changes locator metadata only. It does not change candidate selection, indexed basis, wall mapping, mechanism, disposition, no-go judgment, or verdict.

## Verification
- independent review-loop PASS at rebased exact head `0888326e83fbb354bf1b7b4ec3605041286f49fc`
- real failed occupancy packet replay binds candidates 8-12 and passes unchanged N6 validation
- full suite: 331/331
- audit pipeline passed
- strict audit lint passed with zero errors
- pycompile, vocab lint, diff check, and generated-surface cleanliness passed
- no audit verdict or physics source changed