### PR TITLE
Science: proper-cubic scalar-even antipodal transition lemma

### DIFF
--- a/docs/PROPER_CUBIC_SCALAR_EVEN_ANTIPODAL_TRANSITION_LEMMA_NOTE_2026-07-23.md
+++ b/docs/PROPER_CUBIC_SCALAR_EVEN_ANTIPODAL_TRANSITION_LEMMA_NOTE_2026-07-23.md
@@ -1,0 +1,97 @@
+# Proper-Cubic Scalar–Even Antipodal Transition Lemma
+
+Date: 2026-07-23
+
+Claim type: positive_theorem
+
+Runner: [`scripts/frontier_proper_cubic_scalar_even_antipodal_transition_lemma_2026_07_23.py`](../scripts/frontier_proper_cubic_scalar_even_antipodal_transition_lemma_2026_07_23.py)
+
+Runner cache: [`logs/runner-cache/frontier_proper_cubic_scalar_even_antipodal_transition_lemma_2026_07_23.txt`](../logs/runner-cache/frontier_proper_cubic_scalar_even_antipodal_transition_lemma_2026_07_23.txt)
+
+## Claim
+
+Let the six directed nearest-neighbor labels be paired by reversal, and let
+
+```text
+P_s = |s><s|,
+P_e = (I + R)/2 - P_s,
+P_v = (I - R)/2,
+```
+
+where `R` reverses each directed edge and
+`|s> = (1,1,1,1,1,1)/sqrt(6)`.  For any real `beta` for which
+`tan(beta/2)` is finite, define
+
+```text
+C(beta) = exp[-i tan(beta/2)]
+          (P_s - P_e + exp(i beta) P_v).
+```
+
+Choose any normalized `|e>` in the even subspace and set
+
+```text
+|+> = (|s> + |e>)/sqrt(2),
+|-> = (|s> - |e>)/sqrt(2).
+```
+
+Then
+
+```text
+C(beta)|+> = exp[-i tan(beta/2)] |->,
+C(beta)|-> = exp[-i tan(beta/2)] |+>.
+```
+
+The same identities hold after every proper-cubic reorientation of `|e>`.
+Consequently the scalar–even two-dimensional subspace has a projective
+period-two recurrence under this supplied coin family.
+
+## Proof
+
+The three displayed projectors are mutually orthogonal and sum to the
+identity.  The vectors `|s>` and `|e>` therefore have coin eigenvalues
+`exp[-i tan(beta/2)]` and `-exp[-i tan(beta/2)]`, respectively.  Substitution
+into the definitions of `|+>` and `|->` gives the two swap identities.
+
+A proper-cubic direction permutation fixes `|s>` and preserves all three
+projectors.  It sends `|e>` to another normalized vector in the even
+subspace, so the same two-line calculation applies in every frame.
+
+## Verification
+
+The runner:
+
+- constructs the reversal projectors independently and verifies their
+  Hermitian, idempotent, orthogonal resolution of the six-dimensional space;
+- verifies the scalar/even eigenvalue argument and the resulting swap, inverse,
+  and square identities over train and held `beta` values;
+- compares the independently constructed matrix against the existing
+  [`common_matter_field_coin_family_cycle219_2026_07_16.py`](../scripts/common_matter_field_coin_family_cycle219_2026_07_16.py)
+  implementation;
+- checks the transported identity for all 24 proper-cubic frames using
+  [`proper_cubic_bound_object_equivalence_cycle210_2026_07_16.py`](../scripts/proper_cubic_bound_object_equivalence_cycle210_2026_07_16.py);
+  and
+- includes a mutation control in which the even-sector phase is moved away
+  from `-1`, causing the exact swap gate to fail.
+
+The implementation comparison is a regression check, not a premise of the
+proof.
+
+## Import and support inventory
+
+- The projector decomposition and the displayed matrix family are explicit
+  hypotheses of this finite-dimensional theorem.
+- The phase coordinate `beta`, its selection, and any physical interpretation
+  are not derived here.
+- Proper-cubic reorientation uses finite direction-permutation matrices; it
+  adds no dynamical or observational input.
+- No measured, fitted, literature, normalization, or empirical value is used.
+
+## Scope
+
+This is a conditional algebraic lemma about one supplied six-dimensional coin
+family.  Projective recurrence is not a clock, a duration, a rate, an energy,
+a framework Record, an occurrence law, or proper time.  The lemma supplies no
+preparation, transport, readout, calibration, state-selection, or probability
+rule.  Those physical bridges remain separate questions.
+
+The independent audit lane assigns any audit or effective status.

