### PR TITLE
Harden audit drainer convergence and quarantine repair

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -267,13 +267,17 @@ least every 15 minutes — never silence for a long run.
   supervisor phase continues to emit the 15-minute progress summary. Do not
   leave a drain silently waiting past those bounds.
 - One full pipeline invocation must reach a generated-state fixed point.
-  `compute_load_bearing.py` runs once before invalidation to supply topology
-  criticality and again after the effective-status/invalidation/restore fixed
-  point to refresh status-dependent ancestor metrics. Pipeline-produced ledger
-  metrics are derived outputs in the static checkpoint; their underlying
-  notes, dependency edges, runners, and classifier inputs remain
-  fingerprinted. Never accept a design that requires a second operator-run
-  pipeline merely to stabilize the first.
+  In a full run, `compute_load_bearing.py` first refreshes topology
+  `criticality` from the newly built graph before the ledger seeder consumes
+  it, runs again before invalidation, and finally refreshes status-dependent
+  ancestor metrics after the effective-status/invalidation/restore fixed
+  point. Pipeline-produced ledger status-dependent metrics are derived outputs
+  in the static checkpoint; topology `criticality` remains fingerprinted
+  because the skipped ledger seeder consumes its prior value when deciding
+  whether legacy terminal rows require claim-type re-audit. Their underlying
+  notes, dependency edges, runners, and classifier inputs remain fingerprinted.
+  Never accept a design that requires a second operator-run pipeline merely to
+  stabilize the first.
 - Tracked generated audit surfaces must be commit-invariant. Never embed the
   current `HEAD` commit in a tracked pipeline output: committing that output
   changes `HEAD` and guarantees fresh dirt at the next regeneration.

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -327,6 +327,15 @@ failures. This boundary is fail-closed and does not weaken any audit gate.
   campaign state, unavailable required audit model, authentication failure
   after bounded retry, or an applyability/policy defect that cannot be scoped
   to one row. Preserve artifacts and stop before minting authority.
+- Treat the campaign exclusion JSONL as a closed operational schema. Reject
+  blank records, duplicate JSON keys, unknown exclusion reasons, noncanonical
+  claim ids, missing reason-specific evidence, malformed timestamps, and
+  unexpected fields. A damaged record must hard-stop the whole campaign
+  rather than silently suppressing a claim.
+- Transaction rollback proof is stricter than the normal main-checkout guard:
+  after resetting to the captured `origin/main` OID, require literal empty
+  `git status --porcelain` plus exact local/remote OID equality. The narrowly
+  tolerated lane-certification provenance drift is not clean rollback proof.
 
 If the product surface supports a persistent goal, use it as a watchdog around
 the detached canonical drainer, not as a replacement for the drainer. The goal

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -269,15 +269,18 @@ least every 15 minutes — never silence for a long run.
 - One full pipeline invocation must reach a generated-state fixed point.
   In a full run, `compute_load_bearing.py` first refreshes topology
   `criticality` from the newly built graph before the ledger seeder consumes
-  it, runs again before invalidation, and finally refreshes status-dependent
-  ancestor metrics after the effective-status/invalidation/restore fixed
-  point. Pipeline-produced ledger status-dependent metrics are derived outputs
-  in the static checkpoint; topology `criticality` remains fingerprinted
-  because the skipped ledger seeder consumes its prior value when deciding
-  whether legacy terminal rows require claim-type re-audit. Their underlying
-  notes, dependency edges, runners, and classifier inputs remain fingerprinted.
-  Never accept a design that requires a second operator-run pipeline merely to
-  stabilize the first.
+  it. Because that seeder can discover rows absent from the pre-seed ledger,
+  load-bearing runs again and a second idempotent seed pass consumes the
+  refreshed criticality and records the producer receipt before the static
+  checkpoint binds classifier inputs. The final load-bearing pass refreshes
+  status-dependent ancestor metrics after the effective-status/invalidation/
+  restore fixed point. Pipeline-produced ledger status-dependent metrics are
+  derived outputs in the static checkpoint; topology `criticality` remains
+  fingerprinted because the skipped ledger seeder consumes its prior value
+  when deciding whether legacy terminal rows require claim-type re-audit.
+  Their underlying notes, dependency edges, runners, and classifier inputs
+  remain fingerprinted. Never accept a design that requires a second
+  operator-run pipeline merely to stabilize the first.
 - Tracked generated audit surfaces must be commit-invariant. Never embed the
   current `HEAD` commit in a tracked pipeline output: committing that output
   changes `HEAD` and guarantees fresh dirt at the next regeneration.

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -221,6 +221,9 @@ default session is:
    lock to its batch/panel children. It runs the panel sweep after every batch
    termination before propagating any unrelated hard batch failure, so a mixed
    result cannot strand a valid judicial handoff.
+   Keep the printed campaign artifact directory. It is the durable operational
+   record for schema, compute, blocked-reentry, and safely rolled-back
+   transaction exclusions; it does not carry scientific authority.
 3. If the user names a lane, pass `--lane <name>`. Otherwise the orchestrator
    iterates lanes from `docs/audit/data/lane_certification_config.json`,
    selecting entries whose generated `lane_certification.json` record still
@@ -263,6 +266,14 @@ least every 15 minutes — never silence for a long run.
 - A quiet worker is bounded by the configured stall timer, and every
   supervisor phase continues to emit the 15-minute progress summary. Do not
   leave a drain silently waiting past those bounds.
+- One full pipeline invocation must reach a generated-state fixed point.
+  `compute_load_bearing.py` runs once before invalidation to supply topology
+  criticality and again after the effective-status/invalidation/restore fixed
+  point to refresh status-dependent ancestor metrics. Pipeline-produced ledger
+  metrics are derived outputs in the static checkpoint; their underlying
+  notes, dependency edges, runners, and classifier inputs remain
+  fingerprinted. Never accept a design that requires a second operator-run
+  pipeline merely to stabilize the first.
 - Tracked generated audit surfaces must be commit-invariant. Never embed the
   current `HEAD` commit in a tracked pipeline output: committing that output
   changes `HEAD` and guarantees fresh dirt at the next regeneration.
@@ -289,6 +300,37 @@ least every 15 minutes — never silence for a long run.
   mechanically verified generated-state condition, and relaunch exactly one
   canonical top-level drainer. Do not leave a recoverable sync condition as a
   parked audit campaign.
+
+## Campaign Failure Taxonomy And Persistence
+
+The drainer separates claim-local operational failures from global integrity
+failures. This boundary is fail-closed and does not weaken any audit gate.
+
+- **Claim-local, campaign-quarantined:** exhausted schema delivery; an explicit
+  `compute_required` skip; a post-verdict row that immediately re-enters
+  selection; or an apply/pipeline/lint failure for one validated delivery only
+  after rollback to the synchronized `origin/main` parent is verified clean.
+  Record the exact cause, exclude only that claim for the current campaign,
+  and continue every unrelated ready row.
+- **Resumable control flow:** a banked valid critical seat awaiting its peer,
+  or `judicial_panel_required`. Resume it through the canonical batch/panel
+  edge; neither is a campaign failure.
+- **Global retryable:** a transient fetch/push failure whose remote outcome can
+  be reconciled exactly. Reconcile the intended commit OID before replay; never
+  blindly repeat an uncertain push.
+- **Global hard stop:** dirty or divergent source state, failed rollback,
+  repository invariant failure, unclassifiable generated diff, corrupted
+  campaign state, unavailable required audit model, authentication failure
+  after bounded retry, or an applyability/policy defect that cannot be scoped
+  to one row. Preserve artifacts and stop before minting authority.
+
+If the product surface supports a persistent goal, use it as a watchdog around
+the detached canonical drainer, not as a replacement for the drainer. The goal
+is: keep one clean independent-main campaign running or canonically resumed;
+preserve every Nature-grade gate; continue through claim-local quarantines; and
+stop only at a genuine backlog fixed point, credit exhaustion, or a verified
+global integrity/tooling blocker. A goal cannot repair a nonzero pipeline or
+supervisor exit by itself.
 
 ## Scaling: The One Canonical Fan-Out
 
@@ -473,6 +515,38 @@ The graph-cycle warning is currently expected. Treat any error as a blocker.
 - Treat an accepted verdict as a blocked-row reentry when the post-pipeline row is again `unaudited` and the canonical development-tier selector would immediately choose it. Exclude it for the rest of the campaign, report `blocked_row_reentry_quarantined`, and continue draining every other eligible row. Do not exclude `audit_in_progress` / `awaiting_second` rows; they must resume the missing clean seat normally.
 - Do not stop the top-level drainer merely because a row was excluded this way. Reach the fixed point over all non-excluded rows, then report the blocked rows and their exact invalidation reasons separately from schema-invalid quarantines.
 - Do not write an unsupported blocked verdict into the ledger unless `apply_audit.py` provides such a route. Report skipped blocked rows at the end of the loop and require upstream dependency/status repair before retrying them.
+
+## Quarantine And Skip Repair
+
+Quarantines and skips are routing state, never evidence about whether a claim
+is true. Do not convert them into `audited_conditional`, `audited_failed`, or
+any other ledger verdict. Inspect a completed campaign with:
+
+```bash
+python3 docs/audit/scripts/audit_campaign_repair.py \
+  --campaign-workdir /tmp/audit_loop_campaign_<id>
+```
+
+Repair and re-entry are reason-specific:
+
+| Operational result | Required repair | Re-entry |
+| --- | --- | --- |
+| `schema_invalid_quarantined` | Preserve the malformed response and exact validator errors; correct the CLI transport schema, prompt, or bounded packet-completion defect. Never edit the scientific judgment into validity. | Start a new campaign so a fresh restricted-context seat is selected. |
+| `compute_required_quarantined` / `compute_required` | Produce a SHA-pinned runner cache with `cached_runner_output.py`, a sliced deterministic certificate, or an independent derivation; then run the full pipeline and strict lint. | Start a new campaign after the artifact is current. |
+| `blocked_row_reentry_quarantined` | Repair the recorded classifier promotion, dependency/status cycle, note-hash drift, or other invalidation cause. Require one converged full pipeline. | Start a new campaign only after the row no longer immediately returns to the same dep-ready state. |
+| `claim_transaction_quarantined` | Fix the recorded apply, pipeline, or lint defect and prove the clean full pipeline converges. The failed delivery minted no verdict. | Use a fresh seat in a new campaign unless canonical tooling verifies an exact preserved-envelope replay against the current source/seat fingerprint. |
+| `dependencies are not retained-grade` | Audit or repair the named upstream dependency; do not force the downstream row. | Automatic when dependency closure becomes retained-grade and the pipeline refreshes the queue. |
+| `no_go row` or `source shape requires forensic tier` | Run the required N1-N8 forensic path, one canary at a time. | Through the forensic selector, never by forcing the development batch. |
+| `claim_type ... not batch-auditable` | Route `meta` or `decoration` only when explicitly requested and through their compatible apply contract. | Targeted audit, not default development selection. |
+| `missing ledger row` | Restore or register the canonical row and pass the full pipeline, strict lint, and repository invariants. | New campaign after registry repair. |
+| `judicial_panel_required` | No repair: this is the normal two-seat disagreement handoff. | Immediate five-judge panel, then resume the same lane. |
+
+The exclusion JSONL is append-only incident provenance for one campaign. Do
+not delete individual records to force retry and do not reuse the old campaign
+workdir after repairing prerequisites. Start a new campaign workdir; the row is
+then eligible under current queue and selector rules. A campaign fixed point
+with exclusions means “all non-excluded actionable work drained,” not “the
+entire audit backlog is empty.”
 
 ## Long-Running Runner / Timeout Guard
 
@@ -915,8 +989,9 @@ policy blocker prevents progress:
 | --- | --- |
 | Five-judge panel has no 3-of-5 majority, sides with neither original audit, or produces a hybrid / currently unapplyable tuple | Run another five-judge panel with all prior panel outcomes in context |
 | Cross-confirmation disagreement exists but the five-judge panel cannot be run with the required context/model | Stop as a tooling availability blocker |
-| `apply_audit.py` rejects the verdict JSON or blocks on a hard rule | Stop as an audit tooling blocker after preserving the rejected JSON and exact error |
-| `audit_lint.py --strict` fails after applying the verdict | Restore the pre-apply generated audit diff and stop as a verification blocker |
+| A batch claim's apply/pipeline/lint transaction fails and rollback to synchronized `origin/main` is verified clean | Quarantine that claim for the campaign, preserve the validated delivery and exact error, and continue unrelated rows |
+| `apply_audit.py` rejects a targeted/manual verdict JSON or a hard rule cannot be scoped to one cleanly rolled-back batch claim | Stop as an audit tooling blocker after preserving the rejected JSON and exact error |
+| `audit_lint.py --strict` fails and rollback cannot be verified clean, or the same infrastructure failure repeats across unrelated claims | Stop as a global verification blocker |
 
 ## Commit And Push
 
