### PR TITLE
fix(audit-infra): re-render unclipped SU(3) character-convolution runner packet

### DIFF
--- a/logs/runner-cache/frontier_su3_character_diagonal_convolution_equivalence_narrow.txt
+++ b/logs/runner-cache/frontier_su3_character_diagonal_convolution_equivalence_narrow.txt
@@ -1,22 +1,18 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_su3_character_diagonal_convolution_equivalence_narrow.py
-runner_sha256: cb80613c581f7a42c446bc3a0670dac14dd7ca2fa5fb70d7de6febdd0ccf4890
+runner_sha256: 082f1470caa5e109ee96c5bc2fd38e41df121ece7e198ecaf243064865f4cf21
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 9.22
+elapsed_sec: 11.57
 status: ok
 ----- stdout -----
 
-----------------------------------------------------------------------------------------
 Part 1 (T1): Schur orthogonality on the finite B_4 truncation
-----------------------------------------------------------------------------------------
   Using N_GRID = 80 for Weyl integration; matrix size 25 x 25
   [PASS (A)] Schur orthogonality off-diagonal: <chi_(p,q), chi_(p',q')> = 0 for (p,q) != (p',q') on test pairs  (off-diag pairs=72, ok=72, max err=6.805e-16)
   [PASS (A)] Schur orthogonality diagonal: <chi_(p,q), chi_(p,q)> = 1 on test weights  (diag weights=9, ok=9, max abs deviation=1.199e-14)
 
-----------------------------------------------------------------------------------------
 Part 2 (T2): exact matrix-index contraction for character convolution
-----------------------------------------------------------------------------------------
   [PASS (A)] (T2) a generic fundamental/antifundamental matrix-element contraction is zero  (mechanically checked all 27 (a,b,c) coefficients)
   [PASS (A)] (T2) a generic same-fundamental contraction is Tr D_(1,0)(V) / 3  (symbolic polynomial={(0, 0): Fraction(1, 3), (1, 1): Fraction(1, 3), (2, 2): Fraction(1, 3)})
   [PASS (A)] (T2) raw matrix-element contraction vanishes for every unequal B_4 irrep pair  (checked 600 inequivalent pairs before applying rho)
@@ -25,29 +21,21 @@ Part 2 (T2): exact matrix-index contraction for character convolution
   [PASS (A)] (T2) d_lambda in Z cancels 1/d_mu and gives the exact 25 x 25 identity  (dimension-weighted raw convolution matrix assembled before rho)
   [PASS (A)] (T2) For abstract rational positive-symmetric (rho_(p,q)): the contracted finite sum gives C_{Z/Z_(0,0)} chi_(p,q) = rho_(p,q) chi_(p,q) for every (p,q) in B_4  (all 25 weights in B_4 pass exact matrix-polynomial comparison)
 
-----------------------------------------------------------------------------------------
 Part 3 (T3): uniqueness of (rho_(p,q)) for the diagonal operator R
-----------------------------------------------------------------------------------------
   [PASS (A)] (T3) Two distinct coefficient sequences rho^(1) != rho^(2) differ in exactly the perturbed entries  (entries differing = 2 (one symmetric pair perturbed: (2,1) and (1,2)))
   [PASS (A)] (T3) Diagonal operators agree on every (p,q) except the perturbed pair  (all unaltered eigenvalues are identical between R^(1) and R^(2))
   [PASS (A)] (T3) Diagonal operators disagree on exactly the perturbed pair (2,1) and (1,2)  (R^(1)[(2,1)] = 0.07692307692307693, R^(2)[(2,1)] = 0.08333333333333333)
 
-----------------------------------------------------------------------------------------
 Part 4 (T4): positivity, self-adjointness, conjugation-symmetry of R
-----------------------------------------------------------------------------------------
   [PASS (A)] (T4) R is positive: rho_(p,q) >= 0 on every weight in B_4  (min rho = 0.00125 >= 0)
   [PASS (A)] (T4) R is self-adjoint (diagonal with real entries)  (||R - R^T||_inf = 0.000e+00)
   [PASS (A)] (T4) R commutes with the conjugation swap (p,q) <-> (q,p)  (||[swap, R]||_inf = 0.000e+00)
   [PASS (A)] (T2) Trivial-channel normalization: rho_(0,0) = 1 exactly  (|rho_(0,0) - 1| = 0.000e+00)
 
