### PR TITLE
science: two-presentation swap is proper-rotation conjugacy on the delivered hw=1 carrier

### DIFF
--- a/docs/KCPT_CORNER_CARRIER_TWO_PRESENTATION_SWAP_PROPER_ROTATION_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-07-18.md
+++ b/docs/KCPT_CORNER_CARRIER_TWO_PRESENTATION_SWAP_PROPER_ROTATION_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-07-18.md
@@ -1,0 +1,291 @@
+# KCPT corner carrier: the two-presentation swap is proper-rotation conjugacy on the delivered carrier — K-parity coincides with rotation parity on the Hermitian section (bounded theorem)
+
+- **Registry id:** `kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_bounded_theorem_note_2026-07-18`
+- **Date:** 2026-07-18
+**Claim type:** bounded_theorem
+- **Paired runner:** [kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.py](../scripts/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.py)
+- **Runner cache:** `logs/runner-cache/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.txt`
+
+**Abstract.** The spectral-pairing note supplies a corner carrier `(C, P_chi, K)` and the
+mechanism note flags a two-model presentation pair — the entrywise-conjugate images
+`(C, P_w, K)` and `(C, P_wbar, K)` — with an unfixed binary choice and a live
+Qualification. On the same one-component staggered surface on the periodic `4^3` torus
+that the landed hw=1 delivery note used, this note delivers the presentation-swap as the
+proper cubic rotation `M`: the pi-rotation about `[1,-1,0]` (`det M = +1`), realized as a
+lattice unitary whose hw=1 kernel action is the transposition `TS` (T1). Rotation
+conjugation by `TS` acts on the supplied projector family exactly as entrywise conjugation
+`K`, `TS P_chi TS = conj(P_chi)` for every channel, so the pair is a single 2-orbit of the
+proper rotation and the canonical K-odd separator `D0 = P_w - P_wbar` is exchanged exactly
+as by `K` (T2, T3). On the Hermitian probe section `W_H = a I + b C + conj(b) C^2` the
+antilinear K-exchange coincides exactly with the linear rotation conjugation,
+`conj(W_H) = TS W_H TS`; off the section the two gradings are inequivalent (witnesses
+`C - C^2` and `i I`) (T4). The unfixed binary choice is thereby a rotation-frame
+orientation at the `C_3[111]` axis; the note does not fix it and does not act on the
+memo's live Qualification. An honest operator-level covariance report for a named dressed
+class (T5) is included and consumed by no other claim. All lattice arithmetic is exact
+integer; all carrier algebra is exact symbolic.
+
+## Purpose
+
+The mechanism note's two-model FLAG leaves an unfixed binary choice between the two
+entrywise-conjugate presentations of the supplied corner carrier, and its live
+Qualification keeps that choice conditional. This note asks a structural question about
+that choice: is the exchange of the two presentations a symmetry named by the framework
+axioms? It answers yes on the delivered carrier — the exchange is conjugation by a proper
+cubic rotation named by the LATTICE axiom — and records exactly where the answer stops. It
+reclassifies the unfixed choice as a rotation-frame orientation without fixing it, and it
+leaves the memo's live Qualification untouched. The operator-level covariance report (T5)
+is a separate hardening probe whose computed outcome is consumed by no claim here.
+
+## Supplied objects and consumed readings
+
+This note consumes only the sentences quoted verbatim below; each is reproduced from its
+source without paraphrase, and the paired runner gates both the source text and these
+blockquotes.
+
+From the spectral-pairing note, the supplied corner carrier:
+
+> The real cyclic `C` with `C^3 = I_3` and `C^T = C^2`, the character
+> projectors `P_chi = (I + conj(chi)*C + conj(chi)^2*C^2)/3` for
+> `chi in {1, w, conj(w)}`, `w = -1/2 + (sqrt(3)/2)*i`, and entrywise
+> conjugation `K` in the canonical basis.
+
+and its declared surface FLAG:
+
+> **FLAG — supplied surface:** this is the mechanism note's declared
+> corner surface, not a derived physical carrier.
+
+From the mechanism note, the two-model FLAG and its live Qualification:
+
+> **R2 — K-real derivable initial data.** Derivable initial data is K-real.
+> **FLAG — two-model mechanism:** the entrywise-conjugate presentations in
+> L-K2 satisfy the same named clauses and exchange every K-odd seed. The
+> memo's live Qualification leaves the unfixed choice conditional/open.
+
+From the framework axioms, the axiom-native proper-rotation symmetry set:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with
+> nearest-neighbor adjacency, standard translations, and proper cubic
+> rotations about each site.
+
+and
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under
+> lattice translations and proper cubic rotations.
+
+From the landed hw=1 delivery note, the delivered carrier this note reuses:
+
+> the `C_3[111]` lattice rotation restricted to the hw=1 kernel triplet of
+> the one-component staggered operator on the periodic `4^3` torus IS the
+> real cyclic `C` (entries exactly `{0,1}`, `C^3 = I`, `C^T = C^2`), and
+> ambient complex conjugation restricts to entrywise conjugation `K` in the
+> corner basis (T1).
+
+## Claims
+
+Fix the one-component staggered operator `D` on the periodic `4^3` torus, its exact kernel
+(dimension `8`, spanned by the corner plane waves graded `1+3+3+1`), and the hw=1 kernel
+triplet carrying `V`. The supplied carrier `(C, P_chi, K)` is the real cyclic `C` with
+`C^3 = I`, `C^T = C^2`, its character projectors, and entrywise conjugation `K`, exactly as
+the landed delivery note placed it on this surface. Throughout, `TS` is the transposition
+`[[0,1,0],[1,0,0],[0,0,1]]`, the hw=1 action of the swap.
+
+### Lattice delivery of the presentation-swap rotation (T1, exact)
+
+The swap `R2(x1,x2,x3) = (-x2,-x1,-x3) mod 4` has site matrix
+`M = [[0,-1,0],[-1,0,0],[0,0,-1]]`, an integer orthogonal signed permutation with
+`det M = +1` (PROPER), `M^2 = I`, and fixed axis `M [1,-1,0]^T = [1,-1,0]^T`: the
+pi-rotation about `[1,-1,0]`, an element of the proper cubic rotation group named by the
+LATTICE axiom. Its lattice unitary `U2` (site permutation by `R2`) is a symmetric
+involution that conjugates the landed `C_3[111]` rotation to its inverse
+(`U2 U_R U2 = U_R^T`), conjugates translations by `M`
+(`U2 T1 U2 = T2^3`, `U2 T2 U2 = T1^3`, `U2 T3 U2 = T3^3`), and is sign-free covariant on the
+corner waves (`U2 V8 = V8 PI`, `PI` a subset permutation). Restricted to the hw=1 triplet
+it is the transposition, `U2 V = V TS`. This is the landed delivery standard — translation
+conjugacy together with the kernel action — applied to the swap. A proper rotation that
+acts trivially on the triplet (`diag(-1,-1,1)`) and the improper coordinate mirror
+(`det = -1`, outside the axiom's proper set) are held as negative controls.
+
+### Rotation conjugation equals entrywise conjugation on the supplied projector family (T2, exact)
+
+On the supplied carrier, `TS C TS = C^T = C^2` and `C` is real. For every channel
+`chi in {1, w, wbar}`, `TS P_chi TS = conj(P_chi)`; in particular `TS P_w TS = P_wbar` and
+`TS P_1 TS = P_1`. The generator coherence `P_wbar(C) = P_w(C^2)` shows the rotation image
+presents the same projector with its natural generator. Conjugation by the real `TS`
+composed with `K` is an antilinear involution fixing every `P_chi`, and the probe transform
+is `TS W(a,b,c) TS = W(a,c,b)`.
+
+### The two-model pair is a proper-rotation orbit on the delivered carrier (T3, exact)
+
+On the delivered carrier the entrywise-conjugate presentation pair lies on a single orbit of the proper cubic rotation group named by the LATTICE axiom; the unfixed binary choice in the two-model FLAG is a rotation-frame orientation at the `C_3[111]` axis, and any clause set that breaks the tie must break proper-rotation covariance at that orientation.
+Concretely, `{P_w, P_wbar}` is a 2-orbit under `TS`-conjugation (`TS P_w TS = P_wbar`,
+`TS P_wbar TS = P_w`, `TS P_1 TS = P_1`), this orbit coincides with the entrywise-conjugation
+orbit, and the canonical K-odd separator `D0 = P_w - P_wbar` is exchanged exactly as by `K`:
+`conj(D0) = -D0` and `TS D0 TS = -D0 = conj(D0)`. The memo's live Qualification remains live and unfixed; this note does not act on that slot.
+
+### K-parity equals rotation parity on the Hermitian section (T4, exact)
+
+Channel values are `lam_chi(W(a,b,c)) = a + b*chi + c*chi^2`, with doublet separation
+`lam_w - lam_wbar = i*sqrt(3)*(b - c)`; the swap `b <-> c` fixes `lam_1` and exchanges the
+doublet pair. On the Hermitian section `W_H = a I + b C + conj(b) C^2` (with `b = b1 + i*b2`),
+the antilinear K-exchange coincides exactly with the linear rotation conjugation,
+`conj(W_H) = TS W_H TS`. Off the section the two gradings are inequivalent: `C - C^2` is
+K-even but rotation-odd and separates the doublet, while `i I` is K-odd but rotation-even
+and does not separate. K-parity and rotation parity therefore coincide on the Hermitian
+section and only there: for general complex `(a, b, c)` the difference `conj(W) - TS W TS`
+decomposes as `(conj(a) - a) I + (conj(b) - c) C + (conj(c) - b) C^2` with `I`, `C`, `C^2`
+linearly independent, so it vanishes exactly when `a` is real and `c = conj(b)`.
+
+### Operator-level covariance report for the named dressed class (T5, computed report)
+
+This block is an honest computed report and is consumed by no other claim; T1-T4 use only
+the kernel-action and conjugation facts above and take nothing from it. As computed by the
+paired runner: the undressed lattice unitaries `U2` and `U_R` each fail to commute with the
+staggered operator `D`. Within the named class of `4096` candidates — the `64` diagonal
+sign fields (linear plus bilinear in the site coordinates) times the `64` lattice
+translations, applied to each unitary — exactly `64` members commute with `D` for `U2` and
+`64` for `U_R`. Every commuting member preserves the full eight-dimensional corner-wave
+kernel, yet none of the `64` in either class preserves the hw=1 triplet subspace (the
+off-triplet residual of `U V` is nonzero in every case); a one-bit flip of an exemplar's
+sign field breaks commutation, and the identity dressing has a nonzero commutator with `D`.
+The report records that the operator-commutation standard and the T1 kernel-action standard
+are met by different operator sets on this surface; it makes no claim used elsewhere.
+
+## Gated controls
+
+The paired runner gates, in exact arithmetic: the staggered construction and its exact rank
+`56` / kernel dimension `8` (Block A); the T1 delivery items — `M` proper involution, fixed
+axis, the group relation `M C M = C^T`, `U2` involution and its translation and rotation
+conjugacies, sign-free corner-wave covariance, and the hw=1 transposition (B1); the T2
+projector-family conjugation identities (B2); the T3 orbit and K-odd separator (B3); the T4
+channel values, Hermitian-section coincidence, exact section characterization, and
+off-section witnesses (B4); the
+weight-neutrality guard (B5); the computed T5 report (B6); the verbatim source and note
+quote pairs (B7); ledger shard existence (B8); and note hygiene (B9).
+
+## Negative controls
+
+Three controls separate the delivered result from look-alikes. The proper rotation
+`diag(-1,-1,1)` acts trivially on the hw=1 triplet while permuting sites, so properness
+alone does not deliver the swap. The improper coordinate mirror `x1 <-> x2` has `det = -1`
+and lies outside the axiom's proper rotation set, so no improper element is consumed. The
+witness `i I` is rotation-even yet K-odd, so the K-parity and rotation-parity coincidence is
+a fact about the Hermitian section rather than an identity of all operators.
+
+## No-Go Discipline Gate
+
+This bounded theorem asserts a positive structural coincidence on a supplied carrier; the
+discipline gate records what it does not claim and how each boundary is held.
+
+### N1 — Alternative-presentation scope
+
+The claim ranges over the two entrywise-conjugate presentations named by the FLAG and over
+the proper cubic rotation group; it does not range over other supplied carriers or other
+axes.
+
+| Boundary | Status |
+|---|---|
+| presentation pair and proper rotations only | addressed |
+
+### N2 — No status assertion
+
+No dependency status is asserted or consumed; the note consumes only the quoted sentences.
+
+| Boundary | Status |
+|---|---|
+| status set by the audit lane | addressed |
+
+### N3 — Negative controls present
+
+The trivial-restriction rotation, the improper mirror, and the rotation-even K-odd witness
+separate the result from look-alikes.
+
+| Boundary | Status |
+|---|---|
+| three explicit controls | addressed |
+
+### N4 — Scope boundary stated
+
+The coincidence of K-parity and rotation parity holds on the Hermitian section; off the
+section the two gradings differ, as witnessed.
+
+| Boundary | Status |
+|---|---|
+| Hermitian section only | addressed |
+
+### N5 — Inherited FLAG preserved
+
+The corner surface is the mechanism note's supplied surface; that inherited FLAG is carried
+unchanged, not removed.
+
+| Boundary | Status |
+|---|---|
+| supplied-surface FLAG carried | addressed |
+
+### N6 — No weight selection
+
+No weight `r` is referenced, forced, derived, or selected; the guard exhibits only the
+swap-invariance of the doublet symmetric functions.
+
+| Boundary | Status |
+|---|---|
+| weight-neutral | addressed |
+
+### N7 — Exact arithmetic only
+
+Every gate is exact integer or exact symbolic; the report uses no float, tolerance, or
+randomness.
+
+| Boundary | Status |
+|---|---|
+| exact arithmetic | addressed |
+
+### N8 — Consumed readings are verbatim
+
+Each consumed sentence is quoted without paraphrase and gated against both its source and
+this note's blockquote.
+
+| Boundary | Status |
+|---|---|
+| verbatim quote gates | addressed |
+
+## Non-claims
+
+This note does not fix the presentation choice and does not act on the memo's live
+Qualification. It does not upgrade the supplied corner surface to physically derived status,
+and it does not claim the delivered rotation is the sole operator implementing the exchange.
+The T5 report is consumed by no claim here. No weight `r` is forced, derived, or selected.
+
+## Dependency roles and status boundary
+
+Each dependency supplies a specific object: the framework axioms name the proper cubic
+rotation group and the admissibility covariance; the staggered realization gate names the
+operator surface; the spectral-pairing note supplies the corner carrier and its declared
+FLAG; the mechanism note supplies the two-model FLAG and its live Qualification; and the
+landed hw=1 delivery note supplies the delivered carrier this note reuses. This note adds a
+structural coincidence on that delivered carrier and consumes no status-dependent content
+from any dependency. **Status authority:** independent audit lane only. Statuses of all dependencies are set by the independent audit lane; this note asserts no dependency status and consumes no status-dependent content.
+
+## Dependencies
+
+- [MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md)
+- [STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md](STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md)
+- [KCPT_COUPLING_TRIPLE_TWO_PRESENTATION_DERIVABLE_CLASS_SPECTRAL_PAIRING_BOUNDED_THEOREM_NOTE_2026-07-16.md](KCPT_COUPLING_TRIPLE_TWO_PRESENTATION_DERIVABLE_CLASS_SPECTRAL_PAIRING_BOUNDED_THEOREM_NOTE_2026-07-16.md)
+- [KCPT_ORBIT_CONSTANT_REGISTERED_OCCUPANCY_WEIGHTS_DERIVABLE_PROTOCOL_CLASS_BOUNDED_THEOREM_NOTE_2026-07-12.md](KCPT_ORBIT_CONSTANT_REGISTERED_OCCUPANCY_WEIGHTS_DERIVABLE_PROTOCOL_CLASS_BOUNDED_THEOREM_NOTE_2026-07-12.md)
+- [KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md](KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md)
+
+### Non-citation context handles
+
+Two adjacent `AC_phi_lambda` notes are named for orientation only and are not consumed as
+dependencies:
+
+- `ACPHILAMBDA_C3_RESOLVENT_DETERMINANT_HOLONOMY_COUPLING_NARROW_THEOREM_NOTE_2026-07-12.md`
+- `ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md`
+
+Context orientation only; no content is consumed from either.
+
+## Verification
+
+**The paired runner re-derives every claim above in exact integer and exact symbolic
+arithmetic, prints a PASS or FAIL line per gate, and exits nonzero if any gate fails.**
+**No check passes by literal stipulation.**

--- a/docs/KCPT_CORNER_CARRIER_TWO_PRESENTATION_SWAP_PROPER_ROTATION_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-07-18.md
+++ b/docs/KCPT_CORNER_CARRIER_TWO_PRESENTATION_SWAP_PROPER_ROTATION_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-07-18.md
@@ -6,36 +6,39 @@
 - **Paired runner:** [kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.py](../scripts/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.py)
 - **Runner cache:** `logs/runner-cache/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.txt`
 
-**Abstract.** The spectral-pairing note supplies a corner carrier `(C, P_chi, K)` and the
-mechanism note flags a two-model presentation pair — the entrywise-conjugate images
-`(C, P_w, K)` and `(C, P_wbar, K)` — with an unfixed binary choice and a live
-Qualification. On the same one-component staggered surface on the periodic `4^3` torus
+**Abstract.** The spectral-pairing note supplies a corner carrier `(C, P_chi, K)`. The
+mechanism note's two-model comparison is a joint Pauli/corner comparison; its
+corner-projector restriction contains the entrywise-conjugate pair `P_w`, `P_wbar`.
+On the same one-component staggered surface on the periodic `4^3` torus
 that the landed hw=1 delivery note used, this note delivers the presentation-swap as the
 proper cubic rotation `M`: the pi-rotation about `[1,-1,0]` (`det M = +1`), realized as a
 lattice unitary whose hw=1 kernel action is the transposition `TS` (T1). Rotation
 conjugation by `TS` acts on the supplied projector family exactly as entrywise conjugation
-`K`, `TS P_chi TS = conj(P_chi)` for every channel, so the pair is a single 2-orbit of the
-proper rotation and the canonical K-odd separator `D0 = P_w - P_wbar` is exchanged exactly
+`K`, `TS P_chi TS = conj(P_chi)` for every channel, so the projector pair is a single
+2-orbit of the proper rotation and the canonical K-odd separator `D0 = P_w - P_wbar` is exchanged exactly
 as by `K` (T2, T3). On the Hermitian probe section `W_H = a I + b C + conj(b) C^2` the
 antilinear K-exchange coincides exactly with the linear rotation conjugation,
 `conj(W_H) = TS W_H TS`; off the section the two gradings are inequivalent (witnesses
-`C - C^2` and `i I`) (T4). The unfixed binary choice is thereby a rotation-frame
-orientation at the `C_3[111]` axis; the note does not fix it and does not act on the
-memo's live Qualification. An honest operator-level covariance report for a named dressed
+`C - C^2` and `i I`) (T4). Thus the `w` versus `wbar` projector labeling is a
+rotation-frame orientation at the `C_3[111]` axis. This does not reclassify the full
+Pauli/corner two-model comparison: `sigma_2 tensor I_3` is K-odd but fixed by the
+corner rotation. The note does not fix the mechanism's choice and does not act on its
+live Qualification. An honest operator-level covariance report for a named dressed
 class (T5) is included and consumed by no other claim. All lattice arithmetic is exact
 integer; all carrier algebra is exact symbolic.
 
 ## Purpose
 
