### PR TITLE
Retry transient audit service outages

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -212,6 +212,13 @@ default session is:
    python3 docs/audit/scripts/orchestrate_audit_loop.py --max-workers 4
    ```
 
+   The canonical command has no wall-clock limit and keeps draining until its
+   governed fixed point or a verified resource/integrity blocker. When the
+   operator explicitly requests a bounded campaign, add
+   `--max-runtime-hours 12` (or the requested duration). The limit is checked
+   only between completed batch/panel/canary phases, so it never interrupts a
+   claim transaction, pipeline, lint, or push.
+
    This command owns the complete control loop: drain authenticated targeted
    dispatch and cascade re-audit sources, finish pending judicial work, drain
    configured development lanes in order, drain every other eligible
@@ -349,6 +356,17 @@ failures. This boundary is fail-closed and does not weaken any audit gate.
   blindly repeat an uncertain push. If fetch or ancestry proof is unavailable,
   preserve the local intended commit and hard-stop with
   `push_reconciliation_required`; do not reset to a stale remote-tracking ref.
+- **Auditor service retryable:** a nonzero auditor exit is retryable only when
+  the bounded worker-log tail contains an allowlisted backend/transport outage
+  signature (for example HTTP 502/503/504, service-unavailable circuit-open, or
+  a reset upstream connection) and contains no credit, quota, authentication,
+  billing, or policy marker. Batch, judicial-panel, and forensic-canary seats
+  propagate the same typed temporary-service exit. The top-level orchestrator
+  still finishes the mandatory panel sweep after a batch, then retries the
+  affected canonical phase with capped exponential backoff. The failed seat
+  mints no verdict and is not converted into a scientific or campaign
+  quarantine result. Credit/authentication and unknown worker exits remain
+  hard stops.
 - **Global hard stop:** dirty or divergent source state, failed rollback,
   repository invariant failure, unclassifiable generated diff, corrupted
   campaign state, unavailable required audit model, authentication failure

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -115,6 +115,46 @@ PACKET_COMPLETION_EXIT_GRACE_SECONDS = 10
 COMMAND_TERMINATION_GRACE_SECONDS = 5
 INHERITED_DRAIN_LOCK_FD_ENV = "AUDIT_DRAIN_LOCK_FD"
 LANE_CERTIFICATION_PATH = "docs/audit/data/lane_certification.json"
+TRANSIENT_SERVICE_FAILURE_RESULT = "worker_transient_service_unavailable"
+TRANSIENT_SERVICE_EXIT_CODE = getattr(os, "EX_TEMPFAIL", 75)
+WORKER_FAILURE_LOG_TAIL_BYTES = 256 * 1024
+WORKER_FAILURE_LOG_TAIL_LINES = 80
+TRANSIENT_SERVICE_MARKERS = (
+    "biscuit_baker_service_me_circuit_open",
+    "service unavailable",
+    "bad gateway",
+    "gateway timeout",
+    "upstream connect error",
+    "connection reset by peer",
+    "connection closed before completed",
+    "http 502",
+    "http 503",
+    "http 504",
+    "status 502",
+    "status 503",
+    "status 504",
+    "status code 502",
+    "status code 503",
+    "status code 504",
+)
+NON_RETRYABLE_SERVICE_MARKERS = (
+    "insufficient_quota",
+    "usage limit",
+    "quota exceeded",
+    "out of credit",
+    "out of credits",
+    "credit balance",
+    "billing",
+    "unauthorized",
+    "forbidden",
+    "authentication failed",
+    "invalid api key",
+    "invalid_api_key",
+    "status 401",
+    "status 403",
+    "status code 401",
+    "status code 403",
+)
 
 
 def _repo_identity() -> str:
@@ -1239,6 +1279,41 @@ def packet_completion_pass(
     return completed
 
 
+def retryable_service_failure_marker(text: str) -> str | None:
+    """Classify a bounded terminal diagnostic as a transient service outage."""
+    tail = "\n".join(text.splitlines()[-WORKER_FAILURE_LOG_TAIL_LINES:]).lower()
+    if any(marker in tail for marker in NON_RETRYABLE_SERVICE_MARKERS):
+        return None
+    return next(
+        (marker for marker in TRANSIENT_SERVICE_MARKERS if marker in tail),
+        None,
+    )
+
+
+def retryable_worker_service_failure(job: dict) -> str | None:
+    """Return the matched transient service marker from a bounded log tail.
+
+    A worker exit has no scientific authority. Only a narrow allowlist of
+    transport/backend outage signatures is retryable, and any credit,
+    authentication, or policy marker wins over that allowlist. Unknown exits
+    remain hard failures.
+    """
+    log_path = job.get("log_path")
+    if not isinstance(log_path, Path) or not log_path.is_file():
+        return None
+    try:
+        with log_path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - WORKER_FAILURE_LOG_TAIL_BYTES))
+            decoded = handle.read(WORKER_FAILURE_LOG_TAIL_BYTES).decode(
+                "utf-8", errors="replace"
+            )
+    except OSError:
+        return None
+    return retryable_service_failure_marker(decoded)
+
+
 def finalize_worker(job: dict) -> tuple[dict | None, dict]:
     cid = job["cid"]
     base = {"cid": cid, "pass": job["pass"]}
@@ -1246,6 +1321,17 @@ def finalize_worker(job: dict) -> tuple[dict | None, dict]:
         return None, {**base, "result": "stall_killed"}
     raw_output = job["raw_output"]
     if job.get("returncode") != 0:
+        transient_marker = retryable_worker_service_failure(job)
+        if transient_marker is not None:
+            return None, {
+                **base,
+                "result": TRANSIENT_SERVICE_FAILURE_RESULT,
+                "detail": (
+                    "auditor transport/backend outage; "
+                    f"matched={transient_marker!r}; "
+                    f"log={job['log_path'].name}"
+                ),
+            }
         return None, {**base, "result": f"worker_exit_{job.get('returncode')}"}
     if not raw_output.exists() or raw_output.stat().st_size <= MIN_DELIVERY_BYTES:
         return None, {**base, "result": "no_size_qualified_delivery"}
@@ -3348,19 +3434,11 @@ def main() -> int:
             encoding="utf-8",
         )
         print(f"report: {workdir / 'report.jsonl'}")
-    blocked = report_has_hard_blocker(report)
-    return finish(1 if blocked else 0)
+    return finish(report_exit_code(report))
 
 
-def report_has_hard_blocker(report: list[dict]) -> bool:
-    """Return true only for outcomes that cannot be resumed canonically.
-
-    A cross-seat disagreement is not a failed audit round. It is an explicit
-    handoff to ``orchestrate_judicial_panel.py``. The top-level audit-loop
-    orchestrator consumes that handoff immediately and then resumes the same
-    lane, so returning nonzero here would incorrectly collapse a normal
-    control-flow edge into a campaign stop.
-    """
+def hard_blocking_report_items(report: list[dict]) -> list[dict]:
+    """Return outcomes that were not resolved by a governed companion."""
     accepted = (
         SUCCESS_RESULTS
         | RESUMABLE_HANDOFF_RESULTS
@@ -3379,8 +3457,10 @@ def report_has_hard_blocker(report: list[dict]) -> bool:
         if item.get("result") == CLAIM_TRANSACTION_QUARANTINE_RESULT
     }
     quarantine_companions = SCHEMA_INVALID_RESULTS | {"critical_peer_pending"}
-    return any(
-        item.get("result") not in accepted
+    return [
+        item
+        for item in report
+        if item.get("result") not in accepted
         and not (
             item.get("cid") in recovered
             and item.get("result") in quarantine_companions
@@ -3389,8 +3469,32 @@ def report_has_hard_blocker(report: list[dict]) -> bool:
             item.get("cid") in transaction_quarantined
             and item.get("result") == "apply_or_gate_failed"
         )
-        for item in report
-    )
+    ]
+
+
+def report_exit_code(report: list[dict]) -> int:
+    """Return success, temporary-service failure, or hard failure."""
+    blockers = hard_blocking_report_items(report)
+    if not blockers:
+        return 0
+    if all(
+        item.get("result") == TRANSIENT_SERVICE_FAILURE_RESULT
+        for item in blockers
+    ):
+        return TRANSIENT_SERVICE_EXIT_CODE
+    return 1
+
+
+def report_has_hard_blocker(report: list[dict]) -> bool:
+    """Return true only for outcomes that cannot be resumed canonically.
+
+    A cross-seat disagreement is not a failed audit round. It is an explicit
+    handoff to ``orchestrate_judicial_panel.py``. The top-level audit-loop
+    orchestrator consumes that handoff immediately and then resumes the same
+    lane, so returning nonzero here would incorrectly collapse a normal
+    control-flow edge into a campaign stop.
+    """
+    return bool(hard_blocking_report_items(report))
 
 
 def append_judicial_handoffs(

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -65,6 +65,12 @@ PROGRESS = {
 }
 _STOP_HEARTBEAT = threading.Event()
 _DRAIN_LOCK_HANDLE: TextIO | None = None
+DEFAULT_SERVICE_RETRY_INITIAL_SECONDS = 60
+DEFAULT_SERVICE_RETRY_MAX_SECONDS = 15 * 60
+
+
+class RuntimeLimitReached(Exception):
+    """Raised only at a safe phase boundary after the requested runtime."""
 
 
 def emit(message: str) -> None:
@@ -210,6 +216,46 @@ def summary_line(final: bool = False) -> str:
 def heartbeat() -> None:
     while not _STOP_HEARTBEAT.wait(15 * 60):
         emit(summary_line())
+
+
+def remaining_runtime_seconds(args: argparse.Namespace) -> float | None:
+    hours = float(getattr(args, "max_runtime_hours", 0) or 0)
+    started = PROGRESS.get("started")
+    if hours <= 0 or not isinstance(started, (int, float)):
+        return None
+    return (hours * 60 * 60) - (time.monotonic() - started)
+
+
+def stop_if_runtime_limit_reached(args: argparse.Namespace) -> None:
+    remaining = remaining_runtime_seconds(args)
+    if remaining is not None and remaining <= 0:
+        emit(
+            "STOP requested runtime reached at a completed phase boundary: "
+            f"max_runtime_hours={args.max_runtime_hours}"
+        )
+        raise RuntimeLimitReached
+
+
+def wait_for_service_retry(
+    args: argparse.Namespace,
+    context: str,
+    consecutive_failures: int,
+) -> None:
+    delay = min(
+        args.service_retry_initial_sec
+        * (2 ** min(consecutive_failures - 1, 20)),
+        args.service_retry_max_sec,
+    )
+    remaining = remaining_runtime_seconds(args)
+    if remaining is not None:
+        delay = min(delay, max(0.0, remaining))
+    emit(
+        "retryable auditor service outage: "
+        f"context={context} consecutive={consecutive_failures} "
+        f"backoff_seconds={delay:g}"
+    )
+    if delay > 0:
+        time.sleep(delay)
 
 
 def git_head() -> str:
@@ -378,7 +424,14 @@ def batch_command(
 
 
 def run_panel(args: argparse.Namespace, label: str) -> int:
-    return run_command(label, panel_command(args))
+    transient_failures = 0
+    while True:
+        stop_if_runtime_limit_reached(args)
+        rc = run_command(label, panel_command(args))
+        if rc != batch.TRANSIENT_SERVICE_EXIT_CODE:
+            return rc
+        transient_failures += 1
+        wait_for_service_retry(args, label, transient_failures)
 
 
 def drain_lane(
@@ -388,8 +441,10 @@ def drain_lane(
 ) -> tuple[int, bool]:
     """Drain one scoped phase and panel after every batch."""
     made_progress = False
+    transient_failures = 0
     label = f"{source}-source" if source else (lane or "global-development")
     for cycle in itertools.count(1):
+        stop_if_runtime_limit_reached(args)
         if args.max_lane_cycles and cycle > args.max_lane_cycles:
             emit(f"STOP lane cycle safety bound reached: lane={label}")
             return 4, made_progress
@@ -408,15 +463,25 @@ def drain_lane(
         panel_rc = run_panel(args, f"panel-after-{label}-cycle-{cycle}")
         if panel_rc != 0:
             return panel_rc, made_progress
-        if batch_rc != 0:
-            return batch_rc, made_progress
         after = git_head()
         after_exclusions = campaign_exclusion_keys(
             getattr(args, "campaign_quarantine_file", None)
         )
+        if after != before or after_exclusions != before_exclusions:
+            made_progress = True
+        if batch_rc == batch.TRANSIENT_SERVICE_EXIT_CODE:
+            transient_failures += 1
+            wait_for_service_retry(
+                args,
+                f"batch-{label}-after-panel",
+                transient_failures,
+            )
+            continue
+        if batch_rc != 0:
+            return batch_rc, made_progress
+        transient_failures = 0
         if after == before and after_exclusions == before_exclusions:
             return 0, made_progress
-        made_progress = True
         if args.dry_run:
             return 0, made_progress
 
@@ -663,6 +728,15 @@ def run_forensic_canary(
     )
     if claim_local is None:
         if rc != 0:
+            marker = batch.retryable_service_failure_marker(
+                json.dumps(terminal, sort_keys=True) if terminal else ""
+            )
+            if marker is not None:
+                emit(
+                    "forensic auditor hit a retryable service outage: "
+                    f"claim={claim_id} matched={marker!r}"
+                )
+                return batch.TRANSIENT_SERVICE_EXIT_CODE
             return rc
         terminal_phase = terminal.get("phase") if terminal else None
         if terminal_phase in {"applied", "remote_state_superseded"} or (
@@ -733,6 +807,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="full-pass safety bound; 0 drains to a fixed point (default)",
     )
     parser.add_argument(
+        "--max-runtime-hours",
+        type=float,
+        default=0,
+        help=(
+            "stop successfully at the first completed phase boundary after "
+            "this many hours; 0 has no runtime bound"
+        ),
+    )
+    parser.add_argument(
         "--max-lane-cycles",
         type=int,
         default=0,
@@ -743,6 +826,18 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--runner-timeout-sec", type=int, default=120)
     parser.add_argument("--codex-timeout-sec", type=int, default=2700)
     parser.add_argument("--push-retries", type=int, default=3)
+    parser.add_argument(
+        "--service-retry-initial-sec",
+        type=int,
+        default=DEFAULT_SERVICE_RETRY_INITIAL_SECONDS,
+        help="initial backoff after a typed transient auditor service outage",
+    )
+    parser.add_argument(
+        "--service-retry-max-sec",
+        type=int,
+        default=DEFAULT_SERVICE_RETRY_MAX_SECONDS,
+        help="maximum backoff between typed transient-service batch retries",
+    )
     parser.add_argument(
         "--campaign-workdir",
         type=Path,
@@ -772,11 +867,17 @@ def main(argv: list[str] | None = None) -> int:
         args.runner_timeout_sec,
         args.codex_timeout_sec,
         args.push_retries,
+        args.service_retry_initial_sec,
+        args.service_retry_max_sec,
     )
     if any(value < 1 for value in positive):
         raise SystemExit("worker, round, timeout, and retry values must be positive")
     if args.max_passes < 0 or args.max_lane_cycles < 0:
         raise SystemExit("pass and cycle safety bounds must be non-negative")
+    if args.max_runtime_hours < 0:
+        raise SystemExit("runtime bound must be non-negative")
+    if args.service_retry_initial_sec > args.service_retry_max_sec:
+        raise SystemExit("initial service retry delay cannot exceed its maximum")
     args.worker_id = args.worker_id.strip() or f"worker-{uuid.uuid4().hex[:12]}"
     PROGRESS["worker_id"] = args.worker_id
     emit(
@@ -832,11 +933,13 @@ def main(argv: list[str] | None = None) -> int:
     PROGRESS["last_canary_terminal_phase"] = None
     PROGRESS["last_canary_source"] = None
     forensic_attempted: set[str] = set()
+    forensic_service_failures = 0
     _STOP_HEARTBEAT.clear()
     thread = threading.Thread(target=heartbeat, daemon=True)
     thread.start()
     try:
         for pass_number in itertools.count(1):
+            stop_if_runtime_limit_reached(args)
             if args.max_passes and pass_number > args.max_passes:
                 emit("STOP pass safety bound reached")
                 return 4
@@ -925,10 +1028,20 @@ def main(argv: list[str] | None = None) -> int:
                     or args.lane
                 ):
                     return 0
+                stop_if_runtime_limit_reached(args)
                 forensic_before = after
                 rc = run_forensic_canary(args, forensic_attempted)
+                if rc == batch.TRANSIENT_SERVICE_EXIT_CODE:
+                    forensic_service_failures += 1
+                    wait_for_service_retry(
+                        args,
+                        "forensic-canary",
+                        forensic_service_failures,
+                    )
+                    continue
                 if rc != 0:
                     return rc
+                forensic_service_failures = 0
                 if args.dry_run:
                     return 0
                 synced, detail = batch.sync_origin_main()
@@ -1031,6 +1144,8 @@ def main(argv: list[str] | None = None) -> int:
                     )
                     continue
                 return 0
+    except RuntimeLimitReached:
+        return 0
     finally:
         _STOP_HEARTBEAT.set()
         emit(summary_line(final=True))

--- a/docs/audit/scripts/orchestrate_judicial_panel.py
+++ b/docs/audit/scripts/orchestrate_judicial_panel.py
@@ -51,6 +51,7 @@ MAJORITY = 3
 MIN_VOTE_BYTES = 120
 MAX_FRESH_PANEL_CONTRACT_RETRIES = 2
 VOTE_CONTRACT_ERROR_PREFIX = "vote_contract_error:"
+PANEL_TRANSIENT_SERVICE_RESULT = "panel_transient_service_unavailable"
 
 ALLOWED_SIDES = audit_contract.JUDICIAL_SIDES
 ALLOWED_VERDICTS = audit_contract.TERMINAL_VERDICTS
@@ -544,6 +545,9 @@ def collect_vote(job: dict) -> tuple[dict | None, str]:
         return None, "stall_killed"
     raw = job["raw_output"]
     if job.get("returncode") != 0:
+        marker = batch.retryable_worker_service_failure(job)
+        if marker is not None:
+            return None, f"{batch.TRANSIENT_SERVICE_FAILURE_RESULT}:{marker}"
         return None, f"judge_exit_{job.get('returncode')}"
     if not raw.exists() or raw.stat().st_size <= MIN_VOTE_BYTES:
         return None, "no_size_qualified_vote"
@@ -993,6 +997,24 @@ def run_panel(
             "tally": serialized_tally(votes),
         }
         if len(votes) != PANEL_SIZE:
+            transient_failures = [
+                failure
+                for failure in failures
+                if f":{batch.TRANSIENT_SERVICE_FAILURE_RESULT}:" in failure
+            ]
+            if (
+                transient_failures
+                and len(transient_failures) + len(contract_failures)
+                == len(failures)
+            ):
+                record["result"] = PANEL_TRANSIENT_SERVICE_RESULT
+                write_panel_record(workdir, cid, panel_no, record)
+                return {
+                    "cid": cid,
+                    "result": PANEL_TRANSIENT_SERVICE_RESULT,
+                    "detail": ";".join(failures),
+                    "votes": record["votes"],
+                }
             if failures and len(contract_failures) == len(failures):
                 consecutive_contract_retries += 1
                 if (
@@ -1342,6 +1364,26 @@ def runtime_arg_error(args: argparse.Namespace) -> str | None:
     return None
 
 
+def report_exit_code(report: list[dict], reseat_failures: list[dict]) -> int:
+    """Return success, typed temporary-service failure, or hard failure."""
+    applied = {
+        "audited_clean", "audited_renaming", "audited_conditional",
+        "audited_decoration", "audited_failed", "audited_numerical_match",
+    }
+    panels_ok = all(item.get("result") in applied for item in report)
+    transient = any(
+        item.get("result") == PANEL_TRANSIENT_SERVICE_RESULT
+        for item in report
+    )
+    retryable = all(
+        item.get("result") in applied | {PANEL_TRANSIENT_SERVICE_RESULT}
+        for item in report
+    )
+    if retryable and transient and not reseat_failures:
+        return batch.TRANSIENT_SERVICE_EXIT_CODE
+    return 0 if (panels_ok and not reseat_failures) else 1
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Five-judge panel drainer for cross-confirmation disagreements"
@@ -1481,14 +1523,9 @@ def main() -> int:
         encoding="utf-8",
     )
     print(f"report: {workdir / 'report.jsonl'}")
-    applied = {
-        "audited_clean", "audited_renaming", "audited_conditional",
-        "audited_decoration", "audited_failed", "audited_numerical_match",
-    }
     if reseat_failures:
         print(f"== reseat failures: {len(reseat_failures)} (nonzero exit)")
-    panels_ok = all(item.get("result") in applied for item in report)
-    return 0 if (panels_ok and not reseat_failures) else 1
+    return report_exit_code(report, reseat_failures)
 
 
 if __name__ == "__main__":

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import orchestrate_audit_batch as batch
 import orchestrate_audit_loop as audit_loop
+import orchestrate_judicial_panel as panel
 
 
 class GeneratedProvenanceRecoveryTest(unittest.TestCase):
@@ -669,12 +670,15 @@ def _args() -> argparse.Namespace:
         max_workers=4,
         worker_id="",
         max_passes=0,
+        max_runtime_hours=0,
         max_lane_cycles=0,
         batch_rounds=6,
         stall_minutes=45,
         runner_timeout_sec=120,
         codex_timeout_sec=2700,
         push_retries=3,
+        service_retry_initial_sec=60,
+        service_retry_max_sec=900,
         dispatch_science_fixes=False,
         skip_forensic_canary=True,
         dry_run=False,
@@ -696,6 +700,44 @@ class BatchExitSemanticsTest(unittest.TestCase):
     def test_validation_failure_remains_hard(self):
         report = [{"cid": "row", "result": "validation_failed"}]
         self.assertTrue(batch.report_has_hard_blocker(report))
+
+    def test_transient_service_failure_uses_temporary_exit(self):
+        report = [{
+            "cid": "row",
+            "result": batch.TRANSIENT_SERVICE_FAILURE_RESULT,
+        }]
+        self.assertTrue(batch.report_has_hard_blocker(report))
+        self.assertEqual(
+            batch.report_exit_code(report),
+            batch.TRANSIENT_SERVICE_EXIT_CODE,
+        )
+
+    def test_transient_service_failure_does_not_mask_hard_peer(self):
+        report = [
+            {
+                "cid": "retryable",
+                "result": batch.TRANSIENT_SERVICE_FAILURE_RESULT,
+            },
+            {"cid": "hard", "result": "worker_exit_1"},
+        ]
+        self.assertEqual(batch.report_exit_code(report), 1)
+
+    def test_judicial_service_failure_uses_temporary_exit(self):
+        report = [{
+            "cid": "row",
+            "result": panel.PANEL_TRANSIENT_SERVICE_RESULT,
+        }]
+        self.assertEqual(
+            panel.report_exit_code(report, []),
+            batch.TRANSIENT_SERVICE_EXIT_CODE,
+        )
+        self.assertEqual(
+            panel.report_exit_code(
+                report + [{"cid": "hard", "result": "panel_delivery_short"}],
+                [],
+            ),
+            1,
+        )
 
     def test_campaign_quarantine_makes_only_its_schema_failures_resumable(self):
         report = [
@@ -773,6 +815,77 @@ class SchemaRecoveryTest(unittest.TestCase):
 
         self.assertIn('"projector-kernel obstruction"', guidance)
         self.assertIn("copy the exact mechanism string", guidance)
+
+    def test_worker_503_is_typed_as_retryable_service_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            log = root / "worker.log"
+            log.write_text(
+                "reconnecting 5/5\n"
+                "HTTP 503 Service Unavailable: "
+                "biscuit_baker_service_me_circuit_open\n",
+                encoding="utf-8",
+            )
+            job = {
+                "cid": "row",
+                "pass": 1,
+                "stalled": False,
+                "returncode": 1,
+                "raw_output": root / "missing.json",
+                "log_path": log,
+            }
+
+            envelope, result = batch.finalize_worker(job)
+
+        self.assertIsNone(envelope)
+        self.assertEqual(
+            result["result"],
+            batch.TRANSIENT_SERVICE_FAILURE_RESULT,
+        )
+        self.assertIn("biscuit_baker_service_me_circuit_open", result["detail"])
+
+    def test_credit_marker_wins_over_transient_service_marker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            log = root / "worker.log"
+            log.write_text(
+                "HTTP 503 Service Unavailable\nusage limit reached\n",
+                encoding="utf-8",
+            )
+            job = {
+                "cid": "row",
+                "pass": 1,
+                "stalled": False,
+                "returncode": 1,
+                "raw_output": root / "missing.json",
+                "log_path": log,
+            }
+
+            envelope, result = batch.finalize_worker(job)
+
+        self.assertIsNone(envelope)
+        self.assertEqual(result["result"], "worker_exit_1")
+
+    def test_judicial_vote_503_is_typed_as_retryable_service_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            log = root / "judge.log"
+            log.write_text(
+                "unexpected status 503 Service Unavailable\n",
+                encoding="utf-8",
+            )
+            vote, status = panel.collect_vote({
+                "stalled": False,
+                "returncode": 1,
+                "raw_output": root / "missing.json",
+                "log_path": log,
+            })
+
+        self.assertIsNone(vote)
+        self.assertEqual(
+            status,
+            f"{batch.TRANSIENT_SERVICE_FAILURE_RESULT}:service unavailable",
+        )
 
     def test_campaign_quarantine_persists_exact_failures_once(self):
         report = [
@@ -2922,6 +3035,61 @@ class AutomaticPanelResumeTest(unittest.TestCase):
             ["batch-lane_a-cycle-1", "panel-after-lane_a-cycle-1"],
         )
 
+    def test_transient_service_failure_panels_backs_off_and_retries(self):
+        args = _args()
+        heads = iter(["same", "same", "same", "same"])
+        labels: list[str] = []
+
+        def fake_run(label, command, env=None):
+            labels.append(label)
+            if label == "batch-lane_a-cycle-1":
+                return batch.TRANSIENT_SERVICE_EXIT_CODE
+            return 0
+
+        with mock.patch.object(
+            audit_loop, "git_head", side_effect=lambda: next(heads)
+        ), mock.patch.object(
+            audit_loop, "run_command", side_effect=fake_run
+        ), mock.patch.object(audit_loop.time, "sleep") as sleep:
+            rc, progressed = audit_loop.drain_lane("lane_a", args)
+
+        self.assertEqual(rc, 0)
+        self.assertFalse(progressed)
+        self.assertEqual(
+            labels,
+            [
+                "batch-lane_a-cycle-1",
+                "panel-after-lane_a-cycle-1",
+                "batch-lane_a-cycle-2",
+                "panel-after-lane_a-cycle-2",
+            ],
+        )
+        sleep.assert_called_once_with(60)
+
+    def test_judicial_panel_service_failure_retries_in_place(self):
+        args = _args()
+        with mock.patch.object(
+            audit_loop,
+            "run_command",
+            side_effect=[batch.TRANSIENT_SERVICE_EXIT_CODE, 0],
+        ) as run_command, mock.patch.object(audit_loop.time, "sleep") as sleep:
+            rc = audit_loop.run_panel(args, "panel-test")
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(run_command.call_count, 2)
+        sleep.assert_called_once_with(60)
+
+    def test_runtime_limit_stops_before_starting_another_batch(self):
+        args = _args()
+        args.max_runtime_hours = 1
+        with mock.patch.dict(audit_loop.PROGRESS, {"started": 0}, clear=True), \
+             mock.patch.object(audit_loop.time, "monotonic", return_value=3601), \
+             mock.patch.object(audit_loop, "run_command") as run_command, \
+             self.assertRaises(audit_loop.RuntimeLimitReached):
+            audit_loop.drain_lane("lane_a", args)
+
+        run_command.assert_not_called()
+
     def test_quarantine_only_batch_progress_resumes_until_stable(self):
         args = _args()
         heads = iter(["same", "same", "same", "same"])
@@ -2966,6 +3134,7 @@ class CampaignContractTest(unittest.TestCase):
 
         self.assertNotIn("--development-helper", help_text)
         self.assertNotIn("--coordinator", help_text)
+        self.assertIn("--max-runtime-hours", help_text)
 
     def test_packet_fingerprint_normalizes_transport_bounded_virtual_index(self):
         row = {"claim_id": "target", "deps": []}
@@ -4009,6 +4178,44 @@ class CampaignContractTest(unittest.TestCase):
                 rc = audit_loop.run_forensic_canary(args)
 
             self.assertEqual(rc, 1)
+            self.assertFalse(args.campaign_quarantine_file.exists())
+
+    def test_forensic_503_uses_temporary_service_exit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            campaign = Path(tmp)
+            args = _args()
+            args.campaign_workdir = campaign
+            args.campaign_quarantine_file = (
+                campaign / "campaign-row-exclusions.jsonl"
+            )
+            claim_id = "forensic_row"
+
+            def fake_run(_label, command, env=None):
+                log = Path(command[command.index("--run-log-path") + 1])
+                log.write_text(
+                    json.dumps(
+                        {
+                            "claim_id": claim_id,
+                            "phase": "codex_failed",
+                            "stderr": (
+                                "HTTP 503 Service Unavailable: "
+                                "biscuit_baker_service_me_circuit_open"
+                            ),
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                return 1
+
+            with mock.patch.object(
+                audit_loop,
+                "first_ready_forensic_claim",
+                return_value=claim_id,
+            ), mock.patch.object(audit_loop, "run_command", side_effect=fake_run):
+                rc = audit_loop.run_forensic_canary(args)
+
+            self.assertEqual(rc, batch.TRANSIENT_SERVICE_EXIT_CODE)
             self.assertFalse(args.campaign_quarantine_file.exists())
 
     def test_forensic_zero_exit_without_terminal_outcome_fails_closed(self):


### PR DESCRIPTION
## Root cause

The audit drainer treated every nonzero worker, judicial-panel, and forensic-canary exit as a hard campaign failure. A terminal, retryable backend outage (`biscuit_baker_service_me_circuit_open` / HTTP 502–504) therefore stopped the entire drain even though it had produced no scientific verdict and required only a later retry.

## Changes

- Classify only a narrow allowlist of terminal transport/backend outage signatures as retryable.
- Make credit, quota, billing, authentication, authorization, and unknown failures remain hard stops.
- Propagate retryable service outages with `EX_TEMPFAIL` (75) through batch, panel, and canary phases.
- Retry at safe phase boundaries with capped exponential backoff.
- Preserve the normal unbounded campaign default; add an optional `--max-runtime-hours` boundary for explicitly bounded campaigns.
- Document the failure taxonomy and runtime behavior in the canonical audit-loop skill.
- Add regression coverage across worker classification, mixed failures, batch/panel/canary retries, and safe runtime termination.

## Scientific impact

This changes orchestration only. Transient service failures create no audit verdict, no claim-state mutation, and no quarantine record. Existing Nature-grade gates, two-seat critical-claim rules, fail-closed parsing, and hard-stop treatment of unknown or account-level failures remain unchanged.

## Validation

- `python3 -m unittest docs.audit.scripts.tests.test_audit_loop_orchestrator` — 129 tests passed
- focused new/affected tests — 21 passed
- `python3 docs/audit/scripts/audit_pipeline.py --all` — passed
- `python3 docs/audit/scripts/audit_lint.py --strict` — 0 errors
- `python3 scripts/vocab_lint.py --fix <changed files>` — 0 violations
- `python3 -m py_compile <changed Python files>` — passed
- `git diff --check` — clean
