### PR TITLE
Harden parallel audit drain recovery

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -215,8 +215,14 @@ default session is:
    This command owns the complete control loop: finish pending judicial work,
    drain configured development lanes in order, immediately panel every fresh
    cross-seat disagreement, resume the same lane after the panel lands, repeat
-   until a full pass lands nothing new, then run one forensic canary. Raise
-   toward 6 workers only in a quiet pool per the budget below. The supervisor
+   until a full pass lands nothing new, then run one forensic canary.
+   `--max-workers` is the campaign-wide concurrent Codex-seat ceiling, not
+   merely a development-batch knob: a five-judge panel runs in bounded waves
+   (4+1 at the default) while still collecting one complete five-vote panel.
+   Four is the conservative default, not a universal optimum. It sits inside
+   the measured 4-6 quiet-pool sweet spot while reserving headroom in the
+   shared 8-10-process pool for review-loop and control work; raise toward 6
+   only when that shared pool is quiet. The supervisor
    holds the clone-wide audit lock for the complete campaign and hands that
    lock to its batch/panel children. It runs the panel sweep after every batch
    termination before propagating any unrelated hard batch failure, so a mixed
@@ -260,9 +266,26 @@ least every 15 minutes — never silence for a long run.
 
 ## Drain Liveness And Generated-State Recovery
 
-- A quiet worker is bounded by the configured stall timer, and every
-  supervisor phase continues to emit the 15-minute progress summary. Do not
-  leave a drain silently waiting past those bounds.
+- Bound every Codex seat by both inactivity and absolute wall time. Log churn
+  is not scientific progress and must never extend the wall deadline. The
+  default top-level command passes its `--codex-timeout-sec` to development
+  and judicial seats as `--seat-timeout-sec`.
+- Bound every batch/panel/canary child phase by `--phase-timeout-sec`.
+  Supervisor TERM/HUP/timeout handling must terminate the complete child
+  process group, and child handlers must cooperatively cancel pipeline
+  commands and detached seats. A 15-minute heartbeat is observability, not a
+  substitute for a deadline.
+- Persist phase start/end events and child artifact directories under the
+  top-level `--campaign-workdir`. A campaign that fails after producing a
+  validator-clean judicial majority must replay that preserved judgment only
+  after current source/seat fingerprint and applyability validation; it must
+  not spend five fresh judges merely because pipeline, lint, commit, push, or
+  the supervisor failed afterward.
+- To resume a known external panel artifact directory, pass
+  `--resume-panel-workdir <path>` to the top-level drainer. Reusing the same
+  `--campaign-workdir` automatically discovers prior panel phase directories.
+  Resume artifacts are selection hints only; the current apply validator and
+  generated gates remain the authority.
 - Tracked generated audit surfaces must be commit-invariant. Never embed the
   current `HEAD` commit in a tracked pipeline output: committing that output
   changes `HEAD` and guarantees fresh dirt at the next regeneration.
@@ -316,12 +339,17 @@ python3 docs/audit/scripts/orchestrate_audit_batch.py \
   for that claim -> one pipeline -> one lint -> one commit -> one push inside
   the drainer). A simultaneous critical pair is one claim transaction, not two
   generated-surface transactions; push-race retry replays the whole pair from
-  refreshed `origin/main`. Never add a second committer against the same
-  checkout; parallelism lives in the auditor seats only.
+  refreshed `origin/main`. Batch verdicts, judicial judgments, and reseats
+  must call the same checkpoint-aware generated transaction engine so their
+  rollback, cancellation, push-race, and lost-response behavior cannot drift.
+  Never add a second committer against the same checkout; parallelism lives in
+  the auditor seats only.
 - **Concurrency budget (shared codex pool).** Auditor seats, review-loop
   reviewers, and judicial panels all draw on one pool. Keep the TOTAL
   concurrent codex processes across every lane at or under ~8-10, and
-  coordinate before raising `--max-workers` while review campaigns run.
+  coordinate before raising `--max-workers` while review campaigns run. The
+  top-level ceiling applies to judicial judges as well as development seats;
+  do not bypass it by invoking an unbounded panel child.
   Measured 2026-07-17: ~18 concurrent processes collapsed lane throughput
   from 6-11 landed verdicts/hour to ~1 every 3 hours; a 4-6 seat drain in a
   quiet pool is the sweet spot.

--- a/docs/ai_methodology/skills/audit-loop/agents/openai.yaml
+++ b/docs/ai_methodology/skills/audit-loop/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Audit Loop"
-  short_description: "Run hostile claim audits from the repo queue"
-  default_prompt: "Use $audit-loop to audit the next claim in the repository audit queue and land the result."
+  short_description: "Run robust parallel audits from the repo queue"
+  default_prompt: "Use $audit-loop to drain the repository audit queue with bounded parallel seats, durable resume, and serialized landings."

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -58,15 +58,38 @@ SUCCESS_RESULTS = {
     "compute_required",
 }
 _COMMAND_CONTEXT = threading.local()
+_PROCESS_STOP_EVENT = threading.Event()
 
 
 def _command_cancel_event() -> threading.Event | None:
-    return getattr(_COMMAND_CONTEXT, "cancel_event", None)
+    return getattr(_COMMAND_CONTEXT, "cancel_event", None) or _PROCESS_STOP_EVENT
 
 
 def _command_cancelled() -> bool:
     event = _command_cancel_event()
     return event is not None and event.is_set()
+
+
+def install_shutdown_handlers() -> dict[int, object]:
+    """Turn TERM/HUP into cooperative cancellation for workers and commands."""
+    _PROCESS_STOP_EVENT.clear()
+    previous: dict[int, object] = {}
+
+    def request_stop(_signum, _frame) -> None:
+        _PROCESS_STOP_EVENT.set()
+
+    for signum in (signal.SIGTERM, signal.SIGHUP):
+        previous[signum] = signal.getsignal(signum)
+        signal.signal(signum, request_stop)
+    return previous
+
+
+def restore_shutdown_handlers(previous: dict[int, object]) -> None:
+    for signum, handler in previous.items():
+        signal.signal(signum, handler)
+    _PROCESS_STOP_EVENT.clear()
+
+
 RESUMABLE_HANDOFF_RESULTS = {"judicial_panel_required"}
 SCHEMA_INVALID_RESULTS = {"malformed_json", "validation_failed"}
 SCHEMA_QUARANTINE_RESULT = "schema_invalid_quarantined"
@@ -602,11 +625,13 @@ def launch_worker(
         "auditor": f"codex-audit-batch-{ident}",
         "independence": seat_independence(row, pass_no),
         "workdir": workdir,
+        "started": now,
         "last_size": 0,
         "last_activity": (0, 0.0),
         "last_progress": now,
         "last_progress_wall": now_wall,
         "stalled": False,
+        "deadline_exceeded": False,
     }
 
 
