### PR TITLE
[physics-loop] su3-positive-coefficient: close exact support bridge

### DIFF
--- a/docs/GAUGE_WILSON_SU3_ALL_WEIGHT_POSITIVE_COEFFICIENT_FORMAL_BRIDGE_NOTE_2026-06-07.md
+++ b/docs/GAUGE_WILSON_SU3_ALL_WEIGHT_POSITIVE_COEFFICIENT_FORMAL_BRIDGE_NOTE_2026-06-07.md
@@ -1,149 +1,478 @@
 # Gauge Wilson SU(3) All-Weight Positive-Coefficient Formal Bridge
 
-**Date:** 2026-06-07
-**Type:** exact-support bridge theorem
-**Claim scope:** framework-native bridge for two all-weight facts used by
-gauge-vacuum plaquette residual-environment notes:
+**Date:** 2026-06-07 (post-audit source repair 2026-07-16)
+**Claim type:** positive_theorem
+**Claim scope:** two exact statements on the standard finite-dimensional
+`SU(3)` representation and normalized-Haar surfaces:
 
-1. For every `beta > 0` and every dominant `SU(3)` weight
-   `(p,q) in P_+`, the one-link Wilson class function
-   `w_beta(U) = exp[(beta/6)(chi_(1,0)(U) + chi_(0,1)(U))]` has a
-   strictly positive Peter-Weyl character coefficient `c_(p,q)(beta)`.
-2. Any all-weight coefficient sequence `(z_(p,q))` defines a formal central
-   character distribution on the finite-character test algebra, with
-   unnormalized convolution action
-   `C_Z chi_(p,q) = z_(p,q) chi_(p,q)` on each basis character. This is a
-   formal/distribution statement only; it is not an `L^2`, continuous
-   class-function, or bounded-operator closure without a separate decay
-   theorem.
+1. For every `beta > 0` and every dominant weight `(p,q)`, the one-link
+   Wilson class function
+   `w_beta(U) = exp[(beta/6)(chi_(1,0)(U) + chi_(0,1)(U))]`
+   has strictly positive character coefficient `c_(p,q)(beta)`, and the
+   normalized convolution eigenvalue
+   `a_(p,q)(beta) = c_(p,q)(beta)/(d_(p,q)c_(0,0)(beta))`
+   is strictly positive.
+2. Any all-weight scalar sequence `(z_(p,q))` gives a compatible family of
+   finite central character polynomials whose ordinary Haar convolutions
+   stabilize on every finite-character test vector to
+   `chi_(p,q) -> z_(p,q) chi_(p,q)`.
+
+The second statement is algebraic-dual/finite-test-vector only. It does not
+assert an all-weight `L^2` class function, a continuous class function, a
+measure, a positive distribution, or a bounded operator on a completed
+Hilbert space.
 
 **Primary runner:**
 [`scripts/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.py`](../scripts/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.py)
 
-**Status authority:** independent audit lane only. This bridge does not set an
-audit verdict and does not edit audit ledger files.
+**Status boundary:** audit status is pipeline-derived. This source repair does
+not write or predict an audit verdict.
 
-## Statement
+## 1. Notation
 
-Let `V = 3 direct_sum 3bar`, so that
-
-```text
-chi_V = chi_(1,0) + chi_(0,1).
-```
-
-For `beta >= 0`,
+Let
 
 ```text
-w_beta(U) = exp[(beta/6) chi_V(U)]
-          = sum_{n >= 0} (beta/6)^n chi_V(U)^n / n!.
+G = SU(3),
+E = C^3 = V_(1,0),
+E* = V_(0,1),
+W = E direct_sum E*,
+t = beta/6.
 ```
 
-The product `chi_V^n` is the character of `V^{tensor n}`. Therefore its
-expansion into irreducible `SU(3)` characters has non-negative integer
-coefficients: the coefficients are tensor-product multiplicities.
-
-For any dominant weight `(p,q)`, the irrep `V_(p,q)` occurs in
+Here `E*` is the contragredient representation; for `SU(3)` it is the
+antifundamental `3bar`. Let `dU` be normalized Haar probability measure.
+For a dominant weight `(p,q)`, write
 
 ```text
-Sym^p(3) tensor Sym^q(3bar) subset V^{tensor (p+q)}
+lambda_(p,q) = p omega_1 + q omega_2,
+d_(p,q) = (p+1)(q+1)(p+q+2)/2.
 ```
 
-as its Cartan highest-weight component. Hence the coefficient of
-`chi_(p,q)` in `chi_V^(p+q)` is at least one. When `beta > 0`, the
-`n = p+q` term of the exponential contributes a strictly positive amount
-to `c_(p,q)(beta)`, and all other terms contribute non-negatively. For
-`(p,q)=(0,0)`, the `n=0` term already gives `c_(0,0)(beta) >= 1`.
-
-Therefore:
+Define the tensor-power multiplicity
 
 ```text
-c_(p,q)(beta) > 0       for every beta > 0 and every (p,q) in P_+(SU(3)).
+m_(p,q)(n) = dim Hom_G(V_(p,q), W^(tensor n)).
 ```
 
-The one-link normalized convolution eigenvalue
+Finite-dimensional complete reducibility makes this a non-negative integer,
+and
 
 ```text
-a_(p,q)(beta) = c_(p,q)(beta) / (d_(p,q) c_(0,0)(beta))
+chi_W(U)^n
+  = chi_(W^(tensor n))(U)
+  = sum_(r,s) m_(r,s)(n) chi_(r,s)(U),                         (1)
 ```
 
-is also strictly positive for every `beta > 0`, because
-`d_(p,q) > 0` and `c_(0,0)(beta) > 0`.
+where the sum is finite for each fixed `n`.
 
-## Formal All-Weight Convolution Dictionary
+## 2. Explicit SU(3) Highest-Weight Occurrence
 
-Let `C_fin` be the finite-character test algebra:
+This section proves the contested occurrence directly.
+
+Work with the complexified Lie algebra `sl_3(C)`. Let
+`e_1,e_2,e_3` be the standard basis of `E`, with dual basis
+`e^1,e^2,e^3`. Choose the standard upper-triangular positive-root
+operators
 
 ```text
-C_fin = direct_sum_{(p,q) in P_+} C chi_(p,q).
+E_12, E_23, E_13.
 ```
 
-For any all-weight sequence `(z_(p,q))`, define the formal central
-character distribution
+For a traceless diagonal matrix
+`H = diag(h_1,h_2,h_3)`, the fundamental weights in this convention satisfy
 
 ```text
-Z_z := sum_{(p,q) in P_+} d_(p,q) z_(p,q) chi_(p,q)
+omega_1(H) = h_1,
+omega_2(H) = h_1 + h_2 = -h_3.
 ```
 
-as an element of the algebraic dual of `C_fin`. On basis characters, the
-unnormalized central convolution action is defined coefficientwise by the
-Schur/Peter-Weyl diagonal rule:
+Therefore
 
 ```text
-C_(Z_z) chi_(p,q) = z_(p,q) chi_(p,q).
+H e_1 = omega_1(H) e_1,
+H e^3 = -h_3 e^3 = omega_2(H) e^3.                           (2)
 ```
 
-This is enough for per-weight identities and all-weight formal diagonal
-actions. It does not assert that `Z_z` is an `L^2` class function, a
-continuous class function, a positive measure, or that `C_(Z_z)` is a
-bounded operator on the completed Hilbert space. Those upgrades require
-separate summability/decay hypotheses on `(z_(p,q))`.
-
-## Application To The Plaquette Residual-Environment Row
-
-This bridge supplies two missing authorities for
-`GAUGE_VACUUM_PLAQUETTE_RESIDUAL_ENVIRONMENT_ALL_WEIGHT_CONVOLUTION_IDENTIFICATION_NARROW_THEOREM_NOTE_2026-05-17.md`:
-
-- the strict all-weight positivity/nonzero input for the Wilson one-link
-  coefficients `a_(p,q)(beta)`;
-- the formal all-weight diagonal-convolution object needed when the residual
-  sequence `r_(p,q)^env(beta)` has not been proven to satisfy an `L^2` or
-  continuous-function decay bound.
-
-The application remains per-weight/formal. It does not close the parent
-Perron problem, does not compute framework-point `beta = 6` residual
-coefficients, and does not assert full completed-Hilbert-space operator
-closure.
-
-## Forbidden Imports Check
-
-- No observed values, PDG inputs, fitted selectors, or admitted unit
-  conventions are used.
-- No new framework axiom is introduced.
-- No textbook theorem is imported as a black box: the strict positivity
-  argument is the native tensor-product multiplicity expansion of the Wilson
-  class function on the existing `SU(3)` character basis.
-- External representation-theory language is parallel context only; the
-  load-bearing proof is the Cartan-component occurrence inside finite tensor
-  powers of `3 direct_sum 3bar`.
-
-## Validation
-
-The companion runner checks:
-
-1. every sampled weight `(p,q)` has a finite witness tensor length
-   `n=p+q`;
-2. the strict lower-bound monomial from that witness is positive for
-   `beta > 0`;
-3. `a_(p,q)(beta)` is positive whenever `c_(p,q)(beta)`, `d_(p,q)`, and
-   `c_(0,0)(beta)` are positive;
-4. the `beta=0` boundary is not overclaimed for nontrivial weights;
-5. arbitrary all-weight coefficient data gives a formal diagonal convolution
-   action on finite-character test vectors;
-6. the note and the downstream plaquette note expose the formal/distribution
-   boundary explicitly.
-
-Expected runner summary:
+The dual action is `(X phi)(v) = -phi(Xv)`. Direct calculation gives
 
 ```text
-TOTAL: PASS=38 FAIL=0
+E_12 e_1 = E_23 e_1 = E_13 e_1 = 0,
+E_12 e^3 = E_23 e^3 = E_13 e^3 = 0.                         (3)
 ```
