### PR TITLE
science-fix: formalize exact finite pushforward transport

### DIFF
--- a/docs/POST_RECORD_PERSISTENT_RECORD_PRODUCTION_BRIDGE_PROTOTYPE_2026-06-06.md
+++ b/docs/POST_RECORD_PERSISTENT_RECORD_PRODUCTION_BRIDGE_PROTOTYPE_2026-06-06.md
@@ -1,100 +1,188 @@
-# Post-Record Persistent-Record Production Bridge Prototype
+# Exact Finite Deterministic Pushforward and Product-Kernel Transport Theorem
 
 **Date:** 2026-06-06
-**Type:** exact support / supplied production bridge prototype
-**Claim type:** bounded_theorem
-**Status:** bounded-support interface for supplied finite record-writing bridge
-semantics; audit_required_before_effective_retained=true;
-bare_retained_allowed=false.
+**Type:** positive_theorem
+**Claim type:** positive_theorem
 **Primary runner:**
 [`scripts/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.py`](../scripts/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.py)
 **Cached log:**
 [`logs/runner-cache/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.txt`](../logs/runner-cache/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.txt)
+**Dependencies:** none. The carriers, probability packet, deterministic map,
+observable, and pair kernel below are universally quantified mathematical
+arguments.
 
-## Result
+## 1. Exact finite pushforward
 
-This block gives the three `persistent_record_production_overlap` rows a finite
-supplied-bridge prototype:
+Let `X` and `Y` be nonempty finite sets. Supply an exact rational probability
+packet on `X` and a total deterministic map:
 
 ```text
-supplied pre-record word law
-  + supplied record-writing update
-  + supplied persistence rule
-  + supplied overlap kernel on post-record states
-  + exact pushforward/enumeration
-  => law-scoped post-record distribution and overlap certificate
+P : X -> Q_{>=0},                   sum_{x in X} P(x) = 1,
+F : X -> Y.
 ```
 
-The supplied pre-record law carries probabilities. Post-record states carry realized count/marker information.
-The realized tuple contains no probability field.
+Define the pushforward packet on every target label, including unused labels,
+by
 
