### PR TITLE
science: common-frame pair-generator exchange class registered, with its three limitations (batch R3)

### DIFF
--- a/docs/COMMON_FRAME_PAIR_GENERATOR_EXCHANGE_CLASS_BOUNDED_THEOREM_NOTE_2026-07-25.md
+++ b/docs/COMMON_FRAME_PAIR_GENERATOR_EXCHANGE_CLASS_BOUNDED_THEOREM_NOTE_2026-07-25.md
@@ -1,0 +1,418 @@
+---
+claim_id: common_frame_pair_generator_exchange_class_bounded_theorem_note_2026-07-25
+claim_type: bounded_theorem
+claim_scope: "Under four SUPPLIED hypotheses -- (H1) one M_2(C) site domain on the Z^3 nearest-neighbour graph; (H2) an autonomous time-independent self-adjoint pair generator; (H3) a sum of identical two-site terms; (H4) COMMON-frame SU(2) covariance, one and the same U acting on both sites of an edge -- the commutant of the diagonal frame action on two qubits has complex dimension exactly 2 and equals span{I, SWAP}, so every admissible pair generator is h = a I + b SWAP with a, b real. The licensed quotient (h, t) -> (alpha h + beta I, t/alpha) with alpha > 0 removes a and |b| and leaves exactly sign(b), and the separating invariant is the GROUND-SECTOR DEGENERACY: 1 for b > 0 (the singlet) and 3 for b < 0 (the triplet). RECORDED EXPLICITLY AS A NEGATIVE RESULT: the one-excitation band minimum is NOT a valid separator, because Z^3 nearest-neighbour adjacency is bipartite by the parity of x + y + z, the sublattice relabeling D = diag((-1)^parity) gives D A D = -A, hence spec(A) = -spec(A), and the +J and -J one-excitation bands are identical as multisets after the licensed energy shift; the separator works only on a non-bipartite graph such as the triangle, and Z^3 is not one. THREE LIMITATIONS ARE PART OF THE CLAIM, NOT CAVEATS TO IT. (L1) H4 is a PREMISE THAT CREATES the two-point menu: under INDEPENDENT onsite covariance the commutant is only the scalars, SWAP is not invariant, and no nontrivial pair law survives without a further supplied object (a connection, link variable, shared frame, or symmetry reduction). (L2) 'Exactly two' holds only for the two-site edge class under the supplied identical-pair-term ansatz H3: at three sites H_1 = SWAP_01 + SWAP_02 and H_2 = SWAP_01 SWAP_02 + SWAP_02 SWAP_01 satisfy the same Hermiticity, neighbour-exchange, and common-frame covariance hypotheses, and H_1 + eta H_2 carries a dimensionless eta moving the gap ratio (E1-E0)/(E2-E1) from 2 at eta = 0 to 1 at eta = 1/3, which a gap RATIO argument shows is removable by neither clock rescaling nor energy shift. (L3) The 'inert' identity shift is NOT inert on a record-conditioned active-edge set: on a supplied convention where an edge is active when neither endpoint carries a record, two record sectors with different active-edge counts acquire a relative phase that moves an interference term on a coherent superposition of those sectors, so the energy shift may not be discarded before the domain is fixed. NOT claimed: any selection of sign(b), of |b|, of a rate, or of a time unit; derivability of H2-H4 from Lattice/Qubit/Admissibility/Record; PAIRWISE INDEPENDENCE OF H1-H4 (none is claimed and none is audited here); a well-defined discrete update on overlapping edges; a strict light cone; any record formation rule, formation trigger, instrument, Born weight, sampling rule, actuality, or realized outcome; the general reversible-record obstruction; continuity of a disagreement minimizer; and any relativistic, chiral, fermionic, gauge, species, matter, clock-metric, or gravitational consequence. This note sets no audit verdict and asserts no PASS."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/common_frame_pair_generator_exchange_class_2026_07_25.py
+---
+
+# Common-Frame Pair Generator: The Exchange Class And Its Three Limitations
+
+**Date:** 2026-07-25
+**Type:** bounded_theorem
+**Claim type:** bounded_theorem
+**Scope:** two qubits on one edge of the `Z^3` nearest-neighbour graph under
+four supplied hypotheses; the axioms supply no dynamics.
+**Audit-status authority:** independent audit lane only. This note sets no
+audit verdict and predicts none.
+**Primitive status:** no primitive is approved, registered, edited, or
+enlarged here.
+**Primary runner:**
+[`scripts/common_frame_pair_generator_exchange_class_2026_07_25.py`](../scripts/common_frame_pair_generator_exchange_class_2026_07_25.py)
+**Runner cache:**
+[`logs/runner-cache/common_frame_pair_generator_exchange_class_2026_07_25.txt`](../logs/runner-cache/common_frame_pair_generator_exchange_class_2026_07_25.txt)
+
+**Upstream authority:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+## Purpose
+
+A symmetry classification that reduces an arbitrary Hermitian two-site
+generator to one physical coefficient has been recomputed more than once in
+this repository without ever becoming citable. This note states it once, with
+its limitations attached rather than dropped, and gates every constant in a
+single runner.
+
+The classification is genuinely useful: an arbitrary Hermitian operator on
+`C^2 ⊗ C^2` carries 16 real parameters, and under the stated hypotheses it
+collapses to two, then to one after the licensed quotient. The limitations are
+equally load-bearing, and they are the part that a summary tends to lose: the
+covariance reading is what *creates* the two-point menu rather than a
+notational convenience; the count does not survive enlarging the support past
+one edge; and the identity term is inert only on a fixed active-edge set.
+
+This note claims a **classification**, not a law. It selects no sign, no rate,
+no formation rule, no instrument, and no actual history.
+
+**Prior exploratory surfaces.** Four working notes dated 2026-07-14 under
+`docs/work_history/repo/review_feedback/` explore this route:
+`QUBIT_SYMMETRY_EXCHANGE_LAW_REDUCTION_PROBE_NOTE_2026-07-14.md`,
+`RELATIONAL_QUBIT_DISAGREEMENT_CANONICAL_LAW_ESCALATION_NOTE_2026-07-14.md`,
+`SINGLE_INVARIANT_ACTION_STEELMAN_ATTACK_NOTE_2026-07-14.md`, and
+`FULL_LAW_INVENTORY_ADVERSARIAL_REDUCTION_NOTE_2026-07-14.md`. They are named
+here as **route inputs only** and are deliberately referenced in backticks
+rather than as markdown links: they each carry `Authority: none`, they are not
+consumed as evidence anywhere below, and nothing in this note inherits status
+from them. Every algebraic step is recomputed natively in this note's runner,
+which reads none of those files. Their runners are **not** reused, for reasons
+stated under Verification.
+
+## Hypotheses (all supplied; none derived)
+
+The Qualification in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) requires a
+retained derivation, bridge, or registered primitive before any of these could
+be treated as framework content, and none of them has one. That memo states
+that Admissibility "is not a dynamics axiom" and that it "does not choose a
+Hamiltonian or transfer operator", so H2–H4 cannot be read off the axioms; it
+also lists "source/action and physical-observable identification" among the
+open gates outside axiom content, and H2–H4 sit on that gate.
+
+- **(H1) Domain.** One `M_2(C)` possibility domain per site on the cubic `Z^3`
+  nearest-neighbour graph. *This much is axiom content.*
+- **(H2) Autonomous generator.** Between-record evolution is generated by a
+  time-independent self-adjoint operator. Time-independence is essential and is
+  not implied by strong continuity: the covariant family `h(t) = J(t) SWAP` is
+  pointwise covariant and retains an arbitrary coefficient function.
+- **(H3) Identical two-site terms.** The generator is a sum of identical
+  nearest-neighbour two-site terms. This is an **ansatz**, and L2 below is
+  precisely the cost of it.
+- **(H4) COMMON-frame covariance.** One and the same `U ∈ SU(2)` acts on both
+  sites of an edge. This is the decisive premise; see L1.
+
+**No pairwise independence of H1–H4 is claimed**, and the runner attempts no
+independence audit of them. They are stated as a conjunction and consumed as a
+conjunction.
+
+## Results
+
+**R1 (classification).** Under H1 and H4 the commutant of the diagonal action
+`U ⊗ U` on `C^2 ⊗ C^2` has complex dimension exactly 2 and equals
+`span{I, SWAP}`. Hence under H1–H4 every admissible pair generator is
+
+```text
+h = a I + b SWAP
+  = (a + b/2) I + (b/2)(X⊗X + Y⊗Y + Z⊗Z),
+```
+
+with `a, b` real. The exchange identity `SWAP = (I + X⊗X + Y⊗Y + Z⊗Z)/2` is
+exact. Gates `G1a`–`G1g`; the containment is checked in **both** directions and
+paired with a negative control (`X⊗I` is not in the commutant), so the
+equality is not read off a dimension count alone.
+
+**R2 (quotient).** On a **fixed** active-edge set, the map
+`(h, t) ↦ (α h + β I, t/α)` with `α > 0` leaves the generated channel unchanged
+up to a global phase. Taking `α = 1/|b|` and `β = −α a` carries `h` to
+`sign(b)·SWAP`, so `a` and `|b|` are removed. The sign is **not** removed: the
+two-parameter system `α SWAP + β I = −SWAP` has the unique solution
+`(α, β) = (−1, 0)`, which is not licensed. Positivity of `α` is exactly what
+makes the sign physical — dropping it identifies the two signs. Gates
+`G3a`–`G3f`, with the mutation probe `G3f` supplying the identification that
+the constraint blocks.
+
+**R3 (the separator).** The relabeling-proof invariant separating the two signs
+is the **ground-sector degeneracy**. `SWAP` has spectrum `{+1 (×3), −1 (×1)}`,
+so for `h = a I + b SWAP`:
+
+- `b > 0` has a **one-dimensional** ground sector (the singlet);
+- `b < 0` has a **three-dimensional** ground sector (the triplet).
+
+The degeneracy of the lowest eigenvalue is invariant under every `α > 0`
+rescaling, every `β I` shift, and every common frame change, so it survives the
+whole licensed quotient of R2. Gates `G4a`–`G4f`. `G4f` records the reason a
+weaker invariant will not do: `+SWAP` and `−SWAP` have the **same eigenvalue
+set** `{±1}` and differ only in the multiplicities, so a set-valued spectral
+invariant cannot separate them.
+
+**R4 (the band minimum is NOT a separator — recorded explicitly).** The
+one-excitation band minimum must **not** be used in place of R3. `Z^3`
+nearest-neighbour adjacency is bipartite by the parity of `x + y + z`. Let `D`
+be the diagonal sublattice relabeling `D_xx = (−1)^{parity(x)}`. Then for the
+adjacency matrix `A`
+
+```text
+D² = I,    D A D = −A,    hence  spec(A) = −spec(A).
+```
+
+In the one-excitation sector the exchange sum restricts to `A + (|E|·I − Deg)`,
+which on a regular graph is `A` plus a constant; `Z^3` is 6-regular, so after
+the R2 energy shift the `+J` and `−J` one-excitation bands are **identical as
+multisets**. The band minimum, the band width, and the whole band shape are
+therefore sign-blind on `Z^3` and separate nothing. The separator works only on
+a **non**-bipartite graph — the triangle has `spec(A) = {2, −1, −1}`, no
+diagonal `±1` relabeling reverses it, and its shifted `+J` and `−J` bands do
+differ — and `Z^3` is not one. Gates `G5a`–`G5h`: the one-excitation block is
+**assembled by applying the actual edge permutations**, not asserted from a
+formula, and is verified against the full `2^n` space on two instances;
+`D A D = −A` is checked on the `L = 4` periodic `Z^3` chunk (64 sites, 192
+edges) as well as on `C4`, `Q3`, `K_{3,3}`, and `P3`; the triangle is the
+breaking mutation. `G5h` adds the independent point that the band minimum is
+not even invariant under the `β I` shift, whereas the ground-sector degeneracy
+does not move at all.
+
+## Limitations (all three are part of the claim, not caveats to it)
+
+**L1 — common-frame covariance is a PREMISE that CREATES the two-point menu.**
+H4 is not a notational convenience; it is the physics. Under **independent**
+onsite covariance — separate `SU(2)` actions on the two sites — the commutant
+collapses to complex dimension **1**, the scalars alone; `SWAP` is not
+invariant there. Solving directly, `a I + b SWAP` is independent-onsite
+invariant only for `b = 0`. So under independent onsite covariance **no
+nontrivial pair interaction survives at all** without a further supplied
+object: a connection, a link variable, a shared frame, or a symmetry reduction.
+The axiom sentence "No possibility is privileged" does not choose between the
+two readings. Adopting the exchange class therefore imports a physical premise;
+it does not read one off a symmetry slogan. Gates `G2a`–`G2d`.
+
+**L2 — "exactly two parameters" holds only for the two-site edge class under
+the supplied identical-pair-term ansatz.** The count is a statement about one
+edge under H3, and it does not survive enlarging the support. On three sites
+with a centre and two equivalent neighbours, both
+
+```text
+H_1 = SWAP_01 + SWAP_02,
+H_2 = SWAP_01 SWAP_02 + SWAP_02 SWAP_01
+```
+
+are Hermitian, invariant under exchanging the two equivalent neighbours, and
+invariant under the common-frame diagonal `SU(2)` — they satisfy exactly the
+same symmetry hypotheses. `I`, `H_1`, `H_2` are linearly independent, so the
+family `H_η = H_1 + η H_2` carries a genuinely independent **dimensionless**
+coefficient `η`, and it moves a spectral gap ratio
+
+```text
+(E_1 − E_0)/(E_2 − E_1) = 2   at η = 0,
+                        = 1   at η = 1/3.
+```
+
+A gap **ratio** is invariant under both `α > 0` rescaling and `β I` shift, so
+neither clock rescaling nor an energy-zero choice removes `η`. Symmetry
+licenses the term; it does not fix it. Gates `G6a`–`G6j`. The common-frame
+covariance of `H_1` and `H_2` is **computed** here (`G6c`, `G6d`) — that is the
+property which makes `η` an independent invariant and therefore makes the
+counterexample bite — and `G6e` supplies the negative control (`Z_0 Z_1` is
+Hermitian but fails both symmetry checks) so the covariance gate is not a
+tautology.
+
+**L3 — the "inert" identity term is NOT inert on a record-conditioned
+active-edge set.** R2's removal of `a` is conditional on a **fixed** active-edge
+set. Supply the convention that an edge is active when neither endpoint carries
+a record. Two record sectors then differ in their active-edge count, adding
+`β I` per active edge contributes `β N_active`, and that is not a common scalar
+across sectors of different `N_active`. On a coherent superposition of two such
+sectors the relative phase moves an interference term, which is therefore not a
+removable global phase. The active-edge convention is itself **supplied** — the
+axioms give no formation rule — so L3 is a conditional: *if* record formation
+changes which edges are active, the energy shift may not be discarded before
+the domain is fixed, and a record-dependent active graph needs an explicit
+vacuum/edge energy convention or a superselection argument. Gates `G7a`–`G7e`,
+with `G7d` mutating the record configuration to equal active-edge counts (the
+term becomes inert again) and `G7e` confirming that R2 holds exactly on a fixed
+set, so L3 is a boundary rather than a contradiction.
+
+## Non-Claims
+
+This note does **not** claim, and its runner does not gate:
+
+- any selection of `sign(b)`, of `|b|`, of a rate, or of a time unit;
+- that H2–H4 are derivable from Lattice/Qubit/Admissibility/Record — the axiom
+  memo says the opposite for dynamics;
+- pairwise independence of H1–H4;
+- a well-defined discrete update: on overlapping edges the pair terms do not
+  commute, so a product update still needs an ordering/layering rule or a
+  causal-invariance theorem;
+- a strict light cone. A finite-range continuous generator gives a quasilocal
+  cone with tails, not the exact cone of a layered circuit; the two have
+  different exact causal semantics and one must be chosen and its continuum
+  interpretation proved separately;
+- any record formation, formation trigger, instrument, Born weight, sampling
+  rule, actuality, or single realized outcome. Entanglement **capability** is
+  not sampling and supplies no outcome;
+- the general reversible-record obstruction (that `R ≤ U†RU` forces equality by
+  equal trace and rank). It is left to its exploratory source and is **not**
+  gated here;
+- continuity of any disagreement minimizer over all rank-one projectors;
+- any relativistic, chiral, fermionic, gauge, species, matter, clock-metric, or
+  gravitational consequence. A cubic exchange system has a parity-even
+  quadratic magnon dispersion, not a Weyl sector;
+- any audit verdict. Independent audit remains required.
+
+## No-Go Discipline Gate
+
+The licensed negative content is bounded to L1–L3 and R4:
+
+> Under H1–H4 the two-site pair generator class is exactly `span{I, SWAP}` and
+> the licensed quotient leaves exactly `sign(b)`. Under independent onsite
+> covariance no nontrivial pair term survives. The two-parameter count does not
+> extend past the two-site edge class under H3. The identity term is not inert
+> on a record-conditioned active-edge set. The one-excitation band minimum is
+> not a valid sign separator on the bipartite `Z^3` graph.
+
+No universal no-go against a pair law, an exchange dynamics, or a deeper
+theorem deriving H2–H4 is made.
+
+**Status: the items below were ATTEMPTED and are recorded for the audit lane.
+No closure is claimed and no `PASS` is asserted. Judgement belongs to the
+independent audit lane.**
+
+- **N1 alternative-route enumeration — ATTEMPTED.**
+
+  | route | strongest attempted form | outcome |
+  |---|---|---|
+  | common-frame `SU(2)` covariance | commutant of `U ⊗ U` | dimension 2, `span{I, SWAP}` — the stated class |
+  | independent onsite covariance | commutant of separate `SU(2)` actions | dimension 1, scalars only — L1 |
+  | enlarge support to three sites | `H_1 + η H_2` under the same symmetries | independent dimensionless `η` survives — L2 |
+  | remove `a` by energy shift | `β I` on a fixed active-edge set | succeeds on a fixed graph, fails on a record-conditioned graph — L3 |
+  | remove `sign(b)` by rescaling | `α > 0` clock rescaling | fails; only an unlicensed `α < 0` identifies the signs |
+  | separate signs by band minimum | one-excitation dispersion | **fails on `Z^3`** by the bipartite relabeling — R4 |
+  | separate signs by ground sector | lowest-eigenvalue degeneracy | succeeds, 1 vs 3 — R3 |
+  | drop autonomy | strongly continuous covariant `h(t) = J(t) SWAP` | an arbitrary coefficient function returns; H2 is load-bearing |
+  | discrete layered update instead of a generator | product of overlapping pair terms | ordering/layering rule required; not supplied |
+
+- **N2 wall separation — ATTEMPTED.** Finite controls that keep one wall from
+  being silently renamed as another: covariance reading vs class size (common
+  frame gives dimension 2, independent onsite gives dimension 1); class size vs
+  support (dimension 2 on one edge, `η` appears at three sites); scale freedom
+  vs sign (`α > 0` removes `|b|`, never `sign(b)`); energy zero vs sector
+  (`β I` is inert at fixed `N_active`, not across `N_active ∈ {1,2}`); spectrum
+  vs degeneracy (`+SWAP` and `−SWAP` share the eigenvalue set `{±1}`; only the
+  multiplicities differ); band minimum vs ground sector (the bipartite
+  relabeling moves the band, not the ground degeneracy). A later theorem may
+  tie several rows together. **These controls are not an independence proof,
+  and no claim is made that H1–H4 are pairwise independent.**
+- **N3 hidden-wall scan — ATTEMPTED.** Exposed rather than hidden: the
+  common-versus-independent frame reading; autonomy/time-independence; the
+  identical-pair-term ansatz; the two-site support restriction; the
+  fixed-versus-record-conditioned active-edge set and the supplied
+  active-edge convention itself; the sign of `b`; the magnitude `|b|` and its
+  time unit; the dimensionless interaction angle; overlapping-edge ordering;
+  continuous-versus-circuit causal semantics; the absence of any formation
+  trigger, instrument, weight, or realized member; and the absence of any
+  matter, chirality, clock-metric, or gravity content. Also exposed: the
+  ground-sector invariant reads the `(3,1)` multiplicity split, and it is
+  `G1` — not `G4` — that pins the operator carrying that split to be `SWAP`.
+- **N4 dependency roles, per citation — ATTEMPTED.**
+  - [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md): the H1
+    domain sentence, and the no-dynamics boundary that makes H2–H4 supplied
+    rather than derived. Nothing else is consumed; the memo is not modified.
+  - The four 2026-07-14 exploratory surfaces named in Purpose: **route inputs
+    only**, referenced in backticks so they seed no citation-graph edge. They
+    carry `Authority: none`, they are not modified, and no result below rests
+    on them. Every step is recomputed natively.
+- **N5 resolution and rhetoric audit — ATTEMPTED.**
+  - "Commutant is `span{I, SWAP}`" is a statement about a **two-qubit pair
+    generator under common-frame covariance**, not about a general qubit
+    automaton.
+  - "Exactly two" means two real parameters `a, b` on **one edge under H3**,
+    and L2 states where that stops.
+  - "Inert identity" is true only on a **fixed** active-edge set (L3).
+  - "Ground sector" means the lowest-eigenvalue eigenspace and its
+    **dimension**, not the eigenvalue.
+  - "Band minimum is not invariant" is a positive computation (R4), not a
+    rhetorical hedge.
+  - Entanglement **capability** is not sampling, an outcome, or a record, and
+    no entanglement claim is gated here at all.
+- **N6 partial-closure path — ATTEMPTED.** (1) Test whether the common-frame
+  reading is forced by, or merely compatible with, the Admissibility covariance
+  sentence. (2) Classify the full low-support invariant term basis past one
+  edge, so the L2 `η` family is enumerated rather than exhibited. (3) Search for
+  a conservation or index theorem fixing `sign(b)` rather than registering it.
+  (4) Fix the active-edge/vacuum energy convention, or prove the superselection
+  that makes L3 vacuous. (5) Only then ask whether the generator compiles into
+  a homogeneous nearest-neighbour update on `Z^3`.
+- **N7 strongest steelman — ATTEMPTED.** The strongest opponent is a theorem
+  deriving H2–H4 from the exact admissibility law, so that the pair class
+  becomes theorem content rather than an ansatz, simultaneously fixing
+  `sign(b)` by a conservation or index argument and supplying the active-edge
+  convention that retires L3. Such a theorem would convert most of this note
+  into a corollary and would defeat its bounded framing. Nothing here excludes
+  it; it is not constructed.
+- **N8 cross-cycle echo — ATTEMPTED.** The commutant computation appears in
+  prior exploratory runners by two different methods and agrees. What is new
+  here relative to those surfaces: (i) the sign quotient is gated by
+  construction rather than by a vacuous literal; (ii) the common-frame
+  covariance of the three-site `H_1`, `H_2` is actually computed, which is what
+  makes `η` an independent invariant; (iii) the active-edge non-inertness is
+  built from a record-conditioned sector pair rather than a hand-written
+  diagonal; and (iv) R4 is new — the band-minimum separator is positively
+  refuted on the bipartite `Z^3` graph and the ground-sector degeneracy is put
+  in its place.
+
+## Verification
+
+Primary runner:
+[`scripts/common_frame_pair_generator_exchange_class_2026_07_25.py`](../scripts/common_frame_pair_generator_exchange_class_2026_07_25.py)
+
+```bash
+python3 scripts/common_frame_pair_generator_exchange_class_2026_07_25.py
+```
+
+Result on this note's content: **`PASS=46`, `FAIL=0`** (about 0.7 s). The PASS
+total is a **gate count**, not a count of independent scientific facts.
+
+**Why a new runner rather than the four existing ones.** The 2026-07-14
+runners cannot serve this note: three of its load-bearing constants are
+ungated there. The `sign(b)` quotient is "gated" only by the vacuous literal
+`{-1, 1} == {sign(v) for v in (-3, 5)}`, which never touches `a`, `b`, `α`,
+`β`, or `SWAP`; the common-frame covariance of `H_1` and `H_2` is asserted but
+only Hermiticity and mutual commutation are checked; the active-edge phase is a
+hand-built `sp.diag(1, 2)` with no record-conditioned edge set constructed; one
+pair of their gates is the same check under two labels; and about 34% of one
+runner's PASS lines are prose-needle greps on its own text. R4 exists in none
+of them. Those four surfaces and their runners are left untouched.
+
+**Design rules this runner honours.**
+
+- Exact `sympy` throughout: no float is an input to any load-bearing
+  comparison, no numeric tolerance is used, and eigenvalue ordering goes
+  through an exact three-way comparison that refuses anything it cannot decide
+  symbolically.
+- **No prose-needle gates.** The runner reads no markdown and greps no text,
+  including its own, so the PASS total is entirely mathematical. No gate is
+  self-referential, and none is vacuous: each has a negative control or a
+  mutation partner that makes it fail.
+- **An ordered label manifest with a drift detector.** `EXPECTED_LABELS` fixes
+  the gate sequence; renaming, reordering, adding, or dropping a gate fails the
+  run.
+- **A construction-mutation probe for every claimed constant.** Probes rebuild
+  the object from a changed construction — they do not flip an assertion.
+  `G1e` (a non-invariant candidate must leave the commutant), `G2a` (swap the
+  covariance construction; the dimension must fall to 1), `G3f` (drop the
+  positivity constraint; the two signs must become identified), `G4c` (flip the
+  sign in the construction; the ground degeneracy must move 1 → 3), `G5g`
+  (swap the bipartite graph for a triangle; sign-symmetry must break and the
+  bands must differ), `G6e` and `G6i` (a non-covariant decoy must fail the
+  symmetry gates; sweeping `η` must move the ratio), `G7d` (rebuild the record
+  configuration with equal active-edge counts; the identity term must become
+  inert).
+
+Selected gate lines, verbatim:
+
+```text
+PASS G1a common-frame (diagonal SU(2)) commutant has complex dimension 2 :: dim=2
+PASS G1e MUTATION non-invariant candidate X(x)I is NOT in the commutant (so G1d is not a tautology) :: rank=3
+PASS G2a MUTATION independent-onsite covariance collapses the commutant to complex dimension 1 :: dim=1
+PASS G3e NO positive rescaling plus energy shift maps +SWAP to -SWAP: the only solution has alpha = -1 :: solutions=[{alpha: -1, beta: 0}] positive=[]
+PASS G4b b > 0: ground sector of a*I + b*SWAP is 1-dimensional (the singlet) :: deg=1
+PASS G4c MUTATION flip the sign IN THE CONSTRUCTION: the ground sector becomes 3-dimensional (the triplet) :: deg=3
+PASS G5c Z^3 nearest-neighbour adjacency is bipartite: x + y + z parity is a proper 2-colouring of every edge (L = 4 chunk, 192 edges) :: edges=192 sites=64
+PASS G5e hence spec(A) = -spec(A) as multisets: A is similar to -A through D, so the band is sign-symmetric :: C4:[-2, 0, 0, 2]; Q3:[-3, -1, -1, -1, 1, 1, 1, 3]; K3,3:[-3, 0, 0, 0, 0, 3]; P3:[-sqrt(2), 0, sqrt(2)]
+PASS G5g MUTATION swap the bipartite graph for the non-bipartite triangle ... :: spec=[-1, -1, 2] +J band=[-1, -1, 2] -J band=[-2, 1, 1]
+PASS G6c both COMMUTE with all three diagonal SU(2) generators, i.e. both are common-frame covariant -- the check the source runners asserted but never computed
+PASS G6g gap ratio (E1 - E0)/(E2 - E1) = 2 at eta = 0 :: levels=[-1, 1, 2] ratio=2
+PASS G6h gap ratio = 1 at eta = 1/3 :: levels=[-4/3, 2/3, 8/3] ratio=1
+PASS G7c on a coherent superposition of the two record sectors the identity term MOVES the interference term ... :: witness 1 -> 1/2
+PASS G7d MUTATION ... EQUAL active-edge counts: the same identity term becomes a genuine global phase ... :: N_active=1 vs 1, witness 1 -> 1
+```
+
+**Gate coverage, stated plainly.** `G1`/`G2` are the classification and its
+covariance contrast; `G3` is the quotient; `G4` is the invariant; `G5` is the
+negative result R4 and is the only group that touches graph structure; `G6` is
+the three-site counterexample defeating completeness; `G7` is the
+record-conditioned active-edge boundary. **No gate composes R1–R3 with a
+formation rule, an instrument, a weight, or a realized outcome — nothing in
+this runner touches those, and nothing above claims them.**
+
+No axiom, primitive, registry, ledger, queue, or generated audit surface is
+edited by this note or its runner.

