### PR TITLE
fix(runner): unclip hierarchy fourth-root runner stdout across all modes

### DIFF
--- a/logs/runner-cache/frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.txt
+++ b/logs/runner-cache/frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.txt
@@ -1,26 +1,22 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.py
-runner_sha256: c64afa659936b1af48ce54303d5f504c6e2c31b46c94d2f89c412d3e44799a85
+runner_sha256: 457f2d4d409674ff3ec478200429beebc8b206b88ccf6cb002be4adc11ef723d
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.40
+elapsed_sec: 0.68
 status: ok
 ----- stdout -----
-========================================================================================
 frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.py
 mode=all
 exact A-C theorem; exponent-only D with supplied kappa/sign boundary
-========================================================================================
 
-----------------------------------------------------------------------------------------
-NORMAL: exact theorem and conditional-map reconstruction
-----------------------------------------------------------------------------------------
+-- NORMAL: exact theorem and conditional-map reconstruction
   [PASS][A][theorem] exact real domain of the eta/zeta base is 0 < 1-2^(1-s) < 1 for s>1  (positive domain=Interval.open(1, oo); below-one domain=Reals; g(2)=1/sqrt(2); s=4 base -> 7/8)
-  [PASS][A][theorem] odd/even series split has zero eta/zeta closed-form residual  (residual = 0)
+  [PASS][A][theorem] odd/even series split has zero eta/zeta closed-form residual
   [PASS][A][theorem] Taylor-coefficient comparison has a positive induction certificate  (R_1=s_i + 2; R_(k+1)-2R_k=s_i; decomposition residual=0)
-  [PASS][A][theorem] log g(s) tends to zero, so g(s) tends to one  (lim log(g) = 0)
-  [PASS][A][theorem] the exact target base at s=4 is 7/8  (1 - 2^(-3) = 7/8)
-  [PASS][A][conditional] mass-dimension equation d*p=1 has exponent p=1/d  (solutions = [1/d])
+  [PASS][A][theorem] log g(s) tends to zero, so g(s) tends to one
+  [PASS][A][theorem] the exact target base at s=4 is 7/8
+  [PASS][A][conditional] mass-dimension equation d*p=1 has exponent p=1/d
   [PASS][A][conditional] all supplied dimensionless coefficients share zero dimension residual at p=1/d  (cases=24, residual set={Fraction(0, 1)})
   [PASS][A][boundary] distinct positive dimensionless coefficients remain covariant and give distinct scales  (at |f|=16: values=[2/3, 5])
   [PASS][A][boundary] finite-kappa p=1/d family extends to M(0)=0 for d>0  (cases=12, values={0})
@@ -28,9 +24,7 @@ NORMAL: exact theorem and conditional-map reconstruction
   [PASS][A][conditional] fully supplied coefficient, magnitude rule, carrier, and value close the map conditionally  (conditions=['carrier', 'coefficient', 'magnitude_convention', 'value']; M=3)
   [PASS][A][numerical] high-precision integer sweep supports monotonicity and the unique s=4 hit  (sweep=2..50, hits=[4], g(50)=0.9999999999999999644728632119949597830963019573947234663712291995423064)
 
-----------------------------------------------------------------------------------------
-INDEPENDENT: derivative, rational brackets, and unit covariance
-----------------------------------------------------------------------------------------
+-- INDEPENDENT: derivative, rational brackets, and unit covariance
   [PASS][A][theorem] independent derivative is strictly positive on the exact real domain s>1  (formula residual=0; x/(1-x)>0 and -log(1-x)>0 on Interval.open(0, 1); 0<x<1 exactly when s>1)
   [PASS][A][numerical] derivative samples support but do not carry the real-domain proof  (sampled minimum=1.1093706427202413827662059145992089826883564814040E-32)
   [PASS][A][numerical] independent rigorous eta/zeta partial-sum brackets contain every exact ratio  (s=2..8, max width=2.261e-05)
