### PR TITLE
feat(hierarchy): derive general-L_t Matsubara factorization and multiplicity four

### DIFF
--- a/docs/HIERARCHY_MATSUBARA_DECOMPOSITION_NOTE.md
+++ b/docs/HIERARCHY_MATSUBARA_DECOMPOSITION_NOTE.md
@@ -13,16 +13,104 @@ gap becomes a precise temporal-averaging problem rather than a vague prefactor?
 
 Yes.
 
-On the minimal spatial APBC block `L_s = 2`, all spatial momenta are fixed at
-the Brillouin-zone corners, so:
-
-- `sin^2(k_i) = 1` for `i = 1,2,3`
-- the full `L_t` dependence sits only in the temporal APBC momenta
-  `omega_n = (2n+1) pi / L_t`
-
-For the full staggered Dirac operator with mass `m`:
+For the full staggered Dirac operator with mass `m` on the minimal spatial APBC
+block `L_s = 2`, at every temporal extent `L_t`:
 
 `|det(D + m)| = prod_omega [m^2 + u_0^2 (3 + sin^2 omega)]^4`
+
+with `omega_n = (2n+1) pi / L_t`, `n = 0, ..., L_t - 1`.
+
+The five steps below derive this as an operator identity, symbolically and for
+general `L_t`, rather than reading it off a sampled momentum grid. In particular
+the exponent `4` is derived, not observed.
+
+### Step 1 — the operator splits as space (x) time
+
+Writing the site index as `a * L_t + t`, with `a` running over the 8 spatial
+sites of the `L_s = 2` block, the staggered operator is exactly
+
+`D(m) = m Id + u_0 (B (x) Id_t) + u_0 (eta_4 (x) S)`
+
+where `B` is the 8x8 sum of the three spatial staggered hops,
+`eta_4 = diag((-1)^(x_1+x_2+x_3))` is the fourth staggered sign, and `S` is the
+`L_t x L_t` antisymmetric temporal hop. `B` and `eta_4` are read out of the
+assembled matrix rather than posited; they come out identical for
+`L_t = 2,3,4,5,6,8`, and substituting `Id_8` for `eta_4` fails to reproduce the
+matrix.
+
+### Step 2 — the two-site antiperiodic ring is an operator identity
+
+On a two-site antiperiodic ring the shift `T_i` obeys `T_i^2 = -Id`, and the
+antisymmetric hop `(T_i - T_i^(-1))/2` collapses onto `T_i` itself: forward and
+backward hops connect the same pair of sites, and the antiperiodic wrap flips
+the sign of exactly one of them, so they add rather than cancel. Each spatial
+direction therefore contributes a single `+-1` matrix `A_i` with
+
+`A_i^2 = -Id_8`,   `A_i A_j + A_j A_i = 0`  for `i != j`
+
+and hence, for `B = A_1 + A_2 + A_3`,
+
+`B^2 = -3 Id_8`,  `tr B = 0`,  `eta_4^2 = Id_8`,  `tr eta_4 = 0`,
+`B eta_4 + eta_4 B = 0`
+
+all in exact integer arithmetic. This is what fixes the spatial contribution to
+the constant `3` at every temporal mode and every `L_t`. The momentum-space
+reading — all spatial momenta sitting at Brillouin-zone corners, so
+`sin^2(k_i) = 1` — returns the same number, but only as a property of a sampled
+grid; the identity `A_i^2 = -Id_8` is what carries the derivation, and it needs
+no momentum labels at all.
+
+### Step 3 — the temporal factor diagonalizes at every `L_t`
+
+The temporal hop is `S = (T - T^(-1))/2` for the antiperiodic shift `T`. Cofactor
+expansion of `det(lam Id - T)` leaves only the diagonal product and the single
+full cycle, whose antiperiodic wrap contributes one factor `-1`, so
+
+`charpoly(T) = lam^(L_t) + 1`
+
+at every `L_t` (checked symbolically for `L_t = 2..16`). That polynomial is
+squarefree, so `T` is diagonalizable with `L_t` simple eigenvalues
+`z_n = exp(i omega_n)`, `omega_n = (2n+1) pi / L_t`, and on the eigenvector
+`v(z) = [1, z, ..., z^(L_t - 1)]`
+
+`S v(z) = (1/2)(z - 1/z) v(z) = i sin(omega) v(z)`
+
+So the APBC Matsubara frequencies are an output of the temporal algebra, not an
+input to it.
+
+### Step 4 — multiplicity four, forced by tracelessness
+
+In the temporal eigenbasis `D(m)` is block-diagonal, one 8x8 block per mode:
+
+`D(m)|_omega = m Id_8 + K(omega)`,  `K(omega) = u_0 (B + i sin(omega) eta_4)`
+
+Using only the Step 2 relations,
+
+`K^2 = u_0^2 [B^2 + i sin(omega) (B eta_4 + eta_4 B) - sin^2(omega) eta_4^2]
+     = -u_0^2 (3 + sin^2 omega) Id_8`
+
+`tr K = u_0 [tr B + i sin(omega) tr eta_4] = 0`
+
+A traceless operator on an 8-dimensional space whose square is `-c Id` with
+`c > 0` can only have the eigenvalues `+- i u_0 sqrt(3 + sin^2 omega)`, and
+tracelessness forces them to occur with equal multiplicity, `4` and `4`. Hence
+
+`charpoly K(omega) = (lam^2 + u_0^2 (3 + sin^2 omega))^4`
+
+`det(m Id_8 + K(omega)) = [m^2 + u_0^2 (3 + sin^2 omega)]^4`
+
+The exponent `4` is exactly that `4 + 4` eigenvalue split on the 8-dimensional
+spatial block. It is not fitted, and not read off the tested grid.
+
+### Step 5 — general `L_t`
+
+Step 4 is carried out once symbolically in `(theta, u_0, m)` with `theta` a free
+symbol, so it covers every temporal mode of every `L_t` at once: `L_t` enters
+only through the substitution `theta -> omega_n`. Multiplying the `L_t` blocks
+returns the displayed product formula at every `L_t`, not only on the tested
+grid. The paired runner also rejects the exponents `3` and `5` and the spatial
+constant `2 + sin^2 theta`, and chains symbolic block determinant -> product
+formula -> direct numerical determinant.
 
 This is an exact closed form on the `L_s = 2` APBC hypercube.
 
@@ -65,7 +153,9 @@ That is a much better problem.
 ## UV endpoint picture
 
 `L_t = 2` is the unique APBC endpoint where every temporal mode has