--- a/docs/PROPER_CUBIC_SCALAR_EVEN_ANTIPODAL_TRANSITION_LEMMA_NOTE_2026-07-23.md
+++ b/docs/PROPER_CUBIC_SCALAR_EVEN_ANTIPODAL_TRANSITION_LEMMA_NOTE_2026-07-23.md
@@ -27,7 +27,8 @@ C(beta) = exp[-i tan(beta/2)]
           (P_s - P_e + exp(i beta) P_v).
 ```
 
-Choose any normalized `|e>` in the even subspace and set
+Choose any normalized `|e>` in `ran(P_e)`, the reversal-even subspace
+orthogonal to `|s>`, and set
 
 ```text
 |+> = (|s> + |e>)/sqrt(2),

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 14981,
- "node_count": 4466,
+ "node_count": 4467,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -10937,6 +10937,10 @@
   "propagator_family_unification_note": {
    "deps_hash": "475143577275",
    "out_degree": 5
+  },
+  "proper_cubic_scalar_even_antipodal_transition_lemma_note_2026-07-23": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "protocol_admissibility_3d_realization_bridge_and_word_dispersiveness_narrow_theorem_note_2026-07-10": {
    "deps_hash": "141f668125ad",

--- a/logs/runner-cache/frontier_proper_cubic_scalar_even_antipodal_transition_lemma_2026_07_23.txt
+++ b/logs/runner-cache/frontier_proper_cubic_scalar_even_antipodal_transition_lemma_2026_07_23.txt
@@ -1,0 +1,23 @@
+===== runner cache v1 =====
+runner: scripts/frontier_proper_cubic_scalar_even_antipodal_transition_lemma_2026_07_23.py
+runner_sha256: ed8211dba9c1a30edd4dfb40ae2a5e5564a89bf33d3c354ba978a2785d5d47fe
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.20
+status: ok
+----- stdout -----
+proper-cubic scalar-even antipodal transition lemma runner
+train_betas=(-0.4, -0.3, -0.2, 0.0, 0.7)
+held_betas=(-2.4, -0.35, 1.8)
+PASS: reversal projectors form an orthogonal Hermitian resolution :: {'hermitian': 0.0, 'idempotent': 3.3306690738754696e-16, 'orthogonal': 3.1990901413148286e-16, 'resolution': 0.0}
+PASS: chosen scalar and even vectors obey the exact subspace hypotheses :: {'scalar_norm': 2.220446049250313e-16, 'even_norm': 0.0, 'overlap': 0.0, 'P_scalar': 4.079219866531555e-16, 'P_even': 0.0, 'P_vector_scalar': 0.0, 'P_vector_even': 0.0}
+PASS: independent two-dimensional reduction is the swap matrix :: [[-2.23711432e-17+0.j  1.00000000e+00+0.j]
+ [ 1.00000000e+00+0.j -2.23711432e-17+0.j]]
+PASS: train and held values match the existing supplied coin implementation :: [{'beta': -0.4, 'implementation': 6.798699777552591e-17, 'plus_to_minus': 4.1508855398546356e-16, 'minus_to_plus': 4.0960050327170387e-16, 'inverse_plus': 4.1445008977564065e-16, 'inverse_minus': 4.089534711256607e-16, 'square_plus': 1.0165420363472293e-15, 'square_minus': 9.280235572879398e-16, 'compressed': 8.187347264889583e-16, 'unitarity': 1.3622897151075552e-15}, {'beta': -0.3, 'implementation': 8.326672684688674e-17, 'plus_to_minus': 4.80540321234368e-16, 'minus_to_plus': 4.812411825816293e-16, 'inverse_plus': 4.541663759503481e-16, 'inverse_minus': 4.549078725680712e-16, 'square_plus': 1.0756684430629142e-15, 'square_minus': 9.350594010892291e-16, 'compressed': 8.967997734718074e-16, 'unitarity': 1.2315713236940642e-15}, {'beta': -0.2, 'implementation': 3.3993498887762956e-17, 'plus_to_minus': 4.783498019090551e-16, 'minus_to_plus': 4.379962078080098e-16, 'inverse_plus': 5.000473944787578e-16, 'inverse_minus': 4.1963280002941205e-16, 'square_plus': 8.967379474283283e-16, 'square_minus': 9.601862895844017e-16, 'compressed': 8.595403176392969e-16, 'unitarity': 1.162560798285862e-15}, {'beta': 0.0, 'implementation': 0.0, 'plus_to_minus': 4.4255479601330834e-16, 'minus_to_plus': 4.4255479601330834e-16, 'inverse_plus': 4.4255479601330834e-16, 'inverse_minus': 4.4255479601330834e-16, 'square_plus': 1.0649557891154166e-15, 'square_minus': 1.0586982176966993e-15, 'compressed': 9.46920238423797e-16, 'unitarity': 1.419097581823643e-15}, {'beta': 0.7, 'implementation': 0.0, 'plus_to_minus': 4.697995015182298e-16, 'minus_to_plus': 4.573357540805812e-16, 'inverse_plus': 4.394024088746219e-16, 'inverse_minus': 4.2650214917087394e-16, 'square_plus': 7.421048898892461e-16, 'square_minus': 7.658602774417359e-16, 'compressed': 8.452262592281254e-16, 'unitarity': 1.0596608820731316e-15}, {'beta': -2.4, 'implementation': 0.0, 'plus_to_minus': 4.503336797797561e-16, 'minus_to_plus': 4.592268817375594e-16, 'inverse_plus': 4.503336797797561e-16, 'inverse_minus': 4.592268817375594e-16, 'square_plus': 7.75605710480108e-16, 'square_minus': 8.302423526647771e-16, 'compressed': 8.66149850728098e-16, 'unitarity': 1.0577214989346992e-15}, {'beta': -0.35, 'implementation': 0.0, 'plus_to_minus': 2.6050903327014443e-16, 'minus_to_plus': 2.9663264205780157e-16, 'inverse_plus': 2.8856956868395376e-16, 'inverse_minus': 3.2155615977506903e-16, 'square_plus': 7.701625229033229e-16, 'square_minus': 7.167998311774754e-16, 'compressed': 7.561368568953807e-16, 'unitarity': 1.09821239994011e-15}, {'beta': 1.8, 'implementation': 6.231111271582837e-16, 'plus_to_minus': 5.0601619154557e-16, 'minus_to_plus': 5.0601619154557e-16, 'inverse_plus': 5.039185084589145e-16, 'inverse_minus': 5.039185084589145e-16, 'square_plus': 1.0759090078040745e-15, 'square_minus': 9.581956755997205e-16, 'compressed': 9.934550117644326e-16, 'unitarity': 1.3050056393026082e-15}]
+PASS: swap, inverse, square, compression, and unitarity identities hold :: {'maximum_residual': 1.419097581823643e-15}
+PASS: all 24 proper-cubic frames preserve the transported transition identity :: {'checks': 576, 'maximum_residual': 5.743687592511735e-16}
+PASS: moving the even-sector phase away from minus one breaks the exact swap :: {'minimum_mutation_residual': 0.03535165632659573, 'maximum_mutation_residual': 0.0353516563265958}
+TOTAL: PASS=7 FAIL=0
+
+----- stderr -----
+

--- a/scripts/frontier_proper_cubic_scalar_even_antipodal_transition_lemma_2026_07_23.py
+++ b/scripts/frontier_proper_cubic_scalar_even_antipodal_transition_lemma_2026_07_23.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Verify the proper-cubic scalar-even antipodal transition lemma.
+
+Paired note:
+    docs/PROPER_CUBIC_SCALAR_EVEN_ANTIPODAL_TRANSITION_LEMMA_NOTE_2026-07-23.md
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+import sys
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import common_matter_field_coin_family_cycle219_2026_07_16 as cycle219
+import proper_cubic_bound_object_equivalence_cycle210_2026_07_16 as cycle210
+
+
+TOL = 2e-12
+TRAIN_BETAS = (-0.4, -0.3, -0.2, 0.0, 0.7)
+HELD_BETAS = (-2.4, -0.35, 1.8)
+PASS = 0
+FAIL = 0
+
+I6 = np.eye(6, dtype=complex)
+REVERSE = np.zeros((6, 6), dtype=complex)
+REVERSE[np.arange(6), (1, 0, 3, 2, 5, 4)] = 1
+SCALAR = np.ones(6, dtype=complex) / math.sqrt(6)
+EVEN = np.asarray((0.5, 0.5, -0.5, -0.5, 0.0, 0.0), dtype=complex)
+P_SCALAR = np.outer(SCALAR, SCALAR.conj())
+P_EVEN = (I6 + REVERSE) / 2 - P_SCALAR
+P_VECTOR = (I6 - REVERSE) / 2
+PLUS = (SCALAR + EVEN) / math.sqrt(2)
+MINUS = (SCALAR - EVEN) / math.sqrt(2)
+
+
+def check(label: str, condition: bool, detail: object = "") -> None:
+    global PASS, FAIL
+    if bool(condition):
+        PASS += 1
+        print(f"PASS: {label} :: {detail}")
+    else:
+        FAIL += 1
+        print(f"FAIL: {label} :: {detail}")
+
+
+def common_phase(beta: float) -> complex:
+    return complex(np.exp(-1j * np.tan(beta / 2)))
+
+
+def independent_coin(beta: float, *, even_phase: float = math.pi) -> np.ndarray:
+    phase = common_phase(beta)
+    return phase * (
+        P_SCALAR
+        + np.exp(1j * even_phase) * P_EVEN
+        + np.exp(1j * beta) * P_VECTOR
+    )
+
+
+def projector_controls() -> None:
+    projectors = (P_SCALAR, P_EVEN, P_VECTOR)
+    hermitian = max(float(np.linalg.norm(p - p.conj().T)) for p in projectors)
+    idempotent = max(float(np.linalg.norm(p @ p - p)) for p in projectors)
+    orthogonal = max(
+        float(np.linalg.norm(projectors[i] @ projectors[j]))
+        for i in range(3)
+        for j in range(3)
+        if i != j
+    )
+    resolution = float(np.linalg.norm(sum(projectors) - I6))
+    check(
+        "reversal projectors form an orthogonal Hermitian resolution",
+        max(hermitian, idempotent, orthogonal, resolution) < TOL,
+        {
+            "hermitian": hermitian,
+            "idempotent": idempotent,
+            "orthogonal": orthogonal,
+            "resolution": resolution,
+        },
+    )
+
+    vector_residuals = {
+        "scalar_norm": abs(float(np.vdot(SCALAR, SCALAR).real) - 1),
+        "even_norm": abs(float(np.vdot(EVEN, EVEN).real) - 1),
+        "overlap": abs(complex(np.vdot(SCALAR, EVEN))),
+        "P_scalar": float(np.linalg.norm(P_SCALAR @ SCALAR - SCALAR)),
+        "P_even": float(np.linalg.norm(P_EVEN @ EVEN - EVEN)),
+        "P_vector_scalar": float(np.linalg.norm(P_VECTOR @ SCALAR)),
+        "P_vector_even": float(np.linalg.norm(P_VECTOR @ EVEN)),
+    }
+    check(
+        "chosen scalar and even vectors obey the exact subspace hypotheses",
+        max(vector_residuals.values()) < TOL,
+        vector_residuals,
+    )
+
+    hadamard = np.asarray(((1, 1), (1, -1)), dtype=complex) / math.sqrt(2)
+    abstract_swap = hadamard.conj().T @ np.diag((1, -1)) @ hadamard
+    check(
+        "independent two-dimensional reduction is the swap matrix",
+        np.linalg.norm(abstract_swap - np.asarray(((0, 1), (1, 0)))) < TOL,
+        abstract_swap,
+    )
+
+
+def family_controls() -> None:
+    rows: list[dict[str, float]] = []
+    frame_residuals: list[float] = []
+    for beta in TRAIN_BETAS + HELD_BETAS:
+        phase = common_phase(beta)
+        coin = independent_coin(beta)
+        implemented = cycle219.common_species(beta).coin
+        basis = np.column_stack((PLUS, MINUS))
+        compressed = basis.conj().T @ coin @ basis
+        expected_compressed = phase * np.asarray(((0, 1), (1, 0)), dtype=complex)
+        row = {
+            "beta": beta,
+            "implementation": float(np.linalg.norm(coin - implemented)),
+            "plus_to_minus": float(np.linalg.norm(coin @ PLUS - phase * MINUS)),
+            "minus_to_plus": float(np.linalg.norm(coin @ MINUS - phase * PLUS)),
+            "inverse_plus": float(
+                np.linalg.norm(coin.conj().T @ PLUS - phase.conjugate() * MINUS)
+            ),
+            "inverse_minus": float(
+                np.linalg.norm(coin.conj().T @ MINUS - phase.conjugate() * PLUS)
+            ),
+            "square_plus": float(
+                np.linalg.norm(coin @ coin @ PLUS - phase**2 * PLUS)
+            ),
+            "square_minus": float(
+                np.linalg.norm(coin @ coin @ MINUS - phase**2 * MINUS)
+            ),
+            "compressed": float(np.linalg.norm(compressed - expected_compressed)),
+            "unitarity": float(np.linalg.norm(coin.conj().T @ coin - I6)),
+        }
+        rows.append(row)
+
+        for frame in cycle210.proper_cubic_frames():
+            representation = cycle210.direction_permutation(frame)
+            transported_even = representation @ EVEN
+            transported_plus = (SCALAR + transported_even) / math.sqrt(2)
+            transported_minus = (SCALAR - transported_even) / math.sqrt(2)
+            frame_residuals.extend(
+                (
+                    float(
+                        np.linalg.norm(
+                            representation @ coin @ representation.conj().T - coin
+                        )
+                    ),
+                    float(
+                        np.linalg.norm(
+                            coin @ transported_plus - phase * transported_minus
+                        )
+                    ),
+                    float(
+                        np.linalg.norm(
+                            coin @ transported_minus - phase * transported_plus
+                        )
+                    ),
+                )
+            )
+
+    check(
+        "train and held values match the existing supplied coin implementation",
+        max(row["implementation"] for row in rows) < TOL,
+        rows,
+    )
+    identity_residual = max(
+        max(value for key, value in row.items() if key != "beta") for row in rows
+    )
+    check(
+        "swap, inverse, square, compression, and unitarity identities hold",
+        identity_residual < TOL,
+        {"maximum_residual": identity_residual},
+    )
+    check(
+        "all 24 proper-cubic frames preserve the transported transition identity",
+        max(frame_residuals) < TOL and len(frame_residuals) == 24 * 3 * len(rows),
+        {"checks": len(frame_residuals), "maximum_residual": max(frame_residuals)},
+    )
+
+
+def mutation_control() -> None:
+    mutation_residuals = []
+    for beta in TRAIN_BETAS + HELD_BETAS:
+        mutated = independent_coin(beta, even_phase=math.pi + 0.05)
+        mutation_residuals.append(
+            float(np.linalg.norm(mutated @ PLUS - common_phase(beta) * MINUS))
+        )
+    check(
+        "moving the even-sector phase away from minus one breaks the exact swap",
+        min(mutation_residuals) > 0.03,
+        {
+            "minimum_mutation_residual": min(mutation_residuals),
+            "maximum_mutation_residual": max(mutation_residuals),
+        },
+    )
+
+
+def main() -> int:
+    print("proper-cubic scalar-even antipodal transition lemma runner")
+    print(f"train_betas={TRAIN_BETAS}")
+    print(f"held_betas={HELD_BETAS}")
+    try:
+        projector_controls()
+        family_controls()
+        mutation_control()
+    except Exception as exc:
+        global FAIL
+        FAIL += 1
+        print(f"FAIL: runner exception :: {exc!r}")
+    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# Proper-cubic scalar–even antipodal transition lemma

This PR replaces the rejected campaign-scale review surface with one canonical,
independently reproducible algebraic lemma. Landing is requested only through
the repository review loop; no audit verdict or effective status is supplied.

The prior campaign head `2b1febe83f7462143376bb78ab66838a2c2a6d47` is
preserved on `codex/pr5523-campaign-pre-salvage-20260723`.

## Claim

For the supplied six-direction proper-cubic coin family

```text
C(beta) = exp[-i tan(beta/2)]
          (P_scalar - P_even + exp(i beta) P_vector),
```

the equal scalar/even superpositions are exchanged up to the common phase.
The identity is preserved under all 24 proper-cubic direction
reorientations.

This is a conditional finite-dimensional algebra lemma. It is not a clock,
duration, rate, energy, framework Record, occurrence law, probability rule,
or proper-time result.

## Review repair

The 2026-07-23 review-loop disposition rejected the previous package because
its final-tree evidence, branch-object pins, status language, placement, and
campaign control state were not landable as one science block. This repaired
surface removes that package from the PR rather than refreshing stale hashes:

- one canonical root-level claim note with explicit `Claim type`;
- one decisive runner with nonzero failure exit, an independent two-dimensional
  reduction, full train/held and all-24-frame checks, and a mutation control;
- one SHA-pinned fresh runner cache; and
- the required citation-graph manifest acknowledgment.

There are no branch-ancestry gates, historical commit-object imports,
developer-local transcript paths, self-awarded PASS rows, exported negative
claims, campaign handoffs, receipts, or audit-status payloads in the final
diff.

## Verification

- runner: `7 PASS / 0 FAIL`, normal and optimized execution byte-identical;
- fresh runner cache confirmed;
- changed Python compiles;
- vocabulary lint: zero findings;
- audit validation: one new `positive_theorem` row, `unaudited`, strict lint
  with zero errors;
- repository invariant check: citation-graph delta acknowledged;
- `git diff --check`: clean;
- validation-only audit and effective-status outputs stripped before commit.

The independent audit lane remains the sole authority for audit and effective
status.
