### PR TITLE
fix(runner): compact maradudin asymptotic runner stdout below the audit packet clip

### DIFF
--- a/logs/runner-cache/lattice_greens_maradudin_asymptotic_accepted_premise_runner.txt
+++ b/logs/runner-cache/lattice_greens_maradudin_asymptotic_accepted_premise_runner.txt
@@ -1,53 +1,53 @@
 ===== runner cache v1 =====
 runner: scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py
-runner_sha256: 3889c5bbc03974c0677b8a0bb1f79cc70d0fa0434c9a07d3e203d15b4d639aa0
+runner_sha256: 63d6a97a8b14e4acf7022db5d178a67959478ff93d64338b573953e090a92086
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.40
+elapsed_sec: 0.56
 status: ok
 ----- stdout -----
 CUBIC-LATTICE GREEN ASYMPTOTIC FRAMEWORK-NATIVE REROUTE
 
-== Part 0: source firewall ==
-  PASS: source note file exists (docs/LATTICE_GREENS_MARADUDIN_ASYMPTOTIC_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-27.md)
-  PASS: source contains required phrase: Framework-Native Replacement For The Former Import
-  PASS: source contains required phrase: Textbook Reference Boundary
-  PASS: source contains required phrase: Maradudin
-  PASS: source contains required phrase: Lawler
-  PASS: source contains required phrase: Spitzer
-  PASS: source contains required phrase: parallel textbook provenance
-  PASS: source contains required phrase: not load-bearing authority
-  PASS: source contains required phrase: framework-local theorem
-  PASS: source contains required phrase: It no longer uses a textbook theorem as a load-bearing premise
-  PASS: source contains required phrase: No new axiom is introduced
-  PASS: source contains required phrase: No new accepted premise is introduced
-  PASS: source contains required phrase: MINIMAL_AXIOMS_2026-06-05.md
-  PASS: source contains required phrase: scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py
-  PASS: source contains required phrase: LATTICE_GREENS_FUNCTION_MARADUDIN_TEXTBOOK_IMPORT_NOTE_2026-05-18.md
-  PASS: source contains required phrase: scripts/lattice_greens_z3_asymptotic_normalization_certificate.py
-  PASS: source contains required phrase: bounded_theorem
-  PASS: source contains required phrase: Status authority
-  PASS: source contains required phrase: independent audit lane only
-  PASS: source note excludes forbidden phrase: PDG load-bearing value
-  PASS: source note excludes forbidden phrase: load-bearing fitted
-  PASS: source note excludes forbidden phrase: Monte Carlo measurement consumed
-  PASS: source note excludes forbidden phrase: load-bearing g_bare value
-  PASS: source note excludes forbidden phrase: Wilson plaquette load-bearing input
-  PASS: source note excludes forbidden phrase: Newton constant G_obs imported
-  PASS: source note excludes forbidden phrase: accepted-premise packet entry
-  PASS: source note excludes forbidden phrase: not derived in this bridge
-  PASS: source note excludes forbidden phrase: admitted named import
-  PASS: source note excludes forbidden phrase: single non-framework input
-  PASS: source note excludes forbidden phrase: named textbook theorem remains
-  PASS: source note excludes forbidden phrase: supplied accepted-premise packet
+-- P0 source firewall
+  PASS: source note file exists
+  PASS: phrase present: Framework-Native Replacement For The Former Import
+  PASS: phrase present: Textbook Reference Boundary
+  PASS: phrase present: Maradudin
+  PASS: phrase present: Lawler
+  PASS: phrase present: Spitzer
+  PASS: phrase present: parallel textbook provenance
+  PASS: phrase present: not load-bearing authority
+  PASS: phrase present: framework-local theorem
+  PASS: phrase present: It no longer uses a textbook theorem as a load-bearing premise
+  PASS: phrase present: No new axiom is introduced
+  PASS: phrase present: No new accepted premise is introduced
+  PASS: phrase present: MINIMAL_AXIOMS_2026-06-05.md
+  PASS: phrase present: scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py
+  PASS: phrase present: LATTICE_GREENS_FUNCTION_MARADUDIN_TEXTBOOK_IMPORT_NOTE_2026-05-18.md
+  PASS: phrase present: scripts/lattice_greens_z3_asymptotic_normalization_certificate.py
+  PASS: phrase present: bounded_theorem
+  PASS: phrase present: Status authority
+  PASS: phrase present: independent audit lane only
+  PASS: forbidden phrase absent: PDG load-bearing value
+  PASS: forbidden phrase absent: load-bearing fitted
+  PASS: forbidden phrase absent: Monte Carlo measurement consumed
+  PASS: forbidden phrase absent: load-bearing g_bare value
+  PASS: forbidden phrase absent: Wilson plaquette load-bearing input
+  PASS: forbidden phrase absent: Newton constant G_obs imported
+  PASS: forbidden phrase absent: accepted-premise packet entry
+  PASS: forbidden phrase absent: not derived in this bridge
+  PASS: forbidden phrase absent: admitted named import
+  PASS: forbidden phrase absent: single non-framework input
+  PASS: forbidden phrase absent: named textbook theorem remains
+  PASS: forbidden phrase absent: supplied accepted-premise packet
 
