### PR TITLE
audit-infra: bind N8 universe metadata

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -286,6 +286,9 @@ support `audited_clean`. A gate `PASS` requires at least five genuinely distinct
 N1 mechanism classes, every route closed, complete structured N2-N8 records,
 no unresolved items, a resolved steelman, a complete cross-cycle scan, and no
 failure items. Do not turn five phrasings of one route into five routes. A
+route's `attempt` must name the route-specific calculation or restricted-packet
+test. Normalized `attempt` strings must be pairwise distinct; do not reuse one
+attempt sentence across routes. A
 `RULED OUT BY PRIOR` route must cite either a retained-grade one-hop authority
 or the registered text of an axiom/approved primitive. Conventions, open
 obligations, historical records, and unretained ordinary dependencies cannot
@@ -396,7 +399,7 @@ supply it. Otherwise replace it with:
       "route_id": "<stable short id unique inside this packet>",
       "route_class": "<one of algebraic_rearrangement, symmetry_or_representation, alternate_carrier_or_sector, boundary_or_initial_condition, normalization_or_units, dynamical_or_effective_action, lattice_scale_or_limit, numerical_or_finite_case, convention_or_relabeling, alternate_observable_or_readout, topology_or_global_structure, dependency_or_registry_reclassification>",
       "mechanism": "<physical or mathematical mechanism, distinct from every other route>",
-      "attempt": "<what calculation or restricted-packet test was actually performed>",
+      "attempt": "<route-specific calculation or restricted-packet test actually performed; pairwise distinct from every other attempt>",
       "outcome": "<why the attempt closes the route or why it remains open>",
       "honesty_marker": "<ATTEMPTED | RULED OUT BY PRIOR>",
       "disposition": "<CLOSED | OPEN | UNTESTED>",

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -7834,6 +7834,14 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             template_flat,
         )
         self.assertIn(
+            "Normalized `attempt` strings must be pairwise distinct",
+            template_flat,
+        )
+        self.assertIn(
+            "route-specific calculation or restricted-packet test actually performed",
+            template_flat,
+        )
+        self.assertIn(
             "Copy every `evidence_path` byte-for-byte from this manifest",
             template_flat,
         )
@@ -9867,6 +9875,71 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             m.bind_authenticated_casefold_evidence_paths(blob, unrelated), []
         )
         self.assertEqual(candidate["evidence_path"], "DOCS/SOURCE.MD")
+
+    def test_authenticated_n8_universe_metadata_binds_count_and_digest(self):
+        m = _import_codex_audit_runner()
+        path = "audit-packet://cross-cycle-index/test_no_go"
+        digest = "a" * 64
+        manifest = {
+            path: {
+                "roles": ["cross_cycle_index"],
+                "no_go_row_universe_count": 441,
+                "no_go_row_universe_sha256": digest,
+            }
+        }
+        section = {
+            "evidence_path": path,
+            "no_go_row_universe_count": 440,
+            "no_go_row_universe_sha256": "b" * 64,
+            "packet_complete": True,
+            "echoes": [{"candidate_id": "echo:1"}],
+        }
+        blob = {
+            "verdict": "audited_clean",
+            "no_go_discipline": {"N8_cross_cycle_echo": section},
+        }
+        before_echoes = json.loads(json.dumps(section["echoes"]))
+        changes = m.bind_authenticated_n8_universe_metadata(blob, manifest)
+        self.assertEqual(len(changes), 2)
+        self.assertEqual(section["no_go_row_universe_count"], 441)
+        self.assertEqual(section["no_go_row_universe_sha256"], digest)
+        self.assertEqual(section["echoes"], before_echoes)
+        self.assertTrue(section["packet_complete"])
+        self.assertEqual(blob["verdict"], "audited_clean")
+
+    def test_authenticated_n8_universe_metadata_refuses_wrong_role_or_malformed_data(self):
+        m = _import_codex_audit_runner()
+        path = "audit-packet://cross-cycle-index/test_no_go"
+        section = {
+            "evidence_path": path,
+            "no_go_row_universe_count": 7,
+            "no_go_row_universe_sha256": "c" * 64,
+        }
+        blob = {
+            "no_go_discipline": {"N8_cross_cycle_echo": section},
+        }
+        wrong_role = {
+            path: {
+                "roles": ["source"],
+                "no_go_row_universe_count": 8,
+                "no_go_row_universe_sha256": "d" * 64,
+            }
+        }
+        self.assertEqual(
+            m.bind_authenticated_n8_universe_metadata(blob, wrong_role), []
+        )
+        malformed = {
+            path: {
+                "roles": ["cross_cycle_index"],
+                "no_go_row_universe_count": "8",
+                "no_go_row_universe_sha256": "not-a-digest",
+            }
+        }
+        self.assertEqual(
+            m.bind_authenticated_n8_universe_metadata(blob, malformed), []
+        )
+        self.assertEqual(section["no_go_row_universe_count"], 7)
+        self.assertEqual(section["no_go_row_universe_sha256"], "c" * 64)
 
     def test_authenticated_occurrence_metadata_refuses_cross_label_and_ambiguity(self):
         m = _import_codex_audit_runner()

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1594,6 +1594,50 @@ def bind_authenticated_casefold_evidence_paths(
     return changes
 
 
+def bind_authenticated_n8_universe_metadata(
+    blob: dict,
+    evidence_manifest: dict[str, dict] | None,
+) -> list[dict[str, object]]:
+    """Bind orchestrator-owned N8 no-go-universe count and digest."""
+    if evidence_manifest is None:
+        return []
+    packet = blob.get("no_go_discipline")
+    if not isinstance(packet, dict):
+        return []
+    section = packet.get("N8_cross_cycle_echo")
+    if not isinstance(section, dict):
+        return []
+    path = section.get("evidence_path")
+    if not isinstance(path, str) or not path:
+        return []
+    entry = evidence_manifest.get(path)
+    if (
+        not isinstance(entry, dict)
+        or "cross_cycle_index" not in set(entry.get("roles") or [])
+    ):
+        return []
+    universe = no_go_discipline_gate._cross_cycle_no_go_universe(entry)
+    if universe is None:
+        return []
+    count, digest = universe
+    changes: list[dict[str, object]] = []
+    for field, authenticated in (
+        ("no_go_row_universe_count", count),
+        ("no_go_row_universe_sha256", digest),
+    ):
+        current = section.get(field)
+        if current == authenticated:
+            continue
+        changes.append({
+            "location": "no_go_discipline.N8_cross_cycle_echo",
+            "field": field,
+            "from": current,
+            "to": authenticated,
+        })
+        section[field] = authenticated
+    return changes
+
+
 def bind_authenticated_occurrence_metadata(
     blob: dict,
     evidence_manifest: dict[str, dict] | None,
@@ -2627,6 +2671,16 @@ def main() -> int:
                         "phase": "authenticated_casefold_evidence_paths_bound",
                         "bindings": casefold_path_bindings,
                     }) + "\n")