-The mechanism note's two-model FLAG leaves an unfixed binary choice between the two
-entrywise-conjugate presentations of the supplied corner carrier, and its live
-Qualification keeps that choice conditional. This note asks a structural question about
-that choice: is the exchange of the two presentations a symmetry named by the framework
-axioms? It answers yes on the delivered carrier — the exchange is conjugation by a proper
-cubic rotation named by the LATTICE axiom — and records exactly where the answer stops. It
-reclassifies the unfixed choice as a rotation-frame orientation without fixing it, and it
-leaves the memo's live Qualification untouched. The operator-level covariance report (T5)
-is a separate hardening probe whose computed outcome is consumed by no claim here.
+The mechanism note's two-model FLAG compares a supplied joint Pauli/corner presentation
+with its entrywise-conjugate presentation, and its live Qualification keeps the unfixed
+choice conditional. This note asks a narrower structural question: is the induced exchange
+of the two corner projectors a symmetry named by the framework axioms? It answers yes on
+the delivered carrier — that projector exchange is conjugation by a proper cubic rotation
+named by the LATTICE axiom — and records exactly where the answer stops. It reclassifies
+only the `w` versus `wbar` projector labeling as a rotation-frame orientation; it neither
+implements entrywise conjugation on the full joint presentation nor changes the memo's
+live Qualification. The operator-level covariance report (T5) is a separate hardening
+probe whose computed outcome is consumed by no claim here.
 
 ## Supplied objects and consumed readings
 
@@ -115,13 +118,21 @@ presents the same projector with its natural generator. Conjugation by the real 
 composed with `K` is an antilinear involution fixing every `P_chi`, and the probe transform
 is `TS W(a,b,c) TS = W(a,c,b)`.
 
-### The two-model pair is a proper-rotation orbit on the delivered carrier (T3, exact)
+### The corner-projector pair is a proper-rotation orbit on the delivered carrier (T3, exact)
 
-On the delivered carrier the entrywise-conjugate presentation pair lies on a single orbit of the proper cubic rotation group named by the LATTICE axiom; the unfixed binary choice in the two-model FLAG is a rotation-frame orientation at the `C_3[111]` axis, and any clause set that breaks the tie must break proper-rotation covariance at that orientation.
+On the delivered carrier the entrywise-conjugate corner-projector pair is exchanged by an
+element of the proper cubic rotation group named by the LATTICE axiom. Thus, on this
+restricted surface, the `w` versus `wbar` label is a rotation-frame orientation at the
+`C_3[111]` axis. A carrier-only tie-breaker invariant under the delivered rotation cannot
+distinguish the two; a larger joint construction may consume additional internal or
+co-transforming orientation data and is not classified here.
 Concretely, `{P_w, P_wbar}` is a 2-orbit under `TS`-conjugation (`TS P_w TS = P_wbar`,
 `TS P_wbar TS = P_w`, `TS P_1 TS = P_1`), this orbit coincides with the entrywise-conjugation
 orbit, and the canonical K-odd separator `D0 = P_w - P_wbar` is exchanged exactly as by `K`:
-`conj(D0) = -D0` and `TS D0 TS = -D0 = conj(D0)`. The memo's live Qualification remains live and unfixed; this note does not act on that slot.
+`conj(D0) = -D0` and `TS D0 TS = -D0 = conj(D0)`. This is not the full
+Pauli/corner orbit of the mechanism note: under the natural joint lift `I_2 tensor TS`,
+`sigma_2 tensor I_3` is fixed by rotation conjugation but is K-odd. The memo's live
+Qualification remains live and unfixed; this note does not act on that slot.
 
 ### K-parity equals rotation parity on the Hermitian section (T4, exact)
 
@@ -129,12 +140,17 @@ Channel values are `lam_chi(W(a,b,c)) = a + b*chi + c*chi^2`, with doublet separ
 `lam_w - lam_wbar = i*sqrt(3)*(b - c)`; the swap `b <-> c` fixes `lam_1` and exchanges the
 doublet pair. On the Hermitian section `W_H = a I + b C + conj(b) C^2` (with `b = b1 + i*b2`),
 the antilinear K-exchange coincides exactly with the linear rotation conjugation,
-`conj(W_H) = TS W_H TS`. Off the section the two gradings are inequivalent: `C - C^2` is
+`conj(W_H) = TS W_H TS`. Off the section the two gradings are inequivalent within the
+carrier algebra: `C - C^2` is
 K-even but rotation-odd and separates the doublet, while `i I` is K-odd but rotation-even
 and does not separate. K-parity and rotation parity therefore coincide on the Hermitian
-section and only there: for general complex `(a, b, c)` the difference `conj(W) - TS W TS`
+section of the carrier algebra and only there: for general complex `(a, b, c)` the difference
+`conj(W) - TS W TS`
 decomposes as `(conj(a) - a) I + (conj(b) - c) C + (conj(c) - b) C^2` with `I`, `C`, `C^2`
 linearly independent, so it vanishes exactly when `a` is real and `c = conj(b)`.
+On the larger mechanism surface, `sigma_2 tensor I_3` is a second escape: it is K-odd
+but rotation-even under `I_2 tensor TS`, so the full joint K action is not delivered by
+this corner rotation.
 
 ### Operator-level covariance report for the named dressed class (T5, computed report)
 
@@ -165,103 +181,132 @@ quote pairs (B7); ledger shard existence (B8); and note hygiene (B9).
 
 ## Negative controls
 
-Three controls separate the delivered result from look-alikes. The proper rotation
+Four controls separate the delivered result from look-alikes. The proper rotation
 `diag(-1,-1,1)` acts trivially on the hw=1 triplet while permuting sites, so properness
 alone does not deliver the swap. The improper coordinate mirror `x1 <-> x2` has `det = -1`
 and lies outside the axiom's proper rotation set, so no improper element is consumed. The
 witness `i I` is rotation-even yet K-odd, so the K-parity and rotation-parity coincidence is
-a fact about the Hermitian section rather than an identity of all operators.
+a fact about the Hermitian section rather than an identity of all carrier operators. The
+joint-factor witness `sigma_2 tensor I_3` is K-odd but fixed by `I_2 tensor TS`, so the
+corner-projector orbit is not silently promoted to the mechanism's full Pauli/corner
+presentation.
 
 ## No-Go Discipline Gate
 
-This bounded theorem asserts a positive structural coincidence on a supplied carrier; the
-discipline gate records what it does not claim and how each boundary is held.
+This gate covers the bounded negative content: the carrier-algebra `if and only if` in T4,
+the zero triplet-preserving count inside T5's named finite class, and the boundary between
+the corner-projector result and the mechanism's larger joint presentation.
 
-### N1 — Alternative-presentation scope
+### N1 — Alternative-route enumeration
 
-The claim ranges over the two entrywise-conjugate presentations named by the FLAG and over
-the proper cubic rotation group; it does not range over other supplied carriers or other
-axes.
+| Route attacking the scoped boundary | Marker | Result |
+|---|---|---|
+| delivered proper site rotation | ATTEMPTED | `M` has determinant `+1`, and its exact kernel action is `TS`, which exchanges the projector pair (B1 and B2) |
+| bare coordinate mirror | ATTEMPTED | it also induces the transposition but has determinant `-1`; it is outside the axiom's proper set (B1 item 11) |
+| different proper rotation with trivial restriction | ATTEMPTED | `diag(-1,-1,1)` is proper and moves sites but acts as the identity on the triplet, so properness alone is insufficient (B1 item 10) |
+| general carrier algebra | ATTEMPTED | rotation and K agree exactly on the Hermitian section and differ off it; `C-C^2` and `iI` witness both directions (B4 items 4 through 7) |
+| full joint Pauli/corner presentation | ATTEMPTED | `sigma_2 tensor I_3` is K-odd but fixed by `I_2 tensor TS`; the full mechanism comparison is an explicit escape (B4 item 8) |
+| operator-commuting dressings of `U2` | ATTEMPTED | the complete named `4096`-candidate enumeration has `64` commuting members and zero triplet-preserving members (B6 U2 block) |
+| operator-commuting dressings of `U_R` | ATTEMPTED | the second complete named enumeration also has `64` commuting members and zero triplet-preserving members (B6 UR block) |
 
-| Boundary | Status |
-|---|---|
-| presentation pair and proper rotations only | addressed |
+The last two rows close only the named finite classes. Other sign-field families, internal
+spin lifts, interacting extensions, and larger joint constructions remain untested and are
+not ruled out.
 
-### N2 — No status assertion
+### N2 — Wall-independence audit
 
-No dependency status is asserted or consumed; the note consumes only the quoted sentences.
+The note has three explicit scope boundaries rather than a universal no-go:
 
-| Boundary | Status |
-|---|---|
-| status set by the audit lane | addressed |
+| Boundary pair | Does the first close the second? | Does the second close the first? | Disposition |
+|---|---|---|---|
+| inherited supplied/gate carrier surface; projector-family restriction | no: a lattice carrier does not identify the full K action with rotation | no: the projector identity does not derive the carrier at the mechanism-note origin | independent and stated |
+| projector-family restriction; Hermitian carrier section | no: projector exchange holds while general carrier operators still separate the actions | no: the Hermitian-section identity does not enlarge the claim to the joint presentation | independent and stated |
+| Hermitian carrier section; named dressed operator class | no: carrier-algebra equality does not imply commutation with `D` | no: commuting dressings do not preserve the hw=1 triplet in the searched class | independent and stated |
 
-### N3 — Negative controls present
+No inflated wall count is used; T1-T4 consume none of T5.
 
-The trivial-restriction rotation, the improper mirror, and the rotation-even K-odd witness
-separate the result from look-alikes.
+### N3 — Hidden-wall scan
 
-| Boundary | Status |
-|---|---|
-| three explicit controls | addressed |
+The scan terms are “we assume”, “by construction”, “as is standard”, “the framework
+provides”, “bridge context”, “background”, “naturally”, “obviously”, “standard QFT”,
+“registered”, and “canonical”. “Canonical” occurs only in the supplied-basis and
+separator names; “framework axioms” is accompanied by the two verbatim Lattice and
+Admissibility quotations. The periodic `4^3` surface, corner basis, projector-family
+restriction, Hermitian section, and `4096`-candidate dressing class are all explicit.
+No hidden spin lift, action, readout, measure, or weight rule is consumed.
 
-### N4 — Scope boundary stated
+### N4 — Residual matching
 
-The coincidence of K-parity and rotation parity holds on the Hermitian section; off the
-section the two gradings differ, as witnessed.
+| Cited source | Source residual or role | Residual addressed here | Match? |
+|---|---|---|---|
+| spectral-pairing note | supplied abstract corner carrier and its supplied-surface FLAG | proper-rotation delivery of the projector exchange on the gate-note carrier | yes, at the gate note's bounded surface; the origin FLAG remains |
+| mechanism note | full joint Pauli/corner two-model comparison and live Qualification | corner-projector restriction only | partial, not full; the joint-factor witness prevents use as a closure or reclassification of the full FLAG |
+| landed carrier-delivery note | `C`, projector family, and entrywise `K` on the hw=1 carrier | same `V`, `C`, and periodic `4^3` surface | yes |
+| T5 finite-class report | no prior negative witness is cited | direct complete count in two named classes | direct computation; no residual substitution |
 
-| Boundary | Status |
-|---|---|
-| Hermitian section only | addressed |
+### N5 — Rhetoric and resolution audit
 
