### PR TITLE
fix(audit-infra): re-render unclipped staggered/Wilson det-positivity packet

### DIFF
--- a/logs/runner-cache/frontier_staggered_wilson_det_positivity_bridge_2026_05_05.txt
+++ b/logs/runner-cache/frontier_staggered_wilson_det_positivity_bridge_2026_05_05.txt
@@ -1,118 +1,104 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_staggered_wilson_det_positivity_bridge_2026_05_05.py
-runner_sha256: 2fd8e75e893f059137fff521efb433d5d16c259545975f99e73114ff34037f95
+runner_sha256: 6b2ac42f1d11a1ddbaca181ae159da1e8cff403320c1d5bde713dee2ee3cdeba
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.44
+elapsed_sec: 0.45
 status: ok
 ----- stdout -----
-==============================================================================
 SUPPLIED-SURFACE STAGGERED + WILSON DET-POSITIVITY VERIFIER
-==============================================================================
 seed=42
 supplied surface: M_W = r * d * I (eps-commuting); mass = m * I
-            r = 1, d = 4 (4D); alpha = m + r * d = m + 4
-
+  r = 1, d = 4 (4D); alpha = m + r * d = m + 4
 Block decomposition: eps reorders sites so eps = diag(+I, -I).
 Then M = M_KS + alpha * I has eps-block form
-    [[ +alpha I, +K     ],
-     [ -K^dag,   +alpha I ]]
+  [[ +alpha I, +K ], [ -K^dag, +alpha I ]]
 Bridge: det(M) = prod_i (alpha^2 + sigma_i^2) > 0 unconditionally.
-
-
-=== L = 2, scale = 0.0 ===
+case cols: ldd=log_det_direct, ldb=log_det_bridge, dif=log_diff=|ldd-ldb|, sre/sim=Re/Im of slogdet sign
+L = 2, scale = 0.0
   [PASS] L=2: M_KS has zero diagonal eps-blocks (anticommutation {eps, M_KS} = 0)
-         max |diag block| = 0.000e+00
+    max |diag block| = 0.000e+00
   [PASS] L=2: M_KS lower-left block equals -K^dagger (anti-Hermiticity)
-         max |K_lower + K^dag| = 0.000e+00, alt-form |K_lower - (-K^dag)| = 0.000e+00
-  m=0.10, alpha=4.10: log_det_direct=+67.727375, log_det_bridge=+67.727375, log_diff=8.53e-14, sign_real=+1.000, sign_imag=+0.00e+00
-  m=0.50, alpha=4.50: log_det_direct=+72.195715, log_det_bridge=+72.195715, log_diff=1.42e-14, sign_real=+1.000, sign_imag=+0.00e+00
-  m=1.00, alpha=5.00: log_det_direct=+77.253020, log_det_bridge=+77.253020, log_diff=7.11e-14, sign_real=+1.000, sign_imag=+0.00e+00
-  m=2.00, alpha=6.00: log_det_direct=+86.004455, log_det_bridge=+86.004455, log_diff=1.42e-14, sign_real=+1.000, sign_imag=+0.00e+00
-
-=== L = 2, scale = 0.5 ===
+    max |K_lower + K^dag| = 0.000e+00, alt-form |K_lower - (-K^dag)| = 0.000e+00
+  m=0.10 alpha=4.10 ldd=+67.727375 ldb=+67.727375 dif=8.53e-14 sre=+1.000 sim=+0.00e+00
+  m=0.50 alpha=4.50 ldd=+72.195715 ldb=+72.195715 dif=1.42e-14 sre=+1.000 sim=+0.00e+00
+  m=1.00 alpha=5.00 ldd=+77.253020 ldb=+77.253020 dif=7.11e-14 sre=+1.000 sim=+0.00e+00
+  m=2.00 alpha=6.00 ldd=+86.004455 ldb=+86.004455 dif=1.42e-14 sre=+1.000 sim=+0.00e+00
+L = 2, scale = 0.5
   [PASS] L=2: M_KS has zero diagonal eps-blocks (anticommutation {eps, M_KS} = 0)
-         max |diag block| = 0.000e+00
+    max |diag block| = 0.000e+00
   [PASS] L=2: M_KS lower-left block equals -K^dagger (anti-Hermiticity)
