### PR TITLE
review-loop: parallel-by-default entry (any orchestrator; serial landings)

### DIFF
--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -227,22 +227,55 @@ no topology decisions required from the invoker.
    conflict touching only `docs/audit/data/citation_graph_manifest.json`
    is resolved by regenerating it from the landed tree
    (`build_citation_graph.py` then `write_citation_graph_manifest.py`),
-   never by hand-merge. The fail-closed landing loop is, exactly:
+   never by hand-merge; a manifest regeneration touches only that generated
+   acknowledgment surface, so it needs no new reviewer round — any OTHER
+   conflict fails the landing closed and returns the PR to its worker for
+   re-review on a rebased head. Generated-output restoration is a
+   COMMIT-time rule (see the audit-compatibility gate), not a landing-time
+   step: the commits being landed are already clean. The fail-closed
+   landing loop is, exactly:
    ```bash
-   for i in 1 2 3 4; do
-     git cherry-pick --abort 2>/dev/null || true
-     git fetch -q origin
-     git checkout -q --detach origin/main
-     if git cherry-pick <commits-oldest-first>; then
-       git checkout -q -- docs/audit/data docs/publication 2>/dev/null || true
-       if git push origin HEAD:main; then echo LANDED; break; fi
+   COMMITS=(<oldest-sha> ... <newest-sha>)  # the PR's commits, oldest first
+   landed=""
+   for attempt in 1 2 3 4; do
+     git cherry-pick --abort >/dev/null 2>&1 || true
+     if ! { git fetch -q origin && git checkout -q --detach origin/main; }; then
+       sleep 3; continue
+     fi
+     if ! git cherry-pick "${COMMITS[@]}" >/dev/null 2>&1; then
+       conflicts="$(git diff --name-only --diff-filter=U)"
+       if [ "$conflicts" != "docs/audit/data/citation_graph_manifest.json" ]; then
+         git cherry-pick --abort >/dev/null 2>&1 || true
+         echo "FAILED: source conflict; return the PR to its worker" >&2
+         exit 1
+       fi
+       if ! { python3 docs/audit/scripts/build_citation_graph.py >/dev/null \
+              && python3 docs/audit/scripts/write_citation_graph_manifest.py >/dev/null \
+              && git add docs/audit/data/citation_graph_manifest.json \
+              && GIT_EDITOR=true git cherry-pick --continue >/dev/null; }; then
+         sleep 3; continue
+       fi
+     fi
+     if git push -q origin HEAD:main; then
+       landed="$(git rev-parse HEAD)"
+       break
      fi
      sleep 3
    done
+   if [ -z "$landed" ]; then
+     echo "FAILED: landing did not complete after 4 attempts" >&2
+     exit 1
+   fi
+   git fetch -q origin
+   if ! git merge-base --is-ancestor "$landed" origin/main; then
+     echo "FAILED: $landed not contained in origin/main" >&2
+     exit 1
+   fi
+   echo "LANDED $landed"
    ```
-   Everything conditioned — never a stray `;` before the push (a failed
-   cherry-pick would then push a no-op reported as landed). Verify after:
-   `git fetch && git branch -r --contains <landed-sha> | grep origin/main`.
+   Every step is conditioned; push success captures the landed sha; retry
+   exhaustion and non-containment both exit nonzero — the loop can never
+   report success without the landed sha verified inside `origin/main`.
 6. **Who may kick it off: any orchestrator** — any Claude tier, a codex
    session, or a human. The orchestration is process: every finding and
    every PASS/FAIL verdict comes from the configured reviewer model's seats,

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -200,7 +200,11 @@ no topology decisions required from the invoker.
    in this repo's history.
 3. **One reviewer process per PR at a time**, applicable lenses combined
    into a single pass (two for large diffs), findings written incrementally
-   to an untracked file in that PR's worktree, verdict line last. This is
+   to an untracked file in that PR's worktree, verdict line last. Freeze
+   the PR's original changed-file snapshot BEFORE creating the findings
+   file; the findings file and any reviewer scratch artifacts are named
+   scope exclusions — they never enter `files_to_review`, the changed-file
+   set, or any commit. This is
    the budget-adapted default of the Reviewer Fanout section below: under
    the shared-pool budget, cross-PR parallelism replaces per-lens
    parallelism; full per-lens fanout inside one PR remains available in a
@@ -223,7 +227,22 @@ no topology decisions required from the invoker.
    conflict touching only `docs/audit/data/citation_graph_manifest.json`
    is resolved by regenerating it from the landed tree
    (`build_citation_graph.py` then `write_citation_graph_manifest.py`),