-### N5 — Inherited FLAG preserved
+The equality `TS P_chi TS = conj(P_chi)` is tested at projector resolution. The stronger
+carrier-algebra comparison is tested exactly and holds only on the Hermitian section. The
+joint Pauli/corner comparison is not claimed and has an explicit counter-witness. At the
+lattice-operator resolution, only the two named dressing classes are enumerated; no
+lattice-wide or all-operator nonexistence statement is made. T5's “zero” therefore always
+means zero among the `64` commuting members of the stated `4096`-candidate class.
 
-The corner surface is the mechanism note's supplied surface; that inherited FLAG is carried
-unchanged, not removed.
+### N6 — Partial-closure paths
 
-| Boundary | Status |
-|---|---|
-| supplied-surface FLAG carried | addressed |
+| Candidate path | Current treatment | What it could change |
+|---|---|---|
+| internal spin lift or another joint representation of the rotation | untested | could act nontrivially on the Pauli factor; outside the corner-only proof |
+| co-transforming orientation datum or larger covariant clause set | untested | could select a joint orientation without being a carrier-only invariant |
+| wider sign-field, translation, or interacting dressing class | untested | could contain an operator that both commutes with `D` and preserves the hw=1 triplet |
+| a physical action/readout selector | open outside this note | could fix the mechanism's presentation choice or a weight without contradicting the projector orbit |
 
-### N6 — No weight selection
+These are ordinary downstream theorem paths, not new axioms, and none is foreclosed.
 
-No weight `r` is referenced, forced, derived, or selected; the guard exhibits only the
-swap-invariance of the doublet symmetric functions.
+### N7 — Steelman
 
-| Boundary | Status |
-|---|---|
-| weight-neutral | addressed |
+Strongest objection: the mechanism's entrywise-conjugate presentations include the Pauli
+factor and every K-odd seed, while the rotation proved here acts only on the corner carrier.
+The objection is decisive against reclassifying the full FLAG: `sigma_2 tensor I_3` is the
+exact counterexample. The claim is therefore restricted to the corner projectors and, for
+general carrier probes, to the Hermitian section. A second objection is that the failure of
+the searched commuting dressings may be an artifact of the six-bit sign-field ansatz. That
+is also granted; T5 reports only its named finite class and is consumed by no theorem claim.
 
-### N7 — Exact arithmetic only
+### N8 — Cross-cycle echo
 
-Every gate is exact integer or exact symbolic; the report uses no float, tolerance, or
-randomness.
+The closest echo is the landed carrier-delivery note: its N1 scan already records that joint
+qubit/corner observables escape a bare-carrier classification. The spectral-pairing note
+keeps entrywise `K` distinct from the adjoint and requires an extra declared reading before
+moving the mechanism to the coupling slot. The mechanism note itself constructs a jointly
+K-even qubit/corner witness whose factors are separately K-odd. The older carrier-orbit
+ledger at `.claude/science/physics-loops/carrier-orbit-invariance-2026-05-03/NO_GO_LEDGER.md`
+likewise warns that adding an antisymmetric carrier primitive would break a carrier-only
+swap reduction. Those precedents are respected here by keeping the joint, internal-lift,
+and larger-dressing routes open.
 
-| Boundary | Status |
-|---|---|
-| exact arithmetic | addressed |
-
-### N8 — Consumed readings are verbatim
-
-Each consumed sentence is quoted without paraphrase and gated against both its source and
-this note's blockquote.
-
-| Boundary | Status |
-|---|---|
-| verbatim quote gates | addressed |
+**Gate result: PASS.** The exact projector orbit and Hermitian-section characterization
+survive; the full mechanism FLAG and all operator classes outside T5's finite search remain
+explicitly unclassified.
 
 ## Non-claims
 
-This note does not fix the presentation choice and does not act on the memo's live
-Qualification. It does not upgrade the supplied corner surface to physically derived status,
-and it does not claim the delivered rotation is the sole operator implementing the exchange.
-The T5 report is consumed by no claim here. No weight `r` is forced, derived, or selected.
+This note does not fix the mechanism's presentation choice and does not act on the memo's
+live Qualification. It reclassifies only the `w` versus `wbar` corner-projector label, not
+the full Pauli/corner comparison or every K-odd seed. It does not upgrade the supplied
+corner surface to physically derived status, and it does not claim the delivered rotation
+is the sole operator implementing the exchange. A larger joint construction may use
+internal or co-transforming orientation data. The T5 report is consumed by no claim here.
+No weight `r` is forced, derived, or selected.
 
 ## Dependency roles and status boundary
 
 Each dependency supplies a specific object: the framework axioms name the proper cubic
 rotation group and the admissibility covariance; the staggered realization gate names the
 operator surface; the spectral-pairing note supplies the corner carrier and its declared
-FLAG; the mechanism note supplies the two-model FLAG and its live Qualification; and the
+FLAG; the mechanism note supplies the broader two-model FLAG and its live Qualification,
+which bound rather than enlarge the projector-family result; and the
 landed hw=1 delivery note supplies the delivered carrier this note reuses. This note adds a
 structural coincidence on that delivered carrier and consumes no status-dependent content
 from any dependency. **Status authority:** independent audit lane only. Statuses of all dependencies are set by the independent audit lane; this note asserts no dependency status and consumes no status-dependent content.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 14438,
