### PR TITLE
fix(koide): re-measure the hostile-audit dep classification against the repaired parent

### DIFF
--- a/docs/KOIDE_Q_DELTA_LINKING_RELATION_THEOREM_NOTE_2026-04-20_NOTE_2026-05-17.md
+++ b/docs/KOIDE_Q_DELTA_LINKING_RELATION_THEOREM_NOTE_2026-04-20_NOTE_2026-05-17.md
@@ -21,27 +21,42 @@ Each of 1 named co-cycle deps was checked by case-insensitive substring search a
 
 | classification | count |
 |---|---:|
-| NOT-CITED | 0 |
-| CITED-INFORMATIONAL | 1 |
+| NOT-CITED | 1 |
+| CITED-INFORMATIONAL | 0 |
 | CITED-LOAD-BEARING | 0 |
 | CITED-JUDGMENT-NEEDED | 0 |
 | **total** | **1** |
 
 ## 3. CITED deps — context for audit-lane judgment
 
-| dep | classification | section | line | snippet |
-|---|---|---|---:|---|
-| `scalar_selector_remaining_open_imports_2026-04-20` | informational | Audit dependency repair links | 400 | - [scalar_selector_remaining_open_imports_2026-04-20](SCALAR_SELECTOR_REMAINING_... |
+None. No named co-cycle dep is currently cited in the parent.
 
-## 4. NOT-CITED deps (0)
+## 4. NOT-CITED deps (1)
 
-These 0 deps have ZERO grep hits in the parent. They are pure transitive co-cycle members reached via citation graph closure through retained ancestors. The audit lane can safely treat them as informational/SEE-ALSO for cycle-break purposes.
+This dep has ZERO substring hits in the parent. Zero hits here is not incidental absence: the dep *was* directly cited when this note was first written, and the citation was withdrawn deliberately, in the two steps recorded below.
 
 <details>
 <summary>full list</summary>
 
+- `scalar_selector_remaining_open_imports_2026-04-20`
 
 </details>
+
+### Reclassification record (2026-07-26)
+
+This dep was published above as CITED-INFORMATIONAL. It is re-measured here as NOT-CITED. The classification changed because the parent changed; the measurement below supersedes the original, which was accurate when taken.
+
+| date | commit | change to the parent | hits |
+|---|---|---|---:|
+| 2026-05-16 | `62a903eb0e` | dep carried as a markdown link under "Audit dependency repair links" — a live citation-graph edge | 1 |
+| 2026-05-17 | `2133821219` "audit: land cycle-break graph hygiene" | link converted to a backticked name: the graph edge is broken, the prose remains | 2 |
+| 2026-05-26 | `79d70664e2` "review-loop: land Koide Q-delta formal ratio" | the whole "Audit dependency repair links" section retired, prose included | 0 |
+
+The original measurement recorded the 2026-05-16 state — its section-3 snippet showed the markdown-link form — and was superseded roughly five hours later the same day by the cycle-break commit. Through the middle row the dep was still textually present, so CITED-INFORMATIONAL remained a correct text measurement; only the final row makes it wrong.
+
+The withdrawn text stated its own purpose: the dep was a see-also cross-reference, "backticked to break cycle-0008 in the citation graph", and it recorded that the load-bearing citation direction runs `scalar_selector_remaining_open_imports_2026-04-20` → this theorem note, not the reverse. So zero hits is the state the firewall intends. Restoring the citation to make the paired runner's original expectation hold would reverse that firewall, which is why the runner's expectation is inverted instead: it now fails if the citation is ever reinstated. (Readers checking this against the current cycle inventory should note that the `cycle-0008` id has since been reused for an unrelated cycle; the cycle this text referenced is no longer in the inventory.)
+
+Nothing in the parent is changed by this note, and no withdrawn citation is restored.
 
 ## 5. Audit handoff boundary
 
@@ -57,6 +72,10 @@ This review-loop artifact records source-backed dependency classification only. 
 ## 7. Verification
 
 Paired runner: `scripts/frontier_koide_q_delta_linking_relation_theorem_note_2026-04-20_hostile_audit_findings.py`. Programmatically verifies the NOT-CITED set (expects zero hits) and the CITED set (expects ≥1 hit).
+
+Every grep runs against the **parent**, never against this note. Grepping this note for the dep names it reports on would be self-referential and would gate nothing.
+
+The runner additionally re-reads the counts table in section 2 and fails if it disagrees with the classification the runner itself measures. That check is what would have caught the drift recorded in section 4 at the time it happened, rather than two months later: this note and its runner can no longer disagree with the parent silently.
 
 ## 8. Cross-references (non-load-bearing)
 

--- a/logs/runner-cache/frontier_koide_q_delta_formal_ratio_repair.txt
+++ b/logs/runner-cache/frontier_koide_q_delta_formal_ratio_repair.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_koide_q_delta_formal_ratio_repair.py
 runner_sha256: c49966f809d3a17a18221f39e8a5222147e105db3355e262c7246279c6ef061d
-timeout_sec: 120
+timeout_sec: 180
 exit_code: 0
-elapsed_sec: 1.12
+elapsed_sec: 1.43
 status: ok
 ----- stdout -----
 Koide Q-delta formal ratio repair
@@ -74,32 +74,32 @@ Direct citation firewall
   [PASS] docs/KOIDE_RHO_DELTA_DIMENSIONLESS_DOF_RATIO_BRIDGE_BOUNDED_NOTE_2026-05-25.md:63 citation avoids forbidden authority language
   [PASS] docs/KOIDE_RHO_DELTA_DIMENSIONLESS_DOF_RATIO_BRIDGE_BOUNDED_NOTE_2026-05-25.md:106 citation is explicitly formal/open/contextual
   [PASS] docs/KOIDE_RHO_DELTA_DIMENSIONLESS_DOF_RATIO_BRIDGE_BOUNDED_NOTE_2026-05-25.md:106 citation avoids forbidden authority language
-  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:9 citation is explicitly formal/open/contextual
-  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:9 citation avoids forbidden authority language
-  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:142 citation is explicitly formal/open/contextual
-  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:142 citation avoids forbidden authority language
-  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:179 citation is explicitly formal/open/contextual
-  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:179 citation avoids forbidden authority language
-  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:192 citation is explicitly formal/open/contextual
-  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:192 citation avoids forbidden authority language
+  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:10 citation is explicitly formal/open/contextual
+  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:10 citation avoids forbidden authority language
+  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:147 citation is explicitly formal/open/contextual
+  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:147 citation avoids forbidden authority language
+  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:186 citation is explicitly formal/open/contextual
+  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:186 citation avoids forbidden authority language
+  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:198 citation is explicitly formal/open/contextual
+  [PASS] docs/KOIDE_Z3_QUBIT_RADIAN_BRIDGE_NO_GO_NOTE_2026-04-20.md:198 citation avoids forbidden authority language
   [PASS] docs/RADIAN_BRIDGE_EXPANDED_INVENTORY_BOUNDED_NOTE_2026-05-10_radianexp.md:24 citation is explicitly formal/open/contextual
   [PASS] docs/RADIAN_BRIDGE_EXPANDED_INVENTORY_BOUNDED_NOTE_2026-05-10_radianexp.md:24 citation avoids forbidden authority language
   [PASS] docs/RADIAN_BRIDGE_EXPANDED_INVENTORY_BOUNDED_NOTE_2026-05-10_radianexp.md:592 citation is explicitly formal/open/contextual
   [PASS] docs/RADIAN_BRIDGE_EXPANDED_INVENTORY_BOUNDED_NOTE_2026-05-10_radianexp.md:592 citation avoids forbidden authority language
-  [PASS] docs/SCALAR_SELECTOR_REMAINING_OPEN_IMPORTS_2026-04-20.md:241 citation is explicitly formal/open/contextual
-  [PASS] docs/SCALAR_SELECTOR_REMAINING_OPEN_IMPORTS_2026-04-20.md:241 citation avoids forbidden authority language
-  [PASS] docs/SCALAR_SELECTOR_REMAINING_OPEN_IMPORTS_2026-04-20.md:300 citation is explicitly formal/open/contextual
-  [PASS] docs/SCALAR_SELECTOR_REMAINING_OPEN_IMPORTS_2026-04-20.md:300 citation avoids forbidden authority language
-  [PASS] docs/SCALAR_SELECTOR_REMAINING_OPEN_IMPORTS_2026-04-20.md:410 citation is explicitly formal/open/contextual
-  [PASS] docs/SCALAR_SELECTOR_REMAINING_OPEN_IMPORTS_2026-04-20.md:410 citation avoids forbidden authority language
-  [PASS] docs/SCALAR_SELECTOR_REVIEWER_PACKAGE_2026-04-20.md:173 citation is explicitly formal/open/contextual
-  [PASS] docs/SCALAR_SELECTOR_REVIEWER_PACKAGE_2026-04-20.md:173 citation avoids forbidden authority language
-  [PASS] docs/publication/ci3_z3/DERIVATION_ATLAS.md:388 citation is explicitly formal/open/contextual
-  [PASS] docs/publication/ci3_z3/DERIVATION_ATLAS.md:388 citation avoids forbidden authority language
+  [PASS] docs/SCALAR_SELECTOR_REMAINING_OPEN_IMPORTS_2026-04-20.md:242 citation is explicitly formal/open/contextual
+  [PASS] docs/SCALAR_SELECTOR_REMAINING_OPEN_IMPORTS_2026-04-20.md:242 citation avoids forbidden authority language
+  [PASS] docs/SCALAR_SELECTOR_REMAINING_OPEN_IMPORTS_2026-04-20.md:301 citation is explicitly formal/open/contextual
+  [PASS] docs/SCALAR_SELECTOR_REMAINING_OPEN_IMPORTS_2026-04-20.md:301 citation avoids forbidden authority language
+  [PASS] docs/SCALAR_SELECTOR_REMAINING_OPEN_IMPORTS_2026-04-20.md:412 citation is explicitly formal/open/contextual
+  [PASS] docs/SCALAR_SELECTOR_REMAINING_OPEN_IMPORTS_2026-04-20.md:412 citation avoids forbidden authority language
+  [PASS] docs/SCALAR_SELECTOR_REVIEWER_PACKAGE_2026-04-20.md:183 citation is explicitly formal/open/contextual
+  [PASS] docs/SCALAR_SELECTOR_REVIEWER_PACKAGE_2026-04-20.md:183 citation avoids forbidden authority language
+  [PASS] docs/publication/ci3_z3/DERIVATION_ATLAS.md:387 citation is explicitly formal/open/contextual
+  [PASS] docs/publication/ci3_z3/DERIVATION_ATLAS.md:387 citation avoids forbidden authority language
   [PASS] scripts/frontier_koide_q_delta_linking_relation.py:5 citation is explicitly formal/open/contextual
   [PASS] scripts/frontier_koide_q_delta_linking_relation.py:5 citation avoids forbidden authority language
-  [PASS] scripts/frontier_koide_q_delta_linking_relation_theorem_note_2026-04-20_hostile_audit_findings.py:23 citation is explicitly formal/open/contextual
-  [PASS] scripts/frontier_koide_q_delta_linking_relation_theorem_note_2026-04-20_hostile_audit_findings.py:23 citation avoids forbidden authority language
+  [PASS] scripts/frontier_koide_q_delta_linking_relation_theorem_note_2026-04-20_hostile_audit_findings.py:30 citation is explicitly formal/open/contextual
+  [PASS] scripts/frontier_koide_q_delta_linking_relation_theorem_note_2026-04-20_hostile_audit_findings.py:30 citation avoids forbidden authority language
   [PASS] at least one direct citation was scanned (citations=32)
 
 ========================================================================================

--- a/logs/runner-cache/frontier_koide_q_delta_linking_relation_theorem_note_2026-04-20_hostile_audit_findings.txt
+++ b/logs/runner-cache/frontier_koide_q_delta_linking_relation_theorem_note_2026-04-20_hostile_audit_findings.txt
@@ -1,7 +1,7 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_koide_q_delta_linking_relation_theorem_note_2026-04-20_hostile_audit_findings.py
-runner_sha256: 71c7691261297b708e726e6948419a582c97bdcd61aeb0ccceaca79042137a50
-timeout_sec: 120
+runner_sha256: 77f25819e63a27ca8e97ba89b9510cfee935eaf5f1d4833661159e5800036cf8
+timeout_sec: 180
 exit_code: 0
 elapsed_sec: 0.04
 status: ok
@@ -9,16 +9,22 @@ status: ok
 ==============================================================================
 AUDIT-PREP VERIFIER — koide_q_delta_linking_relation_theorem_note_2026-04-20
 ==============================================================================
-  [PASS] [A] Parent note exists  (KOIDE_Q_DELTA_LINKING_RELATION_THEOREM_NOTE_2026-04-20.md, 16075 bytes)
+  [PASS] [A] Parent note exists  (KOIDE_Q_DELTA_LINKING_RELATION_THEOREM_NOTE_2026-04-20.md, 10613 bytes)
 
 PART 1 — CITED deps (expect: >=1 hit each):
-  [PASS] [A]   scalar_selector_remaining_open_imports_2026-04-20 IS cited (>=1 hit)  (hits = 2)
 
 PART 2 — NOT-CITED deps (expect: 0 hits each):
+  [PASS] [A]   scalar_selector_remaining_open_imports_2026-04-20 NOT cited (0 hits)  (hits = 0)
+
+PART 3 — findings note agrees with the measured classification:
+  [PASS] [A] Findings note exists  (KOIDE_Q_DELTA_LINKING_RELATION_THEOREM_NOTE_2026-04-20_NOTE_2026-05-17.md)
+  [PASS] [A]   NOT-CITED row matches this runner's NOT_CITED_DEPS  (note = 1, runner = 1)
+  [PASS] [A]   CITED rows match this runner's CITED_DEPS  (note = 0, runner = 0)
+  [PASS] [A]   total row matches the classified dep count  (note = 1, runner = 1)
 
 ==============================================================================
-SUMMARY: 2 PASS / 0 FAIL
-Class-A pattern hits: 2
+SUMMARY: 6 PASS / 0 FAIL
+Class-A pattern hits: 6
 ==============================================================================
 
 VERIFIED

--- a/scripts/frontier_koide_q_delta_linking_relation_theorem_note_2026-04-20_hostile_audit_findings.py
+++ b/scripts/frontier_koide_q_delta_linking_relation_theorem_note_2026-04-20_hostile_audit_findings.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 """Audit-prep verifier for koide_q_delta_linking_relation_theorem_note_2026-04-20.
 
-Verifies docs/KOIDE_Q_DELTA_LINKING_RELATION_THEOREM_NOTE_2026-04-20_NOTE_2026-05-17.md.
+Re-measures the co-cycle dep classification published in the findings note
+docs/KOIDE_Q_DELTA_LINKING_RELATION_THEOREM_NOTE_2026-04-20_NOTE_2026-05-17.md.
+The subject of every grep is that note's PARENT — the 2026-04-20 theorem note — so
+PARENT_PATH names the parent, not the findings note. Grepping the findings note for
+the dep names it reports on would be self-referential and would gate nothing.
 
 Programmatic checks:
   - The parent note exists at the expected path.
   - CITED deps (>=1 hit, classification deferred to audit-lane judgment based on context).
   - NOT-CITED deps (0 hits, programmatically certain).
+  - The findings note's own counts table matches the measured classification.
 """
 
 from __future__ import annotations
@@ -20,13 +25,24 @@ FAIL_COUNT = 0
 CLASS_A_HITS = 0
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+# The parent is cited here as a grep target only: this runner measures which dep names
+# appear in its text and consumes none of its claims. Context only, not load-bearing.
 PARENT_PATH = REPO_ROOT / "docs/KOIDE_Q_DELTA_LINKING_RELATION_THEOREM_NOTE_2026-04-20.md"
+FINDINGS_PATH = (
+    REPO_ROOT
+    / "docs/KOIDE_Q_DELTA_LINKING_RELATION_THEOREM_NOTE_2026-04-20_NOTE_2026-05-17.md"
+)
 
 CITED_DEPS = [
-    "scalar_selector_remaining_open_imports_2026-04-20",
 ]
 
+# Reclassified from CITED on 2026-07-26. The parent's "Audit dependency repair links"
+# section — where this dep was carried as a backticked see-also, itself a citation-graph
+# cycle break — was retired wholesale by 79d70664e2 (2026-05-26, "review-loop: land Koide
+# Q-delta formal ratio"). Zero hits is now the state the firewall intends, so the gate is
+# inverted rather than dropped: it fails if the citation is ever reinstated.
 NOT_CITED_DEPS = [
+    "scalar_selector_remaining_open_imports_2026-04-20",
 ]
 
 
@@ -49,6 +65,16 @@ def check(label: str, condition: bool, detail: str = "", class_a: bool = True) -
 
 def grep_count(content: str, needle: str) -> int:
     return len(re.findall(re.escape(needle), content, re.IGNORECASE))
+
+
+def table_count(findings: str, label: str) -> int | None:
+    """Read one row of the findings note's section-2 counts table."""
+    m = re.search(
+        rf"^\|\s*\**{re.escape(label)}\**\s*\|\s*\**(\d+)\**\s*\|",
+        findings,
+        re.MULTILINE | re.IGNORECASE,
+    )
+    return int(m.group(1)) if m else None
 
 
 def main() -> int:
@@ -82,6 +108,40 @@ def main() -> int:
             n == 0,
             f"hits = {n}",
         )
