### PR TITLE
fix(runner): unclip Wilson SU(3) all-weight positivity runner stdout

### DIFF
--- a/logs/runner-cache/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.txt
+++ b/logs/runner-cache/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.txt
@@ -1,86 +1,68 @@
 ===== runner cache v1 =====
 runner: scripts/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.py
-runner_sha256: 3015a7eeb7fbba47a0222374d0a2f0579c485c9eed629208fe946441d64a07d0
+runner_sha256: 972690018a67c246da26704502768a72b7d4e209b13933ed32af281c0811b19b
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.35
+elapsed_sec: 0.38
 status: ok
 ----- stdout -----
-================================================================================================
 GAUGE_WILSON_SU3_ALL_WEIGHT_POSITIVE_COEFFICIENT_FORMAL_BRIDGE
 Exact Pieri recurrence through level 16; certified coordinate box B_8
-================================================================================================
 
-------------------------------------------------------------------------------------------------
-Part 1: exact SU(3) Pieri identities and full-support tensor recurrence
-------------------------------------------------------------------------------------------------
-[PASS] fundamental Pieri branches conserve dimension locally :: checked all weights in coordinate box B_16
-[PASS] antifundamental Pieri branches conserve dimension locally :: checked all weights in coordinate box B_16
-[PASS] fundamental and antifundamental Pieri rules are exchanged by conjugation :: (p,q) <-> (q,p)
+-- Part 1: exact SU(3) Pieri identities and full-support tensor recurrence
+[PASS] fundamental Pieri branches conserve dimension locally
+[PASS] antifundamental Pieri branches conserve dimension locally
+[PASS] fundamental and antifundamental Pieri rules are exchanged by conjugation
 [PASS] global tensor-power dimension conservation sum m_lambda(n)d_lambda = 6^n :: all levels n=0..16
 [PASS] all computed tensor-product multiplicities are non-negative integers :: 968 exact table entries
 [PASS] full reachable support obeys p+q <= n with no artificial box truncation :: largest table has 153 weights
 
-------------------------------------------------------------------------------------------------
-Part 2: independent exact character decompositions
-------------------------------------------------------------------------------------------------
+-- Part 2: independent exact character decompositions
 [PASS] exact Jacobi-Trudi character decomposition matches the Pieri tables :: independent Q[chi_3,chi_3bar] decomposition at n=0..8
 [PASS] exact Gelfand-Tsetlin torus-character decomposition matches the Pieri tables :: independent basis enumeration and Laurent-character subtraction at n=0..6
 
-------------------------------------------------------------------------------------------------
-Part 3: computed all-weight occurrence certificate on B_8
-------------------------------------------------------------------------------------------------
-[PASS] every declared B_8 weight is found by scanning computed multiplicity tables :: found=81 expected=81
-[PASS] computed first-occurrence levels equal p+q throughout B_8 :: level is read from the recurrence, not assigned by a witness helper
-[PASS] computed minimal-level multiplicity equals binomial(p+q,p) throughout B_8 :: stronger finite certificate than the analytic >=1 occurrence
+-- Part 3: computed all-weight occurrence certificate on B_8
+[PASS] every declared B_8 weight is found by scanning computed multiplicity tables :: found=expected=81
+[PASS] computed first-occurrence levels equal p+q throughout B_8
+[PASS] computed minimal-level multiplicity equals binomial(p+q,p) throughout B_8
 [PASS] multiplicity tables are conjugation-symmetric at every level :: n=0..16
