### PR TITLE
audit-infra: require verbatim N7 evidence

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -516,8 +516,8 @@ supply it. Otherwise replace it with:
   },
   "N7_steelman": {
     "route_id": "<the evidenced N1 route that instantiates the strongest steelman>",
-    "argument": "<strongest argument against the no-go>",
-    "resolution": "<why it succeeds or fails in the scoped packet>",
+    "argument": "<copy one complete contiguous live-execution line that contains the selected N1 route mechanism and attempt verbatim>",
+    "resolution": "<copy one complete contiguous line from the cited independent execution or retained/accepted authority; it must name an N2 wall>",
     "resolved": true,
     "evidence_path": "<live runner_stdout path containing the complete argument and matching N1 evidence>",
     "evidence_locator": "<actual locator>",
@@ -692,7 +692,12 @@ N6 must bind every indexed candidate to an exact quoted indexed basis, an N2
 wall, and a substantive closure mechanism. N7 must cite the N1 route surface
 for the steelman and either orchestrator-marked independent execution or a
 retained/accepted, byte-authenticated authority for the resolution; a merely
-different path is not independence. The resolution text must occur there. N8 must bind
+different path is not independence. Copy `N7.argument` byte-for-byte as one
+contiguous line from the selected N1 route's live execution surface; that line
+must contain the route's complete `mechanism` and `attempt` verbatim. Copy
+`N7.resolution` byte-for-byte as one contiguous line from its independent
+resolution surface, and select a line that names an evidenced N2 wall. Do not
+paraphrase either field. N8 must bind
 each mechanism to its exact indexed candidate record. Copy known retirement
 state exactly; when the indexed `lifecycle_state` is `unknown`, preserve
 `retired` as JSON `null`. Applicability is a separate current-scope decision

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -7874,6 +7874,18 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             template_flat,
         )
         self.assertIn(
+            "Copy `N7.argument` byte-for-byte as one contiguous line",
+            template_flat,
+        )
+        self.assertIn(
+            "must contain the route's complete `mechanism` and `attempt` verbatim",
+            template_flat,
+        )
+        self.assertIn(
+            "Copy `N7.resolution` byte-for-byte as one contiguous line",
+            template_flat,
+        )
+        self.assertIn(
             "Copy the complete authenticated tuple",
             template_flat,
         )
@@ -10060,6 +10072,23 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         )
         self.assertNotIn("secret_path", n3_scan_prompt)
         self.assertNotIn("secret_id", n3_scan_prompt)
+        for n7_error in (
+            "N7.argument is not evidenced at its N1 execution path",
+            "N7.resolution is not evidenced at resolution_evidence_path",
+            "N7.argument must name the steelmanned route mechanism",
+            "N7.argument must name the steelmanned route attempt",
+        ):
+            n7_code = m.fresh_schema_retry_code(n7_error)
+            self.assertEqual(
+                n7_code, "N7_EXECUTION_EVIDENCE_VERBATIM_MISMATCH"
+            )
+            n7_prompt = m.render_fresh_schema_retry_prompt(
+                "ORIGINAL RESTRICTED PACKET", n7_code, 1,
+            )
+            self.assertIn("one complete contiguous live-execution line", n7_prompt)
+            self.assertIn("route mechanism and attempt verbatim", n7_prompt)
+            self.assertIn("names an evidenced N2 wall", n7_prompt)
+            self.assertNotIn(n7_error, n7_prompt)
         n4_errors = [
             "N4 witness 1.witness_residual_id must be non-empty",
             "N4 witness 1.claim_residual_id must be a stable residual:<id>",

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1754,6 +1754,13 @@ def fresh_schema_retry_code(validation_error: str) -> str:
         return "N5_AUTHENTICATED_GROUP_TUPLE_MISMATCH"
     if validation_error.startswith("N3 retained_authority hit "):
         return "N3_RETAINED_AUTHORITY_PROVENANCE_MISMATCH"
+    if validation_error in {
+        "N7.argument is not evidenced at its N1 execution path",
+        "N7.resolution is not evidenced at resolution_evidence_path",
+        "N7.argument must name the steelmanned route mechanism",
+        "N7.argument must name the steelmanned route attempt",
+    }:
+        return "N7_EXECUTION_EVIDENCE_VERBATIM_MISMATCH"
     if validation_error.startswith("transport-bounded N8"):
         return "N8_TRANSPORT_BOUND_DISPOSITION_MISMATCH"
     if (
@@ -1861,6 +1868,15 @@ def render_fresh_schema_retry_prompt(
             "including its canonical class prefix and body, byte-for-byte as a "
             "contiguous line from the cited live current-cycle runner_stdout. "
             "Do not summarize, shorten, or paraphrase those five lines.\n"
+        ),
+        "N7_EXECUTION_EVIDENCE_VERBATIM_MISMATCH": (
+            "Static N7 invariant: copy argument byte-for-byte as one complete "
+            "contiguous live-execution line from the selected N1 route surface; "
+            "that line must contain the route mechanism and attempt verbatim. "
+            "Copy resolution byte-for-byte as one complete contiguous line from "
+            "the cited independent execution or retained/accepted authority, "
+            "and choose a line that names an evidenced N2 wall. Do not paraphrase "
+            "either field.\n"
         ),
         "N4_WITNESS_SCHEMA_MISMATCH": (
             "Static N4 invariant: when no N1 route is RULED OUT BY PRIOR, emit "


### PR DESCRIPTION
## Summary
- require N7 argument to copy a complete live N1 execution line containing route mechanism and attempt verbatim
- require N7 resolution to copy a complete independent execution or retained-authority line naming an N2 wall
- map the four observed N7 evidence failures to one sanitized conclusion-blind retry code
- add prompt and retry regressions

Validator logic is unchanged. This changes no science, premise, status, or audit verdict.

## Verification
- independent review-loop PASS at rebased exact head `3fd1a99d37bb436bd37501ee4e147cc84139fdc8`
- rejected R-eta N7 replay passes unchanged validator with exact current runner+authority lines
- focused 2/2; full suite 343/343
- R-eta runner 56/0
- pipeline and strict lint passed
- pycompile/vocab/diff/generated-cleanliness passed