### PR TITLE
feat(kcpt): chiral-parity Lagrangian polarization of Kähler triple

### DIFF
--- a/docs/KCPT_CHIRAL_PARITY_LAGRANGIAN_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-19.md
+++ b/docs/KCPT_CHIRAL_PARITY_LAGRANGIAN_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-19.md
@@ -1,0 +1,58 @@
+# KCPT chiral parity: Lagrangian polarization of the Kähler triple
+
+Date: 2026-07-19
+
+**Type:** bounded_theorem
+
+**Claim boundary:** This is a bounded theorem on one fixed finite surface — the real site representation `R^64` of the full `4^3` staggered lattice `C^64`, its antisymmetric integer adjacency `D2`, the corner-wave kernel frame `V8`, the bulk operator `M = D2 @ D2`, and three landed objects it reads through standard symplectic and Kähler geometry: the total complex structure `J_full = J_ker + J_bulk` (`J_full^2 = -I_64`, ambient-invariant), the staggered chiral parity `S_eps = diag((-1)^{x_1+x_2+x_3})` (a real involution with `S_eps J_full S_eps = -J_full`), and the Unit-10 Kähler triple `(g, J_full, omega)` with `g = I_64` and convention `omega(x,y) = g(J_full x,y)`, matrix `omega = J_full^T g = -J_full`. Writing `C^64 = L_+ (+) L_-` for the `±1` eigenspaces of `S_eps` (the even/odd staggered-parity site sets, each of dimension `32`), it records that each `L_±` is a Lagrangian subspace of `omega`, that `J_full` exchanges the two Lagrangian planes as a linear isomorphism `L_+ -> L_-`, that `S_eps` is an antisymplectic reality involution acting on `h = g + i*omega` as the conjugation `h -> conj(h)`, and that the order-`768` ambient group `G_amb` carries an index-`2` grading (preserve versus swap of the polarization) whose kernel is exactly the centralizer `C_{G_amb}(S_eps)` of order `384`. The symplectic-geometric packaging is the new content; its algebraic core — the vanishing diagonal parity blocks `J_full[L_+,L_+] = J_full[L_-,L_-] = 0` — is the Unit-9 identity `S_eps J_full S_eps = -J_full` re-expressed in parity blocks, not re-derived here. The polarization `{L_±}` is common to both orientations: the sibling `J_alt = J_ker - J_bulk` also exchanges the same `L_±`, and the relationship between the two orientations is inherited unchanged from Unit 9's common-sign-orbit result. `g = I_64` is the Unit-10 counting-choice metric representative, one point of a compatible-metric cone, not a forced one, so `h` and the reality reading inherit that choice. It fixes no free parameter, selects no orientation, and chooses no dynamics; it is `r`-neutral and measure-neutral. Its only inputs are the two linked dependency notes; the symplectic and Kähler vocabulary (Lagrangian subspace, polarization, antisymplectic, reality involution) is descriptive of the computed structure, not an imported axiom. Every load-bearing identity is a vanishing block sliced from an independently built matrix and paired with a discriminating rejector; each float gate is redundant with an exact statement.
+
+## Setting
+
+The surface and its landed complex structure are the ones fixed upstream. The staggered chiral parity `S_eps` and its action on `J_full` are established in [the chiral-parity common-sign-orbit note](KCPT_CHIRAL_PARITY_COMMON_SIGN_ORBIT_BOUNDED_THEOREM_NOTE_2026-07-19.md): `S_eps = diag((-1)^{x_1+x_2+x_3})` is a real involution, and its landed T4 is the total complex-structure sign reversal `S_eps J_full S_eps = -J_full`, scoped to the common-sign orbit `orbit_H(J_full) = {J_full, -J_full}`. The metric, symplectic form, and Hermitian form are the ones assembled in [the Kähler-triple note](KCPT_KAHLER_TRIPLE_AMBIENT_INVARIANT_METRIC_SYMPLECTIC_BOUNDED_THEOREM_NOTE_2026-07-19.md): the `G_amb`-invariant triple `(g, J_full, omega)` with `g = I_64`, convention `omega(x,y) = g(J_full x,y)`, matrix `omega = -J_full`, and positive-definite Hermitian form `h = g + i*omega` on the `32`-dimensional `+i` eigenspace. The total complex structure `J_full = J_ker + J_bulk` and its orientation sibling `J_alt = J_ker - J_bulk` are the `Unit 8` assembly these two parents both read; `Unit 8` enters this note only through them, so it is named in backticks and carries no separate dependency edge.
+
+This note takes one move both parents leave to the side: it reads the single real involution `S_eps` and the landed symplectic form `omega = -J_full` together, in the parity blocks of `S_eps`. The bounded theorem has six parts.
+
+## T1 — real parity polarization
+
+The chiral parity `S_eps` is a real involution on `C^64`: diagonal with entries in `{-1,+1}`, `S_eps^2 = I`, orthogonal (`S_eps^T S_eps = I`), and traceless. Its `±1` eigenspaces `L_+` and `L_-` are the even and odd staggered-parity site sets; each has dimension `32`, and together they partition the standard basis, `L_+ (+) L_- = C^64`. This is the real polarization the rest of the note reads.  [gates G1, G2]
+
+## T2 — each parity plane is Lagrangian
+
+Take the Unit-10 symplectic convention `omega(x,y) = g(J_full x,y)` with `g = I_64`, whose matrix is `omega = J_full^T g = -J_full` (`J_full` antisymmetric). Restricted to `L_+` and to `L_-`, the form vanishes: the diagonal parity blocks `omega[L_+,L_+]` and `omega[L_-,L_-]` are zero, equivalently the diagonal parity blocks of `J_full` vanish. Since `dim L_± = 32` is exactly half of `64`, each `L_±` is a Lagrangian subspace of `omega`. This is Unit 9's T4, `S_eps J_full S_eps = -J_full`, written in parity blocks: the sign reversal is exactly the statement that the diagonal blocks vanish. The form is nondegenerate — its off-diagonal `L_+ × L_-` block is nonzero and its determinant is a nonzero integer — so the two Lagrangian planes are genuinely complementary, not a degenerate coincidence.  [gates G3, G4, G5, G6]
+
+## T3 — `J_full` exchanges the Lagrangian planes
+
+`J_full` anticommutes with `S_eps`, `S_eps J_full + J_full S_eps = 0`, and the anticommutation is genuine (the commutator `S_eps J_full - J_full S_eps` is nonzero). Anticommutation is exactly the statement `J_full(L_+) = L_-` and `J_full(L_-) = L_+`: the diagonal parity blocks of `J_full` vanish and the off-diagonal block `J_full: L_+ -> L_-` has full rank `32`, a linear isomorphism. Hence `(L_+, L_-)` is a transverse Lagrangian pair and `J_full` is the Kähler polarization intertwiner exchanging them.  [gates G7, G8, G9, G10]
+
+## T4 — `S_eps` is an antisymplectic reality involution
+
+Against the symplectic form `S_eps` is antisymplectic: `S_eps^T omega S_eps = -omega`. On the Unit-10 Hermitian form `h = g + i*omega` with `g = I_64` it acts as a reality conjugation, `S_eps^T h S_eps = conj(h) = g - i*omega`, and the conjugation is nontrivial (`h != conj(h)` because `omega != 0`). Equivalently, `S_eps` carries the `+i` eigenspace of `J_full` — the `32`-dimensional holomorphic plane — onto the `-i` eigenspace: `J_full(S_eps V) = -i (S_eps V)` for every `V` with `J_full V = i V`. So `S_eps` interchanges the holomorphic and anti-holomorphic polarizations, a lattice realization of a reality / CP involution `h -> conj(h)`.  [gates G11, G12, G13, G14, G19]
+
+## T5 — ambient index-2 grading
+
+Every element of the order-`768` ambient group `G_amb` is a signed permutation that shifts total staggered parity uniformly, so it maps `L_+` entirely into `L_+` or entirely into `L_-`; either way it preserves the unordered pair `{L_+, L_-}`. The subgroup fixing each plane — the elements that send `L_+` to `L_+` and `L_-` to `L_-` — is exactly the centralizer `C_{G_amb}(S_eps)`, of order `384`; the complementary coset of `384` elements swaps `L_+ <-> L_-`. This is an index-`2` grading `G_amb -> Z/2` (preserve versus swap) with kernel the centralizer, and `384 + 384 = 768`.  [gates G15, G16]
+
+## T6 — orientation neutrality over the same polarization
+
+The orientation sibling `omega_alt = -J_alt` — the `Unit 8` orientation sibling, the Unit-10 non-uniqueness witness — is also reversed by `S_eps`, `S_eps J_alt S_eps = -J_alt`, so `J_alt` too exchanges the SAME parity planes `L_±`: the real polarization `{L_±}` is common to both orientations, and only the exchanging intertwiner differs (`J_full` versus `J_alt`, with `J_full - J_alt = 2 J_bulk != 0`). The relationship between the two orientations is inherited unchanged from Unit 9's common-sign orbit — `orbit_H(J_full) = {J_full, -J_full}`, with `J_alt` in a distinct relative-sign class — and this note adds no further constraint on it; it only records that whichever orientation is read, the underlying Lagrangian polarization is the one fixed by `S_eps`.  [gates G17a, G17b, G17c]
+
+## What the runner checks
+
+The paired runner rebuilds every object from scratch — `D2`, `V8`, `J64`, the shells `Q_m`/`N_m`, `J_ker`, `J_bulk`, `J_full`, `J_alt`, the regenerated `768`-member `G_amb`, the chiral parity `S_eps`, and `g = I_64`, `omega = -J_full`, `h = g + i*omega` — and slices every vanishing-block gate out of an independently assembled matrix.
+
+| Theorem | What it checks | Gates |
+|---------|----------------|-------|
+| T1 | `S_eps` real involution (`S^2 = I`, orthogonal, traceless, entries `±1`); `dim L_± = 32` partitioning `C^64` | G1, G2 |
+| T2 | landed `S_eps J_full S_eps = -J_full`; `omega` vanishes on `L_+` and `L_-`; rejector that the `L_+ × L_-` block is nonzero; nonzero-integer `det omega` | G3, G4, G5, G6 |
+| T3 | `{S_eps, J_full} = 0` with nonzero-commutator rejector; diagonal `J_full` blocks vanish; `L_+ -> L_-` rank `32` | G7, G8, G9, G10 |
+| T4 | `S_eps^T omega S_eps = -omega`; `S_eps^T h S_eps = conj(h)` with nontrivial-conjugation rejector; `+i -> -i` eigenspace swap; `h` Hermitian and `g` a genuine invariant compatible posdef metric | G11, G12, G13, G14, G19 |
+| T5 | `|G_amb| = 768`, `|centralizer| = 384`; every element preserves or swaps `{L_±}`, `384` preserve `= centralizer`, `384` swap | G15, G16 |
+| T6 | `S_eps J_alt S_eps = -J_alt`; `J_alt` exchanges the same `L_±`; rejector `J_full - J_alt = 2 J_bulk != 0` | G17a, G17b, G17c |
+| — | rejector that `J_full` and `J_alt` are genuine complex structures (`J^2 = -I`) | G18 |
+| — | source pins: the two parent notes are actually read (`S_eps J_full S_eps = -J_full` and `common-sign orbit` in Unit 9; `omega(x,y) = g(J_full x,y)` in Unit 10) and this note carries exactly the two dependency links | G20, G21, G22 |
+
+## Boundary (honest-auditor read)
+
+The algebraic core of this unit — the vanishing diagonal parity blocks `J_full[L_+,L_+] = J_full[L_-,L_-] = 0` — is Unit 9's landed T4 `S_eps J_full S_eps = -J_full` re-expressed in the parity blocks of `S_eps`; this note does not re-derive it. The new content is the symplectic-geometric packaging: the real Lagrangian polarization (T1–T2), the plane-exchanging Kähler intertwiner (T3), the antisymplectic reality / CP involution `h -> conj(h)` (T4), and the concrete ambient index-`2` grading with kernel the centralizer of order `384` (T5). `g = I_64` is the Unit-10 counting-choice metric representative — one point of a compatible-metric cone, not a forced one — so `h` and the reality reading inherit that choice; a different compatible metric would give a different Hermitian form while leaving the real polarization `{L_±}` and the parity-block vanishing untouched. The result reads a fixed finite symmetry structure on the `L = 4` torus: no continuum or infinite-volume claim, no Hamiltonian or admissibility dynamics, no probability weight, and nothing pre-record is chosen. It is `r`-neutral and measure-neutral, since `S_eps` commutes with the bulk operator `M`. Its only inputs are the two linked dependency notes; the standard symplectic and Kähler vocabulary is descriptive of the computed blocks, not an imported axiom.
+
+The [paired runner](../scripts/kcpt_chiral_parity_lagrangian_polarization_2026_07_19.py) rebuilds all objects, checks the twenty-four gates above with exact tolerances (`1e-12` for the rational-zero blocks, `1e-8` for eigen and rank, `1e-6` for the rejectors), and prints `TOTAL: PASS=N FAIL=0`, exiting nonzero on any failure. Its cached output belongs at `logs/runner-cache/kcpt_chiral_parity_lagrangian_polarization_2026_07_19.txt`.

