### PR TITLE
fix(audit-infra): re-render unclipped Maradudin lattice-Green runner packet

### DIFF
--- a/logs/runner-cache/lattice_greens_maradudin_asymptotic_accepted_premise_runner.txt
+++ b/logs/runner-cache/lattice_greens_maradudin_asymptotic_accepted_premise_runner.txt
@@ -1,107 +1,99 @@
 ===== runner cache v1 =====
 runner: scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py
-runner_sha256: 3889c5bbc03974c0677b8a0bb1f79cc70d0fa0434c9a07d3e203d15b4d639aa0
+runner_sha256: 0e7cfb619db9ba8aab6382983bfdd36f1e960f538137e1498416179899d9d0a8
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.40
+elapsed_sec: 0.38
 status: ok
 ----- stdout -----
 CUBIC-LATTICE GREEN ASYMPTOTIC FRAMEWORK-NATIVE REROUTE
-
-== Part 0: source firewall ==
+Part 0: source firewall
+  [req: phrase present in note; abs: phrase absent from note]
   PASS: source note file exists (docs/LATTICE_GREENS_MARADUDIN_ASYMPTOTIC_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-27.md)
-  PASS: source contains required phrase: Framework-Native Replacement For The Former Import
-  PASS: source contains required phrase: Textbook Reference Boundary
-  PASS: source contains required phrase: Maradudin
-  PASS: source contains required phrase: Lawler
-  PASS: source contains required phrase: Spitzer
-  PASS: source contains required phrase: parallel textbook provenance
-  PASS: source contains required phrase: not load-bearing authority
-  PASS: source contains required phrase: framework-local theorem
-  PASS: source contains required phrase: It no longer uses a textbook theorem as a load-bearing premise
-  PASS: source contains required phrase: No new axiom is introduced
-  PASS: source contains required phrase: No new accepted premise is introduced
-  PASS: source contains required phrase: MINIMAL_AXIOMS_2026-06-05.md
-  PASS: source contains required phrase: scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py
-  PASS: source contains required phrase: LATTICE_GREENS_FUNCTION_MARADUDIN_TEXTBOOK_IMPORT_NOTE_2026-05-18.md
-  PASS: source contains required phrase: scripts/lattice_greens_z3_asymptotic_normalization_certificate.py
-  PASS: source contains required phrase: bounded_theorem
-  PASS: source contains required phrase: Status authority
-  PASS: source contains required phrase: independent audit lane only
-  PASS: source note excludes forbidden phrase: PDG load-bearing value
-  PASS: source note excludes forbidden phrase: load-bearing fitted
-  PASS: source note excludes forbidden phrase: Monte Carlo measurement consumed
-  PASS: source note excludes forbidden phrase: load-bearing g_bare value
-  PASS: source note excludes forbidden phrase: Wilson plaquette load-bearing input
-  PASS: source note excludes forbidden phrase: Newton constant G_obs imported
-  PASS: source note excludes forbidden phrase: accepted-premise packet entry
-  PASS: source note excludes forbidden phrase: not derived in this bridge
-  PASS: source note excludes forbidden phrase: admitted named import
-  PASS: source note excludes forbidden phrase: single non-framework input
-  PASS: source note excludes forbidden phrase: named textbook theorem remains
-  PASS: source note excludes forbidden phrase: supplied accepted-premise packet
-
-== Part 1: (B1) symbol normalization (sympy) ==
-  PASS: (B1) sympy: lambda(k) at order 2 equals kx^2 + ky^2 + kz^2 (deg2 = kx**2 + ky**2 + kz**2)
-  PASS: (B1) sympy: lambda(k) has no order-3 cross-terms (even-cosine symmetry)
-  PASS: (B1) sympy: lambda(k) has non-zero O(|k|^4) correction (deg4 = -kx**4/12 - ky**4/12 - kz**4/12)
-  PASS: (B1) sympy: axis expansion is eps^2 - eps^4/12 + O(eps^6)
-
-== Part 1b: (B1) symbol normalization (numerical) ==
-  PASS: (B1) axis lambda(eps,0,0) / eps^2 ~ 1 at eps=0.10000 (ratio=0.9991669444)
-  PASS: (B1) diag lambda(eps,eps,eps) / (3 eps^2) ~ 1 at eps=0.10000 (ratio=0.9991669444)
-  PASS: (B1) axis lambda(eps,0,0) / eps^2 ~ 1 at eps=0.05000 (ratio=0.9997916840)
-  PASS: (B1) diag lambda(eps,eps,eps) / (3 eps^2) ~ 1 at eps=0.05000 (ratio=0.9997916840)
-  PASS: (B1) axis lambda(eps,0,0) / eps^2 ~ 1 at eps=0.02500 (ratio=0.9999479178)
-  PASS: (B1) diag lambda(eps,eps,eps) / (3 eps^2) ~ 1 at eps=0.02500 (ratio=0.9999479178)
-  PASS: (B1) axis lambda(eps,0,0) / eps^2 ~ 1 at eps=0.01250 (ratio=0.9999869792)
-  PASS: (B1) diag lambda(eps,eps,eps) / (3 eps^2) ~ 1 at eps=0.01250 (ratio=0.9999869792)
-
-== Part 2: (B2) continuum-kernel unit flux (sympy) ==
-  PASS: (B2) sympy: -d(1/(4 pi r))/dr = 1/(4 pi r^2)
-  PASS: (B2) sympy: int_{S^2} R^2 * (1/(4 pi R^2)) dOmega = 1 (flux = 1)
-  PASS: (B2) numerical: flux at R=1.0 equals 1.0 (flux=1.0000000000000000)
-  PASS: (B2) numerical: flux at R=2.0 equals 1.0 (flux=1.0000000000000000)
-  PASS: (B2) numerical: flux at R=5.0 equals 1.0 (flux=1.0000000000000000)
-  PASS: (B2) numerical: flux at R=10.0 equals 1.0 (flux=1.0000000000000000)
-  PASS: (B2) numerical: flux at R=100.0 equals 1.0 (flux=1.0000000000000000)
-
-== Part 3: (B3) lattice-harmonic residual decay ==
-  PASS: (B3) scaled residual r^5 |Delta_lat phi| bounded at r=16 (scaled=0.278758)
-  PASS: (B3) scaled residual r^5 |Delta_lat phi| bounded at r=32 (scaled=0.278580)
-  PASS: (B3) residual decays by ~r^-5 between r and r/2 at r=32 (ratio=32.020)
-  PASS: (B3) scaled residual r^5 |Delta_lat phi| bounded at r=64 (scaled=0.278536)
-  PASS: (B3) residual decays by ~r^-5 between r and r/2 at r=64 (ratio=32.005)
-  PASS: (B3) scaled residual r^5 |Delta_lat phi| bounded at r=128 (scaled=0.278525)
-  PASS: (B3) residual decays by ~r^-5 between r and r/2 at r=128 (ratio=32.001)
-  PASS: (B3) scaled coefficient stable across r=16..128 (first=0.2788 last=0.2785)
-
-== Part 4: (B4) framework constant identification ==
-  PASS: (B4) sympy: c = 1/(4 pi) for the framework unit point-source convention
-  PASS: (B4) numerical: target c value 1/(4 pi) computed (c = 0.0795774715459477)
-  PASS: (B4) numerical: 4 pi = 12.566370614... (4 pi = 12.566370614359)
-
-== Part 5: dependency status check ==
+  PASS: req: Framework-Native Replacement For The Former Import
+  PASS: req: Textbook Reference Boundary
+  PASS: req: Maradudin
+  PASS: req: Lawler
+  PASS: req: Spitzer
+  PASS: req: parallel textbook provenance
+  PASS: req: not load-bearing authority
+  PASS: req: framework-local theorem
+  PASS: req: It no longer uses a textbook theorem as a load-bearing premise
+  PASS: req: No new axiom is introduced
+  PASS: req: No new accepted premise is introduced
+  PASS: req: MINIMAL_AXIOMS_2026-06-05.md
+  PASS: req: scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py
+  PASS: req: LATTICE_GREENS_FUNCTION_MARADUDIN_TEXTBOOK_IMPORT_NOTE_2026-05-18.md
+  PASS: req: scripts/lattice_greens_z3_asymptotic_normalization_certificate.py
+  PASS: req: bounded_theorem
+  PASS: req: Status authority
+  PASS: req: independent audit lane only
+  PASS: abs: PDG load-bearing value
+  PASS: abs: load-bearing fitted
+  PASS: abs: Monte Carlo measurement consumed
+  PASS: abs: load-bearing g_bare value
+  PASS: abs: Wilson plaquette load-bearing input
+  PASS: abs: Newton constant G_obs imported
+  PASS: abs: accepted-premise packet entry
+  PASS: abs: not derived in this bridge
+  PASS: abs: admitted named import
+  PASS: abs: single non-framework input
+  PASS: abs: named textbook theorem remains
+  PASS: abs: supplied accepted-premise packet
+Part 1: (B1) symbol normalization (sympy)
+  PASS: sympy: lambda(k) at order 2 equals kx^2 + ky^2 + kz^2 (deg2 = kx**2 + ky**2 + kz**2)
+  PASS: sympy: lambda(k) has no order-3 cross-terms (even-cosine symmetry)
+  PASS: sympy: lambda(k) has non-zero O(|k|^4) correction (deg4 = -kx**4/12 - ky**4/12 - kz**4/12)
+  PASS: sympy: axis expansion is eps^2 - eps^4/12 + O(eps^6)
+Part 1b: (B1) symbol normalization (numerical)
+  PASS: axis lambda(eps,0,0) / eps^2 ~ 1 at eps=0.10000 (ratio=0.9991669444)
+  PASS: diag lambda(eps,eps,eps) / (3 eps^2) ~ 1 at eps=0.10000 (ratio=0.9991669444)
+  PASS: axis lambda(eps,0,0) / eps^2 ~ 1 at eps=0.05000 (ratio=0.9997916840)
+  PASS: diag lambda(eps,eps,eps) / (3 eps^2) ~ 1 at eps=0.05000 (ratio=0.9997916840)
+  PASS: axis lambda(eps,0,0) / eps^2 ~ 1 at eps=0.02500 (ratio=0.9999479178)
+  PASS: diag lambda(eps,eps,eps) / (3 eps^2) ~ 1 at eps=0.02500 (ratio=0.9999479178)
+  PASS: axis lambda(eps,0,0) / eps^2 ~ 1 at eps=0.01250 (ratio=0.9999869792)
+  PASS: diag lambda(eps,eps,eps) / (3 eps^2) ~ 1 at eps=0.01250 (ratio=0.9999869792)
+Part 2: (B2) continuum-kernel unit flux (sympy)
+  PASS: sympy: -d(1/(4 pi r))/dr = 1/(4 pi r^2)
+  PASS: sympy: int_{S^2} R^2 * (1/(4 pi R^2)) dOmega = 1 (flux = 1)
+  PASS: numerical: flux at R=1.0 equals 1.0 (flux=1.0000000000000000)
+  PASS: numerical: flux at R=2.0 equals 1.0 (flux=1.0000000000000000)
+  PASS: numerical: flux at R=5.0 equals 1.0 (flux=1.0000000000000000)
+  PASS: numerical: flux at R=10.0 equals 1.0 (flux=1.0000000000000000)
+  PASS: numerical: flux at R=100.0 equals 1.0 (flux=1.0000000000000000)
+Part 3: (B3) lattice-harmonic residual decay
+  PASS: scaled residual r^5 |Delta_lat phi| bounded at r=16 (scaled=0.278758)
+  PASS: scaled residual r^5 |Delta_lat phi| bounded at r=32 (scaled=0.278580)
+  PASS: residual decays by ~r^-5 between r and r/2 at r=32 (ratio=32.020)
+  PASS: scaled residual r^5 |Delta_lat phi| bounded at r=64 (scaled=0.278536)
+  PASS: residual decays by ~r^-5 between r and r/2 at r=64 (ratio=32.005)
+  PASS: scaled residual r^5 |Delta_lat phi| bounded at r=128 (scaled=0.278525)
+  PASS: residual decays by ~r^-5 between r and r/2 at r=128 (ratio=32.001)
+  PASS: scaled coefficient stable across r=16..128 (first=0.2788 last=0.2785)
+Part 4: (B4) framework constant identification
+  PASS: sympy: c = 1/(4 pi) for the framework unit point-source convention
+  PASS: numerical: target c value 1/(4 pi) computed (c = 0.0795774715459477)
+  PASS: numerical: 4 pi = 12.566370614... (4 pi = 12.566370614359)
+Part 5: dependency status check
   PASS: Parent Maradudin wrapper note file exists (docs/LATTICE_GREENS_FUNCTION_MARADUDIN_TEXTBOOK_IMPORT_NOTE_2026-05-18.md)
   PASS: parent carries framework-local proof language
   PASS: Parent normalization certificate runner exists (scripts/lattice_greens_z3_asymptotic_normalization_certificate.py)
   PASS: Parent normalization certificate cache exists (logs/runner-cache/lattice_greens_z3_asymptotic_normalization_certificate.txt)
   PASS: MINIMAL_AXIOMS_2026-06-05.md exists (docs/MINIMAL_AXIOMS_2026-06-05.md)
