### PR TITLE
fix(flavor-carrier): emit N1-N8 discipline packet evidence in-cycle

### DIFF
--- a/docs/FLAVOR_CARRIER_MOMENTUM_TYPE_FROM_TRANSLATION_THEOREM_NOTE_2026-06-15.md
+++ b/docs/FLAVOR_CARRIER_MOMENTUM_TYPE_FROM_TRANSLATION_THEOREM_NOTE_2026-06-15.md
@@ -105,6 +105,47 @@ The proof adds no axiom, approved primitive, selector, convention, imported
 value, or physical identification. Its only inputs are the displayed finite
 definitions and exact finite-dimensional linear algebra.
 
+## Discipline packet evidence (N1-N8)
+
+The same execution emits structured route and resolution evidence for the negative
+content of the Authority limit. The wall referenced throughout is
+**position-diagonality in the site basis**.
+
+Five distinct mechanism classes are attempted in the current cycle, each executed
+symbolically rather than argued:
+
+| Route | Mechanism class | Outcome against the wall |
+|---|---|---|
+| R1 | `diagonal_polynomial_algebra` | blocked: `<psi_k, diag(u) diag(v) diag(x) psi_k> = (1/8) sum_n u_n v_n x_n` for every `k` |
+| R2 | `offdiagonal_translation_observable` | reaches label separation, `<psi_k, T_mu psi_k> = (-1)^(k_mu)`, but every `T_mu` has zero site-basis diagonal |
+| R3 | `mixed_state_convex_combination` | blocked: `tr(rho O)` for `rho = sum_k p_k P_k` depends on `rho` only through `sum_k p_k` |
+| R4 | `eigenbasis_degeneracy_rigidity` | blocked: with all three generators every joint eigenspace has dimension `1` |
+| R5 | `lattice_extent_variation` | blocked: the `Z_L^3` construction gives profile `1/L^3` and expectation `(1/L^3) sum_n w_n` for `L = 2, 3, 4` |
+
+R2 and R4 carry the discriminating content. R2 locates the wall rather than crossing
+it: an observable that does separate the eight character labels exists, and it is off
+the position diagonal. R4 shows the uniform profile is forced by using all three
+translations rather than assumed — dropping to the two-generator subgroup `{T_x, T_y}`
+raises every joint eigenspace to dimension `2` and admits the simultaneous eigenvector
+`(psi_000 + psi_001)/sqrt(2)`, whose position profile
+
+```text
+(1/4, 0, 1/4, 0, 1/4, 0, 1/4, 0)
+```
+
+is not uniform. The runner prints this witness and gates it.
+
+The negative sentence of the Authority limit is tested at all five resolution classes
+`per_element`, `per_site`, `per_mode`, `per_block`, and `lattice_wide`: single-site
+operators `|n><n|` have expectation `1/8` in every character; the site-resolved profile
+is uniform; the symbolic diagonal expectation takes one value across all eight modes;
+the supplied `K_1` block average equals both its complement average and the whole-cell
+average; and `d<psi_k, O psi_k>/dw_n = 1/8` for every `k` and `n`, so the expectation
+depends on the weights through `sum_n w_n` alone.
+
+The residual left open here is whether `T_mu` is a physical observable, which belongs to
+a separate authority surface.
+
 ## Verification and mutation controls
 
 Run the exact certificate:
@@ -116,7 +157,7 @@ python3 scripts/flavor_carrier_momentum_type_from_translation_2026_06_15.py
 Expected:
 
 ```text
-TOTAL: PASS=10 FAIL=0
+TOTAL: PASS=21 FAIL=0
 ```
 
 The same runner exposes reviewer-reproducible mutations for translation-step

--- a/logs/runner-cache/flavor_carrier_momentum_type_from_translation_2026_06_15.txt
+++ b/logs/runner-cache/flavor_carrier_momentum_type_from_translation_2026_06_15.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/flavor_carrier_momentum_type_from_translation_2026_06_15.py
-runner_sha256: cfbb766482823347c6a850c52d701ca66cc8a98f693752480327ebfa441e901e
+runner_sha256: 0ab1e787b20d3be27417f4f3c6bd3fd805b35417031152537f3c919c2a955522
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.33
+elapsed_sec: 0.41
 status: ok
 ----- stdout -----
 Finite translation-character profiles and projectors
