### PR TITLE
fix(audit-infra): re-render unclipped hierarchy fourth-root runner packet

### DIFF
--- a/logs/runner-cache/frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.txt
+++ b/logs/runner-cache/frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.txt
@@ -1,76 +1,58 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.py
-runner_sha256: c64afa659936b1af48ce54303d5f504c6e2c31b46c94d2f89c412d3e44799a85
+runner_sha256: 112c2cb5303bef7977a8f781d983380d090606d6da2d72c969bbd14b8983191d
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.40
+elapsed_sec: 0.61
 status: ok
 ----- stdout -----
-========================================================================================
-frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.py
-mode=all
-exact A-C theorem; exponent-only D with supplied kappa/sign boundary
-========================================================================================
-
-----------------------------------------------------------------------------------------
-NORMAL: exact theorem and conditional-map reconstruction
-----------------------------------------------------------------------------------------
-  [PASS][A][theorem] exact real domain of the eta/zeta base is 0 < 1-2^(1-s) < 1 for s>1  (positive domain=Interval.open(1, oo); below-one domain=Reals; g(2)=1/sqrt(2); s=4 base -> 7/8)
-  [PASS][A][theorem] odd/even series split has zero eta/zeta closed-form residual  (residual = 0)
-  [PASS][A][theorem] Taylor-coefficient comparison has a positive induction certificate  (R_1=s_i + 2; R_(k+1)-2R_k=s_i; decomposition residual=0)
-  [PASS][A][theorem] log g(s) tends to zero, so g(s) tends to one  (lim log(g) = 0)
-  [PASS][A][theorem] the exact target base at s=4 is 7/8  (1 - 2^(-3) = 7/8)
-  [PASS][A][conditional] mass-dimension equation d*p=1 has exponent p=1/d  (solutions = [1/d])
-  [PASS][A][conditional] all supplied dimensionless coefficients share zero dimension residual at p=1/d  (cases=24, residual set={Fraction(0, 1)})
-  [PASS][A][boundary] distinct positive dimensionless coefficients remain covariant and give distinct scales  (at |f|=16: values=[2/3, 5])
-  [PASS][A][boundary] finite-kappa p=1/d family extends to M(0)=0 for d>0  (cases=12, values={0})
-  [PASS][A][boundary] a dimensionless thermal coefficient changes the magnitude without changing covariance  (for T=2 and c_4=(1,16), fourth roots=[2, 4])
-  [PASS][A][conditional] fully supplied coefficient, magnitude rule, carrier, and value close the map conditionally  (conditions=['carrier', 'coefficient', 'magnitude_convention', 'value']; M=3)
-  [PASS][A][numerical] high-precision integer sweep supports monotonicity and the unique s=4 hit  (sweep=2..50, hits=[4], g(50)=0.9999999999999999644728632119949597830963019573947234663712291995423064)
-
-----------------------------------------------------------------------------------------
-INDEPENDENT: derivative, rational brackets, and unit covariance
-----------------------------------------------------------------------------------------
-  [PASS][A][theorem] independent derivative is strictly positive on the exact real domain s>1  (formula residual=0; x/(1-x)>0 and -log(1-x)>0 on Interval.open(0, 1); 0<x<1 exactly when s>1)
-  [PASS][A][numerical] derivative samples support but do not carry the real-domain proof  (sampled minimum=1.1093706427202413827662059145992089826883564814040E-32)
-  [PASS][A][numerical] independent rigorous eta/zeta partial-sum brackets contain every exact ratio  (s=2..8, max width=2.261e-05)
-  [PASS][A][theorem] unit-rescaling covariance lambda^(d*p)=lambda vanishes exactly at p=1/d  (covariance residual=(-lambda + lambda**(d*p))/lambda; solved=0)
-  [PASS][A][boundary] a coefficient of mass dimension q changes the exponent outside the stated map class  (q+d*p=1 gives p=[(1 - q)/d])
-  [PASS][A][conditional] exact positive unit rescalings reproduce M -> lambda M for several d and lambda  (residuals={0}, cases=24)
-  [PASS][A][boundary] absolute-value route is real nonnegative where naive signed roots are not magnitudes  ((-16)^(1/4)=2*(-1)**(1/4); |−16|^(1/4)=2; real_root(-8,3)=-2)
-
-----------------------------------------------------------------------------------------
-HOSTILE: reject sign, normalization, domain, and inference overreads
-----------------------------------------------------------------------------------------
-  [PASS][A][boundary] d <= 0 is rejected by the positive mass-dimension theorem domain  (issues=[['invalid_dimension'], ['invalid_dimension'], ['invalid_dimension']])
-  [PASS][A][boundary] p != 1/d produces a nonzero dimension residual  (residual=1/3, issues=['dimension_covariance_failure', 'wrong_exponent'])
-  [PASS][A][boundary] a dimensionful kappa violates the stated dimensionless-coefficient map class  (residual=1/2, issues=['dimension_covariance_failure', 'dimensionful_kappa'])
-  [PASS][A][boundary] negative f with even d rejects the naive real-positive root  (issues=['nonreal_even_root'])
-  [PASS][A][boundary] negative f with odd d has a signed root, not a nonnegative magnitude  (issues=['signed_not_magnitude'], root=-2)
-  [PASS][A][boundary] unit coefficient is rejected when kappa=1 was not supplied  (issues=['unsupplied_coefficient'])
-  [PASS][A][boundary] an alternate coefficient is also rejected when it was not supplied  (issues=['unsupplied_coefficient'])
-  [PASS][A][boundary] a negative coefficient is rejected for a nonnegative magnitude map  (issues=['negative_magnitude_coefficient'])
-  [PASS][A][boundary] the hostile evaluator preserves a challenged exponent instead of hard-coding 1/d  (M=3*3**(1/3))
-  [PASS][A][boundary] singleton witnesses refute every directed implication among the four supplied conditions  (witnesses={'coefficient': ['coefficient'], 'magnitude_convention': ['magnitude_convention'], 'carrier': ['carrier'], 'value': ['value']})
-  [PASS][A][boundary] physical-value inference is rejected without a carrier and value for f  (issues=['unsupported_physical_inference'])
-  [PASS][A][boundary] kappa=0 is covariant for multiple wrong exponents and cannot witness exponent uniqueness  (tested residuals={0}, cases=9)
-
-----------------------------------------------------------------------------------------
-HYGIENE: source metadata, links, and overread guards
-----------------------------------------------------------------------------------------
-  [PASS][B][hygiene] source note has one explicit positive_theorem author hint  (parsed claim types=['positive_theorem'])
-  [PASS][B][hygiene] cross-cycle echoes are provenance-only conventions or a units-only primitive  (Y0/g0 are provenance-only; scale reference is units-only)
-  [PASS][B][hygiene] N1-N8 packet has current-cycle markers, all directed N2 pairs, and concrete N8 paths  (headings=True; N1 attempted=6; N2 directed pairs=12; N8 paths=2)
-  [PASS][B][hygiene] every local markdown link in the source note resolves to a file  (local links=['../scripts/frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.py'])
-  [PASS][B][hygiene] source note contains no bare M=f^(1/d) or unique-map normalization overread  (bare-map hits=0, unique-map hits=0)
-  [PASS][B][hygiene] source rhetoric does not promote coefficient, physical-value, or empirical authority  (hits={'unique_unit_normalization': 0, 'physical_mass_prediction': 0, 'dimensions_select_kappa': 0})
-
-========================================================================================
+mode=all;A-C exact,D exponent-only
+TAGS: thm=theorem cond=conditional num=numerical bnd=boundary hyg=hygiene
+NORMAL
+[PASS][A][thm] exact real domain of the eta/zeta base is 0 < 1-2^(1-s) < 1 for s>1  (positive domain=Interval.open(1, oo); below-one domain=Reals; g(2)=1/sqrt(2); s=4 base -> 7/8)
+[PASS][A][thm] odd/even series split has zero eta/zeta closed-form residual  (residual = 0)
+[PASS][A][thm] Taylor-coefficient comparison has a positive induction certificate  (R_1=s_i + 2; R_(k+1)-2R_k=s_i; decomposition residual=0)
+[PASS][A][thm] log g(s) tends to zero, so g(s) tends to one  (lim log(g) = 0)
+[PASS][A][thm] the exact target base at s=4 is 7/8  (1 - 2^(-3) = 7/8)
+[PASS][A][cond] mass-dimension equation d*p=1 has exponent p=1/d  (solutions = [1/d])
+[PASS][A][cond] all supplied dimensionless coefficients share zero dimension residual at p=1/d  (cases=24, residual set={Fraction(0, 1)})
+[PASS][A][bnd] distinct positive dimensionless coefficients remain covariant and give distinct scales  (at |f|=16: values=[2/3, 5])
+[PASS][A][bnd] finite-kappa p=1/d family extends to M(0)=0 for d>0  (cases=12, values={0})
+[PASS][A][bnd] a dimensionless thermal coefficient changes the magnitude without changing covariance  (for T=2 and c_4=(1,16), fourth roots=[2, 4])
+[PASS][A][cond] fully supplied coefficient, magnitude rule, carrier, and value close the map conditionally  (conditions=['carrier', 'coefficient', 'magnitude_convention', 'value']; M=3)
+[PASS][A][num] high-precision integer sweep supports monotonicity and the unique s=4 hit  (sweep=2..50, hits=[4], g(50)=0.9999999999999999644728632119949597830963019573947234663712291995423064)
+INDEPENDENT
+[PASS][A][thm] independent derivative is strictly positive on the exact real domain s>1  (formula residual=0; x/(1-x)>0 and -log(1-x)>0 on Interval.open(0, 1); 0<x<1 exactly when s>1)
+[PASS][A][num] derivative samples support but do not carry the real-domain proof  (sampled minimum=1.1093706427202413827662059145992089826883564814040E-32)
+[PASS][A][num] independent rigorous eta/zeta partial-sum brackets contain every exact ratio  (s=2..8, max width=2.261e-05)
+[PASS][A][thm] unit-rescaling covariance lambda^(d*p)=lambda vanishes exactly at p=1/d  (covariance residual=(-lambda + lambda**(d*p))/lambda; solved=0)
+[PASS][A][bnd] a coefficient of mass dimension q changes the exponent outside the stated map class  (q+d*p=1 gives p=[(1 - q)/d])
+[PASS][A][cond] exact positive unit rescalings reproduce M -> lambda M for several d and lambda  (residuals={0}, cases=24)
+[PASS][A][bnd] absolute-value route is real nonnegative where naive signed roots are not magnitudes  ((-16)^(1/4)=2*(-1)**(1/4); |−16|^(1/4)=2; real_root(-8,3)=-2)
+HOSTILE
+[PASS][A][bnd] d <= 0 is rejected by the positive mass-dimension theorem domain  (issues=[['invalid_dimension'], ['invalid_dimension'], ['invalid_dimension']])
+[PASS][A][bnd] p != 1/d produces a nonzero dimension residual  (residual=1/3, issues=['dimension_covariance_failure', 'wrong_exponent'])
+[PASS][A][bnd] a dimensionful kappa violates the stated dimensionless-coefficient map class  (residual=1/2, issues=['dimension_covariance_failure', 'dimensionful_kappa'])
+[PASS][A][bnd] negative f with even d rejects the naive real-positive root  (issues=['nonreal_even_root'])
+[PASS][A][bnd] negative f with odd d has a signed root, not a nonnegative magnitude  (issues=['signed_not_magnitude'], root=-2)
+[PASS][A][bnd] unit coefficient is rejected when kappa=1 was not supplied  (issues=['unsupplied_coefficient'])
+[PASS][A][bnd] an alternate coefficient is also rejected when it was not supplied  (issues=['unsupplied_coefficient'])
+[PASS][A][bnd] a negative coefficient is rejected for a nonnegative magnitude map  (issues=['negative_magnitude_coefficient'])
+[PASS][A][bnd] the hostile evaluator preserves a challenged exponent instead of hard-coding 1/d  (M=3*3**(1/3))
+[PASS][A][bnd] singleton witnesses refute every directed implication among the four supplied conditions  (witnesses={'coefficient': ['coefficient'], 'magnitude_convention': ['magnitude_convention'], 'carrier': ['carrier'], 'value': ['value']})
+[PASS][A][bnd] physical-value inference is rejected without a carrier and value for f  (issues=['unsupported_physical_inference'])
+[PASS][A][bnd] kappa=0 is covariant for multiple wrong exponents and cannot witness exponent uniqueness  (tested residuals={0}, cases=9)
+HYGIENE
+[PASS][B][hyg] source note has one explicit positive_theorem author hint  (parsed claim types=['positive_theorem'])
+[PASS][B][hyg] cross-cycle echoes are provenance-only conventions or a units-only primitive  (Y0/g0 are provenance-only; scale reference is units-only)
+[PASS][B][hyg] N1-N8 packet has current-cycle markers, all directed N2 pairs, and concrete N8 paths  (headings=True; N1 attempted=6; N2 directed pairs=12; N8 paths=2)
+[PASS][B][hyg] every local markdown link in the source note resolves to a file  (local links=['../scripts/frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.py'])
+[PASS][B][hyg] source note contains no bare M=f^(1/d) or unique-map normalization overread  (bare-map hits=0, unique-map hits=0)
+[PASS][B][hyg] source rhetoric does not promote coefficient, physical-value, or empirical authority  (hits={'unique_unit_normalization': 0, 'physical_mass_prediction': 0, 'dimensions_select_kappa': 0})
 EVIDENCE: theorem=7 conditional=4 numerical=3 boundary=17 hygiene=6
 CLASSES: A=31 B=6 C=0 D=0
 MODES: hostile=12 hygiene=6 independent=7 normal=12
 SUMMARY: PASS=37 FAIL=0
