### PR TITLE
docs: add proof-search governance to physics-loop

### DIFF
--- a/.claude/commands/exercise.md
+++ b/.claude/commands/exercise.md
@@ -31,7 +31,10 @@ Examples:
    vocabulary directly.
 4. If subagents are used, require every subagent to perform the same framework
    refresher read and state which refresher surfaces it read before giving
-   conclusions.
+   conclusions. For proof-search fan-out, use neutral route-local briefs,
+   withhold the favored approach and other agents' conclusions during early
+   passes, and require a concrete lemma, construction, equation, falsifier, or
+   exact missing obligation.
 5. State the wall neutrally before proposing routes.
 6. Build the assumptions ledger from approved axioms/primitives upward through
    every explicit and implicit premise used by the stuck lane.
@@ -47,8 +50,9 @@ Examples:
 11. Run the reframing exercise, especially across pre-record/recorded,
    selector/dial, dynamics/kinematics, and central-sector/within-sector
    boundaries.
-12. Synthesize a ranked attack-vector portfolio with first artifacts and stop
-    conditions.
+12. Synthesize a ranked attack-vector portfolio with normalized mathematical
+    approach families, terminal obligations, target-strength relations, first
+    artifacts, and stop/reopen conditions.
 13. If `--artifact` is supplied, write the durable packet under
     `.claude/science/exercises/<slug>/`; otherwise return the structured
     exercise in the response.

--- a/.claude/commands/no-go-gate.md
+++ b/.claude/commands/no-go-gate.md
@@ -24,9 +24,10 @@ routes fail; this gate makes that gap explicit.
 1. Read the skill file above before acting, and perform the skill freshness
    check in `docs/ai_methodology/skills/SKILL_FRESHNESS_CHECK.md`.
 2. Walk N1–N8 in writing against the actual claim text: alternative-route
-   enumeration (≥5 distinct routes), wall-independence audit, hidden-wall
-   scan, residual matching, rhetoric audit, partial-closure path scan,
-   steelman, cross-cycle echo.
+   enumeration (≥5 normalized mathematical approach families),
+   wall-independence audit, hidden-wall scan, residual matching, rhetoric
+   audit, partial-closure path scan, concrete-mechanism steelman, cross-cycle
+   echo.
 3. Run the primitive registry check
    (`docs/ai_methodology/skills/PRIMITIVE_REGISTRY_CHECK.md`) before writing
    "no retained primitive supplies this" or any equivalent wall language.

--- a/.claude/commands/physics-loop.md
+++ b/.claude/commands/physics-loop.md
@@ -41,10 +41,12 @@ execution requests even when the user says only `run`.
    `docs/ai_methodology/skills/PRIMITIVE_REGISTRY_CHECK.md` and enumerate
    approved primitives from `docs/audit/data/axiom_premise_nodes.json` before
    naming imports, walls, or bounded-status sources.
-7. Generate and score a route portfolio; execute only a route that can move
-   claim state, retire an import, close a blocker, prove a no-go, create a
-   decisive artifact, or make a recorded first-principles stretch attempt on a
-   named hard residual.
+7. Generate and score a route portfolio; for theorem or multi-step bridge
+   targets, also write the exact target contract and maintain
+   `APPROACH_REGISTRY.md` using the skill's proof-search governance reference.
+   Execute only a route that can move claim state, retire an import, close a
+   blocker, prove a no-go, create a decisive artifact, or make a recorded
+   first-principles stretch attempt on a named hard residual.
 8. Apply the skill's pre-PR gates in writing: the V1-V5 Promotion Value Gate
    for any retained-positive proposal, and the N1-N8 No-Go Discipline Gate
    (`no-go-discipline` skill) for any negative claim. Record both in the
@@ -67,8 +69,10 @@ execution requests even when the user says only `run`.
 12. Checkpoint `STATE.yaml`, `TRACE_GATE.md`, and `HANDOFF.md` throughout
    unattended work.
 13. After two audit/no-go/blocker cycles in a row, run a stretch attempt before
-   declaring a route blocked. If stuck, fan out 3-5 orthogonal premises before
-   declaring global queue exhaustion.
+   declaring a route blocked. If stuck, fan out 3-5 orthogonal premises with
+   neutral early briefs, concrete-return requirements, and delayed
+   cross-pollination. Mark routes ending at target-equivalent missing lemmas
+   `blocked-equivalent` until a materially new mechanism appears.
 14. Run `review-loop` after each major artifact unless explicitly disabled.
    Treat review demotions/blockers as block-level demotion/pivot events, not
    campaign stops.