@@ -18,7 +18,27 @@ Finite translation-character profiles and projectors
   [PASS] A9 the eight character projectors resolve the identity
   [PASS] A10 the full projector expectation matrix is Kronecker delta  (hw1_matrix=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 FULL PROJECTOR EXPECTATION MATRIX: [[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0], [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0], [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 0, 1]]
-TOTAL: PASS=10 FAIL=0
+DISCIPLINE PACKET (current-cycle live evidence for N1-N8)
+  N2 wall: position-diagonality in the site basis. A route crosses it only by separating the eight character labels with a position-diagonal observable.
+  [PASS] A11 N1 route R1 diagonal_polynomial_algebra  (mechanism: products and powers of position-diagonal site operators; attempt: expectation of diag(u)*diag(v)*diag(x) with independent symbolic weights in all eight characters; outcome: BLOCKED, equals (1/8) sum_n u_n v_n x_n for every k)
+  [PASS] A12 N1 route R2 offdiagonal_translation_observable  (mechanism: off-diagonal translation observable in the site basis; attempt: expectation of T_x, T_y and T_z in all eight characters; outcome: REACHED label separation, the eight triples ((-1)^k_x,(-1)^k_y,(-1)^k_z) are distinct, but every diagonal entry of every T_mu is zero)
+  [PASS] A13 N1 route R3 mixed_state_convex_combination  (mechanism: state-side convex mixture of characters; attempt: tr(rho O) for rho = sum_k p_k P_k with eight free symbolic p_k; outcome: BLOCKED, equals (sum_k p_k) (1/8) sum_n w_n, so it depends on rho only through its trace)
+  [PASS] A14 N1 route R4 eigenbasis_degeneracy_rigidity  (mechanism: joint-eigenbasis degeneracy; attempt: simultaneous eigenspace dimensions for the three generators and for the two-generator subgroup {T_x,T_y}; outcome: BLOCKED at three generators, every joint dimension is 1 so the profile is basis-independent, while the subgroup gives dimension 2 and admits the non-uniform profile (1/4,0,1/4,0,1/4,0,1/4,0))
+  [PASS] A15 N1 route R5 lattice_extent_variation  (mechanism: lattice extent variation; attempt: rebuild every Z_L^3 translation character for L = 2, 3, 4, test every position profile, test the symbolic-weight expectation for a probe character, and require a single-site indicator to be rejected at each extent; outcome: BLOCKED at every extent, the profile is uniform 1/L^3 and the expectation is (1/L^3) sum_n w_n, so the blindness is not an L=2 artifact)
+  N5 rhetoric audit; resolution_classes_checked = [per_element, per_site, per_mode, per_block, lattice_wide]
+  N5 statement S1 phrase: "The formulas here assign no physical carrier, observable, or readout role to either basis."
+  [PASS] A16 N5 resolution class per_element  (per_element: every single-site operator |n><n| has expectation exactly 1/8 in every character, so no individual site element separates the eight labels)
+  [PASS] A17 N5 resolution class per_site  (per_site: the site-resolved position profile of every character is exactly (1/8,...,1/8), so no site-resolved readout separates the eight labels)
+  [PASS] A18 N5 resolution class per_mode  (per_mode: the symbolic diagonal expectation takes one and the same value across all eight character modes, so no mode-resolved readout separates them)
+  [PASS] A19 N5 resolution class per_block  (per_block: the supplied K_1 block average, its five-character complement average, and the whole-cell average of the diagonal expectation are equal)
+  [PASS] A20 N5 resolution class lattice_wide  (lattice_wide: d<psi_k,O psi_k>/dw_n = 1/8 for every character k and every site n, so the expectation depends on the weights through sum_n w_n alone)
+  [PASS] A21 the audited note carries the N5 statement phrase  (note=FLAVOR_CARRIER_MOMENTUM_TYPE_FROM_TRANSLATION_THEOREM_NOTE_2026-06-15.md)
+  N3 hidden-wall scan: no check assumes the finite character-sum identity; every equality is evaluated from the explicit site-basis permutation and character matrices.
+  N4 residual: the residual not settled here is whether T_mu is a physical observable, which belongs to a separate authority surface.
+  N6 partial closure: character-label separation is reached by R2 on the indexed basis "T_mu psi_k = (-1)^(k_mu) psi_k"; it stops at the N2 wall because every T_mu has zero diagonal in the site basis.
+  N7 steelman R2 resolution: every diagonal entry of T_x, T_y and T_z is zero, so the separating observable is not position-diagonal and the N2 wall is untouched.
+  N8 cross-cycle echo: this runner emits current-cycle evidence only; cross-cycle comparison is orchestrator-owned and is not asserted here.
+TOTAL: PASS=21 FAIL=0
 
 ----- stderr -----
 

--- a/scripts/flavor_carrier_momentum_type_from_translation_2026_06_15.py
+++ b/scripts/flavor_carrier_momentum_type_from_translation_2026_06_15.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import itertools
+import pathlib
 from collections.abc import Callable
 
 import sympy as sp
@@ -34,6 +35,33 @@ Site = tuple[int, int, int]
 SITES: tuple[Site, ...] = tuple(itertools.product((0, 1), repeat=3))
 CORNERS: tuple[Site, ...] = SITES
 HW1: tuple[Site, ...] = tuple(k for k in CORNERS if sum(k) == 1)
+NOTE_PATH = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "docs"
+    / "FLAVOR_CARRIER_MOMENTUM_TYPE_FROM_TRANSLATION_THEOREM_NOTE_2026-06-15.md"
+)
+
+
+def general_sites(extent: int) -> tuple[Site, ...]:
+    """Return the lexicographic site list of the periodic ``extent^3`` cell."""
+    return tuple(itertools.product(range(extent), repeat=3))
+
+
+def general_character(k: Site, extent: int, sites: tuple[Site, ...]) -> sp.Matrix:
+    """Return the exact Z_extent^3 translation character on the supplied cell."""
+    root = sp.sqrt(len(sites))
+    return sp.Matrix(
+        [
+            sp.exp(
+                2
+                * sp.pi
+                * sp.I
+                * sp.Rational(sum(ki * ni for ki, ni in zip(k, n)), extent)
+            )
+            / root
+            for n in sites
+        ]
+    )
 
 
 def translation_matrix(axis: int, sites: tuple[Site, ...], step: int = 1) -> sp.Matrix:
