### PR TITLE
repo(single-clock): status-neutral grade-word sweep on the AXIOM_FIRST_SINGLE_CLOCK surface

### DIFF
--- a/docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md
+++ b/docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md
@@ -8,22 +8,23 @@ unit split 2026-06-17; see §0)
 **Type:** bounded_theorem
 **Claim scope:** **Axis-conditional single-clock codimension-1 unitary
 evolution.** Given the declared evolution-axis premise (B-AXIS) below
-and the supplied transfer data of the retained_bounded
+and the supplied transfer data of the cited
 reflection-positivity and spectrum-condition rows — the positive
 Hermitian two-step blocked transfer `T̂²` with blocked time-step
 `2 a_τ` on the staggered fixed-background surface — the framework's
 lattice dynamics is a single-clock codimension-1 unitary evolution:
 (S1′) the generator `H := -(1/(2a_τ)) log(T̂²/M_T)` is the **unique**
-self-adjoint generator (retained finite-dim Stone uniqueness,
-transfer-relative and τ-relative) of the unique strongly continuous
+self-adjoint generator (finite-dim Stone uniqueness per the cited
+narrow row, transfer-relative and τ-relative) of the unique strongly
+continuous
 one-parameter unitary group `U(t) = exp(-itH)` on the finite block
 Hilbert space; (S2′) each lattice time slice `Σ_t = {t} × Z^3` is a
 codimension-1 Cauchy surface: the equal-time local algebra is the
 mutually commuting tensor product of per-site one-qubit `M_2(C)` Pauli
-factors selected from the retained complexification split
+factors selected from the cited complexification split
 `Cl(3,0) ⊗ C ≅ M_2(C) ⊕ M_2(C)`, with the physical carrier one
 summand, and slice data propagates with the
-finite quasilocal Lieb-Robinson envelope of the retained_bounded
+finite quasilocal Lieb-Robinson envelope of the cited
 free-bilinear exact-log bridge on the free `U = 1` bilinear sector; no
 finite-range or interacting/fixed-background exact-log locality is
 claimed outside that sector; (S3′) **the axis
@@ -36,10 +37,10 @@ single out the temporal direction, and the prior revision's S3 claim
 hence no second clock") is **withdrawn** as false-as-written. The
 "exactly one clock" conclusion holds conditional on (B-AXIS) — one
 declared axis/transfer construction (N4), one supplied `τ` (N2), and
-no independent commuting clock factor (N5), per the retained
+no independent commuting clock factor (N5), per the
 single-clock uniqueness scope boundary. The continuum-limit
 identification with a Wightman one-parameter group remains bounded by
-the emergent-Lorentz program's `retained_bounded` free-sector scope.
+the emergent-Lorentz program's free-sector scope.
 **Status authority:** independent audit lane only. This source note
 does not set or predict an audit outcome; audit verdict and effective
 status are set only by the independent audit lane.
@@ -47,7 +48,8 @@ status are set only by the independent audit lane.
 science-fix lane 2026-06-11 (re-scope)
 **Runner:** [`scripts/axiom_first_single_clock_codimension1_evolution_check.py`](../scripts/axiom_first_single_clock_codimension1_evolution_check.py)
 (`TOTAL: PASS=47 FAIL=0`, deterministic, runtime well under one minute)
-**Authority role:** source-note proposal. If retained, this row
+**Authority role:** source-note proposal. Subject to audit-lane
+ratification, this row
 supplies the *axis-conditional* single-clock codimension-1 clauses
 (S1′)+(S2′) cited by `ANOMALY_FORCES_TIME_THEOREM.md` (its SC premise
 row), with the axis-selection content explicitly declared as (B-AXIS)
@@ -215,7 +217,7 @@ codimension-1 Cauchy slice structure** — i.e. `d_t ≤ 1` holds *given*
 that the framework supplies one evolution axis with one transfer
 construction and one time step, and admits no independent commuting
 clock factor. The free `U = 1` bilinear exact-log sector additionally
-has finite quasilocal propagation by the retained_bounded free-bilinear
+has finite quasilocal propagation by the cited free-bilinear
 bridge; propagation beyond that sector is not supplied here. The axis
 premise is anomaly-free (it references no anomaly trace, no chirality
 content), so the consumer's
