### PR TITLE
fix(audit): stop the no-go grade path from destroying its own verdicts

### DIFF
--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -1510,6 +1510,62 @@ def main() -> int:
         if cycle_count:
             add_notice("graph_cycles", f"graph contains {cycle_count} back-edges (cycles)")
 
+    # No-go grade-path health. `retained_no_go` is a named retained grade and
+    # the framework leans on foreclosures constantly, but nothing reported
+    # whether the grade was ever actually reached. It was not: the population
+    # sat at zero for months while clean forensic verdicts were minted and
+    # then reset, and no surface said so. These notices make the grade path
+    # observable without asserting anything about any row's verdict.
+    no_go_rows = [r for r in rows.values() if r.get("claim_type") == "no_go"]
+    if no_go_rows:
+        retained_no_go = sum(
+            1 for r in no_go_rows if r.get("effective_status") == "retained_no_go"
+        )
+        reset_after_clean = 0
+        legacy_snapshot_rows = 0
+        for row in no_go_rows:
+            archived = row.get("previous_audits") or []
+            if row.get("audit_status") in {None, "unaudited"} and any(
+                a.get("audit_status") == "audited_clean"
+                and str(a.get("invalidation_reason") or "").startswith(
+                    "no_go_discipline_packet_"
+                )
+                for a in archived
+            ):
+                reset_after_clean += 1
+            if any(
+                isinstance(a.get("no_go_discipline"), dict)
+                and no_go_discipline_gate.evidence_snapshot_schema_defect(
+                    a["no_go_discipline"]
+                )
+                is not None
+                and isinstance(
+                    (a.get("no_go_discipline") or {}).get("evidence_snapshot"), dict
+                )
+                for a in archived
+            ):
+                legacy_snapshot_rows += 1
+        if retained_no_go == 0:
+            add_notice(
+                "no_go_grade_path_unreached",
+                f"{len(no_go_rows)} no_go rows and 0 at retained_no_go; "
+                "every foreclosure the repo cites is ungraded",
+            )
+        if reset_after_clean:
+            add_notice(
+                "no_go_clean_verdict_reset_by_packet_gate",
+                f"{reset_after_clean} no_go rows are unaudited today but hold an "
+                "archived audited_clean reset by a no_go_discipline_packet_* "
+                "reason; these are re-audit targets, not fresh rows",
+            )
+        if legacy_snapshot_rows:
+            add_notice(
+                "no_go_legacy_evidence_snapshot",
+                f"{legacy_snapshot_rows} no_go rows carry an archived evidence "
+                "snapshot the current reader cannot authenticate (pre-expansion "
+                "entry shape); their forensic evidence is not restorable in place",
+            )
+
     # Output.
     def issue_count(groups: dict[str, list[str]]) -> int:
         return sum(len(items) for items in groups.values())

--- a/docs/audit/scripts/no_go_discipline_gate.py
+++ b/docs/audit/scripts/no_go_discipline_gate.py
@@ -19,6 +19,54 @@ from typing import Any
 
 
 RETAINED_GRADE = {"retained", "retained_bounded", "retained_no_go"}
+
+# Publication-strength rank, mirroring compute_effective_status.RANK. This
+# module is a leaf import for the whole audit lane (apply, invalidate, queue,
+# lint, orchestrators), so it deliberately does not import the pipeline stage
+# that owns the canonical table. `test_snapshot_status_rank_matches_pipeline`
+# asserts the two tables agree, so the copy cannot drift silently.
+SNAPSHOT_STATUS_RANK = {
+    "retained": 100,
+    "retained_no_go": 100,
+    "retained_bounded": 95,
+    "retained_pending_chain": 80,
+    "open_gate": 40,
+    "unaudited": 30,
+    "audit_in_progress": 30,
+    "meta": 25,
+    "audited_decoration": 20,
+    "audited_numerical_match": 15,
+    "audited_renaming": 10,
+    "audited_conditional": 10,
+    "audited_failed": 0,
+}
+
+
+def snapshot_status_rank(status: str | None) -> int:
+    """Rank a manifest authority's effective_status for drift comparison."""
+    if isinstance(status, str) and status.startswith("decoration_under_"):
+        return 70
+    return SNAPSHOT_STATUS_RANK.get(status or "unaudited", -1)
+
+
+# Authenticated-evidence snapshot contract. The tag and the required entry
+# fields must move together: `test_evidence_snapshot_writer_satisfies_reader`
+# fails if `build_evidence_snapshot` ever stops emitting a field the reader
+# demands. Expanding the required set without that guard is what silently
+# voided every stored no-go snapshot on 2026-07-11.
+EVIDENCE_SNAPSHOT_SCHEMA = "no_go_evidence_snapshot_v1"
+EVIDENCE_SNAPSHOT_ENTRY_REQUIRED_FIELDS = frozenset(
+    {
+        "roles",
+        "content_sha256",
+        "verified_locators",
+        "verified_values",
+        "phrase_occurrences",
+        "full_phrase_groups",
+    }
+)
+
+
 PRIOR_AUTHORITY_PREMISE_TYPES = {
     "axiom_or_approved_primitive",
 }
