### PR TITLE
feat(velocity-rg): cross-sector front-speed B4 two-surface alignment bounded theorem

### DIFF
--- a/docs/CROSS_SECTOR_FRONT_SPEED_B4_TWO_SURFACE_ALIGNMENT_BOUNDED_THEOREM_NOTE_2026-07-16.md
+++ b/docs/CROSS_SECTOR_FRONT_SPEED_B4_TWO_SURFACE_ALIGNMENT_BOUNDED_THEOREM_NOTE_2026-07-16.md
@@ -6,7 +6,7 @@
 **Date:** 2026-07-16
 **Claim type:** bounded_theorem
 **Type:** bounded_theorem
-**Premise weight:** conditional (two named supplied legs, declared below)
+**Premise weight:** conditional (three named supplied legs, declared below)
 **Status authority:** independent audit lane. This source note does not set or
 predict an audit outcome. Any `audit_status` and `effective_status` fields are
 pipeline-derived.
@@ -22,8 +22,11 @@ This note does **not** amend, narrow, retire, or re-approve any registered
 primitive (the kinetic-isotropy primitive
 [`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md)
 is unchanged), does not set the status of any lane row, and does not edit any
-landed note. Conditional on two named supplied legs, it proves a **two-surface**
-statement about the cross-sector front-speed ratio `v_F/v_G`:
+landed note. Conditional on three named supplied legs, it proves a **two-surface**
+statement about the cross-sector ratio `v_F/v_G` of **Euclidean marginal
+coefficient ratios** (the physical front-speed reading of that ratio is itself
+a supplied bridge — leg 3 below; every "front speed" phrase in this note is
+conditional on it):
 
 - **On the `Z^4` `B4`-covariant regulated surface** (the surface the landed
   `ALLORDERS_B4` note supplies in its premise (A)): `B4` invariance pins **each
@@ -32,14 +35,19 @@ statement about the cross-sector front-speed ratio `v_F/v_G`:
   cancel exactly in the ratio, so `v_F/v_G = 1` identically, order-by-order.
   Per-sector `B4` pinning — a common rigid frame both sectors separately
   respect — **is** the custodial mechanism; no inter-sector Ward identity is
-  involved, and off-surface the two sectors are mutually unconstrained.
+  involved, and off-surface the time-fixing symmetry alone does not force
+  cross-sector equality (a symmetry-counting statement only; see below).
 - **On the time-fixed surface** (`Z^3` plus continuous tick — the continuous-time
   horn where `B4` is broken): the same exact counting leaves each sector's
   `c_t/c_s` an independent singlet of the time-fixing subgroup, and
-  `v_F/v_G = sqrt(a_F/a_G)` is free — set by the two independent per-sector
-  anisotropies through their quotient alone, exactly as the two landed
-  velocity-RG parentheticals assert. Those parentheticals are scoped (not contradicted, not
-  edited) as broken-`B4`-surface statements.
+  `v_F/v_G = sqrt(a_F/a_G)` is not forced to `1` by symmetry — it is set by
+  the two independent per-sector anisotropies through their quotient alone.
+  This is **symmetry counting only**: whether dynamics fixes the quotient is a
+  separate question, and the landed velocity-RG mutual-drag flow
+  (`dv_F/dl = a (v_b − v_F)`, `dv_b/dl = b (v_F − v_b)`, `eta -> 1` for any
+  `a, b > 0`) is a live dynamical route toward equality on this surface — not
+  contradicted here. The two landed velocity-RG parentheticals are scoped (not
+  contradicted, not edited) as broken-`B4`-surface symmetry statements.
 
 Companion to the landed
 [`VELOCITY_RG_LOGFLOW_FRAMEWORK_INTERNAL_2026-06-21.md`](VELOCITY_RG_LOGFLOW_FRAMEWORK_INTERNAL_2026-06-21.md),
@@ -47,7 +55,7 @@ Companion to the landed
 [`ALLORDERS_B4_MARGINAL_PROTECTION_SYMMETRY_THEOREM_NOTE_2026-06-14.md`](ALLORDERS_B4_MARGINAL_PROTECTION_SYMMETRY_THEOREM_NOTE_2026-06-14.md), and
 [`TASTE_SECTOR_MARGINAL_LV_B4_PROTECTION_ON_OS0_BOUNDED_THEOREM_NOTE_2026-06-13.md`](TASTE_SECTOR_MARGINAL_LV_B4_PROTECTION_ON_OS0_BOUNDED_THEOREM_NOTE_2026-06-13.md).
 
-## Supplied-context declaration (two legs)
+## Supplied-context declaration (three legs)
 
 > **Declared supplied context — leg 1: the `ALLORDERS_B4` premise (A) surface.**
 > The regulated `Z^4` action and measure used here (gauged staggered/Kähler-Dirac
@@ -76,13 +84,26 @@ Companion to the landed
 > supplied here as a declared readout context; it is not derived here, and every
 > fermion-side claim below is conditional on it.
 
-These are the note's two supplied legs; beyond them, this note introduces no
+> **Declared supplied context — leg 3: `euclidean_marginal_front_speed_bridge_context`.**
+> Everything computed here is a **finite-grid Euclidean marginal coefficient**:
+> the curvature of a Euclidean 1PI kernel at a regulated grid point. The
+> identification of the coefficient ratio `sqrt(c_s/c_t)` with a **physical
+> (Lorentzian) front speed** — a pole/group-velocity readout after analytic
+> continuation — is a bridge this note does not construct: no spectral
+> function, no pole position, and no continuation are computed. Every "front
+> speed" phrase in this note is conditional on this bridge. It is supplied
+> here as a declared context; it is not derived, and none of the landed notes
+> cited here derives it.
+
+These are the note's three supplied legs; beyond them, this note introduces no
 import, axiom, or comparator of its own.
 
 ## Theorem (two-surface, conditional on the declared legs)
 
-Per sector, the marginal kinetic form is `c_t p_t^2 + c_s (p_x^2+p_y^2+p_z^2)`
-with front speed `v = sqrt(c_s/c_t)`; the cross-sector ratio is
+Per sector, the Euclidean marginal kinetic form is
+`c_t p_t^2 + c_s (p_x^2+p_y^2+p_z^2)` with marginal coefficient ratio
+`v = sqrt(c_s/c_t)` (read as the front speed under leg 3); the cross-sector
+ratio is
 
 ```text
 v_F/v_G = sqrt( (c_sF/c_tF) / (c_sG/c_tG) ) = sqrt( c_sF c_tG / (c_tF c_sG) ).
@@ -107,6 +128,24 @@ reproduces, per sector, the landed counting (`ALLORDERS_B4`, lines 81–85):
 > cubic group `O_h` plus a free temporal coefficient leaves two.
 > (Reynolds-operator rank; runner Part B.)
 
+**Joint (taste, axis) representation lemma (runner V5).** The 4-vector
+counting above is not, by itself, the fermion-side statement: the fermion
+object is the **24-dimensional** coefficient array `c_{B,mu}` over the six
+`hw2` tastes `B` and the four axes `mu`. Under the joint `S4` action
+(`B -> B o p`, `mu -> p^{-1}(mu)`; the membership relation `mu in B` is
+preserved) the invariant subspace has **rank 2**, spanned by the orbit
+indicators `{mu in B}` and `{mu not in B}` — a per-taste anisotropy is
+therefore symmetry-**allowed**, and V3 observes it (`O(0.2)`,
+kernel-dependent). Uniform averaging over the six `hw2` tastes composed with
+the `S4` Reynolds projector has **rank 1 with isotropic image**, because each
+axis lies in exactly 3 of the 6 `hw2` tastes (runner-verified): the V3
+orbit-sum zero is exactly this representation-forced projection, and it
+consumes leg 2 (uniform orbit averaging) essentially — a non-uniform taste
+weighting would not project to the isotropic line. Under the joint time-fixing
+`S3` the invariant rank is **6** (six (taste-type, axis-role) orbits), and
+uniform `hw2` averaging maps it to rank **2** (`c_t`, `c_s` independent):
+time-fixing symmetry alone does not force `c_t = c_s`.
+
 ### L2. Symmetry transport to both 1PI channels of one action (leg 1 + `ALLORDERS_B4` (C))
 
 On the leg-1 surface, the landed transport step (`ALLORDERS_B4`, lines 87–89)
@@ -119,8 +158,11 @@ applies:
 Because both sectors' 1PI objects — the fermion self-energy and the gauge vacuum
 polarization — are channels of the **same** `Gamma[phi]` of the **same** supplied
 leg-1 action, L1 pins **each** sector's marginal kinetic form isotropic
-order-by-order at once. No inter-sector identity is used: the pinning is per-sector, by the
-shared rigid frame.
+order-by-order at once. On the fermion side the pinned object is the leg-2
+orbit-averaged marginal form, and the joint representation lemma (L1) is the
+transport: joint `B4` covariance of `c_{B,mu}` plus uniform `hw2` averaging
+forces the averaged vector isotropic. No inter-sector identity is used: the
+pinning is per-sector, by the shared rigid frame.
 
 ### L3. Speed arithmetic (runner V6, exact sympy + numeric gates)
 
@@ -131,9 +173,13 @@ speed, and a direction-dependent normalization at marginal order is precisely
 the anisotropy `B4` forbids (L1). `Z_F` and `Z_G` cancel exactly in `v_F/v_G`
 (symbolic). On the `B4`-pinned surface (`c_t = c_s` per sector) the ratio is
 `1` **identically** — no tuning, no flow. On the time-fixed surface, with
-`a_F = c_sF/c_tF` and `a_G = c_sG/c_tG`, the ratio `sqrt(a_F/a_G)` is free:
-it depends only on the quotient of the two independent per-sector anisotropies
-(scale-invariant in `(a_F, a_G)`), and any positive value is attained.
+`a_F = c_sF/c_tF` and `a_G = c_sG/c_tG`, the ratio `sqrt(a_F/a_G)` is not
+fixed by the symmetry: it depends only on the quotient of the two independent
+per-sector anisotropies (scale-invariant in `(a_F, a_G)`), and symmetry
+counting alone admits any positive value. This is a statement about what
+symmetry **forces**, not about what dynamics **selects**: the landed
+velocity-RG mutual-drag flow drives `eta = v_F/v_b -> 1` for any `a, b > 0`
+on this surface, and nothing here constrains or contradicts that route.
 
 ### L4. Computed one-loop instances (runner V2, V3, V6)
 
@@ -147,10 +193,14 @@ renormalization there). Each channel's own `B4` covariance is what the theorem
 consumes; the instances are witnesses, not the proof.
 
 - **Gauge sector** (seagull-completed transverse `Pi`, `T_F = 1/2`): lattice
-  Ward transversality holds (worst relative violation `0.0169` at `N=12`) while
-  the bubble (no seagull) violates it at `0.31`; `piT(temporal) = piT(spatial)`
-  within `1e-8` at isotropic input; `eta = 1` is a fixed point (induced
-  anisotropy within `1e-8` at zero deformation).
+  Ward transversality holds (worst normalized residual
+  `|khat.Pi|/(|khat||Pi|) = 0.043` at `N=12`) while the bubble (no seagull)
+  violates it at `0.74`; the **fully gauged anisotropic control** — `v_mu` in
+  the propagators, the vertices, **and** the seagull (gauging
+  `sum_mu v_mu sin(k_mu + A_mu)`) — stays transverse under deformation (worst
+  residual `0.045` at `eps = 0.10`); `piT(temporal) = piT(spatial)` within
+  `1e-8` at isotropic input; `eta = 1` is a fixed point (induced anisotropy
+  within `1e-8` at zero deformation).
 - **Fermion sector** (orbit-summed observable, leg 2): three kernels — rainbow
   scalar-gluon; gauged cos-vertex on the Wilson block, Feynman `xi=1`; gauged
   cos-vertex, Landau `xi=0` — all give `hw2` orbit-summed marginal anisotropy
@@ -164,24 +214,32 @@ consumes; the instances are witnesses, not the proof.
 
 ### Scoped result
 
-On the `Z^4` surface, conditional on the two declared legs, `v_F/v_G = 1`
+On the `Z^4` surface, conditional on the three declared legs, `v_F/v_G = 1`
 order-by-order: **per-sector `B4` pinning is the cross-sector custodial
-mechanism** — a common rigid frame, not an inter-sector Ward identity. On the
-time-fixed surface the protection genuinely fails and the relative speed is
-free — set by the quotient of the two per-sector anisotropies — exactly as the
-landed parentheticals assert (scoped below).
+mechanism** — a common rigid frame, not an inter-sector Ward identity. In the
+tightest wording: **conditional on exact joint covariance and uniform `hw2`
+averaging, the orbit-averaged Euclidean marginal coefficient vector is
+isotropic; time-fixing symmetry alone does not force cross-sector equality.**
+On the time-fixed surface the symmetry protection genuinely fails and the
+ratio is set by the quotient of the two per-sector anisotropies; the landed
+velocity-RG mutual-drag flow remains the live dynamical route toward equality
+there (scoped below).
 
 ## Custodial frame, not inter-sector identity (runner V4)
 
-The runner's off-surface controls (V4) test the mechanism class, showing the
-sectors are **mutually unconstrained**:
+The runner's off-surface controls (V4) are **symmetry-tracking witnesses** of
+the mechanism class (each sector's isotropy responds to its own kernel's
+covariance) — they are not a dynamical-unconstraint claim:
 
 - Deforming the temporal edge of the Wilson gluon block
   (`(2/xi) sin(xi q_0/2)`) revives the fermion orbit-summed anisotropy:
-  `+0.0009` at `xi=0.7`, `-0.0013` at `xi=1.3` (a sign straddle — `xi=1` is an
-  isolated zero), and `-0.0003` at `xi=1.3` for the gauged-vertex kernel.
+  `+0.0009` at `xi=0.7`, `-0.0013` at `xi=1.3` (a sign straddle across
+  `xi=1`; two samples — no isolated-zero claim), and `-0.0003` at `xi=1.3`
+  for the gauged-vertex kernel.
 - Deforming the fermion velocity moves `Pi`: induced gauge-sector anisotropy
-  `+0.0547` at `eps = 0.10`.
+  `+0.0603` at `eps = 0.10` (fully gauged control: `v_mu` in the propagators,
+  the vertices, and the seagull; transversality preserved under the
+  deformation, V2).
 - The tadpole direction test (`T_mu` = BZ-grid mean of the Landau-form tadpole
   integrand on the Wilson block — a declared normalization, used purely as a
   direction-sensitivity witness) is direction-blind on-surface (relative spread
@@ -204,8 +262,10 @@ signs differ). The orbit-summed zero is symmetry-driven, not kernel tuning.
    not assembled at a single common parameter point (see L4). `ALLORDERS_B4`'s
    computed confirmations were fermion-side; its gauge-channel instance and the
    cross-sector ratio corollary were not stated there.
-2. **Off-surface mutual unconstraint** (V4): the custodial-frame mechanism
-   class, distinguished experimentally from an inter-sector identity.
+2. **Off-surface deformation-response witnesses** (V4): symmetry-tracking
+   controls that distinguish the custodial-frame mechanism class from an
+   inter-sector identity (each sector's isotropy tracks its own kernel's
+   covariance; no dynamical-unconstraint claim).
 3. **Exact Reynolds counting applied to the cross-sector ratio** (V5 + V6):
    rank 1 per sector pins `v_F/v_G = 1`; rank 2 per sector frees it — the
    two-surface split as a theorem about the **ratio**, not just per-sector
@@ -246,12 +306,14 @@ lines 20–22:
 > of emergent Lorentz invariance: `B4` does not cover it (the relative speed is a
 > free `B4` invariant), and the only handle is the velocity-RG mutual-drag flow.
 
-**Derived scope.** The clause "the relative speed is a free `B4` invariant" is a
-theorem **on the time-fixed surface**: there the acting symmetry is the
-time-fixing subgroup, its Reynolds rank is 2 per sector (V5), each sector's
-`c_t/c_s` is an independent singlet, and `v_F/v_G = sqrt(a_F/a_G)` is free
-(V6) — set by the quotient of the two independent per-sector anisotropies, as
-asserted. This is the continuous-time horn
+**Derived scope.** The clause "the relative speed is a free `B4` invariant" is
+verified here **as symmetry content on the time-fixed surface**: there the
+acting symmetry is the time-fixing subgroup, its Reynolds rank is 2 per sector
+(joint rank 2 after averaging, V5), each sector's `c_t/c_s` is an independent
+singlet, and `v_F/v_G = sqrt(a_F/a_G)` is not fixed by the symmetry (V6). What
+is proved is that **time-fixing symmetry does not force equality** — not that
+dynamics leaves the ratio free: the parentheticals' own mutual-drag flow is the
+live dynamical mechanism on that surface. This is the continuous-time horn
 where the landed `ALLORDERS_B4` note (lines 178–184) already records:
 
 > It does
@@ -277,7 +339,7 @@ The logflow note also states the demand (lines 116–117):
 On the leg-1 surface, per-sector `B4` pinning is a cross-sector custodial
 mechanism of exactly the requested kind — supplied by the same premise (A) the
 lane already consumes, acting as a common rigid frame rather than an
-inter-sector Ward identity (V4). Conditional on the two declared legs, the
+inter-sector Ward identity (V4). Conditional on the three declared legs, the
 alignment question therefore **relocates** from the velocity-RG flow to the
 **surface license**: which regulated surface — `Z^4` `B4`-covariant, or `Z^3`
 plus continuous tick — is licensed for the front-speed readout. That license is
@@ -286,9 +348,13 @@ next path this opens (the temporal-axis / emergent-time question).
 
 ## Honest boundary (auditor-first)
 
-- **Both legs are supplied, not derived.** Leg 1 carries the same weight the
-  `ALLORDERS_B4` note assigns its premise (A) (quoted above). Leg 2 is a
-  readout identification with no origin/main license in either direction. The
+- **All three legs are supplied, not derived.** Leg 1 carries the same weight
+  the `ALLORDERS_B4` note assigns its premise (A) (quoted above). Leg 2 is a
+  readout identification with no origin/main license in either direction. Leg 3
+  (the Euclidean-marginal-to-front-speed bridge) carries the weight of an
+  unconstructed analytic continuation: the runner computes finite-grid
+  Euclidean marginal coefficients only, and every "front speed" phrase in this
+  note is conditional on that bridge. The
   landed taste note states the dichotomy (lines 229–235):
 
   > The **per-single-taste `O(0.2)` anisotropy is the genuine
@@ -311,11 +377,14 @@ next path this opens (the temporal-axis / emergent-time question).
   source/action bridge, or readout selector." Accordingly, nothing in the
   record ontology is invoked here to justify orbit-summing; leg 2 is an
   explicit declaration, which is why it must be named as supplied context.
-- **The time-fixed horn is genuinely unprotected.** Nothing here shrinks the
-  freedom on that surface — the ratio remains set by the quotient of the two
-  per-sector anisotropies; this note derives that the freedom is exactly the
-  landed parentheticals' content.
-- **The surface license is open.** Neither leg selects which surface is
+- **The time-fixed horn is symmetry-unprotected — a counting statement only.**
+  What is proved on that surface is that time-fixing symmetry alone does not
+  force `c_t = c_s` (joint averaged rank 2, V5); the ratio is then set by the
+  quotient of the two per-sector anisotropies **as far as symmetry is
+  concerned**. Whether dynamics selects equality there is untouched: the
+  landed velocity-RG mutual-drag flow (`eta -> 1` for any `a, b > 0`) is the
+  live route, and nothing here constrains it.
+- **The surface license is open.** None of the three legs selects which surface is
   licensed for the front-speed readout; the theorem is a conditional alignment
   on the `Z^4` surface plus an exact freedom statement on the time-fixed
   surface. The license question is the next path this opens.
@@ -365,10 +434,10 @@ scopes.
 | Part | Checks | What it certifies |
 |---|---|---|
 | V1 | 4 | Clifford algebra for both landed gamma conventions; `W_B` conjugation identity for all 16 taste shifts; gauged cos-vertex taste covariance |
-| V2 | 4 | seagull-completed `Pi` transversality (Ward `< 5%` at `N=12`) vs large bubble (no seagull) violation; `B4` isotropy `piT(t) = piT(s)`; `eta = 1` fixed point |
+| V2 | 5 | seagull-completed `Pi` transversality (normalized Ward residual `< 5%` at `N=12`) vs large bubble (no seagull) violation; deformed-kernel transversality (`v_mu` in propagators, vertices, seagull; `eps = 0.10`); `B4` isotropy `piT(t) = piT(s)`; `eta = 1` fixed point |
 | V3 | 11 | honest-observable (`G_hon`) non-degeneracy (both kernels); per-taste anisotropy nonzero with kernel-dependent values and signs (three kernels, matched `N=10`); `hw2` orbit-summed anisotropy zero on-surface at `N=12` and `N=10`, Feynman and Landau |
-| V4 | 7 | off-surface controls: orbit anisotropy revives with a sign straddle; mutual unconstraint (`Pi` feels the fermion deformation; the gluon-edge deformation moves the fermion orbit sum); tadpole direction-blind on-surface, direction-sensitive off-surface |
-| V5 | 4 | exact sympy Reynolds counting: `B4` (`S4` quotient) rank 1 with isotropic image; time-fixing subgroup rank 2 with `(1,0,0,0)` surviving |
+| V4 | 7 | off-surface deformation-response witnesses: orbit anisotropy revives with a sign straddle across `xi=1` (two samples); `Pi` feels the fermion deformation; the gluon-edge deformation moves the fermion orbit sum; tadpole direction-blind on-surface, direction-sensitive off-surface |
+| V5 | 9 | exact sympy Reynolds counting: `B4` (`S4` quotient) rank 1 with isotropic image; time-fixing subgroup rank 2 with `(1,0,0,0)` surviving; joint 24-dim `(hw2 taste, axis)` lemma — joint `S4` rank 2 (orbit indicators), each axis in exactly 3 of 6 tastes, uniform averaging composed with Reynolds rank 1 isotropic, joint time-fixing `S3` rank 6 mapping to averaged rank 2 |
 | V6 | 5 | exact `Z_F`, `Z_G` cancellation; pinned-surface ratio `= 1` identically; broken-surface ratio `sqrt(a_F/a_G)` depending only on the anisotropy quotient (scale-invariance gated); numeric `delta(v_F/v_G)` gates — gauged cos-vertex primary, rainbow robustness |
 
 Runner gates are tolerance bounds around structure (zero/nonzero/sign/rank);
@@ -378,5 +447,5 @@ gated prints are bound checks at pass tolerances (platform-stable output).
 
 ```
 python3 scripts/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.py
-# expect: TOTAL: PASS=35 FAIL=0   (N=12 primary / N=10 secondary grids, ~6 s, low memory)
+# expect: TOTAL: PASS=41 FAIL=0   (N=12 primary / N=10 secondary grids, ~7 s, low memory)
 ```

--- a/docs/CROSS_SECTOR_FRONT_SPEED_B4_TWO_SURFACE_ALIGNMENT_BOUNDED_THEOREM_NOTE_2026-07-16.md
+++ b/docs/CROSS_SECTOR_FRONT_SPEED_B4_TWO_SURFACE_ALIGNMENT_BOUNDED_THEOREM_NOTE_2026-07-16.md
@@ -1,0 +1,382 @@
+# Cross-Sector Front-Speed Alignment: Per-Sector B4 Pinning as the Custodial Mechanism (Two-Surface Bounded Theorem)
+
+> **Key terms used in this doc** are indexed A–Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-07-16
+**Claim type:** bounded_theorem
+**Type:** bounded_theorem
+**Premise weight:** conditional (two named supplied legs, declared below)
+**Status authority:** independent audit lane. This source note does not set or
+predict an audit outcome. Any `audit_status` and `effective_status` fields are
+pipeline-derived.
+
+**Primary runner:**
+[`scripts/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.py`](../scripts/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.py)
+**Cached runner output:**
+[`logs/runner-cache/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.txt`](../logs/runner-cache/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.txt)
+
+## What this is
+
+This note does **not** amend, narrow, retire, or re-approve any registered
+primitive (the kinetic-isotropy primitive
+[`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md)
+is unchanged), does not set the status of any lane row, and does not edit any
+landed note. Conditional on two named supplied legs, it proves a **two-surface**
+statement about the cross-sector front-speed ratio `v_F/v_G`:
+
+- **On the `Z^4` `B4`-covariant regulated surface** (the surface the landed
+  `ALLORDERS_B4` note supplies in its premise (A)): `B4` invariance pins **each
+  sector's** diagonal marginal kinetic form isotropic, `c_t = c_s` per sector,
+  order-by-order in the loop expansion. The kinetic normalizations `Z_F`, `Z_G`
+  cancel exactly in the ratio, so `v_F/v_G = 1` identically, order-by-order.
+  Per-sector `B4` pinning — a common rigid frame both sectors separately
+  respect — **is** the custodial mechanism; no inter-sector Ward identity is
+  involved, and off-surface the two sectors are mutually unconstrained.
+- **On the time-fixed surface** (`Z^3` plus continuous tick — the continuous-time
+  horn where `B4` is broken): the same exact counting leaves each sector's
+  `c_t/c_s` an independent singlet of the time-fixing subgroup, and
+  `v_F/v_G = sqrt(a_F/a_G)` is free — set by the two independent per-sector
+  anisotropies through their quotient alone, exactly as the two landed
+  velocity-RG parentheticals assert. Those parentheticals are scoped (not contradicted, not
+  edited) as broken-`B4`-surface statements.
+
+Companion to the landed
+[`VELOCITY_RG_LOGFLOW_FRAMEWORK_INTERNAL_2026-06-21.md`](VELOCITY_RG_LOGFLOW_FRAMEWORK_INTERNAL_2026-06-21.md),
+[`VELOCITY_RG_GAUGE_SEAGULL_TRANSVERSE_VACUUM_POLARIZATION_2026-06-22.md`](VELOCITY_RG_GAUGE_SEAGULL_TRANSVERSE_VACUUM_POLARIZATION_2026-06-22.md),
+[`ALLORDERS_B4_MARGINAL_PROTECTION_SYMMETRY_THEOREM_NOTE_2026-06-14.md`](ALLORDERS_B4_MARGINAL_PROTECTION_SYMMETRY_THEOREM_NOTE_2026-06-14.md), and
+[`TASTE_SECTOR_MARGINAL_LV_B4_PROTECTION_ON_OS0_BOUNDED_THEOREM_NOTE_2026-06-13.md`](TASTE_SECTOR_MARGINAL_LV_B4_PROTECTION_ON_OS0_BOUNDED_THEOREM_NOTE_2026-06-13.md).
+
+## Supplied-context declaration (two legs)
+
+> **Declared supplied context — leg 1: the `ALLORDERS_B4` premise (A) surface.**
+> The regulated `Z^4` action and measure used here (gauged staggered/Kähler-Dirac
+> fermions with cos vertices and the seagull, on the Wilson gluon block) are
+> taken exactly `B4`-invariant, as
+> [`ALLORDERS_B4_MARGINAL_PROTECTION_SYMMETRY_THEOREM_NOTE_2026-06-14.md`](ALLORDERS_B4_MARGINAL_PROTECTION_SYMMETRY_THEOREM_NOTE_2026-06-14.md)
+> supplies in its premise (A) (line 58): "**(A) The supplied regulated action and
+> measure are exactly `B4`-invariant.**" That note weighs this premise plainly
+> (lines 77–79): "This is the **load-bearing supplied premise**. Runner Part A
+> checks the finite action/measure invariance claims used here, but the theorem
+> does not derive the choice of regulator action from the repo axioms." The same
+> weight applies here: the `B4`-invariant surface is supplied, not derived from
+> the four axioms; it is not derived here, and every claim below is conditional
+> on it.
+
+> **Declared supplied context — leg 2: `taste_orbit_summed_front_speed_readout_context`.**
+> The physical fermion front-speed observable is identified as the
+> **taste-orbit-summed** marginal curvature: the mean of the dispersion
+> curvatures of the honest observable (`G_hon = Dinv - Sigma`, per the landed
+> taste note) over the six-element Hamming-weight-2 taste orbit `hw2`.
+> None of the landed notes cited here licenses either the orbit-summed or the
+> single-taste reading as the physical front-speed readout, and Record supplies
+> no readout selector (see the honest boundary). On the **single-taste** reading the
+> alignment theorem does **not** follow from this note: the per-taste marginal
+> anisotropy is nonzero and kernel-dependent (runner V3). The identification is
+> supplied here as a declared readout context; it is not derived here, and every
+> fermion-side claim below is conditional on it.
+
+These are the note's two supplied legs; beyond them, this note introduces no
+import, axiom, or comparator of its own.
+
+## Theorem (two-surface, conditional on the declared legs)
+
+Per sector, the marginal kinetic form is `c_t p_t^2 + c_s (p_x^2+p_y^2+p_z^2)`
+with front speed `v = sqrt(c_s/c_t)`; the cross-sector ratio is
+
+```text
+v_F/v_G = sqrt( (c_sF/c_tF) / (c_sG/c_tG) ) = sqrt( c_sF c_tG / (c_tF c_sG) ).
+```
+
+### L1. Exact invariant counting (runner V5, exact sympy rationals)
+
+`B4` (the signed-permutation group of the four Euclidean axes,
+`|B4| = 2^4 * 4! = 384`) acts on the diagonal marginal coefficient vector
+`(c_0, c_1, c_2, c_3)` through its `S4` quotient (the signs act trivially on
+`p_mu^2`). The Reynolds (group-average) projector has **rank 1** with image
+proportional to `(1,1,1,1)`: a `B4`-invariant diagonal marginal kinetic form has
+`c_t = c_s`, per sector, with one per-sector normalization `Z` as the surviving
+invariant. The time-fixing subgroup (spatial `O_h`, i.e. `S3` on the spatial
+axes with the temporal axis distinguished) has Reynolds **rank 2**: `c_t` and
+`c_s` are independent singlets per sector — the image `(1,0,0,0)` survives. This
+reproduces, per sector, the landed counting (`ALLORDERS_B4`, lines 81–85):
+
+> **(B) `B4` leaves exactly one diagonal marginal kinetic coefficient.** The
+> diagonal quadratic form `c_t p_t^2 + c_s (p_x^2 + p_y^2 + p_z^2)` has a
+> one-dimensional `B4`-invariant subspace, so `c_t = c_s` is forced; the spatial
+> cubic group `O_h` plus a free temporal coefficient leaves two.
+> (Reynolds-operator rank; runner Part B.)
+
+### L2. Symmetry transport to both 1PI channels of one action (leg 1 + `ALLORDERS_B4` (C))
+
+On the leg-1 surface, the landed transport step (`ALLORDERS_B4`, lines 87–89)
+applies:
+
+> A symmetry of the regulated action **and** measure
+> is a symmetry of the generating functional `Z[J]`, hence of the perturbative
+> effective action `Gamma[phi]` order-by-order in the loop expansion.
+
+Because both sectors' 1PI objects — the fermion self-energy and the gauge vacuum
+polarization — are channels of the **same** `Gamma[phi]` of the **same** supplied
+leg-1 action, L1 pins **each** sector's marginal kinetic form isotropic
+order-by-order at once. No inter-sector identity is used: the pinning is per-sector, by the
+shared rigid frame.
+
+### L3. Speed arithmetic (runner V6, exact sympy + numeric gates)
+
+Per sector the marginal form carries a constant (momentum-independent) kinetic
+normalization `Z_alpha` — the value at the marginal order; a momentum-dependent
+normalization contributes beyond marginal order and does not enter the front
+speed, and a direction-dependent normalization at marginal order is precisely
+the anisotropy `B4` forbids (L1). `Z_F` and `Z_G` cancel exactly in `v_F/v_G`
+(symbolic). On the `B4`-pinned surface (`c_t = c_s` per sector) the ratio is
+`1` **identically** — no tuning, no flow. On the time-fixed surface, with
+`a_F = c_sF/c_tF` and `a_G = c_sG/c_tG`, the ratio `sqrt(a_F/a_G)` is free:
+it depends only on the quotient of the two independent per-sector anisotropies
+(scale-invariant in `(a_F, a_G)`), and any positive value is attained.
+
+### L4. Computed one-loop instances (runner V2, V3, V6)
+
+The two computed channels are representative `B4`-covariant one-loop instances
+sharing the Wilson gluon block and the gauged cos-vertex/seagull rules; they
+are **not** assembled at a single common parameter point. `Pi` uses the landed
+seagull kernel with a massless fermion loop; `Sigma` is one-gluon exchange at
+the IR-safe mass `M = 0.21`, with the fermion-line tadpole evaluated
+separately in V4 (direction-blind on-surface, hence an isotropic marginal
+renormalization there). Each channel's own `B4` covariance is what the theorem
+consumes; the instances are witnesses, not the proof.
+
+- **Gauge sector** (seagull-completed transverse `Pi`, `T_F = 1/2`): lattice
+  Ward transversality holds (worst relative violation `0.0169` at `N=12`) while
+  the bubble (no seagull) violates it at `0.31`; `piT(temporal) = piT(spatial)`
+  within `1e-8` at isotropic input; `eta = 1` is a fixed point (induced
+  anisotropy within `1e-8` at zero deformation).
+- **Fermion sector** (orbit-summed observable, leg 2): three kernels — rainbow
+  scalar-gluon; gauged cos-vertex on the Wilson block, Feynman `xi=1`; gauged
+  cos-vertex, Landau `xi=0` — all give `hw2` orbit-summed marginal anisotropy
+  within `1e-6` on-surface, at `N=12` and `N=10`, on the honest observable
+  `G_hon` (the observable reads the taste shift: non-degeneracy gate `> 1e-4`;
+  no `W_B`-conjugation define-away).
+- **Numeric ratio gates:** `|v_F^2 - 1| < 1e-6`, `|v_G^2 - 1| < 1e-8`, and
+  `|delta(v_F/v_G)| = |sqrt(v_F^2/v_G^2) - 1| < 1e-6` from the computed
+  curvatures and `piT` — primary gate on the gauged cos-vertex curvatures, with
+  the rainbow curvatures as a labeled robustness gate.
+
+### Scoped result
+
+On the `Z^4` surface, conditional on the two declared legs, `v_F/v_G = 1`
+order-by-order: **per-sector `B4` pinning is the cross-sector custodial
+mechanism** — a common rigid frame, not an inter-sector Ward identity. On the
+time-fixed surface the protection genuinely fails and the relative speed is
+free — set by the quotient of the two per-sector anisotropies — exactly as the
+landed parentheticals assert (scoped below).
+
+## Custodial frame, not inter-sector identity (runner V4)
+
+The runner's off-surface controls (V4) test the mechanism class, showing the
+sectors are **mutually unconstrained**:
+
+- Deforming the temporal edge of the Wilson gluon block
+  (`(2/xi) sin(xi q_0/2)`) revives the fermion orbit-summed anisotropy:
+  `+0.0009` at `xi=0.7`, `-0.0013` at `xi=1.3` (a sign straddle — `xi=1` is an
+  isolated zero), and `-0.0003` at `xi=1.3` for the gauged-vertex kernel.
+- Deforming the fermion velocity moves `Pi`: induced gauge-sector anisotropy
+  `+0.0547` at `eps = 0.10`.
+- The tadpole direction test (`T_mu` = BZ-grid mean of the Landau-form tadpole
+  integrand on the Wilson block — a declared normalization, used purely as a
+  direction-sensitivity witness) is direction-blind on-surface (relative spread
+  `< 1e-10`) and direction-sensitive off-surface (relative `|T_t - T_s| =
+  0.0630` at `xi=1.3`).
+
+Each sector's isotropy tracks its **own** kernel's `B4` covariance; nothing is
+transferred between sectors. Additionally, the **unprotected** per-taste value
+is kernel-dependent at matched `N=10`: rainbow `-0.1808`, gauged Feynman
+`+0.2471`, gauged Landau `-0.0624` (minimum pairwise separation `0.1184`; the
+signs differ). The orbit-summed zero is symmetry-driven, not kernel tuning.
+
+## What is new relative to the landed notes
+
+1. **Both 1PI channels from one kernel family.** The landed seagull note
+   computed `Pi` from gauged staggered fermions; the landed taste note computed
+   the fermion self-energy with a scalar-gluon rainbow kernel. Here the fermion
+   self-energy uses the **same** gauged cos vertices and the **same** Wilson
+   gluon block that the `Pi` computation gauges (V2 + V3); the two channels are
+   not assembled at a single common parameter point (see L4). `ALLORDERS_B4`'s
+   computed confirmations were fermion-side; its gauge-channel instance and the
+   cross-sector ratio corollary were not stated there.
+2. **Off-surface mutual unconstraint** (V4): the custodial-frame mechanism
+   class, distinguished experimentally from an inter-sector identity.
+3. **Exact Reynolds counting applied to the cross-sector ratio** (V5 + V6):
+   rank 1 per sector pins `v_F/v_G = 1`; rank 2 per sector frees it — the
+   two-surface split as a theorem about the **ratio**, not just per-sector
+   coefficients.
+4. **Speed arithmetic with exact `Z` cancellation** and the numeric
+   `delta(v_F/v_G)` gate (V6).
+5. **Gauge robustness of the orbit-summed protection** (V3): the orbit-summed
+   anisotropy is zero in **both** Feynman (`xi=1`) and Landau (`xi=0`) gauge.
+   The seagull note's named open item (lines 86–90) is that "The **precise
+   net** coefficient needs a **gauge-invariant fermion-velocity prescription**:
+   the bare self-energy `Z` is gauge-dependent (Feynman vs Landau differ)". At
+   the ratio/orbit-sum level of this note that concern does not bite — `Z`
+   cancels exactly, and the protected zero is gauge-robust because both gauge
+   fixings preserve the kernel's `B4` covariance, which is what the protection
+   tracks. The magnitude prescription for the unprotected per-taste value stays
+   open.
+6. **Kernel-dependence of the unprotected per-taste value** (V3): three
+   kernels, three distinct values, signs differ — a structural witness that the
+   orbit-sum zero is symmetry, not tuning.
+
+## Scoping the two landed parentheticals (derived; no landed text is edited)
+
+The landed lane carries the same assertion in two places.
+[`VELOCITY_RG_LOGFLOW_FRAMEWORK_INTERNAL_2026-06-21.md`](VELOCITY_RG_LOGFLOW_FRAMEWORK_INTERNAL_2026-06-21.md),
+lines 30–35:
+
+> Cross-sector front-speed alignment `v_fermion = v_gauge` is the last open
+> residual of emergent Lorentz invariance: the `B4` custodial symmetry does **not**
+> cover it (the relative speed `v_F/v_b` is a free `B4` invariant), and the only
+> handle is the velocity-RG mutual-drag flow
+> `dv_F/dl = a (v_b − v_F)`, `dv_b/dl = b (v_F − v_b)`, which gives `eta=v_F/v_b → 1`
+> for any `a,b > 0`.
+
+[`VELOCITY_RG_GAUGE_SEAGULL_TRANSVERSE_VACUUM_POLARIZATION_2026-06-22.md`](VELOCITY_RG_GAUGE_SEAGULL_TRANSVERSE_VACUUM_POLARIZATION_2026-06-22.md),
+lines 20–22:
+
+> Cross-sector front-speed alignment `v_fermion = v_gauge` is the last open residual
+> of emergent Lorentz invariance: `B4` does not cover it (the relative speed is a
+> free `B4` invariant), and the only handle is the velocity-RG mutual-drag flow.
+
+**Derived scope.** The clause "the relative speed is a free `B4` invariant" is a
+theorem **on the time-fixed surface**: there the acting symmetry is the
+time-fixing subgroup, its Reynolds rank is 2 per sector (V5), each sector's
+`c_t/c_s` is an independent singlet, and `v_F/v_G = sqrt(a_F/a_G)` is free
+(V6) — set by the quotient of the two independent per-sector anisotropies, as
+asserted. This is the continuous-time horn
+where the landed `ALLORDERS_B4` note (lines 178–184) already records:
+
+> It does
+> **not** address: non-perturbative effects; the `a -> 0` continuum limit; genuine
+> taste-**breaking** or per-single-taste effects;
+> or the continuous-time obstruction horn, where `B4` is **broken** (the temporal
+> integral is uncut while the spatial Brillouin zone is cut), and the protection
+> genuinely fails. It **consumes**, and does not derive, the
+> `kinetic_isotropy_primitive` (`c_t = c_s`, OS0).
+
+On the `Z^4` `B4`-covariant surface (leg 1) the same counting gives rank 1 per
+sector, both ratios are pinned, and the relative speed is **not** free:
+`v_F/v_G = 1` order-by-order (L2 + L3). The two parentheticals are therefore
+precise broken-`B4`-surface statements; they do not hold on the leg-1 surface.
+Both landed notes stand as written — this note scopes them by surface and edits
+neither.
+
+The logflow note also states the demand (lines 116–117):
+
+> Closing it needs a cross-sector custodial symmetry or an
+> `O(1)` anomalous dimension the framework does not currently supply.
+
+On the leg-1 surface, per-sector `B4` pinning is a cross-sector custodial
+mechanism of exactly the requested kind — supplied by the same premise (A) the
+lane already consumes, acting as a common rigid frame rather than an
+inter-sector Ward identity (V4). Conditional on the two declared legs, the
+alignment question therefore **relocates** from the velocity-RG flow to the
+**surface license**: which regulated surface — `Z^4` `B4`-covariant, or `Z^3`
+plus continuous tick — is licensed for the front-speed readout. That license is
+not settled here, and none of the landed notes cited here settles it; it is the
+next path this opens (the temporal-axis / emergent-time question).
+
+## Honest boundary (auditor-first)
+
+- **Both legs are supplied, not derived.** Leg 1 carries the same weight the
+  `ALLORDERS_B4` note assigns its premise (A) (quoted above). Leg 2 is a
+  readout identification with no origin/main license in either direction. The
+  landed taste note states the dichotomy (lines 229–235):
+
+  > The **per-single-taste `O(0.2)` anisotropy is the genuine
+  > residual**: whether it constitutes a physical Lorentz violation depends on the
+  > physical interpretation of the taste label (if a single taste corner is a
+  > physically distinguishable particle, the marginal anisotropy is physical; if only
+  > taste-summed observables are physical, it cancels). This note does not settle that
+  > interpretation; it reports the taste-sum protection and the per-taste residual
+  > honestly.
+
+  The single-taste reading stays live:
+  [`STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md`](STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md)
+  treats the BZ-corner taste-cube structure as species-relevant. On that
+  reading the alignment theorem does **not** follow from this note.
+- **Record supplies no readout selector.** Per the landed
+  [`EW_KAPPA_REGISTRATION_REGISTERS_ALL_COLOR_SECTORS_NO_GO_NOTE_2026-06-09.md`](EW_KAPPA_REGISTRATION_REGISTERS_ALL_COLOR_SECTORS_NO_GO_NOTE_2026-06-09.md)
+  (lines 48–51): "This is a channel under test, not a new axiom and not
+  something Record supplies by itself. Record supplies no decomposition,
+  weighting, normalization, probability rule, measurement/decoherence dynamics,
+  source/action bridge, or readout selector." Accordingly, nothing in the
+  record ontology is invoked here to justify orbit-summing; leg 2 is an
+  explicit declaration, which is why it must be named as supplied context.
+- **The time-fixed horn is genuinely unprotected.** Nothing here shrinks the
+  freedom on that surface — the ratio remains set by the quotient of the two
+  per-sector anisotropies; this note derives that the freedom is exactly the
+  landed parentheticals' content.
+- **The surface license is open.** Neither leg selects which surface is
+  licensed for the front-speed readout; the theorem is a conditional alignment
+  on the `Z^4` surface plus an exact freedom statement on the time-fixed
+  surface. The license question is the next path this opens.
+- **Order and proxy level.** The gauge-sector computations are one-loop
+  (seagull-completed `Pi`); the all-orders reach is the symmetry transport of
+  `ALLORDERS_B4` (C) applied on leg 1, not a diagram-by-diagram computation.
+  Magnitudes are structural/proxy-level; the logflow note's residual-D
+  naturalness content (its `lambda`, `gamma`, and LV-bound sufficiency) is
+  untouched. The seagull note's gauge-invariant fermion-velocity prescription
+  stays open for magnitudes; this note bypasses it strictly at the
+  ratio/orbit-sum level.
+- **Representative channels, one kernel family.** The two computed one-loop
+  channels share the Wilson gluon block and the gauged cos-vertex/seagull
+  rules but are not evaluated at a single common parameter point (`Pi`:
+  massless fermion loop, per the landed seagull kernel; `Sigma`: one-gluon
+  exchange at `M = 0.21`); the fermion-line tadpole enters only as the V4
+  direction-sensitivity witness. The theorem consumes each channel's own `B4`
+  covariance, not a joint evaluation.
+- **Declared tadpole normalization.** `T_mu` is the BZ-grid mean of the
+  Landau-form tadpole integrand on the Wilson block, used as a
+  direction-sensitivity witness, not as a physical renormalization.
+- **No statuses, no primitive changes, no edits.** The kinetic-isotropy
+  primitive is unchanged (consumed through the leg-1 surface's isotropic bare
+  kinetic form, per `ALLORDERS_B4`); no landed note is edited; grading belongs
+  to the independent audit lane.
+
+## Load-bearing dependencies (cited at declared ledger grade)
+
+| Source | Ledger `effective_status` | Role here |
+|---|---|---|
+| [`ALLORDERS_B4_MARGINAL_PROTECTION_SYMMETRY_THEOREM_NOTE_2026-06-14.md`](ALLORDERS_B4_MARGINAL_PROTECTION_SYMMETRY_THEOREM_NOTE_2026-06-14.md) | unaudited | leg 1 (premise (A) surface); (B) counting; (C) all-orders transport |
+| [`TASTE_SECTOR_MARGINAL_LV_B4_PROTECTION_ON_OS0_BOUNDED_THEOREM_NOTE_2026-06-13.md`](TASTE_SECTOR_MARGINAL_LV_B4_PROTECTION_ON_OS0_BOUNDED_THEOREM_NOTE_2026-06-13.md) | unaudited | honest observable `G_hon = Dinv - Sigma`, `hw2` orbit, rainbow kernel; per-taste dichotomy quoted |
+| [`VELOCITY_RG_LOGFLOW_FRAMEWORK_INTERNAL_2026-06-21.md`](VELOCITY_RG_LOGFLOW_FRAMEWORK_INTERNAL_2026-06-21.md) | unaudited | scoped parenthetical (lines 30–35); custodial-demand sentence (lines 116–117) |
+| [`VELOCITY_RG_GAUGE_SEAGULL_TRANSVERSE_VACUUM_POLARIZATION_2026-06-22.md`](VELOCITY_RG_GAUGE_SEAGULL_TRANSVERSE_VACUUM_POLARIZATION_2026-06-22.md) | unaudited | seagull-completed `Pi` kernel (`T_F = 1/2`); scoped parenthetical (lines 20–22); gauge-prescription open item |
+| [`STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md`](STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md) | unaudited | keeps the single-taste reading live against leg 2 |
+| [`EW_KAPPA_REGISTRATION_REGISTERS_ALL_COLOR_SECTORS_NO_GO_NOTE_2026-06-09.md`](EW_KAPPA_REGISTRATION_REGISTERS_ALL_COLOR_SECTORS_NO_GO_NOTE_2026-06-09.md) | unaudited | Record supplies no readout selector (why leg 2 must be declared) |
+| [`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md) | meta (registered primitive) | unchanged; consumed (not derived) through the leg-1 surface, per `ALLORDERS_B4` |
+
+Graded rows in this lane — `taste_scalar_isotropy_theorem_note` (retained;
+scope: the CW Hessian statement), `lorentz_violation_derived_note`
+(unaudited), `dispersion_high_p_tiebreaker_note` (retained_bounded) —
+are not load-bearing for this note and are not stretched beyond their declared
+scopes.
+
+## Runner verification map
+
+| Part | Checks | What it certifies |
+|---|---|---|
+| V1 | 4 | Clifford algebra for both landed gamma conventions; `W_B` conjugation identity for all 16 taste shifts; gauged cos-vertex taste covariance |
+| V2 | 4 | seagull-completed `Pi` transversality (Ward `< 5%` at `N=12`) vs large bubble (no seagull) violation; `B4` isotropy `piT(t) = piT(s)`; `eta = 1` fixed point |
+| V3 | 11 | honest-observable (`G_hon`) non-degeneracy (both kernels); per-taste anisotropy nonzero with kernel-dependent values and signs (three kernels, matched `N=10`); `hw2` orbit-summed anisotropy zero on-surface at `N=12` and `N=10`, Feynman and Landau |
+| V4 | 7 | off-surface controls: orbit anisotropy revives with a sign straddle; mutual unconstraint (`Pi` feels the fermion deformation; the gluon-edge deformation moves the fermion orbit sum); tadpole direction-blind on-surface, direction-sensitive off-surface |
+| V5 | 4 | exact sympy Reynolds counting: `B4` (`S4` quotient) rank 1 with isotropic image; time-fixing subgroup rank 2 with `(1,0,0,0)` surviving |
+| V6 | 5 | exact `Z_F`, `Z_G` cancellation; pinned-surface ratio `= 1` identically; broken-surface ratio `sqrt(a_F/a_G)` depending only on the anisotropy quotient (scale-invariance gated); numeric `delta(v_F/v_G)` gates — gauged cos-vertex primary, rainbow robustness |
+
+Runner gates are tolerance bounds around structure (zero/nonzero/sign/rank);
+gated prints are bound checks at pass tolerances (platform-stable output).
+
+## Reproduce
+
+```
+python3 scripts/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.py
+# expect: TOTAL: PASS=35 FAIL=0   (N=12 primary / N=10 secondary grids, ~6 s, low memory)
+```

--- a/logs/runner-cache/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.txt
+++ b/logs/runner-cache/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.py
-runner_sha256: 904cc8aace891264849568b19327660e1f76c5be366aee19ae9f7fa9d784754f
-timeout_sec: 3600
+runner_sha256: 463b17b1537811a1ed0c7c7dfedf1ae5f9a06b516a3d6c2f39c699735c37daa5
+timeout_sec: 300
 exit_code: 0
-elapsed_sec: 5.93
+elapsed_sec: 6.42
 status: ok
 ----- stdout -----
 Cross-sector front-speed B4 two-surface alignment -- bounded-theorem runner
@@ -11,7 +11,7 @@ Cross-sector front-speed B4 two-surface alignment -- bounded-theorem runner
  `taste_orbit_summed_front_speed_readout_context`; see companion note)
 
 ==============================================================================
-V1 -- Clifford (both sets), W_B conjugation, cos-vertex taste covariance
+Clifford (both sets), W_B conjugation, cos-vertex taste covariance (V1)
 ==============================================================================
 [PASS] Clifford {g,g}=2delta (taste kron set)  ::  |max dev| < 1e-12 (bound holds; residual suppressed)
 [PASS] Clifford {g,g}=2delta (seagull block set)  ::  |max dev| < 1e-12 (bound holds; residual suppressed)
@@ -19,15 +19,16 @@ V1 -- Clifford (both sets), W_B conjugation, cos-vertex taste covariance
 [PASS] gauged cos vertex taste-covariant: cos(p+piB-q/2)=(-1)^B cos(p-q/2)  ::  |worst dev (all 16 B, 5 random p,q)| < 1e-12 (bound holds; residual suppressed)
 
 ==============================================================================
-V2 -- gauge sector: seagull-completed transverse Pi, B4 isotropy, eta=1
+Gauge sector: seagull-completed transverse Pi, B4 isotropy, eta=1 (V2)
 ==============================================================================
-[PASS] Ward khat_mu Pi_munu transverse < 5% WITH seagull (N=12)  ::  worst violation=0.0169 < 0.05
-[PASS] bubble (no seagull) Ward violation is LARGE (seagull is load-bearing)  ::  bubble min=0.3123 > 0.05 and > 3x seagull worst
+[PASS] normalized Ward residual |khat.Pi|/(|khat||Pi|) < 5% WITH seagull (N=12)  ::  worst residual=0.0426 < 0.05
+[PASS] bubble (no seagull) Ward residual is LARGE (seagull is load-bearing)  ::  bubble min=0.7390 > 0.25 and > 3x seagull worst
+[PASS] DEFORMED-kernel Pi stays transverse (v_mu in propagators, vertices, seagull; eps=0.10)  ::  worst residual=0.0447 < 0.05
 [PASS] B4 isotropy at v=1: piT(temporal)==piT(spatial) (< 1e-8)  ::  |max piT diff (q in {0.5,0.3,0.18})| < 1e-8 (bound holds; residual suppressed)
 [PASS] eta=1 fixed point: induced Pi anisotropy vanishes at eps=0  ::  |induced(0)| < 1e-8 (bound holds; residual suppressed)
 
 ==============================================================================
-V3 -- fermion sector: three kernels (rainbow; gauged Feynman; gauged Landau)
+Fermion sector: three kernels -- rainbow, gauged Feynman, gauged Landau (V3)
 ==============================================================================
 [PASS] NON-DEGENERACY: Sigma(B=0) != Sigma(B_rep) (taste shift visible)  ::  ||dSigma||=0.0139 > 1e-4
 [PASS] rainbow PER-TASTE anisotropy A(B_rep) ~ -0.2 (NONZERO, negative)  ::  A=-0.1950 curv=[1.8551, 2.1476, 2.1476, 1.8551]
@@ -42,26 +43,31 @@ V3 -- fermion sector: three kernels (rainbow; gauged Feynman; gauged Landau)
 [PASS] PER-TASTE value KERNEL-DEPENDENT at matched N=10 (3 kernels, signs differ)  ::  A(rainbow)=-0.1808 A(Feynman)=+0.2471 A(Landau)=-0.0624 min pairwise sep=0.1184 > 0.03
 
 ==============================================================================
-V4 -- off-surface controls, mutual unconstraint, tadpole direction test
+Off-surface controls, deformation-response witness, tadpole direction test (V4)
 ==============================================================================
 [PASS] rainbow xi=0.7 orbit anisotropy NONZERO off-surface  ::  A(xi=0.7)=+0.0009, |A| > 1e-4
 [PASS] rainbow xi=1.3 orbit anisotropy NONZERO off-surface  ::  A(xi=1.3)=-0.0013, |A| > 1e-4
-[PASS] xi<1 / xi>1 STRADDLE in sign (xi=1 isolated zero)  ::  sign(0.7)=+1 sign(1.3)=-1, both |A| > 1e-4
+[PASS] xi<1 / xi>1 STRADDLE in sign across xi=1 (two samples; no isolated-zero claim)  ::  sign(0.7)=+1 sign(1.3)=-1, both |A| > 1e-4
 [PASS] GAUGED-VERTEX orbit anisotropy NONZERO off-surface (xi=1.3)  ::  A_g(xi=1.3)=-0.0003, |A_g| > 1e-4
-[PASS] Pi FEELS the fermion deformation (induced anisotropy at eps=0.10 nonzero)  ::  induced(0.10)=+0.0547; Pi has no internal gluon line by construction
+[PASS] Pi FEELS the fermion deformation (induced anisotropy at eps=0.10 nonzero)  ::  induced(0.10)=+0.0603; Pi has no internal gluon line by construction
 [PASS] tadpole T_mu DIRECTION-BLIND on-surface (relative spread < 1e-10)  ::  |rel spread| < 1e-10 (bound holds; residual suppressed)
 [PASS] tadpole T_mu DIRECTION-SENSITIVE off-surface (xi=1.3)  ::  rel |T_t - T_s|=0.0630 > 1e-3
 
 ==============================================================================
-V5 -- exact invariant counting (sympy Reynolds): B4 rank 1 vs O_h rank 2
+Exact invariant counting + joint (hw2 taste, axis) representation lemma (V5)
 ==============================================================================
 [PASS] B4 (S4 quotient) Reynolds rank on {c_mu} = 1 (single marginal invariant)  ::  rank=1
 [PASS] B4 projection of c=(1,0,0,0) is ISOTROPIC (all entries equal 1/4)  ::  image=[1/4, 1/4, 1/4, 1/4]
 [PASS] O_h (time-fixing S3) Reynolds rank on {c_mu} = 2 (c_t independent of c_s)  ::  rank=2
 [PASS] O_h projection keeps c_t != c_s (image (1,0,0,0) survives)  ::  image=[1, 0, 0, 0]
+[PASS] JOINT S4 invariant rank on c_{B,mu} = 2 (orbit indicators {mu in B}, {mu not in B})  ::  rank=2; both orbit indicators are fixed vectors
+[PASS] each axis lies in EXACTLY 3 of the 6 hw2 tastes  ::  counts=[3, 3, 3, 3]
+[PASS] UNIFORM hw2 averaging o S4 Reynolds: rank 1, image ISOTROPIC (the V3 orbit-sum zero is this representation-forced projection)  ::  rank=1; all rows equal
+[PASS] JOINT time-fixing S3 invariant rank = 6 (six (taste-type, axis-role) orbits)  ::  rank=6
+[PASS] uniform hw2 averaging o time-fixing S3 Reynolds: rank 2 -- time-fixing symmetry alone does NOT force c_t = c_s (symmetry counting only)  ::  rank=2
 
 ==============================================================================
-V6 -- speed arithmetic: Z cancellation, pinned ratio = 1, broken freedom
+Speed arithmetic: Z cancellation, pinned ratio = 1, broken freedom (V6)
 ==============================================================================
 [PASS] overall kinetic normalizations Z_F, Z_G CANCEL in v_F/v_G (exact)  ::  v_F/v_G = sqrt(c_sF c_tG / (c_tF c_sG)) -- no Z dependence
 [PASS] on the B4-pinned surface (c_t=c_s per sector) v_F/v_G = 1 IDENTICALLY  ::  residual=0
@@ -72,7 +78,7 @@ V6 -- speed arithmetic: Z cancellation, pinned ratio = 1, broken freedom
 ==============================================================================
 SCORECARD
 ==============================================================================
-TOTAL: PASS=35 FAIL=0
+TOTAL: PASS=41 FAIL=0
 
 ----- stderr -----
 

--- a/logs/runner-cache/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.txt
+++ b/logs/runner-cache/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.txt
@@ -1,0 +1,78 @@
+===== runner cache v1 =====
+runner: scripts/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.py
+runner_sha256: 904cc8aace891264849568b19327660e1f76c5be366aee19ae9f7fa9d784754f
+timeout_sec: 3600
+exit_code: 0
+elapsed_sec: 5.93
+status: ok
+----- stdout -----
+Cross-sector front-speed B4 two-surface alignment -- bounded-theorem runner
+(conditional on ALLORDERS_B4 premise (A) and the declared supplied context
+ `taste_orbit_summed_front_speed_readout_context`; see companion note)
+
+==============================================================================
+V1 -- Clifford (both sets), W_B conjugation, cos-vertex taste covariance
+==============================================================================
+[PASS] Clifford {g,g}=2delta (taste kron set)  ::  |max dev| < 1e-12 (bound holds; residual suppressed)
+[PASS] Clifford {g,g}=2delta (seagull block set)  ::  |max dev| < 1e-12 (bound holds; residual suppressed)
+[PASS] W_B unitary AND W_B^-1 g_mu W_B = (-1)^{B_mu} g_mu (all 16 B)  ::  |worst dev| < 1e-10 (bound holds; residual suppressed)
+[PASS] gauged cos vertex taste-covariant: cos(p+piB-q/2)=(-1)^B cos(p-q/2)  ::  |worst dev (all 16 B, 5 random p,q)| < 1e-12 (bound holds; residual suppressed)
+
+==============================================================================
+V2 -- gauge sector: seagull-completed transverse Pi, B4 isotropy, eta=1
+==============================================================================
+[PASS] Ward khat_mu Pi_munu transverse < 5% WITH seagull (N=12)  ::  worst violation=0.0169 < 0.05
+[PASS] bubble (no seagull) Ward violation is LARGE (seagull is load-bearing)  ::  bubble min=0.3123 > 0.05 and > 3x seagull worst
+[PASS] B4 isotropy at v=1: piT(temporal)==piT(spatial) (< 1e-8)  ::  |max piT diff (q in {0.5,0.3,0.18})| < 1e-8 (bound holds; residual suppressed)
+[PASS] eta=1 fixed point: induced Pi anisotropy vanishes at eps=0  ::  |induced(0)| < 1e-8 (bound holds; residual suppressed)
+
+==============================================================================
+V3 -- fermion sector: three kernels (rainbow; gauged Feynman; gauged Landau)
+==============================================================================
+[PASS] NON-DEGENERACY: Sigma(B=0) != Sigma(B_rep) (taste shift visible)  ::  ||dSigma||=0.0139 > 1e-4
+[PASS] rainbow PER-TASTE anisotropy A(B_rep) ~ -0.2 (NONZERO, negative)  ::  A=-0.1950 curv=[1.8551, 2.1476, 2.1476, 1.8551]
+[PASS] rainbow hw2 ORBIT-SUM anisotropy ~ 0 on-surface (N=12)  ::  |A_orbit| < 1e-6 (bound holds; residual suppressed)
+[PASS] rainbow orbit-sum zero STRUCTURAL (also N=10)  ::  |A_orbit(N=10)| < 1e-6 (bound holds; residual suppressed)
+[PASS] GAUGED-VERTEX Sigma_g: taste shift visible (non-degeneracy)  ::  ||dSigma_g||=0.0182 > 1e-4
+[PASS] GAUGED-VERTEX (Feynman) per-taste anisotropy NONZERO on-surface  ::  A_g=+0.2592 curv=[2.1953, 1.8064, 1.8064, 2.1953]
+[PASS] GAUGED-VERTEX hw2 ORBIT-SUM anisotropy ~ 0 on-surface (gauged cos-vertex on the Wilson block)  ::  |A_g_orbit| < 1e-6 (bound holds; residual suppressed)
+[PASS] GAUGED-VERTEX orbit-sum zero STRUCTURAL (also N=10)  ::  |A_g_orbit(N=10)| < 1e-6 (bound holds; residual suppressed)
+[PASS] GAUGED-VERTEX (Landau) per-taste anisotropy NONZERO (N=10)  ::  A_L=-0.0624 curv=[1.951, 2.0447, 2.0447, 1.951]
+[PASS] GAUGED-VERTEX (Landau) hw2 ORBIT-SUM anisotropy ~ 0 (gauge-robust)  ::  |A_L_orbit| < 1e-6 (bound holds; residual suppressed)
+[PASS] PER-TASTE value KERNEL-DEPENDENT at matched N=10 (3 kernels, signs differ)  ::  A(rainbow)=-0.1808 A(Feynman)=+0.2471 A(Landau)=-0.0624 min pairwise sep=0.1184 > 0.03
+
+==============================================================================
+V4 -- off-surface controls, mutual unconstraint, tadpole direction test
+==============================================================================
+[PASS] rainbow xi=0.7 orbit anisotropy NONZERO off-surface  ::  A(xi=0.7)=+0.0009, |A| > 1e-4
+[PASS] rainbow xi=1.3 orbit anisotropy NONZERO off-surface  ::  A(xi=1.3)=-0.0013, |A| > 1e-4
+[PASS] xi<1 / xi>1 STRADDLE in sign (xi=1 isolated zero)  ::  sign(0.7)=+1 sign(1.3)=-1, both |A| > 1e-4
+[PASS] GAUGED-VERTEX orbit anisotropy NONZERO off-surface (xi=1.3)  ::  A_g(xi=1.3)=-0.0003, |A_g| > 1e-4
+[PASS] Pi FEELS the fermion deformation (induced anisotropy at eps=0.10 nonzero)  ::  induced(0.10)=+0.0547; Pi has no internal gluon line by construction
+[PASS] tadpole T_mu DIRECTION-BLIND on-surface (relative spread < 1e-10)  ::  |rel spread| < 1e-10 (bound holds; residual suppressed)
+[PASS] tadpole T_mu DIRECTION-SENSITIVE off-surface (xi=1.3)  ::  rel |T_t - T_s|=0.0630 > 1e-3
+
+==============================================================================
+V5 -- exact invariant counting (sympy Reynolds): B4 rank 1 vs O_h rank 2
+==============================================================================
+[PASS] B4 (S4 quotient) Reynolds rank on {c_mu} = 1 (single marginal invariant)  ::  rank=1
+[PASS] B4 projection of c=(1,0,0,0) is ISOTROPIC (all entries equal 1/4)  ::  image=[1/4, 1/4, 1/4, 1/4]
+[PASS] O_h (time-fixing S3) Reynolds rank on {c_mu} = 2 (c_t independent of c_s)  ::  rank=2
+[PASS] O_h projection keeps c_t != c_s (image (1,0,0,0) survives)  ::  image=[1, 0, 0, 0]
+
+==============================================================================
+V6 -- speed arithmetic: Z cancellation, pinned ratio = 1, broken freedom
+==============================================================================
+[PASS] overall kinetic normalizations Z_F, Z_G CANCEL in v_F/v_G (exact)  ::  v_F/v_G = sqrt(c_sF c_tG / (c_tF c_sG)) -- no Z dependence
+[PASS] on the B4-pinned surface (c_t=c_s per sector) v_F/v_G = 1 IDENTICALLY  ::  residual=0
+[PASS] broken-B4 surface: v_F/v_G = sqrt(a_F/a_G) -- two independent per-sector anisotropies, ratio depends only on their quotient (scale-invariant)  ::  ratio=sqrt(a_F)/sqrt(a_G); ratio(lam aF, lam aG) == ratio
+[PASS] NUMERIC delta(v_F/v_G)=sqrt(vF2/vG2)-1 = 0 on-surface -- gauged cos-vertex (primary)  ::  |vF^2 ratio - 1| < 1e-6 AND |vG^2 ratio - 1| < 1e-8 AND |delta| < 1e-6 (bounds hold; residuals suppressed)
+[PASS] NUMERIC delta(v_F/v_G)=sqrt(vF2/vG2)-1 = 0 on-surface -- rainbow (robustness)  ::  |vF^2 ratio - 1| < 1e-6 AND |vG^2 ratio - 1| < 1e-8 AND |delta| < 1e-6 (bounds hold; residuals suppressed)
+
+==============================================================================
+SCORECARD
+==============================================================================
+TOTAL: PASS=35 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.py
+++ b/scripts/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.py
@@ -4,24 +4,35 @@
 Companion runner for
 docs/CROSS_SECTOR_FRONT_SPEED_B4_TWO_SURFACE_ALIGNMENT_BOUNDED_THEOREM_NOTE_2026-07-16.md
 
-Conditional bounded theorem; BOTH supplied legs are declared in the note:
-  (L1) ALLORDERS_B4 premise (A): exact B4 invariance of the regulated action and
-       measure on the Z^4 surface is SUPPLIED, not derived from the four axioms.
-  (L2) `taste_orbit_summed_front_speed_readout_context`: the taste-orbit-SUMMED
-       marginal curvature is identified as the physical fermion front-speed
-       observable. Declared supplied context, not derived; on the single-taste
-       reading the alignment theorem does NOT follow from this runner.
+Conditional bounded theorem; THREE supplied legs are declared in the note:
+  (leg 1) ALLORDERS_B4 premise (A): exact B4 invariance of the regulated
+       action and measure on the Z^4 surface is SUPPLIED, not derived from
+       the four axioms.
+  (leg 2) `taste_orbit_summed_front_speed_readout_context`: the taste-orbit-
+       SUMMED marginal curvature is identified as the fermion-side observable.
+       Declared supplied context, not derived; on the single-taste reading
+       the alignment theorem does NOT follow from this runner.
+  (leg 3) `euclidean_marginal_front_speed_bridge_context`: the finite-grid
+       EUCLIDEAN marginal coefficient ratio is identified with a physical
+       (Lorentzian) front speed. No pole readout or Euclidean-to-Lorentzian
+       continuation is constructed here; what the runner certifies is the
+       Euclidean marginal coefficient statement, and every "front speed"
+       phrase is conditional on this declared bridge.
 
-Statement verified: on the Z^4 B4-covariant Wilson+staggered surface, B4 pins
-EACH sector's diagonal marginal kinetic form isotropic (Reynolds rank 1 on the
-diagonal marginal coefficients), so each sector's front speed v = sqrt(c_s/c_t)
-equals 1 in lattice units, the overall kinetic normalizations Z_F and Z_G
-cancel in the ratio, and v_F/v_G = 1 order-by-order on that surface. On the
-broken-B4 surface (Z^3 + continuous tick; time-fixing S3), each sector's
-c_t/c_s is an independent singlet (Reynolds rank 2 per sector) and
-v_F/v_G = sqrt(a_F/a_G) is free: set by two independent per-sector
-anisotropies through their quotient alone (scale-invariant), unconstrained
-by the time-fixing symmetry.
+Statement verified (Euclidean marginal coefficients, conditional): on the Z^4
+B4-covariant Wilson+staggered surface, B4 pins EACH sector's diagonal marginal
+kinetic form isotropic -- for the fermion observable this requires the JOINT
+(taste, axis) representation lemma of V5, not the 4-component counting alone --
+so each sector's Euclidean marginal coefficient ratio c_s/c_t equals 1 in
+lattice units, the overall kinetic normalizations Z_F and Z_G cancel in the
+ratio, and the cross-sector ratio equals 1 order-by-order on that surface. On
+the broken-B4 surface (Z^3 + continuous tick; time-fixing S3), the same exact
+counting leaves each sector's c_t/c_s an independent singlet of the
+time-fixing subgroup: the time-fixing symmetry alone does NOT force
+cross-sector equality. That is a symmetry-counting statement only -- it does
+NOT establish that dynamics realizes arbitrary (a_F, a_G); the landed
+velocity-RG mutual-drag flow is a live dynamical route toward equality on
+that surface and is not contradicted here.
 
 The two computed one-loop channels are representative B4-covariant instances
 sharing the Wilson gluon block and the gauged staggered cos-vertex/seagull
