### PR TITLE
feat(flavor): decompose W1b sharpening import into reflection asymmetry + orientation binary

### DIFF
--- a/docs/ACPHILAMBDA_OCCUPANCY_GRAIN_SHARPENING_IMPORT_DECOMPOSITION_REFLECTION_ASYMMETRY_ORIENTATION_DICHOTOMY_BOUNDED_THEOREM_NOTE_2026-07-16.md
+++ b/docs/ACPHILAMBDA_OCCUPANCY_GRAIN_SHARPENING_IMPORT_DECOMPOSITION_REFLECTION_ASYMMETRY_ORIENTATION_DICHOTOMY_BOUNDED_THEOREM_NOTE_2026-07-16.md
@@ -1,0 +1,549 @@
+# Occupancy-Grain Sharpening-Import Decomposition: Reflection-Asymmetry and Orientation Dichotomy over the Declared Record-Influence Class: Bounded Theorem
+
+claim id: `acphilambda_occupancy_grain_sharpening_import_decomposition_reflection_asymmetry_orientation_dichotomy_bounded_theorem_note_2026-07-16`
+
+**Date:** 2026-07-16
+**Type:** bounded_theorem
+**Claim type:** bounded_theorem
+**Premise weight:** conditional. Every claim below is conditional on the declared readings named in this note and on the consumed sources at exactly the live grades listed in Load-bearing dependencies. Nothing consumed is upgraded here, and no derivation obligation is discharged here.
+**Status authority:** independent audit lane only. This source note does not set or predict an audit outcome.
+**Primary runner:** [`scripts/acphilambda_sharpening_import_decomposition_2026_07_16.py`](../scripts/acphilambda_sharpening_import_decomposition_2026_07_16.py)
+**Cache:** [`logs/runner-cache/acphilambda_sharpening_import_decomposition_2026_07_16.txt`](../logs/runner-cache/acphilambda_sharpening_import_decomposition_2026_07_16.txt)
+
+## Purpose
+
+The occupancy-grain rule-class universality note consumes one strict-sharpening
+import at its L3: the majority-amplification hypothesis
+`T_f(q) < q for 0<q<1/2, T_f(q) > q for 1/2<q<1`. This note takes that single
+import apart over the same declared 2-cell record-influence class and proves,
+exactly, that it carries two logically separate contents:
+
+1. a **reflection-asymmetry** content — the per-weight influence profile
+   (declared `g` in D1) must be reflection-asymmetric on the interior (a
+   note-local class written `A` below), which is what keeps the durable
+   weight set on the closed cell equal to `{0, 1/2, 1}` — interior durable
+   weight exactly `{1/2}` — and blocks any extra off-center durable weight; and
+2. an **orientation** content — among reflection-asymmetric profiles, the
+   majority-amplifying orientation (a note-local subclass written `A+`) versus
+   the majority-attenuating orientation (`A-`) is a separate binary that the
+   fixed-point set alone does not fix; it fixes only the stability/selection
+   mode near the interior weight.
+
+The reflection-asymmetry content is stated as an exact characterization of the
+interior fixed set (T1 with T5(i)); the orientation content is a disjoint
+dichotomy `A = A+ ⊔ A-` on top of it (T2, T5(ii)). Two exact
+piecewise-linear witnesses make the separation load-bearing: an amplifying
+member with a non-monotone per-weight influence profile that sits in `A+` but
+not in the monotone-profile subclass `M`, and a reflection-symmetry-broken
+boundary member outside `A` that carries an extra off-center fixed point at
+`q = 17/22`. The identity member `f(q) = q` is the non-recording control with
+`T_f = q` identically.
+
+The four framework axioms (Lattice, Qubit, Admissibility, Record) supply
+neither content: a choice not fixed by the supplied structure remains a named
+conditional or open dependency. This note quantifies over the declared class;
+it selects no profile, no weight, and no dial value, and it discharges no part
+of the open grain derivation obligation.
+
+Record ontology throughout: a supplied registered weight is called durable
+exactly when the declared continued-registration update leaves it stationary,
+as in the consumed note's permanence-to-stationarity reading. No formation,
+occurrence, convergence, or pre-record readout is inferred.
+
+## Supplied objects and consumed readings
+
+1. **The declared record-influence class (2-cell form)**, consumed from the
+   occupancy-grain rule-class universality note (unaudited `bounded_theorem`).
+   That note's declared reading states, verbatim, that
+
+   > "the normalized record influence of a continued-registration rule in that class has the form"
+
+   ```text
+   T_f(q) = f(q) / (f(q)+f(1-q)),
+   f : [0,1] -> [0,1],
+   f continuous and strictly increasing,  f(0)=0.
+   ```
+
+   with `T_f` extended to the endpoints by its limits `T_f(0) = 0`,
+   `T_f(1) = 1`. This note calls the set of all such `f` the family `F`.
+
+2. **The strict-sharpening meaning consumed at that note's L3.** The consumed
+   note frames it, verbatim:
+
+   > For this lemma, **strict sharpening** has its majority-amplification meaning:
+
+   followed verbatim by
+
+   ```text
+   T_f(q) < q  for 0<q<1/2,
+   T_f(q) > q  for 1/2<q<1.
+   ```
+
+   This is the single import decomposed below.
+
+3. **The consumed scope boundary** of that note, verbatim:
+
+   > L3 uses off-center majority amplification as strict sharpening. Bare monotonicity of the influence odds is insufficient, as N2 shows.
+
+   The parent's "influence odds" is its own object, defined there verbatim:
+
+   > with input odds `O(q)=q/(1-q)` and influence odds `F(q)=f(q)/f(1-q)`
+
+   (the parent's symbols; this note's family symbol `F` is unrelated, and the
+   parent's `O`, `F(q)` are not used below).
+
+   The present decomposition sharpens exactly this sentence: it separates the
+   reflection-asymmetry content that governs the interior fixed set from the
+   orientation content, and it re-exhibits the N2 identity member as the
+   non-recording control.
+
+4. **The consumed Record clauses**, from the framework axiom memo (a `meta`
+   axiom note; depending on an axiom confers no bounded status). Verbatim:
+
+   > When present, a record locks exactly one admissible local possibility. A site never carries more than one record; records are permanent.
+
+   and
+
+   > Only records are readable. A readout value is determined by record content alone.
+
+   The permanence-to-stationarity reading — a durably registered interior
+   weight must be a fixed point of every admissible continued-registration
+   update — is consumed as a declared reading exactly as in the parent note's
+   L1; it is not re-derived here.
+
+5. **The consumed qualification clause**, from the same axiom memo, verbatim:
+
+   > A choice not fixed by the supplied structure remains a named conditional or open dependency.
+
+   This is the exact sense in which the two decomposed contents are named
+   conditionals, not axiom consequences (T5).
+
+6. **The weight-to-dial translation**, consumed from the parent note's L3,
+   verbatim in its own derivation:
+
+   ```text
+   p_d = P_d/(P_s+P_d)
+       = 2|b|^2/(a^2+2|b|^2)
+       = 2r/(1+2r).
+   ```
+
+   Through this supplied translation the central interior weight `q = 1/2`
+   corresponds to the dial setting `r = 1/2`. The translation is supplied
+   context only; nothing here forces, derives, or prefers that dial setting.
+
+## Declared symbols D1
+
+The following are note-local symbols for the declared class, in the same
+declared-reading discipline as the parent note's L2/L3 — plain descriptors for
+this note, not proposed framework vocabulary or registry coinages.
+
+> **D1.** On `(0,1]` write the per-weight influence profile `g(x) := f(x)/x`,
+> so that `f(x) = x g(x)` and `g` is continuous with `g > 0`. This is a
+> note-local object, distinct from the parent note's influence odds (the ratio
+> `f(q)/f(1-q)`, quoted in Supplied objects item 3); no claim below is a claim
+> about that ratio. Write the **reflection asymmetry**
+> `h(q) := g(q) - g(1-q)` on `(0,1)` (the sign convention is note-local); it
+> is reflection-odd, `h(1-q) = -h(q)`, so `h(1/2) = 0`. Over the family `F`
+> declare the note-local classes
+>
+> ```text
+> A  := { f in F : h != 0 on (0,1) except at q = 1/2 },        (reflection-asymmetric)
+> A+ := { f in A : h > 0 on (1/2,1) },                         (majority-amplifying)
+> A- := { f in A : h < 0 on (1/2,1) },                         (majority-attenuating)
+> M  := { f in F : g strictly increasing on (0,1] }.           (monotone per-weight influence)
+> ```
+
+Three honesty facts about D1; the runner re-proves the identities and witness
+separations exactly, and fact 3's forward inclusions are one-line consequences
+of D1 shown in place:
+
+1. **The reflection asymmetry `h` is exactly the interior fixed-point control.**
+   With `f(x) = x g(x)`, the exact identity of T1 makes the numerator of
+   `T_f(q) - q` equal `q(1-q) h(q)`, so an interior weight is fixed if and only
+   if `h` vanishes there. `A`-membership is precisely the condition that `h` has
+   no interior zero other than `q = 1/2`.
+
+2. **Orientation is a second, separate binary.** Among `A` members, the sign of
+   `h` on `(1/2,1)` splits `A` into `A+` and `A-` disjointly (T2). The fixed
+   set on the closed cell is `{0, 1/2, 1}` for both orientations; the
+   orientation changes only the stability/selection mode near `q = 1/2`, not
+   the fixed set.
+
+3. **The ladder is strict.** `M ( A+ ( A ( F`. The forward inclusions are
+   one-line consequences of D1: if `g` is strictly increasing, then for
+   `q in (1/2,1)` one has `q > 1-q`, so `h(q) = g(q) - g(1-q) > 0`, and by
+   reflection-oddness `h < 0` on `(0,1/2)`; hence `h` has no interior zero off
+   the center, giving `M => A+` (`A`-membership and the `+` orientation
+   together). `A+ ( A ( F` are restrictions by definition. Each inclusion is
+   proper, separated by an exact witness (T4); the runner additionally gates
+   the affine-subfamily mechanism identity `h(q) = c1(2q - 1)` exactly.
+
+## T1 (reflection-asymmetry fixed-point identity)
+
+> **T1.** For every `f in F`, the exact identity
+>
+> ```text
+> f(q)(1-q) - q f(1-q) = q(1-q) [ g(q) - g(1-q) ] = q(1-q) h(q)
+> ```
+>
+> holds, and it is the numerator of `T_f(q) - q`. Hence on `(0,1)` the
+> interior fixed points of `T_f` are exactly the interior zeros of `h`. The
+> interior fixed set is `{1/2}` — equivalently `Fix(T_f) = {0, 1/2, 1}` on the
+> closed cell — if and only if `f in A`. This interior-fixed-set equivalence is
+> the exact-characterization content isolated in T5(i).
+
+*Reading.* The endpoints `0` and `1` are fixed for every `f in F` by
+`f(0) = 0` and strict increase, exactly as in the parent note. The interior
+story is governed entirely by `h`: a reflection-asymmetric profile keeps a
+single interior fixed weight at the center, while any interior zero of `h` off
+the center is an extra off-center durable weight (N1).
+
+Runner: block `T1_FIXED_POINT` proves the identity symbolically for a generic
+profile, checks that the numerator of `T_f(q) - q` equals `f(q)(1-q) - q f(1-q)`,
+solves the interior fixed condition exactly for the power members `f = q^2` and
+`f = q^3` (interior fixed set `{1/2}` in each case), and confirms the endpoint
+limit extensions `T_f(0) = 0`, `T_f(1) = 1`.
+
+## T2 (sign bridge and orientation dichotomy)
+
+> **T2.** For every `f in F` and interior `q`,
+>
+> ```text
+> T_f(q) - q = q(1-q) h(q) / ( f(q) + f(1-q) ),
+> ```
+>
+> and since `f(0) = 0` with strict increase gives `f > 0` on `(0,1]`, the
+> factor `q(1-q)/(f(q)+f(1-q))` is strictly positive on the interior, giving
+> the sign bridge
+> `sign(T_f(q) - q) = sign(h(q))`. Consequently `A = A+ ⊔ A-` disjointly:
+> a reflection-asymmetric profile is either majority-amplifying (`T_f(q) > q`
+> for `q > 1/2`) or majority-attenuating (`T_f(q) < q` for `q > 1/2`), never
+> both. The class also satisfies the exchange symmetry `T_f(1-q) = 1 - T_f(q)`
+> and the central slope `T_f'(1/2) = f'(1/2) / (2 f(1/2))`; for the power
+> member `f = q^k` the central slope is exactly `k`.
+
+*Reading.* The sign bridge is what turns the parent note's L3 inequality into a
+statement about `h`. Majority amplification (the L3 orientation) is exactly
+`h > 0` on `(1/2,1)`, i.e. membership in `A+`. Attenuation is `A-`. Both keep
+the interior fixed set at the center; the orientation is a genuinely separate
+choice, invisible to the fixed-point count and fixed only by the mode content
+of the L3 import.
+
+Runner: block `T2_SIGN_BRIDGE` proves the full-quotient identity symbolically,
+checks strict positivity of the denominator at a rational sample for two
+members (the class-level positivity is the one-line `f > 0` fact in the box),
+proves the exchange symmetry and the central-slope formula symbolically, and
+confirms the central slope equals `k` for `k = 1/2`, `k = 2`, and symbolic
+`k > 0`.
+
+## T3 (off-center orientation horn) and orbit behaviour
+
+> **T3.** For `f in A+`, off-center amplification holds strictly:
+> `T_f(q) > q` on `(1/2,1)` and `T_f(q) < q` on `(0,1/2)`. The abstract
+> continued-registration orbit `q_{n+1} = T_f(q_n)` from any `q_0 in (1/2,1)`
+> is strictly increasing, stays in `(1/2,1)`, and converges upward with limit
+> `1`. For `f in A-` the strict inequalities reverse and the orbit from
+> `q_0 in (1/2,1)` is strictly decreasing, stays in `(1/2,1)`, and converges
+> downward with limit `1/2`.
+
+*Derivation of the orbit statements.* Confinement: since `f` is strictly
+increasing, `T_f(q) - 1/2 = (f(q) - f(1-q)) / (2(f(q) + f(1-q)))` has the sign
+of `q - 1/2`, so `(1/2,1)` maps into `(1/2,1)` (and `T_f(q) < 1` because
+`f(1-q) > 0` for `q < 1`). A monotone orbit confined to a bounded interval
+converges; on `[1/2,1]` the denominator satisfies
+`f(q) + f(1-q) >= f(1/2) > 0`, so `T_f` is continuous there and the limit is a
+fixed point of `T_f` in `[1/2,1]`, which by T1 lies in `{1/2, 1}`. An `A+`
+orbit is strictly increasing from `q_0 > 1/2`, so its limit is `1`; an `A-`
+orbit is strictly decreasing and stays above `1/2`, so its limit is `1/2`.
+
+*Reading.* Orientation is what selects which side of the central weight the
+recording update pushes toward. This is the stability/selection-mode content of
+the L3 import; the interior fixed set is the same `{0, 1/2, 1}` in both
+orientations. Durability throughout is stationarity, not attraction: the horn
+statements describe the one-step and iterated direction and its limit, and the
+selection mode is a distinguished stationary weight in the sense of the
+stationary-point-not-forced anchor (`retained_bounded`).
+
+Runner: block `T3_HORN` checks off-center amplification `T_f(q) > q` at
+`q = 3/5` for four `A+` members (`q^2`, `q^3`, `q^4`, `q + q^2`) and the mirror
+minority attenuation `T_f(2/5) < 2/5` for `q^2`. Block `ORBITS` iterates the
+`A+` exemplar `f = q^2` from `q_0 = 3/5` (six exact-rational steps, strictly
+increasing, staying in `(1/2,1)`, closing gap to `1` below `1/1000`) and the
+`A-` exemplar `f = sqrt(q)` from `q_0 = 3/4` (six exact-radical steps, strictly
+decreasing, staying above `1/2`, closing gap to `1/2` below `1/100`), with all
+radicals kept exact, and solves the `A-` exemplar's interior fixed set exactly
+(`{1/2}` on `(0,1)`).
+
+## T4 (strict ladder `M ( A+ ( A ( F`)
+
+> **T4.** The note-local classes form a strict ladder
+> `M ( A+ ( A ( F`. Each inclusion is proper, witnessed exactly:
+> the amplifying witness of N0 lies in `A+` but not in `M` (its per-weight
+> influence profile `g` is non-monotone); the member `f = sqrt(q)` lies in
+> `A-`, hence in `A` but not in `A+` and not in `M`; and the identity member
+> `f = q` lies in `F` but not in `A` (its `h` is identically zero), as does
+> the sign-mixed witness `B` of N1.
+
+Runner: block `LADDER` checks the affine-subfamily mechanism identity
+`h(q) = c1 (2q - 1)` symbolically; the non-monotone per-weight profile of the
+N0 witness (`g(1/2) < g(1/4)`) together with `h > 0` at interior samples of
+`(1/2,1)`; the exact derivative `g'(x) = -x^(-3/2)/2 < 0` for `f = sqrt(q)`
+(not in `M`) with an exact conjugate certificate that `h < 0` on `(1/2,1)`
+(in `A-`); the identically-zero `h` of the identity member (in `F`, not in
+`A`); and witness `B`'s exact off-center zero `h(17/22) = 0` (in `F`, not in
+`A`).
+
+## T5 (sharpening-import decomposition)
+
+> **T5.** Over the declared family `F`, the single strict-sharpening import of
+> the parent note's L3 decomposes into two logically separate contents:
+>
+> - **(i) reflection asymmetry** — `f in A`. By T1 this is `necessary and
+>   sufficient` for the interior durable weight set to be exactly `{1/2}`
+>   (no off-center durable weight). Sufficiency and necessity are the two
+>   directions of the T1 zero-of-`h` identity.
+> - **(ii) orientation** — `f in A+` rather than `A-`. By T2 this is a separate
+>   disjoint binary on top of (i); it does not change the interior fixed set and
+>   fixes only the stability/selection mode near `q = 1/2`.
+>
+> The parent note's L3 imports (i) and (ii) together. The four framework axioms
+> supply neither: a choice not fixed by the supplied structure remains a named
+> conditional or open dependency.
+
+The two contents are made load-bearing by exact witnesses in the following
+sections (N0–N2): the N0 member exhibits `A+` without `M`, a sign-mixed
+boundary member outside `A` (N1) shows (i) is load-bearing (an extra
+off-center fixed point appears), and the amplifying/attenuating split shows
+(ii) is not implied by (i).
+
+## N0 (amplifying witness, in `A+` but not in `M`)
+
+Define `g` piecewise linear on `[0,1]` with node values
+
+```text
+g(0) = 1/2,  g(1/4) = 3/5,  g(1/2) = 11/20,  g(3/4) = 4/5,  g(1) = 9/10,
+```
+
+on the pieces `[0,1/4]`, `[1/4,1/2]`, `[1/2,3/4]`, `[3/4,1]` (linear on each),
+and set `f(x) = x g(x)`. The runner names this member `WITNESS_A`; the letter
+names the witness, not the class `A`. Exact facts, all re-proven by runner
+block `WITNESS_A`:
+
+- **The witness is in the family `F`.** `f` is continuous with `f(0) = 0` and
+  `f(1) = 9/10 <= 1`, and strictly increasing: on each linear piece
+  `g = a + b x` the derivative `f' = a + 2 b x` is positive at both piece
+  endpoints, so positive throughout.
+- **The witness is in `A+`.** Exactly and on both pieces of `(1/2,1)` the same
+  affine formula holds,
+
+  ```text
+  h(q) = 4q/5 - 2/5   on (1/2, 1),
+  ```
+
+  which is strictly positive there (e.g. `h(7/8) = 3/10`) and vanishes only at
+  the center, so `h` has no interior zero off `q = 1/2` and is positive on the
+  majority side.
+- **The witness is not in `M`.** `g(1/4) = 3/5 > 11/20 = g(1/2)`, so the
+  per-weight influence profile is non-monotone while the member still
+  amplifies the majority. This is the exact separation `M ( A+` used in T4.
+
+Reading: orientation (content (ii)) does not require a monotone per-weight
+profile. Amplification is controlled by the reflection asymmetry `h` alone,
+which compares `g` across the reflection `q <-> 1-q` and is insensitive to
+`g`'s behaviour within a side.
+
+## N1 (sign-mixed boundary witness `B`, extra fixed point `q = 17/22`)
+
+Define `g` piecewise linear on `[0,1]` with node values
+
+```text
+g(0) = 1/2,  g(1/4) = 7/10,  g(1/2) = 3/5,  g(3/4) = 13/20,  g(1) = 1,
+```
+
+on the pieces `[0,1/4]`, `[1/4,1/2]`, `[1/2,3/4]`, `[3/4,1]` (linear on each),
+and set `f(x) = x g(x)`. Exact facts, all re-proven by runner block
+`WITNESS_B`:
+
+- **`B` is in the family `F`.** `f` is continuous with `f(0) = 0` and
+  `f(1) = 1`, and strictly increasing: on each linear piece `g = a + b x` the
+  derivative `f' = a + 2 b x` is positive at both piece endpoints, so positive
+  throughout.
+- **`B` is reflection-symmetry-broken but sign-mixed, so `B` is NOT in `A`.**
+  Exactly and piece by piece,
+
+  ```text
+  h(q) = 1/10 - q/5      on (1/2, 3/4),
+  h(q) = 11q/5 - 17/10   on (3/4, 1),
+  ```
+
+  so `h(3/4) = -1/20 < 0` while `h(21/22) = 2/5 > 0`: `h` changes sign on
+  `(1/2,1)`, hence has an interior zero there, so `B` is outside `A`.
+- **The extra off-center fixed point is `q = 17/22`.** Solving `h(q) = 0` on
+  `(3/4,1)` gives exactly `q = 17/22`, and back-substitution gives
+  `T_B(17/22) = 17/22` exactly (`g(17/22) = 15/22`, `f(17/22) = 255/484`,
+  `g(5/22) = 15/22`, `f(5/22) = 75/484`, `T_B = 255/330 = 17/22`). This is a
+  durable weight strictly off the center. Below it `T_B(7/10) < 7/10` and above
+  it `T_B(9/10) > 9/10`, so `q = 17/22` sits between an attenuation region and
+  an amplification region.
+
+Reading: reflection asymmetry (`A`-membership) is exactly what forbids an
+off-center durable weight. Drop it — keep only continuity, strict increase, and
+`f(0) = 0` — and an extra off-center fixed point appears. This witness plays the
+same load-bearing negative-control role for content (i) that the parent note's
+N1/N2 controls play for its L2/L3.
+
+## N2 (identity member `f = q`, non-recording control)
+
+For `f(q) = q`, `g(x) = 1` is constant, `h` is identically zero, and
+
+```text
+T_f(q) = q / ( q + (1-q) ) = q
+```
+
+for every `q`. Every weight is fixed: the identity member is non-recording, it
+lies in `F` but not in `A`, and it selects nothing. This is exactly the parent
+note's N2 control. The parent's scope-boundary sentence speaks of its own
+influence odds `f(q)/f(1-q)` (Supplied objects, item 3); for the identity
+member that ratio is `q/(1-q)`, strictly increasing on `(0,1)`, yet the member
+lies outside `A` — that is the parent's sense in which bare influence-odds
+monotonicity is insufficient. In this note's decomposition the same member
+shows the finer fact: its per-weight influence profile `g` is constant, `h`
+vanishes identically, and it imports neither content (i) nor content (ii).
+
+Runner block `IDENTITY` proves `T_f = q` identically, checks a set of rational
+samples are all fixed, and confirms `h` is identically zero.
+
+## Bounded consequence
+
+Over the declared 2-cell record-influence family `F` and the consumed
+permanence-to-stationarity reading, the strict-sharpening import consumed at the
+parent note's L3 is exactly the conjunction of two separate contents:
+reflection asymmetry (`A`-membership), which by T1 is exactly the condition for
+the interior durable weight to be the single central weight `q = 1/2`; and the
+amplifying orientation (`A+`), a disjoint binary that fixes only the
+stability/selection mode. Through the parent note's supplied translation
+`p_d = 2r/(1+2r)`, the central weight `q = 1/2` corresponds to the dial setting
+`r = 1/2`; this note forces, derives, and prefers no dial setting, and the
+distinguished dial settings remain settings of a dial per the
+stationary-point-not-forced anchor.
+
+The grain derivation obligation's closure criterion is, verbatim:
+
+```text
+A closing theorem must derive the physical matter action and its measure, then
+distinguish the count-once `det_C`/holomorphic realization from the
+count-twice `|det_C|^2`/realified realization without inserting the desired
+charged-lepton value or readout dictionary.
+```
+
+This note engages no part of that criterion. It derives no physical matter
+action or measure and identifies its abstract class decomposition with no
+physical realization fork. No part of the obligation is weakened, localized,
+replaced, or discharged; the obligation stands at its live grade. Nothing is
+claimed outside the declared class: non-symmetric families, non-multiplicative
+influence forms, and non-stationarity selection modes are out of scope.
+
+## Honest auditor read / Boundary
+
+- **This note decomposes an import; it derives no new physics.** T1–T5 restate
+  the content of the parent note's L3 import as two separate conditions over
+  the same declared class. No occupancy weight, horn, orientation, or dial value
+  is selected. The decomposition is a statement about the class, not a
+  selection within it.
+- **Everything is class-scoped.** All theorems quantify over the declared
+  2-cell record-influence family `F` and the note-local classes `A`, `A+`,
+  `A-`, `M` built from it. Non-symmetric families, non-multiplicative influence
+  forms, and non-stationarity selection modes are outside scope, exactly as in
+  the parent note's own scope boundary. Membership witnesses are non-emptiness
+  exhibits, not a choice of record rule.
+- **The two contents are genuinely separate, and each is load-bearing.** Content
+  (i) is load-bearing by witness `B`: a member of `F` outside `A` acquires an
+  extra off-center durable weight at `q = 17/22`. Content (ii) is not implied by
+  (i): `A = A+ ⊔ A-` is a disjoint dichotomy, and the attenuating member
+  `f = sqrt(q)` sits in `A-`, sharing the interior fixed set `{0, 1/2, 1}` with
+  every `A+` member while pushing orbits the other way. The amplifying witness
+  (N0) sits in `A+` but not `M`, so the monotone-profile condition `M` is
+  strictly stronger than the amplifying orientation.
+- **The axioms supply neither content.** By the consumed qualification clause, a
+  choice not fixed by the supplied structure remains a named conditional or open
+  dependency. The framework axiom memo is a `meta` note and confers no bounded
+  status; depending on Record here is only the consumed permanence-to-
+  stationarity reading, declared, not a source of bounded status. Both contents
+  (i) and (ii) are named conditionals in exactly this sense.
+- **Durability is stationarity, not attraction.** The horn and orbit statements
+  describe the direction and limit of the abstract continued-registration
+  iteration; the selection mode is a distinguished stationary weight, matching
+  the stationary-point-not-forced anchor (`retained_bounded`). No attractor or
+  convergence claim about a physical state is made.
+- **Conditional premises at live grades.** The consumed sources enter at exactly
+  the grades listed in Load-bearing dependencies: one unaudited `bounded_theorem`
+  parent, one `meta` axiom memo, one `retained_bounded` anchor, and one open
+  obligation shown at `open_gate` with its ledger row `audited_renaming`. Every
+  claim here is conditional on them at those grades; none is upgraded by
+  consumption.
+
+## Non-claims
+
+This note selects no horn, no grain, no orientation, no `r` value, no `Q`
+value, no mass, no mixing angle, no probability rule, no species map, and no
+sector weight. The decomposition in T5 is an exact statement about the declared
+class, not a selection among its members. The dial settings `r = 0`, `r = 1/2`,
+and `r = 1` remain distinguished settings of a dial, per the
+stationary-point-not-forced anchor; nothing here forces or prefers any of them.
+The note adds no axiom, no primitive, no literature comparator, and no supplied
+physical binding, and it coins no framework vocabulary: `A`, `A+`, `A-`, `M`,
+`g`, and `h` are note-local descriptors declared in D1 and proposed for no
+registry. It explicitly consumes the parent declared readings, the Record
+clauses, and the other graded inputs listed below; it changes no audit verdict
+and predicts none; it does not assert that the physical charged-lepton matter
+action registers either content; and it does not derive record formation,
+occurrence, or the physical matter action and measure named by the grain
+obligation's closure criterion.
+
+## Relation to prior notes
+
+The counting-measure correspondence note
+`ACPHILAMBDA_OCCUPANCY_GRAIN_MENU_COUNTING_MEASURE_DYNAMICAL_STATIC_CORRESPONDENCE_BOUNDED_THEOREM_NOTE_2026-07-16.md`
+works over the same declared class at the level of the menu cardinality and the
+uniform-on-support fixed weights. The present note is independent of it: it
+consumes none of its content, seeds no citation edge to it, and shares only the
+parent record-influence family. It is named here for orientation only.
+
+## Load-bearing dependencies
+
+| Dependency | Live grade (cited at exactly this grade) | Consumed content |
+|---|---|---|
+| [`ACPHILAMBDA_OCCUPANCY_GRAIN_RULE_CLASS_UNIVERSALITY_BOUNDED_THEOREM_NOTE_2026-07-11.md`](ACPHILAMBDA_OCCUPANCY_GRAIN_RULE_CLASS_UNIVERSALITY_BOUNDED_THEOREM_NOTE_2026-07-11.md) | unaudited `bounded_theorem` | The declared 2-cell record-influence family `T_f` (L2); the strict-sharpening majority-amplification meaning decomposed here (L3); the scope-boundary sentence that bare influence-odds monotonicity is insufficient; the influence-odds definition itself (the parent's own object, distinguished from this note's per-weight profile); the `p_d = 2r/(1+2r)` weight-to-dial translation; the N1/N2 negative-control pattern. Verbatim clauses are quoted above and gated in runner block `SOURCE_GATES`. |
+| [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | `meta` (doc-header type; framework axiom memo; confers no bounded status; not a graded ledger row) | The verbatim Record clauses (permanence, record-only readability) read as the permanence-to-stationarity discipline, and the qualification clause that an unfixed choice remains a named conditional or open dependency. Depending on the Record axiom is not treated as a source of bounded status. Quoted above and gated in `SOURCE_GATES`. |
+| [`FLAVOR_R_HALF_IS_A_STATIONARY_POINT_NOT_FORCED_2026-06-02.md`](FLAVOR_R_HALF_IS_A_STATIONARY_POINT_NOT_FORCED_2026-06-02.md) | `retained_bounded` | The stationary-point-not-forced framing (distinguished dial settings, durability as stationarity not attraction), consumed in T3, the Bounded consequence, and Non-claims. |
+| [`AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md`](AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md) | `open_gate` (ledger row: `audited_renaming`) | The open grain derivation obligation. Its closure criterion is quoted verbatim in Bounded consequence and gated in runner block `SOURCE_GATES`. This note uses it only to state the boundary and engages no physical-action step. |
+
+## Runner verification map
+
+| Block | Content | Result |
+|---|---|---|
+| `TEXT_INTEGRITY` | Paired note exists; claim id present; each of the four load-bearing dependency filenames appears in the note | PASS=6 FAIL=0 |
+| `T1_FIXED_POINT` | Reflection-asymmetry fixed-point identity, numerator match, exact interior solves for `q^2` and `q^3`, endpoint-limit extensions, reflection-oddness of `h` | PASS=7 FAIL=0 |
+| `T2_SIGN_BRIDGE` | Full-quotient sign-bridge identity, denominator positivity, exchange symmetry, central-slope formula, power-member central slopes including symbolic `k` | PASS=9 FAIL=0 |
+| `T3_HORN` | Off-center amplification `T_f(3/5) > 3/5` for four `A+` members and the mirror attenuation `T_f(2/5) < 2/5` | PASS=5 FAIL=0 |
+| `ORBITS` | `A+` orbit rising toward `1` (exact rationals); `A-` orbit falling toward `1/2` (exact radicals); monotone, in-band, and gap certificates; exact interior fixed-set solve for the `A-` exemplar | PASS=7 FAIL=0 |
+| `WITNESS_A` | `A+` witness of N0: node table gated in note text, continuity, `f(0)=0`/`f(1)<=1`, strict increase, `h` values and the affine side formula `h = 4q/5 - 2/5` with collinearity and slope certificates, non-monotone per-weight profile, one-step amplification | PASS=13 FAIL=0 |
+| `WITNESS_B` | Sign-mixed boundary witness of N1: node table gated in note text, continuity, `f(0)=0`/`f(1)=1`, strict increase, sign-mixed `h`, symbolic side formulas, exact solve `h=0 -> q=17/22`, back-substituted fixed point, below/above sign check | PASS=13 FAIL=0 |
+| `IDENTITY` | N2 identity member: `T_f = q` identically, all rational samples fixed, `h` identically zero | PASS=3 FAIL=0 |
+| `LADDER` | Strict ladder `M ( A+ ( A ( F`: affine mechanism identity, N0 witness in `A+` not `M`, `sqrt` in `A-` not `M` with conjugate certificate, identity member in `F` not `A`, witness `B` off-center zero | PASS=7 FAIL=0 |
+| `SOURCE_GATES` | Verbatim quote gates: each consumed clause present in its source note AND in this note (flattened substring), including the parent's influence-odds definition | PASS=10 FAIL=0 |
+| `NOTE_HYGIENE` | No prose decimals outside code fences, pinned closing/enumeration phrases absent, claim-type line, required sections, the T5 exact-characterization phrase used exactly once | PASS=5 FAIL=0 |
+
+Run:
+
+```bash
+python3 scripts/acphilambda_sharpening_import_decomposition_2026_07_16.py
+```
+
+Cached run result:
+
+```text
+TOTAL: PASS=85 FAIL=0
+```
+
+**No check passes by literal stipulation.**

--- a/docs/ACPHILAMBDA_OCCUPANCY_GRAIN_SHARPENING_IMPORT_DECOMPOSITION_REFLECTION_ASYMMETRY_ORIENTATION_DICHOTOMY_BOUNDED_THEOREM_NOTE_2026-07-16.md
+++ b/docs/ACPHILAMBDA_OCCUPANCY_GRAIN_SHARPENING_IMPORT_DECOMPOSITION_REFLECTION_ASYMMETRY_ORIENTATION_DICHOTOMY_BOUNDED_THEOREM_NOTE_2026-07-16.md
@@ -35,9 +35,9 @@ dichotomy `A = A+ ⊔ A-` on top of it (T2, T5(ii)). Two exact
 piecewise-linear witnesses make the separation load-bearing: an amplifying
 member with a non-monotone per-weight influence profile that sits in `A+` but
 not in the monotone-profile subclass `M`, and a reflection-symmetry-broken
-boundary member outside `A` that carries an extra off-center fixed point at
-`q = 17/22`. The identity member `f(q) = q` is the non-recording control with
-`T_f = q` identically.
+boundary member outside `A` that carries an extra reflected pair of off-center
+fixed points at `q = 5/22` and `q = 17/22`. The identity member `f(q) = q` is
+the non-recording control with `T_f = q` identically.
 
 The four framework axioms (Lattice, Qubit, Admissibility, Record) supply
 neither content: a choice not fixed by the supplied structure remains a named
@@ -218,8 +218,9 @@ limit extensions `T_f(0) = 0`, `T_f(1) = 1`.
 > `sign(T_f(q) - q) = sign(h(q))`. Consequently `A = A+ ⊔ A-` disjointly:
 > a reflection-asymmetric profile is either majority-amplifying (`T_f(q) > q`
 > for `q > 1/2`) or majority-attenuating (`T_f(q) < q` for `q > 1/2`), never
-> both. The class also satisfies the exchange symmetry `T_f(1-q) = 1 - T_f(q)`
-> and the central slope `T_f'(1/2) = f'(1/2) / (2 f(1/2))`; for the power
+> both. Every member also satisfies the exchange symmetry
+> `T_f(1-q) = 1 - T_f(q)`. If `f` is differentiable at `q = 1/2`, then
+> `T_f'(1/2) = f'(1/2) / (2 f(1/2))`; for the differentiable-at-center power
 > member `f = q^k` the central slope is exactly `k`.
 
 *Reading.* The sign bridge is what turns the parent note's L3 inequality into a
@@ -232,9 +233,9 @@ of the L3 import.
 Runner: block `T2_SIGN_BRIDGE` proves the full-quotient identity symbolically,
 checks strict positivity of the denominator at a rational sample for two
 members (the class-level positivity is the one-line `f > 0` fact in the box),
-proves the exchange symmetry and the central-slope formula symbolically, and
-confirms the central slope equals `k` for `k = 1/2`, `k = 2`, and symbolic
-`k > 0`.
+proves the exchange symmetry and, under the stated differentiability condition,
+the central-slope formula symbolically, and confirms the central slope equals
+`k` for `k = 1/2`, `k = 2`, and symbolic `k > 0`.
 
 ## T3 (off-center orientation horn) and orbit behaviour
 
@@ -259,13 +260,13 @@ orbit is strictly decreasing and stays above `1/2`, so its limit is `1/2`.
 *Reading.* Orientation is what selects which side of the central weight the
 recording update pushes toward. This is the stability/selection-mode content of
 the L3 import; the interior fixed set is the same `{0, 1/2, 1}` in both
-orientations. Durability throughout is stationarity, not attraction: the horn
-statements describe the one-step and iterated direction and its limit, and the
-selection mode is a distinguished stationary weight in the sense of the
-stationary-point-not-forced anchor (`retained_bounded`).
+orientations. Durability throughout is fixed-point stationarity under the
+declared update, not attraction: the horn statements describe the one-step and
+iterated direction and its limit. This is distinct from stationarity of an
+entropy or balance functional.
 
 Runner: block `T3_HORN` checks off-center amplification `T_f(q) > q` at
-`q = 3/5` for four `A+` members (`q^2`, `q^3`, `q^4`, `q + q^2`) and the mirror
+`q = 3/5` for four `A+` members (`q^2`, `q^3`, `q^4`, `(q + q^2)/2`) and the mirror
 minority attenuation `T_f(2/5) < 2/5` for `q^2`. Block `ORBITS` iterates the
 `A+` exemplar `f = q^2` from `q_0 = 3/5` (six exact-rational steps, strictly
 increasing, staying in `(1/2,1)`, closing gap to `1` below `1/1000`) and the
@@ -290,8 +291,8 @@ N0 witness (`g(1/2) < g(1/4)`) together with `h > 0` at interior samples of
 `(1/2,1)`; the exact derivative `g'(x) = -x^(-3/2)/2 < 0` for `f = sqrt(q)`
 (not in `M`) with an exact conjugate certificate that `h < 0` on `(1/2,1)`
 (in `A-`); the identically-zero `h` of the identity member (in `F`, not in
-`A`); and witness `B`'s exact off-center zero `h(17/22) = 0` (in `F`, not in
-`A`).
+`A`); and witness `B`'s exact reflected off-center zeros
+`h(5/22) = h(17/22) = 0` (in `F`, not in `A`).
 
 ## T5 (sharpening-import decomposition)
 
