### PR TITLE
Fix SU(3) Wigner decuplet channel identification

### DIFF
--- a/docs/SU3_WIGNER_INTERTWINER_BLOCK1_THEOREM_NOTE_2026-05-03.md
+++ b/docs/SU3_WIGNER_INTERTWINER_BLOCK1_THEOREM_NOTE_2026-05-03.md
@@ -4,19 +4,16 @@
 
 **Claim type:** positive_theorem
 
-**Status:** unaudited positive-theorem candidate. The representation-theoretic
-decomposition and all-\(g\) equivariance statement are exact mathematical
-claims; the supplied matrices, diagonalization, and residual checks are finite
-`complex128` numerical witnesses.
+The representation-theoretic decomposition and all-\(g\) equivariance
+statement are exact mathematical claims. The supplied matrices,
+diagonalization, and residual checks are finite `complex128` numerical
+witnesses. Independent re-audit owns ratification.
 
 **Primary runner:**
 [`frontier_su3_wigner_intertwiner_engine.py`](../scripts/frontier_su3_wigner_intertwiner_engine.py)
 
 **Pinned output:**
 [`frontier_su3_wigner_intertwiner_engine.txt`](../logs/runner-cache/frontier_su3_wigner_intertwiner_engine.txt)
-
-**Block in campaign:** 1 of N; later cube/tensor-network blocks are out of
-scope here.
 
 ## 1. Exact statement
 
@@ -42,6 +39,10 @@ summands. Exchange of the two adjoint factors splits them as
 Sym²(8) = 1 ⊕ 8_s ⊕ 27,       dimensions 1 + 8 + 27 = 36,
 Λ²(8)   = 8_a ⊕ 10 ⊕ 10bar,   dimensions 8 + 10 + 10 = 28.
 ```
+
+The Littlewood–Richardson decomposition, canonical SU(3) Casimir formulas,
+and Casimir invariance are standard representation-theory inputs. No
+measured, fitted, observational, or lattice quantity enters this theorem.
 
 ## 2. Casimir convention and corrected channel labels
 
@@ -80,7 +81,8 @@ H = C2_total + α E + β C3_total,
 α = √2,        β = √3/7,
 ```
 
-the executable channel table is:
+where \(\alpha,\beta\) are auxiliary channel-separation coefficients with no
+physical content. The executable channel table is:
 
 | Channel | Dynkin label | Rank | Exchange | C2 | C3 | H |
 |---|---:|---:|---:|---:|---:|---:|
@@ -125,6 +127,11 @@ the two factors. Functional calculus therefore gives
 
 for every \(g\in SU(3)\), exactly.
 
+The factors \((I\pm C_3/9)/2\) are not standalone projectors on the full
+space: every zero-\(C_3\) sector would receive eigenvalue \(1/2\). They are
+used only after \(L_6(C_2)S_-\) restricts to the 20-dimensional decuplet
+pair, where the cubic spectrum is exactly \(\{-9,+9\}\).
+
 The runner also diagonalizes the finite `complex128` matrix \(H\), groups its
 eigenvectors by the six expected eigenvalues, and forms numerical projectors
 \(P=VV^\dagger\). Floating-point diagonalization supplies reproducible
@@ -155,7 +162,9 @@ The checks include:
 3. \(C_2(1,1)=3\) and \(C_3(1,1)=0\).
 4. Independent fundamental/antifundamental confirmation of the canonical
    cubic-Casimir sign.
-5. Hermiticity and pairwise commutation of \(C_2\), \(E\), and \(C_3\).
+5. Hermiticity and pairwise commutation of \(C_2\), \(E\), and \(C_3\),
+   together with agreement between the total \(C_3\) and an independently
+   expanded coproduct formula.
 6. Six separated \(H\) clusters with ranks `1,8,8,10,10,27`.
 7. Orthonormality of the returned numerical eigenbasis.
 8. For every channel projector: Hermiticity, idempotence, rank, and the
@@ -166,6 +175,14 @@ The checks include:
 11. Hostile controls:
     - the former swapped `10`/`10bar` labels miss the observed \(C_3\) values
       by 18;
+    - a global \(C_3\) sign flip disagrees at order one with the independent
+      coproduct expansion;
+    - the wrong antifundamental convention \(+t_a^*\) gives the fundamental
+      rather than conjugate cubic sign and violates the SU(3) Lie algebra
+      with residual 1;
+    - using \((I+C_3/9)/2\) on the full space gives rank 54 and idempotence
+      residual \(1/4\), while restricting first to \(C_2=6,E=-1\) gives the
+      rank-10 decuplet projector;
     - omitting \(C_3\) leaves only five clusters and one rank-20
       \(C_2=6,E=-1\) projector whose restricted \(C_3\) spectrum is
       \([-9,+9]\).
@@ -196,6 +213,7 @@ projectors:
 | `cubic_casimir(T, d)` | cubic Casimir for supplied generators |
 | `tensor_product_casimir(T)` | total \(C_2\) on \(8\otimes8\) |
 | `tensor_product_cubic_casimir(T, d)` | total \(C_3\) on \(8\otimes8\) |
+| `tensor_product_cubic_casimir_coproduct_expansion(T, d)` | independently expanded total \(C_3\) |
 | `exchange_operator(dim)` | tensor-factor exchange |
 | `cg_decomposition(C2, E, C3)` | numerical \(H\) eigenvalues/eigenbasis |
 | `spectral_channel_projectors(...)` | six eigensolver spectral projectors |
@@ -204,13 +222,15 @@ projectors:
 
 ## 6. Downstream boundary
 
-The [Block 2 note](SU3_WIGNER_INTERTWINER_BLOCK2_THEOREM_NOTE_2026-05-03.md)
-uses only the unordered conjugate pair `10 + 10bar` in its fusion-counting
-rank calculation, and its runner re-bundles its own primitives rather than
+The downstream
+`SU3_WIGNER_INTERTWINER_BLOCK2_THEOREM_NOTE_2026-05-03.md` uses only the
+unordered conjugate pair `10 + 10bar` in its fusion-counting rank
+calculation, and its runner re-bundles its own primitives rather than
 importing this runner. The label correction therefore changes no Block 2
 formula, rank, or API call. Block 3 and later cube/tensor-network blocks
-carry only dependency references and do not pin either corrected
-eigenvalue label. No downstream source changes are needed.
+carry only dependency references and do not pin either corrected eigenvalue
+label. The filename is deliberately backticked here because this is a
+downstream context pointer, not a load-bearing dependency of Block 1.
 
 ## 7. Scope and audit handoff
 
@@ -231,9 +251,7 @@ claim_id: su3_wigner_intertwiner_block1_theorem_note_2026-05-03
 note_path: docs/SU3_WIGNER_INTERTWINER_BLOCK1_THEOREM_NOTE_2026-05-03.md
 runner_path: scripts/frontier_su3_wigner_intertwiner_engine.py
 claim_type: positive_theorem
-intrinsic_status: unaudited
 deps: []
-audit_authority: independent audit lane only
 ```
 
 ## 8. Reproduction
@@ -242,5 +260,6 @@ audit_authority: independent audit lane only
 python3 scripts/frontier_su3_wigner_intertwiner_engine.py
 ```
 
-The SHA-pinned cache linked above is regenerated from the runner and must
-match its live stdout byte for byte after the cache header.
+The SHA-pinned cache linked above is regenerated from the runner. Its stdout
+payload must match live stdout after excluding the cache writer's delimiter
+newline.

--- a/docs/SU3_WIGNER_INTERTWINER_BLOCK1_THEOREM_NOTE_2026-05-03.md
+++ b/docs/SU3_WIGNER_INTERTWINER_BLOCK1_THEOREM_NOTE_2026-05-03.md
@@ -1,192 +1,230 @@
-# SU(3) Wigner Intertwiner Engine — Block 1: (1,1) ⊗ (1,1) CG decomposition
+# SU(3) Wigner Intertwiner Engine — Block 1: (1,1) ⊗ (1,1)
 
 **Date:** 2026-05-03
+
 **Claim type:** positive_theorem