@@ -39,38 +33,32 @@ INDEPENDENT: derivative, rational brackets, and unit covariance
   [PASS][A][conditional] exact positive unit rescalings reproduce M -> lambda M for several d and lambda  (residuals={0}, cases=24)
   [PASS][A][boundary] absolute-value route is real nonnegative where naive signed roots are not magnitudes  ((-16)^(1/4)=2*(-1)**(1/4); |−16|^(1/4)=2; real_root(-8,3)=-2)
 
-----------------------------------------------------------------------------------------
-HOSTILE: reject sign, normalization, domain, and inference overreads
-----------------------------------------------------------------------------------------
-  [PASS][A][boundary] d <= 0 is rejected by the positive mass-dimension theorem domain  (issues=[['invalid_dimension'], ['invalid_dimension'], ['invalid_dimension']])
+-- HOSTILE: reject sign, normalization, domain, and inference overreads
+  [PASS][A][boundary] d <= 0 is rejected by the positive mass-dimension theorem domain
   [PASS][A][boundary] p != 1/d produces a nonzero dimension residual  (residual=1/3, issues=['dimension_covariance_failure', 'wrong_exponent'])
   [PASS][A][boundary] a dimensionful kappa violates the stated dimensionless-coefficient map class  (residual=1/2, issues=['dimension_covariance_failure', 'dimensionful_kappa'])
-  [PASS][A][boundary] negative f with even d rejects the naive real-positive root  (issues=['nonreal_even_root'])
-  [PASS][A][boundary] negative f with odd d has a signed root, not a nonnegative magnitude  (issues=['signed_not_magnitude'], root=-2)
-  [PASS][A][boundary] unit coefficient is rejected when kappa=1 was not supplied  (issues=['unsupplied_coefficient'])
-  [PASS][A][boundary] an alternate coefficient is also rejected when it was not supplied  (issues=['unsupplied_coefficient'])
-  [PASS][A][boundary] a negative coefficient is rejected for a nonnegative magnitude map  (issues=['negative_magnitude_coefficient'])
+  [PASS][A][boundary] negative f with even d rejects the naive real-positive root
+  [PASS][A][boundary] negative f with odd d has a signed root, not a nonnegative magnitude
+  [PASS][A][boundary] unit coefficient is rejected when kappa=1 was not supplied
+  [PASS][A][boundary] an alternate coefficient is also rejected when it was not supplied
+  [PASS][A][boundary] a negative coefficient is rejected for a nonnegative magnitude map
   [PASS][A][boundary] the hostile evaluator preserves a challenged exponent instead of hard-coding 1/d  (M=3*3**(1/3))
-  [PASS][A][boundary] singleton witnesses refute every directed implication among the four supplied conditions  (witnesses={'coefficient': ['coefficient'], 'magnitude_convention': ['magnitude_convention'], 'carrier': ['carrier'], 'value': ['value']})
-  [PASS][A][boundary] physical-value inference is rejected without a carrier and value for f  (issues=['unsupported_physical_inference'])
+  [PASS][A][boundary] singleton witnesses refute every directed implication among the four supplied conditions
+  [PASS][A][boundary] physical-value inference is rejected without a carrier and value for f
   [PASS][A][boundary] kappa=0 is covariant for multiple wrong exponents and cannot witness exponent uniqueness  (tested residuals={0}, cases=9)
 
-----------------------------------------------------------------------------------------
-HYGIENE: source metadata, links, and overread guards
-----------------------------------------------------------------------------------------
-  [PASS][B][hygiene] source note has one explicit positive_theorem author hint  (parsed claim types=['positive_theorem'])
-  [PASS][B][hygiene] cross-cycle echoes are provenance-only conventions or a units-only primitive  (Y0/g0 are provenance-only; scale reference is units-only)
+-- HYGIENE: source metadata, links, and overread guards
+  [PASS][B][hygiene] source note has one explicit positive_theorem author hint
+  [PASS][B][hygiene] cross-cycle echoes are provenance-only conventions or a units-only primitive
   [PASS][B][hygiene] N1-N8 packet has current-cycle markers, all directed N2 pairs, and concrete N8 paths  (headings=True; N1 attempted=6; N2 directed pairs=12; N8 paths=2)
   [PASS][B][hygiene] every local markdown link in the source note resolves to a file  (local links=['../scripts/frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.py'])