@@ -312,8 +313,8 @@ N0 witness (`g(1/2) < g(1/4)`) together with `h > 0` at interior samples of
 
 The two contents are made load-bearing by exact witnesses in the following
 sections (N0–N2): the N0 member exhibits `A+` without `M`, a sign-mixed
-boundary member outside `A` (N1) shows (i) is load-bearing (an extra
-off-center fixed point appears), and the amplifying/attenuating split shows
+boundary member outside `A` (N1) shows (i) is load-bearing (an extra reflected
+pair of off-center fixed points appears), and the amplifying/attenuating split shows
 (ii) is not implied by (i).
 
 ## N0 (amplifying witness, in `A+` but not in `M`)
@@ -352,7 +353,7 @@ profile. Amplification is controlled by the reflection asymmetry `h` alone,
 which compares `g` across the reflection `q <-> 1-q` and is insensitive to
 `g`'s behaviour within a side.
 
-## N1 (sign-mixed boundary witness `B`, extra fixed point `q = 17/22`)
+## N1 (sign-mixed boundary witness `B`, extra fixed-point pair `{5/22, 17/22}`)
 
 Define `g` piecewise linear on `[0,1]` with node values
 
@@ -378,17 +379,22 @@ and set `f(x) = x g(x)`. Exact facts, all re-proven by runner block
 
   so `h(3/4) = -1/20 < 0` while `h(21/22) = 2/5 > 0`: `h` changes sign on
   `(1/2,1)`, hence has an interior zero there, so `B` is outside `A`.
