### PR TITLE
Simplify distributed audit draining to optimistic workers

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -209,7 +209,6 @@ default session is:
 2. Launch the panel-aware top-level drainer:
 
    ```bash
-   AUDIT_WORKER_ID=<unique-coordinator-id> \
    python3 docs/audit/scripts/orchestrate_audit_loop.py --max-workers 4
    ```
 
@@ -220,11 +219,14 @@ default session is:
    resume after the panel lands, then advance the forensic source one
    validated row at a time. Every landed forensic result returns through the
    development phases because it may unblock dependencies. Raise toward 6
-   workers only in a quiet pool per the budget below. The supervisor
-   holds the clone-wide audit lock for the complete campaign and hands that
-   lock to its batch/panel children. It runs the panel sweep after every batch
-   termination before propagating any unrelated hard batch failure, so a mixed
-   result cannot strand a valid judicial handoff.
+   workers only in a quiet pool per the budget below. The drainer generates a
+   unique session id when `AUDIT_WORKER_ID` / `--worker-id` is omitted. The id
+   is only an ordering hint: it disperses independent clones across the queue
+   without assigning an exclusive shard. The supervisor holds the clone-wide
+   audit lock for the complete campaign and hands that lock to its batch/panel
+   children. It runs the panel sweep after every batch termination before
+   propagating any unrelated hard batch failure, so a mixed result cannot
+   strand a valid judicial handoff.
    Keep the printed campaign artifact directory. It is the durable operational
    record for schema, compute, blocked-reentry, and safely rolled-back
    transaction exclusions; it does not carry scientific authority.
@@ -240,12 +242,14 @@ default session is:
    has blocking rows.
 
 When multiple employees or Codex accounts participate, read and follow
-[`references/distributed-drain.md`](references/distributed-drain.md). There is
-one coordinator; every other independent clone runs
-`--development-helper --worker-id <globally-unique-id>`. A helper's exit is
-local information, never global completion. The concurrent-wave coordinator
-uses `--skip-forensic-canary`; after every helper quiesces, one fresh
-coordinator-only campaign runs without that flag and owns final completion.
+[`references/distributed-drain.md`](references/distributed-drain.md). Every
+employee runs the same command from a separate clean clone. There is no leader,
+helper role, global lease, campaign ref, or terminal completion record.
+Independent workers may duplicate computation; immediately before apply, the
+existing current-main provenance check discards stale deliveries, and only a
+fast-forward transaction may land. Each zero-work exit is a worker-local
+observation, never a global certification. Confirm the backlog from a fresh
+canonical status/pipeline read after all visible workers have quiesced.
 
 Do not detach `orchestrate_audit_batch.py` as the whole `/audit-loop`
 campaign. A batch is one inner development-tier step and intentionally yields
@@ -365,17 +369,20 @@ If the product surface supports a persistent goal, use it as a watchdog around
 the detached canonical drainer, not as a replacement for the drainer. The goal
 is: keep one clean independent-main campaign running or canonically resumed;
 preserve every Nature-grade gate; continue through claim-local quarantines; and
-stop only at a genuine backlog fixed point, credit exhaustion, or a verified
-global integrity/tooling blocker. A goal cannot repair a nonzero pipeline or
-supervisor exit by itself.
+after a worker-local fixed point, refresh current `main` and run the same
+command again whenever canonical status still exposes work. Stop only after a
+fresh post-quiescence status confirms a genuine backlog fixed point, credit
+exhaustion, or a verified global integrity/tooling blocker. A goal cannot
+repair a nonzero pipeline or supervisor exit by itself.
 
-## Scaling: Canonical Fan-Out And Distributed Helpers
+## Scaling: Canonical Fan-Out And Optimistic Workers
 
 There is exactly one sanctioned audit machinery: the repo-native batch
 drainer, invoked directly for a scoped inner step or by the top-level
