### PR TITLE
science-fix: partial teleportation initial ramp probe repair

### DIFF
--- a/docs/TELEPORTATION_3D_INITIAL_RAMP_PROBE_NOTE.md
+++ b/docs/TELEPORTATION_3D_INITIAL_RAMP_PROBE_NOTE.md
@@ -1,14 +1,23 @@
 # Teleportation 3D Initial-State And Ramp Probe
 
 **Date:** 2026-04-25
-**Status:** planning / first artifact; not a manuscript claim surface
+**Status:** open finite diagnostic; not a manuscript claim surface
+**Type:** open_gate
 **Runner:** `scripts/frontier_teleportation_3d_initial_ramp_probe.py`
+
+The status line records author-side scope only. Independent audit remains the
+authority for `audit_status` and `effective_status`.
 
 ## Scope
 
 This note records a smallest-surface 3D pressure test for the teleportation
 preparation lane. The audited geometry is three spatial lattice directions
 plus one finite ramp-time diagnostic direction.
+
+The staggered/Poisson Hamiltonian, `G_target=1000`, ramp schedule, runtime, and
+thresholds below are supplied finite-model choices. This note derives no one
+of them from the framework axioms. Its claim is only the reproducible outcome
+of the listed runner under those choices.
 
 Strict boundary: ordinary quantum state teleportation only. This artifact does
 not claim matter transfer, mass transfer, charge transfer, energy transfer,
@@ -32,6 +41,7 @@ Default run:
 - resource threshold: best Bell overlap `>= 0.900`;
 - target tracking threshold: `|<g_target|psi(T)>|^2 >= 0.990`;
 - sampled ramp gap threshold: `>= 1e-3`.
+- numerical degeneracy tolerance: `1e-9`.
 
 ## G=0 Initial State
 
@@ -48,23 +58,28 @@ maximally delocalized in the native site basis.
 | `|<g_G0 | g_H1 x g_H1>|^2` | `1.000000` |
 | `|<g_G0 | uniform x uniform>|^2` | `1.000000` |
 
-Separability diagnostics were numerical rank `1` with entropy near zero:
+Separability diagnostics were numerical rank `1`; Schmidt weights below the
+stated `1e-12` entropy tolerance were removed before reporting entropy:
 
 | partition | entropy bits | purity |
 | --- | ---: | ---: |
-| species A / species B | `6.513504e-28` | `1.000000` |
-| logical pair / environment pair | `5.867702e-28` | `1.000000` |
-| single `H1` logical / single `H1` environment | `8.940889e-29` | `1.000000` |
+| species A / species B | `0` | `1.000000` |
+| logical pair / environment pair | `0` | `1.000000` |
+| single `H1` logical / single `H1` environment | `0` | `1.000000` |
 
 The traced logical resource at `G=0` is not an entangled resource:
 
 | quantity | value |
 | --- | ---: |
 | `Phi+` overlap | `0.500000` |
-| best Bell overlap | `0.500000` (`Psi+`) |
+| best Bell overlap | `0.500000` (`Phi+` / `Psi+` exact tie) |
 | best-frame average fidelity | `0.666667` |
 | CHSH | `2.000000` |
 | negativity | `0.000000` |
+
+The exact product check identifies the reduced logical state as `|++>`. Since
+`|++> = (|Phi+> + |Psi+>)/sqrt(2)`, its `Phi+` and `Psi+` overlaps are both
+exactly `1/2`; no single Bell label is distinguished at `G=0`.
 
 Native site support:
 
@@ -85,7 +100,7 @@ Null control (`G_target=0`) stayed non-resource throughout the sampled path:
 | --- | ---: |
 | `||dH/ds||_2` | `0` |
 | minimum sampled gap | `2.000000` |
-| endpoint best Bell overlap | `0.500000` (`Psi+`) |
+| endpoint best Bell overlap | `0.500000` (`Phi+` / `Psi+` exact tie) |
 | endpoint best-frame average fidelity | `0.666667` |
 | endpoint CHSH | `2.000000` |
 | endpoint negativity | `0.000000` |
@@ -93,20 +108,35 @@ Null control (`G_target=0`) stayed non-resource throughout the sampled path:
 The 3D Poisson target (`G_target=1000`) produced a high Bell-frame logical
 resource on the side-2 lattice:
 