-== Part 1: (B1) symbol normalization (sympy) ==
-  PASS: (B1) sympy: lambda(k) at order 2 equals kx^2 + ky^2 + kz^2 (deg2 = kx**2 + ky**2 + kz**2)
+-- P1 (B1) symbol norm (sympy)
+  PASS: (B1) sympy: lambda(k) at order 2 equals kx^2 + ky^2 + kz^2
   PASS: (B1) sympy: lambda(k) has no order-3 cross-terms (even-cosine symmetry)
   PASS: (B1) sympy: lambda(k) has non-zero O(|k|^4) correction (deg4 = -kx**4/12 - ky**4/12 - kz**4/12)
   PASS: (B1) sympy: axis expansion is eps^2 - eps^4/12 + O(eps^6)
 
-== Part 1b: (B1) symbol normalization (numerical) ==
+-- P1b (B1) symbol norm (numeric)
   PASS: (B1) axis lambda(eps,0,0) / eps^2 ~ 1 at eps=0.10000 (ratio=0.9991669444)
   PASS: (B1) diag lambda(eps,eps,eps) / (3 eps^2) ~ 1 at eps=0.10000 (ratio=0.9991669444)
   PASS: (B1) axis lambda(eps,0,0) / eps^2 ~ 1 at eps=0.05000 (ratio=0.9997916840)
@@ -57,16 +57,16 @@ CUBIC-LATTICE GREEN ASYMPTOTIC FRAMEWORK-NATIVE REROUTE
   PASS: (B1) axis lambda(eps,0,0) / eps^2 ~ 1 at eps=0.01250 (ratio=0.9999869792)
   PASS: (B1) diag lambda(eps,eps,eps) / (3 eps^2) ~ 1 at eps=0.01250 (ratio=0.9999869792)
 
-== Part 2: (B2) continuum-kernel unit flux (sympy) ==
+-- P2 (B2) unit flux (sympy)
   PASS: (B2) sympy: -d(1/(4 pi r))/dr = 1/(4 pi r^2)
-  PASS: (B2) sympy: int_{S^2} R^2 * (1/(4 pi R^2)) dOmega = 1 (flux = 1)
-  PASS: (B2) numerical: flux at R=1.0 equals 1.0 (flux=1.0000000000000000)
-  PASS: (B2) numerical: flux at R=2.0 equals 1.0 (flux=1.0000000000000000)
-  PASS: (B2) numerical: flux at R=5.0 equals 1.0 (flux=1.0000000000000000)
-  PASS: (B2) numerical: flux at R=10.0 equals 1.0 (flux=1.0000000000000000)
-  PASS: (B2) numerical: flux at R=100.0 equals 1.0 (flux=1.0000000000000000)
+  PASS: (B2) sympy: int_{S^2} R^2 * (1/(4 pi R^2)) dOmega = 1
+  PASS: (B2) numerical: flux at R=1.0 equals 1.0
+  PASS: (B2) numerical: flux at R=2.0 equals 1.0
+  PASS: (B2) numerical: flux at R=5.0 equals 1.0
+  PASS: (B2) numerical: flux at R=10.0 equals 1.0
+  PASS: (B2) numerical: flux at R=100.0 equals 1.0
 