-`sin^2 omega = 1`.
+`sin^2 omega = 1`: the mode closest to zero sits at `omega_0 = pi / L_t`, which
+reaches `pi/2` only at `L_t = 2`, so every larger extent carries at least one
+mode with `sin^2 omega < 1`. This is checked exactly over `L_t = 2..16`.
 
 So the one-block hierarchy route is the **maximal temporal-gap endpoint** of
 the exact Matsubara family, not an arbitrary guess.
@@ -88,7 +178,7 @@ density** issue than a direct sixteenth-root correction to the scale.
 
 This still does **not** close the hierarchy theorem.
 
-What it closes is the temporal algebra:
+What it settles is the temporal algebra:
 
 - determinant formula: exact
 - free-energy density formula: exact

--- a/logs/runner-cache/frontier_hierarchy_matsubara_decomposition.txt
+++ b/logs/runner-cache/frontier_hierarchy_matsubara_decomposition.txt
@@ -1,106 +1,78 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_hierarchy_matsubara_decomposition.py
-runner_sha256: 2587ea724a43677e48294bfa6501de2cd72a482af3071b2c3b306fe849d28d99
+runner_sha256: cd61ae9b946cf2df08d63bcf9fe98db79956cf64115be230d05133fd4f07c1cf
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.09
+elapsed_sec: 3.85
 status: ok
 ----- stdout -----
 Hierarchy Matsubara decomposition
-==============================================================================
 