- "node_count": 3965,
+ "edge_count": 14443,
+ "node_count": 3966,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -6837,6 +6837,10 @@
   "kcpt_corner_carrier_lattice_delivery_hw1_doublet_pair_polarization_bounded_theorem_note_2026-07-17": {
    "deps_hash": "3492e302d6ba",
    "out_degree": 4
+  },
+  "kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_bounded_theorem_note_2026-07-18": {
+   "deps_hash": "31650363616a",
+   "out_degree": 5
   },
   "kcpt_coupling_triple_berezin_count_binary_measure_collapse_bounded_theorem_note_2026-07-17": {
    "deps_hash": "79fc309444f4",

--- a/logs/runner-cache/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.txt
+++ b/logs/runner-cache/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.txt
@@ -1,0 +1,155 @@
+===== runner cache v1 =====
+runner: scripts/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.py
+runner_sha256: eb16d94fcd4e8f70e4879fc645938cecae4837034be92a1da20712215dd64a9c
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 6.30
+status: ok
+----- stdout -----
+A.1 PASS 2D is integer antisymmetric with entries in {-1,0,1}
+A.2 PASS exact rank(D) = 56, so dim ker D = 8
+A.3 PASS all eight corner plane waves are exact null vectors of D
+A.4 PASS corner waves orthogonal (V8^T V8 = 64*I), hence they span ker D exactly
+A.5 PASS translations are commuting permutation matrices of order 4
+A.6 PASS hw=1 joint translation characters are exactly (-1,+1,+1), (+1,-1,+1), (+1,+1,-1)
+A.7 PASS U_R is a permutation matrix with U_R^3 = I
+A.8 PASS U_R conjugates translations cyclically: U_R T_mu U_R^T = T_{mu+1 mod 3}
+A.9 PASS landed kernel action: U_R V = V C exactly (C = [[0,0,1],[1,0,0],[0,1,0]])
+B1.1 PASS M is a PROPER signed-permutation involution (det +1, M^T M = I, M^2 = I, one nonzero per row/col in {-1,0,1}): an element of the cubic rotation group O
+B1.2 PASS R2 fixes the [1,-1,0] axis (M [1,-1,0]^T = [1,-1,0]^T): the pi-rotation about [1,-1,0]
+B1.3 PASS group relation R2 R3 R2 = R3^{-1}: M C M = C^T exactly
+B1.4 PASS U2 is a symmetric permutation involution (U2 = U2^T, U2 U2 = I_N)
+B1.5 PASS U2 U_R U2 = U_R^T exactly (the swap conjugates the C_3[111] rotation to its inverse)
+B1.6 PASS translation conjugacy: U2 T1 U2 = T2^3, U2 T2 U2 = T1^3, U2 T3 U2 = T3^3 (translation by M e_mu; -e_mu = 3 e_mu mod 4)
+B1.7 PASS sign-free corner-wave covariance: U2 V8 = V8 PI with PI a pure subset permutation (every entry in {0,1}; (0,)<->(1,), (0,2)<->(1,2), (2,) fixed)
+B1.8 PASS hw=1 kernel action: U2 V = V TS with TS the transposition swapping the (0,) and (1,) corner waves
+B1.9 PASS T1 rejector: TS != I3 and TS C TS != C -- the delivered action genuinely moves C on the triplet
+B1.10 PASS trivial-restriction control: R2b = diag(-1,-1,1) is PROPER (det +1) yet restricts to the identity on the hw=1 triplet (U2b V = V) while moving sites (U2b != I_N): properness alone does not deliver the swap
+B1.11 PASS improper-honesty: the bare coordinate mirror S12 (x1<->x2) has det -1 (not in the axiom's proper rotation set), while the swap M has det +1 (proper): no improper element is consumed
+B2.1 PASS TS C TS = C^T = C^2 exactly, and C is real (conj C = C)
+B2.2 PASS TS P_chi TS = conj(P_chi) for all three channels: rotation conjugation acts on the supplied projector family identically to entrywise K
+B2.3 PASS in particular TS P_w TS = P_wbar and TS P_1 TS = P_1, and the map is nontrivial (P_w != P_wbar)
+B2.4 PASS generator coherence: P_wbar(C) = P_w(C^2) symbolically (the rotated pair is the entrywise-conjugate model presented with its natural generator)
+B2.5 PASS conj(TS) = TS (real rotation); the antilinear involution M -> conj(TS M TS) fixes every P_chi and is nontrivial (moves C to C^2)
+B2.6 PASS probe transform: TS W(a,b,c) TS = W(a,c,b) (the swap exchanges the b and c generator coefficients)
+B3.1 PASS the presentation pair {P_w, P_wbar} is a single 2-orbit under the delivered proper rotation: TS P_w TS = P_wbar, TS P_wbar TS = P_w, TS P_1 TS = P_1
+B3.2 PASS the rotation orbit coincides with the entrywise-conjugation orbit: TS P_chi TS = conj(P_chi) is the same partition of the projector family
+B3.3 PASS canonical K-odd separator D0 = P_w - P_wbar: nonzero, conj(D0) = -D0 (K-odd), and TS D0 TS = -D0 = conj(D0) -- the delivered rotation exchanges the canonical K-odd seed exactly as K does
+B3.4 PASS the rotation image (C^2 with its natural w-channel projector) reproduces the conjugate model: P_w(C^2) = P_wbar(C), so the orbit image is the FLAG's entrywise-conjugate presentation
+B4.1 PASS channel values: W(a,b,c) P_chi = lam_chi P_chi with lam_chi = a + b*chi + c*chi^2; the doublet separation is lam_w - lam_wbar = i*sqrt(3)*(b-c) exactly
+B4.2 PASS under the swap b<->c: lam_1 fixed and the doublet pair is exchanged, lam_w(W(a,c,b)) = lam_wbar(W(a,b,c)) and lam_wbar(W(a,c,b)) = lam_w(W(a,b,c))
+B4.3 PASS Hermitian-section coincidence (keystone): with b = b1 + i*b2, W_H = a*I + b*C + conj(b)*C^2 satisfies conj(W_H) = TS W_H TS exactly -- on the Hermitian section the antilinear K-exchange IS conjugation by the delivered proper rotation
+B4.4 PASS off-section witness skew = C - C^2: K-EVEN (conj skew = skew) but rotation-ODD (TS skew TS = -skew), and it separates the doublet (lam_w - lam_wbar = 2*i*sqrt(3) != 0)
+B4.5 PASS off-section witness i*I: K-ODD (conj = -it) but rotation-EVEN (TS (i*I) TS = i*I), and it does NOT separate (all channel values equal)
+B4.6 PASS the two gradings are inequivalent off the Hermitian section: conj(skew) != TS skew TS and conj(i*I) != TS (i*I) TS, while on the section conj(W_H) = TS W_H TS (item n) -- K-parity and rotation-parity coincide only on the Hermitian section
+B4.7 PASS exact section characterization: for general complex (a,b,c), conj(W) - TS W TS = (conj(a)-a) I + (conj(b)-c) C + (conj(c)-b) C^2, and {I, C, C^2} are linearly independent (rank 3); hence conj(W) = TS W TS holds iff a is real and c = conj(b) -- exactly the Hermitian section, and only there
+B5.1 PASS the swap fixes lam_1 and permutes {lam_w, lam_wbar}: the elementary symmetric functions lam_w + lam_wbar and lam_w * lam_wbar are swap-invariant
+B5.2 PASS the swap genuinely moves the individual doublet values (lam_w(W(a,c,b)) - lam_w(W(a,b,c)) is not identically zero) while fixing their symmetric functions: the invariance is of the pair, not of a pinned value; no target weight r is referenced, forced, derived, or selected
+B5.3 PASS the singlet channel value lam_1 = a + b + c is swap-invariant (fixed): the guard references no weight value
+B6.1 PASS computed undressed status: U2 does NOT commute with D2 (the swap needs a sign dressing to be a D operator symmetry)
+B6.2 PASS computed undressed status: U_R does NOT commute with D2 (the C_3[111] rotation needs a sign dressing to be a D operator symmetry)
+B6.3 PASS U2 dressed search visited exactly 4096 candidates (64 sign fields x 64 translations)
+B6.4 PASS U2 dressed class solution count is exactly 64 (computed live)
+B6.5 PASS U2 exemplar re-check: the reported exemplar commutes with D2
+B6.6 PASS U2 exemplar preserves the full 8-dim corner-wave kernel (D2 U V8 = 0) but does NOT preserve the hw=1 triplet subspace (the off-triplet residual 64*U V - V (V^T U V) is nonzero)
+B6.7 PASS U2 class-scoped count: no member of the named 4096-candidate dressed class preserves the hw=1 triplet subspace (0 of 64 -- computed live)
+B6.8 PASS U2 discriminating rejector: a one-bit flip of the exemplar sign field FAILS to commute with D2
+B6.9 PASS U2 check is live: the identity dressing (s=0, t=0) has a nonzero commutator with D2
+B6 REPORT U2: undressed_commutes=False; visited=4096; solutions=64; triplet_preserving=0; identity_dressing_commutator_nonzero_entries=256
+B6 REPORT U2 exemplar: (a1,a2,a3,b12,b13,b23)=(0, 1, 0, 1, 0, 0); t=(1, 0, 0); one_bit_flip_breaks=(1, 1, 0, 1, 0, 0); compression V^T U V = [[-32, 32, 0], [-32, 32, 0], [0, 0, 32]]
+B6.10 PASS UR dressed search visited exactly 4096 candidates (64 sign fields x 64 translations)
+B6.11 PASS UR dressed class solution count is exactly 64 (computed live)
+B6.12 PASS UR exemplar re-check: the reported exemplar commutes with D2
+B6.13 PASS UR exemplar preserves the full 8-dim corner-wave kernel (D2 U V8 = 0) but does NOT preserve the hw=1 triplet subspace (the off-triplet residual 64*U V - V (V^T U V) is nonzero)
+B6.14 PASS UR class-scoped count: no member of the named 4096-candidate dressed class preserves the hw=1 triplet subspace (0 of 64 -- computed live)
+B6.15 PASS UR discriminating rejector: a one-bit flip of the exemplar sign field FAILS to commute with D2
+B6.16 PASS UR check is live: the identity dressing (s=0, t=0) has a nonzero commutator with D2
+B6 REPORT UR: undressed_commutes=False; visited=4096; solutions=64; triplet_preserving=0; identity_dressing_commutator_nonzero_entries=192
+B6 REPORT UR exemplar: (a1,a2,a3,b12,b13,b23)=(0, 0, 0, 1, 1, 0); t=(0, 0, 0); one_bit_flip_breaks=(1, 0, 0, 1, 1, 0); compression V^T U V = [[0, 0, 32], [32, 32, 0], [32, 32, 0]]
+B7.1 PASS mechanism note carries the R2 + two-model FLAG passage
+B7.2 PASS note blockquotes the R2 + two-model FLAG passage
+B7.3 PASS spectral-pairing note carries the R1c supplied-carrier sentence
+B7.4 PASS note blockquotes the R1c supplied-carrier sentence
+B7.5 PASS spectral-pairing note carries the supplied-surface FLAG sentence
+B7.6 PASS note blockquotes the supplied-surface FLAG sentence
+B7.7 PASS minimal-axioms note carries the proper-rotation Lattice sentence
+B7.8 PASS note blockquotes the proper-rotation Lattice sentence
+B7.9 PASS minimal-axioms note carries the proper-rotation Admissibility sentence
+B7.10 PASS note blockquotes the proper-rotation Admissibility sentence
+B7.11 PASS delivery note carries the landed hw=1 carrier-delivery sentence
+B7.12 PASS note blockquotes the landed hw=1 carrier-delivery sentence
+B8.1 PASS ledger shard file exists: minimal_axioms
+B8.2 PASS ledger shard file exists: staggered_dirac_realization_gate_note_2026-05-03
+B8.3 PASS ledger shard file exists: kcpt_coupling_triple_two_presentation_derivable_class_spectral_pairing_bounded_theorem_note_2026-07-16
+B8.4 PASS ledger shard file exists: kcpt_orbit_constant_registered_occupancy_weights_derivable_protocol_class_bounded_theorem_note_2026-07-12
+B8.5 PASS ledger shard file exists: kcpt_corner_carrier_lattice_delivery_hw1_doublet_pair_polarization_bounded_theorem_note_2026-07-17
+B8.6 PASS ledger shard file exists: acphilambda_c3_resolvent_determinant_holonomy_coupling_narrow_theorem_note_2026-07-12
+B8.7 PASS ledger shard file exists: acphilambda_fermionic_realification_pfaffian_power_identity_narrow_theorem_note_2026-07-12
+B9.1 PASS note carries: ## Purpose
+B9.2 PASS note carries: ## Supplied objects and consumed readings
+B9.3 PASS note carries: ## Claims
+B9.4 PASS note carries: ### Lattice delivery of the presentation-swap rotation (T1, 
+B9.5 PASS note carries: ### Rotation conjugation equals entrywise conjugation on the
+B9.6 PASS note carries: ### The two-model pair is a proper-rotation orbit on the del
+B9.7 PASS note carries: ### K-parity equals rotation parity on the Hermitian section
+B9.8 PASS note carries: ### Operator-level covariance report for the named dressed c
+B9.9 PASS note carries: ## Gated controls
+B9.10 PASS note carries: ## Negative controls
+B9.11 PASS note carries: ## No-Go Discipline Gate
+B9.12 PASS note carries: ### N1 —
+B9.13 PASS note carries: ### N2 —
+B9.14 PASS note carries: ### N3 —
+B9.15 PASS note carries: ### N4 —
+B9.16 PASS note carries: ### N5 —
+B9.17 PASS note carries: ### N6 —
+B9.18 PASS note carries: ### N7 —
+B9.19 PASS note carries: ### N8 —
+B9.20 PASS note carries: ## Non-claims
+B9.21 PASS note carries: ## Dependency roles and status boundary
+B9.22 PASS note carries: ## Dependencies
+B9.23 PASS note carries: ### Non-citation context handles
+B9.24 PASS note carries: ## Verification
+B9.25 PASS note carries: Statuses of all dependencies are set by the independent audi
+B9.26 PASS note carries: **No check passes by literal stipulation.**
+B9.27 PASS note carries: **Status authority:** independent audit lane only.
+B9.28 PASS note carries: Context orientation only; no content is consumed from either
+B9.29 PASS note carries: On the delivered carrier the entrywise-conjugate presentatio
+B9.30 PASS note carries: The memo's live Qualification remains live and unfixed; this
+B9.31 PASS forbidden phrase absent: 'exhaust'
+B9.32 PASS forbidden phrase absent: 'only route'
+B9.33 PASS forbidden phrase absent: 'last route'
+B9.34 PASS forbidden phrase absent: 'bijection'
+B9.35 PASS forbidden phrase absent: 'final'
+B9.36 PASS forbidden phrase absent: 'forces r'
+B9.37 PASS forbidden phrase absent: 'derives r'
+B9.38 PASS forbidden phrase absent: 'selects r'
+B9.39 PASS forbidden phrase absent: 'retained'
+B9.40 PASS forbidden phrase absent: 'discharge'
+B9.41 PASS forbidden phrase absent: 'derived carrier'
+B9.42 PASS forbidden phrase absent: 'dissolv'
+B9.43 PASS forbidden phrase absent: 'retire'
+B9.44 PASS forbidden phrase absent: 'closes the'
+B9.45 PASS source-authored status/value snapshot absent: 'unaudited at writing'
+B9.46 PASS source-authored status/value snapshot absent: 'citation grades at writing'
+B9.47 PASS source-authored status/value snapshot absent: 'audited_renaming'
+B9.48 PASS source-authored status/value snapshot absent: 'honest auditor read'
+B9.49 PASS no bare decimal literals in the note
+B9.50 PASS markdown dependency link present: MINIMAL_AXIOMS_2026-06-29.md
+B9.51 PASS markdown dependency link present: STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md
+B9.52 PASS markdown dependency link present: KCPT_COUPLING_TRIPLE_TWO_PRESENTATION_DERIVABLE_CLASS_SPECTRAL_PAIRING_BOUNDED_THEOREM_NOTE_2026-07-16.md
+B9.53 PASS markdown dependency link present: KCPT_ORBIT_CONSTANT_REGISTERED_OCCUPANCY_WEIGHTS_DERIVABLE_PROTOCOL_CLASS_BOUNDED_THEOREM_NOTE_2026-07-12.md
+B9.54 PASS markdown dependency link present: KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md
+B9.55 PASS non-citation context handle is backticked and unlinked: ACPHILAMBDA_C3_RESOLVENT_DETERMINANT_HOLONOMY_COUPLING_NARROW_THEOREM_NOTE_2026-07-12.md
+B9.56 PASS non-citation context handle is backticked and unlinked: ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md
+B9.57 PASS every cited or handled doc path exists
+PATH note=docs/KCPT_CORNER_CARRIER_TWO_PRESENTATION_SWAP_PROPER_ROTATION_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-07-18.md
+PATH runner=scripts/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.py
+PATH cache=logs/runner-cache/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.txt
+FLAGS: T1 delivers the mechanism note's two-presentation swap as the proper pi-rotation about [1,-1,0] (det M = +1) on the same 4^3 staggered surface as the landed hw=1 carrier, using the landed delivery standard (translation conjugacy + kernel action); T2-T4 show rotation conjugation equals entrywise conjugation on the supplied projector family and coincides with the antilinear K-exchange exactly on the Hermitian section, with off-section inequivalence witnesses; T3 reclassifies the FLAG's unfixed binary choice as a rotation-frame orientation at the C_3[111] axis and opens the predicate that any tie-breaking clause set must break proper-rotation covariance there; the note does not fix the presentation choice and does not act on the memo's live Qualification slot; B5 is weight-neutral (no weight r is referenced, forced, derived, or selected); the corner surface remains the mechanism note's supplied surface (inherited FLAG)
+RESIDUAL (declared-open, inherited): the mechanism note's live Qualification leaves the presentation orientation conditional/open; this note does not act on it
+RESIDUAL (declared-open, inherited): the corner surface is the mechanism note's supplied surface, not a physically derived carrier
+T5 REPORT (computed, consumed by no other claim): undressed U2 does not commute with D2; undressed U_R does not commute with D2; the named 4096-candidate dressed class contains 64 commuting members for U2 and 64 for U_R; none of the 64 members in either class preserves the hw=1 triplet subspace (0 of 64 each); one-bit sign-field flips of the exemplars break commutation (discriminating rejectors); the identity dressings have nonzero commutators with D2
+TOTAL: PASS=132 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.txt
+++ b/logs/runner-cache/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.py
-runner_sha256: eb16d94fcd4e8f70e4879fc645938cecae4837034be92a1da20712215dd64a9c
+runner_sha256: c211457778a39daa4152cb989d65881b858f28491baedd84cb35a102d34b9ceb
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 6.30
+elapsed_sec: 8.09
 status: ok
 ----- stdout -----
 A.1 PASS 2D is integer antisymmetric with entries in {-1,0,1}
@@ -32,10 +32,10 @@ B2.3 PASS in particular TS P_w TS = P_wbar and TS P_1 TS = P_1, and the map is n
 B2.4 PASS generator coherence: P_wbar(C) = P_w(C^2) symbolically (the rotated pair is the entrywise-conjugate model presented with its natural generator)
 B2.5 PASS conj(TS) = TS (real rotation); the antilinear involution M -> conj(TS M TS) fixes every P_chi and is nontrivial (moves C to C^2)
 B2.6 PASS probe transform: TS W(a,b,c) TS = W(a,c,b) (the swap exchanges the b and c generator coefficients)
-B3.1 PASS the presentation pair {P_w, P_wbar} is a single 2-orbit under the delivered proper rotation: TS P_w TS = P_wbar, TS P_wbar TS = P_w, TS P_1 TS = P_1
+B3.1 PASS the corner-projector pair {P_w, P_wbar} is a single 2-orbit under the delivered proper rotation: TS P_w TS = P_wbar, TS P_wbar TS = P_w, TS P_1 TS = P_1
 B3.2 PASS the rotation orbit coincides with the entrywise-conjugation orbit: TS P_chi TS = conj(P_chi) is the same partition of the projector family
 B3.3 PASS canonical K-odd separator D0 = P_w - P_wbar: nonzero, conj(D0) = -D0 (K-odd), and TS D0 TS = -D0 = conj(D0) -- the delivered rotation exchanges the canonical K-odd seed exactly as K does
-B3.4 PASS the rotation image (C^2 with its natural w-channel projector) reproduces the conjugate model: P_w(C^2) = P_wbar(C), so the orbit image is the FLAG's entrywise-conjugate presentation
+B3.4 PASS the rotation image (C^2 with its natural w-channel projector) reproduces the conjugate corner model: P_w(C^2) = P_wbar(C), so the orbit image is the corner-projector restriction of the FLAG's entrywise-conjugate presentation
 B4.1 PASS channel values: W(a,b,c) P_chi = lam_chi P_chi with lam_chi = a + b*chi + c*chi^2; the doublet separation is lam_w - lam_wbar = i*sqrt(3)*(b-c) exactly
 B4.2 PASS under the swap b<->c: lam_1 fixed and the doublet pair is exchanged, lam_w(W(a,c,b)) = lam_wbar(W(a,b,c)) and lam_wbar(W(a,c,b)) = lam_w(W(a,b,c))
 B4.3 PASS Hermitian-section coincidence (keystone): with b = b1 + i*b2, W_H = a*I + b*C + conj(b)*C^2 satisfies conj(W_H) = TS W_H TS exactly -- on the Hermitian section the antilinear K-exchange IS conjugation by the delivered proper rotation
@@ -43,6 +43,7 @@ B4.4 PASS off-section witness skew = C - C^2: K-EVEN (conj skew = skew) but rota
 B4.5 PASS off-section witness i*I: K-ODD (conj = -it) but rotation-EVEN (TS (i*I) TS = i*I), and it does NOT separate (all channel values equal)
 B4.6 PASS the two gradings are inequivalent off the Hermitian section: conj(skew) != TS skew TS and conj(i*I) != TS (i*I) TS, while on the section conj(W_H) = TS W_H TS (item n) -- K-parity and rotation-parity coincide only on the Hermitian section
 B4.7 PASS exact section characterization: for general complex (a,b,c), conj(W) - TS W TS = (conj(a)-a) I + (conj(b)-c) C + (conj(c)-b) C^2, and {I, C, C^2} are linearly independent (rank 3); hence conj(W) = TS W TS holds iff a is real and c = conj(b) -- exactly the Hermitian section, and only there
+B4.8 PASS joint-surface escape: sigma_2 tensor I_3 is K-ODD but fixed by the natural joint lift I_2 tensor TS, so the corner-projector orbit does not implement the mechanism note's full Pauli/corner entrywise-conjugation action
 B5.1 PASS the swap fixes lam_1 and permutes {lam_w, lam_wbar}: the elementary symmetric functions lam_w + lam_wbar and lam_w * lam_wbar are swap-invariant
 B5.2 PASS the swap genuinely moves the individual doublet values (lam_w(W(a,c,b)) - lam_w(W(a,b,c)) is not identically zero) while fixing their symmetric functions: the invariance is of the pair, not of a pinned value; no target weight r is referenced, forced, derived, or selected
 B5.3 PASS the singlet channel value lam_1 = a + b + c is swap-invariant (fixed): the guard references no weight value
@@ -90,7 +91,7 @@ B9.2 PASS note carries: ## Supplied objects and consumed readings
 B9.3 PASS note carries: ## Claims
 B9.4 PASS note carries: ### Lattice delivery of the presentation-swap rotation (T1, 
 B9.5 PASS note carries: ### Rotation conjugation equals entrywise conjugation on the
-B9.6 PASS note carries: ### The two-model pair is a proper-rotation orbit on the del
+B9.6 PASS note carries: ### The corner-projector pair is a proper-rotation orbit on 
 B9.7 PASS note carries: ### K-parity equals rotation parity on the Hermitian section
 B9.8 PASS note carries: ### Operator-level covariance report for the named dressed c
 B9.9 PASS note carries: ## Gated controls
@@ -113,43 +114,45 @@ B9.25 PASS note carries: Statuses of all dependencies are set by the independent
 B9.26 PASS note carries: **No check passes by literal stipulation.**
 B9.27 PASS note carries: **Status authority:** independent audit lane only.
 B9.28 PASS note carries: Context orientation only; no content is consumed from either
-B9.29 PASS note carries: On the delivered carrier the entrywise-conjugate presentatio
-B9.30 PASS note carries: The memo's live Qualification remains live and unfixed; this
-B9.31 PASS forbidden phrase absent: 'exhaust'
-B9.32 PASS forbidden phrase absent: 'only route'
-B9.33 PASS forbidden phrase absent: 'last route'
-B9.34 PASS forbidden phrase absent: 'bijection'
-B9.35 PASS forbidden phrase absent: 'final'
-B9.36 PASS forbidden phrase absent: 'forces r'
-B9.37 PASS forbidden phrase absent: 'derives r'
-B9.38 PASS forbidden phrase absent: 'selects r'
-B9.39 PASS forbidden phrase absent: 'retained'
-B9.40 PASS forbidden phrase absent: 'discharge'
-B9.41 PASS forbidden phrase absent: 'derived carrier'
-B9.42 PASS forbidden phrase absent: 'dissolv'
-B9.43 PASS forbidden phrase absent: 'retire'
-B9.44 PASS forbidden phrase absent: 'closes the'
-B9.45 PASS source-authored status/value snapshot absent: 'unaudited at writing'
-B9.46 PASS source-authored status/value snapshot absent: 'citation grades at writing'
-B9.47 PASS source-authored status/value snapshot absent: 'audited_renaming'
-B9.48 PASS source-authored status/value snapshot absent: 'honest auditor read'
-B9.49 PASS no bare decimal literals in the note
-B9.50 PASS markdown dependency link present: MINIMAL_AXIOMS_2026-06-29.md
-B9.51 PASS markdown dependency link present: STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md
-B9.52 PASS markdown dependency link present: KCPT_COUPLING_TRIPLE_TWO_PRESENTATION_DERIVABLE_CLASS_SPECTRAL_PAIRING_BOUNDED_THEOREM_NOTE_2026-07-16.md
-B9.53 PASS markdown dependency link present: KCPT_ORBIT_CONSTANT_REGISTERED_OCCUPANCY_WEIGHTS_DERIVABLE_PROTOCOL_CLASS_BOUNDED_THEOREM_NOTE_2026-07-12.md
-B9.54 PASS markdown dependency link present: KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md
-B9.55 PASS non-citation context handle is backticked and unlinked: ACPHILAMBDA_C3_RESOLVENT_DETERMINANT_HOLONOMY_COUPLING_NARROW_THEOREM_NOTE_2026-07-12.md
-B9.56 PASS non-citation context handle is backticked and unlinked: ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md
-B9.57 PASS every cited or handled doc path exists
+B9.29 PASS note carries: entrywise-conjugate corner-projector pair is exchanged by an
+B9.30 PASS note carries: Pauli/corner orbit of the mechanism note: under the natural 
+B9.31 PASS note carries: `sigma_2 tensor I_3` is fixed by rotation conjugation but is
+B9.32 PASS note carries: Qualification remains live and unfixed; this note does not a
+B9.33 PASS forbidden phrase absent: 'exhaust'
+B9.34 PASS forbidden phrase absent: 'only route'
+B9.35 PASS forbidden phrase absent: 'last route'
+B9.36 PASS forbidden phrase absent: 'bijection'
+B9.37 PASS forbidden phrase absent: 'final'
+B9.38 PASS forbidden phrase absent: 'forces r'
+B9.39 PASS forbidden phrase absent: 'derives r'
+B9.40 PASS forbidden phrase absent: 'selects r'
+B9.41 PASS forbidden phrase absent: 'retained'
+B9.42 PASS forbidden phrase absent: 'discharge'
+B9.43 PASS forbidden phrase absent: 'derived carrier'
+B9.44 PASS forbidden phrase absent: 'dissolv'
+B9.45 PASS forbidden phrase absent: 'retire'
+B9.46 PASS forbidden phrase absent: 'closes the'
+B9.47 PASS source-authored status/value snapshot absent: 'unaudited at writing'
+B9.48 PASS source-authored status/value snapshot absent: 'citation grades at writing'
+B9.49 PASS source-authored status/value snapshot absent: 'audited_renaming'
+B9.50 PASS source-authored status/value snapshot absent: 'honest auditor read'
+B9.51 PASS no bare decimal literals in the note
+B9.52 PASS markdown dependency link present: MINIMAL_AXIOMS_2026-06-29.md
+B9.53 PASS markdown dependency link present: STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md
+B9.54 PASS markdown dependency link present: KCPT_COUPLING_TRIPLE_TWO_PRESENTATION_DERIVABLE_CLASS_SPECTRAL_PAIRING_BOUNDED_THEOREM_NOTE_2026-07-16.md
+B9.55 PASS markdown dependency link present: KCPT_ORBIT_CONSTANT_REGISTERED_OCCUPANCY_WEIGHTS_DERIVABLE_PROTOCOL_CLASS_BOUNDED_THEOREM_NOTE_2026-07-12.md
+B9.56 PASS markdown dependency link present: KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md
+B9.57 PASS non-citation context handle is backticked and unlinked: ACPHILAMBDA_C3_RESOLVENT_DETERMINANT_HOLONOMY_COUPLING_NARROW_THEOREM_NOTE_2026-07-12.md
+B9.58 PASS non-citation context handle is backticked and unlinked: ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md
+B9.59 PASS every cited or handled doc path exists
 PATH note=docs/KCPT_CORNER_CARRIER_TWO_PRESENTATION_SWAP_PROPER_ROTATION_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-07-18.md
 PATH runner=scripts/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.py
 PATH cache=logs/runner-cache/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.txt
-FLAGS: T1 delivers the mechanism note's two-presentation swap as the proper pi-rotation about [1,-1,0] (det M = +1) on the same 4^3 staggered surface as the landed hw=1 carrier, using the landed delivery standard (translation conjugacy + kernel action); T2-T4 show rotation conjugation equals entrywise conjugation on the supplied projector family and coincides with the antilinear K-exchange exactly on the Hermitian section, with off-section inequivalence witnesses; T3 reclassifies the FLAG's unfixed binary choice as a rotation-frame orientation at the C_3[111] axis and opens the predicate that any tie-breaking clause set must break proper-rotation covariance there; the note does not fix the presentation choice and does not act on the memo's live Qualification slot; B5 is weight-neutral (no weight r is referenced, forced, derived, or selected); the corner surface remains the mechanism note's supplied surface (inherited FLAG)
+FLAGS: T1 delivers the corner-projector restriction of the mechanism note's two-presentation swap as the proper pi-rotation about [1,-1,0] (det M = +1) on the same 4^3 staggered surface as the landed hw=1 carrier, using the landed delivery standard (translation conjugacy + kernel action); T2-T4 show rotation conjugation equals entrywise conjugation on the supplied projector family and coincides with the antilinear K-exchange exactly on the Hermitian section, with off-section inequivalence witnesses; the full Pauli/corner presentation has the exact joint-factor escape sigma_2 tensor I_3 and is not reclassified; the note does not fix the mechanism's presentation choice and does not act on the memo's live Qualification slot; B5 is weight-neutral (no weight r is referenced, forced, derived, or selected); the corner surface remains the mechanism note's supplied surface (inherited FLAG)
 RESIDUAL (declared-open, inherited): the mechanism note's live Qualification leaves the presentation orientation conditional/open; this note does not act on it
 RESIDUAL (declared-open, inherited): the corner surface is the mechanism note's supplied surface, not a physically derived carrier
 T5 REPORT (computed, consumed by no other claim): undressed U2 does not commute with D2; undressed U_R does not commute with D2; the named 4096-candidate dressed class contains 64 commuting members for U2 and 64 for U_R; none of the 64 members in either class preserves the hw=1 triplet subspace (0 of 64 each); one-bit sign-field flips of the exemplars break commutation (discriminating rejectors); the identity dressings have nonzero commutators with D2
-TOTAL: PASS=132 FAIL=0
+TOTAL: PASS=135 FAIL=0
 
 ----- stderr -----
 

--- a/scripts/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.py
+++ b/scripts/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.py
@@ -1,0 +1,1021 @@
+#!/usr/bin/env python3
+"""Two-presentation swap is proper-rotation conjugacy on the delivered hw=1 carrier.
+
+Paired note:
+docs/KCPT_CORNER_CARRIER_TWO_PRESENTATION_SWAP_PROPER_ROTATION_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-07-18.md
+
+The mechanism note's two-model FLAG leaves an unfixed binary choice between the
+entrywise-conjugate presentations of the supplied corner carrier. This runner
+computes, in exact integer and exact symbolic arithmetic, that the pair is
+conjugate under the pi-rotation about [1,-1,0] -- a PROPER cubic rotation named by
+the LATTICE axiom -- delivered on the same 4^3 staggered surface as the landed hw=1
+carrier (T1); rotation conjugation acts on the supplied projector family exactly as
+entrywise conjugation K (T2); the presentation pair is a single 2-orbit of the
+proper rotation and the canonical K-odd separator is exchanged exactly as by K (T3);
+on the Hermitian probe section the antilinear K-exchange coincides exactly with the
+linear rotation conjugation while off the section the two gradings are inequivalent
+(T4); and an honest operator-level covariance report for the named 4096-candidate
+dressed class (T5), consumed by no other claim.
+
+Blocks:
+  A   construction replicated from the landed runner (exact integer): the
+      one-component staggered operator on the periodic 4^3 torus, its exact
+      rank 56 / kernel dimension 8, the eight orthogonal corner plane waves,
+      the translations, and the landed C_3[111] kernel action U_R V = V C
+  B1  T1 -- lattice delivery of the presentation-swap rotation (items a-g)
+  B2  T2 -- rotation conjugation equals entrywise conjugation on the projector
+      family (items h-l)
+  B3  T3 -- the two-model pair is a proper-rotation orbit; canonical K-odd
+      separator exchanged as by K (orbit statement + item p)
+  B4  T4 -- K-parity equals rotation parity on the Hermitian section; off-section
+      inequivalence witnesses (items m, n, o)
+  B5  r-neutrality guard (item q)
+  B6  T5 -- operator-level covariance report for the named dressed class
+      (honest computed report; consumed by no other claim)
+  B7  verbatim quote gates (Q1-Q6): sources carry the consumed sentences and the
+      note blockquotes them
+  B8  ledger shard filename gates (timeless: existence only, no status pins)
+  B9  note hygiene: section presence, forbidden-phrase absence, no bare decimal
+      literals, markdown dependency links, backticked context handles
+
+All lattice arithmetic is exact integer; all carrier algebra is exact symbolic.
+No floats, no tolerances, no randomness. Exit 1 on any failure.
+Cache: logs/runner-cache/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.txt
+"""
+
+import itertools
+import re
+from pathlib import Path
+
+import numpy as np
+import sympy as sp
+from sympy import I, Matrix, Rational, conjugate, eye, sqrt
+
+ROOT = Path(__file__).resolve().parents[1]
+
+NOTE = (
+    "docs/KCPT_CORNER_CARRIER_TWO_PRESENTATION_SWAP_PROPER_ROTATION_"
+    "CONJUGACY_BOUNDED_THEOREM_NOTE_2026-07-18.md"
+)
+RUNNER = (
+    "scripts/kcpt_corner_carrier_two_presentation_swap_proper_rotation_"
+    "conjugacy_2026_07_18.py"
+)
+CACHE = (
+    "logs/runner-cache/kcpt_corner_carrier_two_presentation_swap_proper_"
+    "rotation_conjugacy_2026_07_18.txt"
+)
+
+AXIOMS = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+GATE = "docs/STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md"
+BLOCK05 = (
+    "docs/KCPT_COUPLING_TRIPLE_TWO_PRESENTATION_DERIVABLE_CLASS_"
+    "SPECTRAL_PAIRING_BOUNDED_THEOREM_NOTE_2026-07-16.md"
+)
+MECH = (
+    "docs/KCPT_ORBIT_CONSTANT_REGISTERED_OCCUPANCY_WEIGHTS_DERIVABLE_"
+    "PROTOCOL_CLASS_BOUNDED_THEOREM_NOTE_2026-07-12.md"
+)
+DELIVERY = (
+    "docs/KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_"
+    "POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md"
+)
+
+PASS = 0
+FAIL = 0
+FAILURES = []
+
+
+def check(block, name, condition, detail=""):
+    global PASS, FAIL
+    ok = bool(condition)
+    if ok:
+        PASS += 1
+        status = "PASS"
+    else:
+        FAIL += 1
+        status = "FAIL"
+        FAILURES.append(f"{block}:{name}")
+    suffix = f" [{detail}]" if detail else ""
+    print(f"{block} {status} {name}{suffix}")
+
+
+def mat_zero(M):
+    return all(
+        sp.simplify(sp.expand_complex(sp.expand(M[i, j]))) == 0
+        for i in range(M.rows)
+        for j in range(M.cols)
+    )
+
+
+def is_zero(expr):
+    return sp.simplify(sp.expand_complex(sp.expand(expr))) == 0
+
+
+def flattened(rel):
+    return " ".join((ROOT / rel).read_text(encoding="utf-8").split())
+
+
+def quote_groups(rel):
+    groups, cur = [], []
+    for line in (ROOT / rel).read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if s.startswith(">"):
+            cur.append(s.lstrip(">").strip())
+        else:
+            if cur:
+                groups.append(" ".join(" ".join(cur).split()))
+                cur = []
+    if cur:
+        groups.append(" ".join(" ".join(cur).split()))
+    return groups
+
+
+def in_groups(groups, needle):
+    return any(needle in g for g in groups)
+
+
+# ---------------------------------------------------------------------------
+# A: construction, exact integer arithmetic (replicated from the landed runner)
+# ---------------------------------------------------------------------------
+
+L = 4
+N = L**3
+
+
+def sites():
+    return itertools.product(range(L), repeat=3)
+
+
+def idx(x1, x2, x3):
+    return (x1 * L + x2) * L + x3
+
+
+EMU = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+
+
+def eta_ks(x, mu):
+    if mu == 0:
+        return 1
+    if mu == 1:
+        return (-1) ** x[0]
+    return (-1) ** (x[0] + x[1])
+
+
+# D2 = 2*D so all entries are integers; D = one-component staggered operator
+D2 = np.zeros((N, N), dtype=np.int64)
+for x in sites():
+    for mu, e in enumerate(EMU):
+        xp = tuple((x[k] + e[k]) % L for k in range(3))
+        xm = tuple((x[k] - e[k]) % L for k in range(3))
+        D2[idx(*x), idx(*xp)] += eta_ks(x, mu)
+        D2[idx(*x), idx(*xm)] -= eta_ks(x, mu)
+
+check(
+    "A.1",
+    "2D is integer antisymmetric with entries in {-1,0,1}",
+    np.array_equal(D2, -D2.T) and set(np.unique(D2)) <= {-1, 0, 1},
+)
+
+rank_exact = sp.Matrix(D2.tolist()).rank()
+check("A.2", "exact rank(D) = 56, so dim ker D = 8", rank_exact == 56)
+
+SUBSETS = [
+    (),
+    (0,),
+    (1,),
+    (2,),
+    (0, 1),
+    (0, 2),
+    (1, 2),
+    (0, 1, 2),
+]
+V8 = np.zeros((N, 8), dtype=np.int64)
+for j, S in enumerate(SUBSETS):
+    for x in sites():
+        V8[idx(*x), j] = (-1) ** sum(x[mu] for mu in S)
+
+check(
+    "A.3",
+    "all eight corner plane waves are exact null vectors of D",
+    np.array_equal(D2 @ V8, np.zeros((N, 8), dtype=np.int64)),
+)
+check(
+    "A.4",
+    "corner waves orthogonal (V8^T V8 = 64*I), hence they span ker D exactly",
+    np.array_equal(V8.T @ V8, 64 * np.eye(8, dtype=np.int64)),
+)
+
+Tmat = []
+for mu, e in enumerate(EMU):
+    T = np.zeros((N, N), dtype=np.int64)
+    for x in sites():
+        xp = tuple((x[k] + e[k]) % L for k in range(3))
+        T[idx(*xp), idx(*x)] = 1
+    Tmat.append(T)
+T1, T2, T3 = Tmat
+
+
+def matpow(M, p):
+    return np.linalg.matrix_power(M, p).astype(np.int64)
+
+
+check(
+    "A.5",
+    "translations are commuting permutation matrices of order 4",
+    all(np.array_equal(T.T @ T, np.eye(N, dtype=np.int64)) for T in Tmat)
+    and all(np.array_equal(matpow(T, 4), np.eye(N, dtype=np.int64)) for T in Tmat)
+    and all(
+        np.array_equal(Tmat[a] @ Tmat[b], Tmat[b] @ Tmat[a])
+        for a in range(3)
+        for b in range(3)
+    ),
+)
+
+# hw=1 slots ordered so slot mu carries T_mu eigenvalue -1: columns 1,2,3 of V8
+V = V8[:, 1:4]
+char_ok = True
+for mu, T in enumerate(Tmat):
+    TV = T @ V
+    for j in range(3):
+        expect = -1 if j == mu else 1
+        if not np.array_equal(TV[:, j], expect * V[:, j]):
+            char_ok = False
+check(
+    "A.6",
+    "hw=1 joint translation characters are exactly "
+    "(-1,+1,+1), (+1,-1,+1), (+1,+1,-1)",
+    char_ok,
+)
+
+# U_R: (U_R f)(x) = f(R^{-1} x) with R^{-1}(x1,x2,x3) = (x2,x3,x1)
+UR = np.zeros((N, N), dtype=np.int64)
+for x in sites():
+    xr = (x[1], x[2], x[0])
+    UR[idx(*x), idx(*xr)] = 1
+
+check(
+    "A.7",
+    "U_R is a permutation matrix with U_R^3 = I",
+    np.array_equal(UR.T @ UR, np.eye(N, dtype=np.int64))
+    and np.array_equal(matpow(UR, 3), np.eye(N, dtype=np.int64)),
+)
+check(
+    "A.8",
+    "U_R conjugates translations cyclically: U_R T_mu U_R^T = T_{mu+1 mod 3}",
+    all(np.array_equal(UR @ Tmat[mu] @ UR.T, Tmat[(mu + 1) % 3]) for mu in range(3)),
+)
+
+CINT = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]], dtype=np.int64)
+check(
+    "A.9",
+    "landed kernel action: U_R V = V C exactly (C = [[0,0,1],[1,0,0],[0,1,0]])",
+    np.array_equal(UR @ V, V @ CINT),
+)
+
+# ---------------------------------------------------------------------------
+# B1: T1 -- lattice delivery of the presentation-swap rotation (items a-g)
+# ---------------------------------------------------------------------------
+
+# swap rotation R2(x1,x2,x3) = (-x2,-x1,-x3) mod 4; site matrix M (column action)
+M = np.array([[0, -1, 0], [-1, 0, 0], [0, 0, -1]], dtype=np.int64)
+
+
+def R2(x):
+    return ((-x[1]) % L, (-x[0]) % L, (-x[2]) % L)
+
+
+Msym = Matrix(M.tolist())
+axis = np.array([1, -1, 0], dtype=np.int64)
+row_ok = all(np.count_nonzero(M[i, :]) == 1 for i in range(3))
+col_ok = all(np.count_nonzero(M[:, j]) == 1 for j in range(3))
+check(
+    "B1.1",
+    "M is a PROPER signed-permutation involution (det +1, M^T M = I, M^2 = I, "
+    "one nonzero per row/col in {-1,0,1}): an element of the cubic rotation group O",
+    Msym.det() == 1
+    and np.array_equal(M @ M.T, np.eye(3, dtype=np.int64))
+    and np.array_equal(M @ M, np.eye(3, dtype=np.int64))
+    and row_ok
+    and col_ok
+    and set(np.unique(M)) <= {-1, 0, 1},
+)
+check(
+    "B1.2",
+    "R2 fixes the [1,-1,0] axis (M [1,-1,0]^T = [1,-1,0]^T): the pi-rotation "
+    "about [1,-1,0]",
+    np.array_equal(M @ axis, axis),
+)
+check(
+    "B1.3",
+    "group relation R2 R3 R2 = R3^{-1}: M C M = C^T exactly",
+    np.array_equal(M @ CINT @ M, CINT.T),
+)
+
+# lattice unitary U2[idx(x), idx(R2 x)] = 1 (R2 is an involution, so R2inv = R2)
+U2 = np.zeros((N, N), dtype=np.int64)
+for x in sites():
+    U2[idx(*x), idx(*R2(x))] = 1
+
+check(
+    "B1.4",
+    "U2 is a symmetric permutation involution (U2 = U2^T, U2 U2 = I_N)",
+    np.array_equal(U2, U2.T)
+    and np.array_equal(U2 @ U2, np.eye(N, dtype=np.int64)),
+)
+check(
+    "B1.5",
+    "U2 U_R U2 = U_R^T exactly (the swap conjugates the C_3[111] rotation to "
+    "its inverse)",
+    np.array_equal(U2 @ UR @ U2, UR.T),
+)
+check(
+    "B1.6",
+    "translation conjugacy: U2 T1 U2 = T2^3, U2 T2 U2 = T1^3, U2 T3 U2 = T3^3 "
+    "(translation by M e_mu; -e_mu = 3 e_mu mod 4)",
+    np.array_equal(U2 @ T1 @ U2, matpow(T2, 3))
+    and np.array_equal(U2 @ T2 @ U2, matpow(T1, 3))
+    and np.array_equal(U2 @ T3 @ U2, matpow(T3, 3)),
+)
+
+# sign-free corner-wave covariance: U2 V8 = V8 PI, PI a pure subset permutation
+SUB_INDEX = {S: i for i, S in enumerate(SUBSETS)}
+
+
+def sigma_subset(S):
+    swap = {0: 1, 1: 0, 2: 2}
+    return tuple(sorted(swap[a] for a in S))
+
+
+PI = np.zeros((8, 8), dtype=np.int64)
+for j, S in enumerate(SUBSETS):
+    PI[SUB_INDEX[sigma_subset(S)], j] = 1
+
+pi_perm = all(PI[:, j].sum() == 1 for j in range(8)) and all(
+    PI[i, :].sum() == 1 for i in range(8)
+)
+check(
+    "B1.7",
+    "sign-free corner-wave covariance: U2 V8 = V8 PI with PI a pure subset "
+    "permutation (every entry in {0,1}; (0,)<->(1,), (0,2)<->(1,2), (2,) fixed)",
+    np.array_equal(U2 @ V8, V8 @ PI)
+    and set(np.unique(PI)) <= {0, 1}
+    and pi_perm
+    and PI[SUB_INDEX[(1,)], SUB_INDEX[(0,)]] == 1
+    and PI[SUB_INDEX[(0,)], SUB_INDEX[(1,)]] == 1
+    and PI[SUB_INDEX[(2,)], SUB_INDEX[(2,)]] == 1,
+)
+
+TS = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]], dtype=np.int64)
+check(
+    "B1.8",
+    "hw=1 kernel action: U2 V = V TS with TS the transposition swapping the "
+    "(0,) and (1,) corner waves",
+    np.array_equal(U2 @ V, V @ TS),
+)
+check(
+    "B1.9",
+    "T1 rejector: TS != I3 and TS C TS != C -- the delivered action genuinely "
+    "moves C on the triplet",
+    (not np.array_equal(TS, np.eye(3, dtype=np.int64)))
+    and (not np.array_equal(TS @ CINT @ TS, CINT)),
+)
+
+# negative control: trivial-restriction proper rotation R2b = diag(-1,-1,1)
+R2b_mat = np.array([[-1, 0, 0], [0, -1, 0], [0, 0, 1]], dtype=np.int64)
+
+
+def R2b(x):
+    return ((-x[0]) % L, (-x[1]) % L, x[2])
+
+
+U2b = np.zeros((N, N), dtype=np.int64)
+for x in sites():
+    U2b[idx(*x), idx(*R2b(x))] = 1
+
+check(
+    "B1.10",
+    "trivial-restriction control: R2b = diag(-1,-1,1) is PROPER (det +1) yet "
+    "restricts to the identity on the hw=1 triplet (U2b V = V) while moving "
+    "sites (U2b != I_N): properness alone does not deliver the swap",
+    Matrix(R2b_mat.tolist()).det() == 1
+    and np.array_equal(U2b @ V, V)
+    and (not np.array_equal(U2b, np.eye(N, dtype=np.int64))),
+)
+
+# improper-honesty gate: bare mirror x1<->x2 has det -1, not in the proper set
+S12 = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]], dtype=np.int64)
+check(
+    "B1.11",
+    "improper-honesty: the bare coordinate mirror S12 (x1<->x2) has det -1 "
+    "(not in the axiom's proper rotation set), while the swap M has det +1 "
+    "(proper): no improper element is consumed",
+    Matrix(S12.tolist()).det() == -1 and Msym.det() == 1,
+)
+
+# ---------------------------------------------------------------------------
+# B2: T2 -- rotation conjugation equals entrywise conjugation on the projector
+#     family (items h-l), exact symbolic
+# ---------------------------------------------------------------------------
+
+C3 = Matrix(CINT.tolist())
+TSs = Matrix(TS.tolist())
+
+check(
+    "B2.1",
+    "TS C TS = C^T = C^2 exactly, and C is real (conj C = C)",
+    (TSs * C3 * TSs == C3.T)
+    and (C3.T == C3**2)
+    and mat_zero(conjugate(C3) - C3),
+)
+
+w = Rational(-1, 2) + sqrt(3) / 2 * I
+wb = conjugate(w)
+CHI = [sp.Integer(1), w, wb]
+
+
+def proj(chi, G):
+    P = (eye(3) + conjugate(chi) * G + conjugate(chi) ** 2 * G**2) / 3
+    return P.applyfunc(lambda e: sp.expand_complex(sp.expand(e)))
+
+
+P = {chi: proj(chi, C3) for chi in CHI}
+
+check(
+    "B2.2",
+    "TS P_chi TS = conj(P_chi) for all three channels: rotation conjugation "
+    "acts on the supplied projector family identically to entrywise K",
+    all(mat_zero(TSs * P[chi] * TSs - conjugate(P[chi])) for chi in CHI),
+)
+check(
+    "B2.3",
+    "in particular TS P_w TS = P_wbar and TS P_1 TS = P_1, and the map is "
+    "nontrivial (P_w != P_wbar)",
+    mat_zero(TSs * P[w] * TSs - P[wb])
+    and mat_zero(TSs * P[sp.Integer(1)] * TSs - P[sp.Integer(1)])
+    and (not mat_zero(P[w] - P[wb])),
+)
+check(
+    "B2.4",
+    "generator coherence: P_wbar(C) = P_w(C^2) symbolically (the rotated pair "
+    "is the entrywise-conjugate model presented with its natural generator)",
+    mat_zero(proj(wb, C3) - proj(w, C3**2)),
+)
+check(
+    "B2.5",
+    "conj(TS) = TS (real rotation); the antilinear involution "
+    "M -> conj(TS M TS) fixes every P_chi and is nontrivial (moves C to C^2)",
+    mat_zero(conjugate(TSs) - TSs)
+    and all(mat_zero(conjugate(TSs * P[chi] * TSs) - P[chi]) for chi in CHI)
+    and (not mat_zero(conjugate(TSs * C3 * TSs) - C3)),
+)
+
+pa, pb, pc = sp.symbols("pa pb pc", commutative=True)
+Wp = pa * eye(3) + pb * C3 + pc * C3**2
+check(
+    "B2.6",
+    "probe transform: TS W(a,b,c) TS = W(a,c,b) (the swap exchanges the b and c "
+    "generator coefficients)",
+    mat_zero(TSs * Wp * TSs - (pa * eye(3) + pc * C3 + pb * C3**2)),
+)
+
+# ---------------------------------------------------------------------------
+# B3: T3 -- the two-model pair is a proper-rotation orbit; canonical K-odd
+#     separator (orbit statement + item p), exact symbolic
+# ---------------------------------------------------------------------------
+
+check(
+    "B3.1",
+    "the presentation pair {P_w, P_wbar} is a single 2-orbit under the delivered "
+    "proper rotation: TS P_w TS = P_wbar, TS P_wbar TS = P_w, TS P_1 TS = P_1",
+    mat_zero(TSs * P[w] * TSs - P[wb])
+    and mat_zero(TSs * P[wb] * TSs - P[w])
+    and mat_zero(TSs * P[sp.Integer(1)] * TSs - P[sp.Integer(1)]),
+)
+check(
+    "B3.2",
+    "the rotation orbit coincides with the entrywise-conjugation orbit: "
+    "TS P_chi TS = conj(P_chi) is the same partition of the projector family",
+    all(mat_zero(TSs * P[chi] * TSs - conjugate(P[chi])) for chi in CHI),
+)
+
+D0 = P[w] - P[wb]
+check(
+    "B3.3",
+    "canonical K-odd separator D0 = P_w - P_wbar: nonzero, conj(D0) = -D0 "
+    "(K-odd), and TS D0 TS = -D0 = conj(D0) -- the delivered rotation exchanges "
+    "the canonical K-odd seed exactly as K does",
+    (not mat_zero(D0))
+    and mat_zero(conjugate(D0) + D0)
+    and mat_zero(TSs * D0 * TSs + D0)
+    and mat_zero(TSs * D0 * TSs - conjugate(D0)),
+)
+check(
+    "B3.4",
+    "the rotation image (C^2 with its natural w-channel projector) reproduces "
+    "the conjugate model: P_w(C^2) = P_wbar(C), so the orbit image is the "
+    "FLAG's entrywise-conjugate presentation",
+    mat_zero(proj(w, C3**2) - proj(wb, C3)),
+)
+
+# ---------------------------------------------------------------------------
+# B4: T4 -- K-parity equals rotation parity on the Hermitian section;
+#     off-section inequivalence witnesses (items m, n, o), exact symbolic
+# ---------------------------------------------------------------------------
+
+a, b, c = sp.symbols("a b c", commutative=True)
+Wabc = a * eye(3) + b * C3 + c * C3**2
+lam1 = a + b + c
+lam_w = a + b * w + c * w**2
+lam_wb = a + b * wb + c * wb**2
+check(
+    "B4.1",
+    "channel values: W(a,b,c) P_chi = lam_chi P_chi with lam_chi = a + b*chi + "
+    "c*chi^2; the doublet separation is lam_w - lam_wbar = i*sqrt(3)*(b-c) exactly",
+    mat_zero(Wabc * P[sp.Integer(1)] - lam1 * P[sp.Integer(1)])
+    and mat_zero(Wabc * P[w] - lam_w * P[w])
+    and mat_zero(Wabc * P[wb] - lam_wb * P[wb])
+    and is_zero(lam_w - lam_wb - I * sqrt(3) * (b - c)),
+)
+
+Wswap = a * eye(3) + c * C3 + b * C3**2  # W(a,c,b)
+lam_w_s = a + c * w + b * w**2
+lam_wb_s = a + c * wb + b * wb**2
+check(
+    "B4.2",
+    "under the swap b<->c: lam_1 fixed and the doublet pair is exchanged, "
+    "lam_w(W(a,c,b)) = lam_wbar(W(a,b,c)) and lam_wbar(W(a,c,b)) = lam_w(W(a,b,c))",
+    is_zero(lam_w_s - lam_wb)
+    and is_zero(lam_wb_s - lam_w)
+    and is_zero((a + c + b) - lam1),
+)
+
+b1, b2, ah = sp.symbols("b1 b2 ah", real=True)
+bH = b1 + I * b2
+WH = ah * eye(3) + bH * C3 + conjugate(bH) * C3**2
+check(
+    "B4.3",
+    "Hermitian-section coincidence (keystone): with b = b1 + i*b2, "
+    "W_H = a*I + b*C + conj(b)*C^2 satisfies conj(W_H) = TS W_H TS exactly -- on "
+    "the Hermitian section the antilinear K-exchange IS conjugation by the "
+    "delivered proper rotation",
+    mat_zero(conjugate(WH) - TSs * WH * TSs),
+)
+
+skew = C3 - C3**2
+sep_skew = (a + b * w + c * w**2 - (a + b * wb + c * wb**2)).subs(
+    {a: 0, b: 1, c: -1}
+)
+check(
+    "B4.4",
+    "off-section witness skew = C - C^2: K-EVEN (conj skew = skew) but "
+    "rotation-ODD (TS skew TS = -skew), and it separates the doublet "
+    "(lam_w - lam_wbar = 2*i*sqrt(3) != 0)",
+    mat_zero(conjugate(skew) - skew)
+    and mat_zero(TSs * skew * TSs + skew)
+    and is_zero(sep_skew - 2 * I * sqrt(3))
+    and (not is_zero(sep_skew)),
+)
+
+cImag = I * eye(3)
+check(
+    "B4.5",
+    "off-section witness i*I: K-ODD (conj = -it) but rotation-EVEN "
+    "(TS (i*I) TS = i*I), and it does NOT separate (all channel values equal)",
+    mat_zero(conjugate(cImag) + cImag)
+    and mat_zero(TSs * cImag * TSs - cImag)
+    and is_zero(sp.trace(P[w] * cImag) - sp.trace(P[wb] * cImag)),
+)
+check(
+    "B4.6",
+    "the two gradings are inequivalent off the Hermitian section: "
+    "conj(skew) != TS skew TS and conj(i*I) != TS (i*I) TS, while on the section "
+    "conj(W_H) = TS W_H TS (item n) -- K-parity and rotation-parity coincide only "
+    "on the Hermitian section",
+    (not mat_zero(conjugate(skew) - TSs * skew * TSs))
+    and (not mat_zero(conjugate(cImag) - TSs * cImag * TSs))
+    and mat_zero(conjugate(WH) - TSs * WH * TSs),
+)
+DeltaW = conjugate(Wabc) - TSs * Wabc * TSs
+check(
+    "B4.7",
+    "exact section characterization: for general complex (a,b,c), "
+    "conj(W) - TS W TS = (conj(a)-a) I + (conj(b)-c) C + (conj(c)-b) C^2, and "
+    "{I, C, C^2} are linearly independent (rank 3); hence conj(W) = TS W TS "
+    "holds iff a is real and c = conj(b) -- exactly the Hermitian section, "
+    "and only there",
+    mat_zero(
+        DeltaW
+        - (
+            (conjugate(a) - a) * eye(3)
+            + (conjugate(b) - c) * C3
+            + (conjugate(c) - b) * C3**2
+        )
+    )
+    and sp.Matrix.hstack(
+        eye(3).reshape(9, 1), C3.reshape(9, 1), (C3**2).reshape(9, 1)
+    ).rank()
+    == 3,
+)
+
+# ---------------------------------------------------------------------------
+# B5: r-neutrality guard (item q), exact symbolic
+# ---------------------------------------------------------------------------
+
+sum_pair = lam_w + lam_wb
+prod_pair = lam_w * lam_wb
+sum_pair_s = lam_w_s + lam_wb_s
+prod_pair_s = lam_w_s * lam_wb_s
+check(
+    "B5.1",
+    "the swap fixes lam_1 and permutes {lam_w, lam_wbar}: the elementary "
+    "symmetric functions lam_w + lam_wbar and lam_w * lam_wbar are swap-invariant",
+    is_zero(sum_pair_s - sum_pair) and is_zero(prod_pair_s - prod_pair),
+)
+check(
+    "B5.2",
+    "the swap genuinely moves the individual doublet values "
+    "(lam_w(W(a,c,b)) - lam_w(W(a,b,c)) is not identically zero) while fixing "
+    "their symmetric functions: the invariance is of the pair, not of a pinned "
+    "value; no target weight r is referenced, forced, derived, or selected",
+    not is_zero(lam_w_s - lam_w),
+)
+check(
+    "B5.3",
+    "the singlet channel value lam_1 = a + b + c is swap-invariant (fixed): the "
+    "guard references no weight value",
+    is_zero((a + c + b) - lam1),
+)
+
+# ---------------------------------------------------------------------------
+# B6: T5 -- operator-level covariance report for the named dressed class
+#     (honest computed report; consumed by no other claim)
+# ---------------------------------------------------------------------------
+
+
+def commutes(U):
+    return np.array_equal(U @ D2, D2 @ U)
+
+
+check(
+    "B6.1",
+    "computed undressed status: U2 does NOT commute with D2 (the swap needs a "
+    "sign dressing to be a D operator symmetry)",
+    not commutes(U2),
+)
+check(
+    "B6.2",
+    "computed undressed status: U_R does NOT commute with D2 (the C_3[111] "
+    "rotation needs a sign dressing to be a D operator symmetry)",
+    not commutes(UR),
+)
+
+
+def sign_diag(bits):
+    a1, a2, a3, b12, b13, b23 = bits
+    d = np.empty(N, dtype=np.int64)
+    for x in sites():
+        e = (
+            a1 * x[0]
+            + a2 * x[1]
+            + a3 * x[2]
+            + b12 * x[0] * x[1]
+            + b13 * x[0] * x[2]
+            + b23 * x[1] * x[2]
+        )
+        d[idx(*x)] = -1 if (e & 1) else 1
+    return d
+
+
+SIGN_FIELDS = list(itertools.product((0, 1), repeat=6))  # 64 sign fields
+SIGN_DIAGS = [sign_diag(bits) for bits in SIGN_FIELDS]
+TRANS_LIST = [
+    (t, matpow(T1, t[0]) @ matpow(T2, t[1]) @ matpow(T3, t[2]))
+    for t in itertools.product(range(L), repeat=3)
+]  # 64 lattice translations
+
+
+def dressed_search(base):
+    visited = 0
+    sols = []
+    for bits, dg in zip(SIGN_FIELDS, SIGN_DIAGS):
+        Sbase = (dg[:, None] * base).astype(np.int64)
+        for t, Tt in TRANS_LIST:
+            U = (Sbase @ Tt).astype(np.int64)
+            visited += 1
+            if np.array_equal(U @ D2, D2 @ U):
+                sols.append((bits, t, U))
+    return visited, sols
+
+
+def triplet_compression(U):
+    return V.T @ U @ V
+
+
+def preserves_triplet(U):
+    # V^T V = 64 I, so P = V V^T / 64 is the orthogonal projector onto
+    # span(V); U preserves span(V) iff P U V = U V, i.e. 64 U V = V (V^T U V),
+    # checked here in exact integer arithmetic.
+    return np.array_equal(64 * (U @ V), V @ (V.T @ U @ V))
+
+
+def first_flip_breaks(bits, t):
+    Tt = dict(TRANS_LIST)[t]
+    for bi in range(6):
+        fb = list(bits)
+        fb[bi] ^= 1
+        Uf = (sign_diag(tuple(fb))[:, None] * (INT_BASE @ Tt)).astype(np.int64)
+        if not commutes(Uf):
+            return True, tuple(fb)
+    return False, None
+
+
+for label, base in (("U2", U2), ("UR", UR)):
+    INT_BASE = base
+    visited, sols = dressed_search(base)
+    count = len(sols)
+    preserve_count = sum(1 for (_, _, U) in sols if preserves_triplet(U))
+    id_comm = base @ D2 - D2 @ base
+    id_nnz = int(np.count_nonzero(id_comm))
+    b0 = 3 if label == "U2" else 10
+    check(
+        f"B6.{b0}",
+        f"{label} dressed search visited exactly 4096 candidates "
+        "(64 sign fields x 64 translations)",
+        visited == 4096,
+    )
+    check(
+        f"B6.{b0 + 1}",
+        f"{label} dressed class solution count is exactly 64 (computed live)",
+        count == 64,
+    )
+    bits0, t0, U0 = sols[0]
+    check(
+        f"B6.{b0 + 2}",
+        f"{label} exemplar re-check: the reported exemplar commutes with D2",
+        commutes(U0),
+    )
+    check(
+        f"B6.{b0 + 3}",
+        f"{label} exemplar preserves the full 8-dim corner-wave kernel "
+        "(D2 U V8 = 0) but does NOT preserve the hw=1 triplet subspace "
+        "(the off-triplet residual 64*U V - V (V^T U V) is nonzero)",
+        np.array_equal(D2 @ U0 @ V8, np.zeros((N, 8), dtype=np.int64))
+        and (not preserves_triplet(U0)),
+    )
+    check(
+        f"B6.{b0 + 4}",
+        f"{label} class-scoped count: no member of the named 4096-candidate "
+        "dressed class preserves the hw=1 triplet subspace "
+        "(0 of 64 -- computed live)",
+        preserve_count == 0,
+    )
+    flip_breaks, flip_bits = first_flip_breaks(bits0, t0)
+    check(
+        f"B6.{b0 + 5}",
+        f"{label} discriminating rejector: a one-bit flip of the exemplar sign "
+        "field FAILS to commute with D2",
+        flip_breaks,
+    )
+    check(
+        f"B6.{b0 + 6}",
+        f"{label} check is live: the identity dressing (s=0, t=0) has a nonzero "
+        "commutator with D2",
+        id_nnz > 0,
+    )
+    print(
+        f"B6 REPORT {label}: undressed_commutes={commutes(base)}; "
+        f"visited={visited}; solutions={count}; triplet_preserving={preserve_count}; "
+        f"identity_dressing_commutator_nonzero_entries={id_nnz}"
+    )
+    print(
+        f"B6 REPORT {label} exemplar: (a1,a2,a3,b12,b13,b23)={bits0}; "
+        f"t={t0}; one_bit_flip_breaks={flip_bits}; "
+        f"compression V^T U V = {triplet_compression(U0).tolist()}"
+    )
+
+# ---------------------------------------------------------------------------
+# B7: verbatim quote gates (Q1-Q6)
+# ---------------------------------------------------------------------------
+
+NEEDLE_Q1 = (
+    "**R2 — K-real derivable initial data.** Derivable initial data is K-real. "
+    "**FLAG — two-model mechanism:** the entrywise-conjugate presentations in "
+    "L-K2 satisfy the same named clauses and exchange every K-odd seed. The "
+    "memo's live Qualification leaves the unfixed choice conditional/open."
+)
+NEEDLE_R1C = (
+    "The real cyclic `C` with `C^3 = I_3` and `C^T = C^2`, the character "
+    "projectors `P_chi = (I + conj(chi)*C + conj(chi)^2*C^2)/3` for "
+    "`chi in {1, w, conj(w)}`, `w = -1/2 + (sqrt(3)/2)*i`, and entrywise "
+    "conjugation `K` in the canonical basis."
+)
+NEEDLE_FLAG = (
+    "**FLAG — supplied surface:** this is the mechanism note's declared "
+    "corner surface, not a derived physical carrier."
+)
+NEEDLE_AX1 = (
+    "Physical sites are the points of the cubic lattice `Z^3`, with "
+    "nearest-neighbor adjacency, standard translations, and proper cubic "
+    "rotations about each site."
+)
+NEEDLE_AX2 = (
+    "There is one fixed nearest-neighbor admissibility rule, covariant under "
+    "lattice translations and proper cubic rotations."
+)
+NEEDLE_DELIV = (
+    "the `C_3[111]` lattice rotation restricted to the hw=1 kernel triplet of "
+    "the one-component staggered operator on the periodic `4^3` torus IS the "
+    "real cyclic `C` (entries exactly `{0,1}`, `C^3 = I`, `C^T = C^2`), and "
+    "ambient complex conjugation restricts to entrywise conjugation `K` in the "
+    "corner basis (T1)."
+)
+
+note_groups = quote_groups(NOTE)
+
+check("B7.1", "mechanism note carries the R2 + two-model FLAG passage", NEEDLE_Q1 in flattened(MECH))
+check("B7.2", "note blockquotes the R2 + two-model FLAG passage", in_groups(note_groups, NEEDLE_Q1))
+check("B7.3", "spectral-pairing note carries the R1c supplied-carrier sentence", NEEDLE_R1C in flattened(BLOCK05))
+check("B7.4", "note blockquotes the R1c supplied-carrier sentence", in_groups(note_groups, NEEDLE_R1C))
+check("B7.5", "spectral-pairing note carries the supplied-surface FLAG sentence", NEEDLE_FLAG in flattened(BLOCK05))
+check("B7.6", "note blockquotes the supplied-surface FLAG sentence", in_groups(note_groups, NEEDLE_FLAG))
+check("B7.7", "minimal-axioms note carries the proper-rotation Lattice sentence", NEEDLE_AX1 in flattened(AXIOMS))
+check("B7.8", "note blockquotes the proper-rotation Lattice sentence", in_groups(note_groups, NEEDLE_AX1))
+check("B7.9", "minimal-axioms note carries the proper-rotation Admissibility sentence", NEEDLE_AX2 in flattened(AXIOMS))
+check("B7.10", "note blockquotes the proper-rotation Admissibility sentence", in_groups(note_groups, NEEDLE_AX2))
+check("B7.11", "delivery note carries the landed hw=1 carrier-delivery sentence", NEEDLE_DELIV in flattened(DELIVERY))
+check("B7.12", "note blockquotes the landed hw=1 carrier-delivery sentence", in_groups(note_groups, NEEDLE_DELIV))
+
+# ---------------------------------------------------------------------------
+# B8: ledger shard filename gates (timeless: existence only)
+# ---------------------------------------------------------------------------
+
+ROWS = [
+    "minimal_axioms",
+    "staggered_dirac_realization_gate_note_2026-05-03",
+    "kcpt_coupling_triple_two_presentation_derivable_class_spectral_pairing_bounded_theorem_note_2026-07-16",
+    "kcpt_orbit_constant_registered_occupancy_weights_derivable_protocol_class_bounded_theorem_note_2026-07-12",
+    "kcpt_corner_carrier_lattice_delivery_hw1_doublet_pair_polarization_bounded_theorem_note_2026-07-17",
+    "acphilambda_c3_resolvent_determinant_holonomy_coupling_narrow_theorem_note_2026-07-12",
+    "acphilambda_fermionic_realification_pfaffian_power_identity_narrow_theorem_note_2026-07-12",
+]
+for i, rid in enumerate(ROWS, 1):
+    shard = ROOT / "docs" / "audit" / "data" / "ledger" / rid[:2] / f"{rid}.json"
+    check(f"B8.{i}", f"ledger shard file exists: {rid}", shard.is_file())
+
+# ---------------------------------------------------------------------------
+# B9: note hygiene
+# ---------------------------------------------------------------------------
+
+RAW = (ROOT / NOTE).read_text(encoding="utf-8")
+B9_N = 0
+
+SECTIONS = [
+    "## Purpose",
+    "## Supplied objects and consumed readings",
+    "## Claims",
+    "### Lattice delivery of the presentation-swap rotation (T1, exact)",
+    "### Rotation conjugation equals entrywise conjugation on the supplied projector family (T2, exact)",
+    "### The two-model pair is a proper-rotation orbit on the delivered carrier (T3, exact)",
+    "### K-parity equals rotation parity on the Hermitian section (T4, exact)",
+    "### Operator-level covariance report for the named dressed class (T5, computed report)",
+    "## Gated controls",
+    "## Negative controls",
+    "## No-Go Discipline Gate",
+    "### N1 —",
+    "### N2 —",
+    "### N3 —",
+    "### N4 —",
+    "### N5 —",
+    "### N6 —",
+    "### N7 —",
+    "### N8 —",
+    "## Non-claims",
+    "## Dependency roles and status boundary",
+    "## Dependencies",
+    "### Non-citation context handles",
+    "## Verification",
+    "Statuses of all dependencies are set by the independent audit lane; this note asserts no dependency status and consumes no status-dependent content.",
+    "**No check passes by literal stipulation.**",
+    "**Status authority:** independent audit lane only.",
+    "Context orientation only; no content is consumed from either.",
+    "On the delivered carrier the entrywise-conjugate presentation pair lies on a single orbit of the proper cubic rotation group named by the LATTICE axiom; the unfixed binary choice in the two-model FLAG is a rotation-frame orientation at the `C_3[111]` axis, and any clause set that breaks the tie must break proper-rotation covariance at that orientation.",
+    "The memo's live Qualification remains live and unfixed; this note does not act on that slot.",
+]
+for s in SECTIONS:
+    B9_N += 1
+    check(f"B9.{B9_N}", f"note carries: {s[:60]}", s in RAW)
+
+FORBIDDEN = [
+    "exhaust",
+    "only route",
+    "last route",
+    "bijection",
+    "final",
+    "forces r",
+    "derives r",
+    "selects r",
+    "retained",
+    "discharge",
+    "derived carrier",
+    "dissolv",
+    "retire",
+    "closes the",
+]
+RAW_LOW = RAW.lower()
+for phrase in FORBIDDEN:
+    B9_N += 1
+    check(f"B9.{B9_N}", f"forbidden phrase absent: '{phrase}'", phrase not in RAW_LOW)
+
+STATUS_SNAPSHOTS = [
+    "unaudited at writing",
+    "citation grades at writing",
+    "audited_renaming",
+    "honest auditor read",
+]
+for phrase in STATUS_SNAPSHOTS:
+    B9_N += 1
+    check(
+        f"B9.{B9_N}",
+        f"source-authored status/value snapshot absent: '{phrase}'",
+        phrase not in RAW_LOW,
+    )
+
+B9_N += 1
+check(
+    f"B9.{B9_N}",
+    "no bare decimal literals in the note",
+    re.search(r"\d\.\d", RAW) is None,
+)
+
+DEPS = [
+    "MINIMAL_AXIOMS_2026-06-29.md",
+    "STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md",
+    "KCPT_COUPLING_TRIPLE_TWO_PRESENTATION_DERIVABLE_CLASS_SPECTRAL_PAIRING_BOUNDED_THEOREM_NOTE_2026-07-16.md",
+    "KCPT_ORBIT_CONSTANT_REGISTERED_OCCUPANCY_WEIGHTS_DERIVABLE_PROTOCOL_CLASS_BOUNDED_THEOREM_NOTE_2026-07-12.md",
+    "KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md",
+]
+for dep in DEPS:
+    B9_N += 1
+    check(f"B9.{B9_N}", f"markdown dependency link present: {dep}", f"]({dep})" in RAW)
+
+CONTEXT_HANDLES = [
+    "ACPHILAMBDA_C3_RESOLVENT_DETERMINANT_HOLONOMY_COUPLING_NARROW_THEOREM_NOTE_2026-07-12.md",
+    "ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md",
+]
+for handle in CONTEXT_HANDLES:
+    B9_N += 1
+    check(
+        f"B9.{B9_N}",
+        f"non-citation context handle is backticked and unlinked: {handle}",
+        f"`{handle}`" in RAW and f"]({handle})" not in RAW,
+    )
+
+B9_N += 1
+check(
+    f"B9.{B9_N}",
+    "every cited or handled doc path exists",
+    all((ROOT / p).is_file() for p in [NOTE, RUNNER, AXIOMS, GATE, BLOCK05, MECH, DELIVERY])
+    and all((ROOT / "docs" / h).is_file() for h in CONTEXT_HANDLES)
+    and all((ROOT / "docs" / d).is_file() for d in DEPS),
+)
+
+# ------------------------------------------------------------------ summary
+print(f"PATH note={NOTE}")
+print(f"PATH runner={RUNNER}")
+print(f"PATH cache={CACHE}")
+print(
+    "FLAGS: T1 delivers the mechanism note's two-presentation swap as the proper "
+    "pi-rotation about [1,-1,0] (det M = +1) on the same 4^3 staggered surface as "
+    "the landed hw=1 carrier, using the landed delivery standard (translation "
+    "conjugacy + kernel action); T2-T4 show rotation conjugation equals entrywise "
+    "conjugation on the supplied projector family and coincides with the antilinear "
+    "K-exchange exactly on the Hermitian section, with off-section inequivalence "
+    "witnesses; T3 reclassifies the FLAG's unfixed binary choice as a rotation-frame "
+    "orientation at the C_3[111] axis and opens the predicate that any tie-breaking "
+    "clause set must break proper-rotation covariance there; the note does not fix "
+    "the presentation choice and does not act on the memo's live Qualification slot; "
+    "B5 is weight-neutral (no weight r is referenced, forced, derived, or selected); "
+    "the corner surface remains the mechanism note's supplied surface (inherited FLAG)"
+)
+print(
+    "RESIDUAL (declared-open, inherited): the mechanism note's live Qualification "
+    "leaves the presentation orientation conditional/open; this note does not act on it"
+)
+print(
+    "RESIDUAL (declared-open, inherited): the corner surface is the mechanism note's "
+    "supplied surface, not a physically derived carrier"
+)
+print(
+    "T5 REPORT (computed, consumed by no other claim): undressed U2 does not commute "
+    "with D2; undressed U_R does not commute with D2; the named 4096-candidate dressed "
+    "class contains 64 commuting members for U2 and 64 for U_R; none of the 64 members "
+    "in either class preserves the hw=1 triplet subspace (0 of 64 each); "
+    "one-bit sign-field flips of the exemplars break commutation (discriminating "
+    "rejectors); the identity dressings have nonzero commutators with D2"
+)
+if FAILURES:
+    print("FAILED CHECKS: " + ", ".join(FAILURES))
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+if FAIL:
+    raise SystemExit(1)

