### PR TITLE
audit-infra: bind casefold evidence paths

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -225,6 +225,10 @@ supplied content (whitespace normalization is allowed). A locator must contain
 at least 12 normalized characters. The manifest is an allow-list, not evidence
 by itself:
 
+Copy every `evidence_path` byte-for-byte from this manifest. Evidence paths and
+claim-id URI segments are case-sensitive; do not capitalize or otherwise
+rewrite any path component.
+
 ```json
 {{NO_GO_EVIDENCE_MANIFEST}}
 ```

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -7834,6 +7834,14 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             template_flat,
         )
         self.assertIn(
+            "Copy every `evidence_path` byte-for-byte from this manifest",
+            template_flat,
+        )
+        self.assertIn(
+            "claim-id URI segments are case-sensitive",
+            template_flat,
+        )
+        self.assertIn(
             "`boundary` and `primitive` require separate objects",
             template_flat,
         )
@@ -9791,6 +9799,74 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         self.assertEqual(
             statement["tested_resolutions"], before_judgment["tested_resolutions"]
         )
+
+    def test_authenticated_casefold_evidence_paths_bind_unique_manifest_path(self):
+        m = _import_codex_audit_runner()
+        partial = "audit-packet://partial-closure-index/test_non_supply_no_go"
+        cross = "audit-packet://cross-cycle-index/test_non_supply_no_go"
+        manifest = {
+            partial: {"roles": ["partial_closure_index"], "text": "partial"},
+            cross: {"roles": ["cross_cycle_index"], "text": "cross"},
+        }
+        candidate = {
+            "candidate_id": "candidate:1",
+            "affected_wall": "W_power",
+            "disposition": "W_power remains under test.",
+            "evidence_path": partial.replace(
+                "non_supply_no_go", "non_SUPPLY_NO_GO"
+            ),
+            "evidence_locator": "candidate:1",
+        }
+        echo = {
+            "candidate_id": "echo:1",
+            "disposition": "The echo is addressed for the current scope.",
+            "evidence_path": cross.replace(
+                "non_supply_no_go", "non_SUPPLY_NO_GO"
+            ),
+            "evidence_locator": "echo:1",
+        }
+        packet = {
+            "N6_partial_closure_scan": {"candidates": [candidate]},
+            "N8_cross_cycle_echo": {"echoes": [echo]},
+            "N7_steelman": {
+                "resolution_evidence_path": "DOCS/ACCEPTED.md",
+            },
+        }
+        blob = {"verdict": "audited_clean", "no_go_discipline": packet}
+        before = json.loads(json.dumps(packet))
+        changes = m.bind_authenticated_casefold_evidence_paths(blob, manifest)
+        self.assertEqual(len(changes), 2)
+        self.assertEqual(candidate["evidence_path"], partial)
+        self.assertEqual(echo["evidence_path"], cross)
+        self.assertEqual(
+            packet["N7_steelman"]["resolution_evidence_path"],
+            before["N7_steelman"]["resolution_evidence_path"],
+        )
+        self.assertEqual(candidate["candidate_id"], "candidate:1")
+        self.assertEqual(candidate["disposition"], "W_power remains under test.")
+        self.assertEqual(blob["verdict"], "audited_clean")
+
+    def test_authenticated_casefold_evidence_paths_refuse_ambiguity_and_unrelated_path(self):
+        m = _import_codex_audit_runner()
+        candidate = {"evidence_path": "DOCS/SOURCE.MD"}
+        blob = {
+            "no_go_discipline": {
+                "N6_partial_closure_scan": {"candidates": [candidate]}
+            }
+        }
+        ambiguous = {
+            "docs/Source.md": {"text": "first"},
+            "docs/source.md": {"text": "second"},
+        }
+        self.assertEqual(
+            m.bind_authenticated_casefold_evidence_paths(blob, ambiguous), []
+        )
+        self.assertEqual(candidate["evidence_path"], "DOCS/SOURCE.MD")
+        unrelated = {"docs/OTHER.md": {"text": "other"}}
+        self.assertEqual(
+            m.bind_authenticated_casefold_evidence_paths(blob, unrelated), []
+        )
+        self.assertEqual(candidate["evidence_path"], "DOCS/SOURCE.MD")
 
     def test_authenticated_occurrence_metadata_refuses_cross_label_and_ambiguity(self):
         m = _import_codex_audit_runner()

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1541,6 +1541,59 @@ AUTHENTICATED_OCCURRENCE_FIELDS = (
 )
 
 
