### PR TITLE
science-fix: formalize six-arm projector algebra

### DIFF
--- a/docs/QUARK_ROUTE2_DOUBLE_LOCAL_PROJECTOR_NORMALIZATION_BRIDGE_CONDITIONAL_NOTE_2026-06-21.md
+++ b/docs/QUARK_ROUTE2_DOUBLE_LOCAL_PROJECTOR_NORMALIZATION_BRIDGE_CONDITIONAL_NOTE_2026-06-21.md
@@ -1,100 +1,174 @@
-# Route-2 Double-Local Projector Normalization: Exact Conditional Bridge to `rho_E = 21/4`, with Falsifiers for the Nearby Weaker Laws
+# Exact Signed-Axis Projector Decomposition and Integer-Monomial Theorem
 
 **Date:** 2026-06-21
-**Claim type:** bounded_theorem
-**Claim scope:** conditional-support / exact support boundary
-**Status authority:** independent audit lane only. This source note does not set, claim, or predict an audit outcome.
-**Actual current-surface status:** conditional-support
-**Trace class:** upstream_support
-**Reachability to target:** supports the open Route-2 endpoint by isolating the exact nonseparable primitive that would close it; does not derive that primitive.
-**Primary runner:** [`scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py`](../scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py)
-**Runner cache:** [`logs/runner-cache/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.txt`](../logs/runner-cache/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.txt)
+**Type:** positive_theorem
+**Claim type:** positive_theorem
+**Status authority:** independent audit lane only. This source note does not set or predict an audit outcome.
+**Primary runner:**
+[`scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py`](../scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py)
+**Cached log:**
+[`logs/runner-cache/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.txt`](../logs/runner-cache/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.txt)
+**Dependencies:** none. The carrier, group action, rational arguments, and
+integer exponent below are definitions or universally quantified theorem
+arguments, not framework premises.
 
-## Problem
+## 1. Defined six-arm representation
 
-The Route-2 endpoint target reduces to
-
-```text
-q_T = 5/6,
-q_E = 15/8,
-lambda := q_E/q_T = 9/4,
-rho_E = 6(q_E - 1) = 21/4.
-```
-
-The existing same-domain shell leverage result gives
+Let
 
 ```text
-w_E = 1/3,
-w_T1 = 1/2,
-kappa = w_T1/w_E = 3/2,
-kappa^2 = 9/4.
+Omega = {+x,-x,+y,-y,+z,-z},                 V = Q^Omega.
 ```
 
-The existing covariance no-go stack shows that the value `9/4` is present, but the bridge `lambda = kappa^2` is not forced by `O_h` equivariance, the channel-blind carrier, positivity, the box-size limit, or a generic quadratic invariant.
+Define `B_3` to be the set of all `3 x 3` signed permutation matrices. It
+acts on `Omega` by ordinary matrix multiplication and therefore on `V` by
+permuting coordinates. Direct enumeration gives `3! 2^3 = 48` distinct group
+elements: 24 have determinant `+1` and 24 have determinant `-1`. The runner
+checks all products, inverses, signed-axis images, unique matrices, and all
+`48^2` representation products exactly.
 
-## Stretch Attempt
+This is an explicitly defined finite representation. The labels `A1`, `E`,
+and `T1` below are names for three displayed rational subspaces; they carry no
+physical identification.
 
-This block asks what exact local projector-weight law would close the bridge if it were supplied as a named primitive.
+## 2. Exact orthogonal projectors
 
-For a monomial local-weight law
+Let `R` exchange each signed axis with its antipode, let `S=(I+R)/2`, and
+let `J` be the all-ones `6 x 6` matrix. Define
 
 ```text
-q_X proportional to w_X^p,
+P_A1 = J/6,                 P_E = S - P_A1,                 P_T1 = I - S.
 ```
 
-the covariance is
+Their images have the following mutually orthogonal bases:
 
 ```text
-lambda = q_E/q_T = (w_E/w_T1)^p = (2/3)^p.
+A1: (1,1,1,1,1,1),
+ E: (1,1,-1,-1,0,0), (1,1,1,1,-2,-2),
+T1: (1,-1,0,0,0,0), (0,0,1,-1,0,0), (0,0,0,0,1,-1).
 ```
 
-The runner checks the nearby candidate laws:
-
-| candidate law | exponent `p` | `lambda` | endpoint result |
-|---|---:|---:|---|
-| channel-blind lift | `0` | `1` | misses |
-| raw local projector weight | `1` | `2/3` | misses |
-| raw quadratic projector weight | `2` | `4/9` | misses |
-| single reciprocal local normalization | `-1` | `3/2` | misses |
-| double reciprocal local normalization | `-2` | `9/4` | closes conditionally |
-
-Thus the exact conditional bridge is:
+The six basis vectors are linearly independent, so they span `V`. Direct
+multiplication proves
 
 ```text
-q_X proportional to w_X^-2.
+P_X^T = P_X,                P_X^2 = P_X,
+P_X P_Y = 0  (X != Y),      P_A1 + P_E + P_T1 = I.
 ```
 
-Equivalently, the missing primitive is a double-local projector normalization: one reciprocal local projector weight is not enough; the target needs two reciprocal local-weight factors.
+Thus these are the unique orthogonal projectors onto the three displayed
+subspaces. They commute with every matrix in the defined `B_3` action. Their
+exact ranks, traces, and diagonal entries are
 
-## Conditional Consequence
+| projector | rank | trace | every diagonal entry |
+|---|---:|---:|---:|
+| `P_A1` | `1` | `1` | `1/6` |
+| `P_E` | `2` | `2` | `1/3` |
+| `P_T1` | `3` | `3` | `1/2` |
 
-If a future proof derives that double-local projector normalization from named Route-2 source/tensor/readout structure, then the endpoint chain closes exactly:
+No floating-point reconstruction is used: the runner stores every projector
+entry as an exact `Fraction` and separately reconstructs the matrices from the
+three orthogonal bases.
+
+## 3. Integer-exponent monomial family
+
+For supplied positive rationals `u,v` and any supplied integer `p`, define
 
 ```text
-lambda = (w_E/w_T1)^-2 = 9/4,
-q_E = lambda q_T = (9/4)(5/6) = 15/8,
-rho_E = 6(q_E - 1) = 21/4,
-center T/E = -2 q_T/q_E = -8/9.
+lambda_p(u,v) = (u/v)^p.
 ```
 
-This is conditional support, not an actual current-surface derivation. The primitive is not derived here.
+Negative exponents use the ordinary exact reciprocal power. In the formal
+instance `u=1/3`, `v=1/2`, one has `u/v=2/3`, and
 
-## Falsifiers
+```text
+lambda_p(1/3,1/2) = 9/4    if and only if    p = -2.
+```
 
-The runner records three sharp falsifiers:
+This is a statement over all integers, not a finite scan. Let `nu_2` be the
+2-adic valuation on positive rationals. Equality would imply
 
-1. all one-factor/raw local projector-weight variants miss `lambda=9/4`;
-2. among monomial laws `q_X proportional to w_X^p` with `|p| <= 6`, the unique target exponent is `p=-2`;
-3. nearby center-excess denominator slips (`5`, `7`, `12` instead of the exact `6`) do not close the endpoint chain.
+```text
+p = p nu_2(2/3) = nu_2(9/4) = -2,
+```
 
-## Net
+because `nu_2(2/3)=1`. Conversely, direct exact exponentiation at `p=-2`
+gives `(2/3)^-2=9/4`. The independent oracle repeats the proof with the
+3-adic valuation: `nu_3(2/3)=-1` and `nu_3(9/4)=2`, again forcing `p=-2`.
 
-The open target is no longer vague. A positive proof must derive the double-local reciprocal projector-weight law, or an equivalent nonseparable E/T center-shell covariance primitive. Any route that supplies only one local normalization factor, a raw projector weight, a raw quadratic weight, or a generic equivariant quadratic form cannot close the endpoint.
+The equivalence classifies one equation inside the defined monomial family.
+It does not select an exponent for any application and does not turn that
+integer into a law.
 
-## Scope
+## 4. Supplied affine arithmetic
 
-This does not prove that the double-local normalization primitive is true. It also does not prove impossibility over arbitrary future nonlinear observables. It isolates the exact primitive that would close the current endpoint algebra and records which nearby local-weight laws fail.
+For supplied exact rationals `lambda,q,d`, define
 
-## Forbidden-Imports Check
+```text
+q' = lambda q,                       rho = d(q' - 1).
+```
 
