### PR TITLE
Audit: default parallel drain to 10 workers

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -197,7 +197,7 @@ premises, and permitted metadata context satisfy the marker. Treat a lane's
 cascade queues: draining those rows moves a flagship lane toward
 certification.
 
-## Default Entry: Do The Right Thing, In Parallel (owner-directed 2026-07-17)
+## Default Entry: Do The Right Thing, In Parallel (owner-directed 2026-07-20)
 
 Invoking this skill WITHOUT a specific named claim — including a bare,
 argument-less invocation — means: drain the backlog, in parallel, with the
@@ -209,18 +209,21 @@ default session is:
 2. Launch the panel-aware top-level drainer:
 
    ```bash
-   python3 docs/audit/scripts/orchestrate_audit_loop.py --max-workers 4
+   python3 docs/audit/scripts/orchestrate_audit_loop.py --max-workers 10
    ```
 
    This command owns the complete control loop: finish pending judicial work,
    drain configured development lanes in order, immediately panel every fresh
    cross-seat disagreement, resume the same lane after the panel lands, repeat
-   until a full pass lands nothing new, then run one forensic canary. Raise
-   toward 6 workers only in a quiet pool per the budget below. The supervisor
-   holds the clone-wide audit lock for the complete campaign and hands that
-   lock to its batch/panel children. It runs the panel sweep after every batch
-   termination before propagating any unrelated hard batch failure, so a mixed
-   result cannot strand a valid judicial handoff.
+   until a full pass lands nothing new, then run one forensic canary. Ten
+   workers is the owner-directed default. Lower it only when another active
+   campaign is already consuming the shared Codex pool or a concrete machine,
+   rate-limit, or service constraint requires it; never silently fall back to
+   a lower four- or six-seat configuration. The supervisor holds the
+   clone-wide audit lock for the complete campaign and hands that lock to its
+   batch/panel children. It runs the panel sweep after every batch termination
+   before propagating any unrelated hard batch failure, so a mixed result
+   cannot strand a valid judicial handoff.
 3. If the user names a lane, pass `--lane <name>`. Otherwise the orchestrator
    iterates lanes from `docs/audit/data/lane_certification_config.json`,
    selecting entries whose generated `lane_certification.json` record still
@@ -284,12 +287,15 @@ python3 docs/audit/scripts/orchestrate_audit_batch.py \
   -> commit -> push inside the drainer). Never add a second committer against
   the same checkout; parallelism lives in the auditor seats only.
 - **Concurrency budget (shared codex pool).** Auditor seats, review-loop
-  reviewers, and judicial panels all draw on one pool. Keep the TOTAL
-  concurrent codex processes across every lane at or under ~8-10, and
-  coordinate before raising `--max-workers` while review campaigns run.
-  Measured 2026-07-17: ~18 concurrent processes collapsed lane throughput
-  from 6-11 landed verdicts/hour to ~1 every 3 hours; a 4-6 seat drain in a
-  quiet pool is the sweet spot.
+  reviewers, and judicial panels all draw on one pool. The audit-loop default
+  is one 10-seat orchestrator. Keep the TOTAL concurrent Codex processes
+  across every lane at or under about 10: when another review or judicial
+  campaign is already active, reduce this orchestrator's seat count enough to
+  stay within that total rather than starting a second audit orchestrator.
+  Measured 2026-07-17: about 18 concurrent processes collapsed lane
+  throughput from 6-11 landed verdicts/hour to about 1 every 3 hours. That
+  result is the reason for the 10-seat ceiling, not a reason to default back
+  to four or six seats in a quiet pool.
 - **Development tier only.** The drainer already skips `no_go` rows,
   non-batch-auditable claim types, and forensic-shaped sources at selection;
   do not force them in via `--claims`.

--- a/docs/ai_methodology/skills/audit-loop/agents/openai.yaml
+++ b/docs/ai_methodology/skills/audit-loop/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Audit Loop"
-  short_description: "Run hostile claim audits from the repo queue"
-  default_prompt: "Use $audit-loop to audit the next claim in the repository audit queue and land the result."
+  short_description: "Drain claim audits with 10 parallel workers"
+  default_prompt: "Use $audit-loop to drain the repository audit backlog with 10 parallel fresh-context workers and serialized verified landings."

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -1379,16 +1379,7 @@ def scope_for_args(args: argparse.Namespace, rows: dict[str, dict]) -> set[str]:
     return {claim.strip() for claim in args.claims.split(",") if claim.strip()}
 
 
