### PR TITLE
audit-infra: clarify shared N3 context metadata

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -637,9 +637,12 @@ For every N3 hit and N5 statement, copy `phrase` byte-for-byte from the
 corresponding `full_phrase_groups[].phrase` value in the evidence manifest.
 Copy the complete authenticated tuple—`phrase`, `occurrence_group_id`,
 `occurrence_count`, `occurrence_locator_sha256`, and `evidence_locator`—from
-one and the same `full_phrase_groups[]` record. Never reuse a group id or
-locator digest under a different phrase, even when both occur on the same
-path.
+one and the same `full_phrase_groups[]` record. Different authenticated records
+may legitimately share a context-derived group id or locator digest when
+several phrases occur in the same source context. Reproduce that sharing only
+when the manifest separately lists the complete record for each phrase. Never
+infer an unlisted phrase from a shared id or transplant metadata from another
+phrase's record.
 Never paraphrase a phrase, join two phrases with punctuation or a slash, or
 collapse distinct phrases into one object. For example, `boundary` and
 `primitive` require separate objects even when one source sentence contains

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -7902,6 +7902,14 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             template_flat,
         )
         self.assertIn(
+            "may legitimately share a context-derived group id or locator digest",
+            template_flat,
+        )
+        self.assertIn(
+            "Never infer an unlisted phrase from a shared id",
+            template_flat,
+        )
+        self.assertIn(
             "use a nearby marker-bearing live section header",
             template_flat,
         )
@@ -10037,6 +10045,8 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             "ORIGINAL RESTRICTED PACKET", n3_tuple_code, 1,
         )
         self.assertIn("from one same full_phrase_groups record", n3_tuple_prompt)
+        self.assertIn("may share a context-derived id or digest", n3_tuple_prompt)
+        self.assertIn("Never infer an unlisted phrase", n3_tuple_prompt)
         self.assertNotIn("hit 2", n3_tuple_prompt)
         n3_scan_code = m.fresh_schema_retry_code(
             "N3.hits must exactly disposition orchestrator phrase scan; "

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1844,8 +1844,11 @@ def render_fresh_schema_retry_prompt(
         "N3_AUTHENTICATED_GROUP_TUPLE_MISMATCH": (
             "Static N3 invariant: copy phrase, occurrence_group_id, "
             "occurrence_count, occurrence_locator_sha256, and evidence_locator "
-            "from one same full_phrase_groups record. Never cross-label a group "
-            "id, count, digest, or locator under another phrase.\n"
+            "from one same full_phrase_groups record. Separate authenticated "
+            "phrase records may share a context-derived id or digest; reproduce "
+            "that sharing only when each complete phrase record is listed. Never "
+            "infer an unlisted phrase from a shared id or cross-label a count, "
+            "digest, or locator from another record.\n"
         ),
         "N5_AUTHENTICATED_GROUP_TUPLE_MISMATCH": (
             "Static N5 invariant: copy phrase, occurrence_group_id, "


### PR DESCRIPTION
## Summary
- align N3 prompt guidance with authenticated phrase-group semantics
- allow distinct phrase records to share a context-derived ID/digest only when each complete tuple is separately listed
- forbid inference of unlisted phrases and cross-record metadata transplants
- carry the same conclusion-blind guidance into typed fresh-schema retries

This changes guidance only; validator, binding, hit handling, science, and verdict authority are unchanged.

## Verification
- independent review-loop PASS at rebased exact head `37ab1c0fcc64a4c240ae825c02a6e35d95525805`
- direct validator probes reject unlisted phrase and cross-record transplant
- focused tests 4/4; full suite 334/334
- audit pipeline and strict lint passed
- pycompile/vocab/diff/generated-surface checks passed
- no audit verdict or source claim changed