### PR TITLE
fix(single-clock): re-key two red runners from retired 2026-06-05 axiom manifest to the 2026-06-29 surface

### DIFF
--- a/docs/SINGLE_CLOCK_AXIS_SELECTION_FROM_RECORD_DURABILITY_NARROW_NO_GO_NOTE_2026-06-11.md
+++ b/docs/SINGLE_CLOCK_AXIS_SELECTION_FROM_RECORD_DURABILITY_NARROW_NO_GO_NOTE_2026-06-11.md
@@ -113,8 +113,8 @@ Quoted verbatim from the retained boundaries (one hop):
 |---|---|---|
 | The exchange certificate `W M_KS W^T = M_KS` (residual 0) and the declared (B-AXIS.1–3) | the structure under attack; baseline recomputed in runner block [S] | [`AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md`](AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md) — bounded_theorem, same-lane re-scope; certificate recomputed, not cited blind |
 | N2/N4/N5 reopening clauses; transfer-/τ-relativity | Section 2; runner [D] verbatim checks | `SINGLE_CLOCK_UNIQUENESS_SCOPE_BOUNDARY_2026-06-06.md` — retained_no_go |
-| Record axiom text: durable registration; supplies no "time metric" | route A; runner [RT-REC] | [`MINIMAL_AXIOMS_2026-06-05.md`](MINIMAL_AXIOMS_2026-06-05.md) — approved axiom memo |
-| Record formation not unconditionally forced | route A ("at least one record exists" is not free) | [`RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md`](RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md) — retained_no_go |
+| Record axiom text: record permanence; supplies no "time metric" | route A; runner [RT-REC] | [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) — current axiom memo |
+| Record formation rule/process/state/site/weight/rate not forced (occurrence axiom-supplied) | route A (occurrence alone carries no axis label) | [`RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md`](RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md) — no_go source note (narrowed 2026-07-05) |
 | Clock map supplied, never derived from counts | route A; the record-shaped pin | [`POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md`](POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md) — retained_no_go |
 | (CAP-K) registration cone: (REG-dyn) consumes the framework `H`, (REG-tau) consumes a supplied window | route A circularity check | [`OBSERVABLE_PRINCIPLE_P1_CAP_K_FROM_FINITE_SPEED_REGISTRATION_NARROW_THEOREM_NOTE_2026-06-10.md`](OBSERVABLE_PRINCIPLE_P1_CAP_K_FROM_FINITE_SPEED_REGISTRATION_NARROW_THEOREM_NOTE_2026-06-10.md) — bounded_theorem (conditional realization class) |
 | Anomaly chain constrains the count `d_t`, "not which axis is temporal" | route B | [`ANOMALY_FORCES_TIME_THEOREM.md`](ANOMALY_FORCES_TIME_THEOREM.md) — bounded_theorem (downstream consumer; its own non-circularity text is the kill) |
@@ -164,8 +164,8 @@ chosen, and `W` transports the entire package.
 
 ### 4.2 Route A2 — record/durability does not anchor the axis
 
-The Record axiom's durability clause is intrinsically ordered ("Durable
-means fixed once registered"). The hostile question: is "the axis along
+The Record axiom's permanence clause is intrinsically ordered ("records
+are permanent"). The hostile question: is "the axis along
 which records are durable" pinned to the transfer direction by any
 retained record row, so that B-AXIS would reduce to "at least one record
 exists"? Three kills, one computed and two textual, all at one hop:
@@ -181,10 +181,12 @@ exists"? Three kills, one computed and two textual, all at one hop:
    structure. Durability cannot distinguish W-related axes.
 2. **The record rows are axis-blind by their own text (one hop).** The
    Record axiom supplies no "time metric" (verbatim exclusion);
-   record formation "does **not** hold unconditionally" (retained
-   no-go), so "at least one record exists" is itself a premise, and even
-   granting it, the clock/rate interface (retained_no_go) proves the
-   event order carries no metric and — a fortiori — no lattice-axis
+   record occurrence is axiom-supplied ("Records form.") while the
+   narrowed record-formation no-go keeps the formation
+   rule/process/state/site/weight/rate unforced, so occurrence carries
+   no site/axis datum, and even granting records, the clock/rate
+   interface proves the event order carries no metric and — a fortiori
+   — no lattice-axis
    label: "Without the supplied `tau`, the same record history supports
    many inequivalent rates." The post-record surface supplies order,
    counts, and prefixes; the association of that order with a lattice