-== Part 3: (B3) lattice-harmonic residual decay ==
+-- P3 (B3) residual decay
   PASS: (B3) scaled residual r^5 |Delta_lat phi| bounded at r=16 (scaled=0.278758)
   PASS: (B3) scaled residual r^5 |Delta_lat phi| bounded at r=32 (scaled=0.278580)
   PASS: (B3) residual decays by ~r^-5 between r and r/2 at r=32 (ratio=32.020)
@@ -76,28 +76,28 @@ CUBIC-LATTICE GREEN ASYMPTOTIC FRAMEWORK-NATIVE REROUTE
   PASS: (B3) residual decays by ~r^-5 between r and r/2 at r=128 (ratio=32.001)
   PASS: (B3) scaled coefficient stable across r=16..128 (first=0.2788 last=0.2785)
 
-== Part 4: (B4) framework constant identification ==
+-- P4 (B4) constant identification
   PASS: (B4) sympy: c = 1/(4 pi) for the framework unit point-source convention
   PASS: (B4) numerical: target c value 1/(4 pi) computed (c = 0.0795774715459477)
-  PASS: (B4) numerical: 4 pi = 12.566370614... (4 pi = 12.566370614359)
+  PASS: (B4) numerical: 4 pi = 12.566370614...
 
-== Part 5: dependency status check ==
-  PASS: Parent Maradudin wrapper note file exists (docs/LATTICE_GREENS_FUNCTION_MARADUDIN_TEXTBOOK_IMPORT_NOTE_2026-05-18.md)
+-- P5 dependency status
+  PASS: Parent Maradudin wrapper note file exists
   PASS: parent carries framework-local proof language
-  PASS: Parent normalization certificate runner exists (scripts/lattice_greens_z3_asymptotic_normalization_certificate.py)
-  PASS: Parent normalization certificate cache exists (logs/runner-cache/lattice_greens_z3_asymptotic_normalization_certificate.txt)
-  PASS: MINIMAL_AXIOMS_2026-06-05.md exists (docs/MINIMAL_AXIOMS_2026-06-05.md)
+  PASS: Parent normalization certificate runner exists
+  PASS: Parent normalization certificate cache exists
+  PASS: MINIMAL_AXIOMS_2026-06-05.md exists
 
-== Part 6: no forbidden imports ==
-  PASS: source note excludes literature comparator: PDG obs value
-  PASS: source note excludes literature comparator: fitted selector consumed
-  PASS: source note excludes literature comparator: Newton constant G_obs imported
-  PASS: source note excludes literature comparator: Planck length l_P_obs imported
-  PASS: source note excludes literature comparator: Bekenstein-Hawking entropy observed import
-  PASS: source note excludes literature comparator: Wilson plaquette load-bearing input
-  PASS: source note excludes literature comparator: Monte Carlo measurement consumed
+-- P6 no forbidden imports
+  PASS: comparator absent: PDG obs value
+  PASS: comparator absent: fitted selector consumed
+  PASS: comparator absent: Newton constant G_obs imported
+  PASS: comparator absent: Planck length l_P_obs imported
+  PASS: comparator absent: Bekenstein-Hawking entropy observed import
+  PASS: comparator absent: Wilson plaquette load-bearing input
+  PASS: comparator absent: Monte Carlo measurement consumed
 