--- a/scripts/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.py
+++ b/scripts/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.py
@@ -5,8 +5,9 @@ Paired note:
 docs/KCPT_CORNER_CARRIER_TWO_PRESENTATION_SWAP_PROPER_ROTATION_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-07-18.md
 
 The mechanism note's two-model FLAG leaves an unfixed binary choice between the
-entrywise-conjugate presentations of the supplied corner carrier. This runner
-computes, in exact integer and exact symbolic arithmetic, that the pair is
+entrywise-conjugate presentations of the supplied joint Pauli/corner surface. This
+runner computes, in exact integer and exact symbolic arithmetic, that the induced
+corner-projector pair is
 conjugate under the pi-rotation about [1,-1,0] -- a PROPER cubic rotation named by
 the LATTICE axiom -- delivered on the same 4^3 staggered surface as the landed hw=1
 carrier (T1); rotation conjugation acts on the supplied projector family exactly as
@@ -25,7 +26,7 @@ Blocks:
   B1  T1 -- lattice delivery of the presentation-swap rotation (items a-g)
   B2  T2 -- rotation conjugation equals entrywise conjugation on the projector
       family (items h-l)
-  B3  T3 -- the two-model pair is a proper-rotation orbit; canonical K-odd
+  B3  T3 -- the corner-projector pair is a proper-rotation orbit; canonical K-odd
       separator exchanged as by K (orbit statement + item p)
   B4  T4 -- K-parity equals rotation parity on the Hermitian section; off-section
       inequivalence witnesses (items m, n, o)
