### PR TITLE
Close stale Wilson and Record P1 review-queue entries

### DIFF
--- a/docs/RECORD_P1_DEPENDENCY_AUDIT_NOTE_2026-06-04.md
+++ b/docs/RECORD_P1_DEPENDENCY_AUDIT_NOTE_2026-06-04.md
@@ -341,11 +341,11 @@ python3 scripts/frontier_record_p1_dependency_audit_verifier.py
 The verifier is a review-hygiene check, not a physics proof. It
 verifies:
 
-1. The audited pre-existing direct-dependent count of
-   `observable_principle_from_axiom_note` matches the audit's claimed total
-   (91), and the live post-PR count including this meta report is 92.
-2. The report's per-category lists cover exactly the live 91 direct
-   dependents, with no missing, extra, or duplicated paths.
+1. The frozen category lists and classification arithmetic account for exactly
+   the 91 rows in the 2026-06-04 historical snapshot, with no duplicates.
+2. The current tracked sharded ledger is observed separately: the verifier
+   checks that live direct dependents still exist and have source-note paths,
+   without equating the evolving live set to the frozen snapshot.
 3. The report declares that no source-note rewrites were made.
 4. The classification table accounts for every direct dependent
    (REWRITE + SPLIT + LEAVE = 91).

--- a/docs/RECORD_P1_DEPENDENCY_AUDIT_NOTE_2026-06-04.md
+++ b/docs/RECORD_P1_DEPENDENCY_AUDIT_NOTE_2026-06-04.md
@@ -50,11 +50,13 @@ must keep the old parent)?
 
 ## Method
 
-Direct dependents were enumerated from the live `origin/main` ledger before
-this meta report was added, by inspecting the `deps` array of every row in
-`docs/audit/data/audit_ledger.json` and selecting rows whose deps
-include `observable_principle_from_axiom_note`. The query returned 91
-rows.
+Direct dependents were enumerated from the then-current `origin/main` ledger
+snapshot before this meta report was added, by inspecting the `deps` array of
+every materialized row and selecting rows whose deps included
+`observable_principle_from_axiom_note`. The query returned 91 rows. That count
+belongs to the frozen 2026-06-04 snapshot; the current tracked source of truth
+is the sharded [`docs/audit/data/ledger/`](audit/data/ledger/) tree, whose live
+dependent count may evolve independently.
 
 The 91 rows were partitioned into six batches and each batch was read
 in full. For every note, the content cited from the old parent was
@@ -286,10 +288,12 @@ modified):
 | Direct dependents | 91 (UNCHANGED) |
 | `effective_status` distribution | UNCHANGED |
 
-The live post-PR ledger has 92 direct dependents if this meta report is counted,
-because the report itself cites the old parent it audits. The verifier excludes
-`record_p1_dependency_audit_note_2026-06-04` when checking the original audited
-population and separately checks that the live count including the report is 92.
+At the historical post-report snapshot, counting this meta report itself would
+have raised the direct-dependent total to 92 because the report cites the old
+parent it audits. That 92-row observation is historical, not a live invariant.
+The verifier excludes `record_p1_dependency_audit_note_2026-06-04` only when
+reporting the current direct dependents other than this report; it does not
+equate the evolving live count to either frozen value.
 
 This audit does not declare a new audit-ready subset. Readiness remains a
 pipeline/audit-queue property after the generated surfaces are recomputed.
@@ -327,8 +331,8 @@ pipeline/audit-queue property after the generated surfaces are recomputed.
   node registry; `observable_principle_from_axiom_note` is NOT in
   this file and must not be added.
 - [docs/audit/data/premise_decision_history.json](audit/data/premise_decision_history.json) — non-authoritative admission-era history;
-  `AC_phi_lambda` and other Tier-A admissions live here, not in
-  axiom-premise nodes.
+  former `AC_phi_lambda` and Tier-A decisions are preserved there as
+  provenance only and supply no premise authority.
 
 ## Validation
 
@@ -347,7 +351,7 @@ verifies:
    checks that live direct dependents still exist and have source-note paths,
    without equating the evolving live set to the frozen snapshot.
 3. The report declares that no source-note rewrites were made.