-----------------------------------------------------------------------------------------
 Part 5: concrete instance — trivial coefficient sequence collapses to projection
-----------------------------------------------------------------------------------------
   [PASS (A)] concrete trivial instance: rho = (1, 0, ..., 0) gives projection onto chi_(0,0)  (C_{Z/Z_(0,0)} chi_(p,q) = 1 if (p,q)=(0,0) else 0)
 
-----------------------------------------------------------------------------------------
 Part 6: independent deterministic Haar-SU(3) convolution check
-----------------------------------------------------------------------------------------
   [PASS (A)] explicit low-irrep character formulas reproduce their dimensions at the identity  (dimensions=[1, 3, 3, 8, 6, 6, 10, 10])
   [PASS (A)] explicit character formulas agree with the independent Weyl formula on hostile torus points  (max formula disagreement=1.708e-15)
   [PASS (A)] deterministic Ginibre-QR samples lie in SU(3)  (max unitary err=1.443e-15, max det err=1.342e-15)
@@ -56,60 +44,40 @@ Part 6: independent deterministic Haar-SU(3) convolution check
   [PASS (A)] hostile control rejects conjugating the target character chi_mu(W)  (mutant is 25.5 sigma from the claimed fundamental action and tracks the antifundamental)
   [PASS (A)] hostile control rejects a convolution helper that merely returns rho_target  (lookup-only value=0.400000, Haar estimate=0.903981+0.039124j, separation=27.2 sigma)
 
-----------------------------------------------------------------------------------------
 Narrow theorem summary
-----------------------------------------------------------------------------------------
 
-  Narrow B_4 theorem statement:
+Narrow B_4 theorem statement.
 
-  HYPOTHESIS:
-    Fix N = 4 with B_4 = {(p, q) : 0 <= p, q <= 4}.
-    Let (rho_(p,q))_(p,q in B_4) be an abstract real sequence with:
-      rho_(p,q) >= 0,
-      rho_(p,q) = rho_(q,p),
-      rho_(0,0) = 1.
-    Define
-      R chi_(p,q) = rho_(p,q) chi_(p,q),
-      Z(W)       = sum_(p,q in B_4) d_(p,q) rho_(p,q) chi_(p,q)(W),
-      Z_(0,0)    = d_(0,0) rho_(0,0) = 1,
-      C_{Z/Z_(0,0)} f (V) = int_{SU(3)} (Z(V W^{-1}) / Z_(0,0)) f(W) dW,
-      with normalized Haar probability measure dW.
+HYPOTHESIS:
+  Fix N = 4 with B_4 = {(p, q) : 0 <= p, q <= 4}.
+  Let (rho_(p,q))_(p,q in B_4) be an abstract real sequence with
+  rho_(p,q) >= 0, rho_(p,q) = rho_(q,p), rho_(0,0) = 1. Define
+    R chi_(p,q) = rho_(p,q) chi_(p,q),
+    Z(W) = sum_(p,q in B_4) d_(p,q) rho_(p,q) chi_(p,q)(W),
+    Z_(0,0) = d_(0,0) rho_(0,0) = 1,
+    C_{Z/Z_(0,0)} f (V) = int_{SU(3)} (Z(V W^{-1}) / Z_(0,0)) f(W) dW,
+  with dW the normalized Haar probability measure.
 
-  CONCLUSION:
-    (T1)  Schur character orthogonality on B_4:
-              <chi_(p,q), chi_(p',q')>_Haar
-                 = int_{SU(3)} chi_(p,q)(W) conj(chi_(p',q')(W)) dW
-                 = delta_((p,q),(p',q')).
+CONCLUSION:
+  (T1) Schur character orthogonality on B_4: <chi_(p,q), chi_(p',q')>_Haar
+       = int_{SU(3)} chi_(p,q)(W) conj(chi_(p',q')(W)) dW = delta_((p,q),(p',q')).
+  (T2) Diagonal-action identity: C_{Z/Z_(0,0)} chi_(p,q) = rho_(p,q) chi_(p,q)
+       on V_4.
+  (T3) Coefficient uniqueness: R^(1) = R^(2) iff rho^(1) = rho^(2) on B_4.
+  (T4) R is positive, self-adjoint in the Schur-orthonormal character basis,
+       and commutes with the conjugation swap (p,q) <-> (q,p).
 