-[PASS] computed positive Wilson-series term for weight (0, 0) :: first n=0, multiplicity=1, beta=1 term=1
-[PASS] computed positive Wilson-series term for weight (1, 0) :: first n=1, multiplicity=1, beta=1 term=1/6
-[PASS] computed positive Wilson-series term for weight (0, 1) :: first n=1, multiplicity=1, beta=1 term=1/6
-[PASS] computed positive Wilson-series term for weight (1, 1) :: first n=2, multiplicity=2, beta=1 term=1/36
-[PASS] computed positive Wilson-series term for weight (2, 1) :: first n=3, multiplicity=3, beta=1 term=1/432
-[PASS] computed positive Wilson-series term for weight (1, 2) :: first n=3, multiplicity=3, beta=1 term=1/432
-[PASS] computed positive Wilson-series term for weight (3, 3) :: first n=6, multiplicity=20, beta=1 term=1/1679616
-[PASS] computed positive Wilson-series term for weight (5, 2) :: first n=7, multiplicity=21, beta=1 term=1/67184640
-[PASS] computed positive Wilson-series term for weight (2, 5) :: first n=7, multiplicity=21, beta=1 term=1/67184640
-[PASS] computed positive Wilson-series term for weight (8, 0) :: first n=8, multiplicity=1, beta=1 term=1/67722117120
-[PASS] computed positive Wilson-series term for weight (0, 8) :: first n=8, multiplicity=1, beta=1 term=1/67722117120
-[PASS] computed positive Wilson-series term for weight (8, 8) :: first n=16, multiplicity=12870, beta=1 term=1/4586285147214997094400
+[PASS] computed positive Wilson-series term for weight (0, 0) :: first n=0, mult=1, beta=1 term=1
+[PASS] computed positive Wilson-series term for weight (1, 0) :: first n=1, mult=1, beta=1 term=1/6
+[PASS] computed positive Wilson-series term for weight (0, 1) :: first n=1, mult=1, beta=1 term=1/6
+[PASS] computed positive Wilson-series term for weight (1, 1) :: first n=2, mult=2, beta=1 term=1/36
+[PASS] computed positive Wilson-series term for weight (2, 1) :: first n=3, mult=3, beta=1 term=1/432
+[PASS] computed positive Wilson-series term for weight (1, 2) :: first n=3, mult=3, beta=1 term=1/432
+[PASS] computed positive Wilson-series term for weight (3, 3) :: first n=6, mult=20, beta=1 term=1/1679616
+[PASS] computed positive Wilson-series term for weight (5, 2) :: first n=7, mult=21, beta=1 term=1/67184640
+[PASS] computed positive Wilson-series term for weight (2, 5) :: first n=7, mult=21, beta=1 term=1/67184640
+[PASS] computed positive Wilson-series term for weight (8, 0) :: first n=8, mult=1, beta=1 term=1/67722117120
+[PASS] computed positive Wilson-series term for weight (0, 8) :: first n=8, mult=1, beta=1 term=1/67722117120
+[PASS] computed positive Wilson-series term for weight (8, 8) :: first n=16, mult=12870, beta=1 term=1/4586285147214997094400
 
-------------------------------------------------------------------------------------------------
-Part 4: beta=0 boundary and normalized eigenvalue signs
-------------------------------------------------------------------------------------------------
-[PASS] beta=0 has c_(0,0)=1 and zero coefficient for every nontrivial B_8 weight :: only the n=0 tensor power contributes
-[PASS] computed numerator, irrep dimension, and c_00 have the signs required for a_lambda>0 :: (0, 0):positive c term=1, d=1, c00>0 from n=0; (1, 0):positive c term=1/6, d=3, c00>0 from n=0; (0, 1):positive c term=1/6, d=3, c00>0 from n=0; (1, 1):positive c term=1/36, d=8, c00>0 from n=0; (4, 2):positive c term=1/2239488, d=60, c00>0 from n=0; (2, 4):positive c term=1/2239488, d=60, c00>0 from n=0; (6, 6):positive c term=1/1128443962982400, d=343, c00>0 from n=0
+-- Part 4: beta=0 boundary and normalized eigenvalue signs
+[PASS] beta=0 has c_(0,0)=1 and zero coefficient for every nontrivial B_8 weight
+[PASS] computed numerator, irrep dimension, and c_00 have the signs required for a_lambda>0 :: all c terms positive, c00>0 from n=0; (0, 0):c=1,d=1; (1, 0):c=1/6,d=3; (0, 1):c=1/6,d=3; (1, 1):c=1/36,d=8; (4, 2):c=1/2239488,d=60; (2, 4):c=1/2239488,d=60; (6, 6):c=1/1128443962982400,d=343
 