@@ -242,9 +244,9 @@ What WOULD break the exchange? The runner computes the boundary:
   event order is parametrized by lattice axis `μ`". By Section 4.2 this
   is exactly the bridge the clock/rate interface leaves to be supplied;
   given it, the axis label follows trivially. It is record-adjacent but
-  **not** an axiom consequence (record formation is not forced; the
-  axiom supplies no time metric), so it is a declared input, not an
-  axiom change.
+  **not** an axiom consequence (the axiom supplies record occurrence but
+  no formation rule/site/rate and no time metric), so it is a declared
+  input, not an axiom change.
 - **(PIN-EXT) — weaker, regulator-level.** Asymmetric extents
   `L_τ ≠ L_1` also discriminate (computed: sector spectral radii differ
   on `(6,4,2,2)`), but extents are finite-block regulator data; this
@@ -275,8 +277,10 @@ for any future axis-selection row.
 - **Clock/rate interface:** respected and consumed — no rate, no clock,
   no axis is derived from record counts; the pin's record-shaped form is
   the *supplied-bridge* opening that the no-go itself names.
-- **Record-formation no-go:** respected — nothing here asserts records
-  form; route A2 is conditional on records existing and fails anyway.
+- **Record-formation no-go (narrowed 2026-07-05):** respected —
+  occurrence is axiom-supplied ("Records form."); nothing here derives a
+  formation rule/process/state/site/weight/rate, and route A2 fails even
+  granting records.
 
 ## 7. No-Go Discipline Gate
 
@@ -443,8 +447,8 @@ Z_2 datum (BC asymmetry) or an equivalent registration-direction bridge.
 ------------------------------------------------------------------------
 [RT-REC] ROUTE A2: does record durability anchor the axis? (textual + computed: NO)
 ------------------------------------------------------------------------
-  [PASS][B] Record axiom is axis-blind by its own text: a record supplies no 'time metric' (verbatim in the exclusion list)  -- MINIMAL_AXIOMS_2026-06-05.md
-  [PASS][B] record formation is not forced (retained_no_go): 'at least one record exists' is NOT an axiom consequence, so no axis can be derived from it unconditionally  -- record-formation no-go quoted
+  [PASS][B] Record axiom is axis-blind by its own text: 'time metric' sits in the open-gates exclusion list and record permanence carries no axis label  -- MINIMAL_AXIOMS_2026-06-29.md
+  [PASS][B] record formation supplies no axis datum: occurrence is axiom-supplied ('Records form.') and the narrowed no-go keeps the formation rule/process/state/site/weight/rate unforced, so no axis label can be derived from record formation  -- narrowed record-formation no-go quoted
   [PASS][B] the clock map is supplied, never derived from records (retained_no_go): 'Without the supplied `tau`, the same record history supports many inequivalent rates' — the event ORDER carries no lattice-axis label  -- clock/rate interface quoted
   [PASS][B] the CAP-K registration cone is axis-CONDITIONAL, not axis-selecting: its dynamics clause (REG-dyn) consumes the framework H and its window (REG-tau) consumes a supplied clock — both downstream of B-AXIS, so citing it for axis selection would be circular  -- CAP-K note clauses present
   [PASS][A] durability ('fixed once registered, never un-registered') is operator-order monotonicity of the record counter, and operator order is unitary-transport invariant: the conjugated counter is monotone with the same increment spectra — durability CANNOT distinguish W-related axes  -- monotone before/after = True/True, max increment-spec diff = 8.9e-16
@@ -497,7 +501,7 @@ promote any row.
   [`POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md`](POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md),
   [`RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md`](RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md)
 - record surface consulted:
-  [`MINIMAL_AXIOMS_2026-06-05.md`](MINIMAL_AXIOMS_2026-06-05.md),
+  [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md),
   [`OBSERVABLE_PRINCIPLE_P1_CAP_K_FROM_FINITE_SPEED_REGISTRATION_NARROW_THEOREM_NOTE_2026-06-10.md`](OBSERVABLE_PRINCIPLE_P1_CAP_K_FROM_FINITE_SPEED_REGISTRATION_NARROW_THEOREM_NOTE_2026-06-10.md),
   [`SHARP_RECORD_FISHER_TANGENT_SPACE_NARROW_THEOREM_NOTE_2026-06-06.md`](SHARP_RECORD_FISHER_TANGENT_SPACE_NARROW_THEOREM_NOTE_2026-06-06.md)
 - anomaly consumer (cross-reference; its own text is the route-B kill):

