### PR TITLE
fix(hygiene-convention): repair stale-green hygiene runner with drift-tolerant state checks

### DIFF
--- a/docs/RUNNER_LEDGER_FIELD_PIN_HYGIENE_CONVENTION_PROPOSAL_NOTE_2026-07-02.md
+++ b/docs/RUNNER_LEDGER_FIELD_PIN_HYGIENE_CONVENTION_PROPOSAL_NOTE_2026-07-02.md
@@ -28,7 +28,7 @@ construction, silently, behind a green cache:
 
 - **Field-content pins.** Runners asserting the verbatim content of
   audit-authored row fields (`load_bearing_step`, `load_bearing_step_class`,
-  verdict/rationale text). Instances on live `main` at proposal time:
+  verdict/rationale text). Instances named from the proposal-time sweep:
   - `scripts/frontier_thales_right_angle_narrow.py`
   - `scripts/frontier_half_plane_chart_equivalence_narrow.py`
   - `scripts/frontier_ckm_magnitudes_structural_counts_narrow.py`
@@ -36,6 +36,20 @@ construction, silently, behind a green cache:
   (each reads `docs/audit/data/audit_ledger.json` and asserts
   `load_bearing_step_class == 'A'` for its parent row; all four failed the
   sweep after audit-side field updates while their rows remained retained).
+
+  A 2026-07-24 re-measurement of the same pattern over `scripts/` finds nine
+  runners carrying it, so the proposal-time list named four of nine. The other
+  five follow the identical shape — read the ledger, assert
+  `load_bearing_step_class == 'A'` for their own parent row:
+  - `scripts/audit_companion_ckm_bernoulli_two_ninths_exact.py`
+  - `scripts/audit_companion_dm_neutrino_cascade_geometry_exact.py`
+  - `scripts/audit_companion_dm_neutrino_z3_character_exact.py`
+  - `scripts/audit_companion_dm_neutrino_z3_circulant_nogo_exact.py`
+  - `scripts/audit_companion_g_bare_forced_by_ward_rep_b_record_axiom_invariance_2026_06_04.py`
+
+  Checked against the repo state at the end of 2026-07-02 (commit
+  `952647de06`), all nine already carried the pin then: the class did not grow
+  after the proposal, the proposal-time listing was a partial selection from it.
 - **Exact-tier / exact-state status pins.** Runners asserting one exact
   status string, including non-retained transition states. Instance:
   `scripts/frontier_observable_principle_p1_bridge_extensivity_primitive.py`
@@ -75,9 +89,23 @@ construction, silently, behind a green cache:
   when it runs red, that is the freshness contract working during a
   dependency's transition window, not a defect.
 - `scripts/staggered_dirac_substep1_statistics_selection_check_2026_06_10.py`
-  is the documented tier-exact case: its packet expectation
-  (`== "retained_bounded"`) is stated in its note, i.e. the (H2) exception
-  path with justification.
+  was named here on 2026-07-02 as the tier-exact case, its packet expectation
+  being `== "retained_bounded"`. That runner was rewritten on 2026-07-16
+  (commit `03ca2d51f4`), which removed its ledger reads entirely: it now
+  asserts no status at all, so it is (H1)/(H2)-compliant by containing no pin
+  rather than by taking the exception path. No live runner is named here as an
+  exception-path exemplar. The (H2) exception is a clause of the convention,
+  not a claim about the current contents of `scripts/`; a runner takes it by
+  pinning one tier with its own note saying why, and the audit lane judges
+  that pairing when such a row is reviewed.
+
+  This bullet is also the note's own worked example of §1. From that rewrite
+  until this repair the paired runner asserted the pre-rewrite literal and
+  failed on live execution while its cached output stayed green — a runner
+  pinning another file's internal text goes stale by construction in exactly
+  the way a runner pinning ledger-field content does. The checks below are
+  written to accept either documented state of a named instance rather than
+  freezing the one that happened to hold when the note was written.
 - `scripts/audit_companion_dirac_weyl_fermion_dof_from_lorentz_and_chirality_2026_05_28.py`
   was realigned to the membership form in the 2026-07-02 repair wave after
   its `{"retained"}`-only pin went stale against a retained-grade tier move.