-4. The classification table accounts for every direct dependent
+4. The classification table accounts for every frozen-snapshot direct dependent
    (REWRITE + SPLIT + LEAVE = 91).
 5. `MINIMAL_AXIOMS_2026-06-04.md` is the cited new authority for the
    Record axiom.

--- a/docs/RECORD_P1_DEPENDENCY_AUDIT_NOTE_2026-06-04.md
+++ b/docs/RECORD_P1_DEPENDENCY_AUDIT_NOTE_2026-06-04.md
@@ -276,7 +276,7 @@ Direct dependents of `observable_principle_from_axiom_note` on
 | Direct dependents | 91 |
 | `effective_status = retained` among direct dependents | 0 |
 | `effective_status = retained_bounded` among direct dependents | 0 |
-| `effective_status = audited_clean` among direct dependents | 0 |
+| `audit_status = audited_clean` among direct dependents | 0 |
 | `effective_status = unaudited` among direct dependents | 81 |
 | `claim_type = meta` among direct dependents | 10 |
 

--- a/docs/repo/ACTIVE_REVIEW_QUEUE.md
+++ b/docs/repo/ACTIVE_REVIEW_QUEUE.md
@@ -50,23 +50,6 @@ Current science/open-lane follow-ups:
   Disposition: `fix on main`.
   Detail:
   [`CONFORMAL_CLASS_CAUSAL_SOURCE_PACKET_REVIEW_2026-07-09.md`](../work_history/repo/review_feedback/CONFORMAL_CLASS_CAUSAL_SOURCE_PACKET_REVIEW_2026-07-09.md)
-- `2026-07-10-wilson-plane-representation-ring-route`
-  Scope:
-  `AXIOM_FIRST_REFLECTION_POSITIVITY_WILSON_TEMPORAL_GAUGE_BRIDGE_NARROW_THEOREM_NOTE_2026-06-05.md`
-  and its companion runner.
-  Finding: the `SU(N>=3)` boundary omits a direct representation-ring proof:
-  expanding `exp[(beta/2N)(chi_R + chi_Rbar)]` gives positive powers of
-  `R direct-sum Rbar`, and tensor-power decomposition has nonnegative integer
-  irrep multiplicities. Replace the group-dependent obstruction language and
-  add a runner gate for this analytic route.
-  Disposition: `fix on main`.
-- `2026-07-10-record-p1-dependency-audit-drift`
-  Scope: `RECORD_P1_DEPENDENCY_AUDIT_NOTE_2026-06-04.md` and
-  `scripts/frontier_record_p1_dependency_audit_verifier.py`.
-  Finding: the live dependency graph no longer matches the frozen June 4
-  counts/classification; the runner now fails honestly, and PR #5115 refreshes
-  its previously stale-green cache without changing the content gate.
-  Disposition: `fix on main`.
 - `2026-07-10-acphilambda-retirement-rematch-drift`
   Scope: `ACPHILAMBDA_RETIREMENT_BASIS_REMATCH_AND_CLAIM_SURFACE_NOTE_2026-07-06.md`
   and `scripts/acphilambda_retirement_basis_rematch_claim_surface_2026_07_06.py`.
@@ -206,6 +189,20 @@ Record each new finding as one bullet:
   optional link to a longer packet in work history
 
 ## Queue History
+
+- `2026-07-10-wilson-plane-representation-ring-route`
+  Resolved on `main`: the repaired finite-volume `SU(N)` note proves
+  nonnegative Wilson character coefficients directly from tensor powers of
+  `F direct-sum Fbar`, and the companion adds exact normalization, `SU(3)`
+  fusion, positive-kernel, and wrong-sign gates. The direct runner reports
+  `25 PASS / 0 FAIL`, with a matching current cache SHA.
+
+- `2026-07-10-record-p1-dependency-audit-drift`
+  Resolved as a frozen-history contract: the 91-row June 4 classification is
+  no longer equated to the evolving live graph, and the verifier observes the
+  current tracked sharded ledger separately while preserving the no-rewrite,
+  no-alias, no-premise-insertion, and no-status-edit disciplines. The direct
+  runner passes on the clean current checkout and its cache is SHA-pinned.
 
 - `2026-07-16-uv-gauge-yukawa-direct-consumer-scope-drift`
   Repaired all seven unaudited direct consumers. The UV radius note now

