### PR TITLE
fix(record-function): source the generation sector split from retained authorities

### DIFF
--- a/docs/RECORD_FUNCTION_FINITE_SECTOR_ALGEBRA_2026-06-05.md
+++ b/docs/RECORD_FUNCTION_FINITE_SECTOR_ALGEBRA_2026-06-05.md
@@ -6,7 +6,7 @@
 pipeline-derived after audit. This note does not set, predict, or propose an
 audit outcome.
 **Primary runner:** [`scripts/record_function_finite_sector_algebra_2026_06_05.py`](../scripts/record_function_finite_sector_algebra_2026_06_05.py)
-(sympy + finite subset checks; **SCORECARD 21 PASS / 0 FAIL**).
+(sympy + finite subset checks; **SCORECARD 32 PASS / 0 FAIL**).
 **Cached log:** [`logs/runner-cache/record_function_finite_sector_algebra_2026_06_05.txt`](../logs/runner-cache/record_function_finite_sector_algebra_2026_06_05.txt).
 
 ## Scope and honesty
@@ -125,7 +125,30 @@ gives `d/(u+d)=p`. Thus Record alone cannot select a value.
 
 ## Generation-dial specialization
 
-For the generation two-sector readout, the sector powers are
+For the generation two-sector readout, the two sectors are the `C3` isotypic
+components of the real `C3`-equivariant readout triple. That triple is not
+posited here. The retained
+[Abstract Hermitian-Circulant Fourier Invariant Theorem](KOIDE_KAPPA_SPECTRUM_OPERATOR_BRIDGE_THEOREM_NOTE_2026-04-19.md)
+supplies it exactly: with `C` the cyclic shift, `omega = exp(2 pi i/3)`, and
+`f_k = (1, omega^k, omega^(2k))^T/sqrt(3)` satisfying `C f_k = omega^k f_k`,
+
+```text
+Herm_circ(3) = { H(a,b) = a I + b C + conjugate(b) C^2 : a in R, b in C },
+lambda_k     = a + b omega^k + conjugate(b) omega^(-k),
+```
+
+and those `lambda_k` "are real for all `a in R` and `b in C`". The `f_k` are
+orthonormal, `f_0` carries the trivial character and `(f_1,f_2)` carry the
+two-dimensional block, so the readout power splits over the two isotypic
+sectors as
+
+```text
+|<f_0, lambda>|^2                     = 3a^2,
+|<f_1, lambda>|^2 + |<f_2, lambda>|^2 = 6|b|^2.
+```
+
+Dividing out the common factor `3`, the sector powers are therefore not a
+supplied assignment but the isotypic split itself:
 
 ```text
 singlet readout = a^2,
@@ -152,8 +175,8 @@ s = log2(rho) = log2(2r).
 ```
 
 For the named `Q` endpoint entries, the finite generation readout packet uses
-the standard three-slot Koide structural coordinate attached to the supplied
-`C3`/`K`-real generation context:
+the standard three-slot Koide structural coordinate on that same
+`C3`/`K`-real generation readout:
 
 ```text
 Q = (sum_k lambda_k^2) / (sum_k lambda_k)^2.
@@ -163,8 +186,15 @@ Here the `K`/CPT-real `C3`-equivariant square-root readout has the finite
 character form
 
 ```text
-lambda_k = a + 2|b| cos(theta + 2 pi k/3),     k=0,1,2.
+lambda_k = a + 2|b| cos(theta + 2 pi k/3),     k=0,1,2,
 ```
+
+with `theta = arg(b)`. Neither this coordinate form nor the identity
+`Q = 1/3 + (2/3)r` derived below is assumed here. The retained
+[Registered Positive Mass Triple: Exact C3 Fourier Coordinates and Koide Identity](CHARGED_LEPTON_REGISTERED_MASS_DFT_COORDINATE_THEOREM_NOTE_2026-07-11.md)
+proves both for **any** positive real triple with `z_j = sqrt(m_j)`, obtaining
+`z_j = a + 2|c| cos(phi + 2 pi j/3)` and `Q = 1/3 + 2r/3` with `r = |c|^2/a^2`;
+that note's `c` is this note's `b`, and its `phi` is this note's `theta`.
 
 The `C3` character sums give, exactly,
 
@@ -188,6 +218,11 @@ Q = (singlet readout + doublet readout)/(3 singlet readout).
 
 This is a structural coordinate on the supplied generation readout, not a
 probability, dynamics, occupancy selector, or measured-mass assertion.
+
+The two retained authorities cited above supply the real `C3`-equivariant
+spectrum and the coordinate identity used here; naming that reality condition
+`K`/CPT-real is the standing readout-context pin carried elsewhere in the
+framework, and is not re-derived here.
 
 The named endpoints are:
 
@@ -229,7 +264,18 @@ The runner verifies:
 - generation specialization `rho=2r`, `s=log2(rho)`, and the two named
   endpoints;
 - the finite `C3`/`K`-real power-sum definition of the generation `Q`
-  coordinate, deriving `Q = 1/3 + (2/3)r` before endpoint substitution.
+  coordinate, deriving `Q = 1/3 + (2/3)r` before endpoint substitution;
+- that both cited authority notes exist, that this note links to each of them,
+  and that each one's sharded ledger row carries a retained effective status
+  read from the shard file;
+- exactly, from `lambda_k = a + b omega^k + conjugate(b) omega^(-k)`: reality
+  of every `lambda_k`, the equivalent character form
+  `a + 2|b| cos(theta + 2 pi k/3)`, orthonormality of the `f_k`, the isotypic
+  power split `3a^2 : 6|b|^2`, the power sums `3a` and `3a^2 + 6|b|^2`, their
+  agreement with `3 (singlet + doublet)`, and `Q = 1/3 + (2/3)r`;
+- a discriminating rejector: the alternative assignment `doublet = |b|^2`
+  fails to reproduce `sum_k lambda_k^2`, so the power-split gate is not
+  tautological.
 
 ## Net
 

--- a/docs/RECORD_FUNCTION_FINITE_SECTOR_ALGEBRA_2026-06-05.md
+++ b/docs/RECORD_FUNCTION_FINITE_SECTOR_ALGEBRA_2026-06-05.md
@@ -96,7 +96,7 @@ dynamics. It is not yet a probability calculus.
 For a two-sector record function
 
 ```text
