### PR TITLE
Science fix: narrow DM weak-vector row to finite representation theorem

### DIFF
--- a/docs/DM_NEUTRINO_DIRAC_BRIDGE_THEOREM_NOTE_2026-04-15.md
+++ b/docs/DM_NEUTRINO_DIRAC_BRIDGE_THEOREM_NOTE_2026-04-15.md
@@ -139,9 +139,6 @@ to look for the generation-resolved effective Yukawa.
 This upgrades the branch in one specific way:
 
 - **closed now:** local operator selection on the post-EWSB chiral surface
-- **also closed now:** the direct bridge family carries exact weak-vector
-  representation content (see
-  [`DM_NEUTRINO_WEAK_VECTOR_THEOREM_NOTE_2026-04-15.md`](./DM_NEUTRINO_WEAK_VECTOR_THEOREM_NOTE_2026-04-15.md))
 - **still open:** neutrino-sector normalization / suppression theorem
 
 So the live theorem-grade blocker is no longer:

--- a/docs/DM_NEUTRINO_WEAK_VECTOR_THEOREM_NOTE_2026-04-15.md
+++ b/docs/DM_NEUTRINO_WEAK_VECTOR_THEOREM_NOTE_2026-04-15.md
@@ -1,267 +1,149 @@
-# DM Neutrino Weak Vector Theorem
+# Finite-Dimensional Chiral Vector Representation Theorem
 
-**Status:** bounded support theorem; audit status set only by the independent
-audit lane
-**Date:** 2026-04-15  
-**Branch:** `codex/dm-across-the-line`
+**Date:** 2026-04-15
+
+**Revised:** 2026-07-18
+
+**Type:** positive_theorem
+
+**Status authority:** independent audit lane only. This source note does not
+set or predict an audit outcome.
+
+**Claim scope:** exact identities for the explicit Pauli/Kronecker matrix
+packets on `C^8` and `C^16` displayed below.
 
 **Primary runner:** [`scripts/frontier_dm_neutrino_weak_vector_theorem.py`](../scripts/frontier_dm_neutrino_weak_vector_theorem.py)
+
 **Primary runner cache:** [`logs/runner-cache/frontier_dm_neutrino_weak_vector_theorem.txt`](../logs/runner-cache/frontier_dm_neutrino_weak_vector_theorem.txt)
 
----
-
-## Status
-
-**Exact representation theorem; base normalization cited separately**
-
-The branch now closes one more exact part of the neutrino bridge:
-
-> the direct local chiral bridge family  
-> `Y_i = P_R Gamma_i P_L`  
-> is an exact weak vector under the derived `SU(2)` bivectors.
-
-This is real progress. It upgrades the bridge family from "an axis-picked
-operator that seems plausible" to "a theorem-grade spin-1 weak multiplet."
-
-At the stage of this theorem alone, it still does **not** close the neutrino
-base coupling. The reason is sharp: the weak-vector covariance equations are
-homogeneous, so they do not fix the overall coefficient. The separate
-bosonic-normalization row supplies a base-normalization input outside this
-claim; this note does not re-audit that input or the downstream second-order
-suppression law.
-
----
-
-## The Theorem
+## Statement
 
 Let
 
-- `B_a = -(i/4) sum_{m,n=1}^3 eps_{amn} Gamma_m Gamma_n` be the
-  normalized derived weak bivectors, equivalently
-  `B_1 = -(i/2) Gamma_2 Gamma_3` and cyclic permutations
-- `gamma_5` be the `3+1` chirality operator on `C^16`
-- `P_L = (1 + gamma_5)/2`, `P_R = (1 - gamma_5)/2`
-- `Y_i = P_R Gamma_i P_L`
+- `sigma_x = [[0,1],[1,0]]`,
+- `sigma_y = [[0,-i],[i,0]]`,
+- `sigma_z = [[1,0],[0,-1]]`.
 
-Then:
+The spatial Clifford triple on `C^8` is
 
-1. the bivectors `B_a` form exact `su(2)` on the taste space
-2. the spatial `Gamma_i` family on `C^8` transforms as a vector:
+- `Gamma_1^(8) = sigma_x x I x I`,
+- `Gamma_2^(8) = sigma_y x sigma_x x I`,
+- `Gamma_3^(8) = sigma_y x sigma_y x sigma_x`.
 
-   `[B_a, Gamma_b] = i eps_{abc} Gamma_c`
+The four-generator packet on `C^16` is
 
-3. the same is true for the chiral bridge family on `C^16`:
+- `Gamma_0 = sigma_z x sigma_z x sigma_z x sigma_x`,
+- `Gamma_1 = sigma_x x I x I x I`,
+- `Gamma_2 = sigma_z x sigma_x x I x I`,
+- `Gamma_3 = sigma_z x sigma_z x sigma_x x I`.
 
-   `[B_a, Y_b] = i eps_{abc} Y_c`
+For either spatial triple, define
 
-4. the adjoint Casimir on both families is exactly spin-1:
+`B_a = -(i/4) sum_(m,n=1)^3 eps_(amn) Gamma_m Gamma_n`.
 
-   `sum_a [B_a,[B_a, X_b]] = 2 X_b`
+On `C^16`, also define
 
-   for `X_b = Gamma_b` or `Y_b`
+`gamma_5 = Gamma_0 Gamma_1 Gamma_2 Gamma_3`,
 
-5. the bridge family is trace-orthogonal:
+`P_L = (I + gamma_5)/2`, `P_R = (I - gamma_5)/2`,
 
-   `Tr(Y_i^dag Y_j) = 8 delta_ij`
+and
 
-So the direct post-EWSB bridge is now not only selected as `Gamma_1` after
-axis choice; the full family `Y_i` is an exact weak-vector multiplet.
+`Y_i = P_R Gamma_i P_L`.
 
----
+Then the following identities hold exactly:
 
-## Restricted-Packet Algebra
+1. Each spatial triple satisfies
+   `{Gamma_i,Gamma_j} = 2 delta_ij I`.
+2. The derived matrices have the cyclic form
+   `B_1 = -(i/2) Gamma_2 Gamma_3` and cyclic permutations, form an exact `su(2)`
+   triple, and obey
+   `[B_a,B_b] = i eps_(abc) B_c`.
+3. The spatial Clifford generators obey
+   `[B_a,Gamma_b] = i eps_(abc) Gamma_c`.
+4. `gamma_5` anticommutes with every spatial `Gamma_i`; `P_L` and `P_R`
+   are complementary orthogonal projectors; and every `B_a` commutes with
+   both projectors.
+5. The chiral family obeys
+   `[B_a,Y_b] = i eps_(abc) Y_c`.
+6. The adjoint Casimir is `2` on both displayed vector families:
+   `sum_a [B_a,[B_a,X_b]] = 2 X_b` for `X_b = Gamma_b` or `Y_b`.
+7. The `C^16` chiral family has Gram matrix
+   `Tr(Y_i^dag Y_j) = 8 delta_ij`.
+8. For every scalar `lambda` in `C`, the family `lambda Y_i` obeys the same
+   vector and Casimir equations, and
+   `Tr((lambda Y_i)^dag (lambda Y_j)) = |lambda|^2 8 delta_ij`.
 
-This note does not require an external authority for the load-bearing
-commutator. The exact packet used by the runner is:
+Item 8 is a homogeneous closure property of the displayed matrix equations.
 
