### PR TITLE
science-fix: attempt to close teleportation_bell_measurement_circui...

### DIFF
--- a/docs/TELEPORTATION_BELL_MEASUREMENT_CIRCUIT_NOTE.md
+++ b/docs/TELEPORTATION_BELL_MEASUREMENT_CIRCUIT_NOTE.md
@@ -179,16 +179,41 @@ projector to an ideal logical/taste stabilizer or circuit measurement. The
 remaining gap is physical implementation: deriving or supplying a durable
 native apparatus/gate/readout mechanism with quantified imperfections.
 
-## Downstream Boundary Alignment (2026-06-13)
+## One-Hop Dependency And Boundary Alignment (2026-07-27)
 
-The paired runner now checks the audited downstream teleportation boundary
-stack before accepting the ideal Bell-measurement decomposition. In particular,
-the measurement-record, apparatus-dynamics, retained-axis operator-algebra,
-no-signaling, and conclusion-boundary anchors must already be audited as
-bounded support or audited renaming, alongside the resource and encoding
-anchors used by the planning lane.
+The ideal ingredients used here have the following explicit, scope-pinned
+one-hop suppliers:
 
-This does not turn the ideal circuit into a physical apparatus derivation. It
-only makes the source dependency explicit: the decomposition is a bounded
-logical/taste measurement artifact for ordinary quantum state teleportation,
-with nature-grade closure still held by the parent lane boundary.
+- **Ideal encoded Bell resource.** The retained bounded
+  [RALA theorem](TELEPORTATION_RETAINED_AXIS_OPERATOR_ALGEBRA_CLOSURE_NOTE.md)
+  supplies, in its audited finite-grid algebraic scope, the exact fixed-
+  environment encoded `|Phi+>` resource used by its T8 ideal teleportation
+  identity. This is an algebraic resource on the supplied encoded surface,
+  not a preparation mechanism.
+- **Logical gate or parity-measurement algebra.** The same retained bounded
+  [RALA theorem](TELEPORTATION_RETAINED_AXIS_OPERATOR_ALGEBRA_CLOSURE_NOTE.md)
+  supplies the full retained logical matrix algebra (T1/T2) and the commuting
+  `ZZ`/`XX` Bell projectors (T3). The `CNOT` and `H` matrices in this note are
+  explicit elements of that ideal algebra; no pulse schedule or physical
+  measurement is imported.
+- **Computational readout algebra.** The same retained bounded
+  [RALA theorem](TELEPORTATION_RETAINED_AXIS_OPERATOR_ALGEBRA_CLOSURE_NOTE.md)
+  supplies retained-axis `Z` in the logical algebra (T2), so its two spectral
+  projectors are the ideal computational readout projectors used here. This
+  does not supply a detector or operational taste-only readout apparatus.
+- **Classical record handling.** The retained bounded
+  [causal-channel harness](TELEPORTATION_CAUSAL_CHANNEL_NOTE.md) supplies only
+  positive-latency scheduling, delivery, and duplicate handling for already-
+  created Bell bits. The local matrix calculation in this note fixes the bit
+  convention `(z,x)`; neither source derives durable endogenous record
+  creation.
+
+The paired runner reads the canonical sharded audit rows for those suppliers
+and checks their retained status before accepting the decomposition. It also
+checks the audited
+[teleportation conclusion boundary](TELEPORTATION_CONCLUSION_BOUNDARY_NOTE.md),
+which keeps the lane limited to ordinary quantum state teleportation and holds
+nature-grade physical implementation open. Thus the dependency chain closes
+for the stated ideal logical claim only; encoded-resource preparation,
+physical gates or parity meters, detector dynamics, and durable record
+formation remain explicitly outside this note's claim scope.

--- a/logs/runner-cache/frontier_teleportation_bell_measurement_circuit.txt
+++ b/logs/runner-cache/frontier_teleportation_bell_measurement_circuit.txt
@@ -1,9 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_teleportation_bell_measurement_circuit.py
-runner_sha256: a1a34efce476c6919b200c8d7ec950794a8e229ae9c59d5149b1aacfc163bc8b
+runner_sha256: 63deecbe1fb947f593e7e7808ae45010991d70b8a54815baffd528abed0029ac
+input_fingerprint_sha256: 3402400c7e382991a219a3183aa132eaa79ebe9483d027303d1feed8f26fc0e3
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.46
+elapsed_sec: 0.14
 status: ok
 ----- stdout -----
 TELEPORTATION BELL-MEASUREMENT CIRCUIT/DECOMPOSITION
