### PR TITLE
audit-infra: authenticate independent helper stdout

### DIFF
--- a/docs/audit/scripts/no_go_discipline_gate.py
+++ b/docs/audit/scripts/no_go_discipline_gate.py
@@ -933,6 +933,30 @@ def _canonical_runner_path(repo_root: Path, raw: str | None) -> str:
     return str(raw)
 
 
+def _repo_local_helper_runner_path(
+    repo_root: Path,
+    raw: str | None,
+) -> str | None:
+    helper = _canonical_runner_path(repo_root, raw)
+    relative = Path(helper)
+    if (
+        relative.is_absolute()
+        or not relative.parts
+        or relative.parts[0] != "scripts"
+        or ".." in relative.parts
+    ):
+        return None
+    try:
+        root = repo_root.resolve()
+        resolved = (root / relative).resolve()
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    if not resolved.is_file():
+        return None
+    return helper
+
+
 def premise_type_for_id(repo_root: Path, claim_id: str) -> str | None:
     axioms = _load_json(repo_root, AXIOM_REGISTRY)
     if claim_id in set(axioms.get("canonical_ids") or []):
@@ -1209,6 +1233,18 @@ def partial_closure_index_path(claim_id: str) -> str:
 
 def runner_stdout_evidence_path(claim_id: str) -> str:
     return f"audit-packet://runner-stdout/{claim_id}"
+
+
+def independent_runner_stdout_evidence_path(
+    claim_id: str,
+    runner_path: str,
+) -> str:
+    canonical_path = str(runner_path).replace("\\", "/")
+    path_digest = hashlib.sha256(canonical_path.encode("utf-8")).hexdigest()[:16]
+    return (
+        f"audit-packet://runner-stdout-independent/{claim_id}/"
+        f"{Path(canonical_path).stem}-{path_digest}"
+    )
 
 
 def blind_reaudit_control_path(claim_id: str) -> str:
@@ -1809,7 +1845,9 @@ def build_evidence_manifest(
         text=_read_text(root, runner_path),
     )
     for helper_raw in row.get("helper_runner_paths") or []:
-        helper = _canonical_runner_path(root, helper_raw)
+        helper = _repo_local_helper_runner_path(root, helper_raw)
+        if helper is None:
+            continue
         _add_evidence(
             manifest,
             path=helper,
@@ -2787,7 +2825,7 @@ def forensic_mode() -> bool:
     }
 
 