--- a/.claude/commands/review-loop.md
+++ b/.claude/commands/review-loop.md
@@ -13,11 +13,12 @@ Run the repo-native physics review loop from:
 1. Read the skill file above before acting.
 2. Review only branch/local changes against `origin/main` or `main`.
 3. Fan out the physics reviewers in parallel when the agent environment allows:
-   `CodeRunnerReviewer`, `PhysicsClaimReviewer`, `ImportSupportReviewer`,
-   `NatureRetentionReviewer`, `NoGoDisciplineReviewer` (when negative claims
-   changed), `LabelingConventionReviewer` (when bounded-theorem candidates
-   changed), `RepoGovernanceReviewer`, and optionally
-   `MethodologySkillReviewer`.
+   `CodeRunnerReviewer`, `PhysicsClaimReviewer`,
+   `ProofObligationReviewer` (when theorem/proof/reduction claims changed),
+   `ImportSupportReviewer`, `NatureRetentionReviewer`,
+   `NoGoDisciplineReviewer` (when negative claims changed),
+   `LabelingConventionReviewer` (when bounded-theorem candidates changed),
+   `RepoGovernanceReviewer`, and optionally `MethodologySkillReviewer`.
 4. Fix only verified, narrow findings. Demote overclaims instead of patching
    missing science with prose.
 5. Enforce audit-system compatibility without running the independent audit:
@@ -31,6 +32,8 @@ Run the repo-native physics review loop from:
 7. For math-bearing runner/proof changes, do not trust PASS output alone:
    independently cross-check load-bearing formulas, signs, factors,
    normalizations, expected values, and edge cases before landing.
+   Reconstruct nontrivial proof-obligation graphs and reject proof-complete
+   framing when the terminal missing lemma is target-equivalent or stronger.
 8. Before classifying a dependency as an import, wall, conditional/open input,
    or bounded-status source, read
    `docs/ai_methodology/skills/PRIMITIVE_REGISTRY_CHECK.md`,

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -427,6 +427,9 @@ For the selected claim, read only:
 - `docs/audit/README.md`, `FRESH_LOOK_REQUIREMENTS.md`, `AUDIT_AGENT_PROMPT_TEMPLATE.md`, and `ALGEBRAIC_DECORATION_POLICY.md`.
 
 When writing the verdict, also load `references/nature-grade-rubric.md` from this skill.
+For theorem, proof, or nontrivial reduction claims, also load
+[`../physics-loop/references/proof-search-governance.md`](../physics-loop/references/proof-search-governance.md)
+as audit procedure.
 
 Do not use `CLAIMS_TABLE.md`, `PUBLICATION_MATRIX.md`, `ARXIV_DRAFT.md`, or earlier review summaries to bias the verdict.
 
@@ -448,6 +451,12 @@ Answer these before choosing a verdict:
   second implementation catch the class of error the runner could otherwise
   hide?
 - Is this an independent theorem, or algebraic decoration of an upstream claim?
+- Does the proof match the exact target statement, quantifiers, and required
+  edge cases?
+- Does the proof-obligation graph close without cycles, lost hypotheses, or
+  inadmissible constructed objects?
+- What is the strongest unresolved lemma, and is it weaker than,
+  target-equivalent to, or stronger than the headline claim?
 - Are numerical values current with the runner and the source note?
 - Would a hostile specialist be able to reject the conclusion without making a mistake?
 - If the claim is a `no_go`, a wall-naming `bounded_theorem`, or its rationale would cite walls: have at least 5 distinct attack routes against the no-go been considered (N1)? Are the named walls actually independent (N2)? Are any hidden in "bridge context" / "we assume" / "standard QFT" / "registered" prose (N3)? Do cited witness residuals match the claim's residual (N4)? Are "X is not a Y-fact" phrases verified at every named resolution (N5)? Is the "needs new axiom" framing actually a convention-reframe / labeling ratification (N6)? Can a steelman against the no-go be made convincing (N7)? Has a structurally similar prior wall been retired by a mechanism not considered here (N8)? See `no-go-discipline` skill.
@@ -496,6 +505,13 @@ current claim relies on the wrong expression; use `audited_conditional` with
 may still be true but the artifact is not reliable enough to judge it.
 
 When in doubt, choose the more conservative non-clean verdict.
+
+If a proof or reduction terminates at a target-equivalent or stronger missing
+lemma, do not grant `audited_clean`. Use `audited_conditional`, normally with
+`notes_for_re_audit_if_any: missing_bridge_theorem`, and name both the exact
+terminal obligation and why its strength is comparable to or greater than the
+headline target. If a clean narrow lemma survives independently, state that
+narrow boundary in `claim_scope`.
 
 For claims with `claim_type: no_go`, `bounded_theorem` whose source note names walls/open conditions, or any verdict that would record walls in `verdict_rationale`, apply the No-Go Discipline gate (`no-go-discipline` skill, N1-N8) before recording. Any FAIL forbids `audited_clean`; instead, choose the non-clean verdict whose `verdict_rationale` reflects the corrected narrower claim scope. Specifically:
 

