### PR TITLE
repo: add explicit Type: headers to three untyped claim notes

### DIFF
--- a/docs/ALT_CONNECTIVITY_FAMILY_COMPLEX_FAILURE_NOTE.md
+++ b/docs/ALT_CONNECTIVITY_FAMILY_COMPLEX_FAILURE_NOTE.md
@@ -1,6 +1,7 @@
 # ALT Connectivity Family Complex Failure Note
 
 **Date:** 2026-04-06  
+**Type:** no_go
 **Status:** diagnosed boundary for complex action on the alternative connectivity family
 
 ## Artifact Chain

--- a/docs/CAUSAL_SOURCE_PLACEMENT_ROBUSTNESS_NOTE.md
+++ b/docs/CAUSAL_SOURCE_PLACEMENT_ROBUSTNESS_NOTE.md
@@ -1,6 +1,7 @@
 # Causal Source Placement Robustness Note
 
 **Date:** 2026-04-06  
+**Type:** no_go
 **Status:** diagnosed deeper boundary: family-aware source placement changes the causal ratios, but it does not restore a clean portable causal-field signal across all three families
 
 ## Artifact Chain

--- a/docs/CHSH_STRUCTURAL_BOUND_NARROW_THEOREM_NOTE_2026-05-17.md
+++ b/docs/CHSH_STRUCTURAL_BOUND_NARROW_THEOREM_NOTE_2026-05-17.md
@@ -1,6 +1,7 @@
 # Structural CHSH Bound — Narrow Theorem (Classical 2, Tsirelson 2√2)
 
 **Date:** 2026-05-17
+**Type:** positive_theorem
 **Class:** `positive_theorem` (Class A — pure algebra over retained primitives)
 **Lane:** bell / foundational QM
 **Block:** physics-loop / block09 / 2026-05-17 / bell-inequality-derivation


### PR DESCRIPTION
## Defect

Three claim notes carry no explicit `Type:` / `Claim type:` header, so the citation-graph builder seeds them as `claim_type = positive_theorem` with `claim_type_provenance = default_positive_theorem` (verified on origin/main ledger rows). Two of the three are not positive theorems.

## Fix (one line per note; nothing else changed)

| Note | Added header | Why |
|---|---|---|
| `docs/ALT_CONNECTIVITY_FAMILY_COMPLEX_FAILURE_NOTE.md` | `**Type:** no_go` | The note's own result is a negative boundary: the alternative connectivity family does **not** carry the complex-action crossover on the tested no-restore slice ("clean boundary failure"). |
| `docs/CAUSAL_SOURCE_PLACEMENT_ROBUSTNESS_NOTE.md` | `**Type:** no_go` | The note's final verdict is negative: none of the three tested family-aware placement rules restores a portable causal-field signal across the three families. |
| `docs/CHSH_STRUCTURAL_BOUND_NARROW_THEOREM_NOTE_2026-05-17.md` | `**Type:** positive_theorem` | Matches the note's existing `Class:` line (`positive_theorem`), which the parser does not read; the content is a pure-algebra CHSH/Tsirelson theorem with an exact paired runner. |

`claim_type` stays auditor-set; these are author hints only. No grade language added; audit status authority remains the independent audit lane.

## Validation

- `python3 scripts/vocab_lint.py --fix` on the three notes: 0 violations
- `bash docs/audit/scripts/run_pipeline.sh`: exit 0 (18/18 stages)
- `python3 docs/audit/scripts/audit_lint.py --strict`: no errors (notices only)
- Local pipeline validation confirmed all three rows re-seed as `claim_type_provenance = author_hint` with the intended types; all three rows are `unaudited`, so the note-hash drift is the benign re-audit-pending notice
- All pipeline-regenerated audit outputs restored to origin/main before commit (`git status` clean on `docs/audit/data`, publication surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)