-
-== Part 6: no forbidden imports ==
-  PASS: source note excludes literature comparator: PDG obs value
-  PASS: source note excludes literature comparator: fitted selector consumed
-  PASS: source note excludes literature comparator: Newton constant G_obs imported
-  PASS: source note excludes literature comparator: Planck length l_P_obs imported
-  PASS: source note excludes literature comparator: Bekenstein-Hawking entropy observed import
-  PASS: source note excludes literature comparator: Wilson plaquette load-bearing input
-  PASS: source note excludes literature comparator: Monte Carlo measurement consumed
-
-== Part 7: no new axioms or vocabulary ==
+Part 6: no forbidden imports
+  [lit: literature comparator absent from note]
+  PASS: lit: PDG obs value
+  PASS: lit: fitted selector consumed
+  PASS: lit: Newton constant G_obs imported
+  PASS: lit: Planck length l_P_obs imported
+  PASS: lit: Bekenstein-Hawking entropy observed import
+  PASS: lit: Wilson plaquette load-bearing input
+  PASS: lit: Monte Carlo measurement consumed
+Part 7: no new axioms or vocabulary
   PASS: note disclaims new axiom introduction
   PASS: note disclaims new accepted-premise introduction
   PASS: legacy row consumes parent framework-local theorem
-
 TOTAL: PASS=76 FAIL=0
 VERDICT: framework-native lattice Green asymptotic reroute passes; (B1)-(B4) follow from the parent framework-local Green-kernel theorem plus lattice-internal arithmetic and finite-precision lattice-harmonic residual evaluation. Textbooks are parallel references only.
 

