### PR TITLE
science: kernel-induced representation with central complex structure (bounded theorem)

### DIFF
--- a/docs/KCPT_KERNEL_INDUCED_REPRESENTATION_CENTRAL_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-18.md
+++ b/docs/KCPT_KERNEL_INDUCED_REPRESENTATION_CENTRAL_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-18.md
@@ -1,0 +1,255 @@
+# KCPT kernel induced representation: central complex structure
+
+Date: 2026-07-18
+
+Claim type: bounded theorem — a structure theorem on a fixed finite surface,
+established by exact integer and rational arithmetic (numpy int64 plus sympy; no
+floating point in any load-bearing gate). It states what the induced symmetry
+action on the corner-wave kernel *is*; it fixes no free parameter and forces
+nothing pre-record. The paired runner recomputes every gated quantity from the
+construction, so this note carries no number that the runner does not derive.
+
+## Setting
+
+The surface is the landed periodic staggered lattice on the `4^3` torus, with the
+Kawamoto-Smit staggered phases of the corner-carrier construction: `eta_1 = 1`,
+`eta_2(x) = (-1)^{x_1}`, `eta_3(x) = (-1)^{x_1 + x_2}` (the corner-carrier delivery
+note fixes these and records that "its exact rank is `56`", leaving an eight-
+dimensional kernel; see the
+[corner-carrier note](docs/KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md)).
+The integer antisymmetric operator is written `D2` here, `D2[i, j]` accumulating
+`eta_mu(x)` for the forward neighbour and `-eta_mu(x)` for the backward neighbour
+along each of the three axes, with site order `idx(x1, x2, x3) = (x1*L + x2)*L + x3`,
+`L = 4`, `N = 64`.
+
+The kernel is spanned by the eight corner waves `chi_S(x) = (-1)^{sum_{k in S} x_k}`
+indexed by subsets `S` of `{0, 1, 2}` in the fixed order
+`[(), (0,), (1,), (2,), (0,1), (0,2), (1,2), (0,1,2)]`, "graded by Hamming weight as
+`1 + 3 + 3 + 1`". Stacked as the columns of `V8` these satisfy `D2 @ V8 = 0` and
+`V8^T @ V8 = 64 I`, so `V8` is a scaled isometry onto the kernel.
+
+Each base surface symmetry is dressed. The three bases are the stabiliser
+(identity), the order-two proper rotation `U2: x -> (-x2, -x1, -x3) mod 4`, and the
+proper cubic rotation `UR: x -> (x2, x3, x1)`; these are exactly the
+"standard translations, and proper cubic rotations" admitted by the
+[minimal-axioms note](docs/MINIMAL_AXIOMS_2026-06-29.md). A dressed candidate is
+`U = diag(d) @ base @ trans(t)`, where `trans(t): x -> x - t mod 4` ranges over all
+`64` translations and the quadratic sign field is
+
+`d(x) = (-1)^{a1 x1 + a2 x2 + a3 x3 + b12 x1 x2 + b13 x1 x3 + b23 x2 x3}`
+
+ranging over all `64` sign patterns. Each base therefore carries a dressed class of
+`64 x 64 = 4096` members. The action of a dressed candidate on the kernel is the
+induced operator `K8 = V8^T @ U @ V8`, an integer `8 x 8` matrix. The staggered
+realisation gate handle `STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03` is the
+context for reading `D2` as the staggered Dirac operator on this surface.
+
+## T1 — whole-class kernel preservation and the parity-qubit dictionary
+
+Every one of the `3 x 4096` dressed candidates preserves the corner-wave kernel
+exactly: `64 (U @ V8) = V8 @ K8` as an integer identity, so `U` maps the kernel into
+itself with no residual (gate B1-4). On each base exactly `64` of the `4096`
+candidates commute with `D2` (gate B1-5), and for every commuting member the induced
+`K8` is a scaled orthogonal matrix, `K8^T @ K8 = 4096 I` (gate B1-6).
+
+The induced action reads as a dictionary on the three parity qubits carried by the
+subset index (qubit `k` is the `x_k`-parity bit):
+
+- a translation induces a parity diagonal, `induced(trans(t)) = 64 Z(t)` with
+  `Z(t)_S = (-1)^{sum_{k in S} t_k}` (gate B1-7a);
+- the undressed order-two rotation `U2` induces `64` times the subset permutation that swaps
+  axes `0` and `1` (gate B1-7b), and the undressed rotation `UR` induces `64` times
+  the cyclic subset permutation `0 -> 1 -> 2 -> 0` (gate B1-7c);
+- a linear sign field induces a symmetric-difference convolution: for
+  `d = chi_{(1,2)}`, `induced(diag(d)) = 64 X_{(1,2)}`, the operator
+  `S -> S xor {1, 2}` (gate B1-8).
+
+The general commuting member factors as `K8 = Ms(shat) @ P_base @ Z(t)`, where
+`P_base` is the subset permutation of its base, `Z(t)` its translation diagonal, and
+`Ms(shat)_{S xor R, S} = shat_R` is the convolution by `shat = V8^T @ d`. The worked
+exemplar (base `U2`, bits `(0,1,0,1,0,0)`, `t = (1,0,0)`) commutes with `D2`, and its
+`shat` has support `{(): 32, (0,): -32, (1,): 32, (0,1): 32}` (gate B1-9). Because the
+convolution kernel `shat` carries half-unit weights, most induced members are `64`
+times an orthogonal matrix with `+/- 1/2` entries rather than a signed permutation;
+the runner keeps such members as raw integer matrices wherever a test is scale-
+invariant so that no division corrupts them.
+
+## T2 — forced quadratic class signatures
+
+The `64` commuting members of each base split as `4` sign fields times `16`
+translations (gate B2-4). The quadratic part `(b12, b13, b23)` is pinned by the base:
+
+- stabiliser: purely linear, `(b12, b13, b23) = (0, 0, 0)`, with linear compensator
+  law `(a1, a2, a3) = (0, t1, t1 + t2)` (gates B2-1, B2-3);
+- order-two rotation `U2`: forced `(b12, b13, b23) = (1, 0, 0)` uniformly, law
+  `(a1, a2, a3) = (1 + t1, 1, 1 + t1 + t2)` (gates B2-2, B2-3);
+- rotation `UR`: forced `(b12, b13, b23) = (1, 1, 0)` uniformly, law
+  `(a1, a2, a3) = (t1 + t2, 0, t1)` (gates B2-2, B2-3).
+
+The compensator laws are congruences mod `2` in the translation components, and
+`t3` never enters them, so its parity stays free in every class.
+
+Hamming-grading preservation and triplet preservation occur only in the linear
+stabiliser class, with counts `16 / 0 / 0` across stabiliser / U2 / UR (gate B2-5),
+and the `16` stabiliser grading-preservers are exactly the `a = (0, 0, 0)` members,
+each a pure parity diagonal. The stabiliser Hamming-block support census is
+`32 / 16 / 16` over the three named supports (gate B2-7). The dichotomy is sharp
+at class level: the non-trivial base symmetries can be realised on the kernel at
+all only at their forced quadratic price, no quadratically-dressed member
+preserves the Hamming grading or the triplet, and within the purely-linear
+stabiliser class preservation is confined to the trivially-dressed members.
+
+## T3 — the induced group
+
+The distinct induced images generate a group `G` of order `|G| = 96` (gate B3-1).
+Per-class images close to proper subgroups of orders `16 / 32 / 48`, and among the
+three base pairs only `U2` together with `UR` generates all of `G`
+(closures `32 / 48 / 96`; gate B3-2). The scalar `-64 I` lies in `G`; the centre has
+order `4`, namely `{+/- I, +/- J}`, and exactly two central elements square to `-I`
+(gate B3-3). The exponent is `24`; there are `16` conjugacy classes with sizes
+`[1,1,1,1,6,6,6,6,6,6,8,8,8,8,12,12]`; the commutator subgroup has order `24` and the
+abelianisation has order `4` (gate B3-4). The grading-preserving subgroup of `G` has
+order `4`, equal to the triplet-preserving subgroup, with triplet restrictions
+`{I, diag(1,1,-1), diag(-1,-1,1), -I}` in which the `x1` and `x2` slots are sign-
+locked to a common value (gate B3-5). The sum of all `96` induced matrices is the
+zero matrix, so `G` fixes no vector in the kernel (gate B3-6).
+
+## T4 — central complex structure and rational irreducibility (headline)
+
+The exact commutant of `G` over the rationals is two-dimensional, `span{I, J}`, and
+`Q(J)` is isomorphic to `Q(i)` (gate B4-3). The element `J` is a canonical central
+complex structure: the runner *finds* it as the unique central element that squares
+to `-I` and carries the weight-one corner wave `chi_{x2}` to the vacuum corner
+wave with a `+` sign (canonical orientation),
+and only then gates the found matrix against its closed form — `J` is never hard-
+coded. It satisfies `J^2 = -I`, `J^T = -J`, `trace J = 0`, and is integer-exact at
+scale `64` (gates B4-4, B4-5). Its closed form is the real Pauli word
+`Z (x) iY (x) Z` on the three parity qubits, with the complex axis on the middle
+`x2` parity qubit — the middle link of the staggering chain (`eta_2`, `eta_3`
+above): `J[index(S xor {1}), index(S)] = 64 (-1)^{|S and {0,2}|} (+1 if 1 in S else -1)`,
+with Hamming-block support `{(0,1),(1,0),(1,2),(2,1),(2,3),(3,2)}` and vacuum column
+`-64 e_{(1,)}`.
+
+Because `Q(J)` is a field, `G` admits no proper rational invariant subspace: the
+characteristic polynomial of `J` is `(lambda^2 + 1)^4`, and
+`det(a I + b J) = (a^2 + b^2)^4` factors over the rationals with no linear factor
+(gates B4-6, B4-7). Over the complex numbers the representation splits as exactly one
+conjugate pair `W + Wbar` with `dim W = 4`: the `+i` and `-i` eigenspaces of `J` each
+have dimension `4`, and the character satisfies `<chi, chi> = 2` with Frobenius-Schur
+sum `0`, the complex type (gates B4-1, B4-2, B4-6). The orbit of a single
+Hamming-weight-one corner wave under `G` spans the whole eight-dimensional kernel
+(rank `8`; gate B4-8): each weight-one corner wave is a cyclic vector, so any
+`G`-stable subspace containing one is the whole kernel. The four graded members
+of `G` are simultaneously diagonal — on the graded subgroup alone the kernel
+splits completely into coordinate lines — so the rational irreducibility of the
+full `G` is carried entirely by the members off the graded subgroup (gate B4-9).
+
+## T5 — FLAG registration
+
+The two-presentation binary of the coupling-triple mechanism registers on this
+surface as an orientation choice. The
+[two-presentation mechanism note](docs/KCPT_COUPLING_TRIPLE_TWO_PRESENTATION_DERIVABLE_CLASS_SPECTRAL_PAIRING_BOUNDED_THEOREM_NOTE_2026-07-16.md)
+records:
+
+> **FLAG — two-model mechanism:** the entrywise-conjugate presentations in L-K2 satisfy the same named clauses and exchange every K-odd seed.
+
+> The memo's live Qualification leaves the unfixed choice conditional/open.
+
+At the kernel level: entrywise complex conjugation fixes the entire real induced
+group `G` (every member is a real integer matrix) and carries `ker(J - iI)` onto
+`ker(J + iI)`, exchanging `W` and `Wbar` (gate B5-1). The two entrywise-conjugate
+presentations therefore materialise here as the two central complex structures `+J`
+and `-J` — a choice of which central complex structure is called `i`. The vacuum
+orbit under `G` has size `48` and mixes every Hamming level (its support set spans
+weights `0` through `3`; gate B5-2), so no graded, vacuum-anchored splitting exists to
+prefer one orientation over the other. The graded restrictions commute with a free
+diagonal `diag(w1, w2, w3)`, so the theorem attaches no per-slot weight relation
+(gate B5-3).
+
+## Boundary — what this does NOT establish
+
+- It does NOT select the orientation: `+J` versus `-J` remains the two-presentation
+  choice, exactly as flagged; the theorem exhibits the binary, it does not break it.
+- It does NOT act on the mechanism note's live Qualification: the unfixed choice
+  stays conditional and open at the memo level; this surface adds structure around
+  it, not a decision of it.
+- It derives no `r` value and imposes no weighting: the graded restrictions commute
+  with an unconstrained diagonal (gate B5-3), so no per-slot ratio is forced.
+- It is a finite-surface structure theorem: no continuum limit and no interacting
+  claim are asserted, only exact facts about the `8`-dimensional kernel of a fixed
+  `4^3` operator.
+- Register-not-read: the corner-wave kernel is the record-carrier surface and the
+  induced group is a reconstruction-level symmetry action. The theorem registers
+  structural facts about that carrier and forces nothing pre-record.
+
+## Negative controls
+
+- The undressed rotations `U2` and `UR` do not commute with `D2`, so dressing is
+  required, not cosmetic (gate B6-1).
+- A one-bit change to the T1 exemplar (flipping `b13`, bits `(0,1,0,1,1,0)`, same
+  `t`) breaks commutation with `D2` (gate B6-2).
+- The two wrong-axis Pauli words — the same formula with the complex axis moved to
+  the `x1` parity qubit, and to the `x3` parity qubit — each fail to commute with at
+  least one member of `G`, so the `x2` axis is forced (gate B6-3).
+- A stabiliser candidate with all-zero bits and `t = (1,0,0)` violates the stabiliser
+  compensator law and indeed does not commute with `D2` (gate B6-4).
+
+## Gate map
+
+The runner emits `[Bx.y]`-tagged `PASS/FAIL` lines covering every row below (rows
+spanning several bases or items expand to one line each) and a final
+`TOTAL: PASS=N FAIL=M` line; it exits `0` if and only if `M = 0`.
+
+| Gate | Claim |
+| --- | --- |
+| B1-1 | `D2` integer antisymmetric, entries in `{-1, 0, 1}` |
+| B1-2 | `rank(D2) = 56`, kernel dimension `8` |
+| B1-3 | `D2 @ V8 = 0`, `V8^T @ V8 = 64 I`, grading `1 + 3 + 3 + 1` |
+| B1-4 | all `3 x 4096` dressed candidates preserve the kernel (residual identity) |
+| B1-5 | exactly `64` commuting members per base |
+| B1-6 | each commuting `K8` has `K8^T @ K8 = 4096 I` |
+| B1-7 | dictionary: translation to `Z`-diagonal, base to subset permutation |
+| B1-8 | linear sign field to symmetric-difference permutation `X_{(1,2)}` |
+| B1-9 | exemplar commutes, `K8 = Ms(shat) @ P_swap01 @ Z(t)`, named `shat` support |
+| B1-10 | exemplar `(bits, t)` present in the `U2` commuting set |
+| B2-1 | stabiliser purely linear; `U2`, `UR` have no purely-linear member |
+| B2-2 | forced quadratic signature `(1,0,0)` for `U2`, `(1,1,0)` for `UR` |
+| B2-3 | per-base compensator laws `(a1, a2, a3)` |
+| B2-4 | commuting set is `4` sign fields times `16` translations |
+| B2-5 | grading- and triplet-preserving counts `16 / 0 / 0`; graded stabiliser members are diagonal |
+| B2-6 | distinct induced `K8` per base `= 8`; distinct vacuum images `= 4` |
+| B2-7 | stabiliser Hamming-block-support census `32 / 16 / 16` |
+| B3-1 | `\|G\| = 96` from the `24` distinct generators |
+| B3-2 | single-base closures `16 / 32 / 48`; only `U2 + UR` gives all of `G` |
+| B3-3 | `-64 I` in `G`; centre order `4`; two central squares of `-I` |
+| B3-4 | exponent `24`; `16` conjugacy classes; commutator `24`; abelianisation `4` |
+| B3-5 | graded subgroup order `4`; triplet restrictions; `x1`, `x2` sign-locked |
+| B3-6 | sum over `G` is the zero matrix |
+| B4-1 | sum of `tr(K8)^2` gives `<chi, chi> = 2` |
+| B4-2 | Frobenius-Schur sum `0` |
+| B4-3 | exact commutant over the rationals has dimension `2` |
+| B4-4 | unique canonical `J` found; the other central square of `-I` is `-J` |
+| B4-5 | `J` closed form, `J^2 = -I`, `J^T = -J`, `trace 0`, central, named support, vacuum column |
+| B4-6 | charpoly `(lambda^2 + 1)^4`; both `J`-eigenspaces dimension `4` |
+| B4-7 | `det(aI + bJ) = (a^2 + b^2)^4`, so the commutant is a field |
+| B4-8 | orbit of one Hamming-weight-one carrier spans the kernel (rank `8`) |
+| B4-9 | the four graded members of `G` are diagonal |
+| B5-1 | conjugation fixes `G` and swaps `W` and `Wbar` |
+| B5-2 | vacuum orbit size `48`, mixed-grade support set |
+| B5-3 | graded restrictions commute with `diag(w1, w2, w3)` (weight-neutral) |
+| B6-1 | undressed `U2`, `UR` do not commute with `D2` |
+| B6-2 | one-bit rejector breaks commutation |
+| B6-3 | wrong-axis words on `x1`, `x3` fail; `x2` axis forced |
+| B6-4 | law-violating stabiliser candidate does not commute |
+| B7-1..B7-6 | verbatim source fragments present in source and in this note |
+| B8-1..B8-3 | consumed-dependency ledger shards exist and parse |
+| B9-1..B9-5 | note hygiene: forbidden strings absent, no bare decimals, link inventory, required and verbatim strings present |
+
+## Paired runner and cache
+
+- [paired runner](scripts/kcpt_kernel_induced_representation_central_complex_structure_2026_07_18.py)
+- [runner cache](logs/runner-cache/kcpt_kernel_induced_representation_central_complex_structure_2026_07_18.txt)
+
+The cache path is
+`logs/runner-cache/kcpt_kernel_induced_representation_central_complex_structure_2026_07_18.txt`;
+it records the runner's per-gate lines and final `TOTAL` count.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 14738,
- "node_count": 4395,
+ "node_count": 4396,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -6873,6 +6873,10 @@
   "kcpt_coupling_triple_two_presentation_derivable_class_spectral_pairing_bounded_theorem_note_2026-07-16": {
    "deps_hash": "2e8f0e7f8554",
    "out_degree": 5
+  },
+  "kcpt_kernel_induced_representation_central_complex_structure_bounded_theorem_note_2026-07-18": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "kcpt_orbit_clause_kinvariant_surface_equivalence_narrow_theorem_note_2026-06-10": {
    "deps_hash": "ddf6440cc1c2",

--- a/logs/runner-cache/kcpt_kernel_induced_representation_central_complex_structure_2026_07_18.txt
+++ b/logs/runner-cache/kcpt_kernel_induced_representation_central_complex_structure_2026_07_18.txt
@@ -1,0 +1,114 @@
+===== runner cache v1 =====
+runner: scripts/kcpt_kernel_induced_representation_central_complex_structure_2026_07_18.py
+runner_sha256: 90510792c0019c850a2461d1a90130c233ab8f950374ecfc0ce83cc01fae2935
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 16.81
+status: ok
+----- stdout -----
+== B1 surface and whole-class kernel preservation ==
+[B1.1] PASS D2 integer antisymmetric, entries in {-1,0,1}
+[B1.2] PASS rank(D2)==56 so dim ker==8 (got 56)
+[B1.3] PASS D2@V8==0, V8.T@V8==64I, HW grading 1+3+3+1
+[B1.4-stab] PASS stab: 4096 candidates, all preserve corner kernel (residual identity)
+[B1.4-U2] PASS U2: 4096 candidates, all preserve corner kernel (residual identity)
+[B1.4-UR] PASS UR: 4096 candidates, all preserve corner kernel (residual identity)
+[B1.5-stab] PASS stab: exactly 64 members commute with D2
+[B1.5-U2] PASS U2: exactly 64 members commute with D2
+[B1.5-UR] PASS UR: exactly 64 members commute with D2
+[B1.6-stab] PASS stab: every commuting K8 has K8.T@K8==4096 I
+[B1.6-U2] PASS U2: every commuting K8 has K8.T@K8==4096 I
+[B1.6-UR] PASS UR: every commuting K8 has K8.T@K8==4096 I
+[B1.7a] PASS induced(trans(1,2,3))==64*Z(t) parity diagonal
+[B1.7b] PASS induced(undressed U2)==64*P_swap01 (swap subset axes 0,1)
+[B1.7c] PASS induced(undressed UR)==64*P_sigma (0->1->2->0 on subsets)
+[B1.8] PASS induced(diag chi_{(1,2)})==64*X_{(1,2)} symmetric-difference perm
+[B1.9a] PASS exemplar bits=(0,1,0,1,0,0),t=(1,0,0) commutes with D2
+[B1.9b] PASS exemplar K8 == Ms(shat) @ P_swap01 @ Z(t)
+[B1.9c] PASS exemplar shat support == {():32,(0,):-32,(1,):32,(0,1):32}
+[B1.10] PASS exemplar (bits,t) present in the U2 commuting solution set
+== B2 per-class census and the linear/quadratic dichotomy ==
+[B2.1-stab] PASS stab: all commuting members purely linear (b==0,0,0)
+[B2.1-U2] PASS U2: no purely-linear commuting member
+[B2.1-UR] PASS UR: no purely-linear commuting member
+[B2.2-U2] PASS U2: forced quadratic signature (b12,b13,b23)==(1,0,0)
+[B2.2-UR] PASS UR: forced quadratic signature (b12,b13,b23)==(1,1,0)
+[B2.3-stab] PASS stab compensator law (a1,a2,a3)==(0,t1,t1+t2)
+[B2.3-U2] PASS U2 compensator law (a1,a2,a3)==(1+t1,1,1+t1+t2)
+[B2.3-UR] PASS UR compensator law (a1,a2,a3)==(t1+t2,0,t1)
+[B2.4-stab] PASS stab: commuting set == 4 sign-fields x 16 translations
+[B2.4-U2] PASS U2: commuting set == 4 sign-fields x 16 translations
+[B2.4-UR] PASS UR: commuting set == 4 sign-fields x 16 translations
+[B2.5a] PASS grading-preserving counts per class == 16/0/0
+[B2.5b] PASS triplet-preserving counts per class == 16/0/0
+[B2.5c] PASS the 16 stab grading-preservers are exactly a==(0,0,0), each a pure Z-diagonal
+[B2.6a] PASS distinct induced K8 per class == 8
+[B2.6b] PASS distinct vacuum images (K8 column 0) per class == 4
+[B2.7] PASS stab hw-block-support census == 32/16/16 with the named supports
+== B3 the induced group G ==
+[B3.1] PASS G = closure of 24 distinct induced K8; |G|==96 (got 96)
+[B3.2a] PASS single-class closures <stab>/<U2>/<UR> == 16/32/48
+[B3.2b] PASS pair closures 32/48/96; only U2+UR generate all of G
+[B3.3a] PASS -64 I is in G
+[B3.3b] PASS center Z(G) has order 4 (got 4)
+[B3.3c] PASS exactly 2 central elements square to -I
+[B3.4a] PASS exponent(G)==24 (got 24)
+[B3.4b] PASS 16 conjugacy classes, sizes [1,1,1,1,6x6,8x4,12x2]
+[B3.4c] PASS commutator subgroup order 24; abelianization order 4
+[B3.5a] PASS grading-preserving members of G == 4 == triplet-preserving
+[B3.5b] PASS triplet restrictions == {I, diag(1,1,-1), diag(-1,-1,1), -I}
+[B3.5c] PASS every graded restriction has R[0,0]==R[1,1] (x1,x2 sign-locked)
+[B3.6] PASS sum over G of K8 == 0 (no fixed vector)
+== B4 complex-type irreducibility and the commutant ==
+[B4.1] PASS sum tr(K8)^2 == 786432 == 2*96*4096 so <chi,chi>==2 (got 786432)
+[B4.2] PASS Frobenius-Schur sum over G of tr(mul(K,K))==0 (got 0)
+[B4.3a] PASS a 2-element generating subset closes to all 96
+[B4.3b] PASS exact commutant over Q (raw kron equations) has dimension 2 (got 2)
+[B4.4a] PASS unique central square-(-I) element with J chi_{x2}=+chi_{}
+[B4.4b] PASS the other central square-(-I) element == -J
+[B4.5a] PASS J/64 has 8 nonzeros; J[index(S^{1}),index(S)]==64*(-1)^{|S&{0,2}|}*(+1 iff 1 in S)
+[B4.5b] PASS trace(J)==0, J.T==-J, mul(J,J)==-64 I
+[B4.5c] PASS J commutes with every generator (central)
+[B4.5d] PASS hw-block support of J == {(0,1),(1,0),(1,2),(2,1),(2,3),(3,2)}
+[B4.5e] PASS J column 0 == -64 * e_{(1,)} (vacuum -> minus chi_{x2})
+[B4.6a] PASS charpoly(J/64) == (lambda^2 + 1)^4
+[B4.6b] PASS rank(J/64 - iI)==4 and rank(J/64 + iI)==4 (W and Wbar both 4-dim)
+[B4.7] PASS factor(det(aI + bJ/64)) == (a^2 + b^2)^4 so Q[J] is a field (no proper invariant subspace)
+[B4.8a] PASS rank of 96x8 orbit {K@e_1} == 8 (single hw=1 carrier spans kernel) (got 8)
+[B4.8b] PASS iterative rref from span{e1,e2,e3} stabilizes at dimension 8
+[B4.9] PASS the 4 graded members of G are DIAGONAL (reducible-contrast discriminator)
+== B5 FLAG registration and neutrality ==
+[B5.1a] PASS entrywise conjugation fixes every element of G (all real integer matrices)
+[B5.1b] PASS conjugation carries ker(J/64 - iI) into ker(J/64 + iI): swaps W <-> Wbar
+[B5.2a] PASS vacuum orbit under G has size 48 (got 48)
+[B5.2b] PASS vacuum-orbit hw-support set matches the mixed-grade spec set
+[B5.3] PASS each triplet restriction commutes with diag(w1,w2,w3): no per-slot weight relation (r-neutral)
+== B6 negative controls / rejectors ==
+[B6.1a] PASS undressed U2 does not commute with D2
+[B6.1b] PASS undressed UR does not commute with D2
+[B6.2] PASS one-bit rejector: exemplar with b13 flipped does not commute with D2
+[B6.3a] PASS wrong-axis word J' (complex axis x1) fails to commute with some g in G
+[B6.3b] PASS wrong-axis word J'' (complex axis x3) fails to commute with some g in G
+[B6.4] PASS law rejector: stab bits all-zero, t=(1,0,0) violates the stab law and does not commute
+== B7 verbatim quote gates ==
+[B7.1] PASS verbatim fragment present in source AND in the new note
+[B7.2] PASS verbatim fragment present in source AND in the new note
+[B7.3] PASS verbatim fragment present in source AND in the new note
+[B7.4] PASS verbatim fragment present in source AND in the new note
+[B7.5] PASS verbatim fragment present in source AND in the new note
+[B7.6] PASS verbatim fragment present in source AND in the new note
+== B8 sharded-ledger existence ==
+[B8.1] PASS ledger shard exists and json-parses: kcpt_corner_carrier_lattice_delivery_hw1_doublet_pair_polarization_bounded_theorem_note_2026-07-17.json
+[B8.2] PASS ledger shard exists and json-parses: kcpt_coupling_triple_two_presentation_derivable_class_spectral_pairing_bounded_theorem_note_2026-07-16.json
+[B8.3] PASS ledger shard exists and json-parses: minimal_axioms.json
+== B9 note hygiene ==
+[B9.1] PASS forbidden route/status strings absent (found: [])
+[B9.2] PASS no bare-decimal literal [0-9].[0-9] in note (match: None)
+[B9.3a] PASS exactly 3 markdown links into docs/ (got 3)
+[B9.3b] PASS STAGGERED_DIRAC handle appears backticked and NOT as a link
+[B9.4] PASS required strings present (missing: [])
+[B9.5] PASS PRESERVE-VERBATIM math strings present (missing: [])
+TOTAL: PASS=93 FAIL=0
+
+----- stderr -----
+

--- a/scripts/kcpt_kernel_induced_representation_central_complex_structure_2026_07_18.py
+++ b/scripts/kcpt_kernel_induced_representation_central_complex_structure_2026_07_18.py
@@ -1,0 +1,718 @@
+#!/usr/bin/env python3
+"""KCPT kernel induced representation: central complex structure (bounded theorem).
+
+Integer / rational-exact verification runner. Every gated quantity is recomputed
+from the construction (D2 from the eta phases, V8 from the corner subsets, the
+dressed classes from their definitions); expected values appear only on the
+comparison side of each gate. The complex structure J is FOUND by the runner
+(central element squaring to -I, canonical orientation) and then gated against
+its closed-form Pauli word -- it is never hard-coded.
+
+Group elements are 64 times an orthogonal matrix and 80 of the 96 carry half-unit
+(+-32) entries, so a scalar floor-divide by 64 would corrupt them. Commutant,
+orbit-rank and orbit gates therefore run on the RAW integer matrices (all such
+tests are scale-invariant). The product A@B of two group elements is always
+divisible by 64, so mul(A,B) = (A@B)//64 stays exact.
+
+Paired note: docs/KCPT_KERNEL_INDUCED_REPRESENTATION_CENTRAL_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-18.md
+Cache: logs/runner-cache/kcpt_kernel_induced_representation_central_complex_structure_2026_07_18.txt
+"""
+
+import os
+import re
+import sys
+import json
+import itertools
+import numpy as np
+from sympy import Matrix, eye, symbols, factor, simplify, I as sy_I
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+PASS = 0
+FAIL = 0
+
+
+def gate(tag, cond, desc):
+    global PASS, FAIL
+    ok = bool(cond)
+    print(f"[{tag}] {'PASS' if ok else 'FAIL'} {desc}")
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    return ok
+
+
+# ------------------------------------------------------------------ construction
+L = 4
+N = 64
+
+
+def idx(x1, x2, x3):
+    return (x1 * L + x2) * L + x3
+
+
+coords = np.zeros((N, 3), dtype=np.int64)
+for a in range(L):
+    for b in range(L):
+        for c in range(L):
+            coords[idx(a, b, c)] = (a, b, c)
+
+
+def eta_mu(mu, x):
+    if mu == 0:
+        return 1
+    if mu == 1:
+        return (-1) ** int(x[0])
+    return (-1) ** int(x[0] + x[1])
+
+
+e = [np.array([1, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 1])]
+D2 = np.zeros((N, N), dtype=np.int64)
+for i in range(N):
+    x = coords[i]
+    for mu in range(3):
+        D2[i, idx(*((x + e[mu]) % L))] += eta_mu(mu, x)
+        D2[i, idx(*((x - e[mu]) % L))] -= eta_mu(mu, x)
+
+SUBSETS = [(), (0,), (1,), (2,), (0, 1), (0, 2), (1, 2), (0, 1, 2)]
+HW = [0, 1, 1, 1, 2, 2, 2, 3]
+sub_index = {s: k for k, s in enumerate(SUBSETS)}
+
+
+def sub_xor(sa, sb):
+    return tuple(sorted(set(sa).symmetric_difference(set(sb))))
+
+
+V8 = np.zeros((N, 8), dtype=np.int64)
+for i in range(N):
+    x = coords[i]
+    for k, S in enumerate(SUBSETS):
+        V8[i, k] = (-1) ** int(sum(x[j] for j in S))
+
+
+def perm(fmap):
+    P = np.zeros((N, N), dtype=np.int64)
+    for i in range(N):
+        y = np.array(fmap(coords[i])) % L
+        P[i, idx(int(y[0]), int(y[1]), int(y[2]))] = 1
+    return P
+
+
+UR = perm(lambda x: (x[1], x[2], x[0]))
+U2 = perm(lambda x: (-x[1], -x[0], -x[2]))
+STAB = np.eye(N, dtype=np.int64)
+TR = {t: perm(lambda x, t=t: (x[0] - t[0], x[1] - t[1], x[2] - t[2]))
+      for t in itertools.product(range(L), repeat=3)}
+
+
+def signfield(bits):
+    a1, a2, a3, b12, b13, b23 = bits
+    d = np.zeros(N, dtype=np.int64)
+    for i in range(N):
+        x1, x2, x3 = coords[i]
+        expo = a1 * x1 + a2 * x2 + a3 * x3 + b12 * x1 * x2 + b13 * x1 * x3 + b23 * x2 * x3
+        d[i] = (-1) ** int(expo)
+    return d
+
+
+ALLBITS = list(itertools.product([0, 1], repeat=6))
+SF = {bits: signfield(bits) for bits in ALLBITS}
+BASES = {"stab": STAB, "U2": U2, "UR": UR}
+I8 = 64 * np.eye(8, dtype=np.int64)
+
+
+def induced(U):
+    return V8.T @ U @ V8
+
+
+def mul(A, B):
+    P = A @ B
+    assert np.all(P % 64 == 0), "mul divisibility failure"
+    return P // 64
+
+
+def Zt(t):
+    z = np.array([(-1) ** int(sum(t[k] for k in S)) for S in SUBSETS], dtype=np.int64)
+    return np.diag(z)
+
+
+def subperm(sigma):
+    P = np.zeros((8, 8), dtype=np.int64)
+    for c, S in enumerate(SUBSETS):
+        newS = tuple(sorted(sigma(k) for k in S))
+        P[sub_index[newS], c] = 1
+    return P
+
+
+def X_T(T):
+    P = np.zeros((8, 8), dtype=np.int64)
+    for c, S in enumerate(SUBSETS):
+        P[sub_index[sub_xor(S, T)], c] = 1
+    return P
+
+
+def Ms_from_shat(shat):
+    Ms = np.zeros((8, 8), dtype=np.int64)
+    for r, R in enumerate(SUBSETS):
+        for c, S in enumerate(SUBSETS):
+            Ms[sub_index[sub_xor(R, S)], c] += shat[r]
+    return Ms
+
+
+# ------------------------------------------------------- scan the dressed classes
+scan = {}
+for name, base in BASES.items():
+    cand = 0
+    preserve = 0
+    commuting = []
+    for bits in ALLBITS:
+        diagd = np.diag(SF[bits])
+        for t in itertools.product(range(L), repeat=3):
+            U = diagd @ base @ TR[t]
+            cand += 1
+            UV = U @ V8
+            K8 = V8.T @ UV
+            if np.array_equal(64 * UV, V8 @ K8):
+                preserve += 1
+            if np.array_equal(U @ D2, D2 @ U):
+                commuting.append((bits, t, K8.copy()))
+    scan[name] = dict(cand=cand, preserve=preserve, commuting=commuting)
+
+
+def eqm(a, b):
+    return np.array_equal(a, b)
+
+
+# ============================================================================ B1
+print("== B1 surface and whole-class kernel preservation ==")
+gate("B1.1", eqm(D2.T, -D2) and set(np.unique(D2).tolist()).issubset({-1, 0, 1}),
+     "D2 integer antisymmetric, entries in {-1,0,1}")
+rankD2 = Matrix(D2.tolist()).rank()
+gate("B1.2", rankD2 == 56, f"rank(D2)==56 so dim ker==8 (got {rankD2})")
+gate("B1.3",
+     eqm(D2 @ V8, np.zeros((N, 8), dtype=np.int64))
+     and eqm(V8.T @ V8, 64 * np.eye(8, dtype=np.int64))
+     and sorted([HW.count(h) for h in (0, 1, 2, 3)]) == [1, 1, 3, 3],
+     "D2@V8==0, V8.T@V8==64I, HW grading 1+3+3+1")
+
+for name in BASES:
+    s = scan[name]
+    gate(f"B1.4-{name}", s["cand"] == 4096 and s["preserve"] == 4096,
+         f"{name}: 4096 candidates, all preserve corner kernel (residual identity)")
+for name in BASES:
+    gate(f"B1.5-{name}", len(scan[name]["commuting"]) == 64,
+         f"{name}: exactly 64 members commute with D2")
+for name in BASES:
+    ok = all(eqm(K.T @ K, 4096 * np.eye(8, dtype=np.int64))
+             for _, _, K in scan[name]["commuting"])
+    gate(f"B1.6-{name}", ok, f"{name}: every commuting K8 has K8.T@K8==4096 I")
+
+# B1.7 dictionary
+texmp = (1, 2, 3)
+gate("B1.7a", eqm(induced(TR[texmp]), 64 * Zt(texmp)),
+     "induced(trans(1,2,3))==64*Z(t) parity diagonal")
+P_swap01 = subperm(lambda k: {0: 1, 1: 0, 2: 2}[k])
+P_sigma = subperm(lambda k: {0: 1, 1: 2, 2: 0}[k])
+gate("B1.7b", eqm(induced(U2), 64 * P_swap01),
+     "induced(undressed U2)==64*P_swap01 (swap subset axes 0,1)")
+gate("B1.7c", eqm(induced(UR), 64 * P_sigma),
+     "induced(undressed UR)==64*P_sigma (0->1->2->0 on subsets)")
+
+# B1.8
+d_lin = SF[(0, 1, 1, 0, 0, 0)]
+gate("B1.8", eqm(induced(np.diag(d_lin)), 64 * X_T((1, 2))),
+     "induced(diag chi_{(1,2)})==64*X_{(1,2)} symmetric-difference perm")
+
+# B1.9 factorization exemplar
+bex = (0, 1, 0, 1, 0, 0)
+tex = (1, 0, 0)
+dex = SF[bex]
+Uex = np.diag(dex) @ U2 @ TR[tex]
+gate("B1.9a", eqm(Uex @ D2, D2 @ Uex), "exemplar bits=(0,1,0,1,0,0),t=(1,0,0) commutes with D2")
+K8ex = induced(Uex)
+shat = V8.T @ dex
+gate("B1.9b", eqm(K8ex, Ms_from_shat(shat) @ P_swap01 @ Zt(tex)),
+     "exemplar K8 == Ms(shat) @ P_swap01 @ Z(t)")
+supp = {SUBSETS[r]: int(shat[r]) for r in range(8) if shat[r] != 0}
+gate("B1.9c", supp == {(): 32, (0,): -32, (1,): 32, (0, 1): 32},
+     "exemplar shat support == {():32,(0,):-32,(1,):32,(0,1):32}")
+
+# B1.10
+gate("B1.10", any(b == bex and t == tex for b, t, _ in scan["U2"]["commuting"]),
+     "exemplar (bits,t) present in the U2 commuting solution set")
+
+# ============================================================================ B2
+print("== B2 per-class census and the linear/quadratic dichotomy ==")
+gate("B2.1-stab", all((b[3], b[4], b[5]) == (0, 0, 0) for b, _, _ in scan["stab"]["commuting"]),
+     "stab: all commuting members purely linear (b==0,0,0)")
+gate("B2.1-U2", all((b[3], b[4], b[5]) != (0, 0, 0) for b, _, _ in scan["U2"]["commuting"]),
+     "U2: no purely-linear commuting member")
+gate("B2.1-UR", all((b[3], b[4], b[5]) != (0, 0, 0) for b, _, _ in scan["UR"]["commuting"]),
+     "UR: no purely-linear commuting member")
+gate("B2.2-U2", all((b[3], b[4], b[5]) == (1, 0, 0) for b, _, _ in scan["U2"]["commuting"]),
+     "U2: forced quadratic signature (b12,b13,b23)==(1,0,0)")
+gate("B2.2-UR", all((b[3], b[4], b[5]) == (1, 1, 0) for b, _, _ in scan["UR"]["commuting"]),
+     "UR: forced quadratic signature (b12,b13,b23)==(1,1,0)")
+
+
+def law_ok(name, law):
+    for b, t, _ in scan[name]["commuting"]:
+        exp = tuple(v % 2 for v in law(t))
+        if (b[0], b[1], b[2]) != exp:
+            return False
+    return True
+
+
+gate("B2.3-stab", law_ok("stab", lambda t: (0, t[0], t[0] + t[1])),
+     "stab compensator law (a1,a2,a3)==(0,t1,t1+t2)")
+gate("B2.3-U2", law_ok("U2", lambda t: (1 + t[0], 1, 1 + t[0] + t[1])),
+     "U2 compensator law (a1,a2,a3)==(1+t1,1,1+t1+t2)")
+gate("B2.3-UR", law_ok("UR", lambda t: (t[0] + t[1], 0, t[0])),
+     "UR compensator law (a1,a2,a3)==(t1+t2,0,t1)")
+
+for name in BASES:
+    byb = {}
+    for b, t, _ in scan[name]["commuting"]:
+        byb.setdefault(b, []).append(t)
+    ok = len(byb) == 4 and all(len(v) == 16 for v in byb.values())
+    gate(f"B2.4-{name}", ok, f"{name}: commuting set == 4 sign-fields x 16 translations")
+
+
+def block_diag(K):
+    for i in range(8):
+        for j in range(8):
+            if HW[i] != HW[j] and K[i, j] != 0:
+                return False
+    return True
+
+
+def triplet_pres(K):
+    for c in (1, 2, 3):
+        for r in range(8):
+            if r not in (1, 2, 3) and K[r, c] != 0:
+                return False
+    return True
+
+
+gcount = {name: sum(1 for _, _, K in scan[name]["commuting"] if block_diag(K)) for name in BASES}
+tcount = {name: sum(1 for _, _, K in scan[name]["commuting"] if triplet_pres(K)) for name in BASES}
+gate("B2.5a", (gcount["stab"], gcount["U2"], gcount["UR"]) == (16, 0, 0),
+     "grading-preserving counts per class == 16/0/0")
+gate("B2.5b", (tcount["stab"], tcount["U2"], tcount["UR"]) == (16, 0, 0),
+     "triplet-preserving counts per class == 16/0/0")
+gp_stab = [(b, t, K) for b, t, K in scan["stab"]["commuting"] if block_diag(K)]
+gate("B2.5c",
+     len(gp_stab) == 16
+     and all((b[0], b[1], b[2]) == (0, 0, 0) for b, _, _ in gp_stab)
+     and all(eqm(K, np.diag(np.diag(K))) for _, _, K in gp_stab),
+     "the 16 stab grading-preservers are exactly a==(0,0,0), each a pure Z-diagonal")
+
+dK = {name: {K.tobytes() for _, _, K in scan[name]["commuting"]} for name in BASES}
+dvac = {name: {tuple(K[:, 0].tolist()) for _, _, K in scan[name]["commuting"]} for name in BASES}
+gate("B2.6a", all(len(dK[name]) == 8 for name in BASES),
+     "distinct induced K8 per class == 8")
+gate("B2.6b", all(len(dvac[name]) == 4 for name in BASES),
+     "distinct vacuum images (K8 column 0) per class == 4")
+
+census = {}
+for _, _, K in scan["stab"]["commuting"]:
+    key = frozenset((HW[i], HW[j]) for i in range(8) for j in range(8) if K[i, j] != 0)
+    census[key] = census.get(key, 0) + 1
+exp_census = {
+    frozenset({(0, 1), (1, 0), (1, 2), (2, 1), (2, 3), (3, 2)}): 32,
+    frozenset({(0, 0), (1, 1), (2, 2), (3, 3)}): 16,
+    frozenset({(0, 2), (1, 1), (1, 3), (2, 0), (2, 2), (3, 1)}): 16,
+}
+gate("B2.7", census == exp_census,
+     "stab hw-block-support census == 32/16/16 with the named supports")
+
+# ============================================================================ B3
+print("== B3 the induced group G ==")
+gens_by_class = {name: [K for _, _, K in scan[name]["commuting"]] for name in BASES}
+gens_all = {}
+for name in BASES:
+    for K in gens_by_class[name]:
+        gens_all[K.tobytes()] = K
+GEN = list(gens_all.values())
+
+
+def closure(gs):
+    gs = [g.copy() for g in gs]
+    elts = {g.tobytes(): g for g in gs}
+    frontier = list(elts.values())
+    while frontier:
+        nf = []
+        for x in frontier:
+            for g in gs:
+                p = mul(x, g)
+                k = p.tobytes()
+                if k not in elts:
+                    elts[k] = p
+                    nf.append(p)
+        frontier = nf
+    return list(elts.values())
+
+
+G = closure(GEN)
+gate("B3.1", len(GEN) == 24 and len(G) == 96,
+     f"G = closure of 24 distinct induced K8; |G|==96 (got {len(G)})")
+
+
+def clo_size(names):
+    gs = []
+    for nm in names:
+        gs += gens_by_class[nm]
+    return len(closure(gs))
+
+
+gate("B3.2a", (clo_size(["stab"]), clo_size(["U2"]), clo_size(["UR"])) == (16, 32, 48),
+     "single-class closures <stab>/<U2>/<UR> == 16/32/48")
+gate("B3.2b",
+     (clo_size(["stab", "U2"]), clo_size(["stab", "UR"]), clo_size(["U2", "UR"])) == (32, 48, 96),
+     "pair closures 32/48/96; only U2+UR generate all of G")
+
+gate("B3.3a", any(eqm(g, -I8) for g in G), "-64 I is in G")
+center = [g for g in G if all(eqm(mul(g, h), mul(h, g)) for h in G)]
+gate("B3.3b", len(center) == 4, f"center Z(G) has order 4 (got {len(center)})")
+central_sq = [g for g in center if eqm(mul(g, g), -I8)]
+gate("B3.3c", len(central_sq) == 2, "exactly 2 central elements square to -I")
+
+
+def order(g):
+    p = g.copy()
+    k = 1
+    while not eqm(p, I8):
+        p = mul(p, g)
+        k += 1
+    return k
+
+
+import math
+orders = [order(g) for g in G]
+expo = 1
+for o in orders:
+    expo = expo * o // math.gcd(expo, o)
+gate("B3.4a", expo == 24, f"exponent(G)==24 (got {expo})")
+
+inv = {}
+for g in G:
+    for h in G:
+        if eqm(mul(g, h), I8):
+            inv[g.tobytes()] = h
+            break
+bykey = {g.tobytes(): i for i, g in enumerate(G)}
+remaining = set(range(len(G)))
+sizes = []
+while remaining:
+    i = next(iter(remaining))
+    g = G[i]
+    cls = set()
+    for h in G:
+        cls.add(mul(mul(h, g), inv[h.tobytes()]).tobytes())
+    ids = {bykey[k] for k in cls}
+    sizes.append(len(ids))
+    remaining -= ids
+gate("B3.4b",
+     len(sizes) == 16
+     and sorted(sizes) == [1, 1, 1, 1, 6, 6, 6, 6, 6, 6, 8, 8, 8, 8, 12, 12],
+     "16 conjugacy classes, sizes [1,1,1,1,6x6,8x4,12x2]")
+
+comms = []
+for g in G:
+    for h in G:
+        comms.append(mul(mul(mul(g, h), inv[g.tobytes()]), inv[h.tobytes()]))
+Gp = closure(comms)
+gate("B3.4c", len(Gp) == 24 and (len(G) // len(Gp)) == 4,
+     "commutator subgroup order 24; abelianization order 4")
+
+gG = [g for g in G if block_diag(g)]
+tG = [g for g in G if triplet_pres(g)]
+gate("B3.5a", len(gG) == 4 and len(tG) == 4,
+     "grading-preserving members of G == 4 == triplet-preserving")
+restr = set()
+lock = True
+for g in gG:
+    R = g[np.ix_([1, 2, 3], [1, 2, 3])]
+    assert np.all(R % 64 == 0)
+    Rd = (R // 64)
+    restr.add(tuple(np.diag(Rd).tolist()))
+    if Rd[0, 0] != Rd[1, 1]:
+        lock = False
+gate("B3.5b", restr == {(1, 1, 1), (1, 1, -1), (-1, -1, 1), (-1, -1, -1)},
+     "triplet restrictions == {I, diag(1,1,-1), diag(-1,-1,1), -I}")
+gate("B3.5c", lock, "every graded restriction has R[0,0]==R[1,1] (x1,x2 sign-locked)")
+
+gate("B3.6", eqm(sum(G), np.zeros((8, 8), dtype=np.int64)),
+     "sum over G of K8 == 0 (no fixed vector)")
+
+# ============================================================================ B4
+print("== B4 complex-type irreducibility and the commutant ==")
+sum_tr2 = sum(int(np.trace(g)) ** 2 for g in G)
+gate("B4.1", sum_tr2 == 786432 == 2 * 96 * 4096,
+     f"sum tr(K8)^2 == 786432 == 2*96*4096 so <chi,chi>==2 (got {sum_tr2})")
+fs = sum(int(np.trace(mul(g, g))) for g in G)
+gate("B4.2", fs == 0, f"Frobenius-Schur sum over G of tr(mul(K,K))==0 (got {fs})")
+
+# small generating subset (verify closure 96) then commutant over Q on RAW matrices
+genpair = None
+for i in range(len(GEN)):
+    for j in range(i + 1, len(GEN)):
+        if len(closure([GEN[i], GEN[j]])) == 96:
+            genpair = [GEN[i], GEN[j]]
+            break
+    if genpair:
+        break
+gate("B4.3a", genpair is not None and len(closure(genpair)) == 96,
+     "a 2-element generating subset closes to all 96")
+blocks = []
+for K in genpair:
+    Ki = K.astype(object)
+    M = np.kron(Ki, np.eye(8, dtype=object)) - np.kron(np.eye(8, dtype=object), Ki.T)
+    blocks.append(Matrix(M.tolist()))
+commutant_dim = len(Matrix.vstack(*blocks).nullspace())
+gate("B4.3b", commutant_dim == 2,
+     f"exact commutant over Q (raw kron equations) has dimension 2 (got {commutant_dim})")
+
+# find J: central, squares to -I, orientation J[index(()),index((1,))] > 0
+i_vac = sub_index[()]
+i_x2 = sub_index[(1,)]
+cand_J = [g for g in central_sq if g[i_vac, i_x2] > 0]
+gate("B4.4a", len(cand_J) == 1, "unique central square-(-I) element with J chi_{x2}=+chi_{}")
+J = cand_J[0]
+otherJ = [g for g in central_sq if not eqm(g, J)][0]
+gate("B4.4b", eqm(otherJ, -J), "the other central square-(-I) element == -J")
+
+assert np.all(J % 64 == 0)
+nz = int(np.count_nonzero(J))
+formula_ok = True
+for c, S in enumerate(SUBSETS):
+    r = sub_index[sub_xor(S, (1,))]
+    val = 64 * ((-1) ** len(set(S) & {0, 2})) * (1 if 1 in S else -1)
+    if int(J[r, c]) != val:
+        formula_ok = False
+gate("B4.5a", nz == 8 and formula_ok,
+     "J/64 has 8 nonzeros; J[index(S^{1}),index(S)]==64*(-1)^{|S&{0,2}|}*(+1 iff 1 in S)")
+gate("B4.5b",
+     int(np.trace(J)) == 0 and eqm(J.T, -J) and eqm(mul(J, J), -I8),
+     "trace(J)==0, J.T==-J, mul(J,J)==-64 I")
+gate("B4.5c", all(eqm(J @ g, g @ J) for g in GEN),
+     "J commutes with every generator (central)")
+Jsupp = {(HW[i], HW[j]) for i in range(8) for j in range(8) if J[i, j] != 0}
+gate("B4.5d", Jsupp == {(0, 1), (1, 0), (1, 2), (2, 1), (2, 3), (3, 2)},
+     "hw-block support of J == {(0,1),(1,0),(1,2),(2,1),(2,3),(3,2)}")
+col0 = J[:, i_vac].copy()
+expcol = np.zeros(8, dtype=np.int64)
+expcol[i_x2] = -64
+gate("B4.5e", eqm(col0, expcol), "J column 0 == -64 * e_{(1,)} (vacuum -> minus chi_{x2})")
+
+lam = symbols('lambda')
+Jm = Matrix((J // 64).tolist())
+cp = Jm.charpoly(lam).as_expr()
+gate("B4.6a", simplify(cp - (lam ** 2 + 1) ** 4) == 0,
+     "charpoly(J/64) == (lambda^2 + 1)^4")
+rp = (Jm - sy_I * eye(8)).rank()
+rm = (Jm + sy_I * eye(8)).rank()
+gate("B4.6b", rp == 4 and rm == 4,
+     "rank(J/64 - iI)==4 and rank(J/64 + iI)==4 (W and Wbar both 4-dim)")
+
+sa, sb = symbols('a b')
+detexpr = (sa * eye(8) + sb * Jm).det()
+gate("B4.7", simplify(detexpr - (sa ** 2 + sb ** 2) ** 4) == 0,
+     "factor(det(aI + bJ/64)) == (a^2 + b^2)^4 so Q[J] is a field (no proper invariant subspace)")
+
+e1 = np.zeros(8, dtype=np.int64)
+e1[1] = 1
+orbit = [g @ e1 for g in G]  # RAW integer vectors; rank is scale-invariant
+rank_orbit = Matrix([v.tolist() for v in orbit]).rank()
+gate("B4.8a", rank_orbit == 8,
+     f"rank of 96x8 orbit {{K@e_1}} == 8 (single hw=1 carrier spans kernel) (got {rank_orbit})")
+cur = [np.eye(8, dtype=np.int64)[i] for i in (1, 2, 3)]
+r_cur = Matrix([v.tolist() for v in cur]).rank()
+grew = True
+while grew:
+    grew = False
+    newset = list(cur)
+    for g in G:
+        for v in cur:
+            newset.append(g @ np.array(v))
+    M = Matrix([v.tolist() for v in newset])
+    nr = M.rank()
+    if nr > r_cur:
+        _, piv = M.T.rref()
+        cur = [np.array(newset[p]) for p in piv]
+        r_cur = nr
+        grew = True
+gate("B4.8b", r_cur == 8,
+     "iterative rref from span{e1,e2,e3} stabilizes at dimension 8")
+
+gate("B4.9", len(gG) == 4 and all(eqm(g, np.diag(np.diag(g))) for g in gG),
+     "the 4 graded members of G are DIAGONAL (reducible-contrast discriminator)")
+
+# ============================================================================ B5
+print("== B5 FLAG registration and neutrality ==")
+gate("B5.1a", all(g.dtype == np.int64 for g in G) and all(np.isreal(g).all() for g in G),
+     "entrywise conjugation fixes every element of G (all real integer matrices)")
+basis_plus = (Jm - sy_I * eye(8)).nullspace()
+Aminus = Jm + sy_I * eye(8)
+swap_ok = len(basis_plus) == 4 and all((Aminus * v.conjugate()).is_zero_matrix for v in basis_plus)
+gate("B5.1b", swap_ok,
+     "conjugation carries ker(J/64 - iI) into ker(J/64 + iI): swaps W <-> Wbar")
+
+e0 = np.zeros(8, dtype=np.int64)
+e0[0] = 1
+vac_orbit = {tuple((g @ e0).tolist()) for g in G}  # RAW vectors
+gate("B5.2a", len(vac_orbit) == 48, f"vacuum orbit under G has size 48 (got {len(vac_orbit)})")
+supps = {tuple(sorted({HW[i] for i in range(8) if v[i] != 0})) for v in vac_orbit}
+exp_supps = {(0,), (0, 1, 2), (0, 1, 2, 3), (0, 2), (1,), (1, 2), (1, 2, 3), (1, 3), (2,)}
+gate("B5.2b", supps == exp_supps,
+     "vacuum-orbit hw-support set matches the mixed-grade spec set")
+
+w1, w2, w3 = symbols('w1 w2 w3')
+W = Matrix.diag(w1, w2, w3)
+neutral = True
+for g in gG:
+    R = Matrix((g[np.ix_([1, 2, 3], [1, 2, 3])] // 64).tolist())
+    if not (R * W - W * R).is_zero_matrix:
+        neutral = False
+gate("B5.3", neutral,
+     "each triplet restriction commutes with diag(w1,w2,w3): no per-slot weight relation (r-neutral)")
+
+# ============================================================================ B6
+print("== B6 negative controls / rejectors ==")
+gate("B6.1a", not eqm(U2 @ D2, D2 @ U2), "undressed U2 does not commute with D2")
+gate("B6.1b", not eqm(UR @ D2, D2 @ UR), "undressed UR does not commute with D2")
+brej = (0, 1, 0, 1, 1, 0)
+Urej = np.diag(SF[brej]) @ U2 @ TR[tex]
+gate("B6.2", not eqm(Urej @ D2, D2 @ Urej),
+     "one-bit rejector: exemplar with b13 flipped does not commute with D2")
+
+
+def axis_word(axis, inter, present_axis):
+    Jp = np.zeros((8, 8), dtype=np.int64)
+    for c, S in enumerate(SUBSETS):
+        r = sub_index[sub_xor(S, (axis,))]
+        Jp[r, c] = 64 * ((-1) ** len(set(S) & inter)) * (1 if present_axis in S else -1)
+    return Jp
+
+
+Jx1 = axis_word(0, {1, 2}, 0)
+Jx3 = axis_word(2, {0, 1}, 2)
+gate("B6.3a", any(not eqm(Jx1 @ g, g @ Jx1) for g in G),
+     "wrong-axis word J' (complex axis x1) fails to commute with some g in G")
+gate("B6.3b", any(not eqm(Jx3 @ g, g @ Jx3) for g in G),
+     "wrong-axis word J'' (complex axis x3) fails to commute with some g in G")
+Ulaw = np.diag(SF[(0, 0, 0, 0, 0, 0)]) @ STAB @ TR[(1, 0, 0)]
+gate("B6.4", not eqm(Ulaw @ D2, D2 @ Ulaw),
+     "law rejector: stab bits all-zero, t=(1,0,0) violates the stab law and does not commute")
+
+# ============================================================================ B7
+print("== B7 verbatim quote gates ==")
+NOTE_PATH = os.path.join(
+    ROOT, "docs",
+    "KCPT_KERNEL_INDUCED_REPRESENTATION_CENTRAL_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-18.md")
+MECH_PATH = os.path.join(
+    ROOT, "docs",
+    "KCPT_COUPLING_TRIPLE_TWO_PRESENTATION_DERIVABLE_CLASS_SPECTRAL_PAIRING_BOUNDED_THEOREM_NOTE_2026-07-16.md")
+CARR_PATH = os.path.join(
+    ROOT, "docs",
+    "KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md")
+AX_PATH = os.path.join(ROOT, "docs", "MINIMAL_AXIOMS_2026-06-29.md")
+
+
+def read_text(path):
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return fh.read()
+    except OSError:
+        return None
+
+
+def normalize(text):
+    lines = [re.sub(r'^\s*>\s?', '', ln) for ln in text.split('\n')]
+    return re.sub(r'\s+', ' ', ' '.join(lines)).strip()
+
+
+note_raw = read_text(NOTE_PATH)
+note_norm = normalize(note_raw) if note_raw is not None else ""
+
+FRAGMENTS = [
+    ("B7.1", MECH_PATH,
+     "**FLAG — two-model mechanism:** the entrywise-conjugate presentations in L-K2 satisfy the same named clauses and exchange every K-odd seed."),
+    ("B7.2", MECH_PATH,
+     "The memo's live Qualification leaves the unfixed choice conditional/open."),
+    ("B7.3", CARR_PATH, "graded by Hamming weight as `1 + 3 + 3 + 1`"),
+    ("B7.4", CARR_PATH,
+     "`eta_1 = 1`, `eta_2(x) = (-1)^{x_1}`, `eta_3(x) = (-1)^{x_1 + x_2}`"),
+    ("B7.5", CARR_PATH, "its exact rank is `56`"),
+    ("B7.6", AX_PATH, "standard translations, and proper cubic rotations"),
+]
+for tag, path, frag in FRAGMENTS:
+    src = read_text(path)
+    src_norm = normalize(src) if src is not None else ""
+    frag_norm = normalize(frag)
+    in_src = frag_norm in src_norm
+    in_note = frag_norm in note_norm
+    if not in_src:
+        j = src_norm.find(frag_norm[:24])
+        near = src_norm[j:j + len(frag_norm) + 12] if j >= 0 else "(anchor not found)"
+        print(f"    [{tag}] source fragment missing; nearest actual text: {near!r}")
+    gate(tag, in_src and in_note,
+         f"verbatim fragment present in source AND in the new note")
+
+# ============================================================================ B8
+print("== B8 sharded-ledger existence ==")
+LEDGERS = [
+    ("B8.1", "docs/audit/data/ledger/kc/kcpt_corner_carrier_lattice_delivery_hw1_doublet_pair_polarization_bounded_theorem_note_2026-07-17.json"),
+    ("B8.2", "docs/audit/data/ledger/kc/kcpt_coupling_triple_two_presentation_derivable_class_spectral_pairing_bounded_theorem_note_2026-07-16.json"),
+    ("B8.3", "docs/audit/data/ledger/mi/minimal_axioms.json"),
+]
+for tag, rel in LEDGERS:
+    p = os.path.join(ROOT, rel)
+    ok = False
+    if os.path.exists(p):
+        try:
+            with open(p, "r", encoding="utf-8") as fh:
+                json.load(fh)
+            ok = True
+        except (OSError, json.JSONDecodeError):
+            ok = False
+    gate(tag, ok, f"ledger shard exists and json-parses: {os.path.basename(rel)}")
+
+# ============================================================================ B9
+print("== B9 note hygiene ==")
+if note_raw is None:
+    for tag in ("B9.1", "B9.2", "B9.3a", "B9.3b", "B9.4"):
+        gate(tag, False, "note file not found")
+else:
+    forbidden = ["only route", "last route", "exhaust", "closes the route",
+                 "closes this route", "no other route", "final route",
+                 "retained", "unaudited", "effective_status", "audit grade"]
+    present_forbidden = [s for s in forbidden if s in note_raw]
+    gate("B9.1", not present_forbidden,
+         f"forbidden route/status strings absent (found: {present_forbidden})")
+    dec = re.search(r'[0-9]\.[0-9]', note_raw)
+    gate("B9.2", dec is None,
+         f"no bare-decimal literal [0-9].[0-9] in note (match: {dec.group(0) if dec else None})")
+    links = re.findall(r'\]\(([^)]+)\)', note_raw)
+    docs_links = [u for u in links if 'docs/' in u]
+    gate("B9.3a", len(docs_links) == 3,
+         f"exactly 3 markdown links into docs/ (got {len(docs_links)})")
+    handle = "STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03"
+    backticked = ("`" + handle + "`") in note_raw
+    not_linked = not any(handle in u for u in links)
+    gate("B9.3b", backticked and not_linked,
+         "STAGGERED_DIRAC handle appears backticked and NOT as a link")
+    runner_rel = "scripts/kcpt_kernel_induced_representation_central_complex_structure_2026_07_18.py"
+    cache_rel = "logs/runner-cache/kcpt_kernel_induced_representation_central_complex_structure_2026_07_18.txt"
+    required = ["bounded theorem", "does NOT select", "Boundary", runner_rel, cache_rel]
+    missing = [s for s in required if s not in note_raw]
+    gate("B9.4", not missing, f"required strings present (missing: {missing})")
+    verbatim_math = ["Z (x) iY (x) Z", "(a^2 + b^2)^4", "(lambda^2 + 1)^4"]
+    missing_math = [s for s in verbatim_math if s not in note_raw]
+    gate("B9.5", not missing_math,
+         f"PRESERVE-VERBATIM math strings present (missing: {missing_math})")
+
+# ================================================================= final tally
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded-theorem unit on the staggered corner-wave kernel: the dressed symmetry classes induce a finite matrix group `G` of order 96 on the 8-dimensional kernel, and the rational commutant of `G` is exactly `span{I, J}` where `J = Z (x) iY (x) Z` is a central complex structure (`J^2 = -I`, found by search over the computed center, not hard-coded). The kernel is `Q`-irreducible under `G`; over `C` it splits only into the conjugate pair `W`, `W-bar` (the `+i`/`-i` eigenspaces of `J`). The two-presentation FLAG binary of the coupling-triple mechanism note registers at kernel level as the `+J`/`-J` orientation choice.

## What this responds to

- The **FLAG — two-model mechanism** in the coupling-triple two-presentation note (entrywise-conjugate presentations exchanging every K-odd seed): this unit shows the binary survives to the induced-representation level as exactly one bit — the orientation of the central complex structure — with the note's other induced invariants orientation-blind.
- The corner-carrier hw=1 note's kernel surface: the same 8-dimensional corner-wave kernel, now with its full dressed symmetry group computed.
- FLAG language stays at induced-kernel level, consistent with the landed corner-projector-orbit scoping of the swap-conjugacy row.

## Science content (all runner-gated, exact arithmetic)

- **T1** Whole-class kernel preservation: all 3 x 4096 dressed members preserve the kernel exactly (integer residual `64*(U V8) == V8 K8`), with factorization `K8 = Ms(s-hat) * P_base * Z(t)`.
- **T2** Forced quadratic dressing: non-trivial base symmetries act on the kernel only at forced quadratic signature (stab `(0,0,0)`, U2 `(1,0,0)`, UR `(1,1,0)`) with exact compensator laws (congruences mod 2; `t3`-parity always free); grading/triplet preservation confined to the 16 trivially-dressed stabiliser members.
- **T3** Induced group facts: `|G| = 96`, `-I in G`, center `{+-I, +-J}` of order 4, exponent 24, 16 conjugacy classes, `|[G,G]| = 24`, character-norm gate giving exactly 2 irreducible complex summands, Frobenius-Schur sum 0 (complex type).
- **T4** Headline: rational commutant `= span{I, J}` (a copy of `Q(i)`); `J = Z (x) iY (x) Z` exactly (8 nonzeros, entry rule gated); `charpoly = (lambda^2 + 1)^4`; `det(aI + bJ) = (a^2 + b^2)^4`; `dim W = 4`; every weight-one corner wave is a cyclic vector.
- **T5** FLAG registration: the `+J`/`-J` orientation is the kernel-level image of the two-presentation binary; vacuum orbit size 48; the four graded members of `G` are simultaneously diagonal.
- **Boundary (bounded):** the note does NOT select the orientation, does not act on the mechanism memo's live Qualification, derives no `r`, and is a finite-surface (`L = 4`) register-not-read statement.

## Runner

`scripts/kcpt_kernel_induced_representation_central_complex_structure_2026_07_18.py` — `TOTAL: PASS=93 FAIL=0`, exit 0. Exact integer/rational arithmetic throughout (sympy exact ranks and nullspaces, symbolic charpoly and determinant); B6 negative controls (undressed bases, wrong-sign and wrong-axis rejectors, compensator-law violator); B7 quote-pin gates against the cited notes' primary text; B8 ledger shard-path gates; B9 note-hygiene gates. Cache at `logs/runner-cache/kcpt_kernel_induced_representation_central_complex_structure_2026_07_18.txt`.

## Commits

1. `science:` — the source-only triple (note + paired runner + cache).
2. `audit-infra:` — stage-18 citation-graph manifest refresh acknowledging the new note (sole docs/audit/data change; auto-created ledger shards not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)