### PR TITLE
fix(gauge-vac): narrow Perron/Jacobi underdetermination to the NMAX=5 box

### DIFF
--- a/docs/GAUGE_VACUUM_PLAQUETTE_PERRON_JACOBI_UNDERDETERMINATION_NOTE.md
+++ b/docs/GAUGE_VACUUM_PLAQUETTE_PERRON_JACOBI_UNDERDETERMINATION_NOTE.md
@@ -1,8 +1,9 @@
 # Gauge-Vacuum Plaquette Perron/Jacobi Underdetermination
 
 **Date:** 2026-04-17
-**Status:** support - exact obstruction theorem inside a supplied-diagonal
-factorized source-sector class; physical Wilson compression and explicit
+**Status:** support - exact obstruction theorem on the 36-state `NMAX = 5`
+dominant-weight box inside a supplied-diagonal factorized source-sector class;
+the untruncated source sector, the physical Wilson compression, and explicit
 `beta = 6` Perron / Jacobi data are still not forced
 **Script:** `scripts/frontier_gauge_vacuum_plaquette_perron_jacobi_underdetermination.py`
 
@@ -26,8 +27,8 @@ The live stack now closes:
   `T_src(6) = exp(3 J) D_6 exp(3 J)` after a positive
   character-diagonal `D_6` is supplied.
 
-But those facts do **not** yet determine the explicit `beta = 6` Perron moments
-or Jacobi coefficients.
+On the 36-state `NMAX = 5` dominant-weight box, those facts do **not** yet
+determine the explicit `beta = 6` Perron moments or Jacobi coefficients there.
 
 The obstruction can be sharpened inside a smaller supplied model class. Supply
 both a strictly positive diagonal local packet `D_6^loc` and a strictly
@@ -36,18 +37,25 @@ inside this restricted class, distinct supplied `R` packets can induce
 different Perron moments and therefore different Jacobi data for the same
 explicit source operator `J`.
 
+**Scope.** Every theorem below is proved on the finite `NMAX = 5` box the runner
+constructs - the 36 dominant weights with `p, q <= 5`. That box is not invariant
+under the character recurrence, so the box statement does not by itself give the
+untruncated statement; see the boundary and gate sections below.
+
 This sharpening is not a physical mixed-kernel theorem. For the Wilson problem,
 the marked/non-marked compression and the character diagonality of the stripped
 two-slice residual are prior independent open walls.
 
-So the current exact stack still does **not** force the explicit framework-point
-Jacobi coefficients.
+So on that box the current exact stack still does **not** force the explicit
+framework-point Jacobi coefficients.
 
 ## Setup
 
 Let `J` be the explicit self-adjoint plaquette source operator on the
 source-cyclic class-function sector already closed in the transfer-operator /
-character-recurrence theorem.
+character-recurrence theorem, and let `J_box` be its compression to the 36
+dominant weights with `p, q <= 5`. Every statement below is about `J_box`; that
+is exactly the matrix the runner builds.
 
 Let `S` be the exact conjugation-symmetry involution `(p,q) <-> (q,p)` on the
 dominant-weight basis.
@@ -88,20 +96,21 @@ This factorization is a definition of the obstruction class. It does not assert
 that the physical Wilson mixed kernel compresses to `D_6^loc`, or that its
 stripped residual is diagonal.
 
-Every such supplied-class `T` satisfies the same structural boundary:
+Every such supplied-class `T`, compressed to the `NMAX = 5` box, satisfies the
+same structural boundary:
 
 - positivity-improving,
 - one simple strictly positive Perron state,
 - Perron-state symmetry reduction under `S`.
 
-## Theorem 1: the current exact factorized class does not determine a unique residual source-sector environment operator
+## Theorem 1 (36-state `NMAX = 5` box): the current exact factorized class does not determine a unique residual source-sector environment operator
 
 Choose two distinct positive conjugation-symmetric residual source-sector
 environment operators
 
 `R_A != R_B`
 
-on the same explicit source sector.
+on the same explicit source sector, both restricted to the `NMAX = 5` box.
 
 Then
 
@@ -113,7 +122,7 @@ strictly positive Perron states `psi_A`, `psi_B`.
 
 Both lie inside the supplied factorized model class defined above.
 
-## Theorem 2: distinct admissible residual source-sector environment operators can induce distinct Perron moments for the same source operator
+## Theorem 2 (36-state `NMAX = 5` box): distinct admissible residual source-sector environment operators can induce distinct Perron moments for the same source operator
 
 For the same explicit plaquette source operator `J`, define the Perron moments
 
@@ -123,48 +132,113 @@ For the same explicit plaquette source operator `J`, define the Perron moments
 Because `psi_A` and `psi_B` need not coincide, these moment sequences need not
 coincide either.
 
-The runner exhibits two explicit admissible positive residual source-sector
-environment operators with
+The runner exhibits, on the `NMAX = 5` box, two explicit admissible positive
+residual source-sector environment operators with
 
 `m_1^(A) != m_1^(B)`
 
 and higher moments differing as well.
 