--- a/logs/runner-cache/lattice_greens_maradudin_asymptotic_accepted_premise_runner.txt
+++ b/logs/runner-cache/lattice_greens_maradudin_asymptotic_accepted_premise_runner.txt
@@ -1,9 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py
-runner_sha256: 0e7cfb619db9ba8aab6382983bfdd36f1e960f538137e1498416179899d9d0a8
+runner_sha256: b6f0e98f4942c5f3c1a7c2031cf10bf5185b11c214062c3772248d5e1cd0a3a6
+input_fingerprint_sha256: 142360eb5f65e9e553aa5e010640590fabcce6bb1ecb6aaaab5dc2b71de289a8
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.38
+elapsed_sec: 0.42
 status: ok
 ----- stdout -----
 CUBIC-LATTICE GREEN ASYMPTOTIC FRAMEWORK-NATIVE REROUTE

--- a/scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py
+++ b/scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py
@@ -37,6 +37,13 @@ CLAIM_ID = (
 RUNNER_REL = (
     "scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py"
 )
+AUDIT_INPUT_PATHS = (
+    "docs/LATTICE_GREENS_MARADUDIN_ASYMPTOTIC_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-27.md",
+    "docs/LATTICE_GREENS_FUNCTION_MARADUDIN_TEXTBOOK_IMPORT_NOTE_2026-05-18.md",
+    "docs/MINIMAL_AXIOMS_2026-06-05.md",
+    "logs/runner-cache/lattice_greens_z3_asymptotic_normalization_certificate.txt",
+    "scripts/lattice_greens_z3_asymptotic_normalization_certificate.py",
+)
 NOTE_PATH = (
     ROOT
     / "docs/LATTICE_GREENS_MARADUDIN_ASYMPTOTIC_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-27.md"

--- a/scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py
+++ b/scripts/lattice_greens_maradudin_asymptotic_accepted_premise_runner.py
@@ -62,7 +62,8 @@ def check(name: str, condition: bool, detail: str = "") -> bool:
 
 def part0_source_firewall() -> None:
     """Verify the source note carries the required boundary phrases."""
-    print("\n== Part 0: source firewall ==")
+    print("Part 0: source firewall")
+    print("  [req: phrase present in note; abs: phrase absent from note]")
     check(
         "source note file exists",
         NOTE_PATH.is_file(),
@@ -92,7 +93,7 @@ def part0_source_firewall() -> None:
     ]
     for phrase in required:
         check(
-            f"source contains required phrase: {phrase}",
+            f"req: {phrase}",
             phrase in note or phrase in note_flat,
         )
 
@@ -112,14 +113,14 @@ def part0_source_firewall() -> None:
     ]
     for phrase in forbidden:
         check(
-            f"source note excludes forbidden phrase: {phrase}",
+            f"abs: {phrase}",
             phrase not in note and phrase not in note_flat,
         )
 
 
 def part1_symbol_normalization_symbolic() -> None:
     """(B1) sympy: lambda(k) = |k|^2 + O(|k|^4) on Z^3."""
-    print("\n== Part 1: (B1) symbol normalization (sympy) ==")
+    print("Part 1: (B1) symbol normalization (sympy)")
     kx, ky, kz = sp.symbols("kx ky kz", real=True)
     lam = 6 - 2 * (sp.cos(kx) + sp.cos(ky) + sp.cos(kz))
     # Taylor expand at k=0 to fourth order
@@ -139,7 +140,7 @@ def part1_symbol_normalization_symbolic() -> None:
     )
     target = kx**2 + ky**2 + kz**2
     check(
-        "(B1) sympy: lambda(k) at order 2 equals kx^2 + ky^2 + kz^2",
+        "sympy: lambda(k) at order 2 equals kx^2 + ky^2 + kz^2",
         sp.simplify(deg2 - target) == 0,
         f"deg2 = {sp.simplify(deg2)}",
     )
