### PR TITLE
science-fix: strengthen finite teleportation initial-state certificate

### DIFF
--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/APPROACH_REGISTRY.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/APPROACH_REGISTRY.md
@@ -1,0 +1,14 @@
+# Approach Registry
+
+Exact target contract: certify, only on the default mass-zero `G=0` 1D `N=8`
+and 2D `4x4` surfaces, the unique uniform one-species ground, its exact gap,
+the unique two-register tensor-product ground, rank-one separability, and
+`PR/dim=1`; do not derive operational preparation.
+
+| Mathematical family | Obligation | Result | Strength relative to target |
+|---|---|---|---|
+| Periodic Fourier diagonalization | Unique uniform `H1` ground and exact first gap | closed analytically | equal to finite spectral subtarget |
+| Kronecker-sum spectral calculus | Unique two-register ground and inherited gap | closed analytically | equal to product subtarget |
+| Explicit tensor factorization | Species and logical/environment Schmidt rank one | closed analytically and checked numerically | equal to separability subtarget |
+| Uniform-probability identities | Full support, `PR=N^2`, and `PR/dim=1` | closed analytically and checked numerically | equal to delocalization subtarget |
+| Physical protocol/scaling | Cooling, control, noise, verification, and time bounds | unattempted by scope | strictly stronger than finite target |

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/ARTIFACT_PLAN.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/ARTIFACT_PLAN.md
@@ -1,0 +1,7 @@
+# Artifact Plan
+
+1. Strengthen the note with the exact Fourier spectrum and gaps on the two
+   default surfaces.
+2. Add a nonzero-exit derivation certificate to the existing runner.
+3. Refresh the SHA-pinned runner output and run focused checks.
+4. Apply review-loop backpressure and record the honest open-gate status.

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/ASSUMPTIONS_AND_IMPORTS.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/ASSUMPTIONS_AND_IMPORTS.md
@@ -1,0 +1,27 @@
+# Assumptions and Imports
+
+| Item | Role in claim | Current class | Source surface | Load-bearing? | Needed for target status? | Retirement path | Disposition |
+|---|---|---|---|---|---|---|---|
+| Default 1D `N=8` and 2D `4x4` periodic lattices | Defines the finite claim surface | admitted normalization | target note and runner | yes | yes | fixed scope | explicit |
+| `mass=0`, `G=0`, `t_hop=1` | Fixed control surface reducing the Hamiltonian to `H1=-A` and a Kronecker sum | admitted normalization / boundary condition | target note and runner defaults | yes | yes | explicit finite claim scope plus matrix-identity checks | disclosed and checked |
+| `build_H1` / `build_H2_tensor` implementation | Constructs the finite matrices | computed lattice input | `scripts/frontier_bell_inequality.py` | yes | yes | executable residuals against independently written matrix identities | retired by certificate |
+| Distinguishable-species tensor-product basis `|i,j>` | Fixes the two-species Hilbert-space convention | admitted normalization / boundary condition | `scripts/frontier_bell_inequality.py` | yes | yes | explicit constructor docstring and Kronecker-sum residual | disclosed and checked |
+| Periodic Fourier spectrum of adjacency | Proves unique uniform ground and exact gap | zero-input structural | derivation in target note | yes | yes | analytic derivation | closed |
+| `factor_sites` logical/environment indexing | Defines the audited separability split | admitted normalization / boundary condition | `scripts/frontier_teleportation_resource_from_poisson.py` | yes | yes | explicit indexing plus exact uniform-factor residual | disclosed and checked |
+| Dense eigensolver output | Independent finite numerical cross-check | computed lattice input | SciPy `eigh` in runner | no | no | analytic spectrum | confirmation only |
+| Cooling/control/readout protocol | Would establish operational preparation | unsupported import | absent | no, for finite open-gate boundary | no | future physical protocol | explicitly open |
+| Noise and preparation-time scaling | Would extend beyond the finite diagnostic | unsupported import | absent | no, for finite open-gate boundary | no | future model/theorem | explicitly open |
+
+No observed target values, fitted selectors, literature values, or admitted
+unit conversions enter the finite derivation.
+
+## Counterfactual pass
+
+| Assumption | What if it is wrong? | Concrete alternative | Direction it opens | Feasibility | Score |
+|---|---|---|---|---|---:|
+| Periodic 1D `N=8` and 2D `4x4` geometry | The Fourier spectrum and gap formulas change | Other sizes or boundary conditions | A separate scaling or boundary study, not this finite claim | live but outside scope | 1 |
+| `mass=0`, `G=0`, `t_hop=1` | The uniform vector need not be the same ground state | Nonzero mass/coupling or rescaled hopping | A different initial-state theorem with new spectral inputs | live but outside scope | 1 |
+| Distinguishable ordered species registers | Symmetrization restricts the Hilbert space | Bosonic or fermionic two-particle sector | A different resource encoding and ground-space analysis | live but outside scope | 1 |
+| `factor_sites` split defines the audited logical/environment cut | Another encoding changes the factorization diagnostic | Different logical axis or encoding map | Encoding-portability analysis, not native-site support | live but outside scope | 1 |
+| Native-basis localization uses `PR/dim <= 0.25` | The qualitative threshold label changes | Another declared threshold | Does not change the exact result `PR/dim=1` | insensitive nuisance | 0 |
+| No operational preparation model is supplied | A concrete protocol could close part of the open gate | Cooling/control/noise/readout model with scaling bounds | Operational preparation theorem | live hard residual outside authorized target | 2 |

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/CLAIM_STATUS_CERTIFICATE.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/CLAIM_STATUS_CERTIFICATE.md
@@ -1,0 +1,21 @@
+# Claim Status Certificate
+
+```yaml
+actual_current_surface_status: open
+target_claim_type: open_gate
+trace_class: direct_blocker_closure
+reachability_to_target: closes
+conditional_surface_status: null
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "The finite diagnostic chain is exact, while operational preparation remains explicitly unclosed."
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+- Open imports for the finite diagnostic target: none.
+- Observed, fitted, or literature proof inputs: none.
+- Review-loop disposition: `pass` after one topology-certificate fix and a
+  focused confirmation iteration.
+- Independent audit remains required before the strengthened note can be
+  treated as a clean open-gate authority surface.

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/GOAL.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/GOAL.md
@@ -1,0 +1,7 @@
+# Goal
+
+Close the derivation behind the finite open-gate claim in
+`docs/TELEPORTATION_INITIAL_STATE_PREPARATION_PROBE_NOTE.md`: on the default
+mass-zero, `G=0` 1D `N=8` and 2D `4x4` surfaces, certify uniqueness, exact
+`H1`-ground tensor-product structure, separability, and maximal native-site
+delocalization while leaving physical preparation, noise, and scaling open.

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/HANDOFF.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/HANDOFF.md
@@ -1,0 +1,41 @@
+# Handoff
+
+## Current state
+
+- Block: 01, finite initial-state derivation closure.
+- Actual status: open.
+- Trace: direct blocker closure for the finite mathematical chain.
+- Review-loop: pass after one current-branch topology fix and confirmation;
+  a matching prior branch also carried two clean review iterations.
+- Lock: branch-local isolated worktree; the repo lock helper failed with
+  permission denied at `/Users/jonreilly`.
+
+## Files
+
+- `docs/TELEPORTATION_INITIAL_STATE_PREPARATION_PROBE_NOTE.md`
+- `scripts/frontier_teleportation_initial_state_preparation_probe.py`
+- `logs/runner-cache/frontier_teleportation_initial_state_preparation_probe.txt`
+
+## Remaining blockers
+
+Cooling/control/readout, noise, and operational preparation-time scaling remain
+open by design. They are not needed to certify the finite open-gate boundary.
+
+## Verification
+
+- `python3 -m py_compile scripts/frontier_teleportation_initial_state_preparation_probe.py`
+- default runner: exit `0`, `derivation certificate: PASS`
+- `--gap-threshold 3`: exit `1`, expected certificate failure
+- exact 1D analytic-gap threshold: exit `0`, certificate pass
+- SHA-pinned cache: fresh, exit `0`
+- independent shift-matrix eigenspectrum and pair-sum check: pass
+- independently relabeled helper graph: certificate detects the topology drift
+- `scripts/vocab_lint.py --fix`: no violations
+- audit pipeline plus strict audit lint: no errors; generated authority outputs
+  removed against the worktree's pinned base afterward
+- `git diff --check`: pass
+
+## Next exact action
+
+Send `teleportation_initial_state_preparation_probe_note` to the independent
+audit lane. The branch proposes no audit verdict.

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/LITERATURE_BRIDGES.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/LITERATURE_BRIDGES.md
@@ -1,0 +1,4 @@
+# Literature Bridges
+
+None. The finite closure uses only the explicit lattice matrices and elementary
+periodic Fourier diagonalization.

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/NO_GO_LEDGER.md
@@ -1,0 +1,4 @@
+# No-Go Ledger
+
+No no-go is claimed. Native-basis delocalization is an exact property of the
+audited state, not a theorem that operational preparation is impossible.

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/OPPORTUNITY_QUEUE.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/OPPORTUNITY_QUEUE.md
@@ -1,0 +1,6 @@
+# Opportunity Queue
+
+This is a single-target science-fix block, not a campaign. The only authorized
+opportunity is the finite initial-state derivation closure. Operational
+preparation, noise, control, readout, and scaling are deliberately outside the
+requested claim scope and remain future work.

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/PR_BACKLOG.md
@@ -1,0 +1,21 @@
+# PR Backlog
+
+PR delivery has not been attempted. This science-fix worktree cannot refresh
+remote refs because its linked parent git directory is outside the writable
+sandbox. Review is complete; if delivery is later authorized and the prior
+matching branch is still open, update that landing path instead of opening a
+duplicate PR.
+
+Recovery commands from a writable clone, after confirming the prior branch/PR
+status:
+
+```bash
+git fetch origin
+git switch claude/science-fix/teleportation_initial_state_preparation_probe_note-fa4df0dc
+git add docs/TELEPORTATION_INITIAL_STATE_PREPARATION_PROBE_NOTE.md \
+  scripts/frontier_teleportation_initial_state_preparation_probe.py \
+  logs/runner-cache/frontier_teleportation_initial_state_preparation_probe.txt \
+  .claude/science/physics-loops/teleportation-initial-state-preparation-closure
+git commit -m "physics-loop: certify teleportation initial-state open gate"
+git push -u origin HEAD
+```

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/PR_BODY.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/PR_BODY.md
@@ -1,0 +1,40 @@
+## Science block
+
+Closes the finite derivation behind the teleportation initial-state
+preparation open gate without claiming an operational preparation protocol.
+
+## Artifacts
+
+- [`HANDOFF.md`](.claude/science/physics-loops/teleportation-initial-state-preparation-closure/HANDOFF.md)
+- [`TRACE_GATE.md`](.claude/science/physics-loops/teleportation-initial-state-preparation-closure/TRACE_GATE.md)
+- [`REVIEW_HISTORY.md`](.claude/science/physics-loops/teleportation-initial-state-preparation-closure/REVIEW_HISTORY.md)
+- [`CLAIM_STATUS_CERTIFICATE.md`](.claude/science/physics-loops/teleportation-initial-state-preparation-closure/CLAIM_STATUS_CERTIFICATE.md)
+- [`TELEPORTATION_INITIAL_STATE_PREPARATION_PROBE_NOTE.md`](docs/TELEPORTATION_INITIAL_STATE_PREPARATION_PROBE_NOTE.md)
+- [`frontier_teleportation_initial_state_preparation_probe.py`](scripts/frontier_teleportation_initial_state_preparation_probe.py)
+- [`frontier_teleportation_initial_state_preparation_probe.txt`](logs/runner-cache/frontier_teleportation_initial_state_preparation_probe.txt)
+
+## Claim movement
+
+The note now gives the exact periodic Fourier spectrum, proves the unique
+uniform one-species ground and exact gaps on both default surfaces, propagates
+that result through the two-species Kronecker sum, and closes separability and
+maximal native-support formulas. The runner independently checks the matrix
+identities, expected energies/gaps, factorization, Schmidt ranks, and support,
+and exits nonzero on a failed certificate.
+
+Trace class: `direct_blocker_closure`. Reachability closes the finite
+open-gate statement only. Cooling/control/readout, noise, and operational
+preparation-time scaling remain open.
+
+## Verification
+
+- runner compile/default certificate/cache freshness: pass
+- independent shift-matrix and pair-spectrum check: pass
+- custom high-gap failure and exact-boundary tolerance checks: pass
+- vocabulary lint and diff check: pass
+- audit pipeline and strict lint: no errors
+- review-loop: pass after two iterations
+
+Independent audit is required before the repo treats the changed source as a
+clean open-gate authority surface. This PR contains no audit verdict or
+generated audit-authority output.

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/REVIEW_HISTORY.md
@@ -1,0 +1,84 @@
+# Review History
+
+## Prior matching branch evidence
+
+Commit `ff703369b0` records two clean review iterations for the same source
+delta. That evidence is prior art, not a current-branch self-certification;
+the current branch must still pass the applicable review lenses and checks.
+
+## Current branch
+
+### Iteration 1
+
+- Code/runner: `RISK`. Connectedness, regularity, and degree do not uniquely
+  identify the 2D `4x4` torus, so a rewired helper graph could survive the
+  structural certificate if its low spectrum happened to agree.
+- Physics claim: `OPEN`, with a closed exact finite diagnostic boundary.
+- Proof obligations: `CLOSED` for the scoped finite target; operational
+  preparation is strictly stronger and excluded.
+- Imports/support: `DISCLOSED`; no observed, fitted, literature, or approved-
+  primitive input is load-bearing.
+- Nature retention: `OPEN`; cooling/control/readout, noise, and operational
+  preparation-time scaling remain open.
+- No-go discipline and labeling-convention reviews: not applicable.
+- Repo governance and audit compatibility: `PASS` subject to fixing the
+  topology certificate and rerunning final validation.
+
+Fix: independently reconstruct the claimed periodic adjacency from `dim` and
+`side`, compare it to the helper graph, use it in the `H1=-A` residual, and add
+a relabeling mutation falsifier. The refreshed cache is pinned to runner SHA
+`ef05b9ffc8dfbbf8a7c9dfb1c216b2839584bcfe53c5d9b44bb5764493df1995`.
+
+### Iteration 2
+
+- Code/runner: `PASS`; default certificate, high-gap failure path, exact-gap
+  boundary, independent Fourier/pair-spectrum calculation, topology mutation,
+  and cache freshness all pass.
+- Physics claim boundary: `OPEN`; no operational-preparation claim is made.
+- Proof obligations: `CLOSED` for the finite open-gate target.
+- Imports/support: `CLEAN` for that target.
+- Nature retention: `OPEN` by the explicit operational boundary.
+- No-go discipline: not applicable; delocalization is not presented as an
+  impossibility theorem.
+- Labeling convention: not applicable.
+- Repo governance: `PASS`; native vocabulary and `Type: open_gate` are present.
+- Audit compatibility: `PASS`; the final pipeline run completed with zero
+  strict-lint errors, re-ingested the target as `open_gate`, and placed the
+  source-drift row in the independent audit queue. All generated authority
+  outputs were removed afterward.
+
+Final current-branch review-loop disposition: `pass`.
+
+<!-- Historical review record from the matching unmerged branch follows. -->
+
+## Iteration 1
+
+- Code/runner: `RISK`. The analytic chain passed independent Fourier and
+  adjacency checks, but custom gap-threshold exit semantics and tiny
+  note/cache roundoff rows needed repair.
+- Physics claim: `PASS` as an exact finite boundary inside an open gate. The
+  prose needed to separate native delocalization from operational difficulty.
+- Imports/support: `DISCLOSED`; fixed controls, helper constructors, tensor
+  basis, and factorization convention needed finer classification.
+- Nature retention: `BOUNDED-OPEN`.
+- Repo governance/audit compatibility: `FIX` for source type metadata and
+  closeout details.
+- No-go discipline: not applicable.
+
+All findings were fixed narrowly: the runner now fails custom thresholds
+consistently, uses a tolerance at the exact analytic boundary, avoids no-go or
+operational-preparability language, refreshes its cache, and the note/import
+ledger make every finite convention and operational exclusion explicit.
+
+## Iteration 2
+
+- Code/runner: `PASS`.
+- Physics claim boundary: `PASS`, exact finite boundary on `open_gate`.
+- Imports/support: `CLEAN`.
+- Nature retention: `BOUNDED-OPEN PASS`.
+- Repo governance: `PASS`.
+- Audit compatibility: `PASS`; pipeline and strict lint completed with no
+  errors, and generated audit authority outputs were removed from the branch.
+- No-go discipline: not applicable.
+
+Final review-loop disposition: `pass`. Independent audit remains required.

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/ROUTE_PORTFOLIO.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/ROUTE_PORTFOLIO.md
@@ -1,0 +1,29 @@
+# Route Portfolio
+
+## Prior-art sweep
+
+Searched the locally available `origin/main` commit
+`0216f5f39ba3f47d33b9bee5eb593f3f2ca90984` with statement-level queries for
+`uniform`/`Kronecker`, native-site delocalization, and `H1` tensor products,
+plus a filename sweep for teleportation initial/preparation notes. The matching
+landed note already contains the finite Perron/Kronecker-sum argument and its
+ledger claim type is `open_gate`; the matched result is therefore not novel. A
+separate unmerged remote branch at commit `ff703369b0` contains the
+stronger reviewed executable-certificate form. This block reuses that form
+instead of claiming a new theorem: the material delta is that failed
+load-bearing identities now produce a nonzero runner exit.
+
+| Route | Trace | Claim movement | Risk | Decision |
+|---|---|---|---|---|
+| Restate the existing numerical tables | upstream support | none | audit churn | reject |
+| Derive the periodic Fourier spectrum only | direct blocker closure | closes analytic uniqueness/gap chain | runner could stay non-failing | combine |
+| Add a failing executable certificate only | direct blocker closure | verifies constructors and output | could hide why the result holds | combine |
+| Invent an operational preparation protocol | unknown frontier | could broaden the lane | exceeds scope and time gate | reject |
+
+Selected route: combine the finite Fourier proof with a runner certificate that
+fails on broken structural identities, energies, gaps, factorization,
+separability, or native support.
+
+Target-state classification: the finite theorem is already proven on matching
+premises; the remaining authorized work is runner-backed derivation hygiene for
+the same open-gate boundary, not retained-positive novelty.

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/STATE.yaml
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/STATE.yaml
@@ -1,0 +1,31 @@
+loop_slug: teleportation-initial-state-preparation-closure
+mode: run
+target_status: best-honest-status
+runtime_budget: "roughly 15 minutes of code-writing, per user gate"
+cycle: 1
+science_block: 1
+branch: claude/science-fix/teleportation_initial_state_preparation_probe_note-fa4df0dc
+base: origin/main@0216f5f39ba3f47d33b9bee5eb593f3f2ca90984
+active_route: analytic-fourier-and-executable-certificate
+hard_residual: null
+actual_current_surface_status: open
+trace_class: direct_blocker_closure
+reachability_to_target: closes
+files_touched:
+  - docs/TELEPORTATION_INITIAL_STATE_PREPARATION_PROBE_NOTE.md
+  - scripts/frontier_teleportation_initial_state_preparation_probe.py
+  - logs/runner-cache/frontier_teleportation_initial_state_preparation_probe.txt
+open_imports:
+  - none for the finite diagnostic target
+excluded_operational_obligations:
+  - cooling/control/readout protocol
+  - noise model
+  - preparation-time scaling proof
+no_go_routes: []
+review_disposition: pass after one narrow fix and confirmation
+pr_status: backlog; linked git metadata is outside the writable sandbox
+lock_mode: branch-local isolated worktree
+lock_note: "scripts/automation_lock.py failed with permission denied at /Users/jonreilly"
+skill_freshness: "fetch blocked by linked-worktree permissions; local skill matches the present origin/main ref"
+next_exact_action: send the changed open-gate row to the independent audit lane
+stop_condition: achieved; finite derivation certificate and review disposition pass

--- a/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/TRACE_GATE.md
+++ b/.claude/science/physics-loops/teleportation-initial-state-preparation-closure/TRACE_GATE.md
@@ -1,0 +1,15 @@
+---
+trace_class: direct_blocker_closure
+target_claim_id: teleportation_initial_state_preparation_probe_note
+target_blocker_text: "The assumed G=0 state is a unique separable H1-ground tensor product on the default small surfaces, but it is fully delocalized in the native site basis and the artifact supplies no cooling/control/readout protocol, noise model, or scaling proof."
+source_of_blocker_text: audit_ledger
+reachability_to_target: closes
+reachability_scope: "closes the scoped finite open-gate statement, not the operational preparation obligations"
+artifact_role: runner_certificate
+next_trace_action: "Independently re-audit the strengthened finite derivation while preserving the operational open gate."
+---
+
+The artifact closes the finite mathematical chain and makes the scoped
+open-gate statement executable. It does not close the cooling/control/readout,
+noise, or scaling obligations; those are the correctly bounded content of the
+open gate.

--- a/docs/TELEPORTATION_INITIAL_STATE_PREPARATION_PROBE_NOTE.md
+++ b/docs/TELEPORTATION_INITIAL_STATE_PREPARATION_PROBE_NOTE.md
@@ -1,7 +1,8 @@
 # Teleportation Initial-State Preparation Probe
 
 **Date:** 2026-04-25
-**Status:** planning / first artifact; not a manuscript claim surface
+**Status:** exact boundary theorem on an open gate; operational preparation remains open
+**Type:** open_gate
 **Runner:** `scripts/frontier_teleportation_initial_state_preparation_probe.py`
 
 ## Scope
@@ -57,30 +58,46 @@ single-species `H1` ground states:
 
 ## Derivation Closure
 
-For the two default cases the runner uses `mass=0` and `G=0`. The
-single-species Hamiltonian is therefore the negative adjacency operator on the
-periodic lattice,
+For the two default cases the runner uses `mass=0`, `G=0`, and `t_hop=1`.
+The single-species Hamiltonian is therefore the negative adjacency operator on
+the periodic lattice,
 
 ```text
 H1 = -A,
 ```
 
-with `t_hop=1`. The `1D N=8` cycle is connected and degree `2`; the `2D 4x4`
-torus is connected and degree `4`. For a connected regular graph, the constant
-vector is the Perron eigenvector of `A` with eigenvalue equal to the degree, and
-that top eigenvalue is simple. Hence the `H1=-A` ground state is the unique
+The `1D N=8` cycle is connected and degree `2`; the `2D 4x4` torus is
+connected and degree `4`. Equivalently, periodic Fourier vectors diagonalize
+the two audited Hamiltonians. On a `d`-dimensional side-`L` periodic lattice,
+
+```text
+H1 |k> = -2 sum_(a=1)^d cos(2 pi k_a/L) |k>.
+```
+
+Every cosine is at most one, and equality for every factor occurs only at the
+single momentum `k=(0,...,0)`. Thus the ground vector is unique and is the
 uniform native-site vector
 
 ```text
 |u_N> = N^(-1/2) sum_i |i>,
 ```
 
-with energies `-2` and `-4` in the two audited cases. The finite gaps in the
-table are the runner-computed differences from this simple ground eigenspace to
-the next `H1` eigenspace.
+with energies `-2` and `-4` in the two audited cases. Changing one momentum
+component to the smallest nonzero value gives the exact first gap
 
-At `G=0`, `build_H2_tensor` drops the Poisson diagonal term and the
-two-species Hamiltonian is the Kronecker sum
+```text
+Delta_1 = 2[1 - cos(2 pi/L)].
+```
+
+It is therefore `2-sqrt(2)` for `1D N=8` and `2` for the `2D 4x4` torus,
+matching `0.585786` and `2.000000` in the table. This is an analytic
+finite-surface result; the eigensolver is a check rather than the source of the
+uniqueness or gap claim.
+
+Species `A` and `B` are distinguishable registers in the ordered basis
+`|i>_A x |j>_B`; no bosonic or fermionic symmetrization is imposed. At `G=0`,
+`build_H2_tensor` drops the Poisson diagonal term and the two-species
+Hamiltonian is the Kronecker sum
 
 ```text
 H(G=0) = H1 x I + I x H1.
