### PR TITLE
Derive the Cl(4,0) quaternionic image constructively

### DIFF
--- a/docs/CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27.md
+++ b/docs/CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27.md
@@ -15,19 +15,19 @@ to a sign `e_4^2 = ε I` with `ε ∈ {+1, -1}` are
 
 Among these two extensions, the cell `(p, q) = (3, 1)` is the **unique**
 real-Clifford-algebra extension of `Cl(3, 0)` to total dimension
-`n = 4` whose Cartan-Bott classification target is a single real matrix
+`n = 4` whose derived real-algebra target is a single real matrix
 algebra `M_k(R)` (rather than a quaternionic matrix algebra). The
 `(3, 0)` subalgebra is preserved as the spacelike subalgebra in both
 cases; only the sign `ε = e_4^2` distinguishes the two real
 classifications.
 
 These are purely statements about finite-dimensional real Clifford
-algebras and the Cartan-Bott classification cells at `n = 4`. No
+algebras and their real-algebra identifications at `n = 4`. No
 single-clock evolution input, no anomaly content, no Wick-rotation
-admission beyond the explicit pair-of-signs branch, no chirality-
+input beyond the explicit pair-of-signs branch, no chirality-
 existence claim, no Yang-Mills action, no gauge group, and no `d_t > 1`
 exclusion enter. This narrow theorem does **not** close P2 (the
-hierarchy-formula admission `Z^3 → Z^4`); it isolates the Wick-rotation
+hierarchy-formula open condition `Z^3 → Z^4`); it isolates the Wick-rotation
 signature choice into a single binary algebraic question: the sign
 `ε = e_4^2`.
 
@@ -41,19 +41,19 @@ independent audit lane.
 **Authority role:** narrow class-(A) Clifford-algebra identity that
 isolates the unique real-matrix-algebra classification cell among the
 two sign-extension choices of `Cl(3, 0)` to total dimension `n = 4`.
-This is a **stand-alone algebraic fact**, not an axiom, an admission,
+This is a **stand-alone algebraic fact**, not an axiom, a supplied premise,
 or a forcing chain on the framework's primitives. Its load-bearing
 content is the universal-property characterization of generator
 extension of a Clifford algebra by a single anticommuting generator,
-combined with the Cartan-Bott classification cells at `n = 4`.
+combined with the explicit real-algebra maps and commutants below.
 
 ## 1. Claim scope
 
 Let `Cl(p, q)` denote the real Clifford algebra on `n = p + q`
 generators with `p` generators of square `+1` and `q` of square `-1`,
 all pairwise anticommuting. Let `Cl(3, 0)` be the framework's per-site
-one-qubit operator algebra as stated in `MINIMAL_AXIOMS_2026-05-20.md`
-(Axiom 1), used here only as the source of the three generators
+one-qubit operator algebra as stated by the Qubit axiom in
+`MINIMAL_AXIOMS_2026-06-29.md`, used here only as the source of the three generators
 `e_1, e_2, e_3` satisfying
 
 ```text
@@ -81,13 +81,12 @@ nilpotent of square zero, which is not the Clifford-extension
 condition).
 
 **(S2) `ε = +1` cell.** With `e_4^2 = +I`, the resulting real Clifford
-algebra is `Cl(4, 0)`. By Cartan-Bott (Lawson-Michelsohn, *Spin
-Geometry*, Theorem I.4.3), `Cl(4, 0) ≅ M_2(H)`, the real 2x2 matrix
-algebra over the quaternions `H`.
+algebra is `Cl(4, 0)`. The explicit map in §5.2 identifies it with
+`M_2(H)`, the real 2x2 matrix algebra over the quaternions `H`.
 
 **(S3) `ε = -1` cell.** With `e_4^2 = -I`, the resulting real Clifford
-algebra is `Cl(3, 1)`. By Cartan-Bott, `Cl(3, 1) ≅ M_4(R)`, the real
-4x4 matrix algebra.
+algebra is `Cl(3, 1)`. The explicit spanning representation in §5.3
+identifies it with `M_4(R)`, the real 4x4 matrix algebra.
 
 **(S4) Uniqueness within the n = 4 single-`M_k(R)` cells preserving
 the `Cl(3, 0)` subalgebra.** Among the two extensions (S2)-(S3), the
@@ -108,21 +107,20 @@ The claim (S1)-(S5) is an abstract finite-dimensional real Clifford-
 algebra classification statement. It makes **no** claim that the
 framework's spatial substrate is `Z^4`, that spacetime is `R^{3,1}`,
 that the framework's gauge group is one of the building blocks of
-`Cl(3, 1)`, that the Wick-rotation `Z^3 → Z^4` admission P2 is closed,
+`Cl(3, 1)`, that the Wick-rotation `Z^3 → Z^4` open condition P2 is closed,
 or that the sign-`ε` choice itself is derived from any framework
 primitive. The sign-`ε` choice is the precise content of the P2
-Wick-rotation admission expressed in pure Clifford-algebra language.
+Wick-rotation condition expressed in pure Clifford-algebra language.
 
 ## 2. Why this note exists
 
 The hierarchy-formula honest-status note
 `HIERARCHY_FORMULA_HONEST_STATUS_NOTE_2026-05-10.md` names the
-Wick-rotation `Z^3 → Z^4` admitted convention (P2) as one of four open
-primitives. The present note does not rely on a separate internal
-theorem for the `Cl(3, 1) ≅ M_4(R)` cell; it records the needed
-Cartan-Bott `n = 4` cells directly as standard mathematical
-infrastructure and then isolates the algebraic step that selects
-`(3, 1)` over the other `Cl(3, 0)` one-generator extensions.
+Wick-rotation `Z^3 → Z^4` condition (P2) as open work. The present
+note does not rely on a separate internal theorem for either real-
+algebra cell; it constructs both cells directly and isolates the
+algebraic step that selects `(3, 1)` over the other `Cl(3, 0)` one-
+generator extension.
 
 The present narrow theorem isolates that algebraic step:
 
@@ -133,9 +131,9 @@ The present narrow theorem isolates that algebraic step:
 > unique single-`M_k(R)` real-matrix-algebra cell, and it is
 > `Cl(3, 1) ≅ M_4(R)`.
 
-This **does not close** the hierarchy-formula Wick-rotation admission
-(P2). That admission treats `Z^3 → Z^4` as a convention. After this
-narrow, the admission is restated as:
+This **does not close** the hierarchy-formula Wick-rotation condition
+(P2). That open condition treats `Z^3 → Z^4` as a convention. After
+this narrow, the condition is restated as:
 
 > Among the two extensions `Cl(3, 0) ↪ Cl(p, q)` with `p + q = 4` and
 > `p ≥ 3, q ≥ 0` preserving the `Cl(3, 0)` subalgebra, the cell `(3, 1)`
@@ -153,32 +151,29 @@ load-bearing on the present narrow.
 
 The narrow theorem's payoff is structural: every real Clifford-algebra
 extension `Cl(3, 0) → Cl(p, q)` at total dimension `n = 4` is in one
-of exactly two cells classified by Cartan-Bott, and the `ε = -1`
-cell is the unique single-real-matrix-algebra cell. This is a sharper
-algebraic statement than just recording the isolated Cartan-Bott
-identity `Cl(3, 1) ≅ M_4(R)`.
+of exactly two sign cells, and the `ε = -1` cell is the unique
+single-real-matrix-algebra cell. The proof below derives both target
+algebras rather than accepting their shared real dimension as a
+classification test.
 
 ## 3. Cited authorities (one hop)
 
 No internal note is load-bearing for (S1)-(S5). The load-bearing
-mathematical infrastructure is standard finite-dimensional real
-Clifford-algebra theory: the universal property of `Cl(p, q)`, real
-quadratic-form sign normalization, and the Cartan-Bott classification
-table at `n = 4`. Textbook references are Lawson-Michelsohn, *Spin
-Geometry*, Theorem I.4.3; Atiyah-Bott-Shapiro, "Clifford Modules",
-*Topology* 3 (1964) Suppl. 1, 3-38; and Porteous, *Clifford Algebras
-and the Classical Groups*, Chs. 15-16.
+mathematical infrastructure is the universal property and dimension
+formula for finite-dimensional real Clifford algebras, real quadratic-
+form sign normalization, Hamilton's quaternion multiplication law, and
+elementary real matrix algebra. The `M_2(H)` and `M_4(R)`
+identifications are constructed in §5 and checked by the runner.
+Lawson-Michelsohn, Atiyah-Bott-Shapiro, and Porteous are non-load-bearing
+external cross-checks of the resulting standard classifications.
 
-## 4. Admitted-context inputs
+## 4. Supplied mathematical conditions and imports
 
 - **Standard finite-dimensional real Clifford-algebra theory.** The
-  universal-property dimension formula `dim_R Cl(p, q) = 2^{p+q}`,
-  the Cartan-Bott classification of `Cl(p, q)` for all signatures at
-  `n ≤ 8`, and the specific identifications
-  `Cl(4, 0) ≅ M_2(H)`, `Cl(3, 1) ≅ M_4(R)` are admitted-context
-  mathematical infrastructure on the framework's accepted surface
-  (per `MINIMAL_AXIOMS_2026-05-20.md` ordinary mathematical
-  infrastructure).
+  universal property and dimension formula
+  `dim_R Cl(p, q) = 2^{p+q}` are standard mathematical inputs. No
+  Clifford-classification table or expected classification string is
+  imported as a proof check.
 
 - **Universal property of generator extension.** Given a real Clifford
   algebra `Cl(p, q)` and a new generator `e_{n+1}` with prescribed
@@ -194,11 +189,16 @@ and the Classical Groups*, Chs. 15-16.
   is excluded because it would make `e_4` nilpotent and the algebra
   is not the Clifford extension.
 
-- **Explicit matrix realizations.** The companion runner constructs
-  a faithful `8 × 8` real matrix realization of `Cl(4, 0) ≅ M_2(H)`
-  on `H^2 ≅ R^8` and a faithful `4 × 4` real matrix realization of
-  `Cl(3, 1) ≅ M_4(R)` on `R^4`. This size difference is part of the
-  checked quaternionic-vs-real classification boundary.
+- **Hamilton quaternion algebra.** The multiplication rules
+  `i^2 = j^2 = k^2 = ijk = -1` define `H`. The runner constructs left
+  and right multiplication matrices from this rule; it does not import
+  pre-labelled quaternion matrices.
+
+- **Explicit real-algebra realizations.** The companion runner constructs
+  `Phi: M_2(H) → M_8(R)` from left multiplication on `H^2`, proves
+  that its image is exactly the displayed `Cl(4, 0)` image, and solves
+  its quaternionic commutant. It separately proves that the displayed
+  `Cl(3, 1)` monomials span every matrix unit of `M_4(R)`.
 
 No PDG values consumed. No literature numerical comparators consumed.
 No fitted selectors consumed. No framework-substrate-instance-specific
@@ -235,16 +235,54 @@ e_i^2 = +I,          i ∈ {1, 2, 3, 4},
 {e_i, e_j} = 0,       i ≠ j.
 ```
 
-This is the defining relation set of `Cl(4, 0)`. By Cartan-Bott
-(Lawson-Michelsohn Theorem I.4.3),
+This is the defining relation set of `Cl(4, 0)`. To identify the real
+algebra constructively, write `H = span_R{1,i,j,k}` with Hamilton
+multiplication, and define four matrices in `M_2(H)`:
 
 ```text
-Cl(4, 0)  ≅  M_2(H),                                          (★_{(4,0)})
+g_1 = [ 0   1 ],        g_u = [ 0   u ],    u in {i,j,k}.
+      [ 1   0 ]               [-u   0 ]
 ```
 