@@ -151,7 +152,7 @@ def part1_symbol_normalization_symbolic() -> None:
         if sum(m) == 3
     )
     check(
-        "(B1) sympy: lambda(k) has no order-3 cross-terms (even-cosine symmetry)",
+        "sympy: lambda(k) has no order-3 cross-terms (even-cosine symmetry)",
         sp.simplify(deg3) == 0,
     )
 
@@ -164,7 +165,7 @@ def part1_symbol_normalization_symbolic() -> None:
         if sum(m) == 4
     )
     check(
-        "(B1) sympy: lambda(k) has non-zero O(|k|^4) correction",
+        "sympy: lambda(k) has non-zero O(|k|^4) correction",
         sp.simplify(deg4) != 0,
         f"deg4 = {sp.simplify(deg4)}",
     )
@@ -175,19 +176,19 @@ def part1_symbol_normalization_symbolic() -> None:
     axis_expansion = (lam.subs({kx: eps, ky: 0, kz: 0})).series(eps, 0, 6).removeO()
     expected_axis = eps**2 - eps**4 / sp.Integer(12)
     check(
-        "(B1) sympy: axis expansion is eps^2 - eps^4/12 + O(eps^6)",
+        "sympy: axis expansion is eps^2 - eps^4/12 + O(eps^6)",
         sp.simplify(axis_expansion - expected_axis) == 0,
     )
 
 
 def part1b_symbol_normalization_numerical() -> None:
     """(B1) numerical: lambda(k) / |k|^2 -> 1 as |k| -> 0."""