@@ -2254,14 +2302,48 @@ def build_evidence_snapshot(
                 candidate_id_universe
             )
         entries[path] = snapshot_entry
-    return {"schema": "no_go_evidence_snapshot_v1", "entries": entries}
+    return {"schema": EVIDENCE_SNAPSHOT_SCHEMA, "entries": entries}
+
+
+def evidence_snapshot_schema_defect(packet: dict[str, Any]) -> str | None:
+    """Name the reason a snapshot cannot be read, distinguishing shapes.
+
+    `evidence_manifest_from_snapshot` returns a bare None from ~25 validation
+    points, so a snapshot written by an older writer and a genuinely corrupt
+    one were indistinguishable in the invalidation reason. On 2026-07-11 the
+    reader's required entry-field set was expanded under an unchanged schema
+    tag; every snapshot already on disk became unreadable, and the resulting
+    `no_go_discipline_packet_invalid` reason gave no way to tell a schema
+    migration from evidence tampering. This reports the difference.
+    """
+    if not isinstance(packet, dict):
+        return "packet is not an object"
+    snapshot = packet.get("evidence_snapshot")
+    if not isinstance(snapshot, dict):
+        return "evidence_snapshot is absent or not an object"
+    if snapshot.get("schema") != EVIDENCE_SNAPSHOT_SCHEMA:
+        return f"evidence_snapshot schema is {snapshot.get('schema')!r}"
+    raw_entries = snapshot.get("entries")
+    if not isinstance(raw_entries, dict):
+        return "evidence_snapshot entries is absent or not an object"
+    for path in sorted(raw_entries):
+        stored = raw_entries[path]
+        if not isinstance(stored, dict):
+            return f"entries[{path!r}] is not an object"
+        absent = sorted(EVIDENCE_SNAPSHOT_ENTRY_REQUIRED_FIELDS - set(stored))
+        if absent:
+            return (
+                f"entries[{path!r}] predates the current entry shape; "
+                f"required fields absent: {', '.join(absent)}"
+            )
+    return None
 
 
 def evidence_manifest_from_snapshot(packet: dict[str, Any]) -> dict[str, dict] | None:
     if not isinstance(packet, dict):
         return None
     snapshot = packet.get("evidence_snapshot")
-    if not isinstance(snapshot, dict) or snapshot.get("schema") != "no_go_evidence_snapshot_v1":
+    if not isinstance(snapshot, dict) or snapshot.get("schema") != EVIDENCE_SNAPSHOT_SCHEMA:
         return None
     raw_entries = snapshot.get("entries")
     if not isinstance(raw_entries, dict):
