### PR TITLE
Area law: make multipocket selector no-go self-contained

### DIFF
--- a/docs/AREA_LAW_MULTIPOCKET_SELECTOR_NO_GO_NOTE_2026-04-25.md
+++ b/docs/AREA_LAW_MULTIPOCKET_SELECTOR_NO_GO_NOTE_2026-04-25.md
@@ -132,7 +132,7 @@ This note does not rule out a future positive result. It narrows what such a
 result must prove:
 
 1. derive a multipocket transverse-measure law, such as `mu = 1/2`, from the
-   retained `Cl(3)/Z^3` primitive structure; or
+   supplied `Cl(3)/Z^3` framework structure; or
 2. derive a Schur/edge sector-weight law fixing the required convex average;
    or
 3. construct a gapped horizon carrier whose leading area coefficient is
@@ -167,8 +167,8 @@ rather than Markdown authority links.
 Safe wording:
 
 > Multi-pocket Widom carriers can be calibrated to `c_Widom = 1/4`, but only by
-> imposing an additional pocket-measure or sector-weight selector. The retained
-> `Cl(3)/Z^3` primitive boundary count does not yet derive that selector, so
+> imposing an additional pocket-measure or sector-weight selector. The supplied
+> `Cl(3)/Z^3` framework structure does not yet derive that selector, so
 > the multipocket route remains open only as a sharply specified residual
 > target.
 

--- a/docs/AREA_LAW_MULTIPOCKET_SELECTOR_NO_GO_NOTE_2026-04-25.md
+++ b/docs/AREA_LAW_MULTIPOCKET_SELECTOR_NO_GO_NOTE_2026-04-25.md
@@ -6,19 +6,22 @@
 
 ## Purpose
 
-The retained Widom no-go already says the current half-filled NN carrier gives
-`c_Widom = 1/6`, not `1/4`. It also notes that one can invent a multi-pocket
-Fermi surface whose projected-width integral gives `1/4`.
+This note isolates a selector-free algebraic claim inside the standard
+flat-cut Widom candidate class. Starting from the stated normalization
+`c_Widom = <N_x>/12`, a multi-pocket carrier can be calibrated to `1/4`, but
+the calibration is equivalent to adding a pocket-measure or sector-weight
+selector. The `Cl(3)/Z^3` primitive boundary count, represented here
+by the separate trace `4/16`, does not by itself supply that selector.
 
-This note closes that residual loophole as a framework claim. A multi-pocket
-carrier can be calibrated to `1/4`, but the calibration is equivalent to adding
-a new pocket-measure or sector-weight selector. The retained `Cl(3)/Z^3`
-primitive boundary count does not supply that selector.
+All load-bearing premises and calculations for this no-go are displayed in
+this note. It does not consume an earlier finite-size carrier conclusion or
+either of the later conditional carrier comparisons as scientific authority.
 
 ## Safe statement
 
-For a straight cut normal to `e_x`, the free-fermion Widom coefficient can be
-written as
+The claim is conditional only on the candidate-class Widom normalization and
+ordinary scalar interval-fiber semantics stated here. For a straight cut
+normal to `e_x`, write the free-fermion Widom coefficient as
 
 ```text
 c_Widom = <N_x> / 12,
@@ -95,8 +98,7 @@ rank is counted consistently.
 
 ## Why this is not Target 2 closure
 
-The Planck conditional packet derives `1/4` from a specific finite primitive
-trace:
+The comparison primitive quantity is the specific finite trace
 
 ```text
 H_cell ~= C^16,
@@ -115,9 +117,10 @@ crossing-number or sector-weight selector from the same primitive boundary
 semantics. Without that theorem, the multipocket construction is only a tuned
 comparison carrier.
 
-## Relation to gapped carriers
+## Non-load-bearing comparison to gapped carriers
 
-The same caution applies to the gapped route. Brandao-Horodecki-style
+This comparison is not used by the selector-free algebraic no-go. The same
+caution applies to the gapped route. Brandao-Horodecki-style
 mass-gap or exponential-correlation results can justify an area law, but they
 do not determine the exact ultraviolet entropy per primitive face. A gapped
 horizon/edge carrier would still need a separate theorem deriving its
@@ -139,20 +142,25 @@ Absent one of those selector laws, the residual multipocket Widom route is not
 a physical derivation of Bekenstein-Hawking. It is a parameterized family that
 can be made to contain the desired number.
 
