### PR TITLE
feat(kcpt): CP-completion under H — the real 12 splits into 12⁺/12⁻

### DIFF
--- a/docs/KCPT_CP_COMPLETION_UNDER_EXTENDED_GROUP_BOUNDED_THEOREM_NOTE_2026-07-20.md
+++ b/docs/KCPT_CP_COMPLETION_UNDER_EXTENDED_GROUP_BOUNDED_THEOREM_NOTE_2026-07-20.md
@@ -1,0 +1,86 @@
+# KCPT CP-completion under the extended group H = ⟨G_amb, S_eps⟩: the unique real 12 splits into CP-even 12⁺ and CP-odd 12⁻, and the 20 complex modes CP-double with their anti-holomorphic conjugates
+
+**Type:** bounded_theorem
+**Date:** 2026-07-20
+**Lane:** KCPT (L = 4, N = 64 staggered qubit lattice over the 4³ cube)
+
+## Claim boundary
+
+This note records a complex-representation-theory computation about three specific derived operators — the staggered antisymmetric adjacency D2, the ambient-invariant total complex structure J_full, and the chiral-parity involution S_eps — on one finite lattice (L = 4, N = 64) together with the two derived finite groups G_amb (order 768) and its extension H = ⟨G_amb, S_eps⟩ (order 1536). It fixes no free parameter, selects no bulk sign-family member, and chooses no dynamics. "CP" is used throughout as a geometric label for the lattice parity involution S_eps, exactly as in the Unit-9/11 sibling notes; nothing here is a statement about Standard-Model CP or SM multiplets. Every load-bearing quantity is checked, with explicit wrong-value rejectors, by the companion runner `scripts/kcpt_cp_completion_under_extended_group_2026_07_20.py`.
+
+## T1 — CP-completion decomposition
+
+Adjoining the chiral-parity involution S_eps (Unit 9) to the ambient group G_amb yields the order-1536 group H = ⟨G_amb, S_eps⟩, in which G_amb sits as an index-2 subgroup; the nontrivial coset is S_eps·G_amb (768 elements, disjoint from G_amb). Unit 12 established that the holomorphic 32-plane W (the +i eigenspace of J_full) is a multiplicity-free complex G_amb-representation, `4 + 4 + 6 + 6 + 12 = 32`; Unit 13 identified the rank-12 constituent as the unique self-conjugate (real-type) piece, the two 4's and two 6's being complex-type.
+
+Restricting the full real carrier C^64 = W ⊕ H_− — with H_− the −i eigenspace of J_full, the anti-holomorphic 32-plane — to the extended group H gives
+
+`C^64 = 8 + 8 + 12 + 12 + 12⁺ + 12⁻`  (six multiplicity-free constituents).
+
+The four complex-type G_amb constituents (the two 4's and the two 6's) CP-double with their S_eps-images in H_−: each complex holomorphic constituent joins its anti-holomorphic conjugate into a single irreducible H-representation — the two rank-4's become two irreducible 8's and the two rank-6's become two irreducible 12's. The unique real 12 is the one constituent that does not fuse. Its 24-dimensional H-module — the real 12 in W together with its S_eps-image in H_− — is H-reducible and splits into a CP-even 12⁺ and a CP-odd 12⁻, inequivalent, each meeting W and H_− evenly. "Splits" versus "fuses" is here always a statement about the 24- / 8- / 12-dimensional H-module, never about a subspace of W alone: S_eps carries W ↔ H_− and fixes no nonzero subspace of W.
+
+## T2 — the exact-integer discriminator
+
+The commutant dimensions are exact integers read directly off the signed-permutation traces χ(h) = tr(h) ∈ Z:
+
+- c_G = dim End_{G_amb}(C^64) = (Σ_{g∈G_amb} tr(g)²) / |G_amb| = 9216 / 768 = 12,
+- c_H = dim End_H(C^64) = (Σ_{h∈H} tr(h)²) / |H| = 9216 / 1536 = 6.
+
+The value c_H = 6 (six constituents) rather than 5 (a single unsplit 24) is precisely the statement that the real 12 splits. Every element of the coset S_eps·G_amb is traceless in the 64-rep — Σ_coset tr² = 0 and max|tr| = 0 — because S_eps anticommutes both with the adjacency, S_eps·D2·S_eps = −D2, and with the complex structure, `S_eps J_full S_eps = -J_full` (Unit 9): the coset elements interchange W and H_− and therefore carry zero diagonal. This traceless coset is the exact-integer signature that S_eps is a genuine index-2 CP extension rather than an element already inside G_amb.
+
+## T3 — the 12⁺/12⁻ split, three independent ways
+
+The 24-dimensional H-module built from the real 12 in W together with its S_eps-image in H_− splits as 12⁺ ⊕ 12⁻. This is certified three genuinely independent ways, each a real computed quantity able to fail on its own:
+
+1. **H-commutant dimension 2.** The H-restricted commutant of the 24-block has dimension 2 — two inequivalent H-irreducibles — whereas each of the four complex-pair blocks has H-commutant dimension 1. Splitting the 24-block by a generic self-adjoint element of its H-commutant yields two sub-idempotents of equal rank, sorted [12, 12]. Each 12-half meets W and H_− evenly: tr(Π_{12⁺}·Π_W) = tr(Π_{12⁺}·Π_{H_−}) = 6, and likewise for 12⁻. This is forced — 12⁺ is H-invariant, hence S_eps-invariant, while S_eps swaps Π_W ↔ Π_{H_−}, so the two overlaps are S_eps-conjugate and sum to dim 12. Neither overlap is 0 or 12: the split is CP-diagonal, not a relabelling of W versus H_−.
+
+2. **G_amb-commutant dimension 4 = M_2.** The same 24-block, restricted to G_amb alone, has commutant dimension 4 = M_2: under G_amb the 24 is two copies of one irreducible — the self-conjugate real 12, whose anti-holomorphic image is G_amb-isomorphic to itself. G_amb-commutant 4 (M_2, same content) versus H-commutant 2 (split by the coset): the split is created by the coset, not by G_amb.
+
+3. **Opposite coset character = χ_sgn.** A coset element carries opposite half-characters on the two 12-halves, χ_{12⁻} = −χ_{12⁺} (their sum vanishes and they are distinct and nonzero), while on every G_amb element the two halves share the same character. The two halves therefore differ exactly by the nontrivial sign character χ_sgn of H/G_amb ≅ Z/2, so 12⁻ = 12⁺ ⊗ χ_sgn.
+
+Multiplicity-freeness follows as a corollary of the two gated integers rather than a separate probe: count = 6 constituents together with c_H = 6 forces Σ_i m_i² = 6 over six terms, hence every multiplicity m_i = 1 — the two 8's are inequivalent and the four 12's pairwise inequivalent (a repeated irreducible would push c_H ≥ 8).
+
+## Honest boundary
+
+In the full 64-representation every h ∈ H is a signed permutation, so its character tr(h) ∈ Z is an integer (and coset elements are traceless, tr = 0). Irrationality appears only on the 24-block-restricted half-characters χ_{12±}, which are built with the √m bulk-shell normalizers of J_full; these are real and lie in Q(√2) — for instance ±2√2 — not complex, and no Q(i, …) enters this unit. Only the summed exact-integer class invariants (c_G = 12, c_H = 6, coset trace-sum = 0) and the integer decomposition dimensions are gated; no single character is asserted equal to a target, and the 12⁺/12⁻ split is certified by the opposite-sign structure of the coset half-character, never by its numeric value.
+
+This is a complex-representation fact about specific derived operators (J_full, D2, S_eps) on one finite lattice and one derived group — not a claim about Standard-Model CP or SM multiplets; "CP" here is a geometric label for the lattice parity involution S_eps, the same geometric-label reading as the Unit-9/11 sibling notes. All parents (Units 8, 9, 10, 12, 13) are currently unaudited; this note inherits that and makes no retained-grade or publication-usable claim. It fixes no free parameter, selects no bulk sign-family member, and chooses no dynamics; it is r-neutral, orientation-neutral, and takes no external numerical or literature input.
+
+## Two paths this opens
+
+- Whether the CP-even 12⁺ and CP-odd 12⁻ carry distinguished internal structure as candidate chiral half-sectors — the next question this hands forward is what geometric data on the lattice separates the two halves beyond the bare coset sign.
+- How the two CP-doubled 8's and two 12's organize relative to the split real backbone under the full extended group — a route toward reading the CP-doubling pattern of the complex modes against the one self-conjugate constituent that splits.
+
+## Runner evidence
+
+Companion runner: `scripts/kcpt_cp_completion_under_extended_group_2026_07_20.py`. Each gate below contributes one PASS; the anti-fabrication rejectors (a √m→1 non-complex-structure proxy, wrong commutant values, a vacuous or all-traceless-G_amb coset, a W/H_− relabelling of the split) are wired to FAIL if the object were wrong.
+
+| Gate | What it discriminates | Pass |
+|------|-----------------------|------|
+| G1 | \|G_amb\| = 768; G_amb commutes with D2 (exact) and J_full ([FLOAT]) — complex-linear action; TR-shift witness non-vacuous | 1 |
+| G2 | J_full² = −I, antisymmetric; anti-proxy rejector — the √m→1 rational stand-in fails J² = −I and differs from J_full | 1 |
+| G3 | +i and −i eigenspaces of J_full each dim 32 (W holo, H_− anti-holo) | 1 |
+| G4 | S_eps·D2·S_eps = −D2 (exact integer): S_eps anticommutes with the adjacency | 1 |
+| G5 | S_eps·J_full·S_eps = −J_full ([FLOAT]); rejector ≠ +J_full — S_eps carries W → H_− | 1 |
+| G6 | \|H\| = 1536 = 2·768; G_amb ⊆ H; coset ⊆ H and disjoint (index 2); rejectors ≠ 768, ≠ 3072 | 1 |
+| G7 | c_G = 12 from real integer traces (Σ tr² = 9216); rejectors ≠ 10, 11, 13 | 1 |
+| G8 | c_H = 6 from real integer traces (Σ tr² = 9216); rejectors ≠ 5, 7 — c_H = 6 ⟺ real 12 splits | 1 |
+| G9 | coset traceless (Σ tr² = 0, max\|tr\| = 0); non-vacuous and G_amb not all-traceless | 1 |
+| G10 | idempotent tiling: Σ PW_k = Π_W, Σ PHm_k = Π_{H_−}, each PHm_k supported in H_− ([FLOAT]) | 1 |
+| G11 | per-block H-commutant dims [1,1,1,1,2]; the dim-2 block is exactly the rank-12; Σ = 6 = c_H | 1 |
+| G12 | full H-decomposition dims sorted [8,8,12,12,12,12]; mult-free corollary; rejectors ≠ [8,8,12,12,24], [4,4,6,6,12,32] | 1 |
+| G13 | proof 1 — 24-block H-commutant 2, sub-idempotents [12,12], each half evenly 6+6 in W and H_− (CP-diagonal) | 1 |
+| G14 | proof 2 — 24-block G_amb-commutant 4 = M_2 (same content); rejectors ≠ 2, ≠ 1 | 1 |
+| G15 | proof 3 — a coset element has opposite half-characters (sum ≈ 0, distinct); equal on G_amb; value not gated | 1 |
+| G-MEM | greedy generating sets close to exactly 768 / 1536; loose length bounds; commutants use generators only | 1 |
+| G-PIN-U9 | Unit-9 note contains `S_eps J_full S_eps = -J_full` | 1 |
+| G-PIN-U12 | Unit-12 note contains `4 + 4 + 6 + 6 + 12 = 32` | 1 |
+| G-PIN-U13 | Unit-13 note contains `FS = (0, 0, 0, 0, +1)` | 1 |
+| G-PIN-SELF | this note carries exactly three KCPT dependency links (Units 12, 13, 9); Units 8/10/11 backticked only | 1 |
+
+## Dependencies
+
+- [Unit 12 holomorphic G_amb-representation note](KCPT_HOLOMORPHIC_GAMB_REPRESENTATION_BOUNDED_THEOREM_NOTE_2026-07-20.md) — the five constituents `4 + 4 + 6 + 6 + 12 = 32` that CP-complete, and c_G = 12.
+- [Unit 13 holomorphic reality / CP census note](KCPT_HOLOMORPHIC_REALITY_CP_CENSUS_FROBENIUS_SCHUR_BOUNDED_THEOREM_NOTE_2026-07-20.md) — the rank-12 is the unique self-conjugate constituent, so it is the one constituent that can split under CP.
+- [Unit 9 chiral-parity common-sign-orbit note](KCPT_CHIRAL_PARITY_COMMON_SIGN_ORBIT_BOUNDED_THEOREM_NOTE_2026-07-19.md) — S_eps and the exact sign reversals S_eps·D2·S_eps = −D2 and `S_eps J_full S_eps = -J_full`: the index-2 CP-extension engine and why the coset is traceless.
+
+Units 8, 10, and 11 enter only transitively via Units 12/13/9 and are referenced by name only, never as dependency links: the total complex structure J_full assembled in `KCPT_TOTAL_COMPLEX_STRUCTURE_AMBIENT_INVARIANT_KERNEL_BULK_ASSEMBLY_BOUNDED_THEOREM_NOTE_2026-07-19.md`, the Kähler triple of `KCPT_KAHLER_TRIPLE_AMBIENT_INVARIANT_METRIC_SYMPLECTIC_BOUNDED_THEOREM_NOTE_2026-07-19.md`, and the real-Lagrangian polarization of `KCPT_CHIRAL_PARITY_LAGRANGIAN_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-19.md`.

