### PR TITLE
Erratum: P4's weak-field rival L*sqrt(1-phi) is weak-field linear; the measured 0.50 row is L*(1-sqrt f)

### DIFF
--- a/docs/ERRATUM_WEAK_FIELD_RIVAL_ACTION_FORMULA_IS_MISSTATED_IN_PROBE_P4_NOTE_2026-07-26.md
+++ b/docs/ERRATUM_WEAK_FIELD_RIVAL_ACTION_FORMULA_IS_MISSTATED_IN_PROBE_P4_NOTE_2026-07-26.md
@@ -1,0 +1,141 @@
+# Erratum: the Weak-Field Rival Action Formula Is Misstated in Probe P4 — `L√(1-φ)` Is Weak-Field Linear, and the Measured 0.50 Row Is `L(1-√f)`
+
+**Date:** 2026-07-26
+**Type:** erratum
+**Claim type:** erratum (a correction to the statement of a landed support
+note; no new theorem, no mechanism, no derivation).
+**Status authority:** none. Audit: unset. Constitutional effect: none. This
+note edits no axiom, foundation, Qualification, primitive, registry, policy,
+queue, audit-status, or PR-control surface. **It changes no numerical result,
+no verdict, and no lane status.** It corrects a formula.
+**Primary runner:**
+[`scripts/physical_weak_field_action_form_erratum_cycle707b_2026_07_26.py`](../scripts/physical_weak_field_action_form_erratum_cycle707b_2026_07_26.py)
+(4 PASS / 0 FAIL, exit 0).
+
+## The correction
+
+[`G_NEWTON_SELF_CONSISTENCY_BOUNDED_SHARPENING_NOTE_2026-05-10_planckP4`](G_NEWTON_SELF_CONSISTENCY_BOUNDED_SHARPENING_NOTE_2026-05-10_planckP4.md)
+states, in three places (Barrier B(c) at lines ~89, ~199 and ~305), that the
+alternative to the valley-linear weak-field action is
+
+> `S = L√(1 - φ)` (spent-delay), gives `F~√M = 0.50`, NOT Newtonian
+
+**The formula and the number do not belong together.** What the probe measures
+is a different expression. In
+[`scripts/action_universality_probe.py`](../scripts/action_universality_probe.py),
+`action_value()` defines the sqrt mode as
+
+```python
+if action_mode == "valley_sqrt":
+    return L * (1.0 - np.sqrt(f))
+```
+
+— the square root is on the **field**, giving `S = L(1 - √f)`, whose valley
+depth is `√f`: leading power **1/2**, consistent with the measured
+`F~M = 0.50`. This matches the landed
+[`ACTION_UNIQUENESS_NOTE`](ACTION_UNIQUENESS_NOTE.md), whose sublinear row is
+`S = L(1 - f^0.5)`.
+
+P4's expression has the square root on `1 - φ` instead, and
+
+```text
+1 - sqrt(1 - f) = f/2 + f^2/8 + ...
+```
+
+so `L√(1 - φ)` has leading power **1**, coefficient 1/2. By the landed
+classification it therefore sits in the **Newtonian** class, alongside
+`L(1-f)`, `L exp(-f)` and `L/(1+f)` — the very class it is offered as the
+alternative to.
+
+| expression | source | leading power | class |
+|---|---|---:|---|
+| `L(1-f)` | valley-linear | 1 | Newtonian |
+| `L exp(-f)` | ACTION_UNIQUENESS | 1 | Newtonian |
+| `L/(1+f)` | ACTION_UNIQUENESS | 1 | Newtonian |
+| **`L√(1-φ)`** | **P4's stated rival** | **1** | **Newtonian** |
+| `L(1-√f)` | what the probe measures | 1/2 | sublinear |
+| `L(1-f²)` | ACTION_UNIQUENESS | 2 | superlinear |
+
+## The intended class is right; only the formula is wrong
+
+Three different expressions carry the "spent-delay / sqrt" name across the
+repo, and it is worth recording that two of them agree, so this erratum does
+not disturb any measured result.
+[`ACTION_CROSSOVER_NOTE`](ACTION_CROSSOVER_NOTE.md) defines spent-delay
+geometrically as `S = dl - √(dl² - L²)`. Writing `dl = L(1+ε)`,
+
+```text
+S = L[(1 + eps) - sqrt(2 eps + eps^2)]  ->  L[1 - sqrt(2 eps)],
+```
+
+so the geometric spent-delay has depth `√(2ε)`: leading power **1/2**, with
+coefficient `√2` (row R3 confirms the coefficient converges). So the
+*geometric* spent-delay and the *measured* `L(1-√f)` share the sublinear class,
+and P4's `L√(1-φ)` is the sole outlier among the three.
+
+**Net effect: P4's number `0.50` is correct for the action it meant; the
+formula it prints is not that action.**
+
+## Why this is worth recording
+
+Barrier B(c) is a named admission on the `G_Newton` lane, and it is currently
+discharged only by empirical match:
+
+> "The selection of valley-linear is by EMPIRICAL match to `F~M = 1`, not by
+> retained derivation."
+
+Anyone attacking B(c) from P4's text would be trying to discriminate
+valley-linear from `L√(1-φ)`. Those two expressions share a leading power, so
+**the mass-law exponent cannot discriminate them** — the very observable B(c)
+is stated in terms of. They are not identical functions, and higher-order
+behaviour or a different observable could in principle tell them apart; but the
+comparison as B(c) frames it has no content. The genuine alternative on the
+mass-law observable is the sublinear class. This erratum redirects that work; it
+does not do it.
+
+On framing: the lane's parent row `gravity_full_self_consistency_note` is
+`criticality: critical` with 773 transitive descendants. That count belongs to
+the parent row and is quoted only to indicate why the lane is worth keeping
+tidy — **it does not follow that this transcription error bears on those
+descendants**, and no such claim is made here.
+
+## What this does not do
+
+- It does **not** derive the weak-field action, supply a mechanism for why any
+  exponent takes its value, or change admission (c)'s status. B(c) remains
+  empirically selected and unforced.
+- It does **not** revise any measured number, any log, any cached artifact, or
+  any audit verdict. `F~M = 0.50` stands for the action that was run.
+- It does **not** claim the universality classes are universal. They are landed
+  as a fixed-family observation, explicitly "not promoted to a closed formula
+  or a universal theorem", and are used here only to place expressions in the
+  classes that note defines.
+- It makes no claim about which class the framework's rule should be in.
+
+An accompanying attempt to supply a mechanism for the exponent was rejected at
+the value gate and is **not** part of this change. Nothing from it appears in
+this note or its runner, and it is absent from this branch entirely.
+
+## Scope for independent review
+
+Every row is a leading-power extraction from a closed-form valley depth, with
+no lattice run and no fitted quantity. The rationalized depth forms are used
+because direct evaluation of `1 - g(f)` at `f ~ 1e-9` loses the answer to
+cancellation — for `g = 1 - f²` it underflows to exactly zero, which row R4
+demonstrates deliberately, and R4 also cross-checks every closed form against
+`1 - g(f)` at moderate `f` where the subtraction is safe. R2 reproduces the
+probe's `action_value()` branch inline rather than importing it, so the runner
+is self-contained.
+
+## Dependency citations
+
+The runner imports nothing from the repository.
+[`G_NEWTON_SELF_CONSISTENCY_BOUNDED_SHARPENING_NOTE_2026-05-10_planckP4`](G_NEWTON_SELF_CONSISTENCY_BOUNDED_SHARPENING_NOTE_2026-05-10_planckP4.md)
+is the note corrected.
+[`ACTION_UNIQUENESS_NOTE`](ACTION_UNIQUENESS_NOTE.md) supplies the universality
+classes and the tested forms;
+[`ACTION_CROSSOVER_NOTE`](ACTION_CROSSOVER_NOTE.md) supplies the geometric
+spent-delay definition;
+[`scripts/action_universality_probe.py`](../scripts/action_universality_probe.py)
+supplies what was actually executed. The `criticality` and descendant count are
+read from `docs/audit/data/ledger/gr/gravity_full_self_consistency_note.json`.