@@ -243,7 +245,7 @@ local algebra per site; Admissibility and Record are not load-bearing here).
   used for slices `Σ_t` and for the Lieb-Robinson distance.
 - **Euclidean block (supplied surface, not an axiom).** The staggered
   Dirac + Wilson surface `Λ = (Z/L_τ Z) × (Z/L_s Z)^3` enters only
-  through the retained_bounded RP/SC supplier rows; its status as a
+  through the cited RP/SC supplier rows; its status as a
   gate (not an axiom) is inherited from those rows. No A3/A4 axiom
   status is asserted (the 2026-05-05 audit flagged that carrier as
   superseded; this revision complies).
@@ -273,7 +275,7 @@ No fitted parameters. No observed values used as proof inputs.
   [`SINGLE_CLOCK_BLOCKED_TIME_UNIT_SPLIT_N2_SUPPORT_NOTE_2026-06-17.md`](SINGLE_CLOCK_BLOCKED_TIME_UNIT_SPLIT_N2_SUPPORT_NOTE_2026-06-17.md):
   separates (B-AXIS.1)'s two meanings. The internal blocked-transfer
   denominator for the supplied `T_hat^2` object is fixed by the
-  retained-bounded two-step normalization bridge to `2a_tau`; the
+  cited two-step normalization bridge to `2a_tau`; the
   absolute physical clock unit or time metric represented by `a_tau`
   is not derived from the current framework axioms or Record-count
   layer. This source boundary does not close (B-AXIS.2) or (B-AXIS.3)
@@ -339,7 +341,7 @@ No fitted parameters. No observed values used as proof inputs.
 
 The older declared finite-range generator premise `(B-RANGE)` is no
 longer a current premise of this theorem. It was replaced by the
-retained_bounded R-FBQL supplier on the narrower free bilinear exact-log
+R-FBQL supplier on the narrower free bilinear exact-log
 surface; outside that surface, propagation remains open rather than
 declared.
 
@@ -360,7 +362,7 @@ still-live axis-selection premise:
 
 - **B-RANGE is not a current blocker.** The current claim no longer
   asks the auditor to grant finite range for a generic log-transfer
-  generator. S2'(c) is sourced only by the retained_bounded free
+  generator. S2'(c) is sourced only by the free
   bilinear exact-log/quasilocal bridge (R-FBQL) on its own `U = 1`,
   massive-sector surface. Interacting or fixed-background exact-log
   propagation remains open, but it is not part of this row's current
@@ -368,7 +370,7 @@ still-live axis-selection premise:
 - **B-AXIS remains a real declared premise.** The framework has not
   derived the registration direction, the absolute physical clock
   unit/time metric, or the exclusion of independent commuting transfer
-  factors from the current retained axiom surface. The internal
+  factors from the current axiom surface. The internal
   two-step denominator for `T_hat^2` is separately supported by
   (S-N2-SPLIT); this does not make a physical clock/rate unit follow
   from Record or from the transfer spectrum alone. The follow-up source note
@@ -473,7 +475,7 @@ other under `W`). The framework direction is the same: the approved
 premise sets `c_t = c_s`, which makes the surface *more*
 exchange-symmetric, not less. Therefore the single-clock conclusion
 cannot be derived from RP-admissibility of the action; it holds
-conditional on (B-AXIS), exactly as the retained (G-SCOPE) boundary
+conditional on (B-AXIS), exactly as the (G-SCOPE) boundary
 requires. A two-clock comparator exists mathematically (two commuting
 tensor-factor transfers with a 2-dimensional generator span; runner
 block [C-2CLK]) and is excluded only by (B-AXIS.3) — the premise
@@ -501,7 +503,7 @@ is fixed by (R-CL3) on the one-qubit carrier. (b) is arithmetic.
 `U = 1` bilinear exact-log sector, R-FBQL has already proved the
 finite weighted overlap `W_mu < infinity` and the weighted-path
 Lieb-Robinson envelope with speed `v_mu = 4 W_mu/mu`. This theorem
-imports that retained_bounded propagation clause only on its stated
+imports that propagation clause only on its stated
 sector. The old finite-range step remains false in general: the runner
 keeps a boundary witness showing that a strictly local positive
 transfer can have a non-range-1 logarithm, so the current statement
@@ -531,22 +533,22 @@ conclusion is withdrawn. What survives is: per declared axis and
 supplied `(T̂², 2a_τ)`, the clock is unique (Step 1); selecting the
 axis, the `τ`, and excluding commuting factor clocks is (B-AXIS). ∎
 