-  [PASS][B][hygiene] source note contains no bare M=f^(1/d) or unique-map normalization overread  (bare-map hits=0, unique-map hits=0)
-  [PASS][B][hygiene] source rhetoric does not promote coefficient, physical-value, or empirical authority  (hits={'unique_unit_normalization': 0, 'physical_mass_prediction': 0, 'dimensions_select_kappa': 0})
+  [PASS][B][hygiene] source note contains no bare M=f^(1/d) or unique-map normalization overread
+  [PASS][B][hygiene] source rhetoric does not promote coefficient, physical-value, or empirical authority
 
-========================================================================================
 EVIDENCE: theorem=7 conditional=4 numerical=3 boundary=17 hygiene=6
 CLASSES: A=31 B=6 C=0 D=0
 MODES: hostile=12 hygiene=6 independent=7 normal=12
 SUMMARY: PASS=37 FAIL=0
-========================================================================================
 
 ----- stderr -----
 

--- a/scripts/frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.py
+++ b/scripts/frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.py
@@ -68,8 +68,16 @@ def check(
     condition: object,
     detail: str = "",
     klass: str = "A",
+    fail_detail: str = "",
 ) -> bool:
-    """Record one computed check without relying on Python assert."""
+    """Record one computed check without relying on Python assert.
+
+    ``detail`` always prints. ``fail_detail`` carries the diagnostics that only
+    restate a value already asserted in this check's own label, so they print
+    on FAIL and are suppressed on PASS; the cached stdout of this runner has to
+    fit inside the audit packet's 6000-character budget, and no check line, no
+    class tag, and no failure diagnostic is dropped by that suppression.
+    """
 
     global PASS_COUNT, FAIL_COUNT
     ok = bool(condition)
@@ -81,13 +89,14 @@ def check(
         MODE_COUNTS[mode] += 1
     else:
         FAIL_COUNT += 1
-    suffix = f"  ({detail})" if detail else ""
+    parts = [part for part in (detail, "" if ok else fail_detail) if part]
+    suffix = f"  ({'; '.join(parts)})" if parts else ""
     print(f"  [{tag}][{klass}][{evidence}] {label}{suffix}")
     return ok
 
 
 def section(title: str) -> None:
-    print(f"\n{'-' * 88}\n{title}\n{'-' * 88}")
+    print(f"\n-- {title}")
 
 
 def closed_ratio(s: int) -> Fraction:
@@ -223,7 +232,7 @@ def normal_mode() -> None:
         "theorem",
         "odd/even series split has zero eta/zeta closed-form residual",
         split_residual == 0,
-        detail=f"residual = {split_residual}",
+        fail_detail=f"residual = {split_residual}",
     )
 
     s_i, k_i = sp.symbols("s_i k_i", positive=True, integer=True)
@@ -256,7 +265,7 @@ def normal_mode() -> None:
         "theorem",
         "log g(s) tends to zero, so g(s) tends to one",
         log_limit == 0,
-        detail=f"lim log(g) = {log_limit}",
+        fail_detail=f"lim log(g) = {log_limit}",
     )
 
     value_at_four = closed_ratio(4)
@@ -265,7 +274,7 @@ def normal_mode() -> None:
         "theorem",
         "the exact target base at s=4 is 7/8",
         value_at_four == Fraction(7, 8),
-        detail=f"1 - 2^(-3) = {value_at_four}",
+        fail_detail=f"1 - 2^(-3) = {value_at_four}",
     )
 
     d, p = sp.symbols("d p", positive=True)