-def source_requires_no_go_discipline(
+def source_is_no_go_artifact(
     note_path: str | None,
     note_body: str | None,
     claim_type_hint: str | None,
@@ -2806,6 +2844,17 @@ def source_requires_no_go_discipline(
         # Filename-level no-go authority is always forensic.  A source may
         # explain that an older reading was withdrawn, but that prose cannot
         # silently downgrade the assurance tier of the no-go-named artifact.
+        return True
+    return False
+
+
+def source_requires_no_go_discipline(
+    note_path: str | None,
+    note_body: str | None,
+    claim_type_hint: str | None,
+) -> bool:
+    body = note_body or ""
+    if source_is_no_go_artifact(note_path, body, claim_type_hint):
         return True
     # Wall-naming positive/bounded rows carry the mandatory heavy packet only
     # in the forensic tier; in the development tier the auditor still applies

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -8171,6 +8171,382 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 )
             )
 
+    def test_n7_marker_helper_runs_live_as_independent_stdout(self):
+        m = _import_codex_audit_runner()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            m.REPO_ROOT = root
+            note_path = root / "docs" / "target.md"
+            runner_path = root / "scripts" / "runner.py"
+            helper_path = root / "scripts" / "helper.py"
+            note_path.parent.mkdir(parents=True, exist_ok=True)
+            runner_path.parent.mkdir(parents=True, exist_ok=True)
+            note_path.write_text(_no_go_evidence_text(), encoding="utf-8")
+            runner_path.write_text("print('primary')\n", encoding="utf-8")
+            helper_path.write_text(
+                "print('N7_STEELMAN_RESOLUTION selector wall resolved')\n",
+                encoding="utf-8",
+            )
+            row = {
+                "claim_id": "target",
+                "note_path": "docs/target.md",
+                "runner_path": "scripts/runner.py",
+                "helper_runner_paths": ["scripts/helper.py"],
+                "claim_type": "no_go",
+                "deps": [],
+            }
+            manifest: dict[str, dict] = {}
+            template = (
+                "{{RUNNER_STDOUT}}\n{{HELPER_RUNNER_SOURCES}}\n"
+                "{{FRAMEWORK_PREMISE_CONTEXT}}\n"
+                "{{NO_GO_PARTIAL_CLOSURE_INDEX}}\n"
+                "{{NO_GO_CROSS_CYCLE_INDEX}}\n"
+                "{{NO_GO_EVIDENCE_MANIFEST}}"
+            )
+            with mock.patch.object(
+                m,
+                "get_runner_stdout",
+                return_value=_no_go_evidence_text(),
+            ):
+                prompt = m.render_prompt(
+                    row,
+                    {"target": row},
+                    template,
+                    1,
+                    use_cache=False,
+                    evidence_manifest_out=manifest,
+                )
+            independent_path = (
+                m.no_go_discipline_gate.independent_runner_stdout_evidence_path(
+                    "target", "scripts/helper.py"
+                )
+            )
+            self.assertEqual(
+                manifest[independent_path]["roles"],
+                ["runner_stdout_independent"],
+            )
+            self.assertIn("selector wall resolved", manifest[independent_path]["text"])
+            self.assertIn(independent_path, prompt)
+
+    def test_no_runner_mode_cannot_authenticate_independent_helper_stdout(self):
+        m = _import_codex_audit_runner()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            m.REPO_ROOT = root
+            note_path = root / "docs" / "target.md"
+            runner_path = root / "scripts" / "runner.py"
+            helper_path = root / "scripts" / "helper.py"
+            note_path.parent.mkdir(parents=True, exist_ok=True)
+            runner_path.parent.mkdir(parents=True, exist_ok=True)
+            note_path.write_text(_no_go_evidence_text(), encoding="utf-8")
+            runner_path.write_text("print('primary')\n", encoding="utf-8")
+            helper_path.write_text(
+                "print('N7_STEELMAN_RESOLUTION selector wall resolved')\n",
+                encoding="utf-8",
+            )
+            row = {
+                "claim_id": "target",
+                "note_path": "docs/target.md",
+                "runner_path": "scripts/runner.py",
+                "helper_runner_paths": ["scripts/helper.py"],
+                "claim_type": "no_go",
+                "deps": [],
+            }
+            manifest: dict[str, dict] = {}
+            with (
+                mock.patch.object(m, "get_runner_stdout") as live_stdout,
+                mock.patch.object(
+                    m, "get_independent_runner_stdout"
+                ) as independent_stdout,
+            ):
+                m.render_prompt(
+                    row,
+                    {"target": row},
+                    "{{HELPER_RUNNER_SOURCES}}\n{{FRAMEWORK_PREMISE_CONTEXT}}\n"
+                    "{{NO_GO_PARTIAL_CLOSURE_INDEX}}\n"
+                    "{{NO_GO_CROSS_CYCLE_INDEX}}\n"
+                    "{{NO_GO_EVIDENCE_MANIFEST}}",
+                    0,
+                    skip_runner_stdout=True,
+                    evidence_manifest_out=manifest,
+                )
+            independent_path = (
+                m.no_go_discipline_gate.independent_runner_stdout_evidence_path(
+                    "target", "scripts/helper.py"
+                )
+            )
+            self.assertEqual(
+                manifest[independent_path]["roles"],
+                ["runner_stdout_independent_suppressed"],
+            )
+            live_stdout.assert_not_called()
+            independent_stdout.assert_not_called()
+
+    def test_failing_n7_helper_stdout_is_not_authenticated(self):
+        m = _import_codex_audit_runner()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            m.REPO_ROOT = root
+            note_path = root / "docs" / "target.md"
+            runner_path = root / "scripts" / "runner.py"
+            helper_path = root / "scripts" / "helper.py"
+            note_path.parent.mkdir(parents=True, exist_ok=True)
+            runner_path.parent.mkdir(parents=True, exist_ok=True)
+            note_path.write_text(_no_go_evidence_text(), encoding="utf-8")
+            runner_path.write_text("print('primary')\n", encoding="utf-8")
+            resolution = (
+                "N7_STEELMAN_RESOLUTION selector wall remains unresolved because "
+                "a failing helper cannot authenticate evidence despite printing "
+                "this deliberately long resolution line."
+            )
+            helper_path.write_text(
+                f"print({resolution!r})\n"
+                "raise SystemExit(7)\n",
+                encoding="utf-8",
+            )
+            row = {
+                "claim_id": "target",
+                "note_path": "docs/target.md",
+                "runner_path": "scripts/runner.py",
+                "helper_runner_paths": ["scripts/helper.py"],
+                "claim_type": "no_go",
+                "deps": [],
+            }
+            manifest: dict[str, dict] = {}
+            with mock.patch.object(
+                m,
+                "get_runner_stdout",
+                return_value=_no_go_evidence_text(),
+            ):
+                m.render_prompt(
+                    row,
+                    {"target": row},
+                    "{{HELPER_RUNNER_SOURCES}}\n{{FRAMEWORK_PREMISE_CONTEXT}}\n"
+                    "{{NO_GO_PARTIAL_CLOSURE_INDEX}}\n"
+                    "{{NO_GO_CROSS_CYCLE_INDEX}}\n"
+                    "{{NO_GO_EVIDENCE_MANIFEST}}",
+                    2,
+                    use_cache=False,
+                    evidence_manifest_out=manifest,
+                )
+            independent_path = (
+                m.no_go_discipline_gate.independent_runner_stdout_evidence_path(
+                    "target", "scripts/helper.py"
+                )
+            )
+            self.assertEqual(
+                manifest[independent_path]["roles"],
+                ["runner_stdout_independent_failed"],
+            )
+            self.assertIn("runner exit=7", manifest[independent_path]["text"])
+            packet = _no_go_packet(
+                evidence_path="audit-packet://runner-stdout/target",
+                evidence_locator="No-go obstruction",
+                source_path="docs/target.md",
+                claim_id="target",
+            )
+            packet["N7_steelman"].update({
+                "resolution": resolution,
+                "resolution_evidence_path": independent_path,
+                "resolution_evidence_locator": resolution,
+            })
+            self.assertIn(
+                "must cite authenticated independent execution",
+                m.no_go_discipline_gate._validate_n7(
+                    packet, "PASS", manifest
+                ) or "",
+            )
+
+    def test_independent_helper_stdout_paths_resist_basename_collision(self):
+        m = _import_codex_audit_runner()
+        first = m.no_go_discipline_gate.independent_runner_stdout_evidence_path(
+            "target", "scripts/a/helper.py"
+        )
+        second = m.no_go_discipline_gate.independent_runner_stdout_evidence_path(
+            "target", "scripts/b/helper.py"
+        )
+        self.assertNotEqual(first, second)
+        self.assertIn("/helper-", first)
+        self.assertIn("/helper-", second)
+
+    def test_forensic_positive_row_does_not_run_n7_helper_certificate(self):
+        m = _import_codex_audit_runner()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            m.REPO_ROOT = root
+            note_path = root / "docs" / "positive.md"
+            runner_path = root / "scripts" / "runner.py"
+            helper_path = root / "scripts" / "helper.py"
+            note_path.parent.mkdir(parents=True, exist_ok=True)
+            runner_path.parent.mkdir(parents=True, exist_ok=True)
+            note_path.write_text(
+                "Claim type: positive_theorem\nThe selector wall remains unresolved.\n",
+                encoding="utf-8",
+            )
+            runner_path.write_text("print('primary')\n", encoding="utf-8")
+            helper_path.write_text(
+                "print('N7_STEELMAN_RESOLUTION selector wall resolved')\n",
+                encoding="utf-8",
+            )
+            row = {
+                "claim_id": "positive",
+                "note_path": "docs/positive.md",
+                "runner_path": "scripts/runner.py",
+                "helper_runner_paths": ["scripts/helper.py"],
+                "claim_type": "positive_theorem",
+                "deps": [],
+            }
+            manifest: dict[str, dict] = {}
+            with (
+                mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}),
+                mock.patch.object(
+                    m,
+                    "get_runner_stdout",
+                    return_value=_no_go_evidence_text("PRIMARY_STDOUT"),
+                ),
+                mock.patch.object(
+                    m, "get_independent_runner_stdout"
+                ) as independent_stdout,
+            ):
+                m.render_prompt(
+                    row,
+                    {"positive": row},
+                    "{{HELPER_RUNNER_SOURCES}}\n{{FRAMEWORK_PREMISE_CONTEXT}}\n"
+                    "{{NO_GO_PARTIAL_CLOSURE_INDEX}}\n"
+                    "{{NO_GO_CROSS_CYCLE_INDEX}}\n"
+                    "{{NO_GO_EVIDENCE_MANIFEST}}",
+                    1,
+                    use_cache=False,
+                    evidence_manifest_out=manifest,
+                )
+            independent_stdout.assert_not_called()
+            self.assertFalse(any(
+                "runner-stdout-independent" in path for path in manifest
+            ))
+
+    def test_nonmarker_helper_does_not_run_as_independent_certificate(self):
+        m = _import_codex_audit_runner()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            m.REPO_ROOT = root
+            note_path = root / "docs" / "target.md"
+            runner_path = root / "scripts" / "runner.py"
+            helper_path = root / "scripts" / "helper.py"
+            note_path.parent.mkdir(parents=True, exist_ok=True)
+            runner_path.parent.mkdir(parents=True, exist_ok=True)
+            note_path.write_text(_no_go_evidence_text(), encoding="utf-8")
+            runner_path.write_text("print('primary')\n", encoding="utf-8")
+            helper_path.write_text("print('ordinary helper')\n", encoding="utf-8")
+            row = {
+                "claim_id": "target",
+                "note_path": "docs/target.md",
+                "runner_path": "scripts/runner.py",
+                "helper_runner_paths": ["scripts/helper.py"],
+                "claim_type": "no_go",
+                "deps": [],
+            }
+            with (
+                mock.patch.object(
+                    m,
+                    "get_runner_stdout",
+                    return_value=_no_go_evidence_text("PRIMARY_STDOUT"),
+                ),
+                mock.patch.object(
+                    m, "get_independent_runner_stdout"
+                ) as independent_stdout,
+            ):
+                m.render_prompt(
+                    row,
+                    {"target": row},
+                    "{{HELPER_RUNNER_SOURCES}}\n{{FRAMEWORK_PREMISE_CONTEXT}}\n"
+                    "{{NO_GO_PARTIAL_CLOSURE_INDEX}}\n"
+                    "{{NO_GO_CROSS_CYCLE_INDEX}}\n"
+                    "{{NO_GO_EVIDENCE_MANIFEST}}",
+                    1,
+                    use_cache=False,
+                )
+            independent_stdout.assert_not_called()
+
+    def test_absolute_external_helper_is_rejected_without_path_disclosure(self):
+        m = _import_codex_audit_runner()
+        with tempfile.TemporaryDirectory() as tmp:
+            sandbox = Path(tmp)
+            root = sandbox / "repo"
+            outside = sandbox / "outside.py"
+            m.REPO_ROOT = root
+            note_path = root / "docs" / "target.md"
+            runner_path = root / "scripts" / "runner.py"
+            note_path.parent.mkdir(parents=True, exist_ok=True)
+            runner_path.parent.mkdir(parents=True, exist_ok=True)
+            note_path.write_text(_no_go_evidence_text(), encoding="utf-8")
+            runner_path.write_text("print('primary')\n", encoding="utf-8")
+            outside.write_text(
+                "print('N7_STEELMAN_RESOLUTION selector wall resolved')\n",
+                encoding="utf-8",
+            )
+            row = {
+                "claim_id": "target",
+                "note_path": "docs/target.md",
+                "runner_path": "scripts/runner.py",
+                "helper_runner_paths": [str(outside)],
+                "claim_type": "no_go",
+                "deps": [],
+            }
+            manifest: dict[str, dict] = {}
+            with (
+                mock.patch.object(
+                    m,
+                    "get_runner_stdout",
+                    return_value=_no_go_evidence_text("PRIMARY_STDOUT"),
+                ),
+                mock.patch.object(
+                    m, "get_independent_runner_stdout"
+                ) as independent_stdout,
+            ):
+                prompt = m.render_prompt(
+                    row,
+                    {"target": row},
+                    "{{HELPER_RUNNER_SOURCES}}\n{{FRAMEWORK_PREMISE_CONTEXT}}\n"
+                    "{{NO_GO_PARTIAL_CLOSURE_INDEX}}\n"
+                    "{{NO_GO_CROSS_CYCLE_INDEX}}\n"
+                    "{{NO_GO_EVIDENCE_MANIFEST}}",
+                    1,
+                    use_cache=False,
+                    evidence_manifest_out=manifest,
+                )
+            independent_stdout.assert_not_called()
+            self.assertNotIn(str(outside), prompt)
+            rejected = [
+                entry for entry in manifest.values()
+                if "helper_rejected" in set(entry.get("roles") or [])
+            ]
+            self.assertEqual(len(rejected), 1)
+            self.assertIn("not a repo-local scripts file", rejected[0]["text"])
+
+    def test_symlink_helper_escape_is_rejected(self):
+        m = _import_codex_audit_runner()
+        with tempfile.TemporaryDirectory() as tmp:
+            sandbox = Path(tmp)
+            root = sandbox / "repo"
+            outside = sandbox / "outside.py"
+            scripts = root / "scripts"
+            scripts.mkdir(parents=True, exist_ok=True)
+            outside.write_text(
+                "print('N7_STEELMAN_RESOLUTION selector wall resolved')\n",
+                encoding="utf-8",
+            )
+            link = scripts / "helper.py"
+            link.symlink_to(outside)
+            m.REPO_ROOT = root
+            self.assertIsNone(
+                m.repo_local_helper_runner_path("scripts/helper.py")
+            )
+            stdout, authenticated = m.get_independent_runner_stdout(
+                "scripts/helper.py", 1
+            )
+            self.assertFalse(authenticated)
+            self.assertIn("path rejected", stdout)
+
     def test_source_scan_groups_authenticate_full_bytes_before_display_clipping(self):
         m = _import_codex_audit_runner()
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -120,6 +120,7 @@ CLIPPED_EVIDENCE_MARKERS = (
     "[runner stdout clipped; ",
     "[runner cache excerpt clipped; ",
 )
