### PR TITLE
repair forensic canary quarantine handoff

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -224,6 +224,12 @@ default session is:
    Keep the printed campaign artifact directory. It is the durable operational
    record for schema, compute, blocked-reentry, and safely rolled-back
    transaction exclusions; it does not carry scientific authority.
+   A bounded JSON/schema rejection from the final canary is also claim-local:
+   the supervisor preserves the complete `forensic-canary-*.jsonl` run log,
+   appends a strict `schema_invalid_quarantined` record, reports that the
+   canary did not land, and exits the campaign successfully at its
+   non-excluded fixed point. Unknown execution failures and apply,
+   propagation, or push failures still fail closed.
 3. If the user names a lane, pass `--lane <name>`. Otherwise the orchestrator
    iterates lanes from `docs/audit/data/lane_certification_config.json`,
    selecting entries whose generated `lane_certification.json` record still
@@ -396,6 +402,16 @@ after a canary lands may the forensic lane run more than one seat, and never
 more than two. Parallelizing a failing forensic path multiplies model burn
 with zero landings.
 
+The canary gets the bounded three-seat fresh-schema budget because distinct
+packet-completion defects can surface serially (for example, an N1 route-class
+marker mismatch followed by an N5 rhetoric-scan coverage mismatch). Coverage
+rejects require one exact N3/N5 disposition for every authenticated
+`full_phrase_groups` record on every applicable manifest path; records that
+share a group id or digest are still distinct when their phrase/path tuple is
+distinct. If that bounded budget still ends in malformed JSON or a validator
+reject, quarantine the row for the campaign and continue to the fixed-point
+exit. That is not a landed canary and does not authorize forensic fan-out.
+
 **Seat-blocked judicial rows are reseated, never frozen and never retried
 as recorded.** A disagreement whose recorded seats lack invocation-bound
 full rationales can never finish through a panel. When the original seat
@@ -555,7 +571,7 @@ Repair and re-entry are reason-specific:
 
 | Operational result | Required repair | Re-entry |
 | --- | --- | --- |
-| `schema_invalid_quarantined` | Preserve the malformed response and exact validator errors; correct the CLI transport schema, prompt, or bounded packet-completion defect. Never edit the scientific judgment into validity. | Start a new campaign so a fresh restricted-context seat is selected. |
+| `schema_invalid_quarantined` | Preserve the malformed response, exact validator errors, and any `forensic-canary-*.jsonl` artifact; correct the CLI transport schema, prompt, or bounded packet-completion defect. A failed final canary must enter this route and finish the campaign at its non-excluded fixed point rather than becoming a global schema stop. Never edit the scientific judgment into validity. | Start a new campaign so a fresh restricted-context seat is selected. Reusing the old workdir keeps the claim excluded. |
 | `compute_required_quarantined` / `compute_required` | Produce a SHA-pinned runner cache with `cached_runner_output.py`, a sliced deterministic certificate, or an independent derivation; then run the full pipeline and strict lint. | Start a new campaign after the artifact is current. |
 | `blocked_row_reentry_quarantined` | Repair the recorded classifier promotion, dependency/status cycle, note-hash drift, or other invalidation cause. Require one converged full pipeline. | Start a new campaign only after the row no longer immediately returns to the same dep-ready state. |
 | `claim_transaction_quarantined` | Fix the recorded apply, pipeline, or lint defect and prove the clean full pipeline converges. The failed delivery minted no verdict. | Use a fresh seat in a new campaign unless canonical tooling verifies an exact preserved-envelope replay against the current source/seat fingerprint. |

--- a/docs/ai_methodology/skills/science-fix-loop/SKILL.md
+++ b/docs/ai_methodology/skills/science-fix-loop/SKILL.md
@@ -50,8 +50,8 @@ hard, quarantined, forensic-only, or awaiting a panel.
    supervisor process. Do not infer that a campaign is healthy from a running
    PID, and do not recursively search unrelated user directories.
 4. Preserve `campaign-row-exclusions.jsonl`, rejected responses, delivery
-   envelopes, `campaign-selector-skips.jsonl`, and reports as incident
-   provenance. Never commit them.
+   envelopes, `campaign-selector-skips.jsonl`, `forensic-canary-*.jsonl`, and
+   reports as incident provenance. Never commit them.
 
 ## Build the complete repair inventory
 
@@ -92,6 +92,16 @@ python3 scripts/science_fix_loop.py \
 The second command may create repair candidates, but it must reconstruct them
 from current `origin/main` plus the typed operational record. It must never use
 malformed audit prose as a scientific instruction.
+This includes a failed final forensic canary: its
+`schema_invalid_quarantined` record must select a
+`campaign_schema_transport` operational worker even though the top-level audit
+campaign exited successfully. Inspect the named preserved canary run log for
+the exact validator sequence. Repair a reproducible packet-completion,
+sanitized-guidance, retry-budget, or quarantine-control-flow defect with
+tests; never edit the claim note or reinterpret the rejected JSON as a
+verdict. If current `main` already contains the systemic repair, make no
+duplicate edit and route the row to a fresh restricted-context seat in a new
+campaign.
 Use `--retry-failed` for a campaign incident only after its fingerprint or the
 relevant source on `main` changes; do not spend repeated workers on an
 identical seat-local record.