-    (T2)  Diagonal-action identity:
-              C_{Z/Z_(0,0)} chi_(p,q) = rho_(p,q) chi_(p,q)  on V_4.
+INPUT AND AUTHORITY SURFACE: the complete input is the finite B_4 SU(3)
+  character basis, normalized Haar probability measure, an abstract real
+  nonnegative swap-symmetric sequence with rho_(0,0) = 1, and standard
+  compact-group representation algebra.
+OUTPUT SURFACE: T1, T2, T3, T4 as stated above.
+PARENT PROGRAM DIVISION OF LABOR: a physical Wilson-environment coefficient
+  result supplies the sequence with its own source authority; this theorem
+  supplies the algebraic convolution/diagonal equivalence after that typed
+  input is present.
 
-    (T3)  Coefficient uniqueness:
-              R^(1) = R^(2)  iff  rho^(1) = rho^(2) on B_4.
-
-    (T4)  R is positive, self-adjoint (in the Schur-orthonormal character basis),
-          and commutes with the conjugation swap (p,q) <-> (q,p).
-
-  INPUT AND AUTHORITY SURFACE:
-    The complete input is the finite B_4 SU(3) character basis, normalized
-    Haar probability measure, an abstract real nonnegative swap-symmetric
-    sequence with rho_(0,0) = 1, and standard compact-group representation
-    algebra.
-
-  OUTPUT SURFACE:
-    T1 Schur orthogonality; T2 equality of normalized convolution and diagonal
-    action on V_4; T3 coefficient uniqueness; T4 positivity,
-    self-adjointness, and swap symmetry.
-
-  PARENT PROGRAM DIVISION OF LABOR:
-    A physical Wilson-environment coefficient result supplies the sequence
-    with its own source authority. This theorem supplies the algebraic
-    convolution/diagonal equivalence after that typed input is present.
-
-
-========================================================================================
   TOTAL: PASS=24, FAIL=0
-========================================================================================
 PASS=24 FAIL=0
 
 ----- stderr -----

--- a/scripts/frontier_su3_character_diagonal_convolution_equivalence_narrow.py
+++ b/scripts/frontier_su3_character_diagonal_convolution_equivalence_narrow.py
@@ -74,7 +74,7 @@ def check(label: str, ok: bool, detail: str = "") -> None:
 
 
 def section(title: str) -> None:
-    print("\n" + "-" * 88 + f"\n{title}\n" + "-" * 88)
+    print(f"\n{title}")
 
 
 # =============================================================================