--- a/docs/COMMON_FRAME_PAIR_GENERATOR_EXCHANGE_CLASS_BOUNDED_THEOREM_NOTE_2026-07-25.md
+++ b/docs/COMMON_FRAME_PAIR_GENERATOR_EXCHANGE_CLASS_BOUNDED_THEOREM_NOTE_2026-07-25.md
@@ -1,7 +1,7 @@
 ---
 claim_id: common_frame_pair_generator_exchange_class_bounded_theorem_note_2026-07-25
 claim_type: bounded_theorem
-claim_scope: "Under four SUPPLIED hypotheses -- (H1) one M_2(C) site domain on the Z^3 nearest-neighbour graph; (H2) an autonomous time-independent self-adjoint pair generator; (H3) a sum of identical two-site terms; (H4) COMMON-frame SU(2) covariance, one and the same U acting on both sites of an edge -- the commutant of the diagonal frame action on two qubits has complex dimension exactly 2 and equals span{I, SWAP}, so every admissible pair generator is h = a I + b SWAP with a, b real. The licensed quotient (h, t) -> (alpha h + beta I, t/alpha) with alpha > 0 removes a and |b| and leaves exactly sign(b), and the separating invariant is the GROUND-SECTOR DEGENERACY: 1 for b > 0 (the singlet) and 3 for b < 0 (the triplet). RECORDED EXPLICITLY AS A NEGATIVE RESULT: the one-excitation band minimum is NOT a valid separator, because Z^3 nearest-neighbour adjacency is bipartite by the parity of x + y + z, the sublattice relabeling D = diag((-1)^parity) gives D A D = -A, hence spec(A) = -spec(A), and the +J and -J one-excitation bands are identical as multisets after the licensed energy shift; the separator works only on a non-bipartite graph such as the triangle, and Z^3 is not one. THREE LIMITATIONS ARE PART OF THE CLAIM, NOT CAVEATS TO IT. (L1) H4 is a PREMISE THAT CREATES the two-point menu: under INDEPENDENT onsite covariance the commutant is only the scalars, SWAP is not invariant, and no nontrivial pair law survives without a further supplied object (a connection, link variable, shared frame, or symmetry reduction). (L2) 'Exactly two' holds only for the two-site edge class under the supplied identical-pair-term ansatz H3: at three sites H_1 = SWAP_01 + SWAP_02 and H_2 = SWAP_01 SWAP_02 + SWAP_02 SWAP_01 satisfy the same Hermiticity, neighbour-exchange, and common-frame covariance hypotheses, and H_1 + eta H_2 carries a dimensionless eta moving the gap ratio (E1-E0)/(E2-E1) from 2 at eta = 0 to 1 at eta = 1/3, which a gap RATIO argument shows is removable by neither clock rescaling nor energy shift. (L3) The 'inert' identity shift is NOT inert on a record-conditioned active-edge set: on a supplied convention where an edge is active when neither endpoint carries a record, two record sectors with different active-edge counts acquire a relative phase that moves an interference term on a coherent superposition of those sectors, so the energy shift may not be discarded before the domain is fixed. NOT claimed: any selection of sign(b), of |b|, of a rate, or of a time unit; derivability of H2-H4 from Lattice/Qubit/Admissibility/Record; PAIRWISE INDEPENDENCE OF H1-H4 (none is claimed and none is audited here); a well-defined discrete update on overlapping edges; a strict light cone; any record formation rule, formation trigger, instrument, Born weight, sampling rule, actuality, or realized outcome; the general reversible-record obstruction; continuity of a disagreement minimizer; and any relativistic, chiral, fermionic, gauge, species, matter, clock-metric, or gravitational consequence. This note sets no audit verdict and asserts no PASS."
+claim_scope: "Under four SUPPLIED hypotheses -- (H1) one M_2(C) site domain on the Z^3 nearest-neighbour graph; (H2) an autonomous time-independent self-adjoint pair generator; (H3) a sum of identical two-site terms; (H4) COMMON-frame SU(2) covariance, one and the same U acting on both sites of an edge -- the commutant of the diagonal frame action on two qubits has complex dimension exactly 2 and equals span{I, SWAP}, so every admissible pair generator is h = a I + b SWAP with a, b real. The licensed quotient (h, t) -> (alpha h + beta I, t/alpha) with alpha > 0 removes a and |b| and leaves exactly sign(b), and the separating invariant is the GROUND-SECTOR DEGENERACY: 1 for b > 0 (the singlet) and 3 for b < 0 (the triplet). RECORDED EXPLICITLY AS A NEGATIVE RESULT: the one-excitation band minimum is NOT a valid separator, because Z^3 nearest-neighbour adjacency is bipartite by the parity of x + y + z, the sublattice relabeling D = diag((-1)^parity) gives D A D = -A, hence spec(A) = -spec(A), and the +J and -J one-excitation bands are identical as multisets after the licensed energy shift; the separator works only on a non-bipartite graph such as the triangle, and Z^3 is not one. Separately recorded: the class is frame-COVARIANT and not frame-fixed -- (w^dag (x) w) SWAP is Hermitian for every unitary w but is NOT in span{I, SWAP} for a non-central w, so 'the law is I - SWAP' is not a frame-invariant sentence; what is frame-invariant is the ground-sector degeneracy, which does not move. THREE LIMITATIONS ARE PART OF THE CLAIM, NOT CAVEATS TO IT. (L1) H4 is TWO premises with OPPOSITE statuses, and the two-point menu is a LOWER BOUND rather than an artifact of them. (H4a) correlation -- the edge covariance group is a TWISTED DIAGONAL {(u, w u w^dag)} rather than the independent product; (H4b) flatness -- the twist is trivial, w = I, uniformly. Flatness is SUPPLIED outright. Correlation is the half the Admissibility clause 'determined by, and vary with, the nearest-neighbor conditions' bears on, and the campaign argument that it is forced is a READING of that clause, turning on whether 'No possibility is privileged' means ray-transitivity and on how 'conditions' is typed; that argument is neither gated nor asserted here as a theorem. Three computed facts replace the earlier L1 sentence: (i) the scalars-only collapse under INDEPENDENT onsite covariance is a property of the supplied CONTINUOUS SU(2) and not of independent-onsite covariance as such -- under the finite order-4 group generated by the spin lift of the pi/2 rotation about the edge axis, independent-onsite covariance leaves a Hermitian family of REAL DIMENSION 4 with explicit witness Z (x) Z, and the common-frame chain is 16 -> 10 -> 6 -> 5 -> 2 with every step past 5 bought by the continuous group; (ii) the twisted commutant has dimension EXACTLY 2 for EVERY twist, by the exact generic-matrix identity (I(x)W)(P(x)I + I(x)P)(I(x)W)^-1 = P(x)I + I(x)(W P W^-1), and the ground-sector separator is conjugation-invariant, so dropping flatness leaves the two-point structure intact; (iii) dropping flatness ENLARGES the underdetermination -- a twist assignment on a closed 4-cycle carries a re-framing-invariant loop-product trace 6/5, so no per-site re-framing flattens it and a link field is added on top of the sign bit. Also recorded, not gated: MINIMAL_AXIOMS_2026-06-29.md does not force common-frame covariance -- the standalone word 'frame' occurs zero times in it and its only covariance clause quantifies over lattice translations and proper cubic rotations, never an internal SU(2) -- while prior art in the corpus treats a common PU(2) re-presentation as the narrow SAFE one and site-dependent frames as the horn needing an extra supplied transport. (L2) 'Exactly two' holds only for the two-site edge class under the supplied identical-pair-term ansatz H3: at three sites H_1 = SWAP_01 + SWAP_02 and H_2 = SWAP_01 SWAP_02 + SWAP_02 SWAP_01 satisfy the same Hermiticity, neighbour-exchange, and common-frame covariance hypotheses, and H_1 + eta H_2 carries a dimensionless eta moving the gap ratio (E1-E0)/(E2-E1) from 2 at eta = 0 to 1 at eta = 1/3, which a gap RATIO argument shows is removable by neither clock rescaling nor energy shift. (L3) The 'inert' identity shift is NOT inert on a record-conditioned active-edge set: on a supplied convention where an edge is active when neither endpoint carries a record, two record sectors with different active-edge counts acquire a relative phase that moves an interference term on a coherent superposition of those sectors, so the energy shift may not be discarded before the domain is fixed. NOT claimed: any selection of sign(b), of |b|, of a rate, or of a time unit; derivability of H2-H4 from Lattice/Qubit/Admissibility/Record; PAIRWISE INDEPENDENCE OF H1-H4 (none is claimed and none is audited here); a well-defined discrete update on overlapping edges; a strict light cone; any record formation rule, formation trigger, instrument, Born weight, sampling rule, actuality, or realized outcome; the general reversible-record obstruction; continuity of a disagreement minimizer; and any relativistic, chiral, fermionic, gauge, species, matter, clock-metric, or gravitational consequence. This note sets no audit verdict and asserts no PASS."
 upstream_dependencies:
   - minimal_axioms
 runner: scripts/common_frame_pair_generator_exchange_class_2026_07_25.py