@@ -223,8 +251,256 @@ class Certificate:
         )
 
         print(f"FULL PROJECTOR EXPECTATION MATRIX: {expectation_matrix.tolist()}")
+        self.discipline_packet(translations, characters, projectors)
         print(f"TOTAL: PASS={self.pass_count} FAIL={self.fail_count}")
         return 1 if self.fail_count else 0
+
+    def discipline_packet(
+        self,
+        translations: list[sp.Matrix],
+        characters: dict[Site, sp.Matrix],
+        projectors: dict[Site, sp.Matrix],
+    ) -> None:
+        """Execute and print current-cycle N1-N8 route and resolution evidence."""
+        weights = sp.symbols("w0:8")
+        diagonal = sp.diag(*weights)
+        uniform_value = sum(weights) / 8
+
+        print("DISCIPLINE PACKET (current-cycle live evidence for N1-N8)")
+        print(
+            "  N2 wall: position-diagonality in the site basis. A route crosses it only by"
+            " separating the eight character labels with a position-diagonal observable."
+        )
+
+        u, v, x = sp.symbols("u0:8"), sp.symbols("v0:8"), sp.symbols("x0:8")
+        product_operator = sp.diag(*u) * sp.diag(*v) * sp.diag(*x)
+        product_value = sum(u[i] * v[i] * x[i] for i in range(8)) / 8
+        self.check(
+            "A11 N1 route R1 diagonal_polynomial_algebra",
+            all(
+                sp.expand(
+                    (characters[k].T * product_operator * characters[k])[0] - product_value
+                )
+                == 0
+                for k in CORNERS
+            ),
+            detail=(
+                "mechanism: products and powers of position-diagonal site operators; "
+                "attempt: expectation of diag(u)*diag(v)*diag(x) with independent symbolic "
+                "weights in all eight characters; "
+                "outcome: BLOCKED, equals (1/8) sum_n u_n v_n x_n for every k"
+            ),
+        )
+
+        signatures = {
+            k: tuple(
+                sp.expand((characters[k].T * translations[a] * characters[k])[0])
+                for a in range(3)
+            )
+            for k in CORNERS
+        }
+        self.check(
+            "A12 N1 route R2 offdiagonal_translation_observable",
+            len(set(signatures.values())) == 8
+            and all(
+                signatures[k] == tuple(sp.Integer((-1) ** k[a]) for a in range(3))
+                for k in CORNERS
+            )
+            and all(translations[a][i, i] == 0 for a in range(3) for i in range(8)),
+            detail=(
+                "mechanism: off-diagonal translation observable in the site basis; "
+                "attempt: expectation of T_x, T_y and T_z in all eight characters; "
+                "outcome: REACHED label separation, the eight triples ((-1)^k_x,(-1)^k_y,"
+                "(-1)^k_z) are distinct, but every diagonal entry of every T_mu is zero"
+            ),
+        )
+
+        mixture = sp.symbols("p0:8")
+        density = sum(
+            (mixture[i] * projectors[CORNERS[i]] for i in range(8)), sp.zeros(8)
+        )
+        self.check(
+            "A13 N1 route R3 mixed_state_convex_combination",
+            sp.expand(sp.trace(density * diagonal) - sum(mixture) * uniform_value) == 0,
+            detail=(
+                "mechanism: state-side convex mixture of characters; "
+                "attempt: tr(rho O) for rho = sum_k p_k P_k with eight free symbolic p_k; "
+                "outcome: BLOCKED, equals (sum_k p_k) (1/8) sum_n w_n, so it depends on rho"
+                " only through its trace"
+            ),
+        )
+
+        def joint_dimension(generators: tuple[int, ...], k: Site) -> int:
+            stacked = sp.Matrix.vstack(
+                *[
+                    translations[a] - sp.Integer((-1) ** k[a]) * sp.eye(8)
+                    for a in generators
+                ]
+            )
+            return 8 - stacked.rank()
+
+        witness = (characters[(0, 0, 0)] + characters[(0, 0, 1)]) / sp.sqrt(2)
+        witness_profile = tuple(sp.simplify(sp.conjugate(e) * e) for e in witness)
+        self.check(
+            "A14 N1 route R4 eigenbasis_degeneracy_rigidity",
+            {joint_dimension((0, 1, 2), k) for k in CORNERS} == {1}
+            and {joint_dimension((0, 1), k) for k in CORNERS} == {2}
+            and all(
+                sp.expand(translations[a] * witness - witness) == sp.zeros(8, 1)
+                for a in (0, 1)
+            )
+            and witness_profile == (sp.Rational(1, 4), sp.Integer(0)) * 4,
+            detail=(
+                "mechanism: joint-eigenbasis degeneracy; "
+                "attempt: simultaneous eigenspace dimensions for the three generators and "
+                "for the two-generator subgroup {T_x,T_y}; "
+                "outcome: BLOCKED at three generators, every joint dimension is 1 so the "
+                "profile is basis-independent, while the subgroup gives dimension 2 and "
+                "admits the non-uniform profile (1/4,0,1/4,0,1/4,0,1/4,0)"
+            ),
+        )
+
+        extent_uniform, extent_expectation = True, True
+        for extent in (2, 3, 4):
+            sites = general_sites(extent)
+            count = len(sites)
+            profiles = {
+                k: [sp.simplify(sp.conjugate(e) * e) for e in general_character(k, extent, sites)]
+                for k in sites
+            }
+            if any(p != sp.Rational(1, count) for k in sites for p in profiles[k]):
+                extent_uniform = False
+            general_weights = sp.symbols(f"g0:{count}")
+            probe = sites[1]
+            combined = sum(general_weights[i] * profiles[probe][i] for i in range(count))
+            if sp.expand(combined - sum(general_weights) / count) != 0:
+                extent_expectation = False
+            rejector = sp.zeros(count, 1)
+            rejector[0] = sp.Integer(1)
+            if all(
+                sp.simplify(sp.conjugate(e) * e) == sp.Rational(1, count) for e in rejector
+            ):
+                extent_uniform = False
+        self.check(
+            "A15 N1 route R5 lattice_extent_variation",
+            extent_uniform and extent_expectation,
+            detail=(
+                "mechanism: lattice extent variation; "
+                "attempt: rebuild every Z_L^3 translation character for L = 2, 3, 4, test every "
+                "position profile, test the symbolic-weight expectation for a probe character, "
+                "and require a single-site indicator to be rejected at each extent; "
+                "outcome: BLOCKED at every extent, the profile is uniform 1/L^3 and the "
+                "expectation is (1/L^3) sum_n w_n, so the blindness is not an L=2 artifact"
+            ),
+        )
+
+        statement = (
+            "The formulas here assign no physical carrier, observable, or readout role to"
+            " either basis."
+        )
+        print(
+            "  N5 rhetoric audit; resolution_classes_checked ="
+            " [per_element, per_site, per_mode, per_block, lattice_wide]"
+        )
+        print(f'  N5 statement S1 phrase: "{statement}"')
+
+        site_operators = [
+            sp.diag(*[sp.Integer(1) if i == j else sp.Integer(0) for i in range(8)])
+            for j in range(8)
+        ]
+        self.check(
+            "A16 N5 resolution class per_element",
+            all(
+                sp.expand(
+                    (characters[k].T * site_operators[j] * characters[k])[0] - sp.Rational(1, 8)
+                )
+                == 0
+                for k in CORNERS
+                for j in range(8)
+            ),
+            detail=(
+                "per_element: every single-site operator |n><n| has expectation exactly 1/8 in"
+                " every character, so no individual site element separates the eight labels"
+            ),
+        )
+        self.check(
+            "A17 N5 resolution class per_site",
+            all(
+                tuple(sp.simplify(sp.conjugate(e) * e) for e in characters[k])
+                == (sp.Rational(1, 8),) * 8
+                for k in CORNERS
+            ),
+            detail=(
+                "per_site: the site-resolved position profile of every character is exactly"
+                " (1/8,...,1/8), so no site-resolved readout separates the eight labels"
+            ),
+        )
+        modes = {
+            k: sp.expand((characters[k].T * diagonal * characters[k])[0]) for k in CORNERS
+        }
+        self.check(
+            "A18 N5 resolution class per_mode",
+            len(set(modes.values())) == 1
+            and all(sp.expand(modes[k] - uniform_value) == 0 for k in CORNERS),
+            detail=(
+                "per_mode: the symbolic diagonal expectation takes one and the same value"
+                " across all eight character modes, so no mode-resolved readout separates them"
+            ),
+        )
+        supplied_block = sum(modes[k] for k in HW1) / len(HW1)
+        complement = tuple(k for k in CORNERS if k not in HW1)
+        complement_block = sum(modes[k] for k in complement) / len(complement)
+        whole_cell = sum(modes[k] for k in CORNERS) / len(CORNERS)
+        self.check(
+            "A19 N5 resolution class per_block",
+            sp.expand(supplied_block - complement_block) == 0
+            and sp.expand(supplied_block - whole_cell) == 0,
+            detail=(
+                "per_block: the supplied K_1 block average, its five-character complement"
+                " average, and the whole-cell average of the diagonal expectation are equal"
+            ),
+        )
+        self.check(
+            "A20 N5 resolution class lattice_wide",
+            all(
+                sp.diff(modes[k], weights[n]) == sp.Rational(1, 8)
+                for k in CORNERS
+                for n in range(8)
+            ),
+            detail=(
+                "lattice_wide: d<psi_k,O psi_k>/dw_n = 1/8 for every character k and every"
+                " site n, so the expectation depends on the weights through sum_n w_n alone"
+            ),
+        )
+        note_text = " ".join(NOTE_PATH.read_text(encoding="utf-8").split())
+        self.check(
+            "A21 the audited note carries the N5 statement phrase",
+            " ".join(statement.split()) in note_text,
+            detail=f"note={NOTE_PATH.name}",
+        )
+
+        print(
+            "  N3 hidden-wall scan: no check assumes the finite character-sum identity; every"
+            " equality is evaluated from the explicit site-basis permutation and character"
+            " matrices."
+        )
+        print(
+            "  N4 residual: the residual not settled here is whether T_mu is a physical"
+            " observable, which belongs to a separate authority surface."
+        )
+        print(
+            '  N6 partial closure: character-label separation is reached by R2 on the indexed'
+            ' basis "T_mu psi_k = (-1)^(k_mu) psi_k"; it stops at the N2 wall because every'
+            " T_mu has zero diagonal in the site basis."
+        )
+        print(
+            "  N7 steelman R2 resolution: every diagonal entry of T_x, T_y and T_z is zero, so"
+            " the separating observable is not position-diagonal and the N2 wall is untouched."
+        )
+        print(
+            "  N8 cross-cycle echo: this runner emits current-cycle evidence only; cross-cycle"
+            " comparison is orchestrator-owned and is not asserted here."
+        )
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## What verdict this answers

