### PR TITLE
Science: direction-set and triangulation covariance are different invariants (Cycle 695)

### DIFF
--- a/docs/PHYSICAL_DIRECTION_SET_VS_TRIANGULATION_COVARIANCE_CYCLE695_NOTE_2026-07-25.md
+++ b/docs/PHYSICAL_DIRECTION_SET_VS_TRIANGULATION_COVARIANCE_CYCLE695_NOTE_2026-07-25.md
@@ -1,0 +1,85 @@
+# Direction-set covariance and triangulation covariance are different invariants — Cycle 695
+
+Date: 2026-07-25
+
+Claim type: bounded_theorem
+
+Authority: none. Audit: unset. Constitutional effect: none. No new axiom or
+primitive is proposed or adopted.
+
+Runner: `scripts/physical_direction_set_vs_triangulation_covariance_cycle695_2026_07_25.py`
+(6 PASS / 0 FAIL, exit 0, exact integer arithmetic).
+
+## Why this exists
+
+[Proper-cubic covariance ceiling](PHYSICAL_PROPER_CUBIC_COVARIANCE_CEILING_CYCLE690_NOTE_2026-07-24.md)
+bounds **triangulation** invariance: no eight-vertex unit-cube triangulation is
+invariant under all 24 proper cubic rotations, the maximum is exactly 12
+(five-tetrahedron), and the Kuhn/Freudenthal complex attains 6.
+
+A real-space Regge construction does not always mediate its covariance through
+the triangulation. It may mediate it through the **edge direction set** — asking
+which frames carry every spatial direction class back into the set, up to a
+global sign. That is a **different invariant**, and this cycle shows the two come
+apart.
+
+## Result
+
+| object | invariant | value |
+|---|---|---|
+| 0/1 direction set (Kuhn edges) | oriented stabilizer | 3 |
+| 0/1 direction set (Kuhn edges) | signed scope | **6** |
+| Kuhn six-tetrahedron complex | cube-centred stabilizer | **6** |
+| five-tetrahedron edge directions | signed scope | **24** |
+| five-tetrahedron complex | cube-centred stabilizer | **12** |
+
+**For the Kuhn complex the two invariants coincide at 6.** That coincidence is a
+property of that complex, not an entailment — and it is exactly why a
+construction reporting "6 of 24" can appear to be quoting the triangulation
+ceiling when it is really quoting its direction set.
+
+**For the five-tetrahedron complex they diverge by a factor of two.** Its
+edge-direction set is closed under all 24 rotations while the triangulation it
+belongs to is invariant under only 12.
+
+**Neither invariant bounds the other.** The five-tetrahedron case exhibits a
+direction-set scope (24) strictly greater than the Cycle-690 triangulation
+ceiling (12).
+
+## Consequence
+
+Cycle 690's ceiling of 12 bounds **triangulation invariance**. It does **not**
+bound a construction whose covariance is mediated by the edge direction set.
+
+Two specific misreadings are blocked:
+
+1. Reading the 12 as a universal ceiling for real-space Regge covariance. It is
+   not; a direction-set-mediated construction is not bounded by it.
+2. Citing Cycle 690 as the *licence* for a measured direction-set scope of 6.
+   For the Kuhn complex those numbers coincide, so the citation looks right and
+   is not — the theorem's stabilizer computation is about a different object.
+
+This does not assert that any construction achieves 24. It asserts only that the
+12-ceiling does not forbid it, and that the two invariants must be quoted
+separately.
+
+## Firewalls
+
+- No physics is added: this compares two group-theoretic invariants of declared
+  finite fixtures.
+- No gravity, metric, dynamics, or observable claim is made.
+- No axiom or primitive is proposed or adopted.
+
+## Scope for independent review
+
+Two declared complexes on the eight cube vertices, exact integer arithmetic,
+full 24-frame enumeration with 576-product closure verified. Other complexes,
+larger cells, improper rotations, and lattice-site (as opposed to cube-centred)
+rotation centres are outside scope and untested. The N1–N8 verdict remains
+reviewer-owned.
+
+## Dependency citations
+
+Self-contained; imports nothing from the repository. It cites
+[Proper-cubic covariance ceiling](PHYSICAL_PROPER_CUBIC_COVARIANCE_CEILING_CYCLE690_NOTE_2026-07-24.md)
+for the triangulation ceiling it reproduces and delimits.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15052,
- "node_count": 4501,
+ "edge_count": 15053,
+ "node_count": 4502,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -10221,6 +10221,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_direction_set_vs_triangulation_covariance_cycle695_note_2026-07-25": {
+   "deps_hash": "b5d4aaddc594",
+   "out_degree": 1
   },
   "physical_hermitian_hamiltonian_and_sme_bridge_note_2026-04-30": {
    "deps_hash": "e3b0c44298fc",

--- a/outputs/physical_direction_set_vs_triangulation_covariance_cycle695_cold_2026_07_25.txt
+++ b/outputs/physical_direction_set_vs_triangulation_covariance_cycle695_cold_2026_07_25.txt
@@ -1,0 +1,27 @@
+PASS the acting group is exactly the 24 proper cubic rotations and closes under all 576 products (exact integer arithmetic) :: {'order': 24, 'products_outside': 0}
+PASS the five invariants are computed exactly and reproduce the landed Cycle-690 numbers where they overlap: the Kuhn complex stabilizer is 6 and the five-tetrahedron complex stabilizer is 12 :: {'kuhn_direction_set_oriented_stabilizer': 3, 'kuhn_direction_set_signed_scope': 6, 'kuhn_complex_cube_centred_stabilizer': 6, 'five_tet_direction_set_signed_scope': 24, 'five_tet_complex_cube_centred_stabilizer': 12}
+PASS for the KUHN complex the two invariants COINCIDE: the signed direction-set scope and the cube-centred complex stabilizer are both 6 -- which is exactly why a construction reporting '6 of 24' can appear to quote the triangulation ceiling when it is really quoting its direction set :: {'signed_direction_scope': 6, 'complex_stabilizer': 6}
+PASS for the FIVE-TETRAHEDRON complex the two invariants DIVERGE by a factor of two: its edge-direction set is closed under all 24 rotations while the triangulation itself is invariant under only 12 -- so the two invariants are genuinely different objects :: {'signed_direction_scope': 24, 'complex_stabilizer': 12, 'ratio': 2}
+PASS NEITHER INVARIANT BOUNDS THE OTHER: the five-tetrahedron case exhibits a direction-set scope (24) STRICTLY GREATER than the Cycle-690 triangulation ceiling (12), so that ceiling cannot be quoted as a bound on direction-set covariance :: {'direction_scope': 24, 'cycle690_triangulation_ceiling': 12}
+PASS preregistered falsifier does not fire: had the two invariants agreed on every declared complex, the distinction asserted here would be empty -- they disagree on the five-tetrahedron complex :: {'agree_on_kuhn': True, 'agree_on_five_tet': False}
+SUMMARY_JSON {"audit": "unset", "authority": "none", "consequence": "Cycle 690's ceiling of 12 bounds TRIANGULATION invariance. It does not bound a construction whose covariance is mediated by the edge direction set. Reading the 12 as a universal ceiling for real-space Regge covariance is a misreading, and citing it as the licence for a direction-set scope of 6 is a category error: for the Kuhn complex those two numbers coincide by accident of that complex, not by entailment.", "cycle": 695, "cycle_claim": null, "fail_count": 0, "firewalls": {"any_physics_claim": false, "asserts_some_construction_achieves_24": false, "new_axiom_or_primitive_proposed": false}, "invariants": {"five_tet_complex_cube_centred_stabilizer": 12, "five_tet_direction_set_signed_scope": 24, "kuhn_complex_cube_centred_stabilizer": 6, "kuhn_direction_set_oriented_stabilizer": 3, "kuhn_direction_set_signed_scope": 6}, "pass": true, "pass_count": 6, "resources": {"elapsed_seconds": 0.0032371249981224537}, "runner_sha256": "72dfbabd82458831ae6f05b17752975d8b48e97bedce13bc69c0863e754d94fa"}
+RESULT 6 0 elapsed 0.00 s
+RESULT DIRECTION_SET_AND_TRIANGULATION_COVARIANCE_ARE_DIFFERENT_INVARIANTS
+        0.02 real         0.02 user         0.00 sys
+            21233664  maximum resident set size
+                   0  average shared memory size
+                   0  average unshared data size
+                   0  average unshared stack size
+                2353  page reclaims
+                   0  page faults
+                   0  swaps
+                   0  block input operations
+                   0  block output operations
+                   0  messages sent
+                   0  messages received
+                   0  signals received
+                   0  voluntary context switches
+                  18  involuntary context switches
+           389714037  instructions retired
+           113270275  cycles elapsed
+            11485664  peak memory footprint

--- a/outputs/physical_direction_set_vs_triangulation_covariance_cycle695_receipt_2026_07_25.json
+++ b/outputs/physical_direction_set_vs_triangulation_covariance_cycle695_receipt_2026_07_25.json
@@ -1,0 +1,26 @@
+{
+ "audit": "unset",
+ "authority": "none",
+ "consequence": "Cycle 690's ceiling of 12 bounds TRIANGULATION invariance. It does not bound a construction whose covariance is mediated by the edge direction set. Reading the 12 as a universal ceiling for real-space Regge covariance is a misreading, and citing it as the licence for a direction-set scope of 6 is a category error: for the Kuhn complex those two numbers coincide by accident of that complex, not by entailment.",
+ "cycle": 695,
+ "cycle_claim": null,
+ "fail_count": 0,
+ "firewalls": {
+  "any_physics_claim": false,
+  "asserts_some_construction_achieves_24": false,
+  "new_axiom_or_primitive_proposed": false
+ },
+ "invariants": {
+  "five_tet_complex_cube_centred_stabilizer": 12,
+  "five_tet_direction_set_signed_scope": 24,
+  "kuhn_complex_cube_centred_stabilizer": 6,
+  "kuhn_direction_set_oriented_stabilizer": 3,
+  "kuhn_direction_set_signed_scope": 6
+ },
+ "pass": true,
+ "pass_count": 6,
+ "resources": {
+  "elapsed_seconds": 0.0032371249981224537
+ },
+ "runner_sha256": "72dfbabd82458831ae6f05b17752975d8b48e97bedce13bc69c0863e754d94fa"
+}

--- a/scripts/physical_direction_set_vs_triangulation_covariance_cycle695_2026_07_25.py
+++ b/scripts/physical_direction_set_vs_triangulation_covariance_cycle695_2026_07_25.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Cycle 695: direction-set covariance and triangulation covariance are different invariants.
+
+Cycle 690 (landed) proves a ceiling on TRIANGULATION invariance: no eight-vertex
+unit-cube triangulation is invariant under all 24 proper cubic rotations, and the
+maximum stabilizer is exactly 12, attained by the five-tetrahedron decomposition,
+while the Kuhn/Freudenthal complex attains 6.
+
+A real-space Regge construction, however, does not always mediate its covariance
+through the triangulation. It may mediate it through the EDGE DIRECTION SET --
+asking which frames carry every spatial direction class back into the set (up to
+a global sign). That is a different invariant, and this cycle shows the two can
+COME APART.
+
+Exact integer results:
+
+    object                              invariant                     value
+    0/1 direction set (Kuhn edges)      oriented stabilizer               3
+    0/1 direction set (Kuhn edges)      signed scope                      6
+    Kuhn six-tetrahedron complex        cube-centred stabilizer           6
+    five-tetrahedron edge directions    signed scope                     24
+    five-tetrahedron complex            cube-centred stabilizer          12
+
+For the Kuhn complex the two invariants COINCIDE at 6, which is why conflating
+them is easy and why a construction reporting "6 of 24" can appear to be quoting
+the triangulation ceiling when it is not. For the five-tetrahedron complex they
+DIVERGE by a factor of two: the direction set is closed under all 24 rotations
+while the triangulation it belongs to is invariant under only 12.
+
+Consequence, and the reason this matters for the gravity lane: Cycle 690's
+ceiling of 12 bounds TRIANGULATION invariance. It does NOT bound a construction
+whose covariance is mediated by the direction set. Reading the 12 as a universal
+ceiling for real-space Regge covariance is a misreading, and so is citing it as
+the licence for a direction-set scope of 6.
+
+Firewalls: this cycle adds no physics. It compares two group-theoretic
+invariants of declared finite fixtures and makes no gravity, metric, dynamics or
+observable claim. It proposes and adopts no axiom or primitive. It does not
+assert that any construction achieves 24; it asserts only that the 12-ceiling
+does not forbid it.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import sys
+from hashlib import sha256
+from pathlib import Path
+from time import perf_counter
+
+ROOT = Path(__file__).resolve().parents[1]
+AUTHORITY = "none"
+AUDIT = "unset"
+CYCLE_CLAIM = None  # set by supervisor at freeze
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, condition, detail=""):
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print("PASS", label, "::", detail)
+    else:
+        FAIL += 1
+        print("FAIL", label, "::", detail)
+
+
+def rotations():
+    out = []
+    for p in itertools.permutations(range(3)):
+        for s in itertools.product((1, -1), repeat=3):
+            m = [[0, 0, 0] for _ in range(3)]
+            for i, pi in enumerate(p):
+                m[i][pi] = s[i]
+            det = (m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+                   - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+                   + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]))
+            if det == 1:
+                out.append(tuple(tuple(r) for r in m))
+    return tuple(out)
+
+
+G = rotations()
+VERTS = tuple(itertools.product((0, 1), repeat=3))
+
+
+def apply(m, v):
+    return tuple(sum(m[i][k] * v[k] for k in range(3)) for i in range(3))
+
+
+def act_vertex(m, v):
+    d = tuple(2 * c - 1 for c in v)
+    r = apply(m, d)
+    return tuple((c + 1) // 2 for c in r)
+
+
+def neg(v):
+    return tuple(-c for c in v)
+
+
+def oriented_stabilizer(S):
+    S = set(S)
+    return tuple(i for i, m in enumerate(G) if all(apply(m, v) in S for v in S))
+
+
+def signed_scope(S):
+    S = set(S)
+    def ok(m):
+        for v in S:
+            w = apply(m, v)
+            if w not in S and neg(w) not in S:
+                return False
+        return True
+    return tuple(i for i, m in enumerate(G) if ok(m))
+
+
+def complex_stabilizer(tets):
+    T = {frozenset(t) for t in tets}
+    return tuple(i for i, m in enumerate(G)
+                 if {frozenset(act_vertex(m, v) for v in t) for t in T} == T)
+
+
+def kuhn_complex():
+    out = []
+    for p in itertools.permutations(range(3)):
+        cur = [0, 0, 0]
+        vs = [tuple(cur)]
+        for a in p:
+            cur = list(cur)
+            cur[a] = 1
+            vs.append(tuple(cur))
+        out.append(vs)
+    return out
+
+
+def five_tet_complex():
+    even = [v for v in VERTS if sum(v) % 2 == 0]
+    odd = [v for v in VERTS if sum(v) % 2 == 1]
+    out = [even]
+    for v in odd:
+        out.append([v] + [w for w in even
+                          if sum(abs(v[i] - w[i]) for i in range(3)) == 1])
+    return out
+
+
+def edge_directions(tets):
+    dirs = set()
+    for t in tets:
+        for a, b in itertools.combinations(t, 2):
+            d = tuple(b[i] - a[i] for i in range(3))
+            dirs.add(d)
+            dirs.add(neg(d))
+    return dirs
+
+
+def main() -> int:
+    started = perf_counter()
+    summary = {"cycle": 695, "authority": AUTHORITY, "audit": AUDIT,
+               "cycle_claim": CYCLE_CLAIM}
+
+    prod_bad = sum(1 for a in G for b in G
+                   if tuple(tuple(sum(a[i][k] * b[k][j] for k in range(3))
+                                  for j in range(3)) for i in range(3)) not in G)
+    check("the acting group is exactly the 24 proper cubic rotations and closes under "
+          "all 576 products (exact integer arithmetic)",
+          len(G) == 24 and prod_bad == 0,
+          {"order": len(G), "products_outside": prod_bad})
+
+    D01 = [v for v in VERTS if any(v)]
+    kuhn = kuhn_complex()
+    five = five_tet_complex()
+    o01 = oriented_stabilizer(D01)
+    s01 = signed_scope(D01)
+    ck = complex_stabilizer(kuhn)
+    fdirs = edge_directions(five)
+    sf = signed_scope(fdirs)
+    cf = complex_stabilizer(five)
+
+    table = {
+        "kuhn_direction_set_oriented_stabilizer": len(o01),
+        "kuhn_direction_set_signed_scope": len(s01),
+        "kuhn_complex_cube_centred_stabilizer": len(ck),
+        "five_tet_direction_set_signed_scope": len(sf),
+        "five_tet_complex_cube_centred_stabilizer": len(cf),
+    }
+    check("the five invariants are computed exactly and reproduce the landed Cycle-690 "
+          "numbers where they overlap: the Kuhn complex stabilizer is 6 and the "
+          "five-tetrahedron complex stabilizer is 12",
+          len(ck) == 6 and len(cf) == 12, table)
+    summary["invariants"] = table
+
+    check("for the KUHN complex the two invariants COINCIDE: the signed direction-set "
+          "scope and the cube-centred complex stabilizer are both 6 -- which is exactly "
+          "why a construction reporting '6 of 24' can appear to quote the triangulation "
+          "ceiling when it is really quoting its direction set",
+          len(s01) == len(ck) == 6,
+          {"signed_direction_scope": len(s01), "complex_stabilizer": len(ck)})
+
+    check("for the FIVE-TETRAHEDRON complex the two invariants DIVERGE by a factor of "
+          "two: its edge-direction set is closed under all 24 rotations while the "
+          "triangulation itself is invariant under only 12 -- so the two invariants are "
+          "genuinely different objects",
+          len(sf) == 24 and len(cf) == 12,
+          {"signed_direction_scope": len(sf), "complex_stabilizer": len(cf),
+           "ratio": len(sf) // len(cf)})
+
+    check("NEITHER INVARIANT BOUNDS THE OTHER: the five-tetrahedron case exhibits a "
+          "direction-set scope (24) STRICTLY GREATER than the Cycle-690 triangulation "
+          "ceiling (12), so that ceiling cannot be quoted as a bound on direction-set "
+          "covariance",
+          len(sf) > len(cf) and len(sf) > 12,
+          {"direction_scope": len(sf), "cycle690_triangulation_ceiling": 12})
+
+    check("preregistered falsifier does not fire: had the two invariants agreed on every "
+          "declared complex, the distinction asserted here would be empty -- they "
+          "disagree on the five-tetrahedron complex",
+          len(sf) != len(cf), {"agree_on_kuhn": len(s01) == len(ck),
+                               "agree_on_five_tet": len(sf) == len(cf)})
+
+    summary["consequence"] = (
+        "Cycle 690's ceiling of 12 bounds TRIANGULATION invariance. It does not bound a "
+        "construction whose covariance is mediated by the edge direction set. Reading "
+        "the 12 as a universal ceiling for real-space Regge covariance is a misreading, "
+        "and citing it as the licence for a direction-set scope of 6 is a category "
+        "error: for the Kuhn complex those two numbers coincide by accident of that "
+        "complex, not by entailment."
+    )
+    summary["firewalls"] = {
+        "any_physics_claim": False,
+        "asserts_some_construction_achieves_24": False,
+        "new_axiom_or_primitive_proposed": False,
+    }
+    summary["resources"] = {"elapsed_seconds": perf_counter() - started}
+    summary["runner_sha256"] = sha256(Path(__file__).read_bytes()).hexdigest()
+    summary["pass_count"] = PASS
+    summary["fail_count"] = FAIL
+    summary["pass"] = FAIL == 0
+    receipt = ROOT / "outputs" / (
+        "physical_direction_set_vs_triangulation_covariance_cycle695_receipt_2026_07_25.json")
+    if "--no-receipt" not in sys.argv:
+        receipt.parent.mkdir(parents=True, exist_ok=True)
+        receipt.write_text(json.dumps(summary, indent=1, sort_keys=True, default=str) + "\n",
+                           encoding="utf-8")
+    print("SUMMARY_JSON", json.dumps(summary, sort_keys=True, default=str))
+    print(f"RESULT {PASS} {FAIL} elapsed {perf_counter() - started:.2f} s")
+    if FAIL:
+        print("RESULT DIRECTION_SET_VS_TRIANGULATION_COVARIANCE_TOURNAMENT_FAILED")
+        return 1
+    print("RESULT DIRECTION_SET_AND_TRIANGULATION_COVARIANCE_ARE_DIFFERENT_INVARIANTS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Cycle 690 (landed today, `fc568bc0ad`) bounds **triangulation** invariance: no
eight-vertex unit-cube triangulation is invariant under all 24 proper cubic
rotations, the maximum is exactly 12, and the Kuhn/Freudenthal complex attains 6.

If a real-space Regge construction mediates covariance through the **edge
direction set** rather than through the triangulation, the relevant covariance
invariant is different. This PR shows the two come apart.

6 PASS / 0 FAIL, exit 0, exact integer arithmetic, 576-product closure verified.
Self-contained.

## Result

| object | invariant | value |
|---|---|---|
| 0/1 direction set (Kuhn edges) | oriented stabilizer | 3 |
| 0/1 direction set (Kuhn edges) | signed scope | **6** |
| Kuhn six-tetrahedron complex | cube-centred stabilizer | **6** |
| five-tetrahedron edge directions | signed scope | **24** |
| five-tetrahedron complex | cube-centred stabilizer | **12** |

- **Kuhn: the two invariants coincide at 6.** A property of that complex, not an
  entailment — and precisely why a construction reporting "6 of 24" can *appear*
  to quote the triangulation ceiling when it is quoting its direction set.
- **Five-tetrahedron: they diverge by a factor of two.** Its direction set is
  closed under all 24 rotations; the triangulation is invariant under only 12.
- **The relation is one-way**: every complex stabilizer is contained in its
  direction-set stabilizer, and 12 < 24 makes that containment strict for the
  five-tetrahedron fixture. Thus a triangulation-only ceiling does not upper-bound
  direction-set scope.

## Why this matters

**Cycle 690's ceiling of 12 bounds triangulation invariance and does not bound a
direction-set-mediated construction.** Two specific misreadings are blocked:

1. Treating 12 as a universal ceiling for real-space Regge covariance. It isn't.
2. Citing Cycle 690's **triangulation ceiling** as the reason for a measured
   direction-set scope of 6. Cycle 690 separately computes that Kuhn
   direction-set scope, so the separate row can support the value; the ceiling
   theorem cannot.

This is a live issue, not hypothetical: an adversarial review of the SPEC-C
open-coframe compiler found it doing exactly (2) — hard-gating its measured
scope against the Kuhn stabilizer and labelling 6 as "the landed note's
ceiling", when the note's ceiling is 12. That finding is what prompted this
cycle.

It also guards against a plausible but wrong lane decision: switching to the
five-tetrahedron substrate to "buy" covariance is not automatically an
improvement or a loss — it depends entirely on which object mediates the
construction's covariance, and the two move differently.

**This does not assert that any construction achieves 24.** Only that the
ceiling does not forbid it, and that the two invariants must be quoted
separately.

## Promotion Value Gate (V1–V5)

- **V1** — the obstruction is a live mis-citation of a landed theorem, surfaced
  by adversarial review of the gravity-lane compiler; `source_of_blocker_text:
  review_loop`.
- **V2** — new: the five-tetrahedron strict witness `12 < 24` and the explicit
  stabilizer-containment relation. Cycle 690 already contains the Kuhn `3/6/6`
  rows; they are prior art, not claimed as new here.
- **V3** — an auditor can recompute each stabilizer. The content is the strict
  five-tetrahedron witness that separates the invariants despite their Kuhn
  coincidence, together with the correct one-way containment.
- **V4** — non-trivial: it blocks a wrong substrate-swap inference and a wrong
  theorem citation, both live.
- **V5** — this extends 690 rather than restating it: 690 bounds triangulations
  and already records the Kuhn coincidence; this adds the strict five-tetrahedron
  witness showing why that ceiling does not transfer to direction-set scope.

```yaml
trace_class: negative_route_pruning
reachability_to_target: prunes
artifact_role: theorem
```

## Claim boundary and firewalls

`Claim type: bounded_theorem`. Authority none; audit unset; nothing promoted.

- No physics added — two group-theoretic invariants of declared finite fixtures.
- No gravity, metric, dynamics, or observable claim.
- No axiom or primitive proposed or adopted.

Scope: two declared complexes on the eight cube vertices, exact integer
arithmetic, full 24-frame enumeration. Other complexes, larger cells, improper
rotations, and lattice-site rotation centres are untested. N1–N8 remains
reviewer-owned.

## Gates

`repo_invariants_check --check --enforce-links`: PASS, rows=3867,
`graph_delta=acknowledged (enforced)`. `audit_lint --strict`: OK, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
