### PR TITLE
science-fix: attempt to close gauge_vacuum_plaquette_first_sector_m...

### DIFF
--- a/docs/GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_MINIMAL_BULK_COMPLETION_PACKET_THEOREM_NOTE_2026-04-19.md
+++ b/docs/GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_MINIMAL_BULK_COMPLETION_PACKET_THEOREM_NOTE_2026-04-19.md
@@ -8,10 +8,9 @@ ledger or effective status.
 
 ## Claim
 
-On the explicitly narrowed zero-extension/witness surface supplied by the
-first-sector minimal-bulk completion principle note, the canonical
-factorized-class zero extension produces one explicit Wilson/Perron
-first-layer packet.
+On the finite-cone zero-extension branch supplied by the first-sector
+minimal-bulk completion principle note, the canonical factorized-class zero
+extension produces one explicit Wilson/Perron first-layer packet.
 
 Let `rho_ret` be the first-sector retained packet consumed by the local
 runner helpers, and let `rho_0` be its coefficient-order zero extension to
@@ -39,7 +38,7 @@ m1     = 0.430754683575...
 m2     = 0.249382329102...
 ```
 
-This is a bounded packet theorem on the zero-extension witness branch. It
+This is a bounded packet theorem on the finite-cone zero-extension branch. It
 does not assert that the framework-point Wilson environment packet is
 physically selected by this branch.
 
@@ -61,9 +60,10 @@ external mathematical authority.
 
 ## Boundaries
 
-This note does not prove universal Loewner-minimality for all admissible
-tails. The sibling minimal-bulk completion principle note records that as an
-open derivation gap.
+This note does not re-prove the sibling principle's arbitrary-tail
+coefficient and Loewner minimality theorem on the finite box. It consumes
+only that theorem's zero-extension branch to compute a packet. Neither note
+claims an infinite-weight completion theorem.
 
 This note does not add an axiom, selector law, or physical postulate.
 
@@ -81,8 +81,8 @@ effective-status change.
 ## Dependencies
 
 - [GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_MINIMAL_BULK_COMPLETION_PRINCIPLE_THEOREM_NOTE_2026-04-19.md](GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_MINIMAL_BULK_COMPLETION_PRINCIPLE_THEOREM_NOTE_2026-04-19.md)
-  for the narrowed runner-tested zero-extension/witness surface and for the
-  explicit statement that universal Loewner-minimality remains open.
+  for the unique coefficient- and Loewner-minimal zero extension on the
+  finite 36-slot tail cone.
 - [GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_ZERO_EXTENSION_FACTORIZED_CLASS_THEOREM_NOTE_2026-04-19.md](GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_ZERO_EXTENSION_FACTORIZED_CLASS_THEOREM_NOTE_2026-04-19.md)
   for the explicit factorized-class zero-extension construction and local
   factor diagonal used by the runner.

--- a/docs/GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_MINIMAL_BULK_COMPLETION_PRINCIPLE_THEOREM_NOTE_2026-04-19.md
+++ b/docs/GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_MINIMAL_BULK_COMPLETION_PRINCIPLE_THEOREM_NOTE_2026-04-19.md
@@ -1,102 +1,158 @@
 # Gauge-Vacuum Plaquette First-Sector Minimal-Bulk Completion Principle
 
-**Date:** 2026-04-19 (originally); 2026-05-10 (scope-narrowed per audit verdict); 2026-05-16 (substring-import mechanism removed from runner per audit verdict)
+**Date:** 2026-04-19 (originally); 2026-07-27 (finite-cone proof completed)
 **Claim type:** bounded_theorem
 **Status authority:** independent audit lane only.
 **Primary runner:** [`scripts/frontier_gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_principle_theorem_2026_04_19.py`](../scripts/frontier_gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_principle_theorem_2026_04_19.py)
 
 ## Claim
 
-Fix the retained packet `rho_ret` on the first-symmetric support inside the
-canonical Wilson factorized class.
+Let
 
-Inside the canonical Wilson factorized cone, the coefficient-order
-zero-extension `rho_0` is the unique zero-coefficient lift of `rho_ret`
-that adds zero mass to every higher-weight slot. Equivalently, on the
-explicit witness families exercised by the runner, every nonzero
-nonnegative tail strictly increases at least one positive bulk-tail
-functional (total tail mass, weighted tail mass, squared `l2` mass, or
-support size) and adds a positive-semidefinite Loewner increment to the
-factorized-Wilson transfer.
+```text
+W_5 = {(p,q): 0 <= p,q <= 5}
+R   = {(0,0), (1,0), (0,1), (1,1)}
+```
 
-This is the runner-certified part of the first-sector minimal-bulk
-completion picture. It does not promote a new axiom and does not change
-the framework-point Wilson environment packet that is still open.
+be the 36-slot dominant-weight box and retained support used by the runner.
+Fix the displayed nonnegative conjugation-symmetric retained packet
+`rho_ret` on `R`, and let `E(rho_ret)` be the set of all **full packets on
+this finite box** that are nonnegative, conjugation-symmetric, and restrict
+to `rho_ret` on `R`.  The phrase "full packet" below means all slots of
+`W_5`; no claim about an infinite dominant-weight lattice is made.
 
-## Scope
+Let `rho_0` equal `rho_ret` on `R` and zero off `R`.  Then:
 
-This note is restricted to the runner-tested witness families:
+1. `rho_0` is the unique least element of `E(rho_ret)` in coefficient
+   order.
+2. Every coefficient-order-monotone bulk-tail functional is minimized at
+   `rho_0`.  The minimizer is unique for every functional that is strictly
+   positive on every nonzero admissible tail.  This class includes positive
+   weighted tail mass, positive weighted `p`-mass for every `p > 0`, and
+   positive weighted support size; hence it includes all four functionals
+   printed by the runner.
+3. In the finite canonical factorized model
 
-- the explicit zero-extension packet `rho_0` of `rho_ret` to the
-  retained first-symmetric weights `(0,0), (1,0), (0,1), (1,1)`;
-- two explicit nonnegative tails inside the audited factorized cone,
-  the `(2,0) + (0,2)` witness with mass `0.05 + 0.05` and the
-  `(2,1) + (1,2) + (2,2)` witness with mass `0.03 + 0.03 + 0.02`;
-- the four positive bulk-tail functionals listed above (total tail
-  mass, weighted tail mass, squared `l2` mass, support size);
-- a randomized sweep (n = 64) of admissible nonnegative
-  conjugation-symmetric tails inside the cone, used solely to certify
-  the algebraic identity `delta >= 0 ==> rho_0 + delta >= rho_0`
-  coefficientwise. The sweep does **not** certify universal Loewner
-  monotonicity.
+   ```text
+   T(rho) = M D_loc diag(rho) M,
+   M = exp(beta J / 2),
+   ```
 
-For these explicit witness families the runner certifies coefficient-
-order minimality of `rho_0` and a positive-semidefinite Loewner
-increment for both tested tails inside the canonical factorized cone.
+   where the runner verifies that `M` is real symmetric and invertible and
+   that `D_loc` is strictly positive diagonal, `T(rho_0)` is the unique
+   least element of `{T(rho): rho in E(rho_ret)}` in Loewner order.
 
-## Open derivation gap
+Thus coefficient minimality, functional minimality, and finite-box Loewner
+minimality are separate consequences of one explicit tail-cone
+decomposition.  They are not asserted as definitionally equivalent.
 
-For arbitrary admissible nonnegative conjugation-symmetric tails inside
-the canonical Wilson factorized cone, the universal Loewner-monotonicity
-/ unique-minimality theorem is **not** established by this note or by
-the runner's finite witness checks. The auditor verdict was explicit:
+## Proof
 
-> The coefficient-order zero-extension result is valid on its own
-> terms, but the claimed equivalence to unique Loewner-minimality for
-> all admissible extensions is not established by the provided note and
-> code.
+Write `tau(p,q) = (q,p)`.  The non-retained slots split into disjoint
+`tau`-orbits.  For each such orbit `O`, let `g_O` be its indicator.  If
+`rho` is in `E(rho_ret)`, then
 
-Closing the universal-tail step would require an analytic proof that
-`T(rho_0 + delta) - T(rho_0)` is positive-semidefinite for every
-admissible `delta >= 0` inside the cone, plus a precise definition of
-the class of positive bulk-tail functionals on which strict
-monotonicity is claimed. That remains genuine open derivation work and
-is **not** closed by this note.
+```text
+delta = rho - rho_0 = sum_O a_O g_O,       a_O >= 0.                 (1)
+```
 
-## Dependencies
+Indeed, `delta` vanishes on `R`, is nonnegative, and is constant on every
+conjugation orbit.  Conversely every sum in (1) is an admissible tail.
+Because the orbit supports are disjoint, the coefficients `a_O` are unique.
 
-The runner does **not** import upstream notes via substring matching on
-prose. The previous audit verdict explicitly flagged that mechanism as
-not establishing closed inputs, and that mechanism has been removed.
-The numeric facts used by the runner are now verified directly on the
-packet and on the transfer matrix:
+Equation (1) gives `rho_0 <= rho` coefficientwise for every admissible
+extension.  If another extension were also a least element, it would be at
+most `rho_0`; equality on `R` and nonnegativity off `R` then force it to be
+`rho_0`.  This proves item 1 without a randomized or finite-witness
+inference.
 
-- `rho_ret` is consumed as the numeric vector returned by the local
-  Python helper `completed_sector_data` (an in-tree Python module
-  import). The runner directly checks that this vector is normalized,
-  conjugation-symmetric, nonnegative on `(1,0)/(0,1)`, and zero on
-  `(1,1)`.
-- The local-factor diagonal used in the transfer assembly is consumed
-  from the in-tree Python helper `local_factor_diagonal`. The runner
-  directly checks that the assembled zero-extension transfer is
-  self-adjoint on the truncated dominant-weight box.
+If `F` is coefficient-order-monotone, item 1 gives
+`F(rho_0) <= F(rho)`.  If in addition
 
-The two source notes that originally provided this material are still
-the conceptual references for the underlying retained packet and
-factorized-class existence, and remain conditional-dependency citations
-for that conceptual role; they are NOT treated as closed retained-grade
-inputs by this note. The current effective status of each upstream is
-tracked by the audit ledger; this note does not promote any of them.
+```text
+F(rho_0 + delta) > F(rho_0)
+```
+
+for every nonzero admissible `delta`, the minimizer is unique.  In
+particular, for weights `c_w > 0`, the functionals
+
+```text
+F_{c,p}(rho_0 + delta) = sum_{w off R} c_w delta_w^p,   p > 0,
+S_c(rho_0 + delta)     = sum_{w off R} c_w 1[delta_w > 0]
+```
+
+vanish at `delta = 0` and are strictly positive for every nonzero
+nonnegative tail.  Total tail mass has `c_w = 1, p = 1`; dimension-weighted
+mass has `c_w = dim(w), p = 1`; squared `l2` mass has `c_w = 1, p = 2`; and
+support size has `c_w = 1` in `S_c`.  This proves item 2.  Merely
+nonnegative weights would not ensure uniqueness, which is why strict
+positivity on every tail slot is part of the statement.
+
+Finally, put `A_O = D_loc diag(g_O)`.  Since both factors are diagonal,
+`A_O` is nonnegative diagonal.  For an arbitrary admissible tail, linearity
+and (1) give
+
+```text
+T(rho_0 + delta) - T(rho_0)
+  = M D_loc diag(delta) M
+  = sum_O a_O M A_O M.                                      (2)
+```
+
+For every real vector `x`, symmetry of `M` gives
+
+```text
+x^T M D_loc diag(delta) M x
+  = (M x)^T D_loc diag(delta) (M x) >= 0,
+```
+
+so (2) is positive semidefinite for **every** admissible tail, not only the
+two old witnesses.  If `delta` is nonzero, strict positivity of the diagonal
+of `D_loc` makes `D_loc diag(delta)` nonzero.  Invertibility of `M` makes
+congruence by `M` injective, so the increment in (2) is nonzero.  Hence no
+other admissible extension has the same transfer, and `T(rho_0)` is the
+unique Loewner-least transfer.  The nonzero increment need not be positive
+definite; nonzero positive semidefiniteness is the exact conclusion.
+
+## Scope and boundaries
+
+The theorem is universal over the admissible nonnegative
+conjugation-symmetric tails on `W_5`.  It is not inferred from 64 random
+tails or from the two named tails A and B; those are retained only as
+regression examples in the runner.
+
+The theorem does not address an infinite-weight completion, convergence of
+an infinite transfer operator, signed tails, a non-diagonal local factor, or
+selection of the actual framework-point Wilson environment packet.  It
+adds no physical selector axiom.
+
+The Loewner conclusion uses the displayed factorization and the explicit
+finite-box hypotheses `M = M^T`, `M` invertible, and `D_loc > 0`.  It is not
+a consequence of coefficient order for an arbitrary transfer map.
+
+## Dependency closure
+
+No theorem is imported from an upstream prose note.  The proof above is a
+finite-dimensional conditional algebra theorem for the packet and matrices
+constructed by the primary runner.  The runner obtains those numerical
+objects through in-tree Python functions and directly verifies every
+hypothesis used here:
+
+- the retained packet is finite, normalized, nonnegative, and
+  conjugation-symmetric;
+- the orbit generators partition every non-retained slot;
+- `M` is symmetric and nonsingular on `W_5`;
+- every diagonal entry of `D_loc` is strictly positive;
+- every tail-orbit generator produces a nonzero PSD congruence increment.
+
+The provenance notes for the retained packet and finite factorized model
+remain useful context, but their scientific conclusions are not premises
+of this bounded algebra theorem:
 
 - [GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_TRUNCATED_ENVIRONMENT_PACKET_NOTE_2026-04-19.md](GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_TRUNCATED_ENVIRONMENT_PACKET_NOTE_2026-04-19.md)
-  for the conceptual retained first-sector packet
-  `rho_ret = (1, 0.267139..., 0.267139..., 0)`.
 - [GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_ZERO_EXTENSION_FACTORIZED_CLASS_THEOREM_NOTE_2026-04-19.md](GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_ZERO_EXTENSION_FACTORIZED_CLASS_THEOREM_NOTE_2026-04-19.md)
-  for the conceptual existence of one explicit factorized-class
-  extension of `rho_ret` by zero on every higher weight, providing the
-  local-factor diagonal used by the runner.
 
-The row's effective status is set by the independent audit lane.
+Their audit status is owned by the independent audit lane; this note does
+not promote either row.
 
 ## Verification
 
@@ -112,6 +168,6 @@ Expected:
 PASS=8 FAIL=0
 ```
 