@@ -85,7 +113,7 @@ construction, silently, behind a green cache:
 ## 4. Remediation path (proposed, not executed here)
 
 If this convention is adopted, the named Section-1 instances get narrowed in
-follow-up repair PRs: the four field-content pins move their
+follow-up repair PRs: the field-content pins move their
 `load_bearing_step_class` assertions to report-only prints, and the
 exact-state pins in the extensivity runner become either retained-grade
 membership checks or note-documented justified exceptions. This note edits
@@ -99,9 +127,14 @@ no runner and proposes no wording for those rows' notes.
   audit-lane data; does not modify any named runner.
 - Adoption authority is the independent audit lane; a question to the owner
   or a landed PR is not adoption.
-- The named-instance lists describe live `main` at proposal time and are
-  verified by the paired runner; they are illustrative of the class, not an
-  enumeration bound on it (the runner prints the current census).
+- The named-instance lists describe the proposal-time sweep plus the
+  2026-07-24 re-measurement, and are verified by the paired runner; they are
+  illustrative of the class, not an enumeration bound on it (the runner prints
+  the current census size). A name appearing here is not a claim that the
+  instance is still unrepaired: the runner accepts a named instance in either
+  documented state — still pinning, or narrowed per §4 — and fails only if the
+  file stops handling the field, so a §4 repair landing in a later PR does not
+  require an edit to this note.
 
 ## 6. Command and expected output
 

--- a/logs/runner-cache/runner_ledger_field_pin_hygiene_convention_check_2026_07_02.txt
+++ b/logs/runner-cache/runner_ledger_field_pin_hygiene_convention_check_2026_07_02.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/runner_ledger_field_pin_hygiene_convention_check_2026_07_02.py
-runner_sha256: b4907705e4177adc591d6719f48c738e935f077a9cbfe63e4ab95b9798348e3f
+runner_sha256: 1128a6baa1853ef1969add9a93db8d3f54c8ad463984f30443a1ac6a8918524c
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.73
+elapsed_sec: 1.03
 status: ok
 ----- stdout -----
 runner ledger-field pin hygiene convention check (2026-07-02)
@@ -17,64 +17,23 @@ runner ledger-field pin hygiene convention check (2026-07-02)
 [NOTE] PASS: note contains: (H4) Ledger-census snapshots need a maintenance pattern
 [NOTE] PASS: note contains: Sets, promotes, or changes **no** row's effective status
 [NOTE] PASS: note contains: a question to the owner
-[C1] PASS: named field-content pin present in scripts/frontier_thales_right_angle_narrow.py
-[C1] PASS: note names the instance scripts/frontier_thales_right_angle_narrow.py
-[C1] PASS: named field-content pin present in scripts/frontier_half_plane_chart_equivalence_narrow.py
-[C1] PASS: note names the instance scripts/frontier_half_plane_chart_equivalence_narrow.py
-[C1] PASS: named field-content pin present in scripts/frontier_ckm_magnitudes_structural_counts_narrow.py
-[C1] PASS: note names the instance scripts/frontier_ckm_magnitudes_structural_counts_narrow.py
-[C1] PASS: named field-content pin present in scripts/frontier_z3_conjugate_support_trichotomy_narrow.py
-[C1] PASS: note names the instance scripts/frontier_z3_conjugate_support_trichotomy_narrow.py
-[C2] PASS: extensivity runner pins an exact open_gate state
-[C2] PASS: extensivity runner pins an exact audited_conditional state
-[C2] PASS: note names the exact-state instance
+[C1] PASS: frontier_thales_right_angle_narrow.py  (pins)
+[C1] PASS: frontier_half_plane_chart_equivalence_narrow.py  (pins)
+[C1] PASS: frontier_ckm_magnitudes_structural_counts_narrow.py  (pins)
+[C1] PASS: frontier_z3_conjugate_support_trichotomy_narrow.py  (pins)
+[C1] PASS: audit_companion_ckm_bernoulli_two_ninths_exact.py  (pins)
+[C1] PASS: audit_companion_dm_neutrino_cascade_geometry_exact.py  (pins)
+[C1] PASS: audit_companion_dm_neutrino_z3_character_exact.py  (pins)
+[C1] PASS: audit_companion_dm_neutrino_z3_circulant_nogo_exact.py  (pins)
+[C1] PASS: audit_companion_g_bare_forced_by_ward_rep_b_record_axiom_invariance_2026_06_04.py  (pins)
+  C1 states: {'pins': 9}
+[C2] PASS: extensivity runner state + named in note  (exact-state pins, as named in 2026-07-02)
 [EX] PASS: lh_doublet companion uses the retained-grade membership set