-- **The extra off-center fixed point is `q = 17/22`.** Solving `h(q) = 0` on
-  `(3/4,1)` gives exactly `q = 17/22`, and back-substitution gives
-  `T_B(17/22) = 17/22` exactly (`g(17/22) = 15/22`, `f(17/22) = 255/484`,
-  `g(5/22) = 15/22`, `f(5/22) = 75/484`, `T_B = 255/330 = 17/22`). This is a
-  durable weight strictly off the center. Below it `T_B(7/10) < 7/10` and above
-  it `T_B(9/10) > 9/10`, so `q = 17/22` sits between an attenuation region and
-  an amplification region.
+- **The extra off-center fixed points are the reflected pair
+  `{5/22, 17/22}`.** Solving `h(q) = 0` on `(3/4,1)` gives exactly
+  `q = 17/22`; reflection oddness gives the paired zero `q = 5/22`.
+  Back-substitution gives both fixed points exactly:
+  `g(17/22) = g(5/22) = 15/22`,
+  `f(17/22) = 255/484`, `f(5/22) = 75/484`, and hence
+  `T_B(17/22) = 255/330 = 17/22` while
+  `T_B(5/22) = 75/330 = 5/22`. Thus the closed-cell fixed set of `B` is
+  `{0, 5/22, 1/2, 17/22, 1}`. Below the upper point
+  `T_B(7/10) < 7/10` and above it `T_B(9/10) > 9/10`, so `q = 17/22`
+  sits between an attenuation region and an amplification region.
 
 Reading: reflection asymmetry (`A`-membership) is exactly what forbids an
 off-center durable weight. Drop it — keep only continuity, strict increase, and
-`f(0) = 0` — and an extra off-center fixed point appears. This witness plays the
+`f(0) = 0` — and an extra reflected pair of off-center fixed points appears.
+This witness plays the
 same load-bearing negative-control role for content (i) that the parent note's
 N1/N2 controls play for its L2/L3.
 
@@ -420,12 +426,11 @@ permanence-to-stationarity reading, the strict-sharpening import consumed at the
 parent note's L3 is exactly the conjunction of two separate contents:
 reflection asymmetry (`A`-membership), which by T1 is exactly the condition for
 the interior durable weight to be the single central weight `q = 1/2`; and the
-amplifying orientation (`A+`), a disjoint binary that fixes only the
-stability/selection mode. Through the parent note's supplied translation
+amplifying orientation (`A+`), a disjoint binary that fixes the direction and
+limit of the declared abstract iteration. Through the parent note's supplied translation
 `p_d = 2r/(1+2r)`, the central weight `q = 1/2` corresponds to the dial setting
-`r = 1/2`; this note forces, derives, and prefers no dial setting, and the
-distinguished dial settings remain settings of a dial per the
-stationary-point-not-forced anchor.
+`r = 1/2`; this note forces, derives, and prefers no dial setting. The
+translation supplies no physical lane assignment.
 
 The grain derivation obligation's closure criterion is, verbatim:
 
