### PR TITLE
[physics-loop] uv-gauge-yukawa-singlet-projector exact-support

### DIFF
--- a/docs/UV_GAUGE_TO_YUKAWA_BRIDGE_SC_VS_PERT_NOTE.md
+++ b/docs/UV_GAUGE_TO_YUKAWA_BRIDGE_SC_VS_PERT_NOTE.md
@@ -35,8 +35,9 @@ load-bearing.
 
 ## Claim Scope
 
-Let `N_c = 3` and `N_iso = 2` be the retained bounded representation inputs
-used by the runner. The in-scope theorem is the finite coefficient packet:
+Fix `N_c = 3` and `N_iso = 2` as representation conditions for this bounded
+packet. This row does not derive their physical selection. The in-scope theorem
+is the finite coefficient packet:
 
 1. The SU(`N_c`) generator normalization
 
@@ -212,4 +213,4 @@ would need to prove the expansion-domain/selector surface: why the retained
 framework inputs put the relevant coefficient in the tadpole-improved
 perturbative domain rather than the strong-coupling character domain, with the
 plaquette/`u_0`, `g_bare`, staggered-Dirac, and shared tadpole-transport
-dependencies explicitly closed or admitted.
+dependencies explicitly closed or left as named open conditions.

--- a/docs/UV_GAUGE_TO_YUKAWA_BRIDGE_SC_VS_PERT_NOTE.md
+++ b/docs/UV_GAUGE_TO_YUKAWA_BRIDGE_SC_VS_PERT_NOTE.md
@@ -1,6 +1,6 @@
 # UV Gauge-to-Yukawa Bridge: Perturbative vs Strong-Coupling Coefficients
 
-**Date:** 2026-04-16 (2026-05-29 scope repair).
+**Date:** 2026-04-16 (2026-05-29 scope repair; 2026-07-16 singlet-projector repair).
 **Type:** bounded_theorem.
 **Primary runner:** `scripts/uv_gauge_to_yukawa_bridge_sc_vs_pert_scope_check.py`.
 
@@ -57,17 +57,84 @@ used by the runner. The in-scope theorem is the finite coefficient packet:
    C_pert = 1/(2 N_c).
    ```
 
-2. The leading one-link Haar contraction
+2. Use the pair-space ordering `(ab);(cd)`, with `a,c` fundamental row
+   indices, `b,d` anti-fundamental/column indices, and
 
    ```text
-   integral dU U_ab U^dag_cd = (1/N_c) delta_ad delta_bc
+   U^dag_cd = (U_dc)^*.
    ```
 
-   gives the corresponding leading strong-coupling color-singlet coefficient
+   The exact normalized one-link Haar tensor is
 
    ```text
