### PR TITLE
test: re-bind audit-gate tests to their current gate implementations

### DIFF
--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -396,6 +396,33 @@ def _no_go_packet(
     return packet
 
 
+def _init_runner_repo(root: Path) -> None:
+    """Commit a fixture root so live runners get an isolated HEAD checkout.
+
+    ``codex_audit_runner._run_repo_runner`` executes every runner inside a
+    disposable ``git worktree add --detach HEAD`` checkout of ``REPO_ROOT``,
+    so a fixture that runs a runner (rather than mocking its stdout) must be
+    a real repository with at least one commit. The runner's own working-tree
+    bytes are copied into that checkout, so fixture runners need not be
+    committed themselves — only the root has to be a repo.
+    """
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "audit-test@example.invalid"],
+        cwd=root,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Audit Test"], cwd=root, check=True
+    )
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "--allow-empty", "-m", "fixture baseline"],
+        cwd=root,
+        check=True,
+    )
+
+
 def _import(module_name: str):
     """Force a fresh import each test."""
     if module_name in sys.modules:
@@ -8907,6 +8934,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 "print('N7_STEELMAN_RESOLUTION selector wall resolved')\n",
                 encoding="utf-8",
             )
+            _init_runner_repo(root)
             row = {
                 "claim_id": "target",
                 "note_path": "docs/target.md",
@@ -8964,6 +8992,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 "print('N7_STEELMAN_RESOLUTION boundary resolved')\n",
                 encoding="utf-8",
             )
+            _init_runner_repo(root)
             row = {
                 "claim_id": "target",
                 "note_path": "docs/target.md",
@@ -9076,6 +9105,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 "raise SystemExit(7)\n",
                 encoding="utf-8",
             )
+            _init_runner_repo(root)
             row = {
                 "claim_id": "target",
                 "note_path": "docs/target.md",
@@ -9132,12 +9162,16 @@ class NoGoDisciplineGateTest(unittest.TestCase):
     def test_duplicate_n7_helper_declaration_runs_once_and_stays_authenticated(self):
         m = _import_codex_audit_runner()
         with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
+            root = Path(tmp) / "repo"
+            root.mkdir()
             m.REPO_ROOT = root
             note_path = root / "docs" / "target.md"
             runner_path = root / "scripts" / "runner.py"
             helper_path = root / "scripts" / "helper.py"
-            counter_path = root / "invocations.txt"
+            # Runners execute under a write-deny sandbox rooted at REPO_ROOT
+            # (and in a disposable checkout), so the invocation counter has to
+            # live outside the repo to survive and to be observable here.
+            counter_path = Path(tmp) / "invocations.txt"
             note_path.parent.mkdir(parents=True, exist_ok=True)
             runner_path.parent.mkdir(parents=True, exist_ok=True)
             note_path.write_text(_no_go_evidence_text(), encoding="utf-8")
@@ -9160,6 +9194,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 "    raise SystemExit(7)\n",
                 encoding="utf-8",
             )
+            _init_runner_repo(root)
             row = {
                 "claim_id": "target",
                 "note_path": "docs/target.md",

--- a/docs/audit/scripts/tests/test_fingerprint_v1_stamping.py
+++ b/docs/audit/scripts/tests/test_fingerprint_v1_stamping.py
@@ -206,7 +206,7 @@ class FingerprintV1StampingTest(unittest.TestCase):
             "first_audit": seat,
             "second_audit": {**seat, "auditor": "second-auditor"},
         }
