### PR TITLE
invariants: structured diagnostic for undecodable class-F registry (NIT from #5464)

### DIFF
--- a/docs/audit/scripts/repo_invariants_check.py
+++ b/docs/audit/scripts/repo_invariants_check.py
@@ -686,7 +686,7 @@ def collect_class_f_violations(tracked: list) -> list:
     try:
         with open(registry_path, "r", encoding="utf-8") as fh:
             registry = json.load(fh)
-    except (OSError, json.JSONDecodeError) as exc:
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
         return [{"path": DOC_AUTHORITY_REGISTRY_REL, "problem": f"registry unreadable: {exc}"}]
 
     def read_text(path: str) -> str:

--- a/docs/audit/scripts/tests/test_authoring_gates.py
+++ b/docs/audit/scripts/tests/test_authoring_gates.py
@@ -90,6 +90,26 @@ class ClassFHeaderTest(unittest.TestCase):
         )
 
 
+class ClassFRegistryUnreadableTest(unittest.TestCase):
+    def test_invalid_utf8_registry_yields_structured_violation(self):
+        # An invalid-UTF-8 registry must surface as the structured
+        # "registry unreadable" violation, not a raw UnicodeDecodeError.
+        import tempfile
+        from unittest import mock
+
+        import repo_invariants_check as ric
+
+        with tempfile.TemporaryDirectory() as tmp:
+            reg = Path(tmp) / ric.DOC_AUTHORITY_REGISTRY_REL
+            reg.parent.mkdir(parents=True)
+            reg.write_bytes(b'{"rows": [\xff\xfe]}')
+            with mock.patch.object(ric, "REPO_ROOT", tmp):
+                violations = ric.collect_class_f_violations([])
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0]["path"], ric.DOC_AUTHORITY_REGISTRY_REL)
+        self.assertIn("registry unreadable", violations[0]["problem"])
+
+
 class DirectoryTargetIntegrationTest(unittest.TestCase):
     def test_no_directory_targets_survive_on_authority_surfaces(self):
         # Integration: after the campaign's link fixes, no authority-surface


### PR DESCRIPTION
One-line exception-tuple fix + one test. collect_class_f_violations catches UnicodeDecodeError like the file's sibling readers, so a corrupt registry yields the structured "registry unreadable" violation instead of a raw traceback. No behavior change on valid input; was already fail-nonzero (cannot false-PASS). Full suite green; 18-stage pipeline exit 0 with stage 18 PASS (link_violations=0 class_f_violations=0 graph_delta=acknowledged).

Review gate: sol round to follow before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)