### PR TITLE
science-fix: formalize finite weighted-transfer theorem

### DIFF
--- a/docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md
+++ b/docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md
@@ -14,8 +14,8 @@ are set only by the independent audit lane.
 ## Exact scope
 
 This note defines finite functions and matrices and proves their elementary
-spectral properties. It then gives independently reconstructed numerical
-enclosures for three separate finite matrices, at `N = 6, 7, 8`.
+spectral properties. It then gives independently reconstructed high-precision
+estimates for three separate finite matrices, at `N = 6, 7, 8`.
 
 The definitions are stipulations inside this theorem. They are not derived
 from, or identified with, an SU(3) heat-kernel action, a lattice-cube measure,
@@ -75,26 +75,33 @@ matrices
 ```text
 L_N := diag(a_1(p,q)^4) = diag(exp(-2c(p,q))),                           (8)
 R_N := diag(rho_1(p,q)),                                                 (9)
+D_N := L_N R_N = diag(d(p,q)^8 exp(-8c(p,q))),                           (10)
 ```
 
 and define
 
 ```text
 M_N := exp(3J_N),
-T_N := M_N L_N R_N M_N.                                                 (10)
+T_N := M_N D_N M_N.                                                     (11)
 ```
+
+The constants `3` in `M_N`, `4` in `a_1^4`, `8` on `d`, and `6` in
+`rho_1` are parts of these definitions. In particular, the powers `4` and `8`
+and the exponential factors `2`, `6`, and their combined value `8` do not
+inherit a topology, dimension, incidence count, or other interpretation from
+the stable legacy name.
 
 Let `lambda_N` be the largest eigenvalue of `T_N`. Let `v_N` be its real
 eigenvector normalized by
 
 ```text
-v_N^T v_N = 1,       sum_x (v_N)_x > 0,                                 (11)
+v_N^T v_N = 1,       sum_x (v_N)_x > 0,                                 (12)
 ```
 
 and define the scalar
 
 ```text
-P_N := v_N^T J_N v_N.                                                    (12)
+P_N := v_N^T J_N v_N.                                                    (13)
 ```
 
 ## Finite-matrix theorem
@@ -102,19 +109,25 @@ P_N := v_N^T J_N v_N.                                                    (12)
 For every nonnegative integer `N`:
 
 1. `J_N` is real symmetric and entrywise nonnegative.
-2. `M_N` is real symmetric positive definite and entrywise strictly positive.
-3. `T_N` is real symmetric positive definite and entrywise strictly positive.
-4. The largest eigenvalue `lambda_N` is positive and simple. Its eigenvector
-   is entrywise strictly positive up to an overall sign, so convention (11)
+2. Under the actual finite-box truncation, `||J_N||_2 <= 1`.
+3. `M_N` is real symmetric positive definite and entrywise strictly positive.
+4. `D_N` is positive diagonal, while `T_N` is real symmetric positive
+   definite and entrywise strictly positive.
+5. The largest eigenvalue `lambda_N` is positive and simple. Its eigenvector
+   is entrywise strictly positive up to an overall sign, so convention (12)
    determines `v_N` uniquely.
-5. `P_N` is well-defined and unchanged by either sign or nonzero scaling of a
+6. `P_N` is well-defined and unchanged by either sign or nonzero scaling of a
    representative top eigenvector when written as the normalized quadratic
    expectation `(v^T J_N v)/(v^T v)`.
 
 **Proof.** The move set is inverse-closed: `S = -S`. Therefore (4) gives
 `(J_N)_(x,y) = (J_N)_(y,x)` even at the boundary, because both entries are
 deleted together whenever one endpoint is outside `W_N`. Horizontal and
-vertical moves alone connect the square box.
+vertical moves alone connect the square box for `N >= 1`; the one-vertex
+`N=0` graph is connected as well. Each truncated row has at most six entries,
+each equal to `1/6`, so `||J_N||_infinity <= 1`. Symmetry gives
+`||J_N||_1 = ||J_N||_infinity`, and therefore
+`||J_N||_2 <= sqrt(||J_N||_1 ||J_N||_infinity) <= 1`.
 
 Since `J_N` is real symmetric, `M_N = exp(3J_N)` is real symmetric positive
 definite. For any two indices, connectedness supplies a path of some length
@@ -122,11 +135,12 @@ definite. For any two indices, connectedness supplies a path of some length
 matrix exponential has nonnegative terms and a positive `k`-th term, so every
 entry of `M_N` is strictly positive.
 
-Equations (8) and (9) are positive diagonal matrices and commute. Hence
+Equations (8)-(10) give the explicitly combined positive diagonal `D_N`.
+Hence
 
 ```text
-T_N^T = M_N (L_N R_N) M_N = T_N,
-x^T T_N x = (M_N x)^T (L_N R_N) (M_N x) > 0
+T_N^T = M_N D_N M_N = T_N,
+x^T T_N x = (M_N x)^T D_N (M_N x) > 0
 ```
 
 for nonzero `x`. Every entry of `T_N` is a sum of strictly positive terms.
@@ -135,80 +149,61 @@ simple largest eigenvalue and an entrywise-positive eigenvector. The final
 claim follows because both numerator and denominator are quadratic in the
 chosen representative. ∎
 
-## Certified numerical statement
+## High-precision numerical estimates
 
-An independent `mpmath` implementation reconstructs `J_N`, `M_N`, `L_N`,
-`R_N`, and `T_N` directly from (1)-(10) at 90 decimal digits. It does not call
-the NumPy implementation or read the stored regression centers during matrix
-construction, eigenvector selection, or evaluation of `P_N`.
+An independent `mpmath` implementation reconstructs `J_N`, `M_N`, `D_N`, and
+`T_N` from (1)-(11) at 90 decimal digits and repeats the computation at 110
+digits. This execution path has no module-scope NumPy dependency and does not
+read the stored regression centers, directly or through a reachable helper,
+during matrix construction, eigenvector selection, or evaluation of `P_N`.
 
-For the full computed symmetric eigensystem, write its eigenvector matrix and
-diagonal eigenvalue matrix as `Q_N` and `D_N`. Define the Frobenius residual
-and Gram defect
+The two working precisions agree on the following conservative displays:
 
-```text
-r_N   := ||T_N Q_N - Q_N D_N||_F,
-eta_N := ||Q_N^T Q_N - I||_F.
-```
+| `N` | high-precision estimate of `P_N` | observed top eigengap |
+|---:|---:|---:|
+| 6 | `0.52232431153736166937673139714738059168179320929492` | `4.95928143865115310329935689152` |
+| 7 | `0.52232431507569191793302322384788552461547732886213` | `4.95928144134063313074991808640` |
+| 8 | `0.52232431510373892886326294344235423776746771078887` | `4.95928144135451144353469487140` |
 
-The runner verifies `eta_N < 1` and uses the declared 90-digit
-working-arithmetic guard `g = 10^-60` to form
+At 90 digits the runner reports full-basis residuals, Gram defects, and top
+residuals of order `10^-89` to `10^-90`. These residuals are computed against
+the `mpmath` matrix actually constructed at that working precision. They do
+not bound the difference between that matrix and the exact matrix in (11):
+`mpmath` supplies neither directed rounding for these operations nor an
+analytic operator-norm bound for accumulated rounding in `exp(3J_N)`,
+`exp(-2c)`, and `exp(-6c)`.
 
-```text
-delta_N := r_N/sqrt(1-eta_N) + g.                                       (13)
-```
-
-Indeed, `||Q_N^(-1)||_2 <= 1/sqrt(1-eta_N)`. Thus
-`Q_N^(-1) T_N Q_N = D_N + Q_N^(-1)(T_N Q_N-Q_N D_N)`, and the normal-matrix
-perturbation bound places the exact eigenvalues in the corresponding
-`delta_N` neighborhoods. The top neighborhood is isolated from all the
-others, so it contains exactly one eigenvalue.
-
-If `lambda_hat_1 >= lambda_hat_2` are the two largest computed eigenvalues,
-the runner verifies
+For orientation only, if `Q` and its reported Gram defect `eta` were treated
+as exact stored arrays, `eta < 1` would imply
+`sigma_min(Q)^2 >= 1-eta`, so `Q` would be invertible and
 
 ```text
-gamma_N := lambda_hat_1 - lambda_hat_2 - 2 delta_N > 4.95.               (14)
+||Q^(-1)(TQ-Q Lambda)||_2 <= ||TQ-Q Lambda||_F/sqrt(1-eta).
 ```
 
-Let `tau_N := ||T_N v_hat_N-lambda_hat_1 v_hat_N||_2`. The symmetric
-eigenvector residual-angle bound, the isolated interval above, and the exact
-row-sum bound `||J_N||_2 <= ||J_N||_infinity <= 1` give
+Likewise, for a genuinely bounded perturbation of a symmetric matrix, the
+top-eigenvector residual-angle estimate combined with the exact
+`||J_N||_2 <= 1` bound would change the quadratic expectation by at most
+`2 sin(theta)`: the factor `2` follows from the nuclear norm of the difference
+of the two rank-one projectors. The runner reports these quantities as
+diagnostics only. It does not turn them into an enclosure by adding an
+unproved decimal guard. Nor does it assert that the small-eigenvalue portion
+of the full computed spectrum is pairwise isolated; only the large observed
+top gap is used as a numerical stability diagnostic.
+
+The estimated differences are
 
 ```text
-|P_N - P_hat_N|
-  <= g + 2(tau_N+g)/(lambda_hat_1-lambda_hat_2-delta_N)
-  < 2 x 10^-60.                                                         (15)
+P_7 - P_6 = 3.53833024855629182670050493293e-9,
+P_8 - P_7 = 2.80470109302397195944687131520e-11.
 ```
 
-The independently reconstructed centers and the guarded enclosures are:
-
-| `N` | `P_hat_N` | guarded enclosure `I_N` | lower top-eigenvalue gap |
-|---:|---:|---:|---:|
-| 6 | `0.522324311537361669376731397147380591681793209294921543147251767405388996516` | `P_hat_6 +/- 2e-60` | `> 4.95` |
-| 7 | `0.522324315075691917933023223847885524615477328862129075311171521855593496815` | `P_hat_7 +/- 2e-60` | `> 4.95` |
-| 8 | `0.522324315103738928863262943442354237767467710788871114561329778403325241798` | `P_hat_8 +/- 2e-60` | `> 4.95` |
-
-The raw 90-digit basis residual and Gram-defect norms are reported by the
-runner; the guard, rather than those raw errors, controls the displayed
-enclosure. A 110-digit rerun reproduces every displayed center digit. This is
-an independently reconstructed, guarded a-posteriori certificate, not a
-directed-rounding Arb/ball proof.
-
-The interval differences are also certified:
-
-```text
-P_7 - P_6 = 3.5383302485562918267005049329336841195672075321639e-9
-              +/- 4e-60,
-P_8 - P_7 = 2.8047010930239719594468713151990381926742039250158e-11
-              +/- 4e-60.                                                  (16)
-```
-
-Thus `I_6`, `I_7`, and `I_8` are pairwise disjoint. The three enclosures share
-seven rounded decimal places; `I_7` and `I_8` share ten. They do not certify
-twelve-decimal finite-`N` stability. In particular, `0.5223243151` is only the
-common ten-place rounded display of the `N=7` and `N=8` values. It is not a
-single cutoff-independent value.
+Their signs and displayed digits are stable between 90 and 110 digits, but
+this agreement is numerical evidence, not an outward-rounded proof of exact
+ordering. The three estimates share only seven rounded decimal places; the
+`N=7` and `N=8` estimates share ten, not twelve. In particular,
+`0.5223243151` is only the common ten-place rounded display of the latter two
+estimates, not a cutoff-independent value.
 
 No monotonicity theorem, tail bound in `N`, or `N -> infinity` result is
 claimed.
@@ -227,22 +222,24 @@ python3 scripts/probe_hk_cube_perron_l2_2026_05_06.py --mode intentional-failure
 Normal, high-precision, and hostile modes exit zero only after all checks pass.
 Intentional-failure mode injects an asymmetric recurrence edge, reports a
 failure, and exits nonzero. Hostile mode requires rejection of an asymmetric
-recurrence, a wrong `c` polynomial, wrong `rho` exponential and dimension
-exponents, a missing local factor, a non-dominant eigenvector, a sign/scale
-dependent scalar, an uncertifiable residual-to-gap ratio, false stability
-digits, a wrong reference value, answer-key-fed construction, and illicit
+recurrence, a wrong multiplier exponential, a wrong `c` polynomial, wrong
+local and `rho` exponential factors, a wrong defined dimension exponent, a
+missing local factor, a non-dominant eigenvector, a sign/scale-dependent
+scalar, an insufficient residual-to-gap ratio, false stability digits, a wrong
+reference value, helper-mediated answer-key-fed construction, and illicit
 physical or limiting conclusion tags.
 
 The stored centers are used only after reconstruction as regression checks.
-Static source/import checks reject a reconstruction function that reads those
-centers, repo-local helper imports, literal `True` as check evidence, or
-source-note dependency links.
+An AST call-graph check follows reachable local helpers from both reconstruction
+roots and rejects any answer-key read. Static checks also reject a
+module-scope NumPy import, repo-local helper imports, literal `True` as check
+evidence, or source-note dependency links.
 
 ## Legacy identity and non-claims
 
 The old HK/cube/Perron vocabulary remains in the stable claim id, filename,
 runner filename, and title solely so repository history and citations can find
-this repaired row. Equations (1)-(12) do not supply or inherit their former
+this repaired row. Equations (1)-(13) do not supply or inherit their former
 physical interpretation.
 
 This theorem does not establish any of the following:
@@ -266,6 +263,6 @@ Path A or supplies a physical comparator.
 
 ## Dependencies
 
-None. The integrality, symmetry, positivity, Perron-Frobenius, normalization,
-and residual/gap arguments needed for the theorem are stated here. The primary
-runner is executable evidence, not a source-note premise.
+None. The integrality, symmetry, norm, positivity, Perron-Frobenius, and
+normalization arguments needed for the exact theorem are stated here. The
+primary runner is executable numerical evidence, not a source-note premise.

--- a/docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md
+++ b/docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md
@@ -1,226 +1,271 @@
-# Bridge Gap — HK Cube Perron L_s=2 (Block 06)
+# Bridge Gap — HK Cube Perron (Legacy Identity): Finite Weighted-Transfer Theorem
 
-**Date:** 2026-05-06
-**Type:** bounded support theorem
-**Claim type:** bounded_theorem
-**Status:** bounded support theorem giving a numerical artifact:
-P_cube under HEAT-KERNEL action on the L_s=2 spatial cube at canonical
-Brownian time t = 1, computed by adapting the existing Wilson cube
-Perron runner. Conditional on the same premises as Blocks 01-03 (HK
-character expansion, candidate-ρ ansatz, Block 01's t = 1, retained
-Casimir).
-**Authority role:** source-note + numerical comparator. Audit verdict
-and downstream status are set only by the independent
-audit lane.
-**Primary runner:** [`scripts/probe_hk_cube_perron_l2_2026_05_06.py`](../scripts/probe_hk_cube_perron_l2_2026_05_06.py)
+**Date:** 2026-05-06; narrowed and independently reconstructed 2026-07-16
+**Type:** positive_theorem
+**Claim type:** positive_theorem
+**Status:** candidate self-contained finite numerical-linear-algebra theorem;
+independent audit remains required. The historical HK/cube/Perron words in the
+stable title and path are identity only.
+**Authority role:** source-note proposal. Audit verdict and downstream status
+are set only by the independent audit lane.
+**Primary runner:**
+[`scripts/probe_hk_cube_perron_l2_2026_05_06.py`](../scripts/probe_hk_cube_perron_l2_2026_05_06.py)
 
-## Question
+## Exact scope
 
-Path A from Block 03's named obstruction note: adapt the existing
-[`scripts/frontier_su3_cube_full_rho_perron_2026_05_04.py`](../scripts/frontier_su3_cube_full_rho_perron_2026_05_04.py)
-Wilson cube Perron runner to heat-kernel weights and compute
-`P_cube_HK(L_s=2, t=1)`.
+This note defines finite functions and matrices and proves their elementary
+spectral properties. It then gives independently reconstructed numerical
+enclosures for three separate finite matrices, at `N = 6, 7, 8`.
 
-## Answer
+The definitions are stipulations inside this theorem. They are not derived
+from, or identified with, an SU(3) heat-kernel action, a lattice-cube measure,
+a physical plaquette, a canonical Brownian time, a topology or link count, a
+Wilson comparison, or a thermodynamic observable. The formal parameter is set
+to `t = 1` by definition, not by framework authority.
 
-```
-P_cube_HK(L_s=2, t=1) = 0.5223243151                                       (T6)
-```
+## Definitions
 
-stable to 12 decimal places across NMAX ∈ {6, 7, 8, ...}, computed
-by direct adaptation of the existing Wigner-intertwiner cube Perron
-machinery from Wilson character coefficients `c_λ(β)` (Bessel
-determinants) to heat-kernel character coefficients
-`c_λ_HK(t) = d_λ · exp(-t·C_2(λ)/2)`.
+Let `N` be a nonnegative integer and order the finite square box
 
-## Setup
-
-The L_s=2 spatial cube has 24 directed links and 12 unique unoriented
-plaquettes. The candidate ρ ansatz (per Block 5 of the existing Wilson
-cube work, character-coefficient-agnostic at the index-graph level):
-
-```
-ρ_(p,q)(t) = (d_λ · c_λ(t) / c_(0,0)(t))^12 · d_λ^(-16)                   (1)
+```text
+W_N := {(p,q) : 0 <= p <= N and 0 <= q <= N}
 ```
 
-The factor `d^(-16) = d^(N_components - N_links)` with `N_components = 8`
-on `N_links = 24` is topological — Wilson and HK share it.
+lexicographically. Its cardinality is `m_N = (N+1)^2`.
 
-For Wilson at β=6: `c_λ(6) = ∫ exp((6/3)·Re Tr U) χ_λ dU` (Bessel det),
-giving `P_cube_W = 0.4291049969` (existing runner).
+For nonnegative integers `p,q`, define
 
-For HK at t=1: `c_λ_HK(1) = d_λ · exp(-C_2(λ)/2)` (Schur orthogonality
-+ retained Casimir).
-
-## Step 1: Adapted candidate ρ_HK
-
-Substituting `c_λ_HK = d_λ · exp(-t·C_2/2)` and `c_00_HK = 1·1 = 1`
-into (1):
-
-```
-ρ_HK_(p,q)(t) = (d_λ · d_λ · exp(-t·C_2/2) / 1)^12 · d_λ^(-16)
-              = d_λ^24 · exp(-6 t · C_2) · d_λ^(-16)
-              = d_λ^8 · exp(-6 t · C_2).                                   (2)
+```text
+d(p,q) := ((p+1)(q+1)(p+q+2))/2,                                      (1)
+c(p,q) := (p^2 + pq + q^2 + 3p + 3q)/3.                               (2)
 ```
 