+
+For example, `E_23 E` has image in `span(e_2)`, which `e^3` annihilates,
+and similarly for `E_12` and `E_13`.
+
+For arbitrary `p,q >= 0`, consider the nonzero tensor
+
+```text
+v_(p,q)
+  = e_1^(tensor p) tensor (e^3)^(tensor q)
+  in E^(tensor p) tensor (E*)^(tensor q).                    (4)
+```
+
+The Lie-algebra action on a tensor product is the sum of the actions on its
+factors. Equations `(2)` and `(3)` therefore imply
+
+```text
+weight(v_(p,q)) = p omega_1 + q omega_2,
+E_12 v_(p,q) = E_23 v_(p,q) = E_13 v_(p,q) = 0.              (5)
+```
+
+Thus `v_(p,q)` is an explicit highest-weight vector of dominant weight
+`(p,q)`. It is symmetric separately in its `E` and `E*` factors, so it also
+lies in
+
+```text
+Sym^p(E) tensor Sym^q(E*).
+```
+
+To identify the occurring irreducible without assuming the Cartan-component
+claim, decompose the finite-dimensional unitary `SU(3)` representation
+`E^(tensor p) tensor (E*)^(tensor q)` into irreducibles. Project
+`v_(p,q)` to those summands. Each projection has the same weight and is killed
+by all positive-root operators. In an irreducible finite-dimensional
+`SU(3)` module, the common kernel of the positive-root operators is its
+one-dimensional highest-weight line. Hence every nonzero projection is in an
+irrep whose highest weight is exactly `p omega_1 + q omega_2`. At least one
+projection is nonzero because `v_(p,q)` is nonzero. By the classification of
+finite-dimensional irreducibles by dominant highest weight, that summand is
+`V_(p,q)`.
+
+Finally,
+
+```text
+E^(tensor p) tensor (E*)^(tensor q)
+```
+
+is one direct-sum word inside
+`(E direct_sum E*)^(tensor (p+q))`. Consequently
+
+```text
+m_(p,q)(p+q) >= 1                                            (6)
+```
+
+for every dominant weight `(p,q)`.
+
+This proves only the occurrence needed here. It does not claim that all of
+`Sym^p(E) tensor Sym^q(E*)` is irreducible.
+
+### Elementary representation facts: proved versus used
+
+The note proves explicitly:
+
+- the weights of `e_1` and `e^3`;
+- their annihilation by the three positive-root matrices;
+- weight additivity and positive-root annihilation for the tensor
+  `v_(p,q)`;
+- the embedding of its tensor word into `W^(tensor (p+q))`.
+
+The note uses these standard finite-dimensional facts:
+
+- unitary representations of compact `SU(3)` are completely reducible;
+- the coordinate projections of a `G`-invariant irreducible direct-sum
+  decomposition are `G`-equivariant;
+- finite-dimensional irreducible `SU(3)` representations are classified by
+  dominant highest weight;
+- in an irreducible, the common positive-root kernel is the highest-weight
+  line;
+- Schur's lemma identifies
+  `dim Hom_G(V_(p,q),W^(tensor n))` with the multiplicity of `V_(p,q)`;
+- characters multiply under tensor products and add under direct sums;
+- the `SU(3)` Weyl dimension formula displayed above;
+- for a unitary representation, `|chi(U)| <= dim(V)`;
+- normalized-Haar matrix-element Schur orthogonality;
+- the two explicit `SU(3)` Pieri rules used by the finite runner recurrence.
+
+The first four used facts identify the explicitly constructed vector with an
+occurring copy of `V_(p,q)`; they do not assume the occurrence itself.
+The Pieri rules are not used to prove the all-weight theorem; they are the
+standard exact recurrence input for the independent finite executable
+certificate.
+
+## 3. Legitimate Character-Coefficient Extraction
+
+For every real `beta` and every `U in SU(3)`,
+
+```text
+|chi_W(U)| <= dim(W) = 6.
+```
+
+Hence the exponential series obeys the uniform absolute majorant
+
+```text
+sum_(n>=0) |t|^n |chi_W(U)|^n / n!
+  <= sum_(n>=0) (6|t|)^n/n!
+  = exp(|beta|).                                             (7)
+```
+
+The Weierstrass M-test gives uniform and absolute convergence on compact
+`SU(3)`:
+
+```text
+w_beta(U)
+  = exp[t chi_W(U)]
+  = sum_(n>=0) t^n chi_W(U)^n/n!.                            (8)
+```
+
+Fix `(p,q)`. Since `|chi_(p,q)(U)| <= d_(p,q)`, the coefficient integrands
+also have an absolutely summable majorant:
+
+```text
+sum_(n>=0) integral_G
+  |t^n chi_W(U)^n conj(chi_(p,q)(U))/n!| dU
+  <= d_(p,q) exp(|beta|).                                   (9)
+```
+
+It is therefore legitimate to integrate the series term by term. With the
+standard character coefficient
+
+```text
+c_(p,q)(beta)
+  = integral_G w_beta(U) conj(chi_(p,q)(U)) dU,
+```
+
+equations `(1)`, `(8)`, normalized-Haar character orthogonality, and `(9)`
+give
+
+```text
+c_(p,q)(beta)
+  = sum_(n>=0) (beta/6)^n m_(p,q)(n)/n!.                    (10)
+```
+
+For `beta >= 0`, Tonelli's theorem for non-negative series and the
+representation-dimension identity
+
+```text
+sum_(p,q) m_(p,q)(n) d_(p,q) = dim(W^(tensor n)) = 6^n
+```
+
+also gives
+
+```text
+sum_(p,q) c_(p,q)(beta) d_(p,q) = exp(beta).                (10a)
+```
+
+Thus `sum_(p,q) c_(p,q)(beta) chi_(p,q)` is itself uniformly and
+absolutely convergent, because
+`|chi_(p,q)(U)| <= d_(p,q)`. This justifies using the actual Wilson
+character series in the ordinary convolution calculation below, independently
+of the formal arbitrary-sequence construction.
+
+For `beta > 0`, every summand in `(10)` is non-negative, and `(6)` supplies
+the strictly positive term
+
+```text
+(beta/6)^(p+q) m_(p,q)(p+q)/(p+q)! > 0.
+```
+
+Thus
+
+```text
+c_(p,q)(beta) > 0
+```
+
+for every dominant `(p,q)` when `beta > 0`. The trivial coefficient also
+satisfies `c_(0,0)(beta) >= 1` because of the `n=0` term.
+
+The boundary is separate:
+
+```text
+c_(0,0)(0) = 1,
+c_(p,q)(0) = 0 for (p,q) != (0,0).                         (11)
+```
+
+No strict all-weight positivity is claimed at `beta=0`.
+
+## 4. Derived Convolution Normalization
+
+The diagonal rule is derived here from the finite Haar convolution, not taken
+as its definition.
+
+Let `F` be a finite set of dominant weights and let
+
+```text
+Z_F(W) = sum_(lambda in F) d_lambda z_lambda chi_lambda(W).
+```
+
+For irreducible unitary matrix representations `D^lambda,D^mu`, define
+
+```text
+I_(lambda,mu)(V)
+  = integral_G chi_lambda(VW^(-1)) chi_mu(W) dW.
+```
+
+Expanding the two traces gives
+
+```text
+chi_lambda(VW^(-1))
+  = sum_(a,b) D^lambda(V)_(a b)
+      conj(D^lambda(W)_(a b)),
+
+chi_mu(W) = sum_c D^mu(W)_(c c).
+```
+
+Matrix-element Schur orthogonality then contracts all indices:
+
+```text
+I_(lambda,mu)(V)
+  = sum_(a,b,c) D^lambda(V)_(a b)
+      delta_(lambda,mu) delta_(a,c) delta_(b,c)/d_mu
+  = delta_(lambda,mu) chi_mu(V)/d_mu.                       (12)
+```
+
+Therefore ordinary convolution by the finite polynomial gives
+
+```text
+(C_(Z_F) chi_mu)(V)
+  = sum_(lambda in F) d_lambda z_lambda I_(lambda,mu)(V)
+  = z_mu chi_mu(V)                                          (13)
+```
+
+whenever `mu in F`. The factor `d_lambda` in `Z_F` cancels the
+`1/d_mu` produced by the Schur contraction only on the surviving
+`lambda=mu` branch.
+
+Now let
+
+```text
+C_fin = direct_sum_lambda C chi_lambda.
+```
+
+Let `chi_lambda^vee` be its algebraic dual basis,
+`chi_lambda^vee(chi_mu)=delta_(lambda,mu)`. The all-weight sequence defines
+the algebraic-dual element
+
+```text
+Z_z = sum_lambda d_lambda z_lambda chi_lambda^vee in C_fin^*,
+```
+
+where the displayed sum is formal but its evaluation on every element of
+`C_fin` is finite. The finite polynomial `Z_F` realizes the same coordinates
+on tests supported in `F`.
+
+For a finite test vector `f = sum_(mu in S) f_mu chi_mu`, every finite
+`F` containing `S` gives, by the ordinary finite convolution just derived,
+
+```text
+C_(Z_F) f = sum_(mu in S) z_mu f_mu chi_mu.                  (14)
+```
+
+The right side is unchanged when `F` is enlarged. The formal all-weight
+object `Z_z` is this compatible family of finite central polynomials, and its
+action on `C_fin` is the stabilized value `(14)`. Thus the all-weight
+coefficientwise action is an output of the finite Schur/Peter-Weyl
+contraction, not a definition standing in for that contraction.
+
+Applying `(12)` to the actual Wilson class function
+`w_beta = sum_lambda c_lambda(beta) chi_lambda` gives
+
+```text
+C_(w_beta) chi_(p,q)
+  = c_(p,q)(beta)/d_(p,q) chi_(p,q).
+```
+
+Dividing by the positive trivial-channel eigenvalue `c_(0,0)(beta)` yields
+
+```text
+a_(p,q)(beta)
+  = c_(p,q)(beta)/(d_(p,q)c_(0,0)(beta)) > 0                (15)
+```
+
+for every `(p,q)` and every `beta > 0`.
+
+The matrix-index calculation `(12)` is the dimension-generic contraction
+used by the landed
+`SU3_CHARACTER_DIAGONAL_CONVOLUTION_EQUIVALENCE_NARROW_THEOREM` block; it is
+inlined here because the present conclusion is all-weight on finite tests,
+whereas that block's durable numerical packet is finite.
+
+## 5. Exact Scope Boundary
+
+The compatible family `(Z_F)` and stabilized action `(14)` require no
+summability of `(z_lambda)`, because each test vector has finite support.
+They do not provide:
+
+- an `L^2` or continuous all-weight class function;
+- a countably additive or positive measure;
+- continuity of the formal functional in a completed topology;
+- a bounded, compact, trace-class, or positive operator on a Hilbert-space
+  completion.
+
+Any such upgrade requires a separate decay or summability theorem.
+
+## 6. Direct Consumers And Literal Pins
+
+The current-main direct source consumers were inspected. At this repair
+snapshot:
+
+- the residual-environment all-weight convolution note consumes only the
+  strict nonzero Wilson coefficient and the finite-test formal convolution
+  dictionary;
+- the native positive-class theta note consumes only the strict Wilson
+  coefficient/eigenvalue positivity for `beta > 0`.
+
+Both statements remain within the repaired scope. Because the
+residual-environment note belongs to a separately changing source-sector
+block, its downstream prose is not an executable premise of this source
+theorem or its primary runner. No downstream source-sector identity,
+environment coefficient, `beta=6` value, reflection-positivity upgrade, or
+completed-operator statement is supplied here.
+
+## 7. Forbidden Imports Check
+
+- No observed value, fitted selector, admitted unit convention, or
+  literature numerical comparator is used.
+- No framework axiom or primitive is introduced.
+- The proof uses only the displayed finite-dimensional `SU(3)` matrices,
+  standard compact-group complete reducibility/highest-weight facts, and
+  normalized-Haar Schur orthogonality.
+- No finite-slab pure-gauge reflection-positivity theorem is imported; it is
+  not needed for this one-link coefficient and finite-test convolution
+  theorem.
+
+## 8. Validation
+
+The companion runner:
+
+1. computes the exact multiplicities of
+   `(3 direct_sum 3bar)^(tensor n)` recursively through tensor level `16`,
+   retaining the full reachable support at every level;
+2. certifies every weight in the declared box `B_8` by scanning for its first
+   nonzero computed multiplicity rather than assigning a witness length;
+3. checks exact dimension conservation
+   `sum_(p,q) m_(p,q)(n)d_(p,q)=6^n` at every level and the local Pieri
+   dimension identities;
+4. checks the `beta=0` boundary and exact positive lower monomials at
+   `beta=1`;
+5. reproduces the matrix-index Schur contraction and dimension cancellation
+   on a finite character packet before applying arbitrary rational
+   coefficients;
+6. checks stabilization under enlargement of the finite convolution packet;
+7. rejects missing-Pieri-branch, fundamental/antifundamental-swap,
+   hard-coded-unit-multiplicity, missing-`1/d`, missing-`d_lambda`, and
+   coefficient-only convolution mutants;
+8. checks source-note scope markers while leaving the separately changing
+   downstream consumer prose outside the executable certificate.
+
+Its recurrence is the explicit pair
+
+```text
+V_(a,b) tensor 3
+  = V_(a+1,b)
+    direct_sum [a>0] V_(a-1,b+1)
+    direct_sum [b>0] V_(a,b-1),
+
+V_(a,b) tensor 3bar
+  = V_(a,b+1)
+    direct_sum [b>0] V_(a+1,b-1)
+    direct_sum [a>0] V_(a-1,b).
+```
+
+Starting from `m_(0,0)(0)=1`, it applies both rules at every step and stores
+the resulting integer multiplicity dictionary without a weight cutoff. The
+declared `B_8` is only the set on which the first-occurrence certificate is
+reported; it is not a truncation of the recurrence.
+
+The cache records the exact final pass/fail count.