--- a/logs/runner-cache/frontier_record_p1_dependency_audit_verifier.txt
+++ b/logs/runner-cache/frontier_record_p1_dependency_audit_verifier.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_record_p1_dependency_audit_verifier.py
-runner_sha256: 8d5270c47dcd20af53bb17ae6253a1d11d8f6929f489da32c7720158db1699d2
+runner_sha256: 87c52678e4e17566df32014aa2f394165797ef06e816ebfbc49705f5203c900b
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.38
+elapsed_sec: 0.31
 status: ok
 ----- stdout -----
 Record/P1 dependency audit re-derivation check
@@ -17,7 +17,7 @@ audit_note: docs/RECORD_P1_DEPENDENCY_AUDIT_NOTE_2026-06-04.md
 [PASS] source-path alias registry exists
 [PASS] live ledger still contains direct dependents of the historical parent  (current_observed=100)
 [PASS] all direct dependents have note_path entries  (paths=100, dependents=100)
-[PASS] live status observation completed without becoming snapshot authority  (current unaudited=87, meta=13, retained=0, retained_bounded=0, audited_clean=0)
+[PASS] live status observation completed without becoming snapshot authority  (current unaudited=87, meta=13, retained=0, retained_bounded=0, audit_status audited_clean=0)
 [PASS] observable_principle_from_axiom_note NOT in axiom-premise registry  (axiom_ids_sample=['kinetic_isotropy_primitive', 'minimal_axioms', 'realized_state_primitive'])
 [PASS] observable_principle_from_axiom_note NOT aliased to minimal_axioms  (premise_registry=False, source_path_aliases=False, ledger_row=False)
 [PASS] audit note declares no source-citation rewrites

--- a/logs/runner-cache/frontier_record_p1_dependency_audit_verifier.txt
+++ b/logs/runner-cache/frontier_record_p1_dependency_audit_verifier.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_record_p1_dependency_audit_verifier.py
-runner_sha256: 9df0372ba6ecef242fc9b936443290d73b170010f432a8eb4fc72778b00f93f5
+runner_sha256: faa1b13808a9fb20be8ddb2937771466cfe5518d4bb4a6495beaa370a06953ae
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.20
+elapsed_sec: 0.50
 status: ok
 ----- stdout -----
 Record/P1 dependency audit re-derivation check
@@ -12,7 +12,7 @@ audit_note: docs/RECORD_P1_DEPENDENCY_AUDIT_NOTE_2026-06-04.md
 [PASS] audit note exists
 [PASS] MINIMAL_AXIOMS_2026-06-04.md exists on disk
 [PASS] OBSERVABLE_PRINCIPLE_FROM_AXIOM_NOTE.md exists on disk
-[PASS] audit ledger exists
+[PASS] audit ledger source exists  (sharded=True, legacy_cache=True)
 [PASS] axiom-premise registry exists
 [PASS] live ledger still contains direct dependents of the historical parent  (current_observed=100)
 [PASS] all direct dependents have note_path entries  (paths=100, dependents=100)

--- a/logs/runner-cache/frontier_record_p1_dependency_audit_verifier.txt
+++ b/logs/runner-cache/frontier_record_p1_dependency_audit_verifier.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_record_p1_dependency_audit_verifier.py
-runner_sha256: faa1b13808a9fb20be8ddb2937771466cfe5518d4bb4a6495beaa370a06953ae
+runner_sha256: 8d5270c47dcd20af53bb17ae6253a1d11d8f6929f489da32c7720158db1699d2
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.50
+elapsed_sec: 0.38
 status: ok
 ----- stdout -----
 Record/P1 dependency audit re-derivation check
@@ -14,11 +14,12 @@ audit_note: docs/RECORD_P1_DEPENDENCY_AUDIT_NOTE_2026-06-04.md
 [PASS] OBSERVABLE_PRINCIPLE_FROM_AXIOM_NOTE.md exists on disk
 [PASS] audit ledger source exists  (sharded=True, legacy_cache=True)
 [PASS] axiom-premise registry exists