-- `sigma_x = [[0,1],[1,0]]`
-- `sigma_y = [[0,-i],[i,0]]`
-- `sigma_z = [[1,0],[0,-1]]`
+## Derivation
 
-On `C^8`, the spatial taste generators are
+The Pauli relations give each Clifford identity directly under Kronecker
+multiplication. For an arbitrary spatial Clifford triple,
 
-- `Gamma_1 = sigma_x x I x I`
-- `Gamma_2 = sigma_y x sigma_x x I`
-- `Gamma_3 = sigma_y x sigma_y x sigma_x`
+`[Gamma_m Gamma_n,Gamma_b]`
 
-On `C^16`, the bridge packet uses
+`= 2 delta_(nb) Gamma_m - 2 delta_(mb) Gamma_n`.
 
-- `Gamma_0 = sigma_z x sigma_z x sigma_z x sigma_x`
-- `Gamma_1 = sigma_x x I x I x I`
-- `Gamma_2 = sigma_z x sigma_x x I x I`
-- `Gamma_3 = sigma_z x sigma_z x sigma_x x I`
-- `gamma_5 = Gamma_0 Gamma_1 Gamma_2 Gamma_3`
-- `P_L = (I + gamma_5)/2`, `P_R = (I - gamma_5)/2`
+Substitution in the definition of `B_a` gives
 
-These matrices obey the Clifford relations
+`[B_a,Gamma_b] = i sum_c eps_(abc) Gamma_c`.
 
-`Gamma_i Gamma_j + Gamma_j Gamma_i = 2 delta_ij I`
+The same Clifford products give the cyclic formulas for `B_a` and then
 
-for the spatial `Gamma_i`. The runner also checks that `gamma_5`
-anticommutes with each spatial `Gamma_i` and that `P_L`, `P_R` are
-complementary orthogonal projectors.
+`[B_a,B_b] = i sum_c eps_(abc) B_c`.
 
-The commutator identity then follows directly. For any spatial Clifford
-triple,
+Applying the vector commutator twice yields
 
-`[Gamma_m Gamma_n, Gamma_b] = 2 delta_{nb} Gamma_m - 2 delta_{mb} Gamma_n`.
+`sum_a [B_a,[B_a,Gamma_b]] = 2 Gamma_b`.
 
-Therefore
+On `C^16`, `gamma_5` anticommutes with each spatial generator. It therefore
+commutes with every even product `Gamma_m Gamma_n`, so
+`[B_a,P_L] = [B_a,P_R] = 0`. Consequently,
 
-`[B_a, Gamma_b]`
+`[B_a,Y_b]`
 
-`= -(i/4) sum_{m,n} eps_{amn} [Gamma_m Gamma_n, Gamma_b]`
+`= [B_a,P_R Gamma_b P_L]`
 
-`= i sum_c eps_{abc} Gamma_c`.
+`= P_R [B_a,Gamma_b] P_L`
 
-Because `gamma_5` anticommutes with each spatial `Gamma_i`, every even
-product `Gamma_m Gamma_n` commutes with `gamma_5`. Hence
-`[B_a, P_L] = [B_a, P_R] = 0`, and
+`= i sum_c eps_(abc) Y_c`.
 
-`[B_a, Y_b] = [B_a, P_R Gamma_b P_L]`
+The same double-commutator calculation gives the Casimir identity for `Y_b`.
+Moreover,
 
-`= P_R [B_a, Gamma_b] P_L`
+`Y_i^dag Y_j = P_L Gamma_i Gamma_j P_L`.
 
-`= i sum_c eps_{abc} P_R Gamma_c P_L`
+The explicit Kronecker traces are `Tr(P_L)=8` and
+`Tr(P_L Gamma_i Gamma_j)=0` for `i != j`, proving
+`Tr(Y_i^dag Y_j)=8 delta_ij`.
 
-`= i sum_c eps_{abc} Y_c`.
+Finally, commutators are complex-linear in `Y`, while the Gram form is
+conjugate-linear in its first argument and linear in its second. Thus, for a
+symbolic scalar `lambda`, the vector and Casimir residuals acquire an overall
+factor `lambda`, and the Gram matrix acquires the factor
+`conjugate(lambda) lambda = |lambda|^2`.
 
-The spin-1 Casimir follows by applying the same commutator twice:
+## Boundary
 
-`sum_a [B_a,[B_a,Y_b]] = 2 Y_b`,
+This theorem concerns only the displayed finite matrices and their exact
+algebraic identities. Identifications of these matrices with a physical
+system, and coefficients attached to any such identification, are outside
+the theorem and are neither asserted nor denied.
 
-using `sum_{a,c} eps_{abc} eps_{acd} = -2 delta_bd`. Trace orthogonality is
-the finite-matrix trace identity
+**Downstream hygiene (2026-07-18):** references to this row may cite only the
+displayed finite-matrix identities; they supply no additional physical
+identification or coefficient statement.
 
-`Tr(Y_i^dag Y_j) = Tr(P_L Gamma_i Gamma_j P_L) = 8 delta_ij`,
+## Executable verification
 
-checked exactly by the paired runner on the explicit tensor-product matrices.
-
----
-
-## What This Actually Buys
-
-This theorem closes the representation content of the bridge family.
-
-Before this pass, the branch had:
-
-- an exact operator-selection theorem (`Gamma_1`, not `Xi_5`)
-- an exact second-order cascade geometry
-- an exact weak-matching obstruction to reusing the old `G5` route
-
-Now it also has:
-
-- an exact statement that the direct bridge family carries the correct weak
-  spin-1 transformation law
-
-That means the bridge family is no longer just "the thing picked by axis
-selection." It is a canonically transforming weak object in the derived
-operator algebra.
-
-This matters because it removes one more possible harsh objection:
-
-> "Maybe `Gamma_1` is just a basis artifact and not a genuine weak-sector
-> operator family."
-
-That objection is no longer supported by this finite packet.
-
----
-
-## Why This Still Does Not Fix The Coefficient
-
-The key obstruction is algebraic and exact:
-
-if `Y_i` obeys
-
-`[B_a, Y_b] = i eps_{abc} Y_c`
-
-then for any scalar `lambda`,
-
-`[B_a, lambda Y_b] = i eps_{abc} lambda Y_c`
-
-as well.
-
-Likewise the Casimir equation is homogeneous:
-
-`sum_a [B_a,[B_a, lambda Y_b]] = 2 lambda Y_b`.
-
-So the weak-vector theorem fixes the **representation law**, but not the
-**absolute normalization**.
-
-This is exactly why the theorem does **not** by itself promote any particular
-base benchmark.
-
-That equality would require an extra ingredient beyond covariance, for example:
-
-- a new weak-sector Ward / Slavnov-Taylor-style identity for the direct bridge
-- or a theorem-grade Higgs / bridge field-normalization principle
-- or a stronger gauge-Higgs unification result than the branch currently has
-
-At the stage of this note, none of those are supplied here. The separate
-bosonic-normalization row supplies the field-normalization selector outside
-this claim, but not the second-order suppression law.
-
----
-
-## Relation To Gauge Universality
-
-This also clarifies the scope of the older gauge-universality theorem.
-
-That theorem proves that the three hw=1 fermion species carry isomorphic gauge
-representations. It is a representation-content result. It does **not** prove
-coefficient sharing between different operator families.
-
-The new weak-vector theorem is the same kind of result:
-
-- it proves the direct bridge family is an exact weak vector
-- it does **not** prove the coefficient multiplying that family in the physical
-  neutrino Yukawa equals the weak gauge coupling
-
-So the branch should not treat "exact weak representation" and
-"exact coefficient sharing" as the same achievement. They are not.
-
----
-
-## Updated Blocker
-
-The denominator blocker is now even narrower:
-
-> the branch has fixed the direct local bridge family and its exact weak
-> representation content, but it still lacks the theorem that fixes the
-> suppressed second-order coefficient below the now-selected base surface.
-
-Equivalently:
-
-> the remaining problem is no longer operator selection or weak covariance. It
-> is the suppressed second-order coefficient on the exact `Gamma_1` return.
-
-That is the right Nature-bar statement.
-
----
-
-## Verification
-
-Verified by:
-
-- [`scripts/frontier_dm_neutrino_weak_vector_theorem.py`](../scripts/frontier_dm_neutrino_weak_vector_theorem.py)
-- captured stdout:
-  [`outputs/frontier_dm_neutrino_weak_vector_theorem_2026-05-06.txt`](../outputs/frontier_dm_neutrino_weak_vector_theorem_2026-05-06.txt)
-
-Command:
+Run:
 
 `python3 scripts/frontier_dm_neutrino_weak_vector_theorem.py`
 