--- a/logs/runner-cache/kcpt_cp_completion_under_extended_group_2026_07_20.txt
+++ b/logs/runner-cache/kcpt_cp_completion_under_extended_group_2026_07_20.txt
@@ -1,0 +1,33 @@
+===== runner cache v1 =====
+runner: scripts/kcpt_cp_completion_under_extended_group_2026_07_20.py
+runner_sha256: e874b99b090fc71560ef3a981b27a897325d6bd45c9ab85863442d7a9a40c268
+input_fingerprint_sha256: e9bb99323e9412521626a6316dae5cb87c670e3ad56c3a1cb6c84e07b8a07fe1
+timeout_sec: 180
+exit_code: 0
+elapsed_sec: 23.98
+status: ok
+----- stdout -----
+PASS G1 - |G_amb|=768==768; every U commutes with D2 (max int dev 0==0, witness TR[(1,0,0)] dev 2>0 non-vacuous); [FLOAT] every U commutes with J_full (max 0.0e+00<1e-9): complex-linear G_amb action
+PASS G2 - [FLOAT] J_full^2=-I (||J^2+I||=4.4e-16<1e-9), antisym (||J+J^T||=0.0e+00); ANTI-PROXY REJECTOR: sqrt(m)->1 proxy fails J^2=-I (||.||=0.625>1e-6) and differs from J_full (0.126>1e-6) -- shell normalizers load-bearing, J_full no sign proxy
+PASS G3 - [FLOAT] +i eigenspace dim 32==32 (holo W) and -i dim 32==32 (anti-holo H_-), sum 64==64
+PASS G4 - EXACT: S_eps D2 S_eps == -D2 (S_eps anticommutes with the adjacency; every nearest-neighbor hop flips site parity); != +D2, D2 nonzero
+PASS G5 - [FLOAT] landed Unit-9 identity S_eps J_full S_eps == -J_full (||.+J||=0.0e+00<1e-9); REJECTOR != +J_full (||.-J||=0.748>1e-6): S_eps conjugates +i- to -i-eigenvectors, carrying W -> H_- (pinned by source-grep at G-PIN-U9)
+PASS G6 - |H|=1536==1536==2*768; G_amb subset H (True); the coset S_eps*G_amb subset H (True) and DISJOINT from G_amb (True: index 2); REJECTORS |H|!=768 (S_eps genuinely extends, S_eps not in G_amb) and |H|!=3072
+PASS G7 - c_G = (Sum_{g in G_amb} tr(g)^2)/|G_amb| = 9216/768 = 12==12 [EXACT INTEGER traces]; Sum tr^2 9216==9216, Sum % 768 == 0 (True); REJECTORS c_G != 10/11/13
+PASS G8 - c_H = (Sum_{h in H} tr(h)^2)/|H| = 9216/1536 = 6==6 [EXACT INTEGER traces]; Sum tr^2 9216==9216, Sum % 1536 == 0 (True); REJECTORS c_H != 5 (a single unsplit 24) / != 7. THE DISCRIMINATOR:  c_H = 6  <=>  real 12 splits
+PASS G9 - coset traceless: Sum_{c in S_eps*G_amb} tr(c)^2 = 0==0 and max|tr(c)|=0==0 [EXACT INTEGER: coset carries W <-> H_-, zero diagonal]; NON-VACUITY len(coset)=768==768 and G_amb NOT all-traceless (Sum_G tr^2=9216>0): tracelessness is coset-specific
+PASS G10 - [FLOAT] tiling: Sum_k PW_k == Pi_W=B B^H (||.||=3.9e-16<1e-8) and Sum_k PHm_k == Pi_{H_-}=Bm Bm^H (||.||=2.1e-15<1e-8; S_eps maps W onto H_-), PHm_k=S_eps PW_k S_eps (0.0e+00) each supported in H_- (||Pi_{H_-} PHm_k Pi_{H_-} - PHm_k||=1.1e-15<1e-8)
+PASS G11 - [FLOAT] each block PW_k+PHm_k H-invariant (restr-unitary dev max 2.2e-15<1e-8); H-commutant dims per block = [1, 1, 1, 1, 2] paired to W-ranks [4, 4, 6, 6, 12]: dim 2 is EXACTLY the rank-12 block (True), the other four dim 1; Sum_k d_k=6==6==c_H; REJECTOR not-all-1 (True, real 12 splits) and no d_k>=3
+PASS G12 - FULL H-decomposition dims (sorted) [8, 8, 12, 12, 12, 12]==[8,8,12,12,12,12], sum 64==64, count 6==6==c_H. MULT-FREE COROLLARY: count==6 with c_H==6 forces Sum_i m_i^2=6 over 6 terms => every m_i==1 (the two 8's inequivalent, the four 12's pairwise inequivalent; a repeated irrep would push c_H>=8). REJECTORS != [8,8,12,12,24] (c_H=5 non-split) / != [4,4,6,6,12,32]
+PASS G13 - PROOF 1 (H-commutant): the real-12 block's H-commutant dim == 2 (two inequivalent H-irreps), sub-idempotents 12^+,12^- of equal rank [12, 12]==[12,12]. CP-MIXING [FLOAT]: each half meets W and H_- evenly -- tr(Pi_12+ Pi_W)=6.0000, tr(Pi_12+ Pi_H-)=6.0000, tr(Pi_12- Pi_W)=6.0000, tr(Pi_12- Pi_H-)=6.0000 all ==6 (<1e-6); REJECTOR neither overlap 0 nor 12 (split is CP-diagonal, not a W/H_- relabelling)
+PASS G14 - PROOF 2 (G_amb-commutant = M_2): the SAME 24-block's G_amb-restricted commutant dim = 4==4=M_2 -- under G_amb ALONE the 24 is two copies of ONE irrep (the self-conjugate real 12). REJECTORS != 2 (two distinct G_amb-irreps) / != 1. G_amb-commutant 4 (M_2, same content) vs H-commutant 2 (split by the coset)
+PASS G15 - PROOF 3 (opposite coset character = chi_sgn): a coset element has half-characters (chi_a,chi_b)=(-2.8284,+2.8284), |chi_a+chi_b|=0.0e+00<1e-6 (opposite) and |chi_a-chi_b|=5.657>1e-3 (distinct, nonzero) -- this IS chi_sgn, so 12^- = 12^+ (x) chi_sgn; while on G_amb the two halves are EQUAL (max gap 3.6e-15<1e-6). [value +-2*sqrt(2) irrational, NOT gated -- only the opposite-sign structure]
+PASS G-MEM - MEMORY-BUDGET: small deterministic greedy generating sets close exactly -- G_amb 4 gens -> 768==768, H 5 gens -> 1536==1536 (1<len<=16/20, actual printed, never called minimal); commutant kron stacks use these generators, never a per-element stack over 768/1536 (OOM-avoiding, peak < ~3 GB)
+PASS G-PIN-U9 - SOURCE PIN Unit 9: common-sign-orbit note contains `S_eps J_full S_eps = -J_full` (the sign reversal used by G5/G9)
+PASS G-PIN-U12 - SOURCE PIN Unit 12: holomorphic-rep note contains `4 + 4 + 6 + 6 + 12 = 32` (the decomposition that CP-completes)
+PASS G-PIN-U13 - SOURCE PIN Unit 13: reality/CP-census note contains `FS = (0, 0, 0, 0, +1)` (rank-12 the unique self-conjugate)
+PASS G-PIN-SELF - SELF-NOTE DEPENDENCY DISCIPLINE: total KCPT-links 3==3 (Unit12 1==1, Unit13 1==1, Unit9 1==1); Unit8/10/11 linked 0/0/0==0/0/0 (backticked only, never `](...)`)
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/kcpt_cp_completion_under_extended_group_2026_07_20.py
+++ b/scripts/kcpt_cp_completion_under_extended_group_2026_07_20.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+"""KCPT Unit 14 CP-completion under the extended group H = <G_amb, S_eps> (order 1536).
+
+Rebuilds, from the bare L=4, N=64 staggered-lattice site construction (no import of
+any other runner), the antisymmetric integer adjacency D2, the corner-wave kernel
+frame V8, the bulk operator M = D2 @ D2 with Hamming-shell projectors, the Unit-8
+total complex structure J_full = J_ker + J_bulk, the chiral parity
+S_eps = diag((-1)^{x1+x2+x3}), the order-768 ambient group G_amb, its holomorphic /
+anti-holomorphic 32-planes W = ker(J_full - iI) and H_- = ker(J_full + iI), and the
+five holomorphic G_amb-idempotents {4,4,6,6,12} of the Unit-12 census.
+
+It adjoins S_eps to G_amb to form the order-1536 group H = <G_amb, S_eps> in which
+G_amb is index 2, and decomposes the FULL real carrier C^64 = W (+) H_- under H:
+
+  T1  C^64 = 8 (+) 8 (+) 12 (+) 12 (+) 12^+ (+) 12^- : six multiplicity-free
+      constituents. The four COMPLEX-type G_amb constituents (two 4's, two 6's,
+      Unit 13) CP-DOUBLE with their S_eps-images in H_- into two irreducible 8's
+      and two irreducible 12's; the UNIQUE REAL 12 (Unit 13) is the ONLY one that
+      does NOT fuse -- its 24-dim H-module (the real 12 of W TOGETHER with its
+      S_eps-image in H_-) is H-reducible and SPLITS into a CP-even 12^+ and a
+      CP-odd 12^-.                                               [G6,G10,G11,G12]
+  T2  exact-integer discriminator: c_G = dim End_{G_amb}(C^64) = 12 and
+      c_H = dim End_H(C^64) = 6, from the REAL integer signed-permutation traces
+      chi(h) = tr(h) in Z of the actual 768 / 1536 elements. c_H = 6 (six pieces)
+      rather than 5 (a single unsplit 24) IS the statement that the real 12 splits;
+      every element of the coset S_eps*G_amb is traceless (Sum_coset tr^2 = 0), the
+      index-2 CP signature.                                      [G7,G8,G9]
+  T3  the 12^+/12^- split, THREE independent ways: (1) the 24-block's H-commutant
+      dim = 2 (two inequivalent H-irreps); (2) its G_amb-commutant dim = 4 = M_2
+      (two copies of the SAME self-conjugate real 12 under G_amb alone -- the split
+      is created by the coset, not by G_amb); (3) a coset element carries opposite
+      half-characters chi_{12^-} = -chi_{12^+} on the coset (equal on G_amb) -- the
+      sign character chi_sgn of H/G_amb = Z/2, so 12^- = 12^+ (x) chi_sgn. [G13,G14,G15]
+
+ANTI-FABRICATION DISCIPLINE.  J_full is built ONLY from the shell/kernel machinery
+(V8*J64*V8^T / 64^2 plus Sum_{m in 1,2,3} D2*Q_m/(2*sqrt m)); G2 proves a rational
+sqrt(m)->1 proxy is NOT a complex structure and differs from J_full, so no
+parity/sign proxy stands in for it.  The commutant dimensions c_G, c_H and the
+coset trace-sum are accumulated from the REAL integer traces of the ACTUAL 768 /
+1536 group elements, NEVER from their targets; each carries wrong-value rejectors
+(c_G != 10/11/13, c_H != 5/7, coset non-vacuity + G_amb NOT all-traceless).  The
+12^+/12^- split is certified THREE genuinely independent ways -- an H-commutant
+dim, a G_amb-commutant dim, and an opposite coset half-character -- each a real
+computed quantity able to fail on its own.  Every completeness / identity gate
+carries a discriminating rejector.  In the full 64-rep every h in H is a signed
+permutation so tr(h) in Z is an INTEGER (coset elements traceless, tr = 0);
+irrationality (+-2*sqrt(2) in Q(sqrt 2)) appears ONLY on the 24-block-RESTRICTED
+half-characters chi_{12+-} and is NEVER gated to a numeric value -- G15 gates only
+the opposite-SIGN structure.  The commutants are computed from small deterministic
+greedy generating sets (verified closure == 768 / == 1536), so the kron stacks use
+those sets, NOT all 768/1536 elements (which would OOM the 8 GB machine).
+"""
+import itertools
+import os
+import numpy as np
+
+# Every note this runner reads (three parents + this unit's own note), repo-relative.
+# Plain literal tuple, statically ast-parseable by the runner-cache input fingerprint.
+AUDIT_INPUT_PATHS = (
+    "docs/KCPT_CHIRAL_PARITY_COMMON_SIGN_ORBIT_BOUNDED_THEOREM_NOTE_2026-07-19.md",
+    "docs/KCPT_HOLOMORPHIC_GAMB_REPRESENTATION_BOUNDED_THEOREM_NOTE_2026-07-20.md",
+    "docs/KCPT_HOLOMORPHIC_REALITY_CP_CENSUS_FROBENIUS_SCHUR_BOUNDED_THEOREM_NOTE_2026-07-20.md",
+    "docs/KCPT_CP_COMPLETION_UNDER_EXTENDED_GROUP_BOUNDED_THEOREM_NOTE_2026-07-20.md",   # self-note
+)
+
+L, N = 4, 64
+TOL0 = 1e-12      # exact rational-zero level
+TOL_F = 1e-9      # [FLOAT] identity level (spec-stated)
+TOL_EIG = 1e-8    # eigen / rank / restriction selection
+TOLREJ = 1e-6     # rejector / residual floor
+TOL_COMM = 1e-6   # commutant singular-value null threshold
+
+DOCS = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "docs"))
+U9_NOTE = "KCPT_CHIRAL_PARITY_COMMON_SIGN_ORBIT_BOUNDED_THEOREM_NOTE_2026-07-19.md"
+U12_NOTE = "KCPT_HOLOMORPHIC_GAMB_REPRESENTATION_BOUNDED_THEOREM_NOTE_2026-07-20.md"
+U13_NOTE = "KCPT_HOLOMORPHIC_REALITY_CP_CENSUS_FROBENIUS_SCHUR_BOUNDED_THEOREM_NOTE_2026-07-20.md"
+SELF_NOTE = "KCPT_CP_COMPLETION_UNDER_EXTENDED_GROUP_BOUNDED_THEOREM_NOTE_2026-07-20.md"
+U8_NOTE = "KCPT_TOTAL_COMPLEX_STRUCTURE_AMBIENT_INVARIANT_KERNEL_BULK_ASSEMBLY_BOUNDED_THEOREM_NOTE_2026-07-19.md"
+U10_NOTE = "KCPT_KAHLER_TRIPLE_AMBIENT_INVARIANT_METRIC_SYMPLECTIC_BOUNDED_THEOREM_NOTE_2026-07-19.md"
+U11_NOTE = "KCPT_CHIRAL_PARITY_LAGRANGIAN_POLARIZATION_BOUNDED_THEOREM_NOTE_2026-07-19.md"
+
+# PRESERVE VERBATIM source-pin substrings (grepped from the on-disk parent notes):
+PIN_U9 = "S_eps J_full S_eps = -J_full"
+PIN_U12 = "4 + 4 + 6 + 6 + 12 = 32"
+PIN_U13 = "FS = (0, 0, 0, 0, +1)"
+
+PASS = FAIL = 0
+
+
+def gate(tag, cond, desc):
+    global PASS, FAIL
+    ok = bool(cond)
+    PASS, FAIL = PASS + (1 if ok else 0), FAIL + (0 if ok else 1)
+    print(f"{'PASS' if ok else 'FAIL'} {tag} - {desc}")
+    return ok
+
+
+def note_text(basename):
+    try:
+        with open(os.path.join(DOCS, basename), encoding="utf-8") as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def nrm(X):
+    return float(np.max(np.abs(X)))
+
+
+def eqm(a, b):
+    return np.array_equal(a, b)
+
+
+# ---------------- construction (self-contained; per spec CONSTRUCTION block) ------------
+def idx(a, b, c):
+    return (a * L + b) * L + c
+
+
+coords = np.zeros((N, 3), dtype=np.int64)
+for a in range(L):
+    for b in range(L):
+        for c in range(L):
+            coords[idx(a, b, c)] = (a, b, c)
+
+
+def eta_mu(mu, x):
+    if mu == 0:
+        return 1
+    if mu == 1:
+        return (-1) ** int(x[0])
+    return (-1) ** int(x[0] + x[1])
+
+
+e = [np.array([1, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 1])]
+D2 = np.zeros((N, N), dtype=np.int64)
+for i in range(N):
+    x = coords[i]
+    for mu in range(3):
+        D2[i, idx(*((x + e[mu]) % L))] += eta_mu(mu, x)
+        D2[i, idx(*((x - e[mu]) % L))] -= eta_mu(mu, x)
+
+SUBSETS = [(), (0,), (1,), (2,), (0, 1), (0, 2), (1, 2), (0, 1, 2)]
+sidx = {frozenset(S): k for k, S in enumerate(SUBSETS)}
+V8 = np.zeros((N, 8), dtype=np.int64)
+for i in range(N):
+    x = coords[i]
+    for k, S in enumerate(SUBSETS):
+        V8[i, k] = (-1) ** int(sum(x[j] for j in S))
+
+
+def sgn_subset(S):
+    Sset = frozenset(S)
+    return ((-1) ** len(Sset & frozenset({0, 2}))) * (1 if 1 in Sset else -1)
+
+
+J64 = np.zeros((8, 8), dtype=np.int64)
+for k, S in enumerate(SUBSETS):
+    T = frozenset(S) ^ frozenset({1})
+    J64[sidx[T], k] = 64 * sgn_subset(S)
+Jker_int = V8 @ J64 @ V8.T                       # == 64^2 * J_ker
+
+M = D2 @ D2
+lam = [0, -4, -8, -12]
+Fac = [M - lam[m] * np.eye(N, dtype=np.int64) for m in range(4)]
+Q = []
+for m in range(4):
+    P = np.eye(N, dtype=np.int64)
+    for mp in range(4):
+        if mp != m:
+            P = P @ Fac[mp]
+    Q.append(P)
+Nm = []
+for m in range(4):
+    v = 1
+    for mp in range(4):
+        if mp != m:
+            v *= (lam[m] - lam[mp])
+    Nm.append(v)                                 # (384, -128, 128, -384)
+
+# total complex structure from the shell/kernel machinery (NO parity/sign proxy)
+D2f = D2.astype(float)
+Pf = [Q[m].astype(float) / Nm[m] for m in range(4)]
+Jkerf = Jker_int.astype(float) / (64.0 ** 2)
+Jbulk = sum(D2f @ Pf[m] / (2.0 * np.sqrt(m)) for m in (1, 2, 3))
+Jfull = Jkerf + Jbulk
+
+# rational sqrt(m)->1 proxy: a discriminating counter-object ONLY (G2 anti-proxy rejector)
+Jbulk_proxy = sum(D2f @ Pf[m] / 2.0 for m in (1, 2, 3))
+Jfull_proxy = Jkerf + Jbulk_proxy
+
+# chiral parity S_eps (the Unit-9 involution); integer form for exact identities
+eps = np.array([(-1) ** int(coords[i][0] + coords[i][1] + coords[i][2]) for i in range(N)], dtype=np.int64)
+Seps_int = np.diag(eps)
+Seps = Seps_int.astype(float)
+I64i = np.eye(N, dtype=np.int64)
+
+
+# ---------------- G_amb reconstruction (dressed-symmetry scan + closure) ----------------
+def perm(fmap):
+    P = np.zeros((N, N), dtype=np.int64)
+    for i in range(N):
+        y = np.array(fmap(coords[i])) % L
+        P[i, idx(int(y[0]), int(y[1]), int(y[2]))] = 1
+    return P
+
+
+UR = perm(lambda x: (x[1], x[2], x[0]))
+U2m = perm(lambda x: (-x[1], -x[0], -x[2]))
+STAB = np.eye(N, dtype=np.int64)
+TR = {t: perm(lambda x, t=t: (x[0] - t[0], x[1] - t[1], x[2] - t[2]))
+      for t in itertools.product(range(L), repeat=3)}
+
+
+def signfield(bits):
+    a1, a2, a3, b12, b13, b23 = bits
+    d = np.zeros(N, dtype=np.int64)
+    for i in range(N):
+        x1, x2, x3 = coords[i]
+        expo = a1 * x1 + a2 * x2 + a3 * x3 + b12 * x1 * x2 + b13 * x1 * x3 + b23 * x2 * x3
+        d[i] = (-1) ** int(expo)
+    return d
+
+
+ALLBITS = list(itertools.product([0, 1], repeat=6))
+SF = {bits: signfield(bits) for bits in ALLBITS}
+BASES = {"stab": STAB, "U2": U2m, "UR": UR}
+
+
+def closure_grp(gs):
+    gs = [g0.copy() for g0 in gs]
+    elts = {g0.tobytes(): g0 for g0 in gs}
+    frontier = list(elts.values())
+    while frontier:
+        nf = []
+        for xg in frontier:
+            for g0 in gs:
+                p = xg @ g0
+                key = p.tobytes()
+                if key not in elts:
+                    elts[key] = p
+                    nf.append(p)
+        frontier = nf
+    return list(elts.values())
+
+
+commuting = []
+for name, base in BASES.items():
+    for bits in ALLBITS:
+        dd = np.diag(SF[bits])
+        for t in itertools.product(range(L), repeat=3):
+            U = dd @ base @ TR[t]
+            if eqm(U @ D2, D2 @ U):
+                commuting.append(U.copy())
+Gamb = closure_grp(commuting)
+Gamb_set = {U.tobytes() for U in Gamb}
+
+# small deterministic greedy generating set of G_amb (commutant of a generating set ==
+# commutant of the group); closure certified == 768, so kron stacks use these, not 768.
+Gsorted = sorted(Gamb, key=lambda U: U.tobytes())
+gens_G = []
+seenG = {I64i.tobytes()}
+gen_closure_G = 0
+for U in Gsorted:
+    if eqm(U, I64i) or U.tobytes() in seenG:
+        continue
+    gens_G.append(U)
+    cl = closure_grp(gens_G)
+    seenG = {x.tobytes() for x in cl}
+    gen_closure_G = len(cl)
+    if gen_closure_G == 768:
+        break
+
+# ---------------- extend by S_eps: H = <G_amb, S_eps>, order 1536 -----------------------
+gens_H = gens_G + [Seps_int]
+Hgrp = closure_grp(gens_H)
+gen_closure_H = len(Hgrp)
+Hset = {h.tobytes() for h in Hgrp}
+coset = [Seps_int @ g for g in Gamb]             # the nontrivial coset S_eps * G_amb
+coset_bytes = [c.tobytes() for c in coset]
+gamb_in_H = all(g.tobytes() in Hset for g in Gamb)
+coset_in_H = all(cb in Hset for cb in coset_bytes)
+coset_disjoint = all(cb not in Gamb_set for cb in coset_bytes)
+
+# ---------------- exact-integer class-sums (chi(h) = tr(h) in Z for signed perms) -------
+SG = sum(int(np.trace(g)) ** 2 for g in Gamb)     # = |G_amb| * dim End_{G_amb}(C^64)
+SH = sum(int(np.trace(h)) ** 2 for h in Hgrp)     # = |H|     * dim End_H(C^64)
+Scoset = sum(int(np.trace(c)) ** 2 for c in coset)
+maxtr_coset = max(abs(int(np.trace(c))) for c in coset)
+cG = SG // len(Gamb)
+cH = SH // len(Hgrp)
+
+# ---------------- holomorphic / anti-holomorphic frames --------------------------------
+evals, evecs = np.linalg.eig(Jfull)
+selp = np.where(np.abs(evals - 1j) < TOL_EIG)[0]
+selm = np.where(np.abs(evals + 1j) < TOL_EIG)[0]
+Bh, _ = np.linalg.qr(evecs[:, selp])       # holo W, 64 x 32
+Bm, _ = np.linalg.qr(evecs[:, selm])       # anti-holo H_-, 64 x 32
+PiW = Bh @ Bh.conj().T
+PiHm = Bm @ Bm.conj().T
+
+
+# ---------------- commutant helpers (memory-safe: kron stacks over GENERATORS only) -----
+def commutant_dim(mats, r):
+    Ir = np.eye(r, dtype=complex)
+    A = np.vstack([np.kron(m.T, Ir) - np.kron(Ir, m) for m in mats])
+    s = np.linalg.svd(A, compute_uv=False)
+    return int(np.sum(s < TOL_COMM))
+
+
+def commutant_basis(mats, r, d):
+    Ir = np.eye(r, dtype=complex)
+    A = np.vstack([np.kron(m.T, Ir) - np.kron(Ir, m) for m in mats])
+    Uc, s, Vh = np.linalg.svd(A, full_matrices=False)   # full_matrices=False: no huge U -> OOM-safe
+    del Uc, A
+    return [np.conj(Vh[-(i + 1)]).reshape(r, r, order="F") for i in range(d)]
+
+
+def split_block(Z, basis_mats, r, d):
+    """Split the r-dim block with orthobasis columns Z (64 x r) into d H-irreps via a
+    GENERIC self-adjoint commutant element.  A seed is accepted ONLY on clean d-cluster
+    eigenvalue separation (inter-cluster gap > 1e6 * intra), NEVER by any target rank.
+    Returns (sub-bases in 64-space, per-cluster ranks, seed) or (None, None, -1)."""
+    for seed in range(128):
+        rng = np.random.default_rng(seed)
+        cc = rng.standard_normal(len(basis_mats)) + 1j * rng.standard_normal(len(basis_mats))
+        Y = sum(cc[i] * basis_mats[i] for i in range(len(basis_mats)))
+        Hs = Y + Y.conj().T
+        ww, VV = np.linalg.eigh(Hs)
+        spread = float(ww[-1] - ww[0])
+        if spread <= 0:
+            continue
+        thr = 1e-4 * spread
+        grp = [[0]]
+        for j in range(1, r):
+            if ww[j] - ww[j - 1] > thr:
+                grp.append([j])
+            else:
+                grp[-1].append(j)
+        intra = max((ww[g[-1]] - ww[g[0]]) for g in grp)
+        inter = min((ww[grp[t + 1][0]] - ww[grp[t][-1]]) for t in range(len(grp) - 1)) \
+            if len(grp) > 1 else 0.0
+        if len(grp) == d and inter > 1e6 * max(intra, 1e-18):
+            return [Z @ VV[:, g] for g in grp], [len(g) for g in grp], seed
+    return None, None, -1
+
+
+# ---------------- 5 holomorphic G_amb-idempotents on W (Unit-12 census) -----------------
+Cgens = [Bh.conj().T @ g.astype(complex) @ Bh for g in gens_G]   # 32x32 restrictions
+dimcW = commutant_dim(Cgens, 32)                                  # expect 5
+BsW = commutant_basis(Cgens, 32, dimcW)
+subZW, ranksW, seedW = split_block(Bh, BsW, 32, dimcW)
+if subZW is not None:
+    order = list(np.argsort(ranksW))
+    subZW = [subZW[i] for i in order]
+    ranksW = [ranksW[i] for i in order]
+    PW = [z @ z.conj().T for z in subZW]                          # 64x64, in W; ranks 4,4,6,6,12
+    PHm = [Seps.astype(complex) @ p @ Seps.astype(complex) for p in PW]   # S_eps-images in H_-
+else:
+    PW = PHm = []
+
+# ---------------- H-decomposition: restrict each block PW_k+PHm_k to H, split if reducible
+gensHc = [g.astype(complex) for g in gens_H]
+gensGc = [g.astype(complex) for g in gens_G]
+Hdims = []
+block_dk = []
+block_wrank = []
+block_uni = []
+split_subranks = None
+ZhalfW = None
+dG24 = None
+ov = {"Wp": None, "Hmp": None, "Wm": None, "Hmm": None}
+coset_best = None
+gamb_gap = None
+for k in range(len(PW)):
+    wrank = ranksW[k]
+    block = PW[k] + PHm[k]
+    r = int(round(np.trace(block).real))                         # 2 * wrank
+    ww, VV = np.linalg.eigh((block + block.conj().T) / 2)
+    Z = VV[:, -r:]                                               # 64 x r orthobasis of the block
+    matsH = [Z.conj().T @ g @ Z for g in gensHc]
+    uni = max(nrm(m.conj().T @ m - np.eye(r)) for m in matsH)    # block H-invariant iff restr. unitary
+    d = commutant_dim(matsH, r)
+    block_dk.append(d)
+    block_wrank.append(wrank)
+    block_uni.append(uni)
+    if d == 1:
+        Hdims.append(r)
+        continue
+    # reducible block: split into its d H-irreps
+    BsB = commutant_basis(matsH, r, d)
+    subZb, subr, seedb = split_block(Z, BsB, r, d)
+    if subZb is None:
+        continue
+    ordb = list(np.argsort(subr))
+    subZb = [subZb[i] for i in ordb]
+    subr = [subr[i] for i in ordb]
+    split_subranks = subr[:]
+    Hdims.extend(subr)
+    ZhalfW = subZb                                               # two 64 x 12 half-bases
+    # proof 2 (G14): G_amb-restricted commutant of the SAME 24-block
+    matsG = [Z.conj().T @ g @ Z for g in gensGc]
+    dG24 = commutant_dim(matsG, r)
+    # proof 1 (G13): CP-mixing -- each 12-half meets W and H_- evenly (6 + 6)
+    Pip = ZhalfW[0] @ ZhalfW[0].conj().T
+    Pim = ZhalfW[1] @ ZhalfW[1].conj().T
+    ov["Wp"] = float(np.trace(Pip @ PiW).real)
+    ov["Hmp"] = float(np.trace(Pip @ PiHm).real)
+    ov["Wm"] = float(np.trace(Pim @ PiW).real)
+    ov["Hmm"] = float(np.trace(Pim @ PiHm).real)
+    # proof 3 (G15): a coset element carries opposite half-characters (= chi_sgn)
+    best = None
+    for c in coset:
+        cc0 = c.astype(complex)
+        ta = float(np.trace(ZhalfW[0].conj().T @ cc0 @ ZhalfW[0]).real)
+        tb = float(np.trace(ZhalfW[1].conj().T @ cc0 @ ZhalfW[1]).real)
+        if abs(ta) > 1.0 and (best is None or abs(ta) > abs(best[0])):
+            best = (ta, tb)
+    coset_best = best
+    gg = 0.0                                                     # ... while EQUAL on G_amb
+    for g in [I64i] + gens_G:
+        gc = g.astype(complex)
+        ta = float(np.trace(ZhalfW[0].conj().T @ gc @ ZhalfW[0]).real)
+        tb = float(np.trace(ZhalfW[1].conj().T @ gc @ ZhalfW[1]).real)
+        gg = max(gg, abs(ta - tb))
+    gamb_gap = gg
+
+Hdims_sorted = sorted(Hdims)
+
+# =============================================================================== gates ==
+# ---- group / structure sanity --------------------------------------------------------
+maxD2 = max(int(np.max(np.abs(U @ D2 - D2 @ U))) for U in Gamb)
+TR100 = perm(lambda x: (x[0] - 1, x[1], x[2]))            # innocent shift; breaks staggering
+witnessD2 = int(np.max(np.abs(TR100 @ D2 - D2 @ TR100)))
+maxJcomm = max(nrm(U.astype(float) @ Jfull - Jfull @ U.astype(float)) for U in Gamb)
+gate("G1", len(Gamb) == 768 and maxD2 == 0 and witnessD2 > 0 and maxJcomm < TOL_F,
+     f"|G_amb|={len(Gamb)}==768; every U commutes with D2 (max int dev {maxD2}==0, witness "
+     f"TR[(1,0,0)] dev {witnessD2}>0 non-vacuous); [FLOAT] every U commutes with J_full "
+     f"(max {maxJcomm:.1e}<1e-9): complex-linear G_amb action")
+
+j2 = nrm(Jfull @ Jfull + np.eye(N))
+janti = nrm(Jfull + Jfull.T)
+proxy2 = nrm(Jfull_proxy @ Jfull_proxy + np.eye(N))
+proxydiff = nrm(Jfull - Jfull_proxy)
+gate("G2", j2 < TOL_F and janti < TOL_F and proxy2 > TOLREJ and proxydiff > TOLREJ,
+     f"[FLOAT] J_full^2=-I (||J^2+I||={j2:.1e}<1e-9), antisym (||J+J^T||={janti:.1e}); "
+     f"ANTI-PROXY REJECTOR: sqrt(m)->1 proxy fails J^2=-I (||.||={proxy2:.3f}>1e-6) and differs "
+     f"from J_full ({proxydiff:.3f}>1e-6) -- shell normalizers load-bearing, J_full no sign proxy")
+
+gate("G3", len(selp) == 32 and len(selm) == 32 and len(selp) + len(selm) == 64,
+     f"[FLOAT] +i eigenspace dim {len(selp)}==32 (holo W) and -i dim {len(selm)}==32 (anti-holo H_-), "
+     f"sum {len(selp) + len(selm)}==64")
+
+# ---- S_eps index-2 CP engine (the Unit-9 thread) -------------------------------------
+SD2S = Seps_int @ D2 @ Seps_int
+gate("G4", eqm(SD2S, -D2) and not eqm(SD2S, D2) and nrm(D2) > 0,
+     "EXACT: S_eps D2 S_eps == -D2 (S_eps anticommutes with the adjacency; every nearest-neighbor "
+     "hop flips site parity); != +D2, D2 nonzero")
+
+sjs = nrm(Seps @ Jfull @ Seps + Jfull)
+sjs_plus = nrm(Seps @ Jfull @ Seps - Jfull)
+gate("G5", sjs < TOL_F and sjs_plus > TOLREJ,
+     f"[FLOAT] landed Unit-9 identity S_eps J_full S_eps == -J_full (||.+J||={sjs:.1e}<1e-9); "
+     f"REJECTOR != +J_full (||.-J||={sjs_plus:.3f}>1e-6): S_eps conjugates +i- to -i-eigenvectors, "
+     f"carrying W -> H_- (pinned by source-grep at G-PIN-U9)")
+
+gate("G6", gen_closure_H == 1536 and gen_closure_H == 2 * 768 and gamb_in_H and coset_in_H
+     and coset_disjoint and gen_closure_H != 768 and gen_closure_H != 3072,
+     f"|H|={gen_closure_H}==1536==2*768; G_amb subset H ({gamb_in_H}); the coset S_eps*G_amb subset H "
+     f"({coset_in_H}) and DISJOINT from G_amb ({coset_disjoint}: index 2); REJECTORS |H|!=768 "
+     f"(S_eps genuinely extends, S_eps not in G_amb) and |H|!=3072")
+
+# ---- exact-integer commutant / traceless-coset discriminators ------------------------
+gate("G7", SG == 9216 and SG % 768 == 0 and cG == 12 and cG != 10 and cG != 11 and cG != 13,
+     f"c_G = (Sum_{{g in G_amb}} tr(g)^2)/|G_amb| = {SG}/{len(Gamb)} = {cG}==12 [EXACT INTEGER traces]; "
+     f"Sum tr^2 {SG}==9216, Sum % 768 == 0 ({SG % 768 == 0}); REJECTORS c_G != 10/11/13")
+
+gate("G8", SH == 9216 and SH % 1536 == 0 and cH == 6 and cH != 5 and cH != 7,
+     f"c_H = (Sum_{{h in H}} tr(h)^2)/|H| = {SH}/{len(Hgrp)} = {cH}==6 [EXACT INTEGER traces]; "
+     f"Sum tr^2 {SH}==9216, Sum % 1536 == 0 ({SH % 1536 == 0}); REJECTORS c_H != 5 (a single unsplit "
+     f"24) / != 7. THE DISCRIMINATOR:  c_H = 6  <=>  real 12 splits")
+
+gate("G9", Scoset == 0 and maxtr_coset == 0 and len(coset) == 768 and SG > 0,
+     f"coset traceless: Sum_{{c in S_eps*G_amb}} tr(c)^2 = {Scoset}==0 and max|tr(c)|={maxtr_coset}==0 "
+     f"[EXACT INTEGER: coset carries W <-> H_-, zero diagonal]; NON-VACUITY len(coset)={len(coset)}==768 "
+     f"and G_amb NOT all-traceless (Sum_G tr^2={SG}>0): tracelessness is coset-specific")
+
+# ---- full H-decomposition (lift 5 W-idempotents, pair with S_eps-images, restrict to H)
+sumPW = sum(PW) if PW else np.zeros((N, N), dtype=complex)
+sumPHm = sum(PHm) if PHm else np.zeros((N, N), dtype=complex)
+s1 = nrm(sumPW - PiW)
+s2 = nrm(sumPHm - PiHm)
+s3 = max((nrm(Seps.astype(complex) @ PW[k] @ Seps.astype(complex) - PHm[k]) for k in range(len(PW))),
+         default=1.0)
+s4 = max((nrm(PiHm @ PHm[k] @ PiHm - PHm[k]) for k in range(len(PHm))), default=1.0)
+gate("G10", len(PW) == 5 and s1 < 1e-8 and s2 < 1e-8 and s3 < 1e-8 and s4 < 1e-8,
+     f"[FLOAT] tiling: Sum_k PW_k == Pi_W=B B^H (||.||={s1:.1e}<1e-8) and Sum_k PHm_k == Pi_{{H_-}}=Bm Bm^H "
+     f"(||.||={s2:.1e}<1e-8; S_eps maps W onto H_-), PHm_k=S_eps PW_k S_eps ({s3:.1e}) each supported in "
+     f"H_- (||Pi_{{H_-}} PHm_k Pi_{{H_-}} - PHm_k||={s4:.1e}<1e-8)")
+
+all_uni = (max(block_uni) < 1e-8) if block_uni else False
+split_blocks = [k for k in range(len(block_dk)) if block_dk[k] == 2]
+complex_blocks = [k for k in range(len(block_dk)) if block_dk[k] == 1]
+split_is_rank12 = len(split_blocks) == 1 and block_wrank[split_blocks[0]] == 12
+complex_ok = len(complex_blocks) == 4 and all(block_wrank[k] in (4, 6) for k in complex_blocks)
+sum_dk = sum(block_dk)
+no_high = all(d < 3 for d in block_dk) if block_dk else False
+not_all_one = any(d != 1 for d in block_dk)
+gate("G11", all_uni and split_is_rank12 and complex_ok and sum_dk == 6 and sum_dk == cH
+     and no_high and not_all_one,
+     f"[FLOAT] each block PW_k+PHm_k H-invariant (restr-unitary dev max "
+     f"{max(block_uni) if block_uni else -1:.1e}<1e-8); H-commutant dims per block = "
+     f"{[block_dk[k] for k in range(len(block_dk))]} paired to W-ranks "
+     f"{block_wrank}: dim 2 is EXACTLY the rank-12 block ({split_is_rank12}), the other four dim 1; "
+     f"Sum_k d_k={sum_dk}==6==c_H; REJECTOR not-all-1 ({not_all_one}, real 12 splits) and no d_k>=3")
+
+gate("G12", Hdims_sorted == [8, 8, 12, 12, 12, 12] and sum(Hdims_sorted) == 64
+     and len(Hdims_sorted) == 6 and len(Hdims_sorted) == cH
+     and Hdims_sorted != [8, 8, 12, 12, 24] and Hdims_sorted != [4, 4, 6, 6, 12, 32],
+     f"FULL H-decomposition dims (sorted) {Hdims_sorted}==[8,8,12,12,12,12], sum {sum(Hdims_sorted)}==64, "
+     f"count {len(Hdims_sorted)}==6==c_H. MULT-FREE COROLLARY: count==6 with c_H==6 forces Sum_i m_i^2=6 "
+     f"over 6 terms => every m_i==1 (the two 8's inequivalent, the four 12's pairwise inequivalent; a "
+     f"repeated irrep would push c_H>=8). REJECTORS != [8,8,12,12,24] (c_H=5 non-split) / != [4,4,6,6,12,32]")
+
+# ---- 12^+/12^- split -- three independent proofs -------------------------------------
+overlaps = [ov["Wp"], ov["Hmp"], ov["Wm"], ov["Hmm"]]
+mix_ok = all(o is not None and abs(o - 6.0) < 1e-6 for o in overlaps)
+not_trivial = all(o is not None and abs(o) > 1.0 and abs(o - 12.0) > 1.0 for o in overlaps)
+rank12_dk2 = split_is_rank12 and block_dk[split_blocks[0]] == 2 if split_blocks else False
+gate("G13", rank12_dk2 and split_subranks == [12, 12] and mix_ok and not_trivial,
+     f"PROOF 1 (H-commutant): the real-12 block's H-commutant dim == 2 (two inequivalent H-irreps), "
+     f"sub-idempotents 12^+,12^- of equal rank {split_subranks}==[12,12]. CP-MIXING [FLOAT]: each half "
+     f"meets W and H_- evenly -- tr(Pi_12+ Pi_W)={ov['Wp']:.4f}, tr(Pi_12+ Pi_H-)={ov['Hmp']:.4f}, "
+     f"tr(Pi_12- Pi_W)={ov['Wm']:.4f}, tr(Pi_12- Pi_H-)={ov['Hmm']:.4f} all ==6 (<1e-6); REJECTOR "
+     f"neither overlap 0 nor 12 (split is CP-diagonal, not a W/H_- relabelling)")
+
+gate("G14", dG24 == 4 and dG24 != 2 and dG24 != 1,
+     f"PROOF 2 (G_amb-commutant = M_2): the SAME 24-block's G_amb-restricted commutant dim = {dG24}==4=M_2 "
+     f"-- under G_amb ALONE the 24 is two copies of ONE irrep (the self-conjugate real 12). REJECTORS "
+     f"!= 2 (two distinct G_amb-irreps) / != 1. G_amb-commutant 4 (M_2, same content) vs "
+     f"H-commutant 2 (split by the coset)")
+
+chi_a, chi_b = coset_best if coset_best is not None else (0.0, 0.0)
+opp = abs(chi_a + chi_b) < 1e-6
+distinct = abs(chi_a - chi_b) > 1e-3
+gamb_equal = gamb_gap is not None and gamb_gap < 1e-6
+gate("G15", coset_best is not None and opp and distinct and gamb_equal,
+     f"PROOF 3 (opposite coset character = chi_sgn): a coset element has half-characters "
+     f"(chi_a,chi_b)=({chi_a:+.4f},{chi_b:+.4f}), |chi_a+chi_b|={abs(chi_a + chi_b):.1e}<1e-6 (opposite) "
+     f"and |chi_a-chi_b|={abs(chi_a - chi_b):.3f}>1e-3 (distinct, nonzero) -- this IS chi_sgn, so "
+     f"12^- = 12^+ (x) chi_sgn; while on G_amb the two halves are EQUAL (max gap {gamb_gap:.1e}<1e-6). "
+     f"[value +-2*sqrt(2) irrational, NOT gated -- only the opposite-sign structure]")
+
+# ---- memory-budget gate (build discipline) -------------------------------------------
+gate("G-MEM", gen_closure_G == 768 and gen_closure_H == 1536
+     and 1 < len(gens_G) <= 16 and 1 < len(gens_H) <= 20,
+     f"MEMORY-BUDGET: small deterministic greedy generating sets close exactly -- G_amb "
+     f"{len(gens_G)} gens -> {gen_closure_G}==768, H {len(gens_H)} gens -> {gen_closure_H}==1536 "
+     f"(1<len<=16/20, actual printed, never called minimal); commutant kron stacks use these "
+     f"generators, never a per-element stack over 768/1536 (OOM-avoiding, peak < ~3 GB)")
+
+# ---- source pins + self-note dependency discipline -----------------------------------
+gate("G-PIN-U9", PIN_U9 in note_text(U9_NOTE),
+     f"SOURCE PIN Unit 9: common-sign-orbit note contains `{PIN_U9}` (the sign reversal used by G5/G9)")
+gate("G-PIN-U12", PIN_U12 in note_text(U12_NOTE),
+     f"SOURCE PIN Unit 12: holomorphic-rep note contains `{PIN_U12}` (the decomposition that CP-completes)")
+gate("G-PIN-U13", PIN_U13 in note_text(U13_NOTE),
+     f"SOURCE PIN Unit 13: reality/CP-census note contains `{PIN_U13}` (rank-12 the unique self-conjugate)")
+
+s = note_text(SELF_NOTE)
+ckcpt = s.count("](KCPT_")
+c12 = s.count("](" + U12_NOTE)
+c13 = s.count("](" + U13_NOTE)
+c9 = s.count("](" + U9_NOTE)
+c8 = s.count("](" + U8_NOTE)
+c10 = s.count("](" + U10_NOTE)
+c11 = s.count("](" + U11_NOTE)
+gate("G-PIN-SELF", ckcpt == 3 and c12 == 1 and c13 == 1 and c9 == 1 and c8 == 0 and c10 == 0 and c11 == 0,
+     f"SELF-NOTE DEPENDENCY DISCIPLINE: total KCPT-links {ckcpt}==3 (Unit12 {c12}==1, Unit13 {c13}==1, "
+     f"Unit9 {c9}==1); Unit8/10/11 linked {c8}/{c10}/{c11}==0/0/0 (backticked only, never `](...)`)")
+
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+raise SystemExit(1 if FAIL else 0)


