### PR TITLE
fix(hierarchy): reconcile EW D4 bridge verification total and harden its gates

### DIFF
--- a/docs/HIERARCHY_EW_ORDER_PARAMETER_D4_DENSITY_READOUT_BRIDGE_BOUNDED_SUPPORT_NOTE_2026-06-18.md
+++ b/docs/HIERARCHY_EW_ORDER_PARAMETER_D4_DENSITY_READOUT_BRIDGE_BOUNDED_SUPPORT_NOTE_2026-06-18.md
@@ -32,8 +32,8 @@ the relevant endpoint coefficient surface.
 
 This note proves a conditional algebraic first half only: once a physical
 one-Higgs neutral surface and its order-parameter interpretation are supplied,
-the coordinate `v` is the positive fourth-root coordinate of any positive
-quartic D=4 density
+the EW order-parameter coordinate `v` is the positive fourth-root coordinate of
+any positive quartic D=4 density
 
 ```text
 rho_* = A(L) v(L)^4,       A(L) > 0.
@@ -94,6 +94,20 @@ the unique positive order-parameter ratio is
 v(L) / v_ref = (A_ref / A(L))^(1/4).
 ```
 
+Uniqueness on the positive branch is not assumed. The map `v -> A v^4` is
+strictly increasing on `v > 0`, hence injective there, so a positive density
+fixes exactly one positive coordinate; on all of `R` the same map is even, so
+positivity of `v` is what selects the branch rather than a convention.
+
+The fourth root at a general endpoint pair is irrational, so the paired runner
+closes the solve two independent ways. First, an exact rational witness whose
+coefficient ratio is a perfect fourth power: `A_ref = 16`, `A_L = 81`, and
+`v_ref = 1` give `v_L = 2/3` with `16 * 1^4 = 81 * (2/3)^4 = 16` and
+`(v_L/v_ref)^4 = 16/81 = A_ref/A_L`, all exact in rational arithmetic. Second,
+the real solve at the `7/8` endpoint pair, where
+`(7/8)^(1/4) = 0.967168210134` reproduces the fixed density with a relative
+residual below `1e-15`.
+
 This is the same fourth-root readout as the fixed-density bridge
 [`HIERARCHY_D4_DENSITY_SCALE_READOUT_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-16.md`](HIERARCHY_D4_DENSITY_SCALE_READOUT_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-16.md),
 now tied to the defined neutral vector coordinate rather than an anonymous
@@ -118,9 +132,14 @@ linearly with `v`:
   = (v(L) / v_ref)^4 = A_ref / A(L),
 ```
 
-and similarly for `MZ2`. This is formal algebra only. Calling the readouts W/Z
-masses or `v` a physical VEV still requires the open physical bridge stated
-above.
+and similarly for `MZ2`. Because the positive square roots enter to the fourth
+power, the runner verifies the equivalent rational form
+`(MW2(L)/MW2(ref))^2 = A_ref/A(L)` exactly rather than restating the display,
+and finds the same value across several `(g, gY)` pairs, so no coupling-valued
+prefactor is hiding inside the ratio.
+
+This is formal algebra only. Calling the readouts W/Z masses or `v` a physical
+VEV still requires the open physical bridge stated above.
 
 ## Endpoint Application Boundary
 
@@ -146,12 +165,41 @@ coefficient surface with the physical Higgs density surface.
 
 ## Negative Controls
 
+Each wrong readout is rejected by substituting it back into the density
+equation and measuring the residual, not by comparing it to a label.
+
 - The direct placement `A(L)/A_ref` is the wrong fixed-density direction:
-  it would increase the scale when the endpoint coefficient increases.
+  it would increase the scale when the endpoint coefficient increases. Placed
+  back into `rho_* = A(L) v(L)^4` at the `7/8` endpoint pair it misses the
+  fixed density by a relative residual of `0.3061`.
 - A D=16 root is not the same readout. It fails the D=4 density equation
-  unless the endpoint ratio is trivial.
+  unless the endpoint ratio is trivial; at the same endpoint pair its relative
+  residual is `0.1053`. Both controls sit far above the `0.05` threshold the
+  runner applies, and far above the `1.8e-16` residual of the D=4 solve.
+- Positivity of `v` is load-bearing rather than decorative: the same quartic is
+  even on `R`, so the negative branch carries an identical density and only
+  `v > 0` makes the fourth-root coordinate unique.
 - The theorem uses no observed EW value, no PDG comparator, no fitted selector,
   no new axiom, and no registered approved primitive.
+
+## Scorecard
+
+The paired runner reports a per-section scorecard. Its final check reads the
+declared counts out of the table below and compares them against the counts it
+actually executed, so the table, the Expected fence, and the runner cannot
+drift apart silently.
+
+| Section | Surface | Checks |
+|---|---|---|
+| S1 order-parameter coordinate | `q = 2 H^dagger H = v^2` over a rational grid; exact `rho_* = A v^4 > 0` over an `(A, v)` grid; strict monotonicity on `v > 0`; exact fourth-root recovery of the coordinate; the even-branch control | 5 |
+| S2 fixed-density fourth-root law | endpoint ratio `7/8` independent of `u_0^2`; the exact rational fourth-power witness; the real endpoint solve to machine precision; the two negative controls measured in the density equation | 4 |
+| S3 formal scalar-readout compatibility | `rho = 1` across couplings and coordinates; `(MW2(L)/MW2(ref))^2 = A_ref/A(L)` computed exactly; independence from `(g, gY)` | 3 |
+| S4 source firewalls | bounded-support status fields; the load-bearing markdown links; the stated open residuals; the parent-note citation | 4 |
+| S5 verification-total consistency | this table, the Expected fence, and the runner's executed per-section counts agree | 1 |
+
+```text
+TOTAL: PASS=17 FAIL=0
+```
 
 ## Verification
 
@@ -164,6 +212,6 @@ python3 scripts/frontier_hierarchy_ew_order_parameter_d4_density_readout_bridge_
 Expected:
 
 ```text