-==============================================================================
+PART 0: GENERAL-L_t DERIVATION FROM THE MATRIX
+0A structural extraction from build_dirac_4d_apbc, Lt in [2, 3, 4, 5, 6, 8]
+  [PASS] same-t 8x8 block is t-independent and Lt-independent, giving B_ext
+         max dev over t, over Lt, and from integer values all = 0.0
+  [PASS] different-t part is spatial-block-diagonal and equals kron(eta4_ext, S_ext)
+         off-block max = 0.0, block-vs-reference ratio max dev = 0.0
+  [PASS] eta4_ext read off the blocks equals diag((-1)^(x0+x1+x2))
+         read [1, -1, -1, 1, -1, 1, 1, -1]
+  [PASS] m*Id + u0*kron(B_ext,Id) + u0*kron(eta4_ext,S_ext) == build_dirac_4d_apbc
+         36 points, u0 in [0.6, 1.0, 1.7] x m in [0.0, 0.37], max abs dev = 0.0
+  [PASS] rejector: replacing eta4_ext by the identity does not reproduce the matrix
+         smallest max abs dev over the 36 points = 6.00e-01
+0B exact Clifford relations on the extracted operators (integer arithmetic)
+  [PASS] A_1+A_2+A_3 == B_ext, A_i^2 == -Id_8, and A_iA_j+A_jA_i == 0 for i != j
+         all seven deviations = 0; the 2-site antiperiodic ring gives T_i^2 = -Id
+  [PASS] B_ext^2 == -3*Id_8 and trace(B_ext) == 0
+  [PASS] eta4_ext^2 == Id_8 and trace(eta4_ext) == 0
+  [PASS] B_ext*eta4_ext + eta4_ext*B_ext == 0
+0C temporal spectrum, symbolic and exact, Lt = 2..16
+  [PASS] T_ext read off S_ext is a signed cyclic shift with (1/2)(T-T^-1) == S_ext
+         15 values of Lt, max abs dev = 0.0
+  [PASS] charpoly(T_ext) == lam^Lt + 1 exactly for every Lt in the range
+  [PASS] lam^Lt + 1 is squarefree, so its Lt roots exp(i(2n+1)pi/Lt) are distinct
+         gcd(p, p') == 1 and all Lt roots annihilate p, for every Lt
+  [PASS] S_ext v(z) == ((z-1/z)/2) v(z) on the T_ext eigenvector v(z) = [1,z,..,z^(Lt-1)]
+         residues reduced mod z^Lt + 1 vanish for every Lt; z^Lt = -1 closes the ring
+  [PASS] (z - 1/z)/2 == i*sin(omega) at z = exp(i*omega), so S -> i sin(omega)
+  [PASS] Lt = 2 is the only APBC extent whose temporal modes all have sin^2 omega = 1
+         exact over Lt = 2..16; maximal-gap extents = [2]
+0D symbolic multiplicity-four theorem in (theta, u0, m): one computation, every Lt
+  [PASS] K(theta)^2 == -u0^2*(3 + sin^2 theta)*Id_8 and trace K(theta) == 0
+         traceless, square a negative multiple of Id_8, so the spectrum is +-i*sqrt(c)
+  [PASS] charpoly(K) factors as (lam^2 + u0^2*(3 + sin^2 theta))^mult with mult == 4
+         factor_list returned multiplicity 4; tracelessness forces the 4+4 split
+  [PASS] det(m*Id_8 + K(theta)) == (m^2 + u0^2*(3 + sin^2 theta))^4
+         symbolic identity in theta, u0, m; holds for every temporal mode
+  [PASS] rejector: exponent 3 does not reproduce the block determinant
+         residual at (theta,u0,m) = (0.3,1.1,0.5) is 189
+  [PASS] rejector: exponent 5 does not reproduce the block determinant
+         residual at (theta,u0,m) = (0.3,1.1,0.5) is 753.4
+  [PASS] rejector: 2 + sin^2 theta in place of 3 + sin^2 theta does not reproduce the block determinant
+         residual at (theta,u0,m) = (0.3,1.1,0.5) is 193
+  symbolic section wall time = 2.5 s
+0E closing the loop to the runner's own exact_det_formula
+  [PASS] prod_n [symbolic block det at omega_n] == exact_det_formula
+         Lt in [2, 4, 6, 8] x u0 in [0.6, 0.9, 1.2] x m in [0.0, 0.1, 0.5], 36 points, max rel dev = 0.0e+00
+
 PART 1: CLOSED-FORM DETERMINANT
-==============================================================================
-  Lt=2, u0=0.6, m=0.0: direct=1.84884259e+01, exact=1.84884259e+01, rel=5.76e-16
-  Lt=2, u0=0.6, m=0.1: direct=1.95408755e+01, exact=1.95408755e+01, rel=1.82e-16
-  Lt=2, u0=0.6, m=0.5: direct=6.65416609e+01, exact=6.65416609e+01, rel=2.14e-16
-  Lt=2, u0=0.9, m=0.0: direct=1.21439531e+04, exact=1.21439531e+04, rel=1.35e-15
-  Lt=2, u0=0.9, m=0.1: direct=1.24470630e+04, exact=1.24470630e+04, rel=4.38e-16
-  Lt=2, u0=0.9, m=0.5: direct=2.20091574e+04, exact=2.20091574e+04, rel=0.00e+00
-  Lt=2, u0=1.2, m=0.0: direct=1.21165748e+06, exact=1.21165748e+06, rel=7.69e-16
-  Lt=2, u0=1.2, m=0.1: direct=1.22858867e+06, exact=1.22858867e+06, rel=9.48e-16
-  Lt=2, u0=1.2, m=0.5: direct=1.70214195e+06, exact=1.70214195e+06, rel=3.15e-15
-  Lt=4, u0=0.6, m=0.0: direct=4.03579151e+01, exact=4.03579151e+01, rel=1.76e-16
-  Lt=4, u0=0.6, m=0.1: direct=4.57993733e+01, exact=4.57993733e+01, rel=1.55e-15
-  Lt=4, u0=0.6, m=0.5: direct=7.30518396e+02, exact=7.30518396e+02, rel=1.40e-15
-  Lt=4, u0=0.9, m=0.0: direct=1.74120142e+07, exact=1.74120142e+07, rel=3.42e-15
-  Lt=4, u0=0.9, m=0.1: direct=1.84211327e+07, exact=1.84211327e+07, rel=6.07e-15
-  Lt=4, u0=0.9, m=0.5: direct=6.73104810e+07, exact=6.73104810e+07, rel=4.65e-15
-  Lt=4, u0=1.2, m=0.0: direct=1.73335925e+11, exact=1.73335925e+11, rel=2.11e-15
-  Lt=4, u0=1.2, m=0.1: direct=1.78921302e+11, exact=1.78921302e+11, rel=6.82e-16
-  Lt=4, u0=1.2, m=0.5: direct=3.76089105e+11, exact=3.76089105e+11, rel=4.87e-16
-  Lt=6, u0=0.6, m=0.0: direct=2.27967914e+02, exact=2.27967914e+02, rel=7.48e-16
-  Lt=6, u0=0.6, m=0.1: direct=2.76093470e+02, exact=2.76093470e+02, rel=1.24e-15
-  Lt=6, u0=0.6, m=0.5: direct=1.81847421e+04, exact=1.81847421e+04, rel=1.00e-15
-  Lt=6, u0=0.9, m=0.0: direct=6.46032192e+10, exact=6.46032192e+10, rel=1.18e-15
-  Lt=6, u0=0.9, m=0.1: direct=7.03569207e+10, exact=7.03569207e+10, rel=4.34e-16
-  Lt=6, u0=0.9, m=0.5: direct=4.99933767e+11, exact=4.99933767e+11, rel=6.59e-15
-  Lt=6, u0=1.2, m=0.0: direct=6.41672632e+16, exact=6.41672632e+16, rel=2.32e-14
-  Lt=6, u0=1.2, m=0.1: direct=6.73243220e+16, exact=6.73243220e+16, rel=1.15e-14
-  Lt=6, u0=1.2, m=0.5: direct=2.07274790e+17, exact=2.07274790e+17, rel=7.10e-15
-  Lt=8, u0=0.6, m=0.0: direct=1.38225440e+03, exact=1.38225440e+03, rel=8.22e-16
-  Lt=8, u0=0.6, m=0.1: direct=1.78473280e+03, exact=1.78473280e+03, rel=1.91e-15
-  Lt=8, u0=0.6, m=0.5: direct=4.76119350e+05, exact=4.76119350e+05, rel=2.08e-15
-  Lt=8, u0=0.9, m=0.0: direct=2.57293349e+14, exact=2.57293349e+14, rel=1.82e-15
-  Lt=8, u0=0.9, m=0.1: direct=2.88314106e+14, exact=2.88314106e+14, rel=1.19e-14
-  Lt=8, u0=0.9, m=0.5: direct=3.94481801e+15, exact=3.94481801e+15, rel=1.39e-15
-  Lt=8, u0=1.2, m=0.0: direct=2.54980932e+22, exact=2.54980932e+22, rel=1.50e-14
-  Lt=8, u0=1.2, m=0.1: direct=2.71855459e+22, exact=2.71855459e+22, rel=1.56e-14
-  Lt=8, u0=1.2, m=0.5: direct=1.21876455e+23, exact=1.21876455e+23, rel=2.62e-14
   [PASS] exact Matsubara determinant formula matches direct determinant
-         max relative error = 2.62e-14
+         Lt in [2, 4, 6, 8] x u0 in [0.6, 0.9, 1.2] x m in [0.0, 0.1, 0.5], 36 points, max rel dev = 2.62e-14
 
-==============================================================================
 PART 2: CLOSED-FORM FREE-ENERGY AND CONDENSATE DENSITIES
-==============================================================================
-  Lt=2, m=0.001: f_direct=1.5432096390e-07, f_exact=1.5432096384e-07, c_direct=3.0864188005e-04, c_exact=3.0864188005e-04
-  Lt=2, m=0.01: f_direct=1.5431860621e-05, f_exact=1.5431860621e-05, c_direct=3.0863244962e-03, c_exact=3.0863244962e-03
-  Lt=2, m=0.1: f_direct=1.5408332687e-03, f_exact=1.5408332687e-03, c_direct=3.0769230769e-02, c_exact=3.0769230769e-02
-  Lt=4, m=0.001: f_direct=1.7636681171e-07, f_exact=1.7636681193e-07, c_direct=3.5273356165e-04, c_exact=3.5273356165e-04
-  Lt=4, m=0.01: f_direct=1.7636373258e-05, f_exact=1.7636373258e-05, c_direct=3.5272124440e-03, c_exact=3.5272124440e-03
-  Lt=4, m=0.1: f_direct=1.7605651993e-03, f_exact=1.7605651993e-03, c_direct=3.5149384886e-02, c_exact=3.5149384886e-02
-  Lt=6, m=0.001: f_direct=1.7806264604e-07, f_exact=1.7806264607e-07, c_direct=3.5612522817e-04, c_exact=3.5612522817e-04
-  Lt=6, m=0.01: f_direct=1.7805947932e-05, f_exact=1.7805947932e-05, c_direct=3.5611256133e-03, c_exact=3.5611256133e-03
-  Lt=6, m=0.1: f_direct=1.7774356683e-03, f_exact=1.7774356683e-03, c_direct=3.5485044757e-02, c_exact=3.5485044757e-02
-  Lt=8, m=0.001: f_direct=1.7818502585e-07, f_exact=1.7818502584e-07, c_direct=3.5636998752e-04, c_exact=3.5636998752e-04
-  Lt=8, m=0.01: f_direct=1.7818185060e-05, f_exact=1.7818185060e-05, c_direct=3.5635728673e-03, c_exact=3.5635728673e-03
-  Lt=8, m=0.1: f_direct=1.7786509425e-03, f_exact=1.7786509425e-03, c_direct=3.5509180746e-02, c_exact=3.5509180746e-02
-  Lt=10, m=0.001: f_direct=1.7819381579e-07, f_exact=1.7819381554e-07, c_direct=3.5638756692e-04, c_exact=3.5638756692e-04
-  Lt=10, m=0.01: f_direct=1.7819063954e-05, f_exact=1.7819063954e-05, c_direct=3.5637486306e-03, c_exact=3.5637486306e-03
-  Lt=10, m=0.1: f_direct=1.7787380724e-03, f_exact=1.7787380724e-03, c_direct=3.5510908107e-02, c_exact=3.5510908107e-02
+  grid: Lt in [2, 4, 6, 8, 10] x u0 = 0.9 x m in [0.001, 0.01, 0.1], 15 points; log|det| taken with slogdet
   [PASS] exact free-energy density formula matches direct computation
-         max absolute error = 2.58e-16
+         max abs dev = 2.58e-16
   [PASS] exact condensate density formula matches direct computation
-         max absolute error = 6.94e-18
+         max abs dev = 6.94e-18
 
-==============================================================================
 PART 3: UV ENDPOINT INTERPRETATION
-==============================================================================
-  cond(Lt=2)  = 0.0030863245
-  cond(Lt=10) = 0.0035637486
-  ratio       = 1.1546901938
-  C_obs       = 0.9669215187
-  ratio^(-1/4)  = 0.9646807905
-  ratio^(-1/16) = 0.9910507799
+  u0=0.9, m=0.01: cond(Lt=2)=0.00308632, cond(Lt=10)=0.00356375, R=1.15469019
+  C_obs=0.96692152, R^(-1/4)=0.96468079, R^(-1/16)=0.99105078
   [PASS] dimension-4 compression is closer to the observed hierarchy prefactor than 16th-root compression
          |root4-C_obs|=0.002241, |root16-C_obs|=0.024129
 
-==============================================================================
-SCORECARD: 4 pass, 0 fail out of 4
-==============================================================================
+SCORECARD: 26 pass, 0 fail out of 26
 
 ----- stderr -----
-/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/numpy/linalg/_linalg.py:2406: RuntimeWarning: divide by zero encountered in det
-  r = _umath_linalg.det(a, signature=signature)
-/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/numpy/linalg/_linalg.py:2406: RuntimeWarning: overflow encountered in det
-  r = _umath_linalg.det(a, signature=signature)
-/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/numpy/linalg/_linalg.py:2406: RuntimeWarning: invalid value encountered in det
-  r = _umath_linalg.det(a, signature=signature)
-/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/numpy/linalg/_linalg.py:2349: RuntimeWarning: divide by zero encountered in slogdet
-  sign, logdet = _umath_linalg.slogdet(a, signature=signature)
-/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/numpy/linalg/_linalg.py:2349: RuntimeWarning: overflow encountered in slogdet
-  sign, logdet = _umath_linalg.slogdet(a, signature=signature)
-/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/numpy/linalg/_linalg.py:2349: RuntimeWarning: invalid value encountered in slogdet
-  sign, logdet = _umath_linalg.slogdet(a, signature=signature)
 

--- a/scripts/frontier_hierarchy_matsubara_decomposition.py
+++ b/scripts/frontier_hierarchy_matsubara_decomposition.py
@@ -6,13 +6,22 @@ This script derives and verifies an exact closed-form temporal-mode
 decomposition for the hierarchy determinant on the L_s = 2 APBC hypercube.
 
 Key result:
-  On the minimal spatial APBC block, all spatial momenta sit at the BZ
-  corners, so sin^2(k_i) = 1 for i = 1,2,3. Therefore the full Lt-dependent
-  determinant reduces exactly to a temporal Matsubara average:
+  On the minimal spatial APBC block the two-site antiperiodic shift obeys
+  T_i^2 = -Id, so each spatial hop operator satisfies A_i^2 = -Id exactly.
+  That operator identity -- not a sampled momentum statement -- is what
+  reduces the full Lt-dependent determinant to a temporal Matsubara product:
 
     |det(D + m)| = prod_omega [m^2 + u0^2 (3 + sin^2 omega)]^4
 
   where omega = (2n+1) pi / Lt are the APBC temporal momenta.
+
+Part 0 supplies the general-L_t derivation of that product. The spatial
+operators B and eta4 are extracted structurally from build_dirac_4d_apbc and
+the reconstruction is checked exactly; the Clifford relations are integer
+identities; the temporal factorization is the antiperiodic-circulant
+diagonalization, verified symbolically for L_t = 2..16; and the exponent 4 is
+obtained -- not inserted -- from a single symbolic characteristic-polynomial
+factorization in (theta, u0, m) that covers every L_t at once.
 
 This gives exact formulas for:
   - determinant magnitude
@@ -28,8 +37,10 @@ from __future__ import annotations
 
 import math
 import sys
+import time
 
 import numpy as np
+import sympy as sp
 
 np.set_printoptions(precision=10, linewidth=120, suppress=True)
 
@@ -37,7 +48,14 @@ PASS_COUNT = 0
 FAIL_COUNT = 0
 
 
-def check(name: str, condition: bool, detail: str = ""):
+def check(name: str, condition: bool, detail: str = "", fail_detail: str = ""):
+    """Record a check.
+
+    `detail` is the short evidence line printed on success. `fail_detail`
+    carries the verbose per-point diagnostics and is printed only when the
+    check does not pass, so a clean run stays inside the audit-packet
+    rendering budget without losing any diagnostic power.
+    """
     global PASS_COUNT, FAIL_COUNT
     status = "PASS" if condition else "FAIL"
     if condition:
@@ -47,6 +65,8 @@ def check(name: str, condition: bool, detail: str = ""):
     print(f"  [{status}] {name}")
     if detail:
         print(f"         {detail}")
+    if not condition and fail_detail:
+        print(fail_detail)
 
 
 def build_dirac_4d_apbc(Ls: int, Lt: int, u0: float, mass: float = 0.0):
@@ -124,41 +144,287 @@ def exact_condensate_density(Lt: int, u0: float, mass: float) -> float:
     )
 
 