-No observed masses, fitted targets, or PDG values are consumed. The calculation uses the exact six-arm `O_h` projector weights and exact endpoint algebra. The rationals `5/6`, `15/8`, `9/4`, `-8/9`, and `21/4` appear only as the already-named Route-2 endpoint targets.
+This is an identity by definition. For the exact worked example
+
+```text
+lambda=9/4, q=5/6, d=6  ->  q'=15/8, rho=21/4.
+```
+
+The example is rational arithmetic only. The theorem does not identify these
+arguments with a physical quantity and does not predict a physical endpoint.
+
+## 5. Exact scope and application boundary
+
+The theorem proves only the following finite mathematical facts:
+
+1. the displayed signed-axis matrices form a 48-element group and an exact
+   six-point permutation representation;
+2. the three displayed matrices are the orthogonal projectors onto the three
+   displayed subspaces, with ranks and diagonal entries as stated;
+3. the defined rational monomial equation has the unique integer solution
+   `p=-2`; and
+4. the displayed affine formulas evaluate exactly on supplied arguments.
+
+It does not select an exponent, does not select a normalization, does not
+identify a physical source or readout, and does not predict a physical
+endpoint. In particular, it supplies no law relating physical channel values
+to projector diagonals, no source or tensor functional, no center-shell
+covariance, no normalization rule, and no interpretation of `q'` or `rho`.
+Any application must state those additional premises separately.
+
+The theorem is invariant under audit censuses, queues, ledgers, row counts,
+and other repository metadata. Those inventories are not theorem arguments.
+
+## 6. Falsification and reproducibility
+
+The standard-library runner provides:
+
+- a normal exact construction with full group/cardinality/closure checks,
+  projector idempotence, orthogonality, ranks, traces, diagonal values, basis
+  action, and two prime-valuation uniqueness certificates;
+- an independently coded antipodal-pair action enumeration, orthogonal-basis
+  projector oracle, integer numerator/denominator power oracle over 54 varied
+  rational cases, and affine common-denominator oracle; and
+- hostile mutations for projector perturbations, non-idempotence,
+  nonorthogonality, wrong ranks/weights, group incompleteness, booleans,
+  floats, subclasses, nonpositive inputs, malformed and scan-only uniqueness
+  evidence, false endpoints, and physical source claims that assert exponent
+  or normalization selection.
+
+Every individual intentional-failure fixture and the aggregate exit nonzero.
+Run:
+
+```bash
+python3 scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py
+python3 scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py --independent
+python3 scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py --hostile
+python3 scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py --mode intentional-failure --fixture all
+```
+
+The cached log records the default normal run.
+
+## 7. Consumer boundary
+
+The fresh citation graph has no direct claim consumer of this note. A future
+consumer may use only the exact finite identities above and must provide any
+physical interpretation or selection rule as a separate premise.

--- a/logs/runner-cache/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.txt
+++ b/logs/runner-cache/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py
-runner_sha256: 0776c74f094d4bccabc21401292dab9be391f52c7a76ea456b3f721ed4965f16
+runner_sha256: 7769aafcb309fe2ac7dc1ccbc14690f3fd5ef20a46fd490bc5027c64f5678c34
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.49
+elapsed_sec: 0.54
 status: ok
 ----- stdout -----
 Exact signed-axis projector decomposition and integer-monomial theorem
@@ -15,7 +15,7 @@ Source and implementation boundary
 PASS source note declares a dependency-free positive theorem
 PASS source note denies exponent, normalization, source, and endpoint selection
 PASS implementation uses no numerical-array or float-recovery path
-PASS formal inputs alone authorize no physical application claim
+PASS formal APIs expose no physical selection inputs
 
 ------------------------------------------------------------------------------
 Exact signed-axis group and representation

--- a/logs/runner-cache/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.txt
+++ b/logs/runner-cache/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.txt
@@ -1,39 +1,48 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py
-runner_sha256: e34d06d57fc118b8f19198487aab301b2af447ea82bd2c72b65b66e8e150bada
+runner_sha256: 0776c74f094d4bccabc21401292dab9be391f52c7a76ea456b3f721ed4965f16
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.14
+elapsed_sec: 0.49
 status: ok
 ----- stdout -----
-Route-2 double-local projector-normalization conditional bridge
-======================================================================================
-[EXACT] PASS: the six-arm O_h projector weights are exact and give kappa=3/2
-    w_A1=1/6, w_E=1/3, w_T1=1/2, kappa=w_T1/w_E=3/2
+Exact signed-axis projector decomposition and integer-monomial theorem
+MODE=normal
 
-Candidate local-weight laws
-law                                      exponent p   lambda=(w_E/w_T1)^p   hits target
---------------------------------------------------------------------------------------------------
-channel-blind lift                              0               1              False
-raw local projector weight                      1             2/3              False
-raw quadratic projector weight                  2             4/9              False
-single reciprocal local normalization          -1             3/2              False
-double reciprocal local normalization          -2             9/4              True
-[FALSIFIER] PASS: all one-factor/raw local projector-weight variants miss lambda=9/4
-    channel-blind lift misses; raw local projector weight misses; raw quadratic projector weight misses; single reciprocal local normalization misses; hit=double reciprocal local normalization
-[CONDITIONAL] PASS: conditional on the double reciprocal local normalization primitive, the endpoint chain closes exactly
-    lambda=9/4 -> q_E=15/8, rho_E=21/4, center T/E=-8/9
-[EXACT] PASS: within monomial laws q_X proportional to w_X^p for |p|<=6, p=-2 is the unique target exponent
-    target exponents in [-6,6]: [-2]
-[FIREWALL] PASS: the double reciprocal law is a primitive candidate, not a consequence of equivariance
-    channel_blind lambda=1; target lambda=9/4; single_reciprocal lambda=3/2; raw_quadratic lambda=4/9
-[FALSIFIER] PASS: nearby center-excess denominator slips do not close the endpoint chain
-    d=5: q_E=41/20, center T/E=-100/123; d=7: q_E=7/4, center T/E=-20/21; d=12: q_E=23/16, center T/E=-80/69
+------------------------------------------------------------------------------
+Source and implementation boundary
+------------------------------------------------------------------------------
+PASS source note declares a dependency-free positive theorem
+PASS source note denies exponent, normalization, source, and endpoint selection
+PASS implementation uses no numerical-array or float-recovery path
+PASS formal inputs alone authorize no physical application claim
 
-Verdict:
-The exact positive target is now isolated: a double reciprocal local projector-normalization primitive would give lambda=q_E/q_T=9/4 and hence rho_E=21/4.  The adjacent one-factor, raw, and quadratic variants miss.  The primitive is not derived here; it is the named remaining bridge that a future positive proof must justify.
+------------------------------------------------------------------------------
+Exact signed-axis group and representation
+------------------------------------------------------------------------------
+PASS the full signed-axis group has 48 unique elements, closure, and 24+24 determinant split
+PASS the induced six-arm permutation matrices form an exact representation
+PASS the antipodal-pair action is transitive on all six arms
 
-TOTAL: PASS=6 FAIL=0
+------------------------------------------------------------------------------
+Exact orthogonal projector decomposition
+------------------------------------------------------------------------------
+PASS A1, E, and T1 are mutually orthogonal projectors summing to identity
+PASS projector ranks and traces are exactly 1, 2, and 3
+PASS all diagonal weights are exactly 1/6, 1/3, and 1/2
+PASS pair parity gives P_even=P_A1+P_E and P_T1=I-P_even
+PASS the six displayed orthogonal basis vectors determine the projectors uniquely
+
+------------------------------------------------------------------------------
+Integer monomial and affine arithmetic
+------------------------------------------------------------------------------
+PASS for u=1/3 and v=1/2, lambda_p=(u/v)^p is exact for negative powers
+PASS the 2-adic certificate proves lambda_p=9/4 iff p=-2 over every integer
+PASS the independent 3-adic certificate gives the same unique exponent
+PASS the supplied affine example gives q'=15/8 and rho=21/4 exactly
+
+SUMMARY: MODE=normal PASS=16 FAIL=0
+THEOREM_SCOPE=DEFINED_SIX_ARM_PROJECTORS_INTEGER_MONOMIAL_AND_AFFINE_ARITHMETIC
 
 ----- stderr -----
 

--- a/scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py
+++ b/scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py
@@ -1,204 +1,998 @@
 #!/usr/bin/env python3
-"""Route-2 double-local projector-normalization conditional bridge.
+"""Exact signed-axis projector decomposition and integer-monomial theorem.
 
-This is a stretch attempt on the nonseparable E/T covariance primitive exposed
-by the Route-2 q_E no-go stack.  It does not adopt a new primitive.  It records
-the exact condition under which the covariance bridge would close:
+The historical filename is preserved for claim-graph continuity.  The theorem
+is finite rational algebra on an explicitly defined six-element carrier.  It
+does not select a physical exponent, normalization, source, readout, or
+endpoint.
 
-    q_X must scale as w_X^{-2},
-
-where w_X is the local per-arm projector weight for the E or T1 channel on the
-six-arm O_h star.  Since w_E=1/3 and w_T=1/2, this gives
-
-    q_E/q_T = (w_E/w_T)^{-2} = 9/4.
-
-The runner also falsifies the nearby one-factor and raw quadratic variants.
-No observed masses, fitted targets, or audit verdicts are used.
+Modes:
+  default                              exact construction and proof checks
+  --independent                        independently coded exact oracles
+  --hostile                            reject every hostile mutation
+  --mode intentional-failure --fixture NAME|all
+                                       install mutations and exit nonzero
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import argparse
 from fractions import Fraction