+
+    print()
+    print("PART 3 — findings note agrees with the measured classification:")
+    if not FINDINGS_PATH.exists():
+        check("Findings note exists", False, f"missing: {FINDINGS_PATH}")
+    else:
+        findings = FINDINGS_PATH.read_text(encoding="utf-8")
+        check("Findings note exists", True, FINDINGS_PATH.name)
+        cited_rows = [
+            "CITED-INFORMATIONAL",
+            "CITED-LOAD-BEARING",
+            "CITED-JUDGMENT-NEEDED",
+        ]
+        counts = {lbl: table_count(findings, lbl) for lbl in ["NOT-CITED", *cited_rows, "total"]}
+        missing = [lbl for lbl, n in counts.items() if n is None]
+        if missing:
+            check("  counts table is readable", False, f"unparsed rows: {missing}")
+        else:
+            cited_total = sum(counts[lbl] for lbl in cited_rows)
+            check(
+                "  NOT-CITED row matches this runner's NOT_CITED_DEPS",
+                counts["NOT-CITED"] == len(NOT_CITED_DEPS),
+                f"note = {counts['NOT-CITED']}, runner = {len(NOT_CITED_DEPS)}",
+            )
+            check(
+                "  CITED rows match this runner's CITED_DEPS",
+                cited_total == len(CITED_DEPS),
+                f"note = {cited_total}, runner = {len(CITED_DEPS)}",
+            )
+            check(
+                "  total row matches the classified dep count",
+                counts["total"] == len(CITED_DEPS) + len(NOT_CITED_DEPS),
+                f"note = {counts['total']}, runner = {len(CITED_DEPS) + len(NOT_CITED_DEPS)}",
+            )
 
     print()
     print("=" * 78)