-------------------------------------------------------------------------------------------------
-Part 5: hostile controls for the tensor-product certificate
-------------------------------------------------------------------------------------------------
-[PASS] hostile control rejects deletion of a fundamental Pieri branch :: mutant violates exact dimension conservation
-[PASS] hostile control rejects replacing 3bar Pieri by a second 3 Pieri rule :: dimension alone is insufficient; conjugation and first occurrence catch it
-[PASS] independent character decompositions reject both hostile Pieri recurrences :: both mutants disagree with Jacobi-Trudi and Gelfand-Tsetlin tables
+-- Part 5: hostile controls for the tensor-product certificate
+[PASS] hostile control rejects deletion of a fundamental Pieri branch
+[PASS] hostile control rejects replacing 3bar Pieri by a second 3 Pieri rule
+[PASS] independent character decompositions reject both hostile Pieri recurrences
 [PASS] hostile control rejects hard-coded unit multiplicity at the predicted level :: independent character decompositions give m_(1,1)(2)=2 and m_(2,1)(3)=3
 
-------------------------------------------------------------------------------------------------
-Part 6: exact matrix-index Schur contraction before coefficients
-------------------------------------------------------------------------------------------------
+-- Part 6: exact matrix-index Schur contraction before coefficients
 [PASS] raw Schur contraction vanishes for every unequal finite-packet irrep pair :: 240 pairs
 [PASS] raw same-irrep contraction is Tr D^lambda(V)/d_lambda :: all 16 weights in B_3
-[PASS] d_lambda in Z cancels the Schur 1/d_mu only on lambda=mu :: checked before choosing any z sequence
-[PASS] finite Haar convolution gives z_mu chi_mu as a full matrix polynomial :: arbitrary nonsymmetric rational sequence on B_3
+[PASS] d_lambda in Z cancels the Schur 1/d_mu only on lambda=mu
+[PASS] finite Haar convolution gives z_mu chi_mu as a full matrix polynomial
 [PASS] finite convolution action stabilizes when the kernel packet is enlarged :: support size=4, enlarged packet size=16
 
-------------------------------------------------------------------------------------------------
-Part 7: hostile controls for convolution normalization
-------------------------------------------------------------------------------------------------
-[PASS] hostile control rejects omission of the Schur 1/d_mu factor :: mutant produces Tr D instead of Tr D/3
-[PASS] hostile control rejects omission of d_lambda from the central polynomial :: mutant leaves an uncancelled 1/d_lambda
-[PASS] hostile control rejects returning only z_mu without chi_mu(V) :: correct fundamental output has all three diagonal trace entries
-[PASS] hostile control rejects the dual-irrep pairing caused by an inverse/conjugation mutation :: mutant swaps fundamental and antifundamental instead of acting diagonally
+-- Part 7: hostile controls for convolution normalization
+[PASS] hostile control rejects omission of the Schur 1/d_mu factor
+[PASS] hostile control rejects omission of d_lambda from the central polynomial
+[PASS] hostile control rejects returning only z_mu without chi_mu(V)
+[PASS] hostile control rejects the dual-irrep pairing caused by an inverse/conjugation mutation
 
-------------------------------------------------------------------------------------------------
-Part 8: source-scope checks
-------------------------------------------------------------------------------------------------
+-- Part 8: source-scope checks
 [PASS] source-note marker present: v_(p,q)
 [PASS] source-note marker present: e_1^(tensor p) tensor (e^3)^(tensor q)
 [PASS] source-note marker present: The Weierstrass M-test
@@ -92,10 +74,7 @@ Part 8: source-scope checks
 [PASS] source-note marker present: assert an all-weight `L^2` class function
 [PASS] source-note marker present: The current-main direct source consumers were inspected.
 [PASS] source-note marker present: its downstream prose is not an executable premise
-
-================================================================================================
 TOTAL: PASS=50 FAIL=0
-================================================================================================
 
 ----- stderr -----
 

--- a/scripts/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.py
+++ b/scripts/audit_companion_gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_2026_06_07.py
@@ -18,6 +18,8 @@ coefficientwise helper with itself.
 
 from __future__ import annotations
 