-the real 2x2 matrix algebra over the quaternions `H`. Its real
-dimension is `4 · 2 · 2 = 16`, consistent with `dim_R Cl(4, 0) = 2^4 = 16`
-from the universal-property dimension formula.
+Each `g_a` squares to `+I_2`. The first matrix anticommutes with each
+`g_u`; distinct `g_u,g_v` anticommute because `uv = -vu`. The universal
+property therefore gives a real-algebra homomorphism
+
+```text
+rho_+ : Cl(4,0) -> M_2(H).
+```
+
+Now let `L_q` be the real `4 × 4` matrix for left multiplication by
+`q ∈ H`. Entrywise left multiplication gives the explicit map
+
+```text
+Phi : M_2(H) -> M_8(R),       [q_ab] |-> [L_(q_ab)].
+```
+
+The runner constructs `Phi` from Hamilton multiplication, checks all
+`16 × 16` standard-basis products, and finds real rank 16 for the
+images of the 16 basis elements `E_ab q`, so `Phi` is an injective
+real-algebra map. The 16 Clifford monomials in the displayed `g_a`
+also have rank 16, their union with the `Phi(E_ab q)` basis still has
+rank 16, and the exact change-of-basis determinant is `256`. Thus
+`rho_+` is onto `M_2(H)` and, since both sides have real dimension 16,
+
+```text
+Cl(4, 0)  ≅  M_2(H).                                          (★_{(4,0)})
+```
+
+There is a second, independent type check. Solving `X Phi(g_a) =
+Phi(g_a) X` for all real `8 × 8` matrices gives a four-dimensional
+commutant. It is exactly the diagonal right-`H` action. For its basis
+`1,I,J,K`, the runner derives
+
+```text
+I^2 = J^2 = K^2 = -1,       IJ = K = -JI,
+q q_bar = q_bar q = (a^2+b^2+c^2+d^2) I_8.
+```
+
+So the commutant is quaternionic and division; rank 16 alone is not
+being used as the classification test.
 
 ### 5.3 (S3) `ε = -1` extension: `Cl(3, 1)`
 
@@ -256,36 +294,44 @@ e_4^2 = -I,
 {e_i, e_j} = 0,       i ≠ j.
 ```
 
-This is the defining relation set of `Cl(3, 1)`. By Cartan-Bott,
+This is the defining relation set of `Cl(3, 1)`. The runner displays
+four real `4 × 4` matrices satisfying these relations. Their 16
+Clifford monomials have real rank 16 in the 16-dimensional ambient
+space `M_4(R)`; adjoining the 16 standard matrix units does not
+increase that rank. Hence the generated image is all of `M_4(R)`.
+The universal-property map is faithful because `dim_R Cl(3,1)=16`, so
 
 ```text
-Cl(3, 1)  ≅  M_4(R),                                          (★_{(3,1)})
+Cl(3, 1)  ≅  M_4(R).                                          (★_{(3,1)})
 ```
 
-the real 4x4 matrix algebra. Its real dimension is `4 · 4 = 16`,
-consistent with `dim_R Cl(3, 1) = 2^4 = 16`.
+The independently solved commutant is one-dimensional, exactly
+`R I_4`, which is the real-type counterpart of the quaternionic
+commutant above.
 
 ### 5.4 (S4) Uniqueness within single-`M_k(R)` cells
 
-The Cartan-Bott table at `n = 4` reads
+By §5.1 a one-generator extension of the fixed three positive-square
+generators reaches only `(4,0)` or `(3,1)`. Sections 5.2 and 5.3
+identify those two images directly with `M_2(H)` and `M_4(R)`.
 
-```text
-n = 4:   Cl(4, 0) ≅ M_2(H)
-         Cl(3, 1) ≅ M_4(R)
-         Cl(2, 2) ≅ M_4(R)
-         Cl(1, 3) ≅ M_2(H)
-         Cl(0, 4) ≅ M_2(H)
-```
+For completeness, the two 16-dimensional algebras are not being
+distinguished by their labels. Let `e = E_11`. In `M_2(H)`,
+`e M_2(H) e ≅ H`, a four-dimensional division algebra, so `e` is
+primitive. In a real full matrix algebra every primitive idempotent has
+rank one and its corner is `R`, of real dimension one. Since a
+real-algebra isomorphism preserves primitive idempotents and their
+corners, `M_2(H)` is not isomorphic to `M_4(R)` (and real dimension 16
+forces `k=4` for any candidate `M_k(R)`). The runner computes both
+corner dimensions and the quaternion norm identity.
 
-Among the five `n = 4` cells, the two that yield a **single real
-matrix algebra** `M_k(R)` (not a quaternionic algebra) are
-`(p, q) = (3, 1)` and `(p, q) = (2, 2)`. Among extensions of
-`Cl(3, 0)` (i.e., those preserving `e_1^2 = e_2^2 = e_3^2 = +I`),
-only the cell `(p, q) = (3, 1)` is reached, because `(2, 2)` requires
-two negative-square generators while `Cl(3, 0)` has exactly three
-positive-square generators by hypothesis. Hence (S4) holds: among
-extensions of `Cl(3, 0)`, the cell `(p, q) = (3, 1)` is the unique
-real-Clifford-algebra extension landing on a single `M_k(R)`. ∎
+The runner also tests a mutation control: a duplicated action of
+`M_4(R)` on `R^8` has the same algebra rank 16 and the same commutant
+dimension four as the plus branch, but its commutant is `M_2(R)` and
+contains nonzero zero divisors. It therefore fails the quaternion
+division-norm gate. Hence (S4) follows without a literal classification
+table: among the two reachable extensions, `(3,1)` is the unique one
+landing on a single `M_k(R)`. ∎
 
 ### 5.5 (S5) `Cl(3, 0)` subalgebra preservation
 
@@ -357,7 +403,7 @@ cross-references and are not load-bearing on the present narrow.
 
 ## 8. What this does NOT claim
 
-- Does **not** close P2 (the Wick-rotation admission `Z^3 → Z^4` of
+- Does **not** close P2 (the Wick-rotation condition `Z^3 → Z^4` of
   `HIERARCHY_FORMULA_HONEST_STATUS_NOTE_2026-05-10.md`).
   The narrow restates P2 as the sign-`ε` question
   `ε = e_4^2 ∈ {+1, -1}`, but does not derive `ε = -1` from any
@@ -453,7 +499,7 @@ extension identity. The references to existing
 framework narrow theorems in §9 are informational cross-references
 for the multi-witness reading and are not load-bearing imports. The
 references to
-`MINIMAL_AXIOMS_2026-05-20.md` and
+`MINIMAL_AXIOMS_2026-06-29.md` and
 `HIERARCHY_FORMULA_HONEST_STATUS_NOTE_2026-05-10.md`
 are framework-baseline citations explaining motivation, not
 load-bearing imports.
@@ -463,7 +509,7 @@ load-bearing imports.
 - No PDG observed values consumed.
 - No literature numerical comparators consumed.
 - No fitted selectors consumed.
-- No admitted unit conventions load-bearing on the claim.
+- No supplied unit conventions load-bearing on the claim.
 - No same-surface family arguments.
 - No `Z^3 → Z^4` Wick-rotation closure claimed — the narrow restates
   P2 as the sign-`ε` question, not closes it.
@@ -482,39 +528,38 @@ verifies, at exact rational precision via sympy:
    for every real `ε ≠ 0`, the rescaled generator `e'_4 = e_4 / sqrt(|ε|)`
    satisfies `(e'_4)^2 = sign(ε) I`, so `ε ∈ {+1, -1}` exhausts the
    real-algebra-isomorphism classes.
-2. (S2) Explicit faithful `8 × 8` real-matrix realization of
-   `Cl(4, 0)` generators `Γ_1, Γ_2, Γ_3, Γ_4` satisfying
-   `Γ_i Γ_j + Γ_j Γ_i = 2 δ_{ij} I_8` (all positive-square).
-3. (S2) Sympy verification that the 16 standard monomials of the
-   `(4, 0)` generators are real-linearly independent on that
-   `8 × 8` real representation matching the faithful `M_2(H)` action
-   on `H^2 ≅ R^8`.
-4. (S3) Explicit `4 × 4` real-matrix realization of `Cl(3, 1)`
+2. (S2) Construction of Hamilton multiplication and the explicit
+   real-algebra map `Phi: M_2(H) → M_8(R)` from left multiplication
+   on `H^2`, including all 256 standard-basis products and injective
+   rank 16.
+3. (S2) Four displayed elements of `M_2(H)` satisfy the `Cl(4,0)`
+   relations; their 16 monomials have exactly the same real span as
+   `Phi(M_2(H))`. The exact change-of-basis determinant is `256`.
+4. (S2) The commutant, solved from the matrix equations rather than
+   assumed, has dimension four and equals diagonal right-`H`
+   multiplication. Its quaternion relations and symbolic division-
+   norm identity are checked.
+5. (S3) Explicit `4 × 4` real-matrix realization of `Cl(3, 1)`
    generators `Γ_1, Γ_2, Γ_3, Γ_4` satisfying
    `Γ_i Γ_j + Γ_j Γ_i = 2 η_{ij} I_4` with `η = diag(+1, +1, +1, -1)`.
-5. (S3) Sympy verification that the 16 standard monomials of the
+6. (S3) Sympy verification that the 16 standard monomials of the
    `(3, 1)` generators are real-linearly independent and span all
-   of `M_4(R)`.
-6. (S2)-(S3) Side-by-side check: with the same first three
-   generators `Γ_1, Γ_2, Γ_3` (squaring to `+I_4` in both realizations
-   above), the fourth generator `Γ_4` differs only in the sign of
-   its square (`+I_4` vs `-I_4`), demonstrating that the sign-`ε`
-   branch is the only algebraic input distinguishing the two cells.
-7. (S4) Cartan-Bott uniqueness at `n = 4`: enumerate the five cells
-   `(4, 0)`, `(3, 1)`, `(2, 2)`, `(1, 3)`, `(0, 4)` and verify that
-   only `(3, 1)` and `(2, 2)` land on a single `M_k(R)` real-matrix
-   algebra, with the others landing on quaternionic algebras.
-8. (S4) Restriction to `Cl(3, 0)`-extensions: of the cells reachable
-   by `Cl(3, 0) → Cl(p, q)` with `p + q = 4` and `p ≥ 3`, only
-   `(3, 1)` is a single `M_k(R)` cell; `(4, 0)` lands on `M_2(H)`.
+   of `M_4(R)`, together with a solved one-dimensional real
+   commutant.
+7. (S4) Primitive-corner dimensions `4` and `1` distinguish the
+   quaternionic and real branches. A duplicated `M_4(R)` action gives
+   a same-rank, same-commutant-dimension decoy whose zero divisors fail
+   the quaternion division-norm gate.
+8. (S4) Signature arithmetic from the computed fourth-generator square
+   signs gives exactly `(4,0)` and `(3,1)`, with only the latter's
+   image equal to a single `M_k(R)`.
 9. (S5) `Cl(3, 0)` subalgebra preservation: the 8 monomials
    `{1, Γ_1, Γ_2, Γ_3, Γ_1 Γ_2, Γ_1 Γ_3, Γ_2 Γ_3, Γ_1 Γ_2 Γ_3}` in
    both the `(4, 0)` and the `(3, 1)` realizations span a real
    subalgebra of dimension exactly 8, matching
-   `dim_R Cl(3, 0) = 8`, and the structure constants on this
-   subspace are identical between the two realizations.
+   `dim_R Cl(3, 0) = 8`; all 64 multiplication-table entries agree.
 
-Expected runner result: `PASS = 63`, `FAIL = 0` (exact-symbolic sympy
+Expected runner result: `PASS = 60`, `FAIL = 0` (exact-symbolic sympy
 verification).
 
 ## 14. Cross-references (non-load-bearing)
@@ -536,10 +581,10 @@ verification).
   — companion single-clock codimension-1 evolution theorem; not
   load-bearing on the present narrow.
 - `HIERARCHY_FORMULA_HONEST_STATUS_NOTE_2026-05-10.md`