### PR DESCRIPTION
## Summary

KCPT Unit 14 — **CP-completion under the extended group** `H = ⟨G_amb, S_ε⟩`
(order 1536; `G_amb` at index 2, coset `S_ε·G_amb`). Extends the derivation
surface: restricts the full carrier `C^64 = W ⊕ H_-` from `G_amb` to `H` and
resolves how the landed Unit-12 census `32 = 4 + 4 + 6 + 6 + 12` and its
Unit-13 reality types reorganize under the chiral-parity involution.

## Result

- **`C^64 = 8 + 8 + 12 + 12 + 12⁺ + 12⁻`** — six multiplicity-free `H`-constituents.
  The four complex-type `G_amb` constituents (two 4's, two 6's) **CP-double** with
  their anti-holomorphic `S_ε`-images into two irreducible **8**'s and two **12**'s;
  the **unique real-type 12** (Unit 13) is the one constituent that does not fuse,
  and its 24-dim `H`-module **splits** into a CP-even `12⁺` and CP-odd `12⁻`.
- **Exact-integer discriminator** from signed-permutation traces:
  `c_G = 9216/768 = 12`, `c_H = 9216/1536 = 6`. `c_H = 6` (not 5, a single unsplit
  24) `⟺` the real 12 splits. Every coset element `S_ε·G_amb` is **traceless**
  (it carries `W ↔ H_-`), so `S_H = S_G + S_coset = 9216 + 0`, i.e. `c_H = c_G/2`.