@@ -124,6 +141,32 @@ single-species factor has the analogous full support, participation ratio `N`,
 and `PR/dim = 1`. Thus the state is maximally delocalized in the native basis
 even though it is unique, exactly product, and separable.
 
+## Executable Derivation Certificate
+
+The runner treats this chain as a failing certificate, not only as printed
+diagnostics. For each default case it checks:
+
+- the helper graph equals an independently reconstructed periodic adjacency,
+  is connected and regular, and has degree `2d`;
+- the constructed matrices satisfy `H1=-A` and
+  `H(G=0)=H1 x I + I x H1` with residual at most `1e-10`;
+- the uniform vectors obey the predicted one- and two-species eigenvalue
+  equations and the exact Fourier energies and gaps above;
+- the numerical ground vector has unit fidelity, within tolerance, to both the
+  `H1`-ground tensor product and the uniform tensor product;
+- every stated separability cut has numerical Schmidt rank one;
+- the one- and two-species states have full native support and `PR/dim=1`;
+- the uniform site vector factors as `|+>_logical x |u_env>` in the actual
+  `factor_sites` indexing.
+
+Any failed item makes the runner return a nonzero exit code. The default run
+prints `derivation certificate: PASS`, with zero topology, structural, and
+eigenvector residuals on both surfaces.
+
+This certificate closes only the finite diagnostic chain. It does not turn
+native-basis delocalization into an operational obstruction theorem, nor does
+it supply a method for creating, cooling, controlling, or verifying the state.
+
 ## Separability Diagnostics
 
 The state is product-like on the audited partitions. Entropies are numerical
