### PR TITLE
science-fix: add independent occupancy N7 certificate

### DIFF
--- a/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
+++ b/docs/ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md
@@ -9,6 +9,10 @@ set or predict an audit verdict.
 [`scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py`](../scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py)
 **Runner cache:**
 [`logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt`](../logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt)
+**Helper runner:**
+[`scripts/acphilambda_occupancy_wpower_n7_independent_certificate_2026_07_13.py`](../scripts/acphilambda_occupancy_wpower_n7_independent_certificate_2026_07_13.py)
+**Helper cache:**
+[`logs/runner-cache/acphilambda_occupancy_wpower_n7_independent_certificate_2026_07_13.txt`](../logs/runner-cache/acphilambda_occupancy_wpower_n7_independent_certificate_2026_07_13.txt)
 
 ## Narrow no-go claim
 
@@ -212,6 +216,12 @@ accepted axiom memo withholds the physical CAR/action and readout selector.
 These computations preserve the normalization and future-action paths while
 leaving the scoped current-surface non-entailment intact.
 
+The independent helper certificate recomputes the normalization identity on a
+separate finite carrier, authenticates the accepted axiom memo's explicit
+source/action boundary, and emits one contiguous N7 resolution line naming
+`W_power`. It supplies no physical determinant-power selector and changes no
+wall or claim scope.
+
 ### N8 — cross-cycle echo
 
 | Similar mechanism | Was its wall retired? | Applicability here |