@@ -275,7 +284,7 @@ def normal_mode() -> None:
         "conditional",
         "mass-dimension equation d*p=1 has exponent p=1/d",
         exponent_solutions == [1 / d],
-        detail=f"solutions = {exponent_solutions}",
+        fail_detail=f"solutions = {exponent_solutions}",
     )
 
     valid_cases = [
@@ -499,7 +508,7 @@ def hostile_mode() -> None:
         "boundary",
         "d <= 0 is rejected by the positive mass-dimension theorem domain",
         all(case.issues() == {"invalid_dimension"} for case in invalid_dimensions),
-        detail=f"issues={[sorted(case.issues()) for case in invalid_dimensions]}",
+        fail_detail=f"issues={[sorted(case.issues()) for case in invalid_dimensions]}",
     )
 
     wrong_exponent = ScaleMapCase(d=4, p=Fraction(1, 3))
@@ -545,7 +554,7 @@ def hostile_mode() -> None:
         "boundary",
         "negative f with even d rejects the naive real-positive root",
         "nonreal_even_root" in negative_even.issues(),
-        detail=f"issues={sorted(negative_even.issues())}",
+        fail_detail=f"issues={sorted(negative_even.issues())}",
     )
 
     negative_odd = ScaleMapCase(
@@ -560,7 +569,7 @@ def hostile_mode() -> None:
         "negative f with odd d has a signed root, not a nonnegative magnitude",
         "signed_not_magnitude" in negative_odd.issues()
         and sp.real_root(-8, 3) < 0,
-        detail=f"issues={sorted(negative_odd.issues())}, root={sp.real_root(-8, 3)}",
+        fail_detail=f"issues={sorted(negative_odd.issues())}, root={sp.real_root(-8, 3)}",
     )
 
     unit_coefficient = ScaleMapCase(
@@ -574,7 +583,7 @@ def hostile_mode() -> None:
         "boundary",
         "unit coefficient is rejected when kappa=1 was not supplied",
         "unsupplied_coefficient" in unit_coefficient.issues(),
-        detail=f"issues={sorted(unit_coefficient.issues())}",
+        fail_detail=f"issues={sorted(unit_coefficient.issues())}",
     )
 
     alternate_unsupplied = ScaleMapCase(
@@ -588,7 +597,7 @@ def hostile_mode() -> None:
         "boundary",
         "an alternate coefficient is also rejected when it was not supplied",
         "unsupplied_coefficient" in alternate_unsupplied.issues(),
-        detail=f"issues={sorted(alternate_unsupplied.issues())}",
+        fail_detail=f"issues={sorted(alternate_unsupplied.issues())}",
     )
 
     negative_coefficient = ScaleMapCase(
@@ -602,7 +611,7 @@ def hostile_mode() -> None:
         "a negative coefficient is rejected for a nonnegative magnitude map",
         "negative_magnitude_coefficient" in negative_coefficient.issues()
         and negative_coefficient.magnitude_value() < 0,
-        detail=f"issues={sorted(negative_coefficient.issues())}",
+        fail_detail=f"issues={sorted(negative_coefficient.issues())}",
     )
 
     challenged_power = ScaleMapCase(
@@ -662,7 +671,7 @@ def hostile_mode() -> None:
             case.supplied_conditions() == {name}
             for name, case in condition_witnesses.items()
         ),