+            n8_universe_bindings = bind_authenticated_n8_universe_metadata(
+                blob, exact_evidence_manifest
+            )
+            if n8_universe_bindings:
+                with run_log.open("a", encoding="utf-8") as f:
+                    f.write(json.dumps({
+                        "claim_id": cid,
+                        "phase": "authenticated_n8_universe_metadata_bound",
+                        "bindings": n8_universe_bindings,
+                    }) + "\n")
             occurrence_bindings = bind_authenticated_occurrence_metadata(
                 blob, exact_evidence_manifest
             )
@@ -2743,6 +2797,22 @@ def main() -> int:
                                 ),
                                 "attempt": repair_attempt,
                                 "bindings": repair_casefold_path_bindings,
+                            }) + "\n")
+                    repair_n8_universe_bindings = (
+                        bind_authenticated_n8_universe_metadata(
+                            repair_blob, exact_evidence_manifest
+                        )
+                    )
+                    if repair_n8_universe_bindings:
+                        with run_log.open("a", encoding="utf-8") as f:
+                            f.write(json.dumps({
+                                "claim_id": cid,
+                                "phase": (
+                                    "validation_repair_authenticated_n8_"
+                                    "universe_metadata_bound"
+                                ),
+                                "attempt": repair_attempt,
+                                "bindings": repair_n8_universe_bindings,
                             }) + "\n")
                     repair_bindings = bind_authenticated_occurrence_metadata(
                         repair_blob, exact_evidence_manifest
@@ -2872,6 +2942,22 @@ def main() -> int:
                                 ),
                                 "attempt": schema_attempt,
                                 "bindings": schema_casefold_path_bindings,
+                            }) + "\n")
+                    schema_n8_universe_bindings = (
+                        bind_authenticated_n8_universe_metadata(
+                            schema_blob, exact_evidence_manifest
+                        )
+                    )
+                    if schema_n8_universe_bindings:
+                        with run_log.open("a", encoding="utf-8") as f:
+                            f.write(json.dumps({
+                                "claim_id": cid,
+                                "phase": (
+                                    "fresh_schema_retry_authenticated_n8_"
+                                    "universe_metadata_bound"
+                                ),
+                                "attempt": schema_attempt,
+                                "bindings": schema_n8_universe_bindings,
                             }) + "\n")
                     schema_bindings = bind_authenticated_occurrence_metadata(
                         schema_blob, exact_evidence_manifest


### PR DESCRIPTION
## Summary
- bind N8 no-go universe count and digest from the authenticated cross-cycle index
- fail closed for malformed or wrong-role manifest entries
- require route-specific, pairwise-distinct N1 attempt text

## Verification
- independent review-loop content review: PASS
- full audit-pipeline suite: 347/347
- production manifest casefold-to-N8 probe: PASS
- pipeline, strict lint, vocabulary, compile, and diff checks: PASS
- history-prune replay has identical stable patch ID acec677e269054bf05407a19a7454d327f46aea6

No science, premise, claim, status, verdict, import, comparator, or framing surface changes. The prescribed Sol/xhigh confirmation call was attempted but rejected before review by the account usage limit; do not merge until that confirmation is available.