### PR TITLE
Fix audit drain generated-state sync recovery

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -275,10 +275,11 @@ least every 15 minutes — never silence for a long run.
   rewrite, chmod, replace, or otherwise mutate the generated file. If
   overlapping or non-provenance content appears, preserve it, fail the clean
   check, and stop that transaction.
-- Require the canonical regular-file mode and single-link entry, then verify
-  the same raw bytes and metadata again after the second status read. Refuse
-  read-only, special-mode, hardlinked, or concurrently changed entries so the
-  downstream generator cannot mutate user-owned filesystem state.
+- Require a writable, owner-matched canonical regular file with no flags and a
+  single-link entry, then verify the same raw bytes and metadata again after
+  the second status read. Refuse ACL-denied, immutable, special-mode,
+  hardlinked, or concurrently changed entries so the downstream generator
+  cannot mutate user-owned filesystem state.
 - Keep that recovery fail-closed. It must reject staged changes, source or
   ledger content, verdict-bearing changes, untracked files, deletions, and
   any payload delta beyond the exact allowlisted provenance field. Preserve

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -258,6 +258,28 @@ least every 15 minutes — never silence for a long run.
   one that stops early still reports what landed, what failed, and what
   remains through that forced summary.
 
+## Drain Liveness And Generated-State Recovery
+
+- A quiet worker is bounded by the configured stall timer, and every
+  supervisor phase continues to emit the 15-minute progress summary. Do not
+  leave a drain silently waiting past those bounds.
+- Tracked generated audit surfaces must be commit-invariant. Never embed the
+  current `HEAD` commit in a tracked pipeline output: committing that output
+  changes `HEAD` and guarantees fresh dirt at the next regeneration.
+- Treat mechanically verified provenance-only drift on an explicitly
+  allowlisted generated surface as recoverable coordination state, not as a
+  terminal campaign failure. Normalize it at the clean sync boundary and
+  continue the same supervisor.
+- Keep that recovery fail-closed. It must reject staged changes, source or
+  ledger content, verdict-bearing changes, untracked files, deletions, and
+  any payload delta beyond the exact allowlisted provenance field. Preserve
+  every in-flight claim transaction and user-authored change.
+- If a supervisor exits after a transaction has committed and pushed, verify
+  process absence and exact local/remote synchronization, repair only the
+  mechanically verified generated-state condition, and relaunch exactly one
+  canonical top-level drainer. Do not leave a recoverable sync condition as a
+  parked audit campaign.
+
 ## Scaling: The One Canonical Fan-Out
 
 There is exactly one sanctioned way to parallelize this lane — the

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -268,11 +268,13 @@ least every 15 minutes — never silence for a long run.
   changes `HEAD` and guarantees fresh dirt at the next regeneration.
 - Treat mechanically verified provenance-only drift on an explicitly
   allowlisted generated surface as recoverable coordination state, not as a
-  terminal campaign failure. Normalize it at the clean sync boundary and
-  continue the same supervisor.
-- Subtract only the exact verified provenance patch; never restore the whole
-  generated file. If overlapping or non-provenance content appears before the
-  patch applies, preserve it, fail the clean check, and stop that transaction.
+  terminal campaign failure. Carry that exact state through the clean sync
+  boundary unchanged and continue the same supervisor; the next normal
+  pipeline/commit removes the obsolete provenance field.
+- The clean guard must only classify this state; it must not patch, restore,
+  rewrite, chmod, replace, or otherwise mutate the generated file. If
+  overlapping or non-provenance content appears, preserve it, fail the clean
+  check, and stop that transaction.
 - Keep that recovery fail-closed. It must reject staged changes, source or
   ledger content, verdict-bearing changes, untracked files, deletions, and
   any payload delta beyond the exact allowlisted provenance field. Preserve

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -275,6 +275,10 @@ least every 15 minutes — never silence for a long run.
   rewrite, chmod, replace, or otherwise mutate the generated file. If
   overlapping or non-provenance content appears, preserve it, fail the clean
   check, and stop that transaction.
+- Require the canonical regular-file mode and single-link entry, then verify
+  the same raw bytes and metadata again after the second status read. Refuse
+  read-only, special-mode, hardlinked, or concurrently changed entries so the
+  downstream generator cannot mutate user-owned filesystem state.
 - Keep that recovery fail-closed. It must reject staged changes, source or
   ledger content, verdict-bearing changes, untracked files, deletions, and
   any payload delta beyond the exact allowlisted provenance field. Preserve

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -270,6 +270,9 @@ least every 15 minutes — never silence for a long run.
   allowlisted generated surface as recoverable coordination state, not as a
   terminal campaign failure. Normalize it at the clean sync boundary and
   continue the same supervisor.
+- Subtract only the exact verified provenance patch; never restore the whole
+  generated file. If overlapping or non-provenance content appears before the
+  patch applies, preserve it, fail the clean check, and stop that transaction.
 - Keep that recovery fail-closed. It must reject staged changes, source or
   ledger content, verdict-bearing changes, untracked files, deletions, and
   any payload delta beyond the exact allowlisted provenance field. Preserve

--- a/docs/audit/scripts/compute_lane_certification.py
+++ b/docs/audit/scripts/compute_lane_certification.py
@@ -14,7 +14,6 @@ edit or source change) is the honest coordination signal, not an error.
 from __future__ import annotations
 
 import json
-import subprocess
 from pathlib import Path
 
 import premise_nodes
@@ -47,13 +46,6 @@ def main() -> int:
     config = json.loads(CONFIG.read_text(encoding="utf-8"))
     ledger = json.loads(LEDGER.read_text(encoding="utf-8"))
     rows = ledger.get("rows", {})
-    try:
-        head = subprocess.run(
-            ["git", "rev-parse", "HEAD"], cwd=REPO_ROOT,
-            capture_output=True, text=True, check=True,
-        ).stdout.strip()
-    except Exception:
-        head = None
 
     lanes_out = []
     for lane in config.get("lanes", []):