@@ -131,12 +174,12 @@ zero, purities are `1`, and numerical Schmidt rank is `1`.
 
 | case | partition | entropy bits | purity | max Schmidt weight | numerical rank |
 | --- | --- | ---: | ---: | ---: | ---: |
-| `1d_null_initial` | species A / species B | `6.269359e-28` | `1.000000` | `1.000000` | `1` |
-| `1d_null_initial` | logical pair / environment pair | `8.721861e-28` | `1.000000` | `1.000000` | `1` |
-| `1d_null_initial` | single `H1` logical / environment | `1.234057e-28` | `1.000000` | `1.000000` | `1` |
-| `2d_null_initial` | species A / species B | `3.069446e-29` | `1.000000` | `1.000000` | `1` |
-| `2d_null_initial` | logical pair / environment pair | `2.410512e-29` | `1.000000` | `1.000000` | `1` |
-| `2d_null_initial` | single `H1` logical / environment | `1.808875e-29` | `1.000000` | `1.000000` | `1` |
+| `1d_null_initial` | species A / species B | `7.854128e-28` | `1.000000` | `1.000000` | `1` |
+| `1d_null_initial` | logical pair / environment pair | `1.115915e-27` | `1.000000` | `1.000000` | `1` |
+| `1d_null_initial` | single `H1` logical / environment | `1.211120e-28` | `1.000000` | `1.000000` | `1` |
+| `2d_null_initial` | species A / species B | `2.081948e-29` | `1.000000` | `1.000000` | `1` |
+| `2d_null_initial` | logical pair / environment pair | `2.237988e-29` | `1.000000` | `1.000000` | `1` |
+| `2d_null_initial` | single `H1` logical / environment | `2.071897e-29` | `1.000000` | `1.000000` | `1` |
 
 The traced logical resource at `G=0` is not an entangled teleportation
 resource. It has Bell overlap `0.5`, CHSH `2.0`, and negativity `0.0` in both