@@ -69,19 +70,16 @@ Physical assumptions left open:
   no matter, mass, charge, energy, object transport, or FTL signaling is claimed
 
 Downstream boundary checks:
-  downstream teleportation boundary: teleportation_causal_channel_note has audited bounded/status support: PASS (effective=retained_bounded, audit=audited_clean)
-  downstream teleportation boundary: teleportation_measurement_record_note has audited bounded/status support: PASS (effective=retained_bounded, audit=audited_clean)
-  downstream teleportation boundary: teleportation_apparatus_dynamics_closure_note has audited bounded/status support: PASS (effective=retained_bounded, audit=audited_clean)
-  downstream teleportation boundary: teleportation_dynamical_resource_generation_note has audited bounded/status support: PASS (effective=retained_bounded, audit=audited_clean)
-  downstream teleportation boundary: teleportation_resource_fidelity_note has audited bounded/status support: PASS (effective=retained_bounded, audit=audited_clean)
-  downstream teleportation boundary: teleportation_retained_axis_operator_algebra_closure_note has audited bounded/status support: PASS (effective=retained_bounded, audit=audited_clean)
-  downstream teleportation boundary: teleportation_cross_encoding_maps_note has audited bounded/status support: PASS (effective=retained_bounded, audit=audited_clean)
-  downstream teleportation boundary: teleportation_three_register_cross_encoding_note has audited bounded/status support: PASS (effective=retained_bounded, audit=audited_clean)
-  downstream teleportation boundary: teleportation_no_signaling_audit has audited bounded/status support: PASS (effective=retained_bounded, audit=audited_clean)
-  downstream teleportation boundary: teleportation_3d_operator_consistent_end_to_end_note has audited bounded/status support: PASS (effective=retained_bounded, audit=audited_clean)
-  downstream teleportation boundary: teleportation_conclusion_boundary_note has audited bounded/status support: PASS (effective=audited_renaming, audit=audited_renaming)
-  downstream teleportation boundary: lane remains state-teleportation only with no-transfer boundary: PASS (checked conclusion boundary note)
-  downstream teleportation boundary: finite planning support is not nature-grade closure: PASS (planning closure and nature-grade hold are distinct)
+  Bell-measurement dependency boundary: ideal encoded Bell resource has retained one-hop support: PASS (teleportation_retained_axis_operator_algebra_closure_note: effective=retained_bounded, audit=audited_clean)
+  Bell-measurement dependency boundary: ideal logical gate/parity-measurement algebra has retained one-hop support: PASS (teleportation_retained_axis_operator_algebra_closure_note: effective=retained_bounded, audit=audited_clean)
+  Bell-measurement dependency boundary: ideal computational-readout algebra has retained one-hop support: PASS (teleportation_retained_axis_operator_algebra_closure_note: effective=retained_bounded, audit=audited_clean)
+  Bell-measurement dependency boundary: classical Bell-record handling has retained one-hop support: PASS (teleportation_causal_channel_note: effective=retained_bounded, audit=audited_clean)
+  Bell-measurement dependency boundary: conclusion boundary has audited scope support: PASS (teleportation_conclusion_boundary_note: effective=audited_renaming, audit=audited_renaming)
+  Bell-measurement dependency boundary: source cites retained-axis Bell-resource/gate/parity/readout supplier: PASS (TELEPORTATION_RETAINED_AXIS_OPERATOR_ALGEBRA_CLOSURE_NOTE.md)
+  Bell-measurement dependency boundary: source cites retained classical record-handling supplier: PASS (TELEPORTATION_CAUSAL_CHANNEL_NOTE.md)
+  Bell-measurement dependency boundary: source cites audited conclusion boundary: PASS (TELEPORTATION_CONCLUSION_BOUNDARY_NOTE.md)
+  Bell-measurement dependency boundary: lane remains state-teleportation only with no-transfer boundary: PASS (checked conclusion boundary note)
+  Bell-measurement dependency boundary: finite planning support is not nature-grade closure: PASS (planning closure and nature-grade hold are distinct)
 
 ----- stderr -----
 

--- a/scripts/frontier_teleportation_bell_measurement_circuit.py
+++ b/scripts/frontier_teleportation_bell_measurement_circuit.py
@@ -33,7 +33,20 @@ from typing import Iterable
 
 import numpy as np
 
