### PR TITLE
science-fix: cl3 exclusion runner executed lattice-wide certificates + labeled mechanism classes

### DIFF
--- a/docs/CL3_COMPLEXIFICATION_SPLIT_NARROW_THEOREM_NOTE_2026-05-10.md
+++ b/docs/CL3_COMPLEXIFICATION_SPLIT_NARROW_THEOREM_NOTE_2026-05-10.md
@@ -265,7 +265,7 @@ Expected output: `PASS=N FAIL=0` with `N ≥ 20`.
 
 The dedicated exclusion stress runner constructs the full `8`-dimensional
 complexified algebra and verifies the negative-assertion surface using exact
-sympy/stdlib arithmetic. Its recorded output is `TOTAL: PASS=54 FAIL=0`, including the N5 resolution sweep that restates each authenticated negative statement at the five canonical resolution classes (`per_element`, `per_site`, `per_mode`, `per_block`, `lattice_wide`), with the lattice-wide class honestly reported as checked and not executed for this single-site algebra claim.
+sympy/stdlib arithmetic. Its recorded output is `TOTAL: PASS=62 FAIL=0`, including the executed lattice-wide tensor extension (the joint per-site scalar Clifford systems on the 2-site and 3-site lattice algebras have no solution, and every irreducible 2-site module has dimension `4 = 2^2` by scalar-commutant and exact dimension-count exhaustion, with 2-dimensional per-site restrictions), the five labeled distinct exclusion mechanism classes, and the N5 resolution sweep in which every canonical class (`per_element`, `per_site`, `per_mode`, `per_block`, `lattice_wide`) is executed against a computed certificate.
 
 | Claim surface | Runner | Exact verification |
 |---|---|---|

--- a/docs/CL3_COMPLEXIFICATION_SPLIT_NARROW_THEOREM_NOTE_2026-05-10.md
+++ b/docs/CL3_COMPLEXIFICATION_SPLIT_NARROW_THEOREM_NOTE_2026-05-10.md
@@ -48,9 +48,8 @@ exactly `2` and that no faithful one-dimensional representation exists are
 explicit derived negative assertions. The dedicated exclusion stress runner
 certifies those exclusions exhaustively through the central-idempotent split,
 simple-module dimension classification, scalar-system contradiction, and
-faithfulness-boundary computation. This source note does not set or predict
-audit status; any audit status remains an output of the independent audit
-lane.
+faithfulness-boundary computation. Audit status remains solely an output of
+the independent audit lane.
 
 ## Why this note exists
 
@@ -184,22 +183,20 @@ the full complexification are individually non-faithful:
 `ker ρ_-^C = e_+ · (Cl(3,0) ⊗_R C)`. Their restrictions to the real
 algebra `Cl(3,0)` are faithful real-algebra maps. ∎
 
-## What this note does NOT claim
+## Scope exclusions
 
-- Does **not** identify the abstract Cl(3) site module with a physical
-  per-site Hilbert space on any specific lattice realisation. That
-  bridge depends on the staggered-Dirac realization gate (substep 1)
-  and remains out of scope here.
-- Does **not** force the chirality choice. Both `ρ_+` (with
+- The abstract Cl(3) site module remains distinct from a physical per-site
+  Hilbert space on any specific lattice realisation. That bridge belongs to
+  the staggered-Dirac realization gate (substep 1) and remains out of scope.
+- Both chirality choices are valid: `ρ_+` (with
   `ω → +i`, `γ_i = σ_i`) and `ρ_-` (with `ω → -i`, `γ_i = -σ_i`) are
-  valid faithful 2-dim irreps; the package convention `ρ_+` is a
-  normalisation choice not derived here.
-- Does **not** derive the Pauli exclusion principle, Grassmann
-  anticommutation, or any spin-statistics claim. Those are downstream
-  consequences carried by other notes and gates.
-- Does **not** make any physical / observational claim, consume any
-  PDG value, fitted constant, or admit any lattice convention beyond
-  the abstract real Clifford algebra.
+  faithful 2-dim irreps. The package convention `ρ_+` is a bookkeeping
+  normalisation choice.
+- The Pauli exclusion principle, Grassmann anticommutation, and spin-statistics
+  claims remain downstream consequences carried by other notes and gates.
+- The scope is purely algebraic and consumes zero physical or observational
+  inputs, PDG values, fitted constants, or lattice conventions beyond the
+  abstract real Clifford algebra.
 
 ## Forbidden imports check
 
@@ -251,10 +248,10 @@ on `2 × 2` complex matrices:
    in both realisations.
 5. In each displayed chirality realisation, the Pauli natural module has
    complex dimension `2`, scalar commutant, and a scalar Casimir-like element.
-   This companion check does not classify every simple module; the exhaustive
-   uniqueness and dimension classification is computed by E2 of the dedicated
-   exclusion stress runner below.
-6. Counter-example check: the scalar (`1 × 1`) candidate fails on the
+   The exhaustive uniqueness and dimension classification beyond these
+   displayed modules is computed by E2 of the dedicated exclusion stress
+   runner below.
+6. Counter-example check: the scalar (`1 × 1`) candidate violates the
    anticommutation `{σ_1, σ_2} = 0` because a scalar anticommutes
    with itself only when it is `0`, so a faithful `1 × 1` complex
    Cl(3)-irrep does not exist. The Artin-Wedderburn classification above,
@@ -265,7 +262,7 @@ Expected output: `PASS=N FAIL=0` with `N ≥ 20`.
 
 The dedicated exclusion stress runner constructs the full `8`-dimensional
 complexified algebra and verifies the negative-assertion surface using exact
-sympy/stdlib arithmetic. Its recorded output is `TOTAL: PASS=62 FAIL=0`, including the executed lattice-wide tensor extension (the joint per-site scalar Clifford systems on the 2-site and 3-site lattice algebras have no solution, and every irreducible 2-site module has dimension `4 = 2^2` by scalar-commutant and exact dimension-count exhaustion, with 2-dimensional per-site restrictions), the five labeled distinct exclusion mechanism classes, and the N5 resolution sweep in which every canonical class (`per_element`, `per_site`, `per_mode`, `per_block`, `lattice_wide`) is executed against a computed certificate.
+sympy/stdlib arithmetic. Its recorded output is `TOTAL: PASS=62 FAIL=0`, including the finite-region lattice-wide tensor extension: a one-dimensional complex character on any nonempty finite real `N`-site tensor algebra `Cl(3,0)^{⊗_R N}` would restrict to a forbidden one-site scalar character; and, defining `A_C := Cl(3,0) ⊗_R C`, the computed `A_C ≅ M_2(C) ⊕ M_2(C)` split gives `A_C^{⊗_C N} ≅ ⨁_{s∈{±}^N} M_{2^N}(C)`, so every finite-region simple module has dimension `2^N` and restricts at one site as `2^{N-1}` copies of its 2-dimensional site module. For `N ≥ 2`, those irreducible modules are nonfaithful on the real tensor algebra: its real dimension `8^N` exceeds the real dimension `2·4^N` of the complex endomorphism algebra by the factor `2^{N-1}`. The runner solves the `N=2` and `N=3` scalar systems explicitly and, at `N=2`, constructs all four modules, solves their scalar commutants, verifies their distinct pairs of central characters, explicitly decomposes their site restrictions, computes real map rank `32` and kernel dimension `32` for each, and exhausts the `64`-dimensional algebra by the Artin-Wedderburn count `4 × 16 = 64`. This finite-region algebra statement is restricted to abstract finite tensor powers; infinite quasi-local completions and physical lattice Hilbert-space realizations remain outside its scope. The output also records five labeled distinct exclusion mechanism classes and the N5 resolution sweep in which every canonical class (`per_element`, `per_site`, `per_mode`, `per_block`, `lattice_wide`) is executed against a computed certificate.
 
 | Claim surface | Runner | Exact verification |
 |---|---|---|
@@ -279,8 +276,7 @@ sympy/stdlib arithmetic. Its recorded output is `TOTAL: PASS=62 FAIL=0`, includi
 
 Plain-text (non-load-bearing) reader pointers; following the PR #306
 cleanup pattern, these are written without markdown links so the
-citation-graph builder does not parse them as upstream dependency
-edges:
+citation-graph builder ignores them as upstream dependency edges:
 
 - `AXIOM_FIRST_CL3_PER_SITE_UNIQUENESS_THEOREM_NOTE_2026-04-29.md`
   — parent note carrying the in-scope U1-U3 representation theory
@@ -295,8 +291,8 @@ edges:
 ## Citation-graph note
 
 This note has zero load-bearing markdown-link upstream dependencies.
-The abstract-algebra content of (K1)-(K4) does not consume any other
-note's effective status. The cross-references above are plain-text
+The abstract-algebra content of (K1)-(K4) requires zero effective-status
+inputs from other notes. The cross-references above are plain-text
 reader pointers, not load-bearing deps. The MINIMAL_AXIOMS framework
 baseline memo is named in plain text in the "Cited authorities"
 section above; that connection is informational, not load-bearing for

--- a/logs/runner-cache/cl3_complexification_exclusion_stress_2026_07_13.txt
+++ b/logs/runner-cache/cl3_complexification_exclusion_stress_2026_07_13.txt
@@ -83,24 +83,24 @@ E4: full-complexification kernel and real-algebra faithfulness boundary
 [PASS] E4.TOTAL both 2-dim full-complexification modules are non-faithful, while both real Cl(3,0) restrictions are faithful | ker(pi_+)=e_-A and ker(pi_-)=e_+A
 
 ========================================================================================
-EL: executed lattice-wide tensor extension of both exclusions
+EL: executed finite-region lattice-wide tensor extension of both exclusions
 ========================================================================================
-The one-site exclusions are re-proved on multi-site lattice tensor algebras Cl(3,0)^{tensor N}: a one-dimensional representation of the lattice algebra restricts to multiplicative scalar characters per site factor, and the joint per-site scalar Clifford systems are solved exhaustively; the N=2 irreducible modules are constructed and exhausted by exact dimension count.
+The one-site exclusions are re-proved on real multi-site lattice tensor algebras Cl(3,0)^{tensor_R N}: a one-dimensional complex character of the lattice algebra restricts to multiplicative scalar characters per site factor, and the joint per-site scalar Clifford systems are solved exhaustively; the N=2 irreducible modules are constructed and exhausted by exact dimension count. Here lattice-wide means every nonempty finite site set: restriction to one site makes the scalar contradiction N-independent, while, for A_C := Cl(3,0) tensor_R C, tensor distributivity gives A_C^{tensor_C N} = direct-sum_{s in {+,-}^N} M_{2^N}(C), with 2^N simple modules of dimension 2^N and site-restriction multiplicity 2^(N-1). No infinite quasi-local completion or physical lattice Hilbert-space realization is asserted.
 [PASS] EL.scalar N=2: the joint per-site scalar Clifford system over the 2-site lattice algebra has no solution | unknowns=6, equations=18, solutions=0
 [PASS] EL.scalar N=3: the joint per-site scalar Clifford system over the 3-site lattice algebra has no solution | unknowns=9, equations=27, solutions=0
-[PASS] EL.module (+,+): the 4-dim two-site module is irreducible (scalar commutant) and restricts to the 2-dim site modules | commutant solved to scalars; per-site restriction dimension 2
-[PASS] EL.module (+,-): the 4-dim two-site module is irreducible (scalar commutant) and restricts to the 2-dim site modules | commutant solved to scalars; per-site restriction dimension 2
-[PASS] EL.module (-,+): the 4-dim two-site module is irreducible (scalar commutant) and restricts to the 2-dim site modules | commutant solved to scalars; per-site restriction dimension 2
-[PASS] EL.module (-,-): the 4-dim two-site module is irreducible (scalar commutant) and restricts to the 2-dim site modules | commutant solved to scalars; per-site restriction dimension 2
-[PASS] EL.exhaustion: the four 4-dim two-site modules exhaust the 64-dim two-site algebra by exact dimension count (4 x 16 = 64) | sum of squared dimensions = 64
-[PASS] EL.TOTAL lattice-wide certificates for both exclusions are executed | no lattice-wide one-dim character exists; every two-site irreducible module has dimension 4 = 2^2 with 2-dim per-site restrictions
+[PASS] EL.module (+,+): the 4-dim two-site module is irreducible (scalar commutant), has its stated central characters, and restricts to two copies of each 2-dim site module | commutant rank=15, nullity=1; explicit per-site direct-sum intertwiners; real tensor-algebra map rank=32, kernel dim=32
+[PASS] EL.module (+,-): the 4-dim two-site module is irreducible (scalar commutant), has its stated central characters, and restricts to two copies of each 2-dim site module | commutant rank=15, nullity=1; explicit per-site direct-sum intertwiners; real tensor-algebra map rank=32, kernel dim=32
+[PASS] EL.module (-,+): the 4-dim two-site module is irreducible (scalar commutant), has its stated central characters, and restricts to two copies of each 2-dim site module | commutant rank=15, nullity=1; explicit per-site direct-sum intertwiners; real tensor-algebra map rank=32, kernel dim=32
+[PASS] EL.module (-,-): the 4-dim two-site module is irreducible (scalar commutant), has its stated central characters, and restricts to two copies of each 2-dim site module | commutant rank=15, nullity=1; explicit per-site direct-sum intertwiners; real tensor-algebra map rank=32, kernel dim=32
+[PASS] EL.exhaustion: the four central-character-distinct 4-dim modules exhaust the semisimple 64-dim two-site algebra by Artin-Wedderburn dimension count (4 x 16 = 64) | central characters=[(-1, -1), (-1, 1), (1, -1), (1, 1)]; sum of squared dimensions = 64; symbolic finite-N dimension identity 2^N(2^N)^2=8^N and N>=2 real-dimension nonfaithfulness ratio 2^(N-1)
+[PASS] EL.TOTAL lattice-wide certificates for both exclusions are executed | no finite-region lattice-wide one-dim character exists; the N-site simple dimensions are 2^N, and every N>=2 simple is nonfaithful on the real tensor algebra, with the N=2 modules and kernels constructed explicitly
 
 N1 MECHANISM CLASSES (distinct attack routes, live evidence above):
-mechanism_class 1: central_idempotent_split_and_simplicity (E1 checks)
-mechanism_class 2: exhaustive_module_dimension_classification (E2 checks)
-mechanism_class 3: scalar_polynomial_system_contradiction (E3 checks)
-mechanism_class 4: faithfulness_kernel_computation (E4 checks)
-mechanism_class 5: lattice_tensor_restriction (EL checks)
+mechanism_class 1: route_id=central_split route_class=algebraic_rearrangement mechanism=solve the complete center and central-idempotent algebra, then isolate matrix units in each summand; attempt=test whether an omitted central block or proper ideal supports another simple-module dimension; outcome=E1 exhausts exactly two simple M2(C) summands; honesty_marker=ATTEMPTED disposition=CLOSED
+mechanism_class 2: route_id=module_carriers route_class=alternate_carrier_or_sector mechanism=classify every minimal left ideal in both central sectors; attempt=test alternate irreducible modules or carrier dimensions within either M2(C) block; outcome=E2 finds one 2-dimensional simple-module class per sector; honesty_marker=ATTEMPTED disposition=CLOSED
+mechanism_class 3: route_id=scalar_finite_scan route_class=numerical_or_finite_case mechanism=compute the exact scalar polynomial solve, unit-ideal Groebner basis, and finite square-law scan; attempt=search every one-dimensional scalar candidate for a Clifford character; outcome=E3 finds no solution and exhibits the exact contradiction; honesty_marker=ATTEMPTED disposition=CLOSED
+mechanism_class 4: route_id=faithfulness_boundary route_class=boundary_or_initial_condition mechanism=compute kernels on the full complexification and at the real-algebra restriction boundary; attempt=test whether the faithfulness wording hides an alternate full-complexification representation; outcome=E4 computes the opposite summand kernels and faithful real restrictions; honesty_marker=ATTEMPTED disposition=CLOSED
+mechanism_class 5: route_id=finite_lattice_tensor route_class=lattice_scale_or_limit mechanism=restrict finite-region tensor-algebra characters sitewise and construct the two-site tensor modules; attempt=test whether multiple lattice sites evade the one-site exclusions or change the tensor-power simple-module dimensions; outcome=EL closes the site-character route for every finite N and constructs and exhausts all N=2 blocks; honesty_marker=ATTEMPTED disposition=CLOSED
 
 ========================================================================================
 N5 RESOLUTION SWEEP (per authenticated negative statement)
@@ -111,14 +111,14 @@ per_element: [EXECUTED] each generator pair (x_i, x_j), i != j, already forces t
 per_site: [EXECUTED] Cl(3,0) is the one-site real algebra; the full scalar system over one site was solved exhaustively and is inconsistent
 per_mode: [EXECUTED] every irreducible module (mode) restricts to one central summand and has computed complex dimension 2, never 1
 per_block: [EXECUTED] both central-idempotent blocks e_+A and e_-A carry only the 2-dimensional simple module; no block admits a 1-dimensional faithful action
-lattice_wide: [EXECUTED] executed on the 2-site and 3-site lattice tensor algebras: the joint per-site scalar Clifford systems have no solution, so no lattice-wide one-dimensional character restricts to a faithful one-dimensional site representation
+lattice_wide: [EXECUTED] for every nonempty finite N-site tensor algebra, a unital one-dimensional representation restricts to a forbidden one-site scalar character; the N=2 and N=3 joint systems were also solved explicitly with no solutions
 [PASS] N5 sweep backed by computed certificates :: NEGATIVE STATEMENT 1: no faithful one-dimensional complex re | every executed resolution line restates a computed exclusion above
 NEGATIVE STATEMENT 2: no faithful irreducible complex representation of Cl(3,0) has dimension other than 2
 per_element: [EXECUTED] central idempotent actions on any simple module were solved element-wise to exactly one active summand
 per_site: [EXECUTED] at the single site, the minimal-left-ideal decomposition exhausts all simple quotients and each has dimension 2
 per_mode: [EXECUTED] every irreducible module (mode) is a quotient of its active regular summand and computes to dimension exactly 2
 per_block: [EXECUTED] each 4-dimensional simple block decomposes into two copies of the same 2-dimensional simple module; no other dimension occurs
-lattice_wide: [EXECUTED] executed on the 2-site lattice tensor algebra: every irreducible module has dimension 4 = 2^2 by scalar-commutant and exact dimension-count exhaustion, and each per-site restriction has dimension exactly 2
+lattice_wide: [EXECUTED] at N=1 every faithful irreducible has dimension 2, while for every finite N>=2 the real algebra dimension 8^N exceeds the real endomorphism dimension 2*4^N by ratio 2^(N-1), so no irreducible tensor-power module can be faithful; at N=2 all four real map ranks 32 and kernel dimensions 32 were computed explicitly
 [PASS] N5 sweep backed by computed certificates :: NEGATIVE STATEMENT 2: no faithful irreducible complex repres | every executed resolution line restates a computed exclusion above
 
 ========================================================================================

--- a/logs/runner-cache/cl3_complexification_exclusion_stress_2026_07_13.txt
+++ b/logs/runner-cache/cl3_complexification_exclusion_stress_2026_07_13.txt
@@ -83,27 +83,47 @@ E4: full-complexification kernel and real-algebra faithfulness boundary
 [PASS] E4.TOTAL both 2-dim full-complexification modules are non-faithful, while both real Cl(3,0) restrictions are faithful | ker(pi_+)=e_-A and ker(pi_-)=e_+A
 
 ========================================================================================
+EL: executed lattice-wide tensor extension of both exclusions
+========================================================================================
+The one-site exclusions are re-proved on multi-site lattice tensor algebras Cl(3,0)^{tensor N}: a one-dimensional representation of the lattice algebra restricts to multiplicative scalar characters per site factor, and the joint per-site scalar Clifford systems are solved exhaustively; the N=2 irreducible modules are constructed and exhausted by exact dimension count.
+[PASS] EL.scalar N=2: the joint per-site scalar Clifford system over the 2-site lattice algebra has no solution | unknowns=6, equations=18, solutions=0
+[PASS] EL.scalar N=3: the joint per-site scalar Clifford system over the 3-site lattice algebra has no solution | unknowns=9, equations=27, solutions=0
+[PASS] EL.module (+,+): the 4-dim two-site module is irreducible (scalar commutant) and restricts to the 2-dim site modules | commutant solved to scalars; per-site restriction dimension 2
+[PASS] EL.module (+,-): the 4-dim two-site module is irreducible (scalar commutant) and restricts to the 2-dim site modules | commutant solved to scalars; per-site restriction dimension 2
+[PASS] EL.module (-,+): the 4-dim two-site module is irreducible (scalar commutant) and restricts to the 2-dim site modules | commutant solved to scalars; per-site restriction dimension 2
+[PASS] EL.module (-,-): the 4-dim two-site module is irreducible (scalar commutant) and restricts to the 2-dim site modules | commutant solved to scalars; per-site restriction dimension 2
+[PASS] EL.exhaustion: the four 4-dim two-site modules exhaust the 64-dim two-site algebra by exact dimension count (4 x 16 = 64) | sum of squared dimensions = 64
+[PASS] EL.TOTAL lattice-wide certificates for both exclusions are executed | no lattice-wide one-dim character exists; every two-site irreducible module has dimension 4 = 2^2 with 2-dim per-site restrictions
+
+N1 MECHANISM CLASSES (distinct attack routes, live evidence above):
+mechanism_class 1: central_idempotent_split_and_simplicity (E1 checks)
+mechanism_class 2: exhaustive_module_dimension_classification (E2 checks)
+mechanism_class 3: scalar_polynomial_system_contradiction (E3 checks)
+mechanism_class 4: faithfulness_kernel_computation (E4 checks)
+mechanism_class 5: lattice_tensor_restriction (EL checks)
+
+========================================================================================
 N5 RESOLUTION SWEEP (per authenticated negative statement)
 ========================================================================================
-Each negative statement below is swept over the five canonical resolution classes. Executed classes restate the computed exclusion at that scope; classes with no in-scope instance are checked and reported as not executed. Lines are stable for byte-for-byte citation.
+Each negative statement below is swept over the five canonical resolution classes; every class is executed against a computed certificate above, including the lattice-wide tensor extension. Lines are stable for byte-for-byte citation.
 NEGATIVE STATEMENT 1: no faithful one-dimensional complex representation of Cl(3,0) exists
 per_element: [EXECUTED] each generator pair (x_i, x_j), i != j, already forces the contradiction x_i x_j = -x_j x_i with commuting scalars; the scalar Clifford system has no solution element-by-element
 per_site: [EXECUTED] Cl(3,0) is the one-site real algebra; the full scalar system over one site was solved exhaustively and is inconsistent
 per_mode: [EXECUTED] every irreducible module (mode) restricts to one central summand and has computed complex dimension 2, never 1
 per_block: [EXECUTED] both central-idempotent blocks e_+A and e_-A carry only the 2-dimensional simple module; no block admits a 1-dimensional faithful action
-lattice_wide: [NOT EXECUTED] checked and not executed: the claim is a single-site algebra statement; no lattice-wide instance exists in this note's scope
+lattice_wide: [EXECUTED] executed on the 2-site and 3-site lattice tensor algebras: the joint per-site scalar Clifford systems have no solution, so no lattice-wide one-dimensional character restricts to a faithful one-dimensional site representation
 [PASS] N5 sweep backed by computed certificates :: NEGATIVE STATEMENT 1: no faithful one-dimensional complex re | every executed resolution line restates a computed exclusion above
 NEGATIVE STATEMENT 2: no faithful irreducible complex representation of Cl(3,0) has dimension other than 2
 per_element: [EXECUTED] central idempotent actions on any simple module were solved element-wise to exactly one active summand
 per_site: [EXECUTED] at the single site, the minimal-left-ideal decomposition exhausts all simple quotients and each has dimension 2
 per_mode: [EXECUTED] every irreducible module (mode) is a quotient of its active regular summand and computes to dimension exactly 2
 per_block: [EXECUTED] each 4-dimensional simple block decomposes into two copies of the same 2-dimensional simple module; no other dimension occurs
-lattice_wide: [NOT EXECUTED] checked and not executed: the claim is a single-site algebra statement; no lattice-wide instance exists in this note's scope
+lattice_wide: [EXECUTED] executed on the 2-site lattice tensor algebra: every irreducible module has dimension 4 = 2^2 by scalar-commutant and exact dimension-count exhaustion, and each per-site restriction has dimension exactly 2
 [PASS] N5 sweep backed by computed certificates :: NEGATIVE STATEMENT 2: no faithful irreducible complex repres | every executed resolution line restates a computed exclusion above
 
 ========================================================================================
 TOTAL
 ========================================================================================
 [PASS] UNIVERSAL EXCLUSION CERTIFICATE | faithful irreducible complex Cl(3,0) representations have dimension 2; d=1 is impossible
-TOTAL: PASS=54 FAIL=0
+TOTAL: PASS=62 FAIL=0
 FLAGS: none

--- a/scripts/cl3_complexification_exclusion_stress_2026_07_13.py
+++ b/scripts/cl3_complexification_exclusion_stress_2026_07_13.py
@@ -10,6 +10,7 @@ E2. the exhaustive two-dimensional classification of irreducible modules;
 E3. the one-dimensional no-go and the two-dimensional Pauli control; and
 E4. the faithfulness boundary between the full complexification and the
     original real algebra Cl(3,0).
+EL. the multi-site scalar-character and two-site simple-module extensions.
 
 All algebra is exact SymPy arithmetic.  Every reported check is computed.
 """
@@ -129,8 +130,8 @@ def coordinates_of_matrix(matrix: Matrix) -> Matrix:
 
 def real_coordinates_of_matrix(matrix: Matrix) -> Matrix:
     entries: List[sp.Expr] = []
-    for row in range(2):
-        for col in range(2):
+    for row in range(matrix.rows):
+        for col in range(matrix.cols):
             entries.extend([sp.re(matrix[row, col]), sp.im(matrix[row, col])])
     return Matrix(entries)
 
@@ -762,14 +763,21 @@ def main() -> int:
     )
 
     # ------------------------------------------------------------------ EL
-    section("EL: executed lattice-wide tensor extension of both exclusions")
+    section("EL: executed finite-region lattice-wide tensor extension of both exclusions")
     print(
-        "The one-site exclusions are re-proved on multi-site lattice tensor "
-        "algebras Cl(3,0)^{tensor N}: a one-dimensional representation of the "
-        "lattice algebra restricts to multiplicative scalar characters per "
+        "The one-site exclusions are re-proved on real multi-site lattice tensor "
+        "algebras Cl(3,0)^{tensor_R N}: a one-dimensional complex character of "
+        "the lattice algebra restricts to multiplicative scalar characters per "
         "site factor, and the joint per-site scalar Clifford systems are "
         "solved exhaustively; the N=2 irreducible modules are constructed and "
-        "exhausted by exact dimension count."
+        "exhausted by exact dimension count. Here lattice-wide means every "
+        "nonempty finite site set: restriction to one site makes the scalar "
+        "contradiction N-independent, while, for A_C := Cl(3,0) tensor_R C, "
+        "tensor distributivity gives A_C^{tensor_C N} = "
+        "direct-sum_{s in {+,-}^N} M_{2^N}(C), with 2^N "
+        "simple modules of dimension 2^N and site-restriction multiplicity "
+        "2^(N-1). No infinite quasi-local completion or physical lattice "
+        "Hilbert-space realization is asserted."
     )
     lattice_scalar_ok = True
     for n_sites in (2, 3):
@@ -796,15 +804,23 @@ def main() -> int:
 
     two_site_modules_ok = True
     site_irreps = {1: representation_images(1, pauli), -1: representation_images(-1, pauli)}
+    generator_blade_indices = (1, 2, 4)
+    shuffle = eye(4)[:, [0, 2, 1, 3]]
+    central_character_pairs = set()
     total_square = 0
     for sign_a in (1, -1):
         for sign_b in (1, -1):
             images_a = site_irreps[sign_a]
             images_b = site_irreps[sign_b]
-            joint_generators = (
-                [sp.kronecker_product(g, sp.eye(2)) for g in images_a[:3]]
-                + [sp.kronecker_product(sp.eye(2), g) for g in images_b[:3]]
-            )
+            site_a_generators = [
+                sp.kronecker_product(images_a[index], eye(2))
+                for index in generator_blade_indices
+            ]
+            site_b_generators = [
+                sp.kronecker_product(eye(2), images_b[index])
+                for index in generator_blade_indices
+            ]
+            joint_generators = site_a_generators + site_b_generators
             commutant_entries = [[symbols(f"c{sign_a}{sign_b}_{r}{c}") for c in range(4)] for r in range(4)]
             commutant = Matrix(commutant_entries)
             equations = []
@@ -812,46 +828,158 @@ def main() -> int:
                 difference = sp.expand(commutant * generator - generator * commutant)
                 equations.extend(difference)
             unknowns = [entry for row_entries in commutant_entries for entry in row_entries]
-            solution = sp.solve(equations, unknowns, dict=True)
-            scalar_commutant = False
-            if len(solution) == 1:
-                solved = commutant.subs(solution[0])
-                scalar_value = solved[0, 0]
-                scalar_commutant = bool(
-                    sp.simplify(solved - scalar_value * sp.eye(4)).is_zero_matrix
+            commutant_constraint, commutant_rhs = sp.linear_eq_to_matrix(equations, unknowns)
+            commutant_nullspace = commutant_constraint.nullspace()
+            identity_coordinates = Matrix(
+                [sp.Integer(1) if row == col else sp.Integer(0) for row in range(4) for col in range(4)]
+            )
+            scalar_commutant = (
+                commutant_rhs == zeros(commutant_rhs.rows, 1)
+                and len(commutant_nullspace) == 1
+                and same_subspace(commutant_nullspace, [identity_coordinates])
+            )
+
+            site_a_restriction_ok = all(
+                matrix_equal(
+                    shuffle.T * generator * shuffle,
+                    sp.diag(images_a[index], images_a[index]),
                 )
-            restriction_dims_ok = all(g.shape == (4, 4) for g in joint_generators)
-            two_site_modules_ok = two_site_modules_ok and scalar_commutant and restriction_dims_ok
+                for generator, index in zip(site_a_generators, generator_blade_indices)
+            )
+            site_b_restriction_ok = all(
+                matrix_equal(
+                    generator,
+                    sp.diag(images_b[index], images_b[index]),
+                )
+                for generator, index in zip(site_b_generators, generator_blade_indices)
+            )
+
+            omega_a = sp.kronecker_product(images_a[7], eye(2))
+            omega_b = sp.kronecker_product(eye(2), images_b[7])
+            central_characters_ok = (
+                matrix_equal(omega_a, sign_a * I * eye(4))
+                and matrix_equal(omega_b, sign_b * I * eye(4))
+            )
+            if central_characters_ok:
+                central_character_pairs.add((sign_a, sign_b))
+
+            two_site_real_images = [
+                sp.kronecker_product(images_a[left_mask], images_b[right_mask])
+                for left_mask, right_mask in itertools.product(range(DIM), repeat=2)
+            ]
+            two_site_real_map = Matrix.hstack(
+                *[real_coordinates_of_matrix(image) for image in two_site_real_images]
+            )
+            two_site_real_rank = two_site_real_map.rank()
+            two_site_real_kernel_dim = len(two_site_real_map.nullspace())
+            real_restriction_nonfaithful = (
+                two_site_real_rank == 32 and two_site_real_kernel_dim == 32
+            )
+
+            module_ok = (
+                scalar_commutant
+                and site_a_restriction_ok
+                and site_b_restriction_ok
+                and central_characters_ok
+                and real_restriction_nonfaithful
+            )
+            two_site_modules_ok = two_site_modules_ok and module_ok
             total_square += 16
             check(
                 f"EL.module ({'+' if sign_a == 1 else '-'},{'+' if sign_b == 1 else '-'}): the 4-dim "
-                "two-site module is irreducible (scalar commutant) and restricts "
-                "to the 2-dim site modules",
-                scalar_commutant and restriction_dims_ok,
-                "commutant solved to scalars; per-site restriction dimension 2",
+                "two-site module is irreducible (scalar commutant), has its stated "
+                "central characters, and restricts to two copies of each 2-dim site module",
+                module_ok,
+                f"commutant rank={commutant_constraint.rank()}, nullity={len(commutant_nullspace)}; "
+                "explicit per-site direct-sum intertwiners; real tensor-algebra "
+                f"map rank={two_site_real_rank}, kernel dim={two_site_real_kernel_dim}",
             )
-    dimension_exhausts = total_square == 64
+    expected_character_pairs = {(1, 1), (1, -1), (-1, 1), (-1, -1)}
+    two_site_algebra_dimension = DIM**2
+    finite_n = symbols("finite_N", integer=True, positive=True)
+    finite_region_dimension_identity = (
+        simplify((2**finite_n) * (2**finite_n) ** 2 - DIM**finite_n) == 0
+    )
+    finite_n_ge_two_offset = symbols(
+        "finite_N_minus_one", integer=True, positive=True
+    )
+    finite_region_nonfaithfulness_ratio = simplify(
+        DIM ** (finite_n_ge_two_offset + 1)
+        / (2 * (2 ** (finite_n_ge_two_offset + 1)) ** 2)
+        - 2**finite_n_ge_two_offset
+    ) == 0
+    dimension_exhausts = (
+        two_site_modules_ok
+        and central_character_pairs == expected_character_pairs
+        and total_square == two_site_algebra_dimension
+        and finite_region_dimension_identity
+        and finite_region_nonfaithfulness_ratio
+    )
     check(
-        "EL.exhaustion: the four 4-dim two-site modules exhaust the 64-dim "
-        "two-site algebra by exact dimension count (4 x 16 = 64)",
+        "EL.exhaustion: the four central-character-distinct 4-dim modules exhaust "
+        "the semisimple 64-dim two-site algebra by Artin-Wedderburn dimension count "
+        "(4 x 16 = 64)",
         dimension_exhausts,
-        f"sum of squared dimensions = {total_square}",
+        f"central characters={sorted(central_character_pairs)}; "
+        f"sum of squared dimensions = {total_square}; symbolic finite-N "
+        "dimension identity 2^N(2^N)^2=8^N and N>=2 real-dimension "
+        "nonfaithfulness ratio 2^(N-1)",
     )
     el2_certificate = two_site_modules_ok and dimension_exhausts
     check(
         "EL.TOTAL lattice-wide certificates for both exclusions are executed",
         el1_certificate and el2_certificate,
-        "no lattice-wide one-dim character exists; every two-site irreducible "
-        "module has dimension 4 = 2^2 with 2-dim per-site restrictions",
+        "no finite-region lattice-wide one-dim character exists; the N-site "
+        "simple dimensions are 2^N, and every N>=2 simple is nonfaithful on "
+        "the real tensor algebra, with the N=2 modules and kernels constructed "
+        "explicitly",
     )
 
     print()
     print("N1 MECHANISM CLASSES (distinct attack routes, live evidence above):")
-    print("mechanism_class 1: central_idempotent_split_and_simplicity (E1 checks)")
-    print("mechanism_class 2: exhaustive_module_dimension_classification (E2 checks)")
-    print("mechanism_class 3: scalar_polynomial_system_contradiction (E3 checks)")
-    print("mechanism_class 4: faithfulness_kernel_computation (E4 checks)")
-    print("mechanism_class 5: lattice_tensor_restriction (EL checks)")
+    print(
+        "mechanism_class 1: route_id=central_split "
+        "route_class=algebraic_rearrangement mechanism=solve the complete center "
+        "and central-idempotent algebra, then isolate matrix units in each summand; "
+        "attempt=test whether an omitted central block or proper ideal supports "
+        "another simple-module dimension; outcome=E1 exhausts exactly two simple "
+        "M2(C) summands; honesty_marker=ATTEMPTED disposition=CLOSED"
+    )
+    print(
+        "mechanism_class 2: route_id=module_carriers "
+        "route_class=alternate_carrier_or_sector mechanism=classify every minimal "
+        "left ideal in both central sectors; attempt=test alternate irreducible "
+        "modules or carrier dimensions within either M2(C) block; outcome=E2 finds "
+        "one 2-dimensional simple-module class per sector; "
+        "honesty_marker=ATTEMPTED disposition=CLOSED"
+    )
+    print(
+        "mechanism_class 3: route_id=scalar_finite_scan "
+        "route_class=numerical_or_finite_case mechanism=compute the exact scalar "
+        "polynomial solve, unit-ideal Groebner basis, and finite square-law scan; "
+        "attempt=search every one-dimensional scalar candidate for a Clifford "
+        "character; outcome=E3 finds no solution and exhibits the exact "
+        "contradiction; honesty_marker=ATTEMPTED disposition=CLOSED"
+    )
+    print(
+        "mechanism_class 4: route_id=faithfulness_boundary "
+        "route_class=boundary_or_initial_condition mechanism=compute kernels on "
+        "the full complexification and at the real-algebra restriction boundary; "
+        "attempt=test whether the faithfulness wording hides an alternate "
+        "full-complexification representation; outcome=E4 computes the opposite "
+        "summand kernels and faithful real restrictions; "
+        "honesty_marker=ATTEMPTED disposition=CLOSED"
+    )
+    print(
+        "mechanism_class 5: route_id=finite_lattice_tensor "
+        "route_class=lattice_scale_or_limit mechanism=restrict finite-region "
+        "tensor-algebra characters sitewise and construct the two-site tensor "
+        "modules; attempt=test whether multiple lattice sites evade the one-site "
+        "exclusions or change the tensor-power simple-module dimensions; "
+        "outcome=EL closes the site-character route for every finite N and "
+        "constructs and exhausts all N=2 blocks; "
+        "honesty_marker=ATTEMPTED disposition=CLOSED"
+    )
 
     # ------------------------------------------------------------------ N5
     section("N5 RESOLUTION SWEEP (per authenticated negative statement)")
@@ -887,10 +1015,10 @@ def main() -> int:
                     "faithful action"
                 ), e2_executed),
                 ("lattice_wide", True, (
-                    "executed on the 2-site and 3-site lattice tensor algebras: "
-                    "the joint per-site scalar Clifford systems have no solution, "
-                    "so no lattice-wide one-dimensional character restricts to a "
-                    "faithful one-dimensional site representation"
+                    "for every nonempty finite N-site tensor algebra, a unital "
+                    "one-dimensional representation restricts to a forbidden "
+                    "one-site scalar character; the N=2 and N=3 joint systems "
+                    "were also solved explicitly with no solutions"
                 ), el1_certificate),
             ],
         ),
@@ -916,10 +1044,12 @@ def main() -> int:
                     "occurs"
                 ), e2_executed),
                 ("lattice_wide", True, (
-                    "executed on the 2-site lattice tensor algebra: every "
-                    "irreducible module has dimension 4 = 2^2 by scalar-commutant "
-                    "and exact dimension-count exhaustion, and each per-site "
-                    "restriction has dimension exactly 2"
+                    "at N=1 every faithful irreducible has dimension 2, while for "
+                    "every finite N>=2 the real algebra dimension 8^N exceeds the "
+                    "real endomorphism dimension 2*4^N by ratio 2^(N-1), so no "
+                    "irreducible tensor-power module can be faithful; at N=2 all "
+                    "four real map ranks 32 and kernel dimensions 32 were computed "
+                    "explicitly"
                 ), el2_certificate),
             ],
         ),

--- a/scripts/cl3_complexification_exclusion_stress_2026_07_13.py
+++ b/scripts/cl3_complexification_exclusion_stress_2026_07_13.py
@@ -761,14 +761,105 @@ def main() -> int:
         "ker(pi_+)=e_-A and ker(pi_-)=e_+A",
     )
 
+    # ------------------------------------------------------------------ EL
+    section("EL: executed lattice-wide tensor extension of both exclusions")
+    print(
+        "The one-site exclusions are re-proved on multi-site lattice tensor "
+        "algebras Cl(3,0)^{tensor N}: a one-dimensional representation of the "
+        "lattice algebra restricts to multiplicative scalar characters per "
+        "site factor, and the joint per-site scalar Clifford systems are "
+        "solved exhaustively; the N=2 irreducible modules are constructed and "
+        "exhausted by exact dimension count."
+    )
+    lattice_scalar_ok = True
+    for n_sites in (2, 3):
+        site_unknowns = [
+            [symbols(f"z{site}_{index}") for index in range(1, 4)]
+            for site in range(n_sites)
+        ]
+        joint_system = []
+        for site_vars in site_unknowns:
+            for i in range(3):
+                for j in range(3):
+                    lhs = site_vars[i] * site_vars[j] + site_vars[j] * site_vars[i]
+                    rhs = 2 if i == j else 0
+                    joint_system.append(sp.expand(lhs - rhs))
+        joint_solutions = sp.solve(joint_system, [v for site in site_unknowns for v in site], dict=True)
+        lattice_scalar_ok = lattice_scalar_ok and joint_solutions == []
+        check(
+            f"EL.scalar N={n_sites}: the joint per-site scalar Clifford system over the "
+            f"{n_sites}-site lattice algebra has no solution",
+            joint_solutions == [],
+            f"unknowns={3 * n_sites}, equations={len(joint_system)}, solutions={len(joint_solutions)}",
+        )
+    el1_certificate = lattice_scalar_ok
+
+    two_site_modules_ok = True
+    site_irreps = {1: representation_images(1, pauli), -1: representation_images(-1, pauli)}
+    total_square = 0
+    for sign_a in (1, -1):
+        for sign_b in (1, -1):
+            images_a = site_irreps[sign_a]
+            images_b = site_irreps[sign_b]
+            joint_generators = (
+                [sp.kronecker_product(g, sp.eye(2)) for g in images_a[:3]]
+                + [sp.kronecker_product(sp.eye(2), g) for g in images_b[:3]]
+            )
+            commutant_entries = [[symbols(f"c{sign_a}{sign_b}_{r}{c}") for c in range(4)] for r in range(4)]
+            commutant = Matrix(commutant_entries)
+            equations = []
+            for generator in joint_generators:
+                difference = sp.expand(commutant * generator - generator * commutant)
+                equations.extend(difference)
+            unknowns = [entry for row_entries in commutant_entries for entry in row_entries]
+            solution = sp.solve(equations, unknowns, dict=True)
+            scalar_commutant = False
+            if len(solution) == 1:
+                solved = commutant.subs(solution[0])
+                scalar_value = solved[0, 0]
+                scalar_commutant = bool(
+                    sp.simplify(solved - scalar_value * sp.eye(4)).is_zero_matrix
+                )
+            restriction_dims_ok = all(g.shape == (4, 4) for g in joint_generators)
+            two_site_modules_ok = two_site_modules_ok and scalar_commutant and restriction_dims_ok
+            total_square += 16
+            check(
+                f"EL.module ({'+' if sign_a == 1 else '-'},{'+' if sign_b == 1 else '-'}): the 4-dim "
+                "two-site module is irreducible (scalar commutant) and restricts "
+                "to the 2-dim site modules",
+                scalar_commutant and restriction_dims_ok,
+                "commutant solved to scalars; per-site restriction dimension 2",
+            )
+    dimension_exhausts = total_square == 64
+    check(
+        "EL.exhaustion: the four 4-dim two-site modules exhaust the 64-dim "
+        "two-site algebra by exact dimension count (4 x 16 = 64)",
+        dimension_exhausts,
+        f"sum of squared dimensions = {total_square}",
+    )
+    el2_certificate = two_site_modules_ok and dimension_exhausts
+    check(
+        "EL.TOTAL lattice-wide certificates for both exclusions are executed",
+        el1_certificate and el2_certificate,
+        "no lattice-wide one-dim character exists; every two-site irreducible "
+        "module has dimension 4 = 2^2 with 2-dim per-site restrictions",
+    )
+
+    print()
+    print("N1 MECHANISM CLASSES (distinct attack routes, live evidence above):")
+    print("mechanism_class 1: central_idempotent_split_and_simplicity (E1 checks)")
+    print("mechanism_class 2: exhaustive_module_dimension_classification (E2 checks)")
+    print("mechanism_class 3: scalar_polynomial_system_contradiction (E3 checks)")
+    print("mechanism_class 4: faithfulness_kernel_computation (E4 checks)")
+    print("mechanism_class 5: lattice_tensor_restriction (EL checks)")
+
     # ------------------------------------------------------------------ N5
     section("N5 RESOLUTION SWEEP (per authenticated negative statement)")
     print(
         "Each negative statement below is swept over the five canonical "
-        "resolution classes. Executed classes restate the computed exclusion "
-        "at that scope; classes with no in-scope instance are checked and "
-        "reported as not executed. Lines are stable for byte-for-byte "
-        "citation."
+        "resolution classes; every class is executed against a computed "
+        "certificate above, including the lattice-wide tensor extension. "
+        "Lines are stable for byte-for-byte citation."
     )
     e3_executed = e3_certificate
     e2_executed = e2_certificate
@@ -795,11 +886,12 @@ def main() -> int:
                     "2-dimensional simple module; no block admits a 1-dimensional "
                     "faithful action"
                 ), e2_executed),
-                ("lattice_wide", False, (
-                    "checked and not executed: the claim is a single-site algebra "
-                    "statement; no lattice-wide instance exists in this note's "
-                    "scope"
-                ), True),
+                ("lattice_wide", True, (
+                    "executed on the 2-site and 3-site lattice tensor algebras: "
+                    "the joint per-site scalar Clifford systems have no solution, "
+                    "so no lattice-wide one-dimensional character restricts to a "
+                    "faithful one-dimensional site representation"
+                ), el1_certificate),
             ],
         ),
         (
@@ -823,11 +915,12 @@ def main() -> int:
                     "of the same 2-dimensional simple module; no other dimension "
                     "occurs"
                 ), e2_executed),
-                ("lattice_wide", False, (
-                    "checked and not executed: the claim is a single-site algebra "
-                    "statement; no lattice-wide instance exists in this note's "
-                    "scope"
-                ), True),
+                ("lattice_wide", True, (
+                    "executed on the 2-site lattice tensor algebra: every "
+                    "irreducible module has dimension 4 = 2^2 by scalar-commutant "
+                    "and exact dimension-count exhaustion, and each per-site "
+                    "restriction has dimension exactly 2"
+                ), el2_certificate),
             ],
         ),
     ]


### PR DESCRIPTION
This SCIENCE-FIX supplies the two executed certificate families requested by the CL3 exclusion stress review:

- `EL.scalar` formulates a scalar representation of a nonempty finite-region tensor algebra as commuting scalar images whose restriction to every site factor obeys the per-site Clifford relations. The executed two- and three-site systems have no solutions; the contradiction is already local to one site.
- `EL.module` constructs all four two-site Kronecker modules, solves each joint commutant (nullity one), verifies that each site restriction is two copies of the two-dimensional site irrep, distinguishes the four blocks by their two central-character signs, and checks the Artin-Wedderburn exhaustion `4 x 16 = 64`. It also executes the real faithfulness boundary: the one-site restrictions are faithful, whereas every simple tensor-power module for `N >= 2` is nonfaithful; the four `N=2` real maps have rank 32 and kernel dimension 32.
- The theorem statement is limited to nonempty finite regions. It makes no claim about an infinite quasi-local completion or a physical lattice Hilbert-space realization.
- Five live N1 route records name genuinely distinct mechanism classes and point to their executed E1, E2, E3, E4, and EL certificate families. No sweep line names an unexecuted resolution.

Fresh deterministic result: `TOTAL: PASS=62 FAIL=0`; two runs are byte-identical and match the checked-in cache; runtime is under 2 seconds per run. The companion checks, `py_compile`, `vocab_lint`, portable-link check, and diff check pass.

Exact prior audit repair targets addressed by this PR:

> `runner_artifact_issue: add an executed lattice_wide resolution certificate for both explicit exclusions, or split those exclusions from this row and add a dated boundary update before re-audit.`

> `other: add live current-cycle evidence for at least five genuinely distinct N1 mechanism classes and resolution-specific checks for every authenticated N5 phrase group, then re-audit.`

This PR supplies development/review evidence only; any later forensic audit must independently authenticate its own N7 evidence surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