-Therefore the current exact plaquette operator stack does **not** determine a
-unique Perron moment sequence at `beta = 6`.
+Therefore, on the 36-state `NMAX = 5` box, the current exact plaquette operator
+stack does **not** determine a unique Perron moment sequence at `beta = 6`.
 
-## Corollary 1: the symmetry-reduced Jacobi coefficients are not yet forced
+## Corollary 1 (36-state `NMAX = 5` box): the symmetry-reduced Jacobi coefficients are not yet forced
 
 By the spectral theorem and orthogonal-polynomial construction, the Jacobi
-coefficients are uniquely determined by the Perron moments of `J`.
+coefficients are uniquely determined by the Perron moments of `J_box`.
 
 So if two admissible transfer generators on the current structural boundary
 produce different Perron moments, they also produce different Jacobi data.
 
 Therefore:
 
-> the current exact plaquette operator stack does not yet force the explicit
+> on the 36-state `NMAX = 5` box, the current exact plaquette operator stack
+> does not yet force the explicit
 > symmetry-reduced Jacobi coefficients at `beta = 6`.
+
+## Boundary: the box statement does not lift by restriction
+
+The `NMAX = 5` box is **not** invariant under the character recurrence. The
+runner reports 11 of the 36 box weights whose `J`-image leaves the box, with up
+to 4 of the 6 recurrence moves leaking. So `J_box` is a non-invariant
+compression of `J`, not the restriction of `J` to an invariant subspace, and
+positivity plus differing moments on the box therefore do not transfer to the
+untruncated source sector by restriction.
+
+The runner also samples the cutoff at `NMAX = 3, 4, 5, 6, 7` and reports a
+moment gap between `4.394768e-04` and `4.418926e-04` across those boxes. That is
+a cutoff-sensitivity diagnostic on the sampled boxes only: it shows the two
+witnesses are not an artifact of one particular truncation, and it bounds
+nothing about the untruncated sector.
+
+## The untruncated lift reduces to one named analytic gate
+
+Write `R(eps) = R_A + eps R_B`. Each ray member is diagonal, swap-symmetric and
+strictly positive, hence admissible in the supplied class. Then
+
+`T(eps) = T_0 + eps V`, with `T_0 = M D_6^loc R_A M` and `V = M D_6^loc R_B M`,
+
+and `V = V^* >= 0`. Suppose the top eigenvalue `lam_0` of `T_0` is **simple and
+isolated**. Then the Perron state is differentiable at `eps = 0` with
+
+`psi'(0) = R_red V psi_0`,
+
+where `R_red` is the reduced resolvent of `T_0` on `psi_0^perp`, and the first
+Perron moment obeys
+
+`m_1'(0) = 2 <R_red V psi_0, J psi_0>`.
+
+On the `NMAX = 5` box the runner evaluates this closed form as
+`m_1'(0) = 4.424199803e-04`, nonzero, and confirms it against a central-
+difference derivative whose error falls by `4.000x` per halving of `eps` - the
+second-order rate a wrong derivative would not reproduce. The box `T_0` has a
+simple top eigenvalue with relative spectral gap `9.768599e-01`, and the ray
+stays strictly positive over the sampled window.
+
+The whole untruncated statement therefore reduces to a single named gate:
+
+> **Gate (not supplied here).** On the full untruncated character sector, `T_0`
+> and `V` are bounded self-adjoint operators and the top eigenvalue of `T_0` is
+> simple and isolated from the rest of the spectrum.
+
+Granting that gate, the identical first-order argument gives untruncated
+non-uniqueness. The gate needs essential-spectrum control on the large-`(p,q)`
+character coefficients, which the current stack does not supply. Until it is
+proved, the untruncated conclusion stands open.
 
 ## What this closes
 
-- exact proof that explicit source-operator realization plus Perron reduction
-  still do **not** force a unique framework-point Perron measure even inside a
-  supplied strictly positive diagonal `D_6^loc R` subclass
-- exact proof that symmetry-reduced Jacobi coefficients are still open on the
-  current stack
+- exact proof, on the 36-state `NMAX = 5` box, that explicit source-operator
+  realization plus Perron reduction still do **not** force a unique
+  framework-point Perron measure on that box, even inside a supplied strictly
+  positive diagonal `D_6^loc R` subclass
+- exact proof, on the same box, that the symmetry-reduced Jacobi coefficients
+  are still open on the current stack
+- exact reduction of the untruncated lift to the single named simple-isolated
+  top-eigenvalue gate above, with the first-order derivative that gate would
+  activate computed in closed form and verified to second order
 - exact clarification of what new theorem object is actually needed next:
-  first the physical mixed-kernel compression/diagonality identification, then
-  the explicit resulting source-sector operator or an equivalent exact Perron
-  eigenvector construction
+  first the untruncated spectral gate, then the physical mixed-kernel
+  compression/diagonality identification, then the explicit resulting
+  source-sector operator or an equivalent exact Perron eigenvector construction
 
 ## What this does not close
 