@@ -38,9 +38,18 @@ The classification is genuinely useful: an arbitrary Hermitian operator on
 `C^2 ⊗ C^2` carries 16 real parameters, and under the stated hypotheses it
 collapses to two, then to one after the licensed quotient. The limitations are
 equally load-bearing, and they are the part that a summary tends to lose: the
-covariance reading is what *creates* the two-point menu rather than a
-notational convenience; the count does not survive enlarging the support past
-one edge; and the identity term is inert only on a fixed active-edge set.
+covariance premise is two premises with different statuses and the two-point
+count is a *lower* bound on the underdetermination rather than a product of
+the premise; the count does not survive enlarging the support past one edge;
+and the identity term is inert only on a fixed active-edge set.
+
+**Correction history.** An earlier revision of this note carried an L1 that
+said the opposite of what its own algebra supports — that common-frame
+covariance *creates* the menu and that under independent onsite covariance no
+nontrivial pair law survives at all. Both halves are wrong, and L1 below now
+states what is computed instead. The gates that were already here (`G2a`–`G2d`)
+were correct as computations; the error was in generalising them from the
+supplied continuous `SU(2)` to independent-onsite covariance as such.
 
 This note claims a **classification**, not a law. It selects no sign, no rate,
 no formation rule, no instrument, and no actual history.
@@ -79,7 +88,13 @@ open gates outside axiom content, and H2–H4 sit on that gate.
   nearest-neighbour two-site terms. This is an **ansatz**, and L2 below is
   precisely the cost of it.
 - **(H4) COMMON-frame covariance.** One and the same `U ∈ SU(2)` acts on both
-  sites of an edge. This is the decisive premise; see L1.
+  sites of an edge. This is really **two** premises, and L1 separates them:
+  **(H4a)** the two endpoint actions are *correlated* — the edge covariance
+  group is a twisted diagonal `{(u, w u w†)}` rather than the independent
+  product; and **(H4b)** the twist is *flat*, `w = I`, uniformly. Only H4b is
+  the "one and the same `U`" convention. Both are supplied here; L1 records
+  that they are supplied in different senses and that the classification does
+  not depend on H4b.
 
 **No pairwise independence of H1–H4 is claimed**, and the runner attempts no
 independence audit of them. They are stated as a conjunction and consumed as a
@@ -151,19 +166,157 @@ breaking mutation. `G5h` adds the independent point that the band minimum is
 not even invariant under the `β I` shift, whereas the ground-sector degeneracy
 does not move at all.
 
+**R5 (the class is frame-COVARIANT, not frame-fixed).** For a unitary `w`, the
+operator `(w† ⊗ w) SWAP` is Hermitian — this is exact, since
+`SWAP (w ⊗ w†) = (w† ⊗ w) SWAP` — so it is an admissible pair generator and not
+a formal object. But for a **non-central** `w` it is **not** in `span{I, SWAP}`:
+the span rank rises from 2 to 3. Consequently
+
+> "the law is `I − SWAP`" is **not a frame-invariant sentence**.
+
+It names an operator, and the same law re-presented through a site-dependent
+frame is `I − (w† ⊗ w) SWAP`, which lies outside the class R1 computes. What
+*is* frame-invariant is the R3 separator: unitary conjugation moves no
+eigenvalue multiplicity, so the ground-sector degeneracy of
+`a I + b (w† ⊗ w) SWAP` is still `1` for `b > 0` and `3` for `b < 0`. Gates
+`G10a`–`G10d`; `G10c` is the construction mutation — rebuild with a central
+twist `w = −I` and the operator lands back inside `span{I, SWAP}`, rank `3 → 2`.
+R1 is therefore a classification **relative to a chosen frame**, and R3, not the
+operator's name, carries the frame-independent content.
+
 ## Limitations (all three are part of the claim, not caveats to it)
 
-**L1 — common-frame covariance is a PREMISE that CREATES the two-point menu.**
-H4 is not a notational convenience; it is the physics. Under **independent**
-onsite covariance — separate `SU(2)` actions on the two sites — the commutant
-collapses to complex dimension **1**, the scalars alone; `SWAP` is not
-invariant there. Solving directly, `a I + b SWAP` is independent-onsite
-invariant only for `b = 0`. So under independent onsite covariance **no
-nontrivial pair interaction survives at all** without a further supplied
-object: a connection, a link variable, a shared frame, or a symmetry reduction.
-The axiom sentence "No possibility is privileged" does not choose between the
-two readings. Adopting the exchange class therefore imports a physical premise;
-it does not read one off a symmetry slogan. Gates `G2a`–`G2d`.
+**L1 — the covariance premise is TWO premises with opposite standing, and the
+two-point count is a LOWER BOUND, not an artifact of them.**
+
+H4 bundles **(H4a)** correlation — the edge covariance group is a twisted
+diagonal `{(u, w u w†)}` rather than the independent product — with **(H4b)**
+flatness, `w = I` uniformly. They do not stand or fall together, and the
+five items below are what the algebra and the axiom text actually give.
+
+**(i) The scalars-only collapse belongs to the supplied CONTINUOUS group, not
+to independent-onsite covariance as such.** Gates `G2a`–`G2d` compute the
+collapse for the continuous `SU(2)`: the commutant falls to complex dimension
+**1**, `SWAP` is not invariant, and `a I + b SWAP` is invariant only for
+`b = 0`. That computation stands and is unchanged. What does **not** follow is
+the general sentence. Replace the continuous group by a finite one — the
+order-4 group generated by the spin lift of the `π/2` rotation about the edge
+axis, a finite subgroup drawn from the proper cubic rotations that are the only
+rotations the Lattice axiom names — and
+independent-onsite covariance leaves a Hermitian family of **real dimension 4**,
+with the explicit Hermitian witness
+
+```text
+Z ⊗ Z,   [Z ⊗ Z, u ⊗ I] = 0   and   [Z ⊗ Z, I ⊗ u] = 0   separately,
+```
+
+which is not a multiple of `I`. Gates `G8c`, `G8d`, with construction mutation
+`G8e` (rebuild the same witness against the continuous generators and it stops
+being invariant, so `G8c` does not contradict `G2a`). Whether the proper cubic
+rotations act internally on `M_2(C)` at all is **itself supplied** and is not
+asserted here; the finite group is used only to locate which hypothesis does
+the killing. The same computation locates the rest of the descent: common-frame
+covariance under that finite group leaves real dimension **6** (`G8b`), under
+the full order-8 proper edge stabiliser **5** (`G8f`), and under the bare
+endpoint exchange alone **10** (`G8g`) — the chain
+
+```text
+16 → 10 → 6 → 5 → 2,
+```
+
+in which every step past 5 is bought with the **continuous** group and not with
+a covariance reading.
+
+**(ii) The classification does not depend on the flatness half.** For **every**
+twist the twisted commutant has dimension exactly 2. This is not a sample: for a
+*generic* invertible `W`,
+
+```text
+(I ⊗ W)(P ⊗ I + I ⊗ P)(I ⊗ W)⁻¹ = P ⊗ I + I ⊗ (W P W⁻¹),
+(I ⊗ W) SWAP (I ⊗ W)⁻¹          = (W⁻¹ ⊗ W) SWAP,
+```
+
+are exact symbolic identities (`G9a`, `G9b`), so the twisted diagonal is the
+`(I ⊗ W)`-conjugate of the diagonal and conjugation is a linear bijection on
+commutants. Hence the twisted commutant is `span{I, (w† ⊗ w) SWAP}`, confirmed
+by native solve in both containments on exact unitary twists (`G9c`, `G9d`),
+with construction mutation `G9f` (replace the automorphism twist by the
+degenerate homomorphism `u ↦ I` and the dimension moves `2 → 4`). The R3
+separator is conjugation-invariant, so the ground-sector degeneracy is `1` for
+`b > 0` and `3` for `b < 0` for **every** twist (`G9e`). Relaxing H4b leaves
+the two-point structure exactly where it was.
+
+**(iii) Dropping flatness ENLARGES the underdetermination rather than
+dissolving it.** A twist assignment on the edges transforms under per-site
+re-framing as `w_e ↦ g_x w_e g_y†`, so the loop product around a closed cycle
+is conjugated and its trace is a re-framing invariant. Exhibited exactly: the
+4-cycle assignment `(I, I, I, w)` has loop-product trace `6/5`, which is neither
+`2` nor `−2`, so **no** per-site re-framing carries it to the flat assignment
+(`G10e`, with mutation `G10f` applying actual re-framings and finding the trace
+immobile). Relaxing H4b therefore adds a link field with re-framing-invariant
+content **on top of** the sign bit. Together with (ii): **the two-point menu is
+a lower bound on the underdetermination, not a product of the premise.** By R5
+it is also not even a statement about a fixed operator — `I − SWAP` names an
+operator only relative to a chosen frame.
+
+**(iv) What the axioms do and do not say — recorded, not gated.**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) does **not**
+force common-frame covariance. The standalone word "frame" occurs **zero**
+times in it — all six case-insensitive matches are inside "framework" — and its
+only covariance clause, `:57–58`, reads "There is one fixed nearest-neighbor
+admissibility rule, covariant under lattice translations and proper cubic
+rotations": spatial motions, never an internal `SU(2)`. These are textual facts
+about the memo and they are deliberately **not** gated — this runner reads no
+markdown, and a prose-needle gate would be a grep rather than a computation.
+
+The two halves are nevertheless supplied in different senses, and the note
+records the asymmetry without resolving it. **H4b is supplied outright**: it is
+a convention about which nothing in the memo speaks. **H4a is the half the
+Admissibility clause bears on** — "For each site, the available possibilities
+are determined by, and vary with, the nearest-neighbor conditions" (`:60–61`)
+is a cross-site comparison, and the campaign argument is that a rule
+equivariant under *independent* onsite relabelings of a ray-transitive group
+cannot depend on **what** a neighbour's condition is, only on whether one is
+present. That argument is a **reading** of the axiom, not a computation, and it
+turns on two things the memo does not settle: whether "No possibility is
+privileged" (`:52`) is to be read as ray-transitivity of the covariance group,
+and whether "conditions" is typed as record content or as record occupancy.
+**This note neither gates that argument nor asserts the forcing as a theorem.**
+It records only that flatness and correlation are not supplied in the same
+sense, and that the classification survives dropping flatness either way.
+
+**(v) Prior art in the corpus concludes the opposite polarity from the sentence
+this limitation used to carry.** Two surfaces, quoted exactly and referenced in
+backticks as context only — neither is consumed as evidence, neither is
+modified, and nothing here inherits status from either:
+
+- `docs/COLOR_ARENA_BONDED_PAIR_ADMISSIBILITY_CROSS_SITE_SURFACE_BOUNDED_THEOREM_NOTE_2026-07-06.md:76-78`
+  — "The Qubit axiom itself supplies that / identification: both domains carry
+  the same supplied algebraic presentation / (`M_2(C)`)". That note's own
+  frame-relativity paragraph at `:96-101` adds that "an INDEPENDENT per-site
+  presentation change (`g tensor 1`) does not commute with `S` and moves the
+  split", and registers the leftover at `:198` as "R5 frame transport … a rule
+  for comparing presentations across sites (transport) is not supplied by
+  anything in this note -- open."
+- `docs/work_history/repo/review_feedback/FOUNDATION_LICENSED_PHYSICAL_EQUIVALENCE_WEYL_PAIR_NOTE_2026-07-14.md:29-34`
+  — "The narrow safe / re-presentation is a common complex-linear
+  star-automorphism—an inner / `PU(2)` conjugation—applied to the complete
+  rule, record content, and decoder. / Neither statement licenses arbitrary
+  site-dependent quantum frames, / reflections, antiunitary conjugations,
+  boundary changes, or a quotient over / experimental protocols." Its section
+  "Common versus site-dependent frames" (`:198-216`) says of an arbitrary
+  family `U_x`: "It changes neighbor comparisons by / the relative frame
+  `U_x^dagger U_y`. A particular gauge/connection law may / make those changes
+  redundant, but the foundation does not supply that law."
+
+So the corpus treats a **common** `PU(2)` re-presentation as the narrow safe
+one and **site-dependent** frames as the horn that needs an extra supplied
+object — the reverse of the polarity the old L1 asserted. The two surfaces are
+not in agreement with each other on whether the Qubit axiom *supplies* the
+cross-site identification (the first says it does; the second, and (iv) above,
+say the foundation supplies no transport), and this note takes no side: it
+records the disagreement as the open question it is, consistent with that note's own
+residual `R5 … open`.
 
 **L2 — "exactly two parameters" holds only for the two-site edge class under
 the supplied identical-pair-term ansatz.** The count is a statement about one
@@ -218,7 +371,16 @@ This note does **not** claim, and its runner does not gate:
 - any selection of `sign(b)`, of `|b|`, of a rate, or of a time unit;
 - that H2–H4 are derivable from Lattice/Qubit/Admissibility/Record — the axiom
   memo says the opposite for dynamics;
-- pairwise independence of H1–H4;
+- that the Admissibility axiom **forces** the H4a correlation. L1(iv) records
+  that argument as an axiom **reading** turning on two unsettled words, states
+  that it is not gated here, and asserts no theorem;
+- that the proper cubic rotations act internally on `M_2(C)`. The finite group
+  in `G8` is used only to locate which hypothesis carries the scalars-only
+  collapse; its internal action is supplied and is not claimed;
+- any selection of a twist, a link field, a transport rule, a connection, or a
+  holonomy. L1(iii) exhibits one re-framing-invariant loop product to show that
+  relaxing H4b enlarges the class; it selects nothing;
+- pairwise independence of H1–H4, or of H4a from H4b;
 - a well-defined discrete update: on overlapping edges the pair terms do not
   commute, so a product update still needs an ordering/layering rule or a
   causal-invariance theorem;
@@ -244,10 +406,14 @@ The licensed negative content is bounded to L1–L3 and R4:
 
 > Under H1–H4 the two-site pair generator class is exactly `span{I, SWAP}` and
 > the licensed quotient leaves exactly `sign(b)`. Under independent onsite
-> covariance no nontrivial pair term survives. The two-parameter count does not
+> covariance **with respect to the continuous `SU(2)`** no nontrivial pair term
+> survives; that is a statement about the continuous group and not about
+> independent-onsite covariance as such, since the same covariance with respect
+> to a finite subgroup leaves real dimension 4. The two-parameter count does not
 > extend past the two-site edge class under H3. The identity term is not inert
 > on a record-conditioned active-edge set. The one-excitation band minimum is
-> not a valid sign separator on the bipartite `Z^3` graph.
+> not a valid sign separator on the bipartite `Z^3` graph. `span{I, SWAP}` is
+> not a frame-invariant description of the class.
 
 No universal no-go against a pair law, an exchange dynamics, or a deeper
 theorem deriving H2–H4 is made.
@@ -260,8 +426,12 @@ independent audit lane.**
 
   | route | strongest attempted form | outcome |
   |---|---|---|
-  | common-frame `SU(2)` covariance | commutant of `U ⊗ U` | dimension 2, `span{I, SWAP}` — the stated class |
-  | independent onsite covariance | commutant of separate `SU(2)` actions | dimension 1, scalars only — L1 |
+  | common-frame **continuous** `SU(2)` covariance | commutant of `U ⊗ U` | dimension 2, `span{I, SWAP}` — the stated class |
+  | independent onsite, **continuous** `SU(2)` | commutant of separate `SU(2)` actions | dimension 1, scalars only |
+  | independent onsite, **finite** edge-axis group | same construction, finite group | real dimension **4**, witness `Z ⊗ Z` — L1(i) |
+  | common frame, **finite** edge-axis group | commutant of `u ⊗ u`, `u` of order 4 | real dimension **6**; order-8 stabiliser gives **5** — L1(i) |
+  | **twisted** diagonal `{(u, w u w†)}` | commutant, generic invertible twist | dimension **2 for every twist**, `span{I, (w†⊗w)SWAP}` — L1(ii) |
+  | drop flatness across a closed loop | loop product under `w_e ↦ g_x w_e g_y†` | re-framing-invariant trace `6/5`: a link field is **added** — L1(iii) |
   | enlarge support to three sites | `H_1 + η H_2` under the same symmetries | independent dimensionless `η` survives — L2 |
   | remove `a` by energy shift | `β I` on a fixed active-edge set | succeeds on a fixed graph, fails on a record-conditioned graph — L3 |
   | remove `sign(b)` by rescaling | `α > 0` clock rescaling | fails; only an unlicensed `α < 0` identifies the signs |
@@ -271,7 +441,14 @@ independent audit lane.**
   | discrete layered update instead of a generator | product of overlapping pair terms | ordering/layering rule required; not supplied |
 
 - **N2 wall separation — ATTEMPTED.** Finite controls that keep one wall from
