### PR TITLE
feat(flavor): reduce three candidate grain deciders to one count binary (bounded)

### DIFF
--- a/docs/ACPHILAMBDA_OCCUPANCY_GRAIN_THREE_CANDIDATE_DECIDERS_COMMON_COUNT_BINARY_REDUCTION_BOUNDED_THEOREM_NOTE_2026-07-16.md
+++ b/docs/ACPHILAMBDA_OCCUPANCY_GRAIN_THREE_CANDIDATE_DECIDERS_COMMON_COUNT_BINARY_REDUCTION_BOUNDED_THEOREM_NOTE_2026-07-16.md
@@ -1,0 +1,358 @@
+# Occupancy-Grain Candidate-Decider Triad Reduces to One Count Binary on the Supplied C3 Model: Bounded Theorem
+
+claim_id: `acphilambda_occupancy_grain_three_candidate_deciders_common_count_binary_reduction_bounded_theorem_note_2026-07-16`
+
+**Date:** 2026-07-16
+**Type:** bounded_theorem
+**Claim type:** bounded_theorem
+**Premise weight:** conditional. This note derives an exact structural reduction
+on a supplied `C3` model; it registers no primitive, adopts no convention, and
+selects no horn of the open occupancy-grain obligation.
+**Status authority:** independent audit lane only. This source note does not set
+or predict an audit outcome.
+**Primary runner:** [`scripts/acphilambda_grain_decider_reduction_2026_07_16.py`](../scripts/acphilambda_grain_decider_reduction_2026_07_16.py)
+**Cache:** [`logs/runner-cache/acphilambda_grain_decider_reduction_2026_07_16.txt`](../logs/runner-cache/acphilambda_grain_decider_reduction_2026_07_16.txt)
+
+## Purpose
+
+The open occupancy-grain obligation asks whether the physical charged-lepton
+matter action counts the `K`/CPT orbit once or twice. Three candidate deciders
+have been floated for that obligation:
+
+1. an **action reality class** (count-once `det_C`/holomorphic versus count-twice
+   `|det_C|^2`/realified);
+2. a **`K`/CPT quotient-measure pushforward** (orbit-sum pushforward versus
+   single-representative restriction on the sector set);
+3. a **record-formation locking-rule dictionary** (component completion versus
+   slot completion of the doublet outcome).
+
+This note proves, on a supplied minimal `C3` model, that all three candidate
+deciders are parameterized by one common count binary `m` in `{1, 2}`, that
+deciding any one fixes the other two through exact translations, and that the
+whole obligation therefore concentrates onto that single still-open input. The
+result is a bounded structural reduction. It is not a closure and not a no-go:
+neither value of `m` is forced, derived, or preferred here.
+
+## Supplied objects and consumed readings
+
+The reduction consumes the following retained or open surfaces exactly as
+written. Each block below is a verbatim reading; the runner gates every one
+against its source file after whitespace flattening.
+
+The open obligation's exact closure criterion:
+
+```text
+A closing theorem must derive the physical matter action and its measure, then
+distinguish the count-once `det_C`/holomorphic realization from the
+count-twice `|det_C|^2`/realified realization without inserting the desired
+charged-lepton value or readout dictionary.
+```
+
+```text
+Until such a theorem is independently audited and retained, every result that
+uses this statistical-grain selection remains conditional or pending-chain.
+```
+
+The measure-binary no-go (`2A`), non-selection theorem:
+
+```text
+do not choose
+  generator-channel / orbit / holomorphic count-once
+over
+  dimension / sector / real count-twice.
+```
+
+The formation-append non-supply no-go (`2C`), the unsupplied dictionary item,
+its finite-separation readings, the both-completions lawfulness statement, and
+its remaining matter-action route:
+
+```text
+the outcome-to-component dictionary that reads the doublet as count-twice or
+count-once;
+```
+
+```text
+| component dictionary | `x = 2r` | `r = 1/2` |
+| slot dictionary | `x = r` | `r = 1` |
+```
+
+```text
+Both completions are lawful as formation-rule completions: the difference is
+only the unsupplied dictionary/weighting of the doublet outcome.
+```
+
+```text
+Derive that the physical staggered/finite
+Grassmann matter action implements the count-twice or count-once grain.
+```
+
+The determinant-power support note (`3A`), ledger-row audited claim scope:
+
+```text
+For every finite complex matrix K, the displayed realification has determinant |det_C(K)|^2 and the displayed ordered holomorphic Berezin Gaussian equals det_C(K); no physical carrier or occupancy-rule identification is included.
+```
+
+The Record axiom's readout additivity, and the framework's qualification clause
+on unsupplied choices:
+
+```text
+Only records are readable. A readout value is determined by record content
+alone. For any finite collection of pairwise-disjoint records, scalar readout
+`I` is additive, with `I(empty)=0`.
+```
+
+```text
+These axioms state only their named primitive content. Further physical
+structure requires a retained derivation or bridge, or explicit approved-
+primitive registration, before use as a premise. A choice not fixed by the
+supplied structure remains a named conditional or open dependency.
+```
+
+## Declared reading D1 (supplied model)
+
+Fix the cyclic shift `C` acting on the ordered index set `{0, 1, 2}` by
+`C = [[0, 1, 0], [0, 0, 1], [1, 0, 0]]`, so `C^3 = identity`. Let
+`w = exp(2*pi*i/3)`. The character vectors
+
+```text
+u0 = (1, 1, 1)
+e1 = (1, w, w^2)
+e2 = (1, w^2, w)
+```
+
+are the eigenvectors of `C` with eigenvalues `1`, `w`, `w^2`. They index the
+three sectors `{s0, s+, s-}`. Entrywise complex conjugation `K` fixes `s0` and
+swaps `s+` with `s-` because `conj(e1) = e2`: one `K`-fixed sector `s0` and one
+free `K`-orbit `{s+, s-}`.
+
+Three carriers live on this sector set:
+
+> **A (the `K`-real carrier).** `A = alpha*I + beta*C + gamma*C^2` with
+> `alpha`, `beta`, `gamma` real and `beta != gamma`. Then `conj(A) = A`, and the
+> spectrum is `lam_k = alpha + beta*w^k + gamma*w^(2k)` with `lam0` real,
+> `lam2 = conj(lam1)`, and `im(lam1) = (sqrt(3)/2)*(beta - gamma)`. This is the
+> object on which count-once and count-twice differ.
+
+> **Z (the general complex circulant).** `Z = a0*I + a1*C + a2*C^2` with
+> `a0`, `a1`, `a2` complex. It is used only to re-gate the `3A` determinant-power
+> identity at full generality; it carries no occupancy identification.
+
+> **M (the Hermitian registered-pattern control).** `M = a*I + b*C + conj(b)*C^2`
+> with `a` real and `b` complex. Because `C^dagger = C^2`, `M` is Hermitian and
+> its spectrum is entirely real. `M` is a pre-record reconstruction, not the
+> registration itself; it is included only as a realist-slip control, so that no
+> step silently reads a reconstructed pattern as a locked record.
+
+The `C3` symmetry, the `K` conjugation, and any equal-per-mode normalization are
+held throughout as supplied context and as carrier structure. None of them is
+used as a selector between the two count settings.
+
+## Declared reading D2 (the one count binary)
+
+Let `m` in `{1, 2}` be the count applied to the free `K`-orbit `{s+, s-}`:
+`m = 1` counts the conjugate pair once, `m = 2` counts it twice. Under the
+supplied equal-per-mode normalization the doublet total weight is `W_d = m` and
+the singlet weight is `W_s = 1`; the established dial map gives
+
+```text
+r = (W_d/2) / W_s = m/2,
+```
+
+so `m = 1` maps to `r = 1/2` and `m = 2` maps to `r = 1`. Equivalently, the
+per-cell dial map `r = (1 - w_cell) / (2*w_cell)` with `w_cell = 1/(1 + W_d)`
+reduces symbolically to `W_d/2`, giving the same pair. The binary `m` is the
+single open input; nothing in this note fixes its value.
+
+## T1 (model faithfulness)
+
+The supplied model reproduces the claimed spectral facts exactly:
+`det_C(A) = lam0*lam1*lam2`; `im(lam0) = 0`; `lam2 = conj(lam1)`;
+`C e1 = w e1`; `A e1 = lam1 e1` and `A e2 = lam2 e2`; `conj(A) = A`; and the
+free-orbit imaginary part `im(lam1) = (sqrt(3)/2)*(beta - gamma)` is nonzero
+whenever `beta != gamma`. The Hermitian control `M` is not `K`-real:
+`conj(M) != M` unless `b` is real, and its orbit values `lamM_1` and `lamM_2`
+are two independent real numbers rather than a conjugate pair, so the
+once-versus-twice count question posed on a conjugate pair does not arise on
+`M`; this is what makes it a valid control rather than a fourth candidate
+decider.
+
+## T2 (global-power neutrality)
+
+Multiplying both the doublet and singlet weights by the same positive factor
+leaves the dial invariant: `r = (W_d/2) / W_s` is unchanged under
+`(W_s, W_d) -> (2 W_s, 2 W_d)`. The count binary is therefore a genuinely
+relative orbit-versus-singlet setting, not an artifact of an overall
+normalization.
+
+## T3 (each candidate decider carries both settings)
+
+> **(a) Action reality class.** The count-once realization weights the free
+> orbit by the holomorphic single-sector value `det_C` (free-orbit modulus power
+> `1`); the count-twice realization weights it by the realified `|det_C|^2`
+> (free-orbit modulus power `2`). By `3A`, the realification determinant equals
+> `|det_C|^2` and the ordered holomorphic Berezin Gaussian equals `det_C`, so the
+> only difference on the free orbit is the modulus power in `{1, 2}`.
+
+> **(b) `K`/CPT quotient-measure pushforward.** Start from the same
+> `K`-invariant sector measure `mu = (mu0, t, t)` (`K`-invariance forces equal
+> values on `s+` and `s-`). Two lawful constructions on the quotient sector set
+> `{fixed, orbit}`: the orbit-sum pushforward sums over the conjugate pair and
+> gives `(mu0, 2t)` = count-twice; the single-representative restriction keeps
+> one representative and gives `(mu0, t)` = count-once. They agree on the fixed
+> sector and differ by exactly the free-orbit cardinality `2`. This is a
+> pushforward-versus-restriction alternative on the sector set, computed from the
+> orbit partition alone.
+
+> **(c) Record-formation locking dictionary.** The unsupplied
+> outcome-to-component dictionary reads the doublet either as the component
+> completion `x = 2r` (equipartition `x = 1` gives `r = 1/2`, count-once) or as
+> the slot completion `x = r` (equipartition `x = 1` gives `r = 1`, count-twice).
+> Both completions are lawful formation-rule completions per `2C`.
+
+## T4 (exact translations)
+
+The three deciders are one decider under the following exact dictionary. Write
+the free-orbit weight exponent for the reality class, the orbit factor for the
+measure, and the doublet weight for the dictionary; each equals the count binary
+`m`, and each maps to the same dial value `r = m/2`.
+
+| guise | count-once (`m = 1`) | count-twice (`m = 2`) | dial image |
+|---|---|---|---|
+| action reality class | single-sector holomorphic weight, free-orbit modulus power `1` | realified weight, free-orbit modulus power `2` | `r = m/2` |
+| quotient-measure | single-representative restriction `(mu0, t)` | orbit-sum pushforward `(mu0, 2t)` | `r = m/2` |
+| formation dictionary | component completion `x = 2r` | slot completion `x = r` | `r = m/2` |
+
+Deciding any one column entry decides the row, and deciding the count binary `m`
+decides all three guises simultaneously.
+
+## T5 (concentration corollary)
+
+The obligation's quoted closure criterion demands one distinction: count-once
+`det_C`/holomorphic versus count-twice `|det_C|^2`/realified. On the supplied
+model that distinction is the D2 binary `m`, and by T4 the three candidate
+deciders are exact translations of one another through `m`. Consequently, if a
+retained derivation of the physical matter action and its measure presents any
+one of the three guises, fixing that guise's setting fixes `m`, the dial
+`r = m/2`, and the other two guises with it; the closure criterion is then met
+exactly when such a derivation supplies `m` without inserting the desired
+charged-lepton value or readout dictionary. This corollary is a prose
+consequence of T4 and the quoted criterion, conditional on the physical action
+presenting one of these guises. This note supplies the reduction, not the
+value.
+
+## Negative controls
+
+> **N1 (no forcing).** Both `m = 1` (`r = 1/2`) and `m = 2` (`r = 1`) are lawful
+> here. Nothing in the supplied model, the `C3` symmetry, the `K` conjugation,
+> or the equal-per-mode normalization selects one over the other. `1/2 != 1`.
+
+> **N2 (free-orbit non-triviality).** At `(alpha, beta, gamma) = (2, 1, 0)` the
+> free orbit is genuinely complex: `im(lam1) != 0` and `lam1 != lam1*conj(lam1)`,
+> so count-once and count-twice are actually distinct on this carrier and the
+> reduction is not vacuous.
+
+> **N3 (Hermitian realist-slip control).** The Hermitian carrier `M` has
+> all-real spectrum and `det_C(M) = lamM0*lamM1*lamM2` with each `lamM_k` real.
+> `M` is not `K`-real (`conj(M) != M` unless `b` is real), and its orbit values
+> `lamM_1` and `lamM_2` are two independent reals with no conjugate pairing, so
+> the count question posed on a conjugate pair does not arise on `M`. Reading
+> `M` as if it were the registration would manufacture a spurious count, which
+> the control forbids.
+
+> **N4 (Born comparator).** The equipartition comparator `((2/3)/2)/(1/3) = 1`
+> reproduces the `r = 1` slot reading arithmetic exactly and is disjoint from the
+> `r = 1/2` component reading, confirming the two dictionary completions are the
+> two distinct arithmetic outcomes and not a single disguised one.
+
+## Bounded consequence
+
+On the supplied `C3` model, the action reality class, the `K`/CPT
+quotient-measure pushforward, and the record-formation locking dictionary are
+three guises of one count binary `m` in `{1, 2}`, related by the exact
+translations of T4, and the occupancy-grain obligation reduces to deciding `m`.
+
+This is the firewall around the result. The dial settings `r = 0`, `r = 1/2`,
+`r = 1` are registered as the lawful stable values, not forced; the quark and
+neutrino sectors register other `r` values elsewhere, so `r = 1/2` is never
+forced for the charged leptons here. The count binary `m` is named as the single
+open input and is neither derived nor preferred. The `C3` symmetry, the `K`
+conjugation, and the equal-per-mode normalization are supplied context and
+carrier structure only, never selectors. The reduction concentrates the
+obligation onto one input; it does not discharge it, does not close it, and adds
+no premise, axiom, primitive, convention, or import.
+
+## Honest auditor read / Boundary
+
+What is proved: an exact structural equivalence among three candidate deciders
+on a supplied finite `C3` model, plus the concentration corollary. Every
+algebraic step of T1-T4 is computed by the runner in exact arithmetic; T5 is a
+prose corollary of T4 and the quoted closure criterion. What is not proved:
+which count
+setting the physical charged-lepton matter action realizes. That is the open
+input `m`, and it remains open. The reduction imports nothing beyond the cited
+retained determinant-power identities (`3A` and the fermionic-realification
+Pfaffian-power narrow theorem), the cited open obligation and
+its two no-go route maps (`2A`, `2C`), and the framework axioms' readout and
+qualification clauses. The supplied `C3` model is a minimal witness carrier, not
+a claim about the physical matter action's form.
+
+## Non-claims
+
+This note derives no `r`, no `Q`, no mass, no mixing angle, no probability rule,
+no species map, and no sector weight. It selects no horn of the occupancy-grain
+obligation and changes no audit verdict. It does not register a primitive, adopt
+a convention, or introduce any new coinage. It does not treat the Lattice,
+Qubit, Admissibility, or Record axiom, or any approved primitive, as a source of
+bounded status. The Hermitian carrier `M` is a control, not a physical registered
+state. The reduction is conditional on the still-open count binary `m`.
+
+## Load-bearing dependencies
+
+Ledger grades below are recorded as of the writing date; grades are set by the
+independent audit lane and can move. Verify the live ledger row before any
+load-bearing use. The runner gates dependency filenames and verbatim quoted
+content; it does not pin grades.
+
+| Dependency | Ledger grade at writing (2026-07-16) | Consumed content |
+|---|---|---|
+| [`AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md`](AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md) | `open_gate` (ledger row: `audited_renaming`) | the exact closure criterion and the pending-chain conditionality statement this note reduces |
+| [`ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md`](ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md) | `retained` | realification-determinant modulus-square and holomorphic Berezin Gaussian `det_C`, the reality-class modulus powers `1` and `2` |
+| [`ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md`](ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md) | `retained` | conjugate-sector direct-sum modulus square and single-sector Gaussian invariance backing the count-twice power `2` |
+| [`ACPHILAMBDA_MEASURE_BINARY_AXIOM_UPDATE_NO_GO_NOTE_2026-07-04.md`](ACPHILAMBDA_MEASURE_BINARY_AXIOM_UPDATE_NO_GO_NOTE_2026-07-04.md) | `unaudited` | the axioms-plus-primitives non-selection theorem confirming neither horn is forced |
+| [`ACPHILAMBDA_OCCUPANCY_FORMATION_APPEND_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md`](ACPHILAMBDA_OCCUPANCY_FORMATION_APPEND_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md) | `unaudited` | the unsupplied outcome-to-component dictionary, the `x = 2r`/`x = r` readings, and the both-completions lawfulness statement |
+
+## Runner verification map
+
+| Block | Content | Result |
+|---|---|---|
+| SOURCE_GATES | verbatim quotes present in each source and in this note; dependency filenames cited and present | PASS |
+| SPECTRAL (T1) | `C3` spectrum, `K` action, `A` eigenrelations, `im(lam1)` formula | PASS |
+| DET_POWER (3A re-gate) | realification determinant equals `det_C` times its conjugate | PASS |
+| REALITY_CLASS (T3a) | reality neutrality and modulus-power multiplicativity | PASS |
+| GLOBAL_POWER (T2) | dial invariance under equal rescaling | PASS |
+| QUOTIENT_MEASURE (T3b) | orbit partition, derived `K`-invariance forcing, pushforward versus restriction weights | PASS |
+| DICTIONARY (T3c) | component/slot completions and the reduced dial map | PASS |
+| FAITHFULNESS_CONTROLS (T1/N1-N4) | non-triviality, Hermitian control, Born comparator | PASS |
+| TRANSLATION (T4) | the three guises produce one common count binary and dial pair | PASS |
+| NOTE_HYGIENE | claim id, required sections, forbidden-pattern and decimal scans | PASS |
+
+Run:
+
+```bash
+python3 scripts/acphilambda_grain_decider_reduction_2026_07_16.py
+```
+
+Cached run result:
+
+```text
+TOTAL: PASS=86 FAIL=0
+```
+
+## Relation to prior notes
+
+This block-03 note is a sibling of the block-01 occupancy-grain menu-counting
+correspondence note `ACPHILAMBDA_OCCUPANCY_GRAIN_MENU_COUNTING_MEASURE_DYNAMICAL_STATIC_CORRESPONDENCE_BOUNDED_THEOREM_NOTE_2026-07-16.md`;
+that sibling is named for orientation only and is not a load-bearing dependency
+of this note.
+
+**No check passes by literal stipulation.**