-    print("\n== Part 1b: (B1) symbol normalization (numerical) ==")
+    print("Part 1b: (B1) symbol normalization (numerical)")
     for eps in (1e-1, 5e-2, 2.5e-2, 1.25e-2):
         sym_axis = 6.0 - 2.0 * (math.cos(eps) + math.cos(0.0) + math.cos(0.0))
         ratio_axis = sym_axis / (eps * eps)
         check(
-            f"(B1) axis lambda(eps,0,0) / eps^2 ~ 1 at eps={eps:.5f}",
+            f"axis lambda(eps,0,0) / eps^2 ~ 1 at eps={eps:.5f}",
             abs(ratio_axis - 1.0) < eps * eps / 10.0,
             f"ratio={ratio_axis:.10f}",
         )
@@ -196,7 +197,7 @@ def part1b_symbol_normalization_numerical() -> None:
         )
         ratio_diag = sym_diag / (3.0 * eps * eps)
         check(
-            f"(B1) diag lambda(eps,eps,eps) / (3 eps^2) ~ 1 at eps={eps:.5f}",
+            f"diag lambda(eps,eps,eps) / (3 eps^2) ~ 1 at eps={eps:.5f}",
             abs(ratio_diag - 1.0) < eps * eps / 10.0,
             f"ratio={ratio_diag:.10f}",
         )
@@ -204,14 +205,14 @@ def part1b_symbol_normalization_numerical() -> None:
 
 def part2_unit_flux_symbolic() -> None:
     """(B2) sympy: continuum kernel 1/(4 pi r) carries unit outward flux."""
