### PR TITLE
tooling(audit): reconcile derivation obligations against their own source notes (registry-integrity batch)

### DIFF
--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -105,6 +105,22 @@ primitives in `docs/audit/data/axiom_premise_nodes.json`. Derivation obligations
 historical admissions, governance decisions, and conventions do not satisfy a
 dependency. They must earn retained-grade normally or leave the consumer
 conditional/pending-chain.
+
+An entry in `docs/audit/data/derivation_obligations.json` and the source note
+named by its own `current_path` are two records of the same open obligation, so
+`audit_lint.py` reconciles them: the registry `target` must match the note's
+`## Exact target`, `self_liquidation_condition` must be grounded in the note's
+`## Closure criterion` rather than another section, a declared
+`historical_governance_source` must actually be cited by the note, and the
+obligation's ledger row must be typed `open_gate` — the only typing that keeps
+the registry's promise that an obligation never satisfies dependency closure.
+The lint reports divergence and never repairs it: what an obligation demands is
+owner/audit-lane content, and deciding which of the two surfaces is right is
+not a mechanical call. The population measured when the rule landed is
+grandfathered in `scripts/derivation_obligation_reconciliation_baseline.txt`
+and surfaces as `derivation_obligation_registry_note_divergence` notices; only
+a new divergence errors, a drained line surfaces as
+`..._baseline_stale`, and the `open_gate` typing check is not grandfatherable.
 - `prose_status` — vocabulary-drift status, orthogonal to `audit_status`. See
   `docs/repo/VOCABULARY_HYGIENE_DESIGN.md`. One of:
   - `clean` — no vocabulary drift detected by `vocab_lint`.

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -26,6 +26,10 @@ Checks (all hard rules from FRESH_LOOK_REQUIREMENTS.md and README.md):
        confirmations must be cross-family, strong/external, or same-family
        fresh_context from a distinct restricted-input session.
      - note_hash on row must equal current note hash on disk.
+     - a registered derivation obligation must agree with the source note it
+       registers (exact target, closure condition, declared governance source)
+       and its ledger row must be typed open_gate. Divergence is reported,
+       never repaired: which surface is right is not a mechanical call.
 
   3. Graph health:
      - No dangling deps.
@@ -62,6 +66,16 @@ AUDIT_DISPATCH_QUEUE_PATH = DATA_DIR / "audit_dispatch_queue.json"
 RETIRED_ADMISSIONS_PATH = DATA_DIR / "tier_a_admissions.json"
 RETIRED_OWNER_GOVERNANCE_PATH = DATA_DIR / "owner_governed_premise_nodes.json"
 DERIVATION_OBLIGATIONS_PATH = DATA_DIR / "derivation_obligations.json"