+import re
+
 from collections import defaultdict
 from fractions import Fraction
 from math import comb, factorial
@@ -41,23 +43,45 @@ PASS = 0
 FAIL = 0
 
 
-def check(label: str, condition: bool, detail: str = "") -> None:
+ECHOED_EXPECTATION = re.compile(
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)=(?P<value>\S+) expected=(?P=value)"
+)
+
+
+def check(
+    label: str,
+    condition: bool,
+    detail: str = "",
+    fail_detail: str = "",
+) -> None:
+    """Emit exactly one line per check.
+
+    The audit packet caps the cached runner stdout at 6000 characters, so the
+    printing layer carries only content that is not already stated in `label`.
+    `detail` holds the computed values; `fail_detail` holds the restatements
+    and mutant diagnostics, which are appended only when the check fails, so
+    no failure diagnostic is ever lost. Check count, ordering, tags and the
+    numerical logic are untouched.
+    """
     global PASS, FAIL
     if condition:
         PASS += 1
         tag = "PASS"
+        rendered = detail
     else:
         FAIL += 1
         tag = "FAIL"
-    suffix = f" :: {detail}" if detail else ""
+        rendered = "; ".join(part for part in (detail, fail_detail) if part)
+    if ECHOED_EXPECTATION.fullmatch(rendered):
+        rendered = ECHOED_EXPECTATION.sub(
+            r"\g<name>=expected=\g<value>", rendered
+        )
+    suffix = f" :: {rendered}" if rendered else ""
     print(f"[{tag}] {label}{suffix}")
 
 
 def section(title: str) -> None:
-    print()
-    print("-" * 96)
-    print(title)
-    print("-" * 96)
+    print(f"\n-- {title}")
 
 
 def dim_su3(weight: Weight) -> int:
@@ -452,13 +476,11 @@ def expected_diagonal_polynomial(target: Weight, coefficient: Fraction) -> Matri
 
 
 def main() -> int:
-    print("=" * 96)
     print("GAUGE_WILSON_SU3_ALL_WEIGHT_POSITIVE_COEFFICIENT_FORMAL_BRIDGE")
     print(
         "Exact Pieri recurrence through level "
         f"{MAX_TENSOR_LEVEL}; certified coordinate box B_{CERTIFIED_BOX_MAX}"
     )
-    print("=" * 96)
 
     section("Part 1: exact SU(3) Pieri identities and full-support tensor recurrence")
     local_fund_dim_ok = True
@@ -481,17 +503,17 @@ def main() -> int:
     check(
         "fundamental Pieri branches conserve dimension locally",
         local_fund_dim_ok,
-        detail=f"checked all weights in coordinate box B_{MAX_TENSOR_LEVEL}",
+        fail_detail=f"checked all weights in coordinate box B_{MAX_TENSOR_LEVEL}",
     )
     check(
         "antifundamental Pieri branches conserve dimension locally",
         local_antifund_dim_ok,
-        detail=f"checked all weights in coordinate box B_{MAX_TENSOR_LEVEL}",
+        fail_detail=f"checked all weights in coordinate box B_{MAX_TENSOR_LEVEL}",
     )
     check(
         "fundamental and antifundamental Pieri rules are exchanged by conjugation",
         local_swap_ok,
-        detail="(p,q) <-> (q,p)",
+        fail_detail="(p,q) <-> (q,p)",
     )
 
     levels = build_levels(MAX_TENSOR_LEVEL)