-    print("\n== Part 2: (B2) continuum-kernel unit flux (sympy) ==")
+    print("Part 2: (B2) continuum-kernel unit flux (sympy)")
     r = sp.Symbol("r", positive=True)
     phi = 1 / (4 * sp.pi * r)
     grad_phi_radial = sp.diff(phi, r)
     # -grad phi is the outward radial component = 1/(4 pi r^2)
     minus_grad = -grad_phi_radial
     check(
-        "(B2) sympy: -d(1/(4 pi r))/dr = 1/(4 pi r^2)",
+        "sympy: -d(1/(4 pi r))/dr = 1/(4 pi r^2)",
         sp.simplify(minus_grad - 1 / (4 * sp.pi * r * r)) == 0,
     )
     # Integrate over S^2 at radius R: int_{S^2} R^2 * (1/(4 pi R^2)) dOmega
@@ -225,7 +226,7 @@ def part2_unit_flux_symbolic() -> None:
         (sp.Symbol("ph"), 0, 2 * sp.pi),
     )
     check(
-        "(B2) sympy: int_{S^2} R^2 * (1/(4 pi R^2)) dOmega = 1",
+        "sympy: int_{S^2} R^2 * (1/(4 pi R^2)) dOmega = 1",
         sp.simplify(flux - 1) == 0,
         f"flux = {flux}",
     )
@@ -235,7 +236,7 @@ def part2_unit_flux_symbolic() -> None:
             1.0 / (4.0 * math.pi * radius * radius)
         )
         check(
-            f"(B2) numerical: flux at R={radius:.1f} equals 1.0",
+            f"numerical: flux at R={radius:.1f} equals 1.0",
             math.isclose(flux_num, 1.0, rel_tol=0.0, abs_tol=1e-15),
             f"flux={flux_num:.16f}",
         )
@@ -265,7 +266,7 @@ def graph_laplacian_on_kernel(x: tuple[int, int, int]) -> float:
 
 def part3_lattice_harmonic_residual() -> None:
     """(B3) numerical: (-Delta_lat)(1/(4 pi r)) = O(r^-5) at axis."""
-    print("\n== Part 3: (B3) lattice-harmonic residual decay ==")
+    print("Part 3: (B3) lattice-harmonic residual decay")
     previous = None
     scaled_history = []
     for radius in (16, 32, 64, 128):
@@ -273,7 +274,7 @@ def part3_lattice_harmonic_residual() -> None:
         scaled = residual * (radius**5)
         scaled_history.append(scaled)
         check(
-            f"(B3) scaled residual r^5 |Delta_lat phi| bounded at r={radius}",
+            f"scaled residual r^5 |Delta_lat phi| bounded at r={radius}",
             scaled < 0.29,
             f"scaled={scaled:.6f}",
         )
@@ -281,7 +282,7 @@ def part3_lattice_harmonic_residual() -> None:
             # Each doubling of r should reduce residual by at least factor ~31
             # (i.e. close to 2^5 = 32), reflecting r^-5 decay
             check(
-                f"(B3) residual decays by ~r^-5 between r and r/2 at r={radius}",
+                f"residual decays by ~r^-5 between r and r/2 at r={radius}",
                 residual < previous / 31.0,
                 f"ratio={previous/residual:.3f}",
             )
@@ -292,7 +293,7 @@ def part3_lattice_harmonic_residual() -> None:
         first = scaled_history[0]
         last = scaled_history[-1]
         check(
-            "(B3) scaled coefficient stable across r=16..128",
+            "scaled coefficient stable across r=16..128",
             abs(last - first) / first < 0.5,
             f"first={first:.4f} last={last:.4f}",
         )
@@ -300,7 +301,7 @@ def part3_lattice_harmonic_residual() -> None:
 
 def part4_framework_constant_identification() -> None:
     """(B4) c = 1/(4 pi) is the framework-stencil asymptotic constant."""
-    print("\n== Part 4: (B4) framework constant identification ==")
+    print("Part 4: (B4) framework constant identification")
     # Symbolic: parameterise G(r) = c / r and check that the only c
     # making (-Delta_lat) (G) asymptotically consistent with a unit
     # point source is c = 1/(4 pi).
@@ -311,7 +312,7 @@ def part4_framework_constant_identification() -> None:
     # normalization (B1) and unit-flux convention (B2).
     target_c = sp.Rational(1, 1) / (4 * sp.pi)
     check(
-        "(B4) sympy: c = 1/(4 pi) for the framework unit point-source convention",
+        "sympy: c = 1/(4 pi) for the framework unit point-source convention",
         sp.simplify(target_c - 1 / (4 * sp.pi)) == 0,
     )
     # Cross-check the numeric target used by the native reroute.
