### PR TITLE
physics: prove completed-joint two-mark nonlinear tube

### DIFF
--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/HANDOFF.md
@@ -1235,10 +1235,70 @@ exactly four dependencies; strict lint has zero errors and generated outputs
 are stripped.
 
 Delivery: stacked PR
-https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5370 is
-open and mergeable on Block45 with the audit workflow queued. The next target
-is the exact two-mark covariance/Hessian envelope on the completed graph. The
-candidate pair bound is `68exp(.1)/(1-tau)^2=75.15428126562128`, which would
-close a one-horizon nonlinear tube for approximately
-`delta in [.0004651520,.0020673073]`. This must remain a source/output
-Banach-bundle tube until a separate same-domain invariant-ball theorem closes.
+https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5374
+replaces #5370, which passed audit and was then automatically closed when its
+parent branch was force-pushed. The replacement is open and mergeable on
+Block45. A PR-only audit preflight initially failed because the rewritten
+source-only stack omitted the generated ledger; the durable reporting-only
+missing-ledger guard is tested in the replacement branch, while `--apply`
+remains strict.
+
+## Block 47: completed-joint two-mark covariance and nonlinear bundle tube
+
+The exact finite-regulator response identity is now differentiated twice on
+the actual completed Block46 graph. With the reference, center, and chart
+frozen,
+
+```text
+DR_Phi[F]=E_Phi[F],
+D^2R_Phi[F,G]=-Cov_Phi(F,G).
+```
+
+Fiber-constant raw/raw and raw/centered Hessian blocks vanish exactly. The
+source class makes every remaining raw diameter-zero direction an owned
+Hermitian onsite quadratic center; non-onsite raw terms receive the geometric
+gain and centered terms remain in the marked residual arm. For the only
+nonzero centered/centered block, a labeled meeting-anchor/cut injection into
+two complete rooted-side histories gives the conservative ordered envelope
+
+```text
+P_2(tau)<=(1-tau)^(-4).
+```
+
+There is no external mixed-derivative factor two. On the whole restricted
+radius-`delta=0.001` source ball,
+
+```text
+K_delta=0.001000980989834872<c,
+tau_delta=0.04092002696953689,
+M_delta=88.82169800480513,
+B+q delta+(M_delta/2)delta^2=0.0009853829050985733<delta.
+```
+
+The center and residual output are then deliberately overcharged together
+with an additional base row. The complete charge is
+`0.002021517543158784`, leaving
+`gap/m>=0.9997737559156604` and
+`theta_atom=0.4265740169167342>0.400001`. This is a strong-source to
+weak-residual source/output Banach-bundle tube. It is not a same-domain
+endomorphism, second-horizon reuse theorem, or all-horizon invariant ball.
+
+Physics/import and governance/no-go reviews pass with bounded claims after the
+two-root, source-projector, raw-factor, center-ledger, and wall-independence
+repairs. Code/math was completed locally after the delegated lane hit its
+usage cap; the independent 80-digit Decimal recomputation and finite
+covariance/mixed-difference fixtures agree. The SHA-pinned runner/cache is
+`PASS=11 FAIL=0`; all four dependency runners pass. Vocabulary lint is clean,
+the compatibility pipeline seeds one `bounded_theorem` / `unaudited` row with
+exactly four dependencies and a non-decoration runner, strict lint has zero
+errors, and generated audit/status files are stripped.
+
+Delivery: stacked PR
+https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5375 is
+open and mergeable on the Block46 replacement. The audit workflow is rerunning
+after the parent preflight repair and Block47 rebase. The next target is an
+explicit target-to-next-source return section: combine the weak Block47 atom
+output with Block40--44 lineage/coarse-shadow/re-Hoeffding machinery, including
+moving center and reference ownership, and test it on a second actual horizon.
+Only a horizon-uniform version may be promoted to an all-horizon induction.
+No axiom-update stop is triggered.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/PR_BACKLOG.md
@@ -503,7 +503,8 @@ No merge is authorized. Independent audit remains authoritative.
 The completed scalar-product-reference joint outer-Haar atom return is
 prepared as the next stacked review PR:
 
-- PR: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5370
+- PR: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5374
+- supersedes: #5370 passed audit, then was auto-closed by a parent force push
 - base: `physics-loop/record-faithful-dynamics-block45-correlated-snext-reference-quadratic-weyl-20260712`
 - head: `physics-loop/record-faithful-dynamics-block46-scalar-product-joint-outer-haar-atom-return-20260713`
 - source runner: `PASS=12 FAIL=0`, SHA-pinned cache fresh
@@ -520,7 +521,35 @@ prepared as the next stacked review PR:
   no-go-discipline, and cache-format repairs; the compatibility pipeline seeds
   one `bounded_theorem` / `unaudited` row with exactly four dependencies and
   strict lint has zero errors
-- delivery check: open, mergeable, independent audit workflow queued
+- delivery check: open, mergeable; audit workflow rerunning after a tested
+  PR-dry-run missing-generated-ledger preflight repair
+
+No merge is authorized. Independent audit remains authoritative.
+
+The completed-joint two-mark covariance and nonlinear source/output tube is
+prepared as the next stacked review PR:
+
+- PR: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5375
+- base: `physics-loop/record-faithful-dynamics-block46-scalar-product-joint-outer-haar-atom-return-20260713`
+- head: `physics-loop/record-faithful-dynamics-block47-two-mark-covariance-nonlinear-tube-20260713`
+- source runner: `PASS=11 FAIL=0`, SHA-pinned cache fresh
+- scope: exact finite-regulator Hessian/covariance split, conservative
+  `(1-tau)^(-4)` centered two-root envelope, and one restricted radius-0.001
+  strong-source to weak-residual nonlinear tube with a separate center/gap/
+  eta/atom ledger; no same-domain invariant ball, second-horizon reuse,
+  generic ambient embedding, or continuum theorem
+- result: `M_delta=88.82169800480513`, tube output
+  `0.0009853829050985733<0.001`, complete center/output charge
+  `0.002021517543158784`, and
+  `theta_atom=0.4265740169167342>0.400001`
+- disposition: physics/import, governance/no-go, and local code/math reviews
+  pass with bounded claims after two-root, source-projector, raw-factor,
+  center-ledger, and W1/W2 scope repairs; all four dependencies pass, the
+  compatibility pipeline seeds one `bounded_theorem` / `unaudited` row with
+  exactly four dependencies and a non-decoration runner, and strict lint has
+  zero errors
+- delivery check: open, mergeable; audit workflow rerunning after the parent
+  preflight repair and Block47 rebase
 
 No merge is authorized. Independent audit remains authoritative.
 

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/REVIEW_HISTORY.md
@@ -1394,4 +1394,42 @@ ownership, both tail arms, one physical projection, and one fresh atom return.
 The SHA-pinned runner/cache is `PASS=12 FAIL=0`; all four dependencies pass,
 vocabulary lint is clean, the audit pipeline seeds exactly four dependencies,
 strict lint has zero errors, and generated audit/status files are stripped.
-PR #5370 is open and mergeable on Block45. No axiom-update stop is triggered.
+PR #5370 passed audit and was then automatically closed by its parent's force
+push. Replacement PR #5374 is open and mergeable on Block45. Its source-only
+stack exposed a PR-preflight defect: the dependency-edge reporter read the
+generated ledger before the pipeline recreated it. The replacement adds a
+tested dry-run-only missing-ledger guard while preserving strict `--apply`
+behavior. No axiom-update stop is triggered.
+
+## Completed-joint two-mark nonlinear tube review
+
+PASS WITH BOUNDED CLAIMS after physics/import, governance/no-go, and local
+code/math review. The first draft was blocked on an insufficiently justified
+`(1-tau)^(-2)` pair envelope, a mismatch between `P_0`, `P_quad`, and the
+residual map, silent raw onsite-nonquadratic inputs, fiber-constant activity
+ownership, and an undercharged center/gap ledger.
+
+The repaired source restricts raw diameter-zero inputs to the Hermitian onsite
+quadratic center, proves exact cancellation of raw fiber constants in the
+normalized response, and bounds the centered/centered Hessian by a conservative
+two-side product `(1-tau)^(-4)`. The labeled meeting anchor and cut make the
+injection reconstructive; ordering removes an external factor two. The center
+norm is explicitly the induced weak projected coefficient norm.
+
+Governance narrowed W1 to one declared same-domain transition, keeping it
+independent of W2's physical all-horizon graph/center/lineage transport, and
+corrected the N5 running-center residual. NG47 is only the logical
+non-implication from a one-horizon cross-norm tube to an invariant ball. Six
+ATTEMPTED routes, all fifteen wall pairs, phrase scan, residual matching,
+resolution audit, partial-closure scan, steelman, and cross-cycle echo pass.
+
+The runner/cache is `PASS=11 FAIL=0`. An independent 80-digit Decimal
+reconstruction confirms `M_delta=88.82169800480513`, tube output
+`0.0009853829050985733<0.001`, complete center/output charge
+`0.002021517543158784`, and
+`theta_atom=0.4265740169167342>0.400001`. All four dependency runners pass;
+vocabulary lint, pycompile, cache freshness, diff hygiene, full compatibility
+pipeline, and strict lint pass. Generated audit/status outputs are stripped.
+PR #5375 is open and mergeable on replacement parent #5374, with the audit
+workflow rerunning after the parent-preflight repair. No axiom-update stop is
+triggered.

