### PR TITLE
fix(audit-infra): re-render unclipped gauge-vacuum plaquette runner packet

### DIFF
--- a/logs/runner-cache/frontier_gauge_vacuum_plaquette_transfer_operator_character_recurrence.txt
+++ b/logs/runner-cache/frontier_gauge_vacuum_plaquette_transfer_operator_character_recurrence.txt
@@ -1,29 +1,20 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_gauge_vacuum_plaquette_transfer_operator_character_recurrence.py
-runner_sha256: e4da7117aca2f942c8dd862c9e2fd5827f6c235cffca6eb45ec42ffad156690b
+runner_sha256: 77fa08f636ffe840a38bba6e1c9fd2d31737d7d469e72d6f5d6a1d79dcd37a61
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.38
+elapsed_sec: 0.42
 status: ok
 ----- stdout -----
-========================================================================================
 GAUGE-VACUUM WILSON TRANSFER / SPATIAL-MIXED SOURCE SUPPORT
-========================================================================================
 
 Exact SU(3) character data
   tensor levels checked                    = 0..8
-  dimension sums                           = [1, 6, 36, 216, 1296, 7776, 46656, 279936, 1679616]
-  minimum truncated coefficient            = 1.030056e-09
-  recurrence errors (3,3bar,real)          = 1.361e-13, 1.616e-13, 4.775e-14
   recurrence symmetry error                = 0.000e+00
-  recurrence boundary counts               = {(0, 0): 2, (1, 0): 4, (0, 1): 4, (1, 1): 6}
-  recurrence compressed spectrum           = [-0.439488, 0.877072]
-  sampled SU(3) Wilson Gram min eigenvalue = 1.665696e+00
 
 Finite S3 one-plaquette gauge carrier (SUPPORT)
   link configurations                      = 1296
   physical class-function dimension        = 3
-  pullback/group basis errors              = 6.661e-16, 2.220e-16
   Q / T minimum eigenvalues                = 7.565913e-06, 7.443935e-06
   transfer Gram-factorization error        = 2.220e-16
   temporal-link/projected-kernel error     = 0.000e+00
@@ -44,7 +35,6 @@ Mixed two-slice source (SUPPORT)
 
 Hostile controls
   pointwise-positive symmetric min eig      = -1.000000e+00
-  correct/wrong plaquette gauge errors      = 0.000e+00, 1.500e+00
   selected-vs-repeated slice mismatch       = 6.544801e-02
   selected-vs-repeated mixed mismatch       = 2.100161e-01
   correct/doubled half-weight mismatch      = 3.744333e-01
@@ -53,51 +43,49 @@ Hostile controls
   negative effective-coupling min eig       = -6.696686e-04
 
   [PASS] [SUPPORT] tensor powers of 3 direct-sum 3bar have exact nonnegative integer multiplicities
-         checked all dominant weights through tensor level 8
+    checked all dominant weights through tensor level 8
   [PASS] [SUPPORT] the representation-ring decomposition preserves dimension 6^n
-         dimension sums = [1, 6, 36, 216, 1296, 7776, 46656, 279936, 1679616]
+    dimension sums = [1, 6, 36, 216, 1296, 7776, 46656, 279936, 1679616]
   [PASS] [SUPPORT] positive Taylor weights give nonnegative truncated Wilson coefficients
-         minimum checked partial coefficient = 1.030056e-09
+    minimum checked partial coefficient = 1.030056e-09
   [PASS] [SUPPORT] multiplication by chi_(1,0) obeys the exact SU(3) recurrence
-         maximum error = 1.361e-13
+    maximum error = 1.361e-13
   [PASS] [SUPPORT] multiplication by chi_(0,1) obeys the exact conjugate recurrence
-         maximum error = 1.616e-13
+    maximum error = 1.616e-13
   [PASS] [SUPPORT] the real plaquette source obeys the exact six-neighbor recurrence