@@ -144,8 +187,10 @@ dimensions.
 
 ## Native-Basis Support
 
-The gap is not spectral uniqueness or species entanglement. The gap is that
-the assumed state is maximally delocalized in the native site basis.
+The finite diagnostic fact is that the assumed state is maximally delocalized
+in the native site basis. Delocalization alone is not an operational
+obstruction; the preparation gap is the absence of a supplied physical
+protocol and scaling argument.
 
 | case | state | basis dim | support | participation ratio | `PR/dim` | max probability | site entropy bits |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -164,12 +209,12 @@ The only exact candidate is the delocalized `H1` ground-state tensor product.
 
 | case | candidate | energy excess `E-E0` | ground fidelity | `PR/dim` | logical/env entropy | Bell overlap | negativity |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `1d_null_initial` | `H1` ground tensor product | `-8.881784e-16` | `1.000000` | `1.000000` | `2.548015e-28` | `0.500000` | `0.000000` |
-| `1d_null_initial` | uniform site product | `0` | `1.000000` | `1.000000` | `9.230725e-31` | `0.500000` | `0.000000` |
+| `1d_null_initial` | `H1` ground tensor product | `1.332268e-15` | `1.000000` | `1.000000` | `2.527436e-28` | `0.500000` | `0.000000` |
+| `1d_null_initial` | uniform site product | `8.881784e-16` | `1.000000` | `1.000000` | `3.622957e-30` | `0.500000` | `0.000000` |
 | `1d_null_initial` | localized `|0>_A |0>_B` | `4.000000` | `0.015625` | `0.015625` | `0` | `0.500000` | `0.000000` |
 | `1d_null_initial` | single-env logical `|+>` product | `2.000000` | `0.062500` | `0.062500` | `0` | `0.500000` | `0.000000` |