+# Beside the scripts, not in DATA_DIR: docs/audit/data/ is restored wholesale
+# from the branch merge-base before a science PR is committed, so a baseline
+# there would have every drain silently reverted.
+OBLIGATION_RECONCILIATION_BASELINE_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "audit"
+    / "scripts"
+    / "derivation_obligation_reconciliation_baseline.txt"
+)
 
 ALLOWED_AUDIT_STATUSES = {
     "unaudited",
@@ -528,6 +542,188 @@ def front_door_axiom_pointer_errors(
     return errors
 
 
+def obligation_text_normalize(text: object) -> str:
+    """Registry/note text comparison form: backticks and whitespace dropped."""
+    if not isinstance(text, str):
+        return ""
+    return re.sub(r"\s+", " ", text.replace("`", "")).strip()
+
+
+def markdown_sections(text: str) -> dict[str, str]:
+    """Map each `## Heading` in a source note to its body text."""
+    return {
+        m.group(1).strip(): m.group(2).strip()
+        for m in re.finditer(r"^##\s+(.+?)\s*$(.*?)(?=^##\s|\Z)", text, re.M | re.S)
+    }
+
+
+# Comparison stopwords for obligation grounding. Deliberately small, fixed and
+# purely grammatical: the check is comparative (which section of the note is a
+# registry sentence drawn from), so the list only has to stop function words
+# from swamping the signal. It carries no framework vocabulary.
+OBLIGATION_STOPWORDS = frozenset(
+    """a an and any are as at be been both but by each every for from have if in
+    into is it its must no not of on one or other per rather shall so such than
+    that the their then there these this those to until use used uses was when
+    which while with without all""".split()
+)
+
+
+def obligation_content_words(text: object) -> set[str]:
+    stripped = re.sub(r"[^a-z0-9/_^|.-]+", " ", obligation_text_normalize(text).lower())
+    return {
+        word
+        for word in (token.strip(".") for token in stripped.split())
+        if len(word) >= 3 and word not in OBLIGATION_STOPWORDS
+    }
+
+
+OBLIGATION_RECONCILIATION_KINDS = frozenset(
+    {
+        "exact_target_section_missing",
+        "target_mismatch",
+        "closure_criterion_section_missing",
+        "self_liquidation_condition_missing",
+        "closure_condition_not_grounded",
+        "governance_source_not_cited",
+        "ledger_row_not_open_gate",
+    }
+)
+
+# Not grandfatherable. This one is not a wording divergence between two
+# records of the same obligation: it is the registry's own preamble promise
+# that an obligation "never satisfies dependency closure", carried solely by
+# claim_type == open_gate. Allowing a baseline line to suppress it would let a
+# retyped-and-cleared obligation launder into a retained-grade premise, which
+# is the failure the promise exists to prevent.
+OBLIGATION_RECONCILIATION_NON_GRANDFATHERABLE_KINDS = frozenset(
+    {"ledger_row_not_open_gate"}
+)
+
+
+def obligation_reconciliation_findings(
+    dep_id: str,
+    entry: dict,
+    note_text: str,
+    row: dict | None,
+) -> list[tuple[str, str]]:
+    """Reconcile one derivation-obligation registry entry against its own note.
+
+    Returns ``(kind, message)`` pairs. The registry preamble binds each entry to
+    the exact open target stated by its ``current_path`` note, but nothing read
+    that note: ``target`` was checked for truthiness only and
+    ``self_liquidation_condition`` was never read at all, so a registry record
+    could state a weaker target or a different closure condition than the
+    obligation it registers and no gate would notice.
+
+    Every check is mechanical and reports a divergence; none of them decides
+    which surface is right. What an obligation demands is owner/audit-lane
+    content, so the caller grandfathers today's population and errors only on
+    new divergence.
+    """
+    findings: list[tuple[str, str]] = []
+    source_path = entry.get("current_path") or "<no current_path>"
+    sections = markdown_sections(note_text)
+
+    target_section = sections.get("Exact target")
+    if target_section is None:
+        findings.append(
+            (
+                "exact_target_section_missing",
+                f"{dep_id}: {source_path} has no '## Exact target' section, so the "
+                "registry target cannot be reconciled with the obligation it registers",
+            )
+        )
+    else:
+        registry_target = obligation_text_normalize(entry.get("target"))
+        note_target = obligation_text_normalize(target_section.split("\n\n")[0])
+        if registry_target != note_target:
+            findings.append(
+                (
+                    "target_mismatch",
+                    f"{dep_id}: registry target does not match '## Exact target' in "
+                    f"{source_path}.\n        registry: {registry_target}\n"
+                    f"        note:     {note_target}",
+                )
+            )
+
+    closure_section = sections.get("Closure criterion")
+    if closure_section is None:
+        findings.append(
+            (
+                "closure_criterion_section_missing",
+                f"{dep_id}: {source_path} has no '## Closure criterion' section, so "
+                "self_liquidation_condition has nothing to be grounded in",
+            )
+        )
+    condition = obligation_text_normalize(entry.get("self_liquidation_condition"))
+    if not condition:
+        findings.append(
+            (
+                "self_liquidation_condition_missing",
+                f"{dep_id}: registry entry has no self_liquidation_condition, so the "
+                "registry records nothing about what would close the obligation",
+            )
+        )
+    elif closure_section is not None:
+        condition_words = obligation_content_words(condition)
+        if condition_words:
+            def grounding(body: str) -> float:
+                shared = condition_words & obligation_content_words(body)
+                return len(shared) / len(condition_words)
+
+            closure_grounding = grounding(closure_section)
+            better = sorted(
+                (
+                    (grounding(body), name)
+                    for name, body in sections.items()
+                    if name != "Closure criterion" and grounding(body) > closure_grounding
+                ),
+                reverse=True,
+            )
+            if better:
+                score, name = better[0]
+                findings.append(
+                    (
+                        "closure_condition_not_grounded",
+                        f"{dep_id}: self_liquidation_condition is drawn from "
+                        f"'## {name}' rather than '## Closure criterion' in {source_path} "
+                        f"(content-word grounding {score:.2f} vs {closure_grounding:.2f}); "
+                        "the registry therefore records a different closure condition "
+                        "than the obligation states",
+                    )
+                )
+
+    governance_source = entry.get("historical_governance_source")
+    if governance_source and posixpath.basename(str(governance_source)) not in note_text:
+        findings.append(
+            (
+                "governance_source_not_cited",
+                f"{dep_id}: registry asserts historical_governance_source "
+                f"{governance_source} but {source_path} never cites it",
+            )
+        )
+
+    # The registry preamble promises these entries "never satisfy dependency
+    # closure, never bound or promote downstream rows". That invariant is
+    # carried solely by compute_effective_status.clean_status returning
+    # open_gate for claim_type == open_gate: retyping an obligation row to
+    # bounded_theorem and auditing it clean would launder an open obligation
+    # into a retained-grade premise. Nothing checked the typing.
+    if row is not None and row.get("claim_type") != "open_gate":
+        findings.append(
+            (
+                "ledger_row_not_open_gate",
+                f"{dep_id}: registered derivation obligation has ledger "
+                f"claim_type={row.get('claim_type')!r}, but only 'open_gate' keeps the "
+                "registry's promise that an obligation never satisfies dependency "
+                "closure; report the typing to the audit lane rather than editing "
+                "the row",
+            )
+        )
+    return findings
+
+
 def hash_note_on_disk(note_path_str: str) -> str | None:
     p = REPO_ROOT / note_path_str
     if not p.exists():
@@ -704,6 +900,37 @@ def main() -> int:
                 "derivation_obligations.json overlaps the axiom/primitive foundation: "
                 + ", ".join(sorted(overlap))
             )
+        # Registry <-> source-note reconciliation.
+        #
+        # The registry entry and the note it registers are two records of the
+        # same obligation, and nothing compared them: `target` was checked for
+        # truthiness only, `self_liquidation_condition` was read by no rule in
+        # the repo, and the source note was never opened. A registry that
+        # states a weaker target, or a closure condition copied from a
+        # different section of the note, is invisible to the audit lane
+        # because no ledger row hashes docs/audit/data/.
+        #
+        # This is a ratchet, not a rewrite. What an obligation demands is
+        # owner/audit-lane content, so a divergence is never repaired here and
+        # never picked a side on: today's population is grandfathered verbatim
+        # in derivation_obligation_reconciliation_baseline.txt and reported as
+        # a drainable notice, and only a NEW divergence is an error. Draining
+        # an entry is the owner's adjudication of which surface was right.
+        # The baseline lives beside the scripts rather than in
+        # docs/audit/data/ because that directory is restored wholesale from
+        # origin/main before a science PR lands, which would silently revert
+        # every drain.
+        reconciliation_baseline: set[str] = set()
+        if OBLIGATION_RECONCILIATION_BASELINE_PATH.exists():
+            reconciliation_baseline = {
+                line.strip()
+                for line in OBLIGATION_RECONCILIATION_BASELINE_PATH.read_text(
+                    encoding="utf-8"
+                ).splitlines()
+                if line.strip() and not line.strip().startswith("#")
+            }
+        live_reconciliation_keys: set[str] = set()
+
         for dep_id, entry in sorted(nodes.items()):
             if dep_id not in rows:
                 errors.append(f"derivation obligation {dep_id!r} has no ledger row")
@@ -719,6 +946,37 @@ def main() -> int:
                     f"derivation obligation {dep_id!r} current_path missing on disk: "
                     f"{source_path}"
                 )
