### PR TITLE
Science fix: expose staggered canonical runner source

### DIFF
--- a/docs/STAGGERED_FERMION_CARD_2026-04-11.md
+++ b/docs/STAGGERED_FERMION_CARD_2026-04-11.md
@@ -6,6 +6,9 @@
 **Primary runner:** `scripts/frontier_staggered_17card_finite_scope_repair.py`
 **Canonical runner executed by primary runner:** `scripts/frontier_staggered_17card.py`
 **Status authority:** independent audit lane only.
+**Packet source update (2026-07-16; PR #5385):** claim-scoped audit packets
+include the complete source of `scripts/frontier_staggered_17card.py` alongside
+the primary wrapper.
 
 ## Actual claim
 

--- a/docs/STAGGERED_FERMION_CARD_2026-04-11.md
+++ b/docs/STAGGERED_FERMION_CARD_2026-04-11.md
@@ -6,7 +6,7 @@
 **Primary runner:** `scripts/frontier_staggered_17card_finite_scope_repair.py`
 **Canonical runner executed by primary runner:** `scripts/frontier_staggered_17card.py`
 **Status authority:** independent audit lane only.
-**Packet source update (2026-07-16; PR #5385):** claim-scoped audit packets
+**Packet source update (2026-07-15; PR #5385):** claim-scoped audit packets
 include the complete source of `scripts/frontier_staggered_17card.py` alongside
 the primary wrapper.
 

--- a/docs/audit/scripts/build_citation_graph.py
+++ b/docs/audit/scripts/build_citation_graph.py
@@ -116,6 +116,12 @@ EXPLICIT_PACKET_HELPER_RUNNER_PATHS = {
     "teleportation_acceptance_suite_note": [
         "scripts/frontier_teleportation_acceptance_suite.py",
     ],
+    # This claim's finite-scope wrapper executes the canonical 17-card through
+    # subprocess. Keep that exceptional packet edge claim-scoped: arbitrary
+    # subprocess targets are intentionally not treated as helper imports.
+    "staggered_fermion_card_2026-04-11": [
+        "scripts/frontier_staggered_17card.py",
+    ],
 }
 
 

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -2710,7 +2710,7 @@ class StaggeredExplicitPacketHelperTest(unittest.TestCase):
         note_path = "docs/STAGGERED_FERMION_CARD_2026-04-11.md"
         note_body = (PROJECT_ROOT / note_path).read_text(encoding="utf-8")
         self.assertIn(
-            "Packet source update (2026-07-16; PR #5385)",
+            "Packet source update (2026-07-15; PR #5385)",
             note_body,
         )
         current_note_hash = hashlib.sha256(note_body.encode("utf-8")).hexdigest()

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -2715,16 +2715,31 @@ class StaggeredExplicitPacketHelperTest(unittest.TestCase):
         )
         current_note_hash = hashlib.sha256(note_body.encode("utf-8")).hexdigest()
 
-        shard_path = (
-            PROJECT_ROOT
-            / "docs"
-            / "audit"
-            / "data"
-            / "ledger"
-            / "st"
-            / f"{self.CLAIM_ID}.json"
-        )
-        legacy_row = json.loads(shard_path.read_text(encoding="utf-8"))
+        legacy_row = {
+            "claim_id": self.CLAIM_ID,
+            "note_path": note_path,
+            "title": "Staggered Fermion Canonical 17-Card Finite Runner Certificate",
+            "runner_path": self.PRIMARY,
+            "helper_runner_paths": [],
+            "deps": [],
+            "note_hash": "8aa08f23d6fd946f5f6cfb7daed2b09877bba704ef333de529e32708b84f1152",
+            "previous_audits": [],
+            "audit_status": "audited_conditional",
+            "auditor": "legacy-staggered-packet-auditor",
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "cross_family",
+            "claim_type": "bounded_theorem",
+            "claim_type_provenance": "audited",
+            "claim_scope": "Legacy wrapper-only finite certificate scope.",
+            "audit_state_snapshot": {
+                "criticality": "critical",
+                "deps": [],
+                "dep_effective_status": {},
+                "runner_hash": "00a39ee4060f1d395df0d9e75633c6265d0ea22a971f648b75f82109d2054a8a",
+            },
+        }
         self.assertEqual(legacy_row["audit_status"], "audited_conditional")
         self.assertNotIn(
             "helper_runner_hashes",

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -2703,6 +2703,78 @@ class StaggeredExplicitPacketHelperTest(unittest.TestCase):
             f"helper_runner_hash_changed:{self.HELPER}:{helper_hash[:8]}->00000000",
         )
 
+    def test_packet_source_update_requeues_the_legacy_conditional_row(self):
+        seed = _import("seed_audit_ledger")
+        queue = _import("compute_audit_queue")
+        runner = _import_codex_audit_runner()
+        note_path = "docs/STAGGERED_FERMION_CARD_2026-04-11.md"
+        note_body = (PROJECT_ROOT / note_path).read_text(encoding="utf-8")
+        self.assertIn(
+            "Packet source update (2026-07-16; PR #5385)",
+            note_body,
+        )
+        current_note_hash = hashlib.sha256(note_body.encode("utf-8")).hexdigest()
+
+        shard_path = (
+            PROJECT_ROOT
+            / "docs"
+            / "audit"
+            / "data"
+            / "ledger"
+            / "st"
+            / f"{self.CLAIM_ID}.json"
+        )
+        legacy_row = json.loads(shard_path.read_text(encoding="utf-8"))
+        self.assertEqual(legacy_row["audit_status"], "audited_conditional")
+        self.assertNotIn(
+            "helper_runner_hashes",
+            legacy_row.get("audit_state_snapshot") or {},
+        )
+        self.assertNotEqual(legacy_row["note_hash"], current_note_hash)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp)
+            fixture = CleanLedgerFixture(tmp_root)
+            fixture.write_note(note_path, note_body)
+            fixture.write_graph(
+                {
+                    "nodes": {
+                        self.CLAIM_ID: {
+                            "path": note_path,
+                            "title": legacy_row["title"],
+                            "runner_path": self.PRIMARY,
+                            "helper_runner_paths": [self.HELPER],
+                            "deps": [],
+                            "note_hash": current_note_hash,
+                            "claim_type_seed_hint": "bounded_theorem",
+                            "claim_type_author_hint": "bounded_theorem",
+                            "claim_type_author_hint_raw": "bounded_theorem",
+                        }
+                    }
+                }
+            )
+            fixture.write_ledger(
+                {"schema_version": 1, "rows": {self.CLAIM_ID: legacy_row}}
+            )
+            _patch_repo_root(seed, tmp_root)
+            seeded = seed.seed()
+
+        requeued = seeded["rows"][self.CLAIM_ID]
+        self.assertEqual(seeded["stats"]["re_audit_required"], 1)
+        self.assertEqual(requeued["audit_status"], "unaudited")
+        self.assertIsNone(requeued["audit_state_snapshot"])
+        self.assertEqual(requeued["helper_runner_paths"], [self.HELPER])
+        self.assertEqual(queue.needs_audit(requeued), (True, "unaudited"))
+        self.assertEqual(
+            runner.determine_audit_role(
+                requeued,
+                "codex-gpt-5.6",
+                is_reaudit_candidate=False,
+                is_dispatch_target=False,
+            ),
+            ("first", "cross_family"),
+        )
+
 
 class SeedLedgerTest(unittest.TestCase):
     def setUp(self):

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -2588,6 +2588,122 @@ class BuildCitationGraphParserTest(unittest.TestCase):
         self.assertEqual(helpers, {"keyword_helper"})
 
 
+class StaggeredExplicitPacketHelperTest(unittest.TestCase):
+    CLAIM_ID = "staggered_fermion_card_2026-04-11"
+    PRIMARY = "scripts/frontier_staggered_17card_finite_scope_repair.py"
+    HELPER = "scripts/frontier_staggered_17card.py"
+
+    def test_both_consumers_return_only_the_claim_scoped_canonical_helper(self):
+        citation_graph = _import("build_citation_graph")
+        packet_deps = _import_repo_script("audit_packet_script_deps.py")
+        expected = [self.HELPER]
+
+        self.assertEqual(
+            citation_graph.helper_runner_paths_for_claim(
+                self.CLAIM_ID, self.PRIMARY
+            ),
+            expected,
+        )
+        self.assertEqual(
+            packet_deps.helper_runner_paths_for_claim(
+                self.CLAIM_ID, Path(self.PRIMARY).stem
+            ),
+            expected,
+        )
+
+        # The same subprocess wrapper must not expose its child for any other
+        # claim; the registration is an exact claim exception, not discovery.
+        control_claim = f"{self.CLAIM_ID}-unregistered-control"
+        self.assertEqual(
+            citation_graph.helper_runner_paths_for_claim(
+                control_claim, self.PRIMARY
+            ),
+            [],
+        )
+        self.assertEqual(
+            packet_deps.helper_runner_paths_for_claim(
+                control_claim, Path(self.PRIMARY).stem
+            ),
+            [],
+        )
+
+    def test_citation_graph_row_contains_the_canonical_helper(self):
+        citation_graph = _import("build_citation_graph")
+        note = PROJECT_ROOT / "docs" / "STAGGERED_FERMION_CARD_2026-04-11.md"
+        with mock.patch.object(citation_graph, "discover_notes", return_value=[note]):
+            graph = citation_graph.build_graph()
+
+        row = graph["nodes"][self.CLAIM_ID]
+        self.assertEqual(row["runner_path"], self.PRIMARY)
+        self.assertEqual(row["helper_runner_paths"], [self.HELPER])
+
+    def test_restricted_packet_embeds_the_full_exact_canonical_source(self):
+        runner = _import_codex_audit_runner()
+        row = {
+            "claim_id": self.CLAIM_ID,
+            "note_path": "docs/STAGGERED_FERMION_CARD_2026-04-11.md",
+            "runner_path": self.PRIMARY,
+            "helper_runner_paths": [self.HELPER],
+            "deps": [],
+            "claim_type": "bounded_theorem",
+        }
+        manifest: dict[str, dict] = {}
+        prompt = runner.render_prompt(
+            row,
+            {self.CLAIM_ID: row},
+            "{{HELPER_RUNNER_SOURCES}}",
+            runner_timeout_sec=1,
+            skip_runner_stdout=True,
+            evidence_manifest_out=manifest,
+        )
+
+        canonical_source = (PROJECT_ROOT / self.HELPER).read_text(encoding="utf-8")
+        begin = f"=== BEGIN HELPER RUNNER: {self.HELPER} ===\n"
+        cache = f"=== BEGIN HELPER RUNNER CACHE: {self.HELPER} ==="
+        rendered_source = prompt.split(begin, 1)[1].split(cache, 1)[0]
+        self.assertEqual(rendered_source, canonical_source + "\n")
+        self.assertNotIn("... [truncated; helper is", prompt)
+        self.assertIn("helper", manifest[self.HELPER]["roles"])
+        self.assertIn(canonical_source, manifest[self.HELPER]["text"])
+
+    def test_registered_helper_remains_hash_bound_for_invalidation(self):
+        apply_audit = _import("apply_audit")
+        invalidation = _import("invalidate_stale_audits")
+        row = {
+            "claim_id": self.CLAIM_ID,
+            "note_path": "docs/STAGGERED_FERMION_CARD_2026-04-11.md",
+            "runner_path": self.PRIMARY,
+            "helper_runner_paths": [self.HELPER],
+            "deps": [],
+            "claim_type": "bounded_theorem",
+            "criticality": "critical",
+            "audit_status": "audited_conditional",
+            "negative_assertion_classes": [],
+        }
+        snapshot = apply_audit.snapshot_audit_state(row, {self.CLAIM_ID: row})
+        helper_hash = hashlib.sha256(
+            (PROJECT_ROOT / self.HELPER).read_bytes()
+        ).hexdigest()
+        self.assertEqual(snapshot["helper_runner_hashes"], {self.HELPER: helper_hash})
+
+        audited_row = {**row, "audit_state_snapshot": snapshot}
+        self.assertIsNone(invalidation.detect_invalidation(audited_row, {}))
+
+        runner_hash = snapshot["runner_hash"]
+        with mock.patch.object(
+            invalidation.rc,
+            "runner_sha256",
+            side_effect=lambda path: (
+                "0" * 64 if path == self.HELPER else runner_hash
+            ),
+        ):
+            reason = invalidation.detect_invalidation(audited_row, {})
+        self.assertEqual(
+            reason,
+            f"helper_runner_hash_changed:{self.HELPER}:{helper_hash[:8]}->00000000",
+        )
+
+
 class SeedLedgerTest(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()

--- a/scripts/audit_packet_script_deps.py
+++ b/scripts/audit_packet_script_deps.py
@@ -51,6 +51,12 @@ EXPLICIT_PACKET_HELPER_RUNNER_PATHS = {
         "scripts/frontier_atomic_helium_jastrow_companion.py",
         "scripts/frontier_hydrogen_helium_atomic_lattice_kinetic_dependency_narrow_repair_verifier.py",
     ],
+    # This claim's finite-scope wrapper executes the canonical 17-card through
+    # subprocess. Keep that exceptional packet edge claim-scoped: arbitrary
+    # subprocess targets are intentionally not treated as helper imports.
+    "staggered_fermion_card_2026-04-11": [
+        "scripts/frontier_staggered_17card.py",
+    ],
 }
 
 


### PR DESCRIPTION
## Summary

- register the exact `staggered_fermion_card_2026-04-11` packet-helper edge to `scripts/frontier_staggered_17card.py` in both existing claim-scoped consumers
- keep subprocess handling fail-closed for every other claim; this does not add or revive generic subprocess analysis
- add the dated claim-note source-repair record needed to invalidate the legacy terminal snapshot and route the existing row through normal re-audit
- cover citation-graph row assembly, exact full-source packet rendering, legacy-row requeue, and current-main helper hash snapshot/invalidation behavior

## Science-fix boundary

This is science-fix source repair awaiting independent re-audit after landing. It changes only the claim note source record needed for note-hash invalidation; it does not change the claim type, claim status, audit verdict, queue, or generated audit/status data. No audit worker was run, `apply_audit.py` was not invoked as an audit action, and no verdict was authored or applied.

Exact existing repair target:

`runner_artifact_issue: include the full source of scripts/frontier_staggered_17card.py and every load-bearing helper in the restricted packet, then re-audit whether the four scores are genuinely computed.`

The restricted-packet renderer is repo-native: `scripts/codex_audit_runner.py::render_prompt` consumes `helper_runner_paths`. The regression proves that the rendered helper block contains the complete canonical source byte-for-byte (19,962 bytes, below the 40,000-byte helper limit), rather than only a path or digest.

A disposable pipeline run against the legacy `audited_conditional` fixture proved the dated note repair causes `seed_audit_ledger.py` to set `re_audit_required`, clear the stale snapshot, attach the helper path, and make the normal worker role `first/cross_family`. The disposable run did not launch a worker or apply a verdict, and all generated outputs were stripped.

## Validation

- `python3 -m unittest docs.audit.scripts.tests.test_audit_pipeline.StaggeredExplicitPacketHelperTest` (5 tests)
- `python3 -m unittest docs.audit.scripts.tests.test_audit_pipeline`
- `python3 docs/audit/scripts/audit_lint.py --strict` (no errors; repository warning/notice debt only)
- `python3 scripts/vocab_lint.py --report-only docs/audit/scripts/build_citation_graph.py scripts/audit_packet_script_deps.py docs/audit/scripts/tests/test_audit_pipeline.py docs/STAGGERED_FERMION_CARD_2026-04-11.md` (0 violations)
- `python3 -m py_compile docs/audit/scripts/build_citation_graph.py scripts/audit_packet_script_deps.py docs/audit/scripts/tests/test_audit_pipeline.py`
- `git diff --check`

Generated audit/queue/status outputs produced incidentally by validation were stripped before commit.