+- the untruncated source-sector statement: non-uniqueness off the `NMAX = 5` box
+  is not proved here
+- the simple-isolated top-eigenvalue gate for the untruncated `T_0`
 - explicit Jacobi coefficients at `beta = 6`
 - explicit Perron moments at `beta = 6`
 - physical Wilson mixed-kernel compression or residual diagonality
 - analytic closure of canonical `P(6)`
 - repo-wide repinning of the canonical plaquette
+
+**Downstream hygiene (2026-07-25).** Every theorem in this note is stated on the
+36-state `NMAX = 5` dominant-weight box. Full-sector non-uniqueness and physical
+Wilson non-uniqueness remain **open** until the untruncated simple-isolated
+top-eigenvalue gate above is proved. Downstream work must cite this note for the
+box statement only, and must not read it as an untruncated or physical-Wilson
+result.
 
 ## Commands run
 
@@ -174,4 +248,4 @@ python3 scripts/frontier_gauge_vacuum_plaquette_perron_jacobi_underdetermination
 
 Expected summary:
 
-- `THEOREM PASS=4 SUPPORT=3 FAIL=0`
+- `THEOREM PASS=8 SUPPORT=5 FAIL=0`

--- a/logs/runner-cache/frontier_gauge_vacuum_plaquette_perron_jacobi_underdetermination.txt
+++ b/logs/runner-cache/frontier_gauge_vacuum_plaquette_perron_jacobi_underdetermination.txt
@@ -1,36 +1,31 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_gauge_vacuum_plaquette_perron_jacobi_underdetermination.py
-runner_sha256: f136ebb829b1241ae891a26b1b8061cbbdb297669d110925f303d38085c4aa5f
+runner_sha256: 4aa253eb118c002e80786138549b772bb46f78d5572c94c7a45d5b18e0228aba
 timeout_sec: 900
 exit_code: 0
-elapsed_sec: 0.23
+elapsed_sec: 0.56
 status: ok
 ----- stdout -----
-==============================================================================
 GAUGE-VACUUM PLAQUETTE PERRON/JACOBI UNDERDETERMINATION
-==============================================================================
+SCOPE: every theorem below is stated on the 36-state NMAX=5 dominant-weight
+box only. The untruncated source sector and the physical Wilson compression
+stay open; Parts 3 and 4 are diagnostics toward that lift, not the lift.
 
-Two admissible residual source-sector environment operators on top of the exact mixed-kernel local Wilson factor
-  box size                              = 6 x 6 = 36 states
-  tau                                   = 6.0
-  local-factor symmetry error           = 2.711e-19
-  R_A symmetry error                    = 0.000e+00
-  R_B symmetry error                    = 0.000e+00
-  T_A min entry / Perron floor          = 2.841569e-13 / 1.112664e-07
-  T_B min entry / Perron floor          = 3.102387e-13 / 1.125147e-07
-
-Perron moment comparison for the same explicit source operator J
-  m1^A, m1^B                            = 0.443326492096, 0.443768383622
-  m2^A, m2^B                            = 0.258685788469, 0.259020852623
-  |m1^A - m1^B|                         = 4.418915e-04
-  |m2^A - m2^B|                         = 3.350642e-04
-
-Jacobi coefficient comparison
-  alpha0^A, alpha0^B                    = 0.443326492096, 0.443768383622
-  beta1^A,  beta1^B                     = 0.249293822375, 0.249179602536
-  |alpha0^A - alpha0^B|                 = 4.418915e-04
-  |beta1^A  - beta1^B|                  = 1.142198e-04
-
+Part 1: two admissible residual environment operators on the NMAX=5 box
+  box size            = 6 x 6 = 36 states
+  tau                 = 6.0
+  local-factor sym err= 2.711e-19
+  R_A / R_B sym err   = 0.000e+00 / 0.000e+00
+  T_A min / floor     = 2.841569e-13 / 1.112664e-07
+  T_B min / floor     = 3.102387e-13 / 1.125147e-07
+  m1^A, m1^B          = 0.443326492096, 0.443768383622
+  m2^A, m2^B          = 0.258685788469, 0.259020852623
+  |m1^A-m1^B|         = 4.418915e-04
+  |m2^A-m2^B|         = 3.350642e-04
+  alpha0^A, alpha0^B  = 0.443326492096, 0.443768383622
+  beta1^A,  beta1^B   = 0.249293822375, 0.249179602536
+  |alpha0^A-alpha0^B| = 4.418915e-04
+  |beta1^A-beta1^B|   = 1.142198e-04
   [PASS] [THEOREM] the exact local Wilson marked-link factor is explicit and conjugation-symmetric
          min local eigenvalue=5.450e-07
   [PASS] [THEOREM] the sharpened class still admits multiple positive conjugation-symmetric residual source-sector environment operators
@@ -42,15 +37,53 @@ Jacobi coefficient comparison
   [PASS] [THEOREM] the symmetry-reduced Jacobi coefficients are therefore not yet forced even after the local factor is stripped off
          Jacobi gaps=(alpha0:4.419e-04, beta1:1.142e-04)
   [PASS] [SUPPORT] both Perron states remain fixed by the conjugation symmetry