+            else:
+                note_text = (REPO_ROOT / source_path).read_text(
+                    encoding="utf-8", errors="replace"
+                )
+                for kind, message in obligation_reconciliation_findings(
+                    dep_id, entry, note_text, rows.get(dep_id)
+                ):
+                    key = f"{dep_id}:{kind}"
+                    live_reconciliation_keys.add(key)
+                    if (
+                        key in reconciliation_baseline
+                        and kind
+                        not in OBLIGATION_RECONCILIATION_NON_GRANDFATHERABLE_KINDS
+                    ):
+                        add_notice(
+                            "derivation_obligation_registry_note_divergence",
+                            f"{message} [grandfathered as {key} in "
+                            "derivation_obligation_reconciliation_baseline.txt; "
+                            "drain by owner adjudication of which surface is right]",
+                        )
+                    else:
+                        errors.append(
+                            f"[derivation_obligation_registry_note_divergence] {message}"
+                        )
+
+        for stale in sorted(reconciliation_baseline - live_reconciliation_keys):
+            add_notice(
+                "derivation_obligation_registry_note_divergence_baseline_stale",
+                f"{stale}: listed in derivation_obligation_reconciliation_baseline.txt "
+                "but the divergence no longer reproduces; prune the baseline entry",
+            )
 
     for cid, row in rows.items():
         if row.get("claim_type") == "meta":

--- a/docs/audit/scripts/compute_lane_certification.py
+++ b/docs/audit/scripts/compute_lane_certification.py
@@ -33,7 +33,22 @@ def is_accepted_premise(claim_id: str) -> bool:
 
 
 def status_satisfies_certification(claim_id: str, status: object) -> bool:
-    """Match the pipeline's chain boundary without inventing premise policy."""
+    """Certification's chain boundary, which is STRICTLY STRONGER than retention.
+
+    Retained-grade rows and decorations of retained parents satisfy; accepted
+    premises are skipped by the caller before this is consulted. Metadata does
+    NOT satisfy, per lane_certification_config.json ("Metadata does not").
+
+    That is the whole difference from the retention boundary:
+    compute_effective_status.is_chain_satisfying_status accepts ``meta`` as
+    stable audit context for one-hop dependency closure, and this function does
+    not. The divergence is deliberate policy, but it is not symmetric with
+    audit throughput: a ``meta`` row's clean status is ``meta`` forever
+    (compute_effective_status.clean_status), so a ``meta`` row inside a lane's
+    closure is a permanent blocker that no audit and no science can clear. Read
+    a lane's ``blocking`` list with that in mind, and change this boundary only
+    as a reviewed decision about what "certified" means.
+    """
     if status in RETAINED_GRADE:
         return True
     if isinstance(status, str) and status.startswith("decoration_under_"):

--- a/docs/audit/scripts/derivation_obligation_reconciliation_baseline.txt
+++ b/docs/audit/scripts/derivation_obligation_reconciliation_baseline.txt
@@ -1,0 +1,42 @@
+# Grandfathered derivation-obligation registry/note divergences.
+#
+# audit_lint.obligation_reconciliation_findings reconciles each entry in
+# docs/audit/data/derivation_obligations.json against the source note named by
+# its own current_path. Every divergence listed here reproduces on the state
+# this file was written against; each is reported as a drainable notice
+# instead of an error. Any divergence NOT listed here is an error.
+#
+# This list may only SHRINK. It is not a suppression switch: what an
+# obligation demands is owner/audit-lane content, so the lint never decides
+# which surface is right and never edits either one. Draining a line means the
+# owner adjudicated the divergence and one of the two surfaces was corrected;
+# a drained line then surfaces as a
+# derivation_obligation_registry_note_divergence_baseline_stale notice until
+# it is pruned.
+#
+# Format: <claim_id>:<finding_kind>
+#
+# The file lives beside the scripts, not in docs/audit/data/, because that
+# directory is restored wholesale from the branch merge-base before a science
+# PR is committed; a baseline there would have every drain silently reverted.
+#
+# Open owner questions behind these six lines are recorded in the PR that
+# introduced this file:
+#   - all three entries record a closure condition paraphrased from the note's
+#     "## Running-program relation" rather than its "## Closure criterion", so
+#     the registry omits the matter-action/measure conjunct (AC grain), the
+#     carrier/source-action bridge conjunct (AC R-eta), and the carrier +
+#     readout-map + cross-sector-correspondence conjuncts (theta);
+#   - the AC R-eta registry target omits the note's "clock-rate" exclusion and
+#     the "h" density-class label;
+#   - the theta registry target omits the note's "from the retained framework
+#     chain" provenance restriction and narrows "quark-sector" to "quark";
+#   - the theta entry asserts a historical_governance_source that its own note
+#     does not cite, unlike its two siblings.
+
+ac_orbit_occupancy_statistical_grain_derivation_obligation:closure_condition_not_grounded
+ac_reta_hclass_hunit_readout_derivation_obligation:target_mismatch
+ac_reta_hclass_hunit_readout_derivation_obligation:closure_condition_not_grounded
+theta_quark_determinant_cross_sector_readout_derivation_obligation:target_mismatch
+theta_quark_determinant_cross_sector_readout_derivation_obligation:closure_condition_not_grounded
+theta_quark_determinant_cross_sector_readout_derivation_obligation:governance_source_not_cited