-The eight runner checks certify the witness-family-restricted
-statement above; they do not certify the universal Loewner-monotonicity
-step that the audit verdict flagged as the load-bearing failure.
+The analytic proof above establishes the arbitrary-tail implication.  The
+runner checks its finite-box hypotheses and exhausts the finitely many
+conjugation-orbit generators of the tail cone.

--- a/scripts/frontier_gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_packet_theorem_2026_04_19.py
+++ b/scripts/frontier_gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_packet_theorem_2026_04_19.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python3
 """
-Selected Wilson/Perron packet on the bounded zero-extension witness surface.
+Selected Wilson/Perron packet on the bounded zero-extension branch.
 
-This runner no longer treats the sibling minimal-bulk completion principle as
-a universal least-positive completion theorem.  The principle note was
-narrowed by audit to runner-tested zero-extension/witness families, with the
-universal Loewner-minimality step left open.  The checks below certify only
-the explicit packet obtained on that narrowed surface.
+The sibling principle proves that the zero extension is the unique minimal
+packet on its finite tail cone.  This runner does not infer that status from
+substrings in the sibling note; it directly checks that the selected packet
+has zero tail and then computes the explicit first-layer packet on that
+branch.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
 import math
 import sys
 
 import numpy as np
 
 from frontier_gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_principle_theorem_2026_04_19 import (
+    RETAINED_SUPPORT,
     retained_packet,
     zero_extension,
 )
@@ -35,8 +35,6 @@ from frontier_gauge_vacuum_plaquette_spatial_environment_character_measure impor
     matrix_exponential_symmetric,
 )
 
-
-ROOT = Path(__file__).resolve().parents[1]
 
 PASS_COUNT = 0
 FAIL_COUNT = 0
@@ -56,19 +54,12 @@ def check(name: str, condition: bool, detail: str = "") -> bool:
     return condition
 
 
-def read(rel_path: str) -> str:
-    return (ROOT / rel_path).read_text()
-
-
-def normalized(text: str) -> str:
-    return " ".join(text.lower().split())
-
-
 def selected_transfer_and_packet() -> dict[str, np.ndarray | float]:
     rho_ret, _z00 = retained_packet()
     jmat, weights, index = build_recurrence_matrix(5)
     swap = conjugation_swap_matrix(weights, index)
     rho_ext = zero_extension(weights, index, rho_ret)
+    tail_indices = [i for i, weight in enumerate(weights) if weight not in RETAINED_SUPPORT]
     multiplier = matrix_exponential_symmetric(jmat, BETA / 2.0)
     d_local = local_factor_diagonal(weights)
     transfer = multiplier @ d_local @ np.diag(rho_ext) @ multiplier
@@ -81,6 +72,7 @@ def selected_transfer_and_packet() -> dict[str, np.ndarray | float]:
         "jmat": jmat,
         "swap": swap,
         "rho_ext": rho_ext,
+        "tail_max": float(np.max(np.abs(rho_ext[tail_indices]))),
         "transfer": transfer,
         "eig": float(eig),
         "psi": psi,
@@ -98,18 +90,8 @@ def main() -> int:
     print("=" * 118)
     print()
     print("Question:")
-    print("  What explicit Wilson/Perron first-layer packet is obtained on the narrowed")
-    print("  zero-extension/witness surface of the minimal-bulk completion principle?")
-
-    principle_note = read("docs/GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_MINIMAL_BULK_COMPLETION_PRINCIPLE_THEOREM_NOTE_2026-04-19.md")
-    principle_text = normalized(principle_note)
-    principle_is_bounded_witness_surface = (
-        "runner-tested witness families" in principle_text
-        and "zero-extension packet" in principle_text
-        and "universal loewner-monotonicity" in principle_text
-        and "open derivation gap" in principle_text
-        and "does not promote a new axiom" in principle_text
-    )
+    print("  What explicit Wilson/Perron first-layer packet is obtained on the")
+    print("  finite-cone zero-extension branch of the minimal-bulk principle?")
 
     pkg = selected_transfer_and_packet()
     transfer = np.asarray(pkg["transfer"], dtype=float)
@@ -129,8 +111,9 @@ def main() -> int:
     print()
 
     check(
-        "The sibling minimal-bulk completion principle is narrowed to a bounded zero-extension/witness surface and leaves universal Loewner minimality open",
-        principle_is_bounded_witness_surface,
+        "The selected finite-box packet directly has zero mass in every non-retained slot",
+        pkg["tail_max"] == 0.0,
+        f"max_abs_tail={pkg['tail_max']:.1e}",
     )
     check(
         "That selected extension yields one positive self-adjoint conjugation-symmetric factorized transfer operator",
@@ -149,7 +132,7 @@ def main() -> int:
         f"(alpha0,beta1)=({pkg['alpha0']:.6f},{pkg['beta1']:.6f})",
     )
     check(
-        "So on the narrowed zero-extension/witness surface, the Wilson-side first-layer packet is explicit",
+        "So on the finite-cone zero-extension branch, the Wilson-side first-layer packet is explicit",
         pkg["beta1"] > 0.0,
         f"(m1,m2)=({pkg['m1']:.6f},{pkg['m2']:.6f})",
     )
@@ -157,13 +140,13 @@ def main() -> int:
     print("\n" + "=" * 118)
     print("RESULT")
     print("=" * 118)
-    print("  Selected Wilson/Perron packet on the narrowed zero-extension/witness surface:")
+    print("  Selected Wilson/Perron packet on the finite-cone zero-extension branch:")
     print(f"    - alpha0 = {pkg['alpha0']:.15f}")
     print(f"    - beta1  = {pkg['beta1']:.15f}")
     print(f"    - m1     = {pkg['m1']:.15f}")
     print(f"    - m2     = {pkg['m2']:.15f}")
     print("    - this is now the explicit first-layer packet of the selected")
-    print("      factorized-class zero-extension witness branch")
+    print("      factorized-class finite-cone zero-extension branch")
     print()
     print(f"PASS={PASS_COUNT} FAIL={FAIL_COUNT}")
     return 0 if FAIL_COUNT == 0 else 1

--- a/scripts/frontier_gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_principle_theorem_2026_04_19.py
+++ b/scripts/frontier_gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_principle_theorem_2026_04_19.py
@@ -1,43 +1,27 @@
 #!/usr/bin/env python3
-"""
-Bounded minimal-bulk completion witness check for the first-sector Wilson
-factorized cone.
+"""Finite-cone minimal-bulk completion theorem check.
 
-The first-sector seam already fixes the retained coefficient packet `rho_ret`
-on the first-symmetric support. Inside the exact Wilson factorized class
+On the 36-slot box W_5 = {(p,q): 0 <= p,q <= 5}, an admissible extension
+of the retained first-sector packet is nonnegative, invariant under
+(p,q) <-> (q,p), and fixed on the four retained slots.  The non-retained
+conjugation-orbit indicators are the extreme generators of its tail cone.
 
-    T(rho) = exp(3 J) D_loc diag(rho) exp(3 J),
+The source note proves, for an arbitrary nonnegative combination of those
+generators, that
 
-admissible extensions are the nonnegative conjugation-symmetric full packets
-extending that retained data.
+  * the zero extension is the unique coefficient-order least element;
+  * every tail functional strictly positive away from zero has the zero
+    extension as its unique minimizer; and
+  * T(rho) = M D_loc diag(rho) M is Loewner monotone and injective on the
+    tail cone when M is symmetric/invertible and D_loc is positive diagonal.
 
-This runner certifies bounded, witness-restricted facts only:
-
-1. The retained packet `rho_ret` produced by the local `completed_sector_data`
-   import is normalized, conjugation-symmetric, and zero on the `(1,1)`
-   slot.  No substring import of upstream prose is used to substantiate this
-   property; the assertions are verified directly on the numeric packet.
-
-2. The zero-extension `rho_0` of `rho_ret` to all higher weights produces a
-   self-adjoint, conjugation-symmetric transfer matrix on the truncated
-   dominant-weight box.  This existence-of-one-explicit-extension fact is
-   verified by direct numeric computation on the transfer.
-
-3. For the two explicit witness tails A and B and for a randomized sweep of
-   admissible nonnegative tails inside the cone, the inequality
-   `rho_0 + delta >= rho_0` holds coefficientwise; this is the algebraic
-   identity `delta >= 0 ==> rho_0 + delta >= rho_0` and is what the runner
-   actually checks.  The runner does **not** claim universal Loewner
-   monotonicity for arbitrary admissible tails: that universal step is
-   recorded in the source note as an open derivation gap.
-
-4. For the two named witness tails A and B, the Loewner increment is PSD,
-   and the four sampled positive bulk-tail functionals strictly increase.
+This runner checks all hypotheses and exhausts all orbit generators.  Tails
+A and B remain only as regression examples; no universal claim is inferred
+from a random sweep or from those two examples.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
 
 import numpy as np
@@ -55,8 +39,6 @@ from frontier_gauge_vacuum_plaquette_spatial_environment_character_measure impor
     dim_su3,
 )
 
-
-ROOT = Path(__file__).resolve().parents[1]
 
 PASS_COUNT = 0
 FAIL_COUNT = 0
@@ -79,12 +61,17 @@ def check(name: str, condition: bool, detail: str = "") -> bool:
 
 
 def retained_packet() -> tuple[np.ndarray, float]:
+    """Return the displayed retained packet; its properties are checked here."""
     v_min, _z_min = completed_sector_data()
     z00 = float(v_min[0])
     return np.asarray(v_min / z00, dtype=float), z00
 
 
-def zero_extension(weights: list[tuple[int, int]], index: dict[tuple[int, int], int], rho_ret: np.ndarray) -> np.ndarray:
+def zero_extension(
+    weights: list[tuple[int, int]],
+    index: dict[tuple[int, int], int],
+    rho_ret: np.ndarray,
+) -> np.ndarray:
     rho = np.zeros(len(weights), dtype=float)
     for value, weight in zip(rho_ret, RETAINED_SUPPORT):
         rho[index[weight]] = float(value)
@@ -93,38 +80,51 @@ def zero_extension(weights: list[tuple[int, int]], index: dict[tuple[int, int], 
 
 def add_tail(
     rho0: np.ndarray,
-    weights: list[tuple[int, int]],
     index: dict[tuple[int, int], int],
     updates: dict[tuple[int, int], float],
 ) -> np.ndarray:
     rho = np.array(rho0, dtype=float)
-    for w, val in updates.items():
-        rho[index[w]] += float(val)
+    for weight, value in updates.items():
+        rho[index[weight]] += float(value)
     return rho
 
 
-def random_nonneg_tail(
+def conjugation_error(
+    packet: np.ndarray,
     weights: list[tuple[int, int]],
     index: dict[tuple[int, int], int],
-    rng: np.random.Generator,
-) -> np.ndarray:
-    """Sample a conjugation-symmetric nonnegative tail on the non-retained
-    weights.  Conjugation symmetry: `(p,q)` and `(q,p)` share the same
-    coefficient."""
-    retained = {index[w] for w in RETAINED_SUPPORT}
-    delta = np.zeros(len(weights), dtype=float)
-    visited = set()
-    for i, (p, q) in enumerate(weights):
-        if i in retained or i in visited:
+) -> float:
+    return max(
+        abs(float(packet[i]) - float(packet[index[(q, p)]]))
+        for i, (p, q) in enumerate(weights)
+    )
+
+
+def tail_orbit_generators(
+    weights: list[tuple[int, int]],
+    index: dict[tuple[int, int], int],
+) -> list[tuple[tuple[tuple[int, int], ...], np.ndarray]]:
+    """Indicators of all non-retained (p,q)<->(q,p) orbits.
+
+    Their supports are disjoint and cover the tail, so every admissible tail
+    has one and only one nonnegative expansion in these generators.
+    """
+    retained = set(RETAINED_SUPPORT)
+    visited: set[tuple[int, int]] = set()
+    generators: list[tuple[tuple[tuple[int, int], ...], np.ndarray]] = []
+    for weight in weights:
+        if weight in retained or weight in visited:
             continue
-        value = float(rng.uniform(0.0, 0.05))
-        delta[i] = value
-        j = index[(q, p)]
-        if j != i:
-            delta[j] = value
-            visited.add(j)
-        visited.add(i)
-    return delta
+        partner = (weight[1], weight[0])
+        orbit = (weight,) if partner == weight else (weight, partner)
+        generator = np.zeros(len(weights), dtype=float)
+        for member in orbit:
+            if member in retained:
+                raise AssertionError("retained support must be a union of conjugation orbits")
+            generator[index[member]] = 1.0
+            visited.add(member)
+        generators.append((orbit, generator))
+    return generators
 
 
 def tail_metrics(
@@ -133,179 +133,185 @@ def tail_metrics(
     weights: list[tuple[int, int]],
     index: dict[tuple[int, int], int],
 ) -> dict[str, float]:
-    retained = {index[w] for w in RETAINED_SUPPORT}
-    tail = np.array([rho[i] - rho0[i] for i in range(len(weights)) if i not in retained], dtype=float)
-    dims = np.array([dim_su3(*weights[i]) for i in range(len(weights)) if i not in retained], dtype=float)
+    tail_indices = [i for i, weight in enumerate(weights) if weight not in RETAINED_SUPPORT]
+    tail = np.asarray(rho[tail_indices] - rho0[tail_indices], dtype=float)
+    dims = np.asarray([dim_su3(*weights[i]) for i in tail_indices], dtype=float)
     return {
         "tail_min": float(np.min(tail)) if len(tail) else 0.0,
-        "tail_max": float(np.max(tail)) if len(tail) else 0.0,
         "tail_mass": float(np.sum(tail)),
         "tail_l2_sq": float(np.dot(tail, tail)),
         "tail_dim_mass": float(np.dot(dims, tail)),
-        "tail_support": int(np.count_nonzero(np.abs(tail) > 1.0e-14)),
+        "tail_support": int(np.count_nonzero(tail > 0.0)),
     }
 
 
-def transfer_from_packet(weights: list[tuple[int, int]], rho: np.ndarray) -> np.ndarray:
-    jmat, _weights, _index = build_recurrence_matrix(5)
-    multiplier = matrix_exponential_symmetric(jmat, BETA / 2.0)
-    d_local = local_factor_diagonal(weights)
+def transfer(multiplier: np.ndarray, d_local: np.ndarray, rho: np.ndarray) -> np.ndarray:
     return multiplier @ d_local @ np.diag(np.asarray(rho, dtype=float)) @ multiplier
+
+
+def psd_with_scale(matrix: np.ndarray) -> bool:
+    scale = max(1.0, float(np.linalg.norm(matrix, ord=2)))
+    return float(np.min(np.linalg.eigvalsh(matrix))) >= -1.0e-12 * scale
 
 
 def main() -> int:
     print("=" * 118)
-    print("GAUGE-VACUUM PLAQUETTE FIRST-SECTOR MINIMAL-BULK COMPLETION WITNESS CHECK")
+    print("GAUGE-VACUUM PLAQUETTE FIRST-SECTOR FINITE-CONE MINIMAL-BULK COMPLETION THEOREM")
     print("=" * 118)
-    print()
-    print("Question:")
-    print("  Once the retained first-sector packet rho_ret is fixed, is there already")
-    print("  one bounded zero-extension witness inside the factorized cone, while")
-    print("  the universal Loewner/completion principle remains open?")
 
     rho_ret, z00 = retained_packet()
-    _jmat, weights, index = build_recurrence_matrix(5)
+    jmat, weights, index = build_recurrence_matrix(5)
+    multiplier = matrix_exponential_symmetric(jmat, BETA / 2.0)
+    d_local = local_factor_diagonal(weights)
     rho0 = zero_extension(weights, index, rho_ret)
-    rho_a = add_tail(rho0, weights, index, {(2, 0): 0.05, (0, 2): 0.05})
-    rho_b = add_tail(rho0, weights, index, {(2, 1): 0.03, (1, 2): 0.03, (2, 2): 0.02})
-    t0 = transfer_from_packet(weights, rho0)
-    ta = transfer_from_packet(weights, rho_a)
-    tb = transfer_from_packet(weights, rho_b)
-    delta_a = ta - t0
-    delta_b = tb - t0
+    generators = tail_orbit_generators(weights, index)
 
-    m0 = tail_metrics(rho0, rho0, weights, index)
-    ma = tail_metrics(rho_a, rho0, weights, index)
-    mb = tail_metrics(rho_b, rho0, weights, index)
+    tail_indices = [i for i, weight in enumerate(weights) if weight not in RETAINED_SUPPORT]
+    expected_cover = np.zeros(len(weights), dtype=float)
+    expected_cover[tail_indices] = 1.0
+    actual_cover = np.sum([generator for _orbit, generator in generators], axis=0)
+
+    t0 = transfer(multiplier, d_local, rho0)
+    rho_a = add_tail(rho0, index, {(2, 0): 0.05, (0, 2): 0.05})
+    rho_b = add_tail(rho0, index, {(2, 1): 0.03, (1, 2): 0.03, (2, 2): 0.02})
 
     print()
+    print(f"  finite box / tail slots / tail orbits       = {len(weights)} / {len(tail_indices)} / {len(generators)}")
     print(f"  z00_min                                     = {z00:.12f}")
     print(f"  rho_ret                                     = {np.round(rho_ret, 12).tolist()}")
-    print(f"  zero-extension tail metrics                 = {m0}")
-    print(f"  witness tail A metrics                      = {ma}")
-    print(f"  witness tail B metrics                      = {mb}")
+    print(f"  min diag(D_loc)                             = {float(np.min(np.diag(d_local))):.3e}")
+    print(f"  min singular value(M)                       = {float(np.min(np.linalg.svd(multiplier, compute_uv=False))):.3e}")
     print()
 
-    # Check 1: numeric properties of the retained packet, computed locally
-    # (no substring import of upstream prose).
-    rho_00 = float(rho_ret[0])
-    rho_10 = float(rho_ret[1])
-    rho_01 = float(rho_ret[2])
-    rho_11 = float(rho_ret[3])
+    rho_00, rho_10, rho_01, rho_11 = (float(value) for value in rho_ret)
     check(
-        "Retained packet rho_ret is normalized, conjugation-symmetric, zero on (1,1), nonnegative on (1,0)/(0,1)",
-        abs(rho_00 - 1.0) < 1.0e-12
+        "The supplied retained packet directly satisfies the theorem's finite, normalized, nonnegative symmetry hypotheses",
+        rho_ret.shape == (4,)
+        and np.all(np.isfinite(rho_ret))
+        and abs(rho_00 - 1.0) < 1.0e-12
         and abs(rho_10 - rho_01) < 1.0e-12
-        and rho_10 >= 0.0
-        and rho_01 >= 0.0
-        and abs(rho_11) < 1.0e-12,
-        f"(rho_00,rho_10,rho_01,rho_11)=({rho_00:.6f},{rho_10:.6f},{rho_01:.6f},{rho_11:.6f})",
+        and min(rho_00, rho_10, rho_01, rho_11) >= -1.0e-12,
+        f"rho11={rho_11:.3e}, conjugation_error={abs(rho_10-rho_01):.3e}",
     )
 
-    # Check 2: the zero-extension produces a self-adjoint, conjugation-symmetric
-    # transfer on the truncated dominant-weight box (verified by direct numeric
-    # symmetry, not by substring matching against an upstream note).
-    sym_err = float(np.max(np.abs(t0 - t0.T)))
-    conj_err = 0.0
-    for i, (p, q) in enumerate(weights):
-        j = index[(q, p)]
-        conj_err = max(conj_err, abs(float(rho0[i]) - float(rho0[j])))
+    retained_match_error = max(
+        abs(float(rho0[index[weight]]) - float(value))
+        for weight, value in zip(RETAINED_SUPPORT, rho_ret)
+    )
     check(
-        "Zero-extension transfer t0 is self-adjoint and the underlying packet is conjugation-symmetric on the truncated box",
-        sym_err < 1.0e-10 and conj_err < 1.0e-12,
-        f"(sym_err,conj_err)=({sym_err:.3e},{conj_err:.3e})",
+        "rho_0 is an admissible conjugation-symmetric extension and vanishes on every non-retained slot",
+        retained_match_error < 1.0e-12
+        and float(np.min(rho0)) >= -1.0e-12
+        and conjugation_error(rho0, weights, index) < 1.0e-12
+        and np.count_nonzero(rho0[tail_indices]) == 0,
+        f"retained_match={retained_match_error:.3e}, tail_nonzeros={np.count_nonzero(rho0[tail_indices])}",
     )
 
-    # Check 3: the two named witness tails add nonzero higher-weight mass.
+    generator_symmetry_error = max(
+        conjugation_error(generator, weights, index) for _orbit, generator in generators
+    )
     check(
-        "The two explicit witness tails A and B add nonzero higher-weight mass above the retained packet",
-        ma["tail_support"] > 0 and mb["tail_support"] > 0
-        and ma["tail_mass"] > 0.0 and mb["tail_mass"] > 0.0,
-        f"(supportA,supportB,massA,massB)=({ma['tail_support']},{mb['tail_support']},{ma['tail_mass']:.3e},{mb['tail_mass']:.3e})",
+        "The conjugation-orbit generators are nonnegative, disjoint, and cover every tail slot exactly once",
+        len(generators) > 0
+        and all(float(np.min(generator)) >= 0.0 for _orbit, generator in generators)
+        and np.array_equal(actual_cover, expected_cover)
+        and generator_symmetry_error == 0.0,
+        f"orbits={len(generators)}, cover_error={float(np.max(np.abs(actual_cover-expected_cover))):.1e}",
     )
 
-    # Check 4: witness-restricted coefficientwise minimality.  The runner does
-    # NOT claim universal coefficientwise uniqueness across all admissible
-    # extensions.  This is the witness-restricted statement: the two named
-    # tails are nonneg and dominate rho_0 coefficientwise.
+    # A deterministic tail with a distinct positive coefficient on every
+    # orbit checks the unique coordinate recovery implied by disjoint support.
+    coefficients = np.arange(1, len(generators) + 1, dtype=float) / (10.0 * len(generators))
+    delta = sum(
+        (coefficient * generator for coefficient, (_orbit, generator) in zip(coefficients, generators)),
+        start=np.zeros(len(weights), dtype=float),
+    )
+    recovered = np.asarray(
+        [delta[np.flatnonzero(generator)[0]] for _orbit, generator in generators],
+        dtype=float,
+    )
+    reconstruction = sum(
+        (coefficient * generator for coefficient, (_orbit, generator) in zip(recovered, generators)),
+        start=np.zeros(len(weights), dtype=float),
+    )
     check(
-        "On the two named witness tails A and B, the zero extension is coefficientwise <= the extended packet (witness-restricted, not universal)",
-        m0["tail_mass"] == 0.0 and ma["tail_min"] >= -1.0e-14 and mb["tail_min"] >= -1.0e-14,
-        f"(tail_mass0,tail_minA,tail_minB)=({m0['tail_mass']:.3e},{ma['tail_min']:.3e},{mb['tail_min']:.3e})",
+        "Every admissible tail has unique nonnegative orbit coordinates, proving rho_0 is the unique coefficient-order least extension",
+        np.all(recovered >= 0.0)
+        and np.array_equal(recovered, coefficients)
+        and np.array_equal(reconstruction, delta)
+        and np.all(rho0 + delta >= rho0),
+        f"coordinate_reconstruction_error={float(np.max(np.abs(reconstruction-delta))):.1e}",
     )
 
-    # Check 5: PSD Loewner increment on the two named witness tails.
-    eig_a = float(np.min(np.linalg.eigvalsh(delta_a)))
-    eig_b = float(np.min(np.linalg.eigvalsh(delta_b)))
+    multiplier_symmetry_error = float(np.max(np.abs(multiplier - multiplier.T)))
+    multiplier_smin = float(np.min(np.linalg.svd(multiplier, compute_uv=False)))
+    d_min = float(np.min(np.diag(d_local)))
     check(
-        "The two explicit witness tails A and B produce positive-semidefinite Loewner increments (witness-restricted, not universal)",
-        eig_a > -1.0e-12 and eig_b > -1.0e-12,
-        f"(eigminA,eigminB)=({eig_a:.3e},{eig_b:.3e})",
+        "The factorized transfer has symmetric invertible M and strictly positive diagonal D_loc",
+        multiplier_symmetry_error < 1.0e-12
+        and multiplier_smin > 1.0e-12
+        and np.max(np.abs(d_local - np.diag(np.diag(d_local)))) == 0.0
+        and d_min > 0.0,
+        f"symmetry_error={multiplier_symmetry_error:.3e}, sigma_min={multiplier_smin:.3e}, d_min={d_min:.3e}",
     )
 
-    # Check 6: for the two named witness tails, the zero extension is Loewner-
-    # minimal relative to those tested positive increments.  Witness-restricted.
+    increments = [
+        multiplier @ d_local @ np.diag(generator) @ multiplier
+        for _orbit, generator in generators
+    ]
+    min_increment_eigenvalue = min(float(np.min(np.linalg.eigvalsh(increment))) for increment in increments)
+    min_increment_norm = min(float(np.linalg.norm(increment)) for increment in increments)
     check(
-        "For the two explicit witness tails, the zero extension is Loewner-minimal relative to those tested increments (witness-restricted, not universal)",
-        eig_a > -1.0e-12
-        and eig_b > -1.0e-12
-        and m0["tail_mass"] == 0.0,
-        f"||T_A-T_0||={np.linalg.norm(delta_a):.3e}, ||T_B-T_0||={np.linalg.norm(delta_b):.3e}",
+        "Every tail-orbit generator has a nonzero PSD congruence increment; nonnegative sums prove arbitrary-tail Loewner monotonicity",
+        all(psd_with_scale(increment) for increment in increments)
+        and all(float(np.linalg.norm(increment)) > 0.0 for increment in increments),
+        f"min_eigenvalue={min_increment_eigenvalue:.3e}, min_nonzero_norm={min_increment_norm:.3e}",
     )
 
-    # Check 7: the zero extension minimizes the sampled positive bulk-tail
-    # functionals: total mass, weighted mass, squared l2 mass, support size.
+    generator_metrics = [
+        tail_metrics(rho0 + generator, rho0, weights, index)
+        for _orbit, generator in generators
+    ]
     check(
-        "The zero extension minimizes the four sampled positive bulk-tail functionals on the two witness tails (witness-restricted, not universal)",
-        ma["tail_mass"] > 0.0
+        "Positive weighted mass, p-mass, and support separate zero from every nonzero tail generator",
+        all(
+            metrics["tail_mass"] > 0.0
+            and metrics["tail_dim_mass"] > 0.0
+            and metrics["tail_l2_sq"] > 0.0
+            and metrics["tail_support"] > 0
+            for metrics in generator_metrics
+        ),
+        "strict positivity on all generators extends to every nonzero nonnegative orbit combination",
+    )
+
+    ma = tail_metrics(rho_a, rho0, weights, index)
+    mb = tail_metrics(rho_b, rho0, weights, index)
+    increment_a = transfer(multiplier, d_local, rho_a - rho0)
+    increment_b = transfer(multiplier, d_local, rho_b - rho0)
+    check(
+        "Legacy tails A and B agree with the universal coefficient, functional, and PSD conclusions (regression only)",
+        np.all(rho_a >= rho0)
+        and np.all(rho_b >= rho0)
+        and ma["tail_mass"] > 0.0
         and mb["tail_mass"] > 0.0
-        and ma["tail_dim_mass"] > 0.0
-        and mb["tail_dim_mass"] > 0.0
-        and ma["tail_l2_sq"] > 0.0
-        and mb["tail_l2_sq"] > 0.0
-        and ma["tail_support"] > 0
-        and mb["tail_support"] > 0,
-        f"(massA,massB,dimMassA,dimMassB)=({ma['tail_mass']:.3e},{mb['tail_mass']:.3e},{ma['tail_dim_mass']:.3e},{mb['tail_dim_mass']:.3e})",
-    )
-
-    # Check 8: algebraic coefficientwise step on a randomized sweep of
-    # admissible nonneg conjugation-symmetric tails.  This certifies the
-    # algebraic identity `delta >= 0 ==> rho_0 + delta >= rho_0` rather than
-    # universal Loewner monotonicity, which is recorded as an open gap.
-    rng = np.random.default_rng(20260516)
-    n_samples = 64
-    coeff_min_violations = 0
-    nonneg_violations = 0
-    for _ in range(n_samples):
-        delta = random_nonneg_tail(weights, index, rng)
-        if float(np.min(delta)) < -1.0e-14:
-            nonneg_violations += 1
-        rho_sample = rho0 + delta
-        m_sample = tail_metrics(rho_sample, rho0, weights, index)
-        if m_sample["tail_min"] < -1.0e-14:
-            coeff_min_violations += 1
-    check(
-        "Randomized sweep (n=64) of admissible nonneg conjugation-symmetric tails: delta >= 0 implies rho_0 + delta >= rho_0 coefficientwise",
-        coeff_min_violations == 0 and nonneg_violations == 0,
-        f"(coeff_violations,nonneg_violations)=({coeff_min_violations},{nonneg_violations})",
+        and psd_with_scale(increment_a)
+        and psd_with_scale(increment_b)
+        and float(np.linalg.norm(increment_a)) > 0.0
+        and float(np.linalg.norm(increment_b)) > 0.0,
+        f"massA={ma['tail_mass']:.3e}, massB={mb['tail_mass']:.3e}",
     )
 
     print("\n" + "=" * 118)
     print("RESULT")
     print("=" * 118)
-    print("  Bounded witness result:")
-    print("    - rho_ret is a normalized, conjugation-symmetric, (1,1)-zero packet")
-    print("      (numeric properties checked directly, no substring import)")
-    print("    - the zero-extension produces a self-adjoint, conjugation-symmetric")
-    print("      transfer on the truncated dominant-weight box (numeric check)")
-    print("    - the two witness positive tails remain above the zero extension")
-    print("      in coefficient order and in the tested Loewner increments")
-    print("    - the zero extension minimizes the four sampled positive tail")
-    print("      functionals on the two witness tails")
-    print("    - randomized sweep certifies the algebraic identity")
-    print("      delta >= 0 ==> rho_0 + delta >= rho_0 coefficientwise")
-    print("    - the universal Loewner-minimal theorem for arbitrary admissible")
-    print("      tails remains an open derivation gap (NOT closed by this runner)")
+    print("  Bounded finite-cone result:")
+    print("    - all non-retained conjugation-orbit generators are exhausted")
+    print("    - their nonnegative cone is exactly the set of admissible tails")
+    print("    - rho_0 is the unique coefficient-order least extension")
+    print("    - strictly positive bulk-tail functionals uniquely select rho_0")
+    print("    - positive diagonal congruence proves Loewner monotonicity for every")
+    print("      admissible tail on W_5, with injectivity from M and D_loc")
+    print("    - no infinite-weight or physical environment-selection claim is made")
     print()
     print(f"PASS={PASS_COUNT} FAIL={FAIL_COUNT}")
     return 0 if FAIL_COUNT == 0 else 1


### PR DESCRIPTION
## Summary

Automated attempt by `scripts/science_fix_loop.py` to close the missing
derivation in
`gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_principle_theorem_note_2026-04-19`.

- **Category:** `failed`
- **Transitive descendants if closed:** 281
- **Repair source:** `docs/audit/MISSING_DERIVATION_PROMPTS.md`

## Exact audit repair target

The source prompt quotes this load-bearing step verbatim:

> Among all full nonnegative conjugation-symmetric extensions of rho_ret, the
> minimal-support zero extension is the unique least element in the coefficient
> order and therefore uniquely minimizes every positive bulk-tail functional.

The corresponding verdict rationale says that the former runner's finite
witness checks on tails A and B did not prove universal monotonicity or
uniqueness, and that prose-substring imports could not close the upstream
premises. This PR addresses that exact finite-cone residual; it does not claim
an infinite-weight theorem or physical Wilson-environment selection.

## What this PR does

Codex gpt-5.6-sol at xhigh reasoning was given the missing-derivation prompt
in a clean worktree off `origin/main`. It made the diff in this PR.

## Review checklist

- [ ] Run the repo-native review-loop before landing; automated science
      attempts can be wrong
- [ ] If the new derivation survives review-loop, land it through the normal
      path and let the independent audit batch re-audit the row after merge
- [ ] If the diff is wrong-headed, close this PR; the loop won't retry
      automatically (state file: `logs/science-fix-state.json`)

## Codex output tail

```
Closed the missing derivation on the bounded 36-slot \(W_5\) cone.

Key changes:

- Added an analytic conjugation-orbit decomposition proving unique coefficient-order minimality.
- Precisely defined which positive tail functionals have a unique minimizer.
- Proved universal finite-box Loewner monotonicity via positive-diagonal congruence and injectivity.
- Removed the remaining prose-substring status check from the downstream runner.
- Explicitly excludes infinite-weight and physical environment-selection claims.

Files updated:

- docs/GAUGE_VACUUM_PLAQUETTE_FIRST_SECTOR_MINIMAL_BULK_COMPLETION_PRINCIPLE_THEOREM_NOTE_2026-04-19.md
- scripts/frontier_gauge_vacuum_plaquette_first_sector_minimal_bulk_completion_principle_theorem_2026_04_19.py
- Dependent packet note and runner were aligned with the closure.

Verification:

- Primary theorem: `PASS=8 FAIL=0`
- Packet regression: `PASS=5 FAIL=0`
- Hankel boundary regression: `PASS=4 FAIL=0`
- `py_compile` and `git diff --check`: passed

The requested `physics-loop` skill was unavailable, so I followed the repository-native workflow directly.
```

🤖 Generated by `scripts/science_fix_loop.py` (codex gpt-5.6-sol, xhigh)
