### PR TITLE
fix(cl3): repair the malformed K3 denominator on the audited_failed Clifford root

### DIFF
--- a/docs/CL3_COMPLEXIFICATION_SPLIT_NARROW_THEOREM_NOTE_2026-05-10.md
+++ b/docs/CL3_COMPLEXIFICATION_SPLIT_NARROW_THEOREM_NOTE_2026-05-10.md
@@ -145,7 +145,7 @@ e_+ + e_-   = ((1 - i ω) + (1 + i ω))/2 = 1,
 e_+ · e_-   = ((1 - i ω)(1 + i ω))/4    = (1 - (i ω)²)/4
             = (1 - i² ω²)/4              = (1 - (-1)(-1))/4 = 0,
 e_+²        = ((1 - i ω)/2)²             = (1 - 2 i ω + (i ω)²)/4
-            = (1 - 2 i ω + 1)/(2² ·  )    = (2 - 2 i ω)/4 = e_+,
+            = (1 - 2 i ω + 1)/4           = (2 - 2 i ω)/4 = e_+,
 e_-²        = e_-  (analogous).
 ```
 
@@ -229,6 +229,11 @@ Runner links:
   [`scripts/cl3_complexification_exclusion_stress_2026_07_13.py`](../scripts/cl3_complexification_exclusion_stress_2026_07_13.py)
 - Recorded exclusion stdout:
   [`logs/runner-cache/cl3_complexification_exclusion_stress_2026_07_13.txt`](../logs/runner-cache/cl3_complexification_exclusion_stress_2026_07_13.txt)
+- Independent faithful-direct-sum resolution runner (the N7 surface,
+  distinct from the runner used for the steelman):
+  [`scripts/cl3_pauli_irrep_faithful_direct_sum_n7_independent_2026_07_17.py`](../scripts/cl3_pauli_irrep_faithful_direct_sum_n7_independent_2026_07_17.py)
+- Recorded independent-resolution stdout:
+  [`logs/runner-cache/cl3_pauli_irrep_faithful_direct_sum_n7_independent_2026_07_17.txt`](../logs/runner-cache/cl3_pauli_irrep_faithful_direct_sum_n7_independent_2026_07_17.txt)
 
 The companion runner verifies via sympy exact rational/symbolic arithmetic
 on `2 × 2` complex matrices:

--- a/logs/runner-cache/cl3_pauli_irrep_faithful_direct_sum_n7_independent_2026_07_17.txt
+++ b/logs/runner-cache/cl3_pauli_irrep_faithful_direct_sum_n7_independent_2026_07_17.txt
@@ -1,0 +1,22 @@
+===== runner cache v1 =====
+runner: scripts/cl3_pauli_irrep_faithful_direct_sum_n7_independent_2026_07_17.py
+runner_sha256: e5350cc6e8f15bf4e0fae2782d0ea78a13330ea1b9732c666fa62bb3a5625f4f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.26
+status: ok
+----- stdout -----
+N7_INDEPENDENT_CHECK rho_plus_complex_rank_4 status=PASS
+N7_INDEPENDENT_CHECK rho_minus_complex_rank_4 status=PASS
+N7_INDEPENDENT_CHECK rho_plus_kernel_dim_complex_4 status=PASS
+N7_INDEPENDENT_CHECK rho_minus_kernel_dim_complex_4 status=PASS
+N7_INDEPENDENT_CHECK rho_plus_volume_character_plus_i status=PASS
+N7_INDEPENDENT_CHECK rho_minus_volume_character_minus_i status=PASS
+N7_INDEPENDENT_CHECK direct_sum_complex_rank_8_faithful status=PASS
+N7_INDEPENDENT_CHECK proper_sector_projector_rank_2 status=PASS
+N7_INDEPENDENT_CHECK proper_sector_projector_idempotent status=PASS
+N7_INDEPENDENT_CHECK proper_sector_projector_commutes_with_action status=PASS
+N7_STEELMAN_RESOLUTION wall=irreducible complexified A-module faithfulness boundary; steelman=rho_plus_direct_sum_rho_minus; individual_kernel_dim_complex=4; combined_complex_rank=8; faithful=true; reducible=true; invariant_summand_dims_complex=2,2; conclusion=faithfulness_does_not_recover_irreducibility
+
+----- stderr -----
+


### PR DESCRIPTION
## Why this is worth a PR of two files

A measured citation-graph pass over the live ledger found that the single highest-impact unresolved node in the repository is `cl3_complexification_split_narrow_theorem_note_2026-05-10`:

- `effective_status: audited_failed` (rank 0 — the lowest in the table)
- `dependencies: []` — it is a **root**, so no upstream repair can ever un-stick it
- **~1,732 rows / 44.9% of the ledger** sit downstream of it, with 29 direct citers

And the 2026-07-21 audit round that failed it gives exactly one ground:

> "the K3 idempotence display contains the malformed expression `(1 - 2 i ω + 1)/(2² · )`, although the following equality and runner use the correct denominator 4. … the negative-assertion judgment otherwise passes N1-N8 … the abstract split and dimension conclusions remain runner-supported … **Repair target: replace the malformed denominator with `4`**"

So a dropped character in one displayed line is holding rank-0 `audited_failed` on the Clifford foundation. That matters beyond the row itself: `compute_effective_status.py` returns `retained_pending_chain` for any claim whose chain includes a non-chain-satisfying dep, so while this root stays failed, the entire Cl(3) → staggered-Dirac → per-site-Hilbert cone is capped no matter how many descendants get audited.

## What changed

1. **`docs/CL3_COMPLEXIFICATION_SPLIT_NARROW_THEOREM_NOTE_2026-05-10.md:148`** — `(2² ·  )` → `4`.

   Verified from the algebra before editing, not taken on the auditor's word: with `e₊ = (1 − iω)/2` and `ω² = −1`, `(iω)² = +1`, hence `e₊² = (1 − 2iω + 1)/4 = (2 − 2iω)/4 = e₊`. Denominator 4 is forced. Line 147 and the remainder of line 148 already read `/4`, and the runner normalizes with exact `Rational(1,2)` — the defect never propagated into the mathematics, which is why the auditor could certify everything else while still (correctly) refusing to call the source clean as written.

2. **Recorded the N7 independent-resolution stdout** and linked the runner from the note's Validation block.

   `scripts/cl3_pauli_irrep_faithful_direct_sum_n7_independent_2026_07_17.py` existed on main as source only: `cache_freshness: "missing"`, no `logs/runner-cache/` entry, and not linked from any note (registered only in `audit_dispatch_queue.json`). An earlier round of this same row failed on precisely *"N7 … has no independent resolution surface distinct from the runner used for its steelman"* — so the surface the auditor asked for existed but was invisible. Cache generated with the standard SHA-pinned precompute path.

## Verification

Re-ran on this tree after the edit: exclusion stress runner **62/0**, companion runner **38/0**, N7 independent helper **PASS** (proper-sector projector idempotent, commutes with the action; steelman resolved by reducibility).

## Churn

Deliberately checked against the review-loop skill's audit-hash churn guard, since this note is heavily cited:

- Rows requeued: **1** (the target itself). That requeue is the *only* sanctioned mechanism to un-stick a terminal `audited_failed` row.
- Downstream verdicts at risk: **0**. `dep_weakened` cannot fire because the status moves *up* (`audited_failed` rank 0 → `unaudited` rank 30), and `axiom_premise_changed` cannot fire because this id is not one of the four registered premise nodes.
- The guard's own trigger ("touches **many** existing claim-note files for … cleanup") is not met: one file, one line, and it is a science correction, not cosmetic churn.

No generated audit outputs are shipped. No audit verdict is set or predicted — status is the independent audit lane's alone; this PR only makes the row re-auditable and supplies the evidence surface a prior round asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)