+NS = 8  # 2^3 spatial sites of the L_s = 2 hypercube
+EXTRACT_LT = [2, 3, 4, 5, 6, 8]
+SPECTRUM_LT = list(range(2, 17))
+
+
+def extract_operators(Lt: int):
+    """Read B, eta4, S out of the matrix `build_dirac_4d_apbc` actually builds.
+
+    The flat layout is idx(x0,x1,x2,t) = (((x0)*2 + x1)*2 + x2)*Lt + t, i.e.
+    (8 spatial) (x) (Lt temporal) in numpy.kron(spatial, temporal) order.
+    Nothing here is written down from the algebra: the same-t entries give
+    B, the different-t entries give eta4 (x) S, and the relative sign of each
+    spatial block against the reference block gives eta4's diagonal.
+    """
+    D0 = build_dirac_4d_apbc(2, Lt, 1.0, 0.0)
+    same_t = [
+        np.array([[D0[a * Lt + t, b * Lt + t] for b in range(NS)] for a in range(NS)])
+        for t in range(Lt)
+    ]
+    t_dev = max(float(np.max(np.abs(same_t[t] - same_t[0]))) for t in range(Lt))
+    B = same_t[0]
+
+    diff_t = D0.copy()
+    for a in range(NS):
+        for b in range(NS):
+            for t in range(Lt):
+                diff_t[a * Lt + t, b * Lt + t] = 0.0
+    off_dev = 0.0
+    for a in range(NS):
+        for b in range(NS):
+            if a != b:
+                blk = diff_t[a * Lt:(a + 1) * Lt, b * Lt:(b + 1) * Lt]
+                off_dev = max(off_dev, float(np.max(np.abs(blk))))
+    blocks = [diff_t[a * Lt:(a + 1) * Lt, a * Lt:(a + 1) * Lt] for a in range(NS)]
+    S = blocks[0]
+    pivot = np.unravel_index(np.argmax(np.abs(S)), S.shape)
+    signs = [blocks[a][pivot] / S[pivot] for a in range(NS)]
+    ratio_dev = max(float(np.max(np.abs(blocks[a] - signs[a] * S))) for a in range(NS))
+    imag_dev = max(float(np.max(np.abs(M.imag))) for M in (B, S, np.array(signs)))
+
+    Bi = np.rint(B.real).astype(np.int64)
+    eta = np.rint(np.real(np.array(signs))).astype(np.int64)
+    int_dev = max(float(np.max(np.abs(B.real - Bi))),
+                  float(np.max(np.abs(np.real(np.array(signs)) - eta))))
+    return {
+        "B": Bi, "eta": eta, "S": S.real, "t_dev": t_dev, "off_dev": off_dev,
+        "ratio_dev": ratio_dev, "imag_dev": imag_dev, "int_dev": int_dev,
+    }
+
+
+def shift_from_S(S: np.ndarray) -> np.ndarray:
+    """Signed cyclic shift T read off the forward entries of the extracted S."""
+    Lt = S.shape[0]
+    T = np.zeros((Lt, Lt), dtype=np.int64)
+    for t in range(Lt):
+        T[t, (t + 1) % Lt] = int(np.sign(S[t, (t + 1) % Lt]))
+    return T
+
+
+def direction_hops(B: np.ndarray):
+    """Split B into the three single-coordinate hops, by coordinate pairs."""
+    hops = []
+    for bit in (4, 2, 1):  # x0, x1, x2 in the (((x0)*2+x1)*2+x2) packing
+        A = np.zeros((NS, NS), dtype=np.int64)
+        for a in range(NS):
+            A[a, a ^ bit] = B[a, a ^ bit]
+        hops.append(A)
+    return hops
+
+
+def part0a_structural_extraction():
+    print("\nPART 0: GENERAL-L_t DERIVATION FROM THE MATRIX")
+    print(f"0A structural extraction from build_dirac_4d_apbc, Lt in {EXTRACT_LT}")
+    ex = {Lt: extract_operators(Lt) for Lt in EXTRACT_LT}
+    ref = ex[EXTRACT_LT[0]]
+    b_dev = max(float(np.max(np.abs(ex[Lt]["B"] - ref["B"]))) for Lt in EXTRACT_LT)
+    e_dev = max(float(np.max(np.abs(ex[Lt]["eta"] - ref["eta"]))) for Lt in EXTRACT_LT)
+    check("same-t 8x8 block is t-independent and Lt-independent, giving B_ext",
+          max(ex[Lt]["t_dev"] for Lt in EXTRACT_LT) == 0.0 and b_dev == 0.0
+          and max(ex[Lt]["imag_dev"] + ex[Lt]["int_dev"] for Lt in EXTRACT_LT) == 0.0,
+          "max dev over t, over Lt, and from integer values all = 0.0")
+    check("different-t part is spatial-block-diagonal and equals kron(eta4_ext, S_ext)",
+          max(ex[Lt]["off_dev"] + ex[Lt]["ratio_dev"] for Lt in EXTRACT_LT) == 0.0
+          and e_dev == 0.0,
+          "off-block max = 0.0, block-vs-reference ratio max dev = 0.0")
+    coord = np.array([(-1) ** (((a >> 2) & 1) + ((a >> 1) & 1) + (a & 1)) for a in range(NS)])
+    check("eta4_ext read off the blocks equals diag((-1)^(x0+x1+x2))",
+          bool(np.array_equal(ref["eta"], coord)),
+          f"read {ref['eta'].tolist()}")
+
+    u0s, ms = [0.6, 1.0, 1.7], [0.0, 0.37]
+    worst, rejector, rows = 0.0, math.inf, []
+    for Lt in EXTRACT_LT:
+        Bm, Em, Sm = ex[Lt]["B"], np.diag(ex[Lt]["eta"]), ex[Lt]["S"]
+        for u0 in u0s:
+            for m in ms:
+                D = build_dirac_4d_apbc(2, Lt, u0, m)
+                base = m * np.eye(NS * Lt) + u0 * np.kron(Bm, np.eye(Lt))
+                dev = float(np.max(np.abs(D - (base + u0 * np.kron(Em, Sm)))))
+                rej = float(np.max(np.abs(D - (base + u0 * np.kron(np.eye(NS), Sm)))))
+                worst, rejector = max(worst, dev), min(rejector, rej)
+                rows.append(f"    Lt={Lt} u0={u0} m={m}: dev={dev:.3e} rejector={rej:.3e}")
+    npts = len(EXTRACT_LT) * len(u0s) * len(ms)
+    check("m*Id + u0*kron(B_ext,Id) + u0*kron(eta4_ext,S_ext) == build_dirac_4d_apbc",
+          worst == 0.0,
+          f"{npts} points, u0 in {u0s} x m in {ms}, max abs dev = {worst!r}",
+          "\n".join(rows))
+    check("rejector: replacing eta4_ext by the identity does not reproduce the matrix",
+          rejector > 0.0,
+          f"smallest max abs dev over the {npts} points = {rejector:.2e}",
+          "\n".join(rows))
+    return ref
+
+
+def part0b_clifford(ref):
+    print("0B exact Clifford relations on the extracted operators (integer arithmetic)")
+    B, eta = ref["B"], np.diag(ref["eta"])
+    Id = np.eye(NS, dtype=np.int64)
+    A = direction_hops(B)
+    check("A_1+A_2+A_3 == B_ext, A_i^2 == -Id_8, and A_iA_j+A_jA_i == 0 for i != j",
+          np.max(np.abs(A[0] + A[1] + A[2] - B)) == 0
+          and all(np.max(np.abs(a @ a + Id)) == 0 for a in A)
+          and all(np.max(np.abs(A[i] @ A[j] + A[j] @ A[i])) == 0
+                  for i in range(3) for j in range(i + 1, 3)),
+          "all seven deviations = 0; the 2-site antiperiodic ring gives T_i^2 = -Id")
+    check("B_ext^2 == -3*Id_8 and trace(B_ext) == 0",
+          np.max(np.abs(B @ B + 3 * Id)) == 0 and int(np.trace(B)) == 0)
+    check("eta4_ext^2 == Id_8 and trace(eta4_ext) == 0",
+          np.max(np.abs(eta @ eta - Id)) == 0 and int(np.trace(eta)) == 0)
+    check("B_ext*eta4_ext + eta4_ext*B_ext == 0",
+          np.max(np.abs(B @ eta + eta @ B)) == 0)
+
+
+def part0c_temporal_spectrum():
+    print(f"0C temporal spectrum, symbolic and exact, Lt = {SPECTRUM_LT[0]}..{SPECTRUM_LT[-1]}")
+    lam, z = sp.Symbol("lam"), sp.Symbol("z")
+    rec_dev, cp_ok, sf_ok, root_ok, ev_ok, rows = 0.0, True, True, True, True, []
+    for Lt in SPECTRUM_LT:
+        S = extract_operators(Lt)["S"]
+        T = shift_from_S(S)
+        rec_dev = max(rec_dev, float(np.max(np.abs(T @ T.T - np.eye(Lt)))),
+                      float(np.max(np.abs(0.5 * (T - T.T) - S))))
+        Tsym = sp.Matrix(T.tolist())
+        cp_ok &= Tsym.charpoly(lam) == sp.Poly(lam**Lt + 1, lam)
+        p = sp.Poly(lam**Lt + 1, lam)
+        sf_ok &= sp.gcd(p, p.diff(lam)) == sp.Poly(1, lam)
+        root_ok &= all(sp.exp(sp.I * (2 * n + 1) * sp.pi / Lt) ** Lt + 1 == 0
+                       for n in range(Lt))
+        v = sp.Matrix([z**t for t in range(Lt)])
+        Ssym = sp.Matrix([[sp.Rational(int(round(2 * S[i, j])), 2) for j in range(Lt)]
+                          for i in range(Lt)])
+        r1 = [sp.rem(sp.expand(e), z**Lt + 1, z) for e in (Tsym * v - z * v)]
+        r2 = [sp.rem(sp.expand(sp.cancel(z * e)), z**Lt + 1, z)
+              for e in (Ssym * v - ((z - 1 / z) / 2) * v)]
+        this_ev = all(e == 0 for e in r1) and all(e == 0 for e in r2)
+        ev_ok &= this_ev
+        rows.append(f"    Lt={Lt} charpoly={Tsym.charpoly(lam).as_expr()} "
+                    f"shift_dev={float(np.max(np.abs(0.5 * (T - T.T) - S)))} eigvec={this_ev}")
+    check("T_ext read off S_ext is a signed cyclic shift with (1/2)(T-T^-1) == S_ext",
+          rec_dev == 0.0,
+          f"{len(SPECTRUM_LT)} values of Lt, max abs dev = {rec_dev!r}", "\n".join(rows))
+    check("charpoly(T_ext) == lam^Lt + 1 exactly for every Lt in the range",
+          cp_ok, fail_detail="\n".join(rows))
+    check("lam^Lt + 1 is squarefree, so its Lt roots exp(i(2n+1)pi/Lt) are distinct",
+          sf_ok and root_ok,
+          "gcd(p, p') == 1 and all Lt roots annihilate p, for every Lt")
+    check("S_ext v(z) == ((z-1/z)/2) v(z) on the T_ext eigenvector v(z) = [1,z,..,z^(Lt-1)]",
+          ev_ok,
+          "residues reduced mod z^Lt + 1 vanish for every Lt; z^Lt = -1 closes the ring",
+          "\n".join(rows))
+    w = sp.Symbol("w", real=True)
+    check("(z - 1/z)/2 == i*sin(omega) at z = exp(i*omega), so S -> i sin(omega)",
+          sp.simplify((sp.exp(sp.I * w) - sp.exp(-sp.I * w)) / 2 - sp.I * sp.sin(w)) == 0)
+    flat = [Lt for Lt in SPECTRUM_LT
+            if all(sp.simplify(sp.sin(sp.Rational(2 * n + 1, Lt) * sp.pi) ** 2 - 1) == 0
+                   for n in range(Lt))]
+    check("Lt = 2 is the only APBC extent whose temporal modes all have sin^2 omega = 1",
+          flat == [2],
+          f"exact over Lt = {SPECTRUM_LT[0]}..{SPECTRUM_LT[-1]}; maximal-gap extents = {flat}")
+
+
+def part0d_symbolic_multiplicity(ref):
+    print("0D symbolic multiplicity-four theorem in (theta, u0, m): one computation, every Lt")
+    t_start = time.time()
+    theta = sp.Symbol("theta", real=True)
+    u0 = sp.Symbol("u0", positive=True)
+    m = sp.Symbol("m", real=True)
+    lam = sp.Symbol("lam")
+    K = u0 * (sp.Matrix(ref["B"].tolist())
+              + sp.I * sp.sin(theta) * sp.Matrix(np.diag(ref["eta"]).tolist()))
+    c = 3 + sp.sin(theta) ** 2
+    check("K(theta)^2 == -u0^2*(3 + sin^2 theta)*Id_8 and trace K(theta) == 0",
+          sp.simplify(K**2 + u0**2 * c * sp.eye(NS)) == sp.zeros(NS, NS)
+          and sp.simplify(K.trace()) == 0,
+          "traceless, square a negative multiple of Id_8, so the spectrum is +-i*sqrt(c)")
+    const, factors = sp.factor_list(K.charpoly(lam).as_expr())
+    mult = {sp.simplify(f - (lam**2 + u0**2 * c)) == 0: k for f, k in factors}.get(True)
+    check("charpoly(K) factors as (lam^2 + u0^2*(3 + sin^2 theta))^mult with mult == 4",
+          const == 1 and len(factors) == 1 and mult == 4,
+          f"factor_list returned multiplicity {mult}; tracelessness forces the 4+4 split")
+
+    det_expr = (m * sp.eye(NS) + K).det()
+    pt = {theta: sp.Rational(3, 10), u0: sp.Rational(11, 10), m: sp.Rational(1, 2)}
+
+    def residual(cand):
+        d = sp.expand(det_expr - sp.expand(cand))
+        return d, abs(complex(sp.N(d.subs(pt))))
+
+    d4, _ = residual((m**2 + u0**2 * c) ** 4)
+    check("det(m*Id_8 + K(theta)) == (m^2 + u0^2*(3 + sin^2 theta))^4",
+          d4 == 0, "symbolic identity in theta, u0, m; holds for every temporal mode")
+    for label, cand in (
+        ("exponent 3", (m**2 + u0**2 * c) ** 3),
+        ("exponent 5", (m**2 + u0**2 * c) ** 5),
+        ("2 + sin^2 theta in place of 3 + sin^2 theta", (m**2 + u0**2 * (2 + sp.sin(theta) ** 2)) ** 4),
+    ):
+        d, val = residual(cand)
+        check(f"rejector: {label} does not reproduce the block determinant",
+              d != 0 and val > 1e-6,
+              f"residual at (theta,u0,m) = (0.3,1.1,0.5) is {val:.4g}")
+    print(f"  symbolic section wall time = {time.time() - t_start:.1f} s")
+    return sp.lambdify((theta, u0, m), (m**2 + u0**2 * c) ** 4, "math")
+
+
+def part0e_close_the_loop(block_det):
+    print("0E closing the loop to the runner's own exact_det_formula")
+    Lts, u0s, ms = [2, 4, 6, 8], [0.6, 0.9, 1.2], [0.0, 0.1, 0.5]
+    max_rel, rows = 0.0, []
+    for Lt in Lts:
+        for u0 in u0s:
+            for m in ms:
+                prod = 1.0
+                for w in temporal_modes(Lt):
+                    prod *= block_det(w, u0, m)
+                ref = exact_det_formula(Lt, u0, m)
+                rel = abs(prod - ref) / ref
+                max_rel = max(max_rel, rel)
+                rows.append(f"    Lt={Lt} u0={u0} m={m}: rel={rel:.3e}")
+    check("prod_n [symbolic block det at omega_n] == exact_det_formula",
+          max_rel < 1e-13,
+          f"Lt in {Lts} x u0 in {u0s} x m in {ms}, {len(rows)} points, max rel dev = {max_rel:.1e}",
+          "\n".join(rows))
+
+
 def test_closed_form_determinant():