-## Why this matters
-
-The persistent-record rows need a record-writing law bridge, persistence bridge,
-overlap-kernel bridge, production-time bridge, and baseline bridge before they
-can move beyond bounded pilots.
-
-This prototype supplies a minimal finite form of those bridges:
-
-- pre-record paths are finite words with a supplied probability law;
-- post-record states are tuples of persistent counts and first-hit markers;
-- record updates are monotone and never erase existing marker information;
-- a supplied overlap kernel compares realized post-record states;
-- all probabilities remain law-scoped and external to the post-record state.
-
-This matches the pre-record/post-record split: pre-record laws describe possible
-histories and probabilities; post-record sites store realized information.
-
-## Status certificate
-
-```yaml
-actual_current_surface_status: exact-support
-trace_class: upstream_support
-reachability_to_target: supports
-conditional_surface_status: "persistent-record production rows get an exact finite supplied record-writing bridge prototype"
-hypothetical_axiom_status: null
-admitted_observation_status: null
-proposal_allowed: false
-proposal_allowed_reason: "This branch supplies a finite bridge form and does not derive the production law, overlap kernel, or physical dynamics."
-audit_required_before_effective_retained: true
-bare_retained_allowed: false
+```text
+Q(y) = sum_{x in X : F(x)=y} P(x).
 ```
 
-## Boundaries
+Every summand is nonnegative, so `Q(y)>=0`. Because totality assigns each
+source label to exactly one target fiber, the fibers partition `X`; hence
 
-- Does not edit `docs/audit/data`.
-- Does not apply or predict audit verdicts.
-- Does not promote any row.
-- Does not derive a record-writing law from Record.
-- Does not derive a production kernel, Hamiltonian, instrument, clock/rate, or
-  physical arrow.
-- Does not derive a Born law or prior from Record.
-- Does not select or force a generation/Koide dial location.
-- Does not turn a stable setting into a selected dial.
-- Does not claim asymptotic closure for persistent-record rows.
+```text
+sum_{y in Y} Q(y)
+  = sum_{y in Y} sum_{x:F(x)=y} P(x)
+  = sum_{x in X} P(x)
+  = 1.
+```
 
-## Runner certificate
+This proves that deterministic pushforward preserves exact normalization.
+Surjectivity is unnecessary: an unused target has its empty-fiber value zero.
 
-The runner verifies:
+## 2. Observable pullback identity
 
-- source anchors in this note, the production row map, and persistent-record
-  source notes;
-- the production row map has exactly three `persistent_record_production_overlap`
-  rows;
-- a supplied finite pre-record law pushes forward through a supplied
-  record-writing update to post-record states;
-- post-record states contain realized counts and markers, not probabilities;
-- persistence is monotone under updates;
-- a supplied exact overlap kernel is symmetric, self-normalized, and bounded;
-- law-scoped expected overlap is computed outside the post-record state
-  (`169/320` in the supplied finite example);
-- missing law/update/kernel inputs are rejected;
-- no audit verdict, audit-data write, retained/promoted claim, production-law
-  derivation, physical-arrow derivation, Born-law derivation, or dial-selection
-  flag is set.
+For every exact rational observable `h : Y -> Q`, including signed values,
+finite rearrangement gives
+
+```text
+sum_{y in Y} Q(y) h(y)
+  = sum_{y in Y} sum_{x:F(x)=y} P(x) h(y)
+  = sum_{x in X} P(x) h(F(x)).
+```
+
+Thus expectation after pushforward equals expectation of the pulled-back
+observable before pushforward.
+
+## 3. Product-kernel transport identity
+
+Supply any exact rational pair observable
+
+```text
+K : Y x Y -> Q.
+```
+
+It may be signed, asymmetric, unbounded relative to `[0,1]`, or different from
+one on the diagonal. Those are optional properties of particular supplied
+kernels, rather than hypotheses of the transport identity. Expanding both
+target fibers proves
+
+```text
+sum_{y,y' in Y} Q(y) Q(y') K(y,y')
+  = sum_{x,x' in X} P(x) P(x') K(F(x),F(x')).
+```
+
+Indeed, the coefficient of each `K(y,y')` on the right is
+
+```text
+(sum_{x:F(x)=y} P(x)) (sum_{x':F(x')=y'} P(x')) = Q(y)Q(y').
+```
+
+The multiplication `P(x)P(x')` is essential: the identity concerns the
+product packet `P x P`, not an additive or single-sample surrogate.
+
+## 4. Executable domain and ordering semantics
+
+The runner represents:
+
+- `X` by the unique string labels in an ordered probability tuple;
+- `Y` by a nonempty ordered tuple of unique string labels;
+- `F` by one `(source_label, target_label)` tuple entry per source label;
+- `h` by one `(target_label, Fraction)` entry per target label; and
+- `K` by one `(left_target, right_target, Fraction)` entry per ordered pair in
+  `Y x Y`.
+
+Every numeric value has exact runtime type `Fraction`. Integers, booleans,
+floats, subclasses, and coercion are rejected. Identifiers have exact runtime
+type `str` and are nonempty. Duplicate labels or pairs are rejected.
+
+The order of `Y` fixes pushforward display order. All algebra aligns values by
+labels. Independent permutations of the probability, map, observable, or
+kernel tuples preserve every label assignment and scalar identity. The map
+must be total on `X`; its image may be a proper subset of `Y`.
+
+## 5. Defined word/count example
+
+The following is one finite combinatorial instance, not a physical model.
+Take source labels `LL, LR, RL, RR` with
+
+```text
+P = (1/2, 1/4, 1/8, 1/8).
+```
+
+Define `F` by counting `L` and `R` in each two-letter word and retaining its
+first letter:
+
+```text
+LL -> 2:0:L,   LR -> 1:1:L,   RL -> 1:1:R,   RR -> 0:2:R.
+```
+
+On these four target labels, define
+
+```text
+K(a,b) = 1 / (1 + (L_a-L_b)^2 + (R_a-R_b)^2 + [first_a != first_b]).
+```
+
+This particular supplied kernel is symmetric, takes values in `(0,1]`, and is
+one on the diagonal. Exact enumeration of `Q x Q` gives
+
+```text
+sum_{a,b} Q(a)Q(b)K(a,b) = 169/320.
+```
+
+The associated capped count update
+
+```text
+(l,r,m) --L--> (min(2,l+1), r,       L if m=none else m),
+(l,r,m) --R--> (l,       min(2,r+1), R if m=none else m)
+```
+
+has a direct combinatorial monotonicity lemma: both counts are nondecreasing,
+and a marker different from `none` stays unchanged. This lemma concerns the
+displayed defined update only.
+
+## 6. Exact scope
+
+The theorem conclusion consists exactly of finite pushforward normalization,
+observable pullback, and product-kernel transport. Its probability packet,
+map, observable, and kernel are supplied theorem arguments.
+
+Any application involving physical records, formation, production,
+persistence, transition laws, priors, Born weights, instruments, dynamics,
+Hamiltonians, clocks, rates, arrows, selectors, or dial interpretations
+carries separate model premises. The legacy path name is an identifier and
+adds none of those meanings to the theorem.
+
+Audit censuses, ledgers, queues, row maps, exports, helper runners, hashes, and
+row counts are repository metadata outside the theorem arguments. The proof is
+invariant under changes to those inventories.
+
+## 7. Falsification and reproducibility
+
+The standard-library runner provides:
+
+- a normal exact derivation, including unused targets, collisions, signed
+  observables, an arbitrary signed asymmetric kernel, and the `169/320`
+  combinatorial example;
+- an independent common-denominator implementation exercised across many
+  finite carriers, maps, laws, observables, and kernels; and
+- hostile controls for malformed domains and false pushforward, expectation,
+  collision, product-probability, optional-kernel-property, permutation, and
+  physical-selection claims.
+
+Selectable intentional-failure fixtures promote each hostile mutation to a
+claimed success. Every individual fixture and the aggregate must exit nonzero.
 
 Run:
 
-```text
+```bash
 python3 scripts/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.py
+python3 scripts/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.py --independent
+python3 scripts/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.py --hostile
+python3 scripts/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.py --mode intentional-failure --fixture all
 ```
+
+The cached log records the default normal run. The fresh citation graph has no
+direct claim consumer of this theorem. Any future consumer must preserve the
+supplied-input boundary above.

--- a/logs/runner-cache/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.txt
+++ b/logs/runner-cache/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.txt
@@ -1,84 +1,80 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.py
-runner_sha256: 229b0645950559d7252b41b6150d067fd10e309104cd9b36d19c0a134ac33a0c
+runner_sha256: 99034597a1ccf0de8cc310564918a2387b1b129ddb40a6d256a52ef63518df42
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.91
+elapsed_sec: 0.05
 status: ok
 ----- stdout -----
 
 ------------------------------------------------------------------------------
-Source-anchor checks
+Source theorem and semantic scope checks
 ------------------------------------------------------------------------------
-PASS docs/POST_RECORD_PERSISTENT_RECORD_PRODUCTION_BRIDGE_PROTOTYPE_2026-06-06.md exists
-PASS docs/POST_RECORD_PERSISTENT_RECORD_PRODUCTION_BRIDGE_PROTOTYPE_2026-06-06.md contains: supplied pre-record word law
-PASS docs/POST_RECORD_PERSISTENT_RECORD_PRODUCTION_BRIDGE_PROTOTYPE_2026-06-06.md contains: Post-record states carry realized count/marker information.
-PASS docs/POST_RECORD_PERSISTENT_RECORD_PRODUCTION_BRIDGE_PROTOTYPE_2026-06-06.md contains: does not derive the production law
-PASS docs/POST_RECORD_PERSISTENT_RECORD_PRODUCTION_BRIDGE_PROTOTYPE_2026-06-06.md contains: Does not select or force a generation/Koide dial location
-PASS docs/POST_RECORD_PRODUCTION_DYNAMICS_NEEDED_ROW_MAP_2026-06-06.md exists
-PASS docs/POST_RECORD_PRODUCTION_DYNAMICS_NEEDED_ROW_MAP_2026-06-06.md contains: persistent_record_production_overlap` | 3
-PASS docs/POST_RECORD_PRODUCTION_DYNAMICS_NEEDED_ROW_MAP_2026-06-06.md contains: record-writing law bridge
-PASS docs/POST_RECORD_PRODUCTION_DYNAMICS_NEEDED_ROW_MAP_2026-06-06.md contains: overlap-kernel physical bridge
-PASS docs/POST_RECORD_PRODUCTION_DYNAMICS_NEEDED_ROW_MAP_2026-06-06.md contains: post-record sites carry realized information
-PASS docs/PERSISTENT_RECORD_OVERLAP_KERNEL_NOTE.md exists
-PASS docs/PERSISTENT_RECORD_OVERLAP_KERNEL_NOTE.md contains: mesoscopic persistent record state
-PASS docs/PERSISTENT_RECORD_OVERLAP_KERNEL_NOTE.md contains: sparse count vector
-PASS docs/PERSISTENT_RECORD_OVERLAP_KERNEL_NOTE.md contains: soft overlap kernel
-PASS docs/PERSISTENT_RECORD_REFINEMENT_NOTE.md exists
-PASS docs/PERSISTENT_RECORD_REFINEMENT_NOTE.md contains: first-hit family
-PASS docs/PERSISTENT_RECORD_REFINEMENT_NOTE.md contains: different record-writing law
-PASS docs/PERSISTENT_RECORD_REFINEMENT_NOTE.md contains: first-hit markers influence later
-PASS docs/PERSISTENT_RECORD_MATCHED_COMPARE_NOTE.md exists
-PASS docs/PERSISTENT_RECORD_MATCHED_COMPARE_NOTE.md contains: residual branch-overlap structure
-PASS docs/PERSISTENT_RECORD_MATCHED_COMPARE_NOTE.md contains: competitive middle
-PASS docs/PERSISTENT_RECORD_MATCHED_COMPARE_NOTE.md contains: matched bounded slice
+PASS source note exists
+PASS source contains theorem anchor: **Claim type:** positive_theorem
+PASS source contains theorem anchor: **Dependencies:** none.
+PASS source contains theorem anchor: Q(y) = sum_{x in X : F(x)=y} P(x).
+PASS source contains theorem anchor: sum_{x in X} P(x) h(F(x)).
+PASS source contains theorem anchor: sum_{x,x' in X} P(x) P(x') K(F(x),F(x')).
+PASS source contains theorem anchor: The map must be total on `X`; its image may be a proper subset of `Y`.
+PASS source contains theorem anchor: The legacy path name is an identifier
+PASS source contains theorem anchor: repository metadata outside the theorem arguments
+PASS source excludes stale or physical overclaim: persistent_record_production_overlap` rows
+PASS source excludes stale or physical overclaim: production row map has exactly three
+PASS source excludes stale or physical overclaim: frontier_post_record_audit_evidence_ladder_row_bucketing_2026_06_06\.py
+PASS source excludes stale or physical overclaim: frontier_post_record_production_dynamics_needed_row_map_2026_06_06\.py
+PASS source excludes stale or physical overclaim: docs/audit/data/
+PASS source excludes stale or physical overclaim: \baudit_status\s*:
+PASS source excludes stale or physical overclaim: \beffective_status\s*:
+PASS source excludes stale or physical overclaim: \bRecord (?:derives|supplies|selects|fixes)\b
+PASS source excludes stale or physical overclaim: \bphysical (?:production|record-writing) (?:law|kernel) (?:is|follows)\b
+PASS source excludes stale or physical overclaim: PERSISTENT_RECORD_PRODUCTION_OVERLAP_ROWS
+PASS source excludes stale or physical overclaim: SUPPLIED_RECORD_WRITING_BRIDGE_PROTOTYPE
 
 ------------------------------------------------------------------------------
-Production-row checks
+Exact finite pushforward
 ------------------------------------------------------------------------------
-PASS persistent-record production row count is current snapshot :: {'persistent_record_overlap_kernel_note', 'persistent_record_matched_compare_note', 'persistent_record_refinement_note'}
-PASS persistent-record production row ids match :: {'persistent_record_overlap_kernel_note', 'persistent_record_matched_compare_note', 'persistent_record_refinement_note'}
+PASS colliding fibers sum exactly :: (('red', Fraction(5, 6)), ('blue', Fraction(1, 6)), ('unused', Fraction(0, 1)))
+PASS pushforward is nonnegative
+PASS pushforward is normalized exactly
+PASS unused target is retained with zero mass
+PASS pushforward verifies by target-label semantics
 
 ------------------------------------------------------------------------------
-Supplied bridge checks
+Observable pullback identity
 ------------------------------------------------------------------------------
-PASS supplied pre-record law is normalized :: {('L', 'L'): Fraction(1, 2), ('L', 'R'): Fraction(1, 4), ('R', 'L'): Fraction(1, 8), ('R', 'R'): Fraction(1, 8)}
-PASS post-record pushforward distribution is normalized :: {(2, 0, 'L'): Fraction(1, 2), (1, 1, 'L'): Fraction(1, 4), (1, 1, 'R'): Fraction(1, 8), (0, 2, 'R'): Fraction(1, 8)}
-PASS pushforward has expected support size :: {(2, 0, 'L'): Fraction(1, 2), (1, 1, 'L'): Fraction(1, 4), (1, 1, 'R'): Fraction(1, 8), (0, 2, 'R'): Fraction(1, 8)}
-PASS post-record states carry no probability internally :: [(2, 0, 'L'), (1, 1, 'L'), (1, 1, 'R'), (0, 2, 'R')]
-PASS record counts are monotone under supplied update :: [(0, 0, 'none'), (0, 1, 'R'), (1, 1, 'R'), (2, 1, 'R')]
-PASS first-hit marker persists under supplied update :: [(0, 0, 'none'), (0, 1, 'R'), (1, 1, 'R'), (2, 1, 'R')]
-PASS supplied overlap kernel is symmetric
-PASS supplied overlap kernel is self-normalized
-PASS supplied overlap kernel is bounded in (0,1]
-PASS law-scoped expected overlap is exact rational :: 169/320
-PASS invalid supplied law is rejected
+PASS signed observable target expectation is exact :: -5/6
+PASS observable pullback identity is exact :: -5/6
 
 ------------------------------------------------------------------------------
-Firewall flags
+Arbitrary product-kernel transport
 ------------------------------------------------------------------------------
-PASS audit data written flag is false
-PASS audit verdict applied flag is false
-PASS promoted/retained claim flag is false
-PASS record-writing law derived from Record flag is false
-PASS production kernel selected flag is false
-PASS Record-derived physical arrow flag is false
-PASS Record-derived Born law flag is false
-PASS generation/Koide dial selected flag is false
-PASS stable setting selects dial flag is false
+PASS arbitrary signed asymmetric kernel transports exactly :: 143/216
+PASS transport theorem does not require symmetry
+PASS transport theorem does not require unit bounds
+PASS transport theorem does not require diagonal one
 
-SUMMARY: PASS=44 FAIL=0
-PERSISTENT_RECORD_PRODUCTION_OVERLAP_ROWS=3
-SUPPLIED_RECORD_WRITING_BRIDGE_PROTOTYPE=TRUE
-POST_RECORD_STATE_HAS_INTERNAL_PROBABILITY=FALSE
-RECORD_WRITING_LAW_DERIVED_FROM_RECORD=FALSE
-PRODUCTION_KERNEL_SELECTED=FALSE
-PHYSICAL_ARROW_DERIVED_FROM_RECORD=FALSE
-BORN_LAW_DERIVED_FROM_RECORD=FALSE
-GENERATION_OR_KOIDE_DIAL_SELECTED=FALSE
-STABLE_SETTING_SELECTS_DIAL=FALSE
-AUDIT_LEDGER_WRITTEN=FALSE
-AUDIT_VERDICT_APPLIED=FALSE
+------------------------------------------------------------------------------
+Defined word/count example
+------------------------------------------------------------------------------
+PASS word/count image packet is exact :: (('2:0:L', Fraction(1, 2)), ('1:1:L', Fraction(1, 4)), ('1:1:R', Fraction(1, 8)), ('0:2:R', Fraction(1, 8)))
+PASS defined word kernel is symmetric
+PASS defined word kernel is positive and at most one
+PASS defined word kernel equals one on the diagonal
+PASS defined word example product expectation is 169/320 :: 169/320
+PASS word example also closes through source-product transport
+PASS defined capped counts are componentwise nondecreasing :: [(0, 0, 'none'), (0, 1, 'R'), (1, 1, 'R'), (2, 1, 'R'), (2, 2, 'R')]
+PASS defined first marker is unchanged after its first assignment :: [(0, 0, 'none'), (0, 1, 'R'), (1, 1, 'R'), (2, 1, 'R'), (2, 2, 'R')]
+
+------------------------------------------------------------------------------
+Ordering and carrier permutations
+------------------------------------------------------------------------------
+PASS pushforward is permutation-equivariant by target label
+PASS observable identity is permutation-invariant
+PASS kernel identity is permutation-invariant
+
+SUMMARY: MODE=normal PASS=42 FAIL=0
+THEOREM_SCOPE=EXACT_FINITE_DETERMINISTIC_PUSHFORWARD_OBSERVABLE_AND_PRODUCT_KERNEL_TRANSPORT
 
 ----- stderr -----
 

--- a/logs/runner-cache/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.txt
+++ b/logs/runner-cache/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.txt
@@ -1,6 +1,6 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.py
-runner_sha256: 99034597a1ccf0de8cc310564918a2387b1b129ddb40a6d256a52ef63518df42
+runner_sha256: 49dac2559025ffa9abed89adc590303ba0ceb5817eadedf7e1c560828f9501b5
 timeout_sec: 120
 exit_code: 0
 elapsed_sec: 0.05

--- a/scripts/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.py
+++ b/scripts/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.py
@@ -1,35 +1,34 @@
 #!/usr/bin/env python3
-"""Finite supplied production bridge for persistent post-record states."""
+"""Exact finite deterministic pushforward and product-kernel transport theorem."""
 
 from __future__ import annotations
 
-from collections import Counter, defaultdict
+import argparse
 from fractions import Fraction
+from math import gcd
 from pathlib import Path
-import importlib.util
-import json
+import re
 import sys
+from typing import Callable, TypeAlias
 
 
 ROOT = Path(__file__).resolve().parents[1]
-LEDGER = ROOT / "docs/audit/data/audit_ledger.json"
-ROW_MAP_RUNNER = ROOT / "scripts/frontier_post_record_production_dynamics_needed_row_map_2026_06_06.py"
+NOTE = ROOT / "docs/POST_RECORD_PERSISTENT_RECORD_PRODUCTION_BRIDGE_PROTOTYPE_2026-06-06.md"
+
+Identifier: TypeAlias = str
+ProbabilityPacket: TypeAlias = tuple[tuple[Identifier, Fraction], ...]
+TargetCarrier: TypeAlias = tuple[Identifier, ...]
+MapPacket: TypeAlias = tuple[tuple[Identifier, Identifier], ...]
+ObservablePacket: TypeAlias = tuple[tuple[Identifier, Fraction], ...]
+KernelPacket: TypeAlias = tuple[tuple[Identifier, Identifier, Fraction], ...]
+CountState: TypeAlias = tuple[int, int, str]
+
 PASS = 0
 FAIL = 0
 
-Record = tuple[int, int, str]
 
-
-def load_row_map():
-    spec = importlib.util.spec_from_file_location("production_row_map", ROW_MAP_RUNNER)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"cannot load {ROW_MAP_RUNNER}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-row_map = load_row_map()
+class FractionSubclass(Fraction):
+    """Hostile fixture: subclasses are outside the strict numeric contract."""
 
 
 def report(label: str, ok: bool, detail: str = "") -> None:
@@ -45,237 +44,1169 @@ def report(label: str, ok: bool, detail: str = "") -> None:
 
 
 def section(title: str) -> None:
-    print()
-    print("-" * 78)
-    print(title)
-    print("-" * 78)
+    print(f"\n{'-' * 78}\n{title}\n{'-' * 78}")
 
 
-def read_rel(path: str) -> str:
-    return (ROOT / path).read_text(encoding="utf-8")
+def exact_identifier(value: object, context: str) -> str:
+    if type(value) is not str or not value:
+        raise TypeError(f"{context} must have exact runtime type str and be nonempty")
+    return value
 
 
-def require_text(path: str, needles: list[str]) -> None:
-    text = read_rel(path)
-    report(f"{path} exists", True)
-    for needle in needles:
-        report(f"{path} contains: {needle}", needle in text)
+def exact_fraction(value: object, context: str) -> Fraction:
+    if type(value) is not Fraction:
+        raise TypeError(f"{context} must have exact runtime type Fraction")
+    return value
 
 
-def initial_record() -> Record:
-    return (0, 0, "none")
+def carrier_labels(carrier: TargetCarrier, context: str) -> tuple[str, ...]:
+    if type(carrier) is not tuple or not carrier:
+        raise ValueError(f"{context} must be a nonempty tuple")
+    labels: list[str] = []
+    seen: set[str] = set()
+    for raw_label in carrier:
+        label = exact_identifier(raw_label, f"{context} label")
+        if label in seen:
+            raise ValueError(f"duplicate {context} label: {label}")
+        seen.add(label)
+        labels.append(label)
+    return tuple(labels)
 
 
-def write_record(record: Record, hit: str) -> Record:
-    left, right, first = record
-    if hit not in {"L", "R"}:
-        raise ValueError(f"unknown hit: {hit}")
-    if hit == "L":
-        left = min(2, left + 1)
-    else:
-        right = min(2, right + 1)
-    if first == "none":
-        first = hit
-    return (left, right, first)
+def probability_entries(packet: ProbabilityPacket, context: str) -> tuple[tuple[str, Fraction], ...]:
+    if type(packet) is not tuple or not packet:
+        raise ValueError(f"{context} must be a nonempty tuple")
+    entries: list[tuple[str, Fraction]] = []
+    seen: set[str] = set()
+    for item in packet:
+        if type(item) is not tuple or len(item) != 2:
+            raise TypeError(f"{context} entries must be (identifier, Fraction) tuples")
+        raw_label, raw_value = item
+        label = exact_identifier(raw_label, f"{context} identifier")
+        value = exact_fraction(raw_value, f"{context}[{label}]")
+        if label in seen:
+            raise ValueError(f"duplicate {context} identifier: {label}")
+        seen.add(label)
+        entries.append((label, value))
+    return tuple(entries)
 
 
-def evolve_record(word: tuple[str, ...]) -> Record:
-    record = initial_record()
-    for hit in word:
-        record = write_record(record, hit)
-    return record
+def probability_map(packet: ProbabilityPacket, context: str) -> dict[str, Fraction]:
+    entries = probability_entries(packet, context)
+    if any(value < 0 for _, value in entries):
+        raise ValueError(f"{context} values must be nonnegative")
+    if sum((value for _, value in entries), Fraction(0)) != 1:
+        raise ValueError(f"{context} must sum exactly to one")
+    return dict(entries)
 
 
-def supplied_word_law() -> dict[tuple[str, ...], Fraction]:
-    return {
-        ("L", "L"): Fraction(1, 2),
-        ("L", "R"): Fraction(1, 4),
-        ("R", "L"): Fraction(1, 8),
-        ("R", "R"): Fraction(1, 8),
-    }
+def deterministic_map(
+    probability: ProbabilityPacket,
+    targets: TargetCarrier,
+    mapping: MapPacket,
+) -> dict[str, str]:
+    source_values = probability_map(probability, "source probability")
+    target_labels = carrier_labels(targets, "target carrier")
+    if type(mapping) is not tuple or not mapping:
+        raise ValueError("deterministic map must be a nonempty tuple")
+    values: dict[str, str] = {}
+    for item in mapping:
+        if type(item) is not tuple or len(item) != 2:
+            raise TypeError("map entries must be (source, target) tuples")
+        raw_source, raw_target = item
+        source = exact_identifier(raw_source, "map source identifier")
+        target = exact_identifier(raw_target, "map target identifier")
+        if source in values:
+            raise ValueError(f"map source appears more than once: {source}")
+        if target not in target_labels:
+            raise ValueError(f"map target is outside supplied carrier: {target}")
+        values[source] = target
+    if set(values) != set(source_values):
+        raise ValueError("deterministic map domain must equal the source carrier")
+    return values
 
 
-def validate_law(law: dict[tuple[str, ...], Fraction]) -> bool:
-    return bool(law) and all(p >= 0 for p in law.values()) and sum(law.values(), Fraction(0)) == 1
+def observable_map(targets: TargetCarrier, observable: ObservablePacket) -> dict[str, Fraction]:
+    target_labels = carrier_labels(targets, "target carrier")
+    if type(observable) is not tuple or not observable:
+        raise ValueError("observable must be a nonempty tuple")
+    values: dict[str, Fraction] = {}
+    for item in observable:
+        if type(item) is not tuple or len(item) != 2:
+            raise TypeError("observable entries must be (target, Fraction) tuples")
+        raw_target, raw_value = item
+        target = exact_identifier(raw_target, "observable target identifier")
+        value = exact_fraction(raw_value, f"observable[{target}]")
+        if target in values:
+            raise ValueError(f"duplicate observable target: {target}")
+        values[target] = value
+    if set(values) != set(target_labels):
+        raise ValueError("observable domain must equal the target carrier")
+    return values
 
 
-def pushforward(law: dict[tuple[str, ...], Fraction]) -> dict[Record, Fraction]:
-    if not validate_law(law):
-        raise ValueError("invalid supplied law")
-    dist: dict[Record, Fraction] = defaultdict(Fraction)
-    for word, probability in law.items():
-        dist[evolve_record(word)] += probability
-    return dict(dist)
+def kernel_map(targets: TargetCarrier, kernel: KernelPacket) -> dict[tuple[str, str], Fraction]:
+    target_labels = carrier_labels(targets, "target carrier")
+    if type(kernel) is not tuple or not kernel:
+        raise ValueError("kernel must be a nonempty tuple")
+    values: dict[tuple[str, str], Fraction] = {}
+    for item in kernel:
+        if type(item) is not tuple or len(item) != 3:
+            raise TypeError("kernel entries must be (left, right, Fraction) tuples")
+        raw_left, raw_right, raw_value = item
+        left = exact_identifier(raw_left, "kernel left identifier")
+        right = exact_identifier(raw_right, "kernel right identifier")
+        value = exact_fraction(raw_value, f"kernel[{left},{right}]")
+        pair = (left, right)
+        if pair in values:
+            raise ValueError(f"duplicate kernel pair: {pair}")
+        values[pair] = value
+    expected = {(left, right) for left in target_labels for right in target_labels}
+    if set(values) != expected:
+        raise ValueError("kernel domain must equal the full ordered product Y x Y")
+    return values
 
 
-def record_has_no_probability(record: Record) -> bool:
+def pushforward(
+    probability: ProbabilityPacket,
+    targets: TargetCarrier,
+    mapping: MapPacket,
+) -> ProbabilityPacket:
+    source_values = probability_map(probability, "source probability")
+    target_labels = carrier_labels(targets, "target carrier")
+    images = deterministic_map(probability, targets, mapping)
+    masses = {target: Fraction(0) for target in target_labels}
+    for source, value in source_values.items():
+        masses[images[source]] += value
+    return tuple((target, masses[target]) for target in target_labels)
+
+
+def target_expectation(
+    target_probability: ProbabilityPacket,
+    targets: TargetCarrier,
+    observable: ObservablePacket,
+) -> Fraction:
+    probabilities = probability_map(target_probability, "target probability")
+    target_labels = carrier_labels(targets, "target carrier")
+    if set(probabilities) != set(target_labels):
+        raise ValueError("target probability carrier mismatch")
+    values = observable_map(targets, observable)
+    return sum(
+        (probabilities[target] * values[target] for target in target_labels),
+        Fraction(0),
+    )
+
+
+def source_pullback_expectation(
+    probability: ProbabilityPacket,
+    targets: TargetCarrier,
+    mapping: MapPacket,
+    observable: ObservablePacket,
+) -> Fraction:
+    probabilities = probability_map(probability, "source probability")
+    images = deterministic_map(probability, targets, mapping)
+    values = observable_map(targets, observable)
+    return sum(
+        (probabilities[source] * values[images[source]] for source in probabilities),
+        Fraction(0),
+    )
+
+
+def target_kernel_expectation(
+    target_probability: ProbabilityPacket,
+    targets: TargetCarrier,
+    kernel: KernelPacket,
+) -> Fraction:
+    probabilities = probability_map(target_probability, "target probability")
+    target_labels = carrier_labels(targets, "target carrier")
+    if set(probabilities) != set(target_labels):
+        raise ValueError("target probability carrier mismatch")
+    values = kernel_map(targets, kernel)
+    return sum(
+        (
+            probabilities[left]
+            * probabilities[right]
+            * values[(left, right)]
+            for left in target_labels
+            for right in target_labels
+        ),
+        Fraction(0),
+    )
+
+
+def source_kernel_expectation(
+    probability: ProbabilityPacket,
+    targets: TargetCarrier,
+    mapping: MapPacket,
+    kernel: KernelPacket,
+) -> Fraction:
+    probabilities = probability_map(probability, "source probability")
+    images = deterministic_map(probability, targets, mapping)
+    values = kernel_map(targets, kernel)
+    return sum(
+        (
+            probabilities[left]
+            * probabilities[right]
+            * values[(images[left], images[right])]
+            for left in probabilities
+            for right in probabilities
+        ),
+        Fraction(0),
+    )
+
+
+def equal_by_label(left: ProbabilityPacket, right: ProbabilityPacket) -> bool:
+    try:
+        return probability_map(left, "left probability") == probability_map(
+            right, "right probability"
+        )
+    except (TypeError, ValueError):
+        return False
+
+
+def verify_pushforward(
+    probability: ProbabilityPacket,
+    targets: TargetCarrier,
+    mapping: MapPacket,
+    candidate: ProbabilityPacket,
+) -> bool:
+    try:
+        target_labels = carrier_labels(targets, "target carrier")
+        candidate_values = probability_map(candidate, "candidate pushforward")
+        expected = pushforward(probability, targets, mapping)
+    except (TypeError, ValueError):
+        return False
     return (
-        isinstance(record[0], int)
-        and isinstance(record[1], int)
-        and isinstance(record[2], str)
-        and not any(isinstance(item, Fraction) for item in record)
+        tuple(label for label, _ in candidate) == target_labels
+        and candidate_values == dict(expected)
     )
 
 
-def distance_squared(a: Record, b: Record) -> int:
-    marker_penalty = 0 if a[2] == b[2] else 1
-    return (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + marker_penalty
-
-
-def overlap_kernel(a: Record, b: Record) -> Fraction:
-    return Fraction(1, 1 + distance_squared(a, b))
-
-
-def expected_overlap(dist: dict[Record, Fraction]) -> Fraction:
-    total = Fraction(0)
-    for a, pa in dist.items():
-        for b, pb in dist.items():
-            total += pa * pb * overlap_kernel(a, b)
-    return total
-
-
-def source_anchor_checks() -> None:
-    section("Source-anchor checks")
-    require_text(
-        "docs/POST_RECORD_PERSISTENT_RECORD_PRODUCTION_BRIDGE_PROTOTYPE_2026-06-06.md",
-        [
-            "supplied pre-record word law",
-            "Post-record states carry realized count/marker information.",
-            "does not derive the production law",
-            "Does not select or force a generation/Koide dial location",
-        ],
-    )
-    require_text(
-        "docs/POST_RECORD_PRODUCTION_DYNAMICS_NEEDED_ROW_MAP_2026-06-06.md",
-        [
-            "persistent_record_production_overlap` | 3",
-            "record-writing law bridge",
-            "overlap-kernel physical bridge",
-            "post-record sites carry realized information",
-        ],
-    )
-    require_text(
-        "docs/PERSISTENT_RECORD_OVERLAP_KERNEL_NOTE.md",
-        [
-            "mesoscopic persistent record state",
-            "sparse count vector",
-            "soft overlap kernel",
-        ],
-    )
-    require_text(
-        "docs/PERSISTENT_RECORD_REFINEMENT_NOTE.md",
-        [
-            "first-hit family",
-            "different record-writing law",
-            "first-hit markers influence later",
-        ],
-    )
-    require_text(
-        "docs/PERSISTENT_RECORD_MATCHED_COMPARE_NOTE.md",
-        [
-            "residual branch-overlap structure",
-            "competitive middle",
-            "matched bounded slice",
-        ],
-    )
-
-
-def production_row_checks() -> None:
-    section("Production-row checks")
-    rows = list(json.loads(LEDGER.read_text())["rows"].values())
-    selected = [
-        row
-        for row in rows
-        if row_map.prev.scoped(row)
-        and row_map.prev.classify(row) == "production_dynamics_needed"
-        and row_map.mapped_row(row)["lane"] == "persistent_record_production_overlap"
-    ]
-    ids = {row.get("claim_id") for row in selected}
-    expected = {
-        "persistent_record_matched_compare_note",
-        "persistent_record_overlap_kernel_note",
-        "persistent_record_refinement_note",
+def kernel_properties(targets: TargetCarrier, kernel: KernelPacket) -> dict[str, bool]:
+    labels = carrier_labels(targets, "target carrier")
+    values = kernel_map(targets, kernel)
+    return {
+        "symmetric": all(
+            values[(left, right)] == values[(right, left)]
+            for left in labels
+            for right in labels
+        ),
+        "positive_unit_bounded": all(Fraction(0) < value <= 1 for value in values.values()),
+        "self_one": all(values[(label, label)] == 1 for label in labels),
     }
-    report("persistent-record production row count is current snapshot", len(selected) == 3, str(ids))
-    report("persistent-record production row ids match", ids == expected, str(ids))
 
 
-def bridge_checks() -> None:
-    section("Supplied bridge checks")
-    law = supplied_word_law()
-    report("supplied pre-record law is normalized", validate_law(law), str(law))
-    dist = pushforward(law)
-    report("post-record pushforward distribution is normalized", sum(dist.values(), Fraction(0)) == 1, str(dist))
-    report("pushforward has expected support size", len(dist) == 4, str(dist))
-    report("post-record states carry no probability internally", all(record_has_no_probability(record) for record in dist), str(list(dist)))
+def lcm(left: int, right: int) -> int:
+    return abs(left * right) // gcd(left, right) if left and right else 0
 
-    history = [initial_record()]
-    record = initial_record()
-    for hit in ("R", "L", "L"):
-        record = write_record(record, hit)
-        history.append(record)
-    monotone_counts = all(
-        history[i][0] <= history[i + 1][0] and history[i][1] <= history[i + 1][1]
-        for i in range(len(history) - 1)
+
+def independent_probability_entries(
+    packet: ProbabilityPacket,
+) -> tuple[tuple[str, Fraction], ...]:
+    if type(packet) is not tuple or len(packet) == 0:
+        raise ValueError("independent probability carrier is empty or non-tuple")
+    checked: list[tuple[str, Fraction]] = []
+    labels: list[str] = []
+    for item in packet:
+        if type(item) is not tuple or len(item) != 2:
+            raise TypeError("independent malformed probability entry")
+        raw_label, raw_value = item
+        if type(raw_label) is not str or raw_label == "":
+            raise TypeError("independent probability identifier is not a strict string")
+        if raw_label in labels:
+            raise ValueError("independent duplicate probability identifier")
+        if type(raw_value) is not Fraction:
+            raise TypeError("independent probability value is not a strict Fraction")
+        if raw_value < 0:
+            raise ValueError("independent probability value is negative")
+        labels.append(raw_label)
+        checked.append((raw_label, raw_value))
+    denominator = 1
+    for _, value in checked:
+        denominator = lcm(denominator, value.denominator)
+    integer_total = sum(
+        value.numerator * (denominator // value.denominator)
+        for _, value in checked
     )
-    persistent_marker = all(item[2] in {"none", "R"} for item in history)
-    report("record counts are monotone under supplied update", monotone_counts, str(history))
-    report("first-hit marker persists under supplied update", persistent_marker, str(history))
-
-    records = list(dist)
-    symmetric = all(overlap_kernel(a, b) == overlap_kernel(b, a) for a in records for b in records)
-    self_one = all(overlap_kernel(a, a) == 1 for a in records)
-    bounded = all(Fraction(0) < overlap_kernel(a, b) <= 1 for a in records for b in records)
-    report("supplied overlap kernel is symmetric", symmetric)
-    report("supplied overlap kernel is self-normalized", self_one)
-    report("supplied overlap kernel is bounded in (0,1]", bounded)
-
-    ov = expected_overlap(dist)
-    report("law-scoped expected overlap is exact rational", ov == Fraction(169, 320), str(ov))
-    report("invalid supplied law is rejected", not validate_law({("L",): Fraction(2)}))
+    if integer_total != denominator:
+        raise ValueError("independent probability is not normalized")
+    return tuple(checked)
 
 
-def firewall_checks() -> None:
-    section("Firewall flags")
-    audit_data_written = False
-    audit_verdict_applied = False
-    promoted_or_retained_claim = False
-    record_writing_law_derived_from_record = False
-    production_kernel_selected = False
-    physical_arrow_derived_from_record = False
-    born_law_derived_from_record = False
-    generation_or_koide_dial_selected = False
-    stable_setting_selects_dial = False
+def independent_target_labels(targets: TargetCarrier) -> tuple[str, ...]:
+    if type(targets) is not tuple or len(targets) == 0:
+        raise ValueError("independent target carrier is empty or non-tuple")
+    labels: list[str] = []
+    for target in targets:
+        if type(target) is not str or target == "":
+            raise TypeError("independent target identifier is not a strict string")
+        if target in labels:
+            raise ValueError("independent duplicate target identifier")
+        labels.append(target)
+    return tuple(labels)
 
-    report("audit data written flag is false", not audit_data_written)
-    report("audit verdict applied flag is false", not audit_verdict_applied)
-    report("promoted/retained claim flag is false", not promoted_or_retained_claim)
-    report("record-writing law derived from Record flag is false", not record_writing_law_derived_from_record)
-    report("production kernel selected flag is false", not production_kernel_selected)
-    report("Record-derived physical arrow flag is false", not physical_arrow_derived_from_record)
-    report("Record-derived Born law flag is false", not born_law_derived_from_record)
-    report("generation/Koide dial selected flag is false", not generation_or_koide_dial_selected)
-    report("stable setting selects dial flag is false", not stable_setting_selects_dial)
+
+def independent_mapping_entries(
+    probability: ProbabilityPacket,
+    targets: TargetCarrier,
+    mapping: MapPacket,
+) -> tuple[tuple[str, str], ...]:
+    source = independent_probability_entries(probability)
+    target_labels = independent_target_labels(targets)
+    if type(mapping) is not tuple or len(mapping) == 0:
+        raise ValueError("independent map is empty or non-tuple")
+    checked: list[tuple[str, str]] = []
+    mapped_sources: list[str] = []
+    for item in mapping:
+        if type(item) is not tuple or len(item) != 2:
+            raise TypeError("independent malformed map entry")
+        raw_source, raw_target = item
+        if type(raw_source) is not str or not raw_source:
+            raise TypeError("independent map source is not a strict string")
+        if type(raw_target) is not str or not raw_target:
+            raise TypeError("independent map target is not a strict string")
+        if raw_source in mapped_sources:
+            raise ValueError("independent map source is repeated")
+        if raw_target not in target_labels:
+            raise ValueError("independent map target is outside carrier")
+        mapped_sources.append(raw_source)
+        checked.append((raw_source, raw_target))
+    if sorted(mapped_sources) != sorted(label for label, _ in source):
+        raise ValueError("independent map is not total on the source carrier")
+    return tuple(checked)
+
+
+def independent_observable_entries(
+    targets: TargetCarrier,
+    observable: ObservablePacket,
+) -> tuple[tuple[str, Fraction], ...]:
+    target_labels = independent_target_labels(targets)
+    if type(observable) is not tuple or len(observable) == 0:
+        raise ValueError("independent observable is empty or non-tuple")
+    checked: list[tuple[str, Fraction]] = []
+    labels: list[str] = []
+    for item in observable:
+        if type(item) is not tuple or len(item) != 2:
+            raise TypeError("independent malformed observable entry")
+        raw_label, raw_value = item
+        if type(raw_label) is not str or not raw_label:
+            raise TypeError("independent observable target is not a strict string")
+        if raw_label in labels:
+            raise ValueError("independent duplicate observable target")
+        if type(raw_value) is not Fraction:
+            raise TypeError("independent observable value is not a strict Fraction")
+        labels.append(raw_label)
+        checked.append((raw_label, raw_value))
+    if sorted(labels) != sorted(target_labels):
+        raise ValueError("independent observable domain mismatch")
+    return tuple(checked)
+
+
+def independent_kernel_entries(
+    targets: TargetCarrier,
+    kernel: KernelPacket,
+) -> tuple[tuple[str, str, Fraction], ...]:
+    target_labels = independent_target_labels(targets)
+    if type(kernel) is not tuple or len(kernel) == 0:
+        raise ValueError("independent kernel is empty or non-tuple")
+    checked: list[tuple[str, str, Fraction]] = []
+    pairs: list[tuple[str, str]] = []
+    for item in kernel:
+        if type(item) is not tuple or len(item) != 3:
+            raise TypeError("independent malformed kernel entry")
+        raw_left, raw_right, raw_value = item
+        if type(raw_left) is not str or not raw_left:
+            raise TypeError("independent kernel left target is not a strict string")
+        if type(raw_right) is not str or not raw_right:
+            raise TypeError("independent kernel right target is not a strict string")
+        if type(raw_value) is not Fraction:
+            raise TypeError("independent kernel value is not a strict Fraction")
+        pair = (raw_left, raw_right)
+        if pair in pairs:
+            raise ValueError("independent duplicate kernel pair")
+        pairs.append(pair)
+        checked.append((raw_left, raw_right, raw_value))
+    expected = [(left, right) for left in target_labels for right in target_labels]
+    if sorted(pairs) != sorted(expected):
+        raise ValueError("independent kernel domain mismatch")
+    return tuple(checked)
+
+
+def independent_common_counts(
+    probability: ProbabilityPacket,
+) -> tuple[tuple[tuple[str, int], ...], int]:
+    entries = independent_probability_entries(probability)
+    denominator = 1
+    for _, value in entries:
+        denominator = lcm(denominator, value.denominator)
+    counts = tuple(
+        (label, value.numerator * (denominator // value.denominator))
+        for label, value in entries
+    )
+    return counts, denominator
+
+
+def independent_lookup_image(mapping: tuple[tuple[str, str], ...], source: str) -> str:
+    matches = [target for candidate, target in mapping if candidate == source]
+    if len(matches) != 1:
+        raise ValueError("independent map lookup is not single-valued")
+    return matches[0]
+
+
+def independent_lookup_observable(
+    observable: tuple[tuple[str, Fraction], ...], target: str
+) -> Fraction:
+    matches = [value for candidate, value in observable if candidate == target]
+    if len(matches) != 1:
+        raise ValueError("independent observable lookup is not single-valued")
+    return matches[0]
+
+
+def independent_lookup_kernel(
+    kernel: tuple[tuple[str, str, Fraction], ...], left: str, right: str
+) -> Fraction:
+    matches = [
+        value
+        for candidate_left, candidate_right, value in kernel
+        if candidate_left == left and candidate_right == right
+    ]
+    if len(matches) != 1:
+        raise ValueError("independent kernel lookup is not single-valued")
+    return matches[0]
+
+
+def pushforward_independently(
+    probability: ProbabilityPacket,
+    targets: TargetCarrier,
+    mapping: MapPacket,
+) -> ProbabilityPacket:
+    target_labels = independent_target_labels(targets)
+    map_entries = independent_mapping_entries(probability, targets, mapping)
+    source_counts, denominator = independent_common_counts(probability)
+    output: list[tuple[str, Fraction]] = []
+    for target in target_labels:
+        mass_count = sum(
+            count
+            for source, count in source_counts
+            if independent_lookup_image(map_entries, source) == target
+        )
+        output.append((target, Fraction(mass_count, denominator)))
+    return tuple(output)
+
+
+def observable_transport_independently(
+    probability: ProbabilityPacket,
+    targets: TargetCarrier,
+    mapping: MapPacket,
+    observable: ObservablePacket,
+) -> tuple[Fraction, Fraction]:
+    map_entries = independent_mapping_entries(probability, targets, mapping)
+    observable_entries = independent_observable_entries(targets, observable)
+    source_counts, denominator = independent_common_counts(probability)
+    pushed = pushforward_independently(probability, targets, mapping)
+    target_total = sum(
+        (
+            mass
+            * independent_lookup_observable(observable_entries, target)
+            for target, mass in pushed
+        ),
+        Fraction(0),
+    )
+    source_numerator = sum(
+        (
+            Fraction(count, denominator)
+            * independent_lookup_observable(
+                observable_entries,
+                independent_lookup_image(map_entries, source),
+            )
+            for source, count in source_counts
+        ),
+        Fraction(0),
+    )
+    return target_total, source_numerator
+
+
+def kernel_transport_independently(
+    probability: ProbabilityPacket,
+    targets: TargetCarrier,
+    mapping: MapPacket,
+    kernel: KernelPacket,
+) -> tuple[Fraction, Fraction]:
+    map_entries = independent_mapping_entries(probability, targets, mapping)
+    kernel_entries = independent_kernel_entries(targets, kernel)
+    source_counts, denominator = independent_common_counts(probability)
+    pushed = pushforward_independently(probability, targets, mapping)
+    target_total = sum(
+        (
+            left_mass
+            * right_mass
+            * independent_lookup_kernel(kernel_entries, left, right)
+            for left, left_mass in pushed
+            for right, right_mass in pushed
+        ),
+        Fraction(0),
+    )
+    source_total = sum(
+        (
+            Fraction(left_count * right_count, denominator * denominator)
+            * independent_lookup_kernel(
+                kernel_entries,
+                independent_lookup_image(map_entries, left),
+                independent_lookup_image(map_entries, right),
+            )
+            for left, left_count in source_counts
+            for right, right_count in source_counts
+        ),
+        Fraction(0),
+    )
+    return target_total, source_total
+
+
+def expect_raises(
+    error_types: type[Exception] | tuple[type[Exception], ...],
+    operation: Callable[[], object],
+) -> bool:
+    try:
+        operation()
+    except error_types:
+        return True
+    except Exception:
+        return False
+    return False
+
+
+def source_scope_checks() -> None:
+    section("Source theorem and semantic scope checks")
+    report("source note exists", NOTE.is_file())
+    text = NOTE.read_text(encoding="utf-8")
+    flat = " ".join(text.split())
+    required = (
+        "**Claim type:** positive_theorem",
+        "**Dependencies:** none.",
+        "Q(y) = sum_{x in X : F(x)=y} P(x).",
+        "sum_{x in X} P(x) h(F(x)).",
+        "sum_{x,x' in X} P(x) P(x') K(F(x),F(x')).",
+        "The map must be total on `X`; its image may be a proper subset of `Y`.",
+        "The legacy path name is an identifier",
+        "repository metadata outside the theorem arguments",
+    )
+    for phrase in required:
+        report(f"source contains theorem anchor: {phrase}", phrase in flat)
+    forbidden_patterns = (
+        r"persistent_record_production_overlap` rows",
+        r"production row map has exactly three",
+        r"frontier_post_record_audit_evidence_ladder_row_bucketing_2026_06_06\.py",
+        r"frontier_post_record_production_dynamics_needed_row_map_2026_06_06\.py",
+        r"docs/audit/data/",
+        r"\baudit_status\s*:",
+        r"\beffective_status\s*:",
+        r"\bRecord (?:derives|supplies|selects|fixes)\b",
+        r"\bphysical (?:production|record-writing) (?:law|kernel) (?:is|follows)\b",
+        r"PERSISTENT_RECORD_PRODUCTION_OVERLAP_ROWS",
+        r"SUPPLIED_RECORD_WRITING_BRIDGE_PROTOTYPE",
+    )
+    for pattern in forbidden_patterns:
+        report(
+            f"source excludes stale or physical overclaim: {pattern}",
+            re.search(pattern, flat, flags=re.IGNORECASE) is None,
+        )
+
+
+def simple_example() -> tuple[
+    ProbabilityPacket,
+    TargetCarrier,
+    MapPacket,
+    ObservablePacket,
+    KernelPacket,
+]:
+    probability = (
+        ("a", Fraction(1, 2)),
+        ("b", Fraction(1, 3)),
+        ("c", Fraction(1, 6)),
+    )
+    targets = ("red", "blue", "unused")
+    mapping = (("b", "red"), ("c", "blue"), ("a", "red"))
+    observable = (
+        ("unused", Fraction(11)),
+        ("blue", Fraction(5)),
+        ("red", Fraction(-2)),
+    )
+    kernel = tuple(
+        (
+            left,
+            right,
+            Fraction(
+                (1 if left <= right else -1) * (left_index + 2 * right_index + 1),
+                left_index + right_index + 1,
+            ),
+        )
+        for left_index, left in enumerate(targets)
+        for right_index, right in enumerate(targets)
+    )
+    return probability, targets, mapping, observable, kernel
+
+
+def word_example() -> tuple[ProbabilityPacket, TargetCarrier, MapPacket, KernelPacket]:
+    probability = (
+        ("LL", Fraction(1, 2)),
+        ("LR", Fraction(1, 4)),
+        ("RL", Fraction(1, 8)),
+        ("RR", Fraction(1, 8)),
+    )
+    targets = ("2:0:L", "1:1:L", "1:1:R", "0:2:R")
+    mapping = (
+        ("LL", "2:0:L"),
+        ("LR", "1:1:L"),
+        ("RL", "1:1:R"),
+        ("RR", "0:2:R"),
+    )
+
+    def coordinates(label: str) -> tuple[int, int, str]:
+        left, right, marker = label.split(":")
+        return int(left), int(right), marker
+
+    kernel_entries: list[tuple[str, str, Fraction]] = []
+    for left_label in targets:
+        left_count, right_count, left_marker = coordinates(left_label)
+        for right_label in targets:
+            other_left, other_right, right_marker = coordinates(right_label)
+            distance = (
+                (left_count - other_left) ** 2
+                + (right_count - other_right) ** 2
+                + (0 if left_marker == right_marker else 1)
+            )
+            kernel_entries.append((left_label, right_label, Fraction(1, 1 + distance)))
+    return probability, targets, mapping, tuple(kernel_entries)
+
+
+def update_count_state(state: CountState, symbol: str) -> CountState:
+    left, right, marker = state
+    if symbol == "L":
+        return min(2, left + 1), right, "L" if marker == "none" else marker
+    if symbol == "R":
+        return left, min(2, right + 1), "R" if marker == "none" else marker
+    raise ValueError("count update symbol must be L or R")
+
+
+def normal_checks() -> None:
+    probability, targets, mapping, observable, kernel = simple_example()
+    section("Exact finite pushforward")
+    pushed = pushforward(probability, targets, mapping)
+    expected = (
+        ("red", Fraction(5, 6)),
+        ("blue", Fraction(1, 6)),
+        ("unused", Fraction(0)),
+    )
+    report("colliding fibers sum exactly", pushed == expected, str(pushed))
+    report("pushforward is nonnegative", all(value >= 0 for _, value in pushed))
+    report(
+        "pushforward is normalized exactly",
+        sum((value for _, value in pushed), Fraction(0)) == 1,
+    )
+    report("unused target is retained with zero mass", dict(pushed)["unused"] == 0)
+    report("pushforward verifies by target-label semantics", verify_pushforward(probability, targets, mapping, pushed))
+
+    section("Observable pullback identity")
+    target_value = target_expectation(pushed, targets, observable)
+    source_value = source_pullback_expectation(probability, targets, mapping, observable)
+    report("signed observable target expectation is exact", target_value == Fraction(-5, 6), str(target_value))
+    report("observable pullback identity is exact", target_value == source_value, str(source_value))
+
+    section("Arbitrary product-kernel transport")
+    target_kernel_value = target_kernel_expectation(pushed, targets, kernel)
+    source_kernel_value = source_kernel_expectation(probability, targets, mapping, kernel)
+    properties = kernel_properties(targets, kernel)
+    report("arbitrary signed asymmetric kernel transports exactly", target_kernel_value == source_kernel_value, str(target_kernel_value))
+    report("transport theorem does not require symmetry", not properties["symmetric"])
+    report("transport theorem does not require unit bounds", not properties["positive_unit_bounded"])
+    report("transport theorem does not require diagonal one", not properties["self_one"])
+
+    section("Defined word/count example")
+    word_probability, word_targets, word_mapping, word_kernel = word_example()
+    word_pushed = pushforward(word_probability, word_targets, word_mapping)
+    word_properties = kernel_properties(word_targets, word_kernel)
+    overlap = target_kernel_expectation(word_pushed, word_targets, word_kernel)
+    overlap_source = source_kernel_expectation(word_probability, word_targets, word_mapping, word_kernel)
+    report("word/count image packet is exact", word_pushed == tuple((target, value) for target, (_, value) in zip(word_targets, word_probability)), str(word_pushed))
+    report("defined word kernel is symmetric", word_properties["symmetric"])
+    report("defined word kernel is positive and at most one", word_properties["positive_unit_bounded"])
+    report("defined word kernel equals one on the diagonal", word_properties["self_one"])
+    report("defined word example product expectation is 169/320", overlap == Fraction(169, 320), str(overlap))
+    report("word example also closes through source-product transport", overlap == overlap_source)
+
+    state: CountState = (0, 0, "none")
+    history = [state]
+    for symbol in ("R", "L", "L", "R"):
+        state = update_count_state(state, symbol)
+        history.append(state)
+    report(
+        "defined capped counts are componentwise nondecreasing",
+        all(
+            history[index][0] <= history[index + 1][0]
+            and history[index][1] <= history[index + 1][1]
+            for index in range(len(history) - 1)
+        ),
+        str(history),
+    )
+    report(
+        "defined first marker is unchanged after its first assignment",
+        history[1][2] == "R" and all(item[2] == "R" for item in history[1:]),
+        str(history),
+    )
+
+    section("Ordering and carrier permutations")
+    permuted_probability = tuple(reversed(probability))
+    permuted_targets = (targets[1], targets[2], targets[0])
+    permuted_mapping = tuple(reversed(mapping))
+    permuted_observable = tuple(reversed(observable))
+    permuted_kernel = tuple(reversed(kernel))
+    permuted_pushed = pushforward(permuted_probability, permuted_targets, permuted_mapping)
+    report("pushforward is permutation-equivariant by target label", equal_by_label(permuted_pushed, pushed))
+    report(
+        "observable identity is permutation-invariant",
+        source_pullback_expectation(permuted_probability, permuted_targets, permuted_mapping, permuted_observable)
+        == target_value,
+    )
+    report(
+        "kernel identity is permutation-invariant",
+        source_kernel_expectation(permuted_probability, permuted_targets, permuted_mapping, permuted_kernel)
+        == target_kernel_value,
+    )
+
+
+def generated_cases() -> tuple[
+    tuple[ProbabilityPacket, TargetCarrier, MapPacket, ObservablePacket, KernelPacket], ...
+]:
+    cases: list[
+        tuple[ProbabilityPacket, TargetCarrier, MapPacket, ObservablePacket, KernelPacket]
+    ] = []
+    for source_size in range(1, 6):
+        for target_size in range(1, 5):
+            for variant in range(3):
+                source_labels = tuple(f"s{source_size}_{index}" for index in range(source_size))
+                targets = tuple(f"t{target_size}_{index}" for index in range(target_size))
+                counts = [
+                    (index + 1) * (variant + 2) + ((source_size + index + variant) % 3)
+                    for index in range(source_size)
+                ]
+                if source_size >= 3:
+                    counts[(source_size + variant) % source_size] = 0
+                total = sum(counts)
+                probability = tuple(
+                    (label, Fraction(count, total))
+                    for label, count in zip(source_labels, counts)
+                )
+                mapping = tuple(
+                    (
+                        source,
+                        targets[(index * (variant + 1) + source_size + variant) % target_size],
+                    )
+                    for index, source in enumerate(source_labels)
+                )
+                observable = tuple(
+                    (
+                        target,
+                        Fraction(
+                            (-1 if (index + variant) % 2 else 1) * (index + variant + 2),
+                            variant + 1,
+                        ),
+                    )
+                    for index, target in enumerate(targets)
+                )
+                kernel = tuple(
+                    (
+                        left,
+                        right,
+                        Fraction(
+                            (-1 if (left_index + 2 * right_index + variant) % 2 else 1)
+                            * (left_index + right_index + variant + 1),
+                            left_index + 2 * right_index + 1,
+                        ),
+                    )
+                    for left_index, left in enumerate(targets)
+                    for right_index, right in enumerate(targets)
+                )
+                cases.append((probability, targets, mapping, observable, kernel))
+    return tuple(cases)
+
+
+def independent_checks() -> None:
+    section("Independent reconstruction of the defined word/count example")
+    word_probability, word_targets, word_mapping, word_kernel = word_example()
+    word_primary = pushforward(word_probability, word_targets, word_mapping)
+    word_independent = pushforward_independently(
+        word_probability, word_targets, word_mapping
+    )
+    word_target, word_source = kernel_transport_independently(
+        word_probability, word_targets, word_mapping, word_kernel
+    )
+    report(
+        "independent word/count pushforward agrees by label",
+        equal_by_label(word_independent, word_primary),
+        str(word_independent),
+    )
+    report(
+        "independent target-product example equals 169/320",
+        word_target == Fraction(169, 320),
+        str(word_target),
+    )
+    report(
+        "independent source-product example equals 169/320",
+        word_source == Fraction(169, 320),
+        str(word_source),
+    )
+
+    section("Independent common-denominator finite-family oracle")
+    cases = generated_cases()
+    primary_independent_pushforward = True
+    normalized = True
+    observable_primary = True
+    observable_independent = True
+    kernel_primary = True
+    kernel_independent = True
+    permutation_equivariance = True
+    for probability, targets, mapping, observable, kernel in cases:
+        primary = pushforward(probability, targets, mapping)
+        independent = pushforward_independently(probability, targets, mapping)
+        primary_independent_pushforward &= equal_by_label(primary, independent)
+        normalized &= sum((value for _, value in independent), Fraction(0)) == 1
+
+        primary_target_observable = target_expectation(primary, targets, observable)
+        primary_source_observable = source_pullback_expectation(
+            probability, targets, mapping, observable
+        )
+        independent_target_observable, independent_source_observable = (
+            observable_transport_independently(probability, targets, mapping, observable)
+        )
+        observable_primary &= primary_target_observable == primary_source_observable
+        observable_independent &= (
+            independent_target_observable
+            == independent_source_observable
+            == primary_target_observable
+        )
+
+        primary_target_kernel = target_kernel_expectation(primary, targets, kernel)
+        primary_source_kernel = source_kernel_expectation(
+            probability, targets, mapping, kernel
+        )
+        independent_target_kernel, independent_source_kernel = (
+            kernel_transport_independently(probability, targets, mapping, kernel)
+        )
+        kernel_primary &= primary_target_kernel == primary_source_kernel
+        kernel_independent &= (
+            independent_target_kernel
+            == independent_source_kernel
+            == primary_target_kernel
+        )
+
+        permuted_probability = tuple(reversed(probability))
+        permuted_targets = tuple(reversed(targets))
+        permuted_mapping = tuple(reversed(mapping))
+        permuted_observable = tuple(reversed(observable))
+        permuted_kernel = tuple(reversed(kernel))
+        permuted = pushforward_independently(
+            permuted_probability, permuted_targets, permuted_mapping
+        )
+        permutation_equivariance &= equal_by_label(permuted, primary)
+        permuted_observable_pair = observable_transport_independently(
+            permuted_probability,
+            permuted_targets,
+            permuted_mapping,
+            permuted_observable,
+        )
+        permuted_kernel_pair = kernel_transport_independently(
+            permuted_probability,
+            permuted_targets,
+            permuted_mapping,
+            permuted_kernel,
+        )
+        permutation_equivariance &= (
+            permuted_observable_pair[0] == primary_target_observable
+            and permuted_observable_pair[1] == primary_target_observable
+            and permuted_kernel_pair[0] == primary_target_kernel
+            and permuted_kernel_pair[1] == primary_target_kernel
+        )
+
+    report("independent oracle exercises sixty finite theorem instances", len(cases) == 60)
+    report("independent integer-count pushforwards agree by label", primary_independent_pushforward)
+    report("all independent pushforwards remain normalized", normalized)
+    report("all primary observable identities close", observable_primary)
+    report("all independently coded observable identities close", observable_independent)
+    report("all primary product-kernel identities close", kernel_primary)
+    report("all independently coded product-kernel identities close", kernel_independent)
+    report("all independent tuple permutations preserve theorem values", permutation_equivariance)
+
+    section("Independent malformed-domain checks")
+    probability, targets, mapping, observable, kernel = simple_example()
+    report(
+        "independent route rejects incomplete map",
+        expect_raises(
+            ValueError,
+            lambda: pushforward_independently(probability, targets, mapping[:-1]),
+        ),
+    )
+    report(
+        "independent route rejects inexact probability",
+        expect_raises(
+            TypeError,
+            lambda: pushforward_independently(
+                (("a", Fraction(1, 2)), ("b", 0.5)),  # type: ignore[arg-type]
+                ("y",),
+                (("a", "y"), ("b", "y")),
+            ),
+        ),
+    )
+    report(
+        "independent route rejects incomplete observable",
+        expect_raises(
+            ValueError,
+            lambda: observable_transport_independently(
+                probability, targets, mapping, observable[:-1]
+            ),
+        ),
+    )
+    report(
+        "independent route rejects incomplete kernel",
+        expect_raises(
+            ValueError,
+            lambda: kernel_transport_independently(
+                probability, targets, mapping, kernel[:-1]
+            ),
+        ),
+    )
+
+
+def scope_authorizes(conclusion: str) -> bool:
+    return conclusion in frozenset(
+        {
+            "finite_deterministic_pushforward",
+            "finite_observable_pullback",
+            "finite_product_kernel_transport",
+            "defined_count_update_monotonicity",
+        }
+    )
+
+
+def hostile_mutation_acceptance(name: str) -> bool:
+    probability, targets, mapping, observable, kernel = simple_example()
+    if name == "empty-law":
+        return not expect_raises(ValueError, lambda: pushforward((), targets, ()))
+    if name == "unnormalized-law":
+        bad = (("a", Fraction(1, 2)), ("b", Fraction(1, 3)))
+        return not expect_raises(ValueError, lambda: pushforward(bad, ("y",), (("a", "y"), ("b", "y"))))
+    if name == "negative-law":
+        bad = (("a", Fraction(3, 2)), ("b", Fraction(-1, 2)))
+        return not expect_raises(ValueError, lambda: pushforward(bad, ("y",), (("a", "y"), ("b", "y"))))
+    if name == "float-law":
+        bad = (("a", Fraction(1, 2)), ("b", 0.5))
+        return not expect_raises(TypeError, lambda: pushforward(bad, ("y",), (("a", "y"), ("b", "y"))))  # type: ignore[arg-type]
+    if name == "integer-law":
+        bad = (("a", Fraction(0)), ("b", 1))
+        return not expect_raises(TypeError, lambda: pushforward(bad, ("y",), (("a", "y"), ("b", "y"))))  # type: ignore[arg-type]
+    if name == "bool-law":
+        bad = (("a", Fraction(0)), ("b", True))
+        return not expect_raises(TypeError, lambda: pushforward(bad, ("y",), (("a", "y"), ("b", "y"))))  # type: ignore[arg-type]
+    if name == "fraction-subclass-law":
+        bad = (("a", Fraction(1, 2)), ("b", FractionSubclass(1, 2)))
+        return not expect_raises(TypeError, lambda: pushforward(bad, ("y",), (("a", "y"), ("b", "y"))))  # type: ignore[arg-type]
+    if name == "duplicate-source":
+        bad = (("a", Fraction(1, 2)), ("a", Fraction(1, 2)))
+        return not expect_raises(ValueError, lambda: pushforward(bad, ("y",), (("a", "y"),)))
+    if name == "empty-target-carrier":
+        return not expect_raises(ValueError, lambda: pushforward((("a", Fraction(1)),), (), (("a", "y"),)))
+    if name == "duplicate-target-carrier":
+        return not expect_raises(ValueError, lambda: pushforward((("a", Fraction(1)),), ("y", "y"), (("a", "y"),)))
+    if name == "incomplete-map":
+        return not expect_raises(ValueError, lambda: pushforward(probability, targets, mapping[:-1]))
+    if name == "map-extra-source":
+        bad_map = mapping + (("ghost", "red"),)
+        return not expect_raises(ValueError, lambda: pushforward(probability, targets, bad_map))
+    if name == "map-target-outside":
+        bad_map = (("a", "red"), ("b", "blue"), ("c", "ghost"))
+        return not expect_raises(ValueError, lambda: pushforward(probability, targets, bad_map))
+    if name == "nonexact-map-source":
+        bad_map = ((1, "red"), ("b", "red"), ("c", "blue"))
+        return not expect_raises(TypeError, lambda: pushforward(probability, targets, bad_map))  # type: ignore[arg-type]
+    if name == "nonexact-map-target":
+        bad_map = (("a", 1), ("b", "red"), ("c", "blue"))
+        return not expect_raises(TypeError, lambda: pushforward(probability, targets, bad_map))  # type: ignore[arg-type]
+    if name == "duplicate-map-source":
+        bad_map = (("a", "red"), ("a", "blue"), ("c", "blue"))
+        return not expect_raises(ValueError, lambda: pushforward(probability, targets, bad_map))
+    if name == "observable-missing-target":
+        return not expect_raises(ValueError, lambda: source_pullback_expectation(probability, targets, mapping, observable[:-1]))
+    if name == "observable-extra-target":
+        bad = observable + (("ghost", Fraction(0)),)
+        return not expect_raises(ValueError, lambda: source_pullback_expectation(probability, targets, mapping, bad))
+    if name == "observable-inexact":
+        bad = (("red", Fraction(0)), ("blue", Fraction(0)), ("unused", 0.0))
+        return not expect_raises(TypeError, lambda: source_pullback_expectation(probability, targets, mapping, bad))  # type: ignore[arg-type]
+    if name == "kernel-missing-pair":
+        return not expect_raises(ValueError, lambda: source_kernel_expectation(probability, targets, mapping, kernel[:-1]))
+    if name == "kernel-extra-pair":
+        bad = kernel + (("red", "ghost", Fraction(0)),)
+        return not expect_raises(ValueError, lambda: source_kernel_expectation(probability, targets, mapping, bad))
+    if name == "kernel-duplicate-pair":
+        bad = kernel + (kernel[0],)
+        return not expect_raises(ValueError, lambda: source_kernel_expectation(probability, targets, mapping, bad))
+    if name == "kernel-inexact":
+        bad = kernel[:-1] + ((kernel[-1][0], kernel[-1][1], 0.5),)
+        return not expect_raises(TypeError, lambda: source_kernel_expectation(probability, targets, mapping, bad))  # type: ignore[arg-type]
+    if name == "wrong-pushforward":
+        candidate = (("red", Fraction(1, 6)), ("blue", Fraction(5, 6)), ("unused", Fraction(0)))
+        return verify_pushforward(probability, targets, mapping, candidate)
+    if name == "omitted-collision":
+        candidate = (("red", Fraction(1, 2)), ("blue", Fraction(1, 6)), ("unused", Fraction(1, 3)))
+        return verify_pushforward(probability, targets, mapping, candidate)
+    if name == "wrong-expectation":
+        pushed = pushforward(probability, targets, mapping)
+        mutated = sum((value for _, value in observable), Fraction(0))
+        return mutated == target_expectation(pushed, targets, observable)
+    if name == "wrong-pullback":
+        values = dict(observable)
+        mutated = sum(
+            (mass * values[target] for (_, mass), target in zip(probability, targets)),
+            Fraction(0),
+        )
+        return mutated == source_pullback_expectation(probability, targets, mapping, observable)
+    if name == "diagonal-only-product":
+        pushed = pushforward(probability, targets, mapping)
+        masses = dict(pushed)
+        values = kernel_map(targets, kernel)
+        mutated = sum((masses[target] * values[(target, target)] for target in targets), Fraction(0))
+        return mutated == target_kernel_expectation(pushed, targets, kernel)
+    if name == "additive-product-probability":
+        probabilities = dict(probability)
+        images = deterministic_map(probability, targets, mapping)
+        values = kernel_map(targets, kernel)
+        mutated = sum(
+            (
+                (probabilities[left] + probabilities[right])
+                * values[(images[left], images[right])]
+                for left in probabilities
+                for right in probabilities
+            ),
+            Fraction(0),
+        )
+        return mutated == source_kernel_expectation(probability, targets, mapping, kernel)
+    if name == "carrier-permutation-bug":
+        small_probability = (("a", Fraction(1, 4)), ("b", Fraction(3, 4)))
+        small_targets = ("left", "right")
+        permuted_map = (("b", "left"), ("a", "right"))
+        broken = tuple(
+            (target, mass)
+            for (_, mass), (_, target) in zip(small_probability, permuted_map)
+        )
+        return equal_by_label(
+            broken,
+            pushforward(small_probability, small_targets, permuted_map),
+        )
+    if name == "asymmetric-kernel-certified":
+        return kernel_properties(targets, kernel)["symmetric"]
+    if name == "unbounded-kernel-certified":
+        return kernel_properties(targets, kernel)["positive_unit_bounded"]
+    if name == "nonself-kernel-certified":
+        return kernel_properties(targets, kernel)["self_one"]
+    if name == "physical-selection-inference":
+        return scope_authorizes("physical_record_production_selected")
+    raise KeyError(f"unknown hostile fixture: {name}")
+
+
+HOSTILE_FIXTURES = (
+    "empty-law",
+    "unnormalized-law",
+    "negative-law",
+    "float-law",
+    "integer-law",
+    "bool-law",
+    "fraction-subclass-law",
+    "duplicate-source",
+    "empty-target-carrier",
+    "duplicate-target-carrier",
+    "incomplete-map",
+    "map-extra-source",
+    "map-target-outside",
+    "nonexact-map-source",
+    "nonexact-map-target",
+    "duplicate-map-source",
+    "observable-missing-target",
+    "observable-extra-target",
+    "observable-inexact",
+    "kernel-missing-pair",
+    "kernel-extra-pair",
+    "kernel-duplicate-pair",
+    "kernel-inexact",
+    "wrong-pushforward",
+    "omitted-collision",
+    "wrong-expectation",
+    "wrong-pullback",
+    "diagonal-only-product",
+    "additive-product-probability",
+    "carrier-permutation-bug",
+    "asymmetric-kernel-certified",
+    "unbounded-kernel-certified",
+    "nonself-kernel-certified",
+    "physical-selection-inference",
+)
+
+
+def hostile_checks() -> None:
+    section("Hostile mutation rejection")
+    for name in HOSTILE_FIXTURES:
+        accepted = hostile_mutation_acceptance(name)
+        report(f"hostile mutation rejected: {name}", not accepted)
+
+
+def intentional_failure_checks(fixture: str) -> None:
+    section("Intentional hostile failure controls")
+    selected = HOSTILE_FIXTURES if fixture == "all" else (fixture,)
+    for name in selected:
+        accepted = hostile_mutation_acceptance(name)
+        report(
+            f"intentional false acceptance must fail: {name}",
+            accepted,
+            "mutation did not satisfy the exact theorem contract",
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=("normal", "independent", "hostile", "intentional-failure"),
+        default="normal",
+    )
+    aliases = parser.add_mutually_exclusive_group()
+    aliases.add_argument("--independent", action="store_true", help="alias for --mode independent")
+    aliases.add_argument("--hostile", action="store_true", help="alias for --mode hostile")
+    parser.add_argument("--fixture", choices=("all",) + HOSTILE_FIXTURES, default="all")
+    args = parser.parse_args()
+    if args.independent:
+        if args.mode != "normal":
+            parser.error("--independent cannot combine with explicit non-normal --mode")
+        args.mode = "independent"
+    if args.hostile:
+        if args.mode != "normal":
+            parser.error("--hostile cannot combine with explicit non-normal --mode")
+        args.mode = "hostile"
+    if args.fixture != "all" and args.mode != "intentional-failure":
+        parser.error("--fixture requires --mode intentional-failure")
+    return args
 
 
 def main() -> int:
-    source_anchor_checks()
-    production_row_checks()
-    bridge_checks()
-    firewall_checks()
-    print()
-    print(f"SUMMARY: PASS={PASS} FAIL={FAIL}")
-    print("PERSISTENT_RECORD_PRODUCTION_OVERLAP_ROWS=3")
-    print("SUPPLIED_RECORD_WRITING_BRIDGE_PROTOTYPE=TRUE")
-    print("POST_RECORD_STATE_HAS_INTERNAL_PROBABILITY=FALSE")
-    print("RECORD_WRITING_LAW_DERIVED_FROM_RECORD=FALSE")
-    print("PRODUCTION_KERNEL_SELECTED=FALSE")
-    print("PHYSICAL_ARROW_DERIVED_FROM_RECORD=FALSE")
-    print("BORN_LAW_DERIVED_FROM_RECORD=FALSE")
-    print("GENERATION_OR_KOIDE_DIAL_SELECTED=FALSE")
-    print("STABLE_SETTING_SELECTS_DIAL=FALSE")
-    print("AUDIT_LEDGER_WRITTEN=FALSE")
-    print("AUDIT_VERDICT_APPLIED=FALSE")
+    args = parse_args()
+    source_scope_checks()
+    if args.mode == "normal":
+        normal_checks()
+    elif args.mode == "independent":
+        independent_checks()
+    elif args.mode == "hostile":
+        hostile_checks()
+    else:
+        intentional_failure_checks(args.fixture)
+    print(f"\nSUMMARY: MODE={args.mode} PASS={PASS} FAIL={FAIL}")
+    print("THEOREM_SCOPE=EXACT_FINITE_DETERMINISTIC_PUSHFORWARD_OBSERVABLE_AND_PRODUCT_KERNEL_TRANSPORT")
     return 0 if FAIL == 0 else 1
 
 

--- a/scripts/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.py
+++ b/scripts/frontier_post_record_persistent_record_production_bridge_prototype_2026_06_06.py
@@ -976,17 +976,6 @@ def independent_checks() -> None:
     )
 
 
-def scope_authorizes(conclusion: str) -> bool:
-    return conclusion in frozenset(
-        {
-            "finite_deterministic_pushforward",
-            "finite_observable_pullback",
-            "finite_product_kernel_transport",
-            "defined_count_update_monotonicity",
-        }
-    )
-
-
 def hostile_mutation_acceptance(name: str) -> bool:
     probability, targets, mapping, observable, kernel = simple_example()
     if name == "empty-law":
@@ -1108,7 +1097,15 @@ def hostile_mutation_acceptance(name: str) -> bool:
     if name == "nonself-kernel-certified":
         return kernel_properties(targets, kernel)["self_one"]
     if name == "physical-selection-inference":
-        return scope_authorizes("physical_record_production_selected")
+        return not expect_raises(
+            TypeError,
+            lambda: pushforward(
+                probability,
+                targets,
+                mapping,
+                physical_record_production="selected",  # type: ignore[call-arg]
+            ),
+        )
     raise KeyError(f"unknown hostile fixture: {name}")
 
 


### PR DESCRIPTION
## Summary

- Rewrites the persistent-record production prototype as a dependency-free exact finite deterministic pushforward theorem.
- Proves exact nonnegativity and normalization of `Q(y)=sum_{F(x)=y}P(x)`, signed-observable pullback transport, and full product-kernel transport for arbitrary exact rational `K:Y x Y -> Q`.
- Keeps `169/320` only as a defined word/count combinatorial example and proves the associated capped-count monotonicity lemma without assigning physical meaning.
- Removes row-census, dynamic row-map, ledger, helper, audit-hash, export, and production-bridge coupling.
- Replaces the runner with strict exact-runtime/domain validation, an independently coded common-denominator route, hostile controls, and selectable intentional failures.

## Claim boundary

The conclusion is finite probability algebra only. The probability packet, total deterministic map, observable, and kernel are explicit theorem arguments. Physical records, formation, production, persistence, transition laws, priors, Born weights, instruments, dynamics, Hamiltonians, clocks, rates, arrows, selectors, and dial interpretations remain separate model premises.

A fresh citation graph at the reviewed head gives dependencies `[]`, direct consumers `[]`, and helper runners `[]`. The only textual context beyond inventories is a dated Class-G formation-append sweep; its historical disclaimer classification remains compatible with this narrower theorem.

## Audit repair target (verbatim historical row)

`verdict_rationale`:

> Issue: the finite pushforward and overlap arithmetic are valid for the runner's supplied word law, update, persistence rule, and kernel, but those bridge inputs are assumed rather than derived from the axiom packet. Why this blocks: with no cited retained authority or primitive supplying those inputs, the claim cannot close as a production-record bridge beyond the supplied finite witness. Repair target: a retained theorem deriving or explicitly admitting the record-writing law, persistence/readout rule, and overlap-kernel/production-time bridge. Claim boundary until fixed: the safe result is an exact finite supplied-bridge prototype with law-scoped expected overlap 169/320 and no internal probability field in realized post-record tuples.

`notes_for_re_audit_if_any`:

> missing_bridge_theorem: derive or cite retained record-writing law, persistence rule, and overlap-kernel/production-time bridge, then rerun the finite pushforward certificate.

This repair takes the straightforward non-physical route: it deletes the unsupported production-record bridge claim and preserves the exact finite algebra as a dependency-free theorem.

## Review-loop fix

Review iteration 1 removed a self-confirming hardcoded scope allowlist. The `physical-selection-inference` mutation now makes a real forbidden keyword call to `pushforward(..., physical_record_production="selected")` and is rejected only by the theorem API's `TypeError` boundary. The runner cache was regenerated from that reviewed source.

## Verification

- Exact base: `d4d7cef0836447d3629959b11d36e717cb982f21`
- Exact reviewed head: `b505e221c79f2e3ef798f0b1161cc03e0c2818f7`
- Normal: `PASS=42 FAIL=0`
- Independent: `PASS=35 FAIL=0`
- Hostile: `PASS=54 FAIL=0`
- Intentional failures: all 34 individual fixtures exit 1 with `PASS=20 FAIL=1`; aggregate exits 1 with `PASS=20 FAIL=34`
- External oracle: 8,900 finite cases over carriers up to four sources and three targets, all total maps, normalized count laws, collision/unused-target cases, signed observables, signed asymmetric non-unit kernels, label permutations, exact Unicode labels, malformed domains, and one-point limits
- Independent word/count arithmetic: ordered-pair numerator sum `1014/1920 = 169/320`
- Runner cache: fresh; exact reviewed runner SHA-256 `49dac2559025ffa9abed89adc590303ba0ceb5817eadedf7e1c560828f9501b5`
- Vocabulary lint/render: clean
- Axiom/primitive premise purity: clean; the theorem imports no premise node
- Repository-invariant unit suite: 56 tests passed
- Matched 18-stage validation pipelines: base `31 warnings / 465 notices / 0 errors`; candidate `31 / 464 / 0`
- Matched enforced invariant: both `rows=3754 retained_grade=392 link_violations=0`
- Graph delta: same `3962` nodes, `14489` edges, and `62` known cycles; target remains a root/leaf with no graph edge
- Validation-only candidate reseed: `positive_theorem`, `unaudited`, ready with `queue_reason=unaudited`, dependencies `[]`; the independent audit lane remains the sole verdict authority
- `git diff --check`, portable-link gate, controlled-vocabulary render, and cache freshness: clean

## Audit discipline

This is post-audit repair only. It did not run an audit worker, apply a verdict, or commit generated ledger, queue, graph, dispatch, or effective-status outputs. Both matched pipeline worktrees are disposable; generated outputs are excluded from the PR. The normal audit pipeline will independently reprocess the changed row after landing.

READY — review-loop PASS at exact head `b505e221c79f2e3ef798f0b1161cc03e0c2818f7`.