-         max |K_lower + K^dag| = 0.000e+00, alt-form |K_lower - (-K^dag)| = 0.000e+00
-  m=0.10, alpha=4.10: log_det_direct=+68.572458, log_det_bridge=+68.572458, log_diff=1.42e-14, sign_real=+1.000, sign_imag=+6.02e-19
-  m=0.50, alpha=4.50: log_det_direct=+72.901107, log_det_bridge=+72.901107, log_diff=1.42e-14, sign_real=+1.000, sign_imag=+6.13e-19
-  m=1.00, alpha=5.00: log_det_direct=+77.827347, log_det_bridge=+77.827347, log_diff=1.42e-14, sign_real=+1.000, sign_imag=+3.84e-18
-  m=2.00, alpha=6.00: log_det_direct=+86.406024, log_det_bridge=+86.406024, log_diff=1.42e-14, sign_real=+1.000, sign_imag=-5.18e-19
-
-=== L = 2, scale = 1.0 ===
+    max |K_lower + K^dag| = 0.000e+00, alt-form |K_lower - (-K^dag)| = 0.000e+00
+  m=0.10 alpha=4.10 ldd=+68.572458 ldb=+68.572458 dif=1.42e-14 sre=+1.000 sim=+1.86e-18
+  m=0.50 alpha=4.50 ldd=+72.901107 ldb=+72.901107 dif=0.00e+00 sre=+1.000 sim=-1.37e-18
+  m=1.00 alpha=5.00 ldd=+77.827347 ldb=+77.827347 dif=1.42e-14 sre=+1.000 sim=+4.66e-18
+  m=2.00 alpha=6.00 ldd=+86.406024 ldb=+86.406024 dif=1.42e-14 sre=+1.000 sim=+8.87e-19
+L = 2, scale = 1.0
   [PASS] L=2: M_KS has zero diagonal eps-blocks (anticommutation {eps, M_KS} = 0)
-         max |diag block| = 0.000e+00
+    max |diag block| = 0.000e+00
   [PASS] L=2: M_KS lower-left block equals -K^dagger (anti-Hermiticity)
-         max |K_lower + K^dag| = 0.000e+00, alt-form |K_lower - (-K^dag)| = 0.000e+00
-  m=0.10, alpha=4.10: log_det_direct=+69.736634, log_det_bridge=+69.736634, log_diff=1.42e-14, sign_real=+1.000, sign_imag=-2.92e-18
-  m=0.50, alpha=4.50: log_det_direct=+73.885182, log_det_bridge=+73.885182, log_diff=1.42e-14, sign_real=+1.000, sign_imag=+5.58e-18
-  m=1.00, alpha=5.00: log_det_direct=+78.638336, log_det_bridge=+78.638336, log_diff=0.00e+00, sign_real=+1.000, sign_imag=+1.23e-18
-  m=2.00, alpha=6.00: log_det_direct=+86.982430, log_det_bridge=+86.982430, log_diff=1.42e-14, sign_real=+1.000, sign_imag=+5.58e-18
-
-=== L = 4, scale = 0.0 ===
+    max |K_lower + K^dag| = 0.000e+00, alt-form |K_lower - (-K^dag)| = 0.000e+00
+  m=0.10 alpha=4.10 ldd=+69.736634 ldb=+69.736634 dif=1.42e-14 sre=+1.000 sim=+4.49e-18
+  m=0.50 alpha=4.50 ldd=+73.885182 ldb=+73.885182 dif=1.42e-14 sre=+1.000 sim=-3.35e-18
+  m=1.00 alpha=5.00 ldd=+78.638336 ldb=+78.638336 dif=0.00e+00 sre=+1.000 sim=-4.12e-18
+  m=2.00 alpha=6.00 ldd=+86.982430 ldb=+86.982430 dif=1.42e-14 sre=+1.000 sim=+2.97e-19
+L = 4, scale = 0.0
   [PASS] L=4: M_KS has zero diagonal eps-blocks (anticommutation {eps, M_KS} = 0)
-         max |diag block| = 0.000e+00
+    max |diag block| = 0.000e+00
   [PASS] L=4: M_KS lower-left block equals -K^dagger (anti-Hermiticity)