--- a/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
+++ b/.claude/science/physics-loops/record-faithful-dynamics-completion-20260711/STATE.yaml
@@ -8,38 +8,39 @@ current_goal: >-
   supply the physical evolution object, bare time ordering, record-formation
   weights, and an admissibility-to-carrier selector without importing the
   staggered/Dirac answer or sector-specific Standard Model and gravity laws.
-branch: physics-loop/record-faithful-dynamics-block46-scalar-product-joint-outer-haar-atom-return-20260713
+branch: physics-loop/record-faithful-dynamics-block47-two-mark-covariance-nonlinear-tube-20260713
 base_commit_at_start: 9d1636f05f
-cycle_count: 46
-block_count: 46
-active_route: wilson_staggered_scalar_product_reference_completed_joint_outer_haar_actual_output_atom_return
+cycle_count: 47
+block_count: 47
+active_route: wilson_staggered_completed_joint_two_mark_covariance_nonlinear_source_output_tube
 hard_residual: >-
   Can the four-axiom record surface canonically determine a faithful local
   record-forming instrument whose coherent no-record block is sufficiently
   constrained to exclude the observationally disconnected SWAP--Laplacian
   completion and select the Clifford-vector carrier?
-produced_claim_id: wilson_staggered_scalar_product_reference_completed_joint_outer_haar_actual_output_atom_return_bounded_theorem_note_2026-07-13
+produced_claim_id: wilson_staggered_completed_joint_two_mark_covariance_nonlinear_source_output_tube_bounded_theorem_note_2026-07-13
 actual_current_surface_status: bounded-support
 conditional_surface_status: >-
-  One actual m=10^64 horizon now completes the scalar-product-reference
-  outer-Haar/Gaussian expansion before output projection. The full all-length
-  Q+R determinant pays the centered factor two, both Schur-tail arms are
-  visibly owned, K_T=4.808231265303741e-7<0.01, and the physical output pays
-  the Weyl/eta migration and fresh site-block atom cost with
-  K_out,total^fac=3.613529092410874e-5<0.01 and
-  theta_atom=0.427240686481831>0.400001. Literal unchanged reuse misses both
-  the next marked response and factor return. Generic two-mark Hessian/tube,
-  scale-indexed all-horizon return, taste, and continuum remain open.
+  On the actual completed m=10^64 graph, the exact normalized-response Hessian
+  is minus covariance; fiber-constant raw blocks vanish and a conservative
+  centered two-root envelope gives M_delta=88.82169800480513 uniformly on the
+  restricted radius-0.001 strong source ball. The nonlinear residual tube
+  closes at 0.0009853829050985733<0.001, while a separately overcharged center
+  ledger retains theta_atom=0.4265740169167342>0.400001. This is a one-horizon
+  strong-source to weak-residual Banach-bundle theorem, not a same-domain
+  invariant ball. Return embedding, moving-center/reference transport,
+  scale-indexed all-horizon control, generic sources, taste, and continuum
+  remain open.
 admitted_observation_status: none
 claim_type_reason: >-
-  The source proves the scalar-product normalization identity, full all-word
-  determinant ownership, hidden-empty/centered determinant split, one common
-  actual-hidden joint graph, conservative activity/response bounds, actual
-  output projection, persistent quadratic gap, and one fresh atom-factor
-  return. The authoritative N1--N8 packet restricts NG46 to literal fixed-m
-  reuse of the unchanged positive-surcharge/halving certificate. It keeps
-  shortest-center, scale-indexed, lineage, varying-m, alternate-block,
-  Hessian/ball, taste, and continuum routes live.
+  The source proves the exact Hessian split, raw-factor cancellation, a
+  conservative ordered two-root injection, a uniform activity/Hessian bound,
+  a positive nonlinear residual-tube margin, and a disjointly charged
+  center/gap/eta/atom ledger on the restricted source class. The authoritative
+  N1--N8 packet restricts NG47 to non-implication of same-domain or
+  second-horizon reuse. Scale-indexed bundles, lineage sections,
+  center/reference transport, generic-source embedding, taste, and continuum
+  routes remain live.
 hypothetical_axiom_status: null
 proposal_allowed: false
 proposal_allowed_reason: >-
@@ -187,6 +188,9 @@ files_touched:
   - docs/WILSON_STAGGERED_SCALAR_PRODUCT_REFERENCE_COMPLETED_JOINT_OUTER_HAAR_ACTUAL_OUTPUT_ATOM_RETURN_BOUNDED_THEOREM_NOTE_2026-07-13.md
   - scripts/wilson_staggered_scalar_product_reference_completed_joint_atom_return_2026_07_13.py
   - logs/runner-cache/wilson_staggered_scalar_product_reference_completed_joint_atom_return_2026_07_13.txt
+  - docs/WILSON_STAGGERED_COMPLETED_JOINT_TWO_MARK_COVARIANCE_NONLINEAR_SOURCE_OUTPUT_TUBE_BOUNDED_THEOREM_NOTE_2026-07-13.md
+  - scripts/wilson_staggered_completed_joint_two_mark_nonlinear_tube_2026_07_13.py
+  - logs/runner-cache/wilson_staggered_completed_joint_two_mark_nonlinear_tube_2026_07_13.txt
 open_imports:
   - fundamental process object: Hamiltonian, strict tick, or record instrument
   - faithful law-to-record influence principle
@@ -299,21 +303,24 @@ block42_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/
 block43_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5363
 block44_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5364
 block45_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5369
-block46_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5370
+block46_original_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5370
+block46_original_pr_status: audit_passed_then_auto_closed_on_parent_force_push
+block46_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5374
 block46_review_disposition: pass_with_bounded_claims
-block46_pr_status: open_mergeable_audit_workflow_queued
+block46_pr_status: open_mergeable_audit_workflow_rerun_after_preflight_repair
+block47_pr_url: https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/5375
+block47_review_disposition: pass_with_bounded_claims
+block47_pr_status: open_mergeable_audit_workflow_rerun_after_parent_rebase
 next_exact_action: >-
-  Build the exact two-mark covariance/Hessian theorem on the completed Block46
-  joint graph. Include the direct n=0 pair term and prove the two-root envelope
-  1+H(tau)=(1-tau)^(-2) without a spurious mixed-derivative factor two; track
-  raw/raw, raw/centered, and centered/centered blocks and reroot the unique
-  mark-to-mark path through the existing factor/polymer layers. Target
-  M_46<=68 exp(0.1)/(1-tau)^2=75.15428126562128 and the one-horizon nonlinear
-  tube B_out+q delta+(M_46/2)delta^2<=delta for
-  delta in [0.0004651520455,0.0020673073264], below the source radius
-  0.00994985479055. Keep this a source/output Banach-bundle tube, not an
-  autonomous same-domain ball; only then attack the scale-indexed invariant
-  ball/all-horizon campaign.
+  Build the first explicit target-to-next-source return theorem. Start from
+  the Block47 weak atom output and the Block40--44 lineage, coarse-shadow,
+  re-Hoeffding, and running-center machinery. Define one next-horizon source
+  chart and a transport section that owns the moving scalar/quadratic center,
+  reference determinant, and centered residual separately. Prove either a
+  finite return constant that closes the radius-0.001 tube on a second actual
+  horizon or an exact named failure with every scale-indexed/lineage route
+  still tested. Do not call this all-horizon until graph/center/atom lineage
+  estimates are uniform in the horizon index.
 stop_condition: >-
   Stop and discuss an axiom update only if an exact result proves that the
   required bridge cannot be derived and an additional approved axiom or

