### PR TITLE
skills: unspecified invocation = parallel backlog drain (review-loop + audit-loop)

### DIFF
--- a/.claude/commands/review-loop.md
+++ b/.claude/commands/review-loop.md
@@ -6,20 +6,25 @@ Run the repo-native physics review loop from:
 
 ## Invocation
 
-`/review-loop [focus] [--max-iterations N] [--no-fix] [--no-commit]`
+`/review-loop [target] [focus] [--max-iterations N] [--no-fix] [--no-commit]`
 
-An UNSPECIFIED invocation (`/review-loop` with no focus and no named
-PR/branch) starts the parallel open-PR backlog drain per the skill's
-Default Entry: enumerate open non-draft PRs, one reviewer slot per PR in
-parallel, each worker landing its own PR end to end. Reviewing a specific
-branch or single PR requires naming it as `[focus]`.
+Mode selection:
+- **Zero arguments** (`/review-loop`): the parallel open-PR backlog drain
+  per the skill's Default Entry — enumerate open non-draft PRs, one
+  reviewer slot per PR, each worker landing its own PR end to end.
+- **Named `[target]`** (a branch or PR): focused mode — review only that
+  target's changes against `origin/main` or `main`.
+- **Free-text `[focus]` without a target** (e.g. `/review-loop imports`):
+  the backlog drain with that review emphasis applied in every slot.
+- **Flags without a named target are invalid**: `--no-fix`/`--no-commit`
+  contradict the drain's land-end-to-end contract, so they require a named
+  `[target]`; a bare flag form must stop and ask for one.
 
 ## Required Behavior
 
 1. Read the skill file above before acting.