--- a/docs/ERRATUM_WEAK_FIELD_RIVAL_ACTION_FORMULA_IS_MISSTATED_IN_PROBE_P4_NOTE_2026-07-26.md
+++ b/docs/ERRATUM_WEAK_FIELD_RIVAL_ACTION_FORMULA_IS_MISSTATED_IN_PROBE_P4_NOTE_2026-07-26.md
@@ -99,6 +99,23 @@ the parent row and is quoted only to indicate why the lane is worth keeping
 tidy — **it does not follow that this transcription error bears on those
 descendants**, and no such claim is made here.
 
+## Claim ledger
+
+Per the inference audit (physics-loop step 11). One row per claim; a
+restatement gets its own row.
+
+| ID | Claim | Support | Hypotheses | Shown vs claimed | Falsifier |
+|---|---|---|---|---|---|
+| E1 | `L√(1-φ)` has leading power 1 | row R1/R2, exact closed-form depth `f/(1+√(1-f))` | `f > 0` and small; real branch of the square root | shown: depth/f → 1/2, a finite nonzero limit; claimed: the same | depth/f failing to converge, or converging to 0 or ∞ |
+| E2 | the probe measures `L(1-√f)`, power 1/2 | `action_value()` in `scripts/action_universality_probe.py`, quoted verbatim | none — it is a source quotation | shown: the source defines `valley_sqrt` as `L*(1.0 - np.sqrt(f))`; claimed: the same | the branch reading otherwise on `main` at the searched commit |
+| E3 | P4 pairs the first formula with the second's number | P4 lines ~89, ~199, ~305, quoted | none — a quotation | shown: three occurrences pairing `L√(1-φ)` with 0.50; claimed: the same | any of the three reading `L(1-√f)` |
+| E4 | the geometric spent-delay is also power 1/2 | row R3, expansion of `dl - √(dl²-L²)` at `dl = L(1+ε)` | `ε > 0` and small, so the root is real | shown: depth/√(2ε) → 1 and the log-log slope → 1/2; claimed: the same | the coefficient failing to converge to 1 |
+| E5 | the mass-law exponent cannot discriminate `L(1-f)` from `L√(1-φ)` | E1 plus the landed class definition | the landed classes are keyed to leading power on that fixed family | shown: both have leading power 1, so that one observable cannot separate them; claimed: the same, **and explicitly not** that no observable can — higher-order behaviour may | an observable keyed to leading power that separates them |
+
+Note on E5: an earlier draft claimed the comparison was undecidable outright.
+That overstated it — the two are different functions and only the leading
+mass exponent is blind to the difference. The row records the narrower claim.
+
 ## What this does not do
 
 - It does **not** derive the weak-field action, supply a mechanism for why any