### PR DESCRIPTION
## What this responds to

`scripts/frontier_koide_q_delta_linking_relation_theorem_note_2026-04-20_hostile_audit_findings.py` failed its only CITED-dep gate: it required the parent note to cite `scalar_selector_remaining_open_imports_2026-04-20`, a citation the parent no longer carries. Confirmed pre-existing on pristine `origin/main` — byte-identical failing output from a clean detached worktree — and unrelated to any in-flight PR. It belongs to the stale-registry runner repair sweep class.

The task framed two candidate repairs and set a constraint on both:

> Determine whether the correct repair is updating the runner's expected-dep list to match the repaired note, or restoring the citation; do NOT rewrite the gate merely to go green.

Both candidates are refuted below. The repair landed here is a third thing.

## Why neither candidate is right

**Restoring the citation reverses a firewall.** The removed text stated its own purpose: the dep was a see-also cross-reference, "backticked to break cycle-0008 in the citation graph", and it recorded that the load-bearing citation direction runs `scalar_selector_remaining_open_imports_2026-04-20` → this theorem note, not the reverse. Reinstating it to satisfy a runner would re-add the edge that cycle-break maintenance deliberately removed.

**Blanking `CITED_DEPS` alone is the forbidden move.** With both dep lists empty, PART 1 and PART 2 iterate over nothing and the runner is green because it checks nothing. That is "rewriting the gate merely to go green" precisely.

