### PR TITLE
fix(runner): fit substep3 Hamming-orbit certificate inside the audit stdout budget

### DIFF
--- a/logs/runner-cache/audit_companion_staggered_dirac_substep3_bz_corner_hamming_orbit_2026_05_17.txt
+++ b/logs/runner-cache/audit_companion_staggered_dirac_substep3_bz_corner_hamming_orbit_2026_05_17.txt
@@ -1,132 +1,102 @@
 ===== runner cache v1 =====
 runner: scripts/audit_companion_staggered_dirac_substep3_bz_corner_hamming_orbit_2026_05_17.py
-runner_sha256: 7f5f6e3cbd6cfe5657d6a4afa7e46b8b0975f76a81d6d3fed9514c6a43825438
+runner_sha256: 5921b55094a06b5fe487843f21533bfcadaa46eaa5aab11dd5ebd813aee382e7
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.52
+elapsed_sec: 0.32
 status: ok
 ----- stdout -----
-========================================================================================
 Audit companion (exact-symbolic) for
 STAGGERED_DIRAC_SUBSTEP3_BZ_CORNER_HAMMING_ORBIT_NARROW_THEOREM_NOTE_2026-05-17
 Goal: exhaustive combinatorial verification of S_3-orbit decomposition
       (Z_2)^3 / S_3 = (L_0, L_1, L_2, L_3) with sizes (1, 3, 3, 1)
       plus charge-conjugation involution structure.
-========================================================================================
 
-----------------------------------------------------------------------------------------
-Part 1: (H1) Hypercube cardinality |(Z_2)^3| = 2^3 = 8
-----------------------------------------------------------------------------------------
-  [PASS (A)] (H1) |(Z_2)^3| = 8 by exhaustive enumeration  (|(Z_2)^3| = 8)
-  [PASS (A)] (H1) cardinality matches 2^n = 2^3 = 8  (2^3 = 8)
-  [PASS (A)] (H1) cardinality matches sympy Integer arithmetic
-  [PASS (A)] (H1) all 8 enumerated elements are distinct
+-- Part 1: (H1) Hypercube cardinality |(Z_2)^3| = 2^3 = 8
+[PASS (A)] (H1) |(Z_2)^3| = 8 by exhaustive enumeration
+[PASS (A)] (H1) cardinality matches 2^n = 2^3 = 8
+[PASS (A)] (H1) cardinality matches sympy Integer arithmetic
+[PASS (A)] (H1) all 8 enumerated elements are distinct
 
-----------------------------------------------------------------------------------------
-Part 2: (H2) Hamming-weight grading into 4 level sets
-----------------------------------------------------------------------------------------
-  [PASS (A)] (H2) Hamming-weight level sizes equal (1, 3, 3, 1)  (observed = (1, 3, 3, 1), expected = (1, 3, 3, 1))
-  [PASS (A)] (H2) |L_0| = binomial(3, 0) = 1  (|L_0| = 1)
-  [PASS (A)] (H2) |L_1| = binomial(3, 1) = 3  (|L_1| = 3)
-  [PASS (A)] (H2) |L_2| = binomial(3, 2) = 3  (|L_2| = 3)
-  [PASS (A)] (H2) |L_3| = binomial(3, 3) = 1  (|L_3| = 1)
-  [PASS (A)] (H2) L_0 = {(0, 0, 0)} explicitly  (L_0 = {(0, 0, 0)})
-  [PASS (A)] (H2) L_1 = {e_1, e_2, e_3} explicitly  (L_1 = {(1, 0, 0), (0, 0, 1), (0, 1, 0)})
-  [PASS (A)] (H2) L_2 = {(1,1,0), (1,0,1), (0,1,1)} explicitly  (L_2 = {(1, 0, 1), (1, 1, 0), (0, 1, 1)})
-  [PASS (A)] (H2) L_3 = {(1, 1, 1)} explicitly  (L_3 = {(1, 1, 1)})
+-- Part 2: (H2) Hamming-weight grading into 4 level sets
+[PASS (A)] (H2) Hamming-weight level sizes equal (1, 3, 3, 1) (observed = expected = (1, 3, 3, 1))
+[PASS (A)] (H2) |L_0| = binomial(3, 0) = 1
+[PASS (A)] (H2) |L_1| = binomial(3, 1) = 3
+[PASS (A)] (H2) |L_2| = binomial(3, 2) = 3
+[PASS (A)] (H2) |L_3| = binomial(3, 3) = 1
+[PASS (A)] (H2) L_0 = {(0, 0, 0)} explicitly (L_0 = {(0, 0, 0)})
+[PASS (A)] (H2) L_1 = {e_1, e_2, e_3} explicitly (L_1 = {(1, 0, 0), (0, 0, 1), (0, 1, 0)})
+[PASS (A)] (H2) L_2 = {(1,1,0), (1,0,1), (0,1,1)} explicitly (L_2 = {(1, 0, 1), (1, 1, 0), (0, 1, 1)})
+[PASS (A)] (H2) L_3 = {(1, 1, 1)} explicitly (L_3 = {(1, 1, 1)})
 
