### PR TITLE
coexistence: one audit-lane orchestrator per repo (machine-local lock) + skill contract

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -314,10 +314,13 @@ failure exits nonzero.
 
 **Parallel coexistence with review-loop.** The audit lane and review-loop
 sessions may run at the same time by design; the rules that keep concurrent
-landings cheap are: (1) exactly ONE audit-lane orchestrator per repository —
+landings cheap are: (1) exactly ONE audit-lane orchestrator per clone —
 the drainer and the panel orchestrator enforce this with a machine-local
-exclusive lock and exit with guidance when another instance holds it
-(parallelism belongs in the seats inside the one instance); (2) audit
+exclusive lock keyed to the clone's git common directory, so every worktree
+of that clone shares one lock, and a second instance exits with guidance
+(parallelism belongs in the seats inside the one instance; an INDEPENDENT
+clone has its own lock, and cross-clone coordination stays with this
+contract and the concurrency budget, not the lock); (2) audit
 commits are the expensive racers (they ship regenerated audit surfaces and
 a push race replays the pipeline), review landings are cheap racers
 (cherry-pick retries in seconds) — so the audit lane never waits for

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -312,6 +312,20 @@ through the same per-claim gate ladder as verdicts (pipeline, strict lint,
 serialized commit, race-retried push), mint nothing, and any reseat
 failure exits nonzero.
 
+**Parallel coexistence with review-loop.** The audit lane and review-loop
+sessions may run at the same time by design; the rules that keep concurrent
+landings cheap are: (1) exactly ONE audit-lane orchestrator per repository —
+the drainer and the panel orchestrator enforce this with a machine-local
+exclusive lock and exit with guidance when another instance holds it
+(parallelism belongs in the seats inside the one instance); (2) audit
+commits are the expensive racers (they ship regenerated audit surfaces and
+a push race replays the pipeline), review landings are cheap racers
+(cherry-pick retries in seconds) — so the audit lane never waits for
+review-loop, and review-loop retries rather than queues; (3) neither lane
+hand-merges `docs/audit/data/citation_graph_manifest.json` — a conflict
+touching only that file is resolved by regenerating it from the landed
+tree.
+
 **Apply-gate rejections are data.** When a finished audit is rejected at the
 apply gate (decoration/claim-type mismatch or any compatibility error),
 record the exact rejection with the row id in the run report. Recurring

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -18,6 +18,7 @@ clean guard is repeated immediately before every mutation and race retry.
 from __future__ import annotations
 
 import argparse
+import fcntl
 import hashlib
 import json
 import os
@@ -26,6 +27,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from collections import Counter
@@ -53,6 +55,36 @@ MIN_DELIVERY_BYTES = 200
 PACKET_COMPLETION_STALL_SECONDS = 20 * 60
 PACKET_COMPLETION_POLL_SECONDS = 15
 PACKET_COMPLETION_EXIT_GRACE_SECONDS = 10
+
+
+def acquire_exclusive_drain_lock(label: str):
+    """One audit-lane orchestrator per repository per machine.
+
+    Verdict/reseat commits ship the full regenerated audit-surface set, so
+    two concurrent audit-lane orchestrators race every push and each race
+    costs a multi-minute pipeline replay. Parallelism belongs in the seats
+    INSIDE one orchestrator, never in competing orchestrators. The lock is
+    advisory (flock), machine-local, keyed to the repository path, and
+    released automatically on process exit. Returns an open handle to keep
+    referenced, or None when another orchestrator already holds it.
+    """
+    key = hashlib.sha256(str(REPO_ROOT).encode("utf-8")).hexdigest()[:12]
+    lock_path = Path(tempfile.gettempdir()) / f"audit-lane-{key}.lock"
+    handle = open(lock_path, "w")
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        handle.close()
+        print(
+            "refusing to run: another audit-lane orchestrator holds "
+            f"{lock_path} for this repository. Join the running drain's "
+            "seats (its --max-workers) instead of racing a second "
+            f"instance ({label})."
+        )
+        return None
+    handle.write(f"{label} pid={os.getpid()}\n")
+    handle.flush()
+    return handle
 
 
 def sh(cmd: list[str], timeout: int | None = None) -> subprocess.CompletedProcess:
