### PR TITLE
audit-loop: panel and resume cross-seat disagreements automatically

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -206,24 +206,27 @@ default session is:
 
 1. Setup per "Setup For Each Session" below (fetch, clean worktree,
    pipeline, strict lint).
-2. Finish pending judicial work first — it gates flagship rows:
-   `python3 docs/audit/scripts/orchestrate_judicial_panel.py`
-   (this reseats any disagreement whose recorded seats are unrecoverable —
-   see the reseat contract below — and panels the validly-seated rest).
-3. Drain the development tier in parallel with
-   `python3 docs/audit/scripts/orchestrate_audit_batch.py --lane <name>
-   --max-workers 4` (raise toward 6 only in a quiet pool per the budget
-   below). Default scope rule — no invoker judgment required: use the
-   owner-named lane if one was given; otherwise iterate the lanes of
-   `docs/audit/data/lane_certification_config.json` in listed order,
-   starting from the first lane whose entry in the generated
-   `docs/audit/data/lane_certification.json` reports blocking rows.
-   Reseated rows from step 2 re-enter through whichever lane closure
-   contains them.
-4. Repeat steps 2-3 until a full pass lands nothing new (fresh
-   disagreements surfaced by step 3 get their panel on the next pass),
-   then run the forensic tier as a single canary (rule below), never in
-   the parallel lane.
+2. Launch the panel-aware top-level drainer:
+
+   ```bash
+   python3 docs/audit/scripts/orchestrate_audit_loop.py --max-workers 4
+   ```
+
+   This command owns the complete control loop: finish pending judicial work,
+   drain configured development lanes in order, immediately panel every fresh
+   cross-seat disagreement, resume the same lane after the panel lands, repeat
+   until a full pass lands nothing new, then run one forensic canary. Raise
+   toward 6 workers only in a quiet pool per the budget below.
+3. If the user names a lane, pass `--lane <name>`. Otherwise the orchestrator
+   iterates lanes from `docs/audit/data/lane_certification_config.json`,
+   selecting entries whose generated `lane_certification.json` record still
+   has blocking rows.
+
+Do not detach `orchestrate_audit_batch.py` as the whole `/audit-loop`
+campaign. A batch is one inner development-tier step and intentionally yields
+when cross-seat disagreement appears. Only `orchestrate_audit_loop.py` owns
+the automatic panel-and-resume edge; treating `judicial_panel_required` as a
+terminal campaign failure is an orchestration defect.
 
 The single-claim manual procedure later in this skill remains the special
 case for targeted rows; it is not the default.
@@ -254,7 +257,8 @@ least every 15 minutes — never silence for a long run.
 ## Scaling: The One Canonical Fan-Out
 
 There is exactly one sanctioned way to parallelize this lane — the