@@ -962,8 +1037,9 @@ After each successful direct-main push:
 2. If time and user intent allow, fetch `origin/main`, refresh the queue, exclude any session-local blocked/skip rows, and start the next claim.
 3. Stop if there is an ambiguous independence issue, source-note hash drift that cannot be resolved mechanically, or an audit requiring domain expertise beyond the provided authorities.
 
-For unresolved hard tooling or policy blockers listed above, do not push to
-`main`; preserve the rejected JSON, panel logs, and exact command output, then
-report the blocker. Do not stop merely because a five-judge panel occurred or
-because a panel was unresolved; continue with a fresh panel carrying the prior
-panel outcomes in context.
+For unresolved global hard tooling or policy blockers listed above, do not
+push to `main`; preserve the rejected JSON, panel logs, campaign exclusion
+records, and exact command output, then report the blocker. A verified
+claim-local rollback is quarantined and does not stop the campaign. Do not stop
+merely because a five-judge panel occurred or because a panel was unresolved;
+continue with a fresh panel carrying the prior panel outcomes in context.

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -332,9 +332,10 @@ failures. This boundary is fail-closed and does not weaken any audit gate.
   to one row. Preserve artifacts and stop before minting authority.
 - Treat the campaign exclusion JSONL as a closed operational schema. Reject
   blank records, duplicate JSON keys, unknown exclusion reasons, noncanonical
-  claim ids, missing reason-specific evidence, malformed timestamps, and
-  unexpected fields. A damaged record must hard-stop the whole campaign
-  rather than silently suppressing a claim.
+  claim ids, non-finite numbers, noncanonical UTC timestamps, missing or
+  reason-incompatible failure evidence, unverified transaction rollback
+  evidence, and unexpected fields at every nesting level. A damaged record
+  must hard-stop the whole campaign rather than silently suppressing a claim.
 - Transaction rollback proof is stricter than the normal main-checkout guard:
   after resetting to the captured `origin/main` OID, require literal empty
   `git status --porcelain` plus exact local/remote OID equality. The narrowly

--- a/docs/audit/scripts/audit_campaign_repair.py
+++ b/docs/audit/scripts/audit_campaign_repair.py
@@ -19,37 +19,17 @@ REPO_ROOT = SCRIPTS.parents[2]
 sys.path.insert(0, str(SCRIPTS))
 
 import ledger_io  # noqa: E402
+import orchestrate_audit_batch as batch  # noqa: E402
 
 
-SCHEMA_QUARANTINE = "schema_invalid_quarantined"
-COMPUTE_QUARANTINE = "compute_required_quarantined"
-TRANSACTION_QUARANTINE = "claim_transaction_quarantined"
-BLOCKED_REENTRY = "blocked_row_reentry_quarantined"
+SCHEMA_QUARANTINE = batch.SCHEMA_QUARANTINE_RESULT
+COMPUTE_QUARANTINE = batch.COMPUTE_QUARANTINE_RESULT
+TRANSACTION_QUARANTINE = batch.CLAIM_TRANSACTION_QUARANTINE_RESULT
+BLOCKED_REENTRY = batch.BLOCKED_ROW_QUARANTINE_RESULT
 
 
 def load_exclusions(path: Path) -> list[dict]:
-    records: list[dict] = []
-    for line_number, line in enumerate(
-        path.read_text(encoding="utf-8").splitlines(), start=1
-    ):
-        if not line.strip():
-            continue
-        try:
-            record = json.loads(line)
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"{path}:{line_number}: invalid JSON: {exc.msg}"
-            ) from exc
-        if not isinstance(record, dict):
-            raise ValueError(f"{path}:{line_number}: record is not an object")
-        claim_id = record.get("claim_id")
-        reason = record.get("reason")
-        if not isinstance(claim_id, str) or not claim_id:
-            raise ValueError(f"{path}:{line_number}: missing claim_id")
-        if not isinstance(reason, str) or not reason:
-            raise ValueError(f"{path}:{line_number}: missing reason")
-        records.append(record)
-    return records
+    return batch.load_campaign_exclusion_records(path)
 
 
 def repair_route(record: dict, row: dict | None) -> dict:
@@ -186,7 +166,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         exclusions = load_exclusions(path)
         rows = ledger_io.load_ledger().get("rows", {})
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
+    except (OSError, ValueError) as exc:
         parser.error(str(exc))
     plan = build_plan(exclusions, rows)
     if args.json:

--- a/docs/audit/scripts/audit_campaign_repair.py
+++ b/docs/audit/scripts/audit_campaign_repair.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Explain how campaign-scoped audit exclusions re-enter the drainer.
+
+The audit supervisor records operational exclusions in
+``campaign-row-exclusions.jsonl``.  They are not scientific verdicts and must
+not be copied into the ledger.  This read-only helper joins those records to
+current operational ledger metadata and emits the prerequisite repair route
+for a fresh campaign.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPTS.parents[2]
+sys.path.insert(0, str(SCRIPTS))
+
+import ledger_io  # noqa: E402
+
+
+SCHEMA_QUARANTINE = "schema_invalid_quarantined"
+COMPUTE_QUARANTINE = "compute_required_quarantined"
+TRANSACTION_QUARANTINE = "claim_transaction_quarantined"
+BLOCKED_REENTRY = "blocked_row_reentry_quarantined"
+
+
+def load_exclusions(path: Path) -> list[dict]:
+    records: list[dict] = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"{path}:{line_number}: invalid JSON: {exc.msg}"
+            ) from exc
+        if not isinstance(record, dict):
+            raise ValueError(f"{path}:{line_number}: record is not an object")
+        claim_id = record.get("claim_id")
+        reason = record.get("reason")
+        if not isinstance(claim_id, str) or not claim_id:
+            raise ValueError(f"{path}:{line_number}: missing claim_id")
+        if not isinstance(reason, str) or not reason:
+            raise ValueError(f"{path}:{line_number}: missing reason")
+        records.append(record)
+    return records
+
+
+def repair_route(record: dict, row: dict | None) -> dict:
+    claim_id = record["claim_id"]
+    reason = record["reason"]
+    current = {
+        "audit_status": row.get("audit_status") if row else None,
+        "effective_status": row.get("effective_status") if row else None,
+        "note_path": row.get("note_path") if row else None,
+        "runner_path": row.get("runner_path") if row else None,
+    }
+    result = {
+        "claim_id": claim_id,
+        "reason": reason,
+        "current": current,
+        "failures": record.get("failures") or [],
+    }
+    if row is None:
+        return {
+            **result,
+            "route": "repair_ledger_registration",
+            "ready_for_new_campaign": False,
+            "action": (
+                "Restore or register the missing canonical ledger row, run the "
+                "full pipeline and strict lint, then start a new campaign."
+            ),
+        }
+    if reason == SCHEMA_QUARANTINE:
+        return {
+            **result,
+            "route": "fresh_schema_valid_seat",
+            "ready_for_new_campaign": True,
+            "action": (
+                "Keep the malformed output non-authoritative. Correct the "
+                "transport/prompt defect named in failures, then start a new "
+                "campaign so a fresh restricted-context seat is selected."
+            ),
+        }
+    if reason == COMPUTE_QUARANTINE:
+        runner = str(row.get("runner_path") or "").strip()
+        command = (
+            f"python3 scripts/cached_runner_output.py {runner}"
+            if runner
+            else None
+        )
+        return {
+            **result,
+            "route": "supply_compute_artifact",
+            "ready_for_new_campaign": False,
+            "command": command,
+            "action": (
+                "Produce a SHA-pinned runner cache, sliced deterministic "
+                "certificate, or independent derivation; run the full pipeline "
+                "and strict lint; then start a new campaign."
+            ),
+        }
+    if reason == BLOCKED_REENTRY:
+        resolved = row.get("audit_status") != "unaudited"
+        return {
+            **result,
+            "route": (
+                "already_moved_out_of_reentry"
+                if resolved
+                else "repair_invalidation_cause"
+            ),
+            "ready_for_new_campaign": resolved,
+            "invalidation_reason": record.get("invalidation_reason"),
+            "action": (
+                "The current row no longer has the quarantined unaudited "
+                "re-entry state; verify a full pipeline and strict lint before "
+                "a new campaign."
+                if resolved
+                else
+                "Repair the recorded classifier, dependency, source-hash, or "
+                "status invalidation cause. Require a converged full pipeline "
+                "and strict lint before starting a new campaign."
+            ),
+        }
+    if reason == TRANSACTION_QUARANTINE:
+        return {
+            **result,
+            "route": "repair_claim_transaction",
+            "ready_for_new_campaign": False,
+            "action": (
+                "Repair the recorded apply, pipeline, or strict-lint defect and "
+                "prove the full pipeline is converged. The failed delivery "
+                "minted no verdict; retry with a fresh seat in a new campaign "
+                "unless a separate preserved-delivery replay contract verifies "
+                "the exact envelope and source fingerprint."
+            ),
+        }
+    return {
+        **result,
+        "route": "manual_operational_triage",
+        "ready_for_new_campaign": False,
+        "action": (
+            "Unknown exclusion reason: preserve it, diagnose the operational "
+            "cause, and do not translate it into a scientific verdict."
+        ),
+    }
+
+
+def build_plan(exclusions: list[dict], rows: dict[str, dict]) -> list[dict]:
+    return [
+        repair_route(record, rows.get(record["claim_id"]))
+        for record in exclusions
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render a read-only repair plan for audit campaign exclusions"
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--campaign-workdir",
+        type=Path,
+        help="directory containing campaign-row-exclusions.jsonl",
+    )
+    source.add_argument(
+        "--exclusions",
+        type=Path,
+        help="campaign-row-exclusions.jsonl path",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON only")
+    args = parser.parse_args(argv)
+    path = (
+        args.exclusions
+        if args.exclusions is not None
+        else args.campaign_workdir / "campaign-row-exclusions.jsonl"
+    )
+    if not path.exists():
+        parser.error(f"exclusion file does not exist: {path}")
+    try:
+        exclusions = load_exclusions(path)
+        rows = ledger_io.load_ledger().get("rows", {})
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        parser.error(str(exc))
+    plan = build_plan(exclusions, rows)
+    if args.json:
+        print(json.dumps({"exclusions": plan}, indent=2, sort_keys=True))
+        return 0
+    print(f"audit campaign repair plan: {path}")
+    if not plan:
+        print("  no campaign exclusions")
+        return 0
+    for item in plan:
+        print(
+            f"  {item['claim_id']}: {item['reason']} -> {item['route']} "
+            f"(new_campaign_ready={str(item['ready_for_new_campaign']).lower()})"
+        )
+        if item.get("command"):
+            print(f"    command: {item['command']}")
+        print(f"    {item['action']}")
+    print(
+        "Start repaired rows in a new campaign workdir; reusing the old "
+        "workdir intentionally preserves its exclusions."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -21,6 +21,7 @@ import argparse
 import fcntl
 import hashlib
 import json
+import math
 import os
 import queue
 import re
@@ -1800,6 +1801,99 @@ def _reject_campaign_json_constant(value: str) -> None:
     raise ValueError(f"non-finite JSON value {value!r}")
 
 
+def _contains_non_finite_json_number(value: object) -> bool:
+    if isinstance(value, float):
+        return not math.isfinite(value)
+    if isinstance(value, list):
+        return any(_contains_non_finite_json_number(item) for item in value)
+    if isinstance(value, dict):
+        return any(
+            _contains_non_finite_json_number(item)
+            for item in value.values()
+        )
+    return False
+
+
+def _campaign_failure_schema_error(
+    claim_id: str,
+    reason: str,
+    failure: object,
+) -> str | None:
+    if not isinstance(failure, dict):
+        return "campaign exclusion failure is not an object"
+    result = failure.get("result")
+    if not isinstance(result, str):
+        return "campaign exclusion failure has no string result"
+    if failure.get("cid") != claim_id:
+        return "campaign exclusion failure cid does not match claim_id"
+
+    if reason == SCHEMA_QUARANTINE_RESULT:
+        expected = {"cid", "pass", "result"}
+        if result == "validation_failed":
+            expected.add("detail")
+        elif result != "malformed_json":
+            return (
+                "campaign exclusion failure result is incompatible with "
+                f"{reason!r}"
+            )
+    elif reason == COMPUTE_QUARANTINE_RESULT:
+        if result != "compute_required":
+            return (
+                "campaign exclusion failure result is incompatible with "
+                f"{reason!r}"
+            )
+        expected = {"cid", "pass", "result", "detail"}
+    elif reason == CLAIM_TRANSACTION_QUARANTINE_RESULT:
+        if result == "apply_or_gate_failed":
+            expected = {
+                "cid",
+                "result",
+                "detail",
+                "rollback_verified",
+                "rollback_detail",
+            }
+            if "pass" in failure:
+                expected.add("pass")
+            if failure.get("rollback_verified") is not True:
+                return (
+                    "claim-transaction failure has no verified rollback proof"
+                )
+            rollback_detail = failure.get("rollback_detail")
+            if (
+                not isinstance(rollback_detail, str)
+                or not rollback_detail.strip()
+            ):
+                return (
+                    "claim-transaction failure has no rollback detail"
+                )
+        elif result == CLAIM_TRANSACTION_QUARANTINE_RESULT:
+            expected = {"cid", "result", "detail"}
+        else:
+            return (
+                "campaign exclusion failure result is incompatible with "
+                f"{reason!r}"
+            )
+    else:
+        return f"unsupported failure-bearing exclusion reason {reason!r}"
+
+    if set(failure) != expected:
+        missing = sorted(expected - set(failure))
+        unexpected = sorted(set(failure) - expected)
+        return (
+            "invalid campaign exclusion failure fields "
+            f"(missing={missing}, unexpected={unexpected})"
+        )
+    if "pass" in expected:
+        pass_no = failure.get("pass")
+        if isinstance(pass_no, bool) or pass_no not in {1, 2}:
+            return "campaign exclusion failure pass must be 1 or 2"
+    if "detail" in expected:
+        detail = failure.get("detail")
+        if not isinstance(detail, str) or not detail.strip():
+            return "campaign exclusion failure has no detail"
+    return None
+
+
 def load_campaign_exclusion_records(path: Path | None) -> list[dict]:
     if path is None or not path.exists():
         return []
@@ -1827,6 +1921,11 @@ def load_campaign_exclusion_records(path: Path | None) -> list[dict]:
             raise ValueError(
                 f"{path}:{line_number}: invalid campaign exclusion JSON: {exc}"
             ) from exc
+        if _contains_non_finite_json_number(record):
+            raise ValueError(
+                f"{path}:{line_number}: campaign exclusion contains a "
+                "non-finite JSON number"
+            )
         if not isinstance(record, dict):
             raise ValueError(
                 f"{path}:{line_number}: campaign exclusion is not an object"
@@ -1858,14 +1957,26 @@ def load_campaign_exclusion_records(path: Path | None) -> list[dict]:
                 f"{path}:{line_number}: invalid campaign exclusion fields "
                 f"(missing={missing}, unexpected={unexpected})"
             )
-        if cid.strip() != cid:
+        try:
+            ledger_io.shard_path(cid)
+        except ValueError as exc:
             raise ValueError(
-                f"{path}:{line_number}: campaign exclusion claim_id is not canonical"
-            )
+                f"{path}:{line_number}: campaign exclusion claim_id is not "
+                f"shard-safe: {cid!r}"
+            ) from exc
         recorded_at = record["recorded_at"]
         if not isinstance(recorded_at, str) or not recorded_at:
             raise ValueError(
                 f"{path}:{line_number}: campaign exclusion has no recorded_at"
+            )
+        if not re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+            r"(?:\.\d{6})?\+00:00",
+            recorded_at,
+        ):
+            raise ValueError(
+                f"{path}:{line_number}: campaign exclusion recorded_at "
+                "is not canonical UTC ISO-8601"
             )
         try:
             timestamp = datetime.fromisoformat(recorded_at)