-TOTAL: PASS=12 FAIL=0
+TOTAL: PASS=17 FAIL=0
 VERDICT: bounded support passes for the EW order-parameter D=4 density readout bridge. Endpoint selection, absolute scale, and hierarchy-to-physical-Higgs-density identification remain open.
 ```

--- a/logs/runner-cache/frontier_hierarchy_ew_order_parameter_d4_density_readout_bridge_2026_06_18.txt
+++ b/logs/runner-cache/frontier_hierarchy_ew_order_parameter_d4_density_readout_bridge_2026_06_18.txt
@@ -1,6 +1,6 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_hierarchy_ew_order_parameter_d4_density_readout_bridge_2026_06_18.py
-runner_sha256: 2e6ca95bbb9567620a868c0717e7cb602dbf21ba66b0426ee4eb95c248136daa
+runner_sha256: 7a76c4a57e7039796c17b5327e80c6f63e56ffb1e22b85faf4af15e557be2ba2
 timeout_sec: 120
 exit_code: 0
 elapsed_sec: 0.04
@@ -9,38 +9,49 @@ status: ok
 Hierarchy EW order-parameter D=4 density readout bridge
 ==============================================================================
 
-Section 1: neutral one-Higgs order-parameter coordinate
-  [PASS] neutral Higgs norm gives q = 2 H^dagger H = v^2
-         q=9/4, v^2=9/4
-  [PASS] positive quartic density is exactly rho = A v^4
-         rho=567/176, A v^4=567/176
-  [PASS] positive fourth-root coordinate is unique on v > 0
-         rho/A=81/16, v^4=81/16
+S1 order-parameter coordinate
+  [PASS] q = 2 H^dagger H = v^2 for the neutral vector H(v), over a rational grid
+         7 values of v; sample v=3/2: q=9/4, v^2=9/4
+  [PASS] positive quartic density is exactly rho_* = A v^4 > 0, over an (A, v) grid
+         5x7 pairs; sample rho_*=567/176, A v^4=567/176
+  [PASS] v -> A v^4 is strictly increasing on v > 0, hence injective there
+         rho_* rises 7/2816 -> 45927/176
+  [PASS] the unique positive coordinate is recovered exactly as the fourth root of rho_*/A
+         root(rho_*/A)=3/2, v=3/2; recovery exact on all 35 pairs
+  [PASS] positivity of v is load-bearing: v -> A v^4 is NOT injective on all of R
+         rho_*(-v)=567/176 equals rho_*(v)=567/176; v > 0 selects the branch
 
-Section 2: endpoint coefficient ratio
-  [PASS] endpoint coefficient ratio A_ref/A_L is 7/8
-         A_ref/A_L=7/8
-  [PASS] fixed density forces (v_L/v_ref)^4 = A_ref/A_L
-         same rho_* = A_ref v_ref^4 = A_L v_L^4
-  [PASS] direct placement A_L/A_ref is the wrong fixed-density direction
-         wrong=8/7, correct=7/8
-  [PASS] D=4 fourth-root readout is distinct from D=16 readout
-         D4=0.967168210134, D16=0.991689016736, separation=0.024726
+S2 fixed-density fourth-root law
+  [PASS] endpoint coefficient ratio A_ref/A_L = 7/8, independent of the common u0^2
+         A_2=1/(8u0^2), A_4=1/(7u0^2); ratio=7/8 for all 4 values of u0^2
+  [PASS] exact witness: solving A_ref v_ref^4 = A_L v_L^4 gives (v_L/v_ref)^4 = A_ref/A_L
+         A_ref/A_L=16/81, v_L/v_ref=2/3, rho_*=16=16 (exact)
+  [PASS] endpoint solve at A_ref/A_L = 7/8 reproduces the fixed density to machine precision
+         v_L/v_ref=0.967168210134, density residual=1.82e-16, A_L>A_ref so v_L<v_ref
+  [PASS] wrong-direction and D=16 exponents both MISS the same fixed density by a wide margin
+         (A_L/A_ref)^(1/4): residual=0.3061; (A_ref/A_L)^(1/16): residual=0.1053
 
-Section 3: defined scalar-readout compatibility
-  [PASS] formal rho readout stays one
-         rho_tree=1
-  [PASS] fixed-coupling formal readout ratios follow the same v ratio
-         (sqrt(MW2_L)/sqrt(MW2_ref))^4 = (v_L/v_ref)^4
+S3 formal scalar-readout compatibility
+  [PASS] formal rho readout stays exactly one at every coupling pair and every v
+         4x7 cases; sample g=3, gY=4: rho_tree=1
+  [PASS] formal readout ratios carry the same fourth power: (MW2_L/MW2_ref)^2 = A_ref/A_L
+         (MW2_L/MW2_ref)^2=16/81, (MZ2_L/MZ2_ref)^2=16/81, A_ref/A_L=16/81
+  [PASS] that ratio is independent of (g, gY): no coupling-valued prefactor enters
+         identical fourth power 16/81 at all 4 coupling pairs
 
-Section 4: source firewalls
-  [PASS] new bridge carries bounded-support status fields and no retained claim
-  [PASS] new bridge markdown-links load-bearing EW and D4 readout authorities
-  [PASS] new bridge explicitly leaves endpoint selection and absolute scale open
-  [PASS] parent note cites the new bridge while preserving the residual
+S4 source firewalls
+  [PASS] bridge carries bounded-support status fields and no retained claim
+  [PASS] bridge markdown-links load-bearing EW and D4 readout authorities
+  [PASS] bridge explicitly leaves endpoint selection and absolute scale open
+  [PASS] parent note cites the bridge while preserving the residual
+
+S5 verification-total consistency
+  [PASS] note Scorecard, note Expected fence, and this runner's check count all agree
+         declared S1=5,S2=4,S3=3,S4=4,S5=1 total=17 | actual S1=5,S2=4,S3=3,S4=4,S5=1 total=17 | note TOTAL lines=2
 
 ==============================================================================
-TOTAL: PASS=13 FAIL=0
+per-section: S1=5  S2=4  S3=3  S4=4  S5=1
+TOTAL: PASS=17 FAIL=0
 VERDICT: bounded support passes for the EW order-parameter D=4 density readout bridge. Endpoint selection, absolute scale, and hierarchy-to-physical-Higgs-density identification remain open.
 
 ----- stderr -----

--- a/scripts/frontier_hierarchy_ew_order_parameter_d4_density_readout_bridge_2026_06_18.py
+++ b/scripts/frontier_hierarchy_ew_order_parameter_d4_density_readout_bridge_2026_06_18.py
@@ -1,20 +1,30 @@
 #!/usr/bin/env python3
-"""EW order-parameter D=4 density readout bridge.
+"""EW order-parameter D=4 density readout bridge (bounded support).
 
-This runner verifies a narrow source-side bridge for the hierarchy
-dimensional-compression blocker. It proves only the finite algebra that the
-defined neutral vector coordinate v is the positive
-fourth-root coordinate of a positive quartic D=4 density.
+Verifies the finite algebra behind one narrow source-side bridge for the
+hierarchy dimensional-compression blocker: the defined neutral vector
+coordinate v is the positive fourth-root coordinate of a positive quartic D=4
+density, and holding that density fixed relates two endpoint coefficients by an
+inverse fourth root.
+
+Every step is exact rational arithmetic except the two real-root witnesses in
+S2 (a genuine fourth root and a sixteenth root); those are floats and are
+reported with measured residuals against the density equation itself, so the
+negative controls are separations in the equation rather than in a label.
 
 It does not derive the hierarchy endpoint coefficient surface, the absolute
 EW scale, M_Pl, alpha_LM, or any observed value.
+
+The section check counts below are mirrored in the paired note's Scorecard.
+S5 is the gate holding the note's declared verification total and this runner's
+actual check count in agreement; it must remain the final check.
 """
 
 from __future__ import annotations
 
 from fractions import Fraction
 from pathlib import Path
-import math
+import re
 import sys
 
 
@@ -26,112 +36,261 @@ NOTE_PATH = (
 )
 PARENT_NOTE_PATH = ROOT / "docs" / "HIERARCHY_DIMENSIONAL_COMPRESSION_NOTE.md"
 
+SECTION_ORDER = ("S1", "S2", "S3", "S4", "S5")
+SECTION_TITLES = {
+    "S1": "order-parameter coordinate",
+    "S2": "fixed-density fourth-root law",
+    "S3": "formal scalar-readout compatibility",
+    "S4": "source firewalls",
+    "S5": "verification-total consistency",
+}
+
 PASS_COUNT = 0
 FAIL_COUNT = 0
+SECTION_COUNTS = {key: 0 for key in SECTION_ORDER}
+CURRENT_SECTION = SECTION_ORDER[0]
+
+
+def section(key: str) -> None:
+    global CURRENT_SECTION
+    CURRENT_SECTION = key
+    print(f"\n{key} {SECTION_TITLES[key]}")
 
 
 def check(name: str, condition: bool, detail: str = "") -> None:
     global PASS_COUNT, FAIL_COUNT
-    status = "PASS" if condition else "FAIL"
+    SECTION_COUNTS[CURRENT_SECTION] += 1
     if condition:
         PASS_COUNT += 1
     else:
         FAIL_COUNT += 1
-    print(f"  [{status}] {name}")
+    print(f"  [{'PASS' if condition else 'FAIL'}] {name}")
     if detail:
         print(f"         {detail}")
 
 
-def positive_quartic_density(A: Fraction, v: Fraction) -> Fraction:
-    """rho = A * q^2 with q = 2 H^dagger H = v^2."""
-    q = v * v
-    return A * q * q
+def q_readout(v: Fraction) -> Fraction:
+    """q(H) = 2 H^dagger H for the neutral vector H(v) = (0, v/sqrt(2))^T.
+
+    The 1/sqrt(2) normalization squares to 1/2, so H^dagger H = (0^2 + v^2)/2
+    stays exact in Fractions and q = 2 H^dagger H = v^2.
+    """
+    upper = Fraction(0)
+    h_dagger_h = (upper * upper + v * v) / 2
+    return 2 * h_dagger_h
+
+
+def quartic_density(coeff: Fraction, v: Fraction) -> Fraction:
+    """rho_* = A q(H(v))^2, built from the readout q rather than from v^4."""
+    q = q_readout(v)
+    return coeff * q * q
+
+
+def positive_fourth_root(x: Fraction) -> Fraction | None:
+    """Exact positive rational fourth root of x, or None when it is irrational.
+
+    The candidate is taken from a float estimate and then CONFIRMED by exact
+    exponentiation, so a wrong estimate returns None rather than an approximation.
+    """
+    if x <= 0:
+        return None
+    num = int(round(float(x.numerator) ** 0.25))
+    den = int(round(float(x.denominator) ** 0.25))
+    for n in (num - 1, num, num + 1):
+        for d in (den - 1, den, den + 1):
+            if n > 0 and d > 0 and Fraction(n, d) ** 4 == x:
+                return Fraction(n, d)
+    return None
+
+
+def endpoint_coefficients(u0_sq: Fraction) -> tuple[Fraction, Fraction]:
+    """Supplied endpoint quartic coefficients A_2 = 1/(8 u0^2), A_4 = 1/(7 u0^2)."""
+    return Fraction(1, 8) / u0_sq, Fraction(1, 7) / u0_sq
+
+
+def formal_readouts(g: Fraction, g_y: Fraction, v: Fraction):
+    """Formal scalar labels of the defined quadratic form. No observed input."""
+    mw_sq = g * g * v * v / 4
+    mz_sq = (g * g + g_y * g_y) * v * v / 4
+    cos_sq = g * g / (g * g + g_y * g_y)
+    return mw_sq, mz_sq, mw_sq / (mz_sq * cos_sq)
+
+
+def parse_note_scorecard(note: str) -> tuple[dict[str, tuple[str, int]], int | None]:
+    """Read the paired note's Scorecard table: section key -> (label, declared checks)."""
+    declared: dict[str, tuple[str, int]] = {}
+    if "## Scorecard" not in note:
+        return declared, None
+    body = note.split("## Scorecard", 1)[1].split("\n## ", 1)[0]
+    for line in body.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) != 3 or not cells[2].isdigit():
+            continue
+        head = re.match(r"^(S[1-5])\s+(.+)$", cells[0])
+        if head:
+            declared[head.group(1)] = (head.group(2).strip(), int(cells[2]))
+    totals = re.findall(r"TOTAL: PASS=(\d+) FAIL=(\d+)", body)
+    return declared, int(totals[0][0]) if totals else None
 
 
 def main() -> int:
     print("Hierarchy EW order-parameter D=4 density readout bridge")
     print("=" * 78)
 
-    print("\nSection 1: neutral one-Higgs order-parameter coordinate")
+    # ---------------------------------------------------------------- S1
+    section("S1")
+    v_grid = [Fraction(1, 4), Fraction(1, 2), Fraction(3, 4), Fraction(1),
+              Fraction(3, 2), Fraction(5, 3), Fraction(9, 2)]
+    a_grid = [Fraction(1, 8), Fraction(1, 7), Fraction(7, 11), Fraction(3), Fraction(20, 3)]
     v = Fraction(3, 2)
-    h_norm_sq = v * v / 2
-    q = 2 * h_norm_sq
+    coeff = Fraction(7, 11)
+
+    q_ok = all(q_readout(w) == w * w for w in v_grid)
     check(
-        "neutral Higgs norm gives q = 2 H^dagger H = v^2",
-        q == v * v,
-        f"q={q}, v^2={v * v}",
+        "q = 2 H^dagger H = v^2 for the neutral vector H(v), over a rational grid",
+        q_ok,
+        f"{len(v_grid)} values of v; sample v={v}: q={q_readout(v)}, v^2={v * v}",
     )
 
-    A = Fraction(7, 11)
-    rho = positive_quartic_density(A, v)
-    check(
-        "positive quartic density is exactly rho = A v^4",
-        rho == A * v**4 and rho > 0,
-        f"rho={rho}, A v^4={A * v**4}",
+    rho = quartic_density(coeff, v)
+    density_ok = all(
+        quartic_density(a, w) == a * w**4 and quartic_density(a, w) > 0
+        for a in a_grid
+        for w in v_grid
     )
     check(
-        "positive fourth-root coordinate is unique on v > 0",
-        rho / A == v**4 and v > 0,
-        f"rho/A={rho / A}, v^4={v**4}",
-    )
-
-    print("\nSection 2: endpoint coefficient ratio")
-    # Endpoint coefficients with the common u0^-2 factor removed:
-    # A_2 = 1/(8 u0^2), A_4 = 1/(7 u0^2), hence A_2/A_4 = 7/8.
-    A_ref = Fraction(1, 8)
-    A_L = Fraction(1, 7)
-    coeff_ratio = A_ref / A_L
-    check(
-        "endpoint coefficient ratio A_ref/A_L is 7/8",
-        coeff_ratio == Fraction(7, 8),
-        f"A_ref/A_L={coeff_ratio}",
-    )
-    check(
-        "fixed density forces (v_L/v_ref)^4 = A_ref/A_L",
-        coeff_ratio == Fraction(7, 8),
-        "same rho_* = A_ref v_ref^4 = A_L v_L^4",
-    )
-    wrong_direct = A_L / A_ref
-    check(
-        "direct placement A_L/A_ref is the wrong fixed-density direction",
-        wrong_direct != coeff_ratio and wrong_direct == Fraction(8, 7),
-        f"wrong={wrong_direct}, correct={coeff_ratio}",
-    )
-    d4 = float(coeff_ratio) ** 0.25
-    d16 = float(coeff_ratio) ** (1 / 16)
-    check(
-        "D=4 fourth-root readout is distinct from D=16 readout",
-        abs(d4 / d16 - 1.0) > 0.02,
-        f"D4={d4:.12f}, D16={d16:.12f}, separation={abs(d4 / d16 - 1.0):.6f}",
+        "positive quartic density is exactly rho_* = A v^4 > 0, over an (A, v) grid",
+        density_ok,
+        f"{len(a_grid)}x{len(v_grid)} pairs; sample rho_*={rho}, A v^4={coeff * v**4}",
     )
 
-    print("\nSection 3: defined scalar-readout compatibility")
-    g = Fraction(3, 1)
-    g_y = Fraction(4, 1)
-    v_ref = Fraction(5, 1)
-    # These are formal scalar labels from the defined quadratic form.
-    mw_ref_sq = g * g * v_ref * v_ref / 4
-    mz_ref_sq = (g * g + g_y * g_y) * v_ref * v_ref / 4
-    cos2 = g * g / (g * g + g_y * g_y)
-    rho_tree = mw_ref_sq / (mz_ref_sq * cos2)
-    check(
-        "formal rho readout stays one",
-        rho_tree == 1,
-        f"rho_tree={rho_tree}",
+    rising = all(
+        quartic_density(coeff, v_grid[i]) < quartic_density(coeff, v_grid[i + 1])
+        for i in range(len(v_grid) - 1)
     )
     check(
-        "fixed-coupling formal readout ratios follow the same v ratio",
-        coeff_ratio == Fraction(7, 8),
-        "(sqrt(MW2_L)/sqrt(MW2_ref))^4 = (v_L/v_ref)^4",
+        "v -> A v^4 is strictly increasing on v > 0, hence injective there",
+        rising,
+        f"rho_* rises {quartic_density(coeff, v_grid[0])} -> {quartic_density(coeff, v_grid[-1])}",
     )
 
-    print("\nSection 4: source firewalls")
+    recovered = positive_fourth_root(rho / coeff)
+    grid_recovered = all(
+        positive_fourth_root(quartic_density(a, w) / a) == w for a in a_grid for w in v_grid
+    )
+    check(
+        "the unique positive coordinate is recovered exactly as the fourth root of rho_*/A",
+        recovered == v and grid_recovered,
+        f"root(rho_*/A)={recovered}, v={v}; recovery exact on all {len(a_grid) * len(v_grid)} pairs",
+    )
+
+    check(
+        "positivity of v is load-bearing: v -> A v^4 is NOT injective on all of R",
+        quartic_density(coeff, -v) == rho and -v != v,
+        f"rho_*(-v)={quartic_density(coeff, -v)} equals rho_*(v)={rho}; v > 0 selects the branch",
+    )
+
+    # ---------------------------------------------------------------- S2
+    section("S2")
+    u0_grid = [Fraction(1), Fraction(2, 5), Fraction(9, 4), Fraction(13, 7)]
+    ratios = {endpoint_coefficients(u)[0] / endpoint_coefficients(u)[1] for u in u0_grid}
+    a_ref, a_l = endpoint_coefficients(Fraction(1))
+    check(
+        "endpoint coefficient ratio A_ref/A_L = 7/8, independent of the common u0^2",
+        ratios == {Fraction(7, 8)},
+        f"A_2=1/(8u0^2), A_4=1/(7u0^2); ratio={ratios.pop()} for all {len(u0_grid)} values of u0^2",
+    )
+
+    # Exact witness: a coefficient pair whose ratio is a perfect fourth power,
+    # so the fixed-density solve closes in exact rational arithmetic.
+    ex_ref, ex_l = Fraction(16), Fraction(81)
+    ex_v_ref = Fraction(1)
+    ex_v_l = positive_fourth_root(ex_ref / ex_l)
+    ex_rho_ref = quartic_density(ex_ref, ex_v_ref)
+    ex_rho_l = quartic_density(ex_l, ex_v_l * ex_v_ref)
+    check(
+        "exact witness: solving A_ref v_ref^4 = A_L v_L^4 gives (v_L/v_ref)^4 = A_ref/A_L",
+        ex_v_l == Fraction(2, 3)
+        and ex_rho_ref == ex_rho_l
+        and ex_v_l**4 == ex_ref / ex_l,
+        f"A_ref/A_L={ex_ref / ex_l}, v_L/v_ref={ex_v_l}, rho_*={ex_rho_ref}={ex_rho_l} (exact)",
+    )
+
+    # Endpoint solve at the actual 7/8 ratio: the fourth root is irrational here,
+    # so the density equation is closed numerically and the residual is measured.
+    v_ref = 5.0
+    target_rho = float(a_ref) * v_ref**4
+    x_true = float(a_ref / a_l) ** 0.25
+    v_l = x_true * v_ref
+    resid_true = abs(float(a_l) * v_l**4 - target_rho) / target_rho
+    check(
+        "endpoint solve at A_ref/A_L = 7/8 reproduces the fixed density to machine precision",
+        resid_true < 1e-15 and abs(x_true**4 - 7 / 8) < 1e-15 and v_l < v_ref,
+        f"v_L/v_ref={x_true:.12f}, density residual={resid_true:.2e}, A_L>A_ref so v_L<v_ref",
+    )
+
+    x_flip = float(a_l / a_ref) ** 0.25
+    resid_flip = abs(float(a_l) * (x_flip * v_ref) ** 4 - target_rho) / target_rho
+    x_d16 = float(a_ref / a_l) ** (1 / 16)
+    resid_d16 = abs(float(a_l) * (x_d16 * v_ref) ** 4 - target_rho) / target_rho
+    check(
+        "wrong-direction and D=16 exponents both MISS the same fixed density by a wide margin",
+        resid_flip > 0.05 and resid_d16 > 0.05,
+        f"(A_L/A_ref)^(1/4): residual={resid_flip:.4f}; (A_ref/A_L)^(1/16): residual={resid_d16:.4f}",
+    )
+
+    # ---------------------------------------------------------------- S3
+    section("S3")
+    coupling_grid = [
+        (Fraction(3), Fraction(4)),
+        (Fraction(1), Fraction(1)),
+        (Fraction(5), Fraction(2)),
+        (Fraction(8), Fraction(11)),
+    ]
+    rho_tree_ok = all(
+        formal_readouts(g, g_y, w)[2] == 1 for (g, g_y) in coupling_grid for w in v_grid
+    )
+    g0, g_y0 = coupling_grid[0]
+    check(
+        "formal rho readout stays exactly one at every coupling pair and every v",
+        rho_tree_ok,
+        f"{len(coupling_grid)}x{len(v_grid)} cases; sample g={g0}, gY={g_y0}: rho_tree="
+        f"{formal_readouts(g0, g_y0, v)[2]}",
+    )
+
+    # (sqrt(MW2_L)/sqrt(MW2_ref))^4 = (MW2_L/MW2_ref)^2 for positive square roots,
+    # so the note's displayed readout ratio is COMPUTED here, not restated.
+    mw_ref, mz_ref, _ = formal_readouts(g0, g_y0, ex_v_ref)
+    mw_l, mz_l, _ = formal_readouts(g0, g_y0, ex_v_l * ex_v_ref)
+    check(
+        "formal readout ratios carry the same fourth power: (MW2_L/MW2_ref)^2 = A_ref/A_L",
+        (mw_l / mw_ref) ** 2 == ex_ref / ex_l and (mz_l / mz_ref) ** 2 == ex_ref / ex_l,
+        f"(MW2_L/MW2_ref)^2={(mw_l / mw_ref) ** 2}, (MZ2_L/MZ2_ref)^2={(mz_l / mz_ref) ** 2}, "
+        f"A_ref/A_L={ex_ref / ex_l}",
+    )
+
+    coupling_free = True
+    for g, g_y in coupling_grid:
+        w_ref, z_ref, _ = formal_readouts(g, g_y, ex_v_ref)
+        w_l, z_l, _ = formal_readouts(g, g_y, ex_v_l * ex_v_ref)
+        coupling_free = coupling_free and (w_l / w_ref) ** 2 == ex_ref / ex_l
+        coupling_free = coupling_free and (z_l / z_ref) ** 2 == ex_ref / ex_l
+    check(
+        "that ratio is independent of (g, gY): no coupling-valued prefactor enters",
+        coupling_free,
+        f"identical fourth power {ex_ref / ex_l} at all {len(coupling_grid)} coupling pairs",
+    )
+
+    # ---------------------------------------------------------------- S4
+    section("S4")
     note = NOTE_PATH.read_text(encoding="utf-8")
     parent = PARENT_NOTE_PATH.read_text(encoding="utf-8")
     note_flat = " ".join(note.split())
     parent_flat = " ".join(parent.split())
     check(
-        "new bridge carries bounded-support status fields and no retained claim",
+        "bridge carries bounded-support status fields and no retained claim",
         "**Claim type:** bounded_theorem" in note
         and "**Type:** bounded_theorem" in note
         and "bounded support for the EW order-parameter D4 density readout" in note_flat
@@ -142,24 +301,50 @@ def main() -> int:
         and "bare_retained_allowed: false" in note,
     )
     check(
-        "new bridge markdown-links load-bearing EW and D4 readout authorities",
+        "bridge markdown-links load-bearing EW and D4 readout authorities",
         "[`EW_HIGGS_GAUGE_MASS_DIAGONALIZATION_THEOREM_NOTE_2026-04-26.md`](EW_HIGGS_GAUGE_MASS_DIAGONALIZATION_THEOREM_NOTE_2026-04-26.md)" in note
         and "[`HIERARCHY_D4_DENSITY_SCALE_READOUT_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-16.md`](HIERARCHY_D4_DENSITY_SCALE_READOUT_BRIDGE_BOUNDED_THEOREM_NOTE_2026-06-16.md)" in note,
     )
     check(
-        "new bridge explicitly leaves endpoint selection and absolute scale open",
+        "bridge explicitly leaves endpoint selection and absolute scale open",
         "does not derive that the hierarchy Matsubara endpoint coefficient is the physical Higgs density" in note_flat
         and "does not derive the absolute EW scale" in note_flat
         and "does not use an observed EW value" in note_flat,
     )
     check(
-        "parent note cites the new bridge while preserving the residual",
+        "parent note cites the bridge while preserving the residual",
         "HIERARCHY_EW_ORDER_PARAMETER_D4_DENSITY_READOUT_BRIDGE_BOUNDED_SUPPORT_NOTE_2026-06-18.md" in parent
         and "endpoint-selection residual remains open" in parent_flat
         and "proposal_allowed: false" in parent,
     )
 
+    # ---------------------------------------------------------------- S5
+    section("S5")
+    declared, declared_total = parse_note_scorecard(note)
+    actual = dict(SECTION_COUNTS)
+    actual["S5"] = SECTION_COUNTS["S5"] + 1  # this consistency check itself
+    final_total = PASS_COUNT + FAIL_COUNT + 1
+    note_totals = re.findall(r"TOTAL: PASS=(\d+) FAIL=(\d+)", note)
+    labels_ok = all(declared.get(k, ("", -1))[0] == SECTION_TITLES[k] for k in SECTION_ORDER)
+    counts_ok = all(declared.get(k, ("", -1))[1] == actual[k] for k in SECTION_ORDER)
+    sum_ok = declared_total is not None and declared_total == sum(n for _, n in declared.values())
+    # The note must carry the same total in BOTH the Scorecard and the
+    # Verification block's Expected fence, and carry no stale total anywhere.
+    fences_ok = len(note_totals) >= 2 and all(
+        (int(p), int(f)) == (final_total, 0) for p, f in note_totals
+    )
+    check(
+        "note Scorecard, note Expected fence, and this runner's check count all agree",
+        labels_ok and counts_ok and sum_ok and declared_total == final_total and fences_ok,
+        "declared "
+        + ",".join(f"{k}={declared.get(k, ('', -1))[1]}" for k in SECTION_ORDER)
+        + f" total={declared_total} | actual "
+        + ",".join(f"{k}={actual[k]}" for k in SECTION_ORDER)
+        + f" total={final_total} | note TOTAL lines={len(note_totals)}",
+    )
+
     print("\n" + "=" * 78)
+    print("per-section: " + "  ".join(f"{k}={SECTION_COUNTS[k]}" for k in SECTION_ORDER))
     print(f"TOTAL: PASS={PASS_COUNT} FAIL={FAIL_COUNT}")
     if FAIL_COUNT:
         print("VERDICT: FAIL - EW order-parameter D=4 readout bridge needs repair.")


### PR DESCRIPTION
## Row

`hierarchy_ew_order_parameter_d4_density_readout_bridge_bounded_support_note_2026-06-18`
— `effective_status: audited_failed`, `criticality: critical`, fan 737, `load_bearing_step_class: A`, audit date 2026-07-22.

**Audited `claim_scope` (ledger, authoritative):**
> For the defined neutral vector H(v) and a supplied positive quartic D=4 density, the q=v^2 substitution, inverse fourth-root fixed-density ratio, and as-written runner verification total.

**`verdict_rationale`:**
> Five-judge panel majority (5/5 matching full tuples)… the source expects TOTAL: PASS=12 FAIL=0, while the supplied runner executes 13 checks and reports TOTAL: PASS=13 FAIL=0. Although the class-A finite algebra closes, that factual mismatch leaves the full scoped claim false as written, so audited_failed is the correct conservative tuple.

**`notes_for_re_audit_if_any`:**
> Correct the Verification block's expected total from 12 to 13, or reconcile the runner check count, then re-audit the unchanged algebra.

This PR takes the second branch — reconcile the count — and additionally repairs
two tautological gates found sitting inside the same audited scope, which
explicitly covers "the as-written runner verification total".

## What changed

**1. The count is now derived, not asserted.** The note carries a per-section
`## Scorecard` table. The runner's final check (S5) parses that table, compares
each declared per-section count against the counts it actually executed, and
cross-checks both `TOTAL:` fences in the note. The defect class cannot silently
recur: perturbing the note's number, or adding/removing a runner check, fails
the gate.