A third candidate worth naming and rejecting: repointing `PARENT_PATH` at the findings note itself. The findings note *reports on* these dep names, so it contains every one of them as literal text. Every grep would trivially succeed. Self-referential, and gates nothing.

## What the repair is

The findings note is an **empirical classification of its parent**. The classified state changed, deliberately. So the note and its runner re-measure and re-report reality: `scalar_selector_remaining_open_imports_2026-04-20` moves CITED-INFORMATIONAL → NOT-CITED in both.

This keeps the gate discriminating and inverts it in the direction that matters. It no longer asserts a citation that maintenance withdrew; it now **fails if that citation is ever reinstated**.

## Provenance — a two-step firewall, and a measurement stale within hours

The drift was not one event. Measured across the parent's four revisions:

| date | commit | change to the parent | hits |
|---|---|---|---:|
| 2026-05-16 | `62a903eb0e` | dep carried as a markdown link under "Audit dependency repair links" — a live citation-graph edge | 1 |
| 2026-05-17 | `2133821219` "audit: land cycle-break graph hygiene" | link converted to a backticked name: the graph edge is broken, the prose remains | 2 |
| 2026-05-26 | `79d70664e2` "review-loop: land Koide Q-delta formal ratio" | the whole "Audit dependency repair links" section retired, prose included | 0 |