+INDEPENDENT_N7_RESOLUTION_MARKER = "N7_STEELMAN_RESOLUTION"
 
 # Codex rejects turn input above 1,048,576 characters. Keep a safety margin
 # for transport framing. Only the rendered N8 candidate list may be bounded;
@@ -816,6 +817,67 @@ def get_runner_stdout(runner_path: str | None, default_timeout_sec: int,
         return f"[runner error: {e}]"
 
 
+def repo_local_helper_runner_path(runner_path: str) -> tuple[str, Path] | None:
+    """Resolve a helper to a regular ``scripts/`` file contained by the repo."""
+    canonical = canonical_runner_path(runner_path)
+    relative = Path(canonical)
+    if (
+        relative.is_absolute()
+        or not relative.parts
+        or relative.parts[0] != "scripts"
+        or ".." in relative.parts
+    ):
+        return None
+    try:
+        root = REPO_ROOT.resolve()
+        resolved = (root / relative).resolve()
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    if not resolved.is_file():
+        return None
+    return canonical, resolved
+
+
+def get_independent_runner_stdout(
+    runner_path: str,
+    default_timeout_sec: int,
+) -> tuple[str, bool]:
+    """Execute an N7 helper live and authenticate stdout after exit zero."""
+    local_runner = repo_local_helper_runner_path(runner_path)
+    if local_runner is None:
+        return "[runner path rejected: not a repo-local scripts file]", False
+    runner_path, path = local_runner
+    timeout_sec = runner_timeout_for(runner_path, default_timeout_sec)
+    try:
+        result = subprocess.run(
+            [sys.executable, str(path)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=timeout_sec,
+            env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "scripts")},
+        )
+        if result.returncode != 0:
+            return (
+                f"[runner exit={result.returncode}]\n"
+                f"{result.stdout[-3000:]}\n--- stderr ---\n"
+                f"{result.stderr[-1500:]}",
+                False,
+            )
+        if len(result.stdout) > 6000:
+            return (
+                f"[runner stdout clipped; {len(result.stdout)} chars total]\n"
+                f"{result.stdout[-6000:]}",
+                True,
+            )
+        return result.stdout, True
+    except subprocess.TimeoutExpired:
+        return f"[runner timed out at {timeout_sec}s — likely needs compute-rerun]", False
+    except Exception as error:
+        return f"[runner error: {error}]", False
+
+
 def render_prompt(row: dict, ledger_rows: dict[str, dict],
                   template: str, runner_timeout_sec: int,
                   use_cache: bool = False,
@@ -846,6 +908,11 @@ def render_prompt(row: dict, ledger_rows: dict[str, dict],
 
     full_note_body = read_note_body(note_path) or f"[note missing on disk: {note_path}]"
     no_go_required = no_go_discipline_gate.source_requires_no_go_discipline(
+        note_path,
+        full_note_body,
+        "" if row.get("dispatch_target") else ledger_claim_type,
+    )
+    no_go_artifact = no_go_discipline_gate.source_is_no_go_artifact(
         note_path,
         full_note_body,
         "" if row.get("dispatch_target") else ledger_claim_type,
@@ -1012,21 +1079,33 @@ def render_prompt(row: dict, ledger_rows: dict[str, dict],
     helper_sources_blocks: list[str] = []
     for hp_raw in helper_runner_paths:
         hp = canonical_runner_path(hp_raw)
-        full_hp = REPO_ROOT / hp
-        if not full_hp.exists():
+        local_helper = repo_local_helper_runner_path(hp)
+        if local_helper is None:
+            rejected_path = (
+                "audit-packet://rejected-helper/"
+                f"{cid}/"
+                f"{hashlib.sha256(str(hp).encode('utf-8')).hexdigest()[:16]}"
+            )
             helper_block = (
-                f"=== BEGIN HELPER RUNNER: {hp} ===\n"
-                f"[helper missing on disk: {hp}]\n"
-                f"=== END HELPER RUNNER: {hp} ==="
+                f"=== BEGIN REJECTED HELPER: {rejected_path} ===\n"
+                "[helper rejected: path is not a repo-local scripts file]\n"
+                f"=== END REJECTED HELPER: {rejected_path} ==="
             )
             helper_sources_blocks.append(helper_block)
             no_go_discipline_gate.set_packet_evidence(
-                evidence_manifest, path=hp, role="helper", text=helper_block,
+                evidence_manifest,
+                path=rejected_path,
+                role="helper_rejected",
+                text=helper_block,
                 invocation_bound_rendered_text=True,
             )
             continue
+        hp, full_hp = local_helper
         try:
             hsrc = full_hp.read_text(encoding="utf-8", errors="replace")
+            helper_declares_independent_resolution = (
+                INDEPENDENT_N7_RESOLUTION_MARKER in hsrc
+            )
             if len(hsrc) > HELPER_SOURCE_CHAR_LIMIT:
                 head = hsrc[: HELPER_SOURCE_CHAR_LIMIT // 2]
                 tail = hsrc[-HELPER_SOURCE_CHAR_LIMIT // 2 :]
@@ -1035,9 +1114,45 @@ def render_prompt(row: dict, ledger_rows: dict[str, dict],
                     f"... [truncated; helper is {len(hsrc)} chars total] ...\n\n"
                     f"{tail}"
                 )
+            independent_stdout_block = ""
+            if no_go_artifact and helper_declares_independent_resolution:
+                independent_stdout_path = (
+                    no_go_discipline_gate.independent_runner_stdout_evidence_path(
+                        cid, hp
+                    )
+                )
+                if skip_runner_stdout:
+                    independent_stdout = (
+                        "(independent helper stdout suppressed by --no-runner)"
+                    )
+                    independent_stdout_role = (
+                        "runner_stdout_independent_suppressed"
+                    )
+                else:
+                    independent_stdout, independent_stdout_authenticated = (
+                        get_independent_runner_stdout(hp, runner_timeout_sec)
+                    )
+                    independent_stdout_role = (
+                        "runner_stdout_independent"
+                        if independent_stdout_authenticated
+                        else "runner_stdout_independent_failed"
+                    )
+                no_go_discipline_gate.set_packet_evidence(
+                    evidence_manifest,
+                    path=independent_stdout_path,
+                    role=independent_stdout_role,
+                    text=independent_stdout or "(no stdout captured)",
+                )
+                independent_stdout_block = (
+                    "\n=== BEGIN INDEPENDENT HELPER STDOUT: "
+                    f"{independent_stdout_path} ===\n"
+                    f"{independent_stdout or '(no stdout captured)'}\n"
+                    "=== END INDEPENDENT HELPER STDOUT: "
+                    f"{independent_stdout_path} ==="
+                )
             hcache = (
                 "(helper cache is not audit authority; current helper source "
-                "is inspected and the primary runner is executed live)"
+                "is inspected and marked N7 helpers are executed live)"
             )
             helper_block = (
                 f"=== BEGIN HELPER RUNNER: {hp} ===\n"
@@ -1045,6 +1160,7 @@ def render_prompt(row: dict, ledger_rows: dict[str, dict],
                 f"=== BEGIN HELPER RUNNER CACHE: {hp} ===\n"
                 f"{hcache}\n"
                 f"=== END HELPER RUNNER CACHE: {hp} ===\n"
+                f"{independent_stdout_block}\n"
                 f"=== END HELPER RUNNER: {hp} ==="
             )
             helper_sources_blocks.append(helper_block)


### PR DESCRIPTION
## Summary
- execute explicitly marked N7 helper certificates live for source no-go artifacts
- authenticate independent stdout after a successful exit, with non-authenticating failure/suppressed roles
- bind virtual evidence paths to canonical helper-path digests
- reject absolute external helpers and symlink escapes without path disclosure

## Verification
- independent review-loop content/security review: PASS
- focused adversarial tests: 8/8
- full audit-pipeline suite: 353/353
- pipeline, strict lint, vocabulary, compile, and diff checks: PASS
- history-prune replay has identical stable patch ID 6f94720f756e9d4abb80f0369b59f32036146f26

No science, premise, status, verdict, import, comparator, or auditor-judgment fields change. The prescribed Sol/xhigh confirmation call was attempted but rejected before review by the account usage limit; do not merge until that confirmation is available.