-def main() -> int:
-    drain_lock = None
-
-    def finish(code: int) -> int:
-        nonlocal drain_lock
-        if drain_lock is not None:
-            drain_lock.close()
-            drain_lock = None
-        return code
-
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Parallel development-tier audit drainer")
     scope_group = parser.add_mutually_exclusive_group(required=True)
     scope_group.add_argument("--lane", help="lane name from lane_certification_config.json")
@@ -1404,7 +1395,7 @@ def main() -> int:
             "(gate/template calibration, packet-policy revision)."
         ),
     )
-    parser.add_argument("--max-workers", type=int, default=6)
+    parser.add_argument("--max-workers", type=int, default=10)
     parser.add_argument("--rounds", type=int, default=6)
     parser.add_argument("--stall-minutes", type=int, default=45)
     parser.add_argument("--runner-timeout-sec", type=int, default=120)
@@ -1427,6 +1418,20 @@ def main() -> int:
         ),
     )
     parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main() -> int:
+    drain_lock = None
+
+    def finish(code: int) -> int:
+        nonlocal drain_lock
+        if drain_lock is not None:
+            drain_lock.close()
+            drain_lock = None
+        return code
+
+    parser = build_parser()
     args = parser.parse_args()
     PROGRESS["dry_run"] = bool(args.dry_run)
     if not args.dry_run:

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -394,7 +394,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="Panel-aware end-to-end audit backlog drainer"
     )
     parser.add_argument("--lane", action="append", help="limit to a configured lane")
-    parser.add_argument("--max-workers", type=int, default=4)
+    parser.add_argument("--max-workers", type=int, default=10)
     parser.add_argument(
         "--max-passes",
         type=int,

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -19,7 +19,7 @@ import orchestrate_audit_loop as audit_loop
 def _args() -> argparse.Namespace:
     return argparse.Namespace(
         lane=None,
-        max_workers=4,
+        max_workers=10,
         max_passes=0,
         max_lane_cycles=0,
         batch_rounds=6,
@@ -31,6 +31,37 @@ def _args() -> argparse.Namespace:
         skip_forensic_canary=True,
         dry_run=False,
     )
+
+
+class WorkerDefaultTest(unittest.TestCase):
+    def test_top_level_loop_defaults_to_ten_parallel_workers(self):
+        args = audit_loop.build_parser().parse_args([])
+        self.assertEqual(args.max_workers, 10)
+
+    def test_standalone_batch_defaults_to_ten_parallel_workers(self):
+        args = batch.build_parser().parse_args(["--claims", "row"])
+        self.assertEqual(args.max_workers, 10)
+
+    def test_top_level_loop_propagates_worker_limit_to_batch(self):
+        args = _args()
+        command = audit_loop.batch_command("lane_a", args)
+        worker_flag = command.index("--max-workers")
+        self.assertEqual(command[worker_flag + 1], "10")
+
+        args.max_workers = 7
+        command = audit_loop.batch_command("lane_a", args)
+        worker_flag = command.index("--max-workers")
+        self.assertEqual(command[worker_flag + 1], "7")
+
+    def test_batch_selection_fills_ten_worker_capacity(self):
+        rows = [
+            {"claim_id": f"row-{index}", "criticality": "high"}
+            for index in range(11)
+        ]
+        selected = batch.selected_batch(rows, max_workers=10)
+        self.assertEqual([row["claim_id"] for row in selected], [
+            f"row-{index}" for index in range(10)
+        ])
 
 
 class BatchExitSemanticsTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- make the panel-aware audit loop default to 10 parallel worker seats
- align the standalone batch drainer, skill instructions, and skill UI metadata with that default
- add regression coverage for both parser defaults, top-level propagation, and 10-seat batch selection

## Why

The documented audit entry point still defaulted to four workers, while the requested campaign contract is parallel by default with a maximum/default pool of 10. The standalone batch entry point also used a separate six-worker default. This change makes 10 the single explicit default while preserving a lower override for concrete shared-pool, machine, rate-limit, or service constraints.

## Safety

The clone-wide drain lock, inherited child locking, parallel fresh-context auditor seats, and serialized apply/pipeline/lint/commit/push path are unchanged. The change does not enable source-repair dispatch and does not include regenerated audit-ledger or effective-status outputs.

## Validation

- `python3 -m unittest docs.audit.scripts.tests.test_audit_loop_orchestrator` (23 tests)
- orchestrator and lock reviewer suite (26 tests)
- `python3 -m py_compile` for both orchestrators
- full `docs/audit/scripts/run_pipeline.sh`
- `python3 docs/audit/scripts/audit_lint.py --strict`
- vocabulary lint on all five changed files
- skill quick-validation for canonical and installed audit-loop skills
- `git diff --check`
- pipeline-output-stripped gate
- independent code-runner and methodology reviewer PASS