--- a/logs/runner-cache/physical_weak_field_action_form_erratum_cycle707b_2026_07_26.txt
+++ b/logs/runner-cache/physical_weak_field_action_form_erratum_cycle707b_2026_07_26.txt
@@ -1,0 +1,17 @@
+Cycle 707b - erratum: which action formula is in which class
+==========================================================================
+      L(1-f)        valley-linear    p = 1.000000   (class 1.0)
+      L*exp(-f)                      p = 1.000000   (class 1.0)
+      L/(1+f)                        p = 1.000000   (class 1.0)
+      L*sqrt(1-f)   <- P4's rival    p = 1.000000   (class 1.0)
+      L(1-sqrt f)   <- measured      p = 0.500000   (class 0.5)
+      L(1-f^2)                       p = 2.000000   (class 2.0)
+[PASS] R1 leading power of each named expression  --  6 expressions
+[PASS] R2 the probe's `valley_sqrt` is L*(1-sqrt f), power 1/2; P4's L*sqrt(1-f) is power 1  --  p[valley_sqrt]=0.500000, p[P4]=1.000000, P4 depth/f -> 0.50000000
+      (1) geometric   p = 0.499979   depth/sqrt(2 eps) -> 0.999978
+      (2) measured    p = 0.500000
+      (3) P4          p = 1.000000
+[PASS] R3 the geometric spent-delay and the measured form share p=1/2; P4's formula is the outlier  --  so P4 misstates the formula, not the intended class
+[PASS] R4 control: closed-form depths match 1-g(f) at moderate f; direct subtraction underflows at 1e-9  --  worst disagreement 1.451e-16; direct 1-(1-f^2) at f=1e-9 gives exactly 0
+==========================================================================
+4 PASS / 0 FAIL

