### PR TITLE
authoring gates: directory-target rule, class-F header check, citation-graph delta manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Use these entrypoints in order:
     and [reproduce guide](docs/publication/ci3_z3/REPRODUCE.md)
 11. [Science map by domain](docs/publication/ci3_z3/SCIENCE_MAP.md)
 12. [Open science lanes](docs/lanes/open_science/README.md)
-13. [Full audit ledger (tracked shards)](docs/audit/data/ledger/), summarized in
+13. Full audit ledger: tracked shards under `docs/audit/data/ledger/`, summarized in
     [`effective_status_summary.json`](docs/audit/data/effective_status_summary.json)
 
 ## Current Status
@@ -90,7 +90,7 @@ the current counts, refreshed by `bash docs/audit/scripts/run_pipeline.sh`.
 Source notes and publication tables still contain legacy `retained` /
 `promoted` wording, but the publication-facing authority is the audit-derived
 `effective_status` in the tracked sharded audit ledger
-([`docs/audit/data/ledger/`](docs/audit/data/ledger/), one JSON shard per claim,
+(`docs/audit/data/ledger/`, one JSON shard per claim,
 summarized in
 [`docs/audit/data/effective_status_summary.json`](docs/audit/data/effective_status_summary.json)).
 The monolithic `docs/audit/AUDIT_LEDGER.md` is a local pipeline-materialized

--- a/docs/GRADED_CONSTRAINT_PROGRAM_AND_RECORD_INFLUENCE_CRITERION_2026-07-04.md
+++ b/docs/GRADED_CONSTRAINT_PROGRAM_AND_RECORD_INFLUENCE_CRITERION_2026-07-04.md
@@ -12,7 +12,7 @@ targets, it says so.
 **Status authority:** none. Independent audit lane and owner channels are
 untouched.
 **Premise weight:** none — the policy log's retired-reading-notes formula
-applies to this entire memo: no premise or interpretive weight. Per the
+applies to this entire memo: no premise or interpretive weight. Per the This memo is citable for orientation and scope discipline only.
 Qualification, nothing here is usable as a premise. Every load-bearing item
 below either points at its owning channel (policy entry, bounded note,
 registry, or landed Class D proposal) or is marked OPEN or CANDIDATE. Worker

--- a/docs/GRADED_CONSTRAINT_PROGRAM_AND_RECORD_INFLUENCE_CRITERION_2026-07-04.md
+++ b/docs/GRADED_CONSTRAINT_PROGRAM_AND_RECORD_INFLUENCE_CRITERION_2026-07-04.md
@@ -12,7 +12,8 @@ targets, it says so.
 **Status authority:** none. Independent audit lane and owner channels are
 untouched.
 **Premise weight:** none — the policy log's retired-reading-notes formula
-applies to this entire memo: no premise or interpretive weight. Per the This memo is citable for orientation and scope discipline only.
+applies to this entire memo: no premise or interpretive weight. This memo is
+citable for orientation and scope discipline only. Per the
 Qualification, nothing here is usable as a premise. Every load-bearing item
 below either points at its owning channel (policy entry, bounded note,
 registry, or landed Class D proposal) or is marked OPEN or CANDIDATE. Worker

--- a/docs/KEY_TERMINOLOGY.md
+++ b/docs/KEY_TERMINOLOGY.md
@@ -1,4 +1,4 @@
-<!-- generated; do not edit by hand; source: docs/repo/controlled_vocabulary.yaml hash=52efc0e707a89b2770070e3b0844ea9df4f25622d10bc5049d8eb62d96829460 -->
+<!-- generated; do not edit by hand; source: docs/repo/controlled_vocabulary.yaml hash=dc02750e482ab935590058a2194f976ba8fba24eb54d6abde65acc594de73d05 -->
 # Key Terminology
 
 **Claim type:** meta

--- a/docs/audit/SCIENCE_WORKER_QUEUE.md
+++ b/docs/audit/SCIENCE_WORKER_QUEUE.md
@@ -113,6 +113,6 @@ The first pass demonstrated that **honest downgrade is the highest-yield move** 
   (preserved as context; kept for re-audit if any of the closed lanes needs re-promotion)
 - Audit lane policy: [README.md](README.md), [FRESH_LOOK_REQUIREMENTS.md](FRESH_LOOK_REQUIREMENTS.md), [ALGEBRAIC_DECORATION_POLICY.md](ALGEBRAIC_DECORATION_POLICY.md)
 - Mechanical pipeline: `scripts/run_pipeline.sh`
-- Ledger source of truth: [data/ledger/](data/ledger/) (the rendered `AUDIT_LEDGER.md`
+- Ledger source of truth: `data/ledger/` (the rendered `AUDIT_LEDGER.md`
   is a local cache; rebuild with `python3 scripts/render_audit_ledger.py`)
 - Pending audit queue (mechanical): [AUDIT_QUEUE.md](AUDIT_QUEUE.md)

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,0 +1,15851 @@
+{
+ "edge_count": 14464,
+ "node_count": 3961,
+ "nodes": {
+  "3d_correction_master_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "a1_qubit_interpretation_note_2026-05-20": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "a3_option_c_brannen_rivero_physical_lattice_bounded_obstruction_note_2026-05-08_optc": {
+   "deps_hash": "2ef413449f13",
+   "out_degree": 6
+  },
+  "a3_option_c_brannen_rivero_physical_lattice_bounded_obstruction_note_2026-05-08_optc_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "a3_r1_review_confirms_obstruction_note_2026-05-08_r1hr": {
+   "deps_hash": "64edc3cfac18",
+   "out_degree": 12
+  },
+  "a3_r2_review_confirms_exhaustion_note_2026-05-08_r2hr": {
+   "deps_hash": "d01e534e046d",
+   "out_degree": 8
+  },
+  "a3_r3_review_confirms_obstruction_note_2026-05-08_r3hr": {
+   "deps_hash": "3b30828fd3cf",
+   "out_degree": 8
+  },
+  "a3_r4_review_confirmed_note_2026-05-08_r4hr": {
+   "deps_hash": "48fd2c1c7690",
+   "out_degree": 6
+  },
+  "a3_r5_review_confirms_obstruction_note_2026-05-08_r5hr": {
+   "deps_hash": "7d95802ef22a",
+   "out_degree": 6
+  },
+  "a3_r5_review_confirms_obstruction_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "a3_route1_higgs_yukawa_c3_breaking_bounded_obstruction_note_2026-05-08_r1": {
+   "deps_hash": "cdfafe801f40",
+   "out_degree": 12
+  },
+  "a3_route1_higgs_yukawa_c3_breaking_bounded_obstruction_note_2026-05-08_r1_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "a3_route2_single_clock_c3_obstruction_note_2026-05-08_r2": {
+   "deps_hash": "44184aa625eb",
+   "out_degree": 9
+  },
+  "a3_route2_single_clock_c3_obstruction_note_2026-05-08_r2_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "a3_route3_anomaly_inflow_bounded_obstruction_note_2026-05-08_r3": {
+   "deps_hash": "aa2d63d0f64d",
+   "out_degree": 19
+  },
+  "a3_route3_anomaly_inflow_bounded_obstruction_note_2026-05-08_r3_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "a3_route4_spin6_chain_bounded_obstruction_note_2026-05-08_r4": {
+   "deps_hash": "cf8020cd44eb",
+   "out_degree": 6
+  },
+  "a3_route4_spin6_chain_bounded_obstruction_note_2026-05-08_r4_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "a3_route5_no_proper_quotient_sharpened_obstruction_note_2026-05-08_r5": {
+   "deps_hash": "9e9db398a479",
+   "out_degree": 12
+  },
+  "abcc_cp_phase_no_go_theorem_note_2026-04-19": {
+   "deps_hash": "3092bdd1a007",
+   "out_degree": 1
+  },
+  "abj_anomaly_framework_internal_u1_jacobian_narrow_note_2026-05-27": {
+   "deps_hash": "304efa5adf35",
+   "out_degree": 6
+  },
+  "abj_epsilon_index_square_block_no_go_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "abj_p_comp_scale_free_singlet_completion_classification_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "abj_p_hy_retained_bounded_supplier_wiring_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "abj_p_rec_spintaste_clifford_core_bridge_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "abj_residual_gw_not_necessary_narrow_theorem_note_2026-05-28": {
+   "deps_hash": "ebd9444f69cc",
+   "out_degree": 1
+  },
+  "abj_scale_free_native_abelian_anomaly_core_boundary_note_2026-06-18": {
+   "deps_hash": "26efa80d91ea",
+   "out_degree": 1
+  },
+  "ac_orbit_occupancy_statistical_grain_derivation_obligation": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ac_phi_lambda_preserved_c3_structural_foreclosure_bounded_theorem_note_2026-05-10": {
+   "deps_hash": "5ca33b529bc1",
+   "out_degree": 24
+  },
+  "ac_reta_hclass_hunit_readout_derivation_obligation": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "accessible_prediction_note": {
+   "deps_hash": "ce7f8dd35214",
+   "out_degree": 1
+  },
+  "acphilambda_ambient_equivariant_heat_trace_face_2026-07-02": {
+   "deps_hash": "ba5b993129e0",
+   "out_degree": 1
+  },
+  "acphilambda_ambient_scalar_k_blindness_projective_carrier_2026-07-02": {
+   "deps_hash": "9bb7d633877f",
+   "out_degree": 1
+  },
+  "acphilambda_c3_resolvent_determinant_holonomy_coupling_narrow_theorem_note_2026-07-12": {
+   "deps_hash": "1e349ad43963",
+   "out_degree": 2
+  },
+  "acphilambda_cross_arc_unit_classification_wiring_2026-07-02": {
+   "deps_hash": "034bb527af97",
+   "out_degree": 10
+  },
+  "acphilambda_cycle_flux_transport_face_inventory_2026-07-01": {
+   "deps_hash": "4c035e9ce152",
+   "out_degree": 3
+  },
+  "acphilambda_defect_identity_unit_rescale_obstruction_2026-07-01": {
+   "deps_hash": "6d0655c84e1e",
+   "out_degree": 9
+  },
+  "acphilambda_fermionic_realification_pfaffian_power_identity_narrow_theorem_note_2026-07-12": {
+   "deps_hash": "f8631b9b0278",
+   "out_degree": 1
+  },
+  "acphilambda_fluxed_ring_spectral_functional_route_no_go_2026-07-02": {
+   "deps_hash": "b86ef9f6910c",
+   "out_degree": 2
+  },
+  "acphilambda_hw_complement_reading_registration_equivalence_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "ce9286fca23f",
+   "out_degree": 3
+  },
+  "acphilambda_hw_complementation_equivariance_support_note_2026-06-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "acphilambda_k1_staggered_k_blindness_real_lift_2026-07-02": {
+   "deps_hash": "9bb7d633877f",
+   "out_degree": 1
+  },
+  "acphilambda_k_even_registration_correction_registered_pattern_2026-07-02": {
+   "deps_hash": "bf50a4914920",
+   "out_degree": 2
+  },
+  "acphilambda_k_odd_carrier_registered_datum_test_bounded_note_2026-07-03": {
+   "deps_hash": "61d82376598a",
+   "out_degree": 3
+  },
+  "acphilambda_measure_binary_axiom_update_no_go_note_2026-07-04": {
+   "deps_hash": "11081606a6c5",
+   "out_degree": 5
+  },
+  "acphilambda_occupancy_determinant_power_split_exact_support_note_2026-07-04": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "acphilambda_occupancy_formation_append_non_supply_no_go_note_2026-07-04": {
+   "deps_hash": "ee1b80ea534c",
+   "out_degree": 2
+  },
+  "acphilambda_occupancy_grain_menu_counting_measure_dynamical_static_correspondence_bounded_theorem_note_2026-07-16": {
+   "deps_hash": "27ed0fa7c43b",
+   "out_degree": 8
+  },
+  "acphilambda_occupancy_grain_rule_class_universality_bounded_theorem_note_2026-07-11": {
+   "deps_hash": "6f4e574da539",
+   "out_degree": 4
+  },
+  "acphilambda_occupancy_grain_sharpening_import_decomposition_reflection_asymmetry_orientation_dichotomy_bounded_theorem_note_2026-07-16": {
+   "deps_hash": "5532ee003bde",
+   "out_degree": 3
+  },
+  "acphilambda_occupancy_selection_realized_state_reduction_note_2026-06-11": {
+   "deps_hash": "8f60efefa734",
+   "out_degree": 12
+  },
+  "acphilambda_occurrence_clock_composition_delta_blindness_2026-07-02": {
+   "deps_hash": "ad106f0c808b",
+   "out_degree": 3
+  },
+  "acphilambda_pointer_labeled_refinement_finer_record_clock_2026-07-02": {
+   "deps_hash": "d2278e5d2082",
+   "out_degree": 3
+  },
+  "acphilambda_projective_equivariance_k_odd_trace_2026-07-02": {
+   "deps_hash": "9bb7d633877f",
+   "out_degree": 1
+  },
+  "acphilambda_r_eta_angle_native_frontier_no_go_note_2026-07-04": {
+   "deps_hash": "a53ca3e08a28",
+   "out_degree": 5
+  },
+  "acphilambda_r_eta_direct_license_hclass_hunit_non_supply_no_go_note_2026-07-04": {
+   "deps_hash": "3b0e71cb1f3a",
+   "out_degree": 4
+  },
+  "acphilambda_r_eta_doublet_clock_rate_normalization_no_go_note_2026-07-04": {
+   "deps_hash": "b84f01aa251c",
+   "out_degree": 4
+  },
+  "acphilambda_r_eta_hclass_first_principles_stretch_no_go_note_2026-07-04": {
+   "deps_hash": "899368048161",
+   "out_degree": 3
+  },
+  "acphilambda_r_eta_hunit_approved_primitive_non_supply_no_go_note_2026-07-04": {
+   "deps_hash": "8972f926946e",
+   "out_degree": 5
+  },
+  "acphilambda_r_eta_occurrence_axiom_hygiene_no_go_note_2026-07-04": {
+   "deps_hash": "76da478711d6",
+   "out_degree": 6
+  },
+  "acphilambda_r_eta_readout_identification_narrowing_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "434a891f9cc5",
+   "out_degree": 7
+  },
+  "acphilambda_r_eta_record_formation_non_supply_no_go_note_2026-07-04": {
+   "deps_hash": "5775525765ad",
+   "out_degree": 5
+  },
+  "acphilambda_r_eta_value_face_registered_angle_functional_exactness_relocation_note_2026-07-05": {
+   "deps_hash": "daff697c867d",
+   "out_degree": 7
+  },
+  "acphilambda_r_eta_w2_registrability_context_bridge_note_2026-06-18": {
+   "deps_hash": "b9ea7924767c",
+   "out_degree": 5
+  },
+  "acphilambda_real_holonomy_locus_identity_2026-07-01": {
+   "deps_hash": "87aa773b5eca",
+   "out_degree": 3
+  },
+  "acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_note_2026-07-04": {
+   "deps_hash": "7b707271a9a8",
+   "out_degree": 2
+  },
+  "acphilambda_registrable_cycle_holonomy_normal_form_2026-07-01": {
+   "deps_hash": "1f3678b9f049",
+   "out_degree": 4
+  },
+  "acphilambda_retirement_basis_rematch_and_claim_surface_note_2026-07-06": {
+   "deps_hash": "fc99f259bdfe",
+   "out_degree": 2
+  },
+  "acphilambda_species_bridge_realized_state_decomposition_note_2026-06-11": {
+   "deps_hash": "7a3ac19d0800",
+   "out_degree": 8
+  },
+  "action_architecture_matrix_note": {
+   "deps_hash": "51f751162732",
+   "out_degree": 10
+  },
+  "action_crossover_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "action_family_character_semigroup_discriminator_bounded_note_2026-07-02": {
+   "deps_hash": "5290f76163e5",
+   "out_degree": 3
+  },
+  "action_form_no_go_equivalence_premise_continuum_removal_scoped_relocation_note_2026-06-08": {
+   "deps_hash": "4dd7835b1be8",
+   "out_degree": 2
+  },
+  "action_geometry_bridge_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "action_normalization_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "action_power_3d_gravity_sign_closure_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "action_power_3d_operator_cauchy_note_2026-05-10": {
+   "deps_hash": "7a757ce9ba33",
+   "out_degree": 5
+  },
+  "action_power_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "action_power_scaling_sweep_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "action_uniqueness_audit_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "action_uniqueness_note": {
+   "deps_hash": "8d80d0a97cfc",
+   "out_degree": 1
+  },
+  "active_sector_grounded_by_mass_vs_k_dominant_operator_sieve_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "b156bfeac8a2",
+   "out_degree": 6
+  },
+  "activity_energy_bound_witnesses_bounded_note_2026-07-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "adaptive_coevolving_geometry_no_go": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "adjacency_rank_qubit_clifford_bound_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "017358056d9e",
+   "out_degree": 9
+  },
+  "adm2_global_su3_symmetry_reduces_action_form_bi_invariance_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "17b0cde87f4c",
+   "out_degree": 3
+  },
+  "admissibility_rule_covariance_extension_classification_openness_achiral_oriented_frame_minimal_chiral_channel_bounded_theorem_note_2026-07-03": {
+   "deps_hash": "d69dd5ba8c7f",
+   "out_degree": 4
+  },
+  "admitted_input_registry_tier_a_note_2026-05-23": {
+   "deps_hash": "7f3a8c017199",
+   "out_degree": 3
+  },
+  "affine_imaginary_slot_invariance_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.abstract_algebraic_core_extraction_technique_2026-05-10": {
+   "deps_hash": "4bb4e52fe541",
+   "out_degree": 1
+  },
+  "ai_methodology.ai_accountability_and_disclosure_note_2026-04-25": {
+   "deps_hash": "8990b3713089",
+   "out_degree": 1
+  },
+  "ai_methodology.audit_system_fitness_note_2026-07-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.canonical_framing_paragraph_2026-04-25": {
+   "deps_hash": "8062508cb173",
+   "out_degree": 2
+  },
+  "ai_methodology.llm_skill_pack_2026-04-25": {
+   "deps_hash": "60f23c29f29e",
+   "out_degree": 11
+  },
+  "ai_methodology.methodology_case_studies_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.methodology_evidence_ledger_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.methodology_paper_draft_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.methodology_paper_source_packet_2026-04-25": {
+   "deps_hash": "ae0bc5ef8fa7",
+   "out_degree": 12
+  },
+  "ai_methodology.methodology_synthesis_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.methodology_synthesis_review_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.ai_accountability_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.canonical_framing_paragraph": {
+   "deps_hash": "390db7f5b8d7",
+   "out_degree": 2
+  },
+  "ai_methodology.raw.claude_git_evidence_full": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.claude_machine_dump": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.claude_project_commands": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.claude_prompt_capture": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.claude_repo_hygiene": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.claude_review_packets_full": {
+   "deps_hash": "853990b894c2",
+   "out_degree": 3
+  },
+  "ai_methodology.raw.claude_review_structure": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.claude_settings_and_state": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.claude_subagent_dispatches": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.claude_user_global_commands": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.claude_user_global_rules": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.codex_desktop_machine_dump_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.codex_desktop_prompt_capture_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.codex_desktop_review_hygiene_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.codex_machine_dump": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.codex_prompt_capture": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.codex_repo_hygiene": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.codex_review_structure": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.memory_files": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_049708ba_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_04c820e1": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_130f89f0_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_1e4222c2_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_1e897b5e_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_3024a28f_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_31d6e6cb_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_3df83a47_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_4a3ee29a_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_4cb8cd56_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_4fd1cda5_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_4ffea772_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_596e9a60_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_5e7ed16d_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_60940582_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_67759a49": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_6c2d4f26_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_71937db3_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_855ddec4": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_8c1087ee_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_9b33bd2d_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_9fc3990b_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_b068be5e_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_b5ee8c6c_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_b6905fe0_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_current": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_e0edc37f_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_e895b0c9_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_e9f79d2e_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_eb804083_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_ef33749a_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_f58c210e_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_f85e702e_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_fe95a681_jonreilly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.prompts_session_small": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.protocols": {
+   "deps_hash": "87287f31c965",
+   "out_degree": 3
+  },
+  "ai_methodology.raw.readme": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.repo_audit": {
+   "deps_hash": "b42ad336aab1",
+   "out_degree": 71
+  },
+  "ai_methodology.raw.science_scaffolding": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.raw.workflow_tooling": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.readme": {
+   "deps_hash": "3d8eefee3be6",
+   "out_degree": 24
+  },
+  "ai_methodology.repo_trajectory_and_governance_evidence_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.ai-physics-lane-builder.skill": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.audit-loop.references.nature-grade-rubric": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.audit-loop.skill": {
+   "deps_hash": "2a029dcd27b0",
+   "out_degree": 2
+  },
+  "ai_methodology.skills.exercise.skill": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.methodology-paper-synthesizer.skill": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.no-go-discipline.references.case-studies": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.no-go-discipline.skill": {
+   "deps_hash": "b5c07da13ffd",
+   "out_degree": 1
+  },
+  "ai_methodology.skills.physics-claim-reviewer.skill": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.physics-loop.references.abstract-algebraic-core-extraction": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.physics-loop.references.assumption-import-audit": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.physics-loop.references.literature-bridge-protocol": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.physics-loop.references.long-running-execution": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.physics-loop.references.route-patterns": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.physics-loop.skill": {
+   "deps_hash": "85a9c5467028",
+   "out_degree": 8
+  },
+  "ai_methodology.skills.primitive_registry_check": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.review-loop.skill": {
+   "deps_hash": "2a029dcd27b0",
+   "out_degree": 2
+  },
+  "ai_methodology.skills.reviewer-backpressure-integrator.skill": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.skill_freshness_check": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology.skills.workhorse.skill": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ai_methodology_note_2026-04-25": {
+   "deps_hash": "3eac15647514",
+   "out_degree": 18
+  },
+  "allorders_b4_marginal_protection_symmetry_theorem_note_2026-06-14": {
+   "deps_hash": "b5763395fdbe",
+   "out_degree": 5
+  },
+  "alpha_bare_four_pi_from_z3_plancherel_bridge_bounded_note_2026-05-26": {
+   "deps_hash": "f695c0b79508",
+   "out_degree": 5
+  },
+  "alpha_convention_i2_accepted_premise_bridge_bounded_note_2026-05-27": {
+   "deps_hash": "f5dccfad042e",
+   "out_degree": 2
+  },
+  "alpha_convention_i2_accepted_premise_bridge_dep_resolution_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "1340b37abf28",
+   "out_degree": 3
+  },
+  "alpha_lm_geometric_mean_identity_theorem_note_2026-04-24": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "alpha_s_4loop_running_derivation_partial_note_2026-05-10_4loop": {
+   "deps_hash": "ac6ca871b818",
+   "out_degree": 1
+  },
+  "alpha_s_cmt_coupling_map_derivation_theorem_note_2026-05-17": {
+   "deps_hash": "f0cc06e7f8a1",
+   "out_degree": 4
+  },
+  "alpha_s_derived_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "6b4ba344886a",
+   "out_degree": 1
+  },
+  "alpha_s_derived_note": {
+   "deps_hash": "697f79e92285",
+   "out_degree": 4
+  },
+  "alpha_s_direct_wilson_loop_derivation_theorem_note_2026-04-30": {
+   "deps_hash": "58243ea36809",
+   "out_degree": 2
+  },
+  "alpha_s_direct_wilson_loop_honest_status_audit_note_2026-05-02": {
+   "deps_hash": "fa224ca97885",
+   "out_degree": 4
+  },
+  "alpha_s_heavy_threshold_matching_kernel_theorem_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "alpha_s_sommer_static_potential_root_kernel_theorem_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "alpha_s_tadpole_improvement_vertex_power_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "alpha_s_universal_two_loop_beta_kernel_theorem_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "alt_connectivity_family_basin_note": {
+   "deps_hash": "2ec9b9e82018",
+   "out_degree": 1
+  },
+  "alt_connectivity_family_complex_failure_note": {
+   "deps_hash": "2ec9b9e82018",
+   "out_degree": 1
+  },
+  "alt_connectivity_family_failure_note": {
+   "deps_hash": "d6fd61ecf763",
+   "out_degree": 2
+  },
+  "alt_connectivity_family_fm_transfer_note": {
+   "deps_hash": "d6fd61ecf763",
+   "out_degree": 2
+  },
+  "alt_connectivity_family_operator_cauchy_note_2026-05-10": {
+   "deps_hash": "4bd8b3ec830f",
+   "out_degree": 2
+  },
+  "alt_connectivity_family_sign_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "alternative_coupled_field_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "anderson_phase_mu2_0001_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "angular_kernel_orbit_class_underdetermination_narrow_no_go_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "angular_kernel_underdetermination_no_go_note": {
+   "deps_hash": "27a110b085bb",
+   "out_degree": 2
+  },
+  "angular_kernel_underdetermination_no_go_note_2026-05-17": {
+   "deps_hash": "a2ed572eed55",
+   "out_degree": 1
+  },
+  "anomaly_cancellation_proof_walk_lattice_independence_bounded_note_2026-05-08": {
+   "deps_hash": "6952d5aee220",
+   "out_degree": 6
+  },
+  "anomaly_forces_time_abj_inconsistency_accepted_premise_bridge_bounded_note_2026-05-26": {
+   "deps_hash": "a8f3bf45eda3",
+   "out_degree": 9
+  },
+  "anomaly_forces_time_admission_iii_note_2026-05-17": {
+   "deps_hash": "ce2b53d8d443",
+   "out_degree": 5
+  },
+  "anomaly_forces_time_bridge_premise_manifest_recheck_note_2026-06-17": {
+   "deps_hash": "c552f83f1497",
+   "out_degree": 2
+  },
+  "anomaly_forces_time_fb_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "anomaly_forces_time_note_2026-05-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "anomaly_forces_time_theorem": {
+   "deps_hash": "18e31be85d44",
+   "out_degree": 7
+  },
+  "anomaly_forces_time_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "antigravity_sign_selector_boundary_note": {
+   "deps_hash": "0891dc6c0e92",
+   "out_degree": 11
+  },
+  "architecture_note_directional_measure": {
+   "deps_hash": "d48c8e4fa4ad",
+   "out_degree": 1
+  },
+  "architecture_options": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "architecture_portability_live_reaudit_bridge_note_2026-06-18": {
+   "deps_hash": "664912e8f909",
+   "out_degree": 1
+  },
+  "architecture_portability_sweep_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "area_law_algebraic_spectrum_entropy_no_go_note_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "area_law_coefficient_gap_note": {
+   "deps_hash": "57ff2a81341f",
+   "out_degree": 6
+  },
+  "area_law_majorana_car_fock_equivalence_narrow_theorem_note_2026-05-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "area_law_multipocket_selector_no_go_note_2026-04-25": {
+   "deps_hash": "c338f0b2dfc4",
+   "out_degree": 2
+  },
+  "area_law_native_car_semantics_tightening_note_2026-04-25": {
+   "deps_hash": "e71aacadb844",
+   "out_degree": 2
+  },
+  "area_law_primitive_car_edge_identification_theorem_note_2026-04-25": {
+   "deps_hash": "409b93da0fc1",
+   "out_degree": 3
+  },
+  "area_law_primitive_edge_entropy_selector_no_go_note_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "area_law_primitive_parity_gate_carrier_theorem_note_2026-04-25": {
+   "deps_hash": "f5e586f4386f",
+   "out_degree": 5
+  },
+  "area_law_quarter_broader_no_go_note_2026-04-25": {
+   "deps_hash": "e6440d25e4b9",
+   "out_degree": 4
+  },
+  "arrow_cpt_orientation_do_not_source_cp_odd_action_coefficients_no_go_note_2026-06-08": {
+   "deps_hash": "b48fb166d1ce",
+   "out_degree": 10
+  },
+  "arrow_from_record_formation_past_hypothesis_residual_note_2026-06-05": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "assumption_derivation_ledger": {
+   "deps_hash": "3ef4e198bcd6",
+   "out_degree": 1
+  },
+  "asymmetry_persistence_born_note": {
+   "deps_hash": "27d28fd2d50c",
+   "out_degree": 2
+  },
+  "asymmetry_persistence_collapse_note": {
+   "deps_hash": "40316b7d4a68",
+   "out_degree": 1
+  },
+  "asymmetry_persistence_joint_card_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "asymmetry_persistence_mass_scaling_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "asymmetry_persistence_mass_window_note": {
+   "deps_hash": "d5bd0b61911c",
+   "out_degree": 2
+  },
+  "asymmetry_persistence_pilot_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "atomic_hydrogen_helium_probe_note": {
+   "deps_hash": "dee1a64a57f6",
+   "out_degree": 1
+  },
+  "atomic_lane2_alpha0_running_bridge_boundary_note_2026-04-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "atomic_lane2_physical_unit_limit_boundary_note_2026-04-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "atomic_lane2_qed_running_dependency_firewall_note_2026-04-30": {
+   "deps_hash": "cec216cf349c",
+   "out_degree": 5
+  },
+  "atomic_rydberg_dependency_firewall_note_2026-04-27": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "audit_backlog_note_2026-05-02": {
+   "deps_hash": "84148783161e",
+   "out_degree": 1
+  },
+  "audit_dm_gv_runner_stale_path_cleanup_block_two_note_2026-05-01": {
+   "deps_hash": "5b45a95bc4f1",
+   "out_degree": 1
+  },
+  "audit_dm_runner_stale_path_cleanup_note_2026-05-01": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "audit_landscape_snapshot_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "audit_lhf_leverage_map_for_retained_promotion_note_2026-05-01": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "audit_packet_script_deps_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "audit_structural_issues_snapshot_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "audited_symmetry_synthesis_note": {
+   "deps_hash": "1913c36ef9a4",
+   "out_degree": 6
+  },
+  "axiom_change_proposal_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "axiom_first_bekenstein_bound_theorem_note_2026-05-01": {
+   "deps_hash": "26b03e5d16ee",
+   "out_degree": 8
+  },
+  "axiom_first_birkhoff_theorem_note_2026-05-01": {
+   "deps_hash": "e60c5040d216",
+   "out_degree": 3
+  },
+  "axiom_first_cl3_per_site_uniqueness_theorem_note_2026-04-29": {
+   "deps_hash": "381c41107f12",
+   "out_degree": 2
+  },
+  "axiom_first_cluster_decomposition_temporal_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "c81f78f2bff4",
+   "out_degree": 1
+  },
+  "axiom_first_cluster_decomposition_theorem_note_2026-04-29": {
+   "deps_hash": "5e9f6e12ac8e",
+   "out_degree": 4
+  },
+  "axiom_first_coleman_mermin_wagner_theorem_note_2026-04-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "axiom_first_cpt_theorem_stretch_note_2026-04-29": {
+   "deps_hash": "adda0ecc85dd",
+   "out_degree": 5
+  },
+  "axiom_first_fermionic_stefan_boltzmann_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "9058ea7bec59",
+   "out_degree": 4
+  },
+  "axiom_first_first_law_bh_mechanics_theorem_note_2026-05-01": {
+   "deps_hash": "e53ab6248bcd",
+   "out_degree": 5
+  },
+  "axiom_first_generalized_second_law_theorem_note_2026-05-01": {
+   "deps_hash": "5fe1e9843806",
+   "out_degree": 6
+  },
+  "axiom_first_hawking_temperature_theorem_note_2026-05-01": {
+   "deps_hash": "a0799e0dcd10",
+   "out_degree": 7
+  },
+  "axiom_first_kms_condition_theorem_note_2026-05-01": {
+   "deps_hash": "6ce9eb235dc4",
+   "out_degree": 5
+  },
+  "axiom_first_lattice_noether_abstract_bilinear_continuity_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "axiom_first_lattice_noether_onsite_internal_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "e7682019dd80",
+   "out_degree": 5
+  },
+  "axiom_first_lattice_noether_record_invariance_companion_note_2026-06-04": {
+   "deps_hash": "00b5fe5e35ef",
+   "out_degree": 2
+  },
+  "axiom_first_lattice_noether_theorem_note_2026-04-29": {
+   "deps_hash": "68ed10047cf5",
+   "out_degree": 8
+  },
+  "axiom_first_lattice_wz_fujikawa_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "fb512a01017b",
+   "out_degree": 3
+  },
+  "axiom_first_microcausality_lieb_robinson_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "axiom_first_microcausality_lieb_robinson_theorem_note_2026-05-01": {
+   "deps_hash": "f14c11150a52",
+   "out_degree": 9
+  },
+  "axiom_first_reeh_schlieder_theorem_note_2026-05-01": {
+   "deps_hash": "78aed0cd5e5a",
+   "out_degree": 3
+  },
+  "axiom_first_reflection_positivity_theorem_note_2026-04-29": {
+   "deps_hash": "1e8371577cbd",
+   "out_degree": 10
+  },
+  "axiom_first_reflection_positivity_theorem_note_2026-04-29_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "axiom_first_reflection_positivity_wilson_temporal_gauge_bridge_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "axiom_first_rp_two_step_transfer_matrix_positivity_note_2026-05-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "axiom_first_single_clock_codimension1_evolution_theorem_note_2026-05-03": {
+   "deps_hash": "7f362bf21242",
+   "out_degree": 15
+  },
+  "axiom_first_sm_anomaly_cancellation_complete_note_2026-05-17": {
+   "deps_hash": "6891ac5263d0",
+   "out_degree": 2
+  },
+  "axiom_first_sm_anomaly_cancellation_complete_theorem_note_2026-05-03": {
+   "deps_hash": "1a8ee7bb0af8",
+   "out_degree": 14
+  },
+  "axiom_first_spectrum_condition_blocked_time_normalization_bridge_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "2641ec54e4c7",
+   "out_degree": 1
+  },
+  "axiom_first_spectrum_condition_theorem_note_2026-04-29": {
+   "deps_hash": "5521bfba5a16",
+   "out_degree": 6
+  },
+  "axiom_first_spin_statistics_theorem_note_2026-04-29": {
+   "deps_hash": "628cfe124864",
+   "out_degree": 4
+  },
+  "axiom_first_stefan_boltzmann_note_2026-05-17": {
+   "deps_hash": "2795d6cd641a",
+   "out_degree": 3
+  },
+  "axiom_first_stefan_boltzmann_theorem_note_2026-05-01": {
+   "deps_hash": "0acfb92b91c4",
+   "out_degree": 11
+  },
+  "axiom_first_unruh_temperature_theorem_note_2026-05-01": {
+   "deps_hash": "31ff5c021184",
+   "out_degree": 5
+  },
+  "axiom_first_z_n_equivariant_spectral_asymmetry_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "4809a185c8ae",
+   "out_degree": 2
+  },
+  "axiom_reduction_note": {
+   "deps_hash": "257b97e9b452",
+   "out_degree": 5
+  },
+  "axiom_stack_minimality_cl4c_no_go_theorem_note_2026-04-29": {
+   "deps_hash": "43bbfd6e9fc5",
+   "out_degree": 5
+  },
+  "b_independence_mechanism_note": {
+   "deps_hash": "7283bd77dbc1",
+   "out_degree": 4
+  },
+  "background_independence_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "backreaction_note": {
+   "deps_hash": "26ad6f43a94b",
+   "out_degree": 1
+  },
+  "bae_block_total_frobenius_derivation_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "46ef3dfbed5b",
+   "out_degree": 5
+  },
+  "bae_f1_f3_canonical_selection_bounded_obstruction_note_2026-05-17": {
+   "deps_hash": "4efb5eb4a924",
+   "out_degree": 13
+  },
+  "bae_max_entropy_retained_bounded_obstruction_note_2026-05-10_baemaxent": {
+   "deps_hash": "69de345217cd",
+   "out_degree": 19
+  },
+  "bae_ncg_kodim_real_structure_partial_narrowing_note_2026-05-17": {
+   "deps_hash": "7fb03515c56b",
+   "out_degree": 8
+  },
+  "bae_u1b_canonical_phase_note_2026-05-17": {
+   "deps_hash": "ce6538636126",
+   "out_degree": 14
+  },
+  "bae_u1b_six_ray_dirac_measure_note_2026-05-17": {
+   "deps_hash": "0d278fe7903f",
+   "out_degree": 7
+  },
+  "baryon_charge_integrality_note_2026-05-02": {
+   "deps_hash": "5bb6cdbbaa36",
+   "out_degree": 2
+  },
+  "bbn_eta10_to_omega_b_h2_coefficient_admission_bridge_bounded_note_2026-05-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "bbs_rg_banach_contraction_external_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "bell_inequality_derived_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "bertrand_stable_orbit_upper_bound_support_note_2026-05-20": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "beta23_scheme_convention_demarcation_fixed_spacing_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "783816aed78c",
+   "out_degree": 4
+  },
+  "beta6_delta_analytic_class_frontier_note_2026-05-30": {
+   "deps_hash": "c44208f23670",
+   "out_degree": 12
+  },
+  "beta6_plaquette_certified_convergent_backbone_bounded_note_2026-06-04": {
+   "deps_hash": "f36beaee8199",
+   "out_degree": 3
+  },
+  "beta6_plaquette_closure_note_2026-05-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "beta6_plaquette_connected_beta6_coefficient_bounded_note_2026-05-30": {
+   "deps_hash": "949182954f2e",
+   "out_degree": 3
+  },
+  "beta6_plaquette_cube_sector_closed_form_generating_function_note_2026-05-31": {
+   "deps_hash": "9328af0985de",
+   "out_degree": 6
+  },
+  "beta6_plaquette_cumulant_moment_positivity_no_go_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "beta6_plaquette_d10_coefficient_and_radius_evidence_bounded_note_2026-06-04": {
+   "deps_hash": "f36beaee8199",
+   "out_degree": 3
+  },
+  "beta6_plaquette_d11_coefficient_and_continuation_spread_bounded_note_2026-06-04": {
+   "deps_hash": "5f4d13824625",
+   "out_degree": 2
+  },
+  "beta6_plaquette_d7_coefficient_and_tadpole_verdict_bounded_note_2026-05-30": {
+   "deps_hash": "f15c55cf649c",
+   "out_degree": 1
+  },
+  "beta6_plaquette_d8_coefficient_and_single_pair_verdict_bounded_note_2026-05-30": {
+   "deps_hash": "e8f27fe92ba9",
+   "out_degree": 6
+  },
+  "beta6_plaquette_d9_coefficient_bounded_note_2026-06-04": {
+   "deps_hash": "e79ec1459745",
+   "out_degree": 7
+  },
+  "beta6_plaquette_multicube_resummation_relocation_note_2026-05-31": {
+   "deps_hash": "42cbd3e7d451",
+   "out_degree": 2
+  },
+  "beta6_plaquette_tensor_network_finite_irrep_support_and_recoupling_wall_note_2026-06-04": {
+   "deps_hash": "178143910e2e",
+   "out_degree": 2
+  },
+  "beta6_plaquette_twocube_closed_form_bounded_note_2026-06-04": {
+   "deps_hash": "2bc6085442a2",
+   "out_degree": 3
+  },
+  "beta6_resummation_ansatz_test_harness_bounded_note_2026-05-30": {
+   "deps_hash": "98400269dd53",
+   "out_degree": 9
+  },
+  "beta6_resummation_radius_growth_rate_bounded_note_2026-05-30": {
+   "deps_hash": "42cbd3e7d451",
+   "out_degree": 2
+  },
+  "beta_eff_onset_provenance_and_jet_extension_bounded_note_2026-06-12": {
+   "deps_hash": "b606999aae71",
+   "out_degree": 8
+  },
+  "beta_eff_two_witness_refresh_assessment_note_2026-06-12": {
+   "deps_hash": "dde92ca0445e",
+   "out_degree": 2
+  },
+  "beta_gbare_rescaling_abstract_identity_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "beta_gbare_squared_rescaling_invariance_bounded_note_2026-05-08": {
+   "deps_hash": "305a81f30cfc",
+   "out_degree": 1
+  },
+  "beyond_lattice_qcd_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "bh_entropy_derived_note": {
+   "deps_hash": "e8dee67bcc22",
+   "out_degree": 1
+  },
+  "bh_entropy_rt_ratio_widom_no_go_note": {
+   "deps_hash": "8990b3713089",
+   "out_degree": 1
+  },
+  "bh_quarter_wald_newton_coefficient_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "bh_quarter_wald_noether_framework_carrier_theorem_note_2026-04-29": {
+   "deps_hash": "4d23bb968eea",
+   "out_degree": 6
+  },
+  "binary_octahedral_discrete_spinor_sign_narrow_theorem_note_2026-05-28": {
+   "deps_hash": "a2b1fdf02953",
+   "out_degree": 3
+  },
+  "binom_d_2_equals_twice_dminus1_forces_d_four_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "block_gaussian_schur_marginalization_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "block_spin_cp_compression_color_reemergence_narrow_no_go_note_2026-06-08": {
+   "deps_hash": "6b368532f779",
+   "out_degree": 4
+  },
+  "blocking_isometry_reduces_to_pointer_frame_admission_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "bminusl_anomaly_freedom_note_2026-05-17": {
+   "deps_hash": "ddf579aa951c",
+   "out_degree": 5
+  },
+  "bminusl_anomaly_freedom_theorem_note_2026-04-24": {
+   "deps_hash": "cc08981ca599",
+   "out_degree": 4
+  },
+  "bmv_bounded_negative_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "bmv_entanglement_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "bmv_threebody_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "boost_cone_apbc_sign_neutral_2026-06-23": {
+   "deps_hash": "5b93d4d58e88",
+   "out_degree": 7
+  },
+  "bootstrap_continuation_availability_nonempty_free_orbit_reduction_propagation_closure_bounded_theorem_note_2026-07-04": {
+   "deps_hash": "fc7df57903e1",
+   "out_degree": 5
+  },
+  "born_form_from_lawful_graded_constraint_composite_gleason_bridge_note_2026-07-04": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "born_lane_comparison_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "born_rule_analysis_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "born_rule_from_gleason_busch_derivation_note_2026-05-20": {
+   "deps_hash": "ee9571deda74",
+   "out_degree": 7
+  },
+  "born_scattering_comparison_note": {
+   "deps_hash": "9cf8e0d23288",
+   "out_degree": 2
+  },
+  "bougerol_lacroix_oseledets_met_external_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "bougerol_lacroix_staggered_blocking_gouezel_karlsson_deterministic_cocycle_narrow_no_go_note_2026-05-16": {
+   "deps_hash": "b060fe477e0d",
+   "out_degree": 8
+  },
+  "bougerol_lacroix_staggered_blocking_lyapunov_bridge_no_go_note_2026-05-10": {
+   "deps_hash": "af01e5739589",
+   "out_degree": 4
+  },
+  "bougerol_lacroix_staggered_blocking_submult_tautological_bound_bounded_theorem_note_2026-05-10": {
+   "deps_hash": "bc144734c5bd",
+   "out_degree": 5
+  },
+  "bound_state_selection_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "boundary_law_robustness_note_2026-04-11": {
+   "deps_hash": "5168a3e4ccde",
+   "out_degree": 1
+  },
+  "bounded_admission_registry_proposal_note_2026-06-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "branch_cleanup_recommendation_2026-05-03": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "branch_entanglement_robustness_note_2026-04-11": {
+   "deps_hash": "298e41db1f87",
+   "out_degree": 2
+  },
+  "branch_summary_distracted_napier": {
+   "deps_hash": "853990b894c2",
+   "out_degree": 3
+  },
+  "branching_record_budget_inequality_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "785cf97f5722",
+   "out_degree": 1
+  },
+  "branching_slack_rate_projective_limit_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "brannen_amplitude_equipartition_bae_rename_meta_note_2026-05-09": {
+   "deps_hash": "019829b6a753",
+   "out_degree": 1
+  },
+  "brannen_circulant_is_forced_c3_covariant_record_preserving_generation_form_bounded_theorem_note_2026-06-15": {
+   "deps_hash": "5fd8114a3be5",
+   "out_degree": 1
+  },
+  "brannen_delta_spectral_asymmetry_convention_isolation_note_2026-05-31": {
+   "deps_hash": "3956211a1680",
+   "out_degree": 7
+  },
+  "breakthrough_direction_memo_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "bridge_gap_action_form_uniqueness_no_go_note_2026-05-06": {
+   "deps_hash": "565bcb1b1148",
+   "out_degree": 6
+  },
+  "bridge_gap_hk_cube_perron_note_2026-05-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "bridge_gap_hk_plaquette_closed_form_note_2026-05-06": {
+   "deps_hash": "90614bbf5154",
+   "out_degree": 4
+  },
+  "bridge_gap_hk_thermodynamic_stretch_note_2026-05-06": {
+   "deps_hash": "77d57b5f904d",
+   "out_degree": 5
+  },
+  "bridge_gap_hk_time_derivation_note_2026-05-06": {
+   "deps_hash": "b121cd97f6dd",
+   "out_degree": 4
+  },
+  "bridge_lanes_promotion_proposal_note_2026-05-10_lanes": {
+   "deps_hash": "95f1ec0fd03a",
+   "out_degree": 16
+  },
+  "broad_gravity_derivation_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "broad_surrogate_point_source_compare_note": {
+   "deps_hash": "3a242b0f6335",
+   "out_degree": 4
+  },
+  "broken_graph_action_power_robustness_note": {
+   "deps_hash": "010d7d5bac2c",
+   "out_degree": 3
+  },
+  "busch_povm_effect_gleason_qubit_authority_bridge_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "busch_povm_extension_deps_changed_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "80a7e9448ee1",
+   "out_degree": 3
+  },
+  "busch_povm_extension_on_qubit_lattice_narrow_theorem_note_2026-05-20": {
+   "deps_hash": "cbe42f571241",
+   "out_degree": 3
+  },
+  "bw_bridge_reduction_os0_identification_consumes_only_ir_slope_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "282420a563e5",
+   "out_degree": 8
+  },
+  "bz_volume_two_pi_cubed_record_invariance_companion_note_2026-06-04": {
+   "deps_hash": "31566d78c3b1",
+   "out_degree": 2
+  },
+  "bz_volume_two_pi_cubed_substrate_internal_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "c1_frame_component_from_record_registrability_partial_bounded_note_2026-07-02": {
+   "deps_hash": "ed01a05a50a6",
+   "out_degree": 6
+  },
+  "c1b_degeneracy_locus_partition_totality_bounded_note_2026-07-02": {
+   "deps_hash": "99c9fd8da92e",
+   "out_degree": 4
+  },
+  "c2_w_supplier_reading_fork_fixed_point_unidentifiability_bounded_note_2026-07-02": {
+   "deps_hash": "e5e210df0a69",
+   "out_degree": 2
+  },
+  "c2_weighting_normal_form_one_parameter_uniqueness_bounded_note_2026-07-02": {
+   "deps_hash": "161b289f6620",
+   "out_degree": 3
+  },
+  "c3_generation_readout_context_canonical_definition_note_2026-07-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "c3_symmetry_preserved_interpretation_note_2026-05-08": {
+   "deps_hash": "f9883446b93b",
+   "out_degree": 10
+  },
+  "c3_symmetry_preserved_interpretation_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "c_iso_derived_theorem_note_2026-05-07_w3": {
+   "deps_hash": "3ca7fab8c81d",
+   "out_degree": 2
+  },
+  "c_iso_numerical_convergence_bounded_support_note_2026-05-10_numconv": {
+   "deps_hash": "93f72f4610eb",
+   "out_degree": 5
+  },
+  "c_iso_su3_nlo_closure_bounded_note_2026-05-08_su3nlo": {
+   "deps_hash": "22f51c0ccc67",
+   "out_degree": 4
+  },
+  "c_iso_su3_nnlo_closure_bounded_note_2026-05-10_su3nnlo": {
+   "deps_hash": "d6a5eeda144b",
+   "out_degree": 6
+  },
+  "campaign_consistency_survey_note_2026-05-10_meta": {
+   "deps_hash": "1cab1fb29895",
+   "out_degree": 11
+  },
+  "canonical_harness_index": {
+   "deps_hash": "be70ed3a0072",
+   "out_degree": 299
+  },
+  "canonical_plaquette_alpha_lm_value_certificate_bounded_note_2026-06-16": {
+   "deps_hash": "808c1ccb6109",
+   "out_degree": 1
+  },
+  "canonical_two_cell_context_c3_ew_instance_bounded_note_2026-07-02": {
+   "deps_hash": "9e2e5b8d5531",
+   "out_degree": 3
+  },
+  "capture_deficit_exact_tail_accounting_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "fc0f62cb0f8d",
+   "out_degree": 3
+  },
+  "car_from_positivity_neutrality_note_2026-06-02": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "carrier_attachment_consolidates_to_recurring_chirality_gate_sharpening_note_2026-06-06": {
+   "deps_hash": "7cc9ad8625af",
+   "out_degree": 7
+  },
+  "carrier_orbit_invariance_note_2026-05-03": {
+   "deps_hash": "b9c72baebefe",
+   "out_degree": 4
+  },
+  "causal_cone_speed_map_note": {
+   "deps_hash": "fb9b6d37aa43",
+   "out_degree": 3
+  },
+  "causal_distance_tail_note": {
+   "deps_hash": "9a378714409f",
+   "out_degree": 2
+  },
+  "causal_escape_window_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "causal_field_canonical_chain_note": {
+   "deps_hash": "0bd7b768d334",
+   "out_degree": 6
+  },
+  "causal_field_portability_note": {
+   "deps_hash": "992f9d3fdc5a",
+   "out_degree": 1
+  },
+  "causal_field_reconciliation_note": {
+   "deps_hash": "9a378714409f",
+   "out_degree": 2
+  },
+  "causal_impact_parameter_note": {
+   "deps_hash": "690d3eeef06c",
+   "out_degree": 3
+  },
+  "causal_moving_unification_note": {
+   "deps_hash": "15fe3c5ec448",
+   "out_degree": 5
+  },
+  "causal_propagating_field_live_packet_note_2026-06-05": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "causal_propagating_field_live_reaudit_bridge_note_2026-06-18": {
+   "deps_hash": "b9c3de515254",
+   "out_degree": 1
+  },
+  "causal_source_placement_robustness_note": {
+   "deps_hash": "690d3eeef06c",
+   "out_degree": 3
+  },
+  "centered_u1_fluctuation_law_record_mixture_structure_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "3d91acad8044",
+   "out_degree": 1
+  },
+  "central_band_born_dense_sweep_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "central_band_born_largen_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "central_band_collapse_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "central_band_collapse_strength_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "central_band_dense_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "central_band_dense_joint_highn_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "central_band_dense_joint_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "central_band_dense_largen_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "central_band_layernorm_note": {
+   "deps_hash": "3851a2a4baed",
+   "out_degree": 1
+  },
+  "central_band_mass_window_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "channel_surface_cn_grounding_peripheral_unitary_summand_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "4dc1f9a3b2cd",
+   "out_degree": 6
+  },
+  "charged_lepton_brannen_bae_delta_tier_a_bounded_theorem_note_2026-05-30": {
+   "deps_hash": "a50118a3664b",
+   "out_degree": 9
+  },
+  "charged_lepton_direct_ward_free_yukawa_no_go_note_2026-04-26": {
+   "deps_hash": "921c1234f25a",
+   "out_degree": 2
+  },
+  "charged_lepton_koide_cone_algebraic_equivalence_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "charged_lepton_koide_cone_algebraic_equivalence_note": {
+   "deps_hash": "a22ff87ed3f3",
+   "out_degree": 2
+  },
+  "charged_lepton_koide_note_2026-04-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "charged_lepton_koide_ratio_source_selector_firewall_note_2026-04-27": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "charged_lepton_koide_two_gate_tier_a_bounded_theorem_note_2026-06-02": {
+   "deps_hash": "e5c55ee9983b",
+   "out_degree": 17
+  },
+  "charged_lepton_koide_value_full_chain_of_custody_2026-06-02": {
+   "deps_hash": "8ed1e5e3dca0",
+   "out_degree": 21
+  },
+  "charged_lepton_lane6_theorem_plan_note_2026-04-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "charged_lepton_mass_hierarchy_review_note_2026-04-17": {
+   "deps_hash": "1ed834654945",
+   "out_degree": 5
+  },
+  "charged_lepton_mass_hierarchy_review_note_2026-04-17_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "charged_lepton_op_local_source_selected_line_selector_no_go_note_2026-04-27": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "charged_lepton_radiative_tau_selector_firewall_note_2026-04-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "charged_lepton_registered_mass_dft_coordinate_theorem_note_2026-07-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "charged_lepton_selected_line_generation_selector_no_go_note_2026-04-27": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "charged_lepton_two_higgs_canonical_reduction_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "charged_lepton_typeb_radian_readout_generation_selector_no_go_note_2026-04-27": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "charged_lepton_ue_identity_via_z3_trichotomy_note_2026-04-17": {
+   "deps_hash": "617a66f8c4e3",
+   "out_degree": 7
+  },
+  "charged_lepton_value_reduces_to_one_counting_bit_synthesis_note_2026-06-05": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "charged_lepton_y_tau_m3_premise_self_correction_note_2026-04-28": {
+   "deps_hash": "c5fd57daacfe",
+   "out_degree": 4
+  },
+  "charged_lepton_y_tau_mechanism_stuck_fanout_note_2026-04-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "charged_lepton_y_tau_ward_combined_no_go_note_2026-05-10": {
+   "deps_hash": "021db6d17889",
+   "out_degree": 6
+  },
+  "charged_lepton_y_tau_ward_identity_su2_anchor_note_2026-04-28": {
+   "deps_hash": "6e5f0cf0e48f",
+   "out_degree": 3
+  },
+  "charged_lepton_y_tau_ward_identity_u1_anchor_note_2026-04-28": {
+   "deps_hash": "962ebe35fcd0",
+   "out_degree": 2
+  },
+  "charged_lepton_y_tau_ward_structural_anchor_requirements_positive_theorem_note_2026-05-17": {
+   "deps_hash": "a7f22af043f4",
+   "out_degree": 7
+  },
+  "chern_character_k2_top_form_forces_d_four_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "chiral_3plus1d_boundary_phase_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "chiral_3plus1d_coupled_coin_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "chiral_3plus1d_mixing_period_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "chiral_3plus1d_recurrence_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "chiral_bottleneck_card_proposal": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "chiral_content_is_the_epsilon_d_chirality_import_distinct_from_orientation_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "7137586b416d",
+   "out_degree": 4
+  },
+  "chiral_layer_oscillation_2026-04-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "chiral_split_mass_gravity_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "chiral_walk_synthesis_2026-04-09": {
+   "deps_hash": "b9992638e206",
+   "out_degree": 2
+  },
+  "chiral_walk_synthesis_2026-04-10_addendum": {
+   "deps_hash": "9b4242982270",
+   "out_degree": 7
+  },
+  "chirality_gate_is_two_independent_gates_dirac_vs_generation_scoping_note_2026-06-08": {
+   "deps_hash": "92c36e250532",
+   "out_degree": 3
+  },
+  "chirality_record_typing_interface_2026-06-05": {
+   "deps_hash": "afb32706c492",
+   "out_degree": 6
+  },
+  "chirality_separate_factor_dirac_mass_algebra_support_bounded_note_2026-06-08": {
+   "deps_hash": "a4bb0c06fb4f",
+   "out_degree": 4
+  },
+  "chronology_protection_note_2026-05-17": {
+   "deps_hash": "2f99f9eaf92b",
+   "out_degree": 4
+  },
+  "chronology_protection_operational_no_past_signaling_theorem_note_2026-04-25": {
+   "deps_hash": "01c24be770d6",
+   "out_degree": 9
+  },
+  "chsh_structural_bound_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "chsh_tsirelson_lattice_qubits_bound_note_2026-05-20": {
+   "deps_hash": "09a1f481009d",
+   "out_degree": 5
+  },
+  "circulant_parity_cp_tensor_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "circulant_response_master_identity_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ckm_a_squared_below_w2_y_quantum_closure_theorem_note_2026-04-25": {
+   "deps_hash": "38ddd97e9f9b",
+   "out_degree": 7
+  },
+  "ckm_atlas_axiom_closure_note": {
+   "deps_hash": "10c5805ffd41",
+   "out_degree": 3
+  },
+  "ckm_atlas_closure_formula_algebra_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ckm_atlas_triangle_right_angle_theorem_note_2026-04-24": {
+   "deps_hash": "267c8a26443f",
+   "out_degree": 1
+  },
+  "ckm_barred_apex_angle_exact_closed_form_theorem_note_2026-04-25": {
+   "deps_hash": "feca469ebe64",
+   "out_degree": 6
+  },
+  "ckm_barred_circumradius_exact_closed_form_theorem_note_2026-04-25": {
+   "deps_hash": "feca469ebe64",
+   "out_degree": 6
+  },
+  "ckm_barred_napoleon_triangles_exact_closed_form_theorem_note_2026-04-25": {
+   "deps_hash": "0b17379b5736",
+   "out_degree": 5
+  },
+  "ckm_barred_orthocenter_euler_line_exact_closed_form_theorem_note_2026-04-25": {
+   "deps_hash": "feca469ebe64",
+   "out_degree": 6
+  },
+  "ckm_barred_pedoe_similarity_deficit_closed_form_theorem_note_2026-04-25": {
+   "deps_hash": "fe40b06ea16b",
+   "out_degree": 8
+  },
+  "ckm_barred_triangle_pythagorean_rho_lambda_sum_rule_theorem_note_2026-04-25": {
+   "deps_hash": "feca469ebe64",
+   "out_degree": 6
+  },
+  "ckm_barred_weitzenbock_brocard_polynomial_closed_form_theorem_note_2026-04-25": {
+   "deps_hash": "48aa1b11b02a",
+   "out_degree": 8
+  },
+  "ckm_bernoulli_two_ninths_koide_bridge_support_note_2026-04-25": {
+   "deps_hash": "8b24765776f0",
+   "out_degree": 3
+  },
+  "ckm_brocard_polynomial_vieta_structural_integers_theorem_note_2026-04-25": {
+   "deps_hash": "5a6115c8a071",
+   "out_degree": 3
+  },
+  "ckm_brocard_q_polynomial_perfect_square_decomposition_theorem_note_2026-04-25": {
+   "deps_hash": "5a6115c8a071",
+   "out_degree": 3
+  },
+  "ckm_bs_mixing_phase_derivation_theorem_note_2026-04-25": {
+   "deps_hash": "053abfe6d024",
+   "out_degree": 5
+  },
+  "ckm_classical_number_theory_integer_characterization_theorem_note_2026-04-25": {
+   "deps_hash": "afe74197e6f1",
+   "out_degree": 2
+  },
+  "ckm_composite_positive_volume_alignment_source_action_boundary_note_2026-07-12": {
+   "deps_hash": "ffd2e00429a4",
+   "out_degree": 4
+  },
+  "ckm_compound_magnitudes_circumradius_bridge_theorem_note_2026-04-25": {
+   "deps_hash": "87d28b109d06",
+   "out_degree": 5
+  },
+  "ckm_consecutive_primes_s3_koide_bridge_support_note_2026-04-25": {
+   "deps_hash": "add0d06febdd",
+   "out_degree": 5
+  },
+  "ckm_cp_phase_arctan_sqrt5_bridge_reduction_open_gate_note_2026-06-08": {
+   "deps_hash": "a6021617c9ee",
+   "out_degree": 5
+  },
+  "ckm_cp_phase_rho_eta_to_delta_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ckm_cp_phase_structural_identity_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ckm_cp_phase_structural_identity_theorem_note_2026-04-24": {
+   "deps_hash": "27e606e760ff",
+   "out_degree": 4
+  },
+  "ckm_cp_product_alpha_s_cross_sector_extraction_theorem_note_2026-04-25": {
+   "deps_hash": "b3819d103380",
+   "out_degree": 6
+  },
+  "ckm_cubic_bernoulli_koide_bridge_support_note_2026-04-25": {
+   "deps_hash": "d5c62dd42254",
+   "out_degree": 6
+  },
+  "ckm_down_type_scale_convention_audited_scope_narrow_bounded_note_2026-05-10": {
+   "deps_hash": "ba4d4f7cdf5c",
+   "out_degree": 5
+  },
+  "ckm_down_type_scale_convention_support_note_2026-04-22": {
+   "deps_hash": "423d9f11232c",
+   "out_degree": 2
+  },
+  "ckm_egyptian_bernoulli_closures_koide_bridge_support_note_2026-04-25": {
+   "deps_hash": "160539f94ccc",
+   "out_degree": 7
+  },
+  "ckm_ew_lattice_a4_bridge_retained_identity_note_2026-04-25": {
+   "deps_hash": "cf0fb00fd194",
+   "out_degree": 5
+  },
+  "ckm_first_row_magnitudes_theorem_note_2026-04-24": {
+   "deps_hash": "ba07f60777e4",
+   "out_degree": 4
+  },
+  "ckm_five_sixths_bridge_support_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ckm_five_sixths_exponent_discriminator_support_note_2026-07-02": {
+   "deps_hash": "deb699a7c3f7",
+   "out_degree": 2
+  },
+  "ckm_from_mass_hierarchy_note": {
+   "deps_hash": "f20755eacb51",
+   "out_degree": 5
+  },
+  "ckm_inverse_square_structural_sum_rule_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ckm_jarlskog_exact_nlo_closed_form_theorem_note_2026-04-25": {
+   "deps_hash": "29bebddfe45c",
+   "out_degree": 5
+  },
+  "ckm_kaon_epsilon_k_jarlskog_decomposition_theorem_note_2026-04-25": {
+   "deps_hash": "8eb1439ee95e",
+   "out_degree": 5
+  },
+  "ckm_koide_cross_sector_z3_closure_theorem_note_2026-04-25": {
+   "deps_hash": "f786b9d07ab9",
+   "out_degree": 5
+  },
+  "ckm_magnitudes_structural_counts_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ckm_magnitudes_structural_counts_theorem_note_2026-04-25": {
+   "deps_hash": "ba07f60777e4",
+   "out_degree": 4
+  },
+  "ckm_mass_basis_nni_structural_identities_narrow_theorem_note_2026-06-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ckm_mass_operator_projector_overlap_typing_theorem_note_2026-07-12": {
+   "deps_hash": "5f1c3b064ba8",
+   "out_degree": 1
+  },
+  "ckm_moduli_only_unitarity_jarlskog_area_certificate_theorem_note_2026-04-26": {
+   "deps_hash": "43209d8cc4b6",
+   "out_degree": 1
+  },
+  "ckm_multi_channel_alpha_s_extraction_consistency_theorem_note_2026-04-26": {
+   "deps_hash": "5970e7d83e46",
+   "out_degree": 4
+  },
+  "ckm_multi_projection_bernoulli_family_theorem_note_2026-04-25": {
+   "deps_hash": "5970e7d83e46",
+   "out_degree": 4
+  },
+  "ckm_n9_structural_family_koide_bridge_support_note_2026-04-25": {
+   "deps_hash": "9c6ffbbc9571",
+   "out_degree": 4
+  },
+  "ckm_neutron_edm_bound_note": {
+   "deps_hash": "9fd9d3890b24",
+   "out_degree": 2
+  },
+  "ckm_nlo_barred_triangle_protected_gamma_theorem_note_2026-04-25": {
+   "deps_hash": "ba07f60777e4",
+   "out_degree": 4
+  },
+  "ckm_schur_complement_theorem": {
+   "deps_hash": "c555c9663fb6",
+   "out_degree": 4
+  },
+  "ckm_second_row_magnitudes_theorem_note_2026-04-25": {
+   "deps_hash": "031608bc1047",
+   "out_degree": 7
+  },
+  "ckm_sin_2_beta_bar_nlo_n_quark_ratio_theorem_note_2026-04-25": {
+   "deps_hash": "feca469ebe64",
+   "out_degree": 6
+  },
+  "ckm_small_vs_pmns_large_from_record_readout_context_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "792f3fcf5193",
+   "out_degree": 4
+  },
+  "ckm_thales_cross_system_cp_ratio_theorem_note_2026-04-25": {
+   "deps_hash": "cc9a0d8a96a8",
+   "out_degree": 5
+  },
+  "ckm_thales_pinned_alpha_s_independent_ratios_theorem_note_2026-04-25": {
+   "deps_hash": "e40391ec9c95",
+   "out_degree": 7
+  },
+  "ckm_third_row_magnitudes_theorem_note_2026-04-24": {
+   "deps_hash": "ba07f60777e4",
+   "out_degree": 4
+  },
+  "ckm_wolfenstein_eta_inverse_square_gap_theorem_note_2026-04-26": {
+   "deps_hash": "2e6dc233e14a",
+   "out_degree": 6
+  },
+  "cl31_m4r_dimension_sixteen_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cl3_baryon_qqq_color_singlet_theorem_note_2026-05-02": {
+   "deps_hash": "a24ac7a3a902",
+   "out_degree": 2
+  },
+  "cl3_central_pseudoscalar_schur_separator_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "4514c6f97532",
+   "out_degree": 1
+  },
+  "cl3_chiral_body_diagonal_axis_forced_doublet_h_not_sourced_narrow_no_go_note_2026-06-04": {
+   "deps_hash": "b85d54cea16c",
+   "out_degree": 5
+  },
+  "cl3_chiral_cube_wilson_hop_doubling_foreclosed_narrow_no_go_note_2026-05-27": {
+   "deps_hash": "5e93d700a831",
+   "out_degree": 1
+  },
+  "cl3_color_automorphism_theorem": {
+   "deps_hash": "dbc735773830",
+   "out_degree": 2
+  },
+  "cl3_complexification_split_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cl3_faithful_irrep_dim_two_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "4514c6f97532",
+   "out_degree": 1
+  },
+  "cl3_frame_free_ambient_chiral_grading_no_go_note_2026-06-02": {
+   "deps_hash": "e4bcd5a0d5ed",
+   "out_degree": 6
+  },
+  "cl3_gamma_involution_determinant_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "4514c6f97532",
+   "out_degree": 1
+  },
+  "cl3_hypercharge_eigenvalue_spectrum_on_chiral_cube_narrow_theorem_note_2026-05-27": {
+   "deps_hash": "303b79a983cf",
+   "out_degree": 2
+  },
+  "cl3_normalization_i3_accepted_premise_bridge_bounded_note_2026-05-27": {
+   "deps_hash": "edace2db59a4",
+   "out_degree": 4
+  },
+  "cl3_oh_cubic_lift_faithful_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "785681ca030c",
+   "out_degree": 2
+  },
+  "cl3_pauli_irrep_uniqueness_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cl3_per_site_hilbert_dim_two_theorem_note_2026-05-02": {
+   "deps_hash": "225c65695ac9",
+   "out_degree": 1
+  },
+  "cl3_quark_antiquark_color_singlet_theorem_note_2026-05-02": {
+   "deps_hash": "5e93d700a831",
+   "out_degree": 1
+  },
+  "cl3_sm_embedding_master_note": {
+   "deps_hash": "f01cc784085d",
+   "out_degree": 4
+  },
+  "cl3_sm_embedding_theorem": {
+   "deps_hash": "9d8b70df7789",
+   "out_degree": 3
+  },
+  "cl3_su3_symmetric_base_commutant_gell_mann_embedding_narrow_theorem_note_2026-05-27": {
+   "deps_hash": "303b79a983cf",
+   "out_degree": 2
+  },
+  "cl3_taste_generation_theorem": {
+   "deps_hash": "21255f9e5ecb",
+   "out_degree": 2
+  },
+  "cl3_to_cl31_spinor_extension_narrow_theorem_note_2026-05-27": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "claude_branch_retainability_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "claude_complex_action_carryover_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "claude_complex_action_grown_companion_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "claude_complex_action_grown_companion_note_2026-05-10": {
+   "deps_hash": "7bfe3c0f70cf",
+   "out_degree": 6
+  },
+  "clifford_bimodule_ray_saturation_future_target_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "clifford_chirality_dimension_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "clifford_gamma_not_lattice_species_corner_decoupling_bounded_note_2026-06-08": {
+   "deps_hash": "dc8de00e5e3d",
+   "out_degree": 4
+  },
+  "clifford_volume_chirality_even_dimension_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "closure_c_bb_canonical_mass_coupling_note_2026-05-10_cbb": {
+   "deps_hash": "2d20f59c98da",
+   "out_degree": 2
+  },
+  "closure_c_bb_f2_1_correction_note_2026-05-10_cbb_correction": {
+   "deps_hash": "dc1b90a62406",
+   "out_degree": 6
+  },
+  "closure_c_l1_hk_msbar_3l_conversion_note_2026-05-10_cl1a": {
+   "deps_hash": "22174708aa26",
+   "out_degree": 6
+  },
+  "closure_c_l1_per_graph_casimir_note_2026-05-10_cl1c": {
+   "deps_hash": "8c968adbbd64",
+   "out_degree": 8
+  },
+  "closure_c_staggered_dirac_gate_note_2026-05-10_cstaggered": {
+   "deps_hash": "121e4fed201b",
+   "out_degree": 9
+  },
+  "closure_t1_hf_96_connes_construction_note_2026-05-10_t1hf96": {
+   "deps_hash": "63142729c978",
+   "out_degree": 8
+  },
+  "closure_t1_z10_z20_bz_integrals_note_2026-05-10_t1z10z20": {
+   "deps_hash": "81ba0e4aa8a5",
+   "out_degree": 5
+  },
+  "closure_t2_df_physical_consequences_note_2026-05-10_t2df": {
+   "deps_hash": "49efbf80b208",
+   "out_degree": 5
+  },
+  "closure_t2_gnewton_reaudit_note_2026-05-10_t2gnewton": {
+   "deps_hash": "947bdba999cd",
+   "out_degree": 14
+  },
+  "closure_t2_m1_m2_distinguisher_note_2026-05-10_t2m1m2": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cluster_decomposition_delta_t_finite_lambda_operator_real_note_2026-05-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cluster_decomposition_delta_x_finite_lambda_axis_permutation_narrow_note_2026-06-02": {
+   "deps_hash": "61aa17ce4452",
+   "out_degree": 1
+  },
+  "cluster_decomposition_lr_poisson_tail_repair_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "4656fbed3c8e",
+   "out_degree": 1
+  },
+  "cluster_decomposition_mass_gap_bridge_theorem_note_2026-05-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cluster_decomposition_parent_eq8_repair_narrow_note_2026-06-02": {
+   "deps_hash": "cad0367dcfc9",
+   "out_degree": 4
+  },
+  "cluster_decomposition_spatial_slab_bridge_theorem_note_2026-05-17": {
+   "deps_hash": "782c170e4c65",
+   "out_degree": 2
+  },
+  "cmw_2d_sublattice_no_ssb_theorem_note_2026-05-02": {
+   "deps_hash": "00c51afbafec",
+   "out_degree": 3
+  },
+  "cmw_ward_normalized_bogoliubov_bridge_theorem_note_2026-06-04": {
+   "deps_hash": "0194da942953",
+   "out_degree": 2
+  },
+  "coarse_grained_exterior_law_helper_note_2026-04-14": {
+   "deps_hash": "0ed79feda7a5",
+   "out_degree": 2
+  },
+  "collapse_merger_toy_engine_validation_note_2026-07-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "color_arena_bonded_pair_admissibility_cross_site_surface_bounded_theorem_note_2026-07-06": {
+   "deps_hash": "57580a0f4742",
+   "out_degree": 4
+  },
+  "color_comp_hurwitz_clause_scope_reduction_narrow_theorem_note_2026-07-06": {
+   "deps_hash": "eb235fbb95ac",
+   "out_degree": 2
+  },
+  "color_composition_rule_matter_bilinear_polar_transport_conditional_bounded_theorem_note_2026-07-06": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "color_depolarization_adm2_gating_admissions_collapse_to_two_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "93d9f1287e5c",
+   "out_degree": 1
+  },
+  "color_depolarization_single_frame_dephasing_insufficiency_and_multiframe_exhibit_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "1ef093817d28",
+   "out_degree": 6
+  },
+  "color_derivation_campaign_20260706_assembly_and_honest_rebounding_meta_note_2026-07-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "color_einselection_matter_unitary_primitivity_requires_background_connection_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "0225b08e640d",
+   "out_degree": 5
+  },
+  "color_einselection_pointer_frame_fork_is_a_unistochastic_irreducibility_criterion_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "3e70bccc381e",
+   "out_degree": 7
+  },
+  "color_generation_independent_z3_structures_2026-06-05": {
+   "deps_hash": "303b79a983cf",
+   "out_degree": 2
+  },
+  "color_link_index_routing_carrier_budget_2026-06-05": {
+   "deps_hash": "9da6561cca52",
+   "out_degree": 5
+  },
+  "color_link_index_routing_via_cross_site_matter_bilinear_unitarization_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "89c27536d54a",
+   "out_degree": 5
+  },
+  "color_link_sym2_endpoint_projection_2026-06-05": {
+   "deps_hash": "fa3814c2c545",
+   "out_degree": 3
+  },
+  "color_mr_carrier_routing_split_2026-06-05": {
+   "deps_hash": "f4907c07e216",
+   "out_degree": 7
+  },
+  "color_neutrality_entanglement_depolarization_is_global_invariant_not_connection_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "b8336e270745",
+   "out_degree": 5
+  },
+  "color_orientation_of_the_state_is_predictively_vacuous_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "89059d360385",
+   "out_degree": 3
+  },
+  "color_orientation_three_vs_threebar_succession_candidate_conditional_bounded_theorem_note_2026-07-06": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "color_purity_does_not_reduce_to_past_hypothesis_slot_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "7c453d48f289",
+   "out_degree": 6
+  },
+  "color_singlet_records_g2_factorization_site_local_locking_bounded_theorem_note_2026-07-06": {
+   "deps_hash": "8dd5888e935e",
+   "out_degree": 3
+  },
+  "color_su3_matter_realization_residual_map_2026-06-05": {
+   "deps_hash": "9ee18b4fce9b",
+   "out_degree": 8
+  },
+  "color_su3_restricted_transport_profile_2026-06-05": {
+   "deps_hash": "a2d0139aa5ac",
+   "out_degree": 4
+  },
+  "color_su3_symmetric_base_bridge_from_record_invariance_bounded_note_2026-06-05": {
+   "deps_hash": "fc8e9dfcfc6b",
+   "out_degree": 9
+  },
+  "commensuration_general_lemma_period_parity_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "595f44d7fd2d",
+   "out_degree": 1
+  },
+  "commensuration_unconditional_period_parity_lemma_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "complete_prediction_chain_2026_04_15": {
+   "deps_hash": "ed7953444551",
+   "out_degree": 14
+  },
+  "complex_action_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "complex_selectivity_compare_note": {
+   "deps_hash": "716b08e6ec76",
+   "out_degree": 9
+  },
+  "complex_selectivity_predictor_note": {
+   "deps_hash": "3de32ed25afa",
+   "out_degree": 9
+  },
+  "composite_curvature_sum_rule_band_controls_bounded_theorem_note_2026-07-08": {
+   "deps_hash": "df228b3bd251",
+   "out_degree": 1
+  },
+  "composite_higgs_mechanism_note_2026-05-03": {
+   "deps_hash": "857989322284",
+   "out_degree": 8
+  },
+  "composite_higgs_mechanism_note_2026-05-17": {
+   "deps_hash": "4fbc4ff44eb4",
+   "out_degree": 1
+  },
+  "composite_mass_additivity_binding_defect_two_step_surface_bounded_note_2026-07-08": {
+   "deps_hash": "cc15ea2aa286",
+   "out_degree": 2
+  },
+  "composite_source_additivity_2d_note": {
+   "deps_hash": "bcfd06e4ab26",
+   "out_degree": 1
+  },
+  "composite_source_additivity_note": {
+   "deps_hash": "0e6aceef1b73",
+   "out_degree": 1
+  },
+  "condition_alphabet_identification_coupled_cubic_action_threshold_met_no_odd_channel_below_triples_bounded_theorem_note_2026-07-04": {
+   "deps_hash": "ea33bdb0f987",
+   "out_degree": 5
+  },
+  "conditional_law_depth_axis_depth_stable_event_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "0bfacef594e2",
+   "out_degree": 2
+  },
+  "conditional_law_prefix_ladder_no_finite_k_exhaustion_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "confinement_string_tension_note": {
+   "deps_hash": "245d8d2e9ca0",
+   "out_degree": 2
+  },
+  "connectivity_family_v2_elliptical_duplicate_note": {
+   "deps_hash": "a4d0e67bcea8",
+   "out_degree": 1
+  },
+  "connes_kreimer_birkhoff_factorization_external_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "connes_kreimer_boolean_lattice_idempotent_rb_substrate_narrow_no_go_note_2026-05-16": {
+   "deps_hash": "687a8747d7e9",
+   "out_degree": 7
+  },
+  "connes_kreimer_bridge_16fold_blocking_no_go_theorem_note_2026-05-10": {
+   "deps_hash": "4996c15ce754",
+   "out_degree": 3
+  },
+  "connes_kreimer_partial_sum_rb_b4_external_bounded_note_2026-05-10": {
+   "deps_hash": "04bb29d907bf",
+   "out_degree": 1
+  },
+  "continuum_bridge_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "continuum_convergence_note": {
+   "deps_hash": "fcfcb9b60c9f",
+   "out_degree": 2
+  },
+  "continuum_equivariant_eta_standard_form_delta_firewall_bounded_note_2026-06-12": {
+   "deps_hash": "9eb19f8d9f66",
+   "out_degree": 3
+  },
+  "continuum_identification_note": {
+   "deps_hash": "96b067bcdf3d",
+   "out_degree": 20
+  },
+  "continuum_limit_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "conventions_unification_companion_note_2026-05-08": {
+   "deps_hash": "9b75d87686a6",
+   "out_degree": 6
+  },
+  "corner_axis_free_transfer_extension_per_channel_trace_correspondence_and_mode_set_fork_bounded_note_2026-06-12": {
+   "deps_hash": "46111474d8b7",
+   "out_degree": 3
+  },
+  "corner_fermion_determinant_does_not_select_koide_r_half_narrow_obstruction_note_2026-06-04": {
+   "deps_hash": "48ebef824880",
+   "out_degree": 6
+  },
+  "corner_mode_set_fork_resolution_layer_is_record_dynamics_bounded_note_2026-06-12": {
+   "deps_hash": "3140ecc7e5e3",
+   "out_degree": 2
+  },
+  "corner_transfer_extends_to_fixed_gauge_backgrounds_bounded_note_2026-06-12": {
+   "deps_hash": "311d6b921eb1",
+   "out_degree": 3
+  },
+  "correlator_cycle_phases_readback_blind_or_state_contingent_bounded_note_2026-06-12": {
+   "deps_hash": "7b707271a9a8",
+   "out_degree": 2
+  },
+  "cosmological_constant_result_2026-04-12": {
+   "deps_hash": "bdad8aef31d8",
+   "out_degree": 4
+  },
+  "cosmological_constant_result_2026-04-12_note_2026-05-17": {
+   "deps_hash": "505f27497989",
+   "out_degree": 2
+  },
+  "cosmological_constant_retention_with_r_budget_theorem_note_2026-04-29": {
+   "deps_hash": "2e0ed9a57fcf",
+   "out_degree": 4
+  },
+  "cosmological_constant_spectral_gap_identity_theorem_note": {
+   "deps_hash": "d02d14b3f7eb",
+   "out_degree": 6
+  },
+  "cosmological_constant_vacuum_energy_audit_note": {
+   "deps_hash": "d1eb36ba5304",
+   "out_degree": 1
+  },
+  "cosmology_from_mass_spectrum_note": {
+   "deps_hash": "1b1d1c263835",
+   "out_degree": 5
+  },
+  "cosmology_from_mass_spectrum_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cosmology_frw_kinematic_reduction_theorem_note_2026-04-24": {
+   "deps_hash": "d49a61a66794",
+   "out_degree": 2
+  },
+  "cosmology_open_number_reduction_theorem_note_2026-04-26": {
+   "deps_hash": "724e8a0a258e",
+   "out_degree": 10
+  },
+  "cosmology_scale_identification_and_reduction_note": {
+   "deps_hash": "219a67808201",
+   "out_degree": 2
+  },
+  "cosmology_single_ratio_inverse_reconstruction_theorem_note_2026-04-25": {
+   "deps_hash": "14400756f044",
+   "out_degree": 4
+  },
+  "coulomb_stability_upper_bound_support_note_2026-05-20": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "coupled_field_generated_family_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cpt_c3_cp_squared_scalar_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "381c41107f12",
+   "out_degree": 2
+  },
+  "cpt_d_level_finite_lattice_algebraic_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cpt_exact_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cpt_exact_real_anti_hermitian_d_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cpt_particle_antiparticle_lifetime_equality_theorem_note_2026-05-02": {
+   "deps_hash": "ebd9444f69cc",
+   "out_degree": 1
+  },
+  "cpt_particle_antiparticle_mass_equality_theorem_note_2026-05-02": {
+   "deps_hash": "ebd9444f69cc",
+   "out_degree": 1
+  },
+  "cpt_squared_is_identity_theorem_note_2026-05-02": {
+   "deps_hash": "ebd9444f69cc",
+   "out_degree": 1
+  },
+  "critical_exponents_topology_live_scout_note_2026-06-04": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "critical_exponents_topology_note_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cross_family_universality_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cross_lane_dependency_map_note_2026-04-30": {
+   "deps_hash": "0df8ab8a8b08",
+   "out_degree": 13
+  },
+  "cross_sector_a_squared_koide_vcb_bridge_promoted_via_v8_theorem_note_2026-04-29": {
+   "deps_hash": "5af42829df82",
+   "out_degree": 5
+  },
+  "cross_sector_a_squared_koide_vcb_bridge_support_note_2026-04-25": {
+   "deps_hash": "ead68255754c",
+   "out_degree": 6
+  },
+  "cross_sector_a_squared_koide_vcb_bridge_support_note_2026-04-25_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cte_rconn_spatial_tensor_color_bridge_is_a_cross_domain_coincidence_narrow_no_go_note_2026-06-08": {
+   "deps_hash": "825a4024d61b",
+   "out_degree": 4
+  },
+  "cubic_anisotropy_sections_so3_frame_bounded_theorem_note_2026-06-17": {
+   "deps_hash": "04fc7d8812c4",
+   "out_degree": 3
+  },
+  "cubic_coxeter_edge_lengths_from_matter_correlation_decay_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "cb078be0ad0c",
+   "out_degree": 9
+  },
+  "cubic_coxeter_regge_3plus1_tick_extension_second_variation_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "e5771789d605",
+   "out_degree": 6
+  },
+  "cubic_coxeter_regge_deficit_vanishing_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cubic_coxeter_regge_linearized_action_selection_eh_class_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "cf558302b59d",
+   "out_degree": 4
+  },
+  "cubic_coxeter_regge_ok4_lattice_fingerprint_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "d607319c0e04",
+   "out_degree": 4
+  },
+  "cubic_coxeter_regge_second_variation_equals_linearized_eh_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "11bd292c9d93",
+   "out_degree": 1
+  },
+  "cubic_matching_product_qubit_qca_schedule_orbit_bounded_theorem_note_2026-07-11": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "cubic_orbit_reynolds_projector_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cycle_battery_note_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cycle_battery_scaled_note_2026-04-10": {
+   "deps_hash": "a97e8831a9cb",
+   "out_degree": 1
+  },
+  "cycle_break_frontier_note_2026-04-10": {
+   "deps_hash": "9ae0cba3aa1d",
+   "out_degree": 2
+  },
+  "cycle_break_slice_note_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cyclic_dft_uniform_magnitude_bounded_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "cyclic_projector_compression_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "d2_checkerboard_decimation_step1_closed_form_step2_range_growth_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "d2_orbital_susceptibility_sign_regions_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "d2_sign_boundary_bisection_between_landmarks_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "c27a1fb772f9",
+   "out_degree": 1
+  },
+  "d2_sign_boundary_mass_collapse_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "91cea8fda891",
+   "out_degree": 2
+  },
+  "d2_sign_boundary_tracks_landau_peierls_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "d2_soft_band_truncation_also_closes_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "5a570c4b4b32",
+   "out_degree": 3
+  },
+  "d2_truncated_flow_frozen_ratio_accumulated_budget_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "d2_truncation_error_budget_first_datum_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "d31_magnitude_exponent_translation_probe_2026-06-05": {
+   "deps_hash": "b9f48e3c2767",
+   "out_degree": 11
+  },
+  "d3_checkerboard_step1_closed_form_parity_lemma_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "d3_landau_peierls_single_band_normalization_bounded_theorem_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "d3_lower_bound_source_packet_gate_note_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "d3_native_stable_orbit_upper_bound_composition_note_2026-06-09": {
+   "deps_hash": "70fe0d9f2b94",
+   "out_degree": 5
+  },
+  "d3_orbital_response_decomposition_bounded_theorem_note_2026-06-13": {
+   "deps_hash": "34b16ede6e35",
+   "out_degree": 2
+  },
+  "d3_pinch_native_upper_leg_dimension_selection_composition_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "f933a529b258",
+   "out_degree": 5
+  },
+  "d3_retention_closure_plan_2026-05-20": {
+   "deps_hash": "a9ed7fcb0973",
+   "out_degree": 6
+  },
+  "d3_staggered_two_band_orbital_bounded_theorem_note_2026-06-13": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "d3_step2_range_growth_period_class_dichotomy_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "d3_truncated_closure_recurs_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "d3_truncation_commensuration_criterion_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "cbc2d762bec8",
+   "out_degree": 2
+  },
+  "d3_upper_bound_import_scope_gate_note_2026-06-06": {
+   "deps_hash": "186a0aed05ca",
+   "out_degree": 3
+  },
+  "dark_energy_eos_note": {
+   "deps_hash": "e1c100e93553",
+   "out_degree": 2
+  },
+  "dark_energy_eos_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dark_energy_eos_retained_corollary_theorem_note": {
+   "deps_hash": "44969a98096e",
+   "out_degree": 10
+  },
+  "darwinism_bridge_residual_local_observability_open_gate_note_2026-06-05": {
+   "deps_hash": "9fb5085e81da",
+   "out_degree": 4
+  },
+  "de_sitter_curvature_gap_not_fierz_pauli_mass_diagnostic_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "0b315d22e768",
+   "out_degree": 2
+  },
+  "declared_rg_map_uniform_chain_band_edge_fixed_point_nu_half_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "2d2872b7e917",
+   "out_degree": 1
+  },
+  "decoherence_action_independence_note": {
+   "deps_hash": "e17bb1db4dbc",
+   "out_degree": 1
+  },
+  "decoherence_action_zero_field_per_link_phase_equality_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "decoherence_decision_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "decoherence_failure_analysis": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "delta_magnitude_reduces_to_massless_gravity_scale_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "a38ede67de87",
+   "out_degree": 4
+  },
+  "delta_sign_fixed_negative_by_retained_two_body_mediator_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "b4a33976ecaa",
+   "out_degree": 4
+  },
+  "dense_prune_guard_seed_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "depth_branch_corrected_closed_form_bounded_theorem_note_2026-06-13": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "depth_laurent_root_closed_form_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "det_holonomy_trivial_on_hermitian_positive_circulant_edge_content_bounded_note_2026-06-12": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "det_phase_few_frequency_law_refuted_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "det_phase_harmonic_depth_state_dependent_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "c9025ba861e7",
+   "out_degree": 1
+  },
+  "diamond_absolute_unit_bridge_note": {
+   "deps_hash": "fe0d505751fc",
+   "out_degree": 7
+  },
+  "diamond_ideal_lockin_detector_theorem_note_2026-06-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "diamond_nv_phase_ramp_signal_budget_note": {
+   "deps_hash": "865dd8e7aaba",
+   "out_degree": 8
+  },
+  "diamond_phase_ramp_bridge_card_note": {
+   "deps_hash": "9c83332acb66",
+   "out_degree": 7
+  },
+  "diamond_sensor_prediction_note": {
+   "deps_hash": "346a6f146f60",
+   "out_degree": 4
+  },
+  "diamond_sensor_protocol_note": {
+   "deps_hash": "346a6f146f60",
+   "out_degree": 4
+  },
+  "diamond_signal_budget_hardening_note": {
+   "deps_hash": "ceb537ded336",
+   "out_degree": 2
+  },
+  "dimension_selection_finite_k_centroid_sign_bridge_note_2026-05-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dimension_selection_lower_bound_bridge_v2_2026-05-20": {
+   "deps_hash": "598946438973",
+   "out_degree": 2
+  },
+  "dimension_selection_note": {
+   "deps_hash": "66f7bbe26a96",
+   "out_degree": 1
+  },
+  "dimension_selection_upper_bound_textbook_import_note_2026-05-17": {
+   "deps_hash": "3785111e2e84",
+   "out_degree": 5
+  },
+  "dimension_upper_bound_dependency_edge_repair_note_2026-06-08": {
+   "deps_hash": "1db47e11abd3",
+   "out_degree": 3
+  },
+  "dimensional_gravity_table": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dirac_core_card_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dirac_decoherence_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dirac_field_smoothing_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dirac_lorentz_diagnostic_boundaries_from_rejected_repairs_note_2026-06-07": {
+   "deps_hash": "61a435917b36",
+   "out_degree": 4
+  },
+  "dirac_observable_panel_note": {
+   "deps_hash": "fb04c8d78313",
+   "out_degree": 1
+  },
+  "dirac_source_smoothing_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dirac_v4_convergence_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dirac_weak_coupling_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dirac_weyl_fermion_dof_from_lorentz_and_chirality_admission_bridge_note_2026-05-28": {
+   "deps_hash": "42db6a056a96",
+   "out_degree": 2
+  },
+  "directional_b_density_stencil_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "directional_b_geometry_normalized_holdout_transfer_mass5_note": {
+   "deps_hash": "225c6e2ae22c",
+   "out_degree": 2
+  },
+  "directional_b_geometry_normalized_holdout_transfer_note": {
+   "deps_hash": "882c7eeee3ea",
+   "out_degree": 2
+  },
+  "directional_b_geometry_normalized_overlap_map_note": {
+   "deps_hash": "59f43f9efa37",
+   "out_degree": 3
+  },
+  "directional_b_geometry_normalized_overlap_subcritical_n12_note": {
+   "deps_hash": "e9c5cafaf3ec",
+   "out_degree": 3
+  },
+  "discrete_einstein_regge_lift_note": {
+   "deps_hash": "dfa5ac62f565",
+   "out_degree": 3
+  },
+  "dispersion_high_p_tiebreaker_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dispersion_relation_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "distance_law_3d_64_closure_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "distance_law_breakpoint_note": {
+   "deps_hash": "5e634e692d5e",
+   "out_degree": 2
+  },
+  "distance_law_definitive_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "distance_law_frontier_audit_note": {
+   "deps_hash": "869ee91b9026",
+   "out_degree": 3
+  },
+  "distance_law_portability_note": {
+   "deps_hash": "9abe9b2db7e9",
+   "out_degree": 4
+  },
+  "distance_law_preserving_third_family_note": {
+   "deps_hash": "d6704552b04b",
+   "out_degree": 1
+  },
+  "distracted_napier_reconciliation_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_abcc_assumptions_audit_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_abcc_basin_finite_search_support_note_2026-04-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_abcc_chamber_bound_derivation_note_2026-04-20": {
+   "deps_hash": "fd91005ba4b4",
+   "out_degree": 5
+  },
+  "dm_abcc_chamber_bound_derivation_note_2026-04-20_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_abcc_closure_via_chamber_bound_and_dple_f4_note_2026-04-19": {
+   "deps_hash": "64b0e46e4185",
+   "out_degree": 3
+  },
+  "dm_abcc_exact_target_surface_source_cubic_closure_theorem_note_2026-04-21": {
+   "deps_hash": "0c50e0948ba7",
+   "out_degree": 2
+  },
+  "dm_abcc_five_basin_chamber_dple_support_record_invariance_companion_note_2026-06-04": {
+   "deps_hash": "15fa3a40f6ef",
+   "out_degree": 2
+  },
+  "dm_abcc_five_basin_chamber_dple_support_theorem_note_2026-04-21": {
+   "deps_hash": "a29826972571",
+   "out_degree": 4
+  },
+  "dm_abcc_pmns_nonsingularity_theorem_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_abcc_retained_measurement_closure_theorem_note_2026-04-21": {
+   "deps_hash": "9b8e6835ee09",
+   "out_degree": 4
+  },
+  "dm_abcc_signature_forcing_theorem_note_2026-04-19": {
+   "deps_hash": "fd86dd1df1be",
+   "out_degree": 1
+  },
+  "dm_candidate_mass_window_theorem_note_2026-04-19": {
+   "deps_hash": "a684be4ab33f",
+   "out_degree": 4
+  },
+  "dm_chamber_signature_structure_note_2026-04-19": {
+   "deps_hash": "75cf3f7b03ed",
+   "out_degree": 2
+  },
+  "dm_continuum_limit_velocity_note": {
+   "deps_hash": "be47c45645ac",
+   "out_degree": 1
+  },
+  "dm_current_bank_quantitative_mapping_note_2026-04-21": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_dple_abcc_no_go_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_dple_dimension_parametric_extremum_record_invariance_companion_note_2026-06-04": {
+   "deps_hash": "09e1cc62bbd8",
+   "out_degree": 2
+  },
+  "dm_dple_dimension_parametric_extremum_theorem_note_2026-04-19": {
+   "deps_hash": "76cefe1dd8e9",
+   "out_degree": 1
+  },
+  "dm_effective_parent_one_clock_transfer_boundary_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_effective_parent_one_clock_transfer_boundary_theorem_note_2026-04-18": {
+   "deps_hash": "0ef6cabb7d0f",
+   "out_degree": 3
+  },
+  "dm_eta_bounded_prediction_from_supplied_nsites_v_narrow_theorem_note_2026-05-28": {
+   "deps_hash": "1caa4af159e7",
+   "out_degree": 3
+  },
+  "dm_eta_freezeout_bypass_quantitative_theorem_note_2026-04-25": {
+   "deps_hash": "894f7538f0c4",
+   "out_degree": 4
+  },
+  "dm_eta_g1_cl3_adj3_embedding_algebraic_support_theorem_note_2026-05-06": {
+   "deps_hash": "bd07ae56982d",
+   "out_degree": 8
+  },
+  "dm_eta_g1_coleman_weinberg_bounded_theorem_note_2026-05-06": {
+   "deps_hash": "f28e30e4f0b6",
+   "out_degree": 9
+  },
+  "dm_eta_g1_dynamical_residual_operator_trace_support_theorem_note_2026-05-06": {
+   "deps_hash": "1b43f0378759",
+   "out_degree": 8
+  },
+  "dm_eta_g1_fierz_channel_narrative_correction_note_2026-05-27": {
+   "deps_hash": "39649b542f6b",
+   "out_degree": 6
+  },
+  "dm_eta_g1_operator_bridge_proof_theorem_note_2026-05-06": {
+   "deps_hash": "f27c41dc0774",
+   "out_degree": 7
+  },
+  "dm_eta_nsites_v_structural_support_lift_theorem_note_2026-04-29": {
+   "deps_hash": "ed6e078f5b48",
+   "out_degree": 4
+  },
+  "dm_flagship_closure_review_note_2026-04-17": {
+   "deps_hash": "251d998da3da",
+   "out_degree": 16
+  },
+  "dm_full_closure_64_to_1_channel_weight_bridge_narrow_theorem_note_2026-06-02": {
+   "deps_hash": "b768ed90c422",
+   "out_degree": 2
+  },
+  "dm_full_closure_same_surface_converged_thermal_selector_support_note_2026-04-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_full_closure_same_surface_numerator_selector_boundary_note_2026-04-16": {
+   "deps_hash": "b6ebc7294352",
+   "out_degree": 2
+  },
+  "dm_full_closure_same_surface_thermal_bounding_theorem_note_2026-04-17": {
+   "deps_hash": "b4edfd00b558",
+   "out_degree": 7
+  },
+  "dm_full_closure_same_surface_thermal_integral_representation_theorem_note_2026-04-16": {
+   "deps_hash": "d094eae41548",
+   "out_degree": 1
+  },
+  "dm_full_closure_same_surface_thermal_monotonicity_theorem_note_2026-04-17": {
+   "deps_hash": "18ef7990d683",
+   "out_degree": 2
+  },
+  "dm_full_closure_same_surface_thermal_selector_sensitivity_boundary_note_2026-04-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_full_closure_same_surface_thermal_series_tail_support_note_2026-04-17": {
+   "deps_hash": "18ef7990d683",
+   "out_degree": 2
+  },
+  "dm_leptogenesis_dweh_even_split_transfer_layer_note_2026-04-19": {
+   "deps_hash": "451e00b984c8",
+   "out_degree": 1
+  },
+  "dm_leptogenesis_equilibrium_conversion_theorem_note_2026-04-16": {
+   "deps_hash": "335840686631",
+   "out_degree": 1
+  },
+  "dm_leptogenesis_exact_kernel_closure_note_2026-04-15": {
+   "deps_hash": "e195675e46c1",
+   "out_degree": 3
+  },
+  "dm_leptogenesis_exact_kernel_closure_note_2026-04-15_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_leptogenesis_expansion_axiom_boundary_note_2026-04-16": {
+   "deps_hash": "88b5e466e525",
+   "out_degree": 3
+  },
+  "dm_leptogenesis_flavor_column_functional_theorem_note_2026-04-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_leptogenesis_full_microscopic_reduction_note_2026-04-16": {
+   "deps_hash": "a8b036989b98",
+   "out_degree": 2
+  },
+  "dm_leptogenesis_full_microscopic_reduction_note_2026-04-16_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_leptogenesis_hrad_theorem_note_2026-04-16": {
+   "deps_hash": "a0ec76d30593",
+   "out_degree": 3
+  },
+  "dm_leptogenesis_k00_sparse_face_target_preimage_theorem_note_2026-04-15": {
+   "deps_hash": "7d13923d425c",
+   "out_degree": 1
+  },
+  "dm_leptogenesis_ne_active_column_axiom_boundary_note_2026-04-16": {
+   "deps_hash": "1d77f63de284",
+   "out_degree": 2
+  },
+  "dm_leptogenesis_ne_active_column_axiom_boundary_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_leptogenesis_ne_charged_source_response_reduction_note_2026-04-16": {
+   "deps_hash": "46523bcf2338",
+   "out_degree": 2
+  },
+  "dm_leptogenesis_ne_projected_source_law_derivation_note_2026-04-16": {
+   "deps_hash": "c157eca28868",
+   "out_degree": 5
+  },
+  "dm_leptogenesis_ne_projected_source_law_derivation_note_2026-04-16_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_leptogenesis_ne_projected_source_triplet_sign_theorem_note_2026-04-16": {
+   "deps_hash": "c15ba08a4366",
+   "out_degree": 3
+  },
+  "dm_leptogenesis_pmns_active_projector_reduction_note_2026-04-16": {
+   "deps_hash": "7c87a4c36fd8",
+   "out_degree": 3
+  },
+  "dm_leptogenesis_pmns_active_projector_reduction_note_2026-04-16_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_leptogenesis_pmns_analytic_stationary_classification_theorem_note_2026-04-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_leptogenesis_pmns_breaking_triplet_source_law_note_2026-04-16": {
+   "deps_hash": "16056f6f9a4b",
+   "out_degree": 4
+  },
+  "dm_leptogenesis_pmns_constrained_optimization_algebra_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "fbfaa23064ca",
+   "out_degree": 3
+  },
+  "dm_leptogenesis_pmns_constructive_continuity_closure_theorem_note_2026-04-17": {
+   "deps_hash": "68c41e7ca64e",
+   "out_degree": 5
+  },
+  "dm_leptogenesis_pmns_constructive_projected_source_selector_theorem_note_2026-04-16": {
+   "deps_hash": "d2e564140b8c",
+   "out_degree": 4
+  },
+  "dm_leptogenesis_pmns_cp_bridge_boundary_note_2026-04-16": {
+   "deps_hash": "1150dbf9f894",
+   "out_degree": 4
+  },
+  "dm_leptogenesis_pmns_even_response_sole_axiom_boundary_note_2026-04-16": {
+   "deps_hash": "ff7f6a2d74ea",
+   "out_degree": 5
+  },
+  "dm_leptogenesis_pmns_iseed_selector_route_probes_note_2026-07-02": {
+   "deps_hash": "37b4d9d2a686",
+   "out_degree": 5
+  },
+  "dm_leptogenesis_pmns_microscopic_d_last_mile_note_2026-04-16": {
+   "deps_hash": "2e1bcc415076",
+   "out_degree": 2
+  },
+  "dm_leptogenesis_pmns_microscopic_selector_reduction_theorem_note_2026-04-17": {
+   "deps_hash": "ce6210677c31",
+   "out_degree": 5
+  },
+  "dm_leptogenesis_pmns_minimal_a13_sheet_selector_theorem_note_2026-04-16": {
+   "deps_hash": "98f4fb22d825",
+   "out_degree": 9
+  },
+  "dm_leptogenesis_pmns_minimum_information_source_law_note_2026-04-16": {
+   "deps_hash": "5bbbf5bf9795",
+   "out_degree": 1
+  },
+  "dm_leptogenesis_pmns_multistart_selector_support_note_2026-04-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_leptogenesis_pmns_observable_relative_action_law_note_2026-04-16": {
+   "deps_hash": "c19e6a831a2e",
+   "out_degree": 1
+  },
+  "dm_leptogenesis_pmns_observable_relative_action_law_note_2026-04-16_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_leptogenesis_pmns_off_seed_triplet_sign_boundary_note_2026-04-16": {
+   "deps_hash": "9b5759701e50",
+   "out_degree": 3
+  },
+  "dm_leptogenesis_pmns_oriented_phase_sheet_selector_theorem_note_2026-04-16": {
+   "deps_hash": "75ebd33dadd2",
+   "out_degree": 5
+  },
+  "dm_leptogenesis_pmns_projector_interface_note_2026-04-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_leptogenesis_pmns_reduced_surface_selector_support_note_2026-04-16": {
+   "deps_hash": "9ac7ff952a88",
+   "out_degree": 4
+  },
+  "dm_leptogenesis_pmns_reduction_exhaustion_theorem_note_2026-04-16": {
+   "deps_hash": "0d29872d6c54",
+   "out_degree": 6
+  },
+  "dm_leptogenesis_pmns_relative_action_stationarity_theorem_note_2026-04-16": {
+   "deps_hash": "be5728d32778",
+   "out_degree": 3
+  },
+  "dm_leptogenesis_pmns_selector_bank_cp_sheet_blindness_theorem_note_2026-04-16": {
+   "deps_hash": "d142f7cb0f16",
+   "out_degree": 4
+  },
+  "dm_leptogenesis_pmns_sole_axiom_boundary_note_2026-04-16": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "dm_leptogenesis_pmns_stationary_cp_incompatibility_theorem_note_2026-04-16": {
+   "deps_hash": "2ef3044f671b",
+   "out_degree": 4
+  },
+  "dm_leptogenesis_pmns_transport_extremal_source_candidate_note_2026-04-16": {
+   "deps_hash": "8184e3480510",
+   "out_degree": 1
+  },
+  "dm_leptogenesis_pmns_transport_selector_firewall_note_2026-06-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_leptogenesis_projection_theorem_note_2026-04-15": {
+   "deps_hash": "b752d4ae1a66",
+   "out_degree": 3
+  },
+  "dm_leptogenesis_transport_decomposition_theorem_note_2026-04-16": {
+   "deps_hash": "5f0ddf91107c",
+   "out_degree": 4
+  },
+  "dm_leptogenesis_transport_integral_theorem_note_2026-04-16": {
+   "deps_hash": "165d14dd5e7e",
+   "out_degree": 2
+  },
+  "dm_leptogenesis_transport_status_note_2026-04-16": {
+   "deps_hash": "6f87ff208128",
+   "out_degree": 8
+  },
+  "dm_leptogenesis_transport_status_note_2026-05-10": {
+   "deps_hash": "a3b4c110bdcb",
+   "out_degree": 8
+  },
+  "dm_leptogenesis_universal_yukawa_no_go_note_2026-04-15": {
+   "deps_hash": "19ed807a1467",
+   "out_degree": 3
+  },
+  "dm_leptogenesis_washout_axiom_boundary_note_2026-04-15": {
+   "deps_hash": "a94142fcc984",
+   "out_degree": 2
+  },
+  "dm_lepton_synthesis_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_live_constants_canonical_edge_certificate_note_2026-06-18": {
+   "deps_hash": "4afbf5d4a27e",
+   "out_degree": 1
+  },
+  "dm_m_dm_inverse_band_gauge_audit_bounded_note_2026-05-09": {
+   "deps_hash": "51332d81b09a",
+   "out_degree": 5
+  },
+  "dm_neutrino_atmospheric_scale_theorem_note_2026-04-15": {
+   "deps_hash": "dd09f8ef03cf",
+   "out_degree": 4
+  },
+  "dm_neutrino_bosonic_normalization_observable_principle_bridge_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_neutrino_bosonic_normalization_theorem_note_2026-04-15": {
+   "deps_hash": "25f9c67975e1",
+   "out_degree": 2
+  },
+  "dm_neutrino_breaking_triplet_axiom_law_attempt_note_2026-04-15": {
+   "deps_hash": "4b21d8a49d35",
+   "out_degree": 2
+  },
+  "dm_neutrino_breaking_triplet_cp_theorem_note_2026-04-15": {
+   "deps_hash": "4db105041bfe",
+   "out_degree": 1
+  },
+  "dm_neutrino_canonical_two_higgs_slot_no_go_note_2026-04-15": {
+   "deps_hash": "f6fbd70387a9",
+   "out_degree": 3
+  },
+  "dm_neutrino_cascade_geometry_note_2026-04-14": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_neutrino_ckm_texture_transfer_no_go_note_2026-04-15": {
+   "deps_hash": "f94bb87bca2d",
+   "out_degree": 3
+  },
+  "dm_neutrino_codd_bosonic_normalization_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_neutrino_codd_bosonic_normalization_theorem_note_2026-04-15": {
+   "deps_hash": "2802d3255b5f",
+   "out_degree": 4
+  },
+  "dm_neutrino_cp_kernel_deformation_necessity_note_2026-04-15": {
+   "deps_hash": "996237fc9a45",
+   "out_degree": 2
+  },
+  "dm_neutrino_dirac_bridge_theorem_note_2026-04-15": {
+   "deps_hash": "b5ee876b571b",
+   "out_degree": 1
+  },
+  "dm_neutrino_exact_h_source_surface_preimage_bundle_theorem_note_2026-04-16": {
+   "deps_hash": "f857a30401e8",
+   "out_degree": 3
+  },
+  "dm_neutrino_exact_h_source_surface_theorem_note_2026-04-16": {
+   "deps_hash": "4db105041bfe",
+   "out_degree": 1
+  },
+  "dm_neutrino_hermitian_bridge_carrier_note_2026-04-15": {
+   "deps_hash": "b251b43fc69f",
+   "out_degree": 3
+  },
+  "dm_neutrino_k00_bosonic_normalization_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_neutrino_k00_bosonic_normalization_record_invariance_companion_note_2026-06-04": {
+   "deps_hash": "bcf4d3295faf",
+   "out_degree": 2
+  },
+  "dm_neutrino_k00_bosonic_normalization_theorem_note_2026-04-15": {
+   "deps_hash": "37f1d28ff4f4",
+   "out_degree": 4
+  },
+  "dm_neutrino_observable_bank_exhaustion_theorem_note_2026-04-17": {
+   "deps_hash": "a73e6f7b3428",
+   "out_degree": 10
+  },
+  "dm_neutrino_odd_circulant_current_stack_zero_law_note_2026-04-15": {
+   "deps_hash": "4db5b50c27c0",
+   "out_degree": 3
+  },
+  "dm_neutrino_odd_circulant_z2_slot_theorem_note_2026-04-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_neutrino_odd_mixed_bridge_extension_note_2026-04-15": {
+   "deps_hash": "6f248c3e2bad",
+   "out_degree": 4
+  },
+  "dm_neutrino_operator_selection_obstruction_note_2026-04-14": {
+   "deps_hash": "497af6e258c3",
+   "out_degree": 2
+  },
+  "dm_neutrino_polar_aligned_core_no_go_note_2026-04-15": {
+   "deps_hash": "c4e408d4ed30",
+   "out_degree": 2
+  },
+  "dm_neutrino_positive_polar_h_cp_theorem_note_2026-04-15": {
+   "deps_hash": "07c4046b5565",
+   "out_degree": 2
+  },
+  "dm_neutrino_postcanonical_extension_class_note_2026-04-15": {
+   "deps_hash": "78bef563762c",
+   "out_degree": 5
+  },
+  "dm_neutrino_postcanonical_polar_section_note_2026-04-15": {
+   "deps_hash": "6f04ee79a614",
+   "out_degree": 4
+  },
+  "dm_neutrino_postcanonical_right_frame_obstruction_note_2026-04-15": {
+   "deps_hash": "7de20785bede",
+   "out_degree": 3
+  },
+  "dm_neutrino_postcanonical_slot_support_class_note_2026-04-15": {
+   "deps_hash": "6aea858170b8",
+   "out_degree": 2
+  },
+  "dm_neutrino_readout_det_uniqueness_inapplicable_no_go_note_2026-06-07": {
+   "deps_hash": "d282a9c67c27",
+   "out_degree": 2
+  },
+  "dm_neutrino_schur_suppression_named_admissions_bounded_theorem_note_2026-06-07": {
+   "deps_hash": "c0a965a17a83",
+   "out_degree": 7
+  },
+  "dm_neutrino_schur_suppression_theorem_note_2026-04-15": {
+   "deps_hash": "887319a4122d",
+   "out_degree": 2
+  },
+  "dm_neutrino_singlet_doublet_cp_slot_tool_note_2026-04-15": {
+   "deps_hash": "18b2750e7913",
+   "out_degree": 2
+  },
+  "dm_neutrino_source_amplitude_theorem_note_2026-04-15": {
+   "deps_hash": "f7ef6bfd7df1",
+   "out_degree": 5
+  },
+  "dm_neutrino_source_bank_z3_doublet_block_selection_obstruction_theorem_note_2026-04-16": {
+   "deps_hash": "c61a828e22e8",
+   "out_degree": 4
+  },
+  "dm_neutrino_source_surface_active_affine_point_selection_boundary_note_2026-04-16": {
+   "deps_hash": "fea424fd0169",
+   "out_degree": 4
+  },
+  "dm_neutrino_source_surface_active_curvature_23_symmetric_baseline_boundary_theorem_note_2026-04-17": {
+   "deps_hash": "25e6b10491a3",
+   "out_degree": 4
+  },
+  "dm_neutrino_source_surface_active_half_plane_theorem_note_2026-04-16": {
+   "deps_hash": "de4c2d0ee361",
+   "out_degree": 5
+  },
+  "dm_neutrino_source_surface_active_parity_compatible_diagonal_baseline_theorem_note_2026-04-17": {
+   "deps_hash": "fe96b0f5585a",
+   "out_degree": 2
+  },
+  "dm_neutrino_source_surface_atomic_witness_volume_selector_nonrealization_note_2026-04-18": {
+   "deps_hash": "96d7a072736d",
+   "out_degree": 3
+  },
+  "dm_neutrino_source_surface_bifundamental_invariance_obstruction_theorem_note_2026-04-17": {
+   "deps_hash": "d4433ad9c0e2",
+   "out_degree": 14
+  },
+  "dm_neutrino_source_surface_bundle_window_trichotomy_candidate_note_2026-04-18": {
+   "deps_hash": "20243937a509",
+   "out_degree": 5
+  },
+  "dm_neutrino_source_surface_carrier_normal_form_theorem_note_2026-04-16": {
+   "deps_hash": "4b3453287262",
+   "out_degree": 4
+  },
+  "dm_neutrino_source_surface_carrier_side_conclusion_note_2026-04-18": {
+   "deps_hash": "168f813addc0",
+   "out_degree": 2
+  },
+  "dm_neutrino_source_surface_carrier_side_conclusion_note_2026-04-18_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_neutrino_source_surface_cubic_variational_obstruction_note_2026-04-17": {
+   "deps_hash": "7c4c5d21c2ae",
+   "out_degree": 6
+  },
+  "dm_neutrino_source_surface_endpoint_window_bundle_dominance_candidate_note_2026-04-17": {
+   "deps_hash": "1d29cce8cbfb",
+   "out_degree": 3
+  },
+  "dm_neutrino_source_surface_global_dominance_completeness_obstruction_note_2026-04-17": {
+   "deps_hash": "31539a3f558c",
+   "out_degree": 9
+  },
+  "dm_neutrino_source_surface_global_dominance_completeness_obstruction_note_2026-04-17_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_neutrino_source_surface_info_geometric_selection_obstruction_note_2026-04-17": {
+   "deps_hash": "b2df0184d814",
+   "out_degree": 6
+  },
+  "dm_neutrino_source_surface_intrinsic_slot_theorem_note_2026-04-16": {
+   "deps_hash": "c5c774f0df8a",
+   "out_degree": 4
+  },
+  "dm_neutrino_source_surface_m_spectator_theorem_note_2026-04-16": {
+   "deps_hash": "6bc579bbb71d",
+   "out_degree": 3
+  },
+  "dm_neutrino_source_surface_microscopic_polynomial_impossibility_theorem_note_2026-04-17": {
+   "deps_hash": "51f297ab4337",
+   "out_degree": 8
+  },
+  "dm_neutrino_source_surface_microscopic_positive_probe_representation_theorem_note_2026-04-17": {
+   "deps_hash": "c21de55e06c6",
+   "out_degree": 4
+  },
+  "dm_neutrino_source_surface_microscopic_positive_probe_representation_theorem_note_2026-04-17_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_neutrino_source_surface_observable_grammar_exhaustion_obstruction_note_2026-04-17": {
+   "deps_hash": "ad55b0bcdaf6",
+   "out_degree": 1
+  },
+  "dm_neutrino_source_surface_p3_sylvester_linear_path_signature_theorem_note_2026-04-18": {
+   "deps_hash": "fe42d01d1626",
+   "out_degree": 1
+  },
+  "dm_neutrino_source_surface_parity_compatible_observable_selector_theorem_note_2026-04-17": {
+   "deps_hash": "b158d85f4917",
+   "out_degree": 5
+  },
+  "dm_neutrino_source_surface_parity_mixing_selection_obstruction_note_2026-04-17": {
+   "deps_hash": "6c50a0fc10f6",
+   "out_degree": 15
+  },
+  "dm_neutrino_source_surface_perturbative_uniqueness_theorem_note_2026-04-17": {
+   "deps_hash": "006775a8f7e7",
+   "out_degree": 2
+  },
+  "dm_neutrino_source_surface_quartic_isotropy_and_u2_obstruction_note_2026-04-17": {
+   "deps_hash": "0243d5eeb9a5",
+   "out_degree": 9
+  },
+  "dm_neutrino_source_surface_rival_window_edge_profile_hierarchy_candidate_note_2026-04-18": {
+   "deps_hash": "5c332849976a",
+   "out_degree": 6
+  },
+  "dm_neutrino_source_surface_scalar_baseline_active_quadratic_diagnostic_note_2026-04-17": {
+   "deps_hash": "fd0972df7f5e",
+   "out_degree": 3
+  },
+  "dm_neutrino_source_surface_schur_scalar_baseline_theorem_note_2026-04-17": {
+   "deps_hash": "7b13caeae995",
+   "out_degree": 7
+  },
+  "dm_neutrino_source_surface_shift_quotient_bundle_theorem_note_2026-04-16": {
+   "deps_hash": "32a0e5021e8e",
+   "out_degree": 3
+  },
+  "dm_neutrino_source_surface_slot_torsion_boundary_theorem_note_2026-04-16": {
+   "deps_hash": "eaf7069ee08a",
+   "out_degree": 4
+  },
+  "dm_neutrino_source_surface_split1_window_bundle_dominance_candidate_note_2026-04-17": {
+   "deps_hash": "1d29cce8cbfb",
+   "out_degree": 3
+  },
+  "dm_neutrino_source_surface_split2_boundary_band_transition_candidate_note_2026-04-18": {
+   "deps_hash": "559fc6f6651c",
+   "out_degree": 4
+  },
+  "dm_neutrino_source_surface_split2_edge_profile_transition_candidate_note_2026-04-18": {
+   "deps_hash": "21bb457816df",
+   "out_degree": 4
+  },
+  "dm_neutrino_source_surface_split2_edge_transport_lane_obstruction_candidate_note_2026-04-18": {
+   "deps_hash": "7fbdcb608914",
+   "out_degree": 5
+  },
+  "dm_neutrino_source_surface_split2_low_slack_transport_incompatibility_candidate_note_2026-04-18": {
+   "deps_hash": "c725d55ea672",
+   "out_degree": 6
+  },
+  "dm_neutrino_source_surface_split2_low_slack_upper_m_ridge_candidate_note_2026-04-18": {
+   "deps_hash": "c8444a17494e",
+   "out_degree": 6
+  },
+  "dm_neutrino_source_surface_split2_lower_repair_upper_face_extremals_candidate_note_2026-04-18": {
+   "deps_hash": "5f1a85221fed",
+   "out_degree": 7
+  },
+  "dm_neutrino_source_surface_split2_upper_face_local_neighborhoods_candidate_note_2026-04-18": {
+   "deps_hash": "d8908286b833",
+   "out_degree": 6
+  },
+  "dm_neutrino_source_surface_split2_upper_m_slack_floor_endpoint_candidate_note_2026-04-18": {
+   "deps_hash": "3589e5804b3d",
+   "out_degree": 5
+  },
+  "dm_neutrino_source_surface_z3_doublet_block_current_bank_blindness_theorem_note_2026-04-16": {
+   "deps_hash": "9b1d2716dd7d",
+   "out_degree": 6
+  },
+  "dm_neutrino_source_surface_z3_doublet_block_full_closure_boundary_note_2026-04-16": {
+   "deps_hash": "582eacade719",
+   "out_degree": 6
+  },
+  "dm_neutrino_source_surface_z3_doublet_block_point_selection_theorem_note_2026-04-16": {
+   "deps_hash": "c2a6fae49332",
+   "out_degree": 4
+  },
+  "dm_neutrino_source_surface_z3_parity_split_theorem_note_2026-04-17": {
+   "deps_hash": "e78d50e1689c",
+   "out_degree": 6
+  },
+  "dm_neutrino_transport_chamber_blindness_theorem_note_2026-04-17": {
+   "deps_hash": "eb27cd4bf02b",
+   "out_degree": 9
+  },
+  "dm_neutrino_triplet_character_source_theorem_note_2026-04-15": {
+   "deps_hash": "823175d2f1a6",
+   "out_degree": 1
+  },
+  "dm_neutrino_triplet_even_response_theorem_note_2026-04-15": {
+   "deps_hash": "823175d2f1a6",
+   "out_degree": 1
+  },
+  "dm_neutrino_triplet_normalization_target_note_2026-04-15": {
+   "deps_hash": "3460000b630c",
+   "out_degree": 3
+  },
+  "dm_neutrino_two_higgs_23_symmetric_slot_no_go_note_2026-04-15": {
+   "deps_hash": "de42db332024",
+   "out_degree": 2
+  },
+  "dm_neutrino_two_higgs_closure_attacks_note_2026-04-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_neutrino_two_higgs_continuity_sheet_theorem_note_2026-04-15": {
+   "deps_hash": "3226ad1ebee8",
+   "out_degree": 3
+  },
+  "dm_neutrino_two_higgs_minimality_theorem_note_2026-04-15": {
+   "deps_hash": "faa9899c76f6",
+   "out_degree": 4
+  },
+  "dm_neutrino_two_higgs_right_gram_bridge_note_2026-04-15": {
+   "deps_hash": "9e79afb51bcf",
+   "out_degree": 1
+  },
+  "dm_neutrino_veven_bosonic_normalization_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_neutrino_veven_bosonic_normalization_theorem_note_2026-04-15": {
+   "deps_hash": "3fdb94cdfaa8",
+   "out_degree": 3
+  },
+  "dm_neutrino_vsel_curvature_taste_to_dirac_transport_obstruction_no_go_note_2026-06-07": {
+   "deps_hash": "27620673a9b7",
+   "out_degree": 2
+  },
+  "dm_neutrino_weak_even_swap_reduction_theorem_note_2026-04-15": {
+   "deps_hash": "b9194d8a4f77",
+   "out_degree": 3
+  },
+  "dm_neutrino_weak_matching_obstruction_note_2026-04-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_neutrino_weak_triplet_coefficient_axiom_boundary_note_2026-04-15": {
+   "deps_hash": "54c3e16a8bab",
+   "out_degree": 9
+  },
+  "dm_neutrino_weak_triplet_transfer_class_theorem_note_2026-04-15": {
+   "deps_hash": "c0d085c15817",
+   "out_degree": 5
+  },
+  "dm_neutrino_weak_vector_theorem_note_2026-04-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_neutrino_yukawa_cascade_candidate_note_2026-04-14": {
+   "deps_hash": "ac7c6c29b86a",
+   "out_degree": 3
+  },
+  "dm_neutrino_z3_character_transfer_theorem_note_2026-04-15": {
+   "deps_hash": "ba661e7c5799",
+   "out_degree": 2
+  },
+  "dm_neutrino_z3_circulant_cp_tool_note_2026-04-15": {
+   "deps_hash": "d484e27efe6f",
+   "out_degree": 4
+  },
+  "dm_neutrino_z3_circulant_mass_basis_no_go_note_2026-04-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_neutrino_z3_phase_lift_mixed_bridge_note_2026-04-15": {
+   "deps_hash": "f3a51355833b",
+   "out_degree": 2
+  },
+  "dm_pmns_affine_current_coordinate_reduction_theorem_note_2026-04-21": {
+   "deps_hash": "5009e503969d",
+   "out_degree": 5
+  },
+  "dm_pmns_asymptotic_source_no_go_note_2026-04-20": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_pmns_chamber_spectral_completeness_krawczyk_certificate_note_2026-05-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_pmns_chamber_spectral_completeness_theorem_note_2026-04-20": {
+   "deps_hash": "a205d5cb5593",
+   "out_degree": 4
+  },
+  "dm_pmns_cp_orientation_parity_reduction_note_2026-04-20": {
+   "deps_hash": "b1e3e29ce760",
+   "out_degree": 1
+  },
+  "dm_pmns_cp_orientation_parity_reduction_note_2026-04-20_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_pmns_graph_first_ordered_chain_nonzero_current_activation_theorem_note_2026-04-21": {
+   "deps_hash": "9a555f632be2",
+   "out_degree": 2
+  },
+  "dm_pmns_local_selector_family_no_go_theorem_note_2026-04-20": {
+   "deps_hash": "a1e76f2c7de9",
+   "out_degree": 3
+  },
+  "dm_pmns_native_current_last_mile_reduction_theorem_note_2026-04-21": {
+   "deps_hash": "46acc91605b3",
+   "out_degree": 7
+  },
+  "dm_pmns_ne_seed_surface_exact_source_manifold_theorem_note_2026-04-20": {
+   "deps_hash": "ad4dee777f3f",
+   "out_degree": 9
+  },
+  "dm_pmns_ordered_chain_graded_current_delta_closure_theorem_note_2026-04-21": {
+   "deps_hash": "819917425725",
+   "out_degree": 2
+  },
+  "dm_pmns_upper_octant_source_cubic_selector_theorem_note_2026-04-20": {
+   "deps_hash": "2761e985465e",
+   "out_degree": 6
+  },
+  "dm_pmns_z3_doublet_block_center_positive_sheet_no_go_theorem_note_2026-04-20": {
+   "deps_hash": "276804b3a3e7",
+   "out_degree": 2
+  },
+  "dm_pns_attack_cascade_note_2026-04-19": {
+   "deps_hash": "d341901242dd",
+   "out_degree": 3
+  },
+  "dm_selector_branch_conclusion_note_2026-04-17": {
+   "deps_hash": "f7ef949fd65d",
+   "out_degree": 3
+  },
+  "dm_selector_first_shoulder_exit_threshold_support_criticality_bump_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "bd4549103efa",
+   "out_degree": 4
+  },
+  "dm_selector_first_shoulder_exit_threshold_support_note_2026-04-21": {
+   "deps_hash": "25fa09bd4f4c",
+   "out_degree": 2
+  },
+  "dm_selector_relative_action_recovered_branch_separation_support_theorem_note_2026-04-21": {
+   "deps_hash": "a1dd3d42c2ef",
+   "out_degree": 4
+  },
+  "dm_selector_relative_action_recovered_projection_support_theorem_note_2026-04-21": {
+   "deps_hash": "665df29045ce",
+   "out_degree": 3
+  },
+  "dm_selector_shifted_doublet_imag_sign_support_theorem_note_2026-04-21": {
+   "deps_hash": "a2b954545ff2",
+   "out_degree": 4
+  },
+  "dm_selector_shifted_relative_action_recovered_packet_closure_theorem_note_2026-04-21": {
+   "deps_hash": "56f9905f5a16",
+   "out_degree": 5
+  },
+  "dm_selector_threshold_stabilization_support_theorem_note_2026-04-21": {
+   "deps_hash": "a5d8bbf2066f",
+   "out_degree": 1
+  },
+  "dm_sigma_hier_closure_packet_note_2026-04-20": {
+   "deps_hash": "0fd8ecca886f",
+   "out_degree": 4
+  },
+  "dm_sigma_hier_h_intrinsic_no_go_criticality_bump_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "a0f197849ffe",
+   "out_degree": 2
+  },
+  "dm_sigma_hier_h_intrinsic_no_go_theorem_note_2026-04-20": {
+   "deps_hash": "b1d52c1d5eaf",
+   "out_degree": 4
+  },
+  "dm_sigma_hier_upper_octant_selector_theorem_note_2026-04-20": {
+   "deps_hash": "dc1a983abaab",
+   "out_degree": 2
+  },
+  "dm_split2_dense_grid_lipschitz_dominance_support_note_2026-04-21": {
+   "deps_hash": "5518ea49c5ea",
+   "out_degree": 1
+  },
+  "dm_split2_interval_certified_dominance_closure_theorem_note_2026-04-21": {
+   "deps_hash": "2072250066cd",
+   "out_degree": 3
+  },
+  "dm_strong_cp_gamma_transfer_no_go_note_2026-04-15": {
+   "deps_hash": "9fd9d3890b24",
+   "out_degree": 2
+  },
+  "dm_su3_gauge_loop_obstruction_note_2026-04-25": {
+   "deps_hash": "60123a334e50",
+   "out_degree": 2
+  },
+  "dm_thermal_average_sommerfeld_textbook_import_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_wilson_direct_descendant_batch_authority_note_2026-05-03": {
+   "deps_hash": "eb7506ddc579",
+   "out_degree": 22
+  },
+  "dm_wilson_direct_descendant_boundary_arrest_triplet_y_maximin_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_wilson_direct_descendant_canonical_fiber_mixed_spectral_branch_weight_no_go_note_2026-04-19": {
+   "deps_hash": "70b72611122a",
+   "out_degree": 6
+  },
+  "dm_wilson_direct_descendant_canonical_fiber_schur_entropy_candidate_no_go_note_2026-04-19": {
+   "deps_hash": "7f24c1913174",
+   "out_degree": 5
+  },
+  "dm_wilson_direct_descendant_canonical_path_derivation_no_go_note_2026-04-19": {
+   "deps_hash": "77b4ffa591cb",
+   "out_degree": 7
+  },
+  "dm_wilson_direct_descendant_canonical_path_derivation_no_go_note_2026-04-19_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_wilson_direct_descendant_canonical_path_selector_theorem_note_2026-04-19": {
+   "deps_hash": "e8f04839bd1d",
+   "out_degree": 8
+  },
+  "dm_wilson_direct_descendant_canonical_transport_column_fiber_theorem_note_2026-04-19": {
+   "deps_hash": "6579941a9fcc",
+   "out_degree": 4
+  },
+  "dm_wilson_direct_descendant_canonical_transport_column_fiber_theorem_note_2026-04-19_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_wilson_direct_descendant_constructive_positive_closure_manifold_theorem_note_2026-04-18": {
+   "deps_hash": "c419624eca2e",
+   "out_degree": 3
+  },
+  "dm_wilson_direct_descendant_constructive_positive_closure_manifold_theorem_note_2026-04-18_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_wilson_direct_descendant_constructive_positive_closure_multiplicity_theorem_note_2026-04-18": {
+   "deps_hash": "beeb3bd4f5fc",
+   "out_degree": 3
+  },
+  "dm_wilson_direct_descendant_constructive_transport_plateau_j_iso_derivation_and_schur_isotropy_no_go_note_2026-04-19": {
+   "deps_hash": "1cc24afc976d",
+   "out_degree": 4
+  },
+  "dm_wilson_direct_descendant_constructive_transport_plateau_normalized_schur_determinant_selector_note_2026-04-19": {
+   "deps_hash": "d0021e36845c",
+   "out_degree": 4
+  },
+  "dm_wilson_direct_descendant_constructive_transport_plateau_observable_affine_no_go_note_2026-04-19": {
+   "deps_hash": "9b880796551c",
+   "out_degree": 4
+  },
+  "dm_wilson_direct_descendant_constructive_transport_plateau_schur_spectral_isotropy_selector_note_2026-04-19": {
+   "deps_hash": "7a86793ef1fa",
+   "out_degree": 5
+  },
+  "dm_wilson_direct_descendant_constructive_transport_plateau_theorem_note_2026-04-19": {
+   "deps_hash": "019453aaf46c",
+   "out_degree": 3
+  },
+  "dm_wilson_direct_descendant_flagship_frontier_collapse_theorem_note_2026-04-18": {
+   "deps_hash": "f214a23f2f54",
+   "out_degree": 6
+  },
+  "dm_wilson_direct_descendant_local_observable_coordinate_theorem_note_2026-04-19": {
+   "deps_hash": "06f4d6aa78f1",
+   "out_degree": 3
+  },
+  "dm_wilson_direct_descendant_local_schur_branch_discriminant_theorem_note_2026-04-19": {
+   "deps_hash": "ab0dd51c0e8e",
+   "out_degree": 4
+  },
+  "dm_wilson_direct_descendant_local_schur_source_family_theorem_note_2026-04-18": {
+   "deps_hash": "9444cfcb75e8",
+   "out_degree": 4
+  },
+  "dm_wilson_direct_descendant_microscopic_value_frontier_theorem_note_2026-04-18": {
+   "deps_hash": "0214cca4ddfc",
+   "out_degree": 5
+  },
+  "dm_wilson_direct_descendant_positive_branch_compatibility_and_insufficiency_theorem_note_2026-04-18": {
+   "deps_hash": "ee3999777d4e",
+   "out_degree": 2
+  },
+  "dm_wilson_direct_descendant_projected_source_branch_discriminant_theorem_note_2026-04-18": {
+   "deps_hash": "ba4de1af9458",
+   "out_degree": 3
+  },
+  "dm_wilson_direct_descendant_schur_feshbach_boundary_variational_theorem_note_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dm_wilson_direct_descendant_transport_fiber_minimal_local_spectral_law_no_go_note_2026-04-19": {
+   "deps_hash": "0c1bfdf894a2",
+   "out_degree": 8
+  },
+  "dm_wilson_direct_descendant_transport_fiber_spectral_completion_theorem_note_2026-04-19": {
+   "deps_hash": "54b6c4828b21",
+   "out_degree": 3
+  },
+  "dm_wilson_parent_correctness_audit_note_2026-04-18": {
+   "deps_hash": "b1667b98ad8a",
+   "out_degree": 8
+  },
+  "dm_wilson_to_dweh_adjacent_chain_normal_form_theorem_note_2026-04-18": {
+   "deps_hash": "94e431ddc022",
+   "out_degree": 3
+  },
+  "dm_wilson_to_dweh_hermitian_source_family_current_bank_boundary_note_2026-04-18": {
+   "deps_hash": "d857cc62b67f",
+   "out_degree": 5
+  },
+  "dm_wilson_to_dweh_hermitian_source_family_target_note_2026-04-18": {
+   "deps_hash": "d993dba5158a",
+   "out_degree": 2
+  },
+  "dm_wilson_to_dweh_local_chain_path_algebra_current_bank_boundary_note_2026-04-18": {
+   "deps_hash": "7bf3b01d74dc",
+   "out_degree": 3
+  },
+  "dm_wilson_to_dweh_local_chain_path_algebra_target_note_2026-04-18": {
+   "deps_hash": "a9744f626f59",
+   "out_degree": 3
+  },
+  "dm_wilson_to_dweh_local_path_algebra_minimal_certificate_note_2026-04-18": {
+   "deps_hash": "469ad57e5269",
+   "out_degree": 3
+  },
+  "dm_wilson_to_dweh_structured_extension_criterion_theorem_note_2026-04-18": {
+   "deps_hash": "f19eb4ddacba",
+   "out_degree": 2
+  },
+  "dm_wilson_to_dweh_structured_model_realization_theorem_note_2026-04-18": {
+   "deps_hash": "09e9f76365d0",
+   "out_degree": 3
+  },
+  "dm_z3_texture_factor_theorem_note_2026-04-15": {
+   "deps_hash": "f82cdca1a547",
+   "out_degree": 2
+  },
+  "domain_wall_chiral_edge_from_achiral_cl3_bulk_free_field_bounded_theorem_note_2026-07-04": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "domain_wall_edge_anomaly_inflow_spectral_flow_free_field_bounded_theorem_note_2026-07-05": {
+   "deps_hash": "057e3aa4178f",
+   "out_degree": 2
+  },
+  "domain_wall_edge_content_vs_sm_chiral_fermions_map_bounded_theorem_note_2026-07-05": {
+   "deps_hash": "449c86d27d7d",
+   "out_degree": 7
+  },
+  "doped_flux_response_no_uniform_sign_region_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "down_type_mass_ratio_ckm_dual_note": {
+   "deps_hash": "b12bc8759bdc",
+   "out_degree": 4
+  },
+  "dt1_time_dimension_proof_walk_lattice_independence_bounded_note_2026-05-08": {
+   "deps_hash": "a9e0fa0561e7",
+   "out_degree": 8
+  },
+  "dt1_time_dimension_proof_walk_note_2026-05-17": {
+   "deps_hash": "7cfaf5ef38ff",
+   "out_degree": 7
+  },
+  "dynamics_axiom_minimal_nontriviality_branch_proposal_2026-06-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dynamics_content_sort_ordering_derived_accumulation_irreducible_bounded_note_2026-07-03": {
+   "deps_hash": "23ba149c2cde",
+   "out_degree": 5
+  },
+  "dynamics_coupling_residual_classifier_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dynamics_form_from_record_preservation_gauge_invariant_local_class_bounded_theorem_note_2026-06-05": {
+   "deps_hash": "455caeee0b77",
+   "out_degree": 5
+  },
+  "dynamics_nontriviality_selection_firewall_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "early_family_transfer_connectivity_diagnosis": {
+   "deps_hash": "a617fa504a0b",
+   "out_degree": 6
+  },
+  "edge_deletion_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "edge_deletion_boundary_sweep_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "edge_two_site_framing_supplies_no_native_color_route_record_text_narrow_no_go_note_2026-06-08": {
+   "deps_hash": "23cb4395db57",
+   "out_degree": 6
+  },
+  "eident_decomposition_definitional_proportionality_ctx_match_bounded_note_2026-07-02": {
+   "deps_hash": "b4bd9aab8324",
+   "out_degree": 3
+  },
+  "eigenvalue_anderson_phase_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "electric_sign_law_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "electrostatics_card_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "electrostatics_grown_sign_law_audited_scope_narrow_bounded_note_2026-05-10": {
+   "deps_hash": "81ee2a254c9d",
+   "out_degree": 1
+  },
+  "electrostatics_grown_sign_law_note": {
+   "deps_hash": "bf83186f0efa",
+   "out_degree": 1
+  },
+  "electrostatics_grown_sign_law_source_field_linearity_parity_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "electrostatics_superposition_proxy_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "em_coupling_from_ewsb_note_2026-05-02": {
+   "deps_hash": "ecff93460c67",
+   "out_degree": 3
+  },
+  "em_gravity_coexistence_2x2_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "emergent_gauge_heat_kernel_clt_attractor_conditional_on_bi_invariant_dynamics_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "e2d87f54ff22",
+   "out_degree": 8
+  },
+  "emergent_geometry_growth_note_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "emergent_lorentz_interacting_velocity_rg_attractor_note_2026-06-06": {
+   "deps_hash": "515ed03c2ef5",
+   "out_degree": 7
+  },
+  "emergent_lorentz_invariance_note": {
+   "deps_hash": "019fee56f57f",
+   "out_degree": 3
+  },
+  "emergent_lorentz_radiative_stability_discrete_tick_b4_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "f024dcb49b94",
+   "out_degree": 6
+  },
+  "emergent_lorentz_spatial_bz_power_mixing_boundary_theorem_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "emergent_lorentz_velocity_rg_exchange_matrix_exact_support_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "emergent_metric_conformal_class_from_records_scale_is_the_clock_rate_no_go_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "44373c940f82",
+   "out_degree": 2
+  },
+  "emergent_poincare_free_sector_from_kinetic_isotropy_primitive_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "64a1da554a35",
+   "out_degree": 5
+  },
+  "emergent_product_law_audit_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "emergent_product_law_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "empty_state_bootstrap_all_open_availability_orbit_dichotomy_degree_nine_chirality_wall_bounded_theorem_note_2026-07-04": {
+   "deps_hash": "d8a3bd39934d",
+   "out_degree": 5
+  },
+  "energy_channel_induced_kernel_route_a_note_2026-07-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "energy_covariant_rg_collapse_shifted_coupling_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "energy_gauss_constraint_obstruction_route_b_note_2026-07-08": {
+   "deps_hash": "c2033cd10392",
+   "out_degree": 1
+  },
+  "ep_record_stiffness_conditional_shared_coupling_template_note_2026-06-07": {
+   "deps_hash": "69a1ede16473",
+   "out_degree": 6
+  },
+  "ep_record_stiffness_context_independence_no_go_note_2026-06-17": {
+   "deps_hash": "4b6bf1f2b109",
+   "out_degree": 5
+  },
+  "ep_record_stiffness_weak_field_source_readout_interface_note_2026-06-16": {
+   "deps_hash": "066fb0c52929",
+   "out_degree": 1
+  },
+  "epsilon1_from_cp_chain_note_2026-05-03": {
+   "deps_hash": "8582f7ca3028",
+   "out_degree": 5
+  },
+  "epsstar_coefficient_richardson_moff0_bounded_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "epsstar_curve_pt_boundary_quadrature_collapse_bounded_note_2026-06-12": {
+   "deps_hash": "e9e4718b504b",
+   "out_degree": 2
+  },
+  "epsstar_full_kernel_coefficient_derivation_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "epsstar_sommerfeld_t0_boundary_derivation_bounded_note_2026-06-12": {
+   "deps_hash": "fa5aa0d7f9b9",
+   "out_degree": 3
+  },
+  "equal_channel_energy_reduces_to_equipartition_surface_dictionary_residual_bounded_note_2026-07-02": {
+   "deps_hash": "202f0e621242",
+   "out_degree": 4
+  },
+  "equivalence_principle_harness_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "equivalence_principle_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "equivariant_wilson_eta_densities_vanish_on_tested_window_bounded_note_2026-06-12": {
+   "deps_hash": "e23bb55f4693",
+   "out_degree": 2
+  },
+  "erosion_exact_recurrence_path_product_threshold_obstruction_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e60587486a86",
+   "out_degree": 1
+  },
+  "erosion_geometric_rate_closed_form_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "001ab451f785",
+   "out_degree": 2
+  },
+  "erosion_mobius_derivative_chain_rule_law_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "70aab25133d6",
+   "out_degree": 2
+  },
+  "erosion_rapidity_abelianization_complete_law_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "7e6b96d9ae13",
+   "out_degree": 3
+  },
+  "erosion_rate_table_no_tested_closed_form_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "b625021b6d1f",
+   "out_degree": 1
+  },
+  "eta_188_structural_origin_partial_note_2026-05-03": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "eta_holonomy_base_flux_scope_boundary_note_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "eta_twisted_walk_family_rigid_drift_discovery_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "a1d2df512ebc",
+   "out_degree": 5
+  },
+  "eta_ud2_fixed_token_square_homology_certificate_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "evanescent_barrier_amplitude_suppression_theorem_note": {
+   "deps_hash": "ffe284d02f9a",
+   "out_degree": 4
+  },
+  "evolving_network_prototype_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "evolving_network_prototype_v2_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "evolving_network_prototype_v3_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "evolving_network_prototype_v4_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "evolving_network_prototype_v5_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "evolving_network_prototype_v6_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ew_coupling_derivation_note": {
+   "deps_hash": "ff608592a4ad",
+   "out_degree": 12
+  },
+  "ew_current_fierz_channel_decomposition_note_2026-05-01": {
+   "deps_hash": "2a9d6130ac3c",
+   "out_degree": 2
+  },
+  "ew_current_matching_ozi_suppression_theorem_note_2026-04-27": {
+   "deps_hash": "5d3c347b2413",
+   "out_degree": 2
+  },
+  "ew_current_matching_rule_open_gate_note_2026-05-03": {
+   "deps_hash": "b96f010b2381",
+   "out_degree": 2
+  },
+  "ew_current_traceless_generator_selector_dep_resolution_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "800873f98010",
+   "out_degree": 3
+  },
+  "ew_current_traceless_generator_selector_no_go_note_2026-05-03": {
+   "deps_hash": "722b7376f108",
+   "out_degree": 3
+  },
+  "ew_higgs_gauge_mass_diagonalization_theorem_note_2026-04-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ew_kappa_registration_registers_all_color_sectors_no_go_note_2026-06-09": {
+   "deps_hash": "ff75ae4714de",
+   "out_degree": 6
+  },
+  "ew_kappa_self_energy_object_pin_mc_undecidable_no_go_note_2026-06-08": {
+   "deps_hash": "748eef87af1a",
+   "out_degree": 3
+  },
+  "ew_kappa_weighting_not_axiom_derivable_no_go_note_2026-06-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ew_lattice_cos_sq_theta_w_complement_bridge_theorem_note_2026-04-26": {
+   "deps_hash": "965c1cf20e09",
+   "out_degree": 10
+  },
+  "ewsb_electroweak_dependency_composition_note_2026-06-09": {
+   "deps_hash": "663a244e12ea",
+   "out_degree": 4
+  },
+  "ewsb_pattern_from_higgs_y_note_2026-05-02": {
+   "deps_hash": "1381121484ef",
+   "out_degree": 3
+  },
+  "exact_fixed_energy_schur_decimation_free_chain_form_migration_one_step_map_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "exact_qgen_metzler_violation_all_odd_n_closed_form_bounded_note_2026-07-02": {
+   "deps_hash": "a9cc5fcc7756",
+   "out_degree": 1
+  },
+  "exact_qgen_not_positive_on_zn_wrapped_gaussian_correction_bounded_note_2026-07-02": {
+   "deps_hash": "e13f2c3e8605",
+   "out_degree": 2
+  },
+  "exact_tier_ewitness_bounded_note_2026-05-07_ewitness": {
+   "deps_hash": "382ffbe3c6b3",
+   "out_degree": 7
+  },
+  "exact_tier_path_integral_bounded_note_2026-05-07_exact": {
+   "deps_hash": "ae423068470f",
+   "out_degree": 7
+  },
+  "exp_decay_lieb_robinson_quasilocal_bridge_theorem_note_2026-06-11": {
+   "deps_hash": "50107746920d",
+   "out_degree": 2
+  },
+  "experiment_backmatch_query_pack_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "exponent_derivation": {
+   "deps_hash": "5861e51d4c5d",
+   "out_degree": 1
+  },
+  "f_wedge_f_top_form_forces_d_four_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "family_companion_compare_note": {
+   "deps_hash": "d65483554fad",
+   "out_degree": 3
+  },
+  "fermion_parity_pauli_tensor_involution_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "fermion_parity_z2_grading_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "fermionic_gaussian_npoint_convergence_from_two_point_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "3ee45ca63ce0",
+   "out_degree": 3
+  },
+  "fiber_frame_local_redundancy_bridge_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "db743fbb1464",
+   "out_degree": 4
+  },
+  "field_equation_derivation_note": {
+   "deps_hash": "b9586de19b7c",
+   "out_degree": 1
+  },
+  "fierz_singlet_channel_selector_is_weight_not_partition_narrow_no_go_note_2026-06-08": {
+   "deps_hash": "42f7133f9c11",
+   "out_degree": 5
+  },
+  "fifth_family_complex_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "fifth_family_complex_note": {
+   "deps_hash": "f04592e1dfd3",
+   "out_degree": 2
+  },
+  "fifth_family_radial_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "fifth_family_radial_fm_transfer_note": {
+   "deps_hash": "83267bf9a199",
+   "out_degree": 2
+  },
+  "fifth_family_radial_note": {
+   "deps_hash": "fff62c3b7cb6",
+   "out_degree": 1
+  },
+  "fifth_family_radial_repaired_positive_packet_note_2026-05-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "fine_h_family_universality_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "finite_cell_two_band_closed_form_bounded_theorem_note_2026-06-13": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "finite_rank_gravity_residual_helper_note_2026-04-14": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "finite_rank_source_to_metric_theorem_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "first_order_coframe_unconditionality_no_go_theorem_note_2026-04-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "fixed_field_complex_grown_basin_v2_note": {
+   "deps_hash": "9b334c2c3616",
+   "out_degree": 1
+  },
+  "fixed_field_family_unification_note": {
+   "deps_hash": "fd8df6566a7e",
+   "out_degree": 2
+  },
+  "fixed_field_grown_transfer_scout_note": {
+   "deps_hash": "9b334c2c3616",
+   "out_degree": 1
+  },
+  "fixed_gbare_interacting_existence_ir_target_reframing_bounded_note_2026-06-08": {
+   "deps_hash": "11ba3f1e3f53",
+   "out_degree": 2
+  },
+  "fixed_lattice_gauge_existence_strong_coupling_scope_note_2026-06-09": {
+   "deps_hash": "469a8cc015b6",
+   "out_degree": 2
+  },
+  "flagship_paper_contribution_statement_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_a1prime_debt_and_data_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_absolute_handedness_is_gauge_relative_is_physical_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "42b225a6fa84",
+   "out_degree": 5
+  },
+  "flavor_asymmetry_2over9_forced_weight_2026-05-31": {
+   "deps_hash": "eaf4ec25bd1b",
+   "out_degree": 4
+  },
+  "flavor_asymmetry_identification_principled_not_forced_2026-05-31": {
+   "deps_hash": "49d6488583e1",
+   "out_degree": 3
+  },
+  "flavor_ba_ratio_bound_hs_equipartition_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_block_count_native_via_jcs_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_both_readings_charge_selects_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_carrier_delegation_terminus_local_blind_2026-05-31": {
+   "deps_hash": "391cb02ab103",
+   "out_degree": 2
+  },
+  "flavor_carrier_from_axioms_momentum_forced_2026-05-31": {
+   "deps_hash": "bc43d11ac1fc",
+   "out_degree": 4
+  },
+  "flavor_carrier_measure_scoring_discriminator_bounded_note_2026-07-02": {
+   "deps_hash": "d340fb9a7c90",
+   "out_degree": 5
+  },
+  "flavor_carrier_momentum_type_from_translation_theorem_note_2026-06-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_carrier_not_derived_two_inputs_2026-05-31": {
+   "deps_hash": "bb33eb7b48d3",
+   "out_degree": 1
+  },
+  "flavor_center_trace_closed_capstone_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_chirality_gate_narrows_to_one_spin_statistics_import_2026-05-31": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_det_character_selection_audit_ready_2026-06-04": {
+   "deps_hash": "9fd68c357beb",
+   "out_degree": 5
+  },
+  "flavor_detr_default_full_exercise_note_2026-05-30": {
+   "deps_hash": "0c0fbc15fc2e",
+   "out_degree": 2
+  },
+  "flavor_doublet_metric_default_is_detr_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_doublet_rotation_exhaustive_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_einselection_2sector_modulo_kreality_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_emergent_chirality_no_transport_note_2026-05-30": {
+   "deps_hash": "f795111b77d8",
+   "out_degree": 6
+  },
+  "flavor_equivariant_eta_complementarity_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_find_j_consolidation_kappa_is_the_input_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_find_j_round1_jcs_measure_neutral_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_find_j_round2_power_not_count_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_find_j_round3_dirac_generation_blind_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_find_j_round5_trace_vs_center_state_final_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_frontier_map_form_vs_value_note_2026-05-29": {
+   "deps_hash": "a8f8d026d6b7",
+   "out_degree": 11
+  },
+  "flavor_gauge_holonomy_character_suppression_kernel_narrow_theorem_note_2026-06-18": {
+   "deps_hash": "d62897410292",
+   "out_degree": 6
+  },
+  "flavor_gauge_holonomy_suppresses_r_below_leptonic_wrong_ordering_narrow_no_go_note_2026-06-15": {
+   "deps_hash": "0ea368cf8788",
+   "out_degree": 7
+  },
+  "flavor_gauge_representation_channel_cannot_source_the_sector_r_spread_narrow_no_go_note_2026-06-15": {
+   "deps_hash": "5aaf9d56b041",
+   "out_degree": 8
+  },
+  "flavor_gauge_representation_generation_uniform_core_narrow_theorem_note_2026-06-18": {
+   "deps_hash": "698bccb7c46b",
+   "out_degree": 5
+  },
+  "flavor_generation_space_bridge_reduces_to_open_gate_2026-05-31": {
+   "deps_hash": "bedccd29d028",
+   "out_degree": 1
+  },
+  "flavor_handedness_is_rk_even_time_arrow_insufficient_narrow_no_go_note_2026-06-08": {
+   "deps_hash": "6f5c8af9ce98",
+   "out_degree": 6
+  },
+  "flavor_hw1_staggered_projection_democratic_r0_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_hw_clifford_does_not_constrain_r_2026-06-02": {
+   "deps_hash": "c81168cc53d4",
+   "out_degree": 2
+  },
+  "flavor_idempotent_u1_collapses_note_2026-05-30": {
+   "deps_hash": "0cd2c80d7ca3",
+   "out_degree": 3
+  },
+  "flavor_interacting_matter_build_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_kreal_instrument_two_letter_phase_orthogonal_2026-06-02": {
+   "deps_hash": "bc3587b3f422",
+   "out_degree": 2
+  },
+  "flavor_lane_panel_reduces_to_doublet_mode_count_2026-05-31": {
+   "deps_hash": "06dc1094d889",
+   "out_degree": 2
+  },
+  "flavor_latitude_quantizer_and_rp_selfdual_note_2026-05-30": {
+   "deps_hash": "8fff5ac2d353",
+   "out_degree": 1
+  },
+  "flavor_logdet_factor_2_record_readout_realization_narrow_theorem_note_2026-06-04": {
+   "deps_hash": "281438f59ab4",
+   "out_degree": 3
+  },
+  "flavor_logdet_factor_4a_source_action_identification_narrow_companion_note_2026-06-04": {
+   "deps_hash": "42793913862e",
+   "out_degree": 3
+  },
+  "flavor_logdet_factor_4b_jacobi_derivative_narrow_theorem_note_2026-06-04": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_logdet_form_under_record_axiom_2026-06-04": {
+   "deps_hash": "ea79fe5356ae",
+   "out_degree": 3
+  },
+  "flavor_logdet_generator_three_factor_provenance_2026-06-04": {
+   "deps_hash": "928869d93091",
+   "out_degree": 4
+  },
+  "flavor_max_record_entropy_is_sector_blind_cannot_derive_the_koide_dial_narrow_no_go_note_2026-06-15": {
+   "deps_hash": "d02ad58fd100",
+   "out_degree": 6
+  },
+  "flavor_measure_positivity_agnostic_note_2026-05-31": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_missing_axiom_carrier_measure_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_native_action_predicts_q1_2026-06-02": {
+   "deps_hash": "c81168cc53d4",
+   "out_degree": 2
+  },
+  "flavor_native_beta_no_half_attractor_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_native_double_shift_corner_coupling_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_operator_realization_local_density_2026-05-31": {
+   "deps_hash": "a81013c6fb2e",
+   "out_degree": 5
+  },
+  "flavor_operator_spectral_functionals_do_not_force_r_half_no_go_note_2026-06-02": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "flavor_per_sector_orientation_is_gauge_cp_is_inter_sector_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "7fd6364dbdf7",
+   "out_degree": 3
+  },
+  "flavor_q1_default_rests_on_prr_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_qd_objectivity_fixes_basis_not_weight_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_qubit_berry_holonomy_probe_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_r_half_assumptions_audit_note_2026-05-30": {
+   "deps_hash": "0ec5469ceeeb",
+   "out_degree": 2
+  },
+  "flavor_r_half_is_a_stationary_point_not_forced_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_r_half_is_the_records_flow_separatrix_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_r_half_stable_under_thermalizing_arrow_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_readout_gate_equals_carrier_identification_2026-05-31": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_record_dynamics_sharpens_arrow_stabilizer_fails_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_record_readout_form_not_weight_2026-06-02": {
+   "deps_hash": "c81168cc53d4",
+   "out_degree": 2
+  },
+  "flavor_retention_law_is_a2plus_note_2026-05-31": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_so2_readout_false_binary_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_spin_statistics_forces_modulo_reconstruction_2026-05-31": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_split_the_brick_doublet_complex_structure_2026-06-04": {
+   "deps_hash": "6d9414c1296e",
+   "out_degree": 1
+  },
+  "flavor_substrate_bridge_fails_source_operator_asymmetry_note_2026-05-31": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_substrate_parent_separate_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_supplied_heat_kernel_arrow_r_half_stability_bounded_note_2026-06-04": {
+   "deps_hash": "d5b6a90e7aee",
+   "out_degree": 1
+  },
+  "flavor_trace_vs_center_dissolves_note_2026-05-30": {
+   "deps_hash": "23e6b282d1c4",
+   "out_degree": 1
+  },
+  "flavor_tracial_reference_does_not_select_q23_no_go_note_2026-06-02": {
+   "deps_hash": "0c0fbc15fc2e",
+   "out_degree": 2
+  },
+  "flavor_value_campaign_capstone_four_channel_2026-05-31": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "flavor_zdet_fermionic_statistics_admission_2026-06-04": {
+   "deps_hash": "304a2a71171b",
+   "out_degree": 3
+  },
+  "fm_transfer_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "formation_rate_law_class_reduction_bounded_note_2026-07-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "four_d_distance_width_probe_note": {
+   "deps_hash": "aa2226788d79",
+   "out_degree": 1
+  },
+  "four_hats_frame_connection_generator_stratification_non_reduction_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "fourth_axiom_rg_scale_dynamics_scoping_2026-06-05": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "fourth_family_complex_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "fourth_family_quadrant_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "fractional_charge_denominator_from_n_c_theorem_note_2026-04-24": {
+   "deps_hash": "73797a8ebc97",
+   "out_degree": 5
+  },
+  "fractional_instanton_action_core_from_topological_infrastructure_bounded_note_2026-06-18": {
+   "deps_hash": "d55b3b41051c",
+   "out_degree": 2
+  },
+  "fractional_instanton_dilute_gas_condensate_external_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "915b05f426fd",
+   "out_degree": 2
+  },
+  "framework_bare_alpha_ratio_assumed_input_identity_support_note_2026-04-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "free_bilinear_quasilocal_lr_bridge_theorem_note_2026-06-10": {
+   "deps_hash": "ff73545a1b2e",
+   "out_degree": 3
+  },
+  "free_dirac_antiparticle_mode_algebra_bounded_note_2026-05-30": {
+   "deps_hash": "e8681c65cc8f",
+   "out_degree": 1
+  },
+  "free_dirac_car_positive_energy_equal_time_anticommutator_support_bounded_note_2026-06-08": {
+   "deps_hash": "ff50bba2e409",
+   "out_degree": 1
+  },
+  "free_dirac_poincare_generators_essential_selfadjointness_bounded_note_2026-05-30": {
+   "deps_hash": "e71499077975",
+   "out_degree": 2
+  },
+  "free_dirac_poincare_representation_bounded_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "free_dirac_poincare_stone_differential_generator_coincidence_common_core_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "df81d1e90c93",
+   "out_degree": 4
+  },
+  "free_dirac_wigner_action_strong_continuity_bridge_note_2026-06-07": {
+   "deps_hash": "fd2bf8e140e4",
+   "out_degree": 1
+  },
+  "free_field_lattice_to_continuum_gaussian_measure_bounded_note_2026-05-30": {
+   "deps_hash": "e8681c65cc8f",
+   "out_degree": 1
+  },
+  "free_field_os_wightman_reconstruction_conditional_theorem_note_2026-05-30": {
+   "deps_hash": "7de771394821",
+   "out_degree": 6
+  },
+  "free_scalar_point_split_ward_seagull_diagnostic_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "free_sector_relativistic_qft_support_diagnostics_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "2a8973b607ba",
+   "out_degree": 5
+  },
+  "free_sector_spin_statistics_level1_mechanism_and_reconstruction_reduction_bounded_note_2026-05-30": {
+   "deps_hash": "d1d61e252dcd",
+   "out_degree": 6
+  },
+  "free_staggered_two_step_dispersion_d_dimensional_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "d1da2f9855ac",
+   "out_degree": 2
+  },
+  "frontier_extension_lane_b_protects_lane_a_joint_composition_narrow_note_2026-05-17": {
+   "deps_hash": "1229febd4144",
+   "out_degree": 5
+  },
+  "frontier_extension_lane_opening_note_2026-04-25": {
+   "deps_hash": "2810f22ffb83",
+   "out_degree": 14
+  },
+  "frozen_region_record_saturation_local_finality_boundary_influence_bounded_note_2026-07-03": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "frozen_stars_rigorous_note": {
+   "deps_hash": "77009fc61e1b",
+   "out_degree": 2
+  },
+  "frw_adiabatic_expansion_cosmological_backdrop_open_gate_note_2026-05-28": {
+   "deps_hash": "fa976edefe1c",
+   "out_degree": 3
+  },
+  "frw_c2_source_free_entropy_bookkeeping_bounded_support_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "frw_c3_eos_component_labels_kinetic_bridge_bounded_support_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "frw_c3_kinetic_component_perfect_fluid_lift_bounded_support_note_2026-06-18": {
+   "deps_hash": "89d3348c2833",
+   "out_degree": 2
+  },
+  "fs_forced_modulo_emergent_lorentz_stress_test_note_2026-06-06": {
+   "deps_hash": "6e52f80c81f9",
+   "out_degree": 6
+  },
+  "fs_reconstruction_r_and_tight_link_review_note_2026-06-06": {
+   "deps_hash": "5d5978c46442",
+   "out_degree": 3
+  },
+  "fs_rotation_exchange_discrete_insufficiency_narrow_no_go_note_2026-05-28": {
+   "deps_hash": "aa5fc0b380f0",
+   "out_degree": 2
+  },
+  "fs_rotation_exchange_discrete_insufficiency_record_axiom_invariance_companion_note_2026-06-04": {
+   "deps_hash": "23027abf39aa",
+   "out_degree": 3
+  },
+  "full_pl_s3_atlas_cocycle_closure_theorem_note_2026-05-03": {
+   "deps_hash": "3201cbadbd12",
+   "out_degree": 2
+  },
+  "full_y_squared_trace_su5_gut_note_2026-05-02": {
+   "deps_hash": "e58656e4f3f0",
+   "out_degree": 3
+  },
+  "g2_bridge_c3_current_cannot_beat_gap_a_no_go_note_2026-06-06": {
+   "deps_hash": "543afa7030df",
+   "out_degree": 7
+  },
+  "g3_cross_edge_independence_is_a_formation_gate_atom_marginal_identity_from_qualification_bounded_theorem_note_2026-07-12": {
+   "deps_hash": "37d59708175b",
+   "out_degree": 4
+  },
+  "g3_outcome_factorization_from_unraveled_step_law_narrow_no_go_note_2026-07-11": {
+   "deps_hash": "532b2551c382",
+   "out_degree": 7
+  },
+  "g_2_v_bounded_interval_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "89940830080b",
+   "out_degree": 6
+  },
+  "g_bare_c_iso_convention_orbit_invariance_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "b74b6905ba54",
+   "out_degree": 8
+  },
+  "g_bare_canonical_convention_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "9d21c7c99739",
+   "out_degree": 2
+  },
+  "g_bare_constraint_vs_convention_restatement_abstract_identity_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "g_bare_constraint_vs_convention_restatement_note_2026-05-07": {
+   "deps_hash": "30ca9151cebc",
+   "out_degree": 2
+  },
+  "g_bare_constraint_vs_convention_theorem_note_2026-05-03": {
+   "deps_hash": "535f58ed052b",
+   "out_degree": 2
+  },
+  "g_bare_derivation_note": {
+   "deps_hash": "5c7f7697e7c2",
+   "out_degree": 3
+  },
+  "g_bare_derivation_status_correction_audit_note_2026-05-02": {
+   "deps_hash": "f16855efe888",
+   "out_degree": 3
+  },
+  "g_bare_dynamical_fixation_obstruction_note_2026-04-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "g_bare_forced_by_ward_rep_b_independence_abstract_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "g_bare_forced_by_ward_rep_b_independence_record_axiom_invariance_companion_note_2026-06-04": {
+   "deps_hash": "8fe123f90956",
+   "out_degree": 6
+  },
+  "g_bare_forced_by_ward_rep_b_independence_theorem_note_2026-05-09": {
+   "deps_hash": "aaf75276fc86",
+   "out_degree": 3
+  },
+  "g_bare_forced_via_ward_substitution_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "2804873248ac",
+   "out_degree": 4
+  },
+  "g_bare_h_unit_same_projected_1pi_residue_exhaustion_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "2b9bae5b2112",
+   "out_degree": 5
+  },
+  "g_bare_hilbert_schmidt_rigidity_theorem_note_2026-05-07": {
+   "deps_hash": "b3abafe9a502",
+   "out_degree": 4
+  },
+  "g_bare_l3a_trace_surface_invariance_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "a67ccf3f44cc",
+   "out_degree": 7
+  },
+  "g_bare_l3b_overall_scalar_invariance_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "7ea3779ce65f",
+   "out_degree": 7
+  },
+  "g_bare_parent_finite_link_wilson_beta6_bridge_note_2026-06-18": {
+   "deps_hash": "aabdc59b5531",
+   "out_degree": 2
+  },
+  "g_bare_parent_promotion_gate_map_note_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "g_bare_rescaling_freedom_removal_theorem_note_2026-05-03": {
+   "deps_hash": "5e93d700a831",
+   "out_degree": 1
+  },
+  "g_bare_rigidity_canonical_normalization_algebra_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "8a9208a7c757",
+   "out_degree": 7
+  },
+  "g_bare_rigidity_theorem_note": {
+   "deps_hash": "2a9d6130ac3c",
+   "out_degree": 2
+  },
+  "g_bare_same_slot_beta6_convention_note_2026-07-11": {
+   "deps_hash": "4159db447266",
+   "out_degree": 1
+  },
+  "g_bare_structural_normalization_theorem_note_2026-04-18": {
+   "deps_hash": "e04e5de848e7",
+   "out_degree": 4
+  },
+  "g_bare_two_ward_closure_note_2026-04-18": {
+   "deps_hash": "bebdc7ae72dc",
+   "out_degree": 6
+  },
+  "g_bare_two_ward_h_unit_residue_accepted_premise_bridge_bounded_note_2026-05-26": {
+   "deps_hash": "b9361b9d8146",
+   "out_degree": 2
+  },
+  "g_bare_two_ward_h_unit_residue_dep_resolution_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "22a2199b3bea",
+   "out_degree": 4
+  },
+  "g_bare_two_ward_rep_b_independence_theorem_note_2026-04-19": {
+   "deps_hash": "4678b919e203",
+   "out_degree": 1
+  },
+  "g_bare_two_ward_same_1pi_pinning_theorem_note_2026-04-19": {
+   "deps_hash": "e04beba00aa4",
+   "out_degree": 3
+  },
+  "g_newton_born_as_source_positive_theorem_note_2026-05-10_gnewtong2": {
+   "deps_hash": "6da6064af24c",
+   "out_degree": 9
+  },
+  "g_newton_mass_linear_poisson_composition_bounded_theorem_note_2026-05-10": {
+   "deps_hash": "3e92b7c33f67",
+   "out_degree": 5
+  },
+  "g_newton_self_consistency_bounded_sharpening_note_2026-05-10_planckp4": {
+   "deps_hash": "4cc6af7e7e21",
+   "out_degree": 17
+  },
+  "g_newton_skeleton_selection_bounded_note_2026-05-10_gnewtong1": {
+   "deps_hash": "120bf85c17aa",
+   "out_degree": 9
+  },
+  "g_newton_weak_field_response_bounded_closure_note_2026-05-10_gnewtong3": {
+   "deps_hash": "348eeb5a799e",
+   "out_degree": 10
+  },
+  "g_star_sm_content_at_leptogenesis_from_supplied_thermal_inventory_bounded_theorem_note_2026-05-28": {
+   "deps_hash": "55f24355474d",
+   "out_degree": 11
+  },
+  "g_weak_from_framework_note_2026-05-03": {
+   "deps_hash": "2dd2c7516414",
+   "out_degree": 8
+  },
+  "gamma_full_vs_gamma_crit_decisive_nogo_note_2026-06-08": {
+   "deps_hash": "38233d1aca39",
+   "out_degree": 4
+  },
+  "gap_physics_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_complex_action_falsifier_note": {
+   "deps_hash": "bf83186f0efa",
+   "out_degree": 1
+  },
+  "gate_b_connectivity_tolerance_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_context_independence_no_go_note_2026-06-17": {
+   "deps_hash": "da7a9263442a",
+   "out_degree": 6
+  },
+  "gate_b_dynamics_note": {
+   "deps_hash": "0899be28d135",
+   "out_degree": 21
+  },
+  "gate_b_farfield_bounded_conditional_separator_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_farfield_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_finite_path_sum_propagation_bridge_bounded_theorem_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_finite_radial_scalar_bridge_bounded_theorem_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_grown_distance_law_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_grown_joint_package_note": {
+   "deps_hash": "f81d3dbabaff",
+   "out_degree": 2
+  },
+  "gate_b_grown_propagating_field_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_grown_propagating_field_radical_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_grown_propagating_field_v2_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_grown_propagating_field_v3_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_grown_trapping_frontier_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_grown_trapping_frontier_v2_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_grown_trapping_frontier_v3_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_grown_trapping_transport_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_grown_wavefield_companion_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_h025_distance_law_note": {
+   "deps_hash": "60577518e211",
+   "out_degree": 2
+  },
+  "gate_b_h025_farfield_note": {
+   "deps_hash": "d324a784b4e9",
+   "out_degree": 3
+  },
+  "gate_b_h025_joint_package_note": {
+   "deps_hash": "f81d3dbabaff",
+   "out_degree": 2
+  },
+  "gate_b_local_stencil_connectivity_bridge_bounded_theorem_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_no_restore_farfield_note": {
+   "deps_hash": "d324a784b4e9",
+   "out_degree": 3
+  },
+  "gate_b_no_restore_joint_package_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_nonlabel_connectivity_v1_distance_note": {
+   "deps_hash": "3699d5328373",
+   "out_degree": 2
+  },
+  "gate_b_nonlabel_connectivity_v1_h025_note": {
+   "deps_hash": "3699d5328373",
+   "out_degree": 2
+  },
+  "gate_b_nonlabel_connectivity_v1_joint_note": {
+   "deps_hash": "3699d5328373",
+   "out_degree": 2
+  },
+  "gate_b_nonlabel_connectivity_v1_note": {
+   "deps_hash": "6aef38c513ca",
+   "out_degree": 2
+  },
+  "gate_b_nonlabel_connectivity_v2_note": {
+   "deps_hash": "a1f4f0807456",
+   "out_degree": 3
+  },
+  "gate_b_nonlabel_connectivity_v3_note": {
+   "deps_hash": "a1f4f0807456",
+   "out_degree": 3
+  },
+  "gate_b_nonlabel_sign_grown_transfer_note": {
+   "deps_hash": "264fbb9bb486",
+   "out_degree": 1
+  },
+  "gate_b_operator_cauchy_note_2026-05-10": {
+   "deps_hash": "d4d6c211e3bb",
+   "out_degree": 2
+  },
+  "gate_b_poisson_self_gravity_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_strong_field_observable_split_note": {
+   "deps_hash": "810c3967a0fb",
+   "out_degree": 2
+  },
+  "gate_b_v6_nearfield_comparator_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gate_b_weak_connectivity_note": {
+   "deps_hash": "d324a784b4e9",
+   "out_degree": 3
+  },
+  "gate_b_weak_field_source_action_interface_note_2026-06-16": {
+   "deps_hash": "81a3250545dd",
+   "out_degree": 2
+  },
+  "gate_rp_reground_staggered_only_narrow_theorem_note_2026-05-23": {
+   "deps_hash": "05ba9b923cee",
+   "out_degree": 3
+  },
+  "gauge_algebra_supplied_carrier_gauging_selection_open_gate_note_2026-06-08": {
+   "deps_hash": "b2c856fc96e4",
+   "out_degree": 9
+  },
+  "gauge_center_sector_record_context_and_theta_q_character_grading_obstruction_bounded_theorem_note_2026-07-01": {
+   "deps_hash": "ac92544471f6",
+   "out_degree": 3
+  },
+  "gauge_factor_local_selector_normalizer_theorem_note_2026-06-18": {
+   "deps_hash": "349a245278a0",
+   "out_degree": 1
+  },
+  "gauge_factor_preservation_record_typed_selector_conditional_decomposition_bounded_theorem_note_2026-07-06": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "gauge_gauging_selection_conjugation_independence_no_go_note_2026-06-16": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "gauge_link_binary_registration_capacity_step_kernel_pin_theorem_note_2026-07-02": {
+   "deps_hash": "e925351a8aaf",
+   "out_degree": 5
+  },
+  "gauge_link_central_registration_induced_bi_invariant_step_kernel_theorem_note_2026-07-02": {
+   "deps_hash": "2b08d184c764",
+   "out_degree": 4
+  },
+  "gauge_link_per_record_step_rate_dial_unit_variance_point_theorem_note_2026-07-02": {
+   "deps_hash": "102e38a43a3e",
+   "out_degree": 5
+  },
+  "gauge_matter_closure_gates_2026-04-12": {
+   "deps_hash": "9ef489997f78",
+   "out_degree": 3
+  },
+  "gauge_multiplaquette_character_gluing_emergent_integer_sector_record_context_and_action_pairing_residual_bounded_theorem_note_2026-07-02": {
+   "deps_hash": "62da9519ca43",
+   "out_degree": 2
+  },
+  "gauge_os_step1_wilson_plaquette_decomposition_theta_invariance_reflection_hermiticity_narrow_theorem_note_2026-06-02": {
+   "deps_hash": "31a9fcc0e2a6",
+   "out_degree": 1
+  },
+  "gauge_scalar_bridge_3plus1_native_tube_staging_gate_2026-05-03": {
+   "deps_hash": "eea3000d5b55",
+   "out_degree": 7
+  },
+  "gauge_scalar_kz_beta6_reproduction_contract_firewall_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_scalar_kz_external_lift_gate_status_note_2026-06-06": {
+   "deps_hash": "95f59d008849",
+   "out_degree": 2
+  },
+  "gauge_scalar_kz_su3_beta6_convention_split_note_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_scalar_temporal_completion_theorem_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_scalar_temporal_observable_bridge_implicit_flow_theorem_note_2026-05-03": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_scalar_temporal_observable_bridge_no_go_theorem_note_2026-05-03": {
+   "deps_hash": "8ceca317e5bc",
+   "out_degree": 5
+  },
+  "gauge_scalar_temporal_observable_bridge_stretch_note_2026-05-02": {
+   "deps_hash": "7b96e108ce08",
+   "out_degree": 2
+  },
+  "gauge_sd_loop_equation_beta_coupled_plaquette_bracket_note_2026-07-10": {
+   "deps_hash": "fd4e6fe0c738",
+   "out_degree": 1
+  },
+  "gauge_temporal_gauge_mixed_kernel_spatial_link_factorization_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_adjacent_word_contraction_derived_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "2b851cbf714d",
+   "out_degree": 6
+  },
+  "gauge_vacuum_plaquette_adjacent_word_scorecard_freshness_companion_note_2026-06-16": {
+   "deps_hash": "32cc54365d56",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_beta6_evaluation_seam_reduction_science_only_note_2026-04-17": {
+   "deps_hash": "6e323eeac04e",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_beta6_evaluation_seam_reduction_science_only_note_2026-04-17_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_beta6_scalar_value_insufficiency_note_2026-04-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_bridge_support_note": {
+   "deps_hash": "f0976c9687f1",
+   "out_degree": 3
+  },
+  "gauge_vacuum_plaquette_compressed_rim_evaluation_theorem_note_2026-04-17": {
+   "deps_hash": "fb88ccad0068",
+   "out_degree": 3
+  },
+  "gauge_vacuum_plaquette_compressed_rim_functional_uniqueness_note_2026-04-17": {
+   "deps_hash": "c706e368cf84",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_compression_scope_rho_complete_interface_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "0fbd96fe1d22",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_conjugation_symmetric_retained_sampling_reduction_note_2026-04-17": {
+   "deps_hash": "28f64137458a",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_connected_hierarchy_theorem_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_constant_lift_obstruction_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_derived_word_chain_end_to_end_composition_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "d5844e83b103",
+   "out_degree": 17
+  },
+  "gauge_vacuum_plaquette_distinct_shell_exact_core_narrow_theorem_note_2026-05-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_distinct_shell_theorem_note": {
+   "deps_hash": "077bd521ba86",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_finite_tensor_word_packet_bounded_note_2026-05-10": {
+   "deps_hash": "f373aa01d4de",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_first_sector_completed_triple_current_transfer_family_boundary_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_first_sector_first_hankel_to_dm_boundary_note_2026-04-19": {
+   "deps_hash": "7846ee4cff5e",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_3plus1_full_packet_no_go_theorem_note_2026-04-20": {
+   "deps_hash": "7670d7f39541",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_3plus1_line_closure_endpoint_note_2026-04-20": {
+   "deps_hash": "9d2d9e517c12",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_3plus1_line_closure_endpoint_note_2026-04-20_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_3plus1_line_exact_solve_doublet_theorem_note_2026-04-20": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_3plus1_line_helper_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_3plus1_line_rho1_least_distortion_selector_theorem_note_2026-04-20": {
+   "deps_hash": "5601dd23b364",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_3plus1_line_rho1_orientation_theorem_note_2026-04-20": {
+   "deps_hash": "67f569a70690",
+   "out_degree": 3
+  },
+  "gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_3plus1_reduced_packet_complex_givens_selector_theorem_note_2026-04-20": {
+   "deps_hash": "1db42034474e",
+   "out_degree": 5
+  },
+  "gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_packet_theorem_note_2026-04-19": {
+   "deps_hash": "880a186186e7",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_principle_theorem_note_2026-04-19": {
+   "deps_hash": "1bde52ecde94",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_first_sector_rank_one_factorized_class_boundary_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_first_sector_tail_underdetermination_theorem_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_first_sector_truncated_environment_packet_note_2026-04-19": {
+   "deps_hash": "31ff2d96ebf6",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_first_sector_zero_extension_factorized_class_theorem_note_2026-04-19": {
+   "deps_hash": "e9f5b3a3511d",
+   "out_degree": 3
+  },
+  "gauge_vacuum_plaquette_first_symmetric_three_sample_current_stack_constraint_boundary_note_2026-04-17": {
+   "deps_hash": "2c468204a1cc",
+   "out_degree": 8
+  },
+  "gauge_vacuum_plaquette_first_symmetric_three_sample_exact_radical_reconstruction_map_note_2026-04-17": {
+   "deps_hash": "3ed70a70a8c9",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_first_symmetric_three_sample_minimal_positive_completion_note_2026-04-19": {
+   "deps_hash": "a756bad116f4",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_first_symmetric_three_sample_positive_cone_order_witness_note_2026-04-17": {
+   "deps_hash": "221d672fa38e",
+   "out_degree": 4
+  },
+  "gauge_vacuum_plaquette_first_symmetric_three_sample_reconstruction_note_2026-04-17": {
+   "deps_hash": "43e76557a466",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_first_three_sample_environment_evaluator_route_note_2026-04-17": {
+   "deps_hash": "949d24a1ebb8",
+   "out_degree": 6
+  },
+  "gauge_vacuum_plaquette_first_three_sample_local_wilson_partial_evaluation_note_2026-04-17": {
+   "deps_hash": "d06a7cc92125",
+   "out_degree": 4
+  },
+  "gauge_vacuum_plaquette_first_three_sample_local_wilson_retained_positive_cone_obstruction_note_2026-04-17": {
+   "deps_hash": "fac69a973fdb",
+   "out_degree": 3
+  },
+  "gauge_vacuum_plaquette_four_strip_parity_test_bounded_note_2026-06-12": {
+   "deps_hash": "925445eb97de",
+   "out_degree": 9
+  },
+  "gauge_vacuum_plaquette_framework_point_underdetermination_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_full_slice_rim_lift_integral_boundary_science_only_note_2026-04-17": {
+   "deps_hash": "c21cb86da8c4",
+   "out_degree": 5
+  },
+  "gauge_vacuum_plaquette_hf_identification_diagnostic_bounded_note_2026-06-12": {
+   "deps_hash": "416b5040092f",
+   "out_degree": 5
+  },
+  "gauge_vacuum_plaquette_hierarchy_obstruction_lemmas_bounded_note_2026-05-10": {
+   "deps_hash": "8b642437ba42",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_infinite_hierarchy_obstruction_note": {
+   "deps_hash": "2abec248e680",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_internal_link_contraction_derived_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "74f9d3a4e180",
+   "out_degree": 4
+  },
+  "gauge_vacuum_plaquette_local_environment_factorization_theorem_note": {
+   "deps_hash": "15d3df196608",
+   "out_degree": 3
+  },
+  "gauge_vacuum_plaquette_mixed_cumulant_audit_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_perron_jacobi_underdetermination_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_perron_reduction_theorem_note": {
+   "deps_hash": "df043884ff9b",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_readout_form_trace_vs_perron_bounded_note_2026-06-12": {
+   "deps_hash": "99e5e2ffc049",
+   "out_degree": 4
+  },
+  "gauge_vacuum_plaquette_reduction_existence_theorem_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_residual_environment_all_weight_convolution_identification_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "9ee847f70a56",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_residual_environment_finite_box_bounded_coefficient_narrow_note_2026-05-10": {
+   "deps_hash": "f373aa01d4de",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_residual_environment_finite_box_stripping_uniqueness_narrow_note_2026-05-17": {
+   "deps_hash": "6322b9cb7390",
+   "out_degree": 4
+  },
+  "gauge_vacuum_plaquette_residual_environment_identification_theorem_note": {
+   "deps_hash": "ee7d5b2406fd",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_retained_class_sampling_inversion_note_2026-04-17": {
+   "deps_hash": "25559e428299",
+   "out_degree": 3
+  },
+  "gauge_vacuum_plaquette_rho_pq6_wilson_environment_bounded_note_2026-05-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_rim_boundary_eta_env_constructed_readout_bounded_note_2026-06-12": {
+   "deps_hash": "fce16ebde8be",
+   "out_degree": 8
+  },
+  "gauge_vacuum_plaquette_rim_depth_ladder_deep_rim_limit_bounded_note_2026-06-12": {
+   "deps_hash": "17cd325a4fb0",
+   "out_degree": 11
+  },
+  "gauge_vacuum_plaquette_ring_five_slab_trend_bounded_note_2026-06-12": {
+   "deps_hash": "675f68144eeb",
+   "out_degree": 9
+  },
+  "gauge_vacuum_plaquette_ring_transverse_rho_ladder_bounded_note_2026-06-12": {
+   "deps_hash": "548ff3978ff4",
+   "out_degree": 9
+  },
+  "gauge_vacuum_plaquette_slab_window_coupling_derived_bounded_note_2026-06-12": {
+   "deps_hash": "de0eb80e1986",
+   "out_degree": 5
+  },
+  "gauge_vacuum_plaquette_source_sector_matrix_element_factorization_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_spatial_environment_character_measure_finite_box_convolution_realization_uniqueness_narrow_note_2026-05-17": {
+   "deps_hash": "ee17bb1f7f13",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_spatial_environment_character_measure_theorem_note": {
+   "deps_hash": "67184a23b734",
+   "out_degree": 3
+  },
+  "gauge_vacuum_plaquette_spatial_environment_tensor_transfer_one_word_packet_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_spatial_environment_tensor_transfer_theorem_note": {
+   "deps_hash": "98a000e8b661",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_spatial_environment_transfer_theorem_note": {
+   "deps_hash": "24a577dcf7aa",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_spatial_environment_transfer_underdetermination_note_2026-04-17": {
+   "deps_hash": "8016478836d2",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_spectral_measure_theorem_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_strip_word_deep_ladder_product_axis_bounded_note_2026-06-12": {
+   "deps_hash": "d20e6f83ce83",
+   "out_degree": 8
+  },
+  "gauge_vacuum_plaquette_su3_cg_library_window_displacement_bounded_note_2026-06-12": {
+   "deps_hash": "76bba2ead1d3",
+   "out_degree": 6
+  },
+  "gauge_vacuum_plaquette_su3_full_slice_product_fubini_factorization_note_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_susceptibility_flow_theorem_note": {
+   "deps_hash": "1584319856fe",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_symmetrized_window_displacement_bounded_note_2026-06-12": {
+   "deps_hash": "76bba2ead1d3",
+   "out_degree": 6
+  },
+  "gauge_vacuum_plaquette_tensor_transfer_perron_solve_note": {
+   "deps_hash": "df6bd58c52ff",
+   "out_degree": 7
+  },
+  "gauge_vacuum_plaquette_tensor_word_multiword_perron_ladder_bounded_note_2026-06-11": {
+   "deps_hash": "efe3f7cd7629",
+   "out_degree": 4
+  },
+  "gauge_vacuum_plaquette_tensor_word_perron_derived_rho_composed_readout_bounded_note_2026-06-11": {
+   "deps_hash": "f8529eacec7b",
+   "out_degree": 8
+  },
+  "gauge_vacuum_plaquette_three_strip_environment_rho_ladder_bounded_note_2026-06-12": {
+   "deps_hash": "925445eb97de",
+   "out_degree": 9
+  },
+  "gauge_vacuum_plaquette_transfer_operator_character_recurrence_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauge_vacuum_plaquette_trivial_slice_eigen_identity_lemma_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "1ca95fa2263b",
+   "out_degree": 7
+  },
+  "gauge_vacuum_plaquette_two_strip_environment_rho_composed_readout_bounded_note_2026-06-12": {
+   "deps_hash": "649daf2a6505",
+   "out_degree": 8
+  },
+  "gauge_vacuum_plaquette_u1_density_sign_alternation_narrow_note_2026-05-17": {
+   "deps_hash": "845ce1d0369d",
+   "out_degree": 1
+  },
+  "gauge_vacuum_plaquette_width_reduction_map_derived_coupled_lift_bounded_note_2026-06-12": {
+   "deps_hash": "52ba79d73110",
+   "out_degree": 7
+  },
+  "gauge_vacuum_plaquette_width_two_ladder_structural_lift_bounded_note_2026-06-12": {
+   "deps_hash": "1f5d80896270",
+   "out_degree": 11
+  },
+  "gauge_vacuum_plaquette_window_clebsch_insertion_displacement_bounded_note_2026-06-12": {
+   "deps_hash": "a82ef638659c",
+   "out_degree": 6
+  },
+  "gauge_vacuum_plaquette_window_intertwiner_basis_displacement_bounded_note_2026-06-12": {
+   "deps_hash": "a82ef638659c",
+   "out_degree": 6
+  },
+  "gauge_vacuum_plaquette_window_top_down_integral_displacement_bounded_note_2026-06-12": {
+   "deps_hash": "76bba2ead1d3",
+   "out_degree": 6
+  },
+  "gauge_vacuum_plaquette_windowed_bond_deep_limit_bounded_note_2026-06-12": {
+   "deps_hash": "5694b2320d1e",
+   "out_degree": 7
+  },
+  "gauge_vacuum_plaquette_word_count_all_k_remainder_certificate_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "6d17e594182f",
+   "out_degree": 3
+  },
+  "gauge_vacuum_plaquette_word_count_hilbert_metric_bracket_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "384121cb7241",
+   "out_degree": 5
+  },
+  "gauge_vacuum_plaquette_word_count_power_block_birkhoff_certificate_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "2b851cbf714d",
+   "out_degree": 6
+  },
+  "gauge_vacuum_plaquette_word_count_rescaled_tail_support_note_2026-06-18": {
+   "deps_hash": "7cf55d599c73",
+   "out_degree": 2
+  },
+  "gauge_vacuum_plaquette_word_count_rung_four_deep_rim_bounded_note_2026-06-12": {
+   "deps_hash": "2b851cbf714d",
+   "out_degree": 6
+  },
+  "gauge_vacuum_plaquette_word_count_theta_identification_two_term_asymptotic_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "189b1e38f5aa",
+   "out_degree": 5
+  },
+  "gauge_vacuum_plaquette_word_limit_box_mode_sweep_bounded_note_2026-06-12": {
+   "deps_hash": "6225554df431",
+   "out_degree": 2
+  },
+  "gauge_vacuum_three_sample_radical_reconstruction_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "3ed70a70a8c9",
+   "out_degree": 2
+  },
+  "gauge_wilson_isotropy_boundary_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "02309aacd379",
+   "out_degree": 3
+  },
+  "gauge_wilson_isotropy_boundary_note_2026-05-04": {
+   "deps_hash": "07b9805a48f3",
+   "out_degree": 3
+  },
+  "gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_note_2026-06-07": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gauged_log_transfer_quasilocality_combes_thomas_narrow_theorem_note_2026-06-13": {
+   "deps_hash": "b48fd9e48b4d",
+   "out_degree": 6
+  },
+  "gauged_schwinger_staggered_ed_engine_validation_note_2026-07-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gbare_root_su2_scale_transport_bridge_narrow_theorem_note_2026-06-17": {
+   "deps_hash": "84f25e085f27",
+   "out_degree": 3
+  },
+  "gbare_wilson_action_internal_proof_walk_bounded_note_2026-05-08": {
+   "deps_hash": "c1f22f60682c",
+   "out_degree": 7
+  },
+  "gellmann_completeness_theorem_note_2026-05-02": {
+   "deps_hash": "5e93d700a831",
+   "out_degree": 1
+  },
+  "generated_geometry_synthesis_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "generation_axiom_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "generation_corner_hf_vq_screened_poisson_bridge_narrow_theorem_note_2026-06-07": {
+   "deps_hash": "17a28d7fc265",
+   "out_degree": 4
+  },
+  "generation_degeneracy_minimal_symmetry_breaking_narrow_theorem_note_2026-05-23": {
+   "deps_hash": "c56425af35c7",
+   "out_degree": 2
+  },
+  "generation_dial_dynamics_stability_classifier_2026-06-05": {
+   "deps_hash": "fd76a3a7cc1a",
+   "out_degree": 5
+  },
+  "generation_dial_local_stability_grammar_2026-06-05": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "generation_koide_single_modulus_reduction_2026-06-05": {
+   "deps_hash": "8c5235092fcc",
+   "out_degree": 4
+  },
+  "generation_localization_momentum_corner_delta_ji_protected_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "0b407cd95b3f",
+   "out_degree": 5
+  },
+  "generation_moduli_selector_exact_constraints_bounded_note_2026-07-02": {
+   "deps_hash": "a62548993b1b",
+   "out_degree": 3
+  },
+  "generation_periodic_plane_wave_density_kernel_bridge_note_2026-06-07": {
+   "deps_hash": "8c8f27032276",
+   "out_degree": 1
+  },
+  "generation_prior_stability_2026-06-05": {
+   "deps_hash": "796a19ab55e8",
+   "out_degree": 6
+  },
+  "generation_record_arrow_measure_selector_2026-06-05": {
+   "deps_hash": "bf0f04825406",
+   "out_degree": 5
+  },
+  "generation_record_partition_selector_2026-06-05": {
+   "deps_hash": "e4cefcb1a10f",
+   "out_degree": 1
+  },
+  "generation_triplet_dimension_parity_no_faithful_z_narrow_no_go_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "generation_weight_dial_structure_2026-06-05": {
+   "deps_hash": "00712a62dd66",
+   "out_degree": 4
+  },
+  "geometry_lane_head_to_head_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "geometry_superposition_dag_ensemble_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gl_f_from_berezin_rp_reconstruction_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "33cd6133d912",
+   "out_degree": 8
+  },
+  "gl_f_identification_bridge_decomposition_narrow_theorem_note_2026-06-11": {
+   "deps_hash": "0070d267129e",
+   "out_degree": 6
+  },
+  "gl_f_multiloop_graded_net_cocycle_narrow_no_go_note_2026-06-10": {
+   "deps_hash": "359ac9c7210f",
+   "out_degree": 8
+  },
+  "gleason_on_qubit_lattice_projection_lattice_narrow_theorem_note_2026-05-20": {
+   "deps_hash": "5ffd0b7a9ae7",
+   "out_degree": 2
+  },
+  "global_coherence_held_out2_note": {
+   "deps_hash": "2516e07fc476",
+   "out_degree": 2
+  },
+  "global_coherence_off_scaffold_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "global_coherence_predictor_note": {
+   "deps_hash": "5866f1dfe858",
+   "out_degree": 1
+  },
+  "gluon_tree_level_masslessness_theorem_note_2026-05-02": {
+   "deps_hash": "52107b0c76f5",
+   "out_degree": 3
+  },
+  "gmn_vev_annihilator_l4_support_note_2026-07-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gr_class_expansion_finite_rank_target_note": {
+   "deps_hash": "7e244422e76c",
+   "out_degree": 2
+  },
+  "graded_constraint_interface_consistency_bounded_note_2026-07-04": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "graded_constraint_menu_uniformity_contextuality_and_c3_zero_information_point_bounded_theorem_note_2026-07-11": {
+   "deps_hash": "b7b561655f76",
+   "out_degree": 5
+  },
+  "graded_constraint_primitive_registration_proposal_2026-07-04": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "graded_constraint_program_and_record_influence_criterion_2026-07-04": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "grand_canonical_flux_response_nmod4_alternation_no_net_sign_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "44f0cf67c42e",
+   "out_degree": 1
+  },
+  "graph_braid_n3_fermion_sign_stays_nonfibered_narrow_theorem_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "graph_braid_z3_anyon_exclusion_dichotomy_dep_resolution_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "dda834ca882c",
+   "out_degree": 2
+  },
+  "graph_braid_z3_anyon_exclusion_dichotomy_narrow_theorem_note_2026-05-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "graph_dirac_requirements_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "graph_first_selector_derivation_note": {
+   "deps_hash": "790b6a424aff",
+   "out_degree": 1
+  },
+  "graph_first_su3_integration_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "graph_laplacian_core_card_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "graph_phase_diagram_scout_note": {
+   "deps_hash": "b97eac760781",
+   "out_degree": 3
+  },
+  "graph_scalar_plus_spinor_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "graph_true_kg_vs_cn_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "grav_decoherence_derived_note": {
+   "deps_hash": "31659b938cb3",
+   "out_degree": 5
+  },
+  "gravitational_entanglement_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gravitational_memory_note_2026-04-11": {
+   "deps_hash": "ec6d1e97ce7d",
+   "out_degree": 2
+  },
+  "gravitational_wave_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gravitomagnetic_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "graviton_mass_derived_note": {
+   "deps_hash": "b476ae8791aa",
+   "out_degree": 1
+  },
+  "graviton_mass_derived_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "graviton_mass_spectral_gap_identity_theorem_note": {
+   "deps_hash": "5043745f234d",
+   "out_degree": 9
+  },
+  "graviton_spectral_tower_theorem_note_2026-04-24": {
+   "deps_hash": "ca527d2f68e7",
+   "out_degree": 7
+  },
+  "gravity_attraction_sign_from_source_positivity_and_symmetric_mediator_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "81612f2545ff",
+   "out_degree": 4
+  },
+  "gravity_clean_derivation_note": {
+   "deps_hash": "fb3fc6fc86c8",
+   "out_degree": 7
+  },
+  "gravity_closure_from_weak_field_linear_response_bounded_theorem_note_2026-06-07": {
+   "deps_hash": "9ff1bd5c9c81",
+   "out_degree": 3
+  },
+  "gravity_conformal_scale_split_lensing_records_derived_shapiro_is_the_clock_rate_no_go_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "c571cc52f08d",
+   "out_degree": 4
+  },
+  "gravity_cosmology_tower_lambda_spectral_bridge_theorem_note_2026-04-25": {
+   "deps_hash": "99b5debc2a2b",
+   "out_degree": 4
+  },
+  "gravity_design_blueprint": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gravity_emergent_force_transverse_noncentrality_structure_theorem_note_2026-07-09": {
+   "deps_hash": "a232f5438d12",
+   "out_degree": 2
+  },
+  "gravity_fixed_energy_eikonal_index_bridge_bounded_theorem_note_2026-06-16": {
+   "deps_hash": "5cfc2f91f676",
+   "out_degree": 3
+  },
+  "gravity_full_self_consistency_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gravity_law_cleanup_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gravity_leading_lattice_correction_cubic_anisotropy_theorem_note_2026-06-07": {
+   "deps_hash": "34fbb7e54def",
+   "out_degree": 2
+  },
+  "gravity_observable_hierarchy_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gravity_premise4_refractive_index_from_dispersion_bounded_theorem_note_2026-06-07": {
+   "deps_hash": "c1ea1057a578",
+   "out_degree": 8
+  },
+  "gravity_reviewer_derivation_summary_2026-04-15": {
+   "deps_hash": "3da503e86140",
+   "out_degree": 23
+  },
+  "gravity_scalar_shift_sign_normalization_bounded_theorem_note_2026-06-18": {
+   "deps_hash": "066fb0c52929",
+   "out_degree": 1
+  },
+  "gravity_sign_audit_2026-04-10": {
+   "deps_hash": "7479f0c872ba",
+   "out_degree": 1
+  },
+  "gravity_sign_bottom_is_leading_order_decouples_from_lv_real_bottom_is_emergent_metric_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gravity_sign_from_reflection_positivity_unitarity_reduces_to_emergent_diffeomorphism_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "f9ebe3f59add",
+   "out_degree": 5
+  },
+  "gravity_sign_is_not_a_new_admission_reduces_to_shared_orientation_datum_kcpt_cannot_select_narrow_theorem_note_2026-06-18": {
+   "deps_hash": "15f569d761ca",
+   "out_degree": 9
+  },
+  "gravity_sign_is_one_residual_at_the_tt_kernel_block_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "feb6277bfbc1",
+   "out_degree": 4
+  },
+  "gravity_sign_not_forced_by_arrow_stability_or_spectral_routes_no_go_sharpening_note_2026-06-08": {
+   "deps_hash": "6f3d02462fe3",
+   "out_degree": 3
+  },
+  "gravity_signed_source_density_boundary_note": {
+   "deps_hash": "45e7d8732829",
+   "out_degree": 4
+  },
+  "gravity_signed_source_density_boundary_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gravity_weak_field_source_response_bridge_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "57d9425ce82c",
+   "out_degree": 5
+  },
+  "growing_graph_dynamic_limit_diagnostic_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "growing_graph_dynamic_propagation_replacement_note": {
+   "deps_hash": "909b13dea742",
+   "out_degree": 1
+  },
+  "growing_graph_expansion_card_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "growing_graph_expansion_skeptic_audit_note": {
+   "deps_hash": "8aafec851cd8",
+   "out_degree": 2
+  },
+  "growing_graph_frontier_architecture_transfer_note": {
+   "deps_hash": "8df6c8ca8f1e",
+   "out_degree": 8
+  },
+  "growing_graph_frontier_expansion_proxy_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "growing_graph_static_control_audit_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "grown_transfer_basin_note": {
+   "deps_hash": "b79010b3fea3",
+   "out_degree": 1
+  },
+  "grown_transfer_basin_targeted_repair_note_2026-06-04": {
+   "deps_hash": "bf83186f0efa",
+   "out_degree": 1
+  },
+  "grown_wavefield_companion_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "grown_wavefield_failure_diagnosis_note": {
+   "deps_hash": "687d9aae8f34",
+   "out_degree": 3
+  },
+  "gst_texture_reduces_to_rank1_c3_symmetric_mass_light_mass_from_breaking_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "a07e7d0678dc",
+   "out_degree": 1
+  },
+  "gstar_thermal_seven_eighths_stefan_boltzmann_bridge_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "4fef2c22d0ac",
+   "out_degree": 1
+  },
+  "guard_reconciliation_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "gw_echo_null_result_note": {
+   "deps_hash": "c8ec7ed0b735",
+   "out_degree": 1
+  },
+  "h0125_scalable_scout_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "h0125_wider_replay_note": {
+   "deps_hash": "cda610d1c5cb",
+   "out_degree": 1
+  },
+  "h0125_wider_w4_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "h0125_wider_w4_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "h2t_h0125_narrow_bridge_note": {
+   "deps_hash": "021d82dad0c8",
+   "out_degree": 1
+  },
+  "hadron_lane1_b2_dynamical_screening_boundary_note_2026-04-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hadron_lane1_chiral_condensate_banks_casher_scoping_support_note_2026-04-27": {
+   "deps_hash": "e8bad82ce647",
+   "out_degree": 5
+  },
+  "hadron_lane1_confinement_to_mass_firewall_note_2026-04-27": {
+   "deps_hash": "471de0197ab0",
+   "out_degree": 3
+  },
+  "hadron_lane1_confinement_to_mass_firewall_record_invariance_companion_note_2026-06-04": {
+   "deps_hash": "44383fff871e",
+   "out_degree": 2
+  },
+  "hadron_lane1_sqrt_sigma_b2_gate_repair_audit_note_2026-04-30": {
+   "deps_hash": "358a0db29179",
+   "out_degree": 4
+  },
+  "hadron_lane1_sqrt_sigma_b2_gate_repair_audit_note_2026-04-30_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hadron_lane1_sqrt_sigma_b2_static_energy_bridge_scout_note_2026-04-30": {
+   "deps_hash": "3ba724a0099a",
+   "out_degree": 5
+  },
+  "hadron_lane1_sqrt_sigma_b2_static_energy_bridge_scout_note_2026-04-30_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hadron_lane1_sqrt_sigma_b5_framework_link_audit_note_2026-04-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hadron_lane1_sqrt_sigma_b5_ladder_budget_note_2026-04-30": {
+   "deps_hash": "93d9f1287e5c",
+   "out_degree": 1
+  },
+  "hadron_lane1_sqrt_sigma_retention_gate_audit_support_note_2026-04-27": {
+   "deps_hash": "7ffdac3e5b0d",
+   "out_degree": 4
+  },
+  "hadron_mass_lane1_theorem_plan_support_note_2026-04-27": {
+   "deps_hash": "77133bbae7c7",
+   "out_degree": 7
+  },
+  "hadronic_charges_from_quark_y_note_2026-05-02": {
+   "deps_hash": "5bb6cdbbaa36",
+   "out_degree": 2
+  },
+  "half_plane_chart_equivalence_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hard_geometry_gravity_window_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hard_geometry_head_to_head_note": {
+   "deps_hash": "de22919e90a7",
+   "out_degree": 4
+  },
+  "hard_geometry_local_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "harmonic_depth_hankel_rank_mechanism_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "harmonic_depth_weight_distribution_mechanism_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "7cb30ff94823",
+   "out_degree": 3
+  },
+  "harmonic_ladder_origin_of_capture_deficit_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "340cd02b1d65",
+   "out_degree": 1
+  },
+  "harmonic_ladder_weight_law_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "heat_kernel_gauge_action_native_rp_plane_character_positivity_all_compact_groups_narrow_theorem_note_2026-07-09": {
+   "deps_hash": "88914ca80a6b",
+   "out_degree": 2
+  },
+  "heat_kernel_unique_diffusion_kernel_among_candidate_gauge_actions_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "7b79e2bc121e",
+   "out_degree": 3
+  },
+  "hermitian_lift_theta_h_pk_bounded_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "df15e3194fcf",
+   "out_degree": 2
+  },
+  "hierarchy_alpha_bare_four_pi_continuum_measure_content_attribution_bounded_note_2026-05-26": {
+   "deps_hash": "b39b65fdf5d4",
+   "out_degree": 7
+  },
+  "hierarchy_alpha_lm_dim_trans_reframing_bounded_notation_equivalence_note_2026-05-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hierarchy_alpha_lm_exponent_species_count_bridge_regulator_dependence_no_go_note_2026-05-10": {
+   "deps_hash": "2601eae9eb47",
+   "out_degree": 1
+  },
+  "hierarchy_alpha_lm_magnitude_delta0_open_gate_note_2026-05-30": {
+   "deps_hash": "1a7eccf39274",
+   "out_degree": 1
+  },
+  "hierarchy_aps_eta_staggered_bulk_vanishing_scoping_note_2026-05-26": {
+   "deps_hash": "67b1ffca4ace",
+   "out_degree": 2
+  },
+  "hierarchy_b3_staggered_supplier_cascade_note_2026-06-17": {
+   "deps_hash": "8fd1c7a19b36",
+   "out_degree": 5
+  },
+  "hierarchy_b4_determinant_only_factor_signature_no_go_note_2026-06-17": {
+   "deps_hash": "6c2377134507",
+   "out_degree": 2
+  },
+  "hierarchy_bbs_staggered_taste_blocking_bridge_kms_substrate_narrow_no_go_note_2026-05-15": {
+   "deps_hash": "d36a4ca92c4f",
+   "out_degree": 7
+  },
+  "hierarchy_bbs_staggered_taste_blocking_bridge_narrow_no_go_note_2026-05-10": {
+   "deps_hash": "b4a5f547536d",
+   "out_degree": 4
+  },
+  "hierarchy_bbs_staggered_taste_blocking_bridge_scaffold_availability_bounded_note_2026-05-11": {
+   "deps_hash": "bea9597bc1aa",
+   "out_degree": 5
+  },
+  "hierarchy_bosonic_bilinear_selector_note": {
+   "deps_hash": "856cbaa0dd0a",
+   "out_degree": 2
+  },
+  "hierarchy_d4_density_scale_readout_bridge_bounded_theorem_note_2026-06-16": {
+   "deps_hash": "332046aec1c0",
+   "out_degree": 1
+  },
+  "hierarchy_delta0_attachment_mean_field_feedback_probe_note_2026-06-11": {
+   "deps_hash": "32b32c29d368",
+   "out_degree": 5
+  },
+  "hierarchy_delta0_attachment_route_inventory_synthesis_note_2026-06-11": {
+   "deps_hash": "ae16e2553374",
+   "out_degree": 12
+  },
+  "hierarchy_delta0_b4_attachment_observable_enumeration_note_2026-06-11": {
+   "deps_hash": "7387ff2e46bc",
+   "out_degree": 10
+  },
+  "hierarchy_delta0_b4_current_bank_alpha_attachment_no_go_note_2026-06-18": {
+   "deps_hash": "583bd7288124",
+   "out_degree": 2
+  },
+  "hierarchy_delta0_b4_taste_transfer_ladder_theory_probe_note_2026-06-11": {
+   "deps_hash": "0651503eed00",
+   "out_degree": 12
+  },
+  "hierarchy_delta0_blocking_single_mode_decimation_probe_note_2026-06-11": {
+   "deps_hash": "2a08dc044471",
+   "out_degree": 6
+  },
+  "hierarchy_delta0_ratio_normalized_alpha_s_per_decoupling_reduction_note_2026-06-11": {
+   "deps_hash": "333d6f053960",
+   "out_degree": 6
+  },
+  "hierarchy_delta0_s1_exact_one_link_strong_coupling_probe_note_2026-06-11": {
+   "deps_hash": "ca3e276a4285",
+   "out_degree": 8
+  },
+  "hierarchy_delta0_s1prime_action_cost_decomposition_note_2026-06-11": {
+   "deps_hash": "49489b0f91e6",
+   "out_degree": 10
+  },
+  "hierarchy_delta0_s1prime_taste_region_kernel_share_probe_note_2026-06-11": {
+   "deps_hash": "9d07ddebda24",
+   "out_degree": 9
+  },
+  "hierarchy_delta0_s2_readout_dressing_leading_order_probe_note_2026-06-11": {
+   "deps_hash": "ebf4f16af867",
+   "out_degree": 8
+  },
+  "hierarchy_delta0_s3_fixed_gap_spectrum_no_go_note_2026-06-18": {
+   "deps_hash": "43817e409834",
+   "out_degree": 5
+  },
+  "hierarchy_dimensional_compression_audited_scope_narrow_bounded_note_2026-05-10": {
+   "deps_hash": "f3606d48207b",
+   "out_degree": 1
+  },
+  "hierarchy_dimensional_compression_note": {
+   "deps_hash": "e56071af304e",
+   "out_degree": 5
+  },
+  "hierarchy_dimensional_fourth_root_compression_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hierarchy_effective_potential_endpoint_note": {
+   "deps_hash": "e5da33577542",
+   "out_degree": 1
+  },
+  "hierarchy_ew_order_parameter_d4_density_readout_bridge_bounded_support_note_2026-06-18": {
+   "deps_hash": "fa28713ad572",
+   "out_degree": 2
+  },
+  "hierarchy_fixed_density_physical_selector_no_go_note_2026-06-18": {
+   "deps_hash": "5b327e8341ca",
+   "out_degree": 2
+  },
+  "hierarchy_formula_ew_vev_observable_identification_bridge_bounded_note_2026-05-26": {
+   "deps_hash": "eb8d653b1e73",
+   "out_degree": 9
+  },
+  "hierarchy_formula_honest_status_note_2026-05-10": {
+   "deps_hash": "6c18e639ebc6",
+   "out_degree": 6
+  },
+  "hierarchy_heat_kernel_d4_compression_bounded_theorem_note_2026-05-10": {
+   "deps_hash": "264cda678920",
+   "out_degree": 8
+  },
+  "hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hierarchy_koide_acphilambda_two_bit_decomposition_note_2026-06-06": {
+   "deps_hash": "45bb32faa79f",
+   "out_degree": 7
+  },
+  "hierarchy_lt4_klein_four_sin_squared_uniformity_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hierarchy_lt4_physical_selection_proof_walk_bounded_note_2026-05-10": {
+   "deps_hash": "c8bb04f5bd8e",
+   "out_degree": 7
+  },
+  "hierarchy_matsubara_decomposition_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hierarchy_matsubara_determinant_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "c811bc8baee6",
+   "out_degree": 1
+  },
+  "hierarchy_matsubara_determinant_ratio_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "31a1026460f6",
+   "out_degree": 8
+  },
+  "hierarchy_matsubara_free_energy_density_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "fa2212f9d8f4",
+   "out_degree": 2
+  },
+  "hierarchy_matsubara_quartic_coefficient_ratio_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "9219b8c73452",
+   "out_degree": 8
+  },
+  "hierarchy_meron_substrate_bridge_su2_su3_mismatch_narrow_no_go_note_2026-05-16": {
+   "deps_hash": "8f685ee32010",
+   "out_degree": 7
+  },
+  "hierarchy_seven_eighths_quarter_fermion_boson_scale_conversion_bridge_bounded_note_2026-05-26": {
+   "deps_hash": "d3f3b55c1c83",
+   "out_degree": 4
+  },
+  "hierarchy_seven_eighths_riemann_dirichlet_dimensional_anchor_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hierarchy_seven_eighths_twisted_thermal_zeta_period_quotient_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hierarchy_spatial_bc_and_u0_scaling_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hierarchy_value_frontier_probe_2026-06-05": {
+   "deps_hash": "043f7f48e7e1",
+   "out_degree": 6
+  },
+  "higgs_channel_effective_ntaste_boundary_bounded_note_2026-05-08": {
+   "deps_hash": "0bd5887186af",
+   "out_degree": 3
+  },
+  "higgs_classicality_boundary_operator_absence_no_go_note_2026-05-10": {
+   "deps_hash": "39d02f49e689",
+   "out_degree": 4
+  },
+  "higgs_from_lattice_note": {
+   "deps_hash": "d28b0423e5f4",
+   "out_degree": 2
+  },
+  "higgs_kappa_curv_from_vtaste_symmetric_point_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "22c7cb8b0507",
+   "out_degree": 4
+  },
+  "higgs_lambda_m_pl_bounded_interval_theorem_note_2026-05-10": {
+   "deps_hash": "e931030198c4",
+   "out_degree": 3
+  },
+  "higgs_lattice_eigenvalue_ratio_dep_resolution_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "83f1ad44005f",
+   "out_degree": 2
+  },
+  "higgs_lattice_eigenvalue_ratio_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "2769f51ecd4c",
+   "out_degree": 7
+  },
+  "higgs_lattice_taste_count_and_wj_form_bridge_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "78e0024c5feb",
+   "out_degree": 4
+  },
+  "higgs_mass_12pct_gap_decomposition_bounded_note_2026-05-10_higgss7": {
+   "deps_hash": "a469dd0b15c0",
+   "out_degree": 18
+  },
+  "higgs_mass_derived_note": {
+   "deps_hash": "8277fa90f62a",
+   "out_degree": 14
+  },
+  "higgs_mass_derived_note_2026-05-17": {
+   "deps_hash": "4fbc4ff44eb4",
+   "out_degree": 1
+  },
+  "higgs_mass_from_axiom_note": {
+   "deps_hash": "61fdc7fd3c74",
+   "out_degree": 3
+  },
+  "higgs_mass_from_axiom_status_correction_audit_note_2026-05-02": {
+   "deps_hash": "7bae1ac43512",
+   "out_degree": 3
+  },
+  "higgs_mass_hierarchy_correction_note": {
+   "deps_hash": "7daf43341c1b",
+   "out_degree": 2
+  },
+  "higgs_mass_retention_analysis_note_2026-04-18": {
+   "deps_hash": "df74a4873b3e",
+   "out_degree": 11
+  },
+  "higgs_mass_s4_born_extension_bounded_note_2026-05-10_higgss4": {
+   "deps_hash": "26b747fca1c5",
+   "out_degree": 12
+  },
+  "higgs_mass_s4b_ewsb_selection_bounded_note_2026-05-10_s4bewsb": {
+   "deps_hash": "1b276e1d4a2b",
+   "out_degree": 13
+  },
+  "higgs_mass_wilson_chain_partial_progress_note_2026-05-10_higgsh1": {
+   "deps_hash": "5009b0d301c1",
+   "out_degree": 8
+  },
+  "higgs_mass_wilson_loop_spectroscopy_bounded_note_2026-05-10_higgsh3": {
+   "deps_hash": "3f48d6429b21",
+   "out_degree": 8
+  },
+  "higgs_mean_field_determinant_apbc_taste_bridge_note_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "higgs_mechanism_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "higgs_taste_singlet_projection_bounded_note_2026-05-09": {
+   "deps_hash": "cab11f8e7b63",
+   "out_degree": 8
+  },
+  "higgs_vacuum_explicit_systematic_note": {
+   "deps_hash": "383b1aaaea7c",
+   "out_degree": 5
+  },
+  "higgs_vacuum_stability_new_physics_discrimination_note_2026-05-03": {
+   "deps_hash": "c5e75462f3c8",
+   "out_degree": 7
+  },
+  "higgs_x_s4b_combined_higgs_ewsb_g2_note_2026-05-08_probex_s4b_combined": {
+   "deps_hash": "3a54f29aee00",
+   "out_degree": 9
+  },
+  "higgs_y_from_lhcm_and_yukawa_structure_note_2026-05-02": {
+   "deps_hash": "a0c0dedd8840",
+   "out_degree": 1
+  },
+  "higgs_z3_charge_pmns_gauge_redundancy_theorem_note_2026-04-17": {
+   "deps_hash": "56d57800d2ce",
+   "out_degree": 2
+  },
+  "higher_dimension_status_2026-04-01": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "higher_order_structural_theorems_note": {
+   "deps_hash": "a525afe982f4",
+   "out_degree": 5
+  },
+  "higher_order_structural_theorems_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "higher_symmetry_gravity_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "higher_symmetry_joint_validation_note": {
+   "deps_hash": "da713f94f8ad",
+   "out_degree": 1
+  },
+  "hkd_correspondence_general_charts_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hkd_correspondence_structural_equivalence_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "hkd_entry_sum_full_l_closure_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "7faf41b30063",
+   "out_degree": 1
+  },
+  "hodge_star_middle_form_decomposition_forces_d_four_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "holographic_probe_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hopping_bilinear_hermiticity_theorem_note_2026-05-02": {
+   "deps_hash": "ec6690abc5b2",
+   "out_degree": 1
+  },
+  "hubble_lane5_c1_a1_grassmann_boundary_car_obstruction_note_2026-04-29": {
+   "deps_hash": "bfb6b322c84b",
+   "out_degree": 2
+  },
+  "hubble_lane5_c1_a1_grassmann_no_go_note_2026-04-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hubble_lane5_c1_a2_action_unit_metrology_obstruction_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "70b4d14232a7",
+   "out_degree": 4
+  },
+  "hubble_lane5_c1_a2_action_unit_metrology_obstruction_note_2026-04-29": {
+   "deps_hash": "eade02791e3c",
+   "out_degree": 3
+  },
+  "hubble_lane5_c1_a2_action_unit_no_go_note_2026-04-28": {
+   "deps_hash": "9e62e76a844f",
+   "out_degree": 6
+  },
+  "hubble_lane5_c1_a4_parity_gate_car_boundary_note_2026-04-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hubble_lane5_c1_a4_parity_gate_no_go_note_2026-04-28": {
+   "deps_hash": "7496b324d7c3",
+   "out_degree": 1
+  },
+  "hubble_lane5_c1_a4_parity_gate_no_go_note_hash_drift_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "75662035a784",
+   "out_degree": 3
+  },
+  "hubble_lane5_c1_a5_boolean_coframe_restriction_obstruction_note_2026-04-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hubble_lane5_c1_a6_bilinear_active_block_support_boundary_note_2026-04-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hubble_lane5_c1_carrier_metrology_axiom_audit_note_2026-04-29": {
+   "deps_hash": "b6c175f9a9ba",
+   "out_degree": 5
+  },
+  "hubble_lane5_c1_cl4c_conditional_derivation_chain_construction_note_2026-04-30": {
+   "deps_hash": "715bb2276c46",
+   "out_degree": 8
+  },
+  "hubble_lane5_c1_gate_residual_premise_attack_audit_note_2026-04-28": {
+   "deps_hash": "a79d4b038483",
+   "out_degree": 5
+  },
+  "hubble_lane5_c1_narrow_route_nogo_cluster_2026-04-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hubble_lane5_c2_attack_surface_bipartition_narrow_theorem_note_2026-05-27": {
+   "deps_hash": "dd4936188b89",
+   "out_degree": 10
+  },
+  "hubble_lane5_c2_ckm_pmns_right_sensitive_selector_stretch_note_2026-04-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hubble_lane5_c3_vacuum_topology_no_active_route_note_2026-04-27": {
+   "deps_hash": "e5d00188b8cb",
+   "out_degree": 7
+  },
+  "hubble_lane5_cosmic_history_ratio_necessity_no_go_note_2026-04-26": {
+   "deps_hash": "b1c63d46455d",
+   "out_degree": 9
+  },
+  "hubble_lane5_eta_retirement_gate_audit_note_2026-04-26": {
+   "deps_hash": "6634cb430ac6",
+   "out_degree": 7
+  },
+  "hubble_lane5_planck_c1_gate_audit_note_2026-04-26": {
+   "deps_hash": "08be5fc79f21",
+   "out_degree": 7
+  },
+  "hubble_lane5_two_gate_dependency_firewall_criticality_bump_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "c1b64ce4d62b",
+   "out_degree": 2
+  },
+  "hubble_lane5_two_gate_dependency_firewall_note_2026-04-27": {
+   "deps_hash": "3570ecc97f22",
+   "out_degree": 6
+  },
+  "hubble_lane5_workstream_status_note_2026-04-27": {
+   "deps_hash": "ca352916f1b7",
+   "out_degree": 5
+  },
+  "hubble_tension_structural_lock_theorem_note_2026-04-26": {
+   "deps_hash": "6dfacbc3ab12",
+   "out_degree": 7
+  },
+  "hunit_to_ewsb_doublet_representation_no_go_note_2026-06-15": {
+   "deps_hash": "b24b92fc8116",
+   "out_degree": 2
+  },
+  "hw1_second_order_return_shape_theorem_note": {
+   "deps_hash": "bf0746ad8fcc",
+   "out_degree": 2
+  },
+  "hw_complement_equivalence_extends_to_free_corner_transfer_dynamics_bounded_note_2026-06-12": {
+   "deps_hash": "46111474d8b7",
+   "out_degree": 3
+  },
+  "hydrogen_helium_atomic_lattice_kinetic_dependency_narrow_repair_note_2026-06-02": {
+   "deps_hash": "e8e0cb837a09",
+   "out_degree": 3
+  },
+  "hypercharge_alpha_third_normalization_bridge_bounded_note_2026-05-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "hypercharge_gut_normalization_three_fifths_accepted_premise_bridge_bounded_note_2026-07-10": {
+   "deps_hash": "042e95908eff",
+   "out_degree": 1
+  },
+  "hypercharge_identification_note": {
+   "deps_hash": "086b96ea7cb9",
+   "out_degree": 2
+  },
+  "hypercharge_proof_walk_lattice_independence_bounded_note_2026-05-07": {
+   "deps_hash": "1f0baba37f47",
+   "out_degree": 5
+  },
+  "hypercharge_quark_lepton_naming_convention_note_2026-07-11": {
+   "deps_hash": "042e95908eff",
+   "out_degree": 1
+  },
+  "hypercharge_squared_trace_catalog_theorem_note_2026-04-25": {
+   "deps_hash": "16909cbf4673",
+   "out_degree": 9
+  },
+  "hypercharge_traceless_central_direction_requires_multi_summand_supplied_structure_bounded_theorem_note_2026-07-06": {
+   "deps_hash": "206d91e7b69d",
+   "out_degree": 3
+  },
+  "i1_native_quadratic_static_source_normalization_bridge_2026-06-08": {
+   "deps_hash": "1315eadecbad",
+   "out_degree": 2
+  },
+  "i1_static_readout_is_native_field_integration_2026-06-06": {
+   "deps_hash": "f2eb78f2742a",
+   "out_degree": 8
+  },
+  "i3_zero_exact_theorem_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "impact_parameter_lensing_note": {
+   "deps_hash": "bbfa07daa875",
+   "out_degree": 2
+  },
+  "impact_parameter_portability_extension_note": {
+   "deps_hash": "e3805841ed7b",
+   "out_degree": 3
+  },
+  "impact_parameter_portability_note": {
+   "deps_hash": "cbcde598c269",
+   "out_degree": 2
+  },
+  "independent_generators_heldout_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "index_pairing_not_forced_kinetic_order_selector_no_go_note_2026-06-08": {
+   "deps_hash": "12943db56496",
+   "out_degree": 5
+  },
+  "induced_composite_link_trajectory_covariance_increment_law_non_autonomy_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "5834d8aaae83",
+   "out_degree": 7
+  },
+  "induced_holonomy_matter_state_functional_derived_curvature_trajectory_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "1d1e75efa06d",
+   "out_degree": 9
+  },
+  "industrial_sdp_bootstrap_infrastructure_note_2026-05-03": {
+   "deps_hash": "808c1ccb6109",
+   "out_degree": 1
+  },
+  "industrial_sdp_bootstrap_lattice_bracket_note_2026-05-03": {
+   "deps_hash": "7f4a7c2d3319",
+   "out_degree": 3
+  },
+  "inertial_closure_width_independent_acceleration_two_step_surface_bounded_theorem_note_2026-07-08": {
+   "deps_hash": "cc15ea2aa286",
+   "out_degree": 2
+  },
+  "informative_fraction_covariant_rule_quantization_occupancy_residual_theorem_note_2026-07-02": {
+   "deps_hash": "aca74ece52da",
+   "out_degree": 3
+  },
+  "inner_automorphism_invariance_tracial_identification_narrow_theorem_note_2026-05-20": {
+   "deps_hash": "13a354b49fb5",
+   "out_degree": 2
+  },
+  "instanton_4d_action_8pi2_over_g2_external_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "4af4136b6493",
+   "out_degree": 1
+  },
+  "interacting_rp_fixed_a_u_integrated_bridge_bounded_note_2026-06-05": {
+   "deps_hash": "1700fe450277",
+   "out_degree": 5
+  },
+  "interacting_rp_full_algebra_fixed_a_gauge_invariant_four_fermion_bounded_note_2026-06-05": {
+   "deps_hash": "be0927d9f892",
+   "out_degree": 6
+  },
+  "interacting_transfer_matter_gap_and_gauge_reduction_bounded_note_2026-05-30": {
+   "deps_hash": "15c0b6db762b",
+   "out_degree": 4
+  },
+  "interaction_asymmetry_delta_occupation_curvature_two_body_structure_theorem_note_2026-06-06": {
+   "deps_hash": "f69e82f02399",
+   "out_degree": 4
+  },
+  "interest_map": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "interleaved_mean_map_peripheral_count_collapse_almost_periodicity_removal_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "60590c9ef389",
+   "out_degree": 10
+  },
+  "internal_external_su2_merger_from_universal_property_narrow_theorem_note_2026-05-27": {
+   "deps_hash": "bb3557352742",
+   "out_degree": 5
+  },
+  "internal_external_su2_merger_record_invariance_companion_note_2026-06-04": {
+   "deps_hash": "75cc1b6116cd",
+   "out_degree": 2
+  },
+  "inverse_problem_graph_requirements_note": {
+   "deps_hash": "2cb75aeac319",
+   "out_degree": 3
+  },
+  "inverse_problem_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "irregular_directional_observable_note_2026-04-11": {
+   "deps_hash": "07682cd2364f",
+   "out_degree": 2
+  },
+  "irregular_sign_core_packet_gate_note": {
+   "deps_hash": "9679402e3cd2",
+   "out_degree": 2
+  },
+  "k_dependence_review_safe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "kcpt_coupling_triple_two_presentation_derivable_class_spectral_pairing_bounded_theorem_note_2026-07-16": {
+   "deps_hash": "2e8f0e7f8554",
+   "out_degree": 5
+  },
+  "kcpt_orbit_clause_kinvariant_surface_equivalence_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "ddf6440cc1c2",
+   "out_degree": 3
+  },
+  "kcpt_orbit_constancy_and_determinant_character_boundary_supplied_context_bridge_note_2026-07-04": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "kcpt_orbit_constant_registered_occupancy_weights_derivable_protocol_class_bounded_theorem_note_2026-07-12": {
+   "deps_hash": "a130e116ecf1",
+   "out_degree": 5
+  },
+  "kcpt_orbit_count_is_the_partition_not_the_weight_holomorphic_readout_measure_neutral_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "5e400429bb58",
+   "out_degree": 4
+  },
+  "key_terminology": {
+   "deps_hash": "5832e77696fd",
+   "out_degree": 1
+  },
+  "kinetic_bw_os0_identification_bridge_interface_no_go_note_2026-06-16": {
+   "deps_hash": "9e6d73d5bd5d",
+   "out_degree": 3
+  },
+  "kinetic_isotropy_3d_factorized_protocol_selection_on_analyzed_classes_bounded_theorem_note_2026-07-09": {
+   "deps_hash": "c5c011b474b7",
+   "out_degree": 4
+  },
+  "kinetic_isotropy_3d_simultaneous_tick_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "b4d9febcd879",
+   "out_degree": 5
+  },
+  "kinetic_isotropy_b4_transitivity_route_no_go_2026-06-20": {
+   "deps_hash": "68556cc803ef",
+   "out_degree": 4
+  },
+  "kinetic_isotropy_composition_closure_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "cea993a4d191",
+   "out_degree": 6
+  },
+  "kinetic_isotropy_from_strict_license_chiral_quantization_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "8890637b6557",
+   "out_degree": 11
+  },
+  "kinetic_isotropy_primitive": {
+   "deps_hash": "423d9f11232c",
+   "out_degree": 2
+  },
+  "kinetic_isotropy_primitive_irreducibility_support_2026-06-09": {
+   "deps_hash": "2209bbf2a4f4",
+   "out_degree": 6
+  },
+  "klein_four_product_bz_corners_forces_d_four_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "kms_fermionic_brydges_majorant_external_narrow_theorem_note_2026-05-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_a1_11_probe_campaign_bounded_admission_meta_note_2026-05-08": {
+   "deps_hash": "9db4e46839a2",
+   "out_degree": 17
+  },
+  "koide_a1_brannen_plancherel_identity_support_note_2026-04-25": {
+   "deps_hash": "9adb10d4c224",
+   "out_degree": 8
+  },
+  "koide_a1_closure_recommendation_2026-04-22": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_a1_derivation_status_note": {
+   "deps_hash": "64ae3f1525f8",
+   "out_degree": 14
+  },
+  "koide_a1_derivation_status_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_a1_fractional_topology_no_go_synthesis_note_2026-04-24": {
+   "deps_hash": "0e2bf5596b01",
+   "out_degree": 4
+  },
+  "koide_a1_loop_final_status_2026-04-22": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_a1_loop_investigation_summary": {
+   "deps_hash": "41213b20bad9",
+   "out_degree": 6
+  },
+  "koide_a1_o13_cheeger_simons_rz_no_go_note_2026-04-24": {
+   "deps_hash": "dae75b6e809a",
+   "out_degree": 3
+  },
+  "koide_a1_physical_bridge_attempt_2026-04-22": {
+   "deps_hash": "23b40575e1d2",
+   "out_degree": 4
+  },
+  "koide_a1_probe_continuum_limit_bounded_obstruction_note_2026-05-09_probe15": {
+   "deps_hash": "34ea77df6bad",
+   "out_degree": 25
+  },
+  "koide_a1_probe_flavor_anomaly_bounded_obstruction_note_2026-05-08_probe2": {
+   "deps_hash": "c42a6c198980",
+   "out_degree": 12
+  },
+  "koide_a1_probe_gravity_phase_bounded_obstruction_note_2026-05-08_probe3": {
+   "deps_hash": "847888b4aa23",
+   "out_degree": 25
+  },
+  "koide_a1_probe_lattice_non_conjugation_bounded_obstruction_note_2026-05-09_probe17": {
+   "deps_hash": "925674d9e9c6",
+   "out_degree": 15
+  },
+  "koide_a1_probe_operator_class_bounded_note_2026-05-08_probe6": {
+   "deps_hash": "a8370eb28ff6",
+   "out_degree": 14
+  },
+  "koide_a1_probe_plancherel_peter_weyl_bounded_obstruction_note_2026-05-09_probe12": {
+   "deps_hash": "b9b76e9f720c",
+   "out_degree": 12
+  },
+  "koide_a1_probe_q_readout_functional_bounded_obstruction_note_2026-05-09_probe16": {
+   "deps_hash": "be08af854efa",
+   "out_degree": 17
+  },
+  "koide_a1_probe_real_structure_bounded_obstruction_note_2026-05-09_probe13": {
+   "deps_hash": "d2db139cdd2e",
+   "out_degree": 17
+  },
+  "koide_a1_probe_retained_u1_hunt_bounded_obstruction_note_2026-05-09_probe14": {
+   "deps_hash": "31e12d90c4b4",
+   "out_degree": 9
+  },
+  "koide_a1_probe_rg_fixed_point_bounded_obstruction_note_2026-05-08_probe5": {
+   "deps_hash": "d97b7cdff2ab",
+   "out_degree": 14
+  },
+  "koide_a1_probe_rp_frobenius_bounded_obstruction_note_2026-05-08_probe1": {
+   "deps_hash": "0601c1a44bd6",
+   "out_degree": 13
+  },
+  "koide_a1_probe_spectral_action_bounded_obstruction_note_2026-05-08_probe4": {
+   "deps_hash": "143215737f60",
+   "out_degree": 10
+  },
+  "koide_a1_probe_z2_c3_pairing_bounded_obstruction_note_2026-05-08_probe7": {
+   "deps_hash": "def3ab627a3a",
+   "out_degree": 13
+  },
+  "koide_a1_radian_bridge_irreducibility_audit_note_2026-04-24": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_a1_route_a_koide_nishiura_bounded_obstruction_note_2026-05-08_routea": {
+   "deps_hash": "f39a0561644b",
+   "out_degree": 14
+  },
+  "koide_a1_route_d_newton_girard_bounded_obstruction_note_2026-05-08_routed": {
+   "deps_hash": "9ba6e7b7762d",
+   "out_degree": 17
+  },
+  "koide_a1_route_e_kostant_weyl_bounded_obstruction_note_2026-05-08_routee": {
+   "deps_hash": "7b3be8e958df",
+   "out_degree": 14
+  },
+  "koide_a1_route_f_casimir_difference_bounded_obstruction_note_2026-05-08_routef": {
+   "deps_hash": "c9551a95bcaf",
+   "out_degree": 12
+  },
+  "koide_adjoint_map_quotients_spinor_z2_narrow_no_go_note_2026-06-02": {
+   "deps_hash": "53574622f097",
+   "out_degree": 7
+  },
+  "koide_amplitude_phase_independent_data_narrow_no_go_note_2026-06-04": {
+   "deps_hash": "e6094ebabb59",
+   "out_degree": 6
+  },
+  "koide_anticommuting_eigenvector_vs_eigenvalue_readout_reconciliation_note_2026-06-01": {
+   "deps_hash": "c0241ae1a09f",
+   "out_degree": 2
+  },
+  "koide_anticommuting_operator_derivation_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_aps_block_by_block_forcing_note_2026-04-21": {
+   "deps_hash": "75af2612a46b",
+   "out_degree": 3
+  },
+  "koide_aps_c3_fixed_locus_weights_bridge_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "koide_aps_eta_topological_robustness_bounded_theorem_note_2026-07-02": {
+   "deps_hash": "441528e96f6f",
+   "out_degree": 2
+  },
+  "koide_axiom_native_support_batch_note_2026-04-22": {
+   "deps_hash": "cc92e72a1114",
+   "out_degree": 2
+  },
+  "koide_bae_30_probe_campaign_note_2026-05-09": {
+   "deps_hash": "87b205fa9c18",
+   "out_degree": 2
+  },
+  "koide_bae_probe_cl3_bivector_bounded_obstruction_note_2026-05-17_probecl3bivector": {
+   "deps_hash": "e553f9c50dee",
+   "out_degree": 11
+  },
+  "koide_bae_probe_f1_canonical_functional_bounded_obstruction_note_2026-05-09_probe18": {
+   "deps_hash": "3f33cbdb0d48",
+   "out_degree": 17
+  },
+  "koide_bae_probe_hw_sector_identification_bounded_obstruction_note_2026-05-09_probe27": {
+   "deps_hash": "a6e12d145538",
+   "out_degree": 12
+  },
+  "koide_bae_probe_interacting_dynamics_bounded_obstruction_note_2026-05-09_probe28": {
+   "deps_hash": "3c322870f69b",
+   "out_degree": 23
+  },
+  "koide_bae_probe_kappa_prediction_test_partial_falsification_note_2026-05-09_probe29": {
+   "deps_hash": "a2e74374b42f",
+   "out_degree": 23
+  },
+  "koide_bae_probe_lepton_triplet_c3_cycle_bounded_note_2026-05-09_probe23": {
+   "deps_hash": "df28b11e8041",
+   "out_degree": 16
+  },
+  "koide_bae_probe_native_lattice_flow_bounded_obstruction_note_2026-05-09_probe21": {
+   "deps_hash": "6dc73b703bee",
+   "out_degree": 10
+  },
+  "koide_bae_probe_phi_from_z3_character_note_2026-05-09_probe24": {
+   "deps_hash": "0cef9cf14e7e",
+   "out_degree": 9
+  },
+  "koide_bae_probe_physical_extremization_bounded_obstruction_note_2026-05-09_probe25": {
+   "deps_hash": "8234ae3729b5",
+   "out_degree": 21
+  },
+  "koide_bae_probe_radian_from_dimensions_bounded_note_2026-05-09_probe30": {
+   "deps_hash": "7ea380e657aa",
+   "out_degree": 11
+  },
+  "koide_bae_probe_spectrum_cone_bounded_obstruction_note_2026-05-09_probe22": {
+   "deps_hash": "92d83109e1f1",
+   "out_degree": 14
+  },
+  "koide_bae_probe_vm_cubic_extrema_bounded_obstruction_note_2026-05-09_probe20": {
+   "deps_hash": "492dd02f59e0",
+   "out_degree": 9
+  },
+  "koide_bae_probe_wilson_chain_mass_note_2026-05-09_probe19": {
+   "deps_hash": "e2e3eee24a4a",
+   "out_degree": 11
+  },
+  "koide_bae_probe_wilson_dimensional_consistency_bounded_note_2026-05-09_probe26": {
+   "deps_hash": "033a7e226439",
+   "out_degree": 7
+  },
+  "koide_berezin_detc_vs_detr_fork_mechanism_note_2026-06-04": {
+   "deps_hash": "992e15af19b8",
+   "out_degree": 2
+  },
+  "koide_berry_bundle_obstruction_theorem_note_2026-04-19": {
+   "deps_hash": "f690f5e142e0",
+   "out_degree": 1
+  },
+  "koide_berry_monopole_bridge_reduction_note_2026-05-31": {
+   "deps_hash": "9631d6a61af0",
+   "out_degree": 6
+  },
+  "koide_berry_phase_theorem_note_2026-04-19": {
+   "deps_hash": "2af86ee9e43b",
+   "out_degree": 3
+  },
+  "koide_brannen_callan_harvey_candidate_note_2026-04-22": {
+   "deps_hash": "3dc34f2d1404",
+   "out_degree": 3
+  },
+  "koide_brannen_callan_harvey_candidate_note_2026-04-22_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_brannen_geometry_dirac_support_note_2026-04-22": {
+   "deps_hash": "964cb7082a3a",
+   "out_degree": 3
+  },
+  "koide_brannen_phase_reduction_theorem_note_2026-04-20": {
+   "deps_hash": "97e5bb1bc515",
+   "out_degree": 1
+  },
+  "koide_brannen_phase_reduction_theorem_note_2026-04-20_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_c3_constant_singlet_reparameterization_theorem_note_2026-04-20": {
+   "deps_hash": "6c099f00e5d2",
+   "out_degree": 3
+  },
+  "koide_c3_generator_rephasing_obstruction_narrow_theorem_note_2026-05-29": {
+   "deps_hash": "7d702f859bcd",
+   "out_degree": 2
+  },
+  "koide_c3_singlet_extension_reduction_theorem_note_2026-04-20": {
+   "deps_hash": "c19e8c3a8067",
+   "out_degree": 4
+  },
+  "koide_carrier_locus_decomposition_note_2026-06-01": {
+   "deps_hash": "2804743f3cf6",
+   "out_degree": 8
+  },
+  "koide_carrier_scoring_needs_nontrivial_modular_note_2026-06-02": {
+   "deps_hash": "37bf94df64c0",
+   "out_degree": 7
+  },
+  "koide_circulant_character_bridge_narrow_theorem_note_2026-05-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_circulant_character_bridge_note_2026-04-18": {
+   "deps_hash": "d155890463d9",
+   "out_degree": 2
+  },
+  "koide_circulant_character_derivation_note_2026-04-18": {
+   "deps_hash": "5c6132469757",
+   "out_degree": 12
+  },
+  "koide_circulant_q_two_thirds_algebraic_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_circulant_value_derivation_2026-06-05": {
+   "deps_hash": "cd272fe606ea",
+   "out_degree": 3
+  },
+  "koide_circulant_wilson_target_note_2026-04-18": {
+   "deps_hash": "01dd5cb3aa89",
+   "out_degree": 3
+  },
+  "koide_cl3_selector_gap_note_2026-04-19": {
+   "deps_hash": "fb46a1dfc4bd",
+   "out_degree": 1
+  },
+  "koide_closure_atlas_issues_flagged": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_cone_completing_root_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_cone_three_form_equivalence_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_convention_invariant_scalar_selector_doublet_constancy_narrow_theorem_note_2026-07-12": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "koide_cyclic_projector_block_democracy_note_2026-04-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_cyclic_wilson_3_response_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "451e00b984c8",
+   "out_degree": 1
+  },
+  "koide_cyclic_wilson_descendant_law_note_2026-04-18": {
+   "deps_hash": "451e00b984c8",
+   "out_degree": 1
+  },
+  "koide_delta_azimuth_selector_is_chirality_odd_records_mirror_degeneracy_no_go_note_2026-06-08": {
+   "deps_hash": "3a0234d7cad0",
+   "out_degree": 7
+  },
+  "koide_delta_c3_circulant_spectral_boundary_note_2026-06-08": {
+   "deps_hash": "e6fc1a32e86b",
+   "out_degree": 3
+  },
+  "koide_delta_dimensionless_closure_via_v8_theorem_note_2026-04-29": {
+   "deps_hash": "c355891e0fc5",
+   "out_degree": 6
+  },
+  "koide_delta_eta_density_readout_chain_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "646cea7f0948",
+   "out_degree": 4
+  },
+  "koide_delta_lattice_wilson_selected_eigenline_no_go_note_2026-04-24": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_delta_marked_relative_cobordism_no_go_note_2026-04-24": {
+   "deps_hash": "0e72aa88a372",
+   "out_degree": 1
+  },
+  "koide_delta_phase_and_generation_count_share_one_z2_orientation_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "b57ce614ba97",
+   "out_degree": 7
+  },
+  "koide_delta_radian_period_physical_not_vacuous_narrow_theorem_note_2026-06-04": {
+   "deps_hash": "bb3318de1966",
+   "out_degree": 5
+  },
+  "koide_delta_rank2_selector_is_the_clifford_chirality_domain_wall_edge_bounded_note_2026-06-05": {
+   "deps_hash": "fc45bc30bcea",
+   "out_degree": 6
+  },
+  "koide_dimensionless_note_2026-04-24": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_dimensionless_objection_toy_conditional_algebraic_checks_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_dimensionless_radian_native_unit_separation_narrow_theorem_note_2026-05-25": {
+   "deps_hash": "2a3416bc2e72",
+   "out_degree": 2
+  },
+  "koide_dirac_mass_forces_r_one_lr_coupling_berry_flat_bounded_no_go_note_2026-06-05": {
+   "deps_hash": "4204300cbc8c",
+   "out_degree": 4
+  },
+  "koide_dkd_berry_spectator_note_2026-05-31": {
+   "deps_hash": "ed0bc734c7f7",
+   "out_degree": 3
+  },
+  "koide_doublet_is_frobenius_schur_complex_type_orientation_bounded_note_2026-06-07": {
+   "deps_hash": "3b69b05feb73",
+   "out_degree": 5
+  },
+  "koide_dweh_cyclic_compression_note_2026-04-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_eigenvalue_q23_surface_theorem_note_2026-04-20": {
+   "deps_hash": "89c65392a627",
+   "out_degree": 3
+  },
+  "koide_embedding_framing_writhe_so2_vs_spin_z2_decoupling_narrow_no_go_note_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_emergent_time_eta_conjugation_parity_bounded_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_equipartition_endpoint_registration_asymmetry_bounded_theorem_note_2026-07-12": {
+   "deps_hash": "97a0cfbfb4c0",
+   "out_degree": 4
+  },
+  "koide_explicit_calculations_note": {
+   "deps_hash": "641263c0383e",
+   "out_degree": 3
+  },
+  "koide_factor_split_does_not_force_carrier_value_bridge_no_go_note_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_faithfulness_rotation_scalar_excluded_note_2026-06-01": {
+   "deps_hash": "a213b619c7d9",
+   "out_degree": 5
+  },
+  "koide_finite_beta_weight_is_the_partition_bit_note_2026-06-02": {
+   "deps_hash": "9ea4b6bbff0c",
+   "out_degree": 10
+  },
+  "koide_first_order_section_tie_vs_outcome_label_residual_localization_bounded_theorem_note_2026-07-11": {
+   "deps_hash": "4f32e7a89e48",
+   "out_degree": 8
+  },
+  "koide_first_order_selector_bounded_localization_certificate_2026-06-18": {
+   "deps_hash": "5fc6b62e87fa",
+   "out_degree": 4
+  },
+  "koide_first_order_selector_is_the_chiral_lr_coupling_not_a_symmetry_narrow_note_2026-06-05": {
+   "deps_hash": "b7d9c8dc56ec",
+   "out_degree": 4
+  },
+  "koide_fisher_rao_spherical_reorganization_note_2026-06-01": {
+   "deps_hash": "3faa97d32a91",
+   "out_degree": 5
+  },
+  "koide_fluctuation_modulus_gives_r_one_chirality_is_phase_only_frontier_correction_note_2026-06-04": {
+   "deps_hash": "5f83d2dad1ab",
+   "out_degree": 4
+  },
+  "koide_formation_gate_relocation_tied_measure_per_cell_weight_compatibility_bounded_theorem_note_2026-07-12": {
+   "deps_hash": "f5e5f6540c0f",
+   "out_degree": 6
+  },
+  "koide_formation_weight_conditional_selection_unique_registration_compatible_lawful_weight_bounded_theorem_note_2026-07-12": {
+   "deps_hash": "7467460ae7db",
+   "out_degree": 6
+  },
+  "koide_formation_weight_law_expressibility_classification_bounded_theorem_note_2026-07-12": {
+   "deps_hash": "6e5b1b4bf985",
+   "out_degree": 7
+  },
+  "koide_frobenius_isotype_split_uniqueness_note_2026-04-21": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_full_lattice_schur_inheritance_note_2026-04-18": {
+   "deps_hash": "2737278417dc",
+   "out_degree": 2
+  },
+  "koide_gamma5_factor_bridge_no_go_note_2026-06-06": {
+   "deps_hash": "b8078f86fc9d",
+   "out_degree": 4
+  },
+  "koide_gamma_axis_covariant_full_cube_orbit_law_note_2026-04-18": {
+   "deps_hash": "fad9e2b4f6a0",
+   "out_degree": 1
+  },
+  "koide_gamma_orbit_cyclic_return_candidate_note_2026-04-18": {
+   "deps_hash": "5098e7f07ea2",
+   "out_degree": 2
+  },
+  "koide_gamma_orbit_exponential_value_law_candidate_note_2026-04-18": {
+   "deps_hash": "5098e7f07ea2",
+   "out_degree": 2
+  },
+  "koide_gamma_orbit_observable_selector_generator_line_note_2026-04-18": {
+   "deps_hash": "4f5551dab204",
+   "out_degree": 3
+  },
+  "koide_gamma_orbit_positive_one_clock_semigroup_note_2026-04-18": {
+   "deps_hash": "8a7fc613525d",
+   "out_degree": 4
+  },
+  "koide_gamma_orbit_selected_line_closure_note_2026-04-18": {
+   "deps_hash": "01a6315302f2",
+   "out_degree": 2
+  },
+  "koide_gamma_orbit_selector_bridge_note_2026-04-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_generation_channel_space_holomorphy_channel_independence_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "6149600341df",
+   "out_degree": 7
+  },
+  "koide_generation_id_cl3_grade1_bridge_narrow_theorem_note_2026-06-02": {
+   "deps_hash": "e51951233502",
+   "out_degree": 5
+  },
+  "koide_generation_weight_dial_shape_forced_value_unfixed_qualification_bounded_theorem_note_2026-07-11": {
+   "deps_hash": "1f2e99924b45",
+   "out_degree": 6
+  },
+  "koide_hermitian_records_import_required_narrow_theorem_note_2026-06-02": {
+   "deps_hash": "7f255e301eec",
+   "out_degree": 12
+  },
+  "koide_higgs_dressed_resolvent_root_theorem_note_2026-04-20": {
+   "deps_hash": "fa9de095a696",
+   "out_degree": 2
+  },
+  "koide_higgs_dressed_resolvent_root_theorem_note_2026-04-20_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_import_two_bit_decomposition_note_2026-05-30": {
+   "deps_hash": "fe476a41cd05",
+   "out_degree": 6
+  },
+  "koide_infogeom_foot45_metric_wall_narrow_no_go_note_2026-06-04": {
+   "deps_hash": "9fdbf6c8cbdf",
+   "out_degree": 10
+  },
+  "koide_k_symmetrized_untied_measure_records_only_reconstruction_bounded_theorem_note_2026-07-12": {
+   "deps_hash": "fc9f16c6034c",
+   "out_degree": 3
+  },
+  "koide_kahler_dirac_realization_gives_r_one_index_route_closed_bounded_no_go_note_2026-06-08": {
+   "deps_hash": "049acad94fb0",
+   "out_degree": 6
+  },
+  "koide_kahler_dirac_silent_on_measure_note_2026-05-30": {
+   "deps_hash": "f9daf816b44c",
+   "out_degree": 6
+  },
+  "koide_kappa_block_total_frobenius_algebraic_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "93186659413a",
+   "out_degree": 1
+  },
+  "koide_kappa_block_total_frobenius_measure_theorem_note_2026-04-19": {
+   "deps_hash": "40135407f3d3",
+   "out_degree": 2
+  },
+  "koide_kappa_bookkeeping_flow_class_fixed_point_inversion_and_lane_scoping_bounded_theorem_note_2026-07-11": {
+   "deps_hash": "433105a662c0",
+   "out_degree": 3
+  },
+  "koide_kappa_flow_class_is_the_formation_weight_in_flow_coordinates_bounded_theorem_note_2026-07-12": {
+   "deps_hash": "b2d5e86fa712",
+   "out_degree": 4
+  },
+  "koide_kappa_spectrum_operator_bridge_theorem_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_kappa_two_orbit_dimension_factorization_note_2026-04-19": {
+   "deps_hash": "0a85668ce0f3",
+   "out_degree": 9
+  },
+  "koide_kappa_zd_action_circulant_character_decomposition_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "5867f5ecfaa2",
+   "out_degree": 1
+  },
+  "koide_kodim_real_structure_route_empty_r_undetermined_bounded_no_go_note_2026-06-08": {
+   "deps_hash": "3ce79835b9bc",
+   "out_degree": 5
+  },
+  "koide_lane_audit_batch_note_2026-05-02": {
+   "deps_hash": "53d12976d966",
+   "out_degree": 4
+  },
+  "koide_lightcone_primitive_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_massive_doubling_reduces_to_transfer_positivity_note_2026-06-02": {
+   "deps_hash": "64de8c66e795",
+   "out_degree": 11
+  },
+  "koide_matter_attachment_gate_extra_assumptions_review_note_2026-06-02": {
+   "deps_hash": "aa0d480a3513",
+   "out_degree": 13
+  },
+  "koide_matter_attachment_graded_statistics_gate_narrow_theorem_note_2026-06-02": {
+   "deps_hash": "9815d62c4777",
+   "out_degree": 9
+  },
+  "koide_matter_attachment_reduces_to_ks_audit_narrow_theorem_note_2026-06-02": {
+   "deps_hash": "689eb97d2065",
+   "out_degree": 7
+  },
+  "koide_microscopic_scalar_selector_target_note_2026-04-18": {
+   "deps_hash": "9ab6a78a0ccd",
+   "out_degree": 5
+  },
+  "koide_moment_ratio_uniformity_reduced_carrier_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "ffdfdb7b277b",
+   "out_degree": 2
+  },
+  "koide_moment_ratio_uniformity_theorem_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_mru_demotion_note_2026-04-20": {
+   "deps_hash": "25f3000de50b",
+   "out_degree": 1
+  },
+  "koide_mru_weight_class_obstruction_theorem_note_2026-04-19": {
+   "deps_hash": "451e00b984c8",
+   "out_degree": 1
+  },
+  "koide_native_dimensionless_note_2026-04-24": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_native_zero_section_closure_route_note_2026-04-24": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_native_zero_section_nature_review_note_2026-04-24": {
+   "deps_hash": "d007d8638908",
+   "out_degree": 3
+  },
+  "koide_occupancy_durability_premise_equivalence_on_registered_surface_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "5f7342b36a41",
+   "out_degree": 4
+  },
+  "koide_occupancy_from_locked_record_outcomes_bounded_note_2026-07-03": {
+   "deps_hash": "9cce8446040f",
+   "out_degree": 4
+  },
+  "koide_occupancy_kernel_coefficient_not_fixed_by_retained_corner_measure_bounded_note_2026-06-12": {
+   "deps_hash": "5a5283a862a0",
+   "out_degree": 2
+  },
+  "koide_octahedral_overconstrains_value_bit_narrow_note_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_one_scalar_obstruction_triangulation_theorem_note_2026-04-18": {
+   "deps_hash": "4d05680decbc",
+   "out_degree": 4
+  },
+  "koide_onsite_boost_reconstruction_weyl_faithful_vs_scalar_selection_note_2026-06-02": {
+   "deps_hash": "2e35228c989d",
+   "out_degree": 6
+  },
+  "koide_onsite_weyl_boost_from_bivectors_note_2026-06-01": {
+   "deps_hash": "9a863516c382",
+   "out_degree": 4
+  },
+  "koide_oo_rd_premise_relation_on_current_surface_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "34b13d32d224",
+   "out_degree": 2
+  },
+  "koide_oplocality_brannen_plancherel_callan_harvey_honest_residual_composition_note_2026-05-25": {
+   "deps_hash": "bf926c6fe623",
+   "out_degree": 7
+  },
+  "koide_orbit_occupancy_independence_and_premise_candidate_note_2026-06-09": {
+   "deps_hash": "203bd284b4d9",
+   "out_degree": 4
+  },
+  "koide_order_one_circulant_diagnostic_note_2026-05-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_orientation_blind_count_b_field_gate_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_p1_collapses_frame_residuals_note_2026-06-01": {
+   "deps_hash": "76fae77d63f3",
+   "out_degree": 1
+  },
+  "koide_p_one_clock_3plus1_transport_reduction_note_2026-04-20": {
+   "deps_hash": "63dde859321b",
+   "out_degree": 4
+  },
+  "koide_phase_aps_eta_parity_route_narrow_theorem_note_2026-05-23": {
+   "deps_hash": "e484984cdfc2",
+   "out_degree": 4
+  },
+  "koide_phase_delta_is_also_an_admission_clean_modulus_has_only_degenerate_stationary_points_narrow_no_go_note_2026-06-04": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_pointed_origin_exhaustion_theorem_note_2026-04-24": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_pointer_record_degeneracy_d3_note_2026-05-31": {
+   "deps_hash": "c0ef527696e2",
+   "out_degree": 9
+  },
+  "koide_positive_parent_axis_obstruction_note_2026-04-18": {
+   "deps_hash": "9a38c131b8bb",
+   "out_degree": 1
+  },
+  "koide_positive_paths_first_principles_note_2026-04-18": {
+   "deps_hash": "eb94496efa38",
+   "out_degree": 27
+  },
+  "koide_q23_block_weight_frontier_bounded_note_2026-05-29": {
+   "deps_hash": "0f5e7985321c",
+   "out_degree": 4
+  },
+  "koide_q23_k0_real_block_equivalence_note_2026-05-30": {
+   "deps_hash": "853acae2aef1",
+   "out_degree": 5
+  },
+  "koide_q23_oh_covariance_nogo_note_2026-04-22": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_q_background_zero_z_erasure_criterion_theorem_note_2026-04-25": {
+   "deps_hash": "0078790ed6f0",
+   "out_degree": 1
+  },
+  "koide_q_background_zero_z_erasure_criterion_theorem_note_2026-04-25_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_q_bridge_single_primitive_note_2026-04-22": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_q_delta_closure_package_readme_2026-04-21": {
+   "deps_hash": "dc40163e635f",
+   "out_degree": 5
+  },
+  "koide_q_delta_linking_relation_theorem_note_2026-04-20": {
+   "deps_hash": "5867f5ecfaa2",
+   "out_degree": 1
+  },
+  "koide_q_delta_linking_relation_theorem_note_2026-04-20_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_q_delta_readout_retention_split_no_go_note_2026-04-24": {
+   "deps_hash": "ae68682fddcb",
+   "out_degree": 2
+  },
+  "koide_q_delta_residual_cohomology_obstruction_no_go_note_2026-04-24": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_q_dred_normalization_freedom_no_go_note_2026-06-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_q_eq_3delta_identity_note_2026-04-21": {
+   "deps_hash": "3548456d1ebe",
+   "out_degree": 2
+  },
+  "koide_q_minimal_scale_free_selector_note_2026-04-22": {
+   "deps_hash": "bb3d8e0d7a29",
+   "out_degree": 1
+  },
+  "koide_q_no_hidden_source_audit_2026-04-22": {
+   "deps_hash": "8b55a859247c",
+   "out_degree": 2
+  },
+  "koide_q_normalized_second_order_effective_action_theorem_2026-04-22": {
+   "deps_hash": "6e4eaaa34685",
+   "out_degree": 3
+  },
+  "koide_q_onsite_source_domain_no_go_synthesis_note_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_q_op_locality_c3_fixed_source_support_note_2026-04-27": {
+   "deps_hash": "398f38c0a0df",
+   "out_degree": 2
+  },
+  "koide_q_op_locality_source_domain_closure_theorem_note_2026-04-29": {
+   "deps_hash": "067122443fd3",
+   "out_degree": 5
+  },
+  "koide_q_op_uniqueness_source_domain_support_note_2026-04-25": {
+   "deps_hash": "2049a7f7c363",
+   "out_degree": 5
+  },
+  "koide_q_readout_factorization_theorem_2026-04-22": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_q_reduced_carrier_physical_identification_obstruction_note_2026-06-12": {
+   "deps_hash": "e5d7e84db560",
+   "out_degree": 6
+  },
+  "koide_q_reduced_observable_restriction_theorem_2026-04-22": {
+   "deps_hash": "1c82850896ee",
+   "out_degree": 5
+  },
+  "koide_q_second_order_reviewer_stress_test_note_2026-04-22": {
+   "deps_hash": "586da05baafb",
+   "out_degree": 3
+  },
+  "koide_q_second_order_support_batch_note_2026-04-22": {
+   "deps_hash": "f7f22f64d97e",
+   "out_degree": 6
+  },
+  "koide_q_so2_phase_erasure_support_note_2026-04-25": {
+   "deps_hash": "9ec770af9369",
+   "out_degree": 4
+  },
+  "koide_q_source_domain_canonical_descent_theorem_note_2026-04-25": {
+   "deps_hash": "ce4cec8ee8ec",
+   "out_degree": 3
+  },
+  "koide_q_two_thirds_frobenius_extremum_bridge_bounded_note_2026-05-25": {
+   "deps_hash": "63b8f331c4dd",
+   "out_degree": 3
+  },
+  "koide_q_two_thirds_z3_character_norm_split_recasting_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_quasi_hermitian_metric_operator_escape_closure_bounded_theorem_note_2026-07-12": {
+   "deps_hash": "b896000b42db",
+   "out_degree": 2
+  },
+  "koide_qubit_berry_holonomy_import_note_2026-05-30": {
+   "deps_hash": "a25ff9044dcb",
+   "out_degree": 11
+  },
+  "koide_qubit_lattice_dim_algebraic_closure_note_2026-04-20": {
+   "deps_hash": "3622b3a97aa9",
+   "out_degree": 7
+  },
+  "koide_r_half_durability_stationarity_conditional_chain_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "f9808e9a9e78",
+   "out_degree": 6
+  },
+  "koide_r_half_dynamical_determinant_route_pruning_no_go_note_2026-06-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_r_half_index_readout_non_susy_staggered_dirac_gate_meta_note_2026-06-05": {
+   "deps_hash": "4b23826148d0",
+   "out_degree": 6
+  },
+  "koide_r_half_not_symmetry_protected_dynamical_norm_balance_narrow_no_go_note_2026-06-04": {
+   "deps_hash": "edc41adb134b",
+   "out_degree": 3
+  },
+  "koide_r_half_polarization_selector_tested_static_readout_no_go_note_2026-06-08": {
+   "deps_hash": "20de349b4d46",
+   "out_degree": 7
+  },
+  "koide_r_is_the_weighting_principle_dial_record_dynamics_weighting_blind_bounded_theorem_note_2026-06-15": {
+   "deps_hash": "76433b274316",
+   "out_degree": 2
+  },
+  "koide_r_polarization_orbit_quotient_gate_sharpening_note_2026-06-09": {
+   "deps_hash": "e6b42e44866e",
+   "out_degree": 3
+  },
+  "koide_r_reduces_to_chiral_vs_vector_yukawa_binary_narrow_theorem_note_2026-06-04": {
+   "deps_hash": "f0b59374a8f4",
+   "out_degree": 4
+  },
+  "koide_readout_channel_map_note_2026-05-31": {
+   "deps_hash": "b8ef63cbb657",
+   "out_degree": 3
+  },
+  "koide_readout_lane_demarcation_note_2026-05-30": {
+   "deps_hash": "7f59fe8537e9",
+   "out_degree": 5
+  },
+  "koide_real_rep_block_count_permitted_not_forced_note_2026-05-30": {
+   "deps_hash": "254f0b063491",
+   "out_degree": 6
+  },
+  "koide_reality_favors_signed_readout_shared_mechanism_narrow_theorem_note_2026-06-02": {
+   "deps_hash": "9637e89f4a1d",
+   "out_degree": 8
+  },
+  "koide_reality_type_permitted_not_forced_note_2026-05-30": {
+   "deps_hash": "13673902ab39",
+   "out_degree": 6
+  },
+  "koide_record_orbit_count_does_not_select_r_half_no_go_note_2026-06-07": {
+   "deps_hash": "6cdf4fc576ae",
+   "out_degree": 4
+  },
+  "koide_record_sign_agnostic_eta_refuted_2026-06-04": {
+   "deps_hash": "4b11c34991de",
+   "out_degree": 3
+  },
+  "koide_records_objectivity_conditional_note_2026-05-31": {
+   "deps_hash": "fa04acce1336",
+   "out_degree": 5
+  },
+  "koide_records_pointer_grounds_block_channel_note_2026-05-31": {
+   "deps_hash": "49f6f935be05",
+   "out_degree": 4
+  },
+  "koide_records_reality_shrinks_import_to_sign_note_2026-06-02": {
+   "deps_hash": "28b302f6c983",
+   "out_degree": 17
+  },
+  "koide_retained_wilson_aps_scalar_action_on_rank_two_multiplicity_bridge_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_review_guard_note_2026-04-24": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_reviewer_stress_test_note_2026-04-21": {
+   "deps_hash": "907bb3a699e1",
+   "out_degree": 4
+  },
+  "koide_rho_delta_dimensionless_dof_ratio_bridge_bounded_note_2026-05-25": {
+   "deps_hash": "5867f5ecfaa2",
+   "out_degree": 1
+  },
+  "koide_rp_spectrum_reduce_to_transfer_positivity_narrow_theorem_note_2026-06-02": {
+   "deps_hash": "6e0e8e88709f",
+   "out_degree": 11
+  },
+  "koide_s_l1_topological_chern_simons_note_2026-05-08_probes_l1_topological": {
+   "deps_hash": "c79291fed776",
+   "out_degree": 2
+  },
+  "koide_s_substep4_aclambda_new_science_note_2026-05-08_probes_substep4_aclambda": {
+   "deps_hash": "a7e4ec8ddf27",
+   "out_degree": 10
+  },
+  "koide_scale_selector_reparameterization_theorem_note_2026-04-20": {
+   "deps_hash": "4b130600ddee",
+   "out_degree": 2
+  },
+  "koide_selected_line_cyclic_response_bridge_note_2026-04-18": {
+   "deps_hash": "88f2021fe491",
+   "out_degree": 2
+  },
+  "koide_selected_line_local_radian_bridge_no_go_note_2026-04-20": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_selected_line_provenance_note_2026-04-20": {
+   "deps_hash": "6f28afd33691",
+   "out_degree": 6
+  },
+  "koide_selected_slice_frozen_bank_decomposition_note_2026-04-18": {
+   "deps_hash": "be0c7f2999a4",
+   "out_degree": 4
+  },
+  "koide_selected_slice_spectral_completion_and_minimal_local_spectral_law_no_go_note_2026-04-20": {
+   "deps_hash": "3ad4ba268f1a",
+   "out_degree": 4
+  },
+  "koide_signed_eigenvalue_vs_singular_value_readout_narrow_theorem_note_2026-05-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_signed_readout_is_not_chirality_narrow_no_go_note_2026-06-04": {
+   "deps_hash": "39c713bc5519",
+   "out_degree": 9
+  },
+  "koide_sqrtm_amplitude_principle_note_2026-04-18": {
+   "deps_hash": "dcce121115ec",
+   "out_degree": 5
+  },
+  "koide_staggered_first_order_generation_determinant_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "eb485ece2d98",
+   "out_degree": 8
+  },
+  "koide_t_bae_hopf_coproduct_isotype_note_2026-05-08_probet_bae_hopf": {
+   "deps_hash": "d0413bb7b2e2",
+   "out_degree": 5
+  },
+  "koide_taste_cube_cyclic_source_descent_note_2026-04-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_theta_hierarchy_open_scalar_note_2026-04-19": {
+   "deps_hash": "8acca5df14ee",
+   "out_degree": 1
+  },
+  "koide_three_measures_three_observables_note_2026-05-31": {
+   "deps_hash": "b8ef63cbb657",
+   "out_degree": 3
+  },
+  "koide_tracial_standard_form_carrier_narrow_note_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_transport_gap_constant_no_go_note_2026-04-20": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_two_29_routes_distinct_narrow_theorem_note_2026-05-23": {
+   "deps_hash": "3b760cb1c02d",
+   "out_degree": 2
+  },
+  "koide_u_bae_ncg_spectral_triple_note_2026-05-08_probeu_bae_ncg": {
+   "deps_hash": "338ca6c5adbd",
+   "out_degree": 16
+  },
+  "koide_u_bae_quantum_deformation_note_2026-05-08_probeu_bae_qdeformation": {
+   "deps_hash": "6f82fea10a45",
+   "out_degree": 14
+  },
+  "koide_u_heavy_modular_sl2z_note_2026-05-08_probeu_heavy_modular": {
+   "deps_hash": "71776a85797d",
+   "out_degree": 4
+  },
+  "koide_u_l1_resurgence_trans_series_note_2026-05-08_probeu_l1_resurgence": {
+   "deps_hash": "0495114232c9",
+   "out_degree": 7
+  },
+  "koide_v_bae_maxentropy_thermal_note_2026-05-08_probev_bae_maxent": {
+   "deps_hash": "54108e70bfa9",
+   "out_degree": 16
+  },
+  "koide_v_bae_s3_reflection_note_2026-05-08_probev_bae_s3": {
+   "deps_hash": "018fa320cdae",
+   "out_degree": 21
+  },
+  "koide_v_l1_quartic_casimir_beta2_note_2026-05-08_probev_l1_quartic": {
+   "deps_hash": "d5f31baf710d",
+   "out_degree": 4
+  },
+  "koide_v_quark_dynamical_ssb_note_2026-05-08_probev_quark_dynamical": {
+   "deps_hash": "2094770154e9",
+   "out_degree": 5
+  },
+  "koide_w_substrate_chirality_cl3_z2_note_2026-05-10_probew_substrate_chirality": {
+   "deps_hash": "c1c6166a617b",
+   "out_degree": 4
+  },
+  "koide_weighted_character_source_axis_theorem_note_2026-04-20": {
+   "deps_hash": "5464136b0a82",
+   "out_degree": 2
+  },
+  "koide_x_bae_pauli_antisymmetrization_note_2026-05-08_probex_bae_pauli": {
+   "deps_hash": "4224fd7a4a5f",
+   "out_degree": 11
+  },
+  "koide_x_l1_msbar_native_scheme_note_2026-05-08_probex_l1_msbar": {
+   "deps_hash": "94cd1ab7d299",
+   "out_degree": 8
+  },
+  "koide_x_l1_threshold_heavy_quark_wilson_note_2026-05-08_probex_l1_threshold": {
+   "deps_hash": "a39f70b253c3",
+   "out_degree": 5
+  },
+  "koide_y_bae_topological_index_ktheory_note_2026-05-10_probey_bae_topological": {
+   "deps_hash": "3ace3ee2cf74",
+   "out_degree": 3
+  },
+  "koide_y_l1_ratios_wilson_integer_diff_note_2026-05-08_probey_l1_ratios": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_y_s4b_rge_tier_downgrade_correction_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_y_substrate_anomaly_forcing_note_2026-05-08_probey_substrate_anomaly": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_z3_equivariant_anticommuting_no_go_note_2026-05-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_z3_joint_projector_identity_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_z3_qubit_radian_bridge_no_go_note_2026-04-20": {
+   "deps_hash": "d21efac924a2",
+   "out_degree": 6
+  },
+  "koide_z3_scalar_potential_lepton_mass_tower_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "koide_z3_scalar_potential_support_note_2026-04-19": {
+   "deps_hash": "db8cb045a8a8",
+   "out_degree": 3
+  },
+  "koide_z_quark_qcd_chain_note_2026-05-08_probez_quark_qcd_chain": {
+   "deps_hash": "0332e05fefcc",
+   "out_degree": 3
+  },
+  "koide_z_s4b_rge_import_tier_review_note_2026-05-08_probez_s4b_audit": {
+   "deps_hash": "2f34d8b9204e",
+   "out_degree": 4
+  },
+  "koide_z_substrate_color_geometric_note_2026-05-08_probez_substrate_color_geometric": {
+   "deps_hash": "9c340d2af4e2",
+   "out_degree": 7
+  },
+  "koide_z_substrate_generation_z3_note_2026-05-08_probez_substrate_generation_z3": {
+   "deps_hash": "a22fdf739691",
+   "out_degree": 8
+  },
+  "kolb_turner_freezeout_prefactor_from_supplied_cosmology_boundary_bounded_theorem_note_2026-05-28": {
+   "deps_hash": "6bad67a4748e",
+   "out_degree": 4
+  },
+  "kraus_choi_representation_deps_changed_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "5255f9126c00",
+   "out_degree": 3
+  },
+  "kraus_choi_representation_normalization_reconciled_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "kraus_choi_representation_on_qubit_lattice_narrow_theorem_note_2026-05-20": {
+   "deps_hash": "165690587f99",
+   "out_degree": 2
+  },
+  "kreality_predicate_one_shared_atom_one_consumer_bounded_note_2026-06-12": {
+   "deps_hash": "d8a5c4b47ad0",
+   "out_degree": 3
+  },
+  "ks_eta_vs_jw_string_car_locality_no_go_note_2026-06-02": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "kubo_continuum_limit_families_note": {
+   "deps_hash": "662f1ab350e0",
+   "out_degree": 1
+  },
+  "kubo_continuum_limit_families_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "kubo_continuum_limit_note": {
+   "deps_hash": "bb35ed796ed8",
+   "out_degree": 2
+  },
+  "kubo_eikonal_gap_note": {
+   "deps_hash": "fab8a8e4a279",
+   "out_degree": 2
+  },
+  "kubo_fam2_non_convergence_note_2026-05-02": {
+   "deps_hash": "9bd9250c809b",
+   "out_degree": 2
+  },
+  "kubo_fam2_refinement_note": {
+   "deps_hash": "86a7b2e6419a",
+   "out_degree": 1
+  },
+  "kubo_range_of_validity_note": {
+   "deps_hash": "ba29b296b2a4",
+   "out_degree": 1
+  },
+  "l3a_v3_trace_surface_bounded_obstruction_note_2026-05-07_l3a": {
+   "deps_hash": "805468c60932",
+   "out_degree": 13
+  },
+  "landau_peierls_prefactor_native_derivation_bounded_theorem_note_2026-06-13": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lanes.action-law.readme": {
+   "deps_hash": "454f5c5d573c",
+   "out_degree": 3
+  },
+  "lanes.active_working_lanes_2026-04-26": {
+   "deps_hash": "b3e569e9c1bc",
+   "out_degree": 30
+  },
+  "lanes.coin-walks.readme": {
+   "deps_hash": "38100bd015bc",
+   "out_degree": 2
+  },
+  "lanes.controls.readme": {
+   "deps_hash": "f0b7ee373876",
+   "out_degree": 1
+  },
+  "lanes.generated-geometry.readme": {
+   "deps_hash": "45f30fdbd753",
+   "out_degree": 3
+  },
+  "lanes.mirror.readme": {
+   "deps_hash": "0577e22735e8",
+   "out_degree": 2
+  },
+  "lanes.moonshots.readme": {
+   "deps_hash": "f7c5b9d13f39",
+   "out_degree": 3
+  },
+  "lanes.open_science.01_hadron_mass_program_open_lane_2026-04-26": {
+   "deps_hash": "b4c8410a497d",
+   "out_degree": 7
+  },
+  "lanes.open_science.02_atomic_scale_program_open_lane_2026-04-26": {
+   "deps_hash": "26f31c35bda2",
+   "out_degree": 3
+  },
+  "lanes.open_science.03_quark_mass_retention_open_lane_2026-04-26": {
+   "deps_hash": "3c3a53081356",
+   "out_degree": 6
+  },
+  "lanes.open_science.04_neutrino_quantitative_open_lane_2026-04-26": {
+   "deps_hash": "23caaa67b3fc",
+   "out_degree": 14
+  },
+  "lanes.open_science.05_hubble_constant_derivation_open_lane_2026-04-26": {
+   "deps_hash": "df17b7d3e18e",
+   "out_degree": 24
+  },
+  "lanes.open_science.06_charged_lepton_mass_retention_open_lane_2026-04-26": {
+   "deps_hash": "0a2e32dfc1c7",
+   "out_degree": 8
+  },
+  "lanes.open_science.07_thermalization_kinetic_theory_open_lane_2026-06-12": {
+   "deps_hash": "6c9560098932",
+   "out_degree": 3
+  },
+  "lanes.open_science.08_classical_electromagnetism_light_open_lane_2026-06-12": {
+   "deps_hash": "c6a3b52c48cf",
+   "out_degree": 7
+  },
+  "lanes.open_science.09_phases_of_matter_transitions_open_lane_2026-06-12": {
+   "deps_hash": "78ec81e0a749",
+   "out_degree": 1
+  },
+  "lanes.open_science.10_continuum_hydrodynamics_open_lane_2026-06-12": {
+   "deps_hash": "2a771b5f67ef",
+   "out_degree": 2
+  },
+  "lanes.open_science.readme": {
+   "deps_hash": "9c212f6b0cd1",
+   "out_degree": 19
+  },
+  "lanes.ordered-lattice.readme": {
+   "deps_hash": "acc32198d883",
+   "out_degree": 3
+  },
+  "lanes.readme": {
+   "deps_hash": "9053a36666ed",
+   "out_degree": 10
+  },
+  "lanes.staggered.readme": {
+   "deps_hash": "19ed733ae54f",
+   "out_degree": 2
+  },
+  "lanes_open_science_03_quark_mass_retention_open_lane_2026-04-26_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_3d_dense_refinement_reconciliation_note": {
+   "deps_hash": "bc5f8211bba0",
+   "out_degree": 1
+  },
+  "lattice_3d_dense_spent_delay_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_3d_dense_spent_delay_z2_z5_support_note_2026-04-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_3d_dense_spent_delay_z2_z6_endpoint_note_2026-05-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_3d_dense_window_extension_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_3d_inverse_square_kernel_helper_note_2026-04-04": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_3d_l2_numpy_h0125_audit_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_3d_l2_numpy_h0125_bridge_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_3d_l2_tail_stats_note": {
+   "deps_hash": "e4537437bea3",
+   "out_degree": 1
+  },
+  "lattice_3d_nyquist_diffraction_note": {
+   "deps_hash": "c5d39be892e1",
+   "out_degree": 1
+  },
+  "lattice_3d_tapered_refinement_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_complementarity_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_distance_law_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_family_validation_note": {
+   "deps_hash": "1f073ec8b22d",
+   "out_degree": 2
+  },
+  "lattice_fanout_continuum_note": {
+   "deps_hash": "3b2be6b6254b",
+   "out_degree": 1
+  },
+  "lattice_field_strength_unification_note": {
+   "deps_hash": "d1f698838e74",
+   "out_degree": 1
+  },
+  "lattice_gravity_resolution_note": {
+   "deps_hash": "3f1f52e62750",
+   "out_degree": 1
+  },
+  "lattice_green_function_zero_argument_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "620cf6af7381",
+   "out_degree": 1
+  },
+  "lattice_greens_1_over_r_from_heat_kernel_resolvent_theorem_note_2026-06-07": {
+   "deps_hash": "2b11e69fd3cb",
+   "out_degree": 4
+  },
+  "lattice_greens_function_maradudin_textbook_import_note_2026-05-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_greens_maradudin_asymptotic_accepted_premise_bridge_bounded_note_2026-05-27": {
+   "deps_hash": "1315eadecbad",
+   "out_degree": 2
+  },
+  "lattice_greens_next_order_r5_anisotropy_theorem_note_2026-07-09": {
+   "deps_hash": "937db4362b99",
+   "out_degree": 2
+  },
+  "lattice_keff_continuum_note": {
+   "deps_hash": "611905510ba3",
+   "out_degree": 3
+  },
+  "lattice_kernel_transfer_norm_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_laplacian_shell_localization_identity_bounded_theorem_note_2026-06-16": {
+   "deps_hash": "22da0f98116f",
+   "out_degree": 2
+  },
+  "lattice_nn_continuum_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_nn_deterministic_rescale_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_nn_distance_law_note": {
+   "deps_hash": "2c00b42c2033",
+   "out_degree": 1
+  },
+  "lattice_nn_high_precision_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_nn_light_cone_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_nn_mass_response_note": {
+   "deps_hash": "313147590c92",
+   "out_degree": 3
+  },
+  "lattice_nn_rg_alpha_sweep_note": {
+   "deps_hash": "f4e24300e704",
+   "out_degree": 1
+  },
+  "lattice_nn_rg_gravity_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_nn_rg_reconciliation_note": {
+   "deps_hash": "481c70ec2095",
+   "out_degree": 4
+  },
+  "lattice_noether_carrier_independent_bilateral_identity_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "9480ebbcdb96",
+   "out_degree": 1
+  },
+  "lattice_physical_matching_cluster_obstruction_note_2026-05-02": {
+   "deps_hash": "112510785530",
+   "out_degree": 5
+  },
+  "lattice_physical_matching_theorem_bounded_obstruction_note_2026-05-10_match": {
+   "deps_hash": "d371e450ceb5",
+   "out_degree": 20
+  },
+  "lattice_symmetry_unification_decision_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_synthesis_guard_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lattice_total_momentum_conservation_theorem_note_2026-05-02": {
+   "deps_hash": "53f3aed99a9c",
+   "out_degree": 1
+  },
+  "lattice_weak_field_mass_scaling_note": {
+   "deps_hash": "db83fd9f6ce6",
+   "out_degree": 1
+  },
+  "lattice_weak_field_purity_scaling_note": {
+   "deps_hash": "db83fd9f6ce6",
+   "out_degree": 1
+  },
+  "left_handed_charge_matching_note": {
+   "deps_hash": "8509d3f67d5d",
+   "out_degree": 3
+  },
+  "legacy_exploratory_drivers_note": {
+   "deps_hash": "8e64d7458c65",
+   "out_degree": 2
+  },
+  "lensing_adjoint_kernel_note": {
+   "deps_hash": "45a9558187b4",
+   "out_degree": 2
+  },
+  "lensing_adjoint_kernel_reduced_model_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lensing_adjoint_kernel_shape_note": {
+   "deps_hash": "07879a16afe3",
+   "out_degree": 2
+  },
+  "lensing_beta_sweep_note": {
+   "deps_hash": "275c3f21e952",
+   "out_degree": 2
+  },
+  "lensing_centroid_multipole_no_go_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lensing_combined_invariant_note": {
+   "deps_hash": "11f0f5ae43c9",
+   "out_degree": 1
+  },
+  "lensing_deflection_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lensing_exponent_is_a_dipole_crossover_resolution_bounded_theorem_note_2026-06-07": {
+   "deps_hash": "0d74ad433420",
+   "out_degree": 2
+  },
+  "lensing_finite_path_explanation_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lensing_finite_path_explanation_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lensing_k_sweep_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lensing_long_path_test_note": {
+   "deps_hash": "28cb06273347",
+   "out_degree": 1
+  },
+  "lepton_block_d12_prime_matching_no_go_note_2026-05-10": {
+   "deps_hash": "1a33b18ca22b",
+   "out_degree": 2
+  },
+  "lepton_block_scalar_singlet_composite_uniqueness_d17_prime_theorem_note_2026-05-10": {
+   "deps_hash": "ee997078470d",
+   "out_degree": 1
+  },
+  "lepton_block_tree_level_exchange_d16_prime_theorem_note_2026-05-10": {
+   "deps_hash": "229ffccc4de8",
+   "out_degree": 3
+  },
+  "lepton_brannen_bae_delta_two_ninths_open_gate_note_2026-05-26": {
+   "deps_hash": "9c278f6a2594",
+   "out_degree": 8
+  },
+  "lepton_charge_universality_note_2026-05-02": {
+   "deps_hash": "230a7de25c81",
+   "out_degree": 3
+  },
+  "lepton_mass_scale_mw_over_256_empirical_open_gate_note_2026-05-26": {
+   "deps_hash": "64ddf8166f94",
+   "out_degree": 3
+  },
+  "lepton_phase_modulus_separation_no_go_2026-06-06": {
+   "deps_hash": "e52645d897df",
+   "out_degree": 5
+  },
+  "lepton_scale_frontier_probe_2026-06-05": {
+   "deps_hash": "ad2fdd95b2da",
+   "out_degree": 5
+  },
+  "lepton_shared_higgs_universality_collapse_note": {
+   "deps_hash": "4ec43973bc9f",
+   "out_degree": 2
+  },
+  "lepton_shared_higgs_universality_underdetermination_note": {
+   "deps_hash": "89aabcda8fd3",
+   "out_degree": 1
+  },
+  "lepton_single_higgs_pmns_triviality_note": {
+   "deps_hash": "0ed8f03bc792",
+   "out_degree": 4
+  },
+  "lepton_single_higgs_pmns_triviality_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lepton_yukawa_256_structural_probe_2026-06-05": {
+   "deps_hash": "7cdb468ae887",
+   "out_degree": 5
+  },
+  "lh_anomaly_trace_catalog_theorem_note_2026-04-25": {
+   "deps_hash": "34ecfb18e0e2",
+   "out_degree": 5
+  },
+  "lh_doublet_eigenvalue_ratio_proof_walk_lattice_independence_bounded_note_2026-05-10": {
+   "deps_hash": "8509d3f67d5d",
+   "out_degree": 3
+  },
+  "lh_doublet_partition_ratio_inverse_uniqueness_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "9c11e8656fb4",
+   "out_degree": 1
+  },
+  "lh_doublet_su2_squared_hypercharge_anomaly_cancellation_note_2026-05-01": {
+   "deps_hash": "05987520e4d0",
+   "out_degree": 5
+  },
+  "lh_doublet_traceless_abelian_eigenvalue_ratio_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "5420992392c0",
+   "out_degree": 2
+  },
+  "lh_template_retained_substrate_i3_independence_narrow_theorem_note_2026-05-23": {
+   "deps_hash": "5420992392c0",
+   "out_degree": 2
+  },
+  "lh_traceless_eigenvalue_ratio_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lhcm_matter_assignment_block_proof_walk_lattice_independence_bounded_note_2026-05-10": {
+   "deps_hash": "d7f02ad41770",
+   "out_degree": 3
+  },
+  "lhcm_matter_assignment_from_su3_representation_note_2026-05-02": {
+   "deps_hash": "d60496312b9b",
+   "out_degree": 3
+  },
+  "lhcm_matter_assignment_su3_block_representation_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "5420992392c0",
+   "out_degree": 2
+  },
+  "lhcm_repair_atlas_consolidation_note_2026-05-02": {
+   "deps_hash": "c013a0df6bbc",
+   "out_degree": 12
+  },
+  "lhcm_y_normalization_from_anomaly_and_convention_note_2026-05-02": {
+   "deps_hash": "40b410e0cfc2",
+   "out_degree": 6
+  },
+  "lieb_robinson_equal_time_tensor_locality_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "light_cone_crank_nicolson_lieb_robinson_bridge_note_2026-05-09": {
+   "deps_hash": "92b3406d882f",
+   "out_degree": 1
+  },
+  "light_cone_framing_note": {
+   "deps_hash": "21bf1c0b0553",
+   "out_degree": 3
+  },
+  "linear_response_derivation_note": {
+   "deps_hash": "1a2ccc8fd9bc",
+   "out_degree": 2
+  },
+  "linear_response_second_order_kubo_note": {
+   "deps_hash": "ba29b296b2a4",
+   "out_degree": 1
+  },
+  "linear_response_true_kubo_first_order_closure_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "bf44fba272f9",
+   "out_degree": 4
+  },
+  "linear_response_true_kubo_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "link_local_first_variation_selector_bridge_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "literature_backmatch_live_scan_note": {
+   "deps_hash": "146f5bb6d376",
+   "out_degree": 1
+  },
+  "literature_positioning_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "local_frame_orbit_flat_sector_exact_converse_holonomy_frame_unreachable_residual_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "902cbaf48a4c",
+   "out_degree": 4
+  },
+  "local_tomography_from_qubit_complex_structure_narrow_theorem_note_2026-06-03": {
+   "deps_hash": "4fb4f7ea0100",
+   "out_degree": 4
+  },
+  "local_zsym_predictor_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "localized_source_response_sweep_note": {
+   "deps_hash": "bfa16b759215",
+   "out_degree": 2
+  },
+  "localized_source_response_sweep_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lorentz_boost_covariance_2d_theorem_note": {
+   "deps_hash": "a2ed572eed55",
+   "out_degree": 1
+  },
+  "lorentz_boost_covariance_3plus1d_theorem_note": {
+   "deps_hash": "27a110b085bb",
+   "out_degree": 2
+  },
+  "lorentz_boost_free_staggered_fermion_2point_so4_narrow_theorem_note_2026-05-29": {
+   "deps_hash": "2cfd7cc17d1e",
+   "out_degree": 2
+  },
+  "lorentz_kernel_positive_closure_note": {
+   "deps_hash": "2ba92f8d6618",
+   "out_degree": 3
+  },
+  "lorentz_naturalness_gap_quantified_obstruction_note_2026-06-06": {
+   "deps_hash": "d9db3f63cc2d",
+   "out_degree": 6
+  },
+  "lorentz_violation_angular_fingerprint_ac_phi_lambda_independence_bounded_note_2026-06-08": {
+   "deps_hash": "d92bc4cb83ef",
+   "out_degree": 2
+  },
+  "lorentz_violation_derived_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lp_identification_fails_off_m0_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "lp_two_band_exact_completion_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "351b4268b2d0",
+   "out_degree": 1
+  },
+  "lsp_projective_canonical_kp_equals_p_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "lsp_projective_derivation_from_naimark_frame_narrow_theorem_note_2026-05-22": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "lsp_projective_ratification_reaudit_manifest_note_2026-05-22": {
+   "deps_hash": "127cfec1a18d",
+   "out_degree": 2
+  },
+  "luders_rule_from_composition_consistency_deps_changed_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "62506bff4873",
+   "out_degree": 3
+  },
+  "luders_rule_from_composition_consistency_note_2026-05-20": {
+   "deps_hash": "3a941a6de461",
+   "out_degree": 4
+  },
+  "luders_sequential_effect_composition_pep_bridge_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "luders_sequential_product_conditional_bridge_narrow_theorem_note_2026-05-22": {
+   "deps_hash": "241e6574e8d2",
+   "out_degree": 3
+  },
+  "m2_tensor_d4_dimension_256_bounded_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "m_dm_nsites_v_integer_16_factorization_enumeration_narrow_theorem_note_2026-05-28": {
+   "deps_hash": "cce9e6a23a29",
+   "out_degree": 5
+  },
+  "magnitude_4pi_is_native_coupling_not_gaussian_2026-06-06": {
+   "deps_hash": "0e2de04b74df",
+   "out_degree": 5
+  },
+  "magnitude_reads_minimal_record_block_2026-06-06": {
+   "deps_hash": "ac8d544663fd",
+   "out_degree": 6
+  },
+  "magnitude_temporal_factor_is_count_not_rate_2026-06-06": {
+   "deps_hash": "f6a59c31f7f0",
+   "out_degree": 6
+  },
+  "main_open_cubic_validation_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "mass_mixing_subspace_disjointness_theorem_note": {
+   "deps_hash": "6f1d48b0b059",
+   "out_degree": 3
+  },
+  "mass_observable_rest_gap_inertial_response_universal_function_two_step_surface_bounded_theorem_note_2026-07-08": {
+   "deps_hash": "41ab92ab2ab3",
+   "out_degree": 1
+  },
+  "mass_spectrum_derived_note": {
+   "deps_hash": "95ca07898375",
+   "out_degree": 6
+  },
+  "massless_vector_null_quotient_exact_linear_algebra_theorem_note_2026-06-03": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "massless_vector_polarization_count_from_lorentz_and_gauge_bounded_theorem_note_2026-05-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "matched_2d_4d_decoherence_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "matter_color_depolarization_necessary_for_gauge_link_ad_invariance_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "46533ee3c00f",
+   "out_degree": 3
+  },
+  "matter_gauge_minimal_coupling_fiber_frame_forces_connection_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "d1d09865f0a8",
+   "out_degree": 4
+  },
+  "matter_inertial_closure_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "matter_loop_flux_response_no_uniform_sign_shell_nmod4_resolved_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "matter_radiation_equality_structural_identity_theorem_note_2026-04-24": {
+   "deps_hash": "e7914c71039c",
+   "out_degree": 6
+  },
+  "matter_realization_arena_split_preservation_under_axis_coupled_frames_bounded_theorem_note_2026-07-06": {
+   "deps_hash": "b3ac2d3b0b42",
+   "out_degree": 5
+  },
+  "matter_realization_ks_hop_bridge_edge_diag_membership_bounded_theorem_note_2026-07-06": {
+   "deps_hash": "2d792aa3e992",
+   "out_degree": 5
+  },
+  "matter_realization_qubit_level_cross_site_bilinear_from_k1_structure_bounded_theorem_note_2026-07-06": {
+   "deps_hash": "9c66eb8f4da3",
+   "out_degree": 4
+  },
+  "matter_self_focusing_note": {
+   "deps_hash": "a85d4a63f992",
+   "out_degree": 1
+  },
+  "memory_decay_diagnosis_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "memory_mu2_geometry_sweep_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "mermin_wagner_bogoliubov_textbook_import_note_2026-05-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "meron_half_action_core_from_topological_infrastructure_bounded_note_2026-06-18": {
+   "deps_hash": "109f63cb28a2",
+   "out_degree": 2
+  },
+  "meron_half_instanton_4pi2_over_g2_external_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "2a796a153a89",
+   "out_degree": 2
+  },
+  "meson_charges_from_quark_y_note_2026-05-02": {
+   "deps_hash": "5bb6cdbbaa36",
+   "out_degree": 2
+  },
+  "meson_gauge_invariant_os_transfer_representation_bounded_note_2026-05-30": {
+   "deps_hash": "e45ff6568ef9",
+   "out_degree": 1
+  },
+  "mesoscopic_surrogate_alternate_family_scout_note": {
+   "deps_hash": "60ced80bb877",
+   "out_degree": 6
+  },
+  "mesoscopic_surrogate_annular_tapered_sweep_note": {
+   "deps_hash": "ebd45c2011fb",
+   "out_degree": 2
+  },
+  "mesoscopic_surrogate_backreaction_note": {
+   "deps_hash": "ecce144b9eb1",
+   "out_degree": 6
+  },
+  "mesoscopic_surrogate_compact_floor_sweep_note": {
+   "deps_hash": "feafa2665b19",
+   "out_degree": 3
+  },
+  "mesoscopic_surrogate_compact_floor_sweep_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "mesoscopic_surrogate_h025_constrained_localization_note": {
+   "deps_hash": "feafa2665b19",
+   "out_degree": 3
+  },
+  "mesoscopic_surrogate_localization_frontier_note": {
+   "deps_hash": "75cb5f3c08ff",
+   "out_degree": 4
+  },
+  "mesoscopic_surrogate_localization_sweep_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "mesoscopic_surrogate_multistage_note": {
+   "deps_hash": "85b113908634",
+   "out_degree": 4
+  },
+  "mesoscopic_surrogate_source_2d_note": {
+   "deps_hash": "3a242b0f6335",
+   "out_degree": 4
+  },
+  "mesoscopic_surrogate_threshold_2d_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "mesoscopic_surrogate_two_stage_2d_note": {
+   "deps_hash": "e36a17188660",
+   "out_degree": 5
+  },
+  "microcausality_exact_h_expansion_route_quantified_obstruction_note_2026-06-09": {
+   "deps_hash": "39d65aeb687b",
+   "out_degree": 2
+  },
+  "microcausality_finite_range_h_and_vlr_bridge_theorem_note_2026-05-09": {
+   "deps_hash": "61305a7e0862",
+   "out_degree": 4
+  },
+  "min_time_step_is_the_planck_time_from_the_single_scale_reference_primitive_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "3c3e26353fe0",
+   "out_degree": 4
+  },
+  "min_time_step_tied_to_the_lattice_edge_by_causal_locality_ratio_derived_scale_is_the_clock_rate_no_go_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "6118e3a765d4",
+   "out_degree": 3
+  },
+  "minimal_absorbing_horizon_probe_note": {
+   "deps_hash": "a6594b392dd3",
+   "out_degree": 4
+  },
+  "minimal_axioms": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "minimal_axioms_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "minimal_axioms_2026-05-03": {
+   "deps_hash": "8990b3713089",
+   "out_degree": 1
+  },
+  "minimal_bidirectional_trapping_probe_note": {
+   "deps_hash": "fe791d23a59b",
+   "out_degree": 5
+  },
+  "minimal_source_driven_field_probe_note": {
+   "deps_hash": "6476e2cf8c73",
+   "out_degree": 1
+  },
+  "mirror_2d_gravity_law_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "mirror_2d_operator_cauchy_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "mirror_2d_validation_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "mirror_chokepoint_boundary_fit_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "mirror_chokepoint_note": {
+   "deps_hash": "85aed96d3936",
+   "out_degree": 1
+  },
+  "mirror_gravity_probe_note": {
+   "deps_hash": "da713f94f8ad",
+   "out_degree": 1
+  },
+  "mirror_grown_combined_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "mirror_mutual_information_canonical_families_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "mirror_mutual_information_chokepoint_note": {
+   "deps_hash": "3b044c8926ba",
+   "out_degree": 2
+  },
+  "mirror_mutual_information_note": {
+   "deps_hash": "2cdfd83071d5",
+   "out_degree": 2
+  },
+  "mirror_program_synthesis": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "mirror_vs_central_head_to_head_note": {
+   "deps_hash": "40feb72d9223",
+   "out_degree": 3
+  },
+  "mirror_vs_lattice_program_note": {
+   "deps_hash": "9438f8b0452a",
+   "out_degree": 9
+  },
+  "missing_runner_inventory_2026-05-03": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "mixed_entangled_os_transfer_representation_bounded_note_2026-05-30": {
+   "deps_hash": "e45ff6568ef9",
+   "out_degree": 1
+  },
+  "mixed_os_transfer_representation_bounded_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "moduli_composition_word_dial_sets_densify_word_supplier_residual_bounded_note_2026-07-02": {
+   "deps_hash": "bd3d32b4c997",
+   "out_degree": 2
+  },
+  "momentum_charge_commute_theorem_note_2026-05-02": {
+   "deps_hash": "ec6690abc5b2",
+   "out_degree": 1
+  },
+  "monopole_derived_note": {
+   "deps_hash": "7b7c53a7ca78",
+   "out_degree": 2
+  },
+  "moonshot_diamond_sensor_brainstorm_note": {
+   "deps_hash": "b9e915ea98c4",
+   "out_degree": 4
+  },
+  "moonshot_diamond_sensor_tech_note": {
+   "deps_hash": "b9e915ea98c4",
+   "out_degree": 4
+  },
+  "moonshot_failure_audit_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "moonshot_frontier_brainstorm_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "moonshot_frontier_brainstorm_v2_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "moonshot_frontier_portfolio_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "moonshot_honest_review_2026-04-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "moonshot_mechanism_next_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "moonshot_science_next_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "moonshot_self_gravity_brainstorm_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "moonshot_top20_frontiers": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "moving_source_cross_family_note": {
+   "deps_hash": "fb3aa84178f5",
+   "out_degree": 1
+  },
+  "moving_source_cross_family_replay_note": {
+   "deps_hash": "becbeb297075",
+   "out_degree": 2
+  },
+  "moving_source_retarded_portability_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "multifactor_connes_lott_purchases_not_derives_koide_multiplicity_narrow_obstruction_note_2026-06-04": {
+   "deps_hash": "ecc26c550a95",
+   "out_degree": 10
+  },
+  "multipole_tidal_response_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "multisite_pauli_group_theorem_note_2026-05-02": {
+   "deps_hash": "375d9b100217",
+   "out_degree": 2
+  },
+  "n5_single_generator_clock_exchange_invariance_narrow_no_go_note_2026-06-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "n_eff_from_three_generations_theorem_note_2026-04-24": {
+   "deps_hash": "982000bc2601",
+   "out_degree": 3
+  },
+  "n_f_bounded_z2_reduction_theorem_note_2026-05-07_w2": {
+   "deps_hash": "2400f2e271f8",
+   "out_degree": 5
+  },
+  "n_f_trace_space_bounded_obstruction_note_2026-05-07_w2binary": {
+   "deps_hash": "dd4748251042",
+   "out_degree": 7
+  },
+  "n_f_trace_space_bounded_obstruction_record_invariance_companion_note_2026-06-04": {
+   "deps_hash": "e0625599aa71",
+   "out_degree": 2
+  },
+  "n_f_v3_normalization_bounded_note_2026-05-07_w2norm": {
+   "deps_hash": "be7ef2cbcb99",
+   "out_degree": 7
+  },
+  "naive_lattice_fermion_two_power_d_species_count_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "native_carrier_registration_kernel_rate_vs_unit_variance_point_theorem_note_2026-07-02": {
+   "deps_hash": "f0528fe9a3de",
+   "out_degree": 4
+  },
+  "native_gauge_closure_note": {
+   "deps_hash": "5420992392c0",
+   "out_degree": 2
+  },
+  "native_gauge_left_handed_abelian_surface_bounded_note_2026-05-23": {
+   "deps_hash": "5420992392c0",
+   "out_degree": 2
+  },
+  "native_gauge_transfer_beta_identification_physical_plaquette_relationship_bounded_note_2026-06-12": {
+   "deps_hash": "c86dd99e2b00",
+   "out_degree": 7
+  },
+  "native_gauge_transfer_block_hellmann_monotonicity_rung_eight_bounded_note_2026-06-12": {
+   "deps_hash": "677a46499c34",
+   "out_degree": 2
+  },
+  "native_gauge_transfer_c00_lower_bound_rung_twelve_bounded_note_2026-06-12": {
+   "deps_hash": "ba3ad6325ef9",
+   "out_degree": 2
+  },
+  "native_gauge_transfer_certified_gap_rung_four_bounded_note_2026-06-12": {
+   "deps_hash": "677a46499c34",
+   "out_degree": 2
+  },
+  "native_gauge_transfer_certified_gap_rung_two_bounded_note_2026-06-12": {
+   "deps_hash": "dc9a8b3ece30",
+   "out_degree": 3
+  },
+  "native_gauge_transfer_determinant_mode_tail_rung_thirteen_bounded_note_2026-06-12": {
+   "deps_hash": "709b49cd1e2b",
+   "out_degree": 3
+  },
+  "native_gauge_transfer_diagonal_domination_rung_nine_bounded_note_2026-06-12": {
+   "deps_hash": "2efda481200a",
+   "out_degree": 4
+  },
+  "native_gauge_transfer_hdet_gaussian_core_support_note_2026-06-18": {
+   "deps_hash": "1a311d431cea",
+   "out_degree": 2
+  },
+  "native_gauge_transfer_large_beta_gap_rung_six_bounded_note_2026-06-12": {
+   "deps_hash": "677a46499c34",
+   "out_degree": 2
+  },
+  "native_gauge_transfer_operator_norm_remainder_rung_eight_bounded_note_2026-06-12": {
+   "deps_hash": "d86031b43356",
+   "out_degree": 2
+  },
+  "native_gauge_transfer_outside_weight_tail_rung_fourteen_bounded_note_2026-06-12": {
+   "deps_hash": "af51e4f14e9b",
+   "out_degree": 3
+  },
+  "native_gauge_transfer_reduced_a2_closed_form_rung_sixteen_bounded_note_2026-06-12": {
+   "deps_hash": "8cbdc7a8b37a",
+   "out_degree": 3
+  },
+  "native_gauge_transfer_reduced_a2_discriminant_conjugation_rung_seventeen_bounded_note_2026-06-12": {
+   "deps_hash": "04cef1386fb4",
+   "out_degree": 4
+  },
+  "native_gauge_transfer_reduced_a2_eigenvalue_ratio_eps_cancellation_rung_twenty_bounded_note_2026-06-12": {
+   "deps_hash": "a941551bdb27",
+   "out_degree": 6
+  },
+  "native_gauge_transfer_reduced_a2_spectral_domination_rung_eleven_bounded_note_2026-06-12": {
+   "deps_hash": "221cb15b6c8d",
+   "out_degree": 3
+  },
+  "native_gauge_transfer_reduced_a2_subleading_sign_rung_nineteen_bounded_note_2026-06-12": {
+   "deps_hash": "816011240117",
+   "out_degree": 5
+  },
+  "native_gauge_transfer_reduced_a2_virial_leading_equality_rung_eighteen_bounded_note_2026-06-12": {
+   "deps_hash": "8cbdc7a8b37a",
+   "out_degree": 3
+  },
+  "native_gauge_transfer_strong_coupling_gap_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "677a46499c34",
+   "out_degree": 2
+  },
+  "native_gauge_transfer_uniform_bessel_local_clt_rung_ten_bounded_note_2026-06-12": {
+   "deps_hash": "e9295aff99eb",
+   "out_degree": 1
+  },
+  "native_gauge_transfer_w85_finite_witness_open_gate_note_2026-06-12": {
+   "deps_hash": "63b85afbea4d",
+   "out_degree": 3
+  },
+  "native_gauge_transfer_weyl_determinant_assembly_rung_ten_bounded_note_2026-06-12": {
+   "deps_hash": "66884f8bb85c",
+   "out_degree": 4
+  },
+  "native_gauge_transfer_weyl_determinant_tail_domination_rung_eleven_bounded_note_2026-06-12": {
+   "deps_hash": "ee71ea06a3e9",
+   "out_degree": 4
+  },
+  "native_gauge_transfer_wilson_to_saddle_uniform_rung_nine_bounded_note_2026-06-12": {
+   "deps_hash": "f292f1416726",
+   "out_degree": 3
+  },
+  "native_holonomy_plaquette_center_flux_no_go_note_2026-05-23": {
+   "deps_hash": "2a9d6130ac3c",
+   "out_degree": 2
+  },
+  "nature_discovery_directions_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "nature_ranked_directions_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "neutrino_axiom3_reading_stuck_fanout_note_2026-04-28": {
+   "deps_hash": "20b024f2f449",
+   "out_degree": 6
+  },
+  "neutrino_dirac_global_lift_partial_theorem_note_2026-04-28": {
+   "deps_hash": "7719490ea6a0",
+   "out_degree": 7
+  },
+  "neutrino_dirac_pmns_retained_lane_packet_2026-04-16": {
+   "deps_hash": "320f0c8fdebb",
+   "out_degree": 17
+  },
+  "neutrino_dirac_two_higgs_canonical_reduction_note": {
+   "deps_hash": "acf57d5746c0",
+   "out_degree": 2
+  },
+  "neutrino_dirac_z3_support_trichotomy_note": {
+   "deps_hash": "1530ef68ece0",
+   "out_degree": 4
+  },
+  "neutrino_gamma1_wsource_application_bridge_note_2026-07-09": {
+   "deps_hash": "d8fb11ac801b",
+   "out_degree": 1
+  },
+  "neutrino_lane4_4f_phase2_attack_frame_fanout_note_2026-04-28": {
+   "deps_hash": "a8f0b2ec70d0",
+   "out_degree": 4
+  },
+  "neutrino_lane4_4f_sigma_m_nu_functional_form_theorem_note_2026-04-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "neutrino_lane4_4f_sigma_m_nu_theorem_plan_note_2026-04-28": {
+   "deps_hash": "0a810f136253",
+   "out_degree": 5
+  },
+  "neutrino_lane4_dirac_seesaw_fork_no_go_note_2026-04-27": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "neutrino_lane4_sr2_pfaffian_scalar_two_point_boundary_note_2026-04-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "neutrino_lane4_sr2_premise_audit_note_2026-04-30": {
+   "deps_hash": "8c88ee88a11f",
+   "out_degree": 7
+  },
+  "neutrino_lane4_theorem_plan_note_2026-04-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "neutrino_lane4_workstream_closeout_note_2026-04-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "neutrino_majorana_adjacent_singlet_placement_theorem_note": {
+   "deps_hash": "03e7a0fcf0ce",
+   "out_degree": 3
+  },
+  "neutrino_majorana_algebraic_bridge_obstruction_note": {
+   "deps_hash": "fe304cedd817",
+   "out_degree": 4
+  },
+  "neutrino_majorana_axis_exchange_fixed_point_note": {
+   "deps_hash": "656f58dd1425",
+   "out_degree": 3
+  },
+  "neutrino_majorana_background_normalization_theorem_note": {
+   "deps_hash": "c3bf8c3adbbd",
+   "out_degree": 4
+  },
+  "neutrino_majorana_canonical_local_block_note": {
+   "deps_hash": "176fea7591eb",
+   "out_degree": 4
+  },
+  "neutrino_majorana_charge_two_primitive_reduction_note": {
+   "deps_hash": "a5cac0b904aa",
+   "out_degree": 6
+  },
+  "neutrino_majorana_continuum_bridge_transplant_obstruction_note": {
+   "deps_hash": "70c0f871aa65",
+   "out_degree": 3
+  },
+  "neutrino_majorana_current_atlas_nonrealization_note": {
+   "deps_hash": "7304ed96afb6",
+   "out_degree": 2
+  },
+  "neutrino_majorana_current_stack_exhaustion_note": {
+   "deps_hash": "68cd16e514e2",
+   "out_degree": 5
+  },
+  "neutrino_majorana_current_stack_zero_law_note": {
+   "deps_hash": "1daa01284208",
+   "out_degree": 4
+  },
+  "neutrino_majorana_doublet_block_matching_obstruction_note": {
+   "deps_hash": "d2e9a56ac4df",
+   "out_degree": 4
+  },
+  "neutrino_majorana_endpoint_exchange_midpoint_theorem_note": {
+   "deps_hash": "a94d99ad1dbe",
+   "out_degree": 4
+  },
+  "neutrino_majorana_eps_over_b_residual_ratio_obstruction_note": {
+   "deps_hash": "13ac8942dbd0",
+   "out_degree": 3
+  },
+  "neutrino_majorana_finite_normal_grammar_no_go_note": {
+   "deps_hash": "bed9a6e9695c",
+   "out_degree": 2
+  },
+  "neutrino_majorana_local_pfaffian_uniqueness_note": {
+   "deps_hash": "1c5a05699103",
+   "out_degree": 5
+  },
+  "neutrino_majorana_lower_level_pairing_nogo_note": {
+   "deps_hash": "df15373a5031",
+   "out_degree": 3
+  },
+  "neutrino_majorana_nambu_quadratic_comparator_note": {
+   "deps_hash": "e9f55ac6abcb",
+   "out_degree": 3
+  },
+  "neutrino_majorana_nambu_radial_observable_note": {
+   "deps_hash": "b7b3f014d065",
+   "out_degree": 3
+  },
+  "neutrino_majorana_nambu_source_principle_note": {
+   "deps_hash": "12b8f91cf26a",
+   "out_degree": 4
+  },
+  "neutrino_majorana_native_gaussian_no_go_note": {
+   "deps_hash": "fe2ee27402dc",
+   "out_degree": 1
+  },
+  "neutrino_majorana_no_stationary_scale_theorem_note": {
+   "deps_hash": "833584ec8ef7",
+   "out_degree": 5
+  },
+  "neutrino_majorana_nur_character_boundary_note": {
+   "deps_hash": "99703b52a56e",
+   "out_degree": 2
+  },
+  "neutrino_majorana_nur_charge2_primitive_reduction_note": {
+   "deps_hash": "9b0d44a0bfd6",
+   "out_degree": 5
+  },
+  "neutrino_majorana_observable_principle_obstruction_note": {
+   "deps_hash": "74241de1267a",
+   "out_degree": 5
+  },
+  "neutrino_majorana_operator_axiom_first_note": {
+   "deps_hash": "ee792c8f48cd",
+   "out_degree": 1
+  },
+  "neutrino_majorana_partition_projective_transplant_obstruction_note": {
+   "deps_hash": "0a39f36ca399",
+   "out_degree": 5
+  },
+  "neutrino_majorana_pfaffian_axiom_boundary_note": {
+   "deps_hash": "1c790b5edd82",
+   "out_degree": 3
+  },
+  "neutrino_majorana_pfaffian_extension_note": {
+   "deps_hash": "e89dd85be7ec",
+   "out_degree": 3
+  },
+  "neutrino_majorana_pfaffian_no_forcing_theorem_note": {
+   "deps_hash": "01c435eb522d",
+   "out_degree": 4
+  },
+  "neutrino_majorana_phase_removal_note": {
+   "deps_hash": "67e611d34a29",
+   "out_degree": 4
+  },
+  "neutrino_majorana_residual_sharing_split_theorem_note": {
+   "deps_hash": "fd3b431aa263",
+   "out_degree": 3
+  },
+  "neutrino_majorana_retained_lane_packet_2026-04-16": {
+   "deps_hash": "fcb03306dde8",
+   "out_degree": 9
+  },
+  "neutrino_majorana_retained_lane_packet_2026-04-16_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "neutrino_majorana_scalar_datum_transplant_obstruction_note": {
+   "deps_hash": "e12fad71f8c2",
+   "out_degree": 5
+  },
+  "neutrino_majorana_scale_selector_necessity_note": {
+   "deps_hash": "e78651b67584",
+   "out_degree": 5
+  },
+  "neutrino_majorana_self_dual_staircase_lift_obstruction_note": {
+   "deps_hash": "3957a4696521",
+   "out_degree": 5
+  },
+  "neutrino_majorana_source_ray_theorem_note": {
+   "deps_hash": "27bcec7c5285",
+   "out_degree": 3
+  },
+  "neutrino_majorana_source_response_matching_obstruction_note": {
+   "deps_hash": "d4e8c1ea504e",
+   "out_degree": 5
+  },
+  "neutrino_majorana_staircase_blindness_theorem_note": {
+   "deps_hash": "8c82c4d4f261",
+   "out_degree": 3
+  },
+  "neutrino_majorana_tensor_variational_transplant_obstruction_note": {
+   "deps_hash": "162d240dfeac",
+   "out_degree": 3
+  },
+  "neutrino_majorana_unique_source_slot_note": {
+   "deps_hash": "2dae2998975c",
+   "out_degree": 4
+  },
+  "neutrino_majorana_z3_nonactivation_theorem_note": {
+   "deps_hash": "0112fe413f90",
+   "out_degree": 5
+  },
+  "neutrino_mass_derived_note": {
+   "deps_hash": "daaac9972ba7",
+   "out_degree": 6
+  },
+  "neutrino_mass_reduction_to_dirac_note": {
+   "deps_hash": "5e8f10995b7c",
+   "out_degree": 2
+  },
+  "neutrino_mass_reduction_to_dirac_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "neutrino_normal_grammar_u1_rigidity_note_2026-04-28": {
+   "deps_hash": "beeaeafd21f8",
+   "out_degree": 4
+  },
+  "neutrino_retained_lanes_note_2026-04-16": {
+   "deps_hash": "ba8009520ac7",
+   "out_degree": 5
+  },
+  "neutrino_retained_observable_bounds_theorem_note_2026-04-24": {
+   "deps_hash": "07d0f514ba20",
+   "out_degree": 4
+  },
+  "neutrino_retained_status_note_2026-04-16": {
+   "deps_hash": "8eef42842563",
+   "out_degree": 37
+  },
+  "neutrino_sole_axiom_full_closure_boundary_note": {
+   "deps_hash": "4d6225763e60",
+   "out_degree": 5
+  },
+  "neutrino_two_amplitude_last_mile_reduction_note": {
+   "deps_hash": "8d480f7661e7",
+   "out_degree": 5
+  },
+  "new_parity_is_circulant_phase_narrow_theorem_note_2026-05-23": {
+   "deps_hash": "0f69788696ca",
+   "out_degree": 4
+  },
+  "newphysics_np_ckm_wolfenstein_note_2026-05-10_npckm": {
+   "deps_hash": "4cfc3f54bcc4",
+   "out_degree": 9
+  },
+  "newphysics_np_muon_g2_note_2026-05-10_npg2": {
+   "deps_hash": "ef3c6fe26668",
+   "out_degree": 8
+  },
+  "newphysics_np_neutrino_pmns_note_2026-05-10_npnu": {
+   "deps_hash": "6add7e34234d",
+   "out_degree": 12
+  },
+  "newphysics_np_strong_cp_theta_note_2026-05-10_npcp": {
+   "deps_hash": "a007a5ff3290",
+   "out_degree": 5
+  },
+  "newton_derivation_note": {
+   "deps_hash": "81a9f0943f6c",
+   "out_degree": 3
+  },
+  "newton_derivation_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "newton_derivation_top4_bridge_note": {
+   "deps_hash": "9233abb21d0b",
+   "out_degree": 4
+  },
+  "newton_law_derived_note": {
+   "deps_hash": "cde5db273f36",
+   "out_degree": 1
+  },
+  "newton_persistent_pattern_control_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "newton_poisson_flat_friedmann_textbook_import_note_2026-05-17": {
+   "deps_hash": "2d6927c28c47",
+   "out_degree": 2
+  },
+  "newtonian_distance_law_confirmed": {
+   "deps_hash": "ee879b3e093d",
+   "out_degree": 1
+  },
+  "next_chunk_recommendation": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "nn_lattice_rescaled_c2_derivation_note_2026-05-10": {
+   "deps_hash": "f8563a774007",
+   "out_degree": 3
+  },
+  "nn_lattice_rescaled_c2_derivation_note_2026-05-10_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "nn_lattice_rescaled_c_arm_alpha_constrained_refit_note_2026-05-10": {
+   "deps_hash": "b2be88d12b30",
+   "out_degree": 2
+  },
+  "nn_lattice_rescaled_c_arm_alpha_constrained_refit_note_2026-05-10_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "nn_lattice_rescaled_c_arm_derivation_note_2026-05-10": {
+   "deps_hash": "ab6739030ef6",
+   "out_degree": 2
+  },
+  "nn_lattice_rescaled_c_arm_derivation_note_2026-05-10_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "nn_lattice_rescaled_c_arm_nlo_saddle_note_2026-05-10": {
+   "deps_hash": "27f5a740e297",
+   "out_degree": 3
+  },
+  "nn_lattice_rescaled_c_arm_nnlo_saddle_note_2026-05-10": {
+   "deps_hash": "6785ca79c45e",
+   "out_degree": 4
+  },
+  "nn_lattice_rescaled_continuum_identification_note_2026-05-10": {
+   "deps_hash": "37e880e7239b",
+   "out_degree": 3
+  },
+  "nn_lattice_rescaled_full_kernel_identification_note_2026-05-10": {
+   "deps_hash": "abe85c73a4b9",
+   "out_degree": 2
+  },
+  "nn_lattice_rescaled_kernel_identification_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "nn_lattice_rescaled_operator_cauchy_convergence_note_2026-05-10": {
+   "deps_hash": "8e2fabae6966",
+   "out_degree": 4
+  },
+  "nn_lattice_rescaled_rg_gravity_saturation_note_2026-05-10": {
+   "deps_hash": "3f31e8c642d0",
+   "out_degree": 4
+  },
+  "nn_lattice_rescaled_universal_parameter_theorem_note_2026-05-10": {
+   "deps_hash": "d8ee1c26b8bd",
+   "out_degree": 2
+  },
+  "no_per_site_bosonic_ccr_theorem_note_2026-05-02": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "no_per_site_chirality_theorem_note_2026-05-02": {
+   "deps_hash": "20b934724423",
+   "out_degree": 2
+  },
+  "no_recovery_intermediate_budget_efficiency_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "6de2016ba8a1",
+   "out_degree": 2
+  },
+  "noether_source_current_classification_bounded_note_2026-07-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "nonlabel_grown_basin_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "nonlabel_grown_drift_basin_note": {
+   "deps_hash": "ad0a0cb37ed7",
+   "out_degree": 1
+  },
+  "nonlinear_born_gravity_note": {
+   "deps_hash": "4f2cd49e2cb4",
+   "out_degree": 1
+  },
+  "nspt_high_order_lattice_alpha_n_coefficient_external_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "observable_generator_additivity_from_cluster_decomposition_theorem_note_2026-05-10": {
+   "deps_hash": "d522a9c08709",
+   "out_degree": 2
+  },
+  "observable_principle_audit_note_2026-05-02": {
+   "deps_hash": "d8fb11ac801b",
+   "out_degree": 1
+  },
+  "observable_principle_consumed_sector_bounded_by_ac_phi_lambda_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "0e79a828d369",
+   "out_degree": 6
+  },
+  "observable_principle_det_unique_multiplicative_character_form_selection_narrow_theorem_note_2026-05-28": {
+   "deps_hash": "af62e5496448",
+   "out_degree": 12
+  },
+  "observable_principle_from_axiom_note": {
+   "deps_hash": "26e415f3ae16",
+   "out_degree": 5
+  },
+  "observable_principle_klein_four_apbc_orbit_partition_closed_form_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "61fcb6af8ea9",
+   "out_degree": 10
+  },
+  "observable_principle_p1_br_license_from_record_capacity_narrow_no_go_note_2026-06-10": {
+   "deps_hash": "fcc5a16ab0c1",
+   "out_degree": 13
+  },
+  "observable_principle_p1_bridge_connes_nc_spectral_narrow_note_2026-05-21": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "observable_principle_p1_bridge_extensivity_primitive_narrow_note_2026-05-21": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "observable_principle_p1_bridge_framework_internal_narrow_bounded_note_2026-05-17": {
+   "deps_hash": "fc87dfd9f553",
+   "out_degree": 12
+  },
+  "observable_principle_p1_bridge_free_cumulant_route_narrow_note_2026-05-21": {
+   "deps_hash": "966bea54bf2c",
+   "out_degree": 8
+  },
+  "observable_principle_p1_bridge_gleason_busch_route_narrow_note_2026-05-21": {
+   "deps_hash": "d1e18b54a875",
+   "out_degree": 7
+  },
+  "observable_principle_p1_bridge_jones_index_subfactor_narrow_note_2026-05-21": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "observable_principle_p1_bridge_locality_of_source_derivatives_narrow_note_2026-05-21": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "observable_principle_p1_bridge_operator_algebraic_external_narrow_bounded_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "observable_principle_p1_bridge_operator_algebraic_qubit_reattempt_narrow_note_2026-05-21": {
+   "deps_hash": "ae96a59375f0",
+   "out_degree": 8
+  },
+  "observable_principle_p1_bridge_pre_record_tracial_route_narrow_note_2026-05-21": {
+   "deps_hash": "8c4ba0a61597",
+   "out_degree": 5
+  },
+  "observable_principle_p1_bridge_route_d_sharpened_no_go_note_2026-05-17": {
+   "deps_hash": "151c65095b78",
+   "out_degree": 8
+  },
+  "observable_principle_p1_bridge_route_e_tao_cross_disciplinary_narrow_bounded_note_2026-05-17": {
+   "deps_hash": "d8fb11ac801b",
+   "out_degree": 1
+  },
+  "observable_principle_p1_bridge_shannon_khinchin_external_narrow_bounded_note_2026-05-17": {
+   "deps_hash": "db50a4c55f07",
+   "out_degree": 1
+  },
+  "observable_principle_p1_bridge_structural_reframing_narrow_note_2026-05-21": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "observable_principle_p1_bridge_tempesta_composability_external_narrow_bounded_note_2026-05-17": {
+   "deps_hash": "90be4831c9e5",
+   "out_degree": 9
+  },
+  "observable_principle_p1_bridge_tomita_gibbs_modular_narrow_note_2026-05-21": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "observable_principle_p1_bridge_wave11_route_b_harlow_disjoint_additivity_external_narrow_bounded_note_2026-05-17": {
+   "deps_hash": "1eea0a5eb284",
+   "out_degree": 5
+  },
+  "observable_principle_p1_bridge_wave11_route_c_doplicher_roberts_reconstruction_external_narrow_bounded_note_2026-05-17": {
+   "deps_hash": "1eea0a5eb284",
+   "out_degree": 5
+  },
+  "observable_principle_p1_campaign_closure_synthesis_note_2026-05-18": {
+   "deps_hash": "5cf228ba41b2",
+   "out_degree": 10
+  },
+  "observable_principle_p1_cap_k_from_finite_speed_registration_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "ba964a7df590",
+   "out_degree": 13
+  },
+  "observable_principle_p1_exact_additivity_zero_offset_repair_note_2026-06-13": {
+   "deps_hash": "8825acfb90c6",
+   "out_degree": 1
+  },
+  "observable_principle_p1_exponent_barrier_parameter_selector_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "5e0d7db285b3",
+   "out_degree": 7
+  },
+  "observable_principle_p1_exponent_fixing_irreducibility_narrow_note_2026-05-31": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "observable_principle_p1_nu_license_from_retained_surface_narrow_no_go_note_2026-06-10": {
+   "deps_hash": "b2beb187a5bc",
+   "out_degree": 8
+  },
+  "observable_principle_p1_p2_from_qubit_trace_note_2026-05-20": {
+   "deps_hash": "4bc66054212d",
+   "out_degree": 3
+  },
+  "observable_principle_p1_registration_realization_pin_consolidation_narrow_theorem_note_2026-06-11": {
+   "deps_hash": "0e9776646ebf",
+   "out_degree": 12
+  },
+  "observable_principle_p1_symmetry_type_energy_readout_narrow_note_2026-06-02": {
+   "deps_hash": "9504f48674a7",
+   "out_degree": 9
+  },
+  "observable_principle_p1p2_two_stage_synthesis_narrow_theorem_note_2026-05-28": {
+   "deps_hash": "31b4b7849801",
+   "out_degree": 6
+  },
+  "observable_principle_p2_det_realization_bridge_conditional_on_fermionic_frame_narrow_theorem_note_2026-05-28": {
+   "deps_hash": "33c777e1382d",
+   "out_degree": 4
+  },
+  "observable_principle_p2_phase_blindness_sector_resolved_narrow_theorem_note_2026-06-04": {
+   "deps_hash": "e02f630b4075",
+   "out_degree": 9
+  },
+  "observable_principle_positive_source_cone_p2_elimination_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "d8fb11ac801b",
+   "out_degree": 1
+  },
+  "observable_principle_product_factoring_does_not_force_product_character_no_go_note_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "observable_principle_real_d_block_uniqueness_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "6eeeeb39c927",
+   "out_degree": 1
+  },
+  "observable_principle_record_scalar_map_no_go_note_2026-06-05": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "observable_principle_scale_invariant_source_response_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "e99cf4421e8e",
+   "out_degree": 1
+  },
+  "observable_principle_source_coupled_local_action_admission_candidate_note_2026-05-21": {
+   "deps_hash": "e65a6367bf09",
+   "out_degree": 12
+  },
+  "observable_principle_t1d_determinant_context_quotient_bridge_note_2026-06-18": {
+   "deps_hash": "8646fad4fee0",
+   "out_degree": 1
+  },
+  "observable_principle_t1d_determinant_readout_independence_no_go_note_2026-06-16": {
+   "deps_hash": "ca8fa4076860",
+   "out_degree": 2
+  },
+  "observable_principle_t1d_positive_diagonal_readout_classifier_note_2026-06-18": {
+   "deps_hash": "92ebd754048c",
+   "out_degree": 2
+  },
+  "occupancy_atom_is_the_outcome_dictionary_flow_selects_equipartition_bounded_note_2026-06-12": {
+   "deps_hash": "61b6add32af6",
+   "out_degree": 3
+  },
+  "occupancy_nonexclusivity_mixture_bound_note_2026-06-09": {
+   "deps_hash": "188680808cab",
+   "out_degree": 3
+  },
+  "occupancy_readout_exponent_berezin_subsumption_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "95b72757a210",
+   "out_degree": 5
+  },
+  "oh_schur_boundary_action_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "oh_seven_site_star_shell_leverage_positive_theorem_note_2026-06-10": {
+   "deps_hash": "5b15e3387983",
+   "out_degree": 3
+  },
+  "oh_static_constraint_lift_note": {
+   "deps_hash": "b52689e724c7",
+   "out_degree": 4
+  },
+  "ollivier_einstein_proxy_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "omega_lambda_derivation_note": {
+   "deps_hash": "9b59d77232dc",
+   "out_degree": 1
+  },
+  "omega_lambda_matter_bridge_theorem_note_2026-04-22": {
+   "deps_hash": "f4f3f6286756",
+   "out_degree": 2
+  },
+  "one_generation_anomaly_singlet_completion_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "3ab31b07251d",
+   "out_degree": 1
+  },
+  "one_generation_matter_closure_note": {
+   "deps_hash": "8ab2176d839a",
+   "out_degree": 2
+  },
+  "one_parameter_reduced_shell_law_helpers_umbrella_note_2026-04-13": {
+   "deps_hash": "52a20c694372",
+   "out_degree": 2
+  },
+  "one_parameter_reduced_shell_law_note": {
+   "deps_hash": "03d023bc9c3c",
+   "out_degree": 1
+  },
+  "one_time_dimension_dt1_reduces_to_emergent_dynamics_gate_open_gate_note_2026-06-17": {
+   "deps_hash": "6b456ae72212",
+   "out_degree": 3
+  },
+  "onsite_charge_conserving_endpoint_symmetric_common_hamiltonian_strict_qca_dichotomy_bounded_theorem_note_2026-07-12": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "open_koide_flavor_cluster_consolidation_map_2026-06-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "open_shell_invariant_locus_conditional_neutrality_no_derived_selector_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "5ed0add88d9d",
+   "out_degree": 4
+  },
+  "orbit_occupancy_neutrino_out_of_sample_program_note_2026-06-09": {
+   "deps_hash": "e6b42e44866e",
+   "out_degree": 3
+  },
+  "ordered_lattice_packet_reidentification_note": {
+   "deps_hash": "e0d84bfa17f7",
+   "out_degree": 2
+  },
+  "ordered_lattice_quasi_persistent_relaunch_2d_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ordered_lattice_quasi_persistent_relaunch_note": {
+   "deps_hash": "599444f3c8b2",
+   "out_degree": 1
+  },
+  "osterwalder_schrader_from_framework_narrow_theorem_note_2026-05-27": {
+   "deps_hash": "37b34cf3d5e2",
+   "out_degree": 3
+  },
+  "owner_decision_surface_class_b_premise_reversion_2026-07-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "p2_euclidean_vs_lorentzian_fork_2026-06-05": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "p2_kcpt_orbit_temporal_factor_no_go_2026-06-06": {
+   "deps_hash": "9076e175c5ad",
+   "out_degree": 5
+  },
+  "p2_native_lorentzian_magnitude_test_2026-06-05": {
+   "deps_hash": "d87774012c3c",
+   "out_degree": 11
+  },
+  "p2_phase_blindness_from_rp_transfer_trace_bridge_note_2026-05-28": {
+   "deps_hash": "3891e9f2a7b5",
+   "out_degree": 3
+  },
+  "p2_wick_rotation_sign_epsilon_closure_narrow_theorem_note_2026-05-27": {
+   "deps_hash": "739b524da2eb",
+   "out_degree": 4
+  },
+  "p3_coupling_is_retention_eligible_composition_2026-06-06": {
+   "deps_hash": "e1e14fab8993",
+   "out_degree": 6
+  },
+  "p3_vacuum_stability_knife_edge_in_yt_robustness_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "775df01d5991",
+   "out_degree": 2
+  },
+  "p_flux_finite_species_density_from_determinant_matsubara_surface_narrow_no_go_note_2026-06-10": {
+   "deps_hash": "229a15cfef10",
+   "out_degree": 22
+  },
+  "p_flux_point_zero_set_from_retained_rows_narrow_no_go_note_2026-06-10": {
+   "deps_hash": "150445de041c",
+   "out_degree": 12
+  },
+  "p_flux_selection_from_matter_content_narrow_no_go_note_2026-06-10": {
+   "deps_hash": "391fa86eb332",
+   "out_degree": 12
+  },
+  "p_flux_selection_via_fsb_k_and_z_certificate_conditional_theorem_note_2026-06-11": {
+   "deps_hash": "525d7ea9c445",
+   "out_degree": 5
+  },
+  "p_lh_ncg_primitive_underdetermination_boundary_note_2026-06-18": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "p_lh_order_one_staggered_dirac_open_gate_note_2026-05-10_pplh_order_one": {
+   "deps_hash": "8a73076a5ac8",
+   "out_degree": 6
+  },
+  "packet_memory_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "pairwise_commuting_endpoint_symmetric_edge_hamiltonian_classification_and_strict_qca_boundary_bounded_theorem_note_2026-07-12": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "paper_outline_2026-04-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "parity_operator_basis_dimension5_lv_no_go_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "parity_violation_does_not_reach_generation_triplet_narrow_theorem_note_2026-05-23": {
+   "deps_hash": "f0afa2cae74e",
+   "out_degree": 3
+  },
+  "past_hypothesis_existence_reduction_append_only_well_foundedness_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "72195f0ab7ce",
+   "out_degree": 5
+  },
+  "patched_stationary_system_pl_s3_theorem_note_2026-05-03": {
+   "deps_hash": "30c9889a1997",
+   "out_degree": 3
+  },
+  "pauli_closed_shell_color_marginal_discharge_discrete_reduction_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "49572d19ae22",
+   "out_degree": 8
+  },
+  "pauli_exclusion_from_spin_statistics_theorem_note_2026-05-02": {
+   "deps_hash": "e1d78d788239",
+   "out_degree": 1
+  },
+  "pauli_group_order_theorem_note_2026-05-02": {
+   "deps_hash": "225c65695ac9",
+   "out_degree": 1
+  },
+  "per_plaquette_from_adjacency_license_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "166600f6dd19",
+   "out_degree": 3
+  },
+  "per_plaquette_license_covariant_subdomain_classification_note_2026-07-12": {
+   "deps_hash": "3e8b1d3db13e",
+   "out_degree": 2
+  },
+  "per_plaquette_license_one_tick_reachability_derivation_narrow_theorem_note_2026-07-12": {
+   "deps_hash": "f52cf35bfe49",
+   "out_degree": 3
+  },
+  "per_site_k_equals_1_ratification_reaudit_manifest_note_2026-05-22": {
+   "deps_hash": "127cfec1a18d",
+   "out_degree": 2
+  },
+  "per_site_su2_bridge_bounded_obstruction_note_2026-05-07_w2bridge": {
+   "deps_hash": "f2155727f499",
+   "out_degree": 7
+  },
+  "per_site_su2_spin_half_theorem_note_2026-05-02": {
+   "deps_hash": "20b934724423",
+   "out_degree": 2
+  },
+  "periodic_2d_wraparound_fix_note_2026-04-11": {
+   "deps_hash": "4a473da69b2d",
+   "out_degree": 7
+  },
+  "persistent_inertial_object_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_inertial_response_readiness_note": {
+   "deps_hash": "901b11cb7736",
+   "out_degree": 8
+  },
+  "persistent_object_adaptive_readout_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_object_adaptive_readout_v2_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_object_blended_readout_outer_transfer_sweep_note_2026-04-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_object_blended_readout_transfer_sweep_note_2026-04-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_object_compact_inertial_probe_note_2026-04-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_object_compact_update_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_object_exact_lattice_park_note_2026-04-16": {
+   "deps_hash": "48a447296e7f",
+   "out_degree": 7
+  },
+  "persistent_object_green_scout_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_object_inward_boundary_floor_diagnosis_note_2026-04-16": {
+   "deps_hash": "fc609177da20",
+   "out_degree": 1
+  },
+  "persistent_object_multistage_floor_sweep_note_2026-04-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_object_readout_localization_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_object_readout_taper_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_object_top3_multistage_probe_note_2026-04-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_object_top4_multistage_outer_transfer_sweep_note_2026-04-16": {
+   "deps_hash": "80abeda5f5f7",
+   "out_degree": 2
+  },
+  "persistent_object_top4_multistage_transfer_sweep_note_2026-04-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_record_as_kraus_operator_note_2026-05-20": {
+   "deps_hash": "2b28e8775358",
+   "out_degree": 3
+  },
+  "persistent_record_instrument_construction_narrow_theorem_note_2026-05-22": {
+   "deps_hash": "ee594bc7ac94",
+   "out_degree": 2
+  },
+  "persistent_record_matched_compare_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_record_overlap_kernel_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_record_refinement_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "persistent_record_sidebit_note": {
+   "deps_hash": "c7f25fda525e",
+   "out_degree": 2
+  },
+  "physical_hermitian_hamiltonian_and_sme_bridge_note_2026-04-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "physical_lattice_foundational_interpretation_note_2026-05-08": {
+   "deps_hash": "bb33eb7b48d3",
+   "out_degree": 1
+  },
+  "physical_lattice_necessity_dep_declaration_audit_note_2026-05-02": {
+   "deps_hash": "bb33eb7b48d3",
+   "out_degree": 1
+  },
+  "physical_lattice_necessity_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "physics_critic_tracker": {
+   "deps_hash": "8ed7e6bfb298",
+   "out_degree": 1
+  },
+  "physics_first_attack_plan": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "physics_qa_tracker": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "pl_s3_atlas_refinement_compatibility_theorem_note_2026-05-03": {
+   "deps_hash": "bb95e87c2d44",
+   "out_degree": 2
+  },
+  "pl_s3_regge_offround_canonical_narrow_theorem_note_2026-06-17": {
+   "deps_hash": "538c75fab058",
+   "out_degree": 2
+  },
+  "pl_topology_infrastructure_textbook_import_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "planck_anchor_bp_derivation_probe_2026-06-05": {
+   "deps_hash": "a9376ea05880",
+   "out_degree": 11
+  },
+  "planck_boundary_action_density_accepted_premise_bridge_bounded_note_2026-05-26": {
+   "deps_hash": "b8164ce96292",
+   "out_degree": 4
+  },
+  "planck_boundary_density_extension_theorem_note_2026-04-24": {
+   "deps_hash": "f9df6098ab80",
+   "out_degree": 1
+  },
+  "planck_boundary_orientation_incidence_no_go_note_2026-04-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "planck_finite_response_no_go_note_2026-04-24": {
+   "deps_hash": "25c378ab3dc6",
+   "out_degree": 1
+  },
+  "planck_from_structure_path_opening_meta_note_2026-05-10": {
+   "deps_hash": "956be0352fd5",
+   "out_degree": 7
+  },
+  "planck_hidden_character_delta_zero_positive_theorem_note_2026-05-10_planckp2": {
+   "deps_hash": "69670ed40183",
+   "out_degree": 7
+  },
+  "planck_hidden_character_delta_zero_positive_theorem_note_2026-05-10_planckp2_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "planck_link_local_first_variation_p_a_forcing_theorem_note_2026-04-30": {
+   "deps_hash": "9dba3e384a4c",
+   "out_degree": 7
+  },
+  "planck_mass_conventional_anchor_meta_note_2026-05-27": {
+   "deps_hash": "bbf30a427a7b",
+   "out_degree": 2
+  },
+  "planck_orientation_principle_bounded_note_2026-05-10_planckp3": {
+   "deps_hash": "e54333481da6",
+   "out_degree": 6
+  },
+  "planck_parent_source_hidden_character_no_go_note_2026-04-24": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "planck_primitive_clifford_majorana_edge_derivation_theorem_note_2026-04-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "planck_primitive_coframe_boundary_carrier_theorem_note_2026-04-25": {
+   "deps_hash": "5dec441134b6",
+   "out_degree": 3
+  },
+  "planck_scale_conditional_completion_note_2026-04-24": {
+   "deps_hash": "87792b14c7d7",
+   "out_degree": 10
+  },
+  "planck_scale_lane_status_note_2026-04-23": {
+   "deps_hash": "acd75ee37664",
+   "out_degree": 18
+  },
+  "planck_source_unit_normalization_support_theorem_note_2026-04-25": {
+   "deps_hash": "1a614cf185b3",
+   "out_degree": 3
+  },
+  "planck_substrate_to_carrier_forcing_bounded_note_2026-05-10_planckp1": {
+   "deps_hash": "f09f175e6b63",
+   "out_degree": 10
+  },
+  "planck_target3_clifford_phase_bridge_theorem_note_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "planck_target3_coframe_response_accepted_premise_bridge_bounded_note_2026-05-26": {
+   "deps_hash": "4514c6f97532",
+   "out_degree": 1
+  },
+  "planck_target3_phase_unit_edge_statistics_boundary_note_2026-04-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "plaquette_4d_mc_fss_numerical_theorem_note_2026-05-05": {
+   "deps_hash": "1d84ab0b5e3f",
+   "out_degree": 4
+  },
+  "plaquette_4d_mc_support_note_2026-05-04": {
+   "deps_hash": "75b087c72077",
+   "out_degree": 4
+  },
+  "plaquette_alpha_s_chain_audit_map_synthesis_meta_note_2026-05-10": {
+   "deps_hash": "ff012eac938a",
+   "out_degree": 15
+  },
+  "plaquette_beta6_perturbative_derivation_bounded_obstruction_note_2026-05-27": {
+   "deps_hash": "8921c2773a25",
+   "out_degree": 1
+  },
+  "plaquette_beta6_strong_coupling_character_narrow_theorem_note_2026-05-27": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "plaquette_beta9_environment_cluster_identification_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "3419a3cc1527",
+   "out_degree": 5
+  },
+  "plaquette_bootstrap_framework_integration_note_2026-05-03": {
+   "deps_hash": "b10fc14eb614",
+   "out_degree": 4
+  },
+  "plaquette_bootstrap_framework_specific_positivity_note_2026-05-03": {
+   "deps_hash": "298f827dba90",
+   "out_degree": 5
+  },
+  "plaquette_c6_derivation_framework_su3_narrow_theorem_note_2026-05-27": {
+   "deps_hash": "658cb3921873",
+   "out_degree": 3
+  },
+  "plaquette_environment_contraction_cost_verification_bounded_note_2026-06-12": {
+   "deps_hash": "334b38c34257",
+   "out_degree": 3
+  },
+  "plaquette_environment_quotient_equivariance_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "fa7d37481156",
+   "out_degree": 3
+  },
+  "plaquette_hierarchy_polynomial_boundedness_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "plaquette_marked_slice_bulk_average_translation_bridge_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "4a404eb776b8",
+   "out_degree": 5
+  },
+  "plaquette_mc_certification_protocol_note_2026-06-11": {
+   "deps_hash": "0e8c09b236ed",
+   "out_degree": 3
+  },
+  "plaquette_observable_uniqueness_bounded_note_2026-05-25": {
+   "deps_hash": "541aa0047535",
+   "out_degree": 5
+  },
+  "plaquette_per_step_per_plaquette_normalization_bridge_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "f98ce20816b9",
+   "out_degree": 4
+  },
+  "plaquette_self_consistency_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "plaquette_source_sector_pullback_identity_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "df8f06acee95",
+   "out_degree": 10
+  },
+  "plaquette_v1_picard_fuchs_ode_all_order_proof_note_2026-05-09": {
+   "deps_hash": "a7f356acb90f",
+   "out_degree": 4
+  },
+  "plaquette_v1_picard_fuchs_ode_bounded_synthesis_note_2026-05-06": {
+   "deps_hash": "e126d597d461",
+   "out_degree": 4
+  },
+  "plaquette_v1_picard_fuchs_ode_koutschan_minimality_note_2026-05-06": {
+   "deps_hash": "b6410e4e0f3c",
+   "out_degree": 2
+  },
+  "plaquette_v1_picard_fuchs_ode_minimality_proof_note_2026-05-06": {
+   "deps_hash": "db3705cb7af2",
+   "out_degree": 1
+  },
+  "plaquette_v1_picard_fuchs_ode_note_2026-05-05": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "plaquette_v1_picard_fuchs_ode_rank_bound_citation_note_2026-05-06": {
+   "deps_hash": "b6410e4e0f3c",
+   "out_degree": 2
+  },
+  "plaquette_v1_picard_fuchs_ode_rank_exclusion_r2_d12_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "17a9f479e310",
+   "out_degree": 1
+  },
+  "plaquette_value_derivation_program_specification_and_bracket_reduction_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "676d6bb16b79",
+   "out_degree": 6
+  },
+  "pmns_active_four_real_source_from_transport_note": {
+   "deps_hash": "fa20501d8998",
+   "out_degree": 1
+  },
+  "pmns_active_four_real_source_from_transport_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "pmns_branch_conditioned_quadratic_sheet_closure_note": {
+   "deps_hash": "bbce5dbc42be",
+   "out_degree": 3
+  },
+  "pmns_branch_selector_cp_sheet_blindness_note_2026-05-03": {
+   "deps_hash": "a5e35bd85d48",
+   "out_degree": 9
+  },
+  "pmns_c3_character_holonomy_closure_note": {
+   "deps_hash": "757d5650aa81",
+   "out_degree": 3
+  },
+  "pmns_c3_character_holonomy_closure_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "pmns_c3_character_mode_reduction_note": {
+   "deps_hash": "1491c04cfcac",
+   "out_degree": 4
+  },
+  "pmns_c3_nontrivial_current_boundary_note": {
+   "deps_hash": "97df37464456",
+   "out_degree": 4
+  },
+  "pmns_chart_constant_q_koide_brannen_lift_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "fc787f0e700e",
+   "out_degree": 5
+  },
+  "pmns_chart_constants_retention_note_2026-05-03": {
+   "deps_hash": "6db9ebcd5056",
+   "out_degree": 8
+  },
+  "pmns_commutant_eigenoperator_selector_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "pmns_corner_transport_active_block_note": {
+   "deps_hash": "4b2fd53bcc2f",
+   "out_degree": 3
+  },
+  "pmns_current_bank_value_selection_nogo_note": {
+   "deps_hash": "9237383de8a3",
+   "out_degree": 4
+  },
+  "pmns_dcp_branch_robustness_resolved_by_measured_theta23_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "0f102b2b7c93",
+   "out_degree": 1
+  },
+  "pmns_dcp_forecast_standing_degrades_under_nufit6_bounded_note_2026-06-08": {
+   "deps_hash": "ee90cc2abfd3",
+   "out_degree": 2
+  },
+  "pmns_from_dm_neutrino_source_h_diagonalization_closure_theorem_note_2026-04-17": {
+   "deps_hash": "e5117eb4f4e9",
+   "out_degree": 15
+  },
+  "pmns_graph_axis_to_active_lane_bridge_note": {
+   "deps_hash": "3c09bbe8792b",
+   "out_degree": 3
+  },
+  "pmns_graph_commutant_cycle_value_boundary_note": {
+   "deps_hash": "ca486085ed8a",
+   "out_degree": 4
+  },
+  "pmns_graph_first_axis_alignment_note": {
+   "deps_hash": "fb6334ae17f4",
+   "out_degree": 5
+  },
+  "pmns_graph_first_cycle_frame_support_note": {
+   "deps_hash": "426c15179b36",
+   "out_degree": 3
+  },
+  "pmns_graph_first_forward_cycle_residual_swap_bridge_narrow_theorem_note_2026-05-24": {
+   "deps_hash": "3e24368dacff",
+   "out_degree": 3
+  },
+  "pmns_graph_first_residual_antiunitary_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "337f2ad6feb0",
+   "out_degree": 3
+  },
+  "pmns_hw1_response_column_schur_bridge_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "102c9f160e07",
+   "out_degree": 1
+  },
+  "pmns_hw1_source_transfer_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "pmns_lower_level_end_to_end_closure_note": {
+   "deps_hash": "4790f9ae8517",
+   "out_degree": 1
+  },
+  "pmns_minimal_branch_nonselection_note": {
+   "deps_hash": "89aabcda8fd3",
+   "out_degree": 1
+  },
+  "pmns_neutrino_mass_observables_no_prediction_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "9125400a02cc",
+   "out_degree": 12
+  },
+  "pmns_oriented_cycle_channel_value_law_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "pmns_oriented_cycle_reduced_channel_nonselection_note": {
+   "deps_hash": "2cdad8e95fec",
+   "out_degree": 3
+  },
+  "pmns_oriented_cycle_selection_structure_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "pmns_oriented_cycle_two_prong_composition_bridge_bounded_note_2026-05-26": {
+   "deps_hash": "3d3f79cf5fe3",
+   "out_degree": 3
+  },
+  "pmns_predictive_surface_characterization_campaign_synthesis_note_2026-05-17": {
+   "deps_hash": "2f8133beed22",
+   "out_degree": 20
+  },
+  "pmns_right_conjugacy_invariant_no_go_note": {
+   "deps_hash": "1e42ebe39e33",
+   "out_degree": 2
+  },
+  "pmns_right_conjugacy_invariant_record_axiom_invariance_companion_note_2026-06-04": {
+   "deps_hash": "9424a20a4e99",
+   "out_degree": 4
+  },
+  "pmns_right_polar_section_note": {
+   "deps_hash": "42c719394292",
+   "out_degree": 2
+  },
+  "pmns_scalar_bridge_nonrealization_note": {
+   "deps_hash": "ccc6ac9ff66b",
+   "out_degree": 2
+  },
+  "pmns_sector_exchange_nonforcing_note": {
+   "deps_hash": "c6c5176494e6",
+   "out_degree": 3
+  },
+  "pmns_sector_orientation_orbit_note": {
+   "deps_hash": "12aee227cbc2",
+   "out_degree": 5
+  },
+  "pmns_selector_bank_nonrealization_note": {
+   "deps_hash": "5f544019e068",
+   "out_degree": 1
+  },
+  "pmns_selector_class_space_uniqueness_note": {
+   "deps_hash": "06adf22c7283",
+   "out_degree": 3
+  },
+  "pmns_selector_current_stack_zero_law_note": {
+   "deps_hash": "0c060142220a",
+   "out_degree": 3
+  },
+  "pmns_selector_nonuniversal_support_reduction_note": {
+   "deps_hash": "48ced8fb007c",
+   "out_degree": 4
+  },
+  "pmns_selector_sector_odd_reduction_note": {
+   "deps_hash": "1eddd290b8e6",
+   "out_degree": 2
+  },
+  "pmns_selector_sign_to_branch_reduction_note": {
+   "deps_hash": "18261d1efe18",
+   "out_degree": 3
+  },
+  "pmns_selector_three_identity_support_note_2026-04-21": {
+   "deps_hash": "3ee868c8c5a6",
+   "out_degree": 1
+  },
+  "pmns_selector_three_identity_support_note_2026-04-21_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "pmns_selector_three_identity_support_proposal_readme_2026-04-21": {
+   "deps_hash": "61a94d61f43b",
+   "out_degree": 1
+  },
+  "pmns_selector_unique_amplitude_slot_note": {
+   "deps_hash": "7186a4fc4a99",
+   "out_degree": 1
+  },
+  "pmns_sigma_zero_nogo_note": {
+   "deps_hash": "d9b75a7aac8d",
+   "out_degree": 6
+  },
+  "pmns_sole_axiom_free_point_identity_block_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "24659b3f1db1",
+   "out_degree": 1
+  },
+  "pmns_sole_axiom_hw1_source_transfer_boundary_note": {
+   "deps_hash": "e30f9021fda5",
+   "out_degree": 2
+  },
+  "pmns_theta12_theta13_dcp_predictions_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "2549c3cae5c9",
+   "out_degree": 8
+  },
+  "pmns_theta23_upper_octant_chamber_closure_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "67e8485cbecb",
+   "out_degree": 4
+  },
+  "pmns_theta23_upper_octant_chamber_closure_prediction_note_2026-04-17": {
+   "deps_hash": "26077552ace0",
+   "out_degree": 2
+  },
+  "pmns_theta23_upper_octant_full_3sigma_rectangle_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "9a9808bd862c",
+   "out_degree": 6
+  },
+  "pmns_theta23_upper_octant_threshold_surface_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "67e8485cbecb",
+   "out_degree": 4
+  },
+  "pmns_three_flux_holonomy_closure_note": {
+   "deps_hash": "416d985bcf17",
+   "out_degree": 3
+  },
+  "pmns_three_identity_q_koide_from_v8_support_lift_theorem_note_2026-04-29": {
+   "deps_hash": "1a27d126655d",
+   "out_degree": 2
+  },
+  "pmns_tm2_column_site_basis_kcpt_predicate_bounded_theorem_note_2026-06-07": {
+   "deps_hash": "8ceb03a36fcf",
+   "out_degree": 2
+  },
+  "pmns_tm2_magic_residual_dynamical_generator_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "f59a51c7640b",
+   "out_degree": 6
+  },
+  "pmns_tm2_magnitudes_conditional_bounded_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "pmns_tm2_residual_consequence_bounded_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "pmns_tm2_trimaximal_column_from_record_central_sector_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "e9207e8244f0",
+   "out_degree": 4
+  },
+  "pmns_transfer_operator_dominant_mode_note": {
+   "deps_hash": "fa20501d8998",
+   "out_degree": 1
+  },
+  "pmns_twisted_flux_transfer_holonomy_boundary_note": {
+   "deps_hash": "38e9d921f1c1",
+   "out_degree": 1
+  },
+  "pmns_uniform_scalar_deformation_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "pmns_x6_preimage_localization_closed_outer_frame_interval_certificate_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "6ef7b7d3ad3d",
+   "out_degree": 2
+  },
+  "poisson_3d_self_field_note": {
+   "deps_hash": "a7acf623ff88",
+   "out_degree": 1
+  },
+  "poisson_backreaction_live_threshold_packet_note_2026-05-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "poisson_exhaustive_uniqueness_note": {
+   "deps_hash": "e8d01675fe44",
+   "out_degree": 3
+  },
+  "poisson_self_field_note": {
+   "deps_hash": "519215e3f103",
+   "out_degree": 2
+  },
+  "poisson_self_field_supplied_branch_core_bounded_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "poisson_self_gravity_born_audit_note": {
+   "deps_hash": "68f12a50bbf9",
+   "out_degree": 1
+  },
+  "poisson_self_gravity_loop_note": {
+   "deps_hash": "3906ffb7ae7b",
+   "out_degree": 1
+  },
+  "poisson_self_gravity_loop_v3_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "poisson_self_gravity_mechanism_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "poisson_self_gravity_zero_coupling_exact_reduction_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "portable_package_hierarchy_classifier_note": {
+   "deps_hash": "4692e4ec0e97",
+   "out_degree": 5
+  },
+  "positivity_bridge_requires_orientation_sign_narrow_theorem_note_2026-05-23": {
+   "deps_hash": "0c13e845db90",
+   "out_degree": 3
+  },
+  "positivity_orientation_selects_c3_narrow_theorem_note_2026-05-23": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_admitted_sample_target_vector_interface_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_arrow_orientation_firewall_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_audit_evidence_ladder_row_bucketing_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_character_path_channel_weight_prototype_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_clock_rate_interface_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_conditional_audit_evidence_ladder_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_count_probability_firewall_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_directed_certificate_examples_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_directed_certificate_kernel_selection_firewall_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_dynamics_authority_stack_map_2026-06-06": {
+   "deps_hash": "4c4bd3509e05",
+   "out_degree": 5
+  },
+  "post_record_dynamics_campaign_closeout_index_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_dynamics_family_lift_closeout_index_2026-06-06": {
+   "deps_hash": "66729b113e72",
+   "out_degree": 10
+  },
+  "post_record_expectation_concentration_firewall_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_finite_likelihood_score_interface_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_finite_null_audit_interface_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_finite_supplied_weight_normalization_lemma_note_2026-06-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_finite_target_kernel_stability_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_finite_to_unbounded_family_lift_no_go_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_flow_thermal_stable_setting_certificate_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_generation_koide_stable_location_index_2026-06-06": {
+   "deps_hash": "090f18312050",
+   "out_degree": 4
+  },
+  "post_record_measure_weight_normalization_subdivision_2026-06-06": {
+   "deps_hash": "8c8349ccb997",
+   "out_degree": 1
+  },
+  "post_record_model_selection_firewall_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_persistent_record_production_bridge_prototype_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_production_dynamics_needed_row_map_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_retained_unbounded_dynamics_gate_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_selection_rule_target_vector_firewall_2026-06-06": {
+   "deps_hash": "7b92d81f2fef",
+   "out_degree": 2
+  },
+  "post_record_selector_dial_bucket_subdivision_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_selector_tangent_readout_weight_prototype_2026-06-06": {
+   "deps_hash": "99f809538cfe",
+   "out_degree": 2
+  },
+  "post_record_source_measure_trace_normalization_prototype_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_stability_dynamics_selector_subdivision_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_stable_kernel_count_audit_interface_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_stable_kernel_expected_frequency_interface_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_supplied_concentration_certificate_interface_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_supplied_family_lift_certificate_interface_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_supplied_kernel_selection_rule_interface_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_supplied_orientation_bridge_interface_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_supplied_selection_rule_interface_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_transition_kernel_interface_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "post_record_two_state_markov_stability_interface_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "powers_uhf_tracial_uniqueness_on_qubit_lattice_narrow_theorem_note_2026-05-20": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "pre_record_reference_state_maximal_symmetry_open_gate_note_2026-06-05": {
+   "deps_hash": "d6a3ed267673",
+   "out_degree": 4
+  },
+  "pre_record_reference_state_tracial_derivation_note_2026-05-20": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "presentation_gauge_axis_sign_flip_invariants_twin_detector_gauge_section_orientation_bit_bounded_theorem_note_2026-07-04": {
+   "deps_hash": "20f9332e545f",
+   "out_degree": 3
+  },
+  "primitive_p_bae_m1_m2_duality_note_2026-05-10_ppbae_duality": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "primitive_p_bae_m1_trace_degeneracy_correction_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "primitive_p_heavyq_casimir_closure_note_2026-05-10_ppheavyq_closure": {
+   "deps_hash": "77aa11d0f938",
+   "out_degree": 9
+  },
+  "primitive_p_heavyq_species_proposal_note_2026-05-10_ppheavyq": {
+   "deps_hash": "f5c96e94efb4",
+   "out_degree": 5
+  },
+  "primitive_p_l1_channel_weight_proposal_note_2026-05-10_ppl1": {
+   "deps_hash": "13e148d0c034",
+   "out_degree": 7
+  },
+  "primitive_p_l1_d_period_functor_note_2026-05-10_ppl1_d": {
+   "deps_hash": "5b77aa4653c3",
+   "out_degree": 6
+  },
+  "primitive_p_lh_content_proposal_note_2026-05-10_pplh": {
+   "deps_hash": "7b18851d68fc",
+   "out_degree": 2
+  },
+  "primitive_p_lh_ncg_native_note_2026-05-10_pplh_ncg_native": {
+   "deps_hash": "e052f962b8a8",
+   "out_degree": 1
+  },
+  "primitive_retirement_review_after_four_axiom_reset_note_2026-07-05": {
+   "deps_hash": "5219c6bb5a2c",
+   "out_degree": 8
+  },
+  "primordial_spectrum_note": {
+   "deps_hash": "8d76f496f6c9",
+   "out_degree": 3
+  },
+  "product_form_premise_weakens_to_outcome_factorization_bounded_note_2026-06-12": {
+   "deps_hash": "cbe42f571241",
+   "out_degree": 3
+  },
+  "propagator_family_unification_note": {
+   "deps_hash": "475143577275",
+   "out_degree": 5
+  },
+  "protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_narrow_theorem_note_2026-07-10": {
+   "deps_hash": "141f668125ad",
+   "out_degree": 2
+  },
+  "proton_lifetime_derived_note": {
+   "deps_hash": "3e90d3556a15",
+   "out_degree": 1
+  },
+  "prr_local_derivation_from_jaynes_max_entropy_narrow_theorem_note_2026-05-22": {
+   "deps_hash": "2d1b8bfe3275",
+   "out_degree": 3
+  },
+  "publication.ci3_z3.arxiv_draft": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "publication.ci3_z3.arxiv_package": {
+   "deps_hash": "18bf0d521cff",
+   "out_degree": 1
+  },
+  "publication.ci3_z3.claims_table": {
+   "deps_hash": "1eaa6f251403",
+   "out_degree": 132
+  },
+  "publication.ci3_z3.derivation_atlas": {
+   "deps_hash": "90c01d397067",
+   "out_degree": 590
+  },
+  "publication.ci3_z3.derivation_validation_map": {
+   "deps_hash": "3ccb1013eb51",
+   "out_degree": 257
+  },
+  "publication.ci3_z3.external_reviewer_guide": {
+   "deps_hash": "483b6255bd6e",
+   "out_degree": 2
+  },
+  "publication.ci3_z3.falsifiable_predictions_2026-06-08": {
+   "deps_hash": "fc6ab2ca2d24",
+   "out_degree": 7
+  },
+  "publication.ci3_z3.figure_captions": {
+   "deps_hash": "eb9ba2251ed0",
+   "out_degree": 1
+  },
+  "publication.ci3_z3.figure_plan": {
+   "deps_hash": "51f3196f8a90",
+   "out_degree": 19
+  },
+  "publication.ci3_z3.full_claim_ledger": {
+   "deps_hash": "d64e1593cb82",
+   "out_degree": 222
+  },
+  "publication.ci3_z3.gravity_publication_package_summary_2026-04-15": {
+   "deps_hash": "6cb4978d8801",
+   "out_degree": 14
+  },
+  "publication.ci3_z3.inputs_and_qualifiers_note": {
+   "deps_hash": "efb7480489ee",
+   "out_degree": 26
+  },
+  "publication.ci3_z3.neutrino_dirac_pmns_boundary_packet_2026-04-15": {
+   "deps_hash": "0215716ab122",
+   "out_degree": 2
+  },
+  "publication.ci3_z3.prediction_surface_2026-04-15": {
+   "deps_hash": "9dfc9c10af75",
+   "out_degree": 45
+  },
+  "publication.ci3_z3.publication_matrix": {
+   "deps_hash": "57293d81c047",
+   "out_degree": 221
+  },
+  "publication.ci3_z3.quantitative_summary_table": {
+   "deps_hash": "eadf751a1b38",
+   "out_degree": 71
+  },
+  "publication.ci3_z3.readme": {
+   "deps_hash": "62ab9b1d4828",
+   "out_degree": 3
+  },
+  "publication.ci3_z3.release_environment": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "publication.ci3_z3.reproduce": {
+   "deps_hash": "40168fb1d91e",
+   "out_degree": 3
+  },
+  "publication.ci3_z3.reproducibility_freeze_2026-04-14": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "publication.ci3_z3.results_index": {
+   "deps_hash": "da9e4600a6c5",
+   "out_degree": 340
+  },
+  "publication.ci3_z3.science_map": {
+   "deps_hash": "14d34c8ebe7d",
+   "out_degree": 13
+  },
+  "publication.ci3_z3.usable_derived_values_index": {
+   "deps_hash": "8d51085d6180",
+   "out_degree": 88
+  },
+  "publication.ci3_z3.what_this_paper_does_not_claim": {
+   "deps_hash": "25b45fb70576",
+   "out_degree": 11
+  },
+  "publication_ci3_z3_claims_table_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "pwc_derivation_from_cumulant_generating_functional_narrow_theorem_note_2026-05-22": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "q_integer_spectrum_theorem_note_2026-05-02": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "qcd_beta_3_pure_gauge_vs_full_sm_narrow_theorem_note_2026-06-02": {
+   "deps_hash": "36b3e3d05819",
+   "out_degree": 4
+  },
+  "qcd_low_energy_running_bridge_note_2026-05-01": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "qnm_control_hardening_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "qnm_hardening_feasibility_note": {
+   "deps_hash": "c0fb4487ead1",
+   "out_degree": 3
+  },
+  "qualification_unfixed_choice_clarification_certification_note_2026-07-04": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "quantum_horizon_note": {
+   "deps_hash": "4f23d0307a19",
+   "out_degree": 1
+  },
+  "quantum_local_algebra_does_not_force_boost_action_faith_no_go_note_2026-06-02": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "quark_bae_analog_bounded_obstruction_note_2026-05-10_quarkbae": {
+   "deps_hash": "f4da132799bb",
+   "out_degree": 11
+  },
+  "quark_bicac_endpoint_obstruction_theorem_note_2026-04-19": {
+   "deps_hash": "38e9d921f1c1",
+   "out_degree": 1
+  },
+  "quark_bimodule_lo_shell_normalization_theorem_note_2026-04-19": {
+   "deps_hash": "dfe4b1d380d2",
+   "out_degree": 2
+  },
+  "quark_bimodule_norm_existence_theorem_note_2026-04-19": {
+   "deps_hash": "d118001dbd5d",
+   "out_degree": 1
+  },
+  "quark_bimodule_norm_naturality_theorem_note_2026-04-19": {
+   "deps_hash": "38e9d921f1c1",
+   "out_degree": 1
+  },
+  "quark_c3_a1_source_domain_bridge_no_go_note_2026-04-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_c3_circulant_source_law_boundary_note_2026-04-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_c3_oriented_ward_splitter_algebraic_core_split_note_2026-06-18": {
+   "deps_hash": "6752ab73fdb9",
+   "out_degree": 1
+  },
+  "quark_c3_oriented_ward_splitter_support_note_2026-04-28": {
+   "deps_hash": "dcc79656a624",
+   "out_degree": 4
+  },
+  "quark_c3_oriented_ward_splitter_support_note_hash_drift_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "fb0444df6646",
+   "out_degree": 6
+  },
+  "quark_c3_p1_positive_parent_readout_no_go_note_2026-04-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_cp_carrier_completion_audited_scope_narrow_bounded_note_2026-05-10": {
+   "deps_hash": "e99aad0c554e",
+   "out_degree": 2
+  },
+  "quark_cp_carrier_completion_note_2026-04-18": {
+   "deps_hash": "7aab223c58d4",
+   "out_degree": 1
+  },
+  "quark_cp_carrier_slot_minimality_theorem_note_2026-06-17": {
+   "deps_hash": "aaac3c8e8a2f",
+   "out_degree": 1
+  },
+  "quark_cp_small_correction_boundary_note_2026-06-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_e_channel_endpoint_quotient_law_audited_scope_narrow_bounded_note_2026-05-10": {
+   "deps_hash": "6f21c8e154ea",
+   "out_degree": 3
+  },
+  "quark_e_channel_endpoint_quotient_law_audited_scope_narrow_bounded_note_2026-05-10_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_e_channel_endpoint_quotient_law_note_2026-04-19": {
+   "deps_hash": "7baf9baee28c",
+   "out_degree": 1
+  },
+  "quark_endpoint_denominator_admissibility_note_2026-04-19": {
+   "deps_hash": "2d52ac7843f8",
+   "out_degree": 1
+  },
+  "quark_endpoint_ratio_chain_law_audited_scope_narrow_bounded_note_2026-05-10": {
+   "deps_hash": "664453bfad03",
+   "out_degree": 2
+  },
+  "quark_endpoint_ratio_chain_law_note_2026-04-19": {
+   "deps_hash": "7baf9baee28c",
+   "out_degree": 1
+  },
+  "quark_endpoint_readout_constraints_note_2026-04-19": {
+   "deps_hash": "93c6fd031fdb",
+   "out_degree": 5
+  },
+  "quark_five_sixths_scale_selection_boundary_note_2026-04-28": {
+   "deps_hash": "471de0197ab0",
+   "out_degree": 3
+  },
+  "quark_generation_equivariant_ward_degeneracy_no_go_note_2026-04-28": {
+   "deps_hash": "98cc97f7780b",
+   "out_degree": 3
+  },
+  "quark_generation_stratified_ward_free_matrix_no_go_note_2026-04-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_issr1_bicac_forcing_theorem_note_2026-04-19": {
+   "deps_hash": "31c7df5e0580",
+   "out_degree": 2
+  },
+  "quark_jts_affine_physical_carrier_theorem_note_2026-04-19": {
+   "deps_hash": "ed6378d1bc3e",
+   "out_degree": 4
+  },
+  "quark_jts_physical_point_closure_theorem_note_2026-04-19": {
+   "deps_hash": "839b9d1065cd",
+   "out_degree": 2
+  },
+  "quark_jts_residue_note_2026-04-19": {
+   "deps_hash": "2430ca1beba8",
+   "out_degree": 4
+  },
+  "quark_lane3_bounded_companion_retention_firewall_note_2026-04-27": {
+   "deps_hash": "a9ee1ca9cd9c",
+   "out_degree": 4
+  },
+  "quark_lane3_bounded_companion_retention_firewall_record_axiom_invariance_companion_note_2026-06-04": {
+   "deps_hash": "6e05cf21b282",
+   "out_degree": 9
+  },
+  "quark_lane3_stuck_fanout_synthesis_2026-04-28": {
+   "deps_hash": "aa566cb40a0d",
+   "out_degree": 8
+  },
+  "quark_mass_ratio_full_solve_note_2026-04-18": {
+   "deps_hash": "58cb928eb7ed",
+   "out_degree": 5
+  },
+  "quark_mass_ratio_note_2026-04-18": {
+   "deps_hash": "e3265447a293",
+   "out_degree": 26
+  },
+  "quark_mass_ratios_taste_staircase_support_note_2026-04-25": {
+   "deps_hash": "13187e74164b",
+   "out_degree": 6
+  },
+  "quark_mass_spectrum_koide_scheme_open_gate_note_2026-05-26": {
+   "deps_hash": "3be8d14493e6",
+   "out_degree": 4
+  },
+  "quark_projector_parameter_audit_note_2026-04-19": {
+   "deps_hash": "e99aad0c554e",
+   "out_degree": 2
+  },
+  "quark_projector_parameter_audit_note_2026-05-10": {
+   "deps_hash": "b918e0cb5f7f",
+   "out_degree": 5
+  },
+  "quark_projector_ray_phase_completion_note_2026-04-18": {
+   "deps_hash": "aaac3c8e8a2f",
+   "out_degree": 1
+  },
+  "quark_route2_center_excess_source_target_note_2026-06-21": {
+   "deps_hash": "6a8b9ccede1a",
+   "out_degree": 2
+  },
+  "quark_route2_center_primitive_equivalence_atlas_note_2026-06-21": {
+   "deps_hash": "03e0805c3710",
+   "out_degree": 8
+  },
+  "quark_route2_channel_determinant_quotient_gate_note_2026-06-21": {
+   "deps_hash": "df18f3969a57",
+   "out_degree": 8
+  },
+  "quark_route2_channel_metric_schur_free_parameter_no_go_note_2026-06-21": {
+   "deps_hash": "f3df86ec25ec",
+   "out_degree": 4
+  },
+  "quark_route2_coefficient_selection_boundary_note_2026-06-21": {
+   "deps_hash": "9b9ab1f382fa",
+   "out_degree": 6
+  },
+  "quark_route2_color_complement_seven_eighths_bridge_no_go_note_2026-06-21": {
+   "deps_hash": "0742121887bc",
+   "out_degree": 7
+  },
+  "quark_route2_color_covariance_bridge_equivalence_support_note_2026-06-21": {
+   "deps_hash": "481685875b1a",
+   "out_degree": 5
+  },
+  "quark_route2_color_ray_adjoint_line_selector_boundary_note_2026-06-21": {
+   "deps_hash": "88b2e5b68591",
+   "out_degree": 8
+  },
+  "quark_route2_current_dualization_gate_no_go_note_2026-06-21": {
+   "deps_hash": "b91ebd921d3a",
+   "out_degree": 9
+  },
+  "quark_route2_density_square_primitive_gap_note_2026-06-21": {
+   "deps_hash": "0ab64fc23af3",
+   "out_degree": 7
+  },
+  "quark_route2_double_local_projector_factor_degree_no_go_note_2026-06-21": {
+   "deps_hash": "da505c4dadc4",
+   "out_degree": 4
+  },
+  "quark_route2_double_local_projector_normalization_bridge_conditional_note_2026-06-21": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_route2_dual_compliance_bridge_conditional_support_note_2026-06-21": {
+   "deps_hash": "80924f2bc951",
+   "out_degree": 5
+  },
+  "quark_route2_dual_compliance_current_primitive_gate_no_go_note_2026-06-21": {
+   "deps_hash": "9f8161a6f827",
+   "out_degree": 5
+  },
+  "quark_route2_dual_frame_compliance_conditional_support_note_2026-06-21": {
+   "deps_hash": "0a0bbad2549a",
+   "out_degree": 1
+  },
+  "quark_route2_dual_normalized_source_readout_two_factor_bridge_conditional_note_2026-06-21": {
+   "deps_hash": "5f1db4a768a9",
+   "out_degree": 4
+  },
+  "quark_route2_e_center_blindness_no_go_note_2026-06-17": {
+   "deps_hash": "5d74900d3513",
+   "out_degree": 1
+  },
+  "quark_route2_e_center_current_source_bank_no_go_note_2026-06-21": {
+   "deps_hash": "cb2f9ae267b5",
+   "out_degree": 8
+  },
+  "quark_route2_e_center_excess_seven_eighths_import_boundary_note_2026-06-21": {
+   "deps_hash": "621098282be5",
+   "out_degree": 9
+  },
+  "quark_route2_e_center_fingerprint_exact_support_note_2026-06-21": {
+   "deps_hash": "db5df76fdcd6",
+   "out_degree": 6
+  },
+  "quark_route2_e_center_finite_size_bridge_admissibility_gate_no_go_note_2026-06-21": {
+   "deps_hash": "a8fecb39547c",
+   "out_degree": 4
+  },
+  "quark_route2_e_center_inverse_square_source_law_firewall_note_2026-06-21": {
+   "deps_hash": "263cf2de0123",
+   "out_degree": 12
+  },
+  "quark_route2_e_center_lift_derivation_attempt_bounded_note_2026-06-12": {
+   "deps_hash": "c82dba61b06f",
+   "out_degree": 12
+  },
+  "quark_route2_e_center_lift_measured_calibration_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "e30eaa203f08",
+   "out_degree": 4
+  },
+  "quark_route2_e_center_lift_size_scan_boundary_note_2026-06-21": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_route2_e_center_selector_fanout_no_go_note_2026-06-21": {
+   "deps_hash": "bd2f5a0d366c",
+   "out_degree": 4
+  },
+  "quark_route2_e_center_single_adjoint_line_selector_conditional_support_note_2026-06-21": {
+   "deps_hash": "661f274ab538",
+   "out_degree": 6
+  },
+  "quark_route2_e_center_single_box_limit_underdetermination_no_go_note_2026-06-21": {
+   "deps_hash": "588f55938936",
+   "out_degree": 3
+  },
+  "quark_route2_e_channel_readout_naturality_no_go_note_2026-04-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_route2_e_channel_source_readout_construction_bounded_note_2026-06-12": {
+   "deps_hash": "77a30b318ce9",
+   "out_degree": 14
+  },
+  "quark_route2_ell_e_structural_narrowing_bounded_note_2026-06-12": {
+   "deps_hash": "98b39f598de9",
+   "out_degree": 7
+  },
+  "quark_route2_endpoint_blind_renormalization_no_go_note_2026-06-21": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_route2_endpoint_step_free_active_branch_slopes_bounded_note_2026-06-12": {
+   "deps_hash": "8ea375d06d6b",
+   "out_degree": 2
+  },
+  "quark_route2_endpoint_t_balance_fd_provenance_and_step_stability_bounded_note_2026-06-11": {
+   "deps_hash": "c75924e52f18",
+   "out_degree": 2
+  },
+  "quark_route2_eta_floor_hf_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_route2_exact_readout_map_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_route2_exact_time_coupling_note_2026-04-19": {
+   "deps_hash": "5d74900d3513",
+   "out_degree": 1
+  },
+  "quark_route2_finite_frame_dual_leg_count_boundary_note_2026-06-21": {
+   "deps_hash": "a33889d9fb2a",
+   "out_degree": 5
+  },
+  "quark_route2_fixed_carrier_selector_equation_boundary_note_2026-06-21": {
+   "deps_hash": "de4d19becb6a",
+   "out_degree": 7
+  },
+  "quark_route2_graph_first_su3_spatial_color_bridge_gate_no_go_note_2026-06-21": {
+   "deps_hash": "85a66f63d7fd",
+   "out_degree": 4
+  },
+  "quark_route2_graph_first_su3_spatial_color_functor_firewall_note_2026-06-21": {
+   "deps_hash": "9c363c4b7367",
+   "out_degree": 10
+  },
+  "quark_route2_gravity_metric_rhoe_value_packet_note_2026-06-21": {
+   "deps_hash": "1b8ca12e33d3",
+   "out_degree": 6
+  },
+  "quark_route2_hessian_e_center_bridge_gate_note_2026-06-21": {
+   "deps_hash": "e06a6ff1aa97",
+   "out_degree": 8
+  },
+  "quark_route2_honest_gravity_metric_rhoe_characterization_note_2026-07-02": {
+   "deps_hash": "e1f959fb29e5",
+   "out_degree": 4
+  },
+  "quark_route2_independent_et_channel_selector_firewall_note_2026-06-21": {
+   "deps_hash": "76f3944db604",
+   "out_degree": 6
+  },
+  "quark_route2_inverse_square_center_lift_boundary_note_2026-06-21": {
+   "deps_hash": "1cbeedacb4ca",
+   "out_degree": 6
+  },
+  "quark_route2_inverse_square_channel_law_gate_note_2026-06-21": {
+   "deps_hash": "4d344bb3cd9e",
+   "out_degree": 4
+  },
+  "quark_route2_inverse_square_coefficient_law_gate_note_2026-06-21": {
+   "deps_hash": "0bbd2339aff9",
+   "out_degree": 4
+  },
+  "quark_route2_inverse_square_covariance_primitive_candidate_note_2026-06-21": {
+   "deps_hash": "121871014cca",
+   "out_degree": 4
+  },
+  "quark_route2_kr_gram_nonseparable_degree2_no_go_note_2026-06-21": {
+   "deps_hash": "2686ccce7154",
+   "out_degree": 3
+  },
+  "quark_route2_lift_coordinate_selector_gate_note_2026-06-21": {
+   "deps_hash": "20d3128c5a0f",
+   "out_degree": 7
+  },
+  "quark_route2_log_barrier_record_primitive_gate_note_2026-06-21": {
+   "deps_hash": "43282abb8f73",
+   "out_degree": 8
+  },
+  "quark_route2_magnitude_source_e_center_shear_no_go_note_2026-06-21": {
+   "deps_hash": "7cfee31d888b",
+   "out_degree": 4
+  },
+  "quark_route2_measured_calibration_rescue_transform_firewall_note_2026-06-21": {
+   "deps_hash": "7d2e8c8041d4",
+   "out_degree": 5
+  },
+  "quark_route2_metric_selector_ratio_boundary_note_2026-06-21": {
+   "deps_hash": "63c6db1481bb",
+   "out_degree": 6
+  },
+  "quark_route2_non_color_e_center_source_primitive_firewall_note_2026-06-21": {
+   "deps_hash": "2cfe5dbed6a7",
+   "out_degree": 12
+  },
+  "quark_route2_nonblind_e_center_lift_selector_equivalence_exact_support_note_2026-06-21": {
+   "deps_hash": "8e2b016545f1",
+   "out_degree": 6
+  },
+  "quark_route2_nonblind_source_readout_primitive_gate_no_go_note_2026-06-21": {
+   "deps_hash": "488d0f880ff1",
+   "out_degree": 10
+  },
+  "quark_route2_nonlinear_e_center_readout_primitive_boundary_note_2026-06-21": {
+   "deps_hash": "f3e0185e9ce4",
+   "out_degree": 14
+  },
+  "quark_route2_nonlinear_e_center_tensor_observable_gate_note_2026-06-21": {
+   "deps_hash": "819c0f25f553",
+   "out_degree": 8
+  },
+  "quark_route2_nonlinear_log_curvature_readout_candidate_note_2026-06-21": {
+   "deps_hash": "4d344bb3cd9e",
+   "out_degree": 4
+  },
+  "quark_route2_nonlinear_tensor_observable_class_no_go_note_2026-06-21": {
+   "deps_hash": "f41364c41dfe",
+   "out_degree": 5
+  },
+  "quark_route2_nonseparable_quadratic_equivariant_primitive_no_go_note_2026-06-21": {
+   "deps_hash": "f3df86ec25ec",
+   "out_degree": 4
+  },
+  "quark_route2_normalized_quotient_selector_trichotomy_note_2026-06-21": {
+   "deps_hash": "0131d040d648",
+   "out_degree": 5
+  },
+  "quark_route2_one_pole_channel_volume_no_go_note_2026-06-21": {
+   "deps_hash": "f3df86ec25ec",
+   "out_degree": 4
+  },
+  "quark_route2_physical_color_ray_source_primitive_no_go_note_2026-06-21": {
+   "deps_hash": "5001f0f7bd36",
+   "out_degree": 6
+  },
+  "quark_route2_polynomial_carrier_density_normalization_no_go_note_2026-06-21": {
+   "deps_hash": "28c8b238e7d5",
+   "out_degree": 4
+  },
+  "quark_route2_positive_diagonal_e_center_selector_no_go_note_2026-06-21": {
+   "deps_hash": "ff5e4342e617",
+   "out_degree": 6
+  },
+  "quark_route2_positive_source_functional_cone_no_go_note_2026-06-21": {
+   "deps_hash": "12285012b69e",
+   "out_degree": 5
+  },
+  "quark_route2_qe_box_path_interpolation_family_no_go_note_2026-06-21": {
+   "deps_hash": "7ade92758106",
+   "out_degree": 5
+  },
+  "quark_route2_qe_box_size_scan_closes_bulk_limit_hatch_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "90e5d0c04ff7",
+   "out_degree": 4
+  },
+  "quark_route2_qe_bulk_limit_consumer_boundary_note_2026-06-21": {
+   "deps_hash": "600a4c0bb75b",
+   "out_degree": 6
+  },
+  "quark_route2_qe_covariance_schur_quadratic_no_go_narrow_note_2026-06-14": {
+   "deps_hash": "4fb2074a3e08",
+   "out_degree": 8
+  },
+  "quark_route2_qe_kappa_squared_covariance_sharper_no_go_narrow_note_2026-06-10": {
+   "deps_hash": "bc881c826cdd",
+   "out_degree": 6
+  },
+  "quark_route2_rank_one_carrier_leg_factorization_boundary_note_2026-06-21": {
+   "deps_hash": "f456f01cba05",
+   "out_degree": 2
+  },
+  "quark_route2_rconn_center_ratio_bridge_obstruction_note_2026-04-28": {
+   "deps_hash": "b94c77d99997",
+   "out_degree": 2
+  },
+  "quark_route2_rconn_magnitude_sign_split_exact_support_note_2026-06-21": {
+   "deps_hash": "55b7344c9497",
+   "out_degree": 5
+  },
+  "quark_route2_rconn_signed_center_bridge_selector_firewall_note_2026-06-21": {
+   "deps_hash": "23a182e0d867",
+   "out_degree": 10
+  },
+  "quark_route2_rconn_two_gate_source_bridge_factorization_note_2026-06-21": {
+   "deps_hash": "f6e46664964b",
+   "out_degree": 5
+  },
+  "quark_route2_rconn_typed_bridge_derivation_bounded_note_2026-06-12": {
+   "deps_hash": "7e479d49dd32",
+   "out_degree": 10
+  },
+  "quark_route2_rconn_w1_expanded_authority_sweep_no_go_note_2026-06-21": {
+   "deps_hash": "e8be6cea8c32",
+   "out_degree": 9
+  },
+  "quark_route2_readout_inverse_square_gate_no_go_note_2026-06-21": {
+   "deps_hash": "f2a1d23834bb",
+   "out_degree": 3
+  },
+  "quark_route2_reciprocal_square_dimension_bridge_packet_note_2026-06-21": {
+   "deps_hash": "fd4352f74666",
+   "out_degree": 4
+  },
+  "quark_route2_record_raw_q_selector_gate_note_2026-06-21": {
+   "deps_hash": "7eff69f2b624",
+   "out_degree": 6
+  },
+  "quark_route2_rhoe_floor_family_size_parametrized_ladder_note_2026-07-02": {
+   "deps_hash": "f43031112e6a",
+   "out_degree": 4
+  },
+  "quark_route2_semantic_dimension_bridge_gate_note_2026-06-21": {
+   "deps_hash": "fd4352f74666",
+   "out_degree": 4
+  },
+  "quark_route2_signed_cancellation_firewall_note_2026-06-21": {
+   "deps_hash": "75e9040cc1bd",
+   "out_degree": 5
+  },
+  "quark_route2_single_adjoint_line_current_bank_no_go_note_2026-06-21": {
+   "deps_hash": "972f9ba91075",
+   "out_degree": 5
+  },
+  "quark_route2_slice_semigroup_coordinate_gate_note_2026-06-21": {
+   "deps_hash": "2e02792616c0",
+   "out_degree": 3
+  },
+  "quark_route2_source_augmented_e_center_functor_no_go_note_2026-06-21": {
+   "deps_hash": "d2ceb8760019",
+   "out_degree": 5
+  },
+  "quark_route2_source_count_selector_bridge_boundary_note_2026-06-21": {
+   "deps_hash": "ad4875409bfc",
+   "out_degree": 7
+  },
+  "quark_route2_source_domain_bridge_no_go_note_2026-04-28": {
+   "deps_hash": "8264e6272028",
+   "out_degree": 5
+  },
+  "quark_route2_source_domain_e_center_primitive_gate_note_2026-06-21": {
+   "deps_hash": "e37d54a11fb2",
+   "out_degree": 7
+  },
+  "quark_route2_source_domain_magnitude_typecast_equivalence_no_go_note_2026-06-21": {
+   "deps_hash": "b3f4cd1449aa",
+   "out_degree": 5
+  },
+  "quark_route2_source_domain_sign_support_typecast_remainder_note_2026-06-21": {
+   "deps_hash": "9ac5f9262c22",
+   "out_degree": 6
+  },
+  "quark_route2_source_domain_typecast_scale_normalization_no_go_note_2026-06-21": {
+   "deps_hash": "97482aedb96f",
+   "out_degree": 6
+  },
+  "quark_route2_source_domain_typed_edge_cut_certificate_note_2026-06-21": {
+   "deps_hash": "63b0f5f8ae18",
+   "out_degree": 7
+  },
+  "quark_route2_source_excess_bank_gap_no_go_note_2026-06-21": {
+   "deps_hash": "2a5e7749f3a6",
+   "out_degree": 5
+  },
+  "quark_route2_source_readout_density_primitive_inventory_no_go_note_2026-06-21": {
+   "deps_hash": "f9519c569b19",
+   "out_degree": 8
+  },
+  "quark_route2_source_readout_factorization_gauge_no_go_note_2026-06-21": {
+   "deps_hash": "8373ec25b318",
+   "out_degree": 4
+  },
+  "quark_route2_source_scalar_prep_gate_no_go_note_2026-06-21": {
+   "deps_hash": "7b6193a89ea2",
+   "out_degree": 4
+  },
+  "quark_route2_source_slot_dualization_gate_no_go_note_2026-06-21": {
+   "deps_hash": "7b6193a89ea2",
+   "out_degree": 4
+  },
+  "quark_route2_t_balance_exact_algebraic_value_bounded_note_2026-06-12": {
+   "deps_hash": "c9e77d6d163b",
+   "out_degree": 1
+  },
+  "quark_route2_t_row_primitive_minimality_selector_boundary_note_2026-06-22": {
+   "deps_hash": "51978fd3e5c3",
+   "out_degree": 3
+  },
+  "quark_route2_t_side_endpoint_theorem_attempt_bounded_note_2026-06-12": {
+   "deps_hash": "b166bbcef351",
+   "out_degree": 9
+  },
+  "quark_route2_theta_slice_channel_density_no_go_note_2026-06-21": {
+   "deps_hash": "082de5d379ea",
+   "out_degree": 4
+  },
+  "quark_route2_time_coupling_direct_consumer_ambiguity_gate_note_2026-06-21": {
+   "deps_hash": "6c7667cd447f",
+   "out_degree": 3
+  },
+  "quark_route2_two_pole_density_covariance_primitive_candidate_note_2026-06-21": {
+   "deps_hash": "f3df86ec25ec",
+   "out_degree": 4
+  },
+  "quark_route2_typed_rconn_magnitude_bridge_no_go_note_2026-06-21": {
+   "deps_hash": "f4fa9e2cc1be",
+   "out_degree": 6
+  },
+  "quark_route2_w1_sign_magnitude_split_support_note_2026-06-21": {
+   "deps_hash": "3822d2f2789e",
+   "out_degree": 4
+  },
+  "quark_rpsr_c3_joint_readout_rank_boundary_note_2026-04-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_rpsr_single_scalar_readout_underdetermination_note_2026-04-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "quark_strc_observable_principle_note_2026-04-19": {
+   "deps_hash": "24c771f0a4f7",
+   "out_degree": 1
+  },
+  "quark_top_qfp_attractor_route_no_go_note_2026-05-10": {
+   "deps_hash": "8507be0d855f",
+   "out_degree": 3
+  },
+  "quark_up_amplitude_affine_support_scan_note_2026-04-19": {
+   "deps_hash": "c15d48b8a174",
+   "out_degree": 3
+  },
+  "quark_up_amplitude_candidate_scan_note_2026-04-19": {
+   "deps_hash": "e170fb86639f",
+   "out_degree": 2
+  },
+  "quark_up_amplitude_native_affine_no_go_note_2026-04-19": {
+   "deps_hash": "c15d48b8a174",
+   "out_degree": 3
+  },
+  "quark_up_amplitude_native_expression_scan_note_2026-04-19": {
+   "deps_hash": "02c5f875a5d6",
+   "out_degree": 2
+  },
+  "quark_up_amplitude_provenance_audit_note_2026-04-19": {
+   "deps_hash": "982d4c649974",
+   "out_degree": 5
+  },
+  "quark_up_amplitude_rpsr_conditional_theorem_note_2026-04-19": {
+   "deps_hash": "865ceed653db",
+   "out_degree": 4
+  },
+  "quark_up_amplitude_rpsr_mass_retention_boundary_note_2026-04-28": {
+   "deps_hash": "171168cc6fee",
+   "out_degree": 1
+  },
+  "quark_up_amplitude_scalar_bypass_firewall_note_2026-06-21": {
+   "deps_hash": "62aa122349e6",
+   "out_degree": 8
+  },
+  "quark_up_amplitude_scalar_comparison_bridge_note_2026-04-19": {
+   "deps_hash": "374976f57b15",
+   "out_degree": 2
+  },
+  "quark_up_amplitude_sqrt7_counterexample_simplification_note_2026-04-19": {
+   "deps_hash": "313f7422b51f",
+   "out_degree": 3
+  },
+  "quark_up_amplitude_tensor_endpoint_bridge_note_2026-04-19": {
+   "deps_hash": "448b88311ce8",
+   "out_degree": 5
+  },
+  "quark_up_amplitude_tensor_endpoint_resolution_note_2026-04-19": {
+   "deps_hash": "5570f3b0f2b8",
+   "out_degree": 3
+  },
+  "quark_up_amplitude_two_step_native_scan_note_2026-04-19": {
+   "deps_hash": "c15d48b8a174",
+   "out_degree": 3
+  },
+  "quasi_persistent_relaunch_probe_note": {
+   "deps_hash": "e0d84bfa17f7",
+   "out_degree": 2
+  },
+  "qubit_axiom_hardening_note_2026-05-20": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "qubit_k1_derivation_from_minimality_narrow_theorem_note_2026-05-22": {
+   "deps_hash": "0b48e244e1f7",
+   "out_degree": 2
+  },
+  "qubit_lattice_joint_presentation_tensor_substrate_bridge_note_2026-07-09": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "qubit_link_u2_connection_algebra_bounded_theorem_note_2026-06-04": {
+   "deps_hash": "e949a7fd840a",
+   "out_degree": 4
+  },
+  "r3_geometric_regge_linearization_gives_healthy_lambda1_graviton_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "r_base_group_theory_derivation_theorem_note_2026-04-24": {
+   "deps_hash": "675cc2983f7b",
+   "out_degree": 4
+  },
+  "r_half_open_backlog_formation_law_probe_batch_exact_support_note_2026-07-13": {
+   "deps_hash": "85e5408eca7c",
+   "out_degree": 9
+  },
+  "radial_scaling_protected_angle_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "radian_bridge_expanded_inventory_bounded_note_2026-05-10_radianexp": {
+   "deps_hash": "a5c950991ceb",
+   "out_degree": 10
+  },
+  "radian_unit_convention_reclassification_note_2026-05-10_radianconv": {
+   "deps_hash": "94a27f605946",
+   "out_degree": 12
+  },
+  "rank1_single_source_template_from_k_j_minus_i_structure_gst_hierarchy_locator_note_2026-06-08": {
+   "deps_hash": "7ec7d5527ff7",
+   "out_degree": 1
+  },
+  "rconn_derived_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "rconn_kappa_ew_register_not_read_color_trace_open_gate_note_2026-06-08": {
+   "deps_hash": "9f0b4ae615da",
+   "out_degree": 5
+  },
+  "rconn_vertex_color_singlet_projection_bounded_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "155bd9848dd2",
+   "out_degree": 1
+  },
+  "rd_bridge_anatomy_agreement_conditioned_double_registration_bounded_note_2026-06-12": {
+   "deps_hash": "61b6add32af6",
+   "out_degree": 3
+  },
+  "rd_fixedness_is_arrow_invariant_on_the_retained_flow_family_bounded_note_2026-06-12": {
+   "deps_hash": "d673176fd64a",
+   "out_degree": 2
+  },
+  "reading_note_claims_are_axiom_text_theorems_bounded_note_2026-07-02": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "reading_note_final_derivations_motion_closure_bounded_note_2026-07-02": {
+   "deps_hash": "c5777f7e60a8",
+   "out_degree": 2
+  },
+  "readout_bridge_frame_extension_unifies_marginal_read_and_registered_factor_conditional_bounded_theorem_note_2026-07-06": {
+   "deps_hash": "9c7f3a5777fd",
+   "out_degree": 4
+  },
+  "real_diagonal_source_det_positivity_and_log_readout_lemma_note_2026-06-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "real_record_no_i_unification_proposal_narrow_theorem_note_2026-06-04": {
+   "deps_hash": "192165063043",
+   "out_degree": 4
+  },
+  "realization_row_sigma_reconciliation_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "b77b49964f00",
+   "out_degree": 7
+  },
+  "realized_kinetic_branch_conditional_record_registration_narrow_theorem_note_2026-07-02": {
+   "deps_hash": "bf8fff889a86",
+   "out_degree": 4
+  },
+  "realized_kinetic_branch_d4_pattern_dichotomy_narrow_theorem_note_2026-07-03": {
+   "deps_hash": "7c075cc0633d",
+   "out_degree": 4
+  },
+  "realized_kinetic_branch_discriminator_dichotomy_narrow_theorem_note_2026-07-02": {
+   "deps_hash": "de17e1a9dee2",
+   "out_degree": 5
+  },
+  "realized_kinetic_branch_selected_by_admissibility_variation_narrow_theorem_note_2026-07-02": {
+   "deps_hash": "8d47487fcf44",
+   "out_degree": 5
+  },
+  "realized_kinetic_branch_selection_frame_class_transport_narrow_theorem_note_2026-07-02": {
+   "deps_hash": "d49a9ad6b56c",
+   "out_degree": 5
+  },
+  "realized_kinetic_branch_selection_gauged_background_invariance_narrow_theorem_note_2026-07-02": {
+   "deps_hash": "2dc75e744500",
+   "out_degree": 4
+  },
+  "realized_state_primitive": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "reconstructed_h_quasilocal_from_analytic_dispersion_microcausality_bridge_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "8e0303c6f18c",
+   "out_degree": 2
+  },
+  "record_asymptotic_reset_convergence_ledger_2026-06-05": {
+   "deps_hash": "ffe526446f32",
+   "out_degree": 3
+  },
+  "record_axiom_audit_application_map_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "record_blank_boundary_reset_no_go_2026-06-05": {
+   "deps_hash": "bd23f7108fdf",
+   "out_degree": 4
+  },
+  "record_blank_sink_preparation_regress_no_go_2026-06-05": {
+   "deps_hash": "8d1bb394fff4",
+   "out_degree": 4
+  },
+  "record_born_frequency_boundary_2026-06-05": {
+   "deps_hash": "f89ddafa0bd4",
+   "out_degree": 3
+  },
+  "record_classical_semigroup_boundary_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "record_classicalization_dynamics_firewall_2026-06-05": {
+   "deps_hash": "36a0c253f8c5",
+   "out_degree": 2
+  },
+  "record_clock_rate_normalization_gate_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "record_comparability_import_discipline_support_fork_exhibit_and_conditional_arrow_bounded_note_2026-07-07": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "record_comparability_owner_one_pager_2026-07-04": {
+   "deps_hash": "b84390eaced6",
+   "out_degree": 1
+  },
+  "record_composition_bridge_semigroup_positivity_selection_bounded_note_2026-07-02": {
+   "deps_hash": "42d847d1dbf5",
+   "out_degree": 2
+  },
+  "record_conditional_law_period_scaling_l3_to_l4_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "record_conditional_law_three_point_period_series_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "7dab68b99d29",
+   "out_degree": 1
+  },
+  "record_content_readout_license_split_registration_unreachability_theorem_note_2026-07-02": {
+   "deps_hash": "c228186e4577",
+   "out_degree": 4
+  },
+  "record_context_generator_nonidentifiability_no_go_2026-06-17": {
+   "deps_hash": "234f31786c98",
+   "out_degree": 6
+  },
+  "record_count_bounds_composition_words_finite_dial_bounded_note_2026-07-02": {
+   "deps_hash": "02f5f264fed8",
+   "out_degree": 2
+  },
+  "record_density_slows_lr_front_optical_metric_toy_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "8a453ff8e1b5",
+   "out_degree": 4
+  },
+  "record_dephasing_broadcast_interface_2026-06-05": {
+   "deps_hash": "9f8fd308f473",
+   "out_degree": 3
+  },
+  "record_dominated_pointer_sector_transport_generator_vacuous_link_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "d86767dff638",
+   "out_degree": 7
+  },
+  "record_durability_derives_granularity_not_weight_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "a20344c76284",
+   "out_degree": 4
+  },
+  "record_dynamics_audit_gate_ladder_2026-06-05": {
+   "deps_hash": "6237f35bdb5e",
+   "out_degree": 6
+  },
+  "record_dynamics_koide_dial_firewall_2026-06-05": {
+   "deps_hash": "3842babb6b6e",
+   "out_degree": 3
+  },
+  "record_dynamics_layer_reconciliation_2026-06-05": {
+   "deps_hash": "608f08c479d9",
+   "out_degree": 5
+  },
+  "record_equal_letter_stable_location_2026-06-05": {
+   "deps_hash": "b23a22776d01",
+   "out_degree": 2
+  },
+  "record_erosion_branch_vs_ensemble_persistence_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "6517b6f36957",
+   "out_degree": 2
+  },
+  "record_finite_alphabet_post_record_dynamics_2026-06-05": {
+   "deps_hash": "02fe236d270e",
+   "out_degree": 3
+  },
+  "record_finite_time_reset_semigroup_no_go_2026-06-05": {
+   "deps_hash": "5130b24b6888",
+   "out_degree": 3
+  },
+  "record_formation_append_certification_bounded_note_2026-07-04": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "record_formation_append_consistency_sweep_2026-07-04": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "record_formation_controlled_copy_write_isometry_theorem_note_2026-06-18": {
+   "deps_hash": "2ffb6666f845",
+   "out_degree": 1
+  },
+  "record_formation_front_is_the_domain_wall_free_field_bounded_theorem_note_2026-07-05": {
+   "deps_hash": "672f882e64d4",
+   "out_degree": 2
+  },
+  "record_formation_not_unconditionally_forced_by_minimal_axioms_narrow_no_go_note_2026-06-06": {
+   "deps_hash": "fee7422dc6d9",
+   "out_degree": 2
+  },
+  "record_formation_pointer_non_demolition_dynamics_constraint_bounded_theorem_note_2026-06-05": {
+   "deps_hash": "e39980652ec8",
+   "out_degree": 3
+  },
+  "record_formation_to_kraus_isometry_bridge_2026-06-06": {
+   "deps_hash": "3b37788c6bc3",
+   "out_degree": 3
+  },
+  "record_function_finite_sector_algebra_2026-06-05": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "record_generation_readout_two_sectors_2026-06-05": {
+   "deps_hash": "6b90caf12fc1",
+   "out_degree": 4
+  },
+  "record_history_count_audit_unlock_scan_2026-06-05": {
+   "deps_hash": "91a9f6205545",
+   "out_degree": 2
+  },
+  "record_history_monoid_unbounded_retention_2026-06-05": {
+   "deps_hash": "4af222da471f",
+   "out_degree": 2
+  },
+  "record_history_order_time_rate_firewall_2026-06-05": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "record_iid_typicality_firewall_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "record_instrument_composite_link_pointer_erasure_exact_slaving_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "a3f1c33837e5",
+   "out_degree": 6
+  },
+  "record_instrument_kernel_interface_2026-06-05": {
+   "deps_hash": "b18947498281",
+   "out_degree": 8
+  },
+  "record_local_finite_atom_availability_narrow_theorem_note_2026-06-17": {
+   "deps_hash": "049a3bb15fb8",
+   "out_degree": 2
+  },
+  "record_local_observability_decoder_criterion_2026-06-05": {
+   "deps_hash": "9bf27dd2bf43",
+   "out_degree": 5
+  },
+  "record_markov_generator_embeddability_boundary_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "record_markov_generator_premise_classifier_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "record_occurrence_thinned_iid_frequency_bridge_2026-07-01": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "record_open_system_reset_channel_interface_2026-06-05": {
+   "deps_hash": "c83fa9118690",
+   "out_degree": 4
+  },
+  "record_outcome_observable_principle_canonical_proposal_note_2026-06-05": {
+   "deps_hash": "2b0a8dfd62e0",
+   "out_degree": 1
+  },
+  "record_p1_dependency_audit_note_2026-06-04": {
+   "deps_hash": "84741fe49311",
+   "out_degree": 2
+  },
+  "record_permanence_forces_fresh_site_double_registration_and_agreement_survival_bounded_theorem_note_2026-07-11": {
+   "deps_hash": "308cd6b04735",
+   "out_degree": 2
+  },
+  "record_pointer_broadcast_circuit_interface_2026-06-05": {
+   "deps_hash": "f00deb480370",
+   "out_degree": 5
+  },
+  "record_pointer_broadcast_hamiltonian_conditional_2026-06-05": {
+   "deps_hash": "70d4e5bfd3b3",
+   "out_degree": 4
+  },
+  "record_pointer_controlled_coupling_finite_example_bounded_theorem_note_2026-06-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "record_prerecord_instrument_kernel_gate_2026-06-06": {
+   "deps_hash": "157567f35276",
+   "out_degree": 4
+  },
+  "record_preservation_conserves_the_within_sector_measure_bounded_theorem_note_2026-06-15": {
+   "deps_hash": "7ecbfffe0c41",
+   "out_degree": 2
+  },
+  "record_prior_stability_selector_2026-06-05": {
+   "deps_hash": "51a618af31df",
+   "out_degree": 3
+  },
+  "record_production_interface_principle_2026-06-06": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "record_production_kernel_boundary_2026-06-06": {
+   "deps_hash": "b168a34a356a",
+   "out_degree": 1
+  },
+  "record_production_residual_checklist_2026-06-05": {
+   "deps_hash": "3190ce633dc5",
+   "out_degree": 6
+  },
+  "record_reset_sink_entropy_ledger_2026-06-05": {
+   "deps_hash": "630eac816cd1",
+   "out_degree": 3
+  },
+  "record_reset_with_sink_conditional_2026-06-05": {
+   "deps_hash": "284ce397a303",
+   "out_degree": 3
+  },
+  "record_saturation_availability_census_bounded_note_2026-07-08": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
+  },
+  "record_selective_instrument_atom_criterion_2026-06-05": {
+   "deps_hash": "e4ed3f073c20",
+   "out_degree": 3
+  },
+  "record_selector_audit_sidecar_2026-06-05": {
+   "deps_hash": "67362919fc28",
+   "out_degree": 3
+  },
+  "record_tick_signature_neutral_2026-06-23": {
+   "deps_hash": "b388353f8287",
+   "out_degree": 1
+  },
+  "record_typing_audit_unlock_map_2026-06-05": {
+   "deps_hash": "5326d44099b6",
+   "out_degree": 13
+  },
+  "record_unbounded_finite_additivity_schema_2026-06-06": {
+   "deps_hash": "7a055ce56f6e",
+   "out_degree": 2
+  },
+  "record_write_admissible_one_step_class_controlled_copy_narrow_theorem_note_2026-07-11": {
+   "deps_hash": "be5222e9afb2",
+   "out_degree": 4
+  },
+  "records_only_os_reconstruction_untied_first_order_measure_bounded_theorem_note_2026-07-11": {
+   "deps_hash": "a32c4dfe71ec",
+   "out_degree": 7
+  },
+  "redundancy_not_forced_by_pnd_locality_no_go_note_2026-06-08": {
+   "deps_hash": "d061b57206c8",
+   "out_degree": 5
+  },
+  "reflection_positivity_gauge_half_cauchy_schwarz_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "regge_curved_prism_tick_dispersion_narrow_theorem_note_2026-06-17": {
+   "deps_hash": "7e5bfd516c31",
+   "out_degree": 4
+  },
+  "regge_ok4_frame_section_narrow_theorem_note_2026-06-17": {
+   "deps_hash": "aa05cfece5d8",
+   "out_degree": 4
+  },
+  "register_not_read_scope_correction_panel_verdict_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "registrable_readout_additive_even_phase_free_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "28f13d4d9ca8",
+   "out_degree": 7
+  },
+  "registrable_readout_determinant_character_algebraic_core_split_note_2026-06-18": {
+   "deps_hash": "78fbe012cf29",
+   "out_degree": 2
+  },
+  "registration_reinstates_chirality_no_go_note_2026-06-07": {
+   "deps_hash": "44506016e46e",
+   "out_degree": 3
+  },
+  "relative_orientation_fusion_state_selection_pointer_frame_one_vacuous_quotient_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "790b6a424aff",
+   "out_degree": 1
+  },
+  "reopened_lane_checklist": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "replay_environment_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "repo.active_review_queue": {
+   "deps_hash": "50d243579b8d",
+   "out_degree": 5
+  },
+  "repo.controlled_vocabulary": {
+   "deps_hash": "14354d83e2fa",
+   "out_degree": 2
+  },
+  "repo.four_axiom_narrative_scrub_plan_2026-07-04": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "repo.python_venv_setup": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "repo.repo_organization": {
+   "deps_hash": "98e76a6320aa",
+   "out_degree": 15
+  },
+  "repo.retest_playbook": {
+   "deps_hash": "a5923dac4afa",
+   "out_degree": 6
+  },
+  "repo.review_feedback_workflow": {
+   "deps_hash": "07710643810e",
+   "out_degree": 3
+  },
+  "repo.root_file_guide": {
+   "deps_hash": "eebe2af4a8d1",
+   "out_degree": 3
+  },
+  "repo.vocabulary_hygiene_design": {
+   "deps_hash": "002a5ce918ea",
+   "out_degree": 2
+  },
+  "repo.vocabulary_hygiene_review_2026-05-18": {
+   "deps_hash": "a1806fbb5574",
+   "out_degree": 6
+  },
+  "repo_active_review_queue_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "repo_submission_consolidation_plan_2026-04-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "reproduction_audit_note": {
+   "deps_hash": "8a42070f0969",
+   "out_degree": 3
+  },
+  "residual_d_power_divergent_cs_regeneration_b4_note_2026-06-13": {
+   "deps_hash": "c5b99ba1b2bf",
+   "out_degree": 5
+  },
+  "restricted_strong_field_closure_note": {
+   "deps_hash": "5b0d8fb046ab",
+   "out_degree": 1
+  },
+  "reta_algebraic_irreducibility_genuine_readout_admission_bounded_note_2026-06-12": {
+   "deps_hash": "66a58b8da417",
+   "out_degree": 3
+  },
+  "reta_conversion_factor_carrier_class_elimination_bounded_note_2026-06-12": {
+   "deps_hash": "197c00a654b8",
+   "out_degree": 3
+  },
+  "reta_magnitude_is_continuum_index_theorem_lattice_index_is_integer_bounded_note_2026-06-12": {
+   "deps_hash": "fda6e46f284e",
+   "out_degree": 3
+  },
+  "retained_cross_lane_consistency_support_note_2026-04-22": {
+   "deps_hash": "611a5ced153f",
+   "out_degree": 10
+  },
+  "retardation_discriminator_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "retarded_field_causality_probe_note": {
+   "deps_hash": "507c2d1f4da5",
+   "out_degree": 2
+  },
+  "retarded_field_compact_refinement_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "retarded_field_delay_proxy_note": {
+   "deps_hash": "6dcc5a3cd4b8",
+   "out_degree": 3
+  },
+  "retarded_field_harness_note": {
+   "deps_hash": "9e644cf962a3",
+   "out_degree": 3
+  },
+  "rh_completion_color_anti_fundamental_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "b4b201521fbe",
+   "out_degree": 2
+  },
+  "rh_sector_anomaly_cancellation_identities_note_2026-05-02": {
+   "deps_hash": "785ba75e68d8",
+   "out_degree": 5
+  },
+  "ring_monodromy_does_not_force_car_note_2026-06-04": {
+   "deps_hash": "249b8e8adb93",
+   "out_degree": 6
+  },
+  "route2_readout_record_positivity_does_not_fix_rho_e_narrow_no_go_note_2026-06-08": {
+   "deps_hash": "64eb2ba63e1c",
+   "out_degree": 5
+  },
+  "rp_coupled_multislice_halfspace_gauge_staggered_os_gram_narrow_theorem_note_2026-07-11": {
+   "deps_hash": "6dd0963e11c9",
+   "out_degree": 3
+  },
+  "rp_coupled_two_slice_gauge_staggered_berezin_gram_narrow_theorem_note_2026-07-10": {
+   "deps_hash": "1e2d87e31deb",
+   "out_degree": 4
+  },
+  "rp_gauge_half_wilson_temporal_bridge_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "935828502deb",
+   "out_degree": 6
+  },
+  "rp_mixed_observable_single_transfer_matrix_narrow_theorem_note_2026-05-29": {
+   "deps_hash": "93be5d8f6f59",
+   "out_degree": 2
+  },
+  "rp_p2_gauge_extension_and_realization_residual_note_2026-05-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "rp_rho_ref_radon_nikodym_compatibility_note_2026-05-20": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "rp_two_step_transfer_matrix_singular_mode_c2_tightening_note_2026-06-02": {
+   "deps_hash": "2641ec54e4c7",
+   "out_degree": 1
+  },
+  "rp_wilson_temporal_gauge_bridge_sign_and_positivity_repair_note_2026-06-06": {
+   "deps_hash": "b68130223a99",
+   "out_degree": 5
+  },
+  "rstar_dtotality_axiom_text_instances_bounded_note_2026-07-02": {
+   "deps_hash": "7b707271a9a8",
+   "out_degree": 2
+  },
+  "rule_achirality_from_minimality_qualification_licensing_law_achiral_state_free_bounded_theorem_note_2026-07-04": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "runner_ledger_field_pin_hygiene_convention_proposal_note_2026-07-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "s1_rep_dimension_readoff_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "s3_all_r_boundary_link_disk_theorem_note_2026-05-30": {
+   "deps_hash": "91be04a2a5a1",
+   "out_degree": 4
+  },
+  "s3_anomaly_spacetime_lift_note": {
+   "deps_hash": "b0bade30e5c4",
+   "out_degree": 4
+  },
+  "s3_anomaly_spacetime_lift_note_2026-05-17": {
+   "deps_hash": "33442ecb7e64",
+   "out_degree": 6
+  },
+  "s3_boundary_link_theorem_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "s3_cap_uniqueness_note": {
+   "deps_hash": "3b9fc1f6e901",
+   "out_degree": 1
+  },
+  "s3_endpoint_fiber_uniform_lift_support_2026-06-27": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "s3_general_r_derivation_note": {
+   "deps_hash": "7fad6b7e263a",
+   "out_degree": 3
+  },
+  "s3_mass_matrix_conditional_degeneracy_note_2026-07-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "s3_mass_matrix_no_go_note": {
+   "deps_hash": "c4188d9fecf3",
+   "out_degree": 1
+  },
+  "s3_route2_endpoint_triple_residual_map_bounded_note_2026-06-21": {
+   "deps_hash": "8c65a5db0c51",
+   "out_degree": 17
+  },
+  "s3_taste_cube_decomposition_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "s3_time_bilinear_tensor_action_note": {
+   "deps_hash": "bb23310e20e3",
+   "out_degree": 4
+  },
+  "s3_time_bilinear_tensor_primitive_note": {
+   "deps_hash": "6c467fca703a",
+   "out_degree": 3
+  },
+  "s3_time_bilinear_tensor_primitive_rank1_factorization_note_2026-05-17": {
+   "deps_hash": "a63ccef68ee0",
+   "out_degree": 2
+  },
+  "s3_time_constructed_support_tensor_primitive_note": {
+   "deps_hash": "59b00ab23d65",
+   "out_degree": 1
+  },
+  "s3_time_direct_consumer_ecenter_dependency_classification_note_2026-06-21": {
+   "deps_hash": "0477f35d348c",
+   "out_degree": 6
+  },
+  "s3_time_direct_consumer_readout_ambiguity_packet_note_2026-06-21": {
+   "deps_hash": "8eccc82329ff",
+   "out_degree": 6
+  },
+  "s3_time_endpoint_independent_consumer_inventory_note_2026-06-21": {
+   "deps_hash": "256389169eff",
+   "out_degree": 4
+  },
+  "s3_time_factor_rigidity_readout_primitive_split_note_2026-06-21": {
+   "deps_hash": "b7b57d21996e",
+   "out_degree": 4
+  },
+  "s3_time_observable_hessian_route_note": {
+   "deps_hash": "d90030712e52",
+   "out_degree": 3
+  },
+  "s3_time_primitive_chain_note": {
+   "deps_hash": "695b0c9e02a8",
+   "out_degree": 3
+  },
+  "s3_time_readout_primitive_bridge_assessment_bounded_note_2026-06-12": {
+   "deps_hash": "2bf79acbea93",
+   "out_degree": 4
+  },
+  "s3_time_route2_e_center_consumer_ambiguity_firewall_note_2026-06-21": {
+   "deps_hash": "0a0bbad2549a",
+   "out_degree": 1
+  },
+  "s3_time_spacetime_observable_route_note": {
+   "deps_hash": "59c959121508",
+   "out_degree": 2
+  },
+  "s3_time_spacetime_tensor_primitive_note": {
+   "deps_hash": "22fe4fe3a8ed",
+   "out_degree": 4
+  },
+  "s3_time_spacetime_tensor_primitive_note_2026-05-17": {
+   "deps_hash": "cacdf1f063e8",
+   "out_degree": 5
+  },
+  "s3_time_tensor_build_memo": {
+   "deps_hash": "ff2fe575a980",
+   "out_degree": 2
+  },
+  "s3_time_tensor_primitive_prototype_note": {
+   "deps_hash": "c6da7631bc24",
+   "out_degree": 3
+  },
+  "s3_time_tensorized_schur_primitive_note": {
+   "deps_hash": "22fe4fe3a8ed",
+   "out_degree": 4
+  },
+  "s3_time_tensorized_schur_primitive_note_2026-05-17": {
+   "deps_hash": "29932e269747",
+   "out_degree": 3
+  },
+  "s3_time_theta_to_slice_coupling_factor_rigidity_note_2026-05-17": {
+   "deps_hash": "6c7667cd447f",
+   "out_degree": 3
+  },
+  "s3_time_theta_to_slice_coupling_note": {
+   "deps_hash": "cc3e831306fe",
+   "out_degree": 3
+  },
+  "s3_time_theta_to_slice_readout_witness_criterion_note_2026-06-21": {
+   "deps_hash": "0a0bbad2549a",
+   "out_degree": 1
+  },
+  "s3_time_theta_to_slice_rho_e_dependency_firewall_note_2026-06-21": {
+   "deps_hash": "6c7667cd447f",
+   "out_degree": 3
+  },
+  "s3_time_transfer_matrix_bridge_note": {
+   "deps_hash": "f4a1376a10a7",
+   "out_degree": 6
+  },
+  "s3_time_transfer_matrix_bridge_note_2026-05-17": {
+   "deps_hash": "392eaf6f3e6c",
+   "out_degree": 3
+  },
+  "s3c3_unitary_antiunitary_axis_permutation_split_narrow_theorem_note_2026-05-23": {
+   "deps_hash": "4514c6f97532",
+   "out_degree": 1
+  },
+  "same_family_3d_closure_note": {
+   "deps_hash": "473ab73403e7",
+   "out_degree": 3
+  },
+  "scalar_3plus1_temporal_ratio_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "scalar_cubic_car_qca_triviality_and_six_direction_escape_bounded_theorem_note_2026-07-11": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "scalar_harmonic_tower_theorem_note_2026-04-24": {
+   "deps_hash": "6b88b7457bda",
+   "out_degree": 5
+  },
+  "scalar_i_and_real_generation_structure_k_parity_separation_bounded_note_2026-06-08": {
+   "deps_hash": "fbe1946357be",
+   "out_degree": 3
+  },
+  "scalar_kg_rerun_note_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "scalar_selector_cycle13_meta_closure_status_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "scalar_selector_cycle1_science_review_note_2026-04-19": {
+   "deps_hash": "4dc2935a6cfb",
+   "out_degree": 4
+  },
+  "scalar_selector_full_stack_recovery_note_2026-04-19": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "scalar_selector_proof_chains_2026-04-19": {
+   "deps_hash": "89d6042c8339",
+   "out_degree": 2
+  },
+  "scalar_selector_remaining_open_imports_2026-04-20": {
+   "deps_hash": "48488f2032e5",
+   "out_degree": 7
+  },
+  "scalar_selector_reviewer_package_2026-04-20": {
+   "deps_hash": "24d1374cd2d0",
+   "out_degree": 3
+  },
+  "scalar_selector_synthesis_note_2026-04-19": {
+   "deps_hash": "5875afc92cf1",
+   "out_degree": 9
+  },
+  "scalar_tensor_ray_magnitude_bridge_note_2026-04-19": {
+   "deps_hash": "dfe4b1d380d2",
+   "out_degree": 2
+  },
+  "scalar_trace_tensor_no_go_note": {
+   "deps_hash": "07e9a92fe162",
+   "out_degree": 3
+  },
+  "scalar_trace_tensor_record_invariance_companion_note_2026-06-04": {
+   "deps_hash": "02deca191ed1",
+   "out_degree": 2
+  },
+  "scale_reference_primitive": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "scaling_failure_mechanisms": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "scaling_targets": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "schur_covariance_inheritance_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "70fa3bf728f4",
+   "out_degree": 1
+  },
+  "science_3plus1_line_law_known_limits_note_2026-04-20": {
+   "deps_hash": "3e19d7b5d628",
+   "out_degree": 6
+  },
+  "second_grown_family_complex_boundary_note": {
+   "deps_hash": "3ba1a856c176",
+   "out_degree": 1
+  },
+  "second_grown_family_complex_note": {
+   "deps_hash": "b2f619505ba7",
+   "out_degree": 1
+  },
+  "second_grown_family_note": {
+   "deps_hash": "a2382ad0bac6",
+   "out_degree": 3
+  },
+  "second_grown_family_sign_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "self_consistency_forces_poisson_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "self_consistency_structured_null_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "self_gravity_backreaction_closure_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "self_gravity_born_hardening_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "self_gravity_entropy_note_2026-04-11": {
+   "deps_hash": "217468840e2c",
+   "out_degree": 3
+  },
+  "self_gravity_failure_diagnosis": {
+   "deps_hash": "bc8eef3655b9",
+   "out_degree": 2
+  },
+  "self_gravity_scaling_note_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "semigroup_closure_does_not_force_heat_kernel_quadratic_condition_bounded_note_2026-07-02": {
+   "deps_hash": "36daf746aba1",
+   "out_degree": 2
+  },
+  "session_summary_2026-04-01_dimensional": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "session_summary_2026-04-04": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "session_synthesis_2026-04-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "session_synthesis_2026-04-10_final": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "session_synthesis_2026-04-10_graph_axioms": {
+   "deps_hash": "4540698d5d45",
+   "out_degree": 4
+  },
+  "session_synthesis_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "seventh_family_diagonal_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "seventh_family_diagonal_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "shapiro_delay_note": {
+   "deps_hash": "89dafd055256",
+   "out_degree": 3
+  },
+  "shapiro_experimental_card": {
+   "deps_hash": "292f883f8bc0",
+   "out_degree": 3
+  },
+  "shapiro_family_portability_note": {
+   "deps_hash": "be5db64885c5",
+   "out_degree": 2
+  },
+  "shapiro_five_family_portability_corrected_boundary_note_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "shapiro_qa_retest_note": {
+   "deps_hash": "8efc8d94d49f",
+   "out_degree": 3
+  },
+  "shapiro_static_discriminator_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "shapiro_unique_discriminator_v2_note": {
+   "deps_hash": "8efc8d94d49f",
+   "out_degree": 3
+  },
+  "sharp_record_fisher_tangent_space_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "sigma_hier_uniqueness_theorem_note_2026-04-19": {
+   "deps_hash": "94aa2d15c272",
+   "out_degree": 1
+  },
+  "sigma_mnu_f3_dm_cross_bound_audit_note_2026-04-28": {
+   "deps_hash": "83e8ebd6bfef",
+   "out_degree": 3
+  },
+  "sigma_mnu_f3_stuck_fanout_synthesis_note_2026-04-28": {
+   "deps_hash": "a4d99fc7277a",
+   "out_degree": 10
+  },
+  "sign_portability_invariant_family_second_grown_derivation_theorem_note_2026-05-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "sign_portability_invariant_note": {
+   "deps_hash": "52e6227652fe",
+   "out_degree": 7
+  },
+  "signed_gravity_aps_action_origin_superselection_stability_note": {
+   "deps_hash": "87f31c211962",
+   "out_degree": 4
+  },
+  "signed_gravity_aps_action_origin_superselection_stability_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "signed_gravity_aps_boundary_index_chi_probe_note": {
+   "deps_hash": "7fe73212343b",
+   "out_degree": 4
+  },
+  "signed_gravity_aps_locked_axiom_extension_note": {
+   "deps_hash": "20611932b5ec",
+   "out_degree": 3
+  },
+  "signed_gravity_aps_locked_source_action_proposal_note": {
+   "deps_hash": "6d6db4319cee",
+   "out_degree": 2
+  },
+  "signed_gravity_aps_wald_gauss_bridge_audit_note": {
+   "deps_hash": "e5e9912f0e23",
+   "out_degree": 3
+  },
+  "signed_gravity_boundary_coframe_chi_probe_note": {
+   "deps_hash": "9f075239dd55",
+   "out_degree": 4
+  },
+  "signed_gravity_boundary_coframe_chi_probe_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "signed_gravity_boundary_z2_flux_chi_probe_note": {
+   "deps_hash": "f5d9d7d8a741",
+   "out_degree": 2
+  },
+  "signed_gravity_chi_selector_theorem_or_nogo_note": {
+   "deps_hash": "2e0a6291f559",
+   "out_degree": 4
+  },
+  "signed_gravity_chi_selector_theorem_or_nogo_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "signed_gravity_cl3z3_source_character_derivation_note": {
+   "deps_hash": "e7aea425f93d",
+   "out_degree": 4
+  },
+  "signed_gravity_cl3z3_source_character_derivation_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "signed_gravity_continuum_graded_einstein_localization_note": {
+   "deps_hash": "7670ac68dd45",
+   "out_degree": 9
+  },
+  "signed_gravity_interface_kodd_pfaffian_line_bundle_label_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "signed_gravity_interface_pfaffian_gap_closing_sweep_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "d6a55ec8a3d7",
+   "out_degree": 4
+  },
+  "signed_gravity_mechanism_separation_note": {
+   "deps_hash": "75e3eed907b4",
+   "out_degree": 6
+  },
+  "signed_gravity_native_boundary_complex_containment_note": {
+   "deps_hash": "1cc3592b8a8b",
+   "out_degree": 1
+  },
+  "signed_gravity_native_transfer_kernel_twist_sufficiency_test_narrow_theorem_note_2026-06-11": {
+   "deps_hash": "d1da2f9855ac",
+   "out_degree": 2
+  },
+  "signed_gravity_naturally_hosted_orientation_line_note": {
+   "deps_hash": "f0182b0f60ca",
+   "out_degree": 2
+  },
+  "signed_gravity_nature_grade_closure_blocker_audit_note": {
+   "deps_hash": "ace12f9b28cc",
+   "out_degree": 6
+  },
+  "signed_gravity_non_claim_gate_note": {
+   "deps_hash": "e7703baeff2f",
+   "out_degree": 5
+  },
+  "signed_gravity_nonlocal_boundary_chi_target_note": {
+   "deps_hash": "9183d9f380b5",
+   "out_degree": 4
+  },
+  "signed_gravity_nonlocal_projector_charge_chi_probe_note": {
+   "deps_hash": "7fe73212343b",
+   "out_degree": 4
+  },
+  "signed_gravity_oriented_tensor_source_lift_note": {
+   "deps_hash": "2540a357336d",
+   "out_degree": 4
+  },
+  "signed_gravity_parity_grading_escape_dichotomy_narrow_theorem_note_2026-06-11": {
+   "deps_hash": "96513d4ece80",
+   "out_degree": 3
+  },
+  "signed_gravity_product_grading_eta_sector_selection_bridge_narrow_theorem_note_2026-06-11": {
+   "deps_hash": "2314a284c1a5",
+   "out_degree": 4
+  },
+  "signed_gravity_product_grading_source_activation_obstruction_note_2026-06-17": {
+   "deps_hash": "bc9f017f1550",
+   "out_degree": 1
+  },
+  "signed_gravity_remaining_closure_gates_note": {
+   "deps_hash": "7659804bcade",
+   "out_degree": 1
+  },
+  "signed_gravity_response_backlog_2026-04-25": {
+   "deps_hash": "becd4808514b",
+   "out_degree": 20
+  },
+  "signed_gravity_response_lane_status_note_2026-04-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "signed_gravity_retained_boundary_source_principle_no_go_note": {
+   "deps_hash": "9a76193228f1",
+   "out_degree": 2
+  },
+  "signed_gravity_source_action_escape_hatch_note": {
+   "deps_hash": "0e7e171e4fc5",
+   "out_degree": 2
+  },
+  "signed_gravity_source_character_uniqueness_theorem_note": {
+   "deps_hash": "d3bae28eef3a",
+   "out_degree": 2
+  },
+  "signed_gravity_source_line_origin_tensor_lift_note": {
+   "deps_hash": "d9b4e875973a",
+   "out_degree": 3
+  },
+  "signed_gravity_staggered_dirac_aps_boundary_realization_note": {
+   "deps_hash": "3ff15d41b955",
+   "out_degree": 1
+  },
+  "signed_gravity_tensor_source_transport_retention_dep_resolution_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "52823afa6cde",
+   "out_degree": 3
+  },
+  "signed_gravity_tensor_source_transport_retention_note": {
+   "deps_hash": "0686ddfac8e3",
+   "out_degree": 1
+  },
+  "signed_gravity_wilson_mass_holonomy_twisted_edge_realization_narrow_theorem_note_2026-06-11": {
+   "deps_hash": "e23bb55f4693",
+   "out_degree": 2
+  },
+  "sin2thetaw_proof_walk_lattice_independence_bounded_note_2026-05-08": {
+   "deps_hash": "38fa47c24df2",
+   "out_degree": 4
+  },
+  "sin_squared_theta_w_gut_from_su5_note_2026-05-02": {
+   "deps_hash": "270ebdac4b2b",
+   "out_degree": 3
+  },
+  "single_axiom_hilbert_note": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "single_axiom_information_note": {
+   "deps_hash": "f52d707bb864",
+   "out_degree": 1
+  },
+  "single_clock_antiperiodic_axis_datum_s4_transport_bounded_theorem_note_2026-06-17": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "single_clock_apbc_axis_label_bridge_bounded_theorem_note_2026-06-16": {
+   "deps_hash": "71844971bd74",
+   "out_degree": 2
+  },
+  "single_clock_axis_selection_from_record_durability_narrow_no_go_note_2026-06-11": {
+   "deps_hash": "efc187e08844",
+   "out_degree": 12
+  },
+  "single_clock_blocked_time_unit_split_n2_support_note_2026-06-17": {
+   "deps_hash": "d2ddde9d7a06",
+   "out_degree": 5
+  },
+  "single_clock_independent_commuting_transfer_factor_n5_no_go_note_2026-06-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "single_clock_kms_apbc_axis_supplier_no_go_note_2026-06-16": {
+   "deps_hash": "c29677f85515",
+   "out_degree": 2
+  },
+  "single_clock_physical_clock_admission_inventory_n5_support_note_2026-06-17": {
+   "deps_hash": "d65c6179d3da",
+   "out_degree": 5
+  },
+  "single_clock_stone_finite_dim_uniqueness_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "single_clock_uniqueness_scope_boundary_2026-06-06": {
+   "deps_hash": "4cd2a98ca87c",
+   "out_degree": 1
+  },
+  "single_step_locality_excludes_quadratic_generator_bounded_note_2026-07-02": {
+   "deps_hash": "ccc79bcb9fe8",
+   "out_degree": 2
+  },
+  "site_license_tick_dichotomy_all_periods_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "71548c1b3e14",
+   "out_degree": 7
+  },
+  "site_phase_cube_shift_intertwiner_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "sixth_family_complex_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "sixth_family_distance_law_third_vs_sixth_quick_note": {
+   "deps_hash": "408520327079",
+   "out_degree": 3
+  },
+  "sixth_family_sheared_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "sixth_family_sheared_fm_transfer_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "sixth_family_sheared_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "slab_boundary_eta_globally_zero_per_edge_nonuniversal_no_fractional_carrier_bounded_note_2026-06-12": {
+   "deps_hash": "9defae253834",
+   "out_degree": 2
+  },
+  "slow_variables_derived_one_body_closure_link_is_a_coordinate_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "96b72bb31cc5",
+   "out_degree": 4
+  },
+  "sm_anomaly_closure_retained_anchors_decoupled_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "9db00a34a7e0",
+   "out_degree": 5
+  },
+  "sm_gstar_from_framework_structure_bounded_theorem_note_2026-05-29": {
+   "deps_hash": "fda3572fd904",
+   "out_degree": 11
+  },
+  "sm_gstar_higgs_sector_count_stretch_note_2026-05-29": {
+   "deps_hash": "d3a43df05873",
+   "out_degree": 4
+  },
+  "sm_gstar_hunit_neutral_radial_orbit_support_note_2026-06-18": {
+   "deps_hash": "a868b5060bc9",
+   "out_degree": 2
+  },
+  "sm_gstar_i12_empirical_thermal_comparator_bridge_bounded_note_2026-06-15": {
+   "deps_hash": "335840686631",
+   "out_degree": 1
+  },
+  "sm_gstar_i12_nur_thermal_exclusion_bounded_note_2026-05-29": {
+   "deps_hash": "a8d21ab26239",
+   "out_degree": 3
+  },
+  "sm_gstar_r_matter_residual_reduction_bounded_note_2026-05-29": {
+   "deps_hash": "ad118bb5d1e0",
+   "out_degree": 12
+  },
+  "sm_gstar_residual_retirement_fsb_u1y_bounded_note_2026-05-29": {
+   "deps_hash": "2a9d6130ac3c",
+   "out_degree": 2
+  },
+  "sm_hypercharge_uniqueness_algebraic_solution_enumeration_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "sm_hypercharge_uniqueness_without_nu_r_input_theorem_note_2026-05-02": {
+   "deps_hash": "059b03bdeb8f",
+   "out_degree": 3
+  },
+  "sm_identity_triangulation_convergence_note_2026-05-23": {
+   "deps_hash": "ffc014f77e51",
+   "out_degree": 4
+  },
+  "sm_one_higgs_yukawa_gauge_selection_theorem_note_2026-04-26": {
+   "deps_hash": "a0c0dedd8840",
+   "out_degree": 1
+  },
+  "sm_relativistic_dof_count_import_note_2026-05-17": {
+   "deps_hash": "4fef2c22d0ac",
+   "out_degree": 1
+  },
+  "so4_unique_su2_su2_split_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "sommer_scale_from_wilson_chain_partial_note_2026-05-10_sommer": {
+   "deps_hash": "16174e82c177",
+   "out_degree": 13
+  },
+  "source_driven_field_recovery_h025_pocket_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_driven_field_recovery_sweep_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_field_static_law_classification_bounded_note_2026-07-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_measure_log_selection_boundary_theorem_note_2026-05-30": {
+   "deps_hash": "6295958a5417",
+   "out_degree": 3
+  },
+  "source_measure_pcal_cumulant_mobius_theorem_note_2026-05-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_measure_pcal_retirement_synthesis_note_2026-05-30": {
+   "deps_hash": "6f8c2223d0e1",
+   "out_degree": 3
+  },
+  "source_measure_pcal_rn_cocycle_theorem_note_2026-05-30": {
+   "deps_hash": "0bd8d5217597",
+   "out_degree": 3
+  },
+  "source_measure_planck_action_rn_source_unit_bridge_note_2026-05-30": {
+   "deps_hash": "316c953f9dfc",
+   "out_degree": 3
+  },
+  "source_measure_record_intervention_theorem_note_2026-05-30": {
+   "deps_hash": "75e0f2cca890",
+   "out_degree": 2
+  },
+  "source_measure_sharp_record_orthonormal_response_basis_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_measure_sharp_record_tangent_space_dep_resolution_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "83f874c94ceb",
+   "out_degree": 3
+  },
+  "source_measure_sharp_record_tangent_space_theorem_note_2026-05-30": {
+   "deps_hash": "a656aced379a",
+   "out_degree": 2
+  },
+  "source_resolved_exact_green_h025_pocket_note": {
+   "deps_hash": "3495eac217fb",
+   "out_degree": 2
+  },
+  "source_resolved_exact_green_h025_pocket_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_exact_green_pocket_kernel_reconciliation_narrow_note_2026-06-02": {
+   "deps_hash": "57808558965b",
+   "out_degree": 2
+  },
+  "source_resolved_exact_green_pocket_note": {
+   "deps_hash": "3906ffb7ae7b",
+   "out_degree": 1
+  },
+  "source_resolved_exact_green_pocket_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_exact_green_scaling_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_exact_green_self_consistent_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_generated_architecture_bridge_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_generated_bridge_failure_audit": {
+   "deps_hash": "ce35bfd95b39",
+   "out_degree": 4
+  },
+  "source_resolved_generated_discriminator_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_generated_family_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_generated_new_family_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_generated_new_family_v2_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_generated_support_mass_scaling_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_generated_support_recovery_basin_note": {
+   "deps_hash": "1872ab16defa",
+   "out_degree": 3
+  },
+  "source_resolved_generated_support_recovery_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_generated_wavefield_bridge_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_generated_wavefield_transfer_v2_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_geometry_rule_repair_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_green_robustness_note": {
+   "deps_hash": "3495eac217fb",
+   "out_degree": 2
+  },
+  "source_resolved_propagating_generated_transfer_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_propagating_green_pocket_kernel_display_reconcile_companion_note_2026-06-02": {
+   "deps_hash": "bdd240fc3eae",
+   "out_degree": 1
+  },
+  "source_resolved_propagating_green_pocket_note": {
+   "deps_hash": "3906ffb7ae7b",
+   "out_degree": 1
+  },
+  "source_resolved_radical_geometry_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_retarded_green_corrected_packet_note_2026-05-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_retarded_green_pocket_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_self_consistent_generated_transfer_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_support_localization_split_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_transverse_green_corrected_boundary_note_2026-05-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_transverse_propagating_green_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "source_resolved_wavefield_escalation_note": {
+   "deps_hash": "d3bba27469b6",
+   "out_degree": 4
+  },
+  "source_resolved_wavefield_green_pocket_note": {
+   "deps_hash": "3906ffb7ae7b",
+   "out_degree": 1
+  },
+  "source_resolved_wavefield_mechanism_note": {
+   "deps_hash": "5ba0a91f41c4",
+   "out_degree": 1
+  },
+  "source_resolved_wavefield_v2_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "sourcing_two_channel_wake_quantification_bounded_note_2026-07-08": {
+   "deps_hash": "cfa145c016e8",
+   "out_degree": 1
+  },
+  "spatial_cluster_decomposition_lieb_robinson_real_note_2026-05-19": {
+   "deps_hash": "c81f78f2bff4",
+   "out_degree": 1
+  },
+  "spatial_cubic_time_anisotropy_gate_no_go_2026-06-06": {
+   "deps_hash": "75b86a0c6e5e",
+   "out_degree": 2
+  },
+  "spatial_slab_transfer_operator_positivity_and_delta_x_real_note_2026-05-19": {
+   "deps_hash": "0509803eed09",
+   "out_degree": 4
+  },
+  "species_bridge_minimum_decomposition_bounded_theorem_note_2026-06-13": {
+   "deps_hash": "778bb78dd029",
+   "out_degree": 3
+  },
+  "species_bridge_residual_is_ratification_class_grade_scoped_bounded_note_2026-07-02": {
+   "deps_hash": "b6caef4dcb56",
+   "out_degree": 3
+  },
+  "species_carrier_invariant_ring_no_orbit_separator_exact_note_2026-07-03": {
+   "deps_hash": "5892d1c5ac9c",
+   "out_degree": 1
+  },
+  "species_identification_universal_floor_classification_note_2026-07-03": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "spectral_closure_2026-04-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "spectral_symmetry_note": {
+   "deps_hash": "7785b868fd32",
+   "out_degree": 1
+  },
+  "spectral_trajectory_theorem_2026-04-11": {
+   "deps_hash": "db257ac283db",
+   "out_degree": 7
+  },
+  "sphaleron_coefficient_28_79_from_sm_like_content_admission_bridge_note_2026-05-28": {
+   "deps_hash": "7a3ee4490765",
+   "out_degree": 2
+  },
+  "spin_statistics_berezin_determinant_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "spin_statistics_cardinality_pauli_exclusion_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "1c68fd8955a7",
+   "out_degree": 2
+  },
+  "spin_statistics_fs_admission_located_exercise_note_2026-06-06": {
+   "deps_hash": "8e85237fd4da",
+   "out_degree": 6
+  },
+  "spinnetwork_full_ed_bounded_theorem_note_2026-05-07_w1full": {
+   "deps_hash": "838364dd6763",
+   "out_degree": 4
+  },
+  "spinnetwork_full_ed_lambda2_frontier_broken_note_2026-05-07_w1exact": {
+   "deps_hash": "2af8dda7cbb5",
+   "out_degree": 5
+  },
+  "spinnetwork_full_ed_loop_basis_bounded_theorem_note_2026-05-07_w1exactv2": {
+   "deps_hash": "6bc83b0be0e8",
+   "out_degree": 3
+  },
+  "st1_st2_same_wall_gauge_dynamics_residual_convergence_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "819463065356",
+   "out_degree": 7
+  },
+  "stable_post_record_dial_location_certificate_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "stack_spectral_transcription_weak_registration_faithful_limit_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "916b0ba48f41",
+   "out_degree": 2
+  },
+  "staggered_3d_self_gravity_sign_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_axis_symmetry_is_s3_narrow_theorem_note_2026-05-23": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_backreaction_capture_closure_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_backreaction_green_closure_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_backreaction_iterative_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_backreaction_live_capture_packet_note_2026-05-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_backreaction_live_green_packet_note_2026-05-29": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_backreaction_nonlocal_closure_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_backreaction_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_backreaction_results_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_backreaction_scale_closure_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_backreaction_shell_spectral_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_chiral_symmetry_spectrum_theorem_note_2026-05-02": {
+   "deps_hash": "ebd9444f69cc",
+   "out_degree": 1
+  },
+  "staggered_chirality_selector_enumerator_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "46acb19c42a7",
+   "out_degree": 3
+  },
+  "staggered_dag_note_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_dirac_bz_corner_forcing_theorem_note_2026-05-07": {
+   "deps_hash": "e1a3a67d743a",
+   "out_degree": 5
+  },
+  "staggered_dirac_chirality_parity_bridge_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_dirac_common_hw1_bz_corner_carrier_identification_bridge_narrow_theorem_note_2026-07-05": {
+   "deps_hash": "7a94507e00cc",
+   "out_degree": 6
+  },
+  "staggered_dirac_coupling_sign_channel_registration_narrow_theorem_note_2026-07-03": {
+   "deps_hash": "a1f6dd5306ae",
+   "out_degree": 4
+  },
+  "staggered_dirac_exercise_honest_reassessment_note_2026-06-06": {
+   "deps_hash": "ff1c324491fe",
+   "out_degree": 4
+  },
+  "staggered_dirac_gate_ac_phi_lambda_labeling_convention_accepted_premise_bridge_bounded_note_2026-05-26": {
+   "deps_hash": "4adfde57f095",
+   "out_degree": 6
+  },
+  "staggered_dirac_gate_closure_synthesis_theorem_note_2026-05-17": {
+   "deps_hash": "3f740d848df3",
+   "out_degree": 29
+  },
+  "staggered_dirac_grassmann_forcing_theorem_note_2026-05-07": {
+   "deps_hash": "94315ca0cfff",
+   "out_degree": 7
+  },
+  "staggered_dirac_hw1_three_eigenvalue_structure_positive_theorem_note_2026-05-10": {
+   "deps_hash": "19ddf4d8ec10",
+   "out_degree": 6
+  },
+  "staggered_dirac_kawamoto_smit_conditional_realization_rescoping_companion_note_2026-06-03": {
+   "deps_hash": "190b90abdbd0",
+   "out_degree": 1
+  },
+  "staggered_dirac_kawamoto_smit_forcing_theorem_note_2026-05-07": {
+   "deps_hash": "55bd477105ce",
+   "out_degree": 2
+  },
+  "staggered_dirac_kinetic_class_forcing_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "668043e8df1e",
+   "out_degree": 4
+  },
+  "staggered_dirac_kinetic_class_two_component_exclusion_narrow_theorem_note_2026-06-11": {
+   "deps_hash": "44f1ea05f795",
+   "out_degree": 3
+  },
+  "staggered_dirac_link_integration_class_coupling_transposition_narrow_theorem_note_2026-07-02": {
+   "deps_hash": "cbe3dcb7e870",
+   "out_degree": 4
+  },
+  "staggered_dirac_local_density_readout_bridge_narrow_theorem_note_2026-06-17": {
+   "deps_hash": "db50a4c55f07",
+   "out_degree": 1
+  },
+  "staggered_dirac_minimal_surface_kinetic_corner_nonforcing_no_go_note_2026-07-10": {
+   "deps_hash": "42b006d21a1e",
+   "out_degree": 4
+  },
+  "staggered_dirac_physical_species_direct_theorem_note_2026-05-07": {
+   "deps_hash": "92c95d1ee3d8",
+   "out_degree": 9
+  },
+  "staggered_dirac_pkin_subtree_current_surface_restatement_note_2026-07-03": {
+   "deps_hash": "15bfdd2e0f17",
+   "out_degree": 9
+  },
+  "staggered_dirac_realization_gate_note_2026-05-03": {
+   "deps_hash": "e43649dff1a2",
+   "out_degree": 9
+  },
+  "staggered_dirac_substep1_grassmann_forcing_bridge_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "7110a4de23f9",
+   "out_degree": 4
+  },
+  "staggered_dirac_substep1_jw_bridge_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "4514c6f97532",
+   "out_degree": 1
+  },
+  "staggered_dirac_substep1_statistics_agnostic_no_forcing_note_2026-05-25": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "staggered_dirac_substep1_statistics_gl_f_conditional_discriminator_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "0a6fd0d64c18",
+   "out_degree": 5
+  },
+  "staggered_dirac_substep1_u4_conditional_single_module_narrow_bounded_note_2026-05-17": {
+   "deps_hash": "0b48e244e1f7",
+   "out_degree": 2
+  },
+  "staggered_dirac_substep2_kahler_dirac_equivalence_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "21e248af03e3",
+   "out_degree": 3
+  },
+  "staggered_dirac_substep3_bz_corner_hamming_orbit_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_dirac_substep3_species_reduction_bridge_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "3e906ce36783",
+   "out_degree": 3
+  },
+  "staggered_dirac_substep4_ac_lambda_simultaneous_diagonalization_bridge_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_dirac_substep4_ac_narrow_bounded_note_2026-05-07_substep4ac": {
+   "deps_hash": "9c398bc2f685",
+   "out_degree": 13
+  },
+  "staggered_dirac_substep4_ac_phi_trace_equipartition_bridge_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "5867f5ecfaa2",
+   "out_degree": 1
+  },
+  "staggered_dirac_substep4_amin_joint_c3_automorphism_selector_invariance_bridge_narrow_theorem_note_2026-07-05": {
+   "deps_hash": "2e938b5e5d65",
+   "out_degree": 3
+  },
+  "staggered_dirac_substep4_labeling_no_go_note_2026-05-17": {
+   "deps_hash": "6699f7bcdae3",
+   "out_degree": 8
+  },
+  "staggered_dirac_substep4_positive_ratchet_note_2026-05-10": {
+   "deps_hash": "d38ddcc322a0",
+   "out_degree": 4
+  },
+  "staggered_fermion_card_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_fermion_card_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_fermion_card_h2_positive_source_phi_positivity_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_gbare_trace_surface_bridge_note_2026-06-06": {
+   "deps_hash": "b222f2a65d79",
+   "out_degree": 7
+  },
+  "staggered_geometry_superposition_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_graph_failure_map_note": {
+   "deps_hash": "c737ed4912bd",
+   "out_degree": 1
+  },
+  "staggered_graph_gauge_closure_note": {
+   "deps_hash": "c737ed4912bd",
+   "out_degree": 1
+  },
+  "staggered_graph_gauge_closure_results_2026-04-10": {
+   "deps_hash": "1f24b3e21376",
+   "out_degree": 2
+  },
+  "staggered_graph_observables_note": {
+   "deps_hash": "a3d7bf29a04b",
+   "out_degree": 2
+  },
+  "staggered_graph_portability_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_graph_portability_stress_note": {
+   "deps_hash": "c737ed4912bd",
+   "out_degree": 1
+  },
+  "staggered_hamiltonian_direction_decomposition_bounded_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "ebd9444f69cc",
+   "out_degree": 1
+  },
+  "staggered_kernel_satisfies_z_point_cone_certificate_narrow_theorem_note_2026-06-11": {
+   "deps_hash": "5a9ee5914040",
+   "out_degree": 2
+  },
+  "staggered_layered_backreaction_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_layered_gauge_engineering_note": {
+   "deps_hash": "c737ed4912bd",
+   "out_degree": 1
+  },
+  "staggered_layered_gauge_phase_diagram_note": {
+   "deps_hash": "54dcbc64bbe6",
+   "out_degree": 2
+  },
+  "staggered_layered_loop_threshold_note": {
+   "deps_hash": "e9773e77a1b9",
+   "out_degree": 1
+  },
+  "staggered_newton_blocking_sensitivity_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_newton_reproduction_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_only_det_positivity_case_a_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_os0_supplied_action_ks_blocking_four_taste_module_narrow_theorem_note_2026-07-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_scalar_mass_class_bounded_premise_bridge_note_2026-06-03": {
+   "deps_hash": "e45ff6568ef9",
+   "out_degree": 1
+  },
+  "staggered_scalar_parity_lapse_coupling_external_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_scheme_forced_by_one_qubit_per_site_locality_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "759d64d18fda",
+   "out_degree": 4
+  },
+  "staggered_self_consistent_two_body_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_site_license_tick_dichotomy_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "d99bfb1dc31a",
+   "out_degree": 6
+  },
+  "staggered_taste_is_the_qubit_no_separate_koide_multiplicity_narrow_obstruction_note_2026-06-04": {
+   "deps_hash": "bef2df9b8c9c",
+   "out_degree": 9
+  },
+  "staggered_test_mass_companion_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_two_field_wave_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "staggered_wilson_det_positivity_bridge_theorem_note_2026-05-05": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "stale_narrative_review_2026-05-03": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "standard_model_hypercharge_uniqueness_theorem_note_2026-04-24": {
+   "deps_hash": "72ebcb79c7d3",
+   "out_degree": 7
+  },
+  "star_supported_bridge_class_note": {
+   "deps_hash": "b77af84c23c5",
+   "out_degree": 2
+  },
+  "start_here": {
+   "deps_hash": "15e8dcb8a090",
+   "out_degree": 14
+  },
+  "static_source_readout_i1_accepted_premise_bridge_bounded_note_2026-05-27": {
+   "deps_hash": "63a3ca8f58cf",
+   "out_degree": 3
+  },
+  "static_source_readout_i1_accepted_premise_bridge_dep_resolution_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "88d923197b8c",
+   "out_degree": 5
+  },
+  "statistics_atom_reduces_to_product_form_on_retained_gleason_surface_bounded_note_2026-06-12": {
+   "deps_hash": "95a3d3b632ae",
+   "out_degree": 5
+  },
+  "statistics_outcome_factorization_not_forced_by_born_marginals_narrow_no_go_note_2026-06-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "statistics_product_instance_criterion_bridge_bounded_theorem_note_2026-06-17": {
+   "deps_hash": "ad3b0e02962c",
+   "out_degree": 4
+  },
+  "strc_lo_collinearity_theorem_note_2026-04-19": {
+   "deps_hash": "4a46de74c213",
+   "out_degree": 5
+  },
+  "strong_cp_determinant_readout_bridge_narrow_theorem_note_2026-06-12": {
+   "deps_hash": "71610fe43ab7",
+   "out_degree": 4
+  },
+  "strong_cp_epsilon_pseudotensor_oh_sign_bridge_bounded_note_2026-05-26": {
+   "deps_hash": "0f5aad4aab3b",
+   "out_degree": 1
+  },
+  "strong_cp_gauge_theta_multiplaquette_ftf_is_admissible_not_clean_closeable_bounded_note_2026-06-07": {
+   "deps_hash": "9409154e770b",
+   "out_degree": 5
+  },
+  "strong_cp_gauge_theta_not_forced_by_reality_positivity_or_cpt_bounded_note_2026-06-07": {
+   "deps_hash": "3c042f73b471",
+   "out_degree": 6
+  },
+  "strong_cp_joint_bridge_fails_holomorphic_residual_2026-06-04": {
+   "deps_hash": "492b5d989d67",
+   "out_degree": 6
+  },
+  "strong_cp_operator_basis_and_mass_orientation_theorem_note_2026-05-19": {
+   "deps_hash": "1565e186b482",
+   "out_degree": 5
+  },
+  "strong_cp_parity_measure_correction_orientation_gate_no_go_note_2026-06-08": {
+   "deps_hash": "c947340c8df0",
+   "out_degree": 6
+  },
+  "strong_cp_rp_half_cannot_forbid_cp_odd_imaginary_no_go_note_2026-05-16": {
+   "deps_hash": "822549b650f9",
+   "out_degree": 1
+  },
+  "strong_cp_theta_bar_structured_admission_2026-06-04": {
+   "deps_hash": "27d1af493255",
+   "out_degree": 3
+  },
+  "strong_cp_theta_zero_audited_scope_narrow_bounded_note_2026-05-10": {
+   "deps_hash": "510e05755296",
+   "out_degree": 1
+  },
+  "strong_cp_theta_zero_note": {
+   "deps_hash": "6311da330cc6",
+   "out_degree": 4
+  },
+  "structural_no_go_survey_note": {
+   "deps_hash": "e7df0adc06f6",
+   "out_degree": 2
+  },
+  "structured_chokepoint_bridge_extension_note": {
+   "deps_hash": "479415a0ccca",
+   "out_degree": 1
+  },
+  "structured_chokepoint_bridge_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "structured_mirror_bornsafe_scan_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "structured_mirror_reconciliation_note": {
+   "deps_hash": "c1c727e4e2ec",
+   "out_degree": 1
+  },
+  "structureless_dag_gravity_harness_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "structureless_dag_gravity_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "su2_double_use_reduces_to_one_index_pairing_admission_bounded_note_2026-06-08": {
+   "deps_hash": "61c248cd9bc2",
+   "out_degree": 5
+  },
+  "su2_u0_single_plaquette_beta16_native_interval_bounded_support_note_2026-06-18": {
+   "deps_hash": "522e60fa8b64",
+   "out_degree": 1
+  },
+  "su2_weak_alpha_lattice_one_over_sixteen_pi_anchor_narrow_theorem_note_2026-05-28": {
+   "deps_hash": "fda2cf5d517e",
+   "out_degree": 2
+  },
+  "su2_weak_beta_coefficient_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "f9016420ed6b",
+   "out_degree": 6
+  },
+  "su2_weak_beta_coefficient_structural_closed_form_theorem_note_2026-04-26": {
+   "deps_hash": "0028464a6b7f",
+   "out_degree": 6
+  },
+  "su2_weak_one_loop_inverse_alpha_scale_log_bridge_narrow_theorem_note_2026-06-15": {
+   "deps_hash": "27cb5aa0cb8d",
+   "out_degree": 4
+  },
+  "su2_witten_z2_anomaly_theorem_note_2026-04-24": {
+   "deps_hash": "eeabae877e46",
+   "out_degree": 6
+  },
+  "su3_adjoint_casimir_theorem_note_2026-05-02": {
+   "deps_hash": "5e93d700a831",
+   "out_degree": 1
+  },
+  "su3_anomaly_forced_3bar_completion_theorem_note_2026-05-02": {
+   "deps_hash": "8ab2176d839a",
+   "out_degree": 2
+  },
+  "su3_beta6_gap_bulk_criticality_reduction_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "e2abd5b10874",
+   "out_degree": 4
+  },
+  "su3_bridge_clean_tube_k12_support_2026-05-04": {
+   "deps_hash": "c95e95a31455",
+   "out_degree": 2
+  },
+  "su3_bridge_pr525_flaw_fix_note_2026-05-05": {
+   "deps_hash": "8bf61b9fba5e",
+   "out_degree": 1
+  },
+  "su3_bulk_criticality_premise_rigorous_floor_note_2026-06-09": {
+   "deps_hash": "4c012a5a4057",
+   "out_degree": 1
+  },
+  "su3_casimir_fundamental_algebraic_k1_k3_narrow_proof_walk_bounded_note_2026-05-10": {
+   "deps_hash": "5e93d700a831",
+   "out_degree": 1
+  },
+  "su3_casimir_fundamental_theorem_note_2026-05-02": {
+   "deps_hash": "5e93d700a831",
+   "out_degree": 1
+  },
+  "su3_character_diagonal_convolution_equivalence_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "su3_cube_full_rho_perron_2026-05-04": {
+   "deps_hash": "352fbba4f4d7",
+   "out_degree": 3
+  },
+  "su3_cube_index_graph_shortcut_open_gate_note_2026-05-03": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "su3_cube_perron_solve_combined_theorem_note_2026-05-03": {
+   "deps_hash": "8877d6ca1769",
+   "out_degree": 4
+  },
+  "su3_cubic_anomaly_cancellation_theorem_note_2026-04-24": {
+   "deps_hash": "9b41eb93f110",
+   "out_degree": 4
+  },
+  "su3_dabc_symmetric_theorem_note_2026-05-02": {
+   "deps_hash": "5e93d700a831",
+   "out_degree": 1
+  },
+  "su3_fusion_engine_pr1_theorem_note_2026-05-03": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "su3_low_rank_irrep_picard_fuchs_odes_note_2026-05-05": {
+   "deps_hash": "db3705cb7af2",
+   "out_degree": 1
+  },
+  "su3_tensor_network_engine_roadmap_note_2026-05-03": {
+   "deps_hash": "c427f560da6f",
+   "out_degree": 5
+  },
+  "su3_wigner_block4_staging_block5_orientation_diagnostics_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "a31be138d02d",
+   "out_degree": 3
+  },
+  "su3_wigner_intertwiner_block1_theorem_note_2026-05-03": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "su3_wigner_intertwiner_block2_theorem_note_2026-05-03": {
+   "deps_hash": "acc18f110cf8",
+   "out_degree": 1
+  },
+  "su3_wigner_intertwiner_block3_theorem_note_2026-05-03": {
+   "deps_hash": "a70ce755204e",
+   "out_degree": 2
+  },
+  "su3_wigner_intertwiner_block4_block5_theorem_note_2026-05-03": {
+   "deps_hash": "a31be138d02d",
+   "out_degree": 3
+  },
+  "su3_wigner_l3_cube_haar_mc_negative_result_2026-05-04": {
+   "deps_hash": "e09ffccdeb69",
+   "out_degree": 3
+  },
+  "su3_wigner_l3_treewidth_infeasible_2026-05-04": {
+   "deps_hash": "f7df719a8e13",
+   "out_degree": 2
+  },
+  "su3_wilson_closed_form_fanout_theorem_note_2026-05-04": {
+   "deps_hash": "e0531eaf7817",
+   "out_degree": 4
+  },
+  "su3_wilson_plane_kernel_character_positivity_and_composed_gram_narrow_theorem_note_2026-07-09": {
+   "deps_hash": "4b8ed10215bd",
+   "out_degree": 1
+  },
+  "su3_z3_apbc_variant_probe_2026-05-04": {
+   "deps_hash": "3c8e59c8c3dc",
+   "out_degree": 1
+  },
+  "su5_decomposition_proof_walk_lattice_independence_bounded_note_2026-05-08": {
+   "deps_hash": "f970574b6297",
+   "out_degree": 7
+  },
+  "su5_embedding_from_graph_first_surface_theorem_note_2026-05-07": {
+   "deps_hash": "80c3bd0bc95f",
+   "out_degree": 6
+  },
+  "substep4_ac_lambda_separate_closure_note_2026-05-10_aclambda": {
+   "deps_hash": "dbfddd962a3d",
+   "out_degree": 11
+  },
+  "substep4_ratchet_named_primitives_meta_note_2026-05-10_s4ratchet": {
+   "deps_hash": "b87734c4b27f",
+   "out_degree": 11
+  },
+  "substrate_to_p_a_forcing_theorem_note_2026-04-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "supertrace_index_holomorphic_route_to_koide_r_half_open_lead_note_2026-06-04": {
+   "deps_hash": "77faa5483fd2",
+   "out_degree": 6
+  },
+  "supplied_readout_context_two_component_decomposition_bounded_note_2026-07-02": {
+   "deps_hash": "6184b17147e5",
+   "out_degree": 3
+  },
+  "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "symmetric_two_qubit_clifford_cubic_matching_qca_classification_bounded_theorem_note_2026-07-11": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "symmetry_generated_paired_chokepoint_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "symmetry_head_to_head_note": {
+   "deps_hash": "8120102bb3a5",
+   "out_degree": 2
+  },
+  "symmetry_spectrum_mirror_compare_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "synthesis_note": {
+   "deps_hash": "2b2b3d1de3f4",
+   "out_degree": 19
+  },
+  "synthesis_note_3d": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "taste_scalar_fermion_cw_isotropy_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "taste_scalar_isotropy_theorem_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "taste_sector_marginal_lv_b4_protection_on_os0_bounded_theorem_note_2026-06-13": {
+   "deps_hash": "c4d4181abd4f",
+   "out_degree": 4
+  },
+  "teleportation_3d1_causal_record_channel_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_3d_initial_ramp_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_3d_operator_consistent_end_to_end_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_3d_readout_convention_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_3d_resource_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_acceptance_suite_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_adiabatic_convergence_robustness_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_adiabatic_prep_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_adiabatic_time_evolution_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_apparatus_dynamics_closure_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_bell_measurement_circuit_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_causal_channel_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_conclusion_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_cross_encoding_maps_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_dynamical_resource_generation_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_encoding_portability_note": {
+   "deps_hash": "5700f3cf27ea",
+   "out_degree": 1
+  },
+  "teleportation_end_to_end_poisson_note": {
+   "deps_hash": "97d4ff354733",
+   "out_degree": 2
+  },
+  "teleportation_finite_gapped_preparation_path_support_note_2026-06-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_hard_blocker_attack_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_initial_state_preparation_probe_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_logical_readout_audit": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_measurement_record_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_microscopic_closure_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_native_axioms_scope_split_source_theorem_note_2026-05-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_native_axioms_theory_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_native_record_apparatus_note": {
+   "deps_hash": "2a778f046fbf",
+   "out_degree": 5
+  },
+  "teleportation_native_record_apparatus_scope_split_source_theorem_note_2026-05-16": {
+   "deps_hash": "39e0fd24b0e6",
+   "out_degree": 1
+  },
+  "teleportation_native_transport_theory_note": {
+   "deps_hash": "eccf50bcb214",
+   "out_degree": 5
+  },
+  "teleportation_nature_grade_push_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_no_signaling_audit": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_noise_fault_controls_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_open_item_attack_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_operator_consistent_end_to_end_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_poisson_finite_extraction_core_bounded_note_2026-06-18": {
+   "deps_hash": "5700f3cf27ea",
+   "out_degree": 1
+  },
+  "teleportation_poisson_resource_sweep_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_poisson_resource_sweep_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_preparation_readout_probe_note": {
+   "deps_hash": "c8b75013fbb2",
+   "out_degree": 1
+  },
+  "teleportation_protocol_note": {
+   "deps_hash": "720b9e4693ef",
+   "out_degree": 1
+  },
+  "teleportation_record_field_closure_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_remaining_blocker_reduction_note": {
+   "deps_hash": "1037a3fac3e4",
+   "out_degree": 2
+  },
+  "teleportation_remaining_open_item_attack_note": {
+   "deps_hash": "39e0fd24b0e6",
+   "out_degree": 1
+  },
+  "teleportation_resource_fidelity_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_resource_from_poisson_criticality_bump_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "a2e122f05022",
+   "out_degree": 3
+  },
+  "teleportation_resource_from_poisson_note": {
+   "deps_hash": "fbc0154f4db0",
+   "out_degree": 10
+  },
+  "teleportation_retained_axis_operator_algebra_closure_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_retention_theorem_attack_note": {
+   "deps_hash": "39e0fd24b0e6",
+   "out_degree": 1
+  },
+  "teleportation_taste_readout_operator_model_note": {
+   "deps_hash": "5700f3cf27ea",
+   "out_degree": 1
+  },
+  "teleportation_three_register_cross_encoding_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "teleportation_unconditional_closure_attack_note": {
+   "deps_hash": "39e0fd24b0e6",
+   "out_degree": 1
+  },
+  "teleportation_z_convention_clarification": {
+   "deps_hash": "2741c1000ba9",
+   "out_degree": 5
+  },
+  "tensor_block_closure_test_note": {
+   "deps_hash": "671cfa77fd77",
+   "out_degree": 6
+  },
+  "tensor_composition_requires_local_tomography_beyond_locality_narrow_no_go_note_2026-06-03": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "tensor_matching_completion_theorem_note": {
+   "deps_hash": "0d0b6d5c901a",
+   "out_degree": 7
+  },
+  "tensor_network_connection_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "tensor_product_translation_fermion_operator_bridge_narrow_theorem_note_2026-05-25": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "tensor_product_translation_fermion_operator_bridge_record_invariance_companion_note_2026-06-04": {
+   "deps_hash": "794474cdbf61",
+   "out_degree": 2
+  },
+  "tensor_scalar_ratio_consolidation_theorem_note_2026-04-22": {
+   "deps_hash": "ff3d4efe0043",
+   "out_degree": 2
+  },
+  "tensor_source_map_eta_note": {
+   "deps_hash": "9337a9a98eba",
+   "out_degree": 1
+  },
+  "tensor_support_center_excess_law_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "tensorial_einstein_regge_completion_probe_helper_note_2026-04-14": {
+   "deps_hash": "b31407e7cb28",
+   "out_degree": 2
+  },
+  "thales_right_angle_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "the_small_mixing_angles_theta_c_and_theta_13_are_c3_breaking_order_parameters_unification_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "74d2131f5218",
+   "out_degree": 4
+  },
+  "theorem_bae_newton_girard_unified_obstruction_note_2026-05-10_t2bae": {
+   "deps_hash": "dc75d0194a11",
+   "out_degree": 13
+  },
+  "theorem_l1_4attack_terminality_note_2026-05-10_t2l1": {
+   "deps_hash": "34c59e1f517e",
+   "out_degree": 6
+  },
+  "thermodynamic_ph_quantitative_clause_record_budget_ledger_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "203e7538709c",
+   "out_degree": 4
+  },
+  "theta13_is_the_c3_doublet_breaking_measure_sqrt2_derived_theta_e_the_residual_narrow_theorem_note_2026-06-08": {
+   "deps_hash": "3104ebddc9f6",
+   "out_degree": 3
+  },
+  "theta_4d_carrier_flux_cohomology_intersection_pairing_closed_branch_and_defect_closure_residual_bounded_theorem_note_2026-07-02": {
+   "deps_hash": "0f3baa2f4395",
+   "out_degree": 5
+  },
+  "theta_assembly_paired_shift_fixed_grading_mckean_singer_reduction_narrow_theorem_note_2026-07-02": {
+   "deps_hash": "5d232d0316a6",
+   "out_degree": 3
+  },
+  "theta_cartan_valued_cross_plane_pairing_diagonal_weyl_frame_theorems_and_triality_fractional_values_bounded_theorem_note_2026-07-02": {
+   "deps_hash": "e21210cc45af",
+   "out_degree": 2
+  },
+  "theta_cross_plane_pair_density_geometric_oddness_connector_transport_bounded_theorem_note_2026-07-02": {
+   "deps_hash": "7c4194dd0388",
+   "out_degree": 3
+  },
+  "theta_cross_plane_term_absent_in_supplied_per_plaquette_class_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "3e5774e17b1d",
+   "out_degree": 1
+  },
+  "theta_defect_closure_from_admissibility_test_bounded_note_2026-07-03": {
+   "deps_hash": "a37578c80ad0",
+   "out_degree": 2
+  },
+  "theta_defect_closure_necessity_linking_obstruction_bounded_theorem_note_2026-07-02": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "theta_emergent_q_weighting_reality_rg_stable_bounded_theorem_note_2026-06-13": {
+   "deps_hash": "ac14fcc7ceed",
+   "out_degree": 6
+  },
+  "theta_g1_defect_closure_current_surface_no_go_note_2026-07-04": {
+   "deps_hash": "9a40a950b4d2",
+   "out_degree": 5
+  },
+  "theta_g3_phase_insertion_current_surface_no_go_note_2026-07-04": {
+   "deps_hash": "ecbf8fa206db",
+   "out_degree": 8
+  },
+  "theta_gauge_native_positive_class_emergent_sector_weighting_narrow_theorem_note_2026-07-04": {
+   "deps_hash": "32bf92a74138",
+   "out_degree": 7
+  },
+  "theta_gauge_positive_route_stretch_status_2026-07-04": {
+   "deps_hash": "5b83edfce59f",
+   "out_degree": 7
+  },
+  "theta_gauge_substrate_no_winding_carrier_emergent_q_bridge_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "52f2fba0329f",
+   "out_degree": 5
+  },
+  "theta_gauge_winding_axiom_update_no_go_note_2026-07-04": {
+   "deps_hash": "526d44a95dcc",
+   "out_degree": 5
+  },
+  "theta_gauge_z2_character_collapse_odd_support_and_positive_class_zero_branch_selection_bounded_theorem_note_2026-07-03": {
+   "deps_hash": "158566792693",
+   "out_degree": 5
+  },
+  "theta_gluing_flow_nonsourcing_pair_level_seed_localization_bounded_theorem_note_2026-07-02": {
+   "deps_hash": "62da9519ca43",
+   "out_degree": 2
+  },
+  "theta_link_star_gluing_frame_correlation_pair_composite_dagger_evenness_and_odd_branch_phase_residual_bounded_theorem_note_2026-07-02": {
+   "deps_hash": "e21210cc45af",
+   "out_degree": 2
+  },
+  "theta_mass_determinant_axiom_update_no_go_note_2026-07-04": {
+   "deps_hash": "950f835f3456",
+   "out_degree": 5
+  },
+  "theta_mass_orientation_zero_branch_pairing_forced_on_k_real_surface_narrow_theorem_note_2026-07-01": {
+   "deps_hash": "76146d25d1b8",
+   "out_degree": 2
+  },
+  "theta_mass_side_composition_close_on_shared_occupancy_bridge_bounded_note_2026-07-03": {
+   "deps_hash": "e9494ba78d1e",
+   "out_degree": 5
+  },
+  "theta_mass_side_epsilon_hermiticity_reality_bridge_discharge_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "99f8c2a32aa6",
+   "out_degree": 6
+  },
+  "theta_multi_plaquette_cross_plane_absence_narrowing_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "7b27483abaaa",
+   "out_degree": 2
+  },
+  "theta_native_record_time_spatial_split_orientation_import_localization_conjugation_parity_bridge_bounded_theorem_note_2026-07-03": {
+   "deps_hash": "3087fd343928",
+   "out_degree": 4
+  },
+  "theta_p2_determinant_readout_exhaustion_bridge_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "f4a45fba6f5d",
+   "out_degree": 6
+  },
+  "theta_p2_k_cpt_determinant_character_phase_erasure_bounded_note_2026-06-10": {
+   "deps_hash": "ff9e60ecc2cc",
+   "out_degree": 4
+  },
+  "theta_phase_insertion_triality_flip_table_single_link_nogo_chain_reader_bounded_theorem_note_2026-07-02": {
+   "deps_hash": "0f6f95392b53",
+   "out_degree": 4
+  },
+  "theta_quark_determinant_cross_sector_readout_derivation_obligation": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "theta_retirement_basis_rematch_2026-07-04": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "theta_sector_level_loop_insertions_closed_surface_bounded_theorem_note_2026-07-02": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "theta_seed_spectral_reality_conjugation_symmetric_supplied_structure_bounded_theorem_note_2026-07-02": {
+   "deps_hash": "62da9519ca43",
+   "out_degree": 2
+  },
+  "theta_su3_link_star_pairwise_reduction_local_rigidity_transpose_sheet_and_chiral_sign_escape_bounded_theorem_note_2026-07-02": {
+   "deps_hash": "e21210cc45af",
+   "out_degree": 2
+  },
+  "theta_supplier_flavored_grading_spectral_flow_registers_winding_2d_narrow_theorem_note_2026-07-02": {
+   "deps_hash": "5d232d0316a6",
+   "out_degree": 3
+  },
+  "theta_torus_dual_abelianization_shifted_weight_lattice_gaussian_gluing_stable_weyl_shift_obstruction_bounded_theorem_note_2026-07-02": {
+   "deps_hash": "ac92544471f6",
+   "out_degree": 3
+  },
+  "theta_transpose_sheet_uniqueness_fiber_evidence_bounded_note_2026-07-02": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "third_grown_family_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "third_grown_family_complex_boundary_note": {
+   "deps_hash": "5edbfd1bc495",
+   "out_degree": 1
+  },
+  "third_grown_family_complex_note": {
+   "deps_hash": "244259fedc4b",
+   "out_degree": 1
+  },
+  "third_grown_family_sign_note": {
+   "deps_hash": "244259fedc4b",
+   "out_degree": 1
+  },
+  "thooft_1981_dual_superconductor_center_vortex_confinement_external_narrow_theorem_note_2026-05-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "three_family_card_missing_distance_live_bridge_note_2026-06-18": {
+   "deps_hash": "acb9533ed41f",
+   "out_degree": 1
+  },
+  "three_gen_z3_fourier_diagonalization_theorem_note_2026-05-03": {
+   "deps_hash": "6752ab73fdb9",
+   "out_degree": 1
+  },
+  "three_generation_chirality_boundary_note": {
+   "deps_hash": "c1f4c7804c4c",
+   "out_degree": 6
+  },
+  "three_generation_hw1_distinct_translation_characters_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "70fa3bf728f4",
+   "out_degree": 1
+  },
+  "three_generation_local_algebra_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "three_generation_no_proper_quotient_via_burnside_characters_bridge_bounded_note_2026-05-26": {
+   "deps_hash": "d288d63088c6",
+   "out_degree": 3
+  },
+  "three_generation_observable_count_corollary_note_2026-05-03": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "three_generation_observable_dep_chain_audit_note_2026-05-02": {
+   "deps_hash": "591ec70f8768",
+   "out_degree": 7
+  },
+  "three_generation_observable_m3c_burnside_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "three_generation_observable_no_proper_quotient_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "4c48f851bf2f",
+   "out_degree": 4
+  },
+  "three_generation_observable_theorem_note": {
+   "deps_hash": "9da86840fd4d",
+   "out_degree": 6
+  },
+  "three_generation_rooting_undefined_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "three_generation_rooting_undefined_narrow_theorem_note_2026-05-27": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "three_generation_structure_note": {
+   "deps_hash": "5af88c485e70",
+   "out_degree": 1
+  },
+  "tick_admissibility_realization_bridge_clause_to_predicate_narrow_theorem_note_2026-07-10": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "tick_cell_selection_by_translation_and_variation_clauses_narrow_theorem_note_2026-07-09": {
+   "deps_hash": "8891417e9cce",
+   "out_degree": 2
+  },
+  "tick_unitarity_from_spectrum_reflection_conjugacy_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "2db1d69feed5",
+   "out_degree": 3
+  },
+  "tier_a_korbit_determinant_and_orientation_invariance_bounded_note_2026-06-09": {
+   "deps_hash": "baa4669e408d",
+   "out_degree": 2
+  },
+  "tier_a_residual_owner_adoption_retirement_2026-07-04": {
+   "deps_hash": "fc99f259bdfe",
+   "out_degree": 2
+  },
+  "time_axis_is_the_history_index_record_monotone_direction_bounded_note_2026-07-03": {
+   "deps_hash": "1f65fcda86e7",
+   "out_degree": 2
+  },
+  "tomita_tensor_trace_on_finite_dim_matrix_narrow_theorem_note_2026-05-20": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "topological_instanton_textbook_infrastructure_import_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "transfer_matrix_log_quasilocality_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "eda0f5e71d87",
+   "out_degree": 5
+  },
+  "transfer_trace_correspondence_fixes_kernel_normalization_on_retained_surface_bounded_note_2026-06-12": {
+   "deps_hash": "51d5c5b0fdb3",
+   "out_degree": 2
+  },
+  "translation_abelian_composition_theorem_note_2026-05-02": {
+   "deps_hash": "ec6690abc5b2",
+   "out_degree": 1
+  },
+  "translation_covariance_local_op_theorem_note_2026-05-02": {
+   "deps_hash": "ec6690abc5b2",
+   "out_degree": 1
+  },
+  "triple_stack_collapse_scaling_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "trysquared_proof_walk_lattice_independence_bounded_note_2026-05-08": {
+   "deps_hash": "3f7cd343351a",
+   "out_degree": 7
+  },
+  "two_band_lattice_moyal_full_b2_bounded_theorem_note_2026-06-13": {
+   "deps_hash": "6f1ba1004e07",
+   "out_degree": 1
+  },
+  "two_band_orbital_response_closed_form_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "10b6ffe3f823",
+   "out_degree": 1
+  },
+  "two_endpoint_gauss_law_invariance_profile_bounded_theorem_note_2026-06-05": {
+   "deps_hash": "bd71c5f30cb7",
+   "out_degree": 3
+  },
+  "two_field_retarded_family_closure_note_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "two_field_retarded_probe_note_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "two_sign_comparison_note_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "two_site_qubit_tensor_carrier_bridge_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "4fb4f7ea0100",
+   "out_degree": 4
+  },
+  "u0_plaquette_quartic_derivation_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "u0_su2_bivector_irrep_analytic_derivation_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "4514c6f97532",
+   "out_degree": 1
+  },
+  "u1_det_sector_bi_orbit_quotient_step_law_baseline_decomposition_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "2c3aa3968ee1",
+   "out_degree": 4
+  },
+  "u1_fermion_number_conservation_theorem_note_2026-05-02": {
+   "deps_hash": "45b34f1904c9",
+   "out_degree": 2
+  },
+  "u4_closes_under_qubit_reframe_narrow_theorem_note_2026-05-20": {
+   "deps_hash": "0b48e244e1f7",
+   "out_degree": 2
+  },
+  "u_integration_reading_blind_and_dictionary_blind_on_corner_transfer_bounded_note_2026-06-12": {
+   "deps_hash": "311d6b921eb1",
+   "out_degree": 3
+  },
+  "unification_basin_failure_note": {
+   "deps_hash": "c90c9ba91199",
+   "out_degree": 3
+  },
+  "unified_basin_signed_source_control_support_note_2026-04-30": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "unified_matter_content_ewsb_harness_theorem_note_2026-05-03": {
+   "deps_hash": "392a8698a1ac",
+   "out_degree": 6
+  },
+  "unified_program_note": {
+   "deps_hash": "dd9fd64aa659",
+   "out_degree": 22
+  },
+  "unit_conversion_is_the_accepted_non_bounding_ruler_reconciliation_note_2026-06-08": {
+   "deps_hash": "d292eab310f2",
+   "out_degree": 2
+  },
+  "unit_singlet_overlap_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_3plus1_constraint_multiplier_structure_derived_fiber_metric_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "611a62e6c58e",
+   "out_degree": 7
+  },
+  "universal_gr_a1_invariant_section_note": {
+   "deps_hash": "0e5362631b29",
+   "out_degree": 5
+  },
+  "universal_gr_axiom_first_route_memo": {
+   "deps_hash": "591c5a3464c5",
+   "out_degree": 6
+  },
+  "universal_gr_bd_congruence_invariance_bounded_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_block_constraint_interpretation_note": {
+   "deps_hash": "17a0f2c103e1",
+   "out_degree": 2
+  },
+  "universal_gr_block_ident_note": {
+   "deps_hash": "64fb6aaa4286",
+   "out_degree": 1
+  },
+  "universal_gr_block_normalization_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_canonical_channel_section_and_einstein_signs_narrow_theorem_note_2026-06-17": {
+   "deps_hash": "6beb934413a6",
+   "out_degree": 1
+  },
+  "universal_gr_canonical_projector_connection_note": {
+   "deps_hash": "dc89b6dd1ca1",
+   "out_degree": 1
+  },
+  "universal_gr_casimir_block_localization_context_note_2026-07-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_casimir_block_localization_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_complement_canonical_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_conformal_mode_sign_diagnostic_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "5bec7b0195c7",
+   "out_degree": 3
+  },
+  "universal_gr_constraint_action_stationarity_note": {
+   "deps_hash": "49eaf09dbdfb",
+   "out_degree": 6
+  },
+  "universal_gr_cubic_diffeo_ward_finite_lattice_scaling_support_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "cad9c43eacfc",
+   "out_degree": 2
+  },
+  "universal_gr_cubic_diffeo_ward_operator_telescope_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "e5dc7b9e098a",
+   "out_degree": 6
+  },
+  "universal_gr_cubic_graviton_seagull_vertex_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "31e1a2306ad2",
+   "out_degree": 4
+  },
+  "universal_gr_cubic_ward_finite_scaling_diagnostic_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_curvature_localization_blocker_note": {
+   "deps_hash": "d5350f287a21",
+   "out_degree": 1
+  },
+  "universal_gr_degenerate_supermetric_graviton_sign_no_go_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "33f09c7c4d26",
+   "out_degree": 6
+  },
+  "universal_gr_discrete_global_closure_note": {
+   "deps_hash": "3732f9d91c7a",
+   "out_degree": 4
+  },
+  "universal_gr_einstein_hilbert_closure_synthesis_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "30de6bc098df",
+   "out_degree": 4
+  },
+  "universal_gr_graviton_dispersion_lorentz_isotropy_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "2af9616dead2",
+   "out_degree": 2
+  },
+  "universal_gr_graviton_isotropy_staggered_kahler_dirac_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_induced_cosmological_constant_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "9f0dda0225d8",
+   "out_degree": 4
+  },
+  "universal_gr_induced_graviton_w_native_finite_k_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_invariant_frame_obstruction_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_invariant_nonlinear_completion_note": {
+   "deps_hash": "d4f3acbe4d1d",
+   "out_degree": 3
+  },
+  "universal_gr_isotropic_glue_operator_note": {
+   "deps_hash": "d200da48d06d",
+   "out_degree": 4
+  },
+  "universal_gr_isotropic_schur_localization_note": {
+   "deps_hash": "a9ca9d17ce6f",
+   "out_degree": 2
+  },
+  "universal_gr_lambda_bypass_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_lorentzian_global_atlas_closure_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_lorentzian_signature_extension_note": {
+   "deps_hash": "991838832e45",
+   "out_degree": 6
+  },
+  "universal_gr_metric_reparametrized_vertex_operator_lift_boundary_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "bae5c7f3a538",
+   "out_degree": 4
+  },
+  "universal_gr_newton_tensor_scalar_consistency_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_picurv_route_exhaustion_no_go_note_2026-06-18": {
+   "deps_hash": "da68468a61c3",
+   "out_degree": 8
+  },
+  "universal_gr_polarization_frame_bundle_attempt": {
+   "deps_hash": "e483e1b373c1",
+   "out_degree": 7
+  },
+  "universal_gr_polarization_frame_bundle_blocker_note": {
+   "deps_hash": "74b03aeca58b",
+   "out_degree": 4
+  },
+  "universal_gr_positive_background_extension_note": {
+   "deps_hash": "93e15345fe54",
+   "out_degree": 1
+  },
+  "universal_gr_positive_background_local_closure_note": {
+   "deps_hash": "d5350f287a21",
+   "out_degree": 1
+  },
+  "universal_gr_quadratic_mode_gluing_derivation_narrow_theorem_note_2026-06-09": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_quartic_diffeo_ward_continuum_closure_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_quintic_diffeo_ward_closure_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_round_pl_s3_regge_hessian_canonical_channels_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_sakharov_gnewton_induced_residual_is_metric_dof_posit_narrow_theorem_note_2026-06-17": {
+   "deps_hash": "93647542a57e",
+   "out_degree": 1
+  },
+  "universal_gr_scalar_generator_tt_kernel_sharpening_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "51255e5dd130",
+   "out_degree": 3
+  },
+  "universal_gr_so3_isotypic_orbit_flat_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_spin2_two_derivative_curvature_generator_supplied_flat_atlas_narrow_theorem_note_2026-06-10": {
+   "deps_hash": "df3854c1e2c2",
+   "out_degree": 8
+  },
+  "universal_gr_staggered_tt_projected_stress_triangle_support_bounded_note_2026-06-08": {
+   "deps_hash": "c2420a683c15",
+   "out_degree": 4
+  },
+  "universal_gr_staggered_tt_stiffness_positive_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "12c4b9337b3c",
+   "out_degree": 4
+  },
+  "universal_gr_stress_ward_transverse_seagull_bounded_theorem_note_2026-06-08": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_supermetric_normal_form_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_gr_tensor_action_blocker_note": {
+   "deps_hash": "0017c341dea6",
+   "out_degree": 5
+  },
+  "universal_gr_tensor_action_casimir_equivariant_class_nogo_note_2026-05-17": {
+   "deps_hash": "95a1c0e23420",
+   "out_degree": 6
+  },
+  "universal_gr_tensor_quotient_uniqueness_note": {
+   "deps_hash": "f7a44263a512",
+   "out_degree": 3
+  },
+  "universal_gr_tensor_variational_candidate_note": {
+   "deps_hash": "17a0f2c103e1",
+   "out_degree": 2
+  },
+  "universal_gr_w_hessian_identification_full_finite_k_channel_table_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "81e5de61a009",
+   "out_degree": 5
+  },
+  "universal_qg_abstract_gaussian_completion_note": {
+   "deps_hash": "a9f40fa50939",
+   "out_degree": 5
+  },
+  "universal_qg_canonical_refinement_net_note": {
+   "deps_hash": "c1a828b0833a",
+   "out_degree": 3
+  },
+  "universal_qg_canonical_smooth_geometric_action_note": {
+   "deps_hash": "0731e8d08d6b",
+   "out_degree": 4
+  },
+  "universal_qg_canonical_smooth_gravitational_weak_measure_note": {
+   "deps_hash": "d7a2d34467cf",
+   "out_degree": 5
+  },
+  "universal_qg_canonical_textbook_continuum_gr_closure_note": {
+   "deps_hash": "76911bb47a1b",
+   "out_degree": 8
+  },
+  "universal_qg_canonical_textbook_geometric_action_equivalence_note": {
+   "deps_hash": "9217747092de",
+   "out_degree": 8
+  },
+  "universal_qg_canonical_textbook_weak_measure_equivalence_note": {
+   "deps_hash": "4603a3276d72",
+   "out_degree": 6
+  },
+  "universal_qg_continuum_bridge_reduction_note": {
+   "deps_hash": "f3bc6d047c16",
+   "out_degree": 16
+  },
+  "universal_qg_external_fe_smooth_equivalence_note": {
+   "deps_hash": "09b2663ae16d",
+   "out_degree": 5
+  },
+  "universal_qg_inverse_limit_closure_note": {
+   "deps_hash": "ebc147a1406b",
+   "out_degree": 3
+  },
+  "universal_qg_optional_textbook_comparison_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "universal_qg_pl_field_interface_note": {
+   "deps_hash": "2a47b93597e7",
+   "out_degree": 3
+  },
+  "universal_qg_pl_sobolev_interface_note": {
+   "deps_hash": "6554ebff9302",
+   "out_degree": 4
+  },
+  "universal_qg_pl_weak_form_note": {
+   "deps_hash": "63d57982ea21",
+   "out_degree": 5
+  },
+  "universal_qg_projective_schur_closure_note": {
+   "deps_hash": "93e15345fe54",
+   "out_degree": 1
+  },
+  "universal_qg_smooth_gravitational_global_atlas_note": {
+   "deps_hash": "1b67face20ef",
+   "out_degree": 6
+  },
+  "universal_qg_smooth_gravitational_global_solution_class_note": {
+   "deps_hash": "778bf794c515",
+   "out_degree": 8
+  },
+  "universal_qg_smooth_gravitational_local_identification_note": {
+   "deps_hash": "0a120a9c4bd9",
+   "out_degree": 6
+  },
+  "universal_qg_uv_finite_partition_note": {
+   "deps_hash": "762e17dda8ed",
+   "out_degree": 3
+  },
+  "universal_theta_induced_edm_vanishing_theorem_note_2026-04-24": {
+   "deps_hash": "0a3d18dd6468",
+   "out_degree": 2
+  },
+  "universality_classifier_note": {
+   "deps_hash": "d8faf92865d3",
+   "out_degree": 3
+  },
+  "unordered_mass_multiset_registrability_bridge_narrow_theorem_note_2026-06-11": {
+   "deps_hash": "78fbe012cf29",
+   "out_degree": 2
+  },
+  "unordered_mass_pdep_record_independence_no_go_note_2026-06-18": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "unpromoted_branch_retainability_audit_note": {
+   "deps_hash": "7e53d12c9c31",
+   "out_degree": 8
+  },
+  "unraveled_record_trajectories_supply_nondegenerate_step_distribution_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "5937c684e181",
+   "out_degree": 11
+  },
+  "unraveled_step_law_bi_invariant_quasi_stationarity_split_bounded_theorem_note_2026-06-10": {
+   "deps_hash": "fb8954ed7807",
+   "out_degree": 9
+  },
+  "up_sector_partition_revisit_note_2026-04-19": {
+   "deps_hash": "eaecb942382a",
+   "out_degree": 4
+  },
+  "up_type_mass_ratio_ckm_inversion_note": {
+   "deps_hash": "0786cfa40748",
+   "out_degree": 2
+  },
+  "ut_placement_table_and_species_split_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "26642de56e38",
+   "out_degree": 5
+  },
+  "uv_gauge_to_yukawa_bridge_sc_vs_pert_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "uv_yukawa_strong_coupling_domain_exclusion_radius_certificate_bounded_note_2026-06-06": {
+   "deps_hash": "b3975a39d414",
+   "out_degree": 5
+  },
+  "v_eff_total_njl_style_bounded_theorem_note_2026-05-10": {
+   "deps_hash": "2a5b6028d96c",
+   "out_degree": 7
+  },
+  "v_even_theorem_retention_note_2026-05-03": {
+   "deps_hash": "e8a1c50a5023",
+   "out_degree": 2
+  },
+  "v_taste_one_loop_cw_bounded_theorem_note_2026-05-10": {
+   "deps_hash": "db71d72a7671",
+   "out_degree": 13
+  },
+  "vacuum_critical_stability_note": {
+   "deps_hash": "0a176676c374",
+   "out_degree": 4
+  },
+  "valley_linear_action_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "valley_linear_asymptotic_bridge_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "valley_linear_continuum_synthesis_note": {
+   "deps_hash": "d911369f3655",
+   "out_degree": 5
+  },
+  "valley_linear_mirror_transfer_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "valley_linear_repro_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "valley_linear_robustness_note": {
+   "deps_hash": "52883b0fcba0",
+   "out_degree": 2
+  },
+  "valley_linear_wide_tail_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "vector_gauge_field_kk_tower_theorem_note_2026-04-24": {
+   "deps_hash": "7007832710f9",
+   "out_degree": 5
+  },
+  "vector_magnetic_extension_note": {
+   "deps_hash": "732ace7784f1",
+   "out_degree": 3
+  },
+  "vector_sector_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "velocity_rg_gauge_seagull_transverse_vacuum_polarization_2026-06-22": {
+   "deps_hash": "ba165747f24b",
+   "out_degree": 2
+  },
+  "velocity_rg_logflow_framework_internal_2026-06-21": {
+   "deps_hash": "a30145e2e616",
+   "out_degree": 8
+  },
+  "w_mass_derived_note": {
+   "deps_hash": "246b81948e27",
+   "out_degree": 3
+  },
+  "w_scale_absorption_two_cell_readout_classification_bounded_note_2026-07-02": {
+   "deps_hash": "272e0a64e033",
+   "out_degree": 4
+  },
+  "w_z_mass_ratio_from_ewsb_note_2026-05-02": {
+   "deps_hash": "7e9291bc5464",
+   "out_degree": 3
+  },
+  "wald_noether_bp5_bounded_theorem_note_2026-05-10": {
+   "deps_hash": "d6399a05506c",
+   "out_degree": 10
+  },
+  "walls_attack_20260702_adjudication_brief_meta_note_2026-07-02": {
+   "deps_hash": "012c9058a182",
+   "out_degree": 2
+  },
+  "ward_bogoliubov_no_continuous_ssb_low_d_bridge_theorem_note_2026-06-11": {
+   "deps_hash": "cff99382e46e",
+   "out_degree": 2
+  },
+  "wave_3plus1d_promotions_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_3plus1d_radiation_note": {
+   "deps_hash": "8cb7047557b6",
+   "out_degree": 1
+  },
+  "wave_amplification_near_horizon_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_direct_dm_family_scout_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_direct_dm_h025_fam1_seed0_control_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_direct_dm_h025_fam1_seed0_control_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_direct_dm_h025_fam1_seed1_control_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_direct_dm_h025_fam1_seed1_control_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_direct_dm_h025_fam2_seed0_boundary_note": {
+   "deps_hash": "c4fb40a04568",
+   "out_degree": 2
+  },
+  "wave_direct_dm_h025_fam2_seed0_boundary_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_direct_dm_h025_fam2_seed0_control_note": {
+   "deps_hash": "2fea1dac8e84",
+   "out_degree": 1
+  },
+  "wave_direct_dm_h025_fam2_seed1_control_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_direct_dm_h025_fam2_seed1_followup_note": {
+   "deps_hash": "dc9267d683cb",
+   "out_degree": 5
+  },
+  "wave_direct_dm_h025_fam2_seed1_followup_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_direct_dm_h025_fam2_two_point_synthesis_note": {
+   "deps_hash": "64d4dada04b6",
+   "out_degree": 2
+  },
+  "wave_direct_dm_h025_fam3_seed0_control_note": {
+   "deps_hash": "ced3f7326b52",
+   "out_degree": 2
+  },
+  "wave_direct_dm_h025_fam3_seed1_control_note": {
+   "deps_hash": "3a528eef65e4",
+   "out_degree": 1
+  },
+  "wave_direct_dm_h025_family_pair_synthesis_note": {
+   "deps_hash": "acee67530b3f",
+   "out_degree": 6
+  },
+  "wave_direct_dm_h025_feasibility_note": {
+   "deps_hash": "0bfb1c49f63a",
+   "out_degree": 3
+  },
+  "wave_direct_dm_h025_high_band_boundary_note": {
+   "deps_hash": "db7b0e1a5cb6",
+   "out_degree": 2
+  },
+  "wave_direct_dm_h025_low_band_retention_note": {
+   "deps_hash": "355f19bdaabe",
+   "out_degree": 1
+  },
+  "wave_direct_dm_h025_seed0_crossfamily_note": {
+   "deps_hash": "350f7f538dd8",
+   "out_degree": 2
+  },
+  "wave_direct_dm_h025_seed1_crossfamily_note": {
+   "deps_hash": "18fe1b4ae7b8",
+   "out_degree": 4
+  },
+  "wave_direct_dm_h025_three_family_transfer_note": {
+   "deps_hash": "0a46f5f6fff0",
+   "out_degree": 7
+  },
+  "wave_direct_dm_h025_two_point_synthesis_note": {
+   "deps_hash": "140912916386",
+   "out_degree": 2
+  },
+  "wave_direct_dm_matched_history_note": {
+   "deps_hash": "7d1aa45ca780",
+   "out_degree": 3
+  },
+  "wave_direct_dm_next_widening_recommendation": {
+   "deps_hash": "53a906fdefbb",
+   "out_degree": 8
+  },
+  "wave_direct_dm_portability_batch_note": {
+   "deps_hash": "1ea675b2f204",
+   "out_degree": 7
+  },
+  "wave_direct_dm_post_fam3_successor_note": {
+   "deps_hash": "f2f2e625ba5a",
+   "out_degree": 6
+  },
+  "wave_direct_dm_seed_band_diagnosis_note": {
+   "deps_hash": "c204d4fc7a59",
+   "out_degree": 2
+  },
+  "wave_direct_dm_transfer_diagnostic_note": {
+   "deps_hash": "23b4eb2e1c18",
+   "out_degree": 2
+  },
+  "wave_equation_gravity_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_equation_self_field_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_poisson_cinf_bridge_theorem_note_2026-05-28": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_radiation_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_retardation_continuum_limit_note": {
+   "deps_hash": "b71cd60aae5b",
+   "out_degree": 1
+  },
+  "wave_retardation_lab_prediction_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_retarded_gravity_note": {
+   "deps_hash": "88cba87975ba",
+   "out_degree": 5
+  },
+  "wave_static_boundary_sensitivity_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_static_direct_probe_fine_note": {
+   "deps_hash": "be47c45645ac",
+   "out_degree": 1
+  },
+  "wave_static_fixed_beam_boundary_sensitivity_note": {
+   "deps_hash": "be47c45645ac",
+   "out_degree": 1
+  },
+  "wave_static_matrixfree_fixed_beam_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_static_matrixfree_moving_source_fixed_beam_boundary_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_static_matrixfree_shared_geometry_compare_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wave_static_single_source_compare_note": {
+   "deps_hash": "be47c45645ac",
+   "out_degree": 1
+  },
+  "weak_coupling_retention_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "weak_coupling_sign_sensitivity_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "weak_field_optical_metric_ansatz_diagnostic_bounded_theorem_note_2026-06-09": {
+   "deps_hash": "83ad60d045c1",
+   "out_degree": 4
+  },
+  "wep_source_reduction_finite_spacing_boundary_scaling_window_bounded_note_2026-07-08": {
+   "deps_hash": "647d31982eb9",
+   "out_degree": 2
+  },
+  "wick_rotation_compact_so4_to_lorentzian_dirac_doubling_orientation_note_2026-06-07": {
+   "deps_hash": "12793b17826a",
+   "out_degree": 4
+  },
+  "wide_family_h0125_bridge_reopen_audit": {
+   "deps_hash": "d459edbe16be",
+   "out_degree": 2
+  },
+  "wide_lattice_h2t_distance_law_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wide_lattice_h2t_skeptic_audit_note": {
+   "deps_hash": "9aa2154fc209",
+   "out_degree": 1
+  },
+  "wigner_mode_low_d_sublattice_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wilson_action_surface_selector_real_positive_theorem_note_2026-05-25": {
+   "deps_hash": "9aae4c8a86dc",
+   "out_degree": 1
+  },
+  "wilson_bz_corner_hamming_staircase_bounded_note_2026-05-08": {
+   "deps_hash": "78a3707ade7b",
+   "out_degree": 1
+  },
+  "wilson_bz_corner_hamming_staircase_closed_form_note_2026-05-09": {
+   "deps_hash": "945a6d62e6db",
+   "out_degree": 3
+  },
+  "wilson_corrected_v_taste_tree_level_bounded_note_2026-05-08": {
+   "deps_hash": "a3b7cbcdca3c",
+   "out_degree": 2
+  },
+  "wilson_extremum_curvature_readout_boundary_certificate_2026-06-15": {
+   "deps_hash": "a98aa850c40a",
+   "out_degree": 4
+  },
+  "wilson_generator_rescaling_beta_transformation_narrow_theorem_note_2026-06-16": {
+   "deps_hash": "8921c2773a25",
+   "out_degree": 1
+  },
+  "wilson_m_h_per_channel_closure_bounded_note_2026-05-09": {
+   "deps_hash": "522a01a93910",
+   "out_degree": 6
+  },
+  "wilson_m_h_tree_at_extremum_algebraic_core_split_note_2026-06-18": {
+   "deps_hash": "71561f6df427",
+   "out_degree": 3
+  },
+  "wilson_m_h_tree_at_extremum_all_orders_bounded_note_2026-05-08": {
+   "deps_hash": "d72809da0697",
+   "out_degree": 8
+  },
+  "wilson_m_h_tree_at_extremum_leading_order_in_r_bounded_note_2026-05-08": {
+   "deps_hash": "601499c2a43b",
+   "out_degree": 6
+  },
+  "wilson_mu2_distance_sweep_note_2026-04-11": {
+   "deps_hash": "f9e57576e762",
+   "out_degree": 1
+  },
+  "wilson_normalization_reconciliation_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wilson_real_positive_measure_bounded_premise_bridge_note_2026-06-03": {
+   "deps_hash": "671b0481a87b",
+   "out_degree": 1
+  },
+  "wilson_small_a_matching_beta_gbare_narrow_theorem_note_2026-06-07": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wilson_staggered_minimal_block_spectrum_bridge_note_2026-06-13": {
+   "deps_hash": "a3b7cbcdca3c",
+   "out_degree": 2
+  },
+  "wilson_su3_gauge_transfer_kernel_positivity_bounded_note_2026-05-30": {
+   "deps_hash": "812372861f4f",
+   "out_degree": 2
+  },
+  "wilson_temporal_kernel_casimir_generator_beta_gbare_transport_theorem_note_2026-07-01": {
+   "deps_hash": "a51d03613dbb",
+   "out_degree": 3
+  },
+  "wilson_test_mass_continuum_note_2026-04-11": {
+   "deps_hash": "25d0a1c867bc",
+   "out_degree": 2
+  },
+  "wilson_two_body_open_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wilson_two_body_open_refined_note_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wilson_vtaste_extremum_leading_order_in_r_bounded_note_2026-05-08": {
+   "deps_hash": "ea24e62e2ff4",
+   "out_degree": 4
+  },
+  "wir_cone_agreement_from_sector_alias_uniqueness_bounded_theorem_note_2026-06-11": {
+   "deps_hash": "6b57a306643d",
+   "out_degree": 9
+  },
+  "within_sector_ess_adequacy_conclusion_survives_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "within_sector_k2_three_seed_mixed_event_evidence_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "9761a84f420a",
+   "out_degree": 2
+  },
+  "within_sector_moment_relation_wrapped_gaussian_consistent_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "cf5fbb637d00",
+   "out_degree": 2
+  },
+  "within_sector_third_moment_consistent_all_seeds_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "2dd3a68f91ed",
+   "out_degree": 3
+  },
+  "wolfenstein_lambda_a_product_cancellation_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wolfenstein_lambda_a_structural_identities_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "wolfenstein_lambda_a_structural_identities_theorem_note_2026-04-24": {
+   "deps_hash": "bcb215f704a2",
+   "out_degree": 5
+  },
+  "work_history.atomic.hydrogen_helium_atomic_companion_note_2026-04-18": {
+   "deps_hash": "81a173b4e558",
+   "out_degree": 3
+  },
+  "work_history.atomic.lane2_atomic_autoresearch_parking_note_2026-05-01": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.atomic.readme": {
+   "deps_hash": "1ed96b7ffdf3",
+   "out_degree": 1
+  },
+  "work_history.cabibbo_jarlskog_route_note_2026-04-12": {
+   "deps_hash": "e84c608eab5b",
+   "out_degree": 2
+  },
+  "work_history.ckm.cabibbo_bound_note": {
+   "deps_hash": "57affd625775",
+   "out_degree": 1
+  },
+  "work_history.ckm.ckm_mass_basis_nni_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.ckm.jarlskog_phase_bound_note": {
+   "deps_hash": "21fff523fb83",
+   "out_degree": 2
+  },
+  "work_history.dm.dm_leptogenesis_full_axiom_closure_note_2026-04-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.dm.dm_leptogenesis_full_axiom_closure_note_2026-04-16": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.dm.readme": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.gw_echo_timing_route_note": {
+   "deps_hash": "00fa3fab6117",
+   "out_degree": 1
+  },
+  "work_history.pf.perron_frobenius_route_salvage_note_2026-04-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.pf.readme": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.potential_publication_discoveries_log": {
+   "deps_hash": "5aae484f7851",
+   "out_degree": 2
+  },
+  "work_history.readme": {
+   "deps_hash": "e132f774fa1f",
+   "out_degree": 1
+  },
+  "work_history.repo.backlog.claude_backlog_brief_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.repo.backlog.graph_observables_work_backlog": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.repo.backlog.nature_backlog_2026-04-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.repo.backlog.overnight_work_backlog": {
+   "deps_hash": "7e0290935158",
+   "out_degree": 3
+  },
+  "work_history.repo.backlog.readme": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.repo.backlog.review_hardening_backlog": {
+   "deps_hash": "87287f31c965",
+   "out_degree": 3
+  },
+  "work_history.repo.backlog.work_backlog_2026-04-10": {
+   "deps_hash": "3bf66efbaf91",
+   "out_degree": 5
+  },
+  "work_history.repo.canonical_weave_audit_2026-05-03": {
+   "deps_hash": "540b6492c0fc",
+   "out_degree": 4
+  },
+  "work_history.repo.dm_lane_weave_triage_2026-05-03": {
+   "deps_hash": "af323199a14e",
+   "out_degree": 3
+  },
+  "work_history.repo.evaluation_tools.readme": {
+   "deps_hash": "cb89c4567a92",
+   "out_degree": 5
+  },
+  "work_history.repo.lane_status_board": {
+   "deps_hash": "7cbc0749d4b4",
+   "out_degree": 4
+  },
+  "work_history.repo.review_feedback.adversarial_review_2026_04_05": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.repo.review_feedback.claim_audit_note_2026-04-01": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.repo.review_feedback.claude_dead_end_reopen_audit_note": {
+   "deps_hash": "9012d863fab6",
+   "out_degree": 1
+  },
+  "work_history.repo.review_feedback.claude_frontier_retain_audit_2026-04-11": {
+   "deps_hash": "ecfb42af6768",
+   "out_degree": 4
+  },
+  "work_history.repo.review_feedback.closed_pr_science_salvage_sweep_2026-05-03": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.repo.review_feedback.code_review_last_week_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.repo.review_feedback.conformal_class_causal_source_packet_review_2026-07-09": {
+   "deps_hash": "12ef887d4de7",
+   "out_degree": 3
+  },
+  "work_history.repo.review_feedback.main_control_plane_audit_2026-04-11": {
+   "deps_hash": "03b4af2d891f",
+   "out_degree": 5
+  },
+  "work_history.repo.review_feedback.main_revisit_sweep_2026-04-11": {
+   "deps_hash": "91ded25719f6",
+   "out_degree": 3
+  },
+  "work_history.repo.review_feedback.pr463_axiom_first_weave_review_2026-05-03": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.repo.review_feedback.pr484_kz_external_lift_review_2026-05-03": {
+   "deps_hash": "7b96e108ce08",
+   "out_degree": 2
+  },
+  "work_history.repo.review_feedback.publication_discovery_audit_2026-04-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.repo.review_feedback.readme": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.repo.review_feedback.rerun_required_bug_audit_2026-04-11": {
+   "deps_hash": "007a99cd3b33",
+   "out_degree": 1
+  },
+  "work_history.yt.yt_explicit_systematic_reduction_options_2026-04-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.yt.yt_explicit_systematic_status_review_2026-04-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "work_history.yt.yt_unbounded_program_note": {
+   "deps_hash": "91d7cc45b2cd",
+   "out_degree": 8
+  },
+  "writing_voice_guide_2026-04-25": {
+   "deps_hash": "8990b3713089",
+   "out_degree": 1
+  },
+  "yang_mills_coupling_marginality_forces_d_four_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "ygut_normalization_proof_walk_lattice_independence_bounded_note_2026-05-08": {
+   "deps_hash": "26dc151efed9",
+   "out_degree": 6
+  },
+  "yt_axiom_first_microscopic_bridge_theorem": {
+   "deps_hash": "8f1285fdc120",
+   "out_degree": 19
+  },
+  "yt_bottom_yukawa_retention_analysis_note_2026-04-18": {
+   "deps_hash": "314f0e2c2128",
+   "out_degree": 8
+  },
+  "yt_boundary_bc_transfer_uniqueness_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_boundary_theorem": {
+   "deps_hash": "d92498b385eb",
+   "out_degree": 1
+  },
+  "yt_boundary_theorem_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_bridge_action_invariant_note": {
+   "deps_hash": "07ab29de4f60",
+   "out_degree": 5
+  },
+  "yt_bridge_action_invariant_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_bridge_endpoint_shift_bound_note": {
+   "deps_hash": "1b964c188b4a",
+   "out_degree": 4
+  },
+  "yt_bridge_hessian_selector_note": {
+   "deps_hash": "d236d461a0cf",
+   "out_degree": 4
+  },
+  "yt_bridge_hessian_selector_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_bridge_higher_order_corrections_note": {
+   "deps_hash": "19fa79672270",
+   "out_degree": 3
+  },
+  "yt_bridge_moment_closure_note": {
+   "deps_hash": "71c220bf4af5",
+   "out_degree": 5
+  },
+  "yt_bridge_moment_closure_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_bridge_nonlocal_corrections_note": {
+   "deps_hash": "0f4344dde0ed",
+   "out_degree": 4
+  },
+  "yt_bridge_operator_closure_note": {
+   "deps_hash": "673f44a205af",
+   "out_degree": 4
+  },
+  "yt_bridge_operator_closure_note_2026-05-17": {
+   "deps_hash": "9f2440c2cee9",
+   "out_degree": 2
+  },
+  "yt_bridge_rearrangement_principle_note": {
+   "deps_hash": "9f2440c2cee9",
+   "out_degree": 2
+  },
+  "yt_bridge_rearrangement_principle_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_bridge_uv_class_uniqueness_note": {
+   "deps_hash": "10148205f62e",
+   "out_degree": 6
+  },
+  "yt_bridge_variational_selector_note": {
+   "deps_hash": "114fdac33f21",
+   "out_degree": 4
+  },
+  "yt_class_3_susy_2hdm_analysis_note_2026-04-18": {
+   "deps_hash": "84c56c22d6ef",
+   "out_degree": 10
+  },
+  "yt_class_5_non_ql_yukawa_vertex_note_2026-04-18": {
+   "deps_hash": "eeaf46ae628c",
+   "out_degree": 8
+  },
+  "yt_class_6_c3_breaking_operator_note_2026-04-18": {
+   "deps_hash": "0e6bd61e8c09",
+   "out_degree": 8
+  },
+  "yt_class_7_spontaneous_c3_breaking_note_2026-04-18": {
+   "deps_hash": "975a7a17ab26",
+   "out_degree": 9
+  },
+  "yt_color_projection_correction_note": {
+   "deps_hash": "155bd9848dd2",
+   "out_degree": 1
+  },
+  "yt_connected_source_augmentation_ideal_selector_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_connected_source_selector_scalar_lift_no_go_note_2026-05-29": {
+   "deps_hash": "d462803042a2",
+   "out_degree": 9
+  },
+  "yt_constructive_uv_bridge_note": {
+   "deps_hash": "82e05882a61b",
+   "out_degree": 2
+  },
+  "yt_declared_anchor_bounded_subchain_narrow_theorem_note_2026-05-26": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_eft_bridge_theorem": {
+   "deps_hash": "7360831b97ef",
+   "out_degree": 2
+  },
+  "yt_ew_color_projection_theorem": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_ew_coupling_bridge_note": {
+   "deps_hash": "d0d51d2f3d5d",
+   "out_degree": 3
+  },
+  "yt_ew_coupling_bridge_note_2026-05-17": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_ew_delta_r_retention_analysis_note_2026-04-18": {
+   "deps_hash": "76418e8ba96f",
+   "out_degree": 8
+  },
+  "yt_ew_f_adj_fierz_fraction_bounded_note_2026-05-25": {
+   "deps_hash": "9f27282fd8ef",
+   "out_degree": 2
+  },
+  "yt_ew_higgs_source_intertwiner_gate_note_2026-05-25": {
+   "deps_hash": "396370f0079f",
+   "out_degree": 3
+  },
+  "yt_ew_m_residual_note_2026-05-02": {
+   "deps_hash": "155bd9848dd2",
+   "out_degree": 1
+  },
+  "yt_ew_matching_rule_m_note_2026-05-02": {
+   "deps_hash": "b61ef32f4a35",
+   "out_degree": 2
+  },
+  "yt_ew_neutral_projector_same_surface_carrier_theorem_note_2026-06-18": {
+   "deps_hash": "d15dce452b62",
+   "out_degree": 4
+  },
+  "yt_ew_sin_sq_theta_w_preservation_bounded_note_2026-05-25": {
+   "deps_hash": "672c2802144f",
+   "out_degree": 3
+  },
+  "yt_exact_coarse_grained_bridge_operator_note": {
+   "deps_hash": "8088089d68fb",
+   "out_degree": 5
+  },
+  "yt_exact_hessian_selector_uniqueness_note": {
+   "deps_hash": "b12ad075fbe8",
+   "out_degree": 1
+  },
+  "yt_exact_interacting_bridge_transport_note": {
+   "deps_hash": "273d32ccd329",
+   "out_degree": 8
+  },
+  "yt_exact_schur_normal_form_uniqueness_note": {
+   "deps_hash": "baa43cd241ae",
+   "out_degree": 5
+  },
+  "yt_explicit_systematic_budget_note": {
+   "deps_hash": "b12ad075fbe8",
+   "out_degree": 1
+  },
+  "yt_fh_top_mass_response_physical_intervention_bridge_note_2026-05-25": {
+   "deps_hash": "6fb33a0e7ea4",
+   "out_degree": 6
+  },
+  "yt_fh_top_w_response_ratio_gate_note_2026-05-25": {
+   "deps_hash": "b9407e71a36d",
+   "out_degree": 2
+  },
+  "yt_fierz_projection_defense_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "7ddb90e51a36",
+   "out_degree": 4
+  },
+  "yt_flagship_boundary_note": {
+   "deps_hash": "b76132f9e3fa",
+   "out_degree": 4
+  },
+  "yt_gauge_crossover_theorem": {
+   "deps_hash": "7360831b97ef",
+   "out_degree": 2
+  },
+  "yt_generation_hierarchy_primitive_analysis_note_2026-04-18": {
+   "deps_hash": "9682edfcd574",
+   "out_degree": 9
+  },
+  "yt_h_unit_flavor_column_decomposition_note_2026-04-18": {
+   "deps_hash": "7dd26a630a47",
+   "out_degree": 6
+  },
+  "yt_interacting_bridge_locality_note": {
+   "deps_hash": "ed21236bb8e8",
+   "out_degree": 3
+  },
+  "yt_lambda_normalization_attack_fanout_note_2026-05-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_lsp_signed_record_source_readout_runner_hash_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "1b2e9d501220",
+   "out_degree": 4
+  },
+  "yt_lsp_signed_record_source_readout_support_note_2026-05-24": {
+   "deps_hash": "c82d5e751c95",
+   "out_degree": 3
+  },
+  "yt_lsp_source_scale_boundary_and_strict_response_contract_note_2026-05-26": {
+   "deps_hash": "709c3df01495",
+   "out_degree": 6
+  },
+  "yt_microscopic_schur_class_admissibility_criticality_bump_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "44aa4b64d13d",
+   "out_degree": 2
+  },
+  "yt_microscopic_schur_class_admissibility_note": {
+   "deps_hash": "85ab03da4954",
+   "out_degree": 2
+  },
+  "yt_operational_source_action_bridge_theorem_attempt_note_2026-05-25": {
+   "deps_hash": "af4189bad2f9",
+   "out_degree": 4
+  },
+  "yt_p1_bz_quadrature_2_loop_full_staggered_pt_note_2026-04-18": {
+   "deps_hash": "b45a72b94e2e",
+   "out_degree": 6
+  },
+  "yt_p1_bz_quadrature_full_staggered_pt_note_2026-04-18": {
+   "deps_hash": "745015a61432",
+   "out_degree": 6
+  },
+  "yt_p1_bz_quadrature_numerical_note_2026-04-18": {
+   "deps_hash": "f19334ae4164",
+   "out_degree": 5
+  },
+  "yt_p1_color_factor_retention_note_2026-04-17": {
+   "deps_hash": "0237b421b8a1",
+   "out_degree": 2
+  },
+  "yt_p1_delta_1_bz_computation_note_2026-04-17": {
+   "deps_hash": "4c89d566da59",
+   "out_degree": 3
+  },
+  "yt_p1_delta_2_bz_computation_note_2026-04-17": {
+   "deps_hash": "bd93415caabc",
+   "out_degree": 6
+  },
+  "yt_p1_delta_3_bz_computation_note_2026-04-17": {
+   "deps_hash": "380f6bf3abf7",
+   "out_degree": 4
+  },
+  "yt_p1_delta_r_2_loop_extension_note_2026-04-18": {
+   "deps_hash": "2e242d5f3731",
+   "out_degree": 10
+  },
+  "yt_p1_delta_r_fermion_regulator_dependence_and_scalar_ntaste_resolution_note_2026-06-16": {
+   "deps_hash": "b37c4b309f5d",
+   "out_degree": 3
+  },
+  "yt_p1_delta_r_master_assembly_theorem_note_2026-04-18": {
+   "deps_hash": "cb7a1cbe9d4c",
+   "out_degree": 4
+  },
+  "yt_p1_delta_r_sm_rge_crosscheck_note_2026-04-18": {
+   "deps_hash": "a838f1089c72",
+   "out_degree": 9
+  },
+  "yt_p1_h_unit_renormalization_framework_native_note_2026-04-17": {
+   "deps_hash": "9470138b5089",
+   "out_degree": 4
+  },
+  "yt_p1_i_s_lattice_pt_citation_note_2026-04-17": {
+   "deps_hash": "47e94f9514db",
+   "out_degree": 7
+  },
+  "yt_p1_i_s_native_kernel_settled_bounded_theorem_note_2026-06-16": {
+   "deps_hash": "e1ba51fc61ab",
+   "out_degree": 2
+  },
+  "yt_p1_i_s_revision_verification_note_2026-04-17": {
+   "deps_hash": "dafed7f80b03",
+   "out_degree": 3
+  },
+  "yt_p1_loop_geometric_bound_note_2026-04-17": {
+   "deps_hash": "849f9164ed21",
+   "out_degree": 4
+  },
+  "yt_p1_rep_a_rep_b_cancellation_theorem_note_2026-04-17": {
+   "deps_hash": "30ad7a93b36d",
+   "out_degree": 5
+  },
+  "yt_p1_shared_fierz_no_go_sub_theorem_note_2026-04-17": {
+   "deps_hash": "18172b42ccd1",
+   "out_degree": 4
+  },
+  "yt_p2_f_yt_loop_geometric_bound_note_2026-04-17": {
+   "deps_hash": "c979a1d30c9c",
+   "out_degree": 4
+  },
+  "yt_p2_taste_staircase_beta_functions_note_2026-04-17": {
+   "deps_hash": "29c1fe6f5573",
+   "out_degree": 6
+  },
+  "yt_p2_taste_staircase_dressing_distribution_invariance_theorem_note_2026-05-17": {
+   "deps_hash": "f5a7cf84392f",
+   "out_degree": 6
+  },
+  "yt_p2_taste_staircase_transport_note_2026-04-17": {
+   "deps_hash": "836ce16e7437",
+   "out_degree": 5
+  },
+  "yt_p2_v_matching_theorem_note_2026-04-17": {
+   "deps_hash": "120c6a62d132",
+   "out_degree": 3
+  },
+  "yt_p3_k_series_geometric_bound_note_2026-04-17": {
+   "deps_hash": "1478b1ff12fb",
+   "out_degree": 3
+  },
+  "yt_p3_msbar_to_pole_k1_framework_native_derivation_note_2026-04-17": {
+   "deps_hash": "273b952c717c",
+   "out_degree": 5
+  },
+  "yt_p3_msbar_to_pole_k2_color_factor_retention_note_2026-04-17": {
+   "deps_hash": "ab812bb01b46",
+   "out_degree": 5
+  },
+  "yt_p3_msbar_to_pole_k2_integral_citation_note_2026-04-17": {
+   "deps_hash": "fe3c967d755a",
+   "out_degree": 3
+  },
+  "yt_p3_msbar_to_pole_k3_color_factor_retention_note_2026-04-17": {
+   "deps_hash": "f3fa3c2d315b",
+   "out_degree": 3
+  },
+  "yt_physical_top_intervention_identification_candidate_note_2026-05-25": {
+   "deps_hash": "d781cd47694b",
+   "out_degree": 4
+  },
+  "yt_primitive_source_unit_fisher_normalization_support_note_2026-05-25": {
+   "deps_hash": "783312c4bb86",
+   "out_degree": 3
+  },
+  "yt_primitive_unit_source_action_physical_premise_no_go_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "f22becb5c16b",
+   "out_degree": 9
+  },
+  "yt_primitive_unit_source_action_physical_premise_no_go_note_2026-05-25": {
+   "deps_hash": "65320a4a9180",
+   "out_degree": 4
+  },
+  "yt_qfp_insensitivity_support_note": {
+   "deps_hash": "e144d515341a",
+   "out_degree": 3
+  },
+  "yt_qubit_democratic_top_coefficient_candidate_note_2026-05-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_qubit_neutral_higgs_carrier_ray_bridge_note_2026-05-25": {
+   "deps_hash": "51507615d820",
+   "out_degree": 6
+  },
+  "yt_qubit_neutral_higgs_carrier_ray_bridge_record_axiom_invariance_companion_note_2026-06-04": {
+   "deps_hash": "2eefff4dee97",
+   "out_degree": 4
+  },
+  "yt_qubit_signed_linear_source_response_bridge_candidate_note_2026-05-25": {
+   "deps_hash": "9e880f7260c4",
+   "out_degree": 1
+  },
+  "yt_retention_landing_readiness_2026-04-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_retention_master_manifest_2026-04-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_right_handed_species_dependence_note_2026-04-18": {
+   "deps_hash": "5a317a084ae8",
+   "out_degree": 8
+  },
+  "yt_same_source_ew_higgs_authority_gate_note_2026-05-25": {
+   "deps_hash": "617069a7efdd",
+   "out_degree": 2
+  },
+  "yt_scalar_taste_condensate_selector_no_go_note_2026-05-23": {
+   "deps_hash": "8abe4132d520",
+   "out_degree": 1
+  },
+  "yt_schur_stability_gap_criticality_bump_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "491a1b0d442b",
+   "out_degree": 2
+  },
+  "yt_schur_stability_gap_note": {
+   "deps_hash": "b12ad075fbe8",
+   "out_degree": 1
+  },
+  "yt_signed_linear_democratic_tangent_physical_bridge_attempt_note_2026-05-25": {
+   "deps_hash": "f38dc44249ef",
+   "out_degree": 1
+  },
+  "yt_signed_record_lower_projector_neutral_ray_algebra_core_bounded_note_2026-06-18": {
+   "deps_hash": "7621b56a2319",
+   "out_degree": 3
+  },
+  "yt_source_action_route_exhaustion_summary_note_2026-05-22": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_source_action_support_packet_note_2026-05-22": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_source_coordinate_invariant_top_w_ratio_gate_note_2026-05-25": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_source_covariance_normalization_support_note_2026-05-24": {
+   "deps_hash": "89e9a841da50",
+   "out_degree": 2
+  },
+  "yt_source_covariance_normalization_support_runner_hash_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "e792ddaf8e11",
+   "out_degree": 6
+  },
+  "yt_source_higgs_pole_row_normalization_no_go_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "d90b25619177",
+   "out_degree": 4
+  },
+  "yt_source_higgs_pole_row_normalization_no_go_note_2026-05-23": {
+   "deps_hash": "78c865bf57ca",
+   "out_degree": 3
+  },
+  "yt_source_measure_tier_a_source_unit_boundary_note_2026-05-30": {
+   "deps_hash": "af66e8678708",
+   "out_degree": 5
+  },
+  "yt_ssb_matching_gap_analysis_note_2026-04-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "yt_strict_same_source_top_w_pole_row_contract_note_2026-05-30": {
+   "deps_hash": "fa46e61852c7",
+   "out_degree": 6
+  },
+  "yt_strict_symbolic_top_response_row_packet_note_2026-05-25": {
+   "deps_hash": "89bb4e820d79",
+   "out_degree": 3
+  },
+  "yt_strict_wz_neutral_carrier_response_dep_resolution_hygiene_companion_note_2026-06-04": {
+   "deps_hash": "b6706a4d6a9a",
+   "out_degree": 2
+  },
+  "yt_strict_wz_neutral_carrier_response_packet_note_2026-05-25": {
+   "deps_hash": "647eb53d0d4d",
+   "out_degree": 3
+  },
+  "yt_tier_a_source_action_top_premise_closure_note_2026-05-29": {
+   "deps_hash": "a5e96143757c",
+   "out_degree": 7
+  },
+  "yt_top_coefficient_full_court_press_note_2026-05-25": {
+   "deps_hash": "9fecf06dce95",
+   "out_degree": 7
+  },
+  "yt_top_response_coefficient_underdetermination_no_go_note_2026-05-25": {
+   "deps_hash": "89bb4e820d79",
+   "out_degree": 3
+  },
+  "yt_uv_to_ir_transport_obstruction_theorem_note_2026-04-17": {
+   "deps_hash": "5aa7d2d155fc",
+   "out_degree": 26
+  },
+  "yt_vertex_power_derivation": {
+   "deps_hash": "efaddbf91192",
+   "out_degree": 3
+  },
+  "yt_vertex_power_operator_counting_lemma_note_2026-05-17": {
+   "deps_hash": "096e782402ea",
+   "out_degree": 4
+  },
+  "yt_ward_identity_dependencies_registered_bound_narrow_theorem_note_2026-06-05": {
+   "deps_hash": "2949201939f3",
+   "out_degree": 3
+  },
+  "yt_ward_identity_derivation_theorem": {
+   "deps_hash": "398bcf2ae303",
+   "out_degree": 5
+  },
+  "yt_ward_ratio_tadpole_cancellation_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "7fa57372ad20",
+   "out_degree": 3
+  },
+  "yt_ward_record_axiom_invariance_companion_note_2026-06-04": {
+   "deps_hash": "825f4f6bb3e8",
+   "out_degree": 3
+  },
+  "yt_ward_step3_contact_4fermion_vanishing_narrow_theorem_note_2026-05-17": {
+   "deps_hash": "49357efaae37",
+   "out_degree": 8
+  },
+  "yt_ward_step3_same_1pi_construction_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "1b60a46e0a9a",
+   "out_degree": 4
+  },
+  "yt_ward_tadpole_cancellation_premise_derivation_narrow_theorem_note_2026-06-06": {
+   "deps_hash": "8e4e79bc5d10",
+   "out_degree": 5
+  },
+  "yt_zero_import_authority_note": {
+   "deps_hash": "3e809ff3826f",
+   "out_degree": 2
+  },
+  "yt_zero_import_boundary_ratio_authority_theorem_note_2026-05-17": {
+   "deps_hash": "78f4c4bafa9a",
+   "out_degree": 6
+  },
+  "yt_zero_import_chain_note": {
+   "deps_hash": "53446f609d66",
+   "out_degree": 4
+  },
+  "yukawa_color_projection_theorem": {
+   "deps_hash": "8941fa5ee9cf",
+   "out_degree": 3
+  },
+  "z2_hw1_mass_matrix_parametrization_note": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "z3_character_isomorphism_color_generation_open_gate_note_2026-05-10": {
+   "deps_hash": "9df4bd04ea8c",
+   "out_degree": 4
+  },
+  "z3_character_isomorphism_weyl_axis_cycle_orientation_open_gate_note_2026-05-30": {
+   "deps_hash": "f6ab154e9931",
+   "out_degree": 1
+  },
+  "z3_conjugate_support_trichotomy_narrow_theorem_note_2026-05-02": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "z_n_asymmetry_residual_1_finite_vs_continuum_note_2026-05-31": {
+   "deps_hash": "816f2d7e9dc1",
+   "out_degree": 7
+  },
+  "z_n_spectral_asymmetry_physical_identification_note_2026-05-31": {
+   "deps_hash": "84609f8d3c8c",
+   "out_degree": 6
+  }
+ },
+ "schema_version": 1
+}

--- a/docs/audit/scripts/render_front_door_status.py
+++ b/docs/audit/scripts/render_front_door_status.py
@@ -446,7 +446,7 @@ def main() -> None:
             ]
         ),
         "",
-        "Source: tracked shards in [`docs/audit/data/ledger/`](../audit/data/ledger/) and",
+        "Source: tracked shards under `docs/audit/data/ledger/` and",
         "[`docs/audit/data/effective_status_summary.json`](../audit/data/effective_status_summary.json).",
         "Full audit-ratified row list: [`docs/repo/RETAINED_BACKBONE.md`](RETAINED_BACKBONE.md) (generated).",
         "",

--- a/docs/audit/scripts/repo_invariants_check.py
+++ b/docs/audit/scripts/repo_invariants_check.py
@@ -38,8 +38,9 @@ Invariants measured (tracked state only)
                                target cannot resolve for a fresh clone or
                                GitHub reader; reasons: not-tracked (missing,
                                untracked, or gitignored alike — derived from
-                               the tracked set only), absolute-path, and
-                               outside-repository. Code spans and fenced code
+                               the tracked set only), absolute-path,
+                               outside-repository, irregular-target, and
+                               directory-target. Code spans and fenced code
                                blocks are masked before link extraction.
   authority_links.irregular_surfaces  authority files that are not regular
                                files (never dereferenced)
@@ -642,9 +643,7 @@ CLASS_F_REQUIRED_PHRASES = (
     "no premise or interpretive weight",
     "citable for orientation and scope discipline only",
 )
-CITATION_GRAPH_CACHE = os.path.join(
-    REPO_ROOT, "docs", "audit", "data", "citation_graph.json"
-)
+CITATION_GRAPH_CACHE_REL = "docs/audit/data/citation_graph.json"
 GRAPH_MANIFEST_REL = "docs/audit/data/citation_graph_manifest.json"
 
 
@@ -723,11 +722,14 @@ def collect_graph_manifest_check() -> dict | None:
     criticality. Returns None (skip) when no in-pass graph cache exists —
     the check is only meaningful inside a pipeline run.
     """
-    if not os.path.isfile(CITATION_GRAPH_CACHE):
+    # Resolve from REPO_ROOT at call time like every other collector, so
+    # fixture repos (tests overriding REPO_ROOT) never read this repo's cache.
+    cache_path = os.path.join(REPO_ROOT, CITATION_GRAPH_CACHE_REL)
+    if not os.path.isfile(cache_path):
         return None
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
     from write_citation_graph_manifest import compute_manifest
-    with open(CITATION_GRAPH_CACHE, "r", encoding="utf-8") as fh:
+    with open(cache_path, "r", encoding="utf-8") as fh:
         graph = json.load(fh)
     computed = compute_manifest(graph)
     proc = subprocess.run(

--- a/docs/audit/scripts/repo_invariants_check.py
+++ b/docs/audit/scripts/repo_invariants_check.py
@@ -542,6 +542,14 @@ def collect_authority_links(tracked: list) -> dict:
                 })
             continue
         if is_dir_link:
+            # A directory target renders as a file listing, not an authority
+            # document; every authority citation must dereference to one
+            # reviewable tracked file (front-door campaign, 2026-07-17).
+            violations.append({
+                "target": rel,
+                "reason": "directory-target",
+                "sources": sorted(candidates[rel]),
+            })
             continue
         # The single reason derives from the tracked set ONLY: local ignore
         # rules and untracked scratch files can never change the serialized
@@ -629,6 +637,122 @@ def run_diff(path_a: str, path_b: str, allow: set) -> int:
     return 0
 
 
+DOC_AUTHORITY_REGISTRY_REL = "docs/audit/data/doc_authority_registry.json"
+CLASS_F_REQUIRED_PHRASES = (
+    "no premise or interpretive weight",
+    "citable for orientation and scope discipline only",
+)
+CITATION_GRAPH_CACHE = os.path.join(
+    REPO_ROOT, "docs", "audit", "data", "citation_graph.json"
+)
+GRAPH_MANIFEST_REL = "docs/audit/data/citation_graph_manifest.json"
+
+
+def class_f_violations_from(registry: dict, tracked_set: set, read_text) -> list:
+    """Pure core of the class-F header check (callers supply IO).
+
+    Class F = orientation memo with no premise or interpretive weight
+    (DOCUMENT_AUTHORITY_AND_CITATION_POLICY, 'The Class F header formula').
+    Judged on tracked files only; a registered path that is missing or
+    untracked is itself a violation.
+    """
+    violations = []
+    for row in registry.get("rows", []):
+        if row.get("class") != "F":
+            continue
+        path = row.get("path")
+        if not isinstance(path, str):
+            violations.append({"path": repr(path), "problem": "class-F row has no path"})
+            continue
+        if path not in tracked_set:
+            violations.append({"path": path, "problem": "registered class-F doc is not tracked"})
+            continue
+        try:
+            text = read_text(path)
+        except OSError as exc:
+            violations.append({"path": path, "problem": f"unreadable: {exc}"})
+            continue
+        missing = [p for p in CLASS_F_REQUIRED_PHRASES if p not in text]
+        if missing:
+            violations.append({
+                "path": path,
+                "problem": "missing required class-F header phrase(s): "
+                           + "; ".join(repr(m) for m in missing),
+            })
+    return violations
+
+
+def collect_class_f_violations(tracked: list) -> list:
+    registry_path = os.path.join(REPO_ROOT, DOC_AUTHORITY_REGISTRY_REL)
+    try:
+        with open(registry_path, "r", encoding="utf-8") as fh:
+            registry = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        return [{"path": DOC_AUTHORITY_REGISTRY_REL, "problem": f"registry unreadable: {exc}"}]
+
+    def read_text(path: str) -> str:
+        with open(os.path.join(REPO_ROOT, path), "r", encoding="utf-8") as fh:
+            return fh.read()
+
+    return class_f_violations_from(registry, set(tracked), read_text)
+
+
+def graph_manifest_delta(computed: dict, indexed: dict) -> dict | None:
+    """Named delta between the computed manifest and the index-tracked one.
+
+    Returns None when identical. Pure function; callers supply both sides.
+    """
+    if computed == indexed:
+        return None
+    comp_nodes = computed.get("nodes", {})
+    idx_nodes = indexed.get("nodes", {})
+    added = sorted(set(comp_nodes) - set(idx_nodes))
+    removed = sorted(set(idx_nodes) - set(comp_nodes))
+    changed = sorted(
+        n for n in set(comp_nodes) & set(idx_nodes) if comp_nodes[n] != idx_nodes[n]
+    )
+    return {"added": added, "removed": removed, "changed": changed}
+
+
+def collect_graph_manifest_check() -> dict | None:
+    """Compare the in-pass citation graph against the index-tracked manifest.
+
+    The tracked manifest is the acknowledgment surface: any change that adds,
+    removes, or rewires graph nodes must ship the refreshed manifest, so the
+    delta is visible in the diff instead of silently reshaping audit-lane
+    criticality. Returns None (skip) when no in-pass graph cache exists —
+    the check is only meaningful inside a pipeline run.
+    """
+    if not os.path.isfile(CITATION_GRAPH_CACHE):
+        return None
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from write_citation_graph_manifest import compute_manifest
+    with open(CITATION_GRAPH_CACHE, "r", encoding="utf-8") as fh:
+        graph = json.load(fh)
+    computed = compute_manifest(graph)
+    proc = subprocess.run(
+        ["git", "show", f":{GRAPH_MANIFEST_REL}"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        return {"missing_from_index": True, "delta": None}
+    try:
+        indexed = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {"missing_from_index": False, "unparseable": True, "delta": None}
+    return {"missing_from_index": False, "delta": graph_manifest_delta(computed, indexed)}
+
+
+def _format_graph_delta(delta: dict) -> str:
+    parts = []
+    for key in ("added", "removed", "changed"):
+        items = delta.get(key, [])
+        if items:
+            shown = ", ".join(items[:20]) + (" ..." if len(items) > 20 else "")
+            parts.append(f"{len(items)} {key} ({shown})")
+    return "; ".join(parts) or "content drift"
+
+
 def run_check(enforce_links: bool) -> int:
     snapshot = build_snapshot()
     failures = []
@@ -668,6 +792,39 @@ def run_check(enforce_links: bool) -> int:
         else:
             warnings.append(message)
 
+    class_f_violations = collect_class_f_violations(_git_tracked_files())
+    if class_f_violations:
+        lines = [f"  {item['path']}: {item['problem']}" for item in class_f_violations]
+        message = "class-F registry/header violations:\n" + "\n".join(lines)
+        (failures if enforce_links else warnings).append(message)
+
+    graph_check = collect_graph_manifest_check()
+    graph_delta_note = "skipped (no in-pass graph cache)"
+    if graph_check is not None:
+        remedy = (
+            "acknowledge by refreshing and staging the manifest: "
+            "python3 docs/audit/scripts/write_citation_graph_manifest.py "
+            f"&& git add {GRAPH_MANIFEST_REL}"
+        )
+        if graph_check.get("missing_from_index"):
+            message = f"citation-graph manifest missing from the index; {remedy}"
+            (failures if enforce_links else warnings).append(message)
+            graph_delta_note = "manifest-missing"
+        elif graph_check.get("unparseable"):
+            message = f"citation-graph manifest in the index is not valid JSON; {remedy}"
+            (failures if enforce_links else warnings).append(message)
+            graph_delta_note = "manifest-unparseable"
+        elif graph_check.get("delta") is not None:
+            message = (
+                "citation-graph delta not acknowledged in the index: "
+                + _format_graph_delta(graph_check["delta"])
+                + f"; {remedy}"
+            )
+            (failures if enforce_links else warnings).append(message)
+            graph_delta_note = "delta-unacknowledged"
+        else:
+            graph_delta_note = "acknowledged"
+
     for warning in warnings:
         print(f"WARN: {warning}")
     for failure in failures:
@@ -675,6 +832,8 @@ def run_check(enforce_links: bool) -> int:
     summary = (
         f"rows={ledger['shard_count']} retained_grade={ledger['retained_grade_total']} "
         f"link_violations={len(link_violations)} "
+        f"class_f_violations={len(class_f_violations)} "
+        f"graph_delta={graph_delta_note} "
         f"({'enforced' if enforce_links else 'warn-only'})"
     )
     print(("FAIL " if failures else "PASS ") + summary)

--- a/docs/audit/scripts/run_pipeline.sh
+++ b/docs/audit/scripts/run_pipeline.sh
@@ -50,6 +50,9 @@ python3 scripts/audit_model_family_normalization_guard.py
 echo "==> 1/18 build_citation_graph.py"
 python3 docs/audit/scripts/build_citation_graph.py
 
+echo "==> 1b/18 write_citation_graph_manifest.py (tracked graph-topology acknowledgment)"
+python3 docs/audit/scripts/write_citation_graph_manifest.py
+
 echo "==> 2/18 seed_audit_ledger.py"
 python3 docs/audit/scripts/seed_audit_ledger.py
 

--- a/docs/audit/scripts/tests/test_authoring_gates.py
+++ b/docs/audit/scripts/tests/test_authoring_gates.py
@@ -1,0 +1,106 @@
+"""Tests for the authoring gates: graph-delta manifest, class-F headers,
+and the directory-target link rule (front-door campaign, 2026-07-17)."""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from repo_invariants_check import (
+    CLASS_F_REQUIRED_PHRASES,
+    class_f_violations_from,
+    collect_authority_links,
+    graph_manifest_delta,
+    _git_tracked_files,
+)
+from write_citation_graph_manifest import compute_manifest
+
+
+def _graph(nodes):
+    return {"nodes": {k: {"deps": v} for k, v in nodes.items()}}
+
+
+class ComputeManifestTest(unittest.TestCase):
+    def test_shape_counts_and_determinism(self):
+        g = _graph({"b": ["a"], "a": [], "c": ["a", "b"]})
+        m1 = compute_manifest(g)
+        self.assertEqual(m1["schema_version"], 1)
+        self.assertEqual(m1["node_count"], 3)
+        self.assertEqual(m1["edge_count"], 3)
+        self.assertEqual(m1["nodes"]["c"]["out_degree"], 2)
+        # Dep-order invariance: hashes are computed over sorted deps.
+        g2 = _graph({"b": ["a"], "a": [], "c": ["b", "a"]})
+        self.assertEqual(m1, compute_manifest(g2))
+
+    def test_deps_hash_distinguishes_rewiring(self):
+        m1 = compute_manifest(_graph({"c": ["a", "b"]}))
+        m2 = compute_manifest(_graph({"c": ["a", "x"]}))
+        self.assertEqual(
+            m1["nodes"]["c"]["out_degree"], m2["nodes"]["c"]["out_degree"]
+        )
+        self.assertNotEqual(
+            m1["nodes"]["c"]["deps_hash"], m2["nodes"]["c"]["deps_hash"]
+        )
+
+
+class GraphManifestDeltaTest(unittest.TestCase):
+    def test_identical_is_none(self):
+        m = compute_manifest(_graph({"a": [], "b": ["a"]}))
+        self.assertIsNone(graph_manifest_delta(m, m))
+
+    def test_added_removed_changed_named(self):
+        old = compute_manifest(_graph({"a": [], "b": ["a"]}))
+        new = compute_manifest(_graph({"a": [], "b": ["a", "c"], "c": []}))
+        delta = graph_manifest_delta(new, old)
+        self.assertEqual(delta["added"], ["c"])
+        self.assertEqual(delta["removed"], [])
+        self.assertEqual(delta["changed"], ["b"])
+
+
+class ClassFHeaderTest(unittest.TestCase):
+    REG = {"rows": [
+        {"path": "docs/repo/GOOD.md", "class": "F"},
+        {"path": "docs/repo/BAD.md", "class": "F"},
+        {"path": "docs/repo/UNTRACKED.md", "class": "F"},
+        {"path": "docs/repo/ANY.md", "class": "E"},
+    ]}
+    TEXTS = {
+        "docs/repo/GOOD.md": " ".join(CLASS_F_REQUIRED_PHRASES),
+        "docs/repo/BAD.md": CLASS_F_REQUIRED_PHRASES[0],
+        "docs/repo/ANY.md": "",
+    }
+
+    def _run(self):
+        tracked = {"docs/repo/GOOD.md", "docs/repo/BAD.md", "docs/repo/ANY.md"}
+        return class_f_violations_from(self.REG, tracked, self.TEXTS.__getitem__)
+
+    def test_good_doc_passes_bad_and_untracked_fail(self):
+        violations = self._run()
+        paths = sorted(v["path"] for v in violations)
+        self.assertEqual(paths, ["docs/repo/BAD.md", "docs/repo/UNTRACKED.md"])
+        bad = next(v for v in violations if v["path"] == "docs/repo/BAD.md")
+        self.assertIn(CLASS_F_REQUIRED_PHRASES[1], bad["problem"])
+
+    def test_non_class_f_rows_ignored(self):
+        # docs/repo/ANY.md is class E with empty text and produces no violation.
+        self.assertNotIn(
+            "docs/repo/ANY.md", [v["path"] for v in self._run()]
+        )
+
+
+class DirectoryTargetIntegrationTest(unittest.TestCase):
+    def test_no_directory_targets_survive_on_authority_surfaces(self):
+        # Integration: after the campaign's link fixes, no authority-surface
+        # markdown link may resolve to a directory. Guards the rule itself
+        # (reason must exist) and the repo state (no violators).
+        result = collect_authority_links(_git_tracked_files())
+        dir_violations = [
+            v for v in result["violations"] if v["reason"] == "directory-target"
+        ]
+        self.assertEqual(dir_violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/audit/scripts/tests/test_repo_invariants_check.py
+++ b/docs/audit/scripts/tests/test_repo_invariants_check.py
@@ -138,6 +138,9 @@ class AuthorityLinksTrackedSetTest(unittest.TestCase):
             {
                 "docs/PRESENT_UNTRACKED.md": "not-tracked",
                 "docs/MISSING.md": "not-tracked",
+                # Directory targets render as file listings, not authority
+                # documents (authoring gates, 2026-07-17).
+                "docs/repo": "directory-target",
             },
         )
 
@@ -660,7 +663,8 @@ class RoundSevenProbes(unittest.TestCase):
         root = Path(os.path.realpath(tmp))
         subprocess.run(["git", "init", "-q", str(root)], check=True)
         for rel, payload in ((ric.PREMISE_NODES, {"nodes": {}}),
-                             (ric.OBLIGATIONS, {"nodes": {}})):
+                             (ric.OBLIGATIONS, {"nodes": {}}),
+                             (ric.DOC_AUTHORITY_REGISTRY_REL, {"rows": []})):
             p = root / rel
             p.parent.mkdir(parents=True, exist_ok=True)
             p.write_text(json.dumps(payload))

--- a/docs/audit/scripts/write_citation_graph_manifest.py
+++ b/docs/audit/scripts/write_citation_graph_manifest.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Write the tracked citation-graph manifest from the in-pass graph cache.
+
+The manifest (docs/audit/data/citation_graph_manifest.json) is the
+acknowledgment surface for graph topology: one entry per node with its
+out-degree and a hash of its sorted dependency list. Criticality is graph
+topology only (FRESH_LOOK_REQUIREMENTS section 4), so any change that adds,
+removes, or rewires nodes must ship the refreshed manifest — making the
+topology delta reviewable in the diff instead of silently reshaping
+audit-lane prioritization. repo_invariants_check compares a recomputation
+against the INDEX version and fails (under --enforce-links) on any
+unacknowledged delta.
+
+Deterministic: same citation_graph.json -> byte-identical manifest.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GRAPH_PATH = REPO_ROOT / "docs" / "audit" / "data" / "citation_graph.json"
+MANIFEST_PATH = REPO_ROOT / "docs" / "audit" / "data" / "citation_graph_manifest.json"
+
+
+def compute_manifest(graph: dict) -> dict:
+    nodes: dict[str, dict] = {}
+    for node_id in sorted(graph.get("nodes", {})):
+        deps = sorted(graph["nodes"][node_id].get("deps", []))
+        nodes[node_id] = {
+            "out_degree": len(deps),
+            "deps_hash": hashlib.sha256("\n".join(deps).encode("utf-8")).hexdigest()[:12],
+        }
+    return {
+        "schema_version": 1,
+        "node_count": len(nodes),
+        "edge_count": sum(entry["out_degree"] for entry in nodes.values()),
+        "nodes": nodes,
+    }
+
+
+def main() -> None:
+    with GRAPH_PATH.open(encoding="utf-8") as fh:
+        graph = json.load(fh)
+    manifest = compute_manifest(graph)
+    MANIFEST_PATH.write_text(
+        json.dumps(manifest, indent=1, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(
+        f"Wrote {MANIFEST_PATH.relative_to(REPO_ROOT)} "
+        f"({manifest['node_count']} nodes, {manifest['edge_count']} edges)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/lanes/open_science/README.md
+++ b/docs/lanes/open_science/README.md
@@ -14,7 +14,7 @@ and the associated audit-ledger reset; read them as the lane authors'
 pre-reset scoping language, **not** as current `effective_status`. Most
 pre-reset ratifications are `unaudited` today pending post-reset re-audit.
 The live authorities are the tracked ledger
-([`docs/audit/data/ledger/`](../../audit/data/ledger/)) and the generated
+(`docs/audit/data/ledger/`) and the generated
 [`docs/repo/RETAINED_BACKBONE.md`](../../repo/RETAINED_BACKBONE.md); check a
 row's shard before citing any grade word from this package.
 

--- a/docs/publication/ci3_z3/CLAIMS_TABLE.md
+++ b/docs/publication/ci3_z3/CLAIMS_TABLE.md
@@ -23,7 +23,7 @@ The repo is migrating to the audit-lane vocabulary:
 
 - source notes may self-declare `proposed_retained` or `proposed_promoted`;
 - `retained` and `promoted` are audit-ratified `effective_status` values only;
-- until a row is ratified in the [sharded audit ledger](../../audit/data/ledger/),
+- until a row is ratified in the sharded audit ledger (`docs/audit/data/ledger/`),
   legacy table labels such as `retained`, `retained companion`, or
   `promoted quantitative` should be read as proposed manuscript placement.
 

--- a/docs/publication/ci3_z3/FALSIFIABLE_PREDICTIONS_2026-06-08.md
+++ b/docs/publication/ci3_z3/FALSIFIABLE_PREDICTIONS_2026-06-08.md
@@ -7,7 +7,7 @@ thresholds, bucket assignments, and named external comparison bands stand as
 stated; its per-row status words and source-note standings are as of
 2026-06-08 and are **not** current `effective_status` — the live authority is
 the tracked audit ledger
-([`docs/audit/data/ledger/`](../../audit/data/ledger/)), summarized in
+(`docs/audit/data/ledger/`), summarized in
 [`docs/repo/RETAINED_BACKBONE.md`](../../repo/RETAINED_BACKBONE.md). Where this
 catalog quotes three-axiom-era framing, read it as historical; the current
 baseline is the four named axioms in

--- a/docs/publication/ci3_z3/FIGURE_CAPTIONS.md
+++ b/docs/publication/ci3_z3/FIGURE_CAPTIONS.md
@@ -3,7 +3,7 @@
 These are publication captions aligned to
 [FIGURE_PLAN.md](./FIGURE_PLAN.md). They are intentionally claim-disciplined.
 The current arXiv figure set now exists as live manuscript assets in
-[`./figures/`](./figures/).
+`./figures/`.
 
 ## Core arXiv draft
 

--- a/docs/publication/ci3_z3/FULL_CLAIM_LEDGER.md
+++ b/docs/publication/ci3_z3/FULL_CLAIM_LEDGER.md
@@ -12,7 +12,7 @@ If the matrix and this ledger ever disagree, the matrix wins until this ledger
 is updated.
 
 Audit-transition note: this ledger is narrative package bookkeeping. The
-canonical ratification surface is the [sharded audit ledger](../../audit/data/ledger/).
+canonical ratification surface is the sharded audit ledger (`docs/audit/data/ledger/`).
 Legacy wording such as `retained core` or `promoted` in this file describes
 intended manuscript placement unless the audit ledger gives the row a clean
 `effective_status`.

--- a/docs/publication/ci3_z3/PUBLICATION_MATRIX.md
+++ b/docs/publication/ci3_z3/PUBLICATION_MATRIX.md
@@ -15,7 +15,7 @@ branches should appear here exactly once with one of five dispositions:
 - `frozen-out`
 
 Audit-transition rule: these are manuscript-capture dispositions. The audit
-lane's [sharded ledger](../../audit/data/ledger/) is the canonical source
+lane's sharded ledger (`docs/audit/data/ledger/`) is the canonical source
 for ratified `effective_status`. Until the ledger records a clean verdict, read
 `retained` / `promoted` capture labels in this matrix as proposed package
 placement rather than audit-ratified status.

--- a/docs/publication/ci3_z3/QUANTITATIVE_SUMMARY_TABLE.md
+++ b/docs/publication/ci3_z3/QUANTITATIVE_SUMMARY_TABLE.md
@@ -11,7 +11,7 @@ bridges, and delayed-observability rows, pair it with
 
 Audit-transition note: `Claim-strength status` is the package-facing
 quantitative classification. Ratified claim strength is controlled by
-the [sharded audit ledger](../../audit/data/ledger/); until an audit row is clean,
+the sharded audit ledger (`docs/audit/data/ledger/`); until an audit row is clean,
 legacy `retained` / `promoted` wording here should be read as proposed
 package status.
 

--- a/docs/publication/ci3_z3/SCIENCE_MAP.md
+++ b/docs/publication/ci3_z3/SCIENCE_MAP.md
@@ -5,7 +5,7 @@ notes and runners. For current claim strength, read the generated
 [claims](./CLAIMS_TABLE_EFFECTIVE_STATUS.md),
 [quantitative](./QUANTITATIVE_SUMMARY_TABLE_EFFECTIVE_STATUS.md), and
 [derivation-atlas](./DERIVATION_ATLAS_EFFECTIVE_STATUS.md) views together with
-the row-level [sharded audit ledger](../../audit/data/ledger/) (the rendered
+the row-level sharded audit ledger (`docs/audit/data/ledger/`) (the rendered
 `AUDIT_LEDGER.md` is a local pipeline-materialized cache, not tracked).
 
 Package appearance, a passing runner, and source-note words such as

--- a/docs/repo/CONTROLLED_VOCABULARY.md
+++ b/docs/repo/CONTROLLED_VOCABULARY.md
@@ -1,4 +1,4 @@
-<!-- generated; do not edit by hand; source: docs/repo/controlled_vocabulary.yaml hash=52efc0e707a89b2770070e3b0844ea9df4f25622d10bc5049d8eb62d96829460 -->
+<!-- generated; do not edit by hand; source: docs/repo/controlled_vocabulary.yaml hash=dc02750e482ab935590058a2194f976ba8fba24eb54d6abde65acc594de73d05 -->
 # Controlled Vocabulary
 
 > **Front-door lookup:** Looking up a single term? Go to
@@ -484,7 +484,7 @@ language to the audit-lane propose / ratify vocabulary. Source-note
 - `proposed_promoted` — author proposes promoted-grade; awaits audit ratification
 
 The canonical audit-ratified surface is the tracked sharded ledger
-[docs/audit/data/ledger/](../audit/data/ledger/); the rendered
+`docs/audit/data/ledger/`; the rendered
 `docs/audit/AUDIT_LEDGER.md` is a local pipeline-materialized cache.
 Legacy publication summaries may still use manuscript shorthand, but
 those rows should be read as proposed until the audit ledger marks

--- a/docs/repo/FRONT_DOOR_STATUS.md
+++ b/docs/repo/FRONT_DOOR_STATUS.md
@@ -46,7 +46,7 @@ Owner-approval history for axioms and primitives:
 | Audited numerical-match rows | 6 |
 | Citation cycles detected | 62 |
 
-Source: tracked shards in [`docs/audit/data/ledger/`](../audit/data/ledger/) and
+Source: tracked shards under `docs/audit/data/ledger/` and
 [`docs/audit/data/effective_status_summary.json`](../audit/data/effective_status_summary.json).
 
 ## Audit Queue

--- a/docs/repo/STATE_OF_THE_THEORY_2026-07-16.md
+++ b/docs/repo/STATE_OF_THE_THEORY_2026-07-16.md
@@ -5,7 +5,7 @@
 This memo is citable for orientation and scope discipline only.
 **Status discipline:** every status word in this memo was read from the audit
 ledger's 2026-07-17 nightly state and goes stale from that moment. The live authorities are
-the tracked ledger shards ([`docs/audit/data/ledger/`](../audit/data/ledger/)),
+the tracked ledger shards (`docs/audit/data/ledger/`),
 the generated [`RETAINED_BACKBONE.md`](RETAINED_BACKBONE.md), and
 [`FRONT_DOOR_STATUS.md`](FRONT_DOOR_STATUS.md). Where this memo and the ledger
 disagree, the ledger is right. This memo sets no audit verdict and promotes
@@ -223,5 +223,5 @@ authority-link guard. Then:
 3. [`EXTERNAL_REVIEWER_GUIDE.md`](../publication/ci3_z3/EXTERNAL_REVIEWER_GUIDE.md)
    — the referee's path through the package.
 4. Any claim: open its ledger shard under
-   [`docs/audit/data/ledger/`](../audit/data/ledger/) and read
+   `docs/audit/data/ledger/` and read
    `effective_status`, its dependencies, and the audit rationale.

--- a/docs/repo/controlled_vocabulary.yaml
+++ b/docs/repo/controlled_vocabulary.yaml
@@ -638,7 +638,7 @@ migration_legacy_wording:
     - {label: proposed_promoted, definition: "author proposes promoted-grade; awaits audit ratification"}
   ratified_surface_pointer: |-
     The canonical audit-ratified surface is the tracked sharded ledger
-    [docs/audit/data/ledger/](../audit/data/ledger/); the rendered
+    `docs/audit/data/ledger/`; the rendered
     `docs/audit/AUDIT_LEDGER.md` is a local pipeline-materialized cache.
     Legacy publication summaries may still use manuscript shorthand, but
     those rows should be read as proposed until the audit ledger marks


### PR DESCRIPTION
Machinery PR (one concern: close the mechanical finding classes from the front-door review campaign, so they are caught by stage 18 instead of reviewers).

**Three new checks in repo_invariants_check (enforced under --enforce-links, warn-only otherwise):**
1. **directory-target**: authority-surface markdown links must dereference to one reviewable tracked file. All 13 in-repo violators fixed (code-span + file-link pattern; the FRONT_DOOR_STATUS line is a surgical one-line sync byte-identical to the updated renderer's output).
2. **class-F header formula**: registered class-F docs must carry both policy phrases; the GRADED_CONSTRAINT memo was missing the citable-scope sentence and gains it (mechanical policy sync).
3. **citation-graph delta gate**: new pipeline stage 1b writes a tracked per-node manifest (out-degree + deps hash); stage 18 fails when the in-pass graph differs from the INDEX manifest, naming added/removed/rewired nodes and the one-command remedy. New graph topology now lands as a visible acknowledged diff instead of silently reshaping audit-lane criticality (basis: FRESH_LOOK_REQUIREMENTS §4 — criticality is graph topology only). Initial materialization: 3,961 nodes / 14,464 edges. NOTE for in-flight lanes: a landing that adds notes will see the stage-18 remedy message — run write_citation_graph_manifest.py and stage the manifest.

**Tests**: 7 new (manifest determinism + rewiring hashes, delta naming, class-F pure core, directory-target integration). Full pipeline exit 0: link_violations=0 class_f_violations=0 graph_delta=acknowledged.

Companion to #5463 (author pre-flight checklist, the judgment-side of the same campaign).

Review gate: sol-max review-loop round to follow before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)