### PR TITLE
docs(flavor): scope r=1/2 language to the route, not the setting

### DIFF
--- a/docs/FLAVOR_TRACE_VS_CENTER_DISSOLVES_NOTE_2026-05-30.md
+++ b/docs/FLAVOR_TRACE_VS_CENTER_DISSOLVES_NOTE_2026-05-30.md
@@ -163,16 +163,20 @@ The current source packet does not close the science. The residuals are:
   square-root readout rather than a singular-value/Yukawa readout;
 - **block selector:** why the physical functional should be trace/dimension,
   block-count, or another native reference state;
-- **modulus selector:** why `r = 1/2` should be selected rather than merely
-  matched by `Q_trace = 2/3`;
+- **modulus selector:** whether and how `r = 1/2` is selected rather than
+  merely matched by `Q_trace = 2/3`;
 - **phase/sign chamber:** how the broader `b = |b|e^{i phi}` chamber is selected.
 
 No new axiom, measured mass input, or audit verdict is introduced here.
 
 ## Next Useful Path
 
-The highest-value closure route remains a native selector theorem: records,
-KMS/modular structure, or matter-action dynamics would need to select both the
-signed/Hermitian readout and the `r = 1/2` modulus. A theorem selecting the
+One open route is a native selector theorem: records, KMS/modular structure, or
+matter-action dynamics that select both the signed/Hermitian readout and the
+`r = 1/2` modulus. Such a theorem is a permitted result rather than a
+requirement on this packet: per
+`FLAVOR_R_HALF_IS_A_STATIONARY_POINT_NOT_FORCED_2026-06-02.md`, the special
+values of `r` are distinguished points of one family, carrying different
+sectors, not one value the framework must select. A theorem selecting the
 dimension/trace reading instead would point the packet to `r = 1`/`Q = 1`, not
 to the charged-lepton Koide value.

--- a/docs/KOIDE_Q_DELTA_LINKING_RELATION_THEOREM_NOTE_2026-04-20.md
+++ b/docs/KOIDE_Q_DELTA_LINKING_RELATION_THEOREM_NOTE_2026-04-20.md
@@ -151,9 +151,11 @@ retained parent with independent content. This section takes the second
 route. The first route is not attempted here: under the framework's measure
 discipline the block-weight setting that makes the spectral ratio equal
 `2/3` is a registered per-sector pattern (a dial setting, alongside the
-other sectors' settings), so a derivation forcing it would overreach; any
-future derivation of the registered pattern itself would arrive through new
-record-side science, not through this formal row.
+other sectors' settings), so forcing it from the premises available in this
+row would overreach. That scoping is about this row, not about the setting:
+a future derivation of the registered pattern itself is not excluded here,
+and would arrive through new record-side science rather than through this
+formal row.
 
 ### Cited parent authority (one hop)
 


### PR DESCRIPTION
## What this responds to

Owner directive, 2026-07-17:

> r=1/2 is not prohibited, just we shouldnt assume we have to force it / if the repo says otherwise its wrong / we can force it if we find a path but its not necessarly our objective

A sweep of the r=1/2 note family classified its language four ways: (A) blanket prohibition on forcing, (B) route-local scoping, (C) universal-forcing falsification, (D) objective-framing that makes a selector a program requirement. (B) and (C) are correct as written and are left alone — (C) in particular is physics, since quarks register Q ~ 0.85/0.73 and neutrinos Q ~ 1/3, so *universal* forcing really is falsified. (A) and (D) are the two defects. This PR repairs one of each.

## Changes

**`docs/KOIDE_Q_DELTA_LINKING_RELATION_THEOREM_NOTE_2026-04-20.md`** — kind (A). The decoration-attachment section explained why it does not attempt the derive-from-retained-premises route, and ended with *"so a derivation forcing it would overreach"*. The bare indefinite subject makes that a standing claim about any forcing derivation rather than about this row's premises. Rewritten to scope the overreach to this row and to state that a future derivation of the registered pattern is not excluded.

**`docs/FLAVOR_TRACE_VS_CENTER_DISSOLVES_NOTE_2026-05-30.md`** — kind (D), two spots. The modulus-selector residual asked *"why `r = 1/2` should be selected"*, presupposing that it is; now *"whether and how"*. The Next Useful Path section called a native selector theorem *"the highest-value closure route"* that records/KMS/matter-action dynamics *"would need to select"* — ranking the selector as the program's top objective and framing it as a requirement. Now one open route, a permitted result rather than a requirement, referencing the landed stationary-point framing.

## Cost

Zero. Both rows are `unaudited` with no retained descendants, so re-opening their audits via the note_hash mechanism costs nothing. `FLAVOR_TRACE_VS_CENTER` has no runner references at all. Three runners reference the KOIDE note; a grep for every phrase in the edited sentences (`repair routes`, `second route`, `spectral ratio equal`, `record-side science`, `would overreach`, `dial setting`) returns zero hits in all three, and all three were re-run:

| runner | result |
|---|---|
| `frontier_koide_q_delta_formal_ratio_repair.py` | `TOTAL: PASS=159 FAIL=0` |
| `frontier_koide_q_delta_linking_relation.py` | `SUMMARY: PASS = 15 FAIL = 0` |
| `frontier_koide_q_delta_linking_relation_theorem_note_2026-04-20_hostile_audit_findings.py` | `1 PASS / 1 FAIL` |

The third one's FAIL is **pre-existing and unrelated**: it expects the note to cite `scalar_selector_remaining_open_imports_2026-04-20`, which the 2026-05-25 formal-ratio repair withdrew from the binding claim. Running that runner against a clean `origin/main` checkout produces byte-identical output. Reported rather than repaired — a stale runner expectation is its own unit, and rewriting a gate to go green here would be exactly the wrong move.

## Dependency graph

Unchanged. The stationary-point note is referenced in **backticks**, never as a markdown link, so `build_citation_graph.py`'s `LINK_RE` produces no new edge. Verified programmatically: the extracted link inventory of both files is identical before and after.

## Scope

N5 rhetoric alignment only. No claim, theorem, numeric, runner, or cache changes. The two notes are independent of each other and can be split if the reviewer prefers one note per PR; they are batched because they are the same defect class under the same directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)