### PR TITLE
Fix audit-loop row reentry across batch cycles

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -414,8 +414,10 @@ The graph-cycle warning is currently expected. Treat any error as a blocker.
 
 ## Blocked-Row Loop Guard
 
-- If applying a verdict and rerunning the pipeline immediately invalidates that same row, returns it to the ready queue, or creates a dependency-status cycle that cannot be resolved by the audit verdict alone, do not keep retrying the row in the same audit loop.
-- Restore the pre-claim generated audit diff for that row, record a session-local blocked/skip entry with the claim id and the exact tooling reason, and continue with the next ready row.
+- If applying a verdict and rerunning the pipeline immediately invalidates that same row, returns it to the dep-ready queue, or creates a dependency-status cycle that cannot be resolved by the audit verdict alone, do not keep retrying the row in the same audit campaign.
+- The canonical top-level orchestrator must persist the claim id and exact invalidation reason in its campaign exclusion JSONL and pass that file to every later batch and lane. A batch-local skip set is insufficient because the next batch process would forget it.
+- Treat an accepted verdict as a blocked-row reentry when the post-pipeline row is again `unaudited` and the canonical development-tier selector would immediately choose it. Exclude it for the rest of the campaign, report `blocked_row_reentry_quarantined`, and continue draining every other eligible row. Do not exclude `audit_in_progress` / `awaiting_second` rows; they must resume the missing clean seat normally.
+- Do not stop the top-level drainer merely because a row was excluded this way. Reach the fixed point over all non-excluded rows, then report the blocked rows and their exact invalidation reasons separately from schema-invalid quarantines.
 - Do not write an unsupported blocked verdict into the ledger unless `apply_audit.py` provides such a route. Report skipped blocked rows at the end of the loop and require upstream dependency/status repair before retrying them.
 
 ## Long-Running Runner / Timeout Guard

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -57,11 +57,13 @@ SCHEMA_INVALID_RESULTS = {"malformed_json", "validation_failed"}
 SCHEMA_QUARANTINE_RESULT = "schema_invalid_quarantined"
 SCHEMA_DEFERRED_RESULT = "schema_invalid_peer_deferred"
 SCHEMA_SUPERSEDED_RESULT = "schema_invalid_attempt_superseded"
+BLOCKED_ROW_QUARANTINE_RESULT = "blocked_row_reentry_quarantined"
 SCHEMA_RECOVERY_RESULTS = {
     SCHEMA_QUARANTINE_RESULT,
     SCHEMA_DEFERRED_RESULT,
     SCHEMA_SUPERSEDED_RESULT,
 }
+CAMPAIGN_EXCLUSION_RESULTS = {BLOCKED_ROW_QUARANTINE_RESULT}
 SCIENCE_FIX_RESULTS = {"science_fix_dispatched", "science_fix_dispatch_failed"}
 MIN_DELIVERY_BYTES = 200
 PACKET_COMPLETION_STALL_SECONDS = 20 * 60
@@ -1208,6 +1210,83 @@ def persist_campaign_quarantine(
             )
 
 