--- a/scripts/physical_weak_field_action_form_erratum_cycle707b_2026_07_26.py
+++ b/scripts/physical_weak_field_action_form_erratum_cycle707b_2026_07_26.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Cycle 707b - erratum: the weak-field rival action formula is misstated.
+
+Scope is deliberately small.  This runner establishes ONE thing: which action
+expressions sit in which of the landed universality classes, and that the
+formula Probe P4 names as the rival to valley-linear is not the formula that
+was measured.
+
+It makes no claim about why any exponent takes the value it does, supplies no
+mechanism, and does not touch admission (c)'s derivation status.  An earlier
+version of this cycle did all three and was rejected for overreach; the
+rejected content is recorded in `PR_BACKLOG_707.md` and is not reissued here.
+
+Background.  The landed ACTION_UNIQUENESS_NOTE establishes, on one fixed
+ordered-lattice family, three universality classes keyed to the leading power
+`p` of the field in the action's valley depth `1 - g(f)`:
+
+    p = 0.5  sublinear    F~M = 0.50
+    p = 1    linear       F~M = 1.00   (Newtonian)
+    p = 2    superlinear  F~M = 2.00
+
+Probe P4 writes, in three separate places, that the rival to valley-linear is
+`S = L*sqrt(1 - phi)` and that it gives `F~M = 0.50`.
+
+Rows:
+
+  R1  the leading power of each named expression, exact closed-form depths
+  R2  what the probe source actually measures
+  R3  the three expressions carrying the "spent-delay / sqrt" name, compared
+  R4  control: the depth forms agree with `1 - g(f)` where subtraction is safe
+"""
+
+import math
+
+FAILURES = []
+PASSES = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    (PASSES if ok else FAILURES).append(name)
+    print(f"[{'PASS' if ok else 'FAIL'}] {name}" + (f"  --  {detail}" if detail else ""))
+
+
+# Each entry gives g(f) and the valley depth `1 - g(f)` in a RATIONALIZED form.
+# Evaluating `1 - g(f)` directly at f ~ 1e-9 destroys the answer to
+# cancellation -- for g = 1 - f^2 it underflows to exactly zero.  R4 checks the
+# closed forms against `1 - g(f)` at moderate f, where that subtraction is safe.
+FORMS = {
+    "L(1-f)        valley-linear":  (lambda f: 1 - f,             lambda f: f,                          1.0),
+    "L*exp(-f)":                    (lambda f: math.exp(-f),      lambda f: -math.expm1(-f),            1.0),
+    "L/(1+f)":                      (lambda f: 1 / (1 + f),       lambda f: f / (1 + f),                1.0),
+    "L*sqrt(1-f)   <- P4's rival":  (lambda f: math.sqrt(1 - f),  lambda f: f / (1 + math.sqrt(1 - f)), 1.0),
+    "L(1-sqrt f)   <- measured":    (lambda f: 1 - math.sqrt(f),  lambda f: math.sqrt(f),               0.5),
+    "L(1-f^2)":                     (lambda f: 1 - f * f,         lambda f: f * f,                      2.0),
+}
+
+
+def leading_power(depth, f=1e-9, ratio=10.0):
+    return math.log(depth(f * ratio) / depth(f)) / math.log(ratio)
+
+
+def r1_leading_powers():
+    ok = True
+    for name, (_, depth, expected) in FORMS.items():
+        p = leading_power(depth)
+        print(f"      {name:30s} p = {p:.6f}   (class {expected})")
+        if abs(p - expected) > 1e-6:
+            ok = False
+    check("R1 leading power of each named expression", ok, f"{len(FORMS)} expressions")
+
+
+def r2_what_the_probe_measures():
+    """The probe's `action_value()` defines the sqrt mode as L*(1 - sqrt(f)).
+
+    Reproduced here rather than imported, so the runner stays self-contained:
+
+        if action_mode == "valley_sqrt":
+            return L * (1.0 - np.sqrt(f))
+
+    The square root is on the FIELD.  Its depth is sqrt(f), leading power 1/2 --
+    consistent with the measured F~M = 0.50.
+    """
+    def valley_sqrt(L, f):
+        return L * (1.0 - math.sqrt(f))
+
+    depth = lambda f: 1.0 - valley_sqrt(1.0, f)
+    p = leading_power(depth, f=1e-9)
+    matches_measured_class = abs(p - 0.5) < 1e-9
+
+    # P4's expression, by contrast, is linear: 1 - sqrt(1-f) = f/2 + f^2/8 + ...
+    p4_depth = lambda f: f / (1 + math.sqrt(1 - f))
+    p_p4 = leading_power(p4_depth, f=1e-9)
+    ratio_to_half = p4_depth(1e-10) / 1e-10
+    p4_is_linear = abs(p_p4 - 1.0) < 1e-9 and abs(ratio_to_half - 0.5) < 1e-6
+
+    check(
+        "R2 the probe's `valley_sqrt` is L*(1-sqrt f), power 1/2; P4's L*sqrt(1-f) is power 1",
+        matches_measured_class and p4_is_linear,
+        f"p[valley_sqrt]={p:.6f}, p[P4]={p_p4:.6f}, P4 depth/f -> {ratio_to_half:.8f}",
+    )
+
+
+def r3_three_expressions_one_name():
+    """Three expressions carry the spent-delay / sqrt name.  Two share a class.
+
+    (1) geometric, ACTION_CROSSOVER_NOTE:  S = dl - sqrt(dl^2 - L^2)
+    (2) measured,  ACTION_UNIQUENESS_NOTE: S = L(1 - f^0.5)
+    (3) P4:                                S = L*sqrt(1 - phi)
+
+    With dl = L(1+eps), (1) expands as L[(1+eps) - sqrt(2 eps + eps^2)]
+    -> L[1 - sqrt(2 eps)], so its depth goes as sqrt(eps): power 1/2, with
+    coefficient sqrt(2).  So (1) and (2) agree; (3) is the outlier.
+    """
+    def geometric_depth(eps, L=1.0):
+        dl = L * (1.0 + eps)
+        return L - (dl - math.sqrt(dl * dl - L * L))
+
+    p_geo = leading_power(geometric_depth, f=1e-9)
+    coeff = [geometric_depth(e) / math.sqrt(2 * e) for e in (1e-7, 1e-8, 1e-9)]
+    coeff_converges = all(abs(c - 1.0) < 1e-3 for c in coeff) and (
+        abs(coeff[-1] - 1.0) < abs(coeff[0] - 1.0)
+    )
+
+    p_measured = leading_power(math.sqrt, f=1e-9)
+    p_p4 = leading_power(lambda f: f / (1 + math.sqrt(1 - f)), f=1e-9)
+
+    one_and_two_agree = abs(p_geo - p_measured) < 1e-3
+    three_is_outlier = abs(p_p4 - 1.0) < 1e-9 and abs(p_p4 - p_geo) > 0.4
+
+    print(f"      (1) geometric   p = {p_geo:.6f}   depth/sqrt(2 eps) -> {coeff[-1]:.6f}")
+    print(f"      (2) measured    p = {p_measured:.6f}")
+    print(f"      (3) P4          p = {p_p4:.6f}")
+
+    check(
+        "R3 the geometric spent-delay and the measured form share p=1/2; P4's formula is the outlier",
+        abs(p_geo - 0.5) < 1e-3 and coeff_converges and one_and_two_agree and three_is_outlier,
+        "so P4 misstates the formula, not the intended class",
+    )
+
+
+def r4_depth_forms_control():
+    """The rationalized depths must agree with `1 - g(f)` where that is safe."""
+    ok = True
+    worst = 0.0
+    for name, (g, depth, _) in FORMS.items():
+        for f in (1e-3, 1e-2, 0.1, 0.25):
+            err = abs(depth(f) - (1 - g(f)))
+            worst = max(worst, err)
+            if err > 1e-12 * max(1.0, abs(depth(f))):
+                ok = False
+    # and the direct subtraction really does fail deep in the weak field,
+    # which is why the closed forms are used at all
+    underflows = (1 - (1 - (1e-9) ** 2)) == 0.0
+    check(
+        "R4 control: closed-form depths match 1-g(f) at moderate f; direct subtraction underflows at 1e-9",
+        ok and underflows,
+        f"worst disagreement {worst:.3e}; direct 1-(1-f^2) at f=1e-9 gives exactly 0",
+    )
+
+
+def main() -> int:
+    print("Cycle 707b - erratum: which action formula is in which class")
+    print("=" * 74)
+    r1_leading_powers()
+    r2_what_the_probe_measures()
+    r3_three_expressions_one_name()
+    r4_depth_forms_control()
+    print("=" * 74)
+    print(f"{len(PASSES)} PASS / {len(FAILURES)} FAIL")
+    for f in FAILURES:
+        print(f"  FAILED: {f}")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Erratum: the weak-field rival action formula is misstated in Probe P4

Probe P4 (`G_NEWTON_SELF_CONSISTENCY_BOUNDED_SHARPENING_NOTE_2026-05-10_planckP4`)
states in three places that the alternative to the valley-linear weak-field
action is `S = L√(1 - φ)`, giving `F~M = 0.50`.

**The formula and the number do not belong together.**

`action_value()` in `scripts/action_universality_probe.py` defines the tested
mode as

```python
if action_mode == "valley_sqrt":
    return L * (1.0 - np.sqrt(f))
```

— the square root is on the **field**. Its valley depth is `√f`: leading power
1/2, matching the measured 0.50 and matching `ACTION_UNIQUENESS_NOTE`'s
sublinear row `L(1 - f^0.5)`.

P4's expression puts the root on `1 - φ`, and `1 - √(1-f) = f/2 + f²/8 + …`,
so it has leading power **1** — the Newtonian class it is offered as the
alternative to.

| expression | leading power | class |
|---|---:|---|
| `L(1-f)`, `L exp(-f)`, `L/(1+f)` | 1 | Newtonian |
| **`L√(1-φ)`** — P4's stated rival | **1** | **Newtonian** |
| `L(1-√f)` — what the probe measures | 1/2 | sublinear |
| `L(1-f²)` | 2 | superlinear |

**The intended class is right; only the formula is wrong.** The geometric
spent-delay of `ACTION_CROSSOVER_NOTE`, `S = dl - √(dl² - L²)`, expands with
`dl = L(1+ε)` to `L[1 - √(2ε)]` — also power 1/2. Two of the three expressions
carrying the "spent-delay/sqrt" name agree; P4's is the outlier. No measured
number, log, cached artifact or verdict changes.

**Why it matters.** Barrier B(c) is discharged only by empirical match to
`F~M = 1`. Anyone attacking it from P4's text would try to discriminate two
expressions that share a leading power — so the mass-law exponent, the very
observable B(c) is stated in terms of, cannot tell them apart. The genuine
alternative on that observable is the sublinear class.

### Scope

Does **not** derive the weak-field action, supply a mechanism, or change
admission (c)'s status; B(c) remains empirically selected and unforced. Makes
no claim that the universality classes are universal — they are landed as a
fixed-family observation and are used only to place expressions in the classes
that note defines.

### Verification

Runner 4 PASS / 0 FAIL, cold-run in an isolated worktree at `c329c27b93`, pin
verified against the committed blob (`14090a58…`). Authority none, audit unset.
Rationalized depth forms are used because `1 - g(f)` at `f ~ 1e-9` underflows to
exactly zero for `g = 1 - f²`; row R4 demonstrates that deliberately and
cross-checks every closed form where the subtraction is safe.