-At t=1, normalized to ρ_HK_(0,0) = 1:
+The first expression is an integer: if either `p+1` or `q+1` is even, their
+product is even; if both are odd, their sum `p+q+2` is even. The second is a
+nonnegative rational number and vanishes only at `(0,0)`.
 
-| (p,q) | d_λ | C_2 | ρ_HK,_(p,q) |
-|---|---:|---:|---:|
-| (0,0) | 1 | 0 | 1.0000 |
-| (1,0)/(0,1) | 3 | 4/3 | **2.2010** |
-| (1,1) | 8 | 3 | 0.2555 |
-| (2,0)/(0,2) | 6 | 10/3 | 3.46×10⁻³ |
-| (2,1)/(1,2) | 15 | 16/3 | 3.25×10⁻⁵ |
-| (2,2) | 27 | 8 | 4.03×10⁻¹⁰ |
+Let
 
-**Crucial observation:** ρ_HK_(1,0) = 2.20 is LARGER than ρ_HK_(0,0) = 1.
-This is a structural difference from Wilson, where the (0,0) trivial
-sector dominates. Under HK at t=1, the (1,0)/(0,1) fundamental sectors
-are the dominant contributors to the cube source-sector measure.
-
-This reflects the HK Casimir-suppression structure: the Casimir
-exp(-6t·C_2) factor attenuates higher-(p,q) sectors, while the d^8
-factor (from the cube's 24-link / 8-component topology) amplifies. At
-the (1,0) level, d^8 = 6561 and exp(-8) = 3.35×10⁻⁴ combine to give
-2.20, the dominant non-trivial weight.
-
-## Step 2: Perron solve under HK weights
-
-The Perron transfer operator structure (per the existing Wilson runner
-`build_j`, `build_local_factor`, `perron_value`) is character-
-coefficient-only-dependent through the local plaquette factor
-
-```
-a_link_HK = c_λ_HK / (d_λ · c_00_HK) = (d_λ · exp(-t·C_2/2)) / d_λ
-          = exp(-t·C_2/2).                                                 (3)
+```text
+S := {(1,0), (-1,1), (0,-1), (0,1), (1,-1), (-1,0)}.                   (3)
 ```
 
-This is independent of `d_λ` for HK (in contrast to Wilson, where
-`a_link_W = c_λ(β) / (d_λ · c_00(β))` depends on dimensions through
-Bessel determinants). The HK structure is structurally simpler.
+Define the `m_N x m_N` recurrence matrix, with rows and columns indexed by
+`W_N`, by
 
-The Perron eigenvalue and eigenvector are obtained by symmetric
-eigenproblem on the transfer operator
-`T_HK = M · D_HK^loc · diag(ρ_HK) · M`
-where `M = exp(3 J)` with J the recurrence neighbor operator and
-`D_HK^loc = diag(a_link_HK^4)`.
-
-## Step 3: Numerical result
-
-Run [`scripts/probe_hk_cube_perron_l2_2026_05_06.py`](../scripts/probe_hk_cube_perron_l2_2026_05_06.py):
-
-```
-NMAX  P_cube_HK(t=1)   Perron eigval
-   3   0.5215646412    5.354209
-   4   0.5223043902    5.357664
-   5   0.5223239911    5.357734
-   6   0.5223243115    5.357735
-   7   0.5223243151    5.357735
-   8   0.5223243151    5.357735
+```text
+(J_N)_(x,y) := 1/6  if x-y is in S,
+               0    otherwise.                                       (4)
 ```
 
-Stable to 12 decimal places at NMAX ≥ 7.
+The finite-box truncation is exactly the restriction to pairs `x,y` that both
+belong to `W_N`; no boundary wrap or extra edge is added.
 
-## Step 4: Comparison to all existing values
+For a formal real parameter `t`, define the exponential functions
 
-| Quantity | Numerical | Source |
-|---|---|---|
-| Wilson 1-plaq | 0.4225317396 | V=1 PF ODE certified |
-| Wilson cube L_s=2 | 0.4291049969 | existing runner (5/04) |
-| HK 1-plaq (Block 02) | 0.5134171190 | exp(-2/3) closed form |
-| **HK cube L_s=2 (this)** | **0.5223243151** | **Block 06** |
-| Lattice MC thermo | ≈ 0.5934 | comparator only |
-
-### Differences
-
-| Comparison | Difference |
-|---|---|
-| HK cube − HK 1-plaq | +0.0089 (multi-plaquette correlations contribute positively) |
-| HK cube − Wilson cube | +0.0932 (HK is 22% larger than Wilson at L_s=2) |
-| **HK cube − MC thermo** | **−0.0711 = 235× ε_witness BELOW MC** |
-| Wilson cube − MC thermo | −0.1643 = 543× ε_witness BELOW MC |
-
-**The HK cube is 2.3× CLOSER to the lattice MC value than the Wilson
-cube is, in ε_witness units.** This is suggestive (NOT load-bearing)
-that HK's Casimir-diagonal structure converges faster toward the
-physical thermodynamic value at finite L_s than Wilson's
-Bessel-determinant structure does.
-
-## Theorem 6 (Block 06 deliverable)
-
-**Theorem (T6, bounded support).** Under heat-kernel measure with
-canonical Brownian time t = 1, on the L_s=2 spatial cube with the
-character-coefficient-agnostic candidate-ρ ansatz from Block 5 of the
-existing Wilson cube work:
-
-```
-P_cube_HK(L_s=2, t=1) = 0.5223243151
+```text
+w_t(p,q)   := d(p,q) exp(-t c(p,q)/2),                                 (5)
+a_t(p,q)   := w_t(p,q)/d(p,q) = exp(-t c(p,q)/2),                       (6)
+rho_t(p,q) := d(p,q)^8 exp(-6t c(p,q)).                                 (7)
 ```
 
-stable to 12 decimal places across NMAX ∈ {6, 7, 8}.
+In the rest of the theorem, set `t := 1`. Define the positive diagonal
+matrices
 
-The numerical value is 22% larger than the corresponding Wilson cube
-result 0.4291049969 at L_s=2, and lies 235× ε_witness below the
-lattice MC thermodynamic comparator 0.5934 (vs Wilson cube's 543×
-ε_witness gap).
+```text
+L_N := diag(a_1(p,q)^4) = diag(exp(-2c(p,q))),                           (8)
+R_N := diag(rho_1(p,q)),                                                 (9)
+```
 
-**Proof.** Steps 1-3 + paired runner. ∎
+and define
 
-## Scope and Non-Claims
+```text
+M_N := exp(3J_N),
+T_N := M_N L_N R_N M_N.                                                 (10)
+```
 
-This bounded theorem is for fixed `L_s = 2` and `NMAX >= 6`, using the
-candidate-rho ansatz from the existing Wilson cube work. It does not
-establish the thermodynamic limit and does not break the action-form
-uniqueness no-go.
+Let `lambda_N` be the largest eigenvalue of `T_N`. Let `v_N` be its real
+eigenvector normalized by
 
-The Wilson and MC values in the comparison table are comparators only;
-they are not load-bearing inputs to the heat-kernel cube calculation.
+```text
+v_N^T v_N = 1,       sum_x (v_N)_x > 0,                                 (11)
+```
 
-## What this closes
+and define the scalar
 
-- The "Path A" question from Block 03's named obstruction note: a
-  specific numerical value for HK cube Perron at L_s=2 exists and is
-  computed.
-- The first multi-plaquette HK numerical artifact in the project.
-- Documents the specific structural feature: under HK, ρ_(1,0)(t=1)
-  > ρ_(0,0)(t=1), reversing the Wilson dominant-sector ordering.
+```text
+P_N := v_N^T J_N v_N.                                                    (12)
+```
 
-## What this does NOT close
+## Finite-matrix theorem
 
-- The thermodynamic limit ⟨P⟩_HK(6) under multi-plaquette HK action
-  (Block 03's named obstruction stands).
-- Action-form uniqueness (Block 04's no-go stands).
-- The bridge gap. The 235× ε_witness gap to MC at L_s=2 is far above
-  ε_witness and the L_s → ∞ extrapolation requires the cluster-
-  decomposition estimate Block 03 named.
+For every nonnegative integer `N`:
 
-## Suggestive observations
+1. `J_N` is real symmetric and entrywise nonnegative.
+2. `M_N` is real symmetric positive definite and entrywise strictly positive.
+3. `T_N` is real symmetric positive definite and entrywise strictly positive.
+4. The largest eigenvalue `lambda_N` is positive and simple. Its eigenvector
+   is entrywise strictly positive up to an overall sign, so convention (11)
+   determines `v_N` uniquely.
+5. `P_N` is well-defined and unchanged by either sign or nonzero scaling of a
+   representative top eigenvector when written as the normalized quadratic
+   expectation `(v^T J_N v)/(v^T v)`.
 
-1. HK cube > HK 1-plaq (positive multi-plaquette correlation).
-2. HK cube > Wilson cube (HK gives larger plaquette expectation than
-   Wilson at the same lattice size).
-3. **HK cube is closer to MC than Wilson cube** by ~2.3× in ε_witness
-   units. This is consistent with — but does not prove — the hypothesis
-   that HK is the framework's more-natural action.
+**Proof.** The move set is inverse-closed: `S = -S`. Therefore (4) gives
+`(J_N)_(x,y) = (J_N)_(y,x)` even at the boundary, because both entries are
+deleted together whenever one endpoint is outside `W_N`. Horizontal and
+vertical moves alone connect the square box.
 
-These observations are AUDIT COMPARATORS, not load-bearing inputs to
-any retained-grade claim.
+Since `J_N` is real symmetric, `M_N = exp(3J_N)` is real symmetric positive
+definite. For any two indices, connectedness supplies a path of some length
+`k`; the corresponding entry of `J_N^k` is positive. The power series for the
+matrix exponential has nonnegative terms and a positive `k`-th term, so every
+entry of `M_N` is strictly positive.
 
-## Cross-references
+Equations (8) and (9) are positive diagonal matrices and commute. Hence
 
-- Predecessor (this loop): [`BRIDGE_GAP_HK_THERMODYNAMIC_STRETCH_NOTE_2026-05-06.md`](BRIDGE_GAP_HK_THERMODYNAMIC_STRETCH_NOTE_2026-05-06.md) (Block 03 — Path A target)
-- Wilson cube reference: [`SU3_CUBE_FULL_RHO_PERRON_2026-05-04.md`](SU3_CUBE_FULL_RHO_PERRON_2026-05-04.md) (Wilson cube L_s=2 = 0.4291)
-- Adapted runner base: [`scripts/frontier_su3_cube_full_rho_perron_2026_05_04.py`](../scripts/frontier_su3_cube_full_rho_perron_2026_05_04.py)
-- Block 02 1-plaq: [`BRIDGE_GAP_HK_PLAQUETTE_CLOSED_FORM_NOTE_2026-05-06.md`](BRIDGE_GAP_HK_PLAQUETTE_CLOSED_FORM_NOTE_2026-05-06.md)
-- Block 04 no-go: [`BRIDGE_GAP_ACTION_FORM_UNIQUENESS_NO_GO_NOTE_2026-05-06.md`](BRIDGE_GAP_ACTION_FORM_UNIQUENESS_NO_GO_NOTE_2026-05-06.md)
-- Casimir retained: [`SU3_CASIMIR_FUNDAMENTAL_THEOREM_NOTE_2026-05-02.md`](SU3_CASIMIR_FUNDAMENTAL_THEOREM_NOTE_2026-05-02.md)
+```text
+T_N^T = M_N (L_N R_N) M_N = T_N,
+x^T T_N x = (M_N x)^T (L_N R_N) (M_N x) > 0
+```
 
-## Command
+for nonzero `x`. Every entry of `T_N` is a sum of strictly positive terms.
+Perron-Frobenius applied to this entrywise-positive symmetric matrix gives a
+simple largest eigenvalue and an entrywise-positive eigenvector. The final
+claim follows because both numerator and denominator are quadratic in the
+chosen representative. ∎
+
+## Certified numerical statement
+
+An independent `mpmath` implementation reconstructs `J_N`, `M_N`, `L_N`,
+`R_N`, and `T_N` directly from (1)-(10) at 90 decimal digits. It does not call
+the NumPy implementation or read the stored regression centers during matrix
+construction, eigenvector selection, or evaluation of `P_N`.
+
+For the full computed symmetric eigensystem, write its eigenvector matrix and
+diagonal eigenvalue matrix as `Q_N` and `D_N`. Define the Frobenius residual
+and Gram defect
+
+```text
+r_N   := ||T_N Q_N - Q_N D_N||_F,
+eta_N := ||Q_N^T Q_N - I||_F.
+```
+
+The runner verifies `eta_N < 1` and uses the declared 90-digit
+working-arithmetic guard `g = 10^-60` to form
+
+```text
+delta_N := r_N/sqrt(1-eta_N) + g.                                       (13)
+```
+
+Indeed, `||Q_N^(-1)||_2 <= 1/sqrt(1-eta_N)`. Thus
+`Q_N^(-1) T_N Q_N = D_N + Q_N^(-1)(T_N Q_N-Q_N D_N)`, and the normal-matrix
+perturbation bound places the exact eigenvalues in the corresponding
+`delta_N` neighborhoods. The top neighborhood is isolated from all the
+others, so it contains exactly one eigenvalue.
+
+If `lambda_hat_1 >= lambda_hat_2` are the two largest computed eigenvalues,
+the runner verifies
+
+```text
+gamma_N := lambda_hat_1 - lambda_hat_2 - 2 delta_N > 4.95.               (14)
+```
+
+Let `tau_N := ||T_N v_hat_N-lambda_hat_1 v_hat_N||_2`. The symmetric
+eigenvector residual-angle bound, the isolated interval above, and the exact
+row-sum bound `||J_N||_2 <= ||J_N||_infinity <= 1` give
+
+```text
+|P_N - P_hat_N|
+  <= g + 2(tau_N+g)/(lambda_hat_1-lambda_hat_2-delta_N)
+  < 2 x 10^-60.                                                         (15)
+```
+
+The independently reconstructed centers and the guarded enclosures are:
+
+| `N` | `P_hat_N` | guarded enclosure `I_N` | lower top-eigenvalue gap |
+|---:|---:|---:|---:|
+| 6 | `0.522324311537361669376731397147380591681793209294921543147251767405388996516` | `P_hat_6 +/- 2e-60` | `> 4.95` |
+| 7 | `0.522324315075691917933023223847885524615477328862129075311171521855593496815` | `P_hat_7 +/- 2e-60` | `> 4.95` |
+| 8 | `0.522324315103738928863262943442354237767467710788871114561329778403325241798` | `P_hat_8 +/- 2e-60` | `> 4.95` |
+
+The raw 90-digit basis residual and Gram-defect norms are reported by the
+runner; the guard, rather than those raw errors, controls the displayed
+enclosure. A 110-digit rerun reproduces every displayed center digit. This is
+an independently reconstructed, guarded a-posteriori certificate, not a
+directed-rounding Arb/ball proof.
+
+The interval differences are also certified:
+
+```text
+P_7 - P_6 = 3.5383302485562918267005049329336841195672075321639e-9
+              +/- 4e-60,
+P_8 - P_7 = 2.8047010930239719594468713151990381926742039250158e-11
+              +/- 4e-60.                                                  (16)
+```
+
+Thus `I_6`, `I_7`, and `I_8` are pairwise disjoint. The three enclosures share
+seven rounded decimal places; `I_7` and `I_8` share ten. They do not certify
+twelve-decimal finite-`N` stability. In particular, `0.5223243151` is only the
+common ten-place rounded display of the `N=7` and `N=8` values. It is not a
+single cutoff-independent value.
+
+No monotonicity theorem, tail bound in `N`, or `N -> infinity` result is
+claimed.
+
+## Executable controls
+
+The primary runner has four decisive modes:
 
 ```bash
 python3 scripts/probe_hk_cube_perron_l2_2026_05_06.py
+python3 scripts/probe_hk_cube_perron_l2_2026_05_06.py --mode high-precision --dps 90
+python3 scripts/probe_hk_cube_perron_l2_2026_05_06.py --mode hostile
+python3 scripts/probe_hk_cube_perron_l2_2026_05_06.py --mode intentional-failure
 ```
 
-Expected output: convergent stable value 0.5223243151 at NMAX ≥ 7,
-plus comparators against Wilson cube, HK 1-plaq, and MC thermo.
+Normal, high-precision, and hostile modes exit zero only after all checks pass.
+Intentional-failure mode injects an asymmetric recurrence edge, reports a
+failure, and exits nonzero. Hostile mode requires rejection of an asymmetric
+recurrence, a wrong `c` polynomial, wrong `rho` exponential and dimension
+exponents, a missing local factor, a non-dominant eigenvector, a sign/scale
+dependent scalar, an uncertifiable residual-to-gap ratio, false stability
+digits, a wrong reference value, answer-key-fed construction, and illicit
+physical or limiting conclusion tags.
+
+The stored centers are used only after reconstruction as regression checks.
+Static source/import checks reject a reconstruction function that reads those
+centers, repo-local helper imports, literal `True` as check evidence, or
+source-note dependency links.
+
+## Legacy identity and non-claims
+
+The old HK/cube/Perron vocabulary remains in the stable claim id, filename,
+runner filename, and title solely so repository history and citations can find
+this repaired row. Equations (1)-(12) do not supply or inherit their former
+physical interpretation.
+
+This theorem does not establish any of the following:
+
+- an SU(3) representation formula or heat-kernel measure;
+- a physical action, plaquette, cube, link topology, or multi-plaquette
+  correlation;
+- a canonical physical meaning for `t=1`;
+- a Wilson or Monte Carlo comparison, an action-naturalness ordering, or a
+  statement that one value is “closer” to another;
+- a physical thermodynamic observable or any finite-volume/thermodynamic-limit
+  relationship.
+
+Any downstream physical reuse must add a separate, explicit bridge identifying
+the defined functions and matrices with the proposed physical objects. No such
+bridge is a dependency of this note.
+
+**2026-07-16 downstream hygiene:** the direct thermodynamic-stretch consumer
+was narrowed so this formal theorem no longer closes its physical finite-cube
+Path A or supplies a physical comparator.
+
+## Dependencies
+
+None. The integrality, symmetry, positivity, Perron-Frobenius, normalization,
+and residual/gap arguments needed for the theorem are stated here. The primary
+runner is executable evidence, not a source-note premise.

--- a/docs/BRIDGE_GAP_HK_THERMODYNAMIC_STRETCH_NOTE_2026-05-06.md
+++ b/docs/BRIDGE_GAP_HK_THERMODYNAMIC_STRETCH_NOTE_2026-05-06.md
@@ -1,6 +1,6 @@
 # Bridge Gap — Heat-Kernel Thermodynamic ⟨P⟩(6) Stretch Attempt (Block 03)
 
-**Date:** 2026-05-06
+**Date:** 2026-05-06; 2026-07-16 direct-consumer correction
 **Type:** stretch attempt + named obstruction
 **Claim type:** open_gate
 **Status:** stretch-attempt note + named obstruction packet on the
@@ -18,8 +18,10 @@ Primary cache: `logs/runner-cache/frontier_hk_thermodynamic_stretch_source_packe
 
 The runner checks this note as a source-level open-gate packet: Block 01's
 `t(6)=1`, Block 02's exact single-plaquette `exp(-2/3)`, the Block 03
-multi-plaquette factorization/obstruction, and the later Block 06 finite-cube
-HK Perron comparator. It does not assign an audit verdict or retained status.
+multi-plaquette factorization/obstruction, and the 2026-07-16 correction that
+the historical Block 06 row is now a formal finite-matrix theorem rather than
+a physical finite-cube comparator. It does not assign an audit verdict or
+retained status.
 
 ## Question
 
@@ -141,15 +143,18 @@ combinatorial complexity of `F_Λ` grows exponentially.
 
 For Wilson on the L_s=2 cube,
 [`SU3_CUBE_FULL_RHO_PERRON_2026-05-04.md`](SU3_CUBE_FULL_RHO_PERRON_2026-05-04.md)
-established a finite character-truncated computation giving 0.4291.
-The same machinery adapted to HK weights (`d_λ exp(-t·C_2/2)` instead
-of `c_λ(β)`) would give an analogous L_s=2 finite result.
+records a finite character-truncated computation. A historical follow-up
+instantiated a formally similar weighted-transfer matrix, but its 2026-07-16
+repair no longer identifies the defined dimension polynomial, quadratic,
+recurrence, weights, transfer, or scalar with an HK lattice cube. Therefore it
+does not provide the analogous physical finite result asserted by the older
+version of this paragraph.
 
-But L_s=2 is structurally insufficient — per the exhausted-routes
-consolidation (route 1.2), even with Wilson the L_s=2 cube gives gap
-~543× ε_witness. HK at L_s=2 would similarly be insufficient for
-ε_witness precision; **the thermodynamic limit `L → ∞` requires
-controlled extrapolation**.
+Path A remains open on this source surface. Reusing the formal finite-matrix
+number would first require an independently audited bridge from the proposed
+physical measure and geometry to every defined matrix factor. Even after such
+a bridge, **the thermodynamic limit `L → ∞` would require controlled
+extrapolation**.
 
 For HK, the controlled extrapolation has structural support that Wilson
 lacks: each L_s contributes a Casimir-suppressed term, and the Casimir
@@ -239,13 +244,11 @@ heat-kernel expression. It does not derive a thermodynamic value.
 
 - A specific closed-form value for `⟨P⟩_HK(6)` in the thermodynamic
   limit. The factorization (T3.a) is exact but uncomputed.
-- The L_s=2 finite-cube computation analogous to the Wilson case has now
-  been done in
-  [`BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md`](BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md):
-  `P_cube_HK(L_s=2,t=1)=0.5223243151`. This closes Path A as a
-  finite-volume comparator only; Block 03's named obstruction stands because
-  the result remains fixed-volume and still needs an `L_s -> infinity`
-  cluster-decomposition / exponential-clustering estimate.
+- The physical L_s=2 finite-cube computation analogous to the Wilson case.
+  The legacy row `BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md` now proves only
+  a self-contained finite weighted-transfer theorem about defined matrices.
+  It supplies neither the physical identification bridge nor a finite-volume
+  comparator for this open gate.
 - The cluster-decomposition / exponential-clustering estimate that
   bounds `|⟨P⟩_HK(6) - ⟨P⟩_HK,Λ_finite(6)|`.
 - Block 04's action-form uniqueness question — Wilson vs HK uniqueness
@@ -255,16 +258,12 @@ heat-kernel expression. It does not derive a thermodynamic value.
 
 Two paths from here:
 
-**Path A (computational, finite-cube):** adapt the existing L_s=2
-cube full-ρ Perron runner to HK weights. Compute `⟨P⟩_HK,L_s=2(6)`
-and compare to:
-- Wilson L_s=2 cube: 0.4291
-- Wilson 1-plaq: 0.4225
-- HK 1-plaq (Block 02): 0.5134
-- Lattice MC thermo: ≈ 0.5934
-
-A clean L_s=2 HK computation should close to a specific value via the
-same character-truncation machinery.
+**Path A (computational, finite-cube):** first derive or cite a retained-grade
+bridge identifying a finite weighted-transfer construction with the proposed
+L_s=2 HK measure, geometry, local insertion, normalized state, and observable.
+Only then compute `⟨P⟩_HK,L_s=2(6)` and assess it as a physical finite-volume
+quantity. The legacy formal theorem does not discharge any of those bridge
+clauses.
 
 **Path B (analytic, thermodynamic):** derive the cluster-decomposition
 / exponential-clustering estimate from approved premises (reflection
@@ -282,6 +281,7 @@ Both paths are next-cycle work, scoped beyond this stretch attempt's
 - Sister Wilson L_s=2: [`SU3_CUBE_FULL_RHO_PERRON_2026-05-04.md`](SU3_CUBE_FULL_RHO_PERRON_2026-05-04.md) (Wilson L_s=2 = 0.4291)
 - Wilson β⁶-completion freedom: [`GAUGE_SCALAR_TEMPORAL_OBSERVABLE_BRIDGE_NO_GO_THEOREM_NOTE_2026-05-03.md`](GAUGE_SCALAR_TEMPORAL_OBSERVABLE_BRIDGE_NO_GO_THEOREM_NOTE_2026-05-03.md)
 - Existing cube Perron infra: [`scripts/frontier_su3_cube_full_rho_perron_2026_05_04.py`](../scripts/frontier_su3_cube_full_rho_perron_2026_05_04.py)
-- Completed Path A comparator: [`BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md`](BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md)
+- Historical Block 06 identity (formal-only after the 2026-07-16 repair):
+  `BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md`.
 - Casimir authority: [`SU3_CASIMIR_FUNDAMENTAL_THEOREM_NOTE_2026-05-02.md`](SU3_CASIMIR_FUNDAMENTAL_THEOREM_NOTE_2026-05-02.md)
 - Standard methodology: same as Block 01-02 (Drouffe-Zuber 1983 "Strong coupling and mean field methods in lattice gauge theories" Phys Rep 102 contains the heat-kernel multi-plaquette character expansion in detail)

--- a/logs/runner-cache/frontier_hk_thermodynamic_stretch_source_packet.txt
+++ b/logs/runner-cache/frontier_hk_thermodynamic_stretch_source_packet.txt
@@ -1,6 +1,6 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_hk_thermodynamic_stretch_source_packet.py
-runner_sha256: c6723e16a4f8f7e585af1e57bb9a56d370bf785a0a468b491d07492e8a909627
+runner_sha256: 2e5fc1eaccbfca0030503a84c087729a4e653520e704fdb2cd517a0ea66298d2
 timeout_sec: 120
 exit_code: 0
 elapsed_sec: 0.05
@@ -10,8 +10,8 @@ status: ok
 HK THERMODYNAMIC STRETCH SOURCE PACKET
 ==============================================================================
 
-Question: is Block 03 now runner-backed as an open gate, with
-the later L_s=2 HK cube result included but not overclaimed?
+Question: is Block 03 runner-backed as an open gate, with the
+legacy Block 06 formal theorem excluded from physical Path A?
 
 [PASS] source note title is present: Heat-Kernel Thermodynamic
 [PASS] primary runner metadata names this verifier: Primary runner: `scripts/frontier_hk_thermodynamic_stretch_source_packet.py`
@@ -26,30 +26,31 @@ the later L_s=2 HK cube result included but not overclaimed?
 [PASS] cluster estimate is the open premise blocker: cluster-decomposition / exponential-clustering estimate
 [PASS] current premises do not contain the cluster estimate: current approved primitive or
 retained-premise surface
-[PASS] Block 06 update is cited: BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md
-[PASS] Block 06 finite cube value is cited: 0.5223243151
-[PASS] Block 06 still leaves the named obstruction open: Block 03's named obstruction stands
+[PASS] Block 06 formal-only correction is recorded: formal finite-matrix theorem rather than
+[PASS] physical Path A is explicitly still open: Path A remains open on this source surface
+[PASS] physical identification bridge is required: independently audited bridge from the proposed
+[PASS] legacy row no longer supplies a finite-volume comparator: supplies neither the physical identification bridge nor a finite-volume
+[PASS] Block 06 is no longer a citation-graph dependency: target appears only as code-formatted historical identity
 [PASS] canonical HK Brownian time at beta=6 is one: t(6)=1
 [PASS] single-plaquette HK value matches exp(-2/3): exp(-2/3)=0.513417119032592
-[PASS] L_s=2 HK cube improves over single plaquette: 0.5223243151 > 0.5134171190
-[PASS] L_s=2 HK cube remains below thermodynamic comparator: 0.5223243151 < 0.5934
-[PASS] finite cube gap remains far from epsilon-witness scale: gap=0.0710756849
 [PASS] BRIDGE_GAP_HK_TIME_DERIVATION_NOTE_2026-05-06.md exists: docs/BRIDGE_GAP_HK_TIME_DERIVATION_NOTE_2026-05-06.md
 [PASS] BRIDGE_GAP_HK_TIME_DERIVATION_NOTE_2026-05-06.md cited by Block 03 note: BRIDGE_GAP_HK_TIME_DERIVATION_NOTE_2026-05-06.md
 [PASS] BRIDGE_GAP_HK_PLAQUETTE_CLOSED_FORM_NOTE_2026-05-06.md exists: docs/BRIDGE_GAP_HK_PLAQUETTE_CLOSED_FORM_NOTE_2026-05-06.md
 [PASS] BRIDGE_GAP_HK_PLAQUETTE_CLOSED_FORM_NOTE_2026-05-06.md cited by Block 03 note: BRIDGE_GAP_HK_PLAQUETTE_CLOSED_FORM_NOTE_2026-05-06.md
-[PASS] BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md exists: docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md
-[PASS] BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md cited by Block 03 note: BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md
 [PASS] SU3_CUBE_FULL_RHO_PERRON_2026-05-04.md exists: docs/SU3_CUBE_FULL_RHO_PERRON_2026-05-04.md
 [PASS] SU3_CUBE_FULL_RHO_PERRON_2026-05-04.md cited by Block 03 note: SU3_CUBE_FULL_RHO_PERRON_2026-05-04.md
 [PASS] GAUGE_SCALAR_TEMPORAL_OBSERVABLE_BRIDGE_NO_GO_THEOREM_NOTE_2026-05-03.md exists: docs/GAUGE_SCALAR_TEMPORAL_OBSERVABLE_BRIDGE_NO_GO_THEOREM_NOTE_2026-05-03.md
 [PASS] GAUGE_SCALAR_TEMPORAL_OBSERVABLE_BRIDGE_NO_GO_THEOREM_NOTE_2026-05-03.md cited by Block 03 note: GAUGE_SCALAR_TEMPORAL_OBSERVABLE_BRIDGE_NO_GO_THEOREM_NOTE_2026-05-03.md
 [PASS] SU3_CASIMIR_FUNDAMENTAL_THEOREM_NOTE_2026-05-02.md exists: docs/SU3_CASIMIR_FUNDAMENTAL_THEOREM_NOTE_2026-05-02.md
 [PASS] SU3_CASIMIR_FUNDAMENTAL_THEOREM_NOTE_2026-05-02.md cited by Block 03 note: SU3_CASIMIR_FUNDAMENTAL_THEOREM_NOTE_2026-05-02.md
-[PASS] cube note names finite value: P_cube_HK(L_s=2, t=1) = 0.5223243151
-[PASS] cube note states thermodynamic limit remains open: does not
-establish the thermodynamic limit
-[PASS] cube note preserves Block 03 blocker: Block 03's named obstruction stands
+[PASS] cube note is a finite weighted-transfer theorem: Finite Weighted-Transfer Theorem
+[PASS] cube note class is positive theorem: **Claim type:** positive_theorem
+[PASS] cube note makes legacy names identity-only: identity only
+[PASS] cube note requires a separate downstream physical bridge: Any downstream physical reuse must add a separate, explicit bridge
+[PASS] cube note declares no source-note dependencies: ## Dependencies
+
+None.
+[PASS] cube theorem does not retain the old physical scalar symbol: P_cube_HK absent from repaired source
 [PASS] scripts/probe_hk_time_derivation.py exists: scripts/probe_hk_time_derivation.py
 [PASS] logs/runner-cache/probe_hk_time_derivation.txt exists: logs/runner-cache/probe_hk_time_derivation.txt
 [PASS] scripts/probe_hk_time_derivation.py cache names same runner: scripts/probe_hk_time_derivation.py
@@ -68,23 +69,14 @@ establish the thermodynamic limit
 [PASS] scripts/probe_hk_plaquette_closed_form.py summary has expected pass count: PASS=8 FAIL=0
 [PASS] scripts/probe_hk_plaquette_closed_form.py cache contains required fragment: exp(-2/3)
 [PASS] scripts/probe_hk_plaquette_closed_form.py cache contains required fragment: SUMMARY: PASS=8 FAIL=0
-[PASS] scripts/probe_hk_cube_perron_l2_2026_05_06.py exists: scripts/probe_hk_cube_perron_l2_2026_05_06.py
-[PASS] logs/runner-cache/probe_hk_cube_perron_l2_2026_05_06.txt exists: logs/runner-cache/probe_hk_cube_perron_l2_2026_05_06.txt
-[PASS] scripts/probe_hk_cube_perron_l2_2026_05_06.py cache names same runner: scripts/probe_hk_cube_perron_l2_2026_05_06.py
-[PASS] scripts/probe_hk_cube_perron_l2_2026_05_06.py cache status ok: ok
-[PASS] scripts/probe_hk_cube_perron_l2_2026_05_06.py cache exit code zero: 0
-[PASS] scripts/probe_hk_cube_perron_l2_2026_05_06.py cache sha is fresh: cache=6de88717f28d9e1967a1c3c81776756c2a7b338d3c4998c8feb52692560d5447
-[PASS] scripts/probe_hk_cube_perron_l2_2026_05_06.py cache contains required fragment: P_cube_HK(L_s=2, t=1) ≈ 0.5223243151
-[PASS] scripts/probe_hk_cube_perron_l2_2026_05_06.py cache contains required fragment: Block 03's named obstruction
-[PASS] scripts/probe_hk_cube_perron_l2_2026_05_06.py cache contains required fragment: thermodynamic-limit closure
 
 ==============================================================================
-SUMMARY: PASS=62 FAIL=0
+SUMMARY: PASS=53 FAIL=0
 ==============================================================================
 
 Verdict: bounded source-packet support. Block 03 is runner-backed
-as an open gate; Block 06 closes the finite-cube comparator path,
-but thermodynamic closure still needs the named clustering estimate.
+as an open gate; Block 06 is formal-only and does not close physical
+Path A; thermodynamic closure still needs the named clustering estimate.
 No audit verdict or retained status is assigned.
 
 ----- stderr -----

--- a/logs/runner-cache/probe_hk_cube_perron_l2_2026_05_06.txt
+++ b/logs/runner-cache/probe_hk_cube_perron_l2_2026_05_06.txt
@@ -1,82 +1,31 @@
 ===== runner cache v1 =====
 runner: scripts/probe_hk_cube_perron_l2_2026_05_06.py
-runner_sha256: 6de88717f28d9e1967a1c3c81776756c2a7b338d3c4998c8feb52692560d5447
+runner_sha256: 5e08bb70caca8cdee97302ca07db7fe0940d74ba250a63ec69ac12b377a15fb5
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.18
+elapsed_sec: 0.09
 status: ok
 ----- stdout -----
-========================================================================
-Block 06 — HK Cube Perron L_s=2 (Casimir-diagonal action)
-Companion: docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md
-========================================================================
+FINITE WEIGHTED-TRANSFER THEOREM — NORMAL MODE
+formal parameter: t=1; legacy HK/cube/Perron words are identity only
 
-Adapts existing Wilson cube Perron runner to HK weights.
-Wilson side reference: P_cube_W(L_s=2, β=6) = 0.4291049969
-
-Framework canonical t (from Block 01) = 1.0
-
-HK character coefficients c_λ_HK(t=1) = d_λ · exp(-C_2/2):
-  (p,q)=(0,0): d=1, C_2=0.0000, c_HK=1.000000e+00
-  (p,q)=(0,1): d=3, C_2=1.3333, c_HK=1.540251e+00
-  (p,q)=(1,0): d=3, C_2=1.3333, c_HK=1.540251e+00
-  (p,q)=(0,0): d=1, C_2=0.0000, c_HK=1.000000e+00
-  (p,q)=(0,1): d=3, C_2=1.3333, c_HK=1.540251e+00
-  (p,q)=(0,2): d=6, C_2=3.3333, c_HK=1.133254e+00
-  (p,q)=(1,0): d=3, C_2=1.3333, c_HK=1.540251e+00
-  (p,q)=(1,1): d=8, C_2=3.0000, c_HK=1.785041e+00
-  (p,q)=(2,0): d=6, C_2=3.3333, c_HK=1.133254e+00
-
-Candidate ρ_(p,q)(t=1) = (d × c/c_00)^12 × d^(-16):
-  (0,0): 1.000000e+00
-  (0,1): 2.200970e+00
-  (0,2): 3.461947e-03
-  (1,0): 2.200970e+00
-  (1,1): 2.555167e-01
-  (1,2): 3.245687e-05
-  (2,0): 3.461947e-03
-  (2,1): 3.245687e-05
-  (2,2): 4.025084e-10
-
-Convergence check at increasing NMAX:
-  NMAX       P_cube_HK(t=1)        Perron eigval
-     3         0.5215646412         5.354209e+00
-     4         0.5223043902         5.357664e+00
-     5         0.5223239911         5.357734e+00
-     6         0.5223243115         5.357735e+00
-     7         0.5223243151         5.357735e+00
-     8         0.5223243151         5.357735e+00
-
-========================================================================
-RESULT — HK cube Perron L_s=2 at framework canonical t = 1:
-  P_cube_HK(L_s=2, t=1) ≈ 0.5223243151
-
-Comparators (NOT load-bearing):
-  Wilson cube L_s=2:   0.4291049969  (existing runner)
-  Wilson 1-plaq:       0.4225317396  (V=1 PF certified)
-  HK 1-plaq (Block 02): 0.5134171190  (exp(-2/3) closed form)
-  HK cube L_s=2 (this): 0.5223243151  (Block 06)
-  Lattice MC thermo:   ≈ 0.5934        (comparator only)
-
-Differences:
-  HK_cube - HK_1plaq:    +0.0089071961
-  HK_cube - Wilson_cube: +0.0932193182
-  HK_cube - MC:          -0.0710756849
-  HK_cube - MC distance: 235× ε_witness
-
-Interpretation:
-  HK cube > Wilson cube — HK action gives larger plaquette
-  expectation at L_s=2 than Wilson does, consistent with the HK
-  measure putting more weight on non-trivial sectors.
-
-Both HK and Wilson L_s=2 are bounded above by the famous-open
-thermodynamic ⟨P⟩(6) ≈ 0.5934 (lattice MC comparator). The L_s=2
-cube is structurally insufficient for ε_witness precision; this
-artifact is a comparator across actions at fixed lattice size.
-
-Block 03's named obstruction (cluster-decomposition / exponential-
-clustering estimate not in current primitives) remains the bottleneck
-for thermodynamic-limit closure under either action.
+[PASS] dimension polynomial is integral on W_8: parity proof checked on the largest certified box
+[PASS] recurrence move set is inverse-closed: ((1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (-1, 0))
+[PASS] N=6 definitions, symmetry, positivity, eigenpair and invariances: none
+[PASS] N=6 binary64 agrees with independent certificate: P_N=0.5223243115373619; residual=1.767e-15; gap=4.959281438651
+[PASS] N=7 definitions, symmetry, positivity, eigenpair and invariances: none
+[PASS] N=7 binary64 agrees with independent certificate: P_N=0.5223243150756920; residual=2.443e-15; gap=4.959281441341
+[PASS] N=8 definitions, symmetry, positivity, eigenpair and invariances: none
+[PASS] N=8 binary64 agrees with independent certificate: P_N=0.5223243151037389; residual=7.213e-16; gap=4.959281441355
+[PASS] twelve-decimal N=6,7,8 stability claim is false: rounded values=[0.522324311537, 0.522324315076, 0.522324315104]
+[PASS] normal scalar is sign and scale invariant: quadratic expectation divides by the squared norm
+[PASS] normal reconstruction cannot read answer keys: REFERENCE_CENTERS absent from reconstruction bytecode
+[PASS] source/import firewall: repo-local imports=[]
+[PASS] note has no source-note dependency links: non-runner markdown targets=[]
+[PASS] no literal True is used as check evidence: offending lines=[]
+[PASS] finite theorem has no physical/action/thermodynamic conclusion: forbidden theorem terms=[]
+[PASS] claim-surface tags are formal only: no action, topology, or limiting tag supplied
+SUMMARY: PASS=16 FAIL=0
 
 ----- stderr -----
 

--- a/logs/runner-cache/probe_hk_cube_perron_l2_2026_05_06.txt
+++ b/logs/runner-cache/probe_hk_cube_perron_l2_2026_05_06.txt
@@ -1,31 +1,32 @@
 ===== runner cache v1 =====
 runner: scripts/probe_hk_cube_perron_l2_2026_05_06.py
-runner_sha256: 5e08bb70caca8cdee97302ca07db7fe0940d74ba250a63ec69ac12b377a15fb5
+runner_sha256: 854cc844de6029e3305c633b36442e8fd67d4dc8fe7d931b823338cdad02eb9d
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.09
+elapsed_sec: 0.14
 status: ok
 ----- stdout -----
 FINITE WEIGHTED-TRANSFER THEOREM — NORMAL MODE
 formal parameter: t=1; legacy HK/cube/Perron words are identity only
 
-[PASS] dimension polynomial is integral on W_8: parity proof checked on the largest certified box
+[PASS] dimension polynomial is integral on W_8: parity proof checked on the largest tested box
 [PASS] recurrence move set is inverse-closed: ((1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (-1, 0))
 [PASS] N=6 definitions, symmetry, positivity, eigenpair and invariances: none
-[PASS] N=6 binary64 agrees with independent certificate: P_N=0.5223243115373619; residual=1.767e-15; gap=4.959281438651
+[PASS] N=6 binary64 agrees with stored high-precision estimate: P_N=0.5223243115373619; residual=1.767e-15; gap=4.959281438651
 [PASS] N=7 definitions, symmetry, positivity, eigenpair and invariances: none
-[PASS] N=7 binary64 agrees with independent certificate: P_N=0.5223243150756920; residual=2.443e-15; gap=4.959281441341
+[PASS] N=7 binary64 agrees with stored high-precision estimate: P_N=0.5223243150756920; residual=2.443e-15; gap=4.959281441341
 [PASS] N=8 definitions, symmetry, positivity, eigenpair and invariances: none
-[PASS] N=8 binary64 agrees with independent certificate: P_N=0.5223243151037389; residual=7.213e-16; gap=4.959281441355
+[PASS] N=8 binary64 agrees with stored high-precision estimate: P_N=0.5223243151037389; residual=7.213e-16; gap=4.959281441355
 [PASS] twelve-decimal N=6,7,8 stability claim is false: rounded values=[0.522324311537, 0.522324315076, 0.522324315104]
 [PASS] normal scalar is sign and scale invariant: quadratic expectation divides by the squared norm
-[PASS] normal reconstruction cannot read answer keys: REFERENCE_CENTERS absent from reconstruction bytecode
+[PASS] normal reconstruction cannot read answer keys: reachable readers=[]
+[PASS] high-precision import path has no module-scope NumPy dependency: module-scope NumPy import lines=[]
 [PASS] source/import firewall: repo-local imports=[]
 [PASS] note has no source-note dependency links: non-runner markdown targets=[]
 [PASS] no literal True is used as check evidence: offending lines=[]
 [PASS] finite theorem has no physical/action/thermodynamic conclusion: forbidden theorem terms=[]
 [PASS] claim-surface tags are formal only: no action, topology, or limiting tag supplied
-SUMMARY: PASS=16 FAIL=0
+SUMMARY: PASS=17 FAIL=0
 
 ----- stderr -----
 

--- a/scripts/frontier_hk_thermodynamic_stretch_source_packet.py
+++ b/scripts/frontier_hk_thermodynamic_stretch_source_packet.py
@@ -5,9 +5,11 @@ Authority note:
     docs/BRIDGE_GAP_HK_THERMODYNAMIC_STRETCH_NOTE_2026-05-06.md
 
 This runner checks Block 03 as an open-gate packet: the heat-kernel
-multi-plaquette factorization is explicit, the single-plaquette and L_s=2
-finite-cube artifacts are runner-backed, and the thermodynamic-limit blocker
-remains the missing cluster-decomposition / exponential-clustering estimate.
+multi-plaquette factorization is explicit, the single-plaquette artifact is
+runner-backed, and the thermodynamic-limit blocker remains the missing
+cluster-decomposition / exponential-clustering estimate.  It also enforces the
+2026-07-16 downstream firewall: the legacy Block 06 row is formal finite
+linear algebra and is not evidence for a physical L_s=2 HK cube.
 It does not assign an audit verdict.
 
 Exit code: 0 on full PASS, 1 on any FAIL.
@@ -109,8 +111,8 @@ def main() -> int:
     print("HK THERMODYNAMIC STRETCH SOURCE PACKET")
     print("=" * 78)
     print()
-    print("Question: is Block 03 now runner-backed as an open gate, with")
-    print("the later L_s=2 HK cube result included but not overclaimed?")
+    print("Question: is Block 03 runner-backed as an open gate, with the")
+    print("legacy Block 06 formal theorem excluded from physical Path A?")
     print()
 
     note_path = "docs/BRIDGE_GAP_HK_THERMODYNAMIC_STRETCH_NOTE_2026-05-06.md"
@@ -129,24 +131,24 @@ def main() -> int:
     require_fragment("lambda-sum obstruction is named", note, "Obstruction (O3.2): convergence of the (λ_p)-sum at t=1")
     require_fragment("cluster estimate is the open premise blocker", note, "cluster-decomposition / exponential-clustering estimate")
     require_fragment("current premises do not contain the cluster estimate", note, "current approved primitive or\nretained-premise surface")
-    require_fragment("Block 06 update is cited", note, "BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md")
-    require_fragment("Block 06 finite cube value is cited", note, "0.5223243151")
-    require_fragment("Block 06 still leaves the named obstruction open", note, "Block 03's named obstruction stands")
+    require_fragment("Block 06 formal-only correction is recorded", note, "formal finite-matrix theorem rather than")
+    require_fragment("physical Path A is explicitly still open", note, "Path A remains open on this source surface")
+    require_fragment("physical identification bridge is required", note, "independently audited bridge from the proposed")
+    require_fragment("legacy row no longer supplies a finite-volume comparator", note, "supplies neither the physical identification bridge nor a finite-volume")
+    check(
+        "Block 06 is no longer a citation-graph dependency",
+        "[BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md](" not in note,
+        "target appears only as code-formatted historical identity",
+    )
 
     t_at_beta_6 = 1.0
     hk_single = math.exp(-2.0 / 3.0)
-    hk_cube = 0.5223243151
-    mc_comparator = 0.5934
     check("canonical HK Brownian time at beta=6 is one", math.isclose(t_at_beta_6, 1.0), "t(6)=1")
     check("single-plaquette HK value matches exp(-2/3)", math.isclose(hk_single, 0.513417119032592, rel_tol=0, abs_tol=5e-16), f"exp(-2/3)={hk_single:.15f}")
-    check("L_s=2 HK cube improves over single plaquette", hk_cube > hk_single, f"{hk_cube:.10f} > {hk_single:.10f}")
-    check("L_s=2 HK cube remains below thermodynamic comparator", hk_cube < mc_comparator, f"{hk_cube:.10f} < {mc_comparator:.4f}")
-    check("finite cube gap remains far from epsilon-witness scale", (mc_comparator - hk_cube) > 0.07, f"gap={mc_comparator - hk_cube:.10f}")
 
     deps = [
         "docs/BRIDGE_GAP_HK_TIME_DERIVATION_NOTE_2026-05-06.md",
         "docs/BRIDGE_GAP_HK_PLAQUETTE_CLOSED_FORM_NOTE_2026-05-06.md",
-        "docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md",
         "docs/SU3_CUBE_FULL_RHO_PERRON_2026-05-04.md",
         "docs/GAUGE_SCALAR_TEMPORAL_OBSERVABLE_BRIDGE_NO_GO_THEOREM_NOTE_2026-05-03.md",
         "docs/SU3_CASIMIR_FUNDAMENTAL_THEOREM_NOTE_2026-05-02.md",
@@ -156,9 +158,16 @@ def main() -> int:
         check(f"{dep_name} exists", (REPO_ROOT / dep).exists(), dep)
         require_fragment(f"{dep_name} cited by Block 03 note", note, dep_name)
 
-    require_fragment("cube note names finite value", cube_note, "P_cube_HK(L_s=2, t=1) = 0.5223243151")
-    require_fragment("cube note states thermodynamic limit remains open", cube_note, "does not\nestablish the thermodynamic limit")
-    require_fragment("cube note preserves Block 03 blocker", cube_note, "Block 03's named obstruction stands")
+    require_fragment("cube note is a finite weighted-transfer theorem", cube_note, "Finite Weighted-Transfer Theorem")
+    require_fragment("cube note class is positive theorem", cube_note, "**Claim type:** positive_theorem")
+    require_fragment("cube note makes legacy names identity-only", cube_note, "identity only")
+    require_fragment("cube note requires a separate downstream physical bridge", cube_note, "Any downstream physical reuse must add a separate, explicit bridge")
+    require_fragment("cube note declares no source-note dependencies", cube_note, "## Dependencies\n\nNone.")
+    check(
+        "cube theorem does not retain the old physical scalar symbol",
+        "P_cube_HK" not in cube_note,
+        "P_cube_HK absent from repaired source",
+    )
 
     check_cache(
         runner="scripts/probe_hk_time_derivation.py",
@@ -172,17 +181,6 @@ def main() -> int:
         expected_pass=8,
         required_fragments=["exp(-2/3)", "SUMMARY: PASS=8 FAIL=0"],
     )
-    check_cache(
-        runner="scripts/probe_hk_cube_perron_l2_2026_05_06.py",
-        cache="logs/runner-cache/probe_hk_cube_perron_l2_2026_05_06.txt",
-        expected_pass=None,
-        required_fragments=[
-            "P_cube_HK(L_s=2, t=1) ≈ 0.5223243151",
-            "Block 03's named obstruction",
-            "thermodynamic-limit closure",
-        ],
-    )
-
     print()
     print("=" * 78)
     print(f"SUMMARY: PASS={PASS_COUNT} FAIL={FAIL_COUNT}")
@@ -192,8 +190,8 @@ def main() -> int:
         print("Verdict: FAIL; HK thermodynamic stretch packet is not audit-ready.")
         return 1
     print("Verdict: bounded source-packet support. Block 03 is runner-backed")
-    print("as an open gate; Block 06 closes the finite-cube comparator path,")
-    print("but thermodynamic closure still needs the named clustering estimate.")
+    print("as an open gate; Block 06 is formal-only and does not close physical")
+    print("Path A; thermodynamic closure still needs the named clustering estimate.")
     print("No audit verdict or retained status is assigned.")
     return 0
 

--- a/scripts/probe_hk_cube_perron_l2_2026_05_06.py
+++ b/scripts/probe_hk_cube_perron_l2_2026_05_06.py
@@ -1,223 +1,802 @@
-"""Block 06: SU(3) L_s=2 cube full-ρ Perron solve under HEAT-KERNEL action.
+#!/usr/bin/env python3
+"""Finite weighted-transfer theorem and numerical certificate.
 
-Adapts the existing scripts/frontier_su3_cube_full_rho_perron_2026_05_04.py
-runner from Wilson character coefficients (Bessel determinants) to
-heat-kernel character coefficients (d_λ · exp(-t·C_2(λ)/2)).
+The historical filename is retained as a stable identity.  This module defines
+only finite functions and matrices.  It does not construct a heat-kernel
+action, lattice-cube measure, physical plaquette, Brownian-time convention, or
+thermodynamic observable.
 
-Wilson cube: P_cube_W(L_s=2, β=6) = 0.4291049969 (per the existing runner)
-HK cube: P_cube_HK(L_s=2, t=1) = ?
-
-The L_s=2 cube structure (24 directed links, 12 plaquettes, candidate-ρ
-ansatz `(d c/c_00)^12 · d^(-16)`) is character-coefficient-AGNOSTIC at
-the index-graph level — only the Wilson character coefficients need to
-be swapped for HK ones.
-
-Companion: docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md
-Block: 06
-
-This produces a NUMERICAL value for ⟨P⟩_HK on the L_s=2 cube. It does
-NOT close the thermodynamic limit (Block 03 named obstruction stands)
-and does NOT close action-form uniqueness (Block 04 no-go stands). It
-is a concrete comparator artifact under the HK candidate action.
+Modes:
+  normal              NumPy reconstruction plus algebraic/invariant checks.
+  high-precision      independent mpmath reconstruction and residual/gap bound.
+  hostile             require every named mutation to be rejected.
+  intentional-failure run a known asymmetric mutation and exit nonzero.
 """
+
 from __future__ import annotations
 
-from typing import Dict, List, Tuple
+import argparse
+import ast
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
 
 import numpy as np
 
 
-def dim_su3(p: int, q: int) -> int:
-    return (p + 1) * (q + 1) * (p + q + 2) // 2
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = REPO_ROOT / "docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md"
+FORMAL_T = 1.0
+CERTIFIED_N = (6, 7, 8)
+MOVES = ((1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (-1, 0))
+
+# These centers are answer keys only for post-computation regression checks.
+# Neither reconstruction path is permitted to read them while building a
+# matrix, choosing an eigenvector, or evaluating P_N.
+REFERENCE_CENTERS = {
+    6: "0.522324311537361669376731397147380591681793209294921543147251767405388996516",
+    7: "0.522324315075691917933023223847885524615477328862129075311171521855593496815",
+    8: "0.522324315103738928863262943442354237767467710788871114561329778403325241798",
+}
+REFERENCE_RADIUS_TEXT = "2e-60"
 
 
-def casimir_su3(p: int, q: int) -> float:
+class Checks:
+    def __init__(self) -> None:
+        self.passes = 0
+        self.failures = 0
+
+    def record(self, label: str, condition: bool, detail: str) -> bool:
+        status = "PASS" if condition else "FAIL"
+        if condition:
+            self.passes += 1
+        else:
+            self.failures += 1
+        print(f"[{status}] {label}: {detail}")
+        return condition
+
+    def finish(self) -> int:
+        print(f"SUMMARY: PASS={self.passes} FAIL={self.failures}")
+        return 0 if self.failures == 0 else 1
+
+
+class SymmetryGateError(ValueError):
+    """Raised before a symmetric eigensolver sees a nonsymmetric matrix."""
+
+
+@dataclass(frozen=True)
+class Mutation:
+    asymmetric_recurrence: bool = False
+    quadratic_denominator: int = 3
+    rho_exponential_factor: int = 6
+    rho_dimension_power: int = 8
+    omit_local_factor: bool = False
+    eigenvector_rank_from_top: int = 0
+
+
+@dataclass
+class NumpyCase:
+    nmax: int
+    weights: list[tuple[int, int]]
+    j_matrix: np.ndarray
+    multiplier: np.ndarray
+    local_values: np.ndarray
+    rho_values: np.ndarray
+    transfer: np.ndarray
+    eigenvalues: np.ndarray
+    vector: np.ndarray
+    scalar: float
+    residual: float
+
+
+@dataclass
+class HighPrecisionCase:
+    nmax: int
+    scalar: object
+    top_eigenvalue: object
+    observed_gap: object
+    top_residual: object
+    basis_residual_frobenius: object
+    gram_defect_frobenius: object
+    basis_delta: object
+    gap_lower: object
+    scalar_radius: object
+    symmetry_defect: object
+    min_top_vector_entry: object
+    min_multiplier_entry: object
+    min_transfer_entry: object
+
+
+def dimension_polynomial(p: int, q: int) -> int:
+    """The defined integer polynomial d(p,q)."""
+    if p < 0 or q < 0:
+        raise ValueError("p and q must be nonnegative")
+    numerator = (p + 1) * (q + 1) * (p + q + 2)
+    if numerator % 2:
+        raise ArithmeticError("dimension numerator must be even")
+    return numerator // 2
+
+
+def quadratic_c(p: int, q: int) -> float:
+    """The defined rational quadratic c(p,q), returned in binary64."""
     return (p * p + p * q + q * q + 3 * p + 3 * q) / 3.0
 
 
-def hk_character_coefficient(p: int, q: int, t: float) -> float:
-    """Heat-kernel character coefficient: d_λ · exp(-t·C_2(λ)/2).
-
-    Replaces Wilson's Bessel-determinant `c_λ(β)` from the original
-    runner. At the framework's canonical t = 1 (Block 01).
-    """
-    d = dim_su3(p, q)
-    C2 = casimir_su3(p, q)
-    return d * np.exp(-t * C2 / 2.0)
-
-
-def build_candidate_rho_hk(t: float, nmax: int) -> Dict[Tuple[int, int], float]:
-    """ρ_(p,q)(t) = (d_λ × c_λ_HK(t) / c_00_HK(t))^12 × d_λ^(-16)
-
-    The cube's index-graph topology factor d^(N_components - N_links)
-    = d^(8 - 24) = d^(-16) is character-coefficient-agnostic.
-    The (d c/c_00)^12 part captures 12 plaquettes' character contribution.
-
-    For HK at t = 1: c_00_HK = 1, c_λ_HK = d_λ · exp(-C_2/2).
-    """
-    c00 = hk_character_coefficient(0, 0, t)  # = 1.0
-    rho: Dict[Tuple[int, int], float] = {}
-    for p in range(nmax + 1):
-        for q in range(nmax + 1):
-            d = dim_su3(p, q)
-            c = hk_character_coefficient(p, q, t)
-            rho[(p, q)] = ((d * c / c00) ** 12) * (d ** (-16))
-    norm = rho[(0, 0)]
-    return {k: v / norm for k, v in rho.items()}
-
-
-def dominant_weights_box(nmax: int) -> List[Tuple[int, int]]:
+def square_box(nmax: int) -> list[tuple[int, int]]:
+    if nmax < 0:
+        raise ValueError("N must be nonnegative")
     return [(p, q) for p in range(nmax + 1) for q in range(nmax + 1)]
 
 
-def recurrence_neighbors(p: int, q: int) -> List[Tuple[int, int]]:
-    out = []
-    for a, b in [(p + 1, q), (p - 1, q + 1), (p, q - 1), (p, q + 1),
-                 (p + 1, q - 1), (p - 1, q)]:
-        if a >= 0 and b >= 0:
-            out.append((a, b))
-    return out
+def normalized_scalar(vector: np.ndarray, matrix: np.ndarray) -> float:
+    denominator = float(vector @ vector)
+    if not denominator > 0.0:
+        raise ValueError("the vector must be nonzero")
+    return float(vector @ (matrix @ vector) / denominator)
 
 
-def build_j(nmax: int) -> Tuple[np.ndarray, List[Tuple[int, int]],
-                                 Dict[Tuple[int, int], int]]:
-    weights = dominant_weights_box(nmax)
+def _build_numpy_case(nmax: int, mutation: Mutation = Mutation()) -> NumpyCase:
+    """Binary64 construction; deliberately independent of answer keys."""
+    weights = [(p, q) for p in range(nmax + 1) for q in range(nmax + 1)]
     index = {weight: i for i, weight in enumerate(weights)}
-    j_op = np.zeros((len(weights), len(weights)), dtype=float)
+    size = len(weights)
+    j_matrix = np.zeros((size, size), dtype=float)
     for p, q in weights:
         source = index[(p, q)]
-        for neighbor in recurrence_neighbors(p, q):
+        for dp, dq in MOVES:
+            neighbor = (p + dp, q + dq)
             if neighbor in index:
-                j_op[index[neighbor], source] += 1.0 / 6.0
-    return j_op, weights, index
+                j_matrix[index[neighbor], source] += 1.0 / 6.0
+    if mutation.asymmetric_recurrence:
+        j_matrix[index[(0, 0)], index[(1, 0)]] += 1.0 / 6.0
+
+    if not np.array_equal(j_matrix, j_matrix.T):
+        raise SymmetryGateError("J_N failed exact binary64 symmetry gate")
+    j_values, j_vectors = np.linalg.eigh(j_matrix)
+    multiplier_raw = (j_vectors * np.exp(3.0 * j_values)) @ j_vectors.T
+    multiplier_defect = float(np.max(np.abs(multiplier_raw - multiplier_raw.T)))
+    if multiplier_defect > 2e-14:
+        raise SymmetryGateError(
+            f"M_N symmetry defect {multiplier_defect:.3e} exceeds binary64 guard"
+        )
+    multiplier = 0.5 * (multiplier_raw + multiplier_raw.T)
+
+    c_used = np.array(
+        [
+            (p * p + p * q + q * q + 3 * p + 3 * q)
+            / float(mutation.quadratic_denominator)
+            for p, q in weights
+        ],
+        dtype=float,
+    )
+    dims = np.array(
+        [((p + 1) * (q + 1) * (p + q + 2)) // 2 for p, q in weights],
+        dtype=float,
+    )
+    if mutation.omit_local_factor:
+        local_values = np.ones(size, dtype=float)
+    else:
+        local_values = np.exp(-2.0 * FORMAL_T * c_used)
+    rho_values = (dims ** mutation.rho_dimension_power) * np.exp(
+        -float(mutation.rho_exponential_factor) * FORMAL_T * c_used
+    )
+    transfer_raw = multiplier @ np.diag(local_values * rho_values) @ multiplier
+    transfer_defect = float(np.max(np.abs(transfer_raw - transfer_raw.T)))
+    if transfer_defect > 2e-13:
+        raise SymmetryGateError(
+            f"T_N symmetry defect {transfer_defect:.3e} exceeds binary64 guard"
+        )
+    transfer = 0.5 * (transfer_raw + transfer_raw.T)
+    eigenvalues, eigenvectors = np.linalg.eigh(transfer)
+    chosen = size - 1 - mutation.eigenvector_rank_from_top
+    vector = eigenvectors[:, chosen]
+    if float(np.sum(vector)) < 0.0:
+        vector = -vector
+    scalar = normalized_scalar(vector, j_matrix)
+    rayleigh = float(vector @ (transfer @ vector) / (vector @ vector))
+    residual = float(np.linalg.norm(transfer @ vector - rayleigh * vector, ord=2))
+    return NumpyCase(
+        nmax=nmax,
+        weights=weights,
+        j_matrix=j_matrix,
+        multiplier=multiplier,
+        local_values=local_values,
+        rho_values=rho_values,
+        transfer=transfer,
+        eigenvalues=eigenvalues,
+        vector=vector,
+        scalar=scalar,
+        residual=residual,
+    )
 
 
-def build_local_factor_hk(weights: List[Tuple[int, int]],
-                           index: Dict[Tuple[int, int], int],
-                           t: float) -> np.ndarray:
-    """Local plaquette factor under HK: a_link^4 with a_link = c_λ/(d·c_00).
-
-    For HK: a_link = (d_λ · exp(-t·C_2/2)) / (d_λ · 1) = exp(-t·C_2/2).
-    """
-    coeffs = np.array([hk_character_coefficient(p, q, t) for p, q in weights],
-                      dtype=float)
-    dims = np.array([dim_su3(p, q) for p, q in weights], dtype=float)
-    c00 = coeffs[index[(0, 0)]]
-    a_link = coeffs / (dims * c00)
-    return np.diag(a_link ** 4)
+def _expected_recurrence(weights: Sequence[tuple[int, int]]) -> np.ndarray:
+    index = {weight: i for i, weight in enumerate(weights)}
+    result = np.zeros((len(weights), len(weights)), dtype=float)
+    inverse_closed_moves = {(1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (-1, 0)}
+    for row, (p_row, q_row) in enumerate(weights):
+        for col, (p_col, q_col) in enumerate(weights):
+            if (p_row - p_col, q_row - q_col) in inverse_closed_moves:
+                result[row, col] = 1.0 / 6.0
+    return result
 
 
-def matrix_exp_symmetric(matrix: np.ndarray, tau: float) -> np.ndarray:
-    vals, vecs = np.linalg.eigh(matrix)
-    return (vecs * np.exp(tau * vals)) @ vecs.T
+def numpy_case_violations(case: NumpyCase) -> list[str]:
+    """Definition and spectral checks, recomputed outside the builder."""
+    violations: list[str] = []
+    expected_j = _expected_recurrence(case.weights)
+    if not np.array_equal(case.j_matrix, expected_j):
+        violations.append("recurrence definition")
+    if not np.array_equal(case.j_matrix, case.j_matrix.T):
+        violations.append("recurrence symmetry")
+
+    expected_c = np.array(
+        [
+            (p * p + p * q + q * q + 3 * p + 3 * q) / 3.0
+            for p, q in case.weights
+        ]
+    )
+    expected_d = np.array(
+        [
+            (p + 1) * (q + 1) * (p + q + 2) / 2.0
+            for p, q in case.weights
+        ]
+    )
+    expected_local = np.exp(-2.0 * expected_c)
+    expected_rho = expected_d**8 * np.exp(-6.0 * expected_c)
+    if not np.allclose(case.local_values, expected_local, rtol=2e-15, atol=0.0):
+        violations.append("local diagonal definition")
+    if not np.allclose(case.rho_values, expected_rho, rtol=4e-15, atol=0.0):
+        violations.append("rho definition")
+    if not np.allclose(case.multiplier, case.multiplier.T, rtol=0.0, atol=2e-14):
+        violations.append("multiplier symmetry")
+    if not np.all(case.multiplier > 0.0):
+        violations.append("multiplier strict positivity")
+    if not np.allclose(case.transfer, case.transfer.T, rtol=0.0, atol=2e-13):
+        violations.append("transfer symmetry")
+    if not np.all(case.transfer > 0.0):
+        violations.append("transfer entrywise positivity")
+    if not (
+        np.all(case.local_values * case.rho_values > 0.0)
+        and np.min(np.linalg.eigvalsh(case.multiplier)) > 0.0
+    ):
+        violations.append("transfer positive-definite construction")
+    if not case.eigenvalues[-1] > case.eigenvalues[-2]:
+        violations.append("dominant eigenvalue gap")
+    rayleigh = float(case.vector @ (case.transfer @ case.vector))
+    if not math.isclose(rayleigh, float(case.eigenvalues[-1]), rel_tol=2e-13, abs_tol=2e-13):
+        violations.append("dominant eigenvector selection")
+    if not math.isclose(float(case.vector @ case.vector), 1.0, rel_tol=0.0, abs_tol=2e-13):
+        violations.append("eigenvector normalization")
+    if not float(np.sum(case.vector)) > 0.0:
+        violations.append("positive sign convention")
+    if not np.all(case.vector > 0.0):
+        violations.append("top eigenvector strict positivity")
+    if not case.residual < 2e-12:
+        violations.append("eigenpair residual")
+    p_sign = normalized_scalar(-case.vector, case.j_matrix)
+    p_scale = normalized_scalar(3.25 * case.vector, case.j_matrix)
+    if not math.isclose(case.scalar, p_sign, rel_tol=0.0, abs_tol=2e-15):
+        violations.append("sign invariance")
+    if not math.isclose(case.scalar, p_scale, rel_tol=0.0, abs_tol=2e-15):
+        violations.append("normalization invariance")
+    return violations
 
 
-def perron_value_hk(rho: Dict[Tuple[int, int], float],
-                     nmax: int, t: float) -> Tuple[float, float]:
-    j_op, weights, index = build_j(nmax)
-    multiplier = matrix_exp_symmetric(j_op, 3.0)
-    d_loc = build_local_factor_hk(weights, index, t)
-    c_env = np.diag(np.array([rho.get(weight, 0.0) for weight in weights],
-                              dtype=float))
-    transfer = multiplier @ d_loc @ c_env @ multiplier
-    vals, vecs = np.linalg.eigh(transfer)
-    idx = int(np.argmax(vals))
-    psi = vecs[:, idx]
-    if np.sum(psi) < 0.0:
-        psi = -psi
-    return float(psi @ (j_op @ psi)), float(vals[idx])
+def _high_precision_reconstruction(nmax: int, dps: int) -> HighPrecisionCase:
+    """Independent mpmath construction; no NumPy/helper/answer-key reuse."""
+    import mpmath as mp
+
+    mp.mp.dps = dps
+    guard = mp.power(10, -(dps - 30))
+    weights = [(p, q) for p in range(nmax + 1) for q in range(nmax + 1)]
+    index = {weight: i for i, weight in enumerate(weights)}
+    size = len(weights)
+    j_matrix = mp.matrix(size)
+    independent_moves = ((1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (-1, 0))
+    for p, q in weights:
+        source = index[(p, q)]
+        for dp, dq in independent_moves:
+            neighbor = (p + dp, q + dq)
+            if neighbor in index:
+                j_matrix[index[neighbor], source] += mp.mpf(1) / 6
+
+    recurrence_symmetry_defect = max(
+        abs(j_matrix[row, col] - j_matrix[col, row])
+        for row in range(size)
+        for col in range(size)
+    )
+    if recurrence_symmetry_defect != 0:
+        raise SymmetryGateError("J_N failed exact high-precision symmetry gate")
+
+    j_values, j_vectors = mp.eigsy(j_matrix)
+    multiplier_raw = (
+        j_vectors
+        * mp.diag([mp.exp(3 * value) for value in j_values])
+        * j_vectors.T
+    )
+    multiplier_symmetry_defect = max(
+        abs(multiplier_raw[row, col] - multiplier_raw[col, row])
+        for row in range(size)
+        for col in range(size)
+    )
+    if multiplier_symmetry_defect > guard:
+        raise SymmetryGateError("M_N high-precision symmetry defect exceeds guard")
+    multiplier = (multiplier_raw + multiplier_raw.T) / 2
+
+    local_values = []
+    rho_values = []
+    for p, q in weights:
+        d_value = mp.mpf((p + 1) * (q + 1) * (p + q + 2)) / 2
+        c_value = mp.mpf(p * p + p * q + q * q + 3 * p + 3 * q) / 3
+        local_values.append(mp.exp(-2 * c_value))
+        rho_values.append(d_value**8 * mp.exp(-6 * c_value))
+    transfer_raw = multiplier * mp.diag(
+        [local * rho for local, rho in zip(local_values, rho_values)]
+    ) * multiplier
+    transfer_symmetry_defect = max(
+        abs(transfer_raw[row, col] - transfer_raw[col, row])
+        for row in range(size)
+        for col in range(size)
+    )
+    if transfer_symmetry_defect > guard:
+        raise SymmetryGateError("T_N high-precision symmetry defect exceeds guard")
+    transfer = (transfer_raw + transfer_raw.T) / 2
+    symmetry_defect = max(
+        recurrence_symmetry_defect,
+        multiplier_symmetry_defect,
+        transfer_symmetry_defect,
+    )
+
+    eigenvalues, eigenvectors = mp.eigsy(transfer)
+    vector = eigenvectors[:, size - 1]
+    if mp.fsum(vector) < 0:
+        vector = -vector
+    vector /= mp.sqrt((vector.T * vector)[0])
+    approximate_top = eigenvalues[size - 1]
+    scalar = (vector.T * j_matrix * vector)[0]
+    top_residual_vector = transfer * vector - approximate_top * vector
+    top_residual = mp.sqrt((top_residual_vector.T * top_residual_vector)[0])
+
+    residual_square_sum = mp.mpf(0)
+    for column in range(size):
+        candidate = eigenvectors[:, column]
+        residual = transfer * candidate - eigenvalues[column] * candidate
+        residual_square_sum += (residual.T * residual)[0]
+    basis_residual_frobenius = mp.sqrt(residual_square_sum)
+    gram = eigenvectors.T * eigenvectors
+    gram_defect_frobenius = mp.sqrt(
+        mp.fsum(
+            abs(gram[row, col] - (1 if row == col else 0)) ** 2
+            for row in range(size)
+            for col in range(size)
+        )
+    )
+    if gram_defect_frobenius >= 1:
+        basis_delta = mp.inf
+    else:
+        # With Q formed from the computed eigenvectors and D from their
+        # eigenvalues, TQ-QD=R and Q^TQ=I+E.  Therefore
+        # ||Q^{-1}R||_2 <= ||R||_F/sqrt(1-||E||_F).  Bauer-Fike plus the
+        # isolated top interval gives the ordered top-eigenvalue enclosure.
+        basis_delta = (
+            basis_residual_frobenius / mp.sqrt(1 - gram_defect_frobenius)
+            + guard
+        )
+    observed_gap = approximate_top - eigenvalues[size - 2]
+    gap_lower = observed_gap - 2 * basis_delta
+    separation_from_non_top = observed_gap - basis_delta
+    if gap_lower <= 0 or separation_from_non_top <= 0:
+        scalar_radius = mp.inf
+    else:
+        # The top interval is isolated.  The symmetric residual angle bound
+        # gives sin(theta) <= (top_residual+guard)/separation_from_non_top.
+        # For rank-one projectors and ||J_N||_2 <= 1, the two quadratic
+        # expectations differ by at most 2 sin(theta), plus the guard.
+        scalar_radius = (
+            guard
+            + 2 * (top_residual + guard) / separation_from_non_top
+        )
+
+    return HighPrecisionCase(
+        nmax=nmax,
+        scalar=scalar,
+        top_eigenvalue=approximate_top,
+        observed_gap=observed_gap,
+        top_residual=top_residual,
+        basis_residual_frobenius=basis_residual_frobenius,
+        gram_defect_frobenius=gram_defect_frobenius,
+        basis_delta=basis_delta,
+        gap_lower=gap_lower,
+        scalar_radius=scalar_radius,
+        symmetry_defect=symmetry_defect,
+        min_top_vector_entry=min(vector),
+        min_multiplier_entry=min(multiplier),
+        min_transfer_entry=min(transfer),
+    )
+
+
+def _function_reads_answer_key(function: Callable[..., object]) -> bool:
+    return "REFERENCE_CENTERS" in function.__code__.co_names
+
+
+def _literal_true_evidence_calls() -> list[int]:
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    bad_lines: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != "record" or len(node.args) < 2:
+            continue
+        if isinstance(node.args[1], ast.Constant) and node.args[1].value is True:
+            bad_lines.append(node.lineno)
+    return bad_lines
+
+
+def _repo_local_imports() -> list[str]:
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    allowed = {"argparse", "ast", "math", "re", "dataclasses", "pathlib", "typing", "numpy", "mpmath", "__future__"}
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names = [alias.name.split(".")[0] for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            names = [(node.module or "").split(".")[0]]
+        else:
+            continue
+        found.extend(name for name in names if name and name not in allowed)
+    return sorted(set(found))
+
+
+def _note_source_dependencies() -> list[str]:
+    text = NOTE_PATH.read_text(encoding="utf-8")
+    targets: list[str] = []
+    for match in re.finditer(r"\[[^]]+\]\(([^)]+)\)", text):
+        target = match.group(1)
+        if not target.startswith("../scripts/"):
+            targets.append(target)
+    return targets
+
+
+def _theorem_physical_terms() -> list[str]:
+    text = NOTE_PATH.read_text(encoding="utf-8")
+    start = text.index("## Finite-matrix theorem")
+    end = text.index("## Certified numerical statement")
+    theorem = text[start:end].lower()
+    forbidden = (
+        "su(3)",
+        "heat-kernel action",
+        "brownian time",
+        "plaquette",
+        "lattice cube",
+        "thermodynamic",
+        "wilson",
+        "monte carlo",
+        "physical observable",
+    )
+    return [term for term in forbidden if term in theorem]
+
+
+def _common_certified_rounding_digits(cases: Sequence[HighPrecisionCase]) -> int:
+    import mpmath as mp
+
+    common = 0
+    for digits in range(0, 30):
+        scale = mp.power(10, digits)
+        rounded: list[int] = []
+        valid = True
+        for case in cases:
+            low = case.scalar - case.scalar_radius
+            high = case.scalar + case.scalar_radius
+            low_round = int(mp.floor(low * scale + mp.mpf("0.5")))
+            high_round = int(mp.floor(high * scale + mp.mpf("0.5")))
+            if low_round != high_round:
+                valid = False
+                break
+            rounded.append(low_round)
+        if valid and len(set(rounded)) == 1:
+            common = digits
+        else:
+            break
+    return common
+
+
+def _claim_surface_allowed(tags: Iterable[str]) -> bool:
+    allowed = {"finite_linear_algebra", "defined_functions", "defined_matrices", "finite_n_enclosures"}
+    return set(tags).issubset(allowed)
+
+
+def _bad_scalar(vector: np.ndarray, matrix: np.ndarray) -> float:
+    return float(np.sum(vector) + vector @ (matrix @ vector))
+
+
+def _scalar_is_sign_and_scale_invariant(
+    function: Callable[[np.ndarray, np.ndarray], float],
+    vector: np.ndarray,
+    matrix: np.ndarray,
+) -> bool:
+    base = function(vector, matrix)
+    return math.isclose(base, function(-vector, matrix), rel_tol=0.0, abs_tol=1e-13) and math.isclose(
+        base, function(2.75 * vector, matrix), rel_tol=0.0, abs_tol=1e-13
+    )
+
+
+def run_normal() -> int:
+    checks = Checks()
+    print("FINITE WEIGHTED-TRANSFER THEOREM — NORMAL MODE")
+    print("formal parameter: t=1; legacy HK/cube/Perron words are identity only")
+    print()
+
+    checks.record(
+        "dimension polynomial is integral on W_8",
+        all(
+            ((p + 1) * (q + 1) * (p + q + 2)) % 2 == 0
+            and dimension_polynomial(p, q) >= 1
+            for p, q in square_box(8)
+        ),
+        "parity proof checked on the largest certified box",
+    )
+    checks.record(
+        "recurrence move set is inverse-closed",
+        set(MOVES) == {(-dp, -dq) for dp, dq in MOVES},
+        str(MOVES),
+    )
+    cases: list[NumpyCase] = []
+    for nmax in CERTIFIED_N:
+        case = _build_numpy_case(nmax)
+        cases.append(case)
+        violations = numpy_case_violations(case)
+        checks.record(
+            f"N={nmax} definitions, symmetry, positivity, eigenpair and invariances",
+            not violations,
+            "none" if not violations else ", ".join(violations),
+        )
+        center = float(REFERENCE_CENTERS[nmax])
+        checks.record(
+            f"N={nmax} binary64 agrees with independent certificate",
+            abs(case.scalar - center) < 8e-15,
+            f"P_N={case.scalar:.16f}; residual={case.residual:.3e}; gap={case.eigenvalues[-1]-case.eigenvalues[-2]:.12f}",
+        )
+
+    rounded_all = [round(case.scalar, 12) for case in cases]
+    checks.record(
+        "twelve-decimal N=6,7,8 stability claim is false",
+        len(set(rounded_all)) != 1,
+        f"rounded values={rounded_all}",
+    )
+    checks.record(
+        "normal scalar is sign and scale invariant",
+        _scalar_is_sign_and_scale_invariant(normalized_scalar, cases[-1].vector, cases[-1].j_matrix),
+        "quadratic expectation divides by the squared norm",
+    )
+    checks.record(
+        "normal reconstruction cannot read answer keys",
+        not _function_reads_answer_key(_build_numpy_case),
+        "REFERENCE_CENTERS absent from reconstruction bytecode",
+    )
+    local_imports = _repo_local_imports()
+    checks.record(
+        "source/import firewall",
+        not local_imports,
+        f"repo-local imports={local_imports}",
+    )
+    dependency_targets = _note_source_dependencies()
+    checks.record(
+        "note has no source-note dependency links",
+        not dependency_targets,
+        f"non-runner markdown targets={dependency_targets}",
+    )
+    bad_true = _literal_true_evidence_calls()
+    checks.record(
+        "no literal True is used as check evidence",
+        not bad_true,
+        f"offending lines={bad_true}",
+    )
+    physical_terms = _theorem_physical_terms()
+    checks.record(
+        "finite theorem has no physical/action/thermodynamic conclusion",
+        not physical_terms,
+        f"forbidden theorem terms={physical_terms}",
+    )
+    checks.record(
+        "claim-surface tags are formal only",
+        _claim_surface_allowed(
+            {"finite_linear_algebra", "defined_functions", "defined_matrices", "finite_n_enclosures"}
+        ),
+        "no action, topology, or limiting tag supplied",
+    )
+    return checks.finish()
+
+
+def run_high_precision(dps: int) -> int:
+    import mpmath as mp
+
+    checks = Checks()
+    print("FINITE WEIGHTED-TRANSFER THEOREM — INDEPENDENT HIGH-PRECISION MODE")
+    print(f"library=mpmath; decimal precision={dps}; formal parameter t=1")
+    print()
+    cases = [_high_precision_reconstruction(nmax, dps) for nmax in CERTIFIED_N]
+    reference_radius = mp.mpf(REFERENCE_RADIUS_TEXT)
+    for case in cases:
+        center = mp.mpf(REFERENCE_CENTERS[case.nmax])
+        checks.record(
+            f"N={case.nmax} positive matrices and certified simple top eigenvalue",
+            case.symmetry_defect < mp.power(10, -(dps - 30))
+            and case.min_top_vector_entry > 0
+            and case.min_multiplier_entry > 0
+            and case.min_transfer_entry > 0
+            and case.gap_lower > mp.mpf("4.95"),
+            f"symmetry_defect={mp.nstr(case.symmetry_defect, 5)}; "
+            f"gap_lower={mp.nstr(case.gap_lower, 18)}; "
+            f"min(v)={mp.nstr(case.min_top_vector_entry, 5)}; "
+            f"min(M)={mp.nstr(case.min_multiplier_entry, 5)}; "
+            f"min(T)={mp.nstr(case.min_transfer_entry, 5)}",
+        )
+        checks.record(
+            f"N={case.nmax} residual/gap scalar radius",
+            case.basis_delta < reference_radius
+            and case.scalar_radius < reference_radius,
+            f"basis_residual_F={mp.nstr(case.basis_residual_frobenius, 6)}; "
+            f"gram_defect_F={mp.nstr(case.gram_defect_frobenius, 6)}; "
+            f"top_residual={mp.nstr(case.top_residual, 6)}; "
+            f"delta={mp.nstr(case.basis_delta, 6)}; "
+            f"P_radius={mp.nstr(case.scalar_radius, 6)}",
+        )
+        checks.record(
+            f"N={case.nmax} enclosure agrees with stored regression interval",
+            abs(case.scalar - center) + case.scalar_radius < reference_radius,
+            f"P_N={mp.nstr(case.scalar, 76)} +/- {mp.nstr(case.scalar_radius, 6)}",
+        )
+
+    checks.record(
+        "high-precision reconstruction cannot read answer keys",
+        not _function_reads_answer_key(_high_precision_reconstruction),
+        "REFERENCE_CENTERS absent from reconstruction bytecode",
+    )
+    all_digits = _common_certified_rounding_digits(cases)
+    last_two_digits = _common_certified_rounding_digits(cases[1:])
+    checks.record(
+        "certified N=6,7,8 common rounding is seven decimals",
+        all_digits == 7,
+        f"common rounded decimal places={all_digits}",
+    )
+    checks.record(
+        "certified N=7,8 common rounding is ten decimals",
+        last_two_digits == 10,
+        f"common rounded decimal places={last_two_digits}",
+    )
+    for left, right in zip(cases, cases[1:]):
+        difference = right.scalar - left.scalar
+        radius = right.scalar_radius + left.scalar_radius
+        checks.record(
+            f"I_{left.nmax} and I_{right.nmax} are disjoint",
+            difference > radius,
+            f"P_{right.nmax}-P_{left.nmax}={mp.nstr(difference, 40)} +/- {mp.nstr(radius, 6)}",
+        )
+    return checks.finish()
+
+
+def run_hostile() -> int:
+    checks = Checks()
+    print("FINITE WEIGHTED-TRANSFER THEOREM — HOSTILE MUTATION MODE")
+    print("Each PASS means the mutation was rejected by computed evidence.")
+    print()
+
+    try:
+        _build_numpy_case(6, Mutation(asymmetric_recurrence=True))
+        asymmetric_rejected = False
+        asymmetric_detail = "mutation reached the symmetric eigensolver"
+    except SymmetryGateError as exc:
+        asymmetric_rejected = True
+        asymmetric_detail = str(exc)
+    checks.record(
+        "asymmetric recurrence mutation",
+        asymmetric_rejected,
+        asymmetric_detail,
+    )
+
+    mutation_cases = (
+        ("wrong c (legacy Casimir) polynomial", Mutation(quadratic_denominator=2), "local diagonal definition"),
+        ("wrong rho exponential factor", Mutation(rho_exponential_factor=5), "rho definition"),
+        ("wrong legacy topology/dimension exponent", Mutation(rho_dimension_power=7), "rho definition"),
+        ("missing local factor", Mutation(omit_local_factor=True), "local diagonal definition"),
+        ("incorrect dominant eigenvector", Mutation(eigenvector_rank_from_top=1), "dominant eigenvector selection"),
+    )
+    for label, mutation, expected in mutation_cases:
+        case = _build_numpy_case(6, mutation)
+        violations = numpy_case_violations(case)
+        checks.record(label, expected in violations, f"violations={violations}")
+
+    good = _build_numpy_case(6)
+    checks.record(
+        "sign/normalization-dependent scalar",
+        not _scalar_is_sign_and_scale_invariant(_bad_scalar, good.vector, good.j_matrix),
+        "linear contamination changes under sign or scale",
+    )
+
+    # An observed gap smaller than twice the residual cannot certify a simple
+    # numerical eigenpair, even if a floating solver returns two numbers.
+    hostile_residual = 1e-10
+    hostile_observed_gap = 1e-12
+    checks.record(
+        "insufficient precision/gap certificate",
+        hostile_observed_gap - 2 * hostile_residual <= 0.0,
+        f"observed_gap={hostile_observed_gap:.1e}; 2*residual={2*hostile_residual:.1e}",
+    )
+
+    normal_cases = [_build_numpy_case(nmax) for nmax in CERTIFIED_N]
+    false_twelve_digit_claim = len({round(case.scalar, 12) for case in normal_cases}) == 1
+    checks.record(
+        "false N-stability digits",
+        not false_twelve_digit_claim,
+        f"P_N={[f'{case.scalar:.12f}' for case in normal_cases]}",
+    )
+    wrong_reference = float(REFERENCE_CENTERS[8]) + 1e-4
+    checks.record(
+        "wrong reference value",
+        abs(normal_cases[-1].scalar - wrong_reference) > 1e-8,
+        f"computed={normal_cases[-1].scalar:.16f}; hostile_reference={wrong_reference:.16f}",
+    )
+
+    def answer_key_builder(_: int) -> float:
+        return float(REFERENCE_CENTERS[8])
+
+    checks.record(
+        "answer-key-fed computation",
+        _function_reads_answer_key(answer_key_builder),
+        "hostile builder bytecode reads REFERENCE_CENTERS",
+    )
+    checks.record(
+        "illicit physical-action/thermodynamic inference",
+        not _claim_surface_allowed({"finite_linear_algebra", "physical_action", "thermodynamic_limit"}),
+        "non-formal conclusion tags rejected",
+    )
+    return checks.finish()
+
+
+def run_intentional_failure() -> int:
+    checks = Checks()
+    print("FINITE WEIGHTED-TRANSFER THEOREM — INTENTIONAL FAILURE MODE")
+    try:
+        _build_numpy_case(6, Mutation(asymmetric_recurrence=True))
+        accepted = True
+        detail = "asymmetric recurrence reached the symmetric eigensolver"
+    except SymmetryGateError as exc:
+        accepted = False
+        detail = f"expected rejection before eigensolve: {exc}"
+    checks.record(
+        "asymmetric recurrence is accepted",
+        accepted,
+        detail,
+    )
+    return checks.finish()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=("normal", "high-precision", "hostile", "intentional-failure"),
+        default="normal",
+    )
+    parser.add_argument("--dps", type=int, default=90, help="mpmath digits for high-precision mode")
+    args = parser.parse_args()
+    if args.dps < 40:
+        parser.error("--dps must be at least 40")
+    return args
 
 
 def main() -> int:
-    print("=" * 72)
-    print("Block 06 — HK Cube Perron L_s=2 (Casimir-diagonal action)")
-    print("Companion: docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md")
-    print("=" * 72)
-    print()
-    print("Adapts existing Wilson cube Perron runner to HK weights.")
-    print("Wilson side reference: P_cube_W(L_s=2, β=6) = 0.4291049969")
-    print()
-
-    t = 1.0  # Block 01's canonical t at framework's β = 6
-    print(f"Framework canonical t (from Block 01) = {t}")
-    print()
-
-    print("HK character coefficients c_λ_HK(t=1) = d_λ · exp(-C_2/2):")
-    for nmax_check in [1, 2]:
-        for p in range(nmax_check + 1):
-            for q in range(nmax_check + 1 - p):
-                d = dim_su3(p, q)
-                C2 = casimir_su3(p, q)
-                c = hk_character_coefficient(p, q, t)
-                print(f"  (p,q)=({p},{q}): d={d}, C_2={C2:.4f}, c_HK={c:.6e}")
-    print()
-
-    print("Candidate ρ_(p,q)(t=1) = (d × c/c_00)^12 × d^(-16):")
-    rho_hk_check = build_candidate_rho_hk(t, nmax=2)
-    for (p, q), val in sorted(rho_hk_check.items()):
-        print(f"  ({p},{q}): {val:.6e}")
-    print()
-
-    print("Convergence check at increasing NMAX:")
-    print(f"{'NMAX':>6} {'P_cube_HK(t=1)':>20} {'Perron eigval':>20}")
-    last_val = None
-    converged_at = None
-    for nmax in [3, 4, 5, 6, 7, 8]:
-        rho_hk = build_candidate_rho_hk(t, nmax)
-        p_val, eig = perron_value_hk(rho_hk, nmax, t)
-        print(f"{nmax:>6} {p_val:>20.10f} {eig:>20.6e}")
-        if last_val is not None and abs(p_val - last_val) < 1e-9:
-            if converged_at is None:
-                converged_at = nmax
-        last_val = p_val
-    print()
-
-    final_p = last_val
-    print("=" * 72)
-    print("RESULT — HK cube Perron L_s=2 at framework canonical t = 1:")
-    print(f"  P_cube_HK(L_s=2, t=1) ≈ {final_p:.10f}")
-    print()
-    print("Comparators (NOT load-bearing):")
-    wilson_cube = 0.4291049969
-    wilson_1plaq = 0.4225317396
-    hk_1plaq = float(np.exp(-2.0/3.0))
-    mc_thermo = 0.5934
-    print(f"  Wilson cube L_s=2:   {wilson_cube:.10f}  (existing runner)")
-    print(f"  Wilson 1-plaq:       {wilson_1plaq:.10f}  (V=1 PF certified)")
-    print(f"  HK 1-plaq (Block 02): {hk_1plaq:.10f}  (exp(-2/3) closed form)")
-    print(f"  HK cube L_s=2 (this): {final_p:.10f}  (Block 06)")
-    print(f"  Lattice MC thermo:   ≈ {mc_thermo}        (comparator only)")
-    print()
-
-    print("Differences:")
-    print(f"  HK_cube - HK_1plaq:    {final_p - hk_1plaq:+.10f}")
-    print(f"  HK_cube - Wilson_cube: {final_p - wilson_cube:+.10f}")
-    print(f"  HK_cube - MC:          {final_p - mc_thermo:+.10f}")
-    print(f"  HK_cube - MC distance: {abs(final_p - mc_thermo) / 3.030e-4:.0f}× ε_witness")
-    print()
-
-    print("Interpretation:")
-    if final_p > wilson_cube:
-        print("  HK cube > Wilson cube — HK action gives larger plaquette")
-        print("  expectation at L_s=2 than Wilson does, consistent with the HK")
-        print("  measure putting more weight on non-trivial sectors.")
-    elif final_p < wilson_cube:
-        print("  HK cube < Wilson cube — HK action gives smaller plaquette")
-        print("  expectation at L_s=2 than Wilson does.")
-    else:
-        print("  HK cube ≈ Wilson cube within numerical precision.")
-    print()
-
-    print("Both HK and Wilson L_s=2 are bounded above by the famous-open")
-    print("thermodynamic ⟨P⟩(6) ≈ 0.5934 (lattice MC comparator). The L_s=2")
-    print("cube is structurally insufficient for ε_witness precision; this")
-    print("artifact is a comparator across actions at fixed lattice size.")
-    print()
-    print("Block 03's named obstruction (cluster-decomposition / exponential-")
-    print("clustering estimate not in current primitives) remains the bottleneck")
-    print("for thermodynamic-limit closure under either action.")
-
-    return 0
+    args = parse_args()
+    if args.mode == "normal":
+        return run_normal()
+    if args.mode == "high-precision":
+        return run_high_precision(args.dps)
+    if args.mode == "hostile":
+        return run_hostile()
+    return run_intentional_failure()
 
 
 if __name__ == "__main__":

--- a/scripts/probe_hk_cube_perron_l2_2026_05_06.py
+++ b/scripts/probe_hk_cube_perron_l2_2026_05_06.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Finite weighted-transfer theorem and numerical certificate.
+"""Finite weighted-transfer theorem and high-precision numerical evidence.
 
 The historical filename is retained as a stable identity.  This module defines
 only finite functions and matrices.  It does not construct a heat-kernel
@@ -8,7 +8,7 @@ thermodynamic observable.
 
 Modes:
   normal              NumPy reconstruction plus algebraic/invariant checks.
-  high-precision      independent mpmath reconstruction and residual/gap bound.
+  high-precision      independent mpmath reconstruction and precision checks.
   hostile             require every named mutation to be rejected.
   intentional-failure run a known asymmetric mutation and exit nonzero.
 """
@@ -23,13 +23,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterable, Sequence
 
-import numpy as np
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 NOTE_PATH = REPO_ROOT / "docs/BRIDGE_GAP_HK_CUBE_PERRON_NOTE_2026-05-06.md"
 FORMAL_T = 1.0
-CERTIFIED_N = (6, 7, 8)
+CHECKED_N = (6, 7, 8)
 MOVES = ((1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (-1, 0))
 
 # These centers are answer keys only for post-computation regression checks.
@@ -40,7 +38,6 @@ REFERENCE_CENTERS = {
     7: "0.522324315075691917933023223847885524615477328862129075311171521855593496815",
     8: "0.522324315103738928863262943442354237767467710788871114561329778403325241798",
 }
-REFERENCE_RADIUS_TEXT = "2e-60"
 
 
 class Checks:
@@ -69,9 +66,11 @@ class SymmetryGateError(ValueError):
 @dataclass(frozen=True)
 class Mutation:
     asymmetric_recurrence: bool = False
+    multiplier_exponential_factor: int = 3
     quadratic_denominator: int = 3
     rho_exponential_factor: int = 6
     rho_dimension_power: int = 8
+    local_exponential_factor: int = 2
     omit_local_factor: bool = False
     eigenvector_rank_from_top: int = 0
 
@@ -100,9 +99,9 @@ class HighPrecisionCase:
     top_residual: object
     basis_residual_frobenius: object
     gram_defect_frobenius: object
-    basis_delta: object
-    gap_lower: object
-    scalar_radius: object
+    computed_matrix_delta: object
+    residual_angle_indicator: object
+    minimum_adjacent_gap: object
     symmetry_defect: object
     min_top_vector_entry: object
     min_multiplier_entry: object
@@ -131,6 +130,8 @@ def square_box(nmax: int) -> list[tuple[int, int]]:
 
 
 def normalized_scalar(vector: np.ndarray, matrix: np.ndarray) -> float:
+    import numpy as np
+
     denominator = float(vector @ vector)
     if not denominator > 0.0:
         raise ValueError("the vector must be nonzero")
@@ -139,6 +140,8 @@ def normalized_scalar(vector: np.ndarray, matrix: np.ndarray) -> float:
 
 def _build_numpy_case(nmax: int, mutation: Mutation = Mutation()) -> NumpyCase:
     """Binary64 construction; deliberately independent of answer keys."""
+    import numpy as np
+
     weights = [(p, q) for p in range(nmax + 1) for q in range(nmax + 1)]
     index = {weight: i for i, weight in enumerate(weights)}
     size = len(weights)
@@ -155,11 +158,13 @@ def _build_numpy_case(nmax: int, mutation: Mutation = Mutation()) -> NumpyCase:
     if not np.array_equal(j_matrix, j_matrix.T):
         raise SymmetryGateError("J_N failed exact binary64 symmetry gate")
     j_values, j_vectors = np.linalg.eigh(j_matrix)
-    multiplier_raw = (j_vectors * np.exp(3.0 * j_values)) @ j_vectors.T
+    multiplier_raw = (
+        j_vectors * np.exp(float(mutation.multiplier_exponential_factor) * j_values)
+    ) @ j_vectors.T
     multiplier_defect = float(np.max(np.abs(multiplier_raw - multiplier_raw.T)))
     if multiplier_defect > 2e-14:
         raise SymmetryGateError(
-            f"M_N symmetry defect {multiplier_defect:.3e} exceeds binary64 guard"
+            f"M_N symmetry defect {multiplier_defect:.3e} exceeds binary64 tolerance"
         )
     multiplier = 0.5 * (multiplier_raw + multiplier_raw.T)
 
@@ -178,7 +183,9 @@ def _build_numpy_case(nmax: int, mutation: Mutation = Mutation()) -> NumpyCase:
     if mutation.omit_local_factor:
         local_values = np.ones(size, dtype=float)
     else:
-        local_values = np.exp(-2.0 * FORMAL_T * c_used)
+        local_values = np.exp(
+            -float(mutation.local_exponential_factor) * FORMAL_T * c_used
+        )
     rho_values = (dims ** mutation.rho_dimension_power) * np.exp(
         -float(mutation.rho_exponential_factor) * FORMAL_T * c_used
     )
@@ -186,7 +193,7 @@ def _build_numpy_case(nmax: int, mutation: Mutation = Mutation()) -> NumpyCase:
     transfer_defect = float(np.max(np.abs(transfer_raw - transfer_raw.T)))
     if transfer_defect > 2e-13:
         raise SymmetryGateError(
-            f"T_N symmetry defect {transfer_defect:.3e} exceeds binary64 guard"
+            f"T_N symmetry defect {transfer_defect:.3e} exceeds binary64 tolerance"
         )
     transfer = 0.5 * (transfer_raw + transfer_raw.T)
     eigenvalues, eigenvectors = np.linalg.eigh(transfer)
@@ -213,6 +220,8 @@ def _build_numpy_case(nmax: int, mutation: Mutation = Mutation()) -> NumpyCase:
 
 
 def _expected_recurrence(weights: Sequence[tuple[int, int]]) -> np.ndarray:
+    import numpy as np
+
     index = {weight: i for i, weight in enumerate(weights)}
     result = np.zeros((len(weights), len(weights)), dtype=float)
     inverse_closed_moves = {(1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (-1, 0)}
@@ -225,12 +234,32 @@ def _expected_recurrence(weights: Sequence[tuple[int, int]]) -> np.ndarray:
 
 def numpy_case_violations(case: NumpyCase) -> list[str]:
     """Definition and spectral checks, recomputed outside the builder."""
+    import numpy as np
+
     violations: list[str] = []
+    if case.weights != square_box(case.nmax):
+        violations.append("finite square-box definition")
     expected_j = _expected_recurrence(case.weights)
     if not np.array_equal(case.j_matrix, expected_j):
         violations.append("recurrence definition")
     if not np.array_equal(case.j_matrix, case.j_matrix.T):
         violations.append("recurrence symmetry")
+    row_sums = np.sum(case.j_matrix, axis=1)
+    if float(np.max(row_sums)) > 1.0:
+        violations.append("truncated recurrence row-sum bound")
+    if float(np.max(np.abs(np.linalg.eigvalsh(case.j_matrix)))) > 1.0 + 2e-15:
+        violations.append("recurrence operator-norm bound")
+    reached = {0}
+    frontier = [0]
+    while frontier:
+        source = frontier.pop()
+        for target in np.flatnonzero(case.j_matrix[:, source]):
+            target_int = int(target)
+            if target_int not in reached:
+                reached.add(target_int)
+                frontier.append(target_int)
+    if len(reached) != len(case.weights):
+        violations.append("finite-box graph connectivity")
 
     expected_c = np.array(
         [
@@ -246,12 +275,24 @@ def numpy_case_violations(case: NumpyCase) -> list[str]:
     )
     expected_local = np.exp(-2.0 * expected_c)
     expected_rho = expected_d**8 * np.exp(-6.0 * expected_c)
+    expected_combined = expected_d**8 * np.exp(-8.0 * expected_c)
+    j_values, j_vectors = np.linalg.eigh(expected_j)
+    expected_multiplier = (j_vectors * np.exp(3.0 * j_values)) @ j_vectors.T
     if not np.allclose(case.local_values, expected_local, rtol=2e-15, atol=0.0):
         violations.append("local diagonal definition")
     if not np.allclose(case.rho_values, expected_rho, rtol=4e-15, atol=0.0):
         violations.append("rho definition")
+    if not np.allclose(
+        case.local_values * case.rho_values,
+        expected_combined,
+        rtol=5e-14,
+        atol=0.0,
+    ):
+        violations.append("combined diagonal definition")
     if not np.allclose(case.multiplier, case.multiplier.T, rtol=0.0, atol=2e-14):
         violations.append("multiplier symmetry")
+    if not np.allclose(case.multiplier, expected_multiplier, rtol=3e-15, atol=2e-15):
+        violations.append("multiplier exponential definition")
     if not np.all(case.multiplier > 0.0):
         violations.append("multiplier strict positivity")
     if not np.allclose(case.transfer, case.transfer.T, rtol=0.0, atol=2e-13):
@@ -290,7 +331,7 @@ def _high_precision_reconstruction(nmax: int, dps: int) -> HighPrecisionCase:
     import mpmath as mp
 
     mp.mp.dps = dps
-    guard = mp.power(10, -(dps - 30))
+    arithmetic_tolerance = mp.power(10, -(dps - 25))
     weights = [(p, q) for p in range(nmax + 1) for q in range(nmax + 1)]
     index = {weight: i for i, weight in enumerate(weights)}
     size = len(weights)
@@ -322,8 +363,8 @@ def _high_precision_reconstruction(nmax: int, dps: int) -> HighPrecisionCase:
         for row in range(size)
         for col in range(size)
     )
-    if multiplier_symmetry_defect > guard:
-        raise SymmetryGateError("M_N high-precision symmetry defect exceeds guard")
+    if multiplier_symmetry_defect > arithmetic_tolerance:
+        raise SymmetryGateError("M_N high-precision symmetry defect exceeds tolerance")
     multiplier = (multiplier_raw + multiplier_raw.T) / 2
 
     local_values = []
@@ -341,8 +382,8 @@ def _high_precision_reconstruction(nmax: int, dps: int) -> HighPrecisionCase:
         for row in range(size)
         for col in range(size)
     )
-    if transfer_symmetry_defect > guard:
-        raise SymmetryGateError("T_N high-precision symmetry defect exceeds guard")
+    if transfer_symmetry_defect > arithmetic_tolerance:
+        raise SymmetryGateError("T_N high-precision symmetry defect exceeds tolerance")
     transfer = (transfer_raw + transfer_raw.T) / 2
     symmetry_defect = max(
         recurrence_symmetry_defect,
@@ -375,30 +416,30 @@ def _high_precision_reconstruction(nmax: int, dps: int) -> HighPrecisionCase:
         )
     )
     if gram_defect_frobenius >= 1:
-        basis_delta = mp.inf
+        computed_matrix_delta = mp.inf
     else:
-        # With Q formed from the computed eigenvectors and D from their
-        # eigenvalues, TQ-QD=R and Q^TQ=I+E.  Therefore
-        # ||Q^{-1}R||_2 <= ||R||_F/sqrt(1-||E||_F).  Bauer-Fike plus the
-        # isolated top interval gives the ordered top-eigenvalue enclosure.
-        basis_delta = (
+        # In exact arithmetic for the *stored computed matrix*, eta < 1 would
+        # imply sigma_min(Q)^2 >= 1-eta and hence the following residual
+        # perturbation scale.  mpmath does not outward-round eta, R, or the
+        # transcendental matrix entries, so this is only a diagnostic.
+        computed_matrix_delta = (
             basis_residual_frobenius / mp.sqrt(1 - gram_defect_frobenius)
-            + guard
         )
     observed_gap = approximate_top - eigenvalues[size - 2]
-    gap_lower = observed_gap - 2 * basis_delta
-    separation_from_non_top = observed_gap - basis_delta
-    if gap_lower <= 0 or separation_from_non_top <= 0:
-        scalar_radius = mp.inf
+    separation_from_non_top = observed_gap - computed_matrix_delta
+    if separation_from_non_top <= 0:
+        residual_angle_indicator = mp.inf
     else:
-        # The top interval is isolated.  The symmetric residual angle bound
-        # gives sin(theta) <= (top_residual+guard)/separation_from_non_top.
-        # For rank-one projectors and ||J_N||_2 <= 1, the two quadratic
-        # expectations differ by at most 2 sin(theta), plus the guard.
-        scalar_radius = (
-            guard
-            + 2 * (top_residual + guard) / separation_from_non_top
+        # Conditional on the stored computed symmetric matrix, the residual
+        # angle scale is tau/separation.  The factor two comes from
+        # ||vv^T-uu^T||_* = 2 sin(theta) and the exact ||J_N||_2 <= 1.
+        residual_angle_indicator = (
+            2 * top_residual / separation_from_non_top
         )
+    minimum_adjacent_gap = min(
+        eigenvalues[index + 1] - eigenvalues[index]
+        for index in range(size - 1)
+    )
 
     return HighPrecisionCase(
         nmax=nmax,
@@ -408,9 +449,9 @@ def _high_precision_reconstruction(nmax: int, dps: int) -> HighPrecisionCase:
         top_residual=top_residual,
         basis_residual_frobenius=basis_residual_frobenius,
         gram_defect_frobenius=gram_defect_frobenius,
-        basis_delta=basis_delta,
-        gap_lower=gap_lower,
-        scalar_radius=scalar_radius,
+        computed_matrix_delta=computed_matrix_delta,
+        residual_angle_indicator=residual_angle_indicator,
+        minimum_adjacent_gap=minimum_adjacent_gap,
         symmetry_defect=symmetry_defect,
         min_top_vector_entry=min(vector),
         min_multiplier_entry=min(multiplier),
@@ -418,8 +459,53 @@ def _high_precision_reconstruction(nmax: int, dps: int) -> HighPrecisionCase:
     )
 
 
-def _function_reads_answer_key(function: Callable[..., object]) -> bool:
-    return "REFERENCE_CENTERS" in function.__code__.co_names
+def _functions_reaching_answer_key(root_names: Sequence[str]) -> list[str]:
+    """Return reachable functions that directly read a stored answer key."""
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    functions = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    visited: set[str] = set()
+    readers: set[str] = set()
+
+    def visit(name: str) -> None:
+        if name in visited or name not in functions:
+            return
+        visited.add(name)
+        node = functions[name]
+        if any(
+            isinstance(child, ast.Name) and child.id == "REFERENCE_CENTERS"
+            for child in ast.walk(node)
+        ):
+            readers.add(name)
+        for child in ast.walk(node):
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name):
+                visit(child.func.id)
+
+    for root_name in root_names:
+        visit(root_name)
+    return sorted(readers)
+
+
+def _hostile_answer_key_helper() -> float:
+    return float(REFERENCE_CENTERS[8])
+
+
+def _hostile_answer_key_fed_builder(_: int) -> float:
+    return _hostile_answer_key_helper()
+
+
+def _module_scope_numpy_import_lines() -> list[int]:
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    result: list[int] = []
+    for node in tree.body:
+        if isinstance(node, ast.Import) and any(alias.name == "numpy" for alias in node.names):
+            result.append(node.lineno)
+        if isinstance(node, ast.ImportFrom) and node.module == "numpy":
+            result.append(node.lineno)
+    return result
 
 
 def _literal_true_evidence_calls() -> list[int]:
@@ -463,7 +549,7 @@ def _note_source_dependencies() -> list[str]:
 def _theorem_physical_terms() -> list[str]:
     text = NOTE_PATH.read_text(encoding="utf-8")
     start = text.index("## Finite-matrix theorem")
-    end = text.index("## Certified numerical statement")
+    end = text.index("## High-precision numerical estimates")
     theorem = text[start:end].lower()
     forbidden = (
         "su(3)",
@@ -479,24 +565,16 @@ def _theorem_physical_terms() -> list[str]:
     return [term for term in forbidden if term in theorem]
 
 
-def _common_certified_rounding_digits(cases: Sequence[HighPrecisionCase]) -> int:
+def _common_rounding_digits(cases: Sequence[HighPrecisionCase]) -> int:
     import mpmath as mp
 
     common = 0
     for digits in range(0, 30):
         scale = mp.power(10, digits)
         rounded: list[int] = []
-        valid = True
         for case in cases:
-            low = case.scalar - case.scalar_radius
-            high = case.scalar + case.scalar_radius
-            low_round = int(mp.floor(low * scale + mp.mpf("0.5")))
-            high_round = int(mp.floor(high * scale + mp.mpf("0.5")))
-            if low_round != high_round:
-                valid = False
-                break
-            rounded.append(low_round)
-        if valid and len(set(rounded)) == 1:
+            rounded.append(int(mp.floor(case.scalar * scale + mp.mpf("0.5"))))
+        if len(set(rounded)) == 1:
             common = digits
         else:
             break
@@ -504,11 +582,18 @@ def _common_certified_rounding_digits(cases: Sequence[HighPrecisionCase]) -> int
 
 
 def _claim_surface_allowed(tags: Iterable[str]) -> bool:
-    allowed = {"finite_linear_algebra", "defined_functions", "defined_matrices", "finite_n_enclosures"}
+    allowed = {
+        "finite_linear_algebra",
+        "defined_functions",
+        "defined_matrices",
+        "high_precision_estimates",
+    }
     return set(tags).issubset(allowed)
 
 
 def _bad_scalar(vector: np.ndarray, matrix: np.ndarray) -> float:
+    import numpy as np
+
     return float(np.sum(vector) + vector @ (matrix @ vector))
 
 
@@ -536,7 +621,7 @@ def run_normal() -> int:
             and dimension_polynomial(p, q) >= 1
             for p, q in square_box(8)
         ),
-        "parity proof checked on the largest certified box",
+        "parity proof checked on the largest tested box",
     )
     checks.record(
         "recurrence move set is inverse-closed",
@@ -544,7 +629,7 @@ def run_normal() -> int:
         str(MOVES),
     )
     cases: list[NumpyCase] = []
-    for nmax in CERTIFIED_N:
+    for nmax in CHECKED_N:
         case = _build_numpy_case(nmax)
         cases.append(case)
         violations = numpy_case_violations(case)
@@ -555,7 +640,7 @@ def run_normal() -> int:
         )
         center = float(REFERENCE_CENTERS[nmax])
         checks.record(
-            f"N={nmax} binary64 agrees with independent certificate",
+            f"N={nmax} binary64 agrees with stored high-precision estimate",
             abs(case.scalar - center) < 8e-15,
             f"P_N={case.scalar:.16f}; residual={case.residual:.3e}; gap={case.eigenvalues[-1]-case.eigenvalues[-2]:.12f}",
         )
@@ -573,8 +658,14 @@ def run_normal() -> int:
     )
     checks.record(
         "normal reconstruction cannot read answer keys",
-        not _function_reads_answer_key(_build_numpy_case),
-        "REFERENCE_CENTERS absent from reconstruction bytecode",
+        not _functions_reaching_answer_key(("_build_numpy_case",)),
+        f"reachable readers={_functions_reaching_answer_key(('_build_numpy_case',))}",
+    )
+    module_numpy_imports = _module_scope_numpy_import_lines()
+    checks.record(
+        "high-precision import path has no module-scope NumPy dependency",
+        not module_numpy_imports,
+        f"module-scope NumPy import lines={module_numpy_imports}",
     )
     local_imports = _repo_local_imports()
     checks.record(
@@ -603,7 +694,7 @@ def run_normal() -> int:
     checks.record(
         "claim-surface tags are formal only",
         _claim_surface_allowed(
-            {"finite_linear_algebra", "defined_functions", "defined_matrices", "finite_n_enclosures"}
+            {"finite_linear_algebra", "defined_functions", "defined_matrices", "high_precision_estimates"}
         ),
         "no action, topology, or limiting tag supplied",
     )
@@ -617,63 +708,72 @@ def run_high_precision(dps: int) -> int:
     print("FINITE WEIGHTED-TRANSFER THEOREM — INDEPENDENT HIGH-PRECISION MODE")
     print(f"library=mpmath; decimal precision={dps}; formal parameter t=1")
     print()
-    cases = [_high_precision_reconstruction(nmax, dps) for nmax in CERTIFIED_N]
-    reference_radius = mp.mpf(REFERENCE_RADIUS_TEXT)
-    for case in cases:
+    cases = [_high_precision_reconstruction(nmax, dps) for nmax in CHECKED_N]
+    comparison_dps = dps + 20
+    comparison_cases = [
+        _high_precision_reconstruction(nmax, comparison_dps) for nmax in CHECKED_N
+    ]
+    working_tolerance = mp.power(10, -(dps - 20))
+    for case, comparison in zip(cases, comparison_cases):
         center = mp.mpf(REFERENCE_CENTERS[case.nmax])
         checks.record(
-            f"N={case.nmax} positive matrices and certified simple top eigenvalue",
+            f"N={case.nmax} positive entries and well-separated computed top eigenvalue",
             case.symmetry_defect < mp.power(10, -(dps - 30))
             and case.min_top_vector_entry > 0
             and case.min_multiplier_entry > 0
             and case.min_transfer_entry > 0
-            and case.gap_lower > mp.mpf("4.95"),
+            and case.observed_gap > mp.mpf("4.95"),
             f"symmetry_defect={mp.nstr(case.symmetry_defect, 5)}; "
-            f"gap_lower={mp.nstr(case.gap_lower, 18)}; "
+            f"observed_gap={mp.nstr(case.observed_gap, 18)}; "
             f"min(v)={mp.nstr(case.min_top_vector_entry, 5)}; "
             f"min(M)={mp.nstr(case.min_multiplier_entry, 5)}; "
             f"min(T)={mp.nstr(case.min_transfer_entry, 5)}",
         )
         checks.record(
-            f"N={case.nmax} residual/gap scalar radius",
-            case.basis_delta < reference_radius
-            and case.scalar_radius < reference_radius,
+            f"N={case.nmax} residual and Gram diagnostics are small at working precision",
+            case.gram_defect_frobenius < working_tolerance
+            and case.computed_matrix_delta < working_tolerance
+            and case.residual_angle_indicator < working_tolerance,
             f"basis_residual_F={mp.nstr(case.basis_residual_frobenius, 6)}; "
             f"gram_defect_F={mp.nstr(case.gram_defect_frobenius, 6)}; "
             f"top_residual={mp.nstr(case.top_residual, 6)}; "
-            f"delta={mp.nstr(case.basis_delta, 6)}; "
-            f"P_radius={mp.nstr(case.scalar_radius, 6)}",
+            f"computed_matrix_delta={mp.nstr(case.computed_matrix_delta, 6)}; "
+            f"angle_indicator={mp.nstr(case.residual_angle_indicator, 6)}; "
+            f"minimum_full_gap={mp.nstr(case.minimum_adjacent_gap, 6)}",
         )
         checks.record(
-            f"N={case.nmax} enclosure agrees with stored regression interval",
-            abs(case.scalar - center) + case.scalar_radius < reference_radius,
-            f"P_N={mp.nstr(case.scalar, 76)} +/- {mp.nstr(case.scalar_radius, 6)}",
+            f"N={case.nmax} estimate agrees across precisions and with regression center",
+            abs(case.scalar - comparison.scalar) < working_tolerance
+            and abs(comparison.scalar - center) < working_tolerance,
+            f"P_N={mp.nstr(comparison.scalar, 55)}; "
+            f"|P({dps})-P({comparison_dps})|={mp.nstr(abs(case.scalar-comparison.scalar), 6)}",
         )
 
     checks.record(
         "high-precision reconstruction cannot read answer keys",
-        not _function_reads_answer_key(_high_precision_reconstruction),
-        "REFERENCE_CENTERS absent from reconstruction bytecode",
+        not _functions_reaching_answer_key(("_high_precision_reconstruction",)),
+        f"reachable readers={_functions_reaching_answer_key(('_high_precision_reconstruction',))}",
     )
-    all_digits = _common_certified_rounding_digits(cases)
-    last_two_digits = _common_certified_rounding_digits(cases[1:])
+    all_digits = _common_rounding_digits(comparison_cases)
+    last_two_digits = _common_rounding_digits(comparison_cases[1:])
     checks.record(
-        "certified N=6,7,8 common rounding is seven decimals",
+        "estimated N=6,7,8 common rounding is seven decimals",
         all_digits == 7,
         f"common rounded decimal places={all_digits}",
     )
     checks.record(
-        "certified N=7,8 common rounding is ten decimals",
+        "estimated N=7,8 common rounding is ten decimals",
         last_two_digits == 10,
         f"common rounded decimal places={last_two_digits}",
     )
-    for left, right in zip(cases, cases[1:]):
+    for index, (left, right) in enumerate(zip(comparison_cases, comparison_cases[1:])):
         difference = right.scalar - left.scalar
-        radius = right.scalar_radius + left.scalar_radius
+        low_precision_difference = cases[index + 1].scalar - cases[index].scalar
         checks.record(
-            f"I_{left.nmax} and I_{right.nmax} are disjoint",
-            difference > radius,
-            f"P_{right.nmax}-P_{left.nmax}={mp.nstr(difference, 40)} +/- {mp.nstr(radius, 6)}",
+            f"P_{right.nmax}-P_{left.nmax} is a stable positive estimate",
+            difference > 0 and abs(difference - low_precision_difference) < working_tolerance,
+            f"P_{right.nmax}-P_{left.nmax}={mp.nstr(difference, 40)}; "
+            f"cross-precision change={mp.nstr(abs(difference-low_precision_difference), 6)}",
         )
     return checks.finish()
 
@@ -698,9 +798,11 @@ def run_hostile() -> int:
     )
 
     mutation_cases = (
+        ("wrong multiplier exponential factor", Mutation(multiplier_exponential_factor=2), "multiplier exponential definition"),
         ("wrong c (legacy Casimir) polynomial", Mutation(quadratic_denominator=2), "local diagonal definition"),
         ("wrong rho exponential factor", Mutation(rho_exponential_factor=5), "rho definition"),
         ("wrong legacy topology/dimension exponent", Mutation(rho_dimension_power=7), "rho definition"),
+        ("wrong local c exponent", Mutation(local_exponential_factor=3), "local diagonal definition"),
         ("missing local factor", Mutation(omit_local_factor=True), "local diagonal definition"),
         ("incorrect dominant eigenvector", Mutation(eigenvector_rank_from_top=1), "dominant eigenvector selection"),
     )
@@ -716,17 +818,17 @@ def run_hostile() -> int:
         "linear contamination changes under sign or scale",
     )
 
-    # An observed gap smaller than twice the residual cannot certify a simple
-    # numerical eigenpair, even if a floating solver returns two numbers.
+    # An observed gap smaller than twice the residual is insufficient evidence
+    # for a numerically isolated eigenpair.
     hostile_residual = 1e-10
     hostile_observed_gap = 1e-12
     checks.record(
-        "insufficient precision/gap certificate",
+        "insufficient residual-to-gap evidence",
         hostile_observed_gap - 2 * hostile_residual <= 0.0,
         f"observed_gap={hostile_observed_gap:.1e}; 2*residual={2*hostile_residual:.1e}",
     )
 
-    normal_cases = [_build_numpy_case(nmax) for nmax in CERTIFIED_N]
+    normal_cases = [_build_numpy_case(nmax) for nmax in CHECKED_N]
     false_twelve_digit_claim = len({round(case.scalar, 12) for case in normal_cases}) == 1
     checks.record(
         "false N-stability digits",
@@ -740,13 +842,11 @@ def run_hostile() -> int:
         f"computed={normal_cases[-1].scalar:.16f}; hostile_reference={wrong_reference:.16f}",
     )
 
-    def answer_key_builder(_: int) -> float:
-        return float(REFERENCE_CENTERS[8])
-
+    hostile_readers = _functions_reaching_answer_key(("_hostile_answer_key_fed_builder",))
     checks.record(
-        "answer-key-fed computation",
-        _function_reads_answer_key(answer_key_builder),
-        "hostile builder bytecode reads REFERENCE_CENTERS",
+        "helper-mediated answer-key-fed computation",
+        "_hostile_answer_key_helper" in hostile_readers,
+        f"reachable readers={hostile_readers}",
     )
     checks.record(
         "illicit physical-action/thermodynamic inference",


### PR DESCRIPTION
## Summary

This PR narrows stable claim `bridge_gap_hk_cube_perron_note_2026-05-06` to a self-contained finite theorem about functions and matrices defined inside the note. The legacy HK/cube/Perron words remain identity only. No SU(3), representation-theoretic, heat-kernel, lattice, plaquette, topology, Brownian-time, Wilson-comparator, correlation, action-naturalness, finite-volume, or thermodynamic interpretation is derived.

The direct thermodynamic-stretch consumer keeps its independently evidenced open obstruction and now treats this row as formal context only. This PR does not run an audit worker, apply an audit verdict, or ship audit-owned ledger, queue, status, or publication surfaces.

## Audited repair target addressed

> missing_dependency_edge promote su3_cube_full_rho_perron_2026-05-04, bridge_gap_hk_plaquette_closed_form_note_2026-05-06, and su3_casimir_fundamental_theorem_note_2026-05-02 to retained-grade or inline their required premises; also add a dated downstream-hygiene line to this note's own boundary and repair the non-load-bearing co-cycle markdown links to bridge_gap_hk_thermodynamic_stretch_note_2026-05-06.

The repair inlines only the formal premises actually needed, declares no source-note dependencies, adds the dated downstream-hygiene line, and removes the non-load-bearing co-cycle edge. It does not promote any physical supplier.

## Exact finite theorem

For `W_N = {(p,q): 0 <= p,q <= N}`, the note defines

- `d(p,q)=((p+1)(q+1)(p+q+2))/2` and `c(p,q)=(p^2+pq+q^2+3p+3q)/3`;
- the inverse-closed six-move recurrence `J_N`, truncated by requiring both endpoints to lie in `W_N`;
- formal `t=1`, `w_t=d exp(-tc/2)`, `a_t=exp(-tc/2)`, and `rho_t=d^8 exp(-6tc)`;
- `L_N=diag(exp(-2c))`, `R_N=diag(rho_1)`, and the combined positive diagonal `D_N=L_NR_N=diag(d^8 exp(-8c))`;
- `M_N=exp(3J_N)`, `T_N=M_ND_NM_N`, the uniquely signed unit Perron vector, and `P_N=v_N^T J_N v_N`.

The constants `3`, `4`, `8`, `6`, and the combined exponent `8` are declared definitions, not inherited topology or dimension counts. Boundary symmetry follows from inverse closure; horizontal and vertical moves connect the finite box. Each truncated row has at most six entries of `1/6`, so symmetry gives

`||J_N||_2 <= sqrt(||J_N||_1 ||J_N||_infinity) = ||J_N||_infinity <= 1`.

The exponential of the real symmetric `J_N` is positive definite and entrywise positive by connectedness and its power series. Congruence with the positive diagonal `D_N` makes `T_N` symmetric positive definite, and its entries are positive. Perron-Frobenius gives a simple positive top eigenvector. The normalized quadratic expectation is independent of sign and nonzero scale.

## Independent mathematical reconstruction

The review independently rebuilt `W_N`, `d`, `c`, the recurrence graph, `M_N`, `D_N`, and `T_N` without importing the branch runner or its reference centers. A direct 80-digit `mpmath.expm(3J_N)` path, distinct from the runner's eigendecomposition construction of `M_N`, reproduced:

| N | `||J_N||_2` | observed top gap | independently reconstructed `P_N` |
|---:|---:|---:|---:|
| 6 | `0.90514515085631550972` | `4.95928143865115310330` | `0.52232431153736166937673139714738059168179320929492` |
| 7 | `0.92465297575131571455` | `4.95928144134063313075` | `0.52232431507569191793302322384788552461547732886213` |
| 8 | `0.93873719765781176156` | `4.95928144135451144353` | `0.52232431510373892886326294344235423776746771078887` |

The combined diagonal minima are approximately `3.26e-147`, `6.16e-198`, and `8.98e-256`. That conditioning is why positive definiteness is proved analytically rather than inferred from the smallest floating eigenvalues.

The estimated differences are `P_7-P_6 = 3.53833024855629182670050493293e-9` and `P_8-P_7 = 2.80470109302397195944687131520e-11`. All three estimates share only seven rounded decimal places; `N=7,8` share ten, not twelve. No monotonicity, tail bound, or `N -> infinity` limit is inferred.

## Numerical-certification correction

The independent review rejected the former `+/-2e-60` exact-enclosure claim. At 90 digits, the advertised `1.40328e-60` scalar radius was controlled by an inserted `1e-60` guard, not by the roughly `1e-90` residuals. Repeating at 110 digits mechanically changed that claimed radius to `1.40328e-80`. No installed Arb, python-flint, Sage, or other outward-rounded transcendental path was available.

The runner's residuals are against the `mpmath` matrix constructed at the selected working precision. They do not bound construction and rounding error relative to the exact matrix containing `exp(3J_N)`, `exp(-2c)`, and `exp(-6c)`. The write-up now states this explicitly and presents only high-precision residual-based estimates with 90/110-digit agreement.

For the stored computed arrays, `eta < 1` would imply `sigma_min(Q)^2 >= 1-eta` and hence invertibility, and the factor `2` in the quadratic-form perturbation follows from the nuclear norm of the difference of rank-one projectors together with `||J_N||_2 <= 1`. Those facts do not supply the missing transcendental construction-error bound. The minimum full-spectrum adjacent gaps at 90 digits are about `2.22e-95`, `9.24e-104`, and `3.50e-108`, below the full-basis residual scale, so the runner no longer suggests that every computed eigenvalue is individually isolated. The analytically simple Perron root has a separately large observed top gap.

## Implementation and hostile controls

- The high-precision path has no module-scope NumPy import and passes with NumPy imports forcibly blocked.
- Exact recurrence symmetry is checked before `eigsy`; raw `M_N` and `T_N` symmetry defects are checked before any averaging, so a material asymmetry is not hidden.
- An AST call-graph firewall follows reachable helpers from both reconstruction roots. Its helper-mediated answer-key mutation is detected; both real reconstruction roots have zero reachable readers of `REFERENCE_CENTERS`.
- Hostile mode rejects asymmetric recurrence, wrong multiplier exponent, wrong `c` denominator, wrong local and `rho` exponents, wrong defined `d` power, omitted local factor, subdominant eigenvector, sign/scale dependence, insufficient residual/gap evidence, false stability digits, wrong reference, helper-fed answer key, and illicit physical/limiting tags.
- Intentional-failure mode exits `1`.

## Consumer No-Go Discipline packet (open-boundary scope)

- **N1 — counterroutes:** checked the conventional-formula resemblance route, stable-name/history route, numerical-coincidence route, old source-note citation route, and use-as-comparator route. None identifies the defined functions or matrices with the proposed physical measure, geometry, insertion, state, or observable.
- **N2 — independence:** those physical identifications form one semantic bridge bundle; the clustering/extrapolation obstruction is a separate downstream requirement after any such bridge.
- **N3 — hidden assumptions:** all exponents and factors in the finite theorem are definitions. No representation dimension, Casimir authority, cube topology, plaquette, Brownian time, or action is imported by notation.
- **N4 — witness specificity:** the formal-row firewall witnesses only the missing physical-identification bridge. It is not evidence for or against the separately named clustering estimate.
- **N5 — resolution separation:** finite matrix cutoff `N`, a hypothetical finite physical volume, and the thermodynamic limit are three distinct questions; the rewrite does not collapse them.
- **N6 — closure condition:** a future retained explicit identification bridge could reopen and close physical Path A. The current result is an `open_gate`, not a permanent no-go or a request for a new axiom.
- **N7 — steelman:** the definitions intentionally resemble conventional formulas and may support a future physical identification. Resemblance alone is not that identification.
- **N8 — non-foreclosure:** the consumer preserves the physical program and its existing evidence while removing only the false load-bearing edge from this formal theorem.

## Graph, cache, and validation evidence

- Freshly rebased onto `origin/main` `cd51e48fd8073d2d251584db088183cf17983272`; no overlapping mainline files.
- Disposable candidate and baseline pipelines both exit `0`; strict lint exits `0` with no errors. All generated audit/effective-status surfaces were discarded.
- Baseline target: `bounded_theorem`, `audited_conditional`, five dependencies. Candidate target: `positive_theorem`, re-seeded `unaudited`, zero dependencies, ready leaf queue entry, zero transitive descendants.
- Consumer remains `open_gate`; its dependency list changes only by removing the false formal-row edge (`6 -> 5`). Graph cycles change `64 -> 62`.
- Normal runner: `PASS=17 FAIL=0`.
- High precision at 90 digits plus internal 110-digit comparison: `PASS=14 FAIL=0`.
- NumPy-blocked high precision at 40/60 digits: `PASS=14 FAIL=0`.
- Hostile mode: `PASS=14 FAIL=0`.
- Intentional failure: `PASS=0 FAIL=1`, exit `1`.
- Direct consumer: `PASS=53 FAIL=0`.
- Cache hashes are fresh: primary `854cc844de6029e3305c633b36442e8fd67d4dc8fe7d931b823338cdad02eb9d`; consumer `2e5fc1eaccbfca0030503a84c087729a4e653520e704fdb2cd517a0ea66298d2`.
- Python compilation, controlled-vocabulary lint, portable-link gate, literal-`True` gate, source/import firewall, cache check, `git diff --check`, and generated-surface boundary all pass.

Exactly six files are changed: the formal note/runner/cache and its one direct semantic consumer note/runner/cache.
