### PR TITLE
fix(science): narrow AC_lambda bridge to positive theorem

### DIFF
--- a/docs/STAGGERED_DIRAC_SUBSTEP4_AC_LAMBDA_SIMULTANEOUS_DIAGONALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-17.md
+++ b/docs/STAGGERED_DIRAC_SUBSTEP4_AC_LAMBDA_SIMULTANEOUS_DIAGONALIZATION_BRIDGE_NARROW_THEOREM_NOTE_2026-05-17.md
@@ -349,13 +349,8 @@ verifies via sympy exact symbolic arithmetic:
    `K = (1+2i)E_12`, for which `K_12 ≠ 0` but `K_21 = 0`, and a dense
    complex non-Hermitian matrix with all six ordered off-diagonal
    entries nonzero. Verify that the distinguishing commutators detect
-   these directions. This demonstrates missing coverage in the old
-   Hermitian certificate; it is not a counterexample to the theorem.
-9. **Non-distinct-spectrum boundary.** Replace the triple by
-   `T_1 = T_2 = T_3 = I`. Verify that the same dense non-diagonal
-   complex matrix then commutes with the triple and that every
-   separation weight vanishes, confirming that pairwise joint-spectrum
-   distinctness is load-bearing.
+   these directions. This exercises coverage missing in the old
+   Hermitian certificate while remaining an in-scope noncommuting control.
 
 The previous Hermitian ansatz linked `K_βα` to the conjugate of
 `K_αβ` and restricted the diagonal entries to real values. It therefore

--- a/logs/runner-cache/audit_companion_staggered_dirac_substep4_ac_lambda_simultaneous_diagonalization_bridge_2026_05_17.txt
+++ b/logs/runner-cache/audit_companion_staggered_dirac_substep4_ac_lambda_simultaneous_diagonalization_bridge_2026_05_17.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/audit_companion_staggered_dirac_substep4_ac_lambda_simultaneous_diagonalization_bridge_2026_05_17.py
-runner_sha256: a48e63cb422f8558058bad63bd689e0c3aca74a556a8579a07fe202bb9e065a5
+runner_sha256: 458066dda3fd4874d443d59b07b0df7d4eaa478f865adefbbdbe1dc2a8e5e27e
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.32
+elapsed_sec: 0.44
 status: ok
 ----- stdout -----
 === Substep-4 AC_lambda simultaneous-diagonalization bridge ===
@@ -22,7 +22,7 @@ status: ok
   PASS  [T_3, T_2] = 0
   PASS  [T_3, T_3] = 0
 
-[L1] pairwise-distinct joint signatures are load-bearing
+[L1] theorem hypothesis: pairwise-distinct joint signatures
   PASS  the three joint eigenvalue signatures are pairwise distinct :: signatures = {1: (-1, 1, 1), 2: (1, -1, 1), 3: (1, 1, -1)}
   PASS  ordered pair (1,2) has nonzero exact separation :: deltas = (2, -2, 0); distinguishing mus = [1, 2]; weight = 8
   PASS  ordered pair (1,3) has nonzero exact separation :: deltas = (2, 0, -2); distinguishing mus = [1, 3]; weight = 8
@@ -92,18 +92,16 @@ status: ok
 
 [hostile complex controls]
   PASS  directed E_12 control lies outside the previous Hermitian ansatz :: K_12 is nonzero while K_21 = 0
-  PASS  the full commutator mechanism rejects that non-Hermitian direction :: coverage outside the old ansatz, not a theorem counterexample
+  PASS  the full commutator mechanism rejects that non-Hermitian direction :: coverage outside the old ansatz with the expected nonzero commutators
   PASS  dense hostile K is complex, non-Hermitian, and has all six off-diagonal entries nonzero
   PASS  every dense hostile off-diagonal entry is detected by the triple
-  PASS  dense hostile K fails all three commutator equations :: nonzero counts = {1: 4, 2: 4, 3: 4}
+  PASS  dense hostile K is detected by all three commutator systems :: nonzero counts = {1: 4, 2: 4, 3: 4}
   PASS  one-unitary-blind control is non-Hermitian
   PASS  mixing inside the degenerate +1 eigenspace commutes with T_1
   PASS  the same mixing is detected by T_2 and T_3
-  PASS  coincident identity signatures let dense non-diagonal complex K commute
-  PASS  coincident signatures have zero separation weight
 
 === Summary ===
-PASS=76 FAIL=0
+PASS=74 FAIL=0
 
 ----- stderr -----
 

--- a/scripts/audit_companion_staggered_dirac_substep4_ac_lambda_simultaneous_diagonalization_bridge_2026_05_17.py
+++ b/scripts/audit_companion_staggered_dirac_substep4_ac_lambda_simultaneous_diagonalization_bridge_2026_05_17.py
@@ -27,15 +27,16 @@ The equivalence is checked in two independent exact ways:
          K -> ([K,T_1], [K,T_2], [K,T_3])
      and verify rank 6 with kernel exactly span(E_11,E_22,E_33).
 