-========================================================================================
 
 ----- stderr -----
 

--- a/scripts/frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.py
+++ b/scripts/frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.py
@@ -60,6 +60,17 @@ EVIDENCE_COUNTS: Counter[str] = Counter()
 CLASS_COUNTS: Counter[str] = Counter()
 MODE_COUNTS: Counter[str] = Counter()
 
+# Per-check evidence tags are abbreviated on the printed line and expanded by the
+# TAGS legend below the mode banner; the EVIDENCE summary still names them in full.
+# An unmapped tag prints unabbreviated rather than being dropped.
+EVIDENCE_TAGS = {
+    "theorem": "thm",
+    "conditional": "cond",
+    "numerical": "num",
+    "boundary": "bnd",
+    "hygiene": "hyg",
+}
+
 
 def check(
     mode: str,
@@ -82,12 +93,12 @@ def check(
     else:
         FAIL_COUNT += 1
     suffix = f"  ({detail})" if detail else ""
-    print(f"  [{tag}][{klass}][{evidence}] {label}{suffix}")
+    print(f"[{tag}][{klass}][{EVIDENCE_TAGS.get(evidence, evidence)}] {label}{suffix}")
     return ok
 
 
 def section(title: str) -> None:
-    print(f"\n{'-' * 88}\n{title}\n{'-' * 88}")
+    print(title)
 
 
 def closed_ratio(s: int) -> Fraction:
@@ -185,7 +196,7 @@ class ScaleMapCase:
 
 def normal_mode() -> None:
     mode = "normal"
-    section("NORMAL: exact theorem and conditional-map reconstruction")
+    section("NORMAL")
 
     s = sp.symbols("s", real=True)
     closed_base = 1 - sp.Pow(2, 1 - s)
@@ -372,7 +383,7 @@ def normal_mode() -> None:
 
 def independent_mode() -> None:
     mode = "independent"
-    section("INDEPENDENT: derivative, rational brackets, and unit covariance")
+    section("INDEPENDENT")
 
     s = sp.symbols("s", real=True)
     x = sp.Pow(2, 1 - s)
@@ -489,7 +500,7 @@ def independent_mode() -> None:
 
 def hostile_mode() -> None:
     mode = "hostile"
-    section("HOSTILE: reject sign, normalization, domain, and inference overreads")
+    section("HOSTILE")
 
     invalid_dimensions = [
         ScaleMapCase(d=d0, p=Fraction(1, 4)) for d0 in (0, -1, -4)
@@ -705,7 +716,7 @@ def hostile_mode() -> None:
 
 def hygiene_mode() -> None:
     mode = "hygiene"
-    section("HYGIENE: source metadata, links, and overread guards")
+    section("HYGIENE")
 
     note_text = NOTE_PATH.read_text(encoding="utf-8") if NOTE_PATH.exists() else ""
     claim_types = re.findall(
@@ -844,11 +855,8 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    print("=" * 88)
-    print("frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow.py")
-    print(f"mode={args.mode}")
-    print("exact A-C theorem; exponent-only D with supplied kappa/sign boundary")
-    print("=" * 88)
+    print(f"mode={args.mode};A-C exact,D exponent-only")
+    print("TAGS: " + " ".join(f"{v}={k}" for k, v in EVIDENCE_TAGS.items()))
 
     if args.mode in ("normal", "all"):
         normal_mode()
@@ -858,7 +866,6 @@ def main() -> int:
         hostile_mode()
     hygiene_mode()
 
-    print(f"\n{'=' * 88}")
     print(
         "EVIDENCE: "
         + " ".join(
@@ -872,7 +879,6 @@ def main() -> int:
     )
     print("MODES: " + " ".join(f"{name}={count}" for name, count in sorted(MODE_COUNTS.items())))
     print(f"SUMMARY: PASS={PASS_COUNT} FAIL={FAIL_COUNT}")
-    print("=" * 88)
     return 0 if FAIL_COUNT == 0 else 1
 
 


### PR DESCRIPTION
## Obligation

Ledger row `hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow_theorem_note_2026-05-10`
(`audited_conditional`) carries this artifact-issue obligation, quoted verbatim:

> runner_artifact_issue: provide unclipped SHA-pinned stdout covering every load-bearing execution in all runner modes, or an equivalent complete current-cycle certificate, then repeat the restricted audit.

## Why the packet was incomplete

`cache_excerpt_for_audit()` in `scripts/runner_cache.py` builds the audit packet as

    clipped = len(body) > tail_chars          # tail_chars = 6000
    excerpt = body[-tail_chars:] if clipped else body

It keeps the **last** 6000 characters of the cache file and discards everything before
them. The loss is at the **head**, not the tail.

This runner's cache was **7,404 chars**, so the first **1,404** never reached the auditor.
Measured against the stored pre-edit cache, the clip removed:

- the complete cache header block (`runner_sha256` `c64afa65…`, `timeout_sec`,
  `exit_code`, `elapsed_sec: 0.40`, `status`). Only the 12-character sha prefix that the
  excerpt builder re-prepends survived, so the obligation's *SHA-pinned* requirement was
  met only in truncated form;
- the opening banner — the runner filename, the scope line
  `exact A-C theorem; exponent-only D with supplied kappa/sign boundary`, and **the
  `mode=all` line**. That line is what certifies the run covered *all runner modes*, the
  second thing the obligation names, and it was outside the packet;
- the `NORMAL: exact theorem and conditional-map reconstruction` section banner and
  **five of the thirty-eight verdict lines** (four complete, one cut by the boundary,
  which opened on the fragment `  [PASS][A][theorem] the exact target bas`). The four
  fully-lost checks are all `[A][theorem]`: the exact real domain of the eta/zeta base,
  the odd/even series-split residual, the Taylor-coefficient induction certificate, and
  `log g(s) → 0`.

So both halves of what this obligation asks for were destroyed by the clip: the mode
coverage statement, and four of the seven exact-theorem checks that make the A-C claim
load-bearing.

## What changed

The runner's own printing, and nothing else:

- the `"-" * 88` rules around section titles dropped, and the mode banners compressed to
  their bare titles: `NORMAL`, `INDEPENDENT`, `HOSTILE`, `HYGIENE`. All four are present —
  the rule is applied uniformly, none removed;
- the opening banner's `"=" * 88` rules and three separate lines folded into one:
  `mode=all;A-C exact,D exponent-only`;
- per-check evidence tags abbreviated on the printed line (`theorem` → `thm`,
  `conditional` → `cond`, `numerical` → `num`, `boundary` → `bnd`, `hygiene` → `hyg`) and
  the check line dedented by two spaces. **A `TAGS:` legend line printed under the banner
  gives every expansion**, the `EVIDENCE` summary still names the classes in full, and the
  mapping is a `dict.get(evidence, evidence)` — an unmapped tag prints unabbreviated
  rather than silently disappearing.

No check was added, removed, reordered or weakened; no tolerance changed; no printed
number altered.

Cache: **7,404 → 5,820 chars** (5,822 bytes — the file contains one Unicode minus sign;
the ceiling compares decoded character length, not bytes), leaving 180 of headroom.

## Verification

Tag abbreviation breaks byte-identity of the verdict lines by construction, so each
rewrite is **declared** to the verifier and applied to the pre-edit text before comparison.
Anything not explained by a declared rewrite still fails, and a rewrite matching nothing
is itself a failure.

    runner        : frontier_hierarchy_joint_riemann_dirichlet_dimensional_fourth_root_narrow
    baseline      : stored cache snapshot
    declared subst: '  [PASS][A][boundary' => '[PASS][A][bnd'   (17 occurrence(s) in PRE)
    declared subst: '  [PASS][A][theore' => '[PASS][A][th'   (7 occurrence(s) in PRE)
    declared subst: '  [PASS][B][hygiene' => '[PASS][B][hyg'   (6 occurrence(s) in PRE)
    declared subst: '  [PASS][A][conditional' => '[PASS][A][cond'   (4 occurrence(s) in PRE)
    declared subst: '  [PASS][A][numerical' => '[PASS][A][num'   (3 occurrence(s) in PRE)
    cache bytes   : 7404 -> 5820  (ceiling 6000, headroom 180)
    numeric values: 26 -> 26  lost=0 new=0
    verdict lines : 38 -> 38  identical=True

    RESULT: PASS  (every printed value survives; verdicts byte-identical)

The declared occurrence counts carry their own check: 17 + 7 + 6 + 4 + 3 = 37, exactly the
runner's check count, with the 38th verdict line being the summary. Every check line is
therefore accounted for by a declared rewrite — none slipped through unexplained.

## Scope

Two files — the runner and its cache. No note is touched, so no note hash moves and no
dependent's audit is invalidated. This runner is `runner_path` for exactly this one ledger
row and appears in no row's `helper_runner_paths`, checked across all 3,879 ledger shards.
The runner reads its own note plus `docs/SCALE_REFERENCE_PRIMITIVE_NOTE.md` and
`docs/audit/data/premise_decision_history.json` for its hygiene-mode checks; none of those
files is modified here, and the hygiene checks pass unchanged.

This PR sets no status. Whether the re-rendered packet discharges the obligation is for
the independent audit lane to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
