### PR TITLE
feat(oh-schur): derive the boundary source independently of the target trace

### DIFF
--- a/docs/OH_SCHUR_INDEPENDENT_BOUNDARY_SOURCE_BRIDGE_THEOREM_NOTE_2026-07-25.md
+++ b/docs/OH_SCHUR_INDEPENDENT_BOUNDARY_SOURCE_BRIDGE_THEOREM_NOTE_2026-07-25.md
@@ -1,0 +1,221 @@
+# Independent boundary source from the microscopic source: the Schur bridge theorem
+
+**Date:** 2026-07-25
+**Runner:** `scripts/frontier_oh_schur_independent_boundary_source_bridge.py`
+
+## Purpose
+
+Given a source `rho` on the zero-Dirichlet interior grid of a `size`-cubed box with 6-NN
+negative Laplacian `H_0`, this note constructs a shell-boundary source
+`j_micro = j_micro(rho, H_0)` from the microscopic source and the lattice operator alone,
+and shows that the shell trace of the microscopically sourced field is the unique
+stationary point of a quadratic boundary action driven by it. The construction takes
+`rho` as its only field input: it does not read the target trace, does not build a
+harmonic extension of it, and is not assembled from the object it predicts. The trace it
+yields is therefore compared against one from a separate factorisation and solve of the
+same full lattice system: for four independently prescribed sources at three box sizes,
+and for two exactly specified field classes built by
+`scripts/frontier_same_source_metric_ansatz_scan.py` and
+`scripts/frontier_coarse_grained_exterior_law.py` at size 15.
+
+## Setup
+
+Let `H_0, interior = build_neg_laplacian_sparse(size)` be the 6-NN negative Laplacian on
+the `interior = size - 2` cubed grid of sites strictly inside the box, `n = interior^3`,
+with zero Dirichlet data on the outer faces. Fix `R = 4` and partition the `n` sites
+using the exterior classification of `scripts/frontier_discrete_dtn_shell_kernel.py`:
+`b` = exterior sites (radius `> R`) all six of whose neighbours are also exterior;
+`t` = exterior sites with at least one non-exterior neighbour, the shell; `I` =
+everything else, the strictly interior region (radius `<= R`).
+
+**Separation lemma.** No site of `I` is 6-NN adjacent to a site of `b`: if a `b` site had
+a neighbour in `I`, that neighbour would be non-exterior, so the site would have been
+classified into `t`. Hence `H_Ib = 0` and `H_bI = 0` exactly, as an absence of stored
+matrix entries rather than to rounding. The runner verifies this instead of assuming it,
+and verifies `H_tI`, `H_tb` non-empty, so neither elimination is vacuous. Over `(I, t, b)`:
+
+```
+H_0 = [[H_II, H_It, 0   ],
+       [H_tI, H_tt, H_tb],
+       [0,    H_bt, H_bb]]
+```
+
+## Theorem (two-sided trace equation)
+
+Let `phi` solve `H_0 phi = rho` and write `f := phi_t`. Eliminating `phi_I` via row `I`
+and `phi_b` via row `b`, then substituting both into row `t`, gives the exact identity
+
+```
+S f      =  j_micro
+S       :=  H_tt - H_tI H_II^{-1} H_It - H_tb H_bb^{-1} H_bt
+j_micro :=  rho_t - H_tI H_II^{-1} rho_I - H_tb H_bb^{-1} rho_b
+```
+
+`H_II` and `H_bb` are principal submatrices of the symmetric positive definite `H_0`, so
+both are invertible and `S`, the two-sided Schur complement of `H_0` onto `t`, is itself
+symmetric positive definite. The right-hand side is a functional of `rho` and `H_0` only.
+
+## Corollary (honest stationarity)
+
+Because `S` is symmetric positive definite, `f` is the unique minimiser of
+`I_R(g ; j_micro) = (1/2) g^T S g - j_micro^T g`, whose gradient is
+`grad I_R(g) = S g - j_micro`, so `grad I_R(f) = 0`. The gradient identity carries content
+here: the source on the right was assembled without consulting `f`, so its vanishing at
+`f` is a statement checkable against an independent solve. It is sensitive to `j_micro`
+termwise -- `S` is invertible, so any change to `j_micro` moves the minimiser, and rows
+5a-5c exhibit that for each of its three terms. It is **not** sensitive to `S` entrywise:
+`S f = j_micro` constrains `S` only on the ray through `f`, so `S + eps w w^T` with `w`
+orthogonal to `f` reproduces `f` exactly, and stays symmetric positive definite, at any
+`eps`. Measured at size 13 on the random-in-`I` source, `eps = 1e+04` leaves the
+reconstruction error at `8.7e-15` while moving `S` by `1.5e+02` in largest absolute entry.
+What pins `S` here is the derivation and rows 2-3, not the reconstruction gate.
+
+## Relation to the exterior-only operator
+
+The exterior-only Schur complement is `Lambda_R = H_tt - H_tb H_bb^{-1} H_bt`, so
+`S = Lambda_R - H_tI H_II^{-1} H_It`: the stationarity operator for a microscopically
+sourced configuration carries an extra interior Schur term, and on this family that term
+is not small. The largest absolute entry of `H_tI H_II^{-1} H_It` is `6.188088e-01`
+against an `H_tt` diagonal of `6`; the runner reports this quantity, under the
+max-absolute-entry convention its legend states, and an off-line computation puts the
+induced infinity norm of the same matrix at `3.000000e+00`, half that diagonal. Both are
+identical at all three sizes because the inner region and its adjacent shell layer do not
+change with the box. Pairing `j_micro` with `Lambda_R` misses the true trace by `2.4e-01`
+to `5.1e-01` relative on the four prescribed sources, and by `7.2e-01` on both exact
+classes, so the independent source must be paired with `S` unless the interior Schur term
+annihilates the configuration at hand.
+
+## Why the previous construction's gradient equation was an identity
+
+The earlier note `OH_SCHUR_BOUNDARY_ACTION_NOTE.md`, implemented in
+`scripts/frontier_oh_schur_boundary_action.py`, pairs `Lambda_R` with a source obtained
+by taking the target trace `f`, forming the harmonic extension `u_f` of that same `f`
+into the exterior bulk, and reading the trace flux `(H_0 u_f)|_t`. For such an extension,
+with the strictly interior region held at zero,
+`(H_0 u_g)|_t = H_tt g - H_tb H_bb^{-1} H_bt g = Lambda_R g` identically, for *any* trace
+vector `g`, physical or not. The runner exhibits this with a random `g`: the residual is
+`8.9e-15` at size 13 and comparable at 15 and 17, against `||Lambda_R g||_inf` about
+`1.8e+01`. A residual that vanishes for an arbitrary trace vector cannot distinguish the
+physical trace from any other, so that gradient equation was an algebraic identity of the
+construction rather than a stationarity result. The two sources also differ as objects.
+Their difference is exactly the interior Schur term applied to the trace,
+`j_taut(f) - j_micro = H_tI H_II^{-1} H_It f`, verified off-line to `1.0e-15` against a
+`||j_micro||_inf` of order `1e+00`; rows 7b-7d therefore measure the relative size of that
+term, and no gate here can detect a source reconstructed from the trace — that property
+is established by inspecting which arguments the construction reads, not by a number.
+Relative to `j_micro` the difference runs `1.9e-01` to `5.8e-01` on the four prescribed
+sources and about `2.8e+00` on both exact classes, the latter because those classes are
+sourced strictly inside `I` (below).
+
+## Numerical verification
+
+Seed `20260725`, `cutoff_radius = 4.0`, sizes `13, 15, 17`, runtime about 4 s. Site counts
+`(|I|, |t|, |b|)` are `(257, 782, 292)`, `(257, 1052, 888)`, `(257, 1364, 1754)`.
+
+| # | Check | size 13 | size 15 | size 17 |
+|---|-------|---------|---------|---------|
+| 1 | `nnz(H_Ib)`, `nnz(H_bI)`; block sum vs `n`; `t_box` | `0`, `0`; `1331`=`1331`; `602` | `0`, `0`; `2197`=`2197`; `866` | `0`, `0`; `3375`=`3375`; `1178` |
+| 2 | `\|\|S - S^T\|\|_inf` ; `lambda_min(S)` | `4.440892e-16` ; `6.049261875e-01` | `4.440892e-16` ; `5.507655684e-01` | `5.551115e-16` ; `5.118567811e-01` |
+| 3 | `\|\|S - (Lambda_R - H_tI H_II^-1 H_It)\|\|_inf` ; `\|\|S - S_joint\|\|_inf` | `0.000000e+00` ; `8.881784e-16` | `8.881784e-16` ; `8.881784e-16` | `8.881784e-16` ; `8.881784e-16` |
+| 4a | reconstruction rel. error, point source at centre | `1.107992e-14` | `1.396884e-14` | `1.113781e-14` |
+| 4b | reconstruction rel. error, random source in `I` | `6.409667e-15` | `9.426632e-15` | `7.600553e-15` |
+| 4c | reconstruction rel. error, random source in `b` | `3.470925e-15` | `5.767796e-15` | `6.530465e-15` |
+| 4d | reconstruction rel. error, random source on `I`,`t`,`b` | `3.954689e-15` | `6.854863e-15` | `7.043622e-15` |
+| 4e | reconstruction rel. error, exact local `O_h` class (`xchk` `1.454791e-15`) | — | `1.280216e-14` | — |
+| 4f | reconstruction rel. error, exact finite-rank class (`xchk` `1.224906e-15`) | — | `1.378019e-14` | — |
+| 5a | rejector: drop `-H_tb H_bb^-1 rho_b` | `4.175394e-01` | `5.717319e-01` | `5.032162e-01` |
+| 5b | rejector: drop `-H_tI H_II^-1 rho_I` | `2.661020e-01` | `2.472237e-01` | `3.123370e-01` |
+| 5c | rejector: drop `rho_t` | `1.013921e+00` | `6.526345e-01` | `7.329871e-01` |
+| 6a | rejector: `Lambda_R^-1 j_micro` vs true trace | `2.387521e-01` | `5.113928e-01` | `3.528884e-01` |
+| 6b | same, exact local `O_h` class | — | `7.180982e-01` | — |
+| 6c | same, exact finite-rank class | — | `7.151571e-01` | — |
+| 7a | `\|\|Lambda_R g - (H_0 u_g)\|_t\|\|_inf`, random `g` | `8.881784e-15` | `7.105427e-15` | `8.881784e-15` |
+| 7b | rel. `\|\|j_taut(f) - j_micro\|\|_inf` | `1.901801e-01` | `5.832805e-01` | `3.987182e-01` |
+| 7c | same, exact local `O_h` class | — | `2.765731e+00` | — |
+| 7d | same, exact finite-rank class | — | `2.754925e+00` | — |
+| 8a | perturbed source: prediction vs full solve | `3.827607e-15` | `6.339742e-15` | `6.150760e-15` |
+| 8b | perturbed source: rel. motion of the trace | `5.776783e-04` | `4.167462e-04` | `4.542326e-04` |
+
+Gate directions: row 1 requires the two cross blocks to be empty and both eliminations
+non-vacuous; row 2 requires `||S - S^T||_inf` below `1e-9` and `lambda_min(S)` strictly
+positive; rows 3, 4a–4f, 7a and 8a require small numbers (tolerance `1e-9`); rows 5a–5c,
+6a–6c, 7b–7d and 8b require *large* ones (`> 1e-3` for the rejectors, `> 1e-6` for the
+motion row), so the reconstruction gate cannot pass vacuously. Full run:
+`TOTAL: PASS=51 FAIL=0` over 21 named gates — fifteen at each of the three sizes, six at
+size 15 only. The runner prints each gate statement once, with its tolerance, under a
+`GATES` legend preceded by a preamble factoring out the shared definitions. That legend
+is ordered by the gates' insertion order rather than by row label, so the six
+size-15-only gates are listed after `8b` instead of beside their numeric siblings; each
+states "size 15 only" in its own text. One numeric line per gate per size follows.
+
+Row 3 reports two comparisons that are not of equal standing. `split` compares two
+spellings of the same elimination through the same factorisation; it is bit-exactly
+`0.000000e+00` at size 13 and is solver agreement, not an independent route. `joint`
+compares the two-term split against a single Schur complement of `H_0` onto `t` over
+`X = I ∪ b` from one factorisation of `H_XX`; that agreement is the numerical content of
+the separation lemma.
+
+An off-line probe, not gated by the runner, bounds how sharply row 4 discriminates.
+Scaling one diagonal entry of `S` by `1 + 1e-6`, swept over all `782` entries at size 13
+on the random-in-`I` source, raises the row-4 error to a median of `7.0e-08`, the sweep
+spanning `7.6e-10` to `1.2e-06`. Three of the `782` entries stay below the `1e-9`
+tolerance, so the gate discriminates against a diagonal perturbation of this size at
+`779` of `782` entries rather than at all of them. `j_micro` is itself nonzero at only
+`186` of the `782` shell sites for these sources, so a probe perturbing an entry of
+`j_micro` relative to its own magnitude is undefined on the remaining `596`.
+
+**What the two exact classes do and do not exercise.** Both classes are sourced strictly
+inside `I`: the runner reports `rho_t` and `rho_b` at the `1e-16` level in rows 4e and 4f,
+against a `rho_I` of order `1e+00`. That pair of numbers, not the `xchk` self-guard, is
+what ties each class's field to this operator's site indexing — `xchk` re-solves
+`H_0 x = rho` for the same `rho` the class produced and would return the same vector under
+any flattening convention, so it guards the factorisation and the provenance of `f_true`,
+not the ordering. Even that discriminator is degenerate against one specific confusion:
+both classes are `O_h`-symmetric, so C-order and Fortran-order flattening produce the
+identical vector and the two conventions cannot be told apart here — harmlessly, since
+they agree. On these classes `j_micro` reduces to its single interior term
+`-H_tI H_II^{-1} rho_I`; the `rho_t` and `-H_tb H_bb^{-1} rho_b` terms sit at roundoff
+rather than merely being small. Two consequences, stated rather than hidden. First, the
+two classes test the interior elimination channel only; the full three-term structure of
+`j_micro` is exercised by rows 4a–4d and 5a–5c, whose sources are supported on `I`, on
+`b`, and across all three blocks. Second, a 5a- or 5c-style rejector applied to these
+classes would be vacuous by construction: dropping a term already at roundoff leaves
+`j_micro` unchanged to that order, so such a rejector would return the row-4e/4f error
+itself, of order `1e-14` and far below the `1e-3` floor a rejector must clear. That is why
+rows 5a–5c are not extended to them. The rejector that would move here is the 5b form,
+dropping the interior term, which collapses `j_micro` to roundoff and drives the error to
+`1` — a statement about the classes, not a discriminating test of the theorem.
+
+## What this does not yet supply
+
+1. The box is finite with zero Dirichlet data on its outer faces, so no continuum or
+   infinite-volume limit is addressed. The shell set `t` also contains the outermost
+   interior layer of the box, and that layer is the majority of `t`: `602` of `782` sites
+   at size 13 (`76.98%`), `866` of `1052` (`82.32%`) at size 15, `1178` of `1364`
+   (`86.36%`) at size 17. The fraction grows with the box, so `t` is dominated by box
+   artefact rather than by shell, increasingly so at larger sizes. The runner reports this
+   count as `t_box` in row 1.
+2. `rho` is given data. Nothing here derives it from a variational principle for the
+   matter sector, so the boundary source is independent of the trace but still downstream
+   of an unmodelled source.
+3. The field is a single scalar on a cubic lattice; no tensorial or metric structure is
+   carried. Three box sizes at one cutoff radius are covered, with no scaling law in `R`
+   or `size` for `S` or for the interior Schur term.
+
+## What this opens next
+
+- **Infinite volume.** Enlarge the box at fixed `R` and track `S`, `Lambda_R` and their
+  difference. The interior Schur term is already size-stable at `6.188088e-01` in largest
+  absolute entry and `3.000000e+00` in induced infinity norm, so the correction plausibly
+  has a box-independent limit worth isolating. Isolating it means first separating the
+  shell proper from the outermost box layer that currently dominates `t` — a partition
+  reporting the two subsets separately is the next path this opens.
+- **A derived matter source.** Couple `j_micro` to a `rho` produced by a variational
+  matter sector rather than prescribed, making the chain from action to shell trace
+  derived on the source side too; the axiom surface is
+  [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+- **The tensorial lift.** Repeat the three-block elimination for a multi-component field,
+  where `H_II` and `H_bb` acquire internal indices, and ask whether the separation lemma
+  and the positive definiteness of `S` survive.
+- **Cutoff dependence.** Vary `R` and measure how the interior Schur term and the rejector
+  margins move, separating shell placement from operator.

--- a/logs/runner-cache/frontier_oh_schur_independent_boundary_source_bridge.txt
+++ b/logs/runner-cache/frontier_oh_schur_independent_boundary_source_bridge.txt
@@ -1,0 +1,103 @@
+===== runner cache v1 =====
+runner: scripts/frontier_oh_schur_independent_boundary_source_bridge.py
+runner_sha256: 0ddedcfb7ec3404892c07cf4c4a7281bf4051fd94fabcd66219a9aadb9b0a024
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 2.70
+status: ok
+----- stdout -----
+Independent boundary source from the microscopic source: Schur bridge theorem
+seed=20260725  sizes=(13, 15, 17)  cutoff_radius=4.0
+
+LEGEND  err = rel ||x - x_ref||_inf / ||x_ref||_inf; x = S^-1 j_micro(rho) and x_ref =
+f_true in 4a-4f, f_inf = ||f_true||_inf. ||.||_inf of a matrix = max |entry|, not the
+induced norm. Below tolerance: 2, 3, 4a-4f, 7a, 8a -- exact algebraic identities of the
+three-block elimination, gating the implementation, not the physics. Above a floor:
+5a-5c, 6a-6c, 7b-7d, 8b -- these with gate 1 carry the contingent content. No gate can
+detect a j reconstructed from the target trace, since j_micro = S f_true identically;
+trace-independence is a property of which arguments the construction reads
+(independent_boundary_source takes rho and the operator blocks, never a trace),
+established by inspection of the source, not by a number.
+GATES (once per size unless the gate text says otherwise)
+    1  separation lemma: nnz(H_Ib)=nnz(H_bI)=0, blocks disjoint and summing to n, both eliminations non-vacuous (nnz(H_tI)>0, nnz(H_tb)>0). t_box = sites of t on the box's outermost interior layer, box artefact not shell
+    2  S is SPD: sym = ||S - S^T||_inf < 1e-09, lambda_min(S) > 0
+    3  joint = ||S - S_joint||_inf < 1e-09 IS the separation lemma's numerical content (S_joint: one Schur complement onto t over I u b). split = ||S - (Lambda_R - interior)||_inf < 1e-09 is one elimination spelled two ways, not an independent route. interior = ||H_tI H_II^-1 H_It||_inf, gap = ||S - Lambda_R||_inf
+   4a  reconstruction from rho alone, point source at centre: err < 1e-09
+   4b  same, random source in I: err < 1e-09
+   4c  same, random source in b: err < 1e-09
+   4d  same, random source on I, t, b: err < 1e-09
+   5a  rejector, drop the -H_tb H_bb^-1 rho_b term: err > 1e-03
+   5b  same, drop the -H_tI H_II^-1 rho_I term: err > 1e-03
+   5c  same, drop the rho_t term: err > 1e-03
+   6a  rejector, Lambda_R alone is not the stationarity operator: err of Lambda_R^-1 j_micro > 1e-03
+   7a  TAUTOLOGY EXHIBIT (deliberate): resid = ||Lambda_R g - (H_0 u_g)|_t||_inf < 1e-09 for an ARBITRARY trace g (scale = ||Lambda_R g||_inf); it vanishes for any g, so it fixes no trace
+   7b  j_taut(f_true) - j_micro = H_tI H_II^-1 H_It f_true exactly, so rel = that difference / ||j_micro||_inf measures the interior Schur term's relative size; rel > 1e-03
+   8a  rho perturbed inside I: err of the new prediction < 1e-09
+   8b  the perturbation moved f_pred: moved = err of f_pred' vs f_pred > 1e-06
+   4e  stationarity rerun on the exact local O_h class, size 15 only: err < 1e-09 vs f_true = phi|_t from the class, self-guard xchk < 1e-09 (full solve of rho = H_0 phi)
+   4f  same on the exact finite-rank class, size 15 only: err < 1e-09, xchk < 1e-09
+   6b  same on the exact local O_h class, size 15 only: err > 1e-03
+   6c  same on the exact finite-rank class, size 15 only: err > 1e-03
+   7c  same on the exact local O_h class, size 15 only: rel > 1e-03
+   7d  same on the exact finite-rank class, size 15 only: rel > 1e-03
+
+RESULTS
+  size=13
+     1  ok   nnz_Ib=0 nnz_bI=0 |I|=257 |t|=782 |b|=292 sum=1331 n=1331 disjoint=True nnz_tI=294 nnz_tb=648 t_box=602
+     2  ok   sym=4.440892e-16 lambda_min=6.049261875e-01
+     3  ok   split=0.000000e+00 joint=8.881784e-16 interior=6.188088e-01 gap=6.188088e-01
+    4a  ok   err=1.107992e-14 f_inf=7.671668e-03
+    4b  ok   err=6.409667e-15 f_inf=3.810636e-01
+    4c  ok   err=3.470925e-15 f_inf=3.198638e-01
+    4d  ok   err=3.954689e-15 f_inf=8.702811e-01
+    5a  ok   err=4.175394e-01
+    5b  ok   err=2.661020e-01
+    5c  ok   err=1.013921e+00
+    6a  ok   err=2.387521e-01
+    7a  ok   resid=8.881784e-15 scale=1.827391e+01
+    7b  ok   rel=1.901801e-01
+    8a  ok   err=3.827607e-15
+    8b  ok   moved=5.776783e-04
+  size=15
+     1  ok   nnz_Ib=0 nnz_bI=0 |I|=257 |t|=1052 |b|=888 sum=2197 n=2197 disjoint=True nnz_tI=294 nnz_tb=1152 t_box=866
+     2  ok   sym=4.440892e-16 lambda_min=5.507655684e-01
+     3  ok   split=8.881784e-16 joint=8.881784e-16 interior=6.188088e-01 gap=6.188088e-01
+    4a  ok   err=1.396884e-14 f_inf=9.438078e-03
+    4b  ok   err=9.426632e-15 f_inf=4.122130e-01
+    4c  ok   err=5.767796e-15 f_inf=5.485866e-01
+    4d  ok   err=6.854863e-15 f_inf=1.295691e+00
+    4e  ok   err=1.280216e-14 xchk=1.454791e-15 rho_t=1.075529e-16 rho_b=7.979728e-17 f_inf=2.384842e-02
+    4f  ok   err=1.378019e-14 xchk=1.224906e-15 rho_t=3.053113e-16 rho_b=2.081668e-16 f_inf=9.063740e-02
+    5a  ok   err=5.717319e-01
+    5b  ok   err=2.472237e-01
+    5c  ok   err=6.526345e-01
+    6a  ok   err=5.113928e-01
+    6b  ok   err=7.180982e-01
+    6c  ok   err=7.151571e-01
+    7a  ok   resid=7.105427e-15 scale=1.788311e+01
+    7b  ok   rel=5.832805e-01
+    7c  ok   rel=2.765731e+00
+    7d  ok   rel=2.754925e+00
+    8a  ok   err=6.339742e-15
+    8b  ok   moved=4.167462e-04
+  size=17
+     1  ok   nnz_Ib=0 nnz_bI=0 |I|=257 |t|=1364 |b|=1754 sum=3375 n=3375 disjoint=True nnz_tI=294 nnz_tb=1452 t_box=1178
+     2  ok   sym=5.551115e-16 lambda_min=5.118567811e-01
+     3  ok   split=8.881784e-16 joint=8.881784e-16 interior=6.188088e-01 gap=6.188088e-01
+    4a  ok   err=1.113781e-14 f_inf=1.074681e-02
+    4b  ok   err=7.600553e-15 f_inf=4.309105e-01
+    4c  ok   err=6.530465e-15 f_inf=4.845192e-01
+    4d  ok   err=7.043622e-15 f_inf=1.245206e+00
+    5a  ok   err=5.032162e-01
+    5b  ok   err=3.123370e-01
+    5c  ok   err=7.329871e-01
+    6a  ok   err=3.528884e-01
+    7a  ok   resid=8.881784e-15 scale=1.845706e+01
+    7b  ok   rel=3.987182e-01
+    8a  ok   err=6.150760e-15
+    8b  ok   moved=4.542326e-04
+
+TOTAL: PASS=51 FAIL=0
+
+----- stderr -----
+

--- a/scripts/frontier_oh_schur_independent_boundary_source_bridge.py
+++ b/scripts/frontier_oh_schur_independent_boundary_source_bridge.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+"""Independent boundary source from the microscopic source: the Schur bridge theorem.
+
+What this runner establishes, on the zero-Dirichlet interior grid of a size-cubed
+box with 6-NN negative Laplacian H_0:
+
+  1. The three-block partition (I, t, b) of the interior sites -- strictly interior
+     region I, shell trace t, exterior bulk b -- satisfies H_Ib = 0 exactly, because
+     any exterior site adjacent to a non-exterior site is classified into t. This is
+     verified numerically, not assumed.
+
+  2. For an arbitrary microscopic source rho, the field phi solving H_0 phi = rho has
+     its shell trace f = phi_t determined by the exact two-sided trace equation
+
+         S f = j_micro
+         S       = H_tt - H_tI H_II^{-1} H_It - H_tb H_bb^{-1} H_bt
+         j_micro = rho_t - H_tI H_II^{-1} rho_I - H_tb H_bb^{-1} rho_b
+
+     where j_micro is a functional of rho and the lattice operator alone. It never
+     references f, never references a harmonic extension, and is never reconstructed
+     from the target trace.
+
+  3. S is symmetric positive definite, so f is the unique minimiser of
+         I_R(g ; j_micro) = 1/2 g^T S g - j_micro^T g
+     and grad I_R(f) = S f - j_micro = 0 carries predictive content.
+
+  4. S = Lambda_R - H_tI H_II^{-1} H_It, where Lambda_R = H_tt - H_tb H_bb^{-1} H_bt
+     is the exterior-only Schur complement. The interior Schur term is not negligible
+     on this family, and pairing j_micro with Lambda_R alone fails to reproduce f.
+
+  5. Exhibit: pairing Lambda_R with a source built as the trace flux of the harmonic
+     extension of a trace vector g reproduces Lambda_R g identically for an ARBITRARY
+     g, so the associated gradient residual vanishes for any trace whatsoever and
+     therefore encodes no stationarity information about the physical configuration.
+
+  6. Stationarity is rerun on the two source classes named by the audited row -- the
+     exact local O_h class and the exact finite-rank class -- at size 15, the only
+     size at which those builders are defined. Each class supplies its own field phi;
+     rho = H_0 phi is then the microscopic source of that field, j_micro is built from
+     that rho alone, and S^-1 j_micro is compared against phi|_t taken from the class.
+
+The gates below are of two kinds. The rejectors are designed to fail if the implemented
+object were wrong; the below-tolerance gates are exact algebraic identities of the
+three-block elimination and therefore gate the implementation rather than the physics.
+The reference trace f_true comes from a separate splu factorisation and solve of the
+same H_0 -- a second elimination of the same discretisation, not a second
+discretisation. No gate here can detect a j reconstructed from the target trace, since
+j_micro = S f_true identically; trace-independence is a property of which arguments the
+construction reads -- independent_boundary_source takes rho and the operator blocks,
+never a trace -- and is established by inspection of the source, not by a number.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+from dataclasses import dataclass
+
+from _frontier_loader import load_frontier
+
+import numpy as np
+import scipy.sparse as sparse
+from scipy.sparse.linalg import spsolve, splu
+
+
+SEED = 20260725
+SIZES = (13, 15, 17)
+CUTOFF_RADIUS = 4.0
+CLASS_SIZE = 15
+
+RECON_TOL = 1e-9
+REJECT_TOL = 1e-3
+MOVE_TOL = 1e-6
+
+
+@dataclass
+class Check:
+    size: int
+    gid: str
+    ok: bool
+    detail: str
+
+
+CHECKS: list[Check] = []
+# gid -> gate statement, including the quantity measured and the tolerance it must meet.
+# Printed once as a legend; per-size lines then carry only the measured numbers, which
+# keeps the whole report inside the audit packet's cached-stdout excerpt window.
+GATES: dict[str, str] = {}
+_CURRENT_SIZE = 0
+
+
+def record(gid: str, gate: str, ok: bool, detail: str) -> None:
+    GATES.setdefault(gid, gate)
+    CHECKS.append(Check(size=_CURRENT_SIZE, gid=gid, ok=ok, detail=detail))
+
+
+finite_rank = load_frontier("finite_rank_metric", "frontier_finite_rank_gravity_residual.py")
+dtn = load_frontier("dtn_shell", "frontier_discrete_dtn_shell_kernel.py")
+# The two source classes named by the row this runner supports. Their modules may print
+# at import; only the import is silenced, and exceptions still propagate.
+with contextlib.redirect_stdout(io.StringIO()):
+    same_source = load_frontier("same_source_metric", "frontier_same_source_metric_ansatz_scan.py")
+    coarse = load_frontier("coarse_grained", "frontier_coarse_grained_exterior_law.py")
+
+
+def rel_inf(a: np.ndarray, b: np.ndarray) -> float:
+    """Relative inf-norm distance of a from b."""
+    denom = float(np.max(np.abs(b)))
+    if denom == 0.0:
+        return float(np.max(np.abs(a - b)))
+    return float(np.max(np.abs(a - b))) / denom
+
+
+@dataclass
+class Blocks:
+    """Operator-only data. Deliberately contains no field, trace or solution."""
+
+    size: int
+    interior: int
+    n: int
+    H0: sparse.csr_matrix
+    idx_I: np.ndarray
+    idx_t: np.ndarray
+    idx_b: np.ndarray
+    H_tt: np.ndarray
+    H_tI: np.ndarray
+    H_It: np.ndarray
+    H_tb: np.ndarray
+    H_bt: np.ndarray
+    lu_II: object
+    lu_bb: object
+    lu_H0: object
+    S: np.ndarray
+    S_joint: np.ndarray
+    Lambda_R: np.ndarray
+
+
+def build_blocks(size: int, cutoff_radius: float) -> Blocks:
+    trace_idx, bulk_idx = dtn.exterior_sets(size, cutoff_radius)
+    H0, interior = finite_rank.build_neg_laplacian_sparse(size)
+    n = interior ** 3
+    idx_I = np.setdiff1d(np.arange(n), np.concatenate([trace_idx, bulk_idx]))
+
+    H_tt = H0[trace_idx][:, trace_idx].toarray()
+    H_tI = H0[trace_idx][:, idx_I].toarray()
+    H_It = H0[idx_I][:, trace_idx].toarray()
+    H_tb = H0[trace_idx][:, bulk_idx].toarray()
+    H_bt = H0[bulk_idx][:, trace_idx].toarray()
+
+    lu_II = splu(H0[idx_I][:, idx_I].tocsc())
+    lu_bb = splu(H0[bulk_idx][:, bulk_idx].tocsc())
+    lu_H0 = splu(H0.tocsc())
+
+    # Theorem form: two one-sided Schur terms.
+    S = H_tt - H_tI @ lu_II.solve(H_It) - H_tb @ lu_bb.solve(H_bt)
+
+    # One joint Schur complement onto t over X = I union b, from a single factorisation
+    # of H_XX. Its agreement with S is the numerical content of the block decoupling
+    # H_Ib = 0: the two one-sided eliminations only reproduce the joint one when H_Ib
+    # vanishes, so this comparison, unlike the split spelling below, can fail.
+    idx_X = np.concatenate([idx_I, bulk_idx])
+    H_tX = H0[trace_idx][:, idx_X].toarray()
+    H_Xt = H0[idx_X][:, trace_idx].toarray()
+    lu_XX = splu(H0[idx_X][:, idx_X].tocsc())
+    S_joint = H_tt - H_tX @ lu_XX.solve(H_Xt)
+    del H_tX, H_Xt, lu_XX
+
+    # Exterior-only Schur complement, built exactly as
+    # scripts/frontier_oh_schur_boundary_action.py builds it.
+    if bulk_idx.size:
+        X_sparse = spsolve(H0[bulk_idx][:, bulk_idx].tocsc(), H0[bulk_idx][:, trace_idx].tocsc())
+        Lambda_R = np.asarray(H_tt - H_tb @ X_sparse)
+    else:
+        Lambda_R = H_tt.copy()
+
+    return Blocks(
+        size=size,
+        interior=interior,
+        n=n,
+        H0=H0,
+        idx_I=idx_I,
+        idx_t=trace_idx,
+        idx_b=bulk_idx,
+        H_tt=H_tt,
+        H_tI=H_tI,
+        H_It=H_It,
+        H_tb=H_tb,
+        H_bt=H_bt,
+        lu_II=lu_II,
+        lu_bb=lu_bb,
+        lu_H0=lu_H0,
+        S=S,
+        S_joint=S_joint,
+        Lambda_R=Lambda_R,
+    )
+
+
+def independent_boundary_source(rho: np.ndarray, blk: Blocks) -> np.ndarray:
+    """j_micro from the microscopic source alone.
+
+    `rho` is the ONLY field argument. Nothing about the target trace, the solved
+    field, or any harmonic extension enters here.
+    """
+    return (
+        rho[blk.idx_t]
+        - blk.H_tI @ blk.lu_II.solve(rho[blk.idx_I])
+        - blk.H_tb @ blk.lu_bb.solve(rho[blk.idx_b])
+    )
+
+
+def boundary_source_variant(rho: np.ndarray, blk: Blocks, drop: str) -> np.ndarray:
+    """Deliberately incomplete boundary sources, used only by the rejector gates."""
+    term_t = rho[blk.idx_t]
+    term_I = blk.H_tI @ blk.lu_II.solve(rho[blk.idx_I])
+    term_b = blk.H_tb @ blk.lu_bb.solve(rho[blk.idx_b])
+    if drop == "bulk":
+        return term_t - term_I
+    if drop == "interior":
+        return term_t - term_b
+    if drop == "trace":
+        return -term_I - term_b
+    raise ValueError(f"unknown dropped term: {drop}")
+
+
+def true_trace_from_full_solve(rho: np.ndarray, blk: Blocks) -> np.ndarray:
+    """Ground truth: solve the full n-site system and read off the shell trace."""
+    phi = blk.lu_H0.solve(rho)
+    return phi[blk.idx_t]
+
+
+def harmonic_extension_trace_flux(g: np.ndarray, blk: Blocks) -> np.ndarray:
+    """The previous construction, rebuilt directly.
+
+    Extend an arbitrary trace vector `g` harmonically into the exterior bulk,
+    leave the strictly interior region at zero, apply the full lattice operator
+    and read the result on the shell. This is `(H_0 u_g)|_t`.
+    """
+    u = np.zeros(blk.n, dtype=float)
+    u[blk.idx_t] = g
+    if blk.idx_b.size:
+        u[blk.idx_b] = blk.lu_bb.solve(-(blk.H_bt @ g))
+    return (blk.H0 @ u)[blk.idx_t]
+
+
+def build_sources(blk: Blocks) -> dict[str, np.ndarray]:
+    rng = np.random.default_rng(SEED)
+    n = blk.n
+
+    centre = (blk.size - 1) // 2
+    centre_flat = finite_rank.flat_idx(centre - 1, centre - 1, centre - 1, blk.interior)
+    if centre_flat not in set(blk.idx_I.tolist()):
+        raise RuntimeError("grid centre is not in the strictly interior region I")
+
+    point = np.zeros(n, dtype=float)
+    point[centre_flat] = 1.0
+
+    interior_only = np.zeros(n, dtype=float)
+    interior_only[blk.idx_I] = rng.standard_normal(blk.idx_I.size)
+
+    bulk_only = np.zeros(n, dtype=float)
+    bulk_only[blk.idx_b] = rng.standard_normal(blk.idx_b.size)
+
+    mixed = np.zeros(n, dtype=float)
+    mixed[blk.idx_I] = rng.standard_normal(blk.idx_I.size)
+    mixed[blk.idx_t] = rng.standard_normal(blk.idx_t.size)
+    mixed[blk.idx_b] = rng.standard_normal(blk.idx_b.size)
+
+    return {
+        "point source at centre": point,
+        "random source in I": interior_only,
+        "random source in b": bulk_only,
+        "random source on I, t, b": mixed,
+    }
+
+
+def audited_row_source_classes(blk: Blocks) -> dict[str, tuple[np.ndarray, np.ndarray]]:
+    """The two source classes named by the audited row, at their native size 15.
+
+    Returns label -> (rho, f_true_class). The field `phi` is built by the class's own
+    script; `rho := H_0 phi` is therefore the microscopic source of that field, and
+    `f_true_class := phi|_t` is ground truth taken from the class, not from any solve
+    performed here. Empty at sizes other than CLASS_SIZE, where the builders are not
+    defined.
+    """
+    if blk.size != CLASS_SIZE:
+        return {}
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        grids = {
+            "exact local O_h class": same_source.build_best_phi_grid(),
+            "exact finite-rank class": coarse.build_finite_rank_phi_grid(),
+        }
+
+    classes: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+    for label, phi_grid in grids.items():
+        # Exact inverse of how both builders write the grid; the xchk gate verifies it.
+        phi_flat = np.ascontiguousarray(phi_grid[1:-1, 1:-1, 1:-1]).reshape(-1)
+        classes[label] = (blk.H0 @ phi_flat, phi_flat[blk.idx_t])
+    return classes
+
+
+def run_size(size: int) -> None:
+    global _CURRENT_SIZE
+    _CURRENT_SIZE = size
+
+    blk = build_blocks(size, CUTOFF_RADIUS)
+
+    # ---- check 1: separation lemma and partition integrity -------------------
+    nnz_Ib = int(blk.H0[blk.idx_I][:, blk.idx_b].nnz)
+    nnz_bI = int(blk.H0[blk.idx_b][:, blk.idx_I].nnz)
+    nnz_tI = int(np.count_nonzero(blk.H_tI))
+    nnz_tb = int(np.count_nonzero(blk.H_tb))
+    counts_ok = (blk.idx_I.size + blk.idx_t.size + blk.idx_b.size) == blk.n
+    disjoint_ok = (
+        np.intersect1d(blk.idx_I, blk.idx_t).size == 0
+        and np.intersect1d(blk.idx_I, blk.idx_b).size == 0
+        and np.intersect1d(blk.idx_t, blk.idx_b).size == 0
+    )
+    t_coords = np.unravel_index(blk.idx_t, (blk.interior,) * 3)
+    on_box = np.zeros(blk.idx_t.size, dtype=bool)
+    for axis_coord in t_coords:
+        on_box |= (axis_coord == 0) | (axis_coord == blk.interior - 1)
+    t_box = int(np.count_nonzero(on_box))
+    record(
+        "1",
+        "separation lemma: nnz(H_Ib)=nnz(H_bI)=0, blocks disjoint and summing to n, both "
+        "eliminations non-vacuous (nnz(H_tI)>0, nnz(H_tb)>0). t_box = sites of t on the box's "
+        "outermost interior layer, box artefact not shell",
+        nnz_Ib == 0 and nnz_bI == 0 and counts_ok and disjoint_ok and nnz_tI > 0 and nnz_tb > 0,
+        (
+            f"nnz_Ib={nnz_Ib} nnz_bI={nnz_bI} |I|={blk.idx_I.size} |t|={blk.idx_t.size} "
+            f"|b|={blk.idx_b.size} sum={blk.idx_I.size + blk.idx_t.size + blk.idx_b.size} "
+            f"n={blk.n} disjoint={disjoint_ok} nnz_tI={nnz_tI} nnz_tb={nnz_tb} t_box={t_box}"
+        ),
+    )
+
+    # ---- check 2: S is symmetric positive definite ---------------------------
+    sym_err = float(np.max(np.abs(blk.S - blk.S.T)))
+    min_eig = float(np.min(np.linalg.eigvalsh(0.5 * (blk.S + blk.S.T))))
+    record(
+        "2",
+        "S is SPD: sym = ||S - S^T||_inf < 1e-09, lambda_min(S) > 0",
+        sym_err < 1e-9 and min_eig > 0.0,
+        f"sym={sym_err:.6e} lambda_min={min_eig:.9e}",
+    )
+
+    # ---- check 3: separation lemma numerically, plus solver agreement --------
+    # joint carries the separation lemma. split compares two spellings of the same
+    # elimination through the same factorisations, so it is not an independent route.
+    interior_term = blk.H_tI @ blk.lu_II.solve(blk.H_It)
+    split_resid = float(np.max(np.abs(blk.S - (blk.Lambda_R - interior_term))))
+    joint_resid = float(np.max(np.abs(blk.S - blk.S_joint)))
+    interior_mag = float(np.max(np.abs(interior_term)))
+    lambda_gap = float(np.max(np.abs(blk.S - blk.Lambda_R)))
+    record(
+        "3",
+        "joint = ||S - S_joint||_inf < 1e-09 IS the separation lemma's numerical content "
+        "(S_joint: one Schur complement onto t over I u b). split = ||S - (Lambda_R - "
+        "interior)||_inf < 1e-09 is one elimination spelled two ways, not an "
+        "independent route. interior = ||H_tI H_II^-1 H_It||_inf, gap = ||S - Lambda_R||_inf",
+        split_resid < 1e-9 and joint_resid < 1e-9,
+        (
+            f"split={split_resid:.6e} joint={joint_resid:.6e} "
+            f"interior={interior_mag:.6e} gap={lambda_gap:.6e}"
+        ),
+    )
+
+    # ---- check 4: predictive reconstruction ---------------------------------
+    sources = build_sources(blk)
+    f_true_store: dict[str, np.ndarray] = {}
+    f_pred_store: dict[str, np.ndarray] = {}
+    for gid, (label, rho) in zip("abcd", sources.items()):
+        f_true = true_trace_from_full_solve(rho, blk)
+        j_micro = independent_boundary_source(rho, blk)
+        f_pred = np.linalg.solve(blk.S, j_micro)
+        err = rel_inf(f_pred, f_true)
+        f_true_store[label] = f_true
+        f_pred_store[label] = f_pred
+        lead = "reconstruction from rho alone" if gid == "a" else "same"
+        record(
+            f"4{gid}",
+            f"{lead}, {label}: err < {RECON_TOL:.0e}",
+            err < RECON_TOL,
+            f"err={err:.6e} f_inf={float(np.max(np.abs(f_true))):.6e}",
+        )
+
+    # ---- checks 4e/4f: stationarity rerun on the row's own source classes ----
+    # Size CLASS_SIZE only; empty elsewhere, where the class builders are undefined.
+    class_data: list[tuple[str, np.ndarray, np.ndarray]] = []
+    for gid, (label, (rho_c, f_true_c)) in zip("ef", audited_row_source_classes(blk).items()):
+        j_class = independent_boundary_source(rho_c, blk)
+        f_pred_c = np.linalg.solve(blk.S, j_class)
+        err = rel_inf(f_pred_c, f_true_c)
+        xchk = rel_inf(true_trace_from_full_solve(rho_c, blk), f_true_c)
+        rho_t = float(np.max(np.abs(rho_c[blk.idx_t])))
+        rho_b = float(np.max(np.abs(rho_c[blk.idx_b])))
+        class_data.append((label, j_class, f_true_c))
+        gate_e = (
+            f"stationarity rerun on the {label}, size {CLASS_SIZE} only: err < {RECON_TOL:.0e} "
+            f"vs f_true = phi|_t from the class, self-guard xchk < {RECON_TOL:.0e} "
+            "(full solve of rho = H_0 phi)"
+        )
+        gate_f = (
+            f"same on the {label}, size {CLASS_SIZE} only: "
+            f"err < {RECON_TOL:.0e}, xchk < {RECON_TOL:.0e}"
+        )
+        record(
+            f"4{gid}",
+            gate_e if gid == "e" else gate_f,
+            err < RECON_TOL and xchk < RECON_TOL,
+            (
+                f"err={err:.6e} xchk={xchk:.6e} rho_t={rho_t:.6e} rho_b={rho_b:.6e} "
+                f"f_inf={float(np.max(np.abs(f_true_c))):.6e}"
+            ),
+        )
+
+    mixed_label = "random source on I, t, b"
+    rho_mixed = sources[mixed_label]
+    f_true_mixed = f_true_store[mixed_label]
+    f_pred_mixed = f_pred_store[mixed_label]
+    j_micro_mixed = independent_boundary_source(rho_mixed, blk)
+
+    # ---- check 5: dropped-term rejectors ------------------------------------
+    for gid, (drop, human) in zip("abc", (
+        ("bulk", "drop the -H_tb H_bb^-1 rho_b term"),
+        ("interior", "drop the -H_tI H_II^-1 rho_I term"),
+        ("trace", "drop the rho_t term"),
+    )):
+        j_var = boundary_source_variant(rho_mixed, blk, drop)
+        f_var = np.linalg.solve(blk.S, j_var)
+        err = rel_inf(f_var, f_true_mixed)
+        lead_5 = "rejector, " if gid == "a" else "same, "
+        record(
+            f"5{gid}",
+            f"{lead_5}{human}: err > {REJECT_TOL:.0e}",
+            err > REJECT_TOL,
+            f"err={err:.6e}",
+        )
+
+    # ---- check 6: wrong-operator rejector -----------------------------------
+    f_alt = np.linalg.solve(blk.Lambda_R, j_micro_mixed)
+    err_alt = rel_inf(f_alt, f_true_mixed)
+    record(
+        "6a",
+        "rejector, Lambda_R alone is not the stationarity operator: "
+        f"err of Lambda_R^-1 j_micro > {REJECT_TOL:.0e}",
+        err_alt > REJECT_TOL,
+        f"err={err_alt:.6e}",
+    )
+    for gid, (label, j_class, f_true_c) in zip("bc", class_data):
+        err_alt_c = rel_inf(np.linalg.solve(blk.Lambda_R, j_class), f_true_c)
+        record(
+            f"6{gid}",
+            f"same on the {label}, size {CLASS_SIZE} only: err > {REJECT_TOL:.0e}",
+            err_alt_c > REJECT_TOL,
+            f"err={err_alt_c:.6e}",
+        )
+
+    # ---- check 7: tautology exhibit -----------------------------------------
+    rng_taut = np.random.default_rng(SEED + 1)
+    g_random = rng_taut.standard_normal(blk.idx_t.size)
+    j_taut_random = harmonic_extension_trace_flux(g_random, blk)
+    taut_resid = float(np.max(np.abs(blk.Lambda_R @ g_random - j_taut_random)))
+    record(
+        "7a",
+        "TAUTOLOGY EXHIBIT (deliberate): resid = ||Lambda_R g - (H_0 u_g)|_t||_inf < 1e-09 for an "
+        "ARBITRARY trace g (scale = ||Lambda_R g||_inf); it vanishes for any g, so it "
+        "fixes no trace",
+        taut_resid < 1e-9,
+        (
+            f"resid={taut_resid:.6e} "
+            f"scale={float(np.max(np.abs(blk.Lambda_R @ g_random))):.6e}"
+        ),
+    )
+
+    j_taut_phys = harmonic_extension_trace_flux(f_true_mixed, blk)
+    taut_vs_micro = rel_inf(j_taut_phys, j_micro_mixed)
+    record(
+        "7b",
+        "j_taut(f_true) - j_micro = H_tI H_II^-1 H_It f_true exactly, so rel = that difference / "
+        f"||j_micro||_inf measures the interior Schur term's relative size; rel > {REJECT_TOL:.0e}",
+        taut_vs_micro > REJECT_TOL,
+        f"rel={taut_vs_micro:.6e}",
+    )
+    for gid, (label, j_class, f_true_c) in zip("cd", class_data):
+        rel_c = rel_inf(harmonic_extension_trace_flux(f_true_c, blk), j_class)
+        record(
+            f"7{gid}",
+            f"same on the {label}, size {CLASS_SIZE} only: rel > {REJECT_TOL:.0e}",
+            rel_c > REJECT_TOL,
+            f"rel={rel_c:.6e}",
+        )
+
+    # ---- check 8: source-perturbation consistency ---------------------------
+    rng_pert = np.random.default_rng(SEED + 2)
+    delta_rho = np.zeros(blk.n, dtype=float)
+    delta_rho[blk.idx_I] = 1e-3 * rng_pert.standard_normal(blk.idx_I.size)
+    rho_pert = rho_mixed + delta_rho
+
+    j_pert = independent_boundary_source(rho_pert, blk)
+    f_pred_pert = np.linalg.solve(blk.S, j_pert)
+    f_true_pert = true_trace_from_full_solve(rho_pert, blk)
+    err_pert = rel_inf(f_pred_pert, f_true_pert)
+    record(
+        "8a",
+        f"rho perturbed inside I: err of the new prediction < {RECON_TOL:.0e}",
+        err_pert < RECON_TOL,
+        f"err={err_pert:.6e}",
+    )
+
+    moved = rel_inf(f_pred_pert, f_pred_mixed)
+    record(
+        "8b",
+        f"the perturbation moved f_pred: moved = err of f_pred' vs f_pred > {MOVE_TOL:.0e}",
+        moved > MOVE_TOL,
+        f"moved={moved:.6e}",
+    )
+
+
+def main() -> int:
+    print("Independent boundary source from the microscopic source: Schur bridge theorem")
+    print(f"seed={SEED}  sizes={SIZES}  cutoff_radius={CUTOFF_RADIUS}")
+    print()
+
+    for size in SIZES:
+        run_size(size)
+
+    print(
+        "LEGEND  err = rel ||x - x_ref||_inf / ||x_ref||_inf; x = S^-1 j_micro(rho) and x_ref =\n"
+        "f_true in 4a-4f, f_inf = ||f_true||_inf. ||.||_inf of a matrix = max |entry|, not the\n"
+        "induced norm. Below tolerance: 2, 3, 4a-4f, 7a, 8a -- exact algebraic identities of the\n"
+        "three-block elimination, gating the implementation, not the physics. Above a floor:\n"
+        "5a-5c, 6a-6c, 7b-7d, 8b -- these with gate 1 carry the contingent content. No gate can\n"
+        "detect a j reconstructed from the target trace, since j_micro = S f_true identically;\n"
+        "trace-independence is a property of which arguments the construction reads\n"
+        "(independent_boundary_source takes rho and the operator blocks, never a trace),\n"
+        "established by inspection of the source, not by a number.\n"
+        "GATES (once per size unless the gate text says otherwise)"
+    )
+    for gid, gate in GATES.items():
+        print(f"  {gid:>3}  {gate}")
+    print()
+
+    print("RESULTS")
+    for size in SIZES:
+        print(f"  size={size}")
+        for c in CHECKS:
+            if c.size == size:
+                print(f"   {c.gid:>3}  {'ok  ' if c.ok else 'FAIL'} {c.detail}")
+    print()
+
+    n_pass = sum(c.ok for c in CHECKS)
+    n_fail = sum(not c.ok for c in CHECKS)
+    if n_fail:
+        print("FAILING CHECKS")
+        for c in CHECKS:
+            if not c.ok:
+                print(f"  size={c.size} gid={c.gid}")
+                print(f"    gate:   {GATES[c.gid]}")
+                print(f"    result: {c.detail}")
+        print()
+    print(f"TOTAL: PASS={n_pass} FAIL={n_fail}")
+    return 0 if n_fail == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What verdict this responds to

The terminal audit obligation on `oh_schur_boundary_action_note`:

> missing_bridge_theorem: derive the boundary source j independently from the microscopic source/action, then rerun stationarity without reconstructing j from the target trace.

This PR lands the bridge theorem itself. A second PR follows once this lands, adding the parent-side link and the dated downstream-hygiene line that `docs/audit/README.md:348-354` requires of a dependent-side repair.

## What changed

Source-only triple, all three files new:

- `docs/OH_SCHUR_INDEPENDENT_BOUNDARY_SOURCE_BRIDGE_THEOREM_NOTE_2026-07-25.md`
- `scripts/frontier_oh_schur_independent_boundary_source_bridge.py`
- `logs/runner-cache/frontier_oh_schur_independent_boundary_source_bridge.txt`

The interior sites are partitioned into shell `t`, the sites strictly inside it `I`, and the sites strictly outside it `b`. The separation lemma `H_Ib = H_bI = 0` follows from 6-NN adjacency and is gated numerically. Eliminating both `I` and `b` gives

```
j_micro = rho_t - H_tI H_II^-1 rho_I - H_tb H_bb^-1 rho_b
S       = H_tt - H_tI H_II^-1 H_It - H_tb H_bb^-1 H_bt
        = Lambda_R - H_tI H_II^-1 H_It
S f     = j_micro
```

`independent_boundary_source` takes `rho` and the operator blocks and never a trace. Trace-independence is therefore a property of which arguments the construction reads, established by inspection of the source; no gate can detect a source reconstructed from the trace, because `j_micro = S f_true` identically. The runner's legend says exactly this rather than claiming a gate proves it.

## Runner numbers

`TOTAL: PASS=51 FAIL=0`, 21 named gates over box sizes 13/15/17 (fifteen at each size, six at size 15 only), exit 0, empty stderr, byte-identical on repeat runs.

| | check | size 13 | size 15 | size 17 |
|---|---|---|---|---|
| 1 | `nnz(H_Ib)`, `nnz(H_bI)` | 0, 0 | 0, 0 | 0, 0 |
| 2 | `lambda_min(S)` | 6.049262e-01 | 5.507656e-01 | 5.118568e-01 |
| 3 | `joint` = `S` vs single Schur over `I u b` | 8.881784e-16 | 8.881784e-16 | 8.881784e-16 |
| 4a-4d | reconstruction err, prescribed sources | 3.5e-15 .. 1.1e-14 | 5.8e-15 .. 1.4e-14 | 6.5e-15 .. 1.1e-14 |
| 4e-4f | reconstruction err, two exact classes | -- | 1.280216e-14, 1.378019e-14 | -- |
| 5a-5c | rejectors, drop each `j_micro` term | 2.7e-01 .. 1.0e+00 | 2.5e-01 .. 6.5e-01 | 3.1e-01 .. 7.3e-01 |
| 6a-6c | rejectors, `Lambda_R` in place of `S` | 2.387521e-01 | 5.1e-01 .. 7.2e-01 | 3.528884e-01 |
| 7b-7d | rel. interior Schur term | 1.901801e-01 | 5.8e-01 .. 2.8e+00 | 3.987182e-01 |
| 8b | interior perturbation moves `f_pred` | 5.776783e-04 | 4.167462e-04 | 4.542326e-04 |

Row 7a is a labelled tautology exhibit: `||Lambda_R g - (H_0 u_g)|_t||_inf` vanishes for an arbitrary trace `g`, so it fixes no trace. It is printed to show the shape of the identity the previous construction's gradient equation had.

## Limits the note states about itself

- The reconstruction gate is sensitive to `j_micro` termwise but **not** to `S` entrywise: `S f = j_micro` constrains `S` only on the ray through `f`, and `S + eps w w^T` with `w` orthogonal to `f` reproduces `f` exactly at any `eps` (measured: `eps = 1e+04` leaves the error at `8.7e-15` while moving `S` by `1.5e+02`). What pins `S` is the derivation and rows 2-3.
- Row 3's `split` compares two spellings of one elimination through one factorisation; only `joint` is an independent comparison. The note says so rather than counting both.
- The shell set `t` is dominated by the box's outermost interior layer: 602/782 (76.98%), 866/1052 (82.32%), 1178/1364 (86.36%). The fraction grows with the box. Separating shell proper from box artefact is the next path this opens.
- The two exact classes are sourced strictly inside `I` (`rho_t`, `rho_b` at the `1e-16` level against `rho_I` of order `1e+00`), so they exercise the interior elimination channel only; the full three-term structure is exercised by rows 4a-4d and 5a-5c. Both classes are `O_h`-symmetric, so the `xchk` self-guard is an ordering-blind consistency check, not an ordering detector -- the note says this explicitly.

## Downstream order

This PR must land before the follow-up, which links this note from `docs/OH_SCHUR_BOUNDARY_ACTION_NOTE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)