-v = (u, d),     u+d != 0,
+v = (u, d),     u+d != 0,     u != 0,
 ```
 
 the normalized coordinates
@@ -111,8 +111,9 @@ sum to one and are invariant under global readout scaling. The raw ratio
 rho = d/u
 ```
 
-is also scale-invariant. These are structural readout coordinates. Calling
-them probabilities requires a separate normalization/Born gate.
+is also scale-invariant under a nonzero global scale. These are structural
+readout coordinates. Calling them probabilities requires a separate
+normalization/Born gate.
 
 Finite additivity leaves the normalized coordinate arbitrary: for any supplied
 `p` in `(0,1)`, choosing
@@ -123,13 +124,23 @@ d = p u / (1-p)
 
 gives `d/(u+d)=p`. Thus Record alone cannot select a value.
 
-## Generation-dial specialization
+## Conditional abstract `C3` two-block coordinate
 
-For the generation two-sector readout, the two sectors are the `C3` isotypic
-components of the real `C3`-equivariant readout triple. That triple is not
-posited here. The retained
+This specialization is conditional. Supply:
+
+1. a real `C3` spectrum `lambda` obtained from an abstract
+   Hermitian-circulant element `H(a,b)`; and
+2. an identification of two scalar record coordinates with one third of the
+   trivial and doublet Fourier-projection powers of that spectrum.
+
+Neither supplied input follows from Record. In particular, this note does not
+select a physical carrier, identify the coordinates with generations, supply
+a `K`/CPT readout context, or construct a registered-mass functional.
+
+The
 [Abstract Hermitian-Circulant Fourier Invariant Theorem](KOIDE_KAPPA_SPECTRUM_OPERATOR_BRIDGE_THEOREM_NOTE_2026-04-19.md)
-supplies it exactly: with `C` the cyclic shift, `omega = exp(2 pi i/3)`, and
+establishes the first algebraic input: with `C` the cyclic shift,
+`omega = exp(2 pi i/3)`, and
 `f_k = (1, omega^k, omega^(2k))^T/sqrt(3)` satisfying `C f_k = omega^k f_k`,
 
 ```text
@@ -147,15 +158,15 @@ sectors as
 |<f_1, lambda>|^2 + |<f_2, lambda>|^2 = 6|b|^2.
 ```
 
-Dividing out the common factor `3`, the sector powers are therefore not a
-supplied assignment but the isotypic split itself:
+Under supplied input 2, dividing out the common factor `3` defines the two
+record coordinates:
 
 ```text
 singlet readout = a^2,
 doublet readout = 2|b|^2.
 ```
 
-With
+For `a != 0`, define
 
 ```text
 r = |b|^2/a^2,
@@ -168,33 +179,26 @@ we have
 rho = 2r.
 ```
 
-The exact dial coordinate is therefore
+When also `b != 0`, `rho>0` and the logarithmic dial coordinate is
 
 ```text
 s = log2(rho) = log2(2r).
 ```
 
-For the named `Q` endpoint entries, the finite generation readout packet uses
-the standard three-slot Koide structural coordinate on that same
-`C3`/`K`-real generation readout:
+At `b=0`, `rho=0`; the logarithmic dial is absent and `arg(b)` has no defined
+phase. For `b != 0`, write `theta = arg(b)`. The real spectrum then has the
+equivalent character form
+
+```text
+lambda_k = a + 2|b| cos(theta + 2 pi k/3),     k=0,1,2.
+```
+
+For `a != 0`, so that `sum_k lambda_k = 3a != 0`, define the structural
+three-slot coordinate
 
 ```text
 Q = (sum_k lambda_k^2) / (sum_k lambda_k)^2.
 ```
-
-Here the `K`/CPT-real `C3`-equivariant square-root readout has the finite
-character form
-
-```text
-lambda_k = a + 2|b| cos(theta + 2 pi k/3),     k=0,1,2,
-```
-
-with `theta = arg(b)`. Neither this coordinate form nor the identity
-`Q = 1/3 + (2/3)r` derived below is assumed here. The retained
-[Registered Positive Mass Triple: Exact C3 Fourier Coordinates and Koide Identity](CHARGED_LEPTON_REGISTERED_MASS_DFT_COORDINATE_THEOREM_NOTE_2026-07-11.md)
-proves both for **any** positive real triple with `z_j = sqrt(m_j)`, obtaining
-`z_j = a + 2|c| cos(phi + 2 pi j/3)` and `Q = 1/3 + 2r/3` with `r = |c|^2/a^2`;
-that note's `c` is this note's `b`, and its `phi` is this note's `theta`.
 
 The `C3` character sums give, exactly,
 
@@ -203,7 +207,7 @@ sum_k lambda_k     = 3a,
 sum_k lambda_k^2   = 3a^2 + 6|b|^2.
 ```
 
-Therefore this packet derives the displayed generation-coordinate formula
+Therefore this packet derives the displayed abstract coordinate formula
 before substituting endpoints:
 
 ```text
@@ -216,23 +220,37 @@ Equivalently, in the two-block record-function notation above,
 Q = (singlet readout + doublet readout)/(3 singlet readout).
 ```
 
-This is a structural coordinate on the supplied generation readout, not a
-probability, dynamics, occupancy selector, or measured-mass assertion.
+The
+[Registered Positive Mass Triple: Exact C3 Fourier Coordinates and Koide Identity](CHARGED_LEPTON_REGISTERED_MASS_DFT_COORDINATE_THEOREM_NOTE_2026-07-11.md)
+independently establishes the same Fourier reconstruction and `Q` identity
+when a strictly positive real triple `z_j = sqrt(m_j)` is already supplied.
+In that domain `a>0`, and its phase is defined only when its nontrivial Fourier
+coefficient is nonzero. That theorem does not construct the physical
+registered-mass readout or supply the Record-to-power identification assumed
+here.
 
-The two retained authorities cited above supply the real `C3`-equivariant
-spectrum and the coordinate identity used here; naming that reality condition
-`K`/CPT-real is the standing readout-context pin carried elsewhere in the
-framework, and is not re-derived here.
+This is therefore an abstract structural coordinate under two explicit
+inputs, not a probability, dynamics, occupancy selector, generation
+assignment, or measured-mass assertion.
 
 The named endpoints are:
 
 ```text