-  — package-level honest-status note naming the Wick-rotation admission
-  (P2) as an open primitive; the present narrow restates P2 as the
+  — historical package-level note naming the Wick-rotation condition
+  (P2) as open work; the present narrow restates P2 as the
   sign-`ε` question but does not close it.
-- `MINIMAL_AXIOMS_2026-05-20.md`
+- `MINIMAL_AXIOMS_2026-06-29.md`
   — current framework baseline; the narrow operates on the abstract
   real-Clifford-algebra structure associated with the one-qubit
   operator algebra / `Cl(3, 0)` per-site content without modifying the

--- a/docs/CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27.md
+++ b/docs/CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27.md
@@ -5,9 +5,10 @@
 **Claim scope:** the standalone Clifford-algebra structural identity that,
 given the real Clifford algebra `Cl(3, 0)` with three generators
 `e_1, e_2, e_3` satisfying `{e_i, e_j} = 2 δ_{ij} I`, the only two
-real-Clifford-algebra extensions `A'` obtained by adjoining a single
-new generator `e_4` that anticommutes with `e_1, e_2, e_3` and squares
-to a sign `e_4^2 = ε I` with `ε ∈ {+1, -1}` are
+nondegenerate real-Clifford-algebra extensions `A'` obtained by
+adjoining a single new generator `e_4` that anticommutes with
+`e_1, e_2, e_3` and squares to a sign `e_4^2 = ε I` with
+`ε ∈ {+1, -1}` are
 
 1. `ε = +1`: `A' ≅ Cl(4, 0) ≅ M_2(H)` (real quaternionic 2x2 matrix
    algebra), and
@@ -71,14 +72,14 @@ imposing
 e_4^2 = ε I,                 ε ∈ {+1, -1},
 ```
 
-only two distinct real-Clifford-algebra extensions exist, classified
-by the sign `ε`.
+only two distinct nondegenerate real-Clifford-algebra extensions in
+this `Cl(p, q)` scope exist, classified by the sign `ε`.
 
 **(S1) Sign branch.** `ε ∈ {+1, -1}` exhausts the real-quadratic-form
-extension choices (any real `ε > 0` rescales to `+1`; any real `ε < 0`
-rescales to `-1`; `ε = 0` is excluded because it would make `e_4`
-nilpotent of square zero, which is not the Clifford-extension
-condition).
+nondegenerate extension choices (any real `ε > 0` rescales to `+1`;
+any real `ε < 0` rescales to `-1`; `ε = 0` defines a degenerate
+Clifford algebra and lies outside the nondegenerate `Cl(p, q)`
+extension class considered here).
 
 **(S2) `ε = +1` cell.** With `e_4^2 = +I`, the resulting real Clifford
 algebra is `Cl(4, 0)`. The explicit map in §5.2 identifies it with
@@ -126,8 +127,9 @@ The present narrow theorem isolates that algebraic step:
 
 > Among extensions of the framework's per-site `Cl(3, 0)` algebra by a
 > single additional anticommuting generator `e_4`, only two
-> real-Clifford-algebra extensions exist, and they are distinguished
-> exactly by the sign `ε = e_4^2 ∈ {+1, -1}`. The `ε = -1` cell is the
+> nondegenerate real-Clifford-algebra extensions in this `Cl(p, q)`
+> scope exist, and they are distinguished exactly by the sign
+> `ε = e_4^2 ∈ {+1, -1}`. The `ε = -1` cell is the
 > unique single-`M_k(R)` real-matrix-algebra cell, and it is
 > `Cl(3, 1) ≅ M_4(R)`.
 
@@ -167,7 +169,7 @@ identifications are constructed in §5 and checked by the runner.
 Lawson-Michelsohn, Atiyah-Bott-Shapiro, and Porteous are non-load-bearing
 external cross-checks of the resulting standard classifications.
 
-## 4. Supplied mathematical conditions and imports
+## 4. Mathematical conditions and imports
 
 - **Standard finite-dimensional real Clifford-algebra theory.** The
   universal property and dimension formula
@@ -186,8 +188,8 @@ external cross-checks of the resulting standard classifications.
 - **Real quadratic-form normalization.** Any nonzero real `ε ∈ R`
   rescales to `±1` by `e'_4 := e_4 / sqrt(|ε|)` (real, well-defined
   for `ε ≠ 0`); only the sign of `ε` is real-algebra-invariant. `ε = 0`
-  is excluded because it would make `e_4` nilpotent and the algebra
-  is not the Clifford extension.
+  makes `e_4` nilpotent and defines a degenerate Clifford algebra,
+  outside the nondegenerate `Cl(p, q)` extension class considered here.
 
 - **Hamilton quaternion algebra.** The multiplication rules
   `i^2 = j^2 = k^2 = ijk = -1` define `H`. The runner constructs left
@@ -219,12 +221,12 @@ e_i e_j = -e_j e_i  for  i ≠ j.
 
 With the existing assignments `q_1 = q_2 = q_3 = +1` (the `Cl(3, 0)`
 subalgebra) and `q_4 = ε`, only `ε ≠ 0` gives a nondegenerate Clifford
-algebra (the `ε = 0` case yields a degenerate quadratic form whose
-classification is not the Clifford-algebra classification). By
+algebra in the `Cl(p, q)` class (the `ε = 0` case instead defines the
+Clifford algebra of a degenerate quadratic form). By
 real-quadratic-form-rescaling of `e_4 → e_4 / sqrt(|ε|)`, any nonzero
 real `ε` is real-algebra-isomorphic to `ε ∈ {+1, -1}`. Hence the
-sign-`ε` branch exhausts all real-Clifford-algebra extensions up to
-isomorphism. ∎
+sign-`ε` branch exhausts all nondegenerate one-generator `Cl(p, q)`
+extensions in scope, up to isomorphism. ∎
 
 ### 5.2 (S2) `ε = +1` extension: `Cl(4, 0)`
 
@@ -336,7 +338,8 @@ landing on a single `M_k(R)`. ∎
 ### 5.5 (S5) `Cl(3, 0)` subalgebra preservation
 
 By the universal property of generator extension of Clifford algebras
-(Lawson-Michelsohn, Ch. I §1), the inclusion
+(Lawson-Michelsohn, Ch. I §1, with signature labels translated as in
+§10), the inclusion
 `{e_1, e_2, e_3} ↪ {e_1, e_2, e_3, e_4}` of generator sets induces an
 injective real-algebra homomorphism
 
@@ -362,7 +365,8 @@ This completes the proof of (S1)-(S5).
   faithful irreducible real module is the standard `R^4` action of
   `M_4(R)`, of real dimension 4. This is the abstract algebraic
   underpinning for the Majorana spinor representation at Lorentzian
-  signature `(3, 1)` (Lawson-Michelsohn, Ch. I §5).
+  signature `(3, 1)` (Lawson-Michelsohn, Ch. I §5, with signature
+  labels translated as in §10).
 
 - **Quaternionic-vs-real classification gap.** The `ε = +1` cell
   `Cl(4, 0) ≅ M_2(H)` has irreducible real module of real dimension 8
@@ -378,8 +382,9 @@ This completes the proof of (S1)-(S5).
   complexification. The present narrow records that the real
   classifications, however, are distinct.
 
-- **`Spin(3, 1) ≅ SL(2, C)`.** At the Lie-group level, the spin
-  group `Spin(3, 1)` arising from the even-graded subalgebra of
+- **`Spin^+(3, 1) ≅ SL(2, C)`.** At the Lie-group level, the
+  identity-component spin group `Spin^+(3, 1)` arising from the
+  even-graded subalgebra of
   `Cl(3, 1)` is isomorphic to `SL(2, C)`, the standard universal
   cover of `SO^+(3, 1)`. The corresponding group for the `(4, 0)`
   cell is `Spin(4) ≅ SU(2) × SU(2)` (compact). The qualitative
@@ -409,7 +414,8 @@ cross-references and are not load-bearing on the present narrow.
   `ε = e_4^2 ∈ {+1, -1}`, but does not derive `ε = -1` from any
   framework primitive.
 - Does **not** claim that the sign-`ε` choice itself is forced by
-  any retained primitive on the framework's accepted surface. The
+  any framework axiom or explicitly approved framework primitive on
+  the framework's accepted surface. The
   choice between `Cl(4, 0)` (Euclidean) and `Cl(3, 1)` (Lorentzian)
   is delegated to the existing conditional-3+1 chain
   (`ANOMALY_FORCES_TIME_THEOREM.md`,
@@ -442,7 +448,7 @@ cross-references and are not load-bearing on the present narrow.
   is undetermined; the resulting signatures are exactly `(4, 0)` or
   `(3, 1)`, never `(2, 2)`.
 
-## 9. Relation to existing framework primitives
+## 9. Relation to existing framework Clifford-algebra theorems
 
 The framework's existing narrow theorems on Clifford-algebra structure
 each carry a different algebraic content:
@@ -472,21 +478,19 @@ on the single-`M_k(R)` real-matrix-algebra criterion.
 
 - The narrow theorem does not close P2 from the hierarchy honest-
   status note. The sign-`ε` choice remains the open content of P2.
-- The narrow theorem does not resolve the `Cl(3, 1)` vs `Cl(1, 3)`
-  convention. The Lawson-Michelsohn convention is `(+, +, +, -)`
-  yielding `Cl(3, 1) ≅ M_4(R)`; the opposite convention `(-, -, -, +)`
-  yields `Cl(1, 3) ≅ M_2(H)`. The narrow only operates at the
-  `Cl(3, 0) → Cl(3, 1)` extension under the Lawson-Michelsohn
-  convention; under the opposite convention, the extension of the
-  framework's three positive-square generators would land on
-  `Cl(3, 1)` regardless of convention naming (the framework's
-  one-qubit operator algebra / `Cl(3, 0)` framework baseline fixes the
-  spacelike-generators-square-to-`+1` convention).
+- The narrow fixes its convention in §1: `p` counts positive-square
+  generators and `q` counts negative-square generators. Thus
+  `(+,+,+,-)` is `Cl(3, 1) ≅ M_4(R)` here, while `(-,-,-,+)` is
+  `Cl(1, 3) ≅ M_2(H)`. Lawson-Michelsohn instead impose
+  `v w + w v = -2 q(v, w)`, so their signature labels require the
+  translation `p ↔ q` relative to this note. The runner and theorem
+  use only the explicit generator relations fixed in §1, independent
+  of literature naming conventions.
 - The narrow theorem does not address the `(2, 2)` cell because that
-  cell is not reachable by `Cl(3, 0)`-extension. The general
-  Cartan-Bott classification table records that `Cl(2, 2) ≅ M_4(R)`
-  is also a single-`M_k(R)` cell at `n = 4`; that cell would arise
-  from a `Cl(2, 1)` (or `Cl(1, 2)`) extension, not from `Cl(3, 0)`.
+  signature is not reachable by the one-generator `Cl(3, 0)` extension:
+  the derived sign branches are exactly `(4, 0)` and `(3, 1)`. No
+  algebra classification for the unreachable `(2, 2)` signature is
+  needed or asserted here.
 - The narrow theorem does not address `d_t > 1` exclusion; that is
   delegated to the single-clock codimension-1 evolution theorem
   (`AXIOM_FIRST_SINGLE_CLOCK_CODIMENSION1_EVOLUTION_THEOREM_NOTE_2026-05-03.md`),
@@ -591,9 +595,9 @@ verification).
   baseline.
 - Lawson, H. B. and Michelsohn, M.-L., *Spin Geometry* (Princeton
   Mathematical Series 38), Princeton University Press, 1989,