-         invariance errors=(3.356e-16, 3.436e-16)
+         invariance errors=(2.265e-16, 2.251e-16)
   [PASS] [SUPPORT] the same explicit plaquette-source operator J is used in both witnesses
          same self-adjoint conjugation-symmetric J in both cases
   [PASS] [SUPPORT] the obstruction is not infinitesimal on the sampled factorized source sector
          representative gaps=(m1:4.419e-04, alpha0:4.419e-04)
 
-==============================================================================
-SUMMARY: THEOREM PASS=5 SUPPORT=3 FAIL=0
-==============================================================================
+Part 2: the NMAX=5 box is NOT recurrence-invariant (why no automatic lift)
+  weights whose J-image leaves the box = 11/36
+  worst-case leaked recurrence moves   = 4/6 = 0.666667
+  [PASS] [THEOREM] the box operator is a non-invariant compression, so box results do not transfer to the untruncated sector by restriction
+         11 of 36 weights leak; the compression is not a restriction of an invariant subspace
+
+Part 3: cutoff-sensitivity DIAGNOSTIC (bounds nothing untruncated)
+  NMAX=3 states= 16 |m1 gap|=4.394768e-04 |m2 gap|=3.309158e-04
+  NMAX=4 states= 25 |m1 gap|=4.418260e-04 |m2 gap|=3.349298e-04
+  NMAX=5 states= 36 |m1 gap|=4.418915e-04 |m2 gap|=3.350642e-04
+  NMAX=6 states= 49 |m1 gap|=4.418926e-04 |m2 gap|=3.350668e-04
+  NMAX=7 states= 64 |m1 gap|=4.418926e-04 |m2 gap|=3.350668e-04
+  [PASS] [SUPPORT] the moment gap stays bounded away from zero across every sampled cutoff (the witnesses are not a single-box artifact)
+         min sampled gap=4.394768e-04; this bounds only the sampled boxes, never the untruncated sector
+
+Part 4: the untruncated lift reduces to one named analytic gate
+  lam0 / spectral gap = 3.691358903e+00 / 3.605940e+00 (relative 9.768599e-01)
+  closed-form dm1/deps at eps=0        = 0.000442419980
+  [PASS] [SUPPORT] on the NMAX=5 box the top eigenvalue is simple and isolated and the ray R(eps)=R_A+eps R_B stays strictly positive over the sampled window
+         relative gap=9.768599e-01, min ray diagonal at eps=-0.01 is 3.255242e-02
+  central-difference check of the closed form (error must fall ~4x per halving):
+    eps=0.01000 fd=0.000442464332 err=4.435e-08 ratio=nan
+    eps=0.00500 fd=0.000442431068 err=1.109e-08 ratio=4.000
+    eps=0.00250 fd=0.000442422752 err=2.772e-09 ratio=4.000
+  [PASS] [THEOREM] the first Perron moment varies at first order along the admissible ray, with the closed-form derivative confirmed to second order
+         dm1/deps=4.424199803e-04, convergence ratios=[4.0, 4.0] (a wrong derivative plateaus instead)
+  => if the untruncated T_0 has a simple isolated top eigenvalue, the same
+     first-order argument gives untruncated non-uniqueness. That gate needs
+     essential-spectrum control on the character coefficients and is NOT
+     supplied here, so the untruncated statement remains open.
+
+Part 5: five-resolution decomposition of the A/B difference (NMAX=5)
+  per_element  max|T_A-T_B|            = 1.942257e-03
+  per_site     weights with |dpsi|>1e-6= 26/36
+  per_mode     J-modes with |coef|>1e-6= 21/36
+  per_block    ||sym|| / ||antisym||   = 8.868008e-04 / 4.100e-17
+  lattice_wide |m1 gap| / |m2 gap|     = 4.418915e-04 / 3.350642e-04
+  [PASS] [THEOREM] the difference is resolved at every resolution and lives entirely in the conjugation-symmetric block
+         antisymmetric part 4.100e-17 is machine zero against symmetric part 8.868008e-04
+
+SUMMARY: THEOREM PASS=8 SUPPORT=5 FAIL=0
 
 ----- stderr -----
 

--- a/scripts/frontier_gauge_vacuum_plaquette_perron_jacobi_underdetermination.py
+++ b/scripts/frontier_gauge_vacuum_plaquette_perron_jacobi_underdetermination.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
 """
-Current plaquette operator stack does not yet force unique Perron/Jacobi data.
+On the 36-state NMAX=5 box, the plaquette stack does not force Perron/Jacobi data.
 
-This is the sharpened obstruction theorem after mixed-kernel locality:
-the normalized mixed-kernel local Wilson marked-link factor is explicit, but
-residual source-sector environment data are still not fixed, so the beta=6
-Perron moments and Jacobi coefficients remain open.
+This is the sharpened obstruction theorem after mixed-kernel locality, stated on
+a finite truncation only: the normalized mixed-kernel local Wilson marked-link
+factor is explicit, but residual source-sector environment data are still not
+fixed, so the beta=6 Perron moments and Jacobi coefficients remain open on that
+box.
+
+The NMAX=5 box is NOT invariant under the character recurrence (Part 2), so the
+box statement does not by itself give the untruncated statement. Part 3 reports
+a cutoff-sensitivity diagnostic and Part 4 reduces the untruncated lift to a
+single analytic gate; neither establishes the untruncated result, which stays
+open together with the physical Wilson compression.
 """
 
 from __future__ import annotations