--- a/logs/runner-cache/kcpt_chiral_parity_lagrangian_polarization_2026_07_19.txt
+++ b/logs/runner-cache/kcpt_chiral_parity_lagrangian_polarization_2026_07_19.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/kcpt_chiral_parity_lagrangian_polarization_2026_07_19.py
+runner_sha256: dd18736504ae7ea3ecc9b1a18cdc0476f285a673d0444b18f6aec835800fcf25
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 23.58
+status: ok
+----- stdout -----
+PASS G1 - S_eps real orthogonal involution: S^2=I, S^T S=I, trace=0, entries in {-1,+1}
+PASS G2 - dim L_+ = dim L_- = 32 and L_+ (+) L_- partitions the 64 basis sites
+PASS G3 - landed Unit-9 T4: ||S_eps J_full S_eps + J_full|| < 1e-12
+PASS G4 - LAGRANGIAN: omega vanishes on L_+ and on L_- (diagonal parity blocks = 0)
+PASS G5 - REJECTOR: off-diagonal L_+ x L_- block of omega is nonzero (vanishing is block-specific)
+PASS G6 - omega nondegenerate: |round(det omega)| = 1 >= 1
+PASS G7 - J_full anticommutes with S_eps: ||S_eps J_full + J_full S_eps|| < 1e-12
+PASS G8 - REJECTOR: ||S_eps J_full - J_full S_eps|| nonzero (genuine anticommutation, not both-zero)
+PASS G9 - J_full diagonal parity blocks vanish: J(L_+) subset L_-, J(L_-) subset L_+
+PASS G10 - J_full: L_+ -> L_- is a rank-32 isomorphism (== 32)
+PASS G11 - ANTISYMPLECTIC: ||S_eps^T omega S_eps + omega|| < 1e-12
+PASS G12 - REALITY/CP: ||S_eps^T h S_eps - conj(h)|| < 1e-12 (h -> conj(h) = g - i*omega)
+PASS G13 - REJECTOR: ||h - conj(h)|| nonzero (omega != 0, so conj(h) != h)
+PASS G14 - ANTI-HOLOMORPHIC: +i eigenspace dim 32==32; S_eps sends it to the -i eigenspace (< 1e-8)
+PASS G15 - |G_amb| = 768 == 768 and |C_G_amb(S_eps)| = 384 == 384
+PASS G16 - AMBIENT INDEX-2 GRADING: preserve 384 (== centralizer 384), swap 384, neither 0; 384+384==768
+PASS G17a - ORIENTATION NEUTRALITY (a): ||S_eps J_alt S_eps + J_alt|| < 1e-12
+PASS G17b - ORIENTATION NEUTRALITY (b): J_alt also exchanges the same L_+- (diagonal parity blocks = 0)
+PASS G17c - REJECTOR (non-vacuity): J_full - J_alt = 2 J_bulk, nonzero (the two orientations genuinely differ)
+PASS G18 - REJECTOR: ||J_full^2 + I|| and ||J_alt^2 + I|| < 1e-12 (genuine complex structures)
+PASS G19 - h Hermitian; g is G_amb-invariant, J_full-compatible, posdef (genuine Unit-10 metric)
+PASS G20 - SOURCE PIN Unit 9: note contains 'S_eps J_full S_eps = -J_full' and 'common-sign orbit'
+PASS G21 - SOURCE PIN Unit 10: note contains 'omega(x,y) = g(J_full x,y)'
+PASS G22 - SELF-NOTE DEPENDENCY DISCIPLINE: Unit9-link 1==1, Unit10-link 1==1, total KCPT-links 2==2
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/kcpt_chiral_parity_lagrangian_polarization_2026_07_19.py
+++ b/scripts/kcpt_chiral_parity_lagrangian_polarization_2026_07_19.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""KCPT Unit 11 exact Lagrangian-polarization runner.
+
+Reads the landed Units 8/9/10 objects on the L=4, N=64 staggered lattice through
+standard symplectic / Kaehler geometry.  Writing C^64 = L_+ (+) L_- for the +-1
+eigenspaces of the staggered chiral parity S_eps = diag((-1)^{x1+x2+x3}) (Unit 9),
+and taking the Unit-10 symplectic convention omega(x,y) = g(J_full x,y) with
+g = I_64 (matrix omega = J_full^T g = -J_full), it verifies:
+
+  T1  S_eps is a real involution; L_+ , L_- are the even/odd staggered-parity site
+      sets, dim 32 each, L_+ (+) L_- = C^64.                        [G1, G2]
+  T2  each L_+- is LAGRANGIAN for omega: the diagonal parity blocks of omega (hence
+      of J_full) vanish -- this is Unit 9's T4 S_eps J_full S_eps = -J_full written
+      in parity blocks; omega is nondegenerate.                     [G3, G4, G5, G6]
+  T3  J_full anticommutes with S_eps, so it EXCHANGES the two Lagrangian planes as a
+      rank-32 isomorphism L_+ -> L_- (the Kaehler polarization intertwiner).
+                                                                    [G7, G8, G9, G10]
+  T4  S_eps is ANTISYMPLECTIC (S_eps^T omega S_eps = -omega) and acts on h = g + i*omega
+      as the reality/CP conjugation h -> conj(h), swapping the +-i eigenspaces of J_full.
+                                                                [G11, G12, G13, G14, G19]
+  T5  every element of the order-768 ambient group G_amb preserves the unordered pair
+      {L_+, L_-}; the subgroup fixing each plane is the centralizer C_G_amb(S_eps) of
+      order 384, giving an index-2 grading (preserve vs swap).      [G15, G16]
+  T6  the sibling J_alt = J_ker - J_bulk is also reversed by S_eps, so it exchanges the
+      SAME L_+-; the polarization is common to both orientations, only the intertwiner
+      differs (J_full - J_alt = 2 J_bulk != 0).                     [G17a, G17b, G17c]
+
+Every "vanishing block" gate is sliced from an INDEPENDENTLY built matrix (J_full from
+the D2/V8/J64 shell construction; S_eps from coords), never a matrix set to zero, and is
+paired with a discriminating rejector (G5, G8, G13, G17c, G18) that FAILS for a
+trivial/wrong object.  Load-bearing block identities are exact-rational and land at 0.0;
+the float gates (eig/rank/square) are redundant and tagged in their descriptions.
+"""
+import itertools
+import os
+import numpy as np
+
+L, N = 4, 64
+TOL0 = 1e-12      # rational-zero blocks
+TOL_EIG = 1e-8    # eigen / rank
+TOLREJ = 1e-6     # rejector floor
+
+DOCS = os.environ.get("KCPT_DOCS", os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "docs"))
+U9_NOTE = "KCPT_CHIRAL_PARITY_COMMON_SIGN_ORBIT_BOUNDED_THEOREM_NOTE_2026-07-19.md"
+U10_NOTE = "KCPT_KAHLER_TRIPLE_AMBIENT_INVARIANT_METRIC_SYMPLECTIC_BOUNDED_THEOREM_NOTE_2026-07-19.md"
+SELF_NOTE = "KCPT_CHIRAL_PARITY_LAGRANGIAN_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-19.md"
+
+PASS = FAIL = 0
+
+
+def gate(tag, cond, desc):
+    global PASS, FAIL
+    ok = bool(cond)
+    PASS, FAIL = PASS + (1 if ok else 0), FAIL + (0 if ok else 1)
+    print(f"{'PASS' if ok else 'FAIL'} {tag} - {desc}")
+    return ok
+
+
+def note_text(basename):
+    try:
+        with open(os.path.join(DOCS, basename), encoding="utf-8") as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def nrm(X):
+    return float(np.max(np.abs(X)))
+
+
+# ---------------- construction (self-contained; mirrors the landed Unit-9 runner) ----
+def idx(a, b, c):
+    return (a * L + b) * L + c
+
+
+coords = np.zeros((N, 3), dtype=np.int64)
+for a in range(L):
+    for b in range(L):
+        for c in range(L):
+            coords[idx(a, b, c)] = (a, b, c)
+
+
+def eta_mu(mu, x):
+    if mu == 0:
+        return 1
+    if mu == 1:
+        return (-1) ** int(x[0])
+    return (-1) ** int(x[0] + x[1])
+
+
+e = [np.array([1, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 1])]
+D2 = np.zeros((N, N), dtype=np.int64)
+for i in range(N):
+    x = coords[i]
+    for mu in range(3):
+        D2[i, idx(*((x + e[mu]) % L))] += eta_mu(mu, x)
+        D2[i, idx(*((x - e[mu]) % L))] -= eta_mu(mu, x)
+
+SUBSETS = [(), (0,), (1,), (2,), (0, 1), (0, 2), (1, 2), (0, 1, 2)]
+sidx = {frozenset(S): k for k, S in enumerate(SUBSETS)}
+FULL = frozenset({0, 1, 2})
+V8 = np.zeros((N, 8), dtype=np.int64)
+for i in range(N):
+    x = coords[i]
+    for k, S in enumerate(SUBSETS):
+        V8[i, k] = (-1) ** int(sum(x[j] for j in S))
+
+
+def sgn_subset(S):
+    Sset = frozenset(S)
+    return ((-1) ** len(Sset & frozenset({0, 2}))) * (1 if 1 in Sset else -1)
+
+
+J64 = np.zeros((8, 8), dtype=np.int64)
+for k, S in enumerate(SUBSETS):
+    T = frozenset(S) ^ frozenset({1})
+    J64[sidx[T], k] = 64 * sgn_subset(S)
+
+Jker_int = V8 @ J64 @ V8.T                       # == 64^2 * J_ker
+
+M = D2 @ D2
+lam = [0, -4, -8, -12]
+Fac = [M - lam[m] * np.eye(N, dtype=np.int64) for m in range(4)]
+Q = []
+for m in range(4):
+    P = np.eye(N, dtype=np.int64)
+    for mp in range(4):
+        if mp != m:
+            P = P @ Fac[mp]
+    Q.append(P)
+Nm = []
+for m in range(4):
+    v = 1
+    for mp in range(4):
+        if mp != m:
+            v *= (lam[m] - lam[mp])
+    Nm.append(v)                                 # (384, -128, 128, -384)
+
+# float total complex structure and its orientation sibling
+D2f = D2.astype(float)
+Pf = [Q[m].astype(float) / Nm[m] for m in range(4)]
+Jkerf = Jker_int.astype(float) / (64.0 ** 2)
+Jbulk = sum(D2f @ Pf[m] / (2.0 * np.sqrt(m)) for m in (1, 2, 3))
+Jfull = Jkerf + Jbulk
+Jalt = Jkerf - Jbulk
+
+# the chiral parity and its parity planes
+eps = np.array([(-1) ** int(coords[i][0] + coords[i][1] + coords[i][2]) for i in range(N)], dtype=np.int64)
+Seps = np.diag(eps)
+Sf = Seps.astype(float)
+Ip = np.where(eps > 0)[0]                         # L_+  standard-basis index set
+Im = np.where(eps < 0)[0]                         # L_-  standard-basis index set
+
+# the Unit-10 Kaehler data (built directly from J_full)
+g = np.eye(N)
+w = -Jfull                                        # omega, matrix J_full^T g = -J_full
+h = g.astype(complex) + 1j * w.astype(complex)    # h = g + i*omega
+
+
+# ---------------- G_amb reconstruction (mirror the Unit-9 runner) --------------------
+def perm(fmap):
+    P = np.zeros((N, N), dtype=np.int64)
+    for i in range(N):
+        y = np.array(fmap(coords[i])) % L
+        P[i, idx(int(y[0]), int(y[1]), int(y[2]))] = 1
+    return P
+
+
+UR = perm(lambda x: (x[1], x[2], x[0]))
+U2 = perm(lambda x: (-x[1], -x[0], -x[2]))
+STAB = np.eye(N, dtype=np.int64)
+TR = {t: perm(lambda x, t=t: (x[0] - t[0], x[1] - t[1], x[2] - t[2]))
+      for t in itertools.product(range(L), repeat=3)}
+
+
+def signfield(bits):
+    a1, a2, a3, b12, b13, b23 = bits
+    d = np.zeros(N, dtype=np.int64)
+    for i in range(N):
+        x1, x2, x3 = coords[i]
+        expo = a1 * x1 + a2 * x2 + a3 * x3 + b12 * x1 * x2 + b13 * x1 * x3 + b23 * x2 * x3
+        d[i] = (-1) ** int(expo)
+    return d
+
+
+ALLBITS = list(itertools.product([0, 1], repeat=6))
+SF = {bits: signfield(bits) for bits in ALLBITS}
+BASES = {"stab": STAB, "U2": U2, "UR": UR}
+
+
+def eqm(a, b):
+    return np.array_equal(a, b)
+
+
+def closure_amb(gs):
+    gs = [g0.copy() for g0 in gs]
+    elts = {g0.tobytes(): g0 for g0 in gs}
+    frontier = list(elts.values())
+    while frontier:
+        nf = []
+        for xg in frontier:
+            for g0 in gs:
+                p = xg @ g0
+                key = p.tobytes()
+                if key not in elts:
+                    elts[key] = p
+                    nf.append(p)
+        frontier = nf
+    return list(elts.values())
+
+
+commuting = []
+for name, base in BASES.items():
+    for bits in ALLBITS:
+        dd = np.diag(SF[bits])
+        for t in itertools.product(range(L), repeat=3):
+            U = dd @ base @ TR[t]
+            if eqm(U @ D2, D2 @ U):
+                commuting.append(U.copy())
+Gamb = closure_amb(commuting)
+
+# =========================================================================== gates ===
+# T1 -- real parity polarization
+g1 = (eqm(Seps @ Seps, np.eye(N, dtype=np.int64))
+      and eqm(Seps.T @ Seps, np.eye(N, dtype=np.int64))
+      and round(float(np.trace(Seps))) == 0
+      and set(np.unique(eps).tolist()) <= {-1, 1})
+gate("G1", g1, "S_eps real orthogonal involution: S^2=I, S^T S=I, trace=0, entries in {-1,+1}")
+
+g2 = (len(Ip) == 32 and len(Im) == 32 and sorted(Ip.tolist() + Im.tolist()) == list(range(N)))
+gate("G2", g2, "dim L_+ = dim L_- = 32 and L_+ (+) L_- partitions the 64 basis sites")
+
+# T2 -- each parity plane is Lagrangian for omega = -J_full
+gate("G3", nrm(Sf @ Jfull @ Sf + Jfull) < TOL0,
+     "landed Unit-9 T4: ||S_eps J_full S_eps + J_full|| < 1e-12")
+gate("G4", nrm(w[Ip][:, Ip]) < TOL0 and nrm(w[Im][:, Im]) < TOL0,
+     "LAGRANGIAN: omega vanishes on L_+ and on L_- (diagonal parity blocks = 0)")
+gate("G5", nrm(w[Ip][:, Im]) > TOLREJ,
+     "REJECTOR: off-diagonal L_+ x L_- block of omega is nonzero (vanishing is block-specific)")
+detw = float(np.linalg.det(w))
+gate("G6", abs(round(detw)) >= 1,
+     f"omega nondegenerate: |round(det omega)| = {abs(round(detw))} >= 1")
+
+# T3 -- J_full exchanges the two Lagrangian planes
+gate("G7", nrm(Sf @ Jfull + Jfull @ Sf) < TOL0,
+     "J_full anticommutes with S_eps: ||S_eps J_full + J_full S_eps|| < 1e-12")
+gate("G8", nrm(Sf @ Jfull - Jfull @ Sf) > TOLREJ,
+     "REJECTOR: ||S_eps J_full - J_full S_eps|| nonzero (genuine anticommutation, not both-zero)")
+gate("G9", nrm(Jfull[Ip][:, Ip]) < TOL0 and nrm(Jfull[Im][:, Im]) < TOL0,
+     "J_full diagonal parity blocks vanish: J(L_+) subset L_-, J(L_-) subset L_+")
+rk = int(np.linalg.matrix_rank(Jfull[Im][:, Ip], tol=1e-9))
+gate("G10", rk == 32, f"J_full: L_+ -> L_- is a rank-{rk} isomorphism (== 32)")
+
+# T4 -- S_eps antisymplectic reality involution
+gate("G11", nrm(Sf.T @ w @ Sf + w) < TOL0,
+     "ANTISYMPLECTIC: ||S_eps^T omega S_eps + omega|| < 1e-12")
+gate("G12", nrm(Sf.T @ h @ Sf - np.conj(h)) < TOL0,
+     "REALITY/CP: ||S_eps^T h S_eps - conj(h)|| < 1e-12 (h -> conj(h) = g - i*omega)")
+gate("G13", nrm(h - np.conj(h)) > TOLREJ,
+     "REJECTOR: ||h - conj(h)|| nonzero (omega != 0, so conj(h) != h)")
+evals, evecs = np.linalg.eig(Jfull)
+sel = np.abs(evals - 1j) < TOL_EIG
+V = evecs[:, sel]
+SV = Sf.astype(complex) @ V
+gate("G14", V.shape[1] == 32 and nrm(Jfull @ SV - (-1j) * SV) < TOL_EIG,
+     f"ANTI-HOLOMORPHIC: +i eigenspace dim {V.shape[1]}==32; S_eps sends it to the -i eigenspace (< 1e-8)")
+
+# T5 -- ambient index-2 grading
+cent = sum(1 for U in Gamb if eqm(U @ Seps, Seps @ U))
+gate("G15", len(Gamb) == 768 and cent == 384,
+     f"|G_amb| = {len(Gamb)} == 768 and |C_G_amb(S_eps)| = {cent} == 384")
+preserve = swap = neither = 0
+for U in Gamb:
+    col_img = np.argmax(np.abs(U), axis=0)        # image site of each column (signed perm)
+    par = eps[col_img[Ip]]                        # parity of the images of the L_+ basis
+    if np.all(par == 1):
+        preserve += 1
+    elif np.all(par == -1):
+        swap += 1
+    else:
+        neither += 1
+gate("G16", neither == 0 and preserve + swap == 768 and preserve == 384 == cent and swap == 384,
+     f"AMBIENT INDEX-2 GRADING: preserve {preserve} (== centralizer 384), swap {swap}, neither {neither}; 384+384==768")
+
+# T6 -- orientation neutrality over the SAME polarization
+gate("G17a", nrm(Sf @ Jalt @ Sf + Jalt) < TOL0,
+     "ORIENTATION NEUTRALITY (a): ||S_eps J_alt S_eps + J_alt|| < 1e-12")
+gate("G17b", nrm(Jalt[Ip][:, Ip]) < TOL0 and nrm(Jalt[Im][:, Im]) < TOL0,
+     "ORIENTATION NEUTRALITY (b): J_alt also exchanges the same L_+- (diagonal parity blocks = 0)")
+gate("G17c", nrm((Jfull - Jalt) - 2 * Jbulk) < TOL0 and nrm(Jfull - Jalt) > TOLREJ,
+     "REJECTOR (non-vacuity): J_full - J_alt = 2 J_bulk, nonzero (the two orientations genuinely differ)")
+
+# genuine-complex-structure rejector (a wrong J_full/J_alt fails here)
+gate("G18", nrm(Jfull @ Jfull + np.eye(N)) < TOL0 and nrm(Jalt @ Jalt + np.eye(N)) < TOL0,
+     "REJECTOR: ||J_full^2 + I|| and ||J_alt^2 + I|| < 1e-12 (genuine complex structures)")
+
+# Unit-10 metric is genuine + h Hermitian
+inv = max(nrm(U.T @ g @ U - g) for U in Gamb)
+comp = nrm(Jfull.T @ g @ Jfull - g)
+gate("G19",
+     nrm(h - h.conj().T) < TOL0 and inv < 1e-9 and comp < 1e-9 and float(np.min(np.linalg.eigvalsh(g))) > 0,
+     "h Hermitian; g is G_amb-invariant, J_full-compatible, posdef (genuine Unit-10 metric)")
+
+# source pins -- parents actually read, self-note dependency discipline
+u9 = note_text(U9_NOTE)
+gate("G20", ("S_eps J_full S_eps = -J_full" in u9) and ("common-sign orbit" in u9),
+     "SOURCE PIN Unit 9: note contains 'S_eps J_full S_eps = -J_full' and 'common-sign orbit'")
+u10 = note_text(U10_NOTE)
+gate("G21", "omega(x,y) = g(J_full x,y)" in u10,
+     "SOURCE PIN Unit 10: note contains 'omega(x,y) = g(J_full x,y)'")
+s = note_text(SELF_NOTE)
+c9 = s.count("](" + U9_NOTE)
+c10 = s.count("](" + U10_NOTE)
+ckcpt = s.count("](KCPT_")
+gate("G22", c9 == 1 and c10 == 1 and ckcpt == 2,
+     f"SELF-NOTE DEPENDENCY DISCIPLINE: Unit9-link {c9}==1, Unit10-link {c10}==1, total KCPT-links {ckcpt}==2")
+
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+raise SystemExit(1 if FAIL else 0)


### PR DESCRIPTION
## Goal

KCPT (swap/rotation/conjugacy) lane continuation. Unit 11, unblocked once Unit 10 (the G_amb-invariant Kähler triple `g = I`, `omega = -J_full`, `h = g + i omega`) landed on `main`. This is the symplectic-geometric reading of the chiral-parity involution `S_eps` against that triple.

## What this establishes (bounded theorem)

On `C^64` (the `4^3` staggered lattice), with `S_eps = diag((-1)^{x1+x2+x3})` the staggered chiral-parity involution and `L_± = ±1` eigenspaces (the even/odd parity site sets, dim 32 each):

- **Lagrangian polarization (T1–T2).** Each `L_±` is a Lagrangian 32-plane for `omega = -J_full`: the two diagonal parity blocks of `omega` vanish while the off-diagonal `L_+ × L_-` block is nondegenerate (`|det omega| = 1`).
- **Kähler intertwiner (T3).** `J_full` exchanges `L_+ ↔ L_-` as a rank-32 isomorphism, and anticommutes with `S_eps`.
- **Reality/CP anti-involution (T4).** `S_eps` is antisymplectic (`S^T omega S = -omega`) and sends `h → conj(h) = g - i·omega`, i.e. `S_eps` swaps the `±i` eigenspaces of `J_full`.
- **Ambient index-2 grading (T5).** `G_amb` (order 768) grades onto `Z/2` by preserve-vs-swap of `{L_+, L_-}`; the kernel is exactly the order-384 centralizer `C_{G_amb}(S_eps)` (384 preserve + 384 swap).
- **Orientation neutrality (T6).** `J_alt = J_ker - J_bulk` exchanges the *same* `L_±`, with `J_full - J_alt = 2 J_bulk != 0`; the orientation choice sits in the Unit-9 common-sign orbit / relative-sign class, not in the polarization.

**Honest boundary (in the note).** The algebraic core — `J_full` maps `L_+ → L_-` and `L_- → L_+` — is Unit-9's T4 re-expressed in parity-block form; the new content is the symplectic-geometric packaging (Lagrangian planes, antisymplectic reality involution, index-2 grading of `G_amb`). `g = I_64` is carried as the Unit-10 counting-choice metric representative, one point of the compatible-metric cone. r-neutral, measure-neutral, no imports.

## Files (source-only triple)

- `docs/KCPT_CHIRAL_PARITY_LAGRANGIAN_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-19.md` — note, two dependency links (Unit 9 common-sign-orbit, Unit 10 Kähler-triple).
- `scripts/kcpt_chiral_parity_lagrangian_polarization_2026_07_19.py` — paired runner, **PASS=24 FAIL=0**.
- `logs/runner-cache/kcpt_chiral_parity_lagrangian_polarization_2026_07_19.txt` — cached output.

## Runner

24 gates, all pass. Includes five wrong-value rejectors (off-diagonal block nonzero; genuine anticommutation; `h != conj(h)`; `J_full - J_alt = 2 J_bulk != 0`; `J^2 = -I` for both orientations) so every vanishing-block gate is discriminating, plus two source pins reading the on-disk Unit-9 and Unit-10 notes and a self-note dependency-discipline gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