@@ -1064,6 +1096,10 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
     PROGRESS["dry_run"] = bool(args.dry_run)
+    if not args.dry_run:
+        drain_lock = acquire_exclusive_drain_lock("orchestrate_audit_batch")
+        if drain_lock is None:
+            return 3
     if (
         args.max_workers < 1
         or args.rounds < 1

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -57,8 +57,31 @@ PACKET_COMPLETION_POLL_SECONDS = 15
 PACKET_COMPLETION_EXIT_GRACE_SECONDS = 10
 
 
+def _repo_identity() -> str:
+    """Canonical identity shared by every git worktree of one clone.
+
+    The lock must not key on the checkout root: two worktrees of the same
+    clone would then hold different locks and race pushes anyway. The git
+    common directory is shared across a clone's worktrees. Boundary: an
+    INDEPENDENT clone of the same remote has its own common dir and its own
+    lock — cross-clone coordination stays with the skill's coexistence
+    contract, not this lock.
+    """
+    proc = subprocess.run(
+        ["git", "rev-parse", "--git-common-dir"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    common = (proc.stdout or "").strip()
+    if proc.returncode != 0 or not common:
+        return str(REPO_ROOT.resolve())
+    path = Path(common)
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+    return str(path.resolve())
+
+
 def acquire_exclusive_drain_lock(label: str):
-    """One audit-lane orchestrator per repository per machine.
+    """One audit-lane orchestrator per clone (all its worktrees) per machine.
 
     Verdict/reseat commits ship the full regenerated audit-surface set, so
     two concurrent audit-lane orchestrators race every push and each race
@@ -68,7 +91,7 @@ def acquire_exclusive_drain_lock(label: str):
     released automatically on process exit. Returns an open handle to keep
     referenced, or None when another orchestrator already holds it.
     """
-    key = hashlib.sha256(str(REPO_ROOT).encode("utf-8")).hexdigest()[:12]
+    key = hashlib.sha256(_repo_identity().encode("utf-8")).hexdigest()[:12]
     lock_path = Path(tempfile.gettempdir()) / f"audit-lane-{key}.lock"
     handle = open(lock_path, "w")
     try:

--- a/docs/audit/scripts/orchestrate_judicial_panel.py
+++ b/docs/audit/scripts/orchestrate_judicial_panel.py
@@ -1294,6 +1294,10 @@ def main() -> int:
             )
             return 2
 
+    if not args.dry_run:
+        drain_lock = batch.acquire_exclusive_drain_lock("orchestrate_judicial_panel")
+        if drain_lock is None:
+            return 3
     if not args.dry_run and not (batch.DATA / "citation_graph.json").exists():
         print("derived audit caches missing (fresh clone); running the pipeline once")
         bootstrap = batch.sh(["bash", str(SCRIPTS / "run_pipeline.sh")], timeout=1800)

--- a/docs/audit/scripts/tests/test_drain_lock.py
+++ b/docs/audit/scripts/tests/test_drain_lock.py
@@ -27,7 +27,7 @@ class DrainLockTest(unittest.TestCase):
         import hashlib
         import tempfile
 
-        key = hashlib.sha256(str(batch.REPO_ROOT).encode("utf-8")).hexdigest()[:12]
+        key = hashlib.sha256(batch._repo_identity().encode("utf-8")).hexdigest()[:12]
         expected = Path(tempfile.gettempdir()) / f"audit-lane-{key}.lock"
         handle = batch.acquire_exclusive_drain_lock("test-path")
         try:
@@ -38,6 +38,44 @@ class DrainLockTest(unittest.TestCase):
         finally:
             handle.close()
 
+
+
+class DrainLockWorktreeTest(unittest.TestCase):
+    def test_second_worktree_of_same_clone_shares_the_lock(self):
+        import subprocess
+        import tempfile
+
+        held = batch.acquire_exclusive_drain_lock("wt-primary")
+        self.assertIsNotNone(held)
+        tmp = tempfile.mkdtemp(prefix="drainlock-wt-")
+        wt = Path(tmp) / "wt2"
+        try:
+            subprocess.run(
+                ["git", "worktree", "add", "--detach", str(wt)],
+                cwd=batch.REPO_ROOT, check=True, capture_output=True,
+            )
+            # Hermetic probe: the CURRENT module code (not the worktree's
+            # HEAD checkout) with REPO_ROOT pointed at the second worktree —
+            # tests the keying logic itself, pre- or post-commit.
+            probe = subprocess.run(
+                [sys.executable, "-c",
+                 "import sys; from pathlib import Path\n"
+                 "sys.path.insert(0, sys.argv[1])\n"
+                 "import orchestrate_audit_batch as b\n"
+                 "b.REPO_ROOT = Path(sys.argv[2])\n"
+                 "h = b.acquire_exclusive_drain_lock('wt-secondary')\n"
+                 "print('REFUSED' if h is None else 'ACQUIRED')",
+                 str(Path(batch.__file__).parent), str(wt)],
+                capture_output=True, text=True,
+            )
+            self.assertIn("REFUSED", probe.stdout,
+                          msg=f"stdout={probe.stdout!r} stderr={probe.stderr!r}")
+        finally:
+            held.close()
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", str(wt)],
+                cwd=batch.REPO_ROOT, capture_output=True,
+            )
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/audit/scripts/tests/test_drain_lock.py
+++ b/docs/audit/scripts/tests/test_drain_lock.py
@@ -1,0 +1,43 @@
+"""Exclusive audit-lane orchestrator lock: one instance per repo/machine."""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import orchestrate_audit_batch as batch
+
+
+class DrainLockTest(unittest.TestCase):
+    def test_second_acquire_refused_until_first_released(self):
+        first = batch.acquire_exclusive_drain_lock("test-first")
+        self.assertIsNotNone(first)
+        try:
+            second = batch.acquire_exclusive_drain_lock("test-second")
+            self.assertIsNone(second)
+        finally:
+            first.close()
+        third = batch.acquire_exclusive_drain_lock("test-third")
+        self.assertIsNotNone(third)
+        third.close()
+
+    def test_lock_path_is_repo_keyed_and_outside_repo(self):
+        import hashlib
+        import tempfile
+
+        key = hashlib.sha256(str(batch.REPO_ROOT).encode("utf-8")).hexdigest()[:12]
+        expected = Path(tempfile.gettempdir()) / f"audit-lane-{key}.lock"
+        handle = batch.acquire_exclusive_drain_lock("test-path")
+        try:
+            self.assertEqual(Path(handle.name), expected)
+            self.assertNotIn(
+                str(batch.REPO_ROOT), str(Path(handle.name).parent)
+            )
+        finally:
+            handle.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Final piece of the parallel-kickoff chain (after #5504 and #5506, both landed). Verdict/reseat commits ship regenerated audit surfaces, so competing audit-lane orchestrators race every push at multi-minute pipeline-replay cost — parallelism belongs in the seats inside ONE orchestrator. The drainer and panel orchestrator now take an advisory machine-local flock keyed to the repository path (skipped on --dry-run, auto-released on exit); a second instance exits 3 with join-the-seats guidance. The audit-loop skill gains the coexistence contract: one orchestrator per repo; audit-vs-review race asymmetry (audit never waits, review workers retry in seconds through their own fail-closed loops); manifest-only conflicts regenerate, never hand-merge. 2 lock tests (second-acquire refused until release, live refusal message verified; repo-keyed path outside the repo).

Review gate: one sol xhigh round before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)