-2. With a `[focus]`: review only that branch/PR's changes against
-   `origin/main` or `main`. With no focus: run the Default Entry backlog
-   drain instead.
+2. Select the mode per the Invocation section above; focused mode only
+   when a `[target]` is named.
 3. Fan out the physics reviewers in parallel when the agent environment allows:
    `CodeRunnerReviewer`, `PhysicsClaimReviewer`, `ImportSupportReviewer`,
    `NatureRetentionReviewer`, `NoGoDisciplineReviewer` (when negative claims

--- a/.claude/commands/review-loop.md
+++ b/.claude/commands/review-loop.md
@@ -16,9 +16,10 @@ Mode selection:
   target's changes against `origin/main` or `main`.
 - **Free-text `[focus]` without a target** (e.g. `/review-loop imports`):
   the backlog drain with that review emphasis applied in every slot.
-- **Flags without a named target are invalid**: `--no-fix`/`--no-commit`
-  contradict the drain's land-end-to-end contract, so they require a named
-  `[target]`; a bare flag form must stop and ask for one.
+- **ANY flag without a named target is invalid** (including
+  `--max-iterations`): flags configure a focused single-target run, and
+  `--no-fix`/`--no-commit` contradict the drain's land-end-to-end
+  contract; a bare flag form must stop and ask for a `[target]`.
 
 ## Required Behavior
 

--- a/.claude/commands/review-loop.md
+++ b/.claude/commands/review-loop.md
@@ -8,10 +8,18 @@ Run the repo-native physics review loop from:
 
 `/review-loop [focus] [--max-iterations N] [--no-fix] [--no-commit]`
 
+An UNSPECIFIED invocation (`/review-loop` with no focus and no named
+PR/branch) starts the parallel open-PR backlog drain per the skill's
+Default Entry: enumerate open non-draft PRs, one reviewer slot per PR in
+parallel, each worker landing its own PR end to end. Reviewing a specific
+branch or single PR requires naming it as `[focus]`.
+
 ## Required Behavior
 
 1. Read the skill file above before acting.
-2. Review only branch/local changes against `origin/main` or `main`.
+2. With a `[focus]`: review only that branch/PR's changes against
+   `origin/main` or `main`. With no focus: run the Default Entry backlog
+   drain instead.
 3. Fan out the physics reviewers in parallel when the agent environment allows:
    `CodeRunnerReviewer`, `PhysicsClaimReviewer`, `ImportSupportReviewer`,
    `NatureRetentionReviewer`, `NoGoDisciplineReviewer` (when negative claims

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -199,9 +199,10 @@ certification.
 
 ## Default Entry: Do The Right Thing, In Parallel (owner-directed 2026-07-17)
 
-Invoking this skill WITHOUT a specific named claim means: drain the lane, in
-parallel, with the canonical machinery — no topology decisions required from
-the invoker. The default session is:
+Invoking this skill WITHOUT a specific named claim — including a bare,
+argument-less invocation — means: drain the backlog, in parallel, with the
+canonical machinery — no topology decisions required from the invoker. The
+default session is:
 
 1. Setup per "Setup For Each Session" below (fetch, clean worktree,
    pipeline, strict lint).

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -187,12 +187,15 @@ and must not apply audit verdicts.
 
 ## Default Entry: Parallel PR Review, Any Orchestrator (owner-directed 2026-07-17)
 
-An UNSPECIFIED invocation — no focus, no named branch or PR — IS the
-parallel backlog drain, as is invoking against a SET of open PRs ("review
-the open PRs", "drain the PR backlog"): enumerate the backlog, review in
-parallel, land serially — no topology decisions required from the invoker.
-Reviewing one branch or one PR is the special case that requires naming
-it.
+An UNSPECIFIED invocation — no named branch or PR — IS the parallel
+backlog drain, as is invoking against a SET of open PRs ("review the open
+PRs", "drain the PR backlog"): enumerate the backlog, review in parallel,
+land serially — no topology decisions required from the invoker. Free-text
+focus without a named target (e.g. "imports") is the drain with that
+emphasis applied in every slot. Reviewing one branch or one PR is the
+special case that requires naming the target, and the review-only flags
+(`--no-fix`, `--no-commit`) are valid only with a named target — they
+contradict the drain's land-end-to-end contract.
 
 1. **Enumerate targets**: open, non-draft PRs in scope (drafts stay out of
    scope per the draft rule below). Detect stacks and cumulative-tower

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -187,9 +187,12 @@ and must not apply audit verdicts.
 
 ## Default Entry: Parallel PR Review, Any Orchestrator (owner-directed 2026-07-17)
 
-Invoking this skill against a SET of open PRs ("review the open PRs",
-"drain the PR backlog") means: review them in parallel, land them serially —
-no topology decisions required from the invoker.
+An UNSPECIFIED invocation — no focus, no named branch or PR — IS the
+parallel backlog drain, as is invoking against a SET of open PRs ("review
+the open PRs", "drain the PR backlog"): enumerate the backlog, review in
+parallel, land serially — no topology decisions required from the invoker.
+Reviewing one branch or one PR is the special case that requires naming
+it.
 
 1. **Enumerate targets**: open, non-draft PRs in scope (drafts stay out of
    scope per the draft rule below). Detect stacks and cumulative-tower

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -193,9 +193,9 @@ PRs", "drain the PR backlog"): enumerate the backlog, review in parallel,
 land serially — no topology decisions required from the invoker. Free-text
 focus without a named target (e.g. "imports") is the drain with that
 emphasis applied in every slot. Reviewing one branch or one PR is the
-special case that requires naming the target, and the review-only flags
-(`--no-fix`, `--no-commit`) are valid only with a named target — they
-contradict the drain's land-end-to-end contract.
+special case that requires naming the target, and ANY flag without a named
+target is invalid — stop and ask for a target (see Arguments; the
+review-only flags contradict the drain's land-end-to-end contract).
 
 1. **Enumerate targets**: open, non-draft PRs in scope (drafts stay out of
    scope per the draft rule below). Detect stacks and cumulative-tower
@@ -317,12 +317,23 @@ close-with-reason path; the checklist adds no new disposition.
 
 ## Arguments
 
-Parse:
+Parse, in this order:
 
-- focus text: optional free-text review focus;
-- `--max-iterations N`: optional cap, default `5`;
-- `--no-fix`: review only, do not edit;
+- `[target]`: optional named branch or PR (a PR number/URL, or a token that
+  matches an existing branch). Resolve the target FIRST: a named target
+  selects focused single-target mode; anything that is not a resolvable
+  branch/PR is focus text, not a target.
+- focus text: optional free-text review emphasis. With a target it scopes
+  that review; without a target it scopes every slot of the backlog drain.
+- `--max-iterations N`: optional iteration cap, default `5`.
+- `--no-fix`: review only, do not edit.
 - `--no-commit`: fix locally but do not create iteration commits.
+
+ANY flag without a named target is an invalid invocation — flags configure
+a focused single-target run and contradict or under-specify the drain
+(`--no-fix`/`--no-commit` contradict its land-end-to-end contract) — stop
+and ask for a target instead of guessing. Only the zero-argument and
+focus-text-only forms select the backlog drain.
 
 ## Setup
 


### PR DESCRIPTION
Owner-directed semantics: a bare, argument-less invocation of either loop starts its parallel backlog drain (review-loop: open non-draft PRs, one worker per PR, workers land end to end; audit-loop: the canonical panel+drainer sequence). Naming a branch/PR/claim remains the focused special case. Three files: the review-loop command wrapper (whose review-only-branch-changes rule is now scoped to focused invocations) and both SKILL.md Default Entries.

Review gate: one sol xhigh round, then lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)