@@ -802,54 +802,39 @@ check(
 section("Narrow theorem summary")
 # =============================================================================
 print("""
-  Narrow B_4 theorem statement:
+Narrow B_4 theorem statement.
 
-  HYPOTHESIS:
-    Fix N = 4 with B_4 = {(p, q) : 0 <= p, q <= 4}.
-    Let (rho_(p,q))_(p,q in B_4) be an abstract real sequence with:
-      rho_(p,q) >= 0,
-      rho_(p,q) = rho_(q,p),
-      rho_(0,0) = 1.
-    Define
-      R chi_(p,q) = rho_(p,q) chi_(p,q),
-      Z(W)       = sum_(p,q in B_4) d_(p,q) rho_(p,q) chi_(p,q)(W),
-      Z_(0,0)    = d_(0,0) rho_(0,0) = 1,
-      C_{Z/Z_(0,0)} f (V) = int_{SU(3)} (Z(V W^{-1}) / Z_(0,0)) f(W) dW,
-      with normalized Haar probability measure dW.
+HYPOTHESIS:
+  Fix N = 4 with B_4 = {(p, q) : 0 <= p, q <= 4}.
+  Let (rho_(p,q))_(p,q in B_4) be an abstract real sequence with
+  rho_(p,q) >= 0, rho_(p,q) = rho_(q,p), rho_(0,0) = 1. Define
+    R chi_(p,q) = rho_(p,q) chi_(p,q),
+    Z(W) = sum_(p,q in B_4) d_(p,q) rho_(p,q) chi_(p,q)(W),
+    Z_(0,0) = d_(0,0) rho_(0,0) = 1,
+    C_{Z/Z_(0,0)} f (V) = int_{SU(3)} (Z(V W^{-1}) / Z_(0,0)) f(W) dW,
+  with dW the normalized Haar probability measure.
 
-  CONCLUSION:
-    (T1)  Schur character orthogonality on B_4:
-              <chi_(p,q), chi_(p',q')>_Haar
-                 = int_{SU(3)} chi_(p,q)(W) conj(chi_(p',q')(W)) dW
-                 = delta_((p,q),(p',q')).
+CONCLUSION:
+  (T1) Schur character orthogonality on B_4: <chi_(p,q), chi_(p',q')>_Haar
+       = int_{SU(3)} chi_(p,q)(W) conj(chi_(p',q')(W)) dW = delta_((p,q),(p',q')).
+  (T2) Diagonal-action identity: C_{Z/Z_(0,0)} chi_(p,q) = rho_(p,q) chi_(p,q)
+       on V_4.
+  (T3) Coefficient uniqueness: R^(1) = R^(2) iff rho^(1) = rho^(2) on B_4.
+  (T4) R is positive, self-adjoint in the Schur-orthonormal character basis,
+       and commutes with the conjugation swap (p,q) <-> (q,p).
 
-    (T2)  Diagonal-action identity:
-              C_{Z/Z_(0,0)} chi_(p,q) = rho_(p,q) chi_(p,q)  on V_4.
-
-    (T3)  Coefficient uniqueness:
-              R^(1) = R^(2)  iff  rho^(1) = rho^(2) on B_4.
-
-    (T4)  R is positive, self-adjoint (in the Schur-orthonormal character basis),
-          and commutes with the conjugation swap (p,q) <-> (q,p).
-
-  INPUT AND AUTHORITY SURFACE:
-    The complete input is the finite B_4 SU(3) character basis, normalized
-    Haar probability measure, an abstract real nonnegative swap-symmetric
-    sequence with rho_(0,0) = 1, and standard compact-group representation
-    algebra.
-
-  OUTPUT SURFACE:
-    T1 Schur orthogonality; T2 equality of normalized convolution and diagonal
-    action on V_4; T3 coefficient uniqueness; T4 positivity,
-    self-adjointness, and swap symmetry.
-
-  PARENT PROGRAM DIVISION OF LABOR:
-    A physical Wilson-environment coefficient result supplies the sequence
-    with its own source authority. This theorem supplies the algebraic
-    convolution/diagonal equivalence after that typed input is present.
+INPUT AND AUTHORITY SURFACE: the complete input is the finite B_4 SU(3)
+  character basis, normalized Haar probability measure, an abstract real
+  nonnegative swap-symmetric sequence with rho_(0,0) = 1, and standard
+  compact-group representation algebra.
+OUTPUT SURFACE: T1, T2, T3, T4 as stated above.
+PARENT PROGRAM DIVISION OF LABOR: a physical Wilson-environment coefficient
+  result supplies the sequence with its own source authority; this theorem
+  supplies the algebraic convolution/diagonal equivalence after that typed
+  input is present.
 """)
 
 
-print(f"\n{'='*88}\n  TOTAL: PASS={PASS}, FAIL={FAIL}\n{'='*88}")
+print(f"  TOTAL: PASS={PASS}, FAIL={FAIL}")
 print(f"PASS={PASS} FAIL={FAIL}")
 sys.exit(1 if FAIL > 0 else 0)


### PR DESCRIPTION
## Obligation

Ledger row `su3_character_diagonal_convolution_equivalence_narrow_theorem_note_2026-05-10`
(`audited_conditional`) carries this artifact-issue obligation, quoted verbatim:

> runner_artifact_issue: rerender the complete, unclipped stdout for the primary runner and re-audit the same restricted packet.

## Why the packet was incomplete

`cache_excerpt_for_audit()` in `scripts/runner_cache.py` builds the audit packet as

    clipped = len(body) > tail_chars          # tail_chars = 6000
    excerpt = body[-tail_chars:] if clipped else body

It keeps the **last** 6000 characters of the cache file and discards everything before
them. The loss is at the **head**, not the tail.

This runner's cache was **7,583 chars**, so the first **1,583** never reached the auditor.
Measured against the stored pre-edit cache, the clip removed:

- the complete cache header block (`runner_sha256` `cb80613c…`, `timeout_sec`,
  `exit_code`, `elapsed_sec: 9.22`, `status`). Only the 12-character sha prefix that the
  excerpt builder re-prepends survived;
- the Part 1 and Part 2 section headers, including the truncation parameters
  `Using N_GRID = 80 for Weyl integration; matrix size 25 x 25` — the numbers that fix
  what "the finite B_4 truncation" concretely means;
- **six of the twenty-six verdict lines** (five complete, one cut by the boundary): the
  Schur off-diagonal and Schur diagonal orthogonality checks of T1, and three of the T2
  exact matrix-index contraction checks. The packet opened mid-token on `  [P`.

So on this row the clip did hide checks: T1's orthogonality evidence and part of T2's
contraction evidence were never in the auditor's packet, while T3 and T4 were.

## What changed

The runner's own printing, and nothing else:

- section banners lost their `"-" * 88` rules and the `TOTAL:` line lost its `"=" * 88`
  rules; the section title itself is unchanged;
- the narrow-theorem statement block was reflowed: dedented from a 2-space hanging indent,
  wrapped tighter, and the `OUTPUT SURFACE:` paragraph — which restated T1–T4 in prose
  immediately below the `CONCLUSION:` block that states them formally — condensed to a
  back-reference to that block. The hypothesis, all four conclusions T1–T4, the input and
  authority surface, and the parent-program division of labor are all still printed in
  full.

No check was added, removed, reordered or weakened; no tolerance changed; no printed
number altered.

Cache: **7,583 → 5,853 chars** (5,855 bytes — the file contains one em-dash; the ceiling
compares decoded character length, not bytes).

That leaves 147 chars of headroom. It is the tightest margin in this batch, so worth
quantifying: the only cache field that varies between runs of an unchanged source is
`elapsed_sec`, which moves by at most a couple of characters. The margin is roughly fifty
times the observed run-to-run variation.

## Verification

A mechanical verifier compared the pre-edit cache against the post-edit cache and enforced
five invariants: (1) every numeric value printed before is still printed after (set
equality on parsed floats over the stdout section), (2) no new numeric value appears,
(3) the sequence of verdict-bearing lines is byte-identical, (4) `exit_code` and `status`
are unchanged and `exit_code == 0`, (5) the post-edit body is under the ceiling.

    runner        : frontier_su3_character_diagonal_convolution_equivalence_narrow
    baseline      : stored cache snapshot
    cache bytes   : 7583 -> 5853  (ceiling 6000, headroom 147)
    numeric values: 35 -> 35  lost=0 new=0
    verdict lines : 26 -> 26  identical=True
        cache body 5853 is under the 6000 ceiling but over the 5850 headroom target

    RESULT: PASS  (every printed value survives; verdicts byte-identical)

The advisory line is reported as the tool emitted it. 5850 was my own conservative
headroom target, not a repo threshold; the enforced ceiling is 6000 and the body is 147
under it. Nothing was trimmed to make that advisory disappear.

## Scope

Two files — the runner and its cache. No note is touched, so no note hash moves and no
dependent's audit is invalidated. This runner is `runner_path` for exactly this one ledger
row and appears in no row's `helper_runner_paths`, checked across all 3,879 ledger shards.

This PR sets no status. Whether the re-rendered packet discharges the obligation is for
the independent audit lane to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