@@ -2515,7 +2597,11 @@ def evidence_snapshot_current_error(
     doubly-confirmed cross-family cleans."""
     stored_manifest = evidence_manifest_from_snapshot(packet)
     if stored_manifest is None:
-        return "evidence_snapshot is malformed or predates the current authenticated schema"
+        defect = evidence_snapshot_schema_defect(packet)
+        return (
+            "evidence_snapshot is malformed or predates the current "
+            f"authenticated schema ({defect or 'entry failed field validation'})"
+        )
     stable_roles = {
         "source", "authority", "runner", "helper", "premise_registry",
         "framework_premise",
@@ -2590,9 +2676,24 @@ def evidence_snapshot_current_error(
                 return f"evidence_snapshot raw content hash drifted for {path!r}"
         if set(current.get("roles") or []) != roles:
             return f"evidence_snapshot roles drifted for {path!r}"
-        for field in ("effective_status", "accepted_premise_type"):
-            if current.get(field) != stored.get(field):
-                return f"evidence_snapshot {field} drifted for {path!r}"
+        if current.get("accepted_premise_type") != stored.get("accepted_premise_type"):
+            return f"evidence_snapshot accepted_premise_type drifted for {path!r}"
+        # An authority that got STRONGER is not evidence decay. The
+        # development tier already invalidates on rank decrease only
+        # (invalidate_stale_audits.detect_invalidation), and applying strict
+        # equality here made the audit lane's own throughput destructive:
+        # promoting a cited authority deleted the citing no-go verdict.
+        # Strengthening is re-audit signal instead, carried by
+        # evidence_snapshot_index_growth.
+        stored_status = stored.get("effective_status")
+        current_status = current.get("effective_status")
+        if current_status != stored_status and snapshot_status_rank(
+            current_status
+        ) < snapshot_status_rank(stored_status):
+            return (
+                f"evidence_snapshot effective_status weakened for {path!r}: "
+                f"{stored_status} -> {current_status}"
+            )
     return None
 
 
@@ -2613,6 +2714,18 @@ def evidence_snapshot_index_growth(
     for path, stored in stored_manifest.items():
         roles = set(stored.get("roles") or [])
         current_entry = current_manifest.get(path) or {}
+        # A cited authority that gained strength is a targeted re-audit
+        # signal, never a retroactive deletion. `evidence_snapshot_current_error`
+        # deliberately lets this through; recording it here is what keeps the
+        # movement visible to the dispatcher.
+        stored_status = stored.get("effective_status")
+        current_status = current_entry.get("effective_status")
+        if current_status != stored_status and snapshot_status_rank(
+            current_status
+        ) > snapshot_status_rank(stored_status):
+            growth.setdefault(path, []).append(
+                f"authority_strengthened:{stored_status}->{current_status}"
+            )
         if "source" in roles and (
             stored.get("full_content_sha256")
             == current_entry.get("full_content_sha256")

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -423,6 +423,32 @@ def _import_codex_audit_runner():
     return module
 
 
+def _init_git_fixture_repo(root: Path) -> None:
+    """Make a REPO_ROOT fixture a real repo so live runner execution works.
+
+    `codex_audit_runner._run_repo_runner` executes every runner inside a
+    detached `git worktree` created from REPO_ROOT. A bare tempdir has no
+    HEAD, so the worktree add raises, `get_independent_runner_stdout` catches
+    it, and the evidence role silently becomes
+    `runner_stdout_independent_failed`. Without this the N7 live-authentication
+    tests assert against the failure path instead of the path a forensic no-go
+    packet actually depends on. Call after the fixture files are written.
+    """
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "audit-fixture",
+        "GIT_AUTHOR_EMAIL": "audit-fixture@example.invalid",
+        "GIT_COMMITTER_NAME": "audit-fixture",
+        "GIT_COMMITTER_EMAIL": "audit-fixture@example.invalid",
+    }
+    for command in (
+        ["git", "init", "--quiet", "-b", "main", str(root)],
+        ["git", "-C", str(root), "add", "-A"],
+        ["git", "-C", str(root), "commit", "--quiet", "-m", "fixture"],
+    ):
+        subprocess.run(command, check=True, capture_output=True, env=env)
+
+
 def _import_repo_script(filename: str):
     """Import one repo-root runner under a fresh, test-specific name."""
     module_name = f"repo_script_under_test_{Path(filename).stem}"
@@ -7619,7 +7645,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         changed = json.loads(json.dumps(manifest))
         changed["docs/AUTH.md"]["effective_status"] = "audited_conditional"
         self.assertIn(
-            "effective_status drifted",
+            "effective_status weakened",
             m.evidence_snapshot_current_error(packet, changed) or "",
         )
         changed = json.loads(json.dumps(manifest))
@@ -7632,6 +7658,101 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             "path universe changed",
             m.evidence_snapshot_current_error(packet, changed) or "",
         )
+
+    def test_strengthened_authority_is_growth_signal_not_invalidation(self):
+        """A cited authority getting stronger must not delete the verdict.
+
+        Strict equality on `effective_status` made the audit lane's own
+        throughput destructive: promoting a dependency wiped the no-go row
+        citing it, while the development tier (`invalidate_stale_audits`
+        rank rule) never invalidates on a rank increase.
+        """
+        m = _import("no_go_discipline_gate")
+        manifest = self._manifest()
+        manifest["docs/AUTH.md"] = {
+            "path": "docs/AUTH.md", "roles": ["authority"],
+            "text": "Authority text with a canonical boundary.",
+            "effective_status": "unaudited", "accepted_premise_type": None,
+        }
+        packet = _no_go_packet()
+        _set_no_go_scan_coverage(packet, manifest)
+        packet["evidence_snapshot"] = m.build_evidence_snapshot(packet, manifest)
+        self.assertIsNone(m.evidence_snapshot_current_error(packet, manifest))
+        for stronger in ("retained_bounded", "retained", "retained_no_go"):
+            changed = json.loads(json.dumps(manifest))
+            changed["docs/AUTH.md"]["effective_status"] = stronger
+            self.assertIsNone(
+                m.evidence_snapshot_current_error(packet, changed),
+                f"{stronger} must not invalidate an authenticated verdict",
+            )
+            growth = m.evidence_snapshot_index_growth(packet, changed)
+            self.assertIn(
+                f"authority_strengthened:unaudited->{stronger}",
+                growth.get("docs/AUTH.md", []),
+            )
+
+    def test_evidence_snapshot_writer_satisfies_reader(self):
+        """The writer must emit every entry field the reader demands.
+
+        On 2026-07-11 the reader's required entry-field set grew under an
+        unchanged `no_go_evidence_snapshot_v1` tag, so every snapshot already
+        stored became unreadable and each affected row was reset with an
+        undifferentiated `no_go_discipline_packet_invalid`. This binds the two
+        halves of the contract together.
+        """
+        m = _import("no_go_discipline_gate")
+        manifest = self._manifest()
+        manifest["docs/AUTH.md"] = {
+            "path": "docs/AUTH.md", "roles": ["authority"],
+            "text": "Authority text with a canonical boundary.",
+            "effective_status": "retained", "accepted_premise_type": None,
+        }
+        packet = _no_go_packet()
+        _set_no_go_scan_coverage(packet, manifest)
+        snapshot = m.build_evidence_snapshot(packet, manifest)
+        self.assertEqual(snapshot["schema"], m.EVIDENCE_SNAPSHOT_SCHEMA)
+        for path, entry in snapshot["entries"].items():
+            absent = sorted(
+                m.EVIDENCE_SNAPSHOT_ENTRY_REQUIRED_FIELDS - set(entry)
+            )
+            self.assertEqual(absent, [], f"{path} is missing {absent}")
+        packet["evidence_snapshot"] = snapshot
+        self.assertIsNone(m.evidence_snapshot_schema_defect(packet))
+        self.assertIsNotNone(m.evidence_manifest_from_snapshot(packet))
+
+    def test_legacy_snapshot_shape_is_reported_as_a_migration(self):
+        """A pre-expansion snapshot must not read as corruption."""
+        m = _import("no_go_discipline_gate")
+        manifest = self._manifest()
+        packet = _no_go_packet()
+        _set_no_go_scan_coverage(packet, manifest)
+        snapshot = m.build_evidence_snapshot(packet, manifest)
+        legacy_path = sorted(snapshot["entries"])[0]
+        snapshot["entries"][legacy_path].pop("verified_values")
+        packet["evidence_snapshot"] = snapshot
+        defect = m.evidence_snapshot_schema_defect(packet)
+        self.assertIn("predates the current entry shape", defect or "")
+        self.assertIn("verified_values", defect or "")
+        self.assertIn(
+            "verified_values",
+            m.evidence_snapshot_current_error(packet, manifest) or "",
+        )
+
+    def test_snapshot_status_rank_matches_pipeline(self):
+        """The gate's local rank copy must track the canonical table."""
+        m = _import("no_go_discipline_gate")
+        pipeline = _import("compute_effective_status")
+        self.assertEqual(m.SNAPSHOT_STATUS_RANK, pipeline.RANK)
+        self.assertEqual(
+            m.snapshot_status_rank("decoration_under_parent"),
+            pipeline.status_rank("decoration_under_parent"),
+        )
+        for status in list(pipeline.RANK) + [None, "nonsense"]:
+            self.assertEqual(
+                m.snapshot_status_rank(status),
+                pipeline.status_rank(status),
+                status,
+            )
 
     def test_directional_wall_collapse_removes_the_dependent_wall(self):
         m = _import("no_go_discipline_gate")
@@ -8907,6 +9028,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 "print('N7_STEELMAN_RESOLUTION selector wall resolved')\n",
                 encoding="utf-8",
             )