@@ -108,7 +118,7 @@ for re-entry. "Skipped" without a route is an incomplete campaign result.
 
 | State or result | Owner and repair | Re-entry proof |
 | --- | --- | --- |
-| `schema_invalid_quarantined` | Audit tooling. Preserve the rejected output; reproduce validator/transport behavior. Fix only a systemic prompt, schema, CLI, or bounded completion defect. A seat-local malformed answer gets no source edit. | Fresh restricted-context seat in a new campaign. |
+| `schema_invalid_quarantined` | Audit tooling. Preserve the rejected output and `forensic-canary-*.jsonl` when present; reproduce validator/transport behavior. Fix only a systemic prompt, schema, CLI, bounded completion, or claim-local quarantine/continue defect. A seat-local malformed answer gets no source edit. | Fresh restricted-context seat in a new campaign. |
 | `compute_required` / `compute_required_quarantined` | Physics/runner repair. Produce a SHA-pinned cache, sliced deterministic certificate, faster equivalent runner, or independent derivation. Timeout alone is not a negative verdict. | Completed artifact plus full pipeline and strict lint, then a new campaign. |
 | `blocked_row_reentry_quarantined` | Audit control-plane repair. Fix the recorded classifier promotion, dependency/status cycle, hash drift, or invalidation bug; do not mint a placeholder verdict. | One full pipeline convergence where the row does not immediately return to the same dep-ready state. |
 | `claim_transaction_quarantined` | Audit control-plane repair. Reproduce and fix apply, pipeline, or strict-lint failure. The rolled-back delivery minted no verdict. | Clean full pipeline; normally a fresh seat in a new campaign. |

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -401,17 +401,11 @@ def first_ready_forensic_claim(
     return None
 
 
-def forensic_canary_claim_local_failure(
+def forensic_canary_terminal_record(
     run_log: Path,
     claim_id: str,
-) -> tuple[str, dict] | None:
-    """Classify only typed claim-local canary outcomes from its preserved log.
-
-    Unknown execution, apply, propagation, and push failures remain hard. A
-    malformed or schema-invalid packet minted no verdict and is safe to
-    quarantine for this campaign. Missing runner evidence is compute work, not
-    negative science.
-    """
+) -> dict | None:
+    """Return the last target-scoped terminal record from one canary log."""
     if not run_log.is_file():
         return None
     records: list[dict] = []
@@ -446,10 +440,11 @@ def forensic_canary_claim_local_failure(
         "compute_required",
         "skip_no_runner_log",
         "skip_prompt_transport",
+        "skip_role",
         "weak_clean_unratifiable",
         "dry-run",
     }
-    terminal = next(
+    return next(
         (
             record
             for record in reversed(records)
@@ -457,25 +452,44 @@ def forensic_canary_claim_local_failure(
         ),
         None,
     )
+
+
+def forensic_canary_claim_local_failure(
+    terminal: dict | None,
+    claim_id: str,
+    run_log: Path,
+) -> tuple[str, dict, int] | None:
+    """Classify typed claim-local no-verdict outcomes and their expected exit.
+
+    Unknown execution, apply, propagation, and push failures remain hard. A
+    malformed or schema-invalid packet minted no verdict and is safe to
+    quarantine for this campaign. Missing runner evidence is compute work, not
+    negative science.
+    """
     if terminal is None:
         return None
     phase = terminal["phase"]
     if phase == "validate_failed":
         detail = str(terminal.get("error") or "").strip()
-        if not detail:
+        if not detail or detail.startswith(
+            (
+                "fresh schema retry codex exec failed:",
+                "validation repair codex exec failed:",
+            )
+        ):
             return None
         return batch.SCHEMA_QUARANTINE_RESULT, {
             "cid": claim_id,
             "pass": 1,
             "result": "validation_failed",
             "detail": f"{detail}; preserved_run_log={run_log.name}",
-        }
+        }, 1
     if phase == "json_parse_failed":
         return batch.SCHEMA_QUARANTINE_RESULT, {
             "cid": claim_id,
             "pass": 1,
             "result": "malformed_json",
-        }
+        }, 1
     if phase == "skip_prompt_transport":
         detail = str(
             terminal.get("reason")
@@ -486,7 +500,7 @@ def forensic_canary_claim_local_failure(
             "pass": 1,
             "result": "validation_failed",
             "detail": f"{detail}; preserved_run_log={run_log.name}",
-        }
+        }, 0
     if phase in {"compute_required", "skip_no_runner_log"}:
         detail = str(
             terminal.get("reason")
@@ -498,7 +512,7 @@ def forensic_canary_claim_local_failure(
             "pass": 1,
             "result": "compute_required",
             "detail": detail,
-        }
+        }, 0
     return None
 
 
@@ -541,14 +555,38 @@ def run_forensic_canary(args: argparse.Namespace) -> int:
     env["AUDIT_FORENSIC_MODE"] = "1"
     rc = run_command(f"forensic-canary-{claim_id}", command, env=env)
     try:
-        claim_local = forensic_canary_claim_local_failure(run_log, claim_id)
+        terminal = forensic_canary_terminal_record(run_log, claim_id)
     except (OSError, ValueError) as exc:
         emit(f"invalid forensic canary artifact; refusing quarantine: {exc}")
         return 2
+    claim_local = forensic_canary_claim_local_failure(
+        terminal,
+        claim_id,
+        run_log,
+    )
     if claim_local is None:
-        return rc
+        if rc != 0:
+            return rc
+        terminal_phase = terminal.get("phase") if terminal else None
+        if terminal_phase == "applied" or (
+            args.dry_run and terminal_phase == "dry-run"
+        ):
+            return 0
+        emit(
+            "forensic canary returned success without an applied verdict, "
+            "typed quarantine, or dry-run terminal record; failing closed: "
+            f"claim={claim_id} terminal={terminal_phase or 'missing'}"
+        )
+        return 2
 
-    reason, failure = claim_local
+    reason, failure, expected_rc = claim_local
+    if rc != expected_rc:
+        emit(
+            "forensic canary terminal/exit mismatch; refusing claim-local "
+            f"quarantine: claim={claim_id} terminal={terminal['phase']} "
+            f"expected_exit={expected_rc} actual_exit={rc}"
+        )
+        return rc if rc != 0 else 2
     if reason == batch.SCHEMA_QUARANTINE_RESULT:
         batch.persist_campaign_quarantine(
             args.campaign_quarantine_file,

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -378,9 +378,12 @@ def drain_lane(lane: str, args: argparse.Namespace) -> tuple[int, bool]:
             return 0, made_progress
 
 
-def first_ready_forensic_claim() -> str | None:
+def first_ready_forensic_claim(
+    excluded_claim_ids: set[str] | None = None,
+) -> str | None:
     if not QUEUE.exists():
         return None
+    excluded = excluded_claim_ids or set()
     rows = json.loads(QUEUE.read_text(encoding="utf-8")).get("queue", [])
     for row in rows:
         if (
@@ -389,16 +392,131 @@ def first_ready_forensic_claim() -> str | None:
             and batch.source_requires_forensic(row)
         ):
             claim_id = row.get("claim_id")
-            if isinstance(claim_id, str) and claim_id:
+            if (
+                isinstance(claim_id, str)
+                and claim_id
+                and claim_id not in excluded
+            ):
                 return claim_id
     return None
 
 
+def forensic_canary_claim_local_failure(
+    run_log: Path,
+    claim_id: str,
+) -> tuple[str, dict] | None:
+    """Classify only typed claim-local canary outcomes from its preserved log.
+
+    Unknown execution, apply, propagation, and push failures remain hard. A
+    malformed or schema-invalid packet minted no verdict and is safe to
+    quarantine for this campaign. Missing runner evidence is compute work, not
+    negative science.
+    """
+    if not run_log.is_file():
+        return None
+    records: list[dict] = []
+    for line_number, line in enumerate(
+        run_log.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        if not line.strip():
+            raise ValueError(f"{run_log}:{line_number}: blank canary log record")
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"{run_log}:{line_number}: invalid canary log JSON: {exc.msg}"
+            ) from exc
+        if not isinstance(record, dict):
+            raise ValueError(
+                f"{run_log}:{line_number}: canary log record is not an object"
+            )
+        if record.get("claim_id") in {None, claim_id}:
+            records.append(record)
+
+    terminal_phases = {
+        "applied",
+        "apply_failed",
+        "applied_propagation_failed",
+        "push_failed",
+        "codex_failed",
+        "extract_failed",
+        "json_parse_failed",
+        "validate_failed",
+        "compute_required",
+        "skip_no_runner_log",
+        "skip_prompt_transport",
+        "weak_clean_unratifiable",
+        "dry-run",
+    }
+    terminal = next(
+        (
+            record
+            for record in reversed(records)
+            if record.get("phase") in terminal_phases
+        ),
+        None,
+    )
+    if terminal is None:
+        return None
+    phase = terminal["phase"]
+    if phase == "validate_failed":
+        detail = str(terminal.get("error") or "").strip()
+        if not detail:
+            return None
+        return batch.SCHEMA_QUARANTINE_RESULT, {
+            "cid": claim_id,
+            "pass": 1,
+            "result": "validation_failed",
+            "detail": f"{detail}; preserved_run_log={run_log.name}",
+        }
+    if phase == "json_parse_failed":
+        return batch.SCHEMA_QUARANTINE_RESULT, {
+            "cid": claim_id,
+            "pass": 1,
+            "result": "malformed_json",
+        }
+    if phase == "skip_prompt_transport":
+        detail = str(
+            terminal.get("reason")
+            or "forensic canary prompt exceeded the bounded transport"
+        ).strip()
+        return batch.SCHEMA_QUARANTINE_RESULT, {
+            "cid": claim_id,
+            "pass": 1,
+            "result": "validation_failed",
+            "detail": f"{detail}; preserved_run_log={run_log.name}",
+        }
+    if phase in {"compute_required", "skip_no_runner_log"}:
+        detail = str(
+            terminal.get("reason")
+            or terminal.get("runner_path")
+            or "forensic canary requires a current runner artifact"
+        ).strip()
+        return batch.COMPUTE_QUARANTINE_RESULT, {
+            "cid": claim_id,
+            "pass": 1,
+            "result": "compute_required",
+            "detail": detail,
+        }
+    return None
+
+
 def run_forensic_canary(args: argparse.Namespace) -> int:
-    claim_id = first_ready_forensic_claim()
+    try:
+        excluded = batch.load_campaign_quarantine(
+            args.campaign_quarantine_file
+        )
+    except (OSError, ValueError) as exc:
+        emit(f"invalid campaign state before forensic canary: {exc}")
+        return 2
+    claim_id = first_ready_forensic_claim(excluded)
     if not claim_id:
         emit("no ready forensic-tier row available for the forensic canary")
         return 0
+    run_log = args.campaign_workdir / (
+        f"forensic-canary-{batch.artifact_key(claim_id)}.jsonl"
+    )
     command = [
         sys.executable,
         str(FORENSIC),
@@ -413,13 +531,50 @@ def run_forensic_canary(args: argparse.Namespace) -> int:
         "--validation-repair-attempts",
         "1",
         "--fresh-schema-retry-attempts",
-        "2",
+        "3",
+        "--run-log-path",
+        str(run_log),
     ]
     if args.dry_run:
         command.append("--dry-run")
     env = dict(os.environ)
     env["AUDIT_FORENSIC_MODE"] = "1"
-    return run_command(f"forensic-canary-{claim_id}", command, env=env)
+    rc = run_command(f"forensic-canary-{claim_id}", command, env=env)
+    try:
+        claim_local = forensic_canary_claim_local_failure(run_log, claim_id)
+    except (OSError, ValueError) as exc:
+        emit(f"invalid forensic canary artifact; refusing quarantine: {exc}")
+        return 2
+    if claim_local is None:
+        return rc
+
+    reason, failure = claim_local
+    if reason == batch.SCHEMA_QUARANTINE_RESULT:
+        batch.persist_campaign_quarantine(
+            args.campaign_quarantine_file,
+            {claim_id},
+            [failure],
+        )
+    elif reason == batch.COMPUTE_QUARANTINE_RESULT:
+        batch.persist_compute_required_skips(
+            args.campaign_quarantine_file,
+            {claim_id},
+            [failure],
+        )
+    else:
+        emit(f"unsupported forensic canary quarantine reason: {reason}")
+        return 2
+    try:
+        batch.load_campaign_exclusion_records(args.campaign_quarantine_file)
+    except (OSError, ValueError) as exc:
+        emit(f"forensic canary quarantine did not validate: {exc}")
+        return 2
+    PROGRESS["canary_state"] = f"quarantined:{reason}:{claim_id}"
+    emit(
+        "forensic canary minted no verdict and was quarantined claim-locally: "
+        f"claim={claim_id} reason={reason} artifact={run_log}"
+    )
+    return 0
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -487,6 +642,7 @@ def main(argv: list[str] | None = None) -> int:
     args.campaign_selection_skip_file = (
         campaign_dir / "campaign-selector-skips.jsonl"
     )
+    args.campaign_workdir = campaign_dir
     PROGRESS["quarantine_file"] = args.campaign_quarantine_file
     emit(f"campaign artifacts: {campaign_dir}")
     try:

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -2976,6 +2976,50 @@ class CampaignContractTest(unittest.TestCase):
                 audit_loop.PROGRESS["canary_state"].startswith("quarantined:")
             )
 
+    def test_forensic_compute_skip_is_quarantined_and_returns_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            campaign = Path(tmp)
+            args = _args()
+            args.campaign_workdir = campaign
+            args.campaign_quarantine_file = (
+                campaign / "campaign-row-exclusions.jsonl"
+            )
+            claim_id = "forensic_row"
+
+            def fake_run(_label, command, env=None):
+                log = Path(command[command.index("--run-log-path") + 1])
+                log.write_text(
+                    json.dumps(
+                        {
+                            "claim_id": claim_id,
+                            "phase": "compute_required",
+                            "reason": "runner evidence unavailable",
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                return 0
+
+            with mock.patch.object(
+                audit_loop,
+                "first_ready_forensic_claim",
+                return_value=claim_id,
+            ), mock.patch.object(audit_loop, "run_command", side_effect=fake_run):
+                rc = audit_loop.run_forensic_canary(args)
+
+            records = batch.load_campaign_exclusion_records(
+                args.campaign_quarantine_file
+            )
+            self.assertEqual(rc, 0)
+            self.assertEqual(len(records), 1)
+            self.assertEqual(
+                records[0]["reason"], batch.COMPUTE_QUARANTINE_RESULT
+            )
+            self.assertEqual(
+                records[0]["failures"][0]["result"], "compute_required"
+            )
+
     def test_forensic_unknown_failure_still_fails_closed(self):
         with tempfile.TemporaryDirectory() as tmp:
             campaign = Path(tmp)
@@ -2994,6 +3038,108 @@ class CampaignContractTest(unittest.TestCase):
                             "claim_id": claim_id,
                             "phase": "push_failed",
                             "msg": "remote rejected",
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                return 1
+
+            with mock.patch.object(
+                audit_loop,
+                "first_ready_forensic_claim",
+                return_value=claim_id,
+            ), mock.patch.object(audit_loop, "run_command", side_effect=fake_run):
+                rc = audit_loop.run_forensic_canary(args)
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(args.campaign_quarantine_file.exists())
+
+    def test_forensic_fresh_schema_execution_failure_is_not_quarantined(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            campaign = Path(tmp)
+            args = _args()
+            args.campaign_workdir = campaign
+            args.campaign_quarantine_file = (
+                campaign / "campaign-row-exclusions.jsonl"
+            )
+            claim_id = "forensic_row"
+
+            def fake_run(_label, command, env=None):
+                log = Path(command[command.index("--run-log-path") + 1])
+                log.write_text(
+                    json.dumps(
+                        {
+                            "claim_id": claim_id,
+                            "phase": "validate_failed",
+                            "error": (
+                                "fresh schema retry codex exec failed: "
+                                "transport died"
+                            ),
+                            "blob": {},
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                return 1
+
+            with mock.patch.object(
+                audit_loop,
+                "first_ready_forensic_claim",
+                return_value=claim_id,
+            ), mock.patch.object(audit_loop, "run_command", side_effect=fake_run):
+                rc = audit_loop.run_forensic_canary(args)
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(args.campaign_quarantine_file.exists())
+
+    def test_forensic_zero_exit_without_terminal_outcome_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            campaign = Path(tmp)
+            args = _args()
+            args.campaign_workdir = campaign
+            args.campaign_quarantine_file = (
+                campaign / "campaign-row-exclusions.jsonl"
+            )
+            claim_id = "forensic_row"
+
+            def fake_run(_label, command, env=None):
+                log = Path(command[command.index("--run-log-path") + 1])
+                log.write_text(
+                    json.dumps({"phase": "model_policy"}) + "\n",
+                    encoding="utf-8",
+                )
+                return 0
+
+            with mock.patch.object(
+                audit_loop,
+                "first_ready_forensic_claim",
+                return_value=claim_id,
+            ), mock.patch.object(audit_loop, "run_command", side_effect=fake_run):
+                rc = audit_loop.run_forensic_canary(args)
+
+            self.assertEqual(rc, 2)
+            self.assertFalse(args.campaign_quarantine_file.exists())
+
+    def test_forensic_terminal_exit_mismatch_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            campaign = Path(tmp)
+            args = _args()
+            args.campaign_workdir = campaign
+            args.campaign_quarantine_file = (
+                campaign / "campaign-row-exclusions.jsonl"
+            )
+            claim_id = "forensic_row"
+
+            def fake_run(_label, command, env=None):
+                log = Path(command[command.index("--run-log-path") + 1])
+                log.write_text(
+                    json.dumps(
+                        {
+                            "claim_id": claim_id,
+                            "phase": "compute_required",
+                            "reason": "runner evidence unavailable",
                         }
                     )
                     + "\n",

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -677,6 +677,13 @@ def _args() -> argparse.Namespace:
         dispatch_science_fixes=False,
         skip_forensic_canary=True,
         dry_run=False,
+        campaign_workdir=Path("/tmp/campaign"),
+        campaign_quarantine_file=Path(
+            "/tmp/campaign/campaign-row-exclusions.jsonl"
+        ),
+        campaign_selection_skip_file=Path(
+            "/tmp/campaign/campaign-selector-skips.jsonl"
+        ),
     )
 
 
@@ -2886,6 +2893,123 @@ class CampaignContractTest(unittest.TestCase):
             ):
                 selected = audit_loop.first_ready_forensic_claim()
         self.assertEqual(selected, "bounded_obstruction")
+
+    def test_forensic_selector_skips_campaign_quarantine(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            queue = Path(tmp) / "queue.json"
+            queue.write_text(
+                json.dumps(
+                    {
+                        "queue": [
+                            {
+                                "claim_id": "quarantined",
+                                "ready": True,
+                                "audit_status": "unaudited",
+                            },
+                            {
+                                "claim_id": "next_canary",
+                                "ready": True,
+                                "audit_status": "unaudited",
+                            },
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch.object(audit_loop, "QUEUE", queue), mock.patch.object(
+                batch, "source_requires_forensic", return_value=True
+            ):
+                selected = audit_loop.first_ready_forensic_claim({"quarantined"})
+        self.assertEqual(selected, "next_canary")
+
+    def test_forensic_schema_failure_is_quarantined_and_returns_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            campaign = Path(tmp)
+            args = _args()
+            args.campaign_workdir = campaign
+            args.campaign_quarantine_file = (
+                campaign / "campaign-row-exclusions.jsonl"
+            )
+            claim_id = "forensic_row"
+
+            def fake_run(_label, command, env=None):
+                log = Path(command[command.index("--run-log-path") + 1])
+                log.write_text(
+                    json.dumps(
+                        {
+                            "claim_id": claim_id,
+                            "phase": "validate_failed",
+                            "error": (
+                                "N5.statements must exactly disposition "
+                                "orchestrator rhetoric scan; missing=[redacted]"
+                            ),
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                return 1
+
+            with mock.patch.object(
+                audit_loop,
+                "first_ready_forensic_claim",
+                return_value=claim_id,
+            ), mock.patch.object(audit_loop, "run_command", side_effect=fake_run):
+                rc = audit_loop.run_forensic_canary(args)
+
+            records = batch.load_campaign_exclusion_records(
+                args.campaign_quarantine_file
+            )
+            self.assertEqual(rc, 0)
+            self.assertEqual(len(records), 1)
+            self.assertEqual(
+                records[0]["reason"], batch.SCHEMA_QUARANTINE_RESULT
+            )
+            self.assertEqual(
+                records[0]["failures"][0]["result"], "validation_failed"
+            )
+            self.assertIn(
+                "preserved_run_log",
+                records[0]["failures"][0]["detail"],
+            )
+            self.assertTrue(
+                audit_loop.PROGRESS["canary_state"].startswith("quarantined:")
+            )
+
+    def test_forensic_unknown_failure_still_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            campaign = Path(tmp)
+            args = _args()
+            args.campaign_workdir = campaign
+            args.campaign_quarantine_file = (
+                campaign / "campaign-row-exclusions.jsonl"
+            )
+            claim_id = "forensic_row"
+
+            def fake_run(_label, command, env=None):
+                log = Path(command[command.index("--run-log-path") + 1])
+                log.write_text(
+                    json.dumps(
+                        {
+                            "claim_id": claim_id,
+                            "phase": "push_failed",
+                            "msg": "remote rejected",
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                return 1
+
+            with mock.patch.object(
+                audit_loop,
+                "first_ready_forensic_claim",
+                return_value=claim_id,
+            ), mock.patch.object(audit_loop, "run_command", side_effect=fake_run):
+                rc = audit_loop.run_forensic_canary(args)
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(args.campaign_quarantine_file.exists())
 
     def test_unknown_lane_fails_before_opening_panel(self):
         with mock.patch.object(

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -11657,13 +11657,39 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             "missing=[], extra=[('secret_path', 'sector', 'secret_id')]"
         )
         self.assertEqual(
-            n3_scan_code, "N3_AUTHENTICATED_GROUP_TUPLE_MISMATCH"
+            n3_scan_code, "N3_AUTHENTICATED_GROUP_COVERAGE_MISMATCH"
         )
         n3_scan_prompt = m.render_fresh_schema_retry_prompt(
             "ORIGINAL RESTRICTED PACKET", n3_scan_code, 1,
         )
+        self.assertIn(
+            "every authenticated full_phrase_groups record", n3_scan_prompt
+        )
+        self.assertIn("exactly once in N3.hits", n3_scan_prompt)
+        self.assertIn(
+            "(evidence_path, phrase, occurrence_group_id)", n3_scan_prompt
+        )
         self.assertNotIn("secret_path", n3_scan_prompt)
         self.assertNotIn("secret_id", n3_scan_prompt)
+        n5_scan_code = m.fresh_schema_retry_code(
+            "N5.statements must exactly disposition orchestrator rhetoric scan; "
+            "missing=[('secret_path', 'cannot', 'secret_id')], extra=[]"
+        )
+        self.assertEqual(
+            n5_scan_code, "N5_AUTHENTICATED_GROUP_COVERAGE_MISMATCH"
+        )
+        n5_scan_prompt = m.render_fresh_schema_retry_prompt(
+            "ORIGINAL RESTRICTED PACKET", n5_scan_code, 1,
+        )
+        self.assertIn(
+            "every authenticated full_phrase_groups record", n5_scan_prompt
+        )
+        self.assertIn("exactly once in N5.statements", n5_scan_prompt)
+        self.assertIn(
+            "Shared group ids or digests do not merge", n5_scan_prompt
+        )
+        self.assertNotIn("secret_path", n5_scan_prompt)
+        self.assertNotIn("secret_id", n5_scan_prompt)
         for n7_error in (
             "N7.argument is not evidenced at its N1 execution path",
             "N7.resolution is not evidenced at resolution_evidence_path",

--- a/docs/audit/scripts/tests/test_science_fix_priority.py
+++ b/docs/audit/scripts/tests/test_science_fix_priority.py
@@ -325,6 +325,62 @@ class CampaignRepairIntakeTest(unittest.TestCase):
         self.assertIn("carries no scientific", by_claim["schema"]["prompt_body"])
         self.assertTrue(by_claim["schema"]["state_key"].startswith("campaign:"))
 
+    def test_real_forensic_canary_quarantine_becomes_operational_repair(self):
+        campaign = self._campaign(
+            [
+                {
+                    "claim_id": "forensic_row",
+                    "reason": "schema_invalid_quarantined",
+                    "failures": [
+                        {
+                            "cid": "forensic_row",
+                            "pass": 1,
+                            "result": "validation_failed",
+                            "detail": (
+                                "N5.statements must exactly disposition "
+                                "orchestrator rhetoric scan; "
+                                "preserved_run_log=forensic-canary-row.jsonl"
+                            ),
+                        }
+                    ],
+                    "recorded_at": "2026-07-24T12:00:00+00:00",
+                }
+            ]
+        )
+        (campaign / "forensic-canary-row.jsonl").write_text(
+            json.dumps(
+                {
+                    "claim_id": "forensic_row",
+                    "phase": "validate_failed",
+                    "error": "N5 coverage mismatch",
+                    "blob": {"untrusted": "rejected response"},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        canonical = {
+            "claim_id": "forensic_row",
+            "note_path": "docs/FORENSIC.md",
+            "runner_path": "scripts/forensic.py",
+            "audit_status": "unaudited",
+            "effective_status": "unaudited",
+            "transitive_descendants": 10,
+        }
+
+        candidates = sfl.parse_campaign_workdir(
+            campaign,
+            ledger_loader=lambda _cid: canonical,
+        )
+
+        self.assertEqual(len(candidates), 1)
+        candidate = candidates[0]
+        self.assertEqual(candidate["category"], "campaign_schema_transport")
+        self.assertEqual(candidate["worker_mode"], "operational")
+        self.assertIn("preserved_run_log", candidate["prompt_body"])
+        self.assertIn("carries no scientific", candidate["prompt_body"])
+        self.assertEqual(candidate["note_path"], "docs/FORENSIC.md")
+
     def test_missing_ledger_row_gets_registration_route(self):
         campaign = self._campaign(
             [{"claim_id": "missing", "reason": "unknown_quarantine"}]

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -3244,7 +3244,7 @@ def main() -> int:
                 with run_log.open("a", encoding="utf-8") as f:
                     f.write(json.dumps({
                         "claim_id": cid, "phase": "json_parse_failed",
-                        "reply": reply[:2000]
+                        "reply": reply,
                     }) + "\n")
                 continue
 
@@ -3366,7 +3366,7 @@ def main() -> int:
                                 "claim_id": cid,
                                 "phase": "validation_repair_json_parse_failed",
                                 "attempt": repair_attempt,
-                                "reply": (repair_reply or "")[:2000],
+                                "reply": repair_reply or "",
                             }) + "\n")
                         continue
                     repair_casefold_path_bindings = (
@@ -3505,6 +3505,13 @@ def main() -> int:
                             "fresh schema retry codex exec failed: "
                             f"{schema_stderr.strip()[:300]}"
                         )
+                        with run_log.open("a", encoding="utf-8") as f:
+                            f.write(json.dumps({
+                                "claim_id": cid,
+                                "phase": "fresh_schema_retry_codex_failed",
+                                "attempt": schema_attempt,
+                                "error": err,
+                            }) + "\n")
                         continue
                     schema_reply = extract_response(schema_stdout)
                     schema_retry_compute_required = compute_required_reason(schema_reply)
@@ -3513,6 +3520,13 @@ def main() -> int:
                     schema_blob = parse_verdict_json(schema_reply or "")
                     if schema_blob is None:
                         err = "fresh schema retry reply not valid JSON"
+                        with run_log.open("a", encoding="utf-8") as f:
+                            f.write(json.dumps({
+                                "claim_id": cid,
+                                "phase": "fresh_schema_retry_json_parse_failed",
+                                "attempt": schema_attempt,
+                                "reply": schema_reply or "",
+                            }) + "\n")
                         continue
                     schema_casefold_path_bindings = (
                         bind_authenticated_casefold_evidence_paths(

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -2360,18 +2360,22 @@ def fresh_schema_retry_eligible(validation_error: str | None) -> bool:
 
 def fresh_schema_retry_code(validation_error: str) -> str:
     """Reduce validator text to a conclusion-free control-plane code."""
+    if validation_error.startswith(
+        "N3.hits must exactly disposition orchestrator phrase scan"
+    ):
+        return "N3_AUTHENTICATED_GROUP_COVERAGE_MISMATCH"
     if (
         validation_error.startswith("N3 hit ")
         and "occurrence_" in validation_error
-    ) or validation_error.startswith(
-        "N3.hits must exactly disposition orchestrator phrase scan"
     ):
         return "N3_AUTHENTICATED_GROUP_TUPLE_MISMATCH"
+    if validation_error.startswith(
+        "N5.statements must exactly disposition orchestrator rhetoric scan"
+    ):
+        return "N5_AUTHENTICATED_GROUP_COVERAGE_MISMATCH"
     if (
         validation_error.startswith("N5 statement ")
         and "occurrence_" in validation_error
-    ) or validation_error.startswith(
-        "N5.statements must exactly disposition orchestrator rhetoric scan"
     ):
         return "N5_AUTHENTICATED_GROUP_TUPLE_MISMATCH"
     if validation_error.startswith("N3 retained_authority hit "):
@@ -2479,11 +2483,30 @@ def render_fresh_schema_retry_prompt(
             "infer an unlisted phrase from a shared id or cross-label a count, "
             "digest, or locator from another record.\n"
         ),
+        "N3_AUTHENTICATED_GROUP_COVERAGE_MISMATCH": (
+            "Static N3 coverage invariant: enumerate every authenticated "
+            "full_phrase_groups record from every applicable manifest path "
+            "exactly once in N3.hits. Key coverage by the complete "
+            "(evidence_path, phrase, occurrence_group_id) tuple. Do not "
+            "deduplicate records merely because they share a context-derived "
+            "group id or digest, and do not add a phrase absent from the "
+            "authenticated records. Copy each record's complete occurrence "
+            "tuple without cross-labeling fields.\n"
+        ),
         "N5_AUTHENTICATED_GROUP_TUPLE_MISMATCH": (
             "Static N5 invariant: copy phrase, occurrence_group_id, "
             "occurrence_count, occurrence_locator_sha256, and evidence_locator "
             "from one same full_phrase_groups record. Never cross-label a group "
             "id, count, digest, or locator under another phrase.\n"
+        ),
+        "N5_AUTHENTICATED_GROUP_COVERAGE_MISMATCH": (
+            "Static N5 coverage invariant: enumerate every authenticated "
+            "full_phrase_groups record from every applicable manifest path "
+            "exactly once in N5.statements. Key coverage by the complete "
+            "(evidence_path, phrase, occurrence_group_id) tuple. Shared group "
+            "ids or digests do not merge distinct phrase records. Do not omit, "
+            "deduplicate, or invent records; copy each record's complete "
+            "occurrence tuple from that same record.\n"
         ),
         "N5_TESTED_RESOLUTION_VERBATIM_MISMATCH": (
             "Static N5 invariant: copy every complete tested_resolutions entry, "
@@ -2764,6 +2787,16 @@ def main() -> int:
                         "this way will be tagged with the actual sub-floor "
                         "family and won't satisfy the standard "
                         "independence rule for clean verdicts.")
+    p.add_argument(
+        "--run-log-path",
+        type=Path,
+        default=None,
+        help=(
+            "Write the append-only JSONL run log at this exact path. The path "
+            "must not already exist. Audit-loop uses this to preserve a "
+            "forensic canary's rejected packet inside its campaign workdir."
+        ),
+    )
     args = p.parse_args()
 
     if not 0 <= args.validation_repair_attempts <= 3:
@@ -2808,14 +2841,24 @@ def main() -> int:
             f"verdicts. Use only for testing."
         )
 
-    LOG_DIR.mkdir(parents=True, exist_ok=True)
     run_uuid = uuid.uuid4().hex
     run_id = run_uuid[:8]
     auditor_name_base = args.auditor_name or (
         f"codex-cli-{audit_model}-"
         f"{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}-{run_id}"
     )
-    run_log = LOG_DIR / f"run-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}-{run_id}.jsonl"
+    if args.run_log_path is not None:
+        run_log = args.run_log_path
+        if run_log.exists():
+            print(f"REFUSING: --run-log-path already exists: {run_log}")
+            return 2
+        run_log.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        run_log = LOG_DIR / (
+            f"run-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}-"
+            f"{run_id}.jsonl"
+        )
     print(f"Run log: {run_log}")
     print(f"Auditor (base): {auditor_name_base}  ({auditor_family})")
     print(f"Codex model: {audit_model}  reasoning_effort={reasoning_effort}")


### PR DESCRIPTION
## Summary

Repair the final forensic canary control-flow gap that caused a bounded N1/N5 packet-schema rejection to stop an otherwise fixed-point audit campaign.

- preserve the complete canary JSONL inside the campaign workdir
- route malformed/validator-rejected canaries through the strict `schema_invalid_quarantined` record and return the campaign successfully at its non-excluded fixed point
- route missing runner evidence through `compute_required_quarantined`
- keep unknown execution, apply, propagation, and push failures fail-closed
- give the canary the existing maximum three fresh-schema seats and add distinct N3/N5 coverage guidance for exhaustive authenticated `full_phrase_groups` disposition
- update `audit-loop` and `science-fix-loop`; prove science-fix discovers the canary incident as an operational repair with no scientific authority

## Validation

- `python3 -m unittest docs.audit.scripts.tests.test_audit_loop_orchestrator docs.audit.scripts.tests.test_science_fix_priority` — 115 passed
- `python3 -m unittest docs.audit.scripts.tests.test_audit_pipeline.CodexAuditRunnerTargetSelectionTest` — 26 passed
- full `docs/audit/scripts/run_pipeline.sh` — passed
- `audit_lint.py --strict` — 0 errors
- `repo_invariants_check.py --check --enforce-links` — passed
- skill `quick_validate.py` for audit-loop and science-fix-loop — passed

No scientific note, verdict, ledger row, generated audit output, premise, or retained-grade claim is changed.
