### PR TITLE
Harden distributed audit backlog draining

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -410,9 +410,16 @@ python3 docs/audit/scripts/orchestrate_audit_batch.py \
   ledger and runner bytes. Remote movement supersedes the stale delivery
   without applying or quarantining it.
 - **Live runners never repair a shared checkout.** Execute each primary/helper
-  runner in a disposable isolated worktree, capture stdout/stderr, terminate
-  its process group, and discard the whole checkout. Never infer ownership of
-  a shared untracked/ignored delta and recursively delete it.
+  runner in a disposable isolated worktree and capture stdout/stderr. Bind the
+  runner and every inherited child to an unguessable invocation token; on
+  every completion, timeout, exception, or cancellation, repeatedly enumerate
+  token-bearing processes, revalidate the token immediately before each
+  signal, and fail closed unless none remain. Never retain or signal a bare PID
+  after its identity can change. On macOS, also apply a kernel sandbox that
+  denies writes to the canonical checkout. A containment or checkout-discard
+  failure is a hard error; discard the isolated checkout on every exit path.
+  Never infer ownership of a shared untracked/ignored delta and recursively
+  delete it.
 - **Concurrency budget (shared codex pool).** Auditor seats, review-loop
   reviewers, and judicial panels all draw on one pool. Keep the TOTAL
   concurrent codex processes across every lane at or under ~8-10, and

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -209,14 +209,18 @@ default session is:
 2. Launch the panel-aware top-level drainer:
 
    ```bash
+   AUDIT_WORKER_ID=<unique-coordinator-id> \
    python3 docs/audit/scripts/orchestrate_audit_loop.py --max-workers 4
    ```
 
-   This command owns the complete control loop: finish pending judicial work,
-   drain configured development lanes in order, immediately panel every fresh
-   cross-seat disagreement, resume the same lane after the panel lands, repeat
-   until a full pass lands nothing new, then run one forensic canary. Raise
-   toward 6 workers only in a quiet pool per the budget below. The supervisor
+   This command owns the complete control loop: drain authenticated targeted
+   dispatch and cascade re-audit sources, finish pending judicial work, drain
+   configured development lanes in order, drain every other eligible
+   development row, immediately panel every fresh cross-seat disagreement,
+   resume after the panel lands, then advance the forensic source one
+   validated row at a time. Every landed forensic result returns through the
+   development phases because it may unblock dependencies. Raise toward 6
+   workers only in a quiet pool per the budget below. The supervisor
    holds the clone-wide audit lock for the complete campaign and hands that
    lock to its batch/panel children. It runs the panel sweep after every batch
    termination before propagating any unrelated hard batch failure, so a mixed
@@ -224,16 +228,24 @@ default session is:
    Keep the printed campaign artifact directory. It is the durable operational
    record for schema, compute, blocked-reentry, and safely rolled-back
    transaction exclusions; it does not carry scientific authority.
-   A bounded JSON/schema rejection from the final canary is also claim-local:
+   A bounded JSON/schema rejection from a forensic row is also claim-local:
    the supervisor preserves the complete `forensic-canary-*.jsonl` run log,
-   appends a strict `schema_invalid_quarantined` record, reports that the
-   canary did not land, and exits the campaign successfully at its
-   non-excluded fixed point. Unknown execution failures and apply,
+   appends a strict `schema_invalid_quarantined` record, reports that the row
+   did not land, and advances to the next non-excluded forensic row. Unknown
+   execution failures and apply,
    propagation, or push failures still fail closed.
 3. If the user names a lane, pass `--lane <name>`. Otherwise the orchestrator
    iterates lanes from `docs/audit/data/lane_certification_config.json`,
    selecting entries whose generated `lane_certification.json` record still
    has blocking rows.
+
+When multiple employees or Codex accounts participate, read and follow
+[`references/distributed-drain.md`](references/distributed-drain.md). There is
+one coordinator; every other independent clone runs
+`--development-helper --worker-id <globally-unique-id>`. A helper's exit is
+local information, never global completion. The concurrent-wave coordinator
+uses `--skip-forensic-canary`; after every helper quiesces, one fresh
+coordinator-only campaign runs without that flag and owns final completion.
 
 Do not detach `orchestrate_audit_batch.py` as the whole `/audit-loop`
 campaign. A batch is one inner development-tier step and intentionally yields
@@ -355,11 +367,13 @@ stop only at a genuine backlog fixed point, credit exhaustion, or a verified
 global integrity/tooling blocker. A goal cannot repair a nonzero pipeline or
 supervisor exit by itself.
 
-## Scaling: The One Canonical Fan-Out
+## Scaling: Canonical Fan-Out And Distributed Helpers
 
-There is exactly one sanctioned way to parallelize this lane — the
-repo-native batch drainer, invoked directly for a scoped inner step or by the
-top-level panel-aware orchestrator for the default backlog drain:
+There is exactly one sanctioned audit machinery: the repo-native batch
+drainer, invoked directly for a scoped inner step or by the top-level
+panel-aware orchestrator. Across independent employee clones, use only the
+top-level coordinator/helper contract in
+[`references/distributed-drain.md`](references/distributed-drain.md):
 
 ```bash
 python3 docs/audit/scripts/orchestrate_audit_batch.py \
@@ -383,6 +397,13 @@ python3 docs/audit/scripts/orchestrate_audit_batch.py \
   generated-surface transactions; push-race retry replays the whole pair from
   refreshed `origin/main`. Never add a second committer against the same
   checkout; parallelism lives in the auditor seats only.
+- **Cross-clone seats are optimistic, not authority-racing.** A stable unique
+  worker id rotates each criticality tier while retaining the complete target
+  set, so helpers start in different places without creating abandoned
+  shards. Immediately before apply, the drainer refreshes `origin/main` and
+  binds the delivery to the claim, dependencies, source bytes, and any
+  dispatch/cascade entry that selected it. Remote movement supersedes the
+  stale delivery without applying or quarantining it.
 - **Concurrency budget (shared codex pool).** Auditor seats, review-loop
   reviewers, and judicial panels all draw on one pool. Keep the TOTAL
   concurrent codex processes across every lane at or under ~8-10, and
@@ -394,8 +415,8 @@ python3 docs/audit/scripts/orchestrate_audit_batch.py \
   non-batch-auditable claim types, and forensic-shaped sources at selection;
   do not force them in via `--claims`.
 
-**Forensic tier scales by canary, not by fan-out.** Run exactly ONE
-forensic-tier row at a time until an N1-N8 packet has landed end-to-end
+**Forensic tier scales serially, not by fan-out.** Run exactly ONE
+forensic-tier row at a time until its N1-N8 packet has landed end-to-end
 through validation and apply; record every validator rejection verbatim
 (they are repair evidence for the packet/validator path, not noise). Only
 after a canary lands may the forensic lane run more than one seat, and never
@@ -409,8 +430,9 @@ rejects require one exact N3/N5 disposition for every authenticated
 `full_phrase_groups` record on every applicable manifest path; records that
 share a group id or digest are still distinct when their phrase/path tuple is
 distinct. If that bounded budget still ends in malformed JSON or a validator
-reject, quarantine the row for the campaign and continue to the fixed-point
-exit. That is not a landed canary and does not authorize forensic fan-out.
+reject, quarantine only that row for the campaign and continue to the next
+ready forensic row. That is not a landed canary and does not authorize
+forensic fan-out.
 
 **Seat-blocked judicial rows are reseated, never frozen and never retried
 as recorded.** A disagreement whose recorded seats lack invocation-bound
@@ -433,13 +455,15 @@ failure exits nonzero.
 
 **Parallel coexistence with review-loop.** The audit lane and review-loop
 sessions may run at the same time by design; the rules that keep concurrent
-landings cheap are: (1) exactly ONE audit-lane orchestrator per clone —
+landings cheap are: (1) exactly ONE audit-lane orchestrator per clone and
+exactly ONE coordinator globally — other independent clones use named
+development-helper mode —
 the drainer and the panel orchestrator enforce this with a machine-local
 exclusive lock keyed to the clone's git common directory, so every worktree
 of that clone shares one lock, and a second instance exits with guidance
-(parallelism belongs in the seats inside the one instance; an INDEPENDENT
-clone has its own lock, and cross-clone coordination stays with this
-contract and the concurrency budget, not the lock); (2) audit
+(an INDEPENDENT clone has its own lock, and cross-clone coordination stays
+with the coordinator/helper contract, remote-state preconditions, and the
+concurrency budget, not the lock); (2) audit
 commits are the expensive racers (they ship regenerated audit surfaces and
 a push race replays the pipeline), review landings are cheap racers
 (cherry-pick retries in seconds) — so the audit lane never waits for
@@ -571,7 +595,7 @@ Repair and re-entry are reason-specific:
 
 | Operational result | Required repair | Re-entry |
 | --- | --- | --- |
-| `schema_invalid_quarantined` | Preserve the malformed response, exact validator errors, and any `forensic-canary-*.jsonl` artifact; correct the CLI transport schema, prompt, or bounded packet-completion defect. A failed final canary must enter this route and finish the campaign at its non-excluded fixed point rather than becoming a global schema stop. Never edit the scientific judgment into validity. | Start a new campaign so a fresh restricted-context seat is selected. Reusing the old workdir keeps the claim excluded. |
+| `schema_invalid_quarantined` | Preserve the malformed response, exact validator errors, and any `forensic-canary-*.jsonl` artifact; correct the CLI transport schema, prompt, or bounded packet-completion defect. A failed forensic row enters this route while the coordinator advances through the remaining non-excluded backlog. Never edit the scientific judgment into validity. | Start a new campaign so a fresh restricted-context seat is selected. Reusing the old workdir keeps the claim excluded. |
 | `compute_required_quarantined` / `compute_required` | Produce a SHA-pinned runner cache with `cached_runner_output.py`, a sliced deterministic certificate, or an independent derivation; then run the full pipeline and strict lint. | Start a new campaign after the artifact is current. |
 | `blocked_row_reentry_quarantined` | Repair the recorded classifier promotion, dependency/status cycle, note-hash drift, or other invalidation cause. Require one converged full pipeline. | Start a new campaign only after the row no longer immediately returns to the same dep-ready state. |
 | `claim_transaction_quarantined` | Fix the recorded apply, pipeline, or lint defect and prove the clean full pipeline converges. The failed delivery minted no verdict. | Use a fresh seat in a new campaign unless canonical tooling verifies an exact preserved-envelope replay against the current source/seat fingerprint. |
@@ -755,9 +779,10 @@ PY
 ### Dispatch Queue
 
 `docs/audit/data/audit_dispatch_queue.json` carries provenance and
-promotion re-audit targets, processed only when explicitly selected
-by the user or surfaced by an external dispatcher — not automatically
-pulled by the default selection above.
+promotion re-audit targets. The top-level coordinator authenticates and
+drains ready entries before cascade and regular development work; a
+development helper does not. A manual single-claim run processes this source
+when explicitly selected by the user or surfaced by an external dispatcher.
 
 **Same-status confirmation rule:** if a fresh-context re-audit on a
 dispatch target confirms the same `{claim_type, audit_status,

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -342,7 +342,9 @@ failures. This boundary is fail-closed and does not weaken any audit gate.
   edge; neither is a campaign failure.
 - **Global retryable:** a transient fetch/push failure whose remote outcome can
   be reconciled exactly. Reconcile the intended commit OID before replay; never
-  blindly repeat an uncertain push.
+  blindly repeat an uncertain push. If fetch or ancestry proof is unavailable,
+  preserve the local intended commit and hard-stop with
+  `push_reconciliation_required`; do not reset to a stale remote-tracking ref.
 - **Global hard stop:** dirty or divergent source state, failed rollback,
   repository invariant failure, unclassifiable generated diff, corrupted
   campaign state, unavailable required audit model, authentication failure
@@ -401,9 +403,16 @@ python3 docs/audit/scripts/orchestrate_audit_batch.py \
   worker id rotates each criticality tier while retaining the complete target
   set, so helpers start in different places without creating abandoned
   shards. Immediately before apply, the drainer refreshes `origin/main` and
-  binds the delivery to the claim, dependencies, source bytes, and any
-  dispatch/cascade entry that selected it. Remote movement supersedes the
-  stale delivery without applying or quarantining it.
+  binds the delivery to the complete ledger provenance, exact packet evidence
+  manifest, dependency note bytes, runner/helper declared inputs, computed
+  role/independence/passes, and any dispatch/cascade entry that selected it.
+  The cascade cache must exactly equal a pure recomputation from the current
+  ledger and runner bytes. Remote movement supersedes the stale delivery
+  without applying or quarantining it.
+- **Live runners never repair a shared checkout.** Execute each primary/helper
+  runner in a disposable isolated worktree, capture stdout/stderr, terminate
+  its process group, and discard the whole checkout. Never infer ownership of
+  a shared untracked/ignored delta and recursively delete it.
 - **Concurrency budget (shared codex pool).** Auditor seats, review-loop
   reviewers, and judicial panels all draw on one pool. Keep the TOTAL
   concurrent codex processes across every lane at or under ~8-10, and
@@ -510,6 +519,9 @@ schema). It does not show that the source claim is false or needs editing.
   quarantine the claim for the current top-level campaign. Continue draining
   other ready rows. Pass the campaign quarantine file to every inner batch so
   a new batch cycle cannot immediately burn the same row again.
+- A new campaign-exclusion record is operational progress even when no Git
+  commit landed. Run another bounded batch so quarantine-only rounds cannot be
+  mistaken for a lane fixed point while later unrelated rows remain eligible.
 - Do not apply a verdict, mutate the ledger, or launch a science-editing PR
   from malformed output. A source-repair PR requires a validated non-clean
   verdict with a concrete rationale and repair target.