@@ -458,7 +463,8 @@ influence forms, and non-stationarity selection modes are out of scope.
   exhibits, not a choice of record rule.
 - **The two contents are genuinely separate, and each is load-bearing.** Content
   (i) is load-bearing by witness `B`: a member of `F` outside `A` acquires an
-  extra off-center durable weight at `q = 17/22`. Content (ii) is not implied by
+  extra reflected pair of off-center durable weights at `q = 5/22` and
+  `q = 17/22`. Content (ii) is not implied by
   (i): `A = A+ ⊔ A-` is a disjoint dichotomy, and the attenuating member
   `f = sqrt(q)` sits in `A-`, sharing the interior fixed set `{0, 1/2, 1}` with
   every `A+` member while pushing orbits the other way. The amplifying witness
@@ -470,15 +476,15 @@ influence forms, and non-stationarity selection modes are out of scope.
   status; depending on Record here is only the consumed permanence-to-
   stationarity reading, declared, not a source of bounded status. Both contents
   (i) and (ii) are named conditionals in exactly this sense.
-- **Durability is stationarity, not attraction.** The horn and orbit statements
+- **Durability is fixed-point stationarity under the declared update, not
+  attraction.** The horn and orbit statements
   describe the direction and limit of the abstract continued-registration
-  iteration; the selection mode is a distinguished stationary weight, matching
-  the stationary-point-not-forced anchor (`retained_bounded`). No attractor or
-  convergence claim about a physical state is made.
+  iteration. This is distinct from stationarity of an entropy or balance
+  functional. No attractor or convergence claim about a physical state is made.
 - **Conditional premises at live grades.** The consumed sources enter at exactly
   the grades listed in Load-bearing dependencies: one unaudited `bounded_theorem`
-  parent, one `meta` axiom memo, one `retained_bounded` anchor, and one open
-  obligation shown at `open_gate` with its ledger row `audited_renaming`. Every
+  parent, one `meta` axiom memo, and one open obligation shown at `open_gate`
+  with its ledger row `audited_renaming`. Every
   claim here is conditional on them at those grades; none is upgraded by
   consumption.
 
@@ -487,9 +493,8 @@ influence forms, and non-stationarity selection modes are out of scope.
 This note selects no horn, no grain, no orientation, no `r` value, no `Q`
 value, no mass, no mixing angle, no probability rule, no species map, and no
 sector weight. The decomposition in T5 is an exact statement about the declared
-class, not a selection among its members. The dial settings `r = 0`, `r = 1/2`,
-and `r = 1` remain distinguished settings of a dial, per the
-stationary-point-not-forced anchor; nothing here forces or prefers any of them.
+class, not a selection among its members. Nothing here forces or prefers any
+dial setting.
 The note adds no axiom, no primitive, no literature comparator, and no supplied
 physical binding, and it coins no framework vocabulary: `A`, `A+`, `A-`, `M`,
 `g`, and `h` are note-local descriptors declared in D1 and proposed for no
@@ -515,20 +520,19 @@ parent record-influence family. It is named here for orientation only.
 |---|---|---|
 | [`ACPHILAMBDA_OCCUPANCY_GRAIN_RULE_CLASS_UNIVERSALITY_BOUNDED_THEOREM_NOTE_2026-07-11.md`](ACPHILAMBDA_OCCUPANCY_GRAIN_RULE_CLASS_UNIVERSALITY_BOUNDED_THEOREM_NOTE_2026-07-11.md) | unaudited `bounded_theorem` | The declared 2-cell record-influence family `T_f` (L2); the strict-sharpening majority-amplification meaning decomposed here (L3); the scope-boundary sentence that bare influence-odds monotonicity is insufficient; the influence-odds definition itself (the parent's own object, distinguished from this note's per-weight profile); the `p_d = 2r/(1+2r)` weight-to-dial translation; the N1/N2 negative-control pattern. Verbatim clauses are quoted above and gated in runner block `SOURCE_GATES`. |
 | [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | `meta` (doc-header type; framework axiom memo; confers no bounded status; not a graded ledger row) | The verbatim Record clauses (permanence, record-only readability) read as the permanence-to-stationarity discipline, and the qualification clause that an unfixed choice remains a named conditional or open dependency. Depending on the Record axiom is not treated as a source of bounded status. Quoted above and gated in `SOURCE_GATES`. |
-| [`FLAVOR_R_HALF_IS_A_STATIONARY_POINT_NOT_FORCED_2026-06-02.md`](FLAVOR_R_HALF_IS_A_STATIONARY_POINT_NOT_FORCED_2026-06-02.md) | `retained_bounded` | The stationary-point-not-forced framing (distinguished dial settings, durability as stationarity not attraction), consumed in T3, the Bounded consequence, and Non-claims. |
 | [`AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md`](AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md) | `open_gate` (ledger row: `audited_renaming`) | The open grain derivation obligation. Its closure criterion is quoted verbatim in Bounded consequence and gated in runner block `SOURCE_GATES`. This note uses it only to state the boundary and engages no physical-action step. |
 
 ## Runner verification map
 
 | Block | Content | Result |
 |---|---|---|
-| `TEXT_INTEGRITY` | Paired note exists; claim id present; each of the four load-bearing dependency filenames appears in the note | PASS=6 FAIL=0 |
+| `TEXT_INTEGRITY` | Paired note exists; claim id present; each of the three load-bearing dependency filenames appears in the note | PASS=5 FAIL=0 |
 | `T1_FIXED_POINT` | Reflection-asymmetry fixed-point identity, numerator match, exact interior solves for `q^2` and `q^3`, endpoint-limit extensions, reflection-oddness of `h` | PASS=7 FAIL=0 |
-| `T2_SIGN_BRIDGE` | Full-quotient sign-bridge identity, denominator positivity, exchange symmetry, central-slope formula, power-member central slopes including symbolic `k` | PASS=9 FAIL=0 |
-| `T3_HORN` | Off-center amplification `T_f(3/5) > 3/5` for four `A+` members and the mirror attenuation `T_f(2/5) < 2/5` | PASS=5 FAIL=0 |
+| `T2_SIGN_BRIDGE` | Full-quotient sign-bridge identity, denominator positivity, exchange symmetry, differentiability-qualified central-slope formula, power-member central slopes including symbolic `k` | PASS=9 FAIL=0 |
+| `T3_HORN` | Declared-family gate for the normalized polynomial member, off-center amplification `T_f(3/5) > 3/5` for four `A+` members, and the mirror attenuation `T_f(2/5) < 2/5` | PASS=6 FAIL=0 |
 | `ORBITS` | `A+` orbit rising toward `1` (exact rationals); `A-` orbit falling toward `1/2` (exact radicals); monotone, in-band, and gap certificates; exact interior fixed-set solve for the `A-` exemplar | PASS=7 FAIL=0 |
 | `WITNESS_A` | `A+` witness of N0: node table gated in note text, continuity, `f(0)=0`/`f(1)<=1`, strict increase, `h` values and the affine side formula `h = 4q/5 - 2/5` with collinearity and slope certificates, non-monotone per-weight profile, one-step amplification | PASS=13 FAIL=0 |
-| `WITNESS_B` | Sign-mixed boundary witness of N1: node table gated in note text, continuity, `f(0)=0`/`f(1)=1`, strict increase, sign-mixed `h`, symbolic side formulas, exact solve `h=0 -> q=17/22`, back-substituted fixed point, below/above sign check | PASS=13 FAIL=0 |
+| `WITNESS_B` | Sign-mixed boundary witness of N1: node table gated in note text, continuity, `f(0)=0`/`f(1)=1`, strict increase, sign-mixed `h`, symbolic side formulas, exact upper-half solve `h=0 -> q=17/22`, reflected pair `{5/22,17/22}`, back-substituted fixed points, complete closed-cell fixed set, below/above sign check | PASS=14 FAIL=0 |
 | `IDENTITY` | N2 identity member: `T_f = q` identically, all rational samples fixed, `h` identically zero | PASS=3 FAIL=0 |
 | `LADDER` | Strict ladder `M ( A+ ( A ( F`: affine mechanism identity, N0 witness in `A+` not `M`, `sqrt` in `A-` not `M` with conjugate certificate, identity member in `F` not `A`, witness `B` off-center zero | PASS=7 FAIL=0 |
 | `SOURCE_GATES` | Verbatim quote gates: each consumed clause present in its source note AND in this note (flattened substring), including the parent's influence-odds definition | PASS=10 FAIL=0 |
@@ -543,7 +547,7 @@ python3 scripts/acphilambda_sharpening_import_decomposition_2026_07_16.py
 Cached run result:
 
 ```text
-TOTAL: PASS=85 FAIL=0
+TOTAL: PASS=86 FAIL=0
 ```
 
 **No check passes by literal stipulation.**

--- a/logs/runner-cache/acphilambda_sharpening_import_decomposition_2026_07_16.txt
+++ b/logs/runner-cache/acphilambda_sharpening_import_decomposition_2026_07_16.txt
@@ -1,0 +1,108 @@
+===== runner cache v1 =====
+runner: scripts/acphilambda_sharpening_import_decomposition_2026_07_16.py
+runner_sha256: 00a908c670b48d195c0e23a5f9ccaea445f395422fe3ec1501f836e71ce89254
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 2.39
+status: ok
+----- stdout -----
+[TEXT_INTEGRITY] Note exists, claim id present, dependency filenames cited
+TEXT_INTEGRITY.1 PASS: paired note file exists on disk
+TEXT_INTEGRITY.2 PASS: note states its claim id verbatim
+TEXT_INTEGRITY.3 PASS: note cites dependency filename ACPHILAMBDA_OCCUPANCY_GRAIN_RULE_CLASS_UNIVERSALITY_BOUNDED_THEOREM_NOTE_2026-07-11.md
+TEXT_INTEGRITY.4 PASS: note cites dependency filename MINIMAL_AXIOMS_2026-06-29.md
+TEXT_INTEGRITY.5 PASS: note cites dependency filename FLAVOR_R_HALF_IS_A_STATIONARY_POINT_NOT_FORCED_2026-06-02.md
+TEXT_INTEGRITY.6 PASS: note cites dependency filename AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md
+[T1_FIXED_POINT] Fixed-point identity, interior fixed set, A-membership equivalence
+T1_FIXED_POINT.1 PASS: f(q)(1-q) - q f(1-q) = q(1-q)[g(q) - g(1-q)] exactly
+T1_FIXED_POINT.2 PASS: numerator of T_f(q) - q equals f(q)(1-q) - q f(1-q) exactly
+T1_FIXED_POINT.3 PASS: f = q^2: exact solve of the fixed condition yields only {0, 1/2, 1}
+T1_FIXED_POINT.4 PASS: f = q^3: exact solve of the fixed condition yields only {0, 1/2, 1}
+T1_FIXED_POINT.5 PASS: T_f extends by limit to T_f(0) = 0 (exemplar k=2)
+T1_FIXED_POINT.6 PASS: T_f extends by limit to T_f(1) = 1 (exemplar k=2)
+T1_FIXED_POINT.7 PASS: h is reflection-odd for generic f: h(1-q) = -h(q) exactly
+[T2_SIGN_BRIDGE] Sign bridge, orientation dichotomy support, exchange, central slope
+T2_SIGN_BRIDGE.1 PASS: T_f(q) - q = q(1-q) h(q) / (f(q)+f(1-q)) exactly (full quotient)
+T2_SIGN_BRIDGE.2 PASS: sign-bridge numerator q(1-q) h(q) equals f(q)(1-q) - q f(1-q)
+T2_SIGN_BRIDGE.3 PASS: denominator f(q)+f(1-q) > 0 at q=3/5 for f=q^2
+T2_SIGN_BRIDGE.4 PASS: denominator f(q)+f(1-q) > 0 at q=3/5 for f=sqrt(q)
+T2_SIGN_BRIDGE.5 PASS: exchange symmetry: T_f(1-q) = 1 - T_f(q) exactly
+T2_SIGN_BRIDGE.6 PASS: central slope T_f'(1/2) = f'(1/2)/(2 f(1/2)) exactly
+T2_SIGN_BRIDGE.7 PASS: power member f = q^1/2: central slope is exactly 1/2
+T2_SIGN_BRIDGE.8 PASS: power member f = q^2: central slope is exactly 2
+T2_SIGN_BRIDGE.9 PASS: power member f = q^k, symbolic k > 0: central slope is exactly k
+[T3_HORN] Off-center amplification: T_f(q) > q for q > 1/2 across members
+T3_HORN.1 PASS: f = q^2: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)
+T3_HORN.2 PASS: f = q^3: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)
+T3_HORN.3 PASS: f = q^4: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)
+T3_HORN.4 PASS: f = q + q^2: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)
+T3_HORN.5 PASS: mirror: f = q^2 attenuates the minority side, T_f(2/5) < 2/5
+[ORBITS] Exemplar orbits: A+ rises toward 1; A- falls toward 1/2 (exact)
+ORBITS.1 PASS: A+ orbit f=q^2 from 3/5: strictly increasing over six steps
+ORBITS.2 PASS: A+ orbit f=q^2 from 3/5: every iterate stays in (1/2, 1)
+ORBITS.3 PASS: A+ orbit f=q^2 from 3/5: closing gap to 1 is below 1/1000 after six steps
+ORBITS.4 PASS: A- orbit f=sqrt(q) from 3/4: strictly decreasing over six steps
+ORBITS.5 PASS: A- orbit f=sqrt(q) from 3/4: every iterate stays above 1/2
+ORBITS.6 PASS: A- orbit f=sqrt(q) from 3/4: closing gap to 1/2 is below 1/100 after six steps
+ORBITS.7 PASS: A- exemplar f = sqrt(q): interior fixed set solved exactly = {1/2}
+[WITNESS_A] A+ witness: reflection asymmetry, non-monotone per-weight influence profile
+WITNESS_A.1 PASS: witness A node table gated in note text and matched by g exactly
+WITNESS_A.2 PASS: witness A g continuous at internal breakpoints 1/4, 1/2, 3/4
+WITNESS_A.3 PASS: witness A f(0) = 0 and f(1) = 9/10 <= 1
+WITNESS_A.4 PASS: witness A f' > 0 at every piece endpoint (strictly increasing on [0,1])
+WITNESS_A.5 PASS: witness A h(1/2) = 0 (reflection fixed at center)
+WITNESS_A.6 PASS: witness A h(3/4) = 1/5 derived from g
+WITNESS_A.7 PASS: witness A h(7/8) = 3/10 derived from g (interior sample)
+WITNESS_A.8 PASS: witness A h(q) = 4q/5 - 2/5 on (1/2, 3/4)
+WITNESS_A.9 PASS: witness A h(q) = 4q/5 - 2/5 on (3/4, 1)
+WITNESS_A.10 PASS: witness A affine certificate: side formulas agree, h(1/2) = 0, slope dh/dq = 4/5 > 0
+WITNESS_A.11 PASS: witness A h collinear on each subinterval: midpoint equals endpoint average
+WITNESS_A.12 PASS: witness A per-weight influence profile g non-monotone: g(1/2) = 11/20 < g(1/4) = 3/5
+WITNESS_A.13 PASS: witness A one-step amplification T_A(q) > q at q in {5/8, 3/4, 7/8}
+[WITNESS_B] Sign-mixed boundary witness B, off-center fixed point q* = 17/22
+WITNESS_B.1 PASS: witness B node table gated in note text and matched by g exactly
+WITNESS_B.2 PASS: witness B g continuous at internal breakpoints 1/4, 1/2, 3/4
+WITNESS_B.3 PASS: witness B f(0) = 0 and f(1) = 1
+WITNESS_B.4 PASS: witness B f' > 0 at every piece endpoint (strictly increasing on [0,1])
+WITNESS_B.5 PASS: witness B h(3/4) = -1/20 (negative just above center)
+WITNESS_B.6 PASS: witness B h(21/22) = 2/5 > 0 while h(3/4) < 0: sign-mixed on (1/2, 1)
+WITNESS_B.7 PASS: witness B h(q) = 1/10 - q/5 on (1/2, 3/4)
+WITNESS_B.8 PASS: witness B h(q) = 11q/5 - 17/10 on (3/4, 1)
+WITNESS_B.9 PASS: witness B: solving h(q) = 0 on (3/4, 1) yields exactly {17/22}
+WITNESS_B.10 PASS: witness B off-center fixed point: T_B(q*) = q* by back-substitution
+WITNESS_B.11 PASS: witness B fixed point q* = 17/22 is off-center (q* != 1/2)
+WITNESS_B.12 PASS: witness B below q*: T_B(7/10) < 7/10 (attenuation region)
+WITNESS_B.13 PASS: witness B above q*: T_B(9/10) > 9/10 (amplification region)
+[IDENTITY] N2 identity member f = x: T_f = q identically, h identically zero
+IDENTITY.1 PASS: identity member f = x: T_f(q) = q identically
+IDENTITY.2 PASS: identity member: every rational sample is fixed (T_f(q) = q)
+IDENTITY.3 PASS: identity member: per-weight influence profile g = 1, h identically zero
+[LADDER] Strict ladder M ( A+ ( A ( F on named members
+LADDER.1 PASS: affine mechanism: profile g = c0 + c1 x gives h(q) = c1 (2q - 1) exactly
+LADDER.2 PASS: N0 witness in A+ but not M: g(1/2) < g(1/4) and h > 0 at interior samples
+LADDER.3 PASS: sqrt member f = sqrt(x): g' = -x^(-3/2)/2 exactly (profile strictly decreasing)
+LADDER.4 PASS: sqrt member: g'(x) < 0 at x in {1/4, 1/2} (not in M)
+LADDER.5 PASS: sqrt member in A-: exact conjugate certificate gives h < 0 on (1/2, 1)
+LADDER.6 PASS: identity member in F but not A: h identically 0 (no reflection asymmetry)
+LADDER.7 PASS: witness B in F but not A: off-center interior zero h(17/22) = 0
+[SOURCE_GATES] Verbatim quote gates (flattened substring in source AND this note)
+SOURCE_GATES.1 PASS: Q1 family prose (W1b L2): present verbatim in source and in this note
+SOURCE_GATES.2 PASS: Q2 family form (W1b L2): present verbatim in source and in this note
+SOURCE_GATES.3 PASS: Q3 strict-sharpening framing (W1b L3): present verbatim in source and in this note
+SOURCE_GATES.4 PASS: Q4 strict-sharpening inequalities (W1b L3): present verbatim in source and in this note
+SOURCE_GATES.5 PASS: Q5 scope boundary (W1b): present verbatim in source and in this note
+SOURCE_GATES.6 PASS: Q10 parent influence-odds definition (W1b): present verbatim in source and in this note
+SOURCE_GATES.7 PASS: Q6 Record locking clause (axioms): present verbatim in source and in this note
+SOURCE_GATES.8 PASS: Q7 Record readability clause (axioms): present verbatim in source and in this note
+SOURCE_GATES.9 PASS: Q8 Qualification clause (axioms): present verbatim in source and in this note
+SOURCE_GATES.10 PASS: Q9 obligation closure criterion: present verbatim in source and in this note
+[NOTE_HYGIENE] Note hygiene gates
+NOTE_HYGIENE.1 PASS: no decimal literals outside code fences in the note
+NOTE_HYGIENE.2 PASS: pinned closing / enumeration phrases are absent from the note
+NOTE_HYGIENE.3 PASS: claim-type line is present exactly
+NOTE_HYGIENE.4 PASS: required sections and status-authority line are present
+NOTE_HYGIENE.5 PASS: the T5 exact-characterization phrase appears exactly once in the flattened note
+TOTAL: PASS=85 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/acphilambda_sharpening_import_decomposition_2026_07_16.txt
+++ b/logs/runner-cache/acphilambda_sharpening_import_decomposition_2026_07_16.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/acphilambda_sharpening_import_decomposition_2026_07_16.py
-runner_sha256: 00a908c670b48d195c0e23a5f9ccaea445f395422fe3ec1501f836e71ce89254
+runner_sha256: 5412422a8a169a583ba1588bf584d1a7a0554406a107988a283e8a74b64f9088
 timeout_sec: 600
 exit_code: 0
-elapsed_sec: 2.39
+elapsed_sec: 2.30
 status: ok
 ----- stdout -----
 [TEXT_INTEGRITY] Note exists, claim id present, dependency filenames cited
@@ -11,8 +11,7 @@ TEXT_INTEGRITY.1 PASS: paired note file exists on disk
 TEXT_INTEGRITY.2 PASS: note states its claim id verbatim
 TEXT_INTEGRITY.3 PASS: note cites dependency filename ACPHILAMBDA_OCCUPANCY_GRAIN_RULE_CLASS_UNIVERSALITY_BOUNDED_THEOREM_NOTE_2026-07-11.md
 TEXT_INTEGRITY.4 PASS: note cites dependency filename MINIMAL_AXIOMS_2026-06-29.md
-TEXT_INTEGRITY.5 PASS: note cites dependency filename FLAVOR_R_HALF_IS_A_STATIONARY_POINT_NOT_FORCED_2026-06-02.md
-TEXT_INTEGRITY.6 PASS: note cites dependency filename AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md
+TEXT_INTEGRITY.5 PASS: note cites dependency filename AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md
 [T1_FIXED_POINT] Fixed-point identity, interior fixed set, A-membership equivalence
 T1_FIXED_POINT.1 PASS: f(q)(1-q) - q f(1-q) = q(1-q)[g(q) - g(1-q)] exactly
 T1_FIXED_POINT.2 PASS: numerator of T_f(q) - q equals f(q)(1-q) - q f(1-q) exactly
@@ -27,16 +26,17 @@ T2_SIGN_BRIDGE.2 PASS: sign-bridge numerator q(1-q) h(q) equals f(q)(1-q) - q f(
 T2_SIGN_BRIDGE.3 PASS: denominator f(q)+f(1-q) > 0 at q=3/5 for f=q^2
 T2_SIGN_BRIDGE.4 PASS: denominator f(q)+f(1-q) > 0 at q=3/5 for f=sqrt(q)
 T2_SIGN_BRIDGE.5 PASS: exchange symmetry: T_f(1-q) = 1 - T_f(q) exactly
-T2_SIGN_BRIDGE.6 PASS: central slope T_f'(1/2) = f'(1/2)/(2 f(1/2)) exactly
+T2_SIGN_BRIDGE.6 PASS: under differentiability at 1/2: central slope T_f'(1/2) = f'(1/2)/(2 f(1/2)) exactly
 T2_SIGN_BRIDGE.7 PASS: power member f = q^1/2: central slope is exactly 1/2
 T2_SIGN_BRIDGE.8 PASS: power member f = q^2: central slope is exactly 2
 T2_SIGN_BRIDGE.9 PASS: power member f = q^k, symbolic k > 0: central slope is exactly k
 [T3_HORN] Off-center amplification: T_f(q) > q for q > 1/2 across members
-T3_HORN.1 PASS: f = q^2: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)
-T3_HORN.2 PASS: f = q^3: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)
-T3_HORN.3 PASS: f = q^4: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)
-T3_HORN.4 PASS: f = q + q^2: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)
-T3_HORN.5 PASS: mirror: f = q^2 attenuates the minority side, T_f(2/5) < 2/5
+T3_HORN.1 PASS: normalized polynomial member is in F: f(0)=0, f(1)=1, and f' >= f'(0)=1/2 > 0
+T3_HORN.2 PASS: f = q^2: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)
+T3_HORN.3 PASS: f = q^3: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)
+T3_HORN.4 PASS: f = q^4: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)
+T3_HORN.5 PASS: f = (q + q^2)/2: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)
+T3_HORN.6 PASS: mirror: f = q^2 attenuates the minority side, T_f(2/5) < 2/5
 [ORBITS] Exemplar orbits: A+ rises toward 1; A- falls toward 1/2 (exact)
 ORBITS.1 PASS: A+ orbit f=q^2 from 3/5: strictly increasing over six steps
 ORBITS.2 PASS: A+ orbit f=q^2 from 3/5: every iterate stays in (1/2, 1)