-         max |K_lower + K^dag| = 0.000e+00, alt-form |K_lower - (-K^dag)| = 0.000e+00
-  m=0.10, alpha=4.10: log_det_direct=+1126.260655, log_det_bridge=+1126.260655, log_diff=4.55e-13, sign_real=+1.000, sign_imag=+0.00e+00
-  m=0.50, alpha=4.50: log_det_direct=+1190.910518, log_det_bridge=+1190.910518, log_diff=0.00e+00, sign_real=+1.000, sign_imag=+0.00e+00
-  m=1.00, alpha=5.00: log_det_direct=+1265.337529, log_det_bridge=+1265.337529, log_diff=4.55e-13, sign_real=+1.000, sign_imag=+0.00e+00
-  m=2.00, alpha=6.00: log_det_direct=+1396.700006, log_det_bridge=+1396.700006, log_diff=9.09e-13, sign_real=+1.000, sign_imag=+0.00e+00
-
-=== L = 4, scale = 0.5 ===
+    max |K_lower + K^dag| = 0.000e+00, alt-form |K_lower - (-K^dag)| = 0.000e+00
+  m=0.10 alpha=4.10 ldd=+1126.260655 ldb=+1126.260655 dif=4.55e-13 sre=+1.000 sim=+0.00e+00
+  m=0.50 alpha=4.50 ldd=+1190.910518 ldb=+1190.910518 dif=0.00e+00 sre=+1.000 sim=+0.00e+00
+  m=1.00 alpha=5.00 ldd=+1265.337529 ldb=+1265.337529 dif=4.55e-13 sre=+1.000 sim=+0.00e+00
+  m=2.00 alpha=6.00 ldd=+1396.700006 ldb=+1396.700006 dif=9.09e-13 sre=+1.000 sim=+0.00e+00
+L = 4, scale = 0.5
   [PASS] L=4: M_KS has zero diagonal eps-blocks (anticommutation {eps, M_KS} = 0)
-         max |diag block| = 0.000e+00
+    max |diag block| = 0.000e+00
   [PASS] L=4: M_KS lower-left block equals -K^dagger (anti-Hermiticity)
-         max |K_lower + K^dag| = 0.000e+00, alt-form |K_lower - (-K^dag)| = 0.000e+00
-  m=0.10, alpha=4.10: log_det_direct=+1125.609416, log_det_bridge=+1125.609416, log_diff=9.09e-13, sign_real=+1.000, sign_imag=+1.27e-19
-  m=0.50, alpha=4.50: log_det_direct=+1190.442596, log_det_bridge=+1190.442596, log_diff=6.82e-13, sign_real=+1.000, sign_imag=+1.16e-16
-  m=1.00, alpha=5.00: log_det_direct=+1265.018022, log_det_bridge=+1265.018022, log_diff=2.27e-13, sign_real=+1.000, sign_imag=-1.17e-16
-  m=2.00, alpha=6.00: log_det_direct=+1396.537416, log_det_bridge=+1396.537416, log_diff=4.55e-13, sign_real=+1.000, sign_imag=-3.62e-17
-
-=== L = 4, scale = 1.0 ===
+    max |K_lower + K^dag| = 0.000e+00, alt-form |K_lower - (-K^dag)| = 0.000e+00
+  m=0.10 alpha=4.10 ldd=+1125.609416 ldb=+1125.609416 dif=9.09e-13 sre=+1.000 sim=-2.81e-17
+  m=0.50 alpha=4.50 ldd=+1190.442596 ldb=+1190.442596 dif=6.82e-13 sre=+1.000 sim=+8.32e-17
+  m=1.00 alpha=5.00 ldd=+1265.018022 ldb=+1265.018022 dif=2.27e-13 sre=+1.000 sim=-8.69e-17
+  m=2.00 alpha=6.00 ldd=+1396.537416 ldb=+1396.537416 dif=4.55e-13 sre=+1.000 sim=-3.95e-17
+L = 4, scale = 1.0
   [PASS] L=4: M_KS has zero diagonal eps-blocks (anticommutation {eps, M_KS} = 0)
-         max |diag block| = 0.000e+00
+    max |diag block| = 0.000e+00
   [PASS] L=4: M_KS lower-left block equals -K^dagger (anti-Hermiticity)