--- a/docs/audit/scripts/tests/test_derivation_obligation_reconciliation.py
+++ b/docs/audit/scripts/tests/test_derivation_obligation_reconciliation.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Tests for the derivation-obligation registry/note reconciliation lint.
+
+`docs/audit/data/derivation_obligations.json` and the source note named by each
+entry's `current_path` are two records of the same open obligation. Before this
+rule nothing compared them: `audit_lint` checked `target` for truthiness only,
+no rule in the repository read `self_liquidation_condition`, and the note was
+never opened — so a registry entry could record a weaker target or a closure
+condition copied from a different section of its own note with no gate firing.
+
+The lint never repairs a divergence and never decides which surface is right:
+what an obligation demands is owner/audit-lane content. It reports, and the
+current population is grandfathered in a shrink-only baseline.
+
+Run via:
+  python3 -m unittest docs.audit.scripts.tests.test_derivation_obligation_reconciliation
+or:
+  python3 docs/audit/scripts/tests/test_derivation_obligation_reconciliation.py
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = REPO_ROOT / "audit" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import audit_lint  # noqa: E402
+
+
+ALIGNED_NOTE = """# Example Obligation
+
+**Type:** open_gate
+
+## Exact target
+
+Derive from the retained framework chain whether the widget carrier is the
+`same` physical channel as the sprocket readout.
+
+Trailing paragraph that is not part of the target.
+
+## Closure criterion
+
+A closing theorem must construct the widget carrier, identify its physical
+readout map, and prove the sprocket correspondence.
+
+## Running-program relation
+
+This obligation is self-liquidating. If the running widget program derives
+this exact channel at retained grade, the obligation is removed.
+
+## Non-claims
+
+This note derives no value and changes no audit verdict.
+"""
+
+ALIGNED_ENTRY = {
+    "current_path": "docs/EXAMPLE_OBLIGATION.md",
+    "target": (
+        "Derive from the retained framework chain whether the widget carrier "
+        "is the same physical channel as the sprocket readout."
+    ),
+    "self_liquidation_condition": (
+        "A closing theorem that constructs the widget carrier, identifies its "
+        "physical readout map, and proves the sprocket correspondence removes "
+        "the obligation."
+    ),
+}
+
+OPEN_GATE_ROW = {"claim_type": "open_gate"}
+
+
+def kinds(entry, note=ALIGNED_NOTE, row=OPEN_GATE_ROW, dep_id="example_obligation"):
+    return {
+        kind
+        for kind, _message in audit_lint.obligation_reconciliation_findings(
+            dep_id, entry, note, row
+        )
+    }
+
+
+class ObligationReconciliationRuleTest(unittest.TestCase):
+    def test_aligned_entry_produces_no_findings(self):
+        self.assertEqual(kinds(ALIGNED_ENTRY), set())
+
+    def test_backticks_and_wrapping_do_not_count_as_divergence(self):
+        entry = dict(ALIGNED_ENTRY)
+        entry["target"] = (
+            "Derive from   the retained framework chain whether the `widget`\n"
+            "carrier is the same physical channel as the `sprocket` readout."
+        )
+        self.assertEqual(kinds(entry), set())
+
+    def test_target_that_drops_a_conjunct_is_reported(self):
+        entry = dict(ALIGNED_ENTRY)
+        entry["target"] = (
+            "Derive whether the widget carrier is the same physical channel "
+            "as the sprocket readout."
+        )
+        self.assertIn("target_mismatch", kinds(entry))
+
+    def test_target_mismatch_message_quotes_both_surfaces(self):
+        entry = dict(ALIGNED_ENTRY)
+        entry["target"] = "Derive whether the widget carrier is anything at all."
+        message = dict(
+            audit_lint.obligation_reconciliation_findings(
+                "example_obligation", entry, ALIGNED_NOTE, OPEN_GATE_ROW
+            )
+        )["target_mismatch"]
+        self.assertIn("anything at all", message)
+        self.assertIn("sprocket readout", message)
+
+    def test_missing_exact_target_section_is_reported(self):
+        note = ALIGNED_NOTE.replace("## Exact target", "## Goal")
+        self.assertIn("exact_target_section_missing", kinds(ALIGNED_ENTRY, note=note))
+
+    def test_missing_closure_criterion_section_is_reported(self):
+        note = ALIGNED_NOTE.replace("## Closure criterion", "## How it closes")
+        self.assertIn(
+            "closure_criterion_section_missing", kinds(ALIGNED_ENTRY, note=note)
+        )
+
+    def test_absent_self_liquidation_condition_is_reported(self):
+        entry = dict(ALIGNED_ENTRY)
+        entry.pop("self_liquidation_condition")
+        self.assertIn("self_liquidation_condition_missing", kinds(entry))
+
+    def test_closure_condition_copied_from_another_section_is_reported(self):
+        # The measured defect: the registry paraphrases the note's
+        # "## Running-program relation" instead of its "## Closure criterion",
+        # dropping the conjuncts the auditor treats as binding.
+        entry = dict(ALIGNED_ENTRY)
+        entry["self_liquidation_condition"] = (
+            "A retained widget-program theorem deriving this exact channel "
+            "removes the obligation; until then it blocks dependent closure."
+        )
+        self.assertIn("closure_condition_not_grounded", kinds(entry))
+
+    def test_closure_condition_grounded_in_the_criterion_passes(self):
+        entry = dict(ALIGNED_ENTRY)
+        entry["self_liquidation_condition"] = (
+            "A closing theorem constructing the widget carrier and proving the "
+            "sprocket correspondence removes the obligation."
+        )
+        self.assertNotIn("closure_condition_not_grounded", kinds(entry))
+
+    def test_uncited_governance_source_is_reported(self):
+        entry = dict(ALIGNED_ENTRY)
+        entry["historical_governance_source"] = "docs/SOME_GOVERNANCE_DECISION.md"
+        self.assertIn("governance_source_not_cited", kinds(entry))
+
+    def test_cited_governance_source_passes(self):
+        entry = dict(ALIGNED_ENTRY)
+        entry["historical_governance_source"] = "docs/SOME_GOVERNANCE_DECISION.md"
+        note = ALIGNED_NOTE + "\nAdopted via `SOME_GOVERNANCE_DECISION.md`.\n"
+        self.assertNotIn("governance_source_not_cited", kinds(entry, note=note))
+
+    def test_obligation_row_typed_away_from_open_gate_is_reported(self):
+        # The registry preamble promises obligations "never satisfy dependency
+        # closure". Only claim_type == open_gate carries that promise through
+        # compute_effective_status.clean_status; a bounded_theorem retyping
+        # plus a clean verdict would launder an open obligation into a
+        # retained-grade premise.
+        self.assertIn(
+            "ledger_row_not_open_gate",
+            kinds(ALIGNED_ENTRY, row={"claim_type": "bounded_theorem"}),
+        )
+
+    def test_absent_ledger_row_does_not_assert_a_typing(self):
+        # A registered obligation with no ledger row already errors elsewhere;
+        # this rule must not invent a claim_type for it.
+        self.assertNotIn("ledger_row_not_open_gate", kinds(ALIGNED_ENTRY, row=None))
+
+
+class ObligationReconciliationBaselineTest(unittest.TestCase):
+    """The shipped baseline is a ratchet over the real registry, not a switch."""
+
+    def setUp(self):
+        self.registry = json.loads(
+            audit_lint.DERIVATION_OBLIGATIONS_PATH.read_text(encoding="utf-8")
+        )
+        self.baseline = {
+            line.strip()
+            for line in audit_lint.OBLIGATION_RECONCILIATION_BASELINE_PATH.read_text(
+                encoding="utf-8"
+            ).splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        }
+
+    def live_findings(self):
+        found = set()
+        for dep_id, entry in (self.registry.get("nodes") or {}).items():
+            note_path = audit_lint.REPO_ROOT / (entry.get("current_path") or "")
+            if not note_path.exists():
+                continue
+            note_text = note_path.read_text(encoding="utf-8", errors="replace")
+            for kind, _message in audit_lint.obligation_reconciliation_findings(
+                dep_id, entry, note_text, None
+            ):
+                found.add(f"{dep_id}:{kind}")
+        return found
+
+    def test_every_baseline_line_is_a_registered_id_and_known_kind(self):
+        registered = set(self.registry.get("nodes") or {})
+        for line in sorted(self.baseline):
+            dep_id, _, kind = line.rpartition(":")
+            self.assertIn(dep_id, registered, f"{line}: unregistered obligation id")
+            self.assertIn(
+                kind,
+                audit_lint.OBLIGATION_RECONCILIATION_KINDS,
+                f"{line}: unknown finding kind",
+            )
+
+    def test_no_live_divergence_escapes_the_baseline(self):
+        # Exactly the invariant strict lint enforces: a NEW divergence is an
+        # error. Failing here means a registry entry or its note drifted apart
+        # without owner adjudication.
+        escaped = sorted(self.live_findings() - self.baseline)
+        self.assertEqual(escaped, [], f"un-grandfathered divergences: {escaped}")
+
+    def test_typing_launder_is_not_grandfatherable(self):
+        # ledger_row_not_open_gate protects the registry's own preamble promise
+        # rather than reporting a wording divergence, so the baseline must not
+        # be able to suppress it — in the rule, or in the shipped file.
+        self.assertIn(
+            "ledger_row_not_open_gate",
+            audit_lint.OBLIGATION_RECONCILIATION_NON_GRANDFATHERABLE_KINDS,
+        )
+        laundered = sorted(
+            line for line in self.baseline if line.endswith(":ledger_row_not_open_gate")
+        )
+        self.assertEqual(laundered, [])
+
+
+class ChainSatisfactionBoundaryTest(unittest.TestCase):
+    """Lock the certification/retention divergence the false docstring hid.
+
+    `compute_lane_certification.status_satisfies_certification` claimed to
+    "match the pipeline's chain boundary", but
+    `compute_effective_status.is_chain_satisfying_status` accepts `meta` and it
+    does not. The asymmetry is deliberate policy
+    (`lane_certification_config.json`: "Metadata does not"), and it is why
+    `meta` rows inside a lane closure are permanent blockers. These assertions
+    make a silent drift in either direction fail a test instead of a docstring.
+    """
+
+    def setUp(self):
+        import compute_effective_status
+        import compute_lane_certification
+
+        self.effective = compute_effective_status
+        self.certification = compute_lane_certification
+
+    def test_meta_satisfies_retention_but_not_certification(self):
+        self.assertTrue(self.effective.is_chain_satisfying_status("meta"))
+        self.assertFalse(self.certification.status_satisfies_certification("x", "meta"))
+
+    def test_retained_grade_satisfies_both(self):
+        for status in ("retained", "retained_bounded", "retained_no_go"):
+            self.assertTrue(self.effective.is_chain_satisfying_status(status), status)
+            self.assertTrue(
+                self.certification.status_satisfies_certification("x", status), status
+            )
+
+    def test_unaudited_and_open_gate_satisfy_neither(self):
+        for status in ("unaudited", "open_gate", "retained_pending_chain"):
+            self.assertFalse(self.effective.is_chain_satisfying_status(status), status)
+            self.assertFalse(
+                self.certification.status_satisfies_certification("x", status), status
+            )
+
+    def test_certification_docstring_does_not_claim_parity(self):
+        doc = re.sub(
+            r"\s+", " ", self.certification.status_satisfies_certification.__doc__ or ""
+        )
+        self.assertNotIn("Match the pipeline's chain boundary", doc)
+        self.assertIn("Metadata does NOT satisfy", doc)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Phase-2 batch of the repo-state scrub, executing the registry-integrity repair
list. Every phase-1 finding acted on was independently re-verified here against
`origin/main` @ `4c9e8254d2` before anything was written.