-## Subsequent conditional positive carrier
+## Downstream context comparisons (non-load-bearing)
 
-[AREA_LAW_PRIMITIVE_PARITY_GATE_CARRIER_THEOREM_NOTE_2026-04-25.md](./AREA_LAW_PRIMITIVE_PARITY_GATE_CARRIER_THEOREM_NOTE_2026-04-25.md)
-supplies one such selector conditionally: a residual primitive `Z_2` parity
-gate, equivalently the self-dual low sheet of the transverse nearest-neighbor
-Laplacian, selects a transverse half-zone `mu=1/2`, giving average crossing
-count `3` and `c_Widom=1/4`. This does not invalidate the no-go above; it
-identifies the exact additional carrier premise that the no-go said was
-missing.
+The following later notes are reader orientation only. Their conclusions are
+not premises, witnesses, or scientific authorities for the selector-free
+algebra above, so their filenames are deliberately plain-text context handles
+rather than Markdown authority links.
 
-[AREA_LAW_PRIMITIVE_CAR_EDGE_IDENTIFICATION_THEOREM_NOTE_2026-04-25.md](./AREA_LAW_PRIMITIVE_CAR_EDGE_IDENTIFICATION_THEOREM_NOTE_2026-04-25.md)
-sharpens the premise: in the minimal local complex-CAR edge class supported
-exactly on the rank-four primitive packet, the normal-plus-self-dual-tangent
-carrier is the unique minimal two-mode option that gives `1/4`.
+- `docs/AREA_LAW_PRIMITIVE_PARITY_GATE_CARRIER_THEOREM_NOTE_2026-04-25.md`
+  conditionally supplies a residual primitive `Z_2` parity gate, equivalently
+  the self-dual low sheet of the transverse nearest-neighbor Laplacian. Under
+  that added carrier premise, it selects a transverse half-zone `mu=1/2`,
+  giving average crossing count `3` and `c_Widom=1/4`. This is a downstream
+  comparison showing how an extra selector can leave the selector-free class;
+  it is not support for the no-go.
+- `docs/AREA_LAW_PRIMITIVE_CAR_EDGE_IDENTIFICATION_THEOREM_NOTE_2026-04-25.md`
+  conditionally analyzes the same coefficient inside supplied rank-four CAR,
+  normal-channel, and self-dual tangent-channel conditions. It is a downstream
+  comparison of an explicitly selector-bearing class, not authority for any
+  step above.
 
 ## Package wording
 

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 14464,
- "node_count": 3962,
+ "edge_count": 14469,
+ "node_count": 3963,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1567,8 +1567,8 @@
    "out_degree": 11
   },
   "canonical_harness_index": {
-   "deps_hash": "be70ed3a0072",
-   "out_degree": 299
+   "deps_hash": "1703eb28f7c7",
+   "out_degree": 301
   },
   "canonical_plaquette_alpha_lm_value_certificate_bounded_note_2026-06-16": {
    "deps_hash": "808c1ccb6109",
@@ -4831,8 +4831,8 @@
    "out_degree": 2
   },
   "free_dirac_poincare_representation_bounded_note_2026-05-30": {
-   "deps_hash": "e3b0c44298fc",
-   "out_degree": 0
+   "deps_hash": "b9ec29c7fff9",
+   "out_degree": 1
   },
   "free_dirac_poincare_stone_differential_generator_coincidence_common_core_bounded_theorem_note_2026-06-08": {
    "deps_hash": "df81d1e90c93",
@@ -4861,6 +4861,10 @@
   "free_sector_spin_statistics_level1_mechanism_and_reconstruction_reduction_bounded_note_2026-05-30": {
    "deps_hash": "d1d61e252dcd",
    "out_degree": 6
+  },
+  "free_staggered_pole_residue_dirac_carrier_car_relabeling_bounded_theorem_note_2026-07-17": {
+   "deps_hash": "02cde96f4a48",
+   "out_degree": 2
   },
   "free_staggered_two_step_dispersion_d_dimensional_narrow_theorem_note_2026-06-12": {
    "deps_hash": "d1da2f9855ac",

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,5 +1,5 @@
 {
- "edge_count": 14466,
+ "edge_count": 14464,
  "node_count": 3962,
  "nodes": {
   "3d_correction_master_note": {
@@ -907,8 +907,8 @@
    "out_degree": 0
   },
   "area_law_multipocket_selector_no_go_note_2026-04-25": {
-   "deps_hash": "c338f0b2dfc4",
-   "out_degree": 2
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "area_law_native_car_semantics_tightening_note_2026-04-25": {
    "deps_hash": "e71aacadb844",

--- a/scripts/frontier_area_law_multipocket_selector_no_go.py
+++ b/scripts/frontier_area_law_multipocket_selector_no_go.py
@@ -5,9 +5,9 @@ Residual multipocket selector no-go for the area-law quarter target.
 Authority note:
     docs/AREA_LAW_MULTIPOCKET_SELECTOR_NO_GO_NOTE_2026-04-25.md
 
-The retained Widom no-go leaves a real loophole: invented multipocket Fermi
-surfaces can make the projected-width integral equal the value required for
-c_Widom = 1/4. This runner checks that the loophole is selector-dependent:
+Within the stated flat-cut Widom candidate-class normalization, multipocket
+Fermi surfaces can make the projected-width integral equal the value required
+for c_Widom = 1/4. This runner checks that the equality is selector-dependent:
 the exact quarter is equivalent to an extra transverse-measure or sector-weight
 condition, not to the existing Cl(3)/Z^3 primitive trace c_cell = 4/16.
 
@@ -19,11 +19,27 @@ PStack experiment: frontier-area-law-multipocket-selector-no-go
 from __future__ import annotations
 
 import math
+import re
 import sys
+from pathlib import Path
 
 
 PASS_COUNT = 0
 FAIL_COUNT = 0
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "AREA_LAW_MULTIPOCKET_SELECTOR_NO_GO_NOTE_2026-04-25.md"
+)
+DOWNSTREAM_CONTEXT_NOTES = (
+    "AREA_LAW_PRIMITIVE_PARITY_GATE_CARRIER_THEOREM_NOTE_2026-04-25.md",
+    "AREA_LAW_PRIMITIVE_CAR_EDGE_IDENTIFICATION_THEOREM_NOTE_2026-04-25.md",
+)
+MARKDOWN_NOTE_LINK_RE = re.compile(
+    r"\[[^\]]*\]\(([^)\s#]+\.md)(?:#[^)]*)?\)"
+)
 
 
 def check(name: str, passed: bool, detail: str) -> bool:
@@ -209,13 +225,24 @@ def main() -> int:
     # Residual theorem assembly.
     check(
         "residual multipocket Widom route is selector-dependent",
-        True,
+        math.isclose(widom_from_average_crossings(3.0), c_cell, abs_tol=1e-15)
+        and math.isclose(required_extra_measure_for_quarter(), 0.5, abs_tol=1e-15)
+        and math.isclose(
+            weighted_average([c_simple, c_two_interval], [1.0, 1.0]),
+            c_cell,
+            abs_tol=1e-15,
+        ),
         "c=1/4 iff <N_x>=3, implemented here by mu=1/2 or equal sector weights",
     )
+
+    note_text = NOTE_PATH.read_text(encoding="utf-8")
+    markdown_note_targets = MARKDOWN_NOTE_LINK_RE.findall(note_text)
     check(
-        "Target 2 remains open without a selector/bridge theorem",
-        True,
-        "need to derive pocket measure, sector weight, or gapped edge entropy from Cl(3)/Z^3",
+        "downstream carrier comparisons are non-load-bearing context",
+        not markdown_note_targets
+        and "Downstream context comparisons (non-load-bearing)" in note_text
+        and all(f"`docs/{name}`" in note_text for name in DOWNSTREAM_CONTEXT_NOTES),
+        "target note has no Markdown authority edges; both later carriers are backticked context handles",
     )
 
     print()

--- a/scripts/frontier_area_law_multipocket_selector_no_go.py
+++ b/scripts/frontier_area_law_multipocket_selector_no_go.py
@@ -150,7 +150,7 @@ def main() -> int:
         f"mu={mu_star:.12f}, c(mu)={c_star:.12f}",
     )
     check(
-        "no extra pocket recovers the retained simple value 1/6",
+        "no extra pocket recovers the baseline simple-fiber value 1/6",
         math.isclose(multipocket_coefficient(0.0), 1.0 / 6.0, abs_tol=1e-15),
         f"c(0)={multipocket_coefficient(0.0):.12f}",
     )


### PR DESCRIPTION
## Blocker addressed

> "dependency_not_retained: audit or mark non-load-bearing the two cited conditional carrier notes, then re-audit whether the no-go can stand as a self-contained selector-free algebraic claim."

## Repair

- states the selector-free Widom algebra directly from `c_Widom = <N_x>/12`, interval-fiber parity, and convex weighting, without relying on the withdrawn finite-size carrier framing;
- keeps the same conclusion and open positive exits: `1/4` requires `<N_x>=3`, realized here only after `mu=1/2` or equal sector weights are supplied;
- converts the later parity-gate and rank-four CAR carrier notes to explicit downstream, non-load-bearing backticked context handles;
- acknowledges the intended graph change: the target node goes from two outgoing dependencies to zero;
- replaces the runner's two unconditional `True` checks with a computed selector-dependence check and a source-link regression guard while preserving the 22-check count.

No audit ledger/status, queue, missing-prompt, Free Dirac, PMNS, or publication source is changed. Pipeline-generated ledger/publication projections were produced only in a disposable worktree and discarded.

## No-go discipline self-review (N1-N8; not an audit verdict)

- **N1:** five distinct routes remain explicit and tested: full-pocket integer degeneracy, partial transverse measure, Schur/direct-sum weighting, same-sector species duplication, and a tuned gapped two-level spectrum. The first cannot realize integer multiplicity `3/2`; the other successful numerical matches each expose the added selector rather than defeating the selector-free statement.
- **N2:** the collapsed wall set is one wall—an unsupplied crossing-measure or sector-weight selector. Partial measure and direct-sum weight are alternative realizations, not independent walls.
- **N3:** the Widom normalization and interval-fiber semantics are explicit load-bearing premises; the gapped and later-carrier comparisons are explicitly non-load-bearing.
- **N4:** no prior no-go or carrier note remains as a scientific witness; the rebuilt graph gives this note `deps=[]`.
- **N5:** the negative language stays scoped to the stated flat-cut Widom candidate normalization and displayed primitive trace, not all entropy carriers.
- **N6:** positive closure paths remain open. The later parity/CAR notes illustrate closure after extra supplied carrier conditions and are not mislabeled as forbidden axioms.
- **N7:** the strongest steelman is exactly the parity-gated CAR construction: it supplies `mu=1/2` and reaches `1/4`. That defeats an absolute multipocket no-go, but not the selector-free claim, because it adds the missing selector.
- **N8:** the downstream positive notes are the cross-cycle echo showing how this wall can be retired by additional conditions; the repair preserves them as context without consuming their authority.

## Validation

All commands ran from a disposable worktree based on current `origin/main`:

```text
python3 scripts/frontier_area_law_multipocket_selector_no_go.py
  SUMMARY: PASS=22  FAIL=0

python3 -m py_compile scripts/frontier_area_law_multipocket_selector_no_go.py
git diff --check

python3 scripts/vocab_lint.py --fix \
  docs/AREA_LAW_MULTIPOCKET_SELECTOR_NO_GO_NOTE_2026-04-25.md \
  scripts/frontier_area_law_multipocket_selector_no_go.py
  vocab_lint: 0 files with violations

python3 docs/audit/scripts/build_citation_graph.py
python3 docs/audit/scripts/write_citation_graph_manifest.py
  nodes: 3963; edges: 14469
  asserted target deps=[] and no outgoing target edge

python3 docs/audit/scripts/repo_invariants_check.py --check --enforce-links
  PASS rows=3767 retained_grade=392 link_violations=0 class_f_violations=0 graph_delta=acknowledged (enforced)

bash docs/audit/scripts/run_pipeline.sh
  exit 0; stage-18 repo invariants PASS

python3 docs/audit/scripts/audit_lint.py --strict
  OK: no errors
```

Independent exact-rational check:

```python
from fractions import Fraction

target = Fraction(1, 4)
mu = 6 * target - 1
full_pocket_intervals = 6 * target
simple = Fraction(1, 6)
two_interval = Fraction(1, 3)
weight_ratio = (target - simple) / (two_interval - target)

assert mu == Fraction(1, 2)
assert full_pocket_intervals == Fraction(3, 2)
assert full_pocket_intervals.denominator != 1
assert weight_ratio == 1
assert (simple + weight_ratio * two_interval) / (1 + weight_ratio) == target
```

Mutation checks imported the runner on scratch module instances and verified both changed check families fail: setting `required_extra_measure_for_quarter()` to `0.4` produced `[FAIL] residual multipocket Widom route is selector-dependent`, and injecting a Markdown `.md` target produced `[FAIL] downstream carrier comparisons are non-load-bearing context`.