### PR TITLE
audit: eliminate avoidable drain-loop retries

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -367,6 +367,12 @@ schema). It does not show that the source claim is false or needs editing.
   scientific judgment; only repair the rejected structural packet. Malformed
   JSON and other contract rejects without a narrow judgment-preserving repair
   target go directly to the same exhausted-delivery path.
+- Treat an incompatible verdict/type tuple as a schema-invalid delivery, not
+  as a scientific seat. In particular, `audited_decoration` requires
+  `claim_type=decoration` plus a decoration parent, while `audited_clean`
+  cannot ratify `decoration` or `meta`. Quarantine or retry the invalid seat
+  under the normal delivery rules. Launch a judicial panel only when two
+  validator-clean, applyable seats disagree on their scientific tuples.
 - If a valid critical clean seat survives beside an invalid peer, bank the
   valid seat and let the next top-level batch retry only the missing peer. If
   no valid delivery survives, record every exact validator error and

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -280,9 +280,12 @@ python3 docs/audit/scripts/orchestrate_audit_batch.py \
   xhigh reasoning exactly — per seat, regardless of who orchestrates. Do not
   escalate seats to max; do not mix families inside one row's
   cross-confirmation without the owner's seating policy saying so.
-- **Commits stay serialized** one claim at a time (apply -> pipeline -> lint
-  -> commit -> push inside the drainer). Never add a second committer against
-  the same checkout; parallelism lives in the auditor seats only.
+- **Commits stay serialized** one claim at a time (apply every validated seat
+  for that claim -> one pipeline -> one lint -> one commit -> one push inside
+  the drainer). A simultaneous critical pair is one claim transaction, not two
+  generated-surface transactions; push-race retry replays the whole pair from
+  refreshed `origin/main`. Never add a second committer against the same
+  checkout; parallelism lives in the auditor seats only.
 - **Concurrency budget (shared codex pool).** Auditor seats, review-loop
   reviewers, and judicial panels all draw on one pool. Keep the TOTAL
   concurrent codex processes across every lane at or under ~8-10, and
@@ -349,6 +352,16 @@ returned JSON that the audit contract cannot apply (for example malformed
 JSON, an incomplete N1-N8 packet, or a field whose value contradicts the
 schema). It does not show that the source claim is false or needs editing.
 
+- Every restricted Codex seat (ordinary audit, focused packet completion, and
+  judicial judge) must use CLI `--output-schema` with a transport-level JSON
+  object schema. The canonical Python validators remain the only semantic
+  schema authority; the CLI schema prevents fences/preambles/malformed JSON
+  without duplicating the evolving audit policy.
+- In the development tier, an invalid *optional* N1-N8 packet on a non-clean,
+  non-no-go verdict is removed mechanically only when the unchanged validator
+  accepts the same verdict, declaration, rationale, and every other field with
+  `no_go_discipline=null`. Do this before launching completion. Never use this
+  normalization for clean authority, a no-go source/type, or forensic work.
 - Give parseable N1-N8 structural-packet rejects bounded, error-specific
   completion attempts in the same restricted seat. Preserve every top-level
   scientific judgment; only repair the rejected structural packet. Malformed
@@ -371,6 +384,9 @@ schema). It does not show that the source claim is false or needs editing.
   completed audit batch; it may edit only an isolated worktree and may only
   open a PR. Review-loop and a later independent audit remain mandatory before
   any repair reaches retained state.
+- `missing_dependency_edge` is a repair-actionable conditional class and maps
+  to the `conditional_missing_dependency_edge` science-fix category; do not
+  strand it merely because `missing_bridge_theorem` has a separate lane.
 
 Reaching a development fixed point with schema quarantines means the
 actionable queue drained except for the explicitly reported malformed

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -842,9 +842,13 @@ fresh-panel contract recoveries, a third contract-invalid panel is a hard
 tooling blocker rather than a scientific disagreement or human-review stop.
 
 After a panel majority, go with the majority only if the majority tuple is
-applyable by the audit tooling and the normal gates pass. Apply a representative
-judicial JSON for the majority side, rerun the pipeline, strict lint, and
-`git diff --check`, then land it as the audit result.
+applyable by the audit tooling and the normal gates pass. The apply gate accepts
+the representative judicial JSON only through an invocation-bound
+`judicial_panel_record_v1` that preserves five distinct validator-clean votes,
+the current source/seat fingerprint, and the matching 3-of-5 full-tuple
+majority. The legacy `third_audit` fields are only the stored projection of
+that verified panel record. Once verified, rerun the pipeline, strict lint,
+and `git diff --check`, then land it as the audit result.
 
 No cross-confirmation disagreement should stop at "human review" merely because
 a five-judge panel has no 3-of-5 majority, because the panel majority sides with

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -829,10 +829,17 @@ full first-audit and second-audit arguments as explicit context. Each judge
 must run at the required audit model/reasoning level with a distinct auditor
 identity, vote on the full tuple `(sided_with, ratified_verdict,
 ratified_claim_type, ratified_claim_scope, ratified_load_bearing_step_class,
-negative_assertion_classes)`, and explain errors in the other position. Treat
-whitespace-only scope differences and assertion-class ordering as equivalent,
-but require substantive scope and declaration agreement. A majority is at
-least three matching full-tuple votes out of five.
+ratified_decoration_parent_claim_id, negative_assertion_classes)`, and explain
+errors in the other position. Treat whitespace-only scope differences and
+assertion-class ordering as equivalent, but require substantive scope,
+decoration-parent, and declaration agreement. A majority is at least three
+matching full-tuple votes out of five.
+
+A judge response whose fields violate the semantic vote contract carries no
+scientific authority and does not count as a delivered vote. Preserve the exact
+validator error and launch a fresh five-judge panel; after two consecutive
+fresh-panel contract recoveries, a third contract-invalid panel is a hard
+tooling blocker rather than a scientific disagreement or human-review stop.
 
 After a panel majority, go with the majority only if the majority tuple is
 applyable by the audit tooling and the normal gates pass. Apply a representative

--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -62,10 +62,31 @@ If the runner output is absent only because the runner timed out, exceeded
 the audit wall-time budget, or is known to require a long compute run, that
 is not a scientific audit verdict. Do not convert mere noncompletion into
 `audited_conditional` or `audited_failed`. If the load-bearing step cannot be
-judged without the missing run, return exactly:
+judged without the missing run, return exactly the closed response object
+below: `compute_required` is the only non-null value and every other
+top-level field remains present as `null`.
 
-```
-COMPUTE_REQUIRED: <one sentence naming the missing completed run, sliced runner, cached certificate, or independent derivation needed>
+```json
+{
+  "compute_required": "<one sentence naming the missing completed run, sliced runner, cached certificate, or independent derivation needed>",
+  "claim_id": null,
+  "audit_invocation_id": null,
+  "load_bearing_step": null,
+  "load_bearing_step_class": null,
+  "claim_type": null,
+  "claim_scope": null,
+  "chain_closes": null,
+  "chain_closure_explanation": null,
+  "runner_check_breakdown": null,
+  "verdict": null,
+  "verdict_rationale": null,
+  "negative_assertion_classes": null,
+  "decoration_parent_claim_id": null,
+  "open_dependency_paths": null,
+  "auditor_confidence": null,
+  "notes_for_re_audit_if_any": null,
+  "no_go_discipline": null
+}
 ```
 
 The wrapper must then leave the row pending or blocked for compute and must
@@ -474,8 +495,8 @@ validator still requires substantive values whenever the condition applies.
         "occurrence_count": 1,
         "occurrence_locator_sha256": "<orchestrator-authenticated grouped locator digest>",
         "classification": "<retained_authority | hidden_admission | non_load_bearing>",
-        "promoted_wall": "<matching N2 wall when hidden_admission, otherwise omit>",
-        "rationale": "<required for non_load_bearing: 40+ characters explaining why this exact occurrence carries no premise load>",
+        "promoted_wall": "<matching N2 wall when hidden_admission, otherwise null>",
+        "rationale": "<required for non_load_bearing: 40+ characters explaining why this exact occurrence carries no premise load, otherwise null>",
         "evidence_path": "<manifest path>",
         "evidence_locator": "<actual locator>"
       }
@@ -629,7 +650,10 @@ When the gate is `FAIL`, list only the genuinely evidenced routes; fewer than
 five is valid and records the N1 failure. Do not fabricate extra routes merely
 to reach five.
 
-For `PASS`, omit the five FAIL-only fields. For `FAIL`, all five are required.
+For `PASS`, keep the five FAIL-only fields present: set `demotion`,
+`prior_claim_scope`, `narrowed_claim_scope`, and `next_route` to `null`, and
+set `corrected_wall_set` to `[]`. For `FAIL`, all five require the substantive
+values specified by the semantic contract.
 The orchestrator adds `evidence_snapshot` after validating the exact rendered
 packet; do not emit or fabricate that field. An `audited_clean` PASS must carry
 `chain_closes=true`.