-         combined error = 4.775e-14, symmetry error = 0.000e+00
+    combined error = 4.775e-14, symmetry error = 0.000e+00
   [PASS] [SUPPORT] dominant-weight boundary terms omit exactly the negative labels
-         neighbor counts at (0,0),(1,0),(0,1),(1,1) = [2, 4, 4, 6]
+    neighbor counts at (0,0),(1,0),(0,1),(1,1) = [2, 4, 4, 6]
   [PASS] [SUPPORT] sampled SU(3) Wilson positive-type Gram matrices are positive semidefinite
-         minimum eigenvalue = 1.665696e+00
+    minimum eigenvalue = 1.665696e+00
   [PASS] [SUPPORT] the finite square pullback is an isometry onto the three class functions
-         errors=6.661e-16, 2.220e-16
+    pullback=6.661e-16, group_basis=2.220e-16
   [PASS] [SUPPORT] the finite gauge-projected transfer is positive and has the explicit Gram factorization
-         lambda_min(Q)=7.566e-06, lambda_min(T)=7.444e-06, factor error=2.220e-16
+    lambda_min(Q)=7.566e-06, lambda_min(T)=7.444e-06, factor error=2.220e-16
   [PASS] [SUPPORT] projected convolution equals temporal-link integration on selected square configurations
-         maximum selected-pair error = 0.000e+00
+    maximum selected-pair error = 0.000e+00
   [PASS] [SUPPORT] finite transfer trace and marked spatial insertion equal explicit path sums
-         trace error=4.441e-16, mark error=9.437e-16
+    trace error=4.441e-16, mark error=9.437e-16
   [PASS] [SUPPORT] selected and repeated spatial sources obey their distinct insertion formulas
-         selected error=1.110e-15, repeated error=2.665e-15
+    selected error=1.110e-15, repeated error=2.665e-15
   [PASS] [SUPPORT] selected and repeated mixed sources match their distinct two-slice path sums
-         lambda_min=1.491e-05, selected error=3.553e-15, repeated error=4.441e-16
+    lambda_min=1.491e-05, selected error=3.553e-15, repeated error=4.441e-16
   [PASS] [SUPPORT] mixed source derivatives have H^(circle m) circle exp(gamma H) Schur-power form
-         lambda_min(H)=-5.551e-17, max form error=0.000e+00
+    lambda_min(H)=-5.551e-17, max form error=0.000e+00
   [PASS] [SUPPORT] the marked mixed insertion matches its path sum and source derivative
-         path error=4.996e-16, finite-difference error=9.419e-10
+    path error=4.996e-16, finite-difference error=9.419e-10
   [PASS] [SUPPORT] pointwise positive symmetry alone does not imply quadratic-form positivity
-         counterexample minimum eigenvalue = -1.0
+    counterexample minimum eigenvalue = -1.0
   [PASS] [SUPPORT] the wrong plaquette word fails gauge invariance while the oriented word passes
-         correct error=0.000e+00, wrong error=1.500e+00
+    correct error=0.000e+00, wrong error=1.500e+00
   [PASS] [SUPPORT] wrong slice placement, half weighting, or Haar normalization changes the path sum
-         slice=6.545e-02, half(doubled/missing)=3.744e-01/1.036e-01, Haar=4.245e+09
+    slice=6.545e-02, half(doubled/missing)=3.744e-01/1.036e-01, Haar=4.245e+09
   [PASS] [SUPPORT] negative effective mixed coupling is detected outside the source-positivity domain
-         minimum eigenvalue = -6.696686e-04
+    minimum eigenvalue = -6.696686e-04
   [PASS] [SUPPORT] the compressed recurrence spectrum stays inside the plaquette support interval
-         spectrum=[-0.439488, 0.877072]
+    spectrum=[-0.439488, 0.877072]
 
-========================================================================================
 SUMMARY: THEOREM PASS=0 SUPPORT=21 FAIL=0
-========================================================================================
 
 ----- stderr -----
 