@@ -132,7 +124,6 @@ def main() -> int:
 
     OUT.write_text(json.dumps({
         "schema": "lane_certification_v2",
-        "repo_head": head,
         "lanes": lanes_out,
     }, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     for lane in lanes_out:

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -1144,6 +1144,120 @@ def finalize_worker(job: dict) -> tuple[dict | None, dict]:
     return envelope, result
 
 
+def _file_snapshot_signature(file_stat: os.stat_result) -> tuple:
+    """State that must remain unchanged before an in-place byte rewrite."""
+    return (
+        file_stat.st_dev,
+        file_stat.st_ino,
+        file_stat.st_nlink,
+        file_stat.st_uid,
+        file_stat.st_gid,
+        file_stat.st_size,
+        file_stat.st_mtime_ns,
+        file_stat.st_ctime_ns,
+        stat.S_IMODE(file_stat.st_mode),
+        getattr(file_stat, "st_flags", None),
+    )
+
+
+def _file_entry_signature(file_stat: os.stat_result) -> tuple:
+    """Entry metadata an in-place content rewrite must preserve exactly."""
+    return (
+        file_stat.st_dev,
+        file_stat.st_ino,
+        file_stat.st_nlink,
+        file_stat.st_uid,
+        file_stat.st_gid,
+        stat.S_IMODE(file_stat.st_mode),
+        getattr(file_stat, "st_flags", None),
+    )
+
+
+def _read_open_file(fd: int) -> bytes:
+    os.lseek(fd, 0, os.SEEK_SET)
+    chunks: list[bytes] = []
+    while True:
+        chunk = os.read(fd, 1024 * 1024)
+        if not chunk:
+            return b"".join(chunks)
+        chunks.append(chunk)
+
+
+def _write_all_at(fd: int, content: bytes, offset: int) -> None:
+    written = 0
+    while written < len(content):
+        count = os.pwrite(fd, content[written:], offset + written)
+        if count <= 0:
+            raise OSError("short write while recovering certification provenance")
+        written += count
+
+
+def _rewrite_verified_bytes_in_place(
+    path: Path,
+    *,
+    expected: bytes,
+    replacement: bytes,
+    expected_signature: tuple,
+) -> bool:
+    """Rewrite verified bytes without replacing the file or touching a sibling.
+
+    Keeping the same open inode preserves hardlinks, xattrs, ACLs, ownership,
+    exact permission bits, and every neighboring path. The advisory lock
+    coordinates cooperating writers; the signature and byte checks close the
+    observable check/mutation windows for non-cooperating writers.
+    """
+    flags = os.O_RDWR
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return False
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return False
+        before = os.fstat(fd)
+        if not stat.S_ISREG(before.st_mode):
+            return False
+        if _file_snapshot_signature(before) != expected_signature:
+            return False
+        if _read_open_file(fd) != expected:
+            return False
+
+        prefix = 0
+        shared_limit = min(len(expected), len(replacement))
+        while prefix < shared_limit and expected[prefix] == replacement[prefix]:
+            prefix += 1
+        suffix = 0
+        while (
+            suffix < shared_limit - prefix
+            and expected[len(expected) - suffix - 1]
+            == replacement[len(replacement) - suffix - 1]
+        ):
+            suffix += 1
+
+        if len(expected) == len(replacement):
+            end = len(replacement) - suffix if suffix else len(replacement)
+            _write_all_at(fd, replacement[prefix:end], prefix)
+        else:
+            _write_all_at(fd, replacement, 0)
+            os.ftruncate(fd, len(replacement))
+        os.fsync(fd)
+
+        after = os.fstat(fd)
+        if not stat.S_ISREG(after.st_mode):
+            return False
+        if _file_entry_signature(after) != _file_entry_signature(before):
+            return False
+        return _read_open_file(fd) == replacement
+    except OSError:
+        return False
+    finally:
+        os.close(fd)
+
+
 def recover_lane_certification_provenance_drift(
     status_output: str,
     *,
@@ -1158,11 +1272,10 @@ def recover_lane_certification_provenance_drift(
     be exactly either the committed payload with the obsolete field removed or
     with that field refreshed to the current commit, and refuses every staged,
     untracked, deleted, malformed, metadata, or content-bearing change. The
-    verified content-only Git patch is reversed as raw bytes instead of through
-    Git's working-tree conversion or by restoring the whole file. Exact mode
-    bits are checked across the reversal, an overlapping concurrent write makes
-    the patch fail, and a non-overlapping write survives for the post-recovery
-    clean check.
+    verified content-only Git patch is subtracted through the already-open file
+    descriptor instead of through Git's conversion layer, an external patcher,
+    or a whole-file restore. This preserves the inode and all entry metadata;
+    exact bytes and metadata are rechecked at the mutation boundary.
     """
     if status_output.splitlines() != [f" M {LANE_CERTIFICATION_PATH}"]:
         return False
@@ -1182,15 +1295,7 @@ def recover_lane_certification_provenance_drift(
         return False
     if not stat.S_ISREG(working_stat.st_mode):
         return False
-    working_mode = stat.S_IMODE(working_stat.st_mode)
-    working_signature = (
-        working_stat.st_dev,
-        working_stat.st_ino,
-        working_stat.st_size,
-        working_stat.st_mtime_ns,
-        working_stat.st_ctime_ns,
-        working_mode,
-    )
+    working_signature = _file_snapshot_signature(working_stat)
 
     provenance_pattern = re.compile(
         rb'(?m)^(  "repo_head": ")([0-9a-f]{40})(",)(\r?\n)'
@@ -1241,6 +1346,8 @@ def recover_lane_certification_provenance_drift(
             "--no-textconv",
             "--no-color",
             "--binary",
+            "--src-prefix=a/",
+            "--dst-prefix=b/",
             "--",
             LANE_CERTIFICATION_PATH,
         ],
@@ -1278,66 +1385,24 @@ def recover_lane_certification_provenance_drift(
         current_stat = path.lstat()
     except OSError:
         return False
-    current_signature = (
-        current_stat.st_dev,
-        current_stat.st_ino,
-        current_stat.st_size,
-        current_stat.st_mtime_ns,
-        current_stat.st_ctime_ns,
-        stat.S_IMODE(current_stat.st_mode),
-    )
     if not stat.S_ISREG(current_stat.st_mode):
         return False
-    if current_signature != working_signature:
+    if _file_snapshot_signature(current_stat) != working_signature:
         return False
 
-    patch_path: Path | None = None
-    try:
-        descriptor, temporary = tempfile.mkstemp(
-            prefix="audit-lane-provenance-",
-            suffix=".patch",
-        )
-        patch_path = Path(temporary)
-        with os.fdopen(descriptor, "wb") as handle:
-            handle.write(patch.stdout)
-        reversed_patch = sh(
-            [
-                "patch",
-                "-R",
-                "-p1",
-                "-f",
-                "-s",
-                "-r",
-                os.devnull,
-                "-i",
-                str(patch_path),
-            ],
-            honor_cancel=honor_cancel,
-        )
-        if reversed_patch.returncode != 0:
-            return False
-        try:
-            final_bytes = path.read_bytes()
-            final_stat = path.lstat()
-        except OSError:
-            return False
-        if final_bytes != committed.stdout:
-            return False
-        if not stat.S_ISREG(final_stat.st_mode):
-            return False
-        if stat.S_IMODE(final_stat.st_mode) != working_mode:
-            return False
-        print(
-            "recovered generated certification provenance drift: "
-            f"{LANE_CERTIFICATION_PATH}",
-            flush=True,
-        )
-        return True
-    except OSError:
+    if not _rewrite_verified_bytes_in_place(
+        path,
+        expected=working_bytes,
+        replacement=committed.stdout,
+        expected_signature=working_signature,
+    ):
         return False
-    finally:
-        if patch_path is not None:
-            patch_path.unlink(missing_ok=True)
+    print(
+        "recovered generated certification provenance drift: "
+        f"{LANE_CERTIFICATION_PATH}",
+        flush=True,
+    )
+    return True
 
 
 def clean_main_error(*, honor_cancel: bool = True) -> str | None:

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -1200,6 +1200,12 @@ def recover_lane_certification_provenance_drift(
         return False
     if working_stat.st_nlink != 1:
         return False
+    if working_stat.st_uid != os.geteuid():
+        return False
+    if getattr(working_stat, "st_flags", 0):
+        return False
+    if not os.access(path, os.W_OK):
+        return False
     working_signature = _file_snapshot_signature(working_stat)
 
     provenance_pattern = re.compile(

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -1160,110 +1160,12 @@ def _file_snapshot_signature(file_stat: os.stat_result) -> tuple:
     )
 
 
-def _file_entry_signature(file_stat: os.stat_result) -> tuple:
-    """Entry metadata an in-place content rewrite must preserve exactly."""
-    return (
-        file_stat.st_dev,
-        file_stat.st_ino,
-        file_stat.st_nlink,
-        file_stat.st_uid,
-        file_stat.st_gid,
-        stat.S_IMODE(file_stat.st_mode),
-        getattr(file_stat, "st_flags", None),
-    )
-
-
-def _read_open_file(fd: int) -> bytes:
-    os.lseek(fd, 0, os.SEEK_SET)
-    chunks: list[bytes] = []
-    while True:
-        chunk = os.read(fd, 1024 * 1024)
-        if not chunk:
-            return b"".join(chunks)
-        chunks.append(chunk)
-
-
-def _write_all_at(fd: int, content: bytes, offset: int) -> None:
-    written = 0
-    while written < len(content):
-        count = os.pwrite(fd, content[written:], offset + written)
-        if count <= 0:
-            raise OSError("short write while recovering certification provenance")
-        written += count
-
-
-def _rewrite_verified_bytes_in_place(
-    path: Path,
-    *,
-    expected: bytes,
-    replacement: bytes,
-    expected_signature: tuple,
-) -> bool:
-    """Rewrite verified bytes without replacing the file or touching a sibling.
-
-    Keeping the same open inode preserves hardlinks, xattrs, ACLs, ownership,
-    exact permission bits, and every neighboring path. The advisory lock
-    coordinates cooperating writers; the signature and byte checks close the
-    observable check/mutation windows for non-cooperating writers.
-    """
-    flags = os.O_RDWR
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
-    try:
-        fd = os.open(path, flags)
-    except OSError:
-        return False
-    try:
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except OSError:
-            return False
-        before = os.fstat(fd)
-        if not stat.S_ISREG(before.st_mode):
-            return False
-        if _file_snapshot_signature(before) != expected_signature:
-            return False
-        if _read_open_file(fd) != expected:
-            return False
-
-        prefix = 0
-        shared_limit = min(len(expected), len(replacement))
-        while prefix < shared_limit and expected[prefix] == replacement[prefix]:
-            prefix += 1
-        suffix = 0
-        while (
-            suffix < shared_limit - prefix
-            and expected[len(expected) - suffix - 1]
-            == replacement[len(replacement) - suffix - 1]
-        ):
-            suffix += 1
-
-        if len(expected) == len(replacement):
-            end = len(replacement) - suffix if suffix else len(replacement)
-            _write_all_at(fd, replacement[prefix:end], prefix)
-        else:
-            _write_all_at(fd, replacement, 0)
-            os.ftruncate(fd, len(replacement))
-        os.fsync(fd)
-
-        after = os.fstat(fd)
-        if not stat.S_ISREG(after.st_mode):
-            return False
-        if _file_entry_signature(after) != _file_entry_signature(before):
-            return False
-        return _read_open_file(fd) == replacement
-    except OSError:
-        return False
-    finally:
-        os.close(fd)
-
-
 def recover_lane_certification_provenance_drift(
     status_output: str,
     *,
     honor_cancel: bool = True,
 ) -> bool:
-    """Subtract exact legacy ``repo_head``-only drift at a sync boundary.
+    """Recognize exact legacy ``repo_head``-only drift at a sync boundary.
 
     ``lane_certification.json`` used to embed the current commit. A pipeline
     refresh therefore dirtied the file as soon as a later commit changed
@@ -1272,10 +1174,9 @@ def recover_lane_certification_provenance_drift(
     be exactly either the committed payload with the obsolete field removed or
     with that field refreshed to the current commit, and refuses every staged,
     untracked, deleted, malformed, metadata, or content-bearing change. The
-    verified content-only Git patch is subtracted through the already-open file
-    descriptor instead of through Git's conversion layer, an external patcher,
-    or a whole-file restore. This preserves the inode and all entry metadata;
-    exact bytes and metadata are rechecked at the mutation boundary.
+    verified content-only state is carried through the sync boundary without
+    mutating it. The next normal pipeline/commit removes the obsolete field.
+    This classifier never writes the file, its metadata, or a neighboring path.
     """
     if status_output.splitlines() != [f" M {LANE_CERTIFICATION_PATH}"]:
         return False
@@ -1314,14 +1215,26 @@ def recover_lane_certification_provenance_drift(
     current_head = head.stdout.strip()
     if re.fullmatch(r"[0-9a-f]{40}", current_head) is None:
         return False
-    current_head_bytes = current_head.encode("ascii")
-    with_current_head = (
-        committed.stdout[: provenance.start(2)]
-        + current_head_bytes
-        + committed.stdout[provenance.end(2) :]
-    )
-    if working_bytes not in {without_provenance, with_current_head}:
-        return False
+    if working_bytes != without_provenance:
+        working_matches = list(provenance_pattern.finditer(working_bytes))
+        if len(working_matches) != 1:
+            return False
+        working_provenance = working_matches[0]
+        working_head_bytes = working_provenance.group(2)
+        with_working_head = (
+            committed.stdout[: provenance.start(2)]
+            + working_head_bytes
+            + committed.stdout[provenance.end(2) :]
+        )
+        if working_bytes != with_working_head:
+            return False
+        working_head = working_head_bytes.decode("ascii")
+        ancestor = sh(
+            ["git", "merge-base", "--is-ancestor", working_head, current_head],
+            honor_cancel=honor_cancel,
+        )
+        if ancestor.returncode != 0:
+            return False
 
     metadata = sh(
         [
@@ -1390,15 +1303,8 @@ def recover_lane_certification_provenance_drift(
     if _file_snapshot_signature(current_stat) != working_signature:
         return False
 
-    if not _rewrite_verified_bytes_in_place(
-        path,
-        expected=working_bytes,
-        replacement=committed.stdout,
-        expected_signature=working_signature,
-    ):
-        return False
     print(
-        "recovered generated certification provenance drift: "
+        "recognized generated certification provenance drift: "
         f"{LANE_CERTIFICATION_PATH}",
         flush=True,
     )
@@ -1418,17 +1324,22 @@ def clean_main_error(*, honor_cancel: bool = True) -> str | None:
     if status.returncode != 0:
         return "cannot determine worktree status"
     if status.stdout.strip():
-        recovered = recover_lane_certification_provenance_drift(
+        recognized = recover_lane_certification_provenance_drift(
             status.stdout,
             honor_cancel=honor_cancel,
         )
-        if not recovered:
+        if not recognized:
             return "working tree is not clean"
-        status = sh(["git", "status", "--porcelain"], honor_cancel=honor_cancel)
-        if status.returncode != 0:
-            return "cannot determine worktree status after provenance recovery"
-        if status.stdout.strip():
-            return "working tree is not clean after provenance recovery"
+        status_after = sh(
+            ["git", "status", "--porcelain"],
+            honor_cancel=honor_cancel,
+        )
+        if status_after.returncode != 0:
+            return "cannot determine worktree status after provenance recognition"
+        if status_after.stdout.splitlines() != [
+            f" M {LANE_CERTIFICATION_PATH}"
+        ]:
+            return "working tree is not clean after provenance recognition"
     return None
 
 

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -1136,15 +1136,18 @@ def recover_lane_certification_provenance_drift(
     *,
     honor_cancel: bool = True,
 ) -> bool:
-    """Restore exact legacy ``repo_head``-only drift at a sync boundary.
+    """Subtract exact legacy ``repo_head``-only drift at a sync boundary.
 
     ``lane_certification.json`` used to embed the current commit. A pipeline
     refresh therefore dirtied the file as soon as a later commit changed
     ``HEAD``. This recovery is intentionally narrower than the audit generated
-    path allowlist: it accepts one unstaged modified file, verifies that the
-    parsed payload differs from ``HEAD`` only by the obsolete ``repo_head``
-    field, and refuses every staged, untracked, deleted, or content-bearing
-    change.
+    path allowlist: it accepts one unstaged modified file, requires its bytes to
+    be exactly either the committed payload with the obsolete field removed or
+    with that field refreshed to the current commit, and refuses every staged,
+    untracked, deleted, malformed, or content-bearing change. The exact Git
+    patch is reversed instead of restoring the whole file, so an overlapping
+    concurrent write makes the apply fail and a non-overlapping write survives
+    for the post-recovery clean check.
     """
     if status_output.splitlines() != [f" M {LANE_CERTIFICATION_PATH}"]:
         return False
@@ -1158,45 +1161,87 @@ def recover_lane_certification_provenance_drift(
     path = REPO_ROOT / LANE_CERTIFICATION_PATH
     try:
         working_text = path.read_text(encoding="utf-8")
-        committed_payload = json.loads(committed.stdout)
-        working_payload = json.loads(working_text)
-    except (OSError, json.JSONDecodeError):
-        return False
-    if not isinstance(committed_payload, dict) or not isinstance(
-        working_payload, dict
-    ):
-        return False
-    if committed_payload == working_payload:
+    except (OSError, UnicodeError):
         return False
 
-    committed_without_head = dict(committed_payload)
-    working_without_head = dict(working_payload)
-    committed_without_head.pop("repo_head", None)
-    working_head = working_without_head.pop("repo_head", None)
-    if committed_without_head != working_without_head:
+    provenance_pattern = re.compile(
+        r'(?m)^(  "repo_head": ")([0-9a-f]{40})(",)\n'
+    )
+    provenance_matches = list(provenance_pattern.finditer(committed.stdout))
+    if len(provenance_matches) != 1:
         return False
-    if working_head is not None:
-        head = sh(["git", "rev-parse", "HEAD"], honor_cancel=honor_cancel)
-        if head.returncode != 0 or working_head != head.stdout.strip():
-            return False
+    provenance = provenance_matches[0]
+    without_provenance = (
+        committed.stdout[: provenance.start()]
+        + committed.stdout[provenance.end() :]
+    )
+    head = sh(["git", "rev-parse", "HEAD"], honor_cancel=honor_cancel)
+    if head.returncode != 0:
+        return False
+    current_head = head.stdout.strip()
+    with_current_head = (
+        committed.stdout[: provenance.start(2)]
+        + current_head
+        + committed.stdout[provenance.end(2) :]
+    )
+    if working_text not in {without_provenance, with_current_head}:
+        return False
+
+    try:
+        patch = sh(
+            [
+                "git",
+                "diff",
+                "--no-ext-diff",
+                "--no-color",
+                "--binary",
+                "--",
+                LANE_CERTIFICATION_PATH,
+            ],
+            honor_cancel=honor_cancel,
+        )
+    except UnicodeError:
+        return False
+    if patch.returncode != 0 or not patch.stdout:
+        return False
     try:
         if path.read_text(encoding="utf-8") != working_text:
             return False
-    except OSError:
+    except (OSError, UnicodeError):
         return False
 
-    restored = sh(
-        ["git", "restore", "--worktree", "--", LANE_CERTIFICATION_PATH],
-        honor_cancel=honor_cancel,
-    )
-    if restored.returncode != 0:
+    patch_path: Path | None = None
+    try:
+        descriptor, temporary = tempfile.mkstemp(
+            prefix="audit-lane-provenance-",
+            suffix=".patch",
+        )
+        patch_path = Path(temporary)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(patch.stdout)
+        reversed_patch = sh(
+            [
+                "git",
+                "apply",
+                "--reverse",
+                "--whitespace=nowarn",
+                str(patch_path),
+            ],
+            honor_cancel=honor_cancel,
+        )
+        if reversed_patch.returncode != 0:
+            return False
+        print(
+            "recovered generated certification provenance drift: "
+            f"{LANE_CERTIFICATION_PATH}",
+            flush=True,
+        )
+        return True
+    except OSError:
         return False
-    print(
-        "recovered generated certification provenance drift: "
-        f"{LANE_CERTIFICATION_PATH}",
-        flush=True,
-    )
-    return True
+    finally:
+        if patch_path is not None:
+            patch_path.unlink(missing_ok=True)
 
 
 def clean_main_error(*, honor_cancel: bool = True) -> str | None:

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -159,16 +159,21 @@ def sh(
     timeout: int | None = 120,
     *,
     honor_cancel: bool = True,
+    text: bool = True,
 ) -> subprocess.CompletedProcess:
+    empty = "" if text else b""
+    cancelled_message = (
+        "cancelled before launch" if text else b"cancelled before launch"
+    )
     cancel_event = _command_cancel_event() if honor_cancel else None
     if cancel_event is not None and cancel_event.is_set():
-        return subprocess.CompletedProcess(cmd, 125, "", "cancelled before launch")
+        return subprocess.CompletedProcess(cmd, 125, empty, cancelled_message)
     proc = subprocess.Popen(
         cmd,
         cwd=REPO_ROOT,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
+        text=text,
         start_new_session=True,
     )
     deadline = time.monotonic() + timeout if timeout is not None else None
@@ -178,8 +183,13 @@ def sh(
         try:
             stdout, stderr = proc.communicate(timeout=poll_window)
             if cancel_event is not None and cancel_event.is_set():
+                message = (
+                    "cancelled during command"
+                    if text
+                    else b"cancelled during command"
+                )
                 return subprocess.CompletedProcess(
-                    cmd, 125, stdout or "", stderr or "cancelled during command"
+                    cmd, 125, stdout or empty, stderr or message
                 )
             return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
         except subprocess.TimeoutExpired:
@@ -205,8 +215,10 @@ def sh(
                 pass
             stdout, stderr = proc.communicate()
         reason = "cancelled" if cancelled else f"timed out after {timeout}s"
+        if not text:
+            reason = reason.encode("utf-8")
         return subprocess.CompletedProcess(
-            cmd, 125 if cancelled else 124, stdout or "", stderr or reason
+            cmd, 125 if cancelled else 124, stdout or empty, stderr or reason
         )
 
 
@@ -1144,10 +1156,10 @@ def recover_lane_certification_provenance_drift(
     path allowlist: it accepts one unstaged modified file, requires its bytes to
     be exactly either the committed payload with the obsolete field removed or
     with that field refreshed to the current commit, and refuses every staged,
-    untracked, deleted, malformed, or content-bearing change. The exact Git
-    patch is reversed instead of restoring the whole file, so an overlapping
-    concurrent write makes the apply fail and a non-overlapping write survives
-    for the post-recovery clean check.
+    untracked, deleted, malformed, metadata, or content-bearing change. The
+    verified content-only Git patch is reversed instead of restoring the whole
+    file, so an overlapping concurrent write makes the apply fail and a
+    non-overlapping write survives for the post-recovery clean check.
     """
     if status_output.splitlines() != [f" M {LANE_CERTIFICATION_PATH}"]:
         return False
@@ -1155,17 +1167,18 @@ def recover_lane_certification_provenance_drift(
     committed = sh(
         ["git", "show", f"HEAD:{LANE_CERTIFICATION_PATH}"],
         honor_cancel=honor_cancel,
+        text=False,
     )
     if committed.returncode != 0:
         return False
     path = REPO_ROOT / LANE_CERTIFICATION_PATH
     try:
-        working_text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeError):
+        working_bytes = path.read_bytes()
+    except OSError:
         return False
 
     provenance_pattern = re.compile(
-        r'(?m)^(  "repo_head": ")([0-9a-f]{40})(",)\n'
+        rb'(?m)^(  "repo_head": ")([0-9a-f]{40})(",)(\r?\n)'
     )
     provenance_matches = list(provenance_pattern.finditer(committed.stdout))
     if len(provenance_matches) != 1:
@@ -1179,35 +1192,75 @@ def recover_lane_certification_provenance_drift(
     if head.returncode != 0:
         return False
     current_head = head.stdout.strip()
+    if re.fullmatch(r"[0-9a-f]{40}", current_head) is None:
+        return False
+    current_head_bytes = current_head.encode("ascii")
     with_current_head = (
         committed.stdout[: provenance.start(2)]
-        + current_head
+        + current_head_bytes
         + committed.stdout[provenance.end(2) :]
     )
-    if working_text not in {without_provenance, with_current_head}:
+    if working_bytes not in {without_provenance, with_current_head}:
         return False
 
-    try:
-        patch = sh(
-            [
-                "git",
-                "diff",
-                "--no-ext-diff",
-                "--no-color",
-                "--binary",
-                "--",
-                LANE_CERTIFICATION_PATH,
-            ],
-            honor_cancel=honor_cancel,
-        )
-    except UnicodeError:
+    metadata = sh(
+        [
+            "git",
+            "diff",
+            "--no-ext-diff",
+            "--no-color",
+            "--summary",
+            "--",
+            LANE_CERTIFICATION_PATH,
+        ],
+        honor_cancel=honor_cancel,
+    )
+    if metadata.returncode != 0 or metadata.stdout.strip():
         return False
+
+    patch = sh(
+        [
+            "git",
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-color",
+            "--binary",
+            "--",
+            LANE_CERTIFICATION_PATH,
+        ],
+        honor_cancel=honor_cancel,
+        text=False,
+    )
     if patch.returncode != 0 or not patch.stdout:
         return False
+    forbidden_patch_markers = (
+        b"old mode ",
+        b"new mode ",
+        b"new file mode ",
+        b"deleted file mode ",
+        b"GIT binary patch",
+    )
+    if any(marker in patch.stdout for marker in forbidden_patch_markers):
+        return False
+    metadata = sh(
+        [
+            "git",
+            "diff",
+            "--no-ext-diff",
+            "--no-color",
+            "--summary",
+            "--",
+            LANE_CERTIFICATION_PATH,
+        ],
+        honor_cancel=honor_cancel,
+    )
+    if metadata.returncode != 0 or metadata.stdout.strip():
+        return False
     try:
-        if path.read_text(encoding="utf-8") != working_text:
+        if path.read_bytes() != working_bytes:
             return False
-    except (OSError, UnicodeError):
+    except OSError:
         return False
 
     patch_path: Path | None = None
@@ -1217,7 +1270,7 @@ def recover_lane_certification_provenance_drift(
             suffix=".patch",
         )
         patch_path = Path(temporary)
-        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        with os.fdopen(descriptor, "wb") as handle:
             handle.write(patch.stdout)
         reversed_patch = sh(
             [

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -26,6 +26,7 @@ import queue
 import re
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -1157,9 +1158,11 @@ def recover_lane_certification_provenance_drift(
     be exactly either the committed payload with the obsolete field removed or
     with that field refreshed to the current commit, and refuses every staged,
     untracked, deleted, malformed, metadata, or content-bearing change. The
-    verified content-only Git patch is reversed instead of restoring the whole
-    file, so an overlapping concurrent write makes the apply fail and a
-    non-overlapping write survives for the post-recovery clean check.
+    verified content-only Git patch is reversed as raw bytes instead of through
+    Git's working-tree conversion or by restoring the whole file. Exact mode
+    bits are checked across the reversal, an overlapping concurrent write makes
+    the patch fail, and a non-overlapping write survives for the post-recovery
+    clean check.
     """
     if status_output.splitlines() != [f" M {LANE_CERTIFICATION_PATH}"]:
         return False
@@ -1174,8 +1177,20 @@ def recover_lane_certification_provenance_drift(
     path = REPO_ROOT / LANE_CERTIFICATION_PATH
     try:
         working_bytes = path.read_bytes()
+        working_stat = path.lstat()
     except OSError:
         return False
+    if not stat.S_ISREG(working_stat.st_mode):
+        return False
+    working_mode = stat.S_IMODE(working_stat.st_mode)
+    working_signature = (
+        working_stat.st_dev,
+        working_stat.st_ino,
+        working_stat.st_size,
+        working_stat.st_mtime_ns,
+        working_stat.st_ctime_ns,
+        working_mode,
+    )
 
     provenance_pattern = re.compile(
         rb'(?m)^(  "repo_head": ")([0-9a-f]{40})(",)(\r?\n)'
@@ -1260,7 +1275,20 @@ def recover_lane_certification_provenance_drift(
     try:
         if path.read_bytes() != working_bytes:
             return False
+        current_stat = path.lstat()
     except OSError:
+        return False
+    current_signature = (
+        current_stat.st_dev,
+        current_stat.st_ino,
+        current_stat.st_size,
+        current_stat.st_mtime_ns,
+        current_stat.st_ctime_ns,
+        stat.S_IMODE(current_stat.st_mode),
+    )
+    if not stat.S_ISREG(current_stat.st_mode):
+        return False
+    if current_signature != working_signature:
         return False
 
     patch_path: Path | None = None
@@ -1274,15 +1302,30 @@ def recover_lane_certification_provenance_drift(
             handle.write(patch.stdout)
         reversed_patch = sh(
             [
-                "git",
-                "apply",
-                "--reverse",
-                "--whitespace=nowarn",
+                "patch",
+                "-R",
+                "-p1",
+                "-f",
+                "-s",
+                "-r",
+                os.devnull,
+                "-i",
                 str(patch_path),
             ],
             honor_cancel=honor_cancel,
         )
         if reversed_patch.returncode != 0:
+            return False
+        try:
+            final_bytes = path.read_bytes()
+            final_stat = path.lstat()
+        except OSError:
+            return False
+        if final_bytes != committed.stdout:
+            return False
+        if not stat.S_ISREG(final_stat.st_mode):
+            return False
+        if stat.S_IMODE(final_stat.st_mode) != working_mode:
             return False
         print(
             "recovered generated certification provenance drift: "

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -1196,6 +1196,10 @@ def recover_lane_certification_provenance_drift(
         return False
     if not stat.S_ISREG(working_stat.st_mode):
         return False
+    if stat.S_IMODE(working_stat.st_mode) != 0o644:
+        return False
+    if working_stat.st_nlink != 1:
+        return False
     working_signature = _file_snapshot_signature(working_stat)
 
     provenance_pattern = re.compile(
@@ -1324,6 +1328,14 @@ def clean_main_error(*, honor_cancel: bool = True) -> str | None:
     if status.returncode != 0:
         return "cannot determine worktree status"
     if status.stdout.strip():
+        path = REPO_ROOT / LANE_CERTIFICATION_PATH
+        try:
+            recognition_snapshot = (
+                path.read_bytes(),
+                _file_snapshot_signature(path.lstat()),
+            )
+        except OSError:
+            return "working tree is not clean"
         recognized = recover_lane_certification_provenance_drift(
             status.stdout,
             honor_cancel=honor_cancel,
@@ -1339,6 +1351,15 @@ def clean_main_error(*, honor_cancel: bool = True) -> str | None:
         if status_after.stdout.splitlines() != [
             f" M {LANE_CERTIFICATION_PATH}"
         ]:
+            return "working tree is not clean after provenance recognition"
+        try:
+            stable_snapshot = (
+                path.read_bytes(),
+                _file_snapshot_signature(path.lstat()),
+            )
+        except OSError:
+            return "working tree is not clean after provenance recognition"
+        if stable_snapshot != recognition_snapshot:
             return "working tree is not clean after provenance recognition"
     return None
 

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -85,6 +85,7 @@ PACKET_COMPLETION_POLL_SECONDS = 15
 PACKET_COMPLETION_EXIT_GRACE_SECONDS = 10
 COMMAND_TERMINATION_GRACE_SECONDS = 5
 INHERITED_DRAIN_LOCK_FD_ENV = "AUDIT_DRAIN_LOCK_FD"
+LANE_CERTIFICATION_PATH = "docs/audit/data/lane_certification.json"
 
 
 def _repo_identity() -> str:
@@ -1130,6 +1131,74 @@ def finalize_worker(job: dict) -> tuple[dict | None, dict]:
     return envelope, result
 
 
+def recover_lane_certification_provenance_drift(
+    status_output: str,
+    *,
+    honor_cancel: bool = True,
+) -> bool:
+    """Restore exact legacy ``repo_head``-only drift at a sync boundary.
+
+    ``lane_certification.json`` used to embed the current commit. A pipeline
+    refresh therefore dirtied the file as soon as a later commit changed
+    ``HEAD``. This recovery is intentionally narrower than the audit generated
+    path allowlist: it accepts one unstaged modified file, verifies that the
+    parsed payload differs from ``HEAD`` only by the obsolete ``repo_head``
+    field, and refuses every staged, untracked, deleted, or content-bearing
+    change.
+    """
+    if status_output.splitlines() != [f" M {LANE_CERTIFICATION_PATH}"]:
+        return False
+
+    committed = sh(
+        ["git", "show", f"HEAD:{LANE_CERTIFICATION_PATH}"],
+        honor_cancel=honor_cancel,
+    )
+    if committed.returncode != 0:
+        return False
+    path = REPO_ROOT / LANE_CERTIFICATION_PATH
+    try:
+        working_text = path.read_text(encoding="utf-8")
+        committed_payload = json.loads(committed.stdout)
+        working_payload = json.loads(working_text)
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(committed_payload, dict) or not isinstance(
+        working_payload, dict
+    ):
+        return False
+    if committed_payload == working_payload:
+        return False
+
+    committed_without_head = dict(committed_payload)
+    working_without_head = dict(working_payload)
+    committed_without_head.pop("repo_head", None)
+    working_head = working_without_head.pop("repo_head", None)
+    if committed_without_head != working_without_head:
+        return False
+    if working_head is not None:
+        head = sh(["git", "rev-parse", "HEAD"], honor_cancel=honor_cancel)
+        if head.returncode != 0 or working_head != head.stdout.strip():
+            return False
+    try:
+        if path.read_text(encoding="utf-8") != working_text:
+            return False
+    except OSError:
+        return False
+
+    restored = sh(
+        ["git", "restore", "--worktree", "--", LANE_CERTIFICATION_PATH],
+        honor_cancel=honor_cancel,
+    )
+    if restored.returncode != 0:
+        return False
+    print(
+        "recovered generated certification provenance drift: "
+        f"{LANE_CERTIFICATION_PATH}",
+        flush=True,
+    )
+    return True
+
+
 def clean_main_error(*, honor_cancel: bool = True) -> str | None:
     branch = sh(
         ["git", "rev-parse", "--abbrev-ref", "HEAD"],
@@ -1143,7 +1212,17 @@ def clean_main_error(*, honor_cancel: bool = True) -> str | None:
     if status.returncode != 0:
         return "cannot determine worktree status"
     if status.stdout.strip():
-        return "working tree is not clean"
+        recovered = recover_lane_certification_provenance_drift(
+            status.stdout,
+            honor_cancel=honor_cancel,
+        )
+        if not recovered:
+            return "working tree is not clean"
+        status = sh(["git", "status", "--porcelain"], honor_cancel=honor_cancel)
+        if status.returncode != 0:
+            return "cannot determine worktree status after provenance recovery"
+        if status.stdout.strip():
+            return "working tree is not clean after provenance recovery"
     return None
 
 

--- a/docs/audit/scripts/static_pipeline_checkpoint.py
+++ b/docs/audit/scripts/static_pipeline_checkpoint.py
@@ -191,14 +191,21 @@ def verdict_generated_path(path: str) -> bool:
     )
 
 
+def cache_hash(name: str) -> tuple[str | None, str]:
+    try:
+        digest = hashlib.sha256((DATA / name).read_bytes()).hexdigest()
+    except OSError as exc:
+        return None, f"cannot hash required cache {name}: {exc}"
+    return digest, f"{name} hashed"
+
+
 def cache_hashes() -> tuple[dict[str, str] | None, str]:
     hashes = {}
     for name in STATIC_CACHE_NAMES:
-        path = DATA / name
-        try:
-            hashes[name] = hashlib.sha256(path.read_bytes()).hexdigest()
-        except OSError as exc:
-            return None, f"cannot hash required cache {name}: {exc}"
+        digest, detail = cache_hash(name)
+        if digest is None:
+            return None, detail
+        hashes[name] = digest
     return hashes, "static caches hashed"
 
 
@@ -568,15 +575,15 @@ def prepare_checkpoint() -> tuple[bool, str]:
         return False, detail
     if seed_receipt.get("input_sha256") != static_fingerprint:
         return False, "seed producer receipt has different classifier inputs"
-    hashes, detail = cache_hashes()
-    if hashes is None:
+    citation_graph_hash, detail = cache_hash("citation_graph.json")
+    if citation_graph_hash is None:
         return False, detail
-    if graph_receipt.get("output_sha256") != hashes["citation_graph.json"]:
+    if graph_receipt.get("output_sha256") != citation_graph_hash:
         return False, "citation graph differs from its producer receipt"
     payload = {
         **checkpoint,
         "schema": PREPARED_SCHEMA,
-        "citation_graph_sha256": hashes["citation_graph.json"],
+        "citation_graph_sha256": citation_graph_hash,
         "static_input_sha256": static_fingerprint,
     }
     ok, detail = _write_checkpoint(payload)

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -214,7 +214,7 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         self.assertEqual(self.path.read_bytes(), before)
         self.assertEqual(stat.S_IMODE(self.path.stat().st_mode), before_mode)
 
-    def test_clean_main_recovers_without_normalizing_untracked_mode_bits(self):
+    def test_clean_main_refuses_noncanonical_mode_bits_without_mutation(self):
         for mode in (0o444, 0o600, 0o664, 0o2644, 0o4644):
             with self.subTest(mode=oct(mode)):
                 self.path.chmod(0o644)
@@ -224,16 +224,12 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
 
                 error = self._clean_main_error()
 
-                self.assertIsNone(error)
+                self.assertEqual(error, "working tree is not clean")
                 self.assertEqual(self.path.read_bytes(), before)
                 self.assertEqual(stat.S_IMODE(self.path.stat().st_mode), mode)
 
-    def test_clean_main_recovers_in_place_with_hardlink_and_xattr(self):
+    def test_clean_main_recognition_preserves_xattr(self):
         self._refresh()
-        outside = self.root.parent / f"{self.root.name}-certification-hardlink"
-        outside.unlink(missing_ok=True)
-        os.link(self.path, outside)
-        self.addCleanup(outside.unlink, missing_ok=True)
         before_inode = self.path.stat().st_ino
         before_bytes = self.path.read_bytes()
         xattr_name = "user.audit-recovery-test"
@@ -249,9 +245,7 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
 
         self.assertIsNone(error)
         self.assertEqual(self.path.stat().st_ino, before_inode)
-        self.assertEqual(outside.stat().st_ino, before_inode)
         self.assertEqual(self.path.read_bytes(), before_bytes)
-        self.assertEqual(outside.read_bytes(), before_bytes)
         if hasattr(os, "getxattr"):
             self.assertEqual(os.getxattr(self.path, xattr_name), xattr_value)
         elif xattr_command is not None:
@@ -262,6 +256,23 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
                 text=True,
             ).stdout.strip()
             self.assertEqual(value, xattr_value.decode())
+
+    def test_clean_main_refuses_hardlink_without_mutation(self):
+        self._refresh()
+        before = self.path.read_bytes()
+        outside = self.root.parent / f"{self.root.name}-certification-hardlink"
+        outside.unlink(missing_ok=True)
+        os.link(self.path, outside)
+        self.addCleanup(outside.unlink, missing_ok=True)
+        before_inode = self.path.stat().st_ino
+
+        error = self._clean_main_error()
+
+        self.assertEqual(error, "working tree is not clean")
+        self.assertEqual(self.path.stat().st_ino, before_inode)
+        self.assertEqual(outside.stat().st_ino, before_inode)
+        self.assertEqual(self.path.read_bytes(), before)
+        self.assertEqual(outside.read_bytes(), before)
 
     def test_clean_main_refuses_payload_drift(self):
         refreshed = dict(
@@ -415,13 +426,13 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         raced_text = json.dumps(raced, indent=2, sort_keys=True) + "\n"
         original_sh = batch.sh
         injected = False
-        summary_calls = 0
+        status_calls = 0
 
         def racing_sh(cmd, timeout=120, *, honor_cancel=True, text=True):
-            nonlocal injected, summary_calls
-            if cmd[:2] == ["git", "diff"] and "--summary" in cmd:
-                summary_calls += 1
-            if summary_calls == 2 and not injected:
+            nonlocal injected, status_calls
+            if cmd == ["git", "status", "--porcelain"]:
+                status_calls += 1
+            if status_calls == 2 and not injected:
                 injected = True
                 self.path.write_text(raced_text, encoding="utf-8")
             return original_sh(
@@ -439,7 +450,10 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
             error = batch.clean_main_error()
 
         self.assertTrue(injected)
-        self.assertIsNotNone(error)
+        self.assertEqual(
+            error,
+            "working tree is not clean after provenance recognition",
+        )
         after = json.loads(self.path.read_text(encoding="utf-8"))
         self.assertEqual(
             after["lanes"][0]["blocking"],
@@ -497,13 +511,13 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
                 before_bytes = self.path.read_bytes()
                 original_sh = batch.sh
                 injected = False
-                summary_calls = 0
+                status_calls = 0
 
                 def racing_sh(cmd, timeout=120, *, honor_cancel=True, text=True):
-                    nonlocal injected, summary_calls
-                    if cmd[:2] == ["git", "diff"] and "--summary" in cmd:
-                        summary_calls += 1
-                    if summary_calls == 2 and not injected:
+                    nonlocal injected, status_calls
+                    if cmd == ["git", "status", "--porcelain"]:
+                        status_calls += 1
+                    if status_calls == 2 and not injected:
                         injected = True
                         self.path.chmod(concurrent_mode)
                     return original_sh(
@@ -525,7 +539,10 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
                     error = batch.clean_main_error()
 
                 self.assertTrue(injected)
-                self.assertEqual(error, "working tree is not clean")
+                self.assertEqual(
+                    error,
+                    "working tree is not clean after provenance recognition",
+                )
                 self.assertEqual(self.path.read_bytes(), before_bytes)
                 self.assertEqual(
                     stat.S_IMODE(self.path.stat().st_mode),

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -67,6 +67,14 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
             text=True,
         ).stdout.strip()
 
+    def _git_bytes(self, *args: str) -> bytes:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.root,
+            check=True,
+            capture_output=True,
+        ).stdout
+
     def _write(self, payload: dict) -> None:
         self.path.write_text(
             json.dumps(payload, indent=2, sort_keys=True) + "\n",
@@ -99,6 +107,53 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         self.assertIsNone(error)
         self.assertEqual(json.loads(self.path.read_text()), self.payload)
         self.assertEqual(self._git("status", "--porcelain"), "")
+
+    def test_clean_main_recovers_without_autocrlf_conversion(self):
+        self._git("config", "core.autocrlf", "true")
+        self._refresh()
+        before_mode = stat.S_IMODE(self.path.stat().st_mode)
+
+        error = self._clean_main_error()
+
+        self.assertIsNone(error)
+        self.assertEqual(
+            self.path.read_bytes(),
+            self._git_bytes("show", f"HEAD:{batch.LANE_CERTIFICATION_PATH}"),
+        )
+        self.assertEqual(stat.S_IMODE(self.path.stat().st_mode), before_mode)
+
+    def test_clean_main_recovers_without_attribute_eol_conversion(self):
+        attributes = self.root / ".gitattributes"
+        attributes.write_text("*.json text eol=crlf\n", encoding="utf-8")
+        self._git("add", ".gitattributes")
+        self._git("commit", "-q", "--amend", "--no-edit")
+        self._refresh()
+        before_mode = stat.S_IMODE(self.path.stat().st_mode)
+
+        error = self._clean_main_error()
+
+        self.assertIsNone(error)
+        self.assertEqual(
+            self.path.read_bytes(),
+            self._git_bytes("show", f"HEAD:{batch.LANE_CERTIFICATION_PATH}"),
+        )
+        self.assertEqual(stat.S_IMODE(self.path.stat().st_mode), before_mode)
+
+    def test_clean_main_recovers_without_normalizing_untracked_mode_bits(self):
+        for mode in (0o600, 0o664):
+            with self.subTest(mode=oct(mode)):
+                self._refresh()
+                self.path.chmod(mode)
+                committed = self._git_bytes(
+                    "show",
+                    f"HEAD:{batch.LANE_CERTIFICATION_PATH}",
+                )
+
+                error = self._clean_main_error()
+
+                self.assertIsNone(error)
+                self.assertEqual(self.path.read_bytes(), committed)
+                self.assertEqual(stat.S_IMODE(self.path.stat().st_mode), mode)
 
     def test_clean_main_refuses_payload_drift(self):
         refreshed = dict(
@@ -255,7 +310,7 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
 
         def racing_sh(cmd, timeout=120, *, honor_cancel=True, text=True):
             nonlocal injected
-            if cmd[:3] == ["git", "apply", "--reverse"] and not injected:
+            if cmd[:2] == ["patch", "-R"] and not injected:
                 injected = True
                 self.path.write_text(raced_text, encoding="utf-8")
             return original_sh(
@@ -319,6 +374,51 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
             json.loads(self.path.read_text(encoding="utf-8"))["repo_head"],
             self._git("rev-parse", "HEAD"),
         )
+
+    def test_late_concurrent_mode_change_survives_raw_patch(self):
+        for concurrent_mode in (0o600, 0o744):
+            with self.subTest(concurrent_mode=oct(concurrent_mode)):
+                self.path.chmod(0o644)
+                self._refresh()
+                original_sh = batch.sh
+                injected = False
+
+                def racing_sh(cmd, timeout=120, *, honor_cancel=True, text=True):
+                    nonlocal injected
+                    if cmd[:2] == ["patch", "-R"] and not injected:
+                        injected = True
+                        self.path.chmod(concurrent_mode)
+                    return original_sh(
+                        cmd,
+                        timeout=timeout,
+                        honor_cancel=honor_cancel,
+                        text=text,
+                    )
+
+                with mock.patch.object(
+                    batch,
+                    "REPO_ROOT",
+                    self.root,
+                ), mock.patch.object(
+                    batch,
+                    "sh",
+                    side_effect=racing_sh,
+                ):
+                    error = batch.clean_main_error()
+
+                self.assertTrue(injected)
+                self.assertEqual(error, "working tree is not clean")
+                self.assertEqual(
+                    self.path.read_bytes(),
+                    self._git_bytes(
+                        "show",
+                        f"HEAD:{batch.LANE_CERTIFICATION_PATH}",
+                    ),
+                )
+                self.assertEqual(
+                    stat.S_IMODE(self.path.stat().st_mode),
+                    concurrent_mode,
+                )
 
 
 def _args() -> argparse.Namespace:

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -274,6 +274,43 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         self.assertEqual(self.path.read_bytes(), before)
         self.assertEqual(outside.read_bytes(), before)
 
+    @unittest.skipUnless(sys.platform == "darwin", "macOS ACL semantics")
+    def test_clean_main_refuses_acl_denied_write_without_mutation(self):
+        self._refresh()
+        before = self.path.read_bytes()
+        subprocess.run(
+            ["chmod", "+a", "everyone deny write", str(self.path)],
+            check=True,
+        )
+        try:
+            error = self._clean_main_error()
+        finally:
+            subprocess.run(
+                ["chmod", "-a#", "0", str(self.path)],
+                check=True,
+            )
+
+        self.assertEqual(error, "working tree is not clean")
+        self.assertEqual(self.path.read_bytes(), before)
+        self.assertEqual(stat.S_IMODE(self.path.stat().st_mode), 0o644)
+
+    @unittest.skipUnless(
+        hasattr(os, "chflags") and hasattr(stat, "UF_IMMUTABLE"),
+        "immutable file flags unavailable",
+    )
+    def test_clean_main_refuses_immutable_flag_without_mutation(self):
+        self._refresh()
+        before = self.path.read_bytes()
+        os.chflags(self.path, stat.UF_IMMUTABLE)
+        try:
+            error = self._clean_main_error()
+        finally:
+            os.chflags(self.path, 0)
+
+        self.assertEqual(error, "working tree is not clean")
+        self.assertEqual(self.path.read_bytes(), before)
+        self.assertEqual(stat.S_IMODE(self.path.stat().st_mode), 0o644)
+
     def test_clean_main_refuses_payload_drift(self):
         refreshed = dict(
             self.payload,

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -93,34 +93,110 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
 
     def test_clean_main_recovers_current_head_only_refresh(self):
         self._refresh()
+        before = self.path.read_bytes()
         error = self._clean_main_error()
 
         self.assertIsNone(error)
-        self.assertEqual(json.loads(self.path.read_text()), self.payload)
-        self.assertEqual(self._git("status", "--porcelain"), "")
+        self.assertEqual(self.path.read_bytes(), before)
+        self.assertEqual(
+            self._git("status", "--porcelain"),
+            f"M {batch.LANE_CERTIFICATION_PATH}",
+        )
+
+    def test_clean_main_recognizes_refresh_from_ancestor_head(self):
+        self._refresh()
+        before = self.path.read_bytes()
+        self.source.write_text("later source commit\n", encoding="utf-8")
+        self._git("add", str(self.source.relative_to(self.root)))
+        self._git("commit", "-q", "-m", "move head")
+
+        error = self._clean_main_error()
+
+        self.assertIsNone(error)
+        self.assertEqual(self.path.read_bytes(), before)
+        self.assertEqual(
+            self._git("status", "--porcelain"),
+            f"M {batch.LANE_CERTIFICATION_PATH}",
+        )
+
+    def test_sync_origin_main_fast_forwards_with_recognized_drift(self):
+        with tempfile.TemporaryDirectory() as transport:
+            transport_root = Path(transport)
+            remote = transport_root / "remote.git"
+            other = transport_root / "other"
+            subprocess.run(
+                ["git", "init", "-q", "--bare", "-b", "main", str(remote)],
+                check=True,
+            )
+            self._git("remote", "add", "origin", str(remote))
+            self._git("push", "-q", "-u", "origin", "main")
+            self._refresh()
+            before = self.path.read_bytes()
+            subprocess.run(
+                ["git", "clone", "-q", str(remote), str(other)],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.email", "peer@example.invalid"],
+                cwd=other,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Peer"],
+                cwd=other,
+                check=True,
+            )
+            peer_source = other / "docs" / "SOURCE.md"
+            peer_source.write_text("remote advance\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "docs/SOURCE.md"],
+                cwd=other,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "commit", "-q", "-m", "advance remote"],
+                cwd=other,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "push", "-q", "origin", "main"],
+                cwd=other,
+                check=True,
+            )
+
+            with mock.patch.object(batch, "REPO_ROOT", self.root):
+                synced, detail = batch.sync_origin_main()
+                clean_error = batch.clean_main_error()
+
+            self.assertTrue(synced, detail)
+            self.assertIsNone(clean_error)
+            self.assertEqual(self.path.read_bytes(), before)
+            self.assertEqual(self._git("rev-parse", "HEAD"), detail)
 
     def test_clean_main_recovers_obsolete_field_removal(self):
         refreshed = dict(self.payload)
         refreshed.pop("repo_head")
         self._write(refreshed)
+        before = self.path.read_bytes()
         error = self._clean_main_error()
 
         self.assertIsNone(error)
-        self.assertEqual(json.loads(self.path.read_text()), self.payload)
-        self.assertEqual(self._git("status", "--porcelain"), "")
+        self.assertEqual(self.path.read_bytes(), before)
+        self.assertEqual(
+            self._git("status", "--porcelain"),
+            f"M {batch.LANE_CERTIFICATION_PATH}",
+        )
 
     def test_clean_main_recovers_without_autocrlf_conversion(self):
         self._git("config", "core.autocrlf", "true")
         self._refresh()
+        before = self.path.read_bytes()
         before_mode = stat.S_IMODE(self.path.stat().st_mode)
 
         error = self._clean_main_error()
 
         self.assertIsNone(error)
-        self.assertEqual(
-            self.path.read_bytes(),
-            self._git_bytes("show", f"HEAD:{batch.LANE_CERTIFICATION_PATH}"),
-        )
+        self.assertEqual(self.path.read_bytes(), before)
         self.assertEqual(stat.S_IMODE(self.path.stat().st_mode), before_mode)
 
     def test_clean_main_recovers_without_attribute_eol_conversion(self):
@@ -129,31 +205,27 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         self._git("add", ".gitattributes")
         self._git("commit", "-q", "--amend", "--no-edit")
         self._refresh()
+        before = self.path.read_bytes()
         before_mode = stat.S_IMODE(self.path.stat().st_mode)
 
         error = self._clean_main_error()
 
         self.assertIsNone(error)
-        self.assertEqual(
-            self.path.read_bytes(),
-            self._git_bytes("show", f"HEAD:{batch.LANE_CERTIFICATION_PATH}"),
-        )
+        self.assertEqual(self.path.read_bytes(), before)
         self.assertEqual(stat.S_IMODE(self.path.stat().st_mode), before_mode)
 
     def test_clean_main_recovers_without_normalizing_untracked_mode_bits(self):
-        for mode in (0o600, 0o664):
+        for mode in (0o444, 0o600, 0o664, 0o2644, 0o4644):
             with self.subTest(mode=oct(mode)):
+                self.path.chmod(0o644)
                 self._refresh()
                 self.path.chmod(mode)
-                committed = self._git_bytes(
-                    "show",
-                    f"HEAD:{batch.LANE_CERTIFICATION_PATH}",
-                )
+                before = self.path.read_bytes()
 
                 error = self._clean_main_error()
 
                 self.assertIsNone(error)
-                self.assertEqual(self.path.read_bytes(), committed)
+                self.assertEqual(self.path.read_bytes(), before)
                 self.assertEqual(stat.S_IMODE(self.path.stat().st_mode), mode)
 
     def test_clean_main_recovers_in_place_with_hardlink_and_xattr(self):
@@ -163,6 +235,7 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         os.link(self.path, outside)
         self.addCleanup(outside.unlink, missing_ok=True)
         before_inode = self.path.stat().st_ino
+        before_bytes = self.path.read_bytes()
         xattr_name = "user.audit-recovery-test"
         xattr_value = b"preserve-me"
         xattr_command: list[str] | None = None
@@ -174,15 +247,11 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
 
         error = self._clean_main_error()
 
-        committed = self._git_bytes(
-            "show",
-            f"HEAD:{batch.LANE_CERTIFICATION_PATH}",
-        )
         self.assertIsNone(error)
         self.assertEqual(self.path.stat().st_ino, before_inode)
         self.assertEqual(outside.stat().st_ino, before_inode)
-        self.assertEqual(self.path.read_bytes(), committed)
-        self.assertEqual(outside.read_bytes(), committed)
+        self.assertEqual(self.path.read_bytes(), before_bytes)
+        self.assertEqual(outside.read_bytes(), before_bytes)
         if hasattr(os, "getxattr"):
             self.assertEqual(os.getxattr(self.path, xattr_name), xattr_value)
         elif xattr_command is not None:
@@ -339,30 +408,33 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         self.assertEqual(error, "working tree is not clean")
         self.assertFalse(self.path.exists())
 
-    def test_concurrent_same_file_edit_survives_reverse_patch(self):
+    def test_concurrent_same_file_edit_survives_recognition(self):
         refreshed = self._refresh()
         raced = json.loads(json.dumps(refreshed))
         raced["lanes"][0]["blocking"] = ["concurrent-user-work"]
         raced_text = json.dumps(raced, indent=2, sort_keys=True) + "\n"
-        original_rewrite = batch._rewrite_verified_bytes_in_place
+        original_sh = batch.sh
         injected = False
+        summary_calls = 0
 
-        def racing_rewrite(path, *, expected, replacement, expected_signature):
-            nonlocal injected
-            if not injected:
+        def racing_sh(cmd, timeout=120, *, honor_cancel=True, text=True):
+            nonlocal injected, summary_calls
+            if cmd[:2] == ["git", "diff"] and "--summary" in cmd:
+                summary_calls += 1
+            if summary_calls == 2 and not injected:
                 injected = True
                 self.path.write_text(raced_text, encoding="utf-8")
-            return original_rewrite(
-                path,
-                expected=expected,
-                replacement=replacement,
-                expected_signature=expected_signature,
+            return original_sh(
+                cmd,
+                timeout=timeout,
+                honor_cancel=honor_cancel,
+                text=text,
             )
 
         with mock.patch.object(batch, "REPO_ROOT", self.root), mock.patch.object(
             batch,
-            "_rewrite_verified_bytes_in_place",
-            side_effect=racing_rewrite,
+            "sh",
+            side_effect=racing_sh,
         ):
             error = batch.clean_main_error()
 
@@ -417,31 +489,28 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
             self._git("rev-parse", "HEAD"),
         )
 
-    def test_late_concurrent_mode_change_survives_in_place_rewrite(self):
+    def test_late_concurrent_mode_change_survives_recognition(self):
         for concurrent_mode in (0o600, 0o744):
             with self.subTest(concurrent_mode=oct(concurrent_mode)):
                 self.path.chmod(0o644)
                 self._refresh()
                 before_bytes = self.path.read_bytes()
-                original_rewrite = batch._rewrite_verified_bytes_in_place
+                original_sh = batch.sh
                 injected = False
+                summary_calls = 0
 
-                def racing_rewrite(
-                    path,
-                    *,
-                    expected,
-                    replacement,
-                    expected_signature,
-                ):
-                    nonlocal injected
-                    if not injected:
+                def racing_sh(cmd, timeout=120, *, honor_cancel=True, text=True):
+                    nonlocal injected, summary_calls
+                    if cmd[:2] == ["git", "diff"] and "--summary" in cmd:
+                        summary_calls += 1
+                    if summary_calls == 2 and not injected:
                         injected = True
                         self.path.chmod(concurrent_mode)
-                    return original_rewrite(
-                        path,
-                        expected=expected,
-                        replacement=replacement,
-                        expected_signature=expected_signature,
+                    return original_sh(
+                        cmd,
+                        timeout=timeout,
+                        honor_cancel=honor_cancel,
+                        text=text,
                     )
 
                 with mock.patch.object(
@@ -450,8 +519,8 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
                     self.root,
                 ), mock.patch.object(
                     batch,
-                    "_rewrite_verified_bytes_in_place",
-                    side_effect=racing_rewrite,
+                    "sh",
+                    side_effect=racing_sh,
                 ):
                     error = batch.clean_main_error()
 
@@ -467,38 +536,77 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         self._refresh()
         neighbor = self.path.with_suffix(self.path.suffix + ".orig")
         user_bytes = b"concurrent user backup\n"
-        original_rewrite = batch._rewrite_verified_bytes_in_place
+        original_sh = batch.sh
         injected = False
+        summary_calls = 0
 
-        def racing_rewrite(path, *, expected, replacement, expected_signature):
-            nonlocal injected
-            if not injected:
+        def racing_sh(cmd, timeout=120, *, honor_cancel=True, text=True):
+            nonlocal injected, summary_calls
+            if cmd[:2] == ["git", "diff"] and "--summary" in cmd:
+                summary_calls += 1
+            if summary_calls == 2 and not injected:
                 injected = True
                 neighbor.write_bytes(user_bytes)
-            return original_rewrite(
-                path,
-                expected=expected,
-                replacement=replacement,
-                expected_signature=expected_signature,
+            return original_sh(
+                cmd,
+                timeout=timeout,
+                honor_cancel=honor_cancel,
+                text=text,
             )
 
         with mock.patch.object(batch, "REPO_ROOT", self.root), mock.patch.object(
             batch,
-            "_rewrite_verified_bytes_in_place",
-            side_effect=racing_rewrite,
+            "sh",
+            side_effect=racing_sh,
         ):
             error = batch.clean_main_error()
 
         self.assertTrue(injected)
         self.assertEqual(
             error,
-            "working tree is not clean after provenance recovery",
+            "working tree is not clean after provenance recognition",
         )
         self.assertEqual(neighbor.read_bytes(), user_bytes)
         self.assertEqual(
-            self.path.read_bytes(),
-            self._git_bytes("show", f"HEAD:{batch.LANE_CERTIFICATION_PATH}"),
+            json.loads(self.path.read_text(encoding="utf-8"))["repo_head"],
+            self._git("rev-parse", "HEAD"),
         )
+
+    def test_late_path_replacement_preserves_both_files(self):
+        self._refresh()
+        before = self.path.read_bytes()
+        moved = self.path.with_suffix(self.path.suffix + ".moved")
+        user_bytes = b"concurrent replacement\n"
+        original_sh = batch.sh
+        injected = False
+        summary_calls = 0
+
+        def racing_sh(cmd, timeout=120, *, honor_cancel=True, text=True):
+            nonlocal injected, summary_calls
+            if cmd[:2] == ["git", "diff"] and "--summary" in cmd:
+                summary_calls += 1
+            if summary_calls == 2 and not injected:
+                injected = True
+                self.path.replace(moved)
+                self.path.write_bytes(user_bytes)
+            return original_sh(
+                cmd,
+                timeout=timeout,
+                honor_cancel=honor_cancel,
+                text=text,
+            )
+
+        with mock.patch.object(batch, "REPO_ROOT", self.root), mock.patch.object(
+            batch,
+            "sh",
+            side_effect=racing_sh,
+        ):
+            error = batch.clean_main_error()
+
+        self.assertTrue(injected)
+        self.assertEqual(error, "working tree is not clean")
+        self.assertEqual(moved.read_bytes(), before)
+        self.assertEqual(self.path.read_bytes(), user_bytes)
 
 
 def _args() -> argparse.Namespace:

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -53,6 +54,7 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         self._git("init", "-q", "-b", "main")
         self._git("config", "user.email", "audit-test@example.invalid")
         self._git("config", "user.name", "Audit Test")
+        self._git("config", "core.filemode", "true")
         self._git("add", ".")
         self._git("commit", "-q", "-m", "baseline")
 
@@ -167,6 +169,44 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
                 self.assertEqual(self.path.read_bytes(), content)
                 self._git("restore", "--worktree", "--", batch.LANE_CERTIFICATION_PATH)
 
+    def test_clean_main_refuses_line_ending_drift(self):
+        self._refresh()
+        content = self.path.read_bytes().replace(b"\n", b"\r\n")
+        self.path.write_bytes(content)
+
+        error = self._clean_main_error()
+
+        self.assertEqual(error, "working tree is not clean")
+        self.assertEqual(self.path.read_bytes(), content)
+
+    def test_clean_main_refuses_committed_crlf_normalization(self):
+        committed = self.path.read_bytes().replace(b"\n", b"\r\n")
+        self.path.write_bytes(committed)
+        self._git("add", batch.LANE_CERTIFICATION_PATH)
+        self._git("commit", "-q", "--amend", "--no-edit")
+        refreshed = dict(self.payload, repo_head=self._git("rev-parse", "HEAD"))
+        normalized = (
+            json.dumps(refreshed, indent=2, sort_keys=True) + "\n"
+        ).encode("utf-8")
+        self.path.write_bytes(normalized)
+
+        error = self._clean_main_error()
+
+        self.assertEqual(error, "working tree is not clean")
+        self.assertEqual(self.path.read_bytes(), normalized)
+
+    def test_clean_main_refuses_preexisting_mode_change(self):
+        self._refresh()
+        self.path.chmod(stat.S_IMODE(self.path.stat().st_mode) | stat.S_IXUSR)
+        before_bytes = self.path.read_bytes()
+        before_mode = stat.S_IMODE(self.path.stat().st_mode)
+
+        error = self._clean_main_error()
+
+        self.assertEqual(error, "working tree is not clean")
+        self.assertEqual(self.path.read_bytes(), before_bytes)
+        self.assertEqual(stat.S_IMODE(self.path.stat().st_mode), before_mode)
+
     def test_clean_main_refuses_untracked_source_ledger_and_mixed_state(self):
         cases = ("untracked", "source", "ledger", "mixed")
         for case in cases:
@@ -213,12 +253,17 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         original_sh = batch.sh
         injected = False
 
-        def racing_sh(cmd, timeout=120, *, honor_cancel=True):
+        def racing_sh(cmd, timeout=120, *, honor_cancel=True, text=True):
             nonlocal injected
             if cmd[:3] == ["git", "apply", "--reverse"] and not injected:
                 injected = True
                 self.path.write_text(raced_text, encoding="utf-8")
-            return original_sh(cmd, timeout=timeout, honor_cancel=honor_cancel)
+            return original_sh(
+                cmd,
+                timeout=timeout,
+                honor_cancel=honor_cancel,
+                text=text,
+            )
 
         with mock.patch.object(batch, "REPO_ROOT", self.root), mock.patch.object(
             batch,
@@ -233,6 +278,46 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         self.assertEqual(
             after["lanes"][0]["blocking"],
             ["concurrent-user-work"],
+        )
+
+    def test_concurrent_mode_change_survives_patch_capture(self):
+        self._refresh()
+        original_sh = batch.sh
+        injected = False
+
+        def racing_sh(cmd, timeout=120, *, honor_cancel=True, text=True):
+            nonlocal injected
+            if (
+                cmd[:2] == ["git", "diff"]
+                and "--binary" in cmd
+                and not injected
+            ):
+                injected = True
+                mode = stat.S_IMODE(self.path.stat().st_mode)
+                self.path.chmod(mode | stat.S_IXUSR)
+            return original_sh(
+                cmd,
+                timeout=timeout,
+                honor_cancel=honor_cancel,
+                text=text,
+            )
+
+        with mock.patch.object(batch, "REPO_ROOT", self.root), mock.patch.object(
+            batch,
+            "sh",
+            side_effect=racing_sh,
+        ):
+            error = batch.clean_main_error()
+
+        self.assertTrue(injected)
+        self.assertEqual(error, "working tree is not clean")
+        self.assertEqual(
+            stat.S_IMODE(self.path.stat().st_mode) & stat.S_IXUSR,
+            stat.S_IXUSR,
+        )
+        self.assertEqual(
+            json.loads(self.path.read_text(encoding="utf-8"))["repo_head"],
+            self._git("rev-parse", "HEAD"),
         )
 
 

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -5,6 +5,7 @@ import argparse
 import hashlib
 import json
 import os
+import shutil
 import signal
 import stat
 import subprocess
@@ -154,6 +155,44 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
                 self.assertIsNone(error)
                 self.assertEqual(self.path.read_bytes(), committed)
                 self.assertEqual(stat.S_IMODE(self.path.stat().st_mode), mode)
+
+    def test_clean_main_recovers_in_place_with_hardlink_and_xattr(self):
+        self._refresh()
+        outside = self.root.parent / f"{self.root.name}-certification-hardlink"
+        outside.unlink(missing_ok=True)
+        os.link(self.path, outside)
+        self.addCleanup(outside.unlink, missing_ok=True)
+        before_inode = self.path.stat().st_ino
+        xattr_name = "user.audit-recovery-test"
+        xattr_value = b"preserve-me"
+        xattr_command: list[str] | None = None
+        if hasattr(os, "setxattr"):
+            os.setxattr(self.path, xattr_name, xattr_value)
+        elif shutil.which("xattr"):
+            xattr_command = ["xattr", "-w", xattr_name, xattr_value.decode()]
+            subprocess.run(xattr_command + [str(self.path)], check=True)
+
+        error = self._clean_main_error()
+
+        committed = self._git_bytes(
+            "show",
+            f"HEAD:{batch.LANE_CERTIFICATION_PATH}",
+        )
+        self.assertIsNone(error)
+        self.assertEqual(self.path.stat().st_ino, before_inode)
+        self.assertEqual(outside.stat().st_ino, before_inode)
+        self.assertEqual(self.path.read_bytes(), committed)
+        self.assertEqual(outside.read_bytes(), committed)
+        if hasattr(os, "getxattr"):
+            self.assertEqual(os.getxattr(self.path, xattr_name), xattr_value)
+        elif xattr_command is not None:
+            value = subprocess.run(
+                ["xattr", "-p", xattr_name, str(self.path)],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            self.assertEqual(value, xattr_value.decode())
 
     def test_clean_main_refuses_payload_drift(self):
         refreshed = dict(
@@ -305,25 +344,25 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         raced = json.loads(json.dumps(refreshed))
         raced["lanes"][0]["blocking"] = ["concurrent-user-work"]
         raced_text = json.dumps(raced, indent=2, sort_keys=True) + "\n"
-        original_sh = batch.sh
+        original_rewrite = batch._rewrite_verified_bytes_in_place
         injected = False
 
-        def racing_sh(cmd, timeout=120, *, honor_cancel=True, text=True):
+        def racing_rewrite(path, *, expected, replacement, expected_signature):
             nonlocal injected
-            if cmd[:2] == ["patch", "-R"] and not injected:
+            if not injected:
                 injected = True
                 self.path.write_text(raced_text, encoding="utf-8")
-            return original_sh(
-                cmd,
-                timeout=timeout,
-                honor_cancel=honor_cancel,
-                text=text,
+            return original_rewrite(
+                path,
+                expected=expected,
+                replacement=replacement,
+                expected_signature=expected_signature,
             )
 
         with mock.patch.object(batch, "REPO_ROOT", self.root), mock.patch.object(
             batch,
-            "sh",
-            side_effect=racing_sh,
+            "_rewrite_verified_bytes_in_place",
+            side_effect=racing_rewrite,
         ):
             error = batch.clean_main_error()
 
@@ -333,6 +372,9 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         self.assertEqual(
             after["lanes"][0]["blocking"],
             ["concurrent-user-work"],
+        )
+        self.assertFalse(
+            self.path.with_suffix(self.path.suffix + ".orig").exists()
         )
 
     def test_concurrent_mode_change_survives_patch_capture(self):
@@ -375,24 +417,31 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
             self._git("rev-parse", "HEAD"),
         )
 
-    def test_late_concurrent_mode_change_survives_raw_patch(self):
+    def test_late_concurrent_mode_change_survives_in_place_rewrite(self):
         for concurrent_mode in (0o600, 0o744):
             with self.subTest(concurrent_mode=oct(concurrent_mode)):
                 self.path.chmod(0o644)
                 self._refresh()
-                original_sh = batch.sh
+                before_bytes = self.path.read_bytes()
+                original_rewrite = batch._rewrite_verified_bytes_in_place
                 injected = False
 
-                def racing_sh(cmd, timeout=120, *, honor_cancel=True, text=True):
+                def racing_rewrite(
+                    path,
+                    *,
+                    expected,
+                    replacement,
+                    expected_signature,
+                ):
                     nonlocal injected
-                    if cmd[:2] == ["patch", "-R"] and not injected:
+                    if not injected:
                         injected = True
                         self.path.chmod(concurrent_mode)
-                    return original_sh(
-                        cmd,
-                        timeout=timeout,
-                        honor_cancel=honor_cancel,
-                        text=text,
+                    return original_rewrite(
+                        path,
+                        expected=expected,
+                        replacement=replacement,
+                        expected_signature=expected_signature,
                     )
 
                 with mock.patch.object(
@@ -401,24 +450,55 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
                     self.root,
                 ), mock.patch.object(
                     batch,
-                    "sh",
-                    side_effect=racing_sh,
+                    "_rewrite_verified_bytes_in_place",
+                    side_effect=racing_rewrite,
                 ):
                     error = batch.clean_main_error()
 
                 self.assertTrue(injected)
                 self.assertEqual(error, "working tree is not clean")
-                self.assertEqual(
-                    self.path.read_bytes(),
-                    self._git_bytes(
-                        "show",
-                        f"HEAD:{batch.LANE_CERTIFICATION_PATH}",
-                    ),
-                )
+                self.assertEqual(self.path.read_bytes(), before_bytes)
                 self.assertEqual(
                     stat.S_IMODE(self.path.stat().st_mode),
                     concurrent_mode,
                 )
+
+    def test_late_neighbor_file_is_preserved_and_no_backup_is_created(self):
+        self._refresh()
+        neighbor = self.path.with_suffix(self.path.suffix + ".orig")
+        user_bytes = b"concurrent user backup\n"
+        original_rewrite = batch._rewrite_verified_bytes_in_place
+        injected = False
+
+        def racing_rewrite(path, *, expected, replacement, expected_signature):
+            nonlocal injected
+            if not injected:
+                injected = True
+                neighbor.write_bytes(user_bytes)
+            return original_rewrite(
+                path,
+                expected=expected,
+                replacement=replacement,
+                expected_signature=expected_signature,
+            )
+
+        with mock.patch.object(batch, "REPO_ROOT", self.root), mock.patch.object(
+            batch,
+            "_rewrite_verified_bytes_in_place",
+            side_effect=racing_rewrite,
+        ):
+            error = batch.clean_main_error()
+
+        self.assertTrue(injected)
+        self.assertEqual(
+            error,
+            "working tree is not clean after provenance recovery",
+        )
+        self.assertEqual(neighbor.read_bytes(), user_bytes)
+        self.assertEqual(
+            self.path.read_bytes(),
+            self._git_bytes("show", f"HEAD:{batch.LANE_CERTIFICATION_PATH}"),
+        )
 
 
 def _args() -> argparse.Namespace:

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -31,16 +31,29 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         self.payload = {
             "schema": "lane_certification_v2",
             "repo_head": "a" * 40,
-            "lanes": [{"lane": "test", "blocking": []}],
+            "lanes": [
+                {"lane": "test", "certified": False, "blocking": []}
+            ],
         }
         self.path.write_text(
             json.dumps(self.payload, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
+        self.source = self.root / "docs" / "SOURCE.md"
+        self.source.parent.mkdir(parents=True, exist_ok=True)
+        self.source.write_text("source baseline\n", encoding="utf-8")
+        self.ledger = (
+            self.root / "docs" / "audit" / "data" / "ledger" / "ro" / "row.json"
+        )
+        self.ledger.parent.mkdir(parents=True)
+        self.ledger.write_text(
+            '{"audit_status":"unaudited"}\n',
+            encoding="utf-8",
+        )
         self._git("init", "-q", "-b", "main")
         self._git("config", "user.email", "audit-test@example.invalid")
         self._git("config", "user.name", "Audit Test")
-        self._git("add", batch.LANE_CERTIFICATION_PATH)
+        self._git("add", ".")
         self._git("commit", "-q", "-m", "baseline")
 
     def _git(self, *args: str) -> str:
@@ -58,12 +71,18 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
             encoding="utf-8",
         )
 
-    def test_clean_main_recovers_current_head_only_refresh(self):
+    def _refresh(self) -> dict:
         refreshed = dict(self.payload, repo_head=self._git("rev-parse", "HEAD"))
         self._write(refreshed)
+        return refreshed
 
+    def _clean_main_error(self) -> str | None:
         with mock.patch.object(batch, "REPO_ROOT", self.root):
-            error = batch.clean_main_error()
+            return batch.clean_main_error()
+
+    def test_clean_main_recovers_current_head_only_refresh(self):
+        self._refresh()
+        error = self._clean_main_error()
 
         self.assertIsNone(error)
         self.assertEqual(json.loads(self.path.read_text()), self.payload)
@@ -73,9 +92,7 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
         refreshed = dict(self.payload)
         refreshed.pop("repo_head")
         self._write(refreshed)
-
-        with mock.patch.object(batch, "REPO_ROOT", self.root):
-            error = batch.clean_main_error()
+        error = self._clean_main_error()
 
         self.assertIsNone(error)
         self.assertEqual(json.loads(self.path.read_text()), self.payload)
@@ -88,23 +105,135 @@ class GeneratedProvenanceRecoveryTest(unittest.TestCase):
             lanes=[{"lane": "test", "blocking": ["science-row"]}],
         )
         self._write(refreshed)
-
-        with mock.patch.object(batch, "REPO_ROOT", self.root):
-            error = batch.clean_main_error()
+        error = self._clean_main_error()
 
         self.assertEqual(error, "working tree is not clean")
         self.assertEqual(json.loads(self.path.read_text()), refreshed)
 
     def test_clean_main_refuses_staged_provenance_drift(self):
-        refreshed = dict(self.payload, repo_head=self._git("rev-parse", "HEAD"))
-        self._write(refreshed)
+        refreshed = self._refresh()
         self._git("add", batch.LANE_CERTIFICATION_PATH)
-
-        with mock.patch.object(batch, "REPO_ROOT", self.root):
-            error = batch.clean_main_error()
+        error = self._clean_main_error()
 
         self.assertEqual(error, "working tree is not clean")
         self.assertEqual(json.loads(self.path.read_text()), refreshed)
+
+    def test_clean_main_refuses_type_confused_payload_drift(self):
+        refreshed = self._refresh()
+        refreshed["lanes"][0]["certified"] = 0
+        self._write(refreshed)
+        before = self.path.read_bytes()
+
+        error = self._clean_main_error()
+
+        self.assertEqual(error, "working tree is not clean")
+        self.assertEqual(self.path.read_bytes(), before)
+
+    def test_clean_main_refuses_duplicate_json_keys(self):
+        refreshed = self._refresh()
+        text = json.dumps(refreshed, indent=2, sort_keys=True) + "\n"
+        duplicate = text.replace(
+            '      "certified": false,\n',
+            '      "certified": true,\n      "certified": false,\n',
+        )
+        self.path.write_text(duplicate, encoding="utf-8")
+
+        error = self._clean_main_error()
+
+        self.assertEqual(error, "working tree is not clean")
+        self.assertEqual(self.path.read_text(encoding="utf-8"), duplicate)
+
+    def test_clean_main_refuses_null_or_stale_repo_head(self):
+        for value in (None, "b" * 40):
+            with self.subTest(repo_head=value):
+                refreshed = dict(self.payload, repo_head=value)
+                self._write(refreshed)
+                before = self.path.read_bytes()
+
+                error = self._clean_main_error()
+
+                self.assertEqual(error, "working tree is not clean")
+                self.assertEqual(self.path.read_bytes(), before)
+                self._git("restore", "--worktree", "--", batch.LANE_CERTIFICATION_PATH)
+
+    def test_clean_main_refuses_malformed_or_non_utf8_payload(self):
+        for content in (b"{not-json\n", b"\xff\xfe\x00not-utf8"):
+            with self.subTest(content=content):
+                self.path.write_bytes(content)
+
+                error = self._clean_main_error()
+
+                self.assertEqual(error, "working tree is not clean")
+                self.assertEqual(self.path.read_bytes(), content)
+                self._git("restore", "--worktree", "--", batch.LANE_CERTIFICATION_PATH)
+
+    def test_clean_main_refuses_untracked_source_ledger_and_mixed_state(self):
+        cases = ("untracked", "source", "ledger", "mixed")
+        for case in cases:
+            with self.subTest(case=case):
+                self._refresh()
+                scratch = self.root / "scratch.txt"
+                if case in {"untracked", "mixed"}:
+                    scratch.write_text("scratch\n", encoding="utf-8")
+                if case in {"source", "mixed"}:
+                    self.source.write_text("source user edit\n", encoding="utf-8")
+                if case in {"ledger", "mixed"}:
+                    self.ledger.write_text(
+                        '{"audit_status":"audited_clean"}\n',
+                        encoding="utf-8",
+                    )
+                snapshots = {
+                    path: path.read_bytes()
+                    for path in (self.path, self.source, self.ledger)
+                }
+                if scratch.exists():
+                    snapshots[scratch] = scratch.read_bytes()
+
+                error = self._clean_main_error()
+
+                self.assertEqual(error, "working tree is not clean")
+                for path, expected in snapshots.items():
+                    self.assertEqual(path.read_bytes(), expected)
+                self._git("restore", "--worktree", "--", ".")
+                scratch.unlink(missing_ok=True)
+
+    def test_clean_main_refuses_deleted_certification(self):
+        self.path.unlink()
+
+        error = self._clean_main_error()
+
+        self.assertEqual(error, "working tree is not clean")
+        self.assertFalse(self.path.exists())
+
+    def test_concurrent_same_file_edit_survives_reverse_patch(self):
+        refreshed = self._refresh()
+        raced = json.loads(json.dumps(refreshed))
+        raced["lanes"][0]["blocking"] = ["concurrent-user-work"]
+        raced_text = json.dumps(raced, indent=2, sort_keys=True) + "\n"
+        original_sh = batch.sh
+        injected = False
+
+        def racing_sh(cmd, timeout=120, *, honor_cancel=True):
+            nonlocal injected
+            if cmd[:3] == ["git", "apply", "--reverse"] and not injected:
+                injected = True
+                self.path.write_text(raced_text, encoding="utf-8")
+            return original_sh(cmd, timeout=timeout, honor_cancel=honor_cancel)
+
+        with mock.patch.object(batch, "REPO_ROOT", self.root), mock.patch.object(
+            batch,
+            "sh",
+            side_effect=racing_sh,
+        ):
+            error = batch.clean_main_error()
+
+        self.assertTrue(injected)
+        self.assertIsNotNone(error)
+        after = json.loads(self.path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            after["lanes"][0]["blocking"],
+            ["concurrent-user-work"],
+        )
 
 
 def _args() -> argparse.Namespace:
@@ -1328,9 +1457,9 @@ class ClaimTransactionTest(unittest.TestCase):
             git("add", ".gitignore", str(shard.relative_to(root)))
             git("commit", "-qm", "baseline")
 
-            for name in batch.static_checkpoint.STATIC_CACHE_NAMES:
-                content = f"{{\"cache\": \"{name}\"}}\n".encode()
-                (data / name).write_bytes(content)
+            citation_graph = data / "citation_graph.json"
+            citation_graph.write_bytes(b'{"cache": "citation_graph.json"}\n')
+            runner_classification = data / "runner_classification.json"
             checkpoint = data / "static_pipeline_checkpoint.json"
 
             nonce = "a" * 32
@@ -1360,6 +1489,12 @@ class ClaimTransactionTest(unittest.TestCase):
                 )
                 prepared, prepare_detail = (
                     batch.static_checkpoint.prepare_checkpoint()
+                )
+                runner_cache_absent_at_prepare = (
+                    not runner_classification.exists()
+                )
+                runner_classification.write_bytes(
+                    b'{"cache": "runner_classification.json"}\n'
                 )
                 classifier_receipt_ok, classifier_receipt_detail = (
                     batch.static_checkpoint.record_producer_receipt(
@@ -1450,6 +1585,7 @@ class ClaimTransactionTest(unittest.TestCase):
         self.assertTrue(graph_receipt_ok, graph_receipt_detail)
         self.assertTrue(seed_receipt_ok, seed_receipt_detail)
         self.assertTrue(prepared, prepare_detail)
+        self.assertTrue(runner_cache_absent_at_prepare)
         self.assertTrue(classifier_receipt_ok, classifier_receipt_detail)
         self.assertTrue(captured, capture_detail)
         self.assertTrue(finalized, finalize_detail)

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -21,6 +21,92 @@ import orchestrate_audit_batch as batch
 import orchestrate_audit_loop as audit_loop
 
 
+class GeneratedProvenanceRecoveryTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.path = self.root / batch.LANE_CERTIFICATION_PATH
+        self.path.parent.mkdir(parents=True)
+        self.payload = {
+            "schema": "lane_certification_v2",
+            "repo_head": "a" * 40,
+            "lanes": [{"lane": "test", "blocking": []}],
+        }
+        self.path.write_text(
+            json.dumps(self.payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        self._git("init", "-q", "-b", "main")
+        self._git("config", "user.email", "audit-test@example.invalid")
+        self._git("config", "user.name", "Audit Test")
+        self._git("add", batch.LANE_CERTIFICATION_PATH)
+        self._git("commit", "-q", "-m", "baseline")
+
+    def _git(self, *args: str) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def _write(self, payload: dict) -> None:
+        self.path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def test_clean_main_recovers_current_head_only_refresh(self):
+        refreshed = dict(self.payload, repo_head=self._git("rev-parse", "HEAD"))
+        self._write(refreshed)
+
+        with mock.patch.object(batch, "REPO_ROOT", self.root):
+            error = batch.clean_main_error()
+
+        self.assertIsNone(error)
+        self.assertEqual(json.loads(self.path.read_text()), self.payload)
+        self.assertEqual(self._git("status", "--porcelain"), "")
+
+    def test_clean_main_recovers_obsolete_field_removal(self):
+        refreshed = dict(self.payload)
+        refreshed.pop("repo_head")
+        self._write(refreshed)
+
+        with mock.patch.object(batch, "REPO_ROOT", self.root):
+            error = batch.clean_main_error()
+
+        self.assertIsNone(error)
+        self.assertEqual(json.loads(self.path.read_text()), self.payload)
+        self.assertEqual(self._git("status", "--porcelain"), "")
+
+    def test_clean_main_refuses_payload_drift(self):
+        refreshed = dict(
+            self.payload,
+            repo_head=self._git("rev-parse", "HEAD"),
+            lanes=[{"lane": "test", "blocking": ["science-row"]}],
+        )
+        self._write(refreshed)
+
+        with mock.patch.object(batch, "REPO_ROOT", self.root):
+            error = batch.clean_main_error()
+
+        self.assertEqual(error, "working tree is not clean")
+        self.assertEqual(json.loads(self.path.read_text()), refreshed)
+
+    def test_clean_main_refuses_staged_provenance_drift(self):
+        refreshed = dict(self.payload, repo_head=self._git("rev-parse", "HEAD"))
+        self._write(refreshed)
+        self._git("add", batch.LANE_CERTIFICATION_PATH)
+
+        with mock.patch.object(batch, "REPO_ROOT", self.root):
+            error = batch.clean_main_error()
+
+        self.assertEqual(error, "working tree is not clean")
+        self.assertEqual(json.loads(self.path.read_text()), refreshed)
+
+
 def _args() -> argparse.Namespace:
     return argparse.Namespace(
         lane=None,

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -9866,20 +9866,18 @@ class ComputeLaneCertificationTest(unittest.TestCase):
         self.data = self.root / "docs" / "audit" / "data"
         self.data.mkdir(parents=True)
 
-    def _run(self, lanes: list[dict], rows: dict, *, head="a" * 40):
+    def _run(self, lanes: list[dict], rows: dict):
         m = _import("compute_lane_certification")
         config = self.data / "lane_certification_config.json"
         ledger = self.data / "audit_ledger.json"
         out = self.data / "lane_certification.json"
         config.write_text(json.dumps({"lanes": lanes}), encoding="utf-8")
         ledger.write_text(json.dumps({"rows": rows}), encoding="utf-8")
-        completed = mock.Mock(stdout=head + "\n")
         m.ledger_io.DATA = self.data
         with mock.patch.object(m, "CONFIG", config), \
              mock.patch.object(m, "LEDGER", ledger), \
              mock.patch.object(m, "OUT", out), \
-             mock.patch.object(m, "REPO_ROOT", self.root), \
-             mock.patch.object(m.subprocess, "run", return_value=completed):
+             mock.patch.object(m, "REPO_ROOT", self.root):
             self.assertEqual(m.main(), 0)
         return json.loads(out.read_text(encoding="utf-8")), out.read_bytes()
 
@@ -10008,8 +10006,9 @@ class ComputeLaneCertificationTest(unittest.TestCase):
             "deps": [],
         }}
         lanes = [{"lane": "stable", "root": "root"}]
-        _, first = self._run(lanes, rows)
+        payload, first = self._run(lanes, rows)
         _, second = self._run(lanes, rows)
+        self.assertNotIn("repo_head", payload)
         self.assertEqual(first, second)
 
         script = (


### PR DESCRIPTION
## What changed

- Remove the self-referential `repo_head` field from tracked lane-certification output.
- Recognize only exact, unstaged legacy provenance drift from the current or an ancestor `HEAD` at clean sync boundaries, without mutating the file.
- Require stable raw bytes and metadata across the second status read; refuse payload, staged, untracked, deleted, noncanonical-mode, hardlinked, ACL-denied, immutable, wrong-owner, or concurrently changed state.
- Let the normal full or verdict-only pipeline remove the obsolete field in the next generated audit commit.
- Fix cold-checkout checkpoint preparation so it does not hash ignored `runner_classification.json` before the classifier generates it.
- Add audit-loop liveness and non-mutating generated-state coordination guidance.

## Root cause

`lane_certification.json` embedded the current commit SHA. A later commit necessarily changed `HEAD`, so a pipeline refresh during judicial deliberation dirtied the tracked generated file. The next serialized apply treated that harmless provenance refresh as arbitrary worktree dirt and terminated with `sync_blocked`. The July 23 scheduled GitHub workflow separately failed because checkpoint preparation required an ignored runner cache before its generating step.

## Review-loop

Eight bounded incremental review passes were run. The final independent iteration has `FINAL VERDICT: PASS` with no blocking findings. Earlier iterations exposed and eliminated destructive whole-file, Git conversion, mode, external patch, inode/xattr, interrupted-write, concurrency, ACL, and immutable-file failure paths. The landed design is a non-mutating exact-state classifier.

## Validation

- Recovery tests: 27 passed.
- Complete orchestrator test module: 75 passed.
- Lane-certification tests: 6 passed.
- Python compile checks on all changed Python files.
- Audit-loop skill quick validation.
- Vocabulary lint on every changed file: 0 violations.
- Fresh-clone cold-checkout regression passed without a preexisting runner cache.
- Full audit pipeline passed in a fresh clone.
- Strict audit lint: 0 errors.
- `git diff --check` passed.

Generated audit outputs from validation are intentionally excluded from this infrastructure PR.