-| `2d_null_initial` | `H1` ground tensor product | `0` | `1.000000` | `1.000000` | `4.855549e-29` | `0.500000` | `0.000000` |
-| `2d_null_initial` | uniform site product | `0` | `1.000000` | `1.000000` | `9.685856e-31` | `0.500000` | `0.000000` |
+| `2d_null_initial` | `H1` ground tensor product | `0` | `1.000000` | `1.000000` | `6.594612e-29` | `0.500000` | `0.000000` |
+| `2d_null_initial` | uniform site product | `0` | `1.000000` | `1.000000` | `6.592044e-29` | `0.500000` | `0.000000` |
 | `2d_null_initial` | localized `|0>_A |0>_B` | `8.000000` | `0.003906` | `0.003906` | `0` | `0.500000` | `0.000000` |
 | `2d_null_initial` | single-env logical `|+>` product | `6.000000` | `0.015625` | `0.015625` | `0` | `0.500000` | `0.000000` |
 
@@ -197,7 +242,8 @@ initial-state preparation gap.
 ## Limitations
 
 - Exact small surfaces only: `1D N=8` and `2D 4x4`.
-- No scaling study for the `G=0` gap or preparation time.
+- The displayed Fourier formula is used here only to certify the two default
+  surfaces; no operational preparation-time scaling law follows from it.
 - No bath, cooling, control-noise, calibration, or state-verification model.
 - The native-basis localization threshold is diagnostic, not a theorem.
 - Logical Bell measurement and readout remain idealized in adjacent artifacts.

--- a/logs/runner-cache/frontier_teleportation_initial_state_preparation_probe.txt
+++ b/logs/runner-cache/frontier_teleportation_initial_state_preparation_probe.txt
@@ -1,13 +1,13 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_teleportation_initial_state_preparation_probe.py
-runner_sha256: 4614dde7863ba6c83fbced70006a2f2b141c7b6a52565d9c105304f790db98bb
+runner_sha256: ef05b9ffc8dfbbf8a7c9dfb1c216b2839584bcfe53c5d9b44bb5764493df1995
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.27
+elapsed_sec: 0.32
 status: ok
 ----- stdout -----
 TELEPORTATION INITIAL-STATE PREPARATION PROBE
-Status: planning / first artifact; ordinary quantum state teleportation only
+Status: exact boundary theorem on an open gate; ordinary quantum state teleportation only
 Claim boundary: no matter, mass, charge, energy, object, or faster-than-light transport
 Question: is the G=0 two-species ground state unique, product-like, separable, native-basis simple/localized, and operationally plausible?
 Thresholds: degeneracy_tol=1e-09, support_prob>1e-12, gap>=1e-06, localized_PR_fraction<=0.25
@@ -16,24 +16,26 @@ Case: 1d_null_initial
   setup: dim=1 side=8 N=8 envs/logical_qubit=4 mass=0 G=0
   single-species H1: E0=-2.000000, E1=-1.414214, degeneracy=1, gap_after_ground_space=0.585786
   two-species H(G=0): E0=-4.000000, E1=-3.414214, degeneracy=1, gap_after_ground_space=0.585786
+  analytic derivation certificate: connected=True, regular=True, degree=2/2, E0(H1)=-2.000000, E0(H2)=-4.000000, gap=0.585786
+    residuals: A-A_periodic=0, H1+A=0, H2-KroneckerSum=0, H1|u>-E0|u>=0, H2|uu>-2E0|uu>=0, logical/env factor=0
   exact-product checks: |<g_G0|g_H1 x g_H1>|^2=1.000000, |<g_G0|uniform x uniform>|^2=1.000000
   traced logical resource at G=0: Phi+=0.500000, Bell*=0.500000 (Phi+), CHSH=2.000000, negativity=0.000000, purity=1.000000
   separability diagnostics:
     partition                                  S(bits)     purity  max weight   rank_eff rank_num
-    species A | species B                   6.218312e-28   1.000000    1.000000   1.000000        1
-    logical pair | environment pair         1.229403e-27   1.000000    1.000000   1.000000        1
-    single H1 logical | single H1 environment 1.234057e-28   1.000000    1.000000   1.000000        1
+    species A | species B                   7.854128e-28   1.000000    1.000000   1.000000        1
+    logical pair | environment pair         1.115915e-27   1.000000    1.000000   1.000000        1
+    single H1 logical | single H1 environment 1.211120e-28   1.000000    1.000000   1.000000        1
   native site-basis support:
     state                                            dim  support         PR     PR/dim   max prob  Hsite(bits)
     single H1 ground in native sites                   8        8   8.000000   1.000000   0.125000     3.000000
     two-species G=0 ground in native site pairs       64       64  64.000000   1.000000   0.015625     6.000000
   simple candidate comparison:
     candidate                              E-E0    |<g|c>|2     PR/dim       S_AB      S_L|E     Bell*       neg
-    H1 ground tensor product       -2.664535e-15    1.000000   1.000000 1.159463e-30 2.548015e-28  0.500000  0.000000
-    uniform site product           -1.776357e-15    1.000000   1.000000 8.542265e-32 9.230725e-31  0.500000  0.000000
+    H1 ground tensor product       1.332268e-15    1.000000   1.000000 1.567415e-30 2.527436e-28  0.500000  0.000000
+    uniform site product           8.881784e-16    1.000000   1.000000 5.067005e-31 3.622957e-30  0.500000  0.000000
     localized |0>_A |0>_B              4.000000    0.015625   0.015625          0          0  0.500000  0.000000
     localized separated sites          4.000000    0.015625   0.015625          0          0  0.500000  0.000000
-    single-env logical |+> product     2.000000    0.062500   0.062500 3.135747e-32          0  0.500000  0.000000
+    single-env logical |+> product     2.000000    0.062500   0.062500          0          0  0.500000  0.000000
   local/native-basis preparation status: not localized (threshold PR/dim <= 0.25)
   verdict: unresolved gap: analytic product ground, but maximally delocalized in native site basis
 