**2. Two gates were tautological (anti-fabrication pattern 5).** Both
`check("fixed density forces (v_L/v_ref)^4 = A_ref/A_L", coeff_ratio == Fraction(7, 8), …)`
and the formal-readout gate re-tested the *previous* check's condition. Replaced with:

- an exact rational fourth-power witness — `A_ref = 16`, `A_L = 81`, `v_ref = 1`
  give `v_L = 2/3` with `16*1^4 = 81*(2/3)^4 = 16` and `(v_L/v_ref)^4 = 16/81`,
  all exact in `Fraction` arithmetic — plus the real solve at the `7/8` endpoint
  pair: `v_L/v_ref = 0.967168210134`, density residual `1.82e-16`;
- the formal readout ratio computed exactly as `(MW2_L/MW2_ref)^2 = A_ref/A_L`
  rather than restating the display, identical across four `(g, gY)` pairs, so no
  coupling-valued prefactor hides in the ratio.

**3. Both negative controls compared labels rather than physics.** The
wrong-direction control only asserted `wrong_direct == Fraction(8,7)` (trivially
true); the D=16 control only checked a 2% float separation between two labels.
Both now substitute the wrong readout back into `rho_* = A(L) v(L)^4` and are
rejected by measured residual:

| control | measured residual |
|---|---|
| wrong fixed-density direction `(A_L/A_ref)^(1/4)` | `0.3061` |
| D=16 root `(A_ref/A_L)^(1/16)` | `0.1053` |
| threshold applied | `0.05` |
| correct D=4 solve | `1.82e-16` |