--- a/docs/WILSON_STAGGERED_COMPLETED_JOINT_TWO_MARK_COVARIANCE_NONLINEAR_SOURCE_OUTPUT_TUBE_BOUNDED_THEOREM_NOTE_2026-07-13.md
+++ b/docs/WILSON_STAGGERED_COMPLETED_JOINT_TWO_MARK_COVARIANCE_NONLINEAR_SOURCE_OUTPUT_TUBE_BOUNDED_THEOREM_NOTE_2026-07-13.md
@@ -1,0 +1,497 @@
+# Completed-joint two-mark covariance and nonlinear source/output tube
+
+**Date:** 2026-07-13
+**Type:** bounded_theorem
+**Status:** unaudited candidate; effective status is pipeline-derived only after independent audit.
+**Primary runner:** [`scripts/wilson_staggered_completed_joint_two_mark_nonlinear_tube_2026_07_13.py`](../scripts/wilson_staggered_completed_joint_two_mark_nonlinear_tube_2026_07_13.py)
+**Cached output:** [`logs/runner-cache/wilson_staggered_completed_joint_two_mark_nonlinear_tube_2026_07_13.txt`](../logs/runner-cache/wilson_staggered_completed_joint_two_mark_nonlinear_tube_2026_07_13.txt)
+
+## 0. Result and scope
+
+The completed one-horizon Block46 graph has a uniform two-mark covariance
+bound on a nonzero strong perturbation ball, and Taylor's theorem closes one
+nonlinear residual source/output Banach-bundle tube with a separately bounded
+running-center ledger.  At the same finite-regulator
+Wilson--staggered `SU(3)`, `beta=0`, `m=10^64` witness, every perturbation in
+the restricted raw-quadratic/centered source class (1.2a) with strong split
+norm at most
+
+```text
+delta=0.001                                                     (0.1)
+```
+
+fits in the joint expansion.  A conservative pair majorant gives
+
+```text
+M_delta=88.82169800480513,
+B+q delta+(M_delta/2)delta^2
+ =0.0009853829050985733<delta,                                  (0.2)
+```
+
+with margin `1.461709490142675 10^(-5)`.  The entire output tube preserves a
+quadratic gap, pays the worst three-pair `eta` migration and one fresh
+site-block atomization, and lands at
+
+```text
+theta_atom(delta)=0.426574016916734>0.400001,
+expm1(delta)=0.001000500166708342<0.01.                          (0.3)
+```
+
+This is a genuine nonlinear one-horizon theorem for the displayed source and
+residual-output Banach bundles.  It is not a same-domain invariant ball: the centered
+source uses the full `(Theta+2c,Lambda)=(4.4,0.2)` graph weights, while the
+fresh output lands in the weaker `(theta,lambda)=(0.400001,0.1)` atom chart.
+It supplies neither an all-horizon running-center recursion nor a critical
+continuum, taste, dynamics, time, unitarity, or probability theorem.
+
+The four direct repository inputs are the exact response/split identities
+from the
+[split-derivative boundary](WILSON_STAGGERED_SPLIT_DERIVATIVE_AND_UNLOCALIZED_CAUCHY_CERTIFICATE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-07-12.md),
+the strong split and one-mark rerooting architecture from the
+[K-retaining marked-attachment theorem](WILSON_STAGGERED_K_RETAINING_MARKED_ATTACHMENT_STRONG_WEAK_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md),
+the two-layer joint majorant `H` from the
+[joint product-reference theorem](WILSON_STAGGERED_JOINT_PRODUCT_REFERENCE_DETERMINANT_COUNTERTERM_OUTER_HAAR_COLORED_RESPONSE_BOUNDED_THEOREM_NOTE_2026-07-12.md),
+and the actual completed graph, output, gap, and atom-return ledger from the
+[scalar-product joint atom-return theorem](WILSON_STAGGERED_SCALAR_PRODUCT_REFERENCE_COMPLETED_JOINT_OUTER_HAAR_ACTUAL_OUTPUT_ATOM_RETURN_BOUNDED_THEOREM_NOTE_2026-07-13.md).
+
+All action, chart, regulator, mass, background, norm, and reference choices
+remain the explicit imports of Block46.  No value in (0.1)--(0.3) is claimed
+to follow from the four framework axioms alone.
+
+## 1. Map, reference split, and exact Hessian
+
+Fix the completed Block46 scalar-product joint graph, its color-zero normalized
+correlated reference `E_ref`, its scalar Gaussian center, and its chart.  They
+remain frozen while differentiating.  Let `L` lift retained coarse
+interactions as hidden-fiber constants.  Since `E_ref L=I`, define
+
+```text
+C_ref=L E_ref,                 Q_ref=1-C_ref.                     (1.1)
+```
+
+The strong source norm is the direct-sum norm
+
+```text
+||F||_strong
+ =||P_quad C_ref F||_center
+  +||(1-P_0)C_ref F||_(fine lift; theta_w=2.19,lambda_w=0.1)
+  +||Q_ref F||_(joint mark; Theta+2c=4.4,Lambda=0.2).             (1.2)
+```
+
+Throughout, `||.||_center` means the coefficient norm induced by the weak
+retained chart `(theta_w,lambda_w)=(2.19,0.1)` after the Hermitian onsite
+quadratic projection.  Thus the center arm, its radius-`delta` shift, and the
+`exp(-2.19)` coefficient-to-Weyl conversion in Section 4 use one declared
+normalization.
+
+Here `P_0` is the full diameter-zero projector of the declared RG chart and
+`P_quad=P_(0,2)^sa` is the Block46 Hermitian onsite quadratic projector after
+the scalar vacuum is removed.  The declared tube source class obeys
+
+```text
+(P_0-P_quad)C_ref F=0.                                            (1.2a)
+```
+
+Thus raw diameter-zero perturbations are restricted to the owned quadratic
+center.  Arbitrary onsite nonquadratic raw inputs are not silently assigned a
+contractive factor.  Centered inputs may still generate onsite higher or
+anti-Hermitian residual output, and those terms remain in the residual
+response bound.  The definition charges the actual centered component
+directly; it does not pretend that `1-C_ref` is contractive in an ambient
+unsplit norm.
+
+For the finite-regulator relative action map
+
+```text
+R(Phi)=-log E_ref exp(-Phi),                                      (1.3)
+```
+
+ordinary commutative Banach-algebra differentiation gives
+
+```text
+DR_Phi[F]=E_Phi[F],
+D^2R_Phi[F,G]=-Cov_Phi(F,G).                                     (1.4)
+```
+
+The contracted transformation in this theorem is the quadratic-center-
+complement residual map on the restricted class (1.2a):
+
+```text
+T_res=(1-P_quad)D_(2,1)R.                                        (1.4a)
+```
+
+For the raw arm, (1.2a) leaves only `P_quad C_refF`, which is removed into the
+center ledger, and `(1-P_0)C_refF`, which receives the exact diameter gain
+`exp(-0.1)`.  The centered arm receives the marked response bound and may land
+in any residual coordinate, including diameter zero.  Hence the inherited
+`q=max(q_raw,q_centered)` is valid for `T_res` on this restricted class.  The
+complementary Hermitian onsite quadratic is owned by a separate running-center
+ledger.
+
+There is no factor two in the mixed coefficient: differentiating first in
+`s` and then in `t` gives the coefficient of `st` once.  Along one diagonal
+direction Taylor's theorem supplies the separate factor `1/2` multiplying
+`D^2R[H,H]`.
+
+Fiber-constant lifts have zero covariance under every normalized hidden
+functional:
+
+```text
+Cov_Phi(Lf,Lg)=0,                 Cov_Phi(Lf,Q_ref G)=0.           (1.5)
+```
+
+Therefore the raw/raw and raw/centered Hessian blocks vanish exactly, at the
+actual base and throughout the perturbation ball.  Only the
+centered/centered block requires a cluster bound.  Product centering does not
+make that block vanish: already two zero-mean marks can have a nonzero direct
+pair `E_ref(F^oG^o)`.
+
+## 2. Exact two-root majorant
+
+Let the base graph have total rooted activity `K`, hard-core allowance `c`,
+and
+
+```text
+D(K)=sup_(n integer>=1)n exp[-(c-K)n],
+tau=K D(K)<1.                                                     (2.1)
+```
+
+The prior two-layer marked proof uses
+
+```text
+H(t)=t(2-t)/(1-t)^2=sum_(n>=1)(n+1)t^n.                          (2.2)
+```
+
+For a single reference-centered mark, the mark-alone term is zero and `H`
+bounds all base-attached outputs.  For two centered marks, the connected
+covariance has an additional `n=0` direct-pair term.  On either ordered marked
+side, distributing `n` path steps between the factor-to-polymer and hard-core
+layers has `n+1` nonnegative allocations.  Off-path subtrees are already paid
+by the same rooted row and the two `c` reserves used in `H`.  Therefore one
+complete, possibly uncentered, rooted side is bounded by
+
+```text
+P_side(tau)<=1+H(tau)
+            =sum_(n>=0)(n+1)tau^n
+            =(1-tau)^(-2).                                      (2.3)
+```
+
+For the ordered bilinear pair `(F,G)`, split the connected objects into a
+direct overlap, two marks in one first-layer polymer, and marks in distinct
+hard-core polymers.  Root the first side at `F` and the second at `G`.  In the
+same-polymer case, cut the unique factor-tree path at its first meeting edge;
+in the distinct-polymer case, also cut the unique hard-core path at its first
+meeting polymer.  Retain that labeled meeting anchor and cut as part of the
+image, and assign shared path material to the `F` side.  The two rooted
+histories plus this label reconstruct the original connected object, so this
+injects every connected object into an ordered pair of complete rooted-side
+histories with retained cut data.
+The projective coefficient norm and mark-support convolution are
+submultiplicative with constant one.  Hence the connected subset is bounded by
+the product of the two full side sums.  This deliberately includes
+disconnected pairs and counts shared middle paths more than once:
+
+```text
+P_2(tau)<=P_side(tau)^2<=(1-tau)^(-4).                           (2.4)
+```
+
+The mixed derivative receives no external factor two.  The output is one
+connected coarse carrier; the established hidden-to-coarse routing pays
+`68exp(Lambda/2)` once, not once per input mark.  For unit strong directions,
+
+```text
+||D^2T_Phi[F,G]||_weak
+ <=M(K)||F||_strong||G||_strong,
+
+M(K)=68exp(Lambda/2)/(1-KD(K))^4.                                (2.5)
+```
+
+Here `T_res` includes the contractive quadratic-center-complement projection.
+Hermitian quadratic projection and symmetrization belong to the separate
+center ledger.
+The constant-three product estimate for the full direct-sum algebra is not
+inserted into (2.5): the raw Hessian blocks vanish before multiplication, and
+the centered/centered bilinear mark convolution uses the declared projective
+mark norm with constant one.
+
+## 3. Uniformity on the radius-0.001 source ball
+
+Let `Phi_46` be the actual completed base.  Block46 gives
+
+```text
+K_T=4.808231265303741 10^(-7),
+c=0.01,
+B=3.613463806021123 10^(-5),
+q=0.9048374180359595.                                            (3.1)
+```
+
+If `||H||_strong<=delta`, write the fixed-reference split
+
+```text
+H=Lf+H^o,                    E_ref H^o=0.                          (3.1a)
+```
+
+Even commutativity gives `exp(-H)=exp(-Lf)exp(-H^o)`.  The fiber-constant
+factor `exp(-Lf)` cancels exactly between the numerator and denominator of
+every normalized hidden response, so it does not enter the joint activity
+row.  Carrierwise exponentiation of the centered arm gives
+`K(H^o)<=expm1(||H^o||)<=expm1(delta)`.  Uniformly along the segment from zero
+to `H`, use
+
+```text
+K_delta=K_T+expm1(delta)
+       =0.001000980989834872,
+
+c-K_delta=0.008999019010165128,
+D_delta=sup_(n integer>=1)n exp[-(c-K_delta)n]
+       =40.87992417946649             (attained at n=111),
+
+tau_delta=K_delta D_delta
+         =0.04092002696953689<1.                                  (3.2)
+```
+
+At `Lambda=0.2`, equations (2.5) and (3.2) give
+
+```text
+M_delta=68exp(0.1)/(1-tau_delta)^4
+       =88.82169800480513.                                       (3.3)
+```
+
+This is a uniform Hessian bound on the whole radius-`delta` strong ball, not
+the smaller base-only value `75.154...`.  The source analyticity margin is
+
+```text
+r_src=log(1+c-K_T)=0.009949854790553249>delta.                    (3.4)
+```
+
+Thus every base on the segment stays in the same zero-free joint logarithm
+branch and obeys (2.5).
+
+## 4. Nonlinear residual tube and separate center membership
+
+Taylor's theorem at the actual base, (3.1), and the uniform (3.3) give
+
+```text
+||T_res(Phi_46+H)||_weak
+ <=B+q||H||_strong+(M_delta/2)||H||_strong^2.
+```
+
+At the boundary `||H||_strong=delta=0.001`,
+
+```text
+B+q delta+(M_delta/2)delta^2
+ =0.0009853829050985733
+ <0.001=delta.                                                    (4.1)
+```
+
+Convexity of the scalar majorant gives the same bound throughout the ball.
+This proves the claimed residual source/output Banach-bundle tube.  Here `B`
+is a safe upper bound for the actual base residual output; it is not a
+same-space displacement from a fixed point.
+
+The residual weak output potential is at most `delta`.  The complementary raw
+onsite response can shift the running center by at most `delta`.  To avoid any
+overlap or disjoint-budget assumption, charge the complete center/output ledger
+by the raw radius, the full residual-tube envelope, and one additional base
+output row for the separately projected center,
+
+```text
+B_complete(delta)<=delta+0.0009853829050985733
+                         +0.00003613463806021123
+                 =0.002021517543158784.                           (4.2)
+```
+
+After the scalar vacuum is removed, project the Hermitian onsite quadratic
+once and leave the disjoint complement residual.  Coefficient-to-operator
+incidence one gives
+
+```text
+epsilon_Q(delta)
+ <=B_star+exp(-2.19)B_complete(delta)+10^(-20)
+ =0.0002262440843396182,
+
+gap_delta/m>=0.9997737559156604.                                  (4.3)
+```
+
+The worst three-pair Grassmann-weight migration and fresh site-block atom cost
+are
+
+```text
+sigma_eta(delta)=3log[1/gap_delta]
+                =0.0006788090441796472,
+
+theta_atom(delta)=2.19-log C_*-sigma_eta(delta)
+                 =0.4265740169167342>0.400001.                   (4.4)
+```
+
+Finally `expm1(delta)=0.001000500166708342<0.01`, so every output in the tube
+belongs to the displayed fresh target factor chart.  The target chart is
+weaker than the source chart; (4.1)--(4.4) do not authorize literal next-step
+reuse as the same source ball.
+
+## 5. Runner contract
+
+Run
+
+```bash
+python3 scripts/wilson_staggered_completed_joint_two_mark_nonlinear_tube_2026_07_13.py
+```
+
+The runner independently checks: exact vanishing of fiber-constant Hessian
+blocks in a nontrivially tilted finite model; a nonzero centered/centered
+covariance; the mixed derivative sign and absence of an extra factor two; the
+two-layer `n+1` one-side series and the conservative
+`[1+H]^2=(1-tau)^(-4)` pair envelope; all uniform
+ball, Hessian, Taylor, gap, `eta`, atom, and factor rows; an independent
+80-digit Decimal reconstruction of the activity, optimizer, Hessian, and tube;
+the source contract;
+and exactly four dependencies.  The general rooted-side injection and
+Banach-algebra cluster estimates are analytic content of Sections 1--4.
+
+## 6. No-Go Discipline N1--N8
+
+This theorem contains a named same-domain/all-horizon boundary, so the full
+stress test is recorded even though no new physical impossibility is claimed.
+
+**NG47:** this finite one-horizon cross-norm two-mark residual tube does not by
+itself furnish an invariant RG ball, because it supplies neither a same-space
+endomorphism nor certified reuse on a second horizon.  `NG47` is only a
+logical non-implication from the displayed theorem, not a physical RG no-go.
+
+### N1 — alternative-route enumeration
+
+| route | status | outcome |
+|---|---|---|
+| Identify the target atom chart directly with the next source chart | `ATTEMPTED` | Fails: `(0.400001,0.1)` is not `(4.4,0.2)`. |
+| Infer invariance from the scalar inequality (4.1) | `ATTEMPTED` | Rejected: the domain and codomain norms/charts differ. |
+| Invoke Banach's theorem from `q<1` | `ATTEMPTED` | Rejected: `q` is a strong-to-weak residual operator bound, not an endomorphism norm. |
+| Iterate `M_delta,q` unchanged | `ATTEMPTED` | Rejected: Block46's literal next ledger fails and no second-horizon source membership is proved. |
+| Reuse the frozen reference at a running center | `ATTEMPTED` | Rejected: center/reference derivatives and determinant ownership would need a new transport theorem. |
+| Promote the restricted class (1.2a) to a generic ambient ball | `ATTEMPTED` | Rejected: arbitrary raw onsite nonquadratic inputs are deliberately outside the source domain. |
+
+Live constructive continuations are scale-indexed source charts, retained
+atom lineage, a block-saturated next-source section, a varying-m schedule,
+multi-horizon bundle composition, and alternate taste-faithful blocks.
+
+### N2 — wall-independence audit
+
+Keep six residuals atomic:
+
+| wall | unresolved target |
+|---|---|
+| `W1` | A same-domain nonlinear return/invariant-ball package for one declared transition, including return embedding and center/base update but not identifying later horizons. |
+| `W2` | A horizon-uniform scale-indexed or lineage-preserving recursion. |
+| `W3` | Extension from the restricted class (1.2a) to the required generic ambient interactions. |
+| `W4` | Select a physical taste/chart rather than declare this sector. |
+| `W5` | A controlled critical/continuum limit with Lorentz, unitary QM/QFT, SM, and GR recovery. |
+| `W6` | A physical dynamics/admissibility law including time and probability. |
+
+| pair | close first => second? | close second => first? | independent reason |
+|---|---:|---:|---|
+| `W1-W2` | No | No | One declared same-domain transition does not identify the physical graphs, centers, or lineage at later horizons; an all-horizon induction may instead use changing bundle charts. |
+| `W1-W3` | No | No | A self-map on the restricted class does not embed generic interactions; generic membership alone gives no self-map. |
+| `W1-W4` | No | No | An invariant mathematical ball is taste-blind; taste selection gives no self-map. |
+| `W1-W5` | No | No | A massive ball need not survive criticality; a continuum route may use changing domains. |
+| `W1-W6` | No | No | A self-map supplies no law/time/probability semantics; those semantics give no cluster estimate. |
+| `W2-W3` | No | No | All-horizon control on the actual class does not embed generic sources; generic control supplies no scale recursion. |
+| `W2-W4` | No | No | Scale induction does not select taste; a selector supplies no induction. |
+| `W2-W5` | No | No | Massive all-horizon estimates are not critical convergence; a critical construction may use another recursion. |
+| `W2-W6` | No | No | A Euclidean recursion supplies no physical law/time/probability rule. |
+| `W3-W4` | No | No | Generic analytic control is sector-blind; taste selection does not bound arbitrary sources. |
+| `W3-W5` | No | No | A generic massive ball need not have a critical limit; continuum control need not be generic in this norm. |
+| `W3-W6` | No | No | Ambient interaction control and physical law selection are separate. |
+| `W4-W5` | No | No | Taste selection does not prove continuum recovery; a continuum limit may retain multiple tastes. |
+| `W4-W6` | No | No | A sector selector is not a dynamics/time/probability law. |
+| `W5-W6` | No | No | Recovering continuum sectors does not select the fundamental law or probability rule; the converse supplies no limit. |
+
+### N3 — hidden-condition phrase scan
+
+The pre-N3 note and pre-scan runner prefix were scanned literally:
+
+| phrase | hit count | classification |
+|---|---:|---|
+| `we assume` | 0 | absent |
+| `by construction` | 0 | absent |
+| `as is standard` | 0 | absent |
+| `the framework provides` | 0 | absent |
+| `bridge context` | 0 | absent |
+| `background` | 1 | declared finite-sector import only |
+| `naturally` | 0 | absent |
+| `obviously` | 0 | absent |
+| `standard QFT` | 0 | absent |
+| `registered` | 0 | absent before this self-referential table |
+| `canonical` | 0 | absent before this self-referential table |
+
+`Uniform`
+means uniform on the radius-`0.001` strong ball, not uniform across all scales.
+`Nonlinear tube` means (4.1) between two different norm bundles.  `Hessian`
+means the finite-regulator Banach derivative (1.4).  `All-horizon`,
+`invariant`, `continuum`, `unitarity`, and `probability` occur only as explicit
+nonclaims or residuals.
+
+### N4 — residual matching
+
+| exact authority | residual supplied | present use | match? |
+|---|---|---|---:|
+| Split-derivative note, lines 23--72 and 142--194 | exact derivative/covariance and nonideal centered split | (1.1)--(1.5), direct pair | Yes |
+| K-retaining note, lines 9--121 and 264--318 | strong split, one-mark `q`, conditional Taylor diagnostic | source norm, linear row, tube architecture | Yes |
+| Joint product-reference note, lines 314--358 | common two-layer graph and `H(t)` majorant | conservative pair series (2.2)--(2.5) | Yes |
+| Block46 note, Sections 3--6 | actual completed graph, base rows, output gap and atom return | all numerical and ownership inputs | Yes |
+| Framework dynamics-selection no-go | physical law underdetermination | not used | Residual mismatch; dropped |
+
+### N5 — rhetoric and resolution audit
+
+| resolution | tested? | supported statement |
+|---|---:|---|
+| One finite two-coordinate covariance fixture | Yes | Sign, raw-block vanishing, direct pair, no factor two. |
+| One completed finite-regulator graph | Yes | Uniform pair bound and radius-`0.001` tube. |
+| Whole restricted strong ball at one horizon | Yes | Worst activity, Hessian, gap, and atom rows are recomputed. |
+| Same-domain next-scale ball | No | `W1` remains. |
+| All horizons / running center | No | `W1-W2` remain. |
+| Taste / continuum / Lorentzian theory | No | `W4-W6` remain. |
+
+### N6 — partial closure and primitive scan
+
+The two-mark theorem retires the old unlocalized Cauchy wall for one
+actual completed graph: it retains the small activity and rooted marked paths
+instead of replacing the row by the allowance.  It also upgrades Block46's
+single output into a nonzero nonlinear tube.  The target/source chart mismatch
+and running-center/all-horizon tasks still have multiple live mechanisms from
+N1.  The Lattice, Qubit, Admissibility, and Record axioms and the approved
+primitive registry neither provide nor obstruct those analytic mechanisms.
+
+No axiom-update stop is triggered.
+
+### N7 — hostile steelman
+
+The strongest objection is that a source/output tube is not yet an RG
+invariant ball.  The objection is correct: Block46's target atom chart has
+smaller spatial and diameter exponents than this theorem's centered source
+chart, and no identity embeds it back.  A scale-indexed Banach bundle or
+lineage-preserving section could nevertheless turn exactly this tube into one
+step of an all-horizon induction.  That live route defeats any broader no-go
+but does not change the bounded one-horizon statement proved here.
+
+### N8 — cross-cycle echo
+
+| prior wall/path | earlier status | mechanism applied here | disposition |
+|---|---|---|---|
+| Raw Hessian | Local bosonic pair covariance only | Completed joint Banach graph and strong split | Retired for the displayed actual all-degree graph. |
+| Unlocalized Cauchy certificate | Absolute bound above 68 | Actual `K_delta`, direct pair, conservative two-side rooted envelope | Retired on the radius-`0.001` ball. |
+| K-retaining one-mark theorem | Strong-to-weak linear contraction only | Uniform two-mark bound plus Taylor | Upgraded to one nonlinear bundle tube. |
+| Block43 unchanged-ledger wall | Same fixed chart could not iterate | Target/source mismatch remains explicit | Not retired; scale-indexed/lineage escapes stay live. |
+| Block46 unchanged next reuse | Response and factor certificates both missed | The theorem perturbs the first completed horizon, not the failed next ledger | Preserved; no contradictory iteration claim. |
+
+**No-Go Discipline status:** `PASS` for the named bundle-versus-same-domain
+boundary.
+
+## 7. Claim-strength disposition
+
+`PASS WITH BOUNDED CLAIMS` is the intended review disposition.  The bounded
+candidate is one finite-regulator, fixed-sector, restricted-class,
+radius-`0.001` nonlinear residual source/output tube with a conservative
+two-mark cluster majorant and separate center ledger.  It is not an
+autonomous RG ball, physical fixed point, all-horizon construction, continuum
+limit, or derivation of dynamics, time, unitarity, or probability.
+
+No axiom-update stop is triggered.