-repo-native batch drainer:
+repo-native batch drainer, invoked directly for a scoped inner step or by the
+top-level panel-aware orchestrator for the default backlog drain:
 
 ```bash
 python3 docs/audit/scripts/orchestrate_audit_batch.py \

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -216,7 +216,11 @@ default session is:
    drain configured development lanes in order, immediately panel every fresh
    cross-seat disagreement, resume the same lane after the panel lands, repeat
    until a full pass lands nothing new, then run one forensic canary. Raise
-   toward 6 workers only in a quiet pool per the budget below.
+   toward 6 workers only in a quiet pool per the budget below. The supervisor
+   holds the clone-wide audit lock for the complete campaign and hands that
+   lock to its batch/panel children. It runs the panel sweep after every batch
+   termination before propagating any unrelated hard batch failure, so a mixed
+   result cannot strand a valid judicial handoff.
 3. If the user names a lane, pass `--lane <name>`. Otherwise the orchestrator
    iterates lanes from `docs/audit/data/lane_certification_config.json`,
    selecting entries whose generated `lane_certification.json` record still

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -51,6 +51,7 @@ SUCCESS_RESULTS = {
     "audited_decoration", "audited_numerical_match", "audited_failed",
     "compute_required",
 }
+RESUMABLE_HANDOFF_RESULTS = {"judicial_panel_required"}
 MIN_DELIVERY_BYTES = 200
 PACKET_COMPLETION_STALL_SECONDS = 20 * 60
 PACKET_COMPLETION_POLL_SECONDS = 15
@@ -1282,8 +1283,21 @@ def main() -> int:
             encoding="utf-8",
         )
         print(f"report: {workdir / 'report.jsonl'}")
-    blocked = any(item.get("result") not in SUCCESS_RESULTS for item in report)
+    blocked = report_has_hard_blocker(report)
     return 1 if blocked else 0
+
+
+def report_has_hard_blocker(report: list[dict]) -> bool:
+    """Return true only for outcomes that cannot be resumed canonically.
+
+    A cross-seat disagreement is not a failed audit round. It is an explicit
+    handoff to ``orchestrate_judicial_panel.py``. The top-level audit-loop
+    orchestrator consumes that handoff immediately and then resumes the same
+    lane, so returning nonzero here would incorrectly collapse a normal
+    control-flow edge into a campaign stop.
+    """
+    accepted = SUCCESS_RESULTS | RESUMABLE_HANDOFF_RESULTS
+    return any(item.get("result") not in accepted for item in report)
 
 
 if __name__ == "__main__":

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -56,6 +56,7 @@ MIN_DELIVERY_BYTES = 200
 PACKET_COMPLETION_STALL_SECONDS = 20 * 60
 PACKET_COMPLETION_POLL_SECONDS = 15
 PACKET_COMPLETION_EXIT_GRACE_SECONDS = 10
+INHERITED_DRAIN_LOCK_FD_ENV = "AUDIT_DRAIN_LOCK_FD"
 
 
 def _repo_identity() -> str:
@@ -92,6 +93,19 @@ def acquire_exclusive_drain_lock(label: str):
     released automatically on process exit. Returns an open handle to keep
     referenced, or None when another orchestrator already holds it.
     """
+    inherited_fd = os.environ.get(INHERITED_DRAIN_LOCK_FD_ENV)
+    if inherited_fd:
+        try:
+            fd = int(inherited_fd)
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return os.fdopen(os.dup(fd), "w")
+        except (OSError, ValueError):
+            print(
+                "refusing to run: invalid inherited audit-lane lock fd "
+                f"for {label}"
+            )
+            return None
+
     key = hashlib.sha256(_repo_identity().encode("utf-8")).hexdigest()[:12]
     lock_path = Path(tempfile.gettempdir()) / f"audit-lane-{key}.lock"
     handle = open(lock_path, "w")
@@ -1254,23 +1268,13 @@ def main() -> int:
         # every remaining round and burns seats re-auditing an unchanged
         # claim toward the same outcome. Repair, not repetition, moves it.
         session_skipped.update(row["claim_id"] for row in batch)
-        if not applied_ok or launch_blocked:
-            break
+        current_rows = load_rows()
+        disagreements = append_judicial_handoffs(batch, current_rows, report)
         (workdir / "report.jsonl").write_text(
             "".join(json.dumps(item, sort_keys=True) + "\n" for item in report),
             encoding="utf-8",
         )
-
-        current_rows = load_rows()
-        disagreements = [
-            row["claim_id"]
-            for row in batch
-            if (current_rows.get(row["claim_id"], {}).get("cross_confirmation") or {}).get("status")
-            in {"disagreement", "three_way_disagreement", "disagreement_irresolvable"}
-        ]
-        if disagreements:
-            for cid in disagreements:
-                report.append({"cid": cid, "result": "judicial_panel_required"})
+        if disagreements or not applied_ok or launch_blocked:
             break
 
     print("== batch report ==")
@@ -1298,6 +1302,29 @@ def report_has_hard_blocker(report: list[dict]) -> bool:
     """
     accepted = SUCCESS_RESULTS | RESUMABLE_HANDOFF_RESULTS
     return any(item.get("result") not in accepted for item in report)
+
+
+def append_judicial_handoffs(
+    selected_rows: list[dict], current_rows: dict[str, dict], report: list[dict]
+) -> list[str]:
+    """Record every disagreement that became panel-eligible in this batch."""
+    existing = {
+        item.get("cid")
+        for item in report
+        if item.get("result") == "judicial_panel_required"
+    }
+    disagreements = [
+        row["claim_id"]
+        for row in selected_rows
+        if (current_rows.get(row["claim_id"], {}).get("cross_confirmation") or {}).get(
+            "status"
+        )
+        in {"disagreement", "three_way_disagreement", "disagreement_irresolvable"}
+    ]
+    for cid in disagreements:
+        if cid not in existing:
+            report.append({"cid": cid, "result": "judicial_panel_required"})
+    return disagreements
 
 
 if __name__ == "__main__":

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -21,8 +21,10 @@ import subprocess
 import sys
 import threading
 import time
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TextIO
 
 
 SCRIPTS = Path(__file__).resolve().parent
@@ -44,8 +46,14 @@ PROGRESS = {
     "phase": "startup",
     "pass": 0,
     "lane": None,
+    "attempts": 0,
+    "failures": [],
+    "panel_state": "not_started",
+    "canary_state": "not_started",
+    "baseline_status": {},
 }
 _STOP_HEARTBEAT = threading.Event()
+_DRAIN_LOCK_HANDLE: TextIO | None = None
 
 
 def emit(message: str) -> None:
@@ -53,15 +61,77 @@ def emit(message: str) -> None:
     print(f"[{now}] {message}", flush=True)
 
 
+def ready_row_count() -> int | None:
+    try:
+        payload = json.loads(QUEUE.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return sum(1 for row in payload.get("queue", []) if row.get("ready"))
+
+
+def remaining_blocker_count() -> int | None:
+    try:
+        payload = json.loads(CERTIFICATION.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    lanes = payload.get("lanes", payload) if isinstance(payload, dict) else payload
+    if isinstance(lanes, dict):
+        rows = lanes.values()
+    elif isinstance(lanes, list):
+        rows = lanes
+    else:
+        return None
+    return sum(
+        len(row.get("blocking", []) or [])
+        for row in rows
+        if isinstance(row, dict)
+    )
+
+
+def landed_verdict_counts() -> Counter:
+    baseline = PROGRESS.get("baseline_status") or {}
+    if not baseline:
+        return Counter()
+    try:
+        rows = batch.load_rows()
+    except (OSError, ValueError, json.JSONDecodeError):
+        return Counter()
+    return Counter(
+        str(row.get("audit_status"))
+        for cid, row in rows.items()
+        if row.get("audit_status") != baseline.get(cid)
+        and str(row.get("audit_status", "")).startswith("audited_")
+    )
+
+
+def summary_line(final: bool = False) -> str:
+    elapsed = int(time.monotonic() - PROGRESS["started"])
+    verdicts = landed_verdict_counts()
+    verdict_text = ",".join(
+        f"{name}:{count}" for name, count in verdicts.most_common()
+    ) or "none"
+    failures = Counter(PROGRESS.get("failures") or [])
+    failure_text = ",".join(
+        f"{reason}:{count}" for reason, count in failures.most_common(3)
+    ) or "none"
+    ready = ready_row_count()
+    blockers = remaining_blocker_count()
+    return (
+        f"== audit-loop {'final ' if final else ''}summary "
+        f"elapsed={elapsed // 3600}h{(elapsed % 3600) // 60:02d}m "
+        f"phase={PROGRESS['phase']} pass={PROGRESS['pass']} "
+        f"lane={PROGRESS['lane'] or '-'} attempts={PROGRESS['attempts']} "
+        f"failures={sum(failures.values())} top_failure_reasons={failure_text} "
+        f"verdicts_landed={verdict_text} panel_reseat={PROGRESS['panel_state']} "
+        f"canary={PROGRESS['canary_state']} "
+        f"ready_rows={ready if ready is not None else 'unknown'} "
+        f"remaining_lane_blockers={blockers if blockers is not None else 'unknown'}"
+    )
+
+
 def heartbeat() -> None:
     while not _STOP_HEARTBEAT.wait(15 * 60):
-        elapsed = int(time.monotonic() - PROGRESS["started"])
-        emit(
-            "== audit-loop summary "
-            f"elapsed={elapsed // 3600}h{(elapsed % 3600) // 60:02d}m "
-            f"phase={PROGRESS['phase']} pass={PROGRESS['pass']} "
-            f"lane={PROGRESS['lane'] or '-'}"
-        )
+        emit(summary_line())
 
 
 def git_head() -> str:
@@ -77,8 +147,32 @@ def git_head() -> str:
 
 def run_command(label: str, command: list[str], env: dict[str, str] | None = None) -> int:
     PROGRESS["phase"] = label
+    PROGRESS["attempts"] += 1
+    if label.startswith("panel-"):
+        PROGRESS["panel_state"] = f"running:{label}"
+    if label.startswith("forensic-canary-"):
+        PROGRESS["canary_state"] = f"running:{label}"
     emit(f"START {label}: {' '.join(command)}")
-    proc = subprocess.run(command, cwd=REPO_ROOT, env=env)
+    child_env = dict(os.environ) if env is None else dict(env)
+    pass_fds: tuple[int, ...] = ()
+    if _DRAIN_LOCK_HANDLE is not None:
+        lock_fd = _DRAIN_LOCK_HANDLE.fileno()
+        child_env[batch.INHERITED_DRAIN_LOCK_FD_ENV] = str(lock_fd)
+        pass_fds = (lock_fd,)
+    proc = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        env=child_env,
+        pass_fds=pass_fds,
+    )
+    if label.startswith("panel-"):
+        state = "complete" if proc.returncode == 0 else f"failed_exit_{proc.returncode}"
+        PROGRESS["panel_state"] = f"{state}:{label}"
+    if label.startswith("forensic-canary-"):
+        state = "complete" if proc.returncode == 0 else f"failed_exit_{proc.returncode}"
+        PROGRESS["canary_state"] = f"{state}:{label}"
+    if proc.returncode != 0:
+        PROGRESS["failures"].append(f"{label}:exit={proc.returncode}")
     emit(f"END {label}: exit={proc.returncode} head={git_head()}")
     return proc.returncode
 
@@ -98,14 +192,24 @@ def _lane_names(payload: object) -> list[str]:
     return []
 
 
+def configured_lane_names() -> list[str]:
+    return _lane_names(json.loads(CONFIG.read_text(encoding="utf-8")))
+
+
+def validate_requested_lanes(requested: list[str] | None) -> None:
+    if not requested:
+        return
+    known = configured_lane_names()
+    unknown = [name for name in requested if name not in known]
+    if unknown:
+        raise ValueError(f"unknown lane(s): {', '.join(unknown)}")
+
+
 def blocking_lanes(requested: list[str] | None = None) -> list[tuple[str, int]]:
-    config = json.loads(CONFIG.read_text(encoding="utf-8"))
     certification = json.loads(CERTIFICATION.read_text(encoding="utf-8"))
-    names = _lane_names(config)
+    names = configured_lane_names()
     if requested:
-        unknown = [name for name in requested if name not in names]
-        if unknown:
-            raise ValueError(f"unknown lane(s): {', '.join(unknown)}")
+        validate_requested_lanes(requested)
         names = [name for name in names if name in requested]
     cert_lanes = (
         certification.get("lanes", certification)
@@ -182,17 +286,19 @@ def drain_lane(lane: str, args: argparse.Namespace) -> tuple[int, bool]:
             emit(f"STOP lane cycle safety bound reached: lane={lane}")
             return 4, made_progress
         before = git_head()
-        rc = run_command(
+        batch_rc = run_command(
             f"batch-{lane}-cycle-{cycle}",
             batch_command(lane, args),
         )
-        if rc != 0:
-            return rc, made_progress
-        # This is intentionally unconditional: a no-target panel is cheap,
-        # while missing a newly recorded disagreement stops the whole lane.
-        rc = run_panel(args, f"panel-after-{lane}-cycle-{cycle}")
-        if rc != 0:
-            return rc, made_progress
+        # This is intentionally unconditional, including after a hard batch
+        # result: another row in the same batch may already have recorded a
+        # panel-eligible disagreement. Preserve the hard result only after the
+        # judicial sweep has consumed every resumable handoff.
+        panel_rc = run_panel(args, f"panel-after-{lane}-cycle-{cycle}")
+        if panel_rc != 0:
+            return panel_rc, made_progress
+        if batch_rc != 0:
+            return batch_rc, made_progress
         after = git_head()
         if after == before:
             return 0, made_progress
@@ -209,7 +315,7 @@ def first_ready_forensic_claim() -> str | None:
         if (
             row.get("ready")
             and row.get("audit_status") in {"unaudited", "audit_in_progress"}
-            and row.get("claim_type") == "no_go"
+            and batch.source_requires_forensic(row)
         ):
             claim_id = row.get("claim_id")
             if isinstance(claim_id, str) and claim_id:
@@ -220,7 +326,7 @@ def first_ready_forensic_claim() -> str | None:
 def run_forensic_canary(args: argparse.Namespace) -> int:
     claim_id = first_ready_forensic_claim()
     if not claim_id:
-        emit("no ready no_go row available for the forensic canary")
+        emit("no ready forensic-tier row available for the forensic canary")
         return 0
     command = [
         sys.executable,
@@ -274,6 +380,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    global _DRAIN_LOCK_HANDLE
     args = build_parser().parse_args(argv)
     positive = (
         args.max_workers,
@@ -287,16 +394,42 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("worker, round, timeout, and retry values must be positive")
     if args.max_passes < 0 or args.max_lane_cycles < 0:
         raise SystemExit("pass and cycle safety bounds must be non-negative")
+    try:
+        validate_requested_lanes(args.lane)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        emit(str(exc))
+        return 2
     if not args.dry_run:
+        _DRAIN_LOCK_HANDLE = batch.acquire_exclusive_drain_lock(
+            "orchestrate_audit_loop"
+        )
+        if _DRAIN_LOCK_HANDLE is None:
+            return 3
         error = batch.clean_main_error()
         if error:
             emit(f"refusing to run: {error}. Use a dedicated clean main checkout.")
+            _DRAIN_LOCK_HANDLE.close()
+            _DRAIN_LOCK_HANDLE = None
             return 2
         ok, detail = batch.sync_origin_main()
         if not ok:
             emit(f"refusing to run: {detail}")
+            _DRAIN_LOCK_HANDLE.close()
+            _DRAIN_LOCK_HANDLE = None
             return 2
 
+    try:
+        PROGRESS["baseline_status"] = {
+            cid: row.get("audit_status") for cid, row in batch.load_rows().items()
+        }
+    except (OSError, ValueError, json.JSONDecodeError):
+        PROGRESS["baseline_status"] = {}
+    PROGRESS["started"] = time.monotonic()
+    PROGRESS["attempts"] = 0
+    PROGRESS["failures"] = []
+    PROGRESS["panel_state"] = "not_started"
+    PROGRESS["canary_state"] = "not_started"
+    _STOP_HEARTBEAT.clear()
     thread = threading.Thread(target=heartbeat, daemon=True)
     thread.start()
     try:
@@ -336,11 +469,10 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     finally:
         _STOP_HEARTBEAT.set()
-        elapsed = int(time.monotonic() - PROGRESS["started"])
-        emit(
-            "== audit-loop final summary "
-            f"elapsed={elapsed // 3600}h{(elapsed % 3600) // 60:02d}m"
-        )
+        emit(summary_line(final=True))
+        if _DRAIN_LOCK_HANDLE is not None:
+            _DRAIN_LOCK_HANDLE.close()
+            _DRAIN_LOCK_HANDLE = None
 
 
 if __name__ == "__main__":

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Canonical panel-aware backlog orchestrator for the audit lane.
+
+The batch drainer deliberately stops a batch when fresh cross-seat
+disagreement appears. This supervisor owns the missing control-flow edge:
+
+    panel pending work -> drain lane -> panel new disagreement -> resume lane
+
+It repeats configured lanes until a complete pass lands no commits, then runs
+one forensic no-go canary unless explicitly disabled. Auditor fan-out remains
+inside the existing batch and judicial orchestrators; this process never
+authors or edits verdict content.
+"""
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPTS.parents[2]
+DATA = REPO_ROOT / "docs" / "audit" / "data"
+PANEL = SCRIPTS / "orchestrate_judicial_panel.py"
+BATCH = SCRIPTS / "orchestrate_audit_batch.py"
+FORENSIC = REPO_ROOT / "scripts" / "codex_audit_runner.py"
+CONFIG = DATA / "lane_certification_config.json"
+CERTIFICATION = DATA / "lane_certification.json"
+QUEUE = DATA / "audit_queue.json"
+
+sys.path.insert(0, str(SCRIPTS))
+import orchestrate_audit_batch as batch  # noqa: E402
+
+
+PROGRESS = {
+    "started": time.monotonic(),
+    "phase": "startup",
+    "pass": 0,
+    "lane": None,
+}
+_STOP_HEARTBEAT = threading.Event()
+
+
+def emit(message: str) -> None:
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    print(f"[{now}] {message}", flush=True)
+
+
+def heartbeat() -> None:
+    while not _STOP_HEARTBEAT.wait(15 * 60):
+        elapsed = int(time.monotonic() - PROGRESS["started"])
+        emit(
+            "== audit-loop summary "
+            f"elapsed={elapsed // 3600}h{(elapsed % 3600) // 60:02d}m "
+            f"phase={PROGRESS['phase']} pass={PROGRESS['pass']} "
+            f"lane={PROGRESS['lane'] or '-'}"
+        )
+
+
+def git_head() -> str:
+    proc = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return proc.stdout.strip()
+
+
+def run_command(label: str, command: list[str], env: dict[str, str] | None = None) -> int:
+    PROGRESS["phase"] = label
+    emit(f"START {label}: {' '.join(command)}")
+    proc = subprocess.run(command, cwd=REPO_ROOT, env=env)
+    emit(f"END {label}: exit={proc.returncode} head={git_head()}")
+    return proc.returncode
+
+
+def _lane_names(payload: object) -> list[str]:
+    lanes = payload.get("lanes", payload) if isinstance(payload, dict) else payload
+    if isinstance(lanes, dict):
+        return list(lanes)
+    if isinstance(lanes, list):
+        return [
+            name
+            for entry in lanes
+            if isinstance(entry, dict)
+            for name in [entry.get("name") or entry.get("lane")]
+            if isinstance(name, str) and name
+        ]
+    return []
+
+
+def blocking_lanes(requested: list[str] | None = None) -> list[tuple[str, int]]:
+    config = json.loads(CONFIG.read_text(encoding="utf-8"))
+    certification = json.loads(CERTIFICATION.read_text(encoding="utf-8"))
+    names = _lane_names(config)
+    if requested:
+        unknown = [name for name in requested if name not in names]
+        if unknown:
+            raise ValueError(f"unknown lane(s): {', '.join(unknown)}")
+        names = [name for name in names if name in requested]
+    cert_lanes = (
+        certification.get("lanes", certification)
+        if isinstance(certification, dict)
+        else certification
+    )
+    result: list[tuple[str, int]] = []
+    for name in names:
+        if isinstance(cert_lanes, dict):
+            row = cert_lanes.get(name, {})
+        else:
+            row = next(
+                (
+                    entry
+                    for entry in cert_lanes
+                    if isinstance(entry, dict)
+                    and (entry.get("name") or entry.get("lane")) == name
+                ),
+                {},
+            )
+        blockers = row.get("blocking", []) or []
+        if blockers:
+            result.append((name, len(blockers)))
+    return result
+
+
+def panel_command(args: argparse.Namespace) -> list[str]:
+    command = [
+        sys.executable,
+        str(PANEL),
+        "--stall-minutes",
+        str(args.stall_minutes),
+        "--runner-timeout-sec",
+        str(args.runner_timeout_sec),
+        "--push-retries",
+        str(args.push_retries),
+    ]
+    if args.dry_run:
+        command.append("--dry-run")
+    return command
+
+
+def batch_command(lane: str, args: argparse.Namespace) -> list[str]:
+    command = [
+        sys.executable,
+        str(BATCH),
+        "--lane",
+        lane,
+        "--max-workers",
+        str(args.max_workers),
+        "--rounds",
+        str(args.batch_rounds),
+        "--stall-minutes",
+        str(args.stall_minutes),
+        "--runner-timeout-sec",
+        str(args.runner_timeout_sec),
+        "--push-retries",
+        str(args.push_retries),
+    ]
+    if args.dry_run:
+        command.append("--dry-run")
+    return command
+
+
+def run_panel(args: argparse.Namespace, label: str) -> int:
+    return run_command(label, panel_command(args))
+
+
+def drain_lane(lane: str, args: argparse.Namespace) -> tuple[int, bool]:
+    """Drain one lane, paneling after every batch before deciding to stop."""
+    made_progress = False
+    for cycle in itertools.count(1):
+        if args.max_lane_cycles and cycle > args.max_lane_cycles:
+            emit(f"STOP lane cycle safety bound reached: lane={lane}")
+            return 4, made_progress
+        before = git_head()
+        rc = run_command(
+            f"batch-{lane}-cycle-{cycle}",
+            batch_command(lane, args),
+        )
+        if rc != 0:
+            return rc, made_progress
+        # This is intentionally unconditional: a no-target panel is cheap,
+        # while missing a newly recorded disagreement stops the whole lane.
+        rc = run_panel(args, f"panel-after-{lane}-cycle-{cycle}")
+        if rc != 0:
+            return rc, made_progress
+        after = git_head()
+        if after == before:
+            return 0, made_progress
+        made_progress = True
+        if args.dry_run:
+            return 0, made_progress
+
+
+def first_ready_forensic_claim() -> str | None:
+    if not QUEUE.exists():
+        return None
+    rows = json.loads(QUEUE.read_text(encoding="utf-8")).get("queue", [])
+    for row in rows:
+        if (
+            row.get("ready")
+            and row.get("audit_status") in {"unaudited", "audit_in_progress"}
+            and row.get("claim_type") == "no_go"
+        ):
+            claim_id = row.get("claim_id")
+            if isinstance(claim_id, str) and claim_id:
+                return claim_id
+    return None
+
+
+def run_forensic_canary(args: argparse.Namespace) -> int:
+    claim_id = first_ready_forensic_claim()
+    if not claim_id:
+        emit("no ready no_go row available for the forensic canary")
+        return 0
+    command = [
+        sys.executable,
+        str(FORENSIC),
+        "--claim-id",
+        claim_id,
+        "--push-mode",
+        "none" if args.dry_run else "per-verdict",
+        "--codex-timeout-sec",
+        str(args.codex_timeout_sec),
+        "--runner-timeout-sec",
+        str(args.runner_timeout_sec),
+        "--validation-repair-attempts",
+        "1",
+        "--fresh-schema-retry-attempts",
+        "2",
+    ]
+    if args.dry_run:
+        command.append("--dry-run")
+    env = dict(os.environ)
+    env["AUDIT_FORENSIC_MODE"] = "1"
+    return run_command(f"forensic-canary-{claim_id}", command, env=env)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Panel-aware end-to-end audit backlog drainer"
+    )
+    parser.add_argument("--lane", action="append", help="limit to a configured lane")
+    parser.add_argument("--max-workers", type=int, default=4)
+    parser.add_argument(
+        "--max-passes",
+        type=int,
+        default=0,
+        help="full-pass safety bound; 0 drains to a fixed point (default)",
+    )
+    parser.add_argument(
+        "--max-lane-cycles",
+        type=int,
+        default=0,
+        help="per-lane batch/panel safety bound; 0 drains to a fixed point (default)",
+    )
+    parser.add_argument("--batch-rounds", type=int, default=6)
+    parser.add_argument("--stall-minutes", type=int, default=45)
+    parser.add_argument("--runner-timeout-sec", type=int, default=120)
+    parser.add_argument("--codex-timeout-sec", type=int, default=2700)
+    parser.add_argument("--push-retries", type=int, default=3)
+    parser.add_argument("--skip-forensic-canary", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    positive = (
+        args.max_workers,
+        args.batch_rounds,
+        args.stall_minutes,
+        args.runner_timeout_sec,
+        args.codex_timeout_sec,
+        args.push_retries,
+    )
+    if any(value < 1 for value in positive):
+        raise SystemExit("worker, round, timeout, and retry values must be positive")
+    if args.max_passes < 0 or args.max_lane_cycles < 0:
+        raise SystemExit("pass and cycle safety bounds must be non-negative")
+    if not args.dry_run:
+        error = batch.clean_main_error()
+        if error:
+            emit(f"refusing to run: {error}. Use a dedicated clean main checkout.")
+            return 2
+        ok, detail = batch.sync_origin_main()
+        if not ok:
+            emit(f"refusing to run: {detail}")
+            return 2
+
+    thread = threading.Thread(target=heartbeat, daemon=True)
+    thread.start()
+    try:
+        for pass_number in itertools.count(1):
+            if args.max_passes and pass_number > args.max_passes:
+                emit("STOP pass safety bound reached")
+                return 4
+            PROGRESS["pass"] = pass_number
+            PROGRESS["lane"] = None
+            before = git_head()
+            rc = run_panel(args, f"panel-pass-{pass_number}-opening")
+            if rc != 0:
+                return rc
+            try:
+                lanes = blocking_lanes(args.lane)
+            except ValueError as exc:
+                emit(str(exc))
+                return 2
+            emit(
+                "blocking lanes: "
+                + (", ".join(f"{lane}={count}" for lane, count in lanes) or "none")
+            )
+            for lane, count in lanes:
+                PROGRESS["lane"] = lane
+                emit(f"draining lane={lane} blockers_at_selection={count}")
+                rc, _ = drain_lane(lane, args)
+                if rc != 0:
+                    return rc
+            after = git_head()
+            emit(f"development pass {pass_number}: before={before} after={after}")
+            if after == before:
+                emit("development fixed point reached: full pass landed nothing new")
+                break
+
+        if not args.skip_forensic_canary:
+            return run_forensic_canary(args)
+        return 0
+    finally:
+        _STOP_HEARTBEAT.set()
+        elapsed = int(time.monotonic() - PROGRESS["started"])
+        emit(
+            "== audit-loop final summary "
+            f"elapsed={elapsed // 3600}h{(elapsed % 3600) // 60:02d}m"
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -88,19 +88,29 @@ def remaining_blocker_count() -> int | None:
     )
 
 
+def audit_status_snapshot() -> dict[str, str | None]:
+    """Read the materialized ledger without refreshing or rewriting caches."""
+    ledger_cache = DATA / "audit_ledger.json"
+    try:
+        payload = json.loads(ledger_cache.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return {
+        cid: row.get("audit_status")
+        for cid, row in payload.get("rows", {}).items()
+        if isinstance(row, dict)
+    }
+
+
 def landed_verdict_counts() -> Counter:
     baseline = PROGRESS.get("baseline_status") or {}
     if not baseline:
         return Counter()
-    try:
-        rows = batch.load_rows()
-    except (OSError, ValueError, json.JSONDecodeError):
-        return Counter()
+    current = audit_status_snapshot()
     return Counter(
-        str(row.get("audit_status"))
-        for cid, row in rows.items()
-        if row.get("audit_status") != baseline.get(cid)
-        and str(row.get("audit_status", "")).startswith("audited_")
+        str(status)
+        for cid, status in current.items()
+        if status != baseline.get(cid) and str(status or "").startswith("audited_")
     )
 
 
@@ -418,12 +428,7 @@ def main(argv: list[str] | None = None) -> int:
             _DRAIN_LOCK_HANDLE = None
             return 2
 
-    try:
-        PROGRESS["baseline_status"] = {
-            cid: row.get("audit_status") for cid, row in batch.load_rows().items()
-        }
-    except (OSError, ValueError, json.JSONDecodeError):
-        PROGRESS["baseline_status"] = {}
+    PROGRESS["baseline_status"] = audit_status_snapshot()
     PROGRESS["started"] = time.monotonic()
     PROGRESS["attempts"] = 0
     PROGRESS["failures"] = []

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -38,6 +41,21 @@ class BatchExitSemanticsTest(unittest.TestCase):
         report = [{"cid": "row", "result": "validation_failed"}]
         self.assertTrue(batch.report_has_hard_blocker(report))
 
+    def test_mixed_failure_records_the_judicial_handoff(self):
+        report = [{"cid": "broken", "result": "validation_failed"}]
+        selected = [{"claim_id": "disputed"}]
+        current = {
+            "disputed": {"cross_confirmation": {"status": "disagreement"}}
+        }
+
+        disagreements = batch.append_judicial_handoffs(selected, current, report)
+
+        self.assertEqual(disagreements, ["disputed"])
+        self.assertIn(
+            {"cid": "disputed", "result": "judicial_panel_required"}, report
+        )
+        self.assertTrue(batch.report_has_hard_blocker(report))
+
 
 class AutomaticPanelResumeTest(unittest.TestCase):
     def test_disagreement_batch_is_panelled_then_same_lane_resumes(self):
@@ -67,13 +85,13 @@ class AutomaticPanelResumeTest(unittest.TestCase):
             ],
         )
 
-    def test_batch_hard_failure_stops_before_panel(self):
+    def test_batch_hard_failure_panels_before_stopping(self):
         args = _args()
         labels: list[str] = []
 
         def fake_run(label, command, env=None):
             labels.append(label)
-            return 1
+            return 1 if label.startswith("batch-") else 0
 
         with mock.patch.object(audit_loop, "git_head", return_value="h0"), \
              mock.patch.object(audit_loop, "run_command", side_effect=fake_run):
@@ -81,7 +99,66 @@ class AutomaticPanelResumeTest(unittest.TestCase):
 
         self.assertEqual(rc, 1)
         self.assertFalse(progressed)
-        self.assertEqual(labels, ["batch-lane_a-cycle-1"])
+        self.assertEqual(
+            labels,
+            ["batch-lane_a-cycle-1", "panel-after-lane_a-cycle-1"],
+        )
+
+
+class CampaignContractTest(unittest.TestCase):
+    def test_inherited_campaign_lock_is_reentrant_for_child(self):
+        held = batch.acquire_exclusive_drain_lock("top-level-test")
+        self.assertIsNotNone(held)
+        try:
+            with mock.patch.dict(
+                os.environ,
+                {batch.INHERITED_DRAIN_LOCK_FD_ENV: str(held.fileno())},
+            ):
+                inherited = batch.acquire_exclusive_drain_lock("child-test")
+            self.assertIsNotNone(inherited)
+            inherited.close()
+        finally:
+            held.close()
+
+    def test_forensic_selector_uses_canonical_source_predicate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            queue = Path(tmp) / "queue.json"
+            queue.write_text(
+                json.dumps(
+                    {
+                        "queue": [
+                            {
+                                "claim_id": "bounded_obstruction",
+                                "ready": True,
+                                "audit_status": "unaudited",
+                                "claim_type": "bounded_theorem",
+                                "note_path": "docs/EXAMPLE_OBSTRUCTION_NOTE.md",
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch.object(audit_loop, "QUEUE", queue), mock.patch.object(
+                batch, "source_requires_forensic", return_value=True
+            ):
+                selected = audit_loop.first_ready_forensic_claim()
+        self.assertEqual(selected, "bounded_obstruction")
+
+    def test_unknown_lane_fails_before_opening_panel(self):
+        with mock.patch.object(
+            audit_loop, "configured_lane_names", return_value=["lane_a"]
+        ), mock.patch.object(audit_loop, "run_panel") as run_panel:
+            rc = audit_loop.main(
+                [
+                    "--dry-run",
+                    "--skip-forensic-canary",
+                    "--lane",
+                    "definitely_unknown",
+                ]
+            )
+        self.assertEqual(rc, 2)
+        run_panel.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -160,6 +160,18 @@ class CampaignContractTest(unittest.TestCase):
         self.assertEqual(rc, 2)
         run_panel.assert_not_called()
 
+    def test_verdict_summary_never_rematerializes_ledger_cache(self):
+        with mock.patch.object(
+            audit_loop, "audit_status_snapshot", return_value={"row": "audited_clean"}
+        ), mock.patch.object(batch, "load_rows") as load_rows:
+            with mock.patch.dict(
+                audit_loop.PROGRESS,
+                {"baseline_status": {"row": "audit_in_progress"}},
+            ):
+                counts = audit_loop.landed_verdict_counts()
+        self.assertEqual(counts["audited_clean"], 1)
+        load_rows.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -1,0 +1,88 @@
+"""Panel-aware top-level audit-loop orchestration."""
+from __future__ import annotations
+
+import argparse
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import orchestrate_audit_batch as batch
+import orchestrate_audit_loop as audit_loop
+
+
+def _args() -> argparse.Namespace:
+    return argparse.Namespace(
+        lane=None,
+        max_workers=4,
+        max_passes=0,
+        max_lane_cycles=0,
+        batch_rounds=6,
+        stall_minutes=45,
+        runner_timeout_sec=120,
+        codex_timeout_sec=2700,
+        push_retries=3,
+        skip_forensic_canary=True,
+        dry_run=False,
+    )
+
+
+class BatchExitSemanticsTest(unittest.TestCase):
+    def test_judicial_handoff_is_resumable(self):
+        report = [{"cid": "row", "result": "judicial_panel_required"}]
+        self.assertFalse(batch.report_has_hard_blocker(report))
+
+    def test_validation_failure_remains_hard(self):
+        report = [{"cid": "row", "result": "validation_failed"}]
+        self.assertTrue(batch.report_has_hard_blocker(report))
+
+
+class AutomaticPanelResumeTest(unittest.TestCase):
+    def test_disagreement_batch_is_panelled_then_same_lane_resumes(self):
+        args = _args()
+        # cycle 1 lands the disagreement/panel resolution; cycle 2 reaches
+        # the lane fixed point. drain_lane reads HEAD before/after each cycle.
+        heads = iter(["h0", "h1", "h1", "h1"])
+        labels: list[str] = []
+
+        def fake_run(label, command, env=None):
+            labels.append(label)
+            return 0
+
+        with mock.patch.object(audit_loop, "git_head", side_effect=lambda: next(heads)), \
+             mock.patch.object(audit_loop, "run_command", side_effect=fake_run):
+            rc, progressed = audit_loop.drain_lane("lane_a", args)
+
+        self.assertEqual(rc, 0)
+        self.assertTrue(progressed)
+        self.assertEqual(
+            labels,
+            [
+                "batch-lane_a-cycle-1",
+                "panel-after-lane_a-cycle-1",
+                "batch-lane_a-cycle-2",
+                "panel-after-lane_a-cycle-2",
+            ],
+        )
+
+    def test_batch_hard_failure_stops_before_panel(self):
+        args = _args()
+        labels: list[str] = []
+
+        def fake_run(label, command, env=None):
+            labels.append(label)
+            return 1
+
+        with mock.patch.object(audit_loop, "git_head", return_value="h0"), \
+             mock.patch.object(audit_loop, "run_command", side_effect=fake_run):
+            rc, progressed = audit_loop.drain_lane("lane_a", args)
+
+        self.assertEqual(rc, 1)
+        self.assertFalse(progressed)
+        self.assertEqual(labels, ["batch-lane_a-cycle-1"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
- add a canonical top-level audit-loop orchestrator
- treat `judicial_panel_required` as a resumable handoff, not a hard batch failure
- panel immediately after each development batch and resume the same lane
- drain configured lanes to a real fixed point before the forensic canary
- add regression coverage for handoff and hard-failure semantics

## Why
Cross-seat disagreement is expected control flow for critical audit rows. The batch layer correctly recorded the disagreement but returned nonzero, so detached campaign supervisors interpreted the handoff as a terminal failure and stopped instead of invoking the judicial panel.

## Impact
The audit loop now owns the complete batch → panel → resume transition. Verdict semantics, seat independence, and judicial ratification logic are unchanged.

## Checks
- focused audit-loop regression tests
- existing drain-lock, progress-summary, and judicial-reseat tests
- Python bytecode compilation
- vocabulary lint
- full audit pipeline
- strict audit lint (zero errors; pre-existing warnings only)
- `git diff --check`