### PR TITLE
[physics-loop] staggered-generic-k exact-support repair

### DIFF
--- a/docs/STAGGERED_DIRAC_SUBSTEP4_AC_LAMBDA_SIMULTANEOUS_DIAGONALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-17.md
+++ b/docs/STAGGERED_DIRAC_SUBSTEP4_AC_LAMBDA_SIMULTANEOUS_DIAGONALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-17.md
@@ -145,16 +145,16 @@ unitary triple (2a)-(2c) — is carried by the in-flight substep-3 note
 `STAGGERED_DIRAC_BZ_CORNER_FORCING_THEOREM_NOTE_2026-05-07.md` and is
 out of scope here.
 
-## 4. Admitted-context inputs
+## 4. Mathematical inputs
 
 - **Standard finite-dim complex linear algebra.** Diagonal operators
   commuting in a common eigenbasis; commutator identity; matrix
-  entries via inner products on a chosen basis. Admitted-context
-  mathematical infrastructure on the framework's accepted surface.
+  entries via inner products on a chosen basis. This is standard
+  mathematical infrastructure, not a supplied physics premise.
 - **Exact arithmetic on `3 × 3` complex matrices.** Verified by the
   companion runner via sympy.
 
-No physics conventions admitted beyond the abstract algebraic framing.
+No physics convention is used beyond the abstract algebraic framing.
 No PDG value consumed. No staggered-Dirac / lattice-action / `g_bare` /
 framework-instance-specific input.
 
@@ -246,10 +246,10 @@ dimension `3`. ∎
   `STAGGERED_DIRAC_BZ_CORNER_FORCING_THEOREM_NOTE_2026-05-07.md`
   records the joint eigenvalue triples
   `((-1, +1, +1), (+1, -1, +1), (+1, +1, -1))` for the framework's
-  three lattice translations on hw=1 corners on `Z^3` APBC, but is
-  in-flight and not yet retained; this narrow theorem treats the
-  joint-eigenvalue triples (2a)-(2c) as the abstract input, not as a
-  forced consequence of the framework's substrate.
+  three lattice translations on hw=1 corners on `Z^3` APBC. Its
+  audit-pipeline status is not consumed here; this narrow theorem
+  treats the joint-eigenvalue triples (2a)-(2c) as the abstract input,
+  not as a forced consequence of the framework's substrate.
 - Does **not** derive the substep-2 Kawamoto-Smit kinetic operator
   form or its translation-invariance. Those are carried by separate
   in-flight notes (substep-2 packaging).
@@ -270,7 +270,7 @@ dimension `3`. ∎
 - No PDG observed values consumed.
 - No literature numerical comparators consumed.
 - No fitted selectors consumed.