-The runner checks:
-
-- explicit `C^8` and `C^16` Clifford relations
-- `gamma_5` chirality anticommutation and `P_L`, `P_R` projector algebra
-- exact `su(2)` closure of the weak bivectors
-- exact vector transformation of `Gamma_i`
-- exact vector transformation of `Y_i = P_R Gamma_i P_L`
-- exact spin-1 Casimir `2`
-- trace orthogonality of the bridge family
-- explicit rescaling invariance of the covariance equations
-
-Latest captured result:
-
-`RESULT: 18 PASS, 0 FAIL`
+The runner uses exact SymPy matrices over Gaussian rationals for every
+load-bearing identity. It separately reports numerical support and hostile
+mutation checks. The mutation suite rejects wrong bivector sign and
+normalization, wrong vector sign and index, reversed projector orientation,
+a false Casimir coefficient, false diagonal and off-diagonal Gram claims, and
+a false invariant-Gram claim under non-unit rescaling.

--- a/logs/runner-cache/frontier_dm_neutrino_weak_vector_theorem.txt
+++ b/logs/runner-cache/frontier_dm_neutrino_weak_vector_theorem.txt
@@ -1,76 +1,63 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_dm_neutrino_weak_vector_theorem.py
-runner_sha256: 3da2fa02ce2b619ebf408dbfa0d1b4f9617d9c04fd313de2acc865d5bdf4d121
+runner_sha256: 3e4bdbf64c360ef0f7108ba8125dab89c6c694299090ba2824ad4ec2f35d5626
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.14
+elapsed_sec: 0.49
 status: ok
 ----- stdout -----
 ==============================================================================
-NEUTRINO WEAK VECTOR THEOREM
+FINITE-DIMENSIONAL CHIRAL VECTOR REPRESENTATION THEOREM
 ==============================================================================
 
-Part 0: Explicit Clifford and chirality packet
-  max C^8 spatial Clifford error = 0.000e+00
-  max C^16 spatial Clifford error = 0.000e+00
-  max {Gamma_i, gamma_5} error = 0.000e+00
-  max chiral projector algebra error = 0.000e+00
+Part 1: exact Clifford and chirality packet
+  [PASS][EXACT] C^8 spatial Clifford relations  (9 residuals)
+  [PASS][EXACT] C^16 spatial Clifford relations  (9 residuals)
+  [PASS][EXACT] gamma_5 involution, Hermiticity, and spatial anticommutation  (5 residuals)
+  [PASS][EXACT] oriented complementary chiral projectors  (6 residuals)
 
-  [PASS] C^8 Gamma_i satisfy {Gamma_i,Gamma_j}=2 delta_ij
-  [PASS] C^16 Gamma_i satisfy {Gamma_i,Gamma_j}=2 delta_ij
-  [PASS] gamma_5 anticommutes with each spatial Gamma_i
-  [PASS] P_L and P_R are complementary orthogonal projectors
+Part 2: exact derived bivectors and vector laws
+  [PASS][EXACT] C^8 bivector double-sum equals cyclic formula  (3 residuals)
+  [PASS][EXACT] C^16 bivector double-sum equals cyclic formula  (3 residuals)
+  [PASS][EXACT] C^8 bivectors obey su(2)  (9 residuals)
+  [PASS][EXACT] C^16 bivectors obey su(2)  (9 residuals)
+  [PASS][EXACT] C^8 Gamma family obeys the vector commutator  (9 residuals)
+  [PASS][EXACT] C^16 Gamma family obeys the vector commutator  (9 residuals)
+  [PASS][EXACT] bivectors commute with both chiral projectors  (6 residuals)
 
-Part 1: Derived weak SU(2) on the taste space
-  max su(2) commutator error = 0.000e+00
-  ||sum_a B_a^2 - (3/4)I|| = 0.000e+00
+Part 3: exact chiral family, Casimir, and Gram identities
+  [PASS][EXACT] Y_i has P_R-to-P_L orientation  (9 residuals)
+  [PASS][EXACT] Y_i obeys the vector commutator  (9 residuals)
+  [PASS][EXACT] C^8 Gamma family has adjoint Casimir 2  (3 residuals)
+  [PASS][EXACT] C^16 Gamma family has adjoint Casimir 2  (3 residuals)
+  [PASS][EXACT] Y_i has adjoint Casimir 2  (3 residuals)
+  [PASS][EXACT] Tr(Y_i^dag Y_j) = 8 delta_ij  (1 residuals)
 
-  [PASS] bivectors form exact su(2)  (max err = 0.000e+00)
-  [PASS] fermion-space Casimir is 3/4  (err = 0.000e+00)
-  [PASS] bivector trace Gram matrix is diagonal  (Tr(B_a^dag B_b) = 2 delta_ab)
+Part 4: universal symbolic rescaling identities
+  [PASS][EXACT] symbolic lambda Y_i obeys the vector commutator  (polynomial identity in lambda)
+  [PASS][EXACT] symbolic lambda Y_i has adjoint Casimir 2  (polynomial identity in lambda)
+  [PASS][EXACT] Gram(lambda Y) = conjugate(lambda) lambda Gram(Y)  (symbolic complex scalar)
 
-Part 2: Spatial Gamma_i form an exact weak vector on C^8
-  max vector-law error = 0.000e+00
-  max double-commutator error = 0.000e+00
-  max sum_a B_a G_i B_a + (1/4) G_i error = 0.000e+00
+Part 5: numerical support (non-load-bearing)
+  [PASS][SUPPORT] floating evaluation agrees with exact zero residuals  (max residual = 0.000e+00)
+  [PASS][SUPPORT] lambda=2 sample has Gram diagonal 32  (max residual = 0.000e+00)
 