-[EX] PASS: GL(F) selection check is the documented tier-exact case
+[EX] PASS: staggered substep-1 check is in a state the note records  (no ledger read (repaired 2026-07-16))
 [EX] PASS: dirac_weyl companion carries the realigned retained-grade set
-  census: 89 ledger-reading scripts with equality-pin patterns (context, not pinned)
-    - scripts/audit_companion_ckm_bernoulli_two_ninths_exact.py
-    - scripts/audit_companion_dirac_weyl_fermion_dof_from_lorentz_and_chirality_2026_05_28.py
-    - scripts/audit_companion_dm_neutrino_cascade_geometry_exact.py
-    - scripts/audit_companion_dm_neutrino_dirac_bridge_exact.py
-    - scripts/audit_companion_dm_neutrino_odd_circulant_zero_law_exact.py
-    - scripts/audit_companion_dm_neutrino_z3_character_exact.py
-    - scripts/audit_companion_dm_neutrino_z3_circulant_nogo_exact.py
-    - scripts/audit_companion_dm_selector_first_shoulder_exit_threshold_support_criticality_hygiene_2026_06_04.py
-    - scripts/audit_companion_g_bare_forced_by_ward_rep_b_record_axiom_invariance_2026_06_04.py
-    - scripts/audit_companion_gauge_vacuum_plaquette_residual_environment_all_weight_convolution_identification.py
-    - scripts/audit_companion_higgs_lattice_taste_count_wj_form_2026_06_05.py
-    - scripts/audit_companion_hubble_lane5_c1_a2_action_unit_metrology_obstruction_hygiene_2026_06_04.py
-    - scripts/audit_companion_teleportation_resource_from_poisson_criticality_bump_hygiene_2026_06_04.py
-    - scripts/audit_companion_yt_schur_stability_gap_criticality_hygiene_2026_06_04.py
-    - scripts/audit_companion_yt_ward_identity_dependencies_registered_bound_2026_06_05.py
-    - scripts/axiom_first_reflection_positivity_wilson_temporal_reroute_2026_06_08.py
-    - scripts/codex_audit_runner.py
-    - scripts/fixed_gbare_interacting_existence_ir_target_reframing_2026_06_08.py
-    - scripts/flavor_asymmetry_identification_principled_not_forced_2026_05_31.py
-    - scripts/flavor_center_trace_closed_2026_05_30.py
-    - scripts/flavor_emergent_chirality_no_transport_2026_05_30.py
-    - scripts/flavor_frontier_form_vs_value_2026_05_29.py
-    - scripts/flavor_gauge_representation_generation_uniform_core_2026_06_18.py
-    - scripts/flavor_generation_space_bridge_reduces_to_open_gate_2026_05_31.py
-    - scripts/flavor_lane_panel_reduces_to_doublet_mode_count_2026_05_31.py
-    - scripts/flavor_zdet_fermionic_statistics_admission_2026_06_04.py
-    - scripts/fractional_instanton_action_core_split_2026_06_18.py
-    - scripts/frontier_ckm_magnitudes_structural_counts_narrow.py
-    - scripts/frontier_claude_complex_action_grown_companion_terminal_synthesis.py
-    - scripts/frontier_d3_lower_bound_source_packet_gate_2026_06_06.py
-    - scripts/frontier_finite_rank_source_to_metric_theorem.py
-    - scripts/frontier_gravity_fixed_energy_eikonal_index_bridge_2026_06_16.py
-    - scripts/frontier_gravity_premise4_refractive_index_from_dispersion.py
-    - scripts/frontier_gravity_scalar_shift_sign_normalization_2026_06_18.py
-    - scripts/frontier_half_plane_chart_equivalence_narrow.py
-    - scripts/frontier_hierarchy_b3_staggered_supplier_cascade_2026_06_17.py
-    - scripts/frontier_koide_aps_block_by_block_forcing.py
-    - scripts/frontier_koide_cyclic_wilson_3_response_narrow.py
-    - scripts/frontier_koide_dimensionless_objection_closure_review.py
-    - scripts/frontier_observable_principle_p1_bridge_extensivity_primitive.py
-    ... and 49 more
-[CEN] PASS: every named instance appears in the live census
-TOTAL: PASS=25 FAIL=0
+  census: 79 ledger-reading scripts with equality-pin patterns; 9 carry the load_bearing_step_class field pin (context, not pinned)
+[CEN] PASS: every named instance accounted for (in census, or narrowed on disk)
+TOTAL: PASS=24 FAIL=0
 
 ----- stderr -----
 