- The split is certified **three independent ways**: the 24-block `H`-commutant `= 2`,
  its `G_amb`-commutant `= 4 = M_2`, and a coset element carries opposite
  half-characters `χ_{12⁻} = −χ_{12⁺} = χ_sgn`.
- Multiplicity-free corollary: `count = 6` `∧` `c_H = 6` `⇒` `Σ m_i² = 6` over 6
  terms `⇒` all `m_i = 1`.

## Changes (sanctioned source-only triple)

- `docs/KCPT_CP_COMPLETION_UNDER_EXTENDED_GROUP_BOUNDED_THEOREM_NOTE_2026-07-20.md`
  — `bounded_theorem` note. Depends on Unit 12 + Unit 13 + Unit 9 (markdown links);
  Units 8/10/11 backticked context only.
- `scripts/kcpt_cp_completion_under_extended_group_2026_07_20.py` — paired runner,
  `TOTAL: PASS=20 FAIL=0` (re-run locally, ~24s). Class-A finite-dimensional;
  rebuilds `J_full` independently from the `L=4, N=64` shell/kernel machinery; every
  completeness/identity gate carries a discriminating wrong-value rejector (G2 anti-proxy
  `√m→1` counter-object, G9 coset-traceless with `G_amb` NOT all-traceless, G13 CP-mixing
  overlaps neither 0 nor 12, G15 half-character values ungated).
- `logs/runner-cache/kcpt_cp_completion_under_extended_group_2026_07_20.txt` — cached output.

## Boundary

Parents (Units 8, 9, 10, 12, 13) are currently **unaudited**; this note makes **no**
retained-grade or publication-usable claim. **"CP" is a geometric label for the lattice
parity involution `S_ε` only, not Standard-Model CP.** Every `h ∈ H` is a signed
permutation with `tr(h) ∈ Z`; the only irrationality is the pair of 24-block-restricted
half-characters `±2√2 ∈ Q(√2)`, which are **real** — reality is decided by the gate
STRUCTURE (opposite sign), never the numeric value. `r`-neutral, orientation-neutral,
no external input.

## Downstream

Completes the `G_amb → H` CP-completion of the holomorphic census. The next path this
opens: characterize the `12⁺/12⁻` chiral pair as an `H`-module in its own right, and
carry the six-constituent `H`-decomposition forward as the input to the next unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