**4. Uniqueness is proved, not assumed.** `v -> A v^4` is strictly increasing on
`v > 0`, hence injective there; on all of `R` it is even, so positivity of `v`
selects the branch rather than a convention. The runner checks both directions,
including the even-branch control.

Structure: 13 checks / 4 sections → 17 checks / 5 sections (S1=5, S2=4, S3=3, S4=4, S5=1).

## Verification

- Own re-run post-rebase: `TOTAL: PASS=17 FAIL=0`, exit 0. Cache `runner_sha256`
  verified identical to the runner's actual sha.
- **Discriminating-gate test: 9/9 DISCRIMINATING.** Every gate was re-run with its
  load-bearing term perturbed one at a time (note declared count, note Expected
  fence, note Scorecard total, note firewall prose, a dropped markdown link,
  wrong-direction control given the right root, D=16 control given the D=4
  exponent, readout ratio unsquared, fourth-root recovery downgraded to a square
  root). Each produced a FAIL in the expected section; baseline and restore both
  `exit=0 TOTAL: PASS=17 FAIL=0`. No gate survives perturbation of its own term.
- Budgets measured, not estimated: cache body **3,238 / 6,000**; runner source
  **15,235 / 40,000**; note body **8,418 / 30,000**.
- Sibling scan (five-way: note-text readers, cache parsers, module importers,
  runner-source greppers, prose greppers) run in baseline vs worktree — see below.