--- a/scripts/runner_ledger_field_pin_hygiene_convention_check_2026_07_02.py
+++ b/scripts/runner_ledger_field_pin_hygiene_convention_check_2026_07_02.py
@@ -3,16 +3,23 @@
 
 Verifies (text checks only, no verdicts):
   [NOTE] the note carries the proposal disclaimers and the H1-H4 clauses;
-  [C1]   the four named field-content-pin instances currently contain the
-         described pin pattern (reads audit_ledger.json AND asserts
-         load_bearing_step_class equality);
-  [C2]   the named exact-state-pin instance currently asserts the exact
-         status strings the note describes;
-  [EX]   the named compliant exemplars currently use the membership form /
-         documented tier-exact form;
-  [CEN]  a census scan of scripts/ for ledger-reading runners with equality
-         pins contains the named instances (census printed as context; the
-         count itself is NOT pinned, per the note's own H4).
+  [C1]   each named field-content-pin instance is in a state the note
+         documents -- still pinning (reads the ledger AND asserts
+         load_bearing_step_class equality), or narrowed per section 4 to a
+         report-only read;
+  [C2]   the named exact-state-pin instance is likewise in a documented
+         state (exact-state pins, or narrowed);
+  [EX]   the named compliant exemplars are in a state the note records;
+  [CEN]  every named instance is accounted for against a live census scan of
+         scripts/ (census printed as context; the count itself is NOT pinned,
+         per the note's own H4).
+
+The C1/C2/EX checks assert documented STATES rather than one frozen literal:
+a runner pinning another file's current text goes stale by construction in
+exactly the way the note says a ledger-field pin does -- which is how the
+2026-07-02 tier-exact exemplar pin died when that file was rewritten on
+2026-07-16. Accepting either documented state also keeps this runner from
+freezing the named instances against section 4's own remediation path.
 
 Deterministic, no randomness, seconds. Exits non-zero on any FAIL.
 """
@@ -50,10 +57,17 @@ def src(rel: str) -> str:
 
 
 C1_INSTANCES = [
+    # named from the proposal-time sweep
     "scripts/frontier_thales_right_angle_narrow.py",
     "scripts/frontier_half_plane_chart_equivalence_narrow.py",
     "scripts/frontier_ckm_magnitudes_structural_counts_narrow.py",
     "scripts/frontier_z3_conjugate_support_trichotomy_narrow.py",
+    # added by the 2026-07-24 re-measurement of the same pattern
+    "scripts/audit_companion_ckm_bernoulli_two_ninths_exact.py",
+    "scripts/audit_companion_dm_neutrino_cascade_geometry_exact.py",
+    "scripts/audit_companion_dm_neutrino_z3_character_exact.py",
+    "scripts/audit_companion_dm_neutrino_z3_circulant_nogo_exact.py",
+    "scripts/audit_companion_g_bare_forced_by_ward_rep_b_record_axiom_invariance_2026_06_04.py",
 ]
 C2_INSTANCE = "scripts/frontier_observable_principle_p1_bridge_extensivity_primitive.py"
 EX_MEMBERSHIP = "scripts/audit_companion_lh_doublet_partition_ratio_inverse_uniqueness_exact_2026_05_17.py"
@@ -61,6 +75,7 @@ EX_TIER_EXACT = "scripts/staggered_dirac_substep1_statistics_selection_check_202
 EX_REALIGNED = "scripts/audit_companion_dirac_weyl_fermion_dof_from_lorentz_and_chirality_2026_05_28.py"
 
 READS_LEDGER = re.compile(r"audit_ledger\.json|ledger_status")
+FIELD_PIN = re.compile(r"load_bearing_step_class.\)\s*==\s*.A.")
 EQ_PIN = re.compile(
     r"""load_bearing_step_class\s*.\s*\)?\s*==   # field-content equality
       | ==\s*["'](?:retained|retained_bounded|retained_no_go
@@ -91,41 +106,74 @@ def main() -> int:
         check("NOTE", f"note contains: {phrase.splitlines()[0]}",
               re.search(r"\s+".join(re.escape(w) for w in phrase.split()), note) is not None)
 
-    # [C1] the four named field-content-pin instances
+    # [C1] named field-content-pin instances, in either documented state.
+    # Per the note's section 4 these get narrowed to report-only prints in
+    # follow-up repair PRs, so pinning "still pins" here would freeze the class
+    # against its own remediation path. Passing states: "pins" (as described)
+    # and "narrowed" (field read, no equality pin). A file that vanished, or
+    # that stopped handling the field entirely, is not a documented state.
+    states = {}
     for rel in C1_INSTANCES:
         text = src(rel)
-        ok = (
-            bool(text)
-            and READS_LEDGER.search(text) is not None
-            and "load_bearing_step_class" in text
-            and re.search(r"load_bearing_step_class.\)\s*==\s*.A.", text) is not None
-        )
-        check("C1", f"named field-content pin present in {rel}", ok)
-        check("C1", f"note names the instance {rel}", rel.split("/")[-1] in note)
+        base = rel.split("/")[-1]
+        if not text:
+            state = "gone"
+        elif FIELD_PIN.search(text) and READS_LEDGER.search(text):
+            state = "pins"
+        elif "load_bearing_step_class" in text:
+            state = "narrowed"
+        else:
+            state = "unhandled"
+        states[rel] = state
+        named = base in note
+        why = state if state in ("pins", "narrowed") else f"UNDOCUMENTED STATE {state}"
+        if not named:
+            why += "; NOT NAMED IN NOTE"
+        check("C1", base, state in ("pins", "narrowed") and named, why)
+    tally = {s: sum(1 for v in states.values() if v == s) for s in sorted(set(states.values()))}
+    print(f"  C1 states: {tally}")
 
-    # [C2] the named exact-state-pin instance
+    # [C2] the named exact-state-pin instance, in either documented state
+    # (section 4 narrows it to membership checks or a justified exception).
     text = src(C2_INSTANCE)
-    check("C2", "extensivity runner pins an exact open_gate state",
-          '== "open_gate"' in text and READS_LEDGER.search(text) is not None)
-    check("C2", "extensivity runner pins an exact audited_conditional state",
-          '== "audited_conditional"' in text)
-    check("C2", "note names the exact-state instance",
-          C2_INSTANCE.split("/")[-1] in note)
+    if not text:
+        c2_state = "gone"
+    elif '== "open_gate"' in text or '== "audited_conditional"' in text:
+        c2_state = "exact-state pins, as named in 2026-07-02"
+    else:
+        c2_state = "narrowed (no exact non-retained pin)"
+    check("C2", "extensivity runner state + named in note",
+          c2_state != "gone" and C2_INSTANCE.split("/")[-1] in note, c2_state)
 
     # [EX] compliant exemplars
     text = src(EX_MEMBERSHIP)
     check("EX", "lh_doublet companion uses the retained-grade membership set",
           'retained_grades = {"retained", "retained_bounded", "retained_no_go"}' in text
           and "in retained_grades" in text)
+    # The 2026-07-02 tier-exact exemplar was rewritten on 2026-07-16 and its
+    # ledger reads removed, so the note records both states rather than the
+    # literal that happened to hold when it was written.
     text = src(EX_TIER_EXACT)
-    check("EX", "GL(F) selection check is the documented tier-exact case",
-          '== "retained_bounded"' in text)
+    if not text:
+        state = "gone"
+    elif '== "retained_bounded"' in text:
+        state = "tier-exact pin, as named in 2026-07-02"
+    elif READS_LEDGER.search(text) is None:
+        state = "no ledger read (repaired 2026-07-16)"
+    else:
+        state = "UNDOCUMENTED: reads ledger, no tier-exact pin"
+    check("EX", "staggered substep-1 check is in a state the note records",
+          state.startswith(("tier-exact", "no ledger")), state)
     text = src(EX_REALIGNED)
     check("EX", "dirac_weyl companion carries the realigned retained-grade set",
           '"retained_bounded"' in text and '"retained"' in text)
 
-    # [CEN] census: ledger-reading scripts with equality pins (context print)
+    # [CEN] census: ledger-reading scripts with equality pins (context print).
+    # Per (H4) the count is printed, never pinned. The per-file listing is
+    # omitted: the C1 inventory above names the field-content-pin members,
+    # which is the subpopulation the note's section 1 is about.
     census = []
+    field_pins = 0
     for p in sorted((ROOT / "scripts").glob("*.py")):
         if p.name == Path(__file__).name:
             continue
@@ -135,15 +183,17 @@ def main() -> int:
             continue
         if READS_LEDGER.search(text) and EQ_PIN.search(text):
             census.append(f"scripts/{p.name}")
-    print(f"  census: {len(census)} ledger-reading scripts with equality-pin patterns (context, not pinned)")
-    for rel in census[:40]:
-        print(f"    - {rel}")
-    if len(census) > 40:
-        print(f"    ... and {len(census) - 40} more")
-    named = set(C1_INSTANCES) | {C2_INSTANCE}
-    missing = sorted(named - set(census))
-    check("CEN", "every named instance appears in the live census",
-          not missing, "missing: " + ", ".join(missing) if missing else "")
+            if FIELD_PIN.search(text):
+                field_pins += 1
+    print(f"  census: {len(census)} ledger-reading scripts with equality-pin patterns; "
+          f"{field_pins} carry the load_bearing_step_class field pin (context, not pinned)")
+    # A named instance LEAVES this census when section 4 narrows it, so the
+    # invariant is accounted-for, not present: either still in the census, or
+    # still on disk with the pin removed. Only a vanished file is unaccounted.
+    unaccounted = sorted(rel for rel in set(C1_INSTANCES) | {C2_INSTANCE}
+                         if rel not in census and not src(rel))
+    check("CEN", "every named instance accounted for (in census, or narrowed on disk)",
+          not unaccounted, "unaccounted: " + ", ".join(unaccounted) if unaccounted else "")
 
     print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
     return 0 if FAIL == 0 else 1


### PR DESCRIPTION
## What this responds to

The paired runner for `RUNNER_LEDGER_FIELD_PIN_HYGIENE_CONVENTION_PROPOSAL_NOTE_2026-07-02.md` has been failing on live execution behind a green cache.

| | live run (pre-repair) | committed cache |
|---|---|---|
| exit | 1 | 0 |
| totals | `PASS=24 FAIL=1` | `PASS=25 FAIL=0` |

The failing check was `[EX] GL(F) selection check is the documented tier-exact case`.

## Root cause

The note's own subject matter, turned on itself. The `[EX]` tier-exact exemplar asserted the literal text of `scripts/staggered_dirac_substep1_statistics_selection_check_2026_06_10.py`. Commit `03ca2d51f4` (2026-07-16) rewrote that file and removed its ledger reads — measured: 7 matching `audit_ledger.json` / `ledger_status` / `== "retained_bounded"` lines at `03ca2d51f4^`, 0 after. A runner pinning another file's internal text goes stale by construction in exactly the way the note says a ledger-field pin does.

## What changed (source-only triple: 1 note + 1 runner + 1 cache)

**Not a repoint.** Repointing `EX` at a different currently-compliant file would recreate the identical defect. The checks now classify a documented *state*:

- **`[EX]`** accepts either state the note now records for that exemplar — the 2026-07-02 tier-exact pin, or the post-rewrite no-ledger-read form. It rejects a file that reads the ledger with no tier pin, or that has vanished.
- **`[C1]`/`[C2]`** carried the same freeze defect in a second form: they pinned *"still pins"*, so any §4 remediation PR would have turned this runner red. Both now accept either documented state (`pins`, or `narrowed` per §4). This **decouples downstream repair PRs from this note**, which is what preserves the source-only triple rule for them.
- **§1 field-content-pin list widened from four to nine.** A 2026-07-24 rescan of `scripts/` finds nine runners carrying the pattern. All nine already carried the pin at the end of 2026-07-02 (commit `952647de06`), so this is the proposal-time listing having been a partial selection — consistent with the note's own "illustrative of the class, not an enumeration bound" hedge. **This is not class growth and not an error in the note.**
- **Census listing → count.** The 40-line per-file listing is replaced by a count plus the C1 inventory. Per (H4) the count is printed, never pinned.

## Verification

- Runner: exit 0, `TOTAL: PASS=24 FAIL=0` (NOTE 10 + C1 9 + C2 1 + EX 3 + CEN 1).
- Live states: all nine C1 = `pins`; C2 = exact-state pins as named; EX = no ledger read; census = 79 ledger-reading scripts with equality-pin patterns, 9 carrying the field pin.
- **Ten discriminating-gate controls, 10/10 discriminate**, clean post-restore re-run. Two are positive controls and are the load-bearing ones: `C1` and `C2` must *accept* the §4 narrowed state, since that is exactly what downstream repair PRs will produce. Eight negative: unhandled / gone / not-named-in-note / CEN-unaccounted / EX-undocumented / EX-gone / C2-gone / dropped-H-clause must all reject.

## Blast radius

Zero. Sibling grep finds no runner reading this note. The ledger shard records `effective_status = meta`, `transitive_descendants = 0`, `helper_runner_paths = []`.

## Side benefit

Runner stdout 5411 → **1987** chars; cache 5411 → **2273**. This row's audit packet now fits entirely under the 6000-char excerpt ceiling, so it is no longer head-clipped.

## Scope disclosure

The wider read-site figures gathered while diagnosing this (185/197) are a **measurement of an unguarded-read-site pattern, not proof of 185 broken runners** — only the `ckm_magnitudes_structural_counts` runner is empirically confirmed to fail in the isolated tracked-only checkout. No claim is made here about the rest.

This PR sets no status. Whether the re-rendered packet discharges the obligation is for the independent audit lane to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)