--- a/docs/GAUGE_WILSON_SU3_ALL_WEIGHT_POSITIVE_COEFFICIENT_FORMAL_BRIDGE_NOTE_2026-06-07.md
+++ b/docs/GAUGE_WILSON_SU3_ALL_WEIGHT_POSITIVE_COEFFICIENT_FORMAL_BRIDGE_NOTE_2026-06-07.md
@@ -422,7 +422,7 @@ completed-operator statement is supplied here.
 
 ## 7. Forbidden Imports Check
 
-- No observed value, fitted selector, admitted unit convention, or
+- No observed value, fitted selector, explicit unit convention, or
   literature numerical comparator is used.
 - No framework axiom or primitive is introduced.
 - The proof uses only the displayed finite-dimensional `SU(3)` matrices,
@@ -444,16 +444,20 @@ The companion runner:
 3. checks exact dimension conservation
    `sum_(p,q) m_(p,q)(n)d_(p,q)=6^n` at every level and the local Pieri
    dimension identities;
-4. checks the `beta=0` boundary and exact positive lower monomials at
+4. independently reconstructs the tensor-power decompositions by exact
+   Jacobi-Trudi character algebra through level `8` and by direct
+   Gelfand-Tsetlin torus-character enumeration through level `6`;
+5. checks the `beta=0` boundary and exact positive lower monomials at
    `beta=1`;
-5. reproduces the matrix-index Schur contraction and dimension cancellation
+6. reproduces the matrix-index Schur contraction and dimension cancellation
    on a finite character packet before applying arbitrary rational
    coefficients;
-6. checks stabilization under enlargement of the finite convolution packet;
-7. rejects missing-Pieri-branch, fundamental/antifundamental-swap,
+7. checks stabilization under enlargement of the finite convolution packet;
+8. rejects missing-Pieri-branch, fundamental/antifundamental-swap,
    hard-coded-unit-multiplicity, missing-`1/d`, missing-`d_lambda`, and
-   coefficient-only convolution mutants;
-8. checks source-note scope markers while leaving the separately changing
+   coefficient-only convolution mutants, with the recurrence mutants also
+   required to disagree with both independent character decompositions;
+9. checks source-note scope markers while leaving the separately changing
    downstream consumer prose outside the executable certificate.
 
 Its recurrence is the explicit pair

--- a/logs/runner-cache/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.txt
+++ b/logs/runner-cache/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.txt
@@ -1,77 +1,94 @@
 ===== runner cache v1 =====
 runner: scripts/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.py
-runner_sha256: 4e280a53e064f49a17bf8a331cfdb7f2ddd18821818791084a15044106a239f2
+runner_sha256: 2cb2765371c2a5ea74e2aad0246a3b0c7daf3acdbd2b48c4aaafab988c94bc99
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.09
+elapsed_sec: 0.26
 status: ok
 ----- stdout -----
-========================================================================================
+================================================================================================
 GAUGE_WILSON_SU3_ALL_WEIGHT_POSITIVE_COEFFICIENT_FORMAL_BRIDGE
-Goal: all-weight Wilson coefficient positivity + formal convolution bridge
-========================================================================================
+Exact Pieri recurrence through level 16; certified coordinate box B_8
+================================================================================================
 
-----------------------------------------------------------------------------------------
-Part 1: strict positivity witness for every sampled dominant weight
-----------------------------------------------------------------------------------------
-[PASS] finite Cartan-component witness for weight (0,0) :: n=p+q=0, beta=1 lower monomial=1
-[PASS] finite Cartan-component witness for weight (1,0) :: n=p+q=1, beta=1 lower monomial=1/6
-[PASS] finite Cartan-component witness for weight (0,1) :: n=p+q=1, beta=1 lower monomial=1/6
-[PASS] finite Cartan-component witness for weight (1,1) :: n=p+q=2, beta=1 lower monomial=1/72
-[PASS] finite Cartan-component witness for weight (2,0) :: n=p+q=2, beta=1 lower monomial=1/72
-[PASS] finite Cartan-component witness for weight (0,2) :: n=p+q=2, beta=1 lower monomial=1/72
-[PASS] finite Cartan-component witness for weight (2,1) :: n=p+q=3, beta=1 lower monomial=1/1296
-[PASS] finite Cartan-component witness for weight (1,2) :: n=p+q=3, beta=1 lower monomial=1/1296
-[PASS] finite Cartan-component witness for weight (3,3) :: n=p+q=6, beta=1 lower monomial=1/33592320
-[PASS] finite Cartan-component witness for weight (5,2) :: n=p+q=7, beta=1 lower monomial=1/1410877440
-[PASS] finite Cartan-component witness for weight (2,5) :: n=p+q=7, beta=1 lower monomial=1/1410877440
-[PASS] finite Cartan-component witness for weight (8,0) :: n=p+q=8, beta=1 lower monomial=1/67722117120
-[PASS] finite Cartan-component witness for weight (0,8) :: n=p+q=8, beta=1 lower monomial=1/67722117120
+------------------------------------------------------------------------------------------------
+Part 1: exact SU(3) Pieri identities and full-support tensor recurrence
+------------------------------------------------------------------------------------------------
+[PASS] fundamental Pieri branches conserve dimension locally :: checked all weights in coordinate box B_16
+[PASS] antifundamental Pieri branches conserve dimension locally :: checked all weights in coordinate box B_16
+[PASS] fundamental and antifundamental Pieri rules are exchanged by conjugation :: (p,q) <-> (q,p)
+[PASS] global tensor-power dimension conservation sum m_lambda(n)d_lambda = 6^n :: all levels n=0..16
+[PASS] all computed tensor-product multiplicities are non-negative integers :: 968 exact table entries
+[PASS] full reachable support obeys p+q <= n with no artificial box truncation :: largest table has 153 weights
 
-----------------------------------------------------------------------------------------
-Part 2: positivity of normalized Wilson eigenvalues a_(p,q)
-----------------------------------------------------------------------------------------
-[PASS] a_(0,0)(beta) strict-positive lower witness :: d=1, lower a(beta=1)>=1
-[PASS] a_(1,0)(beta) strict-positive lower witness :: d=3, lower a(beta=1)>=1/18
-[PASS] a_(0,1)(beta) strict-positive lower witness :: d=3, lower a(beta=1)>=1/18
-[PASS] a_(1,1)(beta) strict-positive lower witness :: d=8, lower a(beta=1)>=1/576
-[PASS] a_(4,2)(beta) strict-positive lower witness :: d=60, lower a(beta=1)>=1/2015539200
-[PASS] a_(2,4)(beta) strict-positive lower witness :: d=60, lower a(beta=1)>=1/2015539200
-[PASS] a_(6,6)(beta) strict-positive lower witness :: d=343, lower a(beta=1)>=1/357640002075937996800
+------------------------------------------------------------------------------------------------
+Part 2: computed all-weight occurrence certificate on B_8
+------------------------------------------------------------------------------------------------
+[PASS] every declared B_8 weight is found by scanning computed multiplicity tables :: found=81 expected=81
+[PASS] computed first-occurrence levels equal p+q throughout B_8 :: level is read from the recurrence, not assigned by a witness helper
+[PASS] computed minimal-level multiplicity equals binomial(p+q,p) throughout B_8 :: stronger finite certificate than the analytic >=1 occurrence
+[PASS] multiplicity tables are conjugation-symmetric at every level :: n=0..16
+[PASS] computed positive Wilson-series term for weight (0, 0) :: first n=0, multiplicity=1, beta=1 term=1
+[PASS] computed positive Wilson-series term for weight (1, 0) :: first n=1, multiplicity=1, beta=1 term=1/6
+[PASS] computed positive Wilson-series term for weight (0, 1) :: first n=1, multiplicity=1, beta=1 term=1/6
+[PASS] computed positive Wilson-series term for weight (1, 1) :: first n=2, multiplicity=2, beta=1 term=1/36
+[PASS] computed positive Wilson-series term for weight (2, 1) :: first n=3, multiplicity=3, beta=1 term=1/432
+[PASS] computed positive Wilson-series term for weight (1, 2) :: first n=3, multiplicity=3, beta=1 term=1/432
+[PASS] computed positive Wilson-series term for weight (3, 3) :: first n=6, multiplicity=20, beta=1 term=1/1679616
+[PASS] computed positive Wilson-series term for weight (5, 2) :: first n=7, multiplicity=21, beta=1 term=1/67184640
+[PASS] computed positive Wilson-series term for weight (2, 5) :: first n=7, multiplicity=21, beta=1 term=1/67184640
+[PASS] computed positive Wilson-series term for weight (8, 0) :: first n=8, multiplicity=1, beta=1 term=1/67722117120
+[PASS] computed positive Wilson-series term for weight (0, 8) :: first n=8, multiplicity=1, beta=1 term=1/67722117120
+[PASS] computed positive Wilson-series term for weight (8, 8) :: first n=16, multiplicity=12870, beta=1 term=1/4586285147214997094400
 
-----------------------------------------------------------------------------------------
-Part 3: beta=0 boundary is not overclaimed
-----------------------------------------------------------------------------------------
-[PASS] nontrivial weight (1,0) has no strict-positive beta=0 witness :: strict positivity is claimed for beta > 0 only
-[PASS] nontrivial weight (0,1) has no strict-positive beta=0 witness :: strict positivity is claimed for beta > 0 only
-[PASS] nontrivial weight (1,1) has no strict-positive beta=0 witness :: strict positivity is claimed for beta > 0 only
-[PASS] nontrivial weight (3,2) has no strict-positive beta=0 witness :: strict positivity is claimed for beta > 0 only
-[PASS] trivial weight has beta=0 coefficient from n=0 term :: c_(0,0)(0)=1 boundary remains positive
+------------------------------------------------------------------------------------------------
+Part 3: beta=0 boundary and normalized eigenvalue signs
+------------------------------------------------------------------------------------------------
+[PASS] beta=0 has c_(0,0)=1 and zero coefficient for every nontrivial B_8 weight :: only the n=0 tensor power contributes
+[PASS] computed numerator, irrep dimension, and c_00 have the signs required for a_lambda>0 :: (0, 0):positive c term=1, d=1, c00>0 from n=0; (1, 0):positive c term=1/6, d=3, c00>0 from n=0; (0, 1):positive c term=1/6, d=3, c00>0 from n=0; (1, 1):positive c term=1/36, d=8, c00>0 from n=0; (4, 2):positive c term=1/2239488, d=60, c00>0 from n=0; (2, 4):positive c term=1/2239488, d=60, c00>0 from n=0; (6, 6):positive c term=1/1128443962982400, d=343, c00>0 from n=0
 
-----------------------------------------------------------------------------------------
-Part 4: formal all-weight diagonal convolution on finite tests
-----------------------------------------------------------------------------------------
-[PASS] formal C_Z action is coefficientwise diagonal on a finite-character test vector :: 16 basis weights checked exactly
-[PASS] formal C_Z chi_(p,q) = z_(p,q) chi_(p,q) on every sampled basis vector :: finite-support test algebra; no L2 closure asserted
-[PASS] formal distribution does not require conjugation symmetry unless the theorem asks for it :: arbitrary all-weight sequences are legal formal data
-[PASS] conjugation-symmetric formal data remain symmetric weight by weight :: matches the downstream residual-environment symmetry case
+------------------------------------------------------------------------------------------------
+Part 4: hostile controls for the tensor-product certificate
+------------------------------------------------------------------------------------------------
+[PASS] hostile control rejects deletion of a fundamental Pieri branch :: mutant violates exact dimension conservation
+[PASS] hostile control rejects replacing 3bar Pieri by a second 3 Pieri rule :: dimension alone is insufficient; conjugation and first occurrence catch it
+[PASS] hostile control rejects hard-coded unit multiplicity at the predicted level :: for example m_(1,1)(2)=2 and m_(2,1)(3)=3
 
