### PR TITLE
Fix Test 4 localization comparison on matched outcome space

### DIFF
--- a/docs/SINGLE_AXIOM_HILBERT_NOTE.md
+++ b/docs/SINGLE_AXIOM_HILBERT_NOTE.md
@@ -2,14 +2,16 @@
 
 **Date:** 2026-04-12 (originally); 2026-05-10 (audit-narrowing refresh:
 explicit class-E definitional-compression framing under named admitted
-inputs); 2026-06-17 (runner/source drift repair for Test 4 and synthesis).
+inputs); 2026-06-17 (runner/source drift repair for Test 4 and synthesis);
+2026-07-17 (Test 4 common-outcome-space and Hamiltonian-scale repair).
 **Status:** scope-narrowed bounded operational note. The runner numerically
 verifies four consequences (Hamiltonian-support graph recovery, Born-rule
-`I_3 = 0` at machine precision, unitarity-vs-Lindblad behaviour, tensor-
-product locality) **after** the named inputs `(local d, local Hermitian H,
-Born readout)` are supplied. The "single axiom" framing is a definitional
-compression of those inputs into the phrase "local tensor product Hilbert
-space"; this note **does not** derive the local-Hamiltonian, the locality
+`I_3 = 0` at machine precision, unitarity-vs-Lindblad behaviour, and a
+matched-scale local-H localization contrast) **after** the named inputs
+`(local d, local Hermitian H, Born readout)` are supplied. The "single axiom"
+framing is a definitional compression of those inputs into the phrase
+"local tensor product Hilbert space"; this note **does not** derive the
+local-Hamiltonian, the locality
 restriction, or the Born readout from the bare tensor-product Hilbert
 space alone.
 **Claim type (in-note framing):** bounded operational note —
@@ -32,15 +34,17 @@ for the current paper package remains the Lattice + Quantum + Record
 front-door surface in `docs/MINIMAL_AXIOMS_2026-06-05.md`.
 **Runner:** `scripts/frontier_single_axiom_hilbert.py`
 
-**2026-06-17 runner/source drift repair:** the executable runner and this
-source note now agree that Test 4 does **not** prove monotone distance-decay
-with graph distance. The current fixed-seed Test 4 output reports
-`Locality gradient (near > far): False`; the bounded support is only the
-spread/localization contrast between the supplied tensor-product local
-Hamiltonian and an unfactored random Hamiltonian of the same dimension. The
-runner synthesis has therefore been demoted from the old "single axiom
-reduction" language to the admitted-input operational-support boundary already
-stated in this note.
+**2026-07-17 Test 4 repair:** the executable runner and this source note compare
+both propagators on the same 64 mutually exclusive computational-basis
+outcomes. Both probability distributions are normalized. Before propagation,
+each Hamiltonian is shifted by its trace (which changes only a global phase)
+and rescaled to centered RMS energy
+`sqrt(Tr(H_c^2)/64) = 1`. The fixed seed, initial state `|000000>`,
+dimensionless time `t=1`, and existing twofold spread-contrast criterion are
+unchanged. The control is now described accurately as a dense nonlocal
+Hamiltonian on the same factorized Hilbert space, rather than as an
+"unfactored" space. Test 4 remains a fixed-seed bounded localization contrast;
+it does not prove monotone distance decay or a general localization theorem.
 
 **Audit-dispatch parent candidate:** If a future independent audit
 evaluates whether this Hilbert-surface wrapper is a non-chain-closing
@@ -67,8 +71,8 @@ Hermiticity/locality restriction, Born rule, graph support extraction, or the
 current accepted-input ledger.
 
 Promotion beyond renaming support requires deriving those inputs from a
-strictly smaller retained framework surface, and repairing the Test 4
-source/runner drift before any stronger use.
+strictly smaller retained framework surface. The repaired Test 4 remains only
+a common-space, matched-scale fixed-seed contrast and supplies no stronger use.
 
 ## Audit boundary (2026-05-10 refresh of 2026-05-05 verdict; prior 2026-05-11 re-audit confirmed `audited_renaming` and updated `claim_type` to `bounded_theorem`)
 
