### PR TITLE
audit: align R-eta N7 route evidence

### DIFF
--- a/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_R_ETA_DIRECT_LICENSE_HCLASS_HUNIT_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -111,7 +111,7 @@ Historical decision text identifies provenance only and is not used as proof.
 | Dimensionful scale reference | ATTEMPTED | The [scale-reference primitive](SCALE_REFERENCE_PRIMITIVE_NOTE.md) supplies units conversion and no dimensionless phase, selector, or readout bridge; `beta` is dimensionless, runner Part D. |
 | Kinetic-form isotropy | ATTEMPTED | The [kinetic-isotropy primitive](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md) supplies `c_t=c_s` and no phase, selector, or readout bridge; the family is unchanged, runner Part D. |
 | Exact fixed-locus value | ATTEMPTED | Granting the nonzero value `h=2/9` leaves both `beta=1` and `beta=2`; runner Part A checks the singleton and cycle values separately, including the live `N1 numerical_or_finite_case` finite singleton point-evaluation marker. |
-| Coordinate-convention steelman | ATTEMPTED | N7 convention mechanism: same-observable common-unit rescaling. N7 convention attempt: multiply `h` and `abs(delta_beta)` by the same positive unit factor. N7 convention outcome: `beta=abs(delta_beta)/h` remains invariant and the `W_unit` readout bridge is not selected. Runner Part E verifies the symbolic identity and finite exact examples. |
+| Coordinate-convention steelman | ATTEMPTED | N7 convention mechanism: same-observable common-unit rescaling. ATTEMPTED N7 convention attempt: multiply `h` and `abs(delta_beta)` by the same positive unit factor. N7 convention outcome: `beta=abs(delta_beta)/h` remains invariant and the `W_unit` readout bridge is not selected. Runner Part E verifies the symbolic identity and finite exact examples. |
 
 The runner checks all eight routes. Their authority boundary is the current
 minimal axiom memo, the approved primitive boundary notes, and the explicit

--- a/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
-runner_sha256: 86cf54b9a9f3f6e4c4d76b9d9e232d2950e76f8b22f0daed479f5ecc705ca5e4
+runner_sha256: 7faed77f792b04a1c3e0859acdfb299c1809344cc81e4cbe6aafcc5c7d05a1a6
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.27
+elapsed_sec: 0.33
 status: ok
 ----- stdout -----
 Record additivity and the R-eta unit-calibration countermodel
@@ -55,7 +55,7 @@ N1 route coordinate_convention
   N7 convention mechanism: same-observable common-unit rescaling
   ATTEMPTED N7 convention attempt: multiply h and abs(delta_beta) by the same positive unit factor
   N7 convention outcome: beta=abs(delta_beta)/h remains invariant and the W_unit readout bridge is not selected
-  [PASS] N7 steelman argument: N7 convention mechanism: same-observable common-unit rescaling; N7 convention attempt: multiply h and abs(delta_beta) by the same positive unit factor; N7 convention outcome: beta=abs(delta_beta)/h remains invariant and the W_unit readout bridge is not selected
+  [PASS] N7 steelman argument: N7 convention mechanism: same-observable common-unit rescaling; ATTEMPTED N7 convention attempt: multiply h and abs(delta_beta) by the same positive unit factor; N7 convention outcome: beta=abs(delta_beta)/h remains invariant and the W_unit readout bridge is not selected
   [PASS] N7 relative-normalization guard: beta=2 reaches beta=1 by rescaling abs(delta_beta) without h, which is not a common-unit convention
   [PASS] coordinate unit scales are positive
   [PASS] coordinate_convention ATTEMPTED: common-unit rescaling preserves the beta-one ratio

--- a/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_2026_07_04.py
@@ -198,7 +198,7 @@ def main() -> int:
     )
     check(
         "N7 steelman argument: N7 convention mechanism: same-observable common-unit rescaling; "
-        "N7 convention attempt: multiply h and abs(delta_beta) by the same positive unit factor; "
+        "ATTEMPTED N7 convention attempt: multiply h and abs(delta_beta) by the same positive unit factor; "
         "N7 convention outcome: beta=abs(delta_beta)/h remains invariant and the W_unit readout bridge is not selected",
         ratio_invariant and residual_covariant,
     )
@@ -281,6 +281,7 @@ def main() -> int:
     check(
         "N7 contains the executable coordinate steelman",
         "same-observable common-unit rescaling" in note_flat
+        and "ATTEMPTED N7 convention attempt: multiply `h` and `abs(delta_beta)`" in note_flat
         and "ratio is `Phi_u/H_u = beta`" in note_flat
         and "same-observable identity" in note_flat
         and "readout bridge, or empirical fit is supplied by it" in note_flat,


### PR DESCRIPTION
## Summary
- include the exact already-executed `ATTEMPTED` N1 route attempt in the N7 steelman argument line
- mirror that wording in the no-go note and enforce it in the existing Part F guard
- refresh the deterministic runner cache

This is evidence alignment only. It does not change the beta-family theorem, select `beta=1`, add a premise, or force `r=1/2`.

## Verification
- independent review-loop PASS at rebased exact head `2d007889babfb54ac58abadb22122c9dc83851f7`
- direct validator regression: old string fails and revised string passes the N7 route-attempt containment gate
- primary runner: `PASS=56`, `FAIL=0`
- cache freshness/SHA passed
- audit pipeline and strict lint passed
- no audit verdict or generated status file changed