+[PASS] source-path alias registry exists
 [PASS] live ledger still contains direct dependents of the historical parent  (current_observed=100)
 [PASS] all direct dependents have note_path entries  (paths=100, dependents=100)
 [PASS] live status observation completed without becoming snapshot authority  (current unaudited=87, meta=13, retained=0, retained_bounded=0, audited_clean=0)
 [PASS] observable_principle_from_axiom_note NOT in axiom-premise registry  (axiom_ids_sample=['kinetic_isotropy_primitive', 'minimal_axioms', 'realized_state_primitive'])
-[PASS] observable_principle_from_axiom_note NOT aliased to minimal_axioms
+[PASS] observable_principle_from_axiom_note NOT aliased to minimal_axioms  (premise_registry=False, source_path_aliases=False, ledger_row=False)
 [PASS] audit note declares no source-citation rewrites
 [PASS] audit note declares no source-note text modifications
 [PASS] audit note declares no audit_status edits
@@ -45,7 +46,7 @@ audit_note: docs/RECORD_P1_DEPENDENCY_AUDIT_NOTE_2026-06-04.md
 [PASS] audit note explicitly prohibits adding old to axiom_premise_nodes
 [PASS] audit note explicitly states 'no row was broadened'
 
-TOTAL: PASS=35 FAIL=0
+TOTAL: PASS=36 FAIL=0
 Record/P1 dependency audit verifier passed: frozen 91-row snapshot internally enumerated and classified LEAVE; current ledger observed separately; no source citations rewritten, no aliasing, no axiom-premise insertion, no audit_status edits, blocking-content categories sum to 91, status authority preserved.
 
 ----- stderr -----

--- a/scripts/frontier_record_p1_dependency_audit_verifier.py
+++ b/scripts/frontier_record_p1_dependency_audit_verifier.py
@@ -26,6 +26,12 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 LEDGER = ROOT / "docs" / "audit" / "data" / "audit_ledger.json"
+AUDIT_SCRIPTS = ROOT / "docs" / "audit" / "scripts"
+if str(AUDIT_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(AUDIT_SCRIPTS))
+
+import ledger_io
+
 AXIOM_NODES = ROOT / "docs" / "audit" / "data" / "axiom_premise_nodes.json"
 DECISION_HISTORY = ROOT / "docs" / "audit" / "data" / "premise_decision_history.json"
 AUDIT_NOTE = ROOT / "docs" / "RECORD_P1_DEPENDENCY_AUDIT_NOTE_2026-06-04.md"
@@ -94,11 +100,21 @@ def main() -> int:
     check("MINIMAL_AXIOMS_2026-06-04.md exists on disk", MIN_AXIOMS.exists())
     check("OBSERVABLE_PRINCIPLE_FROM_AXIOM_NOTE.md exists on disk",
           OBSERVABLE_PRINCIPLE.exists())
-    check("audit ledger exists", LEDGER.exists())
+    ledger_source_exists = ledger_io.sharded() or LEDGER.exists()
+    check(
+        "audit ledger source exists",
+        ledger_source_exists,
+        detail=f"sharded={ledger_io.sharded()}, legacy_cache={LEDGER.exists()}",
+    )
     check("axiom-premise registry exists", AXIOM_NODES.exists())
 
     # ---- ledger queries ----
-    rows = json.loads(LEDGER.read_text())["rows"]
+    if not ledger_source_exists:
+        print()
+        print(f"TOTAL: PASS={len(PASSES)} FAIL={len(FAILS)}")
+        return 1
+    ledger_payload = ledger_io.load_ledger()
+    rows = ledger_payload["rows"]
     live_direct_dependents = [
         (cid, row) for cid, row in rows.items()
         if OLD_PARENT_CID in (row.get("deps") or [])
@@ -163,7 +179,7 @@ def main() -> int:
           detail=f"axiom_ids_sample={sorted(axiom_ids)[:3]}")
 
     # Search whole ledger for an alias mapping old -> minimal_axioms