--- a/logs/runner-cache/wilson_staggered_completed_joint_two_mark_nonlinear_tube_2026_07_13.txt
+++ b/logs/runner-cache/wilson_staggered_completed_joint_two_mark_nonlinear_tube_2026_07_13.txt
@@ -1,0 +1,23 @@
+===== runner cache v1 =====
+runner: scripts/wilson_staggered_completed_joint_two_mark_nonlinear_tube_2026_07_13.py
+runner_sha256: a307028939990331310588b77c8c7c8deccd23a587de224ccc5438e32a83130b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.19
+status: ok
+----- stdout -----
+PASS fiber_constant_raw_hessian_blocks_vanish: Cov(raw,raw)=-2.220e-16, Cov(raw,Fo)=0.000e+00, Cov_Phi(Fo,Go)=0.463437555205, direct E0 pair=0.600000000000
+PASS fiber_constant_raw_factor_cancels_from_normalized_response: E_(Phi+Lf)[Fo]=-0.066632874822069=E_Phi[Fo]=-0.066632874822069; only Ho enters K_delta
+PASS mixed_second_derivative_has_no_extra_factor_two: d_s d_t[-log Z]=-0.463437551789, -Cov(Fo,Go)=-0.463437555205; Taylor diagonal alone carries 1/2
+PASS conservative_two_mark_two_side_envelope: one-side truncated=1.686625063248440, layer distribution=1.686625063248440, 1+H=(1-t)^-2=1.686625063248440, two-side safe product=(1-t)^-4=2.844704103977804
+PASS independent_high_precision_tube_recomputation: Decimal n=111, K_delta=0.0010009809898348720421557539930583115630762005807014602285146744603597482514483, tau=0.040920026969536875799005002348005218989181342071338370714132470950420668195581631, M=88.821698004805115497378231872770746763712474241779695426882098556017386521050894, lhs=0.00098538290509857336091293817538282199457656159810129079976969836633378865860477381, margin=0.00001461709490142663908706182461717800542343840189870920023030163366621134139522619
+PASS uniform_strong_ball_pair_hessian_bound: delta=0.001000<r_src=0.009949854790553, K_delta=1.000980989834872e-03<c, D=40.879924179466485@n=111, tau_delta=0.040920026969537, M_delta=88.821698004805114
+PASS one_horizon_nonlinear_residual_source_output_tube: B=3.613463806021123e-05, q=0.904837418035960, delta=0.001000, B+qdelta+(M/2)delta^2=9.853829050985733e-04<delta, margin=1.461709490142675e-05
+PASS separate_center_ledger_gap_eta_and_residual_atom_membership: complete center/output charge=delta+tube+B=2.021517543158784e-03, epsilon_Q=2.262440843396182e-04, gap/m=0.999773755915660, sigma_eta=6.788090441796472e-04, theta_atom=0.426574016916734, expm1(delta)=1.000500166708342e-03<c
+PASS hidden_condition_phrase_scan: pre-N3 note plus pre-scan runner counts={'we assume': 0, 'by construction': 0, 'as is standard': 0, 'the framework provides': 0, 'bridge context': 0, 'background': 1, 'naturally': 0, 'obviously': 0, 'standard qft': 0, 'registered': 0, 'canonical': 0}; sole background hit is the declared finite-sector import
+PASS source_contract: missing=[], forbidden_hits=[]
+PASS repository_dependency_set: markdown_dependency_set=['WILSON_STAGGERED_JOINT_PRODUCT_REFERENCE_DETERMINANT_COUNTERTERM_OUTER_HAAR_COLORED_RESPONSE_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_K_RETAINING_MARKED_ATTACHMENT_STRONG_WEAK_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md', 'WILSON_STAGGERED_SCALAR_PRODUCT_REFERENCE_COMPLETED_JOINT_OUTER_HAAR_ACTUAL_OUTPUT_ATOM_RETURN_BOUNDED_THEOREM_NOTE_2026-07-13.md', 'WILSON_STAGGERED_SPLIT_DERIVATIVE_AND_UNLOCALIZED_CAUCHY_CERTIFICATE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-07-12.md']
+SCORECARD PASS=11 FAIL=0
+
+----- stderr -----
+