Row `flavor_carrier_momentum_type_from_translation_theorem_note_2026-06-15`
(`effective_status: audited_conditional`, `claim_type: bounded_theorem`,
`criticality: critical`, transitive fan **1211**).

`notes_for_re_audit_if_any`:

> `runner_artifact_issue: add current-cycle runner output sufficient to populate the complete N1-N8 discipline packet, including five distinct evidenced N1 mechanism classes and all five N5 resolution-class tests, then re-audit.`

The verdict's own `chain_closure_explanation` confirms the ten original checks are
correct and that the missing item was packet evidence in stdout, not mathematics.
This PR therefore adds evidence, not claims: the six numbered theorem items, the
`claim_scope`, and the `## Authority limit` text are unchanged.

## What changed

`scripts/flavor_carrier_momentum_type_from_translation_2026_06_15.py` gains a
`discipline_packet` stage between the projector-matrix print and the `TOTAL:` line.
**PASS=10 -> PASS=21**, exit 0, 0.5 s against the resolved 120 s timeout.

The N2 wall referenced throughout is **position-diagonality in the site basis**.

### Five distinct N1 mechanism classes, each executed symbolically

| Check | Route | Mechanism class | Outcome against the wall |
|---|---|---|---|
| A11 | R1 | `diagonal_polynomial_algebra` | blocked: `<psi_k, diag(u)diag(v)diag(x) psi_k> = (1/8) sum_n u_n v_n x_n` for every `k` |
| A12 | R2 | `offdiagonal_translation_observable` | reaches label separation, `<psi_k, T_mu psi_k> = (-1)^(k_mu)`, but every `T_mu` has zero site-basis diagonal |
| A13 | R3 | `mixed_state_convex_combination` | blocked: `tr(rho O)` for `rho = sum_k p_k P_k` depends on `rho` only through `sum_k p_k` |
| A14 | R4 | `eigenbasis_degeneracy_rigidity` | blocked: with all three generators every joint eigenspace has dimension `1` |
| A15 | R5 | `lattice_extent_variation` | blocked: the `Z_L^3` construction gives profile `1/L^3` and expectation `(1/L^3) sum_n w_n` for `L = 2, 3, 4` |