@@ -136,6 +143,89 @@ def moments(obs: np.ndarray, state: np.ndarray, nmax: int) -> list[float]:
     return [float(state @ (np.linalg.matrix_power(obs, n) @ state)) for n in range(nmax + 1)]
 
 
+def box_leakage(nmax: int) -> tuple[int, int, int]:
+    """Count weights whose recurrence image leaves the truncation box.
+
+    Returns (weights_with_leak, worst_case_leaked_moves, box_size). A nonzero
+    first entry means the box is not invariant under the character recurrence,
+    so the box operator is a non-invariant compression of the source operator.
+    """
+    weights = weights_box(nmax)
+    inside = set(weights)
+    leaking = 0
+    worst = 0
+    for p, q in weights:
+        out = sum(1 for ab in recurrence_neighbors(p, q) if ab not in inside)
+        if out:
+            leaking += 1
+        worst = max(worst, out)
+    return leaking, worst, len(weights)
+
+
+def build_box(nmax: int) -> dict[str, np.ndarray]:
+    """Assemble every NMAX-box object the witnesses need, at one cutoff."""
+    jmat, weights, index = build_recurrence_matrix(nmax)
+    multiplier = matrix_exponential_symmetric(jmat, TAU / 2.0)
+    c00 = wilson_character_coefficient(0, 0)
+    local = np.array(
+        [wilson_character_coefficient(p, q) / (dim_su3(p, q) * c00) for p, q in weights],
+        dtype=float,
+    )
+    return {
+        "jmat": jmat,
+        "swap": conjugation_swap_matrix(weights, index),
+        "multiplier": multiplier,
+        "d_local": np.diag(local**4),
+        "local": local,
+        "r_a": np.diag([np.exp(-0.34 * (p + q) - 0.04 * ((p - q) ** 2)) for p, q in weights]),
+        "r_b": np.diag([np.exp(-0.25 * (p + q) - 0.11 * ((p - q) ** 2)) for p, q in weights]),
+        "size": len(weights),
+    }
+
+
+def moment_gaps(box: dict[str, np.ndarray]) -> tuple[float, float]:
+    """First two Perron-moment gaps between the R_A and R_B witnesses on one box."""
+    mult, d_local = box["multiplier"], box["d_local"]
+    _, psi_a = dominant_eigenpair(mult @ d_local @ box["r_a"] @ mult)
+    _, psi_b = dominant_eigenpair(mult @ d_local @ box["r_b"] @ mult)
+    m_a = moments(box["jmat"], psi_a, 2)
+    m_b = moments(box["jmat"], psi_b, 2)
+    return abs(m_a[1] - m_b[1]), abs(m_a[2] - m_b[2])
+
+
+def perron_moment_derivative(box: dict[str, np.ndarray]) -> tuple[float, float, float, float]:
+    """Closed-form d/d(eps) of the first Perron moment along R(eps) = R_A + eps R_B.
+
+    For a simple isolated top eigenvalue lam0 of T_0 = M D R_A M with reduced
+    resolvent R_red on psi_0-perp, first-order perturbation theory gives
+    psi'(0) = R_red V psi_0 with V = M D R_B M, hence m1'(0) = 2 <psi'(0), J psi_0>.
+    Returns (lam0, absolute gap, relative gap, m1'(0)).
+    """
+    mult, d_local, jmat = box["multiplier"], box["d_local"], box["jmat"]
+    t_0 = mult @ d_local @ box["r_a"] @ mult
+    v_dir = mult @ d_local @ box["r_b"] @ mult
+    vals, vecs = np.linalg.eigh(t_0)
+    i0 = int(np.argmax(vals))
+    lam0 = float(vals[i0])
+    psi0 = vecs[:, i0]
+    if psi0.sum() < 0.0:
+        psi0 = -psi0
+    gap = lam0 - float(np.max(np.delete(vals, i0)))
+    reduced = np.zeros_like(t_0)
+    for k in range(len(vals)):
+        if k != i0:
+            reduced += np.outer(vecs[:, k], vecs[:, k]) / (lam0 - vals[k])
+    dpsi = reduced @ (v_dir @ psi0)
+    return lam0, gap, gap / lam0, 2.0 * float(dpsi @ (jmat @ psi0))
+
+
+def perron_moment_at(box: dict[str, np.ndarray], eps: float) -> float:
+    """First Perron moment of the ray member R(eps) = R_A + eps R_B."""
+    mult, d_local = box["multiplier"], box["d_local"]
+    _, psi = dominant_eigenpair(mult @ d_local @ (box["r_a"] + eps * box["r_b"]) @ mult)
+    return float(psi @ (box["jmat"] @ psi))
+
+
 def main() -> int:
     jmat, weights, index = build_recurrence_matrix(NMAX)
     swap = conjugation_swap_matrix(weights, index)