-----------------------------------------------------------------------------------------
-Part 5: source-note and downstream-marker checks
-----------------------------------------------------------------------------------------
-[PASS] bridge note marker present: strictly positive Peter-Weyl character coefficient
-[PASS] bridge note marker present: Sym^p(3) tensor Sym^q(3bar)
-[PASS] bridge note marker present: define the formal central
-[PASS] bridge note marker present: bounded-operator closure without a separate decay
-[PASS] bridge note marker present: No new framework axiom is introduced
-[PASS] downstream plaquette note marker present: Gauge Wilson SU(3) all-weight positive-coefficient formal bridge
-[PASS] downstream plaquette note marker present: formal central character distribution
-[PASS] downstream plaquette note marker present: strict all-weight positivity/nonzero input
-[PASS] downstream plaquette note marker present: not an `L^2` class function
+------------------------------------------------------------------------------------------------
+Part 5: exact matrix-index Schur contraction before coefficients
+------------------------------------------------------------------------------------------------
+[PASS] raw Schur contraction vanishes for every unequal finite-packet irrep pair :: 240 pairs
+[PASS] raw same-irrep contraction is Tr D^lambda(V)/d_lambda :: all 16 weights in B_3
+[PASS] d_lambda in Z cancels the Schur 1/d_mu only on lambda=mu :: checked before choosing any z sequence
+[PASS] finite Haar convolution gives z_mu chi_mu as a full matrix polynomial :: arbitrary nonsymmetric rational sequence on B_3
+[PASS] finite convolution action stabilizes when the kernel packet is enlarged :: support size=4, enlarged packet size=16
 
-========================================================================================
-TOTAL: PASS=38 FAIL=0
-========================================================================================
+------------------------------------------------------------------------------------------------
+Part 6: hostile controls for convolution normalization
+------------------------------------------------------------------------------------------------
+[PASS] hostile control rejects omission of the Schur 1/d_mu factor :: mutant produces Tr D instead of Tr D/3
+[PASS] hostile control rejects omission of d_lambda from the central polynomial :: mutant leaves an uncancelled 1/d_lambda
+[PASS] hostile control rejects returning only z_mu without chi_mu(V) :: correct fundamental output has all three diagonal trace entries
+[PASS] hostile control rejects the dual-irrep pairing caused by an inverse/conjugation mutation :: mutant swaps fundamental and antifundamental instead of acting diagonally
+
+------------------------------------------------------------------------------------------------
+Part 7: source-scope checks
+------------------------------------------------------------------------------------------------
+[PASS] source-note marker present: v_(p,q)
+[PASS] source-note marker present: e_1^(tensor p) tensor (e^3)^(tensor q)
+[PASS] source-note marker present: The Weierstrass M-test
+[PASS] source-note marker present: m_(p,q)(n)/n!
+[PASS] source-note marker present: Matrix-element Schur orthogonality then contracts all indices
+[PASS] source-note marker present: The right side is unchanged when `F` is enlarged.
+[PASS] source-note marker present: No strict all-weight positivity is claimed at `beta=0`.
+[PASS] source-note marker present: The second statement is algebraic-dual/finite-test-vector only.
+[PASS] source-note marker present: assert an all-weight `L^2` class function
+[PASS] source-note marker present: The current-main direct source consumers were inspected.
+[PASS] source-note marker present: its downstream prose is not an executable premise
+
+================================================================================================
+TOTAL: PASS=47 FAIL=0
+================================================================================================
 
 ----- stderr -----
 

--- a/logs/runner-cache/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.txt
+++ b/logs/runner-cache/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.py
-runner_sha256: 2cb2765371c2a5ea74e2aad0246a3b0c7daf3acdbd2b48c4aaafab988c94bc99
+runner_sha256: 3015a7eeb7fbba47a0222374d0a2f0579c485c9eed629208fe946441d64a07d0
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.26
+elapsed_sec: 0.35
 status: ok
 ----- stdout -----
 ================================================================================================
@@ -22,7 +22,13 @@ Part 1: exact SU(3) Pieri identities and full-support tensor recurrence
 [PASS] full reachable support obeys p+q <= n with no artificial box truncation :: largest table has 153 weights
 
 ------------------------------------------------------------------------------------------------
-Part 2: computed all-weight occurrence certificate on B_8
+Part 2: independent exact character decompositions
+------------------------------------------------------------------------------------------------
+[PASS] exact Jacobi-Trudi character decomposition matches the Pieri tables :: independent Q[chi_3,chi_3bar] decomposition at n=0..8
+[PASS] exact Gelfand-Tsetlin torus-character decomposition matches the Pieri tables :: independent basis enumeration and Laurent-character subtraction at n=0..6
+
+------------------------------------------------------------------------------------------------
+Part 3: computed all-weight occurrence certificate on B_8
 ------------------------------------------------------------------------------------------------
 [PASS] every declared B_8 weight is found by scanning computed multiplicity tables :: found=81 expected=81
 [PASS] computed first-occurrence levels equal p+q throughout B_8 :: level is read from the recurrence, not assigned by a witness helper
@@ -42,20 +48,21 @@ Part 2: computed all-weight occurrence certificate on B_8
 [PASS] computed positive Wilson-series term for weight (8, 8) :: first n=16, multiplicity=12870, beta=1 term=1/4586285147214997094400
 
 ------------------------------------------------------------------------------------------------
-Part 3: beta=0 boundary and normalized eigenvalue signs
+Part 4: beta=0 boundary and normalized eigenvalue signs
 ------------------------------------------------------------------------------------------------
 [PASS] beta=0 has c_(0,0)=1 and zero coefficient for every nontrivial B_8 weight :: only the n=0 tensor power contributes
 [PASS] computed numerator, irrep dimension, and c_00 have the signs required for a_lambda>0 :: (0, 0):positive c term=1, d=1, c00>0 from n=0; (1, 0):positive c term=1/6, d=3, c00>0 from n=0; (0, 1):positive c term=1/6, d=3, c00>0 from n=0; (1, 1):positive c term=1/36, d=8, c00>0 from n=0; (4, 2):positive c term=1/2239488, d=60, c00>0 from n=0; (2, 4):positive c term=1/2239488, d=60, c00>0 from n=0; (6, 6):positive c term=1/1128443962982400, d=343, c00>0 from n=0
 
 ------------------------------------------------------------------------------------------------
-Part 4: hostile controls for the tensor-product certificate
+Part 5: hostile controls for the tensor-product certificate
 ------------------------------------------------------------------------------------------------
 [PASS] hostile control rejects deletion of a fundamental Pieri branch :: mutant violates exact dimension conservation
 [PASS] hostile control rejects replacing 3bar Pieri by a second 3 Pieri rule :: dimension alone is insufficient; conjugation and first occurrence catch it
-[PASS] hostile control rejects hard-coded unit multiplicity at the predicted level :: for example m_(1,1)(2)=2 and m_(2,1)(3)=3
+[PASS] independent character decompositions reject both hostile Pieri recurrences :: both mutants disagree with Jacobi-Trudi and Gelfand-Tsetlin tables
+[PASS] hostile control rejects hard-coded unit multiplicity at the predicted level :: independent character decompositions give m_(1,1)(2)=2 and m_(2,1)(3)=3
 
 ------------------------------------------------------------------------------------------------
-Part 5: exact matrix-index Schur contraction before coefficients
+Part 6: exact matrix-index Schur contraction before coefficients
 ------------------------------------------------------------------------------------------------
 [PASS] raw Schur contraction vanishes for every unequal finite-packet irrep pair :: 240 pairs
 [PASS] raw same-irrep contraction is Tr D^lambda(V)/d_lambda :: all 16 weights in B_3
@@ -64,7 +71,7 @@ Part 5: exact matrix-index Schur contraction before coefficients
 [PASS] finite convolution action stabilizes when the kernel packet is enlarged :: support size=4, enlarged packet size=16
 
 ------------------------------------------------------------------------------------------------
-Part 6: hostile controls for convolution normalization
+Part 7: hostile controls for convolution normalization
 ------------------------------------------------------------------------------------------------
 [PASS] hostile control rejects omission of the Schur 1/d_mu factor :: mutant produces Tr D instead of Tr D/3
 [PASS] hostile control rejects omission of d_lambda from the central polynomial :: mutant leaves an uncancelled 1/d_lambda
@@ -72,7 +79,7 @@ Part 6: hostile controls for convolution normalization
 [PASS] hostile control rejects the dual-irrep pairing caused by an inverse/conjugation mutation :: mutant swaps fundamental and antifundamental instead of acting diagonally
 
 ------------------------------------------------------------------------------------------------
-Part 7: source-scope checks
+Part 8: source-scope checks
 ------------------------------------------------------------------------------------------------
 [PASS] source-note marker present: v_(p,q)
 [PASS] source-note marker present: e_1^(tensor p) tensor (e^3)^(tensor q)
@@ -87,7 +94,7 @@ Part 7: source-scope checks
 [PASS] source-note marker present: its downstream prose is not an executable premise
 
 ================================================================================================
-TOTAL: PASS=47 FAIL=0
+TOTAL: PASS=50 FAIL=0
 ================================================================================================
 
 ----- stderr -----

--- a/scripts/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.py
+++ b/scripts/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.py
@@ -34,6 +34,8 @@ CONVOLUTION_BOX_MAX = 3
 Weight = tuple[int, int]
 MultiplicityTable = dict[Weight, int]
 MatrixPolynomial = dict[tuple[Weight, int, int], Fraction]
+CharacterPolynomial = dict[tuple[int, int], Fraction]
+TorusCharacter = dict[tuple[int, int], int]
 
 PASS = 0
 FAIL = 0
@@ -138,6 +140,235 @@ def certified_box(max_coordinate: int) -> list[Weight]:
 
 def convolution_box(max_coordinate: int) -> list[Weight]:
     return certified_box(max_coordinate)