The original measurement recorded the **2026-05-16** state — its section-3 snippet preserved the markdown-link form, which is how the ordering is fixed — and was superseded by the cycle-break commit roughly five hours later the same day. Through the middle row the dep was still textually present, so CITED-INFORMATIONAL stayed a correct *text* measurement; only the final row makes it wrong.

Two things then carried the stale state forward. A 2026-05-19 link-aware vocabulary sweep re-landed the artifact without re-measuring. And the committed cache was stale-green: `exit_code: 0`, `2 PASS / 0 FAIL`, with the parent recorded at **16075 bytes** and the CITED gate passing at **2 hits** — the fingerprint of the 05-17 backtick state, frozen. The parent is 10613 bytes today. A cache never proves a runner currently passes.

## PART 3 is a deliberate hardening, not a minimal repair

A minimal repair fixes today's mismatch and leaves the same silent-drift channel open. PART 3 closes it: the runner re-reads the note's own section-2 counts table and fails if it disagrees with the classification the runner itself measured. Note and runner can no longer diverge from the parent quietly — the check that would have caught this drift on the day it happened rather than two months later.

A new gate that cannot fail is worth nothing, so each check was exercised against a perturbation that makes the object wrong. Every control asserts its perturbation matched something first, so none is vacuous:

| control | exit | summary | evidence |
|---|---:|---|---|
| baseline | 0 | 6 PASS / 0 FAIL | — |
| citation reinstated in the parent | 1 | 5 / 1 | `scalar_selector... NOT cited (0 hits) (hits = 1)` |
| note table reset to pre-repair values | 1 | 4 / 2 | NOT-CITED `note = 0, runner = 1`; CITED `note = 1, runner = 0` |
| total row desynced from its own rows | 1 | 5 / 1 | `total row... note = 2, runner = 1` |
| counts table made unparseable | 1 | 3 / 1 | `counts table is readable (unparsed rows: ['NOT-CITED'])` |
| post-restore (the state that ships) | 0 | 6 PASS / 0 FAIL | — |