--- a/docs/ai_methodology/skills/exercise/SKILL.md
+++ b/docs/ai_methodology/skills/exercise/SKILL.md
@@ -26,6 +26,13 @@ agent, not a lightweight summarizer. Every main agent and subagent must perform
 the Framework Refresher Read below before starting its assigned exercise slice.
 Do not use image-generation or visual artifact tools for this skill.
 
+For theorem, proof, or multi-step bridge exercises, read
+[`../physics-loop/references/proof-search-governance.md`](../physics-loop/references/proof-search-governance.md)
+before fan-out. Give early agents neutral route-local briefs without the
+favored approach or other agents' conclusions, require concrete mathematical
+returns, and delay cross-pollination until independent passes expose their
+actual gaps.
+
 For literature search, browse current scholarly sources when network access is
 available. Cite papers or source pages precisely. Literature can suggest proof
 templates, but it is never imported as authority: any external proof must be
@@ -82,6 +89,7 @@ conversation. If `--artifact` is requested, write:
   EXERCISE.md
   ASSUMPTIONS_TABLE.md
   ATTACK_VECTORS.md
+  APPROACH_REGISTRY.md
   LITERATURE_SEARCH.md
   MATH_SECTOR_SEARCH.md
   REFRAMING.md
@@ -93,6 +101,9 @@ conversation. If `--artifact` is requested, write:
 Begin by making the blocker precise:
 
 - the target claim, theorem, import, selector, no-go, or bridge;
+- its quantifiers/domain, allowed premises, and forbidden weakenings;
+- required boundary or degenerate cases and outcomes that do not count as
+  closure;
 - what currently fails;
 - what would count as progress;
 - what would count as a decisive closure, demotion, or no-go;
@@ -264,9 +275,15 @@ New route opened | First decisive test
 End with a compact route portfolio:
 
 ```text
-Rank | Route | Source exercise(s) | Premise challenged |
-Expected status if successful | First artifact | Stop condition
+Rank | Approach family | Route | Source exercise(s) | Premise challenged |
+Terminal obligation | Strength vs target | Expected status if successful |
+First concrete artifact | Stop/reopen condition
 ```
+
+For theorem-heavy exercises, normalize families and strength relations using
+the proof-search governance reference. A route ending at a target-equivalent or
+stronger missing lemma is `blocked-equivalent`, not near closure. Reopen it only
+after naming a materially new mechanism.
 
 Also include:
 

--- a/docs/ai_methodology/skills/exercise/agents/openai.yaml
+++ b/docs/ai_methodology/skills/exercise/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Exercise"
   short_description: "Open new routes at physics walls"
-  default_prompt: "Use $exercise to work through the current physics wall from axioms upward and produce new attack vectors."
+  default_prompt: "Use $exercise to work through the current physics wall from axioms upward and produce independent, concrete attack vectors."
 
 policy:
   allow_implicit_invocation: true

--- a/docs/ai_methodology/skills/no-go-discipline/SKILL.md
+++ b/docs/ai_methodology/skills/no-go-discipline/SKILL.md
@@ -63,6 +63,13 @@ closed. For each route, give:
 - honesty marker: `ATTEMPTED` (tested in this cycle) or `RULED OUT BY PRIOR`
   (closed by an existing retained authority — cite it).
 
+Normalize route families using
+[`../physics-loop/references/proof-search-governance.md`](../physics-loop/references/proof-search-governance.md).
+Two routes count as distinct only when they materially differ in primary
+object/formulation, load-bearing mechanism or invariant, or terminal proof
+obligation. Different agents, notation, or artifact types do not make distinct
+routes.
+
 **Failure condition:** if you can name fewer than 5 distinct routes, the
 no-go is premature. List what you can and stop; do not ship.
 
@@ -182,6 +189,10 @@ no-go.** Use a hostile reviewer voice. Name the specific route or framing
 that might break the claim. Cite the strongest authority that supports the
 counter-argument.
 
+The steelman must identify a concrete unclosed mechanism and terminal
+obligation. Persuasive rhetoric without a mathematically actionable route is
+not by itself evidence that the no-go is premature.
+
 If you can write a convincing steelman, the no-go is premature: there is
 at least one route you have not closed. Demote to partial-attempt and ship
 the steelman as the next cycle's target.
@@ -279,7 +290,8 @@ The cases illustrate:
 
 ## Non-Negotiables
 