--- a/docs/SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md
+++ b/docs/SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md
@@ -71,7 +71,7 @@ current admitted physical-clock transfers = { (T_hat^2, 2 a_tau) }
 
 No second physical-clock transfer is currently admitted.
 
-## Admission Manifest (2026-07-10)
+## Admission Manifest (2026-07-16)
 
 The inventory above is pinned to the explicit dated manifest below instead of
 a runner-preset list. The manifest is carried in this note as a fenced JSON
@@ -87,9 +87,12 @@ recomputes its content from source text:
   direction, so the enumeration cannot silently go stale.
 - **Axiom authority.** The axiom leg reads the current 2026-06-29
   minimal-axiom memo through the stable `minimal_axioms` premise node in
-  `docs/audit/data/axiom_premise_nodes.json`; the 2026-06-05 path cited by
-  the parent packet is a registered alias of the same node, not a second
-  authority.
+  `docs/audit/data/axiom_premise_nodes.json`. The parent packet now cites
+  the 2026-06-29 memo directly; the historical 2026-06-05 path remains a
+  registered alias of the same premise node in the registry, not a second
+  authority. (Manifest refreshed 2026-07-16 after the parent packet
+  re-keyed its axiom citation from the aliased 2026-06-05 path to the
+  current 2026-06-29 memo.)
 - **Computed admission.** `candidates` names each proposed physical-clock
   transfer with per-criterion source evidence (file plus exact anchor) for
   the four-part admission definition above. The runner evaluates the four
