### PR TITLE
audit-infra: --retarget-conditionals operator flag (claims-mode only)

### DIFF
--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -256,7 +256,9 @@ def _iso(stamp: str) -> datetime | None:
 
 
 def compute_targets(
-    scope: set[str], rows: dict[str, dict]
+    scope: set[str],
+    rows: dict[str, dict],
+    retarget: frozenset[str] = frozenset(),
 ) -> tuple[list[dict], list[str]]:
     effective = {cid: row.get("effective_status", "?") for cid, row in rows.items()}
     targets: list[dict] = []
@@ -298,8 +300,10 @@ def compute_targets(
                 "seed_audit_ledger.py + pipeline and commit before auditing"
             )
             continue
-        if audit_status == "unaudited" and awaiting_repair_since_conditional(
-            row, effective, rows
+        if (
+            audit_status == "unaudited"
+            and cid not in retarget
+            and awaiting_repair_since_conditional(row, effective, rows)
         ):
             skipped.append(
                 f"{cid}: awaiting repair (sources and deps unchanged since "
@@ -972,6 +976,17 @@ def main() -> int:
     scope_group = parser.add_mutually_exclusive_group(required=True)
     scope_group.add_argument("--lane", help="lane name from lane_certification_config.json")
     scope_group.add_argument("--claims", help="comma-separated claim ids")
+    parser.add_argument(
+        "--retarget-conditionals",
+        action="store_true",
+        help=(
+            "with --claims only: re-audit named rows even though their "
+            "sources and dependency statuses are unchanged since their last "
+            "audited_conditional. Use when the remedy for the conditional "
+            "was an environment change the repair-wait guard cannot see "
+            "(gate/template calibration, packet-policy revision)."
+        ),
+    )
     parser.add_argument("--max-workers", type=int, default=6)
     parser.add_argument("--rounds", type=int, default=6)
     parser.add_argument("--stall-minutes", type=int, default=45)
@@ -987,6 +1002,11 @@ def main() -> int:
         or args.push_retries < 1
     ):
         parser.error("worker, round, stall, runner-timeout, and retry limits must be positive")
+    if args.retarget_conditionals and not args.claims:
+        parser.error("--retarget-conditionals requires an explicit --claims list")
+    retarget = frozenset(
+        cid.strip() for cid in (args.claims or "").split(",") if cid.strip()
+    ) if args.retarget_conditionals else frozenset()
 
     if not args.dry_run:
         error = clean_main_error()
@@ -1029,7 +1049,7 @@ def main() -> int:
                 report.append({"cid": cid, "result": "judicial_panel_required"})
                 session_skipped.add(cid)
         scope.difference_update(session_skipped)
-        targets, skipped = compute_targets(scope, rows)
+        targets, skipped = compute_targets(scope, rows, retarget=retarget)
         print(f"== round {round_no}: {len(targets)} dep-ready targets, {len(skipped)} skipped")
         for line in skipped:
             print(f"   skip: {line}")

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -13424,10 +13424,6 @@ class N5AdministrativeNegationExclusionTest(unittest.TestCase):
         )
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class BatchOrchestratorRetargetFlagTest(unittest.TestCase):
     """--retarget-conditionals bypasses the repair-wait guard for explicitly
     named claims only (gate/template calibrations are invisible to the
@@ -13464,3 +13460,7 @@ class BatchOrchestratorRetargetFlagTest(unittest.TestCase):
                 retarget=frozenset({"other_row"}),
             )
             self.assertEqual(targets, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -13427,7 +13427,7 @@ class N5AdministrativeNegationExclusionTest(unittest.TestCase):
 class BatchOrchestratorRetargetFlagTest(unittest.TestCase):
     """--retarget-conditionals bypasses the repair-wait guard for explicitly
     named claims only (gate/template calibrations are invisible to the
-    source/dep movement guard; grain wave 6, 2026-07-13)."""
+    source/dep movement guard; 2026-07-13)."""
 
     def test_retarget_bypasses_repair_wait_for_named_claim_only(self):
         m = _import("orchestrate_audit_batch")

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -13426,3 +13426,41 @@ class N5AdministrativeNegationExclusionTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class BatchOrchestratorRetargetFlagTest(unittest.TestCase):
+    """--retarget-conditionals bypasses the repair-wait guard for explicitly
+    named claims only (gate/template calibrations are invisible to the
+    source/dep movement guard; grain wave 6, 2026-07-13)."""
+
+    def test_retarget_bypasses_repair_wait_for_named_claim_only(self):
+        m = _import("orchestrate_audit_batch")
+        row = {
+            "claim_id": "stuck_row",
+            "claim_type": "bounded_theorem",
+            "audit_status": "unaudited",
+            "effective_status": "open_gate",
+            "criticality": None,
+            "deps": [],
+        }
+        with mock.patch.object(
+            m, "awaiting_repair_since_conditional", return_value=True
+        ), mock.patch.object(
+            m, "source_requires_forensic", return_value=False
+        ), mock.patch.object(m, "note_hash_drifted", return_value=False):
+            targets, skipped = m.compute_targets(
+                {"stuck_row"}, {"stuck_row": dict(row)}
+            )
+            self.assertEqual(targets, [])
+            self.assertTrue(any("awaiting repair" in line for line in skipped))
+            targets, _ = m.compute_targets(
+                {"stuck_row"}, {"stuck_row": dict(row)},
+                retarget=frozenset({"stuck_row"}),
+            )
+            self.assertEqual([r["claim_id"] for r in targets], ["stuck_row"])
+            # A different named claim does not unlock this one.
+            targets, _ = m.compute_targets(
+                {"stuck_row"}, {"stuck_row": dict(row)},
+                retarget=frozenset({"other_row"}),
+            )
+            self.assertEqual(targets, [])


### PR DESCRIPTION
A conditional whose remedy is a gate/template calibration (like #5362) is invisible to the repair-wait guard — sources and dep statuses unchanged — so the row stays skipped after the environment is fixed. The new flag, valid only with an explicit `--claims` list, bypasses `awaiting_repair_since_conditional` for exactly the named rows; every other gate (drift, forensic, dep-readiness, type, session-dedup) still applies. Suite 343/343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)