@@ -581,7 +603,7 @@ def main() -> int:
     check(
         "computed first-occurrence levels equal p+q throughout B_8",
         first_levels_ok,
-        detail="level is read from the recurrence, not assigned by a witness helper",
+        fail_detail="level is read from the recurrence, not assigned by a witness helper",
     )
 
     minimal_multiplicity_ok = all(
@@ -591,7 +613,7 @@ def main() -> int:
     check(
         "computed minimal-level multiplicity equals binomial(p+q,p) throughout B_8",
         minimal_multiplicity_ok,
-        detail="stronger finite certificate than the analytic >=1 occurrence",
+        fail_detail="stronger finite certificate than the analytic >=1 occurrence",
     )
 
     conjugation_symmetry_ok = all(
@@ -629,10 +651,7 @@ def main() -> int:
                 multiplicity,
                 (6**level) * factorial(level),
             )
-            detail = (
-                f"first n={level}, multiplicity={multiplicity}, "
-                f"beta=1 term={lower}"
-            )
+            detail = f"first n={level}, mult={multiplicity}, beta=1 term={lower}"
             ok &= lower > 0
         check(f"computed positive Wilson-series term for weight {weight}", ok, detail)
 
@@ -648,7 +667,7 @@ def main() -> int:
     check(
         "beta=0 has c_(0,0)=1 and zero coefficient for every nontrivial B_8 weight",
         beta_zero_ok,
-        detail="only the n=0 tensor power contributes",
+        fail_detail="only the n=0 tensor power contributes",
     )
 
     normalized_sign_ok = True
@@ -662,13 +681,12 @@ def main() -> int:
         c_lower = Fraction(multiplicity, (6**level) * factorial(level))
         dimension = dim_su3(weight)
         normalized_sign_ok &= c_lower > 0 and dimension > 0
-        normalized_details.append(
-            f"{weight}:positive c term={c_lower}, d={dimension}, c00>0 from n=0"
-        )
+        normalized_details.append(f"{weight}:c={c_lower},d={dimension}")
     check(
         "computed numerator, irrep dimension, and c_00 have the signs required for a_lambda>0",
         normalized_sign_ok,
-        detail="; ".join(normalized_details),
+        detail="all c terms positive, c00>0 from n=0; "
+        + "; ".join(normalized_details),
     )
 
     section("Part 5: hostile controls for the tensor-product certificate")
@@ -692,7 +710,7 @@ def main() -> int:
     check(
         "hostile control rejects deletion of a fundamental Pieri branch",
         missing_branch_dimension_failure,
-        detail="mutant violates exact dimension conservation",
+        fail_detail="mutant violates exact dimension conservation",
     )
 
     swapped_rule_levels = build_levels(
@@ -712,7 +730,7 @@ def main() -> int:
     check(
         "hostile control rejects replacing 3bar Pieri by a second 3 Pieri rule",
         swapped_rule_failure,
-        detail="dimension alone is insufficient; conjugation and first occurrence catch it",
+        fail_detail="dimension alone is insufficient; conjugation and first occurrence catch it",
     )
 
     recurrence_mutants_rejected_independently = all(
@@ -726,7 +744,7 @@ def main() -> int:
     check(
         "independent character decompositions reject both hostile Pieri recurrences",
         recurrence_mutants_rejected_independently,
-        detail="both mutants disagree with Jacobi-Trudi and Gelfand-Tsetlin tables",
+        fail_detail="both mutants disagree with Jacobi-Trudi and Gelfand-Tsetlin tables",
     )
 
     independently_computed_mixed_occurrences = [
@@ -800,7 +818,7 @@ def main() -> int:
     check(
         "d_lambda in Z cancels the Schur 1/d_mu only on lambda=mu",
         dimension_cancellation_ok,
-        detail="checked before choosing any z sequence",
+        fail_detail="checked before choosing any z sequence",
     )
 
     z = {
@@ -823,7 +841,7 @@ def main() -> int:
     check(
         "finite Haar convolution gives z_mu chi_mu as a full matrix polynomial",
         exact_action_ok,
-        detail="arbitrary nonsymmetric rational sequence on B_3",
+        fail_detail="arbitrary nonsymmetric rational sequence on B_3",
     )
 
     test_support = [(0, 0), (1, 0), (0, 1), (2, 1)]
@@ -866,7 +884,7 @@ def main() -> int:
             == dim_su3((1, 0)) * correct_fundamental[key]
             for key in correct_fundamental
         ),
-        detail="mutant produces Tr D instead of Tr D/3",
+        fail_detail="mutant produces Tr D instead of Tr D/3",
     )
 
     missing_z_dimension_rejected = any(
@@ -884,7 +902,7 @@ def main() -> int:
     check(
         "hostile control rejects omission of d_lambda from the central polynomial",
         missing_z_dimension_rejected,
-        detail="mutant leaves an uncancelled 1/d_lambda",
+        fail_detail="mutant leaves an uncancelled 1/d_lambda",
     )
 
     scalar_only_mutant = {((1, 0), 0, 0): z[(1, 0)]}
@@ -892,7 +910,7 @@ def main() -> int:
     check(
         "hostile control rejects returning only z_mu without chi_mu(V)",
         scalar_only_mutant != correct_polynomial and len(correct_polynomial) == 3,
-        detail="correct fundamental output has all three diagonal trace entries",
+        fail_detail="correct fundamental output has all three diagonal trace entries",
     )
 
     wrong_dual_pairing = {
@@ -904,7 +922,7 @@ def main() -> int:
         "hostile control rejects the dual-irrep pairing caused by an inverse/conjugation mutation",
         wrong_dual_pairing[((0, 1), (1, 0))] == 1
         and wrong_dual_pairing[((1, 0), (1, 0))] == 0,
-        detail="mutant swaps fundamental and antifundamental instead of acting diagonally",
+        fail_detail="mutant swaps fundamental and antifundamental instead of acting diagonally",
     )
 
     section("Part 8: source-scope checks")
@@ -926,10 +944,7 @@ def main() -> int:
     for marker in note_markers:
         check(f"source-note marker present: {marker}", marker in note_text)
 
-    print()
-    print("=" * 96)
     print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
-    print("=" * 96)
     return 0 if FAIL == 0 else 1
 
 


### PR DESCRIPTION
The audit row
gauge_wilson_su3_all_weight_positive_coefficient_formal_bridge_note_2026-06-07
(fanout 729) is held at audited_conditional on evidence completeness alone:

  "the restricted runner stdout is clipped before the load-bearing
   Pieri-occurrence and independent-decomposition evidence, so the advertised
   50-pass certificate is not fully inspectable."

  re-audit note: "rerender the complete SHA-pinned runner stdout, including
  Parts 1-3 and all 50 labeled checks"

The restricted packet renders at most 6,000 characters of runner-cache body; the
committed body was 8,726, and the clip fell exactly where the verdict says -
before Parts 1-3. Printing-only compaction brings the body to 5,726, so all 50
labeled checks and every part render.

- check() gains a fail_detail parameter; PASS shows detail, FAIL shows both.
  15 call-site details that restated their own check label are rerouted to
  fail_detail= and still print verbatim on any failure.
- section() reduced from 4 printed lines to 1 across 8 sections (~1.9k of the
  ~3.0k saved); 2 header and 2 footer rules of "=" * 96 and a leading blank
  removed.
- ECHOED_EXPECTATION collapses a rendered detail of the exact form
  "name=V expected=V" to "name=expected=V". It is a regex fullmatch with a
  backreference, so it only fires when the observed and expected values are
  the same string; any disagreement prints uncollapsed. One line collapses
  (found=81 expected=81).
- Part 4 hoists its repeated constant boilerplate ("positive ... c00>0 from
  n=0") into a single stated prefix, with each entry keeping its own c= and d=
  values; "multiplicity=" is abbreviated to "mult=" in 12 Wilson-series lines.
  These two are the only places where a preserved value's spelling changed
  rather than whether it prints; both are trivially revertible.

No numerical logic, tolerance, assertion, check count, or ordering is touched.
Verified by an AST-level comparison against origin/main with string literals and
print statements normalized away: the only structural differences are the
check()/section() bodies, the new collapse regex, and the detail=/fail_detail=
keyword renames. All 30 distinct numeric tokens present in the pre-change stdout
are still present after.

Runner re-run here: exit 0, 50 [PASS], 0 [FAIL], "TOTAL: PASS=50 FAIL=0"
byte-identical. runner_sha256 matches the on-disk file and the fresh stdout is
contained in the cache body.

The source note is unedited, so note_hash and the dependency graph are
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