-    print("\n" + "=" * 78)
-    print("PART 1: CLOSED-FORM DETERMINANT")
-    print("=" * 78)
+    print("\nPART 1: CLOSED-FORM DETERMINANT")
 
     Ls = 2
-    max_rel = 0.0
-    for Lt in [2, 4, 6, 8]:
-        for u0 in [0.6, 0.9, 1.2]:
-            for m in [0.0, 0.1, 0.5]:
+    Lts, u0s, ms = [2, 4, 6, 8], [0.6, 0.9, 1.2], [0.0, 0.1, 0.5]
+    max_rel, rows = 0.0, []
+    for Lt in Lts:
+        for u0 in u0s:
+            for m in ms:
                 D = build_dirac_4d_apbc(Ls, Lt, u0, m)
                 direct = abs(np.linalg.det(D))
                 exact = exact_det_formula(Lt, u0, m)
                 rel = abs(direct - exact) / exact
                 max_rel = max(max_rel, rel)
-                print(f"  Lt={Lt}, u0={u0:.1f}, m={m:.1f}: direct={direct:.8e}, exact={exact:.8e}, rel={rel:.2e}")
+                rows.append(f"    Lt={Lt}, u0={u0:.1f}, m={m:.1f}: direct={direct:.8e}, "
+                            f"exact={exact:.8e}, rel={rel:.2e}")
     check("exact Matsubara determinant formula matches direct determinant",
           max_rel < 1e-10,
-          f"max relative error = {max_rel:.2e}")
+          f"Lt in {Lts} x u0 in {u0s} x m in {ms}, {len(rows)} points, "
+          f"max rel dev = {max_rel:.2e}",
+          "\n".join(rows))
 
 
 def test_closed_form_intensive_observables():