@@ -41,24 +43,26 @@ Case: 2d_null_initial
   setup: dim=2 side=4 N=16 envs/logical_qubit=8 mass=0 G=0
   single-species H1: E0=-4.000000, E1=-2.000000, degeneracy=1, gap_after_ground_space=2.000000
   two-species H(G=0): E0=-8.000000, E1=-6.000000, degeneracy=1, gap_after_ground_space=2.000000
+  analytic derivation certificate: connected=True, regular=True, degree=4/4, E0(H1)=-4.000000, E0(H2)=-8.000000, gap=2.000000
+    residuals: A-A_periodic=0, H1+A=0, H2-KroneckerSum=0, H1|u>-E0|u>=0, H2|uu>-2E0|uu>=0, logical/env factor=0
   exact-product checks: |<g_G0|g_H1 x g_H1>|^2=1.000000, |<g_G0|uniform x uniform>|^2=1.000000
   traced logical resource at G=0: Phi+=0.500000, Bell*=0.500000 (Phi+), CHSH=2.000000, negativity=0.000000, purity=1.000000
   separability diagnostics:
     partition                                  S(bits)     purity  max weight   rank_eff rank_num
-    species A | species B                   1.847779e-29   1.000000    1.000000   1.000000        1
-    logical pair | environment pair         1.800077e-29   1.000000    1.000000   1.000000        1
-    single H1 logical | single H1 environment 1.808875e-29   1.000000    1.000000   1.000000        1
+    species A | species B                   2.081948e-29   1.000000    1.000000   1.000000        1
+    logical pair | environment pair         2.237988e-29   1.000000    1.000000   1.000000        1
+    single H1 logical | single H1 environment 2.071897e-29   1.000000    1.000000   1.000000        1
   native site-basis support:
     state                                            dim  support         PR     PR/dim   max prob  Hsite(bits)
     single H1 ground in native sites                  16       16  16.000000   1.000000   0.062500     4.000000
     two-species G=0 ground in native site pairs      256      256 256.000000   1.000000   0.003906     8.000000
   simple candidate comparison:
     candidate                              E-E0    |<g|c>|2     PR/dim       S_AB      S_L|E     Bell*       neg
-    H1 ground tensor product                  0    1.000000   1.000000 1.186505e-30 4.855549e-29  0.500000  0.000000
-    uniform site product                      0    1.000000   1.000000 9.863560e-31 9.685856e-31  0.500000  0.000000
+    H1 ground tensor product                  0    1.000000   1.000000 7.089792e-31 6.594612e-29  0.500000  0.000000
+    uniform site product                      0    1.000000   1.000000 1.150353e-30 6.592044e-29  0.500000  0.000000
     localized |0>_A |0>_B              8.000000    0.003906   0.003906          0          0  0.500000  0.000000
     localized separated sites          8.000000    0.003906   0.003906          0          0  0.500000  0.000000
-    single-env logical |+> product     6.000000    0.015625   0.015625 3.135747e-32          0  0.500000  0.000000
+    single-env logical |+> product     6.000000    0.015625   0.015625          0          0  0.500000  0.000000
   local/native-basis preparation status: not localized (threshold PR/dim <= 0.25)
   verdict: unresolved gap: analytic product ground, but maximally delocalized in native site basis
 
@@ -68,6 +72,7 @@ Conclusion:
   native-basis localized by participation threshold: 0/2
   verdict: unresolved preparation gap, not a spectral/product no-go. The assumed state is unique and separable on these small G=0 surfaces, but it is a fully delocalized coherent native-site superposition.
   Operational read: preparing the state reduces to preparing two independent single-species H1 ground states. This is simple analytically, but this artifact does not supply a cooling/control/readout protocol, noise model, or scaling proof.
+  derivation certificate: PASS
 
 ----- stderr -----
 

--- a/scripts/frontier_teleportation_initial_state_preparation_probe.py
+++ b/scripts/frontier_teleportation_initial_state_preparation_probe.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Initial-state preparation audit for the Poisson teleportation ramp.
 
-Status: planning / first artifact. This bounded diagnostic audits the
-assumption used by the finite-time adiabatic ramp: the two-species ground
-state of the native G=0 Hamiltonian is already available.
+Status: exact boundary theorem on an open gate. This bounded diagnostic
+audits the assumption used by the finite-time adiabatic ramp: the two-species
+ground state of the native G=0 Hamiltonian is already available.
 
 Scope boundary: ordinary quantum state teleportation resources only. This
 does not claim matter transfer, mass transfer, charge transfer, energy
@@ -86,6 +86,23 @@ class ResourceDiagnostics:
 
 
 @dataclasses.dataclass(frozen=True)
+class DerivationCertificate:
+    graph_connected: bool
+    graph_regular: bool
+    graph_degree: int
+    expected_degree: int
+    expected_h1_ground_energy: float
+    expected_h2_ground_energy: float
+    expected_gap: float
+    periodic_adjacency_residual: float
+    h1_negative_adjacency_residual: float
+    h2_kronecker_sum_residual: float
+    h1_uniform_eigen_residual: float
+    h2_uniform_eigen_residual: float
+    logical_env_uniform_factor_residual: float
+
+
+@dataclasses.dataclass(frozen=True)
 class CandidateDiagnostics:
     label: str
     energy: float
@@ -105,6 +122,7 @@ class CaseDiagnostics:
     n_env: int
     h1_spectrum: SpectrumDiagnostics
     h2_spectrum: SpectrumDiagnostics
+    derivation: DerivationCertificate
     h1_tensor_ground_fidelity: float
     uniform_tensor_ground_fidelity: float
     ground_resource: ResourceDiagnostics
@@ -146,6 +164,40 @@ def spectrum_diagnostics(evals: np.ndarray, tolerance: float) -> SpectrumDiagnos
         gap_after_ground_space=gap_after_ground_space,
         min_gap_unique=min_gap_unique,
     )
+
+
+def adjacency_matrix(adjacency: list[list[int]]) -> np.ndarray:
+    matrix = np.zeros((len(adjacency), len(adjacency)), dtype=complex)
+    for site, neighbors in enumerate(adjacency):
+        matrix[site, neighbors] = 1.0
+    return matrix
+
+
+def periodic_adjacency_matrix(dim: int, side: int) -> np.ndarray:
+    """Construct the claimed periodic lattice independently of lane helpers."""
+    shape = (side,) * dim
+    matrix = np.zeros((side**dim, side**dim), dtype=complex)
+    for coordinates in np.ndindex(shape):
+        site = int(np.ravel_multi_index(coordinates, shape))
+        for axis in range(dim):
+            for step in (-1, 1):
+                neighbor = list(coordinates)
+                neighbor[axis] = (neighbor[axis] + step) % side
+                neighbor_site = int(np.ravel_multi_index(tuple(neighbor), shape))
+                matrix[site, neighbor_site] = 1.0
+    return matrix
+
+
+def graph_is_connected(adjacency: list[list[int]]) -> bool:
+    visited = {0}
+    frontier = [0]
+    while frontier:
+        site = frontier.pop()
+        for neighbor in adjacency[site]:
+            if neighbor not in visited:
+                visited.add(neighbor)
+                frontier.append(neighbor)
+    return len(visited) == len(adjacency)
 
 
 def probability_entropy_bits(probabilities: np.ndarray) -> float:
@@ -321,6 +373,59 @@ def run_case(
     factors = factor_sites(case.dim, case.side)
     amp = amplitudes_by_logical_env(h2_ground, n_sites, factors)
     single_h1_tensor = single_species_logical_env_tensor(h1_ground, n_sites, factors)
+    uniform_logical_env = single_species_logical_env_tensor(
+        uniform_single, n_sites, factors
+    )
+
+    adjacency = adjacency_matrix(adj)
+    expected_adjacency = periodic_adjacency_matrix(case.dim, case.side)
+    identity = np.eye(n_sites, dtype=complex)
+    expected_degree = 2 * case.dim
+    expected_h1_ground_energy = -float(expected_degree)
+    expected_h2_ground_energy = 2.0 * expected_h1_ground_energy
+    expected_gap = 2.0 * (1.0 - math.cos(2.0 * math.pi / case.side))
+    expected_logical_env = np.full(
+        (2, len(factors.env_labels)), 1.0 / math.sqrt(n_sites), dtype=complex
+    )
+    derivation = DerivationCertificate(
+        graph_connected=graph_is_connected(adj),
+        graph_regular=all(len(neighbors) == len(adj[0]) for neighbors in adj),
+        graph_degree=len(adj[0]),
+        expected_degree=expected_degree,
+        expected_h1_ground_energy=expected_h1_ground_energy,
+        expected_h2_ground_energy=expected_h2_ground_energy,
+        expected_gap=expected_gap,
+        periodic_adjacency_residual=float(
+            np.max(np.abs(adjacency - expected_adjacency))
+        ),
+        h1_negative_adjacency_residual=float(
+            np.max(np.abs(h1 + expected_adjacency))
+        ),
+        h2_kronecker_sum_residual=float(
+            np.max(
+                np.abs(
+                    h2
+                    - (
+                        np.kron(h1, identity)
+                        + np.kron(identity, h1)
+                    )
+                )
+            )
+        ),
+        h1_uniform_eigen_residual=float(
+            np.linalg.norm(
+                h1 @ uniform_single - expected_h1_ground_energy * uniform_single
+            )
+        ),
+        h2_uniform_eigen_residual=float(
+            np.linalg.norm(
+                h2 @ uniform_tensor - expected_h2_ground_energy * uniform_tensor
+            )
+        ),
+        logical_env_uniform_factor_residual=float(
+            np.max(np.abs(uniform_logical_env - expected_logical_env))
+        ),
+    )
 
     bipartitions = (
         bipartition_from_tensor(
@@ -344,7 +449,11 @@ def run_case(
     )
     supports = (
         support_diagnostics("single H1 ground in native sites", h1_ground, support_threshold),
-        support_diagnostics("two-species G=0 ground in native site pairs", h2_ground, support_threshold),
+        support_diagnostics(
+            "two-species G=0 ground in native site pairs",
+            h2_ground,
+            support_threshold,
+        ),
     )
 
     localized_00 = np.kron(site_basis_state(n_sites, 0), site_basis_state(n_sites, 0))
@@ -413,17 +522,23 @@ def run_case(
         ),
     )
 
-    unique = h2_spectrum.degeneracy == 1 and h2_spectrum.gap_after_ground_space >= gap_threshold
+    unique = (
+        h2_spectrum.degeneracy == 1
+        and h2_spectrum.gap_after_ground_space + 1e-10 >= gap_threshold
+    )
     separable = all(row.entropy_bits <= 1e-8 for row in bipartitions)
     tensor_match = float(abs(np.vdot(h2_ground, h1_tensor_ground)) ** 2)
     product_simple = tensor_match >= 1.0 - 1e-10
     native_local = supports[1].participation_fraction <= localization_fraction_threshold
     if unique and separable and product_simple and native_local:
-        verdict = "preparable candidate"
+        verdict = "finite diagnostic candidate; operational preparation untested"
     elif unique and separable and product_simple:
-        verdict = "unresolved gap: analytic product ground, but maximally delocalized in native site basis"
+        verdict = (
+            "unresolved gap: analytic product ground, but maximally "
+            "delocalized in native site basis"
+        )
     else:
-        verdict = "diagnostic no-go for the assumed initial state"
+        verdict = "diagnostic failure for the assumed initial-state checks"
 
     return CaseDiagnostics(
         case=case,
@@ -431,6 +546,7 @@ def run_case(
         n_env=len(factors.env_labels),
         h1_spectrum=h1_spectrum,
         h2_spectrum=h2_spectrum,
+        derivation=derivation,
         h1_tensor_ground_fidelity=tensor_match,
         uniform_tensor_ground_fidelity=float(abs(np.vdot(h2_ground, uniform_tensor)) ** 2),
         ground_resource=resource_diagnostics(h2_ground, n_sites, factors),
@@ -461,6 +577,26 @@ def print_case(result: CaseDiagnostics, localization_fraction_threshold: float) 
     )
     print_spectrum("single-species H1", result.h1_spectrum)
     print_spectrum("two-species H(G=0)", result.h2_spectrum)
+    derivation = result.derivation
+    print(
+        "  analytic derivation certificate: "
+        f"connected={derivation.graph_connected}, "
+        f"regular={derivation.graph_regular}, "
+        f"degree={derivation.graph_degree}/{derivation.expected_degree}, "
+        f"E0(H1)={fmt_float(derivation.expected_h1_ground_energy)}, "
+        f"E0(H2)={fmt_float(derivation.expected_h2_ground_energy)}, "
+        f"gap={fmt_float(derivation.expected_gap)}"
+    )
+    print(
+        "    residuals: "
+        f"A-A_periodic={fmt_float(derivation.periodic_adjacency_residual)}, "
+        f"H1+A={fmt_float(derivation.h1_negative_adjacency_residual)}, "
+        f"H2-KroneckerSum={fmt_float(derivation.h2_kronecker_sum_residual)}, "
+        f"H1|u>-E0|u>={fmt_float(derivation.h1_uniform_eigen_residual)}, "
+        f"H2|uu>-2E0|uu>={fmt_float(derivation.h2_uniform_eigen_residual)}, "
+        "logical/env factor="
+        f"{fmt_float(derivation.logical_env_uniform_factor_residual)}"
+    )
     print(
         "  exact-product checks: "
         f"|<g_G0|g_H1 x g_H1>|^2={fmt_float(result.h1_tensor_ground_fidelity)}, "
@@ -597,12 +733,110 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("--localization-fraction-threshold must be in (0, 1]")
 
 
+def derivation_failures(
+    result: CaseDiagnostics,
+    gap_threshold: float,
+    tolerance: float = 1e-10,
+) -> list[str]:
+    derivation = result.derivation
+    failures: list[str] = []
+
+    def require(condition: bool, label: str) -> None:
+        if not condition:
+            failures.append(f"{result.case.label}: {label}")
+
+    require(result.case.mass == 0.0 and result.case.G == 0.0, "case is not mass=G=0")
+    require(derivation.graph_connected, "periodic graph is not connected")
+    require(derivation.graph_regular, "periodic graph is not regular")
+    require(
+        derivation.graph_degree == derivation.expected_degree,
+        "periodic graph does not have degree 2*dim",
+    )
+    require(
+        derivation.periodic_adjacency_residual <= tolerance,
+        "helper graph is not the claimed periodic lattice",
+    )
+    require(derivation.h1_negative_adjacency_residual <= tolerance, "H1 != -A")
+    require(derivation.h2_kronecker_sum_residual <= tolerance, "H2 is not the G=0 Kronecker sum")
+    require(
+        derivation.h1_uniform_eigen_residual <= tolerance,
+        "uniform state is not the predicted H1 eigenstate",
+    )
+    require(
+        derivation.h2_uniform_eigen_residual <= tolerance,
+        "uniform tensor is not the predicted H2 eigenstate",
+    )
+    require(
+        derivation.logical_env_uniform_factor_residual <= tolerance,
+        "uniform state does not factor as |+> times |u_env>",
+    )
+    require(result.h1_spectrum.degeneracy == 1, "H1 ground state is not unique")
+    require(result.h2_spectrum.degeneracy == 1, "H2 ground state is not unique")
+    require(
+        result.h2_spectrum.min_gap_unique + tolerance >= gap_threshold,
+        "H2 gap does not meet the configured uniqueness/gap threshold",
+    )
+    require(
+        abs(
+            result.h1_spectrum.ground_energy
+            - derivation.expected_h1_ground_energy
+        )
+        <= tolerance,
+        "H1 ground energy disagrees with Fourier prediction",
+    )
+    require(
+        abs(
+            result.h2_spectrum.ground_energy
+            - derivation.expected_h2_ground_energy
+        )
+        <= tolerance,
+        "H2 ground energy disagrees with Kronecker-sum prediction",
+    )
+    require(
+        abs(result.h1_spectrum.min_gap_unique - derivation.expected_gap)
+        <= tolerance,
+        "H1 gap disagrees with Fourier prediction",
+    )
+    require(
+        abs(result.h2_spectrum.min_gap_unique - derivation.expected_gap)
+        <= tolerance,
+        "H2 gap disagrees with Kronecker-sum prediction",
+    )
+    require(
+        result.h1_tensor_ground_fidelity >= 1.0 - tolerance,
+        "H2 ground is not the H1-ground tensor product",
+    )
+    require(
+        result.uniform_tensor_ground_fidelity >= 1.0 - tolerance,
+        "H2 ground is not the uniform tensor product",
+    )
+    require(
+        all(row.numerical_rank == 1 for row in result.bipartitions),
+        "a claimed separability partition has rank != 1",
+    )
+    require(
+        all(row.support_count == row.dimension for row in result.supports),
+        "uniform ground state does not have full native support",
+    )
+    require(
+        all(
+            abs(row.participation_fraction - 1.0) <= tolerance
+            for row in result.supports
+        ),
+        "uniform ground state does not have PR/dim=1",
+    )
+    return failures
+
+
 def main() -> int:
     args = parse_args()
     validate_args(args)
 
     print("TELEPORTATION INITIAL-STATE PREPARATION PROBE")
-    print("Status: planning / first artifact; ordinary quantum state teleportation only")
+    print(
+        "Status: exact boundary theorem on an open gate; "
+        "ordinary quantum state teleportation only"
+    )
     print(
         "Claim boundary: no matter, mass, charge, energy, object, or faster-than-light transport"
     )
@@ -633,6 +867,12 @@ def main() -> int:
     for result in results:
         print_case(result, args.localization_fraction_threshold)
 
+    certificate_failures = [
+        failure
+        for result in results
+        for failure in derivation_failures(result, args.gap_threshold)
+    ]
+
     unique_count = sum(result.h2_spectrum.degeneracy == 1 for result in results)
     product_count = sum(result.h1_tensor_ground_fidelity >= 1.0 - 1e-10 for result in results)
     localized_count = sum(
@@ -640,7 +880,9 @@ def main() -> int:
         for result in results
     )
     unresolved = [result for result in results if result.verdict.startswith("unresolved")]
-    no_go = [result for result in results if result.verdict.startswith("diagnostic no-go")]
+    failed = [
+        result for result in results if result.verdict.startswith("diagnostic failure")
+    ]
 
     print("Conclusion:")
     print(f"  unique G=0 two-species ground states: {unique_count}/{len(results)}")
@@ -649,8 +891,11 @@ def main() -> int:
         "  native-basis localized by participation threshold: "
         f"{localized_count}/{len(results)}"
     )
-    if no_go:
-        print("  diagnostic no-go cases: " + ", ".join(row.case.label for row in no_go))
+    if failed:
+        print(
+            "  diagnostic failure cases: "
+            + ", ".join(row.case.label for row in failed)
+        )
     elif unresolved:
         print(
             "  verdict: unresolved preparation gap, not a spectral/product no-go. "
@@ -658,13 +903,22 @@ def main() -> int:
             "but it is a fully delocalized coherent native-site superposition."
         )
     else:
-        print("  verdict: preparable candidate under the current small-surface diagnostics")
+        print(
+            "  verdict: finite diagnostic candidate; operational preparation "
+            "remains untested"
+        )
     print(
         "  Operational read: preparing the state reduces to preparing two independent "
         "single-species H1 ground states. This is simple analytically, but this "
         "artifact does not supply a cooling/control/readout protocol, noise model, "
         "or scaling proof."
     )
+    if certificate_failures:
+        print("  derivation certificate: FAIL")
+        for failure in certificate_failures:
+            print(f"    - {failure}")
+        return 1
+    print("  derivation certificate: PASS")
     return 0
 
 


### PR DESCRIPTION
## Summary

This PR preserves a narrow finite diagnostic theorem for
`teleportation_initial_state_preparation_probe_note`. It does **not** close the
row's operational preparation gate.

The canonical independent-audit repair target is:

> missing_bridge_theorem: add and test a physical preparation-and-verification protocol with explicit control noise, resource scaling, and preparation-time bounds.

That target remains open. This salvage supplies no physical preparation or
verification protocol, noise model, resource scaling law, or preparation-time
bound.

## Durable source change

- `docs/TELEPORTATION_INITIAL_STATE_PREPARATION_PROBE_NOTE.md` gives the exact
  Fourier energies and finite gaps for the default periodic surfaces, the
  Kronecker-sum ground-state factorization, separability, and full native-basis
  support.
- `scripts/frontier_teleportation_initial_state_preparation_probe.py` turns
  those finite identities into nonzero-on-failure checks and declares both
  imported helper modules as cache inputs.
- `logs/runner-cache/frontier_teleportation_initial_state_preparation_probe.txt`
  carries the completed helper-bound certificate.

The scope remains the default mass-zero, coupling-zero `1D N=8` and `2D 4x4`
periodic surfaces for ordinary quantum state teleportation. It makes no claim
of matter, mass, charge, energy, or object transport, and no faster-than-light
claim.

After landing, the changed row remains for the independent audit lane to
classify. This PR carries no audit verdict or generated audit-authority output.
