### PR TITLE
feat(kcpt): U26 — Comm as non-split central double cover of T ⋊ B₃; End_Comm(C^N) = C[D2]

### DIFF
--- a/docs/KCPT_D2_COMMUTANT_DOUBLE_COVER_BICOMMUTANT_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-25.md
+++ b/docs/KCPT_D2_COMMUTANT_DOUBLE_COVER_BICOMMUTANT_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-25.md
@@ -1,0 +1,259 @@
+# KCPT D2 commutant double cover and bicommutant structure (L=4 and L=6) (bounded theorem)
+
+**Type:** bounded_theorem
+
+registry id: `kcpt_d2_commutant_double_cover_bicommutant_structure`
+
+## claim_scope
+
+- **Kind:** bounded_theorem. Exact integer group enumeration and an exact-integer
+  minimal-polynomial annihilation, plus a numerically resolved eigenspace/character
+  block, on the fixed staggered lattices L ∈ {4, 6} (N = 64 and N = 216 on the L³ torus).
+  Group orders, the semidirect/extension structure, the derived subgroup, involution
+  lift-squares, and the minimal polynomial of `D2` are exact integer facts; the seven
+  eigenspace-projector characters are resolved at the stated tolerances on those two
+  finite objects.
+- **Object:** the signed-permutation commutant
+  `Comm(D2) = { signed permutation U : U D2 = D2 U }` exactly as enumerated in the landed
+  Unit 25 lane; the permutation-part map `Comm → perms` and its image `I`; the central
+  extension `1 → {±1} → Comm → T ⋊ B₃ → 1`; the derived subgroup `[Comm, Comm]`; and the
+  endomorphism algebra `End_Comm(C^N)` together with its identification with the
+  polynomial algebra `C[D2]`.
+- **Scope limits:** r-neutral. No physical, continuum, or thermodynamic claim is made;
+  every quantity is a numerical invariant of the finite L ∈ {4, 6} construction. The two
+  lattice sizes are two separate finite-surface measurements, not a general-L statement.
+
+## 1. Objects and setup
+
+- Lattices L = 4 (N = 64) and L = 6 (N = 216) on the L³ torus with the same staggered
+  integer antisymmetric adjacency `D2` used by the landed Unit 25 lane (`eta_0 = 1`,
+  `eta_1 = (-1)^{x0}`, `eta_2 = (-1)^{x0+x1}`). `M = D2²` has spectrum `[0, -4, -8, -12]`
+  with shell multiplicities `[8, 24, 24, 8]` at L=4, and `[0, -3, -6, -9]` with
+  `[8, 48, 96, 64]` at L=6 (spectrum and multiplicities recomputed and gated).
+- The full signed-permutation commutant `Comm(D2)`, with `|Comm| = 6144 = 96N` (L=4) and
+  `20736 = 96N` (L=6), is reused verbatim from the landed Unit 25 module: the runner
+  imports it and calls its lattice, support-structure, commutant-enumeration, symmetry
+  group `H`, dressed-rotation `g_r4`, character-sum, and closure interfaces. No enumeration
+  is reimplemented here; this unit reads the enumerated group and derives its structure.
+- The reference hyperoctahedral group `B₃` (order 48, ≅ O_h) is built independently inside
+  this runner as the 48 signed-permutation 3×3 matrices (`itertools.permutations` of the
+  three axes times the eight sign patterns), so every "= B₃" claim is a set equality
+  against a from-scratch object, not against the enumerator that produced `Comm`.
+- Structural generators of `Comm`: the lifts of the three unit translations, the lifts of
+  the three linear maps `A_cyc = [[0,0,1],[1,0,0],[0,1,0]]`,
+  `A_swap = [[0,1,0],[1,0,0],[0,0,1]]`, `A_flip = diag(-1,1,1)`, and the central `-1`
+  (identity permutation with all signs `-1`). Their closure is gated to recover all of
+  `Comm` at both L (a seven-generator presentation of the group).
+- All group-theoretic decisions (composition, inverse, membership, closure, order,
+  involution test, lift-square) use exact integer signed-permutation arithmetic and byte
+  keys; the minimal-polynomial proof stays in exact `int64`; `np.linalg.eigh` of `i·D2`
+  (complex Hermitian) enters only for the eigenspace/projector-character block. No floating
+  tolerance enters any group decision.
+
+## 2. Theorem claims
+
+**T1 (structure; gates STRUCT, KERNEL, TRANS, CANON_LINEAR, B3GEN, STRUCTGENS).** The
+kernel of the permutation-part map `Comm → perms` is exactly `{±1}` (size 2, both signs
+constant). The image `I` contains all `N` translations `T` as a normal subgroup (every
+translation present; each `T`-element conjugated by the three linear generators lands back
+in `T`); `I/T` has exactly 48 cosets; every 0-fixing canonical coset representative is
+LINEAR, `x ↦ Ax mod L`, verified on all N sites, and the 48 matrices `A` are exactly the
+independently built reference `B₃` — the SAME 48-matrix set at L=4 and L=6 — and the 48
+canonical representatives are closed under composition. Hence `I = T ⋊ B₃` as an internal
+semidirect product at the permutation level, and
+`|Comm| = 2·|T|·|B₃| = 2·N·48 = 96N` — the structural account of the Unit 25 census law
+`|Comm| = 6144 / 20736` at both L. The seven structural generators close to all of `Comm`.
+
+**T2 (non-split central double cover; gates INVOL, DERIVED, MINUS1_DERIVED, PIDERIVED,
+EVENSUB, A4IMAGE).** The central extension `1 → {±1} → Comm → T ⋊ B₃ → 1` is a
+**non-split central double cover**, by two independent computations.
+(a) *Involution lift-squares.* Each involution `σ ∈ I` has exactly two lifts `±ŝ` in
+`Comm` sharing one square (`(−ŝ)² = ŝ²`). A split extension via a section would give every
+involution a lift squaring to `+1`; instead, of 359 involutions in `I` at L=4, 192 have
+lift-square `−1`, and of 799 at L=6, 400 have lift-square `−1`. Any lift-square-`−1`
+involution obstructs a section.
+(b) *`−1 ∈ [Comm, Comm]`.* A split central extension is the direct product
+`{±1} × (T ⋊ B₃)`, whose derived subgroup omits `(−1, 1)`; the computed containment
+`−1 ∈ [Comm, Comm]` at both L refutes the direct-product form. Together these refute the
+naive conjecture `Comm ≅ ⟨−1⟩ × (T ⋊ B₃)`.
+Fine structure of the derived subgroup (both L): `|[Comm, Comm]| = 12N = |Comm|/8`
+(abelianization order 8); `π([Comm, Comm]) = [I, I]` has order `6N`; its translation part
+is exactly the **even-parity sublattice** `{v : v₁+v₂+v₃ ≡ 0 mod 2}` (order `N/2`, EXACT
+set equality); and its `B₃`-image is exactly `A₄` (order 12, order-spectrum
+`{1:1, 2:3, 3:8}`, all determinant `+1`). So `[I, I] = T_even ⋊ A₄`, and `[Comm, Comm]` is
+its preimage double cover.
+
+**T3 (bicommutant / spectral completeness; gates MINPOLY, ENDCOMM_CD2, KERDIM, EIGDIMS,
+CHARNORM).** `End_Comm(C^N) = C[D2]` exactly, by four steps. (i) `dim End_Comm = 7` at
+both L, from the landed Unit 25 integer character sum. (ii) `C[D2] ⊆ End_Comm` always, and
+a deterministic sample of the enumerated commutant is re-verified to commute with `D2`.
+(iii) `dim C[D2] = deg minpoly(D2) = ` the number of distinct `D2` eigenvalues `= 7`,
+proven in exact `int64`: with `M = D2²`, the product
+`D2·(M+4I)(M+8I)(M+12I) = 0` at L=4 and `D2·(M+3I)(M+6I)(M+9I) = 0` at L=6 (a degree-7
+annihilating polynomial whose factors are read off the distinct `M`-shells), while dropping
+ANY single factor — including the leading `D2` — leaves a nonzero integer matrix
+(`.any()` true), so the degree is exactly 7. (iv) Equality by the dimension count `7 = 7`.
+Corollary: `End_Comm` is abelian, so the `Comm`-representation on `C^N` is
+**multiplicity-free** with exactly 7 pairwise-inequivalent irreducible components — the 7
+`D2`-eigenspaces. Each eigenspace-projector character, summed over all `|Comm|` group
+elements, has squared norm `1` (irreducible) and pairwise inner product `~0` (inequivalent),
+observed to `≤ 1e-15`. The kernel of `D2` has dimension 8 at both L (a two-size-stable
+anchor) and is a single irreducible component. Eigenspace dimensions, ordered by ascending
+`i·D2` eigenvalue, are `[4, 12, 12, 8, 12, 12, 4]` (L=4, eigenvalues
+`−2√3, −2√2, −2, 0, +2, +2√2, +2√3`) and `[32, 48, 24, 8, 24, 48, 32]` (L=6, eigenvalues
+`−3, −√6, −√3, 0, +√3, +√6, +3`). This is the structural account of the Unit 25 L-stable
+`dim End_Comm = 7` headline: `7 = ` #distinct `D2` eigenvalues, stable because the spectral
+type `{0, ±iμ₁, ±iμ₂, ±iμ₃}` is stable across the two sizes.
+
+**Tie-backs (gates HCAPCOMM, D3, AR4, OCLOSURE, FULLCLOSURE_L4, CROSSL_B3, CROSSL_D3).**
+`H ∩ Comm` and `[Comm, Comm]` have the SAME order `12N` at both L but are DIFFERENT
+subgroups (intersection exactly `3N`). The `B₃`-coordinates of `H ∩ Comm` are exactly the
+6-element proper-rotation dihedral group of the body diagonal,
+`D₃ = {A ∈ B₃ : A(1,1,1)ᵀ = ±(1,1,1)ᵀ, det A = +1} ≅ S₃` (order-spectrum
+`{1:1, 2:3, 3:2}`, all det `+1`) — the SAME 6 matrices at both L, checked as a set equality
+against the independently built body-diagonal predicate subset of the reference `B₃`.
+Adjoining the `B₃`-coordinate of the dressed rotation `g_r4` — which is the bare rotation
+matrix `[[0,1,0],[−1,0,0],[0,0,1]]`, the sign dressing being invisible at the `B₃` level —
+generates the full proper-rotation subgroup `O ≅ S₄` (order 24, order-spectrum
+`{1:1, 2:9, 3:8, 4:6}`, all det `+1`), matched as a set to the det-`+1` half of the
+reference `B₃`. The chain `D₃ (6) ⊂ O (24) ⊂ B₃ (48)` is graded by determinant: `H ∩ Comm`
+reaches only det-`+1` elements at both L, and at L=4 — the only surface on which the full
+closure is enumerated — `⟨H, g_r4⟩ ∩ Comm` likewise reaches only det-`+1` elements, while
+the improper det-`−1` half of `B₃` is reached by `Comm` but not by these subgroups. At L=4 only, the full closure
+`⟨H, g_r4⟩` has order 6144 with `⟨H, g_r4⟩ ∩ Comm` of order `3072 = |Comm|/2` (consistent
+with the landed Unit 25 fact `|⟨H, g_r4⟩ ∩ Comm| = |Comm|/2`), and its `B₃`-localization
+computed from the full closure agrees with the 3×3-matrix-land route (route-agreement gate).
+This 6144 is NOT the Unit 25 graded commutant `GC` (order `2|Comm| = 12288`, a different
+object); this unit does not recompute `GC`.
+
+## 3. Evidence — measured values
+
+| quantity | L=4 (N=64) | L=6 (N=216) |
+|----------|-----------:|------------:|
+| `M` shell mults | `[8, 24, 24, 8]` | `[8, 48, 96, 64]` |
+| `|Comm|` = 96N | 6144 | 20736 |
+| kernel of perm map | `{±1}` (size 2) | `{±1}` (size 2) |
+| `|I|` = 48·N | 3072 | 10368 |
+| translations present in `I` | 64 / 64 | 216 / 216 |
+| `|I/T|`, canonical reps linear | 48, 48/48 | 48, 48/48 |
+| A-set == reference `B₃` | yes (48) | yes (48) |
+| `<A_cyc,A_swap,A_flip>` order | 48 | 48 |
+| 7-generator closure = `|Comm|` | 6144 | 20736 |
+| involutions in `I`, lift-square `−1` | 359, 192 | 799, 400 |
+| `|[Comm,Comm]|` = 12N, abelianization | 768, 8 | 2592, 8 |
+| `−1 ∈ [Comm,Comm]` | yes | yes |
+| `|π([Comm,Comm])|` = 6N | 384 | 1296 |
+| `π(derived) ∩ T` = even-parity sublattice (N/2) | 32 (set-eq) | 108 (set-eq) |
+| `B₃`-image of derived (= `A₄`) | 12, `{1:1,2:3,3:8}`, det+1 | 12, `{1:1,2:3,3:8}`, det+1 |
+| minpoly `D2·∏(M+cᵢI) = 0`, cᵢ | 0, `[4,8,12]` | 0, `[3,6,9]` |
+| drop-one-factor products nonzero | 4/4 | 4/4 |
+| deg minpoly = dim `C[D2]` | 7 | 7 |
+| `dim End_Comm(C^N)` (U25 char sum) | 7 | 7 |
+| commute-with-`D2` sample | 512/512 | 506/506 |
+| `dim ker D2` | 8 | 8 |
+| eigenspace dims (asc `i·D2`) | `[4,12,12,8,12,12,4]` | `[32,48,24,8,24,48,32]` |
+| 7 projector-character norms, max cross | 1.0 (dev ≤1e-15), ≤1e-16 | 1.0 (dev ≤1e-15), ≤1e-16 |
+| `|H ∩ Comm|` = 12N, `|derived ∩ (H∩Comm)|` = 3N | 768, 192 | 2592, 648 |
+| coords(`H∩Comm`) = `D₃` | 6, `{1:1,2:3,3:2}`, det+1 | 6, `{1:1,2:3,3:2}`, det+1 |
+| `A_r4` = `[[0,1,0],[−1,0,0],[0,0,1]]`, det | yes, +1 | yes, +1 |
+| `⟨D₃, A_r4⟩` = `O` | 24, `{1:1,2:9,3:8,4:6}`, det+1 | 24, `{1:1,2:9,3:8,4:6}`, det+1 |
+| `|⟨H,g_r4⟩|`, `∩ Comm` = `|Comm|/2` | 6144, 3072 | — (matrix-land route only) |
+| coords(`H∩Comm`) same 6 across L | yes | yes |
+
+All 50 gates pass with zero failures; the paired runner
+`scripts/kcpt_d2_commutant_double_cover_bicommutant_structure_2026_07_25.py` prints
+`TOTAL: PASS=50 FAIL=0`, wall-clock about 19 s (`np.linalg.eigh` of `i·D2` only for the
+eigenspace/character block). The evidentiary verdict is PASS WITH BOUNDED CLAIMS:
+exact-integer facts where stated, the eigenspace/character block resolved at the gated
+tolerances, everything bounded to the two computed surfaces L = 4 and L = 6.
+
+## 4. The cover-and-bicommutant picture
+
+The signed-permutation commutant of `D2` is not a bare product but a **non-split central
+double cover** of a familiar crystallographic group. At the permutation level `Comm`
+projects onto `I = T ⋊ B₃`: all `N` translations, extended by the full 48-element
+hyperoctahedral point group. The two signs `{±1}` in the kernel are not a spectator factor
+— the cover is non-split, witnessed independently by involutions whose lifts square to `−1`
+and by `−1` sitting inside the commutator subgroup. The derived subgroup is itself the
+double cover of `T_even ⋊ A₄`: the point-group part collapses from `B₃` to its rotation-even
+`A₄`, and the translation part collapses to the even-parity sublattice. On the module side,
+the commutant sees `D2` as a multiplicity-free operator: `End_Comm(C^N) = C[D2]`, a
+commutative algebra of dimension 7 = the number of distinct `D2` eigenvalues, so the 7
+eigenspaces are exactly the 7 inequivalent irreducible components and the 8-dimensional
+kernel of `D2` is one of them. The landed symmetry group `H` and its dressed extension
+`⟨H, g_r4⟩` localize, at the `B₃` level, to the determinant-`+1` rotation chain
+`D₃ ⊂ O ⊂ B₃` (the `⟨H, g_r4⟩` localization enumerated in full at L=4; the chain itself
+generated in matrix land, `⟨D₃, A_r4⟩ = O`, at both L); the improper half of `B₃` is
+present in `Comm` but out of reach of those subgroups. Both the group-order law `96N` and the two-size-stable `dim End_Comm = 7` of the
+Unit 25 census read off directly from this structure: `96N = 2·N·48` and
+`7 = ` #distinct `D2` eigenvalues.
+
+## 5. Dependencies
+
+- [KCPT D2 graded signed-permutation commutant characterization (L=4 and L=6) (bounded theorem)](KCPT_D2_GRADED_SIGNED_PERMUTATION_COMMUTANT_CHARACTERIZATION_BOUNDED_THEOREM_NOTE_2026-07-25.md)
+
+## Boundary
+
+- The structure is a finite fact about the two fixed staggered lattices L ∈ {4, 6}. Group
+  orders, the extension and derived-subgroup structure, involution lift-square counts, the
+  minimal polynomial, endomorphism dimension, and eigenspace dimensions are numerical
+  invariants of those constructions; no continuum limit or physical content is claimed, and
+  the statement is r-neutral.
+- The extension `1 → {±1} → Comm → T ⋊ B₃ → 1` is identified as non-split (two independent
+  obstructions), but its class in `H²(T ⋊ B₃, Z₂)` is not further classified here.
+- The seven irreducible-component dimensions are computed from the exact character sum and
+  the eigenspace decomposition; they are not matched to an abstract character-table
+  classification of `Comm`.
+- Theorems at these sizes: `|Comm| = 96N`, kernel `{±1}`, the `= B₃` identification,
+  `I = T ⋊ B₃`, non-splitness by both obstructions, `|[Comm,Comm]| = 12N` with
+  `[I,I] = T_even ⋊ A₄`, `H ∩ Comm` of order `12N` with `3N` intersection, the
+  `D₃ ⊂ O ⊂ B₃` chain, `dim ker D2 = 8`, and `End_Comm(C^N) = C[D2]` with 7
+  multiplicity-free irreducibles are established at L=4 and L=6. The L-stability of this
+  common FORM (the same `B₃`, the same 6 body-diagonal matrices, `96N`, `12N`, `3N`,
+  `N/2` even sublattice, `A₄`/`D₃`/`O` chain, `dim ker = 8`, seven irreducibles) is an
+  observation at two sizes, stated as a conjectured stable pattern — the general-L
+  statement is the next path this opens, not a theorem here.
+- The body-diagonal `D₃` identification (and the `B₃` and `O` identifications) are
+  computed set equalities against independently built reference matrices at these two L,
+  matched on order, full order-spectrum, and determinant set. The `A₄` identification of
+  the derived subgroup's point-group image is matched on order, full order-spectrum, and
+  determinant set as a subgroup of the set-equality-verified `B₃` — which forces `A₄`,
+  since the det-`+1` half of `B₃` is `O ≅ S₄` and its unique order-12 subgroup is `A₄`.
+- The single dependency row (the landed Unit 25 characterization) is landed on main but
+  itself unaudited; its anchors (`Comm`, `|Comm| = 96N`, `dim End_Comm = 7`, `g_r4`, `H`)
+  are consumed here as landed values, not as audited facts.
+
+## Honest-auditor read
+
+- The dangerous move this unit could make is to presuppose the extension splits — to write
+  `Comm ≅ ⟨−1⟩ × (T ⋊ B₃)`. It does not: two independent computations refute it, an
+  involution whose lift squares to `−1` (192 of 359 at L=4, 400 of 799 at L=6) and the
+  containment `−1 ∈ [Comm, Comm]`. Either alone obstructs a section; both are printed.
+- Every completeness claim is built to fail if the object were wrong. The minimal-polynomial
+  gate multiplies exact integer matrices and checks that the full product vanishes AND that
+  each of the four drop-one-factor products is nonzero (`.any()` on the exact `int64`
+  matrix), so degree 7 is discriminated, not assumed. The character-norm gate is the actual
+  mean of `|χ_k|²` and `χ_j·conj(χ_k)` over all `|Comm|` elements, not an asserted `1`. The
+  `B₃`, `D₃`, and `O` identifications compare order, full order-spectrum, and the
+  determinant set against reference matrices built from scratch, and additionally as full
+  set equalities; the `A₄` identification rests on order, full order-spectrum, and
+  determinant set inside the set-equality-verified `B₃`, which admits exactly one
+  order-12 all-det-`+1` subgroup — an order-only check would not distinguish these.
+- The `96N` law is derived, not fitted: kernel size 2 times `|I| = |T|·|B₃| = N·48`, with
+  `T` shown normal in `I`, the 48 canonical representatives shown linear on all N sites and
+  equal to `B₃`, and closed under composition. The seven-generator closure independently
+  recovers the full `|Comm|`.
+- The tie-back order coincidence is recorded with its resolution: `H ∩ Comm` and
+  `[Comm, Comm]` both have order `12N` yet are different subgroups (intersection `3N`,
+  printed), and the determinant grading explains why the landed rotation witnesses reach only
+  the det-`+1` chain `D₃ ⊂ O ⊂ B₃`. At L=4 the full-closure route and the matrix-land route
+  are checked to agree.
+- Residual softness a reader should weigh: the group facts and the minimal polynomial are
+  exact integers, but the eigenspace dimensions and the seven projector-character norms come
+  from a floating Hermitian diagonalization of `i·D2` (observed character deviations at the
+  `~1e-15` level, gated at `1e-9`/`1e-12`); the tolerances are conventional choices well
+  inside those margins, not derived bounds. Every L-stable statement here is an observation
+  at two sizes, not a proof for all L.
+
+This row is unaudited: its grade is set exclusively by the independent audit lane on
+origin/main, not by this note or its runner.