-Pairwise distinctness is load-bearing.  For every alpha != beta, the exact
-separation weight
+Under the theorem's pairwise-distinct joint-signature hypothesis, every
+alpha != beta has exact separation weight
 
   sum_mu (tau_mu^(beta) - tau_mu^(alpha))^2
 
-equals 8, giving an entrywise reconstruction identity for K_ab from the
-three commutators.  Dense and one-unitary-blind non-Hermitian complex
-controls verify the intended failure modes.  The original generic
-Hermitian specialization is retained as a secondary continuity check.
+equal to 8, giving an entrywise reconstruction identity for K_ab from the
+three commutators.  Directed, dense, and one-unitary-blind non-Hermitian
+complex controls exercise the positive certificate across the quantified
+operator space.  The original generic Hermitian specialization is retained
+as a secondary continuity check.
 
 Expected output: PASS=N FAIL=0 with N >= 50.
 """
@@ -102,7 +103,7 @@ def main() -> int:
             )
 
     # ----- (L1) pairwise-distinct signatures and exact separation -----
-    print("\n[L1] pairwise-distinct joint signatures are load-bearing")
+    print("\n[L1] theorem hypothesis: pairwise-distinct joint signatures")
     check(
         "the three joint eigenvalue signatures are pairwise distinct",
         len(set(signatures.values())) == 3,
@@ -457,7 +458,7 @@ def main() -> int:
         not is_zero_matrix(directed_commutators[1])
         and not is_zero_matrix(directed_commutators[2])
         and is_zero_matrix(directed_commutators[3]),
-        detail="coverage outside the old ansatz, not a theorem counterexample",
+        detail="coverage outside the old ansatz with the expected nonzero commutators",
     )
 
     K_dense_hostile = sp.Matrix(
@@ -491,7 +492,7 @@ def main() -> int:
         ),
     )
     check(
-        "dense hostile K fails all three commutator equations",
+        "dense hostile K is detected by all three commutator systems",
         all(not is_zero_matrix(dense_commutators[mu]) for mu in MUS),
         detail=(
             f"nonzero counts = "
@@ -520,27 +521,6 @@ def main() -> int:
         "the same mixing is detected by T_2 and T_3",
         not is_zero_matrix(blind_commutators[2])
         and not is_zero_matrix(blind_commutators[3]),
-    )
-
-    # If the signatures coincide, the separation weights vanish and the
-    # diagonal-commutant conclusion fails: even the dense hostile K commutes.
-    trivial_commutators = {
-        mu: K_dense_hostile * I3 - I3 * K_dense_hostile
-        for mu in MUS
-    }
-    check(
-        "coincident identity signatures let dense non-diagonal complex K commute",
-        all(is_zero_matrix(matrix) for matrix in trivial_commutators.values())
-        and K_dense_hostile != sp.diag(*K_dense_hostile.diagonal()),
-    )
-    check(
-        "coincident signatures have zero separation weight",
-        all(
-            sum((1 - 1) ** 2 for _mu in MUS) == 0
-            for _alpha in (1, 2, 3)
-            for _beta in (1, 2, 3)
-            if _alpha != _beta
-        ),
     )
 
     # ----- Summary -----


### PR DESCRIPTION
## Summary

- remove the separately asserted non-distinct-spectrum boundary from the positive AC_lambda simultaneous-diagonalization theorem and runner
- keep pairwise-distinct joint signatures as the explicit positive hypothesis used by the proof
- preserve the fully generic complex `3 x 3` operator coverage, all six entrywise reconstructions, the exact `27 x 9` rank-6/nullity-3 certificate, the `C^3` diagonal commutant, and the directed/dense/one-unitary-blind controls
- refresh the SHA-bound runner cache from the exact final runner (`PASS=74 FAIL=0`)

## Why

The latest independent audit found the positive theorem sound but classified the runner's identity-triple counterexample as a separate derived negative boundary without a live No-Go Discipline packet. That boundary is unnecessary for the theorem. This repair takes the narrow honest path: it removes the extra negative assertion instead of adding audit-shaped evidence around it.

## Validation

- target runner and SHA-bound cache: `PASS=74 FAIL=0`
- Python byte compilation: pass
- independent symbolic reconstruction: all six ordered off-diagonal entries recovered with weight 8; commutator map shape `27 x 9`, rank 6, nullity 3, kernel `span(E_11,E_22,E_33)`
- mutation harness: rejected 6/6 bad encodings (coincident signature pair, missing `T_mu`, sign mutation, hidden Hermiticity, coupled opposite entries, dropped off-diagonal coordinate)
- controlled-vocabulary lint, changed-note links, repository invariant/link enforcement, cache freshness, and `git diff --check`: pass
- full repository compatibility pipeline plus `audit_lint.py --strict` in a disposable worktree at current main `5daf949c3196be27df51999ad1f6fb8bb921ab99`: zero errors

## Audit and graph hygiene

- no audit was run and no audit verdict was authored or applied
- no audit ledger, queue, dispatch, lane-certification, publication-effective-status, or front-door generated output is committed
- compatibility generation left the target author-hinted as `positive_theorem`, audit-owned and `unaudited`, with zero dependencies/helpers
- citation topology and all ten direct dependent edges are unchanged