-**Status:** unaudited positive theorem candidate — pure SU(3) representation
-theory; all checks pass to machine precision (1e-15). Effective retained
-status is audit-lane authority only.
-**Primary runner:** `scripts/frontier_su3_wigner_intertwiner_engine.py`
-**Block in campaign:** 1 of N (cube-closure campaign for gauge-scalar bridge
-no-go #477)
 
-## 0. Headline
+**Status:** unaudited positive-theorem candidate. The representation-theoretic
+decomposition and all-\(g\) equivariance statement are exact mathematical
+claims; the supplied matrices, diagonalization, and residual checks are finite
+`complex128` numerical witnesses.
 
-Block 1 deliverable: explicit Clebsch-Gordan decomposition of the SU(3)
-adjoint tensor product
+**Primary runner:**
+[`frontier_su3_wigner_intertwiner_engine.py`](../scripts/frontier_su3_wigner_intertwiner_engine.py)
 
-```text
-(1,1) ⊗ (1,1) = (0,0) ⊕ 2·(1,1) ⊕ (3,0) ⊕ (0,3) ⊕ (2,2)
-              = 1   ⊕ 8   ⊕ 8    ⊕ 10    ⊕ 10̄  ⊕ 27
-                (dimensions: 1 + 8 + 8 + 10 + 10 + 27 = 64 ✓)
-```
+**Pinned output:**
+[`frontier_su3_wigner_intertwiner_engine.txt`](../logs/runner-cache/frontier_su3_wigner_intertwiner_engine.txt)
 
-via simultaneous diagonalization of the **quadratic Casimir + exchange +
-cubic Casimir** on `V_(1,1) ⊗ V_(1,1) = C^8 ⊗ C^8`. Validated to machine
-precision against:
+**Block in campaign:** 1 of N; later cube/tensor-network blocks are out of
+scope here.
 
-- 6 distinct fusion channels with correct dimensions
-- orthonormality of CG basis
-- SU(3) equivariance: `D(g)⊗D(g)` commutes with all 3 operators
-- canonical SU(3) Casimir eigenvalues
-- antisymmetry of `f_abc` and symmetry of `d_abc` structure constants
+## 1. Exact statement
 
-## 1. Algorithm
-
-### 1.1 Building blocks
-
-- **Gell-Mann basis** `{λ_a, a=1..8}`: standard 3x3 traceless Hermitian
-  matrices, normalized `Tr[λ_a λ_b] = 2 δ_(ab)`.
-- **Structure constants:**
-  ```text
-  f_abc = (1/(4i)) Tr[λ_c [λ_a, λ_b]]   (antisymmetric)
-  d_abc = (1/4)   Tr[λ_c {λ_a, λ_b}]    (symmetric, traceless part)
-  ```
-  Computed numerically; verified `f` antisymmetric, `d` symmetric to
-  machine zero.
-- **Adjoint generators:** `T^a_(b,c) = -i f_(abc)` as 8x8 Hermitian matrices.
-  Satisfy `[T^a, T^b] = i f_abc T^c` to machine precision.
-
-### 1.2 Casimirs and exchange
-
-- **Quadratic Casimir on (1,1):**
-  ```text
-  C_2 = Σ_a (T^a)^2
-  ```
-  All eigenvalues = 3 on `V_(1,1)` (matches canonical SU(3) value).
-
-- **Quadratic Casimir on V_(1,1) ⊗ V_(1,1):**
-  ```text
-  C_2_total = C ⊗ I + 2 Σ_a (T^a ⊗ T^a) + I ⊗ C
-            = Σ_a (T^a ⊗ I + I ⊗ T^a)^2
-  ```
-
-- **Cubic Casimir on V_(1,1) ⊗ V_(1,1):**
-  ```text
-  C_3_total = Σ_(abc) d_(abc) (T^a ⊗ I + I ⊗ T^a)
-                                (T^b ⊗ I + I ⊗ T^b)
-                                (T^c ⊗ I + I ⊗ T^c)
-  ```
-  Distinguishes conjugate irreps `(p, q)` and `(q, p)` (e.g., (3,0) vs (0,3))
-  by sign.
-
-- **Exchange operator** `E` swaps the two factors of `V ⊗ V`:
-  ```text
-  E |i⟩ ⊗ |j⟩ = |j⟩ ⊗ |i⟩
-  ```
-  Satisfies `E^2 = I` exactly.
-
-### 1.3 Simultaneous diagonalization
-
-Diagonalize
+The SU(3) adjoint tensor square decomposes as
 
 ```text
-H = C_2_total + α E + β C_3_total
+V_(1,1) ⊗ V_(1,1)
+  ≅ V_(0,0) ⊕ V_(1,1)_s ⊕ V_(1,1)_a
+    ⊕ V_(3,0) ⊕ V_(0,3) ⊕ V_(2,2)
+  ≅ 1 ⊕ 8_s ⊕ 8_a ⊕ 10 ⊕ 10bar ⊕ 27.
 ```
 
-with irrational coefficients `α = sqrt(2), β = sqrt(3)/7` chosen to lift
-all degeneracies. The 6 distinct eigenvalues correspond to the 6 fusion
-channels:
-
-| Eigenvalue | Multiplicity | Identification |
-|---|---|---|
-| 1.4142 | 1 | (0,0) trivial, exchange-symmetric |
-| 1.5858 | 8 | (1,1)_a antisymmetric adjoint copy |
-| 2.3589 | 10 | (3,0) decuplet (10), antisymmetric |
-| 4.4142 | 8 | (1,1)_s symmetric adjoint copy |
-| 6.8127 | 10 | (0,3) antidecuplet (10̄), antisymmetric |
-| 9.4142 | 27 | (2,2) symmetric traceless rank-2 |
-
-The eigenvectors form an orthonormal CG basis on `V_(1,1) ⊗ V_(1,1)`.
-
-## 2. Validation results
-
-`SUMMARY: THEOREM PASS=8 FAIL=0`
-
-| # | Check | Result |
-|---|---|---|
-| V1 | f_abc antisymmetry, d_abc symmetry | machine zero |
-| V2 | adjoint generators Hermitian | machine zero |
-| V3 | Lie algebra `[T^a, T^b] = i f_abc T^c` | 3.3e-16 |
-| V4 | C_2 on (1,1) = 3 (all eigenvalues) | exact |
-| V5 | E^2 = I | machine zero |
-| V6 | dimensions sum to 64 | exact |
-| V7 | 6 channels with dims {1, 8, 8, 10, 10, 27} | exact |
-| V8 | CG basis orthonormal | 2.0e-15 |
-| V9 | SU(3) equivariance of decomposition | 1.3e-15 |
-
-All validation checks pass at machine precision. The CG basis is
-ready for use in Block 2 (4-fold Haar projector).
-
-## 3. Theorem statement
-
-**Theorem (SU(3) (1,1) ⊗ (1,1) CG decomposition, Block 1).**
-The tensor product of two SU(3) adjoint representations decomposes as
+The dimensions are
 
 ```text
-V_(1,1) ⊗ V_(1,1) = V_(0,0) ⊕ V_(1,1)_s ⊕ V_(1,1)_a ⊕ V_(3,0) ⊕ V_(0,3) ⊕ V_(2,2)
+1 + 8 + 8 + 10 + 10 + 27 = 64 = 8 × 8.
 ```
 
-with dimensions 1 + 8 + 8 + 10 + 10 + 27 = 64. The runner
-`scripts/frontier_su3_wigner_intertwiner_engine.py` constructs an
-explicit orthonormal Clebsch-Gordan basis via simultaneous
-diagonalization of the quadratic Casimir, the cubic Casimir, and the
-exchange operator, and validates the construction to machine precision
-against 9 independent identities.
+The Littlewood–Richardson decomposition gives the displayed irreducible
+summands. Exchange of the two adjoint factors splits them as
 
-The CG basis (returned as `eigvecs` from `cg_decomposition()`) is
-SU(3)-equivariant: each fusion-channel block transforms as the
-corresponding irreducible representation under `D(g) ⊗ D(g)` for any
-`g ∈ SU(3)`.
+```text
+Sym²(8) = 1 ⊕ 8_s ⊕ 27,       dimensions 1 + 8 + 27 = 36,
+Λ²(8)   = 8_a ⊕ 10 ⊕ 10bar,   dimensions 8 + 10 + 10 = 28.
+```
 
-**Proof sketch.** The Casimir + exchange + cubic Casimir form a
-maximal commuting set on `V_(1,1) ⊗ V_(1,1)` whose simultaneous
-eigenvalues uniquely label the 6 fusion channels. Numerical
-diagonalization is exact in finite-dimensional linear algebra (no
-truncation, no approximation), with eigenvalues separated by O(1)
-gaps. ∎
+## 2. Casimir convention and corrected channel labels
 
-## 4. Block 1 API (importable for Block 2 and beyond)
+The runner uses the standard Gell-Mann normalization
 
-The runner exposes:
+```text
+t_a = λ_a/2,     Tr(t_a t_b) = δ_ab/2.
+```
 
-| Function | Returns | Used by |
-|---|---|---|
-| `gellmann_basis()` | List of 8 Gell-Mann matrices | All blocks |
-| `structure_constants()` | (f_abc, d_abc) | Blocks 2-5 |
-| `adjoint_generators(f)` | List of 8 adjoint generators | Blocks 2-5 |
-| `adjoint_matrix(g, lam)` | D^(1,1)(g) matrix | Blocks 2-5 |
-| `random_su3(seed)` | Random SU(3) element | All blocks |
-| `adjoint_casimir(T)` | C_2 on (1,1) | Blocks 2-5 |
-| `cubic_casimir(T, d)` | C_3 on (1,1) | Blocks 2-5 |
-| `tensor_product_casimir(T)` | C_2_total on V⊗V | Block 2 |
-| `tensor_product_cubic_casimir(T, d)` | C_3_total on V⊗V | Block 2 |
-| `exchange_operator(dim)` | Exchange E | Block 2 |
-| `cg_decomposition(C, E, C3)` | CG basis | Block 2 |
+For Dynkin label \((p,q)\), the canonical eigenvalues in this convention are
 
-## 5. Scope
+```text
+C2(p,q) = (p² + q² + pq + 3p + 3q)/3,
+C3(p,q) = (p-q)(2p+q+3)(p+2q+3)/18.
+```
 
-### In scope (this Block)
+The sign is anchored independently of the tensor-product eigensolver by
+directly contracting \(d_{abc}t_at_bt_c\) in the fundamental and
+antifundamental representations:
 
-- Pure SU(3) (1,1) ⊗ (1,1) CG decomposition
-- Validated to machine precision against representation-theory identities
+```text
+C3(1,0) = +10/9,       C3(0,1) = -10/9.
+```
 
-### Out of scope (deferred to subsequent Blocks)
+Consequently,
 
-- **Block 2:** 4-fold Haar projector `∫dU [D(U)]⊗4` via CG contraction
-  on the L=3 cube's 4-link incidence structure
-- **Block 3:** L_s=3 cube geometry encoder + tensor-network setup
-- **Block 4:** Cube partition function computation; `P_cube(L=3, β=6)`
-- **Block 5:** Final P_cube vs ε_witness verdict; ship as PR
+```text
+C3(3,0) = +9  for the decuplet 10,
+C3(0,3) = -9  for the antidecuplet 10bar.
+```
 
-### Cluster classification
+With
 
-This is **SU(3) representation theory**, NOT in the
-`gauge_vacuum_plaquette_*` family. It serves as foundational
-infrastructure for downstream lattice gauge work but is itself a
-purely algebraic deliverable. Cluster cap for the gauge-vacuum-plaquette
-family does not apply to this Block.
+```text
+H = C2_total + α E + β C3_total,
+α = √2,        β = √3/7,
+```
 
-## 6. Audit consequence
+the executable channel table is:
+
+| Channel | Dynkin label | Rank | Exchange | C2 | C3 | H |
+|---|---:|---:|---:|---:|---:|---:|
+| `1` | (0,0) | 1 | +1 | 0 | 0 | 1.4142136 |
+| `8_a` | (1,1) | 8 | -1 | 3 | 0 | 1.5857864 |
+| `8_s` | (1,1) | 8 | +1 | 3 | 0 | 4.4142136 |
+| `10` | (3,0) | 10 | -1 | +6 | **+9** | **6.8127089** |
+| `10bar` | (0,3) | 10 | -1 | +6 | **-9** | **2.3588640** |
+| `27` | (2,2) | 27 | +1 | 8 | 0 | 9.4142136 |
+
+This corrects the former reversal of the `10` and `10bar` rows.
+
+## 3. Exact projectors and numerical construction
+
+Let the exact \(C_2\) spectrum on \(8\otimes8\) be
+\(\{0,3,6,8\}\), and define its Lagrange spectral polynomials
+
+```text
+L_c(C2) = ∏_(c'≠c) (C2-c'I)/(c-c').
+```
+
+Let \(S_\pm=(I\pm E)/2\). The six exact joint spectral projectors can be
+written as
+
+```text
+P_1     = L_0(C2) S_+,
+P_8a    = L_3(C2) S_-,
+P_8s    = L_3(C2) S_+,
+P_10    = L_6(C2) S_- (I + C3/9)/2,
+P_10bar = L_6(C2) S_- (I - C3/9)/2,
+P_27    = L_8(C2) S_+.
+```
+
+These expressions are exact on \(8\otimes8\). The quadratic and cubic
+Casimirs commute with the diagonal SU(3) action because they arise from
+central invariant tensors, and exchange commutes with the equal action on
+the two factors. Functional calculus therefore gives
+
+```text
+[D(g)⊗D(g), P_channel] = 0
+```
+
+for every \(g\in SU(3)\), exactly.
+
+The runner also diagonalizes the finite `complex128` matrix \(H\), groups its
+eigenvectors by the six expected eigenvalues, and forms numerical projectors
+\(P=VV^\dagger\). Floating-point diagonalization supplies reproducible
+matrix witnesses and an orthonormal CG basis; it is not described as
+numerically exact and numerical residual size is not the proof of the
+arbitrary-\(g\) statement.
+
+## 4. Executable validation
+
+The runner reports
+
+```text
+SUMMARY: THEOREM PASS=12 FAIL=0
+```
+
+with explicit tolerances
+
+```text
+operator/projector tolerance = 1e-10,
+eigenvalue matching tolerance = 1e-8,
+equivariance witness tolerance = 1e-10.
+```
+
+The checks include:
+
+1. Gell-Mann structure-constant symmetry and normalization.
+2. Hermitian adjoint generators and the SU(3) Lie algebra.
+3. \(C_2(1,1)=3\) and \(C_3(1,1)=0\).
+4. Independent fundamental/antifundamental confirmation of the canonical
+   cubic-Casimir sign.
+5. Hermiticity and pairwise commutation of \(C_2\), \(E\), and \(C_3\).
+6. Six separated \(H\) clusters with ranks `1,8,8,10,10,27`.
+7. Orthonormality of the returned numerical eigenbasis.
+8. For every channel projector: Hermiticity, idempotence, rank, and the
+   expected scalar \(C_2,E,C_3\) actions.
+9. Pairwise projector orthogonality and completeness.
+10. Agreement between the eigensolver projectors and the independent
+    invariant-polynomial construction.
+11. Hostile controls:
+    - the former swapped `10`/`10bar` labels miss the observed \(C_3\) values
+      by 18;
+    - omitting \(C_3\) leaves only five clusters and one rank-20
+      \(C_2=6,E=-1\) projector whose restricted \(C_3\) spectrum is
+      \([-9,+9]\).
+12. For deterministic seeds `11,29,47,83,101`,
+    \(D(g)\otimes D(g)\) commutes numerically with \(C_2\), \(E\), \(C_3\),
+    and each of the six projectors.
+
+The observed decuplet blocks printed by the runner are
+
+```text
+10bar (0,3): H=2.3588640, (C2,E,C3)=(6,-1,-9),
+10    (3,0): H=6.8127089, (C2,E,C3)=(6,-1,+9).
+```
+
+## 5. Importable API
+
+The runner preserves the original primitive API and adds executable channel
+projectors:
+
+| Function | Result |
+|---|---|
+| `gellmann_basis()` | eight standard Gell-Mann matrices |
+| `structure_constants()` | numerical `f_abc, d_abc` arrays |
+| `adjoint_generators(f)` | eight adjoint generators |
+| `adjoint_matrix(g, lam)` | adjoint representation matrix \(D(g)\) |
+| `random_su3(seed)` | deterministic seeded SU(3) element |
+| `adjoint_casimir(T)` | adjoint quadratic Casimir |
+| `cubic_casimir(T, d)` | cubic Casimir for supplied generators |
+| `tensor_product_casimir(T)` | total \(C_2\) on \(8\otimes8\) |
+| `tensor_product_cubic_casimir(T, d)` | total \(C_3\) on \(8\otimes8\) |
+| `exchange_operator(dim)` | tensor-factor exchange |
+| `cg_decomposition(C2, E, C3)` | numerical \(H\) eigenvalues/eigenbasis |
+| `spectral_channel_projectors(...)` | six eigensolver spectral projectors |
+| `invariant_polynomial_projectors(...)` | independent exact-polynomial projectors evaluated numerically |
+| `canonical_su3_casimirs(p, q)` | exact rational \(C_2,C_3\) formula values |
+
+## 6. Downstream boundary
+
+The [Block 2 note](SU3_WIGNER_INTERTWINER_BLOCK2_THEOREM_NOTE_2026-05-03.md)
+uses only the unordered conjugate pair `10 + 10bar` in its fusion-counting
+rank calculation, and its runner re-bundles its own primitives rather than
+importing this runner. The label correction therefore changes no Block 2
+formula, rank, or API call. Block 3 and later cube/tensor-network blocks
+carry only dependency references and do not pin either corrected
+eigenvalue label. No downstream source changes are needed.
+
+## 7. Scope and audit handoff
+
+In scope:
+
+- the exact SU(3) decomposition of \(8\otimes8\);
+- exact joint channel identification by \(C_2,E,C_3\);
+- finite numerical construction and validation of matrix representatives.
+
+Out of scope:
+
+- the four-fold Haar projector beyond its use as a downstream consumer;
+- cube geometry, tensor-network contractions, and plaquette values;
+- any audit verdict or retained-grade assignment.
 
 ```yaml
 claim_id: su3_wigner_intertwiner_block1_theorem_note_2026-05-03
@@ -194,34 +232,15 @@ note_path: docs/SU3_WIGNER_INTERTWINER_BLOCK1_THEOREM_NOTE_2026-05-03.md
 runner_path: scripts/frontier_su3_wigner_intertwiner_engine.py
 claim_type: positive_theorem
 intrinsic_status: unaudited
-deps: []   # self-contained; pure SU(3) rep theory
-verdict_rationale_template: |
-  Block 1 of the cube-closure campaign. Constructs explicit Clebsch-Gordan
-  decomposition of SU(3) (1,1) ⊗ (1,1) = 1 + 8 + 8 + 10 + 10̄ + 27 = 64
-  via simultaneous diagonalization of quadratic + cubic Casimirs +
-  exchange operator on V ⊗ V. All 9 validation identities (structure
-  constant symmetries, Lie algebra, Casimir eigenvalues, exchange E^2=I,
-  dimensional decomposition, orthonormality, SU(3) equivariance) pass at
-  machine precision (≤ 2e-15). Self-contained; no lattice-gauge
-  dependencies. Importable API for Block 2 (4-fold Haar projector).
+deps: []
+audit_authority: independent audit lane only
 ```
 
-## 7. Cross-references
-
-- Continued: future Block 2 (4-fold Haar projector via CG)
-- Eventual target context, not a load-bearing dependency:
-  `GAUGE_SCALAR_TEMPORAL_OBSERVABLE_BRIDGE_NO_GO_THEOREM_NOTE_2026-05-03.md`
-- L_s=2 cube derivation (P_cube = 0.4291): commit e7365f2d2 + PR #492
-- K-Z external lift: PR #484
-
-## 8. Command
+## 8. Reproduction
 
 ```bash
 python3 scripts/frontier_su3_wigner_intertwiner_engine.py
 ```
 
-Expected summary:
-
-```text
-SUMMARY: THEOREM PASS=8 FAIL=0
-```
+The SHA-pinned cache linked above is regenerated from the runner and must
+match its live stdout byte for byte after the cache header.

--- a/docs/repo/ACTIVE_REVIEW_QUEUE.md
+++ b/docs/repo/ACTIVE_REVIEW_QUEUE.md
@@ -20,7 +20,7 @@ truth surface.
 
 ## Current State
 
-As of `2026-07-10`, the queue includes the four runner/cache audit-readiness
+As of `2026-07-16`, the queue includes the four runner/cache audit-readiness
 items below together with the existing science-facing open lanes. The runner
 failures are recorded honestly; no claim or content gate is weakened to clear
 them.

--- a/docs/repo/ACTIVE_REVIEW_QUEUE.md
+++ b/docs/repo/ACTIVE_REVIEW_QUEUE.md
@@ -27,6 +27,17 @@ them.
 
 Current science/open-lane follow-ups:
 
+- `2026-07-16-su3-wigner-downstream-status-prose-drift`
+  Scope:
+  `SU3_WIGNER_BLOCK4_STAGING_BLOCK5_ORIENTATION_DIAGNOSTICS_NARROW_THEOREM_NOTE_2026-05-10.md`
+  and `SU3_WIGNER_INTERTWINER_BLOCK4_BLOCK5_THEOREM_NOTE_2026-05-03.md`.
+  Finding: these pre-existing consumer notes literally describe the Block
+  1-3 dependency packet as retained and pin historical effective statuses,
+  while current claim strength is audit-pipeline-derived and Block 1 is
+  awaiting re-audit after its cubic-Casimir label/equivariance repair. The
+  consumer formulas do not pin the corrected H values or channel ordering,
+  so widening PR #5407 into consumer claim-note hash churn is not justified.
+  Disposition: `fix on main`.
 - `2026-07-10-pr5123-tick-admissibility-physical-realization-bridge`
   Scope:
   `TICK_CELL_SELECTION_BY_TRANSLATION_AND_VARIATION_CLAUSES_NARROW_THEOREM_NOTE_2026-07-09.md`

--- a/logs/runner-cache/frontier_su3_wigner_intertwiner_engine.txt
+++ b/logs/runner-cache/frontier_su3_wigner_intertwiner_engine.txt
@@ -1,13 +1,13 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_su3_wigner_intertwiner_engine.py
-runner_sha256: cb1f049a06ee6fe767cabebbb3839350b9d032342bac5b8b6649282a05d42d99
+runner_sha256: d2505c3c72725bb9367b5dc0be131f6b62fc7bd92e258b2f22978c992b250f1a
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.09
+elapsed_sec: 0.13
 status: ok
 ----- stdout -----
 ==============================================================================
-SU(3) Wigner Intertwiner Engine — Block 1: (1,1) ⊗ (1,1) CG
+SU(3) Wigner Intertwiner Engine: (1,1) ⊗ (1,1) CG
 ==============================================================================
 
 --- Section A: Gell-Mann basis + structure constants ---
@@ -39,7 +39,8 @@ SU(3) Wigner Intertwiner Engine — Block 1: (1,1) ⊗ (1,1) CG
   max Hermiticity error:             1.332e-15
   exchange involution ||E²-I||_max:  0.000e+00
   max pairwise commutator error:      8.882e-15
-  PASS: C2, exchange, and C3 are numerically Hermitian commuting operators with E²=I.
+  cubic coproduct expansion error:    1.332e-15
+  PASS: C2, exchange, and C3 are numerically Hermitian commuting operators; C3 also matches its independent coproduct expansion.
 
 --- Section D: CG decomposition via simultaneous diagonalization ---
   Diagonalizing H = C_2_total + α E + β C_3_total
@@ -69,7 +70,10 @@ SU(3) Wigner Intertwiner Engine — Block 1: (1,1) ⊗ (1,1) CG
 --- Section G: hostile controls ---
   old swapped-label residuals: 10→C3=-9 gives 18.0; 10bar→C3=+9 gives 18.0
   C2+E-only decuplet projector: rank=20, C3 range=[-9.00000000,9.00000000], total clusters=5
-  PASS: hostile controls reject the old swapped labels and reject C2+E as a six-channel identifier.
+  flipped total-C3 residual against coproduct expansion: 5.19615242
+  wrong antifundamental +t*: C3=+1.11111111, residual from -10/9=2.22222222, Lie residual=1.00000000
+  standalone (I+C3/9)/2: rank=54, idempotence residual=0.25000000; after C2=6, E=-1 restriction: rank=10
+  PASS: hostile controls reject the old swapped labels, a global C3 sign flip, the wrong antifundamental conjugation, C2+E-only channel splitting, and standalone use of (I+C3/9)/2.
 
 --- Section H: deterministic SU(3) equivariance witnesses ---
   seed= 11: C2=1.34e-15 E=3.08e-33 C3=1.56e-15; 1=3.00e-16 8_a=1.06e-15 8_s=5.06e-16 10=5.99e-16 10bar=1.01e-15 27=7.72e-16
@@ -91,7 +95,7 @@ Headline:
   Correct cubic convention: 10=(3,0) has C3=+9 and H≈6.8127;
                             10bar=(0,3) has C3=-9 and H≈2.3589.
 
-Block 1 deliverable: six executable spectral projectors plus a
+Deliverable: six executable spectral projectors plus a
 floating-point orthonormal CG basis. Exact block invariance is supplied
 by the analytic commuting-operator identities, not by numerical precision.
 

--- a/logs/runner-cache/frontier_su3_wigner_intertwiner_engine.txt
+++ b/logs/runner-cache/frontier_su3_wigner_intertwiner_engine.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_su3_wigner_intertwiner_engine.py
-runner_sha256: 23db94b78c85f167b7a0daebe428c61643d441c4532cdca8bd6826ddac034d6e
+runner_sha256: cb1f049a06ee6fe767cabebbb3839350b9d032342bac5b8b6649282a05d42d99
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.34
+elapsed_sec: 0.09
 status: ok
 ----- stdout -----
 ==============================================================================
@@ -13,66 +13,87 @@ SU(3) Wigner Intertwiner Engine — Block 1: (1,1) ⊗ (1,1) CG
 --- Section A: Gell-Mann basis + structure constants ---
   f antisymmetry error: 0.000e+00
   d symmetry error:     0.000e+00
-  PASS: structure constants satisfy expected symmetries.
-
   Standard structure constant values:
     f[123] = 1.000000  (expected 1.000000)  [OK]
     f[345] = 0.500000  (expected 0.500000)  [OK]
     f[458] = 0.866025  (expected 0.866025)  [OK]
-  PASS: standard nonzero f_abc spot checks match.
+  PASS: structure constants have the required permutation symmetries and normalization.
 
---- Section B: adjoint generators + quadratic Casimir ---
-  T^a Hermiticity error: 0.000e+00
+--- Section B: adjoint generators + canonical Casimir convention ---
+  T^a Hermiticity error:       0.000e+00
   Lie algebra commutator error: 3.331e-16
-  PASS: adjoint generators satisfy Hermiticity + Lie algebra.
-  C_2 on (1,1) adjoint eigenvalues: [3.0]
-  PASS: all C_2 eigenvalues = 3 (matches SU(3) (1,1) Casimir).
+  PASS: adjoint generators are Hermitian and satisfy [T^a,T^b]=i f_abc T^c.
+  C_2((1,1)) scalar error from 3: 1.332e-15
+  C_3((1,1)) scalar error from 0: 2.776e-16
+  PASS: adjoint Casimirs match C2(1,1)=3 and C3(1,1)=0.
 
---- Section C: tensor product Casimir + exchange operator ---
-  Exchange E^2 - I error: 0.000e+00
-  PASS: exchange operator satisfies E^2 = I.
+  Independent cubic-Casimir sign anchor:
+    Formula: C3(p,q)=(p-q)(2p+q+3)(p+2q+3)/18
+    direct fundamental matrices:     C3(1,0)  = +10/9
+    direct antifundamental matrices: C3(0,1)  = -10/9
+    formula decuplet:     (C2,C3)=(6,9)
+    formula antidecuplet: (C2,C3)=(6,-9)
+  PASS: fundamental matrices anchor the formula sign, so (3,0) has C3=+9 and (0,3) has C3=-9.
+
+--- Section C: tensor-product commuting operators ---
+  max Hermiticity error:             1.332e-15
+  exchange involution ||E²-I||_max:  0.000e+00
+  max pairwise commutator error:      8.882e-15
+  PASS: C2, exchange, and C3 are numerically Hermitian commuting operators with E²=I.
 
 --- Section D: CG decomposition via simultaneous diagonalization ---
   Diagonalizing H = C_2_total + α E + β C_3_total
   α = sqrt(2) = 1.414214, β = sqrt(3)/7 = 0.247436
-  Number of unique eigenvalue clusters: 6
-  (eigenvalue, multiplicity) pairs:
-    H =      1.4142  multiplicity   1
-    H =      1.5858  multiplicity   8
-    H =      2.3589  multiplicity  10
-    H =      4.4142  multiplicity   8
-    H =      6.8127  multiplicity  10
-    H =      9.4142  multiplicity  27
+  six matched dimensions: [1, 8, 8, 10, 10, 27]; total=64
+  eigensolver orthonormality ||V†V-I||_max: 1.776e-15
+  PASS: floating-point H spectrum has six separated clusters with ranks 1,8,8,10,10,27.
+  PASS: the returned floating-point CG eigenbasis is orthonormal within tolerance.
 
-  Total dimension: 64  (expected 64)
-  PASS: dimensions sum to 64 = 8 × 8.
+--- Section E: simultaneous-channel spectral projectors ---
+      1 (0,0) rank= 1: H= 1.4142136, observed (C2,E,C3)=(-0.00000000,+1.00000000,-0.00000000); expected=(0,+1,+0)
+    8_a (1,1) rank= 8: H= 1.5857864, observed (C2,E,C3)=( 3.00000000,-1.00000000,-0.00000000); expected=(3,-1,+0)
+  10bar (0,3) rank=10: H= 2.3588640, observed (C2,E,C3)=( 6.00000000,-1.00000000,-9.00000000); expected=(6,-1,-9)
+    8_s (1,1) rank= 8: H= 4.4142136, observed (C2,E,C3)=( 3.00000000,+1.00000000,-0.00000000); expected=(3,+1,+0)
+     10 (3,0) rank=10: H= 6.8127089, observed (C2,E,C3)=( 6.00000000,-1.00000000,+9.00000000); expected=(6,-1,+9)
+     27 (2,2) rank=27: H= 9.4142136, observed (C2,E,C3)=( 8.00000000,+1.00000000,-0.00000000); expected=(8,+1,+0)
+  PASS: all six spectral projectors are Hermitian, idempotent, have the expected ranks, and carry the expected scalar (C2,E,C3) data.
+  max pairwise projector product: 1.141e-16
+  completeness ||ΣP-I||_max:      7.772e-16
+  PASS: the six projectors are pairwise orthogonal and complete.
 
---- Section F: verify (1,1) ⊗ (1,1) = 1 + 8 + 8 + 10 + 10̄ + 27 ---
-  Expected dimensions (sorted): [1, 8, 8, 10, 10, 27]
-  Actual dimensions (sorted):   [1, 8, 8, 10, 10, 27]
-  PASS: 6 channels with correct dimensions.
+--- Section F: independent invariant-polynomial projectors ---
+  max |P_polynomial-P_eigensolver|: 1.554e-15
+  polynomial completeness error:    2.442e-15
+  PASS: independent commuting-operator polynomials reproduce all six eigensolver projectors.
 
---- Section G: orthonormality of CG eigenbasis ---
-  ||V^† V - I|| = 1.998e-15
-  PASS: CG basis is orthonormal.
+--- Section G: hostile controls ---
+  old swapped-label residuals: 10→C3=-9 gives 18.0; 10bar→C3=+9 gives 18.0
+  C2+E-only decuplet projector: rank=20, C3 range=[-9.00000000,9.00000000], total clusters=5
+  PASS: hostile controls reject the old swapped labels and reject C2+E as a six-channel identifier.
 
---- Section H: SU(3) equivariance of channel decomposition ---
-  ||[D⊗D, C_total]|| = 1.333e-15
-  ||[D⊗D, E]|| = 3.081e-33
-  PASS: D⊗D commutes with both Casimir and exchange.
+--- Section H: deterministic SU(3) equivariance witnesses ---
+  seed= 11: C2=1.34e-15 E=3.08e-33 C3=1.56e-15; 1=3.00e-16 8_a=1.06e-15 8_s=5.06e-16 10=5.99e-16 10bar=1.01e-15 27=7.72e-16
+  seed= 29: C2=1.33e-15 E=3.08e-33 C3=1.55e-15; 1=4.55e-16 8_a=8.80e-16 8_s=5.01e-16 10=7.64e-16 10bar=1.01e-15 27=6.71e-16
+  seed= 47: C2=1.11e-15 E=3.08e-33 C3=1.55e-15; 1=4.55e-16 8_a=1.07e-15 8_s=4.89e-16 10=6.97e-16 10bar=1.14e-15 27=7.08e-16
+  seed= 83: C2=1.33e-15 E=3.08e-33 C3=1.40e-15; 1=3.23e-16 8_a=1.40e-15 8_s=5.21e-16 10=6.30e-16 10bar=1.33e-15 27=8.03e-16
+  seed=101: C2=1.33e-15 E=6.16e-33 C3=1.33e-15; 1=5.01e-16 8_a=1.18e-15 8_s=5.59e-16 10=6.21e-16 10bar=1.19e-15 27=7.03e-16
+  PASS: five independently seeded deterministic SU(3) samples commute with C2, E, C3, and every channel projector within the explicit tolerance.
+  equivariance tolerance: 1.0e-10
+  Boundary: these are finite floating-point implementation witnesses; the all-g statement follows analytically from Casimir invariance, factor-swap invariance, and spectral-polynomial functional calculus.
 
 ==============================================================================
-SUMMARY: THEOREM PASS=8 FAIL=0
+SUMMARY: THEOREM PASS=12 FAIL=0
 ==============================================================================
 
 Headline:
   SU(3) (1,1) ⊗ (1,1) decomposed into 6 fusion channels
   with dimensions [1, 8, 8, 10, 10, 27] = 64 total.
-  Expected: 1 + 8 + 8 + 10 + 10̄ + 27 = 64. Match: True
+  Correct cubic convention: 10=(3,0) has C3=+9 and H≈6.8127;
+                            10bar=(0,3) has C3=-9 and H≈2.3589.
 
-Block 1 deliverable: SU(3) (1,1) ⊗ (1,1) CG basis (64 orthonormal
-vectors organized into 6 irrep blocks). Available as `eigvecs` array
-and importable for Block 2 (4-fold Haar projector).
+Block 1 deliverable: six executable spectral projectors plus a
+floating-point orthonormal CG basis. Exact block invariance is supplied
+by the analytic commuting-operator identities, not by numerical precision.
 
 ----- stderr -----
 

--- a/scripts/frontier_su3_wigner_intertwiner_engine.py
+++ b/scripts/frontier_su3_wigner_intertwiner_engine.py
@@ -1,7 +1,7 @@
-"""SU(3) Wigner intertwiner engine — Block 1 of the cube-closure campaign.
+"""SU(3) Wigner intertwiner engine for the adjoint tensor square.
 
-Block 1 deliverable: explicit Clebsch-Gordan decomposition of the SU(3)
-adjoint tensor product
+Deliverable: explicit Clebsch-Gordan decomposition of the SU(3) adjoint
+tensor product
 
     (1,1) ⊗ (1,1) = (0,0) ⊕ 2·(1,1) ⊕ (3,0) ⊕ (0,3) ⊕ (2,2)
                   = 1   ⊕ 8   ⊕ 8    ⊕ 10    ⊕ 10̄  ⊕ 27
@@ -10,8 +10,9 @@ adjoint tensor product
 via quadratic-Casimir + exchange + cubic-Casimir diagonalization on
 V_(1,1) ⊗ V_(1,1) = C^8 ⊗ C^8.
 
-This is Block 1 of the multi-block plan to build the full SU(3) Wigner-
-Racah machinery needed for the L_s=3 cube tensor-network contraction.
+This finite-dimensional construction supplies representation-theory
+infrastructure used by later SU(3) tensor-network notes; those downstream
+contractions are outside this runner's claim.
 
 Algorithm:
   1. Construct Gell-Mann basis {λ_a, a=1..8} of 3x3 traceless Hermitian
@@ -41,14 +42,13 @@ Validation:
       fundamental and antifundamental matrices.
   V7: D(g)⊗D(g) commutes with C_3 and every channel projector for multiple
       deterministic independently seeded SU(3) elements.
-  V8: hostile controls reject swapped 10/10bar labels and a C_2+E-only
-      rank-20 decuplet-pair projector.
+  V8: hostile controls reject swapped 10/10bar labels, a global C_3 sign
+      flip, a wrong conjugation convention, a C_2+E-only rank-20
+      decuplet-pair projector, and standalone use of (I±C_3/9)/2.
 
-Cluster note: this is SU(3) representation theory, NOT in the
-gauge_vacuum_plaquette family. It is a new infrastructure deliverable
-serving downstream lattice gauge work.
-
-Forbidden imports: none (pure SU(3) rep theory).
+Mathematical inputs: standard SU(3) representation theory, including the
+Littlewood-Richardson decomposition, canonical Casimir formulas, and Casimir
+invariance. There are no measured, fitted, observational, or lattice inputs.
 
 Run:
     python3 scripts/frontier_su3_wigner_intertwiner_engine.py
@@ -224,6 +224,37 @@ def tensor_product_cubic_casimir(T: List[np.ndarray], d: np.ndarray
                 if d[a, b, c] != 0:
                     C = C + d[a, b, c] * T_tot[a] @ T_tot[b] @ T_tot[c]
     return C
+
+
+def tensor_product_cubic_casimir_coproduct_expansion(
+    T: List[np.ndarray],
+    d: np.ndarray,
+) -> np.ndarray:
+    """Independently expand the cubic-Casimir coproduct on V⊗V.
+
+    For Δ(T_a)=T_a⊗I+I⊗T_a and symmetric d_abc,
+
+      Δ(C3) = C3⊗I + I⊗C3
+             + 3 d_abc (T_a T_b⊗T_c + T_a⊗T_b T_c).
+
+    This implementation does not build or cube the total generators.  It
+    anchors the orientation of ``tensor_product_cubic_casimir`` to the same
+    fundamental convention checked below, so a global C3 sign flip cannot
+    merely relabel both projector constructions together.
+    """
+    dim = T[0].shape[0]
+    ident = np.eye(dim, dtype=complex)
+    single_c3 = cubic_casimir(T, d)
+    expanded = np.kron(single_c3, ident) + np.kron(ident, single_c3)
+    for a in range(len(T)):
+        for b in range(len(T)):
+            for c in range(len(T)):
+                if d[a, b, c] != 0:
+                    expanded = expanded + 3.0 * d[a, b, c] * (
+                        np.kron(T[a] @ T[b], T[c])
+                        + np.kron(T[a], T[b] @ T[c])
+                    )
+    return expanded
 
 
 def tensor_product_casimir(T: List[np.ndarray]) -> np.ndarray:
@@ -441,7 +472,7 @@ def expected_su3_casimirs() -> Dict[Tuple[int, int], float]:
 
 def driver() -> int:
     print("=" * 78)
-    print("SU(3) Wigner Intertwiner Engine — Block 1: (1,1) ⊗ (1,1) CG")
+    print("SU(3) Wigner Intertwiner Engine: (1,1) ⊗ (1,1) CG")
     print("=" * 78)
     print()
 
@@ -523,10 +554,47 @@ def driver() -> int:
     print("  Independent cubic-Casimir sign anchor:")
     fundamental = [matrix / 2.0 for matrix in lam]
     antifundamental = [-matrix.conj() for matrix in fundamental]
+    wrong_antifundamental = [matrix.conj() for matrix in fundamental]
     c2_fund = sum(matrix @ matrix for matrix in fundamental)
     c2_antifund = sum(matrix @ matrix for matrix in antifundamental)
     c3_fund = cubic_casimir(fundamental, d)
     c3_antifund = cubic_casimir(antifundamental, d)
+    c3_wrong_antifund = cubic_casimir(wrong_antifundamental, d)
+    antifund_lie_error = 0.0
+    wrong_antifund_lie_error = 0.0
+    for a in range(8):
+        for b in range(8):
+            antifund_expected = sum(
+                1j * f[a, b, c] * antifundamental[c] for c in range(8)
+            )
+            wrong_expected = sum(
+                1j * f[a, b, c] * wrong_antifundamental[c] for c in range(8)
+            )
+            antifund_lie_error = max(
+                antifund_lie_error,
+                float(
+                    np.max(
+                        np.abs(
+                            antifundamental[a] @ antifundamental[b]
+                            - antifundamental[b] @ antifundamental[a]
+                            - antifund_expected
+                        )
+                    )
+                ),
+            )
+            wrong_antifund_lie_error = max(
+                wrong_antifund_lie_error,
+                float(
+                    np.max(
+                        np.abs(
+                            wrong_antifundamental[a] @ wrong_antifundamental[b]
+                            - wrong_antifundamental[b] @ wrong_antifundamental[a]
+                            - wrong_expected
+                        )
+                    )
+                ),
+            )
+    wrong_antifund_c3_scalar = float(np.real(np.trace(c3_wrong_antifund)) / 3.0)
     c2_10, c3_10 = canonical_su3_casimirs(3, 0)
     c2_10bar, c3_10bar = canonical_su3_casimirs(0, 3)
     formula_err = max(
@@ -534,6 +602,7 @@ def driver() -> int:
         float(np.max(np.abs(c2_antifund - (4.0 / 3.0) * np.eye(3)))),
         float(np.max(np.abs(c3_fund - (10.0 / 9.0) * np.eye(3)))),
         float(np.max(np.abs(c3_antifund + (10.0 / 9.0) * np.eye(3)))),
+        antifund_lie_error,
     )
     print("    Formula: C3(p,q)=(p-q)(2p+q+3)(p+2q+3)/18")
     print("    direct fundamental matrices:     C3(1,0)  = +10/9")
@@ -555,6 +624,7 @@ def driver() -> int:
     C_total = tensor_product_casimir(T)
     E = exchange_operator(8)
     C3_total = tensor_product_cubic_casimir(T, d)
+    C3_coproduct = tensor_product_cubic_casimir_coproduct_expansion(T, d)
     ident64 = np.eye(64, dtype=complex)
     hermitian_err = max(
         float(np.max(np.abs(operator - operator.conj().T)))
@@ -566,14 +636,17 @@ def driver() -> int:
         float(np.max(np.abs(C_total @ C3_total - C3_total @ C_total))),
         float(np.max(np.abs(E @ C3_total - C3_total @ E))),
     )
+    c3_coproduct_err = float(np.max(np.abs(C3_total - C3_coproduct)))
     print(f"  max Hermiticity error:             {hermitian_err:.3e}")
     print(f"  exchange involution ||E²-I||_max:  {e_err:.3e}")
     print(f"  max pairwise commutator error:      {operator_comm_err:.3e}")
+    print(f"  cubic coproduct expansion error:    {c3_coproduct_err:.3e}")
     record(
-        "C2, exchange, and C3 are numerically Hermitian commuting operators with E²=I.",
+        "C2, exchange, and C3 are numerically Hermitian commuting operators; C3 also matches its independent coproduct expansion.",
         hermitian_err < OPERATOR_TOL
         and e_err < OPERATOR_TOL
-        and operator_comm_err < OPERATOR_TOL,
+        and operator_comm_err < OPERATOR_TOL
+        and c3_coproduct_err < OPERATOR_TOL,
     )
     print()
 
@@ -585,7 +658,10 @@ def driver() -> int:
     print(f"  α = sqrt(2) = {alpha:.6f}, β = sqrt(3)/7 = {beta:.6f}")
     overlap = eigvecs.conj().T @ eigvecs
     overlap_err = float(np.max(np.abs(overlap - ident64)))
-    actual_pattern = sorted(spec.dimension for spec in CHANNEL_SPECS)
+    actual_pattern = sorted(
+        int(np.linalg.matrix_rank(projector, tol=EIGENVALUE_TOL))
+        for projector in projectors.values()
+    )
     expected_pattern = [1, 8, 8, 10, 10, 27]
     print(f"  six matched dimensions: {actual_pattern}; total={sum(actual_pattern)}")
     print(f"  eigensolver orthonormality ||V†V-I||_max: {overlap_err:.3e}")
@@ -699,6 +775,20 @@ def driver() -> int:
     print("--- Section G: hostile controls ---")
     swapped_10_error = abs(observed_c3["10"] - (-9.0))
     swapped_10bar_error = abs(observed_c3["10bar"] - (+9.0))
+    flipped_total_c3_error = float(
+        np.max(np.abs((-C3_total) - C3_coproduct))
+    )
+    wrong_antifund_c3_error = abs(wrong_antifund_c3_scalar - (-10.0 / 9.0))
+    global_c3_plus = (ident64 + C3_total / 9.0) / 2.0
+    global_c3_plus_rank = int(
+        np.linalg.matrix_rank(global_c3_plus, tol=EIGENVALUE_TOL)
+    )
+    global_c3_plus_idem_error = float(
+        np.max(np.abs(global_c3_plus @ global_c3_plus - global_c3_plus))
+    )
+    restricted_c3_plus_rank = int(
+        np.linalg.matrix_rank(polynomial_projectors["10"], tol=EIGENVALUE_TOL)
+    )
     coarse_eigvals, coarse_eigvecs, _ = cg_decomposition(C_total, E, None)
     coarse_target = 6.0 - alpha
     coarse_indices = np.where(np.abs(coarse_eigvals - coarse_target) < EIGENVALUE_TOL)[0]
@@ -723,10 +813,33 @@ def driver() -> int:
         f"rank={coarse_rank}, C3 range=[{coarse_c3_min:.8f},{coarse_c3_max:.8f}], "
         f"total clusters={coarse_unique_clusters}"
     )
+    print(
+        "  flipped total-C3 residual against coproduct expansion: "
+        f"{flipped_total_c3_error:.8f}"
+    )
+    print(
+        "  wrong antifundamental +t*: "
+        f"C3={wrong_antifund_c3_scalar:+.8f}, "
+        f"residual from -10/9={wrong_antifund_c3_error:.8f}, "
+        f"Lie residual={wrong_antifund_lie_error:.8f}"
+    )
+    print(
+        "  standalone (I+C3/9)/2: "
+        f"rank={global_c3_plus_rank}, "
+        f"idempotence residual={global_c3_plus_idem_error:.8f}; "
+        "after C2=6, E=-1 restriction: "
+        f"rank={restricted_c3_plus_rank}"
+    )
     record(
-        "hostile controls reject the old swapped labels and reject C2+E as a six-channel identifier.",
+        "hostile controls reject the old swapped labels, a global C3 sign flip, the wrong antifundamental conjugation, C2+E-only channel splitting, and standalone use of (I+C3/9)/2.",
         swapped_10_error > 17.0
         and swapped_10bar_error > 17.0
+        and flipped_total_c3_error > 1.0
+        and wrong_antifund_c3_error > 2.0
+        and wrong_antifund_lie_error > 0.9
+        and global_c3_plus_rank == 54
+        and global_c3_plus_idem_error > 0.2
+        and restricted_c3_plus_rank == 10
         and coarse_rank == 20
         and abs(coarse_c3_min + 9.0) < OPERATOR_TOL
         and abs(coarse_c3_max - 9.0) < OPERATOR_TOL
@@ -795,7 +908,7 @@ def driver() -> int:
     print("  Correct cubic convention: 10=(3,0) has C3=+9 and H≈6.8127;")
     print("                            10bar=(0,3) has C3=-9 and H≈2.3589.")
     print()
-    print("Block 1 deliverable: six executable spectral projectors plus a")
+    print("Deliverable: six executable spectral projectors plus a")
     print("floating-point orthonormal CG basis. Exact block invariance is supplied")
     print("by the analytic commuting-operator identities, not by numerical precision.")
     return 0 if fail_count == 0 else 1

--- a/scripts/frontier_su3_wigner_intertwiner_engine.py
+++ b/scripts/frontier_su3_wigner_intertwiner_engine.py
@@ -7,7 +7,8 @@ adjoint tensor product
                   = 1   ⊕ 8   ⊕ 8    ⊕ 10    ⊕ 10̄  ⊕ 27
                     (dimensions: 1 + 8 + 8 + 10 + 10 + 27 = 64 ✓)
 
-via Casimir + exchange diagonalization on V_(1,1) ⊗ V_(1,1) = C^8 ⊗ C^8.
+via quadratic-Casimir + exchange + cubic-Casimir diagonalization on
+V_(1,1) ⊗ V_(1,1) = C^8 ⊗ C^8.
 
 This is Block 1 of the multi-block plan to build the full SU(3) Wigner-
 Racah machinery needed for the L_s=3 cube tensor-network contraction.
@@ -22,21 +23,26 @@ Algorithm:
      V_(1,1) ⊗ V_(1,1):
        C_2_total = (Σ_a (T^a ⊗ I + I ⊗ T^a)^2)
   5. Compute exchange operator E swapping the two factors of V ⊗ V.
-  6. Diagonalize H = C_2 + α E (for some α distinguishing the two adjoint
-     copies in (1,1)⊗(1,1) by symmetry under exchange).
-  7. Group eigenvectors by (C_2, E) eigenvalue → CG basis blocks for each
-     fusion channel.
-  8. Identify each block with an irrep by Casimir eigenvalue and
-     dimensionality.
+  6. Construct C_3_total and diagonalize
+       H = C_2_total + α E + β C_3_total.
+  7. Construct spectral projectors for all six simultaneous
+     (C_2, E, C_3) clusters.
+  8. Independently reconstruct the same projectors as invariant
+     polynomials in C_2, E, and C_3.
 
 Validation:
   V1: 6 distinct fusion channels with dimensions {1, 8, 8, 10, 10, 27}.
   V2: total dimension 64.
   V3: orthonormal basis: <e_i, e_j> = δ_ij.
-  V4: SU(3) equivariance: D(g)⊗D(g) preserves each channel block.
-  V5: Casimir eigenvalues match canonical SU(3) values.
-  V6: exchange eigenvalues distinguish two (1,1) copies (one symmetric,
-      one antisymmetric).
+  V4: projectors are Hermitian, idempotent, pairwise orthogonal, complete,
+      and have ranks 1,8,8,10,10,27.
+  V5: each projector has the expected scalar (C_2,E,C_3) data.
+  V6: the canonical cubic-Casimir convention is anchored independently on
+      fundamental and antifundamental matrices.
+  V7: D(g)⊗D(g) commutes with C_3 and every channel projector for multiple
+      deterministic independently seeded SU(3) elements.
+  V8: hostile controls reject swapped 10/10bar labels and a C_2+E-only
+      rank-20 decuplet-pair projector.
 
 Cluster note: this is SU(3) representation theory, NOT in the
 gauge_vacuum_plaquette family. It is a new infrastructure deliverable
@@ -52,9 +58,43 @@ from __future__ import annotations
 
 import math
 import sys
+from dataclasses import dataclass
+from fractions import Fraction
 from typing import Dict, List, Tuple
 
 import numpy as np
+
+
+OPERATOR_TOL = 1.0e-10
+EIGENVALUE_TOL = 1.0e-8
+EQUIVARIANCE_TOL = 1.0e-10
+SU3_TEST_SEEDS = (11, 29, 47, 83, 101)
+
+
+@dataclass(frozen=True)
+class ChannelSpec:
+    """Exact simultaneous (C2, exchange, C3) data for one 8⊗8 channel."""
+
+    key: str
+    dynkin: Tuple[int, int]
+    name: str
+    dimension: int
+    c2: float
+    exchange: float
+    c3: float
+
+    def h_eigenvalue(self, alpha: float, beta: float) -> float:
+        return self.c2 + alpha * self.exchange + beta * self.c3
+
+
+CHANNEL_SPECS = (
+    ChannelSpec("1", (0, 0), "singlet", 1, 0.0, +1.0, 0.0),
+    ChannelSpec("8_a", (1, 1), "antisymmetric adjoint", 8, 3.0, -1.0, 0.0),
+    ChannelSpec("8_s", (1, 1), "symmetric adjoint", 8, 3.0, +1.0, 0.0),
+    ChannelSpec("10", (3, 0), "decuplet", 10, 6.0, -1.0, +9.0),
+    ChannelSpec("10bar", (0, 3), "antidecuplet", 10, 6.0, -1.0, -9.0),
+    ChannelSpec("27", (2, 2), "27-plet", 27, 8.0, +1.0, 0.0),
+)
 
 
 # ===========================================================================
@@ -143,19 +183,19 @@ def adjoint_casimir(T: List[np.ndarray]) -> np.ndarray:
 
 
 def cubic_casimir(T: List[np.ndarray], d: np.ndarray) -> np.ndarray:
-    """Cubic Casimir on (1,1) adjoint: C_3 = Σ_(abc) d_(abc) T^a T^b T^c.
+    """Cubic Casimir C_3 = Σ_(abc) d_(abc) T^a T^b T^c.
 
     For SU(3), C_3 takes opposite signs on conjugate irreps: e.g.,
     C_3((3,0)) = -C_3((0,3)) (decuplet vs antidecuplet).
 
-    On self-conjugate irreps (e.g., (0,0), (1,1), (2,2)): C_3 may vanish
-    or take symmetric values.
+    On self-conjugate irreps (e.g., (0,0), (1,1), (2,2)), C_3 vanishes.
     """
-    n = 8
-    C = np.zeros((n, n), dtype=complex)
-    for a in range(n):
-        for b in range(n):
-            for c in range(n):
+    n_generators = len(T)
+    dim = T[0].shape[0]
+    C = np.zeros((dim, dim), dtype=complex)
+    for a in range(n_generators):
+        for b in range(n_generators):
+            for c in range(n_generators):
                 if d[a, b, c] != 0:
                     C = C + d[a, b, c] * T[a] @ T[b] @ T[c]
     return C
@@ -270,23 +310,113 @@ def cg_decomposition(C_total: np.ndarray, E: np.ndarray,
     return eigvals, eigvecs, (alpha, beta)
 
 
-def identify_channels(eigvals: np.ndarray, alpha: float
-                       ) -> List[Tuple[float, float, int, int]]:
-    """Group eigenvalues by (C_2, E) eigenvalue and identify channels.
+def canonical_su3_casimirs(p: int, q: int) -> Tuple[Fraction, Fraction]:
+    """Canonical SU(3) Casimirs for Dynkin label (p,q).
 
-    Each unique (C_2, E_eig) pair corresponds to a fusion channel with
-    a specific dimension.
+    The generators use t_a = λ_a/2, with Tr(t_a t_b) = δ_ab/2:
 
-    Returns list of (c2, e_eig, multiplicity_count, irrep_dim).
+      C2(p,q) = (p² + q² + pq + 3p + 3q) / 3
+      C3(p,q) = (p-q)(2p+q+3)(p+2q+3) / 18.
+
+    This convention gives C3(1,0)=+10/9 and C3(3,0)=+9.
     """
-    n = len(eigvals)
-    # Group by eigenvalues with tolerance
-    tol = 1e-6
-    groups: Dict[float, int] = {}
-    for ev in eigvals:
-        key = round(float(ev), 5)
-        groups[key] = groups.get(key, 0) + 1
-    return sorted(groups.items())
+    c2 = Fraction(p * p + q * q + p * q + 3 * p + 3 * q, 3)
+    c3 = Fraction(
+        (p - q) * (2 * p + q + 3) * (p + 2 * q + 3),
+        18,
+    )
+    return c2, c3
+
+
+def spectral_channel_projectors(
+    eigvals: np.ndarray,
+    eigvecs: np.ndarray,
+    alpha: float,
+    beta: float,
+    tol: float = EIGENVALUE_TOL,
+) -> Dict[str, np.ndarray]:
+    """Build the six H-spectral projectors and match them to exact channels."""
+    projectors: Dict[str, np.ndarray] = {}
+    claimed_indices: set[int] = set()
+    for spec in CHANNEL_SPECS:
+        target = spec.h_eigenvalue(alpha, beta)
+        indices = np.where(np.abs(eigvals - target) < tol)[0]
+        if len(indices) != spec.dimension:
+            raise ValueError(
+                f"{spec.key}: expected {spec.dimension} H eigenvectors near "
+                f"{target:.12f}, found {len(indices)}"
+            )
+        overlap = claimed_indices.intersection(int(i) for i in indices)
+        if overlap:
+            raise ValueError(f"{spec.key}: overlapping H cluster indices {overlap}")
+        claimed_indices.update(int(i) for i in indices)
+        basis = eigvecs[:, indices]
+        projectors[spec.key] = basis @ basis.conj().T
+    if len(claimed_indices) != len(eigvals):
+        raise ValueError(
+            f"channel matching covered {len(claimed_indices)} of {len(eigvals)} vectors"
+        )
+    return projectors
+
+
+def lagrange_spectral_projector(
+    operator: np.ndarray,
+    target: float,
+    spectrum: Tuple[float, ...],
+) -> np.ndarray:
+    """Evaluate the Lagrange polynomial selecting one exact eigenvalue."""
+    ident = np.eye(operator.shape[0], dtype=complex)
+    projector = ident.copy()
+    for other in spectrum:
+        if other == target:
+            continue
+        projector = projector @ ((operator - other * ident) / (target - other))
+    return (projector + projector.conj().T) / 2.0
+
+
+def invariant_polynomial_projectors(
+    C_total: np.ndarray,
+    E: np.ndarray,
+    C3_total: np.ndarray,
+) -> Dict[str, np.ndarray]:
+    """Independent channel projectors as exact commuting-operator polynomials.
+
+    This construction does not use H or its eigenvectors.  It uses the exact
+    C2 spectrum {0,3,6,8}, exchange parity, and the C3=±9 split inside C2=6.
+    """
+    ident = np.eye(C_total.shape[0], dtype=complex)
+    c2_spectrum = (0.0, 3.0, 6.0, 8.0)
+    p_c2 = {
+        value: lagrange_spectral_projector(C_total, value, c2_spectrum)
+        for value in c2_spectrum
+    }
+    p_sym = (ident + E) / 2.0
+    p_asym = (ident - E) / 2.0
+    p_c3_plus = (ident + C3_total / 9.0) / 2.0
+    p_c3_minus = (ident - C3_total / 9.0) / 2.0
+    raw = {
+        "1": p_c2[0.0] @ p_sym,
+        "8_a": p_c2[3.0] @ p_asym,
+        "8_s": p_c2[3.0] @ p_sym,
+        "10": p_c2[6.0] @ p_asym @ p_c3_plus,
+        "10bar": p_c2[6.0] @ p_asym @ p_c3_minus,
+        "27": p_c2[8.0] @ p_sym,
+    }
+    return {
+        key: (projector + projector.conj().T) / 2.0
+        for key, projector in raw.items()
+    }
+
+
+def observed_scalar(
+    projector: np.ndarray,
+    operator: np.ndarray,
+    dimension: int,
+) -> Tuple[float, float]:
+    """Return the block trace-average and scalar-action residual."""
+    scalar = float(np.real(np.trace(projector @ operator)) / dimension)
+    residual = float(np.max(np.abs(operator @ projector - scalar * projector)))
+    return scalar, residual
 
 
 def expected_su3_casimirs() -> Dict[Tuple[int, int], float]:
@@ -301,7 +431,7 @@ def expected_su3_casimirs() -> Dict[Tuple[int, int], float]:
       C_2((0,3)) = 6
       C_2((2,2)) = 8
     """
-    return {(p, q): (p ** 2 + q ** 2 + p * q) / 3.0 + p + q
+    return {(p, q): float(canonical_su3_casimirs(p, q)[0])
             for p in range(5) for q in range(5)}
 
 
@@ -318,166 +448,340 @@ def driver() -> int:
     pass_count = 0
     fail_count = 0
 
+    def record(label: str, passed: bool) -> None:
+        nonlocal pass_count, fail_count
+        marker = "PASS" if passed else "FAIL"
+        print(f"  {marker}: {label}")
+        if passed:
+            pass_count += 1
+        else:
+            fail_count += 1
+
     # ===== Section A: build basis + structure constants =====
     print("--- Section A: Gell-Mann basis + structure constants ---")
     lam = gellmann_basis()
     f, d = structure_constants()
-    # Verify f is fully antisymmetric, d is fully symmetric
-    f_asym = np.max(np.abs(f + np.transpose(f, (1, 0, 2))))
-    d_sym = np.max(np.abs(d - np.transpose(d, (1, 0, 2))))
+    f_asym = max(
+        float(np.max(np.abs(f + np.transpose(f, axes))))
+        for axes in ((1, 0, 2), (2, 1, 0), (0, 2, 1))
+    )
+    d_sym = max(
+        float(np.max(np.abs(d - np.transpose(d, axes))))
+        for axes in ((1, 0, 2), (2, 1, 0), (0, 2, 1))
+    )
     print(f"  f antisymmetry error: {f_asym:.3e}")
     print(f"  d symmetry error:     {d_sym:.3e}")
-    if f_asym < 1e-10 and d_sym < 1e-10:
-        print("  PASS: structure constants satisfy expected symmetries.")
-        pass_count += 1
-    else:
-        print("  FAIL: structure constants malformed.")
-        fail_count += 1
-    print()
-
-    # Verify a few standard nonzero constants in 1-based Gell-Mann notation.
-    print("  Standard structure constant values:")
     expected_f = {(0, 1, 2): 1.0,
                   (2, 3, 4): 0.5,  # f_345 = 1/2
                   (3, 4, 7): math.sqrt(3) / 2.0}  # f_458 = sqrt(3)/2
     max_standard_delta = 0.0
+    print("  Standard structure constant values:")
     for (a, b, c), expected in expected_f.items():
         actual = f[a, b, c]
         delta = abs(actual - expected)
         max_standard_delta = max(max_standard_delta, delta)
         marker = "OK" if delta < 1e-10 else "BAD"
         print(f"    f[{a+1}{b+1}{c+1}] = {actual:.6f}  (expected {expected:.6f})  [{marker}]")
-    if max_standard_delta < 1e-10:
-        print("  PASS: standard nonzero f_abc spot checks match.")
-    else:
-        print("  FAIL: standard nonzero f_abc spot checks do not match.")
-        fail_count += 1
+    record(
+        "structure constants have the required permutation symmetries and normalization.",
+        f_asym < OPERATOR_TOL
+        and d_sym < OPERATOR_TOL
+        and max_standard_delta < OPERATOR_TOL,
+    )
     print()
 
     # ===== Section B: adjoint generators + Casimir =====
-    print("--- Section B: adjoint generators + quadratic Casimir ---")
+    print("--- Section B: adjoint generators + canonical Casimir convention ---")
     T = adjoint_generators(f)
-    # Verify Hermiticity
     herm_errors = max(np.max(np.abs(Ta - Ta.conj().T)) for Ta in T)
-    print(f"  T^a Hermiticity error: {herm_errors:.3e}")
-    # Verify [T^a, T^b] = i f_abc T^c
     comm_errors = 0.0
     for a in range(8):
         for b in range(8):
             comm = T[a] @ T[b] - T[b] @ T[a]
             expected = sum(1j * f[a, b, c] * T[c] for c in range(8))
             comm_errors = max(comm_errors, np.max(np.abs(comm - expected)))
+    print(f"  T^a Hermiticity error:       {herm_errors:.3e}")
     print(f"  Lie algebra commutator error: {comm_errors:.3e}")
-    if herm_errors < 1e-10 and comm_errors < 1e-10:
-        print("  PASS: adjoint generators satisfy Hermiticity + Lie algebra.")
-        pass_count += 1
-    else:
-        print("  FAIL: adjoint generator construction broken.")
-        fail_count += 1
+    record(
+        "adjoint generators are Hermitian and satisfy [T^a,T^b]=i f_abc T^c.",
+        herm_errors < OPERATOR_TOL and comm_errors < OPERATOR_TOL,
+    )
 
     C2_adj = adjoint_casimir(T)
     eigvals_C2 = np.linalg.eigvalsh((C2_adj + C2_adj.conj().T) / 2.0)
-    print(f"  C_2 on (1,1) adjoint eigenvalues: {sorted(set(round(float(ev), 4) for ev in eigvals_C2))}")
-    expected_C2_adj = 3.0  # SU(3) (1,1) Casimir
-    if all(abs(float(ev) - expected_C2_adj) < 1e-10 for ev in eigvals_C2):
-        print(f"  PASS: all C_2 eigenvalues = 3 (matches SU(3) (1,1) Casimir).")
-        pass_count += 1
-    else:
-        print(f"  FAIL: C_2 not constant on (1,1).")
-        fail_count += 1
+    c2_adj_err = float(np.max(np.abs(eigvals_C2 - 3.0)))
+    c3_adj = cubic_casimir(T, d)
+    c3_adj_err = float(np.max(np.abs(c3_adj)))
+    print(f"  C_2((1,1)) scalar error from 3: {c2_adj_err:.3e}")
+    print(f"  C_3((1,1)) scalar error from 0: {c3_adj_err:.3e}")
+    record(
+        "adjoint Casimirs match C2(1,1)=3 and C3(1,1)=0.",
+        c2_adj_err < OPERATOR_TOL and c3_adj_err < OPERATOR_TOL,
+    )
     print()
 
-    # ===== Section C: tensor product Casimir + exchange =====
-    print("--- Section C: tensor product Casimir + exchange operator ---")
+    print("  Independent cubic-Casimir sign anchor:")
+    fundamental = [matrix / 2.0 for matrix in lam]
+    antifundamental = [-matrix.conj() for matrix in fundamental]
+    c2_fund = sum(matrix @ matrix for matrix in fundamental)
+    c2_antifund = sum(matrix @ matrix for matrix in antifundamental)
+    c3_fund = cubic_casimir(fundamental, d)
+    c3_antifund = cubic_casimir(antifundamental, d)
+    c2_10, c3_10 = canonical_su3_casimirs(3, 0)
+    c2_10bar, c3_10bar = canonical_su3_casimirs(0, 3)
+    formula_err = max(
+        float(np.max(np.abs(c2_fund - (4.0 / 3.0) * np.eye(3)))),
+        float(np.max(np.abs(c2_antifund - (4.0 / 3.0) * np.eye(3)))),
+        float(np.max(np.abs(c3_fund - (10.0 / 9.0) * np.eye(3)))),
+        float(np.max(np.abs(c3_antifund + (10.0 / 9.0) * np.eye(3)))),
+    )
+    print("    Formula: C3(p,q)=(p-q)(2p+q+3)(p+2q+3)/18")
+    print("    direct fundamental matrices:     C3(1,0)  = +10/9")
+    print("    direct antifundamental matrices: C3(0,1)  = -10/9")
+    print(f"    formula decuplet:     (C2,C3)=({c2_10},{c3_10})")
+    print(f"    formula antidecuplet: (C2,C3)=({c2_10bar},{c3_10bar})")
+    record(
+        "fundamental matrices anchor the formula sign, so (3,0) has C3=+9 and (0,3) has C3=-9.",
+        formula_err < OPERATOR_TOL
+        and c2_10 == 6
+        and c2_10bar == 6
+        and c3_10 == 9
+        and c3_10bar == -9,
+    )
+    print()
+
+    # ===== Section C: tensor product commuting operators =====
+    print("--- Section C: tensor-product commuting operators ---")
     C_total = tensor_product_casimir(T)
     E = exchange_operator(8)
-    # Verify E^2 = I
-    E_sq = E @ E
-    e_err = np.max(np.abs(E_sq - np.eye(64)))
-    print(f"  Exchange E^2 - I error: {e_err:.3e}")
-    if e_err < 1e-10:
-        print("  PASS: exchange operator satisfies E^2 = I.")
-        pass_count += 1
-    else:
-        print("  FAIL: exchange operator broken.")
-        fail_count += 1
+    C3_total = tensor_product_cubic_casimir(T, d)
+    ident64 = np.eye(64, dtype=complex)
+    hermitian_err = max(
+        float(np.max(np.abs(operator - operator.conj().T)))
+        for operator in (C_total, E, C3_total)
+    )
+    e_err = float(np.max(np.abs(E @ E - ident64)))
+    operator_comm_err = max(
+        float(np.max(np.abs(C_total @ E - E @ C_total))),
+        float(np.max(np.abs(C_total @ C3_total - C3_total @ C_total))),
+        float(np.max(np.abs(E @ C3_total - C3_total @ E))),
+    )
+    print(f"  max Hermiticity error:             {hermitian_err:.3e}")
+    print(f"  exchange involution ||E²-I||_max:  {e_err:.3e}")
+    print(f"  max pairwise commutator error:      {operator_comm_err:.3e}")
+    record(
+        "C2, exchange, and C3 are numerically Hermitian commuting operators with E²=I.",
+        hermitian_err < OPERATOR_TOL
+        and e_err < OPERATOR_TOL
+        and operator_comm_err < OPERATOR_TOL,
+    )
     print()
 
     # ===== Section D: CG decomposition via diagonalization =====
     print("--- Section D: CG decomposition via simultaneous diagonalization ---")
-    C3_total = tensor_product_cubic_casimir(T, d)
     eigvals, eigvecs, (alpha, beta) = cg_decomposition(C_total, E, C3_total)
-    print(f"  Diagonalizing H = C_2_total + α E + β C_3_total")
+    projectors = spectral_channel_projectors(eigvals, eigvecs, alpha, beta)
+    print("  Diagonalizing H = C_2_total + α E + β C_3_total")
     print(f"  α = sqrt(2) = {alpha:.6f}, β = sqrt(3)/7 = {beta:.6f}")
-    # Group eigenvalues by clusters
-    rounded = sorted([round(float(ev), 4) for ev in eigvals])
-    unique_vals = sorted(set(rounded))
-    print(f"  Number of unique eigenvalue clusters: {len(unique_vals)}")
-    multiplicities = [(v, rounded.count(v)) for v in unique_vals]
-    print(f"  (eigenvalue, multiplicity) pairs:")
-    for v, m in multiplicities:
-        print(f"    H = {v:>11.4f}  multiplicity {m:>3}")
-    print()
-
-    # ===== Section E: verify dimensions sum to 64 =====
-    total_dim = sum(m for v, m in multiplicities)
-    expected_total = 64
-    print(f"  Total dimension: {total_dim}  (expected {expected_total})")
-    if total_dim == expected_total:
-        print(f"  PASS: dimensions sum to 64 = 8 × 8.")
-        pass_count += 1
-    else:
-        print(f"  FAIL: dimensions don't match.")
-        fail_count += 1
-    print()
-
-    # ===== Section F: verify expected fusion channel pattern =====
-    print("--- Section F: verify (1,1) ⊗ (1,1) = 1 + 8 + 8 + 10 + 10̄ + 27 ---")
-    expected_pattern = sorted([1, 8, 8, 10, 10, 27])
-    actual_pattern = sorted([m for v, m in multiplicities])
-    print(f"  Expected dimensions (sorted): {expected_pattern}")
-    print(f"  Actual dimensions (sorted):   {actual_pattern}")
-    if actual_pattern == expected_pattern:
-        print(f"  PASS: 6 channels with correct dimensions.")
-        pass_count += 1
-    else:
-        print(f"  FAIL: channel pattern mismatch.")
-        fail_count += 1
-    print()
-
-    # ===== Section G: orthogonality of CG basis =====
-    print("--- Section G: orthonormality of CG eigenbasis ---")
     overlap = eigvecs.conj().T @ eigvecs
-    overlap_err = np.max(np.abs(overlap - np.eye(64)))
-    print(f"  ||V^† V - I|| = {overlap_err:.3e}")
-    if overlap_err < 1e-10:
-        print(f"  PASS: CG basis is orthonormal.")
-        pass_count += 1
-    else:
-        print(f"  FAIL: CG basis not orthonormal.")
-        fail_count += 1
+    overlap_err = float(np.max(np.abs(overlap - ident64)))
+    actual_pattern = sorted(spec.dimension for spec in CHANNEL_SPECS)
+    expected_pattern = [1, 8, 8, 10, 10, 27]
+    print(f"  six matched dimensions: {actual_pattern}; total={sum(actual_pattern)}")
+    print(f"  eigensolver orthonormality ||V†V-I||_max: {overlap_err:.3e}")
+    record(
+        "floating-point H spectrum has six separated clusters with ranks 1,8,8,10,10,27.",
+        actual_pattern == expected_pattern and sum(actual_pattern) == 64,
+    )
+    record(
+        "the returned floating-point CG eigenbasis is orthonormal within tolerance.",
+        overlap_err < OPERATOR_TOL,
+    )
     print()
 
-    # ===== Section H: SU(3) equivariance =====
-    print("--- Section H: SU(3) equivariance of channel decomposition ---")
-    # For random g, D⊗D should commute with C_total and preserve channel blocks
-    g = random_su3(seed=11)
-    D = adjoint_matrix(g, lam)
-    DD = np.kron(D, D)
-    # Check [D⊗D, C_total] = 0
-    commutator = DD @ C_total - C_total @ DD
-    comm_err = np.max(np.abs(commutator))
-    print(f"  ||[D⊗D, C_total]|| = {comm_err:.3e}")
-    # Check D⊗D commutes with E
-    EE_comm = DD @ E - E @ DD
-    EE_err = np.max(np.abs(EE_comm))
-    print(f"  ||[D⊗D, E]|| = {EE_err:.3e}")
-    if comm_err < 1e-8 and EE_err < 1e-8:
-        print(f"  PASS: D⊗D commutes with both Casimir and exchange.")
-        pass_count += 1
-    else:
-        print(f"  FAIL: SU(3) equivariance broken.")
-        fail_count += 1
+    # ===== Section E: executable six-channel identification =====
+    print("--- Section E: simultaneous-channel spectral projectors ---")
+    max_projector_herm = 0.0
+    max_projector_idem = 0.0
+    max_scalar_residual = 0.0
+    computed_ranks = []
+    observed_c3: Dict[str, float] = {}
+    for spec in sorted(CHANNEL_SPECS, key=lambda item: item.h_eigenvalue(alpha, beta)):
+        projector = projectors[spec.key]
+        rank = int(np.linalg.matrix_rank(projector, tol=EIGENVALUE_TOL))
+        computed_ranks.append(rank)
+        herm_err = float(np.max(np.abs(projector - projector.conj().T)))
+        idem_err = float(np.max(np.abs(projector @ projector - projector)))
+        c2_obs, c2_res = observed_scalar(projector, C_total, spec.dimension)
+        e_obs, e_res = observed_scalar(projector, E, spec.dimension)
+        c3_obs, c3_res = observed_scalar(projector, C3_total, spec.dimension)
+        observed_c3[spec.key] = c3_obs
+        expected_residual = max(
+            float(np.max(np.abs(C_total @ projector - spec.c2 * projector))),
+            float(np.max(np.abs(E @ projector - spec.exchange * projector))),
+            float(np.max(np.abs(C3_total @ projector - spec.c3 * projector))),
+        )
+        max_projector_herm = max(max_projector_herm, herm_err)
+        max_projector_idem = max(max_projector_idem, idem_err)
+        max_scalar_residual = max(
+            max_scalar_residual,
+            c2_res,
+            e_res,
+            c3_res,
+            expected_residual,
+        )
+        h_observed = c2_obs + alpha * e_obs + beta * c3_obs
+        print(
+            f"  {spec.key:>5} ({spec.dynkin[0]},{spec.dynkin[1]}) "
+            f"rank={rank:>2}: H={h_observed: .7f}, "
+            f"observed (C2,E,C3)=({c2_obs: .8f},{e_obs:+.8f},{c3_obs:+.8f}); "
+            f"expected=({spec.c2:g},{spec.exchange:+g},{spec.c3:+g})"
+        )
+    record(
+        "all six spectral projectors are Hermitian, idempotent, have the expected ranks, and carry the expected scalar (C2,E,C3) data.",
+        sorted(computed_ranks) == expected_pattern
+        and max_projector_herm < OPERATOR_TOL
+        and max_projector_idem < OPERATOR_TOL
+        and max_scalar_residual < OPERATOR_TOL,
+    )
+
+    pairwise_orth_err = 0.0
+    for i, left in enumerate(CHANNEL_SPECS):
+        for right in CHANNEL_SPECS[i + 1:]:
+            pairwise_orth_err = max(
+                pairwise_orth_err,
+                float(np.max(np.abs(projectors[left.key] @ projectors[right.key]))),
+            )
+    completeness_err = float(
+        np.max(
+            np.abs(
+                sum((projectors[spec.key] for spec in CHANNEL_SPECS), np.zeros_like(E))
+                - ident64
+            )
+        )
+    )
+    print(f"  max pairwise projector product: {pairwise_orth_err:.3e}")
+    print(f"  completeness ||ΣP-I||_max:      {completeness_err:.3e}")
+    record(
+        "the six projectors are pairwise orthogonal and complete.",
+        pairwise_orth_err < OPERATOR_TOL and completeness_err < OPERATOR_TOL,
+    )
+    print()
+
+    # ===== Section F: independent invariant-polynomial construction =====
+    print("--- Section F: independent invariant-polynomial projectors ---")
+    polynomial_projectors = invariant_polynomial_projectors(C_total, E, C3_total)
+    polynomial_match_err = max(
+        float(np.max(np.abs(polynomial_projectors[spec.key] - projectors[spec.key])))
+        for spec in CHANNEL_SPECS
+    )
+    polynomial_complete_err = float(
+        np.max(
+            np.abs(
+                sum(
+                    (polynomial_projectors[spec.key] for spec in CHANNEL_SPECS),
+                    np.zeros_like(E),
+                )
+                - ident64
+            )
+        )
+    )
+    print(f"  max |P_polynomial-P_eigensolver|: {polynomial_match_err:.3e}")
+    print(f"  polynomial completeness error:    {polynomial_complete_err:.3e}")
+    record(
+        "independent commuting-operator polynomials reproduce all six eigensolver projectors.",
+        polynomial_match_err < OPERATOR_TOL
+        and polynomial_complete_err < OPERATOR_TOL,
+    )
+    print()
+
+    # ===== Section G: hostile controls =====
+    print("--- Section G: hostile controls ---")
+    swapped_10_error = abs(observed_c3["10"] - (-9.0))
+    swapped_10bar_error = abs(observed_c3["10bar"] - (+9.0))
+    coarse_eigvals, coarse_eigvecs, _ = cg_decomposition(C_total, E, None)
+    coarse_target = 6.0 - alpha
+    coarse_indices = np.where(np.abs(coarse_eigvals - coarse_target) < EIGENVALUE_TOL)[0]
+    coarse_basis = coarse_eigvecs[:, coarse_indices]
+    coarse_projector = coarse_basis @ coarse_basis.conj().T
+    coarse_rank = int(np.linalg.matrix_rank(coarse_projector, tol=EIGENVALUE_TOL))
+    coarse_c3_eigenvalues = np.linalg.eigvalsh(
+        (coarse_basis.conj().T @ C3_total @ coarse_basis
+         + (coarse_basis.conj().T @ C3_total @ coarse_basis).conj().T)
+        / 2.0
+    )
+    coarse_unique_clusters = len(set(np.round(coarse_eigvals, 8)))
+    coarse_c3_min = float(np.min(coarse_c3_eigenvalues))
+    coarse_c3_max = float(np.max(coarse_c3_eigenvalues))
+    print(
+        "  old swapped-label residuals: "
+        f"10→C3=-9 gives {swapped_10_error:.1f}; "
+        f"10bar→C3=+9 gives {swapped_10bar_error:.1f}"
+    )
+    print(
+        "  C2+E-only decuplet projector: "
+        f"rank={coarse_rank}, C3 range=[{coarse_c3_min:.8f},{coarse_c3_max:.8f}], "
+        f"total clusters={coarse_unique_clusters}"
+    )
+    record(
+        "hostile controls reject the old swapped labels and reject C2+E as a six-channel identifier.",
+        swapped_10_error > 17.0
+        and swapped_10bar_error > 17.0
+        and coarse_rank == 20
+        and abs(coarse_c3_min + 9.0) < OPERATOR_TOL
+        and abs(coarse_c3_max - 9.0) < OPERATOR_TOL
+        and coarse_unique_clusters == 5,
+    )
+    print()
+
+    # ===== Section H: deterministic numerical equivariance witnesses =====
+    print("--- Section H: deterministic SU(3) equivariance witnesses ---")
+    max_group_definition_err = 0.0
+    max_operator_equivariance_err = 0.0
+    max_projector_equivariance_err = 0.0
+    for seed in SU3_TEST_SEEDS:
+        g = random_su3(seed=seed)
+        group_err = max(
+            float(np.max(np.abs(g.conj().T @ g - np.eye(3)))),
+            abs(np.linalg.det(g) - 1.0),
+        )
+        D = adjoint_matrix(g, lam)
+        DD = np.kron(D, D)
+        c2_comm = float(np.max(np.abs(DD @ C_total - C_total @ DD)))
+        e_comm = float(np.max(np.abs(DD @ E - E @ DD)))
+        c3_comm = float(np.max(np.abs(DD @ C3_total - C3_total @ DD)))
+        channel_comm = {
+            spec.key: float(
+                np.max(np.abs(DD @ projectors[spec.key] - projectors[spec.key] @ DD))
+            )
+            for spec in CHANNEL_SPECS
+        }
+        max_group_definition_err = max(max_group_definition_err, group_err)
+        max_operator_equivariance_err = max(
+            max_operator_equivariance_err, c2_comm, e_comm, c3_comm
+        )
+        max_projector_equivariance_err = max(
+            max_projector_equivariance_err, *channel_comm.values()
+        )
+        channel_text = " ".join(
+            f"{spec.key}={channel_comm[spec.key]:.2e}" for spec in CHANNEL_SPECS
+        )
+        print(
+            f"  seed={seed:>3}: C2={c2_comm:.2e} E={e_comm:.2e} "
+            f"C3={c3_comm:.2e}; {channel_text}"
+        )
+    record(
+        "five independently seeded deterministic SU(3) samples commute with C2, E, C3, and every channel projector within the explicit tolerance.",
+        max_group_definition_err < EQUIVARIANCE_TOL
+        and max_operator_equivariance_err < EQUIVARIANCE_TOL
+        and max_projector_equivariance_err < EQUIVARIANCE_TOL,
+    )
+    print(f"  equivariance tolerance: {EQUIVARIANCE_TOL:.1e}")
+    print(
+        "  Boundary: these are finite floating-point implementation witnesses; "
+        "the all-g statement follows analytically from Casimir invariance, "
+        "factor-swap invariance, and spectral-polynomial functional calculus."
+    )
     print()
 
     # ===== Summary =====
@@ -486,14 +790,14 @@ def driver() -> int:
     print("=" * 78)
     print()
     print("Headline:")
-    print(f"  SU(3) (1,1) ⊗ (1,1) decomposed into {len(unique_vals)} fusion channels")
+    print(f"  SU(3) (1,1) ⊗ (1,1) decomposed into {len(CHANNEL_SPECS)} fusion channels")
     print(f"  with dimensions {actual_pattern} = {sum(actual_pattern)} total.")
-    print(f"  Expected: 1 + 8 + 8 + 10 + 10̄ + 27 = 64. Match: "
-          f"{actual_pattern == sorted([1, 8, 8, 10, 10, 27])}")
+    print("  Correct cubic convention: 10=(3,0) has C3=+9 and H≈6.8127;")
+    print("                            10bar=(0,3) has C3=-9 and H≈2.3589.")
     print()
-    print("Block 1 deliverable: SU(3) (1,1) ⊗ (1,1) CG basis (64 orthonormal")
-    print("vectors organized into 6 irrep blocks). Available as `eigvecs` array")
-    print("and importable for Block 2 (4-fold Haar projector).")
+    print("Block 1 deliverable: six executable spectral projectors plus a")
+    print("floating-point orthonormal CG basis. Exact block invariance is supplied")
+    print("by the analytic commuting-operator identities, not by numerical precision.")
     return 0 if fail_count == 0 else 1
 
 


### PR DESCRIPTION
## Audit rationale

> The runner genuinely constructs the SU(3) operators and computes the six
> eigenvalue multiplicities, so the load-bearing step is class C rather than a
> printed or tuned result. Under the stated normalization, C3=+9 corresponds
> to (3,0), giving H=6.8127, while C3=-9 corresponds to (0,3), giving H=2.3589;
> the source table assigns these labels oppositely. The equivariance test also
> checks only C2 and exchange for one sampled group element, not C3 or the six
> channel projectors, so it does not establish the advertised blockwise
> equivariance.

## Exact repair target

> Re-audit after swapping the 10/10bar eigenvalue labels, adding canonical
> cubic-Casimir checks and channel-projector equivariance tests, and describing
> the floating-point diagonalization without claiming numerical exactness.

## Repair

- Corrects the executable convention to `10=(3,0)`, `C3=+9`,
  `H=6.8127089`, and `10bar=(0,3)`, `C3=-9`, `H=2.3588640`.
- Constructs six simultaneous `(C2,E,C3)` spectral projectors and checks
  Hermiticity, idempotence, pairwise orthogonality, completeness, ranks
  `1,8,8,10,10,27`, and scalar operator data on every block.
- Independently reconstructs the same six projectors as invariant
  commuting-operator polynomials. The maximum difference from the eigensolver
  projectors is `1.554e-15`; polynomial completeness error is `2.442e-15`.
- Anchors the cubic sign outside the tensor-product eigensolver in two ways:
  direct fundamental/antifundamental contractions give
  `C3(1,0)=+10/9`, `C3(0,1)=-10/9`, and the total `C3` agrees with an
  independently expanded coproduct to `1.332e-15`.
- Adds hostile controls that reject the old label swap (residual `18`), a
  global `C3` sign flip (residual `5.19615242`), the wrong antifundamental
  convention (`Lie residual=1`), and `(C2,E)`-only splitting (five clusters
  with one rank-20 decuplet-pair sector).
- Demonstrates that standalone `(I+C3/9)/2` is not a full-space projector:
  rank `54`, idempotence residual `0.25`; after the correct
  `C2=6,E=-1` restriction, the decuplet projector has rank `10`.
- Checks `C2`, exchange, `C3`, and every channel projector against five
  deterministic SU(3) samples (`11,29,47,83,101`). The largest printed
  operator/projector commutators are `1.56e-15`/`1.40e-15`, against tolerance
  `1e-10`.
- Removes noncanonical authored status/audit-prediction metadata, preserves
  `Claim type: positive_theorem`, and keeps downstream context out of the
  load-bearing dependency graph.

Block 2 and direct consumers were inspected for old H values, label/order
pins, API coupling, and status prose. Block 2 uses only the unordered
`10+10bar` pair and re-bundles its primitives, so no formula or API update is
needed. Two pre-existing later notes literally pin historical retention
language; that governance cleanup is recorded narrowly in
`docs/repo/ACTIVE_REVIEW_QUEUE.md` rather than widening this claim-note repair.

## Independent Sol xhigh review

All reviewer seats used `gpt-5.6-sol` with `xhigh` reasoning.

- Code/runner lens: found that the original repaired runner could still pass
  after globally negating total `C3`, because both projector constructions
  moved together. Iteration 1 added the independent coproduct anchor and
  hostile mutation controls. Re-review: clean.
- Physics/claim lens: verified exact-vs-numerical boundaries, canonical
  Casimirs, projector restriction, hostile controls, and all-g analytic
  equivariance. Re-review: clean.
- Governance/consumer lens: removed source-authored authority/status prose,
  prevented a false Block1-to-Block2 dependency edge, and queued only the
  pre-existing downstream status-language drift. Iteration 2 updated the live
  queue date. Re-review: clean.

Review commits:

- `588870f97ceef795bf364b7e0a1b08d1c5acfadf` — iteration 1 science,
  runner/cache, theorem-boundary, and governance fixes.
- `2c333483ec865767b09cf38402fdb032f6641a35` — iteration 2 queue metadata
  correction.

## Independent calculations

A separate implementation that did not import the runner obtained:

- `C3(3,0)=+9`, `C3(0,3)=-9`.
- `H(10)=6.812708904501`, `H(10bar)=2.358863970753`.
- Projector ranks `1,8,8,10,10,27`.
- Max Hermiticity/idempotence/orthogonality/completeness/scalar-action errors
  `1.665e-16`, `1.665e-15`, `8.429e-16`, `2.442e-15`, `4.441e-15`.
- Eigensolver/polynomial projector agreement `1.887e-15`.
- Seven separately generated exponential-map SU(3) samples had maximum
  `[D(g)⊗D(g),C3]` residual `2.365e-15` and maximum projector commutator
  `7.772e-16`.
- Correct antifundamental convention: `C3=-1.111111111`, Lie residual
  `1.110e-16`; wrong conjugation: `C3=+1.111111111`, Lie residual `1`.

An actual mutation replacing total `C3` by its negative exits `1` with
`PASS=10 FAIL=2`, failing both the coproduct agreement and hostile-control
checks.

## Validation

- Rebased/current-base guard: `origin/main=cd33b5a06d2016de9f733dd9131cc19442ff24f2`;
  no main movement or overlapping files since review began.
- Primary runner twice: byte-identical stdout,
  `SUMMARY: THEOREM PASS=12 FAIL=0`.
- Cache/live contract: exit `0`, empty stderr, `5845` stdout bytes on each
  side, exact payload equality after excluding the cache delimiter newline.
- Fresh runner/cache SHA:
  `d2505c3c72725bb9367b5dc0be131f6b62fc7bd92e258b2f22978c992b250f1a`.
- `python3 -m py_compile`, import/API smoke, direct consumer smoke
  (`PASS=37 FAIL=0`), `git diff --check`, portable-link/dependency checks, and
  controlled-vocabulary fix/report all pass.
- Disposable detached-worktree compatibility pipeline and
  `audit_lint.py --strict`: `3754` rows, `0` errors. The Block 1 row becomes
  canonical `positive_theorem`, `audit_status=unaudited`,
  `effective_status=unaudited`, `deps=[]`, ready with no blocker. Existing
  repository-wide warnings/notices are unchanged and outside this repair.
- Both disposable worktrees were deleted; no generated ledger, queue,
  effective-status, publication-status, front-door, or missing-prompt output
  is present in the PR branch.

## Theorem boundary

The Littlewood–Richardson decomposition, canonical Casimir eigenvalues,
commutation of the diagonal SU(3) action with the Casimirs and factor
exchange, and spectral-polynomial functional calculus supply the exact
all-`g` argument. The `complex128` eigendecomposition, residuals, and sampled
group elements are finite numerical implementation witnesses, not a proof by
numerical exactness.

This review ran no audit worker, audit agent, verdict-writing command,
`codex_audit_runner.py`, or `apply_audit.py`, and it assigns no audit verdict.
Independent post-merge re-audit owns ratification.
