### PR TITLE
feat(kcpt): bulk-block eigenvalue stratification with adjacency-native complex structure

### DIFF
--- a/docs/KCPT_BULK_BLOCK_EIGENVALUE_STRATIFICATION_ADJACENCY_NATIVE_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-19.md
+++ b/docs/KCPT_BULK_BLOCK_EIGENVALUE_STRATIFICATION_ADJACENCY_NATIVE_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-19.md
@@ -1,0 +1,85 @@
+# KCPT bulk-block eigenvalue stratification: Hamming shells, the ker-pi carrier, and adjacency-native complex structures
+
+Date: 2026-07-19
+
+**Type:** bounded_theorem
+
+**Claim boundary:** This is a bounded theorem on one fixed finite surface — the full `4^3` staggered lattice `C^64`, its bulk operator `M = D2 @ D2`, and the eigenvalue strata into which `M` resolves — established with exact integer and exact symbolic arithmetic only, with no floating point in any load-bearing gate. It stratifies the image block of [the ambient isolation note](KCPT_AMBIENT_LATTICE_SYMMETRY_KERNEL_ISOLATION_AVERAGED_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-19.md) into its Hamming shells, resolves each shell's ambient commutant by exact character sums, and exhibits the adjacency-native antisymmetric operators the shells carry. It fixes no free parameter, it selects no orientation, it chooses no dynamics, and it forces nothing pre-record; the paired runner recomputes every gated quantity from the construction rather than reading any value back.
+
+## Setting
+
+The surface is the one built in [the corner-carrier delivery note](KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md): the staggered `4^3` Dirac graph with phases `eta_1 = 1`, `eta_2(x) = (-1)^{x_1}`, `eta_3(x) = (-1)^{x_1 + x_2}`, whose antisymmetric integer adjacency `D2` carries an eight-dimensional kernel spanned by the corner waves `V8`. The delivery note records that this carrier is graded by Hamming weight as `1 + 3 + 3 + 1`, and states of `D2` that "its exact rank is `56`", so the kernel dimension is eight. The symmetry inputs are the lattice symmetries of [the minimal-axioms note](MINIMAL_AXIOMS_2026-06-29.md), the "standard translations, and proper cubic rotations", dressed by the staggered sign fields.
+
+[The ambient isolation note](KCPT_AMBIENT_LATTICE_SYMMETRY_KERNEL_ISOLATION_AVERAGED_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-19.md) assembles those dressed symmetries into the ambient group `G_amb` of order `768` — the `D2`-commuting closure of three named base classes — and resolves the whole-lattice commutant as `dim_C End_{G_amb}(C^64) = 12`, splitting it by kernel and image blocks as "`12 = 2 + 2*0 + 10`: two dimensions on the kernel block ... ten on the image block; and each of the two kernel-image cross terms exactly zero", with the translation-only control `64 = 8 + 2*0 + 56`. The present note stratifies that image block. [The kernel note](KCPT_KERNEL_INDUCED_REPRESENTATION_CENTRAL_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-18.md) and [the kernel K-real note](KCPT_KERNEL_KREAL_READOUT_FACE_CLASSIFICATION_BOUNDED_THEOREM_NOTE_2026-07-18.md) supply the kernel-block reading — the central complex structure `j` whose "exact commutant of `G` over the rationals is two-dimensional, `span{I, j}`", and the orientation-blind invariant Hermitian face — which reappears here as the `m = 0` shell.
+
+The motivating question is what the ambient note's ten on the image block is made of. The bulk operator `M = D2 @ D2` is symmetric and commutes with every ambient member, so the ambient commutant on the image block distributes across the eigenvalue strata of `M`. Those strata turn out to be Hamming shells of a momentum label. This note resolves that distribution shell by shell and reads the antisymmetric content each shell carries. The bounded theorem has five parts.
+
+## T1 — the ker-pi carrier and its eigenvalue stratification
+
+The bulk operator is symmetric, `M = M^T`, because `D2` is antisymmetric. It is carried entirely by the even-translation subgroup: exactly `M = 2 (T_200 + T_020 + T_002) - 6 I`, where `T_2e` is the translation by two sites along axis `e`. So `M` lies in the group algebra of the elementary abelian `(Z/2)^3` of even translations and commutes with every one of its eight members — the `ker pi` carrier the ambient note names as the kernel of the compression onto `G`. Two rejectors pin the identity: the diagonal coefficient is `-6` and not `-5`, and the shifts are the even translations `T_200` and not the odd `T_100`.
+
+The minimal polynomial factors exactly as `M (M + 4 I)(M + 8 I)(M + 12 I) = 0`, so `M` has four eigenvalue strata `lambda_m = -4 m` for `m = 0, 1, 2, 3`. The drop-one products `Q_m = prod_{m' != m}(M - lambda_{m'} I)` are the (unnormalized) stratum projectors, with integer normalizers `N_m = prod_{m' != m}(lambda_m - lambda_{m'}) = (384, -128, 128, -384)`. They satisfy `M Q_m = lambda_m Q_m`, the scaled idempotence `Q_m^2 = N_m Q_m`, mutual orthogonality `Q_m Q_{m'} = 0` for `m != m'`, and the pinned partition of unity `Q_0 - 3 Q_1 + 3 Q_2 - Q_3 = 384 I`. Each `Q_m` is real symmetric, and its entries are bounded integers, the stratum projector carried at exact integer scale.
+
+The stratum dimensions are computed from `tr Q_m / N_m = (8, 24, 24, 8)`, not assumed. The kernel shell coincides with the corner frame, `Q_0 = 6 (V8 V8^T)`, recovering the eight-dimensional kernel of the Setting. The three bulk shells have exact ranks summing to `24 + 24 + 8 = 56`, the rank of `D2`, so the image block `56 = 24 + 24 + 8` is exactly the `m = 1, 2, 3` stratification and the kernel `8` is the `m = 0` shell.
+
+## T2 — momentum diagonalization and the K-geometry
+
+The strata are Hamming shells of a momentum label. For `k` in `(Z/4)^3` the wave `phi_k = i^{k . x}`, taken in split integer real and imaginary parts, is an `M`-eigenvector at `lambda = -4 m(k)`, where `m(k)` is the number of odd components of `k`. A wrong-eigenvalue rejector confirms `M phi_{(1,0,0)} = -4 phi_{(1,0,0)}`, neither zero nor `-8 phi`. The per-shell momentum counts are `(8, 24, 24, 8)`, matching the stratum dimensions exactly: the four Hamming weights of the momentum label enumerate the four eigenvalue strata.
+
+The involution `K : k -> -k (mod 4)` preserves every shell, `m(-k) = m(k)`. It fixes exactly the eight kernel momenta — the components in `{0, 2}` that are their own negatives mod `4` — and every fixed momentum has `m = 0`. On the fifty-six bulk momenta `K` is fixed-point-free, partitioning them into twenty-eight conjugate pairs. So the kernel shell is the `K`-fixed locus and the bulk is `K`-paired, the momentum-side image of the same conjugation the kernel notes read entrywise.
+
+## T3 — the ker-pi isotypic blocks and the ambient orbit structure
+
+The even-translation carrier `(Z/2)^3` has eight characters `eps` in `{0, 1}^3`. Its isotypic idempotent pieces are the integer matrices `R8_eps = sum_{b in {0,1}^3} (-1)^{eps . b} T_{2b}`, one per character. Each eigenvalue stratum is the sum of the characters of its Hamming weight: exactly `8 Q_m = N_m sum_{wt(eps) = m} R8_eps` for every `m`. A wrong-weight rejector confirms the pairing is by weight — `8 Q_1` is not `N_1 sum_{wt(eps) = 2} R8_eps`. So the four strata are the four Hamming-weight isotypic sectors of the `ker pi` carrier, and the stratum dimensions `(8, 24, 24, 8)` are the binomial multiplicities `1, 3, 3, 1` each carried on an eight-dimensional character block.
+
+Regenerating the ambient group `G_amb` independently — scanning the three dressed base classes over the sixty-four sign fields and sixty-four translations, keeping the `192` members that commute with `D2`, and closing to order `768` — every member commutes with `M` and hence with every `Q_m`, since each `Q_m` is a polynomial in `M`. Conjugation by `G_amb` permutes the eight `R8_eps` blocks by permuting the parity axes, and this permutation preserves Hamming weight, so the block orbits are exactly the weight classes, with sizes `1, 3, 3, 1`. The ambient group moves blocks only within a shell; it never mixes shells.
+
+## T4 — the bulk commutant resolution and its Frobenius-Schur split
+
+Exact character sums over the regenerated `768` members resolve each shell's ambient commutant. With `e_m = (1 / (768 N_m^2)) sum_{U in G_amb} tr(U Q_m)^2` computed as an exact rational and gated to be an integer, the per-shell commutant dimensions are `e_m = (2, 4, 4, 2)`, and every cross term `h_{m,m'} = (1 / (768 N_m N_{m'})) sum_U tr(U Q_m) tr(U Q_{m'})` vanishes, so the strata share no equivariant map. The ambient note's ten on the image block resolves across the three bulk shells as `10 = 4 + 4 + 2`, while the kernel shell keeps `e_0 = 2`, matching `span{I, j}`. The reconciliation `sum_m e_m + 2 sum_{m < m'} h_{m,m'} = 12` returns the ambient total. A group-is-load-bearing rejector confirms the resolution needs the full group: restricted to the eight `ker pi` translations alone the same sum gives `e_1 = 192`, not `4`.
+
+The Frobenius-Schur indicators, `nu_m = (1 / (768 N_m)) sum_U tr(U^2 Q_m)` gated integer, are `nu_m = (0, 2, 0, 0)`. They split each commutant into its invariant antisymmetric and invariant symmetric parts, `a_m = (e_m - nu_m) / 2 = (1, 1, 2, 1)` and `s_m = (e_m + nu_m) / 2 = (1, 3, 2, 1)`, with `a_m + s_m = e_m` and `s_m - a_m = nu_m` on every shell. The combination `nu_m = s_m - a_m` records how each shell's invariant forms split: the kernel shell and shells `2`, `3` are balanced (`nu = 0`, equal symmetric and antisymmetric invariants), while shell `1` is symmetric-heavy (`nu_1 = 2`, three symmetric invariants to one antisymmetric). Every shell carries at least one invariant antisymmetric direction, and shell `2` carries two.
+
+## T5 — adjacency-native complex structures and per-mode registration
+
+Because `D2` is a polynomial-commuting square root of `M`, the products `D2 Q_m` are ambient-invariant and antisymmetric, and they square inside their shell: exactly `(D2 Q_m)^2 = -4 m N_m Q_m` for every `m`. On the kernel shell this vanishes, `D2 Q_0 = 0` — the adjacency has no action where it has no eigenvalue. Writing the shell idempotent as `P_m = Q_m / N_m`, the square is `(D2 Q_m)^2 = -4 m N_m^2 P_m` with `-4 m N_m^2 < 0` on every bulk shell, so `D2 Q_m` is a genuine adjacency-native complex structure: an antisymmetric ambient invariant whose square is a negative multiple of the shell idempotent, built from nearest-neighbor adjacency alone. (The raw coefficient against the unnormalized `Q_m` is `-4 m N_m = (0, 512, -1024, 4608)`, whose sign tracks `N_m`; the idempotent normalization is what carries the complex-structure sign.) Equivalently, on each bulk stratum `D2^2 = M = -4 m`, so `D2 / (2 sqrt(m))` squares to `-1`.
+
+The invariant antisymmetric dimensions `a_m` say how rigidly the adjacency fixes that structure. Shells `1` and `3` are adjacency-pinned, `a_1 = a_3 = 1`: the invariant antisymmetric axis is exactly `span(D2 Q_m)`, and the discriminator shows it — a non-invariant antisymmetric perturbation fails membership in `span(D2 Q_1)`, yet its group average lands back on that single axis. Shell `2` is not adjacency-rigid, `a_2 = 2`: a structurally different rank-two adjacency seed, averaged over `G_amb` and compressed to the shell, produces a second invariant antisymmetric operator that is not proportional to `D2 Q_2`, exhibiting the extra axis the character count predicts.
+
+The `m = 1` shell registers the pointer geometry the kernel notes carry, now on a bulk doublet. On the doublet `w` built from a stratum-`1` vector `v` by `J_1 = D2 / 2`, with `J_1 w = i w`, the norm is `|w|^2 = 8 |v|^2`. The K-odd separator `i (D2 Q_1)` registers opposite nonzero sesquilinear values on `w` and its conjugate; the raw projector pair `2 Q_1 -+ i (D2 Q_1)` is one-zero across the conjugate pair, the two rows exchanged by conjugation; and the K-real symmetric face `Q_1` registers the same value on `w` and its conjugate — blind to the doublet exactly as the invariant Hermitian norm form is blind on the kernel shell. The orientation binary `D2 Q_m -> -(D2 Q_m)` swaps the projector rows and flips the K-odd separator while fixing the symmetric face; the note does not choose the orientation.
+
+## Negative controls
+
+- Carrier-identity rejectors: the diagonal coefficient is pinned at `-6` (not `-5`), and the even shift `T_200` is pinned (not the odd `T_100`), so the `ker pi` carrier identity is exact and not approximate.
+- Wrong-weight block rejector: `8 Q_1` is not `N_1 sum_{wt(eps) = 2} R8_eps`, so the Hamming-weight pairing of strata to characters is by weight, not free.
+- Wrong-eigenvalue momentum rejector: `M phi_{(1,0,0)} = -4 phi`, neither `0` nor `-8 phi`, so the momentum label maps to the shell it should.
+- Group-is-load-bearing rejector: restricting the character sum to the eight `ker pi` translations gives `e_1 = 192`, not `4` — the full `768`-member group does the work, not the carrier subgroup.
+- Adjacency-axis discriminator: a non-invariant antisymmetric perturbation of `D2 Q_1` fails `span(D2 Q_1)`, while its group average returns to that axis; a single adjacency seed on shell `2` averages onto `span(D2 Q_2)` while a structurally different seed reaches the independent second axis, so `a_2 = 2` is exhibited and not asserted.
+
+## Boundary
+
+- It stratifies a commutant and reads antisymmetric content; it derives no `r` value and forces no weighting, normalization, or probability. The character sums and group averages are exact algebraic identities of the finite symmetry action — not a dynamical selection, not a measurement process, and not a probability-weight derivation.
+- It does NOT select the orientation: `D2 Q_m` versus `-(D2 Q_m)` remains the two-presentation choice on every bulk shell; the note only classifies which faces register it, and it does not act on the upstream Qualification, which stays open.
+- The ambient group is the `D2`-commuting dressed closure of the three named symmetry classes — a kinematic statement; no Hamiltonian, transfer operator, or admissibility dynamics is chosen.
+- It is a finite fixed-surface statement (`L = 4` torus); no continuum or infinite-volume claim is made.
+- It resolves the explicit named strata and their invariant faces only; the face list is deliberately non-complete, and genuinely antilinear functionals and interacting extensions are untested and outside the claim. It is NOT a universal-degeneracy or indistinguishability claim; no physical identification is made and nothing pre-record is forced.
+
+## Gate map
+
+| Block | What it checks | Gates |
+|-------|----------------|-------|
+| B1 | construction anchor: `D2` antisymmetry, exact rank `56`, `D2 @ V8 = 0`, `V8` orthogonality, Hamming grading `1 + 3 + 3 + 1` | 5 |
+| B2 | `ker pi` carrier identity `M = 2 (T_200 + T_020 + T_002) - 6 I`, symmetry, even-translation commutation, diagonal/shift rejectors | 4 |
+| B3 | minimal polynomial, four strata, projectors `Q_m`, normalizers `(384, -128, 128, -384)`, idempotence, orthogonality, dims `8, 24, 24, 8`, kernel = corner frame, bulk rank `56` | 11 |
+| B4 | momentum diagonalization `phi_k`, per-stratum counts, wrong-eigenvalue rejector, `K : k -> -k` fixes the `8` kernel momenta, fixed-point-free on `56` bulk | 6 |
+| B5 | `ker pi` isotypic blocks `8 Q_m = N_m sum_{wt(eps) = m} R8_eps`, wrong-weight rejector | 2 |
+| B6 | regenerate `G_amb` at `768`, representation self-check, commutation with `M` and every `Q_m`, block permutation by axis, weight-class orbits `1, 3, 3, 1` | 8 |
+| B7 | bulk commutant character sums `e_m = (2, 4, 4, 2)`, cross terms zero, `10 = 4 + 4 + 2`, reconciliation `12`, group-load-bearing rejector | 7 |
+| B8 | Frobenius-Schur `nu_m = (0, 2, 0, 0)`, invariant antisymmetric `a_m = (1, 1, 2, 1)`, symmetric `s_m = (1, 3, 2, 1)`, consistency | 5 |
+| B9 | adjacency-native complex structures `(D2 Q_m)^2 = -4 m N_m Q_m`, invariance, shell-1/3 pinned, shell-2 second axis, span discriminator, complex-structure sign | 11 |
+| B10 | `m = 1` value tables: doublet norm, K-odd separator, projector pair one-zero with K swap, K-real symmetric face | 6 |
+| B11 | note hygiene: links, required strings, pinned math, front matter | 4 |
+
+## Runner and cache
+
+The [paired runner](../scripts/kcpt_bulk_block_eigenvalue_stratification_2026_07_19.py) recomputes every gated quantity from the construction — the bulk operator and its `ker pi` carrier identity, the minimal polynomial and stratum projectors, the momentum diagonalization and `K`-geometry, the isotypic blocks, the regenerated `768`-member ambient group, the commutant and Frobenius-Schur character sums, the adjacency-native complex structures, and the value tables — and checks each identity with exact integer, exact `Fraction`, or exact `sympy` arithmetic, with no floating point in any load-bearing gate. Every commutant dimension is a character sum over the regenerated group, never a hardcoded target, and every completeness identity carries an explicit wrong-value rejector. It prints `TOTAL: PASS=N FAIL=0` and exits nonzero on any failure. Its cached output is stored at [logs/runner-cache/kcpt_bulk_block_eigenvalue_stratification_2026_07_19.txt](../logs/runner-cache/kcpt_bulk_block_eigenvalue_stratification_2026_07_19.txt).

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 14767,
- "node_count": 4401,
+ "edge_count": 14772,
+ "node_count": 4402,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -6860,6 +6860,10 @@
   },
   "kcpt_ambient_lattice_symmetry_kernel_isolation_averaged_complex_structure_bounded_theorem_note_2026-07-19": {
    "deps_hash": "dafb468bb9c4",
+   "out_degree": 5
+  },
+  "kcpt_bulk_block_eigenvalue_stratification_adjacency_native_complex_structure_bounded_theorem_note_2026-07-19": {
+   "deps_hash": "213d0c7c8e09",
    "out_degree": 5
   },
   "kcpt_corner_carrier_antilinear_nonhermitian_kreal_readout_classification_bounded_theorem_note_2026-07-18": {

--- a/logs/runner-cache/kcpt_bulk_block_eigenvalue_stratification_2026_07_19.txt
+++ b/logs/runner-cache/kcpt_bulk_block_eigenvalue_stratification_2026_07_19.txt
@@ -1,0 +1,88 @@
+===== runner cache v1 =====
+runner: scripts/kcpt_bulk_block_eigenvalue_stratification_2026_07_19.py
+runner_sha256: 23036f1d29e3dd7ff942bd00d820ab15e7fc936780322e858f2db232de56d232
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 42.80
+status: ok
+----- stdout -----
+[B1.1] PASS - D2 integer, antisymmetric (D2 == -D2.T), entries in {-1,0,1}
+[B1.2] PASS - exact rank(D2) == 56 via sympy (kernel dimension 8)
+[B1.3] PASS - D2 @ V8 == 0 exactly
+[B1.4] PASS - V8.T @ V8 == 64 * I8 exactly
+[B1.5] PASS - Hamming-weight grading of the kernel frame == 1 + 3 + 3 + 1
+[B2.1] PASS - M = D2 @ D2 is symmetric (D2 antisymmetric)
+[B2.2] PASS - carrier identity: M == 2*(T_200 + T_020 + T_002) - 6*I exactly
+[B2.3] PASS - rejectors: the -6 diagonal and the even-shift T_200 are both pinned
+[B2.4] PASS - M commutes with every even translation (the (Z/2)^3 ker-pi carrier)
+[B3.1] PASS - minimal polynomial M(M+4I)(M+8I)(M+12I) == 0 exactly
+[B3.2] PASS - every drop-one product Q_m = prod_{m'!=m}(M - lambda_m' I) is nonzero
+[B3.3] PASS - normalizers N_m = prod(lambda_m - lambda_m') == [384, -128, 128, -384]
+[B3.4] PASS - eigen-projector action: M Q_m == lambda_m Q_m for all m
+[B3.5] PASS - idempotence up to scale: Q_m^2 == N_m Q_m for all m
+[B3.6] PASS - orthogonality: Q_m Q_m' == 0 for m != m'
+[B3.7] PASS - partition of unity: Q_0 - 3Q_1 + 3Q_2 - Q_3 == 384 I (coefficient pinned)
+[B3.8] PASS - each Q_m is real symmetric
+[B3.9] PASS - stratum dims from tr Q_m / N_m == [8, 24, 24, 8] (expected 8,24,24,8)
+[B3.10] PASS - kernel projector matches corner frame: Q_0 == 6 * V8 @ V8.T
+[B3.11] PASS - bulk rank rank(Q_1)+rank(Q_2)+rank(Q_3) == 56 == 24+24+8 == rank D2
+[info] stratum dims d_m = [8, 24, 24, 8]
+[B4.1] PASS - every momentum wave phi_k is an M-eigenvector at lambda = -4 m(k) (re and im parts)
+[B4.2] PASS - wrong-eigenvalue rejector: M phi_(1,0,0) == -4 phi, not 0 and not -8 phi
+[B4.3] PASS - per-stratum momentum counts == [8, 24, 24, 8] (== stratum dims d_m)
+[B4.4] PASS - K: k -> -k (mod 4) preserves every stratum, m(-k) == m(k)
+[B4.5] PASS - K fixes exactly the 8 kernel (m=0) momenta
+[B4.6] PASS - K is fixed-point-free on the 56 bulk momenta (28 conjugate pairs)
+[B5.1] PASS - block resolution: 8 Q_m == N_m * sum_{wt(eps)=m} R8_eps for all m
+[B5.2] PASS - wrong-weight rejector: 8 Q_1 != N_1 * sum_{wt(eps)=2} R8_eps
+[B6.1] PASS - scan keeps 192 D2-commuting members, 64 per class ({'stab': 64, 'U2': 64, 'UR': 64})
+[B6.2] PASS - BFS closure of the 192 has order exactly 768, all distinct
+[B6.3] PASS - every one of the 768 commutes with D2 exactly
+[B6.4] PASS - orthogonality: U U^T == I64 for all 768 (signed permutations)
+[B6.5] PASS - signed-perm representation self-check: conj_sp == dense U M U^T (sampled)
+[B6.6] PASS - every ambient member commutes with M and with every Q_m
+[B6.7] PASS - G_amb conjugation permutes the 8 ker-pi blocks, preserving Hamming weight
+[B6.8] PASS - block orbits are exactly the weight classes, sizes [1, 1, 3, 3] == 1,3,3,1
+[B7.1] PASS - commutant character sums e_m are exact integers (768 N_m^2 divides the sum)
+[B7.2] PASS - per-stratum commutant dims e_m == [2, 4, 4, 2] (computed by character sum)
+[B7.3] PASS - all cross terms h_{m,m'} == 0 (strata share no equivariant maps)
+[B7.4] PASS - the parent's ten on the image block resolves as 10 = 4 + 4 + 2
+[B7.5] PASS - the kernel shell keeps e_0 == 2 (matching span{I, j})
+[B7.6] PASS - reconciliation: sum_m e_m + 2 sum_{m<m'} h == 12 == parent total 12
+[B7.7] PASS - group-is-load-bearing rejector: e_1 over the 8 ker-pi translations == 192 != 4
+[info] commutant dims e_m = [2, 4, 4, 2]
+[info] cross terms h_(m,m') = { (0, 1): 0, (0, 2): 0, (0, 3): 0, (1, 2): 0, (1, 3): 0, (2, 3): 0 }
+[B8.1] PASS - Frobenius-Schur sums nu_m are exact integers (768 N_m divides the sum)
+[B8.2] PASS - Frobenius-Schur indicators nu_m == [0, 2, 0, 0] (computed by character sum)
+[B8.3] PASS - invariant antisymmetric dims a_m = (e_m - nu_m)/2 == [1, 1, 2, 1]
+[B8.4] PASS - invariant symmetric dims s_m = (e_m + nu_m)/2 == [1, 3, 2, 1]
+[B8.5] PASS - consistency: a_m + s_m == e_m, s_m - a_m == nu_m, all nonnegative
+[info] Frobenius-Schur nu_m = [0, 2, 0, 0]
+[info] invariant antisymmetric dims a_m = [1, 1, 2, 1]
+[info] invariant symmetric dims s_m = [1, 3, 2, 1]
+[B9.1] PASS - D2 commutes with every Q_m (it is a polynomial in M = D2^2)
+[B9.2] PASS - D2 Q_0 == 0: the adjacency vanishes on the kernel stratum
+[B9.3] PASS - each D2 Q_m (m >= 1) is a nonzero real antisymmetric operator
+[B9.4] PASS - each D2 Q_m (m >= 1) commutes with all 768 ambient members
+[B9.5] PASS - square identity: (D2 Q_m)^2 == -4 m N_m Q_m for all m
+[B9.6] PASS - shell 1 is adjacency-pinned: a_1 == 1 and D2 Q_1 is a nonzero invariant axis
+[B9.7] PASS - rejector: the perturbed non-invariant antisymmetric Zpert fails span(D2 Q_1)
+[B9.8] PASS - group-average of Zpert lands back in span(D2 Q_1) (invariant axis restored)
+[B9.9] PASS - shell 3 is adjacency-pinned: a_3 == 1 and D2 Q_3 is a nonzero invariant axis
+[B9.10] PASS - shell 2 not adjacency-rigid: a_2 == 2, a second invariant antisym axis off span(D2 Q_2)
+[B9.11] PASS - complex-structure sign: (D2 Q_m)^2 == -4 m N_m^2 P_m is a negative multiple of the idempotent P_m = Q_m/N_m on every bulk shell, though raw -4 m N_m = (0,512,-1024,4608) is not uniformly negative
+[B10.1] PASS - v = Q_1[:,0] is a nonzero stratum-1 vector: M v == -4 v
+[B10.2] PASS - doublet: D2 A == -2 B and D2 B == 2 A (so J_1 = D2/2 gives J_1 w == i w)
+[B10.3] PASS - doublet norm |w|^2 == A.A + B.B == 8 |v|^2 (|v|^2 = 6144, |w|^2 = 49152)
+[B10.4] PASS - K-odd separator i(D2 Q_1): opposite nonzero values (12582912, -12582912)
+[B10.5] PASS - projector pair one-zero with K swap: 2Q_1-i(D2Q_1)->(-25165824,0), 2Q_1+i(D2Q_1)->(0,-25165824)
+[B10.6] PASS - K-real symmetric face Q_1: SAME value on the conjugate pair (-6291456, -6291456)
+[info] m=1 value tables: |v|^2=6144, |w|^2=49152, i(D2Q1) on (w, conj w)=(12582912, -12582912), projector 2Q1-i(D2Q1) on (w, conj w)=(-25165824, 0), Q1 face=(-6291456, -6291456)
+[B11.1] PASS - forbidden substrings absent from the note (none)
+[B11.2] PASS - required verbatim strings present (all present)
+[B11.3] PASS - all five dependency links present as markdown links and the deps exist
+[B11.4] PASS - note carries the bounded_theorem front matter, claim boundary, and Boundary section
+TOTAL: PASS=69 FAIL=0
+
+----- stderr -----
+

--- a/scripts/kcpt_bulk_block_eigenvalue_stratification_2026_07_19.py
+++ b/scripts/kcpt_bulk_block_eigenvalue_stratification_2026_07_19.py
@@ -1,0 +1,672 @@
+#!/usr/bin/env python3
+"""KCPT bulk-block eigenvalue stratification: Hamming shells, the ker-pi carrier,
+and adjacency-native complex structures.
+
+Class-A finite check on the fixed 4^3 staggered surface. The staggered adjacency
+D2, the corner-wave kernel frame V8, and the ambient D2-commuting dressed closure
+G_amb of order 768 are rebuilt from the construction (machinery copied from the
+landed ambient runner). The eigenvalue strata of M = D2 @ D2 are resolved by exact
+integer projectors, the per-shell commutant dimensions e_m, cross terms h_{m,m'},
+and Frobenius-Schur indicators nu_m are recomputed as exact character sums (Fraction)
+over the regenerated 768 members acting on the stratum projectors -- never hardcoded
+-- and the adjacency-native antisymmetric operators D2 Q_m are exhibited and their
+invariant span tested with an explicit non-invariant rejector. Every load-bearing
+gate uses exact integer numpy (int64, with Python-int / Fraction arithmetic for the
+character sums and sesquilinear values) or exact sympy rank; no floating point enters
+any gate. Each gate prints one line; the script prints a final TOTAL line and exits
+nonzero on any failure.
+"""
+import os
+import re
+import sys
+import itertools
+from fractions import Fraction
+import numpy as np
+import sympy as sp
+
+# ----------------------------------------------------------------------------
+# Bookkeeping
+# ----------------------------------------------------------------------------
+PASS = 0
+FAIL = 0
+
+
+def gate(tag, cond, desc):
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(f"[{tag}] {'PASS' if ok else 'FAIL'} - {desc}")
+    return ok
+
+
+def eqm(a, b):
+    return np.array_equal(a, b)
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+DOCS = os.path.join(ROOT, "docs")
+
+# ----------------------------------------------------------------------------
+# Construction (transcribed verbatim from the landed surface / ambient runner)
+# ----------------------------------------------------------------------------
+L = 4
+N = 64
+
+
+def idx(a, b, c):
+    return (a * L + b) * L + c
+
+
+coords = np.zeros((N, 3), dtype=np.int64)
+for a in range(L):
+    for b in range(L):
+        for c in range(L):
+            coords[idx(a, b, c)] = (a, b, c)
+
+
+def eta_mu(mu, x):
+    if mu == 0:
+        return 1
+    if mu == 1:
+        return (-1) ** int(x[0])
+    return (-1) ** int(x[0] + x[1])
+
+
+e = [np.array([1, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 1])]
+D2 = np.zeros((N, N), dtype=np.int64)
+for i in range(N):
+    x = coords[i]
+    for mu in range(3):
+        D2[i, idx(*((x + e[mu]) % L))] += eta_mu(mu, x)
+        D2[i, idx(*((x - e[mu]) % L))] -= eta_mu(mu, x)
+
+SUBSETS = [(), (0,), (1,), (2,), (0, 1), (0, 2), (1, 2), (0, 1, 2)]
+HW = [len(S) for S in SUBSETS]
+V8 = np.zeros((N, 8), dtype=np.int64)
+for i in range(N):
+    x = coords[i]
+    for k, S in enumerate(SUBSETS):
+        V8[i, k] = (-1) ** int(sum(x[j] for j in S))
+
+
+def perm(fmap):
+    P = np.zeros((N, N), dtype=np.int64)
+    for i in range(N):
+        y = np.array(fmap(coords[i])) % L
+        P[i, idx(int(y[0]), int(y[1]), int(y[2]))] = 1
+    return P
+
+
+UR = perm(lambda x: (x[1], x[2], x[0]))
+U2 = perm(lambda x: (-x[1], -x[0], -x[2]))
+STAB = np.eye(N, dtype=np.int64)
+TR = {t: perm(lambda x, t=t: (x[0] - t[0], x[1] - t[1], x[2] - t[2]))
+      for t in itertools.product(range(L), repeat=3)}
+
+I64 = np.eye(N, dtype=np.int64)
+ZERO = np.zeros((N, N), dtype=np.int64)
+eye8 = np.eye(8, dtype=np.int64)
+
+
+def signfield(bits):
+    a1, a2, a3, b12, b13, b23 = bits
+    d = np.zeros(N, dtype=np.int64)
+    for i in range(N):
+        x1, x2, x3 = coords[i]
+        expo = a1 * x1 + a2 * x2 + a3 * x3 + b12 * x1 * x2 + b13 * x1 * x3 + b23 * x2 * x3
+        d[i] = (-1) ** int(expo)
+    return d
+
+
+ALLBITS = list(itertools.product([0, 1], repeat=6))
+SF = {bits: signfield(bits) for bits in ALLBITS}
+BASES = {"stab": STAB, "U2": U2, "UR": UR}
+
+
+def closure_amb(gs):
+    gs = [g.copy() for g in gs]
+    elts = {g.tobytes(): g for g in gs}
+    frontier = list(elts.values())
+    while frontier:
+        nf = []
+        for xg in frontier:
+            for g in gs:
+                p = xg @ g
+                key = p.tobytes()
+                if key not in elts:
+                    elts[key] = p
+                    nf.append(p)
+        frontier = nf
+    return list(elts.values())
+
+
+def perm_sign(U):
+    cols = np.argmax(np.abs(U), axis=1)
+    signs = U[np.arange(N), cols]
+    return cols, signs
+
+
+def conj_sp(cols, signs, A):
+    # (U A U^T)[a,b] = signs[a] signs[b] A[cols[a], cols[b]] for signed-perm U
+    return A[np.ix_(cols, cols)] * np.outer(signs, signs)
+
+
+def trUQ(U, Q):
+    # tr(U @ Q) == sum_{i,j} U[i,j] Q[j,i] == sum(U * Q.T); entries are small integers
+    return int(np.multiply(U, Q.T).sum())
+
+
+def proportional(A, B):
+    # exact: True iff A and B are linearly dependent (A == r B for rational r, or A == 0)
+    A = A.astype(object)
+    B = B.astype(object)
+    nz = np.argwhere(B != 0)
+    if len(nz) == 0:
+        return bool(np.all(A == 0))
+    i0, j0 = nz[0]
+    num = A[i0, j0]
+    den = B[i0, j0]
+    return bool(np.all(A * den == num * B))
+
+
+# ============================================================================
+# B1 - construction anchored to the landed surface
+# ============================================================================
+gate("B1.1", eqm(D2, -D2.T) and set(np.unique(D2)).issubset({-1, 0, 1}),
+     "D2 integer, antisymmetric (D2 == -D2.T), entries in {-1,0,1}")
+gate("B1.2", sp.Matrix(D2.tolist()).rank() == 56,
+     "exact rank(D2) == 56 via sympy (kernel dimension 8)")
+gate("B1.3", eqm(D2 @ V8, np.zeros((N, 8), dtype=np.int64)),
+     "D2 @ V8 == 0 exactly")
+gate("B1.4", eqm(V8.T @ V8, 64 * eye8),
+     "V8.T @ V8 == 64 * I8 exactly")
+gate("B1.5", HW == [0, 1, 1, 1, 2, 2, 2, 3]
+     and [HW.count(w) for w in (0, 1, 2, 3)] == [1, 3, 3, 1],
+     "Hamming-weight grading of the kernel frame == 1 + 3 + 3 + 1")
+
+# ============================================================================
+# B2 - the ker-pi carrier identity (result 1)
+# ============================================================================
+M = D2 @ D2
+carrier = 2 * (TR[(2, 0, 0)] + TR[(0, 2, 0)] + TR[(0, 0, 2)]) - 6 * I64
+gate("B2.1", eqm(M, M.T),
+     "M = D2 @ D2 is symmetric (D2 antisymmetric)")
+gate("B2.2", eqm(M, carrier),
+     "carrier identity: M == 2*(T_200 + T_020 + T_002) - 6*I exactly")
+gate("B2.3", not eqm(M, 2 * (TR[(2, 0, 0)] + TR[(0, 2, 0)] + TR[(0, 0, 2)]) - 5 * I64)
+     and not eqm(M, 2 * (TR[(1, 0, 0)] + TR[(0, 2, 0)] + TR[(0, 0, 2)]) - 6 * I64),
+     "rejectors: the -6 diagonal and the even-shift T_200 are both pinned")
+even_tr = [TR[t] for t in itertools.product([0, 2], repeat=3)]
+gate("B2.4", all(eqm(M @ T, T @ M) for T in even_tr),
+     "M commutes with every even translation (the (Z/2)^3 ker-pi carrier)")
+
+# ============================================================================
+# B3 - minimal polynomial, strata, projectors (result 2)
+# ============================================================================
+lam = [0, -4, -8, -12]
+Fac = [M - lam[m] * I64 for m in range(4)]
+minpoly = Fac[0] @ Fac[1] @ Fac[2] @ Fac[3]
+gate("B3.1", eqm(minpoly, ZERO),
+     "minimal polynomial M(M+4I)(M+8I)(M+12I) == 0 exactly")
+
+Q = []
+for m in range(4):
+    P = I64.copy()
+    for mp in range(4):
+        if mp != m:
+            P = P @ Fac[mp]
+    Q.append(P)
+drop_nonzero = all(not eqm(Q[m], ZERO) for m in range(4))
+gate("B3.2", drop_nonzero,
+     "every drop-one product Q_m = prod_{m'!=m}(M - lambda_m' I) is nonzero")
+
+Nm = []
+for m in range(4):
+    v = 1
+    for mp in range(4):
+        if mp != m:
+            v *= (lam[m] - lam[mp])
+    Nm.append(v)
+gate("B3.3", Nm == [384, -128, 128, -384],
+     f"normalizers N_m = prod(lambda_m - lambda_m') == {Nm}")
+gate("B3.4", all(eqm(M @ Q[m], lam[m] * Q[m]) for m in range(4)),
+     "eigen-projector action: M Q_m == lambda_m Q_m for all m")
+gate("B3.5", all(eqm(Q[m] @ Q[m], Nm[m] * Q[m]) for m in range(4)),
+     "idempotence up to scale: Q_m^2 == N_m Q_m for all m")
+gate("B3.6", all(eqm(Q[m] @ Q[mp], ZERO) for m in range(4) for mp in range(4) if m != mp),
+     "orthogonality: Q_m Q_m' == 0 for m != m'")
+gate("B3.7", eqm(Q[0] - 3 * Q[1] + 3 * Q[2] - Q[3], 384 * I64)
+     and not eqm(Q[0] - 3 * Q[1] + 3 * Q[2] - Q[3], 383 * I64),
+     "partition of unity: Q_0 - 3Q_1 + 3Q_2 - Q_3 == 384 I (coefficient pinned)")
+gate("B3.8", all(eqm(Q[m], Q[m].T) for m in range(4)),
+     "each Q_m is real symmetric")
+# stratum dims are COMPUTED from tr Q_m / N_m, then checked (not hardcoded first)
+dm = []
+tr_ok = True
+for m in range(4):
+    tq = int(np.trace(Q[m]))
+    if tq % Nm[m] != 0:
+        tr_ok = False
+        dm.append(None)
+    else:
+        dm.append(tq // Nm[m])
+gate("B3.9", tr_ok and dm == [8, 24, 24, 8],
+     f"stratum dims from tr Q_m / N_m == {dm} (expected 8,24,24,8)")
+gate("B3.10", eqm(Q[0], 6 * (V8 @ V8.T)),
+     "kernel projector matches corner frame: Q_0 == 6 * V8 @ V8.T")
+bulk_rank = (sp.Matrix(Q[1].tolist()).rank()
+             + sp.Matrix(Q[2].tolist()).rank()
+             + sp.Matrix(Q[3].tolist()).rank())
+gate("B3.11", bulk_rank == 56 and (dm[1] + dm[2] + dm[3]) == 56,
+     f"bulk rank rank(Q_1)+rank(Q_2)+rank(Q_3) == {bulk_rank} == 24+24+8 == rank D2")
+
+print(f"[info] stratum dims d_m = {dm}")
+
+# ============================================================================
+# B4 - momentum diagonalization and the K-geometry (result 3)
+# ============================================================================
+I_RE = [1, 0, -1, 0]
+I_IM = [0, 1, 0, -1]
+
+
+def wave(k):
+    re = np.zeros(N, dtype=np.int64)
+    im = np.zeros(N, dtype=np.int64)
+    for i in range(N):
+        x = coords[i]
+        r = int((k[0] * x[0] + k[1] * x[1] + k[2] * x[2]) % 4)
+        re[i] = I_RE[r]
+        im[i] = I_IM[r]
+    return re, im
+
+
+def mval(k):
+    return int((k[0] % 2) + (k[1] % 2) + (k[2] % 2))
+
+
+allk = list(itertools.product(range(4), repeat=3))
+eig_ok = True
+for k in allk:
+    wr, wi = wave(k)
+    lm = -4 * mval(k)
+    if not eqm(M @ wr, lm * wr) or not eqm(M @ wi, lm * wi):
+        eig_ok = False
+gate("B4.1", eig_ok,
+     "every momentum wave phi_k is an M-eigenvector at lambda = -4 m(k) (re and im parts)")
+re10, im10 = wave((1, 0, 0))
+gate("B4.2", eqm(M @ re10, -4 * re10) and not eqm(M @ re10, ZERO[:, 0])
+     and not eqm(M @ re10, -8 * re10) and np.any(re10 != 0),
+     "wrong-eigenvalue rejector: M phi_(1,0,0) == -4 phi, not 0 and not -8 phi")
+counts = [sum(1 for k in allk if mval(k) == m) for m in range(4)]
+gate("B4.3", counts == [8, 24, 24, 8],
+     f"per-stratum momentum counts == {counts} (== stratum dims d_m)")
+gate("B4.4", all(mval(tuple((-ki) % 4 for ki in k)) == mval(k) for k in allk),
+     "K: k -> -k (mod 4) preserves every stratum, m(-k) == m(k)")
+fixedK = [k for k in allk if tuple((-ki) % 4 for ki in k) == k]
+gate("B4.5", len(fixedK) == 8 and all(mval(k) == 0 for k in fixedK),
+     "K fixes exactly the 8 kernel (m=0) momenta")
+bulk = [k for k in allk if mval(k) >= 1]
+bulk_fpf = all(tuple((-ki) % 4 for ki in k) != k for k in bulk)
+pairs = set()
+for k in bulk:
+    kk = tuple((-ki) % 4 for ki in k)
+    pairs.add(frozenset((k, kk)))
+gate("B4.6", len(bulk) == 56 and bulk_fpf and len(pairs) == 28,
+     "K is fixed-point-free on the 56 bulk momenta (28 conjugate pairs)")
+
+# ============================================================================
+# B5 - ker-pi isotypic blocks (result 4)
+# ============================================================================
+EPS = list(itertools.product([0, 1], repeat=3))
+R8 = {}
+for eps in EPS:
+    S = np.zeros((N, N), dtype=np.int64)
+    for b in itertools.product([0, 1], repeat=3):
+        t = (2 * b[0], 2 * b[1], 2 * b[2])
+        sgn = (-1) ** int(eps[0] * b[0] + eps[1] * b[1] + eps[2] * b[2])
+        S = S + sgn * TR[t]
+    R8[eps] = S
+block_ok = True
+for m in range(4):
+    rhs = np.zeros((N, N), dtype=np.int64)
+    for eps in EPS:
+        if sum(eps) == m:
+            rhs = rhs + R8[eps]
+    if not eqm(8 * Q[m], Nm[m] * rhs):
+        block_ok = False
+gate("B5.1", block_ok,
+     "block resolution: 8 Q_m == N_m * sum_{wt(eps)=m} R8_eps for all m")
+rhs_wrong = np.zeros((N, N), dtype=np.int64)
+for eps in EPS:
+    if sum(eps) == 2:
+        rhs_wrong = rhs_wrong + R8[eps]
+gate("B5.2", not eqm(8 * Q[1], Nm[1] * rhs_wrong),
+     "wrong-weight rejector: 8 Q_1 != N_1 * sum_{wt(eps)=2} R8_eps")
+
+# ============================================================================
+# B6 - regenerate the ambient group G_amb (order 768) (result setup)
+# ============================================================================
+commuting = {}
+for name, base in BASES.items():
+    lst = []
+    for bits in ALLBITS:
+        dd = np.diag(SF[bits])
+        for t in itertools.product(range(L), repeat=3):
+            U = dd @ base @ TR[t]
+            if eqm(U @ D2, D2 @ U):
+                lst.append(U.copy())
+    commuting[name] = lst
+per_class = {n: len(commuting[n]) for n in BASES}
+amb_scan = [U for n in BASES for U in commuting[n]]
+gate("B6.1", sum(per_class.values()) == 192 and all(v == 64 for v in per_class.values()),
+     f"scan keeps 192 D2-commuting members, 64 per class ({per_class})")
+Gamb = closure_amb(amb_scan)
+gate("B6.2", len(Gamb) == 768 and len(set(U.tobytes() for U in Gamb)) == 768,
+     "BFS closure of the 192 has order exactly 768, all distinct")
+gate("B6.3", all(eqm(U @ D2, D2 @ U) for U in Gamb),
+     "every one of the 768 commutes with D2 exactly")
+gate("B6.4", all(eqm(U @ U.T, I64) for U in Gamb),
+     "orthogonality: U U^T == I64 for all 768 (signed permutations)")
+COLS = []
+SIGNS = []
+for U in Gamb:
+    c, s = perm_sign(U)
+    COLS.append(c)
+    SIGNS.append(s)
+sp_ok = True
+for u in range(0, 768, 97):
+    if not eqm(conj_sp(COLS[u], SIGNS[u], M), Gamb[u] @ M @ Gamb[u].T):
+        sp_ok = False
+gate("B6.5", sp_ok,
+     "signed-perm representation self-check: conj_sp == dense U M U^T (sampled)")
+
+# every ambient member commutes with M (hence with each Q_m, a polynomial in M)
+gate("B6.6", all(eqm(U @ M, M @ U) for U in Gamb)
+     and all(eqm(U @ Q[m], Q[m] @ U) for U in Gamb for m in range(4)),
+     "every ambient member commutes with M and with every Q_m")
+
+# ker-pi blocks are permuted by axis permutation, weight-preserving; orbits {1,3,3,1}
+key_to_eps = {R8[eps].tobytes(): eps for eps in EPS}
+perm_ok = True
+weight_ok = True
+edges = {eps: set() for eps in EPS}
+for u in range(768):
+    for eps in EPS:
+        img = conj_sp(COLS[u], SIGNS[u], R8[eps])
+        kk = img.tobytes()
+        if kk not in key_to_eps:
+            perm_ok = False
+            continue
+        eps2 = key_to_eps[kk]
+        edges[eps].add(eps2)
+        if sum(eps2) != sum(eps):
+            weight_ok = False
+gate("B6.7", perm_ok and weight_ok,
+     "G_amb conjugation permutes the 8 ker-pi blocks, preserving Hamming weight")
+# orbits from the collected edges
+seen = set()
+orbit_sizes = []
+for eps in EPS:
+    if eps in seen:
+        continue
+    stack = [eps]
+    comp = set()
+    while stack:
+        y = stack.pop()
+        if y in comp:
+            continue
+        comp.add(y)
+        for z in edges[y]:
+            if z not in comp:
+                stack.append(z)
+    seen |= comp
+    orbit_sizes.append(len(comp))
+gate("B6.8", sorted(orbit_sizes) == [1, 1, 3, 3],
+     f"block orbits are exactly the weight classes, sizes {sorted(orbit_sizes)} == 1,3,3,1")
+
+# ============================================================================
+# B7 - bulk commutant resolution by exact character sums (result 5, headline)
+# ============================================================================
+G = 768
+tr_all = [[trUQ(U, Q[m]) for U in Gamb] for m in range(4)]
+U2_list = [U @ U for U in Gamb]
+tr2_all = [[trUQ(U2, Q[m]) for U2 in U2_list] for m in range(4)]
+
+e_val = []
+for m in range(4):
+    S = sum(t * t for t in tr_all[m])
+    fr = Fraction(S, G * Nm[m] ** 2)
+    e_val.append(fr)
+gate("B7.1", all(fr.denominator == 1 for fr in e_val),
+     "commutant character sums e_m are exact integers (768 N_m^2 divides the sum)")
+e_int = [int(fr) for fr in e_val]
+gate("B7.2", e_int == [2, 4, 4, 2],
+     f"per-stratum commutant dims e_m == {e_int} (computed by character sum)")
+
+h_val = {}
+h_zero = True
+for m in range(4):
+    for mp in range(m + 1, 4):
+        S = sum(tr_all[m][i] * tr_all[mp][i] for i in range(G))
+        fr = Fraction(S, G * Nm[m] * Nm[mp])
+        h_val[(m, mp)] = fr
+        if fr != 0:
+            h_zero = False
+gate("B7.3", h_zero,
+     "all cross terms h_{m,m'} == 0 (strata share no equivariant maps)")
+gate("B7.4", e_int[1] + e_int[2] + e_int[3] == 10 and (e_int[1], e_int[2], e_int[3]) == (4, 4, 2),
+     "the parent's ten on the image block resolves as 10 = 4 + 4 + 2")
+gate("B7.5", e_int[0] == 2,
+     "the kernel shell keeps e_0 == 2 (matching span{I, j})")
+total = sum(e_int) + 2 * sum(int(v) for v in h_val.values())
+gate("B7.6", total == 12,
+     f"reconciliation: sum_m e_m + 2 sum_{{m<m'}} h == {total} == parent total 12")
+# subgroup rejector: restricting the group to the 8 ker-pi translations changes e_1
+kerpi_mats = even_tr
+S_sub = sum(trUQ(T, Q[1]) ** 2 for T in kerpi_mats)
+e1_sub = Fraction(S_sub, len(kerpi_mats) * Nm[1] ** 2)
+gate("B7.7", e1_sub != e_val[1],
+     f"group-is-load-bearing rejector: e_1 over the 8 ker-pi translations == {e1_sub} != 4")
+
+print(f"[info] commutant dims e_m = {e_int}")
+print(f"[info] cross terms h_(m,m') = {{ {', '.join(f'{k}: {int(v)}' for k, v in h_val.items())} }}")
+
+# ============================================================================
+# B8 - Frobenius-Schur classification (result 6)
+# ============================================================================
+nu_val = []
+for m in range(4):
+    S = sum(tr2_all[m])
+    fr = Fraction(S, G * Nm[m])
+    nu_val.append(fr)
+gate("B8.1", all(fr.denominator == 1 for fr in nu_val),
+     "Frobenius-Schur sums nu_m are exact integers (768 N_m divides the sum)")
+nu_int = [int(fr) for fr in nu_val]
+gate("B8.2", nu_int == [0, 2, 0, 0],
+     f"Frobenius-Schur indicators nu_m == {nu_int} (computed by character sum)")
+a_m = [(e_int[m] - nu_int[m]) for m in range(4)]
+s_m = [(e_int[m] + nu_int[m]) for m in range(4)]
+half_ok = all(a % 2 == 0 for a in a_m) and all(s % 2 == 0 for s in s_m)
+a_m = [a // 2 for a in a_m]
+s_m = [s // 2 for s in s_m]
+gate("B8.3", half_ok and a_m == [1, 1, 2, 1],
+     f"invariant antisymmetric dims a_m = (e_m - nu_m)/2 == {a_m}")
+gate("B8.4", s_m == [1, 3, 2, 1],
+     f"invariant symmetric dims s_m = (e_m + nu_m)/2 == {s_m}")
+gate("B8.5", all(a_m[m] + s_m[m] == e_int[m] and s_m[m] - a_m[m] == nu_int[m] for m in range(4))
+     and all(a_m[m] >= 0 and s_m[m] >= 0 for m in range(4)),
+     "consistency: a_m + s_m == e_m, s_m - a_m == nu_m, all nonnegative")
+
+print(f"[info] Frobenius-Schur nu_m = {nu_int}")
+print(f"[info] invariant antisymmetric dims a_m = {a_m}")
+print(f"[info] invariant symmetric dims s_m = {s_m}")
+
+# ============================================================================
+# B9 - adjacency-native complex structures (result 7)
+# ============================================================================
+DQ = [D2 @ Q[m] for m in range(4)]
+gate("B9.1", all(eqm(D2 @ Q[m], Q[m] @ D2) for m in range(4)),
+     "D2 commutes with every Q_m (it is a polynomial in M = D2^2)")
+gate("B9.2", eqm(DQ[0], ZERO),
+     "D2 Q_0 == 0: the adjacency vanishes on the kernel stratum")
+gate("B9.3", all((not eqm(DQ[m], ZERO)) and eqm(DQ[m].T, -DQ[m]) for m in (1, 2, 3)),
+     "each D2 Q_m (m >= 1) is a nonzero real antisymmetric operator")
+
+
+def invariant(A):
+    return all(eqm(conj_sp(COLS[u], SIGNS[u], A), A) for u in range(768))
+
+
+gate("B9.4", all(invariant(DQ[m]) for m in (1, 2, 3)),
+     "each D2 Q_m (m >= 1) commutes with all 768 ambient members")
+gate("B9.5", all(eqm(DQ[m] @ DQ[m], -4 * m * Nm[m] * Q[m]) for m in range(4)),
+     "square identity: (D2 Q_m)^2 == -4 m N_m Q_m for all m")
+
+# span-membership discriminator on shell 1 (a_1 == 1, so the invariant
+# antisymmetric axis is exactly span(D2 Q_1)).
+u0 = np.zeros(N, dtype=np.int64); u0[0] = 1
+u1 = np.zeros(N, dtype=np.int64); u1[1] = 1
+K0 = np.outer(u0, u1) - np.outer(u1, u0)
+
+
+def avg_of(A):
+    acc = np.zeros((N, N), dtype=np.int64)
+    for u in range(768):
+        acc = acc + conj_sp(COLS[u], SIGNS[u], A)
+    return acc
+
+
+Seed1 = Q[1] @ K0 @ Q[1]
+Zpert = DQ[1] + Seed1
+gate("B9.6", a_m[1] == 1 and invariant(DQ[1]) and not eqm(DQ[1], ZERO),
+     "shell 1 is adjacency-pinned: a_1 == 1 and D2 Q_1 is a nonzero invariant axis")
+gate("B9.7", (not invariant(Seed1)) and (not proportional(Zpert, DQ[1])),
+     "rejector: the perturbed non-invariant antisymmetric Zpert fails span(D2 Q_1)")
+gate("B9.8", proportional(avg_of(Zpert), DQ[1]),
+     "group-average of Zpert lands back in span(D2 Q_1) (invariant axis restored)")
+gate("B9.9", a_m[3] == 1 and invariant(DQ[3]) and not eqm(DQ[3], ZERO),
+     "shell 3 is adjacency-pinned: a_3 == 1 and D2 Q_3 is a nonzero invariant axis")
+
+# shell 2 is not adjacency-rigid (a_2 == 2): exhibit a second invariant
+# antisymmetric operator on stratum 2 that is independent of D2 Q_2. A single
+# rank-two adjacency seed (sites 0,1) averages back onto span(D2 Q_2); a
+# structurally different seed (sites 0,21) reaches the other invariant axis.
+u21 = np.zeros(N, dtype=np.int64); u21[21] = 1
+K0b = np.outer(u0, u21) - np.outer(u21, u0)
+Adj2 = Q[2] @ avg_of(K0) @ Q[2]
+Alt2 = Q[2] @ avg_of(K0b) @ Q[2]
+gate("B9.10", a_m[2] == 2 and (not eqm(Alt2, ZERO)) and invariant(Alt2)
+     and eqm(Alt2.T, -Alt2) and (not proportional(Alt2, DQ[2]))
+     and proportional(Adj2, DQ[2]),
+     "shell 2 not adjacency-rigid: a_2 == 2, a second invariant antisym axis off span(D2 Q_2)")
+
+# B9.11 - complex-structure SIGN. B9.5 gates the square identity
+# (D2 Q_m)^2 == -4 m N_m Q_m, but that coefficient against the unnormalized Q_m
+# is NOT uniformly signed: -4 m N_m = (0, 512, -1024, 4608). The complex-structure
+# property lives in the idempotent normalization P_m = Q_m / N_m, against which the
+# square is -4 m N_m^2 P_m with -4 m N_m^2 < 0 on every bulk shell. This gate pins
+# the sign story (raw coefficient not uniformly negative; idempotent coefficient
+# negative everywhere) and ties it to the actual matrices.
+raw_coeff = [-4 * m * Nm[m] for m in range(4)]
+idem_coeff = [-4 * m * Nm[m] ** 2 for m in range(4)]
+gate("B9.11",
+     raw_coeff == [0, 512, -1024, 4608]
+     and any(raw_coeff[m] > 0 for m in (1, 2, 3))
+     and all(idem_coeff[m] < 0 for m in (1, 2, 3))
+     and all(eqm(Nm[m] * (DQ[m] @ DQ[m]), idem_coeff[m] * Q[m]) for m in (1, 2, 3)),
+     "complex-structure sign: (D2 Q_m)^2 == -4 m N_m^2 P_m is a negative multiple of the idempotent P_m = Q_m/N_m on every bulk shell, though raw -4 m N_m = (0,512,-1024,4608) is not uniformly negative")
+
+# ============================================================================
+# B10 - the m=1 value tables and K-real registration (result 8)
+# ============================================================================
+v = Q[1][:, 0].astype(object)
+gate("B10.1", eqm(M @ Q[1][:, 0], -4 * Q[1][:, 0]) and np.any(Q[1][:, 0] != 0),
+     "v = Q_1[:,0] is a nonzero stratum-1 vector: M v == -4 v")
+A0 = 2 * Q[1][:, 0]
+B0 = -(D2 @ Q[1][:, 0])
+gate("B10.2", eqm(D2 @ A0, -2 * B0) and eqm(D2 @ B0, 2 * A0),
+     "doublet: D2 A == -2 B and D2 B == 2 A (so J_1 = D2/2 gives J_1 w == i w)")
+vv = int(v @ v)
+normw = int(A0.astype(object) @ A0.astype(object)) + int(B0.astype(object) @ B0.astype(object))
+gate("B10.3", normw == 8 * vv,
+     f"doublet norm |w|^2 == A.A + B.B == 8 |v|^2 (|v|^2 = {vv}, |w|^2 = {normw})")
+
+
+def sesq(Mre, Mim, wr, wi):
+    Mre = Mre.astype(object)
+    Mim = Mim.astype(object)
+    wr = wr.astype(object)
+    wi = wi.astype(object)
+    return int(wr @ Mre @ wr + wi @ Mre @ wi + 2 * (wi @ Mim @ wr))
+
+
+# w = A + iB -> (wr, wi) = (A0, B0); conj w -> (A0, -B0)
+Ksep = DQ[1]  # i (D2 Q_1) as Hermitian imaginary part
+sep_w = sesq(ZERO, Ksep, A0, B0)
+sep_cw = sesq(ZERO, Ksep, A0, -B0)
+gate("B10.4", sep_w == -sep_cw and sep_w != 0,
+     f"K-odd separator i(D2 Q_1): opposite nonzero values ({sep_w}, {sep_cw})")
+# raw projector pair 2 Q_1 -+ i(D2 Q_1): Hermitian real part 2 Q_1, imag part -+ D2 Q_1
+Pa_w = sesq(2 * Q[1], -DQ[1], A0, B0)
+Pa_cw = sesq(2 * Q[1], -DQ[1], A0, -B0)
+Pb_w = sesq(2 * Q[1], DQ[1], A0, B0)
+Pb_cw = sesq(2 * Q[1], DQ[1], A0, -B0)
+gate("B10.5", (Pa_w == 0) != (Pa_cw == 0) and (Pb_w == 0) != (Pb_cw == 0)
+     and Pa_w == Pb_cw and Pa_cw == Pb_w,
+     f"projector pair one-zero with K swap: 2Q_1-i(D2Q_1)->({Pa_w},{Pa_cw}), "
+     f"2Q_1+i(D2Q_1)->({Pb_w},{Pb_cw})")
+qf_w = sesq(Q[1], ZERO, A0, B0)
+qf_cw = sesq(Q[1], ZERO, A0, -B0)
+gate("B10.6", qf_w == qf_cw and qf_w != 0,
+     f"K-real symmetric face Q_1: SAME value on the conjugate pair ({qf_w}, {qf_cw})")
+
+print(f"[info] m=1 value tables: |v|^2={vv}, |w|^2={normw}, "
+      f"i(D2Q1) on (w, conj w)=({sep_w}, {sep_cw}), "
+      f"projector 2Q1-i(D2Q1) on (w, conj w)=({Pa_w}, {Pa_cw}), Q1 face=({qf_w}, {qf_cw})")
+
+# ============================================================================
+# B11 - note hygiene (the only gate that reads a target file back)
+# ============================================================================
+NOTE_NAME = "KCPT_BULK_BLOCK_EIGENVALUE_STRATIFICATION_ADJACENCY_NATIVE_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-19.md"
+note_path = os.path.join(DOCS, NOTE_NAME)
+with open(note_path, encoding="utf-8") as fh:
+    note_raw = fh.read()
+note_low = note_raw.lower()
+
+FORBIDDEN = ["the spec", "spectrum", "spectral", "retained", "audited",
+             "conditional", "open_gate", "pass with", "effective_status",
+             "exhausts", "exhausted", "only route", "last route",
+             "closes the", "final route"]
+present_forbidden = [s for s in FORBIDDEN if s in note_low]
+gate("B11.1", present_forbidden == [],
+     f"forbidden substrings absent from the note ({present_forbidden or 'none'})")
+
+REQUIRED = ["bounded_theorem", "10 = 4 + 4 + 2", "ten on the image block",
+            "M = 2 (T_200 + T_020 + T_002) - 6 I", "(D2 Q_m)^2 = -4 m N_m Q_m"]
+missing_req = [s for s in REQUIRED if s not in note_raw]
+gate("B11.2", missing_req == [],
+     f"required verbatim strings present ({missing_req or 'all present'})")
+
+DEP_LINKS = [
+    "MINIMAL_AXIOMS_2026-06-29.md",
+    "KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md",
+    "KCPT_KERNEL_INDUCED_REPRESENTATION_CENTRAL_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-18.md",
+    "KCPT_KERNEL_KREAL_READOUT_FACE_CLASSIFICATION_BOUNDED_THEOREM_NOTE_2026-07-18.md",
+    "KCPT_AMBIENT_LATTICE_SYMMETRY_KERNEL_ISOLATION_AVERAGED_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-19.md",
+]
+link_targets = set(re.findall(r"\]\(([^)]+)\)", note_raw))
+links_present = all(any(d in lt for lt in link_targets) for d in DEP_LINKS)
+deps_exist = all(os.path.isfile(os.path.join(DOCS, d)) for d in DEP_LINKS)
+gate("B11.3", links_present and deps_exist,
+     "all five dependency links present as markdown links and the deps exist")
+gate("B11.4", "**Type:** bounded_theorem" in note_raw and "## Boundary" in note_raw
+     and "**Claim boundary:**" in note_raw,
+     "note carries the bounded_theorem front matter, claim boundary, and Boundary section")
+
+# ----------------------------------------------------------------------------
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## What this responds to

Unit 6 of the KCPT swap/rotation/conjugacy lane. Units 1–5 established, on the
`C^64` staggered bulk block, that the nearest-neighbor adjacency `D2` carries a
K-real complex structure registered on the image/kernel split. This unit asks the
next question that opens: **how does the bulk block stratify under the squared
adjacency `M = D2^2`, and does the adjacency-native complex structure survive that
stratification shell-by-shell?**

## What changed (source-only triple)

- **Note** `docs/KCPT_BULK_BLOCK_EIGENVALUE_STRATIFICATION_ADJACENCY_NATIVE_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-19.md`
  (`bounded_theorem`, out_degree 5).
- **Runner** `scripts/kcpt_bulk_block_eigenvalue_stratification_2026_07_19.py`
  (69 exact integer/rational gates).
- **Cache** `logs/runner-cache/kcpt_bulk_block_eigenvalue_stratification_2026_07_19.txt`.
- Separate `audit-infra:` commit refreshing `citation_graph_manifest.json`
  (node_count 4401→4402, edge_count 14767→14772) for the stage-18 authority-link guard.

## Result

The carrier identity `M = 2 (T_200 + T_020 + T_002) - 6 I` in the `(Z/2)^3`
even-translation group algebra gives the minimal polynomial
`M (M+4I)(M+8I)(M+12I) = 0`, hence four strata `lambda_m = -4 m` with drop-one
projectors `Q_m`, normalizers `N_m = (384, -128, 128, -384)` and dims
`(8, 24, 24, 8)`. Momentum waves `phi_k` are `M`-eigenvectors at
`lambda = -4 wt(k)`; the kernel projector `Q_0 = 6 V8 V8^T` is the corner frame,
and `8 Q_m` resolves into the Hamming-weight isotypic blocks of `ker pi`.

Exact character sums over the order-768 ambient group give commutant dims
`e_m = (2, 4, 4, 2)`, resolving the parent ten on the image block as
`10 = 4 + 4 + 2` with all cross terms zero and Frobenius–Schur `nu_m = (0,2,0,0)`.
On each bulk stratum `D2^2 = -4 m`, so against the idempotent `P_m = Q_m/N_m` the
square `(D2 Q_m)^2 = -4 m N_m^2 P_m` is a **negative** multiple of `P_m` on every
bulk shell: the adjacency-native complex structure is carried stratum-by-stratum by
nearest-neighbor adjacency alone.

## Verification

`python3 scripts/kcpt_bulk_block_eigenvalue_stratification_2026_07_19.py` →
`TOTAL: PASS=69 FAIL=0`, exit 0. All gates are exact integer/rational (Fraction
character sums, sympy rank), with wrong-value rejectors and a sign gate (B9.11)
that pins the raw `-4 m N_m = (0, 512, -1024, 4608)` as **not** uniformly negative
while the idempotent-normalized `-4 m N_m^2 < 0` holds on every bulk shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