@@ -1874,10 +1985,13 @@ def load_campaign_exclusion_records(path: Path | None) -> list[dict]:
                 f"{path}:{line_number}: campaign exclusion recorded_at "
                 "is not ISO-8601"
             ) from exc
-        if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+        if (
+            timestamp.tzinfo is None
+            or timestamp.utcoffset() != timezone.utc.utcoffset(timestamp)
+        ):
             raise ValueError(
                 f"{path}:{line_number}: campaign exclusion recorded_at "
-                "has no timezone"
+                "is not UTC"
             )
         if reason == BLOCKED_ROW_QUARANTINE_RESULT:
             invalidation_reason = record["invalidation_reason"]
@@ -1891,14 +2005,32 @@ def load_campaign_exclusion_records(path: Path | None) -> list[dict]:
                 )
         else:
             failures = record["failures"]
-            if (
-                not isinstance(failures, list)
-                or not failures
-                or not all(isinstance(item, dict) for item in failures)
-            ):
+            if not isinstance(failures, list) or not failures:
                 raise ValueError(
                     f"{path}:{line_number}: campaign exclusion failures "
                     "must be a non-empty list of objects"
+                )
+            for failure in failures:
+                failure_error = _campaign_failure_schema_error(
+                    cid,
+                    reason,
+                    failure,
+                )
+                if failure_error is not None:
+                    raise ValueError(
+                        f"{path}:{line_number}: {failure_error}"
+                    )
+            if (
+                reason == CLAIM_TRANSACTION_QUARANTINE_RESULT
+                and not any(
+                    failure.get("result") == "apply_or_gate_failed"
+                    and failure.get("rollback_verified") is True
+                    for failure in failures
+                )
+            ):
+                raise ValueError(
+                    f"{path}:{line_number}: claim-transaction exclusion has "
+                    "no verified apply/gate rollback failure"
                 )
         records.append(record)
     return records

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -73,12 +73,18 @@ SCHEMA_QUARANTINE_RESULT = "schema_invalid_quarantined"
 SCHEMA_DEFERRED_RESULT = "schema_invalid_peer_deferred"
 SCHEMA_SUPERSEDED_RESULT = "schema_invalid_attempt_superseded"
 BLOCKED_ROW_QUARANTINE_RESULT = "blocked_row_reentry_quarantined"
+COMPUTE_QUARANTINE_RESULT = "compute_required_quarantined"
+CLAIM_TRANSACTION_QUARANTINE_RESULT = "claim_transaction_quarantined"
 SCHEMA_RECOVERY_RESULTS = {
     SCHEMA_QUARANTINE_RESULT,
     SCHEMA_DEFERRED_RESULT,
     SCHEMA_SUPERSEDED_RESULT,
 }
-CAMPAIGN_EXCLUSION_RESULTS = {BLOCKED_ROW_QUARANTINE_RESULT}
+CAMPAIGN_EXCLUSION_RESULTS = {
+    BLOCKED_ROW_QUARANTINE_RESULT,
+    COMPUTE_QUARANTINE_RESULT,
+    CLAIM_TRANSACTION_QUARANTINE_RESULT,
+}
 SCIENCE_FIX_RESULTS = {"science_fix_dispatched", "science_fix_dispatch_failed"}
 MIN_DELIVERY_BYTES = 200
 PACKET_COMPLETION_STALL_SECONDS = 20 * 60
@@ -1757,6 +1763,29 @@ def persist_campaign_quarantine(
     claim_ids: set[str],
     report: list[dict],
 ) -> None:
+    persist_campaign_exclusions(
+        path,
+        claim_ids,
+        reason=SCHEMA_QUARANTINE_RESULT,
+        report=report,
+        companion_results=SCHEMA_INVALID_RESULTS,
+    )
+
+
+def persist_campaign_exclusions(
+    path: Path | None,
+    claim_ids: set[str],
+    *,
+    reason: str,
+    report: list[dict],
+    companion_results: set[str],
+) -> None:
+    """Append one durable campaign-local exclusion record per claim.
+
+    Exclusions are operational state, never audit verdicts.  The exact
+    companion failures stay attached so a later repair campaign can route the
+    row without reading prior scientific rationales.
+    """
     if path is None or not claim_ids:
         return
     existing = load_campaign_quarantine(path)