## What landed (3 mechanical repairs, all tooling, all zero-churn)

**1. `audit_lint` reconciles each derivation obligation against its own note.**

A `derivation_obligations.json` entry and the source note named by its own
`current_path` are two records of the same open obligation. Nothing compared
them: `target` was checked for truthiness only, `grep -rn
self_liquidation_condition docs/audit/scripts/ scripts/` returns zero rule
hits, and the source note was never opened. All three registered obligations
diverge from their notes. The new rule checks

- registry `target` == the note's `## Exact target` first paragraph, after
  backtick/whitespace normalization;
- `self_liquidation_condition` is grounded in the note's `## Closure criterion`
  rather than another section — measured as content-word containment against
  every `##` section, reported comparatively with no magic threshold;
- a declared `historical_governance_source` is actually cited by the note;
- both sections exist and the condition is non-empty;
- the obligation's **ledger row is typed `open_gate`**.

**The rule reports and never repairs.** What an obligation demands is
owner/audit-lane content, so which of the two surfaces is right is not a
mechanical call. The six current divergences are grandfathered verbatim in
`docs/audit/scripts/derivation_obligation_reconciliation_baseline.txt` and
surface as `derivation_obligation_registry_note_divergence` notices; only a NEW
divergence is an error, and a drained line surfaces as `..._baseline_stale` so
the list can only shrink. The baseline deliberately lives beside the scripts,
not in `docs/audit/data/`, because that directory is restored wholesale from
the branch merge-base before a PR is committed and a baseline there would have
each drain silently reverted (same reasoning as #5603).

The `open_gate` typing check is **not grandfatherable**. It is not a wording
divergence: it carries the registry preamble's promise that these entries
"never satisfy dependency closure, never bound or promote downstream rows", and
that promise rests solely on `compute_effective_status.clean_status` returning
`open_gate` for `claim_type == open_gate`. Retyping an obligation row to
`bounded_theorem` and auditing it clean would yield `retained_bounded`, which
`is_chain_satisfying_status` accepts — laundering an open obligation into a
premise. Blast radius if it ever happened: the three obligations carry
215 transitive descendants and direct in-degree 36. All three rows are
correctly `open_gate` today, so this check lands green.

**2. Corrected a false docstring in `compute_lane_certification.py`.**
`status_satisfies_certification` claimed to "match the pipeline's chain
boundary"; `compute_effective_status.is_chain_satisfying_status` accepts `meta`
and it does not. **No behavior change** — the asymmetry is owner-approved
policy, already documented in `lane_certification_config.json` ("Metadata does
not"). But the comment hid a real consequence: **20 lane-blocking entries are
`meta` rows** (3 in `rule_universality_grain`, 17 in `theta_retirement`; 18
distinct ids incl. `key_terminology` and `minimal_axioms_2026-05-03`), and a
`meta` row's clean status is `meta` forever, so no audit and no science can
ever clear them. The docstring now says what the code does and names that
consequence; a new test locks the divergence in both directions so a silent
drift fails a test instead of a comment.

**3. Documented the rule in `docs/audit/README.md`** (no ledger row; zero
churn), placed away from #5603's hunks.

`docs/audit/scripts/tests/test_derivation_obligation_reconciliation.py`: 20 new
tests — aligned entry passes, backticks/wrapping tolerated, each finding kind
fires, baseline lines must name a registered id and a known kind, no live
divergence escapes the baseline, the typing check is not grandfatherable, and
the certification/retention boundary asymmetry is pinned.

## CHURN — measured, not predicted

| | |
|---|---|
| Rows requeued | **0** |
| Verdicts risked | **0** |
| Source notes touched | **0** |
| Ledger shards touched | **0** |
| `docs/audit/data/` files touched | **0** |
| Generated-surface bytes changed by a full pipeline run | **0** |

Phase 1 predicted 0 requeues / 0 retained-at-risk for its tooling batches (R1,
R5). Measured: identical. Full `run_pipeline.sh` reports `newly seeded: 0`,
`dropped (note removed): 0`, `invalidated (hard reset): 0`, and
`git diff --name-only <merge-base> -- docs/audit/data docs/audit/AUDIT_LEDGER.md
docs/audit/AUDIT_QUEUE.md docs/audit/MISSING_DERIVATION_PROMPTS.md
docs/publication docs/repo` is **empty**, so there was nothing to restore.

Independently verified for the record: **no ledger row anywhere has a
`note_path` under `docs/audit/data/` or `docs/audit/scripts/`** (0 of 3873), so
neither the registries nor this baseline can requeue a row.

## Gates

- `vocab_lint --fix` on all five modified files: **0 violations**
- `bash docs/audit/scripts/run_pipeline.sh` (validation only): **exit 0**,
  `repo_invariants_check PASS rows=3873 retained_grade=474 link_violations=0
  graph_delta=acknowledged`
- `audit_lint.py --strict`: **exit 0, "OK: no errors"** (and exit 0 on
  unmodified `origin/main` too, so the rule adds no errors)
- `git diff --check`: clean
- Test suite: **754 tests**, failure set **byte-identical to unmodified
  origin/main** (8: `NoGoDisciplineGateTest` x4, `FingerprintV1StampingTest`
  x3 — owned by a separate session, untouched here — plus
  `test_cleanup_removes_worktree_and_local_branch`, which cannot create a
  nested git worktree in this sandbox and fails the same way on `origin/main`).
  All 20 new tests pass.

## The six grandfathered divergences (owner decision — I did not pick a side)

Reproduce with `python3 docs/audit/scripts/audit_lint.py` and read the
`derivation_obligation_registry_note_divergence` notices.

1. **`ac_orbit_occupancy_...` closure condition.** Registry: "A retained
   kappa/counting-rule theorem deriving this exact grain removes the
   obligation." Note `## Closure criterion`: "must derive the physical matter
   action and its measure, then distinguish the count-once
   `det_C`/holomorphic realization from the count-twice `|det_C|^2` realified
   realization **without inserting the desired charged-lepton value or readout
   dictionary**." The ledger row's own `missing_bridge_theorem` re-audit note
   agrees with the note. **This is the instance named in the campaign brief;
   confirmed.**
2. **`ac_reta_hclass_...` target.** Registry says "no extra normalization or
   transport factor"; the note says "no extra **clock-rate**, transport, or
   normalization factor", and labels the density class `h`. A closing theorem
   admitting a clock-rate factor would satisfy the registry and violate the
   note — and clock-rate/normalization readout is exactly this lane's live
   physics.
3. **`ac_reta_hclass_...` closure condition.** The note requires a physical
   **carrier/source-action bridge** plus either a native eta/holonomy identity
   or an inhomogeneous Record-facing normalization theorem. The carrier
   conjunct is absent from the registry entirely.
4. **`theta_quark_determinant_...` target.** Registry drops the note's "from
   the retained framework chain" provenance restriction (which both siblings
   carry) and narrows "quark-**sector** determinant readout" to "quark
   determinant readout".
5. **`theta_quark_determinant_...` closure condition.** The note names three
   conjuncts plus an insufficiency clause (construct the carrier, identify the
   physical readout map, prove the cross-sector correspondence; "algebraic
   similarity, shared notation, and historical decision text are
   insufficient"); the ledger row names four. The registry compresses all of
   it to "a retained cross-sector determinant-readout theorem".
6. **`theta_quark_determinant_...` governance provenance.** The registry
   asserts `historical_governance_source:
   docs/TIER_A_RESIDUAL_OWNER_ADOPTION_RETIREMENT_2026-07-04.md`, which the
   note never cites — unlike both siblings, which cite it at their lines 15-17.

Pattern, not typos: in all three entries the `self_liquidation_condition` is a
paraphrase of the note's `## Running-program relation`, not its `## Closure
criterion`. Content-word grounding measures 0.36/0.45/0.50 against
Running-program vs 0.18/0.27/0.40 against Closure criterion.

**Why I did not correct the registry.** (a) Every correction *strengthens* what
the machine record demands, which is a scope decision about a live governance
obligation, not plumbing. (b) `acphilambda_retirement_basis` is configured with
these two obligations as its roots, so the lane cannot certify until one
closes — and the machine record of what would close it is the thing in
dispute. (c) The repair sits inside `docs/audit/data/`, the restore surface;
phase 1 flagged that route as genuinely ambiguous and escalated it. Draining
any baseline line is a one-line edit once the owner rules.

## Deferred — owner decisions I refused to make

**A. Register the unregistered gates in `MINIMAL_AXIOMS_2026-06-29.md`,
including `:170`.** Verified: the memo's `## Open Gates Outside The Axioms`
names 8 bullets; 5 are fully unregistered, 2 partially (the
staggered-Dirac/finite-Grassmann conjunct and the theta *gauge* side are both
unregistered), and 1 has its primitive registered but not its gate.

`:170` "source/action and physical-observable identification" is the parent
gate of an entire campaign and is confirmed unregistered — while being actively
load-bearing as a **foreclosure instrument**: the phrase appears as an
`evidence_locator` closing a route in 6 audited ledger shards, e.g.
`gate_b_farfield_note.json:449` "CLOSED: the accepted axioms expressly withhold
source/action and physical-observable identification, so this route cannot
enlarge the bounded certificate." It has no node, no exact target, no closure
criterion, and nothing that would ever tell the repo it had closed.

**Determination: registering it is a policy decision, not a mechanical
repair.** (i) It requires authoring an exact target and a closure criterion —
deciding what would close a framework-level gate is scientific content. (ii)
`audit_lint` requires a registered obligation to have a ledger row, and
`claim_type` is auditor-owned. (iii) The point of registering is that the rows
currently using the phrase to close routes would depend on the new open gate,
which changes their chain status — i.e. it changes row verdicts, which this
batch is forbidden to do.

I also did **not** ship a lint requiring each memo bullet to resolve to a
registry entry (phase-1 R4): there is no mechanical mapping from a prose bullet
to a registry id, so the rule would need either a fuzzy matcher in a hard gate
or an owner-authored allowlist with a reason per bullet. Either is the owner's
call, and the allowlist would be owner content inside the restore surface.

**B. `axiom_premise_nodes.json` `note` fields diverge from their sources
(both verified).**
- `minimal_axioms`: the memo's withholding sentence (`:130-134`) names 12
  bridges that need separate authority. The registry note's closing list omits
  **4**: `P2/modulus`, `log-det`, `Born weights`, `local observability`. The
  omissions run in the dangerous direction — the registry paraphrase silently
  permits four bridges the memo withholds. Its five additions are mostly
  benign (`physical observable bridge` and `state-selection rule` are supported
  elsewhere in the memo).
- `scale_reference_primitive`: the source note `:15-17` and
  `PRIMITIVE_REGISTRY_CHECK.md:23-28` both pin `a^{-1} = M_Pl`; the machine
  registry says only `a^{-1}`, omitting `= M_Pl`. Two surfaces disagree about
  what the sole dimensionful primitive supplies (registry under-grants — the
  safe direction, but still a disagreement).
- `kinetic_isotropy_primitive` and `realized_state_primitive`: faithful. No
  mismatch.

Severity is currently limited: `grep -n 'note' premise_nodes.py` returns 0
hits, so **no tool reads the registry `note` field at all**. It becomes severe
the moment any surface renders it as premise context. Not repaired here: this
edits the premise registry (the highest-stakes surface in the repo) inside the
restore surface, and per `PRIMITIVE_REGISTRY_CHECK.md:13-16` changing what a
primitive grants is a foundation change, not hygiene. For the record, the churn
cost is **0 rows**: `axiom_premise_changed` keys off the row's `note_hash`
(`invalidate_stale_audits.py:565-573`), not the registry file — so this is a
**route** question, not a cost question.

**C. Registry defects cannot currently be repaired through the normal
science-PR route.** `docs/audit/data/derivation_obligations.json` and
`axiom_premise_nodes.json` are hand-curated control data with no pipeline
writer, but they sit inside the directory that is restored wholesale before
every PR. `review-loop/SKILL.md:835-836` carves out "machine-readable
audit/re-audit targeting metadata … that do not assert a verdict"; whether a
registry-text correction qualifies is genuinely ambiguous. This needs an
explicit owner ruling — it is why (A) and (B) are stuck, and it is a finding in
its own right.

**D. The `meta` chain-satisfaction asymmetry itself.** I corrected the false
docstring but changed no semantics. Whether certification should keep excluding
`meta` (leaving 20 permanently-unclearable lane blockers, two lanes
uncertifiable at any audit throughput) or accept it is a decision about what
"certified" means.

**E. Scale-reference convention sentence** (phase-1 R7). The source note pins
`a^{-1} = M_Pl` at `:17` while disclaiming `a/l_P = 1` at `:39-41`, and
`MINIMAL_AXIOMS:172-173` lists that same identification as an open gate. The
disclaimer is worded identically on all three surfaces, so this is a
deliberate, consistent convention — but no registry entry records which
convention makes the pin and the gate compatible. Cost if approved: 2 rows
requeued, both `audited_conditional`, 0 retained at risk. **Owner-gated: this
touches what an approved primitive grants.**

## Not touched, by instruction

- The 439 `no_go` rows (re-verified: 438 `unaudited`, 1 `audited_conditional`,
  **0 `retained_no_go` repo-wide**) — a concurrent wave owns no_go retention.
- Runner hash-pinning (the 95 terminal-verdict rows naming unpinned runners) —
  concurrent wave.
- `NoGoDisciplineGateTest` / `FingerprintV1StampingTest` — separate session.
- `docs/MINIMAL_AXIOMS_2026-06-29.md` — an edit costs 46 requeues and 11
  retained-grade verdicts (2.5% of the 441-row retained library). Nothing here
  requires it.

No verdict, `audit_status`, `effective_status`, or `claim_type` is set,
predicted, or changed anywhere in this branch. No new axiom, primitive,
vocabulary, or status value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
