### PR TITLE
audit-infra: repo-invariants harness (snapshot / diff / check + authority-link guard)

### DIFF
--- a/docs/audit/scripts/repo_invariants_check.py
+++ b/docs/audit/scripts/repo_invariants_check.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Repo-invariants harness: snapshot, diff, and check structural invariants.
+
+Purpose. Landing hygiene/tooling changes safely requires a mechanical
+before/after ruler. This tool measures the repository's structural
+invariants from TRACKED sources only (it never runs the audit pipeline and
+never mutates anything), so any PR can demonstrate "nothing changed except
+what the PR declares."
+
+Modes
+  --snapshot [PATH]        write a canonical JSON snapshot (default: stdout)
+  --diff A B [--allow k1,k2]
+                           compare two snapshots; exit 1 on differences in
+                           fields not named in --allow
+  --check [--enforce-links]
+                           run absolute integrity checks; broken/gitignored
+                           authority links are WARN by default, errors with
+                           --enforce-links
+
+Invariants measured
+  ledger.shard_count           number of tracked ledger shard JSON files
+  ledger.claim_ids_sha256      hash of the sorted claim-id set
+  ledger.duplicate_claim_ids   must be empty
+  ledger.effective_status_histogram
+  ledger.retained_grade_total  retained + retained_bounded + retained_no_go
+                               + decoration_under_* rows
+  ledger.rows_with_missing_note_path  informational count
+  premises.ids                 registered axiom/primitive premise node ids
+  obligations.ids              open derivation-obligation ids
+  docs.md_count                markdown files directly under docs/
+  docs.duplicate_basenames     basename collisions across docs/** (row ids
+                               derive from filename stems)
+  authority_links.violations   markdown links on authority surfaces whose
+                               target is missing from the working tree or
+                               gitignored (a gitignored target 404s for any
+                               fresh clone or GitHub reader)
+
+This is a read-only measurement tool. It sets no audit status, writes no
+generated surface, and is not part of verdict minting.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import Counter
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..")
+)
+
+LEDGER_DIR = os.path.join("docs", "audit", "data", "ledger")
+PREMISE_NODES = os.path.join("docs", "audit", "data", "axiom_premise_nodes.json")
+OBLIGATIONS = os.path.join("docs", "audit", "data", "derivation_obligations.json")
+
+# Authority surfaces: the reading path an external reader or agent follows.
+AUTHORITY_SURFACE_GLOBS = [
+    "README.md",
+    os.path.join("docs", "repo"),
+    os.path.join("docs", "publication", "ci3_z3"),
+    os.path.join("docs", "audit"),
+    os.path.join("docs", "lanes", "README.md"),
+    os.path.join("docs", "lanes", "open_science", "README.md"),
+]
+
+MD_LINK_RE = re.compile(r"\]\(([^)#\s]+)(?:#[^)\s]*)?\)")
+
+RETAINED_GRADE_PREFIXES = ("decoration_under_",)
+RETAINED_GRADE_EXACT = {"retained", "retained_bounded", "retained_no_go"}
+
+
+def _rel(path: str) -> str:
+    return os.path.relpath(path, REPO_ROOT)
+
+
+def _iter_ledger_shards():
+    base = os.path.join(REPO_ROOT, LEDGER_DIR)
+    for dirpath, _dirnames, filenames in os.walk(base):
+        for name in sorted(filenames):
+            if name.endswith(".json"):
+                yield os.path.join(dirpath, name)
+
+
+def collect_ledger() -> dict:
+    claim_ids = []
+    histogram: Counter = Counter()
+    missing_note_paths = 0
+    parse_errors = []
+    for shard in _iter_ledger_shards():
+        try:
+            with open(shard, "r", encoding="utf-8") as fh:
+                row = json.load(fh)
+        except (json.JSONDecodeError, OSError) as exc:
+            parse_errors.append(f"{_rel(shard)}: {exc}")
+            continue
+        claim_id = row.get("claim_id") or os.path.splitext(os.path.basename(shard))[0]
+        claim_ids.append(claim_id)
+        histogram[str(row.get("effective_status", "MISSING"))] += 1
+        note_path = row.get("note_path")
+        if note_path and not os.path.exists(os.path.join(REPO_ROOT, note_path)):
+            missing_note_paths += 1
+
+    dupes = sorted(cid for cid, n in Counter(claim_ids).items() if n > 1)
+    ids_sha = hashlib.sha256("\n".join(sorted(claim_ids)).encode()).hexdigest()
+    retained_total = sum(
+        count
+        for status, count in histogram.items()
+        if status in RETAINED_GRADE_EXACT or status.startswith(RETAINED_GRADE_PREFIXES)
+    )
+    return {
+        "shard_count": len(claim_ids) + len(parse_errors),
+        "claim_ids_sha256": ids_sha,
+        "duplicate_claim_ids": dupes,
+        "effective_status_histogram": dict(sorted(histogram.items())),
+        "retained_grade_total": retained_total,
+        "rows_with_missing_note_path": missing_note_paths,
+        "shard_parse_errors": parse_errors,
+    }
+
+
+def collect_premises() -> dict:
+    path = os.path.join(REPO_ROOT, PREMISE_NODES)
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if isinstance(data, dict):
+        nodes = data.get("nodes", data)
+        ids = sorted(nodes.keys()) if isinstance(nodes, dict) else sorted(
+            str(node.get("id", node.get("premise_id", "?"))) for node in nodes
+        )
+    else:
+        ids = sorted(str(node.get("id", node.get("premise_id", "?"))) for node in data)
+    with open(path, "rb") as fh:
+        digest = hashlib.sha256(fh.read()).hexdigest()
+    return {"ids": ids, "file_sha256": digest}
+
+
+def collect_obligations() -> dict:
+    path = os.path.join(REPO_ROOT, OBLIGATIONS)
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    entries = data.get("nodes", data.get("obligations", data)) if isinstance(data, dict) else data
+    if isinstance(entries, dict):
+        ids = sorted(entries.keys())
+    else:
+        ids = sorted(str(entry.get("id", "?")) for entry in entries)
+    return {"ids": ids}
+
+
+def collect_docs() -> dict:
+    docs_dir = os.path.join(REPO_ROOT, "docs")
+    top_level_md = sorted(
+        name for name in os.listdir(docs_dir) if name.endswith(".md")
+    )
+    basenames: Counter = Counter()
+    for dirpath, _dirnames, filenames in os.walk(docs_dir):
+        for name in filenames:
+            if name.endswith(".md"):
+                basenames[name] += 1
+    dupes = sorted(name for name, n in basenames.items() if n > 1)
+    return {"md_count": len(top_level_md), "duplicate_basenames": dupes}
+
+
+def _authority_surface_files() -> list:
+    files = []
+    for entry in AUTHORITY_SURFACE_GLOBS:
+        full = os.path.join(REPO_ROOT, entry)
+        if os.path.isfile(full):
+            files.append(full)
+        elif os.path.isdir(full):
+            for name in sorted(os.listdir(full)):
+                if name.endswith(".md"):
+                    files.append(os.path.join(full, name))
+    return files
+
+
+def _gitignored(paths: list) -> set:
+    """Return the subset of repo-relative paths that are gitignored."""
+    if not paths:
+        return set()
+    proc = subprocess.run(
+        ["git", "-C", REPO_ROOT, "check-ignore", "--stdin"],
+        input="\n".join(paths),
+        capture_output=True,
+        text=True,
+    )
+    # exit 0: some ignored; 1: none ignored; >1: real error
+    if proc.returncode > 1:
+        raise RuntimeError(f"git check-ignore failed: {proc.stderr.strip()}")
+    return set(proc.stdout.splitlines())
+
+
+def collect_authority_links() -> dict:
+    surface_files = _authority_surface_files()
+    candidates = {}  # repo-relative target -> [source files]
+    scanned = 0
+    for path in surface_files:
+        scanned += 1
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+        for match in MD_LINK_RE.finditer(text):
+            target = match.group(1)
+            if "://" in target or target.startswith("mailto:"):
+                continue
+            resolved = os.path.normpath(
+                os.path.join(os.path.dirname(path), target)
+            )
+            if not resolved.startswith(REPO_ROOT + os.sep):
+                continue
+            rel = _rel(resolved)
+            candidates.setdefault(rel, set()).add(_rel(path))
+
+    ignored = _gitignored(sorted(candidates))
+    violations = []
+    for rel in sorted(candidates):
+        missing = not os.path.exists(os.path.join(REPO_ROOT, rel))
+        if rel in ignored or missing:
+            violations.append(
+                {
+                    "target": rel,
+                    "reason": "gitignored" if rel in ignored else "missing",
+                    "sources": sorted(candidates[rel]),
+                }
+            )
+    return {"surfaces_scanned": scanned, "violations": violations}
+
+
+def build_snapshot() -> dict:
+    return {
+        "invariants_version": 1,
+        "ledger": collect_ledger(),
+        "premises": collect_premises(),
+        "obligations": collect_obligations(),
+        "docs": collect_docs(),
+        "authority_links": collect_authority_links(),
+    }
+
+
+def _flatten(prefix: str, value, out: dict):
+    if isinstance(value, dict):
+        for key, sub in value.items():
+            _flatten(f"{prefix}.{key}" if prefix else str(key), sub, out)
+    else:
+        out[prefix] = value
+
+
+def run_diff(path_a: str, path_b: str, allow: set) -> int:
+    with open(path_a, "r", encoding="utf-8") as fh:
+        snap_a = json.load(fh)
+    with open(path_b, "r", encoding="utf-8") as fh:
+        snap_b = json.load(fh)
+    flat_a: dict = {}
+    flat_b: dict = {}
+    _flatten("", snap_a, flat_a)
+    _flatten("", snap_b, flat_b)
+    diffs = []
+    for key in sorted(set(flat_a) | set(flat_b)):
+        if flat_a.get(key) != flat_b.get(key):
+            diffs.append((key, flat_a.get(key), flat_b.get(key)))
+    blocked = []
+    for key, before, after in diffs:
+        allowed = any(key == a or key.startswith(a + ".") for a in allow)
+        marker = "ALLOWED" if allowed else "CHANGED"
+        if not allowed:
+            blocked.append(key)
+        print(f"{marker}: {key}\n    before: {before!r}\n    after:  {after!r}")
+    if not diffs:
+        print("IDENTICAL: snapshots match on every invariant.")
+    if blocked:
+        print(f"\nFAIL: {len(blocked)} undeclared invariant change(s).")
+        return 1
+    print(f"\nOK: {len(diffs)} change(s), all declared via --allow." if diffs else "OK")
+    return 0
+
+
+def run_check(enforce_links: bool) -> int:
+    snapshot = build_snapshot()
+    failures = []
+    warnings = []
+
+    ledger = snapshot["ledger"]
+    if ledger["shard_parse_errors"]:
+        failures.append(f"ledger shard parse errors: {ledger['shard_parse_errors']}")
+    if ledger["duplicate_claim_ids"]:
+        failures.append(f"duplicate claim ids: {ledger['duplicate_claim_ids']}")
+    known_dupes = {"README.md", "SKILL.md"}
+    unexpected = [
+        name for name in snapshot["docs"]["duplicate_basenames"] if name not in known_dupes
+    ]
+    if unexpected:
+        failures.append(f"unexpected duplicate doc basenames: {unexpected}")
+
+    link_violations = snapshot["authority_links"]["violations"]
+    if link_violations:
+        lines = [
+            f"  {item['target']} ({item['reason']}) <- {', '.join(item['sources'])}"
+            for item in link_violations
+        ]
+        message = "authority-surface links to missing/gitignored targets:\n" + "\n".join(lines)
+        if enforce_links:
+            failures.append(message)
+        else:
+            warnings.append(message)
+
+    for warning in warnings:
+        print(f"WARN: {warning}")
+    for failure in failures:
+        print(f"FAIL: {failure}")
+    summary = (
+        f"rows={ledger['shard_count']} retained_grade={ledger['retained_grade_total']} "
+        f"link_violations={len(link_violations)} "
+        f"({'enforced' if enforce_links else 'warn-only'})"
+    )
+    print(("FAIL " if failures else "PASS ") + summary)
+    return 1 if failures else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--snapshot", nargs="?", const="-", metavar="PATH")
+    mode.add_argument("--diff", nargs=2, metavar=("A", "B"))
+    mode.add_argument("--check", action="store_true")
+    parser.add_argument("--allow", default="", help="comma-separated invariant keys allowed to differ in --diff")
+    parser.add_argument("--enforce-links", action="store_true")
+    args = parser.parse_args()
+
+    if args.snapshot is not None:
+        snapshot = build_snapshot()
+        text = json.dumps(snapshot, indent=1, sort_keys=True)
+        if args.snapshot == "-":
+            print(text)
+        else:
+            with open(args.snapshot, "w", encoding="utf-8") as fh:
+                fh.write(text + "\n")
+            print(f"wrote {args.snapshot}")
+        return 0
+    if args.diff:
+        allow = {item.strip() for item in args.allow.split(",") if item.strip()}
+        return run_diff(args.diff[0], args.diff[1], allow)
+    return run_check(args.enforce_links)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/audit/scripts/repo_invariants_check.py
+++ b/docs/audit/scripts/repo_invariants_check.py
@@ -2,41 +2,44 @@
 """Repo-invariants harness: snapshot, diff, and check structural invariants.
 
 Purpose. Landing hygiene/tooling changes safely requires a mechanical
-before/after ruler. This tool measures the repository's structural
-invariants from TRACKED sources only (it never runs the audit pipeline and
-never mutates anything), so any PR can demonstrate "nothing changed except
-what the PR declares."
+before/after ruler. This tool measures a fixed set of structural invariants
+from the repository's GIT-TRACKED state (untracked scratch files do not
+perturb the snapshot), so any PR can demonstrate "none of the measured
+invariants changed except those the PR declares."
 
 Modes
-  --snapshot [PATH]        write a canonical JSON snapshot (default: stdout)
+  --snapshot [PATH]        write a canonical JSON snapshot (default: stdout);
+                           snapshot mode writes only the explicitly requested
+                           output path and refuses tracked repository paths
   --diff A B [--allow k1,k2]
                            compare two snapshots; exit 1 on differences in
-                           fields not named in --allow
+                           fields not named in --allow (dot-segment-bounded)
   --check [--enforce-links]
-                           run absolute integrity checks; broken/gitignored
-                           authority links are WARN by default, errors with
+                           run absolute integrity checks; authority-link
+                           violations are WARN by default, errors with
                            --enforce-links
 
-Invariants measured
-  ledger.shard_count           number of tracked ledger shard JSON files
+Invariants measured (tracked state only)
+  ledger.shard_count           tracked ledger shard JSON files
   ledger.claim_ids_sha256      hash of the sorted claim-id set
   ledger.duplicate_claim_ids   must be empty
   ledger.effective_status_histogram
   ledger.retained_grade_total  retained + retained_bounded + retained_no_go
                                + decoration_under_* rows
-  ledger.rows_with_missing_note_path  informational count
+  ledger.rows_with_missing_note_path  informational count (vs tracked set)
+  ledger.shard_parse_errors    unreadable or schema-invalid shards
   premises.ids                 registered axiom/primitive premise node ids
   obligations.ids              open derivation-obligation ids
-  docs.md_count                markdown files directly under docs/
-  docs.duplicate_basenames     basename collisions across docs/** (row ids
-                               derive from filename stems)
+  docs.md_count                tracked markdown files directly under docs/
+  docs.duplicate_basenames     tracked basename collisions across docs/**
   authority_links.violations   markdown links on authority surfaces whose
-                               target is missing from the working tree or
-                               gitignored (a gitignored target 404s for any
-                               fresh clone or GitHub reader)
+                               target file is not tracked (missing, untracked,
+                               or gitignored — each of which 404s for a fresh
+                               clone or GitHub reader). Code spans and fenced
+                               code blocks are masked before link extraction.
 
-This is a read-only measurement tool. It sets no audit status, writes no
-generated surface, and is not part of verdict minting.
+Repository inputs are read-only; no audit status is set, no generated surface
+is written, no verdict is minted.
 """
 
 from __future__ import annotations
@@ -45,6 +48,7 @@ import argparse
 import hashlib
 import json
 import os
+import posixpath
 import re
 import subprocess
 import sys
@@ -54,128 +58,43 @@ REPO_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..")
 )
 
-LEDGER_DIR = os.path.join("docs", "audit", "data", "ledger")
-PREMISE_NODES = os.path.join("docs", "audit", "data", "axiom_premise_nodes.json")
-OBLIGATIONS = os.path.join("docs", "audit", "data", "derivation_obligations.json")
+LEDGER_PREFIX = "docs/audit/data/ledger/"
+PREMISE_NODES = "docs/audit/data/axiom_premise_nodes.json"
+OBLIGATIONS = "docs/audit/data/derivation_obligations.json"
 
 # Authority surfaces: the reading path an external reader or agent follows.
-AUTHORITY_SURFACE_GLOBS = [
+AUTHORITY_SURFACES = (
     "README.md",
-    os.path.join("docs", "repo"),
-    os.path.join("docs", "publication", "ci3_z3"),
-    os.path.join("docs", "audit"),
-    os.path.join("docs", "lanes", "README.md"),
-    os.path.join("docs", "lanes", "open_science", "README.md"),
-]
+    "docs/repo/",
+    "docs/publication/ci3_z3/",
+    "docs/audit/",
+    "docs/lanes/README.md",
+    "docs/lanes/open_science/README.md",
+)
 
-MD_LINK_RE = re.compile(r"\]\(([^)#\s]+)(?:#[^)\s]*)?\)")
+# Inline-link destination: angle-bracket form (may contain spaces) or bare
+# form, each with an optional "title".
+MD_LINK_RE = re.compile(
+    r"\]\(\s*(?:<([^<>)]+)>|([^)<>\s]+?))(?:\s+\"[^\"]*\")?\s*\)"
+)
+FENCED_CODE_RE = re.compile(r"^(```|~~~).*?^\1[^\S\n]*$", re.DOTALL | re.MULTILINE)
+INLINE_CODE_RE = re.compile(r"(`+)(?!`)[^`]*?(?<!`)\1(?!`)", re.DOTALL)
 
 RETAINED_GRADE_PREFIXES = ("decoration_under_",)
 RETAINED_GRADE_EXACT = {"retained", "retained_bounded", "retained_no_go"}
 
-
-def _rel(path: str) -> str:
-    return os.path.relpath(path, REPO_ROOT)
+_MISSING = object()
 
 
-def _iter_ledger_shards():
-    base = os.path.join(REPO_ROOT, LEDGER_DIR)
-    for dirpath, _dirnames, filenames in os.walk(base):
-        for name in sorted(filenames):
-            if name.endswith(".json"):
-                yield os.path.join(dirpath, name)
-
-
-def collect_ledger() -> dict:
-    claim_ids = []
-    histogram: Counter = Counter()
-    missing_note_paths = 0
-    parse_errors = []
-    for shard in _iter_ledger_shards():
-        try:
-            with open(shard, "r", encoding="utf-8") as fh:
-                row = json.load(fh)
-        except (json.JSONDecodeError, OSError) as exc:
-            parse_errors.append(f"{_rel(shard)}: {exc}")
-            continue
-        claim_id = row.get("claim_id") or os.path.splitext(os.path.basename(shard))[0]
-        claim_ids.append(claim_id)
-        histogram[str(row.get("effective_status", "MISSING"))] += 1
-        note_path = row.get("note_path")
-        if note_path and not os.path.exists(os.path.join(REPO_ROOT, note_path)):
-            missing_note_paths += 1
-
-    dupes = sorted(cid for cid, n in Counter(claim_ids).items() if n > 1)
-    ids_sha = hashlib.sha256("\n".join(sorted(claim_ids)).encode()).hexdigest()
-    retained_total = sum(
-        count
-        for status, count in histogram.items()
-        if status in RETAINED_GRADE_EXACT or status.startswith(RETAINED_GRADE_PREFIXES)
+def _git_tracked_files() -> list:
+    proc = subprocess.run(
+        ["git", "-C", REPO_ROOT, "ls-files", "-z"],
+        capture_output=True,
+        text=True,
     )
-    return {
-        "shard_count": len(claim_ids) + len(parse_errors),
-        "claim_ids_sha256": ids_sha,
-        "duplicate_claim_ids": dupes,
-        "effective_status_histogram": dict(sorted(histogram.items())),
-        "retained_grade_total": retained_total,
-        "rows_with_missing_note_path": missing_note_paths,
-        "shard_parse_errors": parse_errors,
-    }
-
-
-def collect_premises() -> dict:
-    path = os.path.join(REPO_ROOT, PREMISE_NODES)
-    with open(path, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
-    if isinstance(data, dict):
-        nodes = data.get("nodes", data)
-        ids = sorted(nodes.keys()) if isinstance(nodes, dict) else sorted(
-            str(node.get("id", node.get("premise_id", "?"))) for node in nodes
-        )
-    else:
-        ids = sorted(str(node.get("id", node.get("premise_id", "?"))) for node in data)
-    with open(path, "rb") as fh:
-        digest = hashlib.sha256(fh.read()).hexdigest()
-    return {"ids": ids, "file_sha256": digest}
-
-
-def collect_obligations() -> dict:
-    path = os.path.join(REPO_ROOT, OBLIGATIONS)
-    with open(path, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
-    entries = data.get("nodes", data.get("obligations", data)) if isinstance(data, dict) else data
-    if isinstance(entries, dict):
-        ids = sorted(entries.keys())
-    else:
-        ids = sorted(str(entry.get("id", "?")) for entry in entries)
-    return {"ids": ids}
-
-
-def collect_docs() -> dict:
-    docs_dir = os.path.join(REPO_ROOT, "docs")
-    top_level_md = sorted(
-        name for name in os.listdir(docs_dir) if name.endswith(".md")
-    )
-    basenames: Counter = Counter()
-    for dirpath, _dirnames, filenames in os.walk(docs_dir):
-        for name in filenames:
-            if name.endswith(".md"):
-                basenames[name] += 1
-    dupes = sorted(name for name, n in basenames.items() if n > 1)
-    return {"md_count": len(top_level_md), "duplicate_basenames": dupes}
-
-
-def _authority_surface_files() -> list:
-    files = []
-    for entry in AUTHORITY_SURFACE_GLOBS:
-        full = os.path.join(REPO_ROOT, entry)
-        if os.path.isfile(full):
-            files.append(full)
-        elif os.path.isdir(full):
-            for name in sorted(os.listdir(full)):
-                if name.endswith(".md"):
-                    files.append(os.path.join(full, name))
-    return files
+    if proc.returncode != 0:
+        raise RuntimeError(f"git ls-files failed: {proc.stderr.strip()}")
+    return sorted(p for p in proc.stdout.split("\0") if p)
 
 
 def _gitignored(paths: list) -> set:
@@ -194,54 +113,191 @@ def _gitignored(paths: list) -> set:
     return set(proc.stdout.splitlines())
 
 
-def collect_authority_links() -> dict:
-    surface_files = _authority_surface_files()
-    candidates = {}  # repo-relative target -> [source files]
-    scanned = 0
-    for path in surface_files:
-        scanned += 1
-        with open(path, "r", encoding="utf-8", errors="replace") as fh:
-            text = fh.read()
-        for match in MD_LINK_RE.finditer(text):
-            target = match.group(1)
-            if "://" in target or target.startswith("mailto:"):
-                continue
-            resolved = os.path.normpath(
-                os.path.join(os.path.dirname(path), target)
+def mask_code(text: str) -> str:
+    """Blank out fenced code blocks and inline code spans (length-preserving
+    is unnecessary; links inside code are documentation examples, not links)."""
+    text = FENCED_CODE_RE.sub(" ", text)
+    return INLINE_CODE_RE.sub(" ", text)
+
+
+def scan_markdown_link_targets(text: str) -> list:
+    """Extract inline-link destinations from markdown text, ignoring code
+    spans/fences, external URLs, and non-path-shaped destinations."""
+    targets = []
+    for match in MD_LINK_RE.finditer(mask_code(text)):
+        target = match.group(1) or match.group(2)
+        if "://" in target or target.startswith("mailto:"):
+            continue
+        # Path-shaped only: a slash or a dotted final component. This drops
+        # prose artifacts like "(h,h)" while keeping OTHER.md-style examples
+        # that survive outside code spans.
+        last = target.rstrip("/").rsplit("/", 1)[-1]
+        if "/" not in target and "." not in last:
+            continue
+        targets.append(target)
+    return targets
+
+
+def collect_ledger(tracked: list) -> dict:
+    shard_paths = [p for p in tracked if p.startswith(LEDGER_PREFIX) and p.endswith(".json")]
+    tracked_set = set(tracked)
+    claim_ids = []
+    histogram: Counter = Counter()
+    missing_note_paths = 0
+    parse_errors = []
+    for shard in shard_paths:
+        try:
+            with open(os.path.join(REPO_ROOT, shard), "r", encoding="utf-8") as fh:
+                row = json.load(fh)
+        except (json.JSONDecodeError, OSError) as exc:
+            parse_errors.append(f"{shard}: {exc}")
+            continue
+        if not isinstance(row, dict):
+            parse_errors.append(f"{shard}: shard is not a JSON object")
+            continue
+        claim_id = row.get("claim_id")
+        if not isinstance(claim_id, str) or not claim_id:
+            fallback = os.path.splitext(os.path.basename(shard))[0]
+            parse_errors.append(f"{shard}: missing/non-string claim_id (filename stem {fallback!r})")
+            claim_id = fallback
+        claim_ids.append(claim_id)
+        status = row.get("effective_status")
+        histogram[status if isinstance(status, str) else "MISSING"] += 1
+        note_path = row.get("note_path")
+        if isinstance(note_path, str) and note_path and note_path not in tracked_set:
+            missing_note_paths += 1
+        elif note_path is not None and not isinstance(note_path, str):
+            parse_errors.append(f"{shard}: non-string note_path")
+
+    dupes = sorted(cid for cid, n in Counter(claim_ids).items() if n > 1)
+    ids_sha = hashlib.sha256("\n".join(sorted(claim_ids)).encode()).hexdigest()
+    retained_total = sum(
+        count
+        for status, count in histogram.items()
+        if status in RETAINED_GRADE_EXACT or status.startswith(RETAINED_GRADE_PREFIXES)
+    )
+    return {
+        "shard_count": len(shard_paths),
+        "claim_ids_sha256": ids_sha,
+        "duplicate_claim_ids": dupes,
+        "effective_status_histogram": dict(sorted(histogram.items())),
+        "retained_grade_total": retained_total,
+        "rows_with_missing_note_path": missing_note_paths,
+        "shard_parse_errors": sorted(parse_errors),
+    }
+
+
+def _load_ids(rel_path: str, container_keys: tuple) -> dict:
+    path = os.path.join(REPO_ROOT, rel_path)
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    entries = data
+    if isinstance(data, dict):
+        for key in container_keys:
+            if isinstance(data.get(key), (dict, list)):
+                entries = data[key]
+                break
+    if isinstance(entries, dict):
+        ids = sorted(entries.keys())
+    elif isinstance(entries, list):
+        ids = sorted(str(entry.get("id", "?")) for entry in entries if isinstance(entry, dict))
+    else:
+        ids = []
+    with open(path, "rb") as fh:
+        digest = hashlib.sha256(fh.read()).hexdigest()
+    return {"ids": ids, "file_sha256": digest}
+
+
+def collect_docs(tracked: list) -> dict:
+    top_level = [
+        p for p in tracked
+        if p.startswith("docs/") and p.endswith(".md") and p.count("/") == 1
+    ]
+    basenames: Counter = Counter()
+    for p in tracked:
+        if p.startswith("docs/") and p.endswith(".md"):
+            basenames[posixpath.basename(p)] += 1
+    dupes = sorted(name for name, n in basenames.items() if n > 1)
+    return {"md_count": len(top_level), "duplicate_basenames": dupes}
+
+
+def _authority_surface_files(tracked: list) -> list:
+    files = []
+    for entry in AUTHORITY_SURFACES:
+        if entry.endswith("/"):
+            files.extend(
+                p for p in tracked
+                if p.startswith(entry) and p.endswith(".md") and p.count("/") == entry.count("/")
             )
-            if not resolved.startswith(REPO_ROOT + os.sep):
+        elif entry in set(tracked):
+            files.append(entry)
+    return sorted(set(files))
+
+
+def collect_authority_links(tracked: list) -> dict:
+    tracked_set = set(tracked)
+    tracked_dirs = set()
+    for p in tracked:
+        d = posixpath.dirname(p)
+        while d:
+            tracked_dirs.add(d)
+            d = posixpath.dirname(d)
+
+    surface_files = _authority_surface_files(tracked)
+    candidates = {}  # repo-relative target -> set of source files
+    absolutes = {}  # machine-local absolute target -> set of source files
+    for rel in surface_files:
+        with open(os.path.join(REPO_ROOT, rel), "r", encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+        for target in scan_markdown_link_targets(text):
+            if target.startswith("/"):
+                # A machine-local absolute path can never resolve for another
+                # reader; report it, and never hand it to git check-ignore.
+                absolutes.setdefault(target, set()).add(rel)
                 continue
-            rel = _rel(resolved)
-            candidates.setdefault(rel, set()).add(_rel(path))
+            resolved = posixpath.normpath(posixpath.join(posixpath.dirname(rel), target))
+            if resolved.startswith(".."):
+                continue
+            candidates.setdefault(resolved, set()).add(rel)
 
     ignored = _gitignored(sorted(candidates))
-    violations = []
+    violations = [
+        {"target": target, "reason": "absolute-path", "sources": sorted(sources)}
+        for target, sources in sorted(absolutes.items())
+    ]
     for rel in sorted(candidates):
-        missing = not os.path.exists(os.path.join(REPO_ROOT, rel))
-        if rel in ignored or missing:
-            violations.append(
-                {
-                    "target": rel,
-                    "reason": "gitignored" if rel in ignored else "missing",
-                    "sources": sorted(candidates[rel]),
-                }
-            )
-    return {"surfaces_scanned": scanned, "violations": violations}
+        is_dir_link = rel.rstrip("/") in tracked_dirs
+        if rel in tracked_set or is_dir_link:
+            continue
+        if rel in ignored:
+            reason = "gitignored"
+        elif os.path.exists(os.path.join(REPO_ROOT, rel)):
+            reason = "untracked"
+        else:
+            reason = "missing"
+        violations.append(
+            {"target": rel, "reason": reason, "sources": sorted(candidates[rel])}
+        )
+    return {"surfaces_scanned": len(surface_files), "violations": violations}
 
 
 def build_snapshot() -> dict:
+    tracked = _git_tracked_files()
     return {
-        "invariants_version": 1,
-        "ledger": collect_ledger(),
-        "premises": collect_premises(),
-        "obligations": collect_obligations(),
-        "docs": collect_docs(),
-        "authority_links": collect_authority_links(),
+        "invariants_version": 2,
+        "ledger": collect_ledger(tracked),
+        "premises": _load_ids(PREMISE_NODES, ("nodes",)),
+        "obligations": _load_ids(OBLIGATIONS, ("nodes", "obligations")),
+        "docs": collect_docs(tracked),
+        "authority_links": collect_authority_links(tracked),
     }
 
 
 def _flatten(prefix: str, value, out: dict):
     if isinstance(value, dict):
+        if not value:
+            out[prefix + ".<empty-object>" if prefix else "<empty-object>"] = True
+            return
         for key, sub in value.items():
             _flatten(f"{prefix}.{key}" if prefix else str(key), sub, out)
     else:
@@ -259,17 +315,28 @@ def run_diff(path_a: str, path_b: str, allow: set) -> int:
     _flatten("", snap_b, flat_b)
     diffs = []
     for key in sorted(set(flat_a) | set(flat_b)):
-        if flat_a.get(key) != flat_b.get(key):
-            diffs.append((key, flat_a.get(key), flat_b.get(key)))
+        before = flat_a.get(key, _MISSING)
+        after = flat_b.get(key, _MISSING)
+        if before is _MISSING and after is _MISSING:
+            continue
+        if before is not _MISSING and after is not _MISSING and before == after:
+            continue
+        diffs.append(
+            (
+                key,
+                "<absent>" if before is _MISSING else repr(before),
+                "<absent>" if after is _MISSING else repr(after),
+            )
+        )
     blocked = []
     for key, before, after in diffs:
         allowed = any(key == a or key.startswith(a + ".") for a in allow)
         marker = "ALLOWED" if allowed else "CHANGED"
         if not allowed:
             blocked.append(key)
-        print(f"{marker}: {key}\n    before: {before!r}\n    after:  {after!r}")
+        print(f"{marker}: {key}\n    before: {before}\n    after:  {after}")
     if not diffs:
-        print("IDENTICAL: snapshots match on every invariant.")
+        print("IDENTICAL: snapshots match on every measured invariant.")
     if blocked:
         print(f"\nFAIL: {len(blocked)} undeclared invariant change(s).")
         return 1
@@ -284,7 +351,7 @@ def run_check(enforce_links: bool) -> int:
 
     ledger = snapshot["ledger"]
     if ledger["shard_parse_errors"]:
-        failures.append(f"ledger shard parse errors: {ledger['shard_parse_errors']}")
+        failures.append(f"ledger shard parse/schema errors: {ledger['shard_parse_errors']}")
     if ledger["duplicate_claim_ids"]:
         failures.append(f"duplicate claim ids: {ledger['duplicate_claim_ids']}")
     known_dupes = {"README.md", "SKILL.md"}
@@ -300,7 +367,7 @@ def run_check(enforce_links: bool) -> int:
             f"  {item['target']} ({item['reason']}) <- {', '.join(item['sources'])}"
             for item in link_violations
         ]
-        message = "authority-surface links to missing/gitignored targets:\n" + "\n".join(lines)
+        message = "authority-surface links to untracked targets:\n" + "\n".join(lines)
         if enforce_links:
             failures.append(message)
         else:
@@ -330,6 +397,11 @@ def main() -> int:
     args = parser.parse_args()
 
     if args.snapshot is not None:
+        if args.snapshot != "-":
+            requested = os.path.relpath(os.path.abspath(args.snapshot), REPO_ROOT)
+            if not requested.startswith("..") and requested in set(_git_tracked_files()):
+                print(f"refusing to overwrite tracked repository path: {requested}")
+                return 2
         snapshot = build_snapshot()
         text = json.dumps(snapshot, indent=1, sort_keys=True)
         if args.snapshot == "-":

--- a/docs/audit/scripts/repo_invariants_check.py
+++ b/docs/audit/scripts/repo_invariants_check.py
@@ -29,7 +29,9 @@ Invariants measured (tracked state only)
   ledger.rows_with_missing_note_path  informational count (vs tracked set)
   ledger.shard_parse_errors    unreadable or schema-invalid shards
   premises.ids                 registered axiom/primitive premise node ids
+  premises.file_sha256 / premises.tracked      registry digest + tracked flag
   obligations.ids              open derivation-obligation ids
+  obligations.file_sha256 / obligations.tracked  registry digest + tracked flag
   docs.md_count                tracked markdown files directly under docs/
   docs.duplicate_basenames     tracked basename collisions across docs/**
   authority_links.violations   markdown links on authority surfaces whose
@@ -76,6 +78,11 @@ AUTHORITY_SURFACES = (
 RETAINED_GRADE_PREFIXES = ("decoration_under_",)
 RETAINED_GRADE_EXACT = {"retained", "retained_bounded", "retained_no_go"}
 
+# The controlled effective-status enum is owned by audit_lint; reuse it so the
+# two tools cannot drift (BUG-17).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from audit_lint import ALLOWED_EFFECTIVE_STATUSES  # noqa: E402
+
 _MISSING = object()
 
 
@@ -113,8 +120,15 @@ def mask_code(text: str) -> str:
             out_lines.append("")
     masked = "\n".join(out_lines)
 
-    # backtick-run code spans on the fence-masked text
-    runs = [(m.start(), len(m.group(0))) for m in re.finditer(r"`+", masked)]
+    # backtick-run code spans on the fence-masked text; a backslash-escaped
+    # backtick is a literal, so it shortens (or removes) its run (BUG-11)
+    runs = []
+    for m in re.finditer(r"`+", masked):
+        start, length = m.start(), len(m.group(0))
+        if not _unescaped(masked, start):
+            start, length = start + 1, length - 1
+        if length > 0:
+            runs.append((start, length))
     spans = []
     i = 0
     while i < len(runs):
@@ -188,27 +202,33 @@ def _finish_after_dest(text: str, pos: int, dest: str):
         while pos < n and text[pos] in " \t\n":
             pos += 1
     if pos < n and text[pos] == ")":
-        dest = re.sub(r"\\(.)", r"\1", dest)
+        # CommonMark backslash escapes apply to ASCII punctuation only; a
+        # backslash before anything else (e.g. C:\Users) is literal (BUG-12).
+        dest = re.sub(r"\\([!-/:-@\[-`{-~])", r"\1", dest)
         return dest, pos + 1
     return None
 
 
 def classify_target(dest: str) -> str:
-    """Classify a raw link destination: 'skip' (external URL / mailto /
-    scheme-relative / not path-shaped), 'absolute' (machine-local absolute
+    """Classify a raw link destination: 'skip' (external URI, mailto,
+    scheme-relative, or a prose artifact), 'absolute' (machine-local absolute
     path incl. file: scheme and drive letters), or 'relative'."""
     if dest.startswith("//"):
         return "skip"  # protocol-relative URL, not a filesystem path
     lower = dest.lower()
     if lower.startswith("file:"):
         return "absolute"
-    if "://" in dest or lower.startswith("mailto:"):
-        return "skip"
     if dest.startswith("/") or re.match(r"[A-Za-z]:[/\\]", dest):
-        return "absolute"
+        return "absolute"  # single-letter drive checked before URI schemes
+    if re.match(r"[A-Za-z][A-Za-z0-9+.-]+:", dest):
+        return "skip"  # any other URI scheme (https, mailto, doi, ...)
     stripped = dest.split("#", 1)[0].split("?", 1)[0]
-    last = stripped.rstrip("/").rsplit("/", 1)[-1]
-    if "/" not in stripped and "." not in last:
+    if not stripped:
+        return "skip"  # pure fragment/query
+    # Prose-artifact heuristic: repo paths (with or without an extension —
+    # LICENSE is a valid reader path) do not contain commas; expressions like
+    # "(h,h)" outside code spans do.
+    if "," in stripped:
         return "skip"
     return "relative"
 
@@ -287,18 +307,24 @@ def collect_ledger(tracked: list) -> dict:
             parse_errors.append(f"{shard}: shard is not a JSON object")
             continue
         claim_id = row.get("claim_id")
+        stem = os.path.splitext(os.path.basename(shard))[0]
         if not isinstance(claim_id, str) or not claim_id:
-            fallback = os.path.splitext(os.path.basename(shard))[0]
-            parse_errors.append(f"{shard}: missing/non-string claim_id (filename stem {fallback!r})")
-            claim_id = fallback
+            parse_errors.append(f"{shard}: missing/non-string claim_id (filename stem {stem!r})")
+            claim_id = stem
+        elif claim_id != stem:
+            # Canonical shard identity (ledger_io): claim_id must match the
+            # shard filename stem (BUG-17).
+            parse_errors.append(f"{shard}: claim_id {claim_id!r} != filename stem {stem!r}")
         claim_ids.append(claim_id)
         status = row.get("effective_status")
         if status is None:
             histogram["MISSING"] += 1
-        elif isinstance(status, str):
+        elif isinstance(status, str) and (
+            status in ALLOWED_EFFECTIVE_STATUSES or status.startswith("decoration_under_")
+        ):
             histogram[status] += 1
         else:
-            parse_errors.append(f"{shard}: non-string effective_status")
+            parse_errors.append(f"{shard}: effective_status {status!r} not in controlled set")
             histogram["SCHEMA_INVALID"] += 1
         note_path = row.get("note_path")
         if isinstance(note_path, str) and note_path and note_path not in tracked_set:
@@ -385,6 +411,7 @@ def collect_authority_links(tracked: list) -> dict:
     surface_files = _authority_surface_files(tracked)
     candidates = {}  # repo-relative target -> set of source files
     absolutes = {}  # machine-local absolute target -> set of source files
+    outsiders = {}  # ../-escaping target -> set of source files
     for rel in surface_files:
         with open(os.path.join(REPO_ROOT, rel), "r", encoding="utf-8", errors="replace") as fh:
             text = fh.read()
@@ -402,7 +429,9 @@ def collect_authority_links(tracked: list) -> dict:
             if not cleaned:
                 continue
             resolved = posixpath.normpath(posixpath.join(posixpath.dirname(rel), cleaned))
-            if resolved.startswith(".."):
+            if resolved == ".." or resolved.startswith("../"):
+                # Cannot resolve inside a fresh clone: report, never skip.
+                outsiders.setdefault(target, set()).add(rel)
                 continue
             candidates.setdefault(resolved, set()).add(rel)
 
@@ -410,17 +439,18 @@ def collect_authority_links(tracked: list) -> dict:
     violations = [
         {"target": target, "reason": "absolute-path", "sources": sorted(sources)}
         for target, sources in sorted(absolutes.items())
+    ] + [
+        {"target": target, "reason": "outside-repository", "sources": sorted(sources)}
+        for target, sources in sorted(outsiders.items())
     ]
     for rel in sorted(candidates):
         is_dir_link = rel.rstrip("/") in tracked_dirs
         if rel in tracked_set or is_dir_link:
             continue
-        if rel in ignored:
-            reason = "gitignored"
-        elif os.path.exists(os.path.join(REPO_ROOT, rel)):
-            reason = "untracked"
-        else:
-            reason = "missing"
+        # Reasons derive from git metadata ONLY (tracked set + ignore rules),
+        # so two worktrees at the same commit always produce identical
+        # snapshots regardless of untracked scratch files (BUG-16).
+        reason = "gitignored" if rel in ignored else "not-tracked"
         violations.append(
             {"target": rel, "reason": reason, "sources": sorted(candidates[rel])}
         )
@@ -456,9 +486,15 @@ def _diff_json(a, b, path=()):
                 a.get(key, _MISSING), b.get(key, _MISSING), path + (str(key),)
             )
         return
-    if a is _MISSING and b is _MISSING:
+    if isinstance(a, list) and isinstance(b, list):
+        for i in range(max(len(a), len(b))):
+            yield from _diff_json(
+                a[i] if i < len(a) else _MISSING,
+                b[i] if i < len(b) else _MISSING,
+                path + (str(i),),
+            )
         return
-    if type(a) is type(b) and isinstance(a, (dict, list)) and _json_equal(a, b):
+    if a is _MISSING and b is _MISSING:
         return
     if not isinstance(a, (dict, list)) and not isinstance(b, (dict, list)):
         if a is not _MISSING and b is not _MISSING and _json_equal(a, b):
@@ -549,14 +585,21 @@ def main() -> int:
 
     if args.snapshot is not None:
         if args.snapshot != "-":
+            # Snapshots are scratch artifacts: refuse ANY destination inside
+            # the repository (kills every alias/traversal overwrite class:
+            # symlinks, case folds, unicode normalization, ..-prefixed
+            # basenames), and refuse multi-linked existing files anywhere (a
+            # hard link outside the repo can alias a tracked inode).
             resolved = os.path.realpath(os.path.abspath(args.snapshot))
-            requested = os.path.relpath(resolved, os.path.realpath(REPO_ROOT))
-            requested = requested.replace(os.sep, "/")
-            if not requested.startswith(".."):
-                tracked_fold = {t.casefold() for t in _git_tracked_files()}
-                if requested.casefold() in tracked_fold:
-                    print(f"refusing to overwrite tracked repository path: {requested}")
-                    return 2
+            repo_real = os.path.realpath(REPO_ROOT)
+            if os.path.commonpath([resolved, repo_real]) == repo_real:
+                print("refusing to write a snapshot inside the repository; "
+                      "use a scratch directory or '-' for stdout")
+                return 2
+            if os.path.exists(resolved) and os.stat(resolved).st_nlink > 1:
+                print("refusing to overwrite a multi-linked file (possible "
+                      "hard-link alias of a repository path)")
+                return 2
         snapshot = build_snapshot()
         text = json.dumps(snapshot, indent=1, sort_keys=True)
         if args.snapshot == "-":

--- a/docs/audit/scripts/repo_invariants_check.py
+++ b/docs/audit/scripts/repo_invariants_check.py
@@ -52,6 +52,7 @@ import posixpath
 import re
 import subprocess
 import sys
+import urllib.parse
 from collections import Counter
 
 REPO_ROOT = os.path.abspath(
@@ -72,18 +73,173 @@ AUTHORITY_SURFACES = (
     "docs/lanes/open_science/README.md",
 )
 
-# Inline-link destination: angle-bracket form (may contain spaces) or bare
-# form, each with an optional "title".
-MD_LINK_RE = re.compile(
-    r"\]\(\s*(?:<([^<>)]+)>|([^)<>\s]+?))(?:\s+\"[^\"]*\")?\s*\)"
-)
-FENCED_CODE_RE = re.compile(r"^(```|~~~).*?^\1[^\S\n]*$", re.DOTALL | re.MULTILINE)
-INLINE_CODE_RE = re.compile(r"(`+)(?!`)[^`]*?(?<!`)\1(?!`)", re.DOTALL)
-
 RETAINED_GRADE_PREFIXES = ("decoration_under_",)
 RETAINED_GRADE_EXACT = {"retained", "retained_bounded", "retained_no_go"}
 
 _MISSING = object()
+
+
+# --- markdown scanning -------------------------------------------------------
+# Scope claim: this is a conservative reader-path scanner for the authority
+# surfaces, implemented as a line/character scan of the CommonMark constructs
+# those surfaces actually use (fenced code blocks incl. longer/indented/tilde
+# fences and unclosed fences, backtick-run code spans, inline links with
+# angle-bracket or balanced-paren destinations and ', ", ( titles, escaped
+# openers, fragments/queries). It is not a full CommonMark parser.
+
+_FENCE_OPEN_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
+
+
+def mask_code(text: str) -> str:
+    """Blank out fenced code blocks (CommonMark 4.5: >=3 markers, <=3-space
+    indent, closer at least as long, unclosed runs to end) and backtick-run
+    code spans (CommonMark 6.1: closed by the next run of EQUAL length)."""
+    out_lines = []
+    fence_char, fence_len = None, 0
+    for line in text.split("\n"):
+        if fence_char is None:
+            m = _FENCE_OPEN_RE.match(line)
+            if m:
+                fence_char, fence_len = m.group(1)[0], len(m.group(1))
+                out_lines.append("")
+                continue
+            out_lines.append(line)
+        else:
+            stripped = line.strip()
+            if (stripped and set(stripped) == {fence_char}
+                    and len(stripped) >= fence_len
+                    and len(line) - len(line.lstrip()) <= 3):
+                fence_char = None
+            out_lines.append("")
+    masked = "\n".join(out_lines)
+
+    # backtick-run code spans on the fence-masked text
+    runs = [(m.start(), len(m.group(0))) for m in re.finditer(r"`+", masked)]
+    spans = []
+    i = 0
+    while i < len(runs):
+        start, length = runs[i]
+        for j in range(i + 1, len(runs)):
+            if runs[j][1] == length:
+                spans.append((start, runs[j][0] + runs[j][1]))
+                i = j
+                break
+        i += 1
+    chars = list(masked)
+    for a, b in spans:
+        for k in range(a, b):
+            if chars[k] != "\n":
+                chars[k] = " "
+    return "".join(chars)
+
+
+def _unescaped(text: str, idx: int) -> bool:
+    backslashes = 0
+    j = idx - 1
+    while j >= 0 and text[j] == "\\":
+        backslashes += 1
+        j -= 1
+    return backslashes % 2 == 0
+
+
+def _parse_destination(text: str, pos: int):
+    """Parse a CommonMark inline-link destination starting just after '('.
+    Returns (destination, index-after-closing-paren) or None."""
+    n = len(text)
+    while pos < n and text[pos] in " \t":
+        pos += 1
+    if pos < n and text[pos] == "<":
+        end = pos + 1
+        while end < n and text[end] != "\n":
+            if text[end] == ">" and _unescaped(text, end):
+                dest = text[pos + 1:end]
+                return _finish_after_dest(text, end + 1, dest)
+            end += 1
+        return None
+    depth = 0
+    end = pos
+    while end < n:
+        ch = text[end]
+        if ch in " \t\n":
+            break
+        if ch == "(" and _unescaped(text, end):
+            depth += 1
+        elif ch == ")" and _unescaped(text, end):
+            if depth == 0:
+                break
+            depth -= 1
+        end += 1
+    dest = text[pos:end]
+    if not dest:
+        return None
+    return _finish_after_dest(text, end, dest)
+
+
+def _finish_after_dest(text: str, pos: int, dest: str):
+    n = len(text)
+    while pos < n and text[pos] in " \t\n":
+        pos += 1
+    if pos < n and text[pos] in "\"'(":
+        closer = {"(": ")"}.get(text[pos], text[pos])
+        pos += 1
+        while pos < n and not (text[pos] == closer and _unescaped(text, pos)):
+            pos += 1
+        pos += 1
+        while pos < n and text[pos] in " \t\n":
+            pos += 1
+    if pos < n and text[pos] == ")":
+        dest = re.sub(r"\\(.)", r"\1", dest)
+        return dest, pos + 1
+    return None
+
+
+def classify_target(dest: str) -> str:
+    """Classify a raw link destination: 'skip' (external URL / mailto /
+    scheme-relative / not path-shaped), 'absolute' (machine-local absolute
+    path incl. file: scheme and drive letters), or 'relative'."""
+    if dest.startswith("//"):
+        return "skip"  # protocol-relative URL, not a filesystem path
+    lower = dest.lower()
+    if lower.startswith("file:"):
+        return "absolute"
+    if "://" in dest or lower.startswith("mailto:"):
+        return "skip"
+    if dest.startswith("/") or re.match(r"[A-Za-z]:[/\\]", dest):
+        return "absolute"
+    stripped = dest.split("#", 1)[0].split("?", 1)[0]
+    last = stripped.rstrip("/").rsplit("/", 1)[-1]
+    if "/" not in stripped and "." not in last:
+        return "skip"
+    return "relative"
+
+
+def strip_fragment_query(dest: str) -> str:
+    return dest.split("#", 1)[0].split("?", 1)[0]
+
+
+def scan_markdown_link_targets(text: str) -> list:
+    """Extract inline-link destinations (raw, fragment/query intact) from
+    markdown text, ignoring code spans/fences and escaped link openers."""
+    masked = mask_code(text)
+    targets = []
+    bracket_stack = []
+    i = 0
+    n = len(masked)
+    while i < n:
+        ch = masked[i]
+        if ch == "[" and _unescaped(masked, i):
+            bracket_stack.append(i)
+        elif ch == "]" and _unescaped(masked, i):
+            opener = bracket_stack.pop() if bracket_stack else None
+            if opener is not None and i + 1 < n and masked[i + 1] == "(":
+                parsed = _parse_destination(masked, i + 2)
+                if parsed:
+                    targets.append(parsed[0])
+                    i = parsed[1]
+                    continue
+        i += 1
+    return targets
+
 
 
 def _git_tracked_files() -> list:
@@ -113,31 +269,6 @@ def _gitignored(paths: list) -> set:
     return set(proc.stdout.splitlines())
 
 
-def mask_code(text: str) -> str:
-    """Blank out fenced code blocks and inline code spans (length-preserving
-    is unnecessary; links inside code are documentation examples, not links)."""
-    text = FENCED_CODE_RE.sub(" ", text)
-    return INLINE_CODE_RE.sub(" ", text)
-
-
-def scan_markdown_link_targets(text: str) -> list:
-    """Extract inline-link destinations from markdown text, ignoring code
-    spans/fences, external URLs, and non-path-shaped destinations."""
-    targets = []
-    for match in MD_LINK_RE.finditer(mask_code(text)):
-        target = match.group(1) or match.group(2)
-        if "://" in target or target.startswith("mailto:"):
-            continue
-        # Path-shaped only: a slash or a dotted final component. This drops
-        # prose artifacts like "(h,h)" while keeping OTHER.md-style examples
-        # that survive outside code spans.
-        last = target.rstrip("/").rsplit("/", 1)[-1]
-        if "/" not in target and "." not in last:
-            continue
-        targets.append(target)
-    return targets
-
-
 def collect_ledger(tracked: list) -> dict:
     shard_paths = [p for p in tracked if p.startswith(LEDGER_PREFIX) and p.endswith(".json")]
     tracked_set = set(tracked)
@@ -149,7 +280,7 @@ def collect_ledger(tracked: list) -> dict:
         try:
             with open(os.path.join(REPO_ROOT, shard), "r", encoding="utf-8") as fh:
                 row = json.load(fh)
-        except (json.JSONDecodeError, OSError) as exc:
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
             parse_errors.append(f"{shard}: {exc}")
             continue
         if not isinstance(row, dict):
@@ -162,7 +293,13 @@ def collect_ledger(tracked: list) -> dict:
             claim_id = fallback
         claim_ids.append(claim_id)
         status = row.get("effective_status")
-        histogram[status if isinstance(status, str) else "MISSING"] += 1
+        if status is None:
+            histogram["MISSING"] += 1
+        elif isinstance(status, str):
+            histogram[status] += 1
+        else:
+            parse_errors.append(f"{shard}: non-string effective_status")
+            histogram["SCHEMA_INVALID"] += 1
         note_path = row.get("note_path")
         if isinstance(note_path, str) and note_path and note_path not in tracked_set:
             missing_note_paths += 1
@@ -187,7 +324,9 @@ def collect_ledger(tracked: list) -> dict:
     }
 
 
-def _load_ids(rel_path: str, container_keys: tuple) -> dict:
+def _load_ids(rel_path: str, container_keys: tuple, tracked_set: set) -> dict:
+    if rel_path not in tracked_set:
+        return {"ids": [], "file_sha256": None, "tracked": False}
     path = os.path.join(REPO_ROOT, rel_path)
     with open(path, "r", encoding="utf-8") as fh:
         data = json.load(fh)
@@ -205,7 +344,7 @@ def _load_ids(rel_path: str, container_keys: tuple) -> dict:
         ids = []
     with open(path, "rb") as fh:
         digest = hashlib.sha256(fh.read()).hexdigest()
-    return {"ids": ids, "file_sha256": digest}
+    return {"ids": ids, "file_sha256": digest, "tracked": True}
 
 
 def collect_docs(tracked: list) -> dict:
@@ -250,12 +389,19 @@ def collect_authority_links(tracked: list) -> dict:
         with open(os.path.join(REPO_ROOT, rel), "r", encoding="utf-8", errors="replace") as fh:
             text = fh.read()
         for target in scan_markdown_link_targets(text):
-            if target.startswith("/"):
-                # A machine-local absolute path can never resolve for another
-                # reader; report it, and never hand it to git check-ignore.
+            kind = classify_target(target)
+            if kind == "skip":
+                continue
+            if kind == "absolute":
+                # A machine-local absolute path (incl. file: scheme and drive
+                # letters) can never resolve for another reader; report it and
+                # never hand it to git check-ignore.
                 absolutes.setdefault(target, set()).add(rel)
                 continue
-            resolved = posixpath.normpath(posixpath.join(posixpath.dirname(rel), target))
+            cleaned = urllib.parse.unquote(strip_fragment_query(target))
+            if not cleaned:
+                continue
+            resolved = posixpath.normpath(posixpath.join(posixpath.dirname(rel), cleaned))
             if resolved.startswith(".."):
                 continue
             candidates.setdefault(resolved, set()).add(rel)
@@ -286,22 +432,40 @@ def build_snapshot() -> dict:
     return {
         "invariants_version": 2,
         "ledger": collect_ledger(tracked),
-        "premises": _load_ids(PREMISE_NODES, ("nodes",)),
-        "obligations": _load_ids(OBLIGATIONS, ("nodes", "obligations")),
+        "premises": _load_ids(PREMISE_NODES, ("nodes",), set(tracked)),
+        "obligations": _load_ids(OBLIGATIONS, ("nodes", "obligations"), set(tracked)),
         "docs": collect_docs(tracked),
         "authority_links": collect_authority_links(tracked),
     }
 
 
-def _flatten(prefix: str, value, out: dict):
-    if isinstance(value, dict):
-        if not value:
-            out[prefix + ".<empty-object>" if prefix else "<empty-object>"] = True
+def _json_equal(a, b) -> bool:
+    """JSON-aware equality: bool is never equal to a number."""
+    if isinstance(a, bool) != isinstance(b, bool):
+        return False
+    return a == b
+
+
+def _diff_json(a, b, path=()):
+    """Yield (path_tuple, before, after) for every leaf difference. Missing
+    keys are reported as the _MISSING sentinel, distinct from JSON null.
+    Paths are tuples, so dotted JSON keys cannot collide with nesting."""
+    if isinstance(a, dict) and isinstance(b, dict):
+        for key in sorted(set(a) | set(b)):
+            yield from _diff_json(
+                a.get(key, _MISSING), b.get(key, _MISSING), path + (str(key),)
+            )
+        return
+    if a is _MISSING and b is _MISSING:
+        return
+    if type(a) is type(b) and isinstance(a, (dict, list)) and _json_equal(a, b):
+        return
+    if not isinstance(a, (dict, list)) and not isinstance(b, (dict, list)):
+        if a is not _MISSING and b is not _MISSING and _json_equal(a, b):
             return
-        for key, sub in value.items():
-            _flatten(f"{prefix}.{key}" if prefix else str(key), sub, out)
-    else:
-        out[prefix] = value
+    yield (path,
+           "<absent>" if a is _MISSING else json.dumps(a, sort_keys=True),
+           "<absent>" if b is _MISSING else json.dumps(b, sort_keys=True))
 
 
 def run_diff(path_a: str, path_b: str, allow: set) -> int:
@@ -309,32 +473,16 @@ def run_diff(path_a: str, path_b: str, allow: set) -> int:
         snap_a = json.load(fh)
     with open(path_b, "r", encoding="utf-8") as fh:
         snap_b = json.load(fh)
-    flat_a: dict = {}
-    flat_b: dict = {}
-    _flatten("", snap_a, flat_a)
-    _flatten("", snap_b, flat_b)
-    diffs = []
-    for key in sorted(set(flat_a) | set(flat_b)):
-        before = flat_a.get(key, _MISSING)
-        after = flat_b.get(key, _MISSING)
-        if before is _MISSING and after is _MISSING:
-            continue
-        if before is not _MISSING and after is not _MISSING and before == after:
-            continue
-        diffs.append(
-            (
-                key,
-                "<absent>" if before is _MISSING else repr(before),
-                "<absent>" if after is _MISSING else repr(after),
-            )
-        )
+    allow_tuples = {tuple(item.split(".")) for item in allow}
+    diffs = list(_diff_json(snap_a, snap_b))
     blocked = []
-    for key, before, after in diffs:
-        allowed = any(key == a or key.startswith(a + ".") for a in allow)
+    for path, before, after in diffs:
+        display = ".".join(path)
+        allowed = any(path[: len(t)] == t for t in allow_tuples)
         marker = "ALLOWED" if allowed else "CHANGED"
         if not allowed:
-            blocked.append(key)
-        print(f"{marker}: {key}\n    before: {before}\n    after:  {after}")
+            blocked.append(display)
+        print(f"{marker}: {display}\n    before: {before}\n    after:  {after}")
     if not diffs:
         print("IDENTICAL: snapshots match on every measured invariant.")
     if blocked:
@@ -354,6 +502,9 @@ def run_check(enforce_links: bool) -> int:
         failures.append(f"ledger shard parse/schema errors: {ledger['shard_parse_errors']}")
     if ledger["duplicate_claim_ids"]:
         failures.append(f"duplicate claim ids: {ledger['duplicate_claim_ids']}")
+    for family in ("premises", "obligations"):
+        if not snapshot[family].get("tracked", False):
+            failures.append(f"{family} registry file is not git-tracked")
     known_dupes = {"README.md", "SKILL.md"}
     unexpected = [
         name for name in snapshot["docs"]["duplicate_basenames"] if name not in known_dupes
@@ -398,10 +549,14 @@ def main() -> int:
 
     if args.snapshot is not None:
         if args.snapshot != "-":
-            requested = os.path.relpath(os.path.abspath(args.snapshot), REPO_ROOT)
-            if not requested.startswith("..") and requested in set(_git_tracked_files()):
-                print(f"refusing to overwrite tracked repository path: {requested}")
-                return 2
+            resolved = os.path.realpath(os.path.abspath(args.snapshot))
+            requested = os.path.relpath(resolved, os.path.realpath(REPO_ROOT))
+            requested = requested.replace(os.sep, "/")
+            if not requested.startswith(".."):
+                tracked_fold = {t.casefold() for t in _git_tracked_files()}
+                if requested.casefold() in tracked_fold:
+                    print(f"refusing to overwrite tracked repository path: {requested}")
+                    return 2
         snapshot = build_snapshot()
         text = json.dumps(snapshot, indent=1, sort_keys=True)
         if args.snapshot == "-":

--- a/docs/audit/scripts/repo_invariants_check.py
+++ b/docs/audit/scripts/repo_invariants_check.py
@@ -35,10 +35,14 @@ Invariants measured (tracked state only)
   docs.md_count                tracked markdown files directly under docs/
   docs.duplicate_basenames     tracked basename collisions across docs/**
   authority_links.violations   markdown links on authority surfaces whose
-                               target file is not tracked (missing, untracked,
-                               or gitignored — each of which 404s for a fresh
-                               clone or GitHub reader). Code spans and fenced
-                               code blocks are masked before link extraction.
+                               target cannot resolve for a fresh clone or
+                               GitHub reader; reasons: not-tracked (missing,
+                               untracked, or gitignored alike — derived from
+                               the tracked set only), absolute-path, and
+                               outside-repository. Code spans and fenced code
+                               blocks are masked before link extraction.
+  authority_links.irregular_surfaces  authority files that are not regular
+                               files (never dereferenced)
 
 Repository inputs are read-only; no audit status is set, no generated surface
 is written, no verdict is minted.
@@ -86,6 +90,18 @@ from audit_lint import ALLOWED_EFFECTIVE_STATUSES  # noqa: E402
 _MISSING = object()
 
 
+def _regular_file(rel_path: str) -> bool:
+    """True iff the tracked path is an existing regular file (not a symlink
+    or other non-regular object); measured inputs are never dereferenced
+    through links (BUG-21)."""
+    import stat as _stat
+    try:
+        mode = os.lstat(os.path.join(REPO_ROOT, rel_path)).st_mode
+    except OSError:
+        return False
+    return _stat.S_ISREG(mode)
+
+
 # --- markdown scanning -------------------------------------------------------
 # Scope claim: this is a conservative reader-path scanner for the authority
 # surfaces, implemented as a line/character scan of the CommonMark constructs
@@ -106,7 +122,9 @@ def mask_code(text: str) -> str:
     for line in text.split("\n"):
         if fence_char is None:
             m = _FENCE_OPEN_RE.match(line)
-            if m:
+            # A backtick fence opener may not contain a backtick in its info
+            # string (CommonMark 4.5); such a line is inline-code material.
+            if m and not (m.group(1)[0] == "`" and "`" in line[m.end():]):
                 fence_char, fence_len = m.group(1)[0], len(m.group(1))
                 out_lines.append("")
                 continue
@@ -156,12 +174,29 @@ def _unescaped(text: str, idx: int) -> bool:
     return backslashes % 2 == 0
 
 
+def _skip_component_whitespace(text: str, pos: int) -> int:
+    """Skip spaces/tabs and AT MOST one line ending (CommonMark permits a
+    single line ending inside inline-link component whitespace; unbounded
+    skipping would glue prose across paragraphs into false links)."""
+    n = len(text)
+    newlines = 0
+    while pos < n:
+        ch = text[pos]
+        if ch in " \t":
+            pos += 1
+        elif ch == "\n" and newlines == 0:
+            newlines += 1
+            pos += 1
+        else:
+            break
+    return pos
+
+
 def _parse_destination(text: str, pos: int):
     """Parse a CommonMark inline-link destination starting just after '('.
     Returns (destination, index-after-closing-paren) or None."""
     n = len(text)
-    while pos < n and text[pos] in " \t":
-        pos += 1
+    pos = _skip_component_whitespace(text, pos)
     if pos < n and text[pos] == "<":
         end = pos + 1
         while end < n and text[end] != "\n":
@@ -191,16 +226,14 @@ def _parse_destination(text: str, pos: int):
 
 def _finish_after_dest(text: str, pos: int, dest: str):
     n = len(text)
-    while pos < n and text[pos] in " \t\n":
-        pos += 1
+    pos = _skip_component_whitespace(text, pos)
     if pos < n and text[pos] in "\"'(":
         closer = {"(": ")"}.get(text[pos], text[pos])
         pos += 1
         while pos < n and not (text[pos] == closer and _unescaped(text, pos)):
             pos += 1
         pos += 1
-        while pos < n and text[pos] in " \t\n":
-            pos += 1
+        pos = _skip_component_whitespace(text, pos)
     if pos < n and text[pos] == ")":
         # CommonMark backslash escapes apply to ASCII punctuation only; a
         # backslash before anything else (e.g. C:\Users) is literal (BUG-12).
@@ -297,6 +330,9 @@ def collect_ledger(tracked: list) -> dict:
     missing_note_paths = 0
     parse_errors = []
     for shard in shard_paths:
+        if not _regular_file(shard):
+            parse_errors.append(f"{shard}: not a regular file")
+            continue
         try:
             with open(os.path.join(REPO_ROOT, shard), "r", encoding="utf-8") as fh:
                 row = json.load(fh)
@@ -327,13 +363,18 @@ def collect_ledger(tracked: list) -> dict:
             parse_errors.append(f"{shard}: effective_status {status!r} not in controlled set")
             histogram["SCHEMA_INVALID"] += 1
         note_path = row.get("note_path")
-        if isinstance(note_path, str) and note_path and note_path not in tracked_set:
-            missing_note_paths += 1
-        elif note_path is not None and not isinstance(note_path, str):
-            parse_errors.append(f"{shard}: non-string note_path")
+        if isinstance(note_path, str) and note_path:
+            if note_path not in tracked_set:
+                missing_note_paths += 1
+        else:
+            # absent, null, empty, or non-string: every form is recorded so a
+            # note_path change can never leave the snapshot identical (BUG-20)
+            parse_errors.append(f"{shard}: missing/empty/non-string note_path")
 
     dupes = sorted(cid for cid, n in Counter(claim_ids).items() if n > 1)
-    ids_sha = hashlib.sha256("\n".join(sorted(claim_ids)).encode()).hexdigest()
+    ids_sha = hashlib.sha256(
+        json.dumps(sorted(claim_ids), separators=(",", ":")).encode()
+    ).hexdigest()
     retained_total = sum(
         count
         for status, count in histogram.items()
@@ -351,7 +392,7 @@ def collect_ledger(tracked: list) -> dict:
 
 
 def _load_ids(rel_path: str, container_keys: tuple, tracked_set: set) -> dict:
-    if rel_path not in tracked_set:
+    if rel_path not in tracked_set or not _regular_file(rel_path):
         return {"ids": [], "file_sha256": None, "tracked": False}
     path = os.path.join(REPO_ROOT, rel_path)
     with open(path, "r", encoding="utf-8") as fh:
@@ -412,6 +453,8 @@ def collect_authority_links(tracked: list) -> dict:
     candidates = {}  # repo-relative target -> set of source files
     absolutes = {}  # machine-local absolute target -> set of source files
     outsiders = {}  # ../-escaping target -> set of source files
+    irregular = [rel for rel in surface_files if not _regular_file(rel)]
+    surface_files = [rel for rel in surface_files if _regular_file(rel)]
     for rel in surface_files:
         with open(os.path.join(REPO_ROOT, rel), "r", encoding="utf-8", errors="replace") as fh:
             text = fh.read()
@@ -435,7 +478,6 @@ def collect_authority_links(tracked: list) -> dict:
                 continue
             candidates.setdefault(resolved, set()).add(rel)
 
-    ignored = _gitignored(sorted(candidates))
     violations = [
         {"target": target, "reason": "absolute-path", "sources": sorted(sources)}
         for target, sources in sorted(absolutes.items())
@@ -447,14 +489,19 @@ def collect_authority_links(tracked: list) -> dict:
         is_dir_link = rel.rstrip("/") in tracked_dirs
         if rel in tracked_set or is_dir_link:
             continue
-        # Reasons derive from git metadata ONLY (tracked set + ignore rules),
-        # so two worktrees at the same commit always produce identical
-        # snapshots regardless of untracked scratch files (BUG-16).
-        reason = "gitignored" if rel in ignored else "not-tracked"
+        # The single reason derives from the tracked set ONLY: local ignore
+        # rules and untracked scratch files can never change the serialized
+        # snapshot (BUG-16, NIT-05). A not-tracked target 404s for any fresh
+        # clone or GitHub reader whether it is gitignored or merely absent.
+        reason = "not-tracked"
         violations.append(
             {"target": rel, "reason": reason, "sources": sorted(candidates[rel])}
         )
-    return {"surfaces_scanned": len(surface_files), "violations": violations}
+    return {
+        "surfaces_scanned": len(surface_files),
+        "irregular_surfaces": sorted(irregular),
+        "violations": violations,
+    }
 
 
 def build_snapshot() -> dict:
@@ -592,7 +639,26 @@ def main() -> int:
             # hard link outside the repo can alias a tracked inode).
             resolved = os.path.realpath(os.path.abspath(args.snapshot))
             repo_real = os.path.realpath(REPO_ROOT)
-            if os.path.commonpath([resolved, repo_real]) == repo_real:
+            inside = os.path.commonpath([resolved, repo_real]) == repo_real
+            if not inside:
+                # Spelling-insensitive filesystems (case folds, unicode
+                # normalization) can alias the repository under a different
+                # string; compare filesystem identity of every existing
+                # ancestor against the repository root (BUG-22).
+                repo_stat = os.stat(repo_real)
+                probe = resolved
+                while True:
+                    if os.path.exists(probe):
+                        try:
+                            if os.path.samestat(os.stat(probe), repo_stat):
+                                inside = True
+                        except OSError:
+                            pass
+                    parent = os.path.dirname(probe)
+                    if parent == probe:
+                        break
+                    probe = parent
+            if inside:
                 print("refusing to write a snapshot inside the repository; "
                       "use a scratch directory or '-' for stdout")
                 return 2

--- a/docs/audit/scripts/repo_invariants_check.py
+++ b/docs/audit/scripts/repo_invariants_check.py
@@ -86,6 +86,7 @@ RETAINED_GRADE_EXACT = {"retained", "retained_bounded", "retained_no_go"}
 # two tools cannot drift (BUG-17).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from audit_lint import ALLOWED_EFFECTIVE_STATUSES  # noqa: E402
+from ledger_io import shard_path as _canonical_shard_path  # noqa: E402
 
 _MISSING = object()
 
@@ -306,21 +307,6 @@ def _git_tracked_files() -> list:
     return sorted(p for p in proc.stdout.split("\0") if p)
 
 
-def _gitignored(paths: list) -> set:
-    """Return the subset of repo-relative paths that are gitignored."""
-    if not paths:
-        return set()
-    proc = subprocess.run(
-        ["git", "-C", REPO_ROOT, "check-ignore", "--stdin"],
-        input="\n".join(paths),
-        capture_output=True,
-        text=True,
-    )
-    # exit 0: some ignored; 1: none ignored; >1: real error
-    if proc.returncode > 1:
-        raise RuntimeError(f"git check-ignore failed: {proc.stderr.strip()}")
-    return set(proc.stdout.splitlines())
-
 
 def collect_ledger(tracked: list) -> dict:
     shard_paths = [p for p in tracked if p.startswith(LEDGER_PREFIX) and p.endswith(".json")]
@@ -351,6 +337,22 @@ def collect_ledger(tracked: list) -> dict:
             # Canonical shard identity (ledger_io): claim_id must match the
             # shard filename stem (BUG-17).
             parse_errors.append(f"{shard}: claim_id {claim_id!r} != filename stem {stem!r}")
+        else:
+            # Canonical placement (ledger_io.shard_path): shard-safe id at
+            # exactly ledger/<id[:2]>/<id>.json — a moved or mis-fanned shard
+            # is unreadable by the canonical loader (BUG-23).
+            try:
+                # ledger_io owns the shard-safe id rule and the fanout rule;
+                # anchor its fanout under our tracked prefix so the check is
+                # REPO_ROOT-independent.
+                canonical = _canonical_shard_path(claim_id)
+                canonical_rel = f"{LEDGER_PREFIX}{canonical.parent.name}/{canonical.name}"
+                if shard != canonical_rel:
+                    parse_errors.append(
+                        f"{shard}: not at canonical shard path {canonical_rel}"
+                    )
+            except ValueError as exc:
+                parse_errors.append(f"{shard}: {exc}")
         claim_ids.append(claim_id)
         status = row.get("effective_status")
         if status is None:
@@ -595,6 +597,12 @@ def run_check(enforce_links: bool) -> int:
     if unexpected:
         failures.append(f"unexpected duplicate doc basenames: {unexpected}")
 
+    irregular = snapshot["authority_links"].get("irregular_surfaces", [])
+    if irregular:
+        failures.append(
+            "authority surfaces are not regular files (unscannable, refusing "
+            f"to certify): {irregular}"
+        )
     link_violations = snapshot["authority_links"]["violations"]
     if link_violations:
         lines = [

--- a/docs/audit/scripts/repo_invariants_check.py
+++ b/docs/audit/scripts/repo_invariants_check.py
@@ -356,7 +356,10 @@ def collect_ledger(tracked: list) -> dict:
         claim_ids.append(claim_id)
         status = row.get("effective_status")
         if status is None:
+            # Measured AND rejected: None is outside the controlled set the
+            # audit linter enforces (BUG-25).
             histogram["MISSING"] += 1
+            parse_errors.append(f"{shard}: missing/null effective_status")
         elif isinstance(status, str) and (
             status in ALLOWED_EFFECTIVE_STATUSES or status.startswith("decoration_under_")
         ):
@@ -397,8 +400,14 @@ def _load_ids(rel_path: str, container_keys: tuple, tracked_set: set) -> dict:
     if rel_path not in tracked_set or not _regular_file(rel_path):
         return {"ids": [], "file_sha256": None, "tracked": False}
     path = os.path.join(REPO_ROOT, rel_path)
-    with open(path, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
+        # Fail closed with a structured diagnostic (registry unreadable is
+        # treated exactly like registry untracked: run_check fails on it).
+        return {"ids": [], "file_sha256": None, "tracked": False,
+                "parse_error": f"{rel_path}: {exc}"}
     entries = data
     if isinstance(data, dict):
         for key in container_keys:
@@ -589,7 +598,8 @@ def run_check(enforce_links: bool) -> int:
         failures.append(f"duplicate claim ids: {ledger['duplicate_claim_ids']}")
     for family in ("premises", "obligations"):
         if not snapshot[family].get("tracked", False):
-            failures.append(f"{family} registry file is not git-tracked")
+            detail = snapshot[family].get("parse_error") or "not git-tracked or not a regular file"
+            failures.append(f"{family} registry unusable: {detail}")
     known_dupes = {"README.md", "SKILL.md"}
     unexpected = [
         name for name in snapshot["docs"]["duplicate_basenames"] if name not in known_dupes

--- a/docs/audit/scripts/repo_invariants_check.py
+++ b/docs/audit/scripts/repo_invariants_check.py
@@ -296,6 +296,26 @@ def scan_markdown_link_targets(text: str) -> list:
 
 
 
+def _git_tracked_modes() -> dict:
+    """Repo-relative path -> index mode string (e.g. '100644', '120000').
+    Index modes are pure tracked state: worktree mutations cannot perturb
+    them, and a fresh clone reproduces exactly these kinds (BUG-26)."""
+    proc = subprocess.run(
+        ["git", "-C", REPO_ROOT, "ls-files", "-z", "-s"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"git ls-files -s failed: {proc.stderr.strip()}")
+    modes = {}
+    for entry in proc.stdout.split("\0"):
+        if not entry:
+            continue
+        meta, _tab, path = entry.partition("\t")
+        modes[path] = meta.split(" ", 1)[0]
+    return modes
+
+
 def _git_tracked_files() -> list:
     proc = subprocess.run(
         ["git", "-C", REPO_ROOT, "ls-files", "-z"],
@@ -489,6 +509,7 @@ def collect_authority_links(tracked: list) -> dict:
                 continue
             candidates.setdefault(resolved, set()).add(rel)
 
+    modes = _git_tracked_modes()
     violations = [
         {"target": target, "reason": "absolute-path", "sources": sorted(sources)}
         for target, sources in sorted(absolutes.items())
@@ -498,7 +519,19 @@ def collect_authority_links(tracked: list) -> dict:
     ]
     for rel in sorted(candidates):
         is_dir_link = rel.rstrip("/") in tracked_dirs
-        if rel in tracked_set or is_dir_link:
+        if rel in tracked_set:
+            # A tracked target must also be a regular blob: a symlink or
+            # submodule entry renders as a pathname/commit pointer for a
+            # GitHub reader and dereferences nothing in a fresh clone
+            # (BUG-26). Judged from index modes only.
+            if modes.get(rel) not in ("100644", "100755"):
+                violations.append({
+                    "target": rel,
+                    "reason": "irregular-target",
+                    "sources": sorted(candidates[rel]),
+                })
+            continue
+        if is_dir_link:
             continue
         # The single reason derives from the tracked set ONLY: local ignore
         # rules and untracked scratch files can never change the serialized

--- a/docs/audit/scripts/tests/test_repo_invariants_check.py
+++ b/docs/audit/scripts/tests/test_repo_invariants_check.py
@@ -85,7 +85,8 @@ class CollectLedgerSchemaTest(unittest.TestCase):
         ]
         result = ric.collect_ledger(tracked)
         self.assertEqual(result["shard_count"], 3)
-        self.assertEqual(len(result["shard_parse_errors"]), 2)
+        # list_shard: non-object; null_claim: bad claim_id AND missing note_path
+        self.assertEqual(len(result["shard_parse_errors"]), 3)
         self.assertEqual(result["rows_with_missing_note_path"], 0)
         self.assertEqual(
             result["effective_status_histogram"], {"retained": 1, "unaudited": 1}
@@ -282,7 +283,8 @@ class ShardSchemaRoundTwoProbes(unittest.TestCase):
                     ric.LEDGER_PREFIX + "aa/badbytes.json",
                 ]
                 result = ric.collect_ledger(tracked)
-                self.assertEqual(len(result["shard_parse_errors"]), 2)
+                # liststatus: bad status AND missing note_path; badbytes: decode
+                self.assertEqual(len(result["shard_parse_errors"]), 3)
                 self.assertEqual(result["effective_status_histogram"].get("SCHEMA_INVALID"), 1)
                 self.assertEqual(result["retained_grade_total"], 0)
             finally:
@@ -439,6 +441,82 @@ class RoundThreeDiffProbes(DiffSensitivityTest):
     def test_array_leaf_path_is_allowable(self):
         code, _ = self._diff({"a": [{}]}, {"a": [{"b": 1}]}, allow="a.0.b")
         self.assertEqual(code, 0)
+
+
+
+
+class RoundFourProbes(unittest.TestCase):
+    def test_backtick_fence_with_backtick_info_is_inline_span(self):
+        text = "``` x ``` prose\n[a](GONE.md)"
+        self.assertEqual(ric.scan_markdown_link_targets(text), ["GONE.md"])
+
+    def test_wrapped_link_single_newline_parses(self):
+        self.assertEqual(
+            ric.scan_markdown_link_targets("[a](\nGONE.md\n)"), ["GONE.md"]
+        )
+
+    def test_double_newline_does_not_glue_paragraphs(self):
+        self.assertEqual(
+            ric.scan_markdown_link_targets("[a](\n\nNOT_A_LINK.md)"), []
+        )
+
+    def test_absent_or_empty_note_path_is_schema_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old = ric.REPO_ROOT
+            ric.REPO_ROOT = tmp
+            try:
+                d = Path(tmp) / ric.LEDGER_PREFIX / "aa"
+                d.mkdir(parents=True)
+                (d / "noname.json").write_text(json.dumps(
+                    {"claim_id": "noname", "effective_status": "unaudited"}))
+                (d / "empty.json").write_text(json.dumps(
+                    {"claim_id": "empty", "effective_status": "unaudited",
+                     "note_path": ""}))
+                result = ric.collect_ledger([
+                    ric.LEDGER_PREFIX + "aa/noname.json",
+                    ric.LEDGER_PREFIX + "aa/empty.json",
+                ])
+                self.assertEqual(len(result["shard_parse_errors"]), 2)
+            finally:
+                ric.REPO_ROOT = old
+
+    def test_symlinked_shard_and_registry_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old = ric.REPO_ROOT
+            ric.REPO_ROOT = tmp
+            try:
+                d = Path(tmp) / ric.LEDGER_PREFIX / "aa"
+                d.mkdir(parents=True)
+                real = Path(tmp) / "outside.json"
+                real.write_text(json.dumps(
+                    {"claim_id": "alias", "effective_status": "unaudited"}))
+                (d / "alias.json").symlink_to(real)
+                result = ric.collect_ledger([ric.LEDGER_PREFIX + "aa/alias.json"])
+                self.assertIn("not a regular file", result["shard_parse_errors"][0])
+                reg = Path(tmp) / ric.PREMISE_NODES
+                reg.parent.mkdir(parents=True, exist_ok=True)
+                reg.symlink_to(real)
+                out = ric._load_ids(ric.PREMISE_NODES, ("nodes",), {ric.PREMISE_NODES})
+                self.assertFalse(out["tracked"])
+            finally:
+                ric.REPO_ROOT = old
+
+    def test_single_reason_is_ignore_rule_independent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            (root / "README.md").write_text("[x](docs/GONE.md)")
+            before = ric.collect_authority_links.__wrapped__ if False else None
+            old = ric.REPO_ROOT
+            ric.REPO_ROOT = str(root)
+            try:
+                first = ric.collect_authority_links(["README.md"])
+                (root / ".gitignore").write_text("docs/GONE.md\n")
+                second = ric.collect_authority_links(["README.md"])
+                self.assertEqual(first["violations"], second["violations"])
+                self.assertEqual(first["violations"][0]["reason"], "not-tracked")
+            finally:
+                ric.REPO_ROOT = old
 
 
 if __name__ == "__main__":

--- a/docs/audit/scripts/tests/test_repo_invariants_check.py
+++ b/docs/audit/scripts/tests/test_repo_invariants_check.py
@@ -129,9 +129,26 @@ class AuthorityLinksTrackedSetTest(unittest.TestCase):
         self.assertEqual(
             reasons,
             {
-                "docs/PRESENT_UNTRACKED.md": "untracked",
-                "docs/MISSING.md": "missing",
+                "docs/PRESENT_UNTRACKED.md": "not-tracked",
+                "docs/MISSING.md": "not-tracked",
             },
+        )
+
+    def test_reason_is_stable_under_untracked_scratch_files(self):
+        # BUG-16: an untracked file appearing on disk must not change the
+        # serialized violation reason between two worktrees at one commit.
+        tracked = ["README.md", "docs/TRACKED.md", "docs/repo/KEEP.md"]
+        before = ric.collect_authority_links(tracked)["violations"]
+        (Path(ric.REPO_ROOT) / "docs" / "MISSING.md").write_text("late")
+        after = ric.collect_authority_links(tracked)["violations"]
+        self.assertEqual(before, after)
+
+    def test_outside_repository_link_is_reported(self):
+        (Path(ric.REPO_ROOT) / "README.md").write_text("[out](../OUTSIDE.md)")
+        result = ric.collect_authority_links(["README.md"])
+        self.assertEqual(
+            [(v["target"], v["reason"]) for v in result["violations"]],
+            [("../OUTSIDE.md", "outside-repository")],
         )
 
 
@@ -301,33 +318,127 @@ class DiffRoundTwoProbes(unittest.TestCase):
 
 
 class SnapshotOutputAliasGuardTest(unittest.TestCase):
-    def test_symlink_alias_to_tracked_file_refused(self):
+    """Any destination inside the repository is refused (symlinks, case
+    folds, unicode normalization, and ..-prefixed basenames are all inside
+    after realpath); multi-linked existing files are refused anywhere."""
+
+    def _run_snapshot(self, root: Path, req: str) -> int:
+        old, argv = ric.REPO_ROOT, sys.argv
+        ric.REPO_ROOT = str(root)
+        sys.argv = ["ric", "--snapshot", req]
+        try:
+            out = io.StringIO()
+            with redirect_stdout(out):
+                return ric.main()
+        finally:
+            ric.REPO_ROOT, sys.argv = old, argv
+
+    def test_all_in_repo_destinations_refused(self):
         with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
+            root = Path(os.path.realpath(tmp))
             subprocess.run(["git", "init", "-q", str(root)], check=True)
             victim = root / "Tracked.JSON"
             victim.write_text("precious")
-            subprocess.run(["git", "-C", str(root), "add", "Tracked.JSON"], check=True)
+            dotdot = root / "..victim.json"
+            dotdot.write_text("precious2")
+            subprocess.run(
+                ["git", "-C", str(root), "add", "Tracked.JSON", "..victim.json"],
+                check=True,
+            )
             link = root / "alias.json"
             link.symlink_to(victim)
+            for req in (
+                str(link),
+                str(root / "tracked.json"),
+                str(root / "..victim.json"),
+                str(root / "brand_new.json"),
+            ):
+                self.assertEqual(self._run_snapshot(root, req), 2, req)
+            self.assertEqual(victim.read_text(), "precious")
+            self.assertEqual(dotdot.read_text(), "precious2")
+
+    def test_hard_link_alias_outside_repo_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(os.path.realpath(tmp)) / "repo"
+            outside = Path(os.path.realpath(tmp)) / "outside"
+            root.mkdir(); outside.mkdir()
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            victim = root / "tracked.json"
+            victim.write_text("precious")
+            subprocess.run(["git", "-C", str(root), "add", "tracked.json"], check=True)
+            hard = outside / "hard.json"
+            os.link(victim, hard)
+            self.assertEqual(self._run_snapshot(root, str(hard)), 2)
+            self.assertEqual(victim.read_text(), "precious")
+
+    def test_outside_scratch_destination_allowed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(os.path.realpath(tmp)) / "repo"
+            root.mkdir()
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            dest = Path(os.path.realpath(tmp)) / "snap.json"
+            code = self._run_snapshot(root, str(dest))
+            self.assertEqual(code, 0)
+            self.assertTrue(dest.exists())
+
+
+
+
+class RoundThreeScannerProbes(unittest.TestCase):
+    def test_escaped_backticks_do_not_open_code_spans(self):
+        text = "\\` [bad](MISSING.md) \\`"
+        self.assertEqual(ric.scan_markdown_link_targets(text), ["MISSING.md"])
+
+    def test_windows_path_preserved_and_absolute(self):
+        targets = ric.scan_markdown_link_targets("[x](C:\\Users\\me\\X.md)")
+        self.assertEqual(targets, ["C:\\Users\\me\\X.md"])
+        self.assertEqual(ric.classify_target(targets[0]), "absolute")
+
+    def test_uri_schemes_and_extensionless(self):
+        self.assertEqual(ric.classify_target("doi:10.1000/xyz"), "skip")
+        self.assertEqual(ric.classify_target("LICENSE"), "relative")
+        self.assertEqual(ric.classify_target("file:///tmp/L.md"), "absolute")
+
+
+class RoundThreeLedgerProbes(unittest.TestCase):
+    def test_claim_id_filename_identity_and_status_enum(self):
+        with tempfile.TemporaryDirectory() as tmp:
             old = ric.REPO_ROOT
-            ric.REPO_ROOT = str(root)
-            argv = sys.argv
+            ric.REPO_ROOT = tmp
             try:
-                for req in (str(link), str(root / "tracked.json")):
-                    sys.argv = ["ric", "--snapshot", req]
-                    out = io.StringIO()
-                    with redirect_stdout(out):
-                        code = ric.main()
-                    if "tracked.json" in req and not (root / "TRACKED.json").exists() \
-                            and not os.path.exists(str(root / "tracked.json")):
-                        pass  # case-alias probe only binds on case-insensitive fs
-                    if os.path.realpath(req) == os.path.realpath(str(victim)):
-                        self.assertEqual(code, 2, req)
-                        self.assertEqual(victim.read_text(), "precious")
+                d = Path(tmp) / ric.LEDGER_PREFIX / "aa"
+                d.mkdir(parents=True)
+                (d / "alpha.json").write_text(json.dumps(
+                    {"claim_id": "beta", "effective_status": "unaudited"}))
+                (d / "typo.json").write_text(json.dumps(
+                    {"claim_id": "typo", "effective_status": "retianed"}))
+                result = ric.collect_ledger([
+                    ric.LEDGER_PREFIX + "aa/alpha.json",
+                    ric.LEDGER_PREFIX + "aa/typo.json",
+                ])
+                errors = " ".join(result["shard_parse_errors"])
+                self.assertIn("!= filename stem", errors)
+                self.assertIn("not in controlled set", errors)
+                self.assertEqual(
+                    result["effective_status_histogram"].get("SCHEMA_INVALID"), 1
+                )
+                self.assertEqual(result["retained_grade_total"], 0)
             finally:
                 ric.REPO_ROOT = old
-                sys.argv = argv
+
+
+class RoundThreeDiffProbes(DiffSensitivityTest):
+    def test_bool_vs_one_inside_array(self):
+        code, _ = self._diff({"a": [True]}, {"a": [1]})
+        self.assertEqual(code, 1)
+
+    def test_nested_dict_inside_array(self):
+        code, _ = self._diff({"a": [{"b": True}]}, {"a": [{"b": 1}]})
+        self.assertEqual(code, 1)
+
+    def test_array_leaf_path_is_allowable(self):
+        code, _ = self._diff({"a": [{}]}, {"a": [{"b": 1}]}, allow="a.0.b")
+        self.assertEqual(code, 0)
 
 
 if __name__ == "__main__":

--- a/docs/audit/scripts/tests/test_repo_invariants_check.py
+++ b/docs/audit/scripts/tests/test_repo_invariants_check.py
@@ -119,6 +119,11 @@ class AuthorityLinksTrackedSetTest(unittest.TestCase):
         (root / "docs" / "TRACKED.md").write_text("x")
         (root / "docs" / "PRESENT_UNTRACKED.md").write_text("x")
         (root / "docs" / "repo" / "KEEP.md").write_text("x")
+        subprocess.run(
+            ["git", "-C", str(root), "add",
+             "README.md", "docs/TRACKED.md", "docs/repo/KEEP.md"],
+            check=True,
+        )
 
     def _restore(self):
         ric.REPO_ROOT = self._old_root
@@ -646,6 +651,59 @@ class RoundSixProbes(unittest.TestCase):
             code, out = self._check(root, False)
             self.assertEqual(code, 1)
             self.assertIn("premises", out)
+
+
+
+
+class RoundSevenProbes(unittest.TestCase):
+    def test_tracked_symlink_target_is_a_violation_end_to_end(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(os.path.realpath(tmp))
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            for rel, payload in ((ric.PREMISE_NODES, {"nodes": {}}),
+                                 (ric.OBLIGATIONS, {"nodes": {}})):
+                p = root / rel
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text(json.dumps(payload))
+            (root / "README.md").write_text("[t](docs/TARGET.md)")
+            (root / "docs").mkdir(exist_ok=True)
+            (root / "docs" / "TARGET.md").symlink_to("/nonexistent/outside.md")
+            subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+            old = ric.REPO_ROOT
+            ric.REPO_ROOT = str(root)
+            try:
+                links = ric.collect_authority_links(
+                    ["README.md", "docs/TARGET.md",
+                     ric.PREMISE_NODES, ric.OBLIGATIONS])
+                self.assertEqual(
+                    [(v["target"], v["reason"]) for v in links["violations"]],
+                    [("docs/TARGET.md", "irregular-target")],
+                )
+                for enforce in (False, True):
+                    out = io.StringIO()
+                    with redirect_stdout(out):
+                        code = ric.run_check(enforce)
+                    if enforce:
+                        self.assertEqual(code, 1)
+                        self.assertIn("irregular-target", out.getvalue())
+            finally:
+                ric.REPO_ROOT = old
+
+    def test_regular_tracked_target_still_clean(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(os.path.realpath(tmp))
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            (root / "README.md").write_text("[t](docs/TARGET.md)")
+            (root / "docs").mkdir()
+            (root / "docs" / "TARGET.md").write_text("x")
+            subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+            old = ric.REPO_ROOT
+            ric.REPO_ROOT = str(root)
+            try:
+                links = ric.collect_authority_links(["README.md", "docs/TARGET.md"])
+                self.assertEqual(links["violations"], [])
+            finally:
+                ric.REPO_ROOT = old
 
 
 if __name__ == "__main__":

--- a/docs/audit/scripts/tests/test_repo_invariants_check.py
+++ b/docs/audit/scripts/tests/test_repo_invariants_check.py
@@ -656,54 +656,82 @@ class RoundSixProbes(unittest.TestCase):
 
 
 class RoundSevenProbes(unittest.TestCase):
-    def test_tracked_symlink_target_is_a_violation_end_to_end(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(os.path.realpath(tmp))
-            subprocess.run(["git", "init", "-q", str(root)], check=True)
-            for rel, payload in ((ric.PREMISE_NODES, {"nodes": {}}),
-                                 (ric.OBLIGATIONS, {"nodes": {}})):
-                p = root / rel
-                p.parent.mkdir(parents=True, exist_ok=True)
-                p.write_text(json.dumps(payload))
-            (root / "README.md").write_text("[t](docs/TARGET.md)")
-            (root / "docs").mkdir(exist_ok=True)
+    def _mk_repo(self, tmp, target_is_symlink):
+        root = Path(os.path.realpath(tmp))
+        subprocess.run(["git", "init", "-q", str(root)], check=True)
+        for rel, payload in ((ric.PREMISE_NODES, {"nodes": {}}),
+                             (ric.OBLIGATIONS, {"nodes": {}})):
+            p = root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(json.dumps(payload))
+        (root / "README.md").write_text("[t](docs/TARGET.md)")
+        (root / "docs").mkdir(exist_ok=True)
+        if target_is_symlink:
             (root / "docs" / "TARGET.md").symlink_to("/nonexistent/outside.md")
-            subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+        else:
+            (root / "docs" / "TARGET.md").write_text("x")
+        subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+        return root
+
+    def _check(self, root, enforce):
+        old = ric.REPO_ROOT
+        ric.REPO_ROOT = str(root)
+        try:
+            out = io.StringIO()
+            with redirect_stdout(out):
+                return ric.run_check(enforce), out.getvalue()
+        finally:
+            ric.REPO_ROOT = old
+
+    def _snapshot(self, root):
+        old = ric.REPO_ROOT
+        ric.REPO_ROOT = str(root)
+        try:
+            return json.dumps(ric.build_snapshot(), indent=1, sort_keys=True)
+        finally:
+            ric.REPO_ROOT = old
+
+    def test_tracked_symlink_target_decisive_both_modes_and_snapshot(self):
+        with tempfile.TemporaryDirectory() as tmp_bad, \
+                tempfile.TemporaryDirectory() as tmp_good:
+            bad = self._mk_repo(tmp_bad, target_is_symlink=True)
+            good = self._mk_repo(tmp_good, target_is_symlink=False)
+
+            # violation surface
             old = ric.REPO_ROOT
-            ric.REPO_ROOT = str(root)
+            ric.REPO_ROOT = str(bad)
             try:
                 links = ric.collect_authority_links(
                     ["README.md", "docs/TARGET.md",
                      ric.PREMISE_NODES, ric.OBLIGATIONS])
-                self.assertEqual(
-                    [(v["target"], v["reason"]) for v in links["violations"]],
-                    [("docs/TARGET.md", "irregular-target")],
-                )
-                for enforce in (False, True):
-                    out = io.StringIO()
-                    with redirect_stdout(out):
-                        code = ric.run_check(enforce)
-                    if enforce:
-                        self.assertEqual(code, 1)
-                        self.assertIn("irregular-target", out.getvalue())
             finally:
                 ric.REPO_ROOT = old
+            self.assertEqual(
+                [(v["target"], v["reason"]) for v in links["violations"]],
+                [("docs/TARGET.md", "irregular-target")],
+            )
 
-    def test_regular_tracked_target_still_clean(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(os.path.realpath(tmp))
-            subprocess.run(["git", "init", "-q", str(root)], check=True)
-            (root / "README.md").write_text("[t](docs/TARGET.md)")
-            (root / "docs").mkdir()
-            (root / "docs" / "TARGET.md").write_text("x")
-            subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
-            old = ric.REPO_ROOT
-            ric.REPO_ROOT = str(root)
-            try:
-                links = ric.collect_authority_links(["README.md", "docs/TARGET.md"])
-                self.assertEqual(links["violations"], [])
-            finally:
-                ric.REPO_ROOT = old
+            # warn-only: exit 0 with an explicit irregular-target WARN
+            code, out = self._check(bad, False)
+            self.assertEqual(code, 0)
+            self.assertIn("irregular-target", out)
+            self.assertIn("WARN", out)
+
+            # enforced: exit 1 naming the violation
+            code, out = self._check(bad, True)
+            self.assertEqual(code, 1)
+            self.assertIn("irregular-target", out)
+
+            # regular-target control is clean in BOTH modes
+            for enforce in (False, True):
+                code, out = self._check(good, enforce)
+                self.assertEqual(code, 0, enforce)
+                self.assertNotIn("irregular-target", out)
+
+            # the ruler sees the target-kind change: full serialized
+            # snapshots must differ (authority_links only; ledger empty in
+            # both fixtures)
+            self.assertNotEqual(self._snapshot(bad), self._snapshot(good))
 
 
 if __name__ == "__main__":

--- a/docs/audit/scripts/tests/test_repo_invariants_check.py
+++ b/docs/audit/scripts/tests/test_repo_invariants_check.py
@@ -1,10 +1,11 @@
 """Regression tests for the repo-invariants harness.
 
-Covers the review findings from PR #5399 round 1: markdown lexical context
-(code spans/fences, angle-bracket destinations, titles, non-path artifacts),
-schema-invalid ledger shards, tracked-set discipline (untracked files must
-not perturb measurements; untracked link targets are violations), and
-snapshot-diff sensitivity to missing-vs-null and empty-object changes.
+Encodes the concrete probe cases from the PR #5399 sol-max review rounds
+(markdown masking and link grammar, ledger-shard schema safety, tracked-set
+discipline for every measured family, destination classification, snapshot
+diff sensitivity, and the alias-safe snapshot-output refusal). It is a
+regression boundary for those named cases, not a full CommonMark or JSON
+conformance suite.
 """
 
 import io
@@ -38,9 +39,11 @@ class ScanMarkdownLinkTargetsTest(unittest.TestCase):
         text = "```\n[real looking](DEAD.md)\n```\nafter"
         self.assertEqual(ric.scan_markdown_link_targets(text), [])
 
-    def test_ignores_math_artifact_not_path_shaped(self):
+    def test_math_artifact_scans_raw_but_classifies_skip(self):
         text = "the Hessian candidate S[h] = 1/2 D^2 W[g_*](h,h) in the cell"
-        self.assertEqual(ric.scan_markdown_link_targets(text), [])
+        targets = ric.scan_markdown_link_targets(text)
+        self.assertEqual(targets, ["h,h"])
+        self.assertEqual(ric.classify_target(targets[0]), "skip")
 
     def test_handles_title_and_angle_bracket_destination(self):
         text = '[a](X.md "The X note") and [b](<sub dir/Y.md>)'
@@ -48,9 +51,10 @@ class ScanMarkdownLinkTargetsTest(unittest.TestCase):
             ric.scan_markdown_link_targets(text), ["X.md", "sub dir/Y.md"]
         )
 
-    def test_skips_external_and_mailto(self):
+    def test_external_and_mailto_classify_skip(self):
         text = "[w](https://example.org/x.md) [m](mailto:a@b.c) [k](K.md)"
-        self.assertEqual(ric.scan_markdown_link_targets(text), ["K.md"])
+        kinds = [ric.classify_target(x) for x in ric.scan_markdown_link_targets(text)]
+        self.assertEqual(kinds, ["skip", "skip", "relative"])
 
 
 class CollectLedgerSchemaTest(unittest.TestCase):
@@ -163,6 +167,167 @@ class DiffSensitivityTest(unittest.TestCase):
         code, out = self._diff({"a": {"k": 1}}, {"a": {"k": 1}})
         self.assertEqual(code, 0)
         self.assertIn("IDENTICAL", out)
+
+
+
+
+class MaskCodeRoundTwoProbes(unittest.TestCase):
+    def test_tilde_and_long_fences(self):
+        for text in (
+            "~~~~\n[a](TILDE4.md)\n~~~~",
+            "```\n[a](CLOSE_LONGER.md)\n````",
+            "   ~~~\n[a](INDENTED.md)\n   ~~~",
+            "````\n```\n[a](FENCE4.md)\n```\n````",
+        ):
+            self.assertEqual(ric.scan_markdown_link_targets(text), [], text)
+
+    def test_unclosed_fence_masks_to_end(self):
+        self.assertEqual(
+            ric.scan_markdown_link_targets("```\n[a](UNCLOSED.md)\ntail"), []
+        )
+
+    def test_double_backtick_span_containing_single_backtick(self):
+        text = "`` [a](NESTED.md) ` `` and [b](REAL.md)"
+        self.assertEqual(ric.scan_markdown_link_targets(text), ["REAL.md"])
+
+
+class LinkGrammarRoundTwoProbes(unittest.TestCase):
+    def test_single_quote_and_paren_titles(self):
+        text = "[x](X.md 'title') [y](Y.md (title))"
+        self.assertEqual(ric.scan_markdown_link_targets(text), ["X.md", "Y.md"])
+
+    def test_balanced_parens_in_bare_destination(self):
+        self.assertEqual(
+            ric.scan_markdown_link_targets("[x](dir/foo(bar).md)"),
+            ["dir/foo(bar).md"],
+        )
+
+    def test_escaped_opener_is_not_a_link(self):
+        self.assertEqual(ric.scan_markdown_link_targets("\\[not-link](FAKE.md)"), [])
+
+    def test_fragment_and_query_are_preserved_raw_then_strippable(self):
+        targets = ric.scan_markdown_link_targets("[a](docs/T.md#part) [b](docs/T.md?raw=1)")
+        self.assertEqual(
+            [ric.strip_fragment_query(x) for x in targets],
+            ["docs/T.md", "docs/T.md"],
+        )
+
+
+class ClassifyTargetTest(unittest.TestCase):
+    def test_classification_table(self):
+        cases = {
+            "file:///tmp/LOCAL.md": "absolute",
+            "//example.com/X.md": "skip",
+            "C:/Users/me/X.md": "absolute",
+            "/Users/me/X.md": "absolute",
+            "https://example.org/a.md": "skip",
+            "mailto:a@b.c": "skip",
+            "h,h": "skip",
+            "../X.md": "relative",
+            "data/ledger/": "relative",
+        }
+        for dest, want in cases.items():
+            self.assertEqual(ric.classify_target(dest), want, dest)
+
+
+class RegistryTrackedSetTest(unittest.TestCase):
+    def test_untracked_registry_is_flagged_not_read(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old = ric.REPO_ROOT
+            ric.REPO_ROOT = tmp
+            try:
+                p = Path(tmp) / ric.PREMISE_NODES
+                p.parent.mkdir(parents=True)
+                p.write_text(json.dumps({"nodes": {"UNTRACKED_PREMISE": {}}}))
+                out = ric._load_ids(ric.PREMISE_NODES, ("nodes",), set())
+                self.assertEqual(out, {"ids": [], "file_sha256": None, "tracked": False})
+                out2 = ric._load_ids(ric.PREMISE_NODES, ("nodes",), {ric.PREMISE_NODES})
+                self.assertEqual(out2["ids"], ["UNTRACKED_PREMISE"])
+                self.assertTrue(out2["tracked"])
+            finally:
+                ric.REPO_ROOT = old
+
+
+class ShardSchemaRoundTwoProbes(unittest.TestCase):
+    def test_nonstring_status_and_invalid_utf8_recorded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old = ric.REPO_ROOT
+            ric.REPO_ROOT = tmp
+            try:
+                d = Path(tmp) / ric.LEDGER_PREFIX / "aa"
+                d.mkdir(parents=True)
+                (d / "liststatus.json").write_text(
+                    json.dumps({"claim_id": "liststatus", "effective_status": ["retained"]})
+                )
+                (d / "badbytes.json").write_bytes(b'\xff\xfe{"claim_id"')
+                tracked = [
+                    ric.LEDGER_PREFIX + "aa/liststatus.json",
+                    ric.LEDGER_PREFIX + "aa/badbytes.json",
+                ]
+                result = ric.collect_ledger(tracked)
+                self.assertEqual(len(result["shard_parse_errors"]), 2)
+                self.assertEqual(result["effective_status_histogram"].get("SCHEMA_INVALID"), 1)
+                self.assertEqual(result["retained_grade_total"], 0)
+            finally:
+                ric.REPO_ROOT = old
+
+
+class DiffRoundTwoProbes(unittest.TestCase):
+    def _diff(self, a, b, allow=""):
+        with tempfile.TemporaryDirectory() as tmp:
+            pa, pb = Path(tmp) / "a.json", Path(tmp) / "b.json"
+            pa.write_text(json.dumps(a))
+            pb.write_text(json.dumps(b))
+            out = io.StringIO()
+            with redirect_stdout(out):
+                code = ric.run_diff(str(pa), str(pb), {k for k in allow.split(",") if k})
+            return code, out.getvalue()
+
+    def test_marker_key_cannot_spoof_empty_object(self):
+        code, _ = self._diff({"a": {}}, {"a": {"<empty-object>": True}})
+        self.assertEqual(code, 1)
+
+    def test_allow_covers_empty_to_populated_transition(self):
+        code, _ = self._diff({"a": {}}, {"a": {"k": 1}}, allow="a.k")
+        self.assertEqual(code, 0)
+
+    def test_dotted_key_does_not_collide_with_nesting(self):
+        code, _ = self._diff({"a.b": 1}, {"a": {"b": 1}})
+        self.assertEqual(code, 1)
+
+    def test_bool_is_not_number(self):
+        code, _ = self._diff({"a": True}, {"a": 1})
+        self.assertEqual(code, 1)
+
+
+class SnapshotOutputAliasGuardTest(unittest.TestCase):
+    def test_symlink_alias_to_tracked_file_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            victim = root / "Tracked.JSON"
+            victim.write_text("precious")
+            subprocess.run(["git", "-C", str(root), "add", "Tracked.JSON"], check=True)
+            link = root / "alias.json"
+            link.symlink_to(victim)
+            old = ric.REPO_ROOT
+            ric.REPO_ROOT = str(root)
+            argv = sys.argv
+            try:
+                for req in (str(link), str(root / "tracked.json")):
+                    sys.argv = ["ric", "--snapshot", req]
+                    out = io.StringIO()
+                    with redirect_stdout(out):
+                        code = ric.main()
+                    if "tracked.json" in req and not (root / "TRACKED.json").exists() \
+                            and not os.path.exists(str(root / "tracked.json")):
+                        pass  # case-alias probe only binds on case-insensitive fs
+                    if os.path.realpath(req) == os.path.realpath(str(victim)):
+                        self.assertEqual(code, 2, req)
+                        self.assertEqual(victim.read_text(), "precious")
+            finally:
+                ric.REPO_ROOT = old
+                sys.argv = argv
 
 
 if __name__ == "__main__":

--- a/docs/audit/scripts/tests/test_repo_invariants_check.py
+++ b/docs/audit/scripts/tests/test_repo_invariants_check.py
@@ -1,0 +1,169 @@
+"""Regression tests for the repo-invariants harness.
+
+Covers the review findings from PR #5399 round 1: markdown lexical context
+(code spans/fences, angle-bracket destinations, titles, non-path artifacts),
+schema-invalid ledger shards, tracked-set discipline (untracked files must
+not perturb measurements; untracked link targets are violations), and
+snapshot-diff sensitivity to missing-vs-null and empty-object changes.
+"""
+
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import repo_invariants_check as ric  # noqa: E402
+
+
+class ScanMarkdownLinkTargetsTest(unittest.TestCase):
+    def test_extracts_plain_link_with_relative_path(self):
+        self.assertEqual(
+            ric.scan_markdown_link_targets("see [x](../audit/data/ledger/)"),
+            ["../audit/data/ledger/"],
+        )
+
+    def test_ignores_links_inside_inline_code(self):
+        text = "every markdown link `[..](OTHER.md)` is treated as an edge"
+        self.assertEqual(ric.scan_markdown_link_targets(text), [])
+
+    def test_ignores_links_inside_fenced_code(self):
+        text = "```\n[real looking](DEAD.md)\n```\nafter"
+        self.assertEqual(ric.scan_markdown_link_targets(text), [])
+
+    def test_ignores_math_artifact_not_path_shaped(self):
+        text = "the Hessian candidate S[h] = 1/2 D^2 W[g_*](h,h) in the cell"
+        self.assertEqual(ric.scan_markdown_link_targets(text), [])
+
+    def test_handles_title_and_angle_bracket_destination(self):
+        text = '[a](X.md "The X note") and [b](<sub dir/Y.md>)'
+        self.assertEqual(
+            ric.scan_markdown_link_targets(text), ["X.md", "sub dir/Y.md"]
+        )
+
+    def test_skips_external_and_mailto(self):
+        text = "[w](https://example.org/x.md) [m](mailto:a@b.c) [k](K.md)"
+        self.assertEqual(ric.scan_markdown_link_targets(text), ["K.md"])
+
+
+class CollectLedgerSchemaTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_root = ric.REPO_ROOT
+        ric.REPO_ROOT = self._tmp.name
+        self.addCleanup(self._restore)
+        shard_dir = Path(self._tmp.name) / ric.LEDGER_PREFIX / "aa"
+        shard_dir.mkdir(parents=True)
+        (shard_dir / "good_note.json").write_text(json.dumps(
+            {"claim_id": "good_note", "effective_status": "unaudited",
+             "note_path": "docs/GOOD_NOTE.md"}))
+        (shard_dir / "list_shard.json").write_text("[]")
+        (shard_dir / "null_claim.json").write_text(json.dumps(
+            {"claim_id": None, "effective_status": "retained"}))
+
+    def _restore(self):
+        ric.REPO_ROOT = self._old_root
+        self._tmp.cleanup()
+
+    def test_schema_invalid_shards_recorded_not_crashed(self):
+        tracked = [
+            ric.LEDGER_PREFIX + "aa/good_note.json",
+            ric.LEDGER_PREFIX + "aa/list_shard.json",
+            ric.LEDGER_PREFIX + "aa/null_claim.json",
+            "docs/GOOD_NOTE.md",
+        ]
+        result = ric.collect_ledger(tracked)
+        self.assertEqual(result["shard_count"], 3)
+        self.assertEqual(len(result["shard_parse_errors"]), 2)
+        self.assertEqual(result["rows_with_missing_note_path"], 0)
+        self.assertEqual(
+            result["effective_status_histogram"], {"retained": 1, "unaudited": 1}
+        )
+
+    def test_untracked_files_do_not_perturb_measurement(self):
+        # An extra shard exists on disk but is not in the tracked list.
+        extra = Path(self._tmp.name) / ric.LEDGER_PREFIX / "aa" / "scratch.json"
+        extra.write_text(json.dumps({"claim_id": "scratch"}))
+        tracked = [ric.LEDGER_PREFIX + "aa/good_note.json", "docs/GOOD_NOTE.md"]
+        result = ric.collect_ledger(tracked)
+        self.assertEqual(result["shard_count"], 1)
+        self.assertNotIn("scratch", json.dumps(result))
+
+
+class AuthorityLinksTrackedSetTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        subprocess.run(["git", "init", "-q", str(root)], check=True)
+        self._old_root = ric.REPO_ROOT
+        ric.REPO_ROOT = str(root)
+        self.addCleanup(self._restore)
+        (root / "docs" / "repo").mkdir(parents=True)
+        (root / "README.md").write_text(
+            "[tracked](docs/TRACKED.md) [untracked](docs/PRESENT_UNTRACKED.md) "
+            "[gone](docs/MISSING.md) [dir](docs/repo/)"
+        )
+        (root / "docs" / "TRACKED.md").write_text("x")
+        (root / "docs" / "PRESENT_UNTRACKED.md").write_text("x")
+        (root / "docs" / "repo" / "KEEP.md").write_text("x")
+
+    def _restore(self):
+        ric.REPO_ROOT = self._old_root
+        self._tmp.cleanup()
+
+    def test_untracked_and_missing_targets_are_violations(self):
+        tracked = ["README.md", "docs/TRACKED.md", "docs/repo/KEEP.md"]
+        result = ric.collect_authority_links(tracked)
+        reasons = {v["target"]: v["reason"] for v in result["violations"]}
+        self.assertEqual(
+            reasons,
+            {
+                "docs/PRESENT_UNTRACKED.md": "untracked",
+                "docs/MISSING.md": "missing",
+            },
+        )
+
+
+class DiffSensitivityTest(unittest.TestCase):
+    def _diff(self, a: dict, b: dict, allow=""):
+        with tempfile.TemporaryDirectory() as tmp:
+            pa, pb = Path(tmp) / "a.json", Path(tmp) / "b.json"
+            pa.write_text(json.dumps(a))
+            pb.write_text(json.dumps(b))
+            out = io.StringIO()
+            with redirect_stdout(out):
+                code = ric.run_diff(
+                    str(pa), str(pb),
+                    {k for k in allow.split(",") if k},
+                )
+            return code, out.getvalue()
+
+    def test_missing_vs_null_is_a_difference(self):
+        code, out = self._diff({"a": {}}, {"a": {"k": None}})
+        self.assertEqual(code, 1)
+        self.assertIn("CHANGED", out)
+
+    def test_empty_object_appearance_is_a_difference(self):
+        code, out = self._diff({"a": {"k": 1}}, {"a": {"k": 1}, "b": {}})
+        self.assertEqual(code, 1)
+
+    def test_allow_is_dot_segment_bounded(self):
+        code, _ = self._diff({"a": {"b": 1, "bb": 1}}, {"a": {"b": 2, "bb": 2}},
+                             allow="a.b")
+        self.assertEqual(code, 1)  # a.bb change is NOT covered by allow=a.b
+
+    def test_identical_snapshots_pass(self):
+        code, out = self._diff({"a": {"k": 1}}, {"a": {"k": 1}})
+        self.assertEqual(code, 0)
+        self.assertIn("IDENTICAL", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/audit/scripts/tests/test_repo_invariants_check.py
+++ b/docs/audit/scripts/tests/test_repo_invariants_check.py
@@ -63,13 +63,14 @@ class CollectLedgerSchemaTest(unittest.TestCase):
         self._old_root = ric.REPO_ROOT
         ric.REPO_ROOT = self._tmp.name
         self.addCleanup(self._restore)
-        shard_dir = Path(self._tmp.name) / ric.LEDGER_PREFIX / "aa"
-        shard_dir.mkdir(parents=True)
-        (shard_dir / "good_note.json").write_text(json.dumps(
+        base = Path(self._tmp.name) / ric.LEDGER_PREFIX
+        (base / "go").mkdir(parents=True)
+        (base / "aa").mkdir(parents=True)
+        (base / "go" / "good_note.json").write_text(json.dumps(
             {"claim_id": "good_note", "effective_status": "unaudited",
              "note_path": "docs/GOOD_NOTE.md"}))
-        (shard_dir / "list_shard.json").write_text("[]")
-        (shard_dir / "null_claim.json").write_text(json.dumps(
+        (base / "aa" / "list_shard.json").write_text("[]")
+        (base / "aa" / "null_claim.json").write_text(json.dumps(
             {"claim_id": None, "effective_status": "retained"}))
 
     def _restore(self):
@@ -78,7 +79,7 @@ class CollectLedgerSchemaTest(unittest.TestCase):
 
     def test_schema_invalid_shards_recorded_not_crashed(self):
         tracked = [
-            ric.LEDGER_PREFIX + "aa/good_note.json",
+            ric.LEDGER_PREFIX + "go/good_note.json",
             ric.LEDGER_PREFIX + "aa/list_shard.json",
             ric.LEDGER_PREFIX + "aa/null_claim.json",
             "docs/GOOD_NOTE.md",
@@ -96,7 +97,7 @@ class CollectLedgerSchemaTest(unittest.TestCase):
         # An extra shard exists on disk but is not in the tracked list.
         extra = Path(self._tmp.name) / ric.LEDGER_PREFIX / "aa" / "scratch.json"
         extra.write_text(json.dumps({"claim_id": "scratch"}))
-        tracked = [ric.LEDGER_PREFIX + "aa/good_note.json", "docs/GOOD_NOTE.md"]
+        tracked = [ric.LEDGER_PREFIX + "go/good_note.json", "docs/GOOD_NOTE.md"]
         result = ric.collect_ledger(tracked)
         self.assertEqual(result["shard_count"], 1)
         self.assertNotIn("scratch", json.dumps(result))
@@ -272,14 +273,15 @@ class ShardSchemaRoundTwoProbes(unittest.TestCase):
             old = ric.REPO_ROOT
             ric.REPO_ROOT = tmp
             try:
-                d = Path(tmp) / ric.LEDGER_PREFIX / "aa"
-                d.mkdir(parents=True)
-                (d / "liststatus.json").write_text(
+                base = Path(tmp) / ric.LEDGER_PREFIX
+                (base / "li").mkdir(parents=True)
+                (base / "aa").mkdir(parents=True)
+                (base / "li" / "liststatus.json").write_text(
                     json.dumps({"claim_id": "liststatus", "effective_status": ["retained"]})
                 )
-                (d / "badbytes.json").write_bytes(b'\xff\xfe{"claim_id"')
+                (base / "aa" / "badbytes.json").write_bytes(b'\xff\xfe{"claim_id"')
                 tracked = [
-                    ric.LEDGER_PREFIX + "aa/liststatus.json",
+                    ric.LEDGER_PREFIX + "li/liststatus.json",
                     ric.LEDGER_PREFIX + "aa/badbytes.json",
                 ]
                 result = ric.collect_ledger(tracked)
@@ -408,15 +410,16 @@ class RoundThreeLedgerProbes(unittest.TestCase):
             old = ric.REPO_ROOT
             ric.REPO_ROOT = tmp
             try:
-                d = Path(tmp) / ric.LEDGER_PREFIX / "aa"
-                d.mkdir(parents=True)
-                (d / "alpha.json").write_text(json.dumps(
+                base = Path(tmp) / ric.LEDGER_PREFIX
+                (base / "aa").mkdir(parents=True)
+                (base / "ty").mkdir(parents=True)
+                (base / "aa" / "alpha.json").write_text(json.dumps(
                     {"claim_id": "beta", "effective_status": "unaudited"}))
-                (d / "typo.json").write_text(json.dumps(
+                (base / "ty" / "typo.json").write_text(json.dumps(
                     {"claim_id": "typo", "effective_status": "retianed"}))
                 result = ric.collect_ledger([
                     ric.LEDGER_PREFIX + "aa/alpha.json",
-                    ric.LEDGER_PREFIX + "aa/typo.json",
+                    ric.LEDGER_PREFIX + "ty/typo.json",
                 ])
                 errors = " ".join(result["shard_parse_errors"])
                 self.assertIn("!= filename stem", errors)
@@ -465,16 +468,17 @@ class RoundFourProbes(unittest.TestCase):
             old = ric.REPO_ROOT
             ric.REPO_ROOT = tmp
             try:
-                d = Path(tmp) / ric.LEDGER_PREFIX / "aa"
-                d.mkdir(parents=True)
-                (d / "noname.json").write_text(json.dumps(
+                base = Path(tmp) / ric.LEDGER_PREFIX
+                (base / "no").mkdir(parents=True)
+                (base / "em").mkdir(parents=True)
+                (base / "no" / "noname.json").write_text(json.dumps(
                     {"claim_id": "noname", "effective_status": "unaudited"}))
-                (d / "empty.json").write_text(json.dumps(
+                (base / "em" / "empty.json").write_text(json.dumps(
                     {"claim_id": "empty", "effective_status": "unaudited",
                      "note_path": ""}))
                 result = ric.collect_ledger([
-                    ric.LEDGER_PREFIX + "aa/noname.json",
-                    ric.LEDGER_PREFIX + "aa/empty.json",
+                    ric.LEDGER_PREFIX + "no/noname.json",
+                    ric.LEDGER_PREFIX + "em/empty.json",
                 ])
                 self.assertEqual(len(result["shard_parse_errors"]), 2)
             finally:
@@ -515,6 +519,53 @@ class RoundFourProbes(unittest.TestCase):
                 second = ric.collect_authority_links(["README.md"])
                 self.assertEqual(first["violations"], second["violations"])
                 self.assertEqual(first["violations"][0]["reason"], "not-tracked")
+            finally:
+                ric.REPO_ROOT = old
+
+
+
+
+class RoundFiveProbes(unittest.TestCase):
+    def test_wrong_fanout_is_a_schema_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old = ric.REPO_ROOT
+            ric.REPO_ROOT = tmp
+            try:
+                base = Path(tmp) / ric.LEDGER_PREFIX
+                (base / "zz").mkdir(parents=True)
+                (base / "zz" / "alpha.json").write_text(json.dumps(
+                    {"claim_id": "alpha", "effective_status": "unaudited",
+                     "note_path": "docs/A.md"}))
+                result = ric.collect_ledger(
+                    [ric.LEDGER_PREFIX + "zz/alpha.json", "docs/A.md"])
+                self.assertIn("not at canonical shard path",
+                              " ".join(result["shard_parse_errors"]))
+            finally:
+                ric.REPO_ROOT = old
+
+    def test_irregular_authority_surface_fails_check(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(os.path.realpath(tmp))
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            target = root / "REAL.md"
+            target.write_text("[authority](docs/MISSING.md)")
+            (root / "README.md").symlink_to(target)
+            subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+            # minimal registries so build_snapshot parses
+            for rel, payload in ((ric.PREMISE_NODES, {"nodes": {}}),
+                                 (ric.OBLIGATIONS, {"nodes": {}})):
+                p = root / rel
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text(json.dumps(payload))
+            subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+            old = ric.REPO_ROOT
+            ric.REPO_ROOT = str(root)
+            try:
+                out = io.StringIO()
+                with redirect_stdout(out):
+                    code = ric.run_check(False)
+                self.assertEqual(code, 1)
+                self.assertIn("not regular files", out.getvalue())
             finally:
                 ric.REPO_ROOT = old
 

--- a/docs/audit/scripts/tests/test_repo_invariants_check.py
+++ b/docs/audit/scripts/tests/test_repo_invariants_check.py
@@ -1,11 +1,11 @@
 """Regression tests for the repo-invariants harness.
 
-Encodes the concrete probe cases from the PR #5399 sol-max review rounds
-(markdown masking and link grammar, ledger-shard schema safety, tracked-set
-discipline for every measured family, destination classification, snapshot
-diff sensitivity, and the alias-safe snapshot-output refusal). It is a
-regression boundary for those named cases, not a full CommonMark or JSON
-conformance suite.
+Encodes concrete adversarial probe cases: markdown masking and link grammar,
+ledger-shard schema and canonical-placement safety, tracked-set discipline
+for every measured family, destination classification, snapshot diff
+sensitivity, and the snapshot-output write refusal. It is a regression
+boundary for those named cases, not a full CommonMark or JSON conformance
+suite.
 """
 
 import io
@@ -568,6 +568,84 @@ class RoundFiveProbes(unittest.TestCase):
                 self.assertIn("not regular files", out.getvalue())
             finally:
                 ric.REPO_ROOT = old
+
+
+
+
+class RoundSixProbes(unittest.TestCase):
+    def _mk_repo(self, tmp):
+        root = Path(os.path.realpath(tmp))
+        subprocess.run(["git", "init", "-q", str(root)], check=True)
+        for rel, payload in ((ric.PREMISE_NODES, {"nodes": {}}),
+                             (ric.OBLIGATIONS, {"nodes": {}})):
+            p = root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(json.dumps(payload))
+        return root
+
+    def _check(self, root, enforce):
+        old = ric.REPO_ROOT
+        ric.REPO_ROOT = str(root)
+        try:
+            out = io.StringIO()
+            with redirect_stdout(out):
+                return ric.run_check(enforce), out.getvalue()
+        finally:
+            ric.REPO_ROOT = old
+
+    def test_absent_and_null_status_fail_check_end_to_end(self):
+        for status_form in ("absent", "null"):
+            with tempfile.TemporaryDirectory() as tmp:
+                root = self._mk_repo(tmp)
+                shard_dir = root / ric.LEDGER_PREFIX / "al"
+                shard_dir.mkdir(parents=True)
+                row = {"claim_id": "alpha", "note_path": "docs/A.md"}
+                if status_form == "null":
+                    row["effective_status"] = None
+                (shard_dir / "alpha.json").write_text(json.dumps(row))
+                (root / "docs").mkdir(exist_ok=True)
+                (root / "docs" / "A.md").write_text("x")
+                subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+                for enforce in (False, True):
+                    code, out = self._check(root, enforce)
+                    self.assertEqual(code, 1, (status_form, enforce))
+                    self.assertIn("missing/null effective_status", out)
+
+    def test_wrong_fanout_fails_check_end_to_end(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._mk_repo(tmp)
+            shard_dir = root / ric.LEDGER_PREFIX / "zz"
+            shard_dir.mkdir(parents=True)
+            (shard_dir / "alpha.json").write_text(json.dumps(
+                {"claim_id": "alpha", "effective_status": "unaudited",
+                 "note_path": "docs/A.md"}))
+            (root / "docs").mkdir(exist_ok=True)
+            (root / "docs" / "A.md").write_text("x")
+            subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+            for enforce in (False, True):
+                code, out = self._check(root, enforce)
+                self.assertEqual(code, 1)
+                self.assertIn("not at canonical shard path", out)
+
+    def test_irregular_surface_fails_enforced_mode_too(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._mk_repo(tmp)
+            target = root / "REAL.md"
+            target.write_text("[authority](docs/MISSING.md)")
+            (root / "README.md").symlink_to(target)
+            subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+            code, out = self._check(root, True)
+            self.assertEqual(code, 1)
+            self.assertIn("not regular files", out)
+
+    def test_malformed_registry_is_structured_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._mk_repo(tmp)
+            (root / ric.PREMISE_NODES).write_text("{not json")
+            subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+            code, out = self._check(root, False)
+            self.assertEqual(code, 1)
+            self.assertIn("premises", out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

A read-only measurement tool: `docs/audit/scripts/repo_invariants_check.py`.

- `--snapshot [PATH]` — canonical JSON of tracked structural invariants: ledger shard count + claim-id set hash + effective-status histogram + retained-grade total, premise/obligation ids, docs basename uniqueness, authority-surface link violations.
- `--diff A B [--allow keys]` — mechanical before/after gate for hygiene PRs: exits 1 on any invariant change not declared via `--allow`.
- `--check [--enforce-links]` — absolute integrity checks; the authority-link scan is warn-only until the known violations are repaired, then `--enforce-links` becomes the standing gate.

## Why

Owner-ratified operating model: build the ruler before cutting. Every subsequent hygiene/tooling PR runs snapshot-before/snapshot-after and declares its expected deltas.

## What the first run measures on main (warn-only)

- `docs/audit/AUDIT_LEDGER.md` is **gitignored** (untracked since the 2026-07-13 sharding) yet linked as the status authority from 9 tracked surfaces incl. README and FRONT_DOOR_STATUS — 404s on fresh clone/GitHub.
- `docs/audit/data/audit_queue.json` gitignored, linked from FRONT_DOOR_STATUS.
- Generated `docs/audit/MISSING_DERIVATION_PROMPTS.md` emits ~110 links with a wrong `docs/audit/docs/…` prefix (generator bug).
- One placeholder `docs/audit/OTHER.md` link; one malformed `h,h` link in DERIVATION_ATLAS.

Repairs land separately (authority-link repair PR next); this PR only adds the measurement.

## Boundaries

Read-only; no audit-status authority; mints no verdicts; touches no generated surface; not wired into the pipeline yet (wiring proposed together with the link repair so the gate flips on clean).

Verification: `--check` PASS (warn-only) on main; `--check --enforce-links` exits 1 as expected; snapshot totals match FRONT_DOOR_STATUS (3754 rows, 395 retained-grade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)