Stdout is 1177 chars, well inside the 6000-char audit-packet excerpt window.

## A second gate, passing by accident — found by the sibling runner

Moving the dep between lists dropped `scripts/frontier_koide_q_delta_formal_ratio_repair.py` from `TOTAL: PASS=159 FAIL=0` to `PASS=158 FAIL=1`. Worth reporting in full, because the cause is not the obvious one.

That sibling enforces a **direct citation firewall**: any file citing the 2026-04-20 parent must carry a formal/open/contextual marker within ±4 lines of the citing line, so nothing cites the parent as physical authority. This runner was satisfying it **by accident**. The marker list includes the bare token `open`, and the ±4-line window happened to contain `scalar_selector_remaining_open_imports_2026-04-20` — the substring inside `remaining_open_imports` was the entire basis for the pass. Reclassifying the dep moved that string out of the window and exposed it.

So for this file the firewall was checking a dep name, not a statement about the citation. The repair states the marker for real, adjacent to `PARENT_PATH`:

> The parent is cited here as a grep target only: this runner measures which dep names appear in its text and consumes none of its claims. Context only, not load-bearing.

That is a true description of what the runner does — it greps the parent and reads none of its claims — and it restores `PASS=159 FAIL=0`. Measured: `159/159` on pristine `origin/main` in a tracked-only detached worktree (citation at `:23`) → `158/1` after the reclassification → `159/159` with the marker stated (citation now at `:30`). A restore, not a new pass.