-  [PASS] Gamma_i obey exact weak-vector commutator law
-  [PASS] Gamma_i carry spin-1 Casimir  (sum_a ad(B_a)^2 = 2)
-  [PASS] Gamma_i are trace-orthogonal  (Tr(Gamma_i^dag Gamma_j) = 8 delta_ij)
-  [PASS] conjugation average matches vector identity
-
-Part 3: Chiral bridges Y_i = P_R Gamma_i P_L form the same weak vector on C^16
-  max [B_a, gamma_5] error = 0.000e+00
-  max bridge vector-law error = 0.000e+00
-  max bridge double-commutator error = 0.000e+00
-
-  [PASS] weak generators commute with gamma_5
-  [PASS] bridge family obeys exact weak-vector commutator law
-  [PASS] bridge family carries spin-1 Casimir  (sum_a ad(B_a)^2 = 2)
-  [PASS] bridge family is trace-orthogonal  (Tr(Y_i^dag Y_j) = 8 delta_ij)
-
-Part 4: Weak-vector covariance does not fix absolute normalization
-  lambda = 0.500000: max cov err = 0.000e+00, max Casimir err = 0.000e+00
-  [PASS] scaled family lambda=0.500000 preserves weak-vector covariance  (Tr-scaled norm = 2.000000)
-  lambda = 1.414214: max cov err = 0.000e+00, max Casimir err = 0.000e+00
-  [PASS] scaled family lambda=1.414214 preserves weak-vector covariance  (Tr-scaled norm = 16.000000)
-  lambda = 2.000000: max cov err = 0.000e+00, max Casimir err = 0.000e+00
-  [PASS] scaled family lambda=2.000000 preserves weak-vector covariance  (Tr-scaled norm = 32.000000)
-
-Honest read:
-  1. The direct local chiral bridges Y_i = P_R Gamma_i P_L are now an
-     exact weak-vector family, not just an axis-picked operator guess.
-  2. This is real theorem-grade progress: the bridge family carries the
-     spin-1 Casimir and exact adjoint SU(2) transformation law.
-  3. But covariance alone is homogeneous. Rescaled families lambda Y_i
-     satisfy the same weak-vector equations, so the representation law
-     does not by itself select the physical base normalization.
-  4. Base normalization is a separate input outside this runner.
-     What remains beyond this runner is the second-order suppression
-     law, not weak-vector classification.
+Part 6: hostile mutation rejection
+  [PASS][MUTATION] wrong bivector sign  (validator found 6/9 nonzero residuals)
+  [PASS][MUTATION] wrong bivector normalization  (validator found 12/18 nonzero residuals)
+  [PASS][MUTATION] wrong vector sign  (validator found 6/9 nonzero residuals)
+  [PASS][MUTATION] wrong vector index  (validator found 8/9 nonzero residuals)
+  [PASS][MUTATION] reversed chiral projector orientation  (validator found 2/6 nonzero residuals)
+  [PASS][MUTATION] false adjoint Casimir coefficient 3  (validator found 3/3 nonzero residuals)
+  [PASS][MUTATION] false Gram normalization 16 delta_ij  (validator found 1/1 nonzero residuals)
+  [PASS][MUTATION] false nonzero off-diagonal Gram claim  (validator found 1/1 nonzero residuals)
+  [PASS][MUTATION] false invariant Gram under lambda=2  (validator found 1/1 nonzero residuals)
 
 ==============================================================================
-RESULT: 18 PASS, 0 FAIL
+EXACT: PASS=20 FAIL=0
+SUPPORT: PASS=2 FAIL=0
+MUTATION: PASS=9 FAIL=0
+RESULT: PASS=31 FAIL=0
 ==============================================================================
 
 ----- stderr -----

--- a/logs/runner-cache/frontier_dm_neutrino_weak_vector_theorem.txt
+++ b/logs/runner-cache/frontier_dm_neutrino_weak_vector_theorem.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_dm_neutrino_weak_vector_theorem.py
-runner_sha256: 3e4bdbf64c360ef0f7108ba8125dab89c6c694299090ba2824ad4ec2f35d5626
+runner_sha256: e92e0401ef9404cdfdb9bd80e7d39fb4b1f066b4fa26d25be9a0793e1d06beb8
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.49
+elapsed_sec: 0.50
 status: ok
 ----- stdout -----
 ==============================================================================
@@ -26,7 +26,7 @@ Part 2: exact derived bivectors and vector laws
   [PASS][EXACT] bivectors commute with both chiral projectors  (6 residuals)
 
 Part 3: exact chiral family, Casimir, and Gram identities
-  [PASS][EXACT] Y_i has P_R-to-P_L orientation  (9 residuals)
+  [PASS][EXACT] Y_i maps the P_L subspace to the P_R subspace  (9 residuals)
   [PASS][EXACT] Y_i obeys the vector commutator  (9 residuals)
   [PASS][EXACT] C^8 Gamma family has adjoint Casimir 2  (3 residuals)
   [PASS][EXACT] C^16 Gamma family has adjoint Casimir 2  (3 residuals)

--- a/scripts/frontier_dm_neutrino_weak_vector_theorem.py
+++ b/scripts/frontier_dm_neutrino_weak_vector_theorem.py
@@ -301,7 +301,10 @@ def main() -> int:
     )
 
     print("\nPart 3: exact chiral family, Casimir, and Gram identities")