-from teleportation_boundary_checks_2026_06_13 import print_boundary_results, teleportation_boundary_check_results
+from teleportation_bell_measurement_boundary_checks_2026_07_27 import (
+    bell_measurement_boundary_check_results,
+    print_boundary_results,
+)
+
+
+AUDIT_INPUT_PATHS = (
+    "scripts/teleportation_bell_measurement_boundary_checks_2026_07_27.py",
+    "docs/TELEPORTATION_BELL_MEASUREMENT_CIRCUIT_NOTE.md",
+    "docs/TELEPORTATION_CONCLUSION_BOUNDARY_NOTE.md",
+    "docs/audit/data/ledger/te/teleportation_causal_channel_note.json",
+    "docs/audit/data/ledger/te/teleportation_conclusion_boundary_note.json",
+    "docs/audit/data/ledger/te/teleportation_retained_axis_operator_algebra_closure_note.json",
+)
 
 
 I2 = np.eye(2, dtype=complex)
@@ -577,7 +590,7 @@ def print_summary(
     print("  no matter, mass, charge, energy, object transport, or FTL signaling is claimed")
 
     boundary_ok = print_boundary_results(
-        teleportation_boundary_check_results(Path(__file__).resolve().parents[1])
+        bell_measurement_boundary_check_results(Path(__file__).resolve().parents[1])
     )
 
     return all(pass_checks.values()) and boundary_ok

--- a/scripts/teleportation_bell_measurement_boundary_checks_2026_07_27.py
+++ b/scripts/teleportation_bell_measurement_boundary_checks_2026_07_27.py
@@ -1,0 +1,152 @@
+"""One-hop dependency checks for the ideal Bell-measurement circuit row."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+SUPPLIERS: tuple[tuple[str, str, set[str]], ...] = (
+    (
+        "ideal encoded Bell resource",
+        "teleportation_retained_axis_operator_algebra_closure_note",
+        {"retained_bounded", "retained"},
+    ),
+    (
+        "ideal logical gate/parity-measurement algebra",
+        "teleportation_retained_axis_operator_algebra_closure_note",
+        {"retained_bounded", "retained"},
+    ),
+    (
+        "ideal computational-readout algebra",
+        "teleportation_retained_axis_operator_algebra_closure_note",
+        {"retained_bounded", "retained"},
+    ),
+    (
+        "classical Bell-record handling",
+        "teleportation_causal_channel_note",
+        {"retained_bounded", "retained"},
+    ),
+)
+
+DEPENDENCY_LINKS: tuple[tuple[str, str], ...] = (
+    (
+        "retained-axis Bell-resource/gate/parity/readout supplier",
+        "TELEPORTATION_RETAINED_AXIS_OPERATOR_ALGEBRA_CLOSURE_NOTE.md",
+    ),
+    (
+        "retained classical record-handling supplier",
+        "TELEPORTATION_CAUSAL_CHANNEL_NOTE.md",
+    ),
+    (
+        "audited conclusion boundary",
+        "TELEPORTATION_CONCLUSION_BOUNDARY_NOTE.md",
+    ),
+)
+
+
+def _rows(root: Path, row_ids: set[str]) -> dict[str, dict[str, object]]:
+    """Load only the requested rows from the canonical tracked ledger shards."""
+    ledger_root = root / "docs" / "audit" / "data" / "ledger"
+    rows: dict[str, dict[str, object]] = {}
+    for row_id in sorted(row_ids):
+        path = ledger_root / row_id[:2] / f"{row_id}.json"
+        row = json.loads(path.read_text(encoding="utf-8"))
+        if row.get("claim_id") != row_id:
+            raise ValueError(f"ledger shard claim mismatch: {path}")
+        rows[row_id] = row
+    return rows
+
+
+def _compact(text: str) -> str:
+    return " ".join(text.split())
+
+
+def bell_measurement_boundary_check_results(
+    root: Path,
+    prefix: str = "Bell-measurement dependency boundary",
+) -> list[tuple[str, bool, str]]:
+    """Check retained suppliers, source edges, and the conclusion boundary."""
+    supplier_ids = {row_id for _, row_id, _ in SUPPLIERS}
+    supplier_ids.add("teleportation_conclusion_boundary_note")
+    rows = _rows(root, supplier_ids)
+    out: list[tuple[str, bool, str]] = []
+
+    for role, row_id, allowed in SUPPLIERS:
+        row = rows[row_id]
+        effective = row.get("effective_status")
+        audit = row.get("audit_status")
+        out.append(
+            (
+                f"{prefix}: {role} has retained one-hop support",
+                effective in allowed and audit == "audited_clean",
+                f"{row_id}: effective={effective}, audit={audit}",
+            )
+        )
+
+    conclusion_row = rows["teleportation_conclusion_boundary_note"]
+    out.append(
+        (
+            f"{prefix}: conclusion boundary has audited scope support",
+            conclusion_row.get("effective_status") == "audited_renaming"
+            and conclusion_row.get("audit_status") == "audited_renaming",
+            "teleportation_conclusion_boundary_note: "
+            f"effective={conclusion_row.get('effective_status')}, "
+            f"audit={conclusion_row.get('audit_status')}",
+        )
+    )
+
+    source = (
+        root / "docs" / "TELEPORTATION_BELL_MEASUREMENT_CIRCUIT_NOTE.md"
+    ).read_text(encoding="utf-8")
+    for role, target in DEPENDENCY_LINKS:
+        out.append(
+            (
+                f"{prefix}: source cites {role}",
+                f"]({target})" in source,
+                target,
+            )
+        )
+
+    conclusion = _compact(
+        (root / "docs" / "TELEPORTATION_CONCLUSION_BOUNDARY_NOTE.md").read_text(
+            encoding="utf-8"
+        )
+    )
+    out.append(
+        (
+            f"{prefix}: lane remains state-teleportation only with no-transfer boundary",
+            all(
+                phrase in conclusion
+                for phrase in [
+                    "ordinary quantum state teleportation only",
+                    "No matter, mass, charge, energy, object, or faster-than-light transport is claimed.",
+                    "unconditional_closed = False",
+                    "nature-grade closure HOLD",
+                ]
+            ),
+            "checked conclusion boundary note",
+        )
+    )
+    out.append(
+        (
+            f"{prefix}: finite planning support is not nature-grade closure",
+            "planning_closed = True" in conclusion
+            and "promote_to_nature_grade = False" in conclusion,
+            "planning closure and nature-grade hold are distinct",
+        )
+    )
+    return out
+
+
+def print_boundary_results(results: list[tuple[str, bool, str]]) -> bool:
+    ok = True
+    print()
+    print("Downstream boundary checks:")
+    for label, passed, detail in results:
+        ok = ok and passed
+        print(
+            f"  {label}: {'PASS' if passed else 'FAIL'}"
+            + (f" ({detail})" if detail else "")
+        )
+    return ok


### PR DESCRIPTION
## Summary

Repairs the terminal non-clean row
`teleportation_bell_measurement_circuit_note` by adding explicit one-hop
retained suppliers for its ideal logical ingredients, moving the boundary
helper to canonical sharded-ledger inputs, declaring every mutable cached-runner
input, and refreshing the runner cache.

- **Category:** `conditional_missing_dependency_edge`
- **Final claim type:** `open_gate`
- **Audit authority:** independent audit lane only

## Exact audit repair target

> missing_dependency_edge: add explicit one-hop retained-grade citations for the ideal Bell-resource, gate/parity-measurement, computational-readout, and record-handling suppliers, package the ledger and conclusion-boundary inputs required by the helper, and re-audit.

## Review-loop result

**PASS WITH BOUNDED CLAIMS**

The ideal Bell-projector, CNOT–H readout, bit convention, and teleportation
correction algebra pass an independent exact symbolic recomputation in all four
Bell branches. The note remains an `open_gate`: no native apparatus, gate
schedule, detector, resource-preparation dynamics, durable record formation,
noise model, or nature-grade physical implementation is claimed.

The review fixed two audit/governance issues:

1. Added explicit `Claim type: open_gate` metadata.
2. Kept `TELEPORTATION_CONCLUSION_BOUNDARY_NOTE.md` as fingerprinted,
   non-load-bearing planning context. Making its `audited_renaming` row a
   citation-graph dependency left this target queued but not ready.

The final citation graph has exactly the two retained dependencies needed by
the ideal claim:

- `teleportation_retained_axis_operator_algebra_closure_note`
- `teleportation_causal_channel_note`

Validation confirms the repaired target resets to `unaudited`, re-enters the
ordinary audit queue with `ready: true`, and carries no authored verdict.

## Verification

- paired runner and all 10 dependency/boundary checks: PASS
- independent exact Bell/circuit/teleportation algebra: PASS (4/4 branches)
- changed Python `py_compile`: PASS
- runner cache PR-diff coverage: fresh
- vocabulary lint: clean
- full audit validation pipeline: PASS
- strict audit lint: PASS (no errors)
- citation-graph invariant and manifest acknowledgment: PASS
- repository-portable Markdown links: PASS
- `git diff --check`: PASS

Generated audit ledger, queue, dispatch, and publication-status outputs were
restored after validation. Only the deterministic citation-graph manifest
acknowledgment is included for the dependency change.

🤖 Original repair generated by `scripts/science_fix_loop.py`; final review and
landing performed through the repo-native review loop.