--- a/scripts/frontier_gauge_vacuum_plaquette_transfer_operator_character_recurrence.py
+++ b/scripts/frontier_gauge_vacuum_plaquette_transfer_operator_character_recurrence.py
@@ -63,7 +63,7 @@ def check(name: str, condition: bool, detail: str = "", bucket: str = "SUPPORT")
         FAIL += 1
     print(f"  [{status}] [{bucket}] {name}")
     if detail:
-        print(f"         {detail}")
+        print(f"    {detail}")
 
 
 # ---------------------------------------------------------------------------
@@ -771,26 +771,15 @@ def main() -> int:
         np.linalg.eigvalsh(negative_effective_square["transfer"]).min()
     )
 
-    print("=" * 88)
     print("GAUGE-VACUUM WILSON TRANSFER / SPATIAL-MIXED SOURCE SUPPORT")
-    print("=" * 88)
     print()
     print("Exact SU(3) character data")
     print(f"  tensor levels checked                    = 0..{NMAX_TENSOR}")
-    print(f"  dimension sums                           = {dimension_sums}")
-    print(f"  minimum truncated coefficient            = {coefficient_minimum:.6e}")
-    print(f"  recurrence errors (3,3bar,real)          = "
-          f"{fundamental_error:.3e}, {antifundamental_error:.3e}, {combined_error:.3e}")
     print(f"  recurrence symmetry error                = {recurrence_symmetry_error:.3e}")
-    print(f"  recurrence boundary counts               = {boundary_counts}")
-    print(f"  recurrence compressed spectrum           = "
-          f"[{recurrence_eigenvalues.min():.6f}, {recurrence_eigenvalues.max():.6f}]")
-    print(f"  sampled SU(3) Wilson Gram min eigenvalue = {positive_gram_minimum:.6e}")
     print()
     print("Finite S3 one-plaquette gauge carrier (SUPPORT)")
     print(f"  link configurations                      = {S3_CONFIG_COUNT}")
     print(f"  physical class-function dimension        = {pullback.shape[1]}")
-    print(f"  pullback/group basis errors              = {pullback_error:.3e}, {group_basis_error:.3e}")
     print(f"  Q / T minimum eigenvalues                = {q_minimum:.6e}, {transfer_minimum:.6e}")
     print(f"  transfer Gram-factorization error        = {factorization_error:.3e}")
     print(f"  temporal-link/projected-kernel error     = {temporal_kernel_error:.3e}")
@@ -811,7 +800,6 @@ def main() -> int:
     print()
     print("Hostile controls")
     print(f"  pointwise-positive symmetric min eig      = {counterexample_minimum:.6e}")
-    print(f"  correct/wrong plaquette gauge errors      = {correct_orientation_error:.3e}, {wrong_orientation_error:.3e}")
     print(f"  selected-vs-repeated slice mismatch       = {abs(spatial_single_value-wrong_slice_placement_value):.6e}")
     print(f"  selected-vs-repeated mixed mismatch       = {abs(mixed_single_value-mixed_repeated_value):.6e}")
     print(f"  correct/doubled half-weight mismatch      = {abs(trace_value-wrong_half_trace):.6e}")
@@ -875,7 +863,7 @@ def main() -> int:
     check(
         "the finite square pullback is an isometry onto the three class functions",
         pullback_error < TOL and group_basis_error < TOL,
-        detail=f"errors={pullback_error:.3e}, {group_basis_error:.3e}",
+        detail=f"pullback={pullback_error:.3e}, group_basis={group_basis_error:.3e}",
         bucket="SUPPORT",
     )
     check(
@@ -998,9 +986,7 @@ def main() -> int:
     )
 
     print()
-    print("=" * 88)
     print(f"SUMMARY: THEOREM PASS={THEOREM_PASS} SUPPORT={SUPPORT_PASS} FAIL={FAIL}")
-    print("=" * 88)
     return 0 if FAIL == 0 else 1
 
 