-    run_exact("Y_i has P_R-to-P_L orientation", chiral_orientation_residuals())
+    run_exact(
+        "Y_i maps the P_L subspace to the P_R subspace",
+        chiral_orientation_residuals(),
+    )
     run_exact("Y_i obeys the vector commutator", vector_residuals(B_16, Y))
     run_exact(
         "C^8 Gamma family has adjoint Casimir 2",

--- a/scripts/frontier_dm_neutrino_weak_vector_theorem.py
+++ b/scripts/frontier_dm_neutrino_weak_vector_theorem.py
@@ -1,281 +1,388 @@
 #!/usr/bin/env python3
-"""
-Neutrino Weak Vector Theorem
-============================
+"""Exact verifier for the finite-dimensional chiral vector theorem.
 
-STATUS: EXACT representation theorem; base normalization closed elsewhere
-
-Purpose:
-  Tighten the direct-bridge story one more step:
-
-    do the exact local chiral bridges
-
-        Y_i = P_R Gamma_i P_L
-
-    form a genuine weak vector under the derived SU(2), and if so does that
-    force the neutrino base coupling?
-
-The exact answer from the current branch is:
-
-  1. yes, the bridge family is an exact spin-1 weak vector
-  2. no, that covariance alone does not fix the absolute coefficient
-
-More precisely:
-
-  - the normalized bivectors
-        B_a = -(i/4) sum_{bc} eps_{abc} Gamma_b Gamma_c
-      equivalently B_1=-(i/2)Gamma_2 Gamma_3 cyclically, form exact su(2)
-  - the spatial Gamma_i family on C^8 transforms as a vector:
-        [B_a, Gamma_b] = i eps_{abc} Gamma_c
-        sum_a [B_a,[B_a,Gamma_b]] = 2 Gamma_b
-  - the chiral bridges Y_i = P_R Gamma_i P_L on C^16 obey the same exact
-    vector law and are trace-orthogonal
-  - but the covariance equations are homogeneous: lambda * Y_i satisfies the
-    same weak-vector relations for any scalar lambda
-
-So the theorem closes the representation content of the direct bridge, but it
-does NOT by itself select the physical base normalization. That later step is
-handled separately by the bosonic-normalization theorem.
+All load-bearing checks use SymPy matrices over Gaussian rationals. Floating
+values are printed only in the SUPPORT lane. The MUTATION lane passes only
+when a hostile alteration produces a nonzero residual in a computed
+validator.
 """
 
 from __future__ import annotations
 
-import math
 import sys
-import numpy as np
+from collections.abc import Iterable, Sequence
 
-PASS_COUNT = 0
-FAIL_COUNT = 0
+import sympy as sp
 
 
-def check(name: str, condition: bool, detail: str = "") -> bool:
-    global PASS_COUNT, FAIL_COUNT
+LANES = ("EXACT", "SUPPORT", "MUTATION")
+COUNTS = {lane: {"pass": 0, "fail": 0} for lane in LANES}
+
+
+def report(lane: str, name: str, condition: bool, detail: str = "") -> bool:
     status = "PASS" if condition else "FAIL"
-    if condition:
-        PASS_COUNT += 1
-    else:
-        FAIL_COUNT += 1
-    line = f"  [{status}] {name}"
-    if detail:
-        line += f"  ({detail})"
-    print(line)
+    COUNTS[lane]["pass" if condition else "fail"] += 1
+    suffix = f"  ({detail})" if detail else ""
+    print(f"  [{status}][{lane}] {name}{suffix}")
     return condition
 
 
-I2 = np.eye(2, dtype=complex)
-I8 = np.eye(8, dtype=complex)
-I16 = np.eye(16, dtype=complex)
-
-SX = np.array([[0, 1], [1, 0]], dtype=complex)
-SY = np.array([[0, -1j], [1j, 0]], dtype=complex)
-SZ = np.array([[1, 0], [0, -1]], dtype=complex)
+def is_zero_matrix(matrix: sp.MatrixBase) -> bool:
+    return all(sp.simplify(entry) == 0 for entry in matrix)
 
 
-def kron3(a: np.ndarray, b: np.ndarray, c: np.ndarray) -> np.ndarray:
-    return np.kron(a, np.kron(b, c))
+def all_zero(residuals: Iterable[sp.MatrixBase]) -> bool:
+    return all(is_zero_matrix(residual) for residual in residuals)
 
 
-def kron4(a: np.ndarray, b: np.ndarray, c: np.ndarray, d: np.ndarray) -> np.ndarray:
-    return np.kron(a, np.kron(b, np.kron(c, d)))
+def exact(name: str, residuals: Sequence[sp.MatrixBase], detail: str = "") -> bool:
+    return report(
+        "EXACT",
+        name,
+        all_zero(residuals),
+        detail or f"{len(residuals)} residuals",
+    )
 
 
-def eps(a: int, b: int, c: int) -> int:
-    if len({a, b, c}) < 3:
-        return 0
-    if (a, b, c) in ((1, 2, 3), (2, 3, 1), (3, 1, 2)):
-        return 1
-    return -1
+def reject_mutation(name: str, residuals: Sequence[sp.MatrixBase]) -> bool:
+    nonzero = sum(not is_zero_matrix(residual) for residual in residuals)
+    return report(
+        "MUTATION",
+        name,
+        nonzero > 0,
+        f"validator found {nonzero}/{len(residuals)} nonzero residuals",
+    )
 
 
-G1 = kron3(SX, I2, I2)
-G2 = kron3(SY, SX, I2)
-G3 = kron3(SY, SY, SX)
-G_SPATIAL_8 = [G1, G2, G3]
+I2 = sp.eye(2)
+I8 = sp.eye(8)
+I16 = sp.eye(16)
 
-G0_4D = kron4(SZ, SZ, SZ, SX)
-G1_4D = kron4(SX, I2, I2, I2)
-G2_4D = kron4(SZ, SX, I2, I2)
-G3_4D = kron4(SZ, SZ, SX, I2)
-G_SPATIAL_16 = [G1_4D, G2_4D, G3_4D]
+SX = sp.Matrix([[0, 1], [1, 0]])
+SY = sp.Matrix([[0, -sp.I], [sp.I, 0]])
+SZ = sp.Matrix([[1, 0], [0, -1]])
 
 
-def weak_bivectors(gammas: list[np.ndarray]) -> list[np.ndarray]:
-    return [
-        sum(
-            -0.25j * eps(a, b, c) * gammas[b - 1] @ gammas[c - 1]
-            for b in range(1, 4)
-            for c in range(1, 4)
-        )
-        for a in range(1, 4)
-    ]
+def kron(*factors: sp.MatrixBase) -> sp.MatrixBase:
+    return sp.kronecker_product(*factors)
+
+
+G_SPATIAL_8 = (
+    kron(SX, I2, I2),
+    kron(SY, SX, I2),
+    kron(SY, SY, SX),
+)
+
+G0_16 = kron(SZ, SZ, SZ, SX)
+G_SPATIAL_16 = (
+    kron(SX, I2, I2, I2),
+    kron(SZ, SX, I2, I2),
+    kron(SZ, SZ, SX, I2),
+)
+
+
+def commutator(left: sp.MatrixBase, right: sp.MatrixBase) -> sp.MatrixBase:
+    return left * right - right * left
+
+
+def weak_bivectors(gammas: Sequence[sp.MatrixBase]) -> tuple[sp.MatrixBase, ...]:
+    result = []
+    for a in range(3):
+        bivector = sp.zeros(gammas[0].rows)
+        for m in range(3):
+            for n in range(3):
+                bivector += (
+                    -sp.I
+                    * sp.Rational(1, 4)
+                    * sp.LeviCivita(a, m, n)
+                    * gammas[m]
+                    * gammas[n]
+                )
+        result.append(bivector)
+    return tuple(result)
 
 
 B_8 = weak_bivectors(G_SPATIAL_8)
 B_16 = weak_bivectors(G_SPATIAL_16)
 
-GAMMA5_4D = G0_4D @ G1_4D @ G2_4D @ G3_4D
-P_L = (I16 + GAMMA5_4D) / 2.0
-P_R = (I16 - GAMMA5_4D) / 2.0
-Y_BRIDGES = [P_R @ G @ P_L for G in G_SPATIAL_16]
+GAMMA5 = G0_16 * G_SPATIAL_16[0] * G_SPATIAL_16[1] * G_SPATIAL_16[2]
+P_L = (I16 + GAMMA5) / 2
+P_R = (I16 - GAMMA5) / 2
+Y = tuple(P_R * gamma * P_L for gamma in G_SPATIAL_16)
 
 
-def vector_error(generators: list[np.ndarray], family: list[np.ndarray]) -> float:
-    worst = 0.0
-    for a, B in enumerate(generators, start=1):
-        for b, X in enumerate(family, start=1):
-            target = sum(1j * eps(a, b, c) * family[c - 1] for c in range(1, 4))
-            err = np.linalg.norm(B @ X - X @ B - target)
-            worst = max(worst, float(err))
-    return worst
+VECTOR_TABLE = {
+    (0, 1): (1, 2),
+    (1, 0): (-1, 2),
+    (1, 2): (1, 0),
+    (2, 1): (-1, 0),
+    (2, 0): (1, 1),
+    (0, 2): (-1, 1),
+}
 
 
-def clifford_error(family: list[np.ndarray], identity: np.ndarray) -> float:
-    worst = 0.0
-    for i, Gi in enumerate(family):
-        for j, Gj in enumerate(family):
-            target = 2.0 * identity if i == j else np.zeros_like(identity)
-            err = np.linalg.norm(Gi @ Gj + Gj @ Gi - target)
-            worst = max(worst, float(err))
-    return worst
+def vector_target(
+    a: int,
+    b: int,
+    family: Sequence[sp.MatrixBase],
+    target_sign: int = 1,
+) -> sp.MatrixBase:
+    if a == b:
+        return sp.zeros(family[0].rows)
+    sign, index = VECTOR_TABLE[(a, b)]
+    return target_sign * sign * sp.I * family[index]
 
 
-def double_commutator_error(generators: list[np.ndarray], family: list[np.ndarray], coeff: float) -> float:
-    worst = 0.0
-    for X in family:
-        double = sum(B @ (B @ X - X @ B) - (B @ X - X @ B) @ B for B in generators)
-        err = np.linalg.norm(double - coeff * X)
-        worst = max(worst, float(err))
-    return worst
+def clifford_residuals(
+    family: Sequence[sp.MatrixBase], identity: sp.MatrixBase
+) -> list[sp.MatrixBase]:
+    return [
+        family[i] * family[j]
+        + family[j] * family[i]
+        - (2 * identity if i == j else sp.zeros(identity.rows))
+        for i in range(3)
+        for j in range(3)
+    ]
 
 
-def gram_matrix(family: list[np.ndarray]) -> np.ndarray:
-    n = len(family)
-    gram = np.zeros((n, n), dtype=complex)
-    for i, Xi in enumerate(family):
-        for j, Xj in enumerate(family):
-            gram[i, j] = np.trace(Xi.conj().T @ Xj)
-    return gram
+def cyclic_bivector_residuals(
+    bivectors: Sequence[sp.MatrixBase], gammas: Sequence[sp.MatrixBase]
+) -> list[sp.MatrixBase]:
+    cyclic = ((1, 2), (2, 0), (0, 1))
+    return [
+        bivectors[a] + sp.I * sp.Rational(1, 2) * gammas[m] * gammas[n]
+        for a, (m, n) in enumerate(cyclic)
+    ]
+
+
+def su2_residuals(generators: Sequence[sp.MatrixBase]) -> list[sp.MatrixBase]:
+    return [
+        commutator(generators[a], generators[b])
+        - vector_target(a, b, generators)
+        for a in range(3)
+        for b in range(3)
+    ]
+
+
+def vector_residuals(
+    generators: Sequence[sp.MatrixBase],
+    family: Sequence[sp.MatrixBase],
+    target_sign: int = 1,
+) -> list[sp.MatrixBase]:
+    return [
+        commutator(generators[a], family[b])
+        - vector_target(a, b, family, target_sign)
+        for a in range(3)
+        for b in range(3)
+    ]
+
+
+def casimir_residuals(
+    generators: Sequence[sp.MatrixBase],
+    family: Sequence[sp.MatrixBase],
+    coefficient: sp.Expr,
+) -> list[sp.MatrixBase]:
+    result = []
+    for member in family:
+        double = sum(
+            (
+                commutator(generator, commutator(generator, member))
+                for generator in generators
+            ),
+            sp.zeros(member.rows),
+        )
+        result.append(double - coefficient * member)
+    return result
+
+
+def gram_matrix(family: Sequence[sp.MatrixBase]) -> sp.MatrixBase:
+    return sp.Matrix(
+        3,
+        3,
+        lambda i, j: sp.trace(family[i].H * family[j]),
+    )
+
+
+def projector_residuals(
+    plus: sp.MatrixBase, minus: sp.MatrixBase
+) -> list[sp.MatrixBase]:
+    return [
+        plus * plus - plus,
+        minus * minus - minus,
+        plus * minus,
+        plus + minus - I16,
+        GAMMA5 * plus - plus,
+        GAMMA5 * minus + minus,
+    ]
+
+
+def chirality_residuals() -> list[sp.MatrixBase]:
+    return [
+        GAMMA5 * GAMMA5 - I16,
+        GAMMA5.H - GAMMA5,
+        *(GAMMA5 * gamma + gamma * GAMMA5 for gamma in G_SPATIAL_16),
+    ]
+
+
+def projector_commutator_residuals() -> list[sp.MatrixBase]:
+    return [
+        *(commutator(generator, P_L) for generator in B_16),
+        *(commutator(generator, P_R) for generator in B_16),
+    ]
+
+
+def chiral_orientation_residuals() -> list[sp.MatrixBase]:
+    result = []
+    for member in Y:
+        result.extend(
+            (
+                P_R * member * P_L - member,
+                P_L * member,
+                member * P_R,
+            )
+        )
+    return result
+
+
+def numeric_max(residuals: Iterable[sp.MatrixBase]) -> float:
+    values = (
+        abs(complex(sp.N(entry, 16)))
+        for residual in residuals
+        for entry in residual
+    )
+    return max(values, default=0.0)
 
 
 def main() -> int:
     print("=" * 78)
-    print("NEUTRINO WEAK VECTOR THEOREM")
-    print("=" * 78)
-    print()
-
-    print("Part 0: Explicit Clifford and chirality packet")
-    cliff_8 = clifford_error(G_SPATIAL_8, I8)
-    cliff_16 = clifford_error(G_SPATIAL_16, I16)
-    gamma5_anticomm = max(float(np.linalg.norm(G @ GAMMA5_4D + GAMMA5_4D @ G)) for G in G_SPATIAL_16)
-    projector_err = max(
-        float(np.linalg.norm(P_L @ P_L - P_L)),
-        float(np.linalg.norm(P_R @ P_R - P_R)),
-        float(np.linalg.norm(P_L @ P_R)),
-        float(np.linalg.norm(P_L + P_R - I16)),
-    )
-    print(f"  max C^8 spatial Clifford error = {cliff_8:.3e}")
-    print(f"  max C^16 spatial Clifford error = {cliff_16:.3e}")
-    print(f"  max {{Gamma_i, gamma_5}} error = {gamma5_anticomm:.3e}")
-    print(f"  max chiral projector algebra error = {projector_err:.3e}")
-    print()
-    check("C^8 Gamma_i satisfy {Gamma_i,Gamma_j}=2 delta_ij", cliff_8 < 1e-12)
-    check("C^16 Gamma_i satisfy {Gamma_i,Gamma_j}=2 delta_ij", cliff_16 < 1e-12)
-    check("gamma_5 anticommutes with each spatial Gamma_i", gamma5_anticomm < 1e-12)
-    check("P_L and P_R are complementary orthogonal projectors", projector_err < 1e-12)
-    print()
-
-    print("Part 1: Derived weak SU(2) on the taste space")
-    su2_err = 0.0
-    for a, Ba in enumerate(B_8, start=1):
-        for b, Bb in enumerate(B_8, start=1):
-            target = sum(1j * eps(a, b, c) * B_8[c - 1] for c in range(1, 4))
-            su2_err = max(su2_err, float(np.linalg.norm(Ba @ Bb - Bb @ Ba - target)))
-    casimir_err = np.linalg.norm(sum(B @ B for B in B_8) - 0.75 * I8)
-    gram_b = gram_matrix(B_8)
-    print(f"  max su(2) commutator error = {su2_err:.3e}")
-    print(f"  ||sum_a B_a^2 - (3/4)I|| = {casimir_err:.3e}")
-    print()
-    check("bivectors form exact su(2)", su2_err < 1e-12, detail=f"max err = {su2_err:.3e}")
-    check("fermion-space Casimir is 3/4", casimir_err < 1e-12, detail=f"err = {casimir_err:.3e}")
-    check(
-        "bivector trace Gram matrix is diagonal",
-        np.allclose(gram_b, 2.0 * np.eye(3), atol=1e-12),
-        detail="Tr(B_a^dag B_b) = 2 delta_ab",
-    )
-
-    print()
-    print("Part 2: Spatial Gamma_i form an exact weak vector on C^8")
-    vec_err_8 = vector_error(B_8, G_SPATIAL_8)
-    cas_vec_8 = double_commutator_error(B_8, G_SPATIAL_8, coeff=2.0)
-    gram_g = gram_matrix(G_SPATIAL_8)
-    avg_conj_err = 0.0
-    for G in G_SPATIAL_8:
-        avg_conj_err = max(avg_conj_err, float(np.linalg.norm(sum(B @ G @ B for B in B_8) + 0.25 * G)))
-    print(f"  max vector-law error = {vec_err_8:.3e}")
-    print(f"  max double-commutator error = {cas_vec_8:.3e}")
-    print(f"  max sum_a B_a G_i B_a + (1/4) G_i error = {avg_conj_err:.3e}")
-    print()
-    check("Gamma_i obey exact weak-vector commutator law", vec_err_8 < 1e-12)
-    check("Gamma_i carry spin-1 Casimir", cas_vec_8 < 1e-12, detail="sum_a ad(B_a)^2 = 2")
-    check(
-        "Gamma_i are trace-orthogonal",
-        np.allclose(gram_g, 8.0 * np.eye(3), atol=1e-12),
-        detail="Tr(Gamma_i^dag Gamma_j) = 8 delta_ij",
-    )
-    check("conjugation average matches vector identity", avg_conj_err < 1e-12)
-
-    print()
-    print("Part 3: Chiral bridges Y_i = P_R Gamma_i P_L form the same weak vector on C^16")
-    gamma5_comm = max(float(np.linalg.norm(B @ GAMMA5_4D - GAMMA5_4D @ B)) for B in B_16)
-    vec_err_16 = vector_error(B_16, Y_BRIDGES)
-    cas_vec_16 = double_commutator_error(B_16, Y_BRIDGES, coeff=2.0)
-    gram_y = gram_matrix(Y_BRIDGES)
-    print(f"  max [B_a, gamma_5] error = {gamma5_comm:.3e}")
-    print(f"  max bridge vector-law error = {vec_err_16:.3e}")
-    print(f"  max bridge double-commutator error = {cas_vec_16:.3e}")
-    print()
-    check("weak generators commute with gamma_5", gamma5_comm < 1e-12)
-    check("bridge family obeys exact weak-vector commutator law", vec_err_16 < 1e-12)
-    check("bridge family carries spin-1 Casimir", cas_vec_16 < 1e-12, detail="sum_a ad(B_a)^2 = 2")
-    check(
-        "bridge family is trace-orthogonal",
-        np.allclose(gram_y, 8.0 * np.eye(3), atol=1e-12),
-        detail="Tr(Y_i^dag Y_j) = 8 delta_ij",
-    )
-
-    print()
-    print("Part 4: Weak-vector covariance does not fix absolute normalization")
-    lambdas = [0.5, math.sqrt(2.0), 2.0]
-    for lam in lambdas:
-        scaled = [lam * Y for Y in Y_BRIDGES]
-        err_cov = vector_error(B_16, scaled)
-        err_cas = double_commutator_error(B_16, scaled, coeff=2.0)
-        gram_scaled = gram_matrix(scaled)
-        print(f"  lambda = {lam:.6f}: max cov err = {err_cov:.3e}, max Casimir err = {err_cas:.3e}")
-        check(
-            f"scaled family lambda={lam:.6f} preserves weak-vector covariance",
-            err_cov < 1e-12 and err_cas < 1e-12,
-            detail=f"Tr-scaled norm = {gram_scaled[0,0].real:.6f}",
-        )
-
-    print()
-    print("Honest read:")
-    print("  1. The direct local chiral bridges Y_i = P_R Gamma_i P_L are now an")
-    print("     exact weak-vector family, not just an axis-picked operator guess.")
-    print("  2. This is real theorem-grade progress: the bridge family carries the")
-    print("     spin-1 Casimir and exact adjoint SU(2) transformation law.")
-    print("  3. But covariance alone is homogeneous. Rescaled families lambda Y_i")
-    print("     satisfy the same weak-vector equations, so the representation law")
-    print("     does not by itself select the physical base normalization.")
-    print("  4. Base normalization is a separate input outside this runner.")
-    print("     What remains beyond this runner is the second-order suppression")
-    print("     law, not weak-vector classification.")
-    print()
-    print("=" * 78)
-    print(f"RESULT: {PASS_COUNT} PASS, {FAIL_COUNT} FAIL")
+    print("FINITE-DIMENSIONAL CHIRAL VECTOR REPRESENTATION THEOREM")
     print("=" * 78)
 
-    return 0 if FAIL_COUNT == 0 else 1
+    load_bearing: list[sp.MatrixBase] = []
+
+    def run_exact(name: str, residuals: list[sp.MatrixBase], detail: str = "") -> None:
+        load_bearing.extend(residuals)
+        exact(name, residuals, detail)
+
+    print("\nPart 1: exact Clifford and chirality packet")
+    run_exact("C^8 spatial Clifford relations", clifford_residuals(G_SPATIAL_8, I8))
+    run_exact(
+        "C^16 spatial Clifford relations",
+        clifford_residuals(G_SPATIAL_16, I16),
+    )
+    run_exact(
+        "gamma_5 involution, Hermiticity, and spatial anticommutation",
+        chirality_residuals(),
+    )
+    run_exact("oriented complementary chiral projectors", projector_residuals(P_L, P_R))
+
+    print("\nPart 2: exact derived bivectors and vector laws")
+    run_exact(
+        "C^8 bivector double-sum equals cyclic formula",
+        cyclic_bivector_residuals(B_8, G_SPATIAL_8),
+    )
+    run_exact(
+        "C^16 bivector double-sum equals cyclic formula",
+        cyclic_bivector_residuals(B_16, G_SPATIAL_16),
+    )
+    run_exact("C^8 bivectors obey su(2)", su2_residuals(B_8))
+    run_exact("C^16 bivectors obey su(2)", su2_residuals(B_16))
+    run_exact(
+        "C^8 Gamma family obeys the vector commutator",
+        vector_residuals(B_8, G_SPATIAL_8),
+    )
+    run_exact(
+        "C^16 Gamma family obeys the vector commutator",
+        vector_residuals(B_16, G_SPATIAL_16),
+    )
+    run_exact(
+        "bivectors commute with both chiral projectors",
+        projector_commutator_residuals(),
+    )
+
+    print("\nPart 3: exact chiral family, Casimir, and Gram identities")
+    run_exact("Y_i has P_R-to-P_L orientation", chiral_orientation_residuals())
+    run_exact("Y_i obeys the vector commutator", vector_residuals(B_16, Y))
+    run_exact(
+        "C^8 Gamma family has adjoint Casimir 2",
+        casimir_residuals(B_8, G_SPATIAL_8, sp.Integer(2)),
+    )
+    run_exact(
+        "C^16 Gamma family has adjoint Casimir 2",
+        casimir_residuals(B_16, G_SPATIAL_16, sp.Integer(2)),
+    )
+    run_exact(
+        "Y_i has adjoint Casimir 2",
+        casimir_residuals(B_16, Y, sp.Integer(2)),
+    )
+    gram_y = gram_matrix(Y)
+    run_exact("Tr(Y_i^dag Y_j) = 8 delta_ij", [gram_y - 8 * sp.eye(3)])
+
+    print("\nPart 4: universal symbolic rescaling identities")
+    lam = sp.Symbol("lambda", complex=True)
+    scaled_y = tuple(lam * member for member in Y)
+    run_exact(
+        "symbolic lambda Y_i obeys the vector commutator",
+        vector_residuals(B_16, scaled_y),
+        "polynomial identity in lambda",
+    )
+    run_exact(
+        "symbolic lambda Y_i has adjoint Casimir 2",
+        casimir_residuals(B_16, scaled_y, sp.Integer(2)),
+        "polynomial identity in lambda",
+    )
+    run_exact(
+        "Gram(lambda Y) = conjugate(lambda) lambda Gram(Y)",
+        [gram_matrix(scaled_y) - sp.conjugate(lam) * lam * gram_y],
+        "symbolic complex scalar",
+    )
+
+    print("\nPart 5: numerical support (non-load-bearing)")
+    max_residual = numeric_max(load_bearing)
+    report(
+        "SUPPORT",
+        "floating evaluation agrees with exact zero residuals",
+        max_residual < 1.0e-12,
+        f"max residual = {max_residual:.3e}",
+    )
+    scaled_two_gram = gram_matrix(tuple(2 * member for member in Y))
+    scaled_two_error = numeric_max([scaled_two_gram - 32 * sp.eye(3)])
+    report(
+        "SUPPORT",
+        "lambda=2 sample has Gram diagonal 32",
+        scaled_two_error < 1.0e-12,
+        f"max residual = {scaled_two_error:.3e}",
+    )
+
+    print("\nPart 6: hostile mutation rejection")
+    reject_mutation("wrong bivector sign", su2_residuals(tuple(-generator for generator in B_8)))
+    doubled_b = tuple(2 * generator for generator in B_8)
+    reject_mutation(
+        "wrong bivector normalization",
+        [*su2_residuals(doubled_b), *vector_residuals(doubled_b, G_SPATIAL_8)],
+    )
+    reject_mutation("wrong vector sign", vector_residuals(B_16, Y, target_sign=-1))
+    reject_mutation("wrong vector index", vector_residuals(B_16, (Y[1], Y[0], Y[2])))
+    reject_mutation("reversed chiral projector orientation", projector_residuals(P_R, P_L))
+    reject_mutation(
+        "false adjoint Casimir coefficient 3",
+        casimir_residuals(B_16, Y, sp.Integer(3)),
+    )
+    reject_mutation("false Gram normalization 16 delta_ij", [gram_y - 16 * sp.eye(3)])
+    false_off_diagonal = 8 * sp.eye(3)
+    false_off_diagonal[0, 1] = 1
+    false_off_diagonal[1, 0] = 1
+    reject_mutation("false nonzero off-diagonal Gram claim", [gram_y - false_off_diagonal])
+    reject_mutation("false invariant Gram under lambda=2", [scaled_two_gram - gram_y])
+
+    print("\n" + "=" * 78)
+    total_pass = sum(COUNTS[lane]["pass"] for lane in LANES)
+    total_fail = sum(COUNTS[lane]["fail"] for lane in LANES)
+    for lane in LANES:
+        print(f"{lane}: PASS={COUNTS[lane]['pass']} FAIL={COUNTS[lane]['fail']}")
+    print(f"RESULT: PASS={total_pass} FAIL={total_fail}")
+    print("=" * 78)
+    return 0 if total_fail == 0 else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Scope

Repairs exactly `dm_neutrino_weak_vector_theorem_note_2026-04-15` by narrowing it to a positive finite-dimensional representation theorem.

- Retains the explicit Pauli/Kronecker Clifford packets on `C^8` and `C^16`.
- Rederives the derived `B_a` `su(2)`, chiral projectors, `Y_i=P_R Gamma_i P_L`, vector commutators, adjoint Casimir `2`, and `Tr(Y_i^dag Y_j)=8 delta_ij`.
- States universal scalar rescaling only as a homogeneous closure property, with symbolic `conjugate(lambda) lambda` Gram scaling.
- Removes physical coefficient, normalization, and second-order boundary conclusions.
- Adds the dated 2026-07-18 downstream-hygiene sentence requested by archived audit guidance.

The theorem does not identify the abstract packet with an electroweak-neutrino system and does not assert or deny coefficients attached to any physical identification.

## Executable evidence

Independent review iteration 1 corrected the runner/cache map-direction label to state that `P_R Gamma_i P_L` maps the `P_L` subspace into the `P_R` subspace; the matrix definitions and theorem identities were unchanged. Review commit: `bfabf999ce68945e189afb1f28b372b5c8cb3d68`.

The primary runner now uses exact SymPy matrices over Gaussian rationals. Fresh SHA-bound cache:

- Runner SHA-256: `e92e0401ef9404cdfdb9bd80e7d39fb4b1f066b4fa26d25be9a0793e1d06beb8`
- EXACT: `20 PASS / 0 FAIL`
- SUPPORT: `2 PASS / 0 FAIL`
- MUTATION: `9 PASS / 0 FAIL`
- Total: `31 PASS / 0 FAIL`

The mutation lane rejects computed hostile variants for:

1. Wrong bivector sign.
2. Wrong bivector normalization.
3. Wrong vector sign.
4. Wrong vector index.
5. Reversed chiral projector orientation.
6. False Casimir coefficient `3`.
7. False Gram normalization.
8. False nonzero off-diagonal Gram entry.
9. False invariant Gram under `lambda=2`.

An independent reconstruction that does not import the primary runner reproduced `Gram(Y)=8 I_3`, both carrier Casimirs, the vector law, and symbolic `z conjugate(z)` scaling.

## Consumer disposition

Ledger dependencies and prose/executable references were traced.

- `DM_NEUTRINO_DIRAC_BRIDGE_THEOREM_NOTE_2026-04-15.md`: removed the non-load-bearing citation that used this row to announce physical direct-bridge closure; its independent runner remains `28 PASS / 0 FAIL`.
- `DM_NEUTRINO_SCHUR_SUPPRESSION_NAMED_ADMISSIONS_BOUNDED_THEOREM_NOTE_2026-06-07.md`: unchanged because it consumes only the exact raw Gram identity and explicitly firewalls the physical readout; runner `18 PASS / 0 FAIL`.
- `V_EVEN_THEOREM_RETENTION_NOTE_2026-05-03.md` and its runner: unchanged because they consume only representation content. Both source-dependent checks pass. The legacy runner's two remaining failures are pre-existing checks against unrelated staging-note wording.

## Verification

- Primary runner and fresh SHA-bound cache.
- Direct consumer runners.
- `python3 -m py_compile`.
- Independent exact reconstruction.
- Hostile mutation suite.
- Controlled-vocabulary lint: 0 violations.
- Repository invariants with link enforcement: PASS, 0 link violations.
- Axiom/approved-primitive purity: PASS.
- Staged claim typing: PASS.
- Cache freshness check: PASS.
- `git diff --check`: PASS.

## Audit discipline

This is source-author science-fix work only. No audit-loop, audit worker, `scripts/codex_audit_runner.py`, `apply_audit.py`, audit pipeline, audit verdict, or generated publication/audit surface was invoked or authored. The audit ledger was read for evidence and consumer tracing and was not edited. No axiom, primitive, carrier, admission, premise registry, or publication-governance file changed. Independent review and any later re-audit remain separate.