-- No admitted unit conventions load-bearing on the claim.
+- No unit convention is load-bearing on the claim.
 - No same-surface family arguments.
 - No staggered-Dirac realization gate output consumed (the open gate
   is named in plain text only as the parent identity that contextualizes
@@ -390,9 +390,9 @@ edges:
 - `STAGGERED_DIRAC_SUBSTEP4_AC_PHI_TRACE_EQUIPARTITION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-17.md`
   — sibling AC_φ narrow theorem shipped same date.
 - `STAGGERED_DIRAC_SUBSTEP1_GRASSMANN_FORCING_BRIDGE_NARROW_THEOREM_NOTE_2026-05-16.md`
-  — sister substep-1 narrow bridge (audited_clean).
+  — sister substep-1 narrow bridge; its status remains audit-pipeline-derived.
 - `STAGGERED_DIRAC_SUBSTEP3_SPECIES_REDUCTION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-16.md`
-  — sister substep-3 narrow bridge (audited_clean).
+  — sister substep-3 narrow bridge; its status remains audit-pipeline-derived.
 - `STAGGERED_DIRAC_BZ_CORNER_FORCING_THEOREM_NOTE_2026-05-07.md`
   — pre-existing in-flight substep-3 packaging carrying the
   `Z^3`-substrate hw=1 carrier identification with the explicit
@@ -402,7 +402,7 @@ edges:
   — pre-existing in-flight substep-2 packaging carrying the
   Kawamoto-Smit kinetic operator form whose translation-invariance is
   the bridge to (b) above.
-- `MINIMAL_AXIOMS_2026-05-03.md`
+- `MINIMAL_AXIOMS_2026-06-29.md`
   — framework baseline memo for the physical Cl(3) local algebra and
   Z^3 spatial substrate; the narrow theorem does not consume its
   effective status.

--- a/docs/STAGGERED_DIRAC_SUBSTEP4_AC_LAMBDA_SIMULTANEOUS_DIAGONALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-17.md
+++ b/docs/STAGGERED_DIRAC_SUBSTEP4_AC_LAMBDA_SIMULTANEOUS_DIAGONALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-17.md
@@ -314,35 +314,59 @@ verifies via sympy exact symbolic arithmetic:
 2. **(L1) pairwise distinctness.** For each ordered pair
    `(α, β) ∈ {1, 2, 3}^2` with `α ≠ β`, enumerate the `μ`s for which
    `τ_μ^(α) ≠ τ_μ^(β)` and confirm at least one such `μ` exists.
-3. **(L3) single-`T_μ` off-diagonal vanishing.** Construct a generic
-   symbolic Hermitian `K` with 6 free real parameters (3 diagonal +
-   3 complex off-diagonal). For each ordered pair `(α, β)` with
-   `α ≠ β`, pick the lowest-index `μ` with `τ_μ^(α) ≠ τ_μ^(β)`,
-   and verify the identity
-   `⟨e_α | [K, T_μ] | e_β⟩ = (τ_μ^(β) - τ_μ^(α)) ⟨e_α | K | e_β⟩`.
-4. **(L2) simultaneous diagonalization corollary.** Impose
-   `[K, T_μ] = 0` for `μ = 1, 2, 3` and solve for the off-diagonal
-   parameters of `K`. Verify the unique solution forces all six
-   off-diagonal real parameters to zero.
-5. **(L4) diagonal class.** Verify that a generic diagonal matrix
-   `K = diag(k_1, k_2, k_3)` with `k_α ∈ C` commutes with each `T_μ`
-   for `μ = 1, 2, 3`. Verify the commuting algebra has complex
-   dimension `3`.
-6. **Worked numerical instance.** Plug in `k_1 = 1, k_2 = 2, k_3 = 5`
-   and verify `[diag(1, 2, 5), T_μ] = 0` for all `μ ∈ {1, 2, 3}`.
-7. **Counter-example: non-diagonal `K` with one off-diagonal entry.**
-   Construct `K = diag(1, 2, 5) + |e_1⟩⟨e_2|` (i.e., add an
-   off-diagonal entry between basis vectors 1 and 2). Verify
-   `[K, T_1] ≠ 0` because `τ_1^(1) ≠ τ_1^(2)`. This confirms the
-   distinctness condition is load-bearing for the diagonal-class
-   result.
-8. **Coincidence-set boundary at `T_μ = I`.** If all three eigenvalue
-   triples coincide (e.g., `τ_μ^(α) = +1` for all `μ, α`), then any
-   operator commutes with `T_μ = I` trivially, and the diagonal-class
-   conclusion fails. Confirm this counter-case to verify pairwise
-   distinctness is necessary.
+3. **Generic complex operator coverage.** Construct a fully generic
+   `K ∈ M_3(C)` using independent real and imaginary coordinates for
+   all nine entries: 18 algebraically independent real symbols in
+   total. Verify that opposite off-diagonal entries have disjoint
+   coordinate sets, so no Hermiticity, symmetry, normality, reality,
+   or conjugate-pair relation is imposed.
+4. **(L3) full entrywise identity.** For every `μ` and every matrix
+   entry `(α, β)`, verify exactly
+   `[K,T_μ]_{αβ} =
+   (τ_μ^(β) - τ_μ^(α)) K_{αβ}`. For each of the six ordered
+   off-diagonal entries, also verify the reconstruction identity
+   `Σ_μ (τ_μ^(β)-τ_μ^(α))[K,T_μ]_{αβ} = 8 K_{αβ}`.
+5. **(L2) exact generic-complex solve.** Split all three commutator
+   systems into real and imaginary parts and solve them together.
+   Verify that the equations contain all 12 real coordinates of the
+   six complex ordered off-diagonal entries, contain none of the six
+   real coordinates of the three complex diagonal entries, and force
+   every off-diagonal coordinate independently to zero.
+6. **Independent rank/kernel certificate.** Build the complex-linear
+   map
+   `K ↦ ([K,T_1], [K,T_2], [K,T_3])` as an exact `27 × 9` matrix on
+   the matrix-unit basis. Verify complex rank `6`, nullity `3`, pivot
+   directions exactly the six off-diagonal matrix units, and kernel
+   exactly `span_C{E_11,E_22,E_33}`.
+7. **(L4) exact diagonal commutant.** Verify that
+   `diag(k_1,k_2,k_3)` with three independent complex parameters
+   commutes with every `T_μ`, including a non-Hermitian complex
+   diagonal commuting control. Hence the commutant is exactly `C^3`
+   and has complex dimension `3`.
+8. **Hostile coverage outside the old Hermitian ansatz.** Retain the
+   earlier Hermitian solve only as a secondary continuity check. Then
+   test the directed non-Hermitian matrix direction
+   `K = (1+2i)E_12`, for which `K_12 ≠ 0` but `K_21 = 0`, and a dense
+   complex non-Hermitian matrix with all six ordered off-diagonal
+   entries nonzero. Verify that the distinguishing commutators detect
+   these directions. This demonstrates missing coverage in the old
+   Hermitian certificate; it is not a counterexample to the theorem.
+9. **Non-distinct-spectrum boundary.** Replace the triple by
+   `T_1 = T_2 = T_3 = I`. Verify that the same dense non-diagonal
+   complex matrix then commutes with the triple and that every
+   separation weight vanishes, confirming that pairwise joint-spectrum
+   distinctness is load-bearing.
 
-Expected output: `PASS=N FAIL=0` with `N ≥ 14`.
+The previous Hermitian ansatz linked `K_βα` to the conjugate of
+`K_αβ` and restricted the diagonal entries to real values. It therefore
+covered only a 9-real-dimensional specialization of the
+18-real-dimensional complex matrix space quantified by (L2)-(L4).
+Its successful solve was consistent with the theorem but was not, by
+itself, an executable certificate of the universal complex-linear
+statement. The generic solve and independent complex rank/kernel
+calculation remove that coverage gap.
+
+Expected output: `PASS=N FAIL=0` with `N ≥ 50`.
 
 ## 10. Cross-references
 

--- a/logs/runner-cache/audit_companion_staggered_dirac_substep4_ac_lambda_simultaneous_diagonalization_bridge_2026_05_17.txt
+++ b/logs/runner-cache/audit_companion_staggered_dirac_substep4_ac_lambda_simultaneous_diagonalization_bridge_2026_05_17.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/audit_companion_staggered_dirac_substep4_ac_lambda_simultaneous_diagonalization_bridge_2026_05_17.py
-runner_sha256: 3705418d985d0b6097cd94a80b42d7460ef9a6447a292cb8ffdb8f6897d9932b
+runner_sha256: a48e63cb422f8558058bad63bd689e0c3aca74a556a8579a07fe202bb9e065a5
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.30
+elapsed_sec: 0.32
 status: ok
 ----- stdout -----
 === Substep-4 AC_lambda simultaneous-diagonalization bridge ===
@@ -84,13 +84,15 @@ status: ok
   PASS  diag(k1,k2,k3) commutes with T_2
   PASS  diag(k1,k2,k3) commutes with T_3
   PASS  commuting algebra has complex dimension 3
-  PASS  complex diagonal positive control is non-Hermitian
+  PASS  commuting complex diagonal control is non-Hermitian
   PASS  complex diagonal non-Hermitian control commutes with the full triple
   PASS  [diag(1,2,5), T_1] = 0
   PASS  [diag(1,2,5), T_2] = 0
   PASS  [diag(1,2,5), T_3] = 0
 
 [hostile complex controls]
+  PASS  directed E_12 control lies outside the previous Hermitian ansatz :: K_12 is nonzero while K_21 = 0
+  PASS  the full commutator mechanism rejects that non-Hermitian direction :: coverage outside the old ansatz, not a theorem counterexample
   PASS  dense hostile K is complex, non-Hermitian, and has all six off-diagonal entries nonzero
   PASS  every dense hostile off-diagonal entry is detected by the triple
   PASS  dense hostile K fails all three commutator equations :: nonzero counts = {1: 4, 2: 4, 3: 4}
@@ -101,7 +103,7 @@ status: ok
   PASS  coincident signatures have zero separation weight
 
 === Summary ===
-PASS=74 FAIL=0
+PASS=76 FAIL=0
 
 ----- stderr -----
 

--- a/scripts/audit_companion_staggered_dirac_substep4_ac_lambda_simultaneous_diagonalization_bridge_2026_05_17.py
+++ b/scripts/audit_companion_staggered_dirac_substep4_ac_lambda_simultaneous_diagonalization_bridge_2026_05_17.py
@@ -419,7 +419,7 @@ def main() -> int:
         4 - 5 * sp.I,
     )
     check(
-        "complex diagonal positive control is non-Hermitian",
+        "commuting complex diagonal control is non-Hermitian",
         not is_zero_matrix(K_complex_diagonal - dagger(K_complex_diagonal)),
     )
     check(
@@ -439,6 +439,27 @@ def main() -> int:
 
     # ----- Hostile deterministic complex controls -----
     print("\n[hostile complex controls]")
+    K_directed = sp.zeros(3, 3)
+    K_directed[0, 1] = 1 + 2 * sp.I
+    directed_commutators = {
+        mu: K_directed * T[mu] - T[mu] * K_directed
+        for mu in MUS
+    }
+    check(
+        "directed E_12 control lies outside the previous Hermitian ansatz",
+        K_directed[0, 1] != 0
+        and K_directed[1, 0] == 0
+        and not is_zero_matrix(K_directed - dagger(K_directed)),
+        detail="K_12 is nonzero while K_21 = 0",
+    )
+    check(
+        "the full commutator mechanism rejects that non-Hermitian direction",
+        not is_zero_matrix(directed_commutators[1])
+        and not is_zero_matrix(directed_commutators[2])
+        and is_zero_matrix(directed_commutators[3]),
+        detail="coverage outside the old ansatz, not a theorem counterexample",
+    )
+
     K_dense_hostile = sp.Matrix(
         [
             [1 + 2 * sp.I, 2 - sp.I, -3 + 4 * sp.I],


### PR DESCRIPTION
## Summary

- completes the executable certificate for the universal complex-linear commutant theorem by covering all nine independent complex entries of `K`
- updates the source validation text to describe the exact generic-complex solve, the complex rank/kernel certificate, and the free complex diagonal class
- adds a directed non-Hermitian `E_12` hostile coverage control and refreshes the SHA-pinned runner cache

## Existing audit finding

> The written algebraic argument covers arbitrary linear K, but the supplied runner parameterizes only a generic Hermitian K. Consequently, the advertised executable verification does not cover the theorem's full quantified scope.

Repair target:

> runner_artifact_issue: extend the runner to a fully generic complex K, rerun it, and re-audit the unchanged abstract theorem.

This PR closes that runner-artifact gap without changing the theorem's abstract scope. The theorem remains: every complex-linear operator on `C^3` commuting with the explicit diagonal unitary triple is diagonal, and the commutant is exactly `C^3`.

## Scope and boundary

- no physical-carrier, physical-propagator, species, or lattice-realization claim is added
- pairwise joint-spectrum distinctness, unitarity/commutation, the converse diagonal-class proof, and the non-distinct-spectrum counterexample are retained
- direct consumers were inspected; none assumes a Hermitian-only version of `K`, so no consumer source edit is needed
- trace classification: direct closure of the named runner-artifact repair target

## Validation

- target runner: `PASS=76 FAIL=0`
- runner SHA matches the cache pin: `a48e63cb422f8558058bad63bd689e0c3aca74a556a8579a07fe202bb9e065a5`
- fresh live stdout is byte-identical to the cached stdout payload
- independent exact `Fraction` verifier: complex rank `6`, nullity `3`, off-diagonal pivots exactly `E_12,E_13,E_21,E_23,E_31,E_32`, `FAIL=0`
- `python3 -m py_compile` passes
- `scripts/vocab_lint.py --fix` reports zero violations
- adversarial physics/math, runner/cache, and boundary/consumer review passes: PASS
- disposable audit-system compatibility pipeline plus strict lint: no errors; the repaired row becomes `unaudited` and appears in the ordinary audit queue; all generated outputs were deleted with the disposable worktree
- `git diff --check` passes

The broader common-carrier consumer runner has two pre-existing, unrelated species-reduction verbatim-text pin failures on current `main`; its AC_lambda-specific generic commutant and scope-boundary checks pass. This PR does not widen into that separate wording drift.

## Audit provenance

No audit was run. No audit verdict was applied. No durable audit ledger, queue, effective-status, or publication-status output is included in this PR. Independent post-merge audit remains required before the repository may re-ratify the claim.