-## Consistency with retained no-gos (declared, checked)
+## Consistency with governing no-gos (declared, checked)
 
 - **`SINGLE_CLOCK_UNIQUENESS_SCOPE_BOUNDARY_2026-06-06.md`
-  (retained_no_go).** This revision asserts nothing that row denies:
+  (no_go).** This revision asserts nothing that row denies:
   uniqueness is stated transfer-relative and τ-relative; N2/N4/N5
   appear verbatim as (B-AXIS.1–3) declared premises. The prior
   revision's S3 violated its N4/N5 discipline and is withdrawn.
 - **`SPATIAL_CUBIC_TIME_ANISOTROPY_GATE_NO_GO_2026-06-06.md`
-  (retained_no_go).** No SO(4)/continuum-isotropy wording is claimed
+  (no_go).** No SO(4)/continuum-isotropy wording is claimed
   from spatial cubic checks; the continuum corollary stays bounded by
   the emergent-Lorentz row. Where that row notes `c_t = c_s` is an
   extra premise now supplied by the kinetic-isotropy primitive, this
   note only *uses* the direction of that premise (exchange symmetry),
   never its converse.
 - **`QUANTUM_LOCAL_ALGEBRA_DOES_NOT_FORCE_BOOST_ACTION_FAITH_NO_GO_NOTE_2026-06-02.md`
-  (retained_no_go).** Nothing here derives a physical boost action
+  (no_go).** Nothing here derives a physical boost action
   from the local algebra: (S1′) concerns the single time-translation
   group only; boosts/Lorentz enter only through the bounded continuum
   corollary, which carries that program's own bounded status.
@@ -557,7 +559,7 @@ The identification of `U(t)` with the Wightman one-parameter group of
 a relativistic continuum QFT is **not** part of (S1′)–(S3′); it is
 bounded by the emergent-Lorentz program
 ([`EMERGENT_LORENTZ_INVARIANCE_NOTE.md`](EMERGENT_LORENTZ_INVARIANCE_NOTE.md),
-retained_bounded free-sector structural dispersion scope only). The
+bounded free-sector structural dispersion scope only). The
 ultrahyperbolic well-posedness obstruction for `d_t > 1`
 (Craig-Weinstein 2009; Tegmark 1997) remains an external
 classical-PDE result consumed, if at all, by the downstream consumer,
@@ -581,7 +583,7 @@ For `ANOMALY_FORCES_TIME_THEOREM.md` (premise row SC):
   any unconditional "no second clock" wording. The consumer's SC row
   text predates this re-scope and needs a follow-up edit.
 
-## Relation to the retained Stone narrow row
+## Relation to the Stone narrow row
 
 `SINGLE_CLOCK_STONE_FINITE_DIM_UNIQUENESS_NARROW_THEOREM_NOTE_2026-05-10.md`
 is consumed, not duplicated: the old inline Steps 1–2 re-proved its
@@ -594,15 +596,15 @@ in that row.
 
 ## Honest status
 
-**Bounded theorem.** (S1′) closes from retained/retained_bounded
+**Bounded theorem.** (S1′) closes from its cited
 one-hop inputs given the declared premise; (S2′a,b) closes at the
-retained_bounded level of its suppliers and (S2′c) closes only on the
-free `U = 1` bilinear exact-log sector by the retained_bounded R-FBQL
+bounded level of its suppliers and (S2′c) closes only on the
+free `U = 1` bilinear exact-log sector by the R-FBQL
 supplier; (S3′) is a computed exact certificate plus a declared
 premise. Not positive_theorem: the transfer supply is bounded
 (2-step, staggered-only, fixed background), spatial clustering is
 outside the claim, interacting/fixed-background exact-log propagation
-is not supplied, and the axis selection is a premise by the retained
+is not supplied, and the axis selection is a premise by the
 (G-SCOPE) no-go.
 
 The runner computes the load-bearing content: supply-hypothesis
@@ -616,14 +618,14 @@ two-clock tensor-factor comparator (2-dimensional generator span,
 excluded only by B-AXIS.3); and a finite-range boundary block — a
 strictly local positive transfer whose log-generator has a computed
 nonzero end-to-end Pauli component, with the single-factor contrast