@@ -59,7 +59,7 @@ WITNESS_A.10 PASS: witness A affine certificate: side formulas agree, h(1/2) = 0
 WITNESS_A.11 PASS: witness A h collinear on each subinterval: midpoint equals endpoint average
 WITNESS_A.12 PASS: witness A per-weight influence profile g non-monotone: g(1/2) = 11/20 < g(1/4) = 3/5
 WITNESS_A.13 PASS: witness A one-step amplification T_A(q) > q at q in {5/8, 3/4, 7/8}
-[WITNESS_B] Sign-mixed boundary witness B, off-center fixed point q* = 17/22
+[WITNESS_B] Sign-mixed boundary witness B, off-center fixed-point pair {5/22, 17/22}
 WITNESS_B.1 PASS: witness B node table gated in note text and matched by g exactly
 WITNESS_B.2 PASS: witness B g continuous at internal breakpoints 1/4, 1/2, 3/4
 WITNESS_B.3 PASS: witness B f(0) = 0 and f(1) = 1
@@ -69,10 +69,11 @@ WITNESS_B.6 PASS: witness B h(21/22) = 2/5 > 0 while h(3/4) < 0: sign-mixed on (
 WITNESS_B.7 PASS: witness B h(q) = 1/10 - q/5 on (1/2, 3/4)
 WITNESS_B.8 PASS: witness B h(q) = 11q/5 - 17/10 on (3/4, 1)
 WITNESS_B.9 PASS: witness B: solving h(q) = 0 on (3/4, 1) yields exactly {17/22}
-WITNESS_B.10 PASS: witness B off-center fixed point: T_B(q*) = q* by back-substitution
-WITNESS_B.11 PASS: witness B fixed point q* = 17/22 is off-center (q* != 1/2)
-WITNESS_B.12 PASS: witness B below q*: T_B(7/10) < 7/10 (attenuation region)
-WITNESS_B.13 PASS: witness B above q*: T_B(9/10) > 9/10 (amplification region)
+WITNESS_B.10 PASS: reflection gives the off-center pair {5/22, 17/22}
+WITNESS_B.11 PASS: both off-center points satisfy T_B(q*) = q* by back-substitution
+WITNESS_B.12 PASS: piecewise solve plus reflection gives closed fixed set {0,5/22,1/2,17/22,1}
+WITNESS_B.13 PASS: witness B below q*: T_B(7/10) < 7/10 (attenuation region)
+WITNESS_B.14 PASS: witness B above q*: T_B(9/10) > 9/10 (amplification region)
 [IDENTITY] N2 identity member f = x: T_f = q identically, h identically zero
 IDENTITY.1 PASS: identity member f = x: T_f(q) = q identically
 IDENTITY.2 PASS: identity member: every rational sample is fixed (T_f(q) = q)
@@ -84,7 +85,7 @@ LADDER.3 PASS: sqrt member f = sqrt(x): g' = -x^(-3/2)/2 exactly (profile strict
 LADDER.4 PASS: sqrt member: g'(x) < 0 at x in {1/4, 1/2} (not in M)
 LADDER.5 PASS: sqrt member in A-: exact conjugate certificate gives h < 0 on (1/2, 1)
 LADDER.6 PASS: identity member in F but not A: h identically 0 (no reflection asymmetry)
-LADDER.7 PASS: witness B in F but not A: off-center interior zero h(17/22) = 0
+LADDER.7 PASS: witness B in F but not A: reflected off-center zeros h(5/22)=h(17/22)=0
 [SOURCE_GATES] Verbatim quote gates (flattened substring in source AND this note)
 SOURCE_GATES.1 PASS: Q1 family prose (W1b L2): present verbatim in source and in this note
 SOURCE_GATES.2 PASS: Q2 family form (W1b L2): present verbatim in source and in this note
@@ -102,7 +103,7 @@ NOTE_HYGIENE.2 PASS: pinned closing / enumeration phrases are absent from the no
 NOTE_HYGIENE.3 PASS: claim-type line is present exactly
 NOTE_HYGIENE.4 PASS: required sections and status-authority line are present
 NOTE_HYGIENE.5 PASS: the T5 exact-characterization phrase appears exactly once in the flattened note
-TOTAL: PASS=85 FAIL=0
+TOTAL: PASS=86 FAIL=0
 
 ----- stderr -----
 

--- a/scripts/acphilambda_sharpening_import_decomposition_2026_07_16.py
+++ b/scripts/acphilambda_sharpening_import_decomposition_2026_07_16.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""Exact verification for the occupancy-grain sharpening-import decomposition note.
+
+Claim id:
+  acphilambda_occupancy_grain_sharpening_import_decomposition_reflection_asymmetry_orientation_dichotomy_bounded_theorem_note_2026-07-16
+
+Paired note:
+  docs/ACPHILAMBDA_OCCUPANCY_GRAIN_SHARPENING_IMPORT_DECOMPOSITION_REFLECTION_
+  ASYMMETRY_ORIENTATION_DICHOTOMY_BOUNDED_THEOREM_NOTE_2026-07-16.md
+
+Every check is exact (sympy Rationals / symbolic identities / exact radicals via
+sp.sqrt + sp.radsimp). No float ever enters a pass condition. Each gate computes
+its claim: solved fixed points are found by solving, then gated, then substituted
+back. Blocks:
+
+  TEXT_INTEGRITY   note exists, claim id present, dependency filenames cited
+  T1_FIXED_POINT   fixed-point identity; interior fixed set; A-membership <=>
+  T2_SIGN_BRIDGE   sign bridge sign(T_f(q)-q)=sign(h(q)); exchange; slope
+  T3_HORN          off-center amplification T_f(q)>q for q>1/2
+  ORBITS           A+ orbit rises toward 1; A- orbit falls toward 1/2 (exact)
+  WITNESS_A        A+ witness: reflection asymmetry, non-monotone per-weight profile
+  WITNESS_B        sign-mixed boundary witness B, extra fixed point q* = 17/22
+  IDENTITY         N2 identity member f = x: T_f = q, h identically zero
+  LADDER           strict ladder M ( A+ ( A ( F
+  SOURCE_GATES     verbatim source and boundary quote gates
+  NOTE_HYGIENE     no prose decimals, pinned phrases absent, headers present
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import sympy as sp
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / (
+    "docs/ACPHILAMBDA_OCCUPANCY_GRAIN_SHARPENING_IMPORT_DECOMPOSITION_REFLECTION_"
+    "ASYMMETRY_ORIENTATION_DICHOTOMY_BOUNDED_THEOREM_NOTE_2026-07-16.md"
+)
+W1B_PATH = ROOT / (
+    "docs/ACPHILAMBDA_OCCUPANCY_GRAIN_RULE_CLASS_UNIVERSALITY_BOUNDED_THEOREM_"
+    "NOTE_2026-07-11.md"
+)
+AXIOMS_PATH = ROOT / "docs/MINIMAL_AXIOMS_2026-06-29.md"
+OBLIG_PATH = ROOT / "docs/AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md"
+
+PASS_COUNT = 0
+FAIL_COUNT = 0
+BLOCK_COUNTS = {}
+
+
+def flat(text):
+    # Markdown block-quote markers are layout, not part of the quoted prose.
+    return " ".join(re.sub(r"(?m)^\s*>\s?", "", text).split())
+
+
+def check(block, label, condition):
+    global PASS_COUNT, FAIL_COUNT
+    BLOCK_COUNTS[block] = BLOCK_COUNTS.get(block, 0) + 1
+    number = BLOCK_COUNTS[block]
+    passed = bool(condition)
+    if passed:
+        PASS_COUNT += 1
+        result = "PASS"
+    else:
+        FAIL_COUNT += 1
+        result = "FAIL"
+    print(f"{block}.{number} {result}: {label}")
+
+
+def positive(expr):
+    """Exact strict-positivity decision. No float ever enters the decision."""
+    val = sp.simplify(expr)
+    if val.is_positive is True:
+        return True
+    if val.is_positive is False:
+        return False
+    return bool(val > 0)
+
+
+note_text = NOTE_PATH.read_text(encoding="utf-8")
+w1b_text = W1B_PATH.read_text(encoding="utf-8")
+axioms_text = AXIOMS_PATH.read_text(encoding="utf-8")
+oblig_text = OBLIG_PATH.read_text(encoding="utf-8")
+flat_note = flat(note_text)
+
+q, x = sp.symbols("q x", real=True)
+half = sp.Rational(1, 2)
+
+
+# ---------------------------------------------------------------------------
+print("[TEXT_INTEGRITY] Note exists, claim id present, dependency filenames cited")
+CLAIM_ID = ("acphilambda_occupancy_grain_sharpening_import_decomposition_reflection_"
+            "asymmetry_orientation_dichotomy_bounded_theorem_note_2026-07-16")
+check("TEXT_INTEGRITY", "paired note file exists on disk", NOTE_PATH.is_file())
+check("TEXT_INTEGRITY", "note states its claim id verbatim", CLAIM_ID in note_text)
+
+DEP_FILENAMES = [
+    "ACPHILAMBDA_OCCUPANCY_GRAIN_RULE_CLASS_UNIVERSALITY_BOUNDED_THEOREM_NOTE_2026-07-11.md",
+    "MINIMAL_AXIOMS_2026-06-29.md",
+    "FLAVOR_R_HALF_IS_A_STATIONARY_POINT_NOT_FORCED_2026-06-02.md",
+    "AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md",
+]
+for dep_name in DEP_FILENAMES:
+    check("TEXT_INTEGRITY", f"note cites dependency filename {dep_name}",
+          dep_name in note_text)
+
+# ---------------------------------------------------------------------------
+print("[T1_FIXED_POINT] Fixed-point identity, interior fixed set, A-membership equivalence")
+fsym = sp.Function("f")
+
+
+def g_sym(fcall, t):
+    return fcall(t) / t
+
+
+def h_sym(fcall, t):
+    return g_sym(fcall, t) - g_sym(fcall, 1 - t)
+
+
+def T_sym(fcall, t):
+    return fcall(t) / (fcall(t) + fcall(1 - t))
+
+
+# T1 core identity: the fixed-condition numerator equals q(1-q) h(q).
+h_general = fsym(q) / q - fsym(1 - q) / (1 - q)
+identity_lhs = fsym(q) * (1 - q) - q * fsym(1 - q)
+identity_rhs = q * (1 - q) * h_general
+check("T1_FIXED_POINT", "f(q)(1-q) - q f(1-q) = q(1-q)[g(q) - g(1-q)] exactly",
+      sp.simplify(identity_lhs - identity_rhs) == 0)
+
+num_T_minus_q = sp.together(T_sym(fsym, q) - q).as_numer_denom()[0]
+check("T1_FIXED_POINT", "numerator of T_f(q) - q equals f(q)(1-q) - q f(1-q) exactly",
+      sp.simplify(sp.expand(num_T_minus_q) - sp.expand(identity_lhs)) == 0)
+
+# Power members f = q^k: interior fixed set solved, not asserted.
+for exponent in (sp.Integer(2), sp.Integer(3)):
+    fixed_eq = sp.Eq(q ** exponent * (1 - q), q * (1 - q) ** exponent)
+    fixed_sols = sp.solve(fixed_eq, q)
+    check("T1_FIXED_POINT",
+          f"f = q^{exponent}: exact solve of the fixed condition yields only {{0, 1/2, 1}}",
+          set(fixed_sols) == {sp.Integer(0), half, sp.Integer(1)})
+
+# Endpoint extension limits (computed, not stipulated).
+T_pow = q ** 2 / (q ** 2 + (1 - q) ** 2)
+check("T1_FIXED_POINT", "T_f extends by limit to T_f(0) = 0 (exemplar k=2)",
+      sp.limit(T_pow, q, 0, "+") == 0)
+check("T1_FIXED_POINT", "T_f extends by limit to T_f(1) = 1 (exemplar k=2)",
+      sp.limit(T_pow, q, 1, "-") == 1)
+
+# Reflection-oddness: h(1-q) = -h(q) for generic f, so interior zeros off the
+# center pair up across q <-> 1-q; both directions of the A-membership
+# equivalence are gated on concrete members and witnesses below.
+check("T1_FIXED_POINT", "h is reflection-odd for generic f: h(1-q) = -h(q) exactly",
+      sp.simplify(h_general.subs(q, 1 - q) + h_general) == 0)
+
+# ---------------------------------------------------------------------------
+print("[T2_SIGN_BRIDGE] Sign bridge, orientation dichotomy support, exchange, central slope")
+bridge = T_sym(fsym, q) - q - q * (1 - q) * h_general / (fsym(q) + fsym(1 - q))
+check("T2_SIGN_BRIDGE",
+      "T_f(q) - q = q(1-q) h(q) / (f(q)+f(1-q)) exactly (full quotient)",
+      sp.simplify(bridge) == 0)
+check("T2_SIGN_BRIDGE",
+      "sign-bridge numerator q(1-q) h(q) equals f(q)(1-q) - q f(1-q)",
+      sp.simplify(q * (1 - q) * h_general - identity_lhs) == 0)
+
+# Denominator positivity: f(q)+f(1-q) > 0 on (0,1) for concrete members.
+DENOM_MEMBERS = [("q^2", lambda t: t ** 2), ("sqrt(q)", lambda t: sp.sqrt(t))]
+for name, fcall in DENOM_MEMBERS:
+    val = (fcall(q) + fcall(1 - q)).subs(q, sp.Rational(3, 5))
+    check("T2_SIGN_BRIDGE", f"denominator f(q)+f(1-q) > 0 at q=3/5 for f={name}",
+          positive(val))
+
+# Exchange symmetry T_f(1-q) = 1 - T_f(q).
+check("T2_SIGN_BRIDGE", "exchange symmetry: T_f(1-q) = 1 - T_f(q) exactly",
+      sp.simplify(T_sym(fsym, q).subs(q, 1 - q) - (1 - T_sym(fsym, q))) == 0)
+
+# Central slope T_f'(1/2) = f'(1/2)/(2 f(1/2)).
+T_slope = sp.diff(T_sym(fsym, q), q).subs(q, half)
+target_slope = sp.diff(fsym(q), q).subs(q, half) / (2 * fsym(half))
+check("T2_SIGN_BRIDGE", "central slope T_f'(1/2) = f'(1/2)/(2 f(1/2)) exactly",
+      sp.simplify(T_slope - target_slope) == 0)
+
+for exponent in (sp.Rational(1, 2), sp.Integer(2)):
+    Tk = q ** exponent / (q ** exponent + (1 - q) ** exponent)
+    check("T2_SIGN_BRIDGE", f"power member f = q^{exponent}: central slope is exactly {exponent}",
+          sp.simplify(sp.diff(Tk, q).subs(q, half) - exponent) == 0)
+
+kk = sp.Symbol("k", positive=True)
+Tk_sym = q ** kk / (q ** kk + (1 - q) ** kk)
+check("T2_SIGN_BRIDGE", "power member f = q^k, symbolic k > 0: central slope is exactly k",
+      sp.simplify(sp.diff(Tk_sym, q).subs(q, half) - kk) == 0)
+
+# ---------------------------------------------------------------------------
+print("[T3_HORN] Off-center amplification: T_f(q) > q for q > 1/2 across members")
+HORN_MEMBERS = [
+    ("q^2", lambda t: t ** 2),
+    ("q^3", lambda t: t ** 3),
+    ("q^4", lambda t: t ** 4),
+    ("q + q^2", lambda t: t + t ** 2),
+]
+for name, fcall in HORN_MEMBERS:
+    val = T_sym(fcall, sp.Rational(3, 5)) - sp.Rational(3, 5)
+    check("T3_HORN", f"f = {name}: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)",
+          positive(val))
+check("T3_HORN", "mirror: f = q^2 attenuates the minority side, T_f(2/5) < 2/5",
+      positive(sp.Rational(2, 5) - T_sym(lambda t: t ** 2, sp.Rational(2, 5))))
+
+# ---------------------------------------------------------------------------
+print("[ORBITS] Exemplar orbits: A+ rises toward 1; A- falls toward 1/2 (exact)")
+
+
+def orbit(fcall, q0, steps):
+    pts = [sp.Rational(q0) if not isinstance(q0, sp.Expr) else q0]
+    for _ in range(steps):
+        cur = pts[-1]
+        nxt = sp.radsimp(fcall(cur) / (fcall(cur) + fcall(1 - cur)))
+        pts.append(nxt)
+    return pts
+
+# A+ exemplar f = q^2 (majority-amplifying), start 3/5, six exact-rational steps.
+orb_up = orbit(lambda t: t ** 2, sp.Rational(3, 5), 6)
+check("ORBITS", "A+ orbit f=q^2 from 3/5: strictly increasing over six steps",
+      all(positive(orb_up[i + 1] - orb_up[i]) for i in range(6)))
+check("ORBITS", "A+ orbit f=q^2 from 3/5: every iterate stays in (1/2, 1)",
+      all(positive(p - half) and positive(1 - p) for p in orb_up))
+check("ORBITS", "A+ orbit f=q^2 from 3/5: closing gap to 1 is below 1/1000 after six steps",
+      positive(sp.Rational(1, 1000) - (1 - orb_up[-1])))
+
+# A- exemplar f = sqrt(q) (majority-attenuating), start 3/4, six exact-radical steps.
+orb_dn = orbit(lambda t: sp.sqrt(t), sp.Rational(3, 4), 6)
+check("ORBITS", "A- orbit f=sqrt(q) from 3/4: strictly decreasing over six steps",
+      all(positive(orb_dn[i] - orb_dn[i + 1]) for i in range(6)))
+check("ORBITS", "A- orbit f=sqrt(q) from 3/4: every iterate stays above 1/2",
+      all(positive(p - half) for p in orb_dn))
+check("ORBITS", "A- orbit f=sqrt(q) from 3/4: closing gap to 1/2 is below 1/100 after six steps",
+      positive(sp.Rational(1, 100) - (orb_dn[-1] - half)))
+
+# A- exemplar interior fixed set solved exactly (T1: the limit point 1/2 is the
+# unique interior fixed point of f = sqrt(q)).
+sqrt_fixed = sp.solveset(sp.Eq(sp.sqrt(q) * (1 - q), q * sp.sqrt(1 - q)), q,
+                         sp.Interval.open(0, 1))
+check("ORBITS", "A- exemplar f = sqrt(q): interior fixed set solved exactly = {1/2}",
+      sqrt_fixed == sp.FiniteSet(half))
+
+# ---------------------------------------------------------------------------
+print("[WITNESS_A] A+ witness: reflection asymmetry, non-monotone per-weight influence profile")
+# g piecewise linear (a + b x) on [0,1/4],[1/4,1/2],[1/2,3/4],[3/4,1].
+PIECES_A = [
+    (sp.Integer(0), sp.Rational(1, 4), half, sp.Rational(2, 5)),
+    (sp.Rational(1, 4), half, sp.Rational(13, 20), -sp.Rational(1, 5)),
+    (half, sp.Rational(3, 4), sp.Rational(1, 20), sp.Integer(1)),
+    (sp.Rational(3, 4), sp.Integer(1), half, sp.Rational(2, 5)),
+]
+
+
+def g_pw(pieces, t):
+    for lo, hi, aa, bb in pieces:
+        if bool(lo <= t) and bool(t <= hi):
+            return aa + bb * t
+    raise ValueError(f"g evaluated outside [0,1]: {t}")
+
+
+def f_pw(pieces, t):
+    return t * g_pw(pieces, t)
+
+
+def h_pw(pieces, t):
+    return g_pw(pieces, t) - g_pw(pieces, 1 - t)
+
+
+def T_pw(pieces, t):
+    fa, fb = f_pw(pieces, t), f_pw(pieces, 1 - t)
+    return fa / (fa + fb)
+
+
+NODES_A = {
+    sp.Integer(0): half,
+    sp.Rational(1, 4): sp.Rational(3, 5),
+    half: sp.Rational(11, 20),
+    sp.Rational(3, 4): sp.Rational(4, 5),
+    sp.Integer(1): sp.Rational(9, 10),
+}
+NODES_A_TEXT = "g(0) = 1/2,  g(1/4) = 3/5,  g(1/2) = 11/20,  g(3/4) = 4/5,  g(1) = 9/10,"
+check("WITNESS_A", "witness A node table gated in note text and matched by g exactly",
+      flat(NODES_A_TEXT) in flat_note
+      and all(g_pw(PIECES_A, node) == value for node, value in NODES_A.items()))
+check("WITNESS_A", "witness A g continuous at internal breakpoints 1/4, 1/2, 3/4",
+      all(sp.simplify((PIECES_A[i][2] + PIECES_A[i][3] * PIECES_A[i][1])
+                      - (PIECES_A[i + 1][2] + PIECES_A[i + 1][3] * PIECES_A[i + 1][0])) == 0
+          for i in range(3)))
+check("WITNESS_A", "witness A f(0) = 0 and f(1) = 9/10 <= 1",
+      f_pw(PIECES_A, sp.Integer(0)) == 0
+      and f_pw(PIECES_A, sp.Integer(1)) == sp.Rational(9, 10)
+      and f_pw(PIECES_A, sp.Integer(1)) <= 1)
+fprime_A = []
+for lo, hi, aa, bb in PIECES_A:
+    fprime_A.extend([aa + 2 * bb * lo, aa + 2 * bb * hi])
+check("WITNESS_A", "witness A f' > 0 at every piece endpoint (strictly increasing on [0,1])",
+      all(positive(v) for v in fprime_A))
+
+# h derived from g at the reflection nodes.
+check("WITNESS_A", "witness A h(1/2) = 0 (reflection fixed at center)",
+      h_pw(PIECES_A, half) == 0)
+check("WITNESS_A", "witness A h(3/4) = 1/5 derived from g",
+      h_pw(PIECES_A, sp.Rational(3, 4)) == sp.Rational(1, 5))
+check("WITNESS_A", "witness A h(7/8) = 3/10 derived from g (interior sample)",
+      h_pw(PIECES_A, sp.Rational(7, 8)) == sp.Rational(3, 10))
+
+# Symbolic reflection asymmetry on each side of (1/2,1): h(q) = 4q/5 - 2/5.
+h_upper_lo = sp.expand((PIECES_A[2][2] + PIECES_A[2][3] * q)
+                       - (PIECES_A[1][2] + PIECES_A[1][3] * (1 - q)))
+h_upper_hi = sp.expand((PIECES_A[3][2] + PIECES_A[3][3] * q)
+                       - (PIECES_A[0][2] + PIECES_A[0][3] * (1 - q)))
+h_formula = sp.Rational(4, 5) * q - sp.Rational(2, 5)
+check("WITNESS_A", "witness A h(q) = 4q/5 - 2/5 on (1/2, 3/4)",
+      sp.expand(h_upper_lo - h_formula) == 0)
+check("WITNESS_A", "witness A h(q) = 4q/5 - 2/5 on (3/4, 1)",
+      sp.expand(h_upper_hi - h_formula) == 0)
+check("WITNESS_A",
+      "witness A affine certificate: side formulas agree, h(1/2) = 0, slope dh/dq = 4/5 > 0",
+      sp.expand(h_upper_lo - h_upper_hi) == 0
+      and h_formula.subs(q, half) == 0
+      and sp.diff(h_formula, q) == sp.Rational(4, 5)
+      and positive(sp.diff(h_formula, q)))
+
+# Collinearity certificates (one interior triple per subinterval).
+COLLINEAR_A = [
+    (sp.Rational(9, 16), sp.Rational(5, 8), sp.Rational(11, 16)),   # inside (1/2, 3/4)
+    (sp.Rational(13, 16), sp.Rational(7, 8), sp.Rational(15, 16)),  # inside (3/4, 1)
+]
+check("WITNESS_A", "witness A h collinear on each subinterval: midpoint equals endpoint average",
+      all(h_pw(PIECES_A, mid) == (h_pw(PIECES_A, lo) + h_pw(PIECES_A, hi)) / 2
+          for lo, mid, hi in COLLINEAR_A))
+check("WITNESS_A", "witness A per-weight influence profile g non-monotone: g(1/2) = 11/20 < g(1/4) = 3/5",
+      positive(g_pw(PIECES_A, sp.Rational(1, 4)) - g_pw(PIECES_A, half)))
+check("WITNESS_A", "witness A one-step amplification T_A(q) > q at q in {5/8, 3/4, 7/8}",
+      all(positive(T_pw(PIECES_A, s) - s)
+          for s in (sp.Rational(5, 8), sp.Rational(3, 4), sp.Rational(7, 8))))
+
+# ---------------------------------------------------------------------------
+print("[WITNESS_B] Sign-mixed boundary witness B, off-center fixed point q* = 17/22")
+PIECES_B = [
+    (sp.Integer(0), sp.Rational(1, 4), half, sp.Rational(4, 5)),
+    (sp.Rational(1, 4), half, sp.Rational(4, 5), -sp.Rational(2, 5)),
+    (half, sp.Rational(3, 4), half, sp.Rational(1, 5)),
+    (sp.Rational(3, 4), sp.Integer(1), -sp.Rational(2, 5), sp.Rational(7, 5)),
+]
+NODES_B = {
+    sp.Integer(0): half,
+    sp.Rational(1, 4): sp.Rational(7, 10),
+    half: sp.Rational(3, 5),
+    sp.Rational(3, 4): sp.Rational(13, 20),
+    sp.Integer(1): sp.Integer(1),
+}
+NODES_B_TEXT = "g(0) = 1/2,  g(1/4) = 7/10,  g(1/2) = 3/5,  g(3/4) = 13/20,  g(1) = 1,"
+check("WITNESS_B", "witness B node table gated in note text and matched by g exactly",
+      flat(NODES_B_TEXT) in flat_note
+      and all(g_pw(PIECES_B, node) == value for node, value in NODES_B.items()))
+check("WITNESS_B", "witness B g continuous at internal breakpoints 1/4, 1/2, 3/4",
+      all(sp.simplify((PIECES_B[i][2] + PIECES_B[i][3] * PIECES_B[i][1])
+                      - (PIECES_B[i + 1][2] + PIECES_B[i + 1][3] * PIECES_B[i + 1][0])) == 0
+          for i in range(3)))
+check("WITNESS_B", "witness B f(0) = 0 and f(1) = 1",
+      f_pw(PIECES_B, sp.Integer(0)) == 0 and f_pw(PIECES_B, sp.Integer(1)) == 1)
+fprime_B = []
+for lo, hi, aa, bb in PIECES_B:
+    fprime_B.extend([aa + 2 * bb * lo, aa + 2 * bb * hi])
+check("WITNESS_B", "witness B f' > 0 at every piece endpoint (strictly increasing on [0,1])",
+      all(positive(v) for v in fprime_B))
+
+check("WITNESS_B", "witness B h(3/4) = -1/20 (negative just above center)",
+      h_pw(PIECES_B, sp.Rational(3, 4)) == -sp.Rational(1, 20))
+check("WITNESS_B", "witness B h(21/22) = 2/5 > 0 while h(3/4) < 0: sign-mixed on (1/2, 1)",
+      h_pw(PIECES_B, sp.Rational(21, 22)) == sp.Rational(2, 5)
+      and positive(h_pw(PIECES_B, sp.Rational(21, 22)))
+      and not positive(h_pw(PIECES_B, sp.Rational(3, 4))))
+
+# Symbolic h on each side; the upper side carries the off-center zero.
+h_B_lo = sp.expand((PIECES_B[2][2] + PIECES_B[2][3] * q)
+                   - (PIECES_B[1][2] + PIECES_B[1][3] * (1 - q)))
+h_B_hi = sp.expand((PIECES_B[3][2] + PIECES_B[3][3] * q)
+                   - (PIECES_B[0][2] + PIECES_B[0][3] * (1 - q)))
+check("WITNESS_B", "witness B h(q) = 1/10 - q/5 on (1/2, 3/4)",
+      sp.expand(h_B_lo - (sp.Rational(1, 10) - q / 5)) == 0)
+check("WITNESS_B", "witness B h(q) = 11q/5 - 17/10 on (3/4, 1)",
+      sp.expand(h_B_hi - (sp.Rational(11, 5) * q - sp.Rational(17, 10))) == 0)
+
+# Derive q* by solving h = 0 on (3/4, 1); do not assert the constant.
+qstar_set = sp.solveset(sp.Eq(h_B_hi, 0), q, sp.Interval.open(sp.Rational(3, 4), 1))
+check("WITNESS_B", "witness B: solving h(q) = 0 on (3/4, 1) yields exactly {17/22}",
+      qstar_set == sp.FiniteSet(sp.Rational(17, 22)))
+qstar = list(qstar_set)[0]
+check("WITNESS_B", "witness B off-center fixed point: T_B(q*) = q* by back-substitution",
+      T_pw(PIECES_B, qstar) == qstar)
+check("WITNESS_B", "witness B fixed point q* = 17/22 is off-center (q* != 1/2)",
+      qstar != half)
+check("WITNESS_B", "witness B below q*: T_B(7/10) < 7/10 (attenuation region)",
+      positive(sp.Rational(7, 10) - T_pw(PIECES_B, sp.Rational(7, 10))))
+check("WITNESS_B", "witness B above q*: T_B(9/10) > 9/10 (amplification region)",
+      positive(T_pw(PIECES_B, sp.Rational(9, 10)) - sp.Rational(9, 10)))
+
+# ---------------------------------------------------------------------------
+print("[IDENTITY] N2 identity member f = x: T_f = q identically, h identically zero")
+T_id = q / (q + (1 - q))
+check("IDENTITY", "identity member f = x: T_f(q) = q identically",
+      sp.simplify(T_id - q) == 0)
+check("IDENTITY", "identity member: every rational sample is fixed (T_f(q) = q)",
+      all(T_id.subs(q, s) == s
+          for s in (sp.Rational(1, 5), sp.Rational(2, 5), half,
+                    sp.Rational(3, 5), sp.Rational(4, 5))))
+check("IDENTITY", "identity member: per-weight influence profile g = 1, h identically zero",
+      sp.simplify(h_sym(lambda t: t, q)) == 0)
+
+# ---------------------------------------------------------------------------
+print("[LADDER] Strict ladder M ( A+ ( A ( F on named members")
+# Affine subfamily mechanism: for g = c0 + c1 x the asymmetry is h = c1 (2q - 1),
+# so strict increase of the profile (c1 > 0) forces h > 0 on (1/2, 1): M => A+.
+c0, c1 = sp.symbols("c0 c1", real=True)
+h_aff = (c0 + c1 * q) - (c0 + c1 * (1 - q))
+check("LADDER", "affine mechanism: profile g = c0 + c1 x gives h(q) = c1 (2q - 1) exactly",
+      sp.expand(h_aff - c1 * (2 * q - 1)) == 0)
+# Witness A (N0): in A+ (h > 0 on (1/2,1)) but not in M (profile non-monotone).
+check("LADDER", "N0 witness in A+ but not M: g(1/2) < g(1/4) and h > 0 at interior samples",
+      positive(g_pw(PIECES_A, sp.Rational(1, 4)) - g_pw(PIECES_A, half))
+      and all(positive(h_pw(PIECES_A, s))
+              for s in (sp.Rational(5, 8), sp.Rational(3, 4), sp.Rational(7, 8))))
+# sqrt member: in A- (h < 0 on (1/2,1)), hence in A, not A+, not M.
+g_sqrt = 1 / sp.sqrt(x)
+check("LADDER", "sqrt member f = sqrt(x): g' = -x^(-3/2)/2 exactly (profile strictly decreasing)",
+      sp.simplify(sp.diff(g_sqrt, x) + x ** sp.Rational(-3, 2) / 2) == 0)
+check("LADDER", "sqrt member: g'(x) < 0 at x in {1/4, 1/2} (not in M)",
+      all(not positive(sp.diff(g_sqrt, x).subs(x, s))
+          for s in (sp.Rational(1, 4), half)))
+# Conjugate certificate: h(q) sqrt(q) sqrt(1-q) = sqrt(1-q) - sqrt(q), and
+# (sqrt(1-q) - sqrt(q))(sqrt(1-q) + sqrt(q)) = 1 - 2q < 0 on (1/2,1), so h < 0
+# on all of (1/2,1) (conjugate factor and sqrt(q)sqrt(1-q) are positive there).
+h_sqrt = 1 / sp.sqrt(q) - 1 / sp.sqrt(1 - q)
+num_sqrt = sp.sqrt(1 - q) - sp.sqrt(q)
+conj_sqrt = sp.sqrt(1 - q) + sp.sqrt(q)
+check("LADDER", "sqrt member in A-: exact conjugate certificate gives h < 0 on (1/2, 1)",
+      sp.simplify(h_sqrt * sp.sqrt(q) * sp.sqrt(1 - q) - num_sqrt) == 0
+      and sp.expand(num_sqrt * conj_sqrt - (1 - 2 * q)) == 0)
+check("LADDER", "identity member in F but not A: h identically 0 (no reflection asymmetry)",
+      sp.simplify(h_sym(lambda t: t, q)) == 0)
+check("LADDER", "witness B in F but not A: off-center interior zero h(17/22) = 0",
+      h_pw(PIECES_B, sp.Rational(17, 22)) == 0
+      and sp.Rational(17, 22) != half)
+
+# ---------------------------------------------------------------------------
+print("[SOURCE_GATES] Verbatim quote gates (flattened substring in source AND this note)")
+QUOTES = [
+    ("Q1 family prose (W1b L2)",
+     "the normalized record influence of a continued-registration rule in "
+     "that class has the form",
+     w1b_text),
+    ("Q2 family form (W1b L2)",
+     "T_f(q) = f(q) / (f(q)+f(1-q)), f : [0,1] -> [0,1], "
+     "f continuous and strictly increasing,  f(0)=0.",
+     w1b_text),
+    ("Q3 strict-sharpening framing (W1b L3)",
+     "For this lemma, **strict sharpening** has its majority-amplification meaning:",
+     w1b_text),
+    ("Q4 strict-sharpening inequalities (W1b L3)",
+     "T_f(q) < q  for 0<q<1/2, T_f(q) > q  for 1/2<q<1.",
+     w1b_text),
+    ("Q5 scope boundary (W1b)",
+     "L3 uses off-center majority amplification as strict sharpening. Bare "
+     "monotonicity of the influence odds is insufficient, as N2 shows.",
+     w1b_text),
+    ("Q10 parent influence-odds definition (W1b)",
+     "with input odds `O(q)=q/(1-q)` and influence odds `F(q)=f(q)/f(1-q)`",
+     w1b_text),
+    ("Q6 Record locking clause (axioms)",
+     "When present, a record locks exactly one admissible local possibility. A "
+     "site never carries more than one record; records are permanent.",
+     axioms_text),
+    ("Q7 Record readability clause (axioms)",
+     "Only records are readable. A readout value is determined by record "
+     "content alone.",
+     axioms_text),
+    ("Q8 Qualification clause (axioms)",
+     "A choice not fixed by the supplied structure remains a named conditional "
+     "or open dependency.",
+     axioms_text),
+    ("Q9 obligation closure criterion",
+     "A closing theorem must derive the physical matter action and its "
+     "measure, then distinguish the count-once `det_C`/holomorphic "
+     "realization from the count-twice `|det_C|^2`/realified realization "
+     "without inserting the desired charged-lepton value or readout "
+     "dictionary.",
+     oblig_text),
+]
+for name, quote, source in QUOTES:
+    fq = flat(quote)
+    check("SOURCE_GATES", f"{name}: present verbatim in source and in this note",
+          fq in flat(source) and fq in flat_note)
+
+# ---------------------------------------------------------------------------
+print("[NOTE_HYGIENE] Note hygiene gates")
+outside_fences = []
+in_fence = False
+for line in note_text.splitlines():
+    if line.strip().startswith("```"):
+        in_fence = not in_fence
+        continue
+    if not in_fence:
+        outside_fences.append(line)
+prose = "\n".join(outside_fences)
+decimal_hits = [m.group(0) for m in re.finditer(r"[0-9]\.[0-9]", prose)]
+check("NOTE_HYGIENE", "no decimal literals outside code fences in the note",
+      decimal_hits == [])
+FORBIDDEN = ["closes the route", "only route", "last route", "exhaust",
+             "bijection", "final"]
+check("NOTE_HYGIENE", "pinned closing / enumeration phrases are absent from the note",
+      all(phrase not in note_text.lower() for phrase in FORBIDDEN))
+check("NOTE_HYGIENE", "claim-type line is present exactly",
+      "**Claim type:** bounded_theorem" in note_text)
+check("NOTE_HYGIENE", "required sections and status-authority line are present",
+      "## Honest auditor read / Boundary" in note_text
+      and "## Non-claims" in note_text
+      and "**Status authority:** independent audit lane only." in note_text)
+check("NOTE_HYGIENE", "the T5 exact-characterization phrase appears exactly once in the flattened note",
+      flat_note.lower().count("necessary and sufficient") == 1)
+
+# ---------------------------------------------------------------------------
+print(f"TOTAL: PASS={PASS_COUNT} FAIL={FAIL_COUNT}")
+sys.exit(1 if FAIL_COUNT else 0)

--- a/scripts/acphilambda_sharpening_import_decomposition_2026_07_16.py
+++ b/scripts/acphilambda_sharpening_import_decomposition_2026_07_16.py
@@ -19,7 +19,7 @@ back. Blocks:
   T3_HORN          off-center amplification T_f(q)>q for q>1/2
   ORBITS           A+ orbit rises toward 1; A- orbit falls toward 1/2 (exact)
   WITNESS_A        A+ witness: reflection asymmetry, non-monotone per-weight profile
-  WITNESS_B        sign-mixed boundary witness B, extra fixed point q* = 17/22
+  WITNESS_B        sign-mixed boundary witness B, fixed-point pair 5/22, 17/22
   IDENTITY         N2 identity member f = x: T_f = q, h identically zero
   LADDER           strict ladder M ( A+ ( A ( F
   SOURCE_GATES     verbatim source and boundary quote gates
@@ -98,7 +98,6 @@ check("TEXT_INTEGRITY", "note states its claim id verbatim", CLAIM_ID in note_te
 DEP_FILENAMES = [
     "ACPHILAMBDA_OCCUPANCY_GRAIN_RULE_CLASS_UNIVERSALITY_BOUNDED_THEOREM_NOTE_2026-07-11.md",
     "MINIMAL_AXIOMS_2026-06-29.md",
-    "FLAVOR_R_HALF_IS_A_STATIONARY_POINT_NOT_FORCED_2026-06-02.md",
     "AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md",
 ]
 for dep_name in DEP_FILENAMES:
@@ -175,10 +174,11 @@ for name, fcall in DENOM_MEMBERS:
 check("T2_SIGN_BRIDGE", "exchange symmetry: T_f(1-q) = 1 - T_f(q) exactly",
       sp.simplify(T_sym(fsym, q).subs(q, 1 - q) - (1 - T_sym(fsym, q))) == 0)
 
-# Central slope T_f'(1/2) = f'(1/2)/(2 f(1/2)).
+# If f is differentiable at 1/2, then
+# T_f'(1/2) = f'(1/2)/(2 f(1/2)).
 T_slope = sp.diff(T_sym(fsym, q), q).subs(q, half)
 target_slope = sp.diff(fsym(q), q).subs(q, half) / (2 * fsym(half))
-check("T2_SIGN_BRIDGE", "central slope T_f'(1/2) = f'(1/2)/(2 f(1/2)) exactly",
+check("T2_SIGN_BRIDGE", "under differentiability at 1/2: central slope T_f'(1/2) = f'(1/2)/(2 f(1/2)) exactly",
       sp.simplify(T_slope - target_slope) == 0)
 
 for exponent in (sp.Rational(1, 2), sp.Integer(2)):
@@ -197,8 +197,17 @@ HORN_MEMBERS = [
     ("q^2", lambda t: t ** 2),
     ("q^3", lambda t: t ** 3),
     ("q^4", lambda t: t ** 4),
-    ("q + q^2", lambda t: t + t ** 2),
+    ("(q + q^2)/2", lambda t: (t + t ** 2) / 2),
 ]
+horn_poly = (q + q ** 2) / 2
+horn_poly_prime = sp.diff(horn_poly, q)
+check("T3_HORN",
+      "normalized polynomial member is in F: f(0)=0, f(1)=1, and f' >= f'(0)=1/2 > 0",
+      horn_poly.subs(q, 0) == 0
+      and horn_poly.subs(q, 1) == 1
+      and horn_poly_prime == q + half
+      and positive(horn_poly_prime.subs(q, 0))
+      and positive(sp.diff(horn_poly_prime, q)))
 for name, fcall in HORN_MEMBERS:
     val = T_sym(fcall, sp.Rational(3, 5)) - sp.Rational(3, 5)
     check("T3_HORN", f"f = {name}: T_f(3/5) > 3/5 (off-center amplification, q > 1/2)",
@@ -339,7 +348,7 @@ check("WITNESS_A", "witness A one-step amplification T_A(q) > q at q in {5/8, 3/
           for s in (sp.Rational(5, 8), sp.Rational(3, 4), sp.Rational(7, 8))))
 
 # ---------------------------------------------------------------------------
-print("[WITNESS_B] Sign-mixed boundary witness B, off-center fixed point q* = 17/22")
+print("[WITNESS_B] Sign-mixed boundary witness B, off-center fixed-point pair {5/22, 17/22}")
 PIECES_B = [
     (sp.Integer(0), sp.Rational(1, 4), half, sp.Rational(4, 5)),
     (sp.Rational(1, 4), half, sp.Rational(4, 5), -sp.Rational(2, 5)),
@@ -386,15 +395,29 @@ check("WITNESS_B", "witness B h(q) = 1/10 - q/5 on (1/2, 3/4)",
 check("WITNESS_B", "witness B h(q) = 11q/5 - 17/10 on (3/4, 1)",
       sp.expand(h_B_hi - (sp.Rational(11, 5) * q - sp.Rational(17, 10))) == 0)
 
-# Derive q* by solving h = 0 on (3/4, 1); do not assert the constant.
+# Derive the upper root by solving h = 0 on (3/4, 1), then obtain the lower
+# root by the already-proved reflection oddness; do not assert either constant.
 qstar_set = sp.solveset(sp.Eq(h_B_hi, 0), q, sp.Interval.open(sp.Rational(3, 4), 1))
 check("WITNESS_B", "witness B: solving h(q) = 0 on (3/4, 1) yields exactly {17/22}",
       qstar_set == sp.FiniteSet(sp.Rational(17, 22)))
 qstar = list(qstar_set)[0]
-check("WITNESS_B", "witness B off-center fixed point: T_B(q*) = q* by back-substitution",
-      T_pw(PIECES_B, qstar) == qstar)
-check("WITNESS_B", "witness B fixed point q* = 17/22 is off-center (q* != 1/2)",
-      qstar != half)
+qstar_reflected = 1 - qstar
+qstar_pair = {qstar_reflected, qstar}
+check("WITNESS_B", "reflection gives the off-center pair {5/22, 17/22}",
+      qstar_pair == {sp.Rational(5, 22), sp.Rational(17, 22)})
+check("WITNESS_B", "both off-center points satisfy T_B(q*) = q* by back-substitution",
+      all(T_pw(PIECES_B, root) == root for root in qstar_pair))
+upper_low_roots = sp.solveset(
+    sp.Eq(h_B_lo, 0), q, sp.Interval.open(half, sp.Rational(3, 4)))
+upper_roots = set(upper_low_roots) | set(qstar_set)
+closed_fixed_set = (
+    {sp.Integer(0), half, sp.Integer(1)}
+    | upper_roots
+    | {1 - root for root in upper_roots}
+)
+check("WITNESS_B", "piecewise solve plus reflection gives closed fixed set {0,5/22,1/2,17/22,1}",
+      closed_fixed_set
+      == {sp.Integer(0), sp.Rational(5, 22), half, sp.Rational(17, 22), sp.Integer(1)})
 check("WITNESS_B", "witness B below q*: T_B(7/10) < 7/10 (attenuation region)",
       positive(sp.Rational(7, 10) - T_pw(PIECES_B, sp.Rational(7, 10))))
 check("WITNESS_B", "witness B above q*: T_B(9/10) > 9/10 (amplification region)",
@@ -440,12 +463,15 @@ num_sqrt = sp.sqrt(1 - q) - sp.sqrt(q)
 conj_sqrt = sp.sqrt(1 - q) + sp.sqrt(q)
 check("LADDER", "sqrt member in A-: exact conjugate certificate gives h < 0 on (1/2, 1)",
       sp.simplify(h_sqrt * sp.sqrt(q) * sp.sqrt(1 - q) - num_sqrt) == 0
-      and sp.expand(num_sqrt * conj_sqrt - (1 - 2 * q)) == 0)
+      and sp.expand(num_sqrt * conj_sqrt - (1 - 2 * q)) == 0
+      and sp.simplify_logic(sp.Equivalent(
+          sp.reduce_inequalities([q > half, q < 1, h_sqrt < 0], q),
+          sp.And(q > half, q < 1))) is sp.true)
 check("LADDER", "identity member in F but not A: h identically 0 (no reflection asymmetry)",
       sp.simplify(h_sym(lambda t: t, q)) == 0)
-check("LADDER", "witness B in F but not A: off-center interior zero h(17/22) = 0",
-      h_pw(PIECES_B, sp.Rational(17, 22)) == 0
-      and sp.Rational(17, 22) != half)
+check("LADDER", "witness B in F but not A: reflected off-center zeros h(5/22)=h(17/22)=0",
+      all(h_pw(PIECES_B, root) == 0 for root in qstar_pair)
+      and half not in qstar_pair)
 
 # ---------------------------------------------------------------------------
 print("[SOURCE_GATES] Verbatim quote gates (flattened substring in source AND this note)")


### PR DESCRIPTION
## Summary
- Block 02 of the Koide grain-gate campaign (Target 1, attack surface 1b): decomposes the W1b parent note's L3 sharpening import into exact structure plus a single residual binary.
- T1 proves the exact fixed-point identity `f(q)(1-q) - q f(1-q) = q(1-q) h(q)` with `h(q) = g(q) - g(1-q)` and `g = f/x` the note-local per-weight influence profile (kept explicitly distinct from the parent's influence odds `F(q) = f(q)/f(1-q)`, whose definition is quote-gated).
- T2 gives the sign bridge `T_f(q) - q = q(1-q) h(q) / (f(q) + f(1-q))` and the central slope `T_f'(1/2) = f'(1/2)/(2 f(1/2))`, checked for power members including a symbolic exponent `k`.
- T3/T4 exhibit the off-center amplification horn, exact A+/A- exemplar orbits, and the strict ladder `M ( A+ ( A ( F` on piecewise-affine witnesses: N0 (in A+ with a non-monotone profile), N1 (sign-mixed `h` with off-center fixed point `q* = 17/22`), the sqrt member via an exact conjugate certificate, and the identity member as non-recording control.
- T5 states the reduction: the L3 sharpening import equals A-membership plus one orientation binary (A+ vs A-). No orientation is derived, no dial value is touched, and the note claims no ledger status for its parent.

## Changes
- `docs/ACPHILAMBDA_OCCUPANCY_GRAIN_SHARPENING_IMPORT_DECOMPOSITION_REFLECTION_ASYMMETRY_ORIENTATION_DICHOTOMY_BOUNDED_THEOREM_NOTE_2026-07-16.md` (new bounded theorem note)
- `scripts/acphilambda_sharpening_import_decomposition_2026_07_16.py` (paired class-A runner, exact rational/symbolic gates)
- `logs/runner-cache/acphilambda_sharpening_import_decomposition_2026_07_16.txt` (cached output)

## Test Plan
- [x] Runner: `TOTAL: PASS=85 FAIL=0` (re-run on the current base after fast-forward to origin/main)
- [x] `docs/audit/scripts/audit_lint.py --strict`: no errors introduced by this change (the single pre-existing `structured_mirror_reconciliation_note` note-hash error is present on pristine origin/main)
- [x] `docs/audit/scripts/run_pipeline.sh` run in the worktree; all generated `docs/audit/data/` deltas reverted (source-only triple)
- [x] Independent naming-collision lens re-check: no occurrence of "influence odds" applied to `g`; parent-vs-note object distinction verified unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)