### PR TITLE
repo: stamp complete blocker_fingerprint_v1 snapshots on new conditional/failed verdicts

### DIFF
--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -42,9 +42,18 @@ import audit_invocation
 
 import ledger_io
 
+# Shared constants/validation for the blocker_fingerprint_v1 stamp: the
+# writer imports the comparator's required-keys table so the two can never
+# drift (dispatch-retarget design note, 2026-07-16, section 3b).
+import classify_runner_passes
+import compute_audit_queue
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 LEDGER_PATH = REPO_ROOT / "docs" / "audit" / "data" / "audit_ledger.json"
 AXIOM_PREMISE_NODES_PATH = REPO_ROOT / "docs" / "audit" / "data" / "axiom_premise_nodes.json"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import runner_cache  # noqa: E402  (SHA-pinned runner cache headers)
 
 _AXIOM_PREMISE_IDS: set[str] | None = None
 CLIPPED_EVIDENCE_MARKERS = (
@@ -691,6 +700,115 @@ def judicial_summary_from_blob(judgment: dict) -> dict:
     return summary
 
 
+# Verdicts whose snapshot must carry the complete versioned
+# blocker_fingerprint_v1 baseline set (dispatch-retarget design note,
+# 2026-07-16, section 3b). These are the owner-ruled non-terminal resting
+# states that re-enter the pending queue; the shadow would-park comparator
+# (compute_audit_queue._live_conditional_would_park) reads the live row's
+# top-level audit_state_snapshot for exactly this population. Stamping is
+# reporting-side enablement only: no dispatch decision reads the v1 fields,
+# and legacy rows are never rewritten (their next organic verdict stamps).
+FINGERPRINT_STAMP_VERDICTS = {"audited_conditional", "audited_failed"}
+
+
+def _sha256_file(path: Path) -> str | None:
+    """SHA-256 of a file's bytes; None when unreadable/missing."""
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _fingerprint_policy_versions() -> dict:
+    """Packet/prompt/gate policy versions in force at verdict-write time.
+
+    Computed from the live policy surfaces during this apply pass — never
+    from a cached report. Content hashes are used where no declared version
+    constant exists, so any policy movement is visible as a channel delta.
+    """
+    return {
+        "audit_tuple_agreement_schema": AUDIT_TUPLE_AGREEMENT_SCHEMA,
+        "n8_source_corpus_version": no_go_discipline_gate.N8_SOURCE_CORPUS_VERSION,
+        "no_go_discipline_gate_sha256": _sha256_file(
+            Path(no_go_discipline_gate.__file__)
+        ),
+        "audit_prompt_template_sha256": _sha256_file(
+            REPO_ROOT / "docs" / "audit" / "AUDIT_AGENT_PROMPT_TEMPLATE.md"
+        ),
+    }
+
+
+def _fingerprint_premise_registry_epoch() -> str:
+    """Content identity of the premise registry at verdict-write time.
+
+    The registry (axiom_premise_nodes.json) carries no epoch counter, so the
+    honest epoch marker is its content hash: it changes exactly when the
+    registry changes, and never otherwise (deterministic, timestamp-free).
+    """
+    digest = _sha256_file(
+        REPO_ROOT / "docs" / "audit" / "data" / "axiom_premise_nodes.json"
+    )
+    return digest if digest is not None else "premise_registry_absent"
+
+
+def _fingerprint_runner_cache_state(row: dict) -> dict:
+    """Per-path runner-cache identity for the row's runner and helpers.
+
+    Records the SHA-pinned cache header fields plus freshness, read from
+    disk during this apply pass (logs/runner-cache is the canonical cache
+    surface; see runner_cache.py). Header fields carry no timestamps, so
+    the recorded state is deterministic for a given repo state.
+    """
+    state: dict[str, dict] = {}
+    paths = [
+        p
+        for p in [row.get("runner_path"), *(row.get("helper_runner_paths") or [])]
+        if p
+    ]
+    for path in sorted(set(paths)):
+        _cache_path, header, _body = runner_cache.load_cache(path)
+        header = header or {}
+        state[path] = {
+            "cache_freshness": runner_cache.cache_status(path),
+            "cache_runner_sha256": header.get("runner_sha256"),
+            "cache_status": header.get("status"),
+            "cache_exit_code": header.get("exit_code"),
+        }
+    return state
+
+
+def _fingerprint_artifact_classifier_state(row: dict) -> dict:
+    """Static classifier view of the row's runner at verdict-write time.
+
+    Recomputed from the runner source via classify_runner_passes (the same
+    routines the pipeline classifier uses), never read from the generated
+    runner_classification.json — that file may be stale relative to this
+    apply pass. Mirrors the per_runner entry shape.
+    """
+    runner_path = row.get("runner_path")
+    if not runner_path:
+        return {}
+    p = REPO_ROOT / runner_path
+    if not p.exists():
+        return {"runner_path": runner_path, "exists": False}
+    try:
+        source = p.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {"runner_path": runner_path, "exists": True, "read_error": True}
+    counts = classify_runner_passes.classify_source(source)
+    dominant = max(counts, key=lambda k: counts[k]) if any(counts.values()) else None
+    return {
+        "runner_path": runner_path,
+        "exists": True,
+        "counts": counts,
+        "assert_count": classify_runner_passes.count_assert_pass_lines(source),
+        "dominant_class": dominant,
+        "decoration_candidate": (
+            counts["D"] == 0 and counts["C"] == 0 and counts["A"] + counts["B"] > 0
+        ),
+    }
+
+
 def snapshot_audit_state(row: dict, rows: dict[str, dict]) -> dict:
     deps = sorted(row.get("deps", []))
     runner_hash_value: str | None = None
@@ -713,7 +831,7 @@ def snapshot_audit_state(row: dict, rows: dict[str, dict]) -> dict:
             except OSError:
                 pass
         helper_runner_hashes[helper_path] = helper_hash
-    return {
+    snapshot = {
         "deps": deps,
         "dep_effective_status": {
             d: rows.get(d, {}).get("effective_status") or "unaudited"
@@ -749,6 +867,38 @@ def snapshot_audit_state(row: dict, rows: dict[str, dict]) -> dict:
         "runner_hash": runner_hash_value,
         "helper_runner_hashes": helper_runner_hashes,
     }
+    # v1 blocker-fingerprint stamp for NEW conditional/failed verdict writes
+    # only (dispatch-retarget design note, 2026-07-16, section 3b). Callers
+    # set row["audit_status"] to the just-applied verdict before snapshotting,
+    # so gating on it here covers both the ordinary and the judicial path.
+    # Existing ledger rows are never rewritten — legacy snapshots stay
+    # honestly fail-open in the shadow comparator until organically
+    # re-audited. Every channel value above and below is computed during
+    # this apply pass; nothing is copied from a stale cache or report.
+    if row.get("audit_status") in FINGERPRINT_STAMP_VERDICTS:
+        snapshot["schema"] = compute_audit_queue.BLOCKER_FINGERPRINT_V1
+        snapshot["runner_cache_state"] = _fingerprint_runner_cache_state(row)
+        snapshot["artifact_classifier_state"] = (
+            _fingerprint_artifact_classifier_state(row)
+        )
+        snapshot["policy_versions"] = _fingerprint_policy_versions()
+        snapshot["premise_registry_epoch"] = _fingerprint_premise_registry_epoch()
+        # Writer-side mirror of the comparator's validation matrix: a v1
+        # writer that omits or ill-types a required baseline is a bug and
+        # must fail LOUDLY at write time, never land a snapshot the
+        # comparator would explode on (FingerprintV1Invalid downstream).
+        problems = [
+            key
+            for key, typ in compute_audit_queue.FINGERPRINT_V1_REQUIRED_KEYS.items()
+            if key not in snapshot or not isinstance(snapshot.get(key), typ)
+        ]
+        if problems:
+            raise compute_audit_queue.FingerprintV1Invalid(
+                "refusing to write an incomplete/ill-typed v1 snapshot "
+                f"(missing/ill-typed baselines {problems}) on "
+                f"{row.get('note_path') or row.get('claim_id')}"
+            )
+    return snapshot
 
 
 def legacy_confirmed_clean_claim_type_reaudit(row: dict, verdict: str, xc_status: str | None) -> bool:

--- a/docs/audit/scripts/tests/test_fingerprint_v1_stamping.py
+++ b/docs/audit/scripts/tests/test_fingerprint_v1_stamping.py
@@ -1,0 +1,393 @@
+"""Tests for v1 blocker-fingerprint snapshot stamping (dispatch-retarget
+design note, 2026-07-16, section 3b): the audit-verdict writer stamps a
+complete blocker_fingerprint_v1 snapshot on every NEW conditional/failed
+verdict write, so the shadow would-park comparator sees v1-complete rows
+instead of fail-open legacy ones. Covers: stamped rows are v1-complete and
+park under unchanged current state; every required-key omission fails
+loudly in the comparator; stamp-then-mutate-one-channel un-parks with the
+named reason; the writer itself fails loudly (and transactionally) on an
+incomplete stamp; terminal/clean verdicts stay legacy-shaped (no backfill,
+no scope creep); and byte-identical determinism across identical passes."""
+
+import copy
+import hashlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import apply_audit  # noqa: E402
+import compute_audit_queue as caq  # noqa: E402
+
+NOTE_BODY = "# Fixture theorem note\n\nA small fixture claim.\n"
+DEP_NOTE_BODY = "# Fixture dep note\n\nAn open upstream authority.\n"
+RUNNER_BODY = "import sympy\nassert sympy.simplify(0) == 0\nprint('PASS=1')\n"
+HELPER_BODY = "VALUE = 'helper'\n"
+PROMPT_TEMPLATE_BODY = "# Audit agent prompt template (fixture)\n"
+CLAIM_ID = "fixture_conditional_row"
+NOTE_PATH = "docs/FIXTURE_CONDITIONAL_ROW.md"
+RUNNER_PATH = "scripts/fixture_runner.py"
+HELPER_PATH = "scripts/fixture_helper.py"
+AXIOM_DEP = "fixture_axiom_dep"
+OPEN_DEP = "fixture_open_dep"
+
+
+def _audit_blob(verdict="audited_conditional", **overrides):
+    blob = {
+        "claim_id": CLAIM_ID,
+        "verdict": verdict,
+        "claim_type": "positive_theorem",
+        "claim_scope": "fixture scope",
+        "auditor": "fixture-auditor",
+        "auditor_family": "codex-gpt-5.6",
+        "auditor_model": "gpt-5.6-sol",
+        "auditor_reasoning_effort": "xhigh",
+        "independence": "cross_family",
+        "load_bearing_step_class": "C",
+        "load_bearing_step": "fixture step",
+        "chain_closes": False,
+        "chain_closure_explanation": "upstream dep not retained yet",
+        "verdict_rationale": "conditional on the open upstream dep",
+        "notes_for_re_audit_if_any": "await fixture_open_dep",
+        "audit_date": "2026-07-16T00:00:00+00:00",
+        "negative_assertion_classes": [],
+    }
+    blob.update(overrides)
+    return blob
+
+
+class StampFixture:
+    """Minimal on-disk repo + in-memory ledger that drives the REAL verdict
+    writer (apply_audit.apply_one) end to end, with all module paths
+    redirected into a temp root (mirrors test_audit_pipeline conventions)."""
+
+    def __init__(self, tmp: Path):
+        self.tmp = tmp
+        (tmp / "docs" / "audit" / "data").mkdir(parents=True)
+        (tmp / "scripts").mkdir()
+        self._write(NOTE_PATH, NOTE_BODY)
+        self._write("docs/FIXTURE_OPEN_DEP.md", DEP_NOTE_BODY)
+        self._write(RUNNER_PATH, RUNNER_BODY)
+        self._write(HELPER_PATH, HELPER_BODY)
+        self._write("docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md", PROMPT_TEMPLATE_BODY)
+        self._write(
+            "docs/audit/data/axiom_premise_nodes.json",
+            json.dumps(
+                {"schema_version": 1, "canonical_ids": [AXIOM_DEP]},
+                indent=2, sort_keys=True,
+            ) + "\n",
+        )
+        self.ledger = {
+            "schema_version": 1,
+            "rows": {
+                CLAIM_ID: {
+                    "claim_id": CLAIM_ID,
+                    "note_path": NOTE_PATH,
+                    "note_hash": hashlib.sha256(NOTE_BODY.encode()).hexdigest(),
+                    "deps": [OPEN_DEP, AXIOM_DEP],
+                    "audit_status": "unaudited",
+                    "effective_status": "unaudited",
+                    "claim_type": None,
+                    "criticality": "leaf",
+                    "previous_audits": [],
+                    "runner_path": RUNNER_PATH,
+                    "helper_runner_paths": [HELPER_PATH],
+                },
+                OPEN_DEP: {
+                    "claim_id": OPEN_DEP,
+                    "note_path": "docs/FIXTURE_OPEN_DEP.md",
+                    "note_hash": hashlib.sha256(DEP_NOTE_BODY.encode()).hexdigest(),
+                    "deps": [],
+                    "audit_status": "unaudited",
+                    "effective_status": "unaudited",
+                    "claim_type": "open_gate",
+                    "claim_scope": "dep scope",
+                    "criticality": "leaf",
+                    "previous_audits": [],
+                },
+                AXIOM_DEP: {
+                    "claim_id": AXIOM_DEP,
+                    "note_path": "docs/MINIMAL_AXIOMS_FIXTURE.md",
+                    "note_hash": "axiom_hash_1",
+                    "deps": [],
+                    "audit_status": "unaudited",
+                    "effective_status": "meta",
+                    "claim_type": "meta",
+                    "claim_scope": "axiom scope",
+                    "criticality": "leaf",
+                    "previous_audits": [],
+                },
+            },
+        }
+
+    def _write(self, rel: str, body: str) -> None:
+        path = self.tmp / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+    def write_runner_caches(self) -> None:
+        """Canonical SHA-pinned caches for runner + helper (fixed inputs, so
+        the produced cache bytes are identical across identical fixtures)."""
+        result = {
+            "stdout": "PASS=1", "stderr": "", "timeout_sec": 120,
+            "exit_code": 0, "elapsed_sec": 0.0, "status": "ok",
+        }
+        for path in (RUNNER_PATH, HELPER_PATH):
+            apply_audit.runner_cache.write_cache(path, dict(result))
+
+    def patches(self):
+        return (
+            mock.patch.multiple(
+                apply_audit,
+                REPO_ROOT=self.tmp,
+                LEDGER_PATH=self.tmp / "docs" / "audit" / "data" / "audit_ledger.json",
+                AXIOM_PREMISE_NODES_PATH=(
+                    self.tmp / "docs" / "audit" / "data" / "axiom_premise_nodes.json"
+                ),
+                _AXIOM_PREMISE_IDS=None,
+            ),
+            mock.patch.multiple(
+                apply_audit.runner_cache,
+                REPO_ROOT=self.tmp,
+                CACHE_DIR=self.tmp / "logs" / "runner-cache",
+                LIVE_LOG_DIR=self.tmp / "logs" / "runner-cache" / ".in-progress",
+            ),
+        )
+
+
+class FingerprintV1StampingTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.fx = StampFixture(Path(self._tmp.name))
+        p1, p2 = self.fx.patches()
+        p1.start(); self.addCleanup(p1.stop)
+        p2.start(); self.addCleanup(p2.stop)
+        self.fx.write_runner_caches()
+
+    def _apply(self, verdict="audited_conditional", **overrides):
+        ok, msg = apply_audit.apply_one(self.fx.ledger, _audit_blob(verdict, **overrides))
+        self.assertTrue(ok, msg)
+        return self.fx.ledger["rows"][CLAIM_ID]
+
+    # -- v1 completeness and parking under unchanged current state --------
+
+    def test_conditional_stamp_is_v1_complete_and_parks(self):
+        row = self._apply("audited_conditional")
+        snap = row["audit_state_snapshot"]
+        self.assertEqual(snap.get("schema"), caq.BLOCKER_FINGERPRINT_V1)
+        for key, typ in caq.FINGERPRINT_V1_REQUIRED_KEYS.items():
+            self.assertIn(key, snap)
+            self.assertIsInstance(snap[key], typ, key)
+        # membership data recorded for deps AND helpers
+        self.assertEqual(sorted(snap["dep_effective_status"]), [AXIOM_DEP, OPEN_DEP])
+        self.assertEqual(sorted(snap["helper_runner_hashes"]), [HELPER_PATH])
+        # unchanged current state -> parks: not fail-open, no unpark reason
+        parked, reason = caq._live_conditional_would_park(row, self.fx.ledger["rows"])
+        self.assertTrue(parked)
+        self.assertEqual(reason, "no_recorded_blocker_movement")
+        self.assertFalse(reason.startswith("fail_open"))
+
+    def test_failed_stamp_is_v1_complete_and_parks(self):
+        row = self._apply("audited_failed")
+        snap = row["audit_state_snapshot"]
+        self.assertEqual(snap.get("schema"), caq.BLOCKER_FINGERPRINT_V1)
+        parked, reason = caq._live_conditional_would_park(row, self.fx.ledger["rows"])
+        self.assertTrue(parked)
+        self.assertEqual(reason, "no_recorded_blocker_movement")
+
+    def test_stamp_records_this_pass_channel_values(self):
+        row = self._apply("audited_conditional")
+        snap = row["audit_state_snapshot"]
+        registry_bytes = (
+            self.fx.tmp / "docs" / "audit" / "data" / "axiom_premise_nodes.json"
+        ).read_bytes()
+        self.assertEqual(
+            snap["premise_registry_epoch"],
+            hashlib.sha256(registry_bytes).hexdigest(),
+        )
+        self.assertEqual(
+            snap["policy_versions"]["audit_tuple_agreement_schema"],
+            apply_audit.AUDIT_TUPLE_AGREEMENT_SCHEMA,
+        )
+        self.assertEqual(
+            snap["policy_versions"]["audit_prompt_template_sha256"],
+            hashlib.sha256(PROMPT_TEMPLATE_BODY.encode()).hexdigest(),
+        )
+        runner_sha = hashlib.sha256(RUNNER_BODY.encode()).hexdigest()
+        self.assertEqual(
+            snap["runner_cache_state"][RUNNER_PATH],
+            {"cache_freshness": "fresh", "cache_runner_sha256": runner_sha,
+             "cache_status": "ok", "cache_exit_code": "0"},
+        )
+        self.assertIn(HELPER_PATH, snap["runner_cache_state"])
+        # classifier state recomputed from the runner source (sympy assert
+        # patterns in RUNNER_BODY are class-A), not read from a report file
+        self.assertTrue(snap["artifact_classifier_state"]["exists"])
+        self.assertGreater(snap["artifact_classifier_state"]["counts"]["A"], 0)
+
+    # -- validation matrix: omissions fail loudly in the comparator -------
+
+    def test_each_required_key_omission_raises_loudly(self):
+        row = self._apply("audited_conditional")
+        for key in caq.FINGERPRINT_V1_REQUIRED_KEYS:
+            mutated = copy.deepcopy(row)
+            del mutated["audit_state_snapshot"][key]
+            with self.assertRaises(caq.FingerprintV1Invalid, msg=key):
+                caq._live_conditional_would_park(mutated, self.fx.ledger["rows"])
+
+    def test_each_required_key_ill_typing_raises_loudly(self):
+        row = self._apply("audited_conditional")
+        for key in caq.FINGERPRINT_V1_REQUIRED_KEYS:
+            mutated = copy.deepcopy(row)
+            mutated["audit_state_snapshot"][key] = None
+            with self.assertRaises(caq.FingerprintV1Invalid, msg=key):
+                caq._live_conditional_would_park(mutated, self.fx.ledger["rows"])
+
+    # -- stamp-then-mutate-one-channel un-parks with the named reason ------
+
+    def test_dep_effective_status_movement_unparks(self):
+        row = self._apply("audited_conditional")
+        rows = copy.deepcopy(self.fx.ledger["rows"])
+        rows[OPEN_DEP]["effective_status"] = "retained"
+        parked, reason = caq._live_conditional_would_park(row, rows)
+        self.assertFalse(parked)
+        self.assertEqual(reason, f"dep_effective_status_changed:{OPEN_DEP}")
+
+    def test_dep_claim_type_and_scope_movement_unpark(self):
+        row = self._apply("audited_conditional")
+        for field, snap_field in (
+            ("claim_type", "dep_claim_type"),
+            ("claim_scope", "dep_claim_scope"),
+        ):
+            rows = copy.deepcopy(self.fx.ledger["rows"])
+            rows[OPEN_DEP][field] = "moved_value"
+            parked, reason = caq._live_conditional_would_park(row, rows)
+            self.assertFalse(parked, field)
+            self.assertEqual(reason, f"{snap_field}_changed:{OPEN_DEP}")
+
+    def test_axiom_premise_note_hash_movement_unparks(self):
+        row = self._apply("audited_conditional")
+        self.assertEqual(
+            row["audit_state_snapshot"]["dep_axiom_premise_note_hash"],
+            {AXIOM_DEP: "axiom_hash_1"},
+        )
+        rows = copy.deepcopy(self.fx.ledger["rows"])
+        rows[AXIOM_DEP]["note_hash"] = "axiom_hash_2"
+        parked, reason = caq._live_conditional_would_park(row, rows)
+        self.assertFalse(parked)
+        self.assertEqual(reason, f"dep_axiom_premise_note_hash_changed:{AXIOM_DEP}")
+
+    def test_dep_membership_movement_unparks(self):
+        row = copy.deepcopy(self._apply("audited_conditional"))
+        row["deps"] = row["deps"] + ["fixture_new_dep"]
+        parked, reason = caq._live_conditional_would_park(row, self.fx.ledger["rows"])
+        self.assertFalse(parked)
+        self.assertEqual(reason, "dep_membership_changed")
+
+    def test_helper_membership_movement_unparks(self):
+        row = copy.deepcopy(self._apply("audited_conditional"))
+        row["helper_runner_paths"] = []
+        parked, reason = caq._live_conditional_would_park(row, self.fx.ledger["rows"])
+        self.assertFalse(parked)
+        self.assertEqual(reason, "helper_runner_membership_changed")
+
+    def test_helper_hash_movement_unparks(self):
+        row = copy.deepcopy(self._apply("audited_conditional"))
+        row["helper_runner_hashes_current"] = {HELPER_PATH: "moved_hash"}
+        parked, reason = caq._live_conditional_would_park(row, self.fx.ledger["rows"])
+        self.assertFalse(parked)
+        self.assertEqual(reason, f"helper_runner_hash_changed:{HELPER_PATH}")
+
+    def test_each_opaque_channel_movement_unparks(self):
+        stamped = self._apply("audited_conditional")
+        for snap_key, current_key in caq.FINGERPRINT_V1_OPAQUE_CHANNELS:
+            row = copy.deepcopy(stamped)
+            then_value = row["audit_state_snapshot"][snap_key]
+            if isinstance(then_value, dict):
+                row[current_key] = {**then_value, "moved": True}
+            else:
+                row[current_key] = f"{then_value}_moved"
+            parked, reason = caq._live_conditional_would_park(
+                row, self.fx.ledger["rows"]
+            )
+            self.assertFalse(parked, snap_key)
+            self.assertEqual(reason, f"{snap_key}_changed")
+
+    # -- writer-side fail-loud and transactionality ------------------------
+
+    def test_writer_refuses_incomplete_stamp_loudly_and_transactionally(self):
+        with mock.patch.object(
+            apply_audit, "_fingerprint_policy_versions", return_value=None
+        ):
+            with self.assertRaises(caq.FingerprintV1Invalid):
+                apply_audit.apply_one(self.fx.ledger, _audit_blob())
+        # the failed write must not have committed a verdict
+        self.assertEqual(
+            self.fx.ledger["rows"][CLAIM_ID]["audit_status"], "unaudited"
+        )
+
+    # -- scope: new conditional/failed writes only -------------------------
+
+    def test_clean_verdict_snapshot_stays_legacy_shaped(self):
+        row = self._apply(
+            "audited_clean",
+            chain_closes=True,
+            chain_closure_explanation="closes on fixture inputs",
+            verdict_rationale="clean fixture",
+        )
+        snap = row["audit_state_snapshot"]
+        self.assertNotIn("schema", snap)
+        for key in ("runner_cache_state", "artifact_classifier_state",
+                    "policy_versions", "premise_registry_epoch"):
+            self.assertNotIn(key, snap)
+        # legacy baselines are still written exactly as before
+        self.assertIn("dep_effective_status", snap)
+        self.assertIn("helper_runner_hashes", snap)
+
+    def test_preexisting_legacy_rows_are_not_rewritten(self):
+        legacy_snapshot = {"dep_effective_status": {OPEN_DEP: "unaudited"}}
+        self.fx.ledger["rows"][CLAIM_ID]["audit_status"] = "audited_conditional"
+        self.fx.ledger["rows"][CLAIM_ID]["audit_state_snapshot"] = copy.deepcopy(
+            legacy_snapshot
+        )
+        # No verdict write happens; the legacy row must stay fail-open in the
+        # comparator (the version matrix's honest legacy branch), untouched.
+        parked, reason = caq._live_conditional_would_park(
+            self.fx.ledger["rows"][CLAIM_ID], self.fx.ledger["rows"]
+        )
+        self.assertFalse(parked)
+        self.assertEqual(reason, "fail_open_legacy_unversioned")
+        self.assertEqual(
+            self.fx.ledger["rows"][CLAIM_ID]["audit_state_snapshot"],
+            legacy_snapshot,
+        )
+
+    # -- determinism --------------------------------------------------------
+
+    def test_stamp_is_byte_identical_across_identical_passes(self):
+        first = json.dumps(
+            self._apply("audited_conditional")["audit_state_snapshot"],
+            sort_keys=True,
+        )
+        with tempfile.TemporaryDirectory() as tmp2:
+            fx2 = StampFixture(Path(tmp2))
+            p1, p2 = fx2.patches()
+            with p1, p2:
+                fx2.write_runner_caches()
+                ok, msg = apply_audit.apply_one(fx2.ledger, _audit_blob())
+                self.assertTrue(ok, msg)
+                second = json.dumps(
+                    fx2.ledger["rows"][CLAIM_ID]["audit_state_snapshot"],
+                    sort_keys=True,
+                )
+        self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the v1 snapshot-stamping phase of the dispatch-retarget design note ([AUDIT_DISPATCH_RETARGET_CONDITIONAL_DELTA_AND_CYCLE_ENUMERATOR_NOTE_2026-07-16.md](docs/audit/AUDIT_DISPATCH_RETARGET_CONDITIONAL_DELTA_AND_CYCLE_ENUMERATOR_NOTE_2026-07-16.md), section 3b version matrix): "its next verdict stamps a complete v1 snapshot."

## What

`apply_audit.snapshot_audit_state` now stamps a complete, versioned `blocker_fingerprint_v1` snapshot whenever the verdict being applied is `audited_conditional` or `audited_failed` — on both the ordinary (`apply_one`) and judicial (`apply_judicial_review`) paths, which both set `row["audit_status"]` before snapshotting. On top of the existing dep/helper baselines (`dep_effective_status`, `dep_claim_type`, `dep_claim_scope`, `dep_axiom_premise_note_hash`, `helper_runner_hashes` — these already carry dep/helper membership), the stamp adds:

- `schema: blocker_fingerprint_v1` (marker imported from `compute_audit_queue`, never a second literal),
- `runner_cache_state`: per-path SHA-pinned cache header fields plus freshness for the row's runner and helpers, read from `logs/runner-cache` during this apply pass,
- `artifact_classifier_state`: the static classifier view of the runner, recomputed from the runner source via `classify_runner_passes` routines at write time — never read from the possibly-stale generated `runner_classification.json`,
- `policy_versions`: tuple-agreement schema, N8 source-corpus version, and content hashes of the no-go gate module and the audit prompt template,
- `premise_registry_epoch`: content hash of `axiom_premise_nodes.json` (the registry carries no counter; the content hash changes exactly when the registry changes and never otherwise).

The writer then validates its own stamp against the comparator's `FINGERPRINT_V1_REQUIRED_KEYS` table (imported, so writer and comparator cannot drift) and raises `FingerprintV1Invalid` BEFORE the row is committed — an incomplete or ill-typed v1 stamp is a bug and fails loudly and transactionally; it never lands.

## Reporting-side only — no dispatch behavior change

- No dispatch consumer reads the new snapshot keys. `orchestrate_audit_batch.awaiting_repair_since_conditional`, `invalidate_stale_audits`, `compute_reaudit_candidates`, `restore_overaggressively_invalidated_audits`, `audit_lint`, and the seeder all read specific legacy keys and ignore extras (checked per consumer site).
- The only reader of the v1 fields is the shadow would-park comparator `compute_audit_queue._live_conditional_would_park`, whose output is the `would_park`/`would_park_reason` reporting tags and the front-door shadow counts — zero dispatch effect. Queue membership and ordering are untouched (the landed `GoldenQueueInvarianceTest` pins this).
- The design note's cutover flags (`conditional_delta_gate`, `publication_lane_interleave`) do not exist and are not created here; no Ratification Log entry is spent.

## No backfill

Existing ledger rows are not rewritten. A legacy snapshot honestly records that the complete channel set was NOT captured at verdict time; forging one after the fact would fake "when the blocker was recorded" provenance. Legacy rows stay fail-open in the comparator (the version matrix's legacy branch) until organically re-audited, at which point their new verdict stamps.

## Determinism

Same inputs produce a byte-identical stamp: no timestamps beyond the `audit_date` the verdict already writes, sorted path/dep iteration, content hashes only. Pinned by a two-fresh-fixtures byte-equality test.

## Honest expected effect

- The shadow lane's `shadow_conditional_fail_open_count` decays organically as conditional/failed rows are re-audited; it does not drop at once.
- For newly stamped rows, would-park is real immediately on the channels whose current state the comparator already reads: dep membership, dep effective-status/type/scope, axiom-premise note hash, and helper membership.
- The four opaque channels (`runner_cache_state`, `artifact_classifier_state`, `policy_versions`, `premise_registry_epoch`) VALUES and helper-hash values are recorded as baselines now but compare as unchanged until a later phase populates the row-side `*_current` projections (the comparator's documented absent-projection semantics; no producer for those projections exists yet). Primary/helper runner PATH membership is compared live from the row (helper membership was already compared; review iteration 1 added the primary-path comparison via the cache-state baseline's key set). In-place runner/helper hash drift is meanwhile caught by the existing invalidation lane, which archives and resets such rows out of the live-conditional population — including, after review iteration 1, primary-hash presence transitions (file deleted in place, no-path -> path) for v1-marked snapshots specifically; legacy snapshots keep the conservative both-present rule because many predate the `runner_hash` field.

## Tests

`docs/audit/scripts/tests/test_fingerprint_v1_stamping.py` (26 tests after review iteration 1, driving the real writer end to end): stamped conditional and failed rows are v1-complete and PARK under unchanged current state (no fail-open reason, no unpark); every required-key omission AND ill-typing raises `FingerprintV1Invalid` in the comparator; stamp-then-mutate-one-channel un-parks with the named reason for every compared channel (dep status/type/scope/axiom-hash, dep membership, helper membership, helper hash, all four opaque channels); writer fail-loud is transactional (no verdict committed); clean verdicts stay legacy-shaped; pre-existing legacy rows stay fail-open and untouched; byte-identical determinism across identical passes.

Mutation-verified decisive: (i) stamping on all verdicts, (ii) wrong schema marker, (iii) non-deterministic channel value, (iv) dropped channel with the writer self-check disabled — each mutation fails the suite (1, 11, 2, and 12 test failures respectively).

## Validation

- `python3 -m unittest discover -s docs/audit/scripts/tests`: 467 tests, OK
- `bash docs/audit/scripts/run_pipeline.sh`: exit 0
- `python3 docs/audit/scripts/audit_lint.py --strict`: exit 0, "OK: no errors" (the previously-known `structured_mirror_reconciliation_note` hash-mismatch error no longer fires on current main; nothing new introduced)
- Generated outputs restored before commit; only the two source files ship (no `dispatch_shadow_state.json`, no ledger data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Review-loop update (2026-07-18, iteration 1)

Adversarial round 1 (codex gpt-5.6-sol, max reasoning) returned 2 BLOCKING + 4 MAJOR findings; all are repaired in the follow-up commit `fix: address physics review findings (iteration 1)`:

- BLOCKING: `bool` passed the epoch's `(int, str)` contract (Python bool subclasses int), so an ill-typed v1 stamp could commit and PARK. The validation predicate now lives in ONE shared function, `compute_audit_queue.fingerprint_v1_problems` (bool rejected explicitly), imported and called by the writer — table AND predicate are shared, so the sides structurally cannot drift. Ordinary/judicial/comparator regressions added.
- BLOCKING: primary-runner presence transitions (runner file deleted in place; row stamped runner-less later gaining a path) produced false shadow PARKs. Fixed v1-scoped in both lanes: the comparator compares the cache-state baseline's key set against the row's current runner+helper paths (`runner_cache_membership_changed`), and `invalidate_stale_audits` treats primary-hash presence transitions as `runner_hash_changed:...->missing` / `missing->...` drift for `blocker_fingerprint_v1` snapshots only. The v1 scoping is load-bearing: 78 live legacy audited rows have snapshots predating the `runner_hash` field and must not be archive-reset; a regression pins that conservative branch, and the live ledger carries zero v1 rows today, so no existing row changes.
- MAJOR x3: decisive-assertion gaps (stamped `runner_hash`, helper hashes, helper cache entry, full `policy_versions`, exact classifier state were unpinned; several movement tests were self-confirming). Every channel value is now pinned against independently recomputed hashes/constants/literals; round 1's four surviving mutations now each fail the suite.
- MAJOR: the comparator comment claiming this phase populates the `*_current` projections was corrected (no producer exists; later projection phase).

Fix-commit scope: `compute_audit_queue.py` (shared predicate + membership comparison + comment), `apply_audit.py` (use shared predicate), `invalidate_stale_audits.py` (v1-scoped presence rule), and the test file (16 -> 26 tests). Full suite 477 tests OK; pipeline exit 0; strict lint "OK: no errors".