-    print("\n" + "=" * 78)
-    print("PART 2: CLOSED-FORM FREE-ENERGY AND CONDENSATE DENSITIES")
-    print("=" * 78)
+    print("\nPART 2: CLOSED-FORM FREE-ENERGY AND CONDENSATE DENSITIES")
 
     Ls = 2
     u0 = 0.9
+    Lts, ms = [2, 4, 6, 8, 10], [1e-3, 1e-2, 0.1]
     max_f = 0.0
     max_c = 0.0
-    for Lt in [2, 4, 6, 8, 10]:
+    rows = []
+    for Lt in Lts:
         D0 = build_dirac_4d_apbc(Ls, Lt, u0, 0.0)
         ld0 = np.linalg.slogdet(D0)[1]
         n = Ls**3 * Lt
-        for m in [1e-3, 1e-2, 0.1]:
+        for m in ms:
             Dm = build_dirac_4d_apbc(Ls, Lt, u0, m)
             ldm = np.linalg.slogdet(Dm)[1]
             direct_f = (ldm - ld0) / n
@@ -169,19 +435,18 @@ def test_closed_form_intensive_observables():
             err_c = abs(direct_c - exact_c)
             max_f = max(max_f, err_f)
             max_c = max(max_c, err_c)
-            print(f"  Lt={Lt}, m={m:g}: f_direct={direct_f:.10e}, f_exact={exact_f:.10e}, c_direct={direct_c:.10e}, c_exact={exact_c:.10e}")
+            rows.append(f"    Lt={Lt}, m={m:g}: f_direct={direct_f:.10e}, f_exact={exact_f:.10e}, "
+                        f"c_direct={direct_c:.10e}, c_exact={exact_c:.10e}")
+    print(f"  grid: Lt in {Lts} x u0 = {u0} x m in {ms}, {len(rows)} points; "
+          "log|det| taken with slogdet")
     check("exact free-energy density formula matches direct computation",
-          max_f < 1e-12,
-          f"max absolute error = {max_f:.2e}")
+          max_f < 1e-12, f"max abs dev = {max_f:.2e}", "\n".join(rows))
     check("exact condensate density formula matches direct computation",
-          max_c < 1e-12,
-          f"max absolute error = {max_c:.2e}")
+          max_c < 1e-12, f"max abs dev = {max_c:.2e}", "\n".join(rows))
 
 
 def test_uv_endpoint_interpretation():