@@ -319,14 +320,14 @@ def part4_framework_constant_identification() -> None:
     # asymptotic; the checks above pin the normalization convention.
     c_target_numerical = 1.0 / (4.0 * math.pi)
     check(
-        "(B4) numerical: target c value 1/(4 pi) computed",
+        "numerical: target c value 1/(4 pi) computed",
         math.isclose(c_target_numerical, 0.07957747154594767, rel_tol=1e-15),
         f"c = {c_target_numerical:.16f}",
     )
     # Closed-form 4 pi check
     four_pi = 4.0 * math.pi
     check(
-        "(B4) numerical: 4 pi = 12.566370614...",
+        "numerical: 4 pi = 12.566370614...",
         math.isclose(four_pi, 12.566370614359172, rel_tol=1e-15),
         f"4 pi = {four_pi:.12f}",
     )
@@ -334,7 +335,7 @@ def part4_framework_constant_identification() -> None:
 
 def part5_dependency_status() -> None:
     """Verify load-bearing one-hop dependency is framework-local."""
-    print("\n== Part 5: dependency status check ==")
+    print("Part 5: dependency status check")
     parent = (
         ROOT
         / "docs/LATTICE_GREENS_FUNCTION_MARADUDIN_TEXTBOOK_IMPORT_NOTE_2026-05-18.md"
@@ -376,7 +377,8 @@ def part5_dependency_status() -> None:
 
 def part6_no_forbidden_imports() -> None:
     """No PDG / Monte Carlo / fitted value imported."""
-    print("\n== Part 6: no forbidden imports ==")
+    print("Part 6: no forbidden imports")
+    print("  [lit: literature comparator absent from note]")
     note = NOTE_PATH.read_text(encoding="utf-8")
     forbidden_substrings = [
         "PDG " + "obs " + "value",
@@ -389,14 +391,14 @@ def part6_no_forbidden_imports() -> None:
     ]
     for phrase in forbidden_substrings:
         check(
-            f"source note excludes literature comparator: {phrase}",
+            f"lit: {phrase}",
             phrase not in note,
         )
 
 
 def part7_no_new_axioms() -> None:
     """No new repo vocabulary or repo-wide axiom introduced."""
-    print("\n== Part 7: no new axioms or vocabulary ==")
+    print("Part 7: no new axioms or vocabulary")
     note = NOTE_PATH.read_text(encoding="utf-8")
     note_flat = " ".join(note.split())
     # Verify the note explicitly disclaims new axioms
@@ -428,7 +430,7 @@ def main() -> int:
     part5_dependency_status()
     part6_no_forbidden_imports()
     part7_no_new_axioms()
-    print(f"\nTOTAL: PASS={PASS} FAIL={FAIL}")
+    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
     if FAIL == 0:
         print(
             "VERDICT: framework-native lattice Green asymptotic reroute passes; "


### PR DESCRIPTION
## Obligation

Ledger row `lattice_greens_maradudin_asymptotic_accepted_premise_bridge_bounded_note_2026-05-27`
(`audited_conditional`) carries this artifact-issue obligation, quoted verbatim:

> runner_artifact_issue: provide the complete, unclipped authenticated stdout for the 76-check primary runner so every reported pass can be verified.

## Why the packet was incomplete

`cache_excerpt_for_audit()` in `scripts/runner_cache.py` builds the audit packet as

    clipped = len(body) > tail_chars          # tail_chars = 6000
    excerpt = body[-tail_chars:] if clipped else body

It keeps the **last** 6000 characters of the cache file and discards everything before
them. The loss is at the **head**, not the tail.

This runner's cache was **7,105 chars**, so the first **1,105** never reached the auditor.
Measured against the stored pre-edit cache, the clip removed:

- the complete cache header block (`runner_sha256` `3889c5bb…`, `timeout_sec`,
  `exit_code`, `elapsed_sec: 0.40`, `status`) — the "authenticated" half of what the
  obligation asks for. Only the 12-character sha prefix that the excerpt builder
  re-prepends survived;
- the title `CUBIC-LATTICE GREEN ASYMPTOTIC FRAMEWORK-NATIVE REROUTE` and the
  `== Part 0: source firewall ==` banner;
- **eleven verdict lines** (ten complete, one cut by the boundary, which opened on the
  fragment `  PASS: sou`). The lost checks are the whole opening of the source firewall:
  the source-note-exists check, and the required-phrase checks for
  `Framework-Native Replacement For The Former Imp…`, `Textbook Reference Boundary`,
  `Maradudin`, `Lawler`, `Spitzer`, `parallel textbook provenance`,
  `not load-bearing authority`, `framework-local theorem`, and
  `It no longer uses a textbook theorem as a load-…`.

This is the sharpest case in the batch. The obligation asks that *every reported pass be
verifiable*, and the checks the clip hid are exactly the ones establishing that the
textbook result is cited as parallel provenance rather than load-bearing authority — the
premise on which this row's bounded status rests.

## What changed

The runner's own printing, and nothing else:

- section banners lost their leading blank line and `== … ==` wrapping
  (`== Part 0: source firewall ==` → `Part 0: source firewall`);
- three label families shortened on the printed line:
  `source contains required phrase: X` → `req: X`,
  `source note excludes forbidden phrase: X` → `abs: X`,
  and the per-check `(B1)`/`(B2)`/`(B3)`/`(B4)` prefixes dropped from individual check
  labels.

Two things are deliberately **not** collapsed, because they carry the firewall's meaning:

- `req`, `abs` and `lit` remain three distinct classes — required-phrase, forbidden-phrase,
  and literature-comparator-exclusion are different checks and are still counted
  separately. Post-edit prefix census over the cache: `req: 18, abs: 12, lit: 7`, matching
  the pre-edit counts exactly. Two legend lines print the expansions, e.g.

      [req: phrase present in note; abs: phrase absent from note]

- the `(Bk)` premise tags are still carried by the section banners the checks sit under
  (`Part 1: (B1) symbol normalization (sympy)`, `Part 1b: (B1) … (numerical)`,
  `Part 2: (B2) continuum-kernel unit flux (sympy)`,
  `Part 3: (B3) lattice-harmonic residual decay`,
  `Part 4: (B4) framework constant identification`), so every check's premise attribution
  is still readable from the packet.

No check was added, removed, reordered or weakened; no tolerance changed; no printed
number altered. The note's own pinned count — `TOTAL: PASS=76 FAIL=0` at
`docs/LATTICE_GREENS_MARADUDIN_ASYMPTOTIC_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-27.md:192`
— is unchanged, and the note quotes none of the rewritten label strings.

Cache: **7,105 → 5,816 chars**, leaving 184 of headroom under the ceiling.

## Verification

Label compression breaks byte-identity of the verdict lines by construction, so each
rewrite is **declared** to the verifier and applied to the pre-edit text before comparison.
Anything not explained by a declared rewrite still fails, and a rewrite matching nothing
is itself a failure — so the declarations cannot be used to paper over an unintended
change.

    runner        : lattice_greens_maradudin_asymptotic_accepted_premise_runner
    baseline      : stored cache snapshot
    declared subst: '  PASS: source contains required phrase' => '  PASS: req'   (18 occurrence(s) in PRE)
    declared subst: '  PASS: source note excludes forbidden phrase' => '  PASS: abs'   (12 occurrence(s) in PRE)
    declared subst: '  PASS: source note excludes literature comparator' => '  PASS: lit'   (7 occurrence(s) in PRE)
    declared subst: '  PASS: (B1)' => '  PASS:'   (12 occurrence(s) in PRE)
    declared subst: '  PASS: (B2)' => '  PASS:'   (7 occurrence(s) in PRE)
    declared subst: '  PASS: (B3)' => '  PASS:'   (8 occurrence(s) in PRE)
    declared subst: '  PASS: (B4)' => '  PASS:'   (3 occurrence(s) in PRE)
    cache bytes   : 7105 -> 5816  (ceiling 6000, headroom 184)
    numeric values: 43 -> 43  lost=0 new=0
    verdict lines : 77 -> 77  identical=True

    RESULT: PASS  (every printed value survives; verdicts byte-identical)

Under those seven declarations the full 77-line verdict sequence is byte-identical, every
printed numeric value survives, and no new value appears.

## Scope

Two files — the runner and its cache. No note is touched, so no note hash moves and no
dependent's audit is invalidated. This runner is `runner_path` for exactly this one ledger
row and appears in no row's `helper_runner_paths`, checked across all 3,879 ledger shards.
Three sibling runners share the `source note excludes literature comparator` idiom
(`g_bare_two_ward_h_unit_residue_accepted_premise_runner.py`,
`planck_target3_coframe_response_accepted_premise_runner.py`,
`planck_boundary_action_density_accepted_premise_runner.py`); all three were grepped and
none references this runner or its note.

This PR sets no status. Whether the re-rendered packet discharges the obligation is for
the independent audit lane to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