@@ -677,6 +702,7 @@ def wait_workers(
     jobs: list[dict],
     stall_minutes: int = 45,
     on_claim_ready: Callable[[list[dict]], bool] | None = None,
+    wall_timeout_seconds: int | None = None,
 ) -> bool | None:
     """Monitor seats and optionally drain each complete claim immediately.
 
@@ -730,6 +756,10 @@ def wait_workers(
     PROGRESS["jobs"] = jobs
     try:
         while pending:
+            if _PROCESS_STOP_EVENT.is_set():
+                terminate_workers([jobs[index] for index in pending])
+                pending.clear()
+                raise RuntimeError("audit worker wait cancelled by shutdown signal")
             if commit_failed.is_set():
                 terminate_workers([jobs[index] for index in pending])
                 pending.clear()
@@ -769,6 +799,20 @@ def wait_workers(
                     continue
                 if now_wall - job["last_progress_wall"] >= stall_seconds:
                     job["stalled"] = True
+                    try:
+                        os.killpg(job["proc"].pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    job["returncode"] = job["proc"].wait()
+                    if not job["log_handle"].closed:
+                        job["log_handle"].close()
+                    pending.remove(index)
+                    continue
+                if (
+                    wall_timeout_seconds is not None
+                    and now - job["started"] >= wall_timeout_seconds
+                ):
+                    job["deadline_exceeded"] = True
                     try:
                         os.killpg(job["proc"].pid, signal.SIGKILL)
                     except ProcessLookupError:
@@ -1028,6 +1072,8 @@ def packet_completion_pass(
 def finalize_worker(job: dict) -> tuple[dict | None, dict]:
     cid = job["cid"]
     base = {"cid": cid, "pass": job["pass"]}
+    if job.get("deadline_exceeded"):
+        return None, {**base, "result": "wall_timeout_killed"}
     if job["stalled"]:
         return None, {**base, "result": "stall_killed"}
     raw_output = job["raw_output"]
@@ -1500,6 +1546,88 @@ def reset_to_origin_main() -> tuple[bool, str]:
     return (error is None, error or "reset to origin/main")
 
 
+def commit_generated_transaction(
+    cid: str,
+    retries: int,
+    mutate: Callable[[], tuple[bool, str]],
+    commit_message: str,
+) -> dict:
+    """Run one generated audit mutation through the canonical commit ladder.
+
+    ``mutate`` is replayed from a freshly synchronized ``origin/main`` parent
+    after every push race. Every failure after mutation begins restores the
+    checkout before returning, including cancellation and fetch failure.
+    """
+
+    def fail(result: str, detail: str | None = None) -> dict:
+        reset, reset_detail = reset_to_origin_main()
+        if not reset:
+            return {
+                "ok": False,
+                "result": "race_reset_failed",
+                "detail": reset_detail,
+            }
+        outcome = {"ok": False, "result": result}
+        if detail is not None:
+            outcome["detail"] = detail
+        return outcome
+
+    for attempt in range(1, retries + 1):
+        synced, detail = sync_origin_main()
+        if not synced:
+            return {"ok": False, "result": "sync_blocked", "detail": detail}
+
+        mutated, detail = mutate()
+        if not mutated:
+            return fail("mutation_rejected", detail)
+
+        gated, detail = run_generated_gates()
+        if not gated:
+            return fail("gate_failed", detail)
+
+        committed, detail = stage_and_commit(commit_message)
+        if not committed:
+            return fail("commit_failed", detail)
+        local_commit = detail
+
+        push = sh(["git", "push", "-q", "origin", "HEAD:main"])
+        if push.returncode == 0:
+            return {"ok": True, "result": "landed", "commit": local_commit}
+        if _command_cancelled():
+            return fail("commit_cancelled")
+
+        fetch = sh(["git", "fetch", "origin", "main", "-q"])
+        if fetch.returncode != 0:
+            result = "commit_cancelled" if _command_cancelled() else "push_failed"
+            detail = (
+                None
+                if result == "commit_cancelled"
+                else "push and follow-up fetch failed"
+            )
+            return fail(result, detail)
+        if _command_cancelled():
+            return fail("commit_cancelled")
+
+        landed = sh(
+            ["git", "merge-base", "--is-ancestor", local_commit, "origin/main"]
+        )
+        if _command_cancelled():
+            return fail("commit_cancelled")
+        if landed.returncode == 0:
+            return {"ok": True, "result": "landed", "commit": local_commit}
+        if attempt == retries:
+            return fail("push_race_exhausted")
+
+        reset, reset_detail = reset_to_origin_main()
+        if not reset:
+            return {
+                "ok": False,
+                "result": "race_reset_failed",
+                "detail": reset_detail,
+            }
+    return {"ok": False, "result": "unreachable"}
+
+
 def apply_claim_serialized(
     deliveries: list[tuple[dict, dict]],
     retries: int,
@@ -1516,25 +1644,11 @@ def apply_claim_serialized(
     if len(claim_ids) != 1 or not ordered:
         raise ValueError("one non-empty claim delivery group is required")
     cid = next(iter(claim_ids))
+    mutation_failure: dict | None = None
 
-    def fail_after_local_commit(result: str, detail: str | None = None):
-        reset, reset_detail = reset_to_origin_main()
-        if not reset:
-            return False, [{
-                "cid": cid,
-                "result": "race_reset_failed",
-                "detail": reset_detail,
-            }]
-        failure = {"cid": cid, "result": result}
-        if detail is not None:
-            failure["detail"] = detail
-        return False, [failure]
-
-    for attempt in range(1, retries + 1):
-        synced, detail = sync_origin_main()
-        if not synced:
-            return False, [{"cid": cid, "result": "sync_blocked", "detail": detail}]
-
+    def mutate() -> tuple[bool, str]:
+        nonlocal mutation_failure
+        mutation_failure = None
         for job, envelope in ordered:
             applied, apply_detail = audit_runner.apply_one(
                 envelope["audit"],
@@ -1542,69 +1656,47 @@ def apply_claim_serialized(
                 evidence_manifest=envelope["evidence_manifest"],
             )
             if not applied:
-                reset_to_origin_main()
-                return False, [{
+                mutation_failure = {
                     "cid": cid,
                     "pass": job["pass"],
                     "result": "apply_or_gate_failed",
                     "detail": f"apply rejected: {apply_detail[:400]}",
-                }]
+                }
+                return False, mutation_failure["detail"]
+        return True, "all claim seats applied"
 
-        gated, detail = run_generated_gates()
-        if not gated:
-            reset_to_origin_main()
-            return False, [{"cid": cid, "result": "apply_or_gate_failed", "detail": detail}]
-        verdicts = [str(envelope["audit"].get("verdict")) for _, envelope in ordered]
-        seats = ["first" if job["pass"] == 1 else "second" for job, _ in ordered]
-        committed, detail = stage_and_commit(
+    verdicts = [str(envelope["audit"].get("verdict")) for _, envelope in ordered]
+    seats = ["first" if job["pass"] == 1 else "second" for job, _ in ordered]
+    outcome = commit_generated_transaction(
+        cid,
+        retries,
+        mutate,
+        (
             f"audit: {cid} {'+'.join(verdicts)} "
             f"(codex-cli, {MODEL}, {REASONING}, {'+'.join(seats)}/batch)"
-        )
-        if not committed:
-            reset_to_origin_main()
-            return False, [{"cid": cid, "result": "commit_failed", "detail": detail}]
-        local_commit = detail
-        push = sh(["git", "push", "-q", "origin", "HEAD:main"])
-        if push.returncode == 0:
-            return True, [
-                {
-                    "cid": cid,
-                    "pass": job["pass"],
-                    "result": envelope["audit"].get("verdict"),
-                    "commit": local_commit,
-                }
-                for job, envelope in ordered
-            ]
-
-        if _command_cancelled():
-            return fail_after_local_commit("commit_cancelled")
-
-        fetch = sh(["git", "fetch", "origin", "main", "-q"])
-        if fetch.returncode != 0:
-            result = "commit_cancelled" if _command_cancelled() else "push_failed"
-            detail = None if result == "commit_cancelled" else "push and follow-up fetch failed"
-            return fail_after_local_commit(result, detail)
-        if _command_cancelled():
-            return fail_after_local_commit("commit_cancelled")
-        landed = sh(["git", "merge-base", "--is-ancestor", local_commit, "origin/main"])
-        if _command_cancelled():
-            return fail_after_local_commit("commit_cancelled")
-        if landed.returncode == 0:
-            return True, [
-                {
-                    "cid": cid,
-                    "pass": job["pass"],
-                    "result": envelope["audit"].get("verdict"),
-                    "commit": local_commit,
-                }
-                for job, envelope in ordered
-            ]
-        if attempt == retries:
-            return fail_after_local_commit("push_race_exhausted")
-        reset, reset_detail = reset_to_origin_main()
-        if not reset:
-            return False, [{"cid": cid, "result": "race_reset_failed", "detail": reset_detail}]
-    return False, [{"cid": cid, "result": "unreachable"}]
+        ),
+    )
+    if outcome["ok"]:
+        return True, [
+            {
+                "cid": cid,
+                "pass": job["pass"],
+                "result": envelope["audit"].get("verdict"),
+                "commit": outcome["commit"],
+            }
+            for job, envelope in ordered
+        ]
+    if outcome["result"] == "mutation_rejected" and mutation_failure is not None:
+        return False, [mutation_failure]
+    result = (
+        "apply_or_gate_failed"
+        if outcome["result"] == "gate_failed"
+        else outcome["result"]
+    )
+    failure = {"cid": cid, "result": result}
+    if outcome.get("detail") is not None:
+        failure["detail"] = outcome["detail"]
+    return False, [failure]
 
 
 def apply_one_serialized(
@@ -2038,12 +2130,16 @@ def scope_for_args(args: argparse.Namespace, rows: dict[str, dict]) -> set[str]:
 
 def main() -> int:
     drain_lock = None
+    shutdown_handlers: dict[int, object] = {}
 
     def finish(code: int) -> int:
-        nonlocal drain_lock
+        nonlocal drain_lock, shutdown_handlers
         if drain_lock is not None:
             drain_lock.close()
             drain_lock = None
+        if shutdown_handlers:
+            restore_shutdown_handlers(shutdown_handlers)
+            shutdown_handlers = {}
         return code
 
     parser = argparse.ArgumentParser(description="Parallel development-tier audit drainer")
@@ -2064,6 +2160,7 @@ def main() -> int:
     parser.add_argument("--max-workers", type=int, default=6)
     parser.add_argument("--rounds", type=int, default=6)
     parser.add_argument("--stall-minutes", type=int, default=45)
+    parser.add_argument("--seat-timeout-sec", type=int, default=2700)
     parser.add_argument("--runner-timeout-sec", type=int, default=120)
     parser.add_argument("--push-retries", type=int, default=3)
     parser.add_argument(
@@ -2095,12 +2192,17 @@ def main() -> int:
         args.max_workers < 1
         or args.rounds < 1
         or args.stall_minutes < 1
+        or args.seat_timeout_sec < 1
         or args.runner_timeout_sec < 1
         or args.push_retries < 1
     ):
-        parser.error("worker, round, stall, runner-timeout, and retry limits must be positive")
+        parser.error(
+            "worker, round, stall, seat-timeout, runner-timeout, and retry "
+            "limits must be positive"
+        )
     if args.retarget_conditionals and not args.claims:
         parser.error("--retarget-conditionals requires an explicit --claims list")
+    shutdown_handlers = install_shutdown_handlers()
     retarget = frozenset(
         cid.strip() for cid in (args.claims or "").split(",") if cid.strip()
     ) if args.retarget_conditionals else frozenset()
@@ -2235,6 +2337,7 @@ def main() -> int:
             jobs,
             args.stall_minutes,
             on_claim_ready=apply_ready_claim,
+            wall_timeout_seconds=args.seat_timeout_sec,
         )
         if streamed is True:
             applied_ok = True

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -17,6 +17,8 @@ import argparse
 import itertools
 import json
 import os
+import re
+import signal
 import subprocess
 import sys
 import tempfile
@@ -55,6 +57,7 @@ PROGRESS = {
     "quarantine_file": None,
 }
 _STOP_HEARTBEAT = threading.Event()
+_STOP_REQUESTED = threading.Event()
 _DRAIN_LOCK_HANDLE: TextIO | None = None
 
 
@@ -176,6 +179,71 @@ def heartbeat() -> None:
         emit(summary_line())
 
 
+def append_campaign_event(event: dict) -> None:
+    campaign_dir = PROGRESS.get("campaign_dir")
+    if not isinstance(campaign_dir, Path):
+        return
+    path = campaign_dir / "campaign-events.jsonl"
+    payload = {
+        "schema": "audit_loop_campaign_event_v1",
+        "at": datetime.now(timezone.utc).isoformat(),
+        **event,
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def phase_workdir(kind: str, label: str) -> Path | None:
+    campaign_dir = PROGRESS.get("campaign_dir")
+    if not isinstance(campaign_dir, Path):
+        return None
+    parent = campaign_dir / kind
+    parent.mkdir(parents=True, exist_ok=True)
+    stem = re.sub(r"[^A-Za-z0-9_.-]+", "-", label).strip("-") or "phase"
+    candidate = parent / stem
+    suffix = 1
+    while candidate.exists():
+        candidate = parent / f"{stem}-attempt-{suffix}"
+        suffix += 1
+    return candidate
+
+
+def prior_panel_workdirs(args: argparse.Namespace) -> list[Path]:
+    paths = list(getattr(args, "resume_panel_workdir", []) or [])
+    campaign_dir = PROGRESS.get("campaign_dir")
+    if isinstance(campaign_dir, Path):
+        panel_root = campaign_dir / "panels"
+        if panel_root.is_dir():
+            paths.extend(path for path in panel_root.iterdir() if path.is_dir())
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        resolved = path.expanduser().resolve(strict=False)
+        if resolved not in seen:
+            unique.append(resolved)
+            seen.add(resolved)
+    return unique
+
+
+def terminate_phase_process(proc: subprocess.Popen) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait()
+
+
 def git_head() -> str:
     proc = subprocess.run(
         ["git", "rev-parse", "HEAD"],
@@ -201,22 +269,69 @@ def run_command(label: str, command: list[str], env: dict[str, str] | None = Non
         lock_fd = _DRAIN_LOCK_HANDLE.fileno()
         child_env[batch.INHERITED_DRAIN_LOCK_FD_ENV] = str(lock_fd)
         pass_fds = (lock_fd,)
-    proc = subprocess.run(
+    proc = subprocess.Popen(
         command,
         cwd=REPO_ROOT,
         env=child_env,
         pass_fds=pass_fds,
+        start_new_session=True,
     )
+    artifact_workdir = child_env.get("AUDIT_BATCH_WORKDIR")
+    if "--workdir" in command:
+        index = command.index("--workdir")
+        if index + 1 < len(command):
+            artifact_workdir = command[index + 1]
+    append_campaign_event(
+        {
+            "event": "phase_start",
+            "label": label,
+            "pid": proc.pid,
+            "command": command,
+            "artifact_workdir": artifact_workdir,
+        }
+    )
+    timeout = PROGRESS.get("phase_timeout_sec")
+    deadline = (
+        time.monotonic() + timeout
+        if isinstance(timeout, int) and timeout > 0
+        else None
+    )
+    timed_out = False
+    try:
+        while proc.poll() is None:
+            if _STOP_REQUESTED.wait(1):
+                terminate_phase_process(proc)
+                break
+            if deadline is not None and time.monotonic() >= deadline:
+                timed_out = True
+                emit(f"TIMEOUT {label}: exceeded {timeout}s; terminating phase")
+                terminate_phase_process(proc)
+                break
+    except BaseException:
+        terminate_phase_process(proc)
+        raise
+    returncode = 124 if timed_out else (proc.returncode if proc.returncode is not None else 130)
     if label.startswith("panel-"):
-        state = "complete" if proc.returncode == 0 else f"failed_exit_{proc.returncode}"
+        state = "complete" if returncode == 0 else f"failed_exit_{returncode}"
         PROGRESS["panel_state"] = f"{state}:{label}"
     if label.startswith("forensic-canary-"):
-        state = "complete" if proc.returncode == 0 else f"failed_exit_{proc.returncode}"
+        state = "complete" if returncode == 0 else f"failed_exit_{returncode}"
         PROGRESS["canary_state"] = f"{state}:{label}"
-    if proc.returncode != 0:
-        PROGRESS["failures"].append(f"{label}:exit={proc.returncode}")
-    emit(f"END {label}: exit={proc.returncode} head={git_head()}")
-    return proc.returncode
+    if returncode != 0:
+        PROGRESS["failures"].append(f"{label}:exit={returncode}")
+    head = git_head()
+    append_campaign_event(
+        {
+            "event": "phase_end",
+            "label": label,
+            "pid": proc.pid,
+            "exit": returncode,
+            "head": head,
+            "timed_out": timed_out,
+        }
+    )
+    emit(f"END {label}: exit={returncode} head={head}")
+    return returncode
 
 
 def _lane_names(payload: object) -> list[str]:
@@ -278,17 +393,30 @@ def blocking_lanes(requested: list[str] | None = None) -> list[tuple[str, int]]:
     return result
 
 
-def panel_command(args: argparse.Namespace) -> list[str]:
+def panel_command(
+    args: argparse.Namespace,
+    *,
+    workdir: Path | None = None,
+    resume_workdirs: list[Path] | None = None,
+) -> list[str]:
     command = [
         sys.executable,
         str(PANEL),
+        "--max-workers",
+        str(args.max_workers),
         "--stall-minutes",
         str(args.stall_minutes),
+        "--seat-timeout-sec",
+        str(args.codex_timeout_sec),
         "--runner-timeout-sec",
         str(args.runner_timeout_sec),
         "--push-retries",
         str(args.push_retries),
     ]
+    if workdir is not None:
+        command.extend(["--workdir", str(workdir)])
+    for resume_workdir in resume_workdirs or []:
+        command.extend(["--resume-workdir", str(resume_workdir)])
     if args.dry_run:
         command.append("--dry-run")
     return command
@@ -306,6 +434,8 @@ def batch_command(lane: str, args: argparse.Namespace) -> list[str]:
         str(args.batch_rounds),
         "--stall-minutes",
         str(args.stall_minutes),
+        "--seat-timeout-sec",
+        str(args.codex_timeout_sec),
         "--runner-timeout-sec",
         str(args.runner_timeout_sec),
         "--push-retries",
@@ -322,7 +452,15 @@ def batch_command(lane: str, args: argparse.Namespace) -> list[str]:
 
 
 def run_panel(args: argparse.Namespace, label: str) -> int:
-    return run_command(label, panel_command(args))
+    workdir = phase_workdir("panels", label)
+    return run_command(
+        label,
+        panel_command(
+            args,
+            workdir=workdir,
+            resume_workdirs=prior_panel_workdirs(args),
+        ),
+    )
 
 
 def drain_lane(lane: str, args: argparse.Namespace) -> tuple[int, bool]:
@@ -333,9 +471,14 @@ def drain_lane(lane: str, args: argparse.Namespace) -> tuple[int, bool]:
             emit(f"STOP lane cycle safety bound reached: lane={lane}")
             return 4, made_progress
         before = git_head()
+        batch_workdir = phase_workdir("batches", f"batch-{lane}-cycle-{cycle}")
+        batch_env = dict(os.environ)
+        if batch_workdir is not None:
+            batch_env["AUDIT_BATCH_WORKDIR"] = str(batch_workdir)
         batch_rc = run_command(
             f"batch-{lane}-cycle-{cycle}",
             batch_command(lane, args),
+            env=batch_env,
         )
         # This is intentionally unconditional, including after a hard batch
         # result: another row in the same batch may already have recorded a
@@ -403,7 +546,15 @@ def build_parser() -> argparse.ArgumentParser:
         description="Panel-aware end-to-end audit backlog drainer"
     )
     parser.add_argument("--lane", action="append", help="limit to a configured lane")
-    parser.add_argument("--max-workers", type=int, default=4)
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=4,
+        help=(
+            "campaign-wide concurrent Codex seat ceiling; panels run five "
+            "judges in bounded waves when the ceiling is below five"
+        ),
+    )
     parser.add_argument(
         "--max-passes",
         type=int,
@@ -420,12 +571,23 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--stall-minutes", type=int, default=45)
     parser.add_argument("--runner-timeout-sec", type=int, default=120)
     parser.add_argument("--codex-timeout-sec", type=int, default=2700)
+    parser.add_argument("--phase-timeout-sec", type=int, default=21600)
     parser.add_argument("--push-retries", type=int, default=3)
     parser.add_argument(
         "--campaign-workdir",
         type=Path,
         default=None,
         help="preserve campaign-scoped quarantine/report artifacts in this directory",
+    )
+    parser.add_argument(
+        "--resume-panel-workdir",
+        type=Path,
+        action="append",
+        default=[],
+        help=(
+            "prior judicial workdir containing a preserved majority judgment; "
+            "the panel revalidates it before replay"
+        ),
     )
     parser.add_argument(
         "--dispatch-science-fixes",
@@ -449,6 +611,7 @@ def main(argv: list[str] | None = None) -> int:
         args.stall_minutes,
         args.runner_timeout_sec,
         args.codex_timeout_sec,
+        args.phase_timeout_sec,
         args.push_retries,
     )
     if any(value < 1 for value in positive):
@@ -461,7 +624,18 @@ def main(argv: list[str] | None = None) -> int:
     campaign_dir.mkdir(parents=True, exist_ok=True)
     args.campaign_quarantine_file = campaign_dir / "campaign-row-exclusions.jsonl"
     PROGRESS["quarantine_file"] = args.campaign_quarantine_file
+    PROGRESS["campaign_dir"] = campaign_dir
+    PROGRESS["phase_timeout_sec"] = args.phase_timeout_sec
     emit(f"campaign artifacts: {campaign_dir}")
+    append_campaign_event(
+        {
+            "event": "campaign_start",
+            "head": git_head(),
+            "max_workers": args.max_workers,
+            "seat_timeout_sec": args.codex_timeout_sec,
+            "phase_timeout_sec": args.phase_timeout_sec,
+        }
+    )
     try:
         validate_requested_lanes(args.lane)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
@@ -493,6 +667,15 @@ def main(argv: list[str] | None = None) -> int:
     PROGRESS["panel_state"] = "not_started"
     PROGRESS["canary_state"] = "not_started"
     _STOP_HEARTBEAT.clear()
+    _STOP_REQUESTED.clear()
+    previous_signal_handlers: dict[int, object] = {}
+
+    def request_stop(_signum, _frame) -> None:
+        _STOP_REQUESTED.set()
+
+    for signum in (signal.SIGTERM, signal.SIGHUP):
+        previous_signal_handlers[signum] = signal.getsignal(signum)
+        signal.signal(signum, request_stop)
     thread = threading.Thread(target=heartbeat, daemon=True)
     thread.start()
     try:
@@ -543,7 +726,19 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     finally:
         _STOP_HEARTBEAT.set()
-        emit(summary_line(final=True))
+        final_summary = summary_line(final=True)
+        emit(final_summary)
+        append_campaign_event(
+            {
+                "event": "campaign_end",
+                "head": git_head(),
+                "summary": final_summary,
+                "stop_requested": _STOP_REQUESTED.is_set(),
+            }
+        )
+        for signum, handler in previous_signal_handlers.items():
+            signal.signal(signum, handler)
+        _STOP_REQUESTED.clear()
         if _DRAIN_LOCK_HANDLE is not None:
             _DRAIN_LOCK_HANDLE.close()
             _DRAIN_LOCK_HANDLE = None

--- a/docs/audit/scripts/orchestrate_judicial_panel.py
+++ b/docs/audit/scripts/orchestrate_judicial_panel.py
@@ -261,84 +261,64 @@ def collect_panel_targets(
 RESEAT_OK_RESULTS = {"reseated", "resolved", "recovered"}
 
 
-def _reseat_failure(cid: str, result: str, detail: str) -> dict:
-    """Restore preapply state and return the outcome DICT (failed_after_apply
-    returns an (ok, dict) tuple shaped for apply callers)."""
-    _ok, failure = failed_after_apply(cid, result, detail)
-    return failure
-
-
 def reseat_blocked_row(cid: str, retries: int) -> dict:
     """Persist a reseat through the same per-claim gate ladder as verdicts:
     sync, mutate, pipeline, strict lint, diff check, serialized commit,
     race-retried push."""
-    for attempt in range(1, retries + 1):
-        synced, detail = batch.sync_origin_main()
-        if not synced:
-            return {"cid": cid, "result": "sync_blocked", "detail": detail}
+    mutation_result: str | None = None
+
+    def mutate() -> tuple[bool, str]:
+        nonlocal mutation_result
+        mutation_result = None
         rows = batch.load_rows()
         row = rows.get(cid)
         if row is None:
-            return {"cid": cid, "result": "missing_ledger_row"}
+            mutation_result = "missing_ledger_row"
+            return False, mutation_result
         disposition = reseat_disposition(row)
         if disposition != "blocked":
-            return {"cid": cid, "result": disposition}
+            mutation_result = disposition
+            return False, disposition
         ledger = ledger_io.load_ledger()
         ledger["rows"][cid] = reseat_mutation(ledger["rows"][cid])
         ledger_io.save_ledger(ledger)
-        pipeline = batch.sh(["bash", str(SCRIPTS / "run_pipeline.sh")], timeout=1800)
-        if pipeline.returncode != 0:
-            return _reseat_failure(
-                cid, "reseat_pipeline_failed", (pipeline.stderr or pipeline.stdout)[-400:]
-            )
-        lint = batch.sh(
-            [sys.executable, str(SCRIPTS / "audit_lint.py"), "--strict"], timeout=600
-        )
-        if lint.returncode != 0:
-            return _reseat_failure(
-                cid, "reseat_strict_lint_failed", (lint.stderr or lint.stdout)[-400:]
-            )
-        diff_check = batch.sh(["git", "diff", "--check"])
-        if diff_check.returncode != 0:
-            return _reseat_failure(
-                cid, "reseat_diff_check_failed", diff_check.stdout[-400:]
-            )
-        unexpected = [
-            path
-            for path in batch.changed_paths()
-            if not batch.allowed_generated_path(path)
-        ]
-        if unexpected:
-            return _reseat_failure(
-                cid, "reseat_unexpected_generated_paths", str(unexpected[:8])
-            )
-        committed, detail = batch.stage_and_commit(
+        return True, "row reseated"
+
+    outcome = batch.commit_generated_transaction(
+        cid,
+        retries,
+        mutate,
+        (
             f"audit-infra: reseat cross-confirmation seats for {cid} "
             "(unrecoverable legacy rationales archived; fresh seating opened)"
-        )
-        if not committed:
-            return _reseat_failure(cid, "reseat_commit_failed", detail)
-        local_commit = detail
-        push = batch.sh(["git", "push", "-q", "origin", "HEAD:main"])
-        if push.returncode == 0:
-            return {"cid": cid, "result": "reseated", "commit": local_commit}
-        fetch = batch.sh(["git", "fetch", "origin", "main", "-q"])
-        if fetch.returncode != 0:
-            return {"cid": cid, "result": "reseat_push_failed"}
-        landed = batch.sh(
-            ["git", "merge-base", "--is-ancestor", local_commit, "origin/main"]
-        )
-        if landed.returncode == 0:
-            return {"cid": cid, "result": "reseated", "commit": local_commit}
-        if attempt == retries:
-            return {"cid": cid, "result": "reseat_push_race_exhausted"}
-        error = batch.clean_main_error()
-        if error:
-            return {"cid": cid, "result": "reseat_race_retry_dirty", "detail": error}
-        reset = batch.sh(["git", "reset", "--hard", "origin/main"])
-        if reset.returncode != 0:
-            return {"cid": cid, "result": "reseat_race_reset_failed"}
-    return {"cid": cid, "result": "unreachable"}
+        ),
+    )
+    if outcome["ok"]:
+        return {"cid": cid, "result": "reseated", "commit": outcome["commit"]}
+    if outcome["result"] == "mutation_rejected" and mutation_result is not None:
+        return {"cid": cid, "result": mutation_result}
+
+    gate_result = "reseat_pipeline_failed"
+    detail_text = str(outcome.get("detail") or "")
+    if detail_text.startswith("strict lint failed:"):
+        gate_result = "reseat_strict_lint_failed"
+    elif detail_text.startswith("git diff --check failed:"):
+        gate_result = "reseat_diff_check_failed"
+    elif detail_text.startswith("unexpected generated paths:"):
+        gate_result = "reseat_unexpected_generated_paths"
+    result_map = {
+        "gate_failed": gate_result,
+        "commit_failed": "reseat_commit_failed",
+        "push_failed": "reseat_push_failed",
+        "push_race_exhausted": "reseat_push_race_exhausted",
+        "race_reset_failed": "reseat_race_reset_failed",
+        "commit_cancelled": "reseat_commit_cancelled",
+    }
+    result = result_map.get(outcome["result"], outcome["result"])
+    failure = {"cid": cid, "result": result}
+    if outcome.get("detail"):
+        failure["detail"] = str(outcome["detail"])[-400:]
+    return failure
 
 
 def seat_block(label: str, summary: dict, row: dict) -> str:
@@ -532,14 +512,18 @@ def launch_judge(
         "panel": panel_no,
         "invocation_id": invocation_id,
         "evidence_manifest": evidence_manifest,
+        "started": now,
         "last_size": 0,
         "last_progress": now,
         "stalled": False,
+        "deadline_exceeded": False,
         "returncode": None,
     }
 
 
 def collect_vote(job: dict) -> tuple[dict | None, str]:
+    if job.get("deadline_exceeded"):
+        return None, "wall_timeout_killed"
     if job["stalled"]:
         return None, "stall_killed"
     raw = job["raw_output"]
@@ -770,25 +754,6 @@ def hard_apply_blocker(detail: str) -> bool:
     return str(detail).startswith(HARD_APPLY_BLOCKER_PREFIXES)
 
 
-def restore_preapply_state() -> str | None:
-    reset = batch.sh(["git", "reset", "--hard", "HEAD"])
-    if reset.returncode != 0:
-        return f"reset failed: {(reset.stderr or reset.stdout).strip()[-240:]}"
-    clean = batch.sh(
-        ["git", "clean", "-fd", "--", *audit_runner.AUDIT_DATA_FILES]
-    )
-    if clean.returncode != 0:
-        return f"clean failed: {(clean.stderr or clean.stdout).strip()[-240:]}"
-    return None
-
-
-def failed_after_apply(cid: str, result: str, detail: str) -> tuple[bool, dict]:
-    restore_error = restore_preapply_state()
-    if restore_error:
-        detail = f"{detail}; restore failed: {restore_error}"
-    return False, {"cid": cid, "result": result, "detail": detail}
-
-
 def apply_judgment(
     blob: dict,
     evidence_manifest: dict[str, dict],
@@ -800,80 +765,47 @@ def apply_judgment(
     judgment_path.write_text(
         json.dumps(blob, indent=1, sort_keys=True), encoding="utf-8"
     )
-    for attempt in range(1, retries + 1):
-        synced, detail = batch.sync_origin_main()
-        if not synced:
-            return False, {"cid": cid, "result": "sync_blocked", "detail": detail}
+
+    def mutate() -> tuple[bool, str]:
         applied, apply_detail = audit_runner.apply_one(
             blob, propagate=False, evidence_manifest=evidence_manifest
         )
-        if not applied:
-            return failed_after_apply(
-                cid, "judicial_apply_rejected", apply_detail[-400:]
-            )
-        pipeline = batch.sh(["bash", str(SCRIPTS / "run_pipeline.sh")], timeout=1800)
-        if pipeline.returncode != 0:
-            return failed_after_apply(
-                cid, "pipeline_failed", (pipeline.stderr or pipeline.stdout)[-400:]
-            )
-        lint = batch.sh(
-            [sys.executable, str(SCRIPTS / "audit_lint.py"), "--strict"], timeout=600
-        )
-        if lint.returncode != 0:
-            return failed_after_apply(
-                cid, "strict_lint_failed", (lint.stderr or lint.stdout)[-400:]
-            )
-        diff_check = batch.sh(["git", "diff", "--check"])
-        if diff_check.returncode != 0:
-            return failed_after_apply(
-                cid, "diff_check_failed", diff_check.stdout[-400:]
-            )
-        unexpected = [
-            path
-            for path in batch.changed_paths()
-            if not batch.allowed_generated_path(path)
-        ]
-        if unexpected:
-            return failed_after_apply(
-                cid, "unexpected_generated_paths", str(unexpected[:8])
-            )
-        committed, detail = batch.stage_and_commit(
+        return applied, apply_detail[-400:]
+
+    outcome = batch.commit_generated_transaction(
+        cid,
+        retries,
+        mutate,
+        (
             f"audit: {cid} judicial panel {blob['ratified_verdict']} "
             f"(codex-cli, {batch.MODEL}, {batch.REASONING}, panel/batch)"
-        )
-        if not committed:
-            return failed_after_apply(cid, "commit_failed", detail)
-        local_commit = detail
-        push = batch.sh(["git", "push", "-q", "origin", "HEAD:main"])
-        if push.returncode == 0:
-            return True, {
-                "cid": cid,
-                "result": blob["ratified_verdict"],
-                "sided_with": blob["sided_with"],
-                "commit": local_commit,
-            }
-        fetch = batch.sh(["git", "fetch", "origin", "main", "-q"])
-        if fetch.returncode != 0:
-            return False, {"cid": cid, "result": "push_failed"}
-        landed = batch.sh(
-            ["git", "merge-base", "--is-ancestor", local_commit, "origin/main"]
-        )
-        if landed.returncode == 0:
-            return True, {
-                "cid": cid,
-                "result": blob["ratified_verdict"],
-                "sided_with": blob["sided_with"],
-                "commit": local_commit,
-            }
-        if attempt == retries:
-            return False, {"cid": cid, "result": "push_race_exhausted"}
-        error = batch.clean_main_error()
-        if error:
-            return False, {"cid": cid, "result": "race_retry_dirty", "detail": error}
-        reset = batch.sh(["git", "reset", "--hard", "origin/main"])
-        if reset.returncode != 0:
-            return False, {"cid": cid, "result": "race_reset_failed"}
-    return False, {"cid": cid, "result": "unreachable"}
+        ),
+    )
+    if outcome["ok"]:
+        return True, {
+            "cid": cid,
+            "result": blob["ratified_verdict"],
+            "sided_with": blob["sided_with"],
+            "commit": outcome["commit"],
+        }
+
+    result = outcome["result"]
+    detail = str(outcome.get("detail") or "")
+    if result == "mutation_rejected":
+        result = "judicial_apply_rejected"
+    elif result == "gate_failed":
+        if detail.startswith("strict lint failed:"):
+            result = "strict_lint_failed"
+        elif detail.startswith("git diff --check failed:"):
+            result = "diff_check_failed"
+        elif detail.startswith("unexpected generated paths:"):
+            result = "unexpected_generated_paths"
+        else:
+            result = "pipeline_failed"
+    failure = {"cid": cid, "result": result}
+    if detail:
+        failure["detail"] = detail[-400:]
+    return False, failure
 
 
 def write_panel_record(workdir: Path, cid: str, panel_no: int, record: dict) -> None:
@@ -885,6 +817,55 @@ def write_panel_record(workdir: Path, cid: str, panel_no: int, record: dict) -> 
     (workdir / f"panel-{key}.json").write_text(payload, encoding="utf-8")
 
 
+def load_resumable_judgment(
+    row: dict,
+    rows: dict[str, dict],
+    workdir: Path,
+    resume_workdirs: list[Path],
+    evidence_manifest: dict[str, dict],
+) -> dict | None:
+    """Load an applyable majority without granting stale artifacts authority."""
+    cid = row["claim_id"]
+    filename = f"judgment-{batch.artifact_key(cid)}.json"
+    expected_fingerprint = disagreement_fingerprint(row)
+    for resume_dir in resume_workdirs:
+        path = resume_dir / filename
+        if not path.is_file():
+            continue
+        try:
+            blob = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"   {cid}: cannot resume malformed judgment {path}: {exc}")
+            continue
+        if not isinstance(blob, dict):
+            print(f"   {cid}: cannot resume non-object judgment {path}")
+            continue
+        panel_record = blob.get("judicial_panel_record_v1")
+        if (
+            blob.get("claim_id") != cid
+            or not isinstance(panel_record, dict)
+            or panel_record.get("disagreement_fingerprint")
+            != expected_fingerprint
+        ):
+            print(
+                f"   {cid}: ignoring stale judgment {path}; "
+                "source/seat fingerprint changed"
+            )
+            continue
+        error = judicial_applyability_error(
+            blob, rows, evidence_manifest, workdir
+        )
+        if error is not None:
+            print(
+                f"   {cid}: preserved judgment {path} is no longer applyable: "
+                f"{error[-240:]}"
+            )
+            continue
+        print(f"   {cid}: resuming validated five-judge majority from {path}")
+        return blob
+    return None
+
+
 def run_panel(
     row: dict,
     rows: dict[str, dict],
@@ -893,6 +874,9 @@ def run_panel(
     runner_timeout: int,
     retries: int,
     prior_panels: list[dict],
+    max_workers: int = PANEL_SIZE,
+    seat_timeout_seconds: int = 2700,
+    resume_workdirs: list[Path] | None = None,
 ) -> dict:
     cid = row["claim_id"]
     context_error = seat_context_error(row)
@@ -905,6 +889,19 @@ def run_panel(
     except Exception as exc:
         return {"cid": cid, "result": "packet_render_blocked", "detail": str(exc)}
 
+    resumable = load_resumable_judgment(
+        row,
+        rows,
+        workdir,
+        resume_workdirs or [],
+        evidence_manifest,
+    )
+    if resumable is not None:
+        _ok, result = apply_judgment(
+            resumable, evidence_manifest, workdir, retries
+        )
+        return result
+
     panel_history = copy.deepcopy(prior_panels)
     panel_no = len(panel_history) + 1
     consecutive_contract_retries = 0
@@ -914,10 +911,15 @@ def run_panel(
         consecutive_contract_retries += 1
     while True:
         jobs = []
+        worker_phase = "launch"
         try:
-            for judge_no in range(1, PANEL_SIZE + 1):
-                jobs.append(
-                    launch_judge(
+            for wave_start in range(1, PANEL_SIZE + 1, max_workers):
+                wave = []
+                for judge_no in range(
+                    wave_start,
+                    min(PANEL_SIZE + 1, wave_start + max_workers),
+                ):
+                    job = launch_judge(
                         packet,
                         row,
                         judge_no,
@@ -927,12 +929,29 @@ def run_panel(
                         invocation_id,
                         evidence_manifest,
                     )
+                    jobs.append(job)
+                    wave.append(job)
+                print(
+                    f"   {cid}: launched judges "
+                    f"{wave_start}-{wave_start + len(wave) - 1} "
+                    f"for panel {panel_no}; waiting"
                 )
+                worker_phase = "wait"
+                batch.wait_workers(
+                    wave,
+                    stall_minutes,
+                    wall_timeout_seconds=seat_timeout_seconds,
+                )
+                worker_phase = "launch"
         except Exception as exc:
             batch.terminate_workers(jobs)
             return {
                 "cid": cid,
-                "result": "panel_launch_blocked",
+                "result": (
+                    "panel_wait_blocked"
+                    if worker_phase == "wait"
+                    else "panel_launch_blocked"
+                ),
                 "detail": str(exc),
             }
         except BaseException:
@@ -945,17 +964,6 @@ def run_panel(
                 "cid": cid,
                 "result": "judge_identity_collision",
                 "detail": "panel judges did not receive five distinct identities",
-            }
-        print(
-            f"   {cid}: launched {len(jobs)} judges for panel {panel_no}; waiting"
-        )
-        try:
-            batch.wait_workers(jobs, stall_minutes)
-        except Exception as exc:
-            return {
-                "cid": cid,
-                "result": "panel_wait_blocked",
-                "detail": str(exc),
             }
         votes: list[dict] = []
         failures: list[str] = []
@@ -1336,8 +1344,15 @@ def load_prior_panels(
 
 
 def runtime_arg_error(args: argparse.Namespace) -> str | None:
-    for name in ("stall_minutes", "runner_timeout_sec", "push_retries"):
-        if getattr(args, name) <= 0:
+    defaults = {"max_workers": PANEL_SIZE, "seat_timeout_sec": 2700}
+    for name in (
+        "max_workers",
+        "stall_minutes",
+        "seat_timeout_sec",
+        "runner_timeout_sec",
+        "push_retries",
+    ):
+        if getattr(args, name, defaults.get(name)) <= 0:
             return f"--{name.replace('_', '-')} must be positive"
     return None
 
@@ -1356,9 +1371,27 @@ def main() -> int:
         default=[],
         help="path to a prior panel-<key>.json record to give the judges",
     )
+    parser.add_argument("--max-workers", type=int, default=PANEL_SIZE)
     parser.add_argument("--stall-minutes", type=int, default=45)
+    parser.add_argument("--seat-timeout-sec", type=int, default=2700)
     parser.add_argument("--runner-timeout-sec", type=int, default=120)
     parser.add_argument("--push-retries", type=int, default=3)
+    parser.add_argument(
+        "--workdir",
+        type=Path,
+        default=None,
+        help="fresh directory for this panel phase",
+    )
+    parser.add_argument(
+        "--resume-workdir",
+        type=Path,
+        action="append",
+        default=[],
+        help=(
+            "read-only prior panel workdir whose validated majority judgment "
+            "may be replayed after current fingerprint/applyability checks"
+        ),
+    )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument(
         "--no-reseat",
@@ -1375,6 +1408,7 @@ def main() -> int:
     if arg_error:
         print(f"refusing to run: {arg_error}")
         return 2
+    batch.install_shutdown_handlers()
 
     if not args.dry_run:
         error = batch.clean_main_error()
@@ -1382,9 +1416,13 @@ def main() -> int:
             print(f"refusing to run: {error}. Use a dedicated clean main checkout.")
             return 2
 
-    workdir = Path(
+    workdir = args.workdir or Path(
         os.environ.get("AUDIT_PANEL_WORKDIR")
-        or f"/tmp/audit_panel_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}_{uuid.uuid4().hex[:8]}"
+        or (
+            f"/tmp/audit_panel_"
+            f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}_"
+            f"{uuid.uuid4().hex[:8]}"
+        )
     )
     if not args.dry_run:
         guard_error = workdir_guard_error(workdir)
@@ -1400,6 +1438,17 @@ def main() -> int:
                 "AUDIT_PANEL_WORKDIR at a new path."
             )
             return 2
+        for resume_dir in args.resume_workdir:
+            resume_guard = workdir_guard_error(resume_dir)
+            if resume_guard:
+                print(f"refusing to run: {resume_guard}")
+                return 2
+            if not resume_dir.is_dir():
+                print(
+                    f"refusing to run: resume workdir {resume_dir} "
+                    "does not exist or is not a directory"
+                )
+                return 2
 
     if not args.dry_run:
         drain_lock = batch.acquire_exclusive_drain_lock("orchestrate_judicial_panel")
@@ -1467,6 +1516,9 @@ def main() -> int:
             args.runner_timeout_sec,
             args.push_retries,
             prior_by_claim.get(row["claim_id"], []),
+            max_workers=args.max_workers,
+            seat_timeout_seconds=args.seat_timeout_sec,
+            resume_workdirs=args.resume_workdir,
         )
         report.append(result)
         print(f"   {result['cid']}: {result['result']}")

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -673,7 +673,9 @@ def _args() -> argparse.Namespace:
         stall_minutes=45,
         runner_timeout_sec=120,
         codex_timeout_sec=2700,
+        phase_timeout_sec=21600,
         push_retries=3,
+        resume_panel_workdir=[],
         dispatch_science_fixes=False,
         skip_forensic_canary=True,
         dry_run=False,
@@ -2343,6 +2345,87 @@ class CampaignContractTest(unittest.TestCase):
             "--dispatch-science-fixes",
             audit_loop.batch_command("lane_a", args),
         )
+
+
+class HardDeadlineTest(unittest.TestCase):
+    def test_worker_absolute_deadline_beats_continuous_log_activity(self):
+        class FakeProc:
+            pid = 4242
+            returncode = None
+
+            def poll(self):
+                return self.returncode
+
+            def wait(self):
+                self.returncode = -9
+                return self.returncode
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            log_path = root / "worker.log"
+            log_path.write_text("continuous activity", encoding="utf-8")
+            job = {
+                "cid": "noisy",
+                "row": {"claim_id": "noisy"},
+                "pass": 1,
+                "proc": FakeProc(),
+                "raw_output": root / "worker.out",
+                "log_path": log_path,
+                "log_handle": log_path.open("a", encoding="utf-8"),
+                "started": 0.0,
+                "last_size": 0,
+                "last_activity": (0, 0.0),
+                "last_progress": 0.0,
+                "last_progress_wall": time.time(),
+                "stalled": False,
+                "deadline_exceeded": False,
+            }
+            with mock.patch.object(
+                batch.time, "monotonic", return_value=120.0
+            ), mock.patch.object(batch.os, "killpg") as killpg:
+                result = batch.wait_workers(
+                    [job],
+                    stall_minutes=45,
+                    wall_timeout_seconds=60,
+                )
+
+        self.assertIsNone(result)
+        self.assertTrue(job["deadline_exceeded"])
+        self.assertFalse(job["stalled"])
+        killpg.assert_called_once_with(4242, signal.SIGKILL)
+
+    def test_supervisor_phase_timeout_terminates_process_group(self):
+        class FakeProc:
+            pid = 5252
+            returncode = None
+
+            def poll(self):
+                return self.returncode
+
+            def wait(self, timeout=None):
+                self.returncode = -15
+                return self.returncode
+
+        proc = FakeProc()
+        audit_loop._STOP_REQUESTED.clear()
+        with mock.patch.object(
+            audit_loop.subprocess, "Popen", return_value=proc
+        ), mock.patch.object(
+            audit_loop._STOP_REQUESTED, "wait", return_value=False
+        ), mock.patch.object(
+            audit_loop.time, "monotonic", side_effect=[0.0, 2.0]
+        ), mock.patch.object(
+            audit_loop.os, "killpg"
+        ) as killpg, mock.patch.object(
+            audit_loop, "git_head", return_value="head"
+        ), mock.patch.dict(
+            audit_loop.PROGRESS,
+            {"phase_timeout_sec": 1, "campaign_dir": None},
+        ):
+            result = audit_loop.run_command("bounded-phase", ["fake"])
+
+        self.assertEqual(result, 124)
+        killpg.assert_called_once_with(5252, signal.SIGTERM)
 
 
 if __name__ == "__main__":

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -14457,6 +14457,126 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
         )
         self.assertEqual(len(record["votes"]), 4)
 
+    def test_panel_honors_campaign_worker_ceiling_in_waves(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row()
+        wave_sizes = []
+
+        def fake_launch(
+            _packet, _row, judge_no, panel_no, _workdir, _prior,
+            _invocation_id, _manifest,
+        ):
+            return {
+                "judge": judge_no,
+                "panel": panel_no,
+                "auditor": f"judge-{judge_no}",
+            }
+
+        def fake_wait(jobs, _stall, **_kwargs):
+            wave_sizes.append(len(jobs))
+
+        with mock.patch.object(
+            m, "render_panel_packet", return_value=("packet", {}, "1" * 32)
+        ), mock.patch.object(
+            m, "launch_judge", side_effect=fake_launch
+        ), mock.patch.object(
+            m.batch, "wait_workers", side_effect=fake_wait
+        ), mock.patch.object(
+            m, "collect_vote", return_value=(self._vote(), "ok")
+        ), mock.patch.object(
+            m, "judicial_applyability_error", return_value=None
+        ), mock.patch.object(
+            m,
+            "apply_judgment",
+            return_value=(
+                True,
+                {"cid": "row", "result": "audited_clean", "commit": "abc"},
+            ),
+        ):
+            result = m.run_panel(
+                row,
+                {"row": row},
+                self.tmp,
+                1,
+                1,
+                1,
+                [],
+                max_workers=4,
+            )
+
+        self.assertEqual(result["result"], "audited_clean")
+        self.assertEqual(wave_sizes, [4, 1])
+
+    def test_valid_preserved_majority_replays_without_new_judges(self):
+        m = _import("orchestrate_judicial_panel")
+        row = self._row()
+        votes = [
+            self._vote(
+                _panel_judge=index,
+                _panel_auditor=f"resume-judge-{index}",
+            )
+            for index in range(1, 6)
+        ]
+        blob = m.judicial_blob(
+            row, votes[0], votes, 5, invocation_id="a" * 32
+        )
+        resume_dir = self.tmp / "resume"
+        resume_dir.mkdir()
+        judgment = resume_dir / (
+            f"judgment-{m.batch.artifact_key(row['claim_id'])}.json"
+        )
+        judgment.write_text(json.dumps(blob), encoding="utf-8")
+        current = self.tmp / "current"
+        current.mkdir()
+
+        with mock.patch.object(
+            m, "render_panel_packet", return_value=("packet", {}, "b" * 32)
+        ), mock.patch.object(
+            m, "judicial_applyability_error", return_value=None
+        ) as applyability, mock.patch.object(
+            m,
+            "apply_judgment",
+            return_value=(
+                True,
+                {"cid": "row", "result": "audited_clean", "commit": "abc"},
+            ),
+        ) as apply_judgment, mock.patch.object(
+            m, "launch_judge"
+        ) as launch:
+            result = m.run_panel(
+                row,
+                {"row": row},
+                current,
+                1,
+                1,
+                1,
+                [],
+                resume_workdirs=[resume_dir],
+            )
+
+        self.assertEqual(result["result"], "audited_clean")
+        applyability.assert_called_once()
+        apply_judgment.assert_called_once()
+        launch.assert_not_called()
+
+    def test_judicial_apply_uses_shared_generated_transaction(self):
+        m = _import("orchestrate_judicial_panel")
+        blob = {
+            "claim_id": "row",
+            "ratified_verdict": "audited_clean",
+            "sided_with": "first",
+        }
+        with mock.patch.object(
+            m.batch,
+            "commit_generated_transaction",
+            return_value={"ok": True, "result": "landed", "commit": "abc"},
+        ) as transaction:
+            ok, result = m.apply_judgment(blob, {}, self.tmp, 3)
+
+        self.assertTrue(ok)
+        self.assertEqual(result["commit"], "abc")
+        transaction.assert_called_once()
+
     def test_contract_invalid_vote_runs_fresh_full_panel(self):
         m = _import("orchestrate_judicial_panel")
         row = self._row()
@@ -14644,12 +14764,26 @@ class JudicialPanelOrchestratorTest(unittest.TestCase):
     def test_numeric_runtime_arguments_must_be_positive(self):
         m = _import("orchestrate_judicial_panel")
         valid = argparse.Namespace(
-            stall_minutes=1, runner_timeout_sec=1, push_retries=1
+            max_workers=1,
+            stall_minutes=1,
+            seat_timeout_sec=1,
+            runner_timeout_sec=1,
+            push_retries=1,
         )
         self.assertIsNone(m.runtime_arg_error(valid))
-        for field in ("stall_minutes", "runner_timeout_sec", "push_retries"):
+        for field in (
+            "max_workers",
+            "stall_minutes",
+            "seat_timeout_sec",
+            "runner_timeout_sec",
+            "push_retries",
+        ):
             invalid = argparse.Namespace(
-                stall_minutes=1, runner_timeout_sec=1, push_retries=1
+                max_workers=1,
+                stall_minutes=1,
+                seat_timeout_sec=1,
+                runner_timeout_sec=1,
+                push_retries=1,
             )
             setattr(invalid, field, 0)
             self.assertIn("must be positive", m.runtime_arg_error(invalid))

--- a/docs/audit/scripts/tests/test_judicial_reseat.py
+++ b/docs/audit/scripts/tests/test_judicial_reseat.py
@@ -111,8 +111,16 @@ class ReseatOutcomeShapeTest(unittest.TestCase):
 
         import orchestrate_judicial_panel as panel
 
-        with mock.patch.object(panel, "restore_preapply_state", lambda: None):
-            outcome = panel._reseat_failure("row_x", "reseat_pipeline_failed", "boom")
+        with mock.patch.object(
+            panel.batch,
+            "commit_generated_transaction",
+            return_value={
+                "ok": False,
+                "result": "gate_failed",
+                "detail": "pipeline failed: boom",
+            },
+        ):
+            outcome = panel.reseat_blocked_row("row_x", 3)
         self.assertIsInstance(outcome, dict)
         self.assertEqual(outcome["cid"], "row_x")
         self.assertEqual(outcome["result"], "reseat_pipeline_failed")


### PR DESCRIPTION
## What changed

- enforce absolute per-seat wall deadlines in addition to inactivity stalls
- bound each supervisor phase and terminate its complete process group on timeout or shutdown
- persist campaign phase events and stable panel/batch artifact directories
- resume a preserved five-judge majority only after current disagreement-fingerprint and exact applyability revalidation
- apply the campaign-wide seat ceiling to judicial panels (the default four-seat ceiling schedules a five-judge panel as 4+1)
- route batch verdicts, judicial judgments, and legacy reseats through one checkpoint-aware generated-state transaction engine
- update the audit-loop skill and add deadline, recovery, scheduling, rollback, and replay regressions

## Why

The prior drain treated log activity as liveness, allowed supervisor child phases to wait without an absolute deadline, discarded a valid panel majority after post-vote failures, and maintained three subtly different landing loops. That combination could make a noisy or failed audit appear hung, repeat expensive panel work, and leave rollback behavior inconsistent across landing modes.

Four seats remains a configurable conservative default, not a hard optimum: repository measurements place a quiet drain useful range at 4-6 seats, while the shared review/audit pool should stay around 8-10 total processes. The default preserves headroom for control and review work while keeping panel validity at five independent votes.

## Validation

- python3 -m py_compile on all three changed orchestrators
- audit-loop skill quick_validate.py: PASS
- scripts/vocab_lint.py --fix on every changed file: zero violations
- focused audit regression suite: 119 tests PASS
- full docs/audit/scripts/tests discovery: 646/649 PASS; the same three stale test_fingerprint_v1_stamping judicial fixtures fail unchanged on origin/main
- bash docs/audit/scripts/run_pipeline.sh: stable second pass PASS (the first pass reconciled pre-existing generated score drift, then validation-only outputs were stripped)
- python3 docs/audit/scripts/audit_lint.py --strict: zero errors
- git diff --check: PASS
- generated audit/effective-status PR surface: clean