-    print("\n" + "=" * 78)
-    print("PART 3: UV ENDPOINT INTERPRETATION")
-    print("=" * 78)
+    print("\nPART 3: UV ENDPOINT INTERPRETATION")
 
     u0 = 0.9
     mass = 1e-2
@@ -197,27 +462,27 @@ def test_uv_endpoint_interpretation():
     alpha_lm = alpha_bare / hierarchy_u0
     c_obs = 246.22 / (m_planck * alpha_lm**16)
 
-    print(f"  cond(Lt=2)  = {cond2:.10f}")
-    print(f"  cond(Lt=10) = {cond10:.10f}")
-    print(f"  ratio       = {ratio:.10f}")
-    print(f"  C_obs       = {c_obs:.10f}")
-    print(f"  ratio^(-1/4)  = {root4:.10f}")
-    print(f"  ratio^(-1/16) = {root16:.10f}")
+    print(f"  u0={u0}, m={mass:g}: cond(Lt=2)={cond2:.8f}, cond(Lt=10)={cond10:.8f}, "
+          f"R={ratio:.8f}")
+    print(f"  C_obs={c_obs:.8f}, R^(-1/4)={root4:.8f}, R^(-1/16)={root16:.8f}")
 
-    check("dimension-4 compression is closer to the observed hierarchy prefactor than 16th-root compression",
+    check("dimension-4 compression is closer to the observed hierarchy prefactor "
+          "than 16th-root compression",
           abs(root4 - c_obs) < abs(root16 - c_obs),
           f"|root4-C_obs|={abs(root4-c_obs):.6f}, |root16-C_obs|={abs(root16-c_obs):.6f}")
 
 
 def main():
     print("Hierarchy Matsubara decomposition")
-    print("=" * 78)
+    ref = part0a_structural_extraction()
+    part0b_clifford(ref)
+    part0c_temporal_spectrum()
+    block_det = part0d_symbolic_multiplicity(ref)
+    part0e_close_the_loop(block_det)
     test_closed_form_determinant()
     test_closed_form_intensive_observables()
     test_uv_endpoint_interpretation()
-    print("\n" + "=" * 78)
-    print(f"SCORECARD: {PASS_COUNT} pass, {FAIL_COUNT} fail out of {PASS_COUNT + FAIL_COUNT}")
-    print("=" * 78)
+    print(f"\nSCORECARD: {PASS_COUNT} pass, {FAIL_COUNT} fail out of {PASS_COUNT + FAIL_COUNT}")
     sys.exit(1 if FAIL_COUNT else 0)
 
 


### PR DESCRIPTION
## Verdict answered

Row `hierarchy_matsubara_decomposition_note`, `effective_status: audited_conditional`,
verdict class `scope_too_broad`:

> Add a symbolic general-L_t spectral factorization with the multiplicity-four
> derivation, or narrow this source note to the runner-tested finite grid before
> re-audit.

This PR takes the **generalization** branch, not the narrowing branch.

## What was wrong

The note asserted

`|det(D + m)| = prod_omega [m^2 + u_0^2 (3 + sin^2 omega)]^4`

and justified it by a *sampled-momentum* statement — all spatial momenta sit at
Brillouin-zone corners, so `sin^2(k_i) = 1` — which is a property of the tested grid,
not a derivation. The exponent `4` was asserted with no derivation at all. Two further
claims in the note (the `L_t = 2` UV endpoint uniqueness) were likewise ungated
assertions.

## What changed

The note now derives the formula as an **operator identity**, symbolically and for
general `L_t`, in five steps:

1. **Space (x) time split.** `D(m) = m Id + u_0 (B (x) Id_t) + u_0 (eta_4 (x) S)`, with
   `B` and `eta_4` *read out of the assembled matrix* rather than posited (identical for
   `L_t = 2,3,4,5,6,8`; substituting `Id_8` for `eta_4` fails to reproduce the matrix).
2. **Two-site antiperiodic ring.** The antisymmetric hop collapses onto the shift itself
   (forward and backward hops connect the same pair; the antiperiodic wrap flips one
   sign, so they add), giving `A_i^2 = -Id_8` and `A_iA_j + A_jA_i = 0` in exact integer
   arithmetic, hence `B^2 = -3 Id_8`, `tr B = 0`, `B eta_4 + eta_4 B = 0`. **This**, not
   a sampled momentum grid, is what fixes the spatial constant `3` at every mode and
   every `L_t`. The momentum reading is retained only as a remark that it returns the
   same number.
3. **Temporal spectrum.** Cofactor expansion gives `charpoly(T) = lam^L_t + 1`, which is
   squarefree, so `T` diagonalizes with simple eigenvalues and `S -> i sin(omega_n)`,
   `omega_n = (2n+1) pi / L_t`. The APBC Matsubara frequencies are an **output** of the
   temporal algebra.
4. **Multiplicity four, from tracelessness.** `K(omega) = u_0 (B + i sin(omega) eta_4)`
   satisfies `K^2 = -u_0^2 (3 + sin^2 omega) Id_8` with `tr K = 0`. A traceless operator
   on an 8-dimensional space whose square is `-c Id`, `c > 0`, admits only the
   eigenvalues `+- i u_0 sqrt(3 + sin^2 omega)`, and tracelessness forces the `4 + 4`
   split. **That split is the exponent 4** — not fitted, not read off the grid.
5. **General `L_t`.** The block computation runs once symbolically in `(theta, u_0, m)`
   with `theta` free, so `L_t` enters only via `theta -> omega_n`; it covers every `L_t`.

The paired runner gates all five steps and **discriminates**: it rejects the exponents
`3` and `5` and the spatial constant `2 + sin^2 theta`, rejects `Id_8` in place of
`eta_4`, and chains symbolic block determinant -> product formula -> direct numerical
determinant. A new exact symbolic gate was added for the previously-ungated UV-endpoint
claim: `L_t = 2` is the only APBC extent whose temporal modes all have
`sin^2 omega = 1`, verified over `L_t = 2..16`.

## Runner

- `scripts/frontier_hierarchy_matsubara_decomposition.py`: **26 pass, 0 fail out of 26**,
  exit 0, 3.9 s.
- Cache body **4540 chars**, comfortably inside the 6000-char audit-packet excerpt
  budget, so the runner evidence now renders **unclipped** in the audit packet. The
  previous cache carried ~1300 chars of numpy `slogdet` RuntimeWarnings that were an
  artifact of the Python 3.12 framework build and do not reproduce here.
- Sibling check: `frontier_hierarchy_matsubara_free_energy_density_narrow.py` re-run,
  26/26 pass, unaffected. No runner greps this note's prose.

## Scope

Source-only triple: 1 note + 1 runner + 1 cache. No new note, so no
`citation_graph_manifest.json` change. No new imports, no new axioms, no status
language. The four open items in the note's Honest conclusion are unchanged — this
does not close the hierarchy theorem, it settles the temporal algebra underneath it.

Also rephrases "What it closes is the temporal algebra" -> "What it settles", per the
standing no-closing-framing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)