R2 and R4 carry the discriminating content.

- **R2 locates the wall rather than crossing it.** An observable that *does* separate
  the eight character labels exists; it is off the position diagonal. This pins the
  boundary exactly where the Authority limit places it.
- **R4 shows the uniform profile is forced, not assumed.** Dropping to the
  two-generator subgroup `{T_x, T_y}` raises every joint eigenspace to dimension `2`
  and admits the simultaneous eigenvector `(psi_000 + psi_001)/sqrt(2)`, whose
  position profile `(1/4, 0, 1/4, 0, 1/4, 0, 1/4, 0)` is not uniform. The runner
  prints and gates this witness. Using all three translations is what forces
  uniformity.

### All five N5 resolution classes

`A16`-`A20` test the Authority-limit sentence at exactly
`per_element`, `per_site`, `per_mode`, `per_block`, `lattice_wide`, each emitting its
class-prefixed string verbatim in stdout. `A21` pins the audited sentence to the
note text, so the two cannot drift apart silently.

## Gate discrimination

Every new check must fail if the object were wrong.

| Mutation | New checks it breaks |
|---|---|
| `normalization` | A11, A12, A13, A14, A16-A20 |
| `translation_direction` | A12, A14 |
| `character_phase` | A12, A14 |
| `site_ordering` | A12, A14 |

`A15` builds its own `Z_L^3` cells, so no mutation reaches it — it therefore carries
an explicit **wrong-value rejector**, and I falsification-tested it: a sed-patched
copy replacing the single-site indicator with a genuinely uniform vector prints
`[FAIL] A15`. The gate is not tautological. `A21` is discriminated by the note text
itself.

All seven pre-existing mutations still exit nonzero, so the note's mutation-control
claim is preserved.

## Artifacts

- Cache regenerated through `runner_timeout_for`: **5739 chars** against the 6000
  limit, `exit_code: 0`, `status: ok`, no truncation markers, 261 chars headroom —
  so the packet evidence is fully present, not clipped.
- Note-reading siblings re-run after the note edit:
  `flavor_carrier_from_axioms_momentum_forced_2026_05_31` **PASS=15 FAIL=0**;
  `staggered_dirac_common_hw1_bz_corner_carrier_identification_2026_07_05`
  **PASS=25 FAIL=0**.
- No new note, so no `citation_graph_manifest.json` change. The note gains no
  markdown link, so the dependency edge set is unchanged.
- No status or grade language authored anywhere; grading remains with the
  independent audit lane.

Clean triple: 1 note, 1 runner, 1 cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)