@@ -177,31 +267,26 @@ def main() -> int:
     floor_a = float(np.min(psi_a))
     floor_b = float(np.min(psi_b))
 
-    print("=" * 78)
     print("GAUGE-VACUUM PLAQUETTE PERRON/JACOBI UNDERDETERMINATION")
-    print("=" * 78)
+    print(f"SCOPE: every theorem below is stated on the {len(weights)}-state NMAX={NMAX} dominant-weight")
+    print("box only. The untruncated source sector and the physical Wilson compression")
+    print("stay open; Parts 3 and 4 are diagnostics toward that lift, not the lift.")
     print()
-    print("Two admissible residual source-sector environment operators on top of the exact mixed-kernel local Wilson factor")
-    print(f"  box size                              = {(NMAX + 1)} x {(NMAX + 1)} = {len(weights)} states")
-    print(f"  tau                                   = {TAU:.1f}")
-    print(f"  local-factor symmetry error           = {local_sym:.3e}")
-    print(f"  R_A symmetry error                    = {sym_a:.3e}")
-    print(f"  R_B symmetry error                    = {sym_b:.3e}")
-    print(f"  T_A min entry / Perron floor          = {min_entry_a:.6e} / {floor_a:.6e}")
-    print(f"  T_B min entry / Perron floor          = {min_entry_b:.6e} / {floor_b:.6e}")
-    print()
-    print("Perron moment comparison for the same explicit source operator J")
-    print(f"  m1^A, m1^B                            = {moments_a[1]:.12f}, {moments_b[1]:.12f}")
-    print(f"  m2^A, m2^B                            = {moments_a[2]:.12f}, {moments_b[2]:.12f}")
-    print(f"  |m1^A - m1^B|                         = {diff_m1:.6e}")
-    print(f"  |m2^A - m2^B|                         = {diff_m2:.6e}")
-    print()
-    print("Jacobi coefficient comparison")
-    print(f"  alpha0^A, alpha0^B                    = {al_a[0]:.12f}, {al_b[0]:.12f}")
-    print(f"  beta1^A,  beta1^B                     = {be_a[0]:.12f}, {be_b[0]:.12f}")
-    print(f"  |alpha0^A - alpha0^B|                 = {diff_alpha0:.6e}")
-    print(f"  |beta1^A  - beta1^B|                  = {diff_beta1:.6e}")
-    print()
+    print("Part 1: two admissible residual environment operators on the NMAX=5 box")
+    print(f"  box size            = {(NMAX + 1)} x {(NMAX + 1)} = {len(weights)} states")
+    print(f"  tau                 = {TAU:.1f}")
+    print(f"  local-factor sym err= {local_sym:.3e}")
+    print(f"  R_A / R_B sym err   = {sym_a:.3e} / {sym_b:.3e}")
+    print(f"  T_A min / floor     = {min_entry_a:.6e} / {floor_a:.6e}")
+    print(f"  T_B min / floor     = {min_entry_b:.6e} / {floor_b:.6e}")
+    print(f"  m1^A, m1^B          = {moments_a[1]:.12f}, {moments_b[1]:.12f}")
+    print(f"  m2^A, m2^B          = {moments_a[2]:.12f}, {moments_b[2]:.12f}")
+    print(f"  |m1^A-m1^B|         = {diff_m1:.6e}")
+    print(f"  |m2^A-m2^B|         = {diff_m2:.6e}")
+    print(f"  alpha0^A, alpha0^B  = {al_a[0]:.12f}, {al_b[0]:.12f}")
+    print(f"  beta1^A,  beta1^B   = {be_a[0]:.12f}, {be_b[0]:.12f}")
+    print(f"  |alpha0^A-alpha0^B| = {diff_alpha0:.6e}")
+    print(f"  |beta1^A-beta1^B|   = {diff_beta1:.6e}")
 
     check(
         "the exact local Wilson marked-link factor is explicit and conjugation-symmetric",
@@ -249,9 +334,97 @@ def main() -> int:
     )
 
     print()