-        detail=(
+        fail_detail=(
             "witnesses="
             + str(
                 {
@@ -685,7 +694,7 @@ def hostile_mode() -> None:
         "boundary",
         "physical-value inference is rejected without a carrier and value for f",
         "unsupported_physical_inference" in physical_inference.issues(),
-        detail=f"issues={sorted(physical_inference.issues())}",
+        fail_detail=f"issues={sorted(physical_inference.issues())}",
     )
 
     zero_map_covariance = []
@@ -718,7 +727,7 @@ def hygiene_mode() -> None:
         "hygiene",
         "source note has one explicit positive_theorem author hint",
         claim_types == ["positive_theorem"],
-        detail=f"parsed claim types={claim_types}",
+        fail_detail=f"parsed claim types={claim_types}",
         klass="B",
     )
 
@@ -744,7 +753,7 @@ def hygiene_mode() -> None:
         and "vacuous rescaling convention"
         in conventions.get("g_bare_rigidity_theorem_note", {}).get("class", "")
         and re.search(r"zero\s+dimensionless\s+content", scale_text) is not None,
-        detail="Y0/g0 are provenance-only; scale reference is units-only",
+        fail_detail="Y0/g0 are provenance-only; scale reference is units-only",
         klass="B",
     )
 
@@ -810,7 +819,7 @@ def hygiene_mode() -> None:
         "hygiene",
         "source note contains no bare M=f^(1/d) or unique-map normalization overread",
         not bare_map_hits and not unique_map_hits,
-        detail=f"bare-map hits={len(bare_map_hits)}, unique-map hits={len(unique_map_hits)}",
+        fail_detail=f"bare-map hits={len(bare_map_hits)}, unique-map hits={len(unique_map_hits)}",
         klass="B",
     )
 
@@ -827,7 +836,7 @@ def hygiene_mode() -> None:
         "hygiene",
         "source rhetoric does not promote coefficient, physical-value, or empirical authority",
         all(not hits for hits in forbidden_inferences.values()),
-        detail=f"hits={inference_hit_counts}",
+        fail_detail=f"hits={inference_hit_counts}",
         klass="B",
     )
 
@@ -844,11 +853,9 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    print("=" * 88)
     print("frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.py")
     print(f"mode={args.mode}")
     print("exact A-C theorem; exponent-only D with supplied kappa/sign boundary")
-    print("=" * 88)
 
     if args.mode in ("normal", "all"):
         normal_mode()
@@ -858,7 +865,7 @@ def main() -> int:
         hostile_mode()
     hygiene_mode()
 
-    print(f"\n{'=' * 88}")
+    print()
     print(
         "EVIDENCE: "
         + " ".join(
@@ -872,7 +879,6 @@ def main() -> int:
     )
     print("MODES: " + " ".join(f"{name}={count}" for name, count in sorted(MODE_COUNTS.items())))
     print(f"SUMMARY: PASS={PASS_COUNT} FAIL={FAIL_COUNT}")
-    print("=" * 88)
     return 0 if FAIL_COUNT == 0 else 1
 
 


### PR DESCRIPTION
The audit row
hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow_theorem_note_2026-05-10
(fanout 744) is held at audited_conditional on evidence completeness alone:

  "the supplied runner stdout is clipped and omits part of the load-bearing
   execution record ... Repair target: provide complete SHA-pinned stdout for
   all modes or an equivalent complete current-cycle certificate."

The restricted packet renders at most 6,000 characters of runner-cache body; the
committed body was 8,163. Printing-only compaction brings it to 5,570, so the
default mode=all record - which covers every load-bearing execution of the
normal, independent, and hostile modes - renders complete.

- check() gains a fail_detail parameter; PASS shows detail, FAIL shows both.
  16 call-site details that restated their own label are rerouted to
  fail_detail=, applied by an assert-guarded script rather than a blind sed.
- section() reduced to a single "-- <title>" line; 4 rules of "=" * 88 removed.

No numerical logic, tolerance, assertion, check count, or ordering is touched.
Verified by an AST-level comparison against origin/main with string literals and
print statements normalized away: the only structural differences are the
check()/section() bodies and the detail=/fail_detail= keyword renames.

Runner re-run here in every mode: exit 0 throughout; default 37 [PASS] / 0
[FAIL] with "SUMMARY: PASS=37 FAIL=0" byte-identical, --mode normal PASS=18,
--mode independent PASS=13, --mode hostile PASS=18. Cache regenerated at the
standard relative path and timeout_sec 120; runner_sha256 matches the on-disk
file and the fresh stdout is contained in the cache body.

The source note is unedited, so note_hash and the dependency graph are
unchanged. No sibling runner references this note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