-----------------------------------------------------------------------------------------
-Part 3: (H3) Binomial sum identity sum_k C(3, k) = 2^3 = 8
-----------------------------------------------------------------------------------------
-  [PASS (A)] (H3) sum_{k=0}^3 binomial(3, k) = 8 by direct summation  (sum = 8)
-  [PASS (A)] (H3) sum_{k=0}^3 binomial(3, k) = (1 + 1)^3 = 2^3 = 8
-  [PASS (A)] (H3) sum_{k=0}^3 binomial(3, k) matches |(Z_2)^3|
-  [PASS (A)] (H3) 1 + 3 + 3 + 1 = 8 (partition sum check)  (partition sum = 8)
+-- Part 3: (H3) Binomial sum identity sum_k C(3, k) = 2^3 = 8
+[PASS (A)] (H3) sum_{k=0}^3 binomial(3, k) = 8 by direct summation
+[PASS (A)] (H3) sum_{k=0}^3 binomial(3, k) = (1 + 1)^3 = 2^3 = 8
+[PASS (A)] (H3) sum_{k=0}^3 binomial(3, k) matches |(Z_2)^3|
+[PASS (A)] (H3) 1 + 3 + 3 + 1 = 8 (partition sum check)
 
-----------------------------------------------------------------------------------------
-Part 4: (H4) S_3 preserves Hamming weight (48 instances)
-----------------------------------------------------------------------------------------
-  [PASS (A)] (H4) |S_3| = 6  (|S_3| = 6)
-  [PASS (A)] (H4) S_3 preserves Hamming weight on all (sigma, b) pairs  (6 sigmas * 8 b's = 48 instances)
+-- Part 4: (H4) S_3 preserves Hamming weight (48 instances)
+[PASS (A)] (H4) |S_3| = 6
+[PASS (A)] (H4) S_3 preserves Hamming weight on all (sigma, b) pairs (6 sigmas * 8 b's = 48 instances)
 
-----------------------------------------------------------------------------------------
-Part 5: (H5) S_3 acts transitively on each Hamming level
-----------------------------------------------------------------------------------------
-  [PASS (A)] (H5) S_3 orbit of representative (0, 0, 0) ∈ L_0 equals L_0  (|orbit| = 1, |L_0| = 1)
-  [PASS (A)] (H5) S_3 orbit of representative (0, 0, 1) ∈ L_1 equals L_1  (|orbit| = 3, |L_1| = 3)
-  [PASS (A)] (H5) S_3 orbit of representative (0, 1, 1) ∈ L_2 equals L_2  (|orbit| = 3, |L_2| = 3)
-  [PASS (A)] (H5) S_3 orbit of representative (1, 1, 1) ∈ L_3 equals L_3  (|orbit| = 1, |L_3| = 1)
-  [PASS (A)] (H5) S_3 acts transitively on L_1 (all 9 pairs realized)
-  [PASS (A)] (H5) S_3 acts transitively on L_2 (all 9 pairs realized)
+-- Part 5: (H5) S_3 acts transitively on each Hamming level
+[PASS (A)] (H5) S_3 orbit of representative (0, 0, 0) ∈ L_0 equals L_0 (|orbit| = 1, |L_0| = 1)
+[PASS (A)] (H5) S_3 orbit of representative (0, 0, 1) ∈ L_1 equals L_1 (|orbit| = 3, |L_1| = 3)
+[PASS (A)] (H5) S_3 orbit of representative (0, 1, 1) ∈ L_2 equals L_2 (|orbit| = 3, |L_2| = 3)
+[PASS (A)] (H5) S_3 orbit of representative (1, 1, 1) ∈ L_3 equals L_3 (|orbit| = 1, |L_3| = 1)
+[PASS (A)] (H5) S_3 acts transitively on L_1 (all 9 pairs realized)
+[PASS (A)] (H5) S_3 acts transitively on L_2 (all 9 pairs realized)
 
-----------------------------------------------------------------------------------------
-Part 6: (H6) S_3-orbit decomposition equals Hamming grading
-----------------------------------------------------------------------------------------
-  [PASS (A)] (H6) number of S_3 orbits on (Z_2)^3 equals 4  (|orbits| = 4)
-  [PASS (A)] (H6) orbit cardinality vector equals (1, 3, 3, 1) as multiset  (observed = [1, 1, 3, 3], expected = [1, 1, 3, 3])
-  [PASS (A)] (H6) S_3 orbits = {L_0, L_1, L_2, L_3} (Hamming-weight level sets)
-  [PASS (A)] (H6) orbits cover all of (Z_2)^3 (sum of sizes = 8)  (sum of orbit sizes = 8)
-  [PASS (A)] (H6) orbits are pairwise disjoint (no element appears twice)  (total elements = 8, distinct = 8)
+-- Part 6: (H6) S_3-orbit decomposition equals Hamming grading
+[PASS (A)] (H6) number of S_3 orbits on (Z_2)^3 equals 4
+[PASS (A)] (H6) orbit cardinality vector equals (1, 3, 3, 1) as multiset (observed = expected = [1, 1, 3, 3])
+[PASS (A)] (H6) S_3 orbits = {L_0, L_1, L_2, L_3} (Hamming-weight level sets)
+[PASS (A)] (H6) orbits cover all of (Z_2)^3 (sum of sizes = 8)
+[PASS (A)] (H6) orbits are pairwise disjoint (no element appears twice) (total elements = 8, distinct = 8)
 
-----------------------------------------------------------------------------------------
-Part 7: (H7) Charge-conjugation involution c(b) = (1,1,1) - b
-----------------------------------------------------------------------------------------
-  [PASS (A)] (H7) c is an involution: c(c(b)) = b for all b ∈ (Z_2)^3
-  [PASS (A)] (H7) hw(c(b)) = 3 - hw(b) for all b ∈ (Z_2)^3 (8 instances)
-  [PASS (A)] (H7) c(L_0) = L_3  (c(L_0) size = 1, L_3 size = 1)
-  [PASS (A)] (H7) c(L_1) = L_2  (c(L_1) size = 3, L_2 size = 3)
-  [PASS (A)] (H7) c(L_2) = L_1  (c(L_2) size = 3, L_1 size = 3)
-  [PASS (A)] (H7) c(L_3) = L_0  (c(L_3) size = 1, L_0 size = 1)
-  [PASS (A)] (H7) c commutes with S_3 on all (sigma, b) pairs (48 instances)  (6 sigmas * 8 b's = 48 instances)
-  [PASS (A)] (H7) combined S_3 x Z_2 action has exactly 2 orbits  (|combined orbits| = 2)
-  [PASS (A)] (H7) combined orbit cardinality vector equals (2, 6)  (combined sizes = [2, 6])
-  [PASS (A)] (H7) O_paired = {(0,0,0), (1,1,1)} explicitly
-  [PASS (A)] (H7) O_balanced = L_1 ∪ L_2 explicitly
-  [PASS (A)] (H7) combined orbits cover all of (Z_2)^3 (sum = 8)  (sum = 8)
+-- Part 7: (H7) Charge-conjugation involution c(b) = (1,1,1) - b
+[PASS (A)] (H7) c is an involution: c(c(b)) = b for all b ∈ (Z_2)^3
+[PASS (A)] (H7) hw(c(b)) = 3 - hw(b) for all b ∈ (Z_2)^3 (8 instances)
+[PASS (A)] (H7) c(L_0) = L_3 (c(L_0) size = 1, L_3 size = 1)
+[PASS (A)] (H7) c(L_1) = L_2 (c(L_1) size = 3, L_2 size = 3)
+[PASS (A)] (H7) c(L_2) = L_1 (c(L_2) size = 3, L_1 size = 3)
+[PASS (A)] (H7) c(L_3) = L_0 (c(L_3) size = 1, L_0 size = 1)
+[PASS (A)] (H7) c commutes with S_3 on all (sigma, b) pairs (48 instances)
+[PASS (A)] (H7) combined S_3 x Z_2 action has exactly 2 orbits
+[PASS (A)] (H7) combined orbit cardinality vector equals (2, 6)
+[PASS (A)] (H7) O_paired = {(0,0,0), (1,1,1)} explicitly
+[PASS (A)] (H7) O_balanced = L_1 ∪ L_2 explicitly
+[PASS (A)] (H7) combined orbits cover all of (Z_2)^3 (sum = 8)
 
-----------------------------------------------------------------------------------------
-Part 8: Counter-example for (H5) — non-Hamming partitions fail
-----------------------------------------------------------------------------------------
-  [PASS (A)] (H5 counter) coordinate-value partition gives (4, 4), not (1, 3, 3, 1)  (coord-value split = (4, 4))
+-- Part 8: Counter-example for (H5) — non-Hamming partitions fail
+[PASS (A)] (H5 counter) coordinate-value partition gives (4, 4), not (1, 3, 3, 1)
 
-----------------------------------------------------------------------------------------
-Part 9: Counter-example for (H6) — non-S_3 actions break the orbit count
-----------------------------------------------------------------------------------------
-  [PASS (A)] (H6 counter) Z_2^3 coordinate-flip orbit of (0,0,0) is all 8 vectors (single orbit)  (|coord-flip orbit| = 8)
-  [PASS (A)] (H6 counter) coord-flip orbit count (1) != S_3 orbit count (4)
+-- Part 9: Counter-example for (H6) — non-S_3 actions break the orbit count
+[PASS (A)] (H6 counter) Z_2^3 coordinate-flip orbit of (0,0,0) is all 8 vectors (single orbit)
+[PASS (A)] (H6 counter) coord-flip orbit count (1) != S_3 orbit count (4)
 
-----------------------------------------------------------------------------------------
-Part 10: General-n cross-check, n ∈ {1, 2, 3, 4, 5}
-----------------------------------------------------------------------------------------
-  [PASS (A)] (general-n) at n = 1, Hamming-weight cardinalities equal binom(1, k)  (observed = (1, 1), expected = (1, 1))
-  [PASS (A)] (general-n) at n = 1, sum of level sizes = 2^1 = 2
-  [PASS (A)] (general-n) at n = 2, Hamming-weight cardinalities equal binom(2, k)  (observed = (1, 2, 1), expected = (1, 2, 1))
-  [PASS (A)] (general-n) at n = 2, sum of level sizes = 2^2 = 4
-  [PASS (A)] (general-n) at n = 3, Hamming-weight cardinalities equal binom(3, k)  (observed = (1, 3, 3, 1), expected = (1, 3, 3, 1))
-  [PASS (A)] (general-n) at n = 3, sum of level sizes = 2^3 = 8
-  [PASS (A)] (general-n) at n = 4, Hamming-weight cardinalities equal binom(4, k)  (observed = (1, 4, 6, 4, 1), expected = (1, 4, 6, 4, 1))
-  [PASS (A)] (general-n) at n = 4, sum of level sizes = 2^4 = 16
-  [PASS (A)] (general-n) at n = 5, Hamming-weight cardinalities equal binom(5, k)  (observed = (1, 5, 10, 10, 5, 1), expected = (1, 5, 10, 10, 5, 1))
-  [PASS (A)] (general-n) at n = 5, sum of level sizes = 2^5 = 32
+-- Part 10: General-n cross-check, n ∈ {1, 2, 3, 4, 5}
+[PASS (A)] (general-n) at n = 1, Hamming-weight cardinalities equal binom(1, k) (observed = expected = (1, 1))
+[PASS (A)] (general-n) at n = 1, sum of level sizes = 2^1 = 2
+[PASS (A)] (general-n) at n = 2, Hamming-weight cardinalities equal binom(2, k) (observed = expected = (1, 2, 1))
+[PASS (A)] (general-n) at n = 2, sum of level sizes = 2^2 = 4
+[PASS (A)] (general-n) at n = 3, Hamming-weight cardinalities equal binom(3, k) (observed = expected = (1, 3, 3, 1))
+[PASS (A)] (general-n) at n = 3, sum of level sizes = 2^3 = 8
+[PASS (A)] (general-n) at n = 4, Hamming-weight cardinalities equal binom(4, k) (observed = expected = (1, 4, 6, 4, 1))
+[PASS (A)] (general-n) at n = 4, sum of level sizes = 2^4 = 16
+[PASS (A)] (general-n) at n = 5, Hamming-weight cardinalities equal binom(5, k) (observed = expected = (1, 5, 10, 10, 5, 1))
+[PASS (A)] (general-n) at n = 5, sum of level sizes = 2^5 = 32
 
-----------------------------------------------------------------------------------------
-Summary
-----------------------------------------------------------------------------------------
-  Verified at exact-symbolic precision:
-    (H1) |(Z_2)^3| = 8 = 2^3 (cardinality)
-    (H2) Hamming-weight levels (L_0, L_1, L_2, L_3) of sizes (1, 3, 3, 1)
-    (H3) binomial sum identity sum_k binomial(3, k) = 2^3 = 8
-    (H4) S_3 preserves Hamming weight (48 (sigma, b) instances)
-    (H5) S_3 acts transitively on each L_k (orbits = L_k)
-    (H6) S_3-orbit decomposition = (L_0, L_1, L_2, L_3) = (1, 3, 3, 1)
-    (H7) charge-conjugation c involution, pairs L_0↔L_3, L_1↔L_2
-    (H7) S_3 x Z_2 combined orbits: (2, 6)
-    Counter-examples confirm S_3 is load-bearing (not arbitrary Aut subgroup)
-    General-n cross-check: n in {1..5} confirms binomial pattern
+-- Summary
+Verified at exact-symbolic precision:
+(H1) |(Z_2)^3| = 8 = 2^3; (H2) levels (L_0..L_3) sizes (1, 3, 3, 1);
+(H3) sum_k binomial(3, k) = 2^3 = 8; (H4) S_3 preserves Hamming weight (48);
+(H5) S_3 transitive on each L_k (orbits = L_k);
+(H6) S_3-orbit decomposition = (L_0, L_1, L_2, L_3) = (1, 3, 3, 1);
+(H7) c involution pairs L_0<->L_3, L_1<->L_2; S_3 x Z_2 orbits (2, 6).
+Counter-examples confirm S_3 is load-bearing; general-n n in {1..5} checked.
 
-========================================================================================
 TOTAL: PASS=55, FAIL=0
-========================================================================================
 
 ----- stderr -----
 

--- a/scripts/audit_companion_staggered_dirac_substep3_bz_corner_hamming_orbit_2026_05_17.py
+++ b/scripts/audit_companion_staggered_dirac_substep3_bz_corner_hamming_orbit_2026_05_17.py
@@ -29,6 +29,7 @@ holds at exact symbolic precision.
 from __future__ import annotations
 
 from itertools import permutations, product
+import re
 import sys
 
 try:
@@ -44,23 +45,39 @@ PASS = 0
 FAIL = 0
 
 
-def check(label: str, ok: bool, detail: str = "") -> None:
+_OBSERVED_EXPECTED = re.compile(r"observed = (.*), expected = (.*)")
+
+
+def check(label: str, ok: bool, detail: str = "", fail_detail: str = "") -> None:
+    """Record one class-(A) check and print exactly one line of evidence.
+
+    `detail` is always shown; `fail_detail` carries diagnostics that merely echo
+    the value already asserted in `label`, so it is printed only when the check
+    fails.  The audit packet renders at most 6000 characters of runner stdout,
+    and this compaction keeps the complete per-check execution evidence for all
+    checks inside that budget without dropping any check or any distinct value.
+    """
     global PASS, FAIL
     if ok:
         PASS += 1
         tag = "PASS (A)"
+        shown = detail
     else:
         FAIL += 1
         tag = "FAIL (A)"
-    suffix = f"  ({detail})" if detail else ""
-    print(f"  [{tag}] {label}{suffix}")
+        shown = "; ".join(d for d in (detail, fail_detail) if d)
+    matched = _OBSERVED_EXPECTED.fullmatch(shown)
+    if matched and matched.group(1) == matched.group(2):
+        shown = f"observed = expected = {matched.group(1)}"
+    suffix = f" ({shown})" if shown else ""
+    print(f"[{tag}] {label}{suffix}")
 
 
 def section(title: str) -> None:
-    print()
-    print("-" * 88)
-    print(title)
-    print("-" * 88)
+    # Compact rendering: one short banner line per part.  The audit packet
+    # renders at most 6000 characters of runner stdout, so decorative rules
+    # are omitted to keep the complete per-check evidence inside the budget.
+    print(f"\n-- {title}")
 
 
 # -------------------------------------------------------------------------
@@ -108,13 +125,11 @@ def charge_conjugate(b: tuple[int, ...]) -> tuple[int, ...]:
 
 
 def main() -> int:
-    print("=" * 88)
     print("Audit companion (exact-symbolic) for")
     print("STAGGERED_DIRAC_SUBSTEP3_BZ_CORNER_HAMMING_ORBIT_NARROW_THEOREM_NOTE_2026-05-17")
     print("Goal: exhaustive combinatorial verification of S_3-orbit decomposition")
     print("      (Z_2)^3 / S_3 = (L_0, L_1, L_2, L_3) with sizes (1, 3, 3, 1)")
     print("      plus charge-conjugation involution structure.")
-    print("=" * 88)
 
     n = 3  # framework spatial substrate dimension
     Z2_3 = make_z2_n(n)
@@ -126,12 +141,12 @@ def main() -> int:
     check(
         "(H1) |(Z_2)^3| = 8 by exhaustive enumeration",
         len(Z2_3) == 8,
-        detail=f"|(Z_2)^3| = {len(Z2_3)}",
+        fail_detail=f"|(Z_2)^3| = {len(Z2_3)}",
     )
     check(
         "(H1) cardinality matches 2^n = 2^3 = 8",
         len(Z2_3) == 2**n,
-        detail=f"2^{n} = {2**n}",
+        fail_detail=f"2^{n} = {2**n}",
     )
     check(
         "(H1) cardinality matches sympy Integer arithmetic",
@@ -163,7 +178,7 @@ def main() -> int:
         check(
             f"(H2) |L_{k}| = binomial(3, {k}) = {expected_binom}",
             len(levels[k]) == expected_binom,
-            detail=f"|L_{k}| = {len(levels[k])}",
+            fail_detail=f"|L_{k}| = {len(levels[k])}",
         )
 
     # Exhibit the explicit level sets and verify weight signature
@@ -199,7 +214,7 @@ def main() -> int:
     check(
         "(H3) sum_{k=0}^3 binomial(3, k) = 8 by direct summation",
         binom_sum == 8,
-        detail=f"sum = {binom_sum}",
+        fail_detail=f"sum = {binom_sum}",
     )
     check(
         "(H3) sum_{k=0}^3 binomial(3, k) = (1 + 1)^3 = 2^3 = 8",
@@ -214,7 +229,7 @@ def main() -> int:
     check(
         "(H3) 1 + 3 + 3 + 1 = 8 (partition sum check)",
         partition_sum == 8,
-        detail=f"partition sum = {partition_sum}",
+        fail_detail=f"partition sum = {partition_sum}",
     )
 
     # =========================================================================
@@ -224,7 +239,7 @@ def main() -> int:
     check(
         "(H4) |S_3| = 6",
         n_S3 == 6,
-        detail=f"|S_3| = {n_S3}",
+        fail_detail=f"|S_3| = {n_S3}",
     )
     h4_check = True
     h4_fail_details: list[str] = []
@@ -321,7 +336,7 @@ def main() -> int:
     check(
         "(H6) number of S_3 orbits on (Z_2)^3 equals 4",
         len(orbits_seen) == 4,
-        detail=f"|orbits| = {len(orbits_seen)}",
+        fail_detail=f"|orbits| = {len(orbits_seen)}",
     )
 
     # Verify orbit-cardinality vector
@@ -345,7 +360,7 @@ def main() -> int:
     check(
         "(H6) orbits cover all of (Z_2)^3 (sum of sizes = 8)",
         total_orbit_elements == 8,
-        detail=f"sum of orbit sizes = {total_orbit_elements}",
+        fail_detail=f"sum of orbit sizes = {total_orbit_elements}",
     )
 
     # Orbits are pairwise disjoint
@@ -406,11 +421,7 @@ def main() -> int:
     check(
         "(H7) c commutes with S_3 on all (sigma, b) pairs (48 instances)",
         h7_comm_check,
-        detail=(
-            "6 sigmas * 8 b's = 48 instances"
-            if h7_comm_check
-            else f"fail at {h7_comm_fail[:1]}"
-        ),
+        fail_detail=f"fail at {h7_comm_fail[:1]}",
     )
 
     # Combined S_3 x Z_2 orbits: union of (sigma · b) and (sigma · c(b))
@@ -425,13 +436,13 @@ def main() -> int:
     check(
         "(H7) combined S_3 x Z_2 action has exactly 2 orbits",
         len(s3_z2_orbits) == 2,
-        detail=f"|combined orbits| = {len(s3_z2_orbits)}",
+        fail_detail=f"|combined orbits| = {len(s3_z2_orbits)}",
     )
     combined_orbit_sizes = sorted(len(o) for o in s3_z2_orbits)
     check(
         "(H7) combined orbit cardinality vector equals (2, 6)",
         combined_orbit_sizes == [2, 6],
-        detail=f"combined sizes = {combined_orbit_sizes}",
+        fail_detail=f"combined sizes = {combined_orbit_sizes}",
     )
 
     # Identify O_paired and O_balanced
@@ -451,7 +462,7 @@ def main() -> int:
     check(
         "(H7) combined orbits cover all of (Z_2)^3 (sum = 8)",
         combined_total == 8,
-        detail=f"sum = {combined_total}",
+        fail_detail=f"sum = {combined_total}",
     )
 
     # =========================================================================
@@ -466,7 +477,7 @@ def main() -> int:
     check(
         "(H5 counter) coordinate-value partition gives (4, 4), not (1, 3, 3, 1)",
         coord_split_sizes == (4, 4) and coord_split_sizes != (1, 3, 3, 1),
-        detail=f"coord-value split = {coord_split_sizes}",
+        fail_detail=f"coord-value split = {coord_split_sizes}",
     )
 
     # =========================================================================
@@ -489,7 +500,7 @@ def main() -> int:
     check(
         "(H6 counter) Z_2^3 coordinate-flip orbit of (0,0,0) is all 8 vectors (single orbit)",
         z2_flip_orbit == set(Z2_3),
-        detail=f"|coord-flip orbit| = {len(z2_flip_orbit)}",
+        fail_detail=f"|coord-flip orbit| = {len(z2_flip_orbit)}",
     )
     check(
         "(H6 counter) coord-flip orbit count (1) != S_3 orbit count (4)",
@@ -519,22 +530,16 @@ def main() -> int:
     # =========================================================================
     section("Summary")
     # =========================================================================
-    print("  Verified at exact-symbolic precision:")
-    print("    (H1) |(Z_2)^3| = 8 = 2^3 (cardinality)")
-    print("    (H2) Hamming-weight levels (L_0, L_1, L_2, L_3) of sizes (1, 3, 3, 1)")
-    print("    (H3) binomial sum identity sum_k binomial(3, k) = 2^3 = 8")
-    print("    (H4) S_3 preserves Hamming weight (48 (sigma, b) instances)")
-    print("    (H5) S_3 acts transitively on each L_k (orbits = L_k)")
-    print("    (H6) S_3-orbit decomposition = (L_0, L_1, L_2, L_3) = (1, 3, 3, 1)")
-    print("    (H7) charge-conjugation c involution, pairs L_0↔L_3, L_1↔L_2")
-    print("    (H7) S_3 x Z_2 combined orbits: (2, 6)")
-    print("    Counter-examples confirm S_3 is load-bearing (not arbitrary Aut subgroup)")
-    print("    General-n cross-check: n in {1..5} confirms binomial pattern")
+    print("Verified at exact-symbolic precision:")
+    print("(H1) |(Z_2)^3| = 8 = 2^3; (H2) levels (L_0..L_3) sizes (1, 3, 3, 1);")
+    print("(H3) sum_k binomial(3, k) = 2^3 = 8; (H4) S_3 preserves Hamming weight (48);")
+    print("(H5) S_3 transitive on each L_k (orbits = L_k);")
+    print("(H6) S_3-orbit decomposition = (L_0, L_1, L_2, L_3) = (1, 3, 3, 1);")
+    print("(H7) c involution pairs L_0<->L_3, L_1<->L_2; S_3 x Z_2 orbits (2, 6).")
+    print("Counter-examples confirm S_3 is load-bearing; general-n n in {1..5} checked.")
 
     print()
-    print("=" * 88)
     print(f"TOTAL: PASS={PASS}, FAIL={FAIL}")
-    print("=" * 88)
     return 0 if FAIL == 0 else 1
 
 


### PR DESCRIPTION
## What verdict this responds to

Ledger row `staggered_dirac_substep3_bz_corner_hamming_orbit_narrow_theorem_note_2026-05-17` is `audited_conditional`. The verdict rationale, verbatim:

> Issue: the supplied runner stdout is explicitly clipped and omits Parts 1–3, although its visible summary reports 55 class-(A) passes and the included source implements the stated exhaustive checks. Why this blocks: the packet's binding completeness preflight forbids audited_clean without the complete rendered load-bearing execution evidence. Repair target: provide unclipped SHA-bound stdout or a complete cached certificate; until then, the audited claim remains the narrow bare finite-set theorem, with no physical BZ-corner or species identification included.

Re-audit note, verbatim:

> runner_artifact_issue: supply unclipped SHA-bound stdout or a complete cached certificate covering Parts 1–3 and the full 55-check execution, then rerun the audit.

The block is mechanical, not scientific: `scripts/runner_cache.py::cache_excerpt_for_audit` renders at most 6000 characters of cache body (tail-kept), and this runner emitted 8808.

## What changed

Runner presentation only — **no computational logic is touched**.

- `section()` prints one short banner line instead of two 88-char rules plus a blank line; the two `"=" * 88` banner rules in `main()` are dropped.
- `check()` gains a `fail_detail` channel for diagnostics that merely restate the value already asserted in the label (e.g. label `(H4) |S_3| = 6` with detail `(|S_3| = 6)`). Those echoes now print only when the check fails, so failure diagnostics are unchanged while PASS lines carry no duplicated numeral.
- `check()` collapses `observed = X, expected = X` to `observed = expected = X` when the two sides are textually identical.
- The closing summary states the same seven results in compact form.

Every one of the 55 class-(A) checks still executes identically and still prints its own line, so the auditor's `runner_check_breakdown` A-count is unchanged. Every distinct value still appears.

## Numbers

- `python3 scripts/audit_companion_staggered_dirac_substep3_bz_corner_hamming_orbit_2026_05_17.py` → exit 0, `TOTAL: PASS=55, FAIL=0`, 55 `PASS (A)` lines (re-run by me, not echoed from a log).
- Cache body: **8808 → 5760 chars**, under the 6000-char packet budget. `cache_status` = `fresh`; `cache_excerpt_for_audit` now returns the body with **no** `[runner cache excerpt clipped; ...]` marker — Parts 1–10 render in full.
- Sibling-runner grep (`grep -rln staggered_dirac_substep3_bz_corner_hamming_orbit scripts/`) found three: `p2_kcpt_orbit_temporal_factor_no_go_2026_06_06.py` runs `PASS=26 FAIL=0`. The other two (`frontier_hierarchy_b3_staggered_supplier_cascade_2026_06_17.py`, `magnitude_temporal_factor_is_count_not_rate_2026_06_06.py`) abort before any check on a missing untracked `docs/audit/data/audit_ledger.json` — a pre-existing condition on `origin/main`, unaffected by this change.

No note edit: the note's stated expectation is `PASS=N FAIL=0` with `N ≥ 50`, still satisfied, and leaving the note untouched keeps the dependency graph unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)