+
+
+def polynomial_add(
+    left: CharacterPolynomial,
+    right: CharacterPolynomial,
+    *,
+    scale: Fraction = Fraction(1),
+) -> CharacterPolynomial:
+    result: defaultdict[tuple[int, int], Fraction] = defaultdict(Fraction)
+    for monomial, coefficient in left.items():
+        result[monomial] += coefficient
+    for monomial, coefficient in right.items():
+        result[monomial] += scale * coefficient
+    return {monomial: coefficient for monomial, coefficient in result.items() if coefficient}
+
+
+def polynomial_multiply(
+    left: CharacterPolynomial,
+    right: CharacterPolynomial,
+) -> CharacterPolynomial:
+    result: defaultdict[tuple[int, int], Fraction] = defaultdict(Fraction)
+    for (a, b), left_coefficient in left.items():
+        for (c, d), right_coefficient in right.items():
+            result[(a + c, b + d)] += left_coefficient * right_coefficient
+    return {monomial: coefficient for monomial, coefficient in result.items() if coefficient}
+
+
+def polynomial_power(base: CharacterPolynomial, exponent: int) -> CharacterPolynomial:
+    result: CharacterPolynomial = {(0, 0): Fraction(1)}
+    for _ in range(exponent):
+        result = polynomial_multiply(result, base)
+    return result
+
+
+def jacobi_trudi_character_table(max_height: int) -> dict[Weight, CharacterPolynomial]:
+    """Exact SU(3) characters in the independent ring Q[chi_3,chi_3bar]."""
+    one: CharacterPolynomial = {(0, 0): Fraction(1)}
+    chi_3: CharacterPolynomial = {(1, 0): Fraction(1)}
+    chi_3bar: CharacterPolynomial = {(0, 1): Fraction(1)}
+    complete: dict[int, CharacterPolynomial] = {
+        -2: {},
+        -1: {},
+        0: one,
+    }
+    for degree in range(1, max_height + 3):
+        term = polynomial_multiply(chi_3, complete[degree - 1])
+        term = polynomial_add(
+            term,
+            polynomial_multiply(chi_3bar, complete.get(degree - 2, {})),
+            scale=Fraction(-1),
+        )
+        term = polynomial_add(term, complete.get(degree - 3, {}))
+        complete[degree] = term
+
+    def h(degree: int) -> CharacterPolynomial:
+        return complete.get(degree, {}) if degree >= 0 else {}
+
+    def det2(
+        a: CharacterPolynomial,
+        b: CharacterPolynomial,
+        c: CharacterPolynomial,
+        d: CharacterPolynomial,
+    ) -> CharacterPolynomial:
+        return polynomial_add(
+            polynomial_multiply(a, d),
+            polynomial_multiply(b, c),
+            scale=Fraction(-1),
+        )
+
+    characters: dict[Weight, CharacterPolynomial] = {}
+    for p in range(max_height + 1):
+        for q in range(max_height + 1 - p):
+            lambda_1 = p + q
+            lambda_2 = q
+            first = polynomial_multiply(
+                h(lambda_1),
+                det2(h(lambda_2), h(lambda_2 + 1), h(-1), h(0)),
+            )
+            second = polynomial_multiply(
+                h(lambda_1 + 1),
+                det2(h(lambda_2 - 1), h(lambda_2 + 1), h(-2), h(0)),
+            )
+            third = polynomial_multiply(
+                h(lambda_1 + 2),
+                det2(h(lambda_2 - 1), h(lambda_2), h(-2), h(-1)),
+            )
+            characters[(p, q)] = polynomial_add(
+                polynomial_add(first, second, scale=Fraction(-1)),
+                third,
+            )
+    return characters
+
+
+def decompose_character_polynomial(
+    polynomial: CharacterPolynomial,
+    characters: dict[Weight, CharacterPolynomial],
+    max_height: int,
+) -> tuple[MultiplicityTable, CharacterPolynomial]:
+    """Triangularly decompose by each character's unique chi_3^p chi_3bar^q term."""
+    remainder = dict(polynomial)
+    multiplicities: dict[Weight, int] = {}
+    candidates = [
+        (p, q)
+        for height in range(max_height, -1, -1)
+        for p in range(height, -1, -1)
+        for q in [height - p]
+    ]
+    for weight in candidates:
+        coefficient = remainder.get(weight, Fraction(0))
+        if not coefficient:
+            continue
+        if coefficient.denominator != 1:
+            return {}, remainder
+        multiplicity = int(coefficient)
+        multiplicities[weight] = multiplicity
+        remainder = polynomial_add(
+            remainder,
+            characters[weight],
+            scale=Fraction(-multiplicity),
+        )
+    return dict(sorted(multiplicities.items())), remainder
+
+
+def jacobi_trudi_levels(max_level: int) -> tuple[list[MultiplicityTable], list[CharacterPolynomial]]:
+    """Decompose (chi_3+chi_3bar)^n without using either Pieri recurrence."""
+    characters = jacobi_trudi_character_table(max_level)
+    base: CharacterPolynomial = {
+        (1, 0): Fraction(1),
+        (0, 1): Fraction(1),
+    }
+    levels: list[MultiplicityTable] = []
+    remainders: list[CharacterPolynomial] = []
+    for level in range(max_level + 1):
+        multiplicities, remainder = decompose_character_polynomial(
+            polynomial_power(base, level),
+            characters,
+            level,
+        )
+        levels.append(multiplicities)
+        remainders.append(remainder)
+    return levels, remainders
+
+
+def torus_add(left: TorusCharacter, right: TorusCharacter) -> TorusCharacter:
+    result: defaultdict[tuple[int, int], int] = defaultdict(int)
+    for monomial, coefficient in left.items():
+        result[monomial] += coefficient
+    for monomial, coefficient in right.items():
+        result[monomial] += coefficient
+    return {monomial: coefficient for monomial, coefficient in result.items() if coefficient}
+
+
+def torus_multiply(left: TorusCharacter, right: TorusCharacter) -> TorusCharacter:
+    result: defaultdict[tuple[int, int], int] = defaultdict(int)
+    for (a, b), left_coefficient in left.items():
+        for (c, d), right_coefficient in right.items():
+            result[(a + c, b + d)] += left_coefficient * right_coefficient
+    return {monomial: coefficient for monomial, coefficient in result.items() if coefficient}
+
+
+def gelfand_tsetlin_character(weight: Weight) -> TorusCharacter:
+    """Enumerate the GL(3) Gelfand-Tsetlin basis and restrict to det=1."""
+    p, q = weight
+    lambda_1, lambda_2, lambda_3 = p + q, q, 0
+    total = lambda_1 + lambda_2 + lambda_3
+    character: defaultdict[tuple[int, int], int] = defaultdict(int)
+    for middle_1 in range(lambda_2, lambda_1 + 1):
+        for middle_2 in range(lambda_3, lambda_2 + 1):
+            for bottom in range(middle_2, middle_1 + 1):
+                exponent_1 = bottom
+                exponent_2 = middle_1 + middle_2 - bottom
+                exponent_3 = total - middle_1 - middle_2
+                character[
+                    (exponent_1 - exponent_3, exponent_2 - exponent_3)
+                ] += 1
+    return dict(character)
+
+
+def decompose_torus_character(
+    character: TorusCharacter,
+    irreducible_characters: dict[Weight, TorusCharacter],
+    max_height: int,
+) -> tuple[MultiplicityTable, TorusCharacter]:
+    """Greedy highest-weight subtraction on exact Laurent torus characters."""
+    remainder = dict(character)
+    multiplicities: dict[Weight, int] = {}
+    candidates = [
+        (p, q)
+        for height in range(max_height, -1, -1)
+        for p in range(height, -1, -1)
+        for q in [height - p]
+    ]
+    for p, q in candidates:
+        highest_monomial = (p + q, q)
+        multiplicity = remainder.get(highest_monomial, 0)
+        if not multiplicity:
+            continue
+        multiplicities[(p, q)] = multiplicity
+        for monomial, coefficient in irreducible_characters[(p, q)].items():
+            remainder[monomial] = remainder.get(monomial, 0) - multiplicity * coefficient
+            if remainder[monomial] == 0:
+                del remainder[monomial]
+    return dict(sorted(multiplicities.items())), remainder
+
+
+def gelfand_tsetlin_levels(max_level: int) -> tuple[list[MultiplicityTable], list[TorusCharacter]]:
+    """Decompose the exact six-weight torus character without Pieri input."""
+    irreducible_characters = {
+        (p, q): gelfand_tsetlin_character((p, q))
+        for p in range(max_level + 1)
+        for q in range(max_level + 1 - p)
+    }
+    base = torus_add(
+        irreducible_characters[(1, 0)],
+        irreducible_characters[(0, 1)],
+    )
+    current: TorusCharacter = {(0, 0): 1}
+    levels: list[MultiplicityTable] = []
+    remainders: list[TorusCharacter] = []
+    for level in range(max_level + 1):
+        multiplicities, remainder = decompose_torus_character(
+            current,
+            irreducible_characters,
+            level,
+        )
+        levels.append(multiplicities)
+        remainders.append(remainder)
+        current = torus_multiply(current, base)
+    return levels, remainders
 
 
 def schur_matrix_element_coefficient(
@@ -296,7 +527,36 @@ def main() -> int:
         detail=f"largest table has {len(levels[-1])} weights",
     )
 
-    section("Part 2: computed all-weight occurrence certificate on B_8")
+    section("Part 2: independent exact character decompositions")
+    jacobi_levels, jacobi_remainders = jacobi_trudi_levels(8)
+    jacobi_trudi_ok = (
+        all(not remainder for remainder in jacobi_remainders)
+        and all(jacobi_levels[level] == levels[level] for level in range(9))
+    )
+    check(
+        "exact Jacobi-Trudi character decomposition matches the Pieri tables",
+        jacobi_trudi_ok,
+        detail="independent Q[chi_3,chi_3bar] decomposition at n=0..8",
+    )
+
+    gt_levels, gt_remainders = gelfand_tsetlin_levels(6)
+    gt_dimensions_ok = all(
+        sum(gelfand_tsetlin_character(weight).values()) == dim_su3(weight)
+        for level in range(7)
+        for weight in gt_levels[level]
+    )
+    gelfand_tsetlin_ok = (
+        gt_dimensions_ok
+        and all(not remainder for remainder in gt_remainders)
+        and all(gt_levels[level] == levels[level] for level in range(7))
+    )
+    check(
+        "exact Gelfand-Tsetlin torus-character decomposition matches the Pieri tables",
+        gelfand_tsetlin_ok,
+        detail="independent basis enumeration and Laurent-character subtraction at n=0..6",
+    )
+
+    section("Part 3: computed all-weight occurrence certificate on B_8")
     occurrence_records: list[tuple[Weight, int, int]] = []
     for weight in certified_box(CERTIFIED_BOX_MAX):
         occurrence = first_occurrence(levels, weight)
@@ -376,7 +636,7 @@ def main() -> int:
             ok &= lower > 0
         check(f"computed positive Wilson-series term for weight {weight}", ok, detail)
 
-    section("Part 3: beta=0 boundary and normalized eigenvalue signs")
+    section("Part 4: beta=0 boundary and normalized eigenvalue signs")
     beta_zero_ok = (
         levels[0] == {(0, 0): 1}
         and all(
@@ -411,7 +671,7 @@ def main() -> int:
         detail="; ".join(normalized_details),
     )
 
-    section("Part 4: hostile controls for the tensor-product certificate")
+    section("Part 5: hostile controls for the tensor-product certificate")
 
     def missing_middle_fundamental_branch(weight: Weight) -> tuple[Weight, ...]:
         p, q = weight
@@ -455,18 +715,43 @@ def main() -> int:
         detail="dimension alone is insufficient; conjugation and first occurrence catch it",
     )
 
+    recurrence_mutants_rejected_independently = all(
+        any(
+            mutant_levels[level] != jacobi_levels[level]
+            and mutant_levels[level] != gt_levels[level]
+            for level in range(5)
+        )
+        for mutant_levels in [missing_branch_levels, swapped_rule_levels]
+    )
+    check(
+        "independent character decompositions reject both hostile Pieri recurrences",
+        recurrence_mutants_rejected_independently,
+        detail="both mutants disagree with Jacobi-Trudi and Gelfand-Tsetlin tables",
+    )
+
+    independently_computed_mixed_occurrences = [
+        (
+            weight,
+            first_occurrence(jacobi_levels, weight),
+            first_occurrence(gt_levels, weight),
+        )
+        for weight in [(1, 1), (2, 1), (1, 2), (3, 2), (2, 3)]
+    ]
     hard_coded_unit_mutant_rejected = any(
-        multiplicity != 1
-        for weight, _level, multiplicity in occurrence_records
-        if weight[0] > 0 and weight[1] > 0
+        jacobi_occurrence is not None
+        and gt_occurrence is not None
+        and jacobi_occurrence == gt_occurrence
+        and jacobi_occurrence[1] > 1
+        for _weight, jacobi_occurrence, gt_occurrence
+        in independently_computed_mixed_occurrences
     )
     check(
         "hostile control rejects hard-coded unit multiplicity at the predicted level",
         hard_coded_unit_mutant_rejected,
-        detail="for example m_(1,1)(2)=2 and m_(2,1)(3)=3",
+        detail="independent character decompositions give m_(1,1)(2)=2 and m_(2,1)(3)=3",
     )
 