-== Part 7: no new axioms or vocabulary ==
+-- P7 no new axioms
   PASS: note disclaims new axiom introduction
   PASS: note disclaims new accepted-premise introduction
   PASS: legacy row consumes parent framework-local theorem

--- a/scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py
+++ b/scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py
@@ -46,7 +46,15 @@ PASS = 0
 FAIL = 0
 
 
-def check(name: str, condition: bool, detail: str = "") -> bool:
+def check(
+    name: str, condition: bool, detail: str = "", fail_detail: str = ""
+) -> bool:
+    """Print one check line.
+
+    ``detail`` is printed on PASS and on FAIL; ``fail_detail`` carries
+    diagnostic text (paths, echoed expectations) that only restates the
+    check label, so it is printed on FAIL only.
+    """
     global PASS, FAIL
     status = "PASS" if condition else "FAIL"
     if condition:
@@ -54,19 +62,22 @@ def check(name: str, condition: bool, detail: str = "") -> bool:
     else:
         FAIL += 1
     msg = f"{status}: {name}"
-    if detail:
-        msg += f" ({detail})"
+    extra = detail
+    if not condition and fail_detail:
+        extra = f"{detail}; {fail_detail}" if detail else fail_detail
+    if extra:
+        msg += f" ({extra})"
     print("  " + msg)
     return condition
 
 
 def part0_source_firewall() -> None:
     """Verify the source note carries the required boundary phrases."""
-    print("\n== Part 0: source firewall ==")
+    print("\n-- P0 source firewall")
     check(
         "source note file exists",
         NOTE_PATH.is_file(),
-        str(NOTE_PATH.relative_to(ROOT)),
+        fail_detail=str(NOTE_PATH.relative_to(ROOT)),
     )
     note = NOTE_PATH.read_text(encoding="utf-8")
     note_flat = " ".join(note.split())
@@ -92,7 +103,7 @@ def part0_source_firewall() -> None:
     ]
     for phrase in required:
         check(
-            f"source contains required phrase: {phrase}",
+            f"phrase present: {phrase}",
             phrase in note or phrase in note_flat,
         )
 
@@ -112,14 +123,14 @@ def part0_source_firewall() -> None:
     ]
     for phrase in forbidden:
         check(
-            f"source note excludes forbidden phrase: {phrase}",
+            f"forbidden phrase absent: {phrase}",
             phrase not in note and phrase not in note_flat,
         )
 
 
 def part1_symbol_normalization_symbolic() -> None:
     """(B1) sympy: lambda(k) = |k|^2 + O(|k|^4) on Z^3."""
-    print("\n== Part 1: (B1) symbol normalization (sympy) ==")
+    print("\n-- P1 (B1) symbol norm (sympy)")
     kx, ky, kz = sp.symbols("kx ky kz", real=True)
     lam = 6 - 2 * (sp.cos(kx) + sp.cos(ky) + sp.cos(kz))
     # Taylor expand at k=0 to fourth order
@@ -141,7 +152,7 @@ def part1_symbol_normalization_symbolic() -> None:
     check(
         "(B1) sympy: lambda(k) at order 2 equals kx^2 + ky^2 + kz^2",
         sp.simplify(deg2 - target) == 0,
-        f"deg2 = {sp.simplify(deg2)}",
+        fail_detail=f"deg2 = {sp.simplify(deg2)}",
     )
 
     # Check: there is no order-3 term (cosine is even, so symmetry kills it)
@@ -182,7 +193,7 @@ def part1_symbol_normalization_symbolic() -> None:
 
 def part1b_symbol_normalization_numerical() -> None:
     """(B1) numerical: lambda(k) / |k|^2 -> 1 as |k| -> 0."""
-    print("\n== Part 1b: (B1) symbol normalization (numerical) ==")
+    print("\n-- P1b (B1) symbol norm (numeric)")
     for eps in (1e-1, 5e-2, 2.5e-2, 1.25e-2):
         sym_axis = 6.0 - 2.0 * (math.cos(eps) + math.cos(0.0) + math.cos(0.0))
         ratio_axis = sym_axis / (eps * eps)