-- N1 requires 5 distinct routes, not 5 phrasings of the same route.
+- N1 requires 5 normalized approach families, not 5 phrasings, agents, or
+  artifact types for the same mathematical route.
 - N7 steelman must be the strongest counter-argument, not a token paragraph.
 - N6 "convention reframe vs new axiom" distinction must respect
   `feedback_no_new_axioms.md` — bounded condition with named import-retirement

--- a/docs/ai_methodology/skills/physics-claim-reviewer/SKILL.md
+++ b/docs/ai_methodology/skills/physics-claim-reviewer/SKILL.md
@@ -28,24 +28,29 @@ it is artifact-chain or semantic drift.
 4. **Attack semantic bridges.** Ask what is selected, fitted, imposed,
    imported, conventional, finite-order, protocol-specific, or only shown on
    one surface. Correct algebra can still compare the wrong physical objects.
-5. **Check status language.** Decide whether the evidence supports retained,
+5. **Audit proof obligations.** For theorem, proof, and reduction claims,
+   reconstruct the obligation graph and apply
+   [`../physics-loop/references/proof-search-governance.md`](../physics-loop/references/proof-search-governance.md).
+   Check the exact target, hypothesis preservation, boundary cases,
+   circularity, and the strength of every unresolved terminal lemma.
+6. **Check status language.** Decide whether the evidence supports retained,
    bounded, support, open, no-go, reject, or historical language.
-6. **Scrutinize no-go claims with the same rigor as positive theorems.**
+7. **Scrutinize no-go claims with the same rigor as positive theorems.**
    A wrongly scoped no-go is just as bad as a wrongly scoped positive theorem,
    and can be worse because it forecloses investigation paths prematurely.
    For any `claim_type: no_go` candidate, run the no-go battery in the
    dedicated section below before recommending disposition.
-7. **Check science naming.** Reject new bare shorthand labels that can be
+8. **Check science naming.** Reject new bare shorthand labels that can be
    confused with axioms, assumptions, Lie types, lane stages, route codes, or
    branch blocks. Require explicit scientific names from the controlled
    vocabulary, with shorthand only as a parenthetical alias when needed.
-8. **Classify findings.** Use the local disposition buckets:
+9. **Classify findings.** Use the local disposition buckets:
    `fix on main`, `support-only demotion`, `science-needed`, `reject`,
    `historical only`.
-9. **Recommend the narrowest honest fix.** Prefer wording fixes for wording
+10. **Recommend the narrowest honest fix.** Prefer wording fixes for wording
    problems; demotion for overclaimed support; new science only when a real
    theorem step is missing.
-10. **Write review output.** Lead with findings and file/line references when
+11. **Write review output.** Lead with findings and file/line references when
     possible, then summarize the safe status.
 
 ## Review Questions
@@ -56,6 +61,11 @@ it is artifact-chain or semantic drift.
 - Is a selector, convention, imported datum, or fitted parameter being treated
   as derived?
 - Is the symbol-to-physics identification actually justified?
+- Does the proof match the exact target, including quantifiers and edge cases?
+- Does every reduction preserve its hypotheses and produce admissible objects?
+- Is the strongest unresolved lemma weaker than the target, or is it
+  target-equivalent/stronger and therefore not genuine near-closure?
+- Is any equivalent formulation of the target being used circularly?
 - Is the claim still true under the stated validation path?
 - Does the public package surface match the latest retained evidence?
 - Does the name identify the scientific object, or is it a bare overloaded
@@ -184,6 +194,8 @@ the gates.
 - Do not treat review as cosmetic copyediting.
 - Do not invent fixes that would require missing science.
 - Do not approve arithmetic-only closure when the semantic bridge is open.
+- Do not approve proof-complete language when the terminal missing lemma is
+  target-equivalent or stronger than the headline claim.
 - Do not bury useful no-go results; preserve them as route-pruning evidence.
 - Do not approve overclaimed no-gos. A wrongly scoped no-go is at least
   as harmful as a wrongly scoped positive theorem; apply the No-Go

--- a/docs/ai_methodology/skills/physics-loop/SKILL.md
+++ b/docs/ai_methodology/skills/physics-loop/SKILL.md
@@ -165,6 +165,7 @@ Create or update a durable pack under:
   GOAL.md
   ASSUMPTIONS_AND_IMPORTS.md
   ROUTE_PORTFOLIO.md
+  APPROACH_REGISTRY.md
   OPPORTUNITY_QUEUE.md
   NO_GO_LEDGER.md
   LITERATURE_BRIDGES.md
@@ -180,9 +181,16 @@ Legacy packs under `.claude/science/frontier-workstreams/<slug>/` may be read
 for resume/migration, but new loop state should use `physics-loops`.
 
 Use `STATE.yaml` as the resume surface: current goal, target status, runtime,