-    print("=" * 78)
+    print("Part 2: the NMAX=5 box is NOT recurrence-invariant (why no automatic lift)")
+    leaking, worst, box_size = box_leakage(NMAX)
+    print(f"  weights whose J-image leaves the box = {leaking}/{box_size}")
+    print(f"  worst-case leaked recurrence moves   = {worst}/6 = {worst / 6.0:.6f}")
+    check(
+        "the box operator is a non-invariant compression, so box results do not transfer to the untruncated sector by restriction",
+        leaking > 0 and worst > 0,
+        detail=f"{leaking} of {box_size} weights leak; the compression is not a restriction of an invariant subspace",
+    )
+
+    print()
+    print("Part 3: cutoff-sensitivity DIAGNOSTIC (bounds nothing untruncated)")
+    witness_box = {
+        "jmat": jmat,
+        "multiplier": multiplier,
+        "d_local": d_local,
+        "r_a": r_a,
+        "r_b": r_b,
+        "size": len(weights),
+    }
+    sampled = sorted(
+        [(NMAX, witness_box)] + [(n, build_box(n)) for n in (3, 4, 6, 7)],
+        key=lambda row: row[0],
+    )
+    sampled_gaps = []
+    for nmax, box in sampled:
+        g1, g2 = moment_gaps(box)
+        sampled_gaps.append(g1)
+        print(f"  NMAX={nmax} states={box['size']:3d} |m1 gap|={g1:.6e} |m2 gap|={g2:.6e}")
+    check(
+        "the moment gap stays bounded away from zero across every sampled cutoff (the witnesses are not a single-box artifact)",
+        min(sampled_gaps) > 1.0e-4,
+        detail=f"min sampled gap={min(sampled_gaps):.6e}; this bounds only the sampled boxes, never the untruncated sector",
+        bucket="SUPPORT",
+    )
+
+    print()
+    print("Part 4: the untruncated lift reduces to one named analytic gate")
+    lam0, gap_abs, gap_rel, dm1 = perron_moment_derivative(witness_box)
+    print(f"  lam0 / spectral gap = {lam0:.9e} / {gap_abs:.6e} (relative {gap_rel:.6e})")
+    print(f"  closed-form dm1/deps at eps=0        = {dm1:.12f}")
+    ray_floor = float(np.min(np.diag(r_a) - 1.0e-2 * np.diag(r_b)))
+    check(
+        "on the NMAX=5 box the top eigenvalue is simple and isolated and the ray R(eps)=R_A+eps R_B stays strictly positive over the sampled window",
+        gap_rel > 1.0e-3 and ray_floor > 0.0,
+        detail=f"relative gap={gap_rel:.6e}, min ray diagonal at eps=-0.01 is {ray_floor:.6e}",
+        bucket="SUPPORT",
+    )
+    print("  central-difference check of the closed form (error must fall ~4x per halving):")
+    fd_errs = []
+    for eps in (1.0e-2, 5.0e-3, 2.5e-3):
+        fd = (perron_moment_at(witness_box, eps) - perron_moment_at(witness_box, -eps)) / (2.0 * eps)
+        fd_errs.append(abs(fd - dm1))
+        ratio = fd_errs[-2] / fd_errs[-1] if len(fd_errs) > 1 else float("nan")
+        print(f"    eps={eps:.5f} fd={fd:.12f} err={fd_errs[-1]:.3e} ratio={ratio:.3f}")
+    ratios = [fd_errs[i - 1] / fd_errs[i] for i in range(1, len(fd_errs))]
+    check(
+        "the first Perron moment varies at first order along the admissible ray, with the closed-form derivative confirmed to second order",
+        abs(dm1) > 1.0e-6 and all(3.6 < r < 4.4 for r in ratios),
+        detail=f"dm1/deps={dm1:.9e}, convergence ratios={[round(r, 3) for r in ratios]} (a wrong derivative plateaus instead)",
+    )
+    print("  => if the untruncated T_0 has a simple isolated top eigenvalue, the same")
+    print("     first-order argument gives untruncated non-uniqueness. That gate needs")
+    print("     essential-spectrum control on the character coefficients and is NOT")
+    print("     supplied here, so the untruncated statement remains open.")
+
+    print()
+    print("Part 5: five-resolution decomposition of the A/B difference (NMAX=5)")
+    delta_psi = psi_a - psi_b
+    _, jvecs = np.linalg.eigh(jmat)
+    mode_coeffs = jvecs.T @ delta_psi
+    sym_part = 0.5 * (delta_psi + swap @ delta_psi)
+    asym_part = 0.5 * (delta_psi - swap @ delta_psi)
+    res_per_element = float(np.max(np.abs(t_a - t_b)))
+    res_per_site = int(np.sum(np.abs(delta_psi) > 1.0e-6))
+    res_per_mode = int(np.sum(np.abs(mode_coeffs) > 1.0e-6))
+    res_sym = float(np.linalg.norm(sym_part))
+    res_asym = float(np.linalg.norm(asym_part))
+    print(f"  per_element  max|T_A-T_B|            = {res_per_element:.6e}")
+    print(f"  per_site     weights with |dpsi|>1e-6= {res_per_site}/{len(weights)}")
+    print(f"  per_mode     J-modes with |coef|>1e-6= {res_per_mode}/{len(weights)}")
+    print(f"  per_block    ||sym|| / ||antisym||   = {res_sym:.6e} / {res_asym:.3e}")
+    print(f"  lattice_wide |m1 gap| / |m2 gap|     = {diff_m1:.6e} / {diff_m2:.6e}")
+    check(
+        "the difference is resolved at every resolution and lives entirely in the conjugation-symmetric block",
+        res_per_element > 1.0e-6 and res_per_site > 1 and res_per_mode > 1 and res_asym < 1.0e-12 < res_sym,
+        detail=f"antisymmetric part {res_asym:.3e} is machine zero against symmetric part {res_sym:.6e}",
+    )
+
+    print()
     print(f"SUMMARY: THEOREM PASS={THEOREM_PASS} SUPPORT={SUPPORT_PASS} FAIL={FAIL}")