-panel-aware orchestrator. Across independent employee clones, use only the
-top-level coordinator/helper contract in
-[`references/distributed-drain.md`](references/distributed-drain.md):
+panel-aware orchestrator. Across independent employee clones, run the same
+top-level command described in
+[`references/distributed-drain.md`](references/distributed-drain.md). The
+scoped inner batch remains available for diagnosis or a named claim/lane:
 
 ```bash
 python3 docs/audit/scripts/orchestrate_audit_batch.py \
@@ -401,14 +408,16 @@ python3 docs/audit/scripts/orchestrate_audit_batch.py \
   checkout; parallelism lives in the auditor seats only.
 - **Cross-clone seats are optimistic, not authority-racing.** A stable unique
   worker id rotates each criticality tier while retaining the complete target
-  set, so helpers start in different places without creating abandoned
-  shards. Immediately before apply, the drainer refreshes `origin/main` and
-  binds the delivery to the complete ledger provenance, exact packet evidence
-  manifest, dependency note bytes, runner/helper declared inputs, computed
+  set, so workers start in different places without creating abandoned shards.
+  The top-level drainer generates a unique id when none is supplied.
+  Immediately before apply, the drainer refreshes `origin/main` and binds the
+  delivery to the complete ledger provenance, exact packet evidence manifest,
+  dependency note bytes, runner/helper declared inputs, computed
   role/independence/passes, and any dispatch/cascade entry that selected it.
   The cascade cache must exactly equal a pure recomputation from the current
   ledger and runner bytes. Remote movement supersedes the stale delivery
-  without applying or quarantining it.
+  without applying or quarantining it. Duplicate computation is acceptable;
+  duplicate scientific state is not.
 - **Live runners never repair a shared checkout.** Execute each primary/helper
   runner in a disposable isolated worktree and capture stdout/stderr. Bind the
   runner and every inherited child to an unguessable invocation token; on
@@ -431,13 +440,14 @@ python3 docs/audit/scripts/orchestrate_audit_batch.py \
   non-batch-auditable claim types, and forensic-shaped sources at selection;
   do not force them in via `--claims`.
 
-**Forensic tier scales serially, not by fan-out.** Run exactly ONE
-forensic-tier row at a time until its N1-N8 packet has landed end-to-end
-through validation and apply; record every validator rejection verbatim
-(they are repair evidence for the packet/validator path, not noise). Only
-after a canary lands may the forensic lane run more than one seat, and never
-more than two. Parallelizing a failing forensic path multiplies model burn
-with zero landings.
+**Forensic tier is serial inside each worker, optimistic across clones.** Each
+top-level worker advances at most one forensic row at a time and records every
+validator rejection verbatim (it is repair evidence for the packet/validator
+path, not noise). Different clones may select the same row. The same
+current-main delivery precondition and push-race reconciliation apply: one
+current transaction can land, and a stale duplicate is discarded. Do not add
+intra-clone forensic fan-out; duplicate cross-clone attempts cost compute but
+do not weaken the N1-N8 packet or apply gates.
 
 The canary gets the bounded three-seat fresh-schema budget because distinct
 packet-completion defects can surface serially (for example, an N1 route-class
@@ -471,15 +481,14 @@ failure exits nonzero.
 
 **Parallel coexistence with review-loop.** The audit lane and review-loop
 sessions may run at the same time by design; the rules that keep concurrent
-landings cheap are: (1) exactly ONE audit-lane orchestrator per clone and
-exactly ONE coordinator globally — other independent clones use named
-development-helper mode —
-the drainer and the panel orchestrator enforce this with a machine-local
-exclusive lock keyed to the clone's git common directory, so every worktree
-of that clone shares one lock, and a second instance exits with guidance
-(an INDEPENDENT clone has its own lock, and cross-clone coordination stays
-with the coordinator/helper contract, remote-state preconditions, and the
-concurrency budget, not the lock); (2) audit
+landings cheap are: (1) exactly ONE audit-lane orchestrator per clone; every
+independent clone may run the same top-level command. The drainer and panel
+orchestrator enforce the per-clone boundary with a machine-local exclusive
+lock keyed to the clone's git common directory, so every worktree of that
+clone shares one lock and a second instance exits with guidance. Cross-clone
+safety comes from target dispersion, remote-state supersession, serialized
+claim transactions, and fast-forward push reconciliation—not from a global
+lock or leader; (2) audit
 commits are the expensive racers (they ship regenerated audit surfaces and
 a push race replays the pipeline), review landings are cheap racers
 (cherry-pick retries in seconds) — so the audit lane never waits for
@@ -614,7 +623,7 @@ Repair and re-entry are reason-specific:
 
 | Operational result | Required repair | Re-entry |
 | --- | --- | --- |
-| `schema_invalid_quarantined` | Preserve the malformed response, exact validator errors, and any `forensic-canary-*.jsonl` artifact; correct the CLI transport schema, prompt, or bounded packet-completion defect. A failed forensic row enters this route while the coordinator advances through the remaining non-excluded backlog. Never edit the scientific judgment into validity. | Start a new campaign so a fresh restricted-context seat is selected. Reusing the old workdir keeps the claim excluded. |
+| `schema_invalid_quarantined` | Preserve the malformed response, exact validator errors, and any `forensic-canary-*.jsonl` artifact; correct the CLI transport schema, prompt, or bounded packet-completion defect. A failed forensic row enters this route while the worker advances through the remaining non-excluded backlog. Never edit the scientific judgment into validity. | Start a new campaign so a fresh restricted-context seat is selected. Reusing the old workdir keeps the claim excluded. |
 | `compute_required_quarantined` / `compute_required` | Produce a SHA-pinned runner cache with `cached_runner_output.py`, a sliced deterministic certificate, or an independent derivation; then run the full pipeline and strict lint. | Start a new campaign after the artifact is current. |
 | `blocked_row_reentry_quarantined` | Repair the recorded classifier promotion, dependency/status cycle, note-hash drift, or other invalidation cause. Require one converged full pipeline. | Start a new campaign only after the row no longer immediately returns to the same dep-ready state. |
 | `claim_transaction_quarantined` | Fix the recorded apply, pipeline, or lint defect and prove the clean full pipeline converges. The failed delivery minted no verdict. | Use a fresh seat in a new campaign unless canonical tooling verifies an exact preserved-envelope replay against the current source/seat fingerprint. |
@@ -798,10 +807,11 @@ PY
 ### Dispatch Queue
 
 `docs/audit/data/audit_dispatch_queue.json` carries provenance and
-promotion re-audit targets. The top-level coordinator authenticates and
-drains ready entries before cascade and regular development work; a
-development helper does not. A manual single-claim run processes this source
-when explicitly selected by the user or surfaced by an external dispatcher.
+promotion re-audit targets. The top-level drainer authenticates and
+drains ready entries before cascade and regular development work. Every
+top-level worker runs this same source ordering. A manual single-claim run
+processes this source when explicitly selected by the user or surfaced by an
+external dispatcher.
 
 **Same-status confirmation rule:** if a fresh-context re-audit on a
 dispatch target confirms the same `{claim_type, audit_status,

--- a/docs/ai_methodology/skills/audit-loop/agents/openai.yaml
+++ b/docs/ai_methodology/skills/audit-loop/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Audit Loop"
   short_description: "Run hostile claim audits from the repo queue"
-  default_prompt: "Use $audit-loop to drain the complete audit backlog with the canonical coordinator workflow, preserving Nature-grade gates and continuing through claim-local quarantines."
+  default_prompt: "Use $audit-loop to drain the complete audit backlog with the coordinatorless optimistic workflow, preserving Nature-grade gates and continuing through claim-local quarantines."

--- a/docs/ai_methodology/skills/audit-loop/references/distributed-drain.md
+++ b/docs/ai_methodology/skills/audit-loop/references/distributed-drain.md
@@ -1,112 +1,83 @@
-# Distributed Audit Drain
+# Coordinatorless Audit Drain
 
-Use this operating contract when more than one employee or Codex account is
-helping drain the same repository.
+Use this contract when more than one employee or Codex account is helping
+drain the same repository.
 
-## Roles
+## One command, separate clones
 
-Designate exactly one **coordinator** for the campaign. It owns:
-
-- targeted dispatch and cascade re-audit sources;
-- flagship-lane priority sweeps;
-- judicial panels and reseats;
-- serial forensic rows;
-- the final all-source fixed-point declaration.
-
-During the concurrent development wave, run the coordinator from its own clean
-`main` clone with forensic work deferred:
+Every participant uses a separate clean clone and runs the same command:
 
 ```bash
-AUDIT_WORKER_ID=<unique-coordinator-id> \
-python3 docs/audit/scripts/orchestrate_audit_loop.py \
-  --max-workers 4 --skip-forensic-canary
-```
-
-Every other employee is a **development helper**. Give every helper a stable,
-globally unique worker id and a separate clean `main` clone:
-
-```bash
-AUDIT_WORKER_ID=<unique-employee-account-id> \
-python3 docs/audit/scripts/orchestrate_audit_loop.py \
-  --development-helper --max-workers 2
-```
-
-A helper skips dispatch, cascade, flagship priority passes, panels, and
-forensics. It only drains the complete eligible development set in a
-worker-specific order. The worker id changes ordering; it does not assign an
-exclusive shard. If a helper disappears, every unfinished row remains
-eligible to every surviving worker.
-
-## Collision Safety
-
-- Run at most one orchestrator in any clone. The clone-wide lock covers all
-  worktrees of that clone.
-- Independent clones may run concurrently. Every apply transaction first
-  synchronizes to `origin/main` and compares the current ledger provenance,
-  exact packet evidence manifest, dependency note bytes, runner/helper inputs,
-  computed seat role/independence/passes, and alternate-source selection with
-  the state seen by the restricted seat. The cascade source must exactly match
-  a pure recomputation from current ledger and runner bytes. If anything
-  moved, the stale delivery is discarded as `remote_state_superseded`; it
-  mints no verdict and creates no quarantine.
-- Different claims still commit one at a time per clone. A push race is
-  reconciled against the intended commit and replayed from current
-  `origin/main`; never hand-merge generated audit state. If the remote outcome
-  cannot be reconciled, preserve the intended local commit and stop instead of
-  resetting or replaying an uncertain push.
-- Primary and helper runners execute in disposable isolated worktrees. Their
-  processes and detached children inherit a per-invocation identity token.
-  Cleanup repeatedly enumerates that token, revalidates it immediately before
-  every signal, and fails unless no token-bearing process remains; it never
-  signals a remembered bare PID. On macOS a kernel sandbox additionally denies
-  writes to the canonical checkout. Containment and whole-worktree discard are
-  both mandatory on every exit path; cleanup never deletes deltas observed in
-  the canonical committer checkout.
-- Use unique worker ids. Reusing an id is safe but defeats target dispersion
-  and wastes seats.
-- Keep the combined repository-wide load near 8-10 active Codex processes,
-  including coordinator seats, helper seats, panels, and review-loop
-  reviewers. Separate subscriptions do not remove the shared Git/pipeline
-  bottleneck.
-- Do not run the specialized forensic committer while development helpers are
-  still live. The development batch has remote-state replay guards; the
-  forensic path is intentionally serial. The concurrent-wave coordinator
-  therefore uses `--skip-forensic-canary`.
-
-## Completion Protocol
-
-A helper's zero-progress exit is only a **helper-local development fixed
-point**. It never certifies that the audit is finished because another clone
-may still have an in-flight seat whose commit does not yet exist.
-
-After every helper is quiescent, run a fresh coordinator-only final sweep
-without `--skip-forensic-canary`:
-
-```bash
-AUDIT_WORKER_ID=<unique-coordinator-id> \
 python3 docs/audit/scripts/orchestrate_audit_loop.py --max-workers 4
 ```
 
-The coordinator may declare completion only after:
+Run at most one orchestrator in a clone. The clone-wide lock covers every
+worktree that shares that clone's Git common directory. Separate employees
+must not share one mutable checkout.
 
-1. every helper is quiescent or has reported its local fixed point;
-2. the coordinator performs a fresh final sweep from current `origin/main`;
-3. ready dispatch and cascade sources have no actionable non-forensic target;
-4. flagship and global development phases land nothing;
-5. panels have no resumable handoff;
-6. the serial forensic selector has no ready non-excluded target.
+The drainer generates a unique session id when `AUDIT_WORKER_ID` and
+`--worker-id` are both omitted. The id only rotates target ordering so
+independent workers usually start on different claims. It is not a lock,
+lease, shard assignment, or scientific authority.
 
-The concurrent-wave coordinator is expected to exit at a development fixed
-point. Always start the coordinator-only final campaign after helpers
-quiesce. Campaign-local quarantines and typed selector skips are not proof
-that the entire scientific backlog is empty; report them as governed repair
-inventory and route them through `science-fix-loop`.
+## Deliberately optimistic
 
-Schema-invalid, compute-required, and verified claim-transaction failures
-exclude only their claim for the current campaign. The coordinator continues
-to the next unrelated row. A successfully applied non-clean forensic verdict
-that immediately re-enters unchanged is durably excluded from that campaign
-so it cannot consume the next forensic seat before source repair. A newly
-written exclusion counts as operational progress: the supervisor starts
-another bounded batch even when that round landed no Git commit, and declares
-a lane fixed point only after both HEAD and the exclusion set remain stable.
+There is no coordinator, leader election, heartbeat, campaign ref, shared
+checkout ledger, or global completion record. A Markdown checkout ledger
+would create a new contended source of truth and could strand work after a
+crash, so the canonical workflow does not use one.
+
+Two workers may compute the same claim. That is safe and occasionally
+wasteful:
+
+1. each restricted seat binds its delivery to the source, ledger provenance,
+   dependencies, runner/helper inputs, evidence manifest, role, independence,
+   passes, and selecting dispatch/cascade entry it observed;
+2. immediately before apply, the committer fetches current `origin/main` and
+   rechecks that complete selection fingerprint;
+3. remote movement returns `remote_state_superseded`; the stale delivery mints
+   no verdict and creates no quarantine;
+4. accepted claims still pass the normal apply, full pipeline, strict lint,
+   one-claim commit, and fast-forward push transaction;
+5. a push race is reconciled from fresh `origin/main`; generated audit state is
+   regenerated, never hand-merged.
+
+These existing claim-transaction checks are the safety boundary. Worker ids
+and target rotation only reduce duplicated compute.
+
+## Panels, forensics, and failures
+
+Every worker runs the complete panel-aware loop. Panels and forensic rows are
+serial inside one worker but may overlap optimistically across independent
+clones. The same current-main precondition and push reconciliation decide
+which current transaction can land; stale duplicates are discarded.
+
+Schema-invalid, compute-required, verified claim-transaction failures, and
+post-verdict blocked-row reentries remain claim-local campaign exclusions.
+The worker records the exact repair artifact and continues every unrelated
+eligible row. Unknown execution failures and unreconciled apply, propagation,
+or push failures still stop that worker fail-closed; they do not authorize
+another worker to reinterpret the failed scientific packet.
+
+Keep repository-wide load near 8-10 active Codex processes when practical,
+including audit seats, panels, and review-loop reviewers. This is a throughput
+guideline, not a correctness lock. If capacity is exhausted, lower
+`--max-workers` or restart later.
+
+## Completion is observational
+
+A worker exits after a fresh synchronized pass lands nothing and no ready
+non-excluded forensic target remains. That is a worker-local fixed-point
+observation, not a global certificate: another clone may still have an
+in-flight delivery.
+
+After visible workers quiesce, refresh `main` and read the canonical audit
+queue, lane certification, and campaign exclusion reports. If new work is
+visible, run the same command again. A worker that landed the last in-flight
+verdict naturally loops back through development and drains anything it
+unblocked. A crash after landing may leave newly unblocked work for the next
+ordinary invocation; it never creates a false terminal campaign state.
+
+Route quarantined and typed selector-skip repair inventory through
+`science-fix-loop`. No operational checkout note, worker exit, or local
+campaign artifact may certify retained grade or backlog completion.

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -7,12 +7,13 @@ disagreement appears. This supervisor owns the missing control-flow edge:
     panel pending work -> drain lane -> panel new disagreement -> resume lane
 
 It drains authenticated dispatch and cascade sources, prioritizes configured
-flagship lanes, then drains every remaining eligible development-tier row. A
-coordinator owns panels and advances all forensic sources one validated row at
-a time; named development helpers may run from independent clones with
-dispersed target ordering. Auditor fan-out remains inside the existing batch
-and judicial orchestrators; this process never authors or edits verdict
-content.
+flagship lanes, then drains every remaining eligible development-tier row.
+Every independent clone runs this same complete loop. A per-session worker id
+only disperses target ordering; current ``origin/main`` plus the existing
+delivery-supersession and fast-forward transaction checks remain the authority.
+Duplicate computation is harmless and is discarded when another worker lands
+first. Auditor fan-out remains inside the existing batch and judicial
+orchestrators; this process never authors or edits verdict content.
 """
 from __future__ import annotations
 
@@ -58,6 +59,7 @@ PROGRESS = {
     "last_canary_claim_id": None,
     "last_canary_terminal_phase": None,
     "last_canary_source": None,
+    "worker_id": None,
     "baseline_status": {},
     "quarantine_file": None,
 }
@@ -192,6 +194,7 @@ def summary_line(final: bool = False) -> str:
         f"elapsed={elapsed // 3600}h{(elapsed % 3600) // 60:02d}m "
         f"phase={PROGRESS['phase']} pass={PROGRESS['pass']} "
         f"lane={PROGRESS['lane'] or '-'} attempts={PROGRESS['attempts']} "
+        f"worker_id={PROGRESS['worker_id'] or '-'} "
         f"failures={sum(failures.values())} top_failure_reasons={failure_text} "
         f"verdicts_landed={verdict_text} panel_reseat={PROGRESS['panel_state']} "
         f"canary={PROGRESS['canary_state']} "
@@ -375,9 +378,6 @@ def batch_command(
 
 
 def run_panel(args: argparse.Namespace, label: str) -> int:
-    if getattr(args, "development_helper", False):
-        PROGRESS["panel_state"] = "delegated_to_coordinator"
-        return 0
     return run_command(label, panel_command(args))
 
 
@@ -386,7 +386,7 @@ def drain_lane(
     args: argparse.Namespace,
     source: str | None = None,
 ) -> tuple[int, bool]:
-    """Drain one scoped phase, paneling after every batch when coordinator."""
+    """Drain one scoped phase and panel after every batch."""
     made_progress = False
     label = f"{source}-source" if source else (lane or "global-development")
     for cycle in itertools.count(1):
@@ -722,16 +722,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--worker-id",
         default=os.environ.get("AUDIT_WORKER_ID", ""),
         help=(
-            "stable employee/account identifier used to disperse development "
-            "targets across independent clones"
-        ),
-    )
-    parser.add_argument(
-        "--development-helper",
-        action="store_true",
-        help=(
-            "drain development-tier work only; the one designated coordinator "
-            "owns judicial panels and forensic rows"
+            "optional session identifier used only to disperse target ordering; "
+            "a unique id is generated when omitted"
         ),
     )
     parser.add_argument(
@@ -785,9 +777,12 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("worker, round, timeout, and retry values must be positive")
     if args.max_passes < 0 or args.max_lane_cycles < 0:
         raise SystemExit("pass and cycle safety bounds must be non-negative")
-    if args.development_helper and not args.worker_id.strip():
-        raise SystemExit("--development-helper requires a non-empty --worker-id")
-    args.worker_id = args.worker_id.strip()
+    args.worker_id = args.worker_id.strip() or f"worker-{uuid.uuid4().hex[:12]}"
+    PROGRESS["worker_id"] = args.worker_id
+    emit(
+        "optimistic worker identity: "
+        f"{args.worker_id} (ordering hint only; origin/main is authoritative)"
+    )
     campaign_dir = args.campaign_workdir or Path(
         tempfile.mkdtemp(prefix="audit_loop_campaign_")
     )
@@ -848,25 +843,21 @@ def main(argv: list[str] | None = None) -> int:
             PROGRESS["pass"] = pass_number
             PROGRESS["lane"] = None
             before = git_head()
-            if args.development_helper:
-                PROGRESS["panel_state"] = "delegated_to_coordinator"
-                lanes = []
-            else:
-                rc = run_panel(args, f"panel-pass-{pass_number}-opening")
-                if rc != 0:
-                    return rc
-                if not args.lane:
-                    for source in ("dispatch", "reaudit"):
-                        PROGRESS["lane"] = f"{source}-source"
-                        emit(f"draining ready {source} source rows")
-                        rc, _ = drain_lane(None, args, source=source)
-                        if rc != 0:
-                            return rc
-                try:
-                    lanes = blocking_lanes(args.lane)
-                except ValueError as exc:
-                    emit(str(exc))
-                    return 2
+            rc = run_panel(args, f"panel-pass-{pass_number}-opening")
+            if rc != 0:
+                return rc
+            if not args.lane:
+                for source in ("dispatch", "reaudit"):
+                    PROGRESS["lane"] = f"{source}-source"
+                    emit(f"draining ready {source} source rows")
+                    rc, _ = drain_lane(None, args, source=source)
+                    if rc != 0:
+                        return rc
+            try:
+                lanes = blocking_lanes(args.lane)
+            except ValueError as exc:
+                emit(str(exc))
+                return 2
             emit(
                 "blocking lanes: "
                 + (", ".join(f"{lane}={count}" for lane, count in lanes) or "none")
@@ -896,13 +887,9 @@ def main(argv: list[str] | None = None) -> int:
                 except (OSError, ValueError) as exc:
                     emit(f"invalid campaign state; refusing fixed point: {exc}")
                     return 2
-                fixed_point_kind = (
-                    "helper-local development fixed point"
-                    if args.development_helper
-                    else "development fixed point"
-                )
                 emit(
-                    f"{fixed_point_kind} reached: full pass landed nothing new"
+                    "worker-local development fixed point reached: "
+                    "fresh full pass landed nothing new"
                 )
                 if exclusions[batch.SCHEMA_QUARANTINE_RESULT]:
                     emit(
@@ -934,8 +921,7 @@ def main(argv: list[str] | None = None) -> int:
                         f"{args.campaign_selection_skip_file}"
                     )
                 if (
-                    args.development_helper
-                    or args.skip_forensic_canary
+                    args.skip_forensic_canary
                     or args.lane
                 ):
                     return 0

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -668,7 +668,6 @@ def _args() -> argparse.Namespace:
         lane=None,
         max_workers=4,
         worker_id="",
-        development_helper=False,
         max_passes=0,
         max_lane_cycles=0,
         batch_rounds=6,
@@ -2962,6 +2961,12 @@ class AutomaticPanelResumeTest(unittest.TestCase):
 
 
 class CampaignContractTest(unittest.TestCase):
+    def test_cli_exposes_no_coordinator_or_helper_role(self):
+        help_text = audit_loop.build_parser().format_help()
+
+        self.assertNotIn("--development-helper", help_text)
+        self.assertNotIn("--coordinator", help_text)
+
     def test_packet_fingerprint_normalizes_transport_bounded_virtual_index(self):
         row = {"claim_id": "target", "deps": []}
         rows = {"target": row}
@@ -4084,7 +4089,8 @@ class CampaignContractTest(unittest.TestCase):
         self.assertEqual(rc, 2)
         run_panel.assert_not_called()
 
-    def test_development_helper_skips_panels_and_priority_lane_duplication(self):
+    def test_default_worker_runs_complete_flow_with_generated_identity(self):
+        generated = mock.Mock(hex="0123456789abcdef")
         with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
             audit_loop, "validate_requested_lanes"
         ), mock.patch.object(
@@ -4096,30 +4102,41 @@ class CampaignContractTest(unittest.TestCase):
         ), mock.patch.object(
             audit_loop, "git_head", return_value="same"
         ), mock.patch.object(
-            audit_loop, "run_panel"
+            audit_loop, "run_panel", return_value=0
         ) as run_panel, mock.patch.object(
-            audit_loop, "blocking_lanes"
+            audit_loop, "blocking_lanes", return_value=[("lane_a", 1)]
         ) as blocking_lanes, mock.patch.object(
             audit_loop, "drain_lane", return_value=(0, False)
-        ) as drain_lane:
+        ) as drain_lane, mock.patch.object(
+            audit_loop.uuid, "uuid4", return_value=generated
+        ):
             rc = audit_loop.main(
                 [
                     "--dry-run",
-                    "--development-helper",
-                    "--worker-id",
-                    "employee-alpha",
+                    "--skip-forensic-canary",
                     "--campaign-workdir",
                     tmp,
                 ]
             )
 
         self.assertEqual(rc, 0)
-        run_panel.assert_not_called()
-        blocking_lanes.assert_not_called()
-        drain_lane.assert_called_once()
-        self.assertIsNone(drain_lane.call_args.args[0])
+        run_panel.assert_called_once()
+        blocking_lanes.assert_called_once_with(None)
+        self.assertEqual(
+            [(call.args[0], call.kwargs.get("source")) for call in drain_lane.call_args_list],
+            [
+                (None, "dispatch"),
+                (None, "reaudit"),
+                ("lane_a", None),
+                (None, None),
+            ],
+        )
+        worker_ids = {
+            call.args[1].worker_id for call in drain_lane.call_args_list
+        }
+        self.assertEqual(worker_ids, {"worker-0123456789ab"})
 
-    def test_coordinator_continues_after_claim_local_forensic_exclusion(self):
+    def test_worker_continues_after_claim_local_forensic_exclusion(self):
         lock = mock.Mock()
         canary_calls = 0
 
@@ -4161,7 +4178,7 @@ class CampaignContractTest(unittest.TestCase):
                     "--campaign-workdir",
                     tmp,
                     "--worker-id",
-                    "coordinator",
+                    "worker-alpha",
                 ]
             )
 
@@ -4183,6 +4200,7 @@ class CampaignContractTest(unittest.TestCase):
 
     def test_inner_batches_share_campaign_quarantine_and_dispatch_policy(self):
         args = _args()
+        args.worker_id = "worker-alpha"
         args.campaign_quarantine_file = Path("/tmp/campaign/quarantine.jsonl")
         args.campaign_selection_skip_file = Path(
             "/tmp/campaign/selector-skips.jsonl"
@@ -4194,6 +4212,9 @@ class CampaignContractTest(unittest.TestCase):
         self.assertIn(str(args.campaign_quarantine_file), command)
         self.assertIn("--campaign-selection-skip-file", command)
         self.assertIn(str(args.campaign_selection_skip_file), command)
+        self.assertIn("--worker-id", command)
+        self.assertIn("worker-alpha", command)
+        self.assertNotIn("worker-alpha", audit_loop.panel_command(args))
         self.assertNotIn("--dispatch-science-fixes", command)
 
         args.dispatch_science_fixes = True


### PR DESCRIPTION
## What changed

- Make every employee/account run the same complete audit command from a separate clean clone:

  ```bash
  python3 docs/audit/scripts/orchestrate_audit_loop.py --max-workers 4
  ```

- Generate a unique session id when none is supplied and use it only to rotate target ordering.
- Remove coordinator/helper roles from the CLI and methodology.
- Keep panels and forensic work serial inside each worker while allowing independent clones to overlap optimistically.
- Define every zero-work exit as a worker-local observation, not a global completion certificate.
- Preserve claim-local quarantine/continuation and route repair inventory through `science-fix-loop`.

## Simpler safety model

There is no leader election, heartbeat, global lease, campaign ref, capacity registry, shared checkout ledger, or terminal coordination record.

Workers may occasionally compute the same claim. Immediately before apply, the existing audit transaction refreshes `origin/main` and revalidates the complete source/ledger/dependency/runner/evidence/seat/selection fingerprint. Stale work returns `remote_state_superseded`, mints no verdict, and creates no quarantine. Accepted work still passes the normal apply, full pipeline, strict lint, one-claim commit, and fast-forward push reconciliation.

The tradeoff is bounded duplicate compute instead of a distributed coordinator. No operational state can certify scientific authority or retained grade.

## Scope

Five files only:

- the top-level orchestrator;
- its existing test module;
- the audit-loop skill, distributed-operation reference, and agent prompt.

No batch, panel, forensic, branch-management, audit-data, source-note, runner, or verdict code changes.

## Validation

- Complete orchestrator/transaction suite: 119 tests passed.
- Focused campaign contract suite: 31 tests passed.
- Full audit pipeline passed: 3,863 rows, 431 retained-grade, 632 ready, zero invalidations.
- Enforced repository invariants passed with zero link/class-F violations.
- Strict audit lint: 0 errors; existing 26 warnings and 439 notices only.
- Skill quick validation, controlled-vocabulary lint, Python compilation, and `git diff --check` passed.
- Pipeline validation left no generated audit-state changes in the PR.

This draft may leave draft and land only after a fresh independent GPT-5.6-Sol/max `review-loop` PASS on the exact head.