-    ledger_text = LEDGER.read_text()
+    ledger_text = json.dumps(ledger_payload, sort_keys=True)
     forbidden_alias = (
         '"observable_principle_from_axiom_note"' in ledger_text
         and '"minimal_axioms"' in ledger_text

--- a/scripts/frontier_record_p1_dependency_audit_verifier.py
+++ b/scripts/frontier_record_p1_dependency_audit_verifier.py
@@ -141,18 +141,21 @@ def main() -> int:
     # Status breakdown
     from collections import Counter
     es_counts = Counter(row.get("effective_status") for _, row in direct_dependents)
+    as_counts = Counter(row.get("audit_status") for _, row in direct_dependents)
     ct_counts = Counter(row.get("claim_type") for _, row in direct_dependents)
     unaudited_count = es_counts.get("unaudited", 0)
     meta_count = ct_counts.get("meta", 0)
     retained_count = es_counts.get("retained", 0)
     retained_bounded_count = es_counts.get("retained_bounded", 0)
-    audited_clean_count = es_counts.get("audited_clean", 0)
+    audited_clean_count = as_counts.get("audited_clean", 0)
 
     check("live status observation completed without becoming snapshot authority",
-          sum(es_counts.values()) == n_direct and sum(ct_counts.values()) == n_direct,
+          sum(es_counts.values()) == n_direct
+          and sum(as_counts.values()) == n_direct
+          and sum(ct_counts.values()) == n_direct,
           detail=(f"current unaudited={unaudited_count}, meta={meta_count}, "
                   f"retained={retained_count}, retained_bounded={retained_bounded_count}, "
-                  f"audited_clean={audited_clean_count}"))
+                  f"audit_status audited_clean={audited_clean_count}"))
 
     # ---- discipline: no aliasing, no axiom-premise insertion ----
     axiom_data = json.loads(AXIOM_NODES.read_text())

--- a/scripts/frontier_record_p1_dependency_audit_verifier.py
+++ b/scripts/frontier_record_p1_dependency_audit_verifier.py
@@ -33,6 +33,7 @@ if str(AUDIT_SCRIPTS) not in sys.path:
 import ledger_io
 
 AXIOM_NODES = ROOT / "docs" / "audit" / "data" / "axiom_premise_nodes.json"
+SOURCE_PATH_ALIASES = ROOT / "docs" / "audit" / "data" / "source_path_aliases.json"
 DECISION_HISTORY = ROOT / "docs" / "audit" / "data" / "premise_decision_history.json"
 AUDIT_NOTE = ROOT / "docs" / "RECORD_P1_DEPENDENCY_AUDIT_NOTE_2026-06-04.md"
 MIN_AXIOMS = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-04.md"
@@ -69,7 +70,7 @@ def parse_category_lists(audit_text: str) -> dict[str, list[str]]:
 
     This is intentionally mechanical: the report is the durable semantic
     classification, while this runner verifies that the accounting in that