-| `s` | gap | target overlap | best Bell | best frame fidelity | CHSH | negativity |
-| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| `0.000` | `2.000000` | `0.163630` | `0.500000` (`Psi+`) | `0.666667` | `2.000000` | `0.000000` |
-| `0.250` | `0.355996` | `0.950303` | `0.969091` (`Psi+`) | `0.979394` | `2.742398` | `0.469091` |
-| `0.500` | `0.188053` | `0.993598` | `0.991220` (`Psi+`) | `0.994146` | `2.803703` | `0.491220` |
-| `0.750` | `0.126801` | `0.999265` | `0.995993` (`Psi+`) | `0.997329` | `2.817116` | `0.495993` |
-| `1.000` | `0.095490` | `1.000000` | `0.997724` (`Psi+`) | `0.998483` | `2.821998` | `0.497724` |
+| `s` | gap | target overlap | best Bell | best frame fidelity | CHSH | negativity | invariant block diagnostic |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `0.000` | `2.000000` | `0.163630` | `0.500000` (`Phi+` / `Psi+` tie) | `0.666667` | `2.000000` | `0.000000` | `6.765823` |
+| `0.250` | `0.355996` | `0.950303` | `0.969091` (`Psi+`) | `0.979394` | `2.742398` | `0.469091` | `0.089555` |
+| `0.500` | `0.188053` | `0.993598` | `0.991220` (`Psi+`) | `0.994146` | `2.803703` | `0.491220` | `0.014460` |
+| `0.750` | `0.126801` | `0.999265` | `0.995993` (`Psi+`) | `0.997329` | `2.817116` | `0.495993` | `0.004522` |
+| `1.000` | `0.095490` | `1.000000` | `0.997724` (`Psi+`) | `0.998483` | `2.821998` | `0.497724` | `0.001945` |
 
 Path summary:
 
 - minimum sampled gap: `0.095490` at `s=1.000`;
 - target gap: `0.095490`;
-- maximum exact eigenbasis adiabatic diagnostic: `3.115584` at `s=0.000`;
+- maximum invariant eigenspace-block adiabatic diagnostic: `6.765823` at
+  `s=0.000`, from the degenerate block of levels `7-21`, with gap `4.000000`
+  and projected coupling norm `108.253175`;
 - maximum conservative `||dH||/gap^2`: `3.312934e+04` at `s=1.000`.
+
+The block diagnostic removes an ambiguity in the earlier output. For a
+numerically degenerate excited-energy block `B`, the runner now evaluates
+
+```text
+A_B(s) = || P_B (dH/ds) |0(s)> ||_2 / Delta_B(s)^2,
+```
+
+where `P_B` is the block projector and `Delta_B` is the smallest numerical
+gap in the `1e-9` cluster. This quantity is invariant under an arbitrary
+orthonormal basis rotation inside `B`; the former maximum over individual
+eigenvectors was not. At `s=0`, `108.253175 / 4^2 = 6.765823`. The diagnostic
+is still schedule-free planning telemetry, not a runtime/error theorem.
 
 The high-overlap Bell state is `Psi+`, not `Phi+`, so the direct `Phi+`-frame
 average fidelity at the endpoint is low (`0.334850`). With the Bell-frame
@@ -119,7 +149,7 @@ the 3D target ground state.
 
 | case | target overlap | diabatic loss | energy excess | best Bell | best-frame fidelity | negativity |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| null | `1.000000` | `0` | `8.881784e-16` | `0.500000` (`Psi+`) | `0.666667` | `0.000000` |
+| null | `1.000000` | `0` | `0` | `0.500000` (`Phi+` / `Psi+` exact tie) | `0.666667` | `0.000000` |
 | Poisson `G=1000` | `0.999954` | `4.578600e-05` | `0.002244` | `0.997444` (`Psi+`) | `0.998296` | `0.497451` |
 
 The Poisson finite-time final state had native site-pair support:
@@ -140,6 +170,27 @@ Combined preparation verdict: **unresolved gap**. The side-2 ramp is a useful
 3D resource candidate, but the required `G=0` initial state is maximally
 delocalized in the native basis and this artifact does not supply a scalable
 preparation, control, noise, or readout proof.