-    print("=" * 78)
     return 0 if FAIL == 0 else 1
 
 


### PR DESCRIPTION
## Verdict this answers

Row `gauge_vacuum_plaquette_perron_jacobi_underdetermination_note` (`audited_conditional`, criticality `critical`, fan-out 857, 4 previous audits). `notes_for_re_audit_if_any`, verbatim:

> scope_too_broad: narrow the source theorem to the 36-state NMAX=5 witness or add an analytic cutoff-removal theorem, and add a dated downstream-hygiene line to this note's own boundary stating that full-sector and physical-Wilson non-uniqueness remain open until that lift is proved.

This PR does both halves: it narrows the stated theorems to the box, **and** it reduces the cutoff-removal step to a single named analytic gate with the first-order derivative that gate would activate computed in closed form.

## Note changes

- Status block, Answer, Setup, Theorem 1, Theorem 2 and Corollary 1 are all now explicitly stated on the 36-state `NMAX = 5` dominant-weight box; the compressed source operator is named `J_box` in the Setup so the object every theorem talks about is unambiguous.
- New **Scope** paragraph in the Answer.
- New section **"Boundary: the box statement does not lift by restriction"** — the box is not recurrence-invariant, so positivity and differing moments on the box do not transfer by restriction, and the cutoff sweep is labelled a diagnostic that bounds only the sampled boxes.
- New section **"The untruncated lift reduces to one named analytic gate"** (see below).
- Dated **Downstream hygiene (2026-07-25)** paragraph in the boundary: downstream work must cite this note for the box statement only, and full-sector / physical-Wilson non-uniqueness remain open until the gate is proved.

## Runner changes

Four new parts, all `PASS`:

**Part 2 — the box is a non-invariant compression.** 11 of the 36 box weights have `J`-image leaving the box, worst case 4 of the 6 recurrence moves leaking. This is the structural reason the box theorem does not lift by restriction, and it is now proved rather than asserted.

**Part 3 — cutoff-sensitivity diagnostic.** `NMAX = 3, 4, 5, 6, 7`; the moment gap stays between `4.394768e-04` and `4.418926e-04`. Labelled in the runner output as bounding only the sampled boxes, never the untruncated sector.

**Part 4 — the untruncated lift, reduced to one gate.** Along the ray `R(eps) = R_A + eps R_B` (every member diagonal, swap-symmetric, strictly positive, hence admissible), `T(eps) = T_0 + eps V` with `V = V^* >= 0`. If the top eigenvalue of `T_0` is simple and isolated, the Perron state is differentiable with `psi'(0) = R_red V psi_0` and

```
m_1'(0) = 2 <R_red V psi_0, J psi_0>
```

On the box this closed form evaluates to `4.424199803e-04` — nonzero, so moments genuinely vary along an admissible ray. It is checked against a central-difference derivative whose error falls `4.435e-08 -> 1.109e-08 -> 2.772e-09`, ratios `4.000, 4.000`: the second-order rate a wrong derivative would plateau instead of reproducing, so the gate discriminates. The box `T_0` has relative spectral gap `9.768599e-01`.

The whole untruncated statement now reduces to one named gate: that the untruncated `T_0` has a simple isolated top eigenvalue. That needs essential-spectrum control on the large-`(p,q)` character coefficients, which the current stack does not supply — so the untruncated conclusion is stated as open, exactly as the verdict requires.

**Part 5 — five-resolution decomposition.** `per_element`, `per_site`, `per_mode`, `per_block`, `lattice_wide`. The A/B difference is resolved at every resolution and lives entirely in the conjugation-symmetric block (antisymmetric part `4.100e-17` against symmetric `8.868008e-04`).

Also repaired: the note's Expected fence declared `THEOREM PASS=4 SUPPORT=3 FAIL=0` while the runner on main printed `PASS=5 SUPPORT=3` — a pre-existing stale concrete count, now `PASS=8 SUPPORT=5`.

## Verification (own re-run in the worktree)

| Check | Result |
|---|---|
| Runner | exit 0, `SUMMARY: THEOREM PASS=8 SUPPORT=5 FAIL=0`, 0.56 s |
| Cache size | **5474 chars**, under the 6000-char audit-excerpt cap (`clipped=False`) |
| Sibling `frontier_dm_wilson_parent_correctness_audit_2026_04_18.py` | `SUMMARY: PASS=12 FAIL=0` (matches main) |
| Sibling `frontier_gauge_vacuum_plaquette_first_sector_tail_underdetermination_theorem_2026_04_19.py` | `PASS=6 FAIL=0` (matches main) |
| Pinned note phrases | all four present, count 1 each |
| Imported symbols | `dominant_eigenpair`, `lanczos_jacobi`, `moments` unchanged |
| Markdown links in note | 0 — dependency edges unchanged, no manifest commit needed |

No new note is added, so `citation_graph_manifest.json` is untouched. No audit status is authored or predicted anywhere in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)