## Files — four, not the canonical triple

The docstring expansion shifted the cited line 23 → 30, so the sibling's committed cache reproduced `:23` against a live `:30`: stale stdout sitting behind a still-matching `runner_sha256: c49966f809…`. That is the same defect class this PR exists to repair, so leaving it would be indefensible here of all places. The sibling's row is `audit_status: unaudited` / `effective_status_reason: awaiting_audit`, so the refresh disturbs nothing settled. Its **source is untouched**; only its cache is regenerated, and its summary line is unchanged at `PASS=159 FAIL=0`.

## Blast radius

Nil. The findings-note row has zero deps, zero descendants, zero reverse references anywhere in the ledger shards, leaf criticality, no helper runners, and has never been audited. Its `effective_status: meta` is worth reading carefully: `effective_status_reason: metadata` over `audit_status: unaudited` — mechanical passthrough of `claim_type: meta`, not an earned grade. The rule that a runner-hash change re-queues a row protects rows with a settled status; this row has none to disturb.

(One caution for anyone repeating the reverse-reference check: the findings-note claim id has the parent's claim id as a proper prefix, so a naive grep returns the parent's 11 referencing files and 731 descendants. Grepping the full `..._note_2026-05-17` id returns none.)

Sibling safety: all three scripts naming the parent were run post-edit — the formal-ratio repair at 159/159, `frontier_koide_q_delta_linking_relation.py` at 15/15, and this one at 6/6. No script pins any edited phrase, and the findings note is excluded from the firewall's source scan by filename, so the note edits cannot reach it. The note's H1 title is left byte-identical (unbalanced paren included) because the ledger `title` field records it verbatim, and the `source_path_aliases.json` entry for the note's former path is untouched — no rename here.

Incidental, not repaired in this PR: the note's claim-scope sentence cites `docs/audit/data/audit_queue.json`, which is untracked as of the sharding. It is prose context, not a runner read, so it does not abort anything in a tracked-only checkout — but it is the same untracked-artifact class and worth a separate look.

## Status

This PR sets no status and predicts no grade. Whether the re-measured classification and the hardened gate are correct is for the independent audit lane to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-loop completion (2026-07-28)

The reviewed direct-to-main landing keeps the original four-file scope and adds narrow integrity fixes found during review: exact dependency-identity/list checks (not counts alone), nonempty/disjoint classifier invariants, runner-cache fingerprints for both mutable note inputs, repo-native meta-note wording, removal of the obsolete untracked `audit_queue.json` reference, and runner-contract prose synchronized to the implementation.

Final checks: dependency-classification runner `10 PASS / 0 FAIL`; formal-ratio sibling `159 / 0`; historical sibling `15 / 0`; deterministic normal and `PYTHONOPTIMIZE=2` output; three adverse controls fail on wrong identity, wrong count, and citation reinstatement; vocabulary lint clean; full audit pipeline complete; strict audit lint zero errors. The generated row remains `claim_type: meta`, `audit_status: unaudited`, `effective_status: meta`, with zero dependencies and no queue/dispatch membership. No audit verdict or generated audit/status output is part of the landing.