-where the log returns the local generator exactly. The retained
+where the log returns the local generator exactly. The
 free-bilinear quasilocal LR supplier has its own companion runner.
 
-**Honest claim-status summary.** This is a bounded theorem on retained and
-retained-bounded one-hop inputs plus the declared B-AXIS premise. Its scope is
+**Honest claim-status summary.** This is a bounded theorem on its cited
+one-hop inputs plus the declared B-AXIS premise. Its scope is
 axis-conditional single-clock codimension-1 unitary evolution: with the
 source-supported internal block denominator `2a_tau` for the
-retained-bounded RP/SC two-step transfer supply `T_hat^2`, a still-supplied
+RP/SC two-step transfer supply `T_hat^2`, a still-supplied
 absolute physical clock unit/time metric, one declared evolution axis carrying
 that transfer construction, and no independent commuting transfer factor
 declared as a second clock, the finite-dim Stone row (currently unaudited per ledger) gives the unique
@@ -633,7 +635,7 @@ one-parameter unitary group `U(t) = exp(-itH)`. Each lattice slice `Sigma_t` is
 a codimension-1 Cauchy surface with mutually commuting per-site `M_2(C)`
 tensor-product equal-time algebra.
 
-On the free `U = 1` bilinear exact-log sector only, the retained-bounded
+On the free `U = 1` bilinear exact-log sector only, the
 free-bilinear quasilocal LR bridge supplies finite propagation with envelope
 `||[alpha_t(A_x),B_y]|| <= 2||A_x||||B_y|| exp(-mu d_1(x,y)+4 W_mu |t|)`,
 `0 < d mu < eta < arcsinh(m)`. No interacting/fixed-background exact-log
@@ -641,16 +643,16 @@ propagation claim is made. The prior S3 claim that the temporal direction is
 the unique RP-admissible reflection axis is withdrawn: the staggered hop
 operator is exactly invariant under the time-space exchange unitary
 `W = P_{tau<->1} diag((-1)^{x_tau x_1})`, so axis selection is a premise,
-consistent with the retained single-clock uniqueness scope boundary
+consistent with the single-clock uniqueness scope boundary
 (N2/N4/N5). Continuum Wightman identification stays bounded by the
 emergent-Lorentz program.
 
-Every load-bearing input is retained or retained-bounded on this source
+Every load-bearing input is a cited one-hop source note on this source
 surface except the surviving declared/open pieces of B-AXIS: absolute
 clock-rate/unit content for (B-AXIS.1b), axis/transfer-construction uniqueness
 (B-AXIS.2), and no-independent-factor exclusion (B-AXIS.3). The older B-RANGE
 finite-range generator premise is no longer part of the current claim;
-free-sector propagation is supplied by the retained-bounded R-FBQL bridge.
+free-sector propagation is supplied by the R-FBQL bridge.
 Because these B-AXIS pieces remain declared/open, this branch is not a
 retained-grade proposal. No new axiom, fitted parameter, observed value, or
 status promotion is made here; the independent audit lane remains the only