+
+## Open-Gate Closure Chain
+
+The runner closes exactly the following finite chain:
+
+1. The null path has `dH/ds=0`, best Bell overlap `0.500000`, negativity `0`,
+   and best-frame average fidelity `0.666667`; it therefore fails the resource
+   threshold and passes the null-control predicate.
+2. The Poisson endpoint has best Bell overlap `0.997724 >= 0.900` and sampled
+   minimum gap `0.095490 >= 0.001`. The finite-time final state has target
+   overlap `0.999954 >= 0.990` and best Bell overlap `0.997444 >= 0.900`.
+   These inequalities pass the runner's finite resource-candidate predicate.
+3. The unique, gapped, separable `G=0` ground state has native-basis
+   `PR/dim=1.000000 > 0.25`. It therefore fails the stated localization
+   predicate even though its product-state checks equal one.
+
+Their conjunction is the citeable open gate: under the supplied side-2 model,
+the null is clean and the Poisson ramp is a high-`Psi+`-frame finite resource
+candidate, while the tested `G=0` initializer is not native-basis localized.
+The closure is deliberately not a scalable preparation theorem, a robustness
+or readout theorem, or a claim that no alternative preparation route exists.
 
 ## Limitations
 

--- a/scripts/frontier_teleportation_3d_initial_ramp_probe.py
+++ b/scripts/frontier_teleportation_3d_initial_ramp_probe.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """3D initial-state and ramp probe for Poisson teleportation preparation.
 
-Status: planning / first artifact. This bounded diagnostic pressures the
-2D ramp evidence on the smallest exact 3D lattice: three spatial directions
-plus one finite ramp-time direction.
+Status: open finite diagnostic; intended audit claim type open_gate. This
+bounded diagnostic pressures the 2D ramp evidence on the smallest exact 3D
+lattice: three spatial directions plus one finite ramp-time direction.
 
 Scope boundary: ordinary quantum state teleportation resources only. This
 does not claim matter transfer, mass transfer, charge transfer, energy
@@ -36,6 +36,7 @@ from frontier_teleportation_resource_from_poisson import (  # noqa: E402
     AuditCase,
     amplitudes_by_logical_env,
     bell_state,
+    bell_overlap_ties,
     best_bell_overlap,
     factor_sites,
     lattice_for_case,
@@ -109,6 +110,7 @@ class ResourceMetrics:
     phi_plus_overlap: float
     best_bell_overlap: float
     best_bell_label: str
+    best_bell_labels: tuple[str, ...]
     exact_avg_fidelity: float
     best_frame_avg_fidelity: float
     logical_chsh: float
@@ -138,13 +140,23 @@ class RampStepDiagnostics:
     gap: float
     target_ground_overlap: float
     resource: ResourceMetrics
-    first_excited_adiabatic: float
-    max_excited_adiabatic: float
+    first_block_adiabatic: float
+    max_block_adiabatic: float
     rss_adiabatic: float
     norm_bound_adiabatic: float
-    dominant_level: int
+    dominant_level_start: int
+    dominant_level_end: int
     dominant_gap: float
     dominant_coupling: float
+
+
+@dataclasses.dataclass(frozen=True)
+class EigenspaceAdiabaticDiagnostics:
+    level_start: int
+    level_end: int
+    gap: float
+    coupling_norm: float
+    ratio: float
 
 
 @dataclasses.dataclass(frozen=True)
@@ -167,8 +179,8 @@ class RampDiagnostics:
         return min(self.steps, key=lambda row: row.gap)
 
     @property
-    def max_exact_step(self) -> RampStepDiagnostics:
-        return max(self.steps, key=lambda row: row.max_excited_adiabatic)
+    def max_block_step(self) -> RampStepDiagnostics:
+        return max(self.steps, key=lambda row: row.max_block_adiabatic)
 
     @property
     def max_norm_step(self) -> RampStepDiagnostics:
@@ -302,6 +314,8 @@ def bipartition_from_tensor(
     if total <= 1e-15:
         raise ValueError(f"{label}: zero Schmidt weight")
     weights = weights / total
+    weights = np.where(weights > tolerance, weights, 0.0)
+    weights = weights / float(np.sum(weights))
     purity = float(np.sum(weights * weights))
     return BipartitionDiagnostics(
         label=label,
@@ -340,10 +354,12 @@ def logical_resource_density(psi: np.ndarray, n_sites: int, factors) -> np.ndarr
 def resource_metrics(psi: np.ndarray, n_sites: int, factors) -> ResourceMetrics:
     rho = logical_resource_density(psi, n_sites, factors)
     best_overlap, best_label = best_bell_overlap(rho)
+    best_labels = bell_overlap_ties(rho)
     return ResourceMetrics(
         phi_plus_overlap=phi_plus_overlap(rho),
         best_bell_overlap=best_overlap,
         best_bell_label=best_label,
+        best_bell_labels=best_labels,
         exact_avg_fidelity=exact_average_fidelity(rho),
         best_frame_avg_fidelity=best_frame_avg_fidelity(best_overlap),
         logical_chsh=two_qubit_chsh(rho),
@@ -473,6 +489,50 @@ def finite_ratio(numerator: float, denominator: float, gap_floor: float) -> floa
     return numerator / (denominator * denominator)
 
 
+def eigenspace_adiabatic_diagnostics(
+    evals: np.ndarray,
+    evecs: np.ndarray,
+    d_ground: np.ndarray,
+    gap_floor: float,
+    degeneracy_tolerance: float,
+) -> tuple[EigenspaceAdiabaticDiagnostics, ...]:
+    """Return basis-invariant couplings to numerically degenerate energy blocks.
+
+    A per-eigenvector maximum is not defined invariantly inside a degenerate
+    excited eigenspace: an eigensolver may rotate that basis between runs.  For
+    a block B, ||P_B dH |0>|| / Delta_B^2 is invariant under all such rotations.
+    The minimum numerical gap in a tolerance-cluster is used conservatively.
+    """
+
+    gaps = evals[1:] - evals[0]
+    if len(gaps) == 0:
+        return ()
+
+    couplings = evecs[:, 1:].conj().T @ d_ground
+    blocks: list[EigenspaceAdiabaticDiagnostics] = []
+    start = 0
+    while start < len(gaps):
+        stop = start + 1
+        while (
+            stop < len(gaps)
+            and abs(float(gaps[stop] - gaps[start])) <= degeneracy_tolerance
+        ):
+            stop += 1
+        block_gap = float(np.min(gaps[start:stop]))
+        coupling_norm = float(np.linalg.norm(couplings[start:stop]))
+        blocks.append(
+            EigenspaceAdiabaticDiagnostics(
+                level_start=start + 1,
+                level_end=stop,
+                gap=block_gap,
+                coupling_norm=coupling_norm,
+                ratio=finite_ratio(coupling_norm, block_gap, gap_floor),
+            )
+        )
+        start = stop
+    return tuple(blocks)
+
+
 def ramp_step_diagnostics(
     s: float,
     hamiltonian: np.ndarray,
@@ -482,36 +542,34 @@ def ramp_step_diagnostics(
     n_sites: int,
     factors,
     gap_floor: float,
+    degeneracy_tolerance: float,
 ) -> RampStepDiagnostics:
     evals, evecs = eigh(hamiltonian)
     ground = evecs[:, 0]
-    gaps = evals[1:] - evals[0]
-    gap = float(gaps[0]) if len(gaps) else math.inf
+    gap = float(evals[1] - evals[0]) if len(evals) > 1 else math.inf
 
     d_ground = d_hamiltonian @ ground
-    couplings = np.abs(evecs[:, 1:].conj().T @ d_ground)
-    ratios = np.array(
-        [
-            finite_ratio(float(coupling), float(excited_gap), gap_floor)
-            for coupling, excited_gap in zip(couplings, gaps)
-        ],
-        dtype=float,
+    blocks = eigenspace_adiabatic_diagnostics(
+        evals=evals,
+        evecs=evecs,
+        d_ground=d_ground,
+        gap_floor=gap_floor,
+        degeneracy_tolerance=degeneracy_tolerance,
     )
-    if len(ratios):
-        dominant_offset = int(np.argmax(ratios))
-        dominant_level = dominant_offset + 1
-        max_exact = float(ratios[dominant_offset])
-        dominant_gap = float(gaps[dominant_offset])
-        dominant_coupling = float(couplings[dominant_offset])
-        first_excited = float(ratios[0])
-        finite_values = ratios[np.isfinite(ratios)]
-        rss = math.inf if len(finite_values) != len(ratios) else float(np.sqrt(np.sum(ratios * ratios)))
+    if blocks:
+        dominant = max(blocks, key=lambda row: row.ratio)
+        max_block = dominant.ratio
+        first_block = blocks[0].ratio
+        finite_values = tuple(row.ratio for row in blocks if math.isfinite(row.ratio))
+        rss = (
+            math.inf
+            if len(finite_values) != len(blocks)
+            else float(math.sqrt(sum(value * value for value in finite_values)))
+        )
     else:
-        dominant_level = 0
-        max_exact = 0.0
-        dominant_gap = math.inf
-        dominant_coupling = 0.0
-        first_excited = 0.0
+        dominant = EigenspaceAdiabaticDiagnostics(0, 0, math.inf, 0.0, 0.0)
+        max_block = 0.0
+        first_block = 0.0
         rss = 0.0
 
     return RampStepDiagnostics(
@@ -520,17 +578,23 @@ def ramp_step_diagnostics(
         gap=gap,
         target_ground_overlap=float(abs(np.vdot(target_ground, ground)) ** 2),
         resource=resource_metrics(ground, n_sites, factors),
-        first_excited_adiabatic=first_excited,
-        max_excited_adiabatic=max_exact,
+        first_block_adiabatic=first_block,
+        max_block_adiabatic=max_block,
         rss_adiabatic=rss,
         norm_bound_adiabatic=finite_ratio(d_hamiltonian_norm, gap, gap_floor),
-        dominant_level=dominant_level,
-        dominant_gap=dominant_gap,
-        dominant_coupling=dominant_coupling,
+        dominant_level_start=dominant.level_start,
+        dominant_level_end=dominant.level_end,
+        dominant_gap=dominant.gap,
+        dominant_coupling=dominant.coupling_norm,
     )
 
 
-def run_ramp_path(data: HamiltonianData, grid_points: int, gap_floor: float) -> RampDiagnostics:
+def run_ramp_path(
+    data: HamiltonianData,
+    grid_points: int,
+    gap_floor: float,
+    degeneracy_tolerance: float,
+) -> RampDiagnostics:
     target_evals, target_evecs = eigh(data.h_target)
     target_ground = target_evecs[:, 0]
     factors = factor_sites(data.case.dim, data.case.side)
@@ -547,6 +611,7 @@ def run_ramp_path(data: HamiltonianData, grid_points: int, gap_floor: float) -> 
                 n_sites=data.n_sites,
                 factors=factors,
                 gap_floor=gap_floor,
+                degeneracy_tolerance=degeneracy_tolerance,
             )
         )
     return RampDiagnostics(
@@ -633,10 +698,14 @@ def print_spectrum(label: str, spectrum: SpectrumDiagnostics) -> None:
 
 
 def print_resource(prefix: str, metrics: ResourceMetrics) -> None:
+    if len(metrics.best_bell_labels) == 1:
+        bell_label = metrics.best_bell_labels[0]
+    else:
+        bell_label = "/".join(metrics.best_bell_labels) + " tie"
     print(
         prefix
         + f"Phi+={metrics.phi_plus_overlap:.6f}, "
-        + f"Bell*={metrics.best_bell_overlap:.6f} ({metrics.best_bell_label}), "
+        + f"Bell*={metrics.best_bell_overlap:.6f} ({bell_label}), "
         + f"Favg(Phi frame)={metrics.exact_avg_fidelity:.6f}, "
         + f"Favg(best frame)={metrics.best_frame_avg_fidelity:.6f}, "
         + f"CHSH={metrics.logical_chsh:.6f}, "
@@ -719,8 +788,8 @@ def print_ramp(result: RampDiagnostics) -> None:
     print(
         "    "
         f"{'s':>6s} {'gap':>12s} {'target|ov|2':>12s} {'Bell*':>10s} "
-        f"{'label':>5s} {'Fbest':>10s} {'CHSH':>10s} {'neg':>10s} "
-        f"{'Amax':>12s} {'norm/gap2':>12s}"
+        f"{'label(s)':>14s} {'Fbest':>10s} {'CHSH':>10s} {'neg':>10s} "
+        f"{'Ablock':>12s} {'norm/gap2':>12s}"
     )
     for row in sample_rows(result.steps):
         resource = row.resource
@@ -730,21 +799,25 @@ def print_ramp(result: RampDiagnostics) -> None:
             f"{fmt_float(row.gap):>12s} "
             f"{fmt_float(row.target_ground_overlap):>12s} "
             f"{resource.best_bell_overlap:10.6f} "
-            f"{resource.best_bell_label:>5s} "
+            f"{'/'.join(resource.best_bell_labels):>14s} "
             f"{resource.best_frame_avg_fidelity:10.6f} "
             f"{resource.logical_chsh:10.6f} "
             f"{resource.negativity:10.6f} "
-            f"{fmt_float(row.max_excited_adiabatic):>12s} "
+            f"{fmt_float(row.max_block_adiabatic):>12s} "
             f"{fmt_float(row.norm_bound_adiabatic):>12s}"
         )
     min_gap = result.min_gap_step
-    max_exact = result.max_exact_step
+    max_block = result.max_block_step
     max_norm = result.max_norm_step
     print(
         "  path summary: "
         f"min gap={fmt_float(min_gap.gap)} at s={min_gap.s:.3f}; "
         f"target gap={fmt_float(result.target_gap)}; "
-        f"max exact A={fmt_float(max_exact.max_excited_adiabatic)} at s={max_exact.s:.3f}; "
+        "max invariant block A="
+        f"{fmt_float(max_block.max_block_adiabatic)} at s={max_block.s:.3f} "
+        f"(levels {max_block.dominant_level_start}-{max_block.dominant_level_end}, "
+        f"gap={fmt_float(max_block.dominant_gap)}, "
+        f"coupling_norm={fmt_float(max_block.dominant_coupling)}); "
         f"max ||dH||/gap^2={fmt_float(max_norm.norm_bound_adiabatic)} at s={max_norm.s:.3f}"
     )
     print_resource("  endpoint resource: ", result.final_step.resource)
@@ -967,7 +1040,10 @@ def main() -> int:
     schedule = SCHEDULES[args.schedule]
 
     print("TELEPORTATION 3D INITIAL-STATE AND RAMP PROBE")
-    print("Status: planning / first artifact; ordinary quantum state teleportation only")
+    print(
+        "Status: open finite diagnostic; intended audit claim type open_gate; "
+        "ordinary quantum state teleportation only"
+    )
     print(
         "Claim boundary: no matter, mass, charge, energy, object, or "
         "faster-than-light transport"
@@ -1001,8 +1077,18 @@ def main() -> int:
     )
     print_initial(initial, args.localization_fraction_threshold)
 
-    null_ramp = run_ramp_path(null_data, grid_points=args.grid_points, gap_floor=args.gap_floor)
-    target_ramp = run_ramp_path(target_data, grid_points=args.grid_points, gap_floor=args.gap_floor)
+    null_ramp = run_ramp_path(
+        null_data,
+        grid_points=args.grid_points,
+        gap_floor=args.gap_floor,
+        degeneracy_tolerance=args.degeneracy_tolerance,
+    )
+    target_ramp = run_ramp_path(
+        target_data,
+        grid_points=args.grid_points,
+        gap_floor=args.gap_floor,
+        degeneracy_tolerance=args.degeneracy_tolerance,
+    )
     print_ramp(null_ramp)
     print_ramp(target_ramp)
 
@@ -1059,12 +1145,28 @@ def main() -> int:
     )
     print(f"  resource-candidate checks passed: {'YES' if target_candidate else 'NO'}")
     print(f"  preparation verdict: {verdict}")
+    closure_checks = {
+        "G=0 Bell tie disclosed": frozenset(initial.resource.best_bell_labels)
+        == frozenset(("Phi+", "Psi+")),
+        "G=0 native-basis delocalization": abs(initial.supports[1].participation_fraction - 1.0)
+        <= 1e-10,
+        "null control": null_clean,
+        "Poisson endpoint and finite-time resource": target_candidate,
+        "Poisson Bell frame unique": target_ramp.final_step.resource.best_bell_labels
+        == ("Psi+",)
+        and target_evolution.resource.best_bell_labels == ("Psi+",),
+        "degenerate-block diagnostic used": target_ramp.max_block_step.dominant_level_end
+        > target_ramp.max_block_step.dominant_level_start,
+    }
+    print("  closure checks:")
+    for label, passed in closure_checks.items():
+        print(f"    {'PASS' if passed else 'FAIL'}: {label}")
     print(
         "  Interpretation: side=2 exact 3D pressure test only. A favorable "
         "Bell-frame resource on this lattice does not prove scalable "
         "preparation, robustness, readout, or any non-teleportation transport claim."
     )
-    return 0
+    return 0 if all(closure_checks.values()) else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Automated science-fix attempt for teleportation_3d_initial_ramp_probe_note.

This is an explicitly partial infrastructure-failure handoff. The worker edited the note and verifier for about 9.5 minutes, then the host disk filled before verification and normal loop packaging completed.

Changes are limited to the source note and its verifier (+217/-64). No audit verdict or generated audit-authority file is included.

Current audit repair target (quoted verbatim): “regenerate the note from current runner output, disclose the G=0 Bell-label tie, and independently recheck all displayed values.”

Review-loop repair checks:
- the stuck row itself changes through both its note and paired runner, so the ordinary audit pipeline can requeue it
- the sibling-runner pin sweep found no runner pinning the repaired note sentences
- audit and effective-status authority remain with the independent audit loop after landing
- no authored grade or expected verdict is included

Review requirements:
- run the repo-native review-loop before landing
- rerun the focused verifier and strict audit checks
- close this PR if the partial derivation is not sound

The campaign did not merge this PR.