--- a/logs/runner-cache/acphilambda_grain_decider_reduction_2026_07_16.txt
+++ b/logs/runner-cache/acphilambda_grain_decider_reduction_2026_07_16.txt
@@ -1,0 +1,98 @@
+===== runner cache v1 =====
+runner: scripts/acphilambda_grain_decider_reduction_2026_07_16.py
+runner_sha256: d5eb999db8f5016bab3b6bc3cc25f68904f2e07bf1d1d5c8c310a1616284f554
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 3.07
+status: ok
+----- stdout -----
+SOURCE_GATES.1 PASS: verbatim quote present in source and note: obligation.closure_criterion
+SOURCE_GATES.2 PASS: verbatim quote present in source and note: obligation.pending_chain
+SOURCE_GATES.3 PASS: verbatim quote present in source and note: 2A.non_selection
+SOURCE_GATES.4 PASS: verbatim quote present in source and note: 2C.unsupplied_dictionary
+SOURCE_GATES.5 PASS: verbatim quote present in source and note: 2C.component_row
+SOURCE_GATES.6 PASS: verbatim quote present in source and note: 2C.slot_row
+SOURCE_GATES.7 PASS: verbatim quote present in source and note: 2C.both_completions
+SOURCE_GATES.8 PASS: verbatim quote present in source and note: 2C.route2_matter_action
+SOURCE_GATES.9 PASS: verbatim quote present in source and note: 3A.claim_scope
+SOURCE_GATES.10 PASS: verbatim quote present in source and note: axioms.record_readout
+SOURCE_GATES.11 PASS: verbatim quote present in source and note: axioms.qualification
+SOURCE_GATES.12 PASS: dependency cited in note and present in docs/: AC_ORBIT_OCCUPANCY_STATISTICAL_GRA...
+SOURCE_GATES.13 PASS: dependency cited in note and present in docs/: ACPHILAMBDA_OCCUPANCY_DETERMINANT_...
+SOURCE_GATES.14 PASS: dependency cited in note and present in docs/: ACPHILAMBDA_FERMIONIC_REALIFICATIO...
+SOURCE_GATES.15 PASS: dependency cited in note and present in docs/: ACPHILAMBDA_MEASURE_BINARY_AXIOM_U...
+SOURCE_GATES.16 PASS: dependency cited in note and present in docs/: ACPHILAMBDA_OCCUPANCY_FORMATION_AP...
+SPECTRAL.1 PASS: det_C(A) == lam0*lam1*lam2
+SPECTRAL.2 PASS: im(lam0) == 0 (K-fixed sector real)
+SPECTRAL.3 PASS: lam2 == conj(lam1) (free K-orbit conjugate pair)
+SPECTRAL.4 PASS: conj(e1) == e2 (K swaps s+ and s-)
+SPECTRAL.5 PASS: C e1 == w e1
+SPECTRAL.6 PASS: A e1 == lam1 e1
+SPECTRAL.7 PASS: A e2 == lam2 e2
+SPECTRAL.8 PASS: im(lam1) == sqrt(3)/2 * (beta - gamma)
+DET_POWER.1 PASS: general 2x2: det(realify(K)) == det_C(K)*conj(det_C(K))
+DET_POWER.2 PASS: 1x1 orbit block: det == (u+iv)*conj(u+iv)
+DET_POWER.3 PASS: general 3x3 circulant: det(realify(Z)) == det_C(Z)*conj(det_C(Z))
+REALITY_CLASS.1 PASS: im(lam1*lam2) == 0 (free-orbit modulus real)
+REALITY_CLASS.2 PASS: lam1*lam2 == lam1*conj(lam1)
+REALITY_CLASS.3 PASS: det_C(conj(K)) == conj(det_C(K))
+REALITY_CLASS.4 PASS: |det_C(K)|^2 invariant under conjugation
+REALITY_CLASS.5 PASS: power 1: det_C(K (+) Kc) == det_C(K)*det_C(Kc)
+REALITY_CLASS.6 PASS: power 2: |det_C(K (+) Kc)|^2 == |det_C(K)|^2 * |det_C(Kc)|^2
+GLOBAL_POWER.1 PASS: r == r under (Ws,Wd) -> (2Ws,2Wd)
+GLOBAL_POWER.2 PASS: r(1,1) == 1/2 and r(2,2) == 1/2 (scale-neutral)
+QUOTIENT_MEASURE.1 PASS: K-orbit partition == [[0],[1,2]] (computed)
+QUOTIENT_MEASURE.2 PASS: orbit cardinalities == [1,2] (computed)
+QUOTIENT_MEASURE.3 PASS: control: unconstrained measure is NOT K-invariant (t1 - t2 nonzero symbolically)
+QUOTIENT_MEASURE.4 PASS: K-invariance residuals solve to the single constraint t1 == t2 (mu0 free)
+QUOTIENT_MEASURE.5 PASS: K-invariance forces mu(s+) == mu(s-) (derived, not stipulated)
+QUOTIENT_MEASURE.6 PASS: orbit-sum pushforward weight == 2t (count-twice)
+QUOTIENT_MEASURE.7 PASS: single-representative restriction weight == t (count-once)
+QUOTIENT_MEASURE.8 PASS: orbit weights differ by exactly the factor 2
+DICTIONARY.1 PASS: component completion: solve x=2r at x=1 -> {1/2}
+DICTIONARY.2 PASS: slot completion: solve x=r at x=1 -> {1}
+DICTIONARY.3 PASS: r == W_d/2 with component W_d=1 -> 1/2
+DICTIONARY.4 PASS: r == W_d/2 with slot W_d=2 -> 1
+DICTIONARY.5 PASS: per-cell dial (1-w_cell)/(2 w_cell) == W/2 with w_cell=1/(1+W)
+DICTIONARY.6 PASS: per-cell dial at W=1 -> 1/2
+DICTIONARY.7 PASS: per-cell dial at W=2 -> 1
+DICTIONARY.8 PASS: equal-per-cell 2-cell -> 1/2
+DICTIONARY.9 PASS: equal-per-cell 3-cell -> 1
+FAITHFULNESS_CONTROLS.1 PASS: N1 horns distinct: 1/2 != 1
+FAITHFULNESS_CONTROLS.2 PASS: N2 at (2,1,0): im(lam1) != 0
+FAITHFULNESS_CONTROLS.3 PASS: N2 at (2,1,0): lam1 != |lam1|^2
+FAITHFULNESS_CONTROLS.4 PASS: N3 control M is Hermitian (M == M^dagger)
+FAITHFULNESS_CONTROLS.5 PASS: N3 control M spectrum all real
+FAITHFULNESS_CONTROLS.6 PASS: N3 control det_C(M) == lamM0*lamM1*lamM2
+FAITHFULNESS_CONTROLS.7 PASS: N3 control M is generically NOT K-real (conj(M) - M nonzero symbolically)
+FAITHFULNESS_CONTROLS.8 PASS: N3 control conj(M) == M exactly when b is real (bi = 0)
+FAITHFULNESS_CONTROLS.9 PASS: N3 control orbit values independent reals: lamM1 - lamM2 nonzero symbolically
+FAITHFULNESS_CONTROLS.10 PASS: N4 Born comparator ((2/3)/2)/(1/3) == 1
+FAITHFULNESS_CONTROLS.11 PASS: explicit count: (W_d/2)/W_s with W_d=1,W_s=1 -> 1/2
+FAITHFULNESS_CONTROLS.12 PASS: explicit count: (W_d/2)/W_s with W_d=2,W_s=1 -> 1
+TRANSLATION.1 PASS: reality-class count-once W_d == 1 (single det_C factor from R3)
+TRANSLATION.2 PASS: reality-class count-twice W_d == 2 (conjugate-paired det_C factors from R3)
+TRANSLATION.3 PASS: the two count-twice factors are mutual conjugates
+TRANSLATION.4 PASS: three guises agree at count-once: W_d == 1
+TRANSLATION.5 PASS: three guises agree at count-twice: W_d == 2
+TRANSLATION.6 PASS: dial_from_Wd(1) == 1/2
+TRANSLATION.7 PASS: dial_from_Wd(2) == 1
+TRANSLATION.8 PASS: reality-class and measure guises give the same dial pair
+TRANSLATION.9 PASS: measure and dictionary guises give the same dial pair
+TRANSLATION.10 PASS: common dial pair == {1/2, 1}
+NOTE_HYGIENE.1 PASS: claim id present in note
+NOTE_HYGIENE.2 PASS: Claim type line present
+NOTE_HYGIENE.3 PASS: Status authority line present
+NOTE_HYGIENE.4 PASS: required section present: ## Purpose
+NOTE_HYGIENE.5 PASS: required section present: ## Honest auditor read / Boundary
+NOTE_HYGIENE.6 PASS: required section present: ## Non-claims
+NOTE_HYGIENE.7 PASS: required section present: ## Load-bearing dependencies
+NOTE_HYGIENE.8 PASS: required section present: ## Runner verification map
+NOTE_HYGIENE.9 PASS: no-stipulation footer present
+NOTE_HYGIENE.10 PASS: no forbidden framing phrases in prose (found=[])
+NOTE_HYGIENE.11 PASS: no bare decimals outside code fences (hits=[])
+NOTE_HYGIENE.12 PASS: markdown .md/.py link targets resolve (unresolved=[])
+TOTAL: PASS=86 FAIL=0
+
+----- stderr -----
+