-cycle/block count, active route, hard residual being attacked, files touched,
-open imports, no-go routes, trace-gate classification, review findings, PR
-status, next exact action, and stop condition.
+cycle/block count, active route, approach-family coverage, strongest unresolved
+proof obligation, hard residual being attacked, files touched, open imports,
+no-go routes, trace-gate classification, review findings, PR status, next exact
+action, and stop condition.
+
+For theorem, multi-step bridge, or hard-reduction targets, write the exact
+target contract in `GOAL.md` and maintain `APPROACH_REGISTRY.md` using
+[`references/proof-search-governance.md`](references/proof-search-governance.md).
+Keep mathematical approach families separate from artifact types recorded in
+`ROUTE_PORTFOLIO.md`.
 
 Use `OPPORTUNITY_QUEUE.md` in campaign mode. It must rank candidate science
 targets by:
@@ -453,6 +461,11 @@ For publication-facing or quantitative work, also inspect
 5. **Generate route portfolio.** Produce several independent routes and score
    them by likely claim-state movement. See
    [`references/route-patterns.md`](references/route-patterns.md).
+   For theorem, multi-step bridge, or hard-reduction targets, also apply
+   [`references/proof-search-governance.md`](references/proof-search-governance.md):
+   freeze the exact target contract, normalize routes into mathematical
+   approach families, preserve early-round independence, and classify every
+   terminal missing lemma by strength relative to the target.
    When a route will produce a new source note and companion runner,
    use the abstract-algebraic core extraction reference to separate the
    provable algebraic core from imports, numerical checks, and parent
@@ -621,8 +634,16 @@ routes are risky.
 - **Stuck fan-out:** before declaring "no route passes the gate", generate
   3-5 orthogonal premises/attack frames. If the active tool policy and user
   authorization allow parallel agents, run them in parallel; otherwise emulate
-  the fan-out sequentially in separate notes/sections. Synthesize agreements,
-  contradictions, and the best remaining attack.
+  the fan-out sequentially in separate notes/sections. Give early passes
+  neutral route-local briefs without the favored approach or other passes'
+  conclusions. Require concrete lemmas, constructions, equations, falsifiers,
+  or exact missing obligations; synthesize only after the independent passes
+  expose their real strengths and gaps.
+- **Equivalent-obligation block:** when a route terminates at a missing lemma
+  equivalent to or stronger than the target, mark its approach family
+  `blocked-equivalent` in `APPROACH_REGISTRY.md`. Do not keep assigning work to
+  that family until a new invariant, construction, decomposition, premise, or
+  proof mechanism changes the obligation map.
 - **Longer cadence:** checkpoint every `--checkpoint-interval`, but do not turn
   every checkpoint into a polished artifact. Sustained 90-120 minute hard
   attempts are preferred over several shallow audit cycles.
@@ -763,8 +784,9 @@ In short:
 Stop and write a clear `HANDOFF.md` when:
 
 - runtime or max cycles is reached;
-- no route in the refreshed opportunity queue passes the dramatic-step gate
-  **after** the Deep Work Rules have been satisfied for the active target;
+- no route in the refreshed opportunity queue or active approach-family
+  registry passes the dramatic-step gate **after** the Deep Work Rules and any
+  applicable theorem-strength gap tests have been satisfied for the target;
 - **corollary exhaustion**: every remaining ranked opportunity would produce
   only a one-step algebraic corollary of an already-landed campaign cycle
   with no new load-bearing premise. This is a real stop condition, not a
@@ -822,6 +844,9 @@ Report:
 - trace-gate classification and whether the artifact reaches a known blocker
   or is frontier-only;
 - imports retired or newly exposed;
+- mathematical approach families explored and underexplored;
+- strongest rigorously proved lemma plus the exact remaining proof obligation
+  and its strength relation to the target;
 - artifacts created and checks run;
 - review-loop findings and disposition;
 - commits and PRs created, if any;

--- a/docs/ai_methodology/skills/physics-loop/agents/openai.yaml
+++ b/docs/ai_methodology/skills/physics-loop/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Physics Loop"
   short_description: "Run unattended physics campaigns safely"
-  default_prompt: "Use $physics-loop to run a repo-grounded unattended physics campaign with honest claim status, block-level PRs, and deep stretch attempts."
+  default_prompt: "Use $physics-loop to run a repo-grounded unattended physics campaign with honest claim status, independent approach-family search, block-level PRs, and deep stretch attempts."
 
 policy:
   allow_implicit_invocation: true