@@ -110,7 +113,7 @@ recomputes its content from source text:
 
 ```json
 {
-  "manifest_date": "2026-07-10",
+  "manifest_date": "2026-07-16",
   "surface": "single-clock clock/evolution source packet",
   "packet_notes": [
     "docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md",
@@ -177,16 +180,9 @@ recomputes its content from source text:
       "role": "equal-time tensor-locality input; supplies no transfer"
     },
     {
-      "path": "docs/MINIMAL_AXIOMS_2026-06-05.md",
-      "h1": "Minimal Framework Axioms (Lattice, Quantum, Record)",
-      "linked_by": ["parent"],
-      "role": "aliased historical path of the stable minimal_axioms premise node",
-      "alias_of": "minimal_axioms"
-    },
-    {
       "path": "docs/MINIMAL_AXIOMS_2026-06-29.md",
       "h1": "Minimal Framework Axioms (Lattice, Qubit, Admissibility, Record)",
-      "linked_by": ["n5"],
+      "linked_by": ["parent", "n5"],
       "role": "current minimal-axiom memo; axiom authority for this manifest; supplies no clock",
       "alias_of": "minimal_axioms"
     },

--- a/logs/runner-cache/single_clock_axis_selection_check_2026_06_11.txt
+++ b/logs/runner-cache/single_clock_axis_selection_check_2026_06_11.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/single_clock_axis_selection_check_2026_06_11.py
-runner_sha256: b7cfda7c333a4fea12ec1bec2a5b35dca8f34a941a662a26b77d992d56297fd5
+runner_sha256: 0a158af31ee9e584c6923d228aca5718f062cdba4da6363ec74a8ce5c56814ed
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.08
+elapsed_sec: 0.13
 status: ok
 ----- stdout -----
 ========================================================================
@@ -37,8 +37,8 @@ Z_2 datum (BC asymmetry) or an equivalent registration-direction bridge.
 ------------------------------------------------------------------------
 [RT-REC] ROUTE A2: does record durability anchor the axis? (textual + computed: NO)
 ------------------------------------------------------------------------
-  [PASS][B] Record axiom is axis-blind by its own text: a record supplies no 'time metric' (verbatim in the exclusion list)  -- MINIMAL_AXIOMS_2026-06-05.md
-  [PASS][B] record formation is not forced (retained_no_go): 'at least one record exists' is NOT an axiom consequence, so no axis can be derived from it unconditionally  -- record-formation no-go quoted
+  [PASS][B] Record axiom is axis-blind by its own text: 'time metric' sits in the open-gates exclusion list and record permanence carries no axis label  -- MINIMAL_AXIOMS_2026-06-29.md
+  [PASS][B] record formation supplies no axis datum: occurrence is axiom-supplied ('Records form.') and the narrowed no-go keeps the formation rule/process/state/site/weight/rate unforced, so no axis label can be derived from record formation  -- narrowed record-formation no-go quoted
   [PASS][B] the clock map is supplied, never derived from records (retained_no_go): 'Without the supplied `tau`, the same record history supports many inequivalent rates' — the event ORDER carries no lattice-axis label  -- clock/rate interface quoted
   [PASS][B] the CAP-K registration cone is axis-CONDITIONAL, not axis-selecting: its dynamics clause (REG-dyn) consumes the framework H and its window (REG-tau) consumes a supplied clock — both downstream of B-AXIS, so citing it for axis selection would be circular  -- CAP-K note clauses present
   [PASS][A] durability ('fixed once registered, never un-registered') is operator-order monotonicity of the record counter, and operator order is unitary-transport invariant: the conjugated counter is monotone with the same increment spectra — durability CANNOT distinguish W-related axes  -- monotone before/after = True/True, max increment-spec diff = 8.9e-16

--- a/logs/runner-cache/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.txt
+++ b/logs/runner-cache/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.txt
@@ -1,6 +1,6 @@
 ===== runner cache v1 =====
 runner: scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py
-runner_sha256: a05b41d7cc0b376b421019858f0a0b61a3f0fcc1f00800a61d6fdbd739e6d2ba
+runner_sha256: 5e4d113d9c977a8fab2216cfff90efede62546fb78dfb3e560981d47e5b9457d
 timeout_sec: 120
 exit_code: 0
 elapsed_sec: 0.13
@@ -14,7 +14,7 @@ PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains 'Does not add an axiom'
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains '**Claim boundary:** source-inventory support'
 PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains 'No second physical-clock transfer is currently admitted.'
-PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains '## Admission Manifest (2026-07-10)'
+PASS: SINGLE_CLOCK_PHYSICAL_CLOCK_ADMISSION_INVENTORY_N5_SUPPORT_NOTE_2026-06-17.md contains '## Admission Manifest (2026-07-16)'
 PASS: note states why the support is source-inventory, not algebraic exclusion
 PASS: single-clock source names B-AXIS.3
 PASS: B-AXIS.3 is phrased as an admission statement
@@ -30,15 +30,15 @@ PASS: registry lists minimal_axioms as a canonical premise node
 PASS: registry current path for minimal_axioms is the 2026-06-29 memo
 PASS: registry aliases the 2026-06-05 path to the same premise node
 PASS: note carries exactly one fenced JSON manifest block -- found=1
-PASS: manifest is explicitly dated 2026-07-10
+PASS: manifest is explicitly dated 2026-07-16
 PASS: manifest packet is the parent theorem note plus this inventory note
 PASS: manifest axiom authority matches the registry premise node
-PASS: manifest enumerates 19 packet documents -- got=19
+PASS: manifest enumerates 18 packet documents -- got=18
 PASS: manifest entry paths are unique
 PASS: closed enumeration: manifest entries equal the live packet link union -- missing=[] stale=[]
 PASS: per-entry linked_by matches live link provenance and every role is stated -- mismatches=[]
 PASS: per-entry h1 titles match the live document headers -- mismatches=[]
-PASS: exactly the two minimal-axiom paths are marked as aliases of minimal_axioms
+PASS: exactly the current minimal-axiom path is marked as an alias of minimal_axioms
 PASS: every manifest alias row resolves inside the registry premise node
 PASS: manifest proposes exactly one physical-clock candidate
 PASS: candidate T_hat^2 evaluates as admitted from source evidence -- all four criteria evidenced in packet sources

--- a/scripts/single_clock_axis_selection_check_2026_06_11.py
+++ b/scripts/single_clock_axis_selection_check_2026_06_11.py
@@ -25,9 +25,10 @@ import check, [C] first-principles compute on explicit small lattices,
             escape: the spatial construction is obtained for free by
             conjugation.
   [RT-REC]  W-transport of the record/durability structure: the Record
-            axiom and the retained record rows are axis-blind by their
-            own text (no time metric, no forced formation, supplied
-            clock); durability (= operator-order monotonicity of the
+            axiom and the record rows it consumes are axis-blind by
+            their own text (no time metric, no forced formation
+            rule/site/rate, supplied clock); durability (= operator-order
+            monotonicity of the
             registered-record counter) is unitary-transport invariant
             (computed); the registration-cone slice package (CAP-K
             shape) maps exactly onto the x_1-axis package.
@@ -208,17 +209,22 @@ def block_RT_REC(sec, W, Ls, sites, idx):
     print("[RT-REC] ROUTE A2: does record durability anchor the axis? (textual + computed: NO)")
     print("-" * 72)
 
-    ax = read_doc("MINIMAL_AXIOMS_2026-06-05.md")
-    record("B", "Record axiom is axis-blind by its own text: a record supplies no "
-           "'time metric' (verbatim in the exclusion list)",
-           "time metric" in ax and "Durable means fixed once registered" in ax,
-           "MINIMAL_AXIOMS_2026-06-05.md")
+    ax = read_doc("MINIMAL_AXIOMS_2026-06-29.md")
+    ax_flat = " ".join(ax.split())
+    record("B", "Record axiom is axis-blind by its own text: 'time metric' sits in the "
+           "open-gates exclusion list and record permanence carries no axis label",
+           "time metric, and local observability of records" in ax_flat
+           and "records are permanent" in ax,
+           "MINIMAL_AXIOMS_2026-06-29.md")
 
     rf = read_doc("RECORD_FORMATION_NOT_UNCONDITIONALLY_FORCED_BY_MINIMAL_AXIOMS_NARROW_NO_GO_NOTE_2026-06-06.md")
-    record("B", "record formation is not forced (retained_no_go): 'at least one record "
-           "exists' is NOT an axiom consequence, so no axis can be derived from it "
-           "unconditionally",
-           "does **not** hold unconditionally" in rf, "record-formation no-go quoted")
+    record("B", "record formation supplies no axis datum: occurrence is axiom-supplied "
+           "('Records form.') and the narrowed no-go keeps the formation "
+           "rule/process/state/site/weight/rate unforced, so no axis label can be "
+           "derived from record formation",
+           'occurrence is axiom-supplied by "Records form."' in rf
+           and "do **not** force the formation rule/process/state/site/weight/rate" in rf,
+           "narrowed record-formation no-go quoted")
 
     cr = read_doc("POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md")
     record("B", "the clock map is supplied, never derived from records (retained_no_go): "

--- a/scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py
+++ b/scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py
@@ -149,7 +149,7 @@ def main() -> int:
     assert_contains(NOTE, "Does not add an axiom")
     assert_contains(NOTE, "**Claim boundary:** source-inventory support")
     assert_contains(NOTE, "No second physical-clock transfer is currently admitted.")
-    assert_contains(NOTE, "## Admission Manifest (2026-07-10)")
+    assert_contains(NOTE, "## Admission Manifest (2026-07-16)")
     check("not a theorem over all positive operators" in read(NOTE),
           "note states why the support is source-inventory, not algebraic exclusion")
 
@@ -199,7 +199,7 @@ def main() -> int:
     manifest = extract_manifest(NOTE)
     note_rel = "docs/" + NOTE.name
     parent_rel = "docs/" + SINGLE_CLOCK.name
-    check(manifest.get("manifest_date") == "2026-07-10", "manifest is explicitly dated 2026-07-10")
+    check(manifest.get("manifest_date") == "2026-07-16", "manifest is explicitly dated 2026-07-16")
     check(manifest.get("packet_notes") == [parent_rel, note_rel],
           "manifest packet is the parent theorem note plus this inventory note")
     authority = manifest.get("axiom_authority", {})
@@ -214,7 +214,7 @@ def main() -> int:
     parent_links = md_link_set(SINGLE_CLOCK)
     note_links = md_link_set(NOTE)
     union = parent_links | note_links
-    check(len(entries) == 19, "manifest enumerates 19 packet documents", f"got={len(entries)}")
+    check(len(entries) == 18, "manifest enumerates 18 packet documents", f"got={len(entries)}")
     check(len(entry_paths) == len(set(entry_paths)), "manifest entry paths are unique")
     missing = sorted(union - set(entry_paths))
     stale = sorted(set(entry_paths) - union)
@@ -246,9 +246,9 @@ def main() -> int:
           "per-entry h1 titles match the live document headers",
           f"mismatches={title_mismatches}")
     alias_rows = {e["path"]: e.get("alias_of") for e in entries if "alias_of" in e}
-    check(set(alias_rows) == {"docs/MINIMAL_AXIOMS_2026-06-05.md", "docs/MINIMAL_AXIOMS_2026-06-29.md"}
+    check(set(alias_rows) == {"docs/MINIMAL_AXIOMS_2026-06-29.md"}
           and set(alias_rows.values()) == {"minimal_axioms"},
-          "exactly the two minimal-axiom paths are marked as aliases of minimal_axioms")
+          "exactly the current minimal-axiom path is marked as an alias of minimal_axioms")
     aliased_ok = all(
         path == node.get("current_path") or path in node.get("aliased_paths", [])
         for path in alias_rows


### PR DESCRIPTION
## Defect

Runners failing on main because their expectations were keyed to the RETIRED `MINIMAL_AXIOMS_2026-06-05.md` manifest and to the superseded (pre-2026-07-05) record-formation wording.

## Before / after (verified locally on origin/main, then on this branch)

| Runner | Before | After |
|---|---|---|
| `scripts/single_clock_axis_selection_check_2026_06_11.py` | 22 PASS / 1 FAIL (exit 1) | 23 PASS / 0 FAIL (exit 0) |
| `scripts/single_clock_physical_clock_admission_inventory_n5_support_2026_06_17.py` | 52 PASS / 2 FAIL (exit 1) | 54 PASS / 0 FAIL (exit 0) |
| `scripts/staggered_dirac_substep1_statistics_selection_check_2026_06_10.py` | 24 PASS / 0 FAIL | **already fixed on main** (commit 03ca2d51f4, 2026-07-16); not touched |

## What changed (expectations/manifest references only)

**axis-selection runner** — the two stale `[RT-REC]` textual checks:
- Record-axiom text check re-keyed from the 06-05 memo needles ("Durable means fixed once registered") to the current 06-29 memo: `time metric` in the open-gates exclusion list + `records are permanent`.
- Record-formation check re-keyed from the superseded needle `does **not** hold unconditionally` to the narrowed no-go's current wording: occurrence axiom-supplied by "Records form.", formation rule/process/state/site/weight/rate unforced. The re-keyed message states exactly what the runner verifies; the axis-route conclusion is unchanged.
- Paired note `SINGLE_CLOCK_AXIS_SELECTION_FROM_RECORD_DURABILITY_NARROW_NO_GO_NOTE_2026-06-11.md` updated at the matching spots (input table row, route A2 kill 2, PIN-REG parenthetical, consistency bullet, cited record surface link 06-05 -> 06-29). Embedded expected transcript regenerated — byte-identical to runner stdout (verified by diff).

**N5 inventory runner** — the note's dated admission manifest still enumerated `docs/MINIMAL_AXIOMS_2026-06-05.md` as a parent-linked entry, but the parent packet note now links the 06-29 memo directly (landed earlier on main), so the live link-union recompute flagged it stale. Manifest refreshed and re-dated 2026-07-16: 06-05 entry removed, 06-29 entry `linked_by: [parent, n5]`. Runner constants re-keyed: entry count 19 -> 18, alias set now the single current path, manifest date. The registry-alias check (historical 06-05 path aliases `minimal_axioms` in `axiom_premise_nodes.json`) is untouched and still passes.

## Guard rails observed

- No substantive check weakened or deleted; only stale expectation constants / manifest references updated.
- No widened independence claims: the Record-axiom checks remain scoped to the Record axiom text the runner actually reads — no Admissibility (or any axiom) added to any runner-verified claim.
- No grade language authored; the stale `(retained_no_go)` tag in the rewritten check message / note row was replaced with status-neutral wording (both rows are `unaudited` on the live ledger).
- Runner caches refreshed via `precompute_audit_runners.py` (SHA-pinned).

## Validation

- Both target runners exit 0; six sibling single-clock runners that pin the edited notes all still exit 0
- `vocab_lint.py --fix` on all four source files: 0 violations
- `run_pipeline.sh`: exit 0 (18/18); `audit_lint.py --strict`: no errors
- Both edited rows are `unaudited`; note-hash drift is the benign re-audit-pending notice
- Generated audit outputs restored to origin/main before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)