-   C_strong = 1/N_c^2.
+   H_(ab;cd)
+     = integral dU U_ab U^dag_cd
+     = (1/N_c) delta_ad delta_bc.
    ```
+
+   On the Hilbert-Schmidt pair space, define the normalized color-singlet
+   vector and its rank-one projector by
+
+   ```text
+   S_ab = delta_ab / sqrt(N_c),
+
+   Pi_1(ab;cd) = S_ab S_cd^*
+                = delta_ab delta_cd / N_c.
+   ```
+
+   Thus `sum_ab S_ab^* S_ab = 1`, while `Pi_1^dag = Pi_1`,
+   `Pi_1^2 = Pi_1`, `rank(Pi_1) = 1`, and
+   `Tr(Pi_1) = ||Pi_1||_HS^2 = 1`.
+
+   The complete singlet-channel sandwich is
+
+   ```text
+   (Pi_1 H Pi_1)_(ab;cd)
+     = sum_efgh
+         [delta_ab delta_ef / N_c]
+         [delta_eh delta_fg / N_c]
+         [delta_gh delta_cd / N_c]
+     = delta_ab delta_cd / N_c^2
+     = (1/N_c) Pi_1(ab;cd).
+   ```
+
+   Equivalently, for the rank-four Hilbert-Schmidt inner product
+
+   ```text
+   <A,B>_HS = sum_abcd A_(ab;cd)^* B_(ab;cd),
+   ```
+
+   the normalized-projector coefficient is
+
+   ```text
+   alpha_1
+     = <Pi_1,H>_HS / <Pi_1,Pi_1>_HS
+     = [(1/N_c^2) sum_abcd
+          delta_ab delta_cd delta_ad delta_bc] / 1
+     = 1/N_c.
+   ```
+
+   There are exactly `N_c` nonzero terms in the displayed sum. Therefore the
+   singlet tensor component is
+
+   ```text
+   H^(1)_(ab;cd)
+     = alpha_1 Pi_1(ab;cd)
+     = delta_ab delta_cd / N_c^2.
+   ```
+
+   If `D_(ab;cd) = delta_ab delta_cd` denotes the unnormalized singlet tensor,
+   then `||D||_HS^2 = N_c^2` and
+
+   ```text
+   <D,H>_HS = 1,
+   C_strong = <D,H>_HS / <D,D>_HS = 1/N_c^2.
+   ```
+
+   Hence `1/N_c` is the coefficient of the normalized projector `Pi_1`, while
+   `C_strong = 1/N_c^2` is the coefficient of the unnormalized tensor
+   `delta_ab delta_cd`. These are different coefficient conventions for the
+   same reconstructed singlet component and must not be interchanged.
 
 3. At `N_c = 3`, these are exactly
 
@@ -113,9 +180,20 @@ identity. The primary runner constructs the Gell-Mann generators for `N_c=3`,
 verifies the normalization and all index entries of the Fierz identity, and
 extracts the color-singlet coefficient `1/(2 N_c)`.
 
-The strong-coupling coefficient is the leading one-link Haar contraction. The
-primary runner samples SU(3) Haar matrices as a numerical witness for the
-exact contraction and records the algebraic result `1/N_c^2`.
+For the strong-coupling coefficient, the primary runner instantiates the
+ordered pair basis, `S`, `Pi_1`, `H`, and the unnormalized tensor `D` as finite
+arrays. It verifies the singlet normalization, projector Hermiticity,
+idempotence, rank, trace, and Hilbert-Schmidt norm; evaluates both
+`Pi_1 H Pi_1` and the independent Hilbert-Schmidt coefficient contractions;
+and reconstructs the same singlet tensor component in the normalized and
+unnormalized conventions. The resulting exact coefficients are `1/N_c` and
+`1/N_c^2`, respectively, with `C_strong = 1/9` at `N_c = 3`.
+
+The runner retains the SU(3) Haar sample only as a numerical witness for the
+starting tensor identity. It also includes hostile controls that fail when one
+`1/sqrt(N_c)` projector factor is omitted, when `1/N_c` is misread as the
+coefficient of `delta_ab delta_cd`, or when an index permutation changes the
+projected channel.
 
 The `H_unit` overlap is finite-dimensional Hilbert-space algebra. The
 unit-norm singlet on a six-dimensional `Q_L` block has each diagonal basis

--- a/docs/repo/ACTIVE_REVIEW_QUEUE.md
+++ b/docs/repo/ACTIVE_REVIEW_QUEUE.md
@@ -27,6 +27,16 @@ them.
 
 Current science/open-lane follow-ups:
 
+- `2026-07-16-uv-gauge-yukawa-direct-consumer-scope-drift`
+  Scope: the seven unaudited direct consumers of
+  `UV_GAUGE_TO_YUKAWA_BRIDGE_SC_VS_PERT_NOTE.md`.
+  Finding: several consumers still cite that bridge for retired
+  governing-expansion selection, canonical-surface `alpha_LM`, or historical
+  `delta_PT`/NLO prose that the bridge no longer contains. PR #5414 does not
+  change the public `C_strong = 1/N_c^2` convention, so synchronized claim-note
+  hash churn is not justified in that narrow projector repair; the stale
+  citations remain unaudited and must not inherit authority from it.
+  Disposition: `fix on main`.
 - `2026-07-16-su3-wigner-downstream-status-prose-drift`
   Scope:
   `SU3_WIGNER_BLOCK4_STAGING_BLOCK5_ORIENTATION_DIAGNOSTICS_NARROW_THEOREM_NOTE_2026-05-10.md`

--- a/logs/runner-cache/uv_gauge_to_yukawa_bridge_sc_vs_pert_scope_check.txt
+++ b/logs/runner-cache/uv_gauge_to_yukawa_bridge_sc_vs_pert_scope_check.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/uv_gauge_to_yukawa_bridge_sc_vs_pert_scope_check.py
-runner_sha256: 7daae00ac0a3cdc6043b8b07f3611f77b309c3f69480cda0b4d45c61929394de
+runner_sha256: ff12130bb6b929dceb41188324460ee6aedd4aa4e6e58f519057a1f0e50a3312
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.56
+elapsed_sec: 0.63
 status: ok
 ----- stdout -----
 
@@ -15,6 +15,8 @@ PART 0: SOURCE NOTE SCOPE FIREWALL
   [PASS] source note carries repaired-scope phrase: This row does not prove perturbative convergence
   [PASS] source note carries repaired-scope phrase: No new axiom is introduced
   [PASS] source note carries repaired-scope phrase: bounded coefficient support/comparison note
+  [PASS] source note carries repaired-scope phrase: normalized-projector coefficient is
+  [PASS] source note carries repaired-scope phrase: coefficient of the unnormalized tensor
   [PASS] source note excludes old selector phrase: the perturbative expansion is convergent
   [PASS] source note excludes old selector phrase: the correct input to the main theorem
   [PASS] source note excludes old selector phrase: The canonical surface selects the perturbative expansion
@@ -28,10 +30,36 @@ PART 1: SU(3) FIERZ AND PERTURBATIVE COEFFICIENT
   [PASS] C_pert = 1/(2*N_c) = 1/6
 
 ==============================================================================
-PART 2: ONE-LINK HAAR CONTRACTION AND STRONG COEFFICIENT
+PART 2: EXACT SINGLET PROJECTOR AND STRONG COEFFICIENT
 ==============================================================================
+  [PASS] S_ab = delta_ab/sqrt(N_c) has unit norm
+  [PASS] Pi_1 = S S^dag = delta_ab delta_cd/N_c entrywise
+  [PASS] Pi_1 is Hermitian
+  [PASS] Pi_1 is idempotent
+  [PASS] Pi_1 has rank one
+  [PASS] Tr(Pi_1) = 1
+  [PASS] ||Pi_1||_HS^2 = 1
+  [PASS] H S = (1/N_c) S
+  [PASS] Pi_1 H Pi_1 = (1/N_c) Pi_1
+  [PASS] normalized-projector coefficient is 1/N_c  (alpha_1=1/3)
+  [PASS] singlet component reconstructs delta_ab delta_cd/N_c^2
+  [PASS] <D,H>_HS = 1
+  [PASS] ||D||_HS^2 = N_c^2
+  [PASS] unnormalized-tensor coefficient is C_strong = 1/N_c^2  (C_strong=1/9)
+  [PASS] direct and reconstructed C_strong agree
+  [PASS] C_strong times delta_ab delta_cd reconstructs the singlet component
+  [PASS] N_c=3 gives C_strong = 1/9
+  [PASS] U^dag_cd ordering is distinct from conjugate(U_cd) ordering
+  [PASS] HOSTILE: omitting one projector normalization factor breaks idempotence
+  [PASS] HOSTILE: one-factor projector has trace sqrt(N_c), not one
+  [PASS] HOSTILE: normalized-projector and unnormalized-tensor coefficients differ
+  [PASS] HOSTILE: using 1/N_c on delta_ab delta_cd is too large by N_c
+  [PASS] HOSTILE: b<->d permutation changes H into Pi_1
+  [PASS] HOSTILE: permuted channel has normalized-projector coefficient 1
+  [PASS] HOSTILE: permuted channel has D coefficient 1/N_c, not 1/N_c^2
+
+  Numerical support for the starting Haar identity:
   [PASS] Haar witness for integral dU U_ab U^dag_cd  (max err=0.004)
-  [PASS] C_strong = 1/N_c^2 = 1/9
   [PASS] C_pert and C_strong are distinct coefficients  (delta=0.0556; selector out of scope)
 
 ==============================================================================
@@ -49,7 +77,7 @@ PART 4: H_UNIT SINGLET OVERLAP
   [PASS] all six diagonal overlaps are 1/sqrt(6)
 
 ==============================================================================
-SUMMARY: PASS=21 FAIL=0
+SUMMARY: PASS=47 FAIL=0
 ==============================================================================
 
 ----- stderr -----

--- a/scripts/uv_gauge_to_yukawa_bridge_sc_vs_pert_scope_check.py
+++ b/scripts/uv_gauge_to_yukawa_bridge_sc_vs_pert_scope_check.py
@@ -8,11 +8,17 @@ shared Ward runner, because that runner is load-bearing for other audited rows.
 It checks only the repaired bounded surface:
 
 * C_pert = 1/(2*N_c) from finite SU(3) Fierz algebra;
-* C_strong = 1/N_c^2 from the leading one-link Haar contraction;
+* the normalized singlet S_ab = delta_ab/sqrt(N_c);
+* the rank-one projector Pi_1(ab;cd) = delta_ab delta_cd/N_c;
+* the exact pair-space contraction Pi_1 H Pi_1 = (1/N_c) Pi_1;
+* C_strong = 1/N_c^2 as the coefficient of delta_ab delta_cd, derived rather
+  than hard-coded;
 * the two coefficients differ;
 * the Dirac scalar/pseudoscalar Fierz channels are nonzero and tensor vanishes;
 * the Q_L singlet overlap is 1/sqrt(6);
 * the source note excludes the old expansion-domain selector claim.
+
+The pair ordering is (ab);(cd), and U^dag_cd means conjugate(U_dc).
 """
 
 from __future__ import annotations
@@ -22,6 +28,7 @@ from itertools import product
 from pathlib import Path
 
 import numpy as np
+import sympy as sp
 
 ROOT = Path(__file__).resolve().parents[1]
 NOTE_PATH = ROOT / "docs/UV_GAUGE_TO_YUKAWA_BRIDGE_SC_VS_PERT_NOTE.md"
@@ -55,6 +62,8 @@ def source_firewall() -> None:
         "This row does not prove perturbative convergence",
         "No new axiom is introduced",
         "bounded coefficient support/comparison note",
+        "normalized-projector coefficient is",
+        "coefficient of the unnormalized tensor",
     ]
     forbidden = [
         "the perturbative expansion is convergent",
@@ -80,7 +89,7 @@ def su3_generators() -> list[np.ndarray]:
     return [lam / 2.0 for lam in (l1, l2, l3, l4, l5, l6, l7, l8)]
 
 
-def check_su3_fierz() -> float:
+def check_su3_fierz() -> sp.Rational:
     print("\n" + "=" * 78)
     print("PART 1: SU(3) FIERZ AND PERTURBATIVE COEFFICIENT")
     print("=" * 78)
@@ -100,9 +109,9 @@ def check_su3_fierz() -> float:
             - (1.0 / N_c) * (1.0 if a == b else 0.0) * (1.0 if c == d else 0.0)
         )
         fierz_err = max(fierz_err, abs(lhs - rhs))
-    c_pert = 1.0 / (2.0 * N_c)
+    c_pert = sp.Rational(1, 2 * N_c)
     check("SU(3) Fierz identity holds entrywise", fierz_err < 1e-14, f"max err={fierz_err:.2e}")
-    check("C_pert = 1/(2*N_c) = 1/6", abs(c_pert - 1.0 / 6.0) < 1e-15)
+    check("C_pert = 1/(2*N_c) = 1/6", c_pert == sp.Rational(1, 6))
     return c_pert
 
 
@@ -115,27 +124,171 @@ def random_sun_haar(n: int, rng: np.random.Generator) -> np.ndarray:
     return q * (det_q.conj()) ** (1.0 / n)
 
 
-def check_strong_coupling(c_pert: float) -> None:
+def pair_operator(n: int, entry) -> sp.Matrix:
+    """Flatten a rank-four tensor with pair ordering (ab);(cd)."""
+    pairs = list(product(range(n), repeat=2))
+    return sp.Matrix(n * n, n * n, lambda i, j: entry(*pairs[i], *pairs[j]))
+
+
+def hs_inner(left: sp.Matrix, right: sp.Matrix) -> sp.Expr:
+    """Exact Hilbert-Schmidt inner product for equal-size pair operators."""
+    return sp.simplify(
+        sum(
+            sp.conjugate(left[i, j]) * right[i, j]
+            for i in range(left.rows)
+            for j in range(left.cols)
+        )
+    )
+
+
+def coefficient_along(basis: sp.Matrix, tensor: sp.Matrix) -> sp.Expr:
+    return sp.simplify(hs_inner(basis, tensor) / hs_inner(basis, basis))
+
+
+def check_strong_coupling(c_pert: sp.Rational) -> None:
     print("\n" + "=" * 78)
-    print("PART 2: ONE-LINK HAAR CONTRACTION AND STRONG COEFFICIENT")
+    print("PART 2: EXACT SINGLET PROJECTOR AND STRONG COEFFICIENT")
     print("=" * 78)
+
+    n = N_c
+    pairs = list(product(range(n), repeat=2))
+
+    def delta(i: int, j: int) -> sp.Integer:
+        return sp.Integer(i == j)
+
+    def haar_entry(a: int, b: int, c: int, d: int) -> sp.Expr:
+        return sp.Rational(1, n) * delta(a, d) * delta(b, c)
+
+    singlet = sp.Matrix([delta(a, b) / sp.sqrt(n) for a, b in pairs])
+    unnormalized_singlet = pair_operator(
+        n, lambda a, b, c, d: delta(a, b) * delta(c, d)
+    )
+    projector = sp.simplify(singlet * singlet.H)
+    expected_projector = unnormalized_singlet / n
+    haar = pair_operator(n, haar_entry)
+
+    singlet_norm = sp.simplify((singlet.H * singlet)[0])
+    check("S_ab = delta_ab/sqrt(N_c) has unit norm", singlet_norm == 1)
+    check("Pi_1 = S S^dag = delta_ab delta_cd/N_c entrywise", projector == expected_projector)
+    check("Pi_1 is Hermitian", projector.H == projector)
+    check("Pi_1 is idempotent", projector * projector == projector)
+    check("Pi_1 has rank one", projector.rank() == 1)
+    check("Tr(Pi_1) = 1", sp.trace(projector) == 1)
+    check("||Pi_1||_HS^2 = 1", hs_inner(projector, projector) == 1)
+
+    expected_eigenvector = singlet / n
+    check("H S = (1/N_c) S", haar * singlet == expected_eigenvector)
+    sandwich = sp.simplify(projector * haar * projector)
+    check("Pi_1 H Pi_1 = (1/N_c) Pi_1", sandwich == projector / n)
+
+    projector_coeff = coefficient_along(projector, haar)
+    projected_component = sp.simplify(projector_coeff * projector)
+    check(
+        "normalized-projector coefficient is 1/N_c",
+        projector_coeff == sp.Rational(1, n),
+        f"alpha_1={projector_coeff}",
+    )
+    check(
+        "singlet component reconstructs delta_ab delta_cd/N_c^2",
+        projected_component == unnormalized_singlet / (n * n),
+    )
+
+    c_strong_direct = coefficient_along(unnormalized_singlet, haar)
+    c_strong_reconstructed = coefficient_along(
+        unnormalized_singlet, projected_component
+    )
+    check("<D,H>_HS = 1", hs_inner(unnormalized_singlet, haar) == 1)
+    check(
+        "||D||_HS^2 = N_c^2",
+        hs_inner(unnormalized_singlet, unnormalized_singlet) == n * n,
+    )
+    check(
+        "unnormalized-tensor coefficient is C_strong = 1/N_c^2",
+        c_strong_direct == sp.Rational(1, n * n),
+        f"C_strong={c_strong_direct}",
+    )
+    check(
+        "direct and reconstructed C_strong agree",
+        c_strong_reconstructed == c_strong_direct,
+    )
+    check(
+        "C_strong times delta_ab delta_cd reconstructs the singlet component",
+        c_strong_direct * unnormalized_singlet == projected_component,
+    )
+    check("N_c=3 gives C_strong = 1/9", c_strong_direct == sp.Rational(1, 9))
+
+    # Conjugation/index convention: U^dag_cd = conjugate(U_dc).  Using
+    # conjugate(U_cd) instead gives a different rank-four tensor.
+    wrong_conjugation_order = pair_operator(
+        n,
+        lambda a, b, c, d: sp.Rational(1, n) * delta(a, c) * delta(b, d),
+    )
+    check(
+        "U^dag_cd ordering is distinct from conjugate(U_cd) ordering",
+        wrong_conjugation_order != haar,
+    )
+
+    # Hostile control 1: one of the two 1/sqrt(N_c) factors is omitted.
+    half_normalized_projector = unnormalized_singlet / sp.sqrt(n)
+    check(
+        "HOSTILE: omitting one projector normalization factor breaks idempotence",
+        half_normalized_projector * half_normalized_projector
+        != half_normalized_projector,
+    )
+    check(
+        "HOSTILE: one-factor projector has trace sqrt(N_c), not one",
+        sp.trace(half_normalized_projector) == sp.sqrt(n),
+    )
+
+    # Hostile control 2: 1/N_c is the Pi_1 coefficient, not the D coefficient.
+    confused_reconstruction = sp.simplify(projector_coeff * unnormalized_singlet)
+    check(
+        "HOSTILE: normalized-projector and unnormalized-tensor coefficients differ",
+        projector_coeff != c_strong_direct,
+    )
+    check(
+        "HOSTILE: using 1/N_c on delta_ab delta_cd is too large by N_c",
+        confused_reconstruction != projected_component
+        and confused_reconstruction == n * projected_component,
+    )
+
+    # Hostile control 3: exchanging b and d changes H into Pi_1 and changes
+    # the projected channel coefficient from 1/N_c to 1.
+    permuted_haar = pair_operator(
+        n, lambda a, b, c, d: haar_entry(a, d, c, b)
+    )
+    permuted_projector_coeff = coefficient_along(projector, permuted_haar)
+    permuted_unnormalized_coeff = coefficient_along(
+        unnormalized_singlet, permuted_haar
+    )
+    check("HOSTILE: b<->d permutation changes H into Pi_1", permuted_haar == projector)
+    check(
+        "HOSTILE: permuted channel has normalized-projector coefficient 1",
+        permuted_projector_coeff == 1 and permuted_projector_coeff != projector_coeff,
+    )
+    check(
+        "HOSTILE: permuted channel has D coefficient 1/N_c, not 1/N_c^2",
+        permuted_unnormalized_coeff == sp.Rational(1, n)
+        and permuted_unnormalized_coeff != c_strong_direct,
+    )
+
+    print("\n  Numerical support for the starting Haar identity:")
     rng = np.random.default_rng(20260529)
     n_samples = 20_000
-    sample = np.zeros((N_c, N_c, N_c, N_c), dtype=complex)
+    sample = np.zeros((n, n, n, n), dtype=complex)
     for _ in range(n_samples):
-        u = random_sun_haar(N_c, rng)
+        u = random_sun_haar(n, rng)
+        # einsum label dc implements U^dag_cd = conjugate(U_dc).
         sample += np.einsum("ab,dc->abcd", u, u.conj()) / n_samples
     expected = np.zeros_like(sample)
-    for a, b, c, d in product(range(N_c), repeat=4):
-        expected[a, b, c, d] = (1.0 / N_c) if (a == d and b == c) else 0.0
+    for a, b, c, d in product(range(n), repeat=4):
+        expected[a, b, c, d] = (1.0 / n) if (a == d and b == c) else 0.0
     mc_err = float(np.max(np.abs(sample - expected)))
-    c_strong = 1.0 / (N_c * N_c)
     check("Haar witness for integral dU U_ab U^dag_cd", mc_err < 0.02, f"max err={mc_err:.3f}")
-    check("C_strong = 1/N_c^2 = 1/9", abs(c_strong - 1.0 / 9.0) < 1e-15)
     check(
         "C_pert and C_strong are distinct coefficients",
-        abs(c_pert - c_strong) > 0.01,
-        f"delta={abs(c_pert - c_strong):.4f}; selector out of scope",
+        c_pert != c_strong_direct,
+        f"delta={float(abs(c_pert - c_strong_direct)):.4f}; selector out of scope",
     )
 
 


### PR DESCRIPTION
## Audit repair target

> Add the explicitly normalized color-singlet projector and its complete index contraction to both the source note and runner, demonstrating how the Haar factor 1/N_c yields C_strong = 1/N_c^2.

## Repair

- Defines `S_ab = delta_ab/sqrt(N_c)` and `Pi_1(ab;cd) = delta_ab delta_cd/N_c` with explicit pair ordering and conjugation conventions.
- Evaluates the complete `Pi_1 H Pi_1` contraction and an independent Hilbert--Schmidt extraction, distinguishing the normalized-projector coefficient `1/N_c` from the unnormalized-tensor coefficient `C_strong = 1/N_c^2`.
- Replaces the runner hard-code with exact finite arrays and contractions checking normalization, Hermiticity, idempotence, rank, trace, norm, extraction, and reconstruction.
- Adds meaningful hostile controls for missing normalization, coefficient-basis confusion, and channel/index permutation.
- Keeps Monte Carlo as support only and explicitly excludes expansion selection, convergence, and downstream plaquette/Yukawa authority.
- Applies one narrow review-fix iteration: representation values are fixed packet conditions rather than physically selected inputs, and retired admission-era wording is removed.
- Records pre-existing scope drift in seven unaudited direct consumers in `docs/repo/ACTIVE_REVIEW_QUEUE.md`; no synchronized consumer rewrite is required because this PR does not change the public `C_strong = 1/N_c^2` convention.

## Verification

- Separate Sol xhigh review-loop pass and focused post-fix re-review: `PASS`, no blockers.
- Primary runner: `PASS=47 FAIL=0`, exit 0, empty stderr.
- Live/cache stdout: byte-identical, 4,218 bytes, SHA-256 `35d4c38a2f04a3babf35be21971d6e32ea89db0381ec7a104c1c78123b41481a`.
- Runner/cache source SHA: `ff12130bb6b929dceb41188324460ee6aedd4aa4e6e58f519057a1f0e50a3312`.
- Independent raw rational contractions for `N_c=2,3,4,5` reproduce `alpha_1=1/N_c` and `C_strong=1/N_c^2`.
- Existing SU(3) Fierz, Dirac-channel, and `H_unit` checks remain valid.
- Vocabulary lint: 0 violations. `git diff --check`: pass.
- Disposable audit-system compatibility pipeline: complete; strict lint has no errors; regenerated target is `bounded_theorem`, `unaudited`, and queue-visible. Generated outputs and the disposable worktree were removed.

Independent post-merge review by the audit lane remains required before this bounded claim may receive retained authority. This PR does not supply or imply an audit verdict.