@@ -1767,13 +1796,13 @@ def persist_campaign_quarantine(
                 item
                 for item in report
                 if item.get("cid") == cid
-                and item.get("result") in SCHEMA_INVALID_RESULTS
+                and item.get("result") in companion_results
             ]
             handle.write(
                 json.dumps(
                     {
                         "claim_id": cid,
-                        "reason": SCHEMA_QUARANTINE_RESULT,
+                        "reason": reason,
                         "failures": failures,
                         "recorded_at": datetime.now(timezone.utc).isoformat(),
                     },
@@ -1781,6 +1810,37 @@ def persist_campaign_quarantine(
                 )
                 + "\n"
             )
+
+
+def persist_compute_required_skips(
+    path: Path | None,
+    claim_ids: set[str],
+    report: list[dict],
+) -> None:
+    persist_campaign_exclusions(
+        path,
+        claim_ids,
+        reason=COMPUTE_QUARANTINE_RESULT,
+        report=report,
+        companion_results={"compute_required"},
+    )
+
+
+def persist_claim_transaction_quarantines(
+    path: Path | None,
+    claim_ids: set[str],
+    report: list[dict],
+) -> None:
+    persist_campaign_exclusions(
+        path,
+        claim_ids,
+        reason=CLAIM_TRANSACTION_QUARANTINE_RESULT,
+        report=report,
+        companion_results={
+            "apply_or_gate_failed",
+            CLAIM_TRANSACTION_QUARANTINE_RESULT,
+        },
+    )
 
 
 def _latest_invalidation_reason(row: dict) -> str:
@@ -1979,6 +2039,31 @@ def apply_serialized(
         ok, results = apply_claim_serialized(claim_deliveries, retries)
         report.extend(results)
         if not ok:
+            # apply_claim_serialized rolls an apply/gate rejection back to the
+            # synchronized origin/main parent.  Once that rollback is proven
+            # clean, this is a claim-local operational failure: quarantine the
+            # row for this campaign and keep draining unrelated science.
+            # Sync, reset, commit, and push failures remain global/uncertain
+            # and still stop the batch.
+            claim_local = (
+                bool(results)
+                and all(
+                    item.get("result") == "apply_or_gate_failed"
+                    for item in results
+                )
+                and clean_main_error() is None
+            )
+            if claim_local:
+                report.append({
+                    "cid": cid,
+                    "result": CLAIM_TRANSACTION_QUARANTINE_RESULT,
+                    "detail": (
+                        "apply/pipeline/lint transaction failed after validated "
+                        "delivery; rollback to synchronized origin/main was "
+                        "verified, so this claim is excluded for the campaign"
+                    ),
+                })
+                continue
             return (
                 False,
                 compute_skips,
@@ -2258,9 +2343,26 @@ def main() -> int:
             ) = apply_serialized(jobs, report, args.push_retries)
         session_skipped.update(compute_skips)
         session_skipped.update(schema_quarantines)
+        transaction_quarantines = {
+            item["cid"]
+            for item in report
+            if item.get("result") == CLAIM_TRANSACTION_QUARANTINE_RESULT
+            and isinstance(item.get("cid"), str)
+        }
+        session_skipped.update(transaction_quarantines)
         persist_campaign_quarantine(
             args.campaign_quarantine_file,
             schema_quarantines,
+            report,
+        )
+        persist_compute_required_skips(
+            args.campaign_quarantine_file,
+            compute_skips,
+            report,
+        )
+        persist_claim_transaction_quarantines(
+            args.campaign_quarantine_file,
+            transaction_quarantines,
             report,
         )
         science_handoffs.update(
@@ -2351,12 +2453,21 @@ def report_has_hard_blocker(report: list[dict]) -> bool:
         for item in report
         if item.get("result") in SCHEMA_RECOVERY_RESULTS
     }
+    transaction_quarantined = {
+        item.get("cid")
+        for item in report
+        if item.get("result") == CLAIM_TRANSACTION_QUARANTINE_RESULT
+    }
     quarantine_companions = SCHEMA_INVALID_RESULTS | {"critical_peer_pending"}
     return any(
         item.get("result") not in accepted
         and not (
             item.get("cid") in recovered
             and item.get("result") in quarantine_companions
+        )
+        and not (
+            item.get("cid") in transaction_quarantined
+            and item.get("result") == "apply_or_gate_failed"
         )
         for item in report
     )

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -85,6 +85,10 @@ CAMPAIGN_EXCLUSION_RESULTS = {
     COMPUTE_QUARANTINE_RESULT,
     CLAIM_TRANSACTION_QUARANTINE_RESULT,
 }
+CAMPAIGN_EXCLUSION_REASONS = {
+    SCHEMA_QUARANTINE_RESULT,
+    *CAMPAIGN_EXCLUSION_RESULTS,
+}
 SCIENCE_FIX_RESULTS = {"science_fix_dispatched", "science_fix_dispatch_failed"}
 MIN_DELIVERY_BYTES = 200
 PACKET_COMPLETION_STALL_SECONDS = 20 * 60
@@ -1509,9 +1513,29 @@ def reset_to_origin_main() -> tuple[bool, str]:
     )
     if reset.returncode != 0:
         return False, f"reset failed: {(reset.stderr or reset.stdout).strip()[:240]}"
-    error = clean_main_error(honor_cancel=False)
-    if error is not None:
-        return False, error
+    branch = sh(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        honor_cancel=False,
+    )
+    if branch.returncode != 0:
+        return False, "cannot determine current branch after rollback"
+    if branch.stdout.strip() != "main":
+        return False, (
+            "rollback did not leave main checked out "
+            f"({branch.stdout.strip()!r})"
+        )
+    status = sh(
+        ["git", "status", "--porcelain"],
+        honor_cancel=False,
+    )
+    if status.returncode != 0:
+        return False, "cannot determine worktree status after rollback"
+    if status.stdout.strip():
+        # The normal main guard can tolerate one mechanically recognized
+        # lane-certification provenance drift. Transaction rollback cannot:
+        # quarantine is permitted only after reset proves literal zero-diff
+        # source and generated state.
+        return False, "rollback did not leave a literally clean worktree"
     head = sh(["git", "rev-parse", "HEAD"], honor_cancel=False)
     remote = sh(["git", "rev-parse", "origin/main"], honor_cancel=False)
     if head.returncode != 0 or remote.returncode != 0:
@@ -1763,6 +1787,19 @@ def launch_science_fix_worker(
     return proc.pid, handoff_path, log_path
 
 
+def _campaign_json_object(pairs: list[tuple[str, object]]) -> dict:
+    record: dict = {}
+    for key, value in pairs:
+        if key in record:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        record[key] = value
+    return record
+
+
+def _reject_campaign_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON value {value!r}")
+
+
 def load_campaign_exclusion_records(path: Path | None) -> list[dict]:
     if path is None or not path.exists():
         return []
@@ -1772,13 +1809,23 @@ def load_campaign_exclusion_records(path: Path | None) -> list[dict]:
         start=1,
     ):
         if not line.strip():
-            continue
+            raise ValueError(
+                f"{path}:{line_number}: blank campaign exclusion record"
+            )
         try:
-            record = json.loads(line)
+            record = json.loads(
+                line,
+                object_pairs_hook=_campaign_json_object,
+                parse_constant=_reject_campaign_json_constant,
+            )
         except json.JSONDecodeError as exc:
             raise ValueError(
                 f"{path}:{line_number}: invalid campaign exclusion JSON: "
                 f"{exc.msg}"
+            ) from exc
+        except ValueError as exc:
+            raise ValueError(
+                f"{path}:{line_number}: invalid campaign exclusion JSON: {exc}"
             ) from exc
         if not isinstance(record, dict):
             raise ValueError(
@@ -1794,6 +1841,65 @@ def load_campaign_exclusion_records(path: Path | None) -> list[dict]:
             raise ValueError(
                 f"{path}:{line_number}: campaign exclusion has no reason"
             )
+        if reason not in CAMPAIGN_EXCLUSION_REASONS:
+            raise ValueError(
+                f"{path}:{line_number}: unrecognized campaign exclusion "
+                f"reason {reason!r}"
+            )
+        common_fields = {"claim_id", "reason", "recorded_at"}
+        if reason == BLOCKED_ROW_QUARANTINE_RESULT:
+            expected_fields = common_fields | {"invalidation_reason"}
+        else:
+            expected_fields = common_fields | {"failures"}
+        if set(record) != expected_fields:
+            missing = sorted(expected_fields - set(record))
+            unexpected = sorted(set(record) - expected_fields)
+            raise ValueError(
+                f"{path}:{line_number}: invalid campaign exclusion fields "
+                f"(missing={missing}, unexpected={unexpected})"
+            )
+        if cid.strip() != cid:
+            raise ValueError(
+                f"{path}:{line_number}: campaign exclusion claim_id is not canonical"
+            )
+        recorded_at = record["recorded_at"]
+        if not isinstance(recorded_at, str) or not recorded_at:
+            raise ValueError(
+                f"{path}:{line_number}: campaign exclusion has no recorded_at"
+            )
+        try:
+            timestamp = datetime.fromisoformat(recorded_at)
+        except ValueError as exc:
+            raise ValueError(
+                f"{path}:{line_number}: campaign exclusion recorded_at "
+                "is not ISO-8601"
+            ) from exc
+        if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+            raise ValueError(
+                f"{path}:{line_number}: campaign exclusion recorded_at "
+                "has no timezone"
+            )
+        if reason == BLOCKED_ROW_QUARANTINE_RESULT:
+            invalidation_reason = record["invalidation_reason"]
+            if (
+                not isinstance(invalidation_reason, str)
+                or not invalidation_reason.strip()
+            ):
+                raise ValueError(
+                    f"{path}:{line_number}: blocked-row exclusion has no "
+                    "invalidation_reason"
+                )
+        else:
+            failures = record["failures"]
+            if (
+                not isinstance(failures, list)
+                or not failures
+                or not all(isinstance(item, dict) for item in failures)
+            ):
+                raise ValueError(
+                    f"{path}:{line_number}: campaign exclusion failures "
+                    "must be a non-empty list of objects"
+                )
         records.append(record)
     return records
 

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -1496,14 +1496,29 @@ def stage_and_commit(message: str) -> tuple[bool, str]:
 def reset_to_origin_main() -> tuple[bool, str]:
     # Rollback must remain available after a cancellation request; otherwise
     # an interrupted commit/push can strand dirty or ahead local main state.
+    target = sh(
+        ["git", "rev-parse", "origin/main"],
+        honor_cancel=False,
+    )
+    target_oid = target.stdout.strip()
+    if target.returncode != 0 or not re.fullmatch(r"[0-9a-f]{40}", target_oid):
+        return False, "cannot resolve rollback target origin/main"
     reset = sh(
-        ["git", "reset", "--hard", "origin/main"],
+        ["git", "reset", "--hard", target_oid],
         honor_cancel=False,
     )
     if reset.returncode != 0:
         return False, f"reset failed: {(reset.stderr or reset.stdout).strip()[:240]}"
     error = clean_main_error(honor_cancel=False)
-    return (error is None, error or "reset to origin/main")
+    if error is not None:
+        return False, error
+    head = sh(["git", "rev-parse", "HEAD"], honor_cancel=False)
+    remote = sh(["git", "rev-parse", "origin/main"], honor_cancel=False)
+    if head.returncode != 0 or remote.returncode != 0:
+        return False, "cannot verify rollback refs"
+    if head.stdout.strip() != target_oid or remote.stdout.strip() != target_oid:
+        return False, "rollback did not leave HEAD synchronized with origin/main"
+    return True, f"reset to origin/main at {target_oid}"
 
 
 def apply_claim_serialized(
@@ -1523,17 +1538,26 @@ def apply_claim_serialized(
         raise ValueError("one non-empty claim delivery group is required")
     cid = next(iter(claim_ids))
 
-    def fail_after_local_commit(result: str, detail: str | None = None):
+    def fail_after_transaction(
+        result: str,
+        detail: str | None = None,
+        *,
+        pass_no: int | None = None,
+    ):
         reset, reset_detail = reset_to_origin_main()
         if not reset:
             return False, [{
                 "cid": cid,
                 "result": "race_reset_failed",
-                "detail": reset_detail,
+                "detail": f"{result}: {detail or 'transaction failed'}; {reset_detail}",
             }]
         failure = {"cid": cid, "result": result}
+        if pass_no is not None:
+            failure["pass"] = pass_no
         if detail is not None:
             failure["detail"] = detail
+        failure["rollback_verified"] = True
+        failure["rollback_detail"] = reset_detail
         return False, [failure]
 
     for attempt in range(1, retries + 1):
@@ -1548,18 +1572,15 @@ def apply_claim_serialized(
                 evidence_manifest=envelope["evidence_manifest"],
             )
             if not applied:
-                reset_to_origin_main()
-                return False, [{
-                    "cid": cid,
-                    "pass": job["pass"],
-                    "result": "apply_or_gate_failed",
-                    "detail": f"apply rejected: {apply_detail[:400]}",
-                }]
+                return fail_after_transaction(
+                    "apply_or_gate_failed",
+                    f"apply rejected: {apply_detail[:400]}",
+                    pass_no=job["pass"],
+                )
 
         gated, detail = run_generated_gates()
         if not gated:
-            reset_to_origin_main()
-            return False, [{"cid": cid, "result": "apply_or_gate_failed", "detail": detail}]
+            return fail_after_transaction("apply_or_gate_failed", detail)
         verdicts = [str(envelope["audit"].get("verdict")) for _, envelope in ordered]
         seats = ["first" if job["pass"] == 1 else "second" for job, _ in ordered]
         committed, detail = stage_and_commit(
@@ -1567,8 +1588,7 @@ def apply_claim_serialized(
             f"(codex-cli, {MODEL}, {REASONING}, {'+'.join(seats)}/batch)"
         )
         if not committed:
-            reset_to_origin_main()
-            return False, [{"cid": cid, "result": "commit_failed", "detail": detail}]
+            return fail_after_transaction("commit_failed", detail)
         local_commit = detail
         push = sh(["git", "push", "-q", "origin", "HEAD:main"])
         if push.returncode == 0:
@@ -1583,18 +1603,18 @@ def apply_claim_serialized(
             ]
 
         if _command_cancelled():
-            return fail_after_local_commit("commit_cancelled")
+            return fail_after_transaction("commit_cancelled")
 
         fetch = sh(["git", "fetch", "origin", "main", "-q"])
         if fetch.returncode != 0:
             result = "commit_cancelled" if _command_cancelled() else "push_failed"
             detail = None if result == "commit_cancelled" else "push and follow-up fetch failed"
-            return fail_after_local_commit(result, detail)
+            return fail_after_transaction(result, detail)
         if _command_cancelled():
-            return fail_after_local_commit("commit_cancelled")
+            return fail_after_transaction("commit_cancelled")
         landed = sh(["git", "merge-base", "--is-ancestor", local_commit, "origin/main"])
         if _command_cancelled():
-            return fail_after_local_commit("commit_cancelled")
+            return fail_after_transaction("commit_cancelled")
         if landed.returncode == 0:
             return True, [
                 {
@@ -1606,7 +1626,7 @@ def apply_claim_serialized(
                 for job, envelope in ordered
             ]
         if attempt == retries:
-            return fail_after_local_commit("push_race_exhausted")
+            return fail_after_transaction("push_race_exhausted")
         reset, reset_detail = reset_to_origin_main()
         if not reset:
             return False, [{"cid": cid, "result": "race_reset_failed", "detail": reset_detail}]
@@ -1743,19 +1763,46 @@ def launch_science_fix_worker(
     return proc.pid, handoff_path, log_path
 
 
-def load_campaign_quarantine(path: Path | None) -> set[str]:
+def load_campaign_exclusion_records(path: Path | None) -> list[dict]:
     if path is None or not path.exists():
-        return set()
-    claim_ids: set[str] = set()
-    for line in path.read_text(encoding="utf-8").splitlines():
-        try:
-            row = json.loads(line)
-        except json.JSONDecodeError:
+        return []
+    records: list[dict] = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        if not line.strip():
             continue
-        cid = row.get("claim_id") if isinstance(row, dict) else None
-        if isinstance(cid, str) and cid:
-            claim_ids.add(cid)
-    return claim_ids
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"{path}:{line_number}: invalid campaign exclusion JSON: "
+                f"{exc.msg}"
+            ) from exc
+        if not isinstance(record, dict):
+            raise ValueError(
+                f"{path}:{line_number}: campaign exclusion is not an object"
+            )
+        cid = record.get("claim_id")
+        reason = record.get("reason")
+        if not isinstance(cid, str) or not cid:
+            raise ValueError(
+                f"{path}:{line_number}: campaign exclusion has no claim_id"
+            )
+        if not isinstance(reason, str) or not reason:
+            raise ValueError(
+                f"{path}:{line_number}: campaign exclusion has no reason"
+            )
+        records.append(record)
+    return records
+
+
+def load_campaign_quarantine(path: Path | None) -> set[str]:
+    return {
+        record["claim_id"]
+        for record in load_campaign_exclusion_records(path)
+    }
 
 
 def persist_campaign_quarantine(
@@ -1788,10 +1835,17 @@ def persist_campaign_exclusions(
     """
     if path is None or not claim_ids:
         return
-    existing = load_campaign_quarantine(path)
+    existing = {
+        (record["claim_id"], record["reason"])
+        for record in load_campaign_exclusion_records(path)
+    }
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
-        for cid in sorted(claim_ids - existing):
+        for cid in sorted(
+            candidate
+            for candidate in claim_ids
+            if (candidate, reason) not in existing
+        ):
             failures = [
                 item
                 for item in report
@@ -1902,10 +1956,17 @@ def persist_blocked_row_reentries(
 ) -> None:
     if path is None or not reentries:
         return
-    existing = load_campaign_quarantine(path)
+    existing = {
+        (record["claim_id"], record["reason"])
+        for record in load_campaign_exclusion_records(path)
+    }
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
-        for cid in sorted(set(reentries) - existing):
+        for cid in sorted(
+            candidate
+            for candidate in reentries
+            if (candidate, BLOCKED_ROW_QUARANTINE_RESULT) not in existing
+        ):
             handle.write(
                 json.dumps(
                     {
@@ -2039,19 +2100,20 @@ def apply_serialized(
         ok, results = apply_claim_serialized(claim_deliveries, retries)
         report.extend(results)
         if not ok:
-            # apply_claim_serialized rolls an apply/gate rejection back to the
-            # synchronized origin/main parent.  Once that rollback is proven
-            # clean, this is a claim-local operational failure: quarantine the
-            # row for this campaign and keep draining unrelated science.
+            # apply_claim_serialized marks an apply/gate rejection claim-local
+            # only after reset_to_origin_main proves both a clean worktree and
+            # exact HEAD == origin/main synchronization. Once that explicit
+            # rollback proof is present, quarantine the row for this campaign
+            # and keep draining unrelated science.
             # Sync, reset, commit, and push failures remain global/uncertain
             # and still stop the batch.
             claim_local = (
                 bool(results)
                 and all(
                     item.get("result") == "apply_or_gate_failed"
+                    and item.get("rollback_verified") is True
                     for item in results
                 )
-                and clean_main_error() is None
             )
             if claim_local:
                 report.append({
@@ -2202,7 +2264,13 @@ def main() -> int:
     )
     report: list[dict] = []
     PROGRESS["report"] = report
-    session_skipped = load_campaign_quarantine(args.campaign_quarantine_file)
+    try:
+        session_skipped = load_campaign_quarantine(
+            args.campaign_quarantine_file
+        )
+    except (OSError, ValueError) as exc:
+        print(f"refusing to run with invalid campaign state: {exc}")
+        return finish(2)
     science_handoffs: dict[str, dict] = {}
     if not args.dry_run:
         try:

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -1885,7 +1885,7 @@ def _campaign_failure_schema_error(
         )
     if "pass" in expected:
         pass_no = failure.get("pass")
-        if isinstance(pass_no, bool) or pass_no not in {1, 2}:
+        if type(pass_no) is not int or pass_no not in {1, 2}:
             return "campaign exclusion failure pass must be 1 or 2"
     if "detail" in expected:
         detail = failure.get("detail")

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -118,6 +118,14 @@ def blocked_row_reentry_count() -> int:
     return campaign_exclusion_count(batch.BLOCKED_ROW_QUARANTINE_RESULT)
 
 
+def compute_quarantine_count() -> int:
+    return campaign_exclusion_count(batch.COMPUTE_QUARANTINE_RESULT)
+
+
+def claim_transaction_quarantine_count() -> int:
+    return campaign_exclusion_count(batch.CLAIM_TRANSACTION_QUARANTINE_RESULT)
+
+
 def audit_status_snapshot() -> dict[str, str | None]:
     """Read the materialized ledger without refreshing or rewriting caches."""
     ledger_cache = DATA / "audit_ledger.json"
@@ -167,6 +175,8 @@ def summary_line(final: bool = False) -> str:
         f"ready_rows={ready if ready is not None else 'unknown'} "
         f"remaining_lane_blockers={blockers if blockers is not None else 'unknown'} "
         f"schema_quarantined={schema_quarantine_count()} "
+        f"compute_quarantined={compute_quarantine_count()} "
+        f"transaction_quarantined={claim_transaction_quarantine_count()} "
         f"blocked_row_reentries={blocked_row_reentry_count()}"
     )
 
@@ -535,6 +545,19 @@ def main(argv: list[str] | None = None) -> int:
                         "fixed point excludes post-verdict rows that immediately "
                         "re-entered dep-ready selection; all other eligible rows "
                         f"were drained: {args.campaign_quarantine_file}"
+                    )
+                if compute_quarantine_count():
+                    emit(
+                        "fixed point excludes compute-required rows until their "
+                        "runner cache, sliced certificate, or independent "
+                        f"derivation is repaired: {args.campaign_quarantine_file}"
+                    )
+                if claim_transaction_quarantine_count():
+                    emit(
+                        "fixed point excludes claim-local apply/gate failures "
+                        "whose rollback to origin/main was verified; repair the "
+                        "recorded operational cause before a new campaign: "
+                        f"{args.campaign_quarantine_file}"
                     )
                 break
 

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -90,24 +90,19 @@ def remaining_blocker_count() -> int | None:
     )
 
 
-def campaign_exclusion_count(reason: str) -> int:
+def campaign_exclusion_counts() -> Counter:
     path = PROGRESS.get("quarantine_file")
-    if not isinstance(path, Path) or not path.exists():
-        return 0
-    claim_ids: set[str] = set()
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return 0
-    for line in lines:
-        try:
-            row = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        cid = row.get("claim_id") if isinstance(row, dict) else None
-        if isinstance(cid, str) and cid and row.get("reason") == reason:
-            claim_ids.add(cid)
-    return len(claim_ids)
+    if not isinstance(path, Path):
+        return Counter()
+    pairs = {
+        (record["claim_id"], record["reason"])
+        for record in batch.load_campaign_exclusion_records(path)
+    }
+    return Counter(reason for _cid, reason in pairs)
+
+
+def campaign_exclusion_count(reason: str) -> int:
+    return campaign_exclusion_counts()[reason]
 
 
 def schema_quarantine_count() -> int:
@@ -164,6 +159,20 @@ def summary_line(final: bool = False) -> str:
     ) or "none"
     ready = ready_row_count()
     blockers = remaining_blocker_count()
+    try:
+        exclusions = campaign_exclusion_counts()
+        schema_count: int | str = exclusions[batch.SCHEMA_QUARANTINE_RESULT]
+        compute_count: int | str = exclusions[batch.COMPUTE_QUARANTINE_RESULT]
+        transaction_count: int | str = exclusions[
+            batch.CLAIM_TRANSACTION_QUARANTINE_RESULT
+        ]
+        blocked_count: int | str = exclusions[
+            batch.BLOCKED_ROW_QUARANTINE_RESULT
+        ]
+    except (OSError, ValueError):
+        # The main control path treats malformed campaign state as a hard stop.
+        # Heartbeat/final summaries remain printable without hiding that state.
+        schema_count = compute_count = transaction_count = blocked_count = "invalid"
     return (
         f"== audit-loop {'final ' if final else ''}summary "
         f"elapsed={elapsed // 3600}h{(elapsed % 3600) // 60:02d}m "
@@ -174,10 +183,10 @@ def summary_line(final: bool = False) -> str:
         f"canary={PROGRESS['canary_state']} "
         f"ready_rows={ready if ready is not None else 'unknown'} "
         f"remaining_lane_blockers={blockers if blockers is not None else 'unknown'} "
-        f"schema_quarantined={schema_quarantine_count()} "
-        f"compute_quarantined={compute_quarantine_count()} "
-        f"transaction_quarantined={claim_transaction_quarantine_count()} "
-        f"blocked_row_reentries={blocked_row_reentry_count()}"
+        f"schema_quarantined={schema_count} "
+        f"compute_quarantined={compute_count} "
+        f"transaction_quarantined={transaction_count} "
+        f"blocked_row_reentries={blocked_count}"
     )
 
 
@@ -474,6 +483,7 @@ def main(argv: list[str] | None = None) -> int:
     emit(f"campaign artifacts: {campaign_dir}")
     try:
         validate_requested_lanes(args.lane)
+        batch.load_campaign_exclusion_records(args.campaign_quarantine_file)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         emit(str(exc))
         return 2
@@ -534,25 +544,30 @@ def main(argv: list[str] | None = None) -> int:
             after = git_head()
             emit(f"development pass {pass_number}: before={before} after={after}")
             if after == before:
+                try:
+                    exclusions = campaign_exclusion_counts()
+                except (OSError, ValueError) as exc:
+                    emit(f"invalid campaign state; refusing fixed point: {exc}")
+                    return 2
                 emit("development fixed point reached: full pass landed nothing new")
-                if schema_quarantine_count():
+                if exclusions[batch.SCHEMA_QUARANTINE_RESULT]:
                     emit(
                         "fixed point excludes campaign-scoped schema-invalid "
                         f"quarantines: {args.campaign_quarantine_file}"
                     )
-                if blocked_row_reentry_count():
+                if exclusions[batch.BLOCKED_ROW_QUARANTINE_RESULT]:
                     emit(
                         "fixed point excludes post-verdict rows that immediately "
                         "re-entered dep-ready selection; all other eligible rows "
                         f"were drained: {args.campaign_quarantine_file}"
                     )
-                if compute_quarantine_count():
+                if exclusions[batch.COMPUTE_QUARANTINE_RESULT]:
                     emit(
                         "fixed point excludes compute-required rows until their "
                         "runner cache, sliced certificate, or independent "
                         f"derivation is repaired: {args.campaign_quarantine_file}"
                     )
-                if claim_transaction_quarantine_count():
+                if exclusions[batch.CLAIM_TRANSACTION_QUARANTINE_RESULT]:
                     emit(
                         "fixed point excludes claim-local apply/gate failures "
                         "whose rollback to origin/main was verified; repair the "

--- a/docs/audit/scripts/run_pipeline.sh
+++ b/docs/audit/scripts/run_pipeline.sh
@@ -111,6 +111,13 @@ fi
 echo "==> 3/18 sanitize_legacy_audit_artifacts.py"
 python3 docs/audit/scripts/sanitize_legacy_audit_artifacts.py
 
+# Run the ordinary pre-invalidation metric pass before checkpoint capture.
+# Seeding may add rows that did not exist during the pre-seed refresh; every
+# such row must receive topology criticality before the full-build fingerprint
+# is bound.
+echo "==> 5/18 compute_load_bearing.py"
+python3 docs/audit/scripts/compute_load_bearing.py
+
 if [[ "${PIPELINE_MODE}" == "full" ]]; then
   echo "==> 3b/18 static_pipeline_checkpoint.py prepare (fresh graph/seed proof)"
   python3 docs/audit/scripts/static_pipeline_checkpoint.py prepare
@@ -123,9 +130,6 @@ if [[ "${PIPELINE_MODE}" == "full" ]]; then
 else
   echo "==> 4/18 reuse verified runner classification (verdict-only)"
 fi
-
-echo "==> 5/18 compute_load_bearing.py"
-python3 docs/audit/scripts/compute_load_bearing.py
 
 echo "==> 6/18 compute_effective_status.py"
 python3 docs/audit/scripts/compute_effective_status.py

--- a/docs/audit/scripts/run_pipeline.sh
+++ b/docs/audit/scripts/run_pipeline.sh
@@ -14,6 +14,8 @@
 #
 # Run order:
 #   1. build_citation_graph.py       -> data/citation_graph.json
+#  1c. compute_load_bearing.py       -> refreshes topology criticality before
+#                                       the ledger seeder consumes it
 #   2. seed_audit_ledger.py          -> data/audit_ledger.json (preserves
 #                                       prior audits if note hash unchanged)
 #   3. sanitize_legacy_audit_artifacts.py
@@ -92,6 +94,13 @@ if [[ "${PIPELINE_MODE}" == "full" ]]; then
 
   echo "==> 1b/18 write_citation_graph_manifest.py (tracked graph-topology acknowledgment)"
   python3 docs/audit/scripts/write_citation_graph_manifest.py
+
+  echo "==> 1c/18 compute_load_bearing.py pre-seed topology refresh"
+  # seed_audit_ledger.py consumes prior criticality when deciding whether a
+  # legacy terminal row needs claim-type re-audit. Refresh it from the newly
+  # built graph before seeding so one full run reaches that semantic fixed
+  # point and the static checkpoint can keep criticality fail-closed.
+  python3 docs/audit/scripts/compute_load_bearing.py
 
   echo "==> 2/18 seed_audit_ledger.py"
   python3 docs/audit/scripts/seed_audit_ledger.py

--- a/docs/audit/scripts/run_pipeline.sh
+++ b/docs/audit/scripts/run_pipeline.sh
@@ -114,11 +114,15 @@ python3 docs/audit/scripts/sanitize_legacy_audit_artifacts.py
 # Run the ordinary pre-invalidation metric pass before checkpoint capture.
 # Seeding may add rows that did not exist during the pre-seed refresh; every
 # such row must receive topology criticality before the full-build fingerprint
-# is bound.
+# is bound. A final seed pass below then consumes that refreshed criticality
+# and records the producer receipt at the actual classifier-input fixed point.
 echo "==> 5/18 compute_load_bearing.py"
 python3 docs/audit/scripts/compute_load_bearing.py
 
 if [[ "${PIPELINE_MODE}" == "full" ]]; then
+  echo "==> 3a/18 seed_audit_ledger.py fixed-point receipt"
+  python3 docs/audit/scripts/seed_audit_ledger.py
+
   echo "==> 3b/18 static_pipeline_checkpoint.py prepare (fresh graph/seed proof)"
   python3 docs/audit/scripts/static_pipeline_checkpoint.py prepare
 

--- a/docs/audit/scripts/run_pipeline.sh
+++ b/docs/audit/scripts/run_pipeline.sh
@@ -20,9 +20,12 @@
 #                                      -> removes deprecated author-status keys
 #   4. classify_runner_passes.py     -> data/runner_classification.json
 #                                       (heuristic; optional, slow on cold cache)
-#   5. compute_load_bearing.py       -> updates graph criticality metrics
+#   5. compute_load_bearing.py       -> updates graph criticality metrics used
+#                                       by invalidation
 #   6. compute_effective_status.py   -> applies claim_type-based status + summary
 #   7. invalidate_stale_audits.py    -> resets stale audit verdicts
+#  7a. compute_load_bearing.py       -> refreshes status-dependent descendant
+#                                       metrics after the status fixed point
 #   8. build_cycle_inventory.py      -> data/cycle_inventory.json
 #   9. compute_audit_queue.py        -> data/audit_queue.json (consumes
 #                                       cycle inventory for break targets)
@@ -151,6 +154,14 @@ if [[ "${invalidated}" != "0" || "${restored}" != "0" ]]; then
   echo "invalidate/restore did not reach a fixed point after 10 passes (joint invalidation/restoration)" >&2
   exit 1
 fi
+
+echo "==> 7a/18 compute_load_bearing.py post-status fixed point"
+# The first load-bearing pass supplies topology-derived criticality to the
+# invalidator.  load_bearing_score and max_descendant_status also consume
+# effective_status, which the invalidation/restore loop can change.  Recompute
+# them here so one pipeline invocation reaches generated-state fixed point
+# instead of leaving ancestors one pass stale.
+python3 docs/audit/scripts/compute_load_bearing.py
 
 echo "==> 7b/18 compute_lane_certification.py post-invalidation fixed point"
 python3 docs/audit/scripts/compute_lane_certification.py

--- a/docs/audit/scripts/static_pipeline_checkpoint.py
+++ b/docs/audit/scripts/static_pipeline_checkpoint.py
@@ -70,8 +70,10 @@ VERDICT_GENERATED_PATHS = frozenset({
 # source inputs (notes, dependency edges, and runners) remain fingerprinted;
 # the materialized metrics themselves must not invalidate the checkpoint when
 # a verdict changes descendant effective status during the same pipeline.
+# ``criticality`` is deliberately absent: seed_audit_ledger.py consumes the
+# prior value when deciding whether a legacy terminal row needs claim-type
+# re-audit, so changing it must invalidate fast mode.
 LEDGER_PIPELINE_DERIVED_FIELDS = frozenset({
-    "criticality",
     "direct_in_degree",
     "load_bearing_score",
     "max_descendant_status",

--- a/docs/audit/scripts/static_pipeline_checkpoint.py
+++ b/docs/audit/scripts/static_pipeline_checkpoint.py
@@ -66,10 +66,23 @@ VERDICT_GENERATED_PATHS = frozenset({
     "docs/repo/RETAINED_BACKBONE.md",
 })
 
+# These topology/status metrics are owned by compute_load_bearing.py. Their
+# source inputs (notes, dependency edges, and runners) remain fingerprinted;
+# the materialized metrics themselves must not invalidate the checkpoint when
+# a verdict changes descendant effective status during the same pipeline.
+LEDGER_PIPELINE_DERIVED_FIELDS = frozenset({
+    "criticality",
+    "direct_in_degree",
+    "load_bearing_score",
+    "max_descendant_status",
+    "max_descendant_status_rank",
+    "transitive_descendants",
+})
+
 # Only these known auditor-owned or downstream-derived fields may change
 # without invalidating a skipped seed/classifier pass. Unknown fields are
 # hashed by default, so schema growth fails closed rather than silently being
-# treated as verdict-owned.
+# treated as verdict- or pipeline-owned.
 LEDGER_VERDICT_FIELDS = frozenset({
     "audit_date",
     "audit_invocation_history",
@@ -96,8 +109,6 @@ LEDGER_VERDICT_FIELDS = frozenset({
     "intrinsic_status",
     "load_bearing_step",
     "load_bearing_step_class",
-    "max_descendant_status",
-    "max_descendant_status_rank",
     "negative_assertion_classes",
     "no_go_discipline",
     "notes_for_re_audit_if_any",
@@ -112,7 +123,7 @@ LEDGER_VERDICT_FIELDS = frozenset({
     "runner_check_breakdown",
     "unattributed_audit_provenance",
     "verdict_rationale",
-})
+}) | LEDGER_PIPELINE_DERIVED_FIELDS
 RUNNER_PATH_RE = re.compile(
     r"(scripts/[A-Za-z0-9_./\-]+\.py)|"
     r"(?<![A-Za-z0-9_./\-])([A-Za-z0-9_.\-]+\.py)"

--- a/docs/audit/scripts/tests/test_audit_campaign_repair.py
+++ b/docs/audit/scripts/tests/test_audit_campaign_repair.py
@@ -1,0 +1,92 @@
+"""Repair routing for campaign-scoped audit exclusions."""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import audit_campaign_repair as repair
+
+
+class CampaignRepairTest(unittest.TestCase):
+    def test_load_exclusions_rejects_malformed_records(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "campaign-row-exclusions.jsonl"
+            path.write_text('{"claim_id":"row"}\n', encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "missing reason"):
+                repair.load_exclusions(path)
+
+    def test_routes_operational_exclusions_without_minting_verdicts(self):
+        rows = {
+            "schema": {
+                "audit_status": "unaudited",
+                "effective_status": "unaudited",
+                "note_path": "docs/schema.md",
+            },
+            "compute": {
+                "audit_status": "unaudited",
+                "effective_status": "unaudited",
+                "note_path": "docs/compute.md",
+                "runner_path": "scripts/compute.py",
+            },
+            "blocked": {
+                "audit_status": "unaudited",
+                "effective_status": "unaudited",
+                "note_path": "docs/blocked.md",
+            },
+            "transaction": {
+                "audit_status": "unaudited",
+                "effective_status": "unaudited",
+                "note_path": "docs/transaction.md",
+            },
+        }
+        exclusions = [
+            {"claim_id": "schema", "reason": repair.SCHEMA_QUARANTINE},
+            {"claim_id": "compute", "reason": repair.COMPUTE_QUARANTINE},
+            {
+                "claim_id": "blocked",
+                "reason": repair.BLOCKED_REENTRY,
+                "invalidation_reason": "classifier_promoted_to_class_A",
+            },
+            {
+                "claim_id": "transaction",
+                "reason": repair.TRANSACTION_QUARANTINE,
+            },
+        ]
+
+        plan = repair.build_plan(exclusions, rows)
+        by_claim = {item["claim_id"]: item for item in plan}
+
+        self.assertEqual(by_claim["schema"]["route"], "fresh_schema_valid_seat")
+        self.assertTrue(by_claim["schema"]["ready_for_new_campaign"])
+        self.assertEqual(by_claim["compute"]["route"], "supply_compute_artifact")
+        self.assertEqual(
+            by_claim["compute"]["command"],
+            "python3 scripts/cached_runner_output.py scripts/compute.py",
+        )
+        self.assertEqual(by_claim["blocked"]["route"], "repair_invalidation_cause")
+        self.assertEqual(
+            by_claim["blocked"]["invalidation_reason"],
+            "classifier_promoted_to_class_A",
+        )
+        self.assertEqual(
+            by_claim["transaction"]["route"], "repair_claim_transaction"
+        )
+        self.assertTrue(all("audit_status" in item["current"] for item in plan))
+
+    def test_resolved_blocked_reentry_is_safe_to_reconsider(self):
+        item = repair.repair_route(
+            {"claim_id": "row", "reason": repair.BLOCKED_REENTRY},
+            {"audit_status": "audited_clean", "effective_status": "retained"},
+        )
+
+        self.assertEqual(item["route"], "already_moved_out_of_reentry")
+        self.assertTrue(item["ready_for_new_campaign"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/audit/scripts/tests/test_audit_campaign_repair.py
+++ b/docs/audit/scripts/tests/test_audit_campaign_repair.py
@@ -17,7 +17,7 @@ class CampaignRepairTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "campaign-row-exclusions.jsonl"
             path.write_text('{"claim_id":"row"}\n', encoding="utf-8")
-            with self.assertRaisesRegex(ValueError, "missing reason"):
+            with self.assertRaisesRegex(ValueError, "has no reason"):
                 repair.load_exclusions(path)
 
     def test_routes_operational_exclusions_without_minting_verdicts(self):

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -825,7 +825,61 @@ class SchemaRecoveryTest(unittest.TestCase):
             "pipeline failed",
         )
 
-    def test_apply_gate_failure_continues_after_verified_clean_rollback(self):
+    def test_mixed_seat_causes_persist_both_typed_reasons(self):
+        report = [
+            {
+                "cid": "mixed",
+                "pass": 1,
+                "result": "compute_required",
+                "detail": "cache missing",
+            },
+            {
+                "cid": "mixed",
+                "pass": 2,
+                "result": "validation_failed",
+                "detail": "bad schema",
+            },
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "quarantine.jsonl"
+            batch.persist_campaign_quarantine(path, {"mixed"}, report)
+            batch.persist_compute_required_skips(path, {"mixed"}, report)
+            batch.persist_campaign_quarantine(path, {"mixed"}, report)
+            records = batch.load_campaign_exclusion_records(path)
+
+        self.assertEqual(
+            {(row["claim_id"], row["reason"]) for row in records},
+            {
+                ("mixed", batch.SCHEMA_QUARANTINE_RESULT),
+                ("mixed", batch.COMPUTE_QUARANTINE_RESULT),
+            },
+        )
+        self.assertEqual(len(records), 2)
+
+    def test_campaign_state_loader_rejects_truncated_record(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "quarantine.jsonl"
+            path.write_text(
+                '{"claim_id":"kept","reason":"schema_invalid_quarantined"}\n'
+                '{"claim_id":"torn"',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                ValueError,
+                "invalid campaign exclusion JSON",
+            ):
+                batch.load_campaign_quarantine(path)
+            with mock.patch.dict(
+                audit_loop.PROGRESS,
+                {"quarantine_file": path},
+            ):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "invalid campaign exclusion JSON",
+                ):
+                    audit_loop.campaign_exclusion_counts()
+
+    def test_apply_gate_failure_continues_after_explicit_verified_rollback(self):
         job = {
             "cid": "row",
             "pass": 1,
@@ -848,10 +902,9 @@ class SchemaRecoveryTest(unittest.TestCase):
                     "cid": "row",
                     "result": "apply_or_gate_failed",
                     "detail": "pipeline failed",
+                    "rollback_verified": True,
                 }],
             ),
-        ), mock.patch.object(
-            batch, "clean_main_error", return_value=None
         ):
             ok, compute, schema, handoffs = batch.apply_serialized(
                 [job], report
@@ -866,7 +919,7 @@ class SchemaRecoveryTest(unittest.TestCase):
             {item["result"] for item in report},
         )
 
-    def test_apply_gate_failure_stops_when_rollback_is_not_clean(self):
+    def test_apply_gate_failure_stops_without_explicit_rollback_proof(self):
         job = {
             "cid": "row",
             "pass": 1,
@@ -891,8 +944,6 @@ class SchemaRecoveryTest(unittest.TestCase):
                 False,
                 [{"cid": "row", "result": "apply_or_gate_failed"}],
             ),
-        ), mock.patch.object(
-            batch, "clean_main_error", return_value="working tree is not clean"
         ):
             ok, _, _, _ = batch.apply_serialized([job], report)
 
@@ -1768,19 +1819,69 @@ class ClaimTransactionTest(unittest.TestCase):
         self.assertEqual(result.stderr, "stderr")
 
     def test_rollback_commands_bypass_committer_cancellation(self):
+        oid = "a" * 40
+        target = mock.Mock(returncode=0, stdout=f"{oid}\n", stderr="")
         reset = mock.Mock(returncode=0, stdout="", stderr="")
         branch = mock.Mock(returncode=0, stdout="main\n", stderr="")
         status = mock.Mock(returncode=0, stdout="", stderr="")
+        head = mock.Mock(returncode=0, stdout=f"{oid}\n", stderr="")
+        remote = mock.Mock(returncode=0, stdout=f"{oid}\n", stderr="")
         with mock.patch.object(
-            batch, "sh", side_effect=[reset, branch, status]
+            batch,
+            "sh",
+            side_effect=[target, reset, branch, status, head, remote],
         ) as sh:
             ok, detail = batch.reset_to_origin_main()
 
         self.assertTrue(ok, detail)
-        self.assertEqual(sh.call_count, 3)
+        self.assertEqual(sh.call_count, 6)
         self.assertTrue(
             all(call.kwargs.get("honor_cancel") is False for call in sh.call_args_list)
         )
+
+    def test_reset_to_origin_main_rejects_clean_ref_mismatch(self):
+        target_oid = "a" * 40
+        moved_oid = "b" * 40
+        commands = [
+            mock.Mock(returncode=0, stdout=f"{target_oid}\n", stderr=""),
+            mock.Mock(returncode=0, stdout="", stderr=""),
+            mock.Mock(returncode=0, stdout="main\n", stderr=""),
+            mock.Mock(returncode=0, stdout="", stderr=""),
+            mock.Mock(returncode=0, stdout=f"{target_oid}\n", stderr=""),
+            mock.Mock(returncode=0, stdout=f"{moved_oid}\n", stderr=""),
+        ]
+        with mock.patch.object(batch, "sh", side_effect=commands):
+            ok, detail = batch.reset_to_origin_main()
+
+        self.assertFalse(ok)
+        self.assertIn("HEAD synchronized with origin/main", detail)
+
+    def test_apply_rejection_is_global_when_reset_cannot_be_verified(self):
+        delivery = [(
+            {
+                "cid": "row",
+                "pass": 1,
+                "row": {"claim_id": "row", "criticality": "medium"},
+            },
+            {
+                "audit": {"verdict": "audited_clean"},
+                "evidence_manifest": {},
+            },
+        )]
+        with mock.patch.object(
+            batch, "sync_origin_main", return_value=(True, "base")
+        ), mock.patch.object(
+            batch.audit_runner, "apply_one", return_value=(False, "rejected")
+        ), mock.patch.object(
+            batch,
+            "reset_to_origin_main",
+            return_value=(False, "ref mismatch"),
+        ):
+            ok, results = batch.apply_claim_serialized(delivery, retries=1)
+
+        self.assertFalse(ok)
+        self.assertEqual(results[0]["result"], "race_reset_failed")
+        self.assertIn("ref mismatch", results[0]["detail"])
 
     def test_packet_completion_cancel_skips_exit_grace(self):
         cancel = threading.Event()
@@ -2072,7 +2173,6 @@ class ClaimTransactionTest(unittest.TestCase):
                     json.dumps(dict(
                         before,
                         audit_status="audited_clean",
-                        criticality="high",
                         direct_in_degree=7,
                         transitive_descendants=123,
                         max_descendant_status="retained",
@@ -2082,6 +2182,22 @@ class ClaimTransactionTest(unittest.TestCase):
                     encoding="utf-8",
                 )
                 derived_metrics_ok, derived_metrics_detail = (
+                    batch.static_checkpoint.verify_checkpoint()
+                )
+                shard.write_text(
+                    json.dumps(dict(
+                        before,
+                        audit_status="audited_clean",
+                        criticality="high",
+                        direct_in_degree=7,
+                        transitive_descendants=123,
+                        max_descendant_status="retained",
+                        max_descendant_status_rank=9,
+                        load_bearing_score=42.5,
+                    )),
+                    encoding="utf-8",
+                )
+                criticality_ok, criticality_detail = (
                     batch.static_checkpoint.verify_checkpoint()
                 )
                 shard.write_text(
@@ -2165,6 +2281,8 @@ class ClaimTransactionTest(unittest.TestCase):
         self.assertTrue(receipts_cleaned)
         self.assertTrue(audit_ok)
         self.assertTrue(derived_metrics_ok, derived_metrics_detail)
+        self.assertFalse(criticality_ok)
+        self.assertIn("static repository inputs changed", criticality_detail)
         self.assertFalse(wrong_identity_ok)
         self.assertIn("changed during fast use", wrong_identity_detail)
         self.assertFalse(ignored_note_ok)
@@ -2186,6 +2304,10 @@ class ClaimTransactionTest(unittest.TestCase):
 
     def test_pipeline_recomputes_status_dependent_load_bearing_after_fixed_point(self):
         script = (batch.SCRIPTS / "run_pipeline.sh").read_text(encoding="utf-8")
+        pre_seed = script.index(
+            'echo "==> 1c/18 compute_load_bearing.py pre-seed topology refresh"'
+        )
+        seed = script.index('echo "==> 2/18 seed_audit_ledger.py"')
         first = script.index(
             'echo "==> 5/18 compute_load_bearing.py"'
         )
@@ -2199,6 +2321,8 @@ class ClaimTransactionTest(unittest.TestCase):
             'echo "==> 7b/18 compute_lane_certification.py'
         )
 
+        self.assertLess(pre_seed, seed)
+        self.assertLess(seed, first)
         self.assertLess(first, status)
         self.assertLess(status, final)
         self.assertLess(final, certification)
@@ -2206,7 +2330,7 @@ class ClaimTransactionTest(unittest.TestCase):
             script.count(
                 "python3 docs/audit/scripts/compute_load_bearing.py"
             ),
-            2,
+            3,
         )
 
     def test_run_generated_gates_selects_verdict_only_pipeline(self):

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -860,8 +860,16 @@ class SchemaRecoveryTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "quarantine.jsonl"
             path.write_text(
-                '{"claim_id":"kept","reason":"schema_invalid_quarantined"}\n'
-                '{"claim_id":"torn"',
+                json.dumps(
+                    {
+                        "claim_id": "kept",
+                        "reason": batch.SCHEMA_QUARANTINE_RESULT,
+                        "failures": [{"result": "validation_failed"}],
+                        "recorded_at": "2026-07-23T12:00:00+00:00",
+                    }
+                )
+                + "\n"
+                + '{"claim_id":"torn"',
                 encoding="utf-8",
             )
             with self.assertRaisesRegex(
@@ -878,6 +886,41 @@ class SchemaRecoveryTest(unittest.TestCase):
                     "invalid campaign exclusion JSON",
                 ):
                     audit_loop.campaign_exclusion_counts()
+
+    def test_campaign_state_loader_rejects_corrupt_schema_variants(self):
+        valid_tail = (
+            '"reason":"schema_invalid_quarantined",'
+            '"failures":[{"result":"validation_failed"}],'
+            '"recorded_at":"2026-07-23T12:00:00+00:00"'
+        )
+        cases = {
+            "blank": ("\n", "blank campaign exclusion record"),
+            "duplicate": (
+                '{"claim_id":"first","claim_id":"second",' + valid_tail + "}\n",
+                "duplicate JSON key",
+            ),
+            "unknown reason": (
+                '{"claim_id":"row","reason":"unknown_quarantine",'
+                '"failures":[{"result":"validation_failed"}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "unrecognized campaign exclusion reason",
+            ),
+            "invalid fields": (
+                '{"claim_id":"row",' + valid_tail + ',"typo":[]}\n',
+                "invalid campaign exclusion fields",
+            ),
+            "invalid failures": (
+                '{"claim_id":"row","reason":"schema_invalid_quarantined",'
+                '"failures":[],"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "failures must be a non-empty list",
+            ),
+        }
+        for label, (payload, expected) in cases.items():
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                path = Path(tmp) / "quarantine.jsonl"
+                path.write_text(payload, encoding="utf-8")
+                with self.assertRaisesRegex(ValueError, expected):
+                    batch.load_campaign_quarantine(path)
 
     def test_apply_gate_failure_continues_after_explicit_verified_rollback(self):
         job = {
@@ -1855,6 +1898,24 @@ class ClaimTransactionTest(unittest.TestCase):
 
         self.assertFalse(ok)
         self.assertIn("HEAD synchronized with origin/main", detail)
+
+    def test_reset_to_origin_main_rejects_recognizable_provenance_drift(self):
+        target_oid = "a" * 40
+        commands = [
+            mock.Mock(returncode=0, stdout=f"{target_oid}\n", stderr=""),
+            mock.Mock(returncode=0, stdout="", stderr=""),
+            mock.Mock(returncode=0, stdout="main\n", stderr=""),
+            mock.Mock(
+                returncode=0,
+                stdout=f" M {batch.LANE_CERTIFICATION_PATH}\n",
+                stderr="",
+            ),
+        ]
+        with mock.patch.object(batch, "sh", side_effect=commands):
+            ok, detail = batch.reset_to_origin_main()
+
+        self.assertFalse(ok)
+        self.assertIn("literally clean worktree", detail)
 
     def test_apply_rejection_is_global_when_reset_cannot_be_verified(self):
         delivery = [(

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -2311,6 +2311,9 @@ class ClaimTransactionTest(unittest.TestCase):
         first = script.index(
             'echo "==> 5/18 compute_load_bearing.py"'
         )
+        checkpoint = script.index(
+            'echo "==> 3b/18 static_pipeline_checkpoint.py prepare'
+        )
         status = script.index(
             'echo "==> 6/18 compute_effective_status.py"'
         )
@@ -2323,6 +2326,7 @@ class ClaimTransactionTest(unittest.TestCase):
 
         self.assertLess(pre_seed, seed)
         self.assertLess(seed, first)
+        self.assertLess(first, checkpoint)
         self.assertLess(first, status)
         self.assertLess(status, final)
         self.assertLess(final, certification)

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -717,6 +717,16 @@ class BatchExitSemanticsTest(unittest.TestCase):
                     )
                 )
 
+    def test_verified_claim_transaction_quarantine_is_resumable(self):
+        report = [
+            {"cid": "row", "result": "apply_or_gate_failed", "detail": "boom"},
+            {
+                "cid": "row",
+                "result": batch.CLAIM_TRANSACTION_QUARANTINE_RESULT,
+            },
+        ]
+        self.assertFalse(batch.report_has_hard_blocker(report))
+
     def test_mixed_failure_records_the_judicial_handoff(self):
         report = [{"cid": "broken", "result": "validation_failed"}]
         selected = [{"claim_id": "disputed"}]
@@ -775,6 +785,122 @@ class SchemaRecoveryTest(unittest.TestCase):
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0]["claim_id"], "row")
         self.assertEqual(records[0]["failures"][0]["detail"], "N8 exact validator error")
+
+    def test_compute_and_transaction_exclusions_persist_typed_causes(self):
+        report = [
+            {"cid": "compute", "result": "compute_required", "detail": "cache missing"},
+            {
+                "cid": "transaction",
+                "result": "apply_or_gate_failed",
+                "detail": "pipeline failed",
+            },
+            {
+                "cid": "transaction",
+                "result": batch.CLAIM_TRANSACTION_QUARANTINE_RESULT,
+            },
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "quarantine.jsonl"
+            batch.persist_compute_required_skips(path, {"compute"}, report)
+            batch.persist_claim_transaction_quarantines(
+                path, {"transaction"}, report
+            )
+            records = [
+                json.loads(line) for line in path.read_text().splitlines()
+            ]
+
+        self.assertEqual(
+            {row["reason"] for row in records},
+            {
+                batch.COMPUTE_QUARANTINE_RESULT,
+                batch.CLAIM_TRANSACTION_QUARANTINE_RESULT,
+            },
+        )
+        by_claim = {row["claim_id"]: row for row in records}
+        self.assertEqual(
+            by_claim["compute"]["failures"][0]["detail"], "cache missing"
+        )
+        self.assertEqual(
+            by_claim["transaction"]["failures"][0]["detail"],
+            "pipeline failed",
+        )
+
+    def test_apply_gate_failure_continues_after_verified_clean_rollback(self):
+        job = {
+            "cid": "row",
+            "pass": 1,
+            "row": {
+                "claim_id": "row",
+                "criticality": "medium",
+                "note_path": "docs/row.md",
+            },
+        }
+        envelope = {"audit": {"verdict": "audited_clean"}}
+        report = []
+        with mock.patch.object(
+            batch, "finalize_worker", return_value=(envelope, {"ok": True})
+        ), mock.patch.object(
+            batch,
+            "apply_claim_serialized",
+            return_value=(
+                False,
+                [{
+                    "cid": "row",
+                    "result": "apply_or_gate_failed",
+                    "detail": "pipeline failed",
+                }],
+            ),
+        ), mock.patch.object(
+            batch, "clean_main_error", return_value=None
+        ):
+            ok, compute, schema, handoffs = batch.apply_serialized(
+                [job], report
+            )
+
+        self.assertTrue(ok)
+        self.assertEqual(compute, set())
+        self.assertEqual(schema, set())
+        self.assertEqual(handoffs, [])
+        self.assertIn(
+            batch.CLAIM_TRANSACTION_QUARANTINE_RESULT,
+            {item["result"] for item in report},
+        )
+
+    def test_apply_gate_failure_stops_when_rollback_is_not_clean(self):
+        job = {
+            "cid": "row",
+            "pass": 1,
+            "row": {
+                "claim_id": "row",
+                "criticality": "medium",
+                "note_path": "docs/row.md",
+            },
+        }
+        report = []
+        with mock.patch.object(
+            batch,
+            "finalize_worker",
+            return_value=(
+                {"audit": {"verdict": "audited_clean"}},
+                {"ok": True},
+            ),
+        ), mock.patch.object(
+            batch,
+            "apply_claim_serialized",
+            return_value=(
+                False,
+                [{"cid": "row", "result": "apply_or_gate_failed"}],
+            ),
+        ), mock.patch.object(
+            batch, "clean_main_error", return_value="working tree is not clean"
+        ):
+            ok, _, _, _ = batch.apply_serialized([job], report)
+
+        self.assertFalse(ok)
+        self.assertNotIn(
+            batch.CLAIM_TRANSACTION_QUARANTINE_RESULT,
+            {item["result"] for item in report},
+        )
 
     def test_invalid_optional_packet_is_dropped_without_completion(self):
         invocation = "a" * 32
@@ -1942,6 +2068,26 @@ class ClaimTransactionTest(unittest.TestCase):
                     encoding="utf-8",
                 )
                 audit_ok, _ = batch.static_checkpoint.verify_checkpoint()
+                shard.write_text(
+                    json.dumps(dict(
+                        before,
+                        audit_status="audited_clean",
+                        criticality="high",
+                        direct_in_degree=7,
+                        transitive_descendants=123,
+                        max_descendant_status="retained",
+                        max_descendant_status_rank=9,
+                        load_bearing_score=42.5,
+                    )),
+                    encoding="utf-8",
+                )
+                derived_metrics_ok, derived_metrics_detail = (
+                    batch.static_checkpoint.verify_checkpoint()
+                )
+                shard.write_text(
+                    json.dumps(dict(before, audit_status="audited_clean")),
+                    encoding="utf-8",
+                )
                 with mock.patch.dict(
                     os.environ,
                     {batch.static_checkpoint.EXPECTED_NONCE_ENV: "b" * 32},
@@ -2018,6 +2164,7 @@ class ClaimTransactionTest(unittest.TestCase):
         self.assertTrue(finalized, finalize_detail)
         self.assertTrue(receipts_cleaned)
         self.assertTrue(audit_ok)
+        self.assertTrue(derived_metrics_ok, derived_metrics_detail)
         self.assertFalse(wrong_identity_ok)
         self.assertIn("changed during fast use", wrong_identity_detail)
         self.assertFalse(ignored_note_ok)
@@ -2036,6 +2183,31 @@ class ClaimTransactionTest(unittest.TestCase):
         self.assertIn("static repository inputs changed", ledger_sidecar_detail)
         self.assertFalse(topology_ok)
         self.assertIn("static repository inputs changed", detail)
+
+    def test_pipeline_recomputes_status_dependent_load_bearing_after_fixed_point(self):
+        script = (batch.SCRIPTS / "run_pipeline.sh").read_text(encoding="utf-8")
+        first = script.index(
+            'echo "==> 5/18 compute_load_bearing.py"'
+        )
+        status = script.index(
+            'echo "==> 6/18 compute_effective_status.py"'
+        )
+        final = script.index(
+            'echo "==> 7a/18 compute_load_bearing.py post-status fixed point"'
+        )
+        certification = script.index(
+            'echo "==> 7b/18 compute_lane_certification.py'
+        )
+
+        self.assertLess(first, status)
+        self.assertLess(status, final)
+        self.assertLess(final, certification)
+        self.assertEqual(
+            script.count(
+                "python3 docs/audit/scripts/compute_load_bearing.py"
+            ),
+            2,
+        )
 
     def test_run_generated_gates_selects_verdict_only_pipeline(self):
         completed = mock.Mock(returncode=0, stdout="", stderr="")

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -2372,6 +2372,9 @@ class ClaimTransactionTest(unittest.TestCase):
         first = script.index(
             'echo "==> 5/18 compute_load_bearing.py"'
         )
+        fixed_point_seed = script.index(
+            'echo "==> 3a/18 seed_audit_ledger.py fixed-point receipt"'
+        )
         checkpoint = script.index(
             'echo "==> 3b/18 static_pipeline_checkpoint.py prepare'
         )
@@ -2387,6 +2390,8 @@ class ClaimTransactionTest(unittest.TestCase):
 
         self.assertLess(pre_seed, seed)
         self.assertLess(seed, first)
+        self.assertLess(first, fixed_point_seed)
+        self.assertLess(fixed_point_seed, checkpoint)
         self.assertLess(first, checkpoint)
         self.assertLess(first, status)
         self.assertLess(status, final)
@@ -2396,6 +2401,12 @@ class ClaimTransactionTest(unittest.TestCase):
                 "python3 docs/audit/scripts/compute_load_bearing.py"
             ),
             3,
+        )
+        self.assertEqual(
+            script.count(
+                "python3 docs/audit/scripts/seed_audit_ledger.py"
+            ),
+            2,
         )
 
     def test_run_generated_gates_selects_verdict_only_pipeline(self):

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -788,15 +788,23 @@ class SchemaRecoveryTest(unittest.TestCase):
 
     def test_compute_and_transaction_exclusions_persist_typed_causes(self):
         report = [
-            {"cid": "compute", "result": "compute_required", "detail": "cache missing"},
+            {
+                "cid": "compute",
+                "pass": 1,
+                "result": "compute_required",
+                "detail": "cache missing",
+            },
             {
                 "cid": "transaction",
                 "result": "apply_or_gate_failed",
                 "detail": "pipeline failed",
+                "rollback_verified": True,
+                "rollback_detail": "reset to origin/main",
             },
             {
                 "cid": "transaction",
                 "result": batch.CLAIM_TRANSACTION_QUARANTINE_RESULT,
+                "detail": "claim excluded after verified rollback",
             },
         ]
         with tempfile.TemporaryDirectory() as tmp:
@@ -805,9 +813,7 @@ class SchemaRecoveryTest(unittest.TestCase):
             batch.persist_claim_transaction_quarantines(
                 path, {"transaction"}, report
             )
-            records = [
-                json.loads(line) for line in path.read_text().splitlines()
-            ]
+            records = batch.load_campaign_exclusion_records(path)
 
         self.assertEqual(
             {row["reason"] for row in records},
@@ -864,7 +870,12 @@ class SchemaRecoveryTest(unittest.TestCase):
                     {
                         "claim_id": "kept",
                         "reason": batch.SCHEMA_QUARANTINE_RESULT,
-                        "failures": [{"result": "validation_failed"}],
+                        "failures": [{
+                            "cid": "kept",
+                            "pass": 1,
+                            "result": "validation_failed",
+                            "detail": "bad schema",
+                        }],
                         "recorded_at": "2026-07-23T12:00:00+00:00",
                     }
                 )
@@ -914,6 +925,69 @@ class SchemaRecoveryTest(unittest.TestCase):
                 '"failures":[],"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
                 "failures must be a non-empty list",
             ),
+            "empty failure object": (
+                '{"claim_id":"row","reason":"schema_invalid_quarantined",'
+                '"failures":[{}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "failure has no string result",
+            ),
+            "unexpected failure field": (
+                '{"claim_id":"row","reason":"schema_invalid_quarantined",'
+                '"failures":[{"cid":"row","pass":1,'
+                '"result":"malformed_json","typo":true}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "invalid campaign exclusion failure fields",
+            ),
+            "wrong reason evidence": (
+                '{"claim_id":"row","reason":"compute_required_quarantined",'
+                '"failures":[{"cid":"row","pass":1,'
+                '"result":"validation_failed","detail":"bad schema"}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "failure result is incompatible",
+            ),
+            "transaction without rollback proof": (
+                '{"claim_id":"row","reason":"claim_transaction_quarantined",'
+                '"failures":[{"cid":"row",'
+                '"result":"claim_transaction_quarantined",'
+                '"detail":"quarantined"}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "no verified apply/gate rollback failure",
+            ),
+            "failure cid mismatch": (
+                '{"claim_id":"row","reason":"compute_required_quarantined",'
+                '"failures":[{"cid":"other","pass":1,'
+                '"result":"compute_required","detail":"cache missing"}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "failure cid does not match",
+            ),
+            "shard unsafe claim id": (
+                '{"claim_id":"bad/id","reason":"compute_required_quarantined",'
+                '"failures":[{"cid":"bad/id","pass":1,'
+                '"result":"compute_required","detail":"cache missing"}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "claim_id is not shard-safe",
+            ),
+            "dot-only claim id": (
+                '{"claim_id":".","reason":"compute_required_quarantined",'
+                '"failures":[{"cid":".","pass":1,'
+                '"result":"compute_required","detail":"cache missing"}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "claim_id is not shard-safe",
+            ),
+            "overflow float": (
+                '{"claim_id":"row","reason":"compute_required_quarantined",'
+                '"failures":[{"cid":"row","pass":1,'
+                '"result":"compute_required","detail":1e999}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "non-finite JSON number",
+            ),
+            "noncanonical timestamp separator": (
+                '{"claim_id":"row","reason":"compute_required_quarantined",'
+                '"failures":[{"cid":"row","pass":1,'
+                '"result":"compute_required","detail":"cache missing"}],'
+                '"recorded_at":"2026-07-23x12:00:00+00:00"}\n',
+                "not canonical UTC ISO-8601",
+            ),
         }
         for label, (payload, expected) in cases.items():
             with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
@@ -921,6 +995,25 @@ class SchemaRecoveryTest(unittest.TestCase):
                 path.write_text(payload, encoding="utf-8")
                 with self.assertRaisesRegex(ValueError, expected):
                     batch.load_campaign_quarantine(path)
+
+    def test_campaign_state_loader_accepts_canonical_dotted_claim_id(self):
+        record = {
+            "claim_id": "ai_methodology.raw.canonical_framing_paragraph",
+            "reason": batch.COMPUTE_QUARANTINE_RESULT,
+            "failures": [{
+                "cid": "ai_methodology.raw.canonical_framing_paragraph",
+                "pass": 1,
+                "result": "compute_required",
+                "detail": "cache missing",
+            }],
+            "recorded_at": "2026-07-23T12:00:00+00:00",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "quarantine.jsonl"
+            path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+            loaded = batch.load_campaign_exclusion_records(path)
+
+        self.assertEqual(loaded, [record])
 
     def test_apply_gate_failure_continues_after_explicit_verified_rollback(self):
         job = {

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -960,6 +960,20 @@ class SchemaRecoveryTest(unittest.TestCase):
                 '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
                 "failure cid does not match",
             ),
+            "float pass one": (
+                '{"claim_id":"row","reason":"compute_required_quarantined",'
+                '"failures":[{"cid":"row","pass":1.0,'
+                '"result":"compute_required","detail":"cache missing"}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "failure pass must be 1 or 2",
+            ),
+            "float pass two": (
+                '{"claim_id":"row","reason":"compute_required_quarantined",'
+                '"failures":[{"cid":"row","pass":2.0,'
+                '"result":"compute_required","detail":"cache missing"}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "failure pass must be 1 or 2",
+            ),
             "shard unsafe claim id": (
                 '{"claim_id":"bad/id","reason":"compute_required_quarantined",'
                 '"failures":[{"cid":"bad/id","pass":1,'


### PR DESCRIPTION
## What changed

- make one audit pipeline invocation reach generated-state fixed point by recomputing status-dependent load-bearing metrics after effective-status/invalidation convergence
- classify load-bearing metrics as pipeline-derived checkpoint outputs while continuing to fingerprint their source notes, dependency edges, runners, and classifier inputs
- quarantine a claim-local apply/pipeline/lint failure only after rollback to synchronized `origin/main` is verified clean, then continue unrelated rows
- persist `compute_required` and safely rolled-back transaction exclusions across inner batches
- add a read-only `audit_campaign_repair.py` helper that maps schema, compute, blocked-reentry, transaction, and missing-ledger exclusions to their required repair/re-entry path
- update the audit-loop skill with a failure taxonomy, persistent-goal role, and explicit quarantine/skip repair contract

## Root cause

`compute_load_bearing.py` ran before effective statuses and the invalidation/restore loop settled. A newly applied verdict could therefore leave ancestor `load_bearing_score` values one pipeline pass stale. Because that derived field was included in the static-input fingerprint, checkpoint finalization then failed with `static repository inputs changed since the full pipeline`.

The supervisor also treated any nonzero claim transaction as campaign-fatal. This PR keeps global/uncertain repository failures fatal, but lets one row be campaign-quarantined after a proven clean rollback.

## Scientific safeguards

This does not weaken restricted context, independent math checks, xhigh seating, critical two-seat confirmation, five-judge full-tuple panels, N1-N8/forensic validation, apply validation, strict lint, or repository invariants. Operational exclusions never become scientific verdicts.

## Relationship to #5562

This complements #5562. It addresses deterministic pipeline convergence and quarantine repair; it does not duplicate that PR's process-group cancellation, bounded panel concurrency, or preserved-panel replay work.

## Validation

- `python3 -m unittest docs.audit.scripts.tests.test_audit_campaign_repair docs.audit.scripts.tests.test_audit_loop_orchestrator` — 83 tests passed
- `bash docs/audit/scripts/run_pipeline.sh` — full checkpoint finalized in one invocation
- `python3 docs/audit/scripts/audit_lint.py --strict` — no errors (existing warnings/notices only)
- second `run_pipeline.sh --verdict-only` propagation produced the identical complete generated-diff SHA-256 before and after
- `git diff --check` passed