-         max |K_lower + K^dag| = 0.000e+00, alt-form |K_lower - (-K^dag)| = 0.000e+00
-  m=0.10, alpha=4.10: log_det_direct=+1125.029076, log_det_bridge=+1125.029076, log_diff=2.05e-12, sign_real=+1.000, sign_imag=+6.53e-17
-  m=0.50, alpha=4.50: log_det_direct=+1190.023277, log_det_bridge=+1190.023277, log_diff=1.36e-12, sign_real=+1.000, sign_imag=-7.81e-17
-  m=1.00, alpha=5.00: log_det_direct=+1264.730075, log_det_bridge=+1264.730075, log_diff=1.14e-12, sign_real=+1.000, sign_imag=-9.29e-17
-  m=2.00, alpha=6.00: log_det_direct=+1396.389684, log_det_bridge=+1396.389684, log_diff=2.27e-13, sign_real=+1.000, sign_imag=+7.81e-17
-
---- Bridge assertions ---
+    max |K_lower + K^dag| = 0.000e+00, alt-form |K_lower - (-K^dag)| = 0.000e+00
+  m=0.10 alpha=4.10 ldd=+1125.029076 ldb=+1125.029076 dif=1.82e-12 sre=+1.000 sim=+4.46e-17
+  m=0.50 alpha=4.50 ldd=+1190.023277 ldb=+1190.023277 dif=1.36e-12 sre=+1.000 sim=-6.79e-17
+  m=1.00 alpha=5.00 ldd=+1264.730075 ldb=+1264.730075 dif=1.14e-12 sre=+1.000 sim=-9.78e-17
+  m=2.00 alpha=6.00 ldd=+1396.389684 ldb=+1396.389684 dif=2.27e-13 sre=+1.000 sim=+7.25e-17
+Bridge assertions
   [PASS] balanced sublattice n_+ = n_- on L=2
-         n_+=24, n_-=24
+    n_+=24, n_-=24
   [PASS] balanced sublattice n_+ = n_- on L=2
-         n_+=24, n_-=24
+    n_+=24, n_-=24
   [PASS] balanced sublattice n_+ = n_- on L=2
-         n_+=24, n_-=24
+    n_+=24, n_-=24
   [PASS] balanced sublattice n_+ = n_- on L=4
-         n_+=384, n_-=384
+    n_+=384, n_-=384
   [PASS] balanced sublattice n_+ = n_- on L=4
-         n_+=384, n_-=384
+    n_+=384, n_-=384
   [PASS] balanced sublattice n_+ = n_- on L=4
-         n_+=384, n_-=384
+    n_+=384, n_-=384
   [PASS] every (L, scale, m) case has det(M) > 0
-         checked 24 (L, scale, m) configurations
+    checked 24 (L, scale, m) configurations
   [PASS] bridge factorisation det(M) = prod (alpha^2 + sigma_i^2) matches direct det
-         max log_diff over all cases = 2.05e-12 (tol 1e-7)
+    max log_diff over all cases = 1.82e-12 (tol 1e-7)
   [PASS] L=2 K block has n_+ = 24 singular values
-         got 24
+    got 24
   [PASS] L=2 K block has n_+ = 24 singular values
-         got 24
+    got 24
   [PASS] L=2 K block has n_+ = 24 singular values
-         got 24
+    got 24
   [PASS] L=4 K block has n_+ = 384 singular values
-         got 384
+    got 384
   [PASS] L=4 K block has n_+ = 384 singular values
-         got 384
+    got 384
   [PASS] L=4 K block has n_+ = 384 singular values
-         got 384
-
-==============================================================================
+    got 384
 SUMMARY: PASS=26 FAIL=0
-==============================================================================
 
 ----- stderr -----
 

--- a/scripts/frontier_staggered_wilson_det_positivity_bridge_2026_05_05.py
+++ b/scripts/frontier_staggered_wilson_det_positivity_bridge_2026_05_05.py
@@ -48,7 +48,7 @@ def check(name: str, condition: bool, detail: str = "") -> None:
         FAIL_COUNT += 1
     print(f"  [{status}] {name}")
     if detail:
-        print(f"         {detail}")
+        print(f"    {detail}")
 
 
 # ---- SU(3) generators (Gell-Mann basis) ------------------------------------
@@ -181,8 +181,7 @@ def build_eps_diagonal(L: int) -> np.ndarray:
 # ---- Bridge structural and numerical checks ---------------------------------
 
 def run_volume(L: int, scale: float, masses: list[float], rng: np.random.Generator) -> dict:
-    print()
-    print(f"=== L = {L}, scale = {scale} ===")
+    print(f"L = {L}, scale = {scale}")
     links = build_links(L, scale, rng)
     M_KS = build_M_KS(L, links)
     dim = M_KS.shape[0]