-  Theorem I.4.3 and Table I (textbook reference for the
-  Cartan-Bott classification of `Cl(p, q)` with Bott eightfold
-  periodicity).
+  Theorem I.4.3 and Table I (non-load-bearing textbook cross-check of
+  the Cartan-Bott classification, after translating their
+  `v^2 = -q(v)` sign convention by `p ↔ q`).
 - Atiyah, M. F., Bott, R., and Shapiro, A., "Clifford Modules",
   *Topology* 3 (1964), Supplement 1, 3-38 (original reference for
   the classification table and the connection to topological

--- a/logs/runner-cache/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.txt
+++ b/logs/runner-cache/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.txt
@@ -1,29 +1,25 @@
 ===== runner cache v1 =====
 runner: scripts/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.py
-runner_sha256: dd88e0efd1418e2e6a3c437666746d9fbe38c7a1e79b5424a0dc8617c898765e
+runner_sha256: 65cb0569bc6972a8b6d315eab519aab3cd74bb3737db5d18f7cdc3e509ade156
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.27
+elapsed_sec: 0.96
 status: ok
 ----- stdout -----
 ========================================================================================
 Audit companion (exact-symbolic) for
 CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27
-Goal: sympy verification of Cl(3, 0) -> Cl(3, 1) extension
-      uniqueness among single-M_k(R) real-matrix-algebra
-      Cartan-Bott cells at n = 4 reachable from Cl(3, 0).
+Goal: construct both Cl(3, 0) one-generator sign extensions
+      and distinguish M_2(H) from M_4(R) by explicit algebra maps,
+      solved commutants, and primitive-corner invariants.
 ========================================================================================
 
 ----------------------------------------------------------------------------------------
 Part 1: (S1) Sign-`epsilon` rescaling exhausts the sign branch
 ----------------------------------------------------------------------------------------
-  [PASS (A)] (S1) epsilon = 1: rescaled square = sign(eps) = 1  (eps/|eps| = 1)
-  [PASS (A)] (S1) epsilon = 2: rescaled square = sign(eps) = 1  (eps/|eps| = 1)
-  [PASS (A)] (S1) epsilon = -1: rescaled square = sign(eps) = -1  (eps/|eps| = -1)
-  [PASS (A)] (S1) epsilon = -3: rescaled square = sign(eps) = -1  (eps/|eps| = -1)
-  [PASS (A)] (S1) epsilon = 7/11: rescaled square = sign(eps) = 1  (eps/|eps| = 1)
-  [PASS (A)] (S1) epsilon = -11/13: rescaled square = sign(eps) = -1  (eps/|eps| = -1)
-  [PASS (A)] (S1) epsilon = 0 excluded (degenerate quadratic form, not Clifford extension)  (e_4^2 = 0 yields nilpotent e_4, not a Clifford algebra)
+  [PASS (A)] (S1) positive square +r^2 rescales to +1 for every r > 0  (epsilon = +r^2)
+  [PASS (A)] (S1) negative square -r^2 rescales to -1 for every r > 0  (epsilon = -r^2)
+  [BOUNDARY] epsilon = 0 is excluded by the nondegenerate-extension hypothesis
 
 ----------------------------------------------------------------------------------------
 Part 2: (S2) Cl(4, 0) realization with all Gammas squaring to +I_8
@@ -34,11 +30,8 @@ Part 2: (S2) Cl(4, 0) realization with all Gammas squaring to +I_8
   [PASS (A)] (S2) {σ_x, σ_z} = 0
   [PASS (A)] (S2) {σ_x, ε} = 0
   [PASS (A)] (S2) {σ_z, ε} = 0
-  [PASS (A)] (S2) Q_i^2 = -I_4 (quaternion i)
-  [PASS (A)] (S2) Q_j^2 = -I_4 (quaternion j)
-  [PASS (A)] (S2) Q_k^2 = -I_4 (quaternion k)
-  [PASS (A)] (S2) Q_i Q_j = Q_k
-  [PASS (A)] (S2) Q_j Q_i = -Q_k
+  [PASS (A)] (S2) explicit Phi: M_2(H) -> M_8(R) is injective on its 16-element basis  (computed image-basis rank = 16)
+  [PASS (A)] (S2) Phi preserves all 256 products of standard M_2(H) basis elements  (explicit real-algebra homomorphism)
   [PASS (A)] (S2) Γ_1^2 = +I_8 (Cl(4, 0) signature)  (Cl(4, 0) generator 1)
   [PASS (A)] (S2) Γ_2^2 = +I_8 (Cl(4, 0) signature)  (Cl(4, 0) generator 2)
   [PASS (A)] (S2) Γ_3^2 = +I_8 (Cl(4, 0) signature)  (Cl(4, 0) generator 3)
@@ -51,6 +44,11 @@ Part 2: (S2) Cl(4, 0) realization with all Gammas squaring to +I_8
   [PASS (A)] (S2) {Γ_3, Γ_4} = 0 (Cl(4, 0) off-diagonal)  (anticommute)
   [PASS (A)] (S2) 16 monomial indices enumerated for n = 4  (count = 16)
   [PASS (A)] (S2) Cl(4, 0): 16 monomials have R-linear rank 16 in M_8(R)  (computed rank = 16; dim_R Cl(4, 0) = 16)
+  [PASS (A)] (S2) Clifford-monomial image equals explicit Phi(M_2(H))  (rank(Cl image + Phi basis) = 16)
+  [PASS (A)] (S2) explicit Clifford-to-M_2(H) change-of-basis matrix is invertible  (determinant = 256)
+  [PASS (A)] (S2) solved commutant has dimension 4 and equals diagonal right-H action  (computed dim = 4; joint rank = 4)
+  [PASS (A)] (S2) commutant units satisfy i^2=j^2=k^2=-1 and ij=k=-ji
+  [PASS (A)] (S2) symbolic quaternion norm makes every nonzero commutant element invertible  (q q_bar = q_bar q = (a^2+b^2+c^2+d^2) I_8)
 
 ----------------------------------------------------------------------------------------
 Part 3: (S3) Cl(3, 1) realization with η = diag(+1, +1, +1, -1)
@@ -67,32 +65,33 @@ Part 3: (S3) Cl(3, 1) realization with η = diag(+1, +1, +1, -1)
   [PASS (A)] (S3) {Γ_3, Γ_4} = 0 (Cl(3, 1) off-diagonal)  (anticommute)
   [PASS (A)] (S3) Cl(3, 1): 16 monomials have R-linear rank 16 in M_4(R)  (computed rank = 16; dim_R M_4(R) = 16)
   [PASS (A)] (S3) span(16 Cl(3, 1) monomials) = M_4(R) (rank = 16 = dim_R M_4(R))  (surjective onto M_4(R))
+  [PASS (A)] (S3) Clifford-monomial image equals the standard M_4(R) matrix-unit span  (rank(Cl image + matrix units) = 16)
+  [PASS (A)] (S3) solved commutant is exactly the scalar real algebra R I_4  (computed commutant dimension = 1)
 
 ----------------------------------------------------------------------------------------
 Part 4: (S2)-(S3) Side-by-side: only sign of Γ_4^2 differs
 ----------------------------------------------------------------------------------------
   [PASS (A)] (S4-side) Cl(3, 1): Γ_4^2 = -I (sign ε = -1)  (Cl(3, 1) timelike generator)
   [PASS (A)] (S4-side) Cl(4, 0): Γ_4^2 = +I (sign ε = +1)  (Cl(4, 0) spacelike-extended generator)
-  [PASS (A)] (S4-side) Cl(3, 1) and Cl(4, 0) differ only in sign(Γ_4^2)  (ε = -1 vs ε = +1; this is the entire algebraic distinction)
+  [PASS (A)] (S4-side) computed fourth-generator square coefficients are opposite unit signs  (epsilon_minus = -1; epsilon_plus = 1)
 
 ----------------------------------------------------------------------------------------
-Part 5: (S4) Cartan-Bott cells at n = 4 single-M_k(R) classification
+Part 5: (S4) Constructive real-vs-quaternionic discrimination
 ----------------------------------------------------------------------------------------
-  [PASS (A)] (S4) Cartan-Bott n = 4 cells enumerated (5 cells)  (cells: [(0, 4), (1, 3), (2, 2), (3, 1), (4, 0)])
-  [PASS (A)] (S4) Among n = 4 cells, exactly (3, 1) and (2, 2) land on single M_k(R)  (single-M_k(R) cells: [(2, 2), (3, 1)])
-  [PASS (A)] (S4) Both single-M_k(R) cells have k = 4 (real-dim 16 = 4 * 4)  ((3, 1) -> M_4(R), (2, 2) -> M_4(R))
-  [PASS (A)] (S4) dim_R Cl(4, 0) = 2^4 = 16  (universal-property)
-  [PASS (A)] (S4) dim_R Cl(3, 1) = 2^4 = 16  (universal-property)
-  [PASS (A)] (S4) dim_R Cl(2, 2) = 2^4 = 16  (universal-property)
-  [PASS (A)] (S4) dim_R Cl(1, 3) = 2^4 = 16  (universal-property)
-  [PASS (A)] (S4) dim_R Cl(0, 4) = 2^4 = 16  (universal-property)
+  [PASS (A)] (S4) plus-branch E_11 is idempotent and its corner has real dimension 4  (dim_R(E_11 A_plus E_11) = 4)
+  [PASS (A)] (S4) plus-branch primitive corner is quaternionic division algebra H  (nonzero corner elements invert by quaternion conjugation)
+  [PASS (A)] (S4) minus-branch primitive matrix-unit corner has real dimension 1  (dim_R(E_11 M_4(R) E_11) = 1)
+  [PASS (A)] (S4) a single real matrix algebra of real dimension 16 would have size 4  (integer solutions of k^2 = 16: [4])
+  [PASS (A)] (S4) primitive-corner invariant separates Phi(M_2(H)) from M_4(R)  (quaternionic corner dim 4 vs real corner dim 1)
+  [PASS (A)] (S4 mutation control) duplicated M_4(R) also has rank 16 and commutant dimension 4  (dimension-only classifier is deliberately non-decisive)
+  [PASS (A)] (S4 mutation control) duplicated-M_4(R) commutant has nonzero zero divisors  (M_2(R) commutant fails the quaternion division-norm gate)
 
 ----------------------------------------------------------------------------------------
 Part 6: (S4) Restriction to Cl(3, 0)-extensions at n = 4
 ----------------------------------------------------------------------------------------
-  [PASS (A)] (S4) Cl(3, 0)-extensions at n = 4: exactly {(4, 0), (3, 1)} reachable  (reachable: [(3, 1), (4, 0)])
-  [PASS (A)] (S4) (2, 2) NOT reachable from Cl(3, 0) by single-generator extension  ((2, 2) needs two negative-square generators)
-  [PASS (A)] (S4) Among Cl(3, 0)-extensions at n = 4, only (3, 1) is single-M_k(R)  ((3, 1) → M_4(R) is the unique single-M_k(R) Cl(3, 0)-extension)
+  [PASS (A)] (S4) Cl(3, 0)-extensions at n = 4: exactly {(4, 0), (3, 1)} reachable  (derived from square signs: [(3, 1), (4, 0)])
+  [PASS (A)] (S4) (2, 2) NOT reachable from Cl(3, 0) by single-generator extension  (every derived signature retains the three positive-square generators)
+  [PASS (A)] (S4) Among Cl(3, 0)-extensions at n = 4, only (3, 1) is single-M_k(R)  (minus image is M_4(R); plus image is M_2(H) with quaternionic primitive corner)
 
 ----------------------------------------------------------------------------------------
 Part 7: (S5) Cl(3, 0) subalgebra preservation in both extensions
@@ -104,8 +103,7 @@ Part 7: (S5) Cl(3, 0) subalgebra preservation in both extensions
 ----------------------------------------------------------------------------------------
 Part 8: (S5) Structure constants of Cl(3, 0) subalgebra match
 ----------------------------------------------------------------------------------------
-  [PASS (A)] (S5) Γ_1 Γ_2 expansion in Cl(3, 0) basis (Cl(3, 1) realization)  (coeffs = [0, 0, 0, 0, 1, 0, 0, 0])
-  [PASS (A)] (S5) Γ_1 Γ_2 expansion in Cl(3, 0) basis (Cl(4, 0) realization)  (coeffs = [0, 0, 0, 0, 1, 0, 0, 0])
+  [PASS (A)] (S5) all 64 Cl(3, 0) basis products have identical structure constants  (complete 8 x 8 multiplication table compared)
   [PASS (A)] (S5) Cl(3, 0) volume element ω = Γ_1 Γ_2 Γ_3 satisfies ω^2 = -I (Cl(3, 1) realization)  (standard Cl(3, 0) pseudoscalar relation)
   [PASS (A)] (S5) Cl(3, 0) volume element ω = Γ_1 Γ_2 Γ_3 satisfies ω^2 = -I (Cl(4, 0) realization)  (same Cl(3, 0) pseudoscalar relation)
 
@@ -123,9 +121,9 @@ Part 9: Final sign-extension classification summary
 ----------------------------------------------------------------------------------------
 Final result
 ----------------------------------------------------------------------------------------
-  Note path: /private/tmp/cl3-review-open-20260527-hnkyam/docs/CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27.md
+  Note path: /private/tmp/science-fix-cl3-cl31-m2h-explicit-20260717/docs/CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27.md
   Claim id:  cl3_to_cl31_spinor_extension_narrow_theorem_note_2026-05-27
-  PASS = 63
+  PASS = 60
   FAIL = 0
 
   RESULT: PASS (no failures detected)

--- a/logs/runner-cache/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.txt
+++ b/logs/runner-cache/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.py
-runner_sha256: 65cb0569bc6972a8b6d315eab519aab3cd74bb3737db5d18f7cdc3e509ade156
+runner_sha256: 65207afdbdb691a6f93af047aa89cd02d7f1688e016cfc534e3a426322e897a0
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.96
+elapsed_sec: 0.68
 status: ok
 ----- stdout -----
 ========================================================================================
@@ -121,7 +121,7 @@ Part 9: Final sign-extension classification summary
 ----------------------------------------------------------------------------------------
 Final result
 ----------------------------------------------------------------------------------------
-  Note path: /private/tmp/science-fix-cl3-cl31-m2h-explicit-20260717/docs/CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27.md
+  Note path: docs/CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27.md
   Claim id:  cl3_to_cl31_spinor_extension_narrow_theorem_note_2026-05-27
   PASS = 60
   FAIL = 0

--- a/scripts/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.py
+++ b/scripts/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.py
@@ -1,82 +1,32 @@
 #!/usr/bin/env python3
-"""Exact-symbolic audit-companion runner for
-`CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27.md`.
+"""Exact-symbolic companion for the Cl(3,0) one-generator extension note.
 
-Pattern A narrow class-(A) Clifford-algebra identity. The narrow scope
-is purely the real-Clifford-algebra extension classification:
+The runner proves the two sign branches constructively.  For the positive
+branch it builds Hamilton's quaternions from their multiplication law, defines
+the real-algebra map ``Phi: M_2(H) -> M_8(R)`` by left multiplication on
+``H^2``, and proves that the 16 Clifford monomials span exactly ``Phi(M_2(H))``.
+It independently solves the matrix commutant and proves that the result is the
+quaternion division algebra supplied by diagonal right multiplication.
 
-  (S1) Sign-`ε` exhaustion: any real `ε != 0` rescales to `±1` via
-       e'_4 = e_4 / sqrt(|ε|); only the sign-`ε` branch is the
-       real-algebra-isomorphism input.
-  (S2) `ε = +1` cell: Cl(4, 0) is realized faithfully as four `8 x 8`
-       real matrices Γ_1, ..., Γ_4 all squaring to +I_8 and pairwise
-       anticommuting; the 16 monomials have real-linear rank 16. This
-       matches the faithful real action of `M_2(H)` on `H^2 ≅ R^8`.
-       There is no faithful `4 x 4` real-matrix realization of
-       `Cl(4,0) ≅ M_2(H)`, unlike (S3).
-  (S3) `ε = -1` cell: Cl(3, 1) is realized as four `4 x 4` real matrices
-       Γ_1, ..., Γ_4 satisfying {Γ_i, Γ_j} = 2 η_{ij} I_4 with
-       η = diag(+1, +1, +1, -1); the 16 monomials are real-linearly
-       independent and span all of M_4(R).
-  (S4) Cartan-Bott cells at n = 4: exactly the two cells (3, 1) and
-       (2, 2) land on a single M_k(R) real-matrix algebra; among
-       extensions of Cl(3, 0), only (3, 1) is reachable. The (2, 2)
-       cell requires two negative-square generators and is not
-       reachable from Cl(3, 0) by single-generator extension.
-  (S5) Cl(3, 0) subalgebra preservation: the 8 monomials
-       {1, Γ_1, Γ_2, Γ_3, Γ_1 Γ_2, Γ_1 Γ_3, Γ_2 Γ_3, Γ_1 Γ_2 Γ_3}
-       in both the (4, 0) and (3, 1) realizations span a real
-       subalgebra of dimension exactly 8 with identical structure
-       constants — recovering Cl(3, 0).
+For the negative branch it constructs four real 4x4 generators and proves that
+their 16 monomials span all of ``M_4(R)``.  Primitive-corner dimensions and a
+duplicated-``M_4(R)`` decoy distinguish the two algebra types even when real
+algebra rank and commutant dimension coincide.  No classification string or
+literal Cartan-Bott table participates in a pass/fail check.
 
-The script verifies, at exact rational precision via sympy:
-
-  (1) (S1) Sign-`ε` rescaling identity exhausts the sign branch.
-  (2) (S2) Explicit faithful `8 x 8` real-matrix realization of
-       `Cl(4, 0)` generators all squaring to +I_8 and pairwise
-       anticommuting.
-  (3) (S2) The 16 monomials of the `(4, 0)` generators have real-linear
-       rank 16 in a faithful `8 x 8` real-matrix realization, reflecting
-       the natural action of `Cl(4, 0) ≅ M_2(H)` on `H^2 ≅ R^8`, not
-       on `R^4`.
-  (4) (S3) Explicit `4 x 4` real-matrix realization of `Cl(3, 1)`
-       generators with η = diag(+1, +1, +1, -1).
-  (5) (S3) The 16 monomials of the `(3, 1)` generators are
-       real-linearly independent and span all of M_4(R) (rank 16
-       in the 16-dim vector space M_4(R)).
-  (6) (S2)-(S3) Side-by-side: with the same first three generators
-       Γ_1, Γ_2, Γ_3 (squaring to +I_4 in both realizations), the
-       fourth generator Γ_4 differs only in the sign of its square.
-  (7) (S4) Cartan-Bott table at n = 4 verification: the cells
-       (4, 0), (3, 1), (2, 2), (1, 3), (0, 4) are enumerated; only
-       (3, 1) and (2, 2) land on a single M_k(R) (k = 4); the others
-       land on M_2(H) (real-dim 16 each).
-  (8) (S4) Restriction to Cl(3, 0)-extensions at n = 4: the single
-       added generator with ε = ±1 yields cells (4, 0) and (3, 1)
-       respectively; the (2, 2) cell is unreachable from Cl(3, 0)
-       by single-generator extension.
-  (9) (S5) Cl(3, 0) subalgebra preservation: the 8 monomials of the
-       first three generators span an 8-dim real subalgebra of
-       dimension 8 in both (4, 0) and (3, 1) realizations.
-  (10) (S5) Structure-constant equality on the Cl(3, 0) subalgebra:
-       multiplication table of the 8 monomials is identical between
-       the two realizations.
-
-Companion role: not a new claim row, not a new source note, no status
-promotion. Provides audit-friendly evidence that the narrow theorem's
-load-bearing class-(A) Clifford-algebra extension identity holds at
-exact symbolic / matrix precision.
+The sign normalization and the complete ``Cl(3,0)`` subalgebra multiplication
+table are also checked exactly.  This remains a class-(A) finite-algebra
+companion: it supplies no Wick-rotation, dynamics, or physical sign selector.
 """
 
 from __future__ import annotations
 
-from math import comb
 from pathlib import Path
 import sys
 
 try:
     import sympy
-    from sympy import Matrix, Rational, eye, zeros
+    from sympy import Matrix, eye, zeros
 except ImportError:
     print("FAIL: sympy required for exact algebra")
     sys.exit(1)
@@ -179,59 +129,164 @@ def monomial(generators: list, indices: tuple, identity: Matrix) -> Matrix:
     return M
 
 
+Quaternion = tuple
+QuaternionMatrix2 = list[list[Quaternion]]
+
+Q_ZERO: Quaternion = (0, 0, 0, 0)
+Q_ONE: Quaternion = (1, 0, 0, 0)
+Q_I: Quaternion = (0, 1, 0, 0)
+Q_J: Quaternion = (0, 0, 1, 0)
+Q_K: Quaternion = (0, 0, 0, 1)
+Q_BASIS = [Q_ONE, Q_I, Q_J, Q_K]
+
+
+def q_add(a: Quaternion, b: Quaternion) -> Quaternion:
+    return tuple(x + y for x, y in zip(a, b))
+
+
+def q_neg(a: Quaternion) -> Quaternion:
+    return tuple(-x for x in a)
+
+
+def q_mul(a: Quaternion, b: Quaternion) -> Quaternion:
+    """Hamilton product in the ordered basis (1, i, j, k)."""
+    a0, a1, a2, a3 = a
+    b0, b1, b2, b3 = b
+    return (
+        a0 * b0 - a1 * b1 - a2 * b2 - a3 * b3,
+        a0 * b1 + a1 * b0 + a2 * b3 - a3 * b2,
+        a0 * b2 - a1 * b3 + a2 * b0 + a3 * b1,
+        a0 * b3 + a1 * b2 - a2 * b1 + a3 * b0,
+    )
+
+
+def quaternion_regular_matrix(q: Quaternion, side: str) -> Matrix:
+    """Real 4x4 matrix for left or right multiplication by q on H."""
+    if side not in {"left", "right"}:
+        raise ValueError(f"unknown quaternion action side: {side}")
+    columns = []
+    for basis_element in Q_BASIS:
+        product = (
+            q_mul(q, basis_element)
+            if side == "left"
+            else q_mul(basis_element, q)
+        )
+        columns.append(Matrix(product))
+    return Matrix.hstack(*columns)
+
+
+def h2_zero() -> QuaternionMatrix2:
+    return [[Q_ZERO, Q_ZERO], [Q_ZERO, Q_ZERO]]
+
+
+def h2_unit(row: int, col: int, q: Quaternion) -> QuaternionMatrix2:
+    result = h2_zero()
+    result[row][col] = q
+    return result
+
+
+def h2_add(A: QuaternionMatrix2, B: QuaternionMatrix2) -> QuaternionMatrix2:
+    return [[q_add(A[r][c], B[r][c]) for c in range(2)] for r in range(2)]
+
+
+def h2_mul(A: QuaternionMatrix2, B: QuaternionMatrix2) -> QuaternionMatrix2:
+    return [
+        [
+            q_add(q_mul(A[r][0], B[0][c]), q_mul(A[r][1], B[1][c]))
+            for c in range(2)
+        ]
+        for r in range(2)
+    ]
+
+
+def phi_m2h(A: QuaternionMatrix2) -> Matrix:
+    """Explicit real-algebra map M_2(H) -> M_8(R) by left action on H^2."""
+    blocks = [
+        [quaternion_regular_matrix(A[r][c], "left") for c in range(2)]
+        for r in range(2)
+    ]
+    top = blocks[0][0].row_join(blocks[0][1])
+    bottom = blocks[1][0].row_join(blocks[1][1])
+    return top.col_join(bottom)
+
+
+def matrix_units(n: int) -> list[Matrix]:
+    result = []
+    for row in range(n):
+        for col in range(n):
+            unit = zeros(n)
+            unit[row, col] = 1
+            result.append(unit)
+    return result
+
+
+def basis_coordinates(M: Matrix, basis: list[Matrix]) -> list | None:
+    """Exact coordinates of M in basis, or None when M is outside its span."""
+    coefficient_matrix = Matrix.hstack(*[Matrix(flatten(B)) for B in basis])
+    try:
+        solution = coefficient_matrix.solve(Matrix(flatten(M)))
+    except Exception:
+        return None
+    return [sympy.simplify(solution[i, 0]) for i in range(len(basis))]
+
+
+def commutant_basis(generators: list[Matrix]) -> list[Matrix]:
+    """Solve XG=GX exactly for every supplied generator G."""
+    if not generators:
+        return []
+    n = generators[0].rows
+    ambient_units = matrix_units(n)
+    columns = []
+    for unit in ambient_units:
+        constraints = [Matrix(flatten(unit * G - G * unit)) for G in generators]
+        columns.append(Matrix.vstack(*constraints))
+    system = Matrix.hstack(*columns)
+    return [Matrix(n, n, list(vector)) for vector in system.nullspace()]
+
+
+def block_diagonal_twice(M: Matrix) -> Matrix:
+    """diag(M, M)."""
+    zero = zeros(M.rows, M.cols)
+    return M.row_join(zero).col_join(zero.row_join(M))
+
+
 def main() -> int:
     print("=" * 88)
     print("Audit companion (exact-symbolic) for")
     print("CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27")
-    print("Goal: sympy verification of Cl(3, 0) -> Cl(3, 1) extension")
-    print("      uniqueness among single-M_k(R) real-matrix-algebra")
-    print("      Cartan-Bott cells at n = 4 reachable from Cl(3, 0).")
+    print("Goal: construct both Cl(3, 0) one-generator sign extensions")
+    print("      and distinguish M_2(H) from M_4(R) by explicit algebra maps,")
+    print("      solved commutants, and primitive-corner invariants.")
     print("=" * 88)
 
     # =========================================================================
     section("Part 1: (S1) Sign-`epsilon` rescaling exhausts the sign branch")
     # =========================================================================
-    # For any real epsilon != 0, e'_4 = e_4 / sqrt(|epsilon|) satisfies
-    # (e'_4)^2 = sign(epsilon) I. We verify this symbolically on a few
-    # representative values.
-    for eps_val in [Rational(1, 1), Rational(2, 1), Rational(-1, 1), Rational(-3, 1),
-                    Rational(7, 11), Rational(-11, 13)]:
-        sign_eps = 1 if eps_val > 0 else -1
-        # Rescaled square: (e_4 / sqrt(|eps|))^2 = e_4^2 / |eps| = eps / |eps| = sign(eps)
-        rescaled_sq = eps_val / abs(eps_val)
-        check(
-            f"(S1) epsilon = {eps_val}: rescaled square = sign(eps) = {sign_eps}",
-            rescaled_sq == sign_eps,
-            detail=f"eps/|eps| = {rescaled_sq}",
-        )
-
-    # Check that epsilon = 0 is excluded as the Clifford-extension condition
-    # (a degenerate quadratic form, not a Clifford algebra in the usual sense).
+    # Every nonzero real epsilon is either +r^2 or -r^2 for a unique r>0.
+    # These two symbolic identities therefore cover the entire nondegenerate
+    # branch, rather than a finite sample of epsilon values.
+    r = sympy.symbols("r", positive=True, real=True)
     check(
-        "(S1) epsilon = 0 excluded (degenerate quadratic form, not Clifford extension)",
-        True,
-        detail="e_4^2 = 0 yields nilpotent e_4, not a Clifford algebra",
+        "(S1) positive square +r^2 rescales to +1 for every r > 0",
+        sympy.simplify((r ** 2) / (r ** 2)) == 1,
+        detail="epsilon = +r^2",
     )
+    check(
+        "(S1) negative square -r^2 rescales to -1 for every r > 0",
+        sympy.simplify(-(r ** 2) / (r ** 2)) == -1,
+        detail="epsilon = -r^2",
+    )
+    print("  [BOUNDARY] epsilon = 0 is excluded by the nondegenerate-extension hypothesis")
 
     # =========================================================================
     section("Part 2: (S2) Cl(4, 0) realization with all Gammas squaring to +I_8")
     # =========================================================================
-    # Construct faithful 8x8 real Gammas for Cl(4, 0). We use the
-    # standard tensor-product block decomposition with four generators
-    # squaring to +I_8 and pairwise anticommuting.
-    #
-    # The 4x4 representation here is NOT a faithful M_2(H) representation;
-    # it is a real 4x4 module on which Cl(4, 0) acts. The 16 monomials
-    # therefore span a strict-subalgebra of M_4(R), of real dimension 8,
-    # reflecting the fact that the natural Cl(4, 0) faithful real-module
-    # is R^8 (= H^2), not R^4.
-    #
-    # For (S5) Cl(3, 0)-subalgebra-preservation, what matters is the
-    # action of the first three generators on R^4, which is identical
-    # between (S2) and (S3) realizations by construction.
-
+    # Build the plus branch inside M_2(H) first, then apply the explicit
+    # left-action map Phi: M_2(H) -> M_8(R).  This makes the target algebra
+    # part of the construction rather than a name inferred from dimension.
     I2 = eye(2)
     I4 = eye(4)
+    I8 = eye(8)
     sigma_x = Matrix([[0, 1], [1, 0]])
     sigma_z = Matrix([[1, 0], [0, -1]])
     eps_mat = Matrix([[0, -1], [1, 0]])  # iσ_y as a real matrix
@@ -253,66 +308,54 @@ def main() -> int:
         mat_zero(sigma_z * eps_mat + eps_mat * sigma_z),
     )
 
-    # Common first three generators (same as Cl(3, 1) construction)
+    # Generators for the minus branch are defined now because Part 3 reuses
+    # the same exact 2x2 building blocks.
     Gamma_1 = kron(sigma_x, I2)             # squares to +I_4
     Gamma_2 = kron(sigma_z, sigma_x)        # squares to +I_4
     Gamma_3 = kron(sigma_z, sigma_z)        # squares to +I_4
 
-    # Cl(4, 0) ≅ M_2(H) has faithful real action on H^2 ≅ R^8, not on
-    # R^4. We therefore verify the abstract Cl(4, 0) defining relations
-    # on a standard faithful 8x8 real-matrix realization.
+    # In M_2(H), let
+    #   g_1 = [[0,1],[1,0]],
+    #   g_u = [[0,u],[-u,0]] for u in {i,j,k}.
+    # Since u^2=-1 and distinct imaginary units anticommute, all four g's
+    # square to +1 and anticommute pairwise.
+    gamma_h_1 = h2_add(h2_unit(0, 1, Q_ONE), h2_unit(1, 0, Q_ONE))
 
-    # 8x8 real realization of Cl(4, 0) via the M_2(H) action on H^2 ≅ R^8.
-    # Standard quaternion units:
-    #   1, i, j, k with i^2 = j^2 = k^2 = -1, ij = k.
-    # Real 4x4 representation of quaternions (right-action):
-    Q1 = eye(4)
-    Qi = Matrix([[0, -1, 0, 0],
-                 [1, 0, 0, 0],
-                 [0, 0, 0, -1],
-                 [0, 0, 1, 0]])
-    Qj = Matrix([[0, 0, -1, 0],
-                 [0, 0, 0, 1],
-                 [1, 0, 0, 0],
-                 [0, -1, 0, 0]])
-    Qk = Matrix([[0, 0, 0, -1],
-                 [0, 0, -1, 0],
-                 [0, 1, 0, 0],
-                 [1, 0, 0, 0]])
-    check("(S2) Q_i^2 = -I_4 (quaternion i)", mat_eq(Qi * Qi, -eye(4)))
-    check("(S2) Q_j^2 = -I_4 (quaternion j)", mat_eq(Qj * Qj, -eye(4)))
-    check("(S2) Q_k^2 = -I_4 (quaternion k)", mat_eq(Qk * Qk, -eye(4)))
-    check("(S2) Q_i Q_j = Q_k", mat_eq(Qi * Qj, Qk))
-    check("(S2) Q_j Q_i = -Q_k", mat_eq(Qj * Qi, -Qk))
+    def gamma_h_imaginary(q: Quaternion) -> QuaternionMatrix2:
+        return h2_add(h2_unit(0, 1, q), h2_unit(1, 0, q_neg(q)))
 
-    # Cl(4, 0) 8x8 generators using H ⊗ R^2 = R^8 module:
-    # Γ_a = pure-imaginary quaternion + sigma-x tensor structure.
-    # We use the standard construction:
-    #   Γ_1 = Qi ⊗ σ_x       (8x8, squares to (-I_4)⊗(I_2) = -I_8? No, σ_x^2 = I_2)
-    #
-    # Actually: Γ_a = (pure-imaginary-quaternion)_a ⊗ σ_x has square
-    # (-I_4) ⊗ I_2 = -I_8, which gives Cl(0, 4), not Cl(4, 0).
-    #
-    # For Cl(4, 0) (all squares +1), use:
-    #   Γ'_a = Qi ⊗ σ_x with the σ_x replaced by σ_z (which squares to +I_2),
-    # and combine with the antisymmetric matrix epsilon...
-    #
-    # Cleaner: use the 4-generator Cl(4, 0) realization on R^8 via:
-    #   Γ_1 = σ_x ⊗ I_2 ⊗ I_2
-    #   Γ_2 = σ_z ⊗ σ_x ⊗ I_2
-    #   Γ_3 = σ_z ⊗ σ_z ⊗ σ_x
-    #   Γ_4 = σ_z ⊗ σ_z ⊗ σ_z
-    # All squaring to +I_8, pairwise anticommuting. This is Cl(4, 0) on R^8.
+    Gammas_40_h = [
+        gamma_h_1,
+        gamma_h_imaginary(Q_I),
+        gamma_h_imaginary(Q_J),
+        gamma_h_imaginary(Q_K),
+    ]
+    Gammas_40 = [phi_m2h(G) for G in Gammas_40_h]
+    Gamma_4_8_plus = Gammas_40[3]
 
-    Gamma_1_8 = kron(kron(sigma_x, I2), I2)
-    Gamma_2_8 = kron(kron(sigma_z, sigma_x), I2)
-    Gamma_3_8 = kron(kron(sigma_z, sigma_z), sigma_x)
-    Gamma_4_8_plus = kron(kron(sigma_z, sigma_z), sigma_z)  # squares to +I_8
+    # The standard 16-element real basis of M_2(H), mapped explicitly into
+    # M_8(R).  Its rank proves Phi injective.
+    m2h_basis = [h2_unit(row, col, q) for row in range(2) for col in range(2)
+                 for q in Q_BASIS]
+    phi_basis = [phi_m2h(A) for A in m2h_basis]
+    phi_rank = real_span_rank(phi_basis)
+    check(
+        "(S2) explicit Phi: M_2(H) -> M_8(R) is injective on its 16-element basis",
+        phi_rank == 16,
+        detail=f"computed image-basis rank = {phi_rank}",
+    )
+    phi_multiplicative = all(
+        mat_eq(phi_m2h(h2_mul(A, B)), phi_m2h(A) * phi_m2h(B))
+        for A in m2h_basis
+        for B in m2h_basis
+    )
+    check(
+        "(S2) Phi preserves all 256 products of standard M_2(H) basis elements",
+        phi_multiplicative,
+        detail="explicit real-algebra homomorphism",
+    )
 
-    Gammas_40 = [Gamma_1_8, Gamma_2_8, Gamma_3_8, Gamma_4_8_plus]
-    I8 = eye(8)
-
-    # Verify Cl(4, 0) defining relations on R^8
+    # Verify the plus-branch Clifford relations after applying Phi.
     for i in range(4):
         check(
             f"(S2) Γ_{i+1}^2 = +I_8 (Cl(4, 0) signature)",
@@ -328,7 +371,8 @@ def main() -> int:
                 detail="anticommute",
             )
 
-    # Compute 16 monomial indices and the 16 Cl(4, 0) monomials on R^8
+    # Compute the Clifford image and prove it is exactly image(Phi), not just
+    # another real algebra of the same dimension.
     monomial_indices = enumerate_monomial_indices(4)
     check(
         "(S2) 16 monomial indices enumerated for n = 4",
@@ -343,12 +387,67 @@ def main() -> int:
         rank_40 == 16,
         detail=f"computed rank = {rank_40}; dim_R Cl(4, 0) = 16",
     )
+    joint_rank_40_m2h = real_span_rank(monomials_40 + phi_basis)
+    check(
+        "(S2) Clifford-monomial image equals explicit Phi(M_2(H))",
+        rank_40 == phi_rank == joint_rank_40_m2h == 16,
+        detail=f"rank(Cl image + Phi basis) = {joint_rank_40_m2h}",
+    )
+    transition_40_to_m2h = [basis_coordinates(M, phi_basis) for M in monomials_40]
+    transition_matrix = Matrix.hstack(
+        *[Matrix(coefficients) for coefficients in transition_40_to_m2h
+          if coefficients is not None]
+    )
+    check(
+        "(S2) explicit Clifford-to-M_2(H) change-of-basis matrix is invertible",
+        len(transition_40_to_m2h) == 16
+        and all(coefficients is not None for coefficients in transition_40_to_m2h)
+        and transition_matrix.det() != 0,
+        detail=f"determinant = {transition_matrix.det()}",
+    )
+
+    # Compute the full commutant from X Gamma_a = Gamma_a X.  Independent
+    # right multiplication on H^2 supplies the expected quaternion basis.
+    commutant_40 = commutant_basis(Gammas_40)
+    right_actions = [
+        block_diagonal_twice(quaternion_regular_matrix(q, "right"))
+        for q in Q_BASIS
+    ]
+    # Right multiplication is an anti-representation.  Negating the three
+    # imaginary actions gives the usual Hamilton multiplication order.
+    comm_h = [right_actions[0], -right_actions[1], -right_actions[2], -right_actions[3]]
+    commutant_joint_rank = real_span_rank(commutant_40 + comm_h)
+    check(
+        "(S2) solved commutant has dimension 4 and equals diagonal right-H action",
+        len(commutant_40) == 4
+        and real_span_rank(comm_h) == 4
+        and commutant_joint_rank == 4,
+        detail=f"computed dim = {len(commutant_40)}; joint rank = {commutant_joint_rank}",
+    )
+    check(
+        "(S2) commutant units satisfy i^2=j^2=k^2=-1 and ij=k=-ji",
+        mat_eq(comm_h[1] * comm_h[1], -I8)
+        and mat_eq(comm_h[2] * comm_h[2], -I8)
+        and mat_eq(comm_h[3] * comm_h[3], -I8)
+        and mat_eq(comm_h[1] * comm_h[2], comm_h[3])
+        and mat_eq(comm_h[2] * comm_h[1], -comm_h[3]),
+    )
+    a, b, c, d = sympy.symbols("a b c d", real=True)
+    comm_q = a * comm_h[0] + b * comm_h[1] + c * comm_h[2] + d * comm_h[3]
+    comm_q_conjugate = a * comm_h[0] - b * comm_h[1] - c * comm_h[2] - d * comm_h[3]
+    norm_sq = a ** 2 + b ** 2 + c ** 2 + d ** 2
+    check(
+        "(S2) symbolic quaternion norm makes every nonzero commutant element invertible",
+        mat_eq(comm_q * comm_q_conjugate, norm_sq * I8)
+        and mat_eq(comm_q_conjugate * comm_q, norm_sq * I8),
+        detail="q q_bar = q_bar q = (a^2+b^2+c^2+d^2) I_8",
+    )
 
     # =========================================================================
     section("Part 3: (S3) Cl(3, 1) realization with η = diag(+1, +1, +1, -1)")
     # =========================================================================
-    # The 4x4 real Cl(3, 1) realization: same first three Γ_1, Γ_2, Γ_3 on R^4
-    # (squaring to +I_4 each), plus Γ_4 squaring to -I_4.
+    # The 4x4 real Cl(3, 1) realization uses the three R^4 matrices defined
+    # above (each squaring to +I_4), plus Gamma_4 squaring to -I_4.
 
     Gamma_4 = kron(sigma_z, eps_mat)  # squares to -I_4, anticommutes with Γ_1, Γ_2, Γ_3
 
@@ -383,6 +482,20 @@ def main() -> int:
         rank_31 == 16,
         detail="surjective onto M_4(R)",
     )
+    m4r_basis = matrix_units(4)
+    m4r_joint_rank = real_span_rank(monomials_31 + m4r_basis)
+    check(
+        "(S3) Clifford-monomial image equals the standard M_4(R) matrix-unit span",
+        real_span_rank(m4r_basis) == 16 and m4r_joint_rank == 16,
+        detail=f"rank(Cl image + matrix units) = {m4r_joint_rank}",
+    )
+    commutant_31 = commutant_basis(Gammas_31)
+    check(
+        "(S3) solved commutant is exactly the scalar real algebra R I_4",
+        len(commutant_31) == 1
+        and real_span_rank(commutant_31 + [I4]) == 1,
+        detail=f"computed commutant dimension = {len(commutant_31)}",
+    )
 
     # =========================================================================
     section("Part 4: (S2)-(S3) Side-by-side: only sign of Γ_4^2 differs")
@@ -407,56 +520,106 @@ def main() -> int:
         mat_eq(Gamma_4_8_plus * Gamma_4_8_plus, I8),
         detail="Cl(4, 0) spacelike-extended generator",
     )
-    # Abstract sign-only distinction: the absolute value of the square is +1 in
-    # both cases; only the sign differs.
+    # Extract the scalar-square coefficients from the displayed matrices.  The
+    # branch definition changes only this coefficient; equality of the first
+    # three generators' abstract multiplication tables is checked in Part 8.
+    sign_31 = sympy.trace(Gamma_4 * Gamma_4) / I4.rows
+    sign_40 = sympy.trace(Gamma_4_8_plus * Gamma_4_8_plus) / I8.rows
     check(
-        "(S4-side) Cl(3, 1) and Cl(4, 0) differ only in sign(Γ_4^2)",
-        True,
-        detail="ε = -1 vs ε = +1; this is the entire algebraic distinction",
+        "(S4-side) computed fourth-generator square coefficients are opposite unit signs",
+        sympy.simplify(sign_31 * sign_40) == -1
+        and sympy.simplify(sign_31 ** 2) == 1
+        and sympy.simplify(sign_40 ** 2) == 1,
+        detail=f"epsilon_minus = {sign_31}; epsilon_plus = {sign_40}",
     )
 
     # =========================================================================
-    section("Part 5: (S4) Cartan-Bott cells at n = 4 single-M_k(R) classification")
+    section("Part 5: (S4) Constructive real-vs-quaternionic discrimination")
     # =========================================================================
-    # Standard Cartan-Bott table at n = 4:
-    #   (p, q) = (4, 0): Cl(4, 0) ≅ M_2(H)
-    #   (p, q) = (3, 1): Cl(3, 1) ≅ M_4(R)
-    #   (p, q) = (2, 2): Cl(2, 2) ≅ M_4(R)
-    #   (p, q) = (1, 3): Cl(1, 3) ≅ M_2(H)
-    #   (p, q) = (0, 4): Cl(0, 4) ≅ M_2(H)
-    #
-    # Each cell has real-dimension 16 = 2^4. The single-M_k(R) cells are
-    # exactly (3, 1) and (2, 2), both with k = 4.
-    cartan_bott_n4 = {
-        (4, 0): ("M_2(H)", False),  # not a single M_k(R)
-        (3, 1): ("M_4(R)", True),
-        (2, 2): ("M_4(R)", True),
-        (1, 3): ("M_2(H)", False),
-        (0, 4): ("M_2(H)", False),
-    }
-    single_mk_r_cells = [pq for pq, (_, flag) in cartan_bott_n4.items() if flag]
+    # A primitive idempotent gives an algebra-isomorphism invariant: the real
+    # dimension and division type of its corner eAe.  For M_2(H), e=E_11 has
+    # corner H (dimension four and division).  For M_4(R), a primitive matrix
+    # unit has corner R (dimension one).  This rules out an accidental
+    # identification of the two 16-dimensional real algebras.
+    primitive_h = phi_m2h(h2_unit(0, 0, Q_ONE))
+    corner_h = [primitive_h * B * primitive_h for B in phi_basis]
+    corner_h_basis = [phi_m2h(h2_unit(0, 0, q)) for q in Q_BASIS]
+    corner_h_rank = real_span_rank(corner_h)
     check(
-        "(S4) Cartan-Bott n = 4 cells enumerated (5 cells)",
-        len(cartan_bott_n4) == 5,
-        detail=f"cells: {sorted(cartan_bott_n4.keys())}",
+        "(S4) plus-branch E_11 is idempotent and its corner has real dimension 4",
+        mat_eq(primitive_h * primitive_h, primitive_h)
+        and corner_h_rank == 4
+        and real_span_rank(corner_h + corner_h_basis) == 4,
+        detail=f"dim_R(E_11 A_plus E_11) = {corner_h_rank}",
+    )
+    corner_q = (
+        a * corner_h_basis[0]
+        + b * corner_h_basis[1]
+        + c * corner_h_basis[2]
+        + d * corner_h_basis[3]
+    )
+    corner_q_conjugate = (
+        a * corner_h_basis[0]
+        - b * corner_h_basis[1]
+        - c * corner_h_basis[2]
+        - d * corner_h_basis[3]
     )
     check(
-        "(S4) Among n = 4 cells, exactly (3, 1) and (2, 2) land on single M_k(R)",
-        set(single_mk_r_cells) == {(3, 1), (2, 2)},
-        detail=f"single-M_k(R) cells: {sorted(single_mk_r_cells)}",
+        "(S4) plus-branch primitive corner is quaternionic division algebra H",
+        mat_eq(corner_q * corner_q_conjugate, norm_sq * primitive_h)
+        and mat_eq(corner_q_conjugate * corner_q, norm_sq * primitive_h),
+        detail="nonzero corner elements invert by quaternion conjugation",
+    )
+
+    primitive_r = m4r_basis[0]
+    corner_r = [primitive_r * B * primitive_r for B in m4r_basis]
+    corner_r_rank = real_span_rank(corner_r)
+    check(
+        "(S4) minus-branch primitive matrix-unit corner has real dimension 1",
+        mat_eq(primitive_r * primitive_r, primitive_r) and corner_r_rank == 1,
+        detail=f"dim_R(E_11 M_4(R) E_11) = {corner_r_rank}",
+    )
+
+    real_matrix_sizes = [size for size in range(1, 17) if size * size == rank_40]
+    check(
+        "(S4) a single real matrix algebra of real dimension 16 would have size 4",
+        real_matrix_sizes == [4],
+        detail=f"integer solutions of k^2 = {rank_40}: {real_matrix_sizes}",
     )
     check(
-        "(S4) Both single-M_k(R) cells have k = 4 (real-dim 16 = 4 * 4)",
-        all(cartan_bott_n4[pq][0] == "M_4(R)" for pq in single_mk_r_cells),
-        detail="(3, 1) -> M_4(R), (2, 2) -> M_4(R)",
+        "(S4) primitive-corner invariant separates Phi(M_2(H)) from M_4(R)",
+        corner_h_rank != corner_r_rank,
+        detail=f"quaternionic corner dim {corner_h_rank} vs real corner dim {corner_r_rank}",
     )
-    # Each cell has real-dimension 16
-    for (p, q) in cartan_bott_n4:
-        check(
-            f"(S4) dim_R Cl({p}, {q}) = 2^{p+q} = {2**(p+q)}",
-            2 ** (p + q) == 16,
-            detail=f"universal-property",
-        )
+
+    # Mutation/decoy control.  Let M_4(R) act twice on R^8.  Its image also
+    # has algebra rank 16 and commutant dimension four, so either number by
+    # itself could falsely mimic the plus branch.  The decoy commutant is
+    # M_2(R), however, and contains nonzero zero divisors; the quaternion norm
+    # gate above rejects it.
+    duplicated_m4r_basis = [kron(B, I2) for B in m4r_basis]
+    duplicated_commutant = commutant_basis(duplicated_m4r_basis)
+    expected_duplicated_commutant = [kron(I4, B) for B in matrix_units(2)]
+    check(
+        "(S4 mutation control) duplicated M_4(R) also has rank 16 and commutant dimension 4",
+        real_span_rank(duplicated_m4r_basis) == 16
+        and len(duplicated_commutant) == 4
+        and real_span_rank(duplicated_commutant + expected_duplicated_commutant) == 4,
+        detail="dimension-only classifier is deliberately non-decisive",
+    )
+    decoy_idempotent = kron(I4, Matrix([[1, 0], [0, 0]]))
+    decoy_complement = I8 - decoy_idempotent
+    check(
+        "(S4 mutation control) duplicated-M_4(R) commutant has nonzero zero divisors",
+        not mat_zero(decoy_idempotent)
+        and not mat_zero(decoy_complement)
+        and mat_zero(decoy_idempotent * decoy_complement)
+        and all(
+            mat_zero(decoy_idempotent * B - B * decoy_idempotent)
+            for B in duplicated_m4r_basis
+        ),
+        detail="M_2(R) commutant fails the quaternion division-norm gate",
+    )
 
     # =========================================================================
     section("Part 6: (S4) Restriction to Cl(3, 0)-extensions at n = 4")
@@ -465,24 +628,31 @@ def main() -> int:
     # extension with ε = +1 adds a fourth positive-square generator → Cl(4, 0).
     # A single-generator extension with ε = -1 adds a fourth negative-square
     # generator → Cl(3, 1).
-    # The (2, 2) cell would require TWO negative-square generators; it is
-    # not reachable from Cl(3, 0) by a single-generator extension.
-    reachable = {(4, 0): "ε = +1", (3, 1): "ε = -1"}
-    unreachable = [pq for pq in cartan_bott_n4 if pq not in reachable]
+    # Derive the signatures arithmetically from the computed square signs.
+    def extension_signature(square_sign: int) -> tuple[int, int]:
+        return (3 + int(square_sign > 0), int(square_sign < 0))
+
+    reachable = {
+        extension_signature(int(sign_40)),
+        extension_signature(int(sign_31)),
+    }
     check(
         "(S4) Cl(3, 0)-extensions at n = 4: exactly {(4, 0), (3, 1)} reachable",
-        set(reachable.keys()) == {(4, 0), (3, 1)},
-        detail=f"reachable: {sorted(reachable.keys())}",
+        reachable == {(4, 0), (3, 1)},
+        detail=f"derived from square signs: {sorted(reachable)}",
     )
     check(
         "(S4) (2, 2) NOT reachable from Cl(3, 0) by single-generator extension",
-        (2, 2) in unreachable,
-        detail="(2, 2) needs two negative-square generators",
+        (2, 2) not in reachable,
+        detail="every derived signature retains the three positive-square generators",
     )
     check(
         "(S4) Among Cl(3, 0)-extensions at n = 4, only (3, 1) is single-M_k(R)",
-        (3, 1) in single_mk_r_cells and (4, 0) not in single_mk_r_cells,
-        detail="(3, 1) → M_4(R) is the unique single-M_k(R) Cl(3, 0)-extension",
+        rank_31 == 16
+        and m4r_joint_rank == 16
+        and joint_rank_40_m2h == 16
+        and corner_h_rank != corner_r_rank,
+        detail="minus image is M_4(R); plus image is M_2(H) with quaternionic primitive corner",
     )
 
     # =========================================================================
@@ -531,48 +701,28 @@ def main() -> int:
     # m_a * m_b expressed in the 8-monomial basis has the same
     # coefficients in both realizations (Cl(3, 1) on R^4 and Cl(4, 0) on R^8).
     #
-    # Equivalently, we verify a representative subset of structure constants.
-
-    # Some representative products to check
-    def find_coeff_basis(M: Matrix, basis: list) -> list:
-        """Express M as a real-linear combination of basis matrices and return
-        the coefficients. Returns None if not in the span."""
-        # Flatten M and basis matrices into vectors
-        v = Matrix(flatten(M))
-        cols = [Matrix(flatten(B)) for B in basis]
-        A = Matrix.hstack(*cols)
-        # Solve A x = v
-        try:
-            sol = A.solve(v)
-            return [sympy.simplify(sol[i, 0]) for i in range(len(basis))]
-        except Exception:
-            return None
-
-    # Product Γ_1 Γ_2 in both realizations should expand identically
-    # in the 8-monomial Cl(3, 0) basis (it IS one of the basis elements:
-    # the monomial with index (1, 2), so the coefficient vector is
-    # the unit vector at position (1, 2)).
-    prod_31_12 = Gammas_31[0] * Gammas_31[1]
-    coeffs_31 = find_coeff_basis(prod_31_12, cl3_monomials_31)
-    expected = [0, 0, 0, 0, 1, 0, 0, 0]  # Γ_1 Γ_2 is at position 4 (0-indexed) in cl3_indices
+    # Check every product, not a representative subset.  This comparison is
+    # independent of the different ambient module dimensions.
+    structure_constants_31 = [
+        basis_coordinates(A * B, cl3_monomials_31)
+        for A in cl3_monomials_31
+        for B in cl3_monomials_31
+    ]
+    structure_constants_40 = [
+        basis_coordinates(A * B, cl3_monomials_40)
+        for A in cl3_monomials_40
+        for B in cl3_monomials_40
+    ]
     check(
-        "(S5) Γ_1 Γ_2 expansion in Cl(3, 0) basis (Cl(3, 1) realization)",
-        coeffs_31 == expected,
-        detail=f"coeffs = {coeffs_31}",
+        "(S5) all 64 Cl(3, 0) basis products have identical structure constants",
+        all(coefficients is not None for coefficients in structure_constants_31)
+        and all(coefficients is not None for coefficients in structure_constants_40)
+        and structure_constants_31 == structure_constants_40,
+        detail="complete 8 x 8 multiplication table compared",
     )
 
-    prod_40_12 = Gammas_40[0] * Gammas_40[1]
-    coeffs_40 = find_coeff_basis(prod_40_12, cl3_monomials_40)
-    check(
-        "(S5) Γ_1 Γ_2 expansion in Cl(3, 0) basis (Cl(4, 0) realization)",
-        coeffs_40 == expected,
-        detail=f"coeffs = {coeffs_40}",
-    )
-
-    # Product Γ_1 Γ_2 Γ_3 (the volume element of Cl(3, 0)):
-    # in Cl(3, 0), ω = Γ_1 Γ_2 Γ_3 satisfies ω^2 = +I (since 3 anticommuting
-    # +1-squaring generators give ω^2 = -1 * (+1) * (+1) * (+1) = -1? Let's
-    # actually verify carefully:
+    # Product Γ_1 Γ_2 Γ_3 (the volume element of Cl(3, 0)).  For three
+    # anticommuting +1-square generators, omega^2 = -I:
     # ω^2 = Γ_1 Γ_2 Γ_3 Γ_1 Γ_2 Γ_3
     #     = Γ_1 Γ_2 (-Γ_1) Γ_3 Γ_2 Γ_3   (Γ_3 Γ_1 = -Γ_1 Γ_3)
     #     = -Γ_1 (-Γ_1) Γ_2 Γ_3 Γ_2 Γ_3  (Γ_2 Γ_1 = -Γ_1 Γ_2)

--- a/scripts/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.py
+++ b/scripts/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.py
@@ -33,7 +33,8 @@ except ImportError:
 
 
 ROOT = Path(__file__).resolve().parent.parent
-NOTE_PATH = ROOT / "docs" / "CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27.md"
+NOTE_REL_PATH = Path("docs") / "CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27.md"
+NOTE_PATH = ROOT / NOTE_REL_PATH
 CLAIM_ID = "cl3_to_cl31_spinor_extension_narrow_theorem_note_2026-05-27"
 
 
@@ -758,7 +759,7 @@ def main() -> int:
     # =========================================================================
     section("Final result")
     # =========================================================================
-    print(f"  Note path: {NOTE_PATH}")
+    print(f"  Note path: {NOTE_REL_PATH.as_posix()}")
     print(f"  Claim id:  {CLAIM_ID}")
     print(f"  PASS = {PASS}")
     print(f"  FAIL = {FAIL}")


### PR DESCRIPTION
## Audit repair target

> runner_artifact_issue: extend the runner to identify the Cl(4,0) image explicitly with M_2(H), for example through a computed quaternionic commutant and explicit algebra isomorphism, or provide the cited Cartan-Bott theorem as a one-hop authority; also replace the literal classification-table assertions with derived checks.

## Summary

- Construct Hamilton quaternion multiplication and the explicit real-algebra map `Phi: M_2(H) -> M_8(R)`, verify all 256 basis products, and prove the displayed Clifford image equals `Phi(M_2(H))` by an exact invertible change of basis.
- Solve the full plus-branch commutant, identify its diagonal right-quaternion action, derive its Hamilton relations and division norm, and separate it from `M_4(R)` with primitive-corner invariants.
- Add a mutation control using duplicated `M_4(R)` on `R^8`: it shares rank 16 and commutant dimension four but its `M_2(R)` commutant has nonzero zero divisors.
- Preserve the exact positive and negative sign branches and the explicit `Cl(3,1) = M_4(R)` matrix-unit span while deriving reachability arithmetically instead of consulting literal classification-table strings.
- Align the theorem note with the constructive proof and refresh the policy-required runner cache.

## Validation

- `python3 -m py_compile scripts/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.py`
- `python3 scripts/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.py` — PASS=60, FAIL=0
- `python3 scripts/cached_runner_output.py scripts/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.py --check-only --timeout-sec 120 --tail-chars 5000`
- `python3 scripts/vocab_lint.py --report-only docs/CL3_TO_CL31_SPINOR_EXTENSION_NARROW_THEOREM_NOTE_2026-05-27.md scripts/audit_companion_cl3_to_cl31_spinor_extension_exact_2026_05_27.py` — zero violations
- `python3 docs/audit/scripts/check_staged_claim_typing.py`
- `git diff --check`
- Independent tensor-product matrix cross-check recovered a four-dimensional Hamilton commutant for `Cl(4,0)` and rank 16 for both displayed sign branches.
- `bash docs/audit/scripts/run_pipeline.sh` — all 18 phases and repository invariants passed in the isolated worktree; every generated audit, queue, status, and publication output was restored to `origin/main` before commit.

## Scope and residual risk

The proof still imports the standard Clifford universal property and dimension formula, real sign normalization, Hamilton multiplication, and elementary matrix algebra. Those supplied mathematical conditions are explicit in the note. This remains a finite real-algebra theorem only and does not derive a physical sign selector or close P2.

This row remains unaudited in this PR. Only the independent audit lane may assign a verdict. No audit worker or verdict-application command was run, and no audit ledger, queue, verdict, or generated status output is changed.