--- a/docs/ai_methodology/skills/physics-loop/references/proof-search-governance.md
+++ b/docs/ai_methodology/skills/physics-loop/references/proof-search-governance.md
@@ -1,0 +1,126 @@
+# Proof Search Governance
+
+Use this protocol when a physics-loop target is a theorem, a multi-step
+mathematical bridge, or a hard reduction whose completion depends on proving
+nontrivial intermediate obligations. It governs the search process; it does
+not supply physics premises or weaken the repo's claim-status gates.
+
+## Contents
+
+- Exact Target Contract
+- Approach-Family Registry
+- Independent Search Rounds
+- Concrete-Return Contract
+- Theorem-Strength Gap Test
+- Candidate-Proof Audit
+- Round Synthesis And Handoff
+
+## Exact Target Contract
+
+Before route generation, record:
+
+```text
+Target statement | Quantifiers/domain | Allowed premises |
+Forbidden weakenings | Required edge/degenerate cases |
+Completion witness | Outcomes that do not count as closure
+```
+
+Keep the target neutral. Do not assume an affirmative proof exists or instruct
+workers to suppress a counterexample, a scoped no-go, or an exact remaining
+gap. A runtime budget is work capacity, not evidence that the target is true.
+
+## Approach-Family Registry
+
+Classify a family by the tuple:
+
+```text
+(primary mathematical object/formulation,
+ load-bearing mechanism or invariant,
+ terminal proof obligation)
+```
+
+Do not classify families by agent name, wording, note type, or whether the
+deliverable is a runner, literature bridge, or theorem note. Those are artifact
+types, not mathematical approaches.
+
+Maintain `APPROACH_REGISTRY.md` with:
+
+```text
+Family | Object/formulation | Mechanism/invariant | Terminal obligation |
+Strength vs target | Status | Concrete evidence | Reopen condition
+```
+
+Use `weaker`, `unknown/comparable`, `target-equivalent`, or `stronger` for the
+strength relation. Use `unexplored`, `active`, `provisional`,
+`blocked-local`, `blocked-equivalent`, `retired`, or `candidate-complete` for
+status.
+
+## Independent Search Rounds
+
+- Start with materially incompatible families, not several phrasings of the
+  favored route.
+- Give early workers neutral, route-local briefs. Do not disclose the favored
+  approach or other workers' conclusions unless their task is explicitly
+  synthesis or adversarial review.
+- Redirect new work toward underexplored families when one family becomes
+  saturated.
+- Cross-pollinate only after independent routes have produced a concrete
+  mathematical core and exposed their real gaps.
+- When parallel agents are unavailable, emulate independence with separate
+  context-isolated passes before synthesis.
+
+## Concrete-Return Contract
+
+Every route pass must return at least one of:
+
+- a formal lemma with a proof or proof skeleton whose open steps are named;
+- an explicit construction with admissibility checks;
+- equations, an invariant, or a dependency reduction;
+- a counterexample, falsifier, or exhaustive finite certificate;
+- an exact missing lemma with its dependency graph and the step that failed.
+
+Reject status-only reports, vague optimism, repeated background summaries, and
+claims that a global compatibility step is "routine."
+
+## Theorem-Strength Gap Test
+
+For every unresolved terminal lemma `L` and target `T`:
+
+1. state `L` formally under the same premises as the route;
+2. test whether `L => T`;
+3. test whether `T => L`, possibly after a routine translation;
+4. classify the strength relation in the registry.
+
+If `L` is target-equivalent or stronger, the route is not near closure merely
+because it reached `L`. Mark it `blocked-equivalent` unless the route supplies
+a genuinely new mechanism that advances the proof of `L`.
+
+Reopen a blocked family only when a new invariant, construction, premise,
+decomposition, or proof mechanism changes the obligation map. Record that
+mechanism as the reopen condition; a new worker or new wording is not enough.
+
+## Candidate-Proof Audit
+
+Before marking `candidate-complete`, independently check:
+
+- the conclusion matches the exact target contract, including quantifiers;
+- the proof-obligation graph is acyclic and every leaf is discharged;
+- every reduction preserves hypotheses, domains, and admissibility;
+- every constructed object satisfies the definition actually required;
+- boundary, degenerate, disconnected, singular, normalization, and convention
+  cases relevant to the target are covered;
+- no target-equivalent theorem is imported, renamed, or used circularly;
+- computational evidence is used as proof only when exhaustive or supported by
+  a theorem that makes it decisive.
+
+## Round Synthesis And Handoff
+
+After each round, report family coverage, concrete gains, exact gaps, saturation,
+redirects, and blocked-family reopen conditions. Preserve several incompatible
+routes while budget remains; an elegant reduction does not earn dominance if
+its terminal obligation is target-equivalent.
+
+At handoff, state the strongest rigorously proved result, the exact remaining
+obligation, its strength relation to the target, and the best new mechanisms
+that could reopen blocked families. Never hide the remaining gap behind
+"routine," "standard," or "compatibility."