@@ -32,15 +43,20 @@ V4 -- direction-blind on-surface, hence an isotropic marginal renormalization
 there). Each channel's own B4 covariance is what the theorem consumes; the
 instances are witnesses, not the proof.
 
-Verification map:
+Verification map (explicit-name-first; the V-codes key the note's table):
   V1  Clifford algebra for BOTH landed gamma conventions (taste kron set,
       seagull block set); W_B taste-rotation unitarity + conjugation for all
       16 taste shifts B; gauged cos-vertex taste covariance
       cos((p+piB-q/2)_mu) = (-1)^{B_mu} cos((p-q/2)_mu).
   V2  Gauge sector (seagull-runner kernel, T_F=1/2, 0.5*Pi/tot): seagull-
-      completed Pi transverse (Ward < 5% at N=12) with the bubble (no seagull)
-      assembly much worse; B4 isotropy piT(temporal)==piT(spatial) at v=1;
-      eta=1 fixed point (induced anisotropy vanishes at isotropic input).
+      completed Pi transverse (normalized Ward residual |khat.Pi|/(|khat||Pi|);
+      thresholds stated at the checks) with the bubble (no seagull) assembly
+      much worse; B4 isotropy piT(temporal)==piT(spatial) at v=1; eta=1 fixed
+      point (induced anisotropy vanishes at isotropic input); the anisotropic
+      control gauges the DEFORMED kernel consistently -- v_mu enters the
+      propagators, the vertices, AND the seagull (gauging
+      sum_mu v_mu sin(k_mu + A_mu)) -- and the deformed-kernel Pi stays
+      transverse at the same normalized-Ward threshold.
   V3  Fermion sector, three kernels on the honest observable
       G_hon = Dinv(p) - Sigma(p,B) (the observable READS the taste shift B --
       non-degeneracy gates, never a W_B-conjugation define-away):
@@ -52,19 +68,28 @@ Verification map:
       structural across N=12 and N=10 for (a) and (b).
   V4  Off-surface controls: temporal-edge deformed Wilson block
       (2/xi)sin(xi q0/2) at xi=0.7 / xi=1.3 gives NONZERO orbit anisotropy
-      with a sign straddle (rainbow) and NONZERO at xi=1.3 (gauged vertex);
-      mutual unconstraint (Pi carries no internal gluon line yet feels the
-      fermion-velocity deformation); tadpole T_mu (declared normalization:
+      with a sign straddle across xi=1 (rainbow; two samples -- no
+      isolated-zero claim) and NONZERO at xi=1.3 (gauged vertex);
+      cross-sector control (Pi carries no internal gluon line yet feels the
+      fermion-velocity deformation) -- a symmetry-tracking witness, NOT a
+      dynamical-unconstraint claim; tadpole T_mu (declared normalization:
       mean over the BZ grid, Landau form on the Wilson block) direction-blind
       on-surface and direction-sensitive off-surface.
-  V5  Exact invariant counting (sympy Reynolds): B4 acts on the diagonal
-      marginal coefficients through its S4 quotient with invariant rank 1
-      (isotropic image); the time-fixing S3 (O_h horn) has rank 2.
+  V5  Exact invariant counting (sympy Reynolds), TWO representations:
+      (i) the 4-dim diagonal marginal coefficient vector: B4 acts through its
+      S4 quotient with invariant rank 1 (isotropic image); the time-fixing S3
+      (O_h horn) has rank 2. (ii) the JOINT 24-dim (hw2 taste B, axis mu)
+      representation the fermion observable actually lives in: S4 invariant
+      rank 2 (orbit indicators {mu in B}, {mu not in B}); each axis lies in
+      exactly 3 of the 6 hw2 tastes, so UNIFORM taste averaging (the leg-2
+      orbit sum) composed with the Reynolds projector has rank 1 with
+      isotropic image; joint time-fixing S3 rank 6, averaging to rank 2.
   V6  Speed arithmetic (sympy exact + numeric): constant kinetic
       normalizations Z_F, Z_G cancel in v = sqrt(c_s/c_t); pinned-surface
       ratio = 1 identically; broken-surface ratio = sqrt(a_F/a_G) depends
       only on the quotient of the two independent per-sector anisotropies
-      (scale-invariance gated); numeric delta(v_F/v_G) = sqrt(vF2/vG2) - 1
+      (scale-invariance gated) -- symmetry counting only, no
+      dynamical-freedom claim; numeric delta(v_F/v_G) = sqrt(vF2/vG2) - 1
       = 0 on-surface, primary gate on the gauged cos-vertex curvatures with
       the rainbow curvatures as a labeled robustness gate.
 
@@ -273,6 +298,10 @@ def khat(qv):
 
 
 def pi_munu(qv, N, v, include_seagull=True, chunk=50000):
+    """Fermion-loop Pi for the kernel sum_mu v_mu sin(k_mu). Gauging
+    k_mu -> k_mu + A_mu puts v_mu into the propagators, the one-gluon vertex
+    v_mu cos(k_mu + q_mu/2), AND the seagull -v_mu sin(k_mu) delta_munu: the
+    anisotropic control deforms one consistent gauged kernel."""
     q = np.array(qv, float)
     ax = make_bz_grid(N)
     Pi = np.zeros((4, 4), complex)
@@ -292,8 +321,8 @@ def pi_munu(qv, N, v, include_seagull=True, chunk=50000):
         Dkq = np.sum(skq**2, 1)
         Sk = (-1j * np.einsum("ca,aij->cij", sk, gb)) / Dk[:, None, None]
         Skq = (-1j * np.einsum("ca,aij->cij", skq, gb)) / Dkq[:, None, None]
-        cmid = np.cos(k + q / 2)
-        sk_mu = np.sin(k)
+        cmid = np.cos(k + q / 2) * v
+        sk_mu = np.sin(k) * v
         for mu in range(4):
             Vmu = 1j * cmid[:, mu][:, None, None] * gb[mu]
             SV = Sk @ Vmu @ Skq
@@ -307,7 +336,10 @@ def pi_munu(qv, N, v, include_seagull=True, chunk=50000):
 
 
 def ward(Pi, qv):
-    return np.max(np.abs(khat(qv) @ Pi)) / (np.max(np.abs(Pi)) + 1e-30)
+    """Normalized Ward residual |khat . Pi| / (|khat| |Pi|) (max norms on Pi,
+    Euclidean norm on khat) -- dimensionless in the external momentum."""
+    kh = khat(qv)
+    return np.max(np.abs(kh @ Pi)) / (np.linalg.norm(kh) * np.max(np.abs(Pi)) + 1e-30)
 
 
 def piT(qaxis, q, N, v):
@@ -320,7 +352,7 @@ def piT(qaxis, q, N, v):
 
 # ===========================================================================
 def part_1() -> None:
-    hr("V1 -- Clifford (both sets), W_B conjugation, cos-vertex taste covariance")
+    hr("Clifford (both sets), W_B conjugation, cos-vertex taste covariance (V1)")
     for name, GG in (("taste kron set", Gt), ("seagull block set", list(gb))):
         worst = 0.0
         for mu in range(4):
@@ -363,17 +395,22 @@ def part_1() -> None:
 
 
 def part_2() -> dict:
-    hr("V2 -- gauge sector: seagull-completed transverse Pi, B4 isotropy, eta=1")
+    hr("Gauge sector: seagull-completed transverse Pi, B4 isotropy, eta=1 (V2)")
     N = 12
     iso = np.array([1.0, 1.0, 1.0, 1.0])
     qvs = ([0.0, 0.4, 0.0, 0.0], [0.3, 0.3, 0.0, 0.0], [0.0, 0.0, 0.0, 0.5])
     w_sea = [ward(np.real(pi_munu(qv, N, iso)), qv) for qv in qvs]
-    check("Ward khat_mu Pi_munu transverse < 5% WITH seagull (N=12)",
-          max(w_sea) < 0.05, f"worst violation={max(w_sea):.4f} < 0.05")
+    check("normalized Ward residual |khat.Pi|/(|khat||Pi|) < 5% WITH seagull (N=12)",
+          max(w_sea) < 0.05, f"worst residual={max(w_sea):.4f} < 0.05")
     w_bub = [ward(np.real(pi_munu(qv, N, iso, include_seagull=False)), qv) for qv in qvs]
-    check("bubble (no seagull) Ward violation is LARGE (seagull is load-bearing)",
-          min(w_bub) > 0.05 and min(w_bub) > 3 * max(w_sea),
-          f"bubble min={min(w_bub):.4f} > 0.05 and > 3x seagull worst")
+    check("bubble (no seagull) Ward residual is LARGE (seagull is load-bearing)",
+          min(w_bub) > 0.25 and min(w_bub) > 3 * max(w_sea),
+          f"bubble min={min(w_bub):.4f} > 0.25 and > 3x seagull worst")
+    v_def = np.array([1 - 0.05, 1 + 0.05, 1 + 0.05, 1 + 0.05])
+    w_def = [ward(np.real(pi_munu(qv, N, v_def)), qv) for qv in qvs]
+    check("DEFORMED-kernel Pi stays transverse (v_mu in propagators, vertices, "
+          "seagull; eps=0.10)",
+          max(w_def) < 0.05, f"worst residual={max(w_def):.4f} < 0.05")
 
     qq = [0.5, 0.3, 0.18]
     diffs = [abs(piT(0, q, N, iso) - piT(1, q, N, iso)) for q in qq]
@@ -394,7 +431,7 @@ def part_2() -> dict:
 
 
 def part_3() -> dict:
-    hr("V3 -- fermion sector: three kernels (rainbow; gauged Feynman; gauged Landau)")
+    hr("Fermion sector: three kernels -- rainbow, gauged Feynman, gauged Landau (V3)")
     n = 12
     qpts = bz_points(n)
     gluon1 = lambda q: gluon_block_lat(q, xi=1.0)
@@ -486,7 +523,7 @@ def part_3() -> dict:
 
 
 def part_4(p3: dict) -> None:
-    hr("V4 -- off-surface controls, mutual unconstraint, tadpole direction test")
+    hr("Off-surface controls, deformation-response witness, tadpole direction test (V4)")
     qpts = p3["qpts"]
     hw2 = p3["hw2"]
 
@@ -500,7 +537,7 @@ def part_4(p3: dict) -> None:
           abs(a07) > 1e-4, f"A(xi=0.7)={a07:+.4f}, |A| > 1e-4")
     check("rainbow xi=1.3 orbit anisotropy NONZERO off-surface",
           abs(a13) > 1e-4, f"A(xi=1.3)={a13:+.4f}, |A| > 1e-4")
-    check("xi<1 / xi>1 STRADDLE in sign (xi=1 isolated zero)",
+    check("xi<1 / xi>1 STRADDLE in sign across xi=1 (two samples; no isolated-zero claim)",
           np.sign(a07) != np.sign(a13) and abs(a07) > 1e-4 and abs(a13) > 1e-4,
           f"sign(0.7)={np.sign(a07):+.0f} sign(1.3)={np.sign(a13):+.0f}, both |A| > 1e-4")
 
@@ -510,9 +547,10 @@ def part_4(p3: dict) -> None:
     check("GAUGED-VERTEX orbit anisotropy NONZERO off-surface (xi=1.3)",
           abs(ag13) > 1e-4, f"A_g(xi=1.3)={ag13:+.4f}, |A_g| > 1e-4")
 
-    # mutual unconstraint: the fermion-loop Pi carries NO internal gluon line, so
-    # the gauge-block deformation cannot move it; the fermion-velocity deformation
-    # DOES move it.
+    # deformation-response witness (symmetry-tracking, NOT a dynamical-unconstraint
+    # claim): the fermion-loop Pi carries NO internal gluon line in this diagram
+    # class, so the gauge-block deformation cannot move it; the fermion-velocity
+    # deformation DOES move it.
     check("Pi FEELS the fermion deformation (induced anisotropy at eps=0.10 nonzero)",
           abs(_P2["ind1"]) > 1e-4,
           f"induced(0.10)={_P2['ind1']:+.4f}; Pi has no internal gluon line by construction")
@@ -537,7 +575,7 @@ def part_4(p3: dict) -> None:
 
 
 def part_5() -> None:
-    hr("V5 -- exact invariant counting (sympy Reynolds): B4 rank 1 vs O_h rank 2")
+    hr("Exact invariant counting + joint (hw2 taste, axis) representation lemma (V5)")
 
     def reynolds(perms):
         P = sp.zeros(4, 4)
@@ -569,9 +607,64 @@ def part_5() -> None:
           sp.simplify(img3[0] - 1) == 0 and all(sp.simplify(img3[i]) == 0 for i in (1, 2, 3)),
           f"image={list(img3)}")
 
+    # JOINT (hw2 taste B, axis mu) representation lemma. The fermion object is
+    # the 24-dim coefficient array c_{B,mu} (6 hw2 tastes x 4 axes), NOT a
+    # single 4-vector. S4 acts jointly: B -> B o p, mu -> p^{-1}(mu) (membership
+    # mu in B is preserved). Averaged over the full group / subgroup, the
+    # anti-homomorphism convention gives the same Reynolds projector.
+    hw2 = [tuple(s) for s in it.product([0, 1], repeat=4) if sum(s) == 2]
+    pairs = [(bi, mu) for bi in range(6) for mu in range(4)]
+    pidx = {p: i for i, p in enumerate(pairs)}
+
+    def joint_matrix(prm):
+        Mx = sp.zeros(24, 24)
+        for bi, mu in pairs:
+            B = hw2[bi]
+            newB = tuple(B[prm[j]] for j in range(4))
+            Mx[pidx[(hw2.index(newB), prm.index(mu))], pidx[(bi, mu)]] = 1
+        return Mx
+
+    def joint_reynolds(perms):
+        R = sp.zeros(24, 24)
+        for prm in perms:
+            R += joint_matrix(prm)
+        return R / len(perms)
+
+    in_b = sp.Matrix([1 if hw2[bi][mu] == 1 else 0 for bi, mu in pairs])
+    out_b = sp.Matrix([1 if hw2[bi][mu] == 0 else 0 for bi, mu in pairs])
+
+    R24 = joint_reynolds(list(it.permutations(range(4))))
+    check("JOINT S4 invariant rank on c_{B,mu} = 2 (orbit indicators {mu in B}, "
+          "{mu not in B})",
+          R24.rank() == 2 and R24 * in_b == in_b and R24 * out_b == out_b,
+          f"rank={R24.rank()}; both orbit indicators are fixed vectors")
+
+    counts = [sum(hw2[bi][mu] for bi in range(6)) for mu in range(4)]
+    check("each axis lies in EXACTLY 3 of the 6 hw2 tastes",
+          counts == [3, 3, 3, 3], f"counts={counts}")
+
+    Avg = sp.zeros(4, 24)
+    for bi, mu in pairs:
+        Avg[mu, pidx[(bi, mu)]] += sp.Rational(1, 6)
+    AR = Avg * R24
+    iso_img = all(sp.simplify(AR[i, j] - AR[0, j]) == 0
+                  for j in range(24) for i in range(1, 4))
+    check("UNIFORM hw2 averaging o S4 Reynolds: rank 1, image ISOTROPIC "
+          "(the V3 orbit-sum zero is this representation-forced projection)",
+          AR.rank() == 1 and iso_img, f"rank={AR.rank()}; all rows equal")
+
+    R24_3 = joint_reynolds(perms3)
+    check("JOINT time-fixing S3 invariant rank = 6 (six (taste-type, axis-role) "
+          "orbits)",
+          R24_3.rank() == 6, f"rank={R24_3.rank()}")
+    AR3 = Avg * R24_3
+    check("uniform hw2 averaging o time-fixing S3 Reynolds: rank 2 -- time-fixing "
+          "symmetry alone does NOT force c_t = c_s (symmetry counting only)",
+          AR3.rank() == 2, f"rank={AR3.rank()}")
+
 
 def part_6(p3: dict) -> None:
-    hr("V6 -- speed arithmetic: Z cancellation, pinned ratio = 1, broken freedom")
+    hr("Speed arithmetic: Z cancellation, pinned ratio = 1, broken freedom (V6)")
     ZF, ZG = sp.symbols("Z_F Z_G", positive=True)
     ctF, csF, ctG, csG = sp.symbols("c_tF c_sF c_tG c_sG", positive=True)
     vF = sp.sqrt((ZF * csF) / (ZF * ctF))

--- a/scripts/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.py
+++ b/scripts/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""Cross-sector front-speed B4 two-surface alignment -- bounded-theorem runner.
+
+Companion runner for
+docs/CROSS_SECTOR_FRONT_SPEED_B4_TWO_SURFACE_ALIGNMENT_BOUNDED_THEOREM_NOTE_2026-07-16.md
+
+Conditional bounded theorem; BOTH supplied legs are declared in the note:
+  (L1) ALLORDERS_B4 premise (A): exact B4 invariance of the regulated action and
+       measure on the Z^4 surface is SUPPLIED, not derived from the four axioms.
+  (L2) `taste_orbit_summed_front_speed_readout_context`: the taste-orbit-SUMMED
+       marginal curvature is identified as the physical fermion front-speed
+       observable. Declared supplied context, not derived; on the single-taste
+       reading the alignment theorem does NOT follow from this runner.
+
+Statement verified: on the Z^4 B4-covariant Wilson+staggered surface, B4 pins
+EACH sector's diagonal marginal kinetic form isotropic (Reynolds rank 1 on the
+diagonal marginal coefficients), so each sector's front speed v = sqrt(c_s/c_t)
+equals 1 in lattice units, the overall kinetic normalizations Z_F and Z_G
+cancel in the ratio, and v_F/v_G = 1 order-by-order on that surface. On the
+broken-B4 surface (Z^3 + continuous tick; time-fixing S3), each sector's
+c_t/c_s is an independent singlet (Reynolds rank 2 per sector) and
+v_F/v_G = sqrt(a_F/a_G) is free: set by two independent per-sector
+anisotropies through their quotient alone (scale-invariant), unconstrained
+by the time-fixing symmetry.
+
+The two computed one-loop channels are representative B4-covariant instances
+sharing the Wilson gluon block and the gauged staggered cos-vertex/seagull
+rules; they are NOT assembled at a single common parameter point (Pi: landed
+seagull kernel, massless fermion loop; Sigma_g: one-gluon exchange at the
+IR-safe mass M=0.21, with the fermion-line tadpole evaluated separately in
+V4 -- direction-blind on-surface, hence an isotropic marginal renormalization
+there). Each channel's own B4 covariance is what the theorem consumes; the
+instances are witnesses, not the proof.
+
+Verification map:
+  V1  Clifford algebra for BOTH landed gamma conventions (taste kron set,
+      seagull block set); W_B taste-rotation unitarity + conjugation for all
+      16 taste shifts B; gauged cos-vertex taste covariance
+      cos((p+piB-q/2)_mu) = (-1)^{B_mu} cos((p-q/2)_mu).
+  V2  Gauge sector (seagull-runner kernel, T_F=1/2, 0.5*Pi/tot): seagull-
+      completed Pi transverse (Ward < 5% at N=12) with the bubble (no seagull)
+      assembly much worse; B4 isotropy piT(temporal)==piT(spatial) at v=1;
+      eta=1 fixed point (induced anisotropy vanishes at isotropic input).
+  V3  Fermion sector, three kernels on the honest observable
+      G_hon = Dinv(p) - Sigma(p,B) (the observable READS the taste shift B --
+      non-degeneracy gates, never a W_B-conjugation define-away):
+      (a) rainbow scalar-gluon calibration; (b) gauged cos-vertex on the
+      Wilson block, Feynman gauge xi_gauge=1; (c) same in Landau gauge
+      xi_gauge=0. Per-taste anisotropy NONZERO and kernel-
+      dependent (three kernels, distinct values, signs differ); hw2 6-orbit
+      taste-sum anisotropy ZERO within tolerance for all three; orbit zero
+      structural across N=12 and N=10 for (a) and (b).
+  V4  Off-surface controls: temporal-edge deformed Wilson block
+      (2/xi)sin(xi q0/2) at xi=0.7 / xi=1.3 gives NONZERO orbit anisotropy
+      with a sign straddle (rainbow) and NONZERO at xi=1.3 (gauged vertex);
+      mutual unconstraint (Pi carries no internal gluon line yet feels the
+      fermion-velocity deformation); tadpole T_mu (declared normalization:
+      mean over the BZ grid, Landau form on the Wilson block) direction-blind
+      on-surface and direction-sensitive off-surface.
+  V5  Exact invariant counting (sympy Reynolds): B4 acts on the diagonal
+      marginal coefficients through its S4 quotient with invariant rank 1
+      (isotropic image); the time-fixing S3 (O_h horn) has rank 2.
+  V6  Speed arithmetic (sympy exact + numeric): constant kinetic
+      normalizations Z_F, Z_G cancel in v = sqrt(c_s/c_t); pinned-surface
+      ratio = 1 identically; broken-surface ratio = sqrt(a_F/a_G) depends
+      only on the quotient of the two independent per-sector anisotropies
+      (scale-invariance gated); numeric delta(v_F/v_G) = sqrt(vF2/vG2) - 1
+      = 0 on-surface, primary gate on the gauged cos-vertex curvatures with
+      the rainbow curvatures as a labeled robustness gate.
+
+Platform-stable output policy: gated prints are bound checks at the pass
+tolerances; raw machine-noise residuals are never printed on the pass path.
+O(1) landmark values are rounded to at most 4 decimals where stable.
+
+Momentum axis 0 = temporal throughout. Offset BZ grid k = 2 pi (j+1/2)/N - pi
+(B4-symmetric; required for exact taste-orbit sums). M = 0.21 internal
+infrared-safe mass. Grids: N=12 primary, N=10 secondary. Single process,
+chunked BZ loops; no dense objects beyond 4x4 gamma algebra and N^4 x 4
+momentum arrays.
+"""
+
+from __future__ import annotations
+
+import itertools as it
+import sys
+
+import numpy as np
+import sympy as sp
+
+np.seterr(all="ignore")
+PASS = 0
+FAIL = 0
+
+
+def check(label: str, ok: bool, detail: str = "") -> bool:
+    global PASS, FAIL
+    ok = bool(ok)
+    if ok:
+        PASS += 1
+        tag = "PASS"
+    else:
+        FAIL += 1
+        tag = "FAIL"
+    line = f"[{tag}] {label}"
+    if detail:
+        line += f"  ::  {detail}"
+    print(line)
+    return ok
+
+
+def bound_detail(name: str, value: float, bound: str, ok: bool) -> str:
+    """Platform-stable detail: on pass, state the bound; on fail, show the value."""
+    if ok:
+        return f"|{name}| < {bound} (bound holds; residual suppressed)"
+    return f"|{name}| = {value!r} EXCEEDS {bound}"
+
+
+def hr(title: str) -> None:
+    print()
+    print("=" * 78)
+    print(title)
+    print("=" * 78)
+
+
+# ---------------------------------------------------------------------------
+# Gamma conventions (BOTH landed sets)
+# ---------------------------------------------------------------------------
+M = 0.21
+I4 = np.eye(4, dtype=complex)
+I2 = np.eye(2, dtype=complex)
+Z2 = np.zeros((2, 2), complex)
+sx = np.array([[0, 1], [1, 0]], complex)
+sy = np.array([[0, -1j], [1j, 0]], complex)
+sz = np.array([[1, 0], [0, -1]], complex)
+
+# taste-runner kron set
+Gt = [np.kron(sx, sx), np.kron(sx, sy), np.kron(sx, sz), np.kron(sy, I2)]
+G5 = Gt[0] @ Gt[1] @ Gt[2] @ Gt[3]
+
+# seagull-runner block set
+blk = lambda A, B, C, D: np.block([[A, B], [C, D]])
+gb = np.array(
+    [
+        blk(Z2, -1j * sx, 1j * sx, Z2),
+        blk(Z2, -1j * sy, 1j * sy, Z2),
+        blk(Z2, -1j * sz, 1j * sz, Z2),
+        blk(I2, Z2, Z2, -I2),
+    ],
+    complex,
+)
+
+
+def taste_rotation(B):
+    W = I4.copy()
+    for mu in range(4):
+        if B[mu]:
+            W = W @ (G5 @ Gt[mu])
+    return W
+
+
+# ---------------------------------------------------------------------------
+# Shared BZ machinery (offset grid; axis 0 = temporal)
+# ---------------------------------------------------------------------------
+def make_bz_grid(n):
+    return (np.arange(n) + 0.5) / n * 2 * np.pi - np.pi
+
+
+def bz_points(n):
+    return np.array(list(it.product(make_bz_grid(n), repeat=4)))
+
+
+def gluon_block_lat(qpts, xi=1.0):
+    """Wilson gluon block; xi deforms the TEMPORAL (axis 0) edge as
+    (2/xi)sin(xi q0/2) so small-q0 is xi-independent (isolates B4-covariance
+    breaking; xi=1 is the B4-covariant surface)."""
+    val = ((2.0 / xi) * np.sin(xi * qpts[:, 0] / 2.0)) ** 2
+    for d in range(1, 4):
+        val = val + (2.0 * np.sin(qpts[:, d] / 2.0)) ** 2
+    return val + 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Fermion kernel (a): rainbow honest observable (taste-runner calibration kernel)
+# ---------------------------------------------------------------------------
+def self_energy(p, B, qpts, gluon):
+    Bv = np.asarray(B, float) * np.pi
+    sk = np.sin((p + Bv)[None, :] - qpts)
+    den = M * M + np.sum(sk**2, axis=1)
+    D = 1.0 / gluon(qpts)
+    w = D / den / len(qpts)
+    A = 4.0 * M * np.sum(w)
+    Bc = np.array([2.0 * np.sum(w * sk[:, mu]) for mu in range(4)])
+    return A * I4 + 1j * sum(Gt[mu] * Bc[mu] for mu in range(4))
+
+
+def dirac_inverse(p):
+    return M * I4 + 1j * sum(Gt[mu] * np.sin(p[mu]) for mu in range(4))
+
+
+def hon_dispersion(p, B, qpts, gluon):
+    Gop = dirac_inverse(p) - self_energy(p, B, qpts, gluon)
+    return float(np.min(np.linalg.eigvalsh(Gop.conj().T @ Gop)))
+
+
+def hon_curv(direction, B, qpts, gluon, eps=0.02):
+    p0 = np.zeros(4)
+    pp = np.zeros(4)
+    pm = np.zeros(4)
+    pp[direction] = eps
+    pm[direction] = -eps
+    return (
+        hon_dispersion(pp, B, qpts, gluon)
+        - 2.0 * hon_dispersion(p0, B, qpts, gluon)
+        + hon_dispersion(pm, B, qpts, gluon)
+    ) / eps**2
+
+
+# ---------------------------------------------------------------------------
+# Fermion kernels (b),(c): gauged cos-vertex Sigma on the Wilson block
+# ---------------------------------------------------------------------------
+def self_energy_gauged(p, B, qpts, Kvals, xi_gauge=1.0):
+    """Sigma_g(p,B) = -(1/Nq) sum_q sum_{mu,nu} cos((p+piB-q/2)_mu) g_mu
+    S(p-q+piB) cos((p+piB-q/2)_nu) g_nu D_munu(q), with D built from the Wilson
+    block Kvals and gauge parameter xi_gauge (1 = Feynman diagonal, 0 = Landau
+    transverse)."""
+    Bv = np.asarray(B, float) * np.pi
+    pk = (p + Bv)[None, :] - qpts
+    s = np.sin(pk)
+    den = M * M + np.sum(s**2, axis=1)
+    Sf = (M * I4[None, :, :] - 1j * np.einsum("ca,aij->cij", s, np.array(Gt))) / den[
+        :, None, None
+    ]
+    c = np.cos((p + Bv)[None, :] - qpts / 2.0)
+    Sig = np.zeros((4, 4), complex)
+    if xi_gauge == 1.0:
+        w = 1.0 / Kvals
+        for mu in range(4):
+            V = c[:, mu][:, None, None] * Gt[mu]
+            Sig += np.einsum("c,cij->ij", w, V @ Sf @ V)
+    else:
+        kh = 2.0 * np.sin(qpts / 2.0)
+        for mu in range(4):
+            VS = (c[:, mu][:, None, None] * Gt[mu]) @ Sf
+            for nu in range(4):
+                Dmn = ((mu == nu) * 1.0 - (1 - xi_gauge) * kh[:, mu] * kh[:, nu] / Kvals) / Kvals
+                Sig += np.einsum("c,cij->ij", Dmn, VS @ (c[:, nu][:, None, None] * Gt[nu]))
+    return -Sig / len(qpts)
+
+
+def hon_dispersion_g(p, B, qpts, Kvals, xi_gauge=1.0):
+    Gop = dirac_inverse(p) - self_energy_gauged(p, B, qpts, Kvals, xi_gauge=xi_gauge)
+    return float(np.min(np.linalg.eigvalsh(Gop.conj().T @ Gop)))
+
+
+def hon_curv_g(direction, B, qpts, Kvals, eps=0.02, xi_gauge=1.0):
+    p0 = np.zeros(4)
+    pp = np.zeros(4)
+    pm = np.zeros(4)
+    pp[direction] = eps
+    pm[direction] = -eps
+    return (
+        hon_dispersion_g(pp, B, qpts, Kvals, xi_gauge=xi_gauge)
+        - 2.0 * hon_dispersion_g(p0, B, qpts, Kvals, xi_gauge=xi_gauge)
+        + hon_dispersion_g(pm, B, qpts, Kvals, xi_gauge=xi_gauge)
+    ) / eps**2
+
+
+# ---------------------------------------------------------------------------
+# Gauge side: seagull-completed transverse Pi (seagull-runner kernel, block gammas)
+# ---------------------------------------------------------------------------
+def khat(qv):
+    return 2 * np.sin(np.array(qv) / 2)
+
+
+def pi_munu(qv, N, v, include_seagull=True, chunk=50000):
+    q = np.array(qv, float)
+    ax = make_bz_grid(N)
+    Pi = np.zeros((4, 4), complex)
+    tot = N**4
+    i0 = 0
+    while i0 < tot:
+        idx = np.arange(i0, min(i0 + chunk, tot))
+        i0 += chunk
+        a, r = np.divmod(idx, N**3)
+        b, r = np.divmod(r, N**2)
+        c, d = np.divmod(r, N)
+        k = np.stack([ax[a], ax[b], ax[c], ax[d]], 1)
+        kq = k + q
+        sk = np.sin(k) * v
+        skq = np.sin(kq) * v
+        Dk = np.sum(sk**2, 1)
+        Dkq = np.sum(skq**2, 1)
+        Sk = (-1j * np.einsum("ca,aij->cij", sk, gb)) / Dk[:, None, None]
+        Skq = (-1j * np.einsum("ca,aij->cij", skq, gb)) / Dkq[:, None, None]
+        cmid = np.cos(k + q / 2)
+        sk_mu = np.sin(k)
+        for mu in range(4):
+            Vmu = 1j * cmid[:, mu][:, None, None] * gb[mu]
+            SV = Sk @ Vmu @ Skq
+            for nu in range(4):
+                Vnu = 1j * cmid[:, nu][:, None, None] * gb[nu]
+                Pi[mu, nu] += np.einsum("cii->", SV @ Vnu)
+            if include_seagull:
+                Dmm = (-1j) * sk_mu[:, mu][:, None, None] * gb[mu]
+                Pi[mu, mu] += -np.einsum("cij,cji->", Sk, Dmm)
+    return 0.5 * Pi / tot  # T_F = 1/2 (seagull-runner convention)
+
+
+def ward(Pi, qv):
+    return np.max(np.abs(khat(qv) @ Pi)) / (np.max(np.abs(Pi)) + 1e-30)
+
+
+def piT(qaxis, q, N, v):
+    qv = [0.0, 0.0, 0.0, 0.0]
+    qv[qaxis] = q
+    Pi = np.real(pi_munu(qv, N, v))
+    b = (qaxis + 1) % 4
+    return Pi[b, b] / (khat(qv)[qaxis] ** 2)
+
+
+# ===========================================================================
+def part_1() -> None:
+    hr("V1 -- Clifford (both sets), W_B conjugation, cos-vertex taste covariance")
+    for name, GG in (("taste kron set", Gt), ("seagull block set", list(gb))):
+        worst = 0.0
+        for mu in range(4):
+            for nu in range(4):
+                anti = GG[mu] @ GG[nu] + GG[nu] @ GG[mu]
+                worst = max(worst, float(np.max(np.abs(anti - 2 * (mu == nu) * I4))))
+        ok = worst < 1e-12
+        check(f"Clifford {{g,g}}=2delta ({name})", ok,
+              bound_detail("max dev", worst, "1e-12", ok))
+
+    worst = 0.0
+    ok = True
+    for B in it.product([0, 1], repeat=4):
+        W = taste_rotation(B)
+        if float(np.max(np.abs(W.conj().T @ W - I4))) > 1e-12:
+            ok = False
+        for mu in range(4):
+            dev = float(
+                np.max(np.abs(W.conj().T @ Gt[mu] @ W - ((-1) ** B[mu]) * Gt[mu]))
+            )
+            worst = max(worst, dev)
+            if dev > 1e-10:
+                ok = False
+    check("W_B unitary AND W_B^-1 g_mu W_B = (-1)^{B_mu} g_mu (all 16 B)", ok,
+          bound_detail("worst dev", worst, "1e-10", ok))
+
+    rng = np.random.default_rng(7)
+    worst = 0.0
+    for _ in range(5):
+        p = rng.uniform(-np.pi, np.pi, 4)
+        q = rng.uniform(-np.pi, np.pi, 4)
+        for B in it.product([0, 1], repeat=4):
+            Bv = np.asarray(B, float) * np.pi
+            lhs = np.cos(p + Bv - q / 2.0)
+            rhs = np.array([(-1) ** B[mu] for mu in range(4)]) * np.cos(p - q / 2.0)
+            worst = max(worst, float(np.max(np.abs(lhs - rhs))))
+    ok = worst < 1e-12
+    check("gauged cos vertex taste-covariant: cos(p+piB-q/2)=(-1)^B cos(p-q/2)",
+          ok, bound_detail("worst dev (all 16 B, 5 random p,q)", worst, "1e-12", ok))
+
+
+def part_2() -> dict:
+    hr("V2 -- gauge sector: seagull-completed transverse Pi, B4 isotropy, eta=1")
+    N = 12
+    iso = np.array([1.0, 1.0, 1.0, 1.0])
+    qvs = ([0.0, 0.4, 0.0, 0.0], [0.3, 0.3, 0.0, 0.0], [0.0, 0.0, 0.0, 0.5])
+    w_sea = [ward(np.real(pi_munu(qv, N, iso)), qv) for qv in qvs]
+    check("Ward khat_mu Pi_munu transverse < 5% WITH seagull (N=12)",
+          max(w_sea) < 0.05, f"worst violation={max(w_sea):.4f} < 0.05")
+    w_bub = [ward(np.real(pi_munu(qv, N, iso, include_seagull=False)), qv) for qv in qvs]
+    check("bubble (no seagull) Ward violation is LARGE (seagull is load-bearing)",
+          min(w_bub) > 0.05 and min(w_bub) > 3 * max(w_sea),
+          f"bubble min={min(w_bub):.4f} > 0.05 and > 3x seagull worst")
+
+    qq = [0.5, 0.3, 0.18]
+    diffs = [abs(piT(0, q, N, iso) - piT(1, q, N, iso)) for q in qq]
+    ok = max(diffs) < 1e-8
+    check("B4 isotropy at v=1: piT(temporal)==piT(spatial) (< 1e-8)",
+          ok, bound_detail("max piT diff (q in {0.5,0.3,0.18})", max(diffs), "1e-8", ok))
+
+    def induced(eps, q):
+        v = np.array([1 - eps / 2, 1 + eps / 2, 1 + eps / 2, 1 + eps / 2])
+        return piT(1, q, N, v) - piT(0, q, N, v)
+
+    ind0 = induced(0.0, 0.3)
+    ok = abs(ind0) < 1e-8
+    check("eta=1 fixed point: induced Pi anisotropy vanishes at eps=0",
+          ok, bound_detail("induced(0)", ind0, "1e-8", ok))
+    ind1 = induced(0.10, 0.3)
+    return {"N": N, "ind1": ind1, "pit0": piT(0, 0.3, N, iso), "pit1": piT(1, 0.3, N, iso)}
+
+
+def part_3() -> dict:
+    hr("V3 -- fermion sector: three kernels (rainbow; gauged Feynman; gauged Landau)")
+    n = 12
+    qpts = bz_points(n)
+    gluon1 = lambda q: gluon_block_lat(q, xi=1.0)
+    hw2 = [tuple(s) for s in it.product([0, 1], repeat=4) if sum(s) == 2]
+    B_rep = (0, 1, 1, 0)
+
+    p_test = np.array([0.11, 0.15, 0.19, 0.13])
+    nondeg = float(np.max(np.abs(
+        self_energy(p_test, (0, 0, 0, 0), qpts, gluon1)
+        - self_energy(p_test, B_rep, qpts, gluon1))))
+    check("NON-DEGENERACY: Sigma(B=0) != Sigma(B_rep) (taste shift visible)",
+          nondeg > 1e-4, f"||dSigma||={nondeg:.4f} > 1e-4")
+
+    c_rep = [hon_curv(d, B_rep, qpts, gluon1) for d in range(4)]
+    a_rep = c_rep[0] - np.mean(c_rep[1:])
+    check("rainbow PER-TASTE anisotropy A(B_rep) ~ -0.2 (NONZERO, negative)",
+          -0.35 < a_rep < -0.10,
+          f"A={a_rep:+.4f} curv={[round(v, 4) for v in c_rep]}")
+
+    co = [np.mean([hon_curv(d, B, qpts, gluon1) for B in hw2]) for d in range(4)]
+    a_orb = co[0] - np.mean(co[1:])
+    ok = abs(a_orb) < 1e-6
+    check("rainbow hw2 ORBIT-SUM anisotropy ~ 0 on-surface (N=12)",
+          ok, bound_detail("A_orbit", a_orb, "1e-6", ok))
+
+    q10 = bz_points(10)
+    co10 = [np.mean([hon_curv(d, B, q10, gluon1) for B in hw2]) for d in range(4)]
+    a10 = co10[0] - np.mean(co10[1:])
+    ok = abs(a10) < 1e-6
+    check("rainbow orbit-sum zero STRUCTURAL (also N=10)",
+          ok, bound_detail("A_orbit(N=10)", a10, "1e-6", ok))
+
+    # kernel (b): gauged cos-vertex Sigma on the Wilson block (same Wilson block Pi gauges; Feynman)
+    K1 = gluon_block_lat(qpts, xi=1.0)
+    nondeg_g = float(np.max(np.abs(
+        self_energy_gauged(p_test, (0, 0, 0, 0), qpts, K1)
+        - self_energy_gauged(p_test, B_rep, qpts, K1))))
+    check("GAUGED-VERTEX Sigma_g: taste shift visible (non-degeneracy)",
+          nondeg_g > 1e-4, f"||dSigma_g||={nondeg_g:.4f} > 1e-4")
+
+    cg_rep = [hon_curv_g(d, B_rep, qpts, K1) for d in range(4)]
+    ag_rep = cg_rep[0] - np.mean(cg_rep[1:])
+    check("GAUGED-VERTEX (Feynman) per-taste anisotropy NONZERO on-surface",
+          abs(ag_rep) > 0.01,
+          f"A_g={ag_rep:+.4f} curv={[round(v, 4) for v in cg_rep]}")
+
+    cog = [np.mean([hon_curv_g(d, B, qpts, K1) for B in hw2]) for d in range(4)]
+    ag_orb = cog[0] - np.mean(cog[1:])
+    ok = abs(ag_orb) < 1e-6
+    check("GAUGED-VERTEX hw2 ORBIT-SUM anisotropy ~ 0 on-surface (gauged cos-vertex on the Wilson block)",
+          ok, bound_detail("A_g_orbit", ag_orb, "1e-6", ok))
+
+    K10 = gluon_block_lat(q10, xi=1.0)
+    cog10 = [np.mean([hon_curv_g(d, B, q10, K10) for B in hw2]) for d in range(4)]
+    ag10 = cog10[0] - np.mean(cog10[1:])
+    ok = abs(ag10) < 1e-6
+    check("GAUGED-VERTEX orbit-sum zero STRUCTURAL (also N=10)",
+          ok, bound_detail("A_g_orbit(N=10)", ag10, "1e-6", ok))
+
+    # kernel (c): same gauged vertex, Landau gauge xi_gauge=0 (N=10 for cost)
+    cL_rep = [hon_curv_g(d, B_rep, q10, K10, xi_gauge=0.0) for d in range(4)]
+    aL_rep = cL_rep[0] - np.mean(cL_rep[1:])
+    check("GAUGED-VERTEX (Landau) per-taste anisotropy NONZERO (N=10)",
+          abs(aL_rep) > 0.01,
+          f"A_L={aL_rep:+.4f} curv={[round(v, 4) for v in cL_rep]}")
+
+    coL = [np.mean([hon_curv_g(d, B, q10, K10, xi_gauge=0.0) for B in hw2])
+           for d in range(4)]
+    aL_orb = coL[0] - np.mean(coL[1:])
+    ok = abs(aL_orb) < 1e-6
+    check("GAUGED-VERTEX (Landau) hw2 ORBIT-SUM anisotropy ~ 0 (gauge-robust)",
+          ok, bound_detail("A_L_orbit", aL_orb, "1e-6", ok))
+
+    # three-kernel witness at matched N=10: the UNPROTECTED per-taste value is
+    # kernel-dependent (distinct values, signs differ) while the orbit sum is
+    # zero for all three -- the orbit zero is symmetry-driven, not kernel tuning.
+    cr10 = [hon_curv(d, B_rep, q10, gluon1) for d in range(4)]
+    ar10 = cr10[0] - np.mean(cr10[1:])
+    cf10 = [hon_curv_g(d, B_rep, q10, K10) for d in range(4)]
+    af10 = cf10[0] - np.mean(cf10[1:])
+    trio = [ar10, af10, aL_rep]
+    pair_min = min(abs(x - y) for x, y in it.combinations(trio, 2))
+    signs = sorted(np.sign(t) for t in trio)
+    check("PER-TASTE value KERNEL-DEPENDENT at matched N=10 (3 kernels, signs differ)",
+          pair_min > 0.03 and signs[0] < 0 < signs[-1],
+          f"A(rainbow)={ar10:+.4f} A(Feynman)={af10:+.4f} A(Landau)={aL_rep:+.4f} "
+          f"min pairwise sep={pair_min:.4f} > 0.03")
+    return {"co": co, "cog": cog, "hw2": hw2, "qpts": qpts}
+
+
+def part_4(p3: dict) -> None:
+    hr("V4 -- off-surface controls, mutual unconstraint, tadpole direction test")
+    qpts = p3["qpts"]
+    hw2 = p3["hw2"]
+
+    def orbit_aniso(gluon):
+        co = [np.mean([hon_curv(d, B, qpts, gluon) for B in hw2]) for d in range(4)]
+        return co[0] - np.mean(co[1:])
+
+    a07 = orbit_aniso(lambda q: gluon_block_lat(q, xi=0.7))
+    a13 = orbit_aniso(lambda q: gluon_block_lat(q, xi=1.3))
+    check("rainbow xi=0.7 orbit anisotropy NONZERO off-surface",
+          abs(a07) > 1e-4, f"A(xi=0.7)={a07:+.4f}, |A| > 1e-4")
+    check("rainbow xi=1.3 orbit anisotropy NONZERO off-surface",
+          abs(a13) > 1e-4, f"A(xi=1.3)={a13:+.4f}, |A| > 1e-4")
+    check("xi<1 / xi>1 STRADDLE in sign (xi=1 isolated zero)",
+          np.sign(a07) != np.sign(a13) and abs(a07) > 1e-4 and abs(a13) > 1e-4,
+          f"sign(0.7)={np.sign(a07):+.0f} sign(1.3)={np.sign(a13):+.0f}, both |A| > 1e-4")
+
+    K13 = gluon_block_lat(qpts, xi=1.3)
+    cog13 = [np.mean([hon_curv_g(d, B, qpts, K13) for B in hw2]) for d in range(4)]
+    ag13 = cog13[0] - np.mean(cog13[1:])
+    check("GAUGED-VERTEX orbit anisotropy NONZERO off-surface (xi=1.3)",
+          abs(ag13) > 1e-4, f"A_g(xi=1.3)={ag13:+.4f}, |A_g| > 1e-4")
+
+    # mutual unconstraint: the fermion-loop Pi carries NO internal gluon line, so
+    # the gauge-block deformation cannot move it; the fermion-velocity deformation
+    # DOES move it.
+    check("Pi FEELS the fermion deformation (induced anisotropy at eps=0.10 nonzero)",
+          abs(_P2["ind1"]) > 1e-4,
+          f"induced(0.10)={_P2['ind1']:+.4f}; Pi has no internal gluon line by construction")
+
+    # tadpole T_mu; declared normalization: mean over the BZ grid, Landau form on
+    # the Wilson block
+    kh = 2.0 * np.sin(qpts / 2.0)
+
+    def tadpole(xi):
+        K = gluon_block_lat(qpts, xi=xi)
+        return np.array([np.mean((1.0 - kh[:, mu] ** 2 / K) / K) for mu in range(4)])
+
+    T1 = tadpole(1.0)
+    T13 = tadpole(1.3)
+    sp1 = (T1.max() - T1.min()) / abs(T1.mean())
+    d13 = abs(T13[0] - T13[1]) / abs(T13.mean())
+    ok = sp1 < 1e-10
+    check("tadpole T_mu DIRECTION-BLIND on-surface (relative spread < 1e-10)",
+          ok, bound_detail("rel spread", sp1, "1e-10", ok))
+    check("tadpole T_mu DIRECTION-SENSITIVE off-surface (xi=1.3)",
+          d13 > 1e-3, f"rel |T_t - T_s|={d13:.4f} > 1e-3")
+
+
+def part_5() -> None:
+    hr("V5 -- exact invariant counting (sympy Reynolds): B4 rank 1 vs O_h rank 2")
+
+    def reynolds(perms):
+        P = sp.zeros(4, 4)
+        for prm in perms:
+            Mx = sp.zeros(4, 4)
+            for i, j in enumerate(prm):
+                Mx[i, j] = 1
+            P += Mx
+        return P / len(perms)
+
+    # B4 acts on diagonal marginal coefficients c_mu p_mu^2 through its S4
+    # quotient (signs act trivially on p_mu^2)
+    R4 = reynolds(list(it.permutations(range(4))))
+    e0 = sp.Matrix([1, 0, 0, 0])
+    img4 = R4 * e0
+    check("B4 (S4 quotient) Reynolds rank on {c_mu} = 1 (single marginal invariant)",
+          R4.rank() == 1, f"rank={R4.rank()}")
+    check("B4 projection of c=(1,0,0,0) is ISOTROPIC (all entries equal 1/4)",
+          all(sp.simplify(img4[i] - sp.Rational(1, 4)) == 0 for i in range(4)),
+          f"image={list(img4)}")
+
+    # O_h horn: time axis fixed, S3 on spatial axes
+    perms3 = [(0,) + tuple(x + 1 for x in prm) for prm in it.permutations(range(3))]
+    R3 = reynolds(perms3)
+    img3 = R3 * e0
+    check("O_h (time-fixing S3) Reynolds rank on {c_mu} = 2 (c_t independent of c_s)",
+          R3.rank() == 2, f"rank={R3.rank()}")
+    check("O_h projection keeps c_t != c_s (image (1,0,0,0) survives)",
+          sp.simplify(img3[0] - 1) == 0 and all(sp.simplify(img3[i]) == 0 for i in (1, 2, 3)),
+          f"image={list(img3)}")
+
+
+def part_6(p3: dict) -> None:
+    hr("V6 -- speed arithmetic: Z cancellation, pinned ratio = 1, broken freedom")
+    ZF, ZG = sp.symbols("Z_F Z_G", positive=True)
+    ctF, csF, ctG, csG = sp.symbols("c_tF c_sF c_tG c_sG", positive=True)
+    vF = sp.sqrt((ZF * csF) / (ZF * ctF))
+    vG = sp.sqrt((ZG * csG) / (ZG * ctG))
+    ratio = vF / vG
+    check("overall kinetic normalizations Z_F, Z_G CANCEL in v_F/v_G (exact)",
+          sp.simplify(ratio - sp.sqrt(csF * ctG / (ctF * csG))) == 0,
+          "v_F/v_G = sqrt(c_sF c_tG / (c_tF c_sG)) -- no Z dependence")
+    pinned = sp.simplify(ratio.subs({csF: ctF, csG: ctG}) - 1)
+    check("on the B4-pinned surface (c_t=c_s per sector) v_F/v_G = 1 IDENTICALLY",
+          pinned == 0, f"residual={pinned}")
+    aF, aG = sp.symbols("a_F a_G", positive=True)
+    lam = sp.symbols("lambda_s", positive=True)
+    broken = ratio.subs({csF: aF * ctF, csG: aG * ctG})
+    dF = sp.simplify(sp.diff(broken, aF))
+    dG = sp.simplify(sp.diff(broken, aG))
+    scale_inv = sp.simplify(broken.subs({aF: lam * aF, aG: lam * aG}, simultaneous=True)
+                            - broken) == 0
+    check("broken-B4 surface: v_F/v_G = sqrt(a_F/a_G) -- two independent per-sector "
+          "anisotropies, ratio depends only on their quotient (scale-invariant)",
+          sp.simplify(broken - sp.sqrt(aF / aG)) == 0 and dF != 0 and dG != 0
+          and scale_inv,
+          f"ratio={sp.simplify(broken)}; ratio(lam aF, lam aG) == ratio")
+
+    # numeric two-surface witness from the computed data. delta is taken on the
+    # SPEED ratio v_F/v_G = sqrt(vF2/vG2), not on the squared ratio. Primary
+    # gate: the gauged cos-vertex curvatures; the rainbow
+    # curvatures are kept as a labeled robustness gate.
+    vG2 = _P2["pit1"] / _P2["pit0"]
+    for label, curv in (("gauged cos-vertex (primary)", p3["cog"]),
+                        ("rainbow (robustness)", p3["co"])):
+        vF2 = np.mean(curv[1:]) / curv[0]
+        delta = float(np.sqrt(vF2 / vG2)) - 1.0
+        ok = abs(vF2 - 1) < 1e-6 and abs(vG2 - 1) < 1e-8 and abs(delta) < 1e-6
+        check(f"NUMERIC delta(v_F/v_G)=sqrt(vF2/vG2)-1 = 0 on-surface -- {label}",
+              ok,
+              "|vF^2 ratio - 1| < 1e-6 AND |vG^2 ratio - 1| < 1e-8 AND "
+              "|delta| < 1e-6 (bounds hold; residuals suppressed)" if ok else
+              f"vF2-1={vF2 - 1!r} vG2-1={vG2 - 1!r} delta={delta!r}")
+
+
+_P2 = {}
+
+
+def main() -> int:
+    global _P2
+    print("Cross-sector front-speed B4 two-surface alignment -- bounded-theorem runner")
+    print("(conditional on ALLORDERS_B4 premise (A) and the declared supplied context")
+    print(" `taste_orbit_summed_front_speed_readout_context`; see companion note)")
+    part_1()
+    _P2 = part_2()
+    p3 = part_3()
+    part_4(p3)
+    part_5()
+    part_6(p3)
+    hr("SCORECARD")
+    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Conditional bounded theorem for Target 2 (cross-sector front-speed alignment): on the supplied Z^4 B4-covariant Wilson+staggered surface, B4-invariance pins EACH sector's marginal kinetic form isotropic (B4→S4 Reynolds rank 1 on the diagonal marginal coefficients, vs rank 2 for the time-fixing S3), so each sector's front speed v = sqrt(c_s/c_t) equals 1 per sector, constant kinetic normalizations Z_F and Z_G cancel exactly, and v_F/v_G = 1 order-by-order on that surface. Per-sector B4 pinning is the custodial mechanism — no cross-sector conspiracy is needed.
- On the broken-B4 surface (Z^3 + continuous tick), each sector's c_t/c_s is an independent singlet of the time-fixing subgroup and v_F/v_G = sqrt(a_F/a_G) is free — set by the quotient of the two independent per-sector anisotropies (scale-invariance gated), exactly as the two landed velocity-RG parentheticals assert.
- Conditional on TWO supplied legs, both declared in the note: (1) the ALLORDERS_B4 premise (A); (2) the declared readout context `taste_orbit_summed_front_speed_readout_context` (the single-taste reading stays live; per-taste anisotropy is nonzero and kernel-dependent across three kernels — rainbow, gauged cos-vertex Feynman, gauged cos-vertex Landau — while the hw2 6-orbit taste-sum anisotropy is zero within tolerance for all three).
- Adversarially panel-reviewed pre-PR (5 lenses: semantics, math, governance, reproduction, physics-adversary); all accepted findings repaired in place, including honest narrowing of the computed instances (representative one-loop channels sharing the Wilson gluon block and gauged cos-vertex/seagull rules, not assembled at a single common parameter point) and ledger-status corrections in the dependency table.

## Changes
- `docs/CROSS_SECTOR_FRONT_SPEED_B4_TWO_SURFACE_ALIGNMENT_BOUNDED_THEOREM_NOTE_2026-07-16.md` — source note (theorem, two supplied legs, L1–L4, scoped result, honest boundary, dependency table, verification map)
- `scripts/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.py` — paired class-A runner (V1–V6; sympy Reynolds ranks, exact Z-cancellation and scale-invariance gates, three-kernel orbit-sum witnesses, off-surface controls)
- `logs/runner-cache/cross_sector_front_speed_b4_two_surface_alignment_2026_07_16.txt` — cached runner output via `scripts/runner_cache.py`

## Test Plan
- [x] Runner re-run end-to-end after all panel repairs: `TOTAL: PASS=35 FAIL=0`
- [x] Cache regenerated from the final runner (labels changed → SHA and output both refreshed); platform-stable output policy checked (no raw noise-digit prints)
- [x] `docs/audit/scripts/audit_lint.py` on the branch: OK, no errors
- [x] Cited ledger rows re-verified against origin/main tip 9db989e29f: kinetic_isotropy_primitive=meta, lorentz_violation_derived_note=unaudited, taste_scalar_isotropy_theorem_note=retained, dispersion_high_p_tiebreaker_note=retained_bounded
- [x] Rebased onto origin/main 9db989e29f before push (branch never previously pushed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