+            _init_git_fixture_repo(root)
             row = {
                 "claim_id": "target",
                 "note_path": "docs/target.md",
@@ -8964,6 +9086,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 "print('N7_STEELMAN_RESOLUTION boundary resolved')\n",
                 encoding="utf-8",
             )
+            _init_git_fixture_repo(root)
             row = {
                 "claim_id": "target",
                 "note_path": "docs/target.md",
@@ -9076,6 +9199,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 "raise SystemExit(7)\n",
                 encoding="utf-8",
             )
+            _init_git_fixture_repo(root)
             row = {
                 "claim_id": "target",
                 "note_path": "docs/target.md",
@@ -9137,29 +9261,15 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             note_path = root / "docs" / "target.md"
             runner_path = root / "scripts" / "runner.py"
             helper_path = root / "scripts" / "helper.py"
-            counter_path = root / "invocations.txt"
             note_path.parent.mkdir(parents=True, exist_ok=True)
             runner_path.parent.mkdir(parents=True, exist_ok=True)
             note_path.write_text(_no_go_evidence_text(), encoding="utf-8")
             runner_path.write_text("print('primary')\n", encoding="utf-8")
-            # Stateful helper: the first invocation exits zero with the N7
-            # resolution marker; any second invocation emits a long failure
-            # tail (no clipping marker) and exits nonzero. Canonical dedup must
-            # keep the duplicate declaration from ever triggering that second
-            # invocation, so the authenticated role cannot be poisoned by a
-            # later markerless failure tail on the same evidence surface.
             helper_path.write_text(
-                "import pathlib\n"
-                f"c = pathlib.Path({str(counter_path)!r})\n"
-                "n = int(c.read_text()) if c.exists() else 0\n"
-                "c.write_text(str(n + 1))\n"
-                "if n == 0:\n"
-                "    print('N7_STEELMAN_RESOLUTION selector wall resolved')\n"
-                "else:\n"
-                "    print('POISON ' + 'y' * 9000)\n"
-                "    raise SystemExit(7)\n",
+                "print('N7_STEELMAN_RESOLUTION selector wall resolved')\n",
                 encoding="utf-8",
             )
+            _init_git_fixture_repo(root)
             row = {
                 "claim_id": "target",
                 "note_path": "docs/target.md",
@@ -9169,8 +9279,28 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 "deps": [],
             }
             manifest: dict[str, dict] = {}
-            with mock.patch.object(
-                m, "get_runner_stdout", return_value=_no_go_evidence_text(),
+            # Invocation count is asserted with a call-through spy rather than
+            # a counter file the helper writes: `_run_repo_runner` executes in
+            # a disposable checkout under `sandbox-exec` with `file-write*`
+            # denied across REPO_ROOT, so no runner can carry state between
+            # invocations by design. The spy measures the dedup property
+            # directly while the helper still executes live.
+            invocations: list[str] = []
+            real_independent = m.get_independent_runner_stdout
+
+            def counting_independent(helper: str, timeout_sec: int):
+                invocations.append(helper)
+                return real_independent(helper, timeout_sec)
+
+            with (
+                mock.patch.object(
+                    m, "get_runner_stdout", return_value=_no_go_evidence_text(),
+                ),
+                mock.patch.object(
+                    m,
+                    "get_independent_runner_stdout",
+                    side_effect=counting_independent,
+                ),
             ):
                 m.render_prompt(
                     row,
@@ -9189,7 +9319,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 )
             )
             # The helper ran exactly once; the duplicate declaration was dropped.
-            self.assertEqual(counter_path.read_text(), "1")
+            self.assertEqual(invocations, ["scripts/helper.py"])
             self.assertEqual(
                 manifest[independent_path]["roles"],
                 ["runner_stdout_independent"],
@@ -9197,7 +9327,6 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             self.assertIn(
                 "selector wall resolved", manifest[independent_path]["text"]
             )
-            self.assertNotIn("POISON", manifest[independent_path]["text"])
 
     def test_n7_authenticated_role_revoked_by_failed_sibling(self):
         m = _import("no_go_discipline_gate")


### PR DESCRIPTION
## The question

Phase 1 measured 438 `no_go` rows and **zero** at `retained_no_go` anywhere in
the repository. `retained_no_go` is a named retained grade in
`docs/audit/README.md`. The framework leans on foreclosures constantly. Is the
grade path structural or is it backlog?

## (a) Counts, verified independently against `origin/main` @ `6154f6d4`

Recomputed from the 3873 tracked ledger shards, not from a generated cache:

| | |
|---|---|
| `claim_type: no_go` rows | **439** (438 `unaudited`, 1 `audited_conditional`) |
| `effective_status: retained_no_go` | **0** |
| no_go rows dependency-READY (all deps retained-grade/meta/premise) | **140** |
| no_go rows with a runner on disk | **433 / 439** |
| no_go rows carrying `previous_audits` | **260** |
| archived `audited_clean` entries across no_go rows | **395** |

Phase 1's 438 is now 439; one row was seeded since. Everything else confirms.

## (b) It is neither structural nor backlog. The verdicts are being made and then destroyed.

`compute_effective_status.py:41` maps `no_go -> retained_no_go`, so the
promotion rule exists and works. The rows are not starved of runners, and 140
of them are dependency-ready. And the lane is not ignoring them:

**In the last 14 days, 53 audit commits landed `audited_clean` on rows that are
`claim_type: no_go` today** — through the per-verdict runner path, in
cross-confirmed pairs:

```
2026-07-12  audit: spatial_cubic_time_anisotropy_gate_no_go_2026-06-06 -> audited_clean (... first/cross_family)
2026-07-12  audit: spatial_cubic_time_anisotropy_gate_no_go_2026-06-06 -> audited_clean (... second/fresh_context)
2026-07-12  audit: koide_frobenius_isotype_split_uniqueness_note_2026-04-21 -> audited_clean (... first/cross_family)
2026-07-11  audit: rconn_derived_note -> audited_clean (... first/cross_family)
2026-07-11  audit: yt_ew_color_projection_theorem -> audited_clean (... second/fresh_context)
```

All of them read `unaudited` today.

Across archived history, **187 `audited_clean` no_go verdicts were reset by a
`no_go_discipline_packet_*` reason**. Median verdict lifetime 35 days; 27 lived
under a day; the shortest lived **32 minutes**.

One row's full trace — `spatial_cubic_time_anisotropy_gate_no_go_2026-06-06`,
`criticality: critical`, in-degree 12, 741 transitive descendants:

| minted | verdict | packet | killed by |
|---|---|---|---|
| 2026-06-06 | `audited_clean` (cross_family) | none | — |
| 2026-06-11 | `audited_clean`, cross-confirmation **confirmed** | none | `axiom_premise_changed:kinetic_isotropy_primitive` |
| 2026-07-10 | `audited_clean`, **judicial_review / third_confirmed_first** | none | `no_go_discipline_packet_missing` (15 h) |
| 2026-07-12 | `audited_clean`, cross-confirmation confirmed | full packet + snapshot | `no_go_discipline_packet_invalid` (**32 min**) |

Four clean verdicts, one of them from a five-judge panel, and the row reads
`unaudited`.

### The three mechanisms

1. **`claim_type: no_go` forces the forensic tier everywhere, but no dispatch
   selector will feed it.** `orchestrate_audit_batch.AUDITABLE_TYPES` is
   `{positive_theorem, bounded_theorem, open_gate}`; `select_targets` skips
   no_go rows with `forensic_no_go`, and `compute_alternate_targets` skips them
   again with `source shape requires forensic tier`. The batch drainer produced
   roughly 1100 of ~1108 verdicts in 14 days and can never produce a no-go one.
   The only remaining entry is `orchestrate_audit_loop.run_forensic_canary` —
   **one row per loop pass**, `ready`-only, behind `--skip-forensic-canary`.
   Against 140 ready rows that is the throughput picture.

2. **A development-tier verdict on a no_go row is auto-reset.**
   `invalidate_stale_audits.detect_invalidation` sets `_forensic` from
   `claim_type == "no_go"`, so any clean verdict without an N1–N8 packet
   returns `no_go_discipline_packet_missing` — **162 archived instances**,
   including the judicial-panel verdict above.

3. **A verdict *with* a packet is authenticated against a moving target.**
   - The required entry-field set of `no_go_evidence_snapshot_v1` grew in
     `f225a79561` (landed 2026-07-12 12:43) while the schema tag stayed `v1`.
     **Zero shards in the entire repository contain `verified_values`**, so
     `evidence_manifest_from_snapshot` rejects every stored snapshot. Replaying
     all 30 archived clean forensic packets against current main returns
     `evidence_snapshot is malformed or predates the current authenticated
     schema` — 30 out of 30.
   - `evidence_snapshot_current_error` compared each cited authority's
     `effective_status` by **equality**. Demonstrated on live repo data: a
     dependency moving `meta -> retained` (rank 25 -> 100, a strict
     strengthening) invalidated the citing no-go verdict, while the development
     tier's rank rule (`invalidate_stale_audits.py:535`) did not invalidate at
     all. **Draining the backlog deleted the foreclosures that cited it.**

## (c) Quantified

| | |
|---|---|
| audit verdicts landed on `origin/main`, last 14 days | 1108 |
| of those, targeting a row that is `no_go` today | 53 (4.8%) |
| no_go rows the batch drainer can ever select | 0 |
| no_go rows reachable per audit-loop pass | 1 |
| archived clean no_go verdicts killed by the packet gate | 187 |
| no_go rows `unaudited` today holding an archived clean verdict killed that way | 164 |
| no_go rows whose archived snapshot the current reader cannot read | 40 |
| live rows anywhere carrying an authenticated evidence snapshot | **0** |

## (d) Exposure: the ten most-cited foreclosures

All ten are `criticality: critical` and all ten are `unaudited`. Scope text is
each row's own archived `claim_scope` — the live rows were reset, which strips
`claim_scope`, so the ledger no longer records what was foreclosed.

| in-deg | desc | claim_id | forecloses | if wrong |
|---:|---:|---|---|---|
| 44 | 987 | `yt_ew_color_projection_theorem` | the packet does not derive the connected-trace specialization `kappa_EW = 0` | `kappa_EW = 0` becomes derived; the y_t/EW colour-projection chain gains a step it currently declares open |
| 41 | 755 | `koide_a1_radian_bridge_irreducibility_audit_note_2026-04-24` | the enumerated APBC/BZ/Z3/C9/finite-Wilson/Berry phases are `q*pi` and cannot equal `2/9` | the Koide `delta = 2/9` radian bridge closes from an enumerated source; a route the repo treats as dead reopens |
| 41 | 188 | `quark_route2_e_channel_readout_naturality_no_go_note_2026-04-28` | naturality + low-rational grammar do not force `rho_E = 21/4` | `rho_E` is forced and Route-2 quark readout closes without its admission |
| 41 | 41 | `quark_route2_qe_covariance_schur_quadratic_no_go_narrow_note_2026-06-14` | `lambda = q_E/q_T = kappa^2` is not forced even by a quadratic `O_h`-invariant functional | the covariance bridge is forced; the E-centre datum `rho_E` stops being open |
| 35 | 158 | `quark_route2_source_domain_bridge_no_go_note_2026-04-28` | the packet does not derive `R_conn -> gamma_T/gamma_E = -R_conn` | that bridge algebraically forces `beta_E/alpha_E = 21/4` |
| 30 | 757 | `koide_frobenius_isotype_split_uniqueness_note_2026-04-21` | positive-definiteness + Ad-invariance + orthogonality leave a free isotype weight; `beta = 0` is not forced | the Koide weight is uniquely fixed and the Q-value route closes structurally |
| 30 | 1062 | `rconn_derived_note` | exact SU(3) Fierz gives `F_adj = 8/9`, but the supplied information does not derive `kappa_EW = 0`; `K_EW = 9/8` stays conditional | `K_EW = 9/8` becomes unconditional and the y_t chain's largest conditional step vanishes |
| 29 | 726 | `dm_neutrino_source_surface_active_affine_point_selection_boundary_note_2026-04-16` | **unrecorded** — archived scope is the migration placeholder "Legacy audit row backfilled during scope-aware classification migration" | unknown; 726 descendants ride a foreclosure whose content the ledger does not state |
| 24 | 1167 | `physical_lattice_necessity_note` | on the retained Wilson `beta = 6/g_bare^2` surface, preserving the alpha_s and hierarchy ratios forces `beta = 6`, `u_0 = u_0_can` (no-same-stack regulator boundary) | the physical-lattice necessity argument fails and `beta = 6` loses its necessity framing |
| 22 | 22 | `quark_route2_e_center_blindness_no_go_note_2026-06-17` | constraints omitting the E-centre column cannot select `rho_E = 21/4` | `rho_E = 21/4` is selectable from the reduced carrier |

Concentration is the story: 5 of 10 are the Route-2 `rho_E = 21/4` cluster,
2 are the `kappa_EW = 0` / `K_EW = 9/8` pair feeding y_t, 2 are Koide. Row 8's
foreclosure content is not recorded anywhere in the ledger.

## (e) What this PR changes — three plumbing repairs, zero verdicts

1. **Strengthening no longer deletes a verdict.**
   `evidence_snapshot_current_error` now invalidates on `effective_status`
   **rank decrease** only, matching the development tier, and routes
   strengthening to the existing non-invalidating
   `evidence_snapshot_index_growth` channel as
   `authority_strengthened:<before>-><after>`. Byte drift
   (`full_content_sha256`) and `accepted_premise_type` stay strict; a weakening
   message now carries the before/after.

2. **The snapshot schema contract is now enforced.**
   `EVIDENCE_SNAPSHOT_ENTRY_REQUIRED_FIELDS` is the single shared writer/reader
   contract; `evidence_snapshot_schema_defect()` names the absent field instead
   of reporting a migration with the same string as corruption;
   `test_evidence_snapshot_writer_satisfies_reader` fails if the required set
   ever grows without the writer. That test would have caught `f225a79561`.

3. **The N7 live-authentication path is now covered.**
   Four `NoGoDisciplineGateTest` cases patched `REPO_ROOT` to a bare tempdir,
   so `_run_repo_runner`'s isolated `git worktree add` raised and every live
   helper run was recorded as `runner_stdout_independent_failed`. They asserted
   the failure path of the one mechanism a forensic no-go packet depends on.
   Fixtures now build a real repo; the duplicate-declaration case measures
   dedup with a call-through spy because `sandbox-exec` denies `file-write*`
   across `REPO_ROOT` by design.

Plus three `audit_lint` **notices** (not errors) so the grade path stops being
invisible: `no_go_grade_path_unreached`,
`no_go_clean_verdict_reset_by_packet_gate`, `no_go_legacy_evidence_snapshot`.

### Measured churn

- **0 rows requeued. 0 verdicts risked. 0 ledger shards modified** by a full
  `run_pipeline.sh`. `docs/audit/data/` is byte-identical to the merge-base.
- Every publication `*_EFFECTIVE_STATUS.md` view and `RETAINED_BACKBONE.md`
  re-rendered unchanged.
- One shadow-only movement: `FRONT_DOOR_STATUS` "live conditional/failed rows
  that would park" 234 -> 0, because `fingerprint_policy_versions` hashes
  `no_go_discipline_gate.py`. `_live_conditional_would_park` "carries no
  audit-verdict authority of any kind"; the movement is fail-open — rows become
  dispatch-eligible, none is parked. The generated surface is restored to the
  merge-base in this PR.

### Gates

`vocab_lint --fix` 0 violations · `run_pipeline.sh` complete, invariants **PASS**
`rows=3873 retained_grade=474 link_violations=0 graph_delta=acknowledged` ·
`audit_lint.py --strict` **exit 0** · `git diff --check` clean · 738 tests,
pre-existing failures **7 -> 3**. The remaining 3 (`FingerprintV1StampingTest`)
reproduce identically with these changes stashed and are untouched.

## Refused / left for the owner

- **No verdict set, predicted, or restored.** The 164 reset-after-clean rows
  are re-audit targets for the audit lane alone. I did not run
  `restore_overaggressively_invalidated_audits.py`, and the 40 rows whose
  archived snapshots are unreadable cannot be restored in place — that evidence
  is auditor-produced and is genuinely gone.
- **The dispatch asymmetry is reported, not changed.** Making no_go rows
  drainable at more than one per loop pass is an audit-lane throughput policy
  decision. The two candidate shapes, for the owner: (i) let the forensic
  canary take a small batch per pass rather than a single row, or (ii) make the
  development-tier prompt supply the N1–N8 packet whenever the row is
  `claim_type: no_go`, so a no-go verdict is born forensic instead of being
  minted development-tier and reset. Option (ii) removes mechanism 2 entirely
  and is the one I would argue for; both are verdict-producing changes and are
  not mine to make.
- **`f225a79561`'s consequences are recorded, not reversed.** The schema
  expansion was correct in substance; only its migration was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
