### PR TITLE
Science repair: expose complete admission-port runner to audit

### DIFF
--- a/logs/runner-cache/proper_cubic_local_admission_relations_conditional_port_finite_grade_block_2026_07_23.txt
+++ b/logs/runner-cache/proper_cubic_local_admission_relations_conditional_port_finite_grade_block_2026_07_23.txt
@@ -1,10 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/proper_cubic_local_admission_relations_conditional_port_finite_grade_block_2026_07_23.py
-runner_sha256: 44621b28503d216112a60bba1adb3580e4833693d9708269ee2eae926a3480ed
+runner_sha256: 79f02cc24cf5ec6949a674494c33158871fd208c85a1c9e8a05f64ddb50aa63f
 input_fingerprint_sha256: a1956ea444f0e450c5a5cdecc204db4b05346795319de4b462c25759409b80b0
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 1.57
+elapsed_sec: 1.58
 status: ok
 ----- stdout -----
 FINITE ADMISSION / CONDITIONAL PORT / GRADE SUBSTRATE CERTIFICATE

--- a/outputs/proper_cubic_local_admission_relations_conditional_port_finite_grade_block_receipt_2026_07_23.json
+++ b/outputs/proper_cubic_local_admission_relations_conditional_port_finite_grade_block_receipt_2026_07_23.json
@@ -502,7 +502,7 @@
     "totality_failures": 0,
     "train_words": 42
   },
-  "runner_sha256": "44621b28503d216112a60bba1adb3580e4833693d9708269ee2eae926a3480ed",
+  "runner_sha256": "79f02cc24cf5ec6949a674494c33158871fd208c85a1c9e8a05f64ddb50aa63f",
   "supplied_structure": [
     "six directed nearest-neighbor labels and their opposite pairing",
     "five static accepted-shell sets defining five candidate relations",

--- a/scripts/proper_cubic_local_admission_relations_conditional_port_finite_grade_block_2026_07_23.py
+++ b/scripts/proper_cubic_local_admission_relations_conditional_port_finite_grade_block_2026_07_23.py
@@ -1,24 +1,11 @@
 #!/usr/bin/env python3
-"""Dependency-clean finite admission/port/grade substrate certificate.
+"""Dependency-clean certificate for the note's three bounded finite claims.
 
-This runner reconstructs, without campaign-module imports, the exact finite
-content needed for three deliberately narrow statements:
-
-1. five displayed radius-one, proper-cubic-invariant Boolean relations on a
-   six-direction word are total, nonconstant, and pairwise extensionally
-   distinct;
-2. unique quorum feeds one explicit conditional port, followed by a supplied
-   finite lock/readout preservation algebra;
-3. one supplied endpoint-to-unary calibration feeds a finite denominator-64
-   grade block.
-
-The runner derives no actuality or framework-Record identification.  The
-finite grade and its complete-block count identity supply no probability,
-Born-calibration, corpus, or realized-history bridge.  Physical M2 compilation
-and formation-law selection are outside the proved finite scope.
-
-The implementation is Python-standard-library only.  It does not invoke git,
-subprocesses, a network, archived objects, or another runner.
+It verifies the five proper-cubic relations, the supplied unique-quorum
+port/LOCK algebra, and the supplied denominator-64 grade block.  It derives no
+selection, actuality, Record, Born/history, or physical-M2 bridge.  The runner
+uses only the Python standard library and no external process, network, or
+archived object.
 """
 
 from __future__ import annotations
@@ -74,9 +61,7 @@ def digest(path: Path) -> str:
     return sha256(path.read_bytes()).hexdigest()
 
 
-# ---------------------------------------------------------------------------
 # Proper-cubic action on the six directed nearest-neighbor labels.
-# ---------------------------------------------------------------------------
 Vector = tuple[int, int, int]
 Matrix = tuple[Vector, Vector, Vector]
 DIRECTIONS: tuple[Vector, ...] = (
@@ -172,9 +157,7 @@ def frame_certificate() -> dict[str, object]:
     return result
 
 
-# ---------------------------------------------------------------------------
 # Five explicit local admission relations and exact model separation.
-# ---------------------------------------------------------------------------
 RULES: dict[str, frozenset[int]] = {
     "unique_quorum": frozenset((1,)),
     "odd_shells": frozenset((1, 3, 5)),
@@ -311,9 +294,7 @@ def relation_certificate() -> dict[str, object]:
     return result
 
 
-# ---------------------------------------------------------------------------
 # Unique-quorum conditional port.
-# ---------------------------------------------------------------------------
 @dataclass(frozen=True)
 class ConditionalPort:
     archive6: tuple[int, ...]
@@ -465,9 +446,7 @@ def conditional_port_certificate() -> dict[str, object]:
     return result
 
 
-# ---------------------------------------------------------------------------
 # Supplied finite lock/readout algebra.
-# ---------------------------------------------------------------------------
 @dataclass(frozen=True)
 class LockedPortState:
     payload: tuple[int, ...]
@@ -583,9 +562,7 @@ def finite_preservation_certificate() -> dict[str, object]:
     return result
 
 
-# ---------------------------------------------------------------------------
 # Endpoint-derived denominator-64 finite grade block.
-# ---------------------------------------------------------------------------
 def axis_occupancies(word: tuple[int, ...]) -> tuple[int, int, int]:
     validate_six_word(word)
     return word[0] + word[1], word[2] + word[3], word[4] + word[5]
@@ -840,9 +817,7 @@ def finite_grade_certificate() -> dict[str, object]:
     return result
 
 
-# ---------------------------------------------------------------------------
 # Clean-clone/dependency and source-note controls.
-# ---------------------------------------------------------------------------
 def dependency_closure_certificate() -> dict[str, object]:
     source = Path(__file__).read_text()
     tree = ast.parse(source)


### PR DESCRIPTION
## Scope

Repairs the restricted-packet completeness defect found by the independent audit of the finite proper-cubic admission/port/grade package. The primary runner is reduced from 40,456 to 38,905 UTF-8 bytes, below the packet builder's 40,000-character limit.

## Scientific invariance

Only the module docstring and decorative comment separators changed. The executable AST is identical. The note, claim scope, authority, audit field, formulas, tests, and receipt content are unchanged except for the runner SHA. This is audit accessibility, not a scientific promotion.

## Verification

- reconstructed real audit prompt contains the full runner exactly once, with no truncation marker
- extracted source SHA matches the runner SHA exactly
- runner 6 PASS / 0 FAIL; cached stdout unchanged
- receipt JSON identical after removing runner_sha256
- cache fresh with unchanged input fingerprint
- full pipeline and strict lint pass; the only expected invalidation is this row's runner-hash change
- generated audit/status outputs stripped

## Audit repair target (verbatim)

> runner_artifact_issue: regenerate the restricted packet with the complete SHA-matched scripts/proper_cubic_local_admission_relations_conditional_port_finite_grade_block_2026_07_23.py source, then independently re-check all load-bearing formulas and exhaustive counts.