### PR TITLE
feat(kcpt): closed-form D2 commutant lifts and lattice-size independence

### DIFF
--- a/docs/KCPT_D2_COMMUTANT_CLOSED_FORM_LIFTS_AND_LATTICE_SIZE_INDEPENDENCE_BOUNDED_THEOREM_NOTE_2026-07-25.md
+++ b/docs/KCPT_D2_COMMUTANT_CLOSED_FORM_LIFTS_AND_LATTICE_SIZE_INDEPENDENCE_BOUNDED_THEOREM_NOTE_2026-07-25.md
@@ -1,0 +1,439 @@
+# KCPT D2 commutant closed-form lifts and lattice-size independence (L = 4, 6, 8, 10, 12) (bounded theorem)
+
+**Type:** bounded_theorem
+
+registry id: `kcpt_d2_commutant_closed_form_lifts_lattice_size_independence`
+
+**Primary runner:** `scripts/kcpt_d2_commutant_closed_form_lifts_lattice_size_independence_2026_07_25.py`
+
+## claim_scope
+
+- **Kind:** bounded_theorem. Exact integer signed-permutation algebra on the staggered
+  operator `D2` of the `L³` torus, at the five even sizes L ∈ {4, 6, 8, 10, 12}
+  (N = 64, 216, 512, 1000, 1728). The closed-form sign fields, the commutator signs, the
+  element orders, the 2-torsion quadratic form, the liftability of the 48 point-group
+  matrices, and the constructed element counts are exact integer facts at each of those
+  five sizes. The exhaustive commutant enumeration used as an independent anchor is run
+  at L ∈ {4, 6, 8, 10} only.
+- **Object:** the signed-permutation commutant
+  `Comm(D2) = { signed permutation U : U D2 = D2 U }` of the landed Unit 25 module; the
+  three closed-form translation lifts `t_nu = (x ↦ x + e_nu, zeta_nu)` with
+  `zeta_nu(x) = (-1)^{Σ_{mu > nu} x_mu}`; the commutator pairing `beta` they induce on
+  `T/2T` and the quadratic form `q` on the 2-torsion points `(L/2)v`; the constructive
+  lifts of the 48 hyperoctahedral matrices `B₃`; and the subgroup of `Comm(D2)` these
+  `96N` elements generate.
+- **Scope limits:** r-neutral. No physical, continuum, thermodynamic, flavour or
+  generation-counting claim is made; every quantity is an exact invariant of a finite
+  even-`L` construction. `L` even is required throughout for `zeta_nu` to be well defined
+  on `Z_L`. The equality `|Comm(D2)| = 96N` is established where the exhaustive
+  enumeration was actually run (L ∈ {4, 6, 8, 10}); at L = 12 the construction yields the
+  lower bound `|Comm(D2)| ≥ 96N` and nothing stronger.
+
+## 1. Objects and setup
+
+- Lattices L ∈ {4, 6, 8, 10, 12} on the `L³` torus with the staggered integer
+  antisymmetric adjacency `D2` of the landed Unit 25 lane: `eta_0(x) = 1`,
+  `eta_1(x) = (-1)^{x_0}`, `eta_2(x) = (-1)^{x_0+x_1}`, and explicitly
+  `D2[x, x+e_mu] = eta_mu(x)`, `D2[x, x-e_mu] = -eta_mu(x)`. The runner builds `D2` and
+  the support structures by calling the landed module (`build_lattice`,
+  `support_structures`); nothing about `D2` is re-implemented here.
+- An element of `Comm(D2)` is stored as `g = (p, s)` with `p` a length-`N` permutation of
+  the site basis and `s` a length-`N` sign array; the commutation condition is
+  `s_i s_j · D2[p_i, p_j] = D2[i, j]` for all `i, j`, and composition is
+  `compose(a, b) = (p_b[p_a], s_a · s_b[p_a])`. All group decisions in this unit are
+  exact integer arithmetic on those arrays; no floating tolerance enters anywhere.
+- Every prior unit in this lane read the structure of `Comm(D2)` off an EXHAUSTIVE
+  enumeration of the group, which is what capped the lane at L ∈ {4, 6}. This unit takes
+  that enumeration off the critical path: the translation lifts and the point-group lifts
+  are written down in closed form from the staggered phases, and the enumeration
+  (`enumerate_commutant`) is called only as an independent anchor at the sizes where it
+  still fits the memory budget.
+- The reference hyperoctahedral group `B₃` (order 48) is built independently inside this
+  runner as the 48 signed 3×3 permutation matrices (`itertools.permutations` of the three
+  axes times the eight sign patterns), so every point-group claim is checked against a
+  from-scratch object rather than against the enumerator.
+- What is new relative to the preceding restriction-localization unit
+  (`KCPT_D2_COMMUTANT_EXTENSION_TRANSLATION_LOCALIZATION_BOUNDED_THEOREM_NOTE_2026-07-25`)
+  is where `beta` comes from, and it should not be overstated. That unit obtained the
+  commutator pairing `beta` from the ENUMERATED group at L ∈ {4, 6} — measuring it, then
+  matching it uniquely against the 512 bimultiplicative candidates — and from `beta` it
+  DERIVED the 2-torsion form `q` by an argument this unit reuses unchanged. This unit
+  derives `beta` itself from the staggered phases, so the chain no longer passes through
+  an enumeration at any point, and the same `q` argument then runs at L ∈ {8, 10, 12}
+  where no enumeration is available. The increment is `beta`'s provenance and the
+  resulting reach, not a first derivation of `q`.
+
+## 2. Theorem claims
+
+**T1 (closed-form translation lift; gates G1_TRANSLIFT_L\*, G2_UNIQUE_L\*, G5A_FLIP_L\*,
+G5B_MASK_L\*).** For every even `L` and each `nu ∈ {0,1,2}` the signed permutation
+`t_nu = (x ↦ x + e_nu, zeta_nu)` with
+
+    zeta_nu(x) = (-1)^{ Σ_{mu > nu} x_mu }
+
+lies in `Comm(D2)`, and it is the unique lift of the translation permutation with
+`s(0) = +1`; hence that permutation has exactly two lifts, `±t_nu`.
+
+*Derivation.* Write `p_nu : x ↦ x + e_nu`. On the `mu`-edge at `x` the commutation
+condition `s_i s_j D2[p_i, p_j] = D2[i, j]` reads
+
+    s(x) · s(x+e_mu) · eta_mu(x+e_nu) = eta_mu(x),
+
+so `s(x) s(x+e_mu) = eta_mu(x) eta_mu(x+e_nu)` (signs are `±1`, so division is
+multiplication). The `-e_mu` edges give the same relation, because
+`D2[x, x-e_mu] = -eta_mu(x)` carries the minus on both sides. Now the staggered phases
+are *lower-triangular in the coordinates*: `eta_mu` depends only on `x_0, …, x_{mu-1}`.
+Therefore shifting the argument by `e_nu` changes `eta_mu` exactly when `nu < mu`:
+
+    eta_mu(x + e_nu) / eta_mu(x) = (-1)^{[nu < mu]}.
+
+Hence `s(x+e_mu)/s(x) = (-1)^{[nu < mu]}`: the sign field must flip across a `mu`-edge
+precisely when `mu > nu`, and be constant across the others. The field
+`zeta_nu(x) = (-1)^{Σ_{mu > nu} x_mu}` does exactly that, and it is well defined on `Z_L`
+precisely because `L` is even. Explicitly `zeta_0 = (-1)^{x_1 + x_2}`,
+`zeta_1 = (-1)^{x_2}`, `zeta_2 = +1`.
+
+*Uniqueness.* The nearest-neighbour support graph of `D2` is connected (gated: BFS from
+site 0 reaches all `N` sites at every `L` here), so the edge relations propagate `s` from
+`s(0)` along a spanning tree and determine it completely; the only freedom is the one
+global sign. The runner does not assume this — it runs the propagation from `s(0) = +1`
+independently of the closed form and checks that the propagated field equals `zeta_nu`
+site by site.
+
+*Discrimination.* Two wrong-value rejectors are run rather than an algebraic identity that
+would hold by construction. (a) Flipping the sign of `zeta_nu` at a SINGLE site breaks
+commutation: exhaustively over all `N` sites at L ∈ {4, 6} (192/192 and 648/648 failures
+over the three `nu`), and over a deterministic stride-`N//32` 32-site subset at
+L ∈ {8, 10, 12} (96/96 failures each). (b) Each of the 7 alternative exponent masks —
+every subset of `{0,1,2}` other than the correct `{mu : mu > nu}` — yields a sign field
+that fails commutation: 21/21 at every `L`, while the correct mask commutes 3/3. So the
+mask `{mu : mu > nu}` is singled out by the computation, not by fiat.
+
+**T2 (analytic commutator form; gates G4_BETA_L\*, G4X_LIFTPROD_L4, G4X_LIFTPROD_L6).**
+For all `a, b`,
+
+    [t_a, t_b] = (-1)^{1 - delta_ab} · I,
+
+i.e. the commutator is the central scalar `-1` whenever `a ≠ b` and `+1` when `a = b`. Its
+bimultiplicative extension to `T/2T ≅ F_2³` is
+
+    beta(s, t) = (-1)^{ (Σ s)(Σ t) - s·t }.
+
+*Derivation.* The two translation permutations commute, so `[t_a, t_b]` has trivial
+permutation part and its sign is a constant, obtained by comparing the two orders of
+transport: `t_a` translates by `e_a`, which multiplies `zeta_b` by
+`zeta_b(x+e_a)/zeta_b(x) = (-1)^{[a > b]}` (shifting by `e_a` flips `zeta_b` exactly when
+`a` lies in the mask `{mu : mu > b}`), and symmetrically `t_b` multiplies `zeta_a` by
+`(-1)^{[b > a]}`. The commutator sign is the product,
+
+    [t_a, t_b] = (-1)^{[a>b] + [b>a]} I = (-1)^{1 - delta_ab} I,
+
+since exactly one of `a > b`, `b > a` holds when `a ≠ b` and neither holds when `a = b`.
+Bimultiplicativity then gives, for `s = Σ s_a e_a` and `t = Σ t_b e_b`,
+`beta(s,t) = Π_{a,b} beta(e_a,e_b)^{s_a t_b} = (-1)^{Σ_{a≠b} s_a t_b}`, and
+`Σ_{a≠b} s_a t_b = (Σ s)(Σ t) - s·t`.
+
+This is the same form the preceding restriction-localization unit measured and identified
+at L ∈ {4, 6}: that unit obtained it from the enumerated group, and this unit derives it
+from the staggered phases. The runner does not take it on trust — it forms the nine
+ordered commutators from the ACTUAL closed-form lifts at every `L`, checks each is central
+(9/9) and matches the `a ≠ b` rule, checks the bimultiplicative extension against the
+closed formula on all 64 pairs of `F_2³` classes at every `L`, and at L ∈ {4, 6}
+additionally checks the extension against commutators of actual lift PRODUCTS for all
+8 × 8 class representatives (64/64 central, 64/64 matching).
+
+**T3 (order and 2-torsion; gates G6_ORDER_Q_L\*, XL_DICHOTOMY).** `(t_nu)^k` has sign
+field `zeta_nu^k`, so `t_nu` has order exactly `L` and `(t_nu)^L = +I`. On the 2-torsion
+points of `T`,
+
+    q((L/2) v) = (-1)^{ (L/2)² Σ_{i<j} v_i v_j },      v ∈ {0,1}³,
+
+giving a clean `L mod 4` dichotomy: `L ≡ 0 (mod 4)` ⇒ `q` is trivial on all 8 `v`;
+`L ≡ 2 (mod 4)` ⇒ `q = -I` on exactly the four `v` with at least two odd entries.
+
+*Derivation.* The mask `{mu : mu > nu}` does not contain `nu`, so `zeta_nu` is independent
+of `x_nu` and `zeta_nu(x + e_nu) = zeta_nu(x)`. Powering `t_nu` therefore accumulates no
+cocycle: `(t_nu)^k = (x ↦ x + k e_nu, zeta_nu^k)`. This is the identity exactly when both
+`k ≡ 0 (mod L)` and `zeta_nu^k ≡ +1`. Since `zeta_nu² = +1`, the second condition holds for
+every even `k`; it is a genuine extra requirement only for `nu ∈ {0, 1}`, where `zeta_nu` is
+a nonconstant character, and is vacuous for `nu = 2`, where `zeta_2 = +1` identically. Either
+way `L` is even, so `k = L` is the first such `k` for all three `nu`: the order is exactly
+`L`, with `(t_nu)^L = +I`. For the 2-torsion form,
+let `g_v = Π_nu (t_nu)^{(L/2) v_nu}`; squaring it and reordering the product to pair like
+factors costs one `beta` factor per transposed pair, while each like pair contributes
+`((t_a)^{L/2})² = (t_a)^L = +I`, leaving
+`q((L/2)v) = Π_{a<b} beta(e_a,e_b)^{(L/2)² v_a v_b} = (-1)^{(L/2)² Σ_{a<b} v_a v_b}`.
+The dichotomy is then arithmetic: `(L/2)²` is even iff `L ≡ 0 (mod 4)`; and for
+`L ≡ 2 (mod 4)`, `Σ_{a<b} v_a v_b` is odd exactly for the four `v` with two or three ones.
+
+*Measured `q = -I` sets.* The runner squares the ACTUAL half-power products and reads the
+central sign, then compares against the formula (8/8 agreement at every `L`). Measured:
+empty at L = 4, 8, 12; and `{(0,1,1), (1,0,1), (1,1,0), (1,1,1)}` at both L = 6 and
+L = 10 — the four points with at least two odd entries, exactly as the dichotomy predicts.
+Both branches are confirmed at a new size: L = 8 is the first check of the
+`L ≡ 0 (mod 4)` branch beyond the previously enumerable L ∈ {4, 6}, and L = 10 the first
+check of the `L ≡ 2 (mod 4)` branch beyond L = 6.
+
+**T4 (constructive point-group lifts; gates G7_B3_L\*, G8_SHEAR_L\*, G7E_ENUM_L\*).** At
+each `L ∈ {4, 6, 8, 10, 12}` and for every `A` in the 48-element hyperoctahedral group
+`B₃`, the permutation `x ↦ A x mod L` admits a consistent sign propagation over the
+support graph of `D2`, hence exactly two lifts `±`. Combined with T1 this constructs
+`2 · 48 · N = 96N` distinct elements of `Comm(D2)` at those five sizes, with NO
+enumeration. Unlike T1–T3 this claim is quantified over the sizes tested, not over all
+even `L` — see the derivation note below.
+
+*Derivation and check.* `A ∈ B₃` permutes the six directions `±e_mu` among themselves, so
+`x ↦ Ax` maps nearest-neighbour edges to nearest-neighbour edges and the support graph is
+preserved as a graph; the only question is whether the sign relation
+`s_j = s_i · D2[i,j] · D2[p_i,p_j]` is consistent around cycles. The runner propagates from
+`s(0) = +1` along the BFS spanning tree and then verifies the FULL commutation condition on
+all `N²` entries — a cycle inconsistency shows up either as a missing image edge during
+propagation or as a commutation failure afterwards. Result: 48/48 liftable at every
+L ∈ {4, 6, 8, 10, 12}, with 48 distinct permutation parts. Because the support graph is
+connected the kernel of the permutation-part map is `{±1}`, so each of the 48 has exactly
+two lifts; where the enumeration is available (L ∈ {4, 6, 8, 10}) this is confirmed
+directly by counting the enumerated elements over each constructed permutation part
+(48/48 with exactly two lifts each, and each constructed lift and its negative found in
+the enumerated key set).
+
+*Why T4 is size-quantified and T1–T3 are not.* T1 exhibits a closed-form sign field and
+verifies the edge condition symbolically for all even `L`; T2 and T3 follow from T1 by
+algebra with no size dependence. T4 has no counterpart closed form here: the
+cycle-consistency question is settled by the runner at five sizes rather than by an
+argument. The route to closing that is visible and is recorded in section 6 — the same
+edge condition used for T1, with the translation `p_nu` replaced by `x ↦ Ax`, is a linear
+system over `F₂` in the unknown sign field, and solving it in closed form for all 48 `A`
+would make T4 general-`L`. Until that is done, a reader should take T4 at the five sizes
+and nothing wider.
+
+*Discrimination.* The liftability claim would be vacuous if every integral lattice
+bijection lifted. The runner runs the explicit non-`B₃` rejector `[[1,1,0],[0,1,0],[0,0,1]]`
+— determinant `1`, a genuine bijection of `Z_L³`, but not a signed permutation matrix — and
+finds the propagation inconsistent at every `L` (a tree edge whose image is not a support
+edge). So liftability is a real property of `B₃`, tested against a nontrivial competitor.
+
+**T5 (size independence, exactly where it is exact; gates G3_ENUM_L\*, G9_COUNTS_L\*,
+G9S_SUPPORT_L\*, G10_CLOSURE_L4, G10_CLOSURE_L6, XL_96N, XL_ENUM_EQ).** The construction
+of T1 and T4 yields exactly `96N` distinct elements of `Comm(D2)` at every
+L ∈ {4, 6, 8, 10, 12}. Both halves of the size statement, stated separately:
+
+- **Equality where the enumeration was run.** At L ∈ {4, 6, 8, 10} the exhaustive
+  enumeration gives a liftable-automorphism count `48N` and `|Comm(D2)| = 96N`, matching
+  the constructed count exactly. At L ∈ {4, 6} this is sharpened to KEY-SET EQUALITY: the
+  closure of `{t_x, t_y, t_z, -I}` together with the 48 constructed point-group lifts (52
+  generators) has order `96N` and its key set is EQUAL, as a set of byte keys, to the
+  enumerated `Comm(D2)`. At L ∈ {8, 10} the closure is NOT ATTEMPTED — the runner sets
+  `L_CLOSURE = (4, 6)`, so the cache records no attempt, no failure and no memory figure
+  at those sizes; this is a scoping cut taken to keep the unit inside its budget, not a
+  measured infeasibility, and it should not be read as one. The comparison there is by
+  count plus generator membership: each of the 51 constructed generators and its negative
+  is found in the enumerated key set, with exactly two enumerated lifts per permutation
+  part.
+- **Lower bound where it was not.** At L = 12 no enumeration is run. The construction then
+  establishes only `|Comm(D2)| ≥ 96N = 165888`. Equality there is NOT established by this
+  unit: it would require knowing that the LIFTABLE support-graph automorphisms are exactly
+  the `48N` affine maps `x ↦ Ax + v` at that `L`, which this unit does not prove. Note
+  that this is strictly weaker than requiring the support-graph automorphism group itself
+  to be the affine maps — the L = 4 row below is a lattice where that stronger statement
+  is FALSE (46080 automorphisms against 3072 affine maps) and yet `|Comm(D2)| = 96N` holds
+  exactly, because the non-affine automorphisms fail to lift. The same applies to every
+  larger even `L`.
+
+## 3. Evidence — measured values
+
+| L | N | constructed `2·48·N` | enumerated `nComm` | enumerated `nLift` | support `nStab` | support `nAut` | `q = -I` set | single-site flip rejections |
+|--:|--:|--:|--:|--:|--:|--:|---|---|
+| 4 | 64 | 6144 | 6144 | 3072 | 720 | 46080 | empty | 192/192 (exhaustive, all `N`) |
+| 6 | 216 | 20736 | 20736 | 10368 | 48 | 10368 | `{011, 101, 110, 111}` | 648/648 (exhaustive, all `N`) |
+| 8 | 512 | 49152 | 49152 | 24576 | 48 | 24576 | empty | 96/96 (32-site stride `N//32`) |
+| 10 | 1000 | 96000 | 96000 | 48000 | 48 | 48000 | `{011, 101, 110, 111}` | 96/96 (32-site stride `N//32`) |
+| 12 | 1728 | 165888 | — (≥ 165888) | — | — | — | empty | 96/96 (32-site stride `N//32`) |
+
+Supporting per-`L` measurements, at every L ∈ {4, 6, 8, 10, 12}: closed-form lift commutes
+with `D2` 3/3; BFS propagation from `s(0) = +1` reproduces `zeta_nu` exactly 3/3 on a
+connected support graph; `[t_a, t_b]` central 9/9 with the `-1`-iff-`a≠b` pattern, and the
+bimultiplicative extension matching `(-1)^{(Σs)(Σt) - s·t}` on 64/64 class pairs;
+`(t_nu)^k` sign field `= zeta_nu^k` on `3L`/`3L` powers with order exactly `L`; `q`
+matching the formula 8/8; the 7 alternative exponent masks rejected 21/21; all 48 `B₃`
+matrices liftable 48/48 with 48 distinct permutation parts; the shear rejector not
+liftable. At L ∈ {4, 6} additionally: commutators of actual lift products central 64/64 and
+matching 64/64; closure of the 52 constructed generators equal to the enumerated `Comm` as
+a key set. At L ∈ {4, 6, 8, 10} additionally: `t_nu` and `-t_nu` both present in the
+enumerated `Comm` 3/3 with exactly two enumerated lifts 3/3; each point-group lift and its
+negative present 48/48 with exactly two lifts 48/48.
+
+The constructed count is measured, not asserted: for each of the 48 lifted point-group
+permutations and each of the `N` translations the composite permutation is fingerprinted by
+its images of the four probe sites `0, e_0, e_1, e_2` packed into one `int64`, and the
+number of DISTINCT fingerprints is counted. Distinct fingerprints certify distinct
+permutations, so `48N` distinct fingerprints (3072, 10368, 24576, 48000, 82944 measured)
+give `96N` distinct group elements once the two central signs are included. No injectivity
+is assumed of the fingerprint map.
+
+All 64 gates pass with zero failures; the paired runner
+`scripts/kcpt_d2_commutant_closed_form_lifts_lattice_size_independence_2026_07_25.py`
+prints `TOTAL: PASS=64 FAIL=0`. The runner deliberately emits no wall-clock or
+resident-memory figures: those are machine- and load-dependent, and printing them would
+make the cached output differ on every regeneration. Cost is instead reported here as a
+bound — on the machine used for this unit the full run stayed under two minutes and under
+1.5 GB resident, dominated by the L = 10 enumeration and the L = 12 support build. The
+enumeration structures are freed between sizes, so peak memory tracks the largest single
+`L` rather than their sum, and the L = 12 pass inherits that high-water mark rather than
+adding to it. Every quantity is exact integer arithmetic; there is no floating tolerance
+anywhere in this unit.
+
+## 4. The picture: the lane is no longer enumeration-bound
+
+Up to this unit, everything the lane knew about `Comm(D2)` came from listing its `96N`
+elements — which is why the lane lived at L ∈ {4, 6}. The staggered phases are
+lower-triangular in the coordinates, and that single structural fact is enough to write the
+generators down. A translation by `e_nu` disturbs `eta_mu` exactly when `nu < mu`, so the
+compensating sign field must flip across the `mu`-edges with `mu > nu` and no others — that
+is `zeta_nu(x) = (-1)^{Σ_{mu > nu} x_mu}`, a closed form with no `L`-dependence at all
+beyond the parity of `L`. The whole extension class follows from the same triangularity:
+the commutator `[t_a, t_b] = (-1)^{[a>b]+[b>a]} I` is `-1` off the diagonal because exactly
+one of the two orderings flips, and the 2-torsion form `q = (-1)^{(L/2)² Σ_{i<j} v_i v_j}`
+is trivial or not according to the parity of `L/2` alone. The point group needs no new
+idea: `B₃` permutes the six lattice directions, so its elements preserve the support graph
+and the sign relation propagates consistently — 48 out of 48, at every size tested, while a
+determinant-1 shear that is not a signed permutation fails immediately.
+
+The pay-off is that `96N` becomes a construction rather than a census. At L ∈ {4, 6, 8, 10}
+the exhaustive enumeration is still run and still agrees — including key-set equality at
+L ∈ {4, 6}, where the closure of the 52 closed-form generators is literally the same set of
+elements the enumerator produces. At L = 12 the enumeration is not affordable and the
+honest statement is a lower bound: the construction exhibits `165888` elements and does not
+prove there are no others. The gap between the two halves is a single missing ingredient —
+that the LIFTABLE support-graph automorphisms are exactly the `48N` affine maps at general
+even `L`. The L = 4 row of the table is the reason that ingredient has to be stated in that
+liftability form rather than as a statement about the automorphism group: there the support
+graph carries `46080` automorphisms, far more than the `3072` affine ones, and equality
+still holds — because only the affine ones lift.
+
+## 5. Dependencies
+
+- [KCPT D2 graded signed-permutation commutant characterization (L=4 and L=6) (bounded theorem)](KCPT_D2_GRADED_SIGNED_PERMUTATION_COMMUTANT_CHARACTERIZATION_BOUNDED_THEOREM_NOTE_2026-07-25.md)
+- [KCPT D2 commutant double cover and bicommutant structure (L=4 and L=6) (bounded theorem)](KCPT_D2_COMMUTANT_DOUBLE_COVER_BICOMMUTANT_STRUCTURE_BOUNDED_THEOREM_NOTE_2026-07-25.md)
+
+Context (not a dependency edge): the preceding restriction-localization unit,
+`KCPT_D2_COMMUTANT_EXTENSION_TRANSLATION_LOCALIZATION_BOUNDED_THEOREM_NOTE_2026-07-25`,
+already carries both closed forms — it measured `beta` on the enumerated group at
+L ∈ {4, 6} and matched it uniquely among the 512 bimultiplicative candidates, then derived
+`q` from it. This unit does not consume either result; it re-derives `beta` from the
+staggered phases instead of from an enumeration, and reruns the same `q` argument on that
+derived input, which is what lets both run at L ∈ {8, 10, 12}.
+
+## 6. Next paths this opens
+
+- **Prove that the liftable support-graph automorphisms are exactly the `48N` affine maps
+  at general even `L`.** That is the one missing ingredient that would upgrade T5's lower
+  bound `|Comm(D2)| ≥ 96N` to equality at every even `L`, with no enumeration anywhere.
+  L = 4 fixes the shape such a proof must have: the support-graph automorphism group there
+  is `46080`, strictly larger than the `3072` affine maps, and equality nevertheless holds.
+  So the proof must NOT go through "there are no extra automorphisms" — the extra
+  automorphisms need not go anywhere, they need only fail to lift, which is what the L = 4
+  row measures. A liftability obstruction, not an automorphism census, is the object to
+  chase.
+- **Solve the point-group edge condition in closed form and make T4 general-`L`.** The
+  edge condition of T1 with the translation replaced by `x ↦ Ax` is a linear system over
+  `F₂` in the unknown sign field; a closed-form solution for all 48 `A ∈ B₃`, together
+  with the cycle-holonomy condition, would replace T4's five-size verification with a
+  derivation and remove the last size quantifier from the construction side.
+- **Odd `L`.** `zeta_nu` is not well defined on `Z_L` for odd `L`, so the closed form as
+  written does not apply. What replaces the translation lift on an odd torus — and whether
+  the group order law survives in any form — is untouched here.
+- **Carry the closed-form generators into the bicommutant computations.** The double-cover
+  and bicommutant work in this lane consumed the enumerated group. With generators in
+  closed form, the extension class, the derived subgroup, the endomorphism algebra and the
+  eigenspace/character block become computable at sizes the enumeration cannot reach, which
+  is the natural way to test which of those structures are `L`-stable in form.
+
+## Boundary
+
+- The equality `|Comm(D2)| = 96N` is exhaustively established only at L ∈ {4, 6, 8, 10},
+  where the enumeration was actually run. At L = 12 and at every larger even `L` the
+  construction of T1 and T4 gives only the LOWER BOUND `|Comm(D2)| ≥ 96N`. Equality at
+  those sizes is not claimed here; it would need the support-graph automorphism group to be
+  exactly the affine maps at that `L`.
+- `L` even is required throughout, because `zeta_nu(x) = (-1)^{Σ_{mu > nu} x_mu}` is well
+  defined on `Z_L` only when `L` is even. Odd `L` is outside the scope of this unit.
+- This unit adds no physics identification. It is a statement about the symmetry group of a
+  finite staggered operator `D2` — nothing about `r`, generations, flavour, the continuum
+  limit, or any physical observable is claimed, and the statement is r-neutral.
+- **A planner-supplied anchor did not reproduce as literally labelled, and is recorded
+  here.** The anchor table this unit was built against listed, for the exhaustive
+  enumeration, `nStab = 48` and `nAut = 3072` at L = 4. The landed enumerator actually
+  returns `nStab = 720` and `nAut = 46080` at L = 4, with `nLift = 3072`: the anchor's
+  `nAut` column is the LIFTABLE count `nLift`, and its `nStab` column is `nLift / N`. At
+  L ∈ {6, 8, 10} the two readings coincide (`nStab = 48`, `nAut = nLift = 48N`) and the
+  anchor is exact as written. The substantive claims are unaffected — `nComm = 96N` and
+  `nLift = 48N` hold at all four enumerated sizes, and the constructed set equals the
+  enumerated `Comm(D2)` at L = 4 as a key set — but the L = 4 support-graph census is
+  genuinely different from the liftable census and the runner gates the two separately
+  (`G9S_SUPPORT_L*` against the support-graph values, `G9_COUNTS_L*` against the liftable
+  ones) rather than conflating them.
+- The `q = -I` dichotomy is verified at five sizes covering both residues mod 4
+  (L = 4, 8, 12 for `L ≡ 0`; L = 6, 10 for `L ≡ 2`); it is derived from T2 and T3 for all
+  even `L`, and the five sizes are confirmations of that derivation, not its basis.
+- The single-site sign-flip rejector is exhaustive over all `N` sites only at L ∈ {4, 6}; at
+  L ∈ {8, 10, 12} it runs on a deterministic stride-`N//32` subset of 32 sites per `nu`
+  (no randomness). A sign dressing that differed from `zeta_nu` only at sites outside that
+  subset would not be caught by that particular gate at those sizes — though it would be
+  caught by the full `N²` commutation check of G1 and by the propagation-equality check of
+  G2, both of which are exhaustive at every `L`.
+- The two dependency rows are landed on main; their anchors (`D2`, the support structures,
+  the commutant enumerator, the `96N` census law) are consumed here as landed module
+  values.
+
+## Honest-auditor read
+
+- The dangerous move this unit could make is to let the closed form validate itself — to
+  compute `zeta_nu` and then "check" it against `zeta_nu`. It does not. The sign field is
+  obtained twice by independent routes: once from the closed formula, and once by BFS
+  propagation of the edge relation `s_j = s_i · D2[i,j] · D2[p_i, p_j]` over the support
+  graph starting from `s(0) = +1`, which never sees the formula. The gate compares the two
+  and separately verifies the full `N²` commutation condition. Likewise the commutator
+  signs come from actual signed-permutation products, and `q` comes from actually squaring
+  the half-power products, not from evaluating the formula they are compared against.
+- Every completeness claim is built to fail if the object were wrong, via explicit
+  wrong-value rejectors rather than identities that hold by construction. Single-site sign
+  flips of `zeta_nu` must break commutation, and do (192/192 and 648/648 exhaustively at
+  L = 4, 6; 96/96 on the fixed 32-site subsets at L = 8, 10, 12). Each of the 7 alternative
+  exponent masks must fail, and does (21/21 at every `L`), so the mask `{mu : mu > nu}` is
+  discriminated among all 8 subsets. The determinant-1 shear `[[1,1,0],[0,1,0],[0,0,1]]` —
+  a real lattice bijection — must NOT lift, and does not, at every `L`; without it the
+  "all 48 of `B₃` lift" claim would carry no information.
+- The `96N` count is measured by distinct fingerprints of the constructed permutations, not
+  asserted from `2 · 48 · N`. The fingerprint packs the images of four probe sites
+  (`0`, `e_0`, `e_1`, `e_2`) into one integer, so distinct fingerprints certify distinct
+  permutations; no injectivity of the fingerprint map is assumed anywhere. A collision
+  therefore cannot hide — it would push the distinct count BELOW the constructed `48N` and
+  fail the gate — and the count comes out exactly `48N` at all five sizes, including
+  82944 at L = 12 where nothing is enumerated.
+- The honest asymmetry in T5 is stated rather than smoothed over. At L ∈ {4, 6} the claim
+  is a set equality of byte keys; at L ∈ {8, 10} it is a count plus generator membership,
+  because the runner sets `L_CLOSURE = (4, 6)` and does not attempt the closure at the two
+  larger sizes — a scoping cut, not a measured infeasibility, and the cache records no
+  attempt and no failure there; at L = 12 it is a lower bound and is labelled as such in
+  the runner's own output line. A reader should not read the L = 12 row as an equality.
+- The L = 4 anchor discrepancy is reported rather than absorbed. The planner's anchor table
+  labelled the liftable count as `nAut`; the enumerator's `nAut` at L = 4 is 46080, fifteen
+  times larger. Rather than re-label a gate to match, the runner gates both quantities
+  separately and prints both, and the note records the mismatch. It also happens to be the
+  most informative row in the table: L = 4 is precisely where the support graph has more
+  automorphisms (46080) than affine maps (3072), and yet `|Comm(D2)| = 96N` holds there
+  exactly. That row is what fixes the SHAPE of the missing general-`L` argument — the extra
+  automorphisms need not be absent, they need only fail to lift, and at L = 4 they do fail
+  to lift. The open ingredient is therefore a liftability obstruction, not an automorphism
+  census.
+- Residual softness a reader should weigh, in two distinct places. (i) T1–T3 are derived for
+  all even `L`; T4 is not — its cycle-consistency question is settled by the runner at
+  L ∈ {4, 6, 8, 10, 12} and by no argument, so the construction of `96N` elements is a
+  five-size statement, not a general-`L` one. (ii) Even granting the construction at a given
+  `L`, the step from "the construction gives `96N` elements" to "`Comm(D2)` has exactly `96N`
+  elements" is made only where the enumerator runs (L ∈ {4, 6, 8, 10}); at L = 12 it is not
+  made at all. Section 6 names a concrete route for each: an `F₂` closed form for the
+  point-group edge condition for (i), and the liftability obstruction above for (ii).
+
+This row is unaudited: its grade is set exclusively by the independent audit lane on
+origin/main, not by this note or its runner.