-    report covers exactly the live direct-dependent set.
+    report covers exactly the frozen 91-row historical snapshot.
     """
     categories: dict[str, list[str]] = {}
     current: str | None = None
@@ -107,6 +108,7 @@ def main() -> int:
         detail=f"sharded={ledger_io.sharded()}, legacy_cache={LEDGER.exists()}",
     )
     check("axiom-premise registry exists", AXIOM_NODES.exists())
+    check("source-path alias registry exists", SOURCE_PATH_ALIASES.exists())
 
     # ---- ledger queries ----
     if not ledger_source_exists:
@@ -178,15 +180,46 @@ def main() -> int:
           OLD_PARENT_CID not in axiom_ids,
           detail=f"axiom_ids_sample={sorted(axiom_ids)[:3]}")
 
-    # Search whole ledger for an alias mapping old -> minimal_axioms
-    ledger_text = json.dumps(ledger_payload, sort_keys=True)
-    forbidden_alias = (
-        '"observable_principle_from_axiom_note"' in ledger_text
-        and '"minimal_axioms"' in ledger_text
-        and '"alias_of": "minimal_axioms"' in ledger_text
+    # Inspect the tracked alias authority surfaces directly. The sharded ledger
+    # payload does not contain source-path aliases, so a whole-ledger text
+    # search would not test the actual laundering routes.
+    old_parent_path = str(OBSERVABLE_PRINCIPLE.relative_to(ROOT))
+    minimal_node = (
+        axiom_nodes.get("minimal_axioms", {})
+        if isinstance(axiom_nodes, dict)
+        else {}
     )
-    check("observable_principle_from_axiom_note NOT aliased to minimal_axioms",
-          not forbidden_alias)
+    minimal_paths = {
+        minimal_node.get("current_path"),
+        *(minimal_node.get("aliased_paths") or []),
+    }
+    minimal_paths.discard(None)
+    premise_alias_hit = (
+        old_parent_path in (minimal_node.get("aliased_paths") or [])
+        or OLD_PARENT_CID in (minimal_node.get("legacy_claim_ids") or [])
+    )
+
+    alias_payload = json.loads(SOURCE_PATH_ALIASES.read_text())
+    source_aliases = alias_payload.get("aliases") or {}
+    resolved_path = old_parent_path
+    seen_paths: set[str] = set()
+    while resolved_path in source_aliases and resolved_path not in seen_paths:
+        seen_paths.add(resolved_path)
+        resolved_path = source_aliases[resolved_path]
+    source_alias_hit = resolved_path in minimal_paths
+
+    old_parent_row = rows.get(OLD_PARENT_CID) or {}
+    ledger_alias_hit = old_parent_row.get("alias_of") == "minimal_axioms"
+    forbidden_alias = premise_alias_hit or source_alias_hit or ledger_alias_hit
+    check(
+        "observable_principle_from_axiom_note NOT aliased to minimal_axioms",
+        not forbidden_alias,
+        detail=(
+            f"premise_registry={premise_alias_hit}, "
+            f"source_path_aliases={source_alias_hit}, "
+            f"ledger_row={ledger_alias_hit}"
+        ),
+    )
 
     # ---- discipline: this audit did NOT edit any of the 91 listed source notes ----
     # Verified by checking that the audit note + verifier + cache are the only


### PR DESCRIPTION
## Summary

- Move exactly the Wilson plane representation-ring route and Record/P1 dependency-audit drift entries from the active review list to Queue History.
- Record the merged Wilson `SU(N)` repair evidence from PR #5405: a direct representation-ring proof plus exact normalization, `SU(3)` fusion, kernel-positivity, and wrong-sign runner gates.
- Preserve the Record/P1 June 4 result as a frozen 91-row historical classification while observing the evolving live dependency graph separately.
- Repair the named Record/P1 verifier's clean-checkout portability after ledger sharding by reading the tracked shard source through `ledger_io`, align the note's Validation contract, and refresh only its SHA-pinned cache.

No other active queue item, science result, audit verdict, or audit status authority is changed.

## Evidence

- Wilson repair history: `695416d048` through `9ab13a8034`, merged in #5405.
- Record/P1 frozen-history repair: `10f9c50a71`; the direct runner now also works without the untracked monolithic ledger cache.
- Wilson current runner/cache SHA: `90c5a959f72e4ee9f6236af0c6305fa4a803671acb75bce2388e22cd2919193c`.
- Record/P1 current runner/cache SHA: `87c52678e4e17566df32014aa2f394165797ef06e816ebfbc49705f5203c900b`.

## Verification

- `python3 scripts/audit_companion_reflection_positivity_wilson_temporal_gauge_2026_06_05.py` — `25 PASS / 0 FAIL`.
- `python3 scripts/frontier_record_p1_dependency_audit_verifier.py` — `36 PASS / 0 FAIL`; observes 100 current direct dependents separately from the frozen 91-row snapshot.
- `python3 scripts/frontier_repo_active_review_queue_hostile_audit_findings.py` — `2 PASS / 0 FAIL`.
- `python3 docs/audit/scripts/repo_invariants_check.py --check` — passes; reports only the existing warn-only references to intentionally untracked generated audit caches.
- `python3 scripts/precompute_audit_runners.py --runners scripts/audit_companion_reflection_positivity_wilson_temporal_gauge_2026_06_05.py,scripts/frontier_record_p1_dependency_audit_verifier.py --check-only --allow-non-main` — both caches fresh.
- `python3 -m py_compile scripts/frontier_record_p1_dependency_audit_verifier.py`.
- `git diff --check`.

Audit workers, `codex_audit_runner.py`, `apply_audit.py`, and audit-verdict application were not run.