--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -379,7 +379,10 @@ Definitions you must use:
   - `audited_decoration` — every load-bearing step is class (A), the
     note has zero (D) checks, and the chain reduces to a single upstream
     parent claim plus standard mathematics. (See
-    `ALGEBRAIC_DECORATION_POLICY.md`'s definition.)
+    `ALGEBRAIC_DECORATION_POLICY.md`'s definition.) This verdict requires
+    `claim_type = decoration` and a non-null `decoration_parent_claim_id`.
+    Conversely, `audited_clean` cannot ratify `claim_type = decoration` or
+    `claim_type = meta`.
   - `audited_numerical_match` — class (G) load-bearing step. The chain
     works only at a chosen input scale or chosen input value, with the
     input itself imported from a calibrated external source.
@@ -799,20 +802,21 @@ caught downstream.
 - The wrapping script substitutes the variables, sends the prompt to the
   current best full Codex GPT model in a fresh session, captures the JSON
   response, and validates it against the schema.
-- If JSON parsing fails or required fields are missing, the response is
-  logged as `audit_status = audit_in_progress` with `blocker:
-  malformed_audit_response` and the audit is re-queued.
+- If JSON parsing fails, required fields are missing, or the verdict/type
+  tuple is semantically incompatible, the delivery is rejected before apply.
+  The top-level campaign records the exact validator error, quarantines a row
+  with no surviving valid seat for that campaign, and continues other ready
+  rows. Such a contract reject is not a scientific disagreement.
 - For `criticality: critical` claims (by transitive-descendant count;
   the audit lane intentionally does not use author-declared flagship
   status), the pipeline runs the prompt twice in independent sessions
   and requires matching `verdict`, `claim_type`, and
   `load_bearing_step_class` before landing `audited_clean`. A same-family
   second audit is eligible only when recorded as `independence:
-  fresh_context` from a distinct restricted-input session. Mismatches
-  promote to a judicial third-auditor review. The judicial auditor receives
-  the restricted source packet and the two prior audit arguments, then
-  records whether the first audit, second audit, or neither should be
-  ratified.
+  fresh_context` from a distinct restricted-input session. Only two
+  validator-clean, applyable seats whose scientific tuples disagree promote
+  to a five-judge panel. Invalid seats are quarantined or retried as missing
+  seats; they never create a judicial disagreement.
 - The auditor's session metadata (model version, session ID, timestamp)
   is recorded in the audit row's `auditor` field; the exact
   `auditor_family`, for example `codex-gpt-5.6`, is set automatically when

--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -391,6 +391,7 @@ Return a single JSON object with exactly these fields. No other prose.
 
 ```json
 {
+  "compute_required": null,
   "claim_id": "{{CLAIM_ID}}",
   "audit_invocation_id": "{{AUDIT_INVOCATION_ID}}",
   "load_bearing_step": "<one-sentence quote or paraphrase from the note>",
@@ -415,6 +416,13 @@ Return a single JSON object with exactly these fields. No other prose.
 
 Use `null` when the structured packet is not required and you do not choose to
 supply it. Otherwise replace it with:
+
+The CLI response schema is closed: inside a supplied packet, conditional keys
+are always present. Use `null` for an inapplicable scalar/object field and an
+empty array for an inapplicable list; do not omit keys. In particular, a PASS
+packet uses `demotion`, `prior_claim_scope`, `narrowed_claim_scope`, and
+`next_route` as `null`, and `corrected_wall_set` as `[]`. The semantic
+validator still requires substantive values whenever the condition applies.
 
 ```json
 {

--- a/docs/audit/FRESH_LOOK_REQUIREMENTS.md
+++ b/docs/audit/FRESH_LOOK_REQUIREMENTS.md
@@ -166,20 +166,23 @@ For critical claims:
   `auditor_family` than the first, or record `independence: fresh_context`
   from a distinct same-family auditor/session using only the Section 2
   restricted inputs.
-- Both must return matching `verdict`, matching `claim_type`, and matching
-  `load_bearing_step_class` before the row may move to `audited_clean`.
-- Disagreement on `claim_type` or `load_bearing_step_class` promotes the
-  claim to a third-auditor review and logs the disagreement in
-  `cross_confirmation.status = disagreement`.
-- The third-auditor review is judicial, not a blind retry. The third
-  auditor receives the restricted source packet plus the two prior audit
-  arguments, decides whether the first, second, or neither audit is
-  correct, and records `sided_with` plus a ratified verdict/class/scope.
-  The ledger status must match that decision (`third_confirmed_first`,
-  `third_confirmed_second`, or, after an explicitly human-authorized panel
-  that selects a third applyable tuple, `third_confirmed_hybrid`); a third
-  auditor that cannot ratify an applyable tuple leaves the row blocked for
-  human review.
+- Both must return a matching applyable tuple: `verdict`, `claim_type`,
+  normalized `claim_scope`, `load_bearing_step_class`, decoration parent when
+  applicable, and `negative_assertion_classes`.
+- Disagreement between two validator-clean seats records
+  `cross_confirmation.status = disagreement` and promotes the claim to a
+  governed five-judge panel. A contract-invalid seat is missing, not
+  disagreeing, and must be reseated before any panel.
+- Every panel judge receives the restricted source packet plus both prior
+  audit arguments. At least three of five must match on the complete ratified
+  tuple, including `sided_with` and any decoration parent. A panel with no
+  applyable majority, a majority for neither, or an unapplyable hybrid launches
+  another fresh five-judge panel carrying every prior vote and rationale.
+  Legacy ledger statuses `third_confirmed_first`, `third_confirmed_second`,
+  and `third_confirmed_hybrid` store the representative majority judgment;
+  they do not authorize resolution by one third auditor. Stop only when a hard
+  tooling or policy blocker prevents another required panel or applying an
+  otherwise applyable majority, never merely for human review.
 
 Claims at `criticality = high` (`transitive_descendants >= 30`)
 require `independence != weak` but do not require cross-confirmation by

--- a/docs/audit/FRESH_LOOK_REQUIREMENTS.md
+++ b/docs/audit/FRESH_LOOK_REQUIREMENTS.md
@@ -180,9 +180,12 @@ For critical claims:
   another fresh five-judge panel carrying every prior vote and rationale.
   Legacy ledger statuses `third_confirmed_first`, `third_confirmed_second`,
   and `third_confirmed_hybrid` store the representative majority judgment;
-  they do not authorize resolution by one third auditor. Stop only when a hard
-  tooling or policy blocker prevents another required panel or applying an
-  otherwise applyable majority, never merely for human review.
+  they do not authorize resolution by one third auditor. The apply gate must
+  verify the invocation-bound `judicial_panel_record_v1`: five distinct valid
+  votes, the current source/seat fingerprint, and a matching 3-of-5 full-tuple
+  majority. Stop only when a hard tooling or policy blocker prevents another
+  required panel or applying an otherwise applyable majority, never merely for
+  human review.
 
 Claims at `criticality = high` (`transitive_descendants >= 30`)
 require `independence != weak` but do not require cross-confirmation by

--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -366,6 +366,9 @@ fresh five-judge panel with all prior outcomes in context. Contract-invalid
 seats are reseated before a panel; they are not scientific disagreements. The
 ledger keeps legacy `third_audit` storage fields for the representative panel
 judgment, but a single third auditor has no authority to resolve disagreement.
+The apply gate requires an invocation-bound `judicial_panel_record_v1` carrying
+five distinct valid votes, the current source/seat fingerprint, and a matching
+3-of-5 complete-tuple majority before it writes that legacy projection.
 
 ### Pruning phase (per decoration cluster)
 

--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -357,11 +357,15 @@ ever rescheduling the row for re-audit.
 For high-stakes claims (`criticality = critical` by transitive-descendant
 count; the audit lane does not use author-declared flagship status), a second independent
 agent runs the same audit; the two must agree before `audited_clean` lands.
-If the two audits disagree, the next step is a judicial third-auditor
-review: a fresh auditor reads the restricted source packet and both audit
-arguments, then explicitly ratifies the first audit, the second audit, or
-neither. The ledger records that decision in `cross_confirmation.status`
-and the row's current verdict must match the ratified side.
+If two validator-clean, applyable audits disagree, the next step is a governed
+five-judge panel. Five fresh judges read the restricted source packet and both
+audit arguments, vote on the complete scientific tuple, and explain the error
+in any position they reject. At least three matching votes are required. No
+majority, a majority for neither, or an unapplyable majority launches another
+fresh five-judge panel with all prior outcomes in context. Contract-invalid
+seats are reseated before a panel; they are not scientific disagreements. The
+ledger keeps legacy `third_audit` storage fields for the representative panel
+judgment, but a single third auditor has no authority to resolve disagreement.
 
 ### Pruning phase (per decoration cluster)
 

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -520,6 +520,12 @@ def audit_tuples_match(first: dict, second: dict) -> bool:
         and normalized_claim_scope(first) == normalized_claim_scope(second)
         and normalized_negative_assertion_classes(first)
         == normalized_negative_assertion_classes(second)
+        and audit_contract.decoration_parent_tuple_key(
+            first.get("verdict"), first.get("decoration_parent_claim_id")
+        )
+        == audit_contract.decoration_parent_tuple_key(
+            second.get("verdict"), second.get("decoration_parent_claim_id")
+        )
     )
 
 
@@ -1179,6 +1185,19 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
                 f"{chosen_label}_audit scope; use sided_with='hybrid' to "
                 "ratify a different scope"
             )
+        ratified_parent = (
+            judgment.get("ratified_decoration_parent_claim_id")
+            or judgment.get("decoration_parent_claim_id")
+        )
+        if audit_contract.decoration_parent_tuple_key(
+            ratified_verdict, ratified_parent
+        ) != audit_contract.decoration_parent_tuple_key(
+            chosen.get("verdict"), chosen.get("decoration_parent_claim_id")
+        ):
+            return False, (
+                "ratified_decoration_parent_claim_id does not match the "
+                f"ratified {chosen_label}_audit parent"
+            )
     ratified_decoration_parent = (
         judgment.get("ratified_decoration_parent_claim_id")
         or judgment.get("decoration_parent_claim_id")
@@ -1375,6 +1394,9 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
     missing = REQUIRED_FIELDS - set(audit)
     if missing:
         return False, f"missing required fields: {sorted(missing)}"
+    compute_error = audit_contract.terminal_compute_required_error(audit)
+    if compute_error:
+        return False, compute_error
 
     cid = audit["claim_id"]
     rows = ledger.get("rows", {})

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -39,6 +39,7 @@ from pathlib import Path
 
 import no_go_discipline_gate
 import audit_invocation
+import audit_contract
 
 import ledger_io
 
@@ -542,6 +543,13 @@ def audit_summary_tuple_schema_error(summary: object) -> str | None:
     claim_type = summary.get("claim_type")
     if claim_type not in ALLOWED_CLAIM_TYPES:
         return f"audit summary has invalid claim_type {claim_type!r}"
+    tuple_error = audit_contract.verdict_claim_type_error(
+        verdict,
+        claim_type,
+        summary.get("decoration_parent_claim_id"),
+    )
+    if tuple_error:
+        return f"audit summary has incompatible verdict/claim_type: {tuple_error}"
     scope = summary.get("claim_scope")
     if not isinstance(scope, str) or not scope.strip():
         return "audit summary claim_scope must be a non-empty string"
@@ -1175,10 +1183,15 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
         judgment.get("ratified_decoration_parent_claim_id")
         or judgment.get("decoration_parent_claim_id")
     )
-    if ratified_verdict == "audited_decoration" and not ratified_decoration_parent:
-        return False, "judicial audited_decoration requires decoration_parent_claim_id"
     ratified_class = judgment.get("ratified_load_bearing_step_class")
     final_claim_type = ratified_claim_type or chosen_claim_type or row.get("claim_type")
+    tuple_error = audit_contract.verdict_claim_type_error(
+        ratified_verdict,
+        final_claim_type,
+        ratified_decoration_parent,
+    )
+    if tuple_error:
+        return False, f"judicial verdict/claim_type incompatibility: {tuple_error}"
     note_path = row.get("note_path") or ""
     note_body = ""
     if note_path:
@@ -1492,13 +1505,13 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         )
         audit["no_go_discipline"] = packet
 
-    if verdict == "audited_clean" and claim_type in {"decoration", "meta"}:
-        return False, f"audited_clean cannot ratify claim_type={claim_type!r}"
-    if verdict == "audited_decoration":
-        if claim_type != "decoration":
-            return False, "audited_decoration requires claim_type='decoration'"
-        if not audit.get("decoration_parent_claim_id"):
-            return False, "audited_decoration requires decoration_parent_claim_id"
+    tuple_error = audit_contract.verdict_claim_type_error(
+        verdict,
+        claim_type,
+        audit.get("decoration_parent_claim_id"),
+    )
+    if tuple_error:
+        return False, tuple_error
 
     independence = audit["independence"]
     if independence not in ALLOWED_INDEPENDENCE:

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -34,6 +34,7 @@ import json
 import os
 import re
 import sys
+from collections import Counter
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -1068,7 +1069,135 @@ def validate_auditor_provenance(audit: dict) -> str | None:
     return None
 
 
+def judicial_judgment_vote(judgment: dict) -> dict:
+    """Project the representative apply payload onto the panel vote tuple."""
+    return {
+        "sided_with": judgment.get("sided_with"),
+        "ratified_verdict": judgment.get("ratified_verdict"),
+        "ratified_claim_type": judgment.get("ratified_claim_type"),
+        "ratified_claim_scope": judgment.get("ratified_claim_scope"),
+        "ratified_load_bearing_step_class": judgment.get(
+            "ratified_load_bearing_step_class"
+        ),
+        "ratified_decoration_parent_claim_id": (
+            judgment.get("ratified_decoration_parent_claim_id")
+            or judgment.get("decoration_parent_claim_id")
+        ),
+        "negative_assertion_classes": judgment.get(
+            "negative_assertion_classes"
+        ),
+    }
+
+
+def judicial_panel_record_error(
+    row: dict,
+    judgment: dict,
+    invocation_id: str,
+) -> str | None:
+    """Require an invocation/source-bound 3-of-5 panel attestation."""
+    record = judgment.get("judicial_panel_record_v1")
+    if not isinstance(record, dict):
+        return "judicial_panel_record_v1 is required for panel-majority apply"
+    if record.get("schema") != "judicial_panel_record_v1":
+        return "judicial_panel_record_v1 has an invalid schema"
+    if record.get("cid") != judgment.get("claim_id"):
+        return "judicial_panel_record_v1 claim_id mismatch"
+    if record.get("invocation_id") != invocation_id:
+        return "judicial_panel_record_v1 audit_invocation_id mismatch"
+    panel_no = record.get("panel")
+    if (
+        not isinstance(panel_no, int)
+        or isinstance(panel_no, bool)
+        or panel_no < 1
+    ):
+        return "judicial_panel_record_v1 has an invalid panel number"
+    if record.get("result") != "majority_candidate":
+        return "judicial_panel_record_v1 is not an applyable majority candidate"
+    if record.get("disagreement_fingerprint") != (
+        audit_contract.judicial_disagreement_fingerprint(row)
+    ):
+        return (
+            "judicial_panel_record_v1 does not match the current source and "
+            "cross-confirmation seats"
+        )
+    votes = record.get("votes")
+    if not isinstance(votes, list) or len(votes) != 5:
+        return "judicial_panel_record_v1 must contain exactly five votes"
+
+    prior_auditors = {
+        ((row.get("cross_confirmation") or {}).get("first_audit") or {}).get(
+            "auditor"
+        ),
+        ((row.get("cross_confirmation") or {}).get("second_audit") or {}).get(
+            "auditor"
+        ),
+    }
+    prior_auditors.discard(None)
+    auditors: list[str] = []
+    judges: list[int] = []
+    for index, vote in enumerate(votes, 1):
+        vote_error = audit_contract.judicial_vote_schema_error(vote)
+        if vote_error:
+            return f"judicial_panel_record_v1 vote {index} is invalid: {vote_error}"
+        context_error = audit_contract.sided_judicial_vote_context_error(row, vote)
+        if context_error:
+            return (
+                f"judicial_panel_record_v1 vote {index} is invalid: "
+                f"{context_error}"
+            )
+        judge = vote.get("judge")
+        auditor = vote.get("auditor")
+        if (
+            not isinstance(judge, int)
+            or isinstance(judge, bool)
+            or judge not in range(1, 6)
+        ):
+            return (
+                f"judicial_panel_record_v1 vote {index} has invalid judge seat"
+            )
+        if not isinstance(auditor, str) or not auditor.strip():
+            return (
+                f"judicial_panel_record_v1 vote {index} has no auditor identity"
+            )
+        judges.append(judge)
+        auditors.append(auditor)
+    if set(judges) != set(range(1, 6)):
+        return "judicial_panel_record_v1 does not preserve five distinct judge seats"
+    if len(set(auditors)) != 5:
+        return "judicial_panel_record_v1 does not preserve five distinct identities"
+    if set(auditors) & prior_auditors:
+        return "judicial_panel_record_v1 reuses a prior audit-seat identity"
+
+    tally = Counter(audit_contract.judicial_vote_tuple(vote) for vote in votes)
+    majority_tuple, majority_count = tally.most_common(1)[0]
+    if majority_count < 3:
+        return "judicial_panel_record_v1 has no 3-of-5 complete-tuple majority"
+    if record.get("majority_count") != majority_count:
+        return "judicial_panel_record_v1 majority_count does not match its votes"
+    expected_tally = [
+        {"tuple": [*key[:6], list(key[6])], "count": count}
+        for key, count in tally.most_common()
+    ]
+    if record.get("tally") != expected_tally or record.get("failures") != []:
+        return "judicial_panel_record_v1 tally/failures do not match its votes"
+    if audit_contract.judicial_vote_tuple(
+        judicial_judgment_vote(judgment)
+    ) != majority_tuple:
+        return "judicial panel representative does not match the 3-of-5 majority"
+    majority_auditors = {
+        vote.get("auditor")
+        for vote in votes
+        if audit_contract.judicial_vote_tuple(vote) == majority_tuple
+    }
+    if judgment.get("third_auditor") not in majority_auditors:
+        return "judicial panel representative identity is not a majority voter"
+    return None
+
+
 def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
+    compute_error = audit_contract.terminal_compute_required_error(judgment)
+    if compute_error:
+        return False, compute_error
     missing = JUDICIAL_REQUIRED_FIELDS - set(judgment)
     if missing:
         return False, f"missing required judicial fields: {sorted(missing)}"
@@ -1088,7 +1217,10 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     if audit_invocation_seen(row, invocation_id):
         return False, "audit_invocation_id has already been consumed for this claim"
     if judgment.get("independence") != "judicial_review":
-        return False, "judicial third-auditor review requires independence='judicial_review'"
+        return False, (
+            "judicial panel-majority apply requires independence="
+            "'judicial_review'"
+        )
     provenance_error = validate_auditor_provenance(judgment)
     if provenance_error:
         return False, provenance_error
@@ -1134,7 +1266,9 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
 
     prior_auditors = {first.get("auditor"), second.get("auditor")}
     if judgment.get("third_auditor") in prior_auditors:
-        return False, "judicial third auditor must differ from both prior auditors"
+        return False, (
+            "judicial panel representative must differ from both prior auditors"
+        )
 
     chosen_claim_type = None
     chosen: dict = {}
@@ -1211,6 +1345,9 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     )
     if tuple_error:
         return False, f"judicial verdict/claim_type incompatibility: {tuple_error}"
+    panel_error = judicial_panel_record_error(row, judgment, invocation_id)
+    if panel_error:
+        return False, panel_error
     note_path = row.get("note_path") or ""
     note_body = ""
     if note_path:
@@ -1329,7 +1466,10 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     if tuple_error:
         return False, tuple_error
     row["cross_confirmation"]["third_audit"] = third
-    row["cross_confirmation"]["mode"] = "judicial_third_pass"
+    row["cross_confirmation"]["judicial_panel_record_v1"] = copy.deepcopy(
+        judgment["judicial_panel_record_v1"]
+    )
+    row["cross_confirmation"]["mode"] = "judicial_panel_majority"
 
     row["cross_confirmation"]["status"] = {
         "first": "third_confirmed_first",
@@ -1381,11 +1521,14 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     consume_audit_invocation(row, invocation_id)
     rows[cid] = row
     ledger["rows"] = rows
-    return True, f"judicial third auditor confirmed {side} verdict"
+    return True, f"judicial panel majority confirmed {side} verdict"
 
 
 def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
     audit = dict(audit)
+    compute_error = audit_contract.terminal_compute_required_error(audit)
+    if compute_error:
+        return False, compute_error
     if "_no_go_evidence_manifest" in audit:
         return False, "_no_go_evidence_manifest is reserved for the orchestrator transport"
     if "sided_with" in audit or "third_auditor" in audit:
@@ -1394,10 +1537,6 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
     missing = REQUIRED_FIELDS - set(audit)
     if missing:
         return False, f"missing required fields: {sorted(missing)}"
-    compute_error = audit_contract.terminal_compute_required_error(audit)
-    if compute_error:
-        return False, compute_error
-
     cid = audit["claim_id"]
     rows = ledger.get("rows", {})
     if cid not in rows:

--- a/docs/audit/scripts/audit_contract.py
+++ b/docs/audit/scripts/audit_contract.py
@@ -8,6 +8,13 @@ apply gate cannot disagree about whether a tuple is applyable.
 from __future__ import annotations
 
 
+def terminal_compute_required_error(payload: object) -> str | None:
+    """Reject a compute deferral that is mixed with a terminal audit tuple."""
+    if isinstance(payload, dict) and payload.get("compute_required") is not None:
+        return "compute_required cannot accompany or produce a terminal audit verdict"
+    return None
+
+
 def verdict_claim_type_error(
     verdict: object,
     claim_type: object,
@@ -22,3 +29,13 @@ def verdict_claim_type_error(
         if not decoration_parent_claim_id:
             return "audited_decoration requires decoration_parent_claim_id"
     return None
+
+
+def decoration_parent_tuple_key(
+    verdict: object,
+    decoration_parent_claim_id: object,
+) -> object:
+    """Return the authority-parent component of an agreement tuple."""
+    if verdict != "audited_decoration":
+        return None
+    return decoration_parent_claim_id

--- a/docs/audit/scripts/audit_contract.py
+++ b/docs/audit/scripts/audit_contract.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Shared semantic contract checks for audit verdict tuples.
+
+Transport JSON schemas validate each field independently.  Cross-field policy
+stays here so ordinary seats, stored summaries, judicial votes, and the final
+apply gate cannot disagree about whether a tuple is applyable.
+"""
+from __future__ import annotations
+
+
+def verdict_claim_type_error(
+    verdict: object,
+    claim_type: object,
+    decoration_parent_claim_id: object = None,
+) -> str | None:
+    """Return the canonical incompatibility for a verdict/type tuple."""
+    if verdict == "audited_clean" and claim_type in {"decoration", "meta"}:
+        return f"audited_clean cannot ratify claim_type={claim_type!r}"
+    if verdict == "audited_decoration":
+        if claim_type != "decoration":
+            return "audited_decoration requires claim_type='decoration'"
+        if not decoration_parent_claim_id:
+            return "audited_decoration requires decoration_parent_claim_id"
+    return None

--- a/docs/audit/scripts/audit_contract.py
+++ b/docs/audit/scripts/audit_contract.py
@@ -7,6 +7,40 @@ apply gate cannot disagree about whether a tuple is applyable.
 """
 from __future__ import annotations
 
+import hashlib
+import json
+import re
+
+
+JUDICIAL_VOTE_FIELDS = (
+    "sided_with",
+    "ratified_verdict",
+    "ratified_claim_type",
+    "ratified_claim_scope",
+    "ratified_load_bearing_step_class",
+    "negative_assertion_classes",
+    "judgment_rationale",
+    "first_auditor_error",
+    "second_auditor_error",
+)
+JUDICIAL_SIDES = {"first", "second", "hybrid", "neither"}
+TERMINAL_VERDICTS = {
+    "audited_clean",
+    "audited_renaming",
+    "audited_conditional",
+    "audited_decoration",
+    "audited_failed",
+    "audited_numerical_match",
+}
+CLAIM_TYPES = {
+    "positive_theorem",
+    "bounded_theorem",
+    "no_go",
+    "open_gate",
+    "decoration",
+    "meta",
+}
+
 
 def terminal_compute_required_error(payload: object) -> str | None:
     """Reject a compute deferral that is mixed with a terminal audit tuple."""
@@ -39,3 +73,160 @@ def decoration_parent_tuple_key(
     if verdict != "audited_decoration":
         return None
     return decoration_parent_claim_id
+
+
+def normalized_scope(value: object) -> str:
+    """Normalize whitespace that carries no scientific scope distinction."""
+    return re.sub(r"\s+", " ", str(value or "").strip())
+
+
+def judicial_vote_tuple(vote: dict) -> tuple:
+    """Project a judicial vote onto every field requiring 3-of-5 agreement."""
+    classes = vote.get("negative_assertion_classes")
+    classes_key = (
+        tuple(sorted(classes)) if isinstance(classes, list) else ("<invalid>",)
+    )
+    return (
+        vote.get("sided_with"),
+        vote.get("ratified_verdict"),
+        vote.get("ratified_claim_type"),
+        normalized_scope(vote.get("ratified_claim_scope")),
+        vote.get("ratified_load_bearing_step_class"),
+        decoration_parent_tuple_key(
+            vote.get("ratified_verdict"),
+            vote.get("ratified_decoration_parent_claim_id"),
+        ),
+        classes_key,
+    )
+
+
+def judicial_vote_schema_error(vote: object) -> str | None:
+    """Validate the semantic vote surface shared by panel and apply gates."""
+    if not isinstance(vote, dict):
+        return "vote must be a JSON object"
+    missing = [field for field in JUDICIAL_VOTE_FIELDS if field not in vote]
+    if missing:
+        return f"vote_missing_fields:{','.join(missing)}"
+    if vote.get("sided_with") not in JUDICIAL_SIDES:
+        return "vote has invalid sided_with"
+    if vote.get("ratified_verdict") not in TERMINAL_VERDICTS:
+        return "vote has invalid ratified_verdict"
+    if vote.get("ratified_claim_type") not in CLAIM_TYPES:
+        return "vote has invalid ratified_claim_type"
+    tuple_error = verdict_claim_type_error(
+        vote.get("ratified_verdict"),
+        vote.get("ratified_claim_type"),
+        vote.get("ratified_decoration_parent_claim_id"),
+    )
+    if tuple_error:
+        return f"vote has incompatible verdict/claim_type: {tuple_error}"
+    for field in (
+        "ratified_claim_scope",
+        "ratified_load_bearing_step_class",
+        "judgment_rationale",
+        "first_auditor_error",
+        "second_auditor_error",
+    ):
+        if not isinstance(vote.get(field), str) or not vote[field].strip():
+            return f"vote field {field} must be a non-empty string"
+    if vote.get("ratified_load_bearing_step_class") not in set("ABCDEFG"):
+        return "vote has invalid ratified_load_bearing_step_class"
+    declared = vote.get("negative_assertion_classes")
+    if not isinstance(declared, list) or not all(
+        isinstance(item, str) and item.strip() for item in declared
+    ):
+        return "negative_assertion_classes must be a list of non-empty strings"
+    for field in (
+        "hybrid_resolution_note",
+        "ratified_decoration_parent_claim_id",
+        "ratified_load_bearing_step",
+        "notes_for_re_audit_if_any",
+    ):
+        if field in vote and vote[field] is not None and not isinstance(
+            vote[field], str
+        ):
+            return f"vote field {field} must be a string or null"
+    if "no_go_discipline" in vote and vote["no_go_discipline"] is not None:
+        if not isinstance(vote["no_go_discipline"], dict):
+            return "no_go_discipline must be an object or null"
+    first_error = str(vote.get("first_auditor_error") or "").strip().lower()
+    second_error = str(vote.get("second_auditor_error") or "").strip().lower()
+    if vote.get("sided_with") == "first" and second_error == "none":
+        return "a first-sided vote must explain the second auditor's error"
+    if vote.get("sided_with") == "second" and first_error == "none":
+        return "a second-sided vote must explain the first auditor's error"
+    if vote.get("sided_with") in {"hybrid", "neither"} and (
+        first_error == "none" or second_error == "none"
+    ):
+        return (
+            f"a {vote.get('sided_with')}-sided vote must explain both "
+            "auditors' errors"
+        )
+    return None
+
+
+def sided_judicial_vote_context_error(row: dict, vote: dict) -> str | None:
+    """Reject a sided vote that changes its selected stored seat tuple."""
+    side = vote.get("sided_with")
+    if side not in {"first", "second"}:
+        return None
+    chosen = ((row.get("cross_confirmation") or {}).get(f"{side}_audit") or {})
+    comparisons = (
+        ("verdict", vote.get("ratified_verdict"), chosen.get("verdict")),
+        ("claim_type", vote.get("ratified_claim_type"), chosen.get("claim_type")),
+        (
+            "claim_scope",
+            normalized_scope(vote.get("ratified_claim_scope")),
+            normalized_scope(chosen.get("claim_scope")),
+        ),
+        (
+            "load_bearing_step_class",
+            vote.get("ratified_load_bearing_step_class"),
+            chosen.get("load_bearing_step_class"),
+        ),
+        (
+            "negative_assertion_classes",
+            tuple(sorted(vote.get("negative_assertion_classes") or [])),
+            tuple(sorted(chosen.get("negative_assertion_classes") or [])),
+        ),
+        (
+            "decoration_parent_claim_id",
+            decoration_parent_tuple_key(
+                vote.get("ratified_verdict"),
+                vote.get("ratified_decoration_parent_claim_id"),
+            ),
+            decoration_parent_tuple_key(
+                chosen.get("verdict"), chosen.get("decoration_parent_claim_id")
+            ),
+        ),
+    )
+    mismatches = [name for name, actual, expected in comparisons if actual != expected]
+    if mismatches:
+        return (
+            f"{side}-sided vote changes selected seat tuple fields: "
+            f"{','.join(mismatches)}; use sided_with='hybrid' for corrections"
+        )
+    return None
+
+
+def judicial_disagreement_fingerprint(row: dict) -> dict:
+    """Bind a panel record to the exact source hash and two stored seats."""
+    cross = row.get("cross_confirmation") or {}
+    first = cross.get("first_audit") or {}
+    second = cross.get("second_audit") or {}
+    seat_payload = json.dumps(
+        {"first_audit": first, "second_audit": second},
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return {
+        "schema": "judicial_disagreement_fingerprint_v1",
+        "claim_id": row.get("claim_id"),
+        "note_hash": row.get("note_hash"),
+        "first_audit_invocation_id": first.get("audit_invocation_id"),
+        "second_audit_invocation_id": second.get("audit_invocation_id"),
+        "seat_summaries_sha256": hashlib.sha256(
+            seat_payload.encode("utf-8")
+        ).hexdigest(),
+    }

--- a/docs/audit/scripts/audit_contract.py
+++ b/docs/audit/scripts/audit_contract.py
@@ -40,6 +40,13 @@ CLAIM_TYPES = {
     "decoration",
     "meta",
 }
+POLICY_NEGATIVE_ASSERTION_CLASSES = {
+    "no_go_result",
+    "stretch_attempt_negative",
+    "bounded_with_named_walls",
+    "derived_no_go_boundary",
+    "conditional_wall_rationale",
+}
 
 
 def terminal_compute_required_error(payload: object) -> str | None:
@@ -136,6 +143,14 @@ def judicial_vote_schema_error(vote: object) -> str | None:
         isinstance(item, str) and item.strip() for item in declared
     ):
         return "negative_assertion_classes must be a list of non-empty strings"
+    unknown_classes = sorted(
+        set(declared) - POLICY_NEGATIVE_ASSERTION_CLASSES
+    )
+    if unknown_classes:
+        return (
+            "negative_assertion_classes contains unknown classes "
+            f"{unknown_classes}"
+        )
     for field in (
         "hybrid_resolution_note",
         "ratified_decoration_parent_claim_id",
@@ -149,6 +164,11 @@ def judicial_vote_schema_error(vote: object) -> str | None:
     if "no_go_discipline" in vote and vote["no_go_discipline"] is not None:
         if not isinstance(vote["no_go_discipline"], dict):
             return "no_go_discipline must be an object or null"
+    if vote.get("sided_with") == "hybrid" and (
+        not isinstance(vote.get("hybrid_resolution_note"), str)
+        or not vote["hybrid_resolution_note"].strip()
+    ):
+        return "a hybrid vote must provide a non-empty hybrid_resolution_note"
     first_error = str(vote.get("first_auditor_error") or "").strip().lower()
     second_error = str(vote.get("second_auditor_error") or "").strip().lower()
     if vote.get("sided_with") == "first" and second_error == "none":

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -52,6 +52,7 @@ from urllib.parse import unquote, urlsplit
 import premise_nodes
 import ledger_io
 import no_go_discipline_gate
+import audit_contract
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DATA_DIR = REPO_ROOT / "docs" / "audit" / "data"
@@ -113,6 +114,12 @@ def audit_summary_tuples_match(first: dict, second: dict) -> bool:
         == second.get("load_bearing_step_class")
         and normalized_negative_assertion_classes(first)
         == normalized_negative_assertion_classes(second)
+        and audit_contract.decoration_parent_tuple_key(
+            first.get("verdict"), first.get("decoration_parent_claim_id")
+        )
+        == audit_contract.decoration_parent_tuple_key(
+            second.get("verdict"), second.get("decoration_parent_claim_id")
+        )
     )
 
 
@@ -124,6 +131,7 @@ def live_row_audit_tuple(row: dict) -> dict:
         "claim_scope": row.get("claim_scope"),
         "load_bearing_step_class": row.get("load_bearing_step_class"),
         "negative_assertion_classes": row.get("negative_assertion_classes"),
+        "decoration_parent_claim_id": row.get("decoration_parent_claim_id"),
     }
 
 
@@ -152,6 +160,13 @@ def audit_summary_tuple_schema_error(summary: object) -> str | None:
         or claim_type not in ALLOWED_CLAIM_TYPES
     ):
         return f"audit summary has invalid claim_type {claim_type!r}"
+    tuple_error = audit_contract.verdict_claim_type_error(
+        verdict,
+        claim_type,
+        summary.get("decoration_parent_claim_id"),
+    )
+    if tuple_error:
+        return f"audit summary has incompatible verdict/claim_type: {tuple_error}"
     scope = summary.get("claim_scope")
     if not isinstance(scope, str) or not scope.strip():
         return "audit summary claim_scope must be a non-empty string"
@@ -1042,13 +1057,15 @@ def main() -> int:
                 errors.append(
                     f"{cid}: confirmed cross-confirmation full audit tuple mismatch "
                     "(verdict, claim_type, normalized claim_scope, "
-                    "load_bearing_step_class, negative_assertion_classes)"
+                    "load_bearing_step_class, decoration_parent_claim_id, "
+                    "negative_assertion_classes)"
                 )
             elif not agreement_schema_present and tuples_match is False:
                 message = (
                     f"{cid}: confirmed cross-confirmation full audit tuple mismatch "
                     "(verdict, claim_type, normalized claim_scope, "
-                    "load_bearing_step_class, negative_assertion_classes)"
+                    "load_bearing_step_class, decoration_parent_claim_id, "
+                    "negative_assertion_classes)"
                 )
                 add_notice(
                     "legacy_cross_confirmation_tuple_mismatch",

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -586,7 +586,11 @@ def main() -> int:
         required = source_required or no_go_discipline_gate.output_requires_no_go_discipline(
             audit_like
         ) or bool(audit_like.get("negative_assertion_classes"))
-        if required and packet is None:
+        binds = no_go_discipline_gate.packet_requirement_binds(
+            {**audit_like, "verdict": verdict},
+            source_required=source_required,
+        )
+        if required and binds and packet is None:
             message = (
                 f"{cid}: {label} lacks structured No-Go Discipline and "
                 "cannot be authoritative until fresh re-audit"

--- a/docs/audit/scripts/generate_conditional_prompts.py
+++ b/docs/audit/scripts/generate_conditional_prompts.py
@@ -7,13 +7,14 @@ The existing prompts file covers:
 
 The audited_conditional cohort was missing — the autonomous
 science_fix_loop.py had no queue for it. This script extends coverage
-to the three auditor-written conditional repair classes whose verdicts
+to the four auditor-written conditional repair classes whose verdicts
 contain a concrete repair target. Current category counts are printed at
 runtime because the audit ledger changes as hygiene repairs reset rows for
 re-audit:
 
   audited_conditional_runner_artifact_issue
   audited_conditional_scope_too_broad
+  audited_conditional_missing_dependency_edge
   audited_conditional_missing_bridge_theorem
 
 Synthesized backfilled rows (from backfill_repair_class.py) are
@@ -22,7 +23,7 @@ boilerplate verdict_rationale, not stated by an independent auditor.
 Those rows need re-audit, not autonomous derivation work.
 
 Usage:
-  # idempotent: rewrites the three conditional sections at the file end
+  # idempotent: rewrites the four conditional sections at the file end
   python3 docs/audit/scripts/generate_conditional_prompts.py
 """
 from __future__ import annotations
@@ -66,6 +67,10 @@ CONDITIONAL_SECTIONS = [
         "Auditor judged that a clean bounded core exists inside a claim whose current scope includes an unclosed extension. To close: split the clean bounded core out as its own retained-grade claim and demote the extension to bounded or open scope.",
     ),
     (
+        "audited_conditional_missing_dependency_edge",
+        "Auditor judged that the stated step depends on an authority that is absent from the governed dependency graph. To close: add the exact retained authority edge and align the citing scope, or narrow the claim if no such authority exists.",
+    ),
+    (
         "audited_conditional_missing_bridge_theorem",
         "Auditor judged that the chain needs a new theorem for a physical carrier, readout, unit map, boundary condition, sector choice, normalization, or observable bridge. To close: derive the missing bridge from retained primitives so the audited claim no longer asserts it.",
     ),
@@ -107,6 +112,7 @@ def collect_rows(rows: dict[str, dict], synthesized: set[str]) -> dict[str, list
     map_class = {
         "runner_artifact_issue": "audited_conditional_runner_artifact_issue",
         "scope_too_broad": "audited_conditional_scope_too_broad",
+        "missing_dependency_edge": "audited_conditional_missing_dependency_edge",
         "missing_bridge_theorem": "audited_conditional_missing_bridge_theorem",
     }
     for cid, row in rows.items():

--- a/docs/audit/scripts/invalidate_stale_audits.py
+++ b/docs/audit/scripts/invalidate_stale_audits.py
@@ -421,6 +421,10 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
         audit_status not in {None, "unaudited"}
         and bool(row.get("negative_assertion_classes"))
         and packet is None
+        and no_go_discipline_gate.packet_requirement_binds(
+            {**row, "verdict": audit_status},
+            source_required=source_required,
+        )
     ):
         return "no_go_discipline_packet_missing"
 

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -466,6 +466,18 @@ def launch_worker(
         evidence_manifest_out=evidence_manifest,
         audit_invocation_id=invocation_id,
     )
+    clipped_evidence = prompt_has_clipped_evidence(evidence_manifest)
+    if clipped_evidence:
+        prompt += (
+            "\n\n---\nPACKET COMPLETENESS PREFLIGHT (binding):\n"
+            "The restricted packet contains clipped load-bearing evidence at "
+            f"{json.dumps(clipped_evidence)}. audited_clean is forbidden. "
+            "Return the honest non-clean verdict and repair target. On this "
+            "development-tier non-no-go row, preserve any negative-boundary "
+            "judgment in negative_assertion_classes and rationale prose, but "
+            "leave no_go_discipline=null unless you can supply a structurally "
+            "valid optional packet from the rendered evidence.\n"
+        )
     if len(prompt) > audit_runner.CODEX_INPUT_CHAR_LIMIT:
         raise ValueError(
             f"{cid}: development packet is {len(prompt)} characters; "
@@ -480,6 +492,9 @@ def launch_worker(
     isolated.mkdir(parents=True, exist_ok=False)
     prompt_path = isolated / "AUDIT_TASK.md"
     prompt_path.write_text(prompt, encoding="utf-8")
+    output_schema = audit_runner.write_object_output_schema(
+        isolated / "AUDIT_RESPONSE.schema.json"
+    )
     raw_output = workdir / f"raw-{tag}.txt"
     delivery = workdir / f"delivery-{tag}.json"
     log_path = workdir / f"log-{tag}.txt"
@@ -495,6 +510,7 @@ def launch_worker(
                 "codex", "exec", "--skip-git-repo-check", "--ignore-rules",
                 "--sandbox", "read-only", "--model", MODEL,
                 "-c", f"model_reasoning_effort='{REASONING}'",
+                "--output-schema", str(output_schema),
                 "--output-last-message", str(raw_output), instruction,
             ],
             stdin=subprocess.DEVNULL,
@@ -705,6 +721,10 @@ def packet_completion_pass(
     blob_path.write_text(json.dumps(blob, indent=1), encoding="utf-8")
     out_path = workdir / f"completion-{attempt_key}-out.json"
     out_path.unlink(missing_ok=True)
+    output_schema = audit_runner.write_object_output_schema(
+        job["isolated"] / "AUDIT_COMPLETION_RESPONSE.schema.json",
+        allow_compute_required=False,
+    )
     log_path = workdir / f"completion-{attempt_key}.log"
     error_block = (
         "\nThe validator rejected the previous packet with EXACTLY this "
@@ -749,6 +769,7 @@ def packet_completion_pass(
         "--ignore-user-config", "--ephemeral",
         "--sandbox", "read-only", "--model", MODEL,
         "-c", f"model_reasoning_effort='{REASONING}'",
+        "--output-schema", str(output_schema),
         "--output-last-message", str(out_path), spec,
     ]
     sandbox_exec = Path("/usr/bin/sandbox-exec")
@@ -806,6 +827,8 @@ def packet_completion_pass(
         return None
     if not isinstance(completed, dict):
         return None
+    if completed.get("compute_required") is None:
+        completed.pop("compute_required", None)
     packet = completed.get("no_go_discipline")
     if not isinstance(packet, dict):
         return None
@@ -872,6 +895,24 @@ def finalize_worker(job: dict) -> tuple[dict | None, dict]:
             str(err or ""),
         ))
 
+    optional_packet_dropped = False
+    if error and _packet_error(error) and isinstance(blob.get("no_go_discipline"), dict):
+        # In the development tier a non-clean verdict on a non-no-go source
+        # carries its negative judgment in the declaration/rationale; the
+        # heavyweight packet is optional.  A volunteered but schema-invalid
+        # optional packet must not consume two 20-minute completion attempts
+        # or quarantine an otherwise valid scientific verdict.  Prove that it
+        # is optional by removing only that field and rerunning the unchanged
+        # canonical validator; clean/no-go/forensic verdicts still fail closed.
+        without_optional_packet = dict(blob)
+        without_optional_packet["no_go_discipline"] = None
+        if audit_runner.validate_verdict(
+            without_optional_packet, cid, **validation_args
+        ) is None:
+            blob = without_optional_packet
+            error = None
+            optional_packet_dropped = True
+
     completion_attempt = 0
     while (
         error
@@ -909,7 +950,10 @@ def finalize_worker(job: dict) -> tuple[dict | None, dict]:
     temporary = job["delivery"].with_suffix(".tmp")
     temporary.write_text(json.dumps(envelope, sort_keys=True), encoding="utf-8")
     temporary.replace(job["delivery"])
-    return envelope, {**base, "result": "delivery_validated"}
+    result = {**base, "result": "delivery_validated"}
+    if optional_packet_dropped:
+        result["detail"] = "invalid optional development-tier no_go_discipline dropped"
+    return envelope, result
 
 
 def clean_main_error() -> str | None:
@@ -960,14 +1004,8 @@ def allowed_generated_path(path: str) -> bool:
     )
 
 
-def run_apply_gates(envelope: dict) -> tuple[bool, str]:
-    ok, message = audit_runner.apply_one(
-        envelope["audit"],
-        propagate=False,
-        evidence_manifest=envelope["evidence_manifest"],
-    )
-    if not ok:
-        return False, f"apply rejected: {message[:400]}"
+def run_generated_gates() -> tuple[bool, str]:
+    """Run the expensive generated-surface gates once per claim transaction."""
     pipeline = sh(["bash", str(SCRIPTS / "run_pipeline.sh")], timeout=1800)
     if pipeline.returncode != 0:
         return False, f"pipeline failed: {(pipeline.stderr or pipeline.stdout)[-400:]}"
@@ -981,6 +1019,18 @@ def run_apply_gates(envelope: dict) -> tuple[bool, str]:
     if unexpected:
         return False, f"unexpected generated paths: {unexpected[:8]}"
     return True, "gates passed"
+
+
+def run_apply_gates(envelope: dict) -> tuple[bool, str]:
+    """Compatibility wrapper for one-seat callers and focused tests."""
+    ok, message = audit_runner.apply_one(
+        envelope["audit"],
+        propagate=False,
+        evidence_manifest=envelope["evidence_manifest"],
+    )
+    if not ok:
+        return False, f"apply rejected: {message[:400]}"
+    return run_generated_gates()
 
 
 def stage_and_commit(message: str) -> tuple[bool, str]:
@@ -1002,47 +1052,106 @@ def stage_and_commit(message: str) -> tuple[bool, str]:
     return True, committed.stdout.strip()
 
 
+def reset_to_origin_main() -> tuple[bool, str]:
+    reset = sh(["git", "reset", "--hard", "origin/main"])
+    if reset.returncode != 0:
+        return False, f"reset failed: {(reset.stderr or reset.stdout).strip()[:240]}"
+    error = clean_main_error()
+    return (error is None, error or "reset to origin/main")
+
+
+def apply_claim_serialized(
+    deliveries: list[tuple[dict, dict]],
+    retries: int,
+) -> tuple[bool, list[dict]]:
+    """Apply every validated seat for one claim as one transaction.
+
+    Critical rows commonly deliver both independent seats together. Applying
+    them before one pipeline/lint/commit/push preserves every seat transition
+    while amortizing the generated-surface cost. Push-race retries replay the
+    complete claim transaction from the refreshed canonical parent.
+    """
+    ordered = sorted(deliveries, key=lambda item: item[0]["pass"])
+    claim_ids = {job["cid"] for job, _ in ordered}
+    if len(claim_ids) != 1 or not ordered:
+        raise ValueError("one non-empty claim delivery group is required")
+    cid = next(iter(claim_ids))
+    for attempt in range(1, retries + 1):
+        synced, detail = sync_origin_main()
+        if not synced:
+            return False, [{"cid": cid, "result": "sync_blocked", "detail": detail}]
+
+        for job, envelope in ordered:
+            applied, apply_detail = audit_runner.apply_one(
+                envelope["audit"],
+                propagate=False,
+                evidence_manifest=envelope["evidence_manifest"],
+            )
+            if not applied:
+                reset_to_origin_main()
+                return False, [{
+                    "cid": cid,
+                    "pass": job["pass"],
+                    "result": "apply_or_gate_failed",
+                    "detail": f"apply rejected: {apply_detail[:400]}",
+                }]
+
+        gated, detail = run_generated_gates()
+        if not gated:
+            reset_to_origin_main()
+            return False, [{"cid": cid, "result": "apply_or_gate_failed", "detail": detail}]
+        verdicts = [str(envelope["audit"].get("verdict")) for _, envelope in ordered]
+        seats = ["first" if job["pass"] == 1 else "second" for job, _ in ordered]
+        committed, detail = stage_and_commit(
+            f"audit: {cid} {'+'.join(verdicts)} "
+            f"(codex-cli, {MODEL}, {REASONING}, {'+'.join(seats)}/batch)"
+        )
+        if not committed:
+            reset_to_origin_main()
+            return False, [{"cid": cid, "result": "commit_failed", "detail": detail}]
+        local_commit = detail
+        push = sh(["git", "push", "-q", "origin", "HEAD:main"])
+        if push.returncode == 0:
+            return True, [
+                {
+                    "cid": cid,
+                    "pass": job["pass"],
+                    "result": envelope["audit"].get("verdict"),
+                    "commit": local_commit,
+                }
+                for job, envelope in ordered
+            ]
+
+        fetch = sh(["git", "fetch", "origin", "main", "-q"])
+        if fetch.returncode != 0:
+            return False, [{"cid": cid, "result": "push_failed", "detail": "push and follow-up fetch failed"}]
+        landed = sh(["git", "merge-base", "--is-ancestor", local_commit, "origin/main"])
+        if landed.returncode == 0:
+            return True, [
+                {
+                    "cid": cid,
+                    "pass": job["pass"],
+                    "result": envelope["audit"].get("verdict"),
+                    "commit": local_commit,
+                }
+                for job, envelope in ordered
+            ]
+        if attempt == retries:
+            return False, [{"cid": cid, "result": "push_race_exhausted"}]
+        reset, reset_detail = reset_to_origin_main()
+        if not reset:
+            return False, [{"cid": cid, "result": "race_reset_failed", "detail": reset_detail}]
+    return False, [{"cid": cid, "result": "unreachable"}]
+
+
 def apply_one_serialized(
     job: dict,
     envelope: dict,
     retries: int,
 ) -> tuple[bool, dict]:
-    cid = job["cid"]
-    pass_no = job["pass"]
-    verdict = envelope["audit"].get("verdict")
-    for attempt in range(1, retries + 1):
-        synced, detail = sync_origin_main()
-        if not synced:
-            return False, {"cid": cid, "pass": pass_no, "result": "sync_blocked", "detail": detail}
-        gated, detail = run_apply_gates(envelope)
-        if not gated:
-            return False, {"cid": cid, "pass": pass_no, "result": "apply_or_gate_failed", "detail": detail}
-        pass_word = "first" if pass_no == 1 else "second"
-        committed, detail = stage_and_commit(
-            f"audit: {cid} {verdict} (codex-cli, {MODEL}, {REASONING}, {pass_word}/batch)"
-        )
-        if not committed:
-            return False, {"cid": cid, "pass": pass_no, "result": "commit_failed", "detail": detail}
-        local_commit = detail
-        push = sh(["git", "push", "-q", "origin", "HEAD:main"])
-        if push.returncode == 0:
-            return True, {"cid": cid, "pass": pass_no, "result": verdict, "commit": local_commit}
-
-        fetch = sh(["git", "fetch", "origin", "main", "-q"])
-        if fetch.returncode != 0:
-            return False, {"cid": cid, "pass": pass_no, "result": "push_failed", "detail": "push and follow-up fetch failed"}
-        landed = sh(["git", "merge-base", "--is-ancestor", local_commit, "origin/main"])
-        if landed.returncode == 0:
-            return True, {"cid": cid, "pass": pass_no, "result": verdict, "commit": local_commit}
-        if attempt == retries:
-            return False, {"cid": cid, "pass": pass_no, "result": "push_race_exhausted"}
-        error = clean_main_error()
-        if error:
-            return False, {"cid": cid, "pass": pass_no, "result": "race_retry_dirty", "detail": error}
-        reset = sh(["git", "reset", "--hard", "origin/main"])
-        if reset.returncode != 0:
-            return False, {"cid": cid, "pass": pass_no, "result": "race_reset_failed"}
-    return False, {"cid": cid, "pass": pass_no, "result": "unreachable"}
+    """Backward-compatible one-seat facade over the claim transaction."""
+    ok, results = apply_claim_serialized([(job, envelope)], retries)
+    return ok, results[0]
 
 
 def science_fix_handoff(job: dict, envelope: dict) -> dict | None:
@@ -1061,6 +1170,7 @@ def science_fix_handoff(job: dict, envelope: dict) -> dict | None:
         conditional_categories = {
             "runner_artifact_issue": "conditional_runner_artifact_issue",
             "scope_too_broad": "conditional_scope_too_broad",
+            "missing_dependency_edge": "conditional_missing_dependency_edge",
             "missing_bridge_theorem": "conditional_missing_bridge_theorem",
         }
         prefix = notes.split("—", 1)[0].split(":", 1)[0].strip().lower()
@@ -1395,12 +1505,16 @@ def apply_serialized(
             ),
         })
 
-    for key in sorted(deliveries):
-        job, envelope = deliveries[key]
-        if job["cid"] in invalid_claims:
+    for cid in sorted({delivery_cid for delivery_cid, _ in deliveries}):
+        if cid in invalid_claims:
             continue
-        ok, result = apply_one_serialized(job, envelope, retries)
-        report.append(result)
+        claim_deliveries = [
+            deliveries[key]
+            for key in sorted(deliveries)
+            if key[0] == cid
+        ]
+        ok, results = apply_claim_serialized(claim_deliveries, retries)
+        report.extend(results)
         if not ok:
             return (
                 False,
@@ -1408,9 +1522,10 @@ def apply_serialized(
                 schema_quarantines,
                 list(science_handoffs.values()),
             )
-        handoff = science_fix_handoff(job, envelope)
-        if handoff is not None:
-            science_handoffs[job["cid"]] = handoff
+        for job, envelope in claim_deliveries:
+            handoff = science_fix_handoff(job, envelope)
+            if handoff is not None:
+                science_handoffs[job["cid"]] = handoff
     hard_invalid_claims = invalid_claims - schema_quarantines
     return (
         not hard_invalid_claims,

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -896,7 +896,18 @@ def finalize_worker(job: dict) -> tuple[dict | None, dict]:
         ))
 
     optional_packet_dropped = False
-    if error and _packet_error(error) and isinstance(blob.get("no_go_discipline"), dict):
+    forensic_tier = bool(
+        source_requires_no_go
+        or blob.get("claim_type") == "no_go"
+        or audit_runner.no_go_discipline_gate.forensic_mode()
+    )
+    if (
+        error
+        and _packet_error(error)
+        and isinstance(blob.get("no_go_discipline"), dict)
+        and blob.get("verdict") != "audited_clean"
+        and not forensic_tier
+    ):
         # In the development tier a non-clean verdict on a non-no-go source
         # carries its negative judgment in the declaration/rationale; the
         # heavyweight packet is optional.  A volunteered but schema-invalid

--- a/docs/audit/scripts/orchestrate_judicial_panel.py
+++ b/docs/audit/scripts/orchestrate_judicial_panel.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import argparse
 import copy
-import hashlib
 import json
 import os
 import re
@@ -53,35 +52,10 @@ MIN_VOTE_BYTES = 120
 MAX_FRESH_PANEL_CONTRACT_RETRIES = 2
 VOTE_CONTRACT_ERROR_PREFIX = "vote_contract_error:"
 
-ALLOWED_SIDES = {"first", "second", "hybrid", "neither"}
-ALLOWED_VERDICTS = {
-    "audited_clean",
-    "audited_renaming",
-    "audited_conditional",
-    "audited_decoration",
-    "audited_failed",
-    "audited_numerical_match",
-}
-ALLOWED_CLAIM_TYPES = {
-    "positive_theorem",
-    "bounded_theorem",
-    "no_go",
-    "open_gate",
-    "decoration",
-    "meta",
-}
-
-VOTE_FIELDS = (
-    "sided_with",
-    "ratified_verdict",
-    "ratified_claim_type",
-    "ratified_claim_scope",
-    "ratified_load_bearing_step_class",
-    "negative_assertion_classes",
-    "judgment_rationale",
-    "first_auditor_error",
-    "second_auditor_error",
-)
+ALLOWED_SIDES = audit_contract.JUDICIAL_SIDES
+ALLOWED_VERDICTS = audit_contract.TERMINAL_VERDICTS
+ALLOWED_CLAIM_TYPES = audit_contract.CLAIM_TYPES
+VOTE_FIELDS = audit_contract.JUDICIAL_VOTE_FIELDS
 
 SEAT_ARGUMENT_FIELDS = (
     "verdict",
@@ -106,152 +80,23 @@ SEAT_ARGUMENT_FIELDS = (
 
 
 def norm_scope(value: str) -> str:
-    return re.sub(r"\s+", " ", str(value or "").strip())
+    return audit_contract.normalized_scope(value)
 
 
 def vote_tuple(vote: dict) -> tuple:
-    classes = vote.get("negative_assertion_classes")
-    classes_key = tuple(sorted(classes)) if isinstance(classes, list) else ("<invalid>",)
-    return (
-        vote.get("sided_with"),
-        vote.get("ratified_verdict"),
-        vote.get("ratified_claim_type"),
-        norm_scope(vote.get("ratified_claim_scope") or ""),
-        vote.get("ratified_load_bearing_step_class"),
-        audit_contract.decoration_parent_tuple_key(
-            vote.get("ratified_verdict"),
-            vote.get("ratified_decoration_parent_claim_id"),
-        ),
-        classes_key,
-    )
+    return audit_contract.judicial_vote_tuple(vote)
 
 
 def disagreement_fingerprint(row: dict) -> dict:
-    """Bind panel history to the exact source and two recorded seats."""
-    cross = row.get("cross_confirmation") or {}
-    first = copy.deepcopy(cross.get("first_audit") or {})
-    second = copy.deepcopy(cross.get("second_audit") or {})
-    seat_payload = json.dumps(
-        {"first_audit": first, "second_audit": second},
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    )
-    return {
-        "schema": "judicial_disagreement_fingerprint_v1",
-        "claim_id": row.get("claim_id"),
-        "note_hash": row.get("note_hash"),
-        "first_audit_invocation_id": first.get("audit_invocation_id"),
-        "second_audit_invocation_id": second.get("audit_invocation_id"),
-        "seat_summaries_sha256": hashlib.sha256(
-            seat_payload.encode("utf-8")
-        ).hexdigest(),
-    }
+    return audit_contract.judicial_disagreement_fingerprint(row)
 
 
 def vote_schema_error(vote: object) -> str | None:
-    if not isinstance(vote, dict):
-        return "vote must be a JSON object"
-    missing = [field for field in VOTE_FIELDS if field not in vote]
-    if missing:
-        return f"vote_missing_fields:{','.join(missing)}"
-    if vote.get("sided_with") not in ALLOWED_SIDES:
-        return "vote has invalid sided_with"
-    if vote.get("ratified_verdict") not in ALLOWED_VERDICTS:
-        return "vote has invalid ratified_verdict"
-    if vote.get("ratified_claim_type") not in ALLOWED_CLAIM_TYPES:
-        return "vote has invalid ratified_claim_type"
-    tuple_error = audit_contract.verdict_claim_type_error(
-        vote.get("ratified_verdict"),
-        vote.get("ratified_claim_type"),
-        vote.get("ratified_decoration_parent_claim_id"),
-    )
-    if tuple_error:
-        return f"vote has incompatible verdict/claim_type: {tuple_error}"
-    for field in (
-        "ratified_claim_scope",
-        "ratified_load_bearing_step_class",
-        "judgment_rationale",
-        "first_auditor_error",
-        "second_auditor_error",
-    ):
-        if not isinstance(vote.get(field), str) or not vote[field].strip():
-            return f"vote field {field} must be a non-empty string"
-    declared = vote.get("negative_assertion_classes")
-    if not isinstance(declared, list) or not all(
-        isinstance(item, str) and item.strip() for item in declared
-    ):
-        return "negative_assertion_classes must be a list of non-empty strings"
-    for field in (
-        "hybrid_resolution_note",
-        "ratified_decoration_parent_claim_id",
-        "ratified_load_bearing_step",
-        "notes_for_re_audit_if_any",
-    ):
-        if field in vote and vote[field] is not None and not isinstance(vote[field], str):
-            return f"vote field {field} must be a string or null"
-    if "no_go_discipline" in vote and vote["no_go_discipline"] is not None:
-        if not isinstance(vote["no_go_discipline"], dict):
-            return "no_go_discipline must be an object or null"
-    first_error = str(vote.get("first_auditor_error") or "").strip().lower()
-    second_error = str(vote.get("second_auditor_error") or "").strip().lower()
-    if vote.get("sided_with") == "first" and second_error == "none":
-        return "a first-sided vote must explain the second auditor's error"
-    if vote.get("sided_with") == "second" and first_error == "none":
-        return "a second-sided vote must explain the first auditor's error"
-    if vote.get("sided_with") in {"hybrid", "neither"} and (
-        first_error == "none" or second_error == "none"
-    ):
-        return (
-            f"a {vote.get('sided_with')}-sided vote must explain both "
-            "auditors' errors"
-        )
-    return None
+    return audit_contract.judicial_vote_schema_error(vote)
 
 
 def sided_vote_context_error(row: dict, vote: dict) -> str | None:
-    """Reject a sided vote that changes the selected seat's full tuple."""
-    side = vote.get("sided_with")
-    if side not in {"first", "second"}:
-        return None
-    chosen = ((row.get("cross_confirmation") or {}).get(f"{side}_audit") or {})
-    comparisons = (
-        ("verdict", vote.get("ratified_verdict"), chosen.get("verdict")),
-        ("claim_type", vote.get("ratified_claim_type"), chosen.get("claim_type")),
-        (
-            "claim_scope",
-            norm_scope(vote.get("ratified_claim_scope") or ""),
-            norm_scope(chosen.get("claim_scope") or ""),
-        ),
-        (
-            "load_bearing_step_class",
-            vote.get("ratified_load_bearing_step_class"),
-            chosen.get("load_bearing_step_class"),
-        ),
-        (
-            "negative_assertion_classes",
-            tuple(sorted(vote.get("negative_assertion_classes") or [])),
-            tuple(sorted(chosen.get("negative_assertion_classes") or [])),
-        ),
-        (
-            "decoration_parent_claim_id",
-            audit_contract.decoration_parent_tuple_key(
-                vote.get("ratified_verdict"),
-                vote.get("ratified_decoration_parent_claim_id"),
-            ),
-            audit_contract.decoration_parent_tuple_key(
-                chosen.get("verdict"),
-                chosen.get("decoration_parent_claim_id"),
-            ),
-        ),
-    )
-    mismatches = [name for name, actual, expected in comparisons if actual != expected]
-    if mismatches:
-        return (
-            f"{side}-sided vote changes selected seat tuple fields: "
-            f"{','.join(mismatches)}; use sided_with='hybrid' for corrections"
-        )
-    return None
+    return audit_contract.sided_judicial_vote_context_error(row, vote)
 
 
 def archived_rationale(row: dict, invocation_id: str) -> str:
@@ -707,6 +552,7 @@ def judicial_blob(
     votes: list[dict],
     majority: int,
     invocation_id: str | None = None,
+    panel_no: int = 1,
 ) -> dict:
     context_error = sided_vote_context_error(row, representative)
     if context_error:
@@ -732,6 +578,8 @@ def judicial_blob(
         f"\n[panel breakdown] {json.dumps(breakdown, sort_keys=True)}"
     )
     side = representative.get("sided_with")
+    panel_invocation_id = invocation_id or uuid.uuid4().hex
+    panel_tally = Counter(vote_tuple(vote) for vote in votes)
     cross = row.get("cross_confirmation") or {}
     chosen = (
         (cross.get(f"{side}_audit") or {})
@@ -762,7 +610,7 @@ def judicial_blob(
         "auditor_model": batch.MODEL,
         "auditor_reasoning_effort": batch.REASONING,
         "independence": "judicial_review",
-        "audit_invocation_id": invocation_id or uuid.uuid4().hex,
+        "audit_invocation_id": panel_invocation_id,
         "sided_with": side,
         "ratified_verdict": ratified_verdict,
         "ratified_claim_type": ratified_claim_type,
@@ -772,6 +620,21 @@ def judicial_blob(
         "judgment_rationale": rationale,
         "first_auditor_error": representative.get("first_auditor_error"),
         "second_auditor_error": representative.get("second_auditor_error"),
+        "judicial_panel_record_v1": {
+            "schema": "judicial_panel_record_v1",
+            "cid": row["claim_id"],
+            "panel": panel_no,
+            "invocation_id": panel_invocation_id,
+            "result": "majority_candidate",
+            "disagreement_fingerprint": disagreement_fingerprint(row),
+            "majority_count": majority,
+            "votes": [public_vote(vote) for vote in votes],
+            "failures": [],
+            "tally": [
+                {"tuple": [*key[:6], list(key[6])], "count": count}
+                for key, count in panel_tally.most_common()
+            ],
+        },
     }
     optional_sources = (chosen, representative) if chosen else (representative,)
     for source in optional_sources:
@@ -849,7 +712,7 @@ HARD_APPLY_BLOCKER_PREFIXES = (
     "missing required judicial fields:",
     "unknown claim_id:",
     "audit_invocation_id ",
-    "judicial third-auditor review requires independence=",
+    "judicial panel-majority apply requires independence=",
     "auditor_family=",
     "auditor_model=",
     "auditor_reasoning_effort=",
@@ -860,7 +723,8 @@ HARD_APPLY_BLOCKER_PREFIXES = (
     "first_audit cannot be upgraded",
     "second_audit cannot be upgraded",
     "third_audit cannot be upgraded",
-    "judicial third auditor must differ",
+    "judicial panel representative must differ",
+    "judicial_panel_record_v1",
     "trusted evidence manifest",
     "No-Go Discipline apply requires trusted orchestrator evidence transport",
 )
@@ -1165,7 +1029,12 @@ def run_panel(
             vote for vote in votes if vote_tuple(vote) == top_tuple
         ):
             candidate = judicial_blob(
-                row, representative, votes, count, invocation_id=invocation_id
+                row,
+                representative,
+                votes,
+                count,
+                invocation_id=invocation_id,
+                panel_no=panel_no,
             )
             error = judicial_applyability_error(
                 candidate, rows, evidence_manifest, workdir
@@ -1284,10 +1153,6 @@ def load_prior_panels(
                 len(votes) >= PANEL_SIZE
                 or not isinstance(failures, list)
                 or not failures
-                or not all(
-                    VOTE_CONTRACT_ERROR_PREFIX in str(failure)
-                    for failure in failures
-                )
             ):
                 return {}, f"prior panel {path} has an invalid contract-retry record"
         elif len(votes) != PANEL_SIZE:
@@ -1299,13 +1164,50 @@ def load_prior_panels(
             context_error = sided_vote_context_error(target_rows[cid], vote)
             if context_error:
                 return {}, f"prior panel {path} contains invalid vote: {context_error}"
-        if len({vote.get("judge") for vote in votes}) != len(votes):
+        vote_judges = [vote.get("judge") for vote in votes]
+        vote_auditors = [vote.get("auditor") for vote in votes]
+        if not all(
+            isinstance(judge, int) and not isinstance(judge, bool)
+            and judge in range(1, PANEL_SIZE + 1)
+            for judge in vote_judges
+        ):
+            return {}, f"prior panel {path} contains an invalid judge seat"
+        if len(set(vote_judges)) != len(votes):
             return {}, f"prior panel {path} does not preserve distinct judges"
-        if len({vote.get("auditor") for vote in votes}) != len(votes):
+        if not all(
+            isinstance(auditor, str) and auditor.strip()
+            for auditor in vote_auditors
+        ):
+            return {}, f"prior panel {path} contains an invalid auditor identity"
+        if len(set(vote_auditors)) != len(votes):
             return {}, f"prior panel {path} does not preserve distinct identities"
         if result == "contract_invalid_retry":
+            failure_judges: list[int] = []
+            for failure in failures:
+                match = re.fullmatch(
+                    rf"judge([1-{PANEL_SIZE}]):"
+                    rf"{re.escape(VOTE_CONTRACT_ERROR_PREFIX)}.+",
+                    str(failure),
+                )
+                if match is None:
+                    return {}, (
+                        f"prior panel {path} has an invalid contract-retry record"
+                    )
+                failure_judges.append(int(match.group(1)))
+            if (
+                len(votes) + len(failures) != PANEL_SIZE
+                or len(set(failure_judges)) != len(failure_judges)
+                or set(vote_judges) & set(failure_judges)
+                or set(vote_judges) | set(failure_judges)
+                != set(range(1, PANEL_SIZE + 1))
+            ):
+                return {}, (
+                    f"prior panel {path} has an invalid contract-retry record"
+                )
             grouped.setdefault(cid, []).append(record)
             continue
+        if set(vote_judges) != set(range(1, PANEL_SIZE + 1)):
+            return {}, f"prior panel {path} does not preserve all five judge seats"
         tally = Counter(vote_tuple(vote) for vote in votes)
         top_tuple, count = tally.most_common(1)[0]
         if result == "no_majority" and count >= MAJORITY:

--- a/docs/audit/scripts/orchestrate_judicial_panel.py
+++ b/docs/audit/scripts/orchestrate_judicial_panel.py
@@ -8,7 +8,7 @@ judges with distinct identities. Each judge votes on the full tuple
 
     (sided_with, ratified_verdict, ratified_claim_type,
      ratified_claim_scope, ratified_load_bearing_step_class,
-     negative_assertion_classes)
+     ratified_decoration_parent_claim_id, negative_assertion_classes)
 
 and must explain the error in the position it votes against. A majority is
 at least three matching full-tuple votes out of five (whitespace-only scope
@@ -50,6 +50,8 @@ REPO_ROOT = batch.REPO_ROOT
 PANEL_SIZE = 5
 MAJORITY = 3
 MIN_VOTE_BYTES = 120
+MAX_FRESH_PANEL_CONTRACT_RETRIES = 2
+VOTE_CONTRACT_ERROR_PREFIX = "vote_contract_error:"
 
 ALLOWED_SIDES = {"first", "second", "hybrid", "neither"}
 ALLOWED_VERDICTS = {
@@ -116,6 +118,10 @@ def vote_tuple(vote: dict) -> tuple:
         vote.get("ratified_claim_type"),
         norm_scope(vote.get("ratified_claim_scope") or ""),
         vote.get("ratified_load_bearing_step_class"),
+        audit_contract.decoration_parent_tuple_key(
+            vote.get("ratified_verdict"),
+            vote.get("ratified_decoration_parent_claim_id"),
+        ),
         classes_key,
     )
 
@@ -227,6 +233,17 @@ def sided_vote_context_error(row: dict, vote: dict) -> str | None:
             tuple(sorted(vote.get("negative_assertion_classes") or [])),
             tuple(sorted(chosen.get("negative_assertion_classes") or [])),
         ),
+        (
+            "decoration_parent_claim_id",
+            audit_contract.decoration_parent_tuple_key(
+                vote.get("ratified_verdict"),
+                vote.get("ratified_decoration_parent_claim_id"),
+            ),
+            audit_contract.decoration_parent_tuple_key(
+                chosen.get("verdict"),
+                chosen.get("decoration_parent_claim_id"),
+            ),
+        ),
     )
     mismatches = [name for name, actual, expected in comparisons if actual != expected]
     if mismatches:
@@ -270,6 +287,16 @@ def seat_context_error(row: dict) -> str | None:
         summary = cross.get(label) or {}
         if not summary:
             return f"{label} summary is missing"
+        tuple_error = audit_contract.verdict_claim_type_error(
+            summary.get("verdict"),
+            summary.get("claim_type"),
+            summary.get("decoration_parent_claim_id"),
+        )
+        if tuple_error:
+            return (
+                f"{label} has an incompatible verdict/claim_type tuple: "
+                f"{tuple_error}; fresh cross-confirmation seats are required"
+            )
         if str(summary.get("verdict_rationale") or "").strip():
             continue
         invocation_id = str(summary.get("audit_invocation_id") or "")
@@ -293,11 +320,10 @@ def seat_context_error(row: dict) -> str | None:
 
 
 RESEAT_REASON = (
-    "cross_confirmation_reseat: the recorded seats lack invocation-bound "
-    "full rationales (pre-2026-07-13 apply contract) and envelope backfill "
-    "(backfill_cross_seat_rationales.py) could not recover them; the seats "
-    "are archived here with full provenance and the row is reopened for "
-    "fresh cross-confirmation under the rationale-preserving apply contract"
+    "cross_confirmation_reseat: the recorded seats do not satisfy the current "
+    "rationale-preserving, semantically applyable seat contract; the seats are "
+    "archived here with full provenance and the row is reopened for fresh "
+    "cross-confirmation before any judicial panel"
 )
 
 
@@ -472,8 +498,10 @@ def panel_instructions(
     if prior_panels:
         prior_block = (
             "\n### Prior panel outcomes\n\n"
-            "Earlier five-judge panels on this same disagreement produced the\n"
-            "complete vote/rationale breakdowns below but no applyable majority.\n"
+            "Earlier panel attempts on this same disagreement produced the\n"
+            "vote/rationale and validator-error breakdowns below but no applyable\n"
+            "majority. Contract-invalid attempts may contain fewer than five\n"
+            "accepted votes because invalid vote tuples carry no authority.\n"
             "Weigh their arguments; you are not bound by them.\n\n"
             + json.dumps(prior_panels, indent=1, sort_keys=True)
             + "\n"
@@ -661,7 +689,7 @@ def collect_vote(job: dict) -> tuple[dict | None, str]:
         return None, "malformed_vote_json"
     schema_error = vote_schema_error(vote)
     if schema_error:
-        return None, schema_error
+        return None, f"{VOTE_CONTRACT_ERROR_PREFIX}{schema_error}"
     return vote, "ok"
 
 
@@ -692,7 +720,7 @@ def judicial_blob(
         {
             "judge": vote.get("_panel_judge", index + 1),
             "auditor": vote.get("_panel_auditor"),
-            "tuple": list(vote_tuple(vote)[:5]) + [list(vote_tuple(vote)[5])],
+            "tuple": list(vote_tuple(vote)[:6]) + [list(vote_tuple(vote)[6])],
             "rationale": str(vote.get("judgment_rationale") or "")[:600],
         }
         for index, vote in enumerate(votes)
@@ -980,6 +1008,11 @@ def run_panel(
 
     panel_history = copy.deepcopy(prior_panels)
     panel_no = len(panel_history) + 1
+    consecutive_contract_retries = 0
+    for prior in reversed(panel_history):
+        if prior.get("result") != "contract_invalid_retry":
+            break
+        consecutive_contract_retries += 1
     while True:
         jobs = []
         try:
@@ -1027,14 +1060,23 @@ def run_panel(
             }
         votes: list[dict] = []
         failures: list[str] = []
+        contract_failures: list[str] = []
         for job in jobs:
             vote, status = collect_vote(job)
             if vote is None:
-                failures.append(f"judge{job['judge']}:{status}")
+                failure = f"judge{job['judge']}:{status}"
+                failures.append(failure)
+                if status.startswith(VOTE_CONTRACT_ERROR_PREFIX):
+                    contract_failures.append(failure)
             else:
                 context_error = sided_vote_context_error(row, vote)
                 if context_error:
-                    failures.append(f"judge{job['judge']}:{context_error}")
+                    failure = (
+                        f"judge{job['judge']}:{VOTE_CONTRACT_ERROR_PREFIX}"
+                        f"{context_error}"
+                    )
+                    failures.append(failure)
+                    contract_failures.append(failure)
                 else:
                     vote["_panel_judge"] = job["judge"]
                     vote["_panel_auditor"] = job["auditor"]
@@ -1050,11 +1092,35 @@ def run_panel(
             "votes": [public_vote(vote) for vote in votes],
             "failures": failures,
             "tally": [
-                {"tuple": [*key[:5], list(key[5])], "count": n}
+                {"tuple": [*key[:6], list(key[6])], "count": n}
                 for key, n in tally.most_common()
             ],
         }
         if len(votes) != PANEL_SIZE:
+            if failures and len(contract_failures) == len(failures):
+                consecutive_contract_retries += 1
+                if (
+                    consecutive_contract_retries
+                    <= MAX_FRESH_PANEL_CONTRACT_RETRIES
+                ):
+                    record["result"] = "contract_invalid_retry"
+                    write_panel_record(workdir, cid, panel_no, record)
+                    panel_history.append(record)
+                    print(
+                        f"   {cid}: panel {panel_no} had schema-invalid vote "
+                        "deliveries; launching a fresh five-judge panel with "
+                        "the exact validator errors"
+                    )
+                    panel_no += 1
+                    continue
+                record["result"] = "panel_contract_retries_exhausted"
+                write_panel_record(workdir, cid, panel_no, record)
+                return {
+                    "cid": cid,
+                    "result": "panel_contract_retries_exhausted",
+                    "detail": ";".join(failures),
+                    "votes": record["votes"],
+                }
             record["result"] = "panel_delivery_short"
             write_panel_record(workdir, cid, panel_no, record)
             return {
@@ -1064,6 +1130,7 @@ def run_panel(
                 "votes": record["votes"],
             }
 
+        consecutive_contract_retries = 0
         top_tuple, count = tally.most_common(1)[0]
         if count < MAJORITY:
             record["result"] = "no_majority"
@@ -1158,7 +1225,12 @@ def workdir_guard_error(workdir: Path) -> str | None:
     )
 
 
-PRIOR_PANEL_RESULTS = {"no_majority", "majority_neither", "majority_unapplyable"}
+PRIOR_PANEL_RESULTS = {
+    "no_majority",
+    "majority_neither",
+    "majority_unapplyable",
+    "contract_invalid_retry",
+}
 
 
 def load_prior_panels(
@@ -1202,8 +1274,23 @@ def load_prior_panels(
             )
         if record.get("result") not in PRIOR_PANEL_RESULTS:
             return {}, f"prior panel {path} has invalid result {record.get('result')!r}"
+        result = record["result"]
         votes = record.get("votes")
-        if not isinstance(votes, list) or len(votes) != PANEL_SIZE:
+        if not isinstance(votes, list):
+            return {}, f"prior panel {path} has no vote list"
+        if result == "contract_invalid_retry":
+            failures = record.get("failures")
+            if (
+                len(votes) >= PANEL_SIZE
+                or not isinstance(failures, list)
+                or not failures
+                or not all(
+                    VOTE_CONTRACT_ERROR_PREFIX in str(failure)
+                    for failure in failures
+                )
+            ):
+                return {}, f"prior panel {path} has an invalid contract-retry record"
+        elif len(votes) != PANEL_SIZE:
             return {}, f"prior panel {path} does not contain five vote records"
         for vote in votes:
             schema_error = vote_schema_error(vote)
@@ -1212,13 +1299,15 @@ def load_prior_panels(
             context_error = sided_vote_context_error(target_rows[cid], vote)
             if context_error:
                 return {}, f"prior panel {path} contains invalid vote: {context_error}"
-        if len({vote.get("judge") for vote in votes}) != PANEL_SIZE:
-            return {}, f"prior panel {path} does not preserve five distinct judges"
-        if len({vote.get("auditor") for vote in votes}) != PANEL_SIZE:
-            return {}, f"prior panel {path} does not preserve five distinct identities"
+        if len({vote.get("judge") for vote in votes}) != len(votes):
+            return {}, f"prior panel {path} does not preserve distinct judges"
+        if len({vote.get("auditor") for vote in votes}) != len(votes):
+            return {}, f"prior panel {path} does not preserve distinct identities"
+        if result == "contract_invalid_retry":
+            grouped.setdefault(cid, []).append(record)
+            continue
         tally = Counter(vote_tuple(vote) for vote in votes)
         top_tuple, count = tally.most_common(1)[0]
-        result = record["result"]
         if result == "no_majority" and count >= MAJORITY:
             return {}, f"prior panel {path} labels a majority as no_majority"
         if result == "majority_neither" and not (

--- a/docs/audit/scripts/orchestrate_judicial_panel.py
+++ b/docs/audit/scripts/orchestrate_judicial_panel.py
@@ -587,6 +587,10 @@ def launch_judge(
     isolated = workdir / f"isolated-{tag}"
     isolated.mkdir(parents=True, exist_ok=False)
     (isolated / "PANEL_TASK.md").write_text(prompt, encoding="utf-8")
+    output_schema = audit_runner.write_object_output_schema(
+        isolated / "PANEL_RESPONSE.schema.json",
+        response_kind="judicial_vote",
+    )
     raw_output = workdir / f"raw-{tag}.txt"
     log_path = workdir / f"log-{tag}.txt"
     log_handle = log_path.open("w", encoding="utf-8")
@@ -602,6 +606,7 @@ def launch_judge(
                 "codex", "exec", "--skip-git-repo-check", "--ignore-rules",
                 "--sandbox", "read-only", "--model", batch.MODEL,
                 "-c", f"model_reasoning_effort='{batch.REASONING}'",
+                "--output-schema", str(output_schema),
                 "--output-last-message", str(raw_output), instruction,
             ],
             stdin=subprocess.DEVNULL,

--- a/docs/audit/scripts/orchestrate_judicial_panel.py
+++ b/docs/audit/scripts/orchestrate_judicial_panel.py
@@ -40,6 +40,7 @@ from pathlib import Path
 SCRIPTS = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS))
 import ledger_io  # noqa: E402
+import audit_contract  # noqa: E402
 import orchestrate_audit_batch as batch  # noqa: E402
 import seed_audit_ledger as seed_ledger  # noqa: E402
 
@@ -154,6 +155,13 @@ def vote_schema_error(vote: object) -> str | None:
         return "vote has invalid ratified_verdict"
     if vote.get("ratified_claim_type") not in ALLOWED_CLAIM_TYPES:
         return "vote has invalid ratified_claim_type"
+    tuple_error = audit_contract.verdict_claim_type_error(
+        vote.get("ratified_verdict"),
+        vote.get("ratified_claim_type"),
+        vote.get("ratified_decoration_parent_claim_id"),
+    )
+    if tuple_error:
+        return f"vote has incompatible verdict/claim_type: {tuple_error}"
     for field in (
         "ratified_claim_scope",
         "ratified_load_bearing_step_class",

--- a/docs/audit/scripts/orchestrate_judicial_panel.py
+++ b/docs/audit/scripts/orchestrate_judicial_panel.py
@@ -56,6 +56,16 @@ ALLOWED_SIDES = audit_contract.JUDICIAL_SIDES
 ALLOWED_VERDICTS = audit_contract.TERMINAL_VERDICTS
 ALLOWED_CLAIM_TYPES = audit_contract.CLAIM_TYPES
 VOTE_FIELDS = audit_contract.JUDICIAL_VOTE_FIELDS
+PUBLIC_VOTE_FIELDS = (
+    "judge",
+    "auditor",
+    *VOTE_FIELDS,
+    "ratified_load_bearing_step",
+    "hybrid_resolution_note",
+    "ratified_decoration_parent_claim_id",
+    "notes_for_re_audit_if_any",
+    "no_go_discipline",
+)
 
 SEAT_ARGUMENT_FIELDS = (
     "verdict",
@@ -85,6 +95,15 @@ def norm_scope(value: str) -> str:
 
 def vote_tuple(vote: dict) -> tuple:
     return audit_contract.judicial_vote_tuple(vote)
+
+
+def serialized_tally(votes: list[dict]) -> list[dict]:
+    """Return the canonical JSON form of the complete-tuple vote tally."""
+    tally = Counter(vote_tuple(vote) for vote in votes)
+    return [
+        {"tuple": [*key[:6], list(key[6])], "count": count}
+        for key, count in tally.most_common()
+    ]
 
 
 def disagreement_fingerprint(row: dict) -> dict:
@@ -539,10 +558,24 @@ def collect_vote(job: dict) -> tuple[dict | None, str]:
 
 
 def public_vote(vote: dict) -> dict:
-    return {
+    stored = {
+        **{key: value for key, value in vote.items() if not key.startswith("_")},
         "judge": vote.get("_panel_judge"),
         "auditor": vote.get("_panel_auditor"),
-        **{key: value for key, value in vote.items() if not key.startswith("_")},
+    }
+    return {
+        key: copy.deepcopy(stored[key])
+        for key in PUBLIC_VOTE_FIELDS
+        if key in stored
+    }
+
+
+def canonical_prior_vote(vote: dict) -> dict:
+    """Strip untrusted prior-history fields before showing them to judges."""
+    return {
+        key: copy.deepcopy(vote[key])
+        for key in PUBLIC_VOTE_FIELDS
+        if key in vote
     }
 
 
@@ -554,6 +587,13 @@ def judicial_blob(
     invocation_id: str | None = None,
     panel_no: int = 1,
 ) -> dict:
+    for index, vote in enumerate(votes, 1):
+        schema_error = vote_schema_error(vote)
+        if schema_error:
+            raise ValueError(f"panel vote {index} is invalid: {schema_error}")
+        context_error = sided_vote_context_error(row, vote)
+        if context_error:
+            raise ValueError(f"panel vote {index} is invalid: {context_error}")
     context_error = sided_vote_context_error(row, representative)
     if context_error:
         raise ValueError(context_error)
@@ -579,7 +619,6 @@ def judicial_blob(
     )
     side = representative.get("sided_with")
     panel_invocation_id = invocation_id or uuid.uuid4().hex
-    panel_tally = Counter(vote_tuple(vote) for vote in votes)
     cross = row.get("cross_confirmation") or {}
     chosen = (
         (cross.get(f"{side}_audit") or {})
@@ -630,10 +669,7 @@ def judicial_blob(
             "majority_count": majority,
             "votes": [public_vote(vote) for vote in votes],
             "failures": [],
-            "tally": [
-                {"tuple": [*key[:6], list(key[6])], "count": count}
-                for key, count in panel_tally.most_common()
-            ],
+            "tally": serialized_tally(votes),
         },
     }
     optional_sources = (chosen, representative) if chosen else (representative,)
@@ -659,10 +695,9 @@ def judicial_blob(
             blob["no_go_discipline"] = copy.deepcopy(source["no_go_discipline"])
             break
     if side == "hybrid":
-        blob["hybrid_resolution_note"] = (
-            representative.get("hybrid_resolution_note")
-            or representative.get("judgment_rationale")
-        )
+        blob["hybrid_resolution_note"] = representative[
+            "hybrid_resolution_note"
+        ]
     return blob
 
 
@@ -955,10 +990,7 @@ def run_panel(
             "disagreement_fingerprint": disagreement_fingerprint(row),
             "votes": [public_vote(vote) for vote in votes],
             "failures": failures,
-            "tally": [
-                {"tuple": [*key[:6], list(key[6])], "count": n}
-                for key, n in tally.most_common()
-            ],
+            "tally": serialized_tally(votes),
         }
         if len(votes) != PANEL_SIZE:
             if failures and len(contract_failures) == len(failures):
@@ -1157,6 +1189,8 @@ def load_prior_panels(
                 return {}, f"prior panel {path} has an invalid contract-retry record"
         elif len(votes) != PANEL_SIZE:
             return {}, f"prior panel {path} does not contain five vote records"
+        elif record.get("failures") != []:
+            return {}, f"prior panel {path} has inconsistent failure metadata"
         for vote in votes:
             schema_error = vote_schema_error(vote)
             if schema_error:
@@ -1181,6 +1215,7 @@ def load_prior_panels(
             return {}, f"prior panel {path} contains an invalid auditor identity"
         if len(set(vote_auditors)) != len(votes):
             return {}, f"prior panel {path} does not preserve distinct identities"
+        expected_tally = serialized_tally(votes)
         if result == "contract_invalid_retry":
             failure_judges: list[int] = []
             for failure in failures:
@@ -1204,10 +1239,38 @@ def load_prior_panels(
                 return {}, (
                     f"prior panel {path} has an invalid contract-retry record"
                 )
-            grouped.setdefault(cid, []).append(record)
+            if record.get("tally") != expected_tally:
+                return {}, f"prior panel {path} has inconsistent tally metadata"
+            canonical = {
+                "schema": "judicial_panel_record_v1",
+                "cid": cid,
+                "panel": panel_no,
+                "invocation_id": invocation_id,
+                "result": result,
+                "disagreement_fingerprint": copy.deepcopy(
+                    expected_fingerprint
+                ),
+                "votes": [canonical_prior_vote(vote) for vote in votes],
+                "failures": copy.deepcopy(record["failures"]),
+                "tally": copy.deepcopy(expected_tally),
+            }
+            grouped.setdefault(cid, []).append(canonical)
             continue
         if set(vote_judges) != set(range(1, PANEL_SIZE + 1)):
             return {}, f"prior panel {path} does not preserve all five judge seats"
+        if record.get("tally") != expected_tally:
+            return {}, f"prior panel {path} has inconsistent tally metadata"
+        canonical = {
+            "schema": "judicial_panel_record_v1",
+            "cid": cid,
+            "panel": panel_no,
+            "invocation_id": invocation_id,
+            "result": result,
+            "disagreement_fingerprint": copy.deepcopy(expected_fingerprint),
+            "votes": [canonical_prior_vote(vote) for vote in votes],
+            "failures": [],
+            "tally": copy.deepcopy(expected_tally),
+        }
         tally = Counter(vote_tuple(vote) for vote in votes)
         top_tuple, count = tally.most_common(1)[0]
         if result == "no_majority" and count >= MAJORITY:
@@ -1220,7 +1283,47 @@ def load_prior_panels(
             count >= MAJORITY and top_tuple[0] != "neither"
         ):
             return {}, f"prior panel {path} has an inconsistent unapplyable result"
-        grouped.setdefault(cid, []).append(record)
+        if result == "majority_neither":
+            if record.get("majority") != count:
+                return {}, f"prior panel {path} has inconsistent majority metadata"
+            canonical["majority"] = count
+            canonical["detail"] = (
+                "a neither majority is recorded but never applied; the "
+                "audit-loop skill requires a fresh five-judge panel"
+            )
+        if result == "majority_unapplyable":
+            apply_errors = record.get("apply_errors")
+            majority_votes = [
+                vote for vote in votes if vote_tuple(vote) == top_tuple
+            ]
+            if not isinstance(apply_errors, list) or len(apply_errors) != count:
+                return {}, f"prior panel {path} has invalid apply-error metadata"
+            canonical_errors = []
+            for rejection, majority_vote in zip(apply_errors, majority_votes):
+                expected_identity = (
+                    majority_vote.get("judge"),
+                    majority_vote.get("auditor"),
+                )
+                if (
+                    not isinstance(rejection, dict)
+                    or (rejection.get("judge"), rejection.get("auditor"))
+                    != expected_identity
+                    or not isinstance(rejection.get("error"), str)
+                    or not rejection["error"].strip()
+                    or hard_apply_blocker(rejection["error"])
+                ):
+                    return {}, (
+                        f"prior panel {path} has invalid apply-error metadata"
+                    )
+                canonical_errors.append(
+                    {
+                        "judge": expected_identity[0],
+                        "auditor": expected_identity[1],
+                        "error": rejection["error"],
+                    }
+                )
+            canonical["apply_errors"] = canonical_errors
+        grouped.setdefault(cid, []).append(canonical)
     for records in grouped.values():
         records.sort(key=lambda record: record["panel"])
         rounds = [record["panel"] for record in records]

--- a/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
+++ b/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
@@ -10,11 +10,10 @@ Restored categories:
 
   3. `no_go_discipline_packet_missing` invalidations whose archived audit
      is restorable under the CURRENT no-go trigger. The restoration guard
-     re-runs the live source/output gate: a row that still asserts a
-     gated negative boundary without a packet, or whose archived packet
-     does not round-trip validation, stays invalidated for fresh audit.
-     Only rows the trigger-precision repair no longer gates (honest
-     scoping surfaces and misparse classes) become eligible.
+     re-runs the live source/output gate: retained clean/no-go authority that
+     still requires a packet, or any archived packet that does not round-trip
+     validation, stays invalidated for fresh audit. Development-tier non-clean
+     repair verdicts follow their live optional-packet contract.
 
   4. `dep_weakened:dep_id:before->after` invalidations whose `dep_id`
      has already recovered on the live ledger — through a landed
@@ -571,11 +570,14 @@ def restore_audit_from_previous(
         note_body = (REPO_ROOT / note_path).read_text(encoding="utf-8", errors="replace")
     except OSError:
         pass
-    # Restoring archived clean authority is a certification-like act:
-    # evaluate the negative-boundary gate in the forensic tier so a
-    # packetless negative row cannot re-enter authority through a
-    # development-tier restoration pass (two-tier assurance, 2026-07-12).
-    with _forensic_gate():
+    # Restoring archived clean authority is a certification-like act and uses
+    # the forensic tier. A non-clean development verdict is repair-queue
+    # evidence, not retained authority, so it must use the same packet-binding
+    # rule as live validation/invalidation instead of being promoted to a
+    # stronger tier merely by the restoration transport.
+    restoring_clean = new_row.get("audit_status") == "audited_clean"
+    gate_context = _forensic_gate() if restoring_clean else contextlib.nullcontext()
+    with gate_context:
         source_required = no_go_discipline_gate.source_requires_no_go_discipline(
             note_path, note_body, new_row.get("claim_type")
         )
@@ -591,10 +593,11 @@ def restore_audit_from_previous(
         "no_go_discipline": new_row.get("no_go_discipline"),
         "negative_assertion_classes": new_row.get("negative_assertion_classes"),
     }
-    with _forensic_gate():
+    gate_context = _forensic_gate() if restoring_clean else contextlib.nullcontext()
+    with gate_context:
         output_required = no_go_discipline_gate.output_requires_no_go_discipline(
-        gate_blob
-    )
+            gate_blob
+        )
     # Honor a non-empty declaration present on EITHER storage surface:
     # the archived audit or the reset live row (legacy archives predate
     # the field, but a surviving live declaration is still the auditor's
@@ -606,14 +609,12 @@ def restore_audit_from_previous(
         isinstance(d, list) and bool(d)
         for d in (declared_archived, declared_live)
     )
+    packet_binds = no_go_discipline_gate.packet_requirement_binds(
+        gate_blob, source_required=source_required
+    )
     if (
-        bool(new_row.get("negative_assertion_classes"))
-        and new_row.get("no_go_discipline") is None
-    ):
-        return None
-    if (
-        new_row.get("audit_status") == "audited_clean"
-        and (source_required or output_required or declared_requires)
+        (source_required or output_required or declared_requires)
+        and packet_binds
         and new_row.get("no_go_discipline") is None
     ):
         return None

--- a/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
+++ b/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
@@ -104,6 +104,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import no_go_discipline_gate
+import audit_contract
 
 import ledger_io
 
@@ -293,6 +294,12 @@ def archived_audit_is_lint_compatible(archived: dict) -> bool:
         return False
     if archived.get("claim_type") not in ALLOWED_CLAIM_TYPES:
         return False
+    if audit_contract.verdict_claim_type_error(
+        audit_status,
+        archived.get("claim_type"),
+        archived.get("decoration_parent_claim_id"),
+    ):
+        return False
     if not archived.get("claim_scope"):
         return False
     if archived.get("independence") not in ALLOWED_INDEPENDENCE:
@@ -321,9 +328,24 @@ def archived_audit_is_lint_compatible(archived: dict) -> bool:
     if isinstance(cross, dict):
         for seat_name in ("first_audit", "second_audit", "third_audit"):
             seat = cross.get(seat_name)
-            if not isinstance(seat, dict) or seat.get("verdict") != "audited_clean":
+            if not isinstance(seat, dict):
                 continue
-            if not clean_audit_provenance_is_compatible(seat, top_level=False):
+            seat_verdict = seat.get("verdict")
+            if (
+                seat_verdict in TERMINAL_VERDICTS
+                and audit_contract.verdict_claim_type_error(
+                    seat_verdict,
+                    seat.get("claim_type"),
+                    seat.get("decoration_parent_claim_id"),
+                )
+            ):
+                return False
+            if (
+                seat_verdict == "audited_clean"
+                and not clean_audit_provenance_is_compatible(
+                    seat, top_level=False
+                )
+            ):
                 return False
 
     return True

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -181,6 +181,107 @@ class SchemaRecoveryTest(unittest.TestCase):
         )
         self.assertIn("optional", result["detail"])
 
+    def test_invalid_optional_packet_is_not_dropped_from_clean(self):
+        invocation = "b" * 32
+        blob = {
+            "claim_id": "row",
+            "audit_invocation_id": invocation,
+            "load_bearing_step": "The exact identity follows.",
+            "load_bearing_step_class": "B",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "The exact identity.",
+            "chain_closes": True,
+            "chain_closure_explanation": "The calculation closes.",
+            "verdict": "audited_clean",
+            "verdict_rationale": "The bounded calculation is complete.",
+            "negative_assertion_classes": [],
+            "notes_for_re_audit_if_any": None,
+            "no_go_discipline": {"required": True, "status": "PASS"},
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            raw = root / "raw.json"
+            raw.write_text(json.dumps(blob), encoding="utf-8")
+            job = {
+                "cid": "row",
+                "pass": 1,
+                "stalled": False,
+                "returncode": 0,
+                "raw_output": raw,
+                "row": {
+                    "claim_id": "row",
+                    "note_path": "",
+                    "claim_type": "bounded_theorem",
+                },
+                "evidence_manifest": {},
+                "invocation_id": invocation,
+                "transport_bound": None,
+                "auditor": "test-auditor",
+                "independence": "cross_family",
+                "delivery": root / "delivery.json",
+                "workdir": root,
+                "isolated": root,
+            }
+            with mock.patch.object(
+                batch, "packet_completion_pass", return_value=None
+            ) as completion:
+                envelope, result = batch.finalize_worker(job)
+
+        completion.assert_called_once()
+        self.assertIsNone(envelope)
+        self.assertEqual(result["result"], "validation_failed")
+        self.assertIn("N1_alternative_routes", result["detail"])
+
+    def test_terminal_verdict_cannot_mix_compute_required(self):
+        invocation = "c" * 32
+        blob = {
+            "claim_id": "row",
+            "audit_invocation_id": invocation,
+            "load_bearing_step": "The exact identity follows.",
+            "load_bearing_step_class": "B",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "The exact identity.",
+            "chain_closes": True,
+            "chain_closure_explanation": "The calculation closes.",
+            "verdict": "audited_clean",
+            "verdict_rationale": "The bounded calculation is complete.",
+            "negative_assertion_classes": [],
+            "notes_for_re_audit_if_any": None,
+            "no_go_discipline": None,
+            "compute_required": "run the cached certificate",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            raw = root / "raw.json"
+            raw.write_text(json.dumps(blob), encoding="utf-8")
+            job = {
+                "cid": "row",
+                "pass": 1,
+                "stalled": False,
+                "returncode": 0,
+                "raw_output": raw,
+                "row": {
+                    "claim_id": "row",
+                    "note_path": "",
+                    "claim_type": "bounded_theorem",
+                },
+                "evidence_manifest": {},
+                "invocation_id": invocation,
+                "transport_bound": None,
+                "auditor": "test-auditor",
+                "independence": "cross_family",
+                "delivery": root / "delivery.json",
+                "workdir": root,
+                "isolated": root,
+            }
+            with mock.patch.object(batch, "packet_completion_pass") as completion:
+                envelope, result = batch.finalize_worker(job)
+
+        completion.assert_not_called()
+        self.assertIsNone(envelope)
+        self.assertEqual(result["result"], "validation_failed")
+        self.assertIn("compute_required cannot accompany", result["detail"])
+
     def test_dep_ready_post_verdict_reset_is_persisted_across_batches(self):
         selected = [{"claim_id": "row"}]
         current = {

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -129,6 +129,58 @@ class SchemaRecoveryTest(unittest.TestCase):
         self.assertEqual(records[0]["claim_id"], "row")
         self.assertEqual(records[0]["failures"][0]["detail"], "N8 exact validator error")
 
+    def test_invalid_optional_packet_is_dropped_without_completion(self):
+        invocation = "a" * 32
+        blob = {
+            "claim_id": "row",
+            "audit_invocation_id": invocation,
+            "load_bearing_step": "The bounded implication follows.",
+            "load_bearing_step_class": "B",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "The bounded implication.",
+            "chain_closes": False,
+            "chain_closure_explanation": "A named wall remains.",
+            "verdict": "audited_conditional",
+            "verdict_rationale": "The named wall remains open.",
+            "negative_assertion_classes": ["bounded_with_named_walls"],
+            "notes_for_re_audit_if_any": "scope_too_broad: narrow the claim.",
+            "no_go_discipline": {"required": True, "status": "FAIL"},
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            raw = root / "raw.json"
+            raw.write_text(json.dumps(blob), encoding="utf-8")
+            job = {
+                "cid": "row",
+                "pass": 1,
+                "stalled": False,
+                "returncode": 0,
+                "raw_output": raw,
+                "row": {
+                    "claim_id": "row",
+                    "note_path": "",
+                    "claim_type": "bounded_theorem",
+                },
+                "evidence_manifest": {},
+                "invocation_id": invocation,
+                "transport_bound": None,
+                "auditor": "test-auditor",
+                "independence": "cross_family",
+                "delivery": root / "delivery.json",
+                "workdir": root,
+                "isolated": root,
+            }
+            with mock.patch.object(batch, "packet_completion_pass") as completion:
+                envelope, result = batch.finalize_worker(job)
+
+        completion.assert_not_called()
+        self.assertIsNone(envelope["audit"]["no_go_discipline"])
+        self.assertEqual(
+            envelope["audit"]["negative_assertion_classes"],
+            ["bounded_with_named_walls"],
+        )
+        self.assertIn("optional", result["detail"])
+
     def test_dep_ready_post_verdict_reset_is_persisted_across_batches(self):
         selected = [{"claim_id": "row"}]
         current = {
@@ -427,8 +479,8 @@ class SchemaRecoveryTest(unittest.TestCase):
             return_value=(envelope, {"result": "delivery_validated"}),
         ), mock.patch.object(
             batch,
-            "apply_one_serialized",
-            return_value=(True, {"cid": "row", "result": "audited_failed"}),
+            "apply_claim_serialized",
+            return_value=(True, [{"cid": "row", "result": "audited_failed"}]),
         ):
             ok, _, quarantines, handoffs = batch.apply_serialized([job], [])
 
@@ -464,8 +516,8 @@ class SchemaRecoveryTest(unittest.TestCase):
         with mock.patch.object(batch, "finalize_worker", side_effect=finalize), \
                 mock.patch.object(
                     batch,
-                    "apply_one_serialized",
-                    return_value=(True, {"cid": "row", "result": "audited_clean"}),
+                    "apply_claim_serialized",
+                    return_value=(True, [{"cid": "row", "result": "audited_clean"}]),
                 ):
             ok, _, quarantines, _ = batch.apply_serialized(jobs, report)
 
@@ -504,6 +556,70 @@ class SchemaRecoveryTest(unittest.TestCase):
         self.assertEqual(payload["rows"][0]["claim_id"], "row")
         self.assertTrue(popen.call_args.kwargs["start_new_session"])
         self.assertIn("--retry-failed", popen.call_args.args[0])
+
+    def test_missing_dependency_edge_is_dispatched(self):
+        job = {
+            "cid": "row",
+            "row": {
+                "note_path": "docs/ROW.md",
+                "claim_type": "bounded_theorem",
+                "transitive_descendants": 2,
+            },
+        }
+        envelope = {
+            "audit": {
+                "verdict": "audited_conditional",
+                "claim_type": "bounded_theorem",
+                "claim_scope": "The bounded implication.",
+                "load_bearing_step_class": "B",
+                "notes_for_re_audit_if_any": (
+                    "missing_dependency_edge: cite the retained authority"
+                ),
+                "verdict_rationale": "The cited authority is absent.",
+                "load_bearing_step": "The implication follows from the authority.",
+                "audit_invocation_id": "e" * 32,
+            }
+        }
+
+        handoff = batch.science_fix_handoff(job, envelope)
+
+        self.assertEqual(
+            handoff["category"], "conditional_missing_dependency_edge"
+        )
+
+
+class ClaimTransactionTest(unittest.TestCase):
+    def test_two_seats_share_pipeline_commit_and_push(self):
+        row = {"claim_id": "critical", "criticality": "critical"}
+        deliveries = [
+            (
+                {"cid": "critical", "pass": seat, "row": row},
+                {
+                    "audit": {"verdict": "audited_clean"},
+                    "evidence_manifest": {},
+                },
+            )
+            for seat in (1, 2)
+        ]
+        pushed = mock.Mock(returncode=0, stdout="", stderr="")
+        with mock.patch.object(
+            batch, "sync_origin_main", return_value=(True, "base")
+        ), mock.patch.object(
+            batch.audit_runner, "apply_one", return_value=(True, "applied")
+        ) as apply_one, mock.patch.object(
+            batch, "run_generated_gates", return_value=(True, "gated")
+        ) as gates, mock.patch.object(
+            batch, "stage_and_commit", return_value=(True, "commit")
+        ) as commit, mock.patch.object(batch, "sh", return_value=pushed) as sh:
+            ok, results = batch.apply_claim_serialized(deliveries, retries=3)
+
+        self.assertTrue(ok)
+        self.assertEqual(apply_one.call_count, 2)
+        gates.assert_called_once_with()
+        commit.assert_called_once()
+        self.assertEqual(sh.call_count, 1)
+        self.assertEqual([item["pass"] for item in results], [1, 2])
+        self.assertEqual({item["commit"] for item in results}, {"commit"})
 
 
 class AutomaticPanelResumeTest(unittest.TestCase):

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -890,6 +890,24 @@ class ApplyAuditTest(unittest.TestCase):
         self.fx.write_ledger(ledger)
         return path, note_hash
 
+    def test_apply_rejects_terminal_verdict_mixed_with_compute_required(self):
+        m = _import("apply_audit")
+        audit = {field: "fixture" for field in m.REQUIRED_FIELDS}
+        audit.update({
+            "claim_id": "row",
+            "verdict": "audited_clean",
+            "claim_type": "bounded_theorem",
+            "compute_required": "run the cached certificate",
+        })
+        ledger = {"schema_version": 1, "rows": {}}
+        before = copy.deepcopy(ledger)
+
+        ok, detail = m.apply_one(ledger, audit)
+
+        self.assertFalse(ok)
+        self.assertIn("compute_required cannot accompany", detail)
+        self.assertEqual(ledger, before)
+
     def test_apply_clean_verdict_writes_snapshot_with_runner_hash(self):
         m = _import("apply_audit")
         _patch_repo_root(m, self.tmp_root)
@@ -3957,6 +3975,50 @@ class AuditLintTest(unittest.TestCase):
         self.assertFalse(m.audit_summary_tuples_match(
             first, {**equivalent, "negative_assertion_classes": []}
         ))
+
+        first_decoration = {
+            **first,
+            "verdict": "audited_decoration",
+            "claim_type": "decoration",
+            "decoration_parent_claim_id": "parent-a",
+        }
+        second_decoration = {
+            **first_decoration,
+            "decoration_parent_claim_id": "parent-b",
+        }
+        self.assertFalse(
+            m.audit_summary_tuples_match(first_decoration, second_decoration)
+        )
+
+    def test_tuple_contract_rejects_incompatible_semantics(self):
+        m = _import("audit_lint")
+        base = {
+            "verdict": "audited_clean",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "bounded scope",
+            "load_bearing_step_class": "A",
+            "negative_assertion_classes": [],
+        }
+        self.assertIn(
+            "audited_clean cannot ratify claim_type='meta'",
+            m.audit_summary_tuple_schema_error({**base, "claim_type": "meta"}),
+        )
+        self.assertIn(
+            "audited_decoration requires claim_type='decoration'",
+            m.audit_summary_tuple_schema_error({
+                **base,
+                "verdict": "audited_decoration",
+                "decoration_parent_claim_id": "parent",
+            }),
+        )
+        self.assertIn(
+            "requires decoration_parent_claim_id",
+            m.audit_summary_tuple_schema_error({
+                **base,
+                "verdict": "audited_decoration",
+                "claim_type": "decoration",
+            }),
+        )
 
     def test_lint_rejects_confirmed_scope_mismatch(self):
         m = _import("audit_lint")
@@ -10564,7 +10626,7 @@ class CodexAuditRunnerReauditCandidatesTest(unittest.TestCase):
         )
 
         self.assertEqual(role, "skip")
-        self.assertIn("judicial review needed", reason)
+        self.assertIn("governed five-judge panel required", reason)
 
     def test_load_reaudit_candidates_normalizes_sorts_and_filters_streams(self):
         m = _import_codex_audit_runner()
@@ -11626,6 +11688,37 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             ),
             {"claim_id": "row", "verdict": "audited_failed"},
         )
+        self.assertIn(
+            "compute_required cannot accompany",
+            m.validate_verdict(
+                {
+                    "compute_required": "run the cached certificate",
+                    "claim_id": "row",
+                    "verdict": "audited_clean",
+                },
+                "row",
+            ),
+        )
+
+    def test_prompt_compute_escape_uses_the_closed_json_schema(self):
+        template = (
+            PROJECT_ROOT / "docs" / "audit" / "AUDIT_AGENT_PROMPT_TEMPLATE.md"
+        ).read_text(encoding="utf-8")
+        section = template.split("only non-null value", 1)[1]
+        compute_blob = json.loads(
+            section.split("```json", 1)[1].split("```", 1)[0]
+        )
+        m = _import_codex_audit_runner()
+        schema = m.audit_verdict_output_schema()
+
+        self.assertEqual(set(compute_blob), set(schema["properties"]))
+        self.assertEqual(
+            [key for key, value in compute_blob.items() if value is not None],
+            ["compute_required"],
+        )
+        self.assertNotIn("COMPUTE_REQUIRED:", template)
+        self.assertNotIn("otherwise omit", template)
+        self.assertNotIn("For `PASS`, omit", template)
 
 
 class RelabelUnverifiedCodexAuditsTest(unittest.TestCase):
@@ -11910,6 +12003,41 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
         missing_human_family = dict(human)
         missing_human_family["auditor_family"] = None
         self.assertFalse(m.archived_audit_is_lint_compatible(missing_human_family))
+
+    def test_restore_rejects_incompatible_terminal_tuples(self):
+        m = self._import_and_patch()
+        decoration_as_theorem = self._archived_audit(
+            audit_status="audited_decoration",
+            claim_type="bounded_theorem",
+        )
+        decoration_as_theorem["decoration_parent_claim_id"] = "parent"
+        self.assertFalse(
+            m.archived_audit_is_lint_compatible(decoration_as_theorem)
+        )
+
+        missing_parent = self._archived_audit(
+            audit_status="audited_decoration",
+            claim_type="decoration",
+        )
+        self.assertFalse(m.archived_audit_is_lint_compatible(missing_parent))
+
+        valid_decoration = dict(missing_parent)
+        valid_decoration["decoration_parent_claim_id"] = "parent"
+        self.assertTrue(m.archived_audit_is_lint_compatible(valid_decoration))
+
+        clean_meta = self._archived_audit(claim_type="meta")
+        self.assertFalse(m.archived_audit_is_lint_compatible(clean_meta))
+
+        nested = self._archived_audit(audit_status="audited_conditional")
+        nested["notes_for_re_audit_if_any"] = "other: named repair"
+        nested["cross_confirmation"] = {
+            "first_audit": {
+                "verdict": "audited_decoration",
+                "claim_type": "bounded_theorem",
+                "decoration_parent_claim_id": "parent",
+            }
+        }
+        self.assertFalse(m.archived_audit_is_lint_compatible(nested))
 
     def test_restore_round_trips_and_validates_no_go_packet(self):
         m = self._import_and_patch()
@@ -13698,6 +13826,20 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
             m.vote_tuple(base),
             m.vote_tuple(self._vote(ratified_verdict="audited_conditional")),
         )
+        decoration_a = self._vote(
+            sided_with="hybrid",
+            ratified_verdict="audited_decoration",
+            ratified_claim_type="decoration",
+            ratified_decoration_parent_claim_id="parent-a",
+            hybrid_resolution_note="retain this as decoration",
+        )
+        decoration_b = {
+            **decoration_a,
+            "ratified_decoration_parent_claim_id": "parent-b",
+        }
+        self.assertNotEqual(
+            m.vote_tuple(decoration_a), m.vote_tuple(decoration_b)
+        )
 
     def test_sided_blob_reuses_seat_scope_and_applies(self):
         m = _import("orchestrate_judicial_panel")
@@ -13867,6 +14009,69 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
             m.sided_vote_context_error(row, whitespace_equivalent)
         )
 
+        decoration_row = self._row("decoration-row")
+        decoration_row["cross_confirmation"]["first_audit"].update({
+            "verdict": "audited_decoration",
+            "claim_type": "decoration",
+            "decoration_parent_claim_id": "parent-a",
+        })
+        parent_mismatch = self._vote(
+            ratified_verdict="audited_decoration",
+            ratified_claim_type="decoration",
+            ratified_decoration_parent_claim_id="parent-b",
+        )
+        self.assertIn(
+            "decoration_parent_claim_id",
+            m.sided_vote_context_error(decoration_row, parent_mismatch),
+        )
+
+    def test_judicial_apply_cannot_change_selected_decoration_parent(self):
+        panel = _import("orchestrate_judicial_panel")
+        apply_mod = _import("apply_audit")
+        row = self._row("decoration-apply-row")
+        row["cross_confirmation"]["first_audit"].update({
+            "verdict": "audited_decoration",
+            "claim_type": "decoration",
+            "decoration_parent_claim_id": "parent-a",
+        })
+        vote = self._vote(
+            ratified_verdict="audited_decoration",
+            ratified_claim_type="decoration",
+            ratified_decoration_parent_claim_id="parent-a",
+        )
+        blob = panel.judicial_blob(
+            row, vote, [vote] * 5, 5, invocation_id="8" * 32
+        )
+        blob["ratified_decoration_parent_claim_id"] = "parent-b"
+        ledger = {"schema_version": 1, "rows": {row["claim_id"]: row}}
+        before = copy.deepcopy(ledger)
+
+        ok, detail = apply_mod.apply_judicial_review(ledger, blob)
+
+        self.assertFalse(ok)
+        self.assertIn("does not match the ratified first_audit parent", detail)
+        self.assertEqual(ledger, before)
+
+    def test_invalid_stored_seat_is_reseated_before_panel_launch(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row("invalid-seat")
+        row["cross_confirmation"]["first_audit"].update({
+            "verdict": "audited_decoration",
+            "claim_type": "bounded_theorem",
+            "decoration_parent_claim_id": "parent",
+        })
+
+        targets, reseat = m.collect_panel_targets(
+            ["invalid-seat"], {"invalid-seat": row}
+        )
+
+        self.assertEqual(targets, [])
+        self.assertEqual(reseat, ["invalid-seat"])
+        self.assertIn(
+            "audited_decoration requires claim_type='decoration'",
+            m.seat_context_error(row),
+        )
+
     def test_rationale_is_invocation_bound_and_preserved_in_new_summaries(self):
         m = _import("orchestrate_judicial_panel")
         row = self._row()
@@ -14013,6 +14218,98 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
             next(self.tmp.glob("panel-*-round1.json")).read_text(encoding="utf-8")
         )
         self.assertEqual(len(record["votes"]), 4)
+
+    def test_contract_invalid_vote_runs_fresh_full_panel(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row()
+        launches = []
+
+        def fake_launch(
+            _packet, _row, judge_no, panel_no, _workdir, prior,
+            _invocation_id, _manifest,
+        ):
+            launches.append((panel_no, judge_no, len(prior)))
+            return {
+                "judge": judge_no,
+                "panel": panel_no,
+                "auditor": f"round-{panel_no}-judge-{judge_no}",
+            }
+
+        def fake_collect(job):
+            if job["panel"] == 1 and job["judge"] == 5:
+                return None, (
+                    f"{m.VOTE_CONTRACT_ERROR_PREFIX}"
+                    "audited_decoration requires claim_type='decoration'"
+                )
+            return self._vote(), "ok"
+
+        with mock.patch.object(
+            m, "render_panel_packet", return_value=("packet", {}, "2" * 32)
+        ), mock.patch.object(
+            m, "launch_judge", side_effect=fake_launch
+        ), mock.patch.object(
+            m.batch, "wait_workers", return_value=None
+        ), mock.patch.object(
+            m, "collect_vote", side_effect=fake_collect
+        ), mock.patch.object(
+            m, "judicial_applyability_error", return_value=None
+        ), mock.patch.object(
+            m,
+            "apply_judgment",
+            return_value=(
+                True,
+                {"cid": "row", "result": "audited_clean", "commit": "abc"},
+            ),
+        ):
+            result = m.run_panel(row, {"row": row}, self.tmp, 1, 1, 1, [])
+
+        self.assertEqual(result["result"], "audited_clean")
+        self.assertEqual(len(launches), 10)
+        self.assertTrue(
+            all(prior == 1 for panel, _judge, prior in launches if panel == 2)
+        )
+        first_record = json.loads(
+            next(self.tmp.glob("panel-*-round1.json")).read_text(encoding="utf-8")
+        )
+        self.assertEqual(first_record["result"], "contract_invalid_retry")
+        self.assertEqual(len(first_record["votes"]), 4)
+        self.assertIn(m.VOTE_CONTRACT_ERROR_PREFIX, first_record["failures"][0])
+
+    def test_contract_invalid_vote_retries_are_bounded(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row()
+        launches = []
+
+        def fake_launch(
+            _packet, _row, judge_no, panel_no, _workdir, _prior,
+            _invocation_id, _manifest,
+        ):
+            launches.append((panel_no, judge_no))
+            return {
+                "judge": judge_no,
+                "panel": panel_no,
+                "auditor": f"round-{panel_no}-judge-{judge_no}",
+            }
+
+        def fake_collect(job):
+            if job["judge"] == 5:
+                return None, f"{m.VOTE_CONTRACT_ERROR_PREFIX}invalid tuple"
+            return self._vote(), "ok"
+
+        with mock.patch.object(
+            m, "render_panel_packet", return_value=("packet", {}, "3" * 32)
+        ), mock.patch.object(
+            m, "launch_judge", side_effect=fake_launch
+        ), mock.patch.object(
+            m.batch, "wait_workers", return_value=None
+        ), mock.patch.object(
+            m, "collect_vote", side_effect=fake_collect
+        ), mock.patch.object(m, "apply_judgment") as apply_mock:
+            result = m.run_panel(row, {"row": row}, self.tmp, 1, 1, 1, [])
+
+        self.assertEqual(result["result"], "panel_contract_retries_exhausted")
+        self.assertEqual(len(launches), 15)
+        apply_mock.assert_not_called()
 
     def test_neither_majority_runs_fresh_panel_without_building_blob(self):
         m = _import("orchestrate_judicial_panel")

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -8144,6 +8144,36 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             ) or "",
         )
 
+    def test_runner_rejects_semantically_incompatible_verdict_type_tuple(self):
+        m = _import_codex_audit_runner()
+        base = {
+            field: "test value" for field in m.REQUIRED_VERDICT_FIELDS
+        }
+        base.update({
+            "claim_id": "target",
+            "claim_type": "bounded_theorem",
+            "verdict": "audited_decoration",
+            "negative_assertion_classes": [],
+            "no_go_discipline": None,
+            "decoration_parent_claim_id": "parent",
+        })
+        self.assertEqual(
+            m.validate_verdict(base, "target"),
+            "audited_decoration requires claim_type='decoration'",
+        )
+
+        base.update({
+            "claim_type": "decoration",
+            "verdict": "audited_clean",
+        })
+        self.assertEqual(
+            m.validate_verdict(base, "target"),
+            "audited_clean cannot ratify claim_type='decoration'",
+        )
+
+        base["verdict"] = "audited_decoration"
+        self.assertIsNone(m.validate_verdict(base, "target"))
+
     def test_validation_repair_prompt_reuses_packet_and_preserves_strict_gate(self):
         m = _import_codex_audit_runner()
         original_prompt = "restricted packet with EXACT EVIDENCE LOCATOR"
@@ -13759,6 +13789,65 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
         self.assertIsNone(vote)
         self.assertIn("must explain the second auditor's error", status)
 
+    def test_panel_rejects_semantically_incompatible_votes(self):
+        m = _import("orchestrate_judicial_panel")
+        decoration_as_theorem = self._vote(
+            ratified_verdict="audited_decoration",
+            ratified_claim_type="bounded_theorem",
+            ratified_decoration_parent_claim_id="parent",
+        )
+        self.assertIn(
+            "audited_decoration requires claim_type='decoration'",
+            m.vote_schema_error(decoration_as_theorem) or "",
+        )
+
+        clean_decoration = self._vote(
+            ratified_verdict="audited_clean",
+            ratified_claim_type="decoration",
+            ratified_decoration_parent_claim_id="parent",
+        )
+        self.assertIn(
+            "audited_clean cannot ratify claim_type='decoration'",
+            m.vote_schema_error(clean_decoration) or "",
+        )
+
+        valid_decoration = self._vote(
+            ratified_verdict="audited_decoration",
+            ratified_claim_type="decoration",
+            ratified_decoration_parent_claim_id="parent",
+        )
+        self.assertIsNone(m.vote_schema_error(valid_decoration))
+
+    def test_judicial_apply_rejects_incompatible_tuple_defense_in_depth(self):
+        panel = _import("orchestrate_judicial_panel")
+        apply_mod = _import("apply_audit")
+        row = self._row("incompatible-judicial")
+        vote = self._vote(
+            sided_with="hybrid",
+            hybrid_resolution_note="combine the sound bounded pieces",
+            first_auditor_error="first scope is too broad",
+            second_auditor_error="second scope is too narrow",
+        )
+        blob = panel.judicial_blob(
+            row, vote, [vote] * 5, 5, invocation_id="7" * 32
+        )
+        blob.update({
+            "ratified_verdict": "audited_decoration",
+            "ratified_claim_type": "bounded_theorem",
+            "ratified_decoration_parent_claim_id": "parent",
+        })
+        ledger = {
+            "schema_version": 1,
+            "rows": {"incompatible-judicial": row},
+        }
+        before = copy.deepcopy(ledger)
+        ok, detail = apply_mod.apply_judicial_review(ledger, blob)
+        self.assertFalse(ok)
+        self.assertIn(
+            "audited_decoration requires claim_type='decoration'", detail
+        )
+        self.assertEqual(ledger, before)
+
     def test_sided_vote_must_match_selected_seat_before_blob(self):
         m = _import("orchestrate_judicial_panel")
         row = self._row()
@@ -14569,6 +14658,77 @@ class BatchOrchestratorSeatBankingTest(unittest.TestCase):
                     if verdict == "audited_conditional"
                     else "non_terminal_failed",
                 )
+
+    def test_incompatible_tuple_is_quarantined_before_apply(self):
+        m = _import("orchestrate_audit_batch")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            row = {
+                "claim_id": "incompatible",
+                "claim_type": "bounded_theorem",
+                "criticality": "critical",
+                "audit_status": "unaudited",
+                "effective_status": "unaudited",
+                "cross_confirmation": None,
+                "deps": [],
+                "note_path": "",
+            }
+            jobs = []
+            for pass_no, invocation_id in ((1, "a" * 32), (2, "b" * 32)):
+                raw = root / f"raw-{pass_no}.txt"
+                raw.write_text(
+                    json.dumps({
+                        "claim_id": "incompatible",
+                        "audit_invocation_id": invocation_id,
+                        "load_bearing_step": "an exact bounded identity",
+                        "load_bearing_step_class": "A",
+                        "claim_type": "bounded_theorem",
+                        "claim_scope": "the bounded identity",
+                        "chain_closes": True,
+                        "chain_closure_explanation": "the identity closes",
+                        "verdict": "audited_decoration",
+                        "verdict_rationale": "algebraic reduction",
+                        "negative_assertion_classes": [],
+                        "decoration_parent_claim_id": "parent",
+                        "no_go_discipline": None,
+                    }),
+                    encoding="utf-8",
+                )
+                jobs.append({
+                    "cid": "incompatible",
+                    "pass": pass_no,
+                    "row": row,
+                    "stalled": False,
+                    "returncode": 0,
+                    "raw_output": raw,
+                    "invocation_id": invocation_id,
+                    "transport_bound": None,
+                    "evidence_manifest": {},
+                    "delivery": root / f"delivery-{pass_no}.json",
+                    "workdir": root,
+                })
+
+            report = []
+            with mock.patch.object(m, "apply_claim_serialized") as apply_mock:
+                ok, _, _, _ = m.apply_serialized(jobs, report)
+
+        self.assertTrue(ok)
+        apply_mock.assert_not_called()
+        self.assertEqual(
+            sum(item["result"] == "validation_failed" for item in report),
+            2,
+        )
+        self.assertTrue(all(
+            "audited_decoration requires claim_type='decoration'"
+            in item.get("detail", "")
+            for item in report
+            if item["result"] == "validation_failed"
+        ))
+        self.assertIn(
+            "schema_invalid_quarantined",
+            {item["result"] for item in report},
+        )
+        self.assertFalse(m.report_has_hard_blocker(report))
 
 class N5AdministrativeNegationExclusionTest(unittest.TestCase):
     """N5 administrative calibration fails safe on mixed evidence."""

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -890,6 +890,75 @@ class ApplyAuditTest(unittest.TestCase):
         self.fx.write_ledger(ledger)
         return path, note_hash
 
+    def _attest_judgment(self, module, ledger: dict, judgment: dict) -> dict:
+        """Attach a deterministic five-vote panel record for apply tests."""
+        cid = judgment["claim_id"]
+        invocation_id = judgment.setdefault(
+            "audit_invocation_id",
+            hashlib.sha256(cid.encode("utf-8")).hexdigest()[:32],
+        )
+        judgment.setdefault("negative_assertion_classes", [])
+        vote = {
+            "sided_with": judgment["sided_with"],
+            "ratified_verdict": judgment["ratified_verdict"],
+            "ratified_claim_type": judgment["ratified_claim_type"],
+            "ratified_claim_scope": judgment["ratified_claim_scope"],
+            "ratified_load_bearing_step": judgment.get(
+                "ratified_load_bearing_step"
+            ),
+            "ratified_load_bearing_step_class": judgment[
+                "ratified_load_bearing_step_class"
+            ],
+            "negative_assertion_classes": judgment[
+                "negative_assertion_classes"
+            ],
+            "judgment_rationale": judgment["judgment_rationale"],
+            "first_auditor_error": judgment["first_auditor_error"],
+            "second_auditor_error": judgment["second_auditor_error"],
+            "hybrid_resolution_note": judgment.get("hybrid_resolution_note"),
+            "ratified_decoration_parent_claim_id": judgment.get(
+                "ratified_decoration_parent_claim_id"
+            ),
+            "notes_for_re_audit_if_any": judgment.get(
+                "notes_for_re_audit_if_any"
+            ),
+            "no_go_discipline": judgment.get("no_go_discipline"),
+        }
+        votes = []
+        for judge in range(1, 6):
+            votes.append({
+                **copy.deepcopy(vote),
+                "judge": judge,
+                "auditor": (
+                    judgment["third_auditor"]
+                    if judge == 1
+                    else f"{judgment['third_auditor']}-seat-{judge}"
+                ),
+            })
+        judgment["judicial_panel_record_v1"] = {
+            "schema": "judicial_panel_record_v1",
+            "cid": cid,
+            "panel": 1,
+            "invocation_id": invocation_id,
+            "result": "majority_candidate",
+            "disagreement_fingerprint": (
+                module.audit_contract.judicial_disagreement_fingerprint(
+                    ledger["rows"][cid]
+                )
+            ),
+            "majority_count": 5,
+            "votes": votes,
+            "failures": [],
+            "tally": [{
+                "tuple": [
+                    *module.audit_contract.judicial_vote_tuple(votes[0])[:6],
+                    list(module.audit_contract.judicial_vote_tuple(votes[0])[6]),
+                ],
+                "count": 5,
+            }],
+        }
+        return judgment
+
     def test_apply_rejects_terminal_verdict_mixed_with_compute_required(self):
         m = _import("apply_audit")
         audit = {field: "fixture" for field in m.REQUIRED_FIELDS}
@@ -1711,6 +1780,7 @@ class ApplyAuditTest(unittest.TestCase):
             "hybrid_resolution_note": "ratify the bounded tuple",
             "no_go_discipline": {"status": "PASS"},
         }
+        self._attest_judgment(m, led, judgment)
         forensic_led = json.loads(json.dumps(led))
         packetless_led = json.loads(json.dumps(led))
         with mock.patch.object(
@@ -2251,11 +2321,16 @@ class ApplyAuditTest(unittest.TestCase):
             "ratified_load_bearing_step_class": "C",
             "ratified_claim_scope": "bounded clean scope",
             "ratified_load_bearing_step": "bounded clean step",
-            "judgment_rationale": "human-authorized panel selected a third applyable tuple",
+            "judgment_rationale": "governed panel selected a third applyable tuple",
             "first_auditor_error": "overstated claim type",
             "second_auditor_error": "understated load-bearing class",
-            "hybrid_resolution_note": "human-authorized second-stage panel",
+            "hybrid_resolution_note": "governed second-stage panel",
         }
+        unpanelled = json.loads(json.dumps(led))
+        ok, msg = m.apply_one(unpanelled, dict(audit))
+        self.assertFalse(ok)
+        self.assertIn("judicial_panel_record_v1 is required", msg)
+        self._attest_judgment(m, led, audit)
         legacy_led = json.loads(json.dumps(led))
         legacy_led["rows"]["test_hybrid"]["cross_confirmation"][
             "first_audit"
@@ -2380,6 +2455,7 @@ class ApplyAuditTest(unittest.TestCase):
             "first_auditor_error": "none on the scoped result",
             "second_auditor_error": "treated a supplied authority as absent",
         }
+        self._attest_judgment(m, led, judgment)
 
         before_rejected = json.dumps(led, sort_keys=True)
         ok, msg = m.apply_one(led, dict(judgment))
@@ -2412,6 +2488,7 @@ class ApplyAuditTest(unittest.TestCase):
         led["rows"]["test_judicial_no_go"]["cross_confirmation"]["first_audit"][
             "no_go_discipline"
         ] = prior_packet
+        self._attest_judgment(m, led, judgment)
         with mock.patch.object(m, "trusted_evidence_manifest", return_value=manifest):
             ok, msg = m.apply_one(led, judgment)
         self.assertTrue(ok, msg)
@@ -13870,6 +13947,57 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
         )
         self.assertTrue(ok, detail)
 
+    def test_panel_attestation_rejects_quorum_identity_and_seat_tampering(self):
+        m = _import("orchestrate_judicial_panel")
+        apply_mod = _import("apply_audit")
+        row = self._row("attested-row")
+        votes = [
+            self._vote(
+                _panel_judge=index,
+                _panel_auditor=f"judge-{index}",
+            )
+            for index in range(1, 6)
+        ]
+        blob = m.judicial_blob(
+            row, votes[0], votes, 5, invocation_id="d" * 32
+        )
+
+        single_vote = copy.deepcopy(blob)
+        single_vote["judicial_panel_record_v1"]["votes"] = single_vote[
+            "judicial_panel_record_v1"
+        ]["votes"][:1]
+        ledger = {"schema_version": 1, "rows": {row["claim_id"]: row}}
+        ok, detail = apply_mod.apply_judicial_review(ledger, single_vote)
+        self.assertFalse(ok)
+        self.assertIn("exactly five votes", detail)
+
+        duplicate_identity = copy.deepcopy(blob)
+        panel_votes = duplicate_identity["judicial_panel_record_v1"]["votes"]
+        panel_votes[4]["auditor"] = panel_votes[0]["auditor"]
+        ledger = {"schema_version": 1, "rows": {row["claim_id"]: row}}
+        ok, detail = apply_mod.apply_judicial_review(ledger, duplicate_identity)
+        self.assertFalse(ok)
+        self.assertIn("five distinct identities", detail)
+
+        boolean_seat = copy.deepcopy(blob)
+        boolean_seat["judicial_panel_record_v1"]["votes"][0]["judge"] = True
+        ledger = {"schema_version": 1, "rows": {row["claim_id"]: row}}
+        ok, detail = apply_mod.apply_judicial_review(ledger, boolean_seat)
+        self.assertFalse(ok)
+        self.assertIn("invalid judge seat", detail)
+
+        stale_seat = copy.deepcopy(row)
+        stale_seat["cross_confirmation"]["second_audit"][
+            "verdict_rationale"
+        ] = "changed after the panel rendered"
+        ledger = {
+            "schema_version": 1,
+            "rows": {stale_seat["claim_id"]: stale_seat},
+        }
+        ok, detail = apply_mod.apply_judicial_review(ledger, copy.deepcopy(blob))
+        self.assertFalse(ok)
+        self.assertIn("current source and cross-confirmation seats", detail)
+
     def test_hybrid_blob_with_novel_scope_applies(self):
         m = _import("orchestrate_judicial_panel")
         apply_mod = _import("apply_audit")
@@ -14051,6 +14179,25 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn("does not match the ratified first_audit parent", detail)
         self.assertEqual(ledger, before)
+
+    def test_judicial_apply_rejects_compute_required_discriminator(self):
+        panel = _import("orchestrate_judicial_panel")
+        apply_mod = _import("apply_audit")
+        row = self._row("judicial-compute-row")
+        vote = self._vote()
+        blob = panel.judicial_blob(
+            row, vote, [vote] * 5, 5, invocation_id="9" * 32
+        )
+        blob["compute_required"] = "run the missing independent certificate"
+
+        for entrypoint in (apply_mod.apply_one, apply_mod.apply_judicial_review):
+            ledger = {"schema_version": 1, "rows": {row["claim_id"]: row}}
+            before = copy.deepcopy(ledger)
+            with self.subTest(entrypoint=entrypoint.__name__):
+                ok, detail = entrypoint(ledger, blob)
+                self.assertFalse(ok)
+                self.assertIn("compute_required cannot accompany", detail)
+                self.assertEqual(ledger, before)
 
     def test_invalid_stored_seat_is_reseated_before_panel_launch(self):
         m = _import("orchestrate_judicial_panel")
@@ -14474,6 +14621,122 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
         self.assertIn("duplicates claim-a panel 1", error)
         self.assertIsNotNone(m.workdir_guard_error(m.REPO_ROOT / ".git" / "panel"))
         self.assertIsNone(m.workdir_guard_error(self.tmp / "panel"))
+
+    def test_contract_retry_history_requires_all_five_judge_outcomes(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row("contract-history")
+        votes = [
+            {"judge": judge, "auditor": f"judge-{judge}", **self._vote()}
+            for judge in range(1, 5)
+        ]
+
+        def record(panel=1):
+            return {
+                "schema": "judicial_panel_record_v1",
+                "cid": "contract-history",
+                "panel": panel,
+                "invocation_id": f"{panel}" * 32,
+                "result": "contract_invalid_retry",
+                "disagreement_fingerprint": m.disagreement_fingerprint(row),
+                "votes": copy.deepcopy(votes),
+                "failures": [
+                    "judge5:vote_contract_error:invalid verdict/type tuple"
+                ],
+            }
+
+        valid_path = self.tmp / "valid-contract-retry.json"
+        valid_path.write_text(json.dumps(record()), encoding="utf-8")
+        grouped, error = m.load_prior_panels(
+            [str(valid_path)], {"contract-history": row}
+        )
+        self.assertIsNone(error)
+        self.assertEqual(grouped["contract-history"][0]["panel"], 1)
+
+        invalid_records = {
+            "truncated": {
+                **record(),
+                "votes": [],
+            },
+            "missing-seat": {
+                **record(),
+                "votes": copy.deepcopy(votes[:3]),
+            },
+            "overlap": {
+                **record(),
+                "failures": [
+                    "judge4:vote_contract_error:duplicate judge outcome"
+                ],
+            },
+            "malformed": {
+                **record(),
+                "failures": ["judgeX:vote_contract_error:invalid judge"],
+            },
+        }
+        for label, invalid in invalid_records.items():
+            with self.subTest(label=label):
+                path = self.tmp / f"invalid-{label}.json"
+                path.write_text(json.dumps(invalid), encoding="utf-8")
+                _grouped, error = m.load_prior_panels(
+                    [str(path)], {"contract-history": row}
+                )
+                self.assertIn("invalid contract-retry record", error)
+
+    def test_resumed_contract_retry_budget_counts_only_complete_history(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row()
+        prior = []
+        for panel_no in (1, 2):
+            prior.append({
+                "schema": "judicial_panel_record_v1",
+                "cid": "row",
+                "panel": panel_no,
+                "invocation_id": f"{panel_no}" * 32,
+                "result": "contract_invalid_retry",
+                "disagreement_fingerprint": m.disagreement_fingerprint(row),
+                "votes": [
+                    {
+                        "judge": judge,
+                        "auditor": f"round-{panel_no}-judge-{judge}",
+                        **self._vote(),
+                    }
+                    for judge in range(1, 5)
+                ],
+                "failures": [
+                    "judge5:vote_contract_error:invalid verdict/type tuple"
+                ],
+            })
+        launches = []
+
+        def fake_launch(
+            _packet, _row, judge_no, panel_no, _workdir, _prior,
+            _invocation_id, _manifest,
+        ):
+            launches.append((panel_no, judge_no))
+            return {
+                "judge": judge_no,
+                "panel": panel_no,
+                "auditor": f"round-{panel_no}-judge-{judge_no}",
+            }
+
+        def fake_collect(job):
+            if job["judge"] == 5:
+                return None, f"{m.VOTE_CONTRACT_ERROR_PREFIX}invalid tuple"
+            return self._vote(), "ok"
+
+        with mock.patch.object(
+            m, "render_panel_packet", return_value=("packet", {}, "4" * 32)
+        ), mock.patch.object(
+            m, "launch_judge", side_effect=fake_launch
+        ), mock.patch.object(
+            m.batch, "wait_workers", return_value=None
+        ), mock.patch.object(
+            m, "collect_vote", side_effect=fake_collect
+        ), mock.patch.object(m, "apply_judgment") as apply_mock:
+            result = m.run_panel(row, {"row": row}, self.tmp, 1, 1, 1, prior)
+
+        self.assertEqual(result["result"], "panel_contract_retries_exhausted")
+        self.assertEqual(launches, [(3, judge) for judge in range(1, 6)])
+        apply_mock.assert_not_called()
 
     def test_ordinary_auditor_cannot_resolve_a_disagreement(self):
         apply_mod = _import("apply_audit")

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -13998,6 +13998,26 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn("current source and cross-confirmation seats", detail)
 
+        unknown_minority_classes = copy.deepcopy(blob)
+        panel_votes = unknown_minority_classes["judicial_panel_record_v1"][
+            "votes"
+        ]
+        for vote in panel_votes[3:]:
+            vote.update({
+                "sided_with": "hybrid",
+                "ratified_claim_scope": "a minority corrected identity",
+                "negative_assertion_classes": ["invented_negative_class"],
+                "first_auditor_error": "first scope is too broad",
+                "second_auditor_error": "second scope is too narrow",
+                "hybrid_resolution_note": "combine the bounded pieces",
+            })
+        ledger = {"schema_version": 1, "rows": {row["claim_id"]: row}}
+        ok, detail = apply_mod.apply_judicial_review(
+            ledger, unknown_minority_classes
+        )
+        self.assertFalse(ok)
+        self.assertIn("unknown classes", detail)
+
     def test_hybrid_blob_with_novel_scope_applies(self):
         m = _import("orchestrate_judicial_panel")
         apply_mod = _import("apply_audit")
@@ -14058,6 +14078,36 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
         vote, status = m.collect_vote(job)
         self.assertIsNone(vote)
         self.assertIn("must explain the second auditor's error", status)
+
+        hybrid_without_note = self._vote(
+            sided_with="hybrid",
+            first_auditor_error="first scope is too broad",
+            second_auditor_error="second scope is too narrow",
+        )
+        raw.write_text(
+            json.dumps(hybrid_without_note) + " " * 200, encoding="utf-8"
+        )
+        vote, status = m.collect_vote(job)
+        self.assertIsNone(vote)
+        self.assertIn("non-empty hybrid_resolution_note", status)
+        with self.assertRaisesRegex(ValueError, "hybrid_resolution_note"):
+            m.judicial_blob(
+                self._row(),
+                hybrid_without_note,
+                [hybrid_without_note] * 5,
+                5,
+            )
+
+        unknown_negative_class = self._vote(
+            negative_assertion_classes=["invented_negative_class"]
+        )
+        raw.write_text(
+            json.dumps(unknown_negative_class) + " " * 200,
+            encoding="utf-8",
+        )
+        vote, status = m.collect_vote(job)
+        self.assertIsNone(vote)
+        self.assertIn("unknown classes", status)
 
     def test_panel_rejects_semantically_incompatible_votes(self):
         m = _import("orchestrate_judicial_panel")
@@ -14597,12 +14647,36 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
             "result": "no_majority",
             "disagreement_fingerprint": m.disagreement_fingerprint(row),
             "votes": votes,
+            "failures": [],
+            "tally": m.serialized_tally(votes),
+            "untrusted_extra": "must not reach the next panel",
         }
         path = self.tmp / "prior.json"
         path.write_text(json.dumps(record), encoding="utf-8")
         grouped, error = m.load_prior_panels([str(path)], {"claim-a": row})
         self.assertIsNone(error)
         self.assertEqual(grouped["claim-a"][0]["cid"], "claim-a")
+        self.assertNotIn("untrusted_extra", grouped["claim-a"][0])
+
+        forged_tally = {**record, "tally": []}
+        forged_tally_path = self.tmp / "forged-tally.json"
+        forged_tally_path.write_text(
+            json.dumps(forged_tally), encoding="utf-8"
+        )
+        _grouped, error = m.load_prior_panels(
+            [str(forged_tally_path)], {"claim-a": row}
+        )
+        self.assertIn("inconsistent tally metadata", error)
+
+        forged_failures = {**record, "failures": ["fabricated failure"]}
+        forged_failures_path = self.tmp / "forged-failures.json"
+        forged_failures_path.write_text(
+            json.dumps(forged_failures), encoding="utf-8"
+        )
+        _grouped, error = m.load_prior_panels(
+            [str(forged_failures_path)], {"claim-a": row}
+        )
+        self.assertIn("inconsistent failure metadata", error)
         _grouped, error = m.load_prior_panels(
             [str(path)], {"claim-b": self._row("claim-b")}
         )
@@ -14642,6 +14716,7 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
                 "failures": [
                     "judge5:vote_contract_error:invalid verdict/type tuple"
                 ],
+                "tally": m.serialized_tally(votes),
             }
 
         valid_path = self.tmp / "valid-contract-retry.json"
@@ -14681,6 +14756,66 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
                 )
                 self.assertIn("invalid contract-retry record", error)
 
+    def test_prior_panel_result_metadata_is_validated(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row("result-metadata")
+        votes = [
+            {
+                "judge": judge,
+                "auditor": f"judge-{judge}",
+                **(
+                    self._vote()
+                    if judge <= 3
+                    else self._vote(
+                        sided_with="second",
+                        ratified_verdict="audited_conditional",
+                        ratified_claim_scope="a conditional identity",
+                        first_auditor_error="missed the condition",
+                        second_auditor_error="none",
+                        notes_for_re_audit_if_any=(
+                            "other: check the stated condition"
+                        ),
+                    )
+                ),
+            }
+            for judge in range(1, 6)
+        ]
+        record = {
+            "schema": "judicial_panel_record_v1",
+            "cid": row["claim_id"],
+            "panel": 1,
+            "invocation_id": "9" * 32,
+            "result": "majority_unapplyable",
+            "disagreement_fingerprint": m.disagreement_fingerprint(row),
+            "votes": votes,
+            "failures": [],
+            "tally": m.serialized_tally(votes),
+            "apply_errors": [
+                {
+                    "judge": judge,
+                    "auditor": f"judge-{judge}",
+                    "error": "candidate failed a bounded apply check",
+                }
+                for judge in range(1, 4)
+            ],
+        }
+        valid_path = self.tmp / "valid-unapplyable.json"
+        valid_path.write_text(json.dumps(record), encoding="utf-8")
+        grouped, error = m.load_prior_panels(
+            [str(valid_path)], {row["claim_id"]: row}
+        )
+        self.assertIsNone(error)
+        self.assertEqual(len(grouped[row["claim_id"]][0]["apply_errors"]), 3)
+
+        forged = copy.deepcopy(record)
+        forged["apply_errors"][0]["judge"] = 5
+        forged_path = self.tmp / "forged-unapplyable.json"
+        forged_path.write_text(json.dumps(forged), encoding="utf-8")
+        _grouped, error = m.load_prior_panels(
+            [str(forged_path)], {row["claim_id"]: row}
+        )
+        self.assertIn("invalid apply-error metadata", error)
+
     def test_resumed_contract_retry_budget_counts_only_complete_history(self):
         m = _import("orchestrate_judicial_panel")
         row = self._row()
@@ -14704,6 +14839,14 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
                 "failures": [
                     "judge5:vote_contract_error:invalid verdict/type tuple"
                 ],
+                "tally": m.serialized_tally([
+                    {
+                        "judge": judge,
+                        "auditor": f"round-{panel_no}-judge-{judge}",
+                        **self._vote(),
+                    }
+                    for judge in range(1, 5)
+                ]),
             })
         launches = []
 

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -9504,7 +9504,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 "no_go_discipline_packet_missing",
             )
 
-    def test_packetless_declared_negative_conditional_is_invalidated(self):
+    def test_packetless_declared_negative_conditional_remains_repair_queue(self):
         m = _import("invalidate_stale_audits")
         row = {
             "claim_id": "declared_negative_conditional",
@@ -9513,10 +9513,15 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             "claim_type": "bounded_theorem",
             "negative_assertion_classes": ["bounded_with_named_walls"],
         }
-        self.assertEqual(
-            m.detect_invalidation(row, {"declared_negative_conditional": row}),
-            "no_go_discipline_packet_missing",
-        )
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": ""}):
+            self.assertIsNone(
+                m.detect_invalidation(row, {"declared_negative_conditional": row})
+            )
+        with mock.patch.dict(os.environ, {"AUDIT_FORENSIC_MODE": "1"}):
+            self.assertEqual(
+                m.detect_invalidation(row, {"declared_negative_conditional": row}),
+                "no_go_discipline_packet_missing",
+            )
 
     def test_live_packet_invalid_under_current_policy_is_invalidated(self):
         m = _import("invalidate_stale_audits")
@@ -9975,7 +9980,7 @@ class BatchOrchestratorRoundSemanticsTest(unittest.TestCase):
             m.audit_runner, "PROMPT_TEMPLATE_PATH"
         ) as template_path, mock.patch.object(
             m.subprocess, "Popen", return_value=proc
-        ):
+        ) as popen:
             template_path.read_text.return_value = "template"
             first = m.launch_worker(
                 rows["spin_row"], rows, 1, workdir, 120, 1
@@ -9988,6 +9993,13 @@ class BatchOrchestratorRoundSemanticsTest(unittest.TestCase):
         self.assertNotEqual(first["isolated"], second["isolated"])
         self.assertIn("-r1-p1", str(first["isolated"]))
         self.assertIn("-r2-p1", str(second["isolated"]))
+        command = popen.call_args_list[0].args[0]
+        self.assertIn("--output-schema", command)
+        schema_path = Path(command[command.index("--output-schema") + 1])
+        schema = json.loads(schema_path.read_text())
+        self.assertEqual(schema["type"], "object")
+        self.assertFalse(schema["additionalProperties"])
+        self.assertIn("compute_required", schema["required"])
 
     def test_conditional_rows_wait_for_repair_across_runs(self):
         """A re-queued audited_conditional row is not re-targeted until its
@@ -10229,6 +10241,32 @@ class CodexAuditRunnerModelPolicyTest(unittest.TestCase):
             "priority": priority,
             "supported_reasoning_levels": levels,
         }
+
+    def test_codex_output_schemas_close_every_object(self):
+        m = _import_codex_audit_runner()
+
+        def assert_closed(schema):
+            if not isinstance(schema, dict):
+                return
+            if schema.get("type") == "object":
+                self.assertIs(schema.get("additionalProperties"), False)
+                self.assertEqual(
+                    set(schema.get("required") or []),
+                    set((schema.get("properties") or {}).keys()),
+                )
+            for value in schema.values():
+                if isinstance(value, dict):
+                    assert_closed(value)
+                elif isinstance(value, list):
+                    for item in value:
+                        assert_closed(item)
+
+        audit_schema = m.audit_verdict_output_schema()
+        panel_schema = m.judicial_vote_output_schema()
+        self.assertEqual(audit_schema["type"], "object")
+        self.assertEqual(panel_schema["type"], "object")
+        assert_closed(audit_schema)
+        assert_closed(panel_schema)
 
     def test_best_cached_model_uses_highest_full_gpt_version_not_cache_order(self):
         m = _import_codex_audit_runner()
@@ -11533,15 +11571,31 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
     def test_compute_required_escape_must_be_exact_one_line(self):
         m = _import_codex_audit_runner()
         self.assertEqual(
+            m.compute_required_reason(
+                '{"compute_required":"need the cached certificate",'
+                '"claim_id":null,"verdict":null}'
+            ),
+            "need the cached certificate",
+        )
+        self.assertEqual(
             m.compute_required_reason("COMPUTE_REQUIRED: need the long run"),
             "need the long run",
         )
+        self.assertIsNone(m.compute_required_reason(
+            '{"compute_required":"need it","extra":"not governed"}'
+        ))
         self.assertIsNone(m.compute_required_reason(
             '{"verdict_rationale":"COMPUTE_REQUIRED: quoted only"}'
         ))
         self.assertIsNone(m.compute_required_reason(
             "COMPUTE_REQUIRED: first line\nextra output"
         ))
+        self.assertEqual(
+            m.parse_verdict_json(
+                '{"compute_required":null,"claim_id":"row","verdict":"audited_failed"}'
+            ),
+            {"claim_id": "row", "verdict": "audited_failed"},
+        )
 
 
 class RelabelUnverifiedCodexAuditsTest(unittest.TestCase):
@@ -11898,7 +11952,7 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
             m.restore_audit_from_previous(row, {cid: row})
         )
 
-    def test_restore_refuses_packetless_declared_negative_conditional(self):
+    def test_restore_allows_packetless_declared_negative_conditional_in_development(self):
         m = self._import_and_patch()
         cid = "packetless_declared_conditional"
         note_path = "docs/POSITIVE_CONDITIONAL.md"
@@ -11913,8 +11967,11 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
         ]
         row = self._seed_with_archived(cid, archived)
         row["note_path"] = note_path
-        self.assertIsNone(
-            m.restore_audit_from_previous(row, {cid: row})
+        restored = m.restore_audit_from_previous(row, {cid: row})
+        self.assertIsNotNone(restored)
+        self.assertEqual(
+            restored["negative_assertion_classes"],
+            ["bounded_with_named_walls"],
         )
 
     def test_selects_only_packet_missing_rows_whose_trigger_no_longer_fires(self):
@@ -14390,24 +14447,27 @@ class BatchOrchestratorSeatBankingTest(unittest.TestCase):
                 "result": "validation_failed", "detail": "N7 wording",
             }
 
-        def fake_apply_one(job, envelope, retries):
-            verdict = envelope["audit"]["verdict"]
-            applied.append((job["cid"], job["pass"], verdict))
-            if verdict == "audited_clean":
-                job["row"]["audit_status"] = "audit_in_progress"
-                job["row"]["cross_confirmation"] = {
-                    "status": "awaiting_second",
-                }
-            else:
-                job["row"]["audit_status"] = verdict
-            return True, {
-                "cid": job["cid"], "pass": job["pass"],
-                "result": verdict,
-            }
+        def fake_apply_claim(deliveries, retries):
+            results = []
+            for job, envelope in deliveries:
+                verdict = envelope["audit"]["verdict"]
+                applied.append((job["cid"], job["pass"], verdict))
+                if verdict == "audited_clean":
+                    job["row"]["audit_status"] = "audit_in_progress"
+                    job["row"]["cross_confirmation"] = {
+                        "status": "awaiting_second",
+                    }
+                else:
+                    job["row"]["audit_status"] = verdict
+                results.append({
+                    "cid": job["cid"], "pass": job["pass"],
+                    "result": verdict,
+                })
+            return True, results
 
         report = []
         with mock.patch.object(m, "finalize_worker", side_effect=fake_finalize), \
-                mock.patch.object(m, "apply_one_serialized", side_effect=fake_apply_one):
+                mock.patch.object(m, "apply_claim_serialized", side_effect=fake_apply_claim):
             ok, _, _, _ = m.apply_serialized(jobs, report)
         return ok, report, applied, jobs[0]["row"]
 

--- a/docs/audit/scripts/tests/test_generate_conditional_prompts.py
+++ b/docs/audit/scripts/tests/test_generate_conditional_prompts.py
@@ -35,5 +35,27 @@ class HealLegacyLinkPrefixesTest(unittest.TestCase):
         self.assertEqual(gcp.heal_legacy_link_prefixes(once), once)
 
 
+class ConditionalCategoryCoverageTest(unittest.TestCase):
+    def test_missing_dependency_edge_has_generated_section(self):
+        rows = {
+            "claim": {
+                "audit_status": "audited_conditional",
+                "notes_for_re_audit_if_any": (
+                    "missing_dependency_edge: cite the retained authority"
+                ),
+                "transitive_descendants": 3,
+            }
+        }
+
+        by_class = gcp.collect_rows(rows, synthesized=set())
+
+        self.assertEqual(
+            [item["cid"] for item in by_class[
+                "audited_conditional_missing_dependency_edge"
+            ]],
+            ["claim"],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/audit/scripts/tests/test_science_fix_priority.py
+++ b/docs/audit/scripts/tests/test_science_fix_priority.py
@@ -149,6 +149,15 @@ class AuditHandoffTest(unittest.TestCase):
         self.assertIn("The implication is only asserted.", rows[0]["prompt_body"])
         self.assertNotIn("arbitrary edits", rows[0]["prompt_body"])
 
+    def test_missing_dependency_edge_maps_to_actionable_lane(self):
+        self.assertEqual(
+            sfl.audit_repair_category(
+                "audited_conditional",
+                "missing_dependency_edge: cite the retained authority",
+            ),
+            "conditional_missing_dependency_edge",
+        )
+
     def test_rejects_untrusted_or_incomplete_handoff(self):
         cases = (
             [],

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -62,6 +62,7 @@ import premise_nodes
 import ledger_io
 import no_go_discipline_gate
 import audit_invocation
+import audit_contract
 import compute_audit_dispatch_queue
 
 LEDGER_PATH = AUDIT_DIR / "data" / "audit_ledger.json"
@@ -1966,6 +1967,13 @@ def validate_verdict(
         return invocation_error
     if expected_invocation_id is not None and blob.get("audit_invocation_id") != expected_invocation_id:
         return "audit_invocation_id is absent or does not match the prompt-bound invocation"
+    tuple_error = audit_contract.verdict_claim_type_error(
+        blob.get("verdict"),
+        blob.get("claim_type"),
+        blob.get("decoration_parent_claim_id"),
+    )
+    if tuple_error:
+        return tuple_error
     forensic_tier = bool(
         source_requires_no_go
         or blob.get("claim_type") == "no_go"

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -140,6 +140,310 @@ CODEX_HARD_INPUT_CHAR_LIMIT = 1_048_576
 OUTPUT_INSTRUCTIONS_MARKER = "\n\n---\nOUTPUT INSTRUCTIONS (binding):"
 
 
+def _closed_schema(properties: dict[str, dict]) -> dict:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": list(properties),
+        "additionalProperties": False,
+    }
+
+
+def _nullable(schema: dict) -> dict:
+    return {"anyOf": [schema, {"type": "null"}]}
+
+
+def _string_schema(*, enum: tuple[str, ...] | None = None) -> dict:
+    schema: dict = {"type": "string"}
+    if enum is not None:
+        schema["enum"] = list(enum)
+    return schema
+
+
+def _string_array_schema() -> dict:
+    return {"type": "array", "items": _string_schema()}
+
+
+def no_go_output_schema() -> dict:
+    """Closed transport schema for the canonical N1-N8 response packet.
+
+    Conditional fields are present as nullable values because strict Codex
+    output schemas require every declared property in ``required``. The
+    canonical validators still enforce when those values must be substantive.
+    """
+    evidence_fields = {
+        "evidence_path": _string_schema(),
+        "evidence_locator": _string_schema(),
+    }
+    n1_route = _closed_schema({
+        "route_id": _string_schema(),
+        "route_class": _string_schema(enum=(
+            "algebraic_rearrangement",
+            "symmetry_or_representation",
+            "alternate_carrier_or_sector",
+            "boundary_or_initial_condition",
+            "normalization_or_units",
+            "dynamical_or_effective_action",
+            "lattice_scale_or_limit",
+            "numerical_or_finite_case",
+            "convention_or_relabeling",
+            "alternate_observable_or_readout",
+            "topology_or_global_structure",
+            "dependency_or_registry_reclassification",
+        )),
+        "mechanism": _string_schema(),
+        "attempt": _string_schema(),
+        "outcome": _string_schema(),
+        "honesty_marker": _string_schema(enum=("ATTEMPTED", "RULED OUT BY PRIOR")),
+        "disposition": _string_schema(enum=("CLOSED", "OPEN", "UNTESTED")),
+        "prior_witness_id": _nullable(_string_schema()),
+        **evidence_fields,
+    })
+    n2_pair = _closed_schema({
+        "left": _string_schema(),
+        "right": _string_schema(),
+        "left_closes_right": {"type": "boolean"},
+        "right_closes_left": {"type": "boolean"},
+        "independent": {"type": "boolean"},
+        "rationale": _string_schema(),
+        **evidence_fields,
+    })
+    n3_hit = _closed_schema({
+        "phrase": _string_schema(),
+        "occurrence_group_id": _string_schema(),
+        "occurrence_count": {"type": "integer"},
+        "occurrence_locator_sha256": _string_schema(),
+        "classification": _string_schema(enum=(
+            "retained_authority", "hidden_admission", "non_load_bearing"
+        )),
+        "promoted_wall": _nullable(_string_schema()),
+        "rationale": _nullable(_string_schema()),
+        **evidence_fields,
+    })
+    n4_witness = _closed_schema({
+        "witness_id": _string_schema(),
+        "route_id": _string_schema(),
+        "witness_residual": _string_schema(),
+        "witness_residual_id": _string_schema(),
+        "claim_residual": _string_schema(),
+        "claim_residual_id": _string_schema(),
+        "match": {"type": "boolean"},
+        **evidence_fields,
+        "claim_evidence_path": _string_schema(),
+        "claim_evidence_locator": _string_schema(),
+    })
+    n5_statement = _closed_schema({
+        "phrase": _string_schema(),
+        "occurrence_group_id": _string_schema(),
+        "occurrence_count": {"type": "integer"},
+        "occurrence_locator_sha256": _string_schema(),
+        "resolution_classes_checked": _string_array_schema(),
+        "tested_resolutions": _string_array_schema(),
+        "untested_resolutions": _string_array_schema(),
+        **evidence_fields,
+        "resolution_evidence_path": _string_schema(),
+        "resolution_evidence_locator": _string_schema(),
+    })
+    n6_candidate = _closed_schema({
+        "candidate_id": _string_schema(),
+        "kind": _string_schema(enum=(
+            "approved_primitive", "open_gate", "convention_reframe",
+            "definition_refactor",
+        )),
+        "indexed_basis": _string_schema(),
+        "affected_wall": _string_schema(),
+        "closure_mechanism": _string_schema(),
+        "could_close_wall": {"type": "boolean"},
+        "addressed": {"type": "boolean"},
+        "disposition": _string_schema(),
+        **evidence_fields,
+    })
+    n8_echo = _closed_schema({
+        "candidate_id": _string_schema(),
+        "mechanism": _string_schema(),
+        "retired": _nullable({"type": "boolean"}),
+        "applicable": {"type": "boolean"},
+        "addressed": {"type": "boolean"},
+        "disposition": _string_schema(),
+        **evidence_fields,
+    })
+    scan_common = {
+        "scan_scope": _string_schema(),
+        "scanned_evidence_paths": _string_array_schema(),
+    }
+    section_tail = {
+        "none_found_reason": _nullable(_string_schema()),
+        "unresolved": _string_array_schema(),
+        **evidence_fields,
+    }
+    packet = _closed_schema({
+        "required": {"type": "boolean"},
+        "status": _string_schema(enum=("PASS", "FAIL")),
+        "N1_alternative_routes": {"type": "array", "items": n1_route},
+        "N2_wall_independence": _closed_schema({
+            "walls": _string_array_schema(),
+            "pairwise_checks": {"type": "array", "items": n2_pair},
+            "collapsed_wall_set": _string_array_schema(),
+            "unresolved": _string_array_schema(),
+            **evidence_fields,
+        }),
+        "N3_hidden_wall_scan": _closed_schema({
+            **scan_common,
+            "hits": {"type": "array", "items": n3_hit},
+            **section_tail,
+        }),
+        "N4_residual_matching": _closed_schema({
+            **scan_common,
+            "witnesses": {"type": "array", "items": n4_witness},
+            **section_tail,
+        }),
+        "N5_rhetoric_audit": _closed_schema({
+            **scan_common,
+            "statements": {"type": "array", "items": n5_statement},
+            **section_tail,
+        }),
+        "N6_partial_closure_scan": _closed_schema({
+            "scan_scope": _string_schema(),
+            "premise_classes_checked": _string_array_schema(),
+            "candidates": {"type": "array", "items": n6_candidate},
+            **section_tail,
+        }),
+        "N7_steelman": _closed_schema({
+            "route_id": _string_schema(),
+            "argument": _string_schema(),
+            "resolution": _string_schema(),
+            "resolved": {"type": "boolean"},
+            **evidence_fields,
+            "resolution_evidence_path": _string_schema(),
+            "resolution_evidence_locator": _string_schema(),
+        }),
+        "N8_cross_cycle_echo": _closed_schema({
+            "packet_complete": {"type": "boolean"},
+            "no_go_row_universe_count": {"type": "integer"},
+            "no_go_row_universe_sha256": _string_schema(),
+            "echoes": {"type": "array", "items": n8_echo},
+            **section_tail,
+        }),
+        "failures": _string_array_schema(),
+        "demotion": _nullable(_string_schema(enum=(
+            "partial-attempt-with-named-untested-routes",
+            "partial-narrowing",
+            "bounded-with-corrected-wall-count",
+            "stretch-attempt-with-honest-residual",
+        ))),
+        "prior_claim_scope": _nullable(_string_schema()),
+        "narrowed_claim_scope": _nullable(_string_schema()),
+        "corrected_wall_set": _string_array_schema(),
+        "next_route": _nullable(_closed_schema({
+            "route_id": _string_schema(),
+            "reason_untested": _string_schema(),
+        })),
+    })
+    return _nullable(packet)
+
+
+def audit_verdict_output_schema(*, allow_compute_required: bool = True) -> dict:
+    audit_properties = {
+        "claim_id": _string_schema(),
+        "audit_invocation_id": _string_schema(),
+        "load_bearing_step": _string_schema(),
+        "load_bearing_step_class": _string_schema(enum=tuple("ABCDEFG")),
+        "claim_type": _string_schema(enum=(
+            "positive_theorem", "bounded_theorem", "no_go", "open_gate",
+            "decoration", "meta",
+        )),
+        "claim_scope": _string_schema(),
+        "chain_closes": {"type": "boolean"},
+        "chain_closure_explanation": _string_schema(),
+        "runner_check_breakdown": _closed_schema({
+            "A": {"type": "integer"},
+            "B": {"type": "integer"},
+            "C": {"type": "integer"},
+            "D": {"type": "integer"},
+            "total_pass": {"type": "integer"},
+        }),
+        "verdict": _string_schema(enum=(
+            "audited_clean", "audited_renaming", "audited_conditional",
+            "audited_decoration", "audited_numerical_match", "audited_failed",
+        )),
+        "verdict_rationale": _string_schema(),
+        "negative_assertion_classes": {
+            "type": "array",
+            "items": _string_schema(enum=(
+                "no_go_result", "stretch_attempt_negative",
+                "bounded_with_named_walls", "derived_no_go_boundary",
+                "conditional_wall_rationale",
+            )),
+        },
+        "decoration_parent_claim_id": _nullable(_string_schema()),
+        "open_dependency_paths": _string_array_schema(),
+        "auditor_confidence": _string_schema(enum=("low", "medium", "high")),
+        "notes_for_re_audit_if_any": _string_schema(),
+        "no_go_discipline": no_go_output_schema(),
+    }
+    if not allow_compute_required:
+        return _closed_schema({
+            "compute_required": {"type": "null"},
+            **audit_properties,
+        })
+    # The Codex structured-output endpoint requires a root object and rejects
+    # a root-level anyOf. Use one closed discriminated surface instead: normal
+    # audits set compute_required=null; the compute escape sets it to one line
+    # and every audit field to null. The semantic parser removes the null
+    # transport discriminator before canonical validation/apply.
+    return _closed_schema({
+        "compute_required": _nullable(_string_schema()),
+        **{
+            name: schema if name == "no_go_discipline" else _nullable(schema)
+            for name, schema in audit_properties.items()
+        },
+    })
+
+
+def judicial_vote_output_schema() -> dict:
+    return _closed_schema({
+        "sided_with": _string_schema(enum=("first", "second", "hybrid", "neither")),
+        "ratified_verdict": _string_schema(enum=(
+            "audited_clean", "audited_renaming", "audited_conditional",
+            "audited_decoration", "audited_failed", "audited_numerical_match",
+        )),
+        "ratified_claim_type": _string_schema(enum=(
+            "positive_theorem", "bounded_theorem", "no_go", "open_gate",
+            "decoration", "meta",
+        )),
+        "ratified_claim_scope": _string_schema(),
+        "ratified_load_bearing_step": _nullable(_string_schema()),
+        "ratified_load_bearing_step_class": _string_schema(enum=tuple("ABCDEFG")),
+        "negative_assertion_classes": _string_array_schema(),
+        "judgment_rationale": _string_schema(),
+        "first_auditor_error": _string_schema(),
+        "second_auditor_error": _string_schema(),
+        "hybrid_resolution_note": _nullable(_string_schema()),
+        "ratified_decoration_parent_claim_id": _nullable(_string_schema()),
+        "notes_for_re_audit_if_any": _nullable(_string_schema()),
+        "no_go_discipline": no_go_output_schema(),
+    })
+
+
+def write_object_output_schema(
+    path: Path,
+    *,
+    response_kind: str = "audit",
+    allow_compute_required: bool = True,
+) -> Path:
+    """Write the closed transport schema used by a restricted Codex seat."""
+    if response_kind == "audit":
+        schema = audit_verdict_output_schema(
+            allow_compute_required=allow_compute_required
+        )
+    elif response_kind == "judicial_vote":
+        schema = judicial_vote_output_schema()
+    else:
+        raise ValueError(f"unknown Codex response schema kind {response_kind!r}")
+    path.write_text(json.dumps(schema, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
 def prompt_exceeds_hard_input_limit(prompt: str) -> bool:
     return len(prompt) > CODEX_HARD_INPUT_CHAR_LIMIT
 
@@ -1287,15 +1591,15 @@ def render_prompt(row: dict, ledger_rows: dict[str, dict],
         "OUTPUT INSTRUCTIONS (binding):\n"
         "If the runner output is missing only because of timeout, missing\n"
         "stdout, or compute-budget exhaustion AND the load-bearing step\n"
-        "cannot be judged without that completed run, return EXACTLY one\n"
-        "line of the form:\n"
-        "    COMPUTE_REQUIRED: <one sentence naming the missing run / cached\n"
-        "    certificate / independent derivation needed>\n"
-        "and nothing else. Do NOT fabricate a terminal verdict in that case.\n"
+        "cannot be judged without that completed run, use the response schema's\n"
+        "compute variant: set compute_required to one sentence naming the\n"
+        "missing run / cached certificate / independent derivation needed,\n"
+        "and set EVERY other top-level field to null. Do NOT fabricate a\n"
+        "terminal verdict in that case.\n"
         "\n"
-        "Otherwise, respond with EXACTLY one JSON object matching the schema\n"
-        "in section 5. No markdown fences, no preamble, no explanation\n"
-        "outside the JSON.\n"
+        "Otherwise, set compute_required=null and respond with EXACTLY one JSON\n"
+        "object matching the remaining schema in section 5. No markdown\n"
+        "fences, no preamble, no explanation outside the JSON.\n"
     )
     return prompt
 
@@ -1428,7 +1732,13 @@ def run_codex(prompt: str, isolated_dir: Path, timeout_sec: int,
     isolated_dir.mkdir(parents=True, exist_ok=True)
     cmd = ["codex", "exec", "--skip-git-repo-check"]
     last_message_path = isolated_dir / "codex-last-message.txt"
-    cmd += ["--output-last-message", str(last_message_path)]
+    output_schema_path = write_object_output_schema(
+        isolated_dir / "codex-final-response.schema.json"
+    )
+    cmd += [
+        "--output-schema", str(output_schema_path),
+        "--output-last-message", str(last_message_path),
+    ]
     if reasoning_effort:
         cmd += ["-c", f"model_reasoning_effort={reasoning_effort!r}"]
     if model:
@@ -1588,10 +1898,18 @@ def parse_verdict_json(reply: str) -> dict | None:
     # Drop any tokens-used trailer
     if "\ntokens used" in reply:
         reply = reply.split("\ntokens used", 1)[0].rstrip()
+    def normalized(parsed: object) -> dict | None:
+        if not isinstance(parsed, dict):
+            return None
+        if parsed.get("compute_required") is None:
+            parsed = dict(parsed)
+            parsed.pop("compute_required", None)
+        return parsed
+
     # Try direct parse first
     try:
         parsed = json.loads(reply)
-        return parsed if isinstance(parsed, dict) else None
+        return normalized(parsed)
     except json.JSONDecodeError:
         pass
     # Strip markdown fences if present
@@ -1599,7 +1917,7 @@ def parse_verdict_json(reply: str) -> dict | None:
         stripped = reply.strip("`").lstrip("json").strip()
         try:
             parsed = json.loads(stripped)
-            return parsed if isinstance(parsed, dict) else None
+            return normalized(parsed)
         except json.JSONDecodeError:
             pass
 
@@ -1615,8 +1933,9 @@ def parse_verdict_json(reply: str) -> dict | None:
         candidate = reply[first_open : last_close + 1]
         try:
             parsed = json.loads(candidate)
-            if isinstance(parsed, dict):
-                return parsed
+            normalized_parsed = normalized(parsed)
+            if normalized_parsed is not None:
+                return normalized_parsed
             cursor = first_open + 1
         except json.JSONDecodeError:
             cursor = first_open + 1
@@ -1943,9 +2262,31 @@ def bind_authenticated_n6_candidate_locators(
 
 
 def compute_required_reason(reply: str | None) -> str | None:
-    """Accept only the exact one-line COMPUTE_REQUIRED escape protocol."""
+    """Accept only the governed compute-required escape protocols.
+
+    New structured-output seats return a one-field JSON object.  The legacy
+    exact line remains readable so an in-flight worker started before this
+    migration can still finish without being converted into a false verdict.
+    """
     if not reply:
         return None
+    try:
+        payload = json.loads(reply.strip())
+    except json.JSONDecodeError:
+        payload = None
+    if (
+        isinstance(payload, dict)
+        and "compute_required" in payload
+        and isinstance(payload["compute_required"], str)
+        and payload["compute_required"].strip()
+        and "\n" not in payload["compute_required"].strip()
+        and all(
+            value is None
+            for name, value in payload.items()
+            if name != "compute_required"
+        )
+    ):
+        return payload["compute_required"].strip()[:300]
     match = re.fullmatch(
         r"COMPUTE_REQUIRED:\s*([^\r\n]+)",
         reply.strip(),

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -596,10 +596,9 @@ def resolve_audit_model() -> tuple[str, str, str, list[str]]:
     return selected, codex_family_for_model(selected), source, warnings
 
 
-# Statuses where this runner SHOULD NOT proceed automatically. Disagreements
-# and three-way disagreements need a judicial third-auditor pass that the
-# operator runs manually (per docs/audit/FRESH_LOOK_REQUIREMENTS.md and
-# apply_audit.py's apply_judicial_review path).
+# Statuses where this ordinary-seat runner SHOULD NOT proceed. The top-level
+# audit loop owns the governed five-judge panel and repeat-panel continuation
+# for disagreements (per FRESH_LOOK_REQUIREMENTS.md and audit-loop/SKILL.md).
 SKIP_BLOCKERS = {
     "cross_confirmation_disagreement",
     "third_auditor_disagreement",
@@ -710,11 +709,14 @@ def determine_audit_role(led_row: dict, auditor_family: str,
         cc = {}
     cc_status = cc.get("status")
 
-    # Skip rows that need judicial / human resolution.
+    # Skip rows owned by the top-level five-judge panel orchestrator.
     if blocker in SKIP_BLOCKERS:
-        return "skip", f"blocker={blocker} (judicial review needed; manual)"
+        return "skip", f"blocker={blocker} (governed five-judge panel required)"
     if cc_status in {"disagreement", "three_way_disagreement", "disagreement_irresolvable"}:
-        return "skip", f"cross_confirmation.status={cc_status} (judicial review needed; manual)"
+        return "skip", (
+            f"cross_confirmation.status={cc_status} "
+            "(governed five-judge panel required)"
+        )
 
     # Second-pass on a critical-row first audit that is awaiting cross-confirmation.
     if audit_status == "audit_in_progress" and cc_status == "awaiting_second":
@@ -1955,6 +1957,9 @@ def validate_verdict(
     """Return an error string if the verdict is unusable, else None."""
     if not isinstance(blob, dict):
         return "verdict must be a JSON object"
+    compute_error = audit_contract.terminal_compute_required_error(blob)
+    if compute_error:
+        return compute_error
     missing = REQUIRED_VERDICT_FIELDS - set(blob)
     if missing:
         return f"missing fields: {sorted(missing)}"
@@ -2272,9 +2277,10 @@ def bind_authenticated_n6_candidate_locators(
 def compute_required_reason(reply: str | None) -> str | None:
     """Accept only the governed compute-required escape protocols.
 
-    New structured-output seats return a one-field JSON object.  The legacy
-    exact line remains readable so an in-flight worker started before this
-    migration can still finish without being converted into a false verdict.
+    New structured-output seats return a closed JSON object whose one non-null
+    field is ``compute_required``. The legacy exact line remains readable so
+    an in-flight worker started before this migration can still finish without
+    being converted into a false verdict.
     """
     if not reply:
         return None
@@ -2829,7 +2835,7 @@ def main() -> int:
     print("  first-pass with no prior audit                    -> cross_family")
     print("  second-pass after a prior audit by a different family -> cross_family")
     print("  second-pass after a prior audit by Codex            -> fresh_context")
-    print("  rows in disagreement / awaiting-judicial-review     -> skipped (manual)")
+    print("  rows in disagreement / awaiting-judicial-review     -> top-level panel lane")
     if args.from_dispatch:
         print("Source: audit_dispatch_queue.json (live targeted re-audits)")
         print(f"  ready_only={not args.allow_blocked}")

--- a/scripts/science_fix_loop.py
+++ b/scripts/science_fix_loop.py
@@ -171,6 +171,7 @@ CATEGORIES = (
     "open_gate",
     "conditional_runner_artifact_issue",
     "conditional_scope_too_broad",
+    "conditional_missing_dependency_edge",
     "conditional_missing_bridge_theorem",
 )
 # Scheduling rank within a difficulty bucket: mechanical categories close
@@ -182,9 +183,10 @@ CATEGORY_RANK = {
     "numerical_match": 1,
     "conditional_runner_artifact_issue": 2,
     "conditional_scope_too_broad": 3,
-    "open_gate": 4,
-    "failed": 5,
-    "conditional_missing_bridge_theorem": 6,
+    "conditional_missing_dependency_edge": 4,
+    "open_gate": 5,
+    "failed": 6,
+    "conditional_missing_bridge_theorem": 7,
 }
 
 # NOTE (governance): publication-lane prioritization is deliberately ABSENT.
@@ -256,6 +258,7 @@ def parse_prompts(prompts_file: Path = PROMPTS_FILE):
         r"audited_renaming|audited_failed|audited_numerical_match|open_gate"
         r"|audited_conditional_runner_artifact_issue"
         r"|audited_conditional_scope_too_broad"
+        r"|audited_conditional_missing_dependency_edge"
         r"|audited_conditional_missing_bridge_theorem"
         r")\b"
     )
@@ -266,6 +269,7 @@ def parse_prompts(prompts_file: Path = PROMPTS_FILE):
         "open_gate": "open_gate",
         "audited_conditional_runner_artifact_issue": "conditional_runner_artifact_issue",
         "audited_conditional_scope_too_broad": "conditional_scope_too_broad",
+        "audited_conditional_missing_dependency_edge": "conditional_missing_dependency_edge",
         "audited_conditional_missing_bridge_theorem": "conditional_missing_bridge_theorem",
     }
     for m in re.finditer(header_pattern, text, re.MULTILINE):
@@ -303,6 +307,7 @@ def audit_repair_category(audit_verdict: str, repair_target: str) -> str | None:
         conditional_categories = {
             "runner_artifact_issue": "conditional_runner_artifact_issue",
             "scope_too_broad": "conditional_scope_too_broad",
+            "missing_dependency_edge": "conditional_missing_dependency_edge",
             "missing_bridge_theorem": "conditional_missing_bridge_theorem",
         }
         prefix = repair_target.split("—", 1)[0].split(":", 1)[0].strip().lower()


### PR DESCRIPTION
## Summary
- constrain ordinary, completion, and judicial Codex responses with endpoint-valid closed JSON schemas
- normalize invalid optional development-tier no-go packets and align invalidation/restoration with the live packet-binding policy
- apply simultaneous critical seats as one claim transaction with one pipeline, lint, commit, and push
- route missing_dependency_edge conditional verdicts into the governed science-fix lane
- reject semantically incompatible verdict/type tuples before apply across ordinary seats, stored seat summaries, judicial votes, and judicial apply
- quarantine incompatible deliveries for the current campaign and continue the backlog; panels now receive only validator-clean, applyable scientific disagreements

## Failure addressed
The July 21 drain stopped when an ordinary seat returned `audited_decoration` with `claim_type=bounded_theorem`. Delivery validation accepted that cross-field mismatch, `apply_audit.py` rejected it, and the batch classified the result as `apply_or_gate_failed`, which terminated the top-level drainer. The canonical semantic validator now rejects the tuple as `validation_failed`, so the existing schema-quarantine path records the exact error and continues other ready rows. This is a delivery-contract failure, not a disagreement requiring a judge panel.

## Verification
- 383 tests in `test_audit_pipeline.py`
- 25 audit-loop orchestrator tests
- 12 science-fix priority tests
- 4 conditional-prompt generator tests
- focused incompatible-tuple runner, batch-quarantine, judicial-vote, and judicial-apply regression tests
- full 18-stage audit pipeline
- strict audit lint (no errors)
- vocabulary lint across all branch-modified files (no violations)
- live Codex schema probes for audit/compute and judicial vote responses (original PR verification)
- skill-creator quick validation (original PR verification)
- `git diff --check`