@@ -127,7 +131,7 @@ consequences`, evaluated mechanically by the runner.
 Given the named admitted inputs `(local d, local Hermitian H, Born
 readout, "support = edges" extraction rule)`, do the four numerical
 consequences (graph recovery, `I_3 = 0`, unitarity vs. Lindblad,
-tensor-product locality) follow mechanically?
+matched-scale local-H localization) follow mechanically?
 
 **Definitional compression (class-E):** packaging the four admitted
 inputs together gives the phrase "a finite Hilbert space with local
@@ -202,27 +206,39 @@ instead of migrating toward the potential minimum. The Hermiticity
 restriction is therefore a real admitted input: replacing it with
 non-Hermitian Lindblad dynamics changes the consequence.
 
-### Test 4: Tensor-product/local-H packet gives bounded localization support
+### Test 4: Matched-scale local-H packet gives bounded localization support
 
-Compared a 6-qubit chain (tensor product, local Hamiltonian) to a random
-64x64 Hamiltonian (same dimension, no factorization).
+Compared a 6-qubit chain-local Hamiltonian with a dense nonlocal random
+Hamiltonian on the same 64-dimensional factorized Hilbert space. Both start
+from `|000000>` and are read in the same mutually exclusive computational
+basis. For each raw Hamiltonian `H`, the runner removes the energy origin and
+matches the generator scale by
 
-| Metric               | Tensor product | Unfactored |
-|----------------------|---------------|------------|
-| Participation ratio  | 1.0 / 6 sites | 30.2 / 64 states |
-| Distance dependence  | No monotone decay claim; fixed-seed gradient check is false | No graph-distance notion |
-| Spread ratio         | 29x more localized | baseline |
+`H_c = H - Tr(H) I / 64`,
 
-Without the admitted tensor-product factorization, there is no notion
-of locality, distance, or spatial structure: the propagator spreads
-uniformly rather than respecting any supplied factorization. The runner's
-valid Test 4 support is the participation-ratio/spread contrast. It does not
-establish that the fixed-seed amplitudes decay monotonically with graph
-distance; the runner prints that monotone-gradient diagnostic as false.
-The tensor-product factorization plus the admitted local Hamiltonian
-(inputs 1+2) jointly give the bounded localization contrast. Neither input
-alone suffices: an unfactored same-dimension Hamiltonian gives much broader
-spread.
+`sigma_H = sqrt(Tr(H_c^2) / 64)`, and `H_matched = H_c / sigma_H`.
+
+Thus both evolutions use `sigma_H = 1` at the same dimensionless time `t=1`.
+The shift has no observable effect because it contributes only a global phase;
+the RMS normalization matches the mean-square spectral generator scale. This
+is an explicit comparison convention, not a derived physical energy scale.
+
+| Metric | Chain-local Hamiltonian | Dense nonlocal control |
+|---|---:|---:|
+| Outcome space | 64 basis outcomes | same 64 basis outcomes |
+| Probability sum | 1.000000 | 1.000000 |
+| Centered RMS energy after matching | 1.000000 | 1.000000 |
+| Participation ratio `1/sum_z p(z)^2` | 3.2706 / 64 outcomes | 13.1853 / 64 outcomes |
+| Spread ratio | 4.0314x more localized | baseline |
+
+The participation ratios are now like-for-like: each is computed from one
+normalized distribution over the same 64 mutually exclusive outcomes. The
+comparison isolates the supplied chain-local support restriction by holding
+the factorization, readout basis, initial state, evolution time, and centered
+RMS energy fixed. The dense control does not respect the chain-local support
+restriction and is broader in this fixed sample. Test 4 does not establish
+monotone decay with graph distance. The result is not an ensemble statement
+and does not show that tensor-product factorization alone causes localization.
 
 ## Conclusion (scope-narrowed)
 
@@ -240,10 +256,11 @@ consequences follow mechanically as evaluated by the runner:
 - Unitary toy evolution follows from the admitted Hermitian generator
   (Test 3); a non-Hermitian Lindblad replacement breaks the toy attraction
   profile, confirming the Hermiticity restriction is a real input.
-- The admitted tensor-product factorization gives a bounded localization
-  contrast by participation ratio; an unfactored same-dimension Hamiltonian
-  is much broader. The runner does not claim monotone distance-decay in the
-  fixed Test 4 sample (Test 4).
+- On the admitted factorized Hilbert space, the chain-local Hamiltonian gives a
+  bounded fixed-seed localization contrast against a dense nonlocal control.
+  Both participation ratios use the same normalized 64-outcome space and
+  matched centered RMS energy. The runner does not claim monotone
+  distance-decay or an ensemble theorem (Test 4).
 
 **Definitional-compression framing.** The four admitted inputs
 `(local d, local H, Born readout, "support = edges" rule)` can be

--- a/docs/SINGLE_AXIOM_HILBERT_NOTE.md
+++ b/docs/SINGLE_AXIOM_HILBERT_NOTE.md
@@ -1,12 +1,14 @@
 # Local Tensor Product Hilbert Space + Local Hamiltonian + Born Readout: Operational Reduction Note
 
 **Date:** 2026-04-12 (originally); 2026-05-10 (audit-narrowing refresh:
-explicit class-E definitional-compression framing under named admitted
+explicit class-E definitional-compression framing under named conditional
 inputs); 2026-06-17 (runner/source drift repair for Test 4 and synthesis);
 2026-07-17 (Test 4 common-outcome-space and Hamiltonian-scale repair).
+**Type:** bounded_theorem
 **Status:** scope-narrowed bounded operational note. The runner numerically
 verifies four consequences (Hamiltonian-support graph recovery, Born-rule
-`I_3 = 0` at machine precision, unitarity-vs-Lindblad behaviour, and a
+`I_3 = 0` at machine precision, fixed unitary/strong-dephasing toy behaviour,
+and a
 matched-scale local-H localization contrast) **after** the named inputs
 `(local d, local Hermitian H, Born readout)` are supplied. The "single axiom"
 framing is a definitional compression of those inputs into the phrase
@@ -25,21 +27,22 @@ earlier 2026-05-05 audit row recorded `claim_type: positive_theorem`; the
 2026-05-11 re-audit moved the row to `bounded_theorem`, matching this note's
 scope-narrowed framing. After this source refresh, independent re-audit owns
 the current status.
-**Status authority:** independent audit lane only.
+**Audit-status authority:** independent audit lane only.
 **Authority role:** records that the four numerical consequences follow
-from `(H = ⊗_i H_i, local Hermitian H, Born readout)` as a class-E
+from `(\mathcal H = ⊗_i \mathcal H_i, local Hermitian H, Born readout,
+"support = edges" rule)` as a class-E
 definitional substitution. **Does not** propose retained, positive-
-theorem, or framework-reduction promotion. The accepted-input ledger
-for the current paper package remains the Lattice + Quantum + Record
-front-door surface in `docs/MINIMAL_AXIOMS_2026-06-05.md`.
+theorem, or framework-reduction promotion. The current framework baseline
+remains Lattice + Qubit + Admissibility + Record in
+`docs/MINIMAL_AXIOMS_2026-06-29.md`.
 **Runner:** `scripts/frontier_single_axiom_hilbert.py`
 
 **2026-07-17 Test 4 repair:** the executable runner and this source note compare
 both propagators on the same 64 mutually exclusive computational-basis
 outcomes. Both probability distributions are normalized. Before propagation,
-each Hamiltonian is shifted by its trace (which changes only a global phase)
-and rescaled to centered RMS energy
-`sqrt(Tr(H_c^2)/64) = 1`. The fixed seed, initial state `|000000>`,
+the mean energy `Tr(H)/64` is subtracted from each Hamiltonian (which changes
+only a global phase) and the result is rescaled to centered RMS energy
+`sqrt(Tr(H_c^\dagger H_c)/64) = 1`. The fixed seed, initial state `|000000>`,
 dimensionless time `t=1`, and existing twofold spread-contrast criterion are
 unchanged. The control is now described accurately as a dense nonlocal
 Hamiltonian on the same factorized Hilbert space, rather than as an
@@ -49,14 +52,14 @@ it does not prove monotone distance decay or a general localization theorem.
 **Audit-dispatch parent candidate:** If a future independent audit
 evaluates whether this Hilbert-surface wrapper is a non-chain-closing
 alias/decorative handle, the current framework parent candidate is
-[`MINIMAL_AXIOMS_2026-06-05.md`](MINIMAL_AXIOMS_2026-06-05.md).
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
 This is source-side routing context only; it does not assert an
 `audit_status` or `effective_status`.
 
 **Scope note:** this is an operational support note for Hilbert-surface
-scoping. It is not the load-bearing accepted-input ledger for the current
-paper package, whose framework statement is the Lattice + Quantum + Record
-front-door surface recorded in `docs/MINIMAL_AXIOMS_2026-06-05.md`.
+scoping. It is not the load-bearing framework baseline for the current paper
+package, whose framework statement is the Lattice + Qubit + Admissibility +
+Record surface recorded in `docs/MINIMAL_AXIOMS_2026-06-29.md`.
 
 ## Source boundary (2026-06-12)
 
@@ -102,42 +105,45 @@ The audit's `verdict_rationale`:
 > a first-principles derivation from the stated axiom.*
 
 This note adopts the explicit class-E definitional-compression framing.
-The four named admitted inputs are listed in §"Admitted-context inputs"
-below; each is a real upstream gap, not an import-redirect. The
+The four named conditional inputs are listed in §"Explicit conditional
+inputs" below; each is a real upstream gap, not an import-redirect. The
 load-bearing step is `(local d, local H, Born readout) ⇒ four numerical
 consequences`, evaluated mechanically by the runner.
 
-**Admitted-context inputs (not derived in this note):**
+**Explicit conditional inputs (not derived in this note):**
 
-1. The local Hilbert dimension `d` for each tensor factor `H_i`.
-2. A Hermitian, local-support Hamiltonian `H` on `⊗_i H_i` (the
+1. The local Hilbert dimension `d` for each tensor factor `\mathcal H_i`.
+2. A Hermitian, local-support Hamiltonian `H` on
+   `\mathcal H = ⊗_i \mathcal H_i` (the
    restriction to neighbour-only support is part of the input, not a
    consequence of the tensor-product structure).
 3. The Born readout convention `P(outcome) = |<outcome | psi>|^2`
-   (chosen, not derived; replaced by `p`-norm in Test 2 to confirm
-   `I_3 ≠ 0` for `p ≠ 2`).
+   (chosen, not derived; replaced by the three tested `p`-norm controls in
+   Test 2, which give nonzero sampled `I_3`).
 4. The rule "interaction support of `H` on tensor factors **defines**
    the graph edges" (a graph-extraction convention used by Test 1).
 
 **Cited authorities (cited as related, not as authority closure):**
 
-- [`MINIMAL_AXIOMS_2026-06-05.md`](MINIMAL_AXIOMS_2026-06-05.md) — the
-  current Lattice + Quantum + Record front-door surface. Cited as related,
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) — the current
+  Lattice + Qubit + Admissibility + Record framework baseline. Cited as related,
   not as authority closure for the local-Hamiltonian or Born-readout inputs
-  imported above.
+  specified above.
 
 ## Question (scope-narrowed)
 
-Given the named admitted inputs `(local d, local Hermitian H, Born
+Given the named conditional inputs `(local d, local Hermitian H, Born
 readout, "support = edges" extraction rule)`, do the four numerical
-consequences (graph recovery, `I_3 = 0`, unitarity vs. Lindblad,
+consequences (graph recovery, `I_3 = 0`, fixed unitary/strong-dephasing toy
+behaviour,
 matched-scale local-H localization) follow mechanically?
 
-**Definitional compression (class-E):** packaging the four admitted
+**Definitional compression (class-E):** packaging the four conditional
 inputs together gives the phrase "a finite Hilbert space with local
-tensor product structure, `H = H_1 ⊗ H_2 ⊗ ... ⊗ H_N`". The
+tensor product structure,
+`\mathcal H = \mathcal H_1 ⊗ \mathcal H_2 ⊗ ... ⊗ \mathcal H_N`". The
 load-bearing step is the mechanical evaluation of the four consequences
-under those admitted inputs. **This is not** a first-principles
+under those conditional inputs. **This is not** a first-principles
 derivation of the inputs themselves from a strictly smaller axiom set.
 
 ## Tests and Results
@@ -157,14 +163,14 @@ components.
 | 4     | 8          | 8               | yes   |
 | 5     | 5          | 5               | yes   |
 
-Recovery rate: 100% **under the admitted "support = edges" extraction
+Recovery rate: 100% **under the supplied "support = edges" extraction
 rule (input 4 above)**. The graph in this test is the support of the
-admitted local `H` on the tensor factors, read out under the admitted
+supplied local `H` on the tensor factors, read out under the supplied
 extraction convention. The graph is not derived from the bare tensor-
 product Hilbert space; it is the runner-verified consequence of the
-admitted local `H` and the admitted extraction rule.
+supplied local `H` and the supplied extraction rule.
 
-### Test 2: Admitted Born readout gives `I_3 = 0`
+### Test 2: Supplied Born readout gives `I_3 = 0`
 
 Third-order interference I_3 computed for 200 random state pairs in
 dimension-8 Hilbert space.
@@ -176,16 +182,16 @@ dimension-8 Hilbert space.
 | p-norm p=3.0      | 2.0 x 10^-3  | 2.9 x 10^-2  |
 | p-norm p=4.0      | 1.0 x 10^-3  | 3.6 x 10^-2  |
 
-Under the admitted Born readout `P = |<·|·>|^2` (input 3 above),
-`I_3 = 0` to machine precision. Replacing the admitted Born readout
-with any `p`-norm at `p ≠ 2` gives `I_3 ≠ 0`. This confirms the Born
-readout is a real admitted input: the bare Hilbert tensor-product
-structure does not by itself force `p = 2`. The standard reading
+Under the supplied Born readout `P = |<·|·>|^2` (input 3 above),
+`I_3 = 0` to machine precision. In the same fixed-seed packet, the tested
+controls `p ∈ {1.5, 3, 4}` give nonzero sampled `I_3`. This confirms the Born
+readout is a real conditional input to this packet: the bare Hilbert
+tensor-product structure does not by itself force `p = 2`. The standard reading
 "the inner product forces the Born rule" is a definitional
 substitution: choosing the inner-product convention for readout is
 equivalent to choosing the `p = 2` norm.
 
-### Test 3: Hermitian generator gives unitary toy evolution; Lindblad control breaks it
+### Test 3: Hermitian generator gives unitary toy evolution; fixed strong-dephasing control changes the profile
 
 8-site chain with 1/r gravitational potential. Unitary evolution concentrates
 probability at the gravitational center. Lindblad (non-unitary) evolution with
@@ -199,12 +205,12 @@ increasing dephasing rate gamma:
 | 1.0   | -0.078        | Stuck near source                |
 | 2.0   | -0.167        | Localized at source              |
 
-Unitarity follows from the admitted Hermitian Hamiltonian (input 2
-above). Non-unitary evolution (open systems, Lindblad channels)
-destroys gravitational attraction — particles freeze at their source
-instead of migrating toward the potential minimum. The Hermiticity
-restriction is therefore a real admitted input: replacing it with
-non-Hermitian Lindblad dynamics changes the consequence.
+Unitarity follows from the supplied Hermitian Hamiltonian (input 2 above).
+For this fixed Euler-integrated toy control, adding computational-basis
+dephasing at `gamma = 2` leaves more probability at the source than at the toy
+potential center. This establishes only the stated unitary-versus-strong-
+dephasing profile contrast; it is not a general claim about Lindblad dynamics
+or gravitational attraction.
 
 ### Test 4: Matched-scale local-H packet gives bounded localization support
 
@@ -221,7 +227,8 @@ matches the generator scale by
 Thus both evolutions use `sigma_H = 1` at the same dimensionless time `t=1`.
 The shift has no observable effect because it contributes only a global phase;
 the RMS normalization matches the mean-square spectral generator scale. This
-is an explicit comparison convention, not a derived physical energy scale.
+is an explicit comparison convention, not a derived physical energy scale. It
+does not match bandwidths, higher spectral moments, or entrywise matrix scales.
 
 | Metric | Chain-local Hamiltonian | Dense nonlocal control |
 |---|---:|---:|
@@ -232,37 +239,37 @@ is an explicit comparison convention, not a derived physical energy scale.
 | Spread ratio | 4.0314x more localized | baseline |
 
 The participation ratios are now like-for-like: each is computed from one
-normalized distribution over the same 64 mutually exclusive outcomes. The
-comparison isolates the supplied chain-local support restriction by holding
-the factorization, readout basis, initial state, evolution time, and centered
-RMS energy fixed. The dense control does not respect the chain-local support
-restriction and is broader in this fixed sample. Test 4 does not establish
-monotone decay with graph distance. The result is not an ensemble statement
-and does not show that tensor-product factorization alone causes localization.
+normalized distribution over the same 64 mutually exclusive outcomes. Within
+this fixed construction, the comparison holds the factorization, readout
+basis, initial state, evolution time, and centered RMS energy fixed while
+changing the Hamiltonian support class. The dense control does not respect the
+chain-local support restriction and is broader in this fixed sample. Test 4
+does not establish monotone decay with graph distance. The result is not an
+ensemble statement and does not show that tensor-product factorization alone
+causes localization.
 
 ## Conclusion (scope-narrowed)
 
-Under the four named admitted inputs (local `d`, local Hermitian `H`,
+Under the four named conditional inputs (local `d`, local Hermitian `H`,
 Born readout, "support = edges" extraction rule), the four numerical
 consequences follow mechanically as evaluated by the runner:
 
 - The graph **is recovered** as the interaction support of the
-  admitted local `H` under the admitted "support = edges" extraction
+  supplied local `H` under the supplied "support = edges" extraction
   rule (Test 1).
 - The Born rule `I_3 = 0` **holds** at machine precision under the
-  admitted Born readout (Test 2). Replacing the readout with a
-  `p`-norm for `p ≠ 2` gives `I_3 ≠ 0`, confirming the readout is a
-  real input.
-- Unitary toy evolution follows from the admitted Hermitian generator
-  (Test 3); a non-Hermitian Lindblad replacement breaks the toy attraction
-  profile, confirming the Hermiticity restriction is a real input.
-- On the admitted factorized Hilbert space, the chain-local Hamiltonian gives a
+  supplied Born readout (Test 2). The three tested nonquadratic controls give
+  nonzero sampled `I_3`, confirming the readout is a real conditional input.
+- Unitary toy evolution follows from the supplied Hermitian generator
+  (Test 3); the fixed `gamma = 2` dephasing control leaves more probability at
+  the source than at the toy center. No broader Lindblad claim is made.
+- On the supplied factorized Hilbert space, the chain-local Hamiltonian gives a
   bounded fixed-seed localization contrast against a dense nonlocal control.
   Both participation ratios use the same normalized 64-outcome space and
   matched centered RMS energy. The runner does not claim monotone
   distance-decay or an ensemble theorem (Test 4).
 
-**Definitional-compression framing.** The four admitted inputs
+**Definitional-compression framing.** The four conditional inputs
 `(local d, local H, Born readout, "support = edges" rule)` can be
 packaged together under the phrase "a finite Hilbert space with local
 tensor product structure". This packaging is a class-E definitional
@@ -274,29 +281,27 @@ recorded.
 ## Honest scope limits (explicit, not import-redirect)
 
 1. **The local Hermitian `H` and its locality restriction are real
-   admitted inputs**, not consequences of the bare tensor-product
+   conditional inputs**, not consequences of the bare tensor-product
    Hilbert space. A tensor-product space with all-to-all interactions
    would not give spatial locality; the restriction is part of the
-   admitted package.
+   supplied packet.
 
-2. **The Born readout is a real admitted input.** Test 2 confirms this
-   by demonstrating `I_3 ≠ 0` under any `p`-norm with `p ≠ 2`. The
+2. **The Born readout is a real conditional input.** Test 2 shows nonzero
+   sampled `I_3` for `p ∈ {1.5, 3, 4}`; it does not test every `p ≠ 2`. The
    tensor-product structure does not by itself force `p = 2`.
 
-3. **The "support = edges" graph-extraction rule is a real admitted
+3. **The "support = edges" graph-extraction rule is a real conditional
    input.** Without it, Test 1's recovery procedure is not defined.
    The graph is not a consequence of the tensor-product structure
-   alone; it is the support of the admitted local `H` under the
-   admitted extraction rule.
+   alone; it is the support of the supplied local `H` under the
+   supplied extraction rule.
 
-4. **These are small-system demonstrations (5--8 sites).** The
-   argument is structural and holds at any scale, but large-scale
-   gravitational physics tests (distance law, etc.) use the 3D
-   lattice infrastructure in other frontier scripts.
+4. **These are fixed-seed small-system demonstrations (5--8 sites).** They do
+   not establish large-system scaling, an ensemble result, or a distance law.
 
-5. **Authority surface unchanged.** The accepted-input ledger for the
-   current paper package remains the Lattice + Quantum + Record front-door
-   surface in `docs/MINIMAL_AXIOMS_2026-06-05.md`. This note is a Hilbert-surface
+5. **Authority surface unchanged.** The current framework baseline remains the
+   Lattice + Qubit + Admissibility + Record surface in
+   `docs/MINIMAL_AXIOMS_2026-06-29.md`. This note is a Hilbert-surface
    operational support note; it does not propose framework-reduction
    promotion, nor does it claim to be a smaller axiom set than the
    recorded minimal-axioms surface.

--- a/logs/runner-cache/frontier_single_axiom_hilbert.txt
+++ b/logs/runner-cache/frontier_single_axiom_hilbert.txt
@@ -1,13 +1,13 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_single_axiom_hilbert.py
-runner_sha256: cdfa7098e788c596acdd5f8a51bb8d94a82b8a1edc7030ff4b20a5dab13ebbd9
+runner_sha256: 859d096bc264f5a09e9f46ec10b18dd077f7a05a15fa1d42cc7133c109608bdd
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.38
+elapsed_sec: 0.43
 status: ok
 ----- stdout -----
 SCOPE-NARROWED LOCAL TENSOR PRODUCT HILBERT SUPPORT
-Bounded operational checks under admitted inputs.
+Bounded operational checks under explicit conditions.
 
 ======================================================================
 TEST 1: Graph support recovery under the supplied extraction rule
@@ -19,10 +19,10 @@ TEST 1: Graph support recovery under the supplied extraction rule
   Trial 5: 5 input edges, 5 recovered, match=True
 
   Graph recovery rate: 100% (5/5)
-  PASS: graph support is recovered under the admitted extraction rule
+  PASS: graph support is recovered under the supplied extraction rule
 
 ======================================================================
-TEST 2: Born p=2 readout gives I_3 = 0; p != 2 controls fail
+TEST 2: Born p=2 readout gives I_3 = 0; tested nonquadratic controls are nonzero
 ======================================================================
 
   Hilbert space (Born rule, p=2):
@@ -35,11 +35,11 @@ TEST 2: Born p=2 readout gives I_3 = 0; p != 2 controls fail
     p=3.0: mean |I_3| = 1.9955e-03, max = 2.8700e-02  PASS (nonzero)
     p=4.0: mean |I_3| = 9.9409e-04, max = 3.6208e-02  PASS (nonzero)
 
-  Summary: admitted Born p=2 readout gives I_3 = 0: True
-  Summary: p != 2 violates Born rule: True
+  Summary: supplied Born p=2 readout gives I_3 = 0: True
+  Summary: tested p in {1.5, 3, 4} gives nonzero sampled I_3: True
 
 ======================================================================
-TEST 3: Hermitian generator gives unitary evolution; Lindblad control breaks it
+TEST 3: Hermitian generator is unitary; fixed strong-dephasing control changes the profile
 ======================================================================
 
   Unitary evolution:
@@ -47,7 +47,7 @@ TEST 3: Hermitian generator gives unitary evolution; Lindblad control breaks it
     Probability profile: [0.0012, 0.1316, 0.4253, 0.3107, 0.1069, 0.0212, 0.0028, 0.0003]
     Probability at center > edges: True
 
-  Lindblad (non-unitary) evolution:
+  Lindblad dephasing control (non-unitary open-system evolution):
     gamma=0.0: norm=1.0000, center_excess=+0.1036, profile=[-0.001, 0.123, 0.438, 0.316, 0.103, 0.019, 0.002, 0.000]
     gamma=0.1: norm=1.0000, center_excess=+0.0778, profile=[0.030, 0.151, 0.418, 0.289, 0.093, 0.017, 0.002, 0.000]
     gamma=0.5: norm=1.0000, center_excess=-0.0052, profile=[0.134, 0.233, 0.351, 0.208, 0.062, 0.011, 0.001, 0.000]
@@ -55,8 +55,8 @@ TEST 3: Hermitian generator gives unitary evolution; Lindblad control breaks it
     gamma=2.0: norm=1.0000, center_excess=-0.1669, profile=[0.367, 0.334, 0.205, 0.075, 0.017, 0.002, 0.000, 0.000]
 
   Unitary: probability migrates toward toy attraction center: True
-  Strong Lindblad: probability stuck at source (toy attraction broken): True
-  PASS: Hermitian/unitary control is load-bearing for the toy profile
+  Fixed gamma=2 control: source probability > toy-center probability: True
+  PASS: fixed unitary/strong-dephasing toy contrast
 
 ======================================================================
 TEST 4: Matched-scale local H gives bounded localization support
@@ -81,24 +81,24 @@ TEST 4: Matched-scale local H gives bounded localization support
   PASS: bounded matched-scale localization contrast
 
 ======================================================================
-SYNTHESIS: What the admitted-input packet supports
+SYNTHESIS: What the explicit-condition packet supports
 ======================================================================
 
-  Admitted packet:
+  Supplied packet:
     local factor dimensions + Hermitian local H + Born p=2 readout
     + support-as-edges extraction rule
 
   Test 1 — Support graph recovered:            PASS
     The adjacency graph is recovered from the supplied Hamiltonian support
-    under the admitted extraction rule.
+    under the supplied extraction rule.
 
   Test 2 — Born p=2 readout check:              PASS
-    I_3 = 0 under the admitted p=2 readout.
-    p != 2 theories violate Born rule (I_3 != 0).
+    I_3 = 0 under the supplied p=2 readout.
+    The tested p in {1.5, 3, 4} controls give nonzero sampled I_3.
 
   Test 3 — Hermitian/unitary control:           PASS
-    The supplied Hermitian H gives unitary evolution; a Lindblad replacement
-    destroys the toy attraction profile.
+    The supplied Hermitian H gives unitary evolution; the fixed gamma=2
+    dephasing control leaves more probability at the source than at the center.
 
   Test 4 — Bounded localization contrast:       PASS
     On the same normalized 64-outcome space and at matched centered RMS
@@ -106,8 +106,8 @@ SYNTHESIS: What the admitted-input packet supports
     control. The fixed sample does not prove monotone graph-distance decay.
 
   Conclusion:
-    The runner supports the bounded operational consequences of the admitted
-    packet. It does not derive the local Hamiltonian, locality restriction,
+    The runner supports the bounded operational consequences of the explicit
+    conditions. It does not derive the local Hamiltonian, locality restriction,
     Born readout, or support-as-edges rule from a bare Hilbert-space axiom,
     and it does not reduce the current framework axiom ledger.
 

--- a/logs/runner-cache/frontier_single_axiom_hilbert.txt
+++ b/logs/runner-cache/frontier_single_axiom_hilbert.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_single_axiom_hilbert.py
-runner_sha256: 7ea5ad4c646799e8c7a6a511efd4a37d15b534a99894288174f7ee6b42c1093c
+runner_sha256: cdfa7098e788c596acdd5f8a51bb8d94a82b8a1edc7030ff4b20a5dab13ebbd9
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.40
+elapsed_sec: 0.38
 status: ok
 ----- stdout -----
 SCOPE-NARROWED LOCAL TENSOR PRODUCT HILBERT SUPPORT
@@ -59,39 +59,26 @@ TEST 3: Hermitian generator gives unitary evolution; Lindblad control breaks it
   PASS: Hermitian/unitary control is load-bearing for the toy profile
 
 ======================================================================
-TEST 4: Tensor product factorization gives bounded localization support
+TEST 4: Matched-scale local H gives bounded localization support
 ======================================================================
 
-  (a) Tensor product space (6-qubit chain):
-    Site probabilities: [0.6348, 0.3284, 0.2628, 0.2339, 0.4075, 0.4001]
-    Locality gradient (near > far): False
-    Diagnostic only: the fixed-seed amplitudes are not claimed to decay monotonically.
+  Common comparison contract:
+    Outcome space: 64 mutually exclusive computational-basis outcomes
+    Initial state: |000000>; dimensionless time: 1.0
+    Centered RMS energy before matching: local=2.425855, dense=7.982713
+    Centered RMS energy after matching:  local=1.000000000000, dense=1.000000000000
+    Probability normalization error:    local=2.220e-16, dense=3.331e-16
 
-  (b) Unfactored space (random 64x64 Hamiltonian):
-    Probability spread (std): 1.6543e-02
-    Max probability: 6.2129e-02
-    Min probability: 5.2271e-05
+  Participation ratio on the common outcome space:
+    Chain-local Hamiltonian: PR = 3.2706 / 64 outcomes
+    Dense nonlocal control:  PR = 13.1853 / 64 outcomes
 
-  Participation ratio (how spread is the propagator):
-    Local Hamiltonian:  PR = 1.0 / 6 sites
-    Random Hamiltonian: PR = 30.2 / 64 states
-
-  Distance dependence of propagation:
-    Local (tensor product):
-      distance 0: |G| = 0.279140
-      distance 1: |G| = 0.115061
-      distance 2: |G| = 0.181217
-      distance 3: |G| = 0.104496
-      distance 4: |G| = 0.202841
-      distance 5: |G| = 0.202112
-    Random (unfactored):
-      Top 5 amplitudes: [0.249257, 0.247233, 0.239206, 0.236498, 0.233064]
-      Bottom 5: [0.025534, 0.013398, 0.012560, 0.010231, 0.007230]
-      Ratio top/median: 2.51
-
-  Spread ratio (random/local): 29.0x
-  Tensor-product/local-H packet is more localized by spread ratio: True
-  PASS: bounded localization contrast
+  Spread ratio (dense/local): 4.0314x
+  Same 64-outcome space: True
+  Both distributions normalized: True
+  Centered RMS energies matched: True
+  Existing >2x spread criterion: True
+  PASS: bounded matched-scale localization contrast
 
 ======================================================================
 SYNTHESIS: What the admitted-input packet supports
@@ -114,9 +101,9 @@ SYNTHESIS: What the admitted-input packet supports
     destroys the toy attraction profile.
 
   Test 4 — Bounded localization contrast:       PASS
-    The supplied tensor-product/local-H packet is far less spread than an
-    unfactored random Hamiltonian of the same dimension. The fixed sample
-    does not prove monotone graph-distance decay.
+    On the same normalized 64-outcome space and at matched centered RMS
+    energy, the supplied chain-local H is less spread than a dense nonlocal
+    control. The fixed sample does not prove monotone graph-distance decay.
 
   Conclusion:
     The runner supports the bounded operational consequences of the admitted
@@ -125,6 +112,7 @@ SYNTHESIS: What the admitted-input packet supports
     and it does not reduce the current framework axiom ledger.
 
 Total runtime: 0.1s
+OVERALL: PASS
 
 ----- stderr -----
 

--- a/scripts/frontier_single_axiom_hilbert.py
+++ b/scripts/frontier_single_axiom_hilbert.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Scope-narrowed operational checks for a local tensor-product Hilbert packet.
 
-This runner verifies consequences after four inputs are supplied:
+This runner verifies consequences after four explicit conditions are supplied:
 
 1. local factor dimensions;
 2. a Hermitian Hamiltonian with stipulated local support;
@@ -11,8 +11,9 @@ This runner verifies consequences after four inputs are supplied:
 It does not derive those inputs from a bare Hilbert-space axiom, reduce the
 current framework axiom ledger, or prove a monotone graph-distance decay law.
 Test 4's valid support is the participation-ratio/spread contrast between a
-supplied local tensor-product Hamiltonian and a dense nonlocal control on the
-same normalized computational-basis outcome space.  The two generators are
+supplied chain-local Hamiltonian and a dense nonlocal control on the same
+factorized Hilbert space and normalized computational-basis outcome space. The
+two generators are
 centered and matched to the same RMS energy before propagation.
 
 PStack experiment: single-axiom-hilbert
@@ -289,13 +290,13 @@ def test_graph_emergence():
 
     success_rate = sum(results) / len(results)
     print(f"\n  Graph recovery rate: {success_rate:.0%} ({sum(results)}/{len(results)})")
-    print(f"  PASS: graph support is recovered under the admitted extraction rule" if success_rate == 1.0
+    print(f"  PASS: graph support is recovered under the supplied extraction rule" if success_rate == 1.0
           else f"  PARTIAL: {success_rate:.0%} exact recovery")
     return success_rate
 
 
 # ============================================================================
-# Test 2: admitted Born p=2 readout gives I_3 = 0.
+# Test 2: supplied Born p=2 readout gives I_3 = 0.
 # ============================================================================
 
 def compute_I3_hilbert(dim: int, n_trials: int, rng: np.random.Generator) -> list[float]:
@@ -386,9 +387,9 @@ def compute_I3_pnorm(p: float, dim: int, n_trials: int,
 
 
 def test_born_rule():
-    """Test 2: Born p=2 readout and p != 2 controls."""
+    """Test 2: Born p=2 readout and three tested nonquadratic controls."""
     print("\n" + "=" * 70)
-    print("TEST 2: Born p=2 readout gives I_3 = 0; p != 2 controls fail")
+    print("TEST 2: Born p=2 readout gives I_3 = 0; tested nonquadratic controls are nonzero")
     print("=" * 70)
 
     rng = np.random.default_rng(123)
@@ -421,13 +422,13 @@ def test_born_rule():
     all_nonzero = all(v > 1e-6 for v in p_norm_results.values())
     born_auto = max_hilbert < 1e-10
 
-    print(f"\n  Summary: admitted Born p=2 readout gives I_3 = 0: {born_auto}")
-    print(f"  Summary: p != 2 violates Born rule: {all_nonzero}")
+    print(f"\n  Summary: supplied Born p=2 readout gives I_3 = 0: {born_auto}")
+    print(f"  Summary: tested p in {{1.5, 3, 4}} gives nonzero sampled I_3: {all_nonzero}")
     return born_auto and all_nonzero
 
 
 # ============================================================================
-# Test 3: Hermitian/unitary toy evolution versus Lindblad replacement.
+# Test 3: Hermitian/unitary toy evolution versus fixed dephasing control.
 # ============================================================================
 
 def propagator_unitary(H: np.ndarray, source: int, t: float) -> np.ndarray:
@@ -481,9 +482,9 @@ def propagator_lindblad(H: np.ndarray, source: int, t: float,
 
 
 def test_unitarity():
-    """Test 3: Hermitian/unitary evolution versus Lindblad replacement."""
+    """Test 3: Hermitian/unitary evolution versus fixed dephasing control."""
     print("\n" + "=" * 70)
-    print("TEST 3: Hermitian generator gives unitary evolution; Lindblad control breaks it")
+    print("TEST 3: Hermitian generator is unitary; fixed strong-dephasing control changes the profile")
     print("=" * 70)
 
     if not HAS_SCIPY:
@@ -524,7 +525,7 @@ def test_unitarity():
     print(f"    Probability at center > edges: {attracted}")
 
     # Lindblad (non-unitary) propagator at various damping rates
-    print(f"\n  Lindblad (non-unitary) evolution:")
+    print(f"\n  Lindblad dephasing control (non-unitary open-system evolution):")
     gammas = [0.0, 0.1, 0.5, 1.0, 2.0]
     for gamma in gammas:
         prob_lindblad = propagator_lindblad(H, source, t, gamma, n_steps=200)
@@ -543,7 +544,7 @@ def test_unitarity():
 
     print(f"\n  Unitary: probability migrates toward toy attraction center: "
           f"{attraction_works_unitary}")
-    print(f"  Strong Lindblad: probability stuck at source (toy attraction broken): "
+    print(f"  Fixed gamma=2 control: source probability > toy-center probability: "
           f"{attraction_broken_lindblad}")
     probability_conserved = abs(norm_unitary - 1.0) < 1e-10
     passed = (
@@ -551,8 +552,8 @@ def test_unitarity():
         and attraction_works_unitary
         and attraction_broken_lindblad
     )
-    print("  PASS: Hermitian/unitary control is load-bearing for the toy profile" if passed
-          else "  FAIL: fixed unitary/Lindblad control semantics")
+    print("  PASS: fixed unitary/strong-dephasing toy contrast" if passed
+          else "  FAIL: fixed unitary/strong-dephasing control semantics")
 
     return passed
 
@@ -565,7 +566,8 @@ def test_matched_scale_localization():
     """Test 4: local support gives a bounded fixed-seed localization contrast.
 
     Compare:
-    (a) H = H_1 x H_2 x ... x H_N with a chain-local Hamiltonian;
+    (a) the factorized space H_space = H_1 x H_2 x ... x H_N with a
+        chain-local Hamiltonian;
     (b) the same factorized 64-dimensional space with a dense random
         Hamiltonian that does not respect the chain-local support restriction.
 
@@ -670,31 +672,31 @@ def test_matched_scale_localization():
 
 
 # ============================================================================
-# Synthesis: admitted-input operational support.
+# Synthesis: explicit-condition operational support.
 # ============================================================================
 
 def synthesis(t1: float, t2: bool, t3: bool, t4: bool):
-    """Print the admitted-input synthesis of all four tests."""
+    """Print the explicit-condition synthesis of all four tests."""
     print("\n" + "=" * 70)
-    print("SYNTHESIS: What the admitted-input packet supports")
+    print("SYNTHESIS: What the explicit-condition packet supports")
     print("=" * 70)
 
     print(f"""
-  Admitted packet:
+  Supplied packet:
     local factor dimensions + Hermitian local H + Born p=2 readout
     + support-as-edges extraction rule
 
   Test 1 — Support graph recovered:            {'PASS' if t1 == 1.0 else 'PARTIAL'}
     The adjacency graph is recovered from the supplied Hamiltonian support
-    under the admitted extraction rule.
+    under the supplied extraction rule.
 
   Test 2 — Born p=2 readout check:              {'PASS' if t2 else 'FAIL'}
-    I_3 = 0 under the admitted p=2 readout.
-    p != 2 theories violate Born rule (I_3 != 0).
+    I_3 = 0 under the supplied p=2 readout.
+    The tested p in {{1.5, 3, 4}} controls give nonzero sampled I_3.
 
   Test 3 — Hermitian/unitary control:           {'PASS' if t3 else 'FAIL'}
-    The supplied Hermitian H gives unitary evolution; a Lindblad replacement
-    destroys the toy attraction profile.
+    The supplied Hermitian H gives unitary evolution; the fixed gamma=2
+    dephasing control leaves more probability at the source than at the center.
 
   Test 4 — Bounded localization contrast:       {'PASS' if t4 else 'FAIL'}
     On the same normalized 64-outcome space and at matched centered RMS
@@ -702,8 +704,8 @@ def synthesis(t1: float, t2: bool, t3: bool, t4: bool):
     control. The fixed sample does not prove monotone graph-distance decay.
 
   Conclusion:
-    The runner supports the bounded operational consequences of the admitted
-    packet. It does not derive the local Hamiltonian, locality restriction,
+    The runner supports the bounded operational consequences of the explicit
+    conditions. It does not derive the local Hamiltonian, locality restriction,
     Born readout, or support-as-edges rule from a bare Hilbert-space axiom,
     and it does not reduce the current framework axiom ledger.
 """)
@@ -715,7 +717,7 @@ def synthesis(t1: float, t2: bool, t3: bool, t4: bool):
 
 def main() -> int:
     print("SCOPE-NARROWED LOCAL TENSOR PRODUCT HILBERT SUPPORT")
-    print("Bounded operational checks under admitted inputs.\n")
+    print("Bounded operational checks under explicit conditions.\n")
 
     t0 = time.time()
 

--- a/scripts/frontier_single_axiom_hilbert.py
+++ b/scripts/frontier_single_axiom_hilbert.py
@@ -11,8 +11,9 @@ This runner verifies consequences after four inputs are supplied:
 It does not derive those inputs from a bare Hilbert-space axiom, reduce the
 current framework axiom ledger, or prove a monotone graph-distance decay law.
 Test 4's valid support is the participation-ratio/spread contrast between a
-supplied local tensor-product Hamiltonian and an unfactored random Hamiltonian
-of the same dimension.
+supplied local tensor-product Hamiltonian and a dense nonlocal control on the
+same normalized computational-basis outcome space.  The two generators are
+centered and matched to the same RMS energy before propagation.
 
 PStack experiment: single-axiom-hilbert
 """
@@ -94,6 +95,62 @@ def random_local_hamiltonian(n_sites: int, d: int, edges: list[tuple[int, int]],
                 H += h_pair[row, col] * kron_list(ops)
 
     return H
+
+
+def match_centered_rms_energy(
+    H: np.ndarray, target_rms_energy: float = 1.0
+) -> tuple[np.ndarray, float]:
+    """Remove the global energy origin and match the RMS generator scale.
+
+    For dimension ``D``, the centered RMS energy is
+
+        sqrt(Tr(H_c^dagger H_c) / D),
+        H_c = H - Tr(H) I / D.
+
+    The trace shift changes only the propagator's global phase.  Dividing by
+    this RMS energy gives local and dense Hamiltonians the same typical
+    dimensionless evolution scale without matching either matrix entrywise.
+    """
+    D = H.shape[0]
+    if H.shape != (D, D):
+        raise ValueError("Hamiltonian must be square")
+    if target_rms_energy <= 0.0:
+        raise ValueError("target_rms_energy must be positive")
+
+    hermiticity_residual = np.linalg.norm(H - H.conj().T, ord="fro")
+    if hermiticity_residual > 1e-10:
+        raise ValueError(f"Hamiltonian is not Hermitian: residual={hermiticity_residual}")
+
+    H_centered = H - (np.trace(H) / D) * np.eye(D, dtype=complex)
+    rms_energy = float(np.linalg.norm(H_centered, ord="fro") / np.sqrt(D))
+    if not np.isfinite(rms_energy) or rms_energy <= 0.0:
+        raise ValueError("Hamiltonian has no finite nonzero centered RMS energy")
+
+    return H_centered * (target_rms_energy / rms_energy), rms_energy
+
+
+def normalized_basis_probabilities(
+    H: np.ndarray, source_state: np.ndarray, t: float
+) -> tuple[np.ndarray, float]:
+    """Propagate and return one normalized distribution over basis outcomes."""
+    amplitudes = expm(-1j * H * t) @ source_state
+    probabilities = np.abs(amplitudes) ** 2
+    total = float(np.sum(probabilities))
+    normalization_error = abs(total - 1.0)
+    if normalization_error > 1e-10:
+        raise ValueError(f"Unitary outcome probabilities are not normalized: sum={total}")
+    return probabilities / total, normalization_error
+
+
+def participation_ratio(probabilities: np.ndarray) -> float:
+    """Effective number of populated mutually exclusive outcomes."""
+    if probabilities.ndim != 1:
+        raise ValueError("Participation-ratio input must be one-dimensional")
+    if np.min(probabilities) < -1e-15:
+        raise ValueError("Participation-ratio input contains negative probabilities")
+    if abs(float(np.sum(probabilities)) - 1.0) > 1e-10:
+        raise ValueError("Participation-ratio input must be normalized")
+    return float(1.0 / np.sum(probabilities ** 2))
 
 
 # ============================================================================
@@ -488,31 +545,38 @@ def test_unitarity():
           f"{attraction_works_unitary}")
     print(f"  Strong Lindblad: probability stuck at source (toy attraction broken): "
           f"{attraction_broken_lindblad}")
-    print(f"  PASS: Hermitian/unitary control is load-bearing for the toy profile" if attraction_broken_lindblad
-          else f"  NOTE: Lindblad still shows some attraction (weaker test)")
+    probability_conserved = abs(norm_unitary - 1.0) < 1e-10
+    passed = (
+        probability_conserved
+        and attraction_works_unitary
+        and attraction_broken_lindblad
+    )
+    print("  PASS: Hermitian/unitary control is load-bearing for the toy profile" if passed
+          else "  FAIL: fixed unitary/Lindblad control semantics")
 
-    return True
+    return passed
 
 
 # ============================================================================
-# Test 4: tensor-product/local-H packet gives bounded localization support.
+# Test 4: matched-scale local-H versus dense-control localization support.
 # ============================================================================
 
-def test_tensor_product_essential():
-    """Test 4: tensor-product factorization gives bounded localization support.
+def test_matched_scale_localization():
+    """Test 4: local support gives a bounded fixed-seed localization contrast.
 
     Compare:
-    (a) Tensor product space H = H_1 x H_2 x ... x H_N with local Hamiltonian
-        -> supplies a graph and localized propagator support
-    (b) Single unfactored Hilbert space of the same dimension with a random
-        Hamiltonian -> no supplied graph-distance notion
+    (a) H = H_1 x H_2 x ... x H_N with a chain-local Hamiltonian;
+    (b) the same factorized 64-dimensional space with a dense random
+        Hamiltonian that does not respect the chain-local support restriction.
 
-    The pass criterion is the participation-ratio/spread contrast. The
-    fixed-seed local amplitudes are printed as a diagnostic only and are not
-    required to decay monotonically with graph distance.
+    Both propagators start from the same state, use centered generators with
+    identical RMS energy, and are represented by normalized distributions on
+    the same 64 mutually exclusive computational-basis outcomes.  The pass
+    criterion retains the existing 2x participation-ratio contrast.  No
+    monotone graph-distance claim is made.
     """
     print("\n" + "=" * 70)
-    print("TEST 4: Tensor product factorization gives bounded localization support")
+    print("TEST 4: Matched-scale local H gives bounded localization support")
     print("=" * 70)
 
     if not HAS_SCIPY:
@@ -528,90 +592,81 @@ def test_tensor_product_essential():
 
     # Local Hamiltonian on 1D chain
     edges_chain = [(i, i+1) for i in range(n_sites - 1)]
-    H_local = random_local_hamiltonian(n_sites, d, edges_chain, rng, coupling_strength=0.5)
+    H_local_raw = random_local_hamiltonian(
+        n_sites, d, edges_chain, rng, coupling_strength=0.5
+    )
 
-    # Propagator from site 0
+    # Dense control on the same C^64 outcome space.  It shares the supplied
+    # factor labels for a like-for-like readout, but not the chain-local
+    # Hamiltonian support restriction.
+    H_dense_raw = random_hermitian(D, rng)
+
+    target_rms_energy = 1.0
+    H_local, local_rms_before = match_centered_rms_energy(
+        H_local_raw, target_rms_energy
+    )
+    H_dense, dense_rms_before = match_centered_rms_energy(
+        H_dense_raw, target_rms_energy
+    )
+    local_rms_after = float(np.linalg.norm(H_local, ord="fro") / np.sqrt(D))
+    dense_rms_after = float(np.linalg.norm(H_dense, ord="fro") / np.sqrt(D))
+
+    # Same initial outcome and same dimensionless evolution time.
     source_state = np.zeros(D, dtype=complex)
-    source_state[0] = 1.0  # |000000> = site 0 in computational basis
+    source_state[0] = 1.0  # |000000>
     t = 1.0
-    G_local = expm(-1j * H_local * t) @ source_state
+    probs_local, local_normalization_error = normalized_basis_probabilities(
+        H_local, source_state, t
+    )
+    probs_dense, dense_normalization_error = normalized_basis_probabilities(
+        H_dense, source_state, t
+    )
 
-    # Measure probability at each site (trace over other qubits)
-    probs_local = []
-    for site in range(n_sites):
-        # Probability of finding excitation at site `site`
-        # = sum over all basis states with qubit `site` = 1
-        p = 0.0
-        for basis in range(D):
-            # Check if bit `site` is set (using big-endian convention)
-            bit = (basis >> (n_sites - 1 - site)) & 1
-            if bit == 1:
-                p += abs(G_local[basis]) ** 2
-        probs_local.append(p)
+    print("\n  Common comparison contract:")
+    print(f"    Outcome space: {D} mutually exclusive computational-basis outcomes")
+    print(f"    Initial state: |{'0' * n_sites}>; dimensionless time: {t:.1f}")
+    print(
+        "    Centered RMS energy before matching: "
+        f"local={local_rms_before:.6f}, dense={dense_rms_before:.6f}"
+    )
+    print(
+        "    Centered RMS energy after matching:  "
+        f"local={local_rms_after:.12f}, dense={dense_rms_after:.12f}"
+    )
+    print(
+        "    Probability normalization error:    "
+        f"local={local_normalization_error:.3e}, dense={dense_normalization_error:.3e}"
+    )
 
-    print(f"\n  (a) Tensor product space (6-qubit chain):")
-    print(f"    Site probabilities: [{', '.join(f'{p:.4f}' for p in probs_local)}]")
+    # PR = 1 / sum_z p(z)^2 on the same normalized 64-outcome space.
+    PR_local = participation_ratio(probs_local)
+    PR_dense = participation_ratio(probs_dense)
 
-    # Check locality: nearby sites have higher probability than far sites
-    local_gradient = all(probs_local[i] >= probs_local[i+1] - 0.05
-                        for i in range(n_sites - 1))
-    print(f"    Locality gradient (near > far): {local_gradient}")
-    print("    Diagnostic only: the fixed-seed amplitudes are not claimed to decay monotonically.")
-
-    # --- (b) Unfactored space: random Hamiltonian, same dimension ---
-    H_random = random_hermitian(D, rng)
-
-    G_random = expm(-1j * H_random * t) @ source_state
-    probs_random = np.abs(G_random) ** 2
-
-    # In the unfactored space, there's no meaningful "site" decomposition
-    # So we just look at the probability distribution
-    print(f"\n  (b) Unfactored space (random 64x64 Hamiltonian):")
-    print(f"    Probability spread (std): {np.std(probs_random):.4e}")
-    print(f"    Max probability: {np.max(probs_random):.4e}")
-    print(f"    Min probability: {np.min(probs_random):.4e}")
-
-    # Key comparison: measure the "effective locality" via participation ratio
-    # PR = 1 / sum(p_i^2) -- measures how many states are populated
-    PR_local = 1.0 / np.sum(np.array(probs_local) ** 2) if sum(probs_local) > 0 else D
-    PR_random = 1.0 / np.sum(probs_random ** 2)
-
-    print(f"\n  Participation ratio (how spread is the propagator):")
-    print(f"    Local Hamiltonian:  PR = {PR_local:.1f} / {n_sites} sites")
-    print(f"    Random Hamiltonian: PR = {PR_random:.1f} / {D} states")
-
-    # --- (c) Distance-dependent propagation test ---
-    # In the tensor product space, graph-distance amplitudes are inspectable.
-    # This fixed-seed sample is not used as a monotone-decay proof. In the
-    # unfactored space, there is no graph-distance notion to inspect.
-
-    print(f"\n  Distance dependence of propagation:")
-
-    # For local H: compute |G| at graph distances 0, 1, 2, ...
-    print(f"    Local (tensor product):")
-    for dist in range(n_sites):
-        # Target state: single excitation at site `dist`
-        target = np.zeros(D, dtype=complex)
-        target[1 << (n_sites - 1 - dist)] = 1.0
-        amp = abs(target.conj() @ G_local)
-        print(f"      distance {dist}: |G| = {amp:.6f}")
-
-    # For random H: no notion of distance, check spread
-    # Sort amplitudes and compare decay
-    amps_sorted = sorted(np.abs(G_random), reverse=True)
-    print(f"    Random (unfactored):")
-    print(f"      Top 5 amplitudes: [{', '.join(f'{a:.6f}' for a in amps_sorted[:5])}]")
-    print(f"      Bottom 5: [{', '.join(f'{a:.6f}' for a in amps_sorted[-5:])}]")
-    print(f"      Ratio top/median: {amps_sorted[0] / amps_sorted[D//2]:.2f}")
+    print("\n  Participation ratio on the common outcome space:")
+    print(f"    Chain-local Hamiltonian: PR = {PR_local:.4f} / {D} outcomes")
+    print(f"    Dense nonlocal control:  PR = {PR_dense:.4f} / {D} outcomes")
 
     # --- Summary ---
-    spread_ratio = PR_random / PR_local
-    print(f"\n  Spread ratio (random/local): {spread_ratio:.1f}x")
-    print(f"  Tensor-product/local-H packet is more localized by spread ratio: {spread_ratio > 2.0}")
-    print(f"  PASS: bounded localization contrast" if spread_ratio > 2.0
-          else f"  MARGINAL: ratio only {spread_ratio:.1f}x")
+    same_outcome_space = probs_local.shape == probs_dense.shape == (D,)
+    normalized = max(local_normalization_error, dense_normalization_error) < 1e-10
+    scale_matched = max(
+        abs(local_rms_after - target_rms_energy),
+        abs(dense_rms_after - target_rms_energy),
+        abs(local_rms_after - dense_rms_after),
+    ) < 1e-12
+    spread_ratio = PR_dense / PR_local
+    contrast_pass = spread_ratio > 2.0
+    passed = same_outcome_space and normalized and scale_matched and contrast_pass
 
-    return spread_ratio > 2.0
+    print(f"\n  Spread ratio (dense/local): {spread_ratio:.4f}x")
+    print(f"  Same 64-outcome space: {same_outcome_space}")
+    print(f"  Both distributions normalized: {normalized}")
+    print(f"  Centered RMS energies matched: {scale_matched}")
+    print(f"  Existing >2x spread criterion: {contrast_pass}")
+    print("  PASS: bounded matched-scale localization contrast" if passed
+          else "  FAIL: common-space matched-scale localization contract")
+
+    return passed
 
 
 # ============================================================================
@@ -642,9 +697,9 @@ def synthesis(t1: float, t2: bool, t3: bool, t4: bool):
     destroys the toy attraction profile.
 
   Test 4 — Bounded localization contrast:       {'PASS' if t4 else 'FAIL'}
-    The supplied tensor-product/local-H packet is far less spread than an
-    unfactored random Hamiltonian of the same dimension. The fixed sample
-    does not prove monotone graph-distance decay.
+    On the same normalized 64-outcome space and at matched centered RMS
+    energy, the supplied chain-local H is less spread than a dense nonlocal
+    control. The fixed sample does not prove monotone graph-distance decay.
 
   Conclusion:
     The runner supports the bounded operational consequences of the admitted
@@ -658,7 +713,7 @@ def synthesis(t1: float, t2: bool, t3: bool, t4: bool):
 # Main
 # ============================================================================
 
-def main():
+def main() -> int:
     print("SCOPE-NARROWED LOCAL TENSOR PRODUCT HILBERT SUPPORT")
     print("Bounded operational checks under admitted inputs.\n")
 
@@ -667,13 +722,16 @@ def main():
     t1 = test_graph_emergence()
     t2 = test_born_rule()
     t3 = test_unitarity()
-    t4 = test_tensor_product_essential()
+    t4 = test_matched_scale_localization()
 
     synthesis(t1, t2, t3, t4)
 
     elapsed = time.time() - t0
     print(f"Total runtime: {elapsed:.1f}s")
+    all_pass = t1 == 1.0 and t2 and t3 and t4
+    print(f"OVERALL: {'PASS' if all_pass else 'FAIL'}")
+    return 0 if all_pass else 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Audit blocker (verbatim)

> The runner performs substantive calculations rather than merely printing expected results, and the first three fixed-seed checks support their narrowly stated operational observations. The Test 4 spread ratio compares participation ratios defined on different, differently normalized outcome spaces, so the reported factor of 29 is not evidence that the local tensor-product propagator is more localized. Because one of the four claimed consequences fails on its own verification method, the complete bounded claim does not close.

> Recompute Test 4 with both propagators represented in the same normalized outcome space and with comparable Hamiltonian scaling, then rerun the fixed-seed packet.

## Repair

- Represent both propagators as normalized probabilities on the same 64 mutually exclusive computational-basis outcomes of the same factorized Hilbert space.
- Use the same `|000000>` source and dimensionless `t = 1`, and retain fixed seed 999.
- Remove each Hamiltonian's global energy origin and match the centered RMS generator scale, `sqrt(Tr(H_c^dagger H_c) / 64) = 1`, before propagation.
- Compare the chain-local Hamiltonian with a dense nonlocal control; do not describe the control as an unfactored outcome space.
- Preserve the existing `dense/local > 2` criterion. The repaired fixed sample gives `PR_local = 3.270634323270`, `PR_dense = 13.185329911798`, and ratio `4.031428954923`.
- Keep the conclusion bounded: no ensemble result, monotone distance-decay claim, or derivation of the explicit conditional inputs.

Tests 1-3 retain their accepted fixed-seed computations and numerical results. The runner now also returns a nonzero process status if any stated Test 1-4 contract fails.

## Exact verification

All final checks were run from disposable review worktree commit `c7744d247f1ed3629fb063177c95e935c16748fe` against current `origin/main` (`de9d4f2b2a`). The review fix pass updated the note to the June 29 baseline, replaced legacy admission vocabulary, corrected the Hilbert-space factorization notation, and narrowed the Test 2/3 prose to the controls actually computed; it did not change the Test 1-4 numerical methods or thresholds.

- `python3 -m py_compile scripts/frontier_single_axiom_hilbert.py` — PASS.
- `python3 scripts/frontier_single_axiom_hilbert.py` — PASS: Test 1 `5/5`; Test 2 `max |I_3| = 2.64e-16` with nonzero p-norm controls; Test 3 probability conservation and fixed strong-dephasing control PASS; Test 4 common 64-outcome normalization, matched scale, and `4.0314x` contrast PASS; `OVERALL: PASS`.
- `python3 scripts/cached_runner_output.py --check-only scripts/frontier_single_axiom_hilbert.py` — fresh cache PASS.
- Independent inline NumPy recomputation of Test 4 from the matrix definitions, using an eigensystem propagator rather than the runner's `expm` path — PASS: both probability vectors have shape `(64,)` and sum to one; raw centered RMS scales are `2.425855346850` and `7.982712715289`, both scaled RMS values are one, PRs are `3.270634323270` and `13.185329911798`, the ratio is `4.031428954923`, trace-shift probability errors are at most `1.110e-16`, and repeated matrices/probabilities are byte-identical.
- `python3 scripts/vocab_lint.py --report-only docs/SINGLE_AXIOM_HILBERT_NOTE.md scripts/frontier_single_axiom_hilbert.py logs/runner-cache/frontier_single_axiom_hilbert.txt` — 0 violations.
- `bash docs/audit/scripts/run_pipeline.sh` — PASS; repository invariants `rows=3767 retained_grade=394 link_violations=0 class_f_violations=0`.
- `python3 docs/audit/scripts/audit_lint.py --strict` — PASS with no errors (existing repository warnings/notices only). The generated row is `bounded_theorem / unaudited`, with the authoritative `audited_failed` result preserved in history for independent re-audit.
- `git diff --check origin/main...HEAD` and the review-loop portable-link/no-go/pipeline-output-stripped gates — PASS.
- `python3 scripts/frontier_extension_lane_b_protects_lane_a_joint_composition_narrow.py` — `PASS=355, FAIL=0`.
- `python3 scripts/frontier_chronology_operational_no_past_signaling.py` — unchanged pre-existing exit 1 on both branch and pristine `origin/main`: missing pinned phrase `no derivation of the retained single-clock surface itself`.
- `python3 scripts/frontier_physical_lattice_necessity.py` — unchanged pre-existing exit 1 on both branch and pristine `origin/main`: stale `fixed_gauge_surface_beta6` text pin. Its Hilbert-surface checks are informational, not load-bearing.

The full pipeline was validation-only. No audit verdict, ledger/status, rendered audit/publication output, missing-derivation prompt, or effective-status file is included in this PR.
