### PR TITLE
audit-infra: parenthesized redaction token + legend in effective-status views (fixes prose garble)

### DIFF
--- a/docs/audit/scripts/render_publication_effective_status.py
+++ b/docs/audit/scripts/render_publication_effective_status.py
@@ -103,6 +103,14 @@ PROTECTED_INLINE_RE = re.compile(r"(\[[^\]]+\]\([^)]+\)|\[audit:[^\]]+\])")
 # Parenthesized so the redaction reads as a deliberate editorial token in both
 # label cells and running prose, and stays safe inside markdown link labels.
 REDACTION_TOKEN = "(unratified-source-label)"
+REDACTION_LEGEND = (
+    "**Redaction legend:** every row marked `AUDIT-NONRETAINED ROW` (a row citing "
+    "any non-retained authority, or citing no linked authority at all — the check "
+    "fails closed) has author-side status words replaced by the token "
+    "`(unratified-source-label)` so it cannot be read or scraped as retained "
+    "prose. Each `[audit:...]` badge gives the ledger-derived status of its "
+    "adjacent linked authority; the absence of a badge is never retention."
+)
 SOURCE_STATUS_WORD_RE = re.compile(
     r"\b(?:retained(?:_bounded|_no_go|_pending_chain)?|promoted|"
     r"audited_(?:clean|conditional|renaming|decoration|failed|numerical_match)|"
@@ -404,10 +412,7 @@ def render_table(source_name: str, output_name: str, scope_label: str,
         f"**Retained-grade values:** `retained`, `retained_bounded`, `retained_no_go`. "
         f"Anything else means the audit lane has NOT confirmed the claim, regardless of "
         f"the author-side status text in the row.\n\n"
-        f"**Redaction legend:** in rows citing any non-retained authority, author-side "
-        f"status words are replaced by the token `(unratified-source-label)` so no "
-        f"unratified row can be read or scraped as retained prose; the `[audit:...]` "
-        f"badge on each row carries the ledger-derived status.\n\n"
+        f"{REDACTION_LEGEND}\n\n"
         f"---\n\n"
     )
 

--- a/docs/audit/scripts/render_publication_effective_status.py
+++ b/docs/audit/scripts/render_publication_effective_status.py
@@ -100,6 +100,9 @@ FOUNDATIONAL_ROW_ALLOWLIST = {
     ("RESULTS_INDEX.md", "Framework / claim surface"): {"minimal_axioms"},
 }
 PROTECTED_INLINE_RE = re.compile(r"(\[[^\]]+\]\([^)]+\)|\[audit:[^\]]+\])")
+# Parenthesized so the redaction reads as a deliberate editorial token in both
+# label cells and running prose, and stays safe inside markdown link labels.
+REDACTION_TOKEN = "(unratified-source-label)"
 SOURCE_STATUS_WORD_RE = re.compile(
     r"\b(?:retained(?:_bounded|_no_go|_pending_chain)?|promoted|"
     r"audited_(?:clean|conditional|renaming|decoration|failed|numerical_match)|"
@@ -118,14 +121,14 @@ def _neutralize_source_status_words(line: str) -> str:
     parts = PROTECTED_INLINE_RE.split(line)
     for index, part in enumerate(parts):
         if index % 2 == 0:
-            parts[index] = SOURCE_STATUS_WORD_RE.sub("unratified-source-label", part)
+            parts[index] = SOURCE_STATUS_WORD_RE.sub(REDACTION_TOKEN, part)
             continue
         if part.startswith("[audit:"):
             continue
         link = re.fullmatch(r"\[([^\]]+)\]\(([^)]+)\)", part)
         if link:
             label = SOURCE_STATUS_WORD_RE.sub(
-                "unratified-source-label", link.group(1)
+                REDACTION_TOKEN, link.group(1)
             )
             parts[index] = f"[{label}]({link.group(2)})"
     return "".join(parts)
@@ -401,6 +404,10 @@ def render_table(source_name: str, output_name: str, scope_label: str,
         f"**Retained-grade values:** `retained`, `retained_bounded`, `retained_no_go`. "
         f"Anything else means the audit lane has NOT confirmed the claim, regardless of "
         f"the author-side status text in the row.\n\n"
+        f"**Redaction legend:** in rows citing any non-retained authority, author-side "
+        f"status words are replaced by the token `(unratified-source-label)` so no "
+        f"unratified row can be read or scraped as retained prose; the `[audit:...]` "
+        f"badge on each row carries the ledger-derived status.\n\n"
         f"---\n\n"
     )
 

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -656,6 +656,15 @@ class PublicationEffectiveStatusRenderTest(unittest.TestCase):
             )
             self.assertIn("AUDIT-NONRETAINED ROW", spoofed.splitlines()[2])
 
+    def test_redaction_legend_names_failclosed_scope_and_badge_granularity(self):
+        m = _import("render_publication_effective_status")
+        legend = m.REDACTION_LEGEND
+        self.assertIn("AUDIT-NONRETAINED ROW", legend)
+        self.assertIn("(unratified-source-label)", legend)
+        self.assertIn("fails closed", legend)
+        self.assertIn("absence of a badge is never retention", legend)
+        self.assertIn("adjacent linked authority", legend)
+
     def test_unsafe_row_neutralizes_code_and_link_status_labels(self):
         m = _import("render_publication_effective_status")
         body = (

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -665,8 +665,8 @@ class PublicationEffectiveStatusRenderTest(unittest.TestCase):
             f"{m.DERIVED_UNSAFE}[audit:unaudited] |\n"
         )
         rendered = m.demote_nonretained_table_rows(body)
-        self.assertIn("`unratified-source-label`", rendered)
-        self.assertIn("[unratified-source-label result](X.md)", rendered)
+        self.assertIn("`(unratified-source-label)`", rendered)
+        self.assertIn("[(unratified-source-label) result](X.md)", rendered)
         self.assertNotIn("`retained`", rendered)
 
 


### PR DESCRIPTION
## What

The generated effective-status views neutralize author-side status words in rows citing non-retained authorities — by design, so an unratified row can never be read or scraped as retained prose. But the bare replacement token produced ungrammatical output (~89 cells like *"not unratified-source-label beyond it"*) that reads as tooling failure to an external reviewer.

- Token becomes the parenthesized `(unratified-source-label)` via a named `REDACTION_TOKEN` constant (safe in prose **and** inside markdown link labels, where a bracketed token would break rendering).
- Every generated view header gains a one-line **redaction legend** explaining the token and pointing at the `[audit:...]` badge.
- Invariant unchanged and still test-enforced: no \b(retained|promoted)\b survives in a neutralized row.

## Verification

- `python3 -m unittest docs.audit.scripts.tests.test_audit_pipeline` — **356 tests OK** (two literal expectations updated to the new token).
- Views regenerated locally: 47 tokens in CLAIMS view, legend present, prose now reads as deliberate redaction (*"not (unratified-source-label) beyond the O(alpha_s(v)^2) remainder"*). Generated outputs restored before commit — they land only via the audit lane's nightly refresh.

## Boundaries

Renderer + its tests only. No science, no status authority, no generated surfaces shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)