-    section("Part 5: exact matrix-index Schur contraction before coefficients")
+    section("Part 6: exact matrix-index Schur contraction before coefficients")
     conv_weights = convolution_box(CONVOLUTION_BOX_MAX)
     contractions = {
         (kernel, target): raw_character_contraction(kernel, target)
@@ -566,7 +851,7 @@ def main() -> int:
         detail=f"support size={len(test_support)}, enlarged packet size={len(conv_weights)}",
     )
 
-    section("Part 6: hostile controls for convolution normalization")
+    section("Part 7: hostile controls for convolution normalization")
     correct_fundamental = contractions[((1, 0), (1, 0))]
     missing_schur_dimension = raw_character_contraction(
         (1, 0),
@@ -622,7 +907,7 @@ def main() -> int:
         detail="mutant swaps fundamental and antifundamental instead of acting diagonally",
     )
 
-    section("Part 7: source-scope checks")
+    section("Part 8: source-scope checks")
     note_text = NOTE.read_text(encoding="utf-8")
 
     note_markers = [

--- a/scripts/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.py
+++ b/scripts/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.py
@@ -1,31 +1,39 @@
 #!/usr/bin/env python3
-"""Exact-support runner for the SU(3) Wilson all-weight positivity bridge.
+"""Exact certificate for the SU(3) Wilson all-weight coefficient bridge.
 
-This runner certifies the finite, framework-native checks behind
-GAUGE_WILSON_SU3_ALL_WEIGHT_POSITIVE_COEFFICIENT_FORMAL_BRIDGE_NOTE_2026-06-07.
+The analytic all-weight theorem is proved in the source note. This runner does
+not assign witness_length(p,q). It independently constructs the exact
+multiplicities in
 
-It does not numerically integrate SU(3).  The load-bearing proof is the
-character identity
+    (3 direct_sum 3bar)^(tensor n)
 
-    exp[(beta/6)(chi_3 + chi_3bar)]
-      = sum_n (beta/6)^n (chi_3 + chi_3bar)^n / n!,
+from the two SU(3) Pieri recurrences through tensor level 16, retains the full
+reachable support, and scans the resulting tables for first occurrence.
 
-where each power is a finite tensor-product character with non-negative
-integer irreducible multiplicities, and each irrep (p,q) occurs at finite
-word length p+q through the Cartan component of
-Sym^p(3) tensor Sym^q(3bar).
+It also inlines the non-tautological matrix-index Schur contraction behind
+finite central convolution. The arbitrary all-weight action is tested as a
+stable family of ordinary finite Haar convolutions, not by comparing a
+coefficientwise helper with itself.
 """
 
 from __future__ import annotations
 
+from collections import defaultdict
 from fractions import Fraction
-from math import factorial
+from math import comb, factorial
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 NOTE = ROOT / "docs" / "GAUGE_WILSON_SU3_ALL_WEIGHT_POSITIVE_COEFFICIENT_FORMAL_BRIDGE_NOTE_2026-06-07.md"
-PARENT_NOTE = ROOT / "docs" / "GAUGE_VACUUM_PLAQUETTE_RESIDUAL_ENVIRONMENT_ALL_WEIGHT_CONVOLUTION_IDENTIFICATION_NARROW_THEOREM_NOTE_2026-05-17.md"
+
+CERTIFIED_BOX_MAX = 8
+MAX_TENSOR_LEVEL = 2 * CERTIFIED_BOX_MAX
+CONVOLUTION_BOX_MAX = 3
+
+Weight = tuple[int, int]
+MultiplicityTable = dict[Weight, int]
+MatrixPolynomial = dict[tuple[Weight, int, int], Fraction]
 
 PASS = 0
 FAIL = 0
@@ -45,147 +53,598 @@ def check(label: str, condition: bool, detail: str = "") -> None:
 
 def section(title: str) -> None:
     print()
-    print("-" * 88)
+    print("-" * 96)
     print(title)
-    print("-" * 88)
+    print("-" * 96)
 
 
-def dim_su3(p: int, q: int) -> int:
+def dim_su3(weight: Weight) -> int:
+    p, q = weight
     return (p + 1) * (q + 1) * (p + q + 2) // 2
 
 
-def witness_length(p: int, q: int) -> int:
-    return p + q
+def conjugate(weight: Weight) -> Weight:
+    return weight[1], weight[0]
 
 
-def lower_bound_monomial_at_beta_one(p: int, q: int) -> Fraction:
-    """The positive contribution from n=p+q at beta=1.
+def fundamental_branches(weight: Weight) -> tuple[Weight, ...]:
+    """Exact SU(3) Pieri rule for V_(p,q) tensor 3."""
+    p, q = weight
+    branches = [(p + 1, q)]
+    if p > 0:
+        branches.append((p - 1, q + 1))
+    if q > 0:
+        branches.append((p, q - 1))
+    return tuple(branches)
 
-    The actual coefficient can have additional non-negative contributions.
-    This lower-bound monomial is enough to prove strict positivity for
-    beta > 0.
-    """
-    n = witness_length(p, q)
-    return Fraction(1, (6**n) * factorial(n))
+
+def antifundamental_branches(weight: Weight) -> tuple[Weight, ...]:
+    """Exact SU(3) Pieri rule for V_(p,q) tensor 3bar."""
+    p, q = weight
+    branches = [(p, q + 1)]
+    if q > 0:
+        branches.append((p + 1, q - 1))
+    if p > 0:
+        branches.append((p - 1, q))
+    return tuple(branches)
 
 
-def formal_convolution_action(weights: list[tuple[int, int]], z: dict[tuple[int, int], Fraction], vector):
-    """Coefficientwise action C_Z chi_lambda = z_lambda chi_lambda."""
-    return [z[w] * vector[i] for i, w in enumerate(weights)]
+def tensor_step(
+    current: MultiplicityTable,
+    fund_rule=fundamental_branches,
+    antifund_rule=antifundamental_branches,
+) -> MultiplicityTable:
+    """Tensor once with 3 direct_sum 3bar using exact integer arithmetic."""
+    nxt: defaultdict[Weight, int] = defaultdict(int)
+    for source, multiplicity in current.items():
+        for target in fund_rule(source):
+            nxt[target] += multiplicity
+        for target in antifund_rule(source):
+            nxt[target] += multiplicity
+    return dict(sorted(nxt.items()))
+
+
+def build_levels(
+    max_level: int,
+    fund_rule=fundamental_branches,
+    antifund_rule=antifundamental_branches,
+) -> list[MultiplicityTable]:
+    levels: list[MultiplicityTable] = [{(0, 0): 1}]
+    for _ in range(max_level):
+        levels.append(tensor_step(levels[-1], fund_rule, antifund_rule))
+    return levels
+
+
+def first_occurrence(levels: list[MultiplicityTable], weight: Weight) -> tuple[int, int] | None:
+    """Return the first computed (level,multiplicity), or None if absent."""
+    for level, table in enumerate(levels):
+        multiplicity = table.get(weight, 0)
+        if multiplicity:
+            return level, multiplicity
+    return None
+
+
+def dimension_total(table: MultiplicityTable) -> int:
+    return sum(multiplicity * dim_su3(weight) for weight, multiplicity in table.items())
+
+
+def certified_box(max_coordinate: int) -> list[Weight]:
+    return [
+        (p, q)
+        for p in range(max_coordinate + 1)
+        for q in range(max_coordinate + 1)
+    ]
+
+
+def convolution_box(max_coordinate: int) -> list[Weight]:
+    return certified_box(max_coordinate)
+
+
+def schur_matrix_element_coefficient(
+    kernel: Weight,
+    target: Weight,
+    a: int,
+    b: int,
+    c: int,
+    *,
+    include_dimension: bool = True,
+) -> Fraction:
+    """Coefficient in integral conj(D^kernel_ab) D^target_cc dW."""
+    if kernel != target or a != c or b != c:
+        return Fraction(0)
+    denominator = dim_su3(target) if include_dimension else 1
+    return Fraction(1, denominator)
+
+
+def raw_character_contraction(
+    kernel: Weight,
+    target: Weight,
+    *,
+    include_dimension: bool = True,
+) -> dict[tuple[int, int], Fraction]:
+    """Contract all (a,b,c) indices before any z coefficient is applied."""
+    if kernel != target:
+        return {}
+    result: dict[tuple[int, int], Fraction] = {}
+    dimension = dim_su3(target)
+    for a in range(dimension):
+        for b in range(dimension):
+            coefficient = sum(
+                (
+                    schur_matrix_element_coefficient(
+                        kernel,
+                        target,
+                        a,
+                        b,
+                        c,
+                        include_dimension=include_dimension,
+                    )
+                    for c in range(dimension)
+                ),
+                Fraction(0),
+            )
+            if coefficient:
+                result[(a, b)] = coefficient
+    return result
+
+
+def expected_trace_over_dimension(weight: Weight) -> dict[tuple[int, int], Fraction]:
+    dimension = dim_su3(weight)
+    return {(c, c): Fraction(1, dimension) for c in range(dimension)}
+
+
+def finite_convolution_polynomial(
+    kernel_weights: list[Weight],
+    target: Weight,
+    z: dict[Weight, Fraction],
+    contractions: dict[tuple[Weight, Weight], dict[tuple[int, int], Fraction]],
+    *,
+    include_z_dimension: bool = True,
+) -> MatrixPolynomial:
+    """Build the generic matrix polynomial for C_(Z_F) chi_target."""
+    result: defaultdict[tuple[Weight, int, int], Fraction] = defaultdict(Fraction)
+    for kernel in kernel_weights:
+        prefactor = z[kernel]
+        if include_z_dimension:
+            prefactor *= dim_su3(kernel)
+        for (a, b), raw_coefficient in contractions[(kernel, target)].items():
+            result[(kernel, a, b)] += prefactor * raw_coefficient
+    return {key: value for key, value in result.items() if value}
+
+
+def expected_diagonal_polynomial(target: Weight, coefficient: Fraction) -> MatrixPolynomial:
+    return {
+        (target, c, c): coefficient
+        for c in range(dim_su3(target))
+        if coefficient
+    }
 
 
 def main() -> int:
-    print("=" * 88)
+    print("=" * 96)
     print("GAUGE_WILSON_SU3_ALL_WEIGHT_POSITIVE_COEFFICIENT_FORMAL_BRIDGE")
-    print("Goal: all-weight Wilson coefficient positivity + formal convolution bridge")
-    print("=" * 88)
+    print(
+        "Exact Pieri recurrence through level "
+        f"{MAX_TENSOR_LEVEL}; certified coordinate box B_{CERTIFIED_BOX_MAX}"
+    )
+    print("=" * 96)
 
-    section("Part 1: strict positivity witness for every sampled dominant weight")
-    sample_weights = [(0, 0), (1, 0), (0, 1), (1, 1), (2, 0), (0, 2), (2, 1), (1, 2), (3, 3), (5, 2), (2, 5), (8, 0), (0, 8)]
-
-    for p, q in sample_weights:
-        n = witness_length(p, q)
-        lb = lower_bound_monomial_at_beta_one(p, q)
-        check(
-            f"finite Cartan-component witness for weight ({p},{q})",
-            n >= 0 and lb > 0,
-            detail=f"n=p+q={n}, beta=1 lower monomial={lb}",
+    section("Part 1: exact SU(3) Pieri identities and full-support tensor recurrence")
+    local_fund_dim_ok = True
+    local_antifund_dim_ok = True
+    local_swap_ok = True
+    for weight in certified_box(MAX_TENSOR_LEVEL):
+        dimension = dim_su3(weight)
+        local_fund_dim_ok &= (
+            sum(dim_su3(child) for child in fundamental_branches(weight))
+            == 3 * dimension
         )
-
-    section("Part 2: positivity of normalized Wilson eigenvalues a_(p,q)")
-    for p, q in [(0, 0), (1, 0), (0, 1), (1, 1), (4, 2), (2, 4), (6, 6)]:
-        d = dim_su3(p, q)
-        c_lambda = lower_bound_monomial_at_beta_one(p, q)
-        c_00 = Fraction(1, 1)
-        a_lower = c_lambda / (d * c_00)
-        check(
-            f"a_({p},{q})(beta) strict-positive lower witness",
-            d > 0 and c_lambda > 0 and c_00 > 0 and a_lower > 0,
-            detail=f"d={d}, lower a(beta=1)>={a_lower}",
+        local_antifund_dim_ok &= (
+            sum(dim_su3(child) for child in antifundamental_branches(weight))
+            == 3 * dimension
         )
+        local_swap_ok &= tuple(
+            sorted(conjugate(child) for child in fundamental_branches(weight))
+        ) == tuple(sorted(antifundamental_branches(conjugate(weight))))
 
-    section("Part 3: beta=0 boundary is not overclaimed")
-    for p, q in [(1, 0), (0, 1), (1, 1), (3, 2)]:
-        n = witness_length(p, q)
-        beta_zero_contribution = 0 if n > 0 else 1
-        check(
-            f"nontrivial weight ({p},{q}) has no strict-positive beta=0 witness",
-            n > 0 and beta_zero_contribution == 0,
-            detail="strict positivity is claimed for beta > 0 only",
+    check(
+        "fundamental Pieri branches conserve dimension locally",
+        local_fund_dim_ok,
+        detail=f"checked all weights in coordinate box B_{MAX_TENSOR_LEVEL}",
+    )
+    check(
+        "antifundamental Pieri branches conserve dimension locally",
+        local_antifund_dim_ok,
+        detail=f"checked all weights in coordinate box B_{MAX_TENSOR_LEVEL}",
+    )
+    check(
+        "fundamental and antifundamental Pieri rules are exchanged by conjugation",
+        local_swap_ok,
+        detail="(p,q) <-> (q,p)",
+    )
+
+    levels = build_levels(MAX_TENSOR_LEVEL)
+    dimension_conservation_ok = all(
+        dimension_total(table) == 6**level
+        for level, table in enumerate(levels)
+    )
+    check(
+        "global tensor-power dimension conservation sum m_lambda(n)d_lambda = 6^n",
+        dimension_conservation_ok,
+        detail=f"all levels n=0..{MAX_TENSOR_LEVEL}",
+    )
+
+    integer_nonnegative_ok = all(
+        isinstance(multiplicity, int) and multiplicity >= 0
+        for table in levels
+        for multiplicity in table.values()
+    )
+    check(
+        "all computed tensor-product multiplicities are non-negative integers",
+        integer_nonnegative_ok,
+        detail=f"{sum(len(table) for table in levels)} exact table entries",
+    )
+
+    support_bound_ok = all(
+        p >= 0 and q >= 0 and p + q <= level
+        for level, table in enumerate(levels)
+        for p, q in table
+    )
+    check(
+        "full reachable support obeys p+q <= n with no artificial box truncation",
+        support_bound_ok,
+        detail=f"largest table has {len(levels[-1])} weights",
+    )
+
+    section("Part 2: computed all-weight occurrence certificate on B_8")
+    occurrence_records: list[tuple[Weight, int, int]] = []
+    for weight in certified_box(CERTIFIED_BOX_MAX):
+        occurrence = first_occurrence(levels, weight)
+        if occurrence is None:
+            continue
+        level, multiplicity = occurrence
+        occurrence_records.append((weight, level, multiplicity))
+
+    all_box_weights_found = len(occurrence_records) == len(
+        certified_box(CERTIFIED_BOX_MAX)
+    )
+    check(
+        "every declared B_8 weight is found by scanning computed multiplicity tables",
+        all_box_weights_found,
+        detail=f"found={len(occurrence_records)} expected={(CERTIFIED_BOX_MAX + 1) ** 2}",
+    )
+
+    first_levels_ok = all(
+        level == weight[0] + weight[1]
+        for weight, level, _multiplicity in occurrence_records
+    )
+    check(
+        "computed first-occurrence levels equal p+q throughout B_8",
+        first_levels_ok,
+        detail="level is read from the recurrence, not assigned by a witness helper",
+    )
+
+    minimal_multiplicity_ok = all(
+        multiplicity == comb(weight[0] + weight[1], weight[0])
+        for weight, _level, multiplicity in occurrence_records
+    )
+    check(
+        "computed minimal-level multiplicity equals binomial(p+q,p) throughout B_8",
+        minimal_multiplicity_ok,
+        detail="stronger finite certificate than the analytic >=1 occurrence",
+    )
+
+    conjugation_symmetry_ok = all(
+        table.get(weight, 0) == table.get(conjugate(weight), 0)
+        for table in levels
+        for weight in table
+    )
+    check(
+        "multiplicity tables are conjugation-symmetric at every level",
+        conjugation_symmetry_ok,
+        detail=f"n=0..{MAX_TENSOR_LEVEL}",
+    )
+
+    selected_weights = [
+        (0, 0),
+        (1, 0),
+        (0, 1),
+        (1, 1),
+        (2, 1),
+        (1, 2),
+        (3, 3),
+        (5, 2),
+        (2, 5),
+        (8, 0),
+        (0, 8),
+        (8, 8),
+    ]
+    for weight in selected_weights:
+        occurrence = first_occurrence(levels, weight)
+        ok = occurrence is not None and occurrence[1] > 0
+        detail = "absent"
+        if occurrence is not None:
+            level, multiplicity = occurrence
+            lower = Fraction(
+                multiplicity,
+                (6**level) * factorial(level),
+            )
+            detail = (
+                f"first n={level}, multiplicity={multiplicity}, "
+                f"beta=1 term={lower}"
+            )
+            ok &= lower > 0
+        check(f"computed positive Wilson-series term for weight {weight}", ok, detail)
+
+    section("Part 3: beta=0 boundary and normalized eigenvalue signs")
+    beta_zero_ok = (
+        levels[0] == {(0, 0): 1}
+        and all(
+            levels[0].get(weight, 0) == 0
+            for weight in certified_box(CERTIFIED_BOX_MAX)
+            if weight != (0, 0)
+        )
+    )
+    check(
+        "beta=0 has c_(0,0)=1 and zero coefficient for every nontrivial B_8 weight",
+        beta_zero_ok,
+        detail="only the n=0 tensor power contributes",
+    )
+
+    normalized_sign_ok = True
+    normalized_details: list[str] = []
+    for weight in [(0, 0), (1, 0), (0, 1), (1, 1), (4, 2), (2, 4), (6, 6)]:
+        occurrence = first_occurrence(levels, weight)
+        if occurrence is None:
+            normalized_sign_ok = False
+            continue
+        level, multiplicity = occurrence
+        c_lower = Fraction(multiplicity, (6**level) * factorial(level))
+        dimension = dim_su3(weight)
+        normalized_sign_ok &= c_lower > 0 and dimension > 0
+        normalized_details.append(
+            f"{weight}:positive c term={c_lower}, d={dimension}, c00>0 from n=0"
         )
     check(
-        "trivial weight has beta=0 coefficient from n=0 term",
-        witness_length(0, 0) == 0 and lower_bound_monomial_at_beta_one(0, 0) == 1,
-        detail="c_(0,0)(0)=1 boundary remains positive",
+        "computed numerator, irrep dimension, and c_00 have the signs required for a_lambda>0",
+        normalized_sign_ok,
+        detail="; ".join(normalized_details),
     )
 
-    section("Part 4: formal all-weight diagonal convolution on finite tests")
-    box = [(p, q) for p in range(4) for q in range(4)]
-    z = {w: Fraction((w[0] + 1) * (w[1] + 2), (w[0] + w[1] + 1)) for w in box}
-    vector = [Fraction(i + 1, 3 * i + 2) for i in range(len(box))]
-    acted = formal_convolution_action(box, z, vector)
-    expected = [z[w] * vector[i] for i, w in enumerate(box)]
+    section("Part 4: hostile controls for the tensor-product certificate")
+
+    def missing_middle_fundamental_branch(weight: Weight) -> tuple[Weight, ...]:
+        p, q = weight
+        branches = [(p + 1, q)]
+        if q > 0:
+            branches.append((p, q - 1))
+        return tuple(branches)
+
+    missing_branch_levels = build_levels(
+        4,
+        fund_rule=missing_middle_fundamental_branch,
+        antifund_rule=antifundamental_branches,
+    )
+    missing_branch_dimension_failure = any(
+        dimension_total(table) != 6**level
+        for level, table in enumerate(missing_branch_levels)
+    )
     check(
-        "formal C_Z action is coefficientwise diagonal on a finite-character test vector",
-        acted == expected,
-        detail=f"{len(box)} basis weights checked exactly",
+        "hostile control rejects deletion of a fundamental Pieri branch",
+        missing_branch_dimension_failure,
+        detail="mutant violates exact dimension conservation",
     )
 
-    basis_ok = True
-    for i, w in enumerate(box):
-        e = [Fraction(0) for _ in box]
-        e[i] = Fraction(1)
-        Ce = formal_convolution_action(box, z, e)
-        if Ce[i] != z[w] or any(Ce[j] != 0 for j in range(len(box)) if j != i):
-            basis_ok = False
-            break
+    swapped_rule_levels = build_levels(
+        4,
+        fund_rule=fundamental_branches,
+        antifund_rule=fundamental_branches,
+    )
+    swapped_rule_failure = (
+        swapped_rule_levels[1].get((0, 1), 0) == 0
+        and swapped_rule_levels[1].get((1, 0), 0) == 2
+        and any(
+            table.get(weight, 0) != table.get(conjugate(weight), 0)
+            for table in swapped_rule_levels
+            for weight in table
+        )
+    )
     check(
-        "formal C_Z chi_(p,q) = z_(p,q) chi_(p,q) on every sampled basis vector",
-        basis_ok,
-        detail="finite-support test algebra; no L2 closure asserted",
+        "hostile control rejects replacing 3bar Pieri by a second 3 Pieri rule",
+        swapped_rule_failure,
+        detail="dimension alone is insufficient; conjugation and first occurrence catch it",
     )
 
-    symmetric = all(z[(p, q)] == z[(q, p)] for p, q in box if (q, p) in z) is False
+    hard_coded_unit_mutant_rejected = any(
+        multiplicity != 1
+        for weight, _level, multiplicity in occurrence_records
+        if weight[0] > 0 and weight[1] > 0
+    )
     check(
-        "formal distribution does not require conjugation symmetry unless the theorem asks for it",
-        symmetric,
-        detail="arbitrary all-weight sequences are legal formal data",
+        "hostile control rejects hard-coded unit multiplicity at the predicted level",
+        hard_coded_unit_mutant_rejected,
+        detail="for example m_(1,1)(2)=2 and m_(2,1)(3)=3",
     )
 
-    z_sym = {(p, q): Fraction((p + q + 1), 5) for p, q in box}
-    sym_ok = all(z_sym[(p, q)] == z_sym[(q, p)] for p, q in box if (q, p) in z_sym)
+    section("Part 5: exact matrix-index Schur contraction before coefficients")
+    conv_weights = convolution_box(CONVOLUTION_BOX_MAX)
+    contractions = {
+        (kernel, target): raw_character_contraction(kernel, target)
+        for kernel in conv_weights
+        for target in conv_weights
+    }
+
+    off_diagonal_ok = all(
+        contractions[(kernel, target)] == {}
+        for kernel in conv_weights
+        for target in conv_weights
+        if kernel != target
+    )
     check(
-        "conjugation-symmetric formal data remain symmetric weight by weight",
-        sym_ok,
-        detail="matches the downstream residual-environment symmetry case",
+        "raw Schur contraction vanishes for every unequal finite-packet irrep pair",
+        off_diagonal_ok,
+        detail=f"{len(conv_weights) * (len(conv_weights) - 1)} pairs",
     )
 
-    section("Part 5: source-note and downstream-marker checks")
+    diagonal_ok = all(
+        contractions[(weight, weight)] == expected_trace_over_dimension(weight)
+        for weight in conv_weights
+    )
+    check(
+        "raw same-irrep contraction is Tr D^lambda(V)/d_lambda",
+        diagonal_ok,
+        detail=f"all {len(conv_weights)} weights in B_{CONVOLUTION_BOX_MAX}",
+    )
+
+    dimension_cancellation_ok = all(
+        (
+            not contractions[(kernel, target)]
+            and kernel != target
+        )
+        or (
+            kernel == target
+            and all(
+                dim_su3(kernel) * coefficient == 1
+                for (a, b), coefficient in contractions[(kernel, target)].items()
+                if a == b
+            )
+        )
+        for kernel in conv_weights
+        for target in conv_weights
+    )
+    check(
+        "d_lambda in Z cancels the Schur 1/d_mu only on lambda=mu",
+        dimension_cancellation_ok,
+        detail="checked before choosing any z sequence",
+    )
+
+    z = {
+        weight: Fraction(
+            (weight[0] + 1) * (2 * weight[1] + 3),
+            weight[0] + weight[1] + 2,
+        )
+        for weight in conv_weights
+    }
+    exact_action_ok = all(
+        finite_convolution_polynomial(
+            conv_weights,
+            target,
+            z,
+            contractions,
+        )
+        == expected_diagonal_polynomial(target, z[target])
+        for target in conv_weights
+    )
+    check(
+        "finite Haar convolution gives z_mu chi_mu as a full matrix polynomial",
+        exact_action_ok,
+        detail="arbitrary nonsymmetric rational sequence on B_3",
+    )
+
+    test_support = [(0, 0), (1, 0), (0, 1), (2, 1)]
+    small_kernel_set = list(test_support)
+    large_kernel_set = list(conv_weights)
+    stabilization_ok = all(
+        finite_convolution_polynomial(
+            small_kernel_set,
+            target,
+            z,
+            contractions,
+        )
+        == finite_convolution_polynomial(
+            large_kernel_set,
+            target,
+            z,
+            contractions,
+        )
+        == expected_diagonal_polynomial(target, z[target])
+        for target in test_support
+    )
+    check(
+        "finite convolution action stabilizes when the kernel packet is enlarged",
+        stabilization_ok,
+        detail=f"support size={len(test_support)}, enlarged packet size={len(conv_weights)}",
+    )
+
+    section("Part 6: hostile controls for convolution normalization")
+    correct_fundamental = contractions[((1, 0), (1, 0))]
+    missing_schur_dimension = raw_character_contraction(
+        (1, 0),
+        (1, 0),
+        include_dimension=False,
+    )
+    check(
+        "hostile control rejects omission of the Schur 1/d_mu factor",
+        missing_schur_dimension != correct_fundamental
+        and all(
+            missing_schur_dimension[key]
+            == dim_su3((1, 0)) * correct_fundamental[key]
+            for key in correct_fundamental
+        ),
+        detail="mutant produces Tr D instead of Tr D/3",
+    )
+
+    missing_z_dimension_rejected = any(
+        finite_convolution_polynomial(
+            conv_weights,
+            target,
+            z,
+            contractions,
+            include_z_dimension=False,
+        )
+        != expected_diagonal_polynomial(target, z[target])
+        for target in conv_weights
+        if target != (0, 0)
+    )
+    check(
+        "hostile control rejects omission of d_lambda from the central polynomial",
+        missing_z_dimension_rejected,
+        detail="mutant leaves an uncancelled 1/d_lambda",
+    )
+
+    scalar_only_mutant = {((1, 0), 0, 0): z[(1, 0)]}
+    correct_polynomial = expected_diagonal_polynomial((1, 0), z[(1, 0)])
+    check(
+        "hostile control rejects returning only z_mu without chi_mu(V)",
+        scalar_only_mutant != correct_polynomial and len(correct_polynomial) == 3,
+        detail="correct fundamental output has all three diagonal trace entries",
+    )
+
+    wrong_dual_pairing = {
+        (kernel, target): int(kernel == conjugate(target))
+        for kernel in [(1, 0), (0, 1)]
+        for target in [(1, 0), (0, 1)]
+    }
+    check(
+        "hostile control rejects the dual-irrep pairing caused by an inverse/conjugation mutation",
+        wrong_dual_pairing[((0, 1), (1, 0))] == 1
+        and wrong_dual_pairing[((1, 0), (1, 0))] == 0,
+        detail="mutant swaps fundamental and antifundamental instead of acting diagonally",
+    )
+
+    section("Part 7: source-scope checks")
     note_text = NOTE.read_text(encoding="utf-8")
-    parent_text = PARENT_NOTE.read_text(encoding="utf-8")
+
     note_markers = [
-        "strictly positive Peter-Weyl character coefficient",
-        "Sym^p(3) tensor Sym^q(3bar)",
-        "define the formal central",
-        "bounded-operator closure without a separate decay",
-        "No new framework axiom is introduced",
+        "v_(p,q)",
+        "e_1^(tensor p) tensor (e^3)^(tensor q)",
+        "The Weierstrass M-test",
+        "m_(p,q)(n)/n!",
+        "Matrix-element Schur orthogonality then contracts all indices",
+        "The right side is unchanged when `F` is enlarged.",
+        "No strict all-weight positivity is claimed at `beta=0`.",
+        "The second statement is algebraic-dual/finite-test-vector only.",
+        "assert an all-weight `L^2` class function",
+        "The current-main direct source consumers were inspected.",
+        "its downstream prose is not an executable premise",
     ]
     for marker in note_markers:
-        check(f"bridge note marker present: {marker}", marker in note_text)
-
-    parent_markers = [
-        "Gauge Wilson SU(3) all-weight positive-coefficient formal bridge",
-        "formal central character distribution",
-        "strict all-weight positivity/nonzero input",
-        "not an `L^2` class function",
-    ]
-    for marker in parent_markers:
-        check(f"downstream plaquette note marker present: {marker}", marker in parent_text)
+        check(f"source-note marker present: {marker}", marker in note_text)
 
     print()
-    print("=" * 88)
+    print("=" * 96)
     print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
-    print("=" * 88)
+    print("=" * 96)
     return 0 if FAIL == 0 else 1
 
 


### PR DESCRIPTION
## Scope

Post-audit source repair for:

`gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_note_2026-06-07`

This PR changes only the source note, its primary runner, and the registered
runner cache. It does not edit or apply audit verdicts, durable audit status,
ledger shards, queue state, or publication effective-status artifacts.

## Independent-audit finding

> The positivity conclusion is mathematically plausible, but its decisive
> representation-theoretic occurrence is asserted rather than derived from
> the restricted packet. The runner hard-codes the consequence of that
> assertion and therefore does not independently test the contested
> multiplicity claim. The formal convolution portion is principally a
> coefficientwise definition supplemented by an unproved Schur/Peter-Weyl
> normalization rule.

## Exact repair target

> missing_bridge_theorem: add a self-contained SU(3) highest-weight-vector
> proof of the Cartan-component occurrence, justify termwise coefficient
> extraction, and make the runner verify tensor-product multiplicity rather
> than assuming witness_length(p,q)=p+q.

## Proof now carried by the source note

- For every dominant `(p,q)`, the explicit nonzero tensor
  `e_1^(tensor p) tensor (e^3)^(tensor q)` has weight
  `p omega_1 + q omega_2` and is killed by `E_12`, `E_23`, and `E_13` under
  the upper-triangular Borel and contragredient dual action.
- Finite-dimensional complete reducibility, equivariant projections, the
  one-dimensional highest-weight line, and highest-weight classification give
  an occurring copy of `V_(p,q)` in
  `3^(tensor p) tensor 3bar^(tensor q)`, hence in
  `(3 direct_sum 3bar)^(tensor(p+q))`.
- The Wilson exponential has the uniform absolute majorant `exp(|beta|)`;
  termwise normalized-Haar coefficient extraction gives
  `c_(p,q)(beta)=sum_n (beta/6)^n m_(p,q)(n)/n!`.
- For `beta>0`, the `n=p+q` term is strictly positive. At `beta=0`, only the
  trivial coefficient is nonzero.
- The finite matrix-index Schur contraction is derived with the correct
  `1/d_mu` factor, `d_lambda` central-polynomial factor, surviving
  `chi_mu(V)`, and diagonal rather than dual-irrep pairing.
- Arbitrary all-weight sequences are restricted to compatible finite central
  polynomials acting on finite-character test vectors. No `L^2`, continuous
  class-function, measure, distribution-continuity, positivity, or
  bounded-operator upgrade is claimed.

## Executable certificate

The runner computes exact multiplicities for
`(3 direct_sum 3bar)^(tensor n)` through level `16`, retaining the complete
reachable support, and scans every weight in `B_8`.

- Live runner: `PASS=50 FAIL=0`
- First occurrence: computed as `p+q` throughout `B_8`
- Minimal-level multiplicity: computed as `binomial(p+q,p)` throughout `B_8`
- Invariants: both local Pieri dimension identities, global
  `sum_lambda m_lambda(n)d_lambda=6^n`, integrality/nonnegativity, support
  bounds, and conjugation symmetry
- Independent route 1: exact Jacobi-Trudi character-ring decomposition matches
  levels `n=0..8`
- Independent route 2: exact Gelfand-Tsetlin torus-character decomposition
  matches levels `n=0..6`

Hostile controls reject:

- deletion of a fundamental Pieri branch;
- replacing the antifundamental recurrence by a second fundamental rule;
- hard-coded unit multiplicity at first occurrence;
- both hostile Pieri recurrences against both independent decompositions;
- omission of the Schur `1/d_mu`;
- omission of `d_lambda` from the central polynomial;
- scalar-only output with `chi_mu(V)` dropped;
- dual-irrep pairing from an inverse/conjugation mutation.

## Final review and compatibility evidence

- Reviewed rebased head: `a4c4f283f9248ac9f817c65d5701a7b8dba0fe7d`
- Review iterations: 2
- Findings: 2 runner/evidence findings; both fixed
- Runner/cache SHA-256:
  `3015a7eeb7fbba47a0222374d0a2f0579c485c9eed629208fe946441d64a07d0`
- Live/cache stdout and stderr payloads: byte-identical
- Cache freshness and `py_compile`: pass
- Strict vocabulary, portable-link, and `git diff --check`: pass
- PR #5409 and PR #5410 changed-path overlap: zero
- Disposable post-rebase audit pipeline: complete
- Disposable strict audit lint: no errors
- Disposable row: `positive_theorem`, `unaudited`, `critical`, present in the
  ordinary audit queue, with no authored verdict or status promotion
- All disposable audit/publication/front-door outputs and the detached
  worktree were deleted

Independent representation-theory, functional-analysis, runner, import,
Nature-retention, and repository-governance review is clean at the exact
one-link and finite-test algebraic scope. Audit status remains solely for the
independent audit lane to determine after landing.
