### PR TITLE
science-fix: attempt to close teleportation_acceptance_suite_note

### DIFF
--- a/docs/TELEPORTATION_ACCEPTANCE_SUITE_NOTE.md
+++ b/docs/TELEPORTATION_ACCEPTANCE_SUITE_NOTE.md
@@ -171,13 +171,15 @@ The current list-surface synchronization is checked by:
 python3 scripts/frontier_teleportation_acceptance_suite_note_sync_check.py
 ```
 
-The sync guard runs both `--list-probes` surfaces, parses the default and
-strict-lane inventory tables above, and fails unless every note probe key,
-category, candidate-script list, and row order exactly matches the live
-outputs. It also checks the profile algebra: strict-lane keeps the eight
-default required rows in order, replaces the four default optional hooks, and
-adds exactly sixteen `required-if-present` rows. The current guard reports
-`PASS=8 FAIL=0`.
+The sync guard runs both `--list-probes` surfaces, parses the three descriptive
+probe lists and the default and strict-lane inventory tables above, and fails
+unless every prose-list key and every table key, category, candidate-script
+list, and row order exactly matches the live outputs. It also checks the
+profile algebra: strict-lane keeps the eight default required rows in order,
+replaces the four default optional hooks, and adds exactly sixteen
+`required-if-present` rows. Thus the strict profile is the 24-row sequence
+printed by the live runner, not a selected subset of the strict additions. The
+current guard reports `PASS=11 FAIL=0`.
 
 The previous strict-lane snapshot is cached at
 [`outputs/frontier_teleportation_acceptance_suite_strict_list_probes_2026-05-06.txt`](../outputs/frontier_teleportation_acceptance_suite_strict_list_probes_2026-05-06.txt).
@@ -225,10 +227,11 @@ python3 -m py_compile scripts/frontier_teleportation_acceptance_suite_note_sync_
 
 The current sync-runner cache is SHA-pinned to the guard source at
 [`logs/runner-cache/frontier_teleportation_acceptance_suite_note_sync_check.txt`](../logs/runner-cache/frontier_teleportation_acceptance_suite_note_sync_check.txt)
-and reports `PASS=8 FAIL=0`. Its captured stdout records SHA-256 fingerprints
-for both mutable inputs: this note and the documented acceptance runner.
-Because the shared cache framework currently keys freshness only to runner
-source, rerun the live sync command after either input changes.
+and reports `PASS=11 FAIL=0`. Its header includes a deterministic fingerprint
+of both declared mutable inputs: this note and the documented acceptance
+runner. Its captured stdout also records their individual SHA-256 values. A
+change to the guard or either input therefore makes the cache stale, while a
+live sync run remains the authoritative recurrence check.
 
 The current default probe inventory is cached at
 [`outputs/frontier_teleportation_acceptance_suite_default_list_probes_2026-05-06.txt`](../outputs/frontier_teleportation_acceptance_suite_default_list_probes_2026-05-06.txt).

--- a/logs/runner-cache/frontier_teleportation_acceptance_suite_note_sync_check.txt
+++ b/logs/runner-cache/frontier_teleportation_acceptance_suite_note_sync_check.txt
@@ -1,6 +1,7 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_teleportation_acceptance_suite_note_sync_check.py
-runner_sha256: 9099359571a9b5f0d604f72b78a0cd06050818cd3c903ac12056606f3cbe344f
+runner_sha256: 7e82efe7e92d9842cc01e994df4f4fbc0a0ac9594da12bb48d8309f9e3d2dd57
+input_fingerprint_sha256: 012742bc95459f740010df7bbadbb6f95745b9c859ce1f7263b9dd9490d07842
 timeout_sec: 30
 exit_code: 0
 elapsed_sec: 0.15
@@ -10,10 +11,16 @@ status: ok
 TELEPORTATION ACCEPTANCE SUITE NOTE SYNC CHECK
 ================================================================================================
 acceptance_runner_sha256: d0b70560361dbfab5b46d63a1ef824fe827f56af69719a3a6fa6e949c25d6072
-note_sha256: 36766f9393d3c0a3bd73d1864e343fb4862c5997b6508df298667e20c8b144d6
+note_sha256: 08afdec1434d7c86c4fe27c2e4c7ed1328f6ee3edda66271fbe83431bc879dcb
 
 [PASS] default --list-probes exits zero
 [PASS] strict-lane --list-probes exits zero
+[PASS] note default-required prose list exactly matches the live required prefix
+       note_keys=8 live_keys=8
+[PASS] note optional-hook prose list exactly matches the live optional suffix
+       note_keys=4 live_keys=4
+[PASS] note strict-addition prose list exactly matches the live strict suffix
+       note_keys=16 live_keys=16
 [PASS] note default inventory table exactly matches live default surface
        note_rows=12 live_rows=12
 [PASS] note strict-lane inventory table exactly matches live strict-lane surface
@@ -53,7 +60,7 @@ Strict-lane synchronized rows:
   remaining_open_item_attack             required-if-present frontier_teleportation_remaining_open_item_attack.py
   conclusion_boundary                    required-if-present frontier_teleportation_conclusion_boundary.py
 
-PASS=8 FAIL=0
+PASS=11 FAIL=0
 
 ----- stderr -----
 

--- a/scripts/frontier_teleportation_acceptance_suite_note_sync_check.py
+++ b/scripts/frontier_teleportation_acceptance_suite_note_sync_check.py
@@ -4,10 +4,10 @@
 The audited failure for ``docs/TELEPORTATION_ACCEPTANCE_SUITE_NOTE.md`` was a
 documentation/source sync issue: the strict-lane profile in the note omitted
 present runner probes. This guard executes both live list-probes surfaces and
-checks that the note's default and strict-lane inventory tables exactly match
-them. It also checks the strict-lane profile composition so a table update
-cannot silently change the default-required prefix or retain default-only
-optional hooks.
+checks that the note's descriptive probe lists and its default and strict-lane
+inventory tables exactly match them. It also checks the strict-lane profile
+composition so a table update cannot silently change the default-required
+prefix or retain default-only optional hooks.
 """
 
 from __future__ import annotations
@@ -20,6 +20,10 @@ from pathlib import Path
 
 
 AUDIT_TIMEOUT_SEC = 30
+AUDIT_INPUT_PATHS = (
+    "docs/TELEPORTATION_ACCEPTANCE_SUITE_NOTE.md",
+    "scripts/frontier_teleportation_acceptance_suite.py",
+)
 ROOT = Path(__file__).resolve().parents[1]
 RUNNER = ROOT / "scripts" / "frontier_teleportation_acceptance_suite.py"
 NOTE = ROOT / "docs" / "TELEPORTATION_ACCEPTANCE_SUITE_NOTE.md"
@@ -73,8 +77,32 @@ def parse_list_surface(text: str) -> list[tuple[str, str, str]]:
 TABLE_ROW_RE = re.compile(
     r"^\|\s*`(?P<key>[^`]+)`\s*\|\s*(?P<category>[^|]+?)\s*\|\s*`(?P<script>[^`]+)`\s*\|\s*$"
 )
+PROBE_BULLET_RE = re.compile(r"^-\s+`(?P<key>[^`]+)`:")
+DEFAULT_REQUIRED_HEADING = "## Default Required Probes"
+OPTIONAL_HEADING = "## Optional Hooks"
+DEFAULT_TABLE_INTRO = "The full default `--list-probes` surface"
+STRICT_HEADING = "## Strict-Lane Profile"
+STRICT_TABLE_INTRO = "The full `--strict-lane --list-probes` surface"
 DEFAULT_TABLE_MARKER = "Current synchronized default inventory:"
 STRICT_TABLE_MARKER = "Current synchronized strict inventory:"
+
+
+def parse_note_probe_bullets(
+    text: str, start_marker: str, end_marker: str
+) -> list[str]:
+    start = text.find(start_marker)
+    if start < 0:
+        raise ValueError(f"note is missing probe-list marker: {start_marker!r}")
+    end = text.find(end_marker, start + len(start_marker))
+    if end < 0:
+        raise ValueError(f"note is missing probe-list terminator: {end_marker!r}")
+
+    keys: list[str] = []
+    for raw in text[start:end].splitlines():
+        match = PROBE_BULLET_RE.match(raw.strip())
+        if match:
+            keys.append(match.group("key"))
+    return keys
 
 
 def parse_note_table(text: str, marker: str) -> list[tuple[str, str, str]]:
@@ -131,6 +159,15 @@ def main() -> int:
     default_rows = parse_list_surface(default_stdout)
     strict_rows = parse_list_surface(strict_stdout)
     note_text = NOTE.read_text(encoding="utf-8")
+    note_default_required_keys = parse_note_probe_bullets(
+        note_text, DEFAULT_REQUIRED_HEADING, OPTIONAL_HEADING
+    )
+    note_optional_keys = parse_note_probe_bullets(
+        note_text, OPTIONAL_HEADING, DEFAULT_TABLE_INTRO
+    )
+    note_strict_addition_keys = parse_note_probe_bullets(
+        note_text, STRICT_HEADING, STRICT_TABLE_INTRO
+    )
     note_default_rows = parse_note_table(note_text, DEFAULT_TABLE_MARKER)
     note_strict_rows = parse_note_table(note_text, STRICT_TABLE_MARKER)
 
@@ -142,6 +179,21 @@ def main() -> int:
     strict_keys = {key for key, _category, _script in strict_rows}
     strict_additions = strict_rows[len(default_required_rows) :]
 
+    check(
+        "note default-required prose list exactly matches the live required prefix",
+        note_default_required_keys == [row[0] for row in default_required_rows],
+        f"note_keys={len(note_default_required_keys)} live_keys={len(default_required_rows)}",
+    )
+    check(
+        "note optional-hook prose list exactly matches the live optional suffix",
+        note_optional_keys == [row[0] for row in default_optional_rows],
+        f"note_keys={len(note_optional_keys)} live_keys={len(default_optional_rows)}",
+    )
+    check(
+        "note strict-addition prose list exactly matches the live strict suffix",
+        note_strict_addition_keys == [row[0] for row in strict_additions],
+        f"note_keys={len(note_strict_addition_keys)} live_keys={len(strict_additions)}",
+    )
     check(
         "note default inventory table exactly matches live default surface",
         note_default_rows == default_rows,


### PR DESCRIPTION
## Summary

Automated attempt by `scripts/science_fix_loop.py` to
close the missing derivation in
`teleportation_acceptance_suite_note`.

- **Category:** `failed`
- **Transitive descendants if closed:** 281
- **Repair source:** docs/audit/MISSING_DERIVATION_PROMPTS.md

## What this PR does

Codex gpt-5.6-sol at xhigh reasoning was given the
missing-derivation prompt
in a clean worktree off `origin/main`. It made the diff in this PR.

## Review checklist

- [ ] Run the repo-native review-loop before landing; automated science
      attempts can be wrong
- [ ] If the new derivation survives review-loop, land it through the normal
      path and let the independent audit batch re-audit the row after merge
- [ ] If the diff is wrong-headed, close this PR; the loop won't retry
      automatically (state file: `logs/science-fix-state.json`)

## Codex output tail

```
Closed the acceptance-suite documentation blocker.

- `docs/TELEPORTATION_ACCEPTANCE_SUITE_NOTE.md` now explicitly defines the complete 24-row strict profile.
- `scripts/frontier_teleportation_acceptance_suite_note_sync_check.py` verifies all prose lists and inventory tables and declares both mutable cache inputs.
- `logs/runner-cache/frontier_teleportation_acceptance_suite_note_sync_check.txt` reports `PASS=11 FAIL=0`.

Verification passed: compilation, mutation test, cache freshness, vocabulary lint, full audit pipeline, strict audit lint, and review-loop. Generated audit artifacts were removed afterward.

Governance boundary: the pipeline classifies this row as `meta / unaudited / meta`, so the ordinary audit queue excludes it. The reviewed landing adds target-selection-only dispatcher metadata for an independent fresh-context re-audit; no verdict is authored here.

```

🤖 Generated by `scripts/science_fix_loop.py` (codex gpt-5.6-sol, xhigh)


## Archived audit repair target

> Repair target: sync docs/TELEPORTATION_ACCEPTANCE_SUITE_NOTE.md with the full --strict-lane --list-probes surface or split the audited claim to default-only harness behavior.