-   never by hand-merge.
+   never by hand-merge. The fail-closed landing loop is, exactly:
+   ```bash
+   for i in 1 2 3 4; do
+     git cherry-pick --abort 2>/dev/null || true
+     git fetch -q origin
+     git checkout -q --detach origin/main
+     if git cherry-pick <commits-oldest-first>; then
+       git checkout -q -- docs/audit/data docs/publication 2>/dev/null || true
+       if git push origin HEAD:main; then echo LANDED; break; fi
+     fi
+     sleep 3
+   done
+   ```
+   Everything conditioned — never a stray `;` before the push (a failed
+   cherry-pick would then push a no-op reported as landed). Verify after:
+   `git fetch && git branch -r --contains <landed-sha> | grep origin/main`.
 6. **Who may kick it off: any orchestrator** — any Claude tier, a codex
    session, or a human. The orchestration is process: every finding and
    every PASS/FAIL verdict comes from the configured reviewer model's seats,
@@ -361,9 +380,12 @@ lint to regenerate it.
 On each iteration, set `files_to_review` to the files that changed since their
 last clean review. On iteration 1, use all original changed files.
 
-Run all applicable reviewers in parallel through the available agent/subagent
-mechanism. If parallel agents are unavailable, run the same reviewer passes
-locally and report that limitation.
+Run every applicable reviewer lens. Under the shared-pool concurrency
+budget (Default Entry above), combine the lenses into one or two passes per
+PR — full per-lens parallel fanout through the available agent/subagent
+mechanism is the quiet-pool mode. If parallel agents are unavailable, run
+the same reviewer passes locally and report that limitation. In every mode,
+each applicable lens must be explicitly covered and named in the findings.
 
 ### Required Reviewers
 

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -213,10 +213,17 @@ no topology decisions required from the invoker.
    throughput from 6-11 landed verdicts/hour to ~1 every 3 hours). When the
    audit drain is running at 4+ seats, run at most 2-3 concurrent PR
    reviewers; scale up only in a quiet pool.
-5. **Fixes and landings serialize.** Apply Fix Policy fixes per PR as its
-   round returns; a focused confirmation round follows each fix pass. Land
-   ONE PR at a time through the fail-closed cherry-pick loop, re-fetching
-   `origin/main` before every landing.
+5. **Each worker lands its own PR, end to end.** Fix Policy fixes, the
+   focused confirmation round, the landing, and the close-with-provenance
+   are all the final steps of that PR's own worker — never a separate
+   lander and never turn-taking. Workers land the moment their
+   confirmation passes: `origin/main`'s push atomicity is the only
+   serializer, and a lost push race costs seconds (re-fetch, re-cherry-pick
+   through the fail-closed loop, re-push, generated outputs restored). A
+   conflict touching only `docs/audit/data/citation_graph_manifest.json`
+   is resolved by regenerating it from the landed tree
+   (`build_citation_graph.py` then `write_citation_graph_manifest.py`),
+   never by hand-merge.
 6. **Who may kick it off: any orchestrator** — any Claude tier, a codex
    session, or a human. The orchestration is process: every finding and
    every PASS/FAIL verdict comes from the configured reviewer model's seats,

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -21,8 +21,8 @@ be explicit, and support-only results must not be promoted by prose.
 
 Review-loop is a text/code/math review path. Run it with the user's configured
 highest-tier Codex reviewer model and maximum available reasoning for this
-repo (currently GPT-5.5 at extra-high/xhigh reasoning in the local Codex
-configuration). Do not switch to lower-reasoning models for convenience, and
+repo (currently GPT-5.6-Sol; use the maximum available reasoning tier unless
+the owner directs a specific tier for the episode). Do not switch to lower-reasoning models for convenience, and
 do not use image-generation, image-editing, presentation, document-rendering,
 or visual-generation tools unless the user explicitly asks for a separate
 visual artifact task.