- The three prose strings sibling runners grep are preserved verbatim, each
  against the correct raw-vs-flattened haystack.

## Scope discipline

Every addition verifies a component already inside the audited `claim_scope`. No
new claim, no new axiom, no import, no literature comparator, no observed EW
value, no PDG comparator, no approved primitive, no `r = 1/2` language, no
closing framing, no grade language. The bounded-support status fields and the
open residuals (endpoint selection, absolute scale, hierarchy-to-physical-Higgs-density
identification) are unchanged and still firewalled by S4.

No `citation_graph_manifest.json` change: no new note is added and this note is
already registered.

## Observations for the owner (pre-existing, not repaired here)

1. `scripts/frontier_hierarchy_fixed_density_physical_selector_no_go_2026_06_18.py`
   was **stale-green on main**: its committed cache records `PASS=18 FAIL=0` and
   pins `runner_sha256: ffe31f8af07c…` matching its current runner exactly, but
   run against main the runner produces `exit=1 PASS=17 FAIL=1`. It greps this
   note for prose that had drifted. This PR's note edit makes that cache truthful
   again (worktree run: `exit=0 PASS=18 FAIL=0`), so no extra cache file is
   included. Worth noting as a class: **a matching `runner_sha256` does not mean a
   fresh cache** when the runner reads other files.
2. `scripts/frontier_hierarchy_dimensional_compression_taste_authority_2026_06_15.py`
   crashes identically in both trees with
   `FileNotFoundError: docs/audit/data/audit_ledger.json` — the retired monolithic
   ledger. Pre-existing stale-registry defect on a different (`unaudited`) row,
   unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)