### PR TITLE
Define positive input/output scope for the SU(3) convolution theorem

### DIFF
--- a/docs/SU3_CHARACTER_DIAGONAL_CONVOLUTION_EQUIVALENCE_NARROW_THEOREM_NOTE_2026-05-10.md
+++ b/docs/SU3_CHARACTER_DIAGONAL_CONVOLUTION_EQUIVALENCE_NARROW_THEOREM_NOTE_2026-05-10.md
@@ -94,6 +94,10 @@ is:
 - conjugation-symmetric: it commutes with the involution
   `swap: chi_(p,q) -> chi_(q,p)` on `V_4`.
 
+The condition `rho_(0,0) = 1` is used only to fix the trivial-channel
+normalization `Z_(0,0) = 1` in `(T2)`. Conclusion `(T4)` uses the real,
+nonnegative, swap-symmetric properties of the sequence.
+
 ## Proof
 
 `(T1)` This is the Schur character orthogonality relation for

--- a/docs/SU3_CHARACTER_DIAGONAL_CONVOLUTION_EQUIVALENCE_NARROW_THEOREM_NOTE_2026-05-10.md
+++ b/docs/SU3_CHARACTER_DIAGONAL_CONVOLUTION_EQUIVALENCE_NARROW_THEOREM_NOTE_2026-05-10.md
@@ -2,22 +2,19 @@
 
 **Date:** 2026-05-10
 **Type:** positive_theorem
-**Claim scope:** the standalone abstract-algebraic equivalence on the finite
-`B_4` truncation of the `SU(3)` character basis between:
+**Claim scope:** the input surface is the finite `B_4` `SU(3)` character
+basis, normalized Haar probability measure, an abstract real nonnegative
+swap-symmetric sequence `rho_(p,q)` with `rho_(0,0) = 1`, and standard
+compact-group representation algebra. The output surface is T1 Schur
+orthogonality, T2 equality of normalized convolution and diagonal action on
+`V_4`, T3 coefficient uniqueness, and T4 positivity, self-adjointness, and
+swap symmetry.
 
-- a diagonal positive central operator
-  `R chi_(p,q) = rho_(p,q) chi_(p,q)` indexed by an abstract real coefficient
-  sequence `rho_(p,q) >= 0`, `rho_(0,0) = 1`, `rho_(p,q) = rho_(q,p)`, and
-- the normalized convolution operator `C_{Z/Z_(0,0)}` by the central class
-  function
-  `Z(W) = sum_(p,q) d_(p,q) rho_(p,q) chi_(p,q)(W)`,
-  with `d_(p,q) = (p+1)(q+1)(p+q+2)/2` the irrep dimension and
-  `Z_(0,0) = d_(0,0) rho_(0,0) = 1`.
+The parent Wilson-environment program is a separate coefficient-source
+problem. Once a physical coefficient sequence is supplied with its own
+authority and matches this input signature, this theorem supplies the
+algebraic convolution/diagonal equivalence on `V_4`.
 
-This is purely a fact of finite-dimensional `SU(3)` character algebra
-on the abstract real coefficient sequence `(rho_(p,q))`; **no Wilson
-action, no unmarked spatial environment, no `beta = 6` framework point,
-no specific numerical input** is consumed.
 **Runner:** [`scripts/frontier_su3_character_diagonal_convolution_equivalence_narrow.py`](./../scripts/frontier_su3_character_diagonal_convolution_equivalence_narrow.py)
 
 ## Statement
@@ -150,8 +147,8 @@ chi_mu(W) = sum_c D^mu(W)_(c c).                                          (9)
 ```
 
 Here `W^{-1}` creates the conjugated matrix element in the first character,
-while the target character `chi_mu(W)` is not conjugated. Reordering `(7)`
-gives the precise matrix-element pairing
+while the target character `chi_mu(W)` appears in its direct form. Reordering
+`(7)` gives the precise matrix-element pairing
 
 ```text
 integral conj(D^lambda(W)_(a b)) D^mu(W)_(c d) dW
@@ -177,7 +174,7 @@ I_(lambda,mu)(V)
 
 The last line uses `lambda = mu` only on the surviving Schur-delta branch.
 Thus the trace and the factor `1/d_mu` are outputs of the matrix-index