@@ -184,6 +184,46 @@ pipeline, and verifying the target appears in `docs/audit/AUDIT_DISPATCH_QUEUE.m
 or `docs/audit/data/audit_dispatch_queue.json`. The dispatch manifest is
 target-selection metadata only; it must not be passed to auditors as evidence
 and must not apply audit verdicts.
+
+## Default Entry: Parallel PR Review, Any Orchestrator (owner-directed 2026-07-17)
+
+Invoking this skill against a SET of open PRs ("review the open PRs",
+"drain the PR backlog") means: review them in parallel, land them serially —
+no topology decisions required from the invoker.
+
+1. **Enumerate targets**: open, non-draft PRs in scope (drafts stay out of
+   scope per the draft rule below). Detect stacks and cumulative-tower
+   branches first; stacked PRs review and land bottom-up as deltas, never in
+   parallel with each other.
+2. **One isolated worktree per PR.** Parallel reviews never share a
+   worktree or a checkout; shared worktrees race and have destroyed findings
+   in this repo's history.
+3. **One reviewer process per PR**, applicable lenses combined into a
+   single pass (two for large diffs), findings written incrementally to an
+   untracked file in that PR's worktree, verdict line last.
+4. **Concurrency budget (shared codex pool).** Reviewer processes share one
+   pool with the audit lane's auditor seats and judicial panels. Keep the
+   TOTAL concurrent codex processes across every lane at or under ~8-10
+   (measured 2026-07-17: ~18 concurrent processes collapsed audit-lane
+   throughput from 6-11 landed verdicts/hour to ~1 every 3 hours). When the
+   audit drain is running at 4+ seats, run at most 2-3 concurrent PR
+   reviewers; scale up only in a quiet pool.
+5. **Fixes and landings serialize.** Apply Fix Policy fixes per PR as its
+   round returns; a focused confirmation round follows each fix pass. Land
+   ONE PR at a time through the fail-closed cherry-pick loop, re-fetching
+   `origin/main` before every landing.
+6. **Who may kick it off: any orchestrator** — any Claude tier, a codex
+   session, or a human. The orchestration is process: every finding and
+   every PASS/FAIL verdict comes from the configured reviewer model's seats,
+   the orchestrator fixes only per Fix Policy, and nothing lands without a
+   reviewer PASS on its final state. The orchestrator never self-certifies.
+   Substituting a different reviewer family for a round (for example a
+   fresh-context reviewer when the codex lane is unavailable) requires
+   explicit owner authorization for that episode and must be disclosed in
+   the PR's provenance comment.
+
+The single-PR procedure in the rest of this skill is the inner loop of each
+parallel slot; nothing below is weakened by running slots concurrently.
 
 ## Author Pre-Flight (input hygiene)
 

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -198,9 +198,14 @@ no topology decisions required from the invoker.
 2. **One isolated worktree per PR.** Parallel reviews never share a
    worktree or a checkout; shared worktrees race and have destroyed findings
    in this repo's history.
-3. **One reviewer process per PR**, applicable lenses combined into a
-   single pass (two for large diffs), findings written incrementally to an
-   untracked file in that PR's worktree, verdict line last.
+3. **One reviewer process per PR at a time**, applicable lenses combined
+   into a single pass (two for large diffs), findings written incrementally
+   to an untracked file in that PR's worktree, verdict line last. This is
+   the budget-adapted default of the Reviewer Fanout section below: under
+   the shared-pool budget, cross-PR parallelism replaces per-lens
+   parallelism; full per-lens fanout inside one PR remains available in a
+   quiet pool, and every applicable lens must be explicitly covered either
+   way.
 4. **Concurrency budget (shared codex pool).** Reviewer processes share one
    pool with the audit lane's auditor seats and judicial panels. Keep the
    TOTAL concurrent codex processes across every lane at or under ~8-10

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -222,6 +222,16 @@ no topology decisions required from the invoker.
    explicit owner authorization for that episode and must be disclosed in
    the PR's provenance comment.
 
+7. **Progress reports every 15 minutes.** While any slot is active, emit a
+   summary block to the operator surface at least every 15 minutes — never
+   silence for a long session: a per-PR table (PR number, phase — reviewing
+   round N / fixing / confirmation / landing / landed / closed-with-reason —
+   reviewer runtime, and the finding count so far read from that PR's
+   incremental findings file), landings so far with their main SHAs, the
+   remaining queue, and the current codex process count against the budget.
+   A session that stops early still emits a final block with the same
+   fields; the Final Report section below remains the full closing artifact.
+
 The single-PR procedure in the rest of this skill is the inner loop of each
 parallel slot; nothing below is weakened by running slots concurrently.
 


### PR DESCRIPTION
Companion to #5504's audit-loop default entry, per owner direction: review-loop invoked against a set of open PRs now defaults to parallel per-PR reviewer processes (one isolated worktree each; stacks bottom-up, never parallel within a stack), strictly serialized fixes and landings via the fail-closed loop, and the shared-pool concurrency budget with the dated collapse measurement. Any orchestrator (any Claude tier, codex, human) may start it: findings and PASS/FAIL come only from the configured reviewer model, the orchestrator never self-certifies, and reviewer-family substitution remains per-episode owner-authorized with provenance disclosure. Also fixes the stale GPT-5.5 parenthetical.

Docs-only (one file). Review gate: sol xhigh round (queued behind #5504's round per the one-slot throttle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)