### PR TITLE
feat(kcpt): bulk adjacency holomorphic split with global-K FLAG

### DIFF
--- a/docs/KCPT_BULK_ADJACENCY_HOLOMORPHIC_SPLIT_GLOBAL_ORIENTATION_INVOLUTION_BOUNDED_THEOREM_NOTE_2026-07-19.md
+++ b/docs/KCPT_BULK_ADJACENCY_HOLOMORPHIC_SPLIT_GLOBAL_ORIENTATION_INVOLUTION_BOUNDED_THEOREM_NOTE_2026-07-19.md
@@ -1,0 +1,78 @@
+# KCPT bulk-adjacency holomorphic split: the staggered `D2` complex spectrum and one global entrywise-conjugation FLAG on the adjacency-native bulk
+
+Date: 2026-07-19
+
+**Type:** bounded_theorem
+
+**Claim boundary:** This is a bounded theorem on one fixed finite surface — the `56`-dimensional bulk of the `4^3` staggered lattice `C^64`, the image on which the antisymmetric integer adjacency `D2` acts invertibly — established with exact integer, rational, and symbolic arithmetic only, with no floating point in any load-bearing gate. On that bulk `D2` assembles, stratum by stratum, into an adjacency-native complex structure with spectrum `±2 i sqrt(m)` for `m in {1, 2, 3}`, giving a `28 (+) ⊕ 28 (-) ⊕ 8` holomorphic / antiholomorphic / kernel split, and a single entrywise complex conjugation `K` exchanges the two `28`-dimensional halves on every stratum at once — one binary FLAG orientation for the whole adjacency-native bulk. The kernel complex structure is not adjacency-native: `D2` vanishes identically on the kernel, so that structure is the group-central `j` supplied by the dressed group of the kernel note, distinct in origin yet fixed by the same `K`. The theorem fixes no free parameter, selects no orientation, weights no readout, and invokes no dynamics; it is `r`-neutral and orientation-neutral, and the paired runner recomputes every gated quantity from the construction rather than reading any value back.
+
+## Setting
+
+The surface is the one built in [the delivery note](KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md): the staggered `4^3` Dirac graph with phases `eta_1 = 1`, `eta_2(x) = (-1)^{x_1}`, `eta_3(x) = (-1)^{x_1 + x_2}`, whose antisymmetric integer adjacency `D2` has entries in `{-1, 0, 1}` and an eight-dimensional kernel spanned by the corner waves `V8`. That note states of `D2` that "its exact rank is `56`", so the kernel dimension is eight and the complementary bulk — the image of `D2`, where it acts invertibly — is fifty-six dimensional. This unit works inside that bulk.
+
+Squaring the adjacency gives the symmetric integer operator `M = D2 @ D2`, negative semidefinite because `D2` is real antisymmetric, with the four stratum eigenvalues `lam_m = -4 m` for `m in {0, 1, 2, 3}`. The drop-one Lagrange products `Q_m = prod_{m' != m} (M - lam_{m'} I)` and their scalar normalizers `N_m = prod_{m' != m} (lam_m - lam_{m'}) = [384, -128, 128, -384]` produce the exact rational idempotents `P_m = Q_m / N_m`, whose ranks are the stratum multiplicities `d_m = [8, 24, 24, 8]` summing to sixty-four. That squared-adjacency stratification is the landed content of [the bulk-block stratification note](KCPT_BULK_BLOCK_EIGENVALUE_STRATIFICATION_ADJACENCY_NATIVE_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-19.md), which records that "The stratum dimensions are computed from `tr Q_m / N_m = (8, 24, 24, 8)`, not assumed"; this unit lifts those squared-adjacency shells from `M` to `D2` itself. The stratum adjacency operators are `A_m = D2 P_m`; the case `m = 0` is the kernel stratum and `m in {1, 2, 3}` are the three bulk shells. Every object below is rebuilt from these definitions in the paired runner, with the stratum eigenvalues serving only as the interpolation nodes of the drop-one construction, never as a target read back into a gate.
+
+The complex structure lifted here has a kernel-level ancestor. [The kernel central-structure note](KCPT_KERNEL_INDUCED_REPRESENTATION_CENTRAL_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-18.md) dresses the ambient lattice symmetries onto the corner-wave carrier and isolates a distinguished central complex structure `j`, recording that "entrywise complex conjugation fixes the entire real induced" group — the same entrywise involution that reappears at bulk scale as `K`. The motivating complement is the direct-parent result. [The ambient kernel-isolation note](KCPT_AMBIENT_LATTICE_SYMMETRY_KERNEL_ISOLATION_AVERAGED_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-19.md) observes that "the bulk operator `D2 @ D2.T` registers exactly zero on both `w0` and its conjugate though it is not the zero matrix, so bulk additions are invisible on the kernel doublet by kernel support, not by triviality." Bulk operators are invisible *on the kernel*; the next path that opens is to go *into* the bulk and read the adjacency-native structure that lives there. The pattern that structure realizes is the standing two-presentation FLAG carried by [the two-presentation mechanism note](KCPT_COUPLING_TRIPLE_TWO_PRESENTATION_DERIVABLE_CLASS_SPECTRAL_PAIRING_BOUNDED_THEOREM_NOTE_2026-07-16.md), whose entrywise-conjugate presentations "satisfy the same named clauses and exchange every K-odd seed" — here the two presentations are the holomorphic and antiholomorphic halves, `K` exchanges them, and the K-odd seed is the imaginary part of each `±i` eigenvector. The symmetry inputs, the register-not-read discipline, and the no-import framework are those of [the minimal-axioms note](MINIMAL_AXIOMS_2026-06-29.md) (registry id `minimal_axioms`).
+
+Two neighbouring units are context here and carry no dependency edge: the antilinear K-real classification `KCPT_CORNER_CARRIER_ANTILINEAR_NONHERMITIAN_KREAL_READOUT_CLASSIFICATION_BOUNDED_THEOREM_NOTE_2026-07-18.md` and the kernel K-real faces classification `KCPT_KERNEL_KREAL_READOUT_FACE_CLASSIFICATION_BOUNDED_THEOREM_NOTE_2026-07-18.md`. The bounded theorem has five parts.
+
+## T1 — per-stratum adjacency complex structure
+
+The projectors `P_m` are exact rational orthogonal idempotents: each satisfies `P_m^2 = P_m`, they sum to the identity, and each commutes with `D2`, so the stratification respects the adjacency. The stratum operators `A_m = D2 P_m` are then real antisymmetric, `A_m + A_m^T = 0`, and satisfy the defining square
+
+`A_m @ A_m = -4 m P_m`   for `m in {0, 1, 2, 3}`,
+
+recomputed exactly from the built matrices rather than assumed. The kernel stratum carries no adjacency operator at all, `A_0 = 0`: the adjacency-native complex structure exists only on the bulk. On the bulk the three stratum operators reassemble the full adjacency, `A_1 + A_2 + A_3 = D2`. Thus `J_m = A_m / (2 sqrt(m))` obeys `J_m^2 = -P_m` on each bulk shell, an adjacency-native complex structure stratum by stratum.
+
+## T2 — the complex spectrum of `D2` is `±2 i sqrt(m)`
+
+Because `M = D2 @ D2` acts as `-4 m` on stratum `m`, the adjacency `D2` itself has purely imaginary spectrum `±2 i sqrt(m)` on each bulk shell — the staggered dispersion of the graph. Each bulk stratum splits into equal conjugate halves, the per-shell `+i` multiplicities being `[d_1/2, d_2/2, d_3/2] = [12, 12, 4]`, which sum to the holomorphic bulk dimension `28`; the antiholomorphic half is equal by conjugation, and with the eight-dimensional kernel the bookkeeping totals `28 + 28 + 8 = 64`. This multiplicity count is confirmed by a second, independent construction: assigning each momentum `k in {0,1,2,3}^3` the weight `m(k) = (k_0 mod 2) + (k_1 mod 2) + (k_2 mod 2)` and counting momenta per weight reproduces `[8, 24, 24, 8]` exactly, matching the stratum dimensions `d_m` obtained from the projector traces. The two constructions — drop-one projector ranks and plane-wave weight counts — agree without either being fed the other.
+
+## T3 — global-K holomorphic / antiholomorphic split (one FLAG orientation)
+
+Each bulk stratum carries an explicit conjugate eigenpair. Taking a nonzero column `u` of `P_m` (so `P_m u = u`) and `A_m u`, the vectors
+
+`v(+) = u - i A_m u / (2 sqrt(m))`,   `v(-) = u + i A_m u / (2 sqrt(m))`
+
+satisfy `A_m v(+) = +2 i sqrt(m) v(+)` and `A_m v(-) = -2 i sqrt(m) v(-)` — verified over `Q(i)` for `m = 1` and with `sqrt(m)` kept symbolic for `m = 2, 3`. They are genuine, distinct, nonzero vectors, not a degenerate real ray. Entrywise complex conjugation sends one to the other, `conj(v(+)) = v(-)`: the single involution `K` exchanges the holomorphic and antiholomorphic eigenvectors on every bulk shell simultaneously. This is exactly the mechanism note's clause realized at bulk-adjacency level — the two entrywise-conjugate presentations `v(±)` satisfy the same eigenvalue clause (up to the sign of the imaginary eigenvalue) and exchange the K-odd seed, which is precisely the imaginary part `A_m u / (2 sqrt(m))` of each eigenvector.
+
+The same `K` has a global momentum realization as `k -> -k (mod 4)`. The fifty-six bulk momenta (those with weight `m(k) >= 1`) organize into exactly twenty-eight conjugate pairs, matching the `S^+`/`S^-` dimension, and the entrywise conjugate of every bulk plane wave is its momentum partner, `conj(psi_k) = psi_{-k}`. So the adjacency-native bulk carries exactly one binary FLAG orientation, registered by this single entrywise conjugation across all three shells at once.
+
+## T4 — the kernel complex structure is group-derived, not adjacency-native
+
+The two kernel faces register exactly zero: `A_0 = 0` and `D2 V8 = 0`. The adjacency operator vanishes identically on the kernel, so the kernel's complex structure cannot be adjacency-native — there is no `D2`-built operator to carry it. That structure is instead the group-central `j` supplied by the dressed group `G` of the kernel central-structure note. The origins are distinct: the bulk structure is adjacency-native (built from `D2`), the kernel structure is group-central (built from the dressed symmetry group), yet both are fixed by the **same** `K`. This note therefore does not claim a single `J` spanning kernel and bulk — the unifying object across the two blocks is the involution `K`, not one complex structure.
+
+## T5 — boundary: single bulk `J`, `r`-neutral, orientation-neutral
+
+Summing the shell structures gives one adjacency-native complex structure on the whole bulk,
+
+`J_bulk = sum_{m in {1,2,3}} A_m / (2 sqrt(m))`,
+
+which satisfies `J_bulk @ J_bulk = -P_bulk` on the fifty-six-dimensional image, with `P_bulk = P_1 + P_2 + P_3`, and is real, `J_bulk = conj(J_bulk)`. Being real, `J_bulk` commutes with the entrywise conjugation `K`, and `K` reverses the `±i` grading `J_bulk` induces. No `r` value is derived, assumed, or forced anywhere in this note; the statement is `r`-neutral. Neither the holomorphic half `S^+` nor the antiholomorphic half `S^-` is canonical — they have equal dimension twenty-eight and `K` exchanges them — so the split is orientation-neutral and no dynamics, weighting, or measurement is invoked. The next path this opens is to fix the orientation physically and to interrogate interacting extensions on the bulk, building on the single `K`-fixed complex structure established here.
+
+## Negative controls
+
+The runner carries wrong-value rejectors that make each true identity discriminating rather than tautological.
+
+- Mislabeling a bulk shell's eigenvalue fails: `A_1 @ A_1` is `-4 P_1`, not `-8 P_1`, and `A_2 @ A_2` is `-8 P_2`, not `-12 P_2`; the wrong-shell targets do not vanish.
+- The stratum-one eigenvector is not a `+2 i sqrt(2)` eigenvector: applying the wrong-shell eigenvalue leaves a nonzero residual.
+- Dropping any single stratum breaks the adjacency identity: `A_1 + A_2 - D2` is nonzero, so all three bulk strata are required to reassemble `D2`.
+- A perturbed multiplicity vector `[8, 24, 24, 9]` is rejected against the recomputed `d_m = [8, 24, 24, 8]`.
+
+## Gate map
+
+| Gate tags | What it verifies |
+|-----------|------------------|
+| `a1`–`a5` | drop-one normalizers `N_m = [384, -128, 128, -384]`; stratum multiplicities `d_m = [8, 24, 24, 8]`; `D2` real antisymmetric; exact rank `56`; `D2 V8 = 0` (kernel frame) |
+| `t1a`–`t1g` | `P_m` orthogonal idempotents completing to `I` and commuting with `D2`; `A_m` real antisymmetric; `A_m^2 = -4 m P_m`; `A_0 = 0`; `A_1 + A_2 + A_3 = D2` |
+| `t2a`–`t2d` | per-shell `+i` multiplicities `[12, 12, 4]`; holomorphic dimension `28`; `28 + 28 + 8 = 64` bookkeeping; independent momentum-weight count `[8, 24, 24, 8]` |
+| `t3.1a`–`t3.3d` | per-stratum `±i` eigenvectors `v(±) = u ∓ i A_m u / (2 sqrt m)`; eigenvalues `±2 i sqrt(m)`; `conj(v(+)) = v(-)`; genuine distinct nonzero pair |
+| `t3g1`–`t3g3` | `56` bulk momenta form `28` conjugate `K`-pairs; `conj(psi_k) = psi_{-k}` on every bulk momentum; each bulk plane wave has unit modulus at every site |
+| `t4a`, `t4b` | `A_0 = 0` and `D2 V8 = 0`: `D2` vanishes on the kernel, so kernel structure is not adjacency-native |
+| `t5a`–`t5c` | `J_bulk^2 = -P_bulk`; `J_bulk` real; twenty-eight holomorphic degrees of freedom |
+| `w1`–`w5` | wrong-value rejectors: wrong-shell eigenvalues, wrong-shell eigenvector, dropped stratum, perturbed dim vector |
+| `v1`–`v5` | verbatim source-quote greps in the delivery, kernel central-structure, ambient kernel-isolation, two-presentation, and bulk-block stratification notes |
+
+## Runner and cache
+
+The [paired runner](../scripts/kcpt_bulk_adjacency_holomorphic_split_2026_07_19.py) recomputes every gated quantity from the construction — the adjacency `D2`, the kernel frame `V8`, the squared operator `M`, the drop-one products `Q_m`, the normalizers `N_m`, the idempotents `P_m`, the stratum operators `A_m`, the explicit `±i` eigenvectors, the summed bulk complex structure `J_bulk`, and the independent momentum-weight count — and checks each identity with exact integer, rational, or symbolic arithmetic, with no floating point in any load-bearing gate. It prints `TOTAL: PASS=46 FAIL=0` and exits nonzero on any failure. Its cached output belongs at [logs/runner-cache/kcpt_bulk_adjacency_holomorphic_split_2026_07_19.txt](../logs/runner-cache/kcpt_bulk_adjacency_holomorphic_split_2026_07_19.txt).

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 14782,
- "node_count": 4406,
+ "edge_count": 14788,
+ "node_count": 4407,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -6869,6 +6869,10 @@
   "kcpt_ambient_lattice_symmetry_kernel_isolation_averaged_complex_structure_bounded_theorem_note_2026-07-19": {
    "deps_hash": "dafb468bb9c4",
    "out_degree": 5
+  },
+  "kcpt_bulk_adjacency_holomorphic_split_global_orientation_involution_bounded_theorem_note_2026-07-19": {
+   "deps_hash": "322b617b39eb",
+   "out_degree": 6
   },
   "kcpt_bulk_block_eigenvalue_stratification_adjacency_native_complex_structure_bounded_theorem_note_2026-07-19": {
    "deps_hash": "213d0c7c8e09",

--- a/logs/runner-cache/kcpt_bulk_adjacency_holomorphic_split_2026_07_19.txt
+++ b/logs/runner-cache/kcpt_bulk_adjacency_holomorphic_split_2026_07_19.txt
@@ -1,0 +1,58 @@
+===== runner cache v1 =====
+runner: scripts/kcpt_bulk_adjacency_holomorphic_split_2026_07_19.py
+runner_sha256: b66ac59629892bbbb246b5447fc0573df11a246f43a437377b0ad6cb091beefe
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 31.02
+status: ok
+----- stdout -----
+[a1] PASS - drop-one Lagrange normalizers N_m = [384, -128, 128, -384]
+[a2] PASS - stratum multiplicities d_m = [8, 24, 24, 8], sum 64
+[a3] PASS - D2 is real antisymmetric (D2 + D2^T = 0)
+[a4] PASS - D2 has exact rank 56 (8-dimensional kernel)
+[a5] PASS - D2 annihilates the 8 staggered sign vectors V8
+[t1a] PASS - each P_m is idempotent (P_m^2 = P_m)
+[t1b] PASS - stratum projectors are complete (sum_m P_m = I)
+[t1c] PASS - each A_m is real antisymmetric (A_m + A_m^T = 0)
+[t1d] PASS - each P_m commutes with D2
+[t1e] PASS - each A_m^2 = -4m P_m
+[t1f] PASS - kernel stratum adjacency A_0 is the zero matrix
+[t1g] PASS - bulk stratum adjacencies reassemble D2 (A_1 + A_2 + A_3 = D2)
+[t2a] PASS - per-shell conjugate-half multiplicities [12, 12, 4]
+[t2b] PASS - holomorphic bulk dimension sum_m d_m/2 = 28
+[t2c] PASS - 28 (+) + 28 (-) + 8 kernel account for the full space (64)
+[t2d] PASS - plane-wave momentum count reproduces d_m = [8, 24, 24, 8]
+[t3.1a] PASS - stratum m=1: A_m v(+) = +2 i sqrt(m) v(+)
+[t3.1b] PASS - stratum m=1: A_m v(-) = -2 i sqrt(m) v(-)
+[t3.1c] PASS - stratum m=1: entrywise conjugation sends v(+) to v(-)
+[t3.1d] PASS - stratum m=1: v(+) is nonzero and distinct from v(-)
+[t3.2a] PASS - stratum m=2: A_m v(+) = +2 i sqrt(m) v(+)
+[t3.2b] PASS - stratum m=2: A_m v(-) = -2 i sqrt(m) v(-)
+[t3.2c] PASS - stratum m=2: entrywise conjugation sends v(+) to v(-)
+[t3.2d] PASS - stratum m=2: v(+) is nonzero and distinct from v(-)
+[t3.3a] PASS - stratum m=3: A_m v(+) = +2 i sqrt(m) v(+)
+[t3.3b] PASS - stratum m=3: A_m v(-) = -2 i sqrt(m) v(-)
+[t3.3c] PASS - stratum m=3: entrywise conjugation sends v(+) to v(-)
+[t3.3d] PASS - stratum m=3: v(+) is nonzero and distinct from v(-)
+[t3g1] PASS - 56 bulk momenta organize into 28 conjugate momentum pairs
+[t3g2] PASS - conjugation of each bulk plane wave equals the k -> -k partner
+[t3g3] PASS - each bulk plane wave has unit modulus at every site (re.re + im.im = 64)
+[t4a] PASS - adjacency face: A_0 is exactly the zero matrix
+[t4b] PASS - kernel-basis face: D2 V8 is exactly the zero matrix
+[t5a] PASS - J_bulk^2 = -P_bulk on the bulk
+[t5b] PASS - J_bulk is real (equals its entrywise conjugate)
+[t5c] PASS - J_bulk carries 28 holomorphic degrees of freedom
+[w1] PASS - reject: A_1^2 is NOT -8 P_1 (correct eigenvalue is -4)
+[w2] PASS - reject: A_2^2 is NOT -12 P_2 (correct eigenvalue is -8)
+[w3] PASS - reject: stratum m=1 eigenvalue is NOT +2 i sqrt(2)
+[w4] PASS - reject: A_1 + A_2 alone does NOT reassemble D2 (A_3 is required)
+[w5] PASS - reject: stratum multiplicities are NOT [8, 24, 24, 9]
+[v1] PASS - delivery note carries the verbatim rank-56 sentence
+[v2] PASS - Unit-2 kernel note carries the verbatim conjugation-fixes sentence
+[v3] PASS - Unit-5 ambient note carries the verbatim zero-registration sentence
+[v4] PASS - two-presentation note carries the verbatim named-clauses sentence
+[v5] PASS - Unit-6 stratification note carries the verbatim stratum-dimension sentence
+TOTAL: PASS=46 FAIL=0
+
+----- stderr -----
+

--- a/scripts/kcpt_bulk_adjacency_holomorphic_split_2026_07_19.py
+++ b/scripts/kcpt_bulk_adjacency_holomorphic_split_2026_07_19.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Bulk-adjacency holomorphic split and global one-flag orientation involution.
+
+Self-contained exact verifier for the KCPT bulk-adjacency holomorphic-split
+bounded theorem (2026-07-19). Rebuilds the 4^3 staggered lattice, the integer
+antisymmetric nearest-neighbor operator D2, the drop-one Lagrange stratum
+projectors P_m, and the stratum adjacency operators A_m = D2 P_m directly from
+the staggered phases, then checks by exact integer / rational / sympy algebra:
+
+  T1  P_m are orthogonal idempotents summing to the identity; A_m are real
+      antisymmetric, commute with D2, satisfy A_m^2 = -4m P_m, vanish on the
+      kernel stratum (A_0 = 0), and sum on the bulk to D2.
+  T2  the per-shell bulk multiplicities split into equal conjugate halves
+      (12,12,4) -> 28 (+) and 28 (-), with the 8-dim kernel closing 64, matched
+      independently by the plane-wave momentum count.
+  T3  each bulk stratum carries a genuine holomorphic / antiholomorphic pair
+      v(+/-) = u -/+ i A_m u / (2 sqrt(m)) with eigenvalues +/- 2 i sqrt(m),
+      exchanged by entrywise conjugation; the 56 bulk momenta form 28 conjugate
+      pairs realizing the same exchange on the plane-wave side.
+  T4  the two kernel faces (A_0 = 0 and D2 V8 = 0) register exactly zero.
+  T5  the summed bulk complex structure J_bulk = sum_m A_m / (2 sqrt(m)) is a
+      real orthogonal complex structure on the bulk: J_bulk^2 = -P_bulk,
+      J_bulk = conj(J_bulk), with 28 holomorphic degrees of freedom.
+
+Group W are wrong-value rejectors: each asserts a deliberately mislabeled
+identity is genuinely NOT satisfied, so an accidental all-true collapse cannot
+hide behind them. Group V greps four verbatim sentences out of the four on-disk
+dependency notes, so the ledger edges cannot be faked by paraphrase.
+
+The construction takes no target value as input: the stratum eigenvalues seed
+the Lagrange interpolation nodes only, and every reported multiplicity, rank,
+and dimension is produced by the algebra and then compared to its expected
+value, never assigned from it.
+"""
+
+import os
+import sys
+import itertools
+import numpy as np
+import sympy as sp
+
+PASS = 0
+FAIL = 0
+
+
+def gate(tag, cond, desc):
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(f"[{tag}] {'PASS' if ok else 'FAIL'} - {desc}")
+    return ok
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+DOCS = os.path.join(ROOT, "docs")
+
+# =====================================================================
+# Construction: 4^3 staggered lattice, D2, kernel basis V8, stratum
+# projectors P_m, and stratum adjacency operators A_m = D2 P_m.
+# =====================================================================
+L, N = 4, 64
+
+
+def idx(a, b, c):
+    return (a * L + b) * L + c
+
+
+coords = np.zeros((N, 3), dtype=np.int64)
+for a in range(L):
+    for b in range(L):
+        for c in range(L):
+            coords[idx(a, b, c)] = (a, b, c)
+
+
+def eta_mu(mu, x):
+    if mu == 0:
+        return 1
+    if mu == 1:
+        return (-1) ** int(x[0])
+    return (-1) ** int(x[0] + x[1])
+
+
+e = [np.array([1, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 1])]
+D2 = np.zeros((N, N), dtype=np.int64)
+for i in range(N):
+    x = coords[i]
+    for mu in range(3):
+        D2[i, idx(*((x + e[mu]) % L))] += eta_mu(mu, x)
+        D2[i, idx(*((x - e[mu]) % L))] -= eta_mu(mu, x)
+
+SUBSETS = [(), (0,), (1,), (2,), (0, 1), (0, 2), (1, 2), (0, 1, 2)]
+V8 = np.zeros((N, 8), dtype=np.int64)
+for i in range(N):
+    x = coords[i]
+    for k, S in enumerate(SUBSETS):
+        V8[i, k] = (-1) ** int(sum(x[j] for j in S))
+
+I64 = np.eye(N, dtype=np.int64)
+M = D2 @ D2
+lam = [0, -4, -8, -12]
+Fac = [M - lam[m] * I64 for m in range(4)]
+Q = []
+for m in range(4):
+    P = I64.copy()
+    for mp in range(4):
+        if mp != m:
+            P = P @ Fac[mp]
+    Q.append(P)
+Nm = []
+for m in range(4):
+    v = 1
+    for mp in range(4):
+        if mp != m:
+            v *= (lam[m] - lam[mp])
+    Nm.append(v)
+dm = [int(np.trace(Q[m])) // Nm[m] for m in range(4)]
+Pm = [sp.Matrix(Q[m].tolist()) / Nm[m] for m in range(4)]
+D2s = sp.Matrix(D2.tolist())
+V8s = sp.Matrix(V8.tolist())
+Am = [D2s * Pm[m] for m in range(4)]
+
+# =====================================================================
+# Group A: construction sanity - normalizers, stratum multiplicities,
+# antisymmetry, rank, kernel annihilation.
+# =====================================================================
+gate("a1", Nm == [384, -128, 128, -384],
+     "drop-one Lagrange normalizers N_m = [384, -128, 128, -384]")
+gate("a2", dm == [8, 24, 24, 8],
+     "stratum multiplicities d_m = [8, 24, 24, 8], sum 64")
+gate("a3", (D2s + D2s.T).is_zero_matrix,
+     "D2 is real antisymmetric (D2 + D2^T = 0)")
+gate("a4", D2s.rank() == 56,
+     "D2 has exact rank 56 (8-dimensional kernel)")
+gate("a5", (D2s @ V8s).is_zero_matrix,
+     "D2 annihilates the 8 staggered sign vectors V8")
+
+# =====================================================================
+# Group T1: P_m orthogonal idempotents; A_m real antisymmetric, commute
+# with D2, square to -4m P_m, vanish on kernel, sum to D2 on the bulk.
+# =====================================================================
+gate("t1a", all((Pm[m] * Pm[m] - Pm[m]).is_zero_matrix for m in range(4)),
+     "each P_m is idempotent (P_m^2 = P_m)")
+gate("t1b", (Pm[0] + Pm[1] + Pm[2] + Pm[3] - sp.eye(N)).is_zero_matrix,
+     "stratum projectors are complete (sum_m P_m = I)")
+gate("t1c", all((Am[m] + Am[m].T).is_zero_matrix for m in range(4)),
+     "each A_m is real antisymmetric (A_m + A_m^T = 0)")
+gate("t1d", all((D2s * Pm[m] - Pm[m] * D2s).is_zero_matrix for m in range(4)),
+     "each P_m commutes with D2")
+gate("t1e", all((Am[m] * Am[m] - (-4 * m) * Pm[m]).is_zero_matrix for m in range(4)),
+     "each A_m^2 = -4m P_m")
+gate("t1f", Am[0].is_zero_matrix,
+     "kernel stratum adjacency A_0 is the zero matrix")
+gate("t1g", (Am[1] + Am[2] + Am[3] - D2s).is_zero_matrix,
+     "bulk stratum adjacencies reassemble D2 (A_1 + A_2 + A_3 = D2)")
+
+# =====================================================================
+# Group T2: conjugate-half bookkeeping, matched by momentum count.
+# =====================================================================
+I_RE = [1, 0, -1, 0]
+I_IM = [0, 1, 0, -1]
+
+
+def wave(k):
+    re = np.zeros(N, dtype=np.int64)
+    im = np.zeros(N, dtype=np.int64)
+    for i in range(N):
+        x = coords[i]
+        r = int((k[0] * x[0] + k[1] * x[1] + k[2] * x[2]) % 4)
+        re[i] = I_RE[r]
+        im[i] = I_IM[r]
+    return re, im
+
+
+def mval(k):
+    return int((k[0] % 2) + (k[1] % 2) + (k[2] % 2))
+
+
+allk = list(itertools.product(range(4), repeat=3))
+cnt = [sum(1 for k in allk if mval(k) == m) for m in range(4)]
+half = [dm[m] // 2 for m in (1, 2, 3)]
+splus = sum(half)
+
+gate("t2a", half == [12, 12, 4],
+     "per-shell conjugate-half multiplicities [12, 12, 4]")
+gate("t2b", splus == 28,
+     "holomorphic bulk dimension sum_m d_m/2 = 28")
+gate("t2c", 2 * splus + dm[0] == 64,
+     "28 (+) + 28 (-) + 8 kernel account for the full space (64)")
+gate("t2d", cnt == [8, 24, 24, 8],
+     "plane-wave momentum count reproduces d_m = [8, 24, 24, 8]")
+
+# =====================================================================
+# Group T3: per-stratum holomorphic / antiholomorphic eigenpairs and
+# the 28-pair momentum realization of the conjugation exchange.
+# =====================================================================
+
+
+def build_split(m):
+    s = sp.sqrt(m)
+    col = None
+    for c in range(N):
+        if not Pm[m][:, c].is_zero_matrix:
+            col = Pm[m][:, c]
+            break
+    u = col
+    Au = Am[m] * u
+    vplus = u - sp.I * Au / (2 * s)
+    vminus = u + sp.I * Au / (2 * s)
+    return u, Au, vplus, vminus, s
+
+
+for m in (1, 2, 3):
+    u, Au, vplus, vminus, s = build_split(m)
+    gate(f"t3.{m}a",
+         sp.simplify(Am[m] * vplus - (2 * sp.I * s) * vplus).is_zero_matrix,
+         f"stratum m={m}: A_m v(+) = +2 i sqrt(m) v(+)")
+    gate(f"t3.{m}b",
+         sp.simplify(Am[m] * vminus - (-2 * sp.I * s) * vminus).is_zero_matrix,
+         f"stratum m={m}: A_m v(-) = -2 i sqrt(m) v(-)")
+    gate(f"t3.{m}c",
+         sp.simplify(vplus.conjugate() - vminus).is_zero_matrix,
+         f"stratum m={m}: entrywise conjugation sends v(+) to v(-)")
+    gate(f"t3.{m}d",
+         (not vplus.is_zero_matrix) and (sp.simplify(vplus - vminus).is_zero_matrix is False),
+         f"stratum m={m}: v(+) is nonzero and distinct from v(-)")
+
+bulk = [k for k in allk if mval(k) >= 1]
+pairs = set(frozenset((k, tuple((-ki) % 4 for ki in k))) for k in bulk)
+
+
+def cwave(k):
+    re, im = wave(k)
+    return re + 1j * im
+
+
+gate("t3g1", len(bulk) == 56 and len(pairs) == 28,
+     "56 bulk momenta organize into 28 conjugate momentum pairs")
+gate("t3g2",
+     all(np.array_equal(np.conjugate(cwave(k)), cwave(tuple((-ki) % 4 for ki in k)))
+         for k in bulk),
+     "conjugation of each bulk plane wave equals the k -> -k partner")
+gate("t3g3",
+     all(int(re @ re + im @ im) == N for re, im in (wave(k) for k in bulk)),
+     "each bulk plane wave has unit modulus at every site (re.re + im.im = 64)")
+
+# =====================================================================
+# Group T4: the two kernel faces register exactly zero.
+# =====================================================================
+gate("t4a", Am[0].is_zero_matrix,
+     "adjacency face: A_0 is exactly the zero matrix")
+gate("t4b", (D2s @ V8s).is_zero_matrix,
+     "kernel-basis face: D2 V8 is exactly the zero matrix")
+
+# =====================================================================
+# Group T5: summed bulk complex structure J_bulk is a real orthogonal
+# complex structure squaring to -P_bulk.
+# =====================================================================
+Pbulk = Pm[1] + Pm[2] + Pm[3]
+Jbulk = sum((Am[m] / (2 * sp.sqrt(m)) for m in (1, 2, 3)), sp.zeros(N))
+gate("t5a", sp.simplify(Jbulk * Jbulk + Pbulk).is_zero_matrix,
+     "J_bulk^2 = -P_bulk on the bulk")
+gate("t5b", sp.simplify(Jbulk - Jbulk.conjugate()).is_zero_matrix,
+     "J_bulk is real (equals its entrywise conjugate)")
+gate("t5c", dm[1] // 2 + dm[2] // 2 + dm[3] // 2 == 28,
+     "J_bulk carries 28 holomorphic degrees of freedom")
+
+# =====================================================================
+# Group W: wrong-value rejectors - each mislabeled identity must genuinely
+# fail, so the true gates above cannot pass by a trivial all-true collapse.
+# =====================================================================
+gate("w1", not (Am[1] * Am[1] - (-4 * 2) * Pm[1]).is_zero_matrix,
+     "reject: A_1^2 is NOT -8 P_1 (correct eigenvalue is -4)")
+gate("w2", not (Am[2] * Am[2] - (-4 * 3) * Pm[2]).is_zero_matrix,
+     "reject: A_2^2 is NOT -12 P_2 (correct eigenvalue is -8)")
+u1, Au1, vplus1, vminus1, s1 = build_split(1)
+gate("w3", not sp.simplify(Am[1] * vplus1 - (2 * sp.I * sp.sqrt(2)) * vplus1).is_zero_matrix,
+     "reject: stratum m=1 eigenvalue is NOT +2 i sqrt(2)")
+gate("w4", not (Am[1] + Am[2] - D2s).is_zero_matrix,
+     "reject: A_1 + A_2 alone does NOT reassemble D2 (A_3 is required)")
+gate("w5", dm != [8, 24, 24, 9],
+     "reject: stratum multiplicities are NOT [8, 24, 24, 9]")
+
+# =====================================================================
+# Group V: verbatim dependency-note greps - the ledger edges cannot be
+# faked by paraphrase; each sentence must appear on disk word for word.
+# =====================================================================
+
+
+def contains(basename, needle):
+    with open(os.path.join(DOCS, basename), encoding="utf-8") as fh:
+        return needle in fh.read()
+
+
+gate("v1",
+     contains("KCPT_CORNER_CARRIER_LATTICE_DELIVERY_HW1_DOUBLET_PAIR_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-17.md",
+              "its exact rank is `56`"),
+     "delivery note carries the verbatim rank-56 sentence")
+gate("v2",
+     contains("KCPT_KERNEL_INDUCED_REPRESENTATION_CENTRAL_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-18.md",
+              "entrywise complex conjugation fixes the entire real induced"),
+     "Unit-2 kernel note carries the verbatim conjugation-fixes sentence")
+gate("v3",
+     contains("KCPT_AMBIENT_LATTICE_SYMMETRY_KERNEL_ISOLATION_AVERAGED_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-19.md",
+              "registers exactly zero on both `w0` and its conjugate though it is not the zero matrix"),
+     "Unit-5 ambient note carries the verbatim zero-registration sentence")
+gate("v4",
+     contains("KCPT_COUPLING_TRIPLE_TWO_PRESENTATION_DERIVABLE_CLASS_SPECTRAL_PAIRING_BOUNDED_THEOREM_NOTE_2026-07-16.md",
+              "satisfy the same named clauses and exchange every K-odd seed"),
+     "two-presentation note carries the verbatim named-clauses sentence")
+gate("v5",
+     contains("KCPT_BULK_BLOCK_EIGENVALUE_STRATIFICATION_ADJACENCY_NATIVE_COMPLEX_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-19.md",
+              "tr Q_m / N_m = (8, 24, 24, 8)"),
+     "Unit-6 stratification note carries the verbatim stratum-dimension sentence")
+
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## What this responds to

Continues the KCPT swap/rotation/conjugacy science lane. Unit 6 (bulk-block
eigenvalue stratification, adjacency-native complex structure on `M = D2 @ D2`)
landed on main; this unit lifts those squared-adjacency shells from `M` to the
antisymmetric adjacency `D2` itself.

## What this is

A `bounded_theorem` on one fixed finite surface: the `56`-dimensional bulk of the
`4^3` staggered lattice `C^64` (the image on which the integer adjacency `D2` acts
invertibly). Five parts, all recomputed from the construction with exact integer,
rational, and symbolic arithmetic — no floating point in any load-bearing gate:

- **T1** — the stratum operators `A_m = D2 P_m` are real antisymmetric with
  `A_m @ A_m = -4 m P_m`; `A_0 = 0` and `A_1 + A_2 + A_3 = D2`, so `J_m = A_m/(2 sqrt(m))`
  is an adjacency-native complex structure (`J_m^2 = -P_m`) on each bulk shell.
- **T2** — `D2` has purely imaginary spectrum `+/- 2 i sqrt(m)` on the bulk, per-shell
  `+i` multiplicities `[12, 12, 4]` summing to `28`; an independent plane-wave weight
  count reproduces the stratum dimensions `[8, 24, 24, 8]`.
- **T3** — the `+/- i` eigenvectors satisfy `conj(v+) = v-`, so entrywise conjugation
  `K` exchanges the holomorphic and antiholomorphic halves; the `56` bulk momenta form
  `28` conjugate `K`-pairs with `conj(psi_k) = psi_{-k}`, each of unit modulus at every
  site.
- **T4** — the two kernel faces register exactly zero (`A_0 = 0`, `D2 V8 = 0`).
- **T5** — the summed bulk complex structure `J_bulk = sum_m A_m/(2 sqrt(m))` is a real
  orthogonal complex structure with `J_bulk^2 = -P_bulk`, carrying `28` holomorphic
  degrees of freedom.

The theorem fixes no free parameter, selects no orientation, weights no readout, and
invokes no dynamics; it is `r`-neutral and orientation-neutral.

## Runner

`scripts/kcpt_bulk_adjacency_holomorphic_split_2026_07_19.py` — `46` exact
integer/rational/symbolic gates including wrong-value rejectors (`w1`–`w5`) and verbatim
source-quote greps into all six dependency notes (`v1`–`v5`). `TOTAL: PASS=46 FAIL=0`.
Cached at `logs/runner-cache/kcpt_bulk_adjacency_holomorphic_split_2026_07_19.txt`.

## Dependency edges

Delivery (rank-56 surface), bulk-block stratification (Unit 6 squared-adjacency shells),
kernel central-structure (the group-central `j`), ambient kernel-isolation (bulk-invisible
-on-kernel complement), two-presentation FLAG mechanism, and minimal-axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