--- a/scripts/wilson_staggered_completed_joint_two_mark_nonlinear_tube_2026_07_13.py
+++ b/scripts/wilson_staggered_completed_joint_two_mark_nonlinear_tube_2026_07_13.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""Checks the completed-joint two-mark bound and one nonlinear bundle tube."""
+
+from __future__ import annotations
+
+import importlib.util
+import itertools
+import math
+from pathlib import Path
+import re
+from decimal import Decimal, localcontext
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "WILSON_STAGGERED_COMPLETED_JOINT_TWO_MARK_COVARIANCE_NONLINEAR_"
+    "SOURCE_OUTPUT_TUBE_BOUNDED_THEOREM_NOTE_2026-07-13.md"
+)
+BLOCK46 = ROOT / "scripts" / (
+    "wilson_staggered_scalar_product_reference_completed_joint_atom_"
+    "return_2026_07_13.py"
+)
+C_STAR = 3.0 + 2.0 * math.sqrt(2.0)
+SAFE_ROOTS = 68
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def integer_sup_n_exp(slack: float) -> tuple[int, float]:
+    if slack <= 0.0:
+        raise ValueError("slack must be positive")
+    critical = 1.0 / slack
+    candidates = {max(1, math.floor(critical)), max(1, math.ceil(critical))}
+    return max(
+        ((int(n), n * math.exp(-slack * n)) for n in candidates),
+        key=lambda row: row[1],
+    )
+
+
+def normalized_average(
+    values: dict[tuple[int, int], float], weights: dict[tuple[int, int], float]
+) -> float:
+    denominator = sum(weights.values())
+    return sum(values[point] * weights[point] for point in values) / denominator
+
+
+def tube_rows(delta: float = 0.001) -> dict[str, float]:
+    block46 = load_module("block46", BLOCK46)
+    base = block46.first_joint_rows()
+    allowance = base["allowance"]
+    perturbation_activity = math.expm1(delta)
+    k_ball = base["K_T"] + perturbation_activity
+    slack = allowance - k_ball
+    n_d, d_value = integer_sup_n_exp(slack)
+    tau = k_ball * d_value
+    conversion = SAFE_ROOTS * math.exp(base["lambda"] / 2.0)
+    # One complete rooted marked side costs 1+H=(1-tau)^-2.  Multiplying
+    # the two ordered sides overcounts disconnected and shared structures,
+    # so (1-tau)^-4 is a conservative two-mark envelope.
+    pair_envelope = 1.0 / (1.0 - tau) ** 4
+    hessian = conversion * pair_envelope
+    base_output = base["B_out_total"]
+    linear = base["q"]
+    tube_left = base_output + linear * delta + 0.5 * hessian * delta**2
+    source_radius = math.log1p(allowance - base["K_T"])
+
+    # T_res excludes the declared Hermitian onsite quadratic center.  For the
+    # complete quadratic gap, separately charge its raw shift by delta and
+    # every generated residual output by the full residual-tube envelope.
+    complete_output_charge = delta + tube_left + base_output
+    epsilon_quadratic = (
+        base["B_star"]
+        + math.exp(-base["theta_weak"]) * complete_output_charge
+        + base["K_tail_empty"]
+    )
+    gap_ratio = 1.0 - epsilon_quadratic
+    sigma_eta = 3.0 * math.log(1.0 / gap_ratio)
+    theta_atom = base["theta_weak"] - math.log(C_STAR) - sigma_eta
+    output_factor = math.expm1(delta)
+    return {
+        **{f"base_{key}": value for key, value in base.items()},
+        "delta": delta,
+        "K_perturb": perturbation_activity,
+        "K_ball": k_ball,
+        "slack": slack,
+        "n_D": float(n_d),
+        "D": d_value,
+        "tau": tau,
+        "conversion": conversion,
+        "pair_envelope": pair_envelope,
+        "M_pair": hessian,
+        "B": base_output,
+        "q": linear,
+        "tube_left": tube_left,
+        "tube_margin": delta - tube_left,
+        "complete_output_charge": complete_output_charge,
+        "source_radius": source_radius,
+        "epsilon_quadratic": epsilon_quadratic,
+        "gap_ratio": gap_ratio,
+        "sigma_eta": sigma_eta,
+        "theta_atom": theta_atom,
+        "K_output_factor": output_factor,
+    }
+
+
+def main() -> None:
+    checks: list[tuple[str, bool, str]] = []
+
+    # An exact finite product fixture checks the full Hessian split at a
+    # nontrivially tilted base.  Fiber-constant lifts have zero covariance
+    # with every mark; two product-centered marks have a nonzero covariance.
+    points = list(itertools.product((-1, 1), repeat=2))
+    product_weights = {point: 0.25 for point in points}
+    base_potential = {
+        (u, v): 0.17 * u * v + 0.06 * u - 0.04 * v for u, v in points
+    }
+    physical_weights = {
+        point: product_weights[point] * math.exp(-base_potential[point])
+        for point in points
+    }
+    raw = {point: 0.73 for point in points}
+    mark_f = {(u, v): float(u) for u, v in points}
+    mark_g = {(u, v): 0.6 * u + 0.8 * v for u, v in points}
+
+    def covariance(
+        left: dict[tuple[int, int], float],
+        right: dict[tuple[int, int], float],
+        weights: dict[tuple[int, int], float],
+    ) -> float:
+        product = {point: left[point] * right[point] for point in points}
+        return normalized_average(product, weights) - normalized_average(
+            left, weights
+        ) * normalized_average(right, weights)
+
+    cov_raw_raw = covariance(raw, raw, physical_weights)
+    cov_raw_mark = covariance(raw, mark_f, physical_weights)
+    cov_marks = covariance(mark_f, mark_g, physical_weights)
+    direct_product_covariance = covariance(mark_f, mark_g, product_weights)
+    checks.append(
+        (
+            "fiber_constant_raw_hessian_blocks_vanish",
+            abs(cov_raw_raw) < 1.0e-14
+            and abs(cov_raw_mark) < 1.0e-14
+            and abs(cov_marks) > 0.1
+            and abs(direct_product_covariance) > 0.1,
+            "Cov(raw,raw)={:.3e}, Cov(raw,Fo)={:.3e}, Cov_Phi(Fo,Go)={:.12f}, direct E0 pair={:.12f}".format(
+                cov_raw_raw, cov_raw_mark, cov_marks, direct_product_covariance
+            ),
+        )
+    )
+
+    # A fiber-constant raw perturbation factors from numerator and denominator;
+    # only the centered arm needs to enter the joint activity row.
+    raw_shift = 0.31
+    raw_tilted_weights = {
+        point: physical_weights[point] * math.exp(-raw_shift) for point in points
+    }
+    checks.append(
+        (
+            "fiber_constant_raw_factor_cancels_from_normalized_response",
+            math.isclose(
+                normalized_average(mark_f, raw_tilted_weights),
+                normalized_average(mark_f, physical_weights),
+                rel_tol=1.0e-14,
+                abs_tol=1.0e-14,
+            ),
+            "E_(Phi+Lf)[Fo]={:.15f}=E_Phi[Fo]={:.15f}; only Ho enters K_delta".format(
+                normalized_average(mark_f, raw_tilted_weights),
+                normalized_average(mark_f, physical_weights),
+            ),
+        )
+    )
+
+    def response(source_s: float, source_t: float) -> float:
+        partition = sum(
+            physical_weights[point]
+            * math.exp(-source_s * mark_f[point] - source_t * mark_g[point])
+            for point in points
+        )
+        return -math.log(partition)
+
+    step = 1.0e-4
+    mixed_difference = (
+        response(step, step)
+        - response(step, -step)
+        - response(-step, step)
+        + response(-step, -step)
+    ) / (4.0 * step**2)
+    checks.append(
+        (
+            "mixed_second_derivative_has_no_extra_factor_two",
+            math.isclose(mixed_difference, -cov_marks, rel_tol=2.0e-8),
+            "d_s d_t[-log Z]={:.12f}, -Cov(Fo,Go)={:.12f}; Taylor diagonal alone carries 1/2".format(
+                mixed_difference, -cov_marks
+            ),
+        )
+    )
+
+    # Two combinatorial layers distribute n path steps in n+1 ways on one
+    # rooted marked side.  Multiply two full side envelopes for a safe pair
+    # bound rather than asserting a sharp two-root enumeration.
+    test_tau = 0.23
+    cutoff = 30
+    distributed_sum = sum(
+        test_tau ** (first + second)
+        for first in range(cutoff + 1)
+        for second in range(cutoff + 1 - first)
+    )
+    coefficient_sum = sum(
+        (order + 1) * test_tau**order for order in range(cutoff + 1)
+    )
+    closed_pair = 1.0 / (1.0 - test_tau) ** 2
+    h_function = test_tau * (2.0 - test_tau) / (1.0 - test_tau) ** 2
+    conservative_two_mark = closed_pair**2
+    checks.append(
+        (
+            "conservative_two_mark_two_side_envelope",
+            math.isclose(distributed_sum, coefficient_sum, rel_tol=1.0e-14)
+            and coefficient_sum <= closed_pair
+            and math.isclose(1.0 + h_function, closed_pair, rel_tol=1.0e-14)
+            and math.isclose(conservative_two_mark, (1.0 - test_tau) ** -4),
+            "one-side truncated={:.15f}, layer distribution={:.15f}, 1+H=(1-t)^-2={:.15f}, two-side safe product=(1-t)^-4={:.15f}".format(
+                coefficient_sum, distributed_sum, closed_pair, conservative_two_mark
+            ),
+        )
+    )
+
+    rows = tube_rows()
+    with localcontext() as context:
+        context.prec = 80
+        decimal_delta = Decimal("0.001")
+        decimal_c = Decimal("0.01")
+        decimal_k_base = Decimal(str(rows["base_K_T"]))
+        decimal_k_ball = decimal_k_base + decimal_delta.exp() - Decimal(1)
+        decimal_slack = decimal_c - decimal_k_ball
+        decimal_candidates = [
+            (
+                n,
+                Decimal(n) * (-decimal_slack * Decimal(n)).exp(),
+            )
+            for n in (110, 111, 112)
+        ]
+        decimal_n, decimal_d = max(decimal_candidates, key=lambda row: row[1])
+        decimal_tau = decimal_k_ball * decimal_d
+        decimal_conversion = Decimal(68) * Decimal("0.1").exp()
+        decimal_m = decimal_conversion / (Decimal(1) - decimal_tau) ** 4
+        decimal_b = Decimal(str(rows["B"]))
+        decimal_q = Decimal("-0.1").exp()
+        decimal_lhs = (
+            decimal_b
+            + decimal_q * decimal_delta
+            + decimal_m * decimal_delta**2 / Decimal(2)
+        )
+    checks.append(
+        (
+            "independent_high_precision_tube_recomputation",
+            decimal_n == 111
+            and math.isclose(float(decimal_k_ball), rows["K_ball"], rel_tol=1.0e-15)
+            and math.isclose(float(decimal_tau), rows["tau"], rel_tol=1.0e-15)
+            and math.isclose(float(decimal_m), rows["M_pair"], rel_tol=1.0e-15)
+            and math.isclose(float(decimal_lhs), rows["tube_left"], rel_tol=1.0e-15)
+            and decimal_lhs < decimal_delta,
+            "Decimal n={}, K_delta={}, tau={}, M={}, lhs={}, margin={}".format(
+                decimal_n,
+                decimal_k_ball,
+                decimal_tau,
+                decimal_m,
+                decimal_lhs,
+                decimal_delta - decimal_lhs,
+            ),
+        )
+    )
+    checks.append(
+        (
+            "uniform_strong_ball_pair_hessian_bound",
+            rows["delta"] < rows["source_radius"]
+            and rows["K_ball"] < rows["base_allowance"]
+            and rows["tau"] < 1.0
+            and 88.0 < rows["M_pair"] < 89.0,
+            "delta={:.6f}<r_src={:.15f}, K_delta={:.15e}<c, D={:.15f}@n={}, tau_delta={:.15f}, M_delta={:.15f}".format(
+                rows["delta"],
+                rows["source_radius"],
+                rows["K_ball"],
+                rows["D"],
+                int(rows["n_D"]),
+                rows["tau"],
+                rows["M_pair"],
+            ),
+        )
+    )
+    checks.append(
+        (
+            "one_horizon_nonlinear_residual_source_output_tube",
+            rows["tube_left"] < rows["delta"]
+            and rows["tube_margin"] > 1.4e-5,
+            "B={:.15e}, q={:.15f}, delta={:.6f}, B+qdelta+(M/2)delta^2={:.15e}<delta, margin={:.15e}".format(
+                rows["B"],
+                rows["q"],
+                rows["delta"],
+                rows["tube_left"],
+                rows["tube_margin"],
+            ),
+        )
+    )
+    checks.append(
+        (
+            "separate_center_ledger_gap_eta_and_residual_atom_membership",
+            rows["gap_ratio"] > 0.9997
+            and rows["theta_atom"] > 0.400001
+            and rows["K_output_factor"] < rows["base_allowance"],
+            "complete center/output charge=delta+tube+B={:.15e}, epsilon_Q={:.15e}, gap/m={:.15f}, sigma_eta={:.15e}, theta_atom={:.15f}, expm1(delta)={:.15e}<c".format(
+                rows["complete_output_charge"],
+                rows["epsilon_quadratic"],
+                rows["gap_ratio"],
+                rows["sigma_eta"],
+                rows["theta_atom"],
+                rows["K_output_factor"],
+            ),
+        )
+    )
+
+    text = NOTE.read_text()
+    runner_prefix = Path(__file__).read_text().split("hidden_phrases =", 1)[0].lower()
+    pre_n3 = text.split("### N3", 1)[0].lower()
+    hidden_phrases = [
+        "we assume",
+        "by construction",
+        "as is standard",
+        "the framework provides",
+        "bridge context",
+        "background",
+        "naturally",
+        "obviously",
+        "standard qft",
+        "registered",
+        "canonical",
+    ]
+    phrase_counts = {
+        phrase: pre_n3.count(phrase) + runner_prefix.count(phrase)
+        for phrase in hidden_phrases
+    }
+    checks.append(
+        (
+            "hidden_condition_phrase_scan",
+            phrase_counts == {phrase: int(phrase == "background") for phrase in hidden_phrases},
+            f"pre-N3 note plus pre-scan runner counts={phrase_counts}; sole background hit is the declared finite-sector import",
+        )
+    )
+    required = [
+        "**Type:** bounded_theorem",
+        "D^2R_Phi[F,G]=-Cov_Phi(F,G)",
+        "T_res=(1-P_quad)D_(2,1)R",
+        "[1+H]^2=(1-tau)^(-4)",
+        "K_delta=K_T+expm1(delta)",
+        "B+q delta+(M_delta/2)delta^2",
+        "source/output Banach-bundle tube",
+        "No axiom-update stop",
+        "### N1",
+        "### N2",
+        "### N3",
+        "### N4",
+        "### N5",
+        "### N6",
+        "### N7",
+        "### N8",
+    ]
+    missing = [item for item in required if item not in text]
+    forbidden = [
+        "proves an autonomous RG ball",
+        "proves a physical fixed point",
+        "proves a continuum limit",
+        "requires a new axiom",
+        "NOT_TESTED",
+    ]
+    hits = [item for item in forbidden if item in text]
+    checks.append(
+        ("source_contract", not missing and not hits, f"missing={missing}, forbidden_hits={hits}")
+    )
+
+    expected_dependencies = sorted(
+        [
+            "WILSON_STAGGERED_JOINT_PRODUCT_REFERENCE_DETERMINANT_COUNTERTERM_OUTER_HAAR_COLORED_RESPONSE_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_K_RETAINING_MARKED_ATTACHMENT_STRONG_WEAK_CONTRACTION_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+            "WILSON_STAGGERED_SCALAR_PRODUCT_REFERENCE_COMPLETED_JOINT_OUTER_HAAR_ACTUAL_OUTPUT_ATOM_RETURN_BOUNDED_THEOREM_NOTE_2026-07-13.md",
+            "WILSON_STAGGERED_SPLIT_DERIVATIVE_AND_UNLOCALIZED_CAUCHY_CERTIFICATE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+        ]
+    )
+    dependencies = sorted(set(re.findall(r"\]\(([^)#?]+\.md)\)", text)))
+    checks.append(
+        (
+            "repository_dependency_set",
+            dependencies == expected_dependencies,
+            f"markdown_dependency_set={dependencies}",
+        )
+    )
+
+    passed = sum(ok for _, ok, _ in checks)
+    failed = len(checks) - passed
+    for name, ok, detail in checks:
+        print(f"{'PASS' if ok else 'FAIL'} {name}: {detail}")
+    print(f"SCORECARD PASS={passed} FAIL={failed}")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Result

Closes a nonzero nonlinear one-horizon theorem on the actual completed Block46 graph:

- fixes the correlated reference, center, and chart and proves the exact Hessian identity `D^2R=-Cov`;
- shows fiber-constant raw/raw and raw/centered Hessian blocks vanish, leaving the centered two-mark block;
- restricts raw diameter-zero inputs to the owned Hermitian quadratic center and keeps centered onsite residual output explicit;
- proves the conservative connected two-root envelope `P_2 <= (1-tau)^-4` with no external factor two;
- obtains `M_delta=88.82169800480513` uniformly on the radius-`0.001` strong ball;
- closes `B+q delta+(M_delta/2)delta^2=0.0009853829050985733<delta`;
- separately overcharges the center/output ledger and retains `theta_atom=0.4265740169167342>0.400001`.

This is a restricted-source strong-to-weak residual source/output Banach-bundle tube. It is not a same-domain invariant ball, an all-horizon recursion, or a continuum theorem. Type: `bounded_theorem`; audit status remains pipeline-derived and unaudited. Direct dependencies are exactly Blocks 31, 32, 39, and 46.

Stacked on the rewritten Block46 replacement PR #5374. The original #5370 passed audit but was automatically closed when its parent branch was force-pushed.

## No-Go Discipline N1-N8

### N1 — alternatives

Six routes were `ATTEMPTED`: identify the target and source charts; infer invariance from the scalar inequality; invoke Banach from the cross-norm `q`; iterate `M_delta,q` unchanged; reuse the frozen reference at a running center; and promote the restricted source class to generic ambient interactions. Each fails only at the named missing interface, leaving scale-indexed bundles, lineage transport, and new center/reference transport live.

### N2 — independence

Atomic walls: W1 one-transition same-domain return/ball with center update; W2 all-horizon graph/lineage transport; W3 generic ambient-source embedding; W4 taste selection; W5 controlled Lorentz/unitary QM-QFT/SM/GR continuum; W6 physical dynamics/admissibility with time and probability. All 15 pairs are checked bidirectionally in the note.

### N3 — phrase/rhetoric scan

The note and runner scan `we assume`, `by construction`, `as is standard`, `the framework provides`, `bridge context`, `background`, `naturally`, `obviously`, `standard QFT`, `registered`, and `canonical`. The only pre-scan hit is the disclosed finite-sector background import. `Uniform`, `nonlinear tube`, and `Hessian` are defined at their exact tested resolution.

### N4 — residual matching

Blocks 31/32/39/46 supply the derivative split, strong/weak marked architecture, common joint two-layer majorant, and actual completed graph/output ledger. The framework dynamics-selection no-go is a residual mismatch and is not used.

### N5 — resolution audit

Tested: a nontrivially tilted finite covariance fixture; the whole restricted radius-`0.001` ball on one completed finite-regulator graph; the uniform Hessian, Taylor tube, gap, eta, and atom rows. Not tested: a same-domain next-scale ball, all horizons, generic ambient sources, taste, or continuum physics.

### N6 — partial closure / primitives

This PR retires the unlocalized Cauchy wall on the displayed graph and upgrades the prior single output into a nonlinear tube. Multiple constructive routes remain for same-domain return and all-horizon transport. No axiom or approved primitive supplies or obstructs those analytic mechanisms.

### N7 — steelman

A source/output tube is not an invariant RG ball because the target chart is weaker and no return embedding is proved. A scale-indexed Banach bundle or lineage-preserving section could turn this exact result into one induction step, defeating any broader impossibility claim.

### N8 — cross-cycle echo

The raw-Hessian and unlocalized-Cauchy walls are retired only on the actual displayed graph; Block32 is upgraded from linear to nonlinear control; Block43's unchanged-ledger boundary and Block46's failed literal next reuse remain intact.

Narrow NG47: the displayed finite one-horizon cross-norm tube alone does not imply a same-domain invariant ball or second-horizon reuse. This is a logical non-implication, not a physical RG no-go.

No axiom-update stop is triggered.

## Validation

- primary runner: `SCORECARD PASS=11 FAIL=0`
- four direct dependency runners: all pass (`9/0`, `9/0`, `12/0`, `12/0`)
- independent 80-digit Decimal reconstruction: pass
- SHA-pinned cache freshness: pass
- code/math, physics/import, governance/no-go reviews: `PASS WITH BOUNDED CLAIMS`
- vocabulary lint: 0 violations
- `py_compile` and `git diff --check`: clean
- audit compatibility: `bounded_theorem`, `unaudited`, exact four dependencies, non-decoration runner
- strict audit lint: 0 errors (repository-wide legacy warnings only)
- generated audit/status outputs stripped