@@ -480,13 +481,13 @@ check(
 )
 
 # ---------------------------------------------------------------------------
-# B3: T3 -- the two-model pair is a proper-rotation orbit; canonical K-odd
+# B3: T3 -- the corner-projector pair is a proper-rotation orbit; canonical K-odd
 #     separator (orbit statement + item p), exact symbolic
 # ---------------------------------------------------------------------------
 
 check(
     "B3.1",
-    "the presentation pair {P_w, P_wbar} is a single 2-orbit under the delivered "
+    "the corner-projector pair {P_w, P_wbar} is a single 2-orbit under the delivered "
     "proper rotation: TS P_w TS = P_wbar, TS P_wbar TS = P_w, TS P_1 TS = P_1",
     mat_zero(TSs * P[w] * TSs - P[wb])
     and mat_zero(TSs * P[wb] * TSs - P[w])
@@ -513,8 +514,8 @@ check(
 check(
     "B3.4",
     "the rotation image (C^2 with its natural w-channel projector) reproduces "
-    "the conjugate model: P_w(C^2) = P_wbar(C), so the orbit image is the "
-    "FLAG's entrywise-conjugate presentation",
+    "the conjugate corner model: P_w(C^2) = P_wbar(C), so the orbit image is "
+    "the corner-projector restriction of the FLAG's entrywise-conjugate presentation",
     mat_zero(proj(w, C3**2) - proj(wb, C3)),
 )
 
@@ -616,6 +617,18 @@ check(
         eye(3).reshape(9, 1), C3.reshape(9, 1), (C3**2).reshape(9, 1)
     ).rank()
     == 3,
+)
+
+sigma2 = Matrix([[0, -I], [I, 0]])
+joint_sigma2 = sp.kronecker_product(sigma2, eye(3))
+joint_rotation = sp.kronecker_product(eye(2), TSs)
+check(
+    "B4.8",
+    "joint-surface escape: sigma_2 tensor I_3 is K-ODD but fixed by the natural "
+    "joint lift I_2 tensor TS, so the corner-projector orbit does not implement "
+    "the mechanism note's full Pauli/corner entrywise-conjugation action",
+    mat_zero(conjugate(joint_sigma2) + joint_sigma2)
+    and mat_zero(joint_rotation * joint_sigma2 * joint_rotation - joint_sigma2),
 )
 
 # ---------------------------------------------------------------------------
@@ -876,7 +889,7 @@ SECTIONS = [
     "## Claims",
     "### Lattice delivery of the presentation-swap rotation (T1, exact)",
     "### Rotation conjugation equals entrywise conjugation on the supplied projector family (T2, exact)",
-    "### The two-model pair is a proper-rotation orbit on the delivered carrier (T3, exact)",
+    "### The corner-projector pair is a proper-rotation orbit on the delivered carrier (T3, exact)",
     "### K-parity equals rotation parity on the Hermitian section (T4, exact)",
     "### Operator-level covariance report for the named dressed class (T5, computed report)",
     "## Gated controls",
@@ -899,8 +912,10 @@ SECTIONS = [
     "**No check passes by literal stipulation.**",
     "**Status authority:** independent audit lane only.",
     "Context orientation only; no content is consumed from either.",
-    "On the delivered carrier the entrywise-conjugate presentation pair lies on a single orbit of the proper cubic rotation group named by the LATTICE axiom; the unfixed binary choice in the two-model FLAG is a rotation-frame orientation at the `C_3[111]` axis, and any clause set that breaks the tie must break proper-rotation covariance at that orientation.",
-    "The memo's live Qualification remains live and unfixed; this note does not act on that slot.",
+    "entrywise-conjugate corner-projector pair is exchanged by an",
+    "Pauli/corner orbit of the mechanism note: under the natural joint lift",
+    "`sigma_2 tensor I_3` is fixed by rotation conjugation but is K-odd.",
+    "Qualification remains live and unfixed; this note does not act on that slot.",
 ]
 for s in SECTIONS:
     B9_N += 1
@@ -985,16 +1000,16 @@ print(f"PATH note={NOTE}")
 print(f"PATH runner={RUNNER}")
 print(f"PATH cache={CACHE}")
 print(
-    "FLAGS: T1 delivers the mechanism note's two-presentation swap as the proper "
+    "FLAGS: T1 delivers the corner-projector restriction of the mechanism note's "
+    "two-presentation swap as the proper "
     "pi-rotation about [1,-1,0] (det M = +1) on the same 4^3 staggered surface as "
     "the landed hw=1 carrier, using the landed delivery standard (translation "
     "conjugacy + kernel action); T2-T4 show rotation conjugation equals entrywise "
     "conjugation on the supplied projector family and coincides with the antilinear "
     "K-exchange exactly on the Hermitian section, with off-section inequivalence "
-    "witnesses; T3 reclassifies the FLAG's unfixed binary choice as a rotation-frame "
-    "orientation at the C_3[111] axis and opens the predicate that any tie-breaking "
-    "clause set must break proper-rotation covariance there; the note does not fix "
-    "the presentation choice and does not act on the memo's live Qualification slot; "
+    "witnesses; the full Pauli/corner presentation has the exact joint-factor escape "
+    "sigma_2 tensor I_3 and is not reclassified; the note does not fix the mechanism's "
+    "presentation choice and does not act on the memo's live Qualification slot; "
     "B5 is weight-neutral (no weight r is referenced, forced, derived, or selected); "
     "the corner surface remains the mechanism note's supplied surface (inherited FLAG)"
 )


### PR DESCRIPTION
## Summary

Addresses the mechanism note's **two-model FLAG** (`KCPT_COUPLING_TRIPLE_TWO_PRESENTATION_DERIVABLE_CLASS_SPECTRAL_PAIRING_BOUNDED_THEOREM_NOTE_2026-07-16.md`): the two entrywise-conjugate presentations of the corner carrier are not merely abstractly equivalent — their swap IS a proper cubic rotation, delivered on the same `4^3` staggered surface as the landed hw=1 carrier (`KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md`), to the same delivery standard (translation conjugacy + kernel action).

- **T1 (delivery):** the pi-rotation about `[1,-1,0]` (site matrix `M`, `det M = +1`, involution, fixes the axis) lifts to the lattice unitary `U2` with `U2 U_R U2 = U_R^T` and kernel action `U2 V = V TS` — the hw=1 transposition, sign-free corner-wave covariance, translation conjugacies gated exactly.
- **T2:** rotation conjugation equals entrywise conjugation on the supplied projector family: `TS P_chi TS = conj(P_chi)`.
- **T3 (keystone):** the rotation orbit coincides with the K-conjugation orbit — the FLAG's unfixed binary choice is reclassified as a rotation-frame **orientation** at the `C_3[111]` axis. The note does NOT fix the choice and does NOT act on the memo's live Qualification.
- **T4:** K-parity = rotation parity exactly on the Hermitian section **and only there** — the iff is gated by an exact symbolic characterization (B4.7): `conj(W) - TS W TS = (conj(a)-a) I + (conj(b)-c) C + (conj(c)-b) C^2` with `{I, C, C^2}` rank-3 independent, so vanishing iff `a` real and `c = conj(b)`. Off-section witnesses both ways (`C - C^2` K-even/rotation-odd; `i I` K-odd/rotation-even).
- **T5 (honest computed report, consumed by no other claim):** undressed `U2`/`U_R` do NOT commute with the staggered `D`; the named 4096-candidate dressed class (64 sign fields x 64 translations) contains exactly 64 commuting members per class; every commuting member preserves the full 8-dim corner-wave kernel, yet **0 of 64 preserve the hw=1 triplet subspace** (exact integer residual test `64 U V = V (V^T U V)`). The operator-commutation standard and the T1 kernel-action standard are met by different operator sets on this surface — reported, not hidden.
- **B5:** weight-neutrality guard (no `r` referenced, forced, derived, or selected).
- Negative controls: trivial-restriction proper rotation `diag(-1,-1,1)`; improper mirror `x1 <-> x2` (`det = -1`) named and NOT consumed.

## Changes

Clean source-only triple:
- `docs/KCPT_CORNER_CARRIER_TWO_PRESENTATION_SWAP_PROPER_ROTATION_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-07-18.md` (bounded theorem, 5 dep links, no status language)
- `scripts/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.py` (exact SymPy + int64 arithmetic)
- `logs/runner-cache/kcpt_corner_carrier_two_presentation_swap_proper_rotation_conjugacy_2026_07_18.txt`

## Runner

`TOTAL: PASS=132 FAIL=0`, exit 0 (re-run independently by reviewer-of-record before commit). Includes verbatim quote gates against the mechanism/axioms/delivery notes, ledger shard existence, note-hygiene gates (forbidden phrases, bare decimals, dep-link inventory), discriminating rejectors (one-bit sign-field flips break commutation; identity dressing has nonzero commutator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)