@@ -697,7 +699,7 @@ authority for effective status.
   [`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md)
 - APBC/PBC axis-label bridge (conditional supplier; no status change):
   [`SINGLE_CLOCK_APBC_AXIS_LABEL_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-16.md`](SINGLE_CLOCK_APBC_AXIS_LABEL_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-16.md)
-- continuum bound (retained_bounded):
+- continuum bound (currently unaudited per ledger):
   [`EMERGENT_LORENTZ_INVARIANCE_NOTE.md`](EMERGENT_LORENTZ_INVARIANCE_NOTE.md)
 - downstream consumer (cross-reference only, not a dep):
   `ANOMALY_FORCES_TIME_THEOREM.md` (premise row SC)

--- a/logs/runner-cache/axiom_first_single_clock_codimension1_evolution_check.txt
+++ b/logs/runner-cache/axiom_first_single_clock_codimension1_evolution_check.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/axiom_first_single_clock_codimension1_evolution_check.py
-runner_sha256: e93b82e3bca595b20d98e280245fa8dfde1e28f86f5b7e1dc575e73650dd1db7
+runner_sha256: 55068bbe609126aa757d5e934b68b9246cac8f278f15fd80add93c17c49e97c8
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.61
+elapsed_sec: 0.84
 status: ok
 ----- stdout -----
 ========================================================================
@@ -13,7 +13,7 @@ AXIOM-FIRST SINGLE-CLOCK CODIMENSION-1 EVOLUTION CHECK (2026-06-11)
 Axis-conditional theorem (S1')-(S3'): conditional on B-AXIS, the
 supplied transfer data give one generator, one unitary group, and
 codimension-1 Cauchy slices. Propagation is cited only on the
-retained free U=1 exact-log quasilocal bridge; the staggered action's
+free U=1 exact-log quasilocal bridge; the staggered action's
 exact time-space exchange symmetry shows the axis itself is a premise
 (old S3 withdrawn).
 
@@ -23,14 +23,14 @@ exact time-space exchange symmetry shows the axis itself is a premise
 ------------------------------------------------------------------------
 [A] (S1') SUPPLY HYPOTHESES AND STONE CLOSURE (transfer/tau-relative)
 ------------------------------------------------------------------------
-  [PASS] [A] (R-STONE hyp) T Hermitian (||T-T^dag|| = 1.10e-16)
+  [PASS] [A] (R-STONE hyp) T Hermitian (||T-T^dag|| = 9.72e-17)
   [PASS] [A] (R-STONE hyp) T positive, trivial kernel (min eig = 3.623e-02)
   [PASS] [A] (R-STONE hyp) ||T||_op <= 1 (max eig = 1.000000)
-  [PASS] [A] unique generator: -(1/tau) log T reproduces the supplied H (||H_rec - H|| = 1.76e-14)
-  [PASS] [A] H >= 0 (R-SC2 normalization) (min E = 5.61e-15)
-  [PASS] [A] U(0) = I (resid = 3.24e-15)
-  [PASS] [A] U(s)U(t) = U(s+t) (resid = 3.40e-15)
-  [PASS] [A] U(t)^dag U(t) = I (resid = 6.14e-15)
+  [PASS] [A] unique generator: -(1/tau) log T reproduces the supplied H (||H_rec - H|| = 1.67e-14)
+  [PASS] [A] H >= 0 (R-SC2 normalization) (min E = -1.49e-15)
+  [PASS] [A] U(0) = I (resid = 3.60e-15)
+  [PASS] [A] U(s)U(t) = U(s+t) (resid = 3.67e-15)
+  [PASS] [A] U(t)^dag U(t) = I (resid = 6.81e-15)
   [PASS] [A] generator: i dU/dt|_0 = H within the 2nd-order FD bound (resid = 4.87e-09, bound = 2.64e-04)
   [PASS] [A] N2 load-bearing: same T with tau' = 2 tau gives H' = H/2 exactly (||H' - H/2|| = 0.00e+00  (T alone does NOT fix the clock unit; B-AXIS.1 is a premise))
   [PASS] [A] falsifier: non-Hermitian T -> non-self-adjoint H, non-unitary U (||U^dag U - I|| = 9.82e+05, ||H-H^dag|| = 2.84e+01)
@@ -54,14 +54,14 @@ exact time-space exchange symmetry shows the axis itself is a premise
 [C-BDRY] STRICT FINITE-RANGE BOUNDARY FOR LOG-TRANSFER GENERATORS:
          sanity check + counterexample witness
 ------------------------------------------------------------------------
-  [PASS] [C] (finite-range sanity) block H is exactly finite-range: all Pauli strings with support diameter > 1 vanish (max far-string coeff = 7.03e-17)
+  [PASS] [C] (finite-range sanity) block H is exactly finite-range: all Pauli strings with support diameter > 1 vanish (max far-string coeff = 1.08e-16)
   [PASS] [C] (strict-range boundary) strictly local transfer is positive Hermitian (||T - T^dag|| = 3.38e-16, min eig = 0.2075)
   [PASS] [C] (strict-range boundary) log-generator has a nonzero end-to-end Pauli component (support diameter 2 > range 1) (|coeff[XYY]| = 0.0477)
   [PASS] [C] (strict-range boundary) H_w = -log T is NOT in the range-1 class: ||H_w - P_range1(H_w)||_op > 0 (remainder norm = 0.0759)
-  [PASS] [C] (strict-range contrast) single-factor transfer: -log(e^{-A}) = A exactly (locality preserved when no non-commuting tail exists) (resid = 2.40e-15)
+  [PASS] [C] (strict-range contrast) single-factor transfer: -log(e^{-A}) = A exactly (locality preserved when no non-commuting tail exists) (resid = 3.02e-15)
   BOUNDARY: strict finite-range-ness of a log-transfer generator is
   not automatic. The companion note therefore retires the old B-RANGE
-  premise from the current claim and cites the retained free-bilinear
+  premise from the current claim and cites the free-bilinear
   quasilocal LR bridge only on its stated free U=1 exact-log sector.
 
 ------------------------------------------------------------------------
@@ -71,7 +71,7 @@ exact time-space exchange symmetry shows the axis itself is a premise
   [PASS] [C] EXACT action invariance: || W M_KS W^T - M_KS || = 0 (resid = 0.00e+00 (staggered + mass term))
   [PASS] [C] temporal hop sector maps EXACTLY onto the x_1 hop sector (||W M_t W^T - M_1|| = 0.00e+00, ||W M_1 W^T - M_t|| = 0.00e+00)
   [PASS] [C] transverse hop sectors are fixed by W (resid = 0.00e+00)
-  [PASS] [C] temporal and spatial hop operators are unitarily identical (spectra) (max |spec diff| = 8.44e-15)
+  [PASS] [C] temporal and spatial hop operators are unitarily identical (spectra) (max |spec diff| = 4.44e-15)
   [PASS] [C] W maps the x_1 half-block onto the temporal half-block (|half| = 32)
   [PASS] [C] falsifier: plain axis swap WITHOUT the sign field fails (resid = 5.6569 >> 0 (the intertwiner is non-trivial))
   [PASS] [C] old-T10 criterion is phase-blind: plain (eta-free) temporal hops already flip sign under temporal reflection (resid = 0.00e+00 -> the old T10 tested orientation reversal, not staggered RP structure)
@@ -94,9 +94,9 @@ exact time-space exchange symmetry shows the axis itself is a premise
   [PASS] [D] claim_type is bounded_theorem (no positive_theorem over-claim) (canonical bounded claim type checked)
   [PASS] [D] proposal firewall: B-AXIS remains a declared blocker (no retained-grade proposal while B-AXIS is declared)
   [PASS] [D] spatial-clustering clause not consumed (cluster L2 is conditional) (S2'(b) demoted to conditional remark)
-  [PASS] [D] note retires B-RANGE from current scope (S2'(c) now uses the retained free-sector quasilocal supplier)
+  [PASS] [D] note retires B-RANGE from current scope (S2'(c) now uses the free-sector quasilocal supplier)
   [PASS] [D] note cites the free-bilinear quasilocal LR bridge as propagation supplier (free U=1 exact-log sector and finite quasilocal lightcone named)
-  [PASS] [D] 2026-06-12 firewall: B-RANGE retired, B-AXIS remains the live blocker (axis-selection route-pruning context wired without retained promotion)
+  [PASS] [D] 2026-06-12 firewall: B-RANGE retired, B-AXIS remains the live blocker (axis-selection route-pruning context wired without status promotion)
   [PASS] [D] 2026-06-17 B-AXIS.1 split note is wired (blocked-time denominator support boundary is linked as source support)
   [PASS] [D] B-AXIS.1 split keeps absolute clock unit open (does not derive a physical clock/rate unit)
 

--- a/scripts/axiom_first_single_clock_codimension1_evolution_check.py
+++ b/scripts/axiom_first_single_clock_codimension1_evolution_check.py
@@ -51,7 +51,7 @@ Computes the load-bearing content of the axis-conditional theorem
               computed NONZERO end-to-end Pauli component (support
               diameter 2): strict finite-range-ness of a log-transfer
               generator is not automatic, so the current theorem must
-              cite the retained free-bilinear quasilocal bridge rather
+              cite the free-bilinear quasilocal bridge rather
               than keep the old B-RANGE premise;
               (iii) contrast — a single-factor local transfer logs
               back to its local generator exactly (the failure in (ii)
@@ -559,7 +559,7 @@ def block_C_range_boundary(H: np.ndarray, L: int) -> None:
 
     print("  BOUNDARY: strict finite-range-ness of a log-transfer generator is")
     print("  not automatic. The companion note therefore retires the old B-RANGE")
-    print("  premise from the current claim and cites the retained free-bilinear")
+    print("  premise from the current claim and cites the free-bilinear")
     print("  quasilocal LR bridge only on its stated free U=1 exact-log sector.")
 
 
@@ -611,7 +611,7 @@ def block_D_discipline() -> None:
            ("no longer a current premise" in text
             or "no\nlonger a current premise" in text)
            and "conditional on (B-RANGE)" not in text,
-           "S2'(c) now uses the retained free-sector quasilocal supplier")
+           "S2'(c) now uses the free-sector quasilocal supplier")
     record("D", "note cites the free-bilinear quasilocal LR bridge as propagation supplier",
            "FREE_BILINEAR_QUASILOCAL_LR_BRIDGE_THEOREM_NOTE_2026-06-10.md" in text
            and "R-FBQL" in text
@@ -626,7 +626,7 @@ def block_D_discipline() -> None:
                 or "does not derive B-AXIS" in text
                 or "leaves B-AXIS open" in text)
            and "No retained-grade proposal or status promotion is made here" in text,
-           "axis-selection route-pruning context wired without retained promotion")
+           "axis-selection route-pruning context wired without status promotion")
     record("D", "2026-06-17 B-AXIS.1 split note is wired",
            "SINGLE_CLOCK_BLOCKED_TIME_UNIT_SPLIT_N2_SUPPORT_NOTE_2026-06-17.md" in text
            and "S-N2-SPLIT" in text,
@@ -651,7 +651,7 @@ def main() -> None:
     print("Axis-conditional theorem (S1')-(S3'): conditional on B-AXIS, the")
     print("supplied transfer data give one generator, one unitary group, and")
     print("codimension-1 Cauchy slices. Propagation is cited only on the")
-    print("retained free U=1 exact-log quasilocal bridge; the staggered action's")
+    print("free U=1 exact-log quasilocal bridge; the staggered action's")
     print("exact time-space exchange symmetry shows the axis itself is a premise")
     print("(old S3 withdrawn).")
 


### PR DESCRIPTION
## Defect

The `AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION` note+runner pair carried stale grade vocabulary (`retained` / `retained_bounded` / `retained_no_go`) in live prose and headlines. Verified against the live ledger: every cited supplier named with a grade word is currently `unaudited` (Stone row, RP row, SC row, R-FBQL bridge, G-SCOPE scope boundary, the two other governing no-gos, emergent-Lorentz note) — the sole exception is the equal-time tensor-locality row, which genuinely is `retained_bounded`. The audit ledger's `effective_status` is the only grade authority.

## Files touched

- `docs/AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md`
- `scripts/axiom_first_single_clock_codimension1_evolution_check.py`
- `logs/runner-cache/axiom_first_single_clock_codimension1_evolution_check.txt` (SHA-pinned cache refresh)

## Sweep scope (grade words -> status-neutral role/citation wording; science untouched)

Note: claim-scope headline, authority-role line, Scope, Framework-objects, Inputs (S-N2-SPLIT), B-RANGE retirement paragraph, 2026-06-12 firewall bullets, statement (S3′), derivation Step 2, "Consistency with governing no-gos" heading + three bullet tags (now `(no_go)`), continuum corollary, "Relation to the Stone narrow row" heading, Honest status, Honest claim-status summary, citations tag for the emergent-Lorentz row (now `currently unaudited per ledger`).

Runner: docstring, `[C-BDRY]` boundary print, two `[D]` detail strings, `main()` banner. No check logic, needle, count, or tolerance changed — `TOTAL: PASS=47 FAIL=0` before and after.

## Kept intentionally (not defects)

- Dated §0 changelog entries — historical record of prior revisions, not live claims.
- The runner-pinned disclaimer sentences (`not a retained-grade proposal`, `No retained-grade proposal or status promotion is made here`) — these disclaim a grade rather than assert one, and the paired runner pins them as wording guards.
- `(retained_bounded (per ledger))` on the equal-time tensor-locality input and its citation line — accurate against today's ledger.
- The future-conditional "by a later retained supplier" phrase.

## Validation

- Paired runner: 47 PASS / 0 FAIL before and after
- Eleven sibling runners that read the note: all exit 0, except the two runners red on origin/main for the separate stale-manifest defect (PR #5449's targets); their failure signatures verified identical before/after this change, so this PR does not interact with that one
- `vocab_lint.py --fix`: 0 violations; `run_pipeline.sh`: exit 0 (18/18); `audit_lint.py --strict`: no errors
- Row is `unaudited`; note-hash drift is the benign re-audit-pending notice
- Generated audit outputs restored to origin/main before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)