-rho=1 -> s=0 -> r=1/2 -> Q=2/3
-rho=2 -> s=1 -> r=1   -> Q=1
+rho=1 -> s=0 -> r=1/2 -> Q=2/3    (interior coordinate)
+rho=2 -> s=1 -> r=1   -> Q=1      (formal real-spectrum endpoint)
 ```
 
-The runner verifies these identities exactly and verifies that `rho` remains a
-free readout ratio until a weighting or dynamics gate is supplied.
+The `Q=1` value is not attained by a strictly positive triple because
+
+```text
+(sum_k lambda_k)^2 - sum_k lambda_k^2
+  = 2 sum_(i<j) lambda_i lambda_j > 0.
+```
+
+It is a nonnegative-closure value, for example at a permutation of
+`(3a,0,0)`, or a formal value of the unrestricted real-spectrum algebra. The
+runner verifies the identities and domains exactly and verifies that `rho`
+remains a free readout ratio until a weighting or dynamics gate is supplied.
 
 ## What this unlocks
 
@@ -261,21 +279,23 @@ The runner verifies:
 - associative composition of coarse-grainings;
 - scale invariance of normalized coordinates and ratios;
 - arbitrariness of two-sector normalized coordinates under Record alone;
-- generation specialization `rho=2r`, `s=log2(rho)`, and the two named
-  endpoints;
-- the finite `C3`/`K`-real power-sum definition of the generation `Q`
-  coordinate, deriving `Q = 1/3 + (2/3)r` before endpoint substitution;
+- the conditional abstract `C3` specialization `rho=2r`,
+  `s=log2(rho)`, and the domains and status of the two named endpoints;
+- the finite real-`C3` power-sum definition of `Q`, deriving
+  `Q = 1/3 + (2/3)r` before endpoint substitution;
 - that both cited authority notes exist, that this note links to each of them,
-  and that each one's sharded ledger row carries a retained effective status
-  read from the shard file;
+  and that each one's live sharded ledger row remains dependency-eligible as a
+  pipeline compatibility check, not a proof of semantic scope;
 - exactly, from `lambda_k = a + b omega^k + conjugate(b) omega^(-k)`: reality
   of every `lambda_k`, the equivalent character form
   `a + 2|b| cos(theta + 2 pi k/3)`, orthonormality of the `f_k`, the isotypic
   power split `3a^2 : 6|b|^2`, the power sums `3a` and `3a^2 + 6|b|^2`, their
   agreement with `3 (singlet + doublet)`, and `Q = 1/3 + (2/3)r`;
 - a discriminating rejector: the alternative assignment `doublet = |b|^2`
-  fails to reproduce `sum_k lambda_k^2`, so the power-split gate is not
-  tautological.
+  is not the same polynomial identity for nonzero `b`, while both assignments
+  correctly coincide at the degenerate boundary `b=0`;
+- two distinct supplied update maps preserve finite additivity, so Record does
+  not select dynamics.
 
 ## Net
 

--- a/logs/runner-cache/record_function_finite_sector_algebra_2026_06_05.txt
+++ b/logs/runner-cache/record_function_finite_sector_algebra_2026_06_05.txt
@@ -1,9 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/record_function_finite_sector_algebra_2026_06_05.py
-runner_sha256: 0e85b68f4a6fa29f795e1956505e4bc20bcd3321104bfe6c02f12cbe5c9a161e
+runner_sha256: cd69cf2741221e3442d509fac42e3f5170b4e21eff4ca98354e421c3752654cf
+input_fingerprint_sha256: f346bb2a4f42b5f9c164f484581e087bc1544d7a27af3a6d38509fb498c94dc8
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.84
+elapsed_sec: 0.93
 status: ok
 ----- stdout -----
 [PASS] R1.1 finite additivity holds for every ordered disjoint pair of 4 supplied records
@@ -22,32 +23,33 @@ status: ok
 [PASS] R3.3 readout ratios are invariant under global readout scaling
 [PASS] R3.4 finite additivity leaves normalized two-sector coordinate arbitrary
        for any supplied p in (0,1), choose d=p*u/(1-p)
-[PASS] R4.1 generation sector ratio is doublet/singlet = 2r
+[PASS] R4.1 conditional two-block ratio is doublet/singlet = 2r
        sector_ratio=2*b2/a2
 [PASS] R4.2 dial coordinate is log2(doublet/singlet)
-[PASS] R4.3 C3/KCPT square-root readout power sums define Q
+[PASS] R4.3 real C3 coordinate power sums define Q
        S1=3*alpha; S2=3*alpha**2 + 6*beta**2
 [PASS] R4.4 Q = S2/S1^2 derives Q(r)=1/3+2r/3 before endpoint substitution
        Q=(alpha**2 + 2*beta**2)/(3*alpha**2)
-[PASS] R4.5 two-block powers give the same generation Q coordinate
+[PASS] R4.5 two-block powers give the same abstract C3 Q coordinate
        Q_blocks=(a2 + 2*b2)/(3*a2)
-[PASS] R4.6 sector balance rho=1 gives s=0, r=1/2, Q=2/3
-[PASS] R4.7 real-mode balance rho=2 gives s=1, r=1, Q=1
+[PASS] R4.6 two-block balance rho=1 gives s=0, r=1/2, Q=2/3
+[PASS] R4.7 rho=2 gives formal Q=1, only a nonnegative-closure endpoint
+       strictly positive triples have S1^2-S2>0 and therefore Q<1
 [PASS] R4.8 Record additivity permits arbitrary positive sector ratio rho
        rho remains a free readout ratio until a weighting/dynamics gate is supplied
 [PASS] R5.1 normalized coordinate is not the same object as raw sector ratio
        normalization is an extra coordinate choice, not a new Record axiom
-[PASS] R5.2 finite additivity imposes no autonomous update law on the readout vector
-       the vector is unchanged until an external dynamics map is supplied
+[PASS] R5.2 finite additivity does not select an autonomous update law
+       distinct identity and swap updates preserve the same additive readout rule
 [PASS] R6.0 omega is the exact primitive cube root exp(2 pi i/3)
 [PASS] R6.1 both cited authority notes exist at their exact docs/ paths
 [PASS] R6.2 this note carries a markdown link to each authority
        link targets, not backticks, are what create the ledger edge
-[PASS] R6.3 each authority's sharded ledger row is retained-grade
-       read from shards: ['retained', 'retained']
+[PASS] R6.3 live sharded ledger statuses remain dependency-eligible
+       pipeline compatibility only; read from shards: ['retained', 'retained']
 [PASS] R6.4 every lambda_k is real for a real, b complex
        lambda=[a_s + 2*x_s, a_s - x_s - sqrt(3)*y_s, a_s - x_s + sqrt(3)*y_s]
-[PASS] R6.5 lambda_k = a + 2|b| cos(theta + 2 pi k/3) with |b|=R, theta=arg(b)
+[PASS] R6.5 lambda_k has polar form for R>=0, with phase arbitrary at R=0
 [PASS] R6.6 characters are orthonormal and the isotypic split is 3a^2 : 6|b|^2
        singlet=3*a_s**2; doublet=6*x_s**2 + 6*y_s**2
 [PASS] R6.7 power sums are sum lambda_k = 3a and sum lambda_k^2 = 3a^2 + 6|b|^2
@@ -55,8 +57,8 @@ status: ok
        the note's displayed sector powers are the isotypic split, not a posit
 [PASS] R6.9 Q = (sum lambda_k^2)/(sum lambda_k)^2 = 1/3 + (2/3)r exactly
        Q=(a_s**2 + 2*x_s**2 + 2*y_s**2)/(3*a_s**2)
-[PASS] R6.10 REJECTOR: doublet=|b|^2 fails the power-sum and Q identities
-       residual=3*x_s**2 + 3*y_s**2 (nonzero => gate discriminates)
+[PASS] R6.10 REJECTOR: wrong split is nonidentical and degenerates at b=0
+       residual=3*x_s**2 + 3*y_s**2; b!=0 witness rejects, b=0 coincides
 
 SCORECARD PASS=32 FAIL=0
 FINDING: Record supplies finite additive readout-vector algebra;

--- a/logs/runner-cache/record_function_finite_sector_algebra_2026_06_05.txt
+++ b/logs/runner-cache/record_function_finite_sector_algebra_2026_06_05.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/record_function_finite_sector_algebra_2026_06_05.py
-runner_sha256: 7571026e628811b51dabd4986c54006aa3617a0323944ebea8a948960fba1355
+runner_sha256: 0e85b68f4a6fa29f795e1956505e4bc20bcd3321104bfe6c02f12cbe5c9a161e
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.46
+elapsed_sec: 0.84
 status: ok
 ----- stdout -----
 [PASS] R1.1 finite additivity holds for every ordered disjoint pair of 4 supplied records
@@ -39,8 +39,26 @@ status: ok
        normalization is an extra coordinate choice, not a new Record axiom
 [PASS] R5.2 finite additivity imposes no autonomous update law on the readout vector
        the vector is unchanged until an external dynamics map is supplied
+[PASS] R6.0 omega is the exact primitive cube root exp(2 pi i/3)
+[PASS] R6.1 both cited authority notes exist at their exact docs/ paths
+[PASS] R6.2 this note carries a markdown link to each authority
+       link targets, not backticks, are what create the ledger edge
+[PASS] R6.3 each authority's sharded ledger row is retained-grade
+       read from shards: ['retained', 'retained']
+[PASS] R6.4 every lambda_k is real for a real, b complex
+       lambda=[a_s + 2*x_s, a_s - x_s - sqrt(3)*y_s, a_s - x_s + sqrt(3)*y_s]
+[PASS] R6.5 lambda_k = a + 2|b| cos(theta + 2 pi k/3) with |b|=R, theta=arg(b)
+[PASS] R6.6 characters are orthonormal and the isotypic split is 3a^2 : 6|b|^2
+       singlet=3*a_s**2; doublet=6*x_s**2 + 6*y_s**2
+[PASS] R6.7 power sums are sum lambda_k = 3a and sum lambda_k^2 = 3a^2 + 6|b|^2
+[PASS] R6.8 sum lambda_k^2 = 3 (singlet + doublet) for singlet=a^2, doublet=2|b|^2
+       the note's displayed sector powers are the isotypic split, not a posit
+[PASS] R6.9 Q = (sum lambda_k^2)/(sum lambda_k)^2 = 1/3 + (2/3)r exactly
+       Q=(a_s**2 + 2*x_s**2 + 2*y_s**2)/(3*a_s**2)
+[PASS] R6.10 REJECTOR: doublet=|b|^2 fails the power-sum and Q identities
+       residual=3*x_s**2 + 3*y_s**2 (nonzero => gate discriminates)
 
-SCORECARD PASS=21 FAIL=0
+SCORECARD PASS=32 FAIL=0
 FINDING: Record supplies finite additive readout-vector algebra;
          probability, weighting, and dynamics remain separate gates.
 

--- a/scripts/record_function_finite_sector_algebra_2026_06_05.py
+++ b/scripts/record_function_finite_sector_algebra_2026_06_05.py
@@ -14,11 +14,31 @@ that statement:
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import sympy as sp
 
 
 PASS = 0
 FAIL = 0
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+NOTE_REL = "docs/RECORD_FUNCTION_FINITE_SECTOR_ALGEBRA_2026-06-05.md"
+
+# Direct retained authorities for the generation specialization: the
+# C3-equivariant spectrum (A) and the Fourier-coordinate / Koide identity (B).
+AUTHORITY_A = "KOIDE_KAPPA_SPECTRUM_OPERATOR_BRIDGE_THEOREM_NOTE_2026-04-19.md"
+AUTHORITY_B = "CHARGED_LEPTON_REGISTERED_MASS_DFT_COORDINATE_THEOREM_NOTE_2026-07-11.md"
+AUTHORITIES = (AUTHORITY_A, AUTHORITY_B)
+
+RETAINED_GRADE = {"retained", "retained_bounded", "retained_no_go"}
+
+
+def ledger_shard(note_basename: str) -> Path:
+    rid = note_basename[:-3].lower()
+    return REPO_ROOT / "docs/audit/data/ledger" / rid[:2] / f"{rid}.json"
 
 
 def check(name: str, cond: bool, detail: str = "") -> bool:
@@ -206,6 +226,100 @@ def main() -> int:
     check("R5.2 finite additivity imposes no autonomous update law on the readout vector",
           dynamic_update.free_symbols == {u, d},
           "the vector is unchanged until an external dynamics map is supplied")
+
+    # -------------------------------------------------------------------------
+    # 6. The generation two-block power assignment and the C3/K-real readout
+    # form are not supplied here: they are the isotypic split and the Fourier
+    # coordinate identity carried by two directly cited retained authorities.
+    # This section re-derives both exactly and rejects the wrong split.
+    # -------------------------------------------------------------------------
+    a_s = sp.Symbol("a_s", real=True, nonzero=True)
+    xs, ys = sp.symbols("x_s y_s", real=True)
+    Rs = sp.Symbol("R_s", nonnegative=True)
+    ts = sp.Symbol("t_s", real=True)
+    om = sp.Rational(-1, 2) + sp.sqrt(3) * sp.I / 2
+    check("R6.0 omega is the exact primitive cube root exp(2 pi i/3)",
+          sp.simplify(om - sp.expand_complex(sp.exp(2 * sp.pi * sp.I / 3))) == 0
+          and sp.simplify(om ** 3 - 1) == 0 and sp.simplify(1 + om + om ** 2) == 0)
+
+    check("R6.1 both cited authority notes exist at their exact docs/ paths",
+          all((REPO_ROOT / "docs" / name).is_file() for name in AUTHORITIES))
+
+    note_text = (REPO_ROOT / NOTE_REL).read_text(encoding="utf-8")
+    check("R6.2 this note carries a markdown link to each authority",
+          all(f"]({name})" in note_text for name in AUTHORITIES),
+          "link targets, not backticks, are what create the ledger edge")
+
+    grades = {}
+    for name in AUTHORITIES:
+        shard = ledger_shard(name)
+        grades[name] = (json.loads(shard.read_text(encoding="utf-8")).get("effective_status")
+                        if shard.is_file() else None)
+    check("R6.3 each authority's sharded ledger row is retained-grade",
+          all(g in RETAINED_GRADE for g in grades.values()),
+          f"read from shards: {sorted(grades.values(), key=str)}")
+
+    # Authority A's spectrum, built from its own definition -- nothing here is
+    # computed from the target it is compared against.
+    b_s = xs + sp.I * ys
+    lam = [sp.simplify(sp.expand(sp.expand_complex(
+        a_s + b_s * om ** j + sp.conjugate(b_s) * om ** (-j)))) for j in range(3)]
+    mod_b_sq = xs ** 2 + ys ** 2
+
+    check("R6.4 every lambda_k is real for a real, b complex",
+          all(sp.simplify(sp.im(lam_j)) == 0 for lam_j in lam),
+          f"lambda={lam}")
+
+    b_pol = Rs * sp.cos(ts) + sp.I * Rs * sp.sin(ts)
+    lam_pol = [sp.expand_complex(sp.expand(
+        a_s + b_pol * om ** j + sp.conjugate(b_pol) * om ** (-j))) for j in range(3)]
+    check("R6.5 lambda_k = a + 2|b| cos(theta + 2 pi k/3) with |b|=R, theta=arg(b)",
+          all(sp.simplify(sp.expand_trig(sp.expand(
+              lam_pol[j] - (a_s + 2 * Rs * sp.cos(ts + 2 * sp.pi * j / 3))))) == 0
+              for j in range(3))
+          and all(sp.simplify(sp.expand_trig(sp.expand(
+              lam[j].subs({xs: Rs * sp.cos(ts), ys: Rs * sp.sin(ts)}) - lam_pol[j]))) == 0
+              for j in range(3)))
+
+    chars = [sp.Matrix([om ** (j * n) for n in range(3)]) / sp.sqrt(3) for j in range(3)]
+    gram = sp.simplify(sp.Matrix(3, 3, lambda i, j: (chars[i].conjugate().T * chars[j])[0]))
+    lam_vec = sp.Matrix(lam)
+    powers = [sp.simplify(sp.expand(sp.expand_complex(
+        (chars[j].conjugate().T * lam_vec)[0] * sp.conjugate((chars[j].conjugate().T * lam_vec)[0]))))
+        for j in range(3)]
+    check("R6.6 characters are orthonormal and the isotypic split is 3a^2 : 6|b|^2",
+          gram == sp.eye(3)
+          and sp.simplify(powers[0] - 3 * a_s ** 2) == 0
+          and sp.simplify(powers[1] + powers[2] - 6 * mod_b_sq) == 0,
+          f"singlet={powers[0]}; doublet={sp.simplify(powers[1] + powers[2])}")
+
+    S1 = sp.simplify(sum(lam))
+    S2 = sp.simplify(sp.expand(sum(lam_j ** 2 for lam_j in lam)))
+    check("R6.7 power sums are sum lambda_k = 3a and sum lambda_k^2 = 3a^2 + 6|b|^2",
+          sp.simplify(S1 - 3 * a_s) == 0
+          and sp.simplify(S2 - (3 * a_s ** 2 + 6 * mod_b_sq)) == 0
+          and sp.simplify(S2 - sum(powers)) == 0)
+
+    singlet_power = a_s ** 2
+    doublet_power = 2 * mod_b_sq
+    check("R6.8 sum lambda_k^2 = 3 (singlet + doublet) for singlet=a^2, doublet=2|b|^2",
+          sp.simplify(S2 - 3 * (singlet_power + doublet_power)) == 0,
+          "the note's displayed sector powers are the isotypic split, not a posit")
+
+    r_iso = mod_b_sq / a_s ** 2
+    q_iso = sp.simplify(S2 / S1 ** 2)
+    check("R6.9 Q = (sum lambda_k^2)/(sum lambda_k)^2 = 1/3 + (2/3)r exactly",
+          sp.simplify(q_iso - (sp.Rational(1, 3) + sp.Rational(2, 3) * r_iso)) == 0,
+          f"Q={q_iso}")
+
+    # Discriminating rejector: drop the factor 2 in the doublet power and the
+    # power-sum identity must FAIL. The check passes only on rejection.
+    wrong_doublet = mod_b_sq
+    wrong_residual = sp.simplify(S2 - 3 * (singlet_power + wrong_doublet))
+    wrong_q = sp.simplify(q_iso - (sp.Rational(1, 3) + sp.Rational(2, 3) * r_iso / 2))
+    check("R6.10 REJECTOR: doublet=|b|^2 fails the power-sum and Q identities",
+          wrong_residual != 0 and wrong_q != 0,
+          f"residual={wrong_residual} (nonzero => gate discriminates)")
 
     print(f"\nSCORECARD PASS={PASS} FAIL={FAIL}")
     print("FINDING: Record supplies finite additive readout-vector algebra;")

--- a/scripts/record_function_finite_sector_algebra_2026_06_05.py
+++ b/scripts/record_function_finite_sector_algebra_2026_06_05.py
@@ -27,13 +27,21 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 NOTE_REL = "docs/RECORD_FUNCTION_FINITE_SECTOR_ALGEBRA_2026-06-05.md"
 
-# Direct retained authorities for the generation specialization: the
-# C3-equivariant spectrum (A) and the Fourier-coordinate / Koide identity (B).
 AUTHORITY_A = "KOIDE_KAPPA_SPECTRUM_OPERATOR_BRIDGE_THEOREM_NOTE_2026-04-19.md"
 AUTHORITY_B = "CHARGED_LEPTON_REGISTERED_MASS_DFT_COORDINATE_THEOREM_NOTE_2026-07-11.md"
 AUTHORITIES = (AUTHORITY_A, AUTHORITY_B)
 
-RETAINED_GRADE = {"retained", "retained_bounded", "retained_no_go"}
+# The runner reads these mutable repository inputs. The cache fingerprint must
+# move whenever the note, an authority, or its pipeline-derived status moves.
+AUDIT_INPUT_PATHS = (
+    "docs/RECORD_FUNCTION_FINITE_SECTOR_ALGEBRA_2026-06-05.md",
+    "docs/KOIDE_KAPPA_SPECTRUM_OPERATOR_BRIDGE_THEOREM_NOTE_2026-04-19.md",
+    "docs/CHARGED_LEPTON_REGISTERED_MASS_DFT_COORDINATE_THEOREM_NOTE_2026-07-11.md",
+    "docs/audit/data/ledger/ko/koide_kappa_spectrum_operator_bridge_theorem_note_2026-04-19.json",
+    "docs/audit/data/ledger/ch/charged_lepton_registered_mass_dft_coordinate_theorem_note_2026-07-11.json",
+)
+
+DEPENDENCY_ELIGIBLE_STATUSES = {"retained", "retained_bounded", "retained_no_go"}
 
 
 def ledger_shard(note_basename: str) -> Path:
@@ -158,19 +166,19 @@ def main() -> int:
           "for any supplied p in (0,1), choose d=p*u/(1-p)")
 
     # -------------------------------------------------------------------------
-    # 4. Generation dial coordinates from a two-sector record function.
+    # 4. Conditional abstract C3 coordinates from a two-sector record function.
     # -------------------------------------------------------------------------
     singlet_readout = a2
     doublet_readout = 2 * b2
-    generation_ratio = sp.simplify(b2 / a2)
+    c3_ratio = sp.simplify(b2 / a2)
     sector_ratio = sp.simplify(doublet_readout / singlet_readout)
     s_from_sector_ratio = sp.log(sector_ratio) / ln2
 
-    check("R4.1 generation sector ratio is doublet/singlet = 2r",
-          sp.simplify(sector_ratio - 2 * generation_ratio) == 0,
+    check("R4.1 conditional two-block ratio is doublet/singlet = 2r",
+          sp.simplify(sector_ratio - 2 * c3_ratio) == 0,
           f"sector_ratio={sector_ratio}")
     check("R4.2 dial coordinate is log2(doublet/singlet)",
-          sp.simplify(s_from_sector_ratio - sp.log(2 * generation_ratio) / ln2) == 0)
+          sp.simplify(s_from_sector_ratio - sp.log(2 * c3_ratio) / ln2) == 0)
 
     lambdas = [
         alpha + 2 * beta * sp.cos(theta + 2 * sp.pi * j / 3)
@@ -182,29 +190,36 @@ def main() -> int:
     q_from_r = sp.Rational(1, 3) + sp.Rational(2, 3) * r
     q_from_blocks = sp.simplify((singlet_readout + doublet_readout) / (3 * singlet_readout))
 
-    check("R4.3 C3/KCPT square-root readout power sums define Q",
+    check("R4.3 real C3 coordinate power sums define Q",
           sp.simplify(sum_lambda - 3 * alpha) == 0
           and sp.simplify(sum_lambda_sq - (3 * alpha ** 2 + 6 * beta ** 2)) == 0,
           f"S1={sum_lambda}; S2={sum_lambda_sq}")
     check("R4.4 Q = S2/S1^2 derives Q(r)=1/3+2r/3 before endpoint substitution",
           sp.simplify(q_power_sum.subs(beta, sp.sqrt(r) * alpha) - q_from_r) == 0,
           f"Q={q_power_sum}")
-    check("R4.5 two-block powers give the same generation Q coordinate",
-          sp.simplify(q_from_blocks - (sp.Rational(1, 3) + sp.Rational(2, 3) * generation_ratio)) == 0,
+    check("R4.5 two-block powers give the same abstract C3 Q coordinate",
+          sp.simplify(q_from_blocks - (sp.Rational(1, 3) + sp.Rational(2, 3) * c3_ratio)) == 0,
           f"Q_blocks={q_from_blocks}")
 
     rho_sector = rho
     r_from_rho = rho_sector / 2
     q_from_rho = sp.simplify(q_from_r.subs(r, r_from_rho))
     s_from_rho = sp.log(rho_sector) / ln2
-    check("R4.6 sector balance rho=1 gives s=0, r=1/2, Q=2/3",
+    check("R4.6 two-block balance rho=1 gives s=0, r=1/2, Q=2/3",
           sp.simplify(s_from_rho.subs(rho, 1)) == 0
           and sp.simplify(r_from_rho.subs(rho, 1) - sp.Rational(1, 2)) == 0
           and sp.simplify(q_from_rho.subs(rho, 1) - sp.Rational(2, 3)) == 0)
-    check("R4.7 real-mode balance rho=2 gives s=1, r=1, Q=1",
+    z0, z1, z2 = sp.symbols("z0 z1 z2", positive=True)
+    positive_triple_gap = sp.expand((z0 + z1 + z2) ** 2 - (z0 ** 2 + z1 ** 2 + z2 ** 2))
+    closure_q = sp.simplify(((3 * alpha) ** 2 + 0 + 0) / (3 * alpha) ** 2)
+    check("R4.7 rho=2 gives formal Q=1, only a nonnegative-closure endpoint",
           sp.simplify(s_from_rho.subs(rho, 2) - 1) == 0
           and sp.simplify(r_from_rho.subs(rho, 2) - 1) == 0
-          and sp.simplify(q_from_rho.subs(rho, 2) - 1) == 0)
+          and sp.simplify(q_from_rho.subs(rho, 2) - 1) == 0
+          and sp.simplify(closure_q - 1) == 0
+          and positive_triple_gap == 2 * (z0 * z1 + z0 * z2 + z1 * z2)
+          and positive_triple_gap.is_positive,
+          "strictly positive triples have S1^2-S2>0 and therefore Q<1")
 
     arbitrary_two = sp.Matrix([u, rho * u])
     arbitrary_total = (sp.Matrix([[1, 1]]) * arbitrary_two)[0]
@@ -222,16 +237,28 @@ def main() -> int:
           sp.simplify(born_claim.lhs - born_claim.rhs) != 0,
           "normalization is an extra coordinate choice, not a new Record axiom")
 
-    dynamic_update = sp.Matrix([u, d])
-    check("R5.2 finite additivity imposes no autonomous update law on the readout vector",
-          dynamic_update.free_symbols == {u, d},
-          "the vector is unchanged until an external dynamics map is supplied")
+    supplied_state = sp.Matrix([1, 2])
+    identity_update = sp.eye(2) * supplied_state
+    swap_update = sp.Matrix([[0, 1], [1, 0]]) * supplied_state
+    update_additivity = all(
+        readout(indicator(mask_a | mask_b, 2), updated)
+        == readout(indicator(mask_a, 2), updated)
+        + readout(indicator(mask_b, 2), updated)
+        for updated in (identity_update, swap_update)
+        for mask_a in range(4)
+        for mask_b in range(4)
+        if not mask_a & mask_b
+    )
+    check("R5.2 finite additivity does not select an autonomous update law",
+          identity_update != swap_update and update_additivity,
+          "distinct identity and swap updates preserve the same additive readout rule")
 
     # -------------------------------------------------------------------------
-    # 6. The generation two-block power assignment and the C3/K-real readout
-    # form are not supplied here: they are the isotypic split and the Fourier
-    # coordinate identity carried by two directly cited retained authorities.
-    # This section re-derives both exactly and rejects the wrong split.
+    # 6. Two authority notes establish the abstract Fourier algebra used by the
+    # conditional specialization. They do not supply its physical carrier,
+    # generation interpretation, Record-to-power identification, K/CPT
+    # context, or registered-mass readout. R6.3 is only a live
+    # pipeline-compatibility guard; it is not evidence for semantic scope.
     # -------------------------------------------------------------------------
     a_s = sp.Symbol("a_s", real=True, nonzero=True)
     xs, ys = sp.symbols("x_s y_s", real=True)
@@ -255,9 +282,9 @@ def main() -> int:
         shard = ledger_shard(name)
         grades[name] = (json.loads(shard.read_text(encoding="utf-8")).get("effective_status")
                         if shard.is_file() else None)
-    check("R6.3 each authority's sharded ledger row is retained-grade",
-          all(g in RETAINED_GRADE for g in grades.values()),
-          f"read from shards: {sorted(grades.values(), key=str)}")
+    check("R6.3 live sharded ledger statuses remain dependency-eligible",
+          all(g in DEPENDENCY_ELIGIBLE_STATUSES for g in grades.values()),
+          f"pipeline compatibility only; read from shards: {sorted(grades.values(), key=str)}")
 
     # Authority A's spectrum, built from its own definition -- nothing here is
     # computed from the target it is compared against.
@@ -273,7 +300,7 @@ def main() -> int:
     b_pol = Rs * sp.cos(ts) + sp.I * Rs * sp.sin(ts)
     lam_pol = [sp.expand_complex(sp.expand(
         a_s + b_pol * om ** j + sp.conjugate(b_pol) * om ** (-j))) for j in range(3)]
-    check("R6.5 lambda_k = a + 2|b| cos(theta + 2 pi k/3) with |b|=R, theta=arg(b)",
+    check("R6.5 lambda_k has polar form for R>=0, with phase arbitrary at R=0",
           all(sp.simplify(sp.expand_trig(sp.expand(
               lam_pol[j] - (a_s + 2 * Rs * sp.cos(ts + 2 * sp.pi * j / 3))))) == 0
               for j in range(3))
@@ -312,14 +339,21 @@ def main() -> int:
           sp.simplify(q_iso - (sp.Rational(1, 3) + sp.Rational(2, 3) * r_iso)) == 0,
           f"Q={q_iso}")
 
-    # Discriminating rejector: drop the factor 2 in the doublet power and the
-    # power-sum identity must FAIL. The check passes only on rejection.
+    # Discriminating rejector: dropping the factor 2 does not give the same
+    # polynomial identity, but it necessarily coincides at the boundary b=0.
     wrong_doublet = mod_b_sq
     wrong_residual = sp.simplify(S2 - 3 * (singlet_power + wrong_doublet))
     wrong_q = sp.simplify(q_iso - (sp.Rational(1, 3) + sp.Rational(2, 3) * r_iso / 2))
-    check("R6.10 REJECTOR: doublet=|b|^2 fails the power-sum and Q identities",
-          wrong_residual != 0 and wrong_q != 0,
-          f"residual={wrong_residual} (nonzero => gate discriminates)")
+    nonzero_witness = {a_s: 1, xs: 1, ys: 0}
+    zero_boundary = {xs: 0, ys: 0}
+    check("R6.10 REJECTOR: wrong split is nonidentical and degenerates at b=0",
+          sp.simplify(wrong_residual - 3 * mod_b_sq) == 0
+          and sp.simplify(wrong_q - mod_b_sq / (3 * a_s ** 2)) == 0
+          and wrong_residual.subs(nonzero_witness) == 3
+          and wrong_q.subs(nonzero_witness) == sp.Rational(1, 3)
+          and wrong_residual.subs(zero_boundary) == 0
+          and wrong_q.subs(zero_boundary) == 0,
+          f"residual={wrong_residual}; b!=0 witness rejects, b=0 coincides")
 
     print(f"\nSCORECARD PASS={PASS} FAIL={FAIL}")
     print("FINDING: Record supplies finite additive readout-vector algebra;")


### PR DESCRIPTION
## Review-loop disposition

This PR responds to the ledger repair request for direct authority edges on
`record_function_finite_sector_algebra_2026-06-05`.

The exact recorded repair target is:

> `missing_dependency_edge: add direct retained or accepted authorities for the generation two-block power assignment and C3/K-real readout definition, then rerun the audit.`

The review found that the two cited notes establish the abstract `C3` Fourier
algebra but do **not** establish a physical generation carrier,
Record-to-projection-power identification, `K`/CPT readout context, or
registered-mass functional. The source is therefore narrowed to an explicitly
conditional theorem:

- a real `C3` spectrum from an abstract Hermitian-circulant element is supplied;
- the two Record coordinates are explicitly identified with one third of the
  trivial and doublet projection powers;
- the two linked authority notes support only the Fourier algebra and the
  positive-triple coordinate identity;
- the physical/generation/readout bridge remains outside the theorem and must
  be judged by a fresh independent audit.

No audit grade or closure outcome is asserted by the source.

## Exact checks and review fixes

The primary runner remains `SCORECARD PASS=32 FAIL=0` and now:

- states the `a != 0`, `b != 0`, phase, logarithm, and `Q` domains;
- proves that `Q=1` is a formal/nonnegative-closure endpoint, not a value
  attained by a strictly positive triple;
- checks the alternative doublet assignment as a nonidentical polynomial with
  a nonzero witness and separately checks its required coincidence at `b=0`;
- uses distinct identity and swap update maps as countermodels to dynamics
  selection;
- labels the live ledger-status check as pipeline compatibility, not semantic
  proof; and
- declares the target note, both authority notes, and both authority ledger
  shards in `AUDIT_INPUT_PATHS`, so the canonical cache carries an input
  fingerprint.

An independent plain-Python complex-DFT calculation reproduced the spectrum,
projection powers, power sums, `Q` identity, `b=0` boundary, and strict-positive
`Q<1` domain.

## Complete sibling-consumer sweep

The target-name/path search finds eight sibling runners:

- pass: `flavor_detR_default_full_exercise_2026_05_30.py` (`6/0`);
- pass: `flavor_missing_axiom_carrier_measure_2026_05_30.py` (`9/0`);
- pass: `flavor_tracial_reference_does_not_select_q23_no_go_2026_06_02.py`
  (`39/0`);
- pass: `koide_tracial_standard_form_carrier_2026_06_02.py` (`10/0`);
- pass: `observable_principle_p1_br_license_check_2026_06_10.py` (`31/0`);
- pre-existing exit 1:
  `observable_principle_p1_cap_k_check_2026_06_10.py`;
- pre-existing exit 1:
  `observable_principle_p1_rr_consolidation_check_2026_06_11.py`; and
- pre-existing exit 1: `p_flux_point_zero_set_check_2026_06_10.py`.

The three failures are legacy status/monolithic-ledger or earlier prose-guard
defects, not regressions in this three-file repair. They are recorded rather
than misreported as passing.

## Validation

- primary runner: exit 0, `PASS=32 FAIL=0`, stderr empty;
- cache status: `fresh`, including `input_fingerprint_sha256`;
- `scripts/vocab_lint.py --fix` on all three branch-modified files: zero
  violations and zero rewrites;
- Python syntax and `git diff --check`: pass;
- generated audit ledger/queue/effective-status outputs are not part of this
  PR; the citation graph manifest will be regenerated against the landing base
  and co-landed because the Markdown dependency graph changes.

This PR does not apply an audit verdict and does not claim the repaired row has
passed re-audit.