--- a/logs/runner-cache/kcpt_d2_commutant_closed_form_lifts_lattice_size_independence_2026_07_25.txt
+++ b/logs/runner-cache/kcpt_d2_commutant_closed_form_lifts_lattice_size_independence_2026_07_25.txt
@@ -1,0 +1,102 @@
+===== runner cache v1 =====
+runner: scripts/kcpt_d2_commutant_closed_form_lifts_lattice_size_independence_2026_07_25.py
+runner_sha256: 45813246c7490265ad69450430979d24773bfeb88c04c8f68ab64a2504e08b6a
+input_fingerprint_sha256: 02d98592d4c2ad1e5896610eec57bd83e45aa9061d2135ca56d0b54679fe3442
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 62.24
+status: ok
+----- stdout -----
+KCPT Unit 28 -- closed-form lifts and lattice-size independence
+D2, support structures and the reference enumeration come from scripts/kcpt_d2_graded_signed_permutation_commutant_characterization_2026_07_25.py
+constructive L = (4, 6, 8, 10, 12); exhaustive-enumeration anchor L = (4, 6, 8, 10)
+
+[L = 4]
+  PASS  G1_TRANSLIFT_L4        closed-form zeta_nu lift commutes with D2 on all 64^2 entries: 3/3
+  PASS  G2_UNIQUE_L4           support graph connected (64 sites), BFS propagation from s(0)=+1 reproduces zeta_nu exactly 3/3 -> sign solution unique, two lifts +-
+  PASS  G4_BETA_L4             [t_a,t_b] central 9/9 and = -1 iff a!=b; bimultiplicative extension matches (-1)^[(sum s)(sum t) - s.t] on 64/64 class pairs
+  PASS  G4X_LIFTPROD_L4        commutators of ACTUAL lift products on all 8x8 class reps are central 64/64 and match the extension 64/64
+  PASS  G6_ORDER_Q_L4          (t_nu)^k sign field = zeta_nu^k 12/12, order exactly 4 with (t_nu)^L=+I; q matches formula 8/8; L=0 mod 4 -> q trivial on all 8 v; q=-I set empty
+  PASS  G5A_FLIP_L4            single-site sign flips of zeta_nu break commutation 192/192 (exhaustive N=64 site set, 3 nu)
+  PASS  G5B_MASK_L4            the 7 alternative exponent masks per nu all break commutation 21/21; the mask {mu : mu > nu} commutes 3/3
+  PASS  G7_B3_L4               all 48 B_3 matrices lift by consistent sign propagation 48/48, 48 distinct permutation parts; connected support graph -> exactly two lifts +- each
+  PASS  G8_SHEAR_L4            shear [[1,1,0],[0,1,0],[0,0,1]] det=1, lattice bijection, not a signed permutation: propagation inconsistent -> NOT liftable
+  PASS  G3_ENUM_L4             closed-form t_nu and -t_nu both present in the enumerated Comm 3/3, and the enumerated lifts of that permutation are exactly two 3/3
+  PASS  G7E_ENUM_L4            each constructed point-group lift and its negative lie in the enumerated Comm key set 48/48, with exactly two enumerated lifts each 48/48
+  PASS  G9S_SUPPORT_L4         support-graph Aut census nStab=720 nAut=46080 (=nStab*N); liftable nLift=3072 = 48N; support-graph Aut is STRICTLY LARGER than the liftable subgroup here (46080 > 3072)
+  PASS  G9_COUNTS_L4           constructed 3072 distinct fingerprints x 2 signs = 6144 = 96N; enumerated nComm=6144 = 96N = constructed (EXACT equality)
+  PASS  G10_CLOSURE_L4         closure of {t_x,t_y,t_z,-I} + 48 point-group lifts (52 gens) has order 6144 and key set EQUAL to the enumerated Comm
+
+[L = 6]
+  PASS  G1_TRANSLIFT_L6        closed-form zeta_nu lift commutes with D2 on all 216^2 entries: 3/3
+  PASS  G2_UNIQUE_L6           support graph connected (216 sites), BFS propagation from s(0)=+1 reproduces zeta_nu exactly 3/3 -> sign solution unique, two lifts +-
+  PASS  G4_BETA_L6             [t_a,t_b] central 9/9 and = -1 iff a!=b; bimultiplicative extension matches (-1)^[(sum s)(sum t) - s.t] on 64/64 class pairs
+  PASS  G4X_LIFTPROD_L6        commutators of ACTUAL lift products on all 8x8 class reps are central 64/64 and match the extension 64/64
+  PASS  G6_ORDER_Q_L6          (t_nu)^k sign field = zeta_nu^k 18/18, order exactly 6 with (t_nu)^L=+I; q matches formula 8/8; L=2 mod 4 -> q=-I on the four v with >=2 odd entries; q=-I set [(0, 1, 1), (1, 0, 1), (1, 1, 0), (1, 1, 1)]
+  PASS  G5A_FLIP_L6            single-site sign flips of zeta_nu break commutation 648/648 (exhaustive N=216 site set, 3 nu)
+  PASS  G5B_MASK_L6            the 7 alternative exponent masks per nu all break commutation 21/21; the mask {mu : mu > nu} commutes 3/3
+  PASS  G7_B3_L6               all 48 B_3 matrices lift by consistent sign propagation 48/48, 48 distinct permutation parts; connected support graph -> exactly two lifts +- each
+  PASS  G8_SHEAR_L6            shear [[1,1,0],[0,1,0],[0,0,1]] det=1, lattice bijection, not a signed permutation: propagation inconsistent -> NOT liftable
+  PASS  G3_ENUM_L6             closed-form t_nu and -t_nu both present in the enumerated Comm 3/3, and the enumerated lifts of that permutation are exactly two 3/3
+  PASS  G7E_ENUM_L6            each constructed point-group lift and its negative lie in the enumerated Comm key set 48/48, with exactly two enumerated lifts each 48/48
+  PASS  G9S_SUPPORT_L6         support-graph Aut census nStab=48 nAut=10368 (=nStab*N); liftable nLift=10368 = 48N; support-graph Aut equals the liftable subgroup
+  PASS  G9_COUNTS_L6           constructed 10368 distinct fingerprints x 2 signs = 20736 = 96N; enumerated nComm=20736 = 96N = constructed (EXACT equality)
+  PASS  G10_CLOSURE_L6         closure of {t_x,t_y,t_z,-I} + 48 point-group lifts (52 gens) has order 20736 and key set EQUAL to the enumerated Comm
+
+[L = 8]
+  PASS  G1_TRANSLIFT_L8        closed-form zeta_nu lift commutes with D2 on all 512^2 entries: 3/3
+  PASS  G2_UNIQUE_L8           support graph connected (512 sites), BFS propagation from s(0)=+1 reproduces zeta_nu exactly 3/3 -> sign solution unique, two lifts +-
+  PASS  G4_BETA_L8             [t_a,t_b] central 9/9 and = -1 iff a!=b; bimultiplicative extension matches (-1)^[(sum s)(sum t) - s.t] on 64/64 class pairs
+  PASS  G6_ORDER_Q_L8          (t_nu)^k sign field = zeta_nu^k 24/24, order exactly 8 with (t_nu)^L=+I; q matches formula 8/8; L=0 mod 4 -> q trivial on all 8 v; q=-I set empty
+  PASS  G5A_FLIP_L8            single-site sign flips of zeta_nu break commutation 96/96 (deterministic 32-site stride N//32 site set, 3 nu)
+  PASS  G5B_MASK_L8            the 7 alternative exponent masks per nu all break commutation 21/21; the mask {mu : mu > nu} commutes 3/3
+  PASS  G7_B3_L8               all 48 B_3 matrices lift by consistent sign propagation 48/48, 48 distinct permutation parts; connected support graph -> exactly two lifts +- each
+  PASS  G8_SHEAR_L8            shear [[1,1,0],[0,1,0],[0,0,1]] det=1, lattice bijection, not a signed permutation: propagation inconsistent -> NOT liftable
+  PASS  G3_ENUM_L8             closed-form t_nu and -t_nu both present in the enumerated Comm 3/3, and the enumerated lifts of that permutation are exactly two 3/3
+  PASS  G7E_ENUM_L8            each constructed point-group lift and its negative lie in the enumerated Comm key set 48/48, with exactly two enumerated lifts each 48/48
+  PASS  G9S_SUPPORT_L8         support-graph Aut census nStab=48 nAut=24576 (=nStab*N); liftable nLift=24576 = 48N; support-graph Aut equals the liftable subgroup
+  PASS  G9_COUNTS_L8           constructed 24576 distinct fingerprints x 2 signs = 49152 = 96N; enumerated nComm=49152 = 96N = constructed (EXACT equality)
+
+[L = 10]
+  PASS  G1_TRANSLIFT_L10       closed-form zeta_nu lift commutes with D2 on all 1000^2 entries: 3/3
+  PASS  G2_UNIQUE_L10          support graph connected (1000 sites), BFS propagation from s(0)=+1 reproduces zeta_nu exactly 3/3 -> sign solution unique, two lifts +-
+  PASS  G4_BETA_L10            [t_a,t_b] central 9/9 and = -1 iff a!=b; bimultiplicative extension matches (-1)^[(sum s)(sum t) - s.t] on 64/64 class pairs
+  PASS  G6_ORDER_Q_L10         (t_nu)^k sign field = zeta_nu^k 30/30, order exactly 10 with (t_nu)^L=+I; q matches formula 8/8; L=2 mod 4 -> q=-I on the four v with >=2 odd entries; q=-I set [(0, 1, 1), (1, 0, 1), (1, 1, 0), (1, 1, 1)]
+  PASS  G5A_FLIP_L10           single-site sign flips of zeta_nu break commutation 96/96 (deterministic 32-site stride N//32 site set, 3 nu)
+  PASS  G5B_MASK_L10           the 7 alternative exponent masks per nu all break commutation 21/21; the mask {mu : mu > nu} commutes 3/3
+  PASS  G7_B3_L10              all 48 B_3 matrices lift by consistent sign propagation 48/48, 48 distinct permutation parts; connected support graph -> exactly two lifts +- each
+  PASS  G8_SHEAR_L10           shear [[1,1,0],[0,1,0],[0,0,1]] det=1, lattice bijection, not a signed permutation: propagation inconsistent -> NOT liftable
+  PASS  G3_ENUM_L10            closed-form t_nu and -t_nu both present in the enumerated Comm 3/3, and the enumerated lifts of that permutation are exactly two 3/3
+  PASS  G7E_ENUM_L10           each constructed point-group lift and its negative lie in the enumerated Comm key set 48/48, with exactly two enumerated lifts each 48/48
+  PASS  G9S_SUPPORT_L10        support-graph Aut census nStab=48 nAut=48000 (=nStab*N); liftable nLift=48000 = 48N; support-graph Aut equals the liftable subgroup
+  PASS  G9_COUNTS_L10          constructed 48000 distinct fingerprints x 2 signs = 96000 = 96N; enumerated nComm=96000 = 96N = constructed (EXACT equality)
+
+[L = 12]
+  PASS  G1_TRANSLIFT_L12       closed-form zeta_nu lift commutes with D2 on all 1728^2 entries: 3/3
+  PASS  G2_UNIQUE_L12          support graph connected (1728 sites), BFS propagation from s(0)=+1 reproduces zeta_nu exactly 3/3 -> sign solution unique, two lifts +-
+  PASS  G4_BETA_L12            [t_a,t_b] central 9/9 and = -1 iff a!=b; bimultiplicative extension matches (-1)^[(sum s)(sum t) - s.t] on 64/64 class pairs
+  PASS  G6_ORDER_Q_L12         (t_nu)^k sign field = zeta_nu^k 36/36, order exactly 12 with (t_nu)^L=+I; q matches formula 8/8; L=0 mod 4 -> q trivial on all 8 v; q=-I set empty
+  PASS  G5A_FLIP_L12           single-site sign flips of zeta_nu break commutation 96/96 (deterministic 32-site stride N//32 site set, 3 nu)
+  PASS  G5B_MASK_L12           the 7 alternative exponent masks per nu all break commutation 21/21; the mask {mu : mu > nu} commutes 3/3
+  PASS  G7_B3_L12              all 48 B_3 matrices lift by consistent sign propagation 48/48, 48 distinct permutation parts; connected support graph -> exactly two lifts +- each
+  PASS  G8_SHEAR_L12           shear [[1,1,0],[0,1,0],[0,0,1]] det=1, lattice bijection, not a signed permutation: propagation inconsistent -> NOT liftable
+  PASS  G9_COUNTS_L12          constructed 82944 distinct fingerprints x 2 signs = 165888 = 96N: this is a LOWER BOUND |Comm(D2)| >= 96N (no enumeration run at L=12)
+
+[SUMMARY]
+    L     N   constr      nComm    nLift    nStab     nAut  q=-I set
+    4    64     6144       6144     3072      720    46080  empty
+    6   216    20736      20736    10368       48    10368  [(0, 1, 1), (1, 0, 1), (1, 1, 0), (1, 1, 1)]
+    8   512    49152      49152    24576       48    24576  empty
+   10  1000    96000      96000    48000       48    48000  [(0, 1, 1), (1, 0, 1), (1, 1, 0), (1, 1, 1)]
+   12  1728   165888  >= 165888        -        -        -  empty
+
+[CROSS-L]
+  PASS  XL_96N                 constructed count = 96N at every L in (4, 6, 8, 10, 12)
+  PASS  XL_ENUM_EQ             enumerated nComm = 96N and nLift = 48N at every L in (4, 6, 8, 10) (equality with the construction is anchored ONLY here)
+  PASS  XL_DICHOTOMY           2-torsion dichotomy holds at every L: q trivial for L=0 mod 4, q=-I on exactly 4 points for L=2 mod 4
+
+========================================================================
+TOTAL: PASS=64 FAIL=0
+
+----- stderr -----
+

--- a/scripts/kcpt_d2_commutant_closed_form_lifts_lattice_size_independence_2026_07_25.py
+++ b/scripts/kcpt_d2_commutant_closed_form_lifts_lattice_size_independence_2026_07_25.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""KCPT Unit 28 runner.
+
+Closed-form lifts for Comm(D2), and how far the group law survives growing L.
+
+Every prior unit in this lane read the structure of the signed-permutation
+commutant Comm(D2) off an EXHAUSTIVE enumeration, which capped the lane at
+L in {4, 6}.  This runner takes the enumeration off the critical path: the
+translation lifts and the point-group lifts are written down in CLOSED FORM
+from the staggered phases, and the enumeration is then used only as an
+independent anchor where it is still affordable.
+
+  T1  closed-form translation lift.  t_nu = (x -> x + e_nu, zeta_nu) with
+      zeta_nu(x) = (-1)^{sum_{mu > nu} x_mu} lies in Comm(D2) for every even L;
+      the sign solution with s(0) = +1 is unique, so exactly two lifts +-t_nu.
+  T2  analytic commutator.  [t_a, t_b] = (-1)^{1 - delta_ab} I, whose
+      bimultiplicative extension is beta(s,t) = (-1)^{(sum s)(sum t) - s.t}.
+  T3  order and 2-torsion.  (t_nu)^k has sign field zeta_nu^k, order exactly L,
+      (t_nu)^L = +I; q((L/2) v) = (-1)^{(L/2)^2 sum_{i<j} v_i v_j}.
+  T4  constructive point-group lifts.  All 48 B_3 matrices lift, two lifts each.
+  T5  size independence, exactly where it is exact.  96N constructed elements
+      at every even L tested; equality with Comm(D2) is anchored by the
+      exhaustive enumeration at L in {4, 6, 8, 10} only, and is a LOWER BOUND
+      at L = 12.
+
+This runner imports the Unit 25 module (same scripts/ directory) and builds D2,
+the support structures and the reference enumeration through it verbatim.  No
+quantity is ever computed from the value it is compared against: the sign fields
+come from the closed form or from BFS propagation over the D2 support graph, the
+commutator signs come from actual signed-permutation products, and the
+completeness gates carry explicit WRONG-VALUE REJECTORS (single-site sign flips,
+the seven alternative exponent masks, and a determinant-1 integral shear that is
+not a signed permutation) which must all fail to commute.
+"""
+
+import gc
+import importlib
+import itertools
+import os
+import sys
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+for _p in (_HERE, "scripts"):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+u25 = importlib.import_module(
+    "kcpt_d2_graded_signed_permutation_commutant_characterization_2026_07_25"
+)
+
+AUDIT_INPUT_PATHS = (
+    "scripts/kcpt_d2_graded_signed_permutation_commutant_characterization_2026_07_25.py",
+)
+
+# ---------------------------------------------------------------- gate harness
+_P = [0]
+_F = [0]
+
+
+def gate(name, cond, msg=""):
+    ok = bool(cond)
+    if ok:
+        _P[0] += 1
+        print("  PASS  {:<22} {}".format(name, msg), flush=True)
+    else:
+        _F[0] += 1
+        print("  FAIL  {:<22} {}".format(name, msg), flush=True)
+    return ok
+
+
+# ------------------------------------------------------------------- constants
+# Lattice sizes.  Constructive checks run everywhere; the exhaustive enumeration
+# anchor runs only where it fits the memory budget.
+L_ALL = (4, 6, 8, 10, 12)
+L_ENUM = (4, 6, 8, 10)
+L_CLOSURE = (4, 6)
+
+# Independent anchors for the enumerated census.
+#   ANCHOR_LIFT_PER_COSET : liftable automorphisms per translation coset.
+#   ANCHOR_SUPPORT_STAB   : |Stab_0| inside the SUPPORT-GRAPH automorphism group.
+# These are two different objects.  They agree for L >= 6, and they do NOT agree
+# at L = 4, where the D2 support graph carries automorphisms beyond the affine
+# ones and only the affine ones admit a sign lift.  The L = 4 and L = 6 values are
+# the ones pinned in the landed Unit 25 module's own XREF table and gated there
+# (L = 4: nStab = 720, nAut = 46080, nLift = 3072; L = 6: nStab = 48,
+# nAut = nLift = 10368).  The L = 8 and L = 10 values are this unit's own
+# measurement, and they follow the same census law as L = 6.
+ANCHOR_LIFT_PER_COSET = 48
+ANCHOR_SUPPORT_STAB = {4: 720, 6: 48, 8: 48, 10: 48}
+ANCHOR_SUPPORT_AUT = {4: 46080, 6: 10368, 8: 24576, 10: 48000}
+
+SUBSETS3 = [(), (0,), (1,), (2,), (0, 1), (0, 2), (1, 2), (0, 1, 2)]
+
+SHEAR = np.array([[1, 1, 0], [0, 1, 0], [0, 0, 1]], dtype=np.int64)
+
+
+def build_b3():
+    """The 48 signed 3x3 permutation matrices, built from scratch."""
+    mats = []
+    for perm in itertools.permutations(range(3)):
+        for sg in itertools.product((1, -1), repeat=3):
+            A = np.zeros((3, 3), dtype=np.int64)
+            for r in range(3):
+                A[r, perm[r]] = sg[r]
+            mats.append(A)
+    return mats
+
+
+B3 = build_b3()
+
+
+def det3(A):
+    return int(
+        A[0, 0] * (A[1, 1] * A[2, 2] - A[1, 2] * A[2, 1])
+        - A[0, 1] * (A[1, 0] * A[2, 2] - A[1, 2] * A[2, 0])
+        + A[0, 2] * (A[1, 0] * A[2, 1] - A[1, 1] * A[2, 0])
+    )
+
+
+def is_signed_perm_matrix(A):
+    return (
+        np.array_equal(np.abs(A).sum(axis=0), np.ones(3, dtype=np.int64))
+        and np.array_equal(np.abs(A).sum(axis=1), np.ones(3, dtype=np.int64))
+        and set(np.unique(A).tolist()) <= {-1, 0, 1}
+    )
+
+
+# ----------------------------------------------------- lattice-level machinery
+def affine_perm(A, shift, lat):
+    """Permutation of the site basis induced by x -> A x + shift (mod L)."""
+    coords, idx, N = lat["coords"], lat["idx"], lat["N"]
+    img = coords @ np.asarray(A, dtype=np.int64).T + np.asarray(shift, dtype=np.int64)
+    out = np.empty(N, dtype=np.int64)
+    for i in range(N):
+        out[i] = idx(int(img[i, 0]), int(img[i, 1]), int(img[i, 2]))
+    return out
+
+
+def mask_sign_field(mask, coords):
+    """(-1)^{sum_{mu in mask} x_mu} as an exact integer sign array."""
+    ex = np.zeros(len(coords), dtype=np.int64)
+    for mu in mask:
+        ex = ex + coords[:, mu]
+    return np.where(ex % 2 == 0, 1, -1).astype(np.int64)
+
+
+def zeta_mask(nu):
+    """The closed-form exponent mask {mu : mu > nu} for the nu-translation."""
+    return tuple(mu for mu in range(3) if mu > nu)
+
+
+def propagate(p, sup, D2):
+    """Sign lift of the permutation p by BFS propagation from s(0) = +1.
+
+    Uses the commutation condition s_i s_j D2[p_i, p_j] = D2[i, j] on the edges
+    of the support-graph BFS spanning tree, i.e. s_j = s_i D2[i,j] D2[p_i,p_j].
+    Returns None when a tree edge has no image edge (D2[p_i, p_j] = 0), which is
+    an inconsistency of the propagation itself.
+    """
+    N = sup["N"]
+    order = sup["order"]
+    parent = sup["parent"]
+    s = np.ones(N, dtype=np.int64)
+    for j in order[1:]:
+        j = int(j)
+        i = int(parent[j])
+        a = int(D2[i, j])
+        b = int(D2[p[i], p[j]])
+        if a == 0 or b == 0:
+            return None
+        s[j] = s[i] * a * b
+    return s
+
+
+def sp_identity(N):
+    return (np.arange(N, dtype=np.int64), np.ones(N, dtype=np.int64))
+
+
+def sp_minus_identity(N):
+    return (np.arange(N, dtype=np.int64), -np.ones(N, dtype=np.int64))
+
+
+def sp_pow(g, k, N):
+    r = sp_identity(N)
+    for _ in range(k):
+        r = u25.compose(r, g)
+    return r
+
+
+def commutator(a, b):
+    return u25.compose(u25.compose(a, b), u25.compose(u25.sp_inv(a), u25.sp_inv(b)))
+
+
+def central_sign(g, N):
+    """Return +-1 when g is a central scalar, else None."""
+    p, s = g
+    if not np.array_equal(p, np.arange(N, dtype=np.int64)):
+        return None
+    v = int(s[0])
+    if not np.all(s == v):
+        return None
+    return v
+
+
+def flip_sites(L, N):
+    """Deterministic site set for the single-site sign-flip rejector.
+
+    Exhaustive over all N sites at the two smallest lattices; a deterministic
+    stride-(N//32) 32-site subset above that, to keep the wall time bounded.
+    """
+    if L in L_CLOSURE:
+        return list(range(N)), True
+    step = N // 32
+    return [i * step for i in range(32)], False
+
+
+def constructed_fingerprints(lat, pg_perms):
+    """Injective fingerprints of the 48*N constructed permutation parts.
+
+    The composite T_v o Lift_A has permutation part x -> A x + v; its images of
+    the four probe sites 0, e_0, e_1, e_2 are packed into one int64 key.  Two
+    distinct fingerprints certify two distinct permutations, so counting the
+    distinct fingerprints is a sound lower-bound-and-equality count for the
+    constructed set (no injectivity is assumed of the fingerprint map).
+    """
+    L, N, coords, idx = lat["L"], lat["N"], lat["coords"], lat["idx"]
+    probes = [0]
+    for k in range(3):
+        e = [0, 0, 0]
+        e[k] = 1
+        probes.append(idx(e[0], e[1], e[2]))
+    probes = np.array(probes, dtype=np.int64)
+    fps = np.empty((len(pg_perms), N), dtype=np.int64)
+    for a, pA in enumerate(pg_perms):
+        base = coords[pA[probes]].astype(np.int64)            # (4, 3)
+        img = (base[None, :, :] + coords[:, None, :]) % L      # (N, 4, 3)
+        q = (img[:, :, 0] * L + img[:, :, 1]) * L + img[:, :, 2]
+        fps[a] = ((q[:, 0] * N + q[:, 1]) * N + q[:, 2]) * N + q[:, 3]
+        del base, img, q
+    return fps
+
+
+# ------------------------------------------------------------------- per-L run
+def run_L(L):
+    print("\n[L = {}]".format(L), flush=True)
+    sfx = "L{}".format(L)
+
+    lat = u25.build_lattice(L)
+    N = lat["N"]
+    D2 = lat["D2"]
+    coords = lat["coords"]
+    sup = u25.support_structures(D2)
+
+    # ---------------------------------------------------- T1 closed-form lifts
+    e3 = np.eye(3, dtype=np.int64)
+    trans_perm = [affine_perm(e3, e3[nu], lat) for nu in range(3)]
+    zeta = [mask_sign_field(zeta_mask(nu), coords) for nu in range(3)]
+    tlift = [(trans_perm[nu], zeta[nu]) for nu in range(3)]
+
+    g1 = [u25.commutes_with_D2(tlift[nu], D2) for nu in range(3)]
+    gate("G1_TRANSLIFT_" + sfx, all(g1),
+         "closed-form zeta_nu lift commutes with D2 on all {}^2 entries: {}/3"
+         .format(N, sum(g1)))
+
+    prop = [propagate(trans_perm[nu], sup, D2) for nu in range(3)]
+    g2_match = [prop[nu] is not None and np.array_equal(prop[nu], zeta[nu])
+                for nu in range(3)]
+    g2_s0 = [prop[nu] is not None and int(prop[nu][0]) == 1 for nu in range(3)]
+    gate("G2_UNIQUE_" + sfx,
+         sup["connected"] and len(sup["order"]) == N
+         and all(g2_match) and all(g2_s0) and all(g1),
+         "support graph connected ({} sites), BFS propagation from s(0)=+1 "
+         "reproduces zeta_nu exactly {}/3 -> sign solution unique, two lifts +-"
+         .format(N, sum(g2_match)))
+
+    # -------------------------------------------------- T2 analytic commutator
+    beta_meas = np.zeros((3, 3), dtype=np.int64)
+    beta_central = 0
+    for a in range(3):
+        for b in range(3):
+            c = central_sign(commutator(tlift[a], tlift[b]), N)
+            if c is not None:
+                beta_central += 1
+                beta_meas[a, b] = c
+    beta_target = np.array([[(1 if a == b else -1) for b in range(3)]
+                            for a in range(3)], dtype=np.int64)
+
+    classes = [np.array(v, dtype=np.int64)
+               for v in itertools.product((0, 1), repeat=3)]
+
+    def beta_ext(s, t):
+        r = 1
+        for a in range(3):
+            for b in range(3):
+                if s[a] and t[b]:
+                    r *= int(beta_meas[a, b])
+        return r
+
+    def beta_formula(s, t):
+        return (-1) ** ((int(s.sum()) * int(t.sum()) - int(s @ t)) % 2)
+
+    n_ext_ok = sum(1 for s in classes for t in classes
+                   if beta_ext(s, t) == beta_formula(s, t))
+    gate("G4_BETA_" + sfx,
+         beta_central == 9 and np.array_equal(beta_meas, beta_target)
+         and n_ext_ok == 64,
+         "[t_a,t_b] central 9/9 and = -1 iff a!=b; bimultiplicative extension "
+         "matches (-1)^[(sum s)(sum t) - s.t] on {}/64 class pairs"
+         .format(n_ext_ok))
+
+    if L in L_CLOSURE:
+        reps = []
+        for v in classes:
+            g = sp_identity(N)
+            for nu in range(3):
+                if v[nu]:
+                    g = u25.compose(g, tlift[nu])
+            reps.append(g)
+        n_prod_ok = 0
+        n_prod_central = 0
+        for i, s in enumerate(classes):
+            for j, t in enumerate(classes):
+                c = central_sign(commutator(reps[i], reps[j]), N)
+                if c is not None:
+                    n_prod_central += 1
+                    if c == beta_ext(s, t) and c == beta_formula(s, t):
+                        n_prod_ok += 1
+        gate("G4X_LIFTPROD_" + sfx, n_prod_central == 64 and n_prod_ok == 64,
+             "commutators of ACTUAL lift products on all 8x8 class reps are "
+             "central {}/64 and match the extension {}/64"
+             .format(n_prod_central, n_prod_ok))
+        del reps
+
+    # ---------------------------------------------- T3 order and 2-torsion (q)
+    order_ok = True
+    powsign_ok = 0
+    ident = sp_identity(N)
+    for nu in range(3):
+        g = ident
+        for k in range(1, L + 1):
+            g = u25.compose(g, tlift[nu])
+            is_id = (np.array_equal(g[0], ident[0]) and np.array_equal(g[1], ident[1]))
+            if k < L and is_id:
+                order_ok = False
+            if k == L and not is_id:
+                order_ok = False
+            if np.array_equal(g[1], zeta[nu] ** k):
+                powsign_ok += 1
+    half = [sp_pow(tlift[nu], L // 2, N) for nu in range(3)]
+    q_meas = {}
+    q_form = {}
+    for v in classes:
+        g = ident
+        for nu in range(3):
+            if v[nu]:
+                g = u25.compose(g, half[nu])
+        q_meas[tuple(v.tolist())] = central_sign(u25.compose(g, g), N)
+        pairs = int(v[0] * v[1] + v[0] * v[2] + v[1] * v[2])
+        q_form[tuple(v.tolist())] = (-1) ** (((L // 2) ** 2 * pairs) % 2)
+    q_agree = sum(1 for k in q_meas if q_meas[k] == q_form[k])
+    q_minus = sorted(k for k in q_meas if q_meas[k] == -1)
+    if L % 4 == 0:
+        dich_ok = (q_minus == [])
+        dich = "L=0 mod 4 -> q trivial on all 8 v"
+    else:
+        dich_ok = (q_minus == [(0, 1, 1), (1, 0, 1), (1, 1, 0), (1, 1, 1)])
+        dich = "L=2 mod 4 -> q=-I on the four v with >=2 odd entries"
+    gate("G6_ORDER_Q_" + sfx,
+         order_ok and powsign_ok == 3 * L and q_agree == 8 and dich_ok,
+         "(t_nu)^k sign field = zeta_nu^k {}/{}, order exactly {} with "
+         "(t_nu)^L=+I; q matches formula 8/8; {}; q=-I set {}"
+         .format(powsign_ok, 3 * L, L, dich, q_minus if q_minus else "empty"))
+
+    # ------------------------------------------- G5 sign-dressing rejectors (a)
+    sites, exhaustive = flip_sites(L, N)
+    n_flip_rejected = 0
+    n_flip_tested = 0
+    for nu in range(3):
+        for j in sites:
+            s = zeta[nu].copy()
+            s[j] = -s[j]
+            n_flip_tested += 1
+            if not u25.commutes_with_D2((trans_perm[nu], s), D2):
+                n_flip_rejected += 1
+    gate("G5A_FLIP_" + sfx, n_flip_rejected == n_flip_tested and n_flip_tested > 0,
+         "single-site sign flips of zeta_nu break commutation {}/{} ({} site set"
+         ", 3 nu)".format(n_flip_rejected, n_flip_tested,
+                          "exhaustive N=" + str(N) if exhaustive
+                          else "deterministic 32-site stride N//32"))
+
+    # ------------------------------------------- G5 sign-dressing rejectors (b)
+    n_mask_rejected = 0
+    n_mask_tested = 0
+    n_mask_correct_ok = 0
+    for nu in range(3):
+        good = zeta_mask(nu)
+        for m in SUBSETS3:
+            s = mask_sign_field(m, coords)
+            ok = u25.commutes_with_D2((trans_perm[nu], s), D2)
+            if m == good:
+                if ok:
+                    n_mask_correct_ok += 1
+            else:
+                n_mask_tested += 1
+                if not ok:
+                    n_mask_rejected += 1
+    gate("G5B_MASK_" + sfx,
+         n_mask_rejected == 21 and n_mask_tested == 21 and n_mask_correct_ok == 3,
+         "the 7 alternative exponent masks per nu all break commutation {}/21; "
+         "the mask {{mu : mu > nu}} commutes 3/3".format(n_mask_rejected))
+
+    # ------------------------------------------- T4 constructive B_3 lifts (G7)
+    pg_perms = []
+    pg_lifts = []
+    n_b3_lift = 0
+    zero3 = np.zeros(3, dtype=np.int64)
+    for A in B3:
+        pA = affine_perm(A, zero3, lat)
+        sA = propagate(pA, sup, D2)
+        if sA is not None and u25.commutes_with_D2((pA, sA), D2):
+            n_b3_lift += 1
+            pg_perms.append(pA)
+            pg_lifts.append((pA, sA))
+    n_pg_distinct = len({p.tobytes() for p in pg_perms})
+    gate("G7_B3_" + sfx,
+         n_b3_lift == 48 and n_pg_distinct == 48 and sup["connected"],
+         "all 48 B_3 matrices lift by consistent sign propagation {}/48, "
+         "48 distinct permutation parts; connected support graph -> exactly two "
+         "lifts +- each".format(n_b3_lift))
+
+    # --------------------------------------------------- G8 non-B_3 rejector
+    p_sh = affine_perm(SHEAR, zero3, lat)
+    sh_bijection = (len(set(p_sh.tolist())) == N)
+    s_sh = propagate(p_sh, sup, D2)
+    sh_commutes = (s_sh is not None and u25.commutes_with_D2((p_sh, s_sh), D2))
+    gate("G8_SHEAR_" + sfx,
+         sh_bijection and det3(SHEAR) == 1 and not is_signed_perm_matrix(SHEAR)
+         and not sh_commutes,
+         "shear [[1,1,0],[0,1,0],[0,0,1]] det=1, lattice bijection, not a signed "
+         "permutation: propagation {} -> NOT liftable"
+         .format("inconsistent" if s_sh is None else "consistent but commutation fails"))
+
+    # ---------------------------------------------- G9 constructed element count
+    fps = constructed_fingerprints(lat, pg_perms)
+    n_fp = int(np.unique(fps).size)
+    del fps
+    constructed = 2 * 48 * N
+    gc.collect()
+
+    # --------------------------------------- exhaustive-enumeration anchor block
+    enum = None
+    if L in L_ENUM:
+        ce = u25.enumerate_commutant(lat, sup)
+        Comm = ce["Comm"]
+        nStab, nAut = ce["nStab"], ce["nAut"]
+        nLift, nComm = ce["nLift"], ce["nComm"]
+        enum = (nStab, nAut, nLift, nComm)
+
+        pn = 8 * N
+        targets = {}
+        for nu in range(3):
+            targets[trans_perm[nu].tobytes()] = ("t", nu)
+        for a, pA in enumerate(pg_perms):
+            targets.setdefault(pA.tobytes(), ("A", a))
+        counts = dict.fromkeys(targets, 0)
+        for k in Comm:
+            pref = k[:pn]
+            if pref in counts:
+                counts[pref] += 1
+
+        n_t_in = 0
+        n_t_two = 0
+        for nu in range(3):
+            b = trans_perm[nu].tobytes()
+            if (u25.key(tlift[nu]) in Comm
+                    and u25.key((trans_perm[nu], -zeta[nu])) in Comm):
+                n_t_in += 1
+            if counts[b] == 2:
+                n_t_two += 1
+        gate("G3_ENUM_" + sfx, n_t_in == 3 and n_t_two == 3,
+             "closed-form t_nu and -t_nu both present in the enumerated Comm "
+             "{}/3, and the enumerated lifts of that permutation are exactly "
+             "two {}/3".format(n_t_in, n_t_two))
+
+        n_A_in = 0
+        n_A_two = 0
+        for pA, sA in pg_lifts:
+            if u25.key((pA, sA)) in Comm and u25.key((pA, -sA)) in Comm:
+                n_A_in += 1
+            if counts[pA.tobytes()] == 2:
+                n_A_two += 1
+        gate("G7E_ENUM_" + sfx, n_A_in == 48 and n_A_two == 48,
+             "each constructed point-group lift and its negative lie in the "
+             "enumerated Comm key set {}/48, with exactly two enumerated lifts "
+             "each {}/48".format(n_A_in, n_A_two))
+
+        gate("G9S_SUPPORT_" + sfx,
+             nStab == ANCHOR_SUPPORT_STAB[L] and nAut == ANCHOR_SUPPORT_AUT[L]
+             and nAut == nStab * N and nLift <= nAut
+             and nLift == ANCHOR_LIFT_PER_COSET * N,
+             "support-graph Aut census nStab={} nAut={} (=nStab*N); liftable "
+             "nLift={} = 48N{}".format(
+                 nStab, nAut, nLift,
+                 "; support-graph Aut is STRICTLY LARGER than the liftable "
+                 "subgroup here ({} > {})".format(nAut, nLift) if nAut > nLift
+                 else "; support-graph Aut equals the liftable subgroup"))
+
+        gate("G9_COUNTS_" + sfx,
+             n_pg_distinct == 48 and n_fp == 48 * N and constructed == 96 * N
+             and nComm == 96 * N and nLift == 48 * N and nComm == 2 * nLift
+             and constructed == nComm,
+             "constructed {} distinct fingerprints x 2 signs = {} = 96N; "
+             "enumerated nComm={} = 96N = constructed (EXACT equality)"
+             .format(n_fp, constructed, nComm))
+
+        if L in L_CLOSURE:
+            gens = list(tlift) + [sp_minus_identity(N)] + list(pg_lifts)
+            clos = u25.closure(gens)
+            gate("G10_CLOSURE_" + sfx,
+                 len(clos) == 96 * N and clos.keys() == Comm.keys(),
+                 "closure of {{t_x,t_y,t_z,-I}} + 48 point-group lifts ({} gens)"
+                 " has order {} and key set EQUAL to the enumerated Comm"
+                 .format(len(gens), len(clos)))
+            del clos, gens
+
+        del Comm, ce, counts, targets
+        gc.collect()
+    else:
+        gate("G9_COUNTS_" + sfx,
+             n_pg_distinct == 48 and n_fp == 48 * N and constructed == 96 * N,
+             "constructed {} distinct fingerprints x 2 signs = {} = 96N: this is"
+             " a LOWER BOUND |Comm(D2)| >= 96N (no enumeration run at L={})"
+             .format(n_fp, constructed, L))
+
+    row = dict(L=L, N=N, constructed=constructed, n_fp=n_fp, enum=enum,
+               q_minus=q_minus, flips=(n_flip_rejected, n_flip_tested, exhaustive))
+
+    del lat, sup, D2, coords, trans_perm, zeta, tlift, prop, pg_perms, pg_lifts
+    del half, p_sh, s_sh
+    gc.collect()
+    return row
+
+
+def main():
+    print("KCPT Unit 28 -- closed-form lifts and lattice-size independence")
+    print("D2, support structures and the reference enumeration come from "
+          "scripts/kcpt_d2_graded_signed_permutation_commutant_characterization"
+          "_2026_07_25.py")
+    print("constructive L = {}; exhaustive-enumeration anchor L = {}"
+          .format(L_ALL, L_ENUM))
+
+    rows = []
+    for L in L_ALL:
+        rows.append(run_L(L))
+
+    print("\n[SUMMARY]")
+    print("  {:>3} {:>5} {:>8} {:>10} {:>8} {:>8} {:>8}  {}"
+          .format("L", "N", "constr", "nComm", "nLift", "nStab", "nAut", "q=-I set"))
+    for r in rows:
+        if r["enum"] is None:
+            print("  {:>3} {:>5} {:>8} {:>10} {:>8} {:>8} {:>8}  {}"
+                  .format(r["L"], r["N"], r["constructed"], ">= " + str(96 * r["N"]),
+                          "-", "-", "-", r["q_minus"] if r["q_minus"] else "empty"))
+        else:
+            nStab, nAut, nLift, nComm = r["enum"]
+            print("  {:>3} {:>5} {:>8} {:>10} {:>8} {:>8} {:>8}  {}"
+                  .format(r["L"], r["N"], r["constructed"], nComm, nLift, nStab,
+                          nAut, r["q_minus"] if r["q_minus"] else "empty"))
+
+    print("\n[CROSS-L]")
+    gate("XL_96N", all(r["constructed"] == 96 * r["N"] for r in rows),
+         "constructed count = 96N at every L in {}".format(L_ALL))
+    gate("XL_ENUM_EQ",
+         all(r["enum"][3] == 96 * r["N"] and r["enum"][2] == 48 * r["N"]
+             for r in rows if r["enum"] is not None),
+         "enumerated nComm = 96N and nLift = 48N at every L in {} "
+         "(equality with the construction is anchored ONLY here)".format(L_ENUM))
+    gate("XL_DICHOTOMY",
+         all((r["q_minus"] == []) == (r["L"] % 4 == 0) for r in rows)
+         and all(r["q_minus"] == [(0, 1, 1), (1, 0, 1), (1, 1, 0), (1, 1, 1)]
+                 for r in rows if r["L"] % 4 == 2),
+         "2-torsion dichotomy holds at every L: q trivial for L=0 mod 4, "
+         "q=-I on exactly 4 points for L=2 mod 4")
+
+    print("\n" + "=" * 72)
+    print("TOTAL: PASS={} FAIL={}".format(_P[0], _F[0]))
+    sys.exit(0 if _F[0] == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this is

KCPT lane Unit 28. The preceding units read every structural fact about the signed-permutation
commutant `Comm(D2)` off an EXHAUSTIVE enumeration of the group, which capped the lane at
L ∈ {4, 6}. This unit takes the enumeration off the critical path: the translation lifts and
the point-group lifts are written down in **closed form** from the staggered phases, and the
enumeration is called only as an independent anchor at the sizes where it still fits memory.

## The science

1. **Closed-form translation lifts.** The edge condition on the staggered `D2` is solved by
   `zeta_nu(x) = (-1)^{Σ_{mu > nu} x_mu}` — explicitly `zeta_0 = (-1)^{x_1+x_2}`,
   `zeta_1 = (-1)^{x_2}`, `zeta_2 = +1` — unique up to a global sign. Obtained twice by
   independent routes: the closed formula, and a BFS sign-propagation that never sees the
   formula.

2. **Derived commutator pairing and 2-torsion form.** The lifts induce
   `beta(e_a, e_b) = (-1)^{1 - delta_ab}` on `T/2T`, extending bimultiplicatively to
   `beta(s, t) = (-1)^{(Σs)(Σt) - s·t}`; each lift has order exactly `L`; and the quadratic
   form on the 2-torsion points is `q((L/2)v) = (-1)^{(L/2)² Σ_{i<j} v_i v_j}` — trivial when
   `L ≡ 0 (mod 4)`, and `-I` on exactly the four `v` with at least two odd entries when
   `L ≡ 2 (mod 4)`. The increment over Unit 27 is `beta`'s PROVENANCE, and it should not be
   overstated: Unit 27 already derived `q` from `beta` by an argument this unit reuses
   unchanged, but it obtained `beta` by measuring the enumerated group at L ∈ {4, 6}. Here
   `beta` comes from the staggered phases instead, so the chain passes through no enumeration
   at any point — which is what lets the same `q` argument run at L ∈ {8, 10, 12}, where no
   enumeration is available.

3. **All 48 point-group matrices lift.** At each L ∈ {4, 6, 8, 10, 12}, each of the 48
   hyperoctahedral `B₃` matrices (built from scratch in this runner, not read off the
   enumerator) admits a sign lift, giving a constructive `96N` elements of `Comm(D2)`. Unlike
   items 1–2 this is quantified over the sizes tested, not over all even `L`; the note says so
   in the theorem statement and names the `F₂` closed form that would generalise it.

4. **Lattice-size independence.** The census law `|Comm(D2)| = 96N` is established by
   exhaustive enumeration at L ∈ {4, 6, 8, 10} — extending the lane's verified reach from
   N = 216 to N = 1000. At L = 12 the construction yields the lower bound
   `|Comm(D2)| ≥ 96N = 165888` and the note claims nothing stronger.

## Evidence

`TOTAL: PASS=64 FAIL=0` (14+14+12+12+9 per-L gates at L = 4, 6, 8, 10, 12, plus 3 cross-L
gates), on my own re-run from a clean cache.

| L | N | constructed | `nComm` | `nLift` | `nStab` | `nAut` | `q = -I` set |
|---|---|---|---|---|---|---|---|
| 4 | 64 | 6144 | 6144 | 3072 | 720 | 46080 | empty |
| 6 | 216 | 20736 | 20736 | 10368 | 48 | 10368 | 4 points |
| 8 | 512 | 49152 | 49152 | 24576 | 48 | 24576 | empty |
| 10 | 1000 | 96000 | 96000 | 48000 | 48 | 48000 | 4 points |
| 12 | 1728 | 165888 | ≥ 165888 | — | — | — | empty |

The `constructed` column is this unit's closed-form output; the `nComm`/`nLift`/`nStab`/`nAut`
columns come from the exhaustive enumerator, which is run at L ∈ {4, 6, 8, 10} only. Equality
between the two is anchored exactly where both columns are populated.

Three real wrong-value rejectors are wired in (single-site sign flips, seven alternative
sign masks, a det-1 shear), so the sign-field gates fail if the implemented object is wrong.

## Changes

Source-only triple:
- `docs/KCPT_D2_COMMUTANT_CLOSED_FORM_LIFTS_AND_LATTICE_SIZE_INDEPENDENCE_BOUNDED_THEOREM_NOTE_2026-07-25.md`
- `scripts/kcpt_d2_commutant_closed_form_lifts_lattice_size_independence_2026_07_25.py`
- `logs/runner-cache/…` (regenerated)

Dependency edges (markdown links in §5): the Unit 25 characterization note and the Unit 26
double-cover note. The Unit 27 restriction-localization note is referenced with backticks only
— this unit's runner imports Unit 25 alone, and it consumes neither of Unit 27's results: it
re-derives `beta` from the staggered phases and reruns the `q` argument on that derived input.
A dependency edge would misstate the logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