+def _latest_invalidation_reason(row: dict) -> str:
+    for archived in reversed(row.get("previous_audits") or []):
+        if not isinstance(archived, dict):
+            continue
+        reason = str(archived.get("invalidation_reason") or "").strip()
+        if reason:
+            return reason
+    return "pipeline_reset_to_unaudited_after_applied_verdict"
+
+
+def blocked_row_reentries(
+    selected_rows: list[dict],
+    current_rows: dict[str, dict],
+    report: list[dict],
+) -> dict[str, str]:
+    """Find applied verdicts that the pipeline made immediately selectable.
+
+    The inner batch already skips every attempted row for its own lifetime.
+    This detects the narrower cross-process failure mode: an accepted verdict
+    was committed, but pipeline invalidation reset the same unchanged row to
+    ``unaudited`` and the canonical selector would choose it again.  Such a row
+    cannot make further scientific progress inside the same campaign.
+    """
+    applied = {
+        item.get("cid")
+        for item in report
+        if item.get("result") in SUCCESS_RESULTS - {"compute_required"}
+        and item.get("commit")
+    }
+    reentries: dict[str, str] = {}
+    for selected in selected_rows:
+        cid = selected["claim_id"]
+        row = current_rows.get(cid) or {}
+        if cid not in applied or row.get("audit_status") != "unaudited":
+            continue
+        targets, _ = compute_targets({cid}, current_rows)
+        if not any(target.get("claim_id") == cid for target in targets):
+            continue
+        reason = _latest_invalidation_reason(row)
+        reentries[cid] = reason
+        report.append(
+            {
+                "cid": cid,
+                "result": BLOCKED_ROW_QUARANTINE_RESULT,
+                "detail": (
+                    f"{reason}; accepted verdict was reset to unaudited and "
+                    "dep-ready, so the row is excluded for this campaign"
+                ),
+            }
+        )
+    return reentries
+
+
+def persist_blocked_row_reentries(
+    path: Path | None,
+    reentries: dict[str, str],
+) -> None:
+    if path is None or not reentries:
+        return
+    existing = load_campaign_quarantine(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for cid in sorted(set(reentries) - existing):
+            handle.write(
+                json.dumps(
+                    {
+                        "claim_id": cid,
+                        "reason": BLOCKED_ROW_QUARANTINE_RESULT,
+                        "invalidation_reason": reentries[cid],
+                        "recorded_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+
+
 def apply_serialized(
     jobs: list[dict],
     report: list[dict],
@@ -1415,7 +1494,8 @@ def main() -> int:
         default=None,
         help=(
             "JSONL file shared by one top-level campaign; exhausted "
-            "schema-invalid claims are skipped for the rest of that campaign"
+            "schema-invalid claims and post-verdict blocked-row reentries are "
+            "skipped for the rest of that campaign"
         ),
     )
     parser.add_argument(
@@ -1579,6 +1659,9 @@ def main() -> int:
         # claim toward the same outcome. Repair, not repetition, moves it.
         session_skipped.update(row["claim_id"] for row in batch)
         current_rows = load_rows()
+        reentries = blocked_row_reentries(batch, current_rows, report)
+        session_skipped.update(reentries)
+        persist_blocked_row_reentries(args.campaign_quarantine_file, reentries)
         disagreements = append_judicial_handoffs(batch, current_rows, report)
         (workdir / "report.jsonl").write_text(
             "".join(json.dumps(item, sort_keys=True) + "\n" for item in report),
@@ -1647,6 +1730,7 @@ def report_has_hard_blocker(report: list[dict]) -> bool:
         | RESUMABLE_HANDOFF_RESULTS
         | SCIENCE_FIX_RESULTS
         | SCHEMA_RECOVERY_RESULTS
+        | CAMPAIGN_EXCLUSION_RESULTS
     )
     recovered = {
         item.get("cid")

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -90,7 +90,7 @@ def remaining_blocker_count() -> int | None:
     )
 
 
-def schema_quarantine_count() -> int:
+def campaign_exclusion_count(reason: str) -> int:
     path = PROGRESS.get("quarantine_file")
     if not isinstance(path, Path) or not path.exists():
         return 0
@@ -105,9 +105,17 @@ def schema_quarantine_count() -> int:
         except json.JSONDecodeError:
             continue
         cid = row.get("claim_id") if isinstance(row, dict) else None
-        if isinstance(cid, str) and cid:
+        if isinstance(cid, str) and cid and row.get("reason") == reason:
             claim_ids.add(cid)
     return len(claim_ids)
+
+
+def schema_quarantine_count() -> int:
+    return campaign_exclusion_count(batch.SCHEMA_QUARANTINE_RESULT)
+
+
+def blocked_row_reentry_count() -> int:
+    return campaign_exclusion_count(batch.BLOCKED_ROW_QUARANTINE_RESULT)
 
 
 def audit_status_snapshot() -> dict[str, str | None]:
@@ -158,7 +166,8 @@ def summary_line(final: bool = False) -> str:
         f"canary={PROGRESS['canary_state']} "
         f"ready_rows={ready if ready is not None else 'unknown'} "
         f"remaining_lane_blockers={blockers if blockers is not None else 'unknown'} "
-        f"schema_quarantined={schema_quarantine_count()}"
+        f"schema_quarantined={schema_quarantine_count()} "
+        f"blocked_row_reentries={blocked_row_reentry_count()}"
     )
 
 
@@ -450,7 +459,7 @@ def main(argv: list[str] | None = None) -> int:
         tempfile.mkdtemp(prefix="audit_loop_campaign_")
     )
     campaign_dir.mkdir(parents=True, exist_ok=True)
-    args.campaign_quarantine_file = campaign_dir / "schema-invalid-quarantine.jsonl"
+    args.campaign_quarantine_file = campaign_dir / "campaign-row-exclusions.jsonl"
     PROGRESS["quarantine_file"] = args.campaign_quarantine_file
     emit(f"campaign artifacts: {campaign_dir}")
     try:
@@ -520,6 +529,12 @@ def main(argv: list[str] | None = None) -> int:
                     emit(
                         "fixed point excludes campaign-scoped schema-invalid "
                         f"quarantines: {args.campaign_quarantine_file}"
+                    )
+                if blocked_row_reentry_count():
+                    emit(
+                        "fixed point excludes post-verdict rows that immediately "
+                        "re-entered dep-ready selection; all other eligible rows "
+                        f"were drained: {args.campaign_quarantine_file}"
                     )
                 break
 

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -187,6 +187,172 @@ class SchemaRecoveryTest(unittest.TestCase):
         self.assertEqual(reentries, {})
         compute_targets.assert_not_called()
 
+    def test_two_batches_exclude_reset_row_and_continue_other_seats(self):
+        def row(
+            cid: str,
+            *,
+            audit_status: str = "unaudited",
+            criticality: str | None = None,
+            cross_status: str | None = None,
+            previous_audits: list[dict] | None = None,
+            effective_status: str = "ready_for_audit",
+        ) -> dict:
+            return {
+                "claim_id": cid,
+                "note_path": f"docs/nonexistent-{cid}.md",
+                "claim_type": "positive_theorem",
+                "criticality": criticality,
+                "audit_status": audit_status,
+                "effective_status": effective_status,
+                "cross_confirmation": (
+                    {"status": cross_status} if cross_status else None
+                ),
+                "deps": [],
+                "previous_audits": previous_audits or [],
+            }
+
+        blocked_before = row("blocked")
+        other_before = row("other")
+        second_before = row(
+            "second",
+            audit_status="audit_in_progress",
+            criticality="critical",
+            cross_status="awaiting_second",
+        )
+        first_rows = {
+            item["claim_id"]: item
+            for item in (blocked_before, other_before, second_before)
+        }
+        blocked_after = row(
+            "blocked",
+            previous_audits=[
+                {
+                    "audit_status": "audited_conditional",
+                    "invalidation_reason": "no_go_discipline_packet_missing",
+                }
+            ],
+        )
+        first_after = dict(first_rows, blocked=blocked_after)
+        second_after = {
+            "blocked": blocked_after,
+            "other": row(
+                "other",
+                audit_status="audited_clean",
+                effective_status="retained",
+            ),
+            "second": row(
+                "second",
+                audit_status="audited_clean",
+                criticality="critical",
+                effective_status="retained",
+            ),
+        }
+        launched_by_batch: list[list[tuple[str, int]]] = []
+
+        def run_batch(
+            workdir: Path,
+            exclusion_file: Path,
+            before: dict[str, dict],
+            after: dict[str, dict],
+            max_workers: int,
+        ) -> int:
+            launched: list[tuple[str, int]] = []
+            launched_by_batch.append(launched)
+
+            def launch_worker(selected, _rows, pass_no, *_args):
+                launched.append((selected["claim_id"], pass_no))
+                return {
+                    "cid": selected["claim_id"],
+                    "pass": pass_no,
+                    "row": selected,
+                }
+
+            def apply_serialized(jobs, report, _retries):
+                for job in jobs:
+                    report.append(
+                        {
+                            "cid": job["cid"],
+                            "pass": job["pass"],
+                            "result": "audited_conditional",
+                            "commit": f"commit-{job['cid']}",
+                        }
+                    )
+                return True, set(), set(), []
+
+            argv = [
+                "orchestrate_audit_batch.py",
+                "--claims",
+                "blocked,other,second",
+                "--max-workers",
+                str(max_workers),
+                "--rounds",
+                "1",
+                "--campaign-quarantine-file",
+                str(exclusion_file),
+            ]
+            lock = mock.Mock()
+            with mock.patch.object(sys, "argv", argv), mock.patch.dict(
+                os.environ,
+                {"AUDIT_BATCH_WORKDIR": str(workdir)},
+            ), mock.patch.object(
+                batch, "acquire_exclusive_drain_lock", return_value=lock
+            ), mock.patch.object(
+                batch, "clean_main_error", return_value=None
+            ), mock.patch.object(
+                batch, "load_rows", side_effect=[before, after]
+            ), mock.patch.object(
+                batch, "source_requires_forensic", return_value=False
+            ), mock.patch.object(
+                batch, "launch_worker", side_effect=launch_worker
+            ), mock.patch.object(
+                batch, "wait_workers"
+            ), mock.patch.object(
+                batch, "start_progress_ticker"
+            ), mock.patch.object(
+                batch, "maybe_progress_summary"
+            ), mock.patch.object(
+                batch, "apply_serialized", side_effect=apply_serialized
+            ):
+                result = batch.main()
+            lock.close.assert_called_once_with()
+            return result
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            exclusion_file = root / "campaign-row-exclusions.jsonl"
+            first_rc = run_batch(
+                root / "batch-1",
+                exclusion_file,
+                first_rows,
+                first_after,
+                max_workers=1,
+            )
+            records_after_first = [
+                json.loads(line)
+                for line in exclusion_file.read_text(encoding="utf-8").splitlines()
+            ]
+            second_rc = run_batch(
+                root / "batch-2",
+                exclusion_file,
+                first_after,
+                second_after,
+                max_workers=2,
+            )
+
+        self.assertEqual((first_rc, second_rc), (0, 0))
+        self.assertEqual(launched_by_batch[0], [("blocked", 1)])
+        self.assertNotIn(("blocked", 1), launched_by_batch[1])
+        self.assertEqual(
+            launched_by_batch[1],
+            [("other", 1), ("second", 2)],
+        )
+        self.assertEqual(len(records_after_first), 1)
+        self.assertEqual(records_after_first[0]["claim_id"], "blocked")
+        self.assertEqual(
+            records_after_first[0]["invalidation_reason"],
+            "no_go_discipline_packet_missing",
+        )
+
     def test_science_handoff_requires_valid_actionable_verdict(self):
         job = {
             "cid": "row",

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -129,6 +129,64 @@ class SchemaRecoveryTest(unittest.TestCase):
         self.assertEqual(records[0]["claim_id"], "row")
         self.assertEqual(records[0]["failures"][0]["detail"], "N8 exact validator error")
 
+    def test_dep_ready_post_verdict_reset_is_persisted_across_batches(self):
+        selected = [{"claim_id": "row"}]
+        current = {
+            "row": {
+                "claim_id": "row",
+                "audit_status": "unaudited",
+                "previous_audits": [
+                    {"invalidation_reason": "no_go_discipline_packet_missing"}
+                ],
+            }
+        }
+        report = [
+            {
+                "cid": "row",
+                "result": "audited_conditional",
+                "commit": "deadbeef",
+            }
+        ]
+        with mock.patch.object(batch, "compute_targets", return_value=([current["row"]], [])):
+            reentries = batch.blocked_row_reentries(selected, current, report)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "campaign-row-exclusions.jsonl"
+            batch.persist_blocked_row_reentries(path, reentries)
+            batch.persist_blocked_row_reentries(path, reentries)
+            records = [json.loads(line) for line in path.read_text().splitlines()]
+            loaded = batch.load_campaign_quarantine(path)
+
+        self.assertEqual(
+            reentries, {"row": "no_go_discipline_packet_missing"}
+        )
+        self.assertEqual(loaded, {"row"})
+        self.assertEqual(len(records), 1)
+        self.assertEqual(
+            records[0]["reason"], batch.BLOCKED_ROW_QUARANTINE_RESULT
+        )
+        self.assertEqual(
+            report[-1]["result"], batch.BLOCKED_ROW_QUARANTINE_RESULT
+        )
+
+    def test_banked_clean_seat_remains_eligible_for_second_pass(self):
+        selected = [{"claim_id": "row"}]
+        current = {
+            "row": {
+                "claim_id": "row",
+                "audit_status": "audit_in_progress",
+                "cross_confirmation": {"status": "awaiting_second"},
+            }
+        }
+        report = [
+            {"cid": "row", "result": "audited_clean", "commit": "deadbeef"}
+        ]
+        with mock.patch.object(batch, "compute_targets") as compute_targets:
+            reentries = batch.blocked_row_reentries(selected, current, report)
+
+        self.assertEqual(reentries, {})
+        compute_targets.assert_not_called()
+
     def test_science_handoff_requires_valid_actionable_verdict(self):
         job = {
             "cid": "row",


### PR DESCRIPTION
## What changed

- persist post-verdict blocked-row reentries in the top-level campaign exclusion JSONL
- pass the exclusion across every inner batch and configured lane
- distinguish blocked-row reentries from schema-invalid quarantines in progress and final summaries
- preserve legitimate `audit_in_progress` / `awaiting_second` resumptions
- update the audit-loop skill contract and add regression coverage

## Root cause

The inner batch kept a processed-row skip set only in memory. After a verdict landed, the top-level supervisor launched another batch process; if the pipeline had immediately reset that same row to `unaudited` and dep-ready, the new process selected it again. The campaign could therefore spend every cycle re-auditing one unchanged row instead of draining the remaining lanes.

## Impact

An accepted verdict that immediately re-enters canonical development-tier selection is now excluded for the rest of that campaign with its exact invalidation reason. The supervisor continues through every other eligible row and reaches a fixed point without repeatedly burning auditor seats on the blocked row.

## Validation

- `python3 -m unittest discover -s docs/audit/scripts/tests -p 'test_*.py'` — 569 tests passed
- `bash docs/audit/scripts/run_pipeline.sh` — all 18 stages passed
- `python3 docs/audit/scripts/audit_lint.py --strict` — no errors
- `python3 scripts/vocab_lint.py --fix <changed files>` — no violations
- `python3 .../skill-creator/scripts/quick_validate.py docs/ai_methodology/skills/audit-loop` — valid
- `git diff --check`