--- a/docs/ai_methodology/skills/physics-loop/references/route-patterns.md
+++ b/docs/ai_methodology/skills/physics-loop/references/route-patterns.md
@@ -4,6 +4,12 @@ Use route portfolios to avoid tunnel vision and excessive small iteration.
 Generate several routes, then choose the route most likely to move the claim
 state.
 
+For theorem-heavy or multi-step bridge work, also read
+[`proof-search-governance.md`](proof-search-governance.md). This file classifies
+deliverable route types and scores likely value; the proof-search reference
+normalizes mathematical approach families and detects target-equivalent
+terminal obligations. Do not treat artifact type as approach-family diversity.
+
 ## Route Types
 
 - `constructive theorem`: prove the missing bridge on the retained surface.
@@ -59,7 +65,8 @@ After two cycles scoring `0-1`, the next cycle must target a `2-3` route even
 if the expected deliverable is partial progress rather than closure.
 
 Before declaring no route viable, run stuck fan-out across 3-5 orthogonal
-attack frames. Examples:
+attack frames. Use neutral route-local briefs for independent early passes and
+record the normalized families in `APPROACH_REGISTRY.md`. Examples:
 
 - derive from the smallest algebraic surface, with all phenomenological values
   forbidden;
@@ -69,7 +76,8 @@ attack frames. Examples:
 - prove the strongest impossibility theorem for a full route family;
 - build a falsifier that distinguishes two live interpretations.
 
-Record the fan-out in `ROUTE_PORTFOLIO.md` and synthesize why the selected
+Record the fan-out in `ROUTE_PORTFOLIO.md`, record family coverage and
+target-strength gaps in `APPROACH_REGISTRY.md`, and synthesize why the selected
 next route is best.
 
 ## Successful Patterns From This Repo

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -319,6 +319,18 @@ locally and report that limitation.
   semantic bridges, selector assumptions, status labels, exact/bounded/support
   boundaries, and code/prose drift.
 
+- `ProofObligationReviewer`
+  Trigger when changed content claims a theorem, proof, derivation, reduction,
+  or closure through a nontrivial intermediate lemma. Apply
+  [`docs/ai_methodology/skills/physics-loop/references/proof-search-governance.md`](../physics-loop/references/proof-search-governance.md).
+  Reconstruct the exact target contract and proof-obligation graph; check
+  hypothesis preservation, admissibility of constructed objects, boundary and
+  degenerate cases, circular use of equivalent statements, and whether the
+  strongest unresolved lemma is weaker than, equivalent to, or stronger than
+  the target. Output `CLOSED`, `CONDITIONAL`, `EQUIVALENT-GAP`, or `FAIL`.
+  An elegant reduction ending in a target-equivalent lemma is not near
+  closure and must not receive proof-complete framing.
+
 - `ImportSupportReviewer`
   Inventory every measured, fitted, literature, PDG, cosmological,
   normalization, boundary-condition, or convention input. Classify each as
@@ -465,6 +477,9 @@ Rules:
   without running `no-go-discipline` N1-N8 against the branch content. An
   unscrutinized negative claim forecloses investigation paths permanently and
   is at least as harmful as an overclaimed positive.
+- Do not approve proof-complete framing until the ProofObligationReviewer has
+  reconstructed the obligation graph and ruled out target-equivalent missing
+  lemmas, circular reductions, and uncovered edge cases.
 ````
 
 ## Consolidate Findings
@@ -476,6 +491,7 @@ Present one iteration summary:
 
 ### Code / Runner: PASS | RISK | FAIL
 ### Physics Claim Boundary: RETAINED | SUPPORT | BOUNDED | OPEN | REJECT
+### Proof Obligations: CLOSED | CONDITIONAL | EQUIVALENT-GAP | FAIL | NOT APPLICABLE
 ### Imports / Support: CLEAN | DISCLOSED | DEMOTE | FAIL
 ### Nature Retention: RETAINED | RETAINED SUPPORT | BOUNDED | OPEN | NO-GO | REJECT
 ### No-Go Discipline: PASS | FAIL | NOT APPLICABLE
@@ -493,6 +509,8 @@ Classify every finding:
 - `IMPORTED_VALUE`
 - `SUPPORT_ONLY_DEMOTION`
 - `MISSING_ARTIFACT`
+- `PROOF_OBLIGATION`
+- `EQUIVALENT_STRENGTH_GAP`
 - `SEMANTIC_BRIDGE`
 - `REPO_GOVERNANCE`
 - `AUDIT_COMPATIBILITY`
@@ -592,23 +610,28 @@ Otherwise apply the narrowest honest fix:
    false PASS checks, and code/prose mismatches.
 2. Demote overclaimed status when the artifact supports only support/bounded
    language.