--- a/logs/runner-cache/kcpt_d2_commutant_double_cover_bicommutant_structure_2026_07_25.txt
+++ b/logs/runner-cache/kcpt_d2_commutant_double_cover_bicommutant_structure_2026_07_25.txt
@@ -1,0 +1,80 @@
+===== runner cache v1 =====
+runner: scripts/kcpt_d2_commutant_double_cover_bicommutant_structure_2026_07_25.py
+runner_sha256: e6aa8b55c74d9aa6e99cf0f260d4f8857d7709579845368f8edcd13c952a4fab
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 18.72
+status: ok
+----- stdout -----
+========================================================================
+KCPT U26  Comm(D2) double cover + End_Comm = C[D2]
+========================================================================
+  PASS  REF_B3                     reference B3 size 48
+  PASS  REF_O                      reference O (det +1) size 24
+  PASS  REF_D3                     reference D3 (body-diagonal) size 6
+
+[PHASE A] build L=4 (N=64)
+        nComm=6144 nH=1536 lam=[0, -4, -8, -12] mults=[8, 24, 24, 8]
+
+[PHASE B] gates L=4
+  PASS  SPECTRUM_L4                lam=[0, -4, -8, -12] (anchor [0, -4, -8, -12]), mults=[8, 24, 24, 8] (anchor [8, 24, 24, 8]), |H|=1536 (anchor 1536)
+  PASS  STRUCT_L4                  |I|=3072 (anchor 3072), ker(pi)={+-1} size 2
+  PASS  KERNEL_L4                  kernel = {+1,-1} size 2 (anchor 2)
+  PASS  TRANS_L4                   T present 64/64, normal=True, |I/T|=48 (anchor 48)
+  PASS  CANON_LINEAR_L4            linear 48/48, A-set==B3 True, closed True
+  PASS  B3GEN_L4                   <A_cyc,A_swap,A_flip> = 48 == B3 True
+  PASS  STRUCTGENS_L4              7-gen closure = 6144 (anchor 96N=6144=2*64*48)
+  PASS  INVOL_L4                   involutions 359 (anchor 359), lift-sq=-1 192 (anchor 192)
+  PASS  DERIVED_L4                 |[Comm,Comm]|=768 (anchor 12N=768), abelianization=8 (anchor 8)
+  PASS  MINUS1_DERIVED_L4          -1 in [Comm,Comm] = True
+  PASS  PIDERIVED_L4               |pi([Comm,Comm])|=384 (anchor 6N=384)
+  PASS  EVENSUB_L4                 pi(D) cap T = even sublattice size 32 (anchor N/2=32), set-eq True
+  PASS  A4IMAGE_L4                 B3-image(D) order 12 spectrum {2: 3, 3: 8, 1: 1} dets {1}
+  PASS  MINPOLY_L4                 D2*prod(M+cI)=0 True, drop-one nonzero [True, True, True, True], deg 7 cs [4, 8, 12]
+  PASS  ENDCOMM_CD2_L4             dim End_Comm=7 == deg minpoly=7 == dim C[D2]; commute-sample 512/512
+  PASS  KERDIM_L4                  dim ker D2 = 8 (anchor 8)
+  PASS  EIGDIMS_L4                 eigenspace dims [4, 12, 12, 8, 12, 12, 4] (anchor [4, 12, 12, 8, 12, 12, 4]), sum 64
+  PASS  CHARNORM_L4                7 chars norm 1 (max dev 8.88e-16), cross max 5.55e-17
+  PASS  HCAPCOMM_L4                |H cap Comm|=768 (anchor 12N=768), |D cap (H cap Comm)|=192 (anchor 3N=192), D!=HcapC True
+  PASS  D3_L4                      coords(H cap Comm) order 6 spectrum {3: 2, 2: 3, 1: 1} dets {1} bodydiag-eq True
+  PASS  AR4_L4                     A_r4 == [[0,1,0],[-1,0,0],[0,0,1]] True, in B3 True, det 1
+  PASS  OCLOSURE_L4                <D3,A_r4> order 24 spectrum {1: 1, 3: 8, 2: 9, 4: 6} dets {1} O-eq True
+  PASS  FULLCLOSURE_L4             |<H,g_r4>|=6144 (anchor 6144), cap Comm=3072 (anchor |Comm|/2=3072), route-eq True
+
+[PHASE A] build L=6 (N=216)
+        nComm=20736 nH=5184 lam=[0, -3, -6, -9] mults=[8, 48, 96, 64]
+
+[PHASE B] gates L=6
+  PASS  SPECTRUM_L6                lam=[0, -3, -6, -9] (anchor [0, -3, -6, -9]), mults=[8, 48, 96, 64] (anchor [8, 48, 96, 64]), |H|=5184 (anchor 5184)
+  PASS  STRUCT_L6                  |I|=10368 (anchor 10368), ker(pi)={+-1} size 2
+  PASS  KERNEL_L6                  kernel = {+1,-1} size 2 (anchor 2)
+  PASS  TRANS_L6                   T present 216/216, normal=True, |I/T|=48 (anchor 48)
+  PASS  CANON_LINEAR_L6            linear 48/48, A-set==B3 True, closed True
+  PASS  B3GEN_L6                   <A_cyc,A_swap,A_flip> = 48 == B3 True
+  PASS  STRUCTGENS_L6              7-gen closure = 20736 (anchor 96N=20736=2*216*48)
+  PASS  INVOL_L6                   involutions 799 (anchor 799), lift-sq=-1 400 (anchor 400)
+  PASS  DERIVED_L6                 |[Comm,Comm]|=2592 (anchor 12N=2592), abelianization=8 (anchor 8)
+  PASS  MINUS1_DERIVED_L6          -1 in [Comm,Comm] = True
+  PASS  PIDERIVED_L6               |pi([Comm,Comm])|=1296 (anchor 6N=1296)
+  PASS  EVENSUB_L6                 pi(D) cap T = even sublattice size 108 (anchor N/2=108), set-eq True
+  PASS  A4IMAGE_L6                 B3-image(D) order 12 spectrum {3: 8, 1: 1, 2: 3} dets {1}
+  PASS  MINPOLY_L6                 D2*prod(M+cI)=0 True, drop-one nonzero [True, True, True, True], deg 7 cs [3, 6, 9]
+  PASS  ENDCOMM_CD2_L6             dim End_Comm=7 == deg minpoly=7 == dim C[D2]; commute-sample 506/506
+  PASS  KERDIM_L6                  dim ker D2 = 8 (anchor 8)
+  PASS  EIGDIMS_L6                 eigenspace dims [32, 48, 24, 8, 24, 48, 32] (anchor [32, 48, 24, 8, 24, 48, 32]), sum 216
+  PASS  CHARNORM_L6                7 chars norm 1 (max dev 2.22e-16), cross max 4.39e-17
+  PASS  HCAPCOMM_L6                |H cap Comm|=2592 (anchor 12N=2592), |D cap (H cap Comm)|=648 (anchor 3N=648), D!=HcapC True
+  PASS  D3_L6                      coords(H cap Comm) order 6 spectrum {2: 3, 3: 2, 1: 1} dets {1} bodydiag-eq True
+  PASS  AR4_L6                     A_r4 == [[0,1,0],[-1,0,0],[0,0,1]] True, in B3 True, det 1
+  PASS  OCLOSURE_L6                <D3,A_r4> order 24 spectrum {1: 1, 2: 9, 3: 8, 4: 6} dets {1} O-eq True
+
+[PHASE B] cross-L gates
+  PASS  CROSSL_B3                  A-set(L4)==A-set(L6)==B3 (48 matrices)
+  PASS  CROSSL_D3                  coords(H cap Comm) same 6 matrices at L=4 and L=6
+
+========================================================================
+TOTAL: PASS=50 FAIL=0
+wall-clock: 18.6s
+
+----- stderr -----
+

--- a/scripts/kcpt_d2_commutant_double_cover_bicommutant_structure_2026_07_25.py
+++ b/scripts/kcpt_d2_commutant_double_cover_bicommutant_structure_2026_07_25.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""KCPT Unit 26 runner.
+
+Comm(D2) is a non-split central double cover of T @ B3, and End_Comm = C[D2].
+
+This runner imports the Unit 25 module (same scripts/ directory) and reuses its
+lattice / support / commutant / group construction verbatim.  Every gate here
+DERIVES its quantity from that machinery and compares it against an independent
+anchor constant.  A gate fails (and stays failing) whenever the derived object
+disagrees with its anchor; nothing is computed from its own comparison target.
+
+Theorems:
+  T1  structure       kernel {+-1}, image I = T @ B3, |Comm| = 96 N.
+  T2  double cover     non-split central extension 1 -> {+-1} -> Comm -> T@B3 -> 1;
+                       derived subgroup = T_even @ A4 lifted.
+  T3  bicommutant      End_Comm(C^N) = C[D2], dim 7, multiplicity-free.
+"""
+
+import os
+import sys
+import time
+import itertools
+import numpy as np
+from collections import Counter
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+import kcpt_d2_graded_signed_permutation_commutant_characterization_2026_07_25 as u25
+
+# ---------------------------------------------------------------- gate harness
+_P = [0]
+_F = [0]
+
+
+def gate(name, cond, msg=""):
+    ok = bool(cond)
+    if ok:
+        _P[0] += 1
+        print("  PASS  {:<26} {}".format(name, msg))
+    else:
+        _F[0] += 1
+        print("  FAIL  {:<26} {}".format(name, msg))
+    return ok
+
+
+# ---------------------------------------------------------------- 3x3 helpers
+def det3(A):
+    return int(
+        A[0, 0] * (A[1, 1] * A[2, 2] - A[1, 2] * A[2, 1])
+        - A[0, 1] * (A[1, 0] * A[2, 2] - A[1, 2] * A[2, 0])
+        + A[0, 2] * (A[1, 0] * A[2, 1] - A[1, 1] * A[2, 0])
+    )
+
+
+def mat_order(A):
+    I3 = np.eye(3, dtype=int)
+    B = A.copy()
+    k = 1
+    while not np.array_equal(B, I3):
+        B = B @ A
+        k += 1
+        if k > 64:
+            return -1
+    return k
+
+
+def mat_closure(gens):
+    I3 = np.eye(3, dtype=int)
+    seen = {I3.tobytes(): I3}
+    frontier = [I3]
+    while frontier:
+        nf = []
+        for X in frontier:
+            for G in gens:
+                Y = G @ X
+                ky = Y.tobytes()
+                if ky not in seen:
+                    seen[ky] = Y
+                    nf.append(Y)
+        frontier = nf
+    return seen
+
+
+def reference_B3():
+    mats = []
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((1, -1), repeat=3):
+            A = np.zeros((3, 3), dtype=int)
+            for r in range(3):
+                A[r, perm[r]] = signs[r]
+            mats.append(A)
+    return mats
+
+
+def order_spectrum(mats):
+    return dict(Counter(mat_order(A) for A in mats))
+
+
+def det_set(mats):
+    return set(det3(A) for A in mats)
+
+
+# ---------------------------------------------------------------- lattice maps
+def trans_perm(v, coords, idx, N):
+    p = np.empty(N, dtype=np.int64)
+    for i in range(N):
+        x = coords[i]
+        p[i] = idx(int(x[0] + v[0]), int(x[1] + v[1]), int(x[2] + v[2]))
+    return p
+
+
+def linear_perm(A, coords, idx, N):
+    p = np.empty(N, dtype=np.int64)
+    for i in range(N):
+        y = A @ coords[i]
+        p[i] = idx(int(y[0]), int(y[1]), int(y[2]))
+    return p
+
+
+def b3_coord(perm, coords, idx, L):
+    """B3 coordinate of a permutation in I: strip translation, read the linear
+    action on the three unit vectors, mapping coordinate value L-1 to -1."""
+    t = coords[perm[0]] % L
+    units = (idx(1, 0, 0), idx(0, 1, 0), idx(0, 0, 1))
+    A = np.zeros((3, 3), dtype=int)
+    for mu in range(3):
+        img = (coords[perm[units[mu]]] - t) % L
+        A[:, mu] = [(-1 if int(v) == L - 1 else int(v)) for v in img]
+    return A
+
+
+def linear_verified(perm, A, coords, idx, L, N):
+    t = coords[perm[0]] % L
+    for i in range(N):
+        y = (A @ coords[i] + t) % L
+        if int(perm[i]) != idx(int(y[0]), int(y[1]), int(y[2])):
+            return False
+    return True
+
+
+# ---------------------------------------------------------------- group helpers
+def commutator(a, b):
+    return u25.compose(u25.compose(a, b), u25.compose(u25.sp_inv(a), u25.sp_inv(b)))
+
+
+def derived_subgroup(gens):
+    """Normal closure of the commutators of the generating set = [G, G]."""
+    comms = [commutator(a, b) for a in gens for b in gens]
+    D = u25.closure(comms)
+    conj = list(gens) + [u25.sp_inv(g) for g in gens]
+    for _ in range(12):
+        extra = []
+        for d in list(D.values()):
+            for g in conj:
+                c = u25.compose(u25.compose(u25.sp_inv(g), d), g)
+                if u25.key(c) not in D:
+                    extra.append(c)
+        if not extra:
+            break
+        D = u25.closure(list(D.values()) + extra)
+    return D
+
+
+def eig_projectors(D2, N):
+    """Return (ordered eigenvalues, dims, projectors) of the 7 D2-eigenspaces
+    via the Hermitian operator i*D2."""
+    H = 1j * D2.astype(complex)
+    w, V = np.linalg.eigh(H)
+    rw = np.round(w.real, 6)
+    vals = sorted(set(rw.tolist()))
+    dims = [int(np.sum(rw == v)) for v in vals]
+    projs = []
+    for v in vals:
+        cols = np.where(rw == v)[0]
+        Vk = V[:, cols]
+        projs.append(Vk @ Vk.conj().T)
+    return vals, dims, projs
+
+
+def eig_characters(projs, P, S):
+    """chi_k(U) = tr(U P_k) = sum_i S[i] * P_k[perm[i], i], over all U in Comm."""
+    nComm, N = P.shape
+    ar = np.arange(N)
+    K = len(projs)
+    chis = [np.empty(nComm, dtype=complex) for _ in range(K)]
+    chunk = 2048
+    for c0 in range(0, nComm, chunk):
+        c1 = min(c0 + chunk, nComm)
+        Pblk = P[c0:c1]
+        Sblk = S[c0:c1].astype(complex)
+        for k, Pk in enumerate(projs):
+            vals = Pk[Pblk, ar[None, :]]
+            chis[k][c0:c1] = np.sum(Sblk * vals, axis=1)
+    return chis
+
+
+# ---------------------------------------------------------------- anchor table
+XREF = {
+    4: dict(
+        N=64, lam=[0, -4, -8, -12], mults=[8, 24, 24, 8],
+        nComm=6144, nH=1536, nI=3072, nTrans=64, canon=48,
+        invol=359, liftsq_minus=192, derived=768, abeln=8,
+        pi_derived=384, even_size=32, minpoly_cs=[4, 8, 12], deg=7, ker=8,
+        eigdims=[4, 12, 12, 8, 12, 12, 4], hcapc=768, dcap=192,
+        d3_spectrum={1: 1, 2: 3, 3: 2}, a4_spectrum={1: 1, 2: 3, 3: 8},
+        o_spectrum={1: 1, 2: 9, 3: 8, 4: 6}, full_hg=6144, hg_cap=3072,
+    ),
+    6: dict(
+        N=216, lam=[0, -3, -6, -9], mults=[8, 48, 96, 64],
+        nComm=20736, nH=5184, nI=10368, nTrans=216, canon=48,
+        invol=799, liftsq_minus=400, derived=2592, abeln=8,
+        pi_derived=1296, even_size=108, minpoly_cs=[3, 6, 9], deg=7, ker=8,
+        eigdims=[32, 48, 24, 8, 24, 48,32], hcapc=2592, dcap=648,
+        d3_spectrum={1: 1, 2: 3, 3: 2}, a4_spectrum={1: 1, 2: 3, 3: 8},
+        o_spectrum={1: 1, 2: 9, 3: 8, 4: 6},
+    ),
+}
+
+A_R4_ANCHOR = np.array([[0, 1, 0], [-1, 0, 0], [0, 0, 1]], dtype=int)
+
+
+# ---------------------------------------------------------------- analysis
+def analyze(L, refs):
+    x = XREF[L]
+    N = x["N"]
+    print("\n[PHASE A] build L={} (N={})".format(L, N))
+    lat = u25.build_lattice(L)
+    coords, idx = lat["coords"], lat["idx"]
+    D2, M = lat["D2"], lat["M"]
+    lam = list(lat["lam"])
+    mults = list(lat["mults"])
+    sup = u25.support_structures(D2)
+    ce = u25.enumerate_commutant(lat, sup)
+    Comm = ce["Comm"]
+    nComm = ce["nComm"]
+    grp = u25.build_group(lat)
+    H = grp["H"]
+    nH = grp["nH"]
+    g_r4 = u25.make_g_r4(lat)
+    print("        nComm={} nH={} lam={} mults={}".format(nComm, nH, lam, mults))
+
+    R = dict(N=N, lam=[int(v) for v in lam], mults=[int(v) for v in mults], nH=nH)
+
+    # lift lookup: one representative per permutation image
+    lift_of = {}
+    for g in Comm.values():
+        lift_of.setdefault(g[0].tobytes(), g)
+    I_list = list(lift_of.values())
+    nI = len(lift_of)
+    R["nI"] = nI
+
+    ar = np.arange(N)
+
+    # kernel of the permutation-part map
+    ker = [g for g in Comm.values() if np.array_equal(g[0], ar)]
+    ker_signs = sorted(int(g[1][0]) for g in ker) if ker else []
+    ker_const = all(np.all(g[1] == g[1][0]) for g in ker)
+    R["ker_size"] = len(ker)
+    R["ker_ok"] = (len(ker) == 2 and ker_const and ker_signs == [-1, 1])
+
+    # translations present in I
+    trans_present = 0
+    trans_perms = {}
+    for i in range(N):
+        tp = trans_perm(coords[i], coords, idx, N)
+        trans_perms[tp.tobytes()] = coords[i]
+        if tp.tobytes() in lift_of:
+            trans_present += 1
+    R["trans_present"] = trans_present
+
+    # canonical 0-fixing coset representatives = Stab_I(0)
+    canon = [g[0] for g in I_list if int(g[0][0]) == 0]
+    R["canon"] = len(canon)
+    # linearity + B3 coordinate of each canonical rep
+    A_set = {}
+    lin_ok = 0
+    for p in canon:
+        A = b3_coord(p, coords, idx, L)
+        if linear_verified(p, A, coords, idx, L, N):
+            lin_ok += 1
+        A_set[A.tobytes()] = A
+    R["lin_ok"] = lin_ok
+    R["A_set"] = set(A_set.keys())
+    R["A_eq_ref"] = (set(A_set.keys()) == refs["B3"])
+    # canonical reps closed under composition
+    canon_bytes = set(p.tobytes() for p in canon)
+    closed = True
+    for pi in canon:
+        for pj in canon:
+            comp = pj[pi]
+            if comp.tobytes() not in canon_bytes:
+                closed = False
+                break
+        if not closed:
+            break
+    R["canon_closed"] = closed
+
+    # T normal in I: conjugate every translation by the three linear reps
+    A_cyc = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]], dtype=int)
+    A_swap = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]], dtype=int)
+    A_flip = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=int)
+    lin_perms = [linear_perm(A, coords, idx, N) for A in (A_cyc, A_swap, A_flip)]
+    normal_ok = True
+    for lp in lin_perms:
+        lpi = np.argsort(lp)
+        for i in range(N):
+            tp = trans_perm(coords[i], coords, idx, N)
+            conj = lp[tp[lpi]]  # lp . t . lp^{-1} as permutation
+            if conj.tobytes() not in trans_perms:
+                normal_ok = False
+                break
+        if not normal_ok:
+            break
+    R["normal_ok"] = normal_ok
+
+    # B3 as a matrix group: closure of the three generators
+    B3_mat = mat_closure([A_cyc, A_swap, A_flip])
+    R["B3_mat"] = len(B3_mat)
+    R["B3_mat_eq_ref"] = (set(B3_mat.keys()) == refs["B3"])
+
+    # structural generators: 3 translation lifts + 3 linear lifts + central -1
+    central = (ar.copy(), -np.ones(N, dtype=np.int64))
+    struct_gens = []
+    gens_found = True
+    for mu in range(3):
+        e = np.zeros(3, dtype=int)
+        e[mu] = 1
+        tp = trans_perm(e, coords, idx, N)
+        g = lift_of.get(tp.tobytes())
+        if g is None:
+            gens_found = False
+        else:
+            struct_gens.append(g)
+    for lp in lin_perms:
+        g = lift_of.get(lp.tobytes())
+        if g is None:
+            gens_found = False
+        else:
+            struct_gens.append(g)
+    struct_gens.append(central)
+    R["gens_found"] = gens_found
+    if gens_found:
+        clos = u25.closure(struct_gens)
+        R["struct_closure"] = len(clos)
+    else:
+        R["struct_closure"] = -1
+
+    # involutions in I and their lift-squares
+    invol = 0
+    liftsq_minus = 0
+    same_sq = True
+    for g in I_list:
+        p = g[0]
+        if np.array_equal(p, ar):
+            continue
+        if np.array_equal(p[p], ar):
+            invol += 1
+            s = g[1]
+            sq = s * s[p]
+            v0 = int(sq[0])
+            if not np.all(sq == v0):
+                same_sq = False
+            if v0 == -1:
+                liftsq_minus += 1
+    R["invol"] = invol
+    R["liftsq_minus"] = liftsq_minus
+    R["same_sq"] = same_sq
+
+    # derived subgroup [Comm, Comm]
+    D = derived_subgroup(struct_gens) if gens_found else {}
+    R["derived"] = len(D)
+    R["abeln"] = (nComm // len(D)) if D else -1
+    R["minus1_in_D"] = (u25.key(central) in D) if D else False
+    piD = set()
+    for d in D.values():
+        piD.add(d[0].tobytes())
+    R["pi_derived"] = len(piD)
+    # translations inside pi(D)  ==  even-parity sublattice
+    even_vs = set()
+    for pb in piD:
+        p = np.frombuffer(pb, dtype=np.int64)
+        v = coords[p[0]]
+        if np.array_equal(p, trans_perm(v, coords, idx, N)):
+            even_vs.add(tuple(int(c) for c in v))
+    ref_even = set(
+        tuple(int(c) for c in coords[i]) for i in range(N) if int(coords[i].sum()) % 2 == 0
+    )
+    R["even_size"] = len(even_vs)
+    R["even_eq"] = (even_vs == ref_even)
+    # B3-image of derived = A4
+    a4_mats = {}
+    for pb in piD:
+        p = np.frombuffer(pb, dtype=np.int64)
+        A = b3_coord(p, coords, idx, L)
+        a4_mats[A.tobytes()] = A
+    a4_list = list(a4_mats.values())
+    R["a4_order"] = len(a4_list)
+    R["a4_spectrum"] = order_spectrum(a4_list)
+    R["a4_dets"] = det_set(a4_list)
+    R["a4_in_B3"] = all(k in refs["B3"] for k in a4_mats)
+
+    # ---- T3: minimal polynomial of D2 (exact int64) ----
+    cs = sorted(-l for l in lam if l != 0)
+    R["cs"] = cs
+    Iden = np.eye(N, dtype=np.int64)
+    factors = [D2] + [M + c * Iden for c in cs]
+    P = factors[0].copy()
+    for f in factors[1:]:
+        P = P @ f
+    R["minpoly_zero"] = (not bool(np.any(P)))
+    drop_nonzero = []
+    for kk in range(len(factors)):
+        Q = None
+        for jj in range(len(factors)):
+            if jj == kk:
+                continue
+            Q = factors[jj].copy() if Q is None else Q @ factors[jj]
+        drop_nonzero.append(bool(np.any(Q)))
+    R["drop_nonzero"] = drop_nonzero
+    R["deg"] = 1 + 2 * len(cs)
+
+    # dim End_Comm via the U25 character-sum machinery
+    raw_dim, dim_end = u25.char_dim(Comm)
+    R["dim_end"] = dim_end
+    R["dim_end_raw"] = raw_dim
+    # C[D2] subset End_Comm: spot-check a deterministic sample commutes with D2
+    keys_sorted = sorted(Comm.keys())
+    step = max(1, len(keys_sorted) // 500)
+    sample = keys_sorted[::step]
+    commute_ok = all(u25.commutes_with_D2(Comm[k], D2) for k in sample)
+    R["commute_ok"] = commute_ok
+    R["commute_sample"] = len(sample)
+
+    # ker D2
+    zero_idx = lam.index(0)
+    R["ker_dim"] = int(mults[zero_idx])
+
+    # eigenspace dims + projector characters
+    vals, dims, projs = eig_projectors(D2, N)
+    R["eigdims"] = dims
+    R["eig_sum"] = int(sum(dims))
+    P_arr, S_arr = u25.group_arrays(Comm)
+    chis = eig_characters(projs, P_arr, S_arr)
+    K = len(projs)
+    cmat = np.empty((K, K), dtype=complex)
+    for j in range(K):
+        for k in range(K):
+            cmat[j, k] = np.mean(chis[j] * np.conj(chis[k]))
+    diag = np.real(np.diag(cmat))
+    offmax = 0.0
+    for j in range(K):
+        for k in range(K):
+            if j != k:
+                offmax = max(offmax, abs(cmat[j, k]))
+    R["char_diag_dev"] = float(np.max(np.abs(diag - 1.0)))
+    R["char_offmax"] = float(offmax)
+    R["char_K"] = K
+
+    # ---- tie-backs: H cap Comm ----
+    Hkeys = set(H.keys())
+    Ckeys = set(Comm.keys())
+    HcapC = Hkeys & Ckeys
+    R["hcapc"] = len(HcapC)
+    Dkeys = set(D.keys())
+    R["dcap"] = len(Dkeys & HcapC)
+    R["d_ne_hcapc"] = (Dkeys != HcapC)
+    # body-diagonal dihedral D3
+    d3_mats = {}
+    for k in HcapC:
+        p = Comm[k][0]
+        A = b3_coord(p, coords, idx, L)
+        d3_mats[A.tobytes()] = A
+    d3_list = list(d3_mats.values())
+    R["d3_order"] = len(d3_list)
+    R["d3_spectrum"] = order_spectrum(d3_list)
+    R["d3_dets"] = det_set(d3_list)
+    R["d3_set"] = set(d3_mats.keys())
+    R["d3_eq_ref"] = (set(d3_mats.keys()) == refs["D3"])
+
+    # A_r4
+    A_r4 = b3_coord(g_r4[0], coords, idx, L)
+    R["a_r4"] = A_r4
+    R["a_r4_eq"] = np.array_equal(A_r4, A_R4_ANCHOR)
+    R["a_r4_in_B3"] = (A_r4.tobytes() in refs["B3"])
+    R["a_r4_det"] = det3(A_r4)
+
+    # O = <D3, A_r4>
+    O_mat = mat_closure(d3_list + [A_r4])
+    O_list = list(O_mat.values())
+    R["o_order"] = len(O_list)
+    R["o_spectrum"] = order_spectrum(O_list)
+    R["o_dets"] = det_set(O_list)
+    R["o_eq_ref"] = (set(O_mat.keys()) == refs["O"])
+
+    # full-closure route (L=4 only)
+    if L == 4:
+        HG = u25.closure(grp["gens_H"] + [g_r4])
+        R["full_hg"] = len(HG)
+        HGkeys = set(HG.keys())
+        HGcap = HGkeys & Ckeys
+        R["hg_cap"] = len(HGcap)
+        hg_A = set()
+        for k in HGcap:
+            hg_A.add(b3_coord(HG[k][0], coords, idx, L).tobytes())
+        R["hg_route_eq"] = (hg_A == set(O_mat.keys()))
+
+    return R
+
+
+def run_gates(L, R):
+    x = XREF[L]
+    N = x["N"]
+    print("\n[PHASE B] gates L={}".format(L))
+    gate("SPECTRUM_L{}".format(L),
+         R["lam"] == x["lam"] and R["mults"] == x["mults"] and R["nH"] == x["nH"],
+         "lam={} (anchor {}), mults={} (anchor {}), |H|={} (anchor {})".format(
+             R["lam"], x["lam"], R["mults"], x["mults"], R["nH"], x["nH"]))
+    gate("STRUCT_L{}".format(L),
+         R["nI"] == x["nI"] and R["ker_ok"],
+         "|I|={} (anchor {}), ker(pi)={{+-1}} size {}".format(R["nI"], x["nI"], R["ker_size"]))
+    gate("KERNEL_L{}".format(L),
+         R["ker_ok"] and R["ker_size"] == 2,
+         "kernel = {{+1,-1}} size {} (anchor 2)".format(R["ker_size"]))
+    gate("TRANS_L{}".format(L),
+         R["trans_present"] == x["nTrans"] and R["normal_ok"] and R["canon"] == x["canon"],
+         "T present {}/{}, normal={}, |I/T|={} (anchor {})".format(
+             R["trans_present"], x["nTrans"], R["normal_ok"], R["canon"], x["canon"]))
+    gate("CANON_LINEAR_L{}".format(L),
+         R["lin_ok"] == x["canon"] and R["A_eq_ref"] and R["canon_closed"],
+         "linear {}/{}, A-set==B3 {}, closed {}".format(
+             R["lin_ok"], x["canon"], R["A_eq_ref"], R["canon_closed"]))
+    gate("B3GEN_L{}".format(L),
+         R["B3_mat"] == 48 and R["B3_mat_eq_ref"],
+         "<A_cyc,A_swap,A_flip> = {} == B3 {}".format(R["B3_mat"], R["B3_mat_eq_ref"]))
+    gate("STRUCTGENS_L{}".format(L),
+         R["gens_found"] and R["struct_closure"] == x["nComm"],
+         "7-gen closure = {} (anchor 96N={}=2*{}*48)".format(
+             R["struct_closure"], x["nComm"], x["nTrans"]))
+    gate("INVOL_L{}".format(L),
+         R["invol"] == x["invol"] and R["liftsq_minus"] == x["liftsq_minus"]
+         and R["liftsq_minus"] > 0 and R["same_sq"],
+         "involutions {} (anchor {}), lift-sq=-1 {} (anchor {})".format(
+             R["invol"], x["invol"], R["liftsq_minus"], x["liftsq_minus"]))
+    gate("DERIVED_L{}".format(L),
+         R["derived"] == x["derived"] and R["abeln"] == x["abeln"],
+         "|[Comm,Comm]|={} (anchor 12N={}), abelianization={} (anchor 8)".format(
+             R["derived"], x["derived"], R["abeln"]))
+    gate("MINUS1_DERIVED_L{}".format(L),
+         R["minus1_in_D"],
+         "-1 in [Comm,Comm] = {}".format(R["minus1_in_D"]))
+    gate("PIDERIVED_L{}".format(L),
+         R["pi_derived"] == x["pi_derived"],
+         "|pi([Comm,Comm])|={} (anchor 6N={})".format(R["pi_derived"], x["pi_derived"]))
+    gate("EVENSUB_L{}".format(L),
+         R["even_size"] == x["even_size"] and R["even_eq"],
+         "pi(D) cap T = even sublattice size {} (anchor N/2={}), set-eq {}".format(
+             R["even_size"], x["even_size"], R["even_eq"]))
+    gate("A4IMAGE_L{}".format(L),
+         R["a4_order"] == 12 and R["a4_spectrum"] == x["a4_spectrum"]
+         and R["a4_dets"] == {1} and R["a4_in_B3"],
+         "B3-image(D) order {} spectrum {} dets {}".format(
+             R["a4_order"], R["a4_spectrum"], R["a4_dets"]))
+    gate("MINPOLY_L{}".format(L),
+         R["minpoly_zero"] and all(R["drop_nonzero"]) and R["deg"] == x["deg"]
+         and R["cs"] == x["minpoly_cs"],
+         "D2*prod(M+cI)=0 {}, drop-one nonzero {}, deg {} cs {}".format(
+             R["minpoly_zero"], R["drop_nonzero"], R["deg"], R["cs"]))
+    gate("ENDCOMM_CD2_L{}".format(L),
+         R["dim_end"] == 7 and R["deg"] == 7 and R["commute_ok"],
+         "dim End_Comm={} == deg minpoly={} == dim C[D2]; commute-sample {}/{}".format(
+             R["dim_end"], R["deg"], R["commute_sample"], R["commute_sample"]))
+    gate("KERDIM_L{}".format(L),
+         R["ker_dim"] == x["ker"],
+         "dim ker D2 = {} (anchor 8)".format(R["ker_dim"]))
+    gate("EIGDIMS_L{}".format(L),
+         R["eigdims"] == x["eigdims"] and R["eig_sum"] == N,
+         "eigenspace dims {} (anchor {}), sum {}".format(R["eigdims"], x["eigdims"], R["eig_sum"]))
+    gate("CHARNORM_L{}".format(L),
+         R["char_K"] == 7 and R["char_diag_dev"] <= 1e-9 and R["char_offmax"] <= 1e-12,
+         "7 chars norm 1 (max dev {:.2e}), cross max {:.2e}".format(
+             R["char_diag_dev"], R["char_offmax"]))
+    gate("HCAPCOMM_L{}".format(L),
+         R["hcapc"] == x["hcapc"] and R["dcap"] == x["dcap"] and R["d_ne_hcapc"],
+         "|H cap Comm|={} (anchor 12N={}), |D cap (H cap Comm)|={} (anchor 3N={}), D!=HcapC {}".format(
+             R["hcapc"], x["hcapc"], R["dcap"], x["dcap"], R["d_ne_hcapc"]))
+    gate("D3_L{}".format(L),
+         R["d3_order"] == 6 and R["d3_spectrum"] == x["d3_spectrum"]
+         and R["d3_dets"] == {1} and R["d3_eq_ref"],
+         "coords(H cap Comm) order {} spectrum {} dets {} bodydiag-eq {}".format(
+             R["d3_order"], R["d3_spectrum"], R["d3_dets"], R["d3_eq_ref"]))
+    gate("AR4_L{}".format(L),
+         R["a_r4_eq"] and R["a_r4_in_B3"] and R["a_r4_det"] == 1,
+         "A_r4 == [[0,1,0],[-1,0,0],[0,0,1]] {}, in B3 {}, det {}".format(
+             R["a_r4_eq"], R["a_r4_in_B3"], R["a_r4_det"]))
+    gate("OCLOSURE_L{}".format(L),
+         R["o_order"] == 24 and R["o_spectrum"] == x["o_spectrum"]
+         and R["o_dets"] == {1} and R["o_eq_ref"],
+         "<D3,A_r4> order {} spectrum {} dets {} O-eq {}".format(
+             R["o_order"], R["o_spectrum"], R["o_dets"], R["o_eq_ref"]))
+    if L == 4:
+        gate("FULLCLOSURE_L4",
+             R["full_hg"] == x["full_hg"] and R["hg_cap"] == x["hg_cap"]
+             and R["hg_route_eq"],
+             "|<H,g_r4>|={} (anchor 6144), cap Comm={} (anchor |Comm|/2={}), route-eq {}".format(
+                 R["full_hg"], R["hg_cap"], x["hg_cap"], R["hg_route_eq"]))
+
+
+def main():
+    t0 = time.time()
+    print("=" * 72)
+    print("KCPT U26  Comm(D2) double cover + End_Comm = C[D2]")
+    print("=" * 72)
+    B3ref = reference_B3()
+    refs = {}
+    refs["B3"] = set(A.tobytes() for A in B3ref)
+    refs["O"] = set(A.tobytes() for A in B3ref if det3(A) == 1)
+    diagv = np.array([1, 1, 1])
+    refs["D3"] = set(
+        A.tobytes() for A in B3ref
+        if det3(A) == 1 and (np.array_equal(A @ diagv, diagv) or np.array_equal(A @ diagv, -diagv))
+    )
+    gate("REF_B3", len(refs["B3"]) == 48, "reference B3 size {}".format(len(refs["B3"])))
+    gate("REF_O", len(refs["O"]) == 24, "reference O (det +1) size {}".format(len(refs["O"])))
+    gate("REF_D3", len(refs["D3"]) == 6, "reference D3 (body-diagonal) size {}".format(len(refs["D3"])))
+
+    results = {}
+    for L in (4, 6):
+        results[L] = analyze(L, refs)
+        run_gates(L, results[L])
+
+    print("\n[PHASE B] cross-L gates")
+    gate("CROSSL_B3",
+         results[4]["A_set"] == refs["B3"] and results[6]["A_set"] == refs["B3"]
+         and results[4]["A_set"] == results[6]["A_set"],
+         "A-set(L4)==A-set(L6)==B3 (48 matrices)")
+    gate("CROSSL_D3",
+         results[4]["d3_set"] == results[6]["d3_set"] and results[4]["d3_set"] == refs["D3"],
+         "coords(H cap Comm) same 6 matrices at L=4 and L=6")
+
+    print("\n" + "=" * 72)
+    print("TOTAL: PASS={} FAIL={}".format(_P[0], _F[0]))
+    print("wall-clock: {:.1f}s".format(time.time() - t0))
+    sys.exit(0 if _F[0] == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

KCPT Unit 26: structural characterization of the D2 signed-permutation commutant Comm (|Comm| = 96N, from Unit 25) as a **non-split central double cover** of T ⋊ B₃, plus the exact bicommutant identification End_Comm(C^N) = C[D2], at both computed surfaces L = 4 and L = 6.

- **T1 (cover structure):** the permutation-part map Comm → I has kernel exactly {±1}; the image I is T ⋊ B₃ (all 48 canonical 0-fixing coset representatives are linear and reproduce the full hyperoctahedral group B₃, independently rebuilt from scratch; T is normal in I). Seven structural generators (three unit-translation lifts, lifts of the three B₃ generators, and central −1) close to all of Comm.
- **T2 (non-splitness):** the extension 1 → {±1} → Comm → T ⋊ B₃ → 1 does not split: witnessed both by involutions in I whose two lifts each square to −1 (192/359 at L=4, 400/799 at L=6) and by −1 ∈ [Comm, Comm]. Derived subgroup |[Comm,Comm]| = 12N (768 / 2592), abelianization of order 8; its image in I is T_even ⋊ A₄ (even-parity translation sublattice, exact set equality; point-group image order 12, spectrum {1:1, 2:3, 3:8}, det +1) — the derived subgroup is a double cover of it.
- **T3 (bicommutant):** End_Comm(C^N) = C[D2] exactly: dim End_Comm = 7 (Unit 25 character sum) = deg of the exact integer minimal polynomial D2·(M+4I)(M+8I)(M+12I) = 0 at L=4 / D2·(M+3I)(M+6I)(M+9I) = 0 at L=6 (M = D2²; all four drop-one rejectors nonzero) = dim C[D2]; the seven i·D2 eigenspace characters have norm 1 and pairwise cross-inner-products at machine zero (gated 1e-9 / 1e-12) — multiplicity-free.
- **Tie-backs:** coords(H ∩ Comm) is the body-diagonal S₃ (same 6 det +1 matrices at both L); adjoining A_r4 yields the proper-rotation group O ≅ S₄ (order 24, spectrum {1:1, 2:9, 3:8, 4:6}), giving the chain D₃ ⊂ O ⊂ B₃. The L=4 full-closure figure |⟨H, g_r4⟩| = 6144 is explicitly disambiguated from Unit 25's GC = 12288.

## Runner

`scripts/kcpt_d2_commutant_double_cover_bicommutant_structure_2026_07_25.py` — 50 gates, `TOTAL: PASS=50 FAIL=0`, wall-clock ~19 s. Includes a direct spectrum gate per surface (D2 eigenvalues, multiplicities, |H| against externally sourced anchors), added after the three-lens review. Reuses the landed Unit 25 enumeration module for lattice/commutant construction; all reference groups (B₃, O, D₃) and all structural analysis (matrix closures, derived subgroup, characters) built from scratch in this runner. Exact int64 arithmetic for all counting/minimal-polynomial gates; the eigenspace/character block is floating, gated at stated tolerances.

## Reviewer disclosures

- Bounded to the two computed surfaces L = 4 and L = 6; no general-L claim.
- The extension class in H²(T⋊B₃, Z₂) is witnessed non-trivial but not classified.
- Evidentiary verdict in the note body: PASS WITH BOUNDED CLAIMS (precedented body-prose phrasing; no status header).
- Single dependency edge: the Unit 25 commutant-characterization note.

This row is unaudited: its grade is set exclusively by the independent audit lane on origin/main.

## Test Plan
- [x] Runner re-run from worktree root: `TOTAL: PASS=50 FAIL=0`, exit 0
- [x] Three-lens adversarial review (fabrication-hunt / algebra-re-derive / framing-audit) synthesized before landing
- [x] Cache regenerated via `runner_cache.execute_runner` + `write_cache`
- [x] Source-only triple: one note (docs/), one runner (scripts/), one cache (logs/runner-cache/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