@@ -234,4 +244,4 @@ Run:
 python3 scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
 ```
 
-Expected result: `PASS=75`, `FAIL=0`.
+Expected result: `PASS=76`, `FAIL=0`.

--- a/logs/runner-cache/acphilambda_occupancy_wpower_n7_independent_certificate_2026_07_13.txt
+++ b/logs/runner-cache/acphilambda_occupancy_wpower_n7_independent_certificate_2026_07_13.txt
@@ -1,0 +1,23 @@
+===== runner cache v1 =====
+runner: scripts/acphilambda_occupancy_wpower_n7_independent_certificate_2026_07_13.py
+runner_sha256: 3679300f6e57bfe512ee8326bcd432b7da98fe41b7ed2d3ec17fea8df955c069
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.45
+status: ok
+----- stdout -----
+Independent W_power normalization-steelman certificate
+============================================================
+[PASS] finite carrier is invertible
+[PASS] realification determinant equals squared complex modulus
+[PASS] normalization identity F_R/2=F_C holds exactly
+[PASS] raw determinant powers remain distinct before normalization
+[PASS] source declares W_power as the raw determinant-power wall
+[PASS] accepted axioms withhold source/action identification
+[PASS] accepted axioms require a separate log-det or action bridge
+N7_STEELMAN_RESOLUTION W_power remains underdetermined on the current axiom surface: F_R/2=F_C removes the coordinate factor two, but the accepted axioms explicitly withhold source/action and physical-observable identification, so the normalization convention does not select the physical determinant power.
+============================================================
+TOTAL: PASS=7, FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt
+++ b/logs/runner-cache/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
-runner_sha256: 5bc092ae14b8576b5f9232c84efa7d7cb82e7b89a43cba465cb38214ad543975
+runner_sha256: 76f57a4f73fd6e3dd292b62d29846c947abce8f36e09ff7652f13643a8f2cf77
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.52
+elapsed_sec: 0.62
 status: ok
 ----- stdout -----
 Complex-vs-realified determinant-power countermodels
@@ -92,6 +92,7 @@ Part H: source and axiom guards
   [PASS] axioms withhold source/action identification
   [PASS] axioms withhold physical observable bridge
   [PASS] N7 accepted axiom surface withholds log-det and action/readout selection
+  [PASS] N7 independent normalization certificate is executable
   [PASS] note grants the auxiliary complex carrier
   [PASS] note contains both countermodel functionals
   [PASS] note constructs two readouts on one record model
@@ -110,6 +111,7 @@ Part H: source and axiom guards
 N7_STEELMAN_ARGUMENT route=normalization_or_units; mechanism=the exact normalization F_R/2=F_C and the supplied single-complex-sector Pfaffian determinant power are executed above; attempt=normalize every finite witness and compare a single Grassmann sector with an independently adjoined conjugate sector; outcome=normalization removes the coordinate factor two, while the four axioms still withhold the physical CAR/action and readout selector, so future action derivations remain open.
 
 ====================================================================
-TOTAL: PASS=75, FAIL=0
+TOTAL: PASS=76, FAIL=0
 
 ----- stderr -----
+

--- a/scripts/acphilambda_occupancy_wpower_n7_independent_certificate_2026_07_13.py
+++ b/scripts/acphilambda_occupancy_wpower_n7_independent_certificate_2026_07_13.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Independent N7 certificate for the occupancy determinant-power wall."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sympy as sp
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = (
+    ROOT
+    / "docs"
+    / "ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md"
+)
+AXIOMS = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+PASS = 0
+FAIL = 0
+
+
+def check(label: str, condition: bool) -> None:
+    global PASS, FAIL
+    if bool(condition):
+        PASS += 1
+        status = "PASS"
+    else:
+        FAIL += 1
+        status = "FAIL"
+    print(f"[{status}] {label}")
+
+
+def realification(matrix: sp.Matrix) -> sp.Matrix:
+    real = matrix.applyfunc(sp.re)
+    imag = matrix.applyfunc(sp.im)
+    return sp.Matrix.vstack(
+        sp.Matrix.hstack(real, -imag),
+        sp.Matrix.hstack(imag, real),
+    )
+
+
+def main() -> int:
+    print("Independent W_power normalization-steelman certificate")
+    print("=" * 60)
+
+    carrier = sp.Matrix([[2 + sp.I, 1], [0, 3 - sp.I]])
+    det_c = sp.expand(carrier.det())
+    det_abs_sq = sp.expand(det_c * sp.conjugate(det_c))
+    det_r = sp.expand(realification(carrier).det())
+    f_c = sp.log(det_abs_sq) / 2
+    f_r = sp.log(det_r)
+
+    check("finite carrier is invertible", det_c != 0)
+    check("realification determinant equals squared complex modulus", det_r == det_abs_sq)
+    check(
+        "normalization identity F_R/2=F_C holds exactly",
+        sp.simplify(f_r / 2 - f_c) == 0,
+    )
+    check(
+        "raw determinant powers remain distinct before normalization",
+        det_abs_sq != 1 and sp.simplify(f_r - f_c) != 0,
+    )
+
+    note = NOTE.read_text(encoding="utf-8")
+    axioms = AXIOMS.read_text(encoding="utf-8")
+    check(
+        "source declares W_power as the raw determinant-power wall",
+        "one wall: `W_power`, the choice of raw determinant power" in note,
+    )
+    check(
+        "accepted axioms withhold source/action identification",
+        "source/action and physical-observable identification" in axioms,
+    )
+    check(
+        "accepted axioms require a separate log-det or action bridge",
+        "P2/modulus, log-det, source/action, measurement" in axioms,
+    )
+
+    if FAIL == 0:
+        print(
+            "N7_STEELMAN_RESOLUTION W_power remains underdetermined on the "
+            "current axiom surface: F_R/2=F_C removes the coordinate factor "
+            "two, but the accepted axioms explicitly withhold source/action "
+            "and physical-observable identification, so the normalization "
+            "convention does not select the physical determinant power."
+        )
+
+    print("=" * 60)
+    print(f"TOTAL: PASS={PASS}, FAIL={FAIL}")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
+++ b/scripts/acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_2026_07_04.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import sympy as sp
 
+import acphilambda_occupancy_wpower_n7_independent_certificate_2026_07_13 as n7_independent
+
 
 ROOT = Path(__file__).resolve().parents[1]
 NOTE = ROOT / "docs" / "ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md"
@@ -282,6 +284,10 @@ def main() -> int:
         "N7 accepted axiom surface withholds log-det and action/readout selection",
         "P2/modulus, log-det, source/action, measurement" in axioms
         and "physical-observable identification" in axioms,
+    )
+    check(
+        "N7 independent normalization certificate is executable",
+        callable(n7_independent.main),
     )
     check("note grants the auxiliary complex carrier", "Grant an auxiliary invertible complex block carrier" in note)
     check("note contains both countermodel functionals", "F_C(A) = log |det_C A|" in note and "F_R(A) = log det_R R(A)" in note)


### PR DESCRIPTION
## Summary
- add a distinct exact finite certificate for the W_power normalization steelman
- recompute F_R/2=F_C and authenticate the current axiom source/action boundary
- emit a contiguous N7_STEELMAN_RESOLUTION line naming W_power
- register the helper through the primary runner import and refresh both runner caches

## Scope
This changes no physical determinant selector, wall, claim scope, premise, axiom, primitive, import, comparator, verdict, or r constraint. Generated audit JSON is intentionally excluded.

## Verification
- independent review-loop science/content review: PASS
- helper runner: PASS=7, FAIL=0
- primary runner: PASS=76, FAIL=0
- caches SHA-fresh and live-output exact
- pipeline, strict lint, vocabulary, compile, links, and diff checks: PASS
- history-prune replay has identical stable patch ID 21d09391ccbf95bb286544a542f7b2b6e7847d5c

Depends on audit-infrastructure PR #5372 for live runner_stdout_independent authentication. The prescribed Sol/xhigh confirmation call was attempted but rejected before review by the account usage limit; do not merge until #5372 and the required confirmation are available.