@@ -204,7 +215,7 @@ def part1b_symbol_normalization_numerical() -> None:
 
 def part2_unit_flux_symbolic() -> None:
     """(B2) sympy: continuum kernel 1/(4 pi r) carries unit outward flux."""
-    print("\n== Part 2: (B2) continuum-kernel unit flux (sympy) ==")
+    print("\n-- P2 (B2) unit flux (sympy)")
     r = sp.Symbol("r", positive=True)
     phi = 1 / (4 * sp.pi * r)
     grad_phi_radial = sp.diff(phi, r)
@@ -227,7 +238,7 @@ def part2_unit_flux_symbolic() -> None:
     check(
         "(B2) sympy: int_{S^2} R^2 * (1/(4 pi R^2)) dOmega = 1",
         sp.simplify(flux - 1) == 0,
-        f"flux = {flux}",
+        fail_detail=f"flux = {flux}",
     )
     # Sanity at multiple radii numerically
     for radius in (1.0, 2.0, 5.0, 10.0, 100.0):
@@ -237,7 +248,7 @@ def part2_unit_flux_symbolic() -> None:
         check(
             f"(B2) numerical: flux at R={radius:.1f} equals 1.0",
             math.isclose(flux_num, 1.0, rel_tol=0.0, abs_tol=1e-15),
-            f"flux={flux_num:.16f}",
+            fail_detail=f"flux={flux_num:.16f}",
         )
 
 
@@ -265,7 +276,7 @@ def graph_laplacian_on_kernel(x: tuple[int, int, int]) -> float:
 
 def part3_lattice_harmonic_residual() -> None:
     """(B3) numerical: (-Delta_lat)(1/(4 pi r)) = O(r^-5) at axis."""
-    print("\n== Part 3: (B3) lattice-harmonic residual decay ==")
+    print("\n-- P3 (B3) residual decay")
     previous = None
     scaled_history = []
     for radius in (16, 32, 64, 128):
@@ -300,7 +311,7 @@ def part3_lattice_harmonic_residual() -> None:
 
 def part4_framework_constant_identification() -> None:
     """(B4) c = 1/(4 pi) is the framework-stencil asymptotic constant."""
-    print("\n== Part 4: (B4) framework constant identification ==")
+    print("\n-- P4 (B4) constant identification")
     # Symbolic: parameterise G(r) = c / r and check that the only c
     # making (-Delta_lat) (G) asymptotically consistent with a unit
     # point source is c = 1/(4 pi).
@@ -328,13 +339,13 @@ def part4_framework_constant_identification() -> None:
     check(
         "(B4) numerical: 4 pi = 12.566370614...",
         math.isclose(four_pi, 12.566370614359172, rel_tol=1e-15),
-        f"4 pi = {four_pi:.12f}",
+        fail_detail=f"4 pi = {four_pi:.12f}",
     )
 
 
 def part5_dependency_status() -> None:
     """Verify load-bearing one-hop dependency is framework-local."""