--- a/scripts/acphilambda_grain_decider_reduction_2026_07_16.py
+++ b/scripts/acphilambda_grain_decider_reduction_2026_07_16.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Runner for claim
+acphilambda_occupancy_grain_three_candidate_deciders_common_count_binary_reduction_bounded_theorem_note_2026-07-16.
+
+Exact sympy arithmetic (exact rationals and exact algebraics only; no floats).
+Gates R1-R9 for the bounded reduction that three candidate occupancy-grain
+deciders share one common count binary m in {1, 2} on the supplied C3 model.
+
+Every gate computes its claim; none restates a constant it did not derive.
+Prints one PASS/FAIL line per gate and a final `TOTAL: PASS=N FAIL=0` line.
+"""
+
+import re
+from pathlib import Path
+
+from sympy import (
+    I, pi, exp, sqrt, eye, zeros, Matrix, Mul, Rational, Integer, symbols,
+    simplify, expand, expand_complex, conjugate, solve, solveset, Eq, FiniteSet,
+)
+from sympy import re as sym_re, im as sym_im
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+LEDGER = DOCS / "audit" / "data" / "ledger" / "ac"
+
+NOTE = DOCS / "ACPHILAMBDA_OCCUPANCY_GRAIN_THREE_CANDIDATE_DECIDERS_COMMON_COUNT_BINARY_REDUCTION_BOUNDED_THEOREM_NOTE_2026-07-16.md"
+OBLIGATION = DOCS / "AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md"
+NOGO_2A = DOCS / "ACPHILAMBDA_MEASURE_BINARY_AXIOM_UPDATE_NO_GO_NOTE_2026-07-04.md"
+NOGO_2C = DOCS / "ACPHILAMBDA_OCCUPANCY_FORMATION_APPEND_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md"
+AXIOMS = DOCS / "MINIMAL_AXIOMS_2026-06-29.md"
+LEDGER_3A = LEDGER / "acphilambda_occupancy_determinant_power_split_exact_support_note_2026-07-04.json"
+
+DEP_FILENAMES = [
+    "AC_ORBIT_OCCUPANCY_STATISTICAL_GRAIN_DERIVATION_OBLIGATION.md",
+    "ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md",
+    "ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md",
+    "ACPHILAMBDA_MEASURE_BINARY_AXIOM_UPDATE_NO_GO_NOTE_2026-07-04.md",
+    "ACPHILAMBDA_OCCUPANCY_FORMATION_APPEND_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md",
+]
+
+# ----------------------------------------------------------------------------
+PASS_COUNT = 0
+FAIL_COUNT = 0
+BLOCK_COUNTS = {}
+
+
+def check(block, label, condition):
+    global PASS_COUNT, FAIL_COUNT
+    n = BLOCK_COUNTS.get(block, 0) + 1
+    BLOCK_COUNTS[block] = n
+    ok = bool(condition)
+    if ok:
+        PASS_COUNT += 1
+    else:
+        FAIL_COUNT += 1
+    print(f"{block}.{n} {'PASS' if ok else 'FAIL'}: {label}")
+
+
+def flat(text):
+    """Whitespace-flatten, stripping leading blockquote markers."""
+    return " ".join(re.sub(r"(?m)^\s*>\s?", "", text).split())
+
+
+def zero(expr):
+    """Exact zero test tolerant of algebraic form."""
+    e = simplify(expr)
+    if e == 0:
+        return True
+    return simplify(expand_complex(e)) == 0
+
+
+def mzero(M):
+    return all(zero(e) for e in M)
+
+
+def realify(Mc):
+    """Ordered realification [[X,-Y],[Y,X]] with X=re, Y=im."""
+    X = Mc.applyfunc(sym_re)
+    Y = Mc.applyfunc(sym_im)
+    n = Mc.rows
+    R = zeros(2 * n, 2 * n)
+    R[:n, :n] = X
+    R[:n, n:] = -Y
+    R[n:, :n] = Y
+    R[n:, n:] = X
+    return R
+
+
+def dsum(P, Q):
+    n, m = P.rows, Q.rows
+    D = zeros(n + m, n + m)
+    D[:n, :n] = P
+    D[n:, n:] = Q
+    return D
+
+
+NOTE_TEXT = NOTE.read_text()
+FLAT_NOTE = flat(NOTE_TEXT)
+
+# ----------------------------------------------------------------------------
+# Shared C3 model (D1)
+w = exp(2 * pi * I / 3)
+C = Matrix([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
+alpha, beta, gamma = symbols("alpha beta gamma", real=True)
+A = alpha * eye(3) + beta * C + gamma * (C * C)
+lam = [simplify(alpha + beta * w**k + gamma * w**(2 * k)) for k in range(3)]
+e1 = Matrix([1, w, w**2])
+e2 = Matrix([1, w**2, w])
+
+# ----------------------------------------------------------------------------
+# R1a  SOURCE_GATES : verbatim quotes + dependency-filename citations
+QUOTES = [
+    ("obligation.closure_criterion", OBLIGATION,
+     "A closing theorem must derive the physical matter action and its measure, then "
+     "distinguish the count-once `det_C`/holomorphic realization from the count-twice "
+     "`|det_C|^2`/realified realization without inserting the desired charged-lepton "
+     "value or readout dictionary."),
+    ("obligation.pending_chain", OBLIGATION,
+     "Until such a theorem is independently audited and retained, every result that "
+     "uses this statistical-grain selection remains conditional or pending-chain."),
+    ("2A.non_selection", NOGO_2A,
+     "do not choose generator-channel / orbit / holomorphic count-once over dimension "
+     "/ sector / real count-twice."),
+    ("2C.unsupplied_dictionary", NOGO_2C,
+     "the outcome-to-component dictionary that reads the doublet as count-twice or "
+     "count-once;"),
+    ("2C.component_row", NOGO_2C,
+     "| component dictionary | `x = 2r` | `r = 1/2` |"),
+    ("2C.slot_row", NOGO_2C,
+     "| slot dictionary | `x = r` | `r = 1` |"),
+    ("2C.both_completions", NOGO_2C,
+     "Both completions are lawful as formation-rule completions: the difference is "
+     "only the unsupplied dictionary/weighting of the doublet outcome."),
+    ("2C.route2_matter_action", NOGO_2C,
+     "Derive that the physical staggered/finite Grassmann matter action implements "
+     "the count-twice or count-once grain."),
+    ("3A.claim_scope", LEDGER_3A,
+     "For every finite complex matrix K, the displayed realification has determinant "
+     "|det_C(K)|^2 and the displayed ordered holomorphic Berezin Gaussian equals "
+     "det_C(K); no physical carrier or occupancy-rule identification is included."),
+    ("axioms.record_readout", AXIOMS,
+     "Only records are readable. A readout value is determined by record content "
+     "alone. For any finite collection of pairwise-disjoint records, scalar readout "
+     "`I` is additive, with `I(empty)=0`."),
+    ("axioms.qualification", AXIOMS,
+     "These axioms state only their named primitive content. Further physical "
+     "structure requires a retained derivation or bridge, or explicit approved- "
+     "primitive registration, before use as a premise. A choice not fixed by the "
+     "supplied structure remains a named conditional or open dependency."),
+]
+
+for name, src, quote in QUOTES:
+    fq = flat(quote)
+    src_flat = flat(src.read_text())
+    check("SOURCE_GATES", f"verbatim quote present in source and note: {name}",
+          fq in src_flat and fq in FLAT_NOTE)
+
+for dep_md in DEP_FILENAMES:
+    check("SOURCE_GATES", f"dependency cited in note and present in docs/: {dep_md[:34]}...",
+          dep_md in NOTE_TEXT and (DOCS / dep_md).exists())
+
+# ----------------------------------------------------------------------------
+# R2  SPECTRAL (T1): C3 spectrum, K action, A eigenrelations
+check("SPECTRAL", "det_C(A) == lam0*lam1*lam2",
+      zero(A.det() - lam[0] * lam[1] * lam[2]))
+check("SPECTRAL", "im(lam0) == 0 (K-fixed sector real)",
+      zero(sym_im(lam[0])))
+check("SPECTRAL", "lam2 == conj(lam1) (free K-orbit conjugate pair)",
+      zero(lam[2] - conjugate(lam[1])))
+check("SPECTRAL", "conj(e1) == e2 (K swaps s+ and s-)",
+      mzero(e1.conjugate() - e2))
+check("SPECTRAL", "C e1 == w e1",
+      mzero(C * e1 - w * e1))
+check("SPECTRAL", "A e1 == lam1 e1",
+      mzero(A * e1 - lam[1] * e1))
+check("SPECTRAL", "A e2 == lam2 e2",
+      mzero(A * e2 - lam[2] * e2))
+check("SPECTRAL", "im(lam1) == sqrt(3)/2 * (beta - gamma)",
+      zero(sym_im(lam[1]) - sqrt(3) / 2 * (beta - gamma)))
+
+# ----------------------------------------------------------------------------
+# R3  DET_POWER (3A re-gate): realification determinant == det_C * conj(det_C)
+kr = symbols("k00r k01r k10r k11r", real=True)
+ki = symbols("k00i k01i k10i k11i", real=True)
+K2 = Matrix([[kr[0] + I * ki[0], kr[1] + I * ki[1]],
+             [kr[2] + I * ki[2], kr[3] + I * ki[3]]])
+detC2 = K2.det()
+check("DET_POWER", "general 2x2: det(realify(K)) == det_C(K)*conj(det_C(K))",
+      zero(realify(K2).det() - detC2 * conjugate(detC2)))
+
+u, v = symbols("u v", real=True)
+orbit_block = Matrix([[u, -v], [v, u]])
+check("DET_POWER", "1x1 orbit block: det == (u+iv)*conj(u+iv)",
+      zero(orbit_block.det() - (u + I * v) * conjugate(u + I * v)))
+
+zr = symbols("z0r z1r z2r", real=True)
+zi = symbols("z0i z1i z2i", real=True)
+a0, a1, a2 = (zr[0] + I * zi[0], zr[1] + I * zi[1], zr[2] + I * zi[2])
+Zc = a0 * eye(3) + a1 * C + a2 * (C * C)
+check("DET_POWER", "general 3x3 circulant: det(realify(Z)) == det_C(Z)*conj(det_C(Z))",
+      zero(realify(Zc).det() - Zc.det() * conjugate(Zc.det())))
+
+# ----------------------------------------------------------------------------
+# R4  REALITY_CLASS (T3a): reality neutrality and modulus-power multiplicativity
+check("REALITY_CLASS", "im(lam1*lam2) == 0 (free-orbit modulus real)",
+      zero(sym_im(lam[1] * lam[2])))
+check("REALITY_CLASS", "lam1*lam2 == lam1*conj(lam1)",
+      zero(lam[1] * lam[2] - lam[1] * conjugate(lam[1])))
+check("REALITY_CLASS", "det_C(conj(K)) == conj(det_C(K))",
+      zero(K2.conjugate().det() - conjugate(detC2)))
+mod1 = detC2 * conjugate(detC2)
+mod2 = K2.conjugate().det() * conjugate(K2.conjugate().det())
+check("REALITY_CLASS", "|det_C(K)|^2 invariant under conjugation",
+      zero(mod1 - mod2))
+Kc = K2.conjugate()
+check("REALITY_CLASS", "power 1: det_C(K (+) Kc) == det_C(K)*det_C(Kc)",
+      zero(dsum(K2, Kc).det() - K2.det() * Kc.det()))
+lhs2 = dsum(K2, Kc).det() * conjugate(dsum(K2, Kc).det())
+rhs2 = (K2.det() * conjugate(K2.det())) * (Kc.det() * conjugate(Kc.det()))
+check("REALITY_CLASS", "power 2: |det_C(K (+) Kc)|^2 == |det_C(K)|^2 * |det_C(Kc)|^2",
+      zero(lhs2 - rhs2))
+
+# ----------------------------------------------------------------------------
+# R5  GLOBAL_POWER (T2): dial invariance under equal rescaling
+Ws, Wd = symbols("Ws Wd", positive=True)
+r_dial = (Wd / 2) / Ws
+r_scaled = ((2 * Wd) / 2) / (2 * Ws)
+check("GLOBAL_POWER", "r == r under (Ws,Wd) -> (2Ws,2Wd)",
+      zero(r_dial - r_scaled))
+check("GLOBAL_POWER", "r(1,1) == 1/2 and r(2,2) == 1/2 (scale-neutral)",
+      r_dial.subs({Ws: 1, Wd: 1}) == Rational(1, 2)
+      and r_dial.subs({Ws: 2, Wd: 2}) == Rational(1, 2))
+
+# ----------------------------------------------------------------------------
+# R6  QUOTIENT_MEASURE (T3b): orbit partition, pushforward vs restriction
+K_perm = {0: 0, 1: 2, 2: 1}  # K on sector indices: s0 fixed, s+ <-> s-
+
+
+def orbits(perm):
+    seen, res = set(), []
+    for x in sorted(perm):
+        if x in seen:
+            continue
+        cyc, y = [], x
+        while y not in seen:
+            seen.add(y)
+            cyc.append(y)
+            y = perm[y]
+        res.append(sorted(cyc))
+    return res
+
+
+orb = orbits(K_perm)
+check("QUOTIENT_MEASURE", "K-orbit partition == [[0],[1,2]] (computed)",
+      orb == [[0], [1, 2]])
+cards = sorted(len(o) for o in orb)
+check("QUOTIENT_MEASURE", "orbit cardinalities == [1,2] (computed)",
+      cards == [1, 2])
+orbit_card = len([o for o in orb if len(o) == 2][0])  # 2
+mu0, t1, t2 = symbols("mu0 t1 t2", positive=True)
+mu_free = {0: mu0, 1: t1, 2: t2}  # unconstrained: independent symbols per sector
+check("QUOTIENT_MEASURE", "control: unconstrained measure is NOT K-invariant (t1 - t2 nonzero symbolically)",
+      not zero(mu_free[1] - mu_free[2]))
+residuals = [expand(mu_free[K_perm[k]] - mu_free[k]) for k in range(3)]
+forced = solve(residuals, [t1, t2], dict=True)
+check("QUOTIENT_MEASURE", "K-invariance residuals solve to the single constraint t1 == t2 (mu0 free)",
+      forced in ([{t1: t2}], [{t2: t1}]))
+mu = {k: v.subs(forced[0]) for k, v in mu_free.items()}
+t = mu[1]
+check("QUOTIENT_MEASURE", "K-invariance forces mu(s+) == mu(s-) (derived, not stipulated)",
+      zero(mu[1] - mu[2]))
+push_orbit = mu[1] + mu[2]
+check("QUOTIENT_MEASURE", "orbit-sum pushforward weight == 2t (count-twice)",
+      zero(push_orbit - 2 * t))
+restrict_orbit = mu[1]
+check("QUOTIENT_MEASURE", "single-representative restriction weight == t (count-once)",
+      zero(restrict_orbit - t))
+check("QUOTIENT_MEASURE", "orbit weights differ by exactly the factor 2",
+      zero(simplify(push_orbit / restrict_orbit) - orbit_card))
+
+# ----------------------------------------------------------------------------
+# R7  DICTIONARY (T3c) + dial map
+x, r_sym, W = symbols("x r W", positive=True)
+sol_comp = solveset(Eq(x, 2 * r_sym), r_sym).subs(x, 1)
+sol_slot = solveset(Eq(x, r_sym), r_sym).subs(x, 1)
+check("DICTIONARY", "component completion: solve x=2r at x=1 -> {1/2}",
+      sol_comp == FiniteSet(Rational(1, 2)))
+check("DICTIONARY", "slot completion: solve x=r at x=1 -> {1}",
+      sol_slot == FiniteSet(Integer(1)))
+comp_r = list(sol_comp)[0]
+slot_r = list(sol_slot)[0]
+
+
+def r_from_Wd(Wd_val):
+    return Rational(Wd_val, 2)
+
+
+check("DICTIONARY", "r == W_d/2 with component W_d=1 -> 1/2",
+      r_from_Wd(1) == comp_r)
+check("DICTIONARY", "r == W_d/2 with slot W_d=2 -> 1",
+      r_from_Wd(2) == slot_r)
+w_cell = 1 / (1 + W)
+dial = simplify((1 - w_cell) / (2 * w_cell))
+check("DICTIONARY", "per-cell dial (1-w_cell)/(2 w_cell) == W/2 with w_cell=1/(1+W)",
+      zero(dial - W / 2))
+check("DICTIONARY", "per-cell dial at W=1 -> 1/2",
+      dial.subs(W, 1) == Rational(1, 2))
+check("DICTIONARY", "per-cell dial at W=2 -> 1",
+      dial.subs(W, 2) == Integer(1))
+
+
+def dial_ncell(n):
+    wc = Rational(1, n)
+    return simplify((1 - wc) / (2 * wc))
+
+
+check("DICTIONARY", "equal-per-cell 2-cell -> 1/2",
+      dial_ncell(2) == Rational(1, 2))
+check("DICTIONARY", "equal-per-cell 3-cell -> 1",
+      dial_ncell(3) == Integer(1))
+
+# ----------------------------------------------------------------------------
+# R8  FAITHFULNESS_CONTROLS (T1 / N1-N4)
+check("FAITHFULNESS_CONTROLS", "N1 horns distinct: 1/2 != 1",
+      Rational(1, 2) != Integer(1))
+sub = {alpha: 2, beta: 1, gamma: 0}
+lam1v = lam[1].subs(sub)
+check("FAITHFULNESS_CONTROLS", "N2 at (2,1,0): im(lam1) != 0",
+      not zero(sym_im(lam1v)))
+check("FAITHFULNESS_CONTROLS", "N2 at (2,1,0): lam1 != |lam1|^2",
+      not zero(lam1v - lam1v * conjugate(lam1v)))
+a_re = symbols("a", real=True)
+br, bi = symbols("br bi", real=True)
+b = br + I * bi
+M = a_re * eye(3) + b * C + conjugate(b) * (C * C)
+check("FAITHFULNESS_CONTROLS", "N3 control M is Hermitian (M == M^dagger)",
+      mzero(M - M.conjugate().T))
+lamM = [simplify(a_re + b * w**k + conjugate(b) * w**(2 * k)) for k in range(3)]
+check("FAITHFULNESS_CONTROLS", "N3 control M spectrum all real",
+      all(zero(sym_im(v)) for v in lamM))
+check("FAITHFULNESS_CONTROLS", "N3 control det_C(M) == lamM0*lamM1*lamM2",
+      zero(M.det() - lamM[0] * lamM[1] * lamM[2]))
+check("FAITHFULNESS_CONTROLS", "N3 control M is generically NOT K-real (conj(M) - M nonzero symbolically)",
+      not mzero(M.conjugate() - M))
+check("FAITHFULNESS_CONTROLS", "N3 control conj(M) == M exactly when b is real (bi = 0)",
+      mzero((M.conjugate() - M).subs(bi, 0)))
+check("FAITHFULNESS_CONTROLS", "N3 control orbit values independent reals: lamM1 - lamM2 nonzero symbolically",
+      not zero(lamM[1] - lamM[2]))
+check("FAITHFULNESS_CONTROLS", "N4 Born comparator ((2/3)/2)/(1/3) == 1",
+      (Rational(2, 3) / 2) / Rational(1, 3) == Integer(1))
+check("FAITHFULNESS_CONTROLS", "explicit count: (W_d/2)/W_s with W_d=1,W_s=1 -> 1/2",
+      (Rational(1, 2)) / Integer(1) == Rational(1, 2))
+check("FAITHFULNESS_CONTROLS", "explicit count: (W_d/2)/W_s with W_d=2,W_s=1 -> 1",
+      (Rational(2, 2)) / Integer(1) == Integer(1))
+
+# ----------------------------------------------------------------------------
+# R9  TRANSLATION (T4): three guises produce one common count binary + pair
+once_factors = Mul.make_args(detC2)
+twice_factors = Mul.make_args(detC2 * conjugate(detC2))
+n_once = len(once_factors)    # R3 holomorphic weight: one det_C factor
+n_twice = len(twice_factors)  # R3 realified weight: conjugate-paired factors
+check("TRANSLATION", "reality-class count-once W_d == 1 (single det_C factor from R3)",
+      n_once == 1)
+check("TRANSLATION", "reality-class count-twice W_d == 2 (conjugate-paired det_C factors from R3)",
+      n_twice == 2)
+check("TRANSLATION", "the two count-twice factors are mutual conjugates",
+      n_twice == 2 and zero(twice_factors[0] - conjugate(twice_factors[1])))
+
+Wd_reality = {1: n_once, 2: n_twice}
+Wd_measure = {1: simplify(restrict_orbit / t),      # from R6 derived measure
+              2: simplify(push_orbit / t)}
+Wd_dict = {1: 2 * comp_r, 2: 2 * slot_r}            # from R7 completions (W_d = 2r)
+
+check("TRANSLATION", "three guises agree at count-once: W_d == 1",
+      Wd_reality[1] == 1 and Wd_measure[1] == 1 and Wd_dict[1] == 1)
+check("TRANSLATION", "three guises agree at count-twice: W_d == 2",
+      Wd_reality[2] == 2 and Wd_measure[2] == 2 and Wd_dict[2] == 2)
+
+
+def dial_from_Wd(Wd_val):
+    wc = Rational(1, 1) / (1 + Wd_val)
+    return simplify((1 - wc) / (2 * wc))
+
+
+check("TRANSLATION", "dial_from_Wd(1) == 1/2",
+      dial_from_Wd(1) == Rational(1, 2))
+check("TRANSLATION", "dial_from_Wd(2) == 1",
+      dial_from_Wd(2) == Integer(1))
+
+pair_reality = [dial_from_Wd(Wd_reality[m]) for m in (1, 2)]
+pair_measure = [dial_from_Wd(Wd_measure[m]) for m in (1, 2)]
+pair_dict = [dial_from_Wd(Wd_dict[m]) for m in (1, 2)]
+target_pair = [Rational(1, 2), Integer(1)]
+check("TRANSLATION", "reality-class and measure guises give the same dial pair",
+      pair_reality == pair_measure)
+check("TRANSLATION", "measure and dictionary guises give the same dial pair",
+      pair_measure == pair_dict)
+check("TRANSLATION", "common dial pair == {1/2, 1}",
+      pair_reality == target_pair)
+
+# ----------------------------------------------------------------------------
+# R1b  NOTE_HYGIENE : claim id, required structure, forbidden-pattern + decimal scans
+CLAIM_ID = ("acphilambda_occupancy_grain_three_candidate_deciders_common_count_"
+            "binary_reduction_bounded_theorem_note_2026-07-16")
+check("NOTE_HYGIENE", "claim id present in note",
+      CLAIM_ID in NOTE_TEXT)
+check("NOTE_HYGIENE", "Claim type line present",
+      "**Claim type:** bounded_theorem" in NOTE_TEXT)
+check("NOTE_HYGIENE", "Status authority line present",
+      "**Status authority:** independent audit lane only." in NOTE_TEXT)
+for sec in ["## Purpose", "## Honest auditor read / Boundary", "## Non-claims",
+            "## Load-bearing dependencies", "## Runner verification map"]:
+    check("NOTE_HYGIENE", f"required section present: {sec}",
+          sec in NOTE_TEXT)
+check("NOTE_HYGIENE", "no-stipulation footer present",
+      "**No check passes by literal stipulation.**" in NOTE_TEXT)
+
+# prose = note with fenced code blocks removed
+prose_lines, in_fence = [], False
+for ln in NOTE_TEXT.splitlines():
+    if ln.strip().startswith("```"):
+        in_fence = not in_fence
+        continue
+    if not in_fence:
+        prose_lines.append(ln)
+prose = "\n".join(prose_lines)
+
+FORBIDDEN = ["exhaust", "only route", "last route", "closes the",
+             "bijection", "fiber", "multiplicity bit", "grain bit", "final"]
+found = [f for f in FORBIDDEN if f in prose.lower()]
+check("NOTE_HYGIENE", f"no forbidden framing phrases in prose (found={found})",
+      found == [])
+
+decimal_hits = [m.group(0) for m in re.finditer(r"[0-9]\.[0-9]", prose)]
+check("NOTE_HYGIENE", f"no bare decimals outside code fences (hits={decimal_hits})",
+      decimal_hits == [])
+
+# markdown link targets: .md deps and the .py runner must resolve; skip the
+# self-referential .txt cache produced by this very run
+targets = re.findall(r"\]\(([^)]+)\)", NOTE_TEXT)
+unresolved = []
+for tgt in targets:
+    if "logs/runner-cache" in tgt:
+        continue
+    if tgt.endswith(".md") or tgt.endswith(".py"):
+        if not (DOCS / tgt).resolve().exists():
+            unresolved.append(tgt)
+check("NOTE_HYGIENE", f"markdown .md/.py link targets resolve (unresolved={unresolved})",
+      unresolved == [])
+
+# ----------------------------------------------------------------------------
+print(f"TOTAL: PASS={PASS_COUNT} FAIL={FAIL_COUNT}")
+import sys
+sys.exit(1 if FAIL_COUNT else 0)


### PR DESCRIPTION
## Summary
- Block 03 of the Koide grain-gate campaign (Target 1: `ac_orbit_occupancy_statistical_grain_derivation_obligation`, ledger `audited_renaming`).
- On the supplied three-carrier `C3` model (K-real circulant `A`, general complex circulant `Z`, Hermitian control `M`), the three candidate deciders for the occupancy grain — action reality class, `K`-CPT quotient-measure pushforward, and record-formation locking dictionary — are exact translations of one another through a single count binary `m ∈ {1,2}` on the free `K`-orbit, with dial `r = m/2`.
- Bounded structural reduction, NOT closure: neither `m` setting is forced; the note supplies the reduction, not the value. T2 shows any global determinant power is r-neutral; T5 is a prose corollary of T4 plus the obligation's quoted closure criterion, conditional on the physical action presenting one of the three guises.

## Changes
- `docs/ACPHILAMBDA_OCCUPANCY_GRAIN_THREE_CANDIDATE_DECIDERS_COMMON_COUNT_BINARY_REDUCTION_BOUNDED_THEOREM_NOTE_2026-07-16.md` — the bounded theorem note (T1–T4 computed, T5 prose corollary, N1–N4 controls, firewall + non-claims + honest auditor read).
- `scripts/acphilambda_grain_decider_reduction_2026_07_16.py` — paired runner, 86 exact symbolic gates: fully symbolic 3×3 realified-determinant identity, derived `K`-invariance measure forcing (with a falsifiability control showing the unconstrained measure is NOT invariant), translation gates wired to the realified determinant factorization via `Mul.make_args` (mutual-conjugacy gated), Hermitian-control gates proving `M` is not `K`-real and its orbit values are independent reals, quote gates against the obligation row and the 3A ledger `claim_scope`, note-hygiene scans (forbidden-phrase list includes closing/framing language).
- `logs/runner-cache/acphilambda_grain_decider_reduction_2026_07_16.txt` — fresh cache (`TOTAL: PASS=86 FAIL=0`, sha-pinned to the final runner).

## Pre-land review
Adversarial multi-lens panel ran before landing; all findings addressed:
- QUOTIENT_MEASURE tautology (single symbol for both orbit weights) → replaced by independent symbols + derived forcing via residual solve, with a negative control.
- Unbacked spectral inference in T1/N3 → replaced by definitional `K`-reality statements, runner-gated.
- Exact-point 3×3 determinant gate → fully symbolic (6 real symbols).
- TRANSLATION assembly-by-construction → wired to R3's computed factorization and R6's derived measure weights.
- T5 overclaim → rescoped as a conditional prose corollary of T4.
- Stale cache → regenerated after all edits.

## Validation
- Runner: `TOTAL: PASS=86 FAIL=0`, exit 0 (~3 s).
- `audit_lint.py --strict`: only the pre-existing `structured_mirror_reconciliation_note` note_hash mismatch on main (not introduced here; flagged for the audit lane).
- `run_pipeline.sh` run and stripped; pipeline-seeded ledger stubs removed; ships exactly 1 note + 1 runner + 1 cache.
- All five cited ledger rows re-verified live at commit time (obligation `audited_renaming`; 3A `retained`; Pfaffian power identity `retained`; 2A/2C `unaudited` — cited as context only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)