### PR DESCRIPTION
## Obligation

Ledger row `gauge_vacuum_plaquette_transfer_operator_character_recurrence_note`
(`audited_conditional`) carries this artifact-issue obligation, quoted verbatim:

> runner_artifact_issue: re-render the complete SHA-pinned primary-runner stdout, including all 21 checks and the summary, then rerun the restricted audit.

## Why the packet was incomplete

`cache_excerpt_for_audit()` in `scripts/runner_cache.py` builds the audit packet as

    clipped = len(body) > tail_chars          # tail_chars = 6000
    excerpt = body[-tail_chars:] if clipped else body

It keeps the **last** 6000 characters of the cache file and discards everything before
them. The loss is at the **head**, not the tail.

This runner's cache was **6,418 chars**, so the first **418** never reached the auditor.
Measured against the stored pre-edit cache, the clip removed:

- the complete cache header block — `runner`, `runner_sha256`, `timeout_sec: 120`,
  `exit_code: 0`, `elapsed_sec`, `status: ok`. The excerpt builder re-prepends only a
  12-character sha prefix, so the full digest
  `e4da7117aca2f942c8dd862c9e2fd5827f6c235cffca6eb45ec42ffad156690b`, the clean exit and
  the declared timeout were all outside the packet;
- one banner rule; and the 6000-char boundary fell mid-line, so the packet opened on the
  fragment `ACUUM WILSON TRANSFER / SPATIAL-MIXED SOURCE S`.

**Stated plainly, because it changes how this row should be read: zero verdict lines were
lost.** All 21 checks and the summary were already inside the 6000-char window. What the
clip destroyed on this row is precisely the *SHA-pinning* the obligation names — the
authentication header that ties the printed checks to an identified, cleanly-exited run.

## What changed

The runner's own printing, and nothing else:

- four `"=" * 88` banner rules dropped; check-detail indentation reduced from 9 spaces to 4;
- eight summary echo lines removed. Each re-printed a value that the per-check `detail=`
  strings already print (dimension sums; minimum truncated coefficient; the three
  recurrence errors; boundary counts; compressed spectrum; sampled Gram minimum
  eigenvalue; pullback/group-basis errors; correct/wrong plaquette gauge errors). The
  value-set invariant below is what makes that safe rather than assumed;
- one detail string relabelled from `errors={a}, {b}` to `pullback={a}, group_basis={b}`,
  which names the same two numbers more explicitly.

No check was added, removed, reordered or weakened; no tolerance changed; no printed
number altered.

Cache: **6,418 → 5,391 chars**, leaving 609 of headroom under the ceiling.

## Verification

A mechanical verifier compared the pre-edit cache against the post-edit cache and enforced
five invariants: (1) every numeric value printed before is still printed after (set
equality on parsed floats over the stdout section), (2) no new numeric value appears,
(3) the sequence of verdict-bearing lines is byte-identical, (4) `exit_code` and `status`
are unchanged and `exit_code == 0`, (5) the post-edit body is under the ceiling.

    runner        : frontier_gauge_vacuum_plaquette_transfer_operator_character_recurrence
    baseline      : stored cache snapshot
    cache bytes   : 6418 -> 5391  (ceiling 6000, headroom 609)
    numeric values: 69 -> 69  lost=0 new=0
    verdict lines : 22 -> 22  identical=True

    RESULT: PASS  (every printed value survives; verdicts byte-identical)

Invariant (1) is the load-bearing one for the summary-echo deletions: had any of those
lines been the sole printer of a value, it would show up as `LOST` and the run would fail.

## Scope

Two files — the runner and its cache. No note is touched, so no note hash moves and no
dependent's audit is invalidated. This runner is `runner_path` for exactly this one ledger
row and appears in no row's `helper_runner_paths`, checked across all 3,879 ledger shards.

This PR sets no status. Whether the re-rendered packet discharges the obligation is for
the independent audit lane to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