-    print("\n== Part 5: dependency status check ==")
+    print("\n-- P5 dependency status")
     parent = (
         ROOT
         / "docs/LATTICE_GREENS_FUNCTION_MARADUDIN_TEXTBOOK_IMPORT_NOTE_2026-05-18.md"
@@ -342,7 +353,7 @@ def part5_dependency_status() -> None:
     check(
         "Parent Maradudin wrapper note file exists",
         parent.is_file(),
-        str(parent.relative_to(ROOT)),
+        fail_detail=str(parent.relative_to(ROOT)),
     )
     parent_text = parent.read_text(encoding="utf-8") if parent.is_file() else ""
     check(
@@ -356,7 +367,7 @@ def part5_dependency_status() -> None:
     check(
         "Parent normalization certificate runner exists",
         cert_runner.is_file(),
-        str(cert_runner.relative_to(ROOT)),
+        fail_detail=str(cert_runner.relative_to(ROOT)),
     )
     cert_cache = (
         ROOT / "logs/runner-cache/lattice_greens_z3_asymptotic_normalization_certificate.txt"
@@ -364,19 +375,19 @@ def part5_dependency_status() -> None:
     check(
         "Parent normalization certificate cache exists",
         cert_cache.is_file(),
-        str(cert_cache.relative_to(ROOT)),
+        fail_detail=str(cert_cache.relative_to(ROOT)),
     )
     axioms = ROOT / "docs/MINIMAL_AXIOMS_2026-06-05.md"
     check(
         "MINIMAL_AXIOMS_2026-06-05.md exists",
         axioms.is_file(),
-        str(axioms.relative_to(ROOT)),
+        fail_detail=str(axioms.relative_to(ROOT)),
     )
 
 
 def part6_no_forbidden_imports() -> None:
     """No PDG / Monte Carlo / fitted value imported."""
-    print("\n== Part 6: no forbidden imports ==")
+    print("\n-- P6 no forbidden imports")
     note = NOTE_PATH.read_text(encoding="utf-8")
     forbidden_substrings = [
         "PDG " + "obs " + "value",
@@ -389,14 +400,14 @@ def part6_no_forbidden_imports() -> None:
     ]
     for phrase in forbidden_substrings:
         check(
-            f"source note excludes literature comparator: {phrase}",
+            f"comparator absent: {phrase}",
             phrase not in note,
         )
 
 
 def part7_no_new_axioms() -> None:
     """No new repo vocabulary or repo-wide axiom introduced."""
-    print("\n== Part 7: no new axioms or vocabulary ==")
+    print("\n-- P7 no new axioms")
     note = NOTE_PATH.read_text(encoding="utf-8")
     note_flat = " ".join(note.split())
     # Verify the note explicitly disclaims new axioms


### PR DESCRIPTION
## Verdict this responds to

`lattice_greens_maradudin_asymptotic_accepted_premise_bridge_bounded_note_2026-05-27` is `audited_conditional`, tag `runner_artifact_issue`. The restricted audit packet renders at most 6000 chars of runner cache body (tail-kept), so the load-bearing stdout arrived clipped and clean certification was blocked for mechanical, not scientific, reasons. Transitive descendants: 769.

The lever is the science-side runner's own stdout. The audit tooling is not touched.

## What changed

Two files: the runner and its cache. The note is not at fault and is unmodified.

- `check()` gains `fail_detail` — diagnostic text that only restates its own check label (four dependency path strings, three echoed expectations such as `deg2 = ...`, `flux = ...`, `4 pi = ...`) now prints on FAIL only. A failure still shows the measured value; a pass no longer re-prints what the label already states.
- Three check-label prefixes shortened (`source contains required phrase:` -> `phrase present:`, `source note excludes forbidden phrase:` -> `forbidden phrase absent:`, `source note excludes literature comparator:` -> `comparator absent:`). The variable part of every label — the actual phrase or comparator being tested — is byte-identical and still printed on PASS.
- Section banners reduced to a single short rule line.

No check was added, removed, reordered, or reconditioned. All 27 `check()` call sites keep identical conditions and identical numeric constants.

## Numbers

| | before | after |
|---|---|---|
| cache body chars | 7105 | **5750** |
| exit code | 0 | 0 |
| PASS / FAIL | 76 / 0 | 76 / 0 |

Re-run in the worktree by hand: exit 0, `TOTAL: PASS=76 FAIL=0`, all 76 PASS lines mutually distinct. The `TOTAL:` and 268-char `VERDICT:` lines pinned in the note's `Expected:` block are byte-identical to origin/main, so note and cache remain in agreement. All 18 required phrases, 12 forbidden phrases and 7 literature comparators still appear verbatim in their own PASS lines. No sibling runner in `scripts/` reads this runner or its cache.

## Boundary

This is an evidence-rendering repair. It makes no scientific claim and changes no result. Grading remains entirely with the independent audit lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)