@@ -1085,14 +1097,20 @@ git add docs/audit
 git commit -m "audit: <claim-id> <verdict>"
 ```
 
-Before pushing, fetch and confirm `origin/main` is still the parent or rebase cleanly and rerun the pipeline:
+Before pushing, fetch and confirm `origin/main` is still the validated parent:
 
 ```bash
 git fetch origin main
 git push origin HEAD:main
 ```
 
-If the push is rejected, fetch/rebase onto `origin/main`, rerun pipeline/lint/diff-check, amend only if it is the same audit commit and no one else has consumed it, then push.
+If the push is rejected, reconcile the exact intended commit OID first. If it
+already landed, record success. If canonical source, dependency, packet,
+selection, role, or independence state moved, discard the old seat and build a
+fresh packet; never rebase an already-applied forensic verdict onto that new
+authority state. A manual replay is permitted only after exact source
+fingerprints still match and apply/pipeline/lint/diff-check are rerun from the
+new parent.
 
 ## Loop Control
 

--- a/docs/ai_methodology/skills/audit-loop/agents/openai.yaml
+++ b/docs/ai_methodology/skills/audit-loop/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Audit Loop"
   short_description: "Run hostile claim audits from the repo queue"
-  default_prompt: "Use $audit-loop to audit the next claim in the repository audit queue and land the result."
+  default_prompt: "Use $audit-loop to drain the complete audit backlog with the canonical coordinator workflow, preserving Nature-grade gates and continuing through claim-local quarantines."

--- a/docs/ai_methodology/skills/audit-loop/references/distributed-drain.md
+++ b/docs/ai_methodology/skills/audit-loop/references/distributed-drain.md
@@ -42,14 +42,21 @@ eligible to every surviving worker.
 - Run at most one orchestrator in any clone. The clone-wide lock covers all
   worktrees of that clone.
 - Independent clones may run concurrently. Every apply transaction first
-  synchronizes to `origin/main` and compares the current claim, dependency,
-  source-file, and alternate-source selection fingerprints with the state
-  seen by the restricted seat. If anything moved, the stale delivery is
-  discarded as `remote_state_superseded`; it mints no verdict and creates no
-  quarantine.
+  synchronizes to `origin/main` and compares the current ledger provenance,
+  exact packet evidence manifest, dependency note bytes, runner/helper inputs,
+  computed seat role/independence/passes, and alternate-source selection with
+  the state seen by the restricted seat. The cascade source must exactly match
+  a pure recomputation from current ledger and runner bytes. If anything
+  moved, the stale delivery is discarded as `remote_state_superseded`; it
+  mints no verdict and creates no quarantine.
 - Different claims still commit one at a time per clone. A push race is
   reconciled against the intended commit and replayed from current
-  `origin/main`; never hand-merge generated audit state.
+  `origin/main`; never hand-merge generated audit state. If the remote outcome
+  cannot be reconciled, preserve the intended local commit and stop instead of
+  resetting or replaying an uncertain push.
+- Primary and helper runners execute in disposable isolated worktrees. Their
+  process groups are terminated and the whole worktree is discarded; runner
+  cleanup never deletes deltas observed in the canonical committer checkout.
 - Use unique worker ids. Reusing an id is safe but defeats target dispersion
   and wastes seats.
 - Keep the combined repository-wide load near 8-10 active Codex processes,
@@ -94,4 +101,7 @@ Schema-invalid, compute-required, and verified claim-transaction failures
 exclude only their claim for the current campaign. The coordinator continues
 to the next unrelated row. A successfully applied non-clean forensic verdict
 that immediately re-enters unchanged is durably excluded from that campaign
-so it cannot consume the next forensic seat before source repair.
+so it cannot consume the next forensic seat before source repair. A newly
+written exclusion counts as operational progress: the supervisor starts
+another bounded batch even when that round landed no Git commit, and declares
+a lane fixed point only after both HEAD and the exclusion set remain stable.

--- a/docs/ai_methodology/skills/audit-loop/references/distributed-drain.md
+++ b/docs/ai_methodology/skills/audit-loop/references/distributed-drain.md
@@ -1,0 +1,97 @@
+# Distributed Audit Drain
+
+Use this operating contract when more than one employee or Codex account is
+helping drain the same repository.
+
+## Roles
+
+Designate exactly one **coordinator** for the campaign. It owns:
+
+- targeted dispatch and cascade re-audit sources;
+- flagship-lane priority sweeps;
+- judicial panels and reseats;
+- serial forensic rows;
+- the final all-source fixed-point declaration.
+
+During the concurrent development wave, run the coordinator from its own clean
+`main` clone with forensic work deferred:
+
+```bash
+AUDIT_WORKER_ID=<unique-coordinator-id> \
+python3 docs/audit/scripts/orchestrate_audit_loop.py \
+  --max-workers 4 --skip-forensic-canary
+```
+
+Every other employee is a **development helper**. Give every helper a stable,
+globally unique worker id and a separate clean `main` clone:
+
+```bash
+AUDIT_WORKER_ID=<unique-employee-account-id> \
+python3 docs/audit/scripts/orchestrate_audit_loop.py \
+  --development-helper --max-workers 2
+```
+
+A helper skips dispatch, cascade, flagship priority passes, panels, and
+forensics. It only drains the complete eligible development set in a
+worker-specific order. The worker id changes ordering; it does not assign an
+exclusive shard. If a helper disappears, every unfinished row remains
+eligible to every surviving worker.
+
+## Collision Safety
+
+- Run at most one orchestrator in any clone. The clone-wide lock covers all
+  worktrees of that clone.
+- Independent clones may run concurrently. Every apply transaction first
+  synchronizes to `origin/main` and compares the current claim, dependency,
+  source-file, and alternate-source selection fingerprints with the state
+  seen by the restricted seat. If anything moved, the stale delivery is
+  discarded as `remote_state_superseded`; it mints no verdict and creates no
+  quarantine.
+- Different claims still commit one at a time per clone. A push race is
+  reconciled against the intended commit and replayed from current
+  `origin/main`; never hand-merge generated audit state.
+- Use unique worker ids. Reusing an id is safe but defeats target dispersion
+  and wastes seats.
+- Keep the combined repository-wide load near 8-10 active Codex processes,
+  including coordinator seats, helper seats, panels, and review-loop
+  reviewers. Separate subscriptions do not remove the shared Git/pipeline
+  bottleneck.
+- Do not run the specialized forensic committer while development helpers are
+  still live. The development batch has remote-state replay guards; the
+  forensic path is intentionally serial. The concurrent-wave coordinator
+  therefore uses `--skip-forensic-canary`.
+
+## Completion Protocol
+
+A helper's zero-progress exit is only a **helper-local development fixed
+point**. It never certifies that the audit is finished because another clone
+may still have an in-flight seat whose commit does not yet exist.
+
+After every helper is quiescent, run a fresh coordinator-only final sweep
+without `--skip-forensic-canary`:
+
+```bash
+AUDIT_WORKER_ID=<unique-coordinator-id> \
+python3 docs/audit/scripts/orchestrate_audit_loop.py --max-workers 4
+```
+
+The coordinator may declare completion only after:
+
+1. every helper is quiescent or has reported its local fixed point;
+2. the coordinator performs a fresh final sweep from current `origin/main`;
+3. ready dispatch and cascade sources have no actionable non-forensic target;
+4. flagship and global development phases land nothing;
+5. panels have no resumable handoff;
+6. the serial forensic selector has no ready non-excluded target.
+
+The concurrent-wave coordinator is expected to exit at a development fixed
+point. Always start the coordinator-only final campaign after helpers
+quiesce. Campaign-local quarantines and typed selector skips are not proof
+that the entire scientific backlog is empty; report them as governed repair
+inventory and route them through `science-fix-loop`.
+
+Schema-invalid, compute-required, and verified claim-transaction failures
+exclude only their claim for the current campaign. The coordinator continues
+to the next unrelated row. A successfully applied non-clean forensic verdict
+that immediately re-enters unchanged is durably excluded from that campaign
+so it cannot consume the next forensic seat before source repair.

--- a/docs/ai_methodology/skills/audit-loop/references/distributed-drain.md
+++ b/docs/ai_methodology/skills/audit-loop/references/distributed-drain.md
@@ -55,8 +55,13 @@ eligible to every surviving worker.
   cannot be reconciled, preserve the intended local commit and stop instead of
   resetting or replaying an uncertain push.
 - Primary and helper runners execute in disposable isolated worktrees. Their
-  process groups are terminated and the whole worktree is discarded; runner
-  cleanup never deletes deltas observed in the canonical committer checkout.
+  processes and detached children inherit a per-invocation identity token.
+  Cleanup repeatedly enumerates that token, revalidates it immediately before
+  every signal, and fails unless no token-bearing process remains; it never
+  signals a remembered bare PID. On macOS a kernel sandbox additionally denies
+  writes to the canonical checkout. Containment and whole-worktree discard are
+  both mandatory on every exit path; cleanup never deletes deltas observed in
+  the canonical committer checkout.
 - Use unique worker ids. Reusing an id is safe but defeats target dispersion
   and wastes seats.
 - Keep the combined repository-wide load near 8-10 active Codex processes,

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 14984,
- "node_count": 4475,
+ "edge_count": 14985,
+ "node_count": 4476,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -662,13 +662,17 @@
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
   },
+  "ai_methodology.skills.audit-loop.references.distributed-drain": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
   "ai_methodology.skills.audit-loop.references.nature-grade-rubric": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
   },
   "ai_methodology.skills.audit-loop.skill": {
-   "deps_hash": "5765c9579e98",
-   "out_degree": 3
+   "deps_hash": "efd35745dfd2",
+   "out_degree": 4
   },
   "ai_methodology.skills.exercise.skill": {
    "deps_hash": "ea1b92184d2e",

--- a/docs/audit/scripts/compute_reaudit_candidates.py
+++ b/docs/audit/scripts/compute_reaudit_candidates.py
@@ -166,14 +166,8 @@ def sort_key(entry: dict) -> tuple:
     )
 
 
-def main() -> int:
-    ledger_io.ensure_cache()
-    if not LEDGER_PATH.exists():
-        raise SystemExit("audit_ledger.json missing")
-
-    ledger = json.loads(LEDGER_PATH.read_text(encoding="utf-8"))
-    rows = ledger.get("rows", {})
-
+def build_payload(rows: dict[str, dict]) -> dict:
+    """Return the canonical cache payload from current authoritative inputs."""
     candidates: list[dict] = []
     runner_drift_candidates: list[dict] = []
     for cid, row in rows.items():
@@ -218,7 +212,7 @@ def main() -> int:
     for idx, entry in enumerate(runner_drift_candidates, 1):
         entry["generated_order"] = idx
 
-    output = {
+    return {
         "policy": "reaudit_unblocked_v2_dep_or_runner_drift",
         "policy_summary": (
             "Non-clean audited theorem/no-go/open-gate claims surfaced under "
@@ -244,6 +238,14 @@ def main() -> int:
         "runner_drift_candidates": runner_drift_candidates,
     }
 
+
+def main() -> int:
+    ledger_io.ensure_cache()
+    if not LEDGER_PATH.exists():
+        raise SystemExit("audit_ledger.json missing")
+
+    ledger = json.loads(LEDGER_PATH.read_text(encoding="utf-8"))
+    output = build_payload(ledger.get("rows", {}))
     CANDIDATES_JSON.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n")
 
     print(f"Wrote {CANDIDATES_JSON.relative_to(REPO_ROOT)}")
@@ -251,6 +253,7 @@ def main() -> int:
     print(f"  by criticality: {output['by_criticality']}")
     print(f"  runner drift candidates: {output['total_runner_drift_candidates']}")
     print(f"  by criticality (runner drift): {output['by_criticality_runner_drift']}")
+    candidates = output["candidates"]
     if candidates:
         print("  top dep-ratified candidates:")
         for entry in candidates[:5]:
@@ -260,6 +263,7 @@ def main() -> int:
                 f"({entry['criticality']}, after "
                 f"{','.join(entry['reraudit_after_claim_ids'])})"
             )
+    runner_drift_candidates = output["runner_drift_candidates"]
     if runner_drift_candidates:
         print("  top runner-drift candidates:")
         for entry in runner_drift_candidates[:5]:

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -92,6 +92,7 @@ CAMPAIGN_EXCLUSION_REASONS = {
     *CAMPAIGN_EXCLUSION_RESULTS,
 }
 REMOTE_STATE_SUPERSEDED_RESULT = "remote_state_superseded"
+PUSH_RECONCILIATION_REQUIRED_RESULT = "push_reconciliation_required"
 SELECTION_SKIP_REASONS = {
     "missing_ledger_row",
     "effective_status_not_actionable",
@@ -501,7 +502,7 @@ def source_queue_rows(source: str, rows: dict[str, dict]) -> list[dict]:
     if source == "dispatch":
         return audit_runner.load_dispatch_targets(rows, ready_only=True)
     if source == "reaudit":
-        return audit_runner.load_reaudit_candidates()
+        return audit_runner.load_reaudit_candidates(ledger_rows=rows)
     raise ValueError(f"unknown alternate audit source {source!r}")
 
 
@@ -649,52 +650,48 @@ def passes_for_row(row: dict) -> list[int]:
     return [1, 2] if row.get("criticality") == "critical" else [1]
 
 
-def selection_fingerprint(row: dict, rows: dict[str, dict]) -> str:
-    """Bind a launched seat to the claim/dependency state it actually saw."""
-    source_hashes: dict[str, str] = {}
-    for path in filter(
-        None,
-        (
-            row.get("note_path"),
-            row.get("runner_path"),
-            *(row.get("helper_runner_paths") or []),
-        ),
-    ):
-        source = REPO_ROOT / str(path)
-        try:
-            source_hashes[str(path)] = hashlib.sha256(source.read_bytes()).hexdigest()
-        except OSError:
-            source_hashes[str(path)] = "<missing>"
-    dependency_state = {
-        dep: {
-            "claim_type": (rows.get(dep) or {}).get("claim_type"),
-            "claim_scope": (rows.get(dep) or {}).get("claim_scope"),
-            "effective_status": (rows.get(dep) or {}).get("effective_status"),
-            "note_hash": (rows.get(dep) or {}).get("note_hash"),
-        }
-        for dep in row.get("deps") or []
-    }
+def selection_fingerprint(
+    row: dict,
+    rows: dict[str, dict],
+    evidence_manifest: dict[str, dict] | None = None,
+) -> str:
+    """Bind a launched seat to exact packet bytes and seat provenance."""
+    selection_source = row.get("_selection_source")
+    role, role_independence = audit_runner.determine_audit_role(
+        rows.get(str(row.get("claim_id") or "")) or row,
+        AUDITOR_FAMILY,
+        is_reaudit_candidate=selection_source in {"dispatch", "reaudit"},
+        is_dispatch_target=selection_source == "dispatch",
+    )
+    audit_passes = passes_for_row(row)
     payload = {
-        "claim_id": row.get("claim_id"),
-        "audit_status": row.get("audit_status"),
-        "cross_confirmation_status": (
-            (row.get("cross_confirmation") or {}).get("status")
+        "schema": "audit-batch-selection-fingerprint-v2",
+        "packet_source_fingerprint": (
+            audit_runner.audit_packet_source_fingerprint(
+                row,
+                rows,
+                evidence_manifest,
+            )
         ),
-        "effective_status": row.get("effective_status"),
-        "note_hash": row.get("note_hash"),
-        "claim_type": row.get("claim_type"),
-        "claim_scope": row.get("claim_scope"),
-        "deps": row.get("deps") or [],
-        "audit_invocation_id": row.get("audit_invocation_id"),
-        "audit_invocation_history_count": len(
-            row.get("audit_invocation_history") or []
-        ),
-        "previous_audits_count": len(row.get("previous_audits") or []),
-        "source_hashes": source_hashes,
-        "dependency_state": dependency_state,
+        "batch_control_sha256": hashlib.sha256(
+            Path(__file__).read_bytes()
+        ).hexdigest(),
+        "selection_source": selection_source,
+        "selection_source_fingerprint": row.get("_source_fingerprint"),
+        "role": role,
+        "role_independence": role_independence,
+        "planned_passes": audit_passes,
+        "seat_independence": [
+            seat_independence(row, pass_no) for pass_no in audit_passes
+        ],
     }
     return hashlib.sha256(
-        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
     ).hexdigest()
 
 
@@ -808,7 +805,11 @@ def launch_worker(
         "isolated": isolated,
         "evidence_manifest": evidence_manifest,
         "invocation_id": invocation_id,
-        "selection_fingerprint": selection_fingerprint(row, rows),
+        "selection_fingerprint": selection_fingerprint(
+            row,
+            rows,
+            evidence_manifest,
+        ),
         "selection_source": row.get("_selection_source"),
         "source_fingerprint": row.get("_source_fingerprint"),
         "transport_bound": None,
@@ -1804,27 +1805,12 @@ def apply_claim_serialized(
                         "seat was running; no stale delivery was applied"
                     ),
                 }]
-            current_fingerprint = selection_fingerprint(current_row, current_rows)
-            launched_fingerprints = {
-                str(job["selection_fingerprint"])
-                for job, _envelope in ordered
-            }
-            if launched_fingerprints != {current_fingerprint}:
-                return True, [{
-                    "cid": cid,
-                    "result": REMOTE_STATE_SUPERSEDED_RESULT,
-                    "detail": (
-                        "claim, dependency, or source state changed on "
-                        "origin/main while the restricted seat was running; "
-                        "discard the stale delivery and let a fresh round "
-                        "reselect current state"
-                    ),
-                }]
             launched_sources = {
                 str(job.get("selection_source"))
                 for job, _envelope in ordered
                 if job.get("selection_source")
             }
+            current_selection_row = current_row
             if launched_sources:
                 if len(launched_sources) != 1:
                     return False, [{
@@ -1868,6 +1854,48 @@ def apply_claim_serialized(
                             "delivery was applied"
                         ),
                     }]
+                current_targets, _skipped = compute_alternate_targets(
+                    source,
+                    current_rows,
+                )
+                current_selection_row = next(
+                    (
+                        target
+                        for target in current_targets
+                        if target.get("claim_id") == cid
+                    ),
+                    None,
+                )
+                if not isinstance(current_selection_row, dict):
+                    return True, [{
+                        "cid": cid,
+                        "result": REMOTE_STATE_SUPERSEDED_RESULT,
+                        "detail": (
+                            f"{source} no longer selects this claim with the "
+                            "same actionable role and independence; no stale "
+                            "delivery was applied"
+                        ),
+                    }]
+
+            current_fingerprint = selection_fingerprint(
+                current_selection_row,
+                current_rows,
+            )
+            launched_fingerprints = {
+                str(job["selection_fingerprint"])
+                for job, _envelope in ordered
+            }
+            if launched_fingerprints != {current_fingerprint}:
+                return True, [{
+                    "cid": cid,
+                    "result": REMOTE_STATE_SUPERSEDED_RESULT,
+                    "detail": (
+                        "claim, dependency, governed packet source, runner "
+                        "input, or seat provenance changed on origin/main while "
+                        "the restricted seat was running; discard the stale "
+                        "delivery and let a fresh round reselect current state"
+                    ),
+                }]
 
         for job, envelope in ordered:
             applied, apply_detail = audit_runner.apply_one(
@@ -1906,19 +1934,28 @@ def apply_claim_serialized(
                 for job, envelope in ordered
             ]
 
-        if _command_cancelled():
-            return fail_after_transaction("commit_cancelled")
-
-        fetch = sh(["git", "fetch", "origin", "main", "-q"])
+        # A nonzero client result does not prove rejection: the remote may
+        # have accepted the commit before the response path failed. Reconcile
+        # the exact intended OID even after cancellation. Until that succeeds,
+        # preserve the local commit and stop every later transaction.
+        fetch = sh(
+            ["git", "fetch", "origin", "main", "-q"],
+            honor_cancel=False,
+        )
         if fetch.returncode != 0:
-            result = "commit_cancelled" if _command_cancelled() else "push_failed"
-            detail = None if result == "commit_cancelled" else "push and follow-up fetch failed"
-            return fail_after_transaction(result, detail)
-        if _command_cancelled():
-            return fail_after_transaction("commit_cancelled")
-        landed = sh(["git", "merge-base", "--is-ancestor", local_commit, "origin/main"])
-        if _command_cancelled():
-            return fail_after_transaction("commit_cancelled")
+            return False, [{
+                "cid": cid,
+                "result": PUSH_RECONCILIATION_REQUIRED_RESULT,
+                "commit": local_commit,
+                "detail": (
+                    "push returned nonzero and follow-up fetch failed; remote "
+                    "acceptance is unknown, so the intended commit is preserved"
+                ),
+            }]
+        landed = sh(
+            ["git", "merge-base", "--is-ancestor", local_commit, "origin/main"],
+            honor_cancel=False,
+        )
         if landed.returncode == 0:
             return True, [
                 {
@@ -1929,6 +1966,18 @@ def apply_claim_serialized(
                 }
                 for job, envelope in ordered
             ]
+        if landed.returncode != 1:
+            return False, [{
+                "cid": cid,
+                "result": PUSH_RECONCILIATION_REQUIRED_RESULT,
+                "commit": local_commit,
+                "detail": (
+                    "push returned nonzero and intended-commit ancestry could "
+                    "not be decided; local commit preserved"
+                ),
+            }]
+        if _command_cancelled():
+            return fail_after_transaction("commit_cancelled")
         if attempt == retries:
             return fail_after_transaction("push_race_exhausted")
         reset, reset_detail = reset_to_origin_main()

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Drain routine development-tier audit rows with parallel fresh auditors.
 
-Each round selects dependency-ready unaudited rows from an explicit claim set
-or a configured lane closure, renders the canonical restricted packet, starts
-detached GPT-5.6-sol/xhigh auditors, and then applies deliveries serially:
+Each round selects dependency-ready unaudited rows from an explicit claim set,
+a configured lane closure, the global ledger, or an authenticated dispatch /
+cascade re-audit source; renders the canonical restricted packet; starts
+detached GPT-5.6-sol/xhigh auditors; and then applies deliveries serially:
 
     apply -> pipeline -> strict lint -> diff/scope check -> commit -> push
 
@@ -56,7 +57,7 @@ AUDITABLE_TYPES = {"positive_theorem", "bounded_theorem", "open_gate"}
 SUCCESS_RESULTS = {
     "audited_clean", "audited_renaming", "audited_conditional",
     "audited_decoration", "audited_numerical_match", "audited_failed",
-    "compute_required",
+    "compute_required", "remote_state_superseded",
 }
 _COMMAND_CONTEXT = threading.local()
 
@@ -90,6 +91,7 @@ CAMPAIGN_EXCLUSION_REASONS = {
     SCHEMA_QUARANTINE_RESULT,
     *CAMPAIGN_EXCLUSION_RESULTS,
 }
+REMOTE_STATE_SUPERSEDED_RESULT = "remote_state_superseded"
 SELECTION_SKIP_REASONS = {
     "missing_ledger_row",
     "effective_status_not_actionable",
@@ -100,6 +102,8 @@ SELECTION_SKIP_REASONS = {
     "dependencies_not_retained",
     "note_hash_drift",
     "awaiting_science_repair",
+    "audit_role_not_actionable",
+    "weak_dispatch_independence",
     "unclassified_selector_skip",
 }
 SCIENCE_FIX_RESULTS = {"science_fix_dispatched", "science_fix_dispatch_failed"}
@@ -430,6 +434,7 @@ def compute_targets(
     scope: set[str],
     rows: dict[str, dict],
     retarget: frozenset[str] = frozenset(),
+    worker_id: str = "",
 ) -> tuple[list[dict], list[str]]:
     effective = {cid: row.get("effective_status", "?") for cid, row in rows.items()}
     targets: list[dict] = []
@@ -486,7 +491,126 @@ def compute_targets(
             )
             continue
         targets.append(row)
+    if worker_id:
+        targets = rotate_priority_tiers(targets, worker_id)
     return targets, skipped
+
+
+def source_queue_rows(source: str, rows: dict[str, dict]) -> list[dict]:
+    """Load one authenticated alternate selection stream."""
+    if source == "dispatch":
+        return audit_runner.load_dispatch_targets(rows, ready_only=True)
+    if source == "reaudit":
+        return audit_runner.load_reaudit_candidates()
+    raise ValueError(f"unknown alternate audit source {source!r}")
+
+
+def source_row_fingerprint(row: dict) -> str:
+    return hashlib.sha256(
+        json.dumps(row, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def compute_alternate_targets(
+    source: str,
+    rows: dict[str, dict],
+    worker_id: str = "",
+) -> tuple[list[dict], list[str]]:
+    """Select dispatch/cascade work without weakening their producer contract."""
+    targets: list[dict] = []
+    skipped: list[str] = []
+    for source_row in source_queue_rows(source, rows):
+        cid = str(source_row.get("claim_id") or "")
+        current = rows.get(cid)
+        if not cid or not isinstance(current, dict):
+            skipped.append(f"{cid or '<missing>'}: missing ledger row")
+            continue
+        role, independence = audit_runner.determine_audit_role(
+            current,
+            AUDITOR_FAMILY,
+            is_reaudit_candidate=True,
+            is_dispatch_target=(source == "dispatch"),
+        )
+        if role == "skip":
+            skipped.append(f"{cid}: audit role is not actionable: {independence}")
+            continue
+        if independence == "weak":
+            skipped.append(
+                f"{cid}: dispatch has weak independence; repair provenance "
+                "before a promotion-capable audit"
+            )
+            continue
+        if source_requires_forensic(current):
+            skipped.append(f"{cid}: source shape requires forensic tier")
+            continue
+        if note_hash_drifted(current):
+            skipped.append(
+                f"{cid}: ledger note_hash lags the note file; run "
+                "seed_audit_ledger.py + pipeline and commit before auditing"
+            )
+            continue
+        row = dict(current)
+        for field in (
+            "allowed_context_paths",
+            "dispatch_target",
+            "dispatch_question",
+            "queue_reason",
+            "ready",
+            "ready_blocker",
+            "source_json_path",
+            "source_schema",
+        ):
+            if field in source_row:
+                row[field] = source_row[field]
+        if role == "second":
+            audit_passes = [2]
+        elif role == "first" and row.get("criticality") == "critical":
+            audit_passes = [1, 2]
+        else:
+            audit_passes = [1]
+        row["_audit_passes"] = audit_passes
+        row["_audit_independence"] = independence
+        row["_selection_source"] = source
+        row["_source_fingerprint"] = source_row_fingerprint(source_row)
+        targets.append(row)
+    if worker_id:
+        targets = rotate_priority_tiers(targets, worker_id)
+    return targets, skipped
+
+
+CRITICALITY_PRIORITY = {
+    "critical": 0,
+    "high": 1,
+    "medium": 2,
+    "leaf": 3,
+}
+
+
+def rotate_priority_tiers(targets: list[dict], worker_id: str) -> list[dict]:
+    """Give independent clones distinct starts without creating abandoned shards.
+
+    Every worker retains the complete eligible set, so an employee leaving
+    does not strand a shard. Within each criticality tier, a stable
+    worker-specific rotation spreads initial seats across the backlog. Remote
+    apply preconditions remain the final duplicate-work guard.
+    """
+    ordered: list[dict] = []
+    for tier in range(5):
+        group = [
+            row
+            for row in targets
+            if CRITICALITY_PRIORITY.get(
+                str(row.get("criticality") or ""), 4
+            ) == tier
+        ]
+        if not group:
+            continue
+        digest = hashlib.sha256(
+            f"audit-worker-v1:{worker_id}:{tier}".encode("utf-8")
+        ).digest()
+        offset = int.from_bytes(digest[:8], "big") % len(group)
+        ordered.extend(group[offset:] + group[:offset])
+    return ordered
 
 
 def artifact_key(cid: str) -> str:
@@ -496,6 +620,9 @@ def artifact_key(cid: str) -> str:
 
 
 def seat_independence(row: dict, pass_no: int) -> str:
+    planned = row.get("_audit_independence")
+    if isinstance(planned, str) and planned:
+        return planned
     if pass_no == 2:
         return "fresh_context"
     author_family = row.get("author_family")
@@ -509,10 +636,66 @@ def seat_independence(row: dict, pass_no: int) -> str:
 
 
 def passes_for_row(row: dict) -> list[int]:
+    planned = row.get("_audit_passes")
+    if (
+        isinstance(planned, list)
+        and planned
+        and all(pass_no in {1, 2} for pass_no in planned)
+    ):
+        return list(planned)
     cross_status = (row.get("cross_confirmation") or {}).get("status")
     if row.get("audit_status") == "audit_in_progress" and cross_status == "awaiting_second":
         return [2]
     return [1, 2] if row.get("criticality") == "critical" else [1]
+
+
+def selection_fingerprint(row: dict, rows: dict[str, dict]) -> str:
+    """Bind a launched seat to the claim/dependency state it actually saw."""
+    source_hashes: dict[str, str] = {}
+    for path in filter(
+        None,
+        (
+            row.get("note_path"),
+            row.get("runner_path"),
+            *(row.get("helper_runner_paths") or []),
+        ),
+    ):
+        source = REPO_ROOT / str(path)
+        try:
+            source_hashes[str(path)] = hashlib.sha256(source.read_bytes()).hexdigest()
+        except OSError:
+            source_hashes[str(path)] = "<missing>"
+    dependency_state = {
+        dep: {
+            "claim_type": (rows.get(dep) or {}).get("claim_type"),
+            "claim_scope": (rows.get(dep) or {}).get("claim_scope"),
+            "effective_status": (rows.get(dep) or {}).get("effective_status"),
+            "note_hash": (rows.get(dep) or {}).get("note_hash"),
+        }
+        for dep in row.get("deps") or []
+    }
+    payload = {
+        "claim_id": row.get("claim_id"),
+        "audit_status": row.get("audit_status"),
+        "cross_confirmation_status": (
+            (row.get("cross_confirmation") or {}).get("status")
+        ),
+        "effective_status": row.get("effective_status"),
+        "note_hash": row.get("note_hash"),
+        "claim_type": row.get("claim_type"),
+        "claim_scope": row.get("claim_scope"),
+        "deps": row.get("deps") or [],
+        "audit_invocation_id": row.get("audit_invocation_id"),
+        "audit_invocation_history_count": len(
+            row.get("audit_invocation_history") or []
+        ),
+        "previous_audits_count": len(row.get("previous_audits") or []),
+        "source_hashes": source_hashes,
+        "dependency_state": dependency_state,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
 
 
 def prompt_has_clipped_evidence(manifest: dict[str, dict]) -> list[str]:
@@ -625,6 +808,9 @@ def launch_worker(
         "isolated": isolated,
         "evidence_manifest": evidence_manifest,
         "invocation_id": invocation_id,
+        "selection_fingerprint": selection_fingerprint(row, rows),
+        "selection_source": row.get("_selection_source"),
+        "source_fingerprint": row.get("_source_fingerprint"),
         "transport_bound": None,
         "auditor": f"codex-audit-batch-{ident}",
         "independence": seat_independence(row, pass_no),
@@ -1606,6 +1792,83 @@ def apply_claim_serialized(
         if not synced:
             return False, [{"cid": cid, "result": "sync_blocked", "detail": detail}]
 
+        if all(job.get("selection_fingerprint") for job, _envelope in ordered):
+            current_rows = load_rows()
+            current_row = current_rows.get(cid)
+            if not isinstance(current_row, dict):
+                return True, [{
+                    "cid": cid,
+                    "result": REMOTE_STATE_SUPERSEDED_RESULT,
+                    "detail": (
+                        "claim disappeared from the canonical ledger while its "
+                        "seat was running; no stale delivery was applied"
+                    ),
+                }]
+            current_fingerprint = selection_fingerprint(current_row, current_rows)
+            launched_fingerprints = {
+                str(job["selection_fingerprint"])
+                for job, _envelope in ordered
+            }
+            if launched_fingerprints != {current_fingerprint}:
+                return True, [{
+                    "cid": cid,
+                    "result": REMOTE_STATE_SUPERSEDED_RESULT,
+                    "detail": (
+                        "claim, dependency, or source state changed on "
+                        "origin/main while the restricted seat was running; "
+                        "discard the stale delivery and let a fresh round "
+                        "reselect current state"
+                    ),
+                }]
+            launched_sources = {
+                str(job.get("selection_source"))
+                for job, _envelope in ordered
+                if job.get("selection_source")
+            }
+            if launched_sources:
+                if len(launched_sources) != 1:
+                    return False, [{
+                        "cid": cid,
+                        "result": "sync_blocked",
+                        "detail": "claim transaction mixed alternate sources",
+                    }]
+                source = next(iter(launched_sources))
+                try:
+                    current_source_rows = source_queue_rows(
+                        source,
+                        current_rows,
+                    )
+                except (OSError, ValueError, json.JSONDecodeError) as exc:
+                    return False, [{
+                        "cid": cid,
+                        "result": "sync_blocked",
+                        "detail": (
+                            f"cannot authenticate current {source} source: {exc}"
+                        ),
+                    }]
+                current_source_fingerprints = {
+                    str(row.get("claim_id")): source_row_fingerprint(row)
+                    for row in current_source_rows
+                }
+                launched_source_fingerprints = {
+                    str(job.get("source_fingerprint"))
+                    for job, _envelope in ordered
+                }
+                if (
+                    current_source_fingerprints.get(cid)
+                    not in launched_source_fingerprints
+                    or len(launched_source_fingerprints) != 1
+                ):
+                    return True, [{
+                        "cid": cid,
+                        "result": REMOTE_STATE_SUPERSEDED_RESULT,
+                        "detail": (
+                            f"{source} selection changed on origin/main while "
+                            "the restricted seat was running; no stale "
+                            "delivery was applied"
+                        ),
+                    }]
+
         for job, envelope in ordered:
             applied, apply_detail = audit_runner.apply_one(
                 envelope["audit"],
@@ -2090,6 +2353,13 @@ def selection_skip_reason(detail: str) -> str:
         "awaiting repair (sources and deps unchanged since audited_conditional)"
     ):
         return "awaiting_science_repair"
+    if detail.startswith("audit role is not actionable: "):
+        return "audit_role_not_actionable"
+    if detail == (
+        "dispatch has weak independence; repair provenance before a "
+        "promotion-capable audit"
+    ):
+        return "weak_dispatch_independence"
     return "unclassified_selector_skip"
 
 
@@ -2368,12 +2638,27 @@ def blocked_row_reentries(
     for selected in selected_rows:
         cid = selected["claim_id"]
         row = current_rows.get(cid) or {}
-        if cid not in applied or row.get("audit_status") != "unaudited":
+        if cid not in applied:
             continue
-        targets, _ = compute_targets({cid}, current_rows)
-        if not any(target.get("claim_id") == cid for target in targets):
-            continue
-        reason = _latest_invalidation_reason(row)
+        source = selected.get("_selection_source")
+        if source:
+            try:
+                source_ids = {
+                    source_row.get("claim_id")
+                    for source_row in source_queue_rows(str(source), current_rows)
+                }
+            except (OSError, ValueError, json.JSONDecodeError):
+                source_ids = set()
+            if cid not in source_ids:
+                continue
+            reason = f"{source}_selection_still_live_after_applied_verdict"
+        else:
+            if row.get("audit_status") != "unaudited":
+                continue
+            targets, _ = compute_targets({cid}, current_rows)
+            if not any(target.get("claim_id") == cid for target in targets):
+                continue
+            reason = _latest_invalidation_reason(row)
         reentries[cid] = reason
         report.append(
             {
@@ -2618,7 +2903,13 @@ def scope_for_args(args: argparse.Namespace, rows: dict[str, dict]) -> set[str]:
         for root in roots:
             scope.update(lane_closure(root, rows))
         return scope
-    return {claim.strip() for claim in args.claims.split(",") if claim.strip()}
+    if getattr(args, "all", False):
+        return set(rows)
+    return {
+        claim.strip()
+        for claim in (getattr(args, "claims", "") or "").split(",")
+        if claim.strip()
+    }
 
 
 def main() -> int:
@@ -2635,6 +2926,29 @@ def main() -> int:
     scope_group = parser.add_mutually_exclusive_group(required=True)
     scope_group.add_argument("--lane", help="lane name from lane_certification_config.json")
     scope_group.add_argument("--claims", help="comma-separated claim ids")
+    scope_group.add_argument(
+        "--all",
+        action="store_true",
+        help="drain every eligible development-tier row in the current ledger",
+    )
+    scope_group.add_argument(
+        "--from-dispatch",
+        action="store_true",
+        help="drain ready authenticated targeted dispatch entries",
+    )
+    scope_group.add_argument(
+        "--from-reaudit-candidates",
+        action="store_true",
+        help="drain dependency-strengthened and runner-drift re-audit entries",
+    )
+    parser.add_argument(
+        "--worker-id",
+        default=os.environ.get("AUDIT_WORKER_ID", ""),
+        help=(
+            "stable employee/account identifier used to rotate target order "
+            "within each criticality tier across independent clones"
+        ),
+    )
     parser.add_argument(
         "--retarget-conditionals",
         action="store_true",
@@ -2743,8 +3057,23 @@ def main() -> int:
     for round_no in range(1, args.rounds + 1):
         rows = load_rows()
         try:
-            scope = scope_for_args(args, rows)
-        except ValueError as exc:
+            alternate_source = (
+                "dispatch"
+                if args.from_dispatch
+                else "reaudit" if args.from_reaudit_candidates else None
+            )
+            if alternate_source:
+                targets, skipped = compute_alternate_targets(
+                    alternate_source,
+                    rows,
+                    worker_id=args.worker_id,
+                )
+                scope = {row["claim_id"] for row in targets}
+            else:
+                scope = scope_for_args(args, rows)
+                targets = []
+                skipped = []
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
             print(str(exc))
             return finish(2)
         existing_disagreements = sorted(
@@ -2758,7 +3087,19 @@ def main() -> int:
                 report.append({"cid": cid, "result": "judicial_panel_required"})
                 session_skipped.add(cid)
         scope.difference_update(session_skipped)
-        targets, skipped = compute_targets(scope, rows, retarget=retarget)
+        if alternate_source:
+            targets = [
+                row
+                for row in targets
+                if row["claim_id"] not in session_skipped
+            ]
+        else:
+            targets, skipped = compute_targets(
+                scope,
+                rows,
+                retarget=retarget,
+                worker_id=args.worker_id,
+            )
         print(f"== round {round_no}: {len(targets)} dep-ready targets, {len(skipped)} skipped")
         PROGRESS["round_targets"] = len(targets)
         maybe_progress_summary(force=(round_no == 1))

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -6,10 +6,13 @@ disagreement appears. This supervisor owns the missing control-flow edge:
 
     panel pending work -> drain lane -> panel new disagreement -> resume lane
 
-It repeats configured lanes until a complete pass lands no commits, then runs
-one forensic no-go canary unless explicitly disabled. Auditor fan-out remains
-inside the existing batch and judicial orchestrators; this process never
-authors or edits verdict content.
+It drains authenticated dispatch and cascade sources, prioritizes configured
+flagship lanes, then drains every remaining eligible development-tier row. A
+coordinator owns panels and advances all forensic sources one validated row at
+a time; named development helpers may run from independent clones with
+dispersed target ordering. Auditor fan-out remains inside the existing batch
+and judicial orchestrators; this process never authors or edits verdict
+content.
 """
 from __future__ import annotations
 
@@ -22,6 +25,7 @@ import sys
 import tempfile
 import threading
 import time
+import uuid
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
@@ -51,6 +55,9 @@ PROGRESS = {
     "failures": [],
     "panel_state": "not_started",
     "canary_state": "not_started",
+    "last_canary_claim_id": None,
+    "last_canary_terminal_phase": None,
+    "last_canary_source": None,
     "baseline_status": {},
     "quarantine_file": None,
 }
@@ -313,12 +320,14 @@ def panel_command(args: argparse.Namespace) -> list[str]:
     return command
 
 
-def batch_command(lane: str, args: argparse.Namespace) -> list[str]:
+def batch_command(
+    lane: str | None,
+    args: argparse.Namespace,
+    source: str | None = None,
+) -> list[str]:
     command = [
         sys.executable,
         str(BATCH),
-        "--lane",
-        lane,
         "--max-workers",
         str(args.max_workers),
         "--rounds",
@@ -330,6 +339,19 @@ def batch_command(lane: str, args: argparse.Namespace) -> list[str]:
         "--push-retries",
         str(args.push_retries),
     ]
+    if source == "dispatch":
+        command.append("--from-dispatch")
+    elif source == "reaudit":
+        command.append("--from-reaudit-candidates")
+    elif source is not None:
+        raise ValueError(f"unknown audit source {source!r}")
+    elif lane is None:
+        command.append("--all")
+    else:
+        command.extend(["--lane", lane])
+    worker_id = getattr(args, "worker_id", "")
+    if worker_id:
+        command.extend(["--worker-id", worker_id])
     quarantine_file = getattr(args, "campaign_quarantine_file", None)
     if quarantine_file is not None:
         command.extend(["--campaign-quarantine-file", str(quarantine_file)])
@@ -346,26 +368,34 @@ def batch_command(lane: str, args: argparse.Namespace) -> list[str]:
 
 
 def run_panel(args: argparse.Namespace, label: str) -> int:
+    if getattr(args, "development_helper", False):
+        PROGRESS["panel_state"] = "delegated_to_coordinator"
+        return 0
     return run_command(label, panel_command(args))
 
 
-def drain_lane(lane: str, args: argparse.Namespace) -> tuple[int, bool]:
-    """Drain one lane, paneling after every batch before deciding to stop."""
+def drain_lane(
+    lane: str | None,
+    args: argparse.Namespace,
+    source: str | None = None,
+) -> tuple[int, bool]:
+    """Drain one scoped phase, paneling after every batch when coordinator."""
     made_progress = False
+    label = f"{source}-source" if source else (lane or "global-development")
     for cycle in itertools.count(1):
         if args.max_lane_cycles and cycle > args.max_lane_cycles:
-            emit(f"STOP lane cycle safety bound reached: lane={lane}")
+            emit(f"STOP lane cycle safety bound reached: lane={label}")
             return 4, made_progress
         before = git_head()
         batch_rc = run_command(
-            f"batch-{lane}-cycle-{cycle}",
-            batch_command(lane, args),
+            f"batch-{label}-cycle-{cycle}",
+            batch_command(lane, args, source=source),
         )
         # This is intentionally unconditional, including after a hard batch
         # result: another row in the same batch may already have recorded a
         # panel-eligible disagreement. Preserve the hard result only after the
         # judicial sweep has consumed every resumable handoff.
-        panel_rc = run_panel(args, f"panel-after-{lane}-cycle-{cycle}")
+        panel_rc = run_panel(args, f"panel-after-{label}-cycle-{cycle}")
         if panel_rc != 0:
             return panel_rc, made_progress
         if batch_rc != 0:
@@ -380,10 +410,37 @@ def drain_lane(lane: str, args: argparse.Namespace) -> tuple[int, bool]:
 
 def first_ready_forensic_claim(
     excluded_claim_ids: set[str] | None = None,
+    *,
+    include_alternate_sources: bool = False,
 ) -> str | None:
+    PROGRESS["last_canary_source"] = None
+    excluded = excluded_claim_ids or set()
+    if include_alternate_sources:
+        ledger_rows = batch.load_rows()
+        for source in ("dispatch", "reaudit"):
+            for row in batch.source_queue_rows(source, ledger_rows):
+                claim_id = row.get("claim_id")
+                if (
+                    not isinstance(claim_id, str)
+                    or not claim_id
+                    or claim_id in excluded
+                ):
+                    continue
+                role, independence = batch.audit_runner.determine_audit_role(
+                    ledger_rows.get(claim_id) or {},
+                    batch.AUDITOR_FAMILY,
+                    is_reaudit_candidate=True,
+                    is_dispatch_target=(source == "dispatch"),
+                )
+                if role == "skip" or independence == "weak":
+                    continue
+                if batch.source_requires_forensic(
+                    ledger_rows.get(claim_id) or row
+                ):
+                    PROGRESS["last_canary_source"] = source
+                    return claim_id
     if not QUEUE.exists():
         return None
-    excluded = excluded_claim_ids or set()
     rows = json.loads(QUEUE.read_text(encoding="utf-8")).get("queue", [])
     for row in rows:
         if (
@@ -516,7 +573,13 @@ def forensic_canary_claim_local_failure(
     return None
 
 
-def run_forensic_canary(args: argparse.Namespace) -> int:
+def run_forensic_canary(
+    args: argparse.Namespace,
+    extra_excluded: set[str] | None = None,
+) -> int:
+    PROGRESS["last_canary_claim_id"] = None
+    PROGRESS["last_canary_terminal_phase"] = None
+    PROGRESS["last_canary_source"] = None
     try:
         excluded = batch.load_campaign_quarantine(
             args.campaign_quarantine_file
@@ -524,12 +587,23 @@ def run_forensic_canary(args: argparse.Namespace) -> int:
     except (OSError, ValueError) as exc:
         emit(f"invalid campaign state before forensic canary: {exc}")
         return 2
-    claim_id = first_ready_forensic_claim(excluded)
+    excluded.update(extra_excluded or set())
+    try:
+        claim_id = first_ready_forensic_claim(
+            excluded,
+            include_alternate_sources=True,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        emit(f"cannot authenticate forensic selection sources: {exc}")
+        return 2
     if not claim_id:
+        PROGRESS["canary_state"] = "no_ready_target"
         emit("no ready forensic-tier row available for the forensic canary")
         return 0
+    PROGRESS["last_canary_claim_id"] = claim_id
     run_log = args.campaign_workdir / (
-        f"forensic-canary-{batch.artifact_key(claim_id)}.jsonl"
+        f"forensic-canary-{batch.artifact_key(claim_id)}-"
+        f"{uuid.uuid4().hex[:8]}.jsonl"
     )
     command = [
         sys.executable,
@@ -549,6 +623,11 @@ def run_forensic_canary(args: argparse.Namespace) -> int:
         "--run-log-path",
         str(run_log),
     ]
+    canary_source = PROGRESS.get("last_canary_source")
+    if canary_source == "dispatch":
+        command.append("--from-dispatch")
+    elif canary_source == "reaudit":
+        command.append("--from-reaudit-candidates")
     if args.dry_run:
         command.append("--dry-run")
     env = dict(os.environ)
@@ -559,6 +638,9 @@ def run_forensic_canary(args: argparse.Namespace) -> int:
     except (OSError, ValueError) as exc:
         emit(f"invalid forensic canary artifact; refusing quarantine: {exc}")
         return 2
+    PROGRESS["last_canary_terminal_phase"] = (
+        terminal.get("phase") if terminal else None
+    )
     claim_local = forensic_canary_claim_local_failure(
         terminal,
         claim_id,
@@ -622,6 +704,22 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--lane", action="append", help="limit to a configured lane")
     parser.add_argument("--max-workers", type=int, default=4)
     parser.add_argument(
+        "--worker-id",
+        default=os.environ.get("AUDIT_WORKER_ID", ""),
+        help=(
+            "stable employee/account identifier used to disperse development "
+            "targets across independent clones"
+        ),
+    )
+    parser.add_argument(
+        "--development-helper",
+        action="store_true",
+        help=(
+            "drain development-tier work only; the one designated coordinator "
+            "owns judicial panels and forensic rows"
+        ),
+    )
+    parser.add_argument(
         "--max-passes",
         type=int,
         default=0,
@@ -672,6 +770,9 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("worker, round, timeout, and retry values must be positive")
     if args.max_passes < 0 or args.max_lane_cycles < 0:
         raise SystemExit("pass and cycle safety bounds must be non-negative")
+    if args.development_helper and not args.worker_id.strip():
+        raise SystemExit("--development-helper requires a non-empty --worker-id")
+    args.worker_id = args.worker_id.strip()
     campaign_dir = args.campaign_workdir or Path(
         tempfile.mkdtemp(prefix="audit_loop_campaign_")
     )
@@ -717,6 +818,10 @@ def main(argv: list[str] | None = None) -> int:
     PROGRESS["failures"] = []
     PROGRESS["panel_state"] = "not_started"
     PROGRESS["canary_state"] = "not_started"
+    PROGRESS["last_canary_claim_id"] = None
+    PROGRESS["last_canary_terminal_phase"] = None
+    PROGRESS["last_canary_source"] = None
+    forensic_attempted: set[str] = set()
     _STOP_HEARTBEAT.clear()
     thread = threading.Thread(target=heartbeat, daemon=True)
     thread.start()
@@ -728,14 +833,25 @@ def main(argv: list[str] | None = None) -> int:
             PROGRESS["pass"] = pass_number
             PROGRESS["lane"] = None
             before = git_head()
-            rc = run_panel(args, f"panel-pass-{pass_number}-opening")
-            if rc != 0:
-                return rc
-            try:
-                lanes = blocking_lanes(args.lane)
-            except ValueError as exc:
-                emit(str(exc))
-                return 2
+            if args.development_helper:
+                PROGRESS["panel_state"] = "delegated_to_coordinator"
+                lanes = []
+            else:
+                rc = run_panel(args, f"panel-pass-{pass_number}-opening")
+                if rc != 0:
+                    return rc
+                if not args.lane:
+                    for source in ("dispatch", "reaudit"):
+                        PROGRESS["lane"] = f"{source}-source"
+                        emit(f"draining ready {source} source rows")
+                        rc, _ = drain_lane(None, args, source=source)
+                        if rc != 0:
+                            return rc
+                try:
+                    lanes = blocking_lanes(args.lane)
+                except ValueError as exc:
+                    emit(str(exc))
+                    return 2
             emit(
                 "blocking lanes: "
                 + (", ".join(f"{lane}={count}" for lane, count in lanes) or "none")
@@ -746,6 +862,17 @@ def main(argv: list[str] | None = None) -> int:
                 rc, _ = drain_lane(lane, args)
                 if rc != 0:
                     return rc
+            if not args.lane:
+                PROGRESS["lane"] = "global-development"
+                emit("draining every remaining eligible development-tier row")
+                rc, _ = drain_lane(None, args)
+                if rc != 0:
+                    return rc
+            if not args.dry_run:
+                synced, detail = batch.sync_origin_main()
+                if not synced:
+                    emit(f"cannot verify remote-stable fixed point: {detail}")
+                    return 2
             after = git_head()
             emit(f"development pass {pass_number}: before={before} after={after}")
             if after == before:
@@ -754,7 +881,14 @@ def main(argv: list[str] | None = None) -> int:
                 except (OSError, ValueError) as exc:
                     emit(f"invalid campaign state; refusing fixed point: {exc}")
                     return 2
-                emit("development fixed point reached: full pass landed nothing new")
+                fixed_point_kind = (
+                    "helper-local development fixed point"
+                    if args.development_helper
+                    else "development fixed point"
+                )
+                emit(
+                    f"{fixed_point_kind} reached: full pass landed nothing new"
+                )
                 if exclusions[batch.SCHEMA_QUARANTINE_RESULT]:
                     emit(
                         "fixed point excludes campaign-scoped schema-invalid "
@@ -784,11 +918,109 @@ def main(argv: list[str] | None = None) -> int:
                         "typed selector-skip repair inventory: "
                         f"{args.campaign_selection_skip_file}"
                     )
-                break
-
-        if not args.skip_forensic_canary:
-            return run_forensic_canary(args)
-        return 0
+                if (
+                    args.development_helper
+                    or args.skip_forensic_canary
+                    or args.lane
+                ):
+                    return 0
+                forensic_before = after
+                rc = run_forensic_canary(args, forensic_attempted)
+                if rc != 0:
+                    return rc
+                if args.dry_run:
+                    return 0
+                synced, detail = batch.sync_origin_main()
+                if not synced:
+                    emit(f"cannot reconcile forensic result with origin/main: {detail}")
+                    return 2
+                forensic_after = git_head()
+                canary_claim = PROGRESS.get("last_canary_claim_id")
+                if forensic_after != forensic_before:
+                    if isinstance(canary_claim, str) and canary_claim:
+                        current_rows = batch.load_rows()
+                        current_row = current_rows.get(canary_claim) or {}
+                        canary_source = PROGRESS.get("last_canary_source")
+                        cross_status = (
+                            current_row.get("cross_confirmation") or {}
+                        ).get("status")
+                        awaiting_second = (
+                            current_row.get("audit_status") == "audit_in_progress"
+                            and cross_status == "awaiting_second"
+                        )
+                        if not awaiting_second:
+                            forensic_attempted.add(canary_claim)
+                        reentry_reason = None
+                        if canary_source in {"dispatch", "reaudit"}:
+                            try:
+                                source_ids = {
+                                    row.get("claim_id")
+                                    for row in batch.source_queue_rows(
+                                        str(canary_source),
+                                        current_rows,
+                                    )
+                                }
+                            except (
+                                OSError,
+                                ValueError,
+                                json.JSONDecodeError,
+                            ) as exc:
+                                emit(
+                                    "cannot authenticate post-forensic source "
+                                    f"state: {exc}"
+                                )
+                                return 2
+                            if canary_claim in source_ids:
+                                reentry_reason = (
+                                    f"{canary_source}_selection_still_live_"
+                                    "after_applied_verdict"
+                                )
+                        elif (
+                            current_row.get("audit_status") == "unaudited"
+                            and batch.source_requires_forensic(current_row)
+                        ):
+                            reentry_reason = batch._latest_invalidation_reason(
+                                current_row
+                            )
+                        if reentry_reason is not None:
+                            batch.persist_blocked_row_reentries(
+                                args.campaign_quarantine_file,
+                                {canary_claim: reentry_reason},
+                            )
+                            forensic_attempted.add(canary_claim)
+                            emit(
+                                "forensic verdict re-entered the unchanged "
+                                "ready queue and was excluded for this campaign: "
+                                f"claim={canary_claim} reason={reentry_reason}"
+                            )
+                    emit(
+                        "forensic row landed; returning to development because "
+                        "the new verdict may unblock additional dependencies"
+                    )
+                    continue
+                if isinstance(canary_claim, str) and canary_claim:
+                    forensic_attempted.add(canary_claim)
+                    if PROGRESS.get("last_canary_terminal_phase") == "applied":
+                        reason = (
+                            "applied_forensic_verdict_produced_no_canonical_"
+                            "state_change"
+                        )
+                        batch.persist_blocked_row_reentries(
+                            args.campaign_quarantine_file,
+                            {canary_claim: reason},
+                        )
+                        emit(
+                            "forensic apply produced no canonical commit and "
+                            "was excluded for this campaign: "
+                            f"claim={canary_claim} reason={reason}"
+                        )
+                        continue
+                    emit(
+                        "forensic row minted no verdict and is excluded for "
+                        "this campaign; advancing to the next ready forensic row"
+                    )
+                    continue
+                return 0
     finally:
         _STOP_HEARTBEAT.set()
         emit(summary_line(final=True))

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -108,6 +108,13 @@ def campaign_exclusion_counts() -> Counter:
     return Counter(reason for _cid, reason in pairs)
 
 
+def campaign_exclusion_keys(path: Path | None) -> set[tuple[str, str]]:
+    return {
+        (record["claim_id"], record["reason"])
+        for record in batch.load_campaign_exclusion_records(path)
+    }
+
+
 def campaign_exclusion_count(reason: str) -> int:
     return campaign_exclusion_counts()[reason]
 
@@ -387,6 +394,9 @@ def drain_lane(
             emit(f"STOP lane cycle safety bound reached: lane={label}")
             return 4, made_progress
         before = git_head()
+        before_exclusions = campaign_exclusion_keys(
+            getattr(args, "campaign_quarantine_file", None)
+        )
         batch_rc = run_command(
             f"batch-{label}-cycle-{cycle}",
             batch_command(lane, args, source=source),
@@ -401,7 +411,10 @@ def drain_lane(
         if batch_rc != 0:
             return batch_rc, made_progress
         after = git_head()
-        if after == before:
+        after_exclusions = campaign_exclusion_keys(
+            getattr(args, "campaign_quarantine_file", None)
+        )
+        if after == before and after_exclusions == before_exclusions:
             return 0, made_progress
         made_progress = True
         if args.dry_run:
@@ -499,6 +512,8 @@ def forensic_canary_terminal_record(
         "skip_prompt_transport",
         "skip_role",
         "weak_clean_unratifiable",
+        "remote_state_superseded",
+        "source_refresh_failed",
         "dry-run",
     }
     return next(
@@ -650,7 +665,7 @@ def run_forensic_canary(
         if rc != 0:
             return rc
         terminal_phase = terminal.get("phase") if terminal else None
-        if terminal_phase == "applied" or (
+        if terminal_phase in {"applied", "remote_state_superseded"} or (
             args.dry_run and terminal_phase == "dry-run"
         ):
             return 0
@@ -936,6 +951,15 @@ def main(argv: list[str] | None = None) -> int:
                     return 2
                 forensic_after = git_head()
                 canary_claim = PROGRESS.get("last_canary_claim_id")
+                if (
+                    PROGRESS.get("last_canary_terminal_phase")
+                    == "remote_state_superseded"
+                ):
+                    emit(
+                        "forensic seat was superseded by remote source/state "
+                        "movement; returning to development for fresh selection"
+                    )
+                    continue
                 if forensic_after != forensic_before:
                     if isinstance(canary_claim, str) and canary_claim:
                         current_rows = batch.load_rows()

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -667,6 +667,8 @@ def _args() -> argparse.Namespace:
     return argparse.Namespace(
         lane=None,
         max_workers=4,
+        worker_id="",
+        development_helper=False,
         max_passes=0,
         max_lane_cycles=0,
         batch_rounds=6,
@@ -955,7 +957,11 @@ class SchemaRecoveryTest(unittest.TestCase):
         self.assertEqual([row["claim_id"] for row in targets], ["target"])
         self.assertEqual(
             {record["reason"] for record in records},
-            batch.SELECTION_SKIP_REASONS - {"unclassified_selector_skip"},
+            batch.SELECTION_SKIP_REASONS - {
+                "unclassified_selector_skip",
+                "audit_role_not_actionable",
+                "weak_dispatch_independence",
+            },
         )
 
     def test_selector_skip_loader_rejects_reason_detail_mismatch(self):
@@ -2855,6 +2861,173 @@ class AutomaticPanelResumeTest(unittest.TestCase):
 
 
 class CampaignContractTest(unittest.TestCase):
+    def test_alternate_source_uses_current_role_and_authenticated_fingerprint(self):
+        row = {
+            "claim_id": "dispatch_row",
+            "audit_status": "audited_clean",
+            "effective_status": "retained",
+            "claim_type": "bounded_theorem",
+            "criticality": "high",
+            "author_family": "claude",
+            "auditor_family": "codex-gpt-5.6",
+            "deps": [],
+        }
+        source_row = dict(
+            row,
+            dispatch_target=True,
+            allowed_context_paths=["docs/DISPATCH.md"],
+        )
+        with mock.patch.object(
+            batch, "source_queue_rows", return_value=[source_row]
+        ), mock.patch.object(
+            batch, "source_requires_forensic", return_value=False
+        ), mock.patch.object(
+            batch, "note_hash_drifted", return_value=False
+        ):
+            targets, skipped = batch.compute_alternate_targets(
+                "dispatch",
+                {"dispatch_row": row},
+            )
+
+        self.assertEqual(skipped, [])
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0]["_audit_passes"], [1])
+        self.assertEqual(targets[0]["_audit_independence"], "cross_family")
+        self.assertEqual(targets[0]["_selection_source"], "dispatch")
+        self.assertEqual(
+            targets[0]["_source_fingerprint"],
+            batch.source_row_fingerprint(source_row),
+        )
+
+    def test_applied_alternate_source_that_stays_live_is_campaign_excluded(self):
+        selected = [{
+            "claim_id": "dispatch_row",
+            "_selection_source": "dispatch",
+        }]
+        current = {
+            "dispatch_row": {
+                "claim_id": "dispatch_row",
+                "audit_status": "audited_conditional",
+            }
+        }
+        report = [{
+            "cid": "dispatch_row",
+            "result": "audited_conditional",
+            "commit": "landed",
+        }]
+        with mock.patch.object(
+            batch,
+            "source_queue_rows",
+            return_value=[{"claim_id": "dispatch_row"}],
+        ):
+            reentries = batch.blocked_row_reentries(
+                selected,
+                current,
+                report,
+            )
+
+        self.assertEqual(
+            reentries,
+            {
+                "dispatch_row":
+                    "dispatch_selection_still_live_after_applied_verdict"
+            },
+        )
+        self.assertEqual(
+            report[-1]["result"],
+            batch.BLOCKED_ROW_QUARANTINE_RESULT,
+        )
+
+    def test_worker_rotation_preserves_full_set_and_spreads_starts(self):
+        targets = [
+            {
+                "claim_id": f"critical_{index}",
+                "criticality": "critical",
+            }
+            for index in range(7)
+        ] + [
+            {
+                "claim_id": f"high_{index}",
+                "criticality": "high",
+            }
+            for index in range(7)
+        ]
+
+        first = batch.rotate_priority_tiers(targets, "employee-alpha")
+        repeated = batch.rotate_priority_tiers(targets, "employee-alpha")
+        second = batch.rotate_priority_tiers(targets, "employee-beta")
+
+        self.assertEqual(first, repeated)
+        self.assertEqual(
+            {row["claim_id"] for row in first},
+            {row["claim_id"] for row in targets},
+        )
+        self.assertNotEqual(
+            [row["claim_id"] for row in first],
+            [row["claim_id"] for row in second],
+        )
+        self.assertEqual(
+            [row["criticality"] for row in first],
+            ["critical"] * 7 + ["high"] * 7,
+        )
+
+    def test_remote_claim_movement_discards_stale_delivery(self):
+        row = {"claim_id": "row", "criticality": "high"}
+        deliveries = [(
+            {
+                "cid": "row",
+                "pass": 1,
+                "row": row,
+                "selection_fingerprint": "launched-state",
+            },
+            {
+                "audit": {"verdict": "audited_clean"},
+                "evidence_manifest": {},
+            },
+        )]
+        with mock.patch.object(
+            batch, "sync_origin_main", return_value=(True, "remote")
+        ), mock.patch.object(
+            batch, "load_rows", return_value={"row": row}
+        ), mock.patch.object(
+            batch, "selection_fingerprint", return_value="current-state"
+        ), mock.patch.object(
+            batch.audit_runner, "apply_one"
+        ) as apply_one, mock.patch.object(
+            batch, "run_generated_gates"
+        ) as gates:
+            ok, results = batch.apply_claim_serialized(deliveries, retries=3)
+
+        self.assertTrue(ok)
+        self.assertEqual(
+            results[0]["result"],
+            batch.REMOTE_STATE_SUPERSEDED_RESULT,
+        )
+        apply_one.assert_not_called()
+        gates.assert_not_called()
+
+    def test_runner_execution_removes_only_new_checkout_side_effects(self):
+        marker = f"runner-side-effect-{time.time_ns()}.tmp"
+        marker_path = batch.audit_runner.REPO_ROOT / marker
+        before = batch.audit_runner._runner_worktree_state()
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = Path(tmp) / "runner.py"
+            runner.write_text(
+                "from pathlib import Path\n"
+                f"Path({marker!r}).write_text('generated by runner')\n"
+                "print('runner evidence')\n",
+                encoding="utf-8",
+            )
+            result = batch.audit_runner._run_repo_runner(runner, 30)
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("runner evidence", result.stdout)
+        self.assertFalse(marker_path.exists())
+        self.assertEqual(
+            batch.audit_runner._runner_worktree_state(),
+            before,
+        )
+
     def test_inherited_campaign_lock_is_reentrant_for_child(self):
         held = batch.acquire_exclusive_drain_lock("top-level-test")
         self.assertIsNotNone(held)
@@ -2975,6 +3148,47 @@ class CampaignContractTest(unittest.TestCase):
             self.assertTrue(
                 audit_loop.PROGRESS["canary_state"].startswith("quarantined:")
             )
+
+    def test_forensic_alternate_source_is_forwarded_to_restricted_runner(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            campaign = Path(tmp)
+            args = _args()
+            args.campaign_workdir = campaign
+            args.campaign_quarantine_file = (
+                campaign / "campaign-row-exclusions.jsonl"
+            )
+            claim_id = "cascade_no_go"
+            seen_command: list[str] = []
+
+            def select(*_args, **_kwargs):
+                audit_loop.PROGRESS["last_canary_source"] = "reaudit"
+                return claim_id
+
+            def fake_run(_label, command, env=None):
+                seen_command.extend(command)
+                log = Path(command[command.index("--run-log-path") + 1])
+                log.write_text(
+                    json.dumps(
+                        {
+                            "claim_id": claim_id,
+                            "phase": "applied",
+                            "verdict": "audited_conditional",
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                return 0
+
+            with mock.patch.object(
+                audit_loop,
+                "first_ready_forensic_claim",
+                side_effect=select,
+            ), mock.patch.object(audit_loop, "run_command", side_effect=fake_run):
+                rc = audit_loop.run_forensic_canary(args)
+
+        self.assertEqual(rc, 0)
+        self.assertIn("--from-reaudit-candidates", seen_command)
 
     def test_forensic_compute_skip_is_quarantined_and_returns_success(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -3172,6 +3386,91 @@ class CampaignContractTest(unittest.TestCase):
         self.assertEqual(rc, 2)
         run_panel.assert_not_called()
 
+    def test_development_helper_skips_panels_and_priority_lane_duplication(self):
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            audit_loop, "validate_requested_lanes"
+        ), mock.patch.object(
+            batch, "load_campaign_exclusion_records", return_value=[]
+        ), mock.patch.object(
+            batch, "load_campaign_selection_skip_records", return_value=[]
+        ), mock.patch.object(
+            audit_loop, "audit_status_snapshot", return_value={}
+        ), mock.patch.object(
+            audit_loop, "git_head", return_value="same"
+        ), mock.patch.object(
+            audit_loop, "run_panel"
+        ) as run_panel, mock.patch.object(
+            audit_loop, "blocking_lanes"
+        ) as blocking_lanes, mock.patch.object(
+            audit_loop, "drain_lane", return_value=(0, False)
+        ) as drain_lane:
+            rc = audit_loop.main(
+                [
+                    "--dry-run",
+                    "--development-helper",
+                    "--worker-id",
+                    "employee-alpha",
+                    "--campaign-workdir",
+                    tmp,
+                ]
+            )
+
+        self.assertEqual(rc, 0)
+        run_panel.assert_not_called()
+        blocking_lanes.assert_not_called()
+        drain_lane.assert_called_once()
+        self.assertIsNone(drain_lane.call_args.args[0])
+
+    def test_coordinator_continues_after_claim_local_forensic_exclusion(self):
+        lock = mock.Mock()
+        canary_calls = 0
+
+        def fake_canary(_args, _excluded):
+            nonlocal canary_calls
+            canary_calls += 1
+            audit_loop.PROGRESS["last_canary_claim_id"] = (
+                "quarantined_row" if canary_calls == 1 else None
+            )
+            return 0
+
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            audit_loop, "validate_requested_lanes"
+        ), mock.patch.object(
+            batch, "load_campaign_exclusion_records", return_value=[]
+        ), mock.patch.object(
+            batch, "load_campaign_selection_skip_records", return_value=[]
+        ), mock.patch.object(
+            batch, "acquire_exclusive_drain_lock", return_value=lock
+        ), mock.patch.object(
+            batch, "clean_main_error", return_value=None
+        ), mock.patch.object(
+            batch, "sync_origin_main", return_value=(True, "same")
+        ), mock.patch.object(
+            audit_loop, "audit_status_snapshot", return_value={}
+        ), mock.patch.object(
+            audit_loop, "git_head", return_value="same"
+        ), mock.patch.object(
+            audit_loop, "run_panel", return_value=0
+        ), mock.patch.object(
+            audit_loop, "blocking_lanes", return_value=[]
+        ), mock.patch.object(
+            audit_loop, "drain_lane", return_value=(0, False)
+        ), mock.patch.object(
+            audit_loop, "run_forensic_canary", side_effect=fake_canary
+        ):
+            rc = audit_loop.main(
+                [
+                    "--campaign-workdir",
+                    tmp,
+                    "--worker-id",
+                    "coordinator",
+                ]
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(canary_calls, 2)
+        lock.close.assert_called_once_with()
+
     def test_verdict_summary_never_rematerializes_ledger_cache(self):
         with mock.patch.object(
             audit_loop, "audit_status_snapshot", return_value={"row": "audited_clean"}
@@ -3203,6 +3502,14 @@ class CampaignContractTest(unittest.TestCase):
         self.assertIn(
             "--dispatch-science-fixes",
             audit_loop.batch_command("lane_a", args),
+        )
+        self.assertIn(
+            "--from-dispatch",
+            audit_loop.batch_command(None, args, source="dispatch"),
+        )
+        self.assertNotIn(
+            "--all",
+            audit_loop.batch_command(None, args, source="dispatch"),
         )
 
 

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -2744,7 +2744,7 @@ class ClaimTransactionTest(unittest.TestCase):
         reset.assert_called_once_with()
         self.assertEqual({item["commit"] for item in results}, {"commit-2"})
 
-    def test_push_race_cancellation_rolls_back_local_commit(self):
+    def test_indeterminate_push_cancellation_preserves_local_commit(self):
         cancel = threading.Event()
         row = {"claim_id": "row", "criticality": "high"}
         deliveries = [(
@@ -2780,8 +2780,72 @@ class ClaimTransactionTest(unittest.TestCase):
             del batch._COMMAND_CONTEXT.cancel_event
 
         self.assertFalse(ok)
-        self.assertEqual(results[0]["result"], "commit_cancelled")
-        reset.assert_called_once_with()
+        self.assertEqual(
+            results[0]["result"],
+            batch.PUSH_RECONCILIATION_REQUIRED_RESULT,
+        )
+        self.assertEqual(results[0]["commit"], "local-commit")
+        reset.assert_not_called()
+
+    def test_indeterminate_push_and_failed_fetch_preserves_intended_oid(self):
+        row = {"claim_id": "row", "criticality": "high"}
+        deliveries = [(
+            {"cid": "row", "pass": 1, "row": row},
+            {"audit": {"verdict": "audited_clean"}, "evidence_manifest": {}},
+        )]
+        commands = [
+            subprocess.CompletedProcess(["git", "push"], 1, "", "lost response"),
+            subprocess.CompletedProcess(["git", "fetch"], 1, "", "offline"),
+        ]
+        with mock.patch.object(
+            batch, "sync_origin_main", return_value=(True, "base")
+        ), mock.patch.object(
+            batch.audit_runner, "apply_one", return_value=(True, "applied")
+        ), mock.patch.object(
+            batch, "run_generated_gates", return_value=(True, "gated")
+        ), mock.patch.object(
+            batch, "stage_and_commit", return_value=(True, "intended-commit")
+        ), mock.patch.object(
+            batch, "reset_to_origin_main", return_value=(True, "reset")
+        ) as reset, mock.patch.object(batch, "sh", side_effect=commands):
+            ok, results = batch.apply_claim_serialized(deliveries, retries=3)
+
+        self.assertFalse(ok)
+        self.assertEqual(
+            results[0]["result"],
+            batch.PUSH_RECONCILIATION_REQUIRED_RESULT,
+        )
+        self.assertEqual(results[0]["commit"], "intended-commit")
+        reset.assert_not_called()
+
+    def test_nonzero_push_is_success_when_exact_intended_oid_landed(self):
+        row = {"claim_id": "row", "criticality": "high"}
+        deliveries = [(
+            {"cid": "row", "pass": 1, "row": row},
+            {"audit": {"verdict": "audited_clean"}, "evidence_manifest": {}},
+        )]
+        commands = [
+            subprocess.CompletedProcess(["git", "push"], 1, "", "lost response"),
+            subprocess.CompletedProcess(["git", "fetch"], 0, "", ""),
+            subprocess.CompletedProcess(["git", "merge-base"], 0, "", ""),
+        ]
+        with mock.patch.object(
+            batch, "sync_origin_main", return_value=(True, "base")
+        ), mock.patch.object(
+            batch.audit_runner, "apply_one", return_value=(True, "applied")
+        ), mock.patch.object(
+            batch, "run_generated_gates", return_value=(True, "gated")
+        ), mock.patch.object(
+            batch, "stage_and_commit", return_value=(True, "intended-commit")
+        ), mock.patch.object(
+            batch, "reset_to_origin_main", return_value=(True, "reset")
+        ) as reset, mock.patch.object(batch, "sh", side_effect=commands):
+            ok, results = batch.apply_claim_serialized(deliveries, retries=3)
+
+        self.assertTrue(ok)
+        self.assertEqual(results[0]["result"], "audited_clean")
+        self.assertEqual(results[0]["commit"], "intended-commit")
+        reset.assert_not_called()
 
     def test_terminal_push_race_rolls_back_local_commit(self):
         row = {"claim_id": "row", "criticality": "high"}
@@ -2859,8 +2923,227 @@ class AutomaticPanelResumeTest(unittest.TestCase):
             ["batch-lane_a-cycle-1", "panel-after-lane_a-cycle-1"],
         )
 
+    def test_quarantine_only_batch_progress_resumes_until_stable(self):
+        args = _args()
+        heads = iter(["same", "same", "same", "same"])
+        record = {
+            "claim_id": "quarantined",
+            "reason": batch.COMPUTE_QUARANTINE_RESULT,
+        }
+        exclusions = iter([[], [record], [record], [record]])
+        labels: list[str] = []
+
+        def fake_run(label, command, env=None):
+            labels.append(label)
+            return 0
+
+        with mock.patch.object(
+            audit_loop, "git_head", side_effect=lambda: next(heads)
+        ), mock.patch.object(
+            audit_loop, "run_command", side_effect=fake_run
+        ), mock.patch.object(
+            batch,
+            "load_campaign_exclusion_records",
+            side_effect=lambda _path: next(exclusions),
+        ):
+            rc, progressed = audit_loop.drain_lane("lane_a", args)
+
+        self.assertEqual(rc, 0)
+        self.assertTrue(progressed)
+        self.assertEqual(
+            labels,
+            [
+                "batch-lane_a-cycle-1",
+                "panel-after-lane_a-cycle-1",
+                "batch-lane_a-cycle-2",
+                "panel-after-lane_a-cycle-2",
+            ],
+        )
+
 
 class CampaignContractTest(unittest.TestCase):
+    def test_packet_fingerprint_normalizes_transport_bounded_virtual_index(self):
+        row = {"claim_id": "target", "deps": []}
+        rows = {"target": row}
+        full_text = '{"candidates":[{"candidate_id":"one"}]}'
+        unbounded = {
+            "audit-packet://cross-cycle-index/target": {
+                "path": "audit-packet://cross-cycle-index/target",
+                "roles": ["cross_cycle_index"],
+                "text": full_text,
+            }
+        }
+        bounded = {
+            "audit-packet://cross-cycle-index/target": {
+                "path": "audit-packet://cross-cycle-index/target",
+                "roles": ["cross_cycle_index"],
+                "text": '{"candidates":[]}',
+                "transport_bounded_full_content_sha256": hashlib.sha256(
+                    full_text.encode("utf-8")
+                ).hexdigest(),
+                "transport_bounded_full_candidate_count": 1,
+                "transport_bounded_rendered_candidate_count": 0,
+                "transport_bounded_rendered_candidate_ids": [],
+            }
+        }
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            batch.audit_runner,
+            "REPO_ROOT",
+            Path(tmp),
+        ), mock.patch.object(
+            batch.audit_runner,
+            "PROMPT_TEMPLATE_PATH",
+            Path(tmp) / "missing-template",
+        ):
+            expected = batch.audit_runner.audit_packet_source_fingerprint(
+                row,
+                rows,
+                unbounded,
+            )
+            actual = batch.audit_runner.audit_packet_source_fingerprint(
+                row,
+                rows,
+                bounded,
+            )
+
+        self.assertEqual(actual, expected)
+
+    def test_packet_fingerprint_binds_dependency_bytes_and_seat_provenance(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "docs").mkdir()
+            (root / "scripts").mkdir()
+            (root / "docs" / "target.md").write_text("target", encoding="utf-8")
+            dependency = root / "docs" / "dependency.md"
+            dependency.write_text("dependency v1", encoding="utf-8")
+            runner = root / "scripts" / "runner.py"
+            runner.write_text(
+                "AUDIT_INPUT_PATHS = ('docs/input.json',)\n",
+                encoding="utf-8",
+            )
+            (root / "docs" / "input.json").write_text("input v1", encoding="utf-8")
+            prompt_template = root / "prompt.md"
+            prompt_template.write_text("prompt", encoding="utf-8")
+            rows = {
+                "target": {
+                    "claim_id": "target",
+                    "note_path": "docs/target.md",
+                    "runner_path": "scripts/runner.py",
+                    "deps": ["dependency"],
+                    "criticality": "high",
+                    "claim_type": "bounded_theorem",
+                    "audit_status": "unaudited",
+                    "author_family": "claude",
+                },
+                "dependency": {
+                    "claim_id": "dependency",
+                    "note_path": "docs/dependency.md",
+                    "effective_status": "retained",
+                },
+            }
+            manifest = {
+                "docs/target.md": {
+                    "path": "docs/target.md",
+                    "roles": ["source"],
+                    "text": "target",
+                },
+                "docs/dependency.md": {
+                    "path": "docs/dependency.md",
+                    "roles": ["authority"],
+                    "text": "dependency v1",
+                },
+                "scripts/runner.py": {
+                    "path": "scripts/runner.py",
+                    "roles": ["runner"],
+                    "text": runner.read_text(encoding="utf-8"),
+                },
+                "audit-packet://cross-cycle-index/target": {
+                    "path": "audit-packet://cross-cycle-index/target",
+                    "roles": ["cross_cycle_index"],
+                    "text": "virtual evidence v1",
+                },
+            }
+            with mock.patch.object(
+                batch.audit_runner, "REPO_ROOT", root
+            ), mock.patch.object(
+                batch.audit_runner, "PROMPT_TEMPLATE_PATH", prompt_template
+            ):
+                first = batch.selection_fingerprint(
+                    rows["target"],
+                    rows,
+                    manifest,
+                )
+                dependency.write_text("dependency v2", encoding="utf-8")
+                dependency_changed = batch.selection_fingerprint(
+                    rows["target"],
+                    rows,
+                    manifest,
+                )
+                rows["target"]["author_family"] = "codex-gpt-5.6"
+                provenance_changed = batch.selection_fingerprint(
+                    rows["target"],
+                    rows,
+                    manifest,
+                )
+
+            self.assertNotEqual(first, dependency_changed)
+            self.assertNotEqual(dependency_changed, provenance_changed)
+
+    def test_forensic_precondition_discards_remote_head_movement(self):
+        row = {"claim_id": "row"}
+        commands = [
+            subprocess.CompletedProcess(["git", "fetch"], 0, "", ""),
+            subprocess.CompletedProcess(["git", "rev-parse"], 0, "a" * 40, ""),
+            subprocess.CompletedProcess(["git", "rev-parse"], 0, "b" * 40, ""),
+        ]
+        with mock.patch.object(
+            batch.audit_runner, "git", side_effect=commands
+        ), mock.patch.object(
+            batch.audit_runner, "load_ledger_rows"
+        ) as load_rows:
+            current, result, detail = (
+                batch.audit_runner.audit_delivery_precondition(
+                    row,
+                    source=None,
+                    expected_packet_fingerprint="packet",
+                    expected_selection_fingerprint="selection",
+                    expected_role="first",
+                    expected_independence="cross_family",
+                    auditor_family="codex-gpt-5.6",
+                )
+            )
+
+        self.assertFalse(current)
+        self.assertEqual(result, "remote_state_superseded")
+        self.assertIn("moved", detail)
+        load_rows.assert_not_called()
+
+    def test_forensic_push_never_rebases_already_applied_audit(self):
+        oid = "c" * 40
+        commands: list[list[str]] = []
+
+        def fake_git(*args, check=True):
+            commands.append(list(args))
+            if args[:2] == ("diff", "--cached"):
+                return subprocess.CompletedProcess(args, 1, "", "")
+            if args[0] == "rev-parse":
+                return subprocess.CompletedProcess(args, 0, oid, "")
+            if args[0] == "push":
+                return subprocess.CompletedProcess(args, 1, "", "race")
+            if args[0] == "fetch":
+                return subprocess.CompletedProcess(args, 0, "", "")
+            if args[0] == "merge-base":
+                return subprocess.CompletedProcess(args, 1, "", "")
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        with mock.patch.object(batch.audit_runner, "git", side_effect=fake_git):
+            pushed, detail = batch.audit_runner.commit_and_push_to_main("audit")
+
+        self.assertFalse(pushed)
+        self.assertIn(oid, detail)
+        self.assertIn("preserved", detail)
+        self.assertFalse(any(command[0] == "rebase" for command in commands))
+
     def test_alternate_source_uses_current_role_and_authenticated_fingerprint(self):
         row = {
             "claim_id": "dispatch_row",
@@ -3006,27 +3289,103 @@ class CampaignContractTest(unittest.TestCase):
         apply_one.assert_not_called()
         gates.assert_not_called()
 
-    def test_runner_execution_removes_only_new_checkout_side_effects(self):
-        marker = f"runner-side-effect-{time.time_ns()}.tmp"
-        marker_path = batch.audit_runner.REPO_ROOT / marker
-        before = batch.audit_runner._runner_worktree_state()
+    def test_runner_execution_discards_isolated_checkout_side_effects(self):
         with tempfile.TemporaryDirectory() as tmp:
-            runner = Path(tmp) / "runner.py"
+            root = Path(tmp)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            runner = scripts / "runner.py"
+            detached_marker = root / (
+                f"detached-runner-marker-{time.time_ns()}.txt"
+            )
             runner.write_text(
                 "from pathlib import Path\n"
-                f"Path({marker!r}).write_text('generated by runner')\n"
+                "import subprocess, sys, time\n"
+                "Path('tracked.txt').write_text('runner changed tracked')\n"
+                "Path('operator-note.txt').unlink(missing_ok=True)\n"
+                "Path('logs').mkdir(exist_ok=True)\n"
+                "Path('logs/cache.txt').write_text('runner changed ignored')\n"
+                "subprocess.Popen([\n"
+                "    sys.executable, '-c',\n"
+                "    \"import time; from pathlib import Path; time.sleep(0.3); "
+                f"Path({str(detached_marker)!r}).write_text('late')\",\n"
+                "], start_new_session=True)\n"
+                "time.sleep(0.2)\n"
                 "print('runner evidence')\n",
                 encoding="utf-8",
             )
-            result = batch.audit_runner._run_repo_runner(runner, 30)
+            (root / "tracked.txt").write_text("tracked baseline", encoding="utf-8")
+            (root / ".gitignore").write_text("logs/\n", encoding="utf-8")
+            subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "audit-test@example.invalid"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Audit Test"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(
+                ["git", "commit", "-q", "-m", "baseline"],
+                cwd=root,
+                check=True,
+            )
+            operator_note = root / "operator-note.txt"
+            operator_note.write_text("operator baseline", encoding="utf-8")
+            ignored = root / "logs" / "cache.txt"
+            ignored.parent.mkdir()
+            ignored.write_text("ignored baseline", encoding="utf-8")
+            concurrent = root / "concurrent-note.txt"
 
-        self.assertEqual(result.returncode, 0)
-        self.assertIn("runner evidence", result.stdout)
-        self.assertFalse(marker_path.exists())
-        self.assertEqual(
-            batch.audit_runner._runner_worktree_state(),
-            before,
-        )
+            def create_concurrent_note() -> None:
+                time.sleep(0.05)
+                concurrent.write_text("unrelated concurrent output", encoding="utf-8")
+
+            writer = threading.Thread(target=create_concurrent_note)
+            worktrees_before = subprocess.run(
+                ["git", "worktree", "list", "--porcelain"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            writer.start()
+            with mock.patch.object(batch.audit_runner, "REPO_ROOT", root):
+                result = batch.audit_runner._run_repo_runner(runner, 30)
+            writer.join(timeout=2)
+            time.sleep(0.4)
+            worktrees_after = subprocess.run(
+                ["git", "worktree", "list", "--porcelain"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("runner evidence", result.stdout)
+            self.assertEqual(
+                (root / "tracked.txt").read_text(encoding="utf-8"),
+                "tracked baseline",
+            )
+            self.assertEqual(
+                operator_note.read_text(encoding="utf-8"),
+                "operator baseline",
+            )
+            self.assertEqual(
+                ignored.read_text(encoding="utf-8"),
+                "ignored baseline",
+            )
+            self.assertEqual(
+                concurrent.read_text(encoding="utf-8"),
+                "unrelated concurrent output",
+            )
+            self.assertFalse((root / "late-runner-residue.txt").exists())
+            self.assertFalse(detached_marker.exists())
+            self.assertEqual(worktrees_after, worktrees_before)
 
     def test_inherited_campaign_lock_is_reentrant_for_child(self):
         held = batch.acquire_exclusive_drain_lock("top-level-test")

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -3387,6 +3387,345 @@ class CampaignContractTest(unittest.TestCase):
             self.assertFalse(detached_marker.exists())
             self.assertEqual(worktrees_after, worktrees_before)
 
+    def test_runner_fast_double_fork_is_token_reaped_before_external_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            marker = root / "escaped-double-fork-marker.txt"
+            runner = scripts / "runner.py"
+            runner.write_text(
+                "import os, time\n"
+                "from pathlib import Path\n"
+                "first = os.fork()\n"
+                "if first == 0:\n"
+                "    os.setsid()\n"
+                "    second = os.fork()\n"
+                "    if second > 0:\n"
+                "        os._exit(0)\n"
+                "    time.sleep(0.35)\n"
+                f"    Path({str(marker)!r}).write_text('escaped')\n"
+                "    os._exit(0)\n"
+                "print('direct runner complete')\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "audit-test@example.invalid"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Audit Test"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(
+                ["git", "commit", "-q", "-m", "baseline"],
+                cwd=root,
+                check=True,
+            )
+            tokens = [
+                f"fast-double-fork-token-{attempt}"
+                for attempt in range(5)
+            ]
+            token_uuids = [mock.Mock(hex=token) for token in tokens]
+            with mock.patch.object(
+                batch.audit_runner,
+                "REPO_ROOT",
+                root,
+            ), mock.patch.object(
+                batch.audit_runner,
+                "SANDBOX_EXEC_PATH",
+                root / "missing-sandbox-exec",
+            ), mock.patch.object(
+                batch.audit_runner.uuid,
+                "uuid4",
+                side_effect=token_uuids,
+            ):
+                results = [
+                    batch.audit_runner._run_repo_runner(runner, 30)
+                    for _attempt in range(5)
+                ]
+                remaining = {
+                    token: batch.audit_runner._runner_token_processes(token)
+                    for token in tokens
+                }
+
+            time.sleep(0.5)
+            self.assertTrue(all(result.returncode == 0 for result in results))
+            self.assertTrue(
+                all("direct runner complete" in result.stdout for result in results)
+            )
+            self.assertTrue(all(not pids for pids in remaining.values()))
+            self.assertFalse(marker.exists())
+
+    def test_runner_pid_identity_change_is_never_signaled(self):
+        with mock.patch.object(
+            batch.audit_runner,
+            "_runner_token_processes",
+            return_value={43210},
+        ), mock.patch.object(
+            batch.audit_runner,
+            "_runner_process_has_token",
+            return_value=False,
+        ), mock.patch.object(
+            batch.audit_runner.os,
+            "kill",
+        ) as kill:
+            signaled = batch.audit_runner._signal_runner_token_processes(
+                "retired-token",
+                signal.SIGKILL,
+            )
+
+        self.assertEqual(signaled, set())
+        kill.assert_not_called()
+
+    @unittest.skipUnless(
+        batch.audit_runner.SANDBOX_EXEC_PATH.exists(),
+        "sandbox-exec kernel containment is macOS-specific",
+    )
+    def test_runner_kernel_sandbox_denies_canonical_checkout_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            marker = root / "canonical-write-marker.txt"
+            runner = scripts / "runner.py"
+            runner.write_text(
+                "from pathlib import Path\n"
+                "try:\n"
+                f"    Path({str(marker)!r}).write_text('escaped')\n"
+                "except OSError:\n"
+                "    print('canonical write blocked')\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "audit-test@example.invalid"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Audit Test"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(
+                ["git", "commit", "-q", "-m", "baseline"],
+                cwd=root,
+                check=True,
+            )
+
+            with mock.patch.object(batch.audit_runner, "REPO_ROOT", root):
+                result = batch.audit_runner._run_repo_runner(runner, 30)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("canonical write blocked", result.stdout)
+            self.assertFalse(marker.exists())
+
+    def test_runner_interrupt_still_reaps_process_and_discards_worktree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            marker = root / "interrupt-escape-marker.txt"
+            runner = scripts / "runner.py"
+            runner.write_text(
+                "import time\n"
+                "from pathlib import Path\n"
+                "time.sleep(0.4)\n"
+                f"Path({str(marker)!r}).write_text('escaped')\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "audit-test@example.invalid"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Audit Test"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(
+                ["git", "commit", "-q", "-m", "baseline"],
+                cwd=root,
+                check=True,
+            )
+            real_sleep = time.sleep
+            interrupted = False
+
+            def interrupt_once(seconds):
+                nonlocal interrupted
+                if not interrupted and seconds == 0.05:
+                    interrupted = True
+                    raise KeyboardInterrupt
+                return real_sleep(seconds)
+
+            token = "interrupt-token"
+            token_uuid = mock.Mock(hex=token)
+            with mock.patch.object(
+                batch.audit_runner,
+                "REPO_ROOT",
+                root,
+            ), mock.patch.object(
+                batch.audit_runner,
+                "SANDBOX_EXEC_PATH",
+                root / "missing-sandbox-exec",
+            ), mock.patch.object(
+                batch.audit_runner.uuid,
+                "uuid4",
+                return_value=token_uuid,
+            ), mock.patch.object(
+                batch.audit_runner.time,
+                "sleep",
+                side_effect=interrupt_once,
+            ), self.assertRaises(KeyboardInterrupt):
+                batch.audit_runner._run_repo_runner(runner, 30)
+
+            real_sleep(0.5)
+            self.assertEqual(
+                batch.audit_runner._runner_token_processes(token),
+                set(),
+            )
+            self.assertFalse(marker.exists())
+            worktrees = subprocess.run(
+                ["git", "worktree", "list", "--porcelain"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            self.assertEqual(worktrees.count("\nworktree "), 0)
+
+    def test_runner_timeout_reaps_process_before_worktree_cleanup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            marker = root / "timeout-escape-marker.txt"
+            runner = scripts / "runner.py"
+            runner.write_text(
+                "import time\n"
+                "from pathlib import Path\n"
+                "time.sleep(0.4)\n"
+                f"Path({str(marker)!r}).write_text('escaped')\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "audit-test@example.invalid"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Audit Test"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(
+                ["git", "commit", "-q", "-m", "baseline"],
+                cwd=root,
+                check=True,
+            )
+            token = "timeout-token"
+            token_uuid = mock.Mock(hex=token)
+            with mock.patch.object(
+                batch.audit_runner,
+                "REPO_ROOT",
+                root,
+            ), mock.patch.object(
+                batch.audit_runner,
+                "SANDBOX_EXEC_PATH",
+                root / "missing-sandbox-exec",
+            ), mock.patch.object(
+                batch.audit_runner.uuid,
+                "uuid4",
+                return_value=token_uuid,
+            ), self.assertRaises(subprocess.TimeoutExpired):
+                batch.audit_runner._run_repo_runner(runner, 0)
+
+            time.sleep(0.5)
+            self.assertEqual(
+                batch.audit_runner._runner_token_processes(token),
+                set(),
+            )
+            self.assertFalse(marker.exists())
+
+    def test_runner_error_and_worktree_remove_failure_use_safe_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            runner = scripts / "runner.py"
+            runner.write_text(
+                "raise RuntimeError('expected runner failure')\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "audit-test@example.invalid"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Audit Test"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(
+                ["git", "commit", "-q", "-m", "baseline"],
+                cwd=root,
+                check=True,
+            )
+            real_run = subprocess.run
+            removal_failed = False
+
+            def fail_first_worktree_remove(command, *args, **kwargs):
+                nonlocal removal_failed
+                if (
+                    not removal_failed
+                    and list(command[:3]) == ["git", "worktree", "remove"]
+                ):
+                    removal_failed = True
+                    return subprocess.CompletedProcess(
+                        command,
+                        1,
+                        "",
+                        "injected worktree remove failure",
+                    )
+                return real_run(command, *args, **kwargs)
+
+            with mock.patch.object(
+                batch.audit_runner,
+                "REPO_ROOT",
+                root,
+            ), mock.patch.object(
+                batch.audit_runner.subprocess,
+                "run",
+                side_effect=fail_first_worktree_remove,
+            ):
+                result = batch.audit_runner._run_repo_runner(runner, 30)
+
+            self.assertTrue(removal_failed)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("expected runner failure", result.stderr)
+            worktrees = subprocess.run(
+                ["git", "worktree", "list", "--porcelain"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            self.assertEqual(worktrees.count("\nworktree "), 0)
+
     def test_inherited_campaign_lock_is_reentrant_for_child(self):
         held = batch.acquire_exclusive_drain_lock("top-level-test")
         self.assertIsNotNone(held)

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -10189,6 +10189,8 @@ class BatchOrchestratorRoundSemanticsTest(unittest.TestCase):
         ), mock.patch.object(
             m.audit_runner, "PROMPT_TEMPLATE_PATH"
         ) as template_path, mock.patch.object(
+            m, "selection_fingerprint", return_value="selection"
+        ), mock.patch.object(
             m.subprocess, "Popen", return_value=proc
         ) as popen:
             template_path.read_text.return_value = "template"
@@ -10749,35 +10751,37 @@ class CodexAuditRunnerReauditCandidatesTest(unittest.TestCase):
     def test_load_reaudit_candidates_normalizes_sorts_and_filters_streams(self):
         m = _import_codex_audit_runner()
         path = self.tmp_root / "reaudit_candidates.json"
-        path.write_text(
-            json.dumps(
+        payload = {
+            "candidates": [
                 {
-                    "candidates": [
-                        {
-                            "claim_id": "medium_dep",
-                            "criticality": "medium",
-                            "criticality_rank": 1,
-                            "transitive_descendants": 10,
-                            "load_bearing_score": 2.0,
-                        }
-                    ],
-                    "runner_drift_candidates": [
-                        {
-                            "claim_id": "critical_runner",
-                            "criticality": "critical",
-                            "criticality_rank": 3,
-                            "transitive_descendants": 1,
-                            "load_bearing_score": 1.0,
-                            "queue_reason": "custom_runner_reason",
-                        }
-                    ],
+                    "claim_id": "medium_dep",
+                    "criticality": "medium",
+                    "criticality_rank": 1,
+                    "transitive_descendants": 10,
+                    "load_bearing_score": 2.0,
                 }
-            ),
+            ],
+            "runner_drift_candidates": [
+                {
+                    "claim_id": "critical_runner",
+                    "criticality": "critical",
+                    "criticality_rank": 3,
+                    "transitive_descendants": 1,
+                    "load_bearing_score": 1.0,
+                    "queue_reason": "custom_runner_reason",
+                }
+            ],
+        }
+        path.write_text(
+            json.dumps(payload),
             encoding="utf-8",
         )
         m.REAUDIT_CANDIDATES_PATH = path
 
-        rows = m.load_reaudit_candidates()
+        with mock.patch.object(
+            m, "_expected_reaudit_payload", return_value=payload
+        ):
+            rows = m.load_reaudit_candidates(ledger_rows={})
 
         self.assertEqual([r["claim_id"] for r in rows], ["critical_runner", "medium_dep"])
         self.assertTrue(all(r["ready"] for r in rows))
@@ -10785,8 +10789,43 @@ class CodexAuditRunnerReauditCandidatesTest(unittest.TestCase):
         self.assertEqual(rows[1]["queue_reason"], "reaudit_candidate")
         self.assertEqual(rows[1]["audit_status"], "unaudited")
 
-        dep_only = m.load_reaudit_candidates(include_runner_drift=False)
+        with mock.patch.object(
+            m, "_expected_reaudit_payload", return_value=payload
+        ):
+            dep_only = m.load_reaudit_candidates(
+                include_runner_drift=False,
+                ledger_rows={},
+            )
         self.assertEqual([r["claim_id"] for r in dep_only], ["medium_dep"])
+
+    def test_load_reaudit_candidates_rejects_stale_or_unsupported_payload(self):
+        m = _import_codex_audit_runner()
+        path = self.tmp_root / "reaudit_candidates.json"
+        forged = {
+            "policy": "forged-or-stale-policy",
+            "total_candidates": 0,
+            "total_runner_drift_candidates": 0,
+            "candidates": [{"claim_id": "injected"}],
+            "runner_drift_candidates": [],
+        }
+        path.write_text(json.dumps(forged), encoding="utf-8")
+        m.REAUDIT_CANDIDATES_PATH = path
+
+        with mock.patch.object(
+            m,
+            "_expected_reaudit_payload",
+            return_value={
+                "policy": "reaudit_unblocked_v2_dep_or_runner_drift",
+                "total_candidates": 0,
+                "total_runner_drift_candidates": 0,
+                "candidates": [],
+                "runner_drift_candidates": [],
+            },
+        ), self.assertRaisesRegex(
+            ValueError,
+            "does not exactly match",
+        ):
+            m.load_reaudit_candidates(ledger_rows={})
 
 
 class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -37,7 +37,7 @@ import json
 import os
 import re
 import shutil
-import stat
+import signal
 import subprocess
 import sys
 import tempfile
@@ -65,6 +65,7 @@ import no_go_discipline_gate
 import audit_invocation
 import audit_contract
 import compute_audit_dispatch_queue
+import compute_reaudit_candidates
 
 LEDGER_PATH = AUDIT_DIR / "data" / "audit_ledger.json"
 QUEUE_PATH = AUDIT_DIR / "data" / "audit_queue.json"
@@ -808,26 +809,56 @@ def select_named_targets(queue: list[dict], claim_ids: list[str]) -> list[dict]:
     return [by_id[cid] for cid in claim_ids]
 
 
-def load_reaudit_candidates(criticality_filter: str | None = None,
-                            include_runner_drift: bool = True) -> list[dict]:
-    """Load rows from reaudit_candidates.json, sorted by leverage.
+def _reaudit_json_object(pairs: list[tuple[str, object]]) -> dict:
+    record: dict = {}
+    for key, value in pairs:
+        if key in record:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        record[key] = value
+    return record
 
-    The pipeline writes two streams to that file:
 
-    - `candidates`: rows whose audit was non-clean and where every current
-      dep is now retained-grade. Re-audit may now close the chain.
-    - `runner_drift_candidates`: rows whose audit cited a runner_artifact_issue
-      and whose runner SHA has changed since audit time.
+def _reject_reaudit_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON value {value!r}")
 
-    Both are valid re-audit triggers. Each entry is normalized into the
-    same shape as audit_queue.json rows (claim_id, note_path, runner_path,
-    deps, criticality, etc.) so the rest of the runner can treat them
-    uniformly. The `ready` flag is set to True because this alternate source
-    has already been prefiltered by the re-audit-candidate producer; runner
-    drift rows may still get a non-clean verdict if a different blocker
-    remains.
+
+def _expected_reaudit_payload(ledger_rows: dict[str, dict]) -> dict:
+    """Recompute the producer's complete payload without trusting its cache."""
+    return compute_reaudit_candidates.build_payload(ledger_rows)
+
+
+def load_reaudit_candidates(
+    criticality_filter: str | None = None,
+    include_runner_drift: bool = True,
+    *,
+    ledger_rows: dict[str, dict] | None = None,
+) -> list[dict]:
+    """Load only a byte-for-byte current re-audit producer result.
+
+    The tracked JSON is a generated selection cache, not authority. Recompute
+    both candidate streams from the current ledger and runner bytes and refuse
+    unsupported policy, stale counters, missing rows, or injected rows.
     """
-    payload = json.loads(REAUDIT_CANDIDATES_PATH.read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(
+            REAUDIT_CANDIDATES_PATH.read_text(encoding="utf-8"),
+            object_pairs_hook=_reaudit_json_object,
+            parse_constant=_reject_reaudit_json_constant,
+        )
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"invalid re-audit candidate JSON: {exc.msg}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError("re-audit candidate payload is not an object")
+    current_rows = ledger_rows if ledger_rows is not None else load_ledger_rows()
+    expected = _expected_reaudit_payload(current_rows)
+    if payload != expected:
+        raise ValueError(
+            "reaudit_candidates.json does not exactly match the current "
+            "producer policy, ledger, dependency state, counters, and runner "
+            "bytes; run the full audit pipeline and commit the refreshed cache"
+        )
     streams: list[dict] = []
     streams.extend(payload.get("candidates", []))
     if include_runner_drift:
@@ -1091,134 +1122,386 @@ def find_cached_runner_output(runner_path: str) -> str | None:
     return rc.cache_excerpt_for_audit(runner_path)
 
 
-def _runner_path_signature(relative: str) -> str:
-    path = REPO_ROOT / relative
+AUDIT_PACKET_CONTROL_PATHS = (
+    "scripts/codex_audit_runner.py",
+    "docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md",
+    "docs/audit/scripts/apply_audit.py",
+    "docs/audit/scripts/audit_contract.py",
+    "docs/audit/scripts/audit_invocation.py",
+    "docs/audit/scripts/no_go_discipline_gate.py",
+    "docs/audit/scripts/premise_nodes.py",
+    "docs/audit/scripts/run_pipeline.sh",
+)
+
+
+def _path_content_identity(path: Path) -> dict[str, object]:
+    """Return a stable byte identity without treating a ledger hash as bytes."""
     try:
         info = path.lstat()
     except OSError:
-        return "<missing>"
+        return {"kind": "missing"}
     if path.is_symlink():
         try:
-            return f"symlink:{os.readlink(path)}"
+            link_target = os.readlink(path)
         except OSError:
-            return "symlink:<unreadable>"
+            link_target = "<unreadable>"
+        try:
+            body_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+        except OSError:
+            body_hash = "<unreadable>"
+        return {
+            "kind": "symlink",
+            "target": link_target,
+            "target_bytes_sha256": body_hash,
+        }
     if path.is_file():
         try:
-            return "file:" + hashlib.sha256(path.read_bytes()).hexdigest()
+            body_hash = hashlib.sha256(path.read_bytes()).hexdigest()
         except OSError:
-            return "file:<unreadable>"
-    return f"mode:{stat.S_IFMT(info.st_mode):o}:size:{info.st_size}"
+            body_hash = "<unreadable>"
+        return {"kind": "file", "bytes_sha256": body_hash}
+    return {
+        "kind": "other",
+        "mode": info.st_mode,
+        "size": info.st_size,
+    }
 
 
-def _runner_worktree_state() -> dict[str, tuple[str, str]]:
-    """Return path -> (porcelain status, content identity) for dirty paths."""
+def _packet_manifest_for_fingerprint(
+    row: dict,
+    ledger_rows: dict[str, dict],
+) -> dict[str, dict]:
+    cid = str(row.get("claim_id") or "")
+    packet_row = {**(ledger_rows.get(cid) or {}), **row, "claim_id": cid}
+    if row.get("dispatch_target"):
+        packet_row = no_go_discipline_gate.blind_reaudit_row_projection(
+            packet_row
+        )
+    manifest = no_go_discipline_gate.build_evidence_manifest(
+        packet_row,
+        ledger_rows,
+        REPO_ROOT,
+    )
+    if row.get("dispatch_target"):
+        no_go_discipline_gate.set_packet_evidence(
+            manifest,
+            path=no_go_discipline_gate.blind_reaudit_control_path(cid),
+            role="blind_reaudit_control",
+            text=(
+                "Fresh-context dispatch: prior claim scope and audit judgments "
+                "are withheld from the auditor."
+            ),
+        )
+    return manifest
+
+
+def audit_packet_source_fingerprint(
+    row: dict,
+    ledger_rows: dict[str, dict],
+    evidence_manifest: dict[str, dict] | None = None,
+) -> str:
+    """Bind a seat to exact governed packet sources and ledger provenance."""
+    cid = str(row.get("claim_id") or "")
+    manifest = (
+        evidence_manifest
+        if evidence_manifest is not None
+        else _packet_manifest_for_fingerprint(row, ledger_rows)
+    )
+    manifest_state: dict[str, dict] = {}
+    for path, raw_entry in sorted(manifest.items()):
+        entry = raw_entry if isinstance(raw_entry, dict) else {}
+        roles = {
+            str(role) for role in (entry.get("roles") or [])
+        }
+        if path.startswith("audit-packet://"):
+            if any(role.startswith("runner_stdout") for role in roles):
+                continue
+            canonical_text_hash = entry.get(
+                "transport_bounded_full_content_sha256"
+            )
+            if not canonical_text_hash:
+                canonical_text_hash = hashlib.sha256(
+                    str(entry.get("text") or "").encode("utf-8")
+                ).hexdigest()
+            virtual_state = {
+                key: value
+                for key, value in entry.items()
+                if key not in {
+                    "text",
+                    "invocation_bound_rendered_text",
+                    "transport_bounded_full_content_sha256",
+                    "transport_bounded_full_candidate_count",
+                    "transport_bounded_rendered_candidate_count",
+                    "transport_bounded_rendered_candidate_ids",
+                }
+            }
+            virtual_state["canonical_text_sha256"] = canonical_text_hash
+            manifest_state[path] = virtual_state
+            continue
+        metadata = {
+            key: value
+            for key, value in entry.items()
+            if key not in {"text", "invocation_bound_rendered_text"}
+        }
+        metadata["source_identity"] = _path_content_identity(REPO_ROOT / path)
+        if roles.intersection({"runner", "helper"}):
+            declared = rc.declared_input_paths(REPO_ROOT / path)
+            if declared is not None:
+                metadata["declared_input_identities"] = {
+                    relative: _path_content_identity(REPO_ROOT / relative)
+                    for relative in declared
+                }
+        manifest_state[path] = metadata
+
+    controls = {
+        path: _path_content_identity(REPO_ROOT / path)
+        for path in AUDIT_PACKET_CONTROL_PATHS
+    }
+    controls["<prompt-template-runtime-path>"] = _path_content_identity(
+        PROMPT_TEMPLATE_PATH
+    )
+    ledger_row = ledger_rows.get(cid)
+    dependency_rows = {
+        dep: ledger_rows.get(dep)
+        for dep in (ledger_row or row).get("deps") or []
+    }
+    payload = {
+        "schema": "audit-packet-source-fingerprint-v2",
+        "claim_id": cid,
+        "dispatch_target": bool(row.get("dispatch_target")),
+        "ledger_row": ledger_row,
+        "dependency_rows": dependency_rows,
+        "manifest_state": manifest_state,
+        "control_sources": controls,
+    }
+    return hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def audit_selection_fingerprint(row: dict) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            row,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _runner_descendant_pids(root_pid: int) -> set[int]:
+    """Snapshot recursive descendants before they can orphan via setsid()."""
     result = subprocess.run(
-        [
-            "git", "status", "--porcelain=v1", "-z",
-            "--untracked-files=all",
-        ],
-        cwd=REPO_ROOT,
+        ["ps", "-axo", "pid=,ppid="],
         capture_output=True,
+        text=True,
         check=False,
     )
     if result.returncode != 0:
-        raise RuntimeError("cannot snapshot worktree around runner execution")
-    records = result.stdout.split(b"\0")
-    state: dict[str, tuple[str, str]] = {}
-    index = 0
-    while index < len(records):
-        record = records[index]
-        index += 1
-        if not record:
+        return set()
+    children: dict[int, set[int]] = {}
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
             continue
-        if len(record) < 4:
-            raise RuntimeError("malformed git status record around runner execution")
-        code = record[:2].decode("ascii", errors="replace")
-        path = record[3:].decode("utf-8", errors="surrogateescape")
-        state[path] = (code, _runner_path_signature(path))
-        if "R" in code or "C" in code:
-            if index >= len(records) or not records[index]:
-                raise RuntimeError(
-                    "malformed rename status around runner execution"
-                )
-            source = records[index].decode(
-                "utf-8", errors="surrogateescape"
-            )
-            index += 1
-            state[source] = (code, _runner_path_signature(source))
-    return state
-
-
-def _restore_runner_created_paths(
-    before: dict[str, tuple[str, str]],
-) -> None:
-    """Remove only checkout mutations proven to have been created by a runner."""
-    after = _runner_worktree_state()
-    changed = sorted(
-        path for path, state in after.items()
-        if before.get(path) != state
-    )
-    unsafe_overlap = sorted(path for path in changed if path in before)
-    if unsafe_overlap:
-        raise RuntimeError(
-            "runner modified pre-existing worktree changes: "
-            + ", ".join(unsafe_overlap[:5])
-        )
-    for relative in changed:
-        root = REPO_ROOT.resolve()
-        path = Path(os.path.abspath(REPO_ROOT / relative))
         try:
-            path.relative_to(root)
-        except ValueError as exc:
-            raise RuntimeError(
-                f"runner mutation escaped repository: {relative}"
-            ) from exc
-        tracked = subprocess.run(
-            ["git", "ls-files", "--error-unmatch", "--", relative],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            check=False,
-        )
-        if tracked.returncode == 0:
-            restored = subprocess.run(
-                ["git", "restore", "--staged", "--worktree", "--", relative],
-                cwd=REPO_ROOT,
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            if restored.returncode != 0:
-                raise RuntimeError(
-                    f"cannot restore runner-mutated tracked path {relative}: "
-                    f"{(restored.stderr or restored.stdout).strip()[:200]}"
-                )
-        elif path.is_dir() and not path.is_symlink():
-            shutil.rmtree(path)
-        elif path.exists() or path.is_symlink():
-            path.unlink()
-    if _runner_worktree_state() != before:
-        raise RuntimeError(
-            "runner side-effect cleanup did not restore the prior worktree state"
-        )
+            pid, parent = (int(field) for field in fields)
+        except ValueError:
+            continue
+        children.setdefault(parent, set()).add(pid)
+    descendants: set[int] = set()
+    frontier = list(children.get(root_pid, ()))
+    while frontier:
+        pid = frontier.pop()
+        if pid in descendants:
+            continue
+        descendants.add(pid)
+        frontier.extend(children.get(pid, ()))
+    return descendants
+
+
+def _terminate_runner_process_group(
+    process: subprocess.Popen,
+    descendant_pids: set[int] | None = None,
+) -> None:
+    """Best-effort termination for grouped and observed detached descendants."""
+    detached = set(descendant_pids or ())
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    for pid in detached:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        survivors: set[int] = set()
+        for pid in detached:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                continue
+            survivors.add(pid)
+        try:
+            os.killpg(process.pid, 0)
+        except ProcessLookupError:
+            if not survivors:
+                return
+        detached = survivors
+        time.sleep(0.02)
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    for pid in detached:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
 
 
 def _run_repo_runner(
     path: Path,
     timeout_sec: int,
 ) -> subprocess.CompletedProcess:
-    """Execute a runner and restore any checkout side effects it created."""
-    before = _runner_worktree_state()
+    """Execute in a disposable checkout; never repair/delete shared-worktree deltas."""
+    source_root = REPO_ROOT.resolve()
+    source_path = path.resolve()
     try:
-        return subprocess.run(
-            [sys.executable, str(path)],
+        relative_runner = source_path.relative_to(source_root)
+    except ValueError:
+        relative_runner = Path("scripts") / (
+            f"external-audit-runner-{uuid.uuid4().hex}.py"
+        )
+    with tempfile.TemporaryDirectory(prefix="audit-runner-checkout-") as parent:
+        isolated_root = Path(parent) / "checkout"
+        added = subprocess.run(
+            [
+                "git",
+                "worktree",
+                "add",
+                "--detach",
+                "--quiet",
+                str(isolated_root),
+                "HEAD",
+            ],
             cwd=REPO_ROOT,
             capture_output=True,
             text=True,
-            timeout=timeout_sec,
-            env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "scripts")},
+            check=False,
         )
-    finally:
-        _restore_runner_created_paths(before)
+        if added.returncode != 0:
+            raise RuntimeError(
+                "cannot create isolated runner worktree: "
+                f"{(added.stderr or added.stdout).strip()[:240]}"
+            )
+        cleanup_error: str | None = None
+        try:
+            isolated_runner = isolated_root / relative_runner
+            isolated_runner.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                isolated_bytes = isolated_runner.read_bytes()
+            except OSError:
+                isolated_bytes = None
+            source_bytes = source_path.read_bytes()
+            if isolated_bytes != source_bytes:
+                isolated_runner.write_bytes(source_bytes)
+
+            runner_env = {
+                **os.environ,
+                "PYTHONPATH": str(isolated_root / "scripts"),
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "remote.origin.pushurl",
+                "GIT_CONFIG_VALUE_0": "audit-runner-push-disabled://origin",
+                "GIT_OPTIONAL_LOCKS": "0",
+            }
+            with tempfile.TemporaryFile(
+                mode="w+t",
+                encoding="utf-8",
+            ) as stdout_file, tempfile.TemporaryFile(
+                mode="w+t",
+                encoding="utf-8",
+            ) as stderr_file:
+                process = subprocess.Popen(
+                    [sys.executable, str(isolated_runner)],
+                    cwd=isolated_root,
+                    stdout=stdout_file,
+                    stderr=stderr_file,
+                    text=True,
+                    env=runner_env,
+                    start_new_session=True,
+                )
+                observed_descendants: set[int] = set()
+                deadline = time.monotonic() + timeout_sec
+                timed_out = False
+                while process.poll() is None:
+                    observed_descendants.update(
+                        _runner_descendant_pids(process.pid)
+                    )
+                    if time.monotonic() >= deadline:
+                        timed_out = True
+                        break
+                    time.sleep(0.05)
+                _terminate_runner_process_group(
+                    process,
+                    observed_descendants,
+                )
+                try:
+                    process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    _terminate_runner_process_group(
+                        process,
+                        observed_descendants,
+                    )
+                    process.wait()
+                stdout_file.seek(0)
+                stderr_file.seek(0)
+                stdout = stdout_file.read()
+                stderr = stderr_file.read()
+                if timed_out:
+                    raise subprocess.TimeoutExpired(
+                        process.args,
+                        timeout_sec,
+                        output=stdout,
+                        stderr=stderr,
+                    )
+                return subprocess.CompletedProcess(
+                    process.args,
+                    process.returncode,
+                    stdout,
+                    stderr,
+                )
+        finally:
+            removed = subprocess.run(
+                ["git", "worktree", "remove", "--force", str(isolated_root)],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if removed.returncode != 0:
+                shutil.rmtree(isolated_root, ignore_errors=True)
+                subprocess.run(
+                    ["git", "worktree", "prune"],
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    check=False,
+                )
+                if isolated_root.exists():
+                    cleanup_error = (
+                        "cannot discard isolated runner worktree: "
+                        f"{(removed.stderr or removed.stdout).strip()[:240]}"
+                    )
+            if cleanup_error is not None:
+                raise RuntimeError(cleanup_error)
 
 
 def get_runner_stdout(runner_path: str | None, default_timeout_sec: int,
@@ -1951,8 +2234,13 @@ def assert_main_and_clean() -> str | None:
     return None
 
 
-def commit_and_push_to_main(message: str, max_attempts: int = 3) -> tuple[bool, str]:
-    """Stage audit-data files, commit, push to main with rebase-on-conflict retry."""
+def commit_and_push_to_main(message: str) -> tuple[bool, str]:
+    """Commit one validated transaction and reconcile its exact OID.
+
+    An already-applied audit is never rebased onto a parent it was not
+    validated against. A rejected or indeterminate push preserves the local
+    commit for forensic reconciliation and stops the caller.
+    """
     # Stage every audit-data path that exists
     paths = [p for p in AUDIT_DATA_FILES if (REPO_ROOT / p).exists()]
     add = git("add", *paths, check=False)
@@ -1964,17 +2252,149 @@ def commit_and_push_to_main(message: str, max_attempts: int = 3) -> tuple[bool, 
     commit = git("commit", "-m", message, check=False)
     if commit.returncode != 0:
         return False, f"git commit failed: {(commit.stderr or commit.stdout).strip()[:200]}"
-    for attempt in range(1, max_attempts + 1):
-        push = git("push", "origin", "main", check=False)
-        if push.returncode == 0:
-            return True, f"pushed (attempt {attempt})"
-        # Try fetch + rebase
-        git("fetch", "origin", "main", check=False)
-        rebase = git("rebase", "origin/main", check=False)
-        if rebase.returncode != 0:
-            git("rebase", "--abort", check=False)
-            return False, f"push attempt {attempt} failed and rebase conflicted: {(push.stderr or push.stdout).strip()[:200]}"
-    return False, f"push failed after {max_attempts} attempts"
+    resolved = git("rev-parse", "HEAD", check=False)
+    local_commit = resolved.stdout.strip()
+    if resolved.returncode != 0 or not re.fullmatch(r"[0-9a-f]{40}", local_commit):
+        return False, "commit created but its intended OID cannot be resolved"
+    push = git("push", "origin", "main", check=False)
+    if push.returncode == 0:
+        return True, f"pushed {local_commit}"
+    fetch = git("fetch", "origin", "main", check=False)
+    if fetch.returncode != 0:
+        return False, (
+            f"push state unknown for intended commit {local_commit}; "
+            "follow-up fetch failed; local commit preserved"
+        )
+    landed = git(
+        "merge-base",
+        "--is-ancestor",
+        local_commit,
+        "origin/main",
+        check=False,
+    )
+    if landed.returncode == 0:
+        return True, f"push response failed but {local_commit} is on origin/main"
+    if landed.returncode == 1:
+        return False, (
+            f"push rejected for intended commit {local_commit}; canonical main "
+            "moved; local commit preserved and must not be rebased"
+        )
+    return False, (
+        f"push state unknown for intended commit {local_commit}; ancestry "
+        "reconciliation failed; local commit preserved"
+    )
+
+
+def audit_delivery_precondition(
+    row: dict,
+    *,
+    source: str | None,
+    expected_packet_fingerprint: str,
+    expected_selection_fingerprint: str,
+    expected_role: str,
+    expected_independence: str,
+    auditor_family: str,
+) -> tuple[bool, str, str]:
+    """Refresh remote state and reject a forensic delivery selected on old inputs."""
+    fetch = git("fetch", "origin", "main", check=False)
+    if fetch.returncode != 0:
+        return (
+            False,
+            "source_refresh_failed",
+            f"cannot fetch origin/main: {(fetch.stderr or fetch.stdout).strip()[:240]}",
+        )
+    head = git("rev-parse", "HEAD", check=False)
+    remote = git("rev-parse", "origin/main", check=False)
+    if head.returncode != 0 or remote.returncode != 0:
+        return False, "source_refresh_failed", "cannot resolve local/remote main"
+    if head.stdout.strip() != remote.stdout.strip():
+        return (
+            False,
+            "remote_state_superseded",
+            "origin/main moved while the restricted forensic seat was running",
+        )
+
+    try:
+        current_rows = load_ledger_rows()
+        if source == "dispatch":
+            current_source_rows = load_dispatch_targets(
+                current_rows,
+                ready_only=True,
+                selected_claim_ids={str(row.get("claim_id") or "")},
+                limit=None,
+            )
+        elif source == "reaudit":
+            current_source_rows = load_reaudit_candidates(
+                ledger_rows=current_rows
+            )
+        elif source is None:
+            current_source_rows = load_queue(
+                criticality_filter=None,
+                ready_only=False,
+            )
+        else:
+            return (
+                False,
+                "source_refresh_failed",
+                f"unknown audit selection source {source!r}",
+            )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return (
+            False,
+            "source_refresh_failed",
+            f"cannot authenticate current {source or 'queue'} source: {exc}",
+        )
+
+    cid = str(row.get("claim_id") or "")
+    current_row = next(
+        (
+            candidate
+            for candidate in current_source_rows
+            if candidate.get("claim_id") == cid
+        ),
+        None,
+    )
+    current_ledger_row = current_rows.get(cid)
+    if not isinstance(current_row, dict) or not isinstance(current_ledger_row, dict):
+        return (
+            False,
+            "remote_state_superseded",
+            "the claim is no longer present in its current authenticated source",
+        )
+    current_role, current_independence = determine_audit_role(
+        current_ledger_row,
+        auditor_family,
+        is_reaudit_candidate=source in {"dispatch", "reaudit"},
+        is_dispatch_target=source == "dispatch",
+    )
+    if (current_role, current_independence) != (
+        expected_role,
+        expected_independence,
+    ):
+        return (
+            False,
+            "remote_state_superseded",
+            "seat role or independence changed while the forensic seat was running",
+        )
+    if audit_selection_fingerprint(current_row) != expected_selection_fingerprint:
+        return (
+            False,
+            "remote_state_superseded",
+            "the queue/dispatch/re-audit selection record changed while the "
+            "forensic seat was running",
+        )
+    current_packet_fingerprint = audit_packet_source_fingerprint(
+        current_row,
+        current_rows,
+    )
+    if current_packet_fingerprint != expected_packet_fingerprint:
+        return (
+            False,
+            "remote_state_superseded",
+            "claim, dependency, governed context, runner input, or packet policy "
+            "changed while the forensic seat was running",
+        )
+    return True, "current", head.stdout.strip()
 
 
 CODEX_RESPONSE_RE = re.compile(
@@ -3070,6 +3490,7 @@ def main() -> int:
         queue = load_reaudit_candidates(
             args.criticality,
             include_runner_drift=not args.no_runner_drift_candidates,
+            ledger_rows=ledger_rows,
         )
     else:
         queue = load_queue(args.criticality, ready_only=not args.allow_blocked)
@@ -3300,6 +3721,13 @@ def main() -> int:
                     f"{transport_bound['prompt_chars_after']} chars; "
                     f"{transport_disposition}"
                 )
+
+            delivery_packet_fingerprint = audit_packet_source_fingerprint(
+                row,
+                ledger_rows,
+                exact_evidence_manifest,
+            )
+            delivery_selection_fingerprint = audit_selection_fingerprint(row)
 
             if args.dry_run:
                 print(f"  [dry-run] prompt size: {len(prompt)} chars")
@@ -3776,6 +4204,42 @@ def main() -> int:
                 auditor_model=audit_model,
                 auditor_reasoning_effort=reasoning_effort,
             )
+            if args.push_mode != "none":
+                selection_source = (
+                    "dispatch"
+                    if args.from_dispatch
+                    else "reaudit"
+                    if args.from_reaudit_candidates
+                    else None
+                )
+                current, precondition_result, precondition_detail = (
+                    audit_delivery_precondition(
+                        row,
+                        source=selection_source,
+                        expected_packet_fingerprint=delivery_packet_fingerprint,
+                        expected_selection_fingerprint=(
+                            delivery_selection_fingerprint
+                        ),
+                        expected_role=role,
+                        expected_independence=row_independence,
+                        auditor_family=auditor_family,
+                    )
+                )
+                if not current:
+                    print(
+                        f"  {precondition_result}: {precondition_detail}"
+                    )
+                    with run_log.open("a", encoding="utf-8") as f:
+                        f.write(json.dumps({
+                            "claim_id": cid,
+                            "phase": precondition_result,
+                            "reason": precondition_detail,
+                        }) + "\n")
+                    if precondition_result == "remote_state_superseded":
+                        skipped += 1
+                    else:
+                        failed += 1
+                    continue
             ok, msg = apply_one(
                 full_blob,
                 propagate=not args.no_propagate,

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -37,6 +37,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -1090,6 +1091,136 @@ def find_cached_runner_output(runner_path: str) -> str | None:
     return rc.cache_excerpt_for_audit(runner_path)
 
 
+def _runner_path_signature(relative: str) -> str:
+    path = REPO_ROOT / relative
+    try:
+        info = path.lstat()
+    except OSError:
+        return "<missing>"
+    if path.is_symlink():
+        try:
+            return f"symlink:{os.readlink(path)}"
+        except OSError:
+            return "symlink:<unreadable>"
+    if path.is_file():
+        try:
+            return "file:" + hashlib.sha256(path.read_bytes()).hexdigest()
+        except OSError:
+            return "file:<unreadable>"
+    return f"mode:{stat.S_IFMT(info.st_mode):o}:size:{info.st_size}"
+
+
+def _runner_worktree_state() -> dict[str, tuple[str, str]]:
+    """Return path -> (porcelain status, content identity) for dirty paths."""
+    result = subprocess.run(
+        [
+            "git", "status", "--porcelain=v1", "-z",
+            "--untracked-files=all",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("cannot snapshot worktree around runner execution")
+    records = result.stdout.split(b"\0")
+    state: dict[str, tuple[str, str]] = {}
+    index = 0
+    while index < len(records):
+        record = records[index]
+        index += 1
+        if not record:
+            continue
+        if len(record) < 4:
+            raise RuntimeError("malformed git status record around runner execution")
+        code = record[:2].decode("ascii", errors="replace")
+        path = record[3:].decode("utf-8", errors="surrogateescape")
+        state[path] = (code, _runner_path_signature(path))
+        if "R" in code or "C" in code:
+            if index >= len(records) or not records[index]:
+                raise RuntimeError(
+                    "malformed rename status around runner execution"
+                )
+            source = records[index].decode(
+                "utf-8", errors="surrogateescape"
+            )
+            index += 1
+            state[source] = (code, _runner_path_signature(source))
+    return state
+
+
+def _restore_runner_created_paths(
+    before: dict[str, tuple[str, str]],
+) -> None:
+    """Remove only checkout mutations proven to have been created by a runner."""
+    after = _runner_worktree_state()
+    changed = sorted(
+        path for path, state in after.items()
+        if before.get(path) != state
+    )
+    unsafe_overlap = sorted(path for path in changed if path in before)
+    if unsafe_overlap:
+        raise RuntimeError(
+            "runner modified pre-existing worktree changes: "
+            + ", ".join(unsafe_overlap[:5])
+        )
+    for relative in changed:
+        root = REPO_ROOT.resolve()
+        path = Path(os.path.abspath(REPO_ROOT / relative))
+        try:
+            path.relative_to(root)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"runner mutation escaped repository: {relative}"
+            ) from exc
+        tracked = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", "--", relative],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=False,
+        )
+        if tracked.returncode == 0:
+            restored = subprocess.run(
+                ["git", "restore", "--staged", "--worktree", "--", relative],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if restored.returncode != 0:
+                raise RuntimeError(
+                    f"cannot restore runner-mutated tracked path {relative}: "
+                    f"{(restored.stderr or restored.stdout).strip()[:200]}"
+                )
+        elif path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path)
+        elif path.exists() or path.is_symlink():
+            path.unlink()
+    if _runner_worktree_state() != before:
+        raise RuntimeError(
+            "runner side-effect cleanup did not restore the prior worktree state"
+        )
+
+
+def _run_repo_runner(
+    path: Path,
+    timeout_sec: int,
+) -> subprocess.CompletedProcess:
+    """Execute a runner and restore any checkout side effects it created."""
+    before = _runner_worktree_state()
+    try:
+        return subprocess.run(
+            [sys.executable, str(path)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=timeout_sec,
+            env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "scripts")},
+        )
+    finally:
+        _restore_runner_created_paths(before)
+
+
 def get_runner_stdout(runner_path: str | None, default_timeout_sec: int,
                       use_cache: bool = False) -> str:
     """Get runner output, live by default.
@@ -1111,14 +1242,7 @@ def get_runner_stdout(runner_path: str | None, default_timeout_sec: int,
         return f"[runner missing on disk: {runner_path}]"
     timeout_sec = runner_timeout_for(runner_path, default_timeout_sec)
     try:
-        res = subprocess.run(
-            [sys.executable, str(p)],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            text=True,
-            timeout=timeout_sec,
-            env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "scripts")},
-        )
+        res = _run_repo_runner(p, timeout_sec)
         if res.returncode != 0:
             return f"[runner exit={res.returncode}]\n{res.stdout[-3000:]}\n--- stderr ---\n{res.stderr[-1500:]}"
         if len(res.stdout) > 6000:
@@ -1171,14 +1295,7 @@ def get_independent_runner_stdout(
     runner_path, path = local_runner
     timeout_sec = runner_timeout_for(runner_path, default_timeout_sec)
     try:
-        result = subprocess.run(
-            [sys.executable, str(path)],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            text=True,
-            timeout=timeout_sec,
-            env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "scripts")},
-        )
+        result = _run_repo_runner(path, timeout_sec)
         if result.returncode != 0:
             return (
                 f"[runner exit={result.returncode}]\n"

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -1295,77 +1295,129 @@ def audit_selection_fingerprint(row: dict) -> str:
     ).hexdigest()
 
 
-def _runner_descendant_pids(root_pid: int) -> set[int]:
-    """Snapshot recursive descendants before they can orphan via setsid()."""
+AUDIT_RUNNER_PROCESS_TOKEN_ENV = "CODEX_AUDIT_RUNNER_PROCESS_TOKEN"
+SANDBOX_EXEC_PATH = Path("/usr/bin/sandbox-exec")
+
+
+def _runner_process_has_token(pid: int, token: str) -> bool:
+    """Revalidate a runner-owned process immediately before signaling it."""
+    marker = f"{AUDIT_RUNNER_PROCESS_TOKEN_ENV}={token}"
+    proc_environ = Path("/proc") / str(pid) / "environ"
+    if proc_environ.exists():
+        try:
+            return marker.encode("utf-8") in proc_environ.read_bytes().split(b"\0")
+        except FileNotFoundError:
+            return False
+        except OSError as exc:
+            raise RuntimeError(
+                f"cannot revalidate runner process identity for PID {pid}"
+            ) from exc
     result = subprocess.run(
-        ["ps", "-axo", "pid=,ppid="],
+        ["ps", "eww", "-p", str(pid), "-o", "command="],
         capture_output=True,
         text=True,
         check=False,
     )
     if result.returncode != 0:
-        return set()
-    children: dict[int, set[int]] = {}
+        return False
+    return marker in result.stdout.split()
+
+
+def _runner_token_processes(token: str) -> set[int]:
+    """Find live processes carrying this invocation's unguessable token."""
+    marker = f"{AUDIT_RUNNER_PROCESS_TOKEN_ENV}={token}"
+    proc_root = Path("/proc")
+    if proc_root.is_dir():
+        owned: set[int] = set()
+        try:
+            candidates = tuple(proc_root.iterdir())
+        except OSError as exc:
+            raise RuntimeError(
+                "cannot enumerate token-bound runner processes"
+            ) from exc
+        for candidate in candidates:
+            if not candidate.name.isdigit():
+                continue
+            pid = int(candidate.name)
+            if pid != os.getpid() and _runner_process_has_token(pid, token):
+                owned.add(pid)
+        return owned
+
+    result = subprocess.run(
+        ["ps", "eww", "-axo", "pid=,command="],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("cannot enumerate token-bound runner processes")
+    owned: set[int] = set()
     for line in result.stdout.splitlines():
-        fields = line.split()
-        if len(fields) != 2:
+        fields = line.strip().split(maxsplit=1)
+        if len(fields) != 2 or marker not in fields[1].split():
             continue
         try:
-            pid, parent = (int(field) for field in fields)
+            pid = int(fields[0])
         except ValueError:
             continue
-        children.setdefault(parent, set()).add(pid)
-    descendants: set[int] = set()
-    frontier = list(children.get(root_pid, ()))
-    while frontier:
-        pid = frontier.pop()
-        if pid in descendants:
+        if pid != os.getpid():
+            owned.add(pid)
+    return owned
+
+
+def _signal_runner_token_processes(token: str, sig: int) -> set[int]:
+    """Signal only PIDs whose process identity still carries this token."""
+    signaled: set[int] = set()
+    for pid in _runner_token_processes(token):
+        if not _runner_process_has_token(pid, token):
             continue
-        descendants.add(pid)
-        frontier.extend(children.get(pid, ()))
-    return descendants
-
-
-def _terminate_runner_process_group(
-    process: subprocess.Popen,
-    descendant_pids: set[int] | None = None,
-) -> None:
-    """Best-effort termination for grouped and observed detached descendants."""
-    detached = set(descendant_pids or ())
-    try:
-        os.killpg(process.pid, signal.SIGTERM)
-    except ProcessLookupError:
-        pass
-    for pid in detached:
         try:
-            os.kill(pid, signal.SIGTERM)
+            os.kill(pid, sig)
         except ProcessLookupError:
-            pass
+            continue
+        signaled.add(pid)
+    return signaled
+
+
+def _terminate_runner_process_tree(
+    process: subprocess.Popen,
+    token: str,
+) -> None:
+    """Terminate token-bound descendants without remembered bare PIDs."""
+    _signal_runner_token_processes(token, signal.SIGTERM)
+
     deadline = time.monotonic() + 1.0
     while time.monotonic() < deadline:
-        survivors: set[int] = set()
-        for pid in detached:
-            try:
-                os.kill(pid, 0)
-            except ProcessLookupError:
-                continue
-            survivors.add(pid)
-        try:
-            os.killpg(process.pid, 0)
-        except ProcessLookupError:
-            if not survivors:
-                return
-        detached = survivors
+        remaining = _runner_token_processes(token)
+        if not remaining and process.poll() is not None:
+            return
+        _signal_runner_token_processes(token, signal.SIGTERM)
         time.sleep(0.02)
-    try:
-        os.killpg(process.pid, signal.SIGKILL)
-    except ProcessLookupError:
-        pass
-    for pid in detached:
-        try:
-            os.kill(pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
+
+    _signal_runner_token_processes(token, signal.SIGKILL)
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        remaining = _runner_token_processes(token)
+        if not remaining and process.poll() is not None:
+            return
+        _signal_runner_token_processes(token, signal.SIGKILL)
+        time.sleep(0.02)
+    raise RuntimeError(
+        "token-bound runner descendants survived TERM/KILL containment"
+    )
+
+
+def _runner_command(isolated_runner: Path, source_root: Path) -> list[str]:
+    """Apply kernel write containment when the host provides sandbox-exec."""
+    command = [sys.executable, str(isolated_runner)]
+    if not SANDBOX_EXEC_PATH.exists():
+        return command
+    escaped_root = str(source_root).replace("\\", "\\\\").replace('"', '\\"')
+    profile = (
+        "(version 1) (allow default) "
+        f'(deny file-write* (subpath "{escaped_root}"))'
+    )
+    return [str(SANDBOX_EXEC_PATH), "-p", profile, *command]
 
 
 def _run_repo_runner(
@@ -1415,6 +1467,7 @@ def _run_repo_runner(
             if isolated_bytes != source_bytes:
                 isolated_runner.write_bytes(source_bytes)
 
+            runner_token = uuid.uuid4().hex
             runner_env = {
                 **os.environ,
                 "PYTHONPATH": str(isolated_root / "scripts"),
@@ -1422,6 +1475,7 @@ def _run_repo_runner(
                 "GIT_CONFIG_KEY_0": "remote.origin.pushurl",
                 "GIT_CONFIG_VALUE_0": "audit-runner-push-disabled://origin",
                 "GIT_OPTIONAL_LOCKS": "0",
+                AUDIT_RUNNER_PROCESS_TOKEN_ENV: runner_token,
             }
             with tempfile.TemporaryFile(
                 mode="w+t",
@@ -1431,7 +1485,7 @@ def _run_repo_runner(
                 encoding="utf-8",
             ) as stderr_file:
                 process = subprocess.Popen(
-                    [sys.executable, str(isolated_runner)],
+                    _runner_command(isolated_runner, source_root),
                     cwd=isolated_root,
                     stdout=stdout_file,
                     stderr=stderr_file,
@@ -1439,29 +1493,35 @@ def _run_repo_runner(
                     env=runner_env,
                     start_new_session=True,
                 )
-                observed_descendants: set[int] = set()
                 deadline = time.monotonic() + timeout_sec
                 timed_out = False
-                while process.poll() is None:
-                    observed_descendants.update(
-                        _runner_descendant_pids(process.pid)
-                    )
-                    if time.monotonic() >= deadline:
-                        timed_out = True
-                        break
-                    time.sleep(0.05)
-                _terminate_runner_process_group(
-                    process,
-                    observed_descendants,
-                )
                 try:
-                    process.wait(timeout=2)
-                except subprocess.TimeoutExpired:
-                    _terminate_runner_process_group(
-                        process,
-                        observed_descendants,
-                    )
-                    process.wait()
+                    while process.poll() is None:
+                        if time.monotonic() >= deadline:
+                            timed_out = True
+                            break
+                        time.sleep(0.05)
+                finally:
+                    containment_error: BaseException | None = None
+                    try:
+                        _terminate_runner_process_tree(
+                            process,
+                            runner_token,
+                        )
+                    except BaseException as exc:
+                        containment_error = exc
+                    try:
+                        process.wait(timeout=2)
+                    except subprocess.TimeoutExpired as exc:
+                        if containment_error is None:
+                            containment_error = RuntimeError(
+                                "direct runner process survived containment"
+                            )
+                        containment_error.add_note(
+                            f"direct process wait timed out: {exc}"
+                        )
+                    if containment_error is not None:
+                        raise containment_error
                 stdout_file.seek(0)
                 stderr_file.seek(0)
                 stdout = stdout_file.read()


### PR DESCRIPTION
## What changed

- drain authenticated dispatch, cascade re-audit, flagship, global development, panel, and serial forensic sources to a real fixed point
- support independent employee/account clones with complete target sets, stable worker-specific rotation, and no abandoned shards
- authenticate cascade caches against pure current-state recomputation and bind restricted deliveries to full ledger/dependency bytes, governed packet sources, role, independence, passes, and alternate-source provenance
- reject stale forensic delivery before apply; never rebase an already-applied verdict onto changed authority state
- reconcile the exact intended commit after uncertain pushes, preserving it and hard-stopping when remote state cannot be proven
- count quarantine-only exclusion growth as operational progress so later unrelated rows are not stranded
- execute primary/helper runners in disposable worktrees; use per-invocation process identity with immediate revalidation before signals, plus macOS kernel write containment for the canonical checkout

## Review fixes

Independent round-one review found six defects, including a blocking stale-forensic rebase path; the orchestrator additionally found a quarantine-only fixed-point defect. Iteration 1 closed source freshness, packet provenance, cache authentication, uncertain-push, and liveness findings. A first confirmation correctly rejected best-effort descendant sampling and reusable bare PIDs. Iteration 2 replaced that design with token-bound enumeration and identity revalidation, added kernel checkout-write containment on macOS, and added normal, five-attempt immediate-child, identity-change, timeout, interruption, runner-error, sandbox, and cleanup-fallback regressions.

Independent confirmation on reviewed head `a8f016153e5efa65116eca17b4149b0562bf46a4`: **PASS**.

## Scientific integrity

No audit verdict, source claim, retained-grade status, or publication artifact is changed. Restricted-context, xhigh model, math-audit, N1-N8, apply, pipeline, strict-lint, one-claim transaction, and judicial-panel gates remain in force. Remote movement causes supersession, never authority.

## Validation

- affected unit suite: 140 tests passed
- runner lifecycle confirmation suite: 7 tests passed; five-attempt immediate-child regression passed
- full `docs/audit/scripts/run_pipeline.sh` passed on the reviewed head
- strict audit lint passed with no errors
- link-enforced repository invariants passed (`3856` rows, `429` retained-grade, acknowledged graph delta)
- audit-loop skill validation and vocabulary lint passed
- Python compilation, portable-link scan, pipeline-output-stripped gate, and `git diff --check` passed
- generated audit outputs are excluded; only `docs/audit/data/citation_graph_manifest.json` is retained as the required graph acknowledgment
