### PR TITLE
review-loop: proactive citation-manifest co-landing rule

### DIFF
--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -893,7 +893,10 @@ title/body names the row or quotes its audit repair target):
    a sibling-runner pin sweep was done before every note edit (grep
    `scripts/` for runners pinning the edited sentences); no authored grade
    language anywhere; no `docs/audit/data/` content beyond
-   dispatcher-sidecar targeting metadata.
+   dispatcher-sidecar targeting metadata and the citation-graph manifest
+   acknowledgment (`docs/audit/data/citation_graph_manifest.json`) when the
+   landed commits change graph dependencies (see the landing loop's
+   proactive rule).
 
 7. **Pipeline-output-stripped PASS gate (hard).** After running the pipeline
    for validation, the framework PR must NOT land any pipeline-regenerated
@@ -903,7 +906,11 @@ title/body names the row or quotes its audit repair target):
    merge. The following must hold for review-loop to issue PASS:
 
 ```bash
-# Must produce no output. Any change here means the working tree has
+# Must produce no output EXCEPT, when the landing changes citation-graph
+# dependencies, exactly one staged line for
+# docs/audit/data/citation_graph_manifest.json (the stage-18 delta
+# acknowledgment, which MUST co-land per the landing loop's proactive
+# rule). Any other change here means the working tree has
 # pipeline-regenerated audit-lane outputs left over from validation;
 # drop them (see below) before recommitting.
 git status --porcelain docs/audit/AUDIT_LEDGER.md \

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -236,7 +236,14 @@ review-only flags contradict the drain's land-end-to-end contract).
    never by hand-merge; a manifest regeneration touches only that generated
    acknowledgment surface, so it needs no new reviewer round — any OTHER
    conflict fails the landing closed and returns the PR to its worker for
-   re-review on a rebased head. Generated-output restoration is a
+   re-review on a rebased head. PROACTIVE rule, not just on conflict: when
+   the commits being landed change any citation-graph dependency (new or
+   edited notes with markdown links), the landing set must INCLUDE a
+   refreshed `docs/audit/data/citation_graph_manifest.json`
+   (`build_citation_graph.py` then `write_citation_graph_manifest.py`,
+   staged into the landing) — otherwise the enforced stage-18 guard blocks
+   every subsequent pipeline run on main until someone lands the
+   acknowledgment for you. Generated-output restoration is a
    COMMIT-time rule (see the audit-compatibility gate), not a landing-time
    step: the commits being landed are already clean. The fail-closed
    landing loop is, exactly:

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -927,8 +927,13 @@ git status --porcelain docs/audit/AUDIT_LEDGER.md \
                        docs/publication/ci3_z3/DERIVATION_VALIDATION_MAP_EFFECTIVE_STATUS.md
 ```
 
-If this command prints any lines, BLOCK PASS and instruct the operator to
-DROP the regenerated files before recommitting:
+If this command prints any line OTHER than the single allowed staged
+`docs/audit/data/citation_graph_manifest.json` entry (allowed only when the
+landed commits change graph dependencies), BLOCK PASS and instruct the
+operator to DROP the regenerated files before recommitting. The drop
+sequence deliberately erases everything — including the manifest — and then
+deterministically regenerates and re-stages the manifest when (and only
+when) the landing changes graph dependencies:
 
 ```bash
 git checkout origin/main -- docs/audit/data/ \
@@ -937,6 +942,10 @@ git checkout origin/main -- docs/audit/data/ \
                             'docs/publication/ci3_z3/*_EFFECTIVE_STATUS.md' \
                             docs/publication/ci3_z3/PUBLICATION_AUDIT_DIVERGENCE.md
 git clean -fd -- docs/audit/data/
+# Only when the landed commits change citation-graph dependencies:
+python3 docs/audit/scripts/build_citation_graph.py
+python3 docs/audit/scripts/write_citation_graph_manifest.py
+git add docs/audit/data/citation_graph_manifest.json
 ```
 
 The pipeline is run for VALIDATION only — to confirm the source repair is


### PR DESCRIPTION
Process finding from the defect-lane report: two lanes independently tripped the enforced stage-18 guard by landing dep-changing commits without the refreshed manifest, blocking main's pipeline runs until someone landed the acknowledgment. One-paragraph skill addition making the co-landing rule proactive (landing set includes the refreshed manifest whenever landed commits change graph deps), complementing the existing conflict-time regeneration rule. Docs-only, one file.

Review gate: one sol xhigh round, then lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)