-  being silently renamed as another: covariance reading vs class size (common
+  being silently renamed as another: **group continuity vs covariance reading**
+  (the finite edge-axis group gives 6 common / 4 independent, the continuous
+  group gives 2 common / 1 independent — so "which covariance" and "which group"
+  are separate walls and the old L1 conflated them); **correlation vs flatness**
+  (every twist gives dimension 2, so H4b moves nothing in the count, while H4a
+  moves it from 1 to 2); **operator name vs invariant** (`(w†⊗w)SWAP` leaves
+  `span{I, SWAP}` while the ground-sector degeneracy does not move); covariance
+  reading vs class size (common
   frame gives dimension 2, independent onsite gives dimension 1); class size vs
   support (dimension 2 on one edge, `η` appears at three sites); scale freedom
   vs sign (`α > 0` removes `|b|`, never `sign(b)`); energy zero vs sector
@@ -282,7 +459,12 @@ independent audit lane.**
   tie several rows together. **These controls are not an independence proof,
   and no claim is made that H1–H4 are pairwise independent.**
 - **N3 hidden-wall scan — ATTEMPTED.** Exposed rather than hidden: the
-  common-versus-independent frame reading; autonomy/time-independence; the
+  common-versus-independent frame reading; **the continuity of the internal
+  group, which is what the scalars-only collapse actually needs**; **the
+  splitting of H4 into correlation and flatness, and the fact that "the law is
+  `I − SWAP`" names an operator only relative to a frame**; **whether the proper
+  cubic rotations act internally on `M_2(C)` at all, which is supplied and not
+  claimed here**; autonomy/time-independence; the
   identical-pair-term ansatz; the two-site support restriction; the
   fixed-versus-record-conditioned active-edge set and the supplied
   active-edge convention itself; the sign of `b`; the magnitude `|b|` and its
@@ -313,9 +495,14 @@ independent audit lane.**
     rhetorical hedge.
   - Entanglement **capability** is not sampling, an outcome, or a record, and
     no entanglement claim is gated here at all.
-- **N6 partial-closure path — ATTEMPTED.** (1) Test whether the common-frame
-  reading is forced by, or merely compatible with, the Admissibility covariance
-  sentence. (2) Classify the full low-support invariant term basis past one
+- **N6 partial-closure path — ATTEMPTED.** (1) Type the Admissibility axiom's
+  "conditions" — as record content or as record occupancy — and settle whether
+  "No possibility is privileged" is to be read as ray-transitivity of the
+  covariance group. L1(iv) shows those two words are the whole of what is left
+  between "H4a is a supplied premise" and "H4a is forced", and neither is
+  settled by the memo; this is a question for the owner and the audit lane, not
+  a computation this note can perform. (2) Classify the full low-support
+  invariant term basis past one
   edge, so the L2 `η` family is enumerated rather than exhibited. (3) Search for
   a conservation or index theorem fixing `sign(b)` rather than registering it.
   (4) Fix the active-edge/vacuum energy convention, or prove the superselection
@@ -335,9 +522,14 @@ independent audit lane.**
   covariance of the three-site `H_1`, `H_2` is actually computed, which is what
   makes `η` an independent invariant; (iii) the active-edge non-inertness is
   built from a record-conditioned sector pair rather than a hand-written
-  diagonal; and (iv) R4 is new — the band-minimum separator is positively
+  diagonal; (iv) R4 is new — the band-minimum separator is positively
   refuted on the bipartite `Z^3` graph and the ground-sector degeneracy is put
-  in its place.
+  in its place; and (v) R5 and L1(i)–(iii) are new — the finite-versus-continuous
+  contrast that locates the scalars-only collapse, the every-twist dimension
+  theorem proved from a generic-matrix identity rather than sampled, the
+  re-framing-invariant loop product, and the observation that `span{I, SWAP}` is
+  a frame-relative description. **The earlier revision of this note asserted the
+  contrary of L1(i)–(iii) and is corrected here**; see Purpose.
 
 ## Verification
 
@@ -348,7 +540,7 @@ Primary runner:
 python3 scripts/common_frame_pair_generator_exchange_class_2026_07_25.py
 ```
 
-Result on this note's content: **`PASS=46`, `FAIL=0`** (about 0.7 s). The PASS
+Result on this note's content: **`PASS=65`, `FAIL=0`** (about 1.4 s). The PASS
 total is a **gate count**, not a count of independent scientific facts.
 
 **Why a new runner rather than the four existing ones.** The 2026-07-14
@@ -385,7 +577,27 @@ of them. Those four surfaces and their runners are left untouched.
   bands must differ), `G6e` and `G6i` (a non-covariant decoy must fail the
   symmetry gates; sweeping `η` must move the ratio), `G7d` (rebuild the record
   configuration with equal active-edge counts; the identity term must become
-  inert).
+  inert), `G8e` (rebuild the `Z ⊗ Z` witness against the continuous generators
+  instead of the finite ones; invariance must fail), `G9f` (rebuild the
+  correlation with the degenerate homomorphism `u ↦ I` instead of an
+  automorphism twist; the dimension must move 2 → 4), `G10c` (rebuild the
+  twisted operator with a central twist; the span rank must fall 3 → 2), and
+  `G10f` (apply actual per-site re-framings to the loop product; the trace must
+  not move).
+- **The `G9a`/`G9b` twist identities are symbolic, not sampled.** They are
+  computed on a generic `2 × 2` matrix with nonzero determinant, so "dimension
+  exactly 2 for **every** twist" is proved rather than checked on instances;
+  `G9c`/`G9d` then re-derive it by native solve on exact unitary twists as an
+  independent cross-check.
+- **The Hermitian dimensions in `G8` are solved, not inferred.** The Hermitian
+  ansatz is built from real symbols, the commutation residual is split into its
+  exact real and imaginary parts, and the dimension is the corank of the
+  resulting exact real linear system.
+- **The textual facts in L1(iv) are deliberately ungated.** The word counts and
+  quotations from the axiom memo are recorded in prose with exact line
+  references and left there: gating them would require the runner to grep
+  markdown, which the design rule above forbids and which would not be
+  mathematics.
 
 Selected gate lines, verbatim:
 
@@ -404,13 +616,27 @@ PASS G6g gap ratio (E1 - E0)/(E2 - E1) = 2 at eta = 0 :: levels=[-1, 1, 2] ratio
 PASS G6h gap ratio = 1 at eta = 1/3 :: levels=[-4/3, 2/3, 8/3] ratio=1
 PASS G7c on a coherent superposition of the two record sectors the identity term MOVES the interference term ... :: witness 1 -> 1/2
 PASS G7d MUTATION ... EQUAL active-edge counts: the same identity term becomes a genuine global phase ... :: N_active=1 vs 1, witness 1 -> 1
+PASS G8c INDEPENDENT-onsite covariance under the SAME finite group leaves Hermitian real dimension 4: a nontrivial pair law SURVIVES :: dim_R=4
+PASS G8e MUTATION rebuild the same witness against the CONTINUOUS independent generators: Z(x)Z stops being invariant, so G8c is a statement about the finite group and does not contradict G2a :: continuous group is what kills it
+PASS G8g and with only the bare endpoint exchange the class is Hermitian real dimension 10, so the chain 16 -> 10 -> 6 -> 5 -> 2 is monotone and every step past 5 is supplied :: bare=10 continuous_common=2
+PASS G9a SYMBOLIC, for EVERY invertible W: (I(x)W)(P(x)I + I(x)P)(I(x)W)^-1 = P(x)I + I(x)(W P W^-1), so the twisted diagonal is exactly the (I(x)W)-conjugate of the diagonal -- not a sampled claim :: generic 2x2 W with det W != 0
+PASS G9e the R3 separator is TWIST-INVARIANT: ground-sector degeneracy is 1 for b > 0 and 3 for b < 0 for every twist, so dropping flatness does not dissolve the two-point menu :: (b>0, b<0) degeneracies=[(1, 3), (1, 3), (1, 3), (1, 3)]
+PASS G9f MUTATION rebuild the correlation with the degenerate homomorphism u -> I instead of an automorphism twist: the dimension MOVES 2 -> 4, so 'dimension 2' is carried by the twisted-diagonal construction and is not a tautology :: dim=4
+PASS G10b but it is NOT in span{I, SWAP}: the span rank rises to 3, so 'the law is I - SWAP' is not a frame-invariant sentence :: rank=3
+PASS G10c MUTATION rebuild the same construction with a CENTRAL twist w = -I: the operator lands back inside span{I, SWAP} and the rank falls to 2, so G10b is carried by the twist and not by the algebra :: rank=2
+PASS G10e on a closed 4-cycle the twist assignment (I, I, I, w) has loop product w with exact trace 6/5, which is neither 2 nor -2, so the assignment is NOT gauge-equivalent to the flat one :: trace=6/5
 ```
 
 **Gate coverage, stated plainly.** `G1`/`G2` are the classification and its
 covariance contrast; `G3` is the quotient; `G4` is the invariant; `G5` is the
 negative result R4 and is the only group that touches graph structure; `G6` is
 the three-site counterexample defeating completeness; `G7` is the
-record-conditioned active-edge boundary. **No gate composes R1–R3 with a
+record-conditioned active-edge boundary; `G8` is L1(i), locating the
+scalars-only collapse in the continuity of the group rather than in the
+covariance reading; `G9` is L1(ii), the every-twist dimension theorem and the
+twist-invariance of the separator; `G10` is R5 together with L1(iii), the
+frame-relativity of the operator's name and the re-framing-invariant loop
+product. **No gate composes R1–R3 with a
 formation rule, an instrument, a weight, or a realized outcome — nothing in
 this runner touches those, and nothing above claims them.**
 

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15062,
- "node_count": 4506,
+ "edge_count": 15063,
+ "node_count": 4507,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2409,6 +2409,10 @@
   "commensuration_unconditional_period_parity_lemma_narrow_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "common_frame_pair_generator_exchange_class_bounded_theorem_note_2026-07-25": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "complete_prediction_chain_2026_04_15": {
    "deps_hash": "ed7953444551",

--- a/logs/runner-cache/common_frame_pair_generator_exchange_class_2026_07_25.txt
+++ b/logs/runner-cache/common_frame_pair_generator_exchange_class_2026_07_25.txt
@@ -1,0 +1,92 @@
+===== runner cache v1 =====
+runner: scripts/common_frame_pair_generator_exchange_class_2026_07_25.py
+runner_sha256: c6d9a1da9a6be01d599963c2fb513167ce1b3c12bf4f991dd5db4745ff2c3de8
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.78
+status: ok
+----- stdout -----
+
+==============================================================================
+G1  common-frame commutant = span{I, SWAP}
+==============================================================================
+PASS G1a common-frame (diagonal SU(2)) commutant has complex dimension 2 :: dim=2
+PASS G1b identity lies in the computed commutant :: rank=2
+PASS G1c SWAP lies in the computed commutant :: rank=2
+PASS G1d span{I, SWAP} EQUALS the computed commutant (both containments)
+PASS G1e MUTATION non-invariant candidate X(x)I is NOT in the commutant (so G1d is not a tautology) :: rank=3
+PASS G1f exchange identity SWAP = (I + XX + YY + ZZ)/2 is exact
+PASS G1g finite frame check: (U(x)U) SWAP (U(x)U)^dag = SWAP for exact SU(2) samples, while X(x)I is moved by the same conjugation
+
+==============================================================================
+G2  MUTATION of the covariance construction: independent onsite
+==============================================================================
+PASS G2a MUTATION independent-onsite covariance collapses the commutant to complex dimension 1 :: dim=1
+PASS G2b the single surviving direction is the scalars span{I}
+PASS G2c SWAP is NOT in the independent-onsite commutant (explicit noncommutation with X(x)I)
+PASS G2d hence NO nontrivial pair term survives independent-onsite covariance: a*I + b*SWAP is invariant only for b = 0 :: solutions=[{b: 0}]
+
+==============================================================================
+G3  both sign candidates are Hermitian; the licensed quotient
+==============================================================================
+PASS G3a h = a*I + b*SWAP is Hermitian for symbolic real a, b
+PASS G3b both candidates are Hermitian at exact rational (a, b) and are genuinely different operators
+PASS G3c positive clock rescaling + energy shift leaves the generated channel unchanged up to a global phase (matrix exponentials)
+PASS G3d alpha = 1/|b| > 0 with beta = -alpha*a carries h to sign(b)*SWAP exactly, for BOTH signs -- a and |b| are removed
+PASS G3e NO positive rescaling plus energy shift maps +SWAP to -SWAP: the only solution has alpha = -1 :: solutions=[{alpha: -1, beta: 0}] positive=[]
+PASS G3f MUTATION dropping the positivity constraint on the rescaling IDENTIFIES the two signs (gamma = -1 solves it), so alpha > 0 is exactly what makes the sign physical :: solutions=[{beta: 0, gamma: -1}]
+
+==============================================================================
+G4  ground-sector degeneracy separates the two signs: 1 vs 3
+==============================================================================
+PASS G4a SWAP is the transposition (it exchanges |01> and |10>) and its spectrum is {+1 (x3), -1 (x1)}: the multiplicity split the invariant reads, on the operator G1 pinned :: spectrum={1: 3, -1: 1}
+PASS G4b b > 0: ground sector of a*I + b*SWAP is 1-dimensional (the singlet) :: deg=1
+PASS G4c MUTATION flip the sign IN THE CONSTRUCTION: the ground sector becomes 3-dimensional (the triplet) :: deg=3
+PASS G4d the degeneracies 1 and 3 are invariant across a 3x3 grid of exact (alpha > 0, beta) -- they survive the whole licensed quotient
+PASS G4e the degeneracy is invariant under a common frame change (U(x)U) h (U(x)U)^dag for exact SU(2) samples
+PASS G4f +SWAP and -SWAP have the SAME eigenvalue SET {+1, -1}: only the multiplicities differ, so a set-valued spectral invariant cannot separate the signs and the DEGENERACY is what does :: set={1, -1}
+
+==============================================================================
+G5  the one-excitation band minimum is NOT a sign separator
+==============================================================================
+PASS G5a the one-excitation block ASSEMBLED from the edge permutations equals A + (|E| - deg)*I on every regular instance :: C4: |E|-deg=2; Q3: |E|-deg=9; K3,3: |E|-deg=6; Z^3 torus L=4: |E|-deg=186
+PASS G5b the exchange sum preserves excitation number on the FULL 2^n space (C4 and Q3), so the block is an invariant restriction
+PASS G5c Z^3 nearest-neighbour adjacency is bipartite: x + y + z parity is a proper 2-colouring of every edge (L = 4 chunk, 192 edges) :: edges=192 sites=64
+PASS G5d the sublattice relabeling D = diag((-1)^parity) satisfies D^2 = I and D A D = -A on every bipartite instance INCLUDING the Z^3 chunk :: instances=['C4', 'K3,3', 'P3', 'Q3', 'Z^3 torus L=4']
+PASS G5e hence spec(A) = -spec(A) as multisets: A is similar to -A through D, so the band is sign-symmetric :: C4:[-2, 0, 0, 2]; Q3:[-3, -1, -1, -1, 1, 1, 1, 3]; K3,3:[-3, 0, 0, 0, 0, 3]; P3:[-sqrt(2), 0, sqrt(2)]
+PASS G5f consequently the +J and -J one-excitation bands are IDENTICAL as multisets after the licensed energy shift, so the band minimum (and the whole band shape) separates NOTHING on a bipartite graph :: C4: band=[-2, 0, 0, 2]; Q3: band=[-3, -1, -1, -1, 1, 1, 1, 3]; K3,3: band=[-3, 0, 0, 0, 0, 3]
+PASS G5g MUTATION swap the bipartite graph for the non-bipartite triangle: NO diagonal +-1 relabeling gives D A D = -A, spec(A) is not sign-symmetric, and the shifted +J / -J bands DIFFER -- so the band minimum DOES separate there and the failure is bipartiteness :: spec=[-1, -1, 2] +J band=[-1, -1, 2] -J band=[-2, 1, 1]
+PASS G5h independently, the band minimum is not even a quotient invariant: an energy shift beta*I moves it by beta, whereas the ground-sector degeneracy of G4 does not move at all :: min=-3 -> -1/4
+
+==============================================================================
+G6  three sites: an independent dimensionless eta survives
+==============================================================================
+PASS G6a H_1 = SWAP_01 + SWAP_02 and H_2 = SWAP_01 SWAP_02 + SWAP_02 SWAP_01 are both Hermitian
+PASS G6b both are invariant under the neighbour-exchange automorphism R = SWAP_12 of the three-site star
+PASS G6c both COMMUTE with all three diagonal SU(2) generators, i.e. both are common-frame covariant -- the check the source runners asserted but never computed
+PASS G6d finite frame check: (U(x)U(x)U) H_i (U(x)U(x)U)^dag = H_i for exact SU(2) samples
+PASS G6e MUTATION / negative control: Z_0 Z_1 is Hermitian too, but it FAILS both the common-frame commutation and the neighbour-exchange invariance -- so G6b and G6c are not tautologies
+PASS G6f I, H_1, H_2 are linearly independent, so eta is a genuinely new coefficient and not a disguised rescaling or energy shift :: rank=3
+PASS G6g gap ratio (E1 - E0)/(E2 - E1) = 2 at eta = 0 :: levels=[-1, 1, 2] ratio=2
+PASS G6h gap ratio = 1 at eta = 1/3 :: levels=[-4/3, 2/3, 8/3] ratio=1
+PASS G6i MUTATION sweep eta IN THE CONSTRUCTION: the ratio moves at every sampled value and never returns to a single number, so eta is not removable and 'exactly two parameters' fails past one edge :: ratios={'-1/2': '3', '1/6': '4/3', '1/2': '4/5'}
+PASS G6j the gap RATIO is invariant under h -> alpha*h + beta*I for exact alpha > 0 and beta, so neither clock rescaling nor an energy-zero choice can remove eta
+
+==============================================================================
+G7  the identity term is not inert on a record-conditioned set
+==============================================================================
+PASS G7a the active-edge count is COMPUTED from the graph and the record configuration and differs between the two record sectors :: N_active=1 vs 2 on edges=[(0, 1), (1, 2)]
+PASS G7b the sector phase operator built from those counts is NOT a scalar multiple of the identity :: diag=exp(-I*pi/3), exp(-2*I*pi/3)
+PASS G7c on a coherent superposition of the two record sectors the identity term MOVES the interference term, so it is not a removable global phase :: witness 1 -> 1/2
+PASS G7d MUTATION rebuild the record configuration so both sectors carry EQUAL active-edge counts: the same identity term becomes a genuine global phase and the interference term stops moving :: N_active=1 vs 1, witness 1 -> 1
+PASS G7e on a FIXED active-edge set the identity term IS inert: exp(-i(h + beta*I)t) = exp(-i*beta*t) exp(-i*h*t) exactly, so R2 holds exactly where it is claimed and L3 is a boundary, not a contradiction
+
+==============================================================================
+SUMMARY
+==============================================================================
+
+PASS=46
+FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/common_frame_pair_generator_exchange_class_2026_07_25.txt
+++ b/logs/runner-cache/common_frame_pair_generator_exchange_class_2026_07_25.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/common_frame_pair_generator_exchange_class_2026_07_25.py
-runner_sha256: c6d9a1da9a6be01d599963c2fb513167ce1b3c12bf4f991dd5db4745ff2c3de8
+runner_sha256: 517cfa98289e94daed044e33e727737186f0a5fc48ef0c4de6c02f00c82d6319
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.78
+elapsed_sec: 1.45
 status: ok
 ----- stdout -----
 
@@ -82,10 +82,41 @@ PASS G7d MUTATION rebuild the record configuration so both sectors carry EQUAL a
 PASS G7e on a FIXED active-edge set the identity term IS inert: exp(-i(h + beta*I)t) = exp(-i*beta*t) exp(-i*h*t) exactly, so R2 holds exactly where it is claimed and L3 is a boundary, not a contradiction
 
 ==============================================================================
+G8  the scalars-only collapse needs the CONTINUOUS group
+==============================================================================
+PASS G8a the edge-axis rotation lift is unitary with u^4 = -I, so u (x) u generates a group of order exactly 4 on the edge :: order 4
+PASS G8b COMMON-frame covariance under that FINITE group leaves Hermitian real dimension 6, not 2 -- the step down to 2 is bought by the continuous SU(2) :: dim_R=6
+PASS G8c INDEPENDENT-onsite covariance under the SAME finite group leaves Hermitian real dimension 4: a nontrivial pair law SURVIVES :: dim_R=4
+PASS G8d explicit witness Z(x)Z is Hermitian, commutes with u(x)I and with I(x)u SEPARATELY, and is not a multiple of I :: nontrivial independent-onsite-invariant pair term
+PASS G8e MUTATION rebuild the same witness against the CONTINUOUS independent generators: Z(x)Z stops being invariant, so G8c is a statement about the finite group and does not contradict G2a :: continuous group is what kills it
+PASS G8f the endpoint flip is a unitary involution that inverts the rotation lift, and the FULL order-8 common-frame edge stabiliser still leaves Hermitian real dimension 5, not 2 :: dim_R=5
+PASS G8g and with only the bare endpoint exchange the class is Hermitian real dimension 10, so the chain 16 -> 10 -> 6 -> 5 -> 2 is monotone and every step past 5 is supplied :: bare=10 continuous_common=2
+
+==============================================================================
+G9  the twisted diagonal has commutant dimension 2 for EVERY twist
+==============================================================================
+PASS G9a SYMBOLIC, for EVERY invertible W: (I(x)W)(P(x)I + I(x)P)(I(x)W)^-1 = P(x)I + I(x)(W P W^-1), so the twisted diagonal is exactly the (I(x)W)-conjugate of the diagonal -- not a sampled claim :: generic 2x2 W with det W != 0
+PASS G9b SYMBOLIC, same W: (I(x)W) SWAP (I(x)W)^-1 = (W^-1 (x) W) SWAP, so conjugation carries span{I, SWAP} onto span{I, (W^-1(x)W)SWAP} and the twisted commutant dimension is 2 for EVERY twist
+PASS G9c NATIVE solve on exact unitary twists confirms the symbolic result: complex dimension exactly 2 every time :: dims=[2, 2, 2, 2]
+PASS G9d and the solved commutant EQUALS span{I, (w^dag(x)w)SWAP} in both containments for every sampled twist :: [True, True, True, True]
+PASS G9e the R3 separator is TWIST-INVARIANT: ground-sector degeneracy is 1 for b > 0 and 3 for b < 0 for every twist, so dropping flatness does not dissolve the two-point menu :: (b>0, b<0) degeneracies=[(1, 3), (1, 3), (1, 3), (1, 3)]
+PASS G9f MUTATION rebuild the correlation with the degenerate homomorphism u -> I instead of an automorphism twist: the dimension MOVES 2 -> 4, so 'dimension 2' is carried by the twisted-diagonal construction and is not a tautology :: dim=4
+
+==============================================================================
+G10  the law's NAME is frame-relative; its holonomy is not
+==============================================================================
+PASS G10a (w^dag (x) w) SWAP is Hermitian for every sampled unitary twist, so it is an admissible pair generator, not a formal object
+PASS G10b but it is NOT in span{I, SWAP}: the span rank rises to 3, so 'the law is I - SWAP' is not a frame-invariant sentence :: rank=3
+PASS G10c MUTATION rebuild the same construction with a CENTRAL twist w = -I: the operator lands back inside span{I, SWAP} and the rank falls to 2, so G10b is carried by the twist and not by the algebra :: rank=2
+PASS G10d yet the ground-sector degeneracy of a*I + b*(w^dag(x)w)SWAP is still 1 vs 3: what the frame moves is the operator's NAME, not the separating invariant
+PASS G10e on a closed 4-cycle the twist assignment (I, I, I, w) has loop product w with exact trace 6/5, which is neither 2 nor -2, so the assignment is NOT gauge-equivalent to the flat one :: trace=6/5
+PASS G10f MUTATION apply an actual per-site re-framing to the loop product for every sampled frame: the trace does not move, so no re-framing flattens it -- dropping flatness ENLARGES the class by a link field rather than dissolving the two-point menu :: conjugation-invariant; flat loop product would have trace 2
+
+==============================================================================
 SUMMARY
 ==============================================================================
 
-PASS=46
+PASS=65
 FAIL=0
 
 ----- stderr -----

--- a/scripts/common_frame_pair_generator_exchange_class_2026_07_25.py
+++ b/scripts/common_frame_pair_generator_exchange_class_2026_07_25.py
@@ -1,0 +1,910 @@
+#!/usr/bin/env python3
+"""Exact gates for the common-frame pair-generator exchange-class note.
+
+Every gate is a computation on constructed objects. This runner reads no
+markdown and greps no prose: there are no needle gates, so the PASS total is
+entirely mathematical. It is still a GATE COUNT, not a count of independent
+scientific facts.
+
+Design rules honoured (they are the reason this runner exists rather than the
+four 2026-07-14 probes it supersedes):
+
+* exact `sympy` only -- no float appears as an input to any load-bearing
+  comparison, and no numeric tolerance is used anywhere;
+* every claimed constant is paired with a CONSTRUCTION-mutation probe: the
+  probe rebuilds the object from a changed construction and requires the
+  constant to move.  Mutating an assertion is not accepted as a probe;
+* no vacuous gate: each check can fail on some input, and the negative
+  controls (G1e, G2c, G6e, G5g) exist precisely to show the positive gates
+  are not tautologies;
+* an ordered label manifest with a drift detector closes the run.
+"""
+
+from __future__ import annotations
+
+import functools
+import itertools
+
+import sympy as sp
+
+# --------------------------------------------------------------------------
+# Gate manifest (ordered).  finish() fails the run on any drift.
+# --------------------------------------------------------------------------
+EXPECTED_LABELS = [
+    "G1a", "G1b", "G1c", "G1d", "G1e", "G1f", "G1g",
+    "G2a", "G2b", "G2c", "G2d",
+    "G3a", "G3b", "G3c", "G3d", "G3e", "G3f",
+    "G4a", "G4b", "G4c", "G4d", "G4e", "G4f",
+    "G5a", "G5b", "G5c", "G5d", "G5e", "G5f", "G5g", "G5h",
+    "G6a", "G6b", "G6c", "G6d", "G6e", "G6f", "G6g", "G6h", "G6i", "G6j",
+    "G7a", "G7b", "G7c", "G7d", "G7e",
+]
+
+
+class CheckRunner:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+        self.labels: list[str] = []
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        self.labels.append(label.split()[0])
+        suffix = f" :: {detail}" if detail else ""
+        if condition:
+            self.passed += 1
+            print(f"PASS {label}{suffix}")
+        else:
+            self.failed += 1
+            print(f"FAIL {label}{suffix}")
+
+    def finish(self) -> int:
+        if self.labels != EXPECTED_LABELS:
+            missing = [x for x in EXPECTED_LABELS if x not in self.labels]
+            extra = [x for x in self.labels if x not in EXPECTED_LABELS]
+            print(
+                "FAIL gate-manifest drift: "
+                f"ran={self.labels} expected={EXPECTED_LABELS} "
+                f"missing={missing} unexpected={extra}"
+            )
+            self.failed += 1
+        print()
+        print(f"PASS={self.passed}")
+        print(f"FAIL={self.failed}")
+        return 0 if self.failed == 0 else 1
+
+
+def section(title: str) -> None:
+    print()
+    print("=" * 78)
+    print(title)
+    print("=" * 78)
+
+
+# --------------------------------------------------------------------------
+# Exact primitives
+# --------------------------------------------------------------------------
+I2 = sp.eye(2)
+I4 = sp.eye(4)
+X = sp.Matrix([[0, 1], [1, 0]])
+Y = sp.Matrix([[0, -sp.I], [sp.I, 0]])
+Z = sp.Matrix([[1, 0], [0, -1]])
+PAULIS = (X, Y, Z)
+
+SWAP = sp.Matrix([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+
+# Exact SU(2) samples.  No floats: 3/5 + 4/5 rational rotation, the Hadamard
+# with an exact sqrt(2), and a complex-rational element.
+SAMPLE_SU2 = (
+    sp.Matrix([[sp.Rational(3, 5), sp.Rational(-4, 5)],
+               [sp.Rational(4, 5), sp.Rational(3, 5)]]),
+    (X + Z) / sp.sqrt(2),
+    sp.Matrix([[sp.Rational(3, 5), sp.Rational(4, 5) * sp.I],
+               [sp.Rational(4, 5) * sp.I, sp.Rational(3, 5)]]),
+)
+
+
+def is_zero_matrix(m: sp.Matrix) -> bool:
+    return sp.simplify(m) == sp.zeros(*m.shape)
+
+
+def eq(left: sp.Matrix, right: sp.Matrix) -> bool:
+    return is_zero_matrix(sp.Matrix(left) - sp.Matrix(right))
+
+
+def dag(m: sp.Matrix) -> sp.Matrix:
+    return m.conjugate().T
+
+
+def kron(*mats: sp.Matrix) -> sp.Matrix:
+    out = mats[0]
+    for m in mats[1:]:
+        out = sp.kronecker_product(out, m)
+    return out
+
+
+def vec(m: sp.Matrix) -> sp.Matrix:
+    return sp.Matrix(m).reshape(m.rows * m.cols, 1)
+
+
+def commutant_basis(generators: tuple[sp.Matrix, ...], dim: int):
+    """Exact basis of {M : [M, G] = 0 for every supplied generator G}."""
+    variables = sp.symbols(f"m0:{dim * dim}")
+    candidate = sp.Matrix(dim, dim, variables)
+    equations: list[sp.Expr] = []
+    for generator in generators:
+        equations.extend(candidate * generator - generator * candidate)
+    coefficients, _ = sp.linear_eq_to_matrix(equations, variables)
+    return [sp.Matrix(dim, dim, tuple(v)) for v in coefficients.nullspace()]
+
+
+def span_rank(*matrices: sp.Matrix) -> int:
+    return sp.Matrix.hstack(*(vec(m) for m in matrices)).rank()
+
+
+def exact_less(left, right) -> int:
+    """Exact three-way comparison of two real algebraic sympy numbers.
+
+    No float is used: the sign of the difference is decided symbolically and
+    the helper refuses anything it cannot decide exactly.
+    """
+    difference = sp.simplify(sp.nsimplify(left) - sp.nsimplify(right))
+    if difference == 0:
+        return 0
+    if difference.is_negative:
+        return -1
+    if difference.is_positive:
+        return 1
+    raise AssertionError(f"cannot order {left} against {right} exactly")
+
+
+ORDER_KEY = functools.cmp_to_key(exact_less)
+
+
+def exact_spectrum(matrix: sp.Matrix) -> list:
+    """Sorted exact eigenvalue list WITH multiplicity; refuses a non-real."""
+    out = []
+    for value, multiplicity in matrix.eigenvals().items():
+        value = sp.nsimplify(sp.simplify(value))
+        if not value.is_real:
+            raise AssertionError(f"non-real eigenvalue {value}")
+        out.extend([value] * int(multiplicity))
+    return sorted(out, key=ORDER_KEY)
+
+
+def same_multiset(left: list, right: list) -> bool:
+    if len(left) != len(right):
+        return False
+    return all(exact_less(a, b) == 0 for a, b in zip(left, right))
+
+
+def distinct_levels(matrix: sp.Matrix) -> list:
+    levels: list = []
+    for value in exact_spectrum(matrix):
+        if not levels or exact_less(levels[-1], value) != 0:
+            levels.append(value)
+    return levels
+
+
+def ground_degeneracy(matrix: sp.Matrix) -> int:
+    """Dimension of the lowest-eigenvalue eigenspace, computed from the
+    constructed operator (never assumed from a formula)."""
+    triples = matrix.eigenvects()
+    values = [sp.nsimplify(sp.simplify(t[0])) for t in triples]
+    lowest = sorted(values, key=ORDER_KEY)[0]
+    total = 0
+    for value, _multiplicity, vectors in triples:
+        if exact_less(sp.nsimplify(value), lowest) == 0:
+            total += len(vectors)
+    return total
+
+
+# --------------------------------------------------------------------------
+# G1 -- the common-frame commutant IS span{I, SWAP}
+# --------------------------------------------------------------------------
+def diagonal_generators() -> tuple[sp.Matrix, ...]:
+    """One and the same SU(2) on both sites: J_a = s_a (x) I + I (x) s_a."""
+    return tuple(kron(p, I2) + kron(I2, p) for p in PAULIS)
+
+
+def independent_generators() -> tuple[sp.Matrix, ...]:
+    """Separate SU(2) per site: the six single-site generators."""
+    return tuple([kron(p, I2) for p in PAULIS] + [kron(I2, p) for p in PAULIS])
+
+
+def gate_g1(checks: CheckRunner) -> list[sp.Matrix]:
+    section("G1  common-frame commutant = span{I, SWAP}")
+    basis = commutant_basis(diagonal_generators(), 4)
+    checks.check(
+        "G1a common-frame (diagonal SU(2)) commutant has complex dimension 2",
+        len(basis) == 2,
+        f"dim={len(basis)}",
+    )
+
+    base_rank = span_rank(*basis)
+    checks.check(
+        "G1b identity lies in the computed commutant",
+        span_rank(*basis, I4) == base_rank,
+        f"rank={base_rank}",
+    )
+    checks.check(
+        "G1c SWAP lies in the computed commutant",
+        span_rank(*basis, SWAP) == base_rank,
+        f"rank={base_rank}",
+    )
+    checks.check(
+        "G1d span{I, SWAP} EQUALS the computed commutant (both containments)",
+        span_rank(I4, SWAP) == 2
+        and span_rank(*basis, I4, SWAP) == 2
+        and base_rank == 2,
+    )
+    checks.check(
+        "G1e MUTATION non-invariant candidate X(x)I is NOT in the commutant "
+        "(so G1d is not a tautology)",
+        span_rank(*basis, kron(X, I2)) == 3
+        and not eq(kron(X, I2) * diagonal_generators()[1],
+                   diagonal_generators()[1] * kron(X, I2)),
+        f"rank={span_rank(*basis, kron(X, I2))}",
+    )
+    dot = kron(X, X) + kron(Y, Y) + kron(Z, Z)
+    checks.check(
+        "G1f exchange identity SWAP = (I + XX + YY + ZZ)/2 is exact",
+        eq(SWAP, (I4 + dot) / 2),
+    )
+    checks.check(
+        "G1g finite frame check: (U(x)U) SWAP (U(x)U)^dag = SWAP for exact "
+        "SU(2) samples, while X(x)I is moved by the same conjugation",
+        all(eq(kron(u, u) * SWAP * dag(kron(u, u)), SWAP) for u in SAMPLE_SU2)
+        and any(
+            not eq(kron(u, u) * kron(X, I2) * dag(kron(u, u)), kron(X, I2))
+            for u in SAMPLE_SU2
+        ),
+    )
+    return basis
+
+
+# --------------------------------------------------------------------------
+# G2 -- the independent-onsite contrast: commutant = scalars only
+# --------------------------------------------------------------------------
+def gate_g2(checks: CheckRunner) -> None:
+    section("G2  MUTATION of the covariance construction: independent onsite")
+    basis = commutant_basis(independent_generators(), 4)
+    checks.check(
+        "G2a MUTATION independent-onsite covariance collapses the commutant "
+        "to complex dimension 1",
+        len(basis) == 1,
+        f"dim={len(basis)}",
+    )
+    checks.check(
+        "G2b the single surviving direction is the scalars span{I}",
+        span_rank(basis[0], I4) == 1,
+    )
+    checks.check(
+        "G2c SWAP is NOT in the independent-onsite commutant "
+        "(explicit noncommutation with X(x)I)",
+        not eq(SWAP * kron(X, I2), kron(X, I2) * SWAP)
+        and span_rank(basis[0], SWAP) == 2,
+    )
+    # Solve the general element directly: every commutant member is c*I, so
+    # a pair generator with a nonzero exchange part cannot be invariant.
+    a, b = sp.symbols("a b", real=True)
+    general = a * I4 + b * SWAP
+    residual = general * kron(X, I2) - kron(X, I2) * general
+    solutions = sp.solve(list(residual), [b], dict=True)
+    checks.check(
+        "G2d hence NO nontrivial pair term survives independent-onsite "
+        "covariance: a*I + b*SWAP is invariant only for b = 0",
+        solutions == [{b: 0}],
+        f"solutions={solutions}",
+    )
+
+
+# --------------------------------------------------------------------------
+# G3 -- Hermiticity of both candidates and the licensed quotient
+# --------------------------------------------------------------------------
+def gate_g3(checks: CheckRunner) -> None:
+    section("G3  both sign candidates are Hermitian; the licensed quotient")
+    a, b = sp.symbols("a b", real=True)
+    symbolic = a * I4 + b * SWAP
+    checks.check(
+        "G3a h = a*I + b*SWAP is Hermitian for symbolic real a, b",
+        eq(dag(symbolic), symbolic),
+    )
+    plus = sp.Rational(2, 7) * I4 + sp.Rational(5, 3) * SWAP
+    minus = sp.Rational(2, 7) * I4 - sp.Rational(5, 3) * SWAP
+    checks.check(
+        "G3b both candidates are Hermitian at exact rational (a, b) and are "
+        "genuinely different operators",
+        eq(dag(plus), plus) and eq(dag(minus), minus) and not eq(plus, minus),
+    )
+
+    # Channel-level quotient, built from the exponential rather than asserted.
+    alpha = sp.Rational(3, 2)
+    beta = sp.Rational(-7, 5)
+    t = sp.Rational(4, 9)
+    scaled = alpha * plus + beta * I4
+    left = sp.simplify(sp.exp(-sp.I * scaled * (t / alpha)))
+    right = sp.simplify(
+        sp.exp(-sp.I * beta * t / alpha) * sp.exp(-sp.I * plus * t)
+    )
+    checks.check(
+        "G3c positive clock rescaling + energy shift leaves the generated "
+        "channel unchanged up to a global phase (matrix exponentials)",
+        eq(left, right),
+    )
+
+    both = []
+    for value in (sp.Rational(5, 3), sp.Rational(-5, 3)):
+        h = sp.Rational(2, 7) * I4 + value * SWAP
+        scale = 1 / abs(value)
+        shift = -scale * sp.Rational(2, 7)
+        reduced = sp.simplify(scale * h + shift * I4)
+        both.append(eq(reduced, sp.sign(value) * SWAP))
+    checks.check(
+        "G3d alpha = 1/|b| > 0 with beta = -alpha*a carries h to "
+        "sign(b)*SWAP exactly, for BOTH signs -- a and |b| are removed",
+        all(both),
+    )
+
+    # The sign is NOT removable: solve the actual two-parameter system.
+    alpha_s, beta_s = sp.symbols("alpha beta", real=True)
+    target = alpha_s * SWAP + beta_s * I4 - (-SWAP)
+    raw = sp.solve(list(target), [alpha_s, beta_s], dict=True)
+    positive = [s for s in raw if sp.simplify(s[alpha_s]) > 0]
+    checks.check(
+        "G3e NO positive rescaling plus energy shift maps +SWAP to -SWAP: "
+        "the only solution has alpha = -1",
+        raw == [{alpha_s: -1, beta_s: 0}] and positive == [],
+        f"solutions={raw} positive={positive}",
+    )
+    gamma = sp.symbols("gamma", real=True)
+    relaxed = sp.solve(
+        list(gamma * SWAP + beta_s * I4 - (-SWAP)), [gamma, beta_s], dict=True
+    )
+    checks.check(
+        "G3f MUTATION dropping the positivity constraint on the rescaling "
+        "IDENTIFIES the two signs (gamma = -1 solves it), so alpha > 0 is "
+        "exactly what makes the sign physical",
+        relaxed == [{gamma: -1, beta_s: 0}],
+        f"solutions={relaxed}",
+    )
+
+
+# --------------------------------------------------------------------------
+# G4 -- the invariant: ground-sector degeneracy 1 vs 3
+# --------------------------------------------------------------------------
+def gate_g4(checks: CheckRunner) -> None:
+    section("G4  ground-sector degeneracy separates the two signs: 1 vs 3")
+    eigenvalues = SWAP.eigenvals()
+    ket01 = sp.Matrix([0, 1, 0, 0])
+    ket10 = sp.Matrix([0, 0, 1, 0])
+    checks.check(
+        "G4a SWAP is the transposition (it exchanges |01> and |10>) and its "
+        "spectrum is {+1 (x3), -1 (x1)}: the multiplicity split the "
+        "invariant reads, on the operator G1 pinned",
+        eigenvalues == {sp.Integer(1): 3, sp.Integer(-1): 1}
+        and eq(SWAP * ket01, ket10)
+        and eq(SWAP * ket10, ket01),
+        f"spectrum={eigenvalues}",
+    )
+    a0 = sp.Rational(2, 7)
+    plus = a0 * I4 + sp.Rational(5, 3) * SWAP
+    minus = a0 * I4 - sp.Rational(5, 3) * SWAP
+    deg_plus = ground_degeneracy(plus)
+    checks.check(
+        "G4b b > 0: ground sector of a*I + b*SWAP is 1-dimensional "
+        "(the singlet)",
+        deg_plus == 1,
+        f"deg={deg_plus}",
+    )
+    deg_minus = ground_degeneracy(minus)
+    checks.check(
+        "G4c MUTATION flip the sign IN THE CONSTRUCTION: the ground sector "
+        "becomes 3-dimensional (the triplet)",
+        deg_minus == 3,
+        f"deg={deg_minus}",
+    )
+
+    grid_ok = True
+    for alpha in (sp.Rational(1, 4), sp.Integer(1), sp.Rational(7, 2)):
+        for beta in (sp.Rational(-11, 3), sp.Integer(0), sp.Rational(9, 5)):
+            if ground_degeneracy(alpha * plus + beta * I4) != 1:
+                grid_ok = False
+            if ground_degeneracy(alpha * minus + beta * I4) != 3:
+                grid_ok = False
+    checks.check(
+        "G4d the degeneracies 1 and 3 are invariant across a 3x3 grid of "
+        "exact (alpha > 0, beta) -- they survive the whole licensed quotient",
+        grid_ok,
+    )
+    frame_ok = True
+    for u in SAMPLE_SU2:
+        conj = kron(u, u) * plus * dag(kron(u, u))
+        if ground_degeneracy(sp.simplify(conj)) != 1:
+            frame_ok = False
+    checks.check(
+        "G4e the degeneracy is invariant under a common frame change "
+        "(U(x)U) h (U(x)U)^dag for exact SU(2) samples",
+        frame_ok,
+    )
+    set_plus = set(SWAP.eigenvals())
+    set_minus = set((-SWAP).eigenvals())
+    checks.check(
+        "G4f +SWAP and -SWAP have the SAME eigenvalue SET {+1, -1}: only the "
+        "multiplicities differ, so a set-valued spectral invariant cannot "
+        "separate the signs and the DEGENERACY is what does",
+        set_plus == set_minus
+        and SWAP.eigenvals() != (-SWAP).eigenvals(),
+        f"set={set_plus}",
+    )
+
+
+# --------------------------------------------------------------------------
+# G5 -- the one-excitation band minimum is NOT a separator on Z^3
+# --------------------------------------------------------------------------
+def path_graph(n: int):
+    return list(range(n)), [(i, i + 1) for i in range(n - 1)]
+
+
+def cycle_graph(n: int):
+    return list(range(n)), [(i, (i + 1) % n) for i in range(n)]
+
+
+def cube_graph():
+    nodes = list(range(8))
+    edges = []
+    for u in nodes:
+        for bit in range(3):
+            v = u ^ (1 << bit)
+            if u < v:
+                edges.append((u, v))
+    return nodes, edges
+
+
+def complete_bipartite(m: int, n: int):
+    nodes = list(range(m + n))
+    edges = [(i, m + j) for i in range(m) for j in range(n)]
+    return nodes, edges
+
+
+def z3_torus(length: int):
+    """Nearest-neighbour Z^3 chunk with even period `length` in each axis."""
+    coords = list(itertools.product(range(length), repeat=3))
+    index = {c: i for i, c in enumerate(coords)}
+    edges = set()
+    for c in coords:
+        for axis in range(3):
+            shifted = list(c)
+            shifted[axis] = (c[axis] + 1) % length
+            u, v = index[c], index[tuple(shifted)]
+            edges.add((min(u, v), max(u, v)))
+    return list(range(len(coords))), sorted(edges), coords
+
+
+def adjacency(nodes, edges) -> sp.Matrix:
+    matrix = sp.zeros(len(nodes), len(nodes))
+    for u, v in edges:
+        matrix[u, v] += 1
+        matrix[v, u] += 1
+    return matrix
+
+
+def one_magnon_block(nodes, edges) -> sp.Matrix:
+    """Restriction of sum_e SWAP_e to the one-excitation sector, obtained by
+    APPLYING each edge permutation to each one-excitation basis label.
+
+    Basis label x = the flipped site.  SWAP_uv maps the flipped site u to v,
+    v to u, and fixes every other label.  Nothing about A or the degree is
+    assumed; the block is assembled from the permutation action itself.
+    """
+    size = len(nodes)
+    block = sp.zeros(size, size)
+    for x in nodes:
+        for u, v in edges:
+            if x == u:
+                image = v
+            elif x == v:
+                image = u
+            else:
+                image = x
+            block[image, x] += 1
+    return block
+
+
+def full_space_weight_check(nodes, edges) -> bool:
+    """On the FULL 2^n space, verify sum_e SWAP_e preserves excitation number
+    (so the one-excitation block above is a genuine invariant restriction)."""
+    size = len(nodes)
+    for basis in range(2 ** size):
+        for u, v in edges:
+            bu = (basis >> u) & 1
+            bv = (basis >> v) & 1
+            image = basis
+            if bu != bv:
+                image = basis ^ (1 << u) ^ (1 << v)
+            if bin(image).count("1") != bin(basis).count("1"):
+                return False
+    return True
+
+
+def gate_g5(checks: CheckRunner) -> None:
+    section("G5  the one-excitation band minimum is NOT a sign separator")
+
+    c4_nodes, c4_edges = cycle_graph(4)
+    q3_nodes, q3_edges = cube_graph()
+    k33_nodes, k33_edges = complete_bipartite(3, 3)
+    z3_nodes, z3_edges, z3_coords = z3_torus(4)
+    p3_nodes, p3_edges = path_graph(3)
+
+    regular_family = {
+        "C4": (c4_nodes, c4_edges, 2),
+        "Q3": (q3_nodes, q3_edges, 3),
+        "K3,3": (k33_nodes, k33_edges, 3),
+        "Z^3 torus L=4": (z3_nodes, z3_edges, 6),
+    }
+
+    derived_ok = True
+    detail = []
+    for name, (nodes, edges, degree) in regular_family.items():
+        block = one_magnon_block(nodes, edges)
+        expected = adjacency(nodes, edges) + (len(edges) - degree) * sp.eye(
+            len(nodes)
+        )
+        if not eq(block, expected):
+            derived_ok = False
+        detail.append(f"{name}: |E|-deg={len(edges) - degree}")
+    checks.check(
+        "G5a the one-excitation block ASSEMBLED from the edge permutations "
+        "equals A + (|E| - deg)*I on every regular instance",
+        derived_ok,
+        "; ".join(detail),
+    )
+    checks.check(
+        "G5b the exchange sum preserves excitation number on the FULL 2^n "
+        "space (C4 and Q3), so the block is an invariant restriction",
+        full_space_weight_check(c4_nodes, c4_edges)
+        and full_space_weight_check(q3_nodes, q3_edges),
+    )
+
+    parity_ok = all(
+        (sum(z3_coords[u]) - sum(z3_coords[v])) % 2 == 1 for u, v in z3_edges
+    )
+    checks.check(
+        "G5c Z^3 nearest-neighbour adjacency is bipartite: x + y + z parity "
+        "is a proper 2-colouring of every edge (L = 4 chunk, 192 edges)",
+        parity_ok,
+        f"edges={len(z3_edges)} sites={len(z3_nodes)}",
+    )
+
+    def sublattice(coords_or_colour, nodes):
+        return sp.diag(*[sp.Integer(-1) ** coords_or_colour[n] for n in nodes])
+
+    colours = {
+        "C4": {n: n % 2 for n in c4_nodes},
+        "Q3": {n: bin(n).count("1") % 2 for n in q3_nodes},
+        "K3,3": {n: (0 if n < 3 else 1) for n in k33_nodes},
+        "P3": {n: n % 2 for n in p3_nodes},
+        "Z^3 torus L=4": {n: sum(z3_coords[n]) % 2 for n in z3_nodes},
+    }
+    bipartite_family = dict(regular_family)
+    bipartite_family["P3"] = (p3_nodes, p3_edges, None)
+
+    relabel_ok = True
+    for name, (nodes, edges, _deg) in bipartite_family.items():
+        A = adjacency(nodes, edges)
+        D = sublattice(colours[name], nodes)
+        if not eq(D * D, sp.eye(len(nodes))) or not eq(D * A * D, -A):
+            relabel_ok = False
+    checks.check(
+        "G5d the sublattice relabeling D = diag((-1)^parity) satisfies "
+        "D^2 = I and D A D = -A on every bipartite instance INCLUDING the "
+        "Z^3 chunk",
+        relabel_ok,
+        f"instances={sorted(bipartite_family)}",
+    )
+
+    spectra_ok = True
+    spec_detail = []
+    for name in ("C4", "Q3", "K3,3", "P3"):
+        nodes, edges, _deg = bipartite_family[name]
+        A = adjacency(nodes, edges)
+        spec = exact_spectrum(A)
+        neg = sorted((-value for value in spec), key=ORDER_KEY)
+        if not same_multiset(spec, neg):
+            spectra_ok = False
+        spec_detail.append(f"{name}:{spec}")
+    checks.check(
+        "G5e hence spec(A) = -spec(A) as multisets: A is similar to -A "
+        "through D, so the band is sign-symmetric",
+        spectra_ok,
+        "; ".join(spec_detail),
+    )
+
+    band_ok = True
+    band_detail = []
+    for name in ("C4", "Q3", "K3,3"):
+        nodes, edges, degree = regular_family[name]
+        A = adjacency(nodes, edges)
+        shift = len(edges) - degree
+        for coupling in (sp.Integer(1), sp.Integer(-1)):
+            block = coupling * one_magnon_block(nodes, edges)
+            shifted = block - coupling * shift * sp.eye(len(nodes))
+            if not eq(shifted, coupling * A):
+                band_ok = False
+        plus_band = exact_spectrum(A)
+        minus_band = exact_spectrum(-A)
+        if not same_multiset(plus_band, minus_band):
+            band_ok = False
+        if exact_less(plus_band[0], minus_band[0]) != 0:
+            band_ok = False
+        band_detail.append(f"{name}: band={plus_band}")
+    checks.check(
+        "G5f consequently the +J and -J one-excitation bands are IDENTICAL "
+        "as multisets after the licensed energy shift, so the band minimum "
+        "(and the whole band shape) separates NOTHING on a bipartite graph",
+        band_ok,
+        "; ".join(band_detail),
+    )
+
+    tri_nodes, tri_edges = cycle_graph(3)
+    tri_A = adjacency(tri_nodes, tri_edges)
+    tri_spec = exact_spectrum(tri_A)
+    tri_neg = sorted((-value for value in tri_spec), key=ORDER_KEY)
+    no_relabel = True
+    for signs in itertools.product((1, -1), repeat=3):
+        D = sp.diag(*[sp.Integer(s) for s in signs])
+        if eq(D * tri_A * D, -tri_A):
+            no_relabel = False
+    tri_shift = len(tri_edges) - 2
+    tri_plus = exact_spectrum(one_magnon_block(tri_nodes, tri_edges)
+                              - tri_shift * sp.eye(3))
+    tri_minus = exact_spectrum(-one_magnon_block(tri_nodes, tri_edges)
+                               + tri_shift * sp.eye(3))
+    checks.check(
+        "G5g MUTATION swap the bipartite graph for the non-bipartite "
+        "triangle: NO diagonal +-1 relabeling gives D A D = -A, spec(A) is "
+        "not sign-symmetric, and the shifted +J / -J bands DIFFER -- so the "
+        "band minimum DOES separate there and the failure is bipartiteness",
+        no_relabel
+        and not same_multiset(tri_spec, tri_neg)
+        and not same_multiset(tri_plus, tri_minus)
+        and exact_less(tri_plus[0], tri_minus[0]) != 0,
+        f"spec={tri_spec} +J band={tri_plus} -J band={tri_minus}",
+    )
+
+    A = adjacency(q3_nodes, q3_edges)
+    base_min = exact_spectrum(A)[0]
+    moved_min = exact_spectrum(A + sp.Rational(11, 4) * sp.eye(8))[0]
+    checks.check(
+        "G5h independently, the band minimum is not even a quotient "
+        "invariant: an energy shift beta*I moves it by beta, whereas the "
+        "ground-sector degeneracy of G4 does not move at all",
+        sp.simplify(moved_min - base_min - sp.Rational(11, 4)) == 0
+        and exact_less(moved_min, base_min) != 0,
+        f"min={base_min} -> {moved_min}",
+    )
+
+
+# --------------------------------------------------------------------------
+# G6 -- L2: the three-site eta defeats "exactly two"
+# --------------------------------------------------------------------------
+def three_site_swap(site_a: int, site_b: int) -> sp.Matrix:
+    """SWAP between two of three qubits, built from the basis-label action."""
+    matrix = sp.zeros(8, 8)
+    for index in range(8):
+        bits = [(index >> (2 - k)) & 1 for k in range(3)]
+        bits[site_a], bits[site_b] = bits[site_b], bits[site_a]
+        image = (bits[0] << 2) | (bits[1] << 1) | bits[2]
+        matrix[image, index] = 1
+    return matrix
+
+
+def three_site_generators() -> tuple[sp.Matrix, ...]:
+    return tuple(
+        kron(p, I2, I2) + kron(I2, p, I2) + kron(I2, I2, p) for p in PAULIS
+    )
+
+
+def gate_g6(checks: CheckRunner) -> None:
+    section("G6  three sites: an independent dimensionless eta survives")
+    swap01 = three_site_swap(0, 1)
+    swap02 = three_site_swap(0, 2)
+    swap12 = three_site_swap(1, 2)
+    h1 = swap01 + swap02
+    h2 = swap01 * swap02 + swap02 * swap01
+
+    checks.check(
+        "G6a H_1 = SWAP_01 + SWAP_02 and H_2 = SWAP_01 SWAP_02 + "
+        "SWAP_02 SWAP_01 are both Hermitian",
+        eq(dag(h1), h1) and eq(dag(h2), h2),
+    )
+    checks.check(
+        "G6b both are invariant under the neighbour-exchange automorphism "
+        "R = SWAP_12 of the three-site star",
+        eq(swap12 * h1 * swap12, h1) and eq(swap12 * h2 * swap12, h2),
+    )
+    generators = three_site_generators()
+    checks.check(
+        "G6c both COMMUTE with all three diagonal SU(2) generators, i.e. "
+        "both are common-frame covariant -- the check the source runners "
+        "asserted but never computed",
+        all(eq(h1 * g, g * h1) and eq(h2 * g, g * h2) for g in generators),
+    )
+    frame_ok = True
+    for u in SAMPLE_SU2:
+        conj = kron(u, u, u)
+        if not eq(sp.simplify(conj * h1 * dag(conj)), h1):
+            frame_ok = False
+        if not eq(sp.simplify(conj * h2 * dag(conj)), h2):
+            frame_ok = False
+    checks.check(
+        "G6d finite frame check: (U(x)U(x)U) H_i (U(x)U(x)U)^dag = H_i for "
+        "exact SU(2) samples",
+        frame_ok,
+    )
+    decoy = kron(Z, Z, I2)
+    checks.check(
+        "G6e MUTATION / negative control: Z_0 Z_1 is Hermitian too, but it "
+        "FAILS both the common-frame commutation and the neighbour-exchange "
+        "invariance -- so G6b and G6c are not tautologies",
+        eq(dag(decoy), decoy)
+        and any(not eq(decoy * g, g * decoy) for g in generators)
+        and not eq(swap12 * decoy * swap12, decoy),
+    )
+    checks.check(
+        "G6f I, H_1, H_2 are linearly independent, so eta is a genuinely "
+        "new coefficient and not a disguised rescaling or energy shift",
+        span_rank(sp.eye(8), h1, h2) == 3,
+        f"rank={span_rank(sp.eye(8), h1, h2)}",
+    )
+
+    def gap_ratio(eta):
+        levels = distinct_levels(h1 + eta * h2)
+        return sp.simplify(
+            (levels[1] - levels[0]) / (levels[2] - levels[1])
+        ), levels
+
+    ratio_zero, spec_zero = gap_ratio(sp.Integer(0))
+    checks.check(
+        "G6g gap ratio (E1 - E0)/(E2 - E1) = 2 at eta = 0",
+        ratio_zero == 2,
+        f"levels={spec_zero} ratio={ratio_zero}",
+    )
+    ratio_third, spec_third = gap_ratio(sp.Rational(1, 3))
+    checks.check(
+        "G6h gap ratio = 1 at eta = 1/3",
+        ratio_third == 1,
+        f"levels={spec_third} ratio={ratio_third}",
+    )
+    swept = {}
+    for eta in (sp.Rational(-1, 2), sp.Rational(1, 6), sp.Rational(1, 2)):
+        swept[eta] = gap_ratio(eta)[0]
+    checks.check(
+        "G6i MUTATION sweep eta IN THE CONSTRUCTION: the ratio moves at "
+        "every sampled value and never returns to a single number, so eta "
+        "is not removable and 'exactly two parameters' fails past one edge",
+        len(set(list(swept.values()) + [ratio_zero, ratio_third]))
+        == len(swept) + 2,
+        f"ratios={ {str(k): str(v) for k, v in swept.items()} }",
+    )
+    invariant_ok = True
+    base = h1 + sp.Rational(1, 3) * h2
+    for alpha in (sp.Rational(2, 5), sp.Integer(3)):
+        for beta in (sp.Rational(-8, 7), sp.Rational(6, 5)):
+            levels = distinct_levels(alpha * base + beta * sp.eye(8))
+            ratio = sp.simplify(
+                (levels[1] - levels[0]) / (levels[2] - levels[1])
+            )
+            if ratio != ratio_third:
+                invariant_ok = False
+    checks.check(
+        "G6j the gap RATIO is invariant under h -> alpha*h + beta*I for "
+        "exact alpha > 0 and beta, so neither clock rescaling nor an "
+        "energy-zero choice can remove eta",
+        invariant_ok,
+    )
+
+
+# --------------------------------------------------------------------------
+# G7 -- L3: the identity term is NOT inert on a record-conditioned edge set
+# --------------------------------------------------------------------------
+def active_edges(edges, recorded: frozenset[int]):
+    """SUPPLIED convention: an edge is active when neither endpoint carries a
+    record.  The framework supplies no formation rule; this convention is the
+    antecedent of the conditional L3, not a derived law."""
+    return [e for e in edges if e[0] not in recorded and e[1] not in recorded]
+
+
+def gate_g7(checks: CheckRunner) -> None:
+    section("G7  the identity term is not inert on a record-conditioned set")
+    nodes, edges = path_graph(3)  # sites 0 - 1 - 2, edges (0,1) and (1,2)
+
+    sector_a = frozenset({0})    # one record at an end site
+    sector_b = frozenset()       # no record
+    n_a = len(active_edges(edges, sector_a))
+    n_b = len(active_edges(edges, sector_b))
+    checks.check(
+        "G7a the active-edge count is COMPUTED from the graph and the record "
+        "configuration and differs between the two record sectors",
+        (n_a, n_b) == (1, 2),
+        f"N_active={n_a} vs {n_b} on edges={edges}",
+    )
+
+    beta = sp.Integer(1)
+    t = sp.pi / 3
+    phase = sp.diag(sp.exp(-sp.I * beta * n_a * t),
+                    sp.exp(-sp.I * beta * n_b * t))
+    scalar = phase[0, 0] * sp.eye(2)
+    checks.check(
+        "G7b the sector phase operator built from those counts is NOT a "
+        "scalar multiple of the identity",
+        not eq(sp.simplify(phase - scalar), sp.zeros(2, 2)),
+        f"diag={sp.simplify(phase[0, 0])}, {sp.simplify(phase[1, 1])}",
+    )
+
+    superposition = sp.Matrix([1, 1]) / sp.sqrt(2)
+    witness = sp.Matrix([[0, 1], [1, 0]])
+
+    def expectation(state: sp.Matrix) -> sp.Expr:
+        raw = (dag(state) * witness * state)[0, 0]
+        return sp.simplify(sp.expand_complex(sp.expand(raw)))
+
+    before = expectation(superposition)
+    evolved = phase * superposition
+    after = expectation(evolved)
+    checks.check(
+        "G7c on a coherent superposition of the two record sectors the "
+        "identity term MOVES the interference term, so it is not a removable "
+        "global phase",
+        sp.simplify(before - 1) == 0
+        and sp.simplify(after - sp.Rational(1, 2)) == 0
+        and sp.simplify(after - before) != 0,
+        f"witness {before} -> {after}",
+    )
+
+    sector_c = frozenset({0})
+    sector_d = frozenset({2})
+    n_c = len(active_edges(edges, sector_c))
+    n_d = len(active_edges(edges, sector_d))
+    phase_eq = sp.diag(sp.exp(-sp.I * beta * n_c * t),
+                       sp.exp(-sp.I * beta * n_d * t))
+    after_eq = expectation(phase_eq * superposition)
+    checks.check(
+        "G7d MUTATION rebuild the record configuration so both sectors carry "
+        "EQUAL active-edge counts: the same identity term becomes a genuine "
+        "global phase and the interference term stops moving",
+        (n_c, n_d) == (1, 1)
+        and eq(sp.simplify(phase_eq - phase_eq[0, 0] * sp.eye(2)),
+               sp.zeros(2, 2))
+        and sp.simplify(after_eq - before) == 0,
+        f"N_active={n_c} vs {n_d}, witness {before} -> {after_eq}",
+    )
+
+    h = sp.Rational(2, 7) * I4 + sp.Rational(5, 3) * SWAP
+    shift = sp.Rational(-7, 5)
+    tau = sp.Rational(4, 9)
+    checks.check(
+        "G7e on a FIXED active-edge set the identity term IS inert: "
+        "exp(-i(h + beta*I)t) = exp(-i*beta*t) exp(-i*h*t) exactly, so R2 "
+        "holds exactly where it is claimed and L3 is a boundary, not a "
+        "contradiction",
+        eq(sp.simplify(sp.exp(-sp.I * (h + shift * I4) * tau)),
+           sp.simplify(sp.exp(-sp.I * shift * tau)
+                       * sp.exp(-sp.I * h * tau))),
+    )
+
+
+def main() -> int:
+    checks = CheckRunner()
+    gate_g1(checks)
+    gate_g2(checks)
+    gate_g3(checks)
+    gate_g4(checks)
+    gate_g5(checks)
+    gate_g6(checks)
+    gate_g7(checks)
+    section("SUMMARY")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/common_frame_pair_generator_exchange_class_2026_07_25.py
+++ b/scripts/common_frame_pair_generator_exchange_class_2026_07_25.py
@@ -15,9 +15,17 @@ four 2026-07-14 probes it supersedes):
   probe rebuilds the object from a changed construction and requires the
   constant to move.  Mutating an assertion is not accepted as a probe;
 * no vacuous gate: each check can fail on some input, and the negative
-  controls (G1e, G2c, G6e, G5g) exist precisely to show the positive gates
-  are not tautologies;
+  controls (G1e, G2c, G6e, G5g, G8e, G9f, G10c, G10f) exist precisely to show
+  the positive gates are not tautologies;
 * an ordered label manifest with a drift detector closes the run.
+
+Groups G8-G10 correct limitation L1 of the note.  G2 computes the
+independent-onsite collapse for the CONTINUOUS SU(2) and that computation is
+unchanged; G8 shows the collapse is a property of that group rather than of
+independent-onsite covariance as such, G9 shows the twisted-diagonal commutant
+has dimension exactly 2 for EVERY twist (by a symbolic generic-matrix identity,
+not by sampling), and G10 shows that "the law is I - SWAP" names an operator
+only relative to a frame while the ground-sector separator does not move.
 """
 
 from __future__ import annotations
@@ -38,6 +46,9 @@ EXPECTED_LABELS = [
     "G5a", "G5b", "G5c", "G5d", "G5e", "G5f", "G5g", "G5h",
     "G6a", "G6b", "G6c", "G6d", "G6e", "G6f", "G6g", "G6h", "G6i", "G6j",
     "G7a", "G7b", "G7c", "G7d", "G7e",
+    "G8a", "G8b", "G8c", "G8d", "G8e", "G8f", "G8g",
+    "G9a", "G9b", "G9c", "G9d", "G9e", "G9f",
+    "G10a", "G10b", "G10c", "G10d", "G10e", "G10f",
 ]
 
 
@@ -893,6 +904,276 @@ def gate_g7(checks: CheckRunner) -> None:
     )
 
 
+# --------------------------------------------------------------------------
+# G8 -- the scalars-only collapse is a property of the CONTINUOUS group,
+#       not of independent-onsite covariance as such
+# --------------------------------------------------------------------------
+def herm_commutant_real_dim(generators, dim: int = 4) -> int:
+    """Real dimension of the HERMITIAN part of the commutant, solved natively.
+
+    The Hermitian ansatz is built with real symbols, the commutation residual
+    is split into its exact real and imaginary parts, and the dimension is
+    read off the rank of the resulting exact real linear system.  Nothing is
+    assumed from a formula and no float is used.
+    """
+    entries = sp.symbols(f"h0:{dim * dim}", real=True)
+    parts = sp.symbols(f"k0:{dim * dim}", real=True)
+    candidate = sp.zeros(dim, dim)
+    variables: list[sp.Symbol] = []
+    for row in range(dim):
+        for col in range(dim):
+            if row == col:
+                candidate[row, col] = entries[row * dim + col]
+                variables.append(entries[row * dim + col])
+            elif row < col:
+                real_part = entries[row * dim + col]
+                imag_part = parts[row * dim + col]
+                candidate[row, col] = real_part + sp.I * imag_part
+                candidate[col, row] = real_part - sp.I * imag_part
+                variables.extend([real_part, imag_part])
+    equations: list[sp.Expr] = []
+    for generator in generators:
+        for residual in sp.expand(candidate * generator - generator * candidate):
+            real_part, imag_part = sp.expand(residual).as_real_imag()
+            equations.extend([sp.expand(real_part), sp.expand(imag_part)])
+    coefficients, _ = sp.linear_eq_to_matrix(equations, variables)
+    return len(variables) - coefficients.rank()
+
+
+def edge_axis_rotation() -> sp.Matrix:
+    """Spin lift of the pi/2 lattice rotation about the edge axis.
+
+    This is a FINITE element.  Whether the proper cubic rotations act on
+    M_2(C) at all is itself supplied and is not asserted here; the element is
+    used only to show which group the scalars-only collapse actually needs.
+    """
+    zeta = sp.exp(sp.I * sp.pi / 4)
+    return sp.Matrix([[zeta ** -1, 0], [0, zeta]])
+
+
+def gate_g8(checks: CheckRunner) -> None:
+    section("G8  the scalars-only collapse needs the CONTINUOUS group")
+    rot = edge_axis_rotation()
+    checks.check(
+        "G8a the edge-axis rotation lift is unitary with u^4 = -I, so u (x) u "
+        "generates a group of order exactly 4 on the edge",
+        eq(dag(rot) * rot, I2)
+        and eq(rot ** 4, -I2)
+        and eq(kron(rot, rot) ** 4, I4)
+        and not eq(kron(rot, rot) ** 2, I4),
+        "order 4",
+    )
+
+    common_finite = herm_commutant_real_dim([kron(rot, rot)])
+    checks.check(
+        "G8b COMMON-frame covariance under that FINITE group leaves Hermitian "
+        "real dimension 6, not 2 -- the step down to 2 is bought by the "
+        "continuous SU(2)",
+        common_finite == 6,
+        f"dim_R={common_finite}",
+    )
+
+    independent_finite = herm_commutant_real_dim([kron(rot, I2), kron(I2, rot)])
+    checks.check(
+        "G8c INDEPENDENT-onsite covariance under the SAME finite group leaves "
+        "Hermitian real dimension 4: a nontrivial pair law SURVIVES",
+        independent_finite == 4,
+        f"dim_R={independent_finite}",
+    )
+
+    zz = kron(Z, Z)
+    checks.check(
+        "G8d explicit witness Z(x)Z is Hermitian, commutes with u(x)I and with "
+        "I(x)u SEPARATELY, and is not a multiple of I",
+        eq(dag(zz), zz)
+        and eq(zz * kron(rot, I2), kron(rot, I2) * zz)
+        and eq(zz * kron(I2, rot), kron(I2, rot) * zz)
+        and span_rank(I4, zz) == 2,
+        "nontrivial independent-onsite-invariant pair term",
+    )
+    checks.check(
+        "G8e MUTATION rebuild the same witness against the CONTINUOUS "
+        "independent generators: Z(x)Z stops being invariant, so G8c is a "
+        "statement about the finite group and does not contradict G2a",
+        any(not eq(zz * g, g * zz) for g in independent_generators()),
+        "continuous group is what kills it",
+    )
+
+    flip_lift = sp.Matrix([[0, -sp.I], [-sp.I, 0]])
+    flip = kron(flip_lift, flip_lift) * SWAP
+    full_stabiliser = herm_commutant_real_dim([kron(rot, rot), flip])
+    checks.check(
+        "G8f the endpoint flip is a unitary involution that inverts the "
+        "rotation lift, and the FULL order-8 common-frame edge stabiliser "
+        "still leaves Hermitian real dimension 5, not 2",
+        eq(dag(flip) * flip, I4)
+        and eq(flip * flip, I4)
+        and eq(flip * kron(rot, rot) * dag(flip), dag(kron(rot, rot)))
+        and full_stabiliser == 5,
+        f"dim_R={full_stabiliser}",
+    )
+
+    bare = herm_commutant_real_dim([SWAP])
+    checks.check(
+        "G8g and with only the bare endpoint exchange the class is Hermitian "
+        "real dimension 10, so the chain 16 -> 10 -> 6 -> 5 -> 2 is monotone "
+        "and every step past 5 is supplied",
+        bare == 10 and herm_commutant_real_dim(diagonal_generators()) == 2,
+        f"bare={bare} continuous_common=2",
+    )
+
+
+# --------------------------------------------------------------------------
+# G9 -- the twisted diagonal: dimension exactly 2 for EVERY twist
+# --------------------------------------------------------------------------
+def twisted_generators(twist: sp.Matrix) -> tuple[sp.Matrix, ...]:
+    """Generators of the twisted diagonal {(u, w u w^dag)} on one edge."""
+    return tuple(kron(p, I2) + kron(I2, twist * p * dag(twist)) for p in PAULIS)
+
+
+TWISTS = SAMPLE_SU2 + (
+    sp.Matrix([[sp.Rational(1, 2) + sp.Rational(1, 2) * sp.I,
+                sp.Rational(1, 2) - sp.Rational(1, 2) * sp.I],
+               [-sp.Rational(1, 2) - sp.Rational(1, 2) * sp.I,
+                sp.Rational(1, 2) - sp.Rational(1, 2) * sp.I]]),
+)
+
+
+def gate_g9(checks: CheckRunner) -> None:
+    section("G9  the twisted diagonal has commutant dimension 2 for EVERY twist")
+    symbols = sp.symbols("w0 w1 w2 w3")
+    generic = sp.Matrix(2, 2, symbols)
+    generic_inverse = generic.adjugate() / generic.det()
+    conjugation_ok = all(
+        eq(
+            kron(I2, generic) * (kron(p, I2) + kron(I2, p)) * kron(I2, generic_inverse),
+            kron(p, I2) + kron(I2, sp.simplify(generic * p * generic_inverse)),
+        )
+        for p in PAULIS
+    )
+    checks.check(
+        "G9a SYMBOLIC, for EVERY invertible W: (I(x)W)(P(x)I + I(x)P)(I(x)W)^-1 "
+        "= P(x)I + I(x)(W P W^-1), so the twisted diagonal is exactly the "
+        "(I(x)W)-conjugate of the diagonal -- not a sampled claim",
+        conjugation_ok,
+        "generic 2x2 W with det W != 0",
+    )
+    checks.check(
+        "G9b SYMBOLIC, same W: (I(x)W) SWAP (I(x)W)^-1 = (W^-1 (x) W) SWAP, so "
+        "conjugation carries span{I, SWAP} onto span{I, (W^-1(x)W)SWAP} and "
+        "the twisted commutant dimension is 2 for EVERY twist",
+        eq(kron(I2, generic) * SWAP * kron(I2, generic_inverse),
+           kron(generic_inverse, generic) * SWAP),
+    )
+
+    dims = []
+    equal_spans = []
+    for twist in TWISTS:
+        basis = commutant_basis(twisted_generators(twist), 4)
+        dims.append(len(basis))
+        twisted_swap = kron(dag(twist), twist) * SWAP
+        equal_spans.append(
+            span_rank(I4, twisted_swap) == 2
+            and span_rank(*basis, I4, twisted_swap) == 2
+        )
+    checks.check(
+        "G9c NATIVE solve on exact unitary twists confirms the symbolic result: "
+        "complex dimension exactly 2 every time",
+        all(d == 2 for d in dims),
+        f"dims={dims}",
+    )
+    checks.check(
+        "G9d and the solved commutant EQUALS span{I, (w^dag(x)w)SWAP} in both "
+        "containments for every sampled twist",
+        all(equal_spans),
+        f"{equal_spans}",
+    )
+
+    degeneracies = []
+    for twist in TWISTS:
+        twisted_swap = kron(dag(twist), twist) * SWAP
+        degeneracies.append((
+            ground_degeneracy(sp.Rational(2, 7) * I4 + sp.Rational(5, 3) * twisted_swap),
+            ground_degeneracy(sp.Rational(2, 7) * I4 - sp.Rational(5, 3) * twisted_swap),
+        ))
+    checks.check(
+        "G9e the R3 separator is TWIST-INVARIANT: ground-sector degeneracy is 1 "
+        "for b > 0 and 3 for b < 0 for every twist, so dropping flatness does "
+        "not dissolve the two-point menu",
+        all(pair == (1, 3) for pair in degeneracies),
+        f"(b>0, b<0) degeneracies={degeneracies}",
+    )
+
+    degenerate_twist_dim = len(commutant_basis(tuple(kron(p, I2) for p in PAULIS), 4))
+    checks.check(
+        "G9f MUTATION rebuild the correlation with the degenerate homomorphism "
+        "u -> I instead of an automorphism twist: the dimension MOVES 2 -> 4, "
+        "so 'dimension 2' is carried by the twisted-diagonal construction and "
+        "is not a tautology",
+        degenerate_twist_dim == 4,
+        f"dim={degenerate_twist_dim}",
+    )
+
+
+# --------------------------------------------------------------------------
+# G10 -- "the law is I - SWAP" is not a frame-invariant sentence, and the
+#        twist that moves it carries gauge-invariant holonomy
+# --------------------------------------------------------------------------
+def gate_g10(checks: CheckRunner) -> None:
+    section("G10  the law's NAME is frame-relative; its holonomy is not")
+    twist = SAMPLE_SU2[0]
+    twisted_swap = kron(dag(twist), twist) * SWAP
+    checks.check(
+        "G10a (w^dag (x) w) SWAP is Hermitian for every sampled unitary twist, "
+        "so it is an admissible pair generator, not a formal object",
+        all(eq(dag(kron(dag(t), t) * SWAP), kron(dag(t), t) * SWAP) for t in TWISTS),
+    )
+    checks.check(
+        "G10b but it is NOT in span{I, SWAP}: the span rank rises to 3, so "
+        "'the law is I - SWAP' is not a frame-invariant sentence",
+        span_rank(I4, SWAP, twisted_swap) == 3,
+        f"rank={span_rank(I4, SWAP, twisted_swap)}",
+    )
+    checks.check(
+        "G10c MUTATION rebuild the same construction with a CENTRAL twist "
+        "w = -I: the operator lands back inside span{I, SWAP} and the rank "
+        "falls to 2, so G10b is carried by the twist and not by the algebra",
+        span_rank(I4, SWAP, kron(dag(-I2), -I2) * SWAP) == 2,
+        f"rank={span_rank(I4, SWAP, kron(dag(-I2), -I2) * SWAP)}",
+    )
+    checks.check(
+        "G10d yet the ground-sector degeneracy of a*I + b*(w^dag(x)w)SWAP is "
+        "still 1 vs 3: what the frame moves is the operator's NAME, not the "
+        "separating invariant",
+        ground_degeneracy(sp.Rational(2, 7) * I4 + sp.Rational(5, 3) * twisted_swap) == 1
+        and ground_degeneracy(sp.Rational(2, 7) * I4 - sp.Rational(5, 3) * twisted_swap) == 3,
+    )
+
+    # A twist assignment on a closed 4-cycle of edges.  Per-site re-framing
+    # sends w_e -> g_x w_e g_y^dag, so the loop product is conjugated and its
+    # trace is invariant.
+    holonomy = twist
+    checks.check(
+        "G10e on a closed 4-cycle the twist assignment (I, I, I, w) has loop "
+        "product w with exact trace 6/5, which is neither 2 nor -2, so the "
+        "assignment is NOT gauge-equivalent to the flat one",
+        sp.simplify(sp.trace(holonomy)) == sp.Rational(6, 5)
+        and sp.simplify(sp.trace(holonomy) - 2) != 0
+        and sp.simplify(sp.trace(holonomy) + 2) != 0,
+        f"trace={sp.simplify(sp.trace(holonomy))}",
+    )
+    checks.check(
+        "G10f MUTATION apply an actual per-site re-framing to the loop product "
+        "for every sampled frame: the trace does not move, so no re-framing "
+        "flattens it -- dropping flatness ENLARGES the class by a link field "
+        "rather than dissolving the two-point menu",
+        all(sp.simplify(sp.trace(g * holonomy * dag(g)) - sp.trace(holonomy)) == 0
+            for g in SAMPLE_SU2)
+        and sp.simplify(sp.trace(I2)) == 2,
+        "conjugation-invariant; flat loop product would have trace 2",
+    )
+
+
 def main() -> int:
     checks = CheckRunner()
     gate_g1(checks)
@@ -902,6 +1183,9 @@ def main() -> int:
     gate_g5(checks)
     gate_g6(checks)
     gate_g7(checks)
+    gate_g8(checks)
+    gate_g9(checks)
+    gate_g10(checks)
     section("SUMMARY")
     return checks.finish()
 


### PR DESCRIPTION
## What this is

**Phase-2 batch R3** of the repo-state scrub. Registers the 2026-07-14
pair-generator material as a properly registered `bounded_theorem` claim at
`docs/` root, with a **new consolidated runner**, the **three dropped
limitations restored as part of the claim**, and the **ground-sector
degeneracy** as the invariant.

Files (4):

| file | what |
|---|---|
| `docs/COMMON_FRAME_PAIR_GENERATOR_EXCHANGE_CLASS_BOUNDED_THEOREM_NOTE_2026-07-25.md` | new claim note |
| `scripts/common_frame_pair_generator_exchange_class_2026_07_25.py` | new consolidated runner, 46/0 |
| `logs/runner-cache/common_frame_pair_generator_exchange_class_2026_07_25.txt` | SHA-pinned cache |
| `docs/audit/data/citation_graph_manifest.json` | stage-18 graph acknowledgment: **one node, `out_degree` 1** |

## CHURN COST — measured, not estimated

Measured by snapshotting all 3872 tracked ledger shards at the branch point,
running the pipeline, and diffing every row.

| quantity | measured |
|---|---:|
| rows **requeued** (`note_hash` or `runner_hash` moved) | **0** |
| **verdicts risked** (terminal verdict lost or reset) | **0** |
| rows whose `audit_status` changed | **0** |
| rows whose `effective_status` changed | **0** |
| rows whose `deps` changed | **0** |
| rows **added** | **1** (`common_frame_pair_generator_exchange_class_bounded_theorem_note_2026-07-25`, seeded `unaudited`) |
| new strict-lint errors / warnings / notices | **0 / 0 / 0** |

**Phase 1 predicted 0 requeues for R3. Measured churn is 0. It does not
exceed the prediction.** A new file seeds a new row; no existing note hash
moves. The four 2026-07-14 source surfaces and their four runners are
**not modified** — they stay exploratory, which is both correct and free.

The only reason this is not literally a zero-diff-to-existing-files PR is the
`minimal_axioms` row's topology metrics (`direct_in_degree` 511 → 512,
`load_bearing_score`, `transitive_descendants`), which the pipeline
recomputes. That is generated state; it was **restored from `HEAD`** and is
not shipped.

## Why the note could not simply be written where the work was

`docs/audit/data/excluded_source_patterns.txt:19` contains
`docs/work_history/**`, and `seed_audit_ledger.should_gate_node()` drops any
matching node with no audit history. A result written there can **never**
acquire a claim id, note hash, runner pin, queue entry, or verdict —
*regardless of quality*. The four sources also carry `**Type:** meta` and
`**Authority:** none`, so nothing could cite them. Landing at `docs/` root is
the entire content of this batch.

The four sources are referenced in the note **in backticks, not as markdown
links** — deliberately. They are route inputs, not evidence: every algebraic
step is recomputed natively, the runner reads none of them, and backticks
seed zero citation-graph edges, so no dependency edge is created on a row the
seeder would drop. The note's only markdown-link dependency is
`MINIMAL_AXIOMS_2026-06-29.md`, and the seeded row shows exactly
`deps: ["minimal_axioms"]`.

## The claim, with its limitations attached

Under four **supplied** hypotheses — (H1) one `M_2(C)` site domain on the
`Z^3` nearest-neighbour graph, (H2) an autonomous time-independent
self-adjoint pair generator, (H3) a sum of identical two-site terms, (H4)
**common**-frame `SU(2)` covariance — the commutant of the diagonal frame
action on two qubits has complex dimension exactly 2 and equals
`span{I, SWAP}`, so every admissible pair generator is `h = a I + b SWAP`.
The licensed quotient `(h, t) ↦ (α h + β I, t/α)` with `α > 0` removes `a` and
`|b|` and leaves exactly `sign(b)`.

**The invariant is the ground-sector degeneracy: 1 for `b > 0` (singlet), 3
for `b < 0` (triplet).**

**New result, nowhere else in the repo.** The one-excitation band minimum is
**not** a valid separator: `Z^3` nearest-neighbour adjacency is bipartite by
the parity of `x + y + z`, the sublattice relabeling `D = diag((−1)^parity)`
gives `D A D = −A`, hence `spec(A) = −spec(A)`, so the `+J` and `−J`
one-excitation bands are **identical as multisets** after the licensed energy
shift. Gated on `C4`, `Q3`, `K_{3,3}`, `P3` and on an `L = 4` periodic `Z^3`
chunk (64 sites, 192 edges), with a non-bipartite triangle as the breaking
mutation. `FULL_LAW_…:335-337` gets close ("Checking only the minimum energy
does not certify this reversal") but supplies neither the reason nor the
relabeling.

**The three limitations are carried, not smoothed:**

1. **L1 — common-frame covariance is a PREMISE that CREATES the two-point
   menu.** Under **independent** onsite covariance the commutant collapses to
   the scalars alone; solving directly, `a I + b SWAP` is invariant only for
   `b = 0`, so **no nontrivial pair law survives** without a further supplied
   object (connection, link variable, shared frame, symmetry reduction).
2. **L2 — "exactly two" holds only for the two-site edge class under the
   supplied identical-pair-term ansatz.** At three sites
   `H_1 = SWAP_01 + SWAP_02` and `H_2 = SWAP_01 SWAP_02 + SWAP_02 SWAP_01`
   satisfy the *same* Hermiticity, neighbour-exchange, and common-frame
   hypotheses, and `H_1 + η H_2` carries a dimensionless `η` moving the gap
   ratio `(E_1−E_0)/(E_2−E_1)` from **2** at `η = 0` to **1** at `η = 1/3`.
   A gap **ratio** is invariant under both `α > 0` rescaling and `β I` shift,
   so neither clock rescaling nor an energy-zero choice removes `η`.
3. **L3 — the "inert" identity shift is NOT inert on a record-conditioned
   active-edge set.** Two record sectors with different active-edge counts
   acquire a relative phase that moves an interference term on a coherent
   superposition; it is not a removable global phase.

## Why a NEW runner, and why the four existing ones are not reused

Not reused, and **not edited** (editing them would be hygiene on an
exploratory surface with no ledger row — it buys nothing and is out of scope
for R3). They cannot serve as this note's runner:

- the `sign(b)` quotient is "gated" only by the **vacuous literal**
  `{-1, 1} == {sp.sign(v) for v in (-3, 5)}`
  (`relational_…py:198`), which never touches `a`, `b`, `α`, `β`, or `SWAP`;
- **common-frame covariance of `H_1`/`H_2` is claimed but never computed** —
  `single_…py:238` checks only Hermiticity and mutual commutation;
- the active-edge phase is a **hand-built `sp.diag(1, 2)`**
  (`relational_…py:377-382`), with no record-conditioned edge set constructed;
- `qubit_…py:143` and `:144` are **the same check** under two labels;
- ~**34%** of `qubit_…py`'s 44 PASS lines are **prose-needle greps on its own
  note text**;
- and R4 exists in none of them.

**The new runner: `PASS=46`, `FAIL=0`, ~0.7 s.**

- **Exact `sympy` only.** No float is an input to any load-bearing comparison
  and no numeric tolerance is used anywhere; eigenvalue ordering goes through
  an exact three-way comparison that *refuses* anything it cannot decide
  symbolically (this is why the irrational `P3` spectrum is handled exactly
  rather than floated).
- **Zero needle gates.** The runner reads no markdown — not even its own note
  — so the PASS total is entirely mathematical. Nothing is self-referential
  and nothing is vacuous.
- **Ordered label manifest with a drift detector.** Renaming, reordering,
  adding, or dropping a gate fails the run.
- **A CONSTRUCTION-mutation probe for every claimed constant.** Probes rebuild
  the object from a changed construction; they never flip an assertion.

Gate groups: `G1` commutant = `span{I, SWAP}` (both containments + a negative
control); `G2` independent-onsite contrast (commutant = scalars only); `G3`
Hermiticity of both candidates + the licensed quotient (the vacuous-literal
replacement); `G4` ground-sector degeneracy 1 vs 3, invariant across a 3×3
`(α>0, β)` grid and under frame change; `G5` `D A D = −A`, `spec(A) = −spec(A)`
and the band-minimum failure, with the triangle as the breaker; `G6` the
three-site `η` counterexample **including the covariance check the source
runners omitted**; `G7` the record-conditioned active-edge boundary.

### Adversarial mutation battery: 12/12 caught

Because a reviewer previously showed that mutating a headline constant left
gates passing 20/0, I ran a battery that mutates the **constructions** and
requires gates to fail. Every one was caught:

| construction mutated | gates that failed |
|---|---|
| `SWAP` → CZ-like diagonal | G1c G1d G1f G1g G4a |
| diagonal generators → single-site only | G1a G1c G1d G1e |
| independent generators → diagonal | G2a G2b |
| ground-sector operator `SWAP` → `Z⊗Z` | G4b G4c G4d G4e |
| `Z^3` torus + same-parity face-diagonal edge | G5a G5c G5d |
| one-excitation block drops the off-edge term | G5a G5f |
| relabeling `D` → identity | G5d |
| three-site `H_2` → non-covariant `Z_0 Z_1` | G6b G6c G6d |
| `η` term removed entirely | G6f G6h G6i |
| active-edge convention ignores records | G7a G7b G7c G7d |
| evolution time `π/3` → `2π` | G7b G7c |
| a gate label renamed | manifest drift detector |

Two of my *own* first-pass expectations were wrong and the battery exposed
them — `(0,0,0)–(1,1,1)` is a **parity-changing** edge and leaves `Z^3`
bipartite, and `G4a`'s original form read only the eigenvalue multiset.
`G4a` was strengthened to pin `SWAP` as the transposition. That the
invariant reads the `(3,1)` multiplicity split, while it is `G1` — not `G4` —
that pins the operator carrying it, is stated in the note's N3.

## Gate results

| gate | result |
|---|---|
| `python3 scripts/vocab_lint.py --fix` on all branch-modified files | **0 violations**, 0 auto-corrections, 0 needing human review |
| `bash docs/audit/scripts/run_pipeline.sh` (validation) | **exit 0**, all 18 stages, `Pipeline complete.` |
| `python3 docs/audit/scripts/audit_lint.py --strict` | **exit 0, `OK: no errors`**; 23 warnings / 441 notices, **identical to the pre-existing baseline**, **0** referencing this claim |
| `repo_invariants_check.py --check --enforce-links` | **PASS** `link_violations=0 class_f_violations=0 graph_delta=acknowledged (enforced)` |
| `git diff --check` / `git diff --cached --check` | **exit 0** |
| runner | **`PASS=46 FAIL=0`** |
| mutation battery | **12/12 caught** |

Pipeline-output-stripped gate: `git status --porcelain` over
`docs/audit/AUDIT_LEDGER.md docs/audit/AUDIT_QUEUE.md docs/audit/data
docs/publication/ci3_z3/` prints **exactly one line** — the staged
`docs/audit/data/citation_graph_manifest.json`, which is the single allowed
co-landing file per the review-loop drop sequence
(`docs/ai_methodology/skills/review-loop/SKILL.md:915-975`), required because
this landing adds a graph node. Everything else the pipeline regenerated was
restored from the branch tip and is not shipped.

Registration verified in validation mode before restoring: the seeded row
carries `claim_type: bounded_theorem` (`claim_type_provenance: author_hint`),
`note_hash` pinned, `runner_path:
scripts/common_frame_pair_generator_exchange_class_2026_07_25.py`,
`deps: ["minimal_axioms"]`, `audit_status: unaudited`,
`effective_status: unaudited` / `awaiting_audit`, and it entered
`audit_queue.json` with `ready: true`.

## What I refused to do

- **No audit verdict is set or predicted anywhere.** The note writes no
  status value; the seeded row is `unaudited`.
- **No `Status: PASS` in the No-Go Discipline gate.** N1–N8 are recorded as
  **ATTEMPTED** with the explicit line that no closure is claimed and
  judgement belongs to the audit lane. (Two of the source surfaces award
  themselves `**No-go-discipline status:** PASS`; this note does not.)
- **No pairwise hypothesis independence is claimed.** Stated three times —
  in `claim_scope`, in Hypotheses, and in N2 — and the runner attempts no
  independence audit.
- **The exclusion glob was not touched.** Removing `docs/work_history/**`
  from `excluded_source_patterns.txt` would seed ~465 rows at once; that is
  R4, an owner policy decision, explicitly not dispatched.
- **The four source notes and their four runners were not modified**, and the
  four notes were not moved out of `work_history/` (moving them would create
  four ledger rows for prose that correctly carries `Authority: none` and
  would break the absolute paths their own runners read).
- **No new axiom, primitive, vocabulary, or status value.** Every term used
  already appears in the source surfaces or the canonical templates.

## Mandatory framework refresher — read before acting

`docs/MINIMAL_AXIOMS_2026-06-29.md` (full, 194 lines) — `:103-111`
"Admissibility is not a dynamics axiom… It does not choose a Hamiltonian or
transfer operator", which is why H2–H4 are **supplied**, never derived;
`:170` names "source/action and physical-observable identification" as an
open gate outside axiom content, which is where H2–H4 sit.
`docs/ai_methodology/skills/PRIMITIVE_REGISTRY_CHECK.md` (full, 47 lines) —
the three approved primitives supply no pair generator, covariance reading,
sign, or rate; rule 6 makes anything absent from the registry unapproved.
`docs/audit/README.md` (full, 430 lines) — `claim_type` / `claim_scope` /
`audit_status` / `effective_status` are auditor-owned; exactly two premise
types chain-satisfy (axioms and registered primitives); the exclusion
mechanism and its history-preserving drop rule.

Independent audit remains required. This PR asks for none of it in advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