-        return {
+        judgment = {
             "claim_id": CLAIM_ID,
             "third_auditor": "judicial-panel",
             "auditor_family": "codex-gpt-5.6",
@@ -225,6 +225,68 @@ class FingerprintV1StampingTest(unittest.TestCase):
             "second_auditor_error": "scope incomplete",
             "hybrid_resolution_note": "bounded fixture resolution",
         }
+        return self._attest_judgment(row, judgment)
+
+    def _attest_judgment(self, row: dict, judgment: dict) -> dict:
+        """Attach the five-vote panel attestation apply_audit now requires.
+
+        Panel-majority apply is gated on an invocation- and source-bound
+        ``judicial_panel_record_v1`` (apply_audit.judicial_panel_record_error).
+        These stamping tests only care about what the writer stamps once a
+        judicial verdict is accepted, so the record is a deterministic
+        unanimous panel over this fixture's own judgment tuple. Mirrors
+        ``test_audit_pipeline.ApplyAuditTest._attest_judgment``.
+        """
+        invocation_id = judgment.setdefault(
+            "audit_invocation_id",
+            hashlib.sha256(CLAIM_ID.encode("utf-8")).hexdigest()[:32],
+        )
+        vote = {
+            field: judgment.get(field)
+            for field in (
+                "sided_with",
+                "ratified_verdict",
+                "ratified_claim_type",
+                "ratified_claim_scope",
+                "ratified_load_bearing_step",
+                "ratified_load_bearing_step_class",
+                "negative_assertion_classes",
+                "judgment_rationale",
+                "first_auditor_error",
+                "second_auditor_error",
+                "hybrid_resolution_note",
+            )
+        }
+        votes = [
+            {
+                **copy.deepcopy(vote),
+                "judge": judge,
+                "auditor": (
+                    judgment["third_auditor"]
+                    if judge == 1
+                    else f"{judgment['third_auditor']}-seat-{judge}"
+                ),
+            }
+            for judge in range(1, 6)
+        ]
+        vote_tuple = apply_audit.audit_contract.judicial_vote_tuple(votes[0])
+        judgment["judicial_panel_record_v1"] = {
+            "schema": "judicial_panel_record_v1",
+            "cid": CLAIM_ID,
+            "panel": 1,
+            "invocation_id": invocation_id,
+            "result": "majority_candidate",
+            "disagreement_fingerprint": (
+                apply_audit.audit_contract.judicial_disagreement_fingerprint(row)
+            ),
+            "majority_count": 5,
+            "votes": votes,
+            "failures": [],
+            "tally": [
+                {"tuple": [*vote_tuple[:6], list(vote_tuple[6])], "count": 5}
+            ],
+        }
+        return judgment
 
     # -- v1 completeness and parking under unchanged current state --------
 


### PR DESCRIPTION
Seven tests in the audit-lane suite fail on unmodified `origin/main`. Both clusters are **stale fixtures, not gate regressions** — each gate was hardened in a commit that updated some callers' tests but missed these files. No production code changes here.

Repro on `origin/main`:

```bash
python3 -m unittest docs.audit.scripts.tests.test_audit_pipeline.NoGoDisciplineGateTest docs.audit.scripts.tests.test_fingerprint_v1_stamping.FingerprintV1StampingTest
```

## Cluster A — N7 helper live-stdout authentication (4 tests)

`ef0e78918f` ("fix: address physics review findings (iteration 1)", 2026-07-24) moved every runner execution into a disposable `git worktree add --detach HEAD` checkout, run under a `sandbox-exec` profile that denies writes beneath `REPO_ROOT`.

These four fixtures still pointed `REPO_ROOT` at a bare `tempfile.TemporaryDirectory()`, so `_run_repo_runner` aborted with `not a git repository` and every helper surface came back unauthenticated:

- `test_n7_marker_helper_runs_live_as_independent_stdout`
- `test_n7_marker_helper_runs_live_for_positive_theorem_boundary`
- `test_failing_n7_helper_stdout_is_not_authenticated`
- `test_duplicate_n7_helper_declaration_runs_once_and_stays_authenticated`

The gate stayed **fail-closed** throughout — the role degraded to `runner_stdout_independent_failed`, never to a spurious authentication — so nothing was silently accepted. What was lost is the coverage: the authenticated path was never exercised, and a real fail-open regression would have surfaced as "that test was already red."

Fix: a shared `_init_runner_repo(root)` helper (`git init` + one commit), mirroring the fixture convention in `test_audit_loop_orchestrator.py`, whose six `_run_repo_runner` tests landed in that same commit and have been green all along. The duplicate-declaration test's invocation counter also moves out of `REPO_ROOT` — the write-deny sandbox is exactly what it must not trip.

## Cluster B — judicial-panel fingerprint v1 stamping (3 tests)

`4a993d224f` ("audit: enforce judicial panel attestations", 2026-07-22) made an invocation- and source-bound `judicial_panel_record_v1` mandatory for panel-majority apply. It updated `test_audit_pipeline.py` (adding `ApplyAuditTest._attest_judgment`) but not `test_fingerprint_v1_stamping.py`, so every judicial apply there was rejected with `judicial_panel_record_v1 is required for panel-majority apply` before reaching the stamp under test:

- `test_judicial_conditional_stamps_complete_v1_snapshot`
- `test_judicial_failed_stamps_complete_v1_snapshot`
- `test_judicial_late_snapshot_failure_rolls_back_full_ledger`

Fix: a local `_attest_judgment` mirroring the pipeline-test helper — a deterministic unanimous five-vote record bound to the fixture's own judgment tuple, invocation id, and disagreement fingerprint.

## Verification

Full audit-lane suite: **734 passed**, no failures.

Because these tests were red before, "green" alone would not prove they test anything. Each was mutation-checked against the restored fixture — every mutation is caught:

| Mutation | Caught by |
| --- | --- |
| Authenticate helper stdout on nonzero exit (fail-open) | `test_failing_n7_helper_stdout_is_not_authenticated` |
| Remove helper canonical dedup | `test_duplicate_n7_helper_declaration_runs_once_and_stays_authenticated` |
| Return helper *source* as authenticated stdout without executing | duplicate + failing-helper tests |
| Drop the v1 stamp on the judicial apply path | all 3 judicial stamping tests |

No audit verdict is set or predicted, and no generated audit data is included — `docs/audit/data/`, `docs/audit/AUDIT_QUEUE.md`, `docs/audit/MISSING_DERIVATION_PROMPTS.md` and `docs/publication/ci3_z3/*_EFFECTIVE_STATUS.md` are all at `origin/main`. Branched off `1d713d4302` after `origin/main` advanced mid-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)