+def bind_authenticated_casefold_evidence_paths(
+    blob: dict,
+    evidence_manifest: dict[str, dict] | None,
+) -> list[dict[str, object]]:
+    """Canonicalize N1-N8 evidence-path casing drift after a unique match.
+
+    Evidence paths are orchestrator-owned packet metadata. The auditor owns all
+    cited content and scientific judgment. Restrict traversal to
+    ``no_go_discipline`` and replace an out-of-manifest ``evidence_path`` when
+    its casefold matches exactly one authenticated manifest path. Exact,
+    unrelated, ambiguous, and non-string paths remain untouched and fail
+    closed in the validator.
+    """
+    if evidence_manifest is None:
+        return []
+    packet = blob.get("no_go_discipline")
+    if not isinstance(packet, dict):
+        return []
+    paths_by_casefold: dict[str, list[str]] = {}
+    for path in evidence_manifest:
+        if isinstance(path, str) and path:
+            paths_by_casefold.setdefault(path.casefold(), []).append(path)
+    changes: list[dict[str, object]] = []
+
+    def visit(value: object, location: str) -> None:
+        if isinstance(value, dict):
+            current = value.get("evidence_path")
+            if (
+                isinstance(current, str)
+                and current
+                and current not in evidence_manifest
+            ):
+                matches = paths_by_casefold.get(current.casefold(), [])
+                if len(matches) == 1:
+                    canonical = matches[0]
+                    changes.append({
+                        "location": location,
+                        "field": "evidence_path",
+                        "from": current,
+                        "to": canonical,
+                    })
+                    value["evidence_path"] = canonical
+            for key, item in value.items():
+                if key != "evidence_path":
+                    visit(item, f"{location}.{key}")
+        elif isinstance(value, list):
+            for index, item in enumerate(value, 1):
+                visit(item, f"{location}[{index}]")
+
+    visit(packet, "no_go_discipline")
+    return changes
+
+
 def bind_authenticated_occurrence_metadata(
     blob: dict,
     evidence_manifest: dict[str, dict] | None,
@@ -2564,6 +2617,16 @@ def main() -> int:
                     }) + "\n")
                 continue
 
+            casefold_path_bindings = bind_authenticated_casefold_evidence_paths(
+                blob, exact_evidence_manifest
+            )
+            if casefold_path_bindings:
+                with run_log.open("a", encoding="utf-8") as f:
+                    f.write(json.dumps({
+                        "claim_id": cid,
+                        "phase": "authenticated_casefold_evidence_paths_bound",
+                        "bindings": casefold_path_bindings,
+                    }) + "\n")
             occurrence_bindings = bind_authenticated_occurrence_metadata(
                 blob, exact_evidence_manifest
             )
@@ -2665,6 +2728,22 @@ def main() -> int:
                                 "reply": (repair_reply or "")[:2000],
                             }) + "\n")
                         continue
+                    repair_casefold_path_bindings = (
+                        bind_authenticated_casefold_evidence_paths(
+                            repair_blob, exact_evidence_manifest
+                        )
+                    )
+                    if repair_casefold_path_bindings:
+                        with run_log.open("a", encoding="utf-8") as f:
+                            f.write(json.dumps({
+                                "claim_id": cid,
+                                "phase": (
+                                    "validation_repair_authenticated_casefold_"
+                                    "evidence_paths_bound"
+                                ),
+                                "attempt": repair_attempt,
+                                "bindings": repair_casefold_path_bindings,
+                            }) + "\n")
                     repair_bindings = bind_authenticated_occurrence_metadata(
                         repair_blob, exact_evidence_manifest
                     )
@@ -2778,6 +2857,22 @@ def main() -> int:
                     if schema_blob is None:
                         err = "fresh schema retry reply not valid JSON"
                         continue
+                    schema_casefold_path_bindings = (
+                        bind_authenticated_casefold_evidence_paths(
+                            schema_blob, exact_evidence_manifest
+                        )
+                    )
+                    if schema_casefold_path_bindings:
+                        with run_log.open("a", encoding="utf-8") as f:
+                            f.write(json.dumps({
+                                "claim_id": cid,
+                                "phase": (
+                                    "fresh_schema_retry_authenticated_casefold_"
+                                    "evidence_paths_bound"
+                                ),
+                                "attempt": schema_attempt,
+                                "bindings": schema_casefold_path_bindings,
+                            }) + "\n")
                     schema_bindings = bind_authenticated_occurrence_metadata(
                         schema_blob, exact_evidence_manifest
                     )


### PR DESCRIPTION
## Summary
- require auditors to copy restricted-packet evidence paths byte-for-byte
- canonicalize casing drift when an out-of-manifest no-go evidence_path has exactly one authenticated casefold match
- fail closed for ambiguity or unrelated paths and preserve all judgment fields

## Verification
- independent review-loop GPT-5.6-sol/xhigh: PASS
- python compile: PASS
- focused tests: 3/3
- full audit-pipeline tests: 345/345
- audit pipeline and strict lint: PASS
- actual failed AC(i) blob replay: one locator binding; verdict/scientific fields unchanged

This is audit infrastructure only. It applies no audit verdict and changes no science, premise, claim, status, import, comparator, or framing surface.