@@ -272,9 +271,9 @@ def run_volume(L: int, scale: float, masses: list[float], rng: np.random.Generat
         )
 
         print(
-            f"  m={m:.2f}, alpha={alpha:.2f}: log_det_direct={float(log_det_direct):+.6f}, "
-            f"log_det_bridge={log_det_bridge:+.6f}, log_diff={log_diff:.2e}, "
-            f"sign_real={sign_direct_real:+.3f}, sign_imag={sign_direct_imag:+.2e}"
+            f"  m={m:.2f} alpha={alpha:.2f} ldd={float(log_det_direct):+.6f} "
+            f"ldb={log_det_bridge:+.6f} dif={log_diff:.2e} "
+            f"sre={sign_direct_real:+.3f} sim={sign_direct_imag:+.2e}"
         )
 
     return {
@@ -288,19 +287,16 @@ def run_volume(L: int, scale: float, masses: list[float], rng: np.random.Generat
 
 
 def main() -> int:
-    print("=" * 78)
     print("SUPPLIED-SURFACE STAGGERED + WILSON DET-POSITIVITY VERIFIER")
-    print("=" * 78)
     print(f"seed={SEED}")
     print(f"supplied surface: M_W = r * d * I (eps-commuting); mass = m * I")
-    print(f"            r = 1, d = 4 (4D); alpha = m + r * d = m + 4")
-    print()
+    print(f"  r = 1, d = 4 (4D); alpha = m + r * d = m + 4")
     print("Block decomposition: eps reorders sites so eps = diag(+I, -I).")
     print("Then M = M_KS + alpha * I has eps-block form")
-    print("    [[ +alpha I, +K     ],")
-    print("     [ -K^dag,   +alpha I ]]")
+    print("  [[ +alpha I, +K ], [ -K^dag, +alpha I ]]")
     print("Bridge: det(M) = prod_i (alpha^2 + sigma_i^2) > 0 unconditionally.")
-    print()
+    print("case cols: ldd=log_det_direct, ldb=log_det_bridge,"
+          " dif=log_diff=|ldd-ldb|, sre/sim=Re/Im of slogdet sign")
 
     rng = np.random.default_rng(SEED)
 
@@ -312,8 +308,7 @@ def main() -> int:
             cases.append(volume)
 
     # Aggregate assertions
-    print()
-    print("--- Bridge assertions ---")
+    print("Bridge assertions")
 
     # Balanced sublattice on every L
     for v in cases:
@@ -349,10 +344,7 @@ def main() -> int:
             detail=f"got {v['n_sigmas']}",
         )
 
-    print()
-    print("=" * 78)
     print(f"SUMMARY: PASS={PASS_COUNT} FAIL={FAIL_COUNT}")
-    print("=" * 78)
     return 0 if FAIL_COUNT == 0 else 1
 
 


### PR DESCRIPTION
## Obligation

Ledger row `staggered_wilson_det_positivity_bridge_theorem_note_2026-05-05`
(`audited_conditional`) carries this artifact-issue obligation, quoted verbatim:

> runner_artifact_issue: attach the complete unclipped primary-runner stdout and re-audit the unchanged supplied-surface scope.

## Why the packet was incomplete

`cache_excerpt_for_audit()` in `scripts/runner_cache.py` builds the audit packet as

    clipped = len(body) > tail_chars          # tail_chars = 6000
    excerpt = body[-tail_chars:] if clipped else body

It keeps the **last** 6000 characters of the cache file and discards everything before
them. The loss is at the **head**, not the tail.

This runner's cache was **7,221 chars**, so the first **1,221** never reached the auditor.
Measured against the stored pre-edit cache, the clip removed:

- the complete cache header block (`runner_sha256` `2fd8e75e…`, `timeout_sec`,
  `exit_code`, `elapsed_sec: 0.44`, `status`);
- **the entire supplied-surface preamble** — the title line
  `SUPPLIED-SURFACE STAGGERED + WILSON DET-POSITIVITY VERIFIER`, `seed=42`, the surface
  declaration `supplied surface: M_W = r * d * I (eps-commuting); mass = m * I`, the
  parameter line `r = 1, d = 4 (4D); alpha = m + r * d = m + 4`, the eps-block matrix
  form, the bridge statement
  `Bridge: det(M) = prod_i (alpha^2 + sigma_i^2) > 0 unconditionally.`, and the first
  case banner `=== L = 2, scale = 0.0 ===`;
- two `[PASS]` verdict lines, with the 6000-char boundary cutting mid-number so the packet
  opened on the fragment `_det_direct=+67.727375, log_det_bridge=+67.727`.

The obligation asks for a re-audit of the **unchanged supplied-surface scope**. The
supplied-surface declaration is precisely what the clip removed: the auditor was shown
determinant checks with no statement of the surface they were computed on.

## What changed

The runner's own printing, and nothing else:

- four `"=" * 78` banner rules dropped; the case banner reduced from a blank line plus
  `=== L = 2, scale = 0.0 ===` to `L = 2, scale = 0.0`; check-detail indentation reduced
  from 9 spaces to 4; the assertion banner from `--- Bridge assertions ---` to
  `Bridge assertions`;
- the two-line eps-block matrix display folded onto one line, and the 12-space-indented
  `r = 1, d = 4 (4D)` parameter line re-indented to 2;
- the per-case column labels abbreviated: `log_det_direct` → `ldd`,
  `log_det_bridge` → `ldb`, `log_diff` → `dif`, `sign_real`/`sign_imag` → `sre`/`sim`.
  **A new legend line names every one of them in full**, printed once above the cases:

      case cols: ldd=log_det_direct, ldb=log_det_bridge, dif=log_diff=|ldd-ldb|, sre/sim=Re/Im of slogdet sign

No check was added, removed, reordered or weakened; no tolerance changed; no printed
number altered.

Cache: **7,221 → 5,711 chars**, leaving 289 of headroom under the ceiling.

## Verification — and why the baseline is a live run

A mechanical verifier compared pre-edit against post-edit stdout and enforced five
invariants: (1) every numeric value printed before is still printed after (set equality on
parsed floats over the stdout section), (2) no new numeric value appears, (3) the sequence
of verdict-bearing lines is byte-identical, (4) `exit_code` and `status` are unchanged and
`exit_code == 0`, (5) the post-edit body is under the ceiling.

Run against the **stored cache snapshot**, invariant (1) fails: 16 values lost, 17 new.
That result is reported here rather than suppressed, because it needed explaining before
this PR could be trusted.

Every one of the 33 churned values is a `sign_imag` entry at magnitude 1e-16 to 1e-19 —
the imaginary part of a `slogdet` sign that the runner asserts is real — except two
`log_diff` entries (`2.05e-12` → `1.82e-12`), which are absolute differences between two
log-determinants of magnitude ~1125. No `log_det_direct`, `log_det_bridge`, `sign_real`,
or verdict line moved at all. The verdict-line sequence was byte-identical throughout.

That pattern is consistent with numerical drift, but consistency is not proof. So the
question was settled by a control rather than by argument: **the unedited source was run
twice, back to back, and the two stdouts were byte-identical.** The runner is
deterministic on this machine, so the stored cache's disagreement is drift between the
epoch/machine that wrote it and this one — not run-to-run noise, and not this edit.

That control is what licenses a live-vs-live comparison, which isolates the edit as the
single variable:

    runner        : frontier_staggered_wilson_det_positivity_bridge_2026_05_05
    baseline      : LIVE pre-edit run
    cache bytes   : 7221 -> 5711  (ceiling 6000, headroom 289)
    numeric values: 65 -> 65  lost=0 new=0
    verdict lines : 27 -> 27  identical=True

    RESULT: PASS  (every printed value survives; verdicts byte-identical)

One note on the verifier itself, since it bears on reading the stored-baseline output
above: its noise triage uses an **absolute** floor (1e-13), so it flags the two `log_diff`
entries as "not explainable as drift" when they are absolute differences of ~1125-magnitude
quantities, where the natural noise scale is ~1e-13 x 10^3. The triage line is a heuristic,
not a gate; the determinism control and the live-vs-live PASS are the evidence.

## Scope

Two files — the runner and its cache. No note is touched, so no note hash moves and no
dependent's audit is invalidated. This runner is `runner_path` for exactly this one ledger
row and appears in no row's `helper_runner_paths`, checked across all 3,879 ledger shards.

This PR sets no status. Whether the re-rendered packet discharges the obligation is for
the independent audit lane to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