-contraction, not assumptions from a character-convolution helper.
+contraction itself.
 The indexed calculation is dimension-generic, but the durable claim in this
 note is restricted to the fixed `B_4` packet.
 
@@ -186,9 +183,10 @@ The inverse/conjugation choices are essential. If `W^{-1}` is replaced by
 `chi_mu(U^{-1}) = chi_(mu^*)(U)`, where `mu^* = (q',p')`. Likewise,
 replacing `chi_mu(W)` by its complex conjugate directly inserts
 `chi_(mu^*)(W)`. Either mutation therefore produces the dual-irrep action
-`rho_(mu^*) chi_(mu^*)(V)`, not `rho_mu chi_mu(V)` in general. The runner
-tests both mutations on the complex fundamental character at a `V` for
-which `chi_(1,0)(V) != chi_(0,1)(V)`.
+`rho_(mu^*) chi_(mu^*)(V)`, which generally differs from
+`rho_mu chi_mu(V)`. The runner tests both mutations on the complex
+fundamental character at a `V` for which
+`chi_(1,0)(V) != chi_(0,1)(V)`.
 
 Substituting `(11)` into the full finite sum `(8)` gives the dimension
 cancellation explicitly:
@@ -222,101 +220,56 @@ Conjugation symmetry
 = rho_(p,q) chi_(q,p) = swap rho_(p,q) chi_(p,q) = swap R chi_(p,q)`,
 so `R` commutes with `swap`. ∎
 
-## What this claims
+## Input and output surface
 
-- `(T1)`: the standard Schur orthogonality identity `(5)` for the
-  finite truncation of `SU(3)` characters.
-- `(T2)`: the symbolic identity `C_{Z/Z_(0,0)} chi_(p,q) = rho_(p,q) chi_(p,q)`
-  on `V_4` for every abstract coefficient sequence with the stated symmetry
-  and normalization.
-- `(T3)`: uniqueness — the diagonal operator `R` determines and is
-  determined by its character coefficients `(rho_(p,q))` over `B_4`.
-- `(T4)`: positivity, self-adjointness, and conjugation symmetry of `R`
-  follow from the abstract hypotheses without reference to any physical
-  Wilson construction.
+The complete theorem input is:
 
-## What this does NOT claim
+- the 25 characters indexed by `B_4` and their span `V_4`;
+- normalized Haar probability measure on `SU(3)`;
+- the abstract real sequence `(rho_(p,q))` with nonnegative entries,
+  swap symmetry, and trivial-channel normalization `rho_(0,0) = 1`;
+- standard compact-group representation algebra, including the exact
+  `SU(3)` dimension formula and matrix-element Schur orthogonality.
 
-- Does **not** identify `(rho_(p,q))` with any specific physical
-  Wilson environment coefficients, `beta = 6` framework point data,
-  or unmarked spatial Wilson boundary integral.
-- Does **not** construct the unmarked spatial Wilson environment
-  operator `R_beta^env` or derive its coefficients from a Wilson
-  configuration integral.
-- Does **not** consume the parent residual-environment identification
-  theorem, the parent spatial-environment character-measure theorem, or
-  any of the parent gauge-vacuum plaquette derivation chains.
-- Does **not** consume any PDG observed value, literature numerical
-  comparator, fitted selector, or admitted unit convention.
-- Does **not** close analytic `P(6)`, an all-weight coefficient law, or
-  the full unmarked spatial Wilson tensor-transfer/Perron problem.
+From exactly that input, the theorem returns:
 
-## Relation to the parent plaquette residual environment chain
+- `(T1)` Schur character orthogonality on `B_4`;
+- `(T2)` `C_{Z/Z_(0,0)} = R` on `V_4`;
+- `(T3)` uniqueness of the diagonal coefficient sequence;
+- `(T4)` positivity, self-adjointness, and swap symmetry of `R`.
 
-The parent identification chain — anchored at
-`GAUGE_VACUUM_PLAQUETTE_RESIDUAL_ENVIRONMENT_IDENTIFICATION_THEOREM_NOTE.md`
-and
-`GAUGE_VACUUM_PLAQUETTE_SPATIAL_ENVIRONMENT_CHARACTER_MEASURE_THEOREM_NOTE.md`
-— asserts the load-bearing equality `R_beta^env = C_(Z_beta^env)` on
-the marked-plaquette class-function sector. The auditor's
-recorded objection (verdict `audited_conditional`, repair class
-`missing_bridge_theorem`) was that the parent runners verify
-packaging once a generic positive symmetric `rho_env` sequence is
-supplied, but do not derive the equality from the actual unmarked
-spatial Wilson environment.
+## Division of labor with the parent plaquette program
 
-This narrow theorem isolates a clean algebraic component of that
-load-bearing equality, scoped to abstract `SU(3)` character algebra
-and explicitly disclaiming any Wilson-environment identification.
-Specifically, it proves:
+The parent Wilson-environment program owns the source problem for a physical
+coefficient sequence, including its Wilson configuration-integral provenance,
+normalization, and domain. This theorem owns the algebraic map from any
+sequence matching the input signature above to the corresponding normalized
+central convolution on `V_4`.
 
-> Whatever the actual physical or numerical origin of the coefficient
-> sequence `(rho_(p,q))`, the convolution-by-class-function realization
-> on the finite character-basis truncation **is**, as a matter of
-> finite-dimensional `SU(3)` representation theory, the same operator
-> as the diagonal eigenvalue action.
-
-The narrow theorem does NOT close the parent gate. The remaining
-bridge step — deriving the **physical Wilson coefficients**
-`rho_(p,q)(6)` from the unmarked spatial Wilson environment integral —
-is the separate target addressed by the bounded companion
+A physical application therefore has a two-authority type signature: the
+coefficient-source result supplies `(rho_(p,q))`, and this theorem supplies
+the convolution/diagonal equivalence after that typed input is present. The
+bounded coefficient companion
 `GAUGE_VACUUM_PLAQUETTE_RHO_PQ6_WILSON_ENVIRONMENT_BOUNDED_NOTE_2026-05-09.md`
-and is **outside the scope of this narrow theorem**.
-
-The bounded companion supplies explicit normalized single-link Wilson
-boundary coefficients, but this narrow theorem does not consume them.
-It proves only the abstract algebraic implication after a coefficient
-sequence is supplied. Any use of both notes in the parent chain still
-requires a separate derivation identifying those coefficients and this
-finite character-sector operator with the physical environment
-compression. The two independently audit-able pieces are:
-
-- the **abstract algebraic bridge** (this narrow theorem, finite-dim
-  `SU(3)` representation theory),
-- the **bounded numerical coefficient** (the rho_(p,q)(6) computation,
-  two independent integrators).
-
-The remaining ungated piece — the all-weight or full tensor-transfer
-identification of `R_beta^env` with the **physical** Wilson
-environment compression — remains explicitly open.
+and the full tensor-transfer program each retain authority over their stated
+physical surfaces.
 
 ## Cited dependencies
 
-No repo-source dependencies. This narrow note uses only standard mathematical
-inputs: normalized Haar probability measure, unitary irreducible
-representations, Peter-Weyl theory, and matrix-element Schur orthogonality for
-compact groups. Its durable claim is restricted to the abstract finite `B_4`
-packet; no physical input supplies or enlarges that scope.
+Repository-source dependency set: empty. The mathematical authority surface
+is normalized Haar probability measure, unitary irreducible representations,
+Peter-Weyl theory, and matrix-element Schur orthogonality for compact groups.
+The interface with the parent Wilson program requires a coefficient sequence
+carrying its own physical authority.
 
-## Forbidden imports check
+## Input-authority check
 
-- No PDG observed values consumed.
-- No literature numerical comparators consumed.
-- No fitted selectors consumed.
-- No admitted unit conventions load-bearing on the claim.
-- No same-surface family arguments.
-- No Wilson action or `beta = 6` framework-point input.
-- No identification with the parent plaquette environment operator.
+The complete load-bearing input roster is the finite `B_4` character packet,
+normalized Haar measure, the abstract normalized nonnegative swap-symmetric
+sequence, and standard compact-group representation algebra. Numerical data,
+physical coefficient provenance, environment compression, and Wilson
+configuration-integral construction retain their respective source
+authorities in the parent program.
 
 ## Validation
 
@@ -356,10 +309,11 @@ verifies, on the finite `N = 4` truncation (`B_4 = {(p,q): 0 <= p,q <= 4}`):
    symmetric square, symmetric cube, and conjugate symmetric cube
    characters reproduce `C_Z chi_mu(V) = rho_mu chi_mu(V)` for three
    nontrivial `V` values and an abstract rational symmetric coefficient
-   sequence. This Monte Carlo calculation is support, not the exact proof.
+   sequence. This Monte Carlo calculation supplies independent numerical
+   support; the indexed Schur contraction supplies the exact proof.
 8. Hostile controls that reject a missing `1/d_mu`, `W` in place of
-   `W^{-1}`, conjugating the target character, and a helper that merely
-   returns `rho_mu` without the factor `chi_mu(V)`.
+   `W^{-1}`, conjugating the target character, and the lookup-only value
+   `rho_mu` in place of the V-dependent value `rho_mu chi_mu(V)`.
 
 Expected summary:
 

--- a/logs/runner-cache/frontier_su3_character_diagonal_convolution_equivalence_narrow.txt
+++ b/logs/runner-cache/frontier_su3_character_diagonal_convolution_equivalence_narrow.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_su3_character_diagonal_convolution_equivalence_narrow.py
-runner_sha256: 1359799bb51b8c94ad2e6910731437592b43c8f8cbe22906e71f4ef3b806d220
+runner_sha256: 075dd32a359505addab8b4b98d24b01195bf2bdbf3c978cbb4552b2ed767e437
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 9.17
+elapsed_sec: 8.62
 status: ok
 ----- stdout -----
 
@@ -90,18 +90,21 @@ Narrow theorem summary
     (T4)  R is positive, self-adjoint (in the Schur-orthonormal character basis),
           and commutes with the conjugation swap (p,q) <-> (q,p).
 
-  Load-bearing step class:
-    (A) - pure finite-dim SU(3) representation theory on an abstract real
-    coefficient sequence. No Wilson action, no unmarked spatial environment,
-    no beta = 6 framework-point input, no identification with the parent
-    plaquette environment operator R_beta^env.
+  INPUT AND AUTHORITY SURFACE:
+    The complete input is the finite B_4 SU(3) character basis, normalized
+    Haar probability measure, an abstract real nonnegative swap-symmetric
+    sequence with rho_(0,0) = 1, and standard compact-group representation
+    algebra.
 
-  This narrow theorem isolates the abstract algebraic equivalence between
-  diagonal-coefficient operators and convolution-by-central-class-function
-  operators on the finite SU(3) B_4 character truncation. It does NOT close the
-  parent gate. The remaining physical-Wilson-coefficient derivation is
-  separately addressed by the bounded companion
-  GAUGE_VACUUM_PLAQUETTE_RHO_PQ6_WILSON_ENVIRONMENT_BOUNDED_NOTE_2026-05-09.
+  OUTPUT SURFACE:
+    T1 Schur orthogonality; T2 equality of normalized convolution and diagonal
+    action on V_4; T3 coefficient uniqueness; T4 positivity,
+    self-adjointness, and swap symmetry.
+
+  PARENT PROGRAM DIVISION OF LABOR:
+    A physical Wilson-environment coefficient result supplies the sequence
+    with its own source authority. This theorem supplies the algebraic
+    convolution/diagonal equivalence after that typed input is present.
 
 
 ========================================================================================

--- a/logs/runner-cache/frontier_su3_character_diagonal_convolution_equivalence_narrow.txt
+++ b/logs/runner-cache/frontier_su3_character_diagonal_convolution_equivalence_narrow.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_su3_character_diagonal_convolution_equivalence_narrow.py
-runner_sha256: 075dd32a359505addab8b4b98d24b01195bf2bdbf3c978cbb4552b2ed767e437
+runner_sha256: cb80613c581f7a42c446bc3a0670dac14dd7ca2fa5fb70d7de6febdd0ccf4890
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 8.62
+elapsed_sec: 9.22
 status: ok
 ----- stdout -----
 
@@ -38,7 +38,7 @@ Part 4 (T4): positivity, self-adjointness, conjugation-symmetry of R
   [PASS (A)] (T4) R is positive: rho_(p,q) >= 0 on every weight in B_4  (min rho = 0.00125 >= 0)
   [PASS (A)] (T4) R is self-adjoint (diagonal with real entries)  (||R - R^T||_inf = 0.000e+00)
   [PASS (A)] (T4) R commutes with the conjugation swap (p,q) <-> (q,p)  (||[swap, R]||_inf = 0.000e+00)
-  [PASS (A)] (T4) Normalization: rho_(0,0) = 1 exactly  (|rho_(0,0) - 1| = 0.000e+00)
+  [PASS (A)] (T2) Trivial-channel normalization: rho_(0,0) = 1 exactly  (|rho_(0,0) - 1| = 0.000e+00)
 
 ----------------------------------------------------------------------------------------
 Part 5: concrete instance — trivial coefficient sequence collapses to projection

--- a/scripts/frontier_su3_character_diagonal_convolution_equivalence_narrow.py
+++ b/scripts/frontier_su3_character_diagonal_convolution_equivalence_narrow.py
@@ -29,7 +29,8 @@ THEN the following identities hold on the abstract B_4 packet:
   (T3) Uniqueness: rho^(1) = rho^(2) iff their diagonal operators agree.
 
   (T4) Positivity / self-adjointness / swap-symmetry of R under the
-       abstract hypotheses (rho >= 0, rho symmetric, rho_(0,0) = 1).
+       real nonnegative swap-symmetric hypotheses. The separate condition
+       rho_(0,0) = 1 fixes the trivial-channel normalization used in T2.
 
 The input surface is the finite B_4 SU(3) character basis, normalized Haar
 probability measure, an abstract real nonnegative swap-symmetric sequence
@@ -478,10 +479,10 @@ check(
 # =============================================================================
 section("Part 4 (T4): positivity, self-adjointness, conjugation-symmetry of R")
 # =============================================================================
-# Under the abstract hypothesis (rho >= 0, rho_(p,q) = rho_(q,p), rho_(0,0) = 1),
-# R is a diagonal operator with non-negative real eigenvalues. In the
-# Schur-orthonormal character basis, R is diagonal with real entries, hence
-# self-adjoint.
+# Under the abstract hypotheses rho >= 0 and rho_(p,q) = rho_(q,p), R is a
+# diagonal operator with non-negative real eigenvalues. In the Schur-orthonormal
+# character basis, R is diagonal with real entries, hence self-adjoint. The
+# separate condition rho_(0,0) = 1 fixes the trivial-channel normalization in T2.
 R_matrix = np.diag([float(r) for r in rho1])
 swap_matrix = np.zeros_like(R_matrix)
 for i, (p, q) in enumerate(B_N):
@@ -511,10 +512,10 @@ check(
     detail=f"||[swap, R]||_inf = {commute_err:.3e}",
 )
 
-# Normalization
+# Trivial-channel normalization used in T2
 norm_err = abs(float(rho1[INDEX[(0, 0)]]) - 1.0)
 check(
-    "(T4) Normalization: rho_(0,0) = 1 exactly",
+    "(T2) Trivial-channel normalization: rho_(0,0) = 1 exactly",
     norm_err < 1e-15,
     detail=f"|rho_(0,0) - 1| = {norm_err:.3e}",
 )

--- a/scripts/frontier_su3_character_diagonal_convolution_equivalence_narrow.py
+++ b/scripts/frontier_su3_character_diagonal_convolution_equivalence_narrow.py
@@ -31,11 +31,15 @@ THEN the following identities hold on the abstract B_4 packet:
   (T4) Positivity / self-adjointness / swap-symmetry of R under the
        abstract hypotheses (rho >= 0, rho symmetric, rho_(0,0) = 1).
 
-This is pure abstract finite-dimensional SU(3) representation theory on an
-abstract real coefficient sequence (rho_(p,q)) over the SU(3) character
-basis. **No** Wilson action,
-**no** unmarked spatial environment, **no** beta = 6 framework-point
-input, and **no** physical coefficient data are consumed.
+The input surface is the finite B_4 SU(3) character basis, normalized Haar
+probability measure, an abstract real nonnegative swap-symmetric sequence
+(rho_(p,q)) with rho_(0,0) = 1, and standard compact-group representation
+algebra. The output surface is T1 Schur orthogonality, T2 equality of
+normalized convolution and diagonal action on V_4, T3 coefficient uniqueness,
+and T4 positivity, self-adjointness, and swap symmetry. In the parent
+Wilson-environment program, a physical coefficient result supplies the
+sequence with its own authority; this runner verifies the algebraic map after
+that typed input is present.
 
 The load-bearing verification expands chi_lambda(V W^-1) into generic
 representation-matrix entries and contracts the three matrix indices using
@@ -44,7 +48,7 @@ deterministic Haar-random SU(3) calculation checks the convolution using
 explicit fundamental, antifundamental, adjoint, and low symmetric-power
 character formulas. Hostile mutations reject a missing 1/d factor, W in
 place of W^-1, conjugating the target character, and returning rho_target
-without the V-dependent character.
+alone in place of the V-dependent value rho_target chi_target(V).
 """
 
 from __future__ import annotations
@@ -208,7 +212,7 @@ section("Part 2 (T2): exact matrix-index contraction for character convolution")
 # The dictionaries below are exact symbolic polynomials in the generic
 # entries D^lambda(V)_(a,b): matrix indices are keys and Fraction values are
 # their coefficients. Thus the 1/d factor and the surviving diagonal trace
-# are produced by the indexed contraction, not inserted by a final helper.
+# are produced directly by the indexed contraction.
 MatrixPolynomial = dict[tuple[int, int], Fraction]
 ConvolutionPolynomial = dict[tuple[tuple[int, int], int, int], Fraction | float]
 
@@ -310,7 +314,7 @@ check(
 )
 
 # Hostile mutation: omit the Schur 1/d normalization. It produces Tr D(V),
-# not Tr D(V)/d, already for the fundamental representation.
+# which differs by a factor of d from the required fundamental contraction.
 missing_dimension_mutant = {
     (c, c): Fraction(1) for c in range(d_su3(1, 0))
 }
@@ -411,8 +415,8 @@ rho1 = make_positive_symmetric({
 })
 
 # Apply the finite sum only after the raw contraction and dimension
-# cancellation have been checked. Compare full generic matrix polynomials,
-# not a scalar coefficient lookup.
+# cancellation have been checked. Compare full generic matrix polynomials
+# against independently constructed expected polynomials.
 all_targets_ok = True
 for target in B_N:
     actual = apply_z_convolution(rho1, target)
@@ -542,8 +546,8 @@ check(
 # =============================================================================
 section("Part 6: independent deterministic Haar-SU(3) convolution check")
 # =============================================================================
-# The Monte Carlo convolution below does not use the Weyl integration routine
-# or the symbolic contraction table. It samples Haar-random 3 x 3 SU(3)
+# The Monte Carlo convolution below is independent of the Weyl integration
+# routine and symbolic contraction table. It samples Haar-random 3 x 3 SU(3)
 # matrices and evaluates explicit trace formulas for 1, 3, 3bar, 8, 6, 6bar,
 # 10, and 10bar. A small preflight separately cross-checks those formulas
 # against the Weyl formula at fixed torus points.
@@ -827,18 +831,21 @@ print("""
     (T4)  R is positive, self-adjoint (in the Schur-orthonormal character basis),
           and commutes with the conjugation swap (p,q) <-> (q,p).
 
-  Load-bearing step class:
-    (A) - pure finite-dim SU(3) representation theory on an abstract real
-    coefficient sequence. No Wilson action, no unmarked spatial environment,
-    no beta = 6 framework-point input, no identification with the parent
-    plaquette environment operator R_beta^env.
+  INPUT AND AUTHORITY SURFACE:
+    The complete input is the finite B_4 SU(3) character basis, normalized
+    Haar probability measure, an abstract real nonnegative swap-symmetric
+    sequence with rho_(0,0) = 1, and standard compact-group representation
+    algebra.
 
-  This narrow theorem isolates the abstract algebraic equivalence between
-  diagonal-coefficient operators and convolution-by-central-class-function
-  operators on the finite SU(3) B_4 character truncation. It does NOT close the
-  parent gate. The remaining physical-Wilson-coefficient derivation is
-  separately addressed by the bounded companion
-  GAUGE_VACUUM_PLAQUETTE_RHO_PQ6_WILSON_ENVIRONMENT_BOUNDED_NOTE_2026-05-09.
+  OUTPUT SURFACE:
+    T1 Schur orthogonality; T2 equality of normalized convolution and diagonal
+    action on V_4; T3 coefficient uniqueness; T4 positivity,
+    self-adjointness, and swap symmetry.
+
+  PARENT PROGRAM DIVISION OF LABOR:
+    A physical Wilson-environment coefficient result supplies the sequence
+    with its own source authority. This theorem supplies the algebraic
+    convolution/diagonal equivalence after that typed input is present.
 """)
 
 


### PR DESCRIPTION
## Summary

This post-audit science-fix repairs the 2026-07-17 conditional certification artifact for `su3_character_diagonal_convolution_equivalence_narrow_theorem_note_2026-05-10`. The mathematics was already judged correct with `chain_closes=true`, `negative_assertion_classes=[]`, and 24 class-A runner passes; the sole condition came from exclusion/disclaimer rhetoric on an otherwise positive theorem.

The source now states a complete positive type signature:

- inputs: the finite `B_4` SU(3) character basis, normalized Haar probability measure, an abstract real nonnegative swap-symmetric sequence `rho_(p,q)` with `rho_(0,0)=1`, and standard compact-group representation algebra;
- outputs: T1 Schur orthogonality, T2 equality of normalized convolution and diagonal action on `V_4`, T3 coefficient uniqueness, and T4 positivity, self-adjointness, and swap symmetry.

The exact theorem and proof are retained. The parent Wilson-environment program owns physical coefficient provenance; once a physical sequence is supplied by its own authority, this theorem supplies the algebraic convolution/diagonal equivalence. This is a positive division of labor, with no implication that the abstract sequence has been derived from Wilson configurations.

## Files changed

- `docs/SU3_CHARACTER_DIAGONAL_CONVOLUTION_EQUIVALENCE_NARROW_THEOREM_NOTE_2026-05-10.md`
- `scripts/frontier_su3_character_diagonal_convolution_equivalence_narrow.py`
- `logs/runner-cache/frontier_su3_character_diagonal_convolution_equivalence_narrow.txt`

The cache is refreshed against runner SHA-256 `cb80613c581f7a42c446bc3a0670dac14dd7ca2fa5fb70d7de6febdd0ccf4890`.

## Mathematical and runner verification

- Independent hook-length/Weyl dimension check agrees with `d_(p,q)=(p+1)(q+1)(p+q+2)/2` on all 25 weights in `B_4`; `d_(0,0)=Z_(0,0)=1`.
- The indexed matrix-element contraction returns `delta_(lambda,mu) chi_mu(V)/d_mu` before `rho` is applied, and the `d_lambda` coefficient in `Z` cancels the surviving `1/d_mu`.
- Deterministic Ginibre-QR Haar-SU(3) controls use explicit fundamental, antifundamental, adjoint, and symmetric-power character formulas independently of the symbolic contraction table.
- Target runner: `PASS=24 FAIL=0`.
- Hostile controls reject omission of `1/d`, `W` in place of `W^-1`, conjugating the target, and returning the lookup-only `rho_target` value.
- Python compile, cache freshness, controlled-vocabulary lint, changed-note links, premise purity, enforced repository invariants, rhetoric-discipline assertions, and `git diff --check` all pass.

## Consumer trace

The ledger records 27 direct consumers and 822 transitive descendants. All 27 direct citation contexts were inspected, together with the critical/high-risk transitive surface. They consume this row as the Schur/character-convolution dictionary or inverse-dimension normalization. Physical Wilson consumers separately supply or derive their own coefficient data. No stale consumer required editing, and graph topology is unchanged.

## Audit safety

This was a source-author repair pass only. No audit-loop, audit worker, `scripts/codex_audit_runner.py`, `apply_audit.py`, audit verdict authoring/application, no-go packet, or synthetic N5/N7 stdout ran. No audit ledger, status, queue, dispatch, lane-certification, publication, front-door generated surface, or missing-derivation prompt was edited.

Starting commit was verified clean and exact at `7125cdc4fcb6bacdebf415f4160a05b4c473ecb3`. This PR is ready for the fresh independent Sol xhigh review-loop pass and is not intended for direct merge.