-import itertools
-
-import numpy as np
-
-
-TARGET_QT = Fraction(5, 6)
-TARGET_QE = Fraction(15, 8)
-TARGET_LAMBDA = Fraction(9, 4)
-TARGET_RHO_E = Fraction(21, 4)
-
-ARMS = [(1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)]
-AIDX = {a: i for i, a in enumerate(ARMS)}
+from itertools import permutations, product
+from pathlib import Path
+import re
+import sys
+from typing import Callable, TypeAlias
 
 
-@dataclass
-class Check:
-    name: str
-    ok: bool
-    detail: str
-    status: str
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs/QUARK_ROUTE2_DOUBLE_LOCAL_PROJECTOR_NORMALIZATION_BRIDGE_CONDITIONAL_NOTE_2026-06-21.md"
+
+IntVector3: TypeAlias = tuple[int, int, int]
+IntMatrix3: TypeAlias = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+QVector: TypeAlias = tuple[Fraction, ...]
+QMatrix: TypeAlias = tuple[tuple[Fraction, ...], ...]
+ExponentCertificate: TypeAlias = tuple[int, int, int, int]
+
+PASS = 0
+FAIL = 0
+
+ARMS: tuple[IntVector3, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+ARM_INDEX = {arm: index for index, arm in enumerate(ARMS)}
 
 
-CHECKS: list[Check] = []
+class FractionSubclass(Fraction):
+    """Hostile fixture: exact-looking subclasses are outside the contract."""
 
 
-def record(name: str, ok: bool, detail: str, status: str = "EXACT") -> None:
-    CHECKS.append(Check(name=name, ok=ok, detail=detail, status=status))
-    tag = "PASS" if ok else "FAIL"
-    print(f"[{status}] {tag}: {name}")
-    if detail:
-        print(f"    {detail}")
+class IntSubclass(int):
+    """Hostile fixture: integer subclasses are outside the contract."""
 
 
-def oh_group() -> list[np.ndarray]:
-    mats: list[np.ndarray] = []
-    for perm in itertools.permutations(range(3)):
-        for signs in itertools.product((1, -1), repeat=3):
-            m = np.zeros((3, 3), dtype=int)
-            for row in range(3):
-                m[row, perm[row]] = signs[row]
-            mats.append(m)
-    return mats
+def report(label: str, ok: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if ok:
+        PASS += 1
+        tag = "PASS"
+    else:
+        FAIL += 1
+        tag = "FAIL"
+    suffix = f" :: {detail}" if detail else ""
+    print(f"{tag} {label}{suffix}")
 
 
-def arm_rep(m: np.ndarray) -> np.ndarray:
-    p = np.zeros((6, 6), dtype=float)
-    for arm in ARMS:
-        image = tuple(int(x) for x in (m @ np.array(arm)))
-        p[AIDX[image], AIDX[arm]] = 1.0
-    return p
+def section(title: str) -> None:
+    print(f"\n{'-' * 78}\n{title}\n{'-' * 78}")
 
 
-def fraction_from_float(value: float) -> Fraction:
-    return Fraction(value).limit_denominator(10_000)
+def exact_fraction(value: object, context: str, *, positive: bool = False) -> Fraction:
+    if type(value) is not Fraction:
+        raise TypeError(f"{context} must have exact runtime type Fraction")
+    if positive and value <= 0:
+        raise ValueError(f"{context} must be positive")
+    return value
 
 
-def projector_weights() -> tuple[Fraction, Fraction, Fraction]:
-    reps = [arm_rep(m) for m in oh_group()]
-    p_a1 = sum(reps) / len(reps)
-    antipodal = arm_rep(-np.eye(3, dtype=int))
-    p_t1 = (np.eye(6) - antipodal) / 2.0
-    p_e = (np.eye(6) + antipodal) / 2.0 - p_a1
-    return (
-        fraction_from_float(p_a1[0, 0]),
-        fraction_from_float(p_e[0, 0]),
-        fraction_from_float(p_t1[0, 0]),
+def exact_integer(value: object, context: str) -> int:
+    if type(value) is not int:
+        raise TypeError(f"{context} must have exact runtime type int")
+    return value
+
+
+def strict_qmatrix(value: object, dimension: int = 6) -> QMatrix:
+    if type(value) is not tuple or len(value) != dimension:
+        raise TypeError(f"matrix must be a {dimension}-row tuple")
+    rows: list[tuple[Fraction, ...]] = []
+    for row in value:
+        if type(row) is not tuple or len(row) != dimension:
+            raise TypeError(f"matrix rows must be {dimension}-entry tuples")
+        checked = tuple(exact_fraction(entry, "matrix entry") for entry in row)
+        rows.append(checked)
+    return tuple(rows)
+
+
+def strict_qvector(value: object, dimension: int = 6) -> QVector:
+    if type(value) is not tuple or len(value) != dimension:
+        raise TypeError(f"vector must be a {dimension}-entry tuple")
+    return tuple(exact_fraction(entry, "vector entry") for entry in value)
+
+
+def qzero(dimension: int) -> QMatrix:
+    return tuple(
+        tuple(Fraction(0) for _ in range(dimension)) for _ in range(dimension)
     )
 
 
-def lambda_for_exponent(power: int, w_e: Fraction, w_t: Fraction) -> Fraction:
-    ratio = w_e / w_t
-    if power >= 0:
-        return ratio**power
-    return Fraction(1, 1) / (ratio ** abs(power))
+def qidentity(dimension: int) -> QMatrix:
+    return tuple(
+        tuple(Fraction(int(row == column)) for column in range(dimension))
+        for row in range(dimension)
+    )
 
 
-def endpoint_chain(lambda_value: Fraction) -> tuple[Fraction, Fraction, Fraction]:
-    q_e = lambda_value * TARGET_QT
-    rho_e = 6 * (q_e - 1)
-    center_te = Fraction(-2, 1) * TARGET_QT / q_e
-    return q_e, rho_e, center_te
+def qadd(left: QMatrix, right: QMatrix) -> QMatrix:
+    left = strict_qmatrix(left, len(left))
+    right = strict_qmatrix(right, len(left))
+    return tuple(
+        tuple(left[i][j] + right[i][j] for j in range(len(left)))
+        for i in range(len(left))
+    )
+
+
+def qsub(left: QMatrix, right: QMatrix) -> QMatrix:
+    left = strict_qmatrix(left, len(left))
+    right = strict_qmatrix(right, len(left))
+    return tuple(
+        tuple(left[i][j] - right[i][j] for j in range(len(left)))
+        for i in range(len(left))
+    )
+
+
+def qmul(left: QMatrix, right: QMatrix) -> QMatrix:
+    left = strict_qmatrix(left, len(left))
+    right = strict_qmatrix(right, len(left))
+    dimension = len(left)
+    return tuple(
+        tuple(
+            sum((left[i][k] * right[k][j] for k in range(dimension)), Fraction(0))
+            for j in range(dimension)
+        )
+        for i in range(dimension)
+    )
+
+
+def qtranspose(matrix: QMatrix) -> QMatrix:
+    matrix = strict_qmatrix(matrix, len(matrix))
+    return tuple(tuple(matrix[j][i] for j in range(len(matrix))) for i in range(len(matrix)))
+
+
+def qmatvec(matrix: QMatrix, vector: QVector) -> QVector:
+    matrix = strict_qmatrix(matrix, len(matrix))
+    vector = strict_qvector(vector, len(matrix))
+    return tuple(
+        sum((matrix[i][j] * vector[j] for j in range(len(matrix))), Fraction(0))
+        for i in range(len(matrix))
+    )
+
+
+def qrank(matrix: QMatrix) -> int:
+    checked = strict_qmatrix(matrix, len(matrix))
+    work = [list(row) for row in checked]
+    rows = len(work)
+    columns = len(work[0])
+    pivot_row = 0
+    for column in range(columns):
+        pivot = next((row for row in range(pivot_row, rows) if work[row][column] != 0), None)
+        if pivot is None:
+            continue
+        work[pivot_row], work[pivot] = work[pivot], work[pivot_row]
+        scale = work[pivot_row][column]
+        work[pivot_row] = [entry / scale for entry in work[pivot_row]]
+        for row in range(rows):
+            if row == pivot_row:
+                continue
+            factor = work[row][column]
+            if factor:
+                work[row] = [
+                    work[row][j] - factor * work[pivot_row][j] for j in range(columns)
+                ]
+        pivot_row += 1
+        if pivot_row == rows:
+            break
+    return pivot_row
+
+
+def qtrace(matrix: QMatrix) -> Fraction:
+    matrix = strict_qmatrix(matrix, len(matrix))
+    return sum((matrix[i][i] for i in range(len(matrix))), Fraction(0))
+
+
+def replace_entry(matrix: QMatrix, row: int, column: int, value: Fraction) -> QMatrix:
+    matrix = strict_qmatrix(matrix, len(matrix))
+    exact_fraction(value, "replacement")
+    return tuple(
+        tuple(value if (i, j) == (row, column) else matrix[i][j] for j in range(len(matrix)))
+        for i in range(len(matrix))
+    )
+
+
+def int3_identity() -> IntMatrix3:
+    return ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+
+def strict_int3_matrix(value: object) -> IntMatrix3:
+    if type(value) is not tuple or len(value) != 3:
+        raise TypeError("group matrix must be a three-row tuple")
+    rows: list[tuple[int, int, int]] = []
+    for row in value:
+        if type(row) is not tuple or len(row) != 3:
+            raise TypeError("group matrix rows must be three-entry tuples")
+        checked = tuple(exact_integer(entry, "group matrix entry") for entry in row)
+        rows.append(checked)  # type: ignore[arg-type]
+    return tuple(rows)  # type: ignore[return-value]
+
+
+def int3_mul(left: IntMatrix3, right: IntMatrix3) -> IntMatrix3:
+    left = strict_int3_matrix(left)
+    right = strict_int3_matrix(right)
+    return tuple(
+        tuple(sum(left[i][k] * right[k][j] for k in range(3)) for j in range(3))
+        for i in range(3)
+    )  # type: ignore[return-value]
+
+
+def int3_transpose(matrix: IntMatrix3) -> IntMatrix3:
+    matrix = strict_int3_matrix(matrix)
+    return tuple(tuple(matrix[j][i] for j in range(3)) for i in range(3))  # type: ignore[return-value]
+
+
+def int3_det(matrix: IntMatrix3) -> int:
+    m = strict_int3_matrix(matrix)
+    return (
+        m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+        - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+        + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0])
+    )
+
+
+def int3_matvec(matrix: IntMatrix3, vector: IntVector3) -> IntVector3:
+    matrix = strict_int3_matrix(matrix)
+    if type(vector) is not tuple or len(vector) != 3 or any(type(x) is not int for x in vector):
+        raise TypeError("axis vector must be a strict three-integer tuple")
+    return tuple(sum(matrix[i][j] * vector[j] for j in range(3)) for i in range(3))  # type: ignore[return-value]
+
+
+def signed_axis_group() -> tuple[IntMatrix3, ...]:
+    matrices: list[IntMatrix3] = []
+    for permutation in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows: list[tuple[int, int, int]] = []
+            for row in range(3):
+                rows.append(
+                    tuple(signs[row] if column == permutation[row] else 0 for column in range(3))
+                )
+            matrices.append(tuple(rows))  # type: ignore[arg-type]
+    return tuple(matrices)
+
+
+def is_signed_permutation_matrix(matrix: IntMatrix3) -> bool:
+    try:
+        matrix = strict_int3_matrix(matrix)
+    except (TypeError, ValueError):
+        return False
+    if any(entry not in (-1, 0, 1) for row in matrix for entry in row):
+        return False
+    row_counts = [sum(entry != 0 for entry in row) for row in matrix]
+    column_counts = [sum(matrix[row][column] != 0 for row in range(3)) for column in range(3)]
+    return row_counts == [1, 1, 1] and column_counts == [1, 1, 1]
+
+
+def group_contract(group: object) -> bool:
+    try:
+        if type(group) is not tuple or len(group) != 48:
+            return False
+        checked = tuple(strict_int3_matrix(element) for element in group)
+    except (TypeError, ValueError):
+        return False
+    elements = set(checked)
+    if len(elements) != 48 or any(not is_signed_permutation_matrix(element) for element in checked):
+        return False
+    if int3_identity() not in elements:
+        return False
+    if sum(int3_det(element) == 1 for element in checked) != 24:
+        return False
+    if sum(int3_det(element) == -1 for element in checked) != 24:
+        return False
+    for left in checked:
+        if int3_transpose(left) not in elements or int3_mul(left, int3_transpose(left)) != int3_identity():
+            return False
+        images = tuple(int3_matvec(left, arm) for arm in ARMS)
+        if set(images) != set(ARMS) or len(set(images)) != 6:
+            return False
+        for right in checked:
+            if int3_mul(left, right) not in elements:
+                return False
+    return True
+
+
+def arm_permutation(matrix: IntMatrix3) -> tuple[int, ...]:
+    matrix = strict_int3_matrix(matrix)
+    images: list[int] = []
+    for arm in ARMS:
+        image = int3_matvec(matrix, arm)
+        if image not in ARM_INDEX:
+            raise ValueError("matrix does not preserve the signed-axis carrier")
+        images.append(ARM_INDEX[image])
+    if len(set(images)) != 6:
+        raise ValueError("axis action is not bijective")
+    return tuple(images)
+
+
+def permutation_representation(matrix: IntMatrix3) -> QMatrix:
+    permutation = arm_permutation(matrix)
+    return tuple(
+        tuple(Fraction(int(row == permutation[column])) for column in range(6))
+        for row in range(6)
+    )
+
+
+def representation_homomorphism(group: tuple[IntMatrix3, ...]) -> bool:
+    if not group_contract(group):
+        return False
+    representations = {element: permutation_representation(element) for element in group}
+    return all(
+        representations[int3_mul(left, right)] == qmul(representations[left], representations[right])
+        for left in group
+        for right in group
+    )
+
+
+def direct_projectors() -> tuple[QMatrix, QMatrix, QMatrix, QMatrix]:
+    identity = qidentity(6)
+    constant = tuple(tuple(Fraction(1, 6) for _ in range(6)) for _ in range(6))
+    pair_even = tuple(
+        tuple(Fraction(1, 2) if row // 2 == column // 2 else Fraction(0) for column in range(6))
+        for row in range(6)
+    )
+    even_zero_sum = qsub(pair_even, constant)
+    pair_odd = qsub(identity, pair_even)
+    return constant, even_zero_sum, pair_odd, pair_even
+
+
+def qvector_from_ints(entries: tuple[int, ...]) -> QVector:
+    if type(entries) is not tuple or len(entries) != 6 or any(type(x) is not int for x in entries):
+        raise TypeError("basis vector must be a strict six-integer tuple")
+    return tuple(Fraction(entry) for entry in entries)
+
+
+A1_BASIS = (qvector_from_ints((1, 1, 1, 1, 1, 1)),)
+E_BASIS = (
+    qvector_from_ints((1, 1, -1, -1, 0, 0)),
+    qvector_from_ints((1, 1, 1, 1, -2, -2)),
+)
+T1_BASIS = (
+    qvector_from_ints((1, -1, 0, 0, 0, 0)),
+    qvector_from_ints((0, 0, 1, -1, 0, 0)),
+    qvector_from_ints((0, 0, 0, 0, 1, -1)),
+)
+
+
+def basis_matrix_rank(bases: tuple[tuple[QVector, ...], ...]) -> int:
+    vectors = tuple(vector for basis in bases for vector in basis)
+    matrix = tuple(tuple(vectors[column][row] for column in range(6)) for row in range(6))
+    return qrank(matrix)
+
+
+def projector_action_contract(projectors: tuple[QMatrix, QMatrix, QMatrix]) -> bool:
+    if type(projectors) is not tuple or len(projectors) != 3:
+        return False
+    bases = (A1_BASIS, E_BASIS, T1_BASIS)
+    zero = tuple(Fraction(0) for _ in range(6))
+    for projector_index, projector in enumerate(projectors):
+        for basis_index, basis in enumerate(bases):
+            for vector in basis:
+                expected = vector if projector_index == basis_index else zero
+                if qmatvec(projector, vector) != expected:
+                    return False
+    return basis_matrix_rank(bases) == 6
+
+
+def projector_decomposition_valid(
+    p_a1: object, p_e: object, p_t1: object, group: object
+) -> bool:
+    try:
+        p_a1 = strict_qmatrix(p_a1)
+        p_e = strict_qmatrix(p_e)
+        p_t1 = strict_qmatrix(p_t1)
+        if not group_contract(group):
+            return False
+        checked_group = tuple(strict_int3_matrix(element) for element in group)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return False
+    identity = qidentity(6)
+    zero = qzero(6)
+    projectors = (p_a1, p_e, p_t1)
+    expected_ranks = (1, 2, 3)
+    expected_diagonals = (Fraction(1, 6), Fraction(1, 3), Fraction(1, 2))
+    if qadd(qadd(p_a1, p_e), p_t1) != identity:
+        return False
+    for index, projector in enumerate(projectors):
+        if qtranspose(projector) != projector or qmul(projector, projector) != projector:
+            return False
+        if qrank(projector) != expected_ranks[index] or qtrace(projector) != expected_ranks[index]:
+            return False
+        if tuple(projector[i][i] for i in range(6)) != (expected_diagonals[index],) * 6:
+            return False
+        for representation in map(permutation_representation, checked_group):
+            if qmul(representation, projector) != qmul(projector, representation):
+                return False
+    if any(qmul(projectors[i], projectors[j]) != zero for i in range(3) for j in range(3) if i != j):
+        return False
+    return projector_action_contract(projectors)
+
+
+def dot(left: QVector, right: QVector) -> Fraction:
+    left = strict_qvector(left)
+    right = strict_qvector(right)
+    return sum((a * b for a, b in zip(left, right)), Fraction(0))
+
+
+def independent_basis_projector(basis: tuple[QVector, ...]) -> QMatrix:
+    if type(basis) is not tuple or not basis:
+        raise TypeError("oracle basis must be a nonempty tuple")
+    checked = tuple(strict_qvector(vector) for vector in basis)
+    if any(dot(left, right) != 0 for i, left in enumerate(checked) for right in checked[i + 1 :]):
+        raise ValueError("oracle basis must be orthogonal")
+    if any(dot(vector, vector) == 0 for vector in checked):
+        raise ValueError("oracle basis contains zero")
+    return tuple(
+        tuple(
+            sum(
+                (vector[row] * vector[column] / dot(vector, vector) for vector in checked),
+                Fraction(0),
+            )
+            for column in range(6)
+        )
+        for row in range(6)
+    )
+
+
+def independent_axis_permutations() -> tuple[tuple[int, ...], ...]:
+    actions: list[tuple[int, ...]] = []
+    for pair_permutation in permutations(range(3)):
+        for flips in product((0, 1), repeat=3):
+            action: list[int] = []
+            for source in range(6):
+                source_pair, source_sign = divmod(source, 2)
+                destination_pair = pair_permutation[source_pair]
+                destination_sign = source_sign ^ flips[source_pair]
+                action.append(2 * destination_pair + destination_sign)
+            actions.append(tuple(action))
+    return tuple(actions)
+
+
+def monomial_lambda(u: object, v: object, exponent: object) -> Fraction:
+    u = exact_fraction(u, "u", positive=True)
+    v = exact_fraction(v, "v", positive=True)
+    exponent = exact_integer(exponent, "exponent")
+    return (u / v) ** exponent
+
+
+def independent_monomial_lambda(u: object, v: object, exponent: object) -> Fraction:
+    if type(u) is not Fraction or type(v) is not Fraction:
+        raise TypeError("oracle u and v must be strict Fractions")
+    if u <= 0 or v <= 0:
+        raise ValueError("oracle u and v must be positive")
+    if type(exponent) is not int:
+        raise TypeError("oracle exponent must be a strict int")
+    numerator = u.numerator * v.denominator
+    denominator = u.denominator * v.numerator
+    power = exponent
+    if power < 0:
+        numerator, denominator = denominator, numerator
+        power = -power
+    result_numerator = 1
+    result_denominator = 1
+    for _ in range(power):
+        result_numerator *= numerator
+        result_denominator *= denominator
+    return Fraction(result_numerator, result_denominator)
+
+
+def is_prime(value: object) -> bool:
+    try:
+        value = exact_integer(value, "prime")
+    except TypeError:
+        return False
+    if value < 2:
+        return False
+    divisor = 2
+    while divisor * divisor <= value:
+        if value % divisor == 0:
+            return False
+        divisor += 1
+    return True
+
+
+def integer_valuation(value: int, prime: int) -> int:
+    value = exact_integer(value, "valuation integer")
+    prime = exact_integer(prime, "valuation prime")
+    if value <= 0 or not is_prime(prime):
+        raise ValueError("valuation requires a positive integer and a prime")
+    order = 0
+    while value % prime == 0:
+        value //= prime
+        order += 1
+    return order
+
+
+def rational_valuation(value: object, prime: object) -> int:
+    value = exact_fraction(value, "valuation rational", positive=True)
+    prime = exact_integer(prime, "valuation prime")
+    if not is_prime(prime):
+        raise ValueError("valuation base must be prime")
+    return integer_valuation(value.numerator, prime) - integer_valuation(value.denominator, prime)
+
+
+def make_exponent_certificate(base: object, target: object, prime: object) -> ExponentCertificate:
+    base = exact_fraction(base, "certificate base", positive=True)
+    target = exact_fraction(target, "certificate target", positive=True)
+    prime = exact_integer(prime, "certificate prime")
+    base_order = rational_valuation(base, prime)
+    target_order = rational_valuation(target, prime)
+    if base_order == 0:
+        raise ValueError("chosen valuation cannot certify exponent uniqueness")
+    if target_order % base_order != 0:
+        raise ValueError("target valuation is incompatible with an integer exponent")
+    candidate = target_order // base_order
+    if base**candidate != target:
+        raise ValueError("valuation candidate does not satisfy the exact equation")
+    return prime, base_order, target_order, candidate
+
+
+def verify_exponent_certificate(
+    base: object, target: object, certificate: object
+) -> bool:
+    try:
+        base = exact_fraction(base, "verified base", positive=True)
+        target = exact_fraction(target, "verified target", positive=True)
+        if type(certificate) is not tuple or len(certificate) != 4:
+            return False
+        prime, base_order, target_order, candidate = (
+            exact_integer(entry, "certificate entry") for entry in certificate
+        )
+        expected = make_exponent_certificate(base, target, prime)
+    except (TypeError, ValueError):
+        return False
+    return certificate == expected and base_order * candidate == target_order and base**candidate == target
+
+
+def certified_integer_equivalence(
+    base: object, target: object, exponent: object, certificate: object
+) -> bool:
+    base = exact_fraction(base, "equivalence base", positive=True)
+    target = exact_fraction(target, "equivalence target", positive=True)
+    exponent = exact_integer(exponent, "equivalence exponent")
+    if not verify_exponent_certificate(base, target, certificate):
+        raise ValueError("invalid global uniqueness certificate")
+    prime, base_order, target_order, candidate = certificate  # type: ignore[misc]
+    equality = base**exponent == target
+    if equality and exponent * base_order != target_order:
+        return False
+    return equality == (exponent == candidate)
+
+
+def affine_endpoint(lambda_value: object, q: object, d: object) -> tuple[Fraction, Fraction]:
+    lambda_value = exact_fraction(lambda_value, "lambda")
+    q = exact_fraction(q, "q")
+    d = exact_fraction(d, "d")
+    q_prime = lambda_value * q
+    rho = d * (q_prime - 1)
+    return q_prime, rho
+
+
+def verify_affine_endpoint(
+    lambda_value: object, q: object, d: object, candidate: object
+) -> bool:
+    try:
+        expected = affine_endpoint(lambda_value, q, d)
+        if type(candidate) is not tuple or len(candidate) != 2:
+            return False
+        checked = tuple(exact_fraction(entry, "endpoint candidate") for entry in candidate)
+    except (TypeError, ValueError):
+        return False
+    return checked == expected
+
+
+def independent_affine_endpoint(
+    lambda_value: object, q: object, d: object
+) -> tuple[Fraction, Fraction]:
+    if any(type(value) is not Fraction for value in (lambda_value, q, d)):
+        raise TypeError("oracle affine inputs must be strict Fractions")
+    product_numerator = lambda_value.numerator * q.numerator
+    product_denominator = lambda_value.denominator * q.denominator
+    q_prime = Fraction(product_numerator, product_denominator)
+    difference = Fraction(q_prime.numerator - q_prime.denominator, q_prime.denominator)
+    rho = Fraction(d.numerator * difference.numerator, d.denominator * difference.denominator)
+    return q_prime, rho
+
+
+FORMAL_PREMISES = frozenset(
+    {
+        "defined_signed_axis_carrier",
+        "defined_signed_permutation_action",
+        "finite_rational_linear_algebra",
+        "positive_rational_arguments",
+        "integer_exponent_argument",
+    }
+)
+PHYSICAL_REQUIREMENTS = {
+    "physical exponent selection": frozenset({"physical_weight_law"}),
+    "physical normalization selection": frozenset({"physical_normalization_rule"}),
+    "physical source/readout identification": frozenset({"physical_source_readout_bridge"}),
+    "physical endpoint prediction": frozenset({"physical_endpoint_identification"}),
+}
+
+
+def inference_authorized(conclusion: object, premises: object) -> bool:
+    if type(conclusion) is not str or conclusion not in PHYSICAL_REQUIREMENTS:
+        raise ValueError("unknown physical conclusion")
+    if type(premises) is not frozenset or any(type(item) is not str for item in premises):
+        raise TypeError("premises must be a strict frozenset of strings")
+    return PHYSICAL_REQUIREMENTS[conclusion].issubset(premises)
+
+
+FORBIDDEN_AFFIRMATIVE_SOURCE_PHRASES = (
+    "the theorem selects the physical exponent",
+    "the theorem supplies the physical normalization",
+    "the theorem derives the physical source",
+    "the theorem predicts the physical endpoint",
+)
+
+
+def source_boundary_clean_text(text: object) -> bool:
+    if type(text) is not str:
+        raise TypeError("source text must be a strict string")
+    lowered = text.lower()
+    return not any(phrase in lowered for phrase in FORBIDDEN_AFFIRMATIVE_SOURCE_PHRASES)
+
+
+def source_scope_checks() -> None:
+    section("Source and implementation boundary")
+    note_text = NOTE.read_text()
+    normalized_note = " ".join(note_text.split())
+    runner_text = Path(__file__).read_text()
+    report(
+        "source note declares a dependency-free positive theorem",
+        "**Claim type:** positive_theorem" in note_text
+        and "**Dependencies:** none." in note_text,
+    )
+    report(
+        "source note denies exponent, normalization, source, and endpoint selection",
+        all(
+            marker in normalized_note
+            for marker in (
+                "does not select an exponent",
+                "does not select a normalization",
+                "does not identify a physical source or readout",
+                "does not predict a physical endpoint",
+            )
+        )
+        and source_boundary_clean_text(note_text),
+    )
+    report(
+        "implementation uses no numerical-array or float-recovery path",
+        re.search(r"^\s*(?:from|import)\s+numpy\b", runner_text, re.MULTILINE) is None
+        and ("limit_" + "denominator") not in runner_text
+        and ("d" + "type=float") not in runner_text,
+    )
+    report(
+        "formal inputs alone authorize no physical application claim",
+        all(not inference_authorized(claim, FORMAL_PREMISES) for claim in PHYSICAL_REQUIREMENTS),
+    )
+
+
+def normal_checks() -> None:
+    group = signed_axis_group()
+    p_a1, p_e, p_t1, pair_even = direct_projectors()
+
+    section("Exact signed-axis group and representation")
+    report(
+        "the full signed-axis group has 48 unique elements, closure, and 24+24 determinant split",
+        group_contract(group),
+    )
+    report(
+        "the induced six-arm permutation matrices form an exact representation",
+        representation_homomorphism(group),
+    )
+    report(
+        "the antipodal-pair action is transitive on all six arms",
+        {arm_permutation(element)[0] for element in group} == set(range(6)),
+    )
+
+    section("Exact orthogonal projector decomposition")
+    report(
+        "A1, E, and T1 are mutually orthogonal projectors summing to identity",
+        projector_decomposition_valid(p_a1, p_e, p_t1, group),
+    )
+    report(
+        "projector ranks and traces are exactly 1, 2, and 3",
+        tuple(qrank(projector) for projector in (p_a1, p_e, p_t1)) == (1, 2, 3)
+        and tuple(qtrace(projector) for projector in (p_a1, p_e, p_t1))
+        == (Fraction(1), Fraction(2), Fraction(3)),
+    )
+    report(
+        "all diagonal weights are exactly 1/6, 1/3, and 1/2",
+        tuple(tuple(projector[i][i] for i in range(6)) for projector in (p_a1, p_e, p_t1))
+        == (
+            (Fraction(1, 6),) * 6,
+            (Fraction(1, 3),) * 6,
+            (Fraction(1, 2),) * 6,
+        ),
+    )
+    report(
+        "pair parity gives P_even=P_A1+P_E and P_T1=I-P_even",
+        pair_even == qadd(p_a1, p_e) and p_t1 == qsub(qidentity(6), pair_even),
+    )
+    report(
+        "the six displayed orthogonal basis vectors determine the projectors uniquely",
+        projector_action_contract((p_a1, p_e, p_t1))
+        and basis_matrix_rank((A1_BASIS, E_BASIS, T1_BASIS)) == 6,
+    )
+
+    section("Integer monomial and affine arithmetic")
+    base = Fraction(2, 3)
+    target = Fraction(9, 4)
+    certificate_two = make_exponent_certificate(base, target, 2)
+    certificate_three = make_exponent_certificate(base, target, 3)
+    report(
+        "for u=1/3 and v=1/2, lambda_p=(u/v)^p is exact for negative powers",
+        monomial_lambda(Fraction(1, 3), Fraction(1, 2), -2) == target,
+    )
+    report(
+        "the 2-adic certificate proves lambda_p=9/4 iff p=-2 over every integer",
+        certificate_two == (2, 1, -2, -2)
+        and verify_exponent_certificate(base, target, certificate_two)
+        and all(
+            certified_integer_equivalence(base, target, exponent, certificate_two)
+            for exponent in (-10**6, -3, -2, -1, 0, 1, 10**6)
+        ),
+    )
+    report(
+        "the independent 3-adic certificate gives the same unique exponent",
+        certificate_three == (3, -1, 2, -2)
+        and verify_exponent_certificate(base, target, certificate_three),
+    )
+    report(
+        "the supplied affine example gives q'=15/8 and rho=21/4 exactly",
+        affine_endpoint(Fraction(9, 4), Fraction(5, 6), Fraction(6))
+        == (Fraction(15, 8), Fraction(21, 4)),
+    )
+
+
+def independent_checks() -> None:
+    section("Independent exact construction and arithmetic oracles")
+    group = signed_axis_group()
+    direct_actions = {arm_permutation(element) for element in group}
+    oracle_actions = independent_axis_permutations()
+    report(
+        "pair-permutation/flip enumeration independently recovers all 48 group actions",
+        len(oracle_actions) == 48
+        and len(set(oracle_actions)) == 48
+        and set(oracle_actions) == direct_actions,
+    )
+
+    p_a1, p_e, p_t1, _ = direct_projectors()
+    oracle_projectors = (
+        independent_basis_projector(A1_BASIS),
+        independent_basis_projector(E_BASIS),
+        independent_basis_projector(T1_BASIS),
+    )
+    report(
+        "orthogonal-basis outer products independently recover every projector entry",
+        oracle_projectors == (p_a1, p_e, p_t1),
+    )
+    report(
+        "the independent projectors pass the full group/decomposition contract",
+        projector_decomposition_valid(*oracle_projectors, group),
+    )
+
+    rational_cases = (
+        (Fraction(1, 3), Fraction(1, 2)),
+        (Fraction(2, 5), Fraction(7, 11)),
+        (Fraction(9, 4), Fraction(5, 6)),
+        (Fraction(13, 7), Fraction(3, 8)),
+        (Fraction(1, 97), Fraction(89, 101)),
+        (Fraction(144, 35), Fraction(55, 21)),
+    )
+    exponents = (-17, -8, -3, -1, 0, 1, 2, 5, 13)
+    monomial_agreement = all(
+        monomial_lambda(u, v, exponent) == independent_monomial_lambda(u, v, exponent)
+        for u, v in rational_cases
+        for exponent in exponents
+    )
+    report(
+        "independent numerator/denominator powers agree on 54 varied rational cases",
+        monomial_agreement,
+    )
+
+    affine_cases = (
+        (Fraction(9, 4), Fraction(5, 6), Fraction(6)),
+        (Fraction(-7, 11), Fraction(13, 5), Fraction(3, 8)),
+        (Fraction(0), Fraction(4, 9), Fraction(-5, 2)),
+        (Fraction(17, 19), Fraction(-23, 29), Fraction(31, 37)),
+        (Fraction(101, 7), Fraction(1, 103), Fraction(107, 109)),
+    )
+    report(
+        "independent common-denominator affine arithmetic agrees on varied signed inputs",
+        all(
+            affine_endpoint(lambda_value, q, d)
+            == independent_affine_endpoint(lambda_value, q, d)
+            for lambda_value, q, d in affine_cases
+        ),
+    )
+
+    base = Fraction(2, 3)
+    target = Fraction(9, 4)
+    cert_two = make_exponent_certificate(base, target, 2)
+    cert_three = make_exponent_certificate(base, target, 3)
+    report(
+        "two independent prime valuations force the same global exponent without a scan",
+        cert_two[-1] == cert_three[-1] == -2
+        and cert_two[1] * cert_two[-1] == cert_two[2]
+        and cert_three[1] * cert_three[-1] == cert_three[2]
+        and independent_monomial_lambda(Fraction(1, 3), Fraction(1, 2), -2) == target,
+    )
+
+
+def call_succeeds(function: Callable[[], object]) -> bool:
+    try:
+        function()
+    except (TypeError, ValueError, ZeroDivisionError):
+        return False
+    return True
+
+
+HOSTILE_FIXTURES = (
+    "projector-diagonal-perturbation",
+    "non-idempotent-projector",
+    "nonorthogonal-projectors",
+    "wrong-projector-ranks-weights",
+    "malformed-matrix-container",
+    "duplicate-group-element",
+    "incomplete-group",
+    "bool-exponent",
+    "float-exponent",
+    "int-subclass-exponent",
+    "float-weight",
+    "fraction-subclass-weight",
+    "zero-weight",
+    "malformed-valuation-certificate",
+    "scan-only-global-uniqueness",
+    "wrong-global-exponent",
+    "ambiguous-global-uniqueness",
+    "wrong-affine-endpoint",
+    "integer-affine-coercion",
+    "physical-source-selects-exponent",
+    "physical-source-selects-normalization",
+    "affirmative-physical-source-mutation",
+)
+
+
+def hostile_mutation_acceptance(name: str) -> bool:
+    group = signed_axis_group()
+    p_a1, p_e, p_t1, pair_even = direct_projectors()
+    base = Fraction(2, 3)
+    target = Fraction(9, 4)
+    certificate = make_exponent_certificate(base, target, 2)
+
+    if name == "projector-diagonal-perturbation":
+        mutant = replace_entry(p_a1, 0, 0, p_a1[0][0] + Fraction(1, 6))
+        return projector_decomposition_valid(mutant, p_e, p_t1, group)
+    if name == "non-idempotent-projector":
+        mutant = replace_entry(p_e, 0, 1, p_e[0][1] + Fraction(1, 7))
+        return projector_decomposition_valid(p_a1, mutant, p_t1, group)
+    if name == "nonorthogonal-projectors":
+        return projector_decomposition_valid(p_a1, p_e, qadd(p_t1, p_a1), group)
+    if name == "wrong-projector-ranks-weights":
+        return projector_decomposition_valid(p_a1, pair_even, p_t1, group)
+    if name == "malformed-matrix-container":
+        return projector_decomposition_valid([list(row) for row in p_a1], p_e, p_t1, group)
+    if name == "duplicate-group-element":
+        return group_contract(group[:-1] + (group[0],))
+    if name == "incomplete-group":
+        return group_contract(group[:-1])
+    if name == "bool-exponent":
+        return call_succeeds(lambda: monomial_lambda(Fraction(1, 3), Fraction(1, 2), True))
+    if name == "float-exponent":
+        return call_succeeds(lambda: monomial_lambda(Fraction(1, 3), Fraction(1, 2), -2.0))
+    if name == "int-subclass-exponent":
+        return call_succeeds(
+            lambda: monomial_lambda(Fraction(1, 3), Fraction(1, 2), IntSubclass(-2))
+        )
+    if name == "float-weight":
+        return call_succeeds(lambda: monomial_lambda(1 / 3, Fraction(1, 2), -2))
+    if name == "fraction-subclass-weight":
+        return call_succeeds(
+            lambda: monomial_lambda(FractionSubclass(1, 3), Fraction(1, 2), -2)
+        )
+    if name == "zero-weight":
+        return call_succeeds(lambda: monomial_lambda(Fraction(0), Fraction(1, 2), -2))
+    if name == "malformed-valuation-certificate":
+        return verify_exponent_certificate(base, target, [2, 1, -2, -2])
+    if name == "scan-only-global-uniqueness":
+        return verify_exponent_certificate(base, target, (-2, -6, 6))
+    if name == "wrong-global-exponent":
+        return verify_exponent_certificate(base, target, (2, 1, -2, -1))
+    if name == "ambiguous-global-uniqueness":
+        return call_succeeds(lambda: make_exponent_certificate(Fraction(1), Fraction(1), 2))
+    if name == "wrong-affine-endpoint":
+        return verify_affine_endpoint(
+            Fraction(9, 4),
+            Fraction(5, 6),
+            Fraction(6),
+            (Fraction(15, 8), Fraction(5)),
+        )
+    if name == "integer-affine-coercion":
+        return call_succeeds(lambda: affine_endpoint(Fraction(9, 4), Fraction(5, 6), 6))
+    if name == "physical-source-selects-exponent":
+        return inference_authorized("physical exponent selection", FORMAL_PREMISES)
+    if name == "physical-source-selects-normalization":
+        return inference_authorized("physical normalization selection", FORMAL_PREMISES)
+    if name == "affirmative-physical-source-mutation":
+        mutant = NOTE.read_text() + "\nThe theorem derives the physical source.\n"
+        return source_boundary_clean_text(mutant)
+    if name not in HOSTILE_FIXTURES:
+        raise ValueError(f"unknown hostile fixture: {name}")
+    return verify_exponent_certificate(base, target, certificate)
+
+
+def hostile_checks() -> None:
+    section("Hostile mutation rejection")
+    for name in HOSTILE_FIXTURES:
+        report(f"hostile mutation rejected: {name}", not hostile_mutation_acceptance(name))
+
+
+def intentional_failure_checks(fixture: str) -> None:
+    section("Intentional hostile failure controls")
+    selected = HOSTILE_FIXTURES if fixture == "all" else (fixture,)
+    for name in selected:
+        report(
+            f"intentional false acceptance must fail: {name}",
+            hostile_mutation_acceptance(name),
+            "mutation did not satisfy the exact theorem contract",
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=("normal", "independent", "hostile", "intentional-failure"),
+        default="normal",
+    )
+    aliases = parser.add_mutually_exclusive_group()
+    aliases.add_argument("--independent", action="store_true", help="alias for --mode independent")
+    aliases.add_argument("--hostile", action="store_true", help="alias for --mode hostile")
+    parser.add_argument("--fixture", choices=("all",) + HOSTILE_FIXTURES, default="all")
+    args = parser.parse_args()
+    if args.independent:
+        if args.mode != "normal":
+            parser.error("--independent cannot combine with explicit non-normal --mode")
+        args.mode = "independent"
+    if args.hostile:
+        if args.mode != "normal":
+            parser.error("--hostile cannot combine with explicit non-normal --mode")
+        args.mode = "hostile"
+    if args.fixture != "all" and args.mode != "intentional-failure":
+        parser.error("--fixture requires --mode intentional-failure")
+    return args
 
 
 def main() -> int:
-    print("Route-2 double-local projector-normalization conditional bridge")
-    print("=" * 86)
-
-    w_a1, w_e, w_t = projector_weights()
-    kappa = w_t / w_e
-    record(
-        "the six-arm O_h projector weights are exact and give kappa=3/2",
-        (w_a1, w_e, w_t, kappa) == (Fraction(1, 6), Fraction(1, 3), Fraction(1, 2), Fraction(3, 2)),
-        f"w_A1={w_a1}, w_E={w_e}, w_T1={w_t}, kappa=w_T1/w_E={kappa}",
-    )
-
-    rows: list[tuple[str, int, Fraction, bool]] = [
-        ("channel-blind lift", 0, lambda_for_exponent(0, w_e, w_t), False),
-        ("raw local projector weight", 1, lambda_for_exponent(1, w_e, w_t), False),
-        ("raw quadratic projector weight", 2, lambda_for_exponent(2, w_e, w_t), False),
-        ("single reciprocal local normalization", -1, lambda_for_exponent(-1, w_e, w_t), False),
-        ("double reciprocal local normalization", -2, lambda_for_exponent(-2, w_e, w_t), True),
-    ]
-
-    print("\nCandidate local-weight laws")
-    print("law                                      exponent p   lambda=(w_E/w_T1)^p   hits target")
-    print("-" * 98)
-    for label, power, value, hits in rows:
-        print(f"{label:<42} {power:>6}        {str(value):>8}              {hits}")
-
-    misses = [label for label, _, value, hits in rows if not hits and value != TARGET_LAMBDA]
-    hit_rows = [label for label, _, value, hits in rows if hits and value == TARGET_LAMBDA]
-    record(
-        "all one-factor/raw local projector-weight variants miss lambda=9/4",
-        len(misses) == 4 and hit_rows == ["double reciprocal local normalization"],
-        "; ".join(f"{label} misses" for label in misses) + "; hit=" + ", ".join(hit_rows),
-        status="FALSIFIER",
-    )
-
-    q_e, rho_e, center_te = endpoint_chain(TARGET_LAMBDA)
-    record(
-        "conditional on the double reciprocal local normalization primitive, the endpoint chain closes exactly",
-        q_e == TARGET_QE and rho_e == TARGET_RHO_E and center_te == Fraction(-8, 9),
-        f"lambda={TARGET_LAMBDA} -> q_E={q_e}, rho_E={rho_e}, center T/E={center_te}",
-        status="CONDITIONAL",
-    )
-
-    # Minimality over small integer exponents: if the only local datum is the
-    # per-arm projector weight and the law is a monomial w^p, p=-2 is the unique
-    # small exponent that hits the target.
-    hits = [p for p in range(-6, 7) if lambda_for_exponent(p, w_e, w_t) == TARGET_LAMBDA]
-    record(
-        "within monomial laws q_X proportional to w_X^p for |p|<=6, p=-2 is the unique target exponent",
-        hits == [-2],
-        f"target exponents in [-6,6]: {hits}",
-        status="EXACT",
-    )
-
-    # This is the hidden-import firewall: the target is not obtained from
-    # O_h equivariance alone, because independent E/T scales can multiply any
-    # chosen local-weight law.
-    free_scale_examples = {
-        "channel_blind": Fraction(1, 1),
-        "target": TARGET_LAMBDA,
-        "single_reciprocal": lambda_for_exponent(-1, w_e, w_t),
-        "raw_quadratic": lambda_for_exponent(2, w_e, w_t),
-    }
-    record(
-        "the double reciprocal law is a primitive candidate, not a consequence of equivariance",
-        len(set(free_scale_examples.values())) == len(free_scale_examples),
-        "; ".join(f"{k} lambda={v}" for k, v in free_scale_examples.items()),
-        status="FIREWALL",
-    )
-
-    # Falsify common denominator slips around the exact endpoint denominator 6.
-    wrong_denominators: dict[int, tuple[Fraction, Fraction]] = {}
-    for denom in (5, 7, 12):
-        q_e_wrong = 1 + TARGET_RHO_E / denom
-        center_wrong = Fraction(-2, 1) * TARGET_QT / q_e_wrong
-        wrong_denominators[denom] = (q_e_wrong, center_wrong)
-    wrong_ok = all(q_e != TARGET_QE and c != Fraction(-8, 9) for q_e, c in wrong_denominators.values())
-    record(
-        "nearby center-excess denominator slips do not close the endpoint chain",
-        wrong_ok,
-        "; ".join(f"d={d}: q_E={q}, center T/E={c}" for d, (q, c) in wrong_denominators.items()),
-        status="FALSIFIER",
-    )
-
-    n_pass = sum(check.ok for check in CHECKS)
-    n_fail = sum(not check.ok for check in CHECKS)
-    print("\nVerdict:")
-    print(
-        "The exact positive target is now isolated: a double reciprocal local projector-normalization "
-        "primitive would give lambda=q_E/q_T=9/4 and hence rho_E=21/4.  The adjacent one-factor, raw, "
-        "and quadratic variants miss.  The primitive is not derived here; it is the named remaining "
-        "bridge that a future positive proof must justify."
-    )
-    print(f"\nTOTAL: PASS={n_pass} FAIL={n_fail}")
-    return 0 if n_fail == 0 else 1
+    args = parse_args()
+    print("Exact signed-axis projector decomposition and integer-monomial theorem")
+    print(f"MODE={args.mode}")
+    source_scope_checks()
+    if args.mode == "normal":
+        normal_checks()
+    elif args.mode == "independent":
+        independent_checks()
+    elif args.mode == "hostile":
+        hostile_checks()
+    else:
+        intentional_failure_checks(args.fixture)
+    print(f"\nSUMMARY: MODE={args.mode} PASS={PASS} FAIL={FAIL}")
+    print("THEOREM_SCOPE=DEFINED_SIX_ARM_PROJECTORS_INTEGER_MONOMIAL_AND_AFFINE_ARITHMETIC")
+    return 0 if FAIL == 0 else 1
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    sys.exit(main())

--- a/scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py
+++ b/scripts/frontier_quark_route2_double_local_projector_normalization_bridge_2026_06_21.py
@@ -604,31 +604,6 @@ def independent_affine_endpoint(
     return q_prime, rho
 
 
-FORMAL_PREMISES = frozenset(
-    {
-        "defined_signed_axis_carrier",
-        "defined_signed_permutation_action",
-        "finite_rational_linear_algebra",
-        "positive_rational_arguments",
-        "integer_exponent_argument",
-    }
-)
-PHYSICAL_REQUIREMENTS = {
-    "physical exponent selection": frozenset({"physical_weight_law"}),
-    "physical normalization selection": frozenset({"physical_normalization_rule"}),
-    "physical source/readout identification": frozenset({"physical_source_readout_bridge"}),
-    "physical endpoint prediction": frozenset({"physical_endpoint_identification"}),
-}
-
-
-def inference_authorized(conclusion: object, premises: object) -> bool:
-    if type(conclusion) is not str or conclusion not in PHYSICAL_REQUIREMENTS:
-        raise ValueError("unknown physical conclusion")
-    if type(premises) is not frozenset or any(type(item) is not str for item in premises):
-        raise TypeError("premises must be a strict frozenset of strings")
-    return PHYSICAL_REQUIREMENTS[conclusion].issubset(premises)
-
-
 FORBIDDEN_AFFIRMATIVE_SOURCE_PHRASES = (
     "the theorem selects the physical exponent",
     "the theorem supplies the physical normalization",
@@ -674,8 +649,20 @@ def source_scope_checks() -> None:
         and ("d" + "type=float") not in runner_text,
     )
     report(
-        "formal inputs alone authorize no physical application claim",
-        all(not inference_authorized(claim, FORMAL_PREMISES) for claim in PHYSICAL_REQUIREMENTS),
+        "formal APIs expose no physical selection inputs",
+        not call_succeeds(
+            lambda: monomial_lambda(
+                Fraction(1, 3),
+                Fraction(1, 2),
+                -2,
+                physical_source="selected",  # type: ignore[call-arg]
+            )
+        )
+        and not call_succeeds(
+            lambda: direct_projectors(
+                physical_normalization="selected"  # type: ignore[call-arg]
+            )
+        ),
     )
 
 
@@ -923,9 +910,20 @@ def hostile_mutation_acceptance(name: str) -> bool:
     if name == "integer-affine-coercion":
         return call_succeeds(lambda: affine_endpoint(Fraction(9, 4), Fraction(5, 6), 6))
     if name == "physical-source-selects-exponent":
-        return inference_authorized("physical exponent selection", FORMAL_PREMISES)
+        return call_succeeds(
+            lambda: monomial_lambda(
+                Fraction(1, 3),
+                Fraction(1, 2),
+                -2,
+                physical_source="selected",  # type: ignore[call-arg]
+            )
+        )
     if name == "physical-source-selects-normalization":
-        return inference_authorized("physical normalization selection", FORMAL_PREMISES)
+        return call_succeeds(
+            lambda: direct_projectors(
+                physical_normalization="selected"  # type: ignore[call-arg]
+            )
+        )
     if name == "affirmative-physical-source-mutation":
         mutant = NOTE.read_text() + "\nThe theorem derives the physical source.\n"
         return source_boundary_clean_text(mutant)


### PR DESCRIPTION
## Summary

- Replaces the target-fitted conditional Route-2 bridge with a dependency-free exact theorem on an explicitly defined six-arm signed-axis representation.
- Derives the A1/E/T1 projectors, exact ranks, orthogonality, and uniform diagonal entries `1/6`, `1/3`, and `1/2` using rational matrices and an independent basis oracle.
- Proves `(2/3)^p = 9/4 iff p = -2` over all integers with 2-adic and 3-adic certificates, while keeping the affine `q,d,lambda` calculation as supplied rational arithmetic only.
- Removes every claim that the formal family selects a physical exponent, normalization, source/readout rule, covariance law, or endpoint.

## Audit repair target (verbatim historical row)

`verdict_rationale`:

> Issue: the double reciprocal local projector-normalization law q_X proportional to w_X^-2 is not derived from packet inputs; it is the named missing primitive. Why this blocks: the endpoint rho_E=21/4 follows only after that normalization bridge is admitted. Repair target: derive the double-local normalization from Route-2 source/tensor/readout structure, with a runner that computes the bridge rather than selecting p=-2 against lambda=9/4. Claim boundary until fixed: the note cleanly isolates the conditional algebra and falsifies nearby monomial laws, but it is not a current-surface derivation.

`notes_for_re_audit_if_any`:

> missing_bridge_theorem: add or prove a retained bridge theorem deriving q_X proportional to w_X^-2 from named Route-2 structure, then re-audit this conditional endpoint bridge.

This repair takes the narrow non-physical route: it removes the unsupported Route-2 source/normalization bridge and preserves only the exact finite representation, projector, integer-monomial, and supplied affine arithmetic.

## Exact scope

This PR owns exactly three paths: the source note, its paired runner, and the SHA-pinned normal-run cache. It does not own or modify the already-landed #5455 files present in its base, and it does not edit audit verdicts, ledgers, queues, prompts, axioms, or primitive registries.

The theorem supplies no law relating physical channel values to projector diagonals, no source/tensor functional, no center-shell covariance, no normalization rule, and no interpretation of `q'` or `rho`.

## Review-loop fix

Review iteration 1 removed self-confirming `FORMAL_PREMISES` / `PHYSICAL_REQUIREMENTS` allowlists. The physical-selection controls now make real forbidden calls to `monomial_lambda(..., physical_source="selected")` and `direct_projectors(physical_normalization="selected")`; they pass only when the actual theorem APIs reject those inputs with `TypeError`. The paired cache was regenerated from that reviewed runner.

## Independent verification

- Exact base: `a6c0027e2bba70f540053f29df4c6648bcbfb5c8`
- Exact reviewed head: `62a4e3d6951c874f60308f733838a75b7d25dbbb`
- Normal: `PASS=16 FAIL=0`
- Independent: `PASS=10 FAIL=0`
- Hostile: `PASS=26 FAIL=0`
- All 22 individual intentional-failure fixtures exit 1 with `PASS=4 FAIL=1`; aggregate exits 1 with `PASS=4 FAIL=22`
- External group oracle: 48 unique signed permutation matrices, all 2,304 products, inverse/closure checks, and exact `24+24` determinant split
- External representation oracle: all 2,304 action products and all 48 six-arm permutations
- External projector oracle: direct `R,S,J` construction, independent exact Gaussian ranks `(1,2,3)`, six-basis direct-sum rank, 144 group/projector commutators, all diagonal/trace/idempotence/orthogonality identities
- Exponent proof: independent 2-adic and 3-adic valuations plus 401 exact integer-exponent probes
- Affine/type boundary: 125 varied signed affine triples plus independent strict-type, nonpositive-input, malformed-certificate, malformed-matrix, and forbidden physical-keyword probes
- Fresh graph: 3,962 nodes, 14,489 edges; target dependencies `[]`, incoming consumers `[]`, outgoing edges `[]`, helper runners `[]`, descendants `0`
- Textual reference sweep finds only the paired runner and historical audit row; no source consumer requires narrowing
- No-Go Discipline diff gates empty; the PR ships no negative claim
- Runner cache fresh at reviewed SHA-256 `7769aafcb309fe2ac7dc1ccbc14690f3fd5ef20a46fd490bc5027c64f5678c34`
- Vocabulary lint/render clean; premise-purity guard clean; repository-invariant unit suite 56/56
- Matched 18-stage pipelines: base `31 warnings / 463 notices / 0 errors`; candidate `30 / 462 / 0`
- Matched enforced invariant: both `rows=3754 retained_grade=392 link_violations=0`
- Validation-only candidate reseed: `positive_theorem`, `unaudited`, ready with `queue_reason=unaudited`, dependencies `[]`; the independent audit lane remains the sole verdict authority
- Portable-link, cache-freshness, generated-output exclusion, and `git diff --check` gates clean

## Audit discipline

This is post-audit repair only. Neither author nor reviewer ran an audit worker, applied a verdict, or committed generated ledger, queue, graph, dispatch, or effective-status output. Matched pipeline worktrees are disposable and excluded from the PR. Post-landing automation can independently re-audit the repaired theorem.

READY — review-loop PASS at exact head `62a4e3d6951c874f60308f733838a75b7d25dbbb`.