-3. Mark imported values explicitly; distinguish derived, conditional, fitted,
+3. If a claimed proof or reduction terminates at a target-equivalent or
+   stronger missing lemma, demote the headline to `open_gate`, exact support,
+   or the strongest independently proved narrow lemma. Do not describe the
+   reduction as near closure unless it contains a genuinely new mechanism for
+   the terminal obligation.
+4. Mark imported values explicitly; distinguish derived, conditional, fitted,
    measured, literature, boundary-condition, and insensitive nuisance inputs.
-4. Add or repair paired runner/note references only when the artifact exists.
-5. Make audit-system hygiene fixes only when they do not change the science:
+5. Add or repair paired runner/note references only when the artifact exists.
+6. Make audit-system hygiene fixes only when they do not change the science:
    status-line tier labels, machine-local path removal, stale runner transcript
    refreshes, generated audit queue/ledger seeding, and discoverability wiring.
-6. Rename ambiguous science shorthand to explicit repo vocabulary without
+7. Rename ambiguous science shorthand to explicit repo vocabulary without
    changing the claim boundary. Examples: write `one-qubit operator algebra`
    (or equivalently `M_2(ℂ) ≅ Cl(3,0)`, `physical Cl(3) local algebra` as
    the real-algebra reading — all co-equal labels for the same retained
    algebra-isomorphism class), `Z^3 lattice`,
    `Koide Frobenius-equipartition condition`, or `Lie type A_1` instead of
    bare `A1` / `A2`.
-7. Update `docs/repo/ACTIVE_REVIEW_QUEUE.md` for live unresolved findings.
-8. Route detailed resolved packets to
+8. Update `docs/repo/ACTIVE_REVIEW_QUEUE.md` for live unresolved findings.
+9. Route detailed resolved packets to
    `docs/work_history/repo/review_feedback/` only when a long packet is needed.
-9. When a PR is non-landable but salvageable, preserve only the durable
+10. When a PR is non-landable but salvageable, preserve only the durable
    note/runner content, make the claim boundary canonical, and land that source
    salvage through the current requested landing path. If the rejected branch
    contains substantial non-source packet material, use a clean temporary
@@ -856,7 +879,15 @@ formula is correct. If an issue was reopened because the runner's math was
 wrong, treat the whole formula family as suspect until the changed expression
 and any reused helpers are cross-checked.
 
-11. **Native-language PASS gate (hard).** Changed repo-facing text must use
+11. **Proof-obligation scope PASS gate (hard).** When changed content claims a
+theorem, proof, derivation, reduction, or closure through intermediate lemmas,
+run `ProofObligationReviewer`. `CLOSED` supports the stated proof boundary.
+`CONDITIONAL` supports only a claim whose exact premise and narrower scope are
+explicit. `EQUIVALENT-GAP` forbids proof-complete or near-closure framing and
+requires demotion to `open_gate`, support, or the strongest independently
+proved lemma. `FAIL` blocks PASS until the proof is repaired or narrowed.
+
+12. **Native-language PASS gate (hard).** Changed repo-facing text must use
 controlled, native repo vocabulary. Run `scripts/vocab_lint.py --fix` on all
 branch-modified files before landing, then inspect changed headings, metadata,
 runner banners, claim scopes, table labels, and review comments for

--- a/docs/ai_methodology/skills/review-loop/agents/openai.yaml
+++ b/docs/ai_methodology/skills/review-loop/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Review Loop"
   short_description: "Run physics-specific parallel review loops"
-  default_prompt: "Use $review-loop to review branch changes with physics claim, import, runner, retention, and repo-governance pressure."
+  default_prompt: "Use $review-loop to review branch changes with physics claim, proof-obligation, import, runner, retention, and repo-governance pressure."
 
 policy:
   allow_implicit_invocation: true


### PR DESCRIPTION
## Summary

- add an exact-target contract and normalized mathematical approach-family registry for theorem-heavy physics-loop work
- preserve independent early search rounds, require concrete mathematical returns, and detect target-equivalent missing lemmas before claiming near-closure
- wire proof-obligation checks into exercise, review-loop, audit-loop, physics-claim-reviewer, no-go-discipline, mirrored commands, and UI prompts

## Validation

- skill-creator quick validation for physics-loop, exercise, physics-claim-reviewer, review-loop, audit-loop, and no-go-discipline
- vocabulary lint on all modified Markdown files: 0 violations
- `git diff --check`
- `python3 -m unittest docs.audit.scripts.tests.test_repo_invariants_check` — 56 tests passed
- `python3 docs/audit/scripts/repo_invariants_check.py --check` — PASS; 126 existing warn-only authority-link violations remain outside this change
- fresh-context forward test confirmed exact target contracts, approach-family normalization, independent concrete-return briefs, theorem-strength gap detection, and stop/reopen behavior