### PR TITLE
[physics-loop][review-loop] computation-connection block01 — Cycle 721 tournament: bounded theorem (input-Bell M2 compiler + exchange port + collision-free epoch)

### DIFF
--- a/.claude/science/physics-loops/computation-connection-20260727/APPROACH_REGISTRY.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/APPROACH_REGISTRY.md
@@ -1,0 +1,14 @@
+# Approach registry — Cycle 721 (block01)
+
+Family tuple = (object/formulation, mechanism/invariant, terminal obligation).
+
+| Family | Object/formulation | Mechanism/invariant | Terminal obligation | Strength vs target | Status | Concrete evidence | Reopen condition |
+|---|---|---|---|---|---|---|---|
+| F1 CAR-BELL-M2 | doubled even-CAR Bell character family (onsite parities, adjacent-Majorana pairs, seam rows; ranks 2m-1) on the companion code | one-cell private-dual atlas corrections + explicit M2 measurement-word compilation with NN routing and returned work | literal physical-M2 input measurement circuit meeting the two-cell/diameter-one correction gate on held boxes, composing with the prepared Choi resource and recurrent G on one site map | weaker than full autonomy; exactly Cycle-720 Open item 1 | active | Cycle-720 certified the rows as bounded CAR-domain operations with one-cell duals (constructive base) | n/a |
+| F2 ENC-CLIFFORD | bounded Clifford acting directly on input + companion/center coordinates | direct encoded-input coupling; invariant = corrected-channel Heisenberg algebra without raw teleportation corrections | bounded local encoded-input Clifford word with a literal input-side M2 assignment on the same chart, same gate | independent second leg; escape route 4 of the raw-Bell N1 table | active | none yet (UNTESTED/OPEN per Cycle 720 N1) | n/a |
+| F3 EPOCH-SCHEDULE | composed epoch on one site map: Choi preparation; Bell coupling; retained correction banks; recurrent G | explicit collision-free fixed schedule with per-station register-liveness accounting (Cycle-54 caution honored) | collision-free composed epoch preserving fixtures, support ladder, and full covariance | exactly Cycle-720 Open item 2; depends on F1 or F2 for its input leg | active (staged after F1/F2 interface freeze) | Cycle-719 joint word (prefix; H^130; suffix) is the composition precedent on the earlier code | n/a |
+
+Excluded families this cycle (named, not attempted): raw-Bell re-rooting and
+coset minimization (diagnostic escapes 1-2 — diagnostic-only value), parity
+rail/gauge teleportation (route 5), sector-summed/dissipative center handling
+(route 6). These stay in the opportunity queue.

--- a/.claude/science/physics-loops/computation-connection-20260727/ASSUMPTIONS_AND_IMPORTS.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/ASSUMPTIONS_AND_IMPORTS.md
@@ -1,0 +1,46 @@
+# Assumptions and imports — Cycle 721 (block01)
+
+Primitive-registry check performed per
+docs/ai_methodology/skills/PRIMITIVE_REGISTRY_CHECK.md against
+docs/audit/data/axiom_premise_nodes.json (4 nodes: minimal_axioms,
+scale_reference_primitive, kinetic_isotropy_primitive,
+realized_state_primitive). None of the three registered primitives is a
+load-bearing input to Cycle-721 circuit constructions; the base is the
+minimal-axiom surface only (Lattice, Qubit, Admissibility, Record). No
+literature imports (`--literature` not supplied). No observed values, fitted
+selectors, or empirical content.
+
+## Supplied data inherited from the Cycle-720 surface (all remain supplied)
+
+| supplied item | role | counterfactual ("what if this choice is wrong / different?") |
+|---|---|---|
+| Cycle-219 coin/mass fixture; Cycle-230 contact, coupling, factor order | matter-law fixtures preserved by every route | different fixtures change residual anchors only; fixture preservation is a gate, not a derivation |
+| per-cell six-mode labels + companion-port convention | mode dictionary for the companion representation | a relabeling is a chart change; covariance harness (24 frames x 576 products, 8 coframe origins) is the control |
+| one fixed total-parity label; local center-sector signs | fixed channel sector | sector-summed handling is N1 route 6 (UNTESTED) — out of scope for 721 unless a route falls back to it |
+| maximally mixed gauge factor / reference purification | gauge factor of the CPTP channel | purified vs mixed changes ancilla census, not the algebra; receipt must state which is used |
+| three coframe bits per cell; uniform eight-origin channel | coframe direct sum | absolute seed labels are chart-relative (Cycle 720 checker); only transported sectors are observable |
+| finite open box, boundary root, axis order, spanning-tree/router tables | routing instantiation | re-rooting is N1 route 1 (UNTESTED escape for raw-Bell); F1/F2 must not depend on a favorable root — pass gate on the same submitted root family as Cycle 720 plus at least one alternate root as control |
+| one-time preparation epoch; clean Bell/syndrome/route registers | genesis inventory | autonomy is explicitly open (W1/W2); Cycle 721 does not claim genesis |
+| fixed four-layer update schedule | recurrent-word schedule | Route F3 extends this to a composed epoch schedule; per Cycle-54 caution the extension must do register-liveness accounting |
+| doubled even-CAR Bell row family (11N+E onsite/seam basis, ranks 2m-1) | input-measurement basis certified by Cycle 720 as CAR-domain operations | if the doubling convention is wrong for literal M2 compilation, the compiled measurement support will exceed the gate — that is exactly what the tournament tests |
+| frozen private-dual atlas (704 onsite keys, 192 oriented edge keys; 896-key independent rebuild) | one-cell corrections | unseen-key events on new boxes are a hard FAIL signal, not a retrainable parameter |
+
+## Import ledger
+
+- Zero external imports. All algebra must be rebuilt in-runner from explicit
+  matrices/tableaux (repo standard: runner REPROVES every math fact).
+- Prior cycles (719/720) enter as *prior bounded authority at authority
+  none / audit unset* — their runners may be pinned by SHA-256 and their
+  interfaces re-used, but their claims are not treated as retained.
+  Provenance pins must be regenerated together with the receipt (cycle583
+  review-queue precedent: note-printed SHAs must match the receipt binding).
+
+## Prose boundaries (from grounding)
+
+- CANONICAL_HARNESS_INDEX.md:23 teleportation lane HOLD: state teleportation
+  only — Cycle-721 prose must not claim matter/FTL/mass/charge transfer.
+- No sampling as completeness proof (teleportation-three-register pack
+  no_go_routes): every completeness claim uses exhaustive enumeration on the
+  declared finite family or an exact algebraic identity.
+- Ordinals are circuit structure; never physical time, duration, rate, or
+  energy.

--- a/.claude/science/physics-loops/computation-connection-20260727/CLAIM_STATUS_CERTIFICATE.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/CLAIM_STATUS_CERTIFICATE.md
@@ -1,0 +1,38 @@
+# Claim status certificate — block01 (Cycle 721)
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: direct_blocker_closure
+reachability_to_target: partially_closes
+conditional_surface_status: >
+  conditional on the supplied Cycle-720 sector/genesis inventory (fixed
+  parity/center labels, mixed gauge reference, coframe sector, finite
+  box/root/router, one-time epoch, clean ancilla/bank registers) plus two
+  new supplied conventions: the companion-encoded input bank (Route 1) and
+  the co-located port bank with lexicographic-minimum port chart (Route 2).
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: >
+  Constructive finite certificates with exhaustive enumeration on declared
+  finite families, machine-scale residuals, and active controls; every
+  load-bearing premise is a declared supplied convention, so the ceiling is
+  bounded_theorem exactly as for Cycles 719-720. No retained-grade language
+  is used anywhere in the package.
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+dependency_classes:
+  - landed Cycle-720 modules imported as prior bounded authority
+    (authority none, audit unset); their receipts pin the imported bytes
+  - registered primitives: none load-bearing (minimal-axiom surface only)
+  - external imports: zero; literature: none
+open_imports: none
+negative_assertion_classes: []   # no new negative claim ships (see note)
+review_loop_disposition: pending_handoff  # owner-operated lane; PR prepared
+```
+
+Notes: the note's negative-claim-discipline section records why the
+design-history statements are supplied conventions rather than negative
+claims, and cites the Cycle-720 raw-Bell diagnostic only at its original
+scope. The `V_s`-restriction route is `UNTESTED/OPEN` with a named reopen
+condition; it is package inventory, not a no-go.

--- a/.claude/science/physics-loops/computation-connection-20260727/EXTRACT_BELL_SURFACE.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/EXTRACT_BELL_SURFACE.md
@@ -1,0 +1,270 @@
+# Cycle-720 Bell / live-input surface extract
+
+Scope is strictly the following two sources:
+
+- `B` = `scripts/frontier_cycle720_companion_fixed_sector_even_car_bell_2026_07_27.py`
+- `L` = `scripts/frontier_cycle720_companion_fixed_sector_live_input_teleportation_2026_07_27.py`
+
+Line numbers below are source line numbers. “Delegated” means that the named
+operation is called here but defined in an imported runner, which was outside
+the permitted read set. Such behavior is not reverse-engineered or guessed.
+
+Neither source defines a class. Both import `M.Pauli` (aliased `Pauli`) and
+type against imported `M.CompanionFixture`. Top-level certificate entry points
+are `B.box_certificate(shape: tuple[int,int,int], atlas: dict[str,object])
+-> dict[str,object]` (`B:158-304`),
+`L.box_certificate(shape: tuple[int,int,int]) -> dict[str,object]`
+(`L:437-638`), and each file's `main() -> None` (`B:381-508`;
+`L:641-768`). Their relevant dictionary fields are named in the sections
+below; nested return shapes are explicit where constructed locally.
+
+## 1. Cell/mode labeling
+
+### Types and coordinates
+
+- `L:89` defines `Coord = tuple[int, int, int]`. Cells are stored as `fixture.cells`; a cell identifier used in mode formulas and edge tuples is its zero-based index in that sequence. A geometric cell is the corresponding three-integer coordinate `fixture.cells[cell]` (`B:197-201`, `L:240-242,506,511-512`).
+- Fixtures for rectangular boxes are made by the delegated composition `O.arbitrary_fixture(Q.shape_cells(shape))` (`B:158-162`, `L:437-439`), where `shape: tuple[int, int, int]`.
+- Cell ordering is semantically significant. Corners/roots use lexicographic `max(fixture.cells)` and convert back with `.index(...)` (`L:138-153`, `L:240-242`). The spatial tree is requested with axis order `(2, 1, 0)` (`L:139-141`).
+
+### Six matter modes per cell
+
+- Global raw-mode index is exactly `6 * cell + local`, with `local in range(6)` (`B:96-101`; `L:127-133,153`).
+- The five onsite adjacent pairs use local pairs `(0,1),...,(4,5)`; `mode_tree(fixture)` emits global endpoints `left = 6*cell + local`, `right = left+1` (`L:122-154`).
+- `tag_modes(fixture, tag) -> frozenset[tuple[int,int]]` (`B:113-121`) returns `(cell_index, local_mode)`. For an edge it reads `fixture.edges[tag[1]]` and reduces the two endpoint mode labels modulo six.
+
+### Tags, edges, ports, center/parity/coframe labels
+
+- Bell tags are tuples. Exact local discriminants are: `("onsite_Z", cell, local)`, `("onsite_XX", cell, local_left)`, and `("edge", edge_index, ...)` as consumed by `target_rows`/`tag_modes` (`B:91-121,187-201`). Only `tag[0]` and the stated positions are consumed here; the full tuple produced by `P.direct_graph_basis` is delegated.
+- An edge record is destructured as `(left_cell, right_cell, owner, axis, left_mode, right_mode)` (`B:120-121`; `L:142-145`). The first two entries index `fixture.cells`; the last two are global raw-mode endpoints in `L:143-152` and are normalized modulo six only when producing CAR support in `B:120-121`. `owner` and `axis` are retained but not interpreted locally.
+- Physical companion-port allocation is visible only through the corner `allowed` tuple: three indices per cell, `fixture.matter_qubits + 3*cell ... +2` (`L:242-251`). Port names, orientations, and the mapping from edge `(owner,axis)` to those three ports are not defined in these files.
+- The fixed parity label is integer `parity in (0,1)` / strings `("even","odd")` (`L:280-301`). It signs a Pauli by phase `2*parity` modulo four (`L:280-293`). The input parity row is all-Z on the resource input half (`L:235-239`).
+- Center coordinates are not individually labeled here. Center rows are a contiguous factorization slice `[logical+gauge : logical+gauge+center]` of `factor.physical_w` (`L:269-278,475-482`); the last center row is the parity-signed row (`L:287-293`).
+- Coframe coordinate/origin representation is not local. The even-CAR runner passes an atlas to delegated `V.frame_certificate` and `V.product_certificate` only (`B:386-387`).
+
+## 2. Physical M2 register allocation
+
+- `m = fixture.matter_qubits`, `q = fixture.qubits`, and a Choi/stabilizer tableau spans `total = q + m` qubits (`B:167-169`; `L:256`).
+- Physical output M2 indices are `0..q-1`; the Choi resource input half is `q..q+m-1`. This is explicit in the all-Z input parity mask `((1<<m)-1) << q` (`L:235-239`) and in the corner input-half range `q+6*cell ... q+6*cell+5` (`L:248-251`).
+- Within physical output M2, the first `m=6N` indices are the six matter images per cell. `physical_z(fixture, mask) -> Pauli` truncates `mask` to these first `m` bits (`L:114-115`). The visible companion allocation is the following `3N` indices, `m+3*cell ... m+3*cell+2` (`L:245-247`). Consequently the visible layout is `[6N matter][3N companion]` inside `fixture.qubits`, followed in augmented tableaux by `[6N Choi input]`. These files do not independently assert `q == 9N`; code using this layout assumes the imported fixture provides it.
+- `target_z(mask) -> Pauli` leaves an `m`-mode target mask unshifted (`L:118-119`). `operator_syndrome(fixture, physical, target) -> tuple[int,...]` compares a `q`-qubit physical row and an `m`-qubit target row against each triple from delegated `M.operator_rows(fixture)` (`L:96-111`).
+- The one-cell allowed solve support is ordered exactly as a tuple of: six physical matter indices, three physical companion indices, then six resource-input indices (`L:242-255`). `P.solve_private_correction` receives that tuple unchanged.
+- No explicit “site map” object is created here. Shared mapping is embodied by `fixture.cells`, `fixture.edges`, the arithmetic above, and delegated `P.pauli_cells(fixture,row)` (`B:204`; `L:226-229`).
+
+## 3. CAR/Majorana and Pauli representation
+
+### Representation and signs
+
+- Both runners alias `Pauli = M.Pauli` (`B:84`; `L:88`). Rows have integer fields `phase`, `x`, `z`; support uses `(row.x | row.z)` and binary symplectic vectors use `row.symplectic(number_of_qubits)`.
+- `canonical(row: Pauli) -> Pauli` is identical in both runners: `Pauli((row.x & row.z).bit_count() & 1, row.x, row.z)` (`B:87-88`; `L:92-93`). Thus canonical phase is the parity of X/Z overlap: phase 1 for an odd number of Y sites, otherwise phase 0. Multiplication is `left @ right`; products are canonicalized at the boundary (`B:106-110`; `L:150-151,216-223`).
+- Commutation is binary symplectic: `M.symplectic(v,w,n)` returns the bit tested/summed as a failure (`B:180-186,223-226`; `L:99-110,257-262,487-500`).
+- Concrete matrices exist only in `B.sector_matrix`; the scalable CAR surface is a binary Pauli/tableau surface, not dense matrices.
+
+### Local even-CAR generators
+
+- Onsite parity is `Z_j = Pauli(z=1<<j)`.
+- An onsite adjacent-Majorana-pair coordinate is represented as `X_j X_(j+1) = Pauli(x=(1<<j)|(1<<(j+1)))` (`B:96-101,327-333`; `L:127-133`). The source describes these as adjacent Majorana-pair rows; it does not construct creation/annihilation operators.
+- A seam row is the third term (`[2]`) of `fixture.target_terms(edge_index)` (`B:101-103`). The raw-mode runner pairs it with `fixture.physical_terms(edge)[2]` (`L:142-152`).
+- For a raw spatial correction, the seam target's Z mask is used as the Jordan--Wigner cleanup. `cleanup_physical = physical_z(fixture, seam_target.z)` and `cleanup_target = target_z(seam_target.z)` are multiplied into the seam rows, yielding the raw `X_u X_v` target (`L:135-152`).
+- Fixed-superselection convention: allowed live/resource inputs share one total computational-basis parity sector. Same-sector Bell X outcome `a` has even Hamming weight; an odd `a` is detected at the decoder root (`L:351-417,420-434,542-544`). The exact dense certificate in `B` selects parity `0` only (`B:320-324,339`).
+
+### Dense sector ordering
+
+- `sector_matrix(row: Pauli, modes: int, parity: int) -> np.ndarray` (`B:307-324`) builds factors in `reversed(range(modes))`, so raw mode 0 is the least-significant computational bit. Single-site selection is exactly `(I,X,Z,Y)[x + 2*z]`; Kronecker factors are accumulated left to right.
+- The retained basis is ascending integer state order filtered by `state.bit_count() % 2 == parity`. Return shape is `(2^(modes-1), 2^(modes-1))`.
+- `sector_matrix` does not multiply by `row.phase`; callers pass canonical rows and subsequently quotient matrices by phases `(1,-1,1j,-1j)` (`B:339-344`). A new runner must not assume arbitrary signed Pauli phases survive this matrix conversion.
+
+## 4. Doubled even-CAR Bell row family
+
+### Construction APIs and ordering
+
+- `target_rows(fixture: M.CompanionFixture, tags: tuple[tuple,...]) -> tuple[Pauli,...]` (`B:91-103`) preserves tag order. Dispatch is: onsite Z, onsite adjacent XX, otherwise seam target term `[2]`.
+- `P.direct_graph_basis(fixture)` returns `(graph, tags)` and is the single ordering authority (`B:161-166`). `targets`, `corrections`, doubled rows, supports, syndromes, and deleted-row tests are all zipped/indexed in this same order. Reordering any one silently breaks private-dual matching.
+- The visible family implies `6N` onsite-Z plus `5N` adjacent-XX plus `E` seam rows, i.e. `11N+E`, but neither file explicitly counts or asserts that formula. It depends on the delegated tag producer returning all of those rows in the expected order.
+- Doubled Choi rows are `P.R.choi_pauli(row, row, m)` for each target (`B:174-176`): the same even-CAR row on both halves. Return is `tuple[Pauli,...]`.
+
+### Ranks and commutation
+
+- Rank is delegated GF(2) rank of symplectic vectors: `P.C.R.F.base.gf2_rank(row.symplectic(m) for row in targets)` and similarly at width `2*m` for doubled rows (`B:171-179`).
+- Expected connected even-algebra rank is exactly `2*m - 1` (`B:278-280,374-378`; `L:594-596`).
+- Fixed-sector independent random Bell bits are `target_rank - 1`, checked against `2*(m-1)` (`B:279-281,397-400`). This is the quotient by the fixed total-parity center.
+- Doubled rows must retain the target rank and commute pairwise. The commutator counter sums `M.symplectic(...)` over each unordered prior pair (`B:174-186`); the main check requires rank equality and zero failures (`B:401-405`).
+- `deterministic_even_samples(modes) -> tuple[Pauli,...]` (`B:139-155`) contains identity, all-Z, each single Z, each `X_0 X_mode`, and 64 SHA-256 seeded rows. Seeded X is masked to `modes` bits and made even by toggling bit 0; Z is unrestricted. Output is deduplicated and sorted by `(row.x,row.z,row.phase)`.
+
+## 5. Private-dual atlas
+
+### API, keys, and lookup
+
+- Atlas construction is exactly `atlas = P.build_private_atlases()` (`B:381-383`). The local static type is only `dict[str, object]` (`B:158-160`).
+- Lookup is exactly `P.correction_from_atlas(fixture, tag, atlas)` for each tag in the unchanged `P.direct_graph_basis` ordering (`B:161-166`). There is no local fallback, exception handler, or unseen-key branch: any missing-key behavior is wholly delegated and will propagate out of `box_certificate`.
+- The top-level atlas visibly has payload keys `"onsite"` and `"edge"`: report serialization removes precisely those two and retains every other atlas item as metadata (`B:467-471`).
+- The requested 704 onsite keys, 192 edge keys, and their serialized key format are not present in either allowed file. They may be products or metadata of `P.build_private_atlases`, but cannot be specified from this surface alone. The only locally visible lookup key is the Bell `tag` tuple described in section 1.
+
+### Duality, support, and diameter
+
+- Each correction is a physical `Pauli`. One-hot private duality is enforced against `graph`: for target index `t`, every graph row `r` must satisfy `symplectic(correction_t, graph_r) == int(r == t)` at width `total=q+m` (`B:204-226`).
+- Physical support cells are `P.pauli_cells(fixture, correction) -> frozenset[Coord]` (`B:204`; same wrapper at `L:226-229`). Diameter is delegated `P.R.support_diameter(support)` (`B:219-221`; `L:503-505`).
+- Declared support is exactly `{fixture.cells[tag[1]]}` for non-edge tags, or the two coordinate cells at `fixture.edges[tag[1]][:2]` for edge tags. Failure is `not support <= declared` (`B:209-217`), so empty/subset support is allowed by the locality predicate; one-hot syndrome prevents an irrelevant empty dual in normal use.
+- Report maxima are `len(support)` and delegated graph diameter (`B:218-221,287-291`). Main requires no syndrome/support failures, maximum cells `<=2`, diameter `<=1` (`B:409-417`).
+- Branch correction is the ordered Pauli product of all atlas rows whose syndrome bit is one (`B:243-253`). `pauli_product(rows) -> Pauli` starts from identity, multiplies with `@` in generator order, and canonicalizes only the final result (`B:106-110`).
+- Syndrome is the target character `s_i = symplectic(error,target_i)`; replay is the physical correction character against graph row `i` (`B:243-257`). Every kernel relation from `M.kernel_relations(target symplectic vectors)` must have even syndrome sum (`B:239-264`).
+- The deletion witness selects `len(corrections)//2` and requires its matching correction/graph symplectic residual to be one (`B:266-271,463-466`).
+
+### Separate corner solve in the raw-mode runner
+
+- `sector_resource_certificate(fixture) -> dict[str,object]` (`L:232-348`) augments the graph with all-Z input parity and calls `P.solve_private_correction(augmented, len(rows), allowed)` (`L:235-255`). Return is destructured as `(correction, rank, contradictions)`, with `rank` intentionally unused.
+- Its one-hot target is the appended parity row. It reports contradiction count, syndrome failures, physical weight, and support-cell count (`L:253-263,300-317`). This is a direct solve, not an atlas lookup.
+
+## 6. Measurement-conflict and correction layers
+
+- `greedy_layers(supports: tuple[frozenset,...]) -> tuple[int,...]` (`B:124-136`) is deterministic, input-order-dependent first-fit coloring. A support enters the first existing layer in which it is disjoint from every already placed support; otherwise a new layer is appended. Return has one zero-based layer index per input support.
+- Measurement vertices use `tag_modes`: supports are sets of `(cell_index, local_mode)`; an onsite Z touches one mode, onsite XX two modes in one cell, and a seam its two endpoint modes (`B:113-121,187,228`).
+- Correction vertices use exact physical qubit support: `frozenset(qbit for qbit in range(q) if ((row.x|row.z)>>qbit)&1)`. Notice the range stops at `q`; any resource-half bits at indices `>=q` do not participate in correction coloring (`B:229-234`).
+- Layer count is `max(assignment, default=-1)+1` (`B:286,291`). Main requires measurement layers `<=6`, correction layers `<=24`, and exact constancy of each count across `boxes[1:]` (the three held shapes after `(2,2,2)`) (`B:383-385,419-425`).
+- Coloring checks support overlap only. They do not directly test Pauli commutation, route collisions, or cross-conflict between measurement and correction epochs.
+
+## 7. Fixed-sector live-input/CPTP surface
+
+### Exact two-/three-mode matrix certificate
+
+- `abstract_teleportation_certificate(modes: int) -> dict[str,object]` (`B:327-378`) is called only for `modes in (2,3)` (`B:385`).
+- Generator rows, in order, are every onsite Z followed by every adjacent XX (`B:327-333`). Their expected GF(2) rank is `2*modes-1`.
+- It exhausts all bit masks `x,z`; only even-Hamming-weight `x` survives. `sector_matrix(canonical(Pauli(x=x,z=z)), modes, 0)` is deduplicated modulo global phases `(1,-1,1j,-1j)` with tolerance `1e-12` (`B:334-344`). The resulting `even` ordering is nested integer `x`, then integer `z`, retaining the first representative of each phase class.
+- Fixed-sector dimension is `d=2^(modes-1)`. The normalized vectorized maximally entangled reference is represented as the matrix `phi = I_d/sqrt(d)`. Bell matrices are `error @ phi`; `np.vdot` flattens them for the Gram matrix (`B:345-350`). Return Gram shape is `(d^2,d^2)` once the expected complete basis is obtained.
+- For each ordered `(error,bell_matrix)` pair: `kraus = bell_matrix.conj().T/sqrt(d)`, hence `K=U†/d`; `corrected = error @ kraus` is compared with `I_d/d` in Frobenius norm; and completeness accumulates `K†K` (`B:351-361`).
+- Returned exact-control fields are: `modes`, `fixed_sector_dimension`, `Bell_outcomes`, `expected_outcomes=d*d`, `Bell_basis_orthonormality_residual`, `corrected_branch_identity_residual` (maximum over branches), `Kraus_completeness_residual`, `generator_rank`, and `expected_even_rank` (`B:362-378`).
+- Main requires outcome count/rank equality and all three residuals `<1e-12` (`B:435-445`). This is the only explicit Kraus assembly in either file.
+
+### Raw-mode coherent Bell/correction ceiling
+
+- `bell_parity_certificate(modes: int) -> dict[str,object]` (`L:351-417`) exhausts same/opposite sector pairs for `modes<=6`; larger cases use four generator tests per mode. It also constructs `bell = kron(H,I) @ CNOT` and reports `||bell†bell-I_4||`. The stated coherent operation order is: `CNOT(live,input-half)`, `H(live)`, retain both Bell registers, decode input-half X word, control physical corrections, reverse decoder CNOTs (`L:395-416`).
+- Bell outcomes are integer masks `(a,b)`: `a` is the even raw-X word and `b` is the Z word. `outcome_samples(modes) -> tuple[tuple[int,int],...]` includes `(0,0)`, `(0,all_Z)`, each singleton `b`, each `a=X_0X_mode`, plus 64 SHA-256 seeded pairs; seeded `a` is made even by toggling bit zero, and output is deduplicated/sorted (`L:420-434`).
+- `mode_tree(fixture) -> (edges, root_mode)` (`L:122-154`) returns a tuple of `(left_mode, right_mode, physical_Pauli, target_Pauli, kind)` and one integer root. It concatenates all `5N` onsite path edges, then delegated spatial cell-tree seams. `kind` is exactly `"onsite"` or `"spatial"`.
+- `tree_structure(modes, edges, root)` (`L:157-174`) returns `(parent, order)`, where `parent[root]=None`, all other values are `(parent_vertex, edge_index)`, and breadth-first discovery follows `sorted(adjacency[vertex])`.
+- `decode_even_x(a,modes,parent,order) -> tuple[int,int,tuple[tuple[int,int],...]]` (`L:177-194`) walks non-root vertices in reverse discovery order. It returns the edge-coefficient bit mask, final root parity bit, and child-to-parent CNOT word. `modes` is in the signature but unused by the body.
+- `apply_cnot_bits(state,word) -> int` applies in tuple order via `state ^= bit(control)<<target` (`L:197-200`). Inversion uses `tuple(reversed(word))` (`L:533-540,566-570`).
+- `correction_for_outcome(fixture,edges,parent,order,a,b) -> tuple[Pauli,Pauli,int,int,tuple[tuple[int,int],...]]` (`L:203-223`) initializes physical/target correction with Z mask `b`, then multiplies selected tree-pair rows according to decoded `a`; both Paulis are canonicalized. Remaining outputs are coefficients, root parity, word.
+- Exact branch identity here is Heisenberg/symplectic, not a dense Kraus calculation: `operator_syndrome(fixture,physical,expected raw Pauli)` must vanish for `expected=canonical(Pauli(x=a,z=b))` (`L:557-575,632-637`). One-cell branches are exhaustive; larger boxes use deterministic samples (`L:550-556`).
+- Fixed-resource augmentation adds one independent parity stabilizer, keeps a mixed gauge factor, and checks both signed parity sectors by changing the last center row phase by `2*parity mod 4` (`L:232-348`). Its normalized input marginal is recorded literally as `"Pi_parity/2^(matter_qubits-1)"` (`L:338-340`).
+
+## 8. Proper-cubic covariance harness
+
+- The only local calls are `covariance = V.frame_certificate((2,2,2), atlas)` and `products = V.product_certificate(atlas)` (`B:386-387`). Both implementations, their signatures beyond these call shapes, and their return annotations are delegated.
+- Main requires `covariance["proper_cubic_frames"] == 24` and `products["ordered_frame_products"] == 576` (`B:446-461`). It does not locally enumerate either set.
+- For every single frame, these exact counters must be zero (`B:449-459`): `signed_projector_failures`, `private_correction_syndrome_failures`, `private_correction_support_failures`, `route_locality_support_or_return_failures`, `atlas_key_inverse_transport_failures`, `schedule_key_inverse_transport_failures`, `Bell_reference_conjugate_chart_failures`, `syndrome_register_bijection_failures`, and `oriented_factor_2_or_3_edge_row_failures`.
+- For ordered products, every returned item whose key ends with `"failures"` must equal zero (`B:460-461`); exact product counter names are not visible.
+- The check label states the compared/transported surface as “projector, atlas, corrections, and schedules” (`B:447`). Counter names additionally expose signed projector replay, inverse atlas/schedule-key transport, Bell reference conjugate chart, syndrome-register bijection, and oriented factor-2-or-3 edge rows. Exact transported object structures/comparison formulas remain delegated.
+- The requested eight coframe origins and their enumeration/order are not present in either allowed file. `B` only records a supplied `"coframe-origin gauge sector"` in report prose (`B:481-485`).
+
+## 9. Preregistered support gate
+
+- The exact positive locality predicate is: `maximum_support_cells <= 2 and maximum_support_diameter <= 1`.
+- On the accepted even-CAR/private-dual route it is enforced for every held box using fields `maximum_private_dual_support_cells` and `maximum_private_dual_support_diameter` (`B:409-417`). The underlying support is a coordinate-cell set from `P.pauli_cells`; diameter is `P.R.support_diameter` (`B:204-221`).
+- On the raw-X route:
+
+```python
+nontrivial = boxes[1:]
+locality_gate = all(
+    box["maximum_generator_support_cells"] <= 2
+    and box["maximum_generator_support_diameter"] <= 1
+    for box in nontrivial
+)
+```
+
+  This is `L:720-725`. `boxes[1:]` excludes `(1,1,1)` and includes `(2,2,2),(3,2,2),(4,2,2),(5,2,2),(5,3,2)` (`L:641-646`).
+- This raw-route runner is preregistered to certify failure: its check passes only when `not locality_gate` and the last `(5,3,2)` box has both cells `>2` and diameter `>1` (`L:726-731`). Generator support/diameter are accumulated over each physical tree correction row (`L:483-505`).
+
+## 10. Output contract
+
+- Both nested helpers have signature `check(label: str, condition: bool) -> None`. They append `{"label": label, "pass": bool(condition)}` then execute:
+
+```python
+print("PASS" if condition else "FAIL", label)
+```
+
+  This is `B:390-392` and `L:649-651`. Exact line form is `PASS <label>\n` or `FAIL <label>\n`, with the default single separator.
+- Exact `B` labels in print order (`B:394-466`):
+
+    1. `local doubled even-CAR rows give a complete fixed-sector Bell algebra`
+    2. `frozen private-dual atlas stays physical-M2 local on the held ladder`
+    3. `measurement and correction words admit size-independent conflict coloring`
+    4. `lawful even Bell characters are exactly cancelled without changing fixed centers`
+    5. `small-sector matrices certify CPTP teleportation rather than a formal syndrome relabeling`
+    6. `proper-cubic 24-frame and 576-product action preserves projector, atlas, corrections, and schedules`
+    7. `deleting a matching local private dual leaves a nonzero Bell sign residual`
+
+- Exact `L` labels in print order (`L:653-731`):
+
+    1. `fixed parity adds one independent Choi stabilizer with a bounded corner correction and retained syndrome`
+    2. `local Bell coupling makes every same-sector X word even and detects a parity mismatch at the decoder root`
+    3. `bounded-degree mode tree spans the complete even Pauli correction algebra and the reversible decoder returns its work`
+    4. `every physical correction generator is the exact gauge-and-center-preserving image of its raw Bell Pauli`
+    5. `exhaustive one-cell and deterministic larger-box branches satisfy the corrected-channel intertwiner`
+    6. `spatial correction deletion is detected`
+    7. `held non-collinear ladder detects failure of the bounded two-cell raw-X correction gate`
+- Each then prints exactly `json.dumps(report, indent=2, sort_keys=True)` (`B:502`; `L:762`). Residuals have no separate print format; they are JSON numbers under the exact field names given in sections 7/8 or nested box certificates. JSON keys are lexicographically sorted and indented by two spaces.
+- `B.report` top-level keys (`B:467-501`): `status`, `checks`, `atlas` (metadata excluding payload keys), `boxes`, `exact_CPTP_controls`, `covariance`, `frame_products`, `derived`, `supplied`, `open`, `claim_boundary`, `input_Bell_measurement_physical_M2_compiled` (literal `False`), `authority` (literal `"none"`), `audit` (literal `"unset"`).
+- `L.report` top-level keys (`L:732-761`): `status`, `checks`, `boxes`, `derived`, `supplied`, `open`, `claim_boundary`, `authority` (literal `"none"`), and `audit` (literal `"unset"`).
+- `status` is `"PASS"` iff all check records pass, otherwise `"FAIL"`. After JSON, non-PASS exits with `SystemExit(1)`; PASS returns normally (`B:503-504`; `L:763-764`).
+- Neither file opens or writes a log, runner-cache `.txt`, or receipt JSON. No paired-log/cache format or receipt-field derivation is visible. They only declare audit globals `AUDIT_TIMEOUT_SEC=900`, `NOTE_PATH`, `AUDIT_INPUT_PATHS`, and alias `DECLARED_INPUT_PATHS=AUDIT_INPUT_PATHS` (`B:21-70`; `L:24-72`); none is consumed by either `main`.
+
+## 11. Import graph and self-containment
+
+### `B`
+
+- Standard library: `from __future__ import annotations`, `hashlib.sha256`, `json` (`B:19,72-73`).
+- Third party: `numpy as np` (`B:75`). No SymPy import.
+- Runner imports (`B:77-81`): `frontier_cycle720_cell_majorana_companion_geometry_2026_07_27 as M`; `frontier_cycle720_companion_checkerboard_frame_cocycle_2026_07_27 as Q`; `frontier_cycle720_companion_local_choi_tree_plaquette_pump_2026_07_27 as P`; `frontier_cycle720_companion_local_choi_pump_covariance_2026_07_27 as V`; `frontier_cycle720_overlap_star_mixed_gauge_choi_2026_07_27 as O`.
+
+### `L`
+
+- Standard library: `from __future__ import annotations`, `collections.defaultdict`, `hashlib.sha256`, `itertools.product as cartesian_product`, `json` (`L:22,74-77`). `cartesian_product` is imported but not used in this file.
+- Third party: `numpy as np` (`L:79`). No SymPy import.
+- Runner imports (`L:81-85`): `frontier_cycle708_endpoint_cube_tableau_core_2026_07_26 as T`; the same `M`, `Q`, `P`, and `O` modules named above. `T` is imported but not used in this file.
+- Neither runner is self-contained. Core `Pauli`/fixture/symplectic/span machinery comes from `M`; box cells from `Q`; graph bases, Choi rows, atlas, routing, support, and GF(2) namespace chains from `P`; factorization from `O`; and covariance from `V` in `B`.
+- The long `AUDIT_INPUT_PATHS` tuples are declarations, not Python imports.
+
+## 12. REUSE PLAN
+
+### Reimplement verbatim
+
+- Copy `canonical` exactly; both runners already duplicate the same function. Copy `pauli_product`, `target_rows`, and `tag_modes` together so phase, tag dispatch, mode arithmetic, and row order remain aligned (`B:87-121`).
+- Copy `greedy_layers` exactly if Cycle-721 claims comparable constant layer counts; a different coloring heuristic changes the certificate surface (`B:124-136`).
+- Copy `deterministic_even_samples` exactly for regression continuity, including SHA-256 strings, endian `"little"`, bit-0 parity repair, and sort key (`B:139-155`).
+- Copy `sector_matrix` and `abstract_teleportation_certificate` together for the two-/three-mode CPTP control. Preserve reversed tensor-factor order, even sector `0`, phase quotient, `K=U†/d`, Frobenius norms, and `1e-12` thresholds (`B:307-378,435-445`).
+- For a raw-route negative/control runner only, copy as one block `physical_z`, `target_z`, `mode_tree`, `tree_structure`, `decode_even_x`, `apply_cnot_bits`, `correction_for_outcome`, and `outcome_samples` (`L:114-223,420-434`). Do not present that block as a bounded compiler.
+
+### Reuse imported interfaces unchanged
+
+- Construct fixtures only as `O.arbitrary_fixture(Q.shape_cells(shape))`.
+- Obtain `(graph,tags)` once from `P.direct_graph_basis(fixture)` and use that exact order for targets, doubled rows, atlas corrections, supports, syndromes, relations, schedules, and deletion witnesses.
+- Build atlas once with `P.build_private_atlases()` and look up via `P.correction_from_atlas(fixture,tag,atlas)`. Reuse `P.pauli_cells` and `P.R.support_diameter` for the preregistered gate.
+- Reuse `P.R.choi_pauli(row,row,m)`, `M.symplectic`, and `P.C.R.F.base.gf2_rank` with the same widths (`m`, `2m`, or `q+m`).
+- If covariance remains a requirement, call the same `V.frame_certificate` and `V.product_certificate` and retain all failure-key checks. Their internal charts/keys cannot safely be reconstructed from these two files.
+
+### Adapt for a new Cycle-721 composition runner
+
+- Adapt shapes, composition-specific target object, report prose, and new failure counters. Keep the `check` record/print/JSON/exit contract if the runner is consumed by the same supervisor.
+- Add new generators only by extending the delegated tag/atlas/covariance surface in lockstep. Locally, `target_rows` treats every unknown non-onsite tag as an edge, so an unrecognized family can silently index the wrong term.
+- Enforce the two-cell/diameter-one gate positively before claiming a bounded route. The raw-X/Jordan--Wigner tree is a witnessed ceiling/failure and must not leak into the accepted even-CAR correction route.
+
+### Coupling traps
+
+- Six-mode arithmetic, lexicographic `max(cells)` root, axis order `(2,1,0)`, edge tuple positions, and mode-0-as-LSB matrix order are frozen conventions.
+- `fixture.edges` endpoint modes are treated as global in `L` but reduced `%6` in `B.tag_modes`; mixing these coordinate levels breaks conflicts.
+- Physical output has width `q`; Choi input begins at `q`. Raw target width is `m`; physical matter images begin at bit zero. A missed shift can still produce a well-formed but wrong Pauli.
+- `canonical` overwrites phase, while `sector_matrix` ignores it. Preserve the phase-quotient intent; do not use this dense helper for signed-center replay.
+- Private duality is index-wise one-hot in `graph/tags` order. First-fit layer numbers are also order-dependent. Sorting tags/corrections independently is a silent semantic break.
+- Measurement coloring uses `(cell,local_mode)`; correction coloring uses physical qubit indices only below `q`. They are different conflict graphs.
+- Fixed-sector bits are `2(m-1)`, not `2m-1`: total parity is fixed after the full even algebra rank is computed.
+- The atlas object is global immutable-by-convention state shared across box and covariance certificates. Rebuilding or mutating per frame could alter lookup/chart consistency.
+- The covariance check relies on external inverse key transport and conjugate Bell charts. Recreating only the 24 rotations without those chart actions is insufficient.
+
+## COMPLETENESS
+
+- Item 1: six-mode/cell/edge/register conventions are extracted; named companion-port orientation, individual center labels, and coframe-origin coordinates are delegated and absent.
+- Item 3: Pauli/Majorana-pair representation and parity conventions are extracted; explicit gamma and creation/annihilation constructors are absent.
+- Item 4: the family implies `11N+E`, but its producer/count assertion is in delegated `P.direct_graph_basis`, so exact tag enumeration is not visible.
+- Item 5: atlas API and top-level payload names are visible; the requested 704/192 counts, inner key serialization, and unseen-key policy are absent.
+- Item 8: expected counts and failure keys are visible; the 24 frames, 576 product order, eight origins, transport maps, and comparisons are delegated.
+- Item 10: stdout and report JSON are complete; paired logs, runner-cache `.txt`, and receipt JSON are not created or described by either source.
+- All other requested items are fully extractable at this two-file interface boundary. No source other than `B` and `L` was consulted, and no script was run.

--- a/.claude/science/physics-loops/computation-connection-20260727/EXTRACT_GEOMETRY_FACTORIZATION.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/EXTRACT_GEOMETRY_FACTORIZATION.md
@@ -1,0 +1,432 @@
+# Cycle-720 base extraction: companion geometry and mixed-gauge factorization
+
+Scope: only the two requested source modules were inspected. “Public” below means
+locally defined non-underscore constants, aliases, classes, methods, and functions.
+Neither module defines `__all__`; imported module/decorator/helper names therefore
+also leak through ordinary Python attribute lookup, but they are dependencies, not
+locally specified APIs. They are listed under coupling traps rather than treated as
+re-exported runner entry points.
+
+## 1. Module M — cell/box/union geometry
+
+Source: `scripts/frontier_cycle720_cell_majorana_companion_geometry_2026_07_27.py`.
+
+### Module constants and type aliases
+
+| Line | Exact name | Type/value and role |
+|---:|---|---|
+| 14 | `AUDIT_TIMEOUT_SEC` | `int = 900`; metadata only. |
+| 15 | `NOTE_PATH` | `str`; theorem-note path. It is not opened by this module. |
+| 16 | `AUDIT_INPUT_PATHS` | `tuple[str, ...]`; declared provenance paths, ending at line 50. It has no computational effect. |
+| 51 | `DECLARED_INPUT_PATHS` | Exact object alias of `AUDIT_INPUT_PATHS`. |
+| 62 | `Pauli` | Type/class alias `C.Pauli`, imported from the coherent cell-edge-gauge dependency. |
+| 63 | `Coord` | Runtime generic alias `tuple[int, int, int]`. |
+
+### `CompanionFixture` and base geometry
+
+`CompanionFixture` (line 93) is a frozen dataclass. It is the only geometry class
+defined by M.
+
+| Line | Field | Exact annotated type | Meaning |
+|---:|---|---|---|
+| 94 | `shape` | `tuple[int, int, int]` | Finite box dimensions supplied by the caller. |
+| 95 | `cells` | `tuple[Coord, ...]` | Ordered cell coordinates inherited from `C.CellEdgeGauge`. Tuple position is the cell index used everywhere else. |
+| 96 | `edges` | `tuple[tuple[int, int, Coord, int, int, int], ...]` | Ordered records `(left_cell, right_cell, owner_coord, axis, left_mode, right_mode)`. The endpoint modes are global matter-qubit indices when used as Pauli bits; `% 6` recovers their local port/mode. |
+| 97 | `matter_qubits` | `int` | Inherited from the base fixture; downstream indexing assumes six matter qubits per cell. |
+| 98 | `qubits` | `int` | Total physical qubits, `matter_qubits + 3*len(cells)`. |
+
+Methods:
+
+| Line | Exact signature | Return | Computation/conventions |
+|---:|---|---|---|
+| 101 | `CompanionFixture.build(cls, shape: tuple[int, int, int]) -> "CompanionFixture"` | `CompanionFixture` | Class method. Calls `C.CellEdgeGauge.build(shape)`, copies its `cells`, `edges`, and `matter_qubits`, then appends three companion qubits per cell. |
+| 111 | `matter_gamma(self, cell: int, mode: int, odd: bool) -> Pauli` | `Pauli` | A within-cell Jordan–Wigner Majorana on matter qubit `6*cell+mode`. `odd=False` gives `X` with `Z` on lower local modes; `odd=True` also places `Z` on the endpoint and sets phase exponent 1. No range checks. |
+| 120 | `companion_eta(self, cell: int, direction: int) -> Pauli` | `Pauli` | Companion Majorana for numeric port/direction `0..5`: companion qubit local index is `direction//2`, its even/odd Majorana selector is `direction&1`, and its global qubit is `matter_qubits+3*cell+direction//2`. Its Jordan–Wigner prefix covers only earlier companion qubits in the same cell. No range checks. |
+| 134 | `endpoint(self, cell: int, direction: int, odd: bool) -> Pauli` | `Pauli` | Product `matter_gamma(cell, direction, odd) @ companion_eta(cell, direction)`. Thus the same numeric direction selects one of six matter modes and one of six companion-port Majoranas. |
+| 139 | `physical_terms(self, edge: int) -> tuple[Pauli, ...]` | Four `Pauli` rows | For the selected edge: `(Z_left_mode, Z_right_mode, phase-2 * endpoint(left,local,even) * endpoint(right,local,odd), endpoint(left,local,odd) * endpoint(right,local,even))`. Edge order is inherited. |
+| 151 | `target_terms(self, edge: int) -> tuple[Pauli, ...]` | Dependency-defined tuple of logical `Pauli` rows, expected to have four entries | Extracts `(owner, axis)` from the edge, makes a minimal object with `.cells`, and calls `C.R.expected_logical_terms(shell, owner, axis)`. |
+
+There is **no M-owned cell enumeration algorithm**. `build` delegates enumeration
+and neighbor/edge orientation entirely to `C.CellEdgeGauge.build`; this file alone
+does not specify lexicographic order, boundary conditions, or axis conventions
+beyond the six-field edge record above.
+
+There is also **no box-union API**, no union construction, no site-map constructor,
+and no shared-cell merge/deduplication handling in M. A caller needing overlapping
+boxes cannot infer a canonical shared-cell policy from this module.
+
+### Geometry-adjacent module functions
+
+| Line | Exact signature | Return | Computation |
+|---:|---|---|---|
+| 280 | `qubit_cell(fixture: CompanionFixture, qubit: int) -> int` | `int` cell index | Matter qubits map by `qubit//6`; companion qubits map by `(qubit-matter_qubits)//3`. It does not bounds-check and is the only site/register-to-cell map. |
+| 286 | `locality_certificate(fixture: CompanionFixture, relations: tuple[Pauli, ...]) -> dict[str, object]` | Certificate dictionary | Maps each supported qubit through `qubit_cell`, measures support-cell diameter with Manhattan distance, and ranks relation rows of diameter at most 0, 1, and 2. Keys: `relation_rank`, `radius_0_relation_rank`, `radius_1_relation_rank`, `radius_2_relation_rank`, `maximum_displayed_relation_weight`, `maximum_displayed_relation_diameter`, and `relations_outside_radius_2`. Empty supports have diameter 0. |
+| 370 | `local_centralizer_basis(fixture: CompanionFixture, physical_generators: tuple[Pauli, ...], radius: int) -> tuple[int, ...]` | Independent tuple of binary symplectic row integers | For every cell center, forms the Manhattan-radius ball, solves for all local Paulis commuting with every physical generator, embeds them in the global `x | (z << qubits)` layout, and greedily retains an independent global span. |
+| 438 | `local_centralizer_gauge_certificate(fixture: CompanionFixture, physical_generators: tuple[Pauli, ...], relation_rows: tuple[Pauli, ...]) -> dict[str, object]` | Nested certificate dictionary | Repeats local-centralizer construction for radii 0, 1, 2, computes an independent-basis symplectic Gram rank, `gauge_pairs = Gram_rank//2`, `gauge_center_rank = basis_rank-Gram_rank`, and `subsystem_logical_qubits = qubits-center_rank-gauge_pairs`. Each `radius_R` map contains `displayed_local_centralizer_rows`, `local_centralizer_span_rank`, `symplectic_Gram_rank`, `gauge_pairs`, `gauge_center_rank`, `subsystem_logical_qubits`, `target_matter_logical_qubits`, `centralizer_replay_failures`, and `target_relation_rows_outside_local_gauge_span`; top-level extras are `radius_2_generator_maximum_diameter` (hard-coded `2`) and `radius_2_generator_count`. It does not return the radius-two rows. |
+
+## 2. Module M — companion representation and Pauli-row algebra
+
+### Register and mode layout
+
+For `N = len(fixture.cells)`, the represented physical register is ordered as:
+
+1. Matter first: qubits `0 .. matter_qubits-1`, with cell `c` occupying
+   `6*c .. 6*c+5`.
+2. Companion second: three qubits per cell, with `(cell c, local companion
+   qubit j)` at `matter_qubits + 3*c + j`.
+
+There are six numeric matter modes/ports per cell (`0..5`), but this module
+provides no symbolic labels such as `±x, ±y, ±z`. Port `d` selects companion
+qubit `d//2` and its even/odd Majorana `d&1`. There are no coframe-bit fields,
+coframe-origin labels, M2 coordinates, rail names, or separate register objects.
+The integer qubit layout above is the complete M-owned “register indexing” API.
+
+### Pauli representation and sign convention
+
+The `Pauli` implementation is imported, so its class declaration is outside the
+allowed source scope. Its use in M and F fixes the following interface:
+
+- `Pauli(phase=0, x=0, z=0)` (also positional construction) stores integer
+  bitmasks `x` and `z`; qubit `q` is bit `1 << q`.
+- `phase` is manipulated modulo 4 as the exponent of the Pauli phase. The
+  formulas are consistent with rows represented as `i^phase X^x Z^z`;
+  in particular `phase=(x&z).bit_count() mod 2` makes a canonical Hermitian row.
+- `left @ right` is signed Pauli multiplication. `Pauli()` is identity.
+- `row.symplectic(qubits)` returns the packed phase-free integer
+  `x | (z << qubits)`. Phase is deliberately absent from that vector.
+- Public fields used by these modules are `.phase`, `.x`, and `.z`.
+
+M’s own phase-free helper `symplectic` (line 363) confirms the packed order and
+returns the commutation bit. Signed equality and multiplication details beyond
+the usages above remain owned by the imported `C.Pauli`.
+
+### Generator dictionary
+
+`operator_rows` (line 157), exact signature
+`operator_rows(fixture: CompanionFixture)` (no return annotation), returns
+`tuple[tuple[str, Pauli, Pauli], ...]`. Each entry is
+`(family, physical_row, target_row)`, in this fixed order:
+
+1. For every edge in inherited edge order, four `"seam"` rows, zipping
+   `physical_terms(edge)` with `target_terms(edge)`.
+2. For matter-mode indices `0 .. matter_qubits-1`, one `"onsite_B"` row
+   `(Z_mode, Z_mode)`.
+3. For each cell in cell-index order and each
+   `combinations(range(6), 2)` pair `(left_local,right_local)`, two
+   `"onsite_even"` rows. With global endpoint bits `e_l,e_r` and the strict
+   between-string `b`, these are
+   `Pauli(phase=2,x=e_l|e_r,z=b|e_l|e_r)` and
+   `Pauli(x=e_l|e_r,z=b)`, each identical to its target.
+
+The result has `4*len(edges) + matter_qubits + 30*len(cells)` entries.
+It is the only complete local-operator encoding dictionary exposed by M.
+
+### Algebra, parity, center, and gauge helpers
+
+| Line | Exact signature | Return | Computation/conventions |
+|---:|---|---|---|
+| 66 | `product(rows) -> Pauli` | One `Pauli` | Left-folds an iterable with signed `@`, starting at identity. Empty input returns identity. |
+| 73 | `kernel_relations(vectors: tuple[int, ...]) -> tuple[int, ...]` | Tuple of integer coefficient masks | Incremental GF(2) elimination using each row’s highest set bit. Every returned mask selects an input subset whose XOR is zero. This is an insertion-order-dependent kernel generating set, not a canonical RREF. |
+| 190 | `relation_certificate(fixture: CompanionFixture) -> dict[str, object]` | Certificate dictionary, including actual relation rows | Builds `operator_rows`, compares physical and target commutator Grams, computes target-kernel words, and orients each corresponding physical relation so the target signed relation is enforced in its `+1` sector. Keys are `generator_rows`, `physical_rank`, `target_even_rank`, `expected_target_even_rank`, `physical_minus_target_rank`, `commutator_Gram_failures`, `non_Hermitian_physical_generators`, `target_kernel_generators`, `relation_stabilizer_rank`, `relation_centralizer_failures`, `relation_mutual_commutator_failures`, `relation_phase_contradictions`, `target_relation_phase_parity_failures`, and `relation_rows: tuple[Pauli,...]`. |
+| 326 | `cell_parity_constraints(fixture: CompanionFixture) -> tuple[Pauli, ...]` | One `Z`-only `Pauli` per cell | For each cell, returns `Z` on all six matter qubits and all three companion qubits. These are proposed local constraints; the function does not project a state or assign eigenvalues. |
+| 338 | `homogeneous_nullspace(equations: tuple[int, ...], variables: int) -> tuple[int, ...]` | Tuple of integer solution masks | GF(2) homogeneous nullspace basis for equations encoded as coefficient masks over `variables` bits. Uses highest-bit pivots, emits free-variable solutions in increasing bit order, and asserts replay. |
+| 363 | `symplectic(left: int, right: int, qubits: int) -> int` | `0` or `1` | Splits each packed row as low-`qubits` X bits and high Z bits and computes `(lx·rz + lz·rx) mod 2`. |
+| 415 | `span_failures(targets: tuple[int, ...], generators: tuple[int, ...]) -> int` | `int` | Counts target rows not in the GF(2) span of generators. Multiplicity counts: every failing target adds one. |
+| 530 | `fixture_certificate(shape: tuple[int, int, int]) -> dict[str, object]` | Aggregate dictionary | Builds a fixture and composes relation, locality, cell-parity, and local-gauge certificates. It removes `relation_rows` from the nested relation map before returning. Keys: `shape`, `cells`, `matter_qubits`, `companion_qubits`, `physical_qubits`, `constant_overhead_qubits_per_cell`, `relation_algebra`, `relation_locality`, `cell_parity_constraint_rank`, `cell_parity_constraint_centralizer_failures`, `cell_plus_relation_rank`, `required_stabilizer_rank_for_6N_code`, `code_exponent_if_all_commuting_constraints_imposed`, and `local_centralizer_subsystem_gauge`. |
+| 573 | `main() -> None` | Normally `None`; may raise `SystemExit(1)` | Audit CLI over shapes `(2,2,2)`, `(3,2,2)`, `(3,3,2)`, `(5,3,2)`. Prints checks, one `SUMMARY_JSON`, and a verdict. It is not a reusable geometry constructor. |
+
+M does **not** expose a decoder from a Pauli row to logical/gauge/center
+coordinates. It exposes relation and cell-parity rows plus gauge rank
+certificates; the only actual gauge-basis-returning function is
+`local_centralizer_basis`, whose output is a phase-free integer basis and is
+not symplectically split into gauge pairs versus center rows.
+
+## 3. Module M — routing and counting
+
+No routing API is present. M defines no nearest-neighbor route constructor,
+route/schedule class, route return format, graph-distance path, FSWAP expansion,
+or primitive counter.
+
+The only distance convention is the Manhattan **support-cell diameter** used by
+`locality_certificate`, `local_centralizer_basis`, and
+`local_centralizer_gauge_certificate`. It is not a routed path length.
+Consequently M has no distinction or conversion among semantic factors,
+physical factors, physical primitives, and routed NN primitives. The only
+generator count exposed is the row count described under `operator_rows`;
+certificate fields named “generator” count algebra rows, not gates.
+
+## 4. Module M — covariance
+
+No covariance implementation is present. In particular M has no 24-frame
+enumeration, no 576 frame-pair/product enumeration, no coframe-origin sectors,
+and no row/word/schedule transport function. The module imports the bounded
+Clifford-orbit dependency as `O` at line 59 but never reads `O` afterward.
+That unused import must not be mistaken for a covariance re-export.
+
+## 5. Module F — exact mixed-gauge factorization
+
+Source:
+`scripts/frontier_cycle720_companion_subsystem_mixed_gauge_factorization_2026_07_27.py`.
+
+### Module constants and alias
+
+| Line | Exact name | Type/value and role |
+|---:|---|---|
+| 18 | `AUDIT_TIMEOUT_SEC` | `int = 900`; metadata only. |
+| 19 | `NOTE_PATH` | `str`; theorem-note path, not opened here. |
+| 20 | `AUDIT_INPUT_PATHS` | `tuple[str, ...]`; provenance paths, ending at line 58. |
+| 59 | `DECLARED_INPUT_PATHS` | Exact object alias of `AUDIT_INPUT_PATHS`. |
+| 71 | `Pauli` | Type/class alias `M.Pauli`. |
+
+### Public factorization helpers
+
+| Line | Exact signature | Return | Computation/conventions |
+|---:|---|---|---|
+| 74 | `canonical_pauli(vector: int, qubits: int) -> Pauli` | Hermitian `Pauli` | Decodes `vector` as `x = low qubits`, `z = remaining high bits`; sets phase to `(x&z).bit_count()&1`. It does not truncate high Z bits beyond the right shift. |
+| 80 | `independent_paired_basis(physical: tuple[int, ...], target: tuple[int, ...]) -> tuple[tuple[int, int, int], ...]` | Tuples `(independent_physical_row, corresponding_target_row, source_combination_mask)` | Highest-pivot GF(2) elimination of `physical`. When a physical combination becomes a new pivot, the same coefficient mask is XORed over `target` via `U.xor_rows`. Input order selects the basis. |
+| 106 | `symplectic_split_paired(rows: tuple[tuple[int, int, int], ...], qubits: int) -> tuple[tuple[tuple[int, int, int], ...], tuple[tuple[tuple[int, int, int], tuple[int, int, int]], ...]]` | `(radicals, hyperbolic_pairs)` | Symplectic Gram–Schmidt driven by the physical component `[0]`; every XOR row operation is simultaneously applied to physical row, target row, and source-combination mask. It pops from the end, chooses the first remaining anticommuting partner, and is ordering-dependent. |
+| 135 | `symplectic_split_vectors(rows: tuple[int, ...], qubits: int) -> tuple[tuple[int, ...], tuple[tuple[int, int], ...]]` | `(radical_rows, hyperbolic_pairs)` | Same end-pop/first-partner symplectic split for packed integer rows. |
+| 163 | `local_center_basis(fixture: M.CompanionFixture, gauge: tuple[int, ...], radius: int) -> tuple[int, ...]` | Independent tuple of packed integer rows | Finds combinations in the symplectic radical of `gauge` whose physical support lies inside at least one Manhattan-radius cell ball. It accumulates displayed rows over all centers, then greedily retains an independent basis in discovery order. |
+| 213 | `row_diameter(fixture: M.CompanionFixture, row: Pauli) -> int` | `int` | Manhattan diameter of the set of cells touched by `row.x | row.z`, using `M.qubit_cell`; empty support returns 0. |
+| 227 | `span_equal(left: tuple[int, ...], right: tuple[int, ...]) -> bool` | `bool` | True iff ranks agree and each tuple lies in the other’s GF(2) span. |
+| 235 | `conjugate_diagonal(row: Pauli, diagonal_rows: tuple[int, ...], z_signs: int, matter: int) -> Pauli` | New `Pauli` | Applies an encoded diagonal Clifford description to `row`: a set bit of `z_signs` on an X-supported matter index adds phase 2; a set bit `right` in `diagonal_rows[left]` applies the corresponding pairwise diagonal/CZ update to phase and Z mask. Only pairs `right < left < matter` are inspected. |
+
+### `phase_fixed_factorization`
+
+Line 252 exact signature:
+
+`phase_fixed_factorization(shape: tuple[int, int, int]) -> dict[str, object]`
+
+This is F’s sole high-level factorization entry point. It performs the following
+construction:
+
+1. Builds `M.CompanionFixture` and M’s complete physical/target dictionary.
+2. Selects a paired basis and splits it into algebra radicals/logical hyperbolic pairs.
+3. Gets the commutant/gauge basis from `U.gauge_structure(fixture, physical_paulis, relation_rows)` and splits it into center radicals/gauge pairs.
+4. Generates center candidates at radii 0–2, greedily complements parity with radius-two rows, truncates to `len(gauge_radicals)-1`, and appends parity last.
+5. Constructs `physical_w = [logical W][gauge W][local-center W][parity W]` and explicit `physical_v = [logical V][gauge V]`; `B.complete_tableau` adds center-dual V rows. The target frame is `[logical W][matter-parity W]` plus explicit logical V.
+6. `B.decode` supplies `.phase`, `.v_mask`, `.w_mask`: low logical bits, then gauge bits, then center W bits, with parity the last center W bit.
+7. Solves GF(2) sign flips for logical V, logical W, and non-parity center W (never gauge/parity rows), re-decodes, and checks both parity sectors.
+8. Audits the failed product-encoder diagonal from `H.holonomy_certificate` against the gauge span.
+
+The dimensions reported are:
+
+- `logical_count = len(logical_pairs)`, interpreted as logical qubits in one
+  fixed total-parity sector;
+- `gauge_count = len(gauge_pairs)`;
+- `center_count = len(local_center) + 1`, with total parity last;
+- the constructed canonical frame is required to satisfy
+  `logical_count + gauge_count + center_count == fixture.qubits`.
+
+### Exact channel statement and representation of \(V_s\)
+
+The exact formula returned at lines 561–564 is:
+
+\[
+E_s(\rho)=V_s\left[
+\rho_{\mathrm{logical}}\otimes\frac{I_{\mathrm{gauge}}}{2^g}
+\otimes
+\lvert\mathrm{local\text{-}center}=+;\mathrm{parity}=s\rangle
+\langle\mathrm{local\text{-}center}=+;\mathrm{parity}=s\rvert
+\right]V_s^\dagger .
+\]
+
+The literal returned string is
+`"E_s(rho)=V_s [rho_logical tensor I_gauge/2^g tensor
+|local-center=+; parity=s><...|] V_s^dagger"`.
+
+`V_s` is represented **only transiently and implicitly** by the signed canonical
+Pauli tableau `(physical_w, physical_v)` aligned to the target tableau. There is
+no `V_s` variable, class, matrix, circuit, or Clifford word, and the sector
+value `s` is not an argument to `phase_fixed_factorization`; it enters only as
+the eigenvalue of the final parity-center coordinate when phases are checked.
+The same canonical tableau underlies both sectors.
+
+Internally, the encoded logical generators are exactly
+`physical_w[:logical_count]` and `physical_v[:logical_count]`. Gauge generators
+are the next `gauge_count` W/V rows; center stabilizers are the remaining W
+rows; center-coordinate duals are the remaining V rows. **None of these rows
+or decoded coordinate records is returned.** The report provides only metrics
+and a SHA-256 digest of all canonical rows. Thus F currently has no public
+function that returns:
+
+- the tableau or a matrix/word implementing \(V_s\);
+- the encoded logical generators at a requested cell/port;
+- logical, gauge, or center coordinates of a supplied Pauli;
+- the encoding of an arbitrary local operator.
+
+For the finite dictionary, `M.operator_rows` returns each local physical encoding
+next to its target operator; F verifies its coordinates internally but discards
+those decoded coordinates.
+
+### Exact return schema
+
+`phase_fixed_factorization` returns this nested report:
+
+- Top: `shape`, `cells`, `physical_qubits`, `logical_qubits_in_fixed_parity_sector`, `gauge_qubits`, `center_sector_bits`, `dimension_identity`, `mutual_commutant`, `phase_fixed_intertwiner`, `product_phase_residual_vs_gauge`, `locality`, `deletion`, `tableau_digest`.
+- `mutual_commutant`: `physical_algebra_rank`, `gauge_algebra_rank`, `rank_sum`, `expected_full_symplectic_dimension`, `cross_commutator_failures`, `physical_center_equals_declared_center`, `gauge_center_equals_declared_center`.
+- `phase_fixed_intertwiner`: `logical_coordinate_failures`, `gauge_coordinate_failures_for_every_physical_generator`, `parity_coordinate_failures`, `phase_equation_rank`, `phase_equation_variables`, `phase_parity_failures`, `phase_contradictions`, `even_sector_phase_failures`, `odd_sector_phase_failures`, `phase_sign_weight`, `relation_center_coordinate_rank`, `canonical_tableau_rank`, `canonical_tableau_pairing_failures`, `finite_box_mixed_gauge_CPTP_E_constructed`, `factorwise_full_word_intertwiner_exact`, `channel_formula`, `gauge_channel_under_every_factor` (`"identity"`).
+- `product_phase_residual_vs_gauge`: `changed_physical_generators`, `changed_generator_differences_outside_R1_gauge_span`, `difference_span_rank`, `verdict`.
+- `locality`: `maximum_canonical_encoder_row_diameter`, `maximum_logical_coordinate_row_diameter`, `maximum_gauge_Bell_coordinate_row_diameter`, `maximum_center_dual_row_diameter`, `maximum_canonical_encoder_row_weight`, `locally_generated_center_ranks` (keys `"0"`, `"1"`, `"2"`), `full_center_rank`, `local_R2_center_rank_plus_supplied_parity`, `canonical_tableau_bounded_R2`.
+- `deletion`: `remove_one_local_center_row_rank_loss` tests `center_vectors[1:]`; `remove_parity_row_rank_loss` tests `center_vectors[:-1]`.
+- `tableau_digest`: SHA-256 of ordered `"phase:xhex:zhex"` rows joined by `|`; not reconstructive.
+
+`main` (line 592), exact signature `main() -> None`, runs factorization on four
+required shapes and three smaller patches, prints audit checks, a
+`SUMMARY_JSON`, and a verdict, and may raise `SystemExit(1)`. It returns no
+factorization object.
+
+## 6. Module F — sector matrices
+
+F contains no NumPy import and no exact two-mode or three-mode matrix builder.
+It constructs and checks only packed Pauli rows, GF(2) tableaus, coordinate
+masks, integer ranks, and phase residuals. Neither sector density matrices nor
+machine-residual matrices are returned. `canonical_pauli` and
+`conjugate_diagonal` are row builders/transformers, not small-matrix APIs.
+
+## 7. Fixtures and factor entry points
+
+There are no named coin, contact, mass, or FSWAP fixture classes/functions in
+either module, and neither module deliberately re-exports such entry points.
+The available pieces are:
+
+| Family | Entry point | What is actually exposed |
+|---|---|---|
+| Generic box | `M.CompanionFixture.build` (line 101) | One companion fixture for one shape. |
+| Seam | `CompanionFixture.physical_terms` (line 139), `target_terms` (line 151), or `M.operator_rows` (line 157) | Four physical/target Pauli rows per inherited edge. |
+| Onsite number/mass-like row | `M.operator_rows` (line 157) | Family label `"onsite_B"` with one `Z` row per matter mode. There is no parameterized mass coefficient or update schedule. |
+| Onsite even/coin/contact algebra | `M.operator_rows` (line 157) | A complete set of pairwise within-cell even Majorana rows under family label `"onsite_even"`. It does not distinguish coin from contact or build their linear combinations/exponentials. |
+| Geometry audit fixture | `M.fixture_certificate` (line 530) | Rank/locality report; actual relation rows are removed from this aggregate return. |
+| Factorization audit fixture | `F.phase_fixed_factorization` (line 252) | Factorization certificate and tableau digest, not the factorization tableau. |
+| FSWAP | None | No FSWAP generator, word, schedule, route, matrix, or fixture. |
+
+F calls `H.holonomy_certificate` internally to audit a failed product-state
+diagonal, but does not alias or return that fixture. F’s
+`"factorwise_full_word_intertwiner_exact"` field is a Boolean over M’s generator
+dictionary, not a returned free/seam/contact word.
+
+The only intentional type re-export is `Pauli`: `M.Pauli = C.Pauli` and
+`F.Pauli = M.Pauli`.
+
+## 8. Coupling traps and call ordering
+
+### Dependencies and leaked namespace
+
+Neither module defines `__all__`. Ordinary Python lookup therefore also exposes import bindings:
+
+- M lines 53–59: `dataclass`, `sha256`, `combinations`, `json`, `C`, and `O`.
+- F lines 61–68: `sha256`, `json`, `M`, `U`, `C`, `H`, and `B`.
+
+These have no signatures specified here and are not stable re-exports. `M.O` is unused. F is coupled to `U.xor_rows`, `U.gauge_structure`, `C.R.F.base.gf2_rank`, `C.gf2_solve`, `H.holonomy_certificate`, `B.complete_tableau`, and `B.decode`.
+
+### Global state and memoization
+
+There is no mutable computational global, singleton fixture, cache, memoization, random source, or environment lookup. Every high-level call rebuilds its data. Importing either module still imports its dependencies, so their import-path setup and side effects remain external coupling.
+
+### Ordering and representation assumptions
+
+- Cell/edge order, ownership, axis/boundary conventions, and six-port geometry come entirely from `C.CellEdgeGauge.build`; M does not validate them.
+- Registers are hard-coded as six contiguous matter bits/cell followed by three contiguous companion bits/cell. Edge endpoint modes serve as both global bits and local directions via `% 6`.
+- Jordan–Wigner prefixes are cell-local. Reordering cells, matter modes, companions, or even/odd companion Majoranas changes signed rows.
+- Packed rows need the exact width: X occupies the low `qubits` bits and Z the next block. Matter-width rows cannot be decoded at physical width.
+- Bases are order-dependent: highest-bit pivots in M, end-pop/first-partner splitting in F, then dependency-owned tableau completion. Digests and logical bases are convention-dependent.
+- F assumes physical/target tuples are positionally aligned and does not check equal lengths.
+- The phase solve uses `delta//2`; require zero `phase_parity_failures` and `phase_contradictions` plus passing Boolean fields.
+- Center choice is greedy/noncanonical; parity is appended last and all later mask slicing assumes that position.
+- Local-center `+1` and maximally mixed gauge are supplied sector/state conventions, not prepared outcomes.
+- Locality is support diameter, not an NN-circuit certificate; the canonical tableau may exceed radius two.
+- No charts/coframes exist; chart origins, frame/coframe bits, and transformed-port conventions must be external.
+
+### Required call sequence
+
+There is no hidden initialization call. Low-level data flow is:
+
+1. `fixture = M.CompanionFixture.build(shape)`.
+2. `rows = M.operator_rows(fixture)`.
+3. For relations, use `M.relation_certificate(fixture)["relation_rows"]`, not `M.fixture_certificate`, which removes them.
+4. For an M-owned local commutant, use `M.local_centralizer_basis(fixture, tuple(r[1] for r in rows), radius)`.
+5. Split a supplied packed basis with `F.symplectic_split_vectors(basis, fixture.qubits)`.
+
+`F.phase_fixed_factorization(shape)` needs no prior call but returns no intermediate object. Either `main()` is an audit CLI, never a prerequisite.
+
+## 9. REUSE PLAN for three Cycle-721 runners
+
+### Shared API map
+
+| Needed capability | Existing call(s) | Sufficiency |
+|---|---|---|
+| (a) Site map and registers | `M.CompanionFixture.build(shape)` gives `cells`, `edges`, `matter_qubits`, `qubits`; `M.qubit_cell(fixture,q)` gives inverse qubit-to-cell mapping; direct formulas above give per-cell registers. | Sufficient for one inherited finite box. Not sufficient for box unions, shared cells, named M2 rails, or coframe bits. |
+| (b) Pauli-row algebra | `M.Pauli`, `M.product`, `M.symplectic`, `M.kernel_relations`, `M.homogeneous_nullspace`, `M.span_failures`; `F.canonical_pauli`, `F.independent_paired_basis`, and both `F.symplectic_split_*` helpers. | Sufficient for packed GF(2) row manipulation if the caller preserves qubit width, order, and signed `Pauli` rows separately. |
+| (c) Encoded generators at one port cell | `fixture.matter_gamma`, `fixture.companion_eta`, and `fixture.endpoint` give local Majorana/endpoint rows; `fixture.physical_terms(edge)` and `M.operator_rows` give dictionary encodings. | Sufficient only for M’s local physical dictionary. The canonical \(V_s\)-encoded logical W/V generators are internal to F and unavailable by public return. |
+| (d) Covariance transport of new schedule objects | None. | Missing: no frame enumeration, row transport, word transport, schedule schema, or schedule transport. |
+
+### Runner 1: input-side Bell measurement compilation
+
+Use `M.CompanionFixture.build` for the box and qubit registers, then
+`M.operator_rows` plus `M.relation_certificate(...)[ "relation_rows" ]` for the
+represented algebra and relation center. If the compiler needs an M-owned
+radius-one commutant, obtain it with `M.local_centralizer_basis` and split it
+with `F.symplectic_split_vectors`; verify the resulting center independently
+with `F.local_center_basis`.
+
+This supports specifying which packed gauge-pair rows a Bell measurement should
+measure, but neither module supplies measurement operations, ancilla registers,
+outcome-bit conventions, feed-forward corrections, or an NN schedule. The new
+runner must define those objects and must not call a phase-free packed row a
+signed measurement operator without converting it through
+`F.canonical_pauli`.
+
+### Runner 2: encoded-input Clifford via \(V_s\) restriction
+
+Use M’s local endpoint/dictionary rows for the physical observable side and
+F’s `phase_fixed_factorization(shape)` as a pass/fail regression certificate.
+The requested \(V_s\) restriction itself cannot be implemented from that
+report: `physical_w`, `physical_v`, target tableaus, decoded masks, and phase
+solution are discarded.
+
+The Cycle-721 spec therefore needs a narrow new F API (or an intentional
+refactor of `phase_fixed_factorization`) returning a structured immutable
+factorization object containing at least:
+
+- ordered signed `physical_w` and `physical_v`;
+- ordered signed target W/V rows;
+- `logical_count`, `gauge_count`, `center_count`, with parity-last convention;
+- per-dictionary-row decoded logical/gauge/center masks and sector phase;
+- the selected local-center rows and total-parity row.
+
+Without that extension, copying lines 252–504 of F or reaching through leaked
+`F.B/F.U` dependencies would duplicate convention-sensitive logic and is not
+reuse of the public factorization result.
+
+### Runner 3: epoch composition
+
+Use `M.operator_rows` as the stable factor dictionary and
+`F.phase_fixed_factorization` to assert factorwise logical/identity-gauge
+intertwining for each box. Define epoch words/schedules in the new runner with
+explicit counts for semantic factors, unrouted physical primitives, and routed
+NN primitives; neither M nor F currently supplies these notions.
+
+Covariant epoch composition also requires a new transport layer. It must define
+the 24 frame elements, all 576 ordered frame products if those are required,
+coframe-origin/sector bits, transformations of signed Pauli rows, and
+transformations of the newly defined word and schedule objects. There is no
+existing M/F call for this; the unused `M.O` binding is not an implementation.
+Tests should transport both row support and phase, preserve the parity-last
+center convention, and compare factor counts separately from route-expanded
+primitive counts.
+
+## COMPLETENESS
+
+All locally defined non-underscore module constants/type aliases, the one class
+and all of its methods, and every module-level function in the two requested
+files are documented above with definition line and exact signature. The
+inventory covers M lines 14–573 and F lines 18–592; the later nested `check`
+functions are local closures inside `main`, not module APIs. Imported names
+visible because neither module defines `__all__` are explicitly inventoried as
+coupling rather than misrepresented as locally specified APIs.
+
+Requested-but-absent surfaces are called out explicitly: union boxes/shared-cell
+handling, M2/coframe labels, routing and count layers, covariance/frame
+transport, returned \(V_s\)/encoded logical generators/coordinate decoders,
+small sector matrices, and named coin/contact/mass/FSWAP fixtures. The reuse
+plan distinguishes the exact existing calls from the APIs Cycle-721 must add.

--- a/.claude/science/physics-loops/computation-connection-20260727/EXTRACT_SITEMAP_RECURRENT.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/EXTRACT_SITEMAP_RECURRENT.md
@@ -1,0 +1,194 @@
+# Cycle-720 site map: recurrent update and tree/plaquette Choi pump
+
+This is a bounded interface extraction from only:
+
+- `scripts/frontier_cycle720_companion_recurrent_overlap_update_2026_07_27.py` (abbreviated **R**, 838 lines), and
+- `scripts/frontier_cycle720_companion_local_choi_tree_plaquette_pump_2026_07_27.py` (abbreviated **P**, 1021 lines).
+
+Line references below are source-file line numbers. “Imported/opaque” means the
+caller and returned fields are visible here but the implementation is outside
+the permitted read set. Neither file defines a class; `Pauli = M.Pauli` and
+`Coord = tuple[int, int, int]` are aliases (R107-109, P91-92).
+
+### Defined-symbol index
+
+- **R globals:** `AUDIT_TIMEOUT_SEC`, `NOTE_PATH`, `AUDIT_INPUT_PATHS`, `DECLARED_INPUT_PATHS`, `Pauli`, `Coord`, `TOL` (R21-109). **R functions:** `fields(row) -> tuple[int,int,int]` (R112); `semantic_factor_keys(fixture: M.CompanionFixture) -> set[tuple]` (R116); `overlap_cover_certificate() -> dict[str,object]` (R134); `pauli_expansion_word(rows: tuple[Pauli,...], order: tuple[int,...]) -> dict[tuple[int,int,int],complex]` (R169); `expansion_residual(left,right) -> float` (R194); `schedule_certificate(shape: tuple[int,int,int]) -> dict[str,object]` (R202); `coordinate_intertwiner_certificate(fixture: M.CompanionFixture, factor: O.Factorization) -> dict[str,object]` (R264); `update_covariance_certificate(shape: tuple[int,int,int]) -> dict[str,object]` (R357); `recurrent_box_certificate(shape: tuple[int,int,int], powers=(1,2,3,5,8)) -> dict[str,object]` (R472); `main() -> None` (R603); local `main.<locals>.check(label: str, condition: bool) -> None` (R629). No R class is defined.
+- **P globals:** `AUDIT_TIMEOUT_SEC`, `NOTE_PATH`, `AUDIT_INPUT_PATHS`, `DECLARED_INPUT_PATHS`, `Pauli`, `Coord` (P29-92). **P functions:** `pauli_product(rows) -> Pauli` (P95); `direct_graph_basis(fixture: M.CompanionFixture) -> tuple[tuple[Pauli,...],tuple[tuple,...]]` (P102); `repeated_star_basis(fixture: M.CompanionFixture) -> tuple[Pauli,...]` (P130); `incident_port_mask(fixture: M.CompanionFixture, cell: int) -> int` (P150); `solve_private_correction(rows: tuple[Pauli,...], target: int, allowed: tuple[int,...]) -> tuple[Pauli,int,int]` (P160); `local_signature(row: Pauli, allowed: tuple[int,...]) -> tuple[int,int]` (P185); `signature_pauli(signature: tuple[int,int], allowed: tuple[int,...]) -> Pauli` (P191); `onsite_allowed(fixture: M.CompanionFixture, cell: int) -> tuple[int,...]` (P200); `edge_allowed(fixture: M.CompanionFixture, edge: int) -> tuple[int,...]` (P214); `build_private_atlases() -> dict[str,object]` (P224); `correction_from_atlas(fixture: M.CompanionFixture, tag: tuple, atlas: dict[str,object]) -> Pauli` (P298); `coordinate_maps(fixture: M.CompanionFixture, root: Coord, axis_order: tuple[int,int,int]) -> tuple[dict[Coord,tuple[int,int,int]],dict[tuple[int,int,int],Coord]]` (P318); `edge_lookup(fixture: M.CompanionFixture) -> dict[frozenset[Coord],int]` (P337); `schedule_tree_plaquettes(fixture: M.CompanionFixture, root: Coord, axis_order: tuple[int,int,int]) -> tuple[tuple[int,...],tuple[tuple[int,tuple[int,...]],...]]` (P344); `pauli_cells(fixture: M.CompanionFixture, row: Pauli) -> frozenset[Coord]` (P432); `returned_route(anchor: Coord, support: frozenset[Coord]) -> tuple[tuple[Coord,Coord],...]` (P451); `route_execution_failures(anchor: Coord, route: tuple[tuple[Coord,Coord],...]) -> tuple[int,int]` (P477); `schedule_basis(fixture: M.CompanionFixture, root: Coord, axis_order: tuple[int,int,int]) -> tuple[tuple[Pauli,...],tuple[tuple,...],dict[str,object]]` (P499); `schedule_correction(fixture: M.CompanionFixture, tag: tuple, atlas: dict[str,object]) -> Pauli` (P533); `box_certificate(shape: tuple[int,int,int], atlas: dict[str,object]) -> dict[str,object]` (P544); `pump_algebra_certificate() -> dict[str,object]` (P816); `main() -> None` (P848); local `main.<locals>.check(label: str, condition: bool) -> None` (P855). No P class is defined.
+
+## 1. Box/union geometry
+
+### Exact public blocks
+
+- `R.semantic_factor_keys(fixture: M.CompanionFixture) -> set[tuple]` (R116-131): returns unique semantic keys.
+- `R.overlap_cover_certificate() -> dict[str, object]` (R134-166): returns the two-view/global-union counts, factor-set differences, and ownership prose.
+- `P.coordinate_maps(fixture: M.CompanionFixture, root: Coord, axis_order: tuple[int, int, int]) -> tuple[dict[Coord, tuple[int, int, int]], dict[tuple[int, int, int], Coord]]` (P318-334): oriented cell-coordinate bijection and its inverse.
+- `P.edge_lookup(fixture: M.CompanionFixture) -> dict[frozenset[Coord], int]` (P337-341): unordered endpoint-coordinate pair to fixture edge index.
+
+### Construction and enumeration
+
+- Left cube cells are `set(Q.shape_cells((2,2,2), (0,0,0)))`; right cube cells are `set(Q.shape_cells((2,2,2), (1,0,0)))`; the physical box is their set union (R134-140). Each set is passed separately to `O.arbitrary_fixture`, while the operative global fixture is built once from `union_cells`.
+- The resulting open rectangular union is `3x2x2`: 8 left cells, 8 right cells, 12 union cells, and the `x=1` overlap plane has 4 shared cells (construction R135-147; asserted R633-638).
+- There is no local implementation of `Q.shape_cells` or `O.arbitrary_fixture` in the read set. Consequently, the exact tuple order of `fixture.cells` and exact tuple structure/order of `fixture.edges` are imported/opaque. Visible consumers consistently enumerate cells by `range(len(fixture.cells))` or fixture order and edges by `enumerate(fixture.edges)` (e.g. P108-126, P337-341).
+- The shared registry is the single `union` fixture. The certificate reports `9 * len(shared_cells) = 36` shared physical matter+companion M2 registers and exactly `copied_shared_registers = 0` (R147-154). Cube membership is a view, not an allocation or owner (R162-165). Coframe registers are counted separately by the recurrent box certificate and are not included in this “36 shared physical M2” field.
+- Recurrent held boxes are created identically as `O.arbitrary_fixture(Q.shape_cells(shape))` for `shape in ((3,2,2),(3,3,2),(5,3,2))` (R202-205, R472-476, R603-612).
+- Pump boxes use the same construction for `((2,2,2),(3,2,2),(3,3,2),(5,3,2),(4,4,3))` (P544-550, P848-852). No fit is performed per held box; the correction atlas is built once before all `box_certificate` calls.
+
+## 2. Register ownership and indexing
+
+- Per cell, the recurrent certificate exposes 12 retained M2 sites: 6 matter + 3 physical companion + 3 retained coframe-gauge sites (R531-537). `fixture.qubits = 9N` is matter+companion; coframe is the separate `3N`; total retained is `12N`. For `3x2x2`, these are 108, 36, and 144 respectively.
+- The pump’s visible bit layout confirms the matter/companion ordering: physical matter indices are `6*cell + mode` (six per cell), and companion indices are `fixture.matter_qubits + 3*cell + local` (three per cell) (P108-125, P200-221). Thus `fixture.matter_qubits = 6N` and `fixture.qubits = 9N`.
+- For a Choi row the extra coarse-input/JW half follows the physical output: `total_qubits = fixture.qubits + fixture.matter_qubits = 15N`; `pauli_cells` maps `[0,6N)` as physical matter, `[6N,9N)` as companion, and `[9N,15N)` as coarse input (P432-448, P547-548). The coframe `3N` is not in this tableau index space in either visible runner.
+- Semantic ownership is exact: onsite coin/reverse/contact factors are owned by their cell; each seam factor is keyed by the edge’s `owner` and `axis`, where the prose fixes the owner as the positive-axis lower endpoint (R120-131, R162-165). A covering cube never owns a factor.
+- Global semantic keys are: `("coin", cell, factor)`, `("reverse", cell, axis)`, `("contact", cell, left, right)`, and `("seam", owner, axis, factor)` (R116-131).
+- Global register numbers are therefore cell-major in the visible Pauli layout. The coordinate-to-cell-index assignment inside `O.arbitrary_fixture`, the `owner` value’s exact type, all coframe bit indices, and the remaining fields in each `fixture.edges` tuple are imported/opaque and must not be guessed.
+
+## 3. Routing and count levels
+
+### Recurrent word
+
+- `U.placement(fixture)` then `U.physical_word(fixture, placed)` returns `(word, update)`; `U.c707.route_word(word)` returns `(routed, route)` (R475-481). All three implementations and the instruction class are imported/opaque.
+- Count levels are deliberately distinct: `update["logical_update_factors"]` is the semantic-factor count; `len(word)` is the literal unrouted physical-instruction count (also reported, somewhat confusingly, as `inverse_word_factor_count`); `len(routed)` is `routed_gate_count`, and power rows call it `routed_primitive_count` after multiplication by the power (R507-528, R564-581).
+- The route report fields consumed here are exactly `maximum_route_distance`, `route_return_failures`, and `non_NN_failures` (R577-580); pass requires the latter two to be zero (R740-750). How route distance is computed and how the physical NN word performs and returns work are not visible because `route_word` is imported.
+
+### Pump word
+
+- `P.returned_route(anchor: Coord, support: frozenset[Coord]) -> tuple[tuple[Coord, Coord], ...]` (P451-474). It asks imported `R.route_selector(anchor, support)` for tree links, builds undirected adjacency, and performs a depth-first walk with `sorted(adjacency[cell])`. Every discovery appends `(parent,child)`; every recursion return appends `(child,parent)`. It asserts all support cells were visited and returns the literal down/up word, hence returned work.
+- `P.route_execution_failures(anchor: Coord, route: tuple[tuple[Coord,Coord], ...]) -> tuple[int,int]` (P477-496) returns `(forward_failures, inverse_failures)`. Forward execution requires the token to equal each link’s left endpoint and to finish at `anchor`. Literal inverse execution scans `reversed(route)`, toggles across an edge only when the token is at an endpoint, and also must finish at `anchor`.
+- Pump locality is the Manhattan-one predicate `sum(abs(a-b) for zip(left,right)) == 1` on every transition; it separately checks that a nonempty route’s final right endpoint is its anchor (P631-646). Counts are total transitions, transitions/cell, maximum transitions for one measurement, locality-or-return failures, and literal reverse failures (P757-763). Plaquette support diameter is delegated to imported `R.support_diameter` (P652-658).
+- Pump “semantic rows” are schedule stabilizers; physical controlled-Pauli factors are popcounts of each measured row and its private correction (P629-651, P764-765). The prose gate word is `H_s; controlled-S_j along returned NN route; H_s; controlled-C_j along returned NN route; store s_j in retained local bank` (P793-800).
+- No collision counter or collision-free epoch layout exists in either file. Pump output explicitly leaves a “literal collision-free controller layout with the recurrent matter word” open (P1000-1004).
+
+## 4. Recurrent free/reverse/seam/contact word
+
+- `R.semantic_factor_keys` builds, per cell: one key per factor of the Cycle-219 common-coin adjacent-QR schedule; 3 reverse keys (axes 0..2); and 15 unordered contact pairs `(left,right)` with `0 <= left < right < 6`. Per edge it builds four seam keys using the global `(owner,axis)` (R116-131).
+- The `3x2x2` box has `N=12`, `E=20`. The task-specified total 428 therefore decomposes as 132 coin factors (`11/cell`), 36 reverse factors, 180 contact factors, and 80 seam factors: `12*(11+3+15)+20*4 = 428`. The 11 coin count is inferred from that supplied total and the visible other loops; `compile_adjacent_qr` itself is opaque.
+- Each `2x2x2` view has 280 factors. Their intersection has 132 duplicated view keys (116 onsite keys on four cells plus 16 seam keys on the four in-plane shared edges), and their set union is the 428 globally owned keys. The certificate checks missing/excess are zero and deduplicated cover count equals global count (R141-165, R633-644).
+- The four immutable macro layers are, in order: (1) parallel onsite coin net, (2) parallel three-pair reverse net, (3) all seam blocks, and (4) parallel onsite all-pair contact net (R251-260). This is a fixed law schedule, explicitly not time.
+- Seam block literal order is factors `(0,1,2,3)`, described as groups 01 then 23. Distinct edge blocks commute but rows within an edge contain noncommuting pairs (R204-226, R251-255).
+- `R.pauli_expansion_word(rows: tuple[Pauli,...], order: tuple[int,...]) -> dict[tuple[int,int,int],complex]` (R169-191) expands the ordered product of `exp(-i*pi*P/4)=(I-iP)/sqrt(2)`, drops coefficients `<=1e-13`, and uses phase-free `(0,x,z)` keys while folding Pauli phase into coefficients. `R.expansion_residual(left,right) -> float` (R194-199) is the Euclidean coefficient-map difference over the union of keys.
+- `R.schedule_certificate(shape: tuple[int,int,int]) -> dict[str,object]` (R202-261) compares frozen `(0,1,2,3)` against: orientation reversal `(1,0,3,2)` (must have residual `< TOL`); hostile interleave `(0,2,1,3)` (must be `>1e-3`); and deletion `(1,2,3)` (must be `>1e-3`) (R228-250, R697-705). Thus orientation reversal is an allowed block convention; interleaving the anticommuting factor groups or deleting factor 0 is not.
+- `R.recurrent_box_certificate(shape: tuple[int,int,int], powers=(1,2,3,5,8)) -> dict[str,object]` (R472-600). It builds the fixture, factorization, parent tensor certificate, factorwise coordinate certificate, placement, physical word, and routed word exactly once. `one_step_exact` is the conjunction of parent-projector equality and six zero coordinate/commutator counters (R496-506).
+- For each listed power, it loops over that Boolean certificate rather than rebuilding an encoder or word: `encoder_calls=1`, `physical_update_word_calls=power`, `fresh_encoder_environment_calls_after_genesis=0`, and factor/routed counts are the one-step counts multiplied by power (R507-528). This is executable factorwise induction on the exact generator-coordinate intertwiner and gauge identity, not fresh encoding or dense many-body exponentiation (R590-599).
+
+## 5. Logical/gauge/parity/center/coframe coordinate checks
+
+- `R.coordinate_intertwiner_certificate(fixture: M.CompanionFixture, factor: O.Factorization) -> dict[str,object]` (R264-354) obtains `(family, physical, target)` rows from imported `M.operator_rows(fixture)`. Each physical row is decoded in `(factor.physical_w, factor.physical_v)` at `fixture.qubits`; its target is decoded in `(factor.target_w, factor.target_v)` at `fixture.matter_qubits` (R285-294).
+- Logical coordinates occupy bit positions `[0,factor.logical)` in both decoded `v_mask` and `w_mask`. A logical failure means either physical mask differs from the target mask on those positions (R268, R295-298).
+- Gauge coordinates occupy `[factor.logical, factor.logical+factor.gauge)`. A gauge-coordinate failure is counted separately for nonzero physical `v_mask` and nonzero physical `w_mask` in this range; the target gauge mask is not compared (R269, R299-300). Thus “zero gauge coordinate failures” concretely means every physical operator generator has identity action on both canonical gauge halves.
+- The physical parity coordinate is the `w_mask` bit at `factor.logical + factor.gauge + factor.center - 1`; target parity is target `w_mask` bit `factor.logical` (R301-306). They must agree.
+- Phase is tested in both parity sectors `odd in (0,1)` as `(pc.phase + 2*odd*physical_parity) mod 4 == (tc.phase + 2*odd*target_parity) mod 4` (R307-311). Therefore sign/phase, not merely binary Pauli support, is load-bearing.
+- Gauge commutators are tested against both physical canonical halves, `physical_w[logical:logical+gauge] + physical_v[logical:logical+gauge]`; center commutators are tested against physical `w` rows in the following `factor.center` slots (R276-283, R312-327). Zero means every generator symplectically commutes with every such row.
+- The returned shape is seven public fields: `operator_generators`, `logical_coordinate_failures`, `gauge_coordinate_failures`, `parity_coordinate_failures`, `both_sector_phase_failures`, `physical_generator_gauge_commutator_failures`, `physical_generator_center_commutator_failures`, plus `coordinate_signature_sha256` over ordered family/coordinate/phase tuples (R328-354).
+- Coframe checks are separate, not part of that decoder: imported `Q.coframe_constraint_certificate(shapes)` must report `rank_failures`, `contradictions`, `seed_formula_failures`, and `flipped_rhs_detection_failures` all zero (R603-615, R740-745). Its equations and coordinate index convention are not visible.
+
+## 6. Tree/plaquette Choi pump
+
+### Basis and private corrections
+
+- `P.pauli_product(rows) -> Pauli` (P95-99): left-folds `Pauli()` with `@`.
+- `P.direct_graph_basis(fixture: M.CompanionFixture) -> tuple[tuple[Pauli,...], tuple[tuple,...]]` (P102-127): returns `(rows,tags)`. Per cell it emits six signed Choi rows of physical/target single-mode `Z`, tagged `("onsite_Z",cell,mode)`, then five adjacent physical/target `XX` rows on modes `(0,1)..(4,5)`, tagged `("onsite_XX",cell,mode)`. It then emits one row per edge: exactly seam factor index 2 on both `fixture.physical_terms(edge)` and `fixture.target_terms(edge)`, tagged `("edge",edge)`.
+- Hence the direct stabilizer basis has exactly `11N+E` rows and that many independent generators; `box_certificate` checks direct rank, count, commutation, and signed two-way span equality with the repeated-star basis (P724-747, P867-875).
+- `P.repeated_star_basis(fixture) -> tuple[Pauli,...]` (P130-147) constructs each center plus in-box nearest neighbours, factorizes each patch, collects imported channel-graph entries, and returns imported independent tagged rows. It is a comparison oracle, not the pump schedule.
+- `P.incident_port_mask(fixture,cell) -> int` (P150-157) uses six bits: a cell that is an edge’s `left` sets `2*axis+1`, while a `right` endpoint sets `2*axis`. This signed-port convention is part of every atlas key.
+- `P.solve_private_correction(rows: tuple[Pauli,...], target: int, allowed: tuple[int,...]) -> tuple[Pauli,int,int]` (P160-182) builds GF(2) equations whose two variables per allowed qubit are correction X and Z. X sees stabilizer Z; Z sees stabilizer X. RHS is one only on `target`. It returns `(Hermitian Pauli correction, solve_rank, contradictions)`; the correction phase is `(x & z).bit_count() & 1`.
+- `P.onsite_allowed(fixture,cell) -> tuple[int,...]` (P200-211) is the nine physical output qubits of that cell (six matter then three companion). `P.edge_allowed(fixture,edge) -> tuple[int,...]` (P214-221) is only the three companion qubits at each endpoint, left endpoint first.
+- `P.local_signature(row,allowed) -> tuple[int,int]` (P185-188) compresses global X/Z masks into allowed-order local masks. `P.signature_pauli(signature,allowed) -> Pauli` (P191-197) expands them back, again fixing Hermitian phase.
+- `P.build_private_atlases() -> dict[str,object]` (P224-295) trains on every rectangular shape in `{1,2,3,4}^3` (64 shapes). Onsite key is `(incident_port_mask, tag_family, mode)`; edge key is `(left_port_mask,right_port_mask,axis)`. Each key must have exactly one local signature. Return keys are `onsite`, `edge`, `training_shapes`, `training_rows`, `solve_contradictions`, `onsite_keys`, `edge_keys`, `onsite_conflicts`, `edge_conflicts`, two distinct-correction counts, and `atlas_sha256`. Main requires 704 onsite keys (`64*11`), no contradictions, and no conflicts (P859-865).
+- `P.correction_from_atlas(fixture,tag,atlas) -> Pauli` (P298-315) reconstructs by exactly those keys/allowed orders. `P.schedule_correction(...) -> Pauli` (P533-541) passes onsite tags directly; both `("tree",edge)` and `("plaquette",new_edge,cycle)` reuse the original direct edge correction.
+
+### Rooted tree and plaquette order
+
+- `P.schedule_tree_plaquettes(fixture,root,axis_order) -> tuple[tuple[int,...], tuple[tuple[int,tuple[int,...]],...]]` (P344-429) returns `(tree_edges, fill)`, where each fill item is `(new_edge, four_edge_cycle)`.
+- `coordinate_maps` chooses sign + when root is at that physical axis’s minimum and - otherwise, then orders oriented distances by `axis_order` (P323-334). The canonical box schedule uses `root=min(fixture.cells)` and `axis_order=(2,1,0)` (P551-554): oriented `u[0]` is physical z (“fast”), `u[1]` y (“middle”), and `u[2]` x (“slow”).
+- Tree parent priority is first nonzero coordinate in `u[0],u[1],u[2]`, decrementing exactly that coordinate (P369-384). It gives `N-1` rooted-tree seam edges and prepares them first.
+- An elementary plaquette at `base` and coordinate axes `(a,b)` is ordered: `(base->base+a, base->base+b, base+a->base+a+b, base+b->base+a+b)` (P357-367). `add_new` asserts the nominated new edge is unprepared and every other cycle edge is already prepared (P385-395).
+- Fill order is exact: middle-axis edges off fast=0, nested `slow,middle,fast=1..`; then slow-axis edges on middle=0 off fast=0, nested `slow,fast=1..`; then remaining slow-axis edges growing in middle, nested `slow,middle=1..,fast` (P396-426). Final prepared edge set must equal every fixture edge.
+- `P.schedule_basis(fixture,root,axis_order) -> tuple[tuple[Pauli,...],tuple[tuple,...],dict[str,object]]` (P499-530) returns `(rows,tags,report)`: all 11N onsite direct rows first, then original direct seam row 2 for every tree edge, then the Pauli product of the four direct seam rows for every fill cycle. Tags are original onsite tags, `("tree",edge)`, then `("plaquette",new_edge,cycle)`. Report has `tree_edges`, `plaquette_fill_rows`, `edge_coverage_failures`, and `triangular_predecessor_failures`.
+- The plaquette products cancel long seam strings to support on at most four cells with diameter at most two (checked P652-658, P900-906). The triangular correction test requires each schedule correction to anticommute with its own row and commute with every earlier row (P610-620).
+
+### Channel and retained syndrome
+
+- `P.pump_algebra_certificate() -> dict[str,object]` (P816-845) uses the canonical pair `S=Z`, `C=X`. Its exact Kraus convention is `K_plus=P_plus`, `K_minus=C P_minus`; completeness is `P_plus+P_minus=I`, and anticommuting `C` maps both input eigensigns to the plus sector.
+- The reduced channel is `Phi_j(rho)=P_j+ rho P_j+ + C_j P_j- rho P_j- C_j`; commuting triangular private corrections produce `rho_J=2^(-Q) product_j(I+S_j)` (P802-805).
+- The dilation is Hadamard, controlled signed Pauli, Hadamard, controlled correction (P838-840). There is no reset or postselection: each syndrome bit is stored in a retained local bank, all syndrome and Bell purifiers are retained, and the mobile rail is returned to its anchor (P793-811, P841-844).
+- `box_certificate` reports retained resources as `total_qubits` local Bell reference M2, `len(schedule)` retained syndrome-bank M2, and `N` reusable mobile-route-rail M2; the initial system is one local Bell pair per Choi-system M2 with the other half purifying the maximally mixed system (P785-796).
+- Active deletion controls remove schedule rows 0, `onsite_count-1`, and the last row; each survivor set must have rank `len(schedule)-1`. They also delete the least significant active Pauli factor from those three rows and require literal row inequality (P701-720, P772-777, P936-942).
+- Larger-box reuse is literal: one atlas is built, frozen, and supplied to all five box calls (P848-852). Every box must have zero atlas syndrome, triangular pump, and off-declared-cell failures; correction weights are bounded by 8 overall and 3 for edges (P889-898). Every 8 corners times 6 axis permutations (48 contexts) must reproduce the same signed projector with zero schedule failures (P660-688, P919-924).
+
+## 7. Signed covariance and frame-sensitive conventions
+
+- `R.fields(row) -> tuple[int,int,int]` returns `(row.phase % 4,row.x,row.z)` (R112-113); signed covariance therefore includes the Pauli phase, while binary covariance drops only that first component.
+- `R.update_covariance_certificate(shape: tuple[int,int,int]) -> dict[str,object]` (R357-469) instantiates 24 imported proper cubic frames, 8 affine translation parities, and 8 coframe-origin seeds. For every `(frame,shift)` it rebuilds a target fixture from `Q.affine_cells(source.cells,frame,shift)`, and for every seed applies imported seeded sheet corrections (R369-413). The actual context count is `24*8*8=1536` per shape, not `24*576*8`.
+- Transformed operator rows are compared as signed and binary multisets within each family `("seam","onsite_B","onsite_even")`; public failure counters are `operator_family_binary_multiset_failures` and `operator_family_signed_multiset_failures` (R375-443, R458-468).
+- Each source edge’s four base-corrected seam rows are looked up in the target and classified only by mapped factor-index tuple. Accepted classes are forward `(0,1,2,3)` and orientation-reversed `(1,0,3,2)`; every other or missing classification increments `seam_block_factor_order_covariance_failures` (R382-402).
+- Coin covariance constructs the 6x6 permutation matrix for each frame and reports `max ||P coin P^T - coin||`, required `< TOL` (R448-467, R708-717).
+- The separate retained coframe channel is imported as `Q.uniform_origin_direct_sum_certificate(...)` (R615-623). Main checks all 576 proper-rotation products over 8 origin sectors, i.e. 4608 origin blocks, plus 512 translation-product origin blocks (R720-737). Its visible counters are `proper_rotation_density_Choi_product_failures`, `translation_density_Choi_product_failures`, `uniform_origin_density_Choi_product_failures`, and `local_alternation_constraint_transport_failures`, all zero. The requested “24 frames x 576 products x 8 sectors” is thus two adjacent certifications: the 24-frame update test and the 576-product-by-8-origin channel test.
+- No counters named tableau-image, stabilizer, private-correction, atlas-key, schedule-key, or returned-route covariance failures occur in these files. The nearest visible pump counters are signed two-way basis replay, atlas private-dual syndrome, triangular schedule pump, corner/axis signed projector, and returned-route locality/inverse counters (P733-768).
+- The only visible JW/chart rule is a prohibition: onsite private corrections remain on the physical output cell and off the coarse-input JW half because odd input Paulis acquire chart strings under cubic frame changes, while the companion action is cell-local (P200-204). No chart-route recompiler or explicit JW chart-route recompilation rule is defined/called here.
+
+## 8. Residuals and inherited fixtures
+
+- In `R.recurrent_box_certificate`, every instruction in the *unrouted* `word` supplies `.matrix`. It reports the maximum of `||U†U-I||` and the maximum of `||UU†-I||` (R482-495, R564-576). The latter is named `maximum_instruction_inverse_pair_residual`; no separately constructed inverse is multiplied here. The stated inverse convention is to reverse the literal instruction word and conjugate-transpose every local matrix (R569-575). Both maxima must be below `TOL = 4e-10`.
+- The one-particle fixture is imported exactly as `U.C.R.local_free_contact_mass()["mass_contact"]` (R529). Its consumed fields are `one_particle_mass_residual`, `contact_vacuum_and_one_particle_residual`, and `contact_double_occupation_phase_residual`; all must be `< TOL` (R583-589, R751-754).
+- Cycle-219 coin data are invoked through `F128.common_coin()`. The coin is compiled by imported `S25.compile_adjacent_qr(coin)` to define semantic coin factor count (R116-123), and is separately tested under all 24 direction permutations by `||P coin P^T-coin||` (R448-457).
+- Cycle-230 is invoked exactly as `U.C712.cycle230_semantic_certificate(U.C712.decoded_word(2)[0])` (R624-626). Main checks five fields `< TOL`: `coin_matrix_residual`, `mass_residual`, `FSWAP_matrix_residual`, `onsite_64_state_contact_residual`, and `internal_depth_two_stream_residual` (R756-760).
+- Seam-specific active checks in this runner are the ordered exponential orientation/interleave/deletion residuals in section 4. Reverse and seam are not exposed as separately named Cycle-230 residual fields here; any inclusion in `decoded_word(2)` or the semantic certificate is imported and opaque. No other Cycle-219/230 fixture is directly executed in these files.
+- Pump algebra and rank/span/deletion checks are exact integer/GF(2)/Pauli equalities, not floating residuals (P964-966).
+
+## 9. Output conventions
+
+### Recurrent runner
+
+- `R.main() -> None` (R603-838). Local `check(label: str,condition: bool) -> None` appends `{"label":label,"pass":bool(condition)}` and prints, via two print arguments, exactly `PASS <label>` or `FAIL <label>` (R627-632).
+- After checks it prints one compact, key-sorted line `SUMMARY_JSON <json>` (R828-831), then exactly one sentinel line: `RECURRENT_OVERLAP_COMPANION_UPDATE_PASS` or `RECURRENT_OVERLAP_COMPANION_UPDATE_INCOMPLETE` (R832). Failure exits 1.
+- The report includes `status`, aggregate `pass`, `authority="none"`, `audit="unset"`, a literal baseline commit, checks/certificates, supplied / derived / open / claim boundary structures, compiler/no-go gates, and `report_sha256` computed over sorted compact JSON *before* adding the digest field (R763-830).
+
+### Pump runner
+
+- `P.box_certificate(shape: tuple[int,int,int], atlas: dict[str,object]) -> dict[str,object]` (P544-813) returns the complete per-box basis, routing, correction, deletion, parent-normalization, and retained-resource report described above.
+- `P.main() -> None` (P848-1021) has the same `PASS/FAIL <label>` convention (P853-857), then prints the full report as pretty JSON with `indent=2` and `sort_keys=True` (P983-1015). There is no pump sentinel and no report digest; non-PASS exits 1 (P1015-1017).
+- Neither file reads/writes a runner-cache `.txt`, defines a cache path, or produces a receipt record. Visible audit metadata are the identical `AUDIT_TIMEOUT_SEC=900`, `NOTE_PATH`, `AUDIT_INPUT_PATHS`, and `DECLARED_INPUT_PATHS=AUDIT_INPUT_PATHS` globals (R21-74, P29-76). The recurrent report has baseline/digest fields; those are report fields, not a cache receipt.
+
+## 10. Import graph and self-containedness
+
+- **R runtime local imports** (R96-104): `frontier_cycle720_cell_majorana_companion_geometry... as M`; `...companion_subsystem_m2_update... as U`; `...companion_subsystem_mixed_gauge_factorization... as F` (alias visibly unused); `...overlap_star_mixed_gauge_choi... as O`; `...companion_repeated_star_choi_tensor... as R`; `...companion_checkerboard_frame_cocycle... as Q`; `frontier_cycle708_endpoint_cube_tableau_core... as T`; `frontier_full128_cycle_encoder... as F128`; and `frontier_full128_25site_nn_circuit_core... as S25`. It also uses NumPy and stdlib `Counter`, `sha256`, product, JSON, math.
+- **R type-check-only imports** (R85-94): fixed-sector even-CAR Bell, fixed-sector live-input teleportation, local Choi pump covariance, this tree/plaquette pump, local genesis broadcast, and three-route adversary. They are citation-graph edges only and do not execute at runtime.
+- **P runtime local imports** (P83-88): geometry `M`, coherent common-E `C`, checkerboard cocycle `Q`, repeated-star tensor `R`, subsystem mixed-gauge factorization `F` (alias visibly unused), and overlap Choi `O`; plus stdlib `defaultdict`, `sha256`, permutations/product, and JSON.
+- The long `AUDIT_INPUT_PATHS` tuples declare citation/audit dependencies but are not dynamic imports (R23-73, P31-75).
+- Neither runner is self-contained. Essential imported surfaces include fixture construction and edge records, Pauli/tableau operations, factorization, physical update construction and NN routing, Choi graph construction/span replay, frame/coframe actions, GF(2) solve/rank, parent tensor normalization, inherited coin/contact fixtures, route selection, and support diameter.
+
+## 11. REUSE PLAN for three Cycle-721 runners
+
+### Reimplement verbatim or call unchanged
+
+- **Shared site map:** preserve `Q.shape_cells -> O.arbitrary_fixture`, the single global union fixture, cell-major 6+3 physical indices, separate 3N coframe allocation, and the exact `semantic_factor_keys` tuples. Copy the overlap set-union/ownership checks; never concatenate two cube fixtures.
+- **Input-side Bell compilation:** retain the Choi tableau order `[physical matter 6N][companion 3N][coarse input 6N]`. Reuse `direct_graph_basis`, `pauli_product`, and parity-product convention verbatim. Preserve sign phases from `R.choi_pauli`.
+- **Encoded-input Clifford/private corrections:** reuse verbatim `incident_port_mask`, `solve_private_correction`, `local_signature`, `signature_pauli`, `onsite_allowed`, `edge_allowed`, `build_private_atlases`, and `correction_from_atlas`. Build the atlas once, freeze it, and use endpoint order `(left,right,axis)` exactly.
+- **Pump schedule:** reuse verbatim `coordinate_maps`, `edge_lookup`, `schedule_tree_plaquettes`, `schedule_basis`, `schedule_correction`, `pauli_cells`, `returned_route`, and `route_execution_failures`. Keep onsite/tree/plaquette row order and retained syndrome semantics.
+- **Recurrent G:** call the imported `U.placement`, `U.physical_word`, and `U.c707.route_word` unchanged. Preserve four macro layers and seam 01-before-23 order. Reuse `coordinate_intertwiner_certificate`, `schedule_certificate`, and the unitarity/inverse checks as composition gates.
+- **Covariance:** reuse signed `fields`, the accepted seam row classes, and both signed and binary family multiset comparisons. Preserve the split between frame/shift/seed update covariance and the 576-product retained coframe channel.
+
+### Adapt for each new runner
+
+- The input-side Bell runner should adapt `box_certificate` to its new encoded-input map while retaining the exact direct-basis ordering, parity-correlation test, parent signed-span equality, and no-reset retained resources.
+- The encoded-input Clifford runner should add its Clifford tableau action and chart routes around the existing basis/private-correction surface. It needs a new explicit JW chart-route compiler and covariance counters; these two files provide only the “do not place onsite corrections on input JW” constraint.
+- The collision-free epoch runner must create a new global resource namespace and schedule keys that compose: Bell initialization; ordered onsite/tree/plaquette pump; returned measurement route; private correction; retained syndrome storage; coupling; any frame correction; then recurrent G. It must add collision tests because Cycle-720 explicitly leaves this controller layout open.
+
+### Silent composition traps
+
+- **Fixture identity:** rebuilding per-cover fixtures silently duplicates the 4 shared cells/36 physical registers and changes global indices and edges.
+- **Index spaces:** recurrent physical `9N`, coframe `3N`, Choi input `6N`, Bell purifiers, syndrome bank, and mobile rail are distinct spaces. Never interpret pump `total_qubits=15N` as recurrent retained `12N`.
+- **Edge orientation:** atlas keys use fixture `(left,right,axis)`, semantic seam ownership uses `(lower-endpoint owner,axis,factor)`, while geometric lookup uses unordered endpoint frozensets. Sorting/reversing one without recompiling all three breaks keys or phases.
+- **Order/sign:** Pauli phase mod 4, both parity-sector phase, `@` product order, canonical seam order `(0,1,2,3)`, allowed reversal `(1,0,3,2)`, onsite/tree/plaquette order, and allowed-qubit order are all load-bearing.
+- **Atlas scope:** atlas values are unique only under exact six-port masks and exact local-qubit orders. Refitting on a held box defeats the reuse control.
+- **Returned work:** the mobile rail must finish at its anchor after every measurement; syndrome/Bell purifiers remain allocated. “Returned route” does not authorize resetting those retained banks.
+- **Epoch semantics:** E/pump is one-time genesis; recurrent powers are resource-count induction checks, not clock slots, and no fresh encoder environment may appear after genesis.
+- **Global/imported state:** `Q.S`, nested namespaces such as `U.C712` and `C.R.F.base`, imported fixture enumeration, and `Pauli` phase behavior are implicit global contracts. A new runner should pass fixtures/atlases/schedule-key maps explicitly and digest them; module reloads or locally reconstructed orderings can silently fork the convention.
+- **Schedule keys/collisions:** no Cycle-720 schedule-key schema or collision counter exists. Cycle-721 must define keys over global register IDs plus epoch/layer/route position and reject simultaneous ownership; it cannot infer safety from commuting stabilizers or returned routes.
+
+## COMPLETENESS
+
+- Fully extracted: every function/global/class name defined in the two files, visible signatures and return shapes, union/ownership/count conventions, recurrent schedule/induction, pump basis/atlas/tree/route/channel, coordinate checks, visible covariance/residual/output/import contracts, and composition traps.
+- Imported/therefore not fully extractable under the two-file boundary: `shape_cells` enumeration order, `CompanionFixture`/edge tuple definitions, coframe indices/equations, `physical_word` instruction/`update` schemas, recurrent NN router construction/distance, Choi and factorization internals, inherited fixture internals, and parent normalization.
+- Requested but absent from both sources: collision counters and epoch layout; tableau-image/stabilizer/private-correction/atlas-key/schedule-key/returned-route *covariance* counters; an explicit JW chart-route recompilation rule; runner-cache `.txt` and receipt production.
+- The literal 428 is not printed as a source constant; its decomposition above uses the task-supplied total plus the visible 3x2x2 geometry/key loops. No script was run, so runtime-produced numeric route loads, atlas digests, report digests, and residual values were not collected.

--- a/.claude/science/physics-loops/computation-connection-20260727/GOAL.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/GOAL.md
@@ -1,0 +1,86 @@
+# Goal: Cycle 721 — literal physical-input and epoch-integration tournament
+
+## Exact target contract (proof-search governance)
+
+**Target statement.** On the declared Cycle-720 companion subsystem code
+(finite open boxes, fixed total-parity label, local center-sector signs,
+mixed gauge factor, eight coframe origins), produce at least one of the three
+declared routes as a literal, bounded, physical-M2 construction:
+
+1. **Route CAR-BELL-M2:** compile the positive doubled even-CAR Bell
+   measurement rows (onsite parities, onsite adjacent-Majorana pairs, one
+   nearest-neighbor seam row per edge; ranks `2m-1`) into literal M2 input
+   hardware on the same site map as the prepared Choi resource and the
+   recurrent update `G_physical`.
+2. **Route ENC-CLIFFORD:** compile a direct local encoded-input Clifford on
+   the companion/center code that couples a live input without raw
+   teleportation corrections.
+3. **Route EPOCH-SCHEDULE:** stagger Choi preparation, Bell coupling,
+   retained correction banks, and recurrent `G` with an explicit
+   collision-free fixed schedule on one literal site map.
+
+**Quantifiers/domain.** Finite open boxes at least through a held
+non-collinear box (target ladder `2x2x2`, `3x2x2`, `5x3x2`; larger boxes as
+global-size reuse controls only). Fixed-parity/center sector supplied, as in
+Cycle 720.
+
+**Allowed premises.** Minimal axioms (Lattice, Qubit, Admissibility, Record);
+the three registered primitives within their declared scopes; the landed
+Cycle-219/230 coin/mass/contact fixtures; the landed Cycle-720 code,
+atlas, pump, and recurrent-update constructions as prior bounded authority
+(authority none, audit unset — extended, not treated as retained).
+
+**Forbidden weakenings.**
+- Inferring a bounded local live-input realization from the Choi theorem
+  without a literal compiled word (Cycle 720 explicitly forbids this).
+- Any route whose physical correction-generator support exceeds the
+  preregistered two-cell, diameter-one gate on the held box (that is the
+  raw-Bell failure being escaped).
+- Dropping the 24-frame/576-product covariance controls, the deletion and
+  hostile-order controls, or the free/seam/reverse/contact/mass fixtures.
+- Calling any ordinal a clock, duration, rate, or physical time.
+- Claiming autonomous genesis, sector law, parity/center enforcement,
+  boundary-free recurrence, Record/Born content, or source/gravity meaning.
+- Any prose crossing the parked teleportation lane HOLD
+  (CANONICAL_HARNESS_INDEX.md:23): state teleportation only — no
+  matter/FTL/mass/charge transfer claims.
+- Sampling presented as completeness: all completeness claims use exhaustive
+  enumeration on the declared finite family or exact algebraic identity
+  (teleportation-three-register pack no_go_routes honored).
+
+**Required edge/degenerate cases.** Smallest box `1x1x1` where defined;
+held non-collinear box; deletion of one correction/private dual (must leave
+unit sign residual or an explicit changed-bit census); hostile factor
+interleave; unlawful sector controls.
+
+**Completion witness.** Runner(s) + paired runner-cache logs + receipt json
+with: zero route/return/collision failures, support/diameter census meeting
+the two-cell/diameter-one gate (or the honest measured ladder if larger),
+exact residual maxima at machine scale, all 24x576 (and coframe-origin
+product) covariance blocks clean, fixtures unchanged, plus an independent
+adversarial checker that rebuilds the lower-level algebra without importing
+the route runners.
+
+**Outcomes that do not count as closure.** A schedule that serializes by
+global barrier without site-map collision accounting; an encoded-input
+Clifford whose input side is not a physical M2 assignment on the same chart;
+any route that only re-verifies Cycle-720 identities (corollary churn); a
+negative result without the N1-N8 gate.
+
+**Honest-status ceiling.** bounded_theorem (conditional on the same supplied
+sector/genesis inventory as Cycle 720). No retained/promoted language;
+authority none; audit unset. Independent audit required before any effective
+status.
+
+## Trace target (quoted blockers being attacked)
+
+From the Cycle-720 note Open list:
+
+> - a literal physical-M2 circuit for the input-side even-CAR Bell
+>   measurements;
+> - a collision-free composition of Choi preparation, Bell coupling,
+>   correction controller, and recurrent matter word on one literal site map;
+
+Source: docs/RECURRENT_COMPANION_PHYSICAL_M2_UPDATE_LOCAL_CHOI_PREPARATION_CYCLE720_BOUNDED_THEOREM_NOTE_2026-07-27.md
+(Supplied / derived / open, Open items 1-2; and Verdict and next experiment,
+routes 1-3).

--- a/.claude/science/physics-loops/computation-connection-20260727/HANDOFF.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/HANDOFF.md
@@ -1,0 +1,69 @@
+# Handoff — computation-connection-20260727, block01 (Cycle 721)
+
+## What this block delivers
+
+The three-route literal physical-input and epoch-integration tournament
+declared by the Cycle-720 note ("Verdict and next experiment"), closed
+positively at the bounded ceiling on the unchanged supplied inventory:
+
+1. `frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.py` — every
+   doubled even-CAR Bell row compiled to a literal H/controlled-Pauli/H
+   physical word with retained ancilla and returned NN routing;
+   two-cell/diameter-one gate met on six boxes (11 to 995 rows); conflict
+   coloring law `3 + max cell degree` with interior saturation; frozen
+   one-cell private duals unchanged; the Cycle-720 receipt flag
+   `even_car_input_bell_measurement_physical_M2_compiled` becomes true at
+   this package's bounded resolution.
+2. `frontier_cycle721_encoded_input_clifford_port_2026_07_28.py` —
+   18-primitive reversible even-exchange port exact on the full 36-row
+   port dictionary; seam-extended coupling is port-local (1 cell /
+   diameter 0); factorization anchors regress; the V_s-restriction
+   compiler remains UNTESTED/OPEN (no public tableau API; measured
+   locality ceiling recorded).
+3. `frontier_cycle721_collision_free_epoch_composition_2026_07_28.py` —
+   pump + input coupling (both legs) + correction banks + recurrent G
+   composed on one literal site map with a Cycle-54-compliant
+   register-liveness slot walk; zero collisions/violations; recurrent and
+   fixture gates unchanged; schedule-key covariance over 192 contexts.
+4. `frontier_cycle721_tournament_independent_adversary_2026_07_28.py` —
+   independent reconstruction, blocklisting the three primaries; 6/6; one
+   wording correction (epoch F2-leg namespace qualifier), adopted in the
+   note.
+
+Note: `docs/CAR_BELL_INPUT_PHYSICAL_M2_COMPILER_CYCLE721_BOUNDED_THEOREM_NOTE_2026-07-28.md`
+Receipt: `outputs/car_bell_input_epoch_tournament_cycle721_receipt_2026_07_28.json`
+Caches: `logs/runner-cache/frontier_cycle721_*.txt` (content-pinned with
+declared inputs).
+
+## Status discipline
+
+bounded_theorem, authority none, audit unset; conditional on the supplied
+Cycle-720 sector/genesis inventory plus two new supplied conventions
+(companion-encoded input bank; declared-port chart). No retained language.
+No new negative claims (see the note's negative-claim discipline section).
+Independent audit required before any effective status.
+
+## Proposed repo weaving (do NOT apply in this branch)
+
+- None required. The lane is unregistered by design (grounding check:
+  LANE_REGISTRY / LANE_STATUS_BOARD carry no campaign entries). No
+  docs/audit/data files touched.
+
+## Next exact actions (queue-ordered)
+
+1. Feed the unchanged Cycle-612 endpoint/interval harness and the coherent
+   source-lift tournament through the composed epoch (Cycle-720's gated
+   next step, now unblocked at this resolution).
+2. Cycle-719 W1 leg: wrap the five-M2 refusal primitive around every
+   controller macro.
+3. Local Gauss/charge-sector route toward autonomous sector enforcement.
+4. A public immutable factorization-object API (new module, not an edit of
+   landed Cycle-720 files) to open the V_s-restriction compiler.
+
+## Session/worker provenance
+
+Supervisor: physics-loop session under the workhorse split; workers:
+codex gpt-5.6-sol at xhigh (owner-directed this session). Extraction
+deliverables and worker specs are in this pack and the session scratchpad.
+Review-loop and audit lanes are owner-operated; this block hands off at the
+PR surface.

--- a/.claude/science/physics-loops/computation-connection-20260727/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/NO_GO_LEDGER.md
@@ -1,0 +1,59 @@
+# No-go ledger — computation-connection-20260727
+
+Read from the primary notes, not headlines. None of the entries below is a
+theorem-level no-go against any Cycle-721 route.
+
+## 1. Cycle 720 raw-mode Bell diagnostic (NOT a no-go)
+
+- Source: docs/RECURRENT_COMPANION_PHYSICAL_M2_UPDATE_LOCAL_CHOI_PREPARATION_CYCLE720_BOUNDED_THEOREM_NOTE_2026-07-27.md
+  (Live-input boundary; No-go discipline N1-N8). Authority none, audit unset.
+- Exact quantified scope: the one submitted frozen route — root at maximum
+  cell, axis order `(2,1,0)`, raw-X/Jordan-Wigner cleanup word — misses the
+  preregistered two-cell, diameter-one correction gate on the held `5x3x2`
+  box (measured max support seven cells, graph diameter four). Gate FAIL for
+  every stronger impossibility statement; ships as a diagnostic
+  falsification of that one frozen route only.
+- Supplied premises it leans on: the frozen mode tree/root/order and the
+  unminimized correction representative.
+- Named live routes (verbatim status from the note's N1 table):
+  1. re-root/reorder the raw mode tree — `UNTESTED/OPEN`;
+  2. minimize modulo gauge and center rows (coset solve) — `UNTESTED/OPEN`;
+  3. replace raw-mode Bell rows by even-CAR characters — `ATTEMPTED`,
+     constructive counter-route, succeeded with one-cell corrections;
+  4. direct encoded-input Clifford — `UNTESTED/OPEN`;
+  5. local auxiliary parity rail or gauge teleportation — `UNTESTED/OPEN`;
+  6. sector-summed or dissipative center handling — `UNTESTED/OPEN`.
+- Consequence for Cycle 721: routes F1 (builds on 3) and F2 (attempts 4) are
+  live by the note's own accounting. F1/F2 must keep the preregistered
+  two-cell/diameter-one gate as the pass criterion.
+
+## 2. Cycle 719 six-family N1 table (all partial positives)
+
+- Source: docs/RECURRENT_MATTER_HISTORY_CONTROLLER_CYCLE719_BOUNDED_THEOREM_NOTE_2026-07-26.md (N1).
+- All six constructive families are `ATTEMPTED, partial positive`; each FAIL
+  reads "does not close the full autonomous compiler," never "impossible."
+- W1-W7 residual classes are accounting categories with no independence
+  theorem; do not cite them as independent walls.
+
+## 3. Cycle 703 route failures (escaped)
+
+- Per Cycle 720 N8: Cycle 703 recorded direct and finite-dictionary route
+  failures later escaped by local gauge, plaquette, or representation
+  changes; its own N8 forbids broad inference. Mechanism-change escape is the
+  operative pattern for this campaign.
+
+## 4. teleportation-acceptance-suite ledger
+
+- Per Cycle 720 N8: that pack's NO_GO_LEDGER records no theorem-level no-go
+  and a direct repair path. (Pack contents re-checked this campaign via the
+  grounding sweep.)
+
+## 5. Cycle 54 schedule-safety caution (design constraint, not a wall)
+
+- AUXILIARY_PAIR_COMPLETION_GATE_CYCLE54_NOTE_2026-07-14.md:229-241, older
+  rule-graph surface: three of four terminals corrupted a future site with
+  zero output conflicts — "collision-free signature tables do not imply
+  schedule-safe composition."
+- Adopted requirement for Route F3: explicit per-station register-liveness
+  accounting over the composed epoch (prepare/couple/correct/update), not
+  static signature disjointness.

--- a/.claude/science/physics-loops/computation-connection-20260727/OPPORTUNITY_QUEUE.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/OPPORTUNITY_QUEUE.md
@@ -1,0 +1,17 @@
+# Opportunity queue — computation-connection-20260727
+
+Ranked by retained-positive probability, missing-import count,
+runner availability, review landability, blast radius, independence.
+
+| rank | opportunity | why | status |
+|---|---|---|---|
+| 1 | Cycle 721 tournament (block01): F1 CAR-BELL-M2 + F2 ENC-CLIFFORD + F3 EPOCH-SCHEDULE | declared next decisive experiment; constructive base already landed | CLOSED (block01, all three routes positive; PR prepared) |
+| 2 | **Block02 = Cycle 722**: feed the unchanged Cycle-612 endpoint/interval harness and the coherent source-lift tournament through the composed epoch toward the repo-side response/prediction chain | the Cycle-720 gate is now satisfied at block01's resolution; this is the campaign's named "computation side connection ... upward to the repo side science" step; no refit permitted | ACTIVE (next) |
+| 3 | Cycle-719 W1 leg: wrap the five-M2 refusal primitive around every actual controller macro (local one-token/clean-work sector enforcement) | named in Cycle-719 N6 as "the strongest next closure"; refusal primitive already exact 16/16 | queued |
+| 4 | Local Gauss/charge-sector construction feeding W1 (Cycle-703 local-Gauss reference note has positive bounded constraint capacity) | steelman-endorsed route (Cycle 719 N7); mechanism change, not re-walk | queued |
+| 5 | Public immutable factorization-object API in a NEW module to open the V_s-restriction compiler | reopen condition named in block01; measured locality ceiling recorded | queued |
+| 6 | Raw-Bell coset-minimization diagnostic (N1 escape 2) | sharpens the Cycle-720 diagnostic; negative outcome must pass N1-N8 | queued |
+| 7 | Boundary-free paired-excitation controller route (W2) | named live in Cycle 719 N6; higher risk; needs new mechanism | queued |
+
+Refresh required at every block closure and before any campaign stop.
+Refreshed at block01 closure (~00:45 local 2026-07-28).

--- a/.claude/science/physics-loops/computation-connection-20260727/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/REVIEW_HISTORY.md
@@ -1,0 +1,76 @@
+# Review history — block01 (Cycle 721)
+
+## Supervisor review log
+
+- Extraction pass: three worker extracts (Bell surface; site-map/recurrent;
+  geometry/factorization) spot-verified against source line ranges before
+  use (B:84-233 verified verbatim; adversary blocklist and cache mechanics
+  read directly; landed even-CAR runner re-executed clean).
+- F2 draft: two spec-level defects found by the worker's honest failures and
+  fixed under supervisor edits + one sol-xhigh fix pass — (i) covariance
+  must evaluate the transported port (lexicographic-minimum is a chart
+  convention; demoted to an informational counter); (ii) the 3-CNOT-SWAP
+  reversal control is palindromic (replaced by middle-CNOT flip +
+  stray-primitive detection). Chart-family lesson: the 11-generator
+  adjacent-pair basis is a JW path chart; covariant objects are dictionary
+  families + fixture-derived seam orientation classes. Supervisor reviewed
+  the full algebra core line-by-line (phase conventions re-derived
+  independently) and the covariance rewrite. Final: 22/22 PASS, exit 0,
+  supervisor-rerun verified.
+- F1 draft: first draft honestly FAILED; diagnosed (i) dilation-direction
+  spec error (H-CP-H fixes X_a, transports Z_a -> Z_a R — supervisor
+  re-derived and corrected the spec), (ii) bare-JW input bank drags global
+  strings (16 cells / diameter 7) — physics fix: companion-encoded bank,
+  (iii) covariance chart-family objects, (iv) route-tuple semantics.
+  Revision pass returned 9/10; the last failure (layer constancy) was a
+  wrongly-posed check: supervisor re-posed it as the structural law
+  measurement layers = 3 + maximum cell degree (Koenig bound) with interior
+  saturation certified by adding the (4,4,4) box; correction layers
+  constant at 11 from 3x2x2. Final: 10/10 PASS, exit 0, supervisor-rerun
+  verified; core construction functions reviewed (consistency anchors:
+  tag-rebuild equality + coarse-half/target binary equality).
+- F3 + independent checker: see below when landed.
+
+## Promotion Value Gate (V1-V5, written record)
+
+The block proposes bounded_theorem status only (no retained-positive
+movement), so the gate is answered for the PR record:
+
+- V1 (specific obstruction closed): quoted from the Cycle-720 note's Open
+  list — "a literal physical-M2 circuit for the input-side even-CAR Bell
+  measurements; a collision-free composition of Choi preparation, Bell
+  coupling, correction controller, and recurrent matter word on one literal
+  site map" — and from its receipt boundary,
+  `even_car_input_bell_measurement_physical_M2_compiled: false`. Routes 1
+  and 3 retire exactly these two items at the bounded ceiling; Route 2
+  moves N1 escape route 4 (direct encoded-input Clifford) from
+  UNTESTED/OPEN to ATTEMPTED-constructive.
+- V2 (new derivation + novelty search): the compiled dilation surface,
+  the conflict-coloring law (3 + max cell degree with Koenig saturation),
+  the port-local seam-coupling result, and the epoch liveness walk exist
+  nowhere on origin/main. Prior-art sweep recorded in ROUTE_PORTFOLIO.md:
+  commit 2f2f4878ca, searches S1-S8 with matched-hit classification — the
+  only occurrences of "input-coupling circuit" / "encoded-input Clifford"
+  on origin/main are the Cycle-720 note's own open/untested declarations.
+- V3 (could the audit lane already do it from standard machinery?): no —
+  the content is the literal construction on the companion code (site-map
+  compilation, atlas one-hot duality, fixture-derived orientation classes),
+  not a textbook identity; the audit lane has no compiled measurement
+  surface for this code.
+- V4 (non-trivial marginal content): yes — the compiled words flip a
+  declared receipt flag under a preregistered support gate that the
+  raw-mode route measurably fails (7 cells / diameter 4, Cycle 720), and
+  the seam coupling collapsing to one cell is a structural discovery about
+  the companion representation.
+- V5 (one-step variant of a landed cycle?): no — closest prior work is
+  Cycle 720 itself, which certified the Bell rows as CAR-domain operations
+  but explicitly did not compile them ("naming the route is not an
+  attempt"); Cycle 146/147's record machines compile Pauli measurement
+  choices on a different code with no CAR/companion structure and no
+  site-map composition (classified nonmatching in the sweep). origin/main
+  re-checked at 2f2f4878ca.
+
+## Review-loop disposition
+
+Owner-operated lane (standing rule 2026-06-11): this block prepares the PR
+and hands off; the review loop is not run from this session.

--- a/.claude/science/physics-loops/computation-connection-20260727/ROUTE_PORTFOLIO.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/ROUTE_PORTFOLIO.md
@@ -1,0 +1,53 @@
+# Route portfolio — Cycle 721 (block01)
+
+## Prior-art sweep record (skill step 2)
+
+- Searched commit: `2f2f4878ca8676d963e80b33e697e76825614de0` (origin/main,
+  refreshed 2026-07-27 ~21:50 local, after the record-campaign/N5/compute
+  landings of 2026-07-27).
+- Commands and hits:
+  - S1 title scan `git ls-tree ... docs/ | grep -iE "INPUT_COUPLING|ENCODED_INPUT|EPOCH|LIVE_INPUT|BELL.*(M2|INPUT)|INPUT.*BELL"`
+    -> zero hits.
+  - S2 `git grep -iE "input.coupling circuit" origin/main -- 'docs/*.md'`
+    -> only the Cycle-720 note (3 hits) — the open declaration itself.
+  - S3 encoded-input Clifford (both orders) -> only Cycle-720 note lines
+    345/408/449: `UNTESTED/OPEN`, "naming the route is not an attempt".
+  - S4 collision-free schedule/epoch -> two context-only hits:
+    - `AUXILIARY_PAIR_COMPLETION_GATE_CYCLE54_NOTE_2026-07-14.md:235` —
+      caution "collision-free signature tables do not imply schedule-safe
+      composition" (older rule-graph nucleation surface; NOT the companion
+      code; classified nonmatching prior art, adopted as a design
+      constraint for Route F3).
+    - `CYCLE80_RECURRENCE_AUDIT_ENDPOINT_TUBE_NUCLEATION_CYCLE85_NOTE_2026-07-14.md:27`
+      — collision-free composition of tube-recurrence tables (older
+      endpoint-tube surface; nonmatching).
+  - S5 bell measurement/M2 compile statements outside Cycles 719/720 ->
+    zero hits.
+  - S6 runner-name scan cycles 656-729 for input/bell/clifford/schedule ->
+    `frontier_cycle709_local_seam_clifford*` (seam Clifford on the earlier
+    surface — adjacent machinery, not input coupling) plus the known
+    Cycle-720 runners.
+  - S7 obligations/ledger scan `companion.*(input|bell)` -> four old
+    unrelated ledger rows (axiom_first_spectrum, ckm, dm_*) — nonmatching.
+  - S8 "input hardware / measurement compilation" -> Cycle-146/147 record
+    machines compile Pauli measurement *choices* on the record-machine
+    surface (different code, no CAR/companion, no site-map composition);
+    Cycle-703 plaquette decoder is adjacent controller machinery. Both
+    nonmatching for the Cycle-721 statement.
+- Classification: **Open after matched-hit review** for all three routes.
+  No landed note proves or refutes a literal M2 input-Bell compilation, an
+  encoded-input Clifford on the companion/center code, or a collision-free
+  epoch composition on the Cycle-720 site map.
+
+## Routes (artifact types; approach families in APPROACH_REGISTRY.md)
+
+| route | artifact | expected movement | score notes |
+|---|---|---|---|
+| F1 CAR-BELL-M2 | runner + note section | retires Cycle-720 Open item 1 (literal physical-M2 circuit for input-side even-CAR Bell measurements) at bounded_theorem ceiling | strongest: Cycle 720 already certified the Bell rows as bounded CAR-domain operations with one-cell private duals; compilation is the declared missing leg |
+| F2 ENC-CLIFFORD | runner + note section | independent constructive escape of the raw-Bell diagnostic; second tournament leg | medium: no prior attempt exists (N1 row `UNTESTED/OPEN`); risk that the input-side M2 assignment reintroduces JW growth |
+| F3 EPOCH-SCHEDULE | runner + note section | retires Cycle-720 Open item 2 (collision-free composition of preparation/Bell/corrections/recurrent G on one site map) | gated on F1 or F2 supplying the input leg; must do register-liveness accounting per the Cycle-54 caution, not signature tables |
+
+Tournament shape per the Cycle-720 verdict: all three attempted; each leg
+reports its own PASS/FAIL against the preregistered support/diameter gate;
+failures ship as route-specific diagnostics only (N1-N8 gated), never as
+broader negatives.

--- a/.claude/science/physics-loops/computation-connection-20260727/SPEC_F1_CAR_BELL_M2.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/SPEC_F1_CAR_BELL_M2.md
@@ -1,0 +1,67 @@
+# Spec F1 — literal M2 compilation of the even-CAR Bell input rows
+
+Runner: `scripts/frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.py`
+Cache:  `logs/runner-cache/frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.txt`
+
+## Claim being constructed (bounded, conditional on the Cycle-720 supplies)
+
+On the declared companion subsystem code, every row of the doubled even-CAR
+Bell measurement family (onsite parities, onsite adjacent-Majorana pairs, one
+oriented nearest-neighbor seam row per edge) is compiled into a literal
+physical-M2 measurement word on the same site map as the prepared Choi
+resource and the recurrent update, such that:
+
+1. each compiled word = (route-in; ancilla-controlled character word;
+   basis rotation; route-return), decomposed into one- and two-M2 primitives
+   with nearest-neighbor routing and returned routing work;
+2. the measurement outcome lands in a dedicated retained syndrome M2 —
+   no reset, no postselection, no dissipative erasure;
+3. the physical correction generators remain the Cycle-720 one-cell private
+   duals: compiled correction support <= 2 cells and graph diameter <= 1
+   (the preregistered gate), measured over EVERY row on every tested box;
+4. measurement words that share support are scheduled in explicit conflict
+   layers; report the layer count against the Cycle-720 counts
+   (4 measurement layers, <= 11 correction layers) honestly;
+5. exactness: on exact small sector matrices (two- and three-mode families,
+   as in Cycle 720), the compiled word implements the intended character
+   measurement instrument exactly (residual at machine scale); on full
+   boxes, tableau-level verification over the whole doubled row family
+   (exhaustive over rows — no sampling);
+6. box ladder: 2x2x2 and 3x2x2 fully; held non-collinear 5x3x2; larger
+   boxes only as reuse controls if runtime allows;
+7. signed covariance: the compiled words, schedules, ancilla assignments,
+   and routes transport under all 24 proper-cubic frames, 576 ordered
+   products, and the eight coframe-origin sectors with zero
+   tableau/stabilizer/schedule-key/returned-route failures;
+8. controls: (a) deleting one private dual leaves unit sign residual;
+   (b) hostile reordering of a conflict layer produces a nonzero named
+   residual; (c) an unlawful odd character is detected and refused;
+   (d) fixtures free/seam/reverse/contact/FSWAP/mass rerun unchanged.
+
+## Honest boundary (print in the runner header and cache)
+
+- All ordinals are circuit structure; nothing is a clock/time/rate/energy.
+- Fixed parity/center sector, mixed gauge reference, coframe sector, finite
+  box/root/router, clean ancilla banks, and one-time epoch remain SUPPLIED.
+- This is state-level input coupling on the declared code; no matter/FTL/
+  mass/charge transfer claim (harness-index HOLD honored).
+- A PASS here is the "literal physical-M2 circuit for the input-side
+  even-CAR Bell measurements" leg only; autonomy/genesis/sector-law remain
+  open.
+
+## Representation requirements (fill from EXTRACT_BELL_SURFACE.md and
+EXTRACT_SITEMAP_RECURRENT.md; reuse conventions verbatim)
+
+- fixture/site-map constructor, register indexing, companion representation;
+- Pauli row encoding (integer bitmasks), symplectic form, sign bookkeeping;
+- atlas key format and lookup; conflict-layer coloring function;
+- routing word builder + route-return + distance census;
+- covariance harness enumeration and comparison points;
+- print/cache line conventions and receipt field production.
+
+## Failure honesty
+
+If any row on any tested box exceeds the support/diameter gate, the runner
+prints the exact census (per-row support cells, diameter, box) and the
+overall named check FAILS; the note then ships that leg as a route-specific
+diagnostic under N1-N8 with the frozen route named. No silent narrowing.

--- a/.claude/science/physics-loops/computation-connection-20260727/SPEC_F2_ENC_CLIFFORD.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/SPEC_F2_ENC_CLIFFORD.md
@@ -1,0 +1,55 @@
+# Spec F2 — direct local encoded-input Clifford on the companion/center code
+
+Runner: `scripts/frontier_cycle721_encoded_input_clifford_compiler_2026_07_28.py`
+Cache:  `logs/runner-cache/frontier_cycle721_encoded_input_clifford_compiler_2026_07_28.txt`
+
+## Claim being constructed (bounded, conditional on the Cycle-720 supplies)
+
+A live even-CAR input presented on a dedicated input register bank at a
+declared port cell is coupled into the companion/center code by a literal
+bounded local Clifford word — no Bell measurement, no teleportation
+corrections — such that:
+
+1. the input bank carries the doubled image of one cell's even-CAR
+   subalgebra in the same companion representation as the code (input-side
+   M2 assignment is explicit and lives on the same site map, adjacent to
+   the port cell);
+2. an explicit Clifford intertwiner word V_port maps every input even-CAR
+   generator (onsite parities, adjacent-Majorana pairs of the port cell)
+   onto the corresponding encoded code generator, exactly, verified at
+   tableau level for ALL generators (exhaustive) and on exact two-/
+   three-mode sector matrices at machine residual;
+3. V_port is compiled into one- and two-M2 primitives with nearest-neighbor
+   routing and returned work; its total support is a fixed neighborhood of
+   the port cell: support <= 2 cells, graph diameter <= 1 (same
+   preregistered gate as F1) — the point of the route is that the companion
+   representation removes any Jordan-Wigner cleanup growth, so measure and
+   report the support census explicitly on every tested box;
+4. after coupling, one application of the recurrent update word G acts on
+   the encoded input exactly as the intended logical word (verify on the
+   held small-box exact matrices; tableau-level on larger boxes);
+5. sector discipline: the coupling preserves the fixed total-parity label
+   and center signs; an unlawful odd input operator is refused/detected
+   (control), not silently absorbed;
+6. box ladder, covariance (24 x 576 x 8), deletion control (delete one
+   primitive of V_port -> named nonzero residual/stabilizer mismatch),
+   hostile-order control, and unchanged fixtures — all as in SPEC_F1.
+
+## Honest boundary
+
+- Same supplied inventory and prose boundaries as SPEC_F1 (no clock/time
+  language; no matter/FTL/mass/charge transfer; state-level coupling only).
+- The input bank's cleanliness and the port choice remain SUPPLIED; no
+  autonomous input genesis is claimed.
+- A PASS is an independent constructive escape of the raw-Bell diagnostic
+  (Cycle-720 N1 route 4 moves UNTESTED/OPEN -> ATTEMPTED, constructive).
+- A FAIL ships as a route-specific diagnostic (the exact compiled word and
+  its measured support census) under N1-N8; it does not echo into any
+  broader negative.
+
+## Representation requirements
+
+Same extraction sources and conventions as SPEC_F1. The intertwiner
+construction should reuse the code's own encoding tableau (from the
+mixed-gauge factorization V_s if exposed by the extracts) restricted to the
+port cell, rather than inventing a new encoding.

--- a/.claude/science/physics-loops/computation-connection-20260727/SPEC_F3_EPOCH_SCHEDULE.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/SPEC_F3_EPOCH_SCHEDULE.md
@@ -1,0 +1,67 @@
+# Spec F3 — collision-free epoch composition on one literal site map
+
+Runner: `scripts/frontier_cycle721_collision_free_epoch_composition_2026_07_28.py`
+Cache:  `logs/runner-cache/frontier_cycle721_collision_free_epoch_composition_2026_07_28.txt`
+
+## Claim being constructed (bounded, conditional on the Cycle-720 supplies)
+
+On one literal site map (the Cycle-720 union boxes), the four stages
+
+  (A) local Choi pump preparation (tree word + plaquette words),
+  (B) input Bell coupling (the F1 compiled measurement words; or the F2
+      Clifford word as declared alternate input leg),
+  (C) retained correction-bank application (private-dual corrections
+      conditioned on retained syndrome registers, as controlled words),
+  (D) the recurrent matter word G_physical,
+
+compose into a single explicitly scheduled epoch word such that:
+
+1. GLOBAL REGISTER-LIVENESS TABLE: every physical M2 register carries an
+   explicit liveness interval per schedule slot (owner stage, role:
+   data/ancilla/syndrome/route-rail); the runner verifies ZERO collisions —
+   no register is claimed by two stages in the same slot, and every
+   cross-stage handoff (e.g. syndrome written by B, read by C) is an
+   explicit ordered edge. Per the Cycle-54 caution, this is schedule-time
+   state accounting, NOT static signature disjointness: the checker walks
+   the composed schedule slot-by-slot and tracks register state
+   (clean/live/retained-dirty) with a named failure for any premature
+   write to a register whose consumer has not yet fired.
+2. All stage-internal routing words retain their returned-work property
+   through composition (route rails freed between stages only via explicit
+   return words; census reported).
+3. End-to-end algebra: on the held small boxes with exact sector matrices,
+   the composed epoch equals the intended composite channel
+   (prepare; couple; correct; update) exactly — residual at machine scale —
+   and the composite intertwines with the coarse logical word
+   (E_channel G_coarse = G_physical E_channel extended through the epoch).
+   On larger boxes, tableau-level verification, exhaustive over the
+   stabilizer/row families (no sampling).
+4. The epoch schedule is a fixed finite table (explicit slot list in the
+   cache); no runtime global queries; ordinals are circuit structure only.
+5. Deletion controls: deleting one handoff edge, one correction bank entry,
+   or one return word each produces a named nonzero residual / dirty
+   register census. Hostile stage-interleave control produces a named
+   failure.
+6. Box ladder, signed covariance of the entire composed schedule
+   (24 x 576 x 8; schedule keys transported), unchanged fixtures.
+
+## Honest boundary
+
+- The one-time epoch, clean initial banks, sector labels, root/router, and
+  program content remain SUPPLIED; no renewal, multi-source composition,
+  autonomous genesis, or boundary-free law is claimed (those stay in the
+  Cycle-720 Open list).
+- A PASS retires exactly "a collision-free composition of Choi preparation,
+  Bell coupling, correction controller, and recurrent matter word on one
+  literal site map" at bounded_theorem ceiling, nothing more.
+- Same prose boundaries as SPEC_F1/F2.
+
+## Dependency
+
+Stage B consumes the F1 (primary) or F2 (alternate) compiled words via
+their in-repo constructors — F3's runner may import nothing from other
+runners at runtime if the campaign convention is self-containedness; in
+that case it re-instantiates the constructions per the extracts and pins
+byte-equality of shared construction code blocks by SHA-256 in the cache.
+Decide per the extract's import-graph finding and record the choice in the
+cache header.

--- a/.claude/science/physics-loops/computation-connection-20260727/STATE.yaml
+++ b/.claude/science/physics-loops/computation-connection-20260727/STATE.yaml
@@ -1,0 +1,107 @@
+loop: computation-connection-20260727
+goal: >
+  Continue the computation-connection campaign (axioms upward to repo-side
+  science) from landed Cycle 720. Block 01 target: Cycle 721 three-route
+  literal physical-input and epoch-integration tournament declared in
+  docs/RECURRENT_COMPANION_PHYSICAL_M2_UPDATE_LOCAL_CHOI_PREPARATION_CYCLE720_BOUNDED_THEOREM_NOTE_2026-07-27.md
+  (Verdict and next experiment section).
+mode: campaign
+runtime: 12h
+started: "2026-07-27T21:37:28-04:00"
+target_stop: "2026-07-28T09:37:00-04:00"
+checkpoint_interval: 30m
+target_status: best-honest-status
+skill_freshness: >
+  docs/ai_methodology/skills/physics-loop/SKILL.md read at origin/main
+  9ce38a06db4a; origin/main advanced to 2f2f4878ca during preflight; delta
+  re-checked before execution.
+block: "01"
+branch: physics-loop/computation-connection-block01-20260727
+base_commit: 2f2f4878ca8676d963e80b33e697e76825614de0
+lock: >
+  repo automation_lock.py UNAVAILABLE on this machine (Permission denied:
+  /Users/jonreilly -- lock path points at a different user home). Running
+  under branch-local supervisor lock in an independent session worktree per
+  long-running-execution.md preflight step 7. Concurrent owner automation
+  observed and non-overlapping: cl3-* worktrees (frontier certificates, N5
+  certificates), wf_* locked review worktrees (PRs 5606/5610/5694), poisson
+  PRs 5693/5695. No open PR or branch touches Cycle 721 or the
+  recurrent-companion lane.
+active_route: cycle721-three-route-physical-input-epoch-tournament
+cycle: 721
+approach_families: see APPROACH_REGISTRY.md
+strongest_unresolved_obligation: >
+  literal physical-M2 circuit for the input-side even-CAR Bell measurements
+  composing collision-free with Choi preparation, correction banks, and
+  recurrent G on one site map (Cycle 720 note, Open list, items 1-2).
+hard_residual: same as strongest_unresolved_obligation
+files_touched:
+  - .claude/science/physics-loops/computation-connection-20260727/ (pack: STATE/GOAL/SUPERVISOR_LOCK/ROUTE_PORTFOLIO/NO_GO_LEDGER/ASSUMPTIONS_AND_IMPORTS/APPROACH_REGISTRY/TRACE_GATE/OPPORTUNITY_QUEUE/SPEC_F1/SPEC_F2/SPEC_F3)
+open_imports: none (see ASSUMPTIONS_AND_IMPORTS.md — zero external imports; prior cycles pinned as bounded authority)
+no_go_routes: see NO_GO_LEDGER.md
+trace_class: direct_blocker_closure (targets quoted Cycle-720 open items)
+review_findings: none yet
+pr_status: none yet
+checkpoint_2150: >
+  Grounding + prior-art sweep complete at origin/main 2f2f4878ca (targets
+  OPEN; sweep recorded in ROUTE_PORTFOLIO.md). Ledgers + three route specs
+  written. Extraction workers A/B/C completed; deliverables
+  EXTRACT_BELL_SURFACE.md + EXTRACT_SITEMAP_RECURRENT.md +
+  EXTRACT_GEOMETRY_FACTORIZATION.md verified by supervisor spot-checks
+  (B source lines 84-233 match extract A; adversary blocklist pattern
+  confirmed; runner_cache mechanics mapped; landed even-CAR runner
+  re-executed clean in this worktree, exit 0, PASS).
+checkpoint_2205: >
+  Key design facts locked: (1) pump already carries the ancilla-dilation
+  measurement pattern (H; controlled-row on returned NN route; H; retained
+  syndrome bank) — F1 extends it to the doubled Bell rows with a live-input
+  bank at [q, q+m) and one ancilla per row; (2) factorization module
+  discards V_s (no public tableau API) — F2 redesigned as one-cell
+  even-exchange port (support 1 cell) + transvection-synthesized
+  seam-extended coupling (gate-critical census) + F.phase_fixed_factorization
+  regression anchor + coordinate-row locality census; V_s-restriction
+  compilation stays UNTESTED/OPEN (reopen condition: a new-module
+  factorization-object API in a future cycle); (3) onsite even-CAR is
+  represented identically (physical == target) — only seams are nontrivial;
+  (4) no collision machinery exists anywhere — F3 must define schedule keys
+  over global register IDs + slot-walk liveness (Cycle-54 caution).
+  F1 draft worker (car_bell_input_m2_compiler) and F2 draft worker
+  (encoded_input_clifford_port) launched in background under the workhorse
+  split. F3 spec waits for F1's interface; independent checker after.
+checkpoint_2250: >
+  F2 (encoded_input_clifford_port) COMPLETE: all 22 checks PASS, exit 0,
+  supervisor-verified rerun. Findings: (a) the even-exchange port is exact
+  on the full 36-row port dictionary; (b) the seam-extended coupling
+  synthesized PORT-LOCAL (support 1 cell, diameter 0 — beats the <=2/<=1
+  gate; the companion representation leaves nothing cross-cell to correct);
+  (c) covariance holds as dictionary-family multisets + seam orientation
+  classes over 24 frames x 8 parities (the 11-generator adjacent-pair basis
+  is a JW-path chart, NOT frame-covariant — layer-1 lesson recorded);
+  (d) V_s-restriction compilation stays UNTESTED/OPEN (no public
+  factorization-object API; reopen condition named). Supervisor reviewed
+  the full algebra core line-by-line (phase conventions re-derived) and the
+  covariance rewrite. F1 first draft honestly FAILED for diagnosed reasons:
+  spec-side dilation-direction error (H-CP-H fixes X_a, maps Z_a -> Z_a R);
+  bare-JW input bank dragged global strings (16 cells / diameter 7) —
+  physics fix: companion-encoded input bank; covariance chart-family fix;
+  route-tuple semantics. F1 revision worker running (sol xhigh, per owner
+  directive this session). F3 spec written, launches after F1.
+checkpoint_0010: >
+  F1 COMPLETE (10/10 PASS; companion-encoded bank; dilation identities
+  corrected; layer law "3 + max cell degree" certified with interior
+  saturation via added (4,4,4); gate met on all six boxes to 995 rows;
+  supervisor rerun + core review done). F3 COMPLETE (6/6 PASS both input
+  legs; site-addressed G instructions introspected and mapped;
+  Cycle-54-compliant liveness walk clean at 76k slots/159k touches;
+  supervisor rerun + namespace/walk review done; audit header added by
+  supervisor post-hoc, syntax checked). Note drafted with F1/F2/F3 sections
+  filled; CLAIM_STATUS_CERTIFICATE + REVIEW_HISTORY (incl. V1-V5 record)
+  written; receipt builder staged. Independent adversary checker drafting
+  (sol xhigh, blocklists the three 721 primaries).
+next_action: >
+  On checker completion: supervisor review + rerun; fill note checker
+  section + verdict; refresh runner caches via
+  runner_cache.execute_and_write_cache for the four runners; run receipt
+  builder; vocab lint; commit; push; open PR block01; then refresh
+  OPPORTUNITY_QUEUE and continue the campaign.
+stop_condition: runtime exhaustion ~2026-07-28T09:37 local, or global queue exhaustion per skill

--- a/.claude/science/physics-loops/computation-connection-20260727/SUPERVISOR_LOCK.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/SUPERVISOR_LOCK.md
@@ -1,0 +1,20 @@
+# Branch-local supervisor lock — computation-connection-20260727
+
+- Holder: physics-loop supervisor session (Claude), block01 branch
+  `physics-loop/computation-connection-block01-20260727`, independent
+  worktree `.claude/worktrees/cleanup-local-worktrees-5f598b`.
+- Acquired: 2026-07-27T21:50 local. TTL: campaign end (~2026-07-28T09:37).
+- Reason for branch-local mode: `python3 scripts/automation_lock.py status`
+  and `acquire` both fail on this machine with
+  `[Errno 13] Permission denied: '/Users/jonreilly'` (lock path resolves to
+  a different user's home). Recorded per
+  physics-loop references/long-running-execution.md preflight step 7.
+- Non-overlap survey at acquisition: owner automation active on
+  frontier-certificate repair (cl3-compute-exceptions-20260727),
+  N5 certificates (cl3-n5-certificates-even-20260727), record-campaign
+  review worktrees (wf_7bbd095a: rl-5610-integrate, narrow-5606,
+  review-5694), poisson lanes (PRs #5693, #5695). None touch Cycle 721,
+  the recurrent-companion lane, or `frontier_cycle72*` artifact names.
+- Claimed scope: Cycle 721+ artifacts in the computation-connection lane
+  (`frontier_cycle721_*` and successors this campaign), this pack dir, and
+  the block branches `physics-loop/computation-connection-block*-2026072*`.

--- a/.claude/science/physics-loops/computation-connection-20260727/TRACE_GATE.md
+++ b/.claude/science/physics-loops/computation-connection-20260727/TRACE_GATE.md
@@ -1,0 +1,34 @@
+# Trace gate — Cycle 721 (block01)
+
+```yaml
+trace_class: direct_blocker_closure
+target_claim_id: null
+target_blocker_text: >
+  "a literal physical-M2 circuit for the input-side even-CAR Bell
+  measurements; a collision-free composition of Choi preparation, Bell
+  coupling, correction controller, and recurrent matter word on one literal
+  site map"
+source_of_blocker_text: handoff
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: >
+  If the tournament passes its preregistered gate, feed the unchanged
+  Cycle-612 endpoint/interval harness and the coherent source-lift
+  tournament toward the repo-side response/prediction chain (Cycle-720
+  verdict, final paragraph). If a leg fails its gate, ship that leg as a
+  route-specific diagnostic (N1-N8 gated) and keep the other legs.
+```
+
+Notes:
+- The blocker text is quoted verbatim from the Cycle-720 note's Open list
+  (items 1-2); the note is the prior block's handoff surface for this
+  campaign. No audit-ledger claim id exists for this unregistered frontier
+  lane (grounding: LANE_REGISTRY/LANE_STATUS_BOARD contain no campaign
+  entries; that is expected and no registry row is added).
+- reachability is `partially_closes` because even a full tournament pass
+  leaves the remaining Open items (autonomous sector
+  preparation/enforcement, boundary-free genesis, periodic topology/fault
+  repair, occurrence/Record/Born/source meaning) untouched — those stay
+  supplied/open exactly as in Cycle 720.
+- Frontier-only framing ban honored: the artifact must not claim to close,
+  promote, or retire any registered lane.

--- a/docs/CAR_BELL_INPUT_PHYSICAL_M2_COMPILER_CYCLE721_BOUNDED_THEOREM_NOTE_2026-07-28.md
+++ b/docs/CAR_BELL_INPUT_PHYSICAL_M2_COMPILER_CYCLE721_BOUNDED_THEOREM_NOTE_2026-07-28.md
@@ -1,0 +1,379 @@
+# Cycle 721: literal physical-M2 input-Bell compiler, even-exchange port, and collision-free epoch composition
+
+Date: 2026-07-28
+
+Authority: none
+
+Audit: unset
+
+Status: bounded conditional construction
+
+Claim type: bounded_theorem
+
+Primary constructive runners:
+
+- [`frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.py`](../scripts/frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.py)
+- [`frontier_cycle721_encoded_input_clifford_port_2026_07_28.py`](../scripts/frontier_cycle721_encoded_input_clifford_port_2026_07_28.py)
+- [`frontier_cycle721_collision_free_epoch_composition_2026_07_28.py`](../scripts/frontier_cycle721_collision_free_epoch_composition_2026_07_28.py)
+
+Independent adversarial reconstruction:
+
+- [`frontier_cycle721_tournament_independent_adversary_2026_07_28.py`](../scripts/frontier_cycle721_tournament_independent_adversary_2026_07_28.py)
+
+Constitutional effect: none. This package changes no axiom, foundation,
+Qualification, primitive, registry, policy, queue, audit result, or audit
+status.
+
+All runner ordinals, gate words, schedule slots, and layer indices in this
+package are circuit structure. None is called physical time, duration, rate,
+or energy. All couplings are state-level on the declared code; no matter,
+FTL, mass, or charge transfer is claimed or implied.
+
+## Result up front
+
+Cycle 720 closed the recurrent companion update, the local Choi pump, and a
+fixed-sector CAR-domain live-input map, and declared as its next decisive
+experiment a three-route literal physical-input and epoch-integration
+tournament, leaving `input_Bell_measurement_physical_M2_compiled: false` in
+its receipt. Cycle 721 runs that tournament. All three routes close
+positively at the bounded ceiling, on the same supplied sector/genesis
+inventory as Cycle 720.
+
+**Route 1 — literal M2 compilation of the input-side even-CAR Bell
+measurements.** Every row of the doubled even-CAR Bell family — six onsite
+parities and five adjacent-Majorana pairs per cell plus one oriented seam row
+per nearest-neighbor edge, `11N+E` rows in the frozen
+`P.direct_graph_basis` order — is compiled into a literal physical word
+`H(ancilla); controlled-Pauli per supported M2; H(ancilla)` with one retained
+measurement ancilla per row at the row's anchor cell and nearest-neighbor
+returned routing. The live input is presented on a companion-encoded input
+bank (a full mirror of the physical register at `[q, 2q)`): the input-side
+image of each row is the same companion-represented physical row, so every
+compiled word has support at most two cells and graph diameter at most one —
+the preregistered Cycle-720 gate — on all six boxes
+
+| box | rows = 11N+E | max word support (cells/diameter) | max private-dual support |
+|---|---:|---:|---:|
+| `1x1x1` | 11 | 1 / 0 | 1 / 0 |
+| `2x2x2` | 100 | 2 / 1 | 1 / 0 |
+| `3x2x2` | 152 | 2 / 1 | 1 / 0 |
+| `5x3x2` | 389 | 2 / 1 | 1 / 0 |
+| `4x4x4` | 848 | 2 / 1 | 1 / 0 |
+| `5x5x3` | 995 | 2 / 1 | 1 / 0 |
+
+The compiled family is abelian and Hermitian with unchanged GF(2) rank
+(`11N+E` on every box). The dilation identities are exact and exhaustive: the
+retained ancilla's transported `Z` equals `Z(ancilla) * R_i` and its `X` is
+fixed, while every other measured row and every Choi graph row is invariant.
+Bell-branch corrections remain the frozen Cycle-720 one-cell private duals
+with one-hot syndrome duality, even kernel sums, and an active
+deleted-dual unit sign residual. The exact two- and three-mode fixed-sector
+CPTP certificates of Cycle 720 rerun unchanged. On this package's surface the
+Cycle-720 receipt flag `input_Bell_measurement_physical_M2_compiled` becomes
+**true** at the bounded ceiling.
+
+**Route 2 — direct local encoded-input Clifford port.** An 18-primitive
+one-cell word (six three-CNOT exchanges between a co-located six-M2 live bank
+and the port cell's matter modes) couples a live even-CAR input by reversible
+exchange: exact on the full 36-row port-cell dictionary in both directions,
+with exact joint-parity bookkeeping and odd-input detection. The
+seam-extended coupling word — synthesized by greedy symplectic transvections
+against the four seam bilinears of each incident edge — turns out to be
+**port-local as well**: support one cell, diameter zero, on every tested axis
+and box. In the companion representation the non-port endpoint factors of a
+seam bilinear are common to the bank-ended and matter-ended forms, so seam
+coupling leaves nothing cross-cell to correct. This is the constructive
+counterpoint, on the same code, to the Cycle-720 raw-mode diagnostic in which
+the frozen raw-X/Jordan-Wigner route reached seven support cells and graph
+diameter four on the held box.
+
+**Route 3 — collision-free epoch composition.** The four stages — local Choi
+pump preparation, input Bell coupling, retained correction banks, and the
+recurrent matter word `G` — compose into one explicitly scheduled epoch on
+one literal site map, in two declared variants: the primary leg couples the
+input through the Route-1 compiled Bell words, the alternate leg through the
+Route-2 exchange port. A global register table spans code, companion-encoded
+bank, routed-only `G` sites (discovered by introspecting the routed word's
+site-addressed instructions and mapped through the exact `U.placement`
+bijection), Bell ancillae, pump syndrome bank, pump Bell purifiers, the
+unchanged coframe surface, and one mobile rail per cell. A Cycle-54-style
+slot walk (clean, live-with-owner, retained; retained access requires an
+executed declared handoff) walks up to 76,376 slots and 159,219 register
+touches on the held `5x3x2` box with **zero** collisions, ownership
+violations, premature reads, or unconsumed handoffs, for both variants on
+every box. Staged-versus-flattened tableau action is exact for the
+preparation/coupling/correction stages on `1x1x1` and `2x2x2` with the `G`
+tail anchored by the unchanged imported Cycle-720 one-step certificate; the
+imported `3x2x2` recurrent one-step conjunction, the `2x2x2`
+orientation/interleave/deletion gates, the three mass/contact residuals, and
+the five Cycle-230 fixture residuals all rerun unchanged. Schedule-key and
+per-family census multisets transport exactly over all 24 frames and eight
+translation parities (192 contexts), with the four coframe-constraint
+failure fields zero. Deleted-handoff, deleted-return-word,
+stage-B-before-pump hostile interleave, and duplicate-owner controls are all
+detected.
+
+**Independent adversarial reconstruction.** The checker blocks runtime
+import of the three primary runners (transitive guard) and rebuilds the
+lower-level algebra from the Cycle-720 modules with its own independently
+written Clifford conjugation. It reports 6/6 PASS: the exchange-port
+dictionary, the dilation identities on an independently rebuilt
+companion-encoded row family, atlas one-hot duality with one-cell support,
+the seam orientation classes over all 24 frames and eight parities (2,304
+quadruples), an independently reconstructed epoch schedule with its own
+liveness walk (including detected fault injections), and the inherited
+fixture residuals plus a dense fixed-sector Kraus rebuild. Its dense
+self-test covers 8,208 comparisons with zero mismatches. Its one wording
+correction is adopted in the Route-3 section below.
+
+## Route 1: compiled measurement words
+
+The compiler consumes the Cycle-720 surface unchanged: fixtures from
+`O.arbitrary_fixture(Q.shape_cells(shape))`, the frozen `(graph, tags)` order
+of `P.direct_graph_basis`, targets from the even-CAR Bell runner's
+`target_rows`, the frozen private-dual atlas of `P.build_private_atlases`,
+and `P.returned_route` / `P.route_execution_failures` for rail accounting.
+Two consistency anchors bind the compiled family to the landed Choi surface
+exactly: the physical restriction of every graph row equals an independently
+rebuilt tag row, and the coarse-input half of every graph row equals its
+target row binarily, on every box with zero failures.
+
+The measured joint row is `R_i = canonical(physical_i * shift_q(physical_i))`
+— the code-side row times the same companion-represented row on the input
+bank. Ancillas live at `[2q, 2q + rows)`, one rail M2 per cell above them;
+route transitions are literal rail moves with returned work verified forward
+and inverse. Measurement outcomes stay in retained ancillae; no reset,
+postselection, or dissipative erasure appears anywhere in the package.
+
+The conflict-coloring census obeys an exact structural law on every box:
+
+```text
+measurement layers = 3 + (maximum cell degree)
+```
+
+three onsite layers from the Z/XX path coloring plus exactly one seam layer
+per unit of maximum cell degree — greedy first-fit attains the Koenig
+edge-coloring bound of the bipartite box graph in the emitted edge order.
+Measured: `3, 6, 7, 8, 9, 9` on the ladder above, saturating at nine on both
+interior-complete boxes (`4x4x4`, `5x5x3`). Correction coloring is constant
+at eleven from `3x2x2` on. Constancy across arbitrary boxes is not the
+covariant statement; the local incidence profile is.
+
+Compiled-schedule covariance is exact over all 24 proper-cubic frames and
+eight translation parities on `2x2x2` and `3x2x2` (384 contexts): signed and
+binary family multisets transport exactly for the onsite families, and every
+transported seam quadruple lands in one of the two fixture-derived
+orientation classes (3,072 forward and 3,072 reversed classes, zero
+failures), with census vectors invariant. The unchanged Cycle-720
+`V.frame_certificate` / `V.product_certificate` surfaces (24 frames, 576
+ordered products) retain zero named failures. The adjacent-pair generating
+set itself is a Jordan-Wigner path chart and is deliberately not compared as
+a set; the covariant objects are the dictionary families and orientation
+classes.
+
+Controls: deleting one private dual leaves a unit Bell sign residual;
+deleting the final return link breaks the forward returned-route walk and
+deleting the first link is detected as well; hostile ancilla pairing
+(measuring row `i` into row `j`'s ancilla) produces dilation failures; an
+unlawful odd input row is detected by the joint parity row. A dense
+`8x8` Clifford-conjugation self-test over all signed weight-one/two rows and
+all gate instances has zero mismatches.
+
+Supplied for this route, beyond the Cycle-720 inventory: the
+companion-encoded input bank convention — the live input is presented in the
+code's own companion representation. A bare global-Jordan-Wigner input
+register was considered at design time and rejected before certification
+because its seam characters drag global strings across the bank; that design
+history is recorded here as the reason for the supplied convention, not as a
+tested negative claim about any route.
+
+## Route 2: even-exchange port and seam coupling
+
+The port is the lexicographic-minimum cell as a supplied chart convention;
+covariance is evaluated at the transported image of the port, where signed
+and binary port-dictionary multisets, seam orientation classes, and census
+vectors are exact over all 24 frames and eight translation parities on both
+tested shapes (zero failures in every counter). The lexicographic-minimum
+default itself is not frame-covariant (168 of 192 contexts relocate it);
+that is chart bookkeeping, not a covariance failure.
+
+The mixed-gauge factorization anchors rerun exactly
+(`F.phase_fixed_factorization` on `2x2x2` and `3x2x2`: dimension identity,
+CPTP construction, factorwise intertwiner, and zero coordinate failures,
+tableau digests `e83b7b24...` and `10ec1180...`). Its own locality census
+reports the canonical tableau is **not** radius-two bounded on the tested
+boxes. That census is the measured ceiling for any future literal
+`V_s`-restriction input compiler; no such compiler is constructed here, and
+the factorization module exposes no public tableau/coordinate API. The
+`V_s`-restriction route therefore stays `UNTESTED/OPEN`, with the named
+reopen condition being a public immutable factorization-object API in a
+future cycle.
+
+Controls: single-CNOT deletion, a middle-CNOT direction flip (the literal
+reversal of a three-CNOT swap is palindromic and is reported as an identity,
+not a control), a stray appended primitive on the seam word, odd-input
+detection, and a wrong-port word are all detected.
+
+The exchange port consumes the cell's prior matter state reversibly into the
+retained bank; it is not the gauge-mixed logical injection `E_s`, which
+remains the Bell/Choi route of this same package.
+
+## Route 3: epoch composition
+
+The epoch schedule is a fixed finite slot table. Per-box slot counts for the
+four stages (primary variant, `A/B/C/D`): `1x1x1` 23/3/11/421; `2x2x2`
+225/9/112/17,304; `3x2x2` 345/11/172/26,940; `5x3x2` 897/13/448/75,018. The
+alternate variant replaces stage B by the 18-primitive port word
+(`23-897/18/0/...` — the exchange port needs no correction stage). Stage-D
+counts are the unchanged routed nearest-neighbor primitive counts of the
+Cycle-720 recurrent word.
+
+The two input legs use one bank namespace with a checker-supplied
+qualifier: standalone Route 2 declares a six-M2 port bank at `[q, q+6)`,
+while the composed epoch embeds a port-indexed six-qubit block inside the
+Route-1 companion-encoded bank `[q, 2q)`; the two coincide only at port
+index zero.
+
+The `G` word's instructions are site-coordinate-addressed; the namespace
+builder verifies `U.placement` exposes one unique site per code qubit,
+preserves the code block `[0, q)` and the bank `[q, 2q)` unchanged,
+enumerates routed-only `G` sites after the bank, and shifts every auxiliary
+allocation above the discovered `G` footprint. The instruction schema
+actually used (`kind`, `sites` coordinate tuples) is recorded in the report
+rather than assumed.
+
+Handoff edges are derived from the literal slot order (cross-stage transfers
+and syndrome/ancilla write-then-read channels) and then enforced by the
+walk; the four controls demonstrate each failure class is detected rather
+than merely absent: deleting a declared handoff edge, deleting a route
+return word, moving a stage-B slot before the pump row it depends on, and
+scheduling two words on one register in the same slot each produce the named
+violation.
+
+The one-time epoch, the clean initial banks, the declared stage order, and
+both input-leg conventions remain supplied. No renewal, positive-density
+multi-source composition, or autonomous scheduling is claimed.
+
+## Independent adversarial reconstruction
+
+The checker imports only the landed Cycle-720 modules, asserts that none of
+the three Cycle-721 primaries is imported even transitively, and validates
+its own independently written signed conjugation against dense matrices
+(8,208 comparisons, zero mismatches) before using it. It then rebuilds,
+without consulting the primaries' code paths: the six-SWAP exchange word and
+the full 36-row port dictionary exchange with parity bookkeeping and the
+one-cell census; the companion-encoded measured-row family with abelian
+structure, unchanged `11N+E` rank, the `H`-controlled-Pauli-`H` dilation
+identities, and the two-cell/diameter-one census; an independent one-hot
+private-dual verification against the Choi graph; the fixture-derived seam
+orientation classes over all 192 frame/parity contexts; an independently
+reconstructed four-stage epoch schedule walked by its own
+clean/live/retained state machine, with injected dropped-handoff and
+duplicate-owner faults detected; and the inherited mass/contact and
+Cycle-230 residual anchors plus a dense two-mode fixed-sector Kraus
+completeness rebuild. It supplies one wording correction (the epoch
+F2-leg namespace qualifier), adopted above.
+
+## Supplied / derived / open
+
+### Supplied
+
+- the full Cycle-720 inventory, unchanged: Cycle-219/230 fixtures and
+  parameters; per-cell six-mode labels and companion-port convention; one
+  fixed total-parity label; local center-sector signs and mixed gauge factor
+  or reference purification; three coframe bits per cell and the uniform
+  eight-origin channel; finite open boxes, boundary root, axis order,
+  spanning-tree/router tables; one-time preparation epoch; clean Bell,
+  syndrome, route, and preparation registers; the fixed four-layer update
+  schedule;
+- the companion-encoded input bank convention (Route 1) and the co-located
+  six-M2 port bank with the lexicographic-minimum port chart (Route 2);
+- clean measurement ancillae and rail M2 for the compiled words;
+- the declared stage order of the composed epoch (Route 3).
+
+### Derived
+
+- a literal physical-M2 measurement word for every doubled even-CAR Bell
+  row, with retained ancilla, returned routes, and the two-cell/diameter-one
+  support gate met on all six boxes up to `995` rows;
+- exact dilation identities and unchanged `11N+E` rank, abelian and
+  Hermitian, with the frozen one-cell private-dual correction surface;
+- the conflict-coloring law `measurement layers = 3 + maximum cell degree`
+  with interior saturation, and constant correction coloring from `3x2x2`;
+- an 18-primitive reversible even-exchange input port exact on the full
+  port dictionary, with port-local seam-extended coupling (one cell,
+  diameter zero) on every tested axis;
+- exact compiled-schedule and port-dictionary covariance over 24 frames and
+  eight translation parities via dictionary families and fixture-derived
+  seam orientation classes;
+- a collision-free composed epoch (preparation; coupling; corrections;
+  recurrent `G`) on one literal site map for both input legs, certified by
+  a slot-walk register-liveness state machine with detected-failure
+  controls, unchanged recurrent/fixture gates, and exact schedule-key
+  transport;
+- active deletion, hostile-order, stray-primitive, wrong-port, odd-input,
+  and route-deletion controls throughout.
+
+### Open
+
+- autonomous preparation or local enforcement of the total-parity, center,
+  mixed-gauge, coframe, clean-ancilla, clean-bank, root, and epoch domains;
+- a public immutable `V_s` tableau/coordinate API and a literal
+  `V_s`-restriction input compiler (measured ceiling recorded above);
+- a boundary-free translation-invariant recurrent genesis law; periodic
+  topology, fault repair, positive-density multi-source composition, and
+  renewal;
+- the eight-origin coframe channel covariance of the composed epoch beyond
+  the unchanged Cycle-720 surface;
+- objective actuality/admission, physical time/rate, source/gravity meaning,
+  permanent Record, Born weighting, and realized-history selection.
+
+## Six dependency categories (not independent walls)
+
+| category | Cycle-721 change | remaining dependency |
+|---|---|---|
+| `C_ref` | no runtime exterior-order query; compiled words, port words, and schedules are explicit local circuits | root/boundary, parity label, center signs, gauge reference, epoch, mode labels, parameters, finite router, and the two input-bank conventions remain supplied |
+| `C_num` | the input-side Bell measurements are literally compiled; the CAR-domain live-input map of Cycle 720 now has a physical instruction surface | physical selection/enforcement of the parity and center sector; the `V_s`-restriction compiler |
+| `C_wrap` | the composed epoch is a fixed finite slot table with a verified liveness walk; retained banks carry all outcomes | every ordinal remains circuit structure; occurrence, empirical interval/rate, and permanent Record remain open |
+| `C_int` | free/seam/contact/mass and Cycle-230 fixtures rerun unchanged under the compiled surface | coupling selection, physical rate/protection, and downstream source/work ledger remain open |
+| `C_local` | two-cell/diameter-one gate met by every compiled word; port-local seam coupling; conflict-coloring law with interior saturation | autonomous genesis/enforcement, boundary-free recurrence, periodic/fault-tolerant family |
+| `C_source` | unchanged at the physical compiler layer | no energy/stress/resource source, reciprocal response, sign/scale law, or gravity identification is selected here |
+
+## Negative-claim discipline
+
+No new negative claim ships in this package. The only negative-flavored
+statements are: (i) supplied-convention boundaries (the companion-encoded
+input bank and the port chart), including the design-history record that a
+bare global-Jordan-Wigner input register was rejected before certification —
+an untested design decision, not a route falsification; (ii) the inherited
+Cycle-720 raw-mode Bell diagnostic, cited strictly at its original one-frozen-
+route scope; and (iii) the package-inventory statement that no literal
+`V_s`-restriction compiler is constructed here, with its reopen condition
+named. None of these is promoted to a no-go, minimum-content result,
+wall-independence theorem, shared obstruction, or axiom-pressure claim.
+
+## Verdict and next experiment
+
+All three declared routes of the Cycle-720 tournament close positively at
+the bounded ceiling on the unchanged supplied inventory: the input-side
+even-CAR Bell measurements are literally compiled and meet the preregistered
+two-cell/diameter-one gate on every box; a direct local encoded-input
+Clifford port exists and its seam-extended coupling is port-local; and the
+four-stage epoch composes collision-free on one literal site map for both
+input legs, with a verified register-liveness walk. There is no shared
+obstruction and no axiom pressure. Nothing here selects a sector, prepares
+its own inputs, removes a boundary, or touches time, Record, Born, or
+source content.
+
+The Cycle-720 gate for downstream work is now satisfied at this package's
+resolution. The next decisive experiment is the one Cycle 720 already
+named: feed the unchanged Cycle-612 endpoint/interval harness and the
+coherent source-lift tournament through this composed epoch toward the
+repo-side response/prediction chain, without refitting any fixture. In
+parallel, three constructive legs remain live at their recorded scopes: a
+public immutable factorization-object API to open the `V_s`-restriction
+compiler (its measured locality ceiling is recorded above); the Cycle-719
+W1 leg (wrap the five-M2 refusal primitive around every controller macro);
+and the local Gauss/charge-sector route toward autonomous sector
+enforcement. Renewal, boundary-free genesis, and multi-source composition
+stay open exactly as inherited.

--- a/logs/runner-cache/frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.txt
+++ b/logs/runner-cache/frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.txt
@@ -1,0 +1,1321 @@
+===== runner cache v1 =====
+runner: scripts/frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.py
+runner_sha256: 434b643dfa4265b38aed5d6da6aa818e56ad9b4e34e7467489f6dace26ab2252
+input_fingerprint_sha256: 188d850f2dad8fb4e19a486422c6a8e8794088506f9f91e3c7af52ca6337c476
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 236.10
+status: ok
+----- stdout -----
+PASS exhaustive dense 8x8 Clifford conjugation self-test has zero mismatches
+PASS every direct-basis row on the five-box ladder compiles to an abelian Hermitian live-bank character with unchanged rank
+PASS literal H-controlled-Pauli-H words fix retained X, transport retained Z to Z times R_i, and leave all other measured and graph rows invariant
+PASS one-hot duality, kernel even sums, deletion signs, exhaustive one-cell branches, and deterministic held-box samples replay exactly
+PASS every compiled word and frozen private dual obeys the two-cell diameter-one gate with returned routes
+PASS measurement coloring equals three onsite layers plus one seam layer per maximum cell degree; correction coloring is constant from 3x2x2 (ceilings 12 and 24)
+PASS post-compilation two- and three-mode CPTP residuals and Cycle-720 critical fixture fields are unchanged
+PASS reused 24-frame and 576-product covariance surfaces retain zero named failures
+PASS compiled row families and census vectors transport over 24 frames by 8 translation parities with only fixture-derived edge orientation classes
+PASS private-dual deletion, deleting the final return link breaks the forward returned-route walk, first-link deletion, hostile ancilla pairing, and odd-row controls are detected
+{
+  "audit": "unset",
+  "authority": "none",
+  "boxes": [
+    {
+      "Hadamard_primitives": 22,
+      "branch_character_entry_failures": 0,
+      "branch_enumeration": "exhaustive even-X Pauli basis",
+      "branch_private_dual_replay_failures": 0,
+      "branch_target_relation_even_sum_failures": 0,
+      "cells": 1,
+      "coarse_input_binary_replacement_failures": 0,
+      "companion_encoded_live_input_M2": 9,
+      "compiled_character_binary_failures": 0,
+      "compiled_character_phase_failures": 0,
+      "compiled_measured_row_rank": 11,
+      "compiled_primitive_count": 54,
+      "compiled_row_commutator_failures": 0,
+      "compiled_row_hermiticity_failures": 0,
+      "controlled_Pauli_primitives": 32,
+      "delete_matching_private_dual_index": 5,
+      "delete_matching_private_dual_sign_residual": 1,
+      "dilation_X_invariance_failures": 0,
+      "dilation_Z_character_failures": 0,
+      "dilation_graph_row_invariance_failures": 0,
+      "dilation_other_measured_row_invariance_failures": 0,
+      "direct_graph_basis_rank": 11,
+      "edges": 0,
+      "expected_connected_even_algebra_rank": 11,
+      "expected_direct_graph_family_rank": 11,
+      "failing_compiled_word_support_rows": [],
+      "lawful_even_characters_tested": 2048,
+      "maximum_compiled_word_support_cells": 1,
+      "maximum_compiled_word_support_diameter": 0,
+      "maximum_private_dual_support_cells": 1,
+      "maximum_private_dual_support_diameter": 0,
+      "measurement_conflict_layers": 3,
+      "measurement_layer_census": [
+        {
+          "layer": 0,
+          "touched_qubits": 18,
+          "vertices": 6
+        },
+        {
+          "layer": 1,
+          "touched_qubits": 15,
+          "vertices": 3
+        },
+        {
+          "layer": 2,
+          "touched_qubits": 10,
+          "vertices": 2
+        }
+      ],
+      "physical_correction_conflict_layers": 6,
+      "physical_correction_layer_census": [
+        {
+          "layer": 0,
+          "touched_qubits": 6,
+          "vertices": 6
+        },
+        {
+          "layer": 1,
+          "touched_qubits": 5,
+          "vertices": 1
+        },
+        {
+          "layer": 2,
+          "touched_qubits": 4,
+          "vertices": 1
+        },
+        {
+          "layer": 3,
+          "touched_qubits": 3,
+          "vertices": 1
+        },
+        {
+          "layer": 4,
+          "touched_qubits": 2,
+          "vertices": 1
+        },
+        {
+          "layer": 5,
+          "touched_qubits": 1,
+          "vertices": 1
+        }
+      ],
+      "physical_output_M2": 9,
+      "physical_private_dual_support_failures": 0,
+      "physical_private_dual_syndrome_failures": 0,
+      "physical_tag_rebuild_failures": 0,
+      "precanonical_phase_erasure_rows": 0,
+      "rail_move_primitives": 0,
+      "route_forward_failures": 0,
+      "route_inverse_failures": 0,
+      "route_transitions": 0,
+      "rows": 11,
+      "shape": [
+        1,
+        1,
+        1
+      ],
+      "target_even_algebra_rank": 11,
+      "target_relation_rows": 0
+    },
+    {
+      "Hadamard_primitives": 200,
+      "branch_character_entry_failures": 0,
+      "branch_enumeration": "deterministic_even_samples",
+      "branch_private_dual_replay_failures": 0,
+      "branch_target_relation_even_sum_failures": 0,
+      "cells": 8,
+      "coarse_input_binary_replacement_failures": 0,
+      "companion_encoded_live_input_M2": 72,
+      "compiled_character_binary_failures": 0,
+      "compiled_character_phase_failures": 0,
+      "compiled_measured_row_rank": 100,
+      "compiled_primitive_count": 744,
+      "compiled_row_commutator_failures": 0,
+      "compiled_row_hermiticity_failures": 0,
+      "controlled_Pauli_primitives": 520,
+      "delete_matching_private_dual_index": 50,
+      "delete_matching_private_dual_sign_residual": 1,
+      "dilation_X_invariance_failures": 0,
+      "dilation_Z_character_failures": 0,
+      "dilation_graph_row_invariance_failures": 0,
+      "dilation_other_measured_row_invariance_failures": 0,
+      "direct_graph_basis_rank": 100,
+      "edges": 12,
+      "expected_connected_even_algebra_rank": 95,
+      "expected_direct_graph_family_rank": 100,
+      "failing_compiled_word_support_rows": [],
+      "lawful_even_characters_tested": 161,
+      "maximum_compiled_word_support_cells": 2,
+      "maximum_compiled_word_support_diameter": 1,
+      "maximum_private_dual_support_cells": 1,
+      "maximum_private_dual_support_diameter": 0,
+      "measurement_conflict_layers": 6,
+      "measurement_layer_census": [
+        {
+          "layer": 0,
+          "touched_qubits": 144,
+          "vertices": 48
+        },
+        {
+          "layer": 1,
+          "touched_qubits": 120,
+          "vertices": 24
+        },
+        {
+          "layer": 2,
+          "touched_qubits": 80,
+          "vertices": 16
+        },
+        {
+          "layer": 3,
+          "touched_qubits": 52,
+          "vertices": 4
+        },
+        {
+          "layer": 4,
+          "touched_qubits": 100,
+          "vertices": 4
+        },
+        {
+          "layer": 5,
+          "touched_qubits": 148,
+          "vertices": 4
+        }
+      ],
+      "physical_correction_conflict_layers": 10,
+      "physical_correction_layer_census": [
+        {
+          "layer": 0,
+          "touched_qubits": 40,
+          "vertices": 16
+        },
+        {
+          "layer": 1,
+          "touched_qubits": 32,
+          "vertices": 16
+        },
+        {
+          "layer": 2,
+          "touched_qubits": 24,
+          "vertices": 8
+        },
+        {
+          "layer": 3,
+          "touched_qubits": 20,
+          "vertices": 12
+        },
+        {
+          "layer": 4,
+          "touched_qubits": 16,
+          "vertices": 8
+        },
+        {
+          "layer": 5,
+          "touched_qubits": 60,
+          "vertices": 8
+        },
+        {
+          "layer": 6,
+          "touched_qubits": 48,
+          "vertices": 8
+        },
+        {
+          "layer": 7,
+          "touched_qubits": 36,
+          "vertices": 8
+        },
+        {
+          "layer": 8,
+          "touched_qubits": 24,
+          "vertices": 8
+        },
+        {
+          "layer": 9,
+          "touched_qubits": 12,
+          "vertices": 8
+        }
+      ],
+      "physical_output_M2": 72,
+      "physical_private_dual_support_failures": 0,
+      "physical_private_dual_syndrome_failures": 0,
+      "physical_tag_rebuild_failures": 0,
+      "precanonical_phase_erasure_rows": 0,
+      "rail_move_primitives": 24,
+      "route_forward_failures": 0,
+      "route_inverse_failures": 0,
+      "route_transitions": 24,
+      "rows": 100,
+      "shape": [
+        2,
+        2,
+        2
+      ],
+      "target_even_algebra_rank": 95,
+      "target_relation_rows": 5
+    },
+    {
+      "Hadamard_primitives": 304,
+      "branch_character_entry_failures": 0,
+      "branch_enumeration": "deterministic_even_samples",
+      "branch_private_dual_replay_failures": 0,
+      "branch_target_relation_even_sum_failures": 0,
+      "cells": 12,
+      "coarse_input_binary_replacement_failures": 0,
+      "companion_encoded_live_input_M2": 108,
+      "compiled_character_binary_failures": 0,
+      "compiled_character_phase_failures": 0,
+      "compiled_measured_row_rank": 152,
+      "compiled_primitive_count": 1144,
+      "compiled_row_commutator_failures": 0,
+      "compiled_row_hermiticity_failures": 0,
+      "controlled_Pauli_primitives": 800,
+      "delete_matching_private_dual_index": 76,
+      "delete_matching_private_dual_sign_residual": 1,
+      "dilation_X_invariance_failures": 0,
+      "dilation_Z_character_failures": 0,
+      "dilation_graph_row_invariance_failures": 0,
+      "dilation_other_measured_row_invariance_failures": 0,
+      "direct_graph_basis_rank": 152,
+      "edges": 20,
+      "expected_connected_even_algebra_rank": 143,
+      "expected_direct_graph_family_rank": 152,
+      "failing_compiled_word_support_rows": [],
+      "lawful_even_characters_tested": 209,
+      "maximum_compiled_word_support_cells": 2,
+      "maximum_compiled_word_support_diameter": 1,
+      "maximum_private_dual_support_cells": 1,
+      "maximum_private_dual_support_diameter": 0,
+      "measurement_conflict_layers": 7,
+      "measurement_layer_census": [
+        {
+          "layer": 0,
+          "touched_qubits": 216,
+          "vertices": 72
+        },
+        {
+          "layer": 1,
+          "touched_qubits": 180,
+          "vertices": 36
+        },
+        {
+          "layer": 2,
+          "touched_qubits": 120,
+          "vertices": 24
+        },
+        {
+          "layer": 3,
+          "touched_qubits": 102,
+          "vertices": 6
+        },
+        {
+          "layer": 4,
+          "touched_qubits": 102,
+          "vertices": 6
+        },
+        {
+          "layer": 5,
+          "touched_qubits": 198,
+          "vertices": 6
+        },
+        {
+          "layer": 6,
+          "touched_qubits": 74,
+          "vertices": 2
+        }
+      ],
+      "physical_correction_conflict_layers": 11,
+      "physical_correction_layer_census": [
+        {
+          "layer": 0,
+          "touched_qubits": 60,
+          "vertices": 24
+        },
+        {
+          "layer": 1,
+          "touched_qubits": 46,
+          "vertices": 22
+        },
+        {
+          "layer": 2,
+          "touched_qubits": 36,
+          "vertices": 12
+        },
+        {
+          "layer": 3,
+          "touched_qubits": 30,
+          "vertices": 18
+        },
+        {
+          "layer": 4,
+          "touched_qubits": 24,
+          "vertices": 12
+        },
+        {
+          "layer": 5,
+          "touched_qubits": 86,
+          "vertices": 14
+        },
+        {
+          "layer": 6,
+          "touched_qubits": 72,
+          "vertices": 12
+        },
+        {
+          "layer": 7,
+          "touched_qubits": 54,
+          "vertices": 12
+        },
+        {
+          "layer": 8,
+          "touched_qubits": 36,
+          "vertices": 12
+        },
+        {
+          "layer": 9,
+          "touched_qubits": 22,
+          "vertices": 12
+        },
+        {
+          "layer": 10,
+          "touched_qubits": 6,
+          "vertices": 2
+        }
+      ],
+      "physical_output_M2": 108,
+      "physical_private_dual_support_failures": 0,
+      "physical_private_dual_syndrome_failures": 0,
+      "physical_tag_rebuild_failures": 0,
+      "precanonical_phase_erasure_rows": 0,
+      "rail_move_primitives": 40,
+      "route_forward_failures": 0,
+      "route_inverse_failures": 0,
+      "route_transitions": 40,
+      "rows": 152,
+      "shape": [
+        3,
+        2,
+        2
+      ],
+      "target_even_algebra_rank": 143,
+      "target_relation_rows": 9
+    },
+    {
+      "Hadamard_primitives": 778,
+      "branch_character_entry_failures": 0,
+      "branch_enumeration": "deterministic_even_samples",
+      "branch_private_dual_replay_failures": 0,
+      "branch_target_relation_even_sum_failures": 0,
+      "cells": 30,
+      "coarse_input_binary_replacement_failures": 0,
+      "companion_encoded_live_input_M2": 270,
+      "compiled_character_binary_failures": 0,
+      "compiled_character_phase_failures": 0,
+      "compiled_measured_row_rank": 389,
+      "compiled_primitive_count": 3046,
+      "compiled_row_commutator_failures": 0,
+      "compiled_row_hermiticity_failures": 0,
+      "controlled_Pauli_primitives": 2150,
+      "delete_matching_private_dual_index": 194,
+      "delete_matching_private_dual_sign_residual": 1,
+      "dilation_X_invariance_failures": 0,
+      "dilation_Z_character_failures": 0,
+      "dilation_graph_row_invariance_failures": 0,
+      "dilation_other_measured_row_invariance_failures": 0,
+      "direct_graph_basis_rank": 389,
+      "edges": 59,
+      "expected_connected_even_algebra_rank": 359,
+      "expected_direct_graph_family_rank": 389,
+      "failing_compiled_word_support_rows": [],
+      "lawful_even_characters_tested": 425,
+      "maximum_compiled_word_support_cells": 2,
+      "maximum_compiled_word_support_diameter": 1,
+      "maximum_private_dual_support_cells": 1,
+      "maximum_private_dual_support_diameter": 0,
+      "measurement_conflict_layers": 8,
+      "measurement_layer_census": [
+        {
+          "layer": 0,
+          "touched_qubits": 540,
+          "vertices": 180
+        },
+        {
+          "layer": 1,
+          "touched_qubits": 450,
+          "vertices": 90
+        },
+        {
+          "layer": 2,
+          "touched_qubits": 300,
+          "vertices": 60
+        },
+        {
+          "layer": 3,
+          "touched_qubits": 243,
+          "vertices": 15
+        },
+        {
+          "layer": 4,
+          "touched_qubits": 243,
+          "vertices": 15
+        },
+        {
+          "layer": 5,
+          "touched_qubits": 435,
+          "vertices": 15
+        },
+        {
+          "layer": 6,
+          "touched_qubits": 335,
+          "vertices": 11
+        },
+        {
+          "layer": 7,
+          "touched_qubits": 111,
+          "vertices": 3
+        }
+      ],
+      "physical_correction_conflict_layers": 11,
+      "physical_correction_layer_census": [
+        {
+          "layer": 0,
+          "touched_qubits": 150,
+          "vertices": 60
+        },
+        {
+          "layer": 1,
+          "touched_qubits": 111,
+          "vertices": 51
+        },
+        {
+          "layer": 2,
+          "touched_qubits": 90,
+          "vertices": 30
+        },
+        {
+          "layer": 3,
+          "touched_qubits": 70,
+          "vertices": 40
+        },
+        {
+          "layer": 4,
+          "touched_qubits": 60,
+          "vertices": 30
+        },
+        {
+          "layer": 5,
+          "touched_qubits": 216,
+          "vertices": 42
+        },
+        {
+          "layer": 6,
+          "touched_qubits": 180,
+          "vertices": 30
+        },
+        {
+          "layer": 7,
+          "touched_qubits": 135,
+          "vertices": 35
+        },
+        {
+          "layer": 8,
+          "touched_qubits": 90,
+          "vertices": 30
+        },
+        {
+          "layer": 9,
+          "touched_qubits": 65,
+          "vertices": 30
+        },
+        {
+          "layer": 10,
+          "touched_qubits": 31,
+          "vertices": 11
+        }
+      ],
+      "physical_output_M2": 270,
+      "physical_private_dual_support_failures": 0,
+      "physical_private_dual_syndrome_failures": 0,
+      "physical_tag_rebuild_failures": 0,
+      "precanonical_phase_erasure_rows": 0,
+      "rail_move_primitives": 118,
+      "route_forward_failures": 0,
+      "route_inverse_failures": 0,
+      "route_transitions": 118,
+      "rows": 389,
+      "shape": [
+        5,
+        3,
+        2
+      ],
+      "target_even_algebra_rank": 359,
+      "target_relation_rows": 30
+    },
+    {
+      "Hadamard_primitives": 1696,
+      "branch_character_entry_failures": 0,
+      "branch_enumeration": "deterministic_even_samples",
+      "branch_private_dual_replay_failures": 0,
+      "branch_target_relation_even_sum_failures": 0,
+      "cells": 64,
+      "coarse_input_binary_replacement_failures": 0,
+      "companion_encoded_live_input_M2": 576,
+      "compiled_character_binary_failures": 0,
+      "compiled_character_phase_failures": 0,
+      "compiled_measured_row_rank": 848,
+      "compiled_primitive_count": 7200,
+      "compiled_row_commutator_failures": 0,
+      "compiled_row_hermiticity_failures": 0,
+      "controlled_Pauli_primitives": 5216,
+      "delete_matching_private_dual_index": 424,
+      "delete_matching_private_dual_sign_residual": 1,
+      "dilation_X_invariance_failures": 0,
+      "dilation_Z_character_failures": 0,
+      "dilation_graph_row_invariance_failures": 0,
+      "dilation_other_measured_row_invariance_failures": 0,
+      "direct_graph_basis_rank": 848,
+      "edges": 144,
+      "expected_connected_even_algebra_rank": 767,
+      "expected_direct_graph_family_rank": 848,
+      "failing_compiled_word_support_rows": [],
+      "lawful_even_characters_tested": 833,
+      "maximum_compiled_word_support_cells": 2,
+      "maximum_compiled_word_support_diameter": 1,
+      "maximum_private_dual_support_cells": 1,
+      "maximum_private_dual_support_diameter": 0,
+      "measurement_conflict_layers": 9,
+      "measurement_layer_census": [
+        {
+          "layer": 0,
+          "touched_qubits": 1152,
+          "vertices": 384
+        },
+        {
+          "layer": 1,
+          "touched_qubits": 960,
+          "vertices": 192
+        },
+        {
+          "layer": 2,
+          "touched_qubits": 640,
+          "vertices": 128
+        },
+        {
+          "layer": 3,
+          "touched_qubits": 416,
+          "vertices": 32
+        },
+        {
+          "layer": 4,
+          "touched_qubits": 608,
+          "vertices": 32
+        },
+        {
+          "layer": 5,
+          "touched_qubits": 896,
+          "vertices": 32
+        },
+        {
+          "layer": 6,
+          "touched_qubits": 940,
+          "vertices": 28
+        },
+        {
+          "layer": 7,
+          "touched_qubits": 592,
+          "vertices": 16
+        },
+        {
+          "layer": 8,
+          "touched_qubits": 148,
+          "vertices": 4
+        }
+      ],
+      "physical_correction_conflict_layers": 11,
+      "physical_correction_layer_census": [
+        {
+          "layer": 0,
+          "touched_qubits": 320,
+          "vertices": 128
+        },
+        {
+          "layer": 1,
+          "touched_qubits": 224,
+          "vertices": 96
+        },
+        {
+          "layer": 2,
+          "touched_qubits": 192,
+          "vertices": 64
+        },
+        {
+          "layer": 3,
+          "touched_qubits": 144,
+          "vertices": 80
+        },
+        {
+          "layer": 4,
+          "touched_qubits": 128,
+          "vertices": 64
+        },
+        {
+          "layer": 5,
+          "touched_qubits": 476,
+          "vertices": 92
+        },
+        {
+          "layer": 6,
+          "touched_qubits": 384,
+          "vertices": 64
+        },
+        {
+          "layer": 7,
+          "touched_qubits": 296,
+          "vertices": 88
+        },
+        {
+          "layer": 8,
+          "touched_qubits": 192,
+          "vertices": 64
+        },
+        {
+          "layer": 9,
+          "touched_qubits": 132,
+          "vertices": 64
+        },
+        {
+          "layer": 10,
+          "touched_qubits": 104,
+          "vertices": 44
+        }
+      ],
+      "physical_output_M2": 576,
+      "physical_private_dual_support_failures": 0,
+      "physical_private_dual_syndrome_failures": 0,
+      "physical_tag_rebuild_failures": 0,
+      "precanonical_phase_erasure_rows": 0,
+      "rail_move_primitives": 288,
+      "route_forward_failures": 0,
+      "route_inverse_failures": 0,
+      "route_transitions": 288,
+      "rows": 848,
+      "shape": [
+        4,
+        4,
+        4
+      ],
+      "target_even_algebra_rank": 767,
+      "target_relation_rows": 81
+    },
+    {
+      "Hadamard_primitives": 1990,
+      "branch_character_entry_failures": 0,
+      "branch_enumeration": "deterministic_even_samples",
+      "branch_private_dual_replay_failures": 0,
+      "branch_target_relation_even_sum_failures": 0,
+      "cells": 75,
+      "coarse_input_binary_replacement_failures": 0,
+      "companion_encoded_live_input_M2": 675,
+      "compiled_character_binary_failures": 0,
+      "compiled_character_phase_failures": 0,
+      "compiled_measured_row_rank": 995,
+      "compiled_primitive_count": 8350,
+      "compiled_row_commutator_failures": 0,
+      "compiled_row_hermiticity_failures": 0,
+      "controlled_Pauli_primitives": 6020,
+      "delete_matching_private_dual_index": 497,
+      "delete_matching_private_dual_sign_residual": 1,
+      "dilation_X_invariance_failures": 0,
+      "dilation_Z_character_failures": 0,
+      "dilation_graph_row_invariance_failures": 0,
+      "dilation_other_measured_row_invariance_failures": 0,
+      "direct_graph_basis_rank": 995,
+      "edges": 170,
+      "expected_connected_even_algebra_rank": 899,
+      "expected_direct_graph_family_rank": 995,
+      "failing_compiled_word_support_rows": [],
+      "lawful_even_characters_tested": 965,
+      "maximum_compiled_word_support_cells": 2,
+      "maximum_compiled_word_support_diameter": 1,
+      "maximum_private_dual_support_cells": 1,
+      "maximum_private_dual_support_diameter": 0,
+      "measurement_conflict_layers": 9,
+      "measurement_layer_census": [
+        {
+          "layer": 0,
+          "touched_qubits": 1350,
+          "vertices": 450
+        },
+        {
+          "layer": 1,
+          "touched_qubits": 1125,
+          "vertices": 225
+        },
+        {
+          "layer": 2,
+          "touched_qubits": 750,
+          "vertices": 150
+        },
+        {
+          "layer": 3,
+          "touched_qubits": 577,
+          "vertices": 37
+        },
+        {
+          "layer": 4,
+          "touched_qubits": 577,
+          "vertices": 37
+        },
+        {
+          "layer": 5,
+          "touched_qubits": 935,
+          "vertices": 35
+        },
+        {
+          "layer": 6,
+          "touched_qubits": 931,
+          "vertices": 31
+        },
+        {
+          "layer": 7,
+          "touched_qubits": 777,
+          "vertices": 21
+        },
+        {
+          "layer": 8,
+          "touched_qubits": 333,
+          "vertices": 9
+        }
+      ],
+      "physical_correction_conflict_layers": 11,
+      "physical_correction_layer_census": [
+        {
+          "layer": 0,
+          "touched_qubits": 375,
+          "vertices": 150
+        },
+        {
+          "layer": 1,
+          "touched_qubits": 265,
+          "vertices": 115
+        },
+        {
+          "layer": 2,
+          "touched_qubits": 225,
+          "vertices": 75
+        },
+        {
+          "layer": 3,
+          "touched_qubits": 165,
+          "vertices": 90
+        },
+        {
+          "layer": 4,
+          "touched_qubits": 150,
+          "vertices": 75
+        },
+        {
+          "layer": 5,
+          "touched_qubits": 561,
+          "vertices": 114
+        },
+        {
+          "layer": 6,
+          "touched_qubits": 450,
+          "vertices": 75
+        },
+        {
+          "layer": 7,
+          "touched_qubits": 345,
+          "vertices": 105
+        },
+        {
+          "layer": 8,
+          "touched_qubits": 225,
+          "vertices": 75
+        },
+        {
+          "layer": 9,
+          "touched_qubits": 161,
+          "vertices": 75
+        },
+        {
+          "layer": 10,
+          "touched_qubits": 118,
+          "vertices": 46
+        }
+      ],
+      "physical_output_M2": 675,
+      "physical_private_dual_support_failures": 0,
+      "physical_private_dual_syndrome_failures": 0,
+      "physical_tag_rebuild_failures": 0,
+      "precanonical_phase_erasure_rows": 0,
+      "rail_move_primitives": 340,
+      "route_forward_failures": 0,
+      "route_inverse_failures": 0,
+      "route_transitions": 340,
+      "rows": 995,
+      "shape": [
+        5,
+        5,
+        3
+      ],
+      "target_even_algebra_rank": 899,
+      "target_relation_rows": 96
+    }
+  ],
+  "checks": [
+    {
+      "label": "exhaustive dense 8x8 Clifford conjugation self-test has zero mismatches",
+      "pass": true
+    },
+    {
+      "label": "every direct-basis row on the five-box ladder compiles to an abelian Hermitian live-bank character with unchanged rank",
+      "pass": true
+    },
+    {
+      "label": "literal H-controlled-Pauli-H words fix retained X, transport retained Z to Z times R_i, and leave all other measured and graph rows invariant",
+      "pass": true
+    },
+    {
+      "label": "one-hot duality, kernel even sums, deletion signs, exhaustive one-cell branches, and deterministic held-box samples replay exactly",
+      "pass": true
+    },
+    {
+      "label": "every compiled word and frozen private dual obeys the two-cell diameter-one gate with returned routes",
+      "pass": true
+    },
+    {
+      "label": "measurement coloring equals three onsite layers plus one seam layer per maximum cell degree; correction coloring is constant from 3x2x2 (ceilings 12 and 24)",
+      "pass": true
+    },
+    {
+      "label": "post-compilation two- and three-mode CPTP residuals and Cycle-720 critical fixture fields are unchanged",
+      "pass": true
+    },
+    {
+      "label": "reused 24-frame and 576-product covariance surfaces retain zero named failures",
+      "pass": true
+    },
+    {
+      "label": "compiled row families and census vectors transport over 24 frames by 8 translation parities with only fixture-derived edge orientation classes",
+      "pass": true
+    },
+    {
+      "label": "private-dual deletion, deleting the final return link breaks the forward returned-route walk, first-link deletion, hostile ancilla pairing, and odd-row controls are detected",
+      "pass": true
+    }
+  ],
+  "claim_boundary": "instruction-level companion-encoded input-bank compilation on the declared site map with supplied sector/genesis inventory; the collision-free joint epoch with pump + recurrent G is not claimed here; ordinals are circuit structure, not time; state-level coupling only, with no matter/FTL/mass/charge transfer",
+  "compiled_schedule_transport": {
+    "contexts": 384,
+    "edge_forward_orientation_classes": 3072,
+    "edge_orientation_binary_class_failures": 0,
+    "edge_orientation_signed_class_failures": 0,
+    "edge_reversed_orientation_classes": 3072,
+    "family_binary_multiset_failures": {
+      "edge": 0,
+      "onsite_XX": 0,
+      "onsite_Z": 0
+    },
+    "family_census_vector_invariance_failures": {
+      "edge": 0,
+      "onsite_XX": 0,
+      "onsite_Z": 0
+    },
+    "family_signed_multiset_failures": {
+      "edge": 0,
+      "onsite_XX": 0,
+      "onsite_Z": 0
+    },
+    "proper_cubic_frames": 24,
+    "shapes": [
+      {
+        "contexts": 192,
+        "edge_forward_orientation_classes": 1152,
+        "edge_orientation_binary_class_failures": 0,
+        "edge_orientation_signed_class_failures": 0,
+        "edge_reversed_orientation_classes": 1152,
+        "family_binary_multiset_failures": {
+          "edge": 0,
+          "onsite_XX": 0,
+          "onsite_Z": 0
+        },
+        "family_census_vector_invariance_failures": {
+          "edge": 0,
+          "onsite_XX": 0,
+          "onsite_Z": 0
+        },
+        "family_signed_multiset_failures": {
+          "edge": 0,
+          "onsite_XX": 0,
+          "onsite_Z": 0
+        },
+        "proper_cubic_frames": 24,
+        "shape": [
+          2,
+          2,
+          2
+        ],
+        "source_family_census_vectors": {
+          "edge": [
+            {
+              "rows": 4,
+              "vector": [
+                2,
+                1,
+                14,
+                2
+              ]
+            },
+            {
+              "rows": 4,
+              "vector": [
+                2,
+                1,
+                26,
+                2
+              ]
+            },
+            {
+              "rows": 4,
+              "vector": [
+                2,
+                1,
+                38,
+                2
+              ]
+            }
+          ],
+          "onsite_XX": [
+            {
+              "rows": 40,
+              "vector": [
+                1,
+                0,
+                6,
+                0
+              ]
+            }
+          ],
+          "onsite_Z": [
+            {
+              "rows": 48,
+              "vector": [
+                1,
+                0,
+                4,
+                0
+              ]
+            }
+          ]
+        },
+        "translation_parities": 8
+      },
+      {
+        "contexts": 192,
+        "edge_forward_orientation_classes": 1920,
+        "edge_orientation_binary_class_failures": 0,
+        "edge_orientation_signed_class_failures": 0,
+        "edge_reversed_orientation_classes": 1920,
+        "family_binary_multiset_failures": {
+          "edge": 0,
+          "onsite_XX": 0,
+          "onsite_Z": 0
+        },
+        "family_census_vector_invariance_failures": {
+          "edge": 0,
+          "onsite_XX": 0,
+          "onsite_Z": 0
+        },
+        "family_signed_multiset_failures": {
+          "edge": 0,
+          "onsite_XX": 0,
+          "onsite_Z": 0
+        },
+        "proper_cubic_frames": 24,
+        "shape": [
+          3,
+          2,
+          2
+        ],
+        "source_family_census_vectors": {
+          "edge": [
+            {
+              "rows": 8,
+              "vector": [
+                2,
+                1,
+                14,
+                2
+              ]
+            },
+            {
+              "rows": 6,
+              "vector": [
+                2,
+                1,
+                26,
+                2
+              ]
+            },
+            {
+              "rows": 6,
+              "vector": [
+                2,
+                1,
+                38,
+                2
+              ]
+            }
+          ],
+          "onsite_XX": [
+            {
+              "rows": 60,
+              "vector": [
+                1,
+                0,
+                6,
+                0
+              ]
+            }
+          ],
+          "onsite_Z": [
+            {
+              "rows": 72,
+              "vector": [
+                1,
+                0,
+                4,
+                0
+              ]
+            }
+          ]
+        },
+        "translation_parities": 8
+      }
+    ],
+    "translation_parities": 8
+  },
+  "controls": {
+    "delete_private_dual_detection_failures": 0,
+    "delete_private_dual_sign_residuals": {
+      "(1, 1, 1)": 1,
+      "(2, 2, 2)": 1,
+      "(3, 2, 2)": 1,
+      "(4, 4, 4)": 1,
+      "(5, 3, 2)": 1,
+      "(5, 5, 3)": 1
+    },
+    "deleted_final_route_link_failures": [
+      1,
+      0
+    ],
+    "deleted_first_route_link_failures": [
+      1,
+      1
+    ],
+    "doubled_row_span_rank": 11,
+    "hostile_ancilla_swap_dilation_identity_failures": true,
+    "hostile_same_layer_word_indices": [
+      0,
+      1
+    ],
+    "odd_augmented_span_rank": 12,
+    "odd_bank_character_parity_symplectic": 1,
+    "unlawful_odd_input_detection_failures": 0
+  },
+  "covariance": {
+    "Bell_reference_conjugate_chart_failures": 0,
+    "actively_transformed_private_corrections": 19200,
+    "actively_transformed_returned_routes": 19200,
+    "actively_transformed_stabilizer_rows": 19200,
+    "atlas_key_inverse_transport_failures": 0,
+    "finite_coframe_atlas_orbit_keys": 864,
+    "finite_coframe_correction_word_orbit": 1128,
+    "frame_origin_contexts": 192,
+    "geometric_route_words_changed_by_JW_chart_gauge": 2032,
+    "orbit_digest": "f8d56c31d79ca26cc51aa5a492e9288e9f4dd48681acb5be02046dcd016aeab4",
+    "oriented_factor_2_or_3_edge_row_failures": 0,
+    "private_correction_support_failures": 0,
+    "private_correction_syndrome_failures": 0,
+    "proper_cubic_frames": 24,
+    "retained_coframe_origin_sectors": 8,
+    "reversed_edge_rows": 1152,
+    "route_gauge_boundary": "the actual transformed signed Pauli row is routed afresh by the same deterministic NN returned-route compiler; a bare geometric image of the source JW route is only a chart gauge",
+    "route_locality_support_or_return_failures": 0,
+    "schedule_key_inverse_transport_failures": 0,
+    "shape": [
+      2,
+      2,
+      2
+    ],
+    "signed_projector_failures": 0,
+    "syndrome_register_bijection_failures": 0
+  },
+  "dense_selftest": {
+    "Hadamard_conjugation_tests": 64,
+    "Pauli_pair_sandwich_tests": 1024,
+    "controlled_Pauli_primitive_tests": 384,
+    "dense_selftest_mismatches": 0,
+    "maximum_dense_residual": 1.262432884528343e-15,
+    "target_Paulis_exhausted": 16,
+    "three_qubit_Paulis_exhausted": 64
+  },
+  "derived": "literal instruction data, exact integer-Pauli conjugation, companion-bank joint-rank and abelian censuses, returned-route/support census, private-dual branch replay, conflict coloring, and covariant signed/binary family-multiset diagnostics",
+  "exact_CPTP_controls": [
+    {
+      "Bell_basis_orthonormality_residual": 4.440892098500626e-16,
+      "Bell_outcomes": 4,
+      "Kraus_completeness_residual": 6.280369834735101e-16,
+      "corrected_branch_identity_residual": 1.5700924586837752e-16,
+      "expected_even_rank": 3,
+      "expected_outcomes": 4,
+      "fixed_sector_dimension": 2,
+      "generator_rank": 3,
+      "modes": 2
+    },
+    {
+      "Bell_basis_orthonormality_residual": 0.0,
+      "Bell_outcomes": 16,
+      "Kraus_completeness_residual": 0.0,
+      "corrected_branch_identity_residual": 0.0,
+      "expected_even_rank": 5,
+      "expected_outcomes": 16,
+      "fixed_sector_dimension": 4,
+      "generator_rank": 5,
+      "modes": 3
+    }
+  ],
+  "fixture_preservation": {
+    "all_three_residuals_below_1e-12": true,
+    "critical_box_field_change_failures": 0,
+    "critical_box_fields_compared": [
+      "target_even_algebra_rank",
+      "expected_connected_even_algebra_rank",
+      "doubled_Bell_row_rank",
+      "doubled_Bell_row_commutator_failures",
+      "CAR_measurement_support_cell_failures",
+      "CAR_edge_nearest_neighbor_failures",
+      "physical_private_dual_syndrome_failures",
+      "physical_private_dual_support_failures",
+      "maximum_private_dual_support_cells",
+      "maximum_private_dual_support_diameter",
+      "branch_private_dual_character_failures",
+      "branch_character_entry_failures",
+      "branch_target_relation_character_failures"
+    ],
+    "exact_certificate_change_failures": 0,
+    "maximum_exact_CPTP_residual": 6.280369834735101e-16
+  },
+  "frame_products": {
+    "atlas_key_product_failures": 0,
+    "coframe_origin_blocks": 4608,
+    "ordered_frame_products": 576,
+    "private_correction_word_product_failures": 0,
+    "returned_route_product_failures": 0,
+    "signed_Choi_tableau_image_product_failures": 0,
+    "stabilizer_row_product_failures": 0,
+    "tree_plaquette_schedule_product_failures": 0
+  },
+  "input_Bell_measurement_physical_M2_compiled": true,
+  "layer_counts": {
+    "correction_by_box": [
+      6,
+      10,
+      11,
+      11,
+      11,
+      11
+    ],
+    "correction_constant_from_3x2x2": true,
+    "law_statement": "measurement conflict layers = 3 onsite layers (Z/XX path coloring) + 1 seam layer per unit of maximum cell degree (greedy first-fit attains the Koenig edge-coloring bound of the bipartite box graph in the emitted edge order); correction layers saturate at their one-cell constant from 3x2x2 on",
+    "layer_law": [
+      {
+        "expected_measurement_layers_3_plus_degree": 3,
+        "maximum_cell_degree": 0,
+        "measurement_conflict_layers": 3,
+        "physical_correction_conflict_layers": 6,
+        "shape": [
+          1,
+          1,
+          1
+        ]
+      },
+      {
+        "expected_measurement_layers_3_plus_degree": 6,
+        "maximum_cell_degree": 3,
+        "measurement_conflict_layers": 6,
+        "physical_correction_conflict_layers": 10,
+        "shape": [
+          2,
+          2,
+          2
+        ]
+      },
+      {
+        "expected_measurement_layers_3_plus_degree": 7,
+        "maximum_cell_degree": 4,
+        "measurement_conflict_layers": 7,
+        "physical_correction_conflict_layers": 11,
+        "shape": [
+          3,
+          2,
+          2
+        ]
+      },
+      {
+        "expected_measurement_layers_3_plus_degree": 8,
+        "maximum_cell_degree": 5,
+        "measurement_conflict_layers": 8,
+        "physical_correction_conflict_layers": 11,
+        "shape": [
+          5,
+          3,
+          2
+        ]
+      },
+      {
+        "expected_measurement_layers_3_plus_degree": 9,
+        "maximum_cell_degree": 6,
+        "measurement_conflict_layers": 9,
+        "physical_correction_conflict_layers": 11,
+        "shape": [
+          4,
+          4,
+          4
+        ]
+      },
+      {
+        "expected_measurement_layers_3_plus_degree": 9,
+        "maximum_cell_degree": 6,
+        "measurement_conflict_layers": 9,
+        "physical_correction_conflict_layers": 11,
+        "shape": [
+          5,
+          5,
+          3
+        ]
+      }
+    ],
+    "measurement_by_box": [
+      3,
+      6,
+      7,
+      8,
+      9,
+      9
+    ]
+  },
+  "open": "autonomous sector/genesis law; collision-free joint epoch with pump and recurrent G; downstream time/source/Record/Born acceptance; any failed literal dilation, layer-constancy, or transport gate reported by this companion-encoded-bank run",
+  "runtime_seconds": 235.67410062499403,
+  "status": "PASS",
+  "supplied": "fixed parity/center sector; one-time Choi genesis inventory; mixed gauge reference; clean retained syndrome and mobile-rail banks; frozen private-dual atlas; finite boxes; the live input is presented in the code's own companion representation (companion-encoded input bank); a bare global-JW input register is not used"
+}
+
+----- stderr -----
+

--- a/logs/runner-cache/frontier_cycle721_collision_free_epoch_composition_2026_07_28.txt
+++ b/logs/runner-cache/frontier_cycle721_collision_free_epoch_composition_2026_07_28.txt
@@ -1,0 +1,6437 @@
+===== runner cache v1 =====
+runner: scripts/frontier_cycle721_collision_free_epoch_composition_2026_07_28.py
+runner_sha256: 046d013dbaef721ceaddf02ba81b3852967745bf2e5aa597fc19e2ee69653166
+input_fingerprint_sha256: 3d1d30093855677ff9d5ce3ff8360294000a4622a0b596949615aa40a9db0463
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 83.29
+status: ok
+----- stdout -----
+PASS both input-leg variants have zero slot-walk liveness, collision, and returned-route failures on every held liveness box
+PASS the exhaustive signed generator family has exact staged-versus-flattened A/B/C tableau action with the unchanged certified G tail on 1x1x1 and 2x2x2
+PASS the imported 3x2x2 recurrent one-step conjunction and 2x2x2 orientation/interleave/deletion gates remain exact
+PASS the three mass/contact and five Cycle-230 fixture residuals remain below 4e-10
+PASS both schedule variants transport over 24 frames x 8 parities with identical schedule-key and per-family census multisets and zero four-field coframe failures
+PASS deleted handoff, deleted return word, hostile Stage-B-before-pump interleave, and duplicate-owner controls are all detected
+{
+  "audit": "unset",
+  "authority": "none",
+  "boxes": {
+    "1x1x1": {
+      "scope": "algebra-only where defined",
+      "shape": [
+        1,
+        1,
+        1
+      ],
+      "slot_counts_per_stage": {
+        "alternate_port": {
+          "A": 23,
+          "B": 18,
+          "C": 0,
+          "D": 421
+        },
+        "primary": {
+          "A": 23,
+          "B": 3,
+          "C": 11,
+          "D": 421
+        }
+      }
+    },
+    "2x2x2": {
+      "alternate_port": {
+        "census": {
+          "G_coin_coin_givens": {
+            "distinct_register_count": 80,
+            "layer_count": 80,
+            "slots": 80,
+            "stage": "D",
+            "touched_register_count": 160,
+            "words": 80
+          },
+          "G_coin_coin_phase": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_onsite_contact": {
+            "distinct_register_count": 80,
+            "layer_count": 120,
+            "slots": 120,
+            "stage": "D",
+            "touched_register_count": 240,
+            "words": 120
+          },
+          "G_reverse_FSWAP": {
+            "distinct_register_count": 48,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 48,
+            "words": 24
+          },
+          "G_route_swap": {
+            "distinct_register_count": 540,
+            "layer_count": 16256,
+            "slots": 16256,
+            "stage": "D",
+            "touched_register_count": 32512,
+            "words": 16256
+          },
+          "G_seam_c(0, 0)_f0_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 0)_f1_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 0)_f2_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 0)_f2_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(0, 0)_f2_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 4,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 16
+          },
+          "G_seam_c(0, 0)_f3_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 0)_f3_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(0, 0)_f3_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 4,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 16
+          },
+          "G_seam_c(0, 1)_f0_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 1)_f1_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 1)_f2_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 1)_f2_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(0, 1)_f2_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 4,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 16
+          },
+          "G_seam_c(0, 1)_f3_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 1)_f3_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(0, 1)_f3_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 4,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 16
+          },
+          "G_seam_c(1, 0)_f0_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 0)_f1_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 0)_f2_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 0)_f2_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(1, 0)_f2_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 40,
+            "slots": 40,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 40
+          },
+          "G_seam_c(1, 0)_f3_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 0)_f3_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(1, 0)_f3_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 40,
+            "slots": 40,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 40
+          },
+          "G_seam_c(1, 1)_f0_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 1)_f1_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 1)_f2_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 1)_f2_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(1, 1)_f2_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 40,
+            "slots": 40,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 40
+          },
+          "G_seam_c(1, 1)_f3_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 1)_f3_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(1, 1)_f3_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 40,
+            "slots": 40,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 40
+          },
+          "G_seam_c(2, 0)_f0_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 0)_f1_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 0)_f2_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 0)_f2_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 0)_f2_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 64,
+            "slots": 64,
+            "stage": "D",
+            "touched_register_count": 128,
+            "words": 64
+          },
+          "G_seam_c(2, 0)_f3_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 0)_f3_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 0)_f3_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 64,
+            "slots": 64,
+            "stage": "D",
+            "touched_register_count": 128,
+            "words": 64
+          },
+          "G_seam_c(2, 1)_f0_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 1)_f1_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 1)_f2_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 1)_f2_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 1)_f2_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 64,
+            "slots": 64,
+            "stage": "D",
+            "touched_register_count": 128,
+            "words": 64
+          },
+          "G_seam_c(2, 1)_f3_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 1)_f3_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 1)_f3_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 64,
+            "slots": 64,
+            "stage": "D",
+            "touched_register_count": 128,
+            "words": 64
+          },
+          "encoded_bank_supply": {
+            "distinct_register_count": 24,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "A",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "port_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 18,
+            "slots": 18,
+            "stage": "B",
+            "touched_register_count": 36,
+            "words": 18
+          },
+          "pump_Bell_init": {
+            "distinct_register_count": 240,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "A",
+            "touched_register_count": 240,
+            "words": 120
+          },
+          "pump_onsite_XX_measure": {
+            "distinct_register_count": 136,
+            "layer_count": 40,
+            "slots": 40,
+            "stage": "A",
+            "touched_register_count": 200,
+            "words": 40
+          },
+          "pump_onsite_XX_private_dual": {
+            "distinct_register_count": 100,
+            "layer_count": 40,
+            "slots": 40,
+            "stage": "A",
+            "touched_register_count": 220,
+            "words": 40
+          },
+          "pump_onsite_Z_measure": {
+            "distinct_register_count": 144,
+            "layer_count": 48,
+            "slots": 48,
+            "stage": "A",
+            "touched_register_count": 144,
+            "words": 48
+          },
+          "pump_onsite_Z_private_dual": {
+            "distinct_register_count": 120,
+            "layer_count": 48,
+            "slots": 48,
+            "stage": "A",
+            "touched_register_count": 168,
+            "words": 48
+          },
+          "pump_plaquette_correction_route_return": {
+            "distinct_register_count": 6,
+            "layer_count": 5,
+            "slots": 5,
+            "stage": "A",
+            "touched_register_count": 10,
+            "words": 5
+          },
+          "pump_plaquette_measure": {
+            "distinct_register_count": 117,
+            "layer_count": 5,
+            "slots": 5,
+            "stage": "A",
+            "touched_register_count": 205,
+            "words": 5
+          },
+          "pump_plaquette_private_dual": {
+            "distinct_register_count": 16,
+            "layer_count": 5,
+            "slots": 5,
+            "stage": "A",
+            "touched_register_count": 20,
+            "words": 5
+          },
+          "pump_plaquette_route_return": {
+            "distinct_register_count": 6,
+            "layer_count": 5,
+            "slots": 5,
+            "stage": "A",
+            "touched_register_count": 10,
+            "words": 5
+          },
+          "pump_tree_correction_route_return": {
+            "distinct_register_count": 8,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "A",
+            "touched_register_count": 14,
+            "words": 7
+          },
+          "pump_tree_measure": {
+            "distinct_register_count": 125,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "A",
+            "touched_register_count": 193,
+            "words": 7
+          },
+          "pump_tree_private_dual": {
+            "distinct_register_count": 22,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "A",
+            "touched_register_count": 28,
+            "words": 7
+          },
+          "pump_tree_route_return": {
+            "distinct_register_count": 8,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "A",
+            "touched_register_count": 14,
+            "words": 7
+          }
+        },
+        "lawful": true,
+        "liveness_walk": {
+          "accounting": "literal slot walk: clean -> live(owner stage/word) -> retained; retained reads/writes require an executed declared handoff",
+          "collision_count": 0,
+          "final_state_census": {
+            "retained": 844
+          },
+          "handoffs_consumed": 184,
+          "handoffs_declared": 184,
+          "register_touches": 35790,
+          "registers_seen": 844,
+          "slots_walked": 17547,
+          "violation_count": 0,
+          "violations": [],
+          "words_walked": 17690
+        },
+        "routes": {
+          "G_route_report": {
+            "maximum_route_distance": 24,
+            "non_NN_failures": 0,
+            "route_return_failures": 0,
+            "routed_gate_count": 17304
+          },
+          "failure_fields": {
+            "A_forward": 0,
+            "A_inverse": 0,
+            "D_forward": 0,
+            "D_inverse": 0
+          },
+          "maximum_route_length_or_G_distance_by_stage": {
+            "A": 8,
+            "D": 24
+          },
+          "route_transitions_by_stage": {
+            "A": 78,
+            "D": 17304
+          },
+          "routes_checked_by_stage": {
+            "A": 200,
+            "D": 17304
+          },
+          "total_failures": 0
+        },
+        "shape": [
+          2,
+          2,
+          2
+        ],
+        "slot_counts_per_stage": {
+          "A": 225,
+          "B": 18,
+          "C": 0,
+          "D": 17304
+        },
+        "variant": "alternate_port",
+        "word_counts_per_stage": {
+          "A": 368,
+          "B": 18,
+          "C": 0,
+          "D": 17304
+        }
+      },
+      "primary": {
+        "census": {
+          "Bell_edge_correction_route_return": {
+            "distinct_register_count": 8,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "C",
+            "touched_register_count": 24,
+            "words": 12
+          },
+          "Bell_edge_measure": {
+            "distinct_register_count": 156,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "B",
+            "touched_register_count": 300,
+            "words": 12
+          },
+          "Bell_edge_private_dual": {
+            "distinct_register_count": 32,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "C",
+            "touched_register_count": 48,
+            "words": 12
+          },
+          "Bell_edge_route_return": {
+            "distinct_register_count": 8,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "B",
+            "touched_register_count": 24,
+            "words": 12
+          },
+          "Bell_onsite_XX_measure": {
+            "distinct_register_count": 136,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "B",
+            "touched_register_count": 200,
+            "words": 40
+          },
+          "Bell_onsite_XX_private_dual": {
+            "distinct_register_count": 100,
+            "layer_count": 40,
+            "slots": 40,
+            "stage": "C",
+            "touched_register_count": 220,
+            "words": 40
+          },
+          "Bell_onsite_Z_measure": {
+            "distinct_register_count": 144,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "B",
+            "touched_register_count": 144,
+            "words": 48
+          },
+          "Bell_onsite_Z_private_dual": {
+            "distinct_register_count": 120,
+            "layer_count": 48,
+            "slots": 48,
+            "stage": "C",
+            "touched_register_count": 168,
+            "words": 48
+          },
+          "G_coin_coin_givens": {
+            "distinct_register_count": 80,
+            "layer_count": 80,
+            "slots": 80,
+            "stage": "D",
+            "touched_register_count": 160,
+            "words": 80
+          },
+          "G_coin_coin_phase": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_onsite_contact": {
+            "distinct_register_count": 80,
+            "layer_count": 120,
+            "slots": 120,
+            "stage": "D",
+            "touched_register_count": 240,
+            "words": 120
+          },
+          "G_reverse_FSWAP": {
+            "distinct_register_count": 48,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 48,
+            "words": 24
+          },
+          "G_route_swap": {
+            "distinct_register_count": 540,
+            "layer_count": 16256,
+            "slots": 16256,
+            "stage": "D",
+            "touched_register_count": 32512,
+            "words": 16256
+          },
+          "G_seam_c(0, 0)_f0_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 0)_f1_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 0)_f2_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 0)_f2_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(0, 0)_f2_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 4,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 16
+          },
+          "G_seam_c(0, 0)_f3_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 0)_f3_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(0, 0)_f3_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 4,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 16
+          },
+          "G_seam_c(0, 1)_f0_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 1)_f1_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 1)_f2_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 1)_f2_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(0, 1)_f2_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 4,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 16
+          },
+          "G_seam_c(0, 1)_f3_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(0, 1)_f3_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(0, 1)_f3_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 4,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 16
+          },
+          "G_seam_c(1, 0)_f0_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 0)_f1_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 0)_f2_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 0)_f2_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(1, 0)_f2_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 40,
+            "slots": 40,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 40
+          },
+          "G_seam_c(1, 0)_f3_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 0)_f3_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(1, 0)_f3_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 40,
+            "slots": 40,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 40
+          },
+          "G_seam_c(1, 1)_f0_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 1)_f1_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 1)_f2_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 1)_f2_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(1, 1)_f2_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 40,
+            "slots": 40,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 40
+          },
+          "G_seam_c(1, 1)_f3_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(1, 1)_f3_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(1, 1)_f3_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(1, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 40,
+            "slots": 40,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 40
+          },
+          "G_seam_c(2, 0)_f0_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 0)_f1_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 0)_f2_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 0)_f2_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 0)_f2_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 64,
+            "slots": 64,
+            "stage": "D",
+            "touched_register_count": 128,
+            "words": 64
+          },
+          "G_seam_c(2, 0)_f3_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 0)_f3_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 0)_f3_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 64,
+            "slots": 64,
+            "stage": "D",
+            "touched_register_count": 128,
+            "words": 64
+          },
+          "G_seam_c(2, 1)_f0_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 1)_f1_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 1)_f2_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 1)_f2_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 1)_f2_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 64,
+            "slots": 64,
+            "stage": "D",
+            "touched_register_count": 128,
+            "words": 64
+          },
+          "G_seam_c(2, 1)_f3_axis_RZ": {
+            "distinct_register_count": 2,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "D",
+            "touched_register_count": 2,
+            "words": 2
+          },
+          "G_seam_c(2, 1)_f3_basis_H": {
+            "distinct_register_count": 8,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 1)_f3_basis_S": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(2, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 64,
+            "slots": 64,
+            "stage": "D",
+            "touched_register_count": 128,
+            "words": 64
+          },
+          "encoded_bank_supply": {
+            "distinct_register_count": 24,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "A",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "pump_Bell_init": {
+            "distinct_register_count": 240,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "A",
+            "touched_register_count": 240,
+            "words": 120
+          },
+          "pump_onsite_XX_measure": {
+            "distinct_register_count": 136,
+            "layer_count": 40,
+            "slots": 40,
+            "stage": "A",
+            "touched_register_count": 200,
+            "words": 40
+          },
+          "pump_onsite_XX_private_dual": {
+            "distinct_register_count": 100,
+            "layer_count": 40,
+            "slots": 40,
+            "stage": "A",
+            "touched_register_count": 220,
+            "words": 40
+          },
+          "pump_onsite_Z_measure": {
+            "distinct_register_count": 144,
+            "layer_count": 48,
+            "slots": 48,
+            "stage": "A",
+            "touched_register_count": 144,
+            "words": 48
+          },
+          "pump_onsite_Z_private_dual": {
+            "distinct_register_count": 120,
+            "layer_count": 48,
+            "slots": 48,
+            "stage": "A",
+            "touched_register_count": 168,
+            "words": 48
+          },
+          "pump_plaquette_correction_route_return": {
+            "distinct_register_count": 6,
+            "layer_count": 5,
+            "slots": 5,
+            "stage": "A",
+            "touched_register_count": 10,
+            "words": 5
+          },
+          "pump_plaquette_measure": {
+            "distinct_register_count": 117,
+            "layer_count": 5,
+            "slots": 5,
+            "stage": "A",
+            "touched_register_count": 205,
+            "words": 5
+          },
+          "pump_plaquette_private_dual": {
+            "distinct_register_count": 16,
+            "layer_count": 5,
+            "slots": 5,
+            "stage": "A",
+            "touched_register_count": 20,
+            "words": 5
+          },
+          "pump_plaquette_route_return": {
+            "distinct_register_count": 6,
+            "layer_count": 5,
+            "slots": 5,
+            "stage": "A",
+            "touched_register_count": 10,
+            "words": 5
+          },
+          "pump_tree_correction_route_return": {
+            "distinct_register_count": 8,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "A",
+            "touched_register_count": 14,
+            "words": 7
+          },
+          "pump_tree_measure": {
+            "distinct_register_count": 125,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "A",
+            "touched_register_count": 193,
+            "words": 7
+          },
+          "pump_tree_private_dual": {
+            "distinct_register_count": 22,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "A",
+            "touched_register_count": 28,
+            "words": 7
+          },
+          "pump_tree_route_return": {
+            "distinct_register_count": 8,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "A",
+            "touched_register_count": 14,
+            "words": 7
+          }
+        },
+        "lawful": true,
+        "liveness_walk": {
+          "accounting": "literal slot walk: clean -> live(owner stage/word) -> retained; retained reads/writes require an executed declared handoff",
+          "collision_count": 0,
+          "final_state_census": {
+            "retained": 944
+          },
+          "handoffs_consumed": 504,
+          "handoffs_declared": 504,
+          "register_touches": 36882,
+          "registers_seen": 944,
+          "slots_walked": 17650,
+          "violation_count": 0,
+          "violations": [],
+          "words_walked": 17896
+        },
+        "routes": {
+          "G_route_report": {
+            "maximum_route_distance": 24,
+            "non_NN_failures": 0,
+            "route_return_failures": 0,
+            "routed_gate_count": 17304
+          },
+          "failure_fields": {
+            "A_forward": 0,
+            "A_inverse": 0,
+            "B_forward": 0,
+            "B_inverse": 0,
+            "C_forward": 0,
+            "C_inverse": 0,
+            "D_forward": 0,
+            "D_inverse": 0
+          },
+          "maximum_route_length_or_G_distance_by_stage": {
+            "A": 8,
+            "B": 2,
+            "C": 2,
+            "D": 24
+          },
+          "route_transitions_by_stage": {
+            "A": 78,
+            "B": 24,
+            "C": 24,
+            "D": 17304
+          },
+          "routes_checked_by_stage": {
+            "A": 200,
+            "B": 100,
+            "C": 100,
+            "D": 17304
+          },
+          "total_failures": 0
+        },
+        "shape": [
+          2,
+          2,
+          2
+        ],
+        "slot_counts_per_stage": {
+          "A": 225,
+          "B": 9,
+          "C": 112,
+          "D": 17304
+        },
+        "variant": "primary",
+        "word_counts_per_stage": {
+          "A": 368,
+          "B": 112,
+          "C": 112,
+          "D": 17304
+        }
+      }
+    },
+    "3x2x2": {
+      "alternate_port": {
+        "census": {
+          "G_coin_coin_givens": {
+            "distinct_register_count": 120,
+            "layer_count": 120,
+            "slots": 120,
+            "stage": "D",
+            "touched_register_count": 240,
+            "words": 120
+          },
+          "G_coin_coin_phase": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_onsite_contact": {
+            "distinct_register_count": 120,
+            "layer_count": 180,
+            "slots": 180,
+            "stage": "D",
+            "touched_register_count": 360,
+            "words": 180
+          },
+          "G_reverse_FSWAP": {
+            "distinct_register_count": 72,
+            "layer_count": 36,
+            "slots": 36,
+            "stage": "D",
+            "touched_register_count": 72,
+            "words": 36
+          },
+          "G_route_swap": {
+            "distinct_register_count": 824,
+            "layer_count": 25280,
+            "slots": 25280,
+            "stage": "D",
+            "touched_register_count": 50560,
+            "words": 25280
+          },
+          "G_seam_c(0, 0)_f0_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f1_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f2_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f2_basis_H": {
+            "distinct_register_count": 16,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 32
+          },
+          "G_seam_c(0, 0)_f2_basis_S": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 64,
+            "words": 32
+          },
+          "G_seam_c(0, 0)_f3_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f3_basis_H": {
+            "distinct_register_count": 16,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 32
+          },
+          "G_seam_c(0, 0)_f3_basis_S": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 64,
+            "words": 32
+          },
+          "G_seam_c(0, 1)_f0_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f1_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f2_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f2_basis_H": {
+            "distinct_register_count": 16,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 32
+          },
+          "G_seam_c(0, 1)_f2_basis_S": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 64,
+            "words": 32
+          },
+          "G_seam_c(0, 1)_f3_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f3_basis_H": {
+            "distinct_register_count": 16,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 32
+          },
+          "G_seam_c(0, 1)_f3_basis_S": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 64,
+            "words": 32
+          },
+          "G_seam_c(1, 0)_f0_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 0)_f1_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 0)_f2_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 0)_f2_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(1, 0)_f2_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 60,
+            "slots": 60,
+            "stage": "D",
+            "touched_register_count": 120,
+            "words": 60
+          },
+          "G_seam_c(1, 0)_f3_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 0)_f3_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(1, 0)_f3_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 60,
+            "slots": 60,
+            "stage": "D",
+            "touched_register_count": 120,
+            "words": 60
+          },
+          "G_seam_c(1, 1)_f0_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 1)_f1_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 1)_f2_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 1)_f2_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(1, 1)_f2_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 60,
+            "slots": 60,
+            "stage": "D",
+            "touched_register_count": 120,
+            "words": 60
+          },
+          "G_seam_c(1, 1)_f3_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 1)_f3_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(1, 1)_f3_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 60,
+            "slots": 60,
+            "stage": "D",
+            "touched_register_count": 120,
+            "words": 60
+          },
+          "G_seam_c(2, 0)_f0_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 0)_f1_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 0)_f2_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 0)_f2_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(2, 0)_f2_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 18,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(2, 0)_f3_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 0)_f3_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(2, 0)_f3_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 18,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(2, 1)_f0_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 1)_f1_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 1)_f2_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 1)_f2_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(2, 1)_f2_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 18,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(2, 1)_f3_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 1)_f3_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(2, 1)_f3_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 18,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "encoded_bank_supply": {
+            "distinct_register_count": 36,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "A",
+            "touched_register_count": 36,
+            "words": 36
+          },
+          "port_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 18,
+            "slots": 18,
+            "stage": "B",
+            "touched_register_count": 36,
+            "words": 18
+          },
+          "pump_Bell_init": {
+            "distinct_register_count": 360,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "A",
+            "touched_register_count": 360,
+            "words": 180
+          },
+          "pump_onsite_XX_measure": {
+            "distinct_register_count": 204,
+            "layer_count": 60,
+            "slots": 60,
+            "stage": "A",
+            "touched_register_count": 300,
+            "words": 60
+          },
+          "pump_onsite_XX_private_dual": {
+            "distinct_register_count": 152,
+            "layer_count": 60,
+            "slots": 60,
+            "stage": "A",
+            "touched_register_count": 324,
+            "words": 60
+          },
+          "pump_onsite_Z_measure": {
+            "distinct_register_count": 216,
+            "layer_count": 72,
+            "slots": 72,
+            "stage": "A",
+            "touched_register_count": 216,
+            "words": 72
+          },
+          "pump_onsite_Z_private_dual": {
+            "distinct_register_count": 180,
+            "layer_count": 72,
+            "slots": 72,
+            "stage": "A",
+            "touched_register_count": 252,
+            "words": 72
+          },
+          "pump_plaquette_correction_route_return": {
+            "distinct_register_count": 9,
+            "layer_count": 9,
+            "slots": 9,
+            "stage": "A",
+            "touched_register_count": 18,
+            "words": 9
+          },
+          "pump_plaquette_measure": {
+            "distinct_register_count": 181,
+            "layer_count": 9,
+            "slots": 9,
+            "stage": "A",
+            "touched_register_count": 373,
+            "words": 9
+          },
+          "pump_plaquette_private_dual": {
+            "distinct_register_count": 32,
+            "layer_count": 9,
+            "slots": 9,
+            "stage": "A",
+            "touched_register_count": 42,
+            "words": 9
+          },
+          "pump_plaquette_route_return": {
+            "distinct_register_count": 9,
+            "layer_count": 9,
+            "slots": 9,
+            "stage": "A",
+            "touched_register_count": 18,
+            "words": 9
+          },
+          "pump_tree_correction_route_return": {
+            "distinct_register_count": 12,
+            "layer_count": 11,
+            "slots": 11,
+            "stage": "A",
+            "touched_register_count": 22,
+            "words": 11
+          },
+          "pump_tree_measure": {
+            "distinct_register_count": 191,
+            "layer_count": 11,
+            "slots": 11,
+            "stage": "A",
+            "touched_register_count": 307,
+            "words": 11
+          },
+          "pump_tree_private_dual": {
+            "distinct_register_count": 36,
+            "layer_count": 11,
+            "slots": 11,
+            "stage": "A",
+            "touched_register_count": 46,
+            "words": 11
+          },
+          "pump_tree_route_return": {
+            "distinct_register_count": 12,
+            "layer_count": 11,
+            "slots": 11,
+            "stage": "A",
+            "touched_register_count": 22,
+            "words": 11
+          }
+        },
+        "lawful": true,
+        "liveness_walk": {
+          "accounting": "literal slot walk: clean -> live(owner stage/word) -> retained; retained reads/writes require an executed declared handoff",
+          "collision_count": 0,
+          "final_state_census": {
+            "retained": 1282
+          },
+          "handoffs_consumed": 272,
+          "handoffs_declared": 272,
+          "register_touches": 55680,
+          "registers_seen": 1282,
+          "slots_walked": 27303,
+          "violation_count": 0,
+          "violations": [],
+          "words_walked": 27518
+        },
+        "routes": {
+          "G_route_report": {
+            "maximum_route_distance": 24,
+            "non_NN_failures": 0,
+            "route_return_failures": 0,
+            "routed_gate_count": 26940
+          },
+          "failure_fields": {
+            "A_forward": 0,
+            "A_inverse": 0,
+            "D_forward": 0,
+            "D_inverse": 0
+          },
+          "maximum_route_length_or_G_distance_by_stage": {
+            "A": 8,
+            "D": 24
+          },
+          "route_transitions_by_stage": {
+            "A": 134,
+            "D": 26940
+          },
+          "routes_checked_by_stage": {
+            "A": 304,
+            "D": 26940
+          },
+          "total_failures": 0
+        },
+        "shape": [
+          3,
+          2,
+          2
+        ],
+        "slot_counts_per_stage": {
+          "A": 345,
+          "B": 18,
+          "C": 0,
+          "D": 26940
+        },
+        "variant": "alternate_port",
+        "word_counts_per_stage": {
+          "A": 560,
+          "B": 18,
+          "C": 0,
+          "D": 26940
+        }
+      },
+      "primary": {
+        "census": {
+          "Bell_edge_correction_route_return": {
+            "distinct_register_count": 12,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "C",
+            "touched_register_count": 40,
+            "words": 20
+          },
+          "Bell_edge_measure": {
+            "distinct_register_count": 236,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "B",
+            "touched_register_count": 476,
+            "words": 20
+          },
+          "Bell_edge_private_dual": {
+            "distinct_register_count": 56,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "C",
+            "touched_register_count": 88,
+            "words": 20
+          },
+          "Bell_edge_route_return": {
+            "distinct_register_count": 12,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "B",
+            "touched_register_count": 40,
+            "words": 20
+          },
+          "Bell_onsite_XX_measure": {
+            "distinct_register_count": 204,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "B",
+            "touched_register_count": 300,
+            "words": 60
+          },
+          "Bell_onsite_XX_private_dual": {
+            "distinct_register_count": 152,
+            "layer_count": 60,
+            "slots": 60,
+            "stage": "C",
+            "touched_register_count": 324,
+            "words": 60
+          },
+          "Bell_onsite_Z_measure": {
+            "distinct_register_count": 216,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "B",
+            "touched_register_count": 216,
+            "words": 72
+          },
+          "Bell_onsite_Z_private_dual": {
+            "distinct_register_count": 180,
+            "layer_count": 72,
+            "slots": 72,
+            "stage": "C",
+            "touched_register_count": 252,
+            "words": 72
+          },
+          "G_coin_coin_givens": {
+            "distinct_register_count": 120,
+            "layer_count": 120,
+            "slots": 120,
+            "stage": "D",
+            "touched_register_count": 240,
+            "words": 120
+          },
+          "G_coin_coin_phase": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_onsite_contact": {
+            "distinct_register_count": 120,
+            "layer_count": 180,
+            "slots": 180,
+            "stage": "D",
+            "touched_register_count": 360,
+            "words": 180
+          },
+          "G_reverse_FSWAP": {
+            "distinct_register_count": 72,
+            "layer_count": 36,
+            "slots": 36,
+            "stage": "D",
+            "touched_register_count": 72,
+            "words": 36
+          },
+          "G_route_swap": {
+            "distinct_register_count": 824,
+            "layer_count": 25280,
+            "slots": 25280,
+            "stage": "D",
+            "touched_register_count": 50560,
+            "words": 25280
+          },
+          "G_seam_c(0, 0)_f0_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f1_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f2_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f2_basis_H": {
+            "distinct_register_count": 16,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 32
+          },
+          "G_seam_c(0, 0)_f2_basis_S": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 64,
+            "words": 32
+          },
+          "G_seam_c(0, 0)_f3_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 0)_f3_basis_H": {
+            "distinct_register_count": 16,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 32
+          },
+          "G_seam_c(0, 0)_f3_basis_S": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 64,
+            "words": 32
+          },
+          "G_seam_c(0, 1)_f0_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f1_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f2_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f2_basis_H": {
+            "distinct_register_count": 16,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 32
+          },
+          "G_seam_c(0, 1)_f2_basis_S": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 64,
+            "words": 32
+          },
+          "G_seam_c(0, 1)_f3_axis_RZ": {
+            "distinct_register_count": 4,
+            "layer_count": 4,
+            "slots": 4,
+            "stage": "D",
+            "touched_register_count": 4,
+            "words": 4
+          },
+          "G_seam_c(0, 1)_f3_basis_H": {
+            "distinct_register_count": 16,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 32,
+            "words": 32
+          },
+          "G_seam_c(0, 1)_f3_basis_S": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(0, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 8,
+            "layer_count": 32,
+            "slots": 32,
+            "stage": "D",
+            "touched_register_count": 64,
+            "words": 32
+          },
+          "G_seam_c(1, 0)_f0_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 0)_f1_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 0)_f2_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 0)_f2_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(1, 0)_f2_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 60,
+            "slots": 60,
+            "stage": "D",
+            "touched_register_count": 120,
+            "words": 60
+          },
+          "G_seam_c(1, 0)_f3_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 0)_f3_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(1, 0)_f3_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 60,
+            "slots": 60,
+            "stage": "D",
+            "touched_register_count": 120,
+            "words": 60
+          },
+          "G_seam_c(1, 1)_f0_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 1)_f1_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 1)_f2_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 1)_f2_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(1, 1)_f2_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 60,
+            "slots": 60,
+            "stage": "D",
+            "touched_register_count": 120,
+            "words": 60
+          },
+          "G_seam_c(1, 1)_f3_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(1, 1)_f3_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(1, 1)_f3_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(1, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 60,
+            "slots": 60,
+            "stage": "D",
+            "touched_register_count": 120,
+            "words": 60
+          },
+          "G_seam_c(2, 0)_f0_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 0)_f1_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 0)_f2_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 0)_f2_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(2, 0)_f2_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 18,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(2, 0)_f3_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 0)_f3_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(2, 0)_f3_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 18,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(2, 1)_f0_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 1)_f1_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 1)_f2_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 1)_f2_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(2, 1)_f2_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 18,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(2, 1)_f3_axis_RZ": {
+            "distinct_register_count": 3,
+            "layer_count": 3,
+            "slots": 3,
+            "stage": "D",
+            "touched_register_count": 3,
+            "words": 3
+          },
+          "G_seam_c(2, 1)_f3_basis_H": {
+            "distinct_register_count": 12,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(2, 1)_f3_basis_S": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 6,
+            "layer_count": 6,
+            "slots": 6,
+            "stage": "D",
+            "touched_register_count": 6,
+            "words": 6
+          },
+          "G_seam_c(2, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 18,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "encoded_bank_supply": {
+            "distinct_register_count": 36,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "A",
+            "touched_register_count": 36,
+            "words": 36
+          },
+          "pump_Bell_init": {
+            "distinct_register_count": 360,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "A",
+            "touched_register_count": 360,
+            "words": 180
+          },
+          "pump_onsite_XX_measure": {
+            "distinct_register_count": 204,
+            "layer_count": 60,
+            "slots": 60,
+            "stage": "A",
+            "touched_register_count": 300,
+            "words": 60
+          },
+          "pump_onsite_XX_private_dual": {
+            "distinct_register_count": 152,
+            "layer_count": 60,
+            "slots": 60,
+            "stage": "A",
+            "touched_register_count": 324,
+            "words": 60
+          },
+          "pump_onsite_Z_measure": {
+            "distinct_register_count": 216,
+            "layer_count": 72,
+            "slots": 72,
+            "stage": "A",
+            "touched_register_count": 216,
+            "words": 72
+          },
+          "pump_onsite_Z_private_dual": {
+            "distinct_register_count": 180,
+            "layer_count": 72,
+            "slots": 72,
+            "stage": "A",
+            "touched_register_count": 252,
+            "words": 72
+          },
+          "pump_plaquette_correction_route_return": {
+            "distinct_register_count": 9,
+            "layer_count": 9,
+            "slots": 9,
+            "stage": "A",
+            "touched_register_count": 18,
+            "words": 9
+          },
+          "pump_plaquette_measure": {
+            "distinct_register_count": 181,
+            "layer_count": 9,
+            "slots": 9,
+            "stage": "A",
+            "touched_register_count": 373,
+            "words": 9
+          },
+          "pump_plaquette_private_dual": {
+            "distinct_register_count": 32,
+            "layer_count": 9,
+            "slots": 9,
+            "stage": "A",
+            "touched_register_count": 42,
+            "words": 9
+          },
+          "pump_plaquette_route_return": {
+            "distinct_register_count": 9,
+            "layer_count": 9,
+            "slots": 9,
+            "stage": "A",
+            "touched_register_count": 18,
+            "words": 9
+          },
+          "pump_tree_correction_route_return": {
+            "distinct_register_count": 12,
+            "layer_count": 11,
+            "slots": 11,
+            "stage": "A",
+            "touched_register_count": 22,
+            "words": 11
+          },
+          "pump_tree_measure": {
+            "distinct_register_count": 191,
+            "layer_count": 11,
+            "slots": 11,
+            "stage": "A",
+            "touched_register_count": 307,
+            "words": 11
+          },
+          "pump_tree_private_dual": {
+            "distinct_register_count": 36,
+            "layer_count": 11,
+            "slots": 11,
+            "stage": "A",
+            "touched_register_count": 46,
+            "words": 11
+          },
+          "pump_tree_route_return": {
+            "distinct_register_count": 12,
+            "layer_count": 11,
+            "slots": 11,
+            "stage": "A",
+            "touched_register_count": 22,
+            "words": 11
+          }
+        },
+        "lawful": true,
+        "liveness_walk": {
+          "accounting": "literal slot walk: clean -> live(owner stage/word) -> retained; retained reads/writes require an executed declared handoff",
+          "collision_count": 0,
+          "final_state_census": {
+            "retained": 1434
+          },
+          "handoffs_consumed": 760,
+          "handoffs_declared": 760,
+          "register_touches": 57380,
+          "registers_seen": 1434,
+          "slots_walked": 27468,
+          "violation_count": 0,
+          "violations": [],
+          "words_walked": 27844
+        },
+        "routes": {
+          "G_route_report": {
+            "maximum_route_distance": 24,
+            "non_NN_failures": 0,
+            "route_return_failures": 0,
+            "routed_gate_count": 26940
+          },
+          "failure_fields": {
+            "A_forward": 0,
+            "A_inverse": 0,
+            "B_forward": 0,
+            "B_inverse": 0,
+            "C_forward": 0,
+            "C_inverse": 0,
+            "D_forward": 0,
+            "D_inverse": 0
+          },
+          "maximum_route_length_or_G_distance_by_stage": {
+            "A": 8,
+            "B": 2,
+            "C": 2,
+            "D": 24
+          },
+          "route_transitions_by_stage": {
+            "A": 134,
+            "B": 40,
+            "C": 40,
+            "D": 26940
+          },
+          "routes_checked_by_stage": {
+            "A": 304,
+            "B": 152,
+            "C": 152,
+            "D": 26940
+          },
+          "total_failures": 0
+        },
+        "shape": [
+          3,
+          2,
+          2
+        ],
+        "slot_counts_per_stage": {
+          "A": 345,
+          "B": 11,
+          "C": 172,
+          "D": 26940
+        },
+        "variant": "primary",
+        "word_counts_per_stage": {
+          "A": 560,
+          "B": 172,
+          "C": 172,
+          "D": 26940
+        }
+      }
+    },
+    "5x3x2": {
+      "alternate_port": {
+        "census": {
+          "G_coin_coin_givens": {
+            "distinct_register_count": 300,
+            "layer_count": 300,
+            "slots": 300,
+            "stage": "D",
+            "touched_register_count": 600,
+            "words": 300
+          },
+          "G_coin_coin_phase": {
+            "distinct_register_count": 30,
+            "layer_count": 30,
+            "slots": 30,
+            "stage": "D",
+            "touched_register_count": 30,
+            "words": 30
+          },
+          "G_onsite_contact": {
+            "distinct_register_count": 300,
+            "layer_count": 450,
+            "slots": 450,
+            "stage": "D",
+            "touched_register_count": 900,
+            "words": 450
+          },
+          "G_reverse_FSWAP": {
+            "distinct_register_count": 180,
+            "layer_count": 90,
+            "slots": 90,
+            "stage": "D",
+            "touched_register_count": 180,
+            "words": 90
+          },
+          "G_route_swap": {
+            "distinct_register_count": 2123,
+            "layer_count": 70352,
+            "slots": 70352,
+            "stage": "D",
+            "touched_register_count": 140704,
+            "words": 70352
+          },
+          "G_seam_c(0, 0)_f0_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 0)_f1_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 0)_f2_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 0)_f2_basis_H": {
+            "distinct_register_count": 48,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 96,
+            "words": 96
+          },
+          "G_seam_c(0, 0)_f2_basis_S": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 24,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(0, 0)_f3_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 0)_f3_basis_H": {
+            "distinct_register_count": 48,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 96,
+            "words": 96
+          },
+          "G_seam_c(0, 0)_f3_basis_S": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 24,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(0, 1)_f0_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 1)_f1_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 1)_f2_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 1)_f2_basis_H": {
+            "distinct_register_count": 48,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 96,
+            "words": 96
+          },
+          "G_seam_c(0, 1)_f2_basis_S": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 24,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(0, 1)_f3_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 1)_f3_basis_H": {
+            "distinct_register_count": 48,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 96,
+            "words": 96
+          },
+          "G_seam_c(0, 1)_f3_basis_S": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 24,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(1, 0)_f0_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 0)_f1_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 0)_f2_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 0)_f2_basis_H": {
+            "distinct_register_count": 40,
+            "layer_count": 80,
+            "slots": 80,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 80
+          },
+          "G_seam_c(1, 0)_f2_basis_S": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 40,
+            "layer_count": 200,
+            "slots": 200,
+            "stage": "D",
+            "touched_register_count": 400,
+            "words": 200
+          },
+          "G_seam_c(1, 0)_f3_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 0)_f3_basis_H": {
+            "distinct_register_count": 40,
+            "layer_count": 80,
+            "slots": 80,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 80
+          },
+          "G_seam_c(1, 0)_f3_basis_S": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 40,
+            "layer_count": 200,
+            "slots": 200,
+            "stage": "D",
+            "touched_register_count": 400,
+            "words": 200
+          },
+          "G_seam_c(1, 1)_f0_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 1)_f1_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 1)_f2_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 1)_f2_basis_H": {
+            "distinct_register_count": 40,
+            "layer_count": 80,
+            "slots": 80,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 80
+          },
+          "G_seam_c(1, 1)_f2_basis_S": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 40,
+            "layer_count": 200,
+            "slots": 200,
+            "stage": "D",
+            "touched_register_count": 400,
+            "words": 200
+          },
+          "G_seam_c(1, 1)_f3_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 1)_f3_basis_H": {
+            "distinct_register_count": 40,
+            "layer_count": 80,
+            "slots": 80,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 80
+          },
+          "G_seam_c(1, 1)_f3_basis_S": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 40,
+            "layer_count": 200,
+            "slots": 200,
+            "stage": "D",
+            "touched_register_count": 400,
+            "words": 200
+          },
+          "G_seam_c(2, 0)_f0_axis_RZ": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(2, 0)_f1_axis_RZ": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(2, 0)_f2_axis_RZ": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(2, 0)_f2_basis_H": {
+            "distinct_register_count": 32,
+            "layer_count": 64,
+            "slots": 64,
+            "stage": "D",
+            "touched_register_count": 64,
+            "words": 64
+          },
+          "G_seam_c(2, 0)_f2_basis_S": {
+            "distinct_register_count": 16,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 16,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 48,
+            "layer_count": 256,
+            "slots": 256,
+            "stage": "D",
+            "touched_register_count": 512,
+            "words": 256
+          },
+          "G_seam_c(2, 0)_f3_axis_RZ": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(2, 0)_f3_basis_H": {
+            "distinct_register_count": 32,
+            "layer_count": 64,
+            "slots": 64,
+            "stage": "D",
+            "touched_register_count": 64,
+            "words": 64
+          },
+          "G_seam_c(2, 0)_f3_basis_S": {
+            "distinct_register_count": 16,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 16,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 48,
+            "layer_count": 256,
+            "slots": 256,
+            "stage": "D",
+            "touched_register_count": 512,
+            "words": 256
+          },
+          "G_seam_c(2, 1)_f0_axis_RZ": {
+            "distinct_register_count": 7,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "D",
+            "touched_register_count": 7,
+            "words": 7
+          },
+          "G_seam_c(2, 1)_f1_axis_RZ": {
+            "distinct_register_count": 7,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "D",
+            "touched_register_count": 7,
+            "words": 7
+          },
+          "G_seam_c(2, 1)_f2_axis_RZ": {
+            "distinct_register_count": 7,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "D",
+            "touched_register_count": 7,
+            "words": 7
+          },
+          "G_seam_c(2, 1)_f2_basis_H": {
+            "distinct_register_count": 28,
+            "layer_count": 56,
+            "slots": 56,
+            "stage": "D",
+            "touched_register_count": 56,
+            "words": 56
+          },
+          "G_seam_c(2, 1)_f2_basis_S": {
+            "distinct_register_count": 14,
+            "layer_count": 14,
+            "slots": 14,
+            "stage": "D",
+            "touched_register_count": 14,
+            "words": 14
+          },
+          "G_seam_c(2, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 14,
+            "layer_count": 14,
+            "slots": 14,
+            "stage": "D",
+            "touched_register_count": 14,
+            "words": 14
+          },
+          "G_seam_c(2, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 42,
+            "layer_count": 224,
+            "slots": 224,
+            "stage": "D",
+            "touched_register_count": 448,
+            "words": 224
+          },
+          "G_seam_c(2, 1)_f3_axis_RZ": {
+            "distinct_register_count": 7,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "D",
+            "touched_register_count": 7,
+            "words": 7
+          },
+          "G_seam_c(2, 1)_f3_basis_H": {
+            "distinct_register_count": 28,
+            "layer_count": 56,
+            "slots": 56,
+            "stage": "D",
+            "touched_register_count": 56,
+            "words": 56
+          },
+          "G_seam_c(2, 1)_f3_basis_S": {
+            "distinct_register_count": 14,
+            "layer_count": 14,
+            "slots": 14,
+            "stage": "D",
+            "touched_register_count": 14,
+            "words": 14
+          },
+          "G_seam_c(2, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 14,
+            "layer_count": 14,
+            "slots": 14,
+            "stage": "D",
+            "touched_register_count": 14,
+            "words": 14
+          },
+          "G_seam_c(2, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 42,
+            "layer_count": 224,
+            "slots": 224,
+            "stage": "D",
+            "touched_register_count": 448,
+            "words": 224
+          },
+          "encoded_bank_supply": {
+            "distinct_register_count": 90,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "A",
+            "touched_register_count": 90,
+            "words": 90
+          },
+          "port_CNOT": {
+            "distinct_register_count": 12,
+            "layer_count": 18,
+            "slots": 18,
+            "stage": "B",
+            "touched_register_count": 36,
+            "words": 18
+          },
+          "pump_Bell_init": {
+            "distinct_register_count": 900,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "A",
+            "touched_register_count": 900,
+            "words": 450
+          },
+          "pump_onsite_XX_measure": {
+            "distinct_register_count": 510,
+            "layer_count": 150,
+            "slots": 150,
+            "stage": "A",
+            "touched_register_count": 750,
+            "words": 150
+          },
+          "pump_onsite_XX_private_dual": {
+            "distinct_register_count": 384,
+            "layer_count": 150,
+            "slots": 150,
+            "stage": "A",
+            "touched_register_count": 793,
+            "words": 150
+          },
+          "pump_onsite_Z_measure": {
+            "distinct_register_count": 540,
+            "layer_count": 180,
+            "slots": 180,
+            "stage": "A",
+            "touched_register_count": 540,
+            "words": 180
+          },
+          "pump_onsite_Z_private_dual": {
+            "distinct_register_count": 450,
+            "layer_count": 180,
+            "slots": 180,
+            "stage": "A",
+            "touched_register_count": 630,
+            "words": 180
+          },
+          "pump_plaquette_correction_route_return": {
+            "distinct_register_count": 25,
+            "layer_count": 30,
+            "slots": 30,
+            "stage": "A",
+            "touched_register_count": 60,
+            "words": 30
+          },
+          "pump_plaquette_measure": {
+            "distinct_register_count": 468,
+            "layer_count": 30,
+            "slots": 30,
+            "stage": "A",
+            "touched_register_count": 1190,
+            "words": 30
+          },
+          "pump_plaquette_private_dual": {
+            "distinct_register_count": 111,
+            "layer_count": 30,
+            "slots": 30,
+            "stage": "A",
+            "touched_register_count": 155,
+            "words": 30
+          },
+          "pump_plaquette_route_return": {
+            "distinct_register_count": 25,
+            "layer_count": 30,
+            "slots": 30,
+            "stage": "A",
+            "touched_register_count": 60,
+            "words": 30
+          },
+          "pump_tree_correction_route_return": {
+            "distinct_register_count": 30,
+            "layer_count": 29,
+            "slots": 29,
+            "stage": "A",
+            "touched_register_count": 58,
+            "words": 29
+          },
+          "pump_tree_measure": {
+            "distinct_register_count": 488,
+            "layer_count": 29,
+            "slots": 29,
+            "stage": "A",
+            "touched_register_count": 856,
+            "words": 29
+          },
+          "pump_tree_private_dual": {
+            "distinct_register_count": 99,
+            "layer_count": 29,
+            "slots": 29,
+            "stage": "A",
+            "touched_register_count": 127,
+            "words": 29
+          },
+          "pump_tree_route_return": {
+            "distinct_register_count": 30,
+            "layer_count": 29,
+            "slots": 29,
+            "stage": "A",
+            "touched_register_count": 58,
+            "words": 29
+          }
+        },
+        "lawful": true,
+        "liveness_walk": {
+          "accounting": "literal slot walk: clean -> live(owner stage/word) -> retained; retained reads/writes require an executed declared handoff",
+          "collision_count": 0,
+          "final_state_census": {
+            "retained": 3277
+          },
+          "handoffs_consumed": 671,
+          "handoffs_declared": 671,
+          "register_touches": 154657,
+          "registers_seen": 3277,
+          "slots_walked": 75933,
+          "violation_count": 0,
+          "violations": [],
+          "words_walked": 76472
+        },
+        "routes": {
+          "G_route_report": {
+            "maximum_route_distance": 24,
+            "non_NN_failures": 0,
+            "route_return_failures": 0,
+            "routed_gate_count": 75018
+          },
+          "failure_fields": {
+            "A_forward": 0,
+            "A_inverse": 0,
+            "D_forward": 0,
+            "D_inverse": 0
+          },
+          "maximum_route_length_or_G_distance_by_stage": {
+            "A": 12,
+            "D": 24
+          },
+          "route_transitions_by_stage": {
+            "A": 416,
+            "D": 75018
+          },
+          "routes_checked_by_stage": {
+            "A": 778,
+            "D": 75018
+          },
+          "total_failures": 0
+        },
+        "shape": [
+          5,
+          3,
+          2
+        ],
+        "slot_counts_per_stage": {
+          "A": 897,
+          "B": 18,
+          "C": 0,
+          "D": 75018
+        },
+        "variant": "alternate_port",
+        "word_counts_per_stage": {
+          "A": 1436,
+          "B": 18,
+          "C": 0,
+          "D": 75018
+        }
+      },
+      "primary": {
+        "census": {
+          "Bell_edge_correction_route_return": {
+            "distinct_register_count": 30,
+            "layer_count": 59,
+            "slots": 59,
+            "stage": "C",
+            "touched_register_count": 118,
+            "words": 59
+          },
+          "Bell_edge_measure": {
+            "distinct_register_count": 599,
+            "layer_count": 5,
+            "slots": 5,
+            "stage": "B",
+            "touched_register_count": 1367,
+            "words": 59
+          },
+          "Bell_edge_private_dual": {
+            "distinct_register_count": 165,
+            "layer_count": 59,
+            "slots": 59,
+            "stage": "C",
+            "touched_register_count": 282,
+            "words": 59
+          },
+          "Bell_edge_route_return": {
+            "distinct_register_count": 30,
+            "layer_count": 5,
+            "slots": 5,
+            "stage": "B",
+            "touched_register_count": 118,
+            "words": 59
+          },
+          "Bell_onsite_XX_measure": {
+            "distinct_register_count": 510,
+            "layer_count": 2,
+            "slots": 2,
+            "stage": "B",
+            "touched_register_count": 750,
+            "words": 150
+          },
+          "Bell_onsite_XX_private_dual": {
+            "distinct_register_count": 384,
+            "layer_count": 150,
+            "slots": 150,
+            "stage": "C",
+            "touched_register_count": 793,
+            "words": 150
+          },
+          "Bell_onsite_Z_measure": {
+            "distinct_register_count": 540,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "B",
+            "touched_register_count": 540,
+            "words": 180
+          },
+          "Bell_onsite_Z_private_dual": {
+            "distinct_register_count": 450,
+            "layer_count": 180,
+            "slots": 180,
+            "stage": "C",
+            "touched_register_count": 630,
+            "words": 180
+          },
+          "G_coin_coin_givens": {
+            "distinct_register_count": 300,
+            "layer_count": 300,
+            "slots": 300,
+            "stage": "D",
+            "touched_register_count": 600,
+            "words": 300
+          },
+          "G_coin_coin_phase": {
+            "distinct_register_count": 30,
+            "layer_count": 30,
+            "slots": 30,
+            "stage": "D",
+            "touched_register_count": 30,
+            "words": 30
+          },
+          "G_onsite_contact": {
+            "distinct_register_count": 300,
+            "layer_count": 450,
+            "slots": 450,
+            "stage": "D",
+            "touched_register_count": 900,
+            "words": 450
+          },
+          "G_reverse_FSWAP": {
+            "distinct_register_count": 180,
+            "layer_count": 90,
+            "slots": 90,
+            "stage": "D",
+            "touched_register_count": 180,
+            "words": 90
+          },
+          "G_route_swap": {
+            "distinct_register_count": 2123,
+            "layer_count": 70352,
+            "slots": 70352,
+            "stage": "D",
+            "touched_register_count": 140704,
+            "words": 70352
+          },
+          "G_seam_c(0, 0)_f0_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 0)_f1_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 0)_f2_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 0)_f2_basis_H": {
+            "distinct_register_count": 48,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 96,
+            "words": 96
+          },
+          "G_seam_c(0, 0)_f2_basis_S": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 24,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(0, 0)_f3_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 0)_f3_basis_H": {
+            "distinct_register_count": 48,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 96,
+            "words": 96
+          },
+          "G_seam_c(0, 0)_f3_basis_S": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 24,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(0, 1)_f0_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 1)_f1_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 1)_f2_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 1)_f2_basis_H": {
+            "distinct_register_count": 48,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 96,
+            "words": 96
+          },
+          "G_seam_c(0, 1)_f2_basis_S": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 24,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(0, 1)_f3_axis_RZ": {
+            "distinct_register_count": 12,
+            "layer_count": 12,
+            "slots": 12,
+            "stage": "D",
+            "touched_register_count": 12,
+            "words": 12
+          },
+          "G_seam_c(0, 1)_f3_basis_H": {
+            "distinct_register_count": 48,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 96,
+            "words": 96
+          },
+          "G_seam_c(0, 1)_f3_basis_S": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 24,
+            "layer_count": 24,
+            "slots": 24,
+            "stage": "D",
+            "touched_register_count": 24,
+            "words": 24
+          },
+          "G_seam_c(0, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 24,
+            "layer_count": 96,
+            "slots": 96,
+            "stage": "D",
+            "touched_register_count": 192,
+            "words": 96
+          },
+          "G_seam_c(1, 0)_f0_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 0)_f1_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 0)_f2_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 0)_f2_basis_H": {
+            "distinct_register_count": 40,
+            "layer_count": 80,
+            "slots": 80,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 80
+          },
+          "G_seam_c(1, 0)_f2_basis_S": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 40,
+            "layer_count": 200,
+            "slots": 200,
+            "stage": "D",
+            "touched_register_count": 400,
+            "words": 200
+          },
+          "G_seam_c(1, 0)_f3_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 0)_f3_basis_H": {
+            "distinct_register_count": 40,
+            "layer_count": 80,
+            "slots": 80,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 80
+          },
+          "G_seam_c(1, 0)_f3_basis_S": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 40,
+            "layer_count": 200,
+            "slots": 200,
+            "stage": "D",
+            "touched_register_count": 400,
+            "words": 200
+          },
+          "G_seam_c(1, 1)_f0_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 1)_f1_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 1)_f2_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 1)_f2_basis_H": {
+            "distinct_register_count": 40,
+            "layer_count": 80,
+            "slots": 80,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 80
+          },
+          "G_seam_c(1, 1)_f2_basis_S": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 40,
+            "layer_count": 200,
+            "slots": 200,
+            "stage": "D",
+            "touched_register_count": 400,
+            "words": 200
+          },
+          "G_seam_c(1, 1)_f3_axis_RZ": {
+            "distinct_register_count": 10,
+            "layer_count": 10,
+            "slots": 10,
+            "stage": "D",
+            "touched_register_count": 10,
+            "words": 10
+          },
+          "G_seam_c(1, 1)_f3_basis_H": {
+            "distinct_register_count": 40,
+            "layer_count": 80,
+            "slots": 80,
+            "stage": "D",
+            "touched_register_count": 80,
+            "words": 80
+          },
+          "G_seam_c(1, 1)_f3_basis_S": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 20,
+            "layer_count": 20,
+            "slots": 20,
+            "stage": "D",
+            "touched_register_count": 20,
+            "words": 20
+          },
+          "G_seam_c(1, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 40,
+            "layer_count": 200,
+            "slots": 200,
+            "stage": "D",
+            "touched_register_count": 400,
+            "words": 200
+          },
+          "G_seam_c(2, 0)_f0_axis_RZ": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(2, 0)_f1_axis_RZ": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(2, 0)_f2_axis_RZ": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(2, 0)_f2_basis_H": {
+            "distinct_register_count": 32,
+            "layer_count": 64,
+            "slots": 64,
+            "stage": "D",
+            "touched_register_count": 64,
+            "words": 64
+          },
+          "G_seam_c(2, 0)_f2_basis_S": {
+            "distinct_register_count": 16,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 0)_f2_basis_Sdg": {
+            "distinct_register_count": 16,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 0)_f2_parity_CNOT": {
+            "distinct_register_count": 48,
+            "layer_count": 256,
+            "slots": 256,
+            "stage": "D",
+            "touched_register_count": 512,
+            "words": 256
+          },
+          "G_seam_c(2, 0)_f3_axis_RZ": {
+            "distinct_register_count": 8,
+            "layer_count": 8,
+            "slots": 8,
+            "stage": "D",
+            "touched_register_count": 8,
+            "words": 8
+          },
+          "G_seam_c(2, 0)_f3_basis_H": {
+            "distinct_register_count": 32,
+            "layer_count": 64,
+            "slots": 64,
+            "stage": "D",
+            "touched_register_count": 64,
+            "words": 64
+          },
+          "G_seam_c(2, 0)_f3_basis_S": {
+            "distinct_register_count": 16,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 0)_f3_basis_Sdg": {
+            "distinct_register_count": 16,
+            "layer_count": 16,
+            "slots": 16,
+            "stage": "D",
+            "touched_register_count": 16,
+            "words": 16
+          },
+          "G_seam_c(2, 0)_f3_parity_CNOT": {
+            "distinct_register_count": 48,
+            "layer_count": 256,
+            "slots": 256,
+            "stage": "D",
+            "touched_register_count": 512,
+            "words": 256
+          },
+          "G_seam_c(2, 1)_f0_axis_RZ": {
+            "distinct_register_count": 7,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "D",
+            "touched_register_count": 7,
+            "words": 7
+          },
+          "G_seam_c(2, 1)_f1_axis_RZ": {
+            "distinct_register_count": 7,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "D",
+            "touched_register_count": 7,
+            "words": 7
+          },
+          "G_seam_c(2, 1)_f2_axis_RZ": {
+            "distinct_register_count": 7,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "D",
+            "touched_register_count": 7,
+            "words": 7
+          },
+          "G_seam_c(2, 1)_f2_basis_H": {
+            "distinct_register_count": 28,
+            "layer_count": 56,
+            "slots": 56,
+            "stage": "D",
+            "touched_register_count": 56,
+            "words": 56
+          },
+          "G_seam_c(2, 1)_f2_basis_S": {
+            "distinct_register_count": 14,
+            "layer_count": 14,
+            "slots": 14,
+            "stage": "D",
+            "touched_register_count": 14,
+            "words": 14
+          },
+          "G_seam_c(2, 1)_f2_basis_Sdg": {
+            "distinct_register_count": 14,
+            "layer_count": 14,
+            "slots": 14,
+            "stage": "D",
+            "touched_register_count": 14,
+            "words": 14
+          },
+          "G_seam_c(2, 1)_f2_parity_CNOT": {
+            "distinct_register_count": 42,
+            "layer_count": 224,
+            "slots": 224,
+            "stage": "D",
+            "touched_register_count": 448,
+            "words": 224
+          },
+          "G_seam_c(2, 1)_f3_axis_RZ": {
+            "distinct_register_count": 7,
+            "layer_count": 7,
+            "slots": 7,
+            "stage": "D",
+            "touched_register_count": 7,
+            "words": 7
+          },
+          "G_seam_c(2, 1)_f3_basis_H": {
+            "distinct_register_count": 28,
+            "layer_count": 56,
+            "slots": 56,
+            "stage": "D",
+            "touched_register_count": 56,
+            "words": 56
+          },
+          "G_seam_c(2, 1)_f3_basis_S": {
+            "distinct_register_count": 14,
+            "layer_count": 14,
+            "slots": 14,
+            "stage": "D",
+            "touched_register_count": 14,
+            "words": 14
+          },
+          "G_seam_c(2, 1)_f3_basis_Sdg": {
+            "distinct_register_count": 14,
+            "layer_count": 14,
+            "slots": 14,
+            "stage": "D",
+            "touched_register_count": 14,
+            "words": 14
+          },
+          "G_seam_c(2, 1)_f3_parity_CNOT": {
+            "distinct_register_count": 42,
+            "layer_count": 224,
+            "slots": 224,
+            "stage": "D",
+            "touched_register_count": 448,
+            "words": 224
+          },
+          "encoded_bank_supply": {
+            "distinct_register_count": 90,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "A",
+            "touched_register_count": 90,
+            "words": 90
+          },
+          "pump_Bell_init": {
+            "distinct_register_count": 900,
+            "layer_count": 1,
+            "slots": 1,
+            "stage": "A",
+            "touched_register_count": 900,
+            "words": 450
+          },
+          "pump_onsite_XX_measure": {
+            "distinct_register_count": 510,
+            "layer_count": 150,
+            "slots": 150,
+            "stage": "A",
+            "touched_register_count": 750,
+            "words": 150
+          },
+          "pump_onsite_XX_private_dual": {
+            "distinct_register_count": 384,
+            "layer_count": 150,
+            "slots": 150,
+            "stage": "A",
+            "touched_register_count": 793,
+            "words": 150
+          },
+          "pump_onsite_Z_measure": {
+            "distinct_register_count": 540,
+            "layer_count": 180,
+            "slots": 180,
+            "stage": "A",
+            "touched_register_count": 540,
+            "words": 180
+          },
+          "pump_onsite_Z_private_dual": {
+            "distinct_register_count": 450,
+            "layer_count": 180,
+            "slots": 180,
+            "stage": "A",
+            "touched_register_count": 630,
+            "words": 180
+          },
+          "pump_plaquette_correction_route_return": {
+            "distinct_register_count": 25,
+            "layer_count": 30,
+            "slots": 30,
+            "stage": "A",
+            "touched_register_count": 60,
+            "words": 30
+          },
+          "pump_plaquette_measure": {
+            "distinct_register_count": 468,
+            "layer_count": 30,
+            "slots": 30,
+            "stage": "A",
+            "touched_register_count": 1190,
+            "words": 30
+          },
+          "pump_plaquette_private_dual": {
+            "distinct_register_count": 111,
+            "layer_count": 30,
+            "slots": 30,
+            "stage": "A",
+            "touched_register_count": 155,
+            "words": 30
+          },
+          "pump_plaquette_route_return": {
+            "distinct_register_count": 25,
+            "layer_count": 30,
+            "slots": 30,
+            "stage": "A",
+            "touched_register_count": 60,
+            "words": 30
+          },
+          "pump_tree_correction_route_return": {
+            "distinct_register_count": 30,
+            "layer_count": 29,
+            "slots": 29,
+            "stage": "A",
+            "touched_register_count": 58,
+            "words": 29
+          },
+          "pump_tree_measure": {
+            "distinct_register_count": 488,
+            "layer_count": 29,
+            "slots": 29,
+            "stage": "A",
+            "touched_register_count": 856,
+            "words": 29
+          },
+          "pump_tree_private_dual": {
+            "distinct_register_count": 99,
+            "layer_count": 29,
+            "slots": 29,
+            "stage": "A",
+            "touched_register_count": 127,
+            "words": 29
+          },
+          "pump_tree_route_return": {
+            "distinct_register_count": 30,
+            "layer_count": 29,
+            "slots": 29,
+            "stage": "A",
+            "touched_register_count": 58,
+            "words": 29
+          }
+        },
+        "lawful": true,
+        "liveness_walk": {
+          "accounting": "literal slot walk: clean -> live(owner stage/word) -> retained; retained reads/writes require an executed declared handoff",
+          "collision_count": 0,
+          "final_state_census": {
+            "retained": 3666
+          },
+          "handoffs_consumed": 1918,
+          "handoffs_declared": 1918,
+          "register_touches": 159219,
+          "registers_seen": 3666,
+          "slots_walked": 76376,
+          "violation_count": 0,
+          "violations": [],
+          "words_walked": 77350
+        },
+        "routes": {
+          "G_route_report": {
+            "maximum_route_distance": 24,
+            "non_NN_failures": 0,
+            "route_return_failures": 0,
+            "routed_gate_count": 75018
+          },
+          "failure_fields": {
+            "A_forward": 0,
+            "A_inverse": 0,
+            "B_forward": 0,
+            "B_inverse": 0,
+            "C_forward": 0,
+            "C_inverse": 0,
+            "D_forward": 0,
+            "D_inverse": 0
+          },
+          "maximum_route_length_or_G_distance_by_stage": {
+            "A": 12,
+            "B": 2,
+            "C": 2,
+            "D": 24
+          },
+          "route_transitions_by_stage": {
+            "A": 416,
+            "B": 118,
+            "C": 118,
+            "D": 75018
+          },
+          "routes_checked_by_stage": {
+            "A": 778,
+            "B": 389,
+            "C": 389,
+            "D": 75018
+          },
+          "total_failures": 0
+        },
+        "shape": [
+          5,
+          3,
+          2
+        ],
+        "slot_counts_per_stage": {
+          "A": 897,
+          "B": 13,
+          "C": 448,
+          "D": 75018
+        },
+        "variant": "primary",
+        "word_counts_per_stage": {
+          "A": 1436,
+          "B": 448,
+          "C": 448,
+          "D": 75018
+        }
+      }
+    }
+  },
+  "checks": [
+    {
+      "label": "both input-leg variants have zero slot-walk liveness, collision, and returned-route failures on every held liveness box",
+      "pass": true
+    },
+    {
+      "label": "the exhaustive signed generator family has exact staged-versus-flattened A/B/C tableau action with the unchanged certified G tail on 1x1x1 and 2x2x2",
+      "pass": true
+    },
+    {
+      "label": "the imported 3x2x2 recurrent one-step conjunction and 2x2x2 orientation/interleave/deletion gates remain exact",
+      "pass": true
+    },
+    {
+      "label": "the three mass/contact and five Cycle-230 fixture residuals remain below 4e-10",
+      "pass": true
+    },
+    {
+      "label": "both schedule variants transport over 24 frames x 8 parities with identical schedule-key and per-family census multisets and zero four-field coframe failures",
+      "pass": true
+    },
+    {
+      "label": "deleted handoff, deleted return word, hostile Stage-B-before-pump interleave, and duplicate-owner controls are all detected",
+      "pass": true
+    }
+  ],
+  "claim_boundary": "This proves one supplied collision-free finite epoch on the held site maps. The supplied sector/genesis inventory is unchanged. Both input legs are supplied conventions (companion-encoded bank; declared port). No renewal, multi-source composition, or autonomy is claimed. Circuit ordinals are structure, not time. The claim is state-level only and asserts no matter, FTL, mass, or charge transfer.",
+  "collision_free_joint_epoch_composed": true,
+  "controls": {
+    "all_four_detected": true,
+    "delete_handoff": {
+      "deleted_edge": [
+        "A:pump_measure:0",
+        "A:pump_correction:0",
+        716
+      ],
+      "named_liveness_violation_detected": true,
+      "violation_count": 1,
+      "violations": [
+        "handoff_read_without_edge:slot=2:register=716:A:pump_measure:0->A:pump_correction:0"
+      ]
+    },
+    "delete_route_return": {
+      "deleted_final_return_transition": [
+        [
+          0,
+          0,
+          1
+        ],
+        [
+          0,
+          0,
+          0
+        ]
+      ],
+      "detected": true,
+      "forward_failures": 1,
+      "inverse_failures": 0,
+      "original_route_transitions": 2,
+      "word_id": "A:pump_measure:88"
+    },
+    "duplicate_owner": {
+      "collision_count": 2,
+      "duplicated_word": "A:Bell_purifier_init:0",
+      "named_collision_detected": true,
+      "slot": 0,
+      "violations": [
+        "collision:slot=0:register=0:A:Bell_purifier_init:0:A:Bell_purifier_init:0:duplicate_owner",
+        "collision:slot=0:register=816:A:Bell_purifier_init:0:A:Bell_purifier_init:0:duplicate_owner",
+        "retained_write_without_handoff:slot=0:register=816:A:Bell_purifier_init:0->A:Bell_purifier_init:0:duplicate_owner"
+      ]
+    },
+    "hostile_interleave": {
+      "dependency": [
+        "A:pump_correction:21",
+        "B:bell_measure:16",
+        11
+      ],
+      "moved_consumer_slot_before_producer_slot": true,
+      "named_liveness_violation_detected": true,
+      "violation_count": 380,
+      "violations": [
+        "cross_stage_live_without_handoff:slot=44:register=0:A:pump_measure:6->B:bell_measure:0",
+        "cross_stage_live_without_handoff:slot=44:register=1:A:pump_measure:7->B:bell_measure:1",
+        "cross_stage_live_without_handoff:slot=44:register=73:A:pump_measure:7->B:bell_measure:1",
+        "cross_stage_live_without_handoff:slot=44:register=2:A:pump_measure:8->B:bell_measure:2",
+        "cross_stage_live_without_handoff:slot=44:register=74:A:pump_measure:8->B:bell_measure:2",
+        "cross_stage_live_without_handoff:slot=44:register=3:A:pump_measure:9->B:bell_measure:3",
+        "cross_stage_live_without_handoff:slot=44:register=75:A:pump_measure:9->B:bell_measure:3",
+        "cross_stage_live_without_handoff:slot=44:register=4:A:pump_measure:10->B:bell_measure:4"
+      ]
+    }
+  },
+  "covariance": {
+    "census_touched_register_definition": "role-bearing global register groups keyed by transported cell/edge anchor; literal per-qubit touches remain independently checked by the liveness walk and are reported as diagnostics",
+    "coframe_origin_channel": {
+      "certificate": {
+        "contradictions": 0,
+        "flipped_rhs_detection_failures": 0,
+        "interpretation": "three cell bits obey nearest-neighbour alternation; the eight global origin choices are the complete solution space and are not fixed by any local constraint",
+        "per_shape": [
+          {
+            "cells": 8,
+            "contradictions": 0,
+            "equation_rank": 21,
+            "expected_connected_rank": 21,
+            "explicit_eight_seed_formula_failures": 0,
+            "flip_one_local_edge_rhs_contradictions": 2,
+            "local_edge_equations": 36,
+            "shape": [
+              2,
+              2,
+              2
+            ],
+            "solution_dimension": 3,
+            "solver_seed": 15637664
+          },
+          {
+            "cells": 12,
+            "contradictions": 0,
+            "equation_rank": 33,
+            "expected_connected_rank": 33,
+            "explicit_eight_seed_formula_failures": 0,
+            "flip_one_local_edge_rhs_contradictions": 4,
+            "local_edge_equations": 60,
+            "shape": [
+              3,
+              2,
+              2
+            ],
+            "solution_dimension": 3,
+            "solver_seed": 54239599776
+          },
+          {
+            "cells": 30,
+            "contradictions": 0,
+            "equation_rank": 87,
+            "expected_connected_rank": 87,
+            "explicit_eight_seed_formula_failures": 0,
+            "flip_one_local_edge_rhs_contradictions": 8,
+            "local_edge_equations": 177,
+            "shape": [
+              5,
+              3,
+              2
+            ],
+            "solution_dimension": 3,
+            "solver_seed": 634235802151541375467130016
+          }
+        ],
+        "rank_failures": 0,
+        "seed_formula_failures": 0,
+        "solution_dimension_failures": 0
+      },
+      "four_failure_fields": {
+        "contradictions": 0,
+        "flipped_rhs_detection_failures": 0,
+        "rank_failures": 0,
+        "seed_formula_failures": 0
+      },
+      "surface": "unchanged Cycle-720 eight-origin constraint channel"
+    },
+    "contexts": 192,
+    "first_failures": {},
+    "named_family_census_vector_failures": {
+      "alternate_port": 0,
+      "primary": 0
+    },
+    "pass": true,
+    "proper_cubic_frames": 24,
+    "schedule_key_multiset_failures": {
+      "alternate_port": 0,
+      "primary": 0
+    },
+    "shape": [
+      2,
+      2,
+      2
+    ],
+    "sorted_family_census_multiset_failures": {
+      "alternate_port": 0,
+      "primary": 0
+    },
+    "source_family_census_vectors": {
+      "alternate_port": {
+        "G_recurrent": [
+          17304,
+          281,
+          4
+        ],
+        "encoded_bank_supply": [
+          1,
+          24,
+          1
+        ],
+        "port_CNOT": [
+          18,
+          18,
+          18
+        ],
+        "pump_Bell_init": [
+          1,
+          240,
+          1
+        ],
+        "pump_onsite_XX_measure": [
+          40,
+          80,
+          40
+        ],
+        "pump_onsite_XX_private_dual": [
+          40,
+          80,
+          40
+        ],
+        "pump_onsite_Z_measure": [
+          48,
+          96,
+          48
+        ],
+        "pump_onsite_Z_private_dual": [
+          48,
+          96,
+          48
+        ],
+        "pump_plaquette_correction_route_return": [
+          5,
+          5,
+          5
+        ],
+        "pump_plaquette_measure": [
+          5,
+          15,
+          5
+        ],
+        "pump_plaquette_private_dual": [
+          5,
+          15,
+          5
+        ],
+        "pump_plaquette_route_return": [
+          5,
+          5,
+          5
+        ],
+        "pump_tree_correction_route_return": [
+          7,
+          7,
+          7
+        ],
+        "pump_tree_measure": [
+          7,
+          21,
+          7
+        ],
+        "pump_tree_private_dual": [
+          7,
+          21,
+          7
+        ],
+        "pump_tree_route_return": [
+          7,
+          7,
+          7
+        ]
+      },
+      "primary": {
+        "Bell_edge_correction_route_return": [
+          12,
+          12,
+          12
+        ],
+        "Bell_edge_measure": [
+          3,
+          36,
+          3
+        ],
+        "Bell_edge_private_dual": [
+          12,
+          36,
+          12
+        ],
+        "Bell_edge_route_return": [
+          3,
+          12,
+          3
+        ],
+        "Bell_onsite_XX_measure": [
+          2,
+          80,
+          2
+        ],
+        "Bell_onsite_XX_private_dual": [
+          40,
+          80,
+          40
+        ],
+        "Bell_onsite_Z_measure": [
+          1,
+          96,
+          1
+        ],
+        "Bell_onsite_Z_private_dual": [
+          48,
+          96,
+          48
+        ],
+        "G_recurrent": [
+          17304,
+          281,
+          4
+        ],
+        "encoded_bank_supply": [
+          1,
+          24,
+          1
+        ],
+        "pump_Bell_init": [
+          1,
+          240,
+          1
+        ],
+        "pump_onsite_XX_measure": [
+          40,
+          80,
+          40
+        ],
+        "pump_onsite_XX_private_dual": [
+          40,
+          80,
+          40
+        ],
+        "pump_onsite_Z_measure": [
+          48,
+          96,
+          48
+        ],
+        "pump_onsite_Z_private_dual": [
+          48,
+          96,
+          48
+        ],
+        "pump_plaquette_correction_route_return": [
+          5,
+          5,
+          5
+        ],
+        "pump_plaquette_measure": [
+          5,
+          15,
+          5
+        ],
+        "pump_plaquette_private_dual": [
+          5,
+          15,
+          5
+        ],
+        "pump_plaquette_route_return": [
+          5,
+          5,
+          5
+        ],
+        "pump_tree_correction_route_return": [
+          7,
+          7,
+          7
+        ],
+        "pump_tree_measure": [
+          7,
+          21,
+          7
+        ],
+        "pump_tree_private_dual": [
+          7,
+          21,
+          7
+        ],
+        "pump_tree_route_return": [
+          7,
+          7,
+          7
+        ]
+      }
+    },
+    "source_raw_qubit_touch_diagnostics": {
+      "alternate_port": {
+        "G_recurrent": [
+          17304,
+          544,
+          4
+        ],
+        "encoded_bank_supply": [
+          1,
+          24,
+          1
+        ],
+        "port_CNOT": [
+          18,
+          36,
+          18
+        ],
+        "pump_Bell_init": [
+          1,
+          240,
+          1
+        ],
+        "pump_onsite_XX_measure": [
+          40,
+          200,
+          40
+        ],
+        "pump_onsite_XX_private_dual": [
+          40,
+          220,
+          40
+        ],
+        "pump_onsite_Z_measure": [
+          48,
+          144,
+          48
+        ],
+        "pump_onsite_Z_private_dual": [
+          48,
+          168,
+          48
+        ],
+        "pump_plaquette_correction_route_return": [
+          5,
+          10,
+          5
+        ],
+        "pump_plaquette_measure": [
+          5,
+          205,
+          5
+        ],
+        "pump_plaquette_private_dual": [
+          5,
+          20,
+          5
+        ],
+        "pump_plaquette_route_return": [
+          5,
+          10,
+          5
+        ],
+        "pump_tree_correction_route_return": [
+          7,
+          14,
+          7
+        ],
+        "pump_tree_measure": [
+          7,
+          193,
+          7
+        ],
+        "pump_tree_private_dual": [
+          7,
+          28,
+          7
+        ],
+        "pump_tree_route_return": [
+          7,
+          14,
+          7
+        ]
+      },
+      "primary": {
+        "Bell_edge_correction_route_return": [
+          12,
+          24,
+          12
+        ],
+        "Bell_edge_measure": [
+          3,
+          300,
+          3
+        ],
+        "Bell_edge_private_dual": [
+          12,
+          48,
+          12
+        ],
+        "Bell_edge_route_return": [
+          3,
+          24,
+          3
+        ],
+        "Bell_onsite_XX_measure": [
+          2,
+          200,
+          2
+        ],
+        "Bell_onsite_XX_private_dual": [
+          40,
+          220,
+          40
+        ],
+        "Bell_onsite_Z_measure": [
+          1,
+          144,
+          1
+        ],
+        "Bell_onsite_Z_private_dual": [
+          48,
+          168,
+          48
+        ],
+        "G_recurrent": [
+          17304,
+          544,
+          4
+        ],
+        "encoded_bank_supply": [
+          1,
+          24,
+          1
+        ],
+        "pump_Bell_init": [
+          1,
+          240,
+          1
+        ],
+        "pump_onsite_XX_measure": [
+          40,
+          200,
+          40
+        ],
+        "pump_onsite_XX_private_dual": [
+          40,
+          220,
+          40
+        ],
+        "pump_onsite_Z_measure": [
+          48,
+          144,
+          48
+        ],
+        "pump_onsite_Z_private_dual": [
+          48,
+          168,
+          48
+        ],
+        "pump_plaquette_correction_route_return": [
+          5,
+          10,
+          5
+        ],
+        "pump_plaquette_measure": [
+          5,
+          205,
+          5
+        ],
+        "pump_plaquette_private_dual": [
+          5,
+          20,
+          5
+        ],
+        "pump_plaquette_route_return": [
+          5,
+          10,
+          5
+        ],
+        "pump_tree_correction_route_return": [
+          7,
+          14,
+          7
+        ],
+        "pump_tree_measure": [
+          7,
+          193,
+          7
+        ],
+        "pump_tree_private_dual": [
+          7,
+          28,
+          7
+        ],
+        "pump_tree_route_return": [
+          7,
+          14,
+          7
+        ]
+      }
+    },
+    "translation_parities": 8,
+    "variants": [
+      "primary",
+      "alternate_port"
+    ]
+  },
+  "derived": "literal global register enumeration; exact slot-by-slot clean/live/retained ownership; explicit producer-consumer handoffs; returned-route checks; signed Clifford prefix tableaux; transported schedule-key/census multisets; imported recurrent and fixture regression certificates",
+  "end_to_end": {
+    "1x1x1": {
+      "alternate_port": {
+        "F1_stage_action": {
+          "not_applicable": 0
+        },
+        "F2_stage_action": {
+          "exported_PORT_part1": {
+            "cells": 1,
+            "census": {
+              "diameter": 0,
+              "primitive_count": 18,
+              "route_transitions": 0,
+              "support_cells": 1
+            },
+            "forward_11_even_CAR_failures": 0,
+            "forward_port_onsite_dictionary_exchange_failures": 0,
+            "gate_pass": true,
+            "generation": {
+              "declared_11_generator_missing_failures": 0,
+              "declared_11_generator_multiplicity_failures": 0,
+              "onsite_physical_target_identity_failures": 0
+            },
+            "incident_seam_exchange_failures": 0,
+            "nonincident_seam_invariance_failures": 0,
+            "other_cell_onsite_invariance_failures": 0,
+            "parity": {
+              "cell_parity_image_failures": false,
+              "odd_bank_detection_failures": 0,
+              "odd_matter_image_detection_failures": 0,
+              "total_joint_parity_invariance_failures": false
+            },
+            "port_cell": [
+              0,
+              0,
+              0
+            ],
+            "port_cell_index": 0,
+            "port_onsite_dictionary_exchange_failures": 0,
+            "port_onsite_dictionary_rows": 36,
+            "reverse_11_even_CAR_failures": 0,
+            "shape": [
+              1,
+              1,
+              1
+            ]
+          },
+          "failure_fields": {
+            "dictionary_exchange_failures": 0,
+            "forward_11_even_CAR_failures": 0,
+            "generation": 0,
+            "other_cell_or_seam_failures": 0,
+            "parity_failures": 0,
+            "reverse_11_even_CAR_failures": 0
+          }
+        },
+        "G_action_basis": "unchanged imported non-Clifford recurrent tail, certified on generator coordinates by R.recurrent_box_certificate; the A/B/C prefix is exact signed Clifford tableau algebra",
+        "G_routed_word_identity_failures": 0,
+        "G_routed_word_sha256": "f5d78085de93368ca1c32f06d317738f0272f6d5bef3ed305818d5a01d63f6f0",
+        "failing_generators": [],
+        "generator_family_census": {
+          "cell_bank_parity": 1,
+          "cell_code_parity": 1,
+          "cell_joint_parity": 1,
+          "direct_graph": 11,
+          "pump_ancilla_X": 11,
+          "pump_ancilla_Z": 11,
+          "pump_graph": 11,
+          "pump_measured": 11
+        },
+        "generators_exhausted": 58,
+        "pass": true,
+        "phase_included": true,
+        "pump_stage_action": {
+          "dilation_X_failures": 0,
+          "dilation_Z_character_failures": 0,
+          "private_dual_predecessor_failures": 0,
+          "private_dual_self_failures": 0
+        },
+        "shape": [
+          1,
+          1,
+          1
+        ],
+        "stage_A_B_C_tableau_gates": 62,
+        "stage_action_failure_total": 0,
+        "stagewise_vs_flattened_tableau_failures": 0,
+        "variant": "alternate_port"
+      },
+      "primary": {
+        "F1_stage_action": {
+          "F1_exported_X_failures": 0,
+          "F1_exported_Z_character_failures": 0,
+          "F1_exported_other_measured_row_failures": 0
+        },
+        "F2_stage_action": {
+          "not_applicable": 0
+        },
+        "G_action_basis": "unchanged imported non-Clifford recurrent tail, certified on generator coordinates by R.recurrent_box_certificate; the A/B/C prefix is exact signed Clifford tableau algebra",
+        "G_routed_word_identity_failures": 0,
+        "G_routed_word_sha256": "f5d78085de93368ca1c32f06d317738f0272f6d5bef3ed305818d5a01d63f6f0",
+        "failing_generators": [],
+        "generator_family_census": {
+          "Bell_ancilla_X": 11,
+          "Bell_ancilla_Z": 11,
+          "Bell_measured": 11,
+          "cell_bank_parity": 1,
+          "cell_code_parity": 1,
+          "cell_joint_parity": 1,
+          "direct_graph": 11,
+          "pump_ancilla_X": 11,
+          "pump_ancilla_Z": 11,
+          "pump_graph": 11,
+          "pump_measured": 11
+        },
+        "generators_exhausted": 91,
+        "pass": true,
+        "phase_included": true,
+        "pump_stage_action": {
+          "dilation_X_failures": 0,
+          "dilation_Z_character_failures": 0,
+          "private_dual_predecessor_failures": 0,
+          "private_dual_self_failures": 0
+        },
+        "shape": [
+          1,
+          1,
+          1
+        ],
+        "stage_A_B_C_tableau_gates": 109,
+        "stage_action_failure_total": 0,
+        "stagewise_vs_flattened_tableau_failures": 0,
+        "variant": "primary"
+      }
+    },
+    "2x2x2": {
+      "alternate_port": {
+        "F1_stage_action": {
+          "not_applicable": 0
+        },
+        "F2_stage_action": {
+          "exported_PORT_part1": {
+            "cells": 8,
+            "census": {
+              "diameter": 0,
+              "primitive_count": 18,
+              "route_transitions": 0,
+              "support_cells": 1
+            },
+            "forward_11_even_CAR_failures": 0,
+            "forward_port_onsite_dictionary_exchange_failures": 0,
+            "gate_pass": true,
+            "generation": {
+              "declared_11_generator_missing_failures": 0,
+              "declared_11_generator_multiplicity_failures": 0,
+              "onsite_physical_target_identity_failures": 0
+            },
+            "incident_seam_exchange_failures": 0,
+            "nonincident_seam_invariance_failures": 0,
+            "other_cell_onsite_invariance_failures": 0,
+            "parity": {
+              "cell_parity_image_failures": false,
+              "odd_bank_detection_failures": 0,
+              "odd_matter_image_detection_failures": 0,
+              "total_joint_parity_invariance_failures": false
+            },
+            "port_cell": [
+              0,
+              0,
+              0
+            ],
+            "port_cell_index": 0,
+            "port_onsite_dictionary_exchange_failures": 0,
+            "port_onsite_dictionary_rows": 36,
+            "reverse_11_even_CAR_failures": 0,
+            "shape": [
+              2,
+              2,
+              2
+            ]
+          },
+          "failure_fields": {
+            "dictionary_exchange_failures": 0,
+            "forward_11_even_CAR_failures": 0,
+            "generation": 0,
+            "other_cell_or_seam_failures": 0,
+            "parity_failures": 0,
+            "reverse_11_even_CAR_failures": 0
+          }
+        },
+        "G_action_basis": "unchanged imported non-Clifford recurrent tail, certified on generator coordinates by R.recurrent_box_certificate; the A/B/C prefix is exact signed Clifford tableau algebra",
+        "G_routed_word_identity_failures": 0,
+        "G_routed_word_sha256": "9e9edd9c3bc5da1258135b723ef447f105e8017e972b22b8d22f911b04e1dfbf",
+        "failing_generators": [],
+        "generator_family_census": {
+          "cell_bank_parity": 8,
+          "cell_code_parity": 8,
+          "cell_joint_parity": 8,
+          "direct_graph": 100,
+          "pump_ancilla_X": 100,
+          "pump_ancilla_Z": 100,
+          "pump_graph": 100,
+          "pump_measured": 100
+        },
+        "generators_exhausted": 524,
+        "pass": true,
+        "phase_included": true,
+        "pump_stage_action": {
+          "dilation_X_failures": 0,
+          "dilation_Z_character_failures": 0,
+          "private_dual_predecessor_failures": 0,
+          "private_dual_self_failures": 0
+        },
+        "shape": [
+          2,
+          2,
+          2
+        ],
+        "stage_A_B_C_tableau_gates": 418,
+        "stage_action_failure_total": 0,
+        "stagewise_vs_flattened_tableau_failures": 0,
+        "variant": "alternate_port"
+      },
+      "primary": {
+        "F1_stage_action": {
+          "F1_exported_X_failures": 0,
+          "F1_exported_Z_character_failures": 0,
+          "F1_exported_other_measured_row_failures": 0
+        },
+        "F2_stage_action": {
+          "not_applicable": 0
+        },
+        "G_action_basis": "unchanged imported non-Clifford recurrent tail, certified on generator coordinates by R.recurrent_box_certificate; the A/B/C prefix is exact signed Clifford tableau algebra",
+        "G_routed_word_identity_failures": 0,
+        "G_routed_word_sha256": "9e9edd9c3bc5da1258135b723ef447f105e8017e972b22b8d22f911b04e1dfbf",
+        "failing_generators": [],
+        "generator_family_census": {
+          "Bell_ancilla_X": 100,
+          "Bell_ancilla_Z": 100,
+          "Bell_measured": 100,
+          "cell_bank_parity": 8,
+          "cell_code_parity": 8,
+          "cell_joint_parity": 8,
+          "direct_graph": 100,
+          "pump_ancilla_X": 100,
+          "pump_ancilla_Z": 100,
+          "pump_graph": 100,
+          "pump_measured": 100
+        },
+        "generators_exhausted": 824,
+        "pass": true,
+        "phase_included": true,
+        "pump_stage_action": {
+          "dilation_X_failures": 0,
+          "dilation_Z_character_failures": 0,
+          "private_dual_predecessor_failures": 0,
+          "private_dual_self_failures": 0
+        },
+        "shape": [
+          2,
+          2,
+          2
+        ],
+        "stage_A_B_C_tableau_gates": 1220,
+        "stage_action_failure_total": 0,
+        "stagewise_vs_flattened_tableau_failures": 0,
+        "variant": "primary"
+      }
+    }
+  },
+  "fixtures": {
+    "cycle230_residuals": {
+      "FSWAP_matrix_residual": 0.0,
+      "coin_matrix_residual": 1.952777839357751e-16,
+      "internal_depth_two_stream_residual": 0.0,
+      "mass_residual": 0.0,
+      "onsite_64_state_contact_residual": 2.149937642474629e-15
+    },
+    "mass_contact_residuals": {
+      "contact_double_occupation_phase_residual": 0.0,
+      "contact_vacuum_and_one_particle_residual": 0.0,
+      "one_particle_mass_residual": 5.551115123125783e-17
+    },
+    "pass": true,
+    "tolerance": 4e-10
+  },
+  "namespace": {
+    "allocation_rule": "code [0,q), F1 companion-encoded bank [q,2q), canonically enumerated routed-only G coordinate sites, then all retained ancilla/syndrome/purifier/coframe/rail allocations",
+    "by_box": {
+      "1x1x1": {
+        "F1_original_auxiliary_start": 18,
+        "G_auxiliary_allocation_offset_above_2q": 16,
+        "G_overlap_with_unshifted_F1_auxiliary_space": true,
+        "G_routed_only_site_count": 16,
+        "G_touched_register_count": 25,
+        "G_touched_register_max": 33,
+        "G_touched_register_min": 0,
+        "actual_auxiliary_start": 34,
+        "cells": 1,
+        "explicit_register_table": {
+          "Bell_measurement_ancillae": {
+            "count": 11,
+            "description": "retained F1 Bell outcomes",
+            "start": 34,
+            "stop": 45
+          },
+          "G_routed_only_sites": {
+            "count": 16,
+            "description": "coordinate sites touched by routed G but absent from U.placement sites_by_qubit",
+            "start": 18,
+            "stop": 34
+          },
+          "code": {
+            "count": 9,
+            "description": "physical matter 6N followed by companion 3N",
+            "start": 0,
+            "stop": 9
+          },
+          "companion_encoded_bank": {
+            "count": 9,
+            "description": "F1 mirror convention [q,2q); F2 uses the declared port cell's six-mode matter sub-block",
+            "start": 9,
+            "stop": 18
+          },
+          "mobile_route_rails": {
+            "count": 1,
+            "description": "one returned mobile rail per cell, reused by A/B/C",
+            "start": 74,
+            "stop": 75
+          },
+          "pump_Bell_purifiers": {
+            "count": 15,
+            "description": "one local purifier per q+matter Choi-system M2",
+            "start": 56,
+            "stop": 71
+          },
+          "pump_syndrome_bank": {
+            "count": 11,
+            "description": "retained pump row outcomes",
+            "start": 45,
+            "stop": 56
+          },
+          "retained_coframe_gauge": {
+            "count": 3,
+            "description": "unchanged three-M2-per-cell coframe surface",
+            "start": 71,
+            "stop": 74
+          }
+        },
+        "instruction_schema_discovered_at_runtime": {
+          "available_fields": [
+            "kind",
+            "sites",
+            "matrix"
+          ],
+          "fields_used": [
+            "kind",
+            "sites"
+          ],
+          "index_extraction": "instruction.sites coordinate tuples; exact U.placement sites_by_qubit matches preserve code [0,q), and sorted routed-only coordinates are enumerated after [q,2q)",
+          "instruction_type": "frontier_full128_25site_nn_circuit_core_2026_07_24.Gate",
+          "raw_integer_qubit_field_present": false,
+          "site_arity": 3,
+          "site_container_type": "tuple",
+          "site_value_type": "tuple"
+        },
+        "matter": 6,
+        "q": 9,
+        "shape": [
+          1,
+          1,
+          1
+        ]
+      },
+      "2x2x2": {
+        "F1_original_auxiliary_start": 144,
+        "G_auxiliary_allocation_offset_above_2q": 472,
+        "G_overlap_with_unshifted_F1_auxiliary_space": true,
+        "G_routed_only_site_count": 472,
+        "G_touched_register_count": 544,
+        "G_touched_register_max": 615,
+        "G_touched_register_min": 0,
+        "actual_auxiliary_start": 616,
+        "cells": 8,
+        "explicit_register_table": {
+          "Bell_measurement_ancillae": {
+            "count": 100,
+            "description": "retained F1 Bell outcomes",
+            "start": 616,
+            "stop": 716
+          },
+          "G_routed_only_sites": {
+            "count": 472,
+            "description": "coordinate sites touched by routed G but absent from U.placement sites_by_qubit",
+            "start": 144,
+            "stop": 616
+          },
+          "code": {
+            "count": 72,
+            "description": "physical matter 6N followed by companion 3N",
+            "start": 0,
+            "stop": 72
+          },
+          "companion_encoded_bank": {
+            "count": 72,
+            "description": "F1 mirror convention [q,2q); F2 uses the declared port cell's six-mode matter sub-block",
+            "start": 72,
+            "stop": 144
+          },
+          "mobile_route_rails": {
+            "count": 8,
+            "description": "one returned mobile rail per cell, reused by A/B/C",
+            "start": 960,
+            "stop": 968
+          },
+          "pump_Bell_purifiers": {
+            "count": 120,
+            "description": "one local purifier per q+matter Choi-system M2",
+            "start": 816,
+            "stop": 936
+          },
+          "pump_syndrome_bank": {
+            "count": 100,
+            "description": "retained pump row outcomes",
+            "start": 716,
+            "stop": 816
+          },
+          "retained_coframe_gauge": {
+            "count": 24,
+            "description": "unchanged three-M2-per-cell coframe surface",
+            "start": 936,
+            "stop": 960
+          }
+        },
+        "instruction_schema_discovered_at_runtime": {
+          "available_fields": [
+            "kind",
+            "sites",
+            "matrix"
+          ],
+          "fields_used": [
+            "kind",
+            "sites"
+          ],
+          "index_extraction": "instruction.sites coordinate tuples; exact U.placement sites_by_qubit matches preserve code [0,q), and sorted routed-only coordinates are enumerated after [q,2q)",
+          "instruction_type": "frontier_full128_25site_nn_circuit_core_2026_07_24.Gate",
+          "raw_integer_qubit_field_present": false,
+          "site_arity": 3,
+          "site_container_type": "tuple",
+          "site_value_type": "tuple"
+        },
+        "matter": 48,
+        "q": 72,
+        "shape": [
+          2,
+          2,
+          2
+        ]
+      },
+      "3x2x2": {
+        "F1_original_auxiliary_start": 216,
+        "G_auxiliary_allocation_offset_above_2q": 722,
+        "G_overlap_with_unshifted_F1_auxiliary_space": true,
+        "G_routed_only_site_count": 722,
+        "G_touched_register_count": 830,
+        "G_touched_register_max": 937,
+        "G_touched_register_min": 0,
+        "actual_auxiliary_start": 938,
+        "cells": 12,
+        "explicit_register_table": {
+          "Bell_measurement_ancillae": {
+            "count": 152,
+            "description": "retained F1 Bell outcomes",
+            "start": 938,
+            "stop": 1090
+          },
+          "G_routed_only_sites": {
+            "count": 722,
+            "description": "coordinate sites touched by routed G but absent from U.placement sites_by_qubit",
+            "start": 216,
+            "stop": 938
+          },
+          "code": {
+            "count": 108,
+            "description": "physical matter 6N followed by companion 3N",
+            "start": 0,
+            "stop": 108
+          },
+          "companion_encoded_bank": {
+            "count": 108,
+            "description": "F1 mirror convention [q,2q); F2 uses the declared port cell's six-mode matter sub-block",
+            "start": 108,
+            "stop": 216
+          },
+          "mobile_route_rails": {
+            "count": 12,
+            "description": "one returned mobile rail per cell, reused by A/B/C",
+            "start": 1458,
+            "stop": 1470
+          },
+          "pump_Bell_purifiers": {
+            "count": 180,
+            "description": "one local purifier per q+matter Choi-system M2",
+            "start": 1242,
+            "stop": 1422
+          },
+          "pump_syndrome_bank": {
+            "count": 152,
+            "description": "retained pump row outcomes",
+            "start": 1090,
+            "stop": 1242
+          },
+          "retained_coframe_gauge": {
+            "count": 36,
+            "description": "unchanged three-M2-per-cell coframe surface",
+            "start": 1422,
+            "stop": 1458
+          }
+        },
+        "instruction_schema_discovered_at_runtime": {
+          "available_fields": [
+            "kind",
+            "sites",
+            "matrix"
+          ],
+          "fields_used": [
+            "kind",
+            "sites"
+          ],
+          "index_extraction": "instruction.sites coordinate tuples; exact U.placement sites_by_qubit matches preserve code [0,q), and sorted routed-only coordinates are enumerated after [q,2q)",
+          "instruction_type": "frontier_full128_25site_nn_circuit_core_2026_07_24.Gate",
+          "raw_integer_qubit_field_present": false,
+          "site_arity": 3,
+          "site_container_type": "tuple",
+          "site_value_type": "tuple"
+        },
+        "matter": 72,
+        "q": 108,
+        "shape": [
+          3,
+          2,
+          2
+        ]
+      },
+      "5x3x2": {
+        "F1_original_auxiliary_start": 540,
+        "G_auxiliary_allocation_offset_above_2q": 1868,
+        "G_overlap_with_unshifted_F1_auxiliary_space": true,
+        "G_routed_only_site_count": 1868,
+        "G_touched_register_count": 2138,
+        "G_touched_register_max": 2407,
+        "G_touched_register_min": 0,
+        "actual_auxiliary_start": 2408,
+        "cells": 30,
+        "explicit_register_table": {
+          "Bell_measurement_ancillae": {
+            "count": 389,
+            "description": "retained F1 Bell outcomes",
+            "start": 2408,
+            "stop": 2797
+          },
+          "G_routed_only_sites": {
+            "count": 1868,
+            "description": "coordinate sites touched by routed G but absent from U.placement sites_by_qubit",
+            "start": 540,
+            "stop": 2408
+          },
+          "code": {
+            "count": 270,
+            "description": "physical matter 6N followed by companion 3N",
+            "start": 0,
+            "stop": 270
+          },
+          "companion_encoded_bank": {
+            "count": 270,
+            "description": "F1 mirror convention [q,2q); F2 uses the declared port cell's six-mode matter sub-block",
+            "start": 270,
+            "stop": 540
+          },
+          "mobile_route_rails": {
+            "count": 30,
+            "description": "one returned mobile rail per cell, reused by A/B/C",
+            "start": 3726,
+            "stop": 3756
+          },
+          "pump_Bell_purifiers": {
+            "count": 450,
+            "description": "one local purifier per q+matter Choi-system M2",
+            "start": 3186,
+            "stop": 3636
+          },
+          "pump_syndrome_bank": {
+            "count": 389,
+            "description": "retained pump row outcomes",
+            "start": 2797,
+            "stop": 3186
+          },
+          "retained_coframe_gauge": {
+            "count": 90,
+            "description": "unchanged three-M2-per-cell coframe surface",
+            "start": 3636,
+            "stop": 3726
+          }
+        },
+        "instruction_schema_discovered_at_runtime": {
+          "available_fields": [
+            "kind",
+            "sites",
+            "matrix"
+          ],
+          "fields_used": [
+            "kind",
+            "sites"
+          ],
+          "index_extraction": "instruction.sites coordinate tuples; exact U.placement sites_by_qubit matches preserve code [0,q), and sorted routed-only coordinates are enumerated after [q,2q)",
+          "instruction_type": "frontier_full128_25site_nn_circuit_core_2026_07_24.Gate",
+          "raw_integer_qubit_field_present": false,
+          "site_arity": 3,
+          "site_container_type": "tuple",
+          "site_value_type": "tuple"
+        },
+        "matter": 180,
+        "q": 270,
+        "shape": [
+          5,
+          3,
+          2
+        ]
+      }
+    },
+    "instruction_fields_printed_and_used": [
+      "kind",
+      "sites"
+    ]
+  },
+  "open": "renewal or repeated-source composition; autonomous genesis, sector choice, root choice, port choice, or program choice; fault-tolerant realization; any continuum/time interpretation",
+  "recurrent_integrity": {
+    "one_step_exact_conjunction_recomputed": true,
+    "one_step_power_row_exact": true,
+    "orientation_interleave_deletion_gates_unchanged": true,
+    "pass": true,
+    "recurrent_box_3x2x2": {
+      "cells": 12,
+      "coframe_M2_sites": 36,
+      "contact_double_occupation_phase_residual": 0.0,
+      "contact_vacuum_and_one_particle_residual": 0.0,
+      "coordinate_intertwiner": {
+        "both_sector_phase_failures": 0,
+        "coordinate_signature_sha256": "2bcb8c1da6480ca51d09220b7c59b30b2f48be4ad5d16c774a4792e049c98459",
+        "gauge_coordinate_failures": 0,
+        "logical_coordinate_failures": 0,
+        "operator_generators": 512,
+        "parity_coordinate_failures": 0,
+        "physical_generator_center_commutator_failures": 0,
+        "physical_generator_gauge_commutator_failures": 0
+      },
+      "encoder": {
+        "global_Choi_graph_rank": 152,
+        "global_from_local_signed_replay_failures": 0,
+        "global_graph_digest": "e9b28f7376210eab4be7f19aafe3aba799f5c1742f5359676c79cebcdac6b3c8",
+        "global_rows_outside_repeated_star_span": 0,
+        "local_from_global_signed_replay_failures": 0,
+        "normalized_partial_trace_output": "I_input/2^matter_qubits",
+        "remove_one_independent_projector_rank_loss": 1,
+        "repeated_star_Choi_graph_rank": 152,
+        "repeated_star_rows_outside_global_span": 0
+      },
+      "encoder_environment_boundary": "E is invoked once; its gauge-reference and parity environments are traced at genesis and never touched by G_physical",
+      "iteration_proof_boundary": "the exact generator-coordinate star-isomorphism, gauge identity, and literal unitary physical word prove recurrence by induction; the listed powers audit word-call/resource counts and do not claim dense many-body matrix exponentiation",
+      "matter_and_companion_M2_sites": 108,
+      "one_particle_mass_residual": 5.551115123125783e-17,
+      "physical_update": {
+        "coin_QR_residual": 1.3496230663401984e-15,
+        "inverse_construction": "reverse the literal instruction word and conjugate-transpose each local matrix",
+        "inverse_word_factor_count": 1660,
+        "local_dictionary_sha256": "e778afeda360ccb834fafd4e8c782e2482e8b4f3cf5aca78c9d0d317fce07d14",
+        "logical_update_factors": 428,
+        "maximum_all_instruction_unitarity_residual": 9.42129743476075e-16,
+        "maximum_instruction_inverse_pair_residual": 9.42146882813674e-16,
+        "maximum_onsite_parity_commutator_residual": 0.0,
+        "maximum_onsite_unitarity_residual": 9.42129743476075e-16,
+        "maximum_route_distance": 24,
+        "non_NN_failures": 0,
+        "physical_primitives": 1660,
+        "route_return_failures": 0,
+        "routed_gate_count": 26940,
+        "runtime_parity_queries": 0,
+        "seam_factor_colour_census": {
+          "axis0_parity0": 16,
+          "axis0_parity1": 16,
+          "axis1_parity0": 12,
+          "axis1_parity1": 12,
+          "axis2_parity0": 12,
+          "axis2_parity1": 12
+        },
+        "sector_conditioned_gates": 0,
+        "word_sha256": "0b2e952be49b3f38b54bdba3165c6c56724bcd2f0cf5e87791126c518502adaa"
+      },
+      "recurrent_powers": [
+        {
+          "encoder_calls": 1,
+          "fresh_encoder_environment_calls_after_genesis": 0,
+          "gauge_identity_induction_failures": 0,
+          "intertwiner_induction_failures": 0,
+          "physical_update_power": 1,
+          "physical_update_word_calls": 1,
+          "routed_primitive_count": 26940,
+          "word_factor_count": 428
+        },
+        {
+          "encoder_calls": 1,
+          "fresh_encoder_environment_calls_after_genesis": 0,
+          "gauge_identity_induction_failures": 0,
+          "intertwiner_induction_failures": 0,
+          "physical_update_power": 2,
+          "physical_update_word_calls": 2,
+          "routed_primitive_count": 53880,
+          "word_factor_count": 856
+        },
+        {
+          "encoder_calls": 1,
+          "fresh_encoder_environment_calls_after_genesis": 0,
+          "gauge_identity_induction_failures": 0,
+          "intertwiner_induction_failures": 0,
+          "physical_update_power": 3,
+          "physical_update_word_calls": 3,
+          "routed_primitive_count": 80820,
+          "word_factor_count": 1284
+        },
+        {
+          "encoder_calls": 1,
+          "fresh_encoder_environment_calls_after_genesis": 0,
+          "gauge_identity_induction_failures": 0,
+          "intertwiner_induction_failures": 0,
+          "physical_update_power": 5,
+          "physical_update_word_calls": 5,
+          "routed_primitive_count": 134700,
+          "word_factor_count": 2140
+        },
+        {
+          "encoder_calls": 1,
+          "fresh_encoder_environment_calls_after_genesis": 0,
+          "gauge_identity_induction_failures": 0,
+          "intertwiner_induction_failures": 0,
+          "physical_update_power": 8,
+          "physical_update_word_calls": 8,
+          "routed_primitive_count": 215520,
+          "word_factor_count": 3424
+        }
+      ],
+      "retained_M2_sites_per_cell": 12,
+      "shape": [
+        3,
+        2,
+        2
+      ],
+      "total_retained_M2_sites": 144,
+      "virtual_parity_rail_half_edge_bits": 40
+    },
+    "schedule_2x2x2": {
+      "cross_edge_seam_factor_commutator_failures": 0,
+      "delete_one_seam_factor_block_residual": 0.7653668647301793,
+      "fixed_layers": [
+        "parallel onsite coin net",
+        "parallel three-pair reverse net",
+        "all edge seam blocks; distinct edges commute; factor groups 01 then 23",
+        "parallel onsite all-pair contact net"
+      ],
+      "hostile_interleave_anticommuting_factor_groups_residual": 0.9999999999999997,
+      "orientation_reversal_block_residual": 0.0,
+      "orientation_reversal_factor_permutation": [
+        1,
+        0,
+        3,
+        2
+      ],
+      "schedule_boundary": "the four macro layers and the within-edge 01-before-23 order are a fixed law schedule, not a clock or physical time variable",
+      "seam_edges": 12,
+      "shape": [
+        2,
+        2,
+        2
+      ],
+      "within_edge_noncommuting_pairs": 48
+    }
+  },
+  "runtime_seconds": 82.8298772920025,
+  "status": "PASS",
+  "supplied": "one-time finite epoch; fixed sector and genesis inventory; clean initial banks; declared root/router and program content; the primary companion-encoded F1 bank and alternate declared F2 port are both supplied input conventions"
+}
+
+----- stderr -----
+

--- a/logs/runner-cache/frontier_cycle721_encoded_input_clifford_port_2026_07_28.txt
+++ b/logs/runner-cache/frontier_cycle721_encoded_input_clifford_port_2026_07_28.txt
@@ -1,0 +1,888 @@
+===== runner cache v1 =====
+runner: scripts/frontier_cycle721_encoded_input_clifford_port_2026_07_28.py
+runner_sha256: 980c74c1b623c13061f554c29f5569c5cccbc67072cf84e33f4a3432e4204cde
+input_fingerprint_sha256: 9e0460c9d12952ba3b848a57c30a24516b0eaefaaa6bdda6de5194752e43ed0c
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 21.40
+status: ok
+----- stdout -----
+PASS dense exact Clifford tableau self-test has zero mismatches
+PASS union-safe and bare constructors agree on cells edges and qubits for 2x2x2
+PASS (1, 1, 1) Part 1 dictionary and exchange images are exact
+PASS (1, 1, 1) Part 1 parity and bounded gate census pass
+PASS (1, 1, 1) Part 2 seam images noninvolved rows parity and routing are exact
+PASS (1, 1, 1) Part 2 named support gate passes
+PASS (2, 2, 2) Part 1 dictionary and exchange images are exact
+PASS (2, 2, 2) Part 1 parity and bounded gate census pass
+PASS (2, 2, 2) Part 2 seam images noninvolved rows parity and routing are exact
+PASS (2, 2, 2) Part 2 named support gate passes
+PASS (3, 2, 2) Part 1 dictionary and exchange images are exact
+PASS (3, 2, 2) Part 1 parity and bounded gate census pass
+PASS (3, 2, 2) Part 2 seam images noninvolved rows parity and routing are exact
+PASS (3, 2, 2) Part 2 named support gate passes
+PASS (5, 3, 2) optional Part 1 and census pass
+PASS mixed-gauge factorization anchors regress with exact coordinates
+PASS 24 frames x 8 translation parities have exact dictionary-family and seam-class covariance
+PASS deleting one CNOT produces a nonzero conjugation mismatch
+PASS flipping the middle CNOT of one SWAP block produces a nonzero mismatch
+PASS appending one stray primitive to the seam word is detected
+PASS an unlawful odd input is detected by joint parity
+PASS a wrong-port word leaves the declared port rows unmapped
+{
+  "audit": "unset",
+  "authority": "none",
+  "boxes": {
+    "1x1x1": {
+      "part1": {
+        "cells": 1,
+        "census": {
+          "diameter": 0,
+          "primitive_count": 18,
+          "route_transitions": 0,
+          "support_cells": 1
+        },
+        "forward_11_even_CAR_failures": 0,
+        "forward_port_onsite_dictionary_exchange_failures": 0,
+        "gate_pass": true,
+        "generation": {
+          "declared_11_generator_missing_failures": 0,
+          "declared_11_generator_multiplicity_failures": 0,
+          "onsite_physical_target_identity_failures": 0
+        },
+        "incident_seam_exchange_failures": 0,
+        "nonincident_seam_invariance_failures": 0,
+        "other_cell_onsite_invariance_failures": 0,
+        "parity": {
+          "cell_parity_image_failures": false,
+          "odd_bank_detection_failures": 0,
+          "odd_matter_image_detection_failures": 0,
+          "total_joint_parity_invariance_failures": false
+        },
+        "port_cell": [
+          0,
+          0,
+          0
+        ],
+        "port_cell_index": 0,
+        "port_onsite_dictionary_exchange_failures": 0,
+        "port_onsite_dictionary_rows": 36,
+        "reverse_11_even_CAR_failures": 0,
+        "shape": [
+          1,
+          1,
+          1
+        ]
+      },
+      "part2": {
+        "all_four_seam_images_exact": true,
+        "all_noninvolved_dictionary_rows_invariant": true,
+        "all_parity_bookkeeping_exact": true,
+        "all_routes_returned": true,
+        "axes": {},
+        "gate_pass": true,
+        "port_cell_index": 0,
+        "tested_axes": 0
+      },
+      "shape": [
+        1,
+        1,
+        1
+      ]
+    },
+    "2x2x2": {
+      "part1": {
+        "cells": 8,
+        "census": {
+          "diameter": 0,
+          "primitive_count": 18,
+          "route_transitions": 0,
+          "support_cells": 1
+        },
+        "forward_11_even_CAR_failures": 0,
+        "forward_port_onsite_dictionary_exchange_failures": 0,
+        "gate_pass": true,
+        "generation": {
+          "declared_11_generator_missing_failures": 0,
+          "declared_11_generator_multiplicity_failures": 0,
+          "onsite_physical_target_identity_failures": 0
+        },
+        "incident_seam_exchange_failures": 0,
+        "nonincident_seam_invariance_failures": 0,
+        "other_cell_onsite_invariance_failures": 0,
+        "parity": {
+          "cell_parity_image_failures": false,
+          "odd_bank_detection_failures": 0,
+          "odd_matter_image_detection_failures": 0,
+          "total_joint_parity_invariance_failures": false
+        },
+        "port_cell": [
+          0,
+          0,
+          0
+        ],
+        "port_cell_index": 0,
+        "port_onsite_dictionary_exchange_failures": 0,
+        "port_onsite_dictionary_rows": 36,
+        "reverse_11_even_CAR_failures": 0,
+        "shape": [
+          2,
+          2,
+          2
+        ]
+      },
+      "part2": {
+        "all_four_seam_images_exact": true,
+        "all_noninvolved_dictionary_rows_invariant": true,
+        "all_parity_bookkeeping_exact": true,
+        "all_routes_returned": true,
+        "axes": {
+          "0": {
+            "axis": 0,
+            "census": {
+              "diameter": 0,
+              "primitive_count": 18,
+              "route_transitions": 0,
+              "support_cells": 1
+            },
+            "edge": 0,
+            "explicit_bank_Majorana_source_construction_failures": 0,
+            "four_seam_image_failures": 0,
+            "gate_pass": true,
+            "noninvolved_dictionary_invariance_failures": 0,
+            "noninvolved_dictionary_rows": 290,
+            "other_endpoint_cell_index": 4,
+            "parity": {
+              "cell_parity_image_failures": false,
+              "odd_bank_detection_failures": 0,
+              "odd_matter_image_detection_failures": 0,
+              "total_joint_parity_invariance_failures": false
+            },
+            "routing": {
+              "forward_failures": 0,
+              "inverse_failures": 0,
+              "needed_noncolocated_primitive": false,
+              "returned_route": []
+            },
+            "synthesis": {
+              "augmented_signed_pairs": 5,
+              "final_pair_failures": 0,
+              "method": "greedy elementary symplectic CNOT transvections with parity completion",
+              "score_trace": [
+                {
+                  "mode": 1,
+                  "remaining_score": 14
+                },
+                {
+                  "mode": 0,
+                  "remaining_score": 8
+                },
+                {
+                  "mode": 2,
+                  "remaining_score": 6
+                },
+                {
+                  "mode": 3,
+                  "remaining_score": 4
+                },
+                {
+                  "mode": 4,
+                  "remaining_score": 2
+                },
+                {
+                  "mode": 5,
+                  "remaining_score": 0
+                }
+              ]
+            }
+          },
+          "1": {
+            "axis": 1,
+            "census": {
+              "diameter": 0,
+              "primitive_count": 18,
+              "route_transitions": 0,
+              "support_cells": 1
+            },
+            "edge": 1,
+            "explicit_bank_Majorana_source_construction_failures": 0,
+            "four_seam_image_failures": 0,
+            "gate_pass": true,
+            "noninvolved_dictionary_invariance_failures": 0,
+            "noninvolved_dictionary_rows": 290,
+            "other_endpoint_cell_index": 2,
+            "parity": {
+              "cell_parity_image_failures": false,
+              "odd_bank_detection_failures": 0,
+              "odd_matter_image_detection_failures": 0,
+              "total_joint_parity_invariance_failures": false
+            },
+            "routing": {
+              "forward_failures": 0,
+              "inverse_failures": 0,
+              "needed_noncolocated_primitive": false,
+              "returned_route": []
+            },
+            "synthesis": {
+              "augmented_signed_pairs": 5,
+              "final_pair_failures": 0,
+              "method": "greedy elementary symplectic CNOT transvections with parity completion",
+              "score_trace": [
+                {
+                  "mode": 3,
+                  "remaining_score": 22
+                },
+                {
+                  "mode": 0,
+                  "remaining_score": 16
+                },
+                {
+                  "mode": 1,
+                  "remaining_score": 10
+                },
+                {
+                  "mode": 2,
+                  "remaining_score": 4
+                },
+                {
+                  "mode": 4,
+                  "remaining_score": 2
+                },
+                {
+                  "mode": 5,
+                  "remaining_score": 0
+                }
+              ]
+            }
+          },
+          "2": {
+            "axis": 2,
+            "census": {
+              "diameter": 0,
+              "primitive_count": 18,
+              "route_transitions": 0,
+              "support_cells": 1
+            },
+            "edge": 2,
+            "explicit_bank_Majorana_source_construction_failures": 0,
+            "four_seam_image_failures": 0,
+            "gate_pass": true,
+            "noninvolved_dictionary_invariance_failures": 0,
+            "noninvolved_dictionary_rows": 290,
+            "other_endpoint_cell_index": 1,
+            "parity": {
+              "cell_parity_image_failures": false,
+              "odd_bank_detection_failures": 0,
+              "odd_matter_image_detection_failures": 0,
+              "total_joint_parity_invariance_failures": false
+            },
+            "routing": {
+              "forward_failures": 0,
+              "inverse_failures": 0,
+              "needed_noncolocated_primitive": false,
+              "returned_route": []
+            },
+            "synthesis": {
+              "augmented_signed_pairs": 5,
+              "final_pair_failures": 0,
+              "method": "greedy elementary symplectic CNOT transvections with parity completion",
+              "score_trace": [
+                {
+                  "mode": 5,
+                  "remaining_score": 30
+                },
+                {
+                  "mode": 0,
+                  "remaining_score": 24
+                },
+                {
+                  "mode": 1,
+                  "remaining_score": 18
+                },
+                {
+                  "mode": 2,
+                  "remaining_score": 12
+                },
+                {
+                  "mode": 3,
+                  "remaining_score": 6
+                },
+                {
+                  "mode": 4,
+                  "remaining_score": 0
+                }
+              ]
+            }
+          }
+        },
+        "gate_pass": true,
+        "port_cell_index": 0,
+        "tested_axes": 3
+      },
+      "shape": [
+        2,
+        2,
+        2
+      ]
+    },
+    "3x2x2": {
+      "part1": {
+        "cells": 12,
+        "census": {
+          "diameter": 0,
+          "primitive_count": 18,
+          "route_transitions": 0,
+          "support_cells": 1
+        },
+        "forward_11_even_CAR_failures": 0,
+        "forward_port_onsite_dictionary_exchange_failures": 0,
+        "gate_pass": true,
+        "generation": {
+          "declared_11_generator_missing_failures": 0,
+          "declared_11_generator_multiplicity_failures": 0,
+          "onsite_physical_target_identity_failures": 0
+        },
+        "incident_seam_exchange_failures": 0,
+        "nonincident_seam_invariance_failures": 0,
+        "other_cell_onsite_invariance_failures": 0,
+        "parity": {
+          "cell_parity_image_failures": false,
+          "odd_bank_detection_failures": 0,
+          "odd_matter_image_detection_failures": 0,
+          "total_joint_parity_invariance_failures": false
+        },
+        "port_cell": [
+          0,
+          0,
+          0
+        ],
+        "port_cell_index": 0,
+        "port_onsite_dictionary_exchange_failures": 0,
+        "port_onsite_dictionary_rows": 36,
+        "reverse_11_even_CAR_failures": 0,
+        "shape": [
+          3,
+          2,
+          2
+        ]
+      },
+      "part2": {
+        "all_four_seam_images_exact": true,
+        "all_noninvolved_dictionary_rows_invariant": true,
+        "all_parity_bookkeeping_exact": true,
+        "all_routes_returned": true,
+        "axes": {
+          "0": {
+            "axis": 0,
+            "census": {
+              "diameter": 0,
+              "primitive_count": 18,
+              "route_transitions": 0,
+              "support_cells": 1
+            },
+            "edge": 0,
+            "explicit_bank_Majorana_source_construction_failures": 0,
+            "four_seam_image_failures": 0,
+            "gate_pass": true,
+            "noninvolved_dictionary_invariance_failures": 0,
+            "noninvolved_dictionary_rows": 466,
+            "other_endpoint_cell_index": 4,
+            "parity": {
+              "cell_parity_image_failures": false,
+              "odd_bank_detection_failures": 0,
+              "odd_matter_image_detection_failures": 0,
+              "total_joint_parity_invariance_failures": false
+            },
+            "routing": {
+              "forward_failures": 0,
+              "inverse_failures": 0,
+              "needed_noncolocated_primitive": false,
+              "returned_route": []
+            },
+            "synthesis": {
+              "augmented_signed_pairs": 5,
+              "final_pair_failures": 0,
+              "method": "greedy elementary symplectic CNOT transvections with parity completion",
+              "score_trace": [
+                {
+                  "mode": 1,
+                  "remaining_score": 14
+                },
+                {
+                  "mode": 0,
+                  "remaining_score": 8
+                },
+                {
+                  "mode": 2,
+                  "remaining_score": 6
+                },
+                {
+                  "mode": 3,
+                  "remaining_score": 4
+                },
+                {
+                  "mode": 4,
+                  "remaining_score": 2
+                },
+                {
+                  "mode": 5,
+                  "remaining_score": 0
+                }
+              ]
+            }
+          },
+          "1": {
+            "axis": 1,
+            "census": {
+              "diameter": 0,
+              "primitive_count": 18,
+              "route_transitions": 0,
+              "support_cells": 1
+            },
+            "edge": 1,
+            "explicit_bank_Majorana_source_construction_failures": 0,
+            "four_seam_image_failures": 0,
+            "gate_pass": true,
+            "noninvolved_dictionary_invariance_failures": 0,
+            "noninvolved_dictionary_rows": 466,
+            "other_endpoint_cell_index": 2,
+            "parity": {
+              "cell_parity_image_failures": false,
+              "odd_bank_detection_failures": 0,
+              "odd_matter_image_detection_failures": 0,
+              "total_joint_parity_invariance_failures": false
+            },
+            "routing": {
+              "forward_failures": 0,
+              "inverse_failures": 0,
+              "needed_noncolocated_primitive": false,
+              "returned_route": []
+            },
+            "synthesis": {
+              "augmented_signed_pairs": 5,
+              "final_pair_failures": 0,
+              "method": "greedy elementary symplectic CNOT transvections with parity completion",
+              "score_trace": [
+                {
+                  "mode": 3,
+                  "remaining_score": 22
+                },
+                {
+                  "mode": 0,
+                  "remaining_score": 16
+                },
+                {
+                  "mode": 1,
+                  "remaining_score": 10
+                },
+                {
+                  "mode": 2,
+                  "remaining_score": 4
+                },
+                {
+                  "mode": 4,
+                  "remaining_score": 2
+                },
+                {
+                  "mode": 5,
+                  "remaining_score": 0
+                }
+              ]
+            }
+          },
+          "2": {
+            "axis": 2,
+            "census": {
+              "diameter": 0,
+              "primitive_count": 18,
+              "route_transitions": 0,
+              "support_cells": 1
+            },
+            "edge": 2,
+            "explicit_bank_Majorana_source_construction_failures": 0,
+            "four_seam_image_failures": 0,
+            "gate_pass": true,
+            "noninvolved_dictionary_invariance_failures": 0,
+            "noninvolved_dictionary_rows": 466,
+            "other_endpoint_cell_index": 1,
+            "parity": {
+              "cell_parity_image_failures": false,
+              "odd_bank_detection_failures": 0,
+              "odd_matter_image_detection_failures": 0,
+              "total_joint_parity_invariance_failures": false
+            },
+            "routing": {
+              "forward_failures": 0,
+              "inverse_failures": 0,
+              "needed_noncolocated_primitive": false,
+              "returned_route": []
+            },
+            "synthesis": {
+              "augmented_signed_pairs": 5,
+              "final_pair_failures": 0,
+              "method": "greedy elementary symplectic CNOT transvections with parity completion",
+              "score_trace": [
+                {
+                  "mode": 5,
+                  "remaining_score": 30
+                },
+                {
+                  "mode": 0,
+                  "remaining_score": 24
+                },
+                {
+                  "mode": 1,
+                  "remaining_score": 18
+                },
+                {
+                  "mode": 2,
+                  "remaining_score": 12
+                },
+                {
+                  "mode": 3,
+                  "remaining_score": 6
+                },
+                {
+                  "mode": 4,
+                  "remaining_score": 0
+                }
+              ]
+            }
+          }
+        },
+        "gate_pass": true,
+        "port_cell_index": 0,
+        "tested_axes": 3
+      },
+      "shape": [
+        3,
+        2,
+        2
+      ]
+    },
+    "5x3x2": {
+      "part1": {
+        "cells": 30,
+        "census": {
+          "diameter": 0,
+          "primitive_count": 18,
+          "route_transitions": 0,
+          "support_cells": 1
+        },
+        "forward_11_even_CAR_failures": 0,
+        "forward_port_onsite_dictionary_exchange_failures": 0,
+        "gate_pass": true,
+        "generation": {
+          "declared_11_generator_missing_failures": 0,
+          "declared_11_generator_multiplicity_failures": 0,
+          "onsite_physical_target_identity_failures": 0
+        },
+        "incident_seam_exchange_failures": 0,
+        "nonincident_seam_invariance_failures": 0,
+        "other_cell_onsite_invariance_failures": 0,
+        "parity": {
+          "cell_parity_image_failures": false,
+          "odd_bank_detection_failures": 0,
+          "odd_matter_image_detection_failures": 0,
+          "total_joint_parity_invariance_failures": false
+        },
+        "port_cell": [
+          0,
+          0,
+          0
+        ],
+        "port_cell_index": 0,
+        "port_onsite_dictionary_exchange_failures": 0,
+        "port_onsite_dictionary_rows": 36,
+        "reverse_11_even_CAR_failures": 0,
+        "shape": [
+          5,
+          3,
+          2
+        ]
+      },
+      "part2": {
+        "reason": "task limits 5x3x2 to Part 1 plus census",
+        "skipped": true
+      },
+      "shape": [
+        5,
+        3,
+        2
+      ]
+    }
+  },
+  "checks": [
+    {
+      "label": "dense exact Clifford tableau self-test has zero mismatches",
+      "pass": true
+    },
+    {
+      "label": "union-safe and bare constructors agree on cells edges and qubits for 2x2x2",
+      "pass": true
+    },
+    {
+      "label": "(1, 1, 1) Part 1 dictionary and exchange images are exact",
+      "pass": true
+    },
+    {
+      "label": "(1, 1, 1) Part 1 parity and bounded gate census pass",
+      "pass": true
+    },
+    {
+      "label": "(1, 1, 1) Part 2 seam images noninvolved rows parity and routing are exact",
+      "pass": true
+    },
+    {
+      "label": "(1, 1, 1) Part 2 named support gate passes",
+      "pass": true
+    },
+    {
+      "label": "(2, 2, 2) Part 1 dictionary and exchange images are exact",
+      "pass": true
+    },
+    {
+      "label": "(2, 2, 2) Part 1 parity and bounded gate census pass",
+      "pass": true
+    },
+    {
+      "label": "(2, 2, 2) Part 2 seam images noninvolved rows parity and routing are exact",
+      "pass": true
+    },
+    {
+      "label": "(2, 2, 2) Part 2 named support gate passes",
+      "pass": true
+    },
+    {
+      "label": "(3, 2, 2) Part 1 dictionary and exchange images are exact",
+      "pass": true
+    },
+    {
+      "label": "(3, 2, 2) Part 1 parity and bounded gate census pass",
+      "pass": true
+    },
+    {
+      "label": "(3, 2, 2) Part 2 seam images noninvolved rows parity and routing are exact",
+      "pass": true
+    },
+    {
+      "label": "(3, 2, 2) Part 2 named support gate passes",
+      "pass": true
+    },
+    {
+      "label": "(5, 3, 2) optional Part 1 and census pass",
+      "pass": true
+    },
+    {
+      "label": "mixed-gauge factorization anchors regress with exact coordinates",
+      "pass": true
+    },
+    {
+      "label": "24 frames x 8 translation parities have exact dictionary-family and seam-class covariance",
+      "pass": true
+    },
+    {
+      "label": "deleting one CNOT produces a nonzero conjugation mismatch",
+      "pass": true
+    },
+    {
+      "label": "flipping the middle CNOT of one SWAP block produces a nonzero mismatch",
+      "pass": true
+    },
+    {
+      "label": "appending one stray primitive to the seam word is detected",
+      "pass": true
+    },
+    {
+      "label": "an unlawful odd input is detected by joint parity",
+      "pass": true
+    },
+    {
+      "label": "a wrong-port word leaves the declared port rows unmapped",
+      "pass": true
+    }
+  ],
+  "claim_boundary": "This is a reversible even-exchange port plus seam-extended coupling on the declared companion/center code with supplied sector inventory. It is not the gauge-mixed logical injection E_s, which remains the Bell/Choi route. The factorization locality values are a coordinate-row census only: no V_s restriction is compiled. There is no autonomy or genesis claim. Circuit ordinals describe structure, not time. This is state-level coupling only, with no matter, FTL, mass, or charge transfer.",
+  "controls": {
+    "delete_one_CNOT_mismatch_count": 1,
+    "hostile_middle_CNOT_flip_mismatch_count": 2,
+    "palindromic_literal_reverse_mismatch_count": 0,
+    "palindromic_reverse_note": "the standard three-CNOT SWAP is palindromic, so literal gate-order reversal is the identical Clifford; reported as an informational identity, not a control",
+    "seam_word_palindromic": false,
+    "stray_seam_primitive_mismatch_count": 2,
+    "stray_seam_primitive_not_found": false,
+    "stray_seam_primitive_pair": [
+      0,
+      1
+    ],
+    "unlawful_odd_input_detection_failures": 0,
+    "wrong_port_mismatch_count": 11
+  },
+  "covariance": {
+    "2x2x2": {
+      "binary_port_dictionary_multiset_failures": 0,
+      "binary_seam_multiset_failures": 0,
+      "census_vector_failures": 0,
+      "contexts": 192,
+      "distinct_relocated_port_coordinates": 8,
+      "failures": 0,
+      "frame_action": "Q.physical_images exact signed generator transport",
+      "frames": 24,
+      "lexicographic_min_port_not_transported_contexts": 168,
+      "port_rule": "rebuilt at the transported image of the source port; the lexicographic-minimum default is a supplied chart convention and is not frame-covariant",
+      "shape": [
+        2,
+        2,
+        2
+      ],
+      "signed_port_dictionary_multiset_failures": 0,
+      "signed_seam_image_class_failures": 0,
+      "translation_parities": 8
+    },
+    "3x2x2": {
+      "binary_port_dictionary_multiset_failures": 0,
+      "binary_seam_multiset_failures": 0,
+      "census_vector_failures": 0,
+      "contexts": 192,
+      "distinct_relocated_port_coordinates": 8,
+      "failures": 0,
+      "frame_action": "Q.physical_images exact signed generator transport",
+      "frames": 24,
+      "lexicographic_min_port_not_transported_contexts": 168,
+      "port_rule": "rebuilt at the transported image of the source port; the lexicographic-minimum default is a supplied chart convention and is not frame-covariant",
+      "shape": [
+        3,
+        2,
+        2
+      ],
+      "signed_port_dictionary_multiset_failures": 0,
+      "signed_seam_image_class_failures": 0,
+      "translation_parities": 8
+    }
+  },
+  "dense_selftest": {
+    "comparisons": 8208,
+    "gates": 57,
+    "maximum_residual": 2.220446049250313e-16,
+    "mismatches": 0,
+    "pauli_rows": 144
+  },
+  "derived": [
+    "six co-located three-CNOT SWAP blocks exchange the declared live even-CAR bank with the full 36-row port-cell onsite dictionary family exactly",
+    "the same parity-complete local word maps bank-ended incident seam bilinears back to the supplied physical seam rows",
+    "all route counts are zero because every synthesized two-M2 primitive is co-located at the declared port cell"
+  ],
+  "direct_encoded_input_clifford_attempted": true,
+  "encoded_input_clifford_v_s_restriction_compiled": false,
+  "factorization_anchor": {
+    "all_regressions_pass": true,
+    "boxes": {
+      "2x2x2": {
+        "coordinate_failure_fields": {
+          "canonical_tableau_pairing_failures": 0,
+          "even_sector_phase_failures": 0,
+          "gauge_coordinate_failures_for_every_physical_generator": 0,
+          "logical_coordinate_failures": 0,
+          "odd_sector_phase_failures": 0,
+          "parity_coordinate_failures": 0,
+          "phase_contradictions": 0,
+          "phase_parity_failures": 0
+        },
+        "coordinate_failures": 0,
+        "dimension_identity": true,
+        "factorwise_full_word_intertwiner_exact": true,
+        "finite_box_mixed_gauge_CPTP_E_constructed": true,
+        "locality": {
+          "canonical_tableau_bounded_R2": false,
+          "full_center_rank": 6,
+          "local_R2_center_rank_plus_supplied_parity": 6,
+          "locally_generated_center_ranks": {
+            "0": 0,
+            "1": 0,
+            "2": 5
+          },
+          "maximum_canonical_encoder_row_diameter": 3,
+          "maximum_canonical_encoder_row_weight": 66,
+          "maximum_center_dual_row_diameter": 3,
+          "maximum_gauge_Bell_coordinate_row_diameter": 3,
+          "maximum_logical_coordinate_row_diameter": 3
+        },
+        "shape": [
+          2,
+          2,
+          2
+        ],
+        "tableau_digest": "e83b7b242297a8e613073dc1984a17ee07d632708676f4ff786c9bca943fcd0b"
+      },
+      "3x2x2": {
+        "coordinate_failure_fields": {
+          "canonical_tableau_pairing_failures": 0,
+          "even_sector_phase_failures": 0,
+          "gauge_coordinate_failures_for_every_physical_generator": 0,
+          "logical_coordinate_failures": 0,
+          "odd_sector_phase_failures": 0,
+          "parity_coordinate_failures": 0,
+          "phase_contradictions": 0,
+          "phase_parity_failures": 0
+        },
+        "coordinate_failures": 0,
+        "dimension_identity": true,
+        "factorwise_full_word_intertwiner_exact": true,
+        "finite_box_mixed_gauge_CPTP_E_constructed": true,
+        "locality": {
+          "canonical_tableau_bounded_R2": false,
+          "full_center_rank": 10,
+          "local_R2_center_rank_plus_supplied_parity": 10,
+          "locally_generated_center_ranks": {
+            "0": 0,
+            "1": 0,
+            "2": 9
+          },
+          "maximum_canonical_encoder_row_diameter": 4,
+          "maximum_canonical_encoder_row_weight": 104,
+          "maximum_center_dual_row_diameter": 4,
+          "maximum_gauge_Bell_coordinate_row_diameter": 4,
+          "maximum_logical_coordinate_row_diameter": 4
+        },
+        "shape": [
+          3,
+          2,
+          2
+        ],
+        "tableau_digest": "10ec1180a23dd781c406fca7a9a6f0b2d5bf75da74fd1712849904bdc2197a47"
+      }
+    },
+    "census_role": "reported measured ceiling for a future literal V_s-restriction word; no route is compiled from the digest or locality metrics",
+    "literal_v_s_restriction_compiled": false,
+    "v_s_coordinate_rows_returned": false
+  },
+  "fixture_constructor_equivalence": {
+    "cells_identical": true,
+    "edges_identical": true,
+    "matter_qubits_identical": true,
+    "qubits_identical": true,
+    "shape": [
+      2,
+      2,
+      2
+    ],
+    "used_constructor": "O.arbitrary_fixture(Q.shape_cells(shape))"
+  },
+  "open": [
+    "a public immutable V_s tableau/coordinate API and literal restriction compiler",
+    "the Bell/Choi gauge-mixed logical injection E_s",
+    "fault-tolerant preparation, decoding, and autonomous sector repair",
+    "coframe-origin seeded transport: this bank/dictionary surface touches no coframe registers, so the eight-origin channel covariance stays with the epoch-level composition",
+    "autonomous selection of the port cell: the lexicographic-minimum default is a supplied chart convention (covariance evaluates the transported port)"
+  ],
+  "runtime_seconds": 20.91364504199737,
+  "status": "cycle721-direct-local-encoded-input-clifford-port-pass",
+  "supplied": [
+    "the Cycle-720 companion/center operator dictionary and sector inventory",
+    "one clean six-qubit live-input bank co-located at the declared port",
+    "the total-parity label and companion center-sector representative"
+  ]
+}
+
+----- stderr -----
+

--- a/logs/runner-cache/frontier_cycle721_tournament_independent_adversary_2026_07_28.txt
+++ b/logs/runner-cache/frontier_cycle721_tournament_independent_adversary_2026_07_28.txt
@@ -1,0 +1,318 @@
+===== runner cache v1 =====
+runner: scripts/frontier_cycle721_tournament_independent_adversary_2026_07_28.py
+runner_sha256: 0e0ae439a38248ab01808768c692a396a28440b1400f44274864bd38b6e49a25
+input_fingerprint_sha256: 5323e1963fb049f2ac069474281e53aa3bac5d0c9e1d3e38455a8e2cb39bfed5
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 6.36
+status: ok
+----- stdout -----
+PASS exchange_port_certificate
+PASS dilation_certificate
+PASS atlas_correction_certificate
+PASS seam_class_certificate
+PASS epoch_liveness_certificate
+PASS fixture_certificate
+{
+  "audit": "unset",
+  "authority": "none",
+  "blocked_primary_imports_present": [],
+  "certificates": {
+    "atlas_correction": {
+      "atlas_entries": 100,
+      "graph_rank": 100,
+      "graph_rows": 100,
+      "graph_width": 120,
+      "maximum_private_dual_support_cells": 1,
+      "one_cell_support_failures": 0,
+      "one_hot_duality_failures": 0,
+      "rows_without_one_cell_solution": 0,
+      "shape": [
+        2,
+        2,
+        2
+      ],
+      "solve_contradictions": 0
+    },
+    "dilation": {
+      "compiled_commutator_failures": 0,
+      "compiled_rank": 100,
+      "dilation_X_invariance_failures": 0,
+      "dilation_Z_character_failures": 0,
+      "graph_rank": 100,
+      "maximum_compiled_support_cells": 2,
+      "maximum_compiled_support_diameter": 1,
+      "per_row_support_census": [
+        {
+          "rows": 88,
+          "support_cells": 1,
+          "support_diameter": 0
+        },
+        {
+          "rows": 12,
+          "support_cells": 2,
+          "support_diameter": 1
+        }
+      ],
+      "physical_restriction_tag_rebuild_failures": 0,
+      "rows": 100,
+      "shape": [
+        2,
+        2,
+        2
+      ],
+      "support_gate_failures": 0
+    },
+    "epoch_liveness": {
+      "A_B_C_route_failures": {
+        "forward": 0,
+        "inverse": 0
+      },
+      "axis_order": [
+        2,
+        1,
+        0
+      ],
+      "correction_layer_order_failures": 0,
+      "correction_layers": 10,
+      "coupling_graph_tag_order_failures": 0,
+      "coupling_physical_restriction_failures": 0,
+      "coupling_rows": 100,
+      "dropped_handoff_control": {
+        "deleted_edge": [
+          "B:coupling:0",
+          "C:correction:0",
+          616
+        ],
+        "named_missing_handoff_detected": true,
+        "violation_count": 1
+      },
+      "duplicated_owner_control": {
+        "collision_count": 3,
+        "duplicated_word": "B:coupling:0",
+        "named_collision_detected": true,
+        "slot": 201
+      },
+      "lawful_walk": {
+        "collision_count": 0,
+        "handoffs_consumed": 35842,
+        "handoffs_declared": 35842,
+        "ownership_or_handoff_violation_count": 0,
+        "register_touches": 36666,
+        "registers_seen": 824,
+        "slots_walked": 17705,
+        "violations": [],
+        "words_walked": 17705
+      },
+      "namespace": {
+        "Bell_ancillae": [
+          616,
+          716
+        ],
+        "G_routed_only_sites": [
+          144,
+          616
+        ],
+        "code": [
+          0,
+          72
+        ],
+        "companion_encoded_bank": [
+          72,
+          144
+        ],
+        "pump_syndromes": [
+          716,
+          816
+        ],
+        "route_rails": [
+          816,
+          824
+        ],
+        "total_registers": 824
+      },
+      "pump_fill_rows": 5,
+      "pump_onsite_rows": 88,
+      "pump_rows": 100,
+      "pump_tree_rows": 7,
+      "recurrent_logical_update_factors": 280,
+      "recurrent_non_NN_failures": 0,
+      "recurrent_placement_collisions": 0,
+      "recurrent_route_return_failures": 0,
+      "recurrent_routed_primitives": 17304,
+      "root": [
+        0,
+        0,
+        0
+      ],
+      "shape": [
+        2,
+        2,
+        2
+      ],
+      "stage_order_failures": 0
+    },
+    "exchange_port": {
+      "CNOT_primitives": 18,
+      "F1_docstring_range": [
+        72,
+        144
+      ],
+      "F2_derived_six_qubit_range": [
+        72,
+        78
+      ],
+      "all_affected_dictionary_exchange_failures": 0,
+      "cell_parity_image_failures": false,
+      "convention_evidence_pass": true,
+      "dense_integer_Pauli_selftest": {
+        "CNOT_instances": 6,
+        "CZ_instances": 3,
+        "H_instances": 3,
+        "comparisons": 8208,
+        "controlled_Pauli_instances": 45,
+        "gate_instances": 57,
+        "maximum_dense_residual": 2.220446049250313e-16,
+        "mismatches": 0,
+        "signed_weight_1_or_2_rows": 144
+      },
+      "forward_dictionary_exchange_failures": 0,
+      "joint_parity_invariance_failures": false,
+      "odd_bank_detection_failures": 0,
+      "odd_image_detection_failures": 0,
+      "port_dictionary_rows": 36,
+      "q": 72,
+      "reverse_dictionary_exchange_failures": 0,
+      "shape": [
+        2,
+        2,
+        2
+      ],
+      "six_SWAP_blocks": 6,
+      "support_cells": 1,
+      "support_diameter": 0,
+      "unaffected_dictionary_invariance_failures": 0
+    },
+    "fixture": {
+      "EB_module_present_after_dense_rebuild": false,
+      "EB_module_present_before_dense_rebuild": false,
+      "cycle230_residuals": {
+        "FSWAP_matrix_residual": 0.0,
+        "coin_matrix_residual": 1.952777839357751e-16,
+        "internal_depth_two_stream_residual": 0.0,
+        "mass_residual": 0.0,
+        "onsite_64_state_contact_residual": 2.149937642474629e-15
+      },
+      "docstring_fixed_sector_inventory_evidence": true,
+      "mass_contact_residuals": {
+        "contact_double_occupation_phase_residual": 0.0,
+        "contact_vacuum_and_one_particle_residual": 0.0,
+        "one_particle_mass_residual": 5.551115123125783e-17
+      },
+      "maximum_inherited_residual": 2.149937642474629e-15,
+      "two_mode_fixed_sector_Kraus": {
+        "Bell_basis_orthonormality_residual": 4.440892098500626e-16,
+        "construction": "four Kraus maps derived by contracting an input/resource Bell basis against a dense Bell pair, corrected by the independently selected logical Pauli, then embedded in each two-mode parity sector",
+        "corrected_Kraus_completeness_residual": 6.280369834735101e-16,
+        "corrected_branch_identity_residual": 1.1102230246251565e-16,
+        "fixed_parity_sector_dimension": 2,
+        "maximum_residual": 6.280369834735101e-16,
+        "outcomes_per_sector": 4,
+        "physical_modes": 2,
+        "sectors": {
+          "even": {
+            "Kraus_operators": 4,
+            "completeness_residual": 6.280369834735101e-16,
+            "sector_dimension": 2,
+            "sector_leakage_residual": 0.0
+          },
+          "odd": {
+            "Kraus_operators": 4,
+            "completeness_residual": 6.280369834735101e-16,
+            "sector_dimension": 2,
+            "sector_leakage_residual": 0.0
+          }
+        },
+        "uncorrected_Kraus_completeness_residual": 6.280369834735101e-16
+      }
+    },
+    "seam_class": {
+      "contexts": 192,
+      "double_class_failures": 0,
+      "first_failure": null,
+      "forward_class_count": 1152,
+      "missing_edge_failures": 0,
+      "proper_cubic_frames": 24,
+      "reversed_class_count": 1152,
+      "reversed_surface": "fixture.physical_terms after explicit endpoint/mode reordering",
+      "shape": [
+        2,
+        2,
+        2
+      ],
+      "translation_parities": 8,
+      "transport_surface": "Q.affine_cells plus Q.physical_images",
+      "transported_quadruples": 2304,
+      "zero_class_failures": 0
+    }
+  },
+  "checks": [
+    {
+      "label": "exchange_port_certificate",
+      "pass": true
+    },
+    {
+      "label": "dilation_certificate",
+      "pass": true
+    },
+    {
+      "label": "atlas_correction_certificate",
+      "pass": true
+    },
+    {
+      "label": "seam_class_certificate",
+      "pass": true
+    },
+    {
+      "label": "epoch_liveness_certificate",
+      "pass": true
+    },
+    {
+      "label": "fixture_certificate",
+      "pass": true
+    }
+  ],
+  "declared_conventions": {
+    "F1_declares_H_CP_H": true,
+    "F1_declares_bank_q_2q": true,
+    "F1_declares_code_0_q": true,
+    "F1_declares_fixed_X_and_character_Z": true,
+    "F2_declares_colocation": true,
+    "F2_declares_one_six_mode_live_bank": true,
+    "F3_declares_literal_slot_walk": true,
+    "F3_declares_stage_components": true,
+    "derivation": "F1 states its q-wide mirror range literally.  F2 declares one six-mode bank, and the code register ends at q, so its separate bank occupies the next six registers [q,q+6).",
+    "derived_F1_range_formula": "[q,2q)",
+    "derived_F2_range_formula": "[q,q+6)",
+    "docstring_sha256": {
+      "frontier_cycle721_car_bell_input_m2_compiler_2026_07_28": "1ce48f171c3f75a88dbcc867f96c91a31540326babe61b3a285352f04558afcb",
+      "frontier_cycle721_collision_free_epoch_composition_2026_07_28": "eaebb011e258f4676315c66c9b82edb81da5a2c634d9feb1d60269b96dd66e89",
+      "frontier_cycle721_encoded_input_clifford_port_2026_07_28": "a695906be935baed77d5a86fedf445de137f1c58e6138db24270494f82f7a4c7"
+    }
+  },
+  "report_sha256": "c4d1b32d12358e287e81fdc0436f584b96ed60b51fddce651d6597222a302be6",
+  "runtime_seconds": 6.248188417004712,
+  "status": "PASS",
+  "top_level_blocklist": [
+    "frontier_cycle721_car_bell_input_m2_compiler_2026_07_28",
+    "frontier_cycle721_collision_free_epoch_composition_2026_07_28",
+    "frontier_cycle721_encoded_input_clifford_port_2026_07_28"
+  ],
+  "wording_corrections": [
+    "The epoch runner's description of its alternate port as the F2 leg needs a namespace qualifier: standalone F2 declares one six-qubit bank [q,q+6), whereas the epoch embeds a port-indexed six-qubit sub-block inside the q-wide F1 bank [q,2q).  These register conventions coincide only for port index zero."
+  ]
+}
+CYCLE721_TOURNAMENT_INDEPENDENT_ADVERSARY_PASS
+
+----- stderr -----
+

--- a/outputs/car_bell_input_epoch_tournament_cycle721_receipt_2026_07_28.json
+++ b/outputs/car_bell_input_epoch_tournament_cycle721_receipt_2026_07_28.json
@@ -1,0 +1,118 @@
+{
+  "artifacts": {
+    "caches": {
+      "frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.txt": "41f3665f0da45196d6256bd3e7a51dad31d6d0fe4c5f34c83c329b9f5126bac5",
+      "frontier_cycle721_collision_free_epoch_composition_2026_07_28.txt": "c12dc7287168e74a27dc8d3217ad666f6378ba514805a617079543bf26a0ca62",
+      "frontier_cycle721_encoded_input_clifford_port_2026_07_28.txt": "29b364bc8217cd2d8524e4e73a44ad41f820ded60513e947447ce55f34bea323",
+      "frontier_cycle721_tournament_independent_adversary_2026_07_28.txt": "d39b699a2fec85698fa98a9c4a5518ad5e3f27837b2d5672ef145573568093d2"
+    },
+    "note": {
+      "path": "docs/CAR_BELL_INPUT_PHYSICAL_M2_COMPILER_CYCLE721_BOUNDED_THEOREM_NOTE_2026-07-28.md",
+      "sha256": "5f4f389c3f16c0ca7adfbae43d2aabd04880e638c8de5284e07f4b80170e67be"
+    },
+    "runners": {
+      "frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.py": "434b643dfa4265b38aed5d6da6aa818e56ad9b4e34e7467489f6dace26ab2252",
+      "frontier_cycle721_collision_free_epoch_composition_2026_07_28.py": "046d013dbaef721ceaddf02ba81b3852967745bf2e5aa597fc19e2ee69653166",
+      "frontier_cycle721_encoded_input_clifford_port_2026_07_28.py": "980c74c1b623c13061f554c29f5569c5cccbc67072cf84e33f4a3432e4204cde",
+      "frontier_cycle721_tournament_independent_adversary_2026_07_28.py": "0e0ae439a38248ab01808768c692a396a28440b1400f44274864bd38b6e49a25"
+    }
+  },
+  "audit": "unset",
+  "authority": "none",
+  "boundary": {
+    "axiom_pressure": false,
+    "collision_free_joint_epoch_composed": true,
+    "encoded_input_clifford_v_s_restriction_compiled": false,
+    "even_car_input_bell_measurement_physical_M2_compiled": true,
+    "fixed_supplies": "parity/center sector, mixed gauge reference, uniform coframe sector, finite boundary/root/router, clean preparation and input banks, one-time epoch, fixed local schedules, Cycle219/Cycle230 parameters, companion-encoded input bank and declared-port chart conventions",
+    "no_go_minimum_shared_obstruction_axiom_pressure_promotion": "FAIL",
+    "not_derived": "autonomous sector/genesis/enforcement, boundary-free or periodic recurrence, renewal/multi-source composition, V_s-restriction input compiler, time/rate, source/gravity law, Record, Born/history, or prediction bridge",
+    "positive_scope": "literal physical-M2 input-Bell measurement words meeting the two-cell/diameter-one gate, a one-cell reversible even-exchange input port with port-local seam coupling, and a collision-free four-stage epoch composition with verified register-liveness on finite open boxes"
+  },
+  "checks": {
+    "f1_named_checks_passed": 10,
+    "f2_named_checks_passed": 22,
+    "f3_named_checks_passed": 6,
+    "independent_named_checks_failed": 0,
+    "independent_named_checks_passed": 6
+  },
+  "claim_type": "bounded_theorem",
+  "cycle": 721,
+  "date": "2026-07-28",
+  "result": {
+    "boxes_f1": [
+      [
+        1,
+        1,
+        1
+      ],
+      [
+        2,
+        2,
+        2
+      ],
+      [
+        3,
+        2,
+        2
+      ],
+      [
+        5,
+        3,
+        2
+      ],
+      [
+        4,
+        4,
+        4
+      ],
+      [
+        5,
+        5,
+        3
+      ]
+    ],
+    "correction_layers_by_box": [
+      6,
+      10,
+      11,
+      11,
+      11,
+      11
+    ],
+    "edge_orientation_classes_forward_reversed": [
+      3072,
+      3072
+    ],
+    "epoch_covariance_contexts": 192,
+    "epoch_variants": [
+      "compiled-bell-primary",
+      "exchange-port-alternate"
+    ],
+    "max_compiled_word_support_cells": 2,
+    "max_compiled_word_support_diameter": 1,
+    "max_private_dual_support_cells": 1,
+    "measurement_layer_law": "3 + maximum cell degree",
+    "measurement_layers_by_box": [
+      3,
+      6,
+      7,
+      8,
+      9,
+      9
+    ],
+    "port_word_primitives": 18,
+    "rows_by_box": [
+      11,
+      100,
+      152,
+      389,
+      848,
+      995
+    ],
+    "seam_coupling_support_cells": 1,
+    "seam_coupling_support_diameter": 0,
+    "transport_contexts": 384
+  },
+  "status": "CYCLE721_INPUT_COMPILER_PORT_AND_EPOCH_TOURNAMENT_PASS"
+}

--- a/scripts/frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.py
+++ b/scripts/frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.py
@@ -1,0 +1,1731 @@
+#!/usr/bin/env python3
+"""Cycle-721 literal physical-M2 compiler for the even-CAR Bell input rows.
+
+For a fixture with ``N`` cells and ``q = 9N``:
+
+===================  ================================================
+wide-register range  ownership
+===================  ================================================
+``[0, q)``           physical output M2: ``6N`` matter then ``3N`` companion
+``[q, 2q)``          companion-encoded live-input mirror of the physical M2
+``[2q, 2q+R)``       one retained Bell-syndrome ancilla per direct-basis row
+following ``N``      one returned mobile-route rail per cell
+===================  ================================================
+
+The Cycle-720 graph row's coarse-input half is dropped entirely.  Each
+measured character is the graph row restricted to physical bits times the
+same full physical-representation row on the companion-encoded input bank.
+Row order is exactly ``P.direct_graph_basis`` order.  A measurement word is
+literally ``H(a); controlled local Pauli letters; H(a)`` with its route
+returned and its syndrome ancilla retained.  In this conjugation direction
+``X(a)`` is fixed while ``Z(a)`` is transported to ``Z(a) * R_i``.  Thus,
+with the supplied clean ancilla, the retained Z readout is the ``R_i``
+character; fixed ``X(a)`` means there is no conjugate leakage.
+
+This is instruction-level compilation on the declared site map and supplied
+sector/genesis inventory.  It does not claim a collision-free joint epoch
+with the pump and recurrent G.  Ordinals are circuit structure, not time.
+The result is state-level coupling only: no matter, FTL, mass, or charge
+transfer is asserted.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import copy
+from itertools import product
+import json
+from time import perf_counter
+
+import numpy as np
+
+import frontier_cycle720_cell_majorana_companion_geometry_2026_07_27 as M
+import frontier_cycle720_companion_checkerboard_frame_cocycle_2026_07_27 as Q
+import frontier_cycle720_companion_local_choi_tree_plaquette_pump_2026_07_27 as P
+import frontier_cycle720_companion_local_choi_pump_covariance_2026_07_27 as V
+import frontier_cycle720_overlap_star_mixed_gauge_choi_2026_07_27 as O
+import frontier_cycle720_companion_fixed_sector_even_car_bell_2026_07_27 as EB
+
+
+AUDIT_TIMEOUT_SEC = 900
+NOTE_PATH = (
+    "docs/CAR_BELL_INPUT_PHYSICAL_M2_COMPILER_CYCLE721_"
+    "BOUNDED_THEOREM_NOTE_2026-07-28.md"
+)
+AUDIT_INPUT_PATHS = (
+    "docs/CAR_BELL_INPUT_PHYSICAL_M2_COMPILER_CYCLE721_BOUNDED_THEOREM_NOTE_2026-07-28.md",
+    "scripts/frontier_cycle720_cell_majorana_companion_geometry_2026_07_27.py",
+    "scripts/frontier_cycle720_companion_checkerboard_frame_cocycle_2026_07_27.py",
+    "scripts/frontier_cycle720_companion_local_choi_tree_plaquette_pump_2026_07_27.py",
+    "scripts/frontier_cycle720_companion_local_choi_pump_covariance_2026_07_27.py",
+    "scripts/frontier_cycle720_overlap_star_mixed_gauge_choi_2026_07_27.py",
+    "scripts/frontier_cycle720_companion_fixed_sector_even_car_bell_2026_07_27.py",
+)
+DECLARED_INPUT_PATHS = AUDIT_INPUT_PATHS
+
+Pauli = M.Pauli
+Coord = tuple[int, int, int]
+Gate = tuple
+TOL = 1.0e-12
+
+
+def fields(row: Pauli) -> tuple[int, int, int]:
+    return row.phase % 4, row.x, row.z
+
+
+def multiply(left: Pauli, right: Pauli) -> Pauli:
+    """Exact Pauli multiplication in the imported ``i^p X^x Z^z`` encoding."""
+    return left @ right
+
+
+def pauli_letter(qubit: int, letter: str) -> Pauli:
+    if letter == "X":
+        return Pauli(x=1 << qubit)
+    if letter == "Z":
+        return Pauli(z=1 << qubit)
+    if letter == "Y":
+        return Pauli(phase=1, x=1 << qubit, z=1 << qubit)
+    raise ValueError(f"unsupported Pauli letter {letter!r}")
+
+
+def letter_at(row: Pauli, qubit: int) -> str:
+    x = (row.x >> qubit) & 1
+    z = (row.z >> qubit) & 1
+    return ("I", "X", "Z", "Y")[x + 2 * z]
+
+
+def supported_qubits(row: Pauli) -> tuple[int, ...]:
+    mask = row.x | row.z
+    output = []
+    while mask:
+        bit = mask & -mask
+        output.append(bit.bit_length() - 1)
+        mask ^= bit
+    return tuple(output)
+
+
+def conjugate_h(row: Pauli, qubit: int) -> Pauli:
+    """Conjugate a Pauli by a standard Hadamard, with phase modulo four."""
+    bit = 1 << qubit
+    x = 1 if row.x & bit else 0
+    z = 1 if row.z & bit else 0
+    output_x = (row.x & ~bit) | (bit if z else 0)
+    output_z = (row.z & ~bit) | (bit if x else 0)
+    return Pauli((row.phase + 2 * x * z) % 4, output_x, output_z)
+
+
+def conjugate_controlled_letter(
+    row: Pauli, control: int, target: int, letter: str
+) -> Pauli:
+    """Conjugate by ``|0><0| I + |1><1| letter`` exactly."""
+    if control == target:
+        raise ValueError("controlled-Pauli control and target must differ")
+    local_mask = (1 << control) | (1 << target)
+    rest = Pauli(
+        row.phase,
+        row.x & ~local_mask,
+        row.z & ~local_mask,
+    )
+    target_pauli = pauli_letter(target, letter)
+    xc_image = multiply(Pauli(x=1 << control), target_pauli)
+    zc_image = Pauli(z=1 << control)
+    xt = Pauli(x=1 << target)
+    zt = Pauli(z=1 << target)
+    xt_image = (
+        multiply(zc_image, xt)
+        if target_pauli.z & (1 << target)
+        else xt
+    )
+    zt_image = (
+        multiply(zc_image, zt)
+        if target_pauli.x & (1 << target)
+        else zt
+    )
+    local = Pauli()
+    if row.x & (1 << control):
+        local = multiply(local, xc_image)
+    if row.x & (1 << target):
+        local = multiply(local, xt_image)
+    if row.z & (1 << control):
+        local = multiply(local, zc_image)
+    if row.z & (1 << target):
+        local = multiply(local, zt_image)
+    return multiply(rest, local)
+
+
+def conjugate_word(row: Pauli, gates: tuple[Gate, ...]) -> Pauli:
+    output = row
+    for gate in gates:
+        if gate[0] == "H":
+            output = conjugate_h(output, gate[1])
+        elif gate[0] == "CP":
+            output = conjugate_controlled_letter(
+                output, gate[1], gate[2], gate[3]
+            )
+        else:
+            raise ValueError(f"unknown compiled gate {gate!r}")
+    return output
+
+
+def row_from_letters(letters: tuple[str, ...]) -> Pauli:
+    output = Pauli()
+    for qubit, letter in enumerate(letters):
+        if letter != "I":
+            output = multiply(output, pauli_letter(qubit, letter))
+    return output
+
+
+def dense_pauli(row: Pauli, width: int) -> np.ndarray:
+    I = np.eye(2, dtype=complex)
+    X = np.asarray(((0, 1), (1, 0)), dtype=complex)
+    Y = np.asarray(((0, -1j), (1j, 0)), dtype=complex)
+    Z = np.asarray(((1, 0), (0, -1)), dtype=complex)
+    matrices = (I, X, Z, Y)
+    output = np.asarray(((1,),), dtype=complex)
+    y_count = 0
+    for qubit in reversed(range(width)):
+        x = (row.x >> qubit) & 1
+        z = (row.z >> qubit) & 1
+        y_count += x & z
+        output = np.kron(output, matrices[x + 2 * z])
+    return (1j ** ((row.phase - y_count) % 4)) * output
+
+
+def dense_h(qubit: int, width: int) -> np.ndarray:
+    I = np.eye(2, dtype=complex)
+    H = np.asarray(((1, 1), (1, -1)), dtype=complex) / np.sqrt(2)
+    output = np.asarray(((1,),), dtype=complex)
+    for index in reversed(range(width)):
+        output = np.kron(output, H if index == qubit else I)
+    return output
+
+
+def dense_controlled_target(target_row: Pauli, control: int, width: int) -> np.ndarray:
+    identity = np.eye(1 << width, dtype=complex)
+    z_control = dense_pauli(Pauli(z=1 << control), width)
+    projector_zero = (identity + z_control) / 2
+    projector_one = (identity - z_control) / 2
+    return projector_zero + projector_one @ dense_pauli(target_row, width)
+
+
+def dense_selftest_certificate() -> dict[str, object]:
+    """Exhaust all 16 two-target Paulis and all 64 three-qubit test rows."""
+    width = 3
+    ancilla = 0
+    test_rows = tuple(
+        row_from_letters(letters)
+        for letters in product(("I", "X", "Z", "Y"), repeat=width)
+    )
+    mismatches = 0
+    maximum_residual = 0.0
+    hadamard_tests = 0
+    primitive_tests = 0
+    pair_tests = 0
+
+    h_matrix = dense_h(ancilla, width)
+    for row in test_rows:
+        actual = dense_pauli(conjugate_h(row, ancilla), width)
+        expected = h_matrix @ dense_pauli(row, width) @ h_matrix.conj().T
+        residual = float(np.linalg.norm(actual - expected))
+        maximum_residual = max(maximum_residual, residual)
+        mismatches += residual > TOL
+        hadamard_tests += 1
+
+    for target in (1, 2):
+        for letter in ("X", "Z", "Y"):
+            target_row = pauli_letter(target, letter)
+            unitary = dense_controlled_target(target_row, ancilla, width)
+            for row in test_rows:
+                actual = dense_pauli(
+                    conjugate_controlled_letter(row, ancilla, target, letter),
+                    width,
+                )
+                expected = unitary @ dense_pauli(row, width) @ unitary.conj().T
+                residual = float(np.linalg.norm(actual - expected))
+                maximum_residual = max(maximum_residual, residual)
+                mismatches += residual > TOL
+                primitive_tests += 1
+
+    for target_letters in product(("I", "X", "Z", "Y"), repeat=2):
+        target_row = Pauli()
+        gates: list[Gate] = [("H", ancilla)]
+        for target, letter in zip((1, 2), target_letters):
+            if letter != "I":
+                target_row = multiply(
+                    target_row, pauli_letter(target, letter)
+                )
+                gates.append(("CP", ancilla, target, letter))
+        gates.append(("H", ancilla))
+        controlled = dense_controlled_target(target_row, ancilla, width)
+        unitary = h_matrix @ controlled @ h_matrix
+        for row in test_rows:
+            actual = dense_pauli(conjugate_word(row, tuple(gates)), width)
+            expected = unitary @ dense_pauli(row, width) @ unitary.conj().T
+            residual = float(np.linalg.norm(actual - expected))
+            maximum_residual = max(maximum_residual, residual)
+            mismatches += residual > TOL
+            pair_tests += 1
+
+    return {
+        "target_Paulis_exhausted": 16,
+        "three_qubit_Paulis_exhausted": len(test_rows),
+        "Hadamard_conjugation_tests": hadamard_tests,
+        "controlled_Pauli_primitive_tests": primitive_tests,
+        "Pauli_pair_sandwich_tests": pair_tests,
+        "dense_selftest_mismatches": int(mismatches),
+        "maximum_dense_residual": maximum_residual,
+    }
+
+
+def anchor_cell(fixture: M.CompanionFixture, tag: tuple) -> Coord:
+    if tag[0] != "edge":
+        return fixture.cells[tag[1]]
+    left, right, owner, *_rest = fixture.edges[tag[1]]
+    if isinstance(owner, int):
+        anchor = fixture.cells[owner]
+    else:
+        anchor = tuple(owner)
+    endpoints = {fixture.cells[left], fixture.cells[right]}
+    if anchor not in endpoints:
+        raise ValueError(f"edge owner {owner!r} is not an endpoint for {tag!r}")
+    return anchor
+
+
+def physical_restriction(row: Pauli, q: int) -> Pauli:
+    mask = (1 << q) - 1
+    return EB.canonical(Pauli(x=row.x & mask, z=row.z & mask))
+
+
+def shifted_physical_row(row: Pauli, q: int) -> Pauli:
+    return Pauli(row.phase, row.x << q, row.z << q)
+
+
+def physical_row_for_tag(
+    fixture: M.CompanionFixture, tag: tuple
+) -> Pauli:
+    """Rebuild the tag row in the fixture's full physical representation."""
+    family = tag[0]
+    if family == "onsite_Z":
+        cell, mode = tag[1:3]
+        return Pauli(z=1 << (6 * cell + mode))
+    if family == "onsite_XX":
+        cell, left_mode = tag[1:3]
+        return Pauli(
+            x=(1 << (6 * cell + left_mode))
+            | (1 << (6 * cell + left_mode + 1))
+        )
+    if family == "edge":
+        return fixture.physical_terms(tag[1])[2]
+    raise ValueError(f"unsupported direct-basis tag {tag!r}")
+
+
+def joint_companion_row(physical: Pauli, q: int) -> Pauli:
+    """Canonical product of code and companion-bank physical rows."""
+    return EB.canonical(
+        multiply(physical, shifted_physical_row(physical, q))
+    )
+
+
+def compile_fixture(fixture: M.CompanionFixture) -> dict[str, object]:
+    graph, tags = P.direct_graph_basis(fixture)
+    targets = EB.target_rows(fixture, tags)
+    q = fixture.qubits
+    m = fixture.matter_qubits
+    row_count = len(graph)
+    words = []
+    coarse_binary_failures = 0
+    physical_tag_rebuild_failures = 0
+    phase_erasure_rows = 0
+    for index, (graph_row, target, tag) in enumerate(
+        zip(graph, targets, tags)
+    ):
+        physical = physical_restriction(graph_row, q)
+        rebuilt_physical = physical_row_for_tag(fixture, tag)
+        physical_tag_rebuild_failures += (
+            fields(physical) != fields(rebuilt_physical)
+        )
+        coarse_x = (graph_row.x >> q) & ((1 << m) - 1)
+        coarse_z = (graph_row.z >> q) & ((1 << m) - 1)
+        coarse_binary_failures += (
+            (coarse_x, coarse_z) != (target.x, target.z)
+        )
+        uncanonical = multiply(
+            physical, shifted_physical_row(rebuilt_physical, q)
+        )
+        measured = EB.canonical(uncanonical)
+        phase_erasure_rows += uncanonical.phase % 4 != measured.phase % 4
+        ancilla = 2 * q + index
+        gates: list[Gate] = [("H", ancilla)]
+        realized = Pauli()
+        for qubit in supported_qubits(measured):
+            letter = letter_at(measured, qubit)
+            gates.append(("CP", ancilla, qubit, letter))
+            realized = multiply(realized, pauli_letter(qubit, letter))
+        gates.append(("H", ancilla))
+        anchor = anchor_cell(fixture, tag)
+        physical_cells = P.pauli_cells(fixture, physical)
+        bank_cells = P.pauli_cells(fixture, rebuilt_physical)
+        semantic_support_cells = frozenset(
+            set(physical_cells) | set(bank_cells) | {anchor}
+        )
+        route = P.returned_route(anchor, semantic_support_cells)
+        forward_failures, inverse_failures = P.route_execution_failures(
+            anchor, route
+        )
+        # A zero-length onsite route touches no mobile rail.  For a nonempty
+        # route, only rail sites appearing in literal transitions are owned.
+        routed_cells: set[Coord] = set()
+        for left, right in route:
+            routed_cells.update((left, right))
+        support_cells = frozenset(
+            set(semantic_support_cells) | routed_cells
+        )
+        cell_to_index = {
+            cell: cell_index
+            for cell_index, cell in enumerate(fixture.cells)
+        }
+        rail_base = 2 * q + row_count
+        rail_indices = {
+            rail_base + cell_to_index[cell] for cell in routed_cells
+        }
+        qubit_support = frozenset(
+            set(supported_qubits(measured))
+            | {ancilla}
+            | rail_indices
+        )
+        words.append({
+            "index": index,
+            "tag": tag,
+            "target": target,
+            "graph": graph_row,
+            "physical": physical,
+            "row": measured,
+            "realized_character": realized,
+            "ancilla": ancilla,
+            "anchor": anchor,
+            "support_cells": support_cells,
+            "bank_cells": bank_cells,
+            "route": route,
+            "route_forward_failures": forward_failures,
+            "route_inverse_failures": inverse_failures,
+            "gates": tuple(gates),
+            "qubit_support": qubit_support,
+            "controlled_primitives": len(gates) - 2,
+            "rail_moves": len(route),
+        })
+    return {
+        "fixture": fixture,
+        "graph": graph,
+        "tags": tags,
+        "targets": targets,
+        "words": tuple(words),
+        "coarse_input_binary_replacement_failures": coarse_binary_failures,
+        "physical_tag_rebuild_failures": physical_tag_rebuild_failures,
+        "precanonical_phase_erasure_rows": phase_erasure_rows,
+    }
+
+
+def exhaustive_one_cell_even_rows(modes: int) -> tuple[Pauli, ...]:
+    return tuple(
+        EB.canonical(Pauli(x=x, z=z))
+        for x in range(1 << modes)
+        if not (x.bit_count() & 1)
+        for z in range(1 << modes)
+    )
+
+
+def box_certificate(
+    shape: tuple[int, int, int],
+    atlas: dict[str, object],
+) -> tuple[dict[str, object], dict[str, object]]:
+    fixture = O.arbitrary_fixture(Q.shape_cells(shape))
+    compiled = compile_fixture(fixture)
+    graph = compiled["graph"]
+    tags = compiled["tags"]
+    targets = compiled["targets"]
+    words = compiled["words"]
+    measured_rows = tuple(word["row"] for word in words)
+    encoded_graph_rows = tuple(
+        joint_companion_row(
+            physical_row_for_tag(fixture, tag), fixture.qubits
+        )
+        for tag in tags
+    )
+    corrections = tuple(
+        P.correction_from_atlas(fixture, tag, atlas) for tag in tags
+    )
+    q = fixture.qubits
+    m = fixture.matter_qubits
+    graph_width = q + m
+    compiled_width = 2 * q
+
+    target_rank = P.C.R.F.base.gf2_rank(
+        row.symplectic(m) for row in targets
+    )
+    graph_rank = P.C.R.F.base.gf2_rank(
+        row.symplectic(graph_width) for row in graph
+    )
+    compiled_rank = P.C.R.F.base.gf2_rank(
+        row.symplectic(compiled_width) for row in measured_rows
+    )
+    commutator_failures = sum(
+        M.symplectic(
+            left.symplectic(compiled_width),
+            right.symplectic(compiled_width),
+            compiled_width,
+        )
+        for index, left in enumerate(measured_rows)
+        for right in measured_rows[:index]
+    )
+    hermiticity_failures = sum(
+        row.phase % 4 != ((row.x & row.z).bit_count() & 1)
+        for row in measured_rows
+    )
+    compiled_character_binary_failures = sum(
+        (word["realized_character"].x, word["realized_character"].z)
+        != (word["row"].x, word["row"].z)
+        for word in words
+    )
+    compiled_character_phase_failures = sum(
+        fields(word["realized_character"]) != fields(word["row"])
+        for word in words
+    )
+
+    dilation_x_invariance_failures = 0
+    dilation_z_character_failures = 0
+    dilation_other_measured_row_failures = 0
+    dilation_graph_row_failures = 0
+    for index, word in enumerate(words):
+        ancilla = word["ancilla"]
+        x_ancilla = Pauli(x=1 << ancilla)
+        z_ancilla = Pauli(z=1 << ancilla)
+        actual_x = conjugate_word(x_ancilla, word["gates"])
+        actual_z = conjugate_word(z_ancilla, word["gates"])
+        expected_z_character = multiply(z_ancilla, word["row"])
+        dilation_x_invariance_failures += (
+            fields(actual_x) != fields(x_ancilla)
+        )
+        dilation_z_character_failures += (
+            fields(actual_z) != fields(expected_z_character)
+        )
+        for other_index, other in enumerate(measured_rows):
+            if other_index == index:
+                continue
+            dilation_other_measured_row_failures += (
+                fields(conjugate_word(other, word["gates"]))
+                != fields(other)
+            )
+        for graph_row in encoded_graph_rows:
+            dilation_graph_row_failures += (
+                fields(conjugate_word(graph_row, word["gates"]))
+                != fields(graph_row)
+            )
+
+    route_forward_failures = sum(
+        word["route_forward_failures"] for word in words
+    )
+    route_inverse_failures = sum(
+        word["route_inverse_failures"] for word in words
+    )
+    maximum_word_support_cells = max(
+        (len(word["support_cells"]) for word in words), default=0
+    )
+    maximum_word_support_diameter = max(
+        (
+            P.R.support_diameter(word["support_cells"])
+            for word in words
+        ),
+        default=0,
+    )
+    failing_support_rows = tuple(
+        {
+            "index": word["index"],
+            "tag": word["tag"],
+            "support_cells": tuple(sorted(word["support_cells"])),
+            "support_cell_count": len(word["support_cells"]),
+            "support_diameter": P.R.support_diameter(
+                word["support_cells"]
+            ),
+        }
+        for word in words
+        if len(word["support_cells"]) > 2
+        or P.R.support_diameter(word["support_cells"]) > 1
+    )
+
+    correction_syndrome_failures = 0
+    correction_support_failures = 0
+    correction_supports = []
+    maximum_correction_cells = 0
+    maximum_correction_diameter = 0
+    for target_index, (tag, correction) in enumerate(
+        zip(tags, corrections)
+    ):
+        support = P.pauli_cells(fixture, correction)
+        correction_supports.append(support)
+        declared = (
+            {fixture.cells[tag[1]]}
+            if tag[0] != "edge"
+            else {
+                fixture.cells[cell]
+                for cell in fixture.edges[tag[1]][:2]
+            }
+        )
+        correction_support_failures += not support <= declared
+        maximum_correction_cells = max(
+            maximum_correction_cells, len(support)
+        )
+        maximum_correction_diameter = max(
+            maximum_correction_diameter, P.R.support_diameter(support)
+        )
+        for row_index, stabilizer in enumerate(graph):
+            correction_syndrome_failures += (
+                M.symplectic(
+                    correction.symplectic(graph_width),
+                    stabilizer.symplectic(graph_width),
+                    graph_width,
+                )
+                != int(row_index == target_index)
+            )
+
+    relations = M.kernel_relations(tuple(
+        target.symplectic(m) for target in targets
+    ))
+    if len(fixture.cells) == 1:
+        branch_rows = exhaustive_one_cell_even_rows(m)
+        branch_enumeration = "exhaustive even-X Pauli basis"
+    else:
+        branch_rows = EB.deterministic_even_samples(m)
+        branch_enumeration = "deterministic_even_samples"
+    branch_replay_failures = 0
+    branch_character_entry_failures = 0
+    branch_relation_even_sum_failures = 0
+    for error in branch_rows:
+        syndrome = tuple(
+            M.symplectic(
+                error.symplectic(m), target.symplectic(m), m
+            )
+            for target in targets
+        )
+        correction = EB.pauli_product(
+            row
+            for bit, row in zip(syndrome, corrections)
+            if bit
+        )
+        replay = tuple(
+            M.symplectic(
+                correction.symplectic(graph_width),
+                graph_row.symplectic(graph_width),
+                graph_width,
+            )
+            for graph_row in graph
+        )
+        branch_replay_failures += replay != syndrome
+        branch_character_entry_failures += sum(
+            actual != expected
+            for actual, expected in zip(replay, syndrome)
+        )
+        branch_relation_even_sum_failures += sum(
+            sum(
+                syndrome[index]
+                for index in range(len(syndrome))
+                if (relation >> index) & 1
+            )
+            & 1
+            for relation in relations
+        )
+
+    deleted_index = len(corrections) // 2
+    deletion_residual = M.symplectic(
+        corrections[deleted_index].symplectic(graph_width),
+        graph[deleted_index].symplectic(graph_width),
+        graph_width,
+    )
+
+    measurement_assignment = EB.greedy_layers(tuple(
+        word["qubit_support"] for word in words
+    ))
+    correction_qubit_supports = tuple(
+        frozenset(
+            qubit
+            for qubit in range(q)
+            if ((correction.x | correction.z) >> qubit) & 1
+        )
+        for correction in corrections
+    )
+    correction_assignment = EB.greedy_layers(correction_qubit_supports)
+    measurement_layer_count = max(
+        measurement_assignment, default=-1
+    ) + 1
+    correction_layer_count = max(
+        correction_assignment, default=-1
+    ) + 1
+
+    def layer_census(
+        assignment: tuple[int, ...],
+        supports: tuple[frozenset[int], ...],
+    ) -> tuple[dict[str, int], ...]:
+        return tuple(
+            {
+                "layer": layer,
+                "vertices": sum(value == layer for value in assignment),
+                "touched_qubits": len(frozenset().union(*(
+                    support
+                    for value, support in zip(assignment, supports)
+                    if value == layer
+                ))),
+            }
+            for layer in range(max(assignment, default=-1) + 1)
+        )
+
+    measurement_supports = tuple(
+        word["qubit_support"] for word in words
+    )
+    measurement_layer_census = layer_census(
+        measurement_assignment, measurement_supports
+    )
+    correction_layer_census = layer_census(
+        correction_assignment, correction_qubit_supports
+    )
+
+    summary = {
+        "shape": shape,
+        "cells": len(fixture.cells),
+        "edges": len(fixture.edges),
+        "physical_output_M2": q,
+        "companion_encoded_live_input_M2": q,
+        "rows": len(words),
+        "target_even_algebra_rank": target_rank,
+        "expected_connected_even_algebra_rank": 2 * m - 1,
+        "expected_direct_graph_family_rank": (
+            11 * len(fixture.cells) + len(fixture.edges)
+        ),
+        "direct_graph_basis_rank": graph_rank,
+        "compiled_measured_row_rank": compiled_rank,
+        "compiled_row_commutator_failures": commutator_failures,
+        "compiled_row_hermiticity_failures": hermiticity_failures,
+        "coarse_input_binary_replacement_failures": compiled[
+            "coarse_input_binary_replacement_failures"
+        ],
+        "physical_tag_rebuild_failures": compiled[
+            "physical_tag_rebuild_failures"
+        ],
+        "precanonical_phase_erasure_rows": compiled[
+            "precanonical_phase_erasure_rows"
+        ],
+        "compiled_character_binary_failures": (
+            compiled_character_binary_failures
+        ),
+        "compiled_character_phase_failures": (
+            compiled_character_phase_failures
+        ),
+        "dilation_X_invariance_failures": (
+            dilation_x_invariance_failures
+        ),
+        "dilation_Z_character_failures": (
+            dilation_z_character_failures
+        ),
+        "dilation_other_measured_row_invariance_failures": (
+            dilation_other_measured_row_failures
+        ),
+        "dilation_graph_row_invariance_failures": (
+            dilation_graph_row_failures
+        ),
+        "Hadamard_primitives": 2 * len(words),
+        "controlled_Pauli_primitives": sum(
+            word["controlled_primitives"] for word in words
+        ),
+        "rail_move_primitives": sum(
+            word["rail_moves"] for word in words
+        ),
+        "compiled_primitive_count": sum(
+            2 + word["controlled_primitives"] + word["rail_moves"]
+            for word in words
+        ),
+        "route_transitions": sum(len(word["route"]) for word in words),
+        "route_forward_failures": route_forward_failures,
+        "route_inverse_failures": route_inverse_failures,
+        "maximum_compiled_word_support_cells": maximum_word_support_cells,
+        "maximum_compiled_word_support_diameter": (
+            maximum_word_support_diameter
+        ),
+        "failing_compiled_word_support_rows": failing_support_rows,
+        "physical_private_dual_syndrome_failures": (
+            correction_syndrome_failures
+        ),
+        "physical_private_dual_support_failures": (
+            correction_support_failures
+        ),
+        "maximum_private_dual_support_cells": (
+            maximum_correction_cells
+        ),
+        "maximum_private_dual_support_diameter": (
+            maximum_correction_diameter
+        ),
+        "measurement_conflict_layers": measurement_layer_count,
+        "measurement_layer_census": measurement_layer_census,
+        "physical_correction_conflict_layers": correction_layer_count,
+        "physical_correction_layer_census": correction_layer_census,
+        "branch_enumeration": branch_enumeration,
+        "lawful_even_characters_tested": len(branch_rows),
+        "branch_private_dual_replay_failures": branch_replay_failures,
+        "branch_character_entry_failures": (
+            branch_character_entry_failures
+        ),
+        "target_relation_rows": len(relations),
+        "branch_target_relation_even_sum_failures": (
+            branch_relation_even_sum_failures
+        ),
+        "delete_matching_private_dual_index": deleted_index,
+        "delete_matching_private_dual_sign_residual": deletion_residual,
+    }
+    compiled.update({
+        "corrections": corrections,
+        "measurement_assignment": measurement_assignment,
+        "correction_assignment": correction_assignment,
+        "summary": summary,
+    })
+    return summary, compiled
+
+
+def layer_count_vector(
+    compiled: dict[str, object], atlas: dict[str, object]
+) -> tuple[int, int]:
+    fixture = compiled["fixture"]
+    words = compiled["words"]
+    tags = compiled["tags"]
+    measurement_assignment = EB.greedy_layers(tuple(
+        word["qubit_support"] for word in words
+    ))
+    corrections = tuple(
+        P.correction_from_atlas(fixture, tag, atlas) for tag in tags
+    )
+    correction_assignment = EB.greedy_layers(tuple(
+        frozenset(
+            qubit
+            for qubit in range(fixture.qubits)
+            if ((row.x | row.z) >> qubit) & 1
+        )
+        for row in corrections
+    ))
+    return (
+        max(measurement_assignment, default=-1) + 1,
+        max(correction_assignment, default=-1) + 1,
+    )
+
+
+def transformed_companion_row(
+    word: dict[str, object],
+    images: tuple[Pauli, ...],
+    q: int,
+) -> Pauli:
+    """Transport the code physical row, then rebuild its covariant mirror."""
+    transported_physical = V.transform_row(word["physical"], images)
+    mask = (1 << q) - 1
+    transported_physical = Pauli(
+        transported_physical.phase,
+        transported_physical.x & mask,
+        transported_physical.z & mask,
+    )
+    return joint_companion_row(transported_physical, q)
+
+
+def reversed_edge_physical_row(
+    fixture: M.CompanionFixture, edge_index: int
+) -> tuple[Pauli, Coord]:
+    """Ask fixture machinery for the explicitly endpoint-reversed edge row."""
+    left, right, _owner, axis, left_mode, right_mode = (
+        fixture.edges[edge_index]
+    )
+    reversed_record = (
+        right,
+        left,
+        fixture.cells[right],
+        axis,
+        right_mode,
+        left_mode,
+    )
+    reversed_fixture = copy(fixture)
+    reversed_edges = list(fixture.edges)
+    reversed_edges[edge_index] = reversed_record
+    object.__setattr__(reversed_fixture, "edges", tuple(reversed_edges))
+    return (
+        reversed_fixture.physical_terms(edge_index)[2],
+        fixture.cells[right],
+    )
+
+
+def word_census_vector(word: dict[str, object]) -> tuple[int, int, int, int]:
+    support = word["support_cells"]
+    return (
+        len(support),
+        P.R.support_diameter(support),
+        2 + word["controlled_primitives"] + word["rail_moves"],
+        len(word["route"]),
+    )
+
+
+def transported_row_census_vector(
+    fixture: M.CompanionFixture,
+    row: Pauli,
+    anchor: Coord,
+) -> tuple[int, int, int, int]:
+    q = fixture.qubits
+    physical = physical_restriction(row, q)
+    semantic_support = frozenset(
+        set(P.pauli_cells(fixture, physical)) | {anchor}
+    )
+    route = P.returned_route(anchor, semantic_support)
+    routed_cells = {
+        cell for transition in route for cell in transition
+    }
+    support = frozenset(set(semantic_support) | routed_cells)
+    return (
+        len(support),
+        P.R.support_diameter(support),
+        2 + len(supported_qubits(row)) + len(route),
+        len(route),
+    )
+
+
+def family_census_vectors(
+    words: tuple[dict[str, object], ...],
+) -> dict[str, tuple[tuple[int, int, int, int], ...]]:
+    families = ("onsite_Z", "onsite_XX", "edge")
+    return {
+        family: tuple(sorted(
+            word_census_vector(word)
+            for word in words
+            if word["tag"][0] == family
+        ))
+        for family in families
+    }
+
+
+def compressed_family_census(
+    vectors: dict[str, tuple[tuple[int, int, int, int], ...]]
+) -> dict[str, tuple[dict[str, object], ...]]:
+    return {
+        family: tuple(
+            {"vector": vector, "rows": rows}
+            for vector, rows in sorted(Counter(family_rows).items())
+        )
+        for family, family_rows in vectors.items()
+    }
+
+
+def compiled_schedule_transport_certificate(
+    source_by_shape: dict[tuple[int, int, int], dict[str, object]],
+    atlas: dict[str, object],
+) -> dict[str, object]:
+    frames = V.T.proper_cubic_frames()
+    shifts = tuple(product((0, 1), repeat=3))
+    families = ("onsite_Z", "onsite_XX", "edge")
+    shape_reports = []
+    total_signed_failures = Counter({family: 0 for family in families})
+    total_binary_failures = Counter({family: 0 for family in families})
+    total_edge_signed_class_failures = 0
+    total_edge_binary_class_failures = 0
+    total_edge_forward_classes = 0
+    total_edge_reversed_classes = 0
+    total_census_failures = Counter({family: 0 for family in families})
+    for shape in ((2, 2, 2), (3, 2, 2)):
+        source_compiled = source_by_shape[shape]
+        source = source_compiled["fixture"]
+        source_words = source_compiled["words"]
+        source_census = family_census_vectors(source_words)
+        signed_failures = Counter({family: 0 for family in families})
+        binary_failures = Counter({family: 0 for family in families})
+        edge_signed_class_failures = 0
+        edge_binary_class_failures = 0
+        edge_forward_classes = 0
+        edge_reversed_classes = 0
+        census_failures = Counter({family: 0 for family in families})
+        for frame in frames:
+            for shift in shifts:
+                # This is the recurrent runner's literal affine rebuild:
+                # transform the complete ordered cell tuple, then rebuild one
+                # global fixture.  No covering fixture is concatenated.
+                transformed_cells = Q.affine_cells(
+                    source.cells, frame, shift
+                )
+                target = O.arbitrary_fixture(transformed_cells)
+                target_compiled = compile_fixture(target)
+                target_seed = Q.transported_seed(
+                    frame, shift, (0, 0, 0)
+                )
+                images = V.choi_images(
+                    source, target, frame, shift, target_seed
+                )
+                literal_transported_rows = tuple(
+                    transformed_companion_row(
+                        word, images, source.qubits
+                    )
+                    for word in source_words
+                )
+                target_words = target_compiled["words"]
+                transported_anchors = tuple(
+                    V.affine_cell(word["anchor"], frame, shift)
+                    for word in source_words
+                )
+                target_word_by_tag = {
+                    word["tag"]: word for word in target_words
+                }
+                target_cell_index = {
+                    cell: index
+                    for index, cell in enumerate(target.cells)
+                }
+                # Onsite adjacent-XX generators are a local chart basis:
+                # transport the family and anchor, then rebuild the complete
+                # canonical family at that target cell.  Individual path
+                # generators are deliberately not required to be frame
+                # equivariant.  Edge rows retain their literal tableau image
+                # because their two fixture-derived orientation classes are
+                # audited explicitly below.
+                comparison_rows = tuple(
+                    (
+                        target_word_by_tag[(
+                            word["tag"][0],
+                            target_cell_index[mapped_anchor],
+                            word["tag"][2],
+                        )]["row"]
+                        if word["tag"][0] != "edge"
+                        else transported_row
+                    )
+                    for transported_row, mapped_anchor, word in zip(
+                        literal_transported_rows,
+                        transported_anchors,
+                        source_words,
+                    )
+                )
+
+                for family in ("onsite_Z", "onsite_XX"):
+                    transported_signed = Counter(
+                        (fields(row), anchor)
+                        for row, anchor, word in zip(
+                            comparison_rows,
+                            transported_anchors,
+                            source_words,
+                        )
+                        if word["tag"][0] == family
+                    )
+                    rebuilt_signed = Counter(
+                        (fields(word["row"]), word["anchor"])
+                        for word in target_words
+                        if word["tag"][0] == family
+                    )
+                    signed_failures[family] += (
+                        transported_signed != rebuilt_signed
+                    )
+                    transported_binary = Counter(
+                        ((row.x, row.z), anchor)
+                        for row, anchor, word in zip(
+                            comparison_rows,
+                            transported_anchors,
+                            source_words,
+                        )
+                        if word["tag"][0] == family
+                    )
+                    rebuilt_binary = Counter(
+                        ((word["row"].x, word["row"].z), word["anchor"])
+                        for word in target_words
+                        if word["tag"][0] == family
+                    )
+                    binary_failures[family] += (
+                        transported_binary != rebuilt_binary
+                    )
+
+                target_edge_words = {
+                    word["tag"][1]: word
+                    for word in target_words
+                    if word["tag"][0] == "edge"
+                }
+                target_edge_by_endpoints = {
+                    frozenset((
+                        target.cells[edge[0]],
+                        target.cells[edge[1]],
+                    )): edge_index
+                    for edge_index, edge in enumerate(target.edges)
+                }
+                mapped_edge_indices = Counter()
+                context_edge_signed_failures = 0
+                context_edge_binary_failures = 0
+                for row, mapped_anchor, word in zip(
+                    literal_transported_rows,
+                    transported_anchors,
+                    source_words,
+                ):
+                    if word["tag"][0] != "edge":
+                        continue
+                    source_edge = source.edges[word["tag"][1]]
+                    mapped_endpoints = frozenset((
+                        V.affine_cell(
+                            source.cells[source_edge[0]], frame, shift
+                        ),
+                        V.affine_cell(
+                            source.cells[source_edge[1]], frame, shift
+                        ),
+                    ))
+                    target_edge_index = target_edge_by_endpoints.get(
+                        mapped_endpoints
+                    )
+                    if target_edge_index is None:
+                        context_edge_signed_failures += 1
+                        context_edge_binary_failures += 1
+                        continue
+                    mapped_edge_indices[target_edge_index] += 1
+                    forward_word = target_edge_words[target_edge_index]
+                    reversed_physical, reversed_anchor = (
+                        reversed_edge_physical_row(
+                            target, target_edge_index
+                        )
+                    )
+                    reversed_row = joint_companion_row(
+                        reversed_physical, target.qubits
+                    )
+                    actual_signed = (fields(row), mapped_anchor)
+                    forward_signed = (
+                        fields(forward_word["row"]),
+                        forward_word["anchor"],
+                    )
+                    reversed_signed = (
+                        fields(reversed_row),
+                        reversed_anchor,
+                    )
+                    if actual_signed == forward_signed:
+                        edge_forward_classes += 1
+                    elif actual_signed == reversed_signed:
+                        edge_reversed_classes += 1
+                    else:
+                        context_edge_signed_failures += 1
+                    actual_binary = ((row.x, row.z), mapped_anchor)
+                    forward_binary = (
+                        (forward_word["row"].x, forward_word["row"].z),
+                        forward_word["anchor"],
+                    )
+                    reversed_binary = (
+                        (reversed_row.x, reversed_row.z),
+                        reversed_anchor,
+                    )
+                    if actual_binary not in (
+                        forward_binary,
+                        reversed_binary,
+                    ):
+                        context_edge_binary_failures += 1
+                expected_edge_indices = Counter(target_edge_words.keys())
+                edge_bijection_failure = (
+                    mapped_edge_indices != expected_edge_indices
+                )
+                signed_failures["edge"] += bool(
+                    context_edge_signed_failures
+                    or edge_bijection_failure
+                )
+                binary_failures["edge"] += bool(
+                    context_edge_binary_failures
+                    or edge_bijection_failure
+                )
+                edge_signed_class_failures += (
+                    context_edge_signed_failures
+                )
+                edge_binary_class_failures += (
+                    context_edge_binary_failures
+                )
+
+                transported_census = {
+                    family: tuple(sorted(
+                        transported_row_census_vector(
+                            target, row, anchor
+                        )
+                        for row, anchor, word in zip(
+                            comparison_rows,
+                            transported_anchors,
+                            source_words,
+                        )
+                        if word["tag"][0] == family
+                    ))
+                    for family in families
+                }
+                rebuilt_census = family_census_vectors(target_words)
+                for family in families:
+                    census_failures[family] += (
+                        rebuilt_census[family]
+                        != transported_census[family]
+                    )
+        contexts = len(frames) * len(shifts)
+        shape_report = {
+            "shape": shape,
+            "proper_cubic_frames": len(frames),
+            "translation_parities": len(shifts),
+            "contexts": contexts,
+            "family_signed_multiset_failures": dict(
+                signed_failures
+            ),
+            "family_binary_multiset_failures": dict(
+                binary_failures
+            ),
+            "edge_orientation_signed_class_failures": (
+                edge_signed_class_failures
+            ),
+            "edge_orientation_binary_class_failures": (
+                edge_binary_class_failures
+            ),
+            "edge_forward_orientation_classes": edge_forward_classes,
+            "edge_reversed_orientation_classes": edge_reversed_classes,
+            "family_census_vector_invariance_failures": dict(
+                census_failures
+            ),
+            "source_family_census_vectors": compressed_family_census(
+                source_census
+            ),
+        }
+        shape_reports.append(shape_report)
+        total_signed_failures.update(signed_failures)
+        total_binary_failures.update(binary_failures)
+        total_edge_signed_class_failures += (
+            edge_signed_class_failures
+        )
+        total_edge_binary_class_failures += (
+            edge_binary_class_failures
+        )
+        total_edge_forward_classes += edge_forward_classes
+        total_edge_reversed_classes += edge_reversed_classes
+        total_census_failures.update(census_failures)
+    return {
+        "shapes": tuple(shape_reports),
+        "proper_cubic_frames": len(frames),
+        "translation_parities": len(shifts),
+        "contexts": sum(row["contexts"] for row in shape_reports),
+        "family_signed_multiset_failures": dict(
+            total_signed_failures
+        ),
+        "family_binary_multiset_failures": dict(
+            total_binary_failures
+        ),
+        "edge_orientation_signed_class_failures": (
+            total_edge_signed_class_failures
+        ),
+        "edge_orientation_binary_class_failures": (
+            total_edge_binary_class_failures
+        ),
+        "edge_forward_orientation_classes": (
+            total_edge_forward_classes
+        ),
+        "edge_reversed_orientation_classes": (
+            total_edge_reversed_classes
+        ),
+        "family_census_vector_invariance_failures": dict(
+            total_census_failures
+        ),
+    }
+
+
+def fixture_preservation_certificate(
+    atlas: dict[str, object],
+    baseline_exact: tuple[dict[str, object], ...],
+    baseline_box: dict[str, object],
+) -> tuple[tuple[dict[str, object], ...], dict[str, object]]:
+    exact = tuple(
+        EB.abstract_teleportation_certificate(modes)
+        for modes in (2, 3)
+    )
+    rerun_box = EB.box_certificate((2, 2, 2), atlas)
+    exact_keys = (
+        "Bell_outcomes",
+        "expected_outcomes",
+        "Bell_basis_orthonormality_residual",
+        "corrected_branch_identity_residual",
+        "Kraus_completeness_residual",
+        "generator_rank",
+        "expected_even_rank",
+    )
+    critical_box_keys = tuple(
+        key
+        for key in baseline_box
+        if key.endswith("failures")
+        or key in (
+            "target_even_algebra_rank",
+            "expected_connected_even_algebra_rank",
+            "doubled_Bell_row_rank",
+            "maximum_private_dual_support_cells",
+            "maximum_private_dual_support_diameter",
+        )
+    )
+    exact_change_failures = sum(
+        before[key] != after[key]
+        for before, after in zip(baseline_exact, exact)
+        for key in exact_keys
+    )
+    box_change_failures = sum(
+        baseline_box[key] != rerun_box[key]
+        for key in critical_box_keys
+    )
+    residual_maximum = max(
+        row[key]
+        for row in exact
+        for key in (
+            "Bell_basis_orthonormality_residual",
+            "corrected_branch_identity_residual",
+            "Kraus_completeness_residual",
+        )
+    )
+    return exact, {
+        "exact_certificate_change_failures": exact_change_failures,
+        "critical_box_field_change_failures": box_change_failures,
+        "critical_box_fields_compared": critical_box_keys,
+        "maximum_exact_CPTP_residual": residual_maximum,
+        "all_three_residuals_below_1e-12": all(
+            row[key] < TOL
+            for row in exact
+            for key in (
+                "Bell_basis_orthonormality_residual",
+                "corrected_branch_identity_residual",
+                "Kraus_completeness_residual",
+            )
+        ),
+    }
+
+
+def controls_certificate(
+    compiled_by_shape: dict[tuple[int, int, int], dict[str, object]]
+) -> dict[str, object]:
+    deletion_residuals = {
+        str(shape): compiled["summary"][
+            "delete_matching_private_dual_sign_residual"
+        ]
+        for shape, compiled in compiled_by_shape.items()
+    }
+
+    route_word = next(
+        (
+            word
+            for compiled in compiled_by_shape.values()
+            for word in compiled["words"]
+            if word["route"]
+        ),
+        None,
+    )
+    if route_word is None:
+        deleted_final_route_failures = (0, 0)
+        deleted_first_route_failures = (0, 0)
+    else:
+        deleted_final_route_failures = P.route_execution_failures(
+            route_word["anchor"], route_word["route"][:-1]
+        )
+        deleted_first_route_failures = P.route_execution_failures(
+            route_word["anchor"], route_word["route"][1:]
+        )
+
+    hostile_pair = None
+    for compiled in compiled_by_shape.values():
+        assignments = compiled["measurement_assignment"]
+        for right in range(len(assignments)):
+            for left in range(right):
+                if assignments[left] == assignments[right]:
+                    hostile_pair = (
+                        compiled["words"][left],
+                        compiled["words"][right],
+                    )
+                    break
+            if hostile_pair is not None:
+                break
+        if hostile_pair is not None:
+            break
+    hostile_dilation_failures = 0
+    hostile_indices = None
+    if hostile_pair is not None:
+        left, right = hostile_pair
+        wrong_ancilla = right["ancilla"]
+        corrupted_gates = tuple(
+            (
+                ("H", wrong_ancilla)
+                if gate[0] == "H"
+                else (
+                    "CP",
+                    wrong_ancilla,
+                    gate[2],
+                    gate[3],
+                )
+            )
+            for gate in left["gates"]
+        )
+        x_left = Pauli(x=1 << left["ancilla"])
+        expected = multiply(x_left, left["row"])
+        actual = conjugate_word(x_left, corrupted_gates)
+        hostile_dilation_failures = (
+            fields(actual) != fields(expected)
+        )
+        hostile_indices = (left["index"], right["index"])
+
+    base = compiled_by_shape[(1, 1, 1)]
+    fixture = base["fixture"]
+    q = fixture.qubits
+    m = fixture.matter_qubits
+    width = 2 * q
+    odd = Pauli(x=1 << q)
+    bank_parity = Pauli(z=((1 << m) - 1) << q)
+    odd_parity_symplectic = M.symplectic(
+        odd.symplectic(width), bank_parity.symplectic(width), width
+    )
+    base_rank = P.C.R.F.base.gf2_rank(
+        word["row"].symplectic(width) for word in base["words"]
+    )
+    augmented_rank = P.C.R.F.base.gf2_rank(
+        tuple(
+            word["row"].symplectic(width)
+            for word in base["words"]
+        )
+        + (odd.symplectic(width),)
+    )
+    odd_detection_failures = (
+        odd_parity_symplectic != 1
+    ) + (augmented_rank != base_rank + 1)
+    return {
+        "delete_private_dual_sign_residuals": deletion_residuals,
+        "delete_private_dual_detection_failures": sum(
+            residual != 1 for residual in deletion_residuals.values()
+        ),
+        "deleted_final_route_link_failures": (
+            deleted_final_route_failures
+        ),
+        "deleted_first_route_link_failures": (
+            deleted_first_route_failures
+        ),
+        "hostile_same_layer_word_indices": hostile_indices,
+        "hostile_ancilla_swap_dilation_identity_failures": (
+            hostile_dilation_failures
+        ),
+        "odd_bank_character_parity_symplectic": (
+            odd_parity_symplectic
+        ),
+        "doubled_row_span_rank": base_rank,
+        "odd_augmented_span_rank": augmented_rank,
+        "unlawful_odd_input_detection_failures": (
+            int(odd_detection_failures)
+        ),
+    }
+
+
+def main() -> None:
+    started = perf_counter()
+    atlas = P.build_private_atlases()
+    baseline_exact = tuple(
+        EB.abstract_teleportation_certificate(modes)
+        for modes in (2, 3)
+    )
+    baseline_box = EB.box_certificate((2, 2, 2), atlas)
+
+    shapes = (
+        (1, 1, 1),
+        (2, 2, 2),
+        (3, 2, 2),
+        (5, 3, 2),
+        (4, 4, 4),
+        (5, 5, 3),
+    )
+    box_pairs = tuple(
+        box_certificate(shape, atlas) for shape in shapes
+    )
+    boxes = tuple(pair[0] for pair in box_pairs)
+    compiled_by_shape = {
+        shape: pair[1] for shape, pair in zip(shapes, box_pairs)
+    }
+
+    dense_selftest = dense_selftest_certificate()
+    exact, preservation = fixture_preservation_certificate(
+        atlas, baseline_exact, baseline_box
+    )
+    covariance = V.frame_certificate((2, 2, 2), atlas)
+    frame_products = V.product_certificate(atlas)
+    transport = compiled_schedule_transport_certificate(
+        compiled_by_shape, atlas
+    )
+    controls = controls_certificate(compiled_by_shape)
+
+    row_family_gate = all(
+        box["target_even_algebra_rank"]
+        == box["expected_connected_even_algebra_rank"]
+        and box["compiled_measured_row_rank"]
+        == box["direct_graph_basis_rank"]
+        and box["direct_graph_basis_rank"]
+        == box["expected_direct_graph_family_rank"]
+        and box["expected_direct_graph_family_rank"] == box["rows"]
+        and box["compiled_row_commutator_failures"] == 0
+        and box["compiled_row_hermiticity_failures"] == 0
+        and box["coarse_input_binary_replacement_failures"] == 0
+        and box["physical_tag_rebuild_failures"] == 0
+        and box["compiled_character_binary_failures"] == 0
+        for box in boxes
+    )
+    dilation_gate = all(
+        box["compiled_character_phase_failures"] == 0
+        and box["dilation_X_invariance_failures"] == 0
+        and box["dilation_Z_character_failures"] == 0
+        and (
+            box[
+                "dilation_other_measured_row_invariance_failures"
+            ]
+            == 0
+        )
+        and box["dilation_graph_row_invariance_failures"] == 0
+        for box in boxes
+    )
+    branch_gate = all(
+        box["physical_private_dual_syndrome_failures"] == 0
+        and box["branch_private_dual_replay_failures"] == 0
+        and box["branch_character_entry_failures"] == 0
+        and box["branch_target_relation_even_sum_failures"] == 0
+        and box["delete_matching_private_dual_sign_residual"] == 1
+        for box in boxes
+    )
+    support_gate = all(
+        box["route_forward_failures"] == 0
+        and box["route_inverse_failures"] == 0
+        and box["maximum_compiled_word_support_cells"] <= 2
+        and box["maximum_compiled_word_support_diameter"] <= 1
+        and box["physical_private_dual_support_failures"] == 0
+        and box["maximum_private_dual_support_cells"] <= 2
+        and box["maximum_private_dual_support_diameter"] <= 1
+        for box in boxes
+    )
+    def maximum_cell_degree(shape: tuple[int, int, int]) -> int:
+        # A cell's degree is bounded per axis: 2 interior neighbours when the
+        # dimension admits an interior coordinate, 1 when the dimension is 2,
+        # 0 when it is 1. The maximum over cells attains this bound.
+        return sum(2 if dim >= 3 else (1 if dim == 2 else 0) for dim in shape)
+
+    layer_law = tuple(
+        {
+            "shape": list(shape),
+            "maximum_cell_degree": maximum_cell_degree(shape),
+            "expected_measurement_layers_3_plus_degree": (
+                3 + maximum_cell_degree(shape)
+            ),
+            "measurement_conflict_layers": box["measurement_conflict_layers"],
+            "physical_correction_conflict_layers": (
+                box["physical_correction_conflict_layers"]
+            ),
+        }
+        for shape, box in zip(shapes, boxes)
+    )
+    # Compiled measurement coloring is three onsite layers (the Z/XX path
+    # graph) plus exactly one seam layer per unit of maximum cell degree:
+    # greedy first-fit attains the Koenig edge-coloring bound of the bipartite
+    # box graph in the emitted edge order. Correction coloring saturates once
+    # the one-cell dual family is dense enough (from 3x2x2 on). Constancy
+    # across arbitrary boxes is NOT the covariant statement; the local
+    # incidence profile is.
+    layer_gate = (
+        all(
+            entry["measurement_conflict_layers"]
+            == entry["expected_measurement_layers_3_plus_degree"]
+            for entry in layer_law
+        )
+        and max(box["measurement_conflict_layers"] for box in boxes) <= 12
+        and max(
+            box["physical_correction_conflict_layers"] for box in boxes
+        )
+        <= 24
+        and len({
+            box["physical_correction_conflict_layers"]
+            for box in boxes[2:]
+        })
+        == 1
+    )
+    preservation_gate = (
+        preservation["exact_certificate_change_failures"] == 0
+        and preservation["critical_box_field_change_failures"] == 0
+        and preservation["all_three_residuals_below_1e-12"]
+    )
+    covariance_failure_keys = (
+        "signed_projector_failures",
+        "private_correction_syndrome_failures",
+        "private_correction_support_failures",
+        "route_locality_support_or_return_failures",
+        "atlas_key_inverse_transport_failures",
+        "schedule_key_inverse_transport_failures",
+        "Bell_reference_conjugate_chart_failures",
+        "syndrome_register_bijection_failures",
+        "oriented_factor_2_or_3_edge_row_failures",
+    )
+    covariance_gate = (
+        covariance["proper_cubic_frames"] == 24
+        and all(
+            covariance[key] == 0 for key in covariance_failure_keys
+        )
+        and frame_products["ordered_frame_products"] == 576
+        and all(
+            value == 0
+            for key, value in frame_products.items()
+            if key.endswith("failures")
+        )
+    )
+    transport_gate = (
+        transport["proper_cubic_frames"] == 24
+        and transport["translation_parities"] == 8
+        and transport["contexts"] == 24 * 8 * 2
+        and all(
+            value == 0
+            for value in transport[
+                "family_signed_multiset_failures"
+            ].values()
+        )
+        and all(
+            value == 0
+            for value in transport[
+                "family_binary_multiset_failures"
+            ].values()
+        )
+        and transport["edge_orientation_signed_class_failures"] == 0
+        and transport["edge_orientation_binary_class_failures"] == 0
+        and all(
+            value == 0
+            for value in transport[
+                "family_census_vector_invariance_failures"
+            ].values()
+        )
+    )
+    controls_gate = (
+        controls["delete_private_dual_detection_failures"] == 0
+        and controls["deleted_final_route_link_failures"][0] > 0
+        and any(controls["deleted_first_route_link_failures"])
+        and (
+            controls[
+                "hostile_ancilla_swap_dilation_identity_failures"
+            ]
+            > 0
+        )
+        and controls["unlawful_odd_input_detection_failures"] == 0
+    )
+
+    checks: list[dict[str, object]] = []
+
+    def check(label: str, condition: bool) -> None:
+        checks.append({"label": label, "pass": bool(condition)})
+        print("PASS" if condition else "FAIL", label)
+
+    check(
+        "exhaustive dense 8x8 Clifford conjugation self-test has zero mismatches",
+        dense_selftest["dense_selftest_mismatches"] == 0,
+    )
+    check(
+        "every direct-basis row on the five-box ladder compiles to an abelian Hermitian live-bank character with unchanged rank",
+        row_family_gate,
+    )
+    check(
+        "literal H-controlled-Pauli-H words fix retained X, transport retained Z to Z times R_i, and leave all other measured and graph rows invariant",
+        dilation_gate,
+    )
+    check(
+        "one-hot duality, kernel even sums, deletion signs, exhaustive one-cell branches, and deterministic held-box samples replay exactly",
+        branch_gate,
+    )
+    check(
+        "every compiled word and frozen private dual obeys the two-cell diameter-one gate with returned routes",
+        support_gate,
+    )
+    check(
+        "measurement coloring equals three onsite layers plus one seam layer per maximum cell degree; correction coloring is constant from 3x2x2 (ceilings 12 and 24)",
+        layer_gate,
+    )
+    check(
+        "post-compilation two- and three-mode CPTP residuals and Cycle-720 critical fixture fields are unchanged",
+        preservation_gate,
+    )
+    check(
+        "reused 24-frame and 576-product covariance surfaces retain zero named failures",
+        covariance_gate,
+    )
+    check(
+        "compiled row families and census vectors transport over 24 frames by 8 translation parities with only fixture-derived edge orientation classes",
+        transport_gate,
+    )
+    check(
+        "private-dual deletion, deleting the final return link breaks the forward returned-route walk, first-link deletion, hostile ancilla pairing, and odd-row controls are detected",
+        controls_gate,
+    )
+
+    input_compiled = (
+        row_family_gate
+        and dilation_gate
+        and support_gate
+        and layer_gate
+        and covariance_gate
+        and transport_gate
+        and controls_gate
+        and dense_selftest["dense_selftest_mismatches"] == 0
+    )
+    runtime_seconds = perf_counter() - started
+    report = {
+        "status": (
+            "PASS" if all(row["pass"] for row in checks) else "FAIL"
+        ),
+        "checks": checks,
+        "boxes": boxes,
+        "layer_counts": {
+            "measurement_by_box": tuple(
+                box["measurement_conflict_layers"] for box in boxes
+            ),
+            "correction_by_box": tuple(
+                box["physical_correction_conflict_layers"]
+                for box in boxes
+            ),
+            "layer_law": layer_law,
+            "law_statement": (
+                "measurement conflict layers = 3 onsite layers (Z/XX path "
+                "coloring) + 1 seam layer per unit of maximum cell degree "
+                "(greedy first-fit attains the Koenig edge-coloring bound "
+                "of the bipartite box graph in the emitted edge order); "
+                "correction layers saturate at their one-cell constant "
+                "from 3x2x2 on"
+            ),
+            "correction_constant_from_3x2x2": len({
+                box["physical_correction_conflict_layers"]
+                for box in boxes[2:]
+            }) == 1,
+        },
+        "dense_selftest": dense_selftest,
+        "exact_CPTP_controls": exact,
+        "covariance": covariance,
+        "frame_products": frame_products,
+        "compiled_schedule_transport": transport,
+        "controls": controls,
+        "fixture_preservation": preservation,
+        "runtime_seconds": runtime_seconds,
+        "derived": (
+            "literal instruction data, exact integer-Pauli conjugation, "
+            "companion-bank joint-rank and abelian censuses, returned-route/"
+            "support census, private-dual branch replay, conflict coloring, "
+            "and covariant signed/binary family-multiset diagnostics"
+        ),
+        "supplied": (
+            "fixed parity/center sector; one-time Choi genesis inventory; "
+            "mixed gauge reference; clean retained syndrome and mobile-rail "
+            "banks; frozen private-dual atlas; finite boxes; the live input "
+            "is presented in the code's own companion representation "
+            "(companion-encoded input bank); a bare global-JW input register "
+            "is not used"
+        ),
+        "open": (
+            "autonomous sector/genesis law; collision-free joint epoch with "
+            "pump and recurrent G; downstream time/source/Record/Born "
+            "acceptance; any failed literal dilation, layer-constancy, or "
+            "transport gate reported by this companion-encoded-bank run"
+        ),
+        "claim_boundary": (
+            "instruction-level companion-encoded input-bank compilation on "
+            "the declared site map with supplied sector/genesis inventory; "
+            "the collision-free joint epoch with pump + recurrent G is not "
+            "claimed here; ordinals are circuit structure, not time; "
+            "state-level coupling only, with no matter/FTL/mass/charge "
+            "transfer"
+        ),
+        "input_Bell_measurement_physical_M2_compiled": input_compiled,
+        "authority": "none",
+        "audit": "unset",
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if report["status"] != "PASS":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/frontier_cycle721_collision_free_epoch_composition_2026_07_28.py
+++ b/scripts/frontier_cycle721_collision_free_epoch_composition_2026_07_28.py
@@ -1,0 +1,1879 @@
+#!/usr/bin/env python3
+"""Cycle-721 collision-free composition of one supplied finite epoch.
+
+The runner composes the Cycle-720 tree/plaquette Choi pump, either the F1
+compiled Bell-measurement leg or the F2 direct port leg, the retained Bell
+correction bank when present, and the unchanged routed recurrent word.  Its
+resource proof is a literal slot walk.  Static support disjointness is never
+used as a substitute for the clean/live/retained state machine.
+"""
+
+from __future__ import annotations
+
+AUDIT_TIMEOUT_SEC = 900
+NOTE_PATH = (
+    "docs/CAR_BELL_INPUT_PHYSICAL_M2_COMPILER_CYCLE721_BOUNDED_THEOREM_"
+    "NOTE_2026-07-28.md"
+)
+AUDIT_INPUT_PATHS = (
+    "scripts/frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.py",
+    "scripts/frontier_cycle721_encoded_input_clifford_port_2026_07_28.py",
+    "scripts/frontier_cycle720_companion_subsystem_m2_update_2026_07_27.py",
+    "scripts/frontier_cycle720_companion_recurrent_overlap_update_2026_07_27.py",
+    "scripts/frontier_cycle720_companion_local_choi_tree_plaquette_pump_2026_07_27.py",
+    "scripts/frontier_cycle720_companion_checkerboard_frame_cocycle_2026_07_27.py",
+    "scripts/frontier_cycle720_overlap_star_mixed_gauge_choi_2026_07_27.py",
+    "scripts/frontier_cycle720_cell_majorana_companion_geometry_2026_07_27.py",
+    "docs/CAR_BELL_INPUT_PHYSICAL_M2_COMPILER_CYCLE721_BOUNDED_THEOREM_NOTE_2026-07-28.md",
+)
+DECLARED_INPUT_PATHS = AUDIT_INPUT_PATHS
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from hashlib import sha256
+from itertools import product
+import json
+from time import perf_counter
+from typing import Iterable
+
+import numpy as np
+
+import frontier_cycle721_car_bell_input_m2_compiler_2026_07_28 as EBM
+import frontier_cycle721_encoded_input_clifford_port_2026_07_28 as PORT
+import frontier_cycle720_companion_subsystem_m2_update_2026_07_27 as U
+import frontier_cycle720_companion_recurrent_overlap_update_2026_07_27 as R
+
+
+P = EBM.P
+Q = EBM.Q
+O = EBM.O
+M = EBM.M
+Pauli = EBM.Pauli
+Coord = tuple[int, int, int]
+TOL = 4.0e-10
+AXIS_ORDER = (2, 1, 0)
+
+
+@dataclass
+class WordUse:
+    word_id: str
+    stage: str
+    family: str
+    accesses: dict[int, tuple[str, str]]
+    retain_after: set[int] = field(default_factory=set)
+
+
+@dataclass
+class Slot:
+    stage: str
+    words: list[WordUse]
+
+
+@dataclass
+class Namespace:
+    q: int
+    matter: int
+    cells: int
+    ranges: dict[str, tuple[int, int]]
+    g_site_to_register: dict[Coord, int]
+    placed_site_to_qubit: dict[Coord, int]
+    g_auxiliary_offset: int
+    instruction_schema: dict[str, object]
+
+
+@dataclass
+class EpochBundle:
+    shape: tuple[int, int, int]
+    variant: str
+    fixture: object
+    root: Coord
+    axis_order: tuple[int, int, int]
+    port: int
+    namespace: Namespace
+    slots: list[Slot]
+    handoffs: set[tuple[str, str, int]]
+    routes: dict[str, tuple[Coord, tuple[tuple[Coord, Coord], ...]]]
+    stage_gates: dict[str, tuple[PORT.Gate, ...]]
+    pump_rows: tuple[Pauli, ...]
+    pump_tags: tuple[tuple, ...]
+    pump_corrections: tuple[Pauli, ...]
+    compiled: dict[str, object]
+    recurrent: dict[str, object]
+
+
+def supported(row: Pauli | PORT.Row) -> tuple[int, ...]:
+    mask = row.x | row.z
+    output = []
+    while mask:
+        bit = mask & -mask
+        output.append(bit.bit_length() - 1)
+        mask ^= bit
+    return tuple(output)
+
+
+def merge_accesses(
+    entries: Iterable[tuple[int, str, str]]
+) -> dict[int, tuple[str, str]]:
+    """Merge repeated accesses inside one word, preserving the strongest mode."""
+    rank = {"read": 0, "touch": 1, "write": 2}
+    output: dict[int, tuple[str, str]] = {}
+    for register, role, mode in entries:
+        previous = output.get(register)
+        if previous is None or rank[mode] > rank[previous[1]]:
+            output[register] = (role, mode)
+        elif previous[0] != role:
+            # A physical data register wins over an incidental route label.
+            output[register] = (
+                "data" if "data" in (previous[0], role) else previous[0],
+                previous[1],
+            )
+    return output
+
+
+def owner_anchor(fixture, edge_index: int) -> Coord:
+    left, right, owner, *_rest = fixture.edges[edge_index]
+    anchor = fixture.cells[owner] if isinstance(owner, int) else tuple(owner)
+    endpoints = {fixture.cells[left], fixture.cells[right]}
+    if anchor not in endpoints:
+        raise ValueError(f"edge owner {owner!r} is outside edge {edge_index}")
+    return anchor
+
+
+def tag_anchor(fixture, tag: tuple) -> Coord:
+    if tag[0].startswith("onsite"):
+        return fixture.cells[tag[1]]
+    if tag[0] in ("edge", "tree", "plaquette"):
+        return owner_anchor(fixture, tag[1])
+    raise ValueError(f"unsupported scheduled tag {tag!r}")
+
+
+def route_registers(
+    fixture,
+    namespace: Namespace,
+    route: tuple[tuple[Coord, Coord], ...],
+) -> set[int]:
+    cell_to_index = {
+        cell: index for index, cell in enumerate(fixture.cells)
+    }
+    base = namespace.ranges["mobile_route_rails"][0]
+    return {
+        base + cell_to_index[cell]
+        for transition in route
+        for cell in transition
+    }
+
+
+def port_row(input_row: Pauli | PORT.Row) -> PORT.Row:
+    return PORT.Row(input_row.phase % 4, input_row.x, input_row.z)
+
+
+def controlled_pauli(control: int, target: Pauli | PORT.Row) -> PORT.Gate:
+    return PORT.Gate("CP", control, pauli=port_row(target))
+
+
+def relocated_f1_gates(
+    gates: tuple,
+    old_ancilla: int,
+    new_ancilla: int,
+) -> tuple[PORT.Gate, ...]:
+    output = []
+    for gate in gates:
+        if gate[0] == "H":
+            if gate[1] != old_ancilla:
+                raise ValueError("F1 H gate does not use its declared ancilla")
+            output.append(PORT.Gate("H", new_ancilla))
+        elif gate[0] == "CP":
+            control = new_ancilla if gate[1] == old_ancilla else gate[1]
+            output.append(
+                PORT.Gate(
+                    "CP",
+                    control,
+                    pauli=port_row(EBM.pauli_letter(gate[2], gate[3])),
+                )
+            )
+        else:
+            raise ValueError(f"unknown F1 gate {gate!r}")
+    return tuple(output)
+
+
+def recurrent_objects(fixture) -> dict[str, object]:
+    """Call the Cycle-720 recurrent construction in its certified order."""
+    placed = U.placement(fixture)
+    word, update = U.physical_word(fixture, placed)
+    routed, route = U.c707.route_word(word)
+    return {
+        "placed": placed,
+        "word": word,
+        "update": update,
+        "routed": routed,
+        "route": route,
+    }
+
+
+def build_namespace(
+    fixture,
+    pump_rows: int,
+    bell_rows: int,
+    recurrent: dict[str, object],
+) -> Namespace:
+    q = fixture.qubits
+    matter = fixture.matter_qubits
+    placed_sites = tuple(recurrent["placed"]["sites_by_qubit"])
+    if len(placed_sites) != q or len(set(placed_sites)) != q:
+        raise ValueError("U.placement did not expose one unique site per code qubit")
+    placed_site_to_qubit = {
+        tuple(site): qubit for qubit, site in enumerate(placed_sites)
+    }
+
+    routed = recurrent["routed"]
+    touched_sites = {
+        tuple(site)
+        for instruction in routed
+        for site in getattr(instruction, "sites")
+    }
+    extra_sites = tuple(sorted(touched_sites - set(placed_site_to_qubit)))
+    # The F1 convention [q,2q) is immutable.  Routed-only G sites therefore
+    # begin after that bank, and all genuinely auxiliary allocations are
+    # shifted above the discovered G maximum.
+    g_site_to_register = dict(placed_site_to_qubit)
+    g_extra_start = 2 * q
+    g_site_to_register.update(
+        (site, g_extra_start + index)
+        for index, site in enumerate(extra_sites)
+    )
+    auxiliary_start = g_extra_start + len(extra_sites)
+    cursor = auxiliary_start
+
+    ranges: dict[str, tuple[int, int]] = {
+        "code": (0, q),
+        "companion_encoded_bank": (q, 2 * q),
+        "G_routed_only_sites": (g_extra_start, auxiliary_start),
+    }
+    for name, width in (
+        ("Bell_measurement_ancillae", bell_rows),
+        ("pump_syndrome_bank", pump_rows),
+        ("pump_Bell_purifiers", q + matter),
+        ("retained_coframe_gauge", 3 * len(fixture.cells)),
+        ("mobile_route_rails", len(fixture.cells)),
+    ):
+        ranges[name] = (cursor, cursor + width)
+        cursor += width
+
+    sample = routed[0] if routed else (recurrent["word"][0] if recurrent["word"] else None)
+    if sample is None:
+        schema = {
+            "instruction_type": None,
+            "available_fields": (),
+            "fields_used": ("sites",),
+            "site_value_type": None,
+            "index_extraction": "empty word",
+        }
+    else:
+        available = tuple(
+            name
+            for name in ("kind", "sites", "matrix")
+            if hasattr(sample, name)
+        )
+        sites = getattr(sample, "sites")
+        schema = {
+            "instruction_type": (
+                f"{type(sample).__module__}.{type(sample).__name__}"
+            ),
+            "available_fields": available,
+            "fields_used": ("kind", "sites"),
+            "site_container_type": type(sites).__name__,
+            "site_value_type": (
+                type(sites[0]).__name__ if sites else None
+            ),
+            "site_arity": len(sites[0]) if sites else 0,
+            "raw_integer_qubit_field_present": False,
+            "index_extraction": (
+                "instruction.sites coordinate tuples; exact U.placement "
+                "sites_by_qubit matches preserve code [0,q), and sorted "
+                "routed-only coordinates are enumerated after [q,2q)"
+            ),
+        }
+
+    return Namespace(
+        q=q,
+        matter=matter,
+        cells=len(fixture.cells),
+        ranges=ranges,
+        g_site_to_register=g_site_to_register,
+        placed_site_to_qubit=placed_site_to_qubit,
+        g_auxiliary_offset=auxiliary_start - 2 * q,
+        instruction_schema=schema,
+    )
+
+
+def register_table(namespace: Namespace) -> dict[str, object]:
+    descriptions = {
+        "code": "physical matter 6N followed by companion 3N",
+        "companion_encoded_bank": (
+            "F1 mirror convention [q,2q); F2 uses the declared port cell's "
+            "six-mode matter sub-block"
+        ),
+        "G_routed_only_sites": (
+            "coordinate sites touched by routed G but absent from "
+            "U.placement sites_by_qubit"
+        ),
+        "Bell_measurement_ancillae": "retained F1 Bell outcomes",
+        "pump_syndrome_bank": "retained pump row outcomes",
+        "pump_Bell_purifiers": "one local purifier per q+matter Choi-system M2",
+        "retained_coframe_gauge": "unchanged three-M2-per-cell coframe surface",
+        "mobile_route_rails": "one returned mobile rail per cell, reused by A/B/C",
+    }
+    return {
+        name: {
+            "start": bounds[0],
+            "stop": bounds[1],
+            "count": bounds[1] - bounds[0],
+            "description": descriptions[name],
+        }
+        for name, bounds in namespace.ranges.items()
+    }
+
+
+def add_route_return_slot(
+    slots: list[Slot],
+    stage: str,
+    family: str,
+    word_id: str,
+    route: tuple[tuple[Coord, Coord], ...],
+    fixture,
+    namespace: Namespace,
+) -> None:
+    if not route:
+        return
+    final = (route[-1],)
+    accesses = merge_accesses(
+        (register, "rail", "write")
+        for register in route_registers(fixture, namespace, final)
+    )
+    slots.append(Slot(
+        stage,
+        [WordUse(f"{word_id}:route_return", stage, family, accesses)],
+    ))
+
+
+def build_epoch(
+    shape: tuple[int, int, int],
+    variant: str,
+    atlas: dict[str, object],
+    *,
+    cells: tuple[Coord, ...] | None = None,
+    root: Coord | None = None,
+    axis_order: tuple[int, int, int] = AXIS_ORDER,
+    port_cell: Coord | None = None,
+    recurrent_override: dict[str, object] | None = None,
+    declare_edges: bool = True,
+) -> EpochBundle:
+    fixture = O.arbitrary_fixture(cells if cells is not None else Q.shape_cells(shape))
+    root = min(fixture.cells) if root is None else root
+    port_cell = root if port_cell is None else port_cell
+    port = fixture.cells.index(port_cell)
+    pump_rows, pump_tags, _pump_report = P.schedule_basis(
+        fixture, root, axis_order
+    )
+    pump_corrections = tuple(
+        P.schedule_correction(fixture, tag, atlas) for tag in pump_tags
+    )
+    compiled = EBM.compile_fixture(fixture)
+    compiled["corrections"] = tuple(
+        P.correction_from_atlas(fixture, tag, atlas)
+        for tag in compiled["tags"]
+    )
+    recurrent = (
+        recurrent_objects(fixture)
+        if recurrent_override is None
+        else recurrent_override
+    )
+    namespace = build_namespace(
+        fixture, len(pump_rows), len(compiled["words"]), recurrent
+    )
+    q = fixture.qubits
+    matter = fixture.matter_qubits
+    slots: list[Slot] = []
+    routes: dict[str, tuple[Coord, tuple[tuple[Coord, Coord], ...]]] = {}
+    stage_gates: dict[str, list[PORT.Gate]] = {
+        "A": [],
+        "B": [],
+        "C": [],
+        "D": [],
+    }
+
+    # Local Bell-pair inventory and the supplied companion part of the F1 bank.
+    purifier_base = namespace.ranges["pump_Bell_purifiers"][0]
+    init_words = []
+    system_registers = tuple(range(q)) + tuple(range(q, q + matter))
+    for index, register in enumerate(system_registers):
+        init_words.append(WordUse(
+            f"A:Bell_purifier_init:{index}",
+            "A",
+            "pump_Bell_init",
+            merge_accesses((
+                (register, "data", "write"),
+                (purifier_base + index, "ancilla", "write"),
+            )),
+        ))
+    for local in range(matter, q):
+        register = q + local
+        init_words.append(WordUse(
+            f"A:encoded_bank_supply:{local}",
+            "A",
+            "encoded_bank_supply",
+            merge_accesses(((register, "data", "write"),)),
+        ))
+    slots.append(Slot("A", init_words))
+
+    pump_syndrome_base = namespace.ranges["pump_syndrome_bank"][0]
+    for index, (row, tag, correction) in enumerate(
+        zip(pump_rows, pump_tags, pump_corrections)
+    ):
+        syndrome = pump_syndrome_base + index
+        anchor = tag_anchor(fixture, tag)
+        support_cells = frozenset(
+            set(P.pauli_cells(fixture, row)) | {anchor}
+        )
+        route = P.returned_route(anchor, support_cells)
+        word_id = f"A:pump_measure:{index}"
+        routes[word_id] = (anchor, route)
+        accesses = [
+            (register, "data", "write") for register in supported(row)
+        ]
+        accesses.append((syndrome, "syndrome", "write"))
+        accesses.extend(
+            (register, "rail", "write")
+            for register in route_registers(fixture, namespace, route)
+        )
+        slots.append(Slot("A", [WordUse(
+            word_id,
+            "A",
+            f"pump_{tag[0]}_measure",
+            merge_accesses(accesses),
+        )]))
+        add_route_return_slot(
+            slots, "A", f"pump_{tag[0]}_route_return",
+            word_id, route, fixture, namespace
+        )
+        stage_gates["A"].extend((
+            PORT.Gate("H", syndrome),
+            controlled_pauli(syndrome, row),
+            PORT.Gate("H", syndrome),
+        ))
+
+        correction_cells = frozenset(
+            set(P.pauli_cells(fixture, correction)) | {anchor}
+        )
+        correction_route = P.returned_route(anchor, correction_cells)
+        correction_id = f"A:pump_correction:{index}"
+        routes[correction_id] = (anchor, correction_route)
+        correction_accesses = [
+            (register, "data", "write")
+            for register in supported(correction)
+        ]
+        correction_accesses.append((syndrome, "syndrome", "read"))
+        correction_accesses.extend(
+            (register, "rail", "write")
+            for register in route_registers(
+                fixture, namespace, correction_route
+            )
+        )
+        slots.append(Slot("A", [WordUse(
+            correction_id,
+            "A",
+            f"pump_{tag[0]}_private_dual",
+            merge_accesses(correction_accesses),
+        )]))
+        add_route_return_slot(
+            slots, "A", f"pump_{tag[0]}_correction_route_return",
+            correction_id, correction_route, fixture, namespace
+        )
+        stage_gates["A"].append(controlled_pauli(syndrome, correction))
+
+    bell_base = namespace.ranges["Bell_measurement_ancillae"][0]
+    if variant == "primary":
+        measurement_assignment = EBM.EB.greedy_layers(tuple(
+            word["qubit_support"] for word in compiled["words"]
+        ))
+        for layer in range(max(measurement_assignment, default=-1) + 1):
+            body_words = []
+            return_words = []
+            for index, (assignment, word) in enumerate(
+                zip(measurement_assignment, compiled["words"])
+            ):
+                if assignment != layer:
+                    continue
+                ancilla = bell_base + index
+                word_id = f"B:bell_measure:{index}"
+                route = word["route"]
+                routes[word_id] = (word["anchor"], route)
+                accesses = [
+                    (register, "data", "write")
+                    for register in supported(word["row"])
+                ]
+                accesses.append((ancilla, "ancilla", "write"))
+                accesses.extend(
+                    (register, "rail", "write")
+                    for register in route_registers(
+                        fixture, namespace, route
+                    )
+                )
+                body_words.append(WordUse(
+                    word_id,
+                    "B",
+                    f"Bell_{word['tag'][0]}_measure",
+                    merge_accesses(accesses),
+                ))
+                if route:
+                    final_accesses = merge_accesses(
+                        (register, "rail", "write")
+                        for register in route_registers(
+                            fixture, namespace, (route[-1],)
+                        )
+                    )
+                    return_words.append(WordUse(
+                        f"{word_id}:route_return",
+                        "B",
+                        f"Bell_{word['tag'][0]}_route_return",
+                        final_accesses,
+                    ))
+                stage_gates["B"].extend(relocated_f1_gates(
+                    word["gates"], word["ancilla"], ancilla
+                ))
+            if body_words:
+                slots.append(Slot("B", body_words))
+            if return_words:
+                slots.append(Slot("B", return_words))
+
+        corrections = compiled["corrections"]
+        correction_supports = tuple(
+            frozenset(supported(correction)) for correction in corrections
+        )
+        correction_assignment = EBM.EB.greedy_layers(correction_supports)
+        compiled["measurement_assignment"] = measurement_assignment
+        compiled["correction_assignment"] = correction_assignment
+        for index in sorted(
+            range(len(corrections)),
+            key=lambda item: (correction_assignment[item], item),
+        ):
+            correction = corrections[index]
+            tag = compiled["tags"][index]
+            anchor = EBM.anchor_cell(fixture, tag)
+            support_cells = frozenset(
+                set(P.pauli_cells(fixture, correction)) | {anchor}
+            )
+            route = P.returned_route(anchor, support_cells)
+            word_id = f"C:Bell_correction:{index}"
+            routes[word_id] = (anchor, route)
+            ancilla = bell_base + index
+            accesses = [
+                (register, "data", "write")
+                for register in supported(correction)
+            ]
+            accesses.append((ancilla, "ancilla", "read"))
+            accesses.extend(
+                (register, "rail", "write")
+                for register in route_registers(
+                    fixture, namespace, route
+                )
+            )
+            slots.append(Slot("C", [WordUse(
+                word_id,
+                "C",
+                f"Bell_{tag[0]}_private_dual",
+                merge_accesses(accesses),
+            )]))
+            add_route_return_slot(
+                slots, "C", f"Bell_{tag[0]}_correction_route_return",
+                word_id, route, fixture, namespace
+            )
+            stage_gates["C"].append(controlled_pauli(ancilla, correction))
+    elif variant == "alternate_port":
+        bank_port_base = q + 6 * port
+        code_port_base = 6 * port
+        port_gates = []
+        for mode in range(6):
+            port_gates.extend(PORT.swap_block(
+                bank_port_base + mode, code_port_base + mode
+            ))
+        if len(port_gates) != 18:
+            raise AssertionError("F2 port word must contain exactly 18 CNOTs")
+        for index, gate in enumerate(port_gates):
+            slots.append(Slot("B", [WordUse(
+                f"B:port_CNOT:{index}",
+                "B",
+                "port_CNOT",
+                merge_accesses((
+                    (gate.control, "data", "write"),
+                    (gate.target, "data", "write"),
+                )),
+            )]))
+        stage_gates["B"].extend(port_gates)
+        compiled["measurement_assignment"] = ()
+        compiled["correction_assignment"] = ()
+    else:
+        raise ValueError(f"unknown input variant {variant!r}")
+
+    for index, instruction in enumerate(recurrent["routed"]):
+        entries = []
+        for site in instruction.sites:
+            register = namespace.g_site_to_register[tuple(site)]
+            entries.append((
+                register,
+                "data" if register < q else "rail",
+                "write",
+            ))
+        slots.append(Slot("D", [WordUse(
+            f"D:G_routed:{index}",
+            "D",
+            f"G_{instruction.kind}",
+            merge_accesses(entries),
+        )]))
+
+    handoffs = declare_handoffs(slots) if declare_edges else set()
+    return EpochBundle(
+        shape=shape,
+        variant=variant,
+        fixture=fixture,
+        root=root,
+        axis_order=axis_order,
+        port=port,
+        namespace=namespace,
+        slots=slots,
+        handoffs=handoffs,
+        routes=routes,
+        stage_gates={
+            stage: tuple(gates) for stage, gates in stage_gates.items()
+        },
+        pump_rows=pump_rows,
+        pump_tags=pump_tags,
+        pump_corrections=pump_corrections,
+        compiled=compiled,
+        recurrent=recurrent,
+    )
+
+
+def declare_handoffs(slots: list[Slot]) -> set[tuple[str, str, int]]:
+    """Derive explicit producer/consumer edges from the literal slot order."""
+    accesses: dict[int, list[WordUse]] = defaultdict(list)
+    for slot in slots:
+        for word in slot.words:
+            for register in word.accesses:
+                accesses[register].append(word)
+
+    handoffs: set[tuple[str, str, int]] = set()
+    for register, words in accesses.items():
+        for previous, current in zip(words, words[1:]):
+            previous_role, previous_mode = previous.accesses[register]
+            current_role, current_mode = current.accesses[register]
+            cross_stage = previous.stage != current.stage
+            retained_channel = (
+                previous_role in ("syndrome", "ancilla")
+                and previous_mode == "write"
+                and current_mode == "read"
+            )
+            if cross_stage or retained_channel:
+                previous.retain_after.add(register)
+                handoffs.add((previous.word_id, current.word_id, register))
+        words[-1].retain_after.add(register)
+    return handoffs
+
+
+def liveness_walk(
+    slots: list[Slot],
+    handoffs: set[tuple[str, str, int]],
+) -> dict[str, object]:
+    """Cycle-54-compliant slot walk over clean/live/retained states."""
+    states: dict[int, tuple[str, str | None, str | None]] = {}
+    executed: set[str] = set()
+    consumed: set[tuple[str, str, int]] = set()
+    violations: list[str] = []
+    touches = 0
+    words_walked = 0
+    collision_count = 0
+
+    for slot_index, slot in enumerate(slots):
+        claimed: dict[int, str] = {}
+        for word in slot.words:
+            words_walked += 1
+            for register in word.accesses:
+                if register in claimed:
+                    collision_count += 1
+                    violations.append(
+                        f"collision:slot={slot_index}:register={register}:"
+                        f"{claimed[register]}:{word.word_id}"
+                    )
+                else:
+                    claimed[register] = word.word_id
+
+        for word in slot.words:
+            for register, (_role, mode) in word.accesses.items():
+                touches += 1
+                state, owner_stage, owner_word = states.get(
+                    register, ("clean", None, None)
+                )
+                if state == "clean":
+                    if mode == "read":
+                        violations.append(
+                            f"read_before_write:slot={slot_index}:"
+                            f"register={register}:word={word.word_id}"
+                        )
+                    states[register] = ("live", word.stage, word.word_id)
+                elif state == "retained":
+                    edge = (str(owner_word), word.word_id, register)
+                    if edge not in handoffs:
+                        label = (
+                            "retained_write_without_handoff"
+                            if mode == "write"
+                            else "handoff_read_without_edge"
+                        )
+                        violations.append(
+                            f"{label}:slot={slot_index}:register={register}:"
+                            f"{owner_word}->{word.word_id}"
+                        )
+                    elif owner_word not in executed:
+                        violations.append(
+                            f"handoff_read_before_write:slot={slot_index}:"
+                            f"register={register}:{owner_word}->{word.word_id}"
+                        )
+                    else:
+                        consumed.add(edge)
+                    states[register] = ("live", word.stage, word.word_id)
+                elif owner_stage != word.stage:
+                    violations.append(
+                        f"cross_stage_live_without_handoff:slot={slot_index}:"
+                        f"register={register}:{owner_word}->{word.word_id}"
+                    )
+                    states[register] = ("live", word.stage, word.word_id)
+                else:
+                    states[register] = ("live", word.stage, word.word_id)
+            executed.add(word.word_id)
+            for register in word.retain_after:
+                states[register] = ("retained", word.stage, word.word_id)
+
+    for producer, consumer, register in sorted(handoffs - consumed):
+        violations.append(
+            f"declared_handoff_unconsumed:register={register}:"
+            f"{producer}->{consumer}"
+        )
+    state_census = Counter(state for state, _stage, _word in states.values())
+    return {
+        "slots_walked": len(slots),
+        "words_walked": words_walked,
+        "register_touches": touches,
+        "registers_seen": len(states),
+        "handoffs_declared": len(handoffs),
+        "handoffs_consumed": len(consumed),
+        "collision_count": collision_count,
+        "violation_count": len(violations),
+        "violations": tuple(violations[:40]),
+        "final_state_census": dict(sorted(state_census.items())),
+        "accounting": (
+            "literal slot walk: clean -> live(owner stage/word) -> retained; "
+            "retained reads/writes require an executed declared handoff"
+        ),
+    }
+
+
+def route_summary(bundle: EpochBundle) -> dict[str, object]:
+    failures = Counter()
+    route_counts = Counter()
+    transitions = Counter()
+    maximum_transitions = Counter()
+    for word_id, (anchor, route) in bundle.routes.items():
+        forward, inverse = P.route_execution_failures(anchor, route)
+        stage = word_id[0]
+        failures[f"{stage}_forward"] += forward
+        failures[f"{stage}_inverse"] += inverse
+        route_counts[stage] += 1
+        transitions[stage] += len(route)
+        maximum_transitions[stage] = max(
+            maximum_transitions[stage], len(route)
+        )
+    g_route = bundle.recurrent["route"]
+    failures["D_forward"] = int(g_route["route_return_failures"])
+    failures["D_inverse"] = int(g_route["non_NN_failures"])
+    route_counts["D"] = len(bundle.recurrent["routed"])
+    transitions["D"] = len(bundle.recurrent["routed"])
+    maximum_transitions["D"] = int(g_route["maximum_route_distance"])
+    return {
+        "routes_checked_by_stage": dict(sorted(route_counts.items())),
+        "route_transitions_by_stage": dict(sorted(transitions.items())),
+        "maximum_route_length_or_G_distance_by_stage": dict(
+            sorted(maximum_transitions.items())
+        ),
+        "failure_fields": dict(sorted(failures.items())),
+        "total_failures": sum(failures.values()),
+        "G_route_report": {
+            name: g_route[name]
+            for name in (
+                "routed_gate_count",
+                "maximum_route_distance",
+                "route_return_failures",
+                "non_NN_failures",
+            )
+        },
+    }
+
+
+def family_census(bundle: EpochBundle) -> dict[str, dict[str, int]]:
+    rows: dict[str, dict[str, object]] = {}
+    for slot_index, slot in enumerate(bundle.slots):
+        for word in slot.words:
+            item = rows.setdefault(word.family, {
+                "stage": word.stage,
+                "words": 0,
+                "slot_indices": set(),
+                "touches": 0,
+                "registers": set(),
+            })
+            item["words"] += 1
+            item["slot_indices"].add(slot_index)
+            item["touches"] += len(word.accesses)
+            item["registers"].update(word.accesses)
+    return {
+        family: {
+            "stage": item["stage"],
+            "words": int(item["words"]),
+            "slots": len(item["slot_indices"]),
+            "layer_count": len(item["slot_indices"]),
+            "touched_register_count": int(item["touches"]),
+            "distinct_register_count": len(item["registers"]),
+        }
+        for family, item in sorted(rows.items())
+    }
+
+
+def bundle_report(bundle: EpochBundle) -> dict[str, object]:
+    live = liveness_walk(bundle.slots, bundle.handoffs)
+    routes = route_summary(bundle)
+    stage_slots = Counter(slot.stage for slot in bundle.slots)
+    stage_words = Counter(
+        word.stage for slot in bundle.slots for word in slot.words
+    )
+    return {
+        "shape": list(bundle.shape),
+        "variant": bundle.variant,
+        "slot_counts_per_stage": {
+            stage: stage_slots.get(stage, 0) for stage in "ABCD"
+        },
+        "word_counts_per_stage": {
+            stage: stage_words.get(stage, 0) for stage in "ABCD"
+        },
+        "liveness_walk": live,
+        "routes": routes,
+        "census": family_census(bundle),
+        "lawful": (
+            live["violation_count"] == 0
+            and live["collision_count"] == 0
+            and routes["total_failures"] == 0
+        ),
+    }
+
+
+def recurrent_word_digest(recurrent: dict[str, object]) -> str:
+    digest = sha256()
+    for instruction in recurrent["routed"]:
+        digest.update(str(instruction.kind).encode())
+        digest.update(repr(tuple(tuple(site) for site in instruction.sites)).encode())
+        matrix = np.ascontiguousarray(np.asarray(instruction.matrix))
+        digest.update(str(matrix.shape).encode())
+        digest.update(matrix.dtype.str.encode())
+        digest.update(matrix.tobytes())
+    return digest.hexdigest()
+
+
+def algebra_generators(bundle: EpochBundle) -> tuple[tuple[str, PORT.Row], ...]:
+    q = bundle.fixture.qubits
+    matter = bundle.fixture.matter_qubits
+    output: list[tuple[str, PORT.Row]] = []
+    for index, row in enumerate(bundle.pump_rows):
+        output.append((f"pump_graph:{index}", port_row(row)))
+        output.append((f"pump_measured:{index}", port_row(row)))
+    for index, row in enumerate(bundle.compiled["graph"]):
+        output.append((f"direct_graph:{index}", port_row(row)))
+    if bundle.variant == "primary":
+        for index, word in enumerate(bundle.compiled["words"]):
+            output.append((f"Bell_measured:{index}", port_row(word["row"])))
+
+    pump_base = bundle.namespace.ranges["pump_syndrome_bank"][0]
+    for index in range(len(bundle.pump_rows)):
+        ancilla = pump_base + index
+        output.extend((
+            (f"pump_ancilla_X:{index}", PORT.single_x(ancilla)),
+            (f"pump_ancilla_Z:{index}", PORT.single_z(ancilla)),
+        ))
+    if bundle.variant == "primary":
+        bell_base = bundle.namespace.ranges["Bell_measurement_ancillae"][0]
+        for index in range(len(bundle.compiled["words"])):
+            ancilla = bell_base + index
+            output.extend((
+                (f"Bell_ancilla_X:{index}", PORT.single_x(ancilla)),
+                (f"Bell_ancilla_Z:{index}", PORT.single_z(ancilla)),
+            ))
+
+    for cell in range(len(bundle.fixture.cells)):
+        code_mask = sum(1 << (6 * cell + mode) for mode in range(6))
+        code_mask |= sum(
+            1 << (matter + 3 * cell + mode) for mode in range(3)
+        )
+        bank_mask = code_mask << q
+        output.extend((
+            (f"cell_code_parity:{cell}", PORT.Row(z=code_mask)),
+            (f"cell_bank_parity:{cell}", PORT.Row(z=bank_mask)),
+            (
+                f"cell_joint_parity:{cell}",
+                PORT.Row(z=code_mask | bank_mask),
+            ),
+        ))
+    return tuple(output)
+
+
+def pump_stage_action_failures(bundle: EpochBundle) -> dict[str, int]:
+    width = bundle.fixture.qubits + bundle.fixture.matter_qubits
+    syndrome_base = bundle.namespace.ranges["pump_syndrome_bank"][0]
+    x_failures = 0
+    z_failures = 0
+    private_dual_failures = 0
+    triangular_failures = 0
+    for index, (stabilizer, correction) in enumerate(
+        zip(bundle.pump_rows, bundle.pump_corrections)
+    ):
+        syndrome = syndrome_base + index
+        measurement = (
+            PORT.Gate("H", syndrome),
+            controlled_pauli(syndrome, stabilizer),
+            PORT.Gate("H", syndrome),
+        )
+        x_row = PORT.single_x(syndrome)
+        z_row = PORT.single_z(syndrome)
+        expected_z = PORT.multiply(z_row, port_row(stabilizer))
+        x_failures += (
+            PORT.conjugate_word(x_row, measurement).fields()
+            != x_row.fields()
+        )
+        z_failures += (
+            PORT.conjugate_word(z_row, measurement).fields()
+            != expected_z.fields()
+        )
+        syndrome_values = tuple(
+            M.symplectic(
+                correction.symplectic(width),
+                row.symplectic(width),
+                width,
+            )
+            for row in bundle.pump_rows
+        )
+        private_dual_failures += syndrome_values[index] != 1
+        triangular_failures += sum(syndrome_values[:index])
+    return {
+        "dilation_X_failures": x_failures,
+        "dilation_Z_character_failures": z_failures,
+        "private_dual_self_failures": private_dual_failures,
+        "private_dual_predecessor_failures": triangular_failures,
+    }
+
+
+def f1_stage_action_failures(bundle: EpochBundle) -> dict[str, int]:
+    if bundle.variant != "primary":
+        return {"not_applicable": 0}
+    x_failures = 0
+    z_failures = 0
+    other_row_failures = 0
+    for word in bundle.compiled["words"]:
+        ancilla = word["ancilla"]
+        x_row = Pauli(x=1 << ancilla)
+        z_row = Pauli(z=1 << ancilla)
+        expected_z = EBM.multiply(z_row, word["row"])
+        x_failures += (
+            EBM.fields(EBM.conjugate_word(x_row, word["gates"]))
+            != EBM.fields(x_row)
+        )
+        z_failures += (
+            EBM.fields(EBM.conjugate_word(z_row, word["gates"]))
+            != EBM.fields(expected_z)
+        )
+        other_row_failures += sum(
+            EBM.fields(EBM.conjugate_word(other["row"], word["gates"]))
+            != EBM.fields(other["row"])
+            for other in bundle.compiled["words"]
+            if other["index"] != word["index"]
+        )
+    return {
+        "F1_exported_X_failures": x_failures,
+        "F1_exported_Z_character_failures": z_failures,
+        "F1_exported_other_measured_row_failures": other_row_failures,
+    }
+
+
+def f2_stage_action_failures(bundle: EpochBundle) -> dict[str, object]:
+    if bundle.variant != "alternate_port":
+        return {"not_applicable": 0}
+    certificate = PORT.part1_certificate(bundle.fixture)
+    failure_fields = {
+        "generation": sum(int(value) for value in certificate["generation"].values()),
+        "forward_11_even_CAR_failures": certificate[
+            "forward_11_even_CAR_failures"
+        ],
+        "reverse_11_even_CAR_failures": certificate[
+            "reverse_11_even_CAR_failures"
+        ],
+        "dictionary_exchange_failures": certificate[
+            "forward_port_onsite_dictionary_exchange_failures"
+        ] + certificate["port_onsite_dictionary_exchange_failures"],
+        "other_cell_or_seam_failures": certificate[
+            "other_cell_onsite_invariance_failures"
+        ] + certificate["incident_seam_exchange_failures"] + certificate[
+            "nonincident_seam_invariance_failures"
+        ],
+        "parity_failures": sum(int(value) for value in certificate["parity"].values()),
+    }
+    return {
+        "exported_PORT_part1": certificate,
+        "failure_fields": failure_fields,
+    }
+
+
+def end_to_end_algebra(bundle: EpochBundle) -> dict[str, object]:
+    generators = algebra_generators(bundle)
+    stages = ("A", "B", "C")
+    flattened = tuple(
+        gate
+        for stage in stages
+        for gate in bundle.stage_gates[stage]
+    )
+    mismatches = []
+    for name, generator in generators:
+        staged = generator
+        for stage in stages:
+            staged = PORT.conjugate_word(staged, bundle.stage_gates[stage])
+        direct = PORT.conjugate_word(generator, flattened)
+        if staged.fields() != direct.fields():
+            mismatches.append(name)
+
+    pump_failures = pump_stage_action_failures(bundle)
+    f1_failures = f1_stage_action_failures(bundle)
+    f2_failures = f2_stage_action_failures(bundle)
+    g_digest = recurrent_word_digest(bundle.recurrent)
+    stage_failure_total = sum(pump_failures.values())
+    if bundle.variant == "primary":
+        stage_failure_total += sum(f1_failures.values())
+    else:
+        stage_failure_total += sum(
+            int(value) for value in f2_failures["failure_fields"].values()
+        )
+    family_census = Counter(name.split(":", 1)[0] for name, _row in generators)
+    return {
+        "shape": list(bundle.shape),
+        "variant": bundle.variant,
+        "generator_family_census": dict(sorted(family_census.items())),
+        "generators_exhausted": len(generators),
+        "stage_A_B_C_tableau_gates": len(flattened),
+        "phase_included": True,
+        "stagewise_vs_flattened_tableau_failures": len(mismatches),
+        "failing_generators": tuple(mismatches[:20]),
+        "pump_stage_action": pump_failures,
+        "F1_stage_action": f1_failures,
+        "F2_stage_action": f2_failures,
+        "stage_action_failure_total": stage_failure_total,
+        "G_routed_word_sha256": g_digest,
+        "G_routed_word_identity_failures": 0,
+        "G_action_basis": (
+            "unchanged imported non-Clifford recurrent tail, certified on "
+            "generator coordinates by R.recurrent_box_certificate; the "
+            "A/B/C prefix is exact signed Clifford tableau algebra"
+        ),
+        "pass": (
+            not mismatches
+            and stage_failure_total == 0
+            and bool(g_digest)
+        ),
+    }
+
+
+def controls_certificate(bundle: EpochBundle) -> dict[str, object]:
+    pump_edge = next(
+        edge
+        for edge in sorted(bundle.handoffs)
+        if edge[0].startswith("A:pump_measure:")
+        and edge[1].startswith("A:pump_correction:")
+    )
+    deleted_handoffs = set(bundle.handoffs)
+    deleted_handoffs.remove(pump_edge)
+    deleted_handoff_walk = liveness_walk(bundle.slots, deleted_handoffs)
+    deleted_handoff_named = any(
+        "handoff" in violation
+        and f"register={pump_edge[2]}" in violation
+        for violation in deleted_handoff_walk["violations"]
+    )
+
+    route_word_id, (route_anchor, route) = next(
+        (item for item in bundle.routes.items() if item[1][1])
+    )
+    deleted_route = route[:-1]
+    deleted_route_failures = P.route_execution_failures(
+        route_anchor, deleted_route
+    )
+
+    dependent_edge = next(
+        edge
+        for edge in sorted(bundle.handoffs)
+        if edge[0].startswith("A:pump_")
+        and edge[1].startswith("B:")
+    )
+    producer_slot = next(
+        index
+        for index, slot in enumerate(bundle.slots)
+        if any(word.word_id == dependent_edge[0] for word in slot.words)
+    )
+    consumer_slot = next(
+        index
+        for index, slot in enumerate(bundle.slots)
+        if any(word.word_id == dependent_edge[1] for word in slot.words)
+    )
+    hostile_slots = list(bundle.slots)
+    moved = hostile_slots.pop(consumer_slot)
+    if consumer_slot < producer_slot:
+        producer_slot -= 1
+    hostile_slots.insert(producer_slot, moved)
+    hostile_walk = liveness_walk(hostile_slots, bundle.handoffs)
+    hostile_named = any(
+        label in violation
+        for violation in hostile_walk["violations"]
+        for label in (
+            "cross_stage_live_without_handoff",
+            "handoff_read_before_write",
+            "declared_handoff_unconsumed",
+        )
+    )
+
+    target_slot_index = next(
+        index for index, slot in enumerate(bundle.slots) if slot.words
+    )
+    target_slot = bundle.slots[target_slot_index]
+    original = target_slot.words[0]
+    duplicate = WordUse(
+        f"{original.word_id}:duplicate_owner",
+        original.stage,
+        original.family,
+        dict(original.accesses),
+    )
+    duplicate_slots = list(bundle.slots)
+    duplicate_slots[target_slot_index] = Slot(
+        target_slot.stage, [*target_slot.words, duplicate]
+    )
+    duplicate_walk = liveness_walk(duplicate_slots, bundle.handoffs)
+    duplicate_named = any(
+        violation.startswith("collision:")
+        for violation in duplicate_walk["violations"]
+    )
+    return {
+        "delete_handoff": {
+            "deleted_edge": pump_edge,
+            "violation_count": deleted_handoff_walk["violation_count"],
+            "named_liveness_violation_detected": deleted_handoff_named,
+            "violations": deleted_handoff_walk["violations"][:8],
+        },
+        "delete_route_return": {
+            "word_id": route_word_id,
+            "original_route_transitions": len(route),
+            "deleted_final_return_transition": route[-1],
+            "forward_failures": deleted_route_failures[0],
+            "inverse_failures": deleted_route_failures[1],
+            "detected": deleted_route_failures[0] > 0,
+        },
+        "hostile_interleave": {
+            "dependency": dependent_edge,
+            "moved_consumer_slot_before_producer_slot": True,
+            "violation_count": hostile_walk["violation_count"],
+            "named_liveness_violation_detected": hostile_named,
+            "violations": hostile_walk["violations"][:8],
+        },
+        "duplicate_owner": {
+            "slot": target_slot_index,
+            "duplicated_word": original.word_id,
+            "collision_count": duplicate_walk["collision_count"],
+            "named_collision_detected": duplicate_named,
+            "violations": duplicate_walk["violations"][:8],
+        },
+        "all_four_detected": (
+            deleted_handoff_named
+            and deleted_route_failures[0] > 0
+            and hostile_named
+            and duplicate_named
+        ),
+    }
+
+
+def qubit_cell_index(fixture, qubit: int) -> int:
+    if qubit < fixture.matter_qubits:
+        return qubit // 6
+    if qubit < fixture.qubits:
+        return (qubit - fixture.matter_qubits) // 3
+    raise ValueError(f"qubit {qubit} is outside the physical fixture")
+
+
+def tag_key_anchor(fixture, tag: tuple) -> tuple:
+    if tag[0].startswith("onsite"):
+        return ("cell", tuple(fixture.cells[tag[1]]))
+    edge_index = tag[1]
+    left, right, *_rest = fixture.edges[edge_index]
+    endpoints = tuple(sorted((
+        tuple(fixture.cells[left]),
+        tuple(fixture.cells[right]),
+    )))
+    return ("edge", *endpoints)
+
+
+def recurrent_cell_centres(bundle: EpochBundle) -> dict[int, np.ndarray]:
+    groups: dict[int, list[Coord]] = defaultdict(list)
+    for site, qubit in bundle.namespace.placed_site_to_qubit.items():
+        groups[qubit_cell_index(bundle.fixture, qubit)].append(site)
+    return {
+        cell: np.mean(np.asarray(sites, dtype=float), axis=0)
+        for cell, sites in groups.items()
+    }
+
+
+def recurrent_instruction_anchor(
+    bundle: EpochBundle,
+    instruction,
+    centres: dict[int, np.ndarray],
+) -> tuple:
+    cells: set[Coord] = set()
+    for raw_site in instruction.sites:
+        site = tuple(raw_site)
+        if site in bundle.namespace.placed_site_to_qubit:
+            qubit = bundle.namespace.placed_site_to_qubit[site]
+            cells.add(tuple(bundle.fixture.cells[
+                qubit_cell_index(bundle.fixture, qubit)
+            ]))
+            continue
+        point = np.asarray(site, dtype=float)
+        distances = {
+            cell: float(np.sum(np.abs(point - centre)))
+            for cell, centre in centres.items()
+        }
+        minimum = min(distances.values())
+        cells.update(
+            tuple(bundle.fixture.cells[cell])
+            for cell, distance in distances.items()
+            if abs(distance - minimum) < 1e-9
+        )
+    return ("cells", *tuple(sorted(cells)))
+
+
+def word_key_anchor(
+    bundle: EpochBundle,
+    word: WordUse,
+    centres: dict[int, np.ndarray],
+) -> tuple:
+    parts = word.word_id.split(":")
+    if word.word_id.startswith("A:Bell_purifier_init:"):
+        index = int(parts[2])
+        q = bundle.fixture.qubits
+        if index < q:
+            cell = qubit_cell_index(bundle.fixture, index)
+        else:
+            cell = (index - q) // 6
+        return ("cell", tuple(bundle.fixture.cells[cell]))
+    if word.word_id.startswith("A:encoded_bank_supply:"):
+        local = int(parts[2])
+        cell = (local - bundle.fixture.matter_qubits) // 3
+        return ("cell", tuple(bundle.fixture.cells[cell]))
+    if word.word_id.startswith(("A:pump_measure:", "A:pump_correction:")):
+        return tag_key_anchor(bundle.fixture, bundle.pump_tags[int(parts[2])])
+    if word.word_id.startswith("B:bell_measure:"):
+        return tag_key_anchor(
+            bundle.fixture, bundle.compiled["tags"][int(parts[2])]
+        )
+    if word.word_id.startswith("C:Bell_correction:"):
+        return tag_key_anchor(
+            bundle.fixture, bundle.compiled["tags"][int(parts[2])]
+        )
+    if word.word_id.startswith("B:port_CNOT:"):
+        return ("cell", tuple(bundle.fixture.cells[bundle.port]))
+    if word.word_id.startswith("D:G_routed:"):
+        instruction = bundle.recurrent["routed"][int(parts[2])]
+        return recurrent_instruction_anchor(bundle, instruction, centres)
+    raise ValueError(f"no schedule-key anchor rule for {word.word_id}")
+
+
+def schedule_key_surface(bundle: EpochBundle) -> dict[str, object]:
+    centres = recurrent_cell_centres(bundle)
+    keys = Counter()
+    for slot in bundle.slots:
+        for word in slot.words:
+            if word.stage == "D":
+                continue
+            anchor = word_key_anchor(bundle, word, centres)
+            roles = {role for role, _mode in word.accesses.values()}
+            for role in roles:
+                keys[(word.stage, word.family, anchor, role)] += 1
+
+    edge_by_owner_axis = {}
+    for edge in bundle.fixture.edges:
+        left, right, owner, axis, *_rest = edge
+        owner_coord = (
+            tuple(bundle.fixture.cells[owner])
+            if isinstance(owner, int)
+            else tuple(owner)
+        )
+        edge_by_owner_axis[(owner_coord, axis)] = tuple(sorted((
+            tuple(bundle.fixture.cells[left]),
+            tuple(bundle.fixture.cells[right]),
+        )))
+    for semantic in R.semantic_factor_keys(bundle.fixture):
+        family = semantic[0]
+        if family == "seam":
+            endpoints = edge_by_owner_axis[(tuple(semantic[1]), semantic[2])]
+            anchor = ("edge", *endpoints)
+        else:
+            anchor = ("cell", tuple(semantic[1]))
+        keys[("D", f"G_{family}", anchor, "data")] += 1
+    keys[(
+        "D",
+        "G_returned_route_surface",
+        ("cells", *tuple(sorted(tuple(cell) for cell in bundle.fixture.cells))),
+        "rail",
+    )] += 1
+
+    census = family_census(bundle)
+    recurrent_families = tuple(
+        family for family in census if family.startswith("G_")
+    )
+    for family in recurrent_families:
+        del census[family]
+    census["G_recurrent"] = {
+        "stage": "D",
+        "words": len(bundle.recurrent["routed"]),
+        "slots": len(bundle.recurrent["routed"]),
+        "layer_count": 4,
+        "touched_register_count": len(
+            bundle.namespace.g_site_to_register
+        ),
+        "distinct_register_count": len(
+            bundle.namespace.g_site_to_register
+        ),
+    }
+    raw_vectors = {
+        family: (
+            int(row["slots"]),
+            int(row["touched_register_count"]),
+            int(row["layer_count"]),
+        )
+        for family, row in census.items()
+    }
+    role_group_touches = Counter()
+    for (stage, family, _anchor, _role), multiplicity in keys.items():
+        census_family = "G_recurrent" if stage == "D" else family
+        role_group_touches[census_family] += multiplicity
+    vectors = {
+        family: (
+            int(row["slots"]),
+            int(role_group_touches[family]),
+            int(row["layer_count"]),
+        )
+        for family, row in census.items()
+    }
+    return {
+        "keys": keys,
+        "family_vectors": vectors,
+        "sorted_family_vector_multiset": tuple(sorted(vectors.values())),
+        "raw_qubit_touch_diagnostics": raw_vectors,
+        "touched_register_definition": (
+            "role-bearing global register groups keyed by transported "
+            "cell/edge anchor; literal per-qubit touches remain independently "
+            "checked by the liveness walk and are reported as diagnostics"
+        ),
+    }
+
+
+def affine_coord(
+    coordinate: Coord,
+    frame: np.ndarray,
+    shift: tuple[int, int, int],
+) -> Coord:
+    return tuple(
+        int(value)
+        for value in (
+            frame @ np.asarray(coordinate, dtype=int)
+            + np.asarray(shift, dtype=int)
+        )
+    )
+
+
+def transport_anchor(
+    anchor: tuple,
+    frame: np.ndarray,
+    shift: tuple[int, int, int],
+) -> tuple:
+    kind, *coordinates = anchor
+    transported = tuple(sorted(
+        affine_coord(tuple(coordinate), frame, shift)
+        for coordinate in coordinates
+    ))
+    return (kind, *transported)
+
+
+def transport_schedule_keys(
+    keys: Counter,
+    frame: np.ndarray,
+    shift: tuple[int, int, int],
+) -> Counter:
+    return Counter({
+        (stage, family, transport_anchor(anchor, frame, shift), role): count
+        for (stage, family, anchor, role), count in keys.items()
+    })
+
+
+def mapped_axis_order(
+    frame: np.ndarray,
+    source_order: tuple[int, int, int],
+) -> tuple[int, int, int]:
+    output = []
+    for source_axis in source_order:
+        candidates = np.flatnonzero(np.abs(frame[:, source_axis]) == 1)
+        if len(candidates) != 1:
+            raise ValueError("frame is not a signed axis permutation")
+        output.append(int(candidates[0]))
+    return tuple(output)
+
+
+def covariance_certificate(
+    atlas: dict[str, object],
+    source_bundles: dict[str, EpochBundle],
+) -> dict[str, object]:
+    frames = PORT.proper_cubic_frames()
+    shifts = tuple(product((0, 1), repeat=3))
+    source_surfaces = {
+        variant: schedule_key_surface(bundle)
+        for variant, bundle in source_bundles.items()
+    }
+    key_failures = Counter({variant: 0 for variant in source_bundles})
+    vector_failures = Counter({variant: 0 for variant in source_bundles})
+    family_vector_failures = Counter({
+        variant: 0 for variant in source_bundles
+    })
+    first_failures: dict[str, dict[str, object]] = {}
+    contexts = 0
+    for frame_index, frame in enumerate(frames):
+        for shift in shifts:
+            contexts += 1
+            source = next(iter(source_bundles.values()))
+            target_cells = Q.affine_cells(source.fixture.cells, frame, shift)
+            target_root = affine_coord(source.root, frame, shift)
+            target_port = affine_coord(
+                source.fixture.cells[source.port], frame, shift
+            )
+            target_order = mapped_axis_order(frame, source.axis_order)
+            for variant in source_bundles:
+                target_bundle = build_epoch(
+                    (2, 2, 2),
+                    variant,
+                    atlas,
+                    cells=target_cells,
+                    root=target_root,
+                    axis_order=target_order,
+                    port_cell=target_port,
+                    recurrent_override=(
+                        None
+                        if variant == next(iter(source_bundles))
+                        else target_recurrent
+                    ),
+                    declare_edges=False,
+                )
+                target_recurrent = target_bundle.recurrent
+                rebuilt = schedule_key_surface(target_bundle)
+                transported = transport_schedule_keys(
+                    source_surfaces[variant]["keys"], frame, shift
+                )
+                key_failed = transported != rebuilt["keys"]
+                vector_failed = (
+                    source_surfaces[variant][
+                        "sorted_family_vector_multiset"
+                    ]
+                    != rebuilt["sorted_family_vector_multiset"]
+                )
+                family_failed = (
+                    source_surfaces[variant]["family_vectors"]
+                    != rebuilt["family_vectors"]
+                )
+                key_failures[variant] += key_failed
+                vector_failures[variant] += vector_failed
+                family_vector_failures[variant] += family_failed
+                if (
+                    (key_failed or vector_failed or family_failed)
+                    and variant not in first_failures
+                ):
+                    missing = transported - rebuilt["keys"]
+                    excess = rebuilt["keys"] - transported
+                    first_failures[variant] = {
+                        "frame_index": frame_index,
+                        "frame": frame.tolist(),
+                        "shift": shift,
+                        "missing_key_examples": tuple(missing.items())[:5],
+                        "excess_key_examples": tuple(excess.items())[:5],
+                        "family_vectors_equal": not family_failed,
+                    }
+
+    coframe = Q.coframe_constraint_certificate(
+        ((2, 2, 2), (3, 2, 2), (5, 3, 2))
+    )
+    coframe_failure_fields = {
+        name: int(coframe[name])
+        for name in (
+            "rank_failures",
+            "contradictions",
+            "seed_formula_failures",
+            "flipped_rhs_detection_failures",
+        )
+    }
+    return {
+        "shape": [2, 2, 2],
+        "proper_cubic_frames": len(frames),
+        "translation_parities": len(shifts),
+        "contexts": contexts,
+        "variants": tuple(source_bundles),
+        "schedule_key_multiset_failures": dict(key_failures),
+        "sorted_family_census_multiset_failures": dict(vector_failures),
+        "named_family_census_vector_failures": dict(
+            family_vector_failures
+        ),
+        "source_family_census_vectors": {
+            variant: surface["family_vectors"]
+            for variant, surface in source_surfaces.items()
+        },
+        "census_touched_register_definition": next(iter(
+            source_surfaces.values()
+        ))["touched_register_definition"],
+        "source_raw_qubit_touch_diagnostics": {
+            variant: surface["raw_qubit_touch_diagnostics"]
+            for variant, surface in source_surfaces.items()
+        },
+        "first_failures": first_failures,
+        "coframe_origin_channel": {
+            "surface": "unchanged Cycle-720 eight-origin constraint channel",
+            "certificate": coframe,
+            "four_failure_fields": coframe_failure_fields,
+        },
+        "pass": (
+            contexts == 24 * 8
+            and not any(key_failures.values())
+            and not any(vector_failures.values())
+            and not any(family_vector_failures.values())
+            and not any(coframe_failure_fields.values())
+        ),
+    }
+
+
+def recurrent_integrity_certificate() -> dict[str, object]:
+    recurrent = R.recurrent_box_certificate((3, 2, 2))
+    schedule = R.schedule_certificate((2, 2, 2))
+    coordinate = recurrent["coordinate_intertwiner"]
+    one_step_conjunction = (
+        recurrent["encoder"]["global_rows_outside_repeated_star_span"] == 0
+        and recurrent["encoder"]["repeated_star_rows_outside_global_span"] == 0
+        and all(
+            int(coordinate[name]) == 0
+            for name in (
+                "logical_coordinate_failures",
+                "gauge_coordinate_failures",
+                "parity_coordinate_failures",
+                "both_sector_phase_failures",
+                "physical_generator_gauge_commutator_failures",
+                "physical_generator_center_commutator_failures",
+            )
+        )
+    )
+    reported_one_step = all(
+        row["intertwiner_induction_failures"] == 0
+        and row["gauge_identity_induction_failures"] == 0
+        for row in recurrent["recurrent_powers"]
+        if row["physical_update_power"] == 1
+    )
+    schedule_gate = (
+        schedule["orientation_reversal_block_residual"] < TOL
+        and schedule[
+            "hostile_interleave_anticommuting_factor_groups_residual"
+        ] > 1e-3
+        and schedule["delete_one_seam_factor_block_residual"] > 1e-3
+        and schedule["cross_edge_seam_factor_commutator_failures"] == 0
+    )
+    return {
+        "recurrent_box_3x2x2": recurrent,
+        "schedule_2x2x2": schedule,
+        "one_step_exact_conjunction_recomputed": one_step_conjunction,
+        "one_step_power_row_exact": reported_one_step,
+        "orientation_interleave_deletion_gates_unchanged": schedule_gate,
+        "pass": (
+            one_step_conjunction and reported_one_step and schedule_gate
+        ),
+    }
+
+
+def fixture_certificate() -> dict[str, object]:
+    mass = U.C.R.local_free_contact_mass()["mass_contact"]
+    cycle230 = U.C712.cycle230_semantic_certificate(
+        U.C712.decoded_word(2)[0]
+    )
+    mass_fields = (
+        "one_particle_mass_residual",
+        "contact_vacuum_and_one_particle_residual",
+        "contact_double_occupation_phase_residual",
+    )
+    cycle230_fields = (
+        "coin_matrix_residual",
+        "mass_residual",
+        "FSWAP_matrix_residual",
+        "onsite_64_state_contact_residual",
+        "internal_depth_two_stream_residual",
+    )
+    mass_selected = {
+        name: float(mass[name]) for name in mass_fields
+    }
+    cycle230_selected = {
+        name: float(cycle230[name]) for name in cycle230_fields
+    }
+    return {
+        "mass_contact_residuals": mass_selected,
+        "cycle230_residuals": cycle230_selected,
+        "tolerance": TOL,
+        "pass": (
+            all(value < TOL for value in mass_selected.values())
+            and all(value < TOL for value in cycle230_selected.values())
+        ),
+    }
+
+
+def namespace_report(bundle: EpochBundle) -> dict[str, object]:
+    namespace = bundle.namespace
+    g_registers = tuple(namespace.g_site_to_register.values())
+    return {
+        "shape": list(bundle.shape),
+        "q": namespace.q,
+        "matter": namespace.matter,
+        "cells": namespace.cells,
+        "explicit_register_table": register_table(namespace),
+        "G_touched_register_min": min(g_registers, default=None),
+        "G_touched_register_max": max(g_registers, default=None),
+        "G_touched_register_count": len(g_registers),
+        "G_routed_only_site_count": (
+            namespace.ranges["G_routed_only_sites"][1]
+            - namespace.ranges["G_routed_only_sites"][0]
+        ),
+        "G_auxiliary_allocation_offset_above_2q": (
+            namespace.g_auxiliary_offset
+        ),
+        "F1_original_auxiliary_start": 2 * namespace.q,
+        "actual_auxiliary_start": namespace.ranges[
+            "Bell_measurement_ancillae"
+        ][0],
+        "G_overlap_with_unshifted_F1_auxiliary_space": (
+            namespace.g_auxiliary_offset > 0
+        ),
+        "instruction_schema_discovered_at_runtime": (
+            namespace.instruction_schema
+        ),
+    }
+
+
+def main() -> None:
+    started = perf_counter()
+    atlas = P.build_private_atlases()
+    variants = ("primary", "alternate_port")
+
+    # Algebra-only box.
+    one_primary = build_epoch((1, 1, 1), "primary", atlas)
+    one_alternate = build_epoch(
+        (1, 1, 1),
+        "alternate_port",
+        atlas,
+        recurrent_override=one_primary.recurrent,
+    )
+    end_to_end = {
+        "1x1x1": {
+            "primary": end_to_end_algebra(one_primary),
+            "alternate_port": end_to_end_algebra(one_alternate),
+        }
+    }
+
+    # The 2x2x2 bundles are retained as the covariance/control sources.
+    source_primary = build_epoch((2, 2, 2), "primary", atlas)
+    source_alternate = build_epoch(
+        (2, 2, 2),
+        "alternate_port",
+        atlas,
+        recurrent_override=source_primary.recurrent,
+    )
+    source_bundles = {
+        "primary": source_primary,
+        "alternate_port": source_alternate,
+    }
+    end_to_end["2x2x2"] = {
+        variant: end_to_end_algebra(source_bundles[variant])
+        for variant in variants
+    }
+
+    boxes: dict[str, object] = {
+        "1x1x1": {
+            "shape": [1, 1, 1],
+            "scope": "algebra-only where defined",
+            "slot_counts_per_stage": {
+                variant: {
+                    stage: sum(
+                        slot.stage == stage
+                        for slot in (
+                            one_primary.slots
+                            if variant == "primary"
+                            else one_alternate.slots
+                        )
+                    )
+                    for stage in "ABCD"
+                }
+                for variant in variants
+            },
+        },
+        "2x2x2": {
+            variant: bundle_report(source_bundles[variant])
+            for variant in variants
+        },
+    }
+    namespace_by_box = {
+        "1x1x1": namespace_report(one_primary),
+        "2x2x2": namespace_report(source_primary),
+    }
+
+    for shape in ((3, 2, 2), (5, 3, 2)):
+        primary = build_epoch(shape, "primary", atlas)
+        alternate = build_epoch(
+            shape,
+            "alternate_port",
+            atlas,
+            recurrent_override=primary.recurrent,
+        )
+        key = "x".join(map(str, shape))
+        boxes[key] = {
+            "primary": bundle_report(primary),
+            "alternate_port": bundle_report(alternate),
+        }
+        namespace_by_box[key] = namespace_report(primary)
+
+    controls = controls_certificate(source_primary)
+    recurrent_integrity = recurrent_integrity_certificate()
+    fixtures = fixture_certificate()
+    covariance = covariance_certificate(atlas, source_bundles)
+
+    liveness_gate = all(
+        boxes[shape][variant]["lawful"]
+        for shape in ("2x2x2", "3x2x2", "5x3x2")
+        for variant in variants
+    )
+    algebra_gate = all(
+        end_to_end[shape][variant]["pass"]
+        for shape in ("1x1x1", "2x2x2")
+        for variant in variants
+    )
+    recurrent_gate = recurrent_integrity["pass"]
+    fixtures_gate = fixtures["pass"]
+    covariance_gate = covariance["pass"]
+    controls_gate = controls["all_four_detected"]
+
+    checks: list[dict[str, object]] = []
+
+    def check(label: str, condition: bool) -> None:
+        checks.append({"label": label, "pass": bool(condition)})
+        print("PASS" if condition else "FAIL", label)
+
+    check(
+        "both input-leg variants have zero slot-walk liveness, collision, and returned-route failures on every held liveness box",
+        liveness_gate,
+    )
+    check(
+        "the exhaustive signed generator family has exact staged-versus-flattened A/B/C tableau action with the unchanged certified G tail on 1x1x1 and 2x2x2",
+        algebra_gate,
+    )
+    check(
+        "the imported 3x2x2 recurrent one-step conjunction and 2x2x2 orientation/interleave/deletion gates remain exact",
+        recurrent_gate,
+    )
+    check(
+        "the three mass/contact and five Cycle-230 fixture residuals remain below 4e-10",
+        fixtures_gate,
+    )
+    check(
+        "both schedule variants transport over 24 frames x 8 parities with identical schedule-key and per-family census multisets and zero four-field coframe failures",
+        covariance_gate,
+    )
+    check(
+        "deleted handoff, deleted return word, hostile Stage-B-before-pump interleave, and duplicate-owner controls are all detected",
+        controls_gate,
+    )
+
+    passing = all(row["pass"] for row in checks)
+    runtime_seconds = perf_counter() - started
+    report = {
+        "status": "PASS" if passing else "FAIL",
+        "checks": checks,
+        "namespace": {
+            "by_box": namespace_by_box,
+            "allocation_rule": (
+                "code [0,q), F1 companion-encoded bank [q,2q), canonically "
+                "enumerated routed-only G coordinate sites, then all retained "
+                "ancilla/syndrome/purifier/coframe/rail allocations"
+            ),
+            "instruction_fields_printed_and_used": ("kind", "sites"),
+        },
+        "boxes": boxes,
+        "end_to_end": end_to_end,
+        "recurrent_integrity": recurrent_integrity,
+        "fixtures": fixtures,
+        "covariance": covariance,
+        "controls": controls,
+        "derived": (
+            "literal global register enumeration; exact slot-by-slot "
+            "clean/live/retained ownership; explicit producer-consumer "
+            "handoffs; returned-route checks; signed Clifford prefix "
+            "tableaux; transported schedule-key/census multisets; imported "
+            "recurrent and fixture regression certificates"
+        ),
+        "supplied": (
+            "one-time finite epoch; fixed sector and genesis inventory; "
+            "clean initial banks; declared root/router and program content; "
+            "the primary companion-encoded F1 bank and alternate declared "
+            "F2 port are both supplied input conventions"
+        ),
+        "open": (
+            "renewal or repeated-source composition; autonomous genesis, "
+            "sector choice, root choice, port choice, or program choice; "
+            "fault-tolerant realization; any continuum/time interpretation"
+        ),
+        "claim_boundary": (
+            "This proves one supplied collision-free finite epoch on the "
+            "held site maps. The supplied sector/genesis inventory is "
+            "unchanged. Both input legs are supplied conventions "
+            "(companion-encoded bank; declared port). No renewal, "
+            "multi-source composition, or autonomy is claimed. Circuit "
+            "ordinals are structure, not time. The claim is state-level "
+            "only and asserts no matter, FTL, mass, or charge transfer."
+        ),
+        "runtime_seconds": runtime_seconds,
+        "collision_free_joint_epoch_composed": bool(
+            liveness_gate
+            and algebra_gate
+            and recurrent_gate
+            and fixtures_gate
+            and covariance_gate
+            and controls_gate
+        ),
+        "authority": "none",
+        "audit": "unset",
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if not passing:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/frontier_cycle721_encoded_input_clifford_port_2026_07_28.py
+++ b/scripts/frontier_cycle721_encoded_input_clifford_port_2026_07_28.py
@@ -1,0 +1,1535 @@
+#!/usr/bin/env python3
+"""Cycle-721 direct local encoded-input Clifford port.
+
+This runner deliberately does not reconstruct the transient mixed-gauge V_s
+tableau.  It tests the direct dictionary-level coupling: a six-mode live input
+bank co-located with a declared port cell is exchanged with that cell's matter
+register, first on the local even-CAR generators and then on incident seam
+bilinears.
+"""
+
+from __future__ import annotations
+
+AUDIT_TIMEOUT_SEC = 900
+NOTE_PATH = (
+    "docs/CAR_BELL_INPUT_PHYSICAL_M2_COMPILER_CYCLE721_BOUNDED_"
+    "THEOREM_NOTE_2026-07-28.md"
+)
+AUDIT_INPUT_PATHS = (
+    "scripts/frontier_cycle720_cell_majorana_companion_geometry_2026_07_27.py",
+    "scripts/frontier_cycle720_companion_subsystem_mixed_gauge_factorization_2026_07_27.py",
+    "scripts/frontier_cycle720_companion_checkerboard_frame_cocycle_2026_07_27.py",
+    "scripts/frontier_cycle720_overlap_star_mixed_gauge_choi_2026_07_27.py",
+    "scripts/frontier_cycle720_companion_local_choi_tree_plaquette_pump_2026_07_27.py",
+    "docs/CAR_BELL_INPUT_PHYSICAL_M2_COMPILER_CYCLE721_BOUNDED_THEOREM_NOTE_2026-07-28.md",
+)
+DECLARED_INPUT_PATHS = AUDIT_INPUT_PATHS
+
+from collections import Counter
+from dataclasses import dataclass
+from itertools import combinations, permutations, product
+import json
+import time
+
+import numpy as np
+
+import frontier_cycle720_cell_majorana_companion_geometry_2026_07_27 as M
+import frontier_cycle720_companion_subsystem_mixed_gauge_factorization_2026_07_27 as F
+import frontier_cycle720_companion_checkerboard_frame_cocycle_2026_07_27 as Q
+import frontier_cycle720_overlap_star_mixed_gauge_choi_2026_07_27 as O
+import frontier_cycle720_companion_local_choi_tree_plaquette_pump_2026_07_27 as P
+
+
+@dataclass(frozen=True)
+class Row:
+    """Integer Pauli row i^phase X^x Z^z."""
+
+    phase: int = 0
+    x: int = 0
+    z: int = 0
+
+    def fields(self) -> tuple[int, int, int]:
+        return self.phase % 4, self.x, self.z
+
+
+@dataclass(frozen=True)
+class Gate:
+    kind: str
+    control: int
+    target: int = -1
+    pauli: Row = Row()
+
+
+def row(pauli) -> Row:
+    return Row(pauli.phase % 4, pauli.x, pauli.z)
+
+
+def multiply(left: Row, right: Row) -> Row:
+    return Row(
+        (
+            left.phase
+            + right.phase
+            + 2 * (left.z & right.x).bit_count()
+        )
+        % 4,
+        left.x ^ right.x,
+        left.z ^ right.z,
+    )
+
+
+def product_rows(rows) -> Row:
+    output = Row()
+    for item in rows:
+        output = multiply(output, item)
+    return output
+
+
+def anticommutes(left: Row, right: Row) -> int:
+    return (
+        (left.x & right.z).bit_count()
+        + (left.z & right.x).bit_count()
+    ) & 1
+
+
+def single_x(qubit: int) -> Row:
+    return Row(x=1 << qubit)
+
+
+def single_z(qubit: int) -> Row:
+    return Row(z=1 << qubit)
+
+
+def generator_image(gate: Gate, kind: str, qubit: int) -> Row:
+    base = single_x(qubit) if kind == "X" else single_z(qubit)
+    if gate.kind == "H":
+        if qubit != gate.control:
+            return base
+        return single_z(qubit) if kind == "X" else single_x(qubit)
+    if gate.kind == "CNOT":
+        c, t = gate.control, gate.target
+        if kind == "X" and qubit == c:
+            return Row(x=(1 << c) | (1 << t))
+        if kind == "Z" and qubit == t:
+            return Row(z=(1 << c) | (1 << t))
+        return base
+    if gate.kind == "CZ":
+        a, b = gate.control, gate.target
+        if kind == "X" and qubit == a:
+            return Row(x=1 << a, z=1 << b)
+        if kind == "X" and qubit == b:
+            return Row(x=1 << b, z=1 << a)
+        return base
+    if gate.kind == "CP":
+        c = gate.control
+        if kind == "X" and qubit == c:
+            return multiply(single_x(c), gate.pauli)
+        if qubit == c:
+            return base
+        if anticommutes(base, gate.pauli):
+            return multiply(single_z(c), base)
+        return base
+    raise ValueError(f"unknown gate {gate.kind}")
+
+
+def conjugate_gate(input_row: Row, gate: Gate) -> Row:
+    """Conjugate by one Clifford using exact signed generator images."""
+    output = Row(phase=input_row.phase % 4)
+    bits = input_row.x
+    while bits:
+        low = bits & -bits
+        qubit = low.bit_length() - 1
+        output = multiply(output, generator_image(gate, "X", qubit))
+        bits ^= low
+    bits = input_row.z
+    while bits:
+        low = bits & -bits
+        qubit = low.bit_length() - 1
+        output = multiply(output, generator_image(gate, "Z", qubit))
+        bits ^= low
+    return output
+
+
+def conjugate_word(input_row: Row, word: tuple[Gate, ...]) -> Row:
+    output = input_row
+    for gate in word:
+        output = conjugate_gate(output, gate)
+    return output
+
+
+def swap_block(left: int, right: int) -> tuple[Gate, ...]:
+    return (
+        Gate("CNOT", left, right),
+        Gate("CNOT", right, left),
+        Gate("CNOT", left, right),
+    )
+
+
+def port_word(fixture, port: int) -> tuple[Gate, ...]:
+    bank = fixture.qubits
+    output = []
+    for mode in range(6):
+        output.extend(swap_block(bank + mode, 6 * port + mode))
+    return tuple(output)
+
+
+def bank_gamma(fixture, port: int, mode: int, odd: bool) -> Row:
+    del port  # the one live bank is declared at the selected port cell
+    endpoint = fixture.qubits + mode
+    prefix = sum(1 << (fixture.qubits + item) for item in range(mode))
+    return Row(
+        phase=int(odd),
+        x=1 << endpoint,
+        z=prefix | ((1 << endpoint) if odd else 0),
+    )
+
+
+def replace_port_matter_with_bank(
+    input_row: Row, fixture, port: int
+) -> Row:
+    x, z = input_row.x, input_row.z
+    for mode in range(6):
+        matter_bit = 1 << (6 * port + mode)
+        bank_bit = 1 << (fixture.qubits + mode)
+        if x & matter_bit:
+            x ^= matter_bit | bank_bit
+        if z & matter_bit:
+            z ^= matter_bit | bank_bit
+    return Row(input_row.phase, x, z)
+
+
+def dense_row(input_row: Row, qubits: int) -> np.ndarray:
+    identity = np.eye(2, dtype=complex)
+    x_matrix = np.array([[0, 1], [1, 0]], dtype=complex)
+    z_matrix = np.array([[1, 0], [0, -1]], dtype=complex)
+    factors = []
+    for qubit in reversed(range(qubits)):
+        local = identity
+        if (input_row.x >> qubit) & 1:
+            local = local @ x_matrix
+        if (input_row.z >> qubit) & 1:
+            local = local @ z_matrix
+        factors.append(local)
+    output = factors[0]
+    for factor in factors[1:]:
+        output = np.kron(output, factor)
+    return (1j ** (input_row.phase % 4)) * output
+
+
+def dense_gate(gate: Gate, qubits: int) -> np.ndarray:
+    dimension = 1 << qubits
+    if gate.kind == "H":
+        return (
+            dense_row(single_x(gate.control), qubits)
+            + dense_row(single_z(gate.control), qubits)
+        ) / np.sqrt(2.0)
+    if gate.kind == "CNOT":
+        output = np.zeros((dimension, dimension), dtype=complex)
+        for basis in range(dimension):
+            target = basis
+            if (basis >> gate.control) & 1:
+                target ^= 1 << gate.target
+            output[target, basis] = 1.0
+        return output
+    if gate.kind == "CZ":
+        output = np.eye(dimension, dtype=complex)
+        for basis in range(dimension):
+            if ((basis >> gate.control) & 1) and (
+                (basis >> gate.target) & 1
+            ):
+                output[basis, basis] = -1.0
+        return output
+    if gate.kind == "CP":
+        z_control = dense_row(single_z(gate.control), qubits)
+        identity = np.eye(dimension, dtype=complex)
+        p0 = (identity + z_control) / 2
+        p1 = (identity - z_control) / 2
+        return p0 + p1 @ dense_row(gate.pauli, qubits)
+    raise ValueError(gate.kind)
+
+
+def dense_selftest() -> dict[str, object]:
+    """All signed weight-one/two Paulis against dense three-qubit gates."""
+    base_rows = []
+    local = (
+        Row(),
+        Row(x=1),
+        Row(phase=1, x=1, z=1),
+        Row(z=1),
+    )
+    for labels in product(range(4), repeat=3):
+        weight = sum(label != 0 for label in labels)
+        if weight not in (1, 2):
+            continue
+        canonical = Row()
+        for qubit, label in enumerate(labels):
+            item = local[label]
+            shifted = Row(
+                item.phase,
+                item.x << qubit,
+                item.z << qubit,
+            )
+            canonical = multiply(canonical, shifted)
+        for extra_phase in range(4):
+            base_rows.append(
+                Row(
+                    canonical.phase + extra_phase,
+                    canonical.x,
+                    canonical.z,
+                )
+            )
+
+    gates = []
+    gates.extend(Gate("H", qubit) for qubit in range(3))
+    gates.extend(
+        Gate("CNOT", control, target)
+        for control in range(3)
+        for target in range(3)
+        if control != target
+    )
+    gates.extend(Gate("CZ", left, right) for left, right in combinations(range(3), 2))
+    for control in range(3):
+        targets = tuple(qubit for qubit in range(3) if qubit != control)
+        for labels in product(range(4), repeat=len(targets)):
+            if not any(labels):
+                continue
+            pauli = Row()
+            for target, label in zip(targets, labels):
+                item = local[label]
+                pauli = multiply(
+                    pauli,
+                    Row(item.phase, item.x << target, item.z << target),
+                )
+            gates.append(Gate("CP", control, pauli=pauli))
+
+    mismatches = 0
+    maximum_residual = 0.0
+    for gate in gates:
+        unitary = dense_gate(gate, 3)
+        for input_row in base_rows:
+            actual = dense_row(conjugate_gate(input_row, gate), 3)
+            expected = unitary @ dense_row(input_row, 3) @ unitary.conj().T
+            residual = float(np.max(np.abs(actual - expected)))
+            maximum_residual = max(maximum_residual, residual)
+            mismatches += residual > 1e-10
+    return {
+        "pauli_rows": len(base_rows),
+        "gates": len(gates),
+        "comparisons": len(base_rows) * len(gates),
+        "mismatches": mismatches,
+        "maximum_residual": maximum_residual,
+    }
+
+
+def fixture_for_cells(cells):
+    return O.arbitrary_fixture(tuple(cells))
+
+
+def fixture_for_shape(shape: tuple[int, int, int]):
+    return fixture_for_cells(Q.shape_cells(shape))
+
+
+def displayed_shape(fixture) -> list[int]:
+    return [
+        max(cell[axis] for cell in fixture.cells)
+        - min(cell[axis] for cell in fixture.cells)
+        + 1
+        for axis in range(3)
+    ]
+
+
+def fixture_path_equivalence() -> dict[str, object]:
+    union_fixture = fixture_for_shape((2, 2, 2))
+    bare_fixture = M.CompanionFixture.build((2, 2, 2))
+    return {
+        "shape": [2, 2, 2],
+        "cells_identical": union_fixture.cells == bare_fixture.cells,
+        "edges_identical": union_fixture.edges == bare_fixture.edges,
+        "matter_qubits_identical": (
+            union_fixture.matter_qubits == bare_fixture.matter_qubits
+        ),
+        "qubits_identical": union_fixture.qubits == bare_fixture.qubits,
+        "used_constructor": "O.arbitrary_fixture(Q.shape_cells(shape))",
+    }
+
+
+def support_census(fixture, port: int, word: tuple[Gate, ...]) -> dict[str, int]:
+    cells = set()
+    for gate in word:
+        qubits = [gate.control]
+        if gate.target >= 0:
+            qubits.append(gate.target)
+        qubits.extend(
+            qubit
+            for qubit in range(fixture.qubits + 6)
+            if ((gate.pauli.x | gate.pauli.z) >> qubit) & 1
+        )
+        for qubit in qubits:
+            if qubit >= fixture.qubits:
+                cells.add(port)
+            else:
+                cells.add(M.qubit_cell(fixture, qubit))
+    diameter = max(
+        (
+            sum(
+                abs(a - b)
+                for a, b in zip(fixture.cells[left], fixture.cells[right])
+            )
+            for left in cells
+            for right in cells
+        ),
+        default=0,
+    )
+    return {
+        "support_cells": len(cells),
+        "diameter": diameter,
+        "primitive_count": len(word),
+        "route_transitions": 0,
+    }
+
+
+def port_target_rows(fixture, port: int) -> tuple[tuple[Row, Row], ...]:
+    targets = []
+    for mode in range(6):
+        targets.append(
+            (
+                single_z(fixture.qubits + mode),
+                single_z(6 * port + mode),
+            )
+        )
+    for mode in range(5):
+        targets.append(
+            (
+                Row(
+                    x=(1 << (fixture.qubits + mode))
+                    | (1 << (fixture.qubits + mode + 1))
+                ),
+                Row(
+                    x=(1 << (6 * port + mode))
+                    | (1 << (6 * port + mode + 1))
+                ),
+            )
+        )
+    return tuple(targets)
+
+
+def port_dictionary_pairs(
+    fixture, port: int
+) -> tuple[tuple[Row, Row], ...]:
+    """Bank/physical pairs for the full onsite dictionary at one cell."""
+    cell_mask = sum(1 << (6 * port + mode) for mode in range(6))
+    cell_mask |= sum(
+        1 << (fixture.matter_qubits + 3 * port + mode)
+        for mode in range(3)
+    )
+    pairs = []
+    for family, physical_pauli, _target in M.operator_rows(fixture):
+        if family not in ("onsite_B", "onsite_even"):
+            continue
+        physical = row(physical_pauli)
+        support = physical.x | physical.z
+        if support and not support & ~cell_mask:
+            pairs.append(
+                (
+                    replace_port_matter_with_bank(physical, fixture, port),
+                    physical,
+                )
+            )
+    return tuple(pairs)
+
+
+def dictionary_port_generation_certificate(fixture, port: int) -> dict[str, int]:
+    dictionary = M.operator_rows(fixture)
+    onsite_identity_failures = sum(
+        row(physical).fields() != row(target).fields()
+        for family, physical, target in dictionary
+        if family in ("onsite_B", "onsite_even")
+    )
+    missing = 0
+    multiplicity_failures = 0
+    for _bank, physical in port_target_rows(fixture, port):
+        matches = sum(
+            row(candidate).fields() == physical.fields()
+            for family, candidate, _target in dictionary
+            if family in ("onsite_B", "onsite_even")
+        )
+        missing += matches == 0
+        multiplicity_failures += matches != 1
+    return {
+        "onsite_physical_target_identity_failures": onsite_identity_failures,
+        "declared_11_generator_missing_failures": missing,
+        "declared_11_generator_multiplicity_failures": multiplicity_failures,
+    }
+
+
+def parity_certificate(fixture, port: int, word: tuple[Gate, ...]) -> dict[str, int]:
+    bank_parity = Row(
+        z=sum(1 << (fixture.qubits + mode) for mode in range(6))
+    )
+    matter = sum(1 << (6 * port + mode) for mode in range(6))
+    companion = sum(
+        1 << (fixture.matter_qubits + 3 * port + mode)
+        for mode in range(3)
+    )
+    cell_parity = Row(z=matter | companion)
+    expected_cell_image = Row(z=bank_parity.z | companion)
+    total = multiply(cell_parity, bank_parity)
+    odd_detection_failures = 0
+    odd_image_detection_failures = 0
+    for mode in range(6):
+        odd = single_x(fixture.qubits + mode)
+        odd_detection_failures += anticommutes(odd, total) != 1
+        odd_image_detection_failures += (
+            anticommutes(conjugate_word(odd, word), total) != 1
+        )
+    return {
+        "cell_parity_image_failures": (
+            conjugate_word(cell_parity, word).fields()
+            != expected_cell_image.fields()
+        ),
+        "total_joint_parity_invariance_failures": (
+            conjugate_word(total, word).fields() != total.fields()
+        ),
+        "odd_bank_detection_failures": odd_detection_failures,
+        "odd_matter_image_detection_failures": odd_image_detection_failures,
+    }
+
+
+def incident_edges_by_axis(fixture, port: int) -> dict[int, int]:
+    output = {}
+    for edge, record in enumerate(fixture.edges):
+        left, right, _owner, axis, _left_mode, _right_mode = record
+        if port in (left, right) and axis not in output:
+            output[axis] = edge
+    return output
+
+
+def part1_certificate(fixture) -> dict[str, object]:
+    port = fixture.cells.index(min(fixture.cells))
+    word = port_word(fixture, port)
+    dictionary = M.operator_rows(fixture)
+    generation = dictionary_port_generation_certificate(fixture, port)
+
+    forward_failures = sum(
+        conjugate_word(bank, word).fields() != physical.fields()
+        for bank, physical in port_target_rows(fixture, port)
+    )
+    reverse_failures = sum(
+        conjugate_word(physical, word).fields() != bank.fields()
+        for bank, physical in port_target_rows(fixture, port)
+    )
+    port_dictionary_pairs_at_cell = port_dictionary_pairs(fixture, port)
+    forward_dictionary_failures = sum(
+        conjugate_word(bank, word).fields() != physical.fields()
+        for bank, physical in port_dictionary_pairs_at_cell
+    )
+
+    onsite_exchange_failures = 0
+    onsite_other_cell_invariance_failures = 0
+    seam_incident_failures = 0
+    seam_nonincident_invariance_failures = 0
+    seam_cursor = 0
+    for family, physical_pauli, _target in dictionary:
+        physical = row(physical_pauli)
+        actual = conjugate_word(physical, word)
+        if family == "seam":
+            edge = seam_cursor // 4
+            seam_cursor += 1
+            left, right, *_rest = fixture.edges[edge]
+            if port in (left, right):
+                expected = replace_port_matter_with_bank(
+                    physical, fixture, port
+                )
+                seam_incident_failures += actual.fields() != expected.fields()
+            else:
+                seam_nonincident_invariance_failures += (
+                    actual.fields() != physical.fields()
+                )
+            continue
+        support_on_port = bool(
+            (physical.x | physical.z)
+            & sum(1 << (6 * port + mode) for mode in range(6))
+        )
+        if support_on_port:
+            expected = replace_port_matter_with_bank(physical, fixture, port)
+            onsite_exchange_failures += actual.fields() != expected.fields()
+        else:
+            onsite_other_cell_invariance_failures += (
+                actual.fields() != physical.fields()
+            )
+
+    parity = parity_certificate(fixture, port, word)
+    census = support_census(fixture, port, word)
+    return {
+        "shape": displayed_shape(fixture),
+        "cells": len(fixture.cells),
+        "port_cell_index": port,
+        "port_cell": list(fixture.cells[port]),
+        "generation": generation,
+        "forward_11_even_CAR_failures": forward_failures,
+        "reverse_11_even_CAR_failures": reverse_failures,
+        "port_onsite_dictionary_rows": len(port_dictionary_pairs_at_cell),
+        "forward_port_onsite_dictionary_exchange_failures": (
+            forward_dictionary_failures
+        ),
+        "port_onsite_dictionary_exchange_failures": onsite_exchange_failures,
+        "other_cell_onsite_invariance_failures": (
+            onsite_other_cell_invariance_failures
+        ),
+        "incident_seam_exchange_failures": seam_incident_failures,
+        "nonincident_seam_invariance_failures": (
+            seam_nonincident_invariance_failures
+        ),
+        "parity": parity,
+        "census": census,
+        "gate_pass": census["support_cells"] <= 2 and census["diameter"] <= 1,
+    }
+
+
+def seam_source_target_rows(fixture, port: int, edge: int):
+    left, right, _owner, _axis, left_mode, right_mode = fixture.edges[edge]
+    physical = tuple(row(item) for item in fixture.physical_terms(edge))
+    left_local, right_local = left_mode % 6, right_mode % 6
+
+    def endpoint(cell: int, mode: int, odd: bool) -> Row:
+        if cell == port:
+            return multiply(
+                bank_gamma(fixture, port, mode, odd),
+                row(fixture.companion_eta(cell, mode)),
+            )
+        return row(fixture.endpoint(cell, mode, odd))
+
+    source = (
+        (
+            single_z(fixture.qubits + left_local)
+            if left == port else single_z(left_mode)
+        ),
+        (
+            single_z(fixture.qubits + right_local)
+            if right == port else single_z(right_mode)
+        ),
+        product_rows(
+            (
+                Row(phase=2),
+                endpoint(left, left_local, False),
+                endpoint(right, right_local, True),
+            )
+        ),
+        product_rows(
+            (
+                endpoint(left, left_local, True),
+                endpoint(right, right_local, False),
+            )
+        ),
+    )
+    replacement_source = tuple(
+        replace_port_matter_with_bank(item, fixture, port)
+        for item in physical
+    )
+    replacement_failures = sum(
+        explicit.fields() != replaced.fields()
+        for explicit, replaced in zip(source, replacement_source)
+    )
+    return source, physical, replacement_failures
+
+
+def row_distance(left: Row, right: Row) -> int:
+    return (
+        (left.x ^ right.x).bit_count()
+        + (left.z ^ right.z).bit_count()
+        + int((left.phase - right.phase) % 4 != 0)
+    )
+
+
+def greedy_symplectic_transvection_word(
+    fixture, port: int, source: tuple[Row, ...], target: tuple[Row, ...]
+) -> tuple[tuple[Gate, ...], dict[str, object]]:
+    """Greedy CNOT-transvection synthesis, parity-completed on six modes.
+
+    The seam pairs alone can underdetermine higher bank modes.  The requested
+    Part-1 parity image fixes that freedom.  Candidate three-CNOT swaps are
+    accepted in their best score order; all are needed by the parity-complete
+    signed-pair system.
+    """
+    bank_parity = Row(
+        z=sum(1 << (fixture.qubits + mode) for mode in range(6))
+    )
+    matter_parity = Row(
+        z=sum(1 << (6 * port + mode) for mode in range(6))
+    )
+    augmented_source = (*source, bank_parity)
+    augmented_target = (*target, matter_parity)
+    chosen: list[Gate] = []
+    remaining = set(range(6))
+    score_trace = []
+    while remaining:
+        candidates = []
+        for mode in sorted(remaining):
+            trial = (*chosen, *swap_block(
+                fixture.qubits + mode, 6 * port + mode
+            ))
+            score = sum(
+                row_distance(conjugate_word(left, trial), right)
+                for left, right in zip(augmented_source, augmented_target)
+            )
+            candidates.append((score, mode, trial))
+        score, mode, trial = min(candidates)
+        chosen = list(trial)
+        remaining.remove(mode)
+        score_trace.append({"mode": mode, "remaining_score": score})
+    final_failures = sum(
+        conjugate_word(left, tuple(chosen)).fields() != right.fields()
+        for left, right in zip(augmented_source, augmented_target)
+    )
+    return tuple(chosen), {
+        "method": "greedy elementary symplectic CNOT transvections with parity completion",
+        "score_trace": score_trace,
+        "augmented_signed_pairs": len(augmented_source),
+        "final_pair_failures": final_failures,
+    }
+
+
+def oriented_seam_target_rows(
+    fixture, edge: int, reverse_orientation: bool
+) -> tuple[Row, ...]:
+    """Rebuild the four physical seam factors in either endpoint orientation."""
+    left, right, _owner, _axis, left_mode, right_mode = fixture.edges[edge]
+    left_local, right_local = left_mode % 6, right_mode % 6
+    if reverse_orientation:
+        left, right = right, left
+        left_local, right_local = right_local, left_local
+
+    def endpoint(cell: int, mode: int, odd: bool) -> Row:
+        return row(fixture.endpoint(cell, mode, odd))
+
+    return (
+        single_z(6 * left + left_local),
+        single_z(6 * right + right_local),
+        product_rows(
+            (
+                Row(phase=2),
+                endpoint(left, left_local, False),
+                endpoint(right, right_local, True),
+            )
+        ),
+        product_rows(
+            (
+                endpoint(left, left_local, True),
+                endpoint(right, right_local, False),
+            )
+        ),
+    )
+
+
+def rebuilt_seam_images(
+    fixture, port: int, edge: int, reverse_orientation: bool = False
+) -> tuple[Row, ...]:
+    """Conjugate one bank-ended seam quadruple through its rebuilt seam word."""
+    if reverse_orientation:
+        target = oriented_seam_target_rows(fixture, edge, True)
+        source = tuple(
+            replace_port_matter_with_bank(item, fixture, port)
+            for item in target
+        )
+    else:
+        source, target, _explicit_failures = seam_source_target_rows(
+            fixture, port, edge
+        )
+    seam_word, _synthesis = greedy_symplectic_transvection_word(
+        fixture, port, source, target
+    )
+    return tuple(conjugate_word(item, seam_word) for item in source)
+
+
+def seam_certificate(fixture, port: int, edge: int) -> dict[str, object]:
+    source, target, explicit_source_failures = seam_source_target_rows(
+        fixture, port, edge
+    )
+    word, synthesis = greedy_symplectic_transvection_word(
+        fixture, port, source, target
+    )
+    seam_failures = sum(
+        conjugate_word(left, word).fields() != right.fields()
+        for left, right in zip(source, target)
+    )
+    swapped_port_mask = sum(1 << (6 * port + mode) for mode in range(6))
+    dictionary_invariance_failures = 0
+    dictionary_invariance_rows = 0
+    seam_cursor = 0
+    for family, physical_pauli, _logical in M.operator_rows(fixture):
+        physical = row(physical_pauli)
+        current_edge = None
+        if family == "seam":
+            current_edge = seam_cursor // 4
+            seam_cursor += 1
+        involved = current_edge == edge or bool(
+            (physical.x | physical.z) & swapped_port_mask
+        )
+        if not involved:
+            dictionary_invariance_rows += 1
+            dictionary_invariance_failures += (
+                conjugate_word(physical, word).fields() != physical.fields()
+            )
+    parity = parity_certificate(fixture, port, word)
+    census = support_census(fixture, port, word)
+    left, right, _owner, axis, _lm, _rm = fixture.edges[edge]
+    other = right if left == port else left
+    route = ()
+    route_forward_failures, route_inverse_failures = (
+        P.route_execution_failures(fixture.cells[port], route)
+    )
+    return {
+        "edge": edge,
+        "axis": axis,
+        "other_endpoint_cell_index": other,
+        "explicit_bank_Majorana_source_construction_failures": (
+            explicit_source_failures
+        ),
+        "four_seam_image_failures": seam_failures,
+        "noninvolved_dictionary_rows": dictionary_invariance_rows,
+        "noninvolved_dictionary_invariance_failures": (
+            dictionary_invariance_failures
+        ),
+        "parity": parity,
+        "synthesis": synthesis,
+        "routing": {
+            "needed_noncolocated_primitive": False,
+            "returned_route": route,
+            "forward_failures": route_forward_failures,
+            "inverse_failures": route_inverse_failures,
+        },
+        "census": census,
+        "gate_pass": census["support_cells"] <= 2 and census["diameter"] <= 1,
+    }
+
+
+def part2_certificate(fixture) -> dict[str, object]:
+    port = fixture.cells.index(min(fixture.cells))
+    selected = incident_edges_by_axis(fixture, port)
+    axes = {
+        str(axis): seam_certificate(fixture, port, edge)
+        for axis, edge in sorted(selected.items())
+    }
+    return {
+        "port_cell_index": port,
+        "tested_axes": len(axes),
+        "axes": axes,
+        "all_four_seam_images_exact": all(
+            item["explicit_bank_Majorana_source_construction_failures"] == 0
+            and item["four_seam_image_failures"] == 0
+            for item in axes.values()
+        ),
+        "all_noninvolved_dictionary_rows_invariant": all(
+            item["noninvolved_dictionary_invariance_failures"] == 0
+            for item in axes.values()
+        ),
+        "all_parity_bookkeeping_exact": all(
+            not any(item["parity"].values()) for item in axes.values()
+        ),
+        "all_routes_returned": all(
+            item["routing"]["forward_failures"] == 0
+            and item["routing"]["inverse_failures"] == 0
+            for item in axes.values()
+        ),
+        "gate_pass": all(item["gate_pass"] for item in axes.values()),
+    }
+
+
+def proper_cubic_frames() -> tuple[np.ndarray, ...]:
+    frames = []
+    for permutation in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            frame = np.zeros((3, 3), dtype=int)
+            for target_axis, source_axis in enumerate(permutation):
+                frame[target_axis, source_axis] = signs[target_axis]
+            if round(np.linalg.det(frame)) == 1:
+                frames.append(frame)
+    assert len(frames) == 24
+    return tuple(frames)
+
+
+def canonicalize_row(
+    input_row: Row, fixture, port: int, other: int | None = None
+) -> tuple[int, int, int]:
+    mapping = {}
+    for mode in range(6):
+        mapping[6 * port + mode] = mode
+    for mode in range(3):
+        mapping[fixture.matter_qubits + 3 * port + mode] = 6 + mode
+    if other is not None:
+        for mode in range(6):
+            mapping[6 * other + mode] = 9 + mode
+        for mode in range(3):
+            mapping[fixture.matter_qubits + 3 * other + mode] = 15 + mode
+    for mode in range(6):
+        mapping[fixture.qubits + mode] = 18 + mode
+    x = z = 0
+    unknown = 0
+    for old in range(fixture.qubits + 6):
+        active_x = (input_row.x >> old) & 1
+        active_z = (input_row.z >> old) & 1
+        if not (active_x or active_z):
+            continue
+        if old not in mapping:
+            unknown += 1
+            continue
+        new = mapping[old]
+        x |= active_x << new
+        z |= active_z << new
+    if unknown:
+        raise AssertionError("row escaped declared port/edge union")
+    return input_row.phase % 4, x, z
+
+
+def covariance_signature(
+    fixture, port: int | None = None
+) -> tuple[Counter, Counter, tuple]:
+    if port is None:
+        port = fixture.cells.index(min(fixture.cells))
+    word = port_word(fixture, port)
+    port_images = Counter(
+        canonicalize_row(conjugate_word(bank, word), fixture, port)
+        for bank, _target in port_dictionary_pairs(fixture, port)
+    )
+    seam_images = Counter()
+    seam_census = []
+    for axis, edge in sorted(incident_edges_by_axis(fixture, port).items()):
+        source, target, _explicit_failures = seam_source_target_rows(
+            fixture, port, edge
+        )
+        seam_word, _synthesis = greedy_symplectic_transvection_word(
+            fixture, port, source, target
+        )
+        left, right, *_rest = fixture.edges[edge]
+        other = right if left == port else left
+        for item in source:
+            seam_images[canonicalize_row(
+                conjugate_word(item, seam_word), fixture, port, other
+            )] += 1
+        census = support_census(fixture, port, seam_word)
+        seam_census.append(
+            (
+                axis,
+                census["support_cells"],
+                census["diameter"],
+                census["primitive_count"],
+                census["route_transitions"],
+            )
+        )
+    port_census = support_census(fixture, port, word)
+    census_vector = (
+        port_census["support_cells"],
+        port_census["diameter"],
+        port_census["primitive_count"],
+        port_census["route_transitions"],
+        tuple(sorted(item[1:] for item in seam_census)),
+    )
+    return port_images, seam_images, census_vector
+
+
+def apply_physical_images(
+    input_row: Row, images
+) -> Row:
+    """Apply Q's signed physical X/Z generator images to one source row."""
+    x_images, z_images = images
+    output = Row(phase=input_row.phase % 4)
+    bits = input_row.x
+    while bits:
+        low = bits & -bits
+        qubit = low.bit_length() - 1
+        output = multiply(output, row(x_images[qubit]))
+        bits ^= low
+    bits = input_row.z
+    while bits:
+        low = bits & -bits
+        qubit = low.bit_length() - 1
+        output = multiply(output, row(z_images[qubit]))
+        bits ^= low
+    return output
+
+
+def binary_fields(input_row: Row) -> tuple[int, int]:
+    return input_row.x, input_row.z
+
+
+def physical_output_multisets(
+    fixture, port: int | None = None
+) -> tuple[Counter, dict[int, tuple[Row, ...]]]:
+    """Full port dictionary multiset and ordered incident-edge seam images."""
+    if port is None:
+        port = fixture.cells.index(min(fixture.cells))
+    word = port_word(fixture, port)
+    port_images = Counter(
+        conjugate_word(bank, word).fields()
+        for bank, _target in port_dictionary_pairs(fixture, port)
+    )
+    seam_images = {}
+    for _axis, edge in sorted(incident_edges_by_axis(fixture, port).items()):
+        seam_images[edge] = rebuilt_seam_images(fixture, port, edge)
+    return port_images, seam_images
+
+
+def transported_edge_lookup(
+    source, source_edge: int, target, frame, shift
+) -> int | None:
+    left, right, *_rest = source.edges[source_edge]
+    endpoint_coordinates = frozenset(
+        tuple(
+            int(value)
+            for value in (
+                frame @ np.asarray(source.cells[cell])
+                + np.asarray(shift)
+            )
+        )
+        for cell in (left, right)
+    )
+    for edge, record in enumerate(target.edges):
+        target_left, target_right, *_target_rest = record
+        if frozenset(
+            (
+                target.cells[target_left],
+                target.cells[target_right],
+            )
+        ) == endpoint_coordinates:
+            return edge
+    return None
+
+
+def seam_factor_index_class(
+    transported: tuple[Row, ...], rebuilt_forward: tuple[Row, ...]
+) -> tuple[int, ...] | None:
+    factor_indices = []
+    for transported_row in transported:
+        matches = tuple(
+            factor
+            for factor, target_row in enumerate(rebuilt_forward)
+            if binary_fields(transported_row) == binary_fields(target_row)
+        )
+        if len(matches) != 1:
+            return None
+        factor_indices.append(matches[0])
+    return tuple(factor_indices)
+
+
+def covariance_certificate(
+    shape: tuple[int, int, int]
+) -> dict[str, object]:
+    frames = proper_cubic_frames()
+    shifts = tuple(product((0, 1), repeat=3))
+    source = fixture_for_shape(shape)
+    source_port = source.cells.index(min(source.cells))
+    source_port_rows, source_seam_rows = physical_output_multisets(source)
+    reference_census = covariance_signature(source)[2]
+    signed_port_dictionary_failures = 0
+    binary_port_dictionary_failures = 0
+    signed_seam_class_failures = 0
+    binary_seam_failures = 0
+    census_failures = 0
+    lexicographic_min_not_transported = 0
+    port_relocations = Counter()
+    for frame in frames:
+        for shift in shifts:
+            transformed_cells = Q.affine_cells(
+                source.cells, frame, shift
+            )
+            fixture = fixture_for_cells(transformed_cells)
+            source_port_image = tuple(
+                int(value)
+                for value in (
+                    frame @ np.asarray(source.cells[source_port])
+                    + np.asarray(shift)
+                )
+            )
+            # The port is supplied chart data: it transports with the frame.
+            # The lexicographic-minimum default used at build time is a
+            # convention, not a covariant object; count how often they differ
+            # as an informational census only.
+            port = fixture.cells.index(source_port_image)
+            port_relocations[fixture.cells[port]] += 1
+            lexicographic_min_not_transported += (
+                source_port_image != min(fixture.cells)
+            )
+
+            images = Q.physical_images(source, fixture, frame, shift)
+            transported_port = Counter()
+            for fields, multiplicity in source_port_rows.items():
+                transported = apply_physical_images(Row(*fields), images)
+                transported_port[transported.fields()] += multiplicity
+
+            target_port, target_seam = physical_output_multisets(
+                fixture, port
+            )
+            signed_port_dictionary_failures += (
+                transported_port != target_port
+            )
+            binary_port_dictionary_failures += Counter(
+                (x, z)
+                for (_phase, x, z), multiplicity
+                in transported_port.items()
+                for _copy in range(multiplicity)
+            ) != Counter(
+                (x, z)
+                for (_phase, x, z), multiplicity in target_port.items()
+                for _copy in range(multiplicity)
+            )
+
+            for source_edge, source_quadruple in source_seam_rows.items():
+                target_edge = transported_edge_lookup(
+                    source, source_edge, fixture, frame, shift
+                )
+                transported_quadruple = tuple(
+                    apply_physical_images(item, images)
+                    for item in source_quadruple
+                )
+                if target_edge is None or target_edge not in target_seam:
+                    signed_seam_class_failures += 1
+                    binary_seam_failures += 1
+                    continue
+
+                rebuilt_forward = target_seam[target_edge]
+                binary_seam_failures += Counter(
+                    binary_fields(item) for item in transported_quadruple
+                ) != Counter(
+                    binary_fields(item) for item in rebuilt_forward
+                )
+                factor_class = seam_factor_index_class(
+                    transported_quadruple, rebuilt_forward
+                )
+                if factor_class == (0, 1, 2, 3):
+                    signed_match = all(
+                        transported.fields() == rebuilt.fields()
+                        for transported, rebuilt in zip(
+                            transported_quadruple, rebuilt_forward
+                        )
+                    )
+                elif factor_class == (1, 0, 3, 2):
+                    rebuilt_reversed = rebuilt_seam_images(
+                        fixture, port, target_edge, True
+                    )
+                    reversed_class = seam_factor_index_class(
+                        rebuilt_reversed, rebuilt_forward
+                    )
+                    signed_match = (
+                        reversed_class == (1, 0, 3, 2)
+                        and all(
+                            transported.fields() == rebuilt.fields()
+                            for transported, rebuilt in zip(
+                                transported_quadruple, rebuilt_reversed
+                            )
+                        )
+                    )
+                else:
+                    signed_match = False
+                signed_seam_class_failures += not signed_match
+
+            census_failures += (
+                covariance_signature(fixture, port)[2] != reference_census
+            )
+    return {
+        "shape": list(shape),
+        "frames": len(frames),
+        "translation_parities": len(shifts),
+        "contexts": len(frames) * len(shifts),
+        "port_rule": (
+            "rebuilt at the transported image of the source port; the "
+            "lexicographic-minimum default is a supplied chart convention "
+            "and is not frame-covariant"
+        ),
+        "frame_action": "Q.physical_images exact signed generator transport",
+        "distinct_relocated_port_coordinates": len(port_relocations),
+        "lexicographic_min_port_not_transported_contexts": (
+            lexicographic_min_not_transported
+        ),
+        "signed_port_dictionary_multiset_failures": (
+            signed_port_dictionary_failures
+        ),
+        "binary_port_dictionary_multiset_failures": (
+            binary_port_dictionary_failures
+        ),
+        "signed_seam_image_class_failures": signed_seam_class_failures,
+        "binary_seam_multiset_failures": binary_seam_failures,
+        "census_vector_failures": census_failures,
+        "failures": (
+            signed_port_dictionary_failures
+            + binary_port_dictionary_failures
+            + signed_seam_class_failures
+            + binary_seam_failures
+            + census_failures
+        ),
+    }
+
+
+def factorization_anchor_certificate() -> dict[str, object]:
+    output = {}
+    for shape in ((2, 2, 2), (3, 2, 2)):
+        report = F.phase_fixed_factorization(shape)
+        phase = report["phase_fixed_intertwiner"]
+        coordinate_fields = (
+            "logical_coordinate_failures",
+            "gauge_coordinate_failures_for_every_physical_generator",
+            "parity_coordinate_failures",
+            "phase_parity_failures",
+            "phase_contradictions",
+            "even_sector_phase_failures",
+            "odd_sector_phase_failures",
+            "canonical_tableau_pairing_failures",
+        )
+        coordinate_failures = sum(int(phase[name]) for name in coordinate_fields)
+        output["x".join(map(str, shape))] = {
+            "shape": list(shape),
+            "dimension_identity": bool(report["dimension_identity"]),
+            "finite_box_mixed_gauge_CPTP_E_constructed": bool(
+                phase["finite_box_mixed_gauge_CPTP_E_constructed"]
+            ),
+            "factorwise_full_word_intertwiner_exact": bool(
+                phase["factorwise_full_word_intertwiner_exact"]
+            ),
+            "coordinate_failures": coordinate_failures,
+            "coordinate_failure_fields": {
+                name: phase[name] for name in coordinate_fields
+            },
+            "tableau_digest": report["tableau_digest"],
+            "locality": report["locality"],
+        }
+    return {
+        "boxes": output,
+        "all_regressions_pass": all(
+            item["dimension_identity"]
+            and item["finite_box_mixed_gauge_CPTP_E_constructed"]
+            and item["factorwise_full_word_intertwiner_exact"]
+            and item["coordinate_failures"] == 0
+            for item in output.values()
+        ),
+        "v_s_coordinate_rows_returned": False,
+        "literal_v_s_restriction_compiled": False,
+        "census_role": (
+            "reported measured ceiling for a future literal V_s-restriction "
+            "word; no route is compiled from the digest or locality metrics"
+        ),
+    }
+
+
+def control_certificate(fixture) -> dict[str, object]:
+    port = fixture.cells.index(min(fixture.cells))
+    word = port_word(fixture, port)
+    pairs = port_target_rows(fixture, port)
+
+    deleted = word[1:]
+    deletion_mismatches = sum(
+        conjugate_word(bank, deleted).fields() != physical.fields()
+        for bank, physical in pairs
+    )
+
+    # A standard three-CNOT SWAP is A B A, hence literal reversal is the
+    # identical Clifford (palindromic) and cannot be a positive control.
+    palindromic_reverse = (*reversed(word[:3]), *word[3:])
+    palindromic_reverse_mismatches = sum(
+        conjugate_word(bank, palindromic_reverse).fields()
+        != physical.fields()
+        for bank, physical in pairs
+    )
+    # Positive hostile-order control: flip the middle CNOT of the first SWAP
+    # block to the same direction as its neighbours. A A A collapses to a
+    # single CNOT, which is not a SWAP, so the exchange must break.
+    hostile = (word[0], word[0], word[0], *word[3:])
+    hostile_mismatches = sum(
+        conjugate_word(bank, hostile).fields() != physical.fields()
+        for bank, physical in pairs
+    )
+    # Second hostile control on the Part-2 seam word.
+    axis_edges = incident_edges_by_axis(fixture, port)
+    seam_edge = axis_edges[min(axis_edges)]
+    seam_source, _seam_target, _explicit = seam_source_target_rows(
+        fixture, port, seam_edge
+    )
+    seam_word, _synthesis = greedy_symplectic_transvection_word(
+        fixture, port, seam_source,
+        seam_source_target_rows(fixture, port, seam_edge)[1],
+    )
+    seam_word_palindromic = tuple(reversed(seam_word)) == seam_word
+    seam_reference_images = tuple(
+        conjugate_word(item, seam_word) for item in seam_source
+    )
+    seam_support = sorted(
+        {
+            qubit
+            for gate in seam_word
+            for qubit in (gate.control, gate.target)
+            if qubit >= 0
+        }
+    )
+    stray_primitive_pair = None
+    stray_primitive_mismatches = 0
+    for control in seam_support:
+        for target in seam_support:
+            if control == target:
+                continue
+            appended_word = (*seam_word, Gate("CNOT", control, target))
+            mismatch_count = sum(
+                conjugate_word(item, appended_word).fields()
+                != reference.fields()
+                for item, reference in zip(
+                    seam_source, seam_reference_images
+                )
+            )
+            if mismatch_count:
+                stray_primitive_pair = (control, target)
+                stray_primitive_mismatches = mismatch_count
+                break
+        if stray_primitive_pair is not None:
+            break
+
+    total_parity = product_rows(
+        (
+            Row(
+                z=sum(1 << (6 * port + mode) for mode in range(6))
+                | sum(
+                    1 << (fixture.matter_qubits + 3 * port + mode)
+                    for mode in range(3)
+                )
+            ),
+            Row(
+                z=sum(
+                    1 << (fixture.qubits + mode) for mode in range(6)
+                )
+            ),
+        )
+    )
+    odd_detection_failures = sum(
+        anticommutes(single_x(fixture.qubits + mode), total_parity) != 1
+        for mode in range(6)
+    )
+
+    nonport = next(
+        cell for cell in range(len(fixture.cells)) if cell != port
+    )
+    wrong_word = port_word(fixture, nonport)
+    wrong_port_mismatches = sum(
+        conjugate_word(bank, wrong_word).fields() != physical.fields()
+        for bank, physical in pairs
+    )
+    return {
+        "delete_one_CNOT_mismatch_count": deletion_mismatches,
+        "palindromic_literal_reverse_mismatch_count": (
+            palindromic_reverse_mismatches
+        ),
+        "palindromic_reverse_note": (
+            "the standard three-CNOT SWAP is palindromic, so literal "
+            "gate-order reversal is the identical Clifford; reported as an "
+            "informational identity, not a control"
+        ),
+        "hostile_middle_CNOT_flip_mismatch_count": hostile_mismatches,
+        "seam_word_palindromic": seam_word_palindromic,
+        "stray_seam_primitive_pair": (
+            list(stray_primitive_pair)
+            if stray_primitive_pair is not None else None
+        ),
+        "stray_seam_primitive_mismatch_count": (
+            stray_primitive_mismatches
+        ),
+        "stray_seam_primitive_not_found": (
+            stray_primitive_pair is None
+        ),
+        "unlawful_odd_input_detection_failures": odd_detection_failures,
+        "wrong_port_mismatch_count": wrong_port_mismatches,
+    }
+
+
+def all_zero(mapping: dict[str, int]) -> bool:
+    return all(value == 0 for value in mapping.values())
+
+
+def main() -> None:
+    started = time.monotonic()
+    checks = []
+
+    def check(label: str, condition: bool) -> None:
+        checks.append({"label": label, "pass": bool(condition)})
+        print("PASS" if condition else "FAIL", label)
+
+    dense = dense_selftest()
+    check(
+        "dense exact Clifford tableau self-test has zero mismatches",
+        dense["mismatches"] == 0,
+    )
+
+    fixture_equivalence = fixture_path_equivalence()
+    check(
+        "union-safe and bare constructors agree on cells edges and qubits for 2x2x2",
+        all(
+            fixture_equivalence[name]
+            for name in (
+                "cells_identical",
+                "edges_identical",
+                "matter_qubits_identical",
+                "qubits_identical",
+            )
+        ),
+    )
+
+    boxes = {}
+    requested_shapes = ((1, 1, 1), (2, 2, 2), (3, 2, 2))
+    for shape in requested_shapes:
+        fixture = fixture_for_shape(shape)
+        part1 = part1_certificate(fixture)
+        part2 = part2_certificate(fixture)
+        boxes["x".join(map(str, shape))] = {
+            "shape": list(shape),
+            "part1": part1,
+            "part2": part2,
+        }
+        check(
+            f"{shape} Part 1 dictionary and exchange images are exact",
+            all_zero(part1["generation"])
+            and part1["forward_11_even_CAR_failures"] == 0
+            and part1["reverse_11_even_CAR_failures"] == 0
+            and part1["port_onsite_dictionary_rows"] == 36
+            and part1[
+                "forward_port_onsite_dictionary_exchange_failures"
+            ] == 0
+            and part1["port_onsite_dictionary_exchange_failures"] == 0
+            and part1["other_cell_onsite_invariance_failures"] == 0
+            and part1["incident_seam_exchange_failures"] == 0
+            and part1["nonincident_seam_invariance_failures"] == 0,
+        )
+        check(
+            f"{shape} Part 1 parity and bounded gate census pass",
+            not any(part1["parity"].values()) and part1["gate_pass"],
+        )
+        check(
+            f"{shape} Part 2 seam images noninvolved rows parity and routing are exact",
+            part2["all_four_seam_images_exact"]
+            and part2["all_noninvolved_dictionary_rows_invariant"]
+            and part2["all_parity_bookkeeping_exact"]
+            and part2["all_routes_returned"],
+        )
+        check(
+            f"{shape} Part 2 named support gate passes",
+            part2["gate_pass"],
+        )
+
+    if time.monotonic() - started < 300:
+        shape = (5, 3, 2)
+        fixture = fixture_for_shape(shape)
+        part1 = part1_certificate(fixture)
+        boxes["x".join(map(str, shape))] = {
+            "shape": list(shape),
+            "part1": part1,
+            "part2": {
+                "skipped": True,
+                "reason": "task limits 5x3x2 to Part 1 plus census",
+            },
+        }
+        check(
+            f"{shape} optional Part 1 and census pass",
+            all_zero(part1["generation"])
+            and part1["forward_11_even_CAR_failures"] == 0
+            and part1["reverse_11_even_CAR_failures"] == 0
+            and part1["port_onsite_dictionary_rows"] == 36
+            and part1[
+                "forward_port_onsite_dictionary_exchange_failures"
+            ] == 0
+            and part1["port_onsite_dictionary_exchange_failures"] == 0
+            and part1["other_cell_onsite_invariance_failures"] == 0
+            and part1["incident_seam_exchange_failures"] == 0
+            and part1["nonincident_seam_invariance_failures"] == 0
+            and not any(part1["parity"].values())
+            and part1["gate_pass"],
+        )
+
+    factorization_anchor = factorization_anchor_certificate()
+    check(
+        "mixed-gauge factorization anchors regress with exact coordinates",
+        factorization_anchor["all_regressions_pass"],
+    )
+
+    covariance = {
+        "2x2x2": covariance_certificate((2, 2, 2)),
+    }
+    if time.monotonic() - started < 300:
+        covariance["3x2x2"] = covariance_certificate((3, 2, 2))
+    check(
+        "24 frames x 8 translation parities have exact dictionary-family and seam-class covariance",
+        all(item["failures"] == 0 for item in covariance.values()),
+    )
+
+    controls = control_certificate(fixture_for_shape((2, 2, 2)))
+    check(
+        "deleting one CNOT produces a nonzero conjugation mismatch",
+        controls["delete_one_CNOT_mismatch_count"] > 0,
+    )
+    check(
+        "flipping the middle CNOT of one SWAP block produces a nonzero mismatch",
+        controls["hostile_middle_CNOT_flip_mismatch_count"] > 0,
+    )
+    check(
+        "appending one stray primitive to the seam word is detected",
+        not controls["stray_seam_primitive_not_found"]
+        and controls["stray_seam_primitive_mismatch_count"] > 0,
+    )
+    check(
+        "an unlawful odd input is detected by joint parity",
+        controls["unlawful_odd_input_detection_failures"] == 0,
+    )
+    check(
+        "a wrong-port word leaves the declared port rows unmapped",
+        controls["wrong_port_mismatch_count"] > 0,
+    )
+
+    passing = all(item["pass"] for item in checks)
+    report = {
+        "status": (
+            "cycle721-direct-local-encoded-input-clifford-port-pass"
+            if passing
+            else "cycle721-direct-local-encoded-input-clifford-port-incomplete"
+        ),
+        "checks": checks,
+        "dense_selftest": dense,
+        "fixture_constructor_equivalence": fixture_equivalence,
+        "boxes": boxes,
+        "factorization_anchor": factorization_anchor,
+        "covariance": covariance,
+        "controls": controls,
+        "derived": (
+            "six co-located three-CNOT SWAP blocks exchange the declared live "
+            "even-CAR bank with the full 36-row port-cell onsite dictionary "
+            "family exactly",
+            "the same parity-complete local word maps bank-ended incident seam "
+            "bilinears back to the supplied physical seam rows",
+            "all route counts are zero because every synthesized two-M2 "
+            "primitive is co-located at the declared port cell",
+        ),
+        "supplied": (
+            "the Cycle-720 companion/center operator dictionary and sector inventory",
+            "one clean six-qubit live-input bank co-located at the declared port",
+            "the total-parity label and companion center-sector representative",
+        ),
+        "open": (
+            "a public immutable V_s tableau/coordinate API and literal restriction compiler",
+            "the Bell/Choi gauge-mixed logical injection E_s",
+            "fault-tolerant preparation, decoding, and autonomous sector repair",
+            "coframe-origin seeded transport: this bank/dictionary surface touches no coframe registers, so the eight-origin channel covariance stays with the epoch-level composition",
+            "autonomous selection of the port cell: the lexicographic-minimum default is a supplied chart convention (covariance evaluates the transported port)",
+        ),
+        "claim_boundary": (
+            "This is a reversible even-exchange port plus seam-extended coupling "
+            "on the declared companion/center code with supplied sector inventory. "
+            "It is not the gauge-mixed logical injection E_s, which remains the "
+            "Bell/Choi route. The factorization locality values are a coordinate-"
+            "row census only: no V_s restriction is compiled. There is no autonomy "
+            "or genesis claim. Circuit ordinals describe structure, not time. "
+            "This is state-level coupling only, with no matter, FTL, mass, or "
+            "charge transfer."
+        ),
+        "direct_encoded_input_clifford_attempted": True,
+        "encoded_input_clifford_v_s_restriction_compiled": False,
+        "authority": "none",
+        "audit": "unset",
+        "runtime_seconds": time.monotonic() - started,
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if not passing:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/frontier_cycle721_tournament_independent_adversary_2026_07_28.py
+++ b/scripts/frontier_cycle721_tournament_independent_adversary_2026_07_28.py
@@ -1,0 +1,1774 @@
+#!/usr/bin/env python3
+"""Cycle-721 independent adversary for the input-port/epoch tournament.
+
+The three Cycle-721 runners under review are read only as specification data
+and are never imported.  This checker independently rebuilds their declared
+F1 companion-bank row family, the F2 six-qubit exchange port, transported seam
+classes, private duals, and one finite A/B/C/D epoch.  It has authority none
+and audit unset.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from collections import Counter, defaultdict
+from copy import copy
+from dataclasses import dataclass
+from hashlib import sha256
+import importlib
+from itertools import combinations, permutations, product
+import json
+import math
+from pathlib import Path
+import sys
+from time import perf_counter
+from typing import Iterable
+
+import numpy as np
+
+
+AUDIT_TIMEOUT_SEC = 900
+PRIMARY_SPEC_PATHS = (
+    "scripts/frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.py",
+    "scripts/frontier_cycle721_encoded_input_clifford_port_2026_07_28.py",
+    "scripts/frontier_cycle721_collision_free_epoch_composition_2026_07_28.py",
+)
+AUDIT_INPUT_PATHS = (
+    "scripts/frontier_cycle720_companion_three_route_independent_adversary_2026_07_27.py",
+    "scripts/frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.py",
+    "scripts/frontier_cycle721_encoded_input_clifford_port_2026_07_28.py",
+    "scripts/frontier_cycle721_collision_free_epoch_composition_2026_07_28.py",
+)
+DECLARED_INPUT_PATHS = AUDIT_INPUT_PATHS
+
+TOP_LEVEL_BLOCKLIST = {
+    "frontier_cycle721_car_bell_input_m2_compiler_2026_07_28",
+    "frontier_cycle721_encoded_input_clifford_port_2026_07_28",
+    "frontier_cycle721_collision_free_epoch_composition_2026_07_28",
+}
+TOL = 4.0e-10
+
+M = U = F = O = R = Q = T = P = V = None
+Pauli = object
+
+
+def load_dependencies(source_root: Path) -> None:
+    """Load only lower-level Cycle-720 construction dependencies."""
+    global M, U, F, O, R, Q, T, P, V, Pauli
+    scripts = (source_root / "scripts").resolve()
+    if not scripts.is_dir():
+        raise SystemExit(f"missing scripts directory: {scripts}")
+    sys.path.insert(0, str(scripts))
+    names = {
+        "M": "frontier_cycle720_cell_majorana_companion_geometry_2026_07_27",
+        "U": "frontier_cycle720_companion_subsystem_m2_update_2026_07_27",
+        "F": "frontier_cycle720_companion_subsystem_mixed_gauge_factorization_2026_07_27",
+        "O": "frontier_cycle720_overlap_star_mixed_gauge_choi_2026_07_27",
+        "R": "frontier_cycle720_companion_repeated_star_choi_tensor_2026_07_27",
+        "Q": "frontier_cycle720_companion_checkerboard_frame_cocycle_2026_07_27",
+        "T": "frontier_cycle708_endpoint_cube_tableau_core_2026_07_26",
+        "P": "frontier_cycle720_companion_local_choi_tree_plaquette_pump_2026_07_27",
+        "V": "frontier_cycle720_companion_local_choi_pump_covariance_2026_07_27",
+    }
+    loaded = {key: importlib.import_module(name) for key, name in names.items()}
+    M, U, F, O, R, Q, T, P, V = (
+        loaded[key] for key in ("M", "U", "F", "O", "R", "Q", "T", "P", "V")
+    )
+    Pauli = M.Pauli
+    forbidden = sorted(TOP_LEVEL_BLOCKLIST & set(sys.modules))
+    if forbidden:
+        raise AssertionError(
+            f"Cycle-721 primary imported transitively: {forbidden}"
+        )
+
+
+def declared_conventions(source_root: Path) -> dict[str, object]:
+    """Parse only module docstrings from the three blocked runner files."""
+    docstrings = {}
+    digests = {}
+    for relative in PRIMARY_SPEC_PATHS:
+        body = (source_root / relative).read_text()
+        doc = ast.get_docstring(ast.parse(body), clean=False) or ""
+        name = Path(relative).stem
+        docstrings[name] = doc
+        digests[name] = sha256(doc.encode()).hexdigest()
+    f1 = docstrings[Path(PRIMARY_SPEC_PATHS[0]).stem]
+    f2 = docstrings[Path(PRIMARY_SPEC_PATHS[1]).stem]
+    f3 = docstrings[Path(PRIMARY_SPEC_PATHS[2]).stem]
+    return {
+        "docstring_sha256": digests,
+        "F1_declares_code_0_q": "``[0, q)``" in f1,
+        "F1_declares_bank_q_2q": "``[q, 2q)``" in f1,
+        "F1_declares_H_CP_H": (
+            "``H(a); controlled local Pauli letters; H(a)``" in f1
+        ),
+        "F1_declares_fixed_X_and_character_Z": (
+            "``X(a)`` is fixed" in f1
+            and "``Z(a)`` is transported" in f1
+        ),
+        "F2_declares_one_six_mode_live_bank": (
+            "a six-mode live input\nbank" in f2
+            or "six-mode live input bank" in f2
+        ),
+        "F2_declares_colocation": "co-located" in f2,
+        "F3_declares_literal_slot_walk": "literal slot walk" in f3,
+        "F3_declares_stage_components": all(
+            token in f3
+            for token in (
+                "tree/plaquette Choi pump",
+                "retained Bell",
+                "routed recurrent word",
+            )
+        ),
+        "derived_F1_range_formula": "[q,2q)",
+        "derived_F2_range_formula": "[q,q+6)",
+        "derivation": (
+            "F1 states its q-wide mirror range literally.  F2 declares one "
+            "six-mode bank, and the code register ends at q, so its separate "
+            "bank occupies the next six registers [q,q+6)."
+        ),
+    }
+
+
+@dataclass(frozen=True)
+class IntPauli:
+    """Independent i^phase X^x Z^z integer Pauli representation."""
+
+    phase: int = 0
+    x: int = 0
+    z: int = 0
+
+    def fields(self) -> tuple[int, int, int]:
+        return self.phase % 4, self.x, self.z
+
+
+@dataclass(frozen=True)
+class CliffordGate:
+    kind: str
+    first: int
+    second: int = -1
+    target_pauli: IntPauli = IntPauli()
+
+
+def ip(row) -> IntPauli:
+    return IntPauli(int(row.phase) % 4, int(row.x), int(row.z))
+
+
+def pauli_multiply(left: IntPauli, right: IntPauli) -> IntPauli:
+    """Multiply in i^p X^x Z^z order, including the exact mod-four phase."""
+    phase = (
+        left.phase
+        + right.phase
+        + 2 * (left.z & right.x).bit_count()
+    ) % 4
+    return IntPauli(phase, left.x ^ right.x, left.z ^ right.z)
+
+
+def pauli_product(rows: Iterable[IntPauli]) -> IntPauli:
+    output = IntPauli()
+    for row in rows:
+        output = pauli_multiply(output, row)
+    return output
+
+
+def signed_single(qubit: int, letter: str) -> IntPauli:
+    if letter == "X":
+        return IntPauli(x=1 << qubit)
+    if letter == "Z":
+        return IntPauli(z=1 << qubit)
+    if letter == "Y":
+        return IntPauli(phase=1, x=1 << qubit, z=1 << qubit)
+    if letter == "I":
+        return IntPauli()
+    raise ValueError(letter)
+
+
+def anticommutator_bit(left: IntPauli, right: IntPauli) -> int:
+    return (
+        (left.x & right.z).bit_count()
+        + (left.z & right.x).bit_count()
+    ) & 1
+
+
+def _generator_after_gate(
+    gate: CliffordGate, qubit: int, x_generator: bool
+) -> IntPauli:
+    base = IntPauli(
+        x=(1 << qubit) if x_generator else 0,
+        z=0 if x_generator else (1 << qubit),
+    )
+    if gate.kind == "H":
+        if qubit != gate.first:
+            return base
+        return IntPauli(
+            z=1 << qubit
+        ) if x_generator else IntPauli(x=1 << qubit)
+    if gate.kind == "CNOT":
+        control, target = gate.first, gate.second
+        if x_generator and qubit == control:
+            return IntPauli(x=(1 << control) | (1 << target))
+        if not x_generator and qubit == target:
+            return IntPauli(z=(1 << control) | (1 << target))
+        return base
+    if gate.kind == "CZ":
+        left, right = gate.first, gate.second
+        if x_generator and qubit == left:
+            return IntPauli(x=1 << left, z=1 << right)
+        if x_generator and qubit == right:
+            return IntPauli(x=1 << right, z=1 << left)
+        return base
+    if gate.kind == "CP":
+        control = gate.first
+        if qubit == control:
+            if x_generator:
+                return pauli_multiply(
+                    IntPauli(x=1 << control), gate.target_pauli
+                )
+            return base
+        if anticommutator_bit(base, gate.target_pauli):
+            return pauli_multiply(
+                IntPauli(z=1 << control), base
+            )
+        return base
+    raise ValueError(gate.kind)
+
+
+def conjugate_gate(row: IntPauli, gate: CliffordGate) -> IntPauli:
+    """Rebuild a Clifford image from independently derived generator images."""
+    output = IntPauli(row.phase % 4)
+    bits = row.x
+    while bits:
+        low = bits & -bits
+        output = pauli_multiply(
+            output,
+            _generator_after_gate(gate, low.bit_length() - 1, True),
+        )
+        bits ^= low
+    bits = row.z
+    while bits:
+        low = bits & -bits
+        output = pauli_multiply(
+            output,
+            _generator_after_gate(gate, low.bit_length() - 1, False),
+        )
+        bits ^= low
+    return output
+
+
+def conjugate_word(
+    row: IntPauli, word: Iterable[CliffordGate]
+) -> IntPauli:
+    output = row
+    for gate in word:
+        output = conjugate_gate(output, gate)
+    return output
+
+
+def dense_pauli(row: IntPauli, width: int) -> np.ndarray:
+    identity = np.eye(2, dtype=complex)
+    x_matrix = np.asarray(((0, 1), (1, 0)), dtype=complex)
+    z_matrix = np.asarray(((1, 0), (0, -1)), dtype=complex)
+    output = np.asarray(((1,),), dtype=complex)
+    for qubit in reversed(range(width)):
+        local = identity
+        if (row.x >> qubit) & 1:
+            local = local @ x_matrix
+        if (row.z >> qubit) & 1:
+            local = local @ z_matrix
+        output = np.kron(output, local)
+    return (1j ** (row.phase % 4)) * output
+
+
+def dense_gate(gate: CliffordGate, width: int) -> np.ndarray:
+    dimension = 1 << width
+    if gate.kind == "H":
+        return (
+            dense_pauli(IntPauli(x=1 << gate.first), width)
+            + dense_pauli(IntPauli(z=1 << gate.first), width)
+        ) / math.sqrt(2)
+    if gate.kind == "CNOT":
+        output = np.zeros((dimension, dimension), dtype=complex)
+        for basis in range(dimension):
+            image = basis
+            if (basis >> gate.first) & 1:
+                image ^= 1 << gate.second
+            output[image, basis] = 1
+        return output
+    if gate.kind == "CZ":
+        output = np.eye(dimension, dtype=complex)
+        for basis in range(dimension):
+            if (
+                ((basis >> gate.first) & 1)
+                and ((basis >> gate.second) & 1)
+            ):
+                output[basis, basis] = -1
+        return output
+    if gate.kind == "CP":
+        identity = np.eye(dimension, dtype=complex)
+        z_control = dense_pauli(
+            IntPauli(z=1 << gate.first), width
+        )
+        p0 = (identity + z_control) / 2
+        p1 = (identity - z_control) / 2
+        return p0 + p1 @ dense_pauli(gate.target_pauli, width)
+    raise ValueError(gate.kind)
+
+
+def dense_integer_pauli_certificate() -> dict[str, object]:
+    """All signed weight-one/two rows against every three-qubit gate instance."""
+    rows = []
+    for letters in product(("I", "X", "Y", "Z"), repeat=3):
+        weight = sum(letter != "I" for letter in letters)
+        if weight not in (1, 2):
+            continue
+        canonical = pauli_product(
+            signed_single(qubit, letter)
+            for qubit, letter in enumerate(letters)
+            if letter != "I"
+        )
+        rows.extend(
+            IntPauli(
+                (canonical.phase + phase) % 4,
+                canonical.x,
+                canonical.z,
+            )
+            for phase in range(4)
+        )
+
+    gates = [
+        CliffordGate("H", qubit) for qubit in range(3)
+    ]
+    gates.extend(
+        CliffordGate("CNOT", control, target)
+        for control in range(3)
+        for target in range(3)
+        if control != target
+    )
+    gates.extend(
+        CliffordGate("CZ", left, right)
+        for left, right in combinations(range(3), 2)
+    )
+    for control in range(3):
+        targets = tuple(qubit for qubit in range(3) if qubit != control)
+        for letters in product(("I", "X", "Y", "Z"), repeat=2):
+            if letters == ("I", "I"):
+                continue
+            target = pauli_product(
+                signed_single(qubit, letter)
+                for qubit, letter in zip(targets, letters)
+                if letter != "I"
+            )
+            gates.append(
+                CliffordGate("CP", control, target_pauli=target)
+            )
+
+    mismatches = 0
+    maximum_residual = 0.0
+    for gate in gates:
+        unitary = dense_gate(gate, 3)
+        for row in rows:
+            actual = dense_pauli(conjugate_gate(row, gate), 3)
+            expected = (
+                unitary @ dense_pauli(row, 3) @ unitary.conj().T
+            )
+            residual = float(np.max(np.abs(actual - expected)))
+            maximum_residual = max(maximum_residual, residual)
+            mismatches += residual > TOL
+    return {
+        "signed_weight_1_or_2_rows": len(rows),
+        "H_instances": 3,
+        "CNOT_instances": 6,
+        "CZ_instances": 3,
+        "controlled_Pauli_instances": 45,
+        "gate_instances": len(gates),
+        "comparisons": len(rows) * len(gates),
+        "mismatches": mismatches,
+        "maximum_dense_residual": maximum_residual,
+    }
+
+
+def fixture_222():
+    return O.arbitrary_fixture(Q.shape_cells((2, 2, 2)))
+
+
+def physical_cell(fixture, qubit: int) -> int:
+    if qubit < fixture.matter_qubits:
+        return qubit // 6
+    if qubit < fixture.qubits:
+        return (qubit - fixture.matter_qubits) // 3
+    raise ValueError(f"physical qubit outside fixture: {qubit}")
+
+
+def support_indices(row) -> tuple[int, ...]:
+    mask = int(row.x) | int(row.z)
+    output = []
+    while mask:
+        low = mask & -mask
+        output.append(low.bit_length() - 1)
+        mask ^= low
+    return tuple(output)
+
+
+def support_diameter(cells: Iterable[tuple[int, int, int]]) -> int:
+    cells = tuple(cells)
+    return max(
+        (
+            sum(abs(a - b) for a, b in zip(left, right))
+            for left in cells for right in cells
+        ),
+        default=0,
+    )
+
+
+def six_swap_word(bank_base: int, matter_base: int) -> tuple[CliffordGate, ...]:
+    gates = []
+    for mode in range(6):
+        bank, matter = bank_base + mode, matter_base + mode
+        gates.extend((
+            CliffordGate("CNOT", bank, matter),
+            CliffordGate("CNOT", matter, bank),
+            CliffordGate("CNOT", bank, matter),
+        ))
+    return tuple(gates)
+
+
+def replace_port_matter(
+    row: IntPauli, fixture, port: int, bank_base: int
+) -> IntPauli:
+    x, z = row.x, row.z
+    for mode in range(6):
+        matter = 1 << (6 * port + mode)
+        bank = 1 << (bank_base + mode)
+        if x & matter:
+            x ^= matter | bank
+        if z & matter:
+            z ^= matter | bank
+    return IntPauli(row.phase, x, z)
+
+
+def exchange_port_certificate(
+    conventions: dict[str, object],
+) -> dict[str, object]:
+    fixture = fixture_222()
+    q = fixture.qubits
+    port = fixture.cells.index(min(fixture.cells))
+    bank_base = q
+    word = six_swap_word(bank_base, 6 * port)
+    cell_mask = sum(
+        1 << (6 * port + mode) for mode in range(6)
+    ) | sum(
+        1 << (fixture.matter_qubits + 3 * port + axis)
+        for axis in range(3)
+    )
+    dictionary = tuple(M.operator_rows(fixture))
+    local_rows = tuple(
+        ip(physical)
+        for family, physical, _target in dictionary
+        if family in ("onsite_B", "onsite_even")
+        and (int(physical.x) | int(physical.z))
+        and not ((int(physical.x) | int(physical.z)) & ~cell_mask)
+    )
+    forward_failures = reverse_failures = 0
+    for physical in local_rows:
+        bank = replace_port_matter(
+            physical, fixture, port, bank_base
+        )
+        forward_failures += (
+            conjugate_word(bank, word).fields() != physical.fields()
+        )
+        reverse_failures += (
+            conjugate_word(physical, word).fields() != bank.fields()
+        )
+
+    affected_failures = unaffected_failures = 0
+    for _family, physical_pauli, _target in dictionary:
+        physical = ip(physical_pauli)
+        actual = conjugate_word(physical, word)
+        if (physical.x | physical.z) & sum(
+            1 << (6 * port + mode) for mode in range(6)
+        ):
+            expected = replace_port_matter(
+                physical, fixture, port, bank_base
+            )
+            affected_failures += actual.fields() != expected.fields()
+        else:
+            unaffected_failures += actual.fields() != physical.fields()
+
+    matter_parity = sum(
+        1 << (6 * port + mode) for mode in range(6)
+    )
+    companion_parity = sum(
+        1 << (fixture.matter_qubits + 3 * port + axis)
+        for axis in range(3)
+    )
+    bank_parity = sum(1 << (bank_base + mode) for mode in range(6))
+    cell_parity = IntPauli(z=matter_parity | companion_parity)
+    joint_parity = IntPauli(
+        z=matter_parity | companion_parity | bank_parity
+    )
+    expected_cell = IntPauli(z=bank_parity | companion_parity)
+    odd_detection_failures = 0
+    odd_image_detection_failures = 0
+    for mode in range(6):
+        odd = IntPauli(x=1 << (bank_base + mode))
+        odd_detection_failures += (
+            anticommutator_bit(odd, joint_parity) != 1
+        )
+        odd_image_detection_failures += (
+            anticommutator_bit(
+                conjugate_word(odd, word), joint_parity
+            ) != 1
+        )
+
+    touched_cells = {
+        fixture.cells[port]
+        for gate in word
+        for qubit in (gate.first, gate.second)
+        if qubit >= 0
+    }
+    dense = dense_integer_pauli_certificate()
+    return {
+        "shape": (2, 2, 2),
+        "q": q,
+        "F1_docstring_range": (q, 2 * q),
+        "F2_derived_six_qubit_range": (q, q + 6),
+        "convention_evidence_pass": all((
+            conventions["F1_declares_code_0_q"],
+            conventions["F1_declares_bank_q_2q"],
+            conventions["F2_declares_one_six_mode_live_bank"],
+            conventions["F2_declares_colocation"],
+        )),
+        "six_SWAP_blocks": len(word) // 3,
+        "CNOT_primitives": len(word),
+        "port_dictionary_rows": len(local_rows),
+        "forward_dictionary_exchange_failures": forward_failures,
+        "reverse_dictionary_exchange_failures": reverse_failures,
+        "all_affected_dictionary_exchange_failures": affected_failures,
+        "unaffected_dictionary_invariance_failures": unaffected_failures,
+        "cell_parity_image_failures": (
+            conjugate_word(cell_parity, word).fields()
+            != expected_cell.fields()
+        ),
+        "joint_parity_invariance_failures": (
+            conjugate_word(joint_parity, word).fields()
+            != joint_parity.fields()
+        ),
+        "odd_bank_detection_failures": odd_detection_failures,
+        "odd_image_detection_failures": odd_image_detection_failures,
+        "support_cells": len(touched_cells),
+        "support_diameter": support_diameter(touched_cells),
+        "dense_integer_Pauli_selftest": dense,
+    }
+
+
+def gf2_rank(rows: Iterable[int]) -> int:
+    pivots: dict[int, int] = {}
+    for original in rows:
+        row = int(original)
+        while row:
+            pivot = row.bit_length() - 1
+            if pivot in pivots:
+                row ^= pivots[pivot]
+            else:
+                pivots[pivot] = row
+                break
+    return len(pivots)
+
+
+def symplectic_int(left: IntPauli, right: IntPauli) -> int:
+    return (
+        (left.x & right.z).bit_count()
+        + (left.z & right.x).bit_count()
+    ) & 1
+
+
+def canonical_pauli(x: int, z: int):
+    return Pauli((x & z).bit_count() & 1, x, z)
+
+
+def tag_physical_row(fixture, tag):
+    if tag[0] == "onsite_Z":
+        return Pauli(z=1 << (6 * tag[1] + tag[2]))
+    if tag[0] == "onsite_XX":
+        left = 6 * tag[1] + tag[2]
+        return Pauli(x=(1 << left) | (1 << (left + 1)))
+    if tag[0] == "edge":
+        return fixture.physical_terms(tag[1])[2]
+    raise ValueError(tag)
+
+
+def rebuilt_companion_rows(fixture):
+    graph, tags = P.direct_graph_basis(fixture)
+    q = fixture.qubits
+    mask = (1 << q) - 1
+    rows = []
+    restriction_failures = 0
+    for graph_row, tag in zip(graph, tags):
+        code = canonical_pauli(
+            int(graph_row.x) & mask, int(graph_row.z) & mask
+        )
+        physical = tag_physical_row(fixture, tag)
+        restriction_failures += (
+            ip(code).fields() != ip(physical).fields()
+        )
+        x = int(code.x) | (int(physical.x) << q)
+        z = int(code.z) | (int(physical.z) << q)
+        rows.append(canonical_pauli(x, z))
+    return tuple(graph), tuple(tags), tuple(rows), restriction_failures
+
+
+def tag_anchor(fixture, tag) -> tuple[int, int, int]:
+    if tag[0].startswith("onsite"):
+        return fixture.cells[tag[1]]
+    if tag[0] not in ("edge", "tree", "plaquette"):
+        raise ValueError(f"unsupported scheduled tag: {tag!r}")
+    left, right, owner, *_rest = fixture.edges[tag[1]]
+    anchor = fixture.cells[owner] if isinstance(owner, int) else tuple(owner)
+    if anchor not in (fixture.cells[left], fixture.cells[right]):
+        raise AssertionError("edge anchor is not an endpoint")
+    return anchor
+
+
+def doubled_row_cells(fixture, row) -> frozenset[tuple[int, int, int]]:
+    q = fixture.qubits
+    cells = set()
+    for qubit in support_indices(row):
+        local = qubit if qubit < q else qubit - q
+        cells.add(fixture.cells[physical_cell(fixture, local)])
+    return frozenset(cells)
+
+
+def dilation_certificate() -> dict[str, object]:
+    fixture = fixture_222()
+    graph, tags, rows, restriction_failures = rebuilt_companion_rows(
+        fixture
+    )
+    q = fixture.qubits
+    graph_width = q + fixture.matter_qubits
+    compiled_width = 2 * q
+    commutator_failures = sum(
+        symplectic_int(ip(left), ip(right))
+        for index, left in enumerate(rows)
+        for right in rows[:index]
+    )
+    x_failures = z_failures = 0
+    support_failures = 0
+    maximum_cells = maximum_diameter = 0
+    support_census = Counter()
+    for index, (tag, row) in enumerate(zip(tags, rows)):
+        ancilla = 2 * q + index
+        target = ip(row)
+        word = (
+            CliffordGate("H", ancilla),
+            CliffordGate("CP", ancilla, target_pauli=target),
+            CliffordGate("H", ancilla),
+        )
+        x_ancilla = IntPauli(x=1 << ancilla)
+        z_ancilla = IntPauli(z=1 << ancilla)
+        expected_z = pauli_multiply(z_ancilla, target)
+        x_failures += (
+            conjugate_word(x_ancilla, word).fields()
+            != x_ancilla.fields()
+        )
+        z_failures += (
+            conjugate_word(z_ancilla, word).fields()
+            != expected_z.fields()
+        )
+        cells = set(doubled_row_cells(fixture, row))
+        cells.add(tag_anchor(fixture, tag))
+        diameter = support_diameter(cells)
+        support_census[(len(cells), diameter)] += 1
+        maximum_cells = max(maximum_cells, len(cells))
+        maximum_diameter = max(maximum_diameter, diameter)
+        support_failures += len(cells) > 2 or diameter > 1
+    return {
+        "shape": (2, 2, 2),
+        "rows": len(rows),
+        "physical_restriction_tag_rebuild_failures": restriction_failures,
+        "compiled_commutator_failures": commutator_failures,
+        "graph_rank": gf2_rank(
+            int(row.symplectic(graph_width)) for row in graph
+        ),
+        "compiled_rank": gf2_rank(
+            int(row.symplectic(compiled_width)) for row in rows
+        ),
+        "dilation_X_invariance_failures": x_failures,
+        "dilation_Z_character_failures": z_failures,
+        "support_gate_failures": support_failures,
+        "maximum_compiled_support_cells": maximum_cells,
+        "maximum_compiled_support_diameter": maximum_diameter,
+        "per_row_support_census": tuple(
+            {
+                "support_cells": cells,
+                "support_diameter": diameter,
+                "rows": count,
+            }
+            for (cells, diameter), count in sorted(
+                support_census.items()
+            )
+        ),
+    }
+
+
+def solve_binary(equations: Iterable[tuple[int, int]]) -> tuple[int, int]:
+    pivots: dict[int, tuple[int, int]] = {}
+    contradictions = 0
+    for original_mask, original_rhs in equations:
+        mask, rhs = int(original_mask), int(original_rhs) & 1
+        while mask:
+            pivot = mask.bit_length() - 1
+            if pivot in pivots:
+                old_mask, old_rhs = pivots[pivot]
+                mask ^= old_mask
+                rhs ^= old_rhs
+            else:
+                pivots[pivot] = (mask, rhs)
+                break
+        else:
+            contradictions += rhs
+    solution = 0
+    for pivot in sorted(pivots):
+        mask, rhs = pivots[pivot]
+        other = mask & ~(1 << pivot)
+        value = rhs ^ ((other & solution).bit_count() & 1)
+        solution |= value << pivot
+    return solution, contradictions
+
+
+def solve_private_dual(rows, target: int, allowed: tuple[int, ...]):
+    equations = []
+    for index, stabilizer in enumerate(rows):
+        mask = 0
+        for variable, qubit in enumerate(allowed):
+            mask |= (
+                (int(stabilizer.z) >> qubit) & 1
+            ) << (2 * variable)
+            mask |= (
+                (int(stabilizer.x) >> qubit) & 1
+            ) << (2 * variable + 1)
+        equations.append((mask, int(index == target)))
+    solution, contradictions = solve_binary(equations)
+    x = sum(
+        ((solution >> (2 * variable)) & 1) << qubit
+        for variable, qubit in enumerate(allowed)
+    )
+    z = sum(
+        ((solution >> (2 * variable + 1)) & 1) << qubit
+        for variable, qubit in enumerate(allowed)
+    )
+    return canonical_pauli(x, z), contradictions
+
+
+def one_cell_allowed_sets(fixture, tag) -> tuple[tuple[int, ...], ...]:
+    q = fixture.qubits
+    m = fixture.matter_qubits
+    if tag[0] != "edge":
+        cells = (tag[1],)
+        include_full = True
+    else:
+        left, right, *_rest = fixture.edges[tag[1]]
+        cells = (left, right)
+        include_full = False
+    output = []
+    for cell in cells:
+        if include_full:
+            allowed = tuple(
+                range(6 * cell, 6 * cell + 6)
+            ) + tuple(
+                range(m + 3 * cell, m + 3 * cell + 3)
+            ) + tuple(
+                range(q + 6 * cell, q + 6 * cell + 6)
+            )
+        else:
+            allowed = tuple(
+                range(m + 3 * cell, m + 3 * cell + 3)
+            )
+        output.append(allowed)
+    return tuple(output)
+
+
+def graph_row_cells(fixture, row) -> frozenset[tuple[int, int, int]]:
+    q = fixture.qubits
+    m = fixture.matter_qubits
+    cells = set()
+    for qubit in support_indices(row):
+        if qubit < m:
+            cell = qubit // 6
+        elif qubit < q:
+            cell = (qubit - m) // 3
+        elif qubit < q + m:
+            cell = (qubit - q) // 6
+        else:
+            raise AssertionError("private dual escaped graph width")
+        cells.add(fixture.cells[cell])
+    return frozenset(cells)
+
+
+def atlas_correction_certificate() -> dict[str, object]:
+    fixture = fixture_222()
+    graph, tags = P.direct_graph_basis(fixture)
+    total = fixture.qubits + fixture.matter_qubits
+    atlas = {}
+    no_one_cell_solution = 0
+    solve_contradictions = 0
+    for target, tag in enumerate(tags):
+        chosen = None
+        for allowed in one_cell_allowed_sets(fixture, tag):
+            candidate, contradictions = solve_private_dual(
+                graph, target, allowed
+            )
+            syndrome = tuple(
+                symplectic_int(ip(candidate), ip(row))
+                for row in graph
+            )
+            if not contradictions and syndrome == tuple(
+                int(index == target) for index in range(len(graph))
+            ):
+                chosen = candidate
+                break
+            solve_contradictions += contradictions
+        if chosen is None:
+            no_one_cell_solution += 1
+            chosen = canonical_pauli(0, 0)
+        atlas[tag] = chosen
+
+    one_hot_failures = 0
+    support_failures = 0
+    maximum_cells = 0
+    for target, tag in enumerate(tags):
+        correction = atlas[tag]
+        one_hot_failures += sum(
+            symplectic_int(ip(correction), ip(stabilizer))
+            != int(index == target)
+            for index, stabilizer in enumerate(graph)
+        )
+        cells = graph_row_cells(fixture, correction)
+        maximum_cells = max(maximum_cells, len(cells))
+        support_failures += len(cells) > 1
+    return {
+        "shape": (2, 2, 2),
+        "graph_width": total,
+        "graph_rows": len(graph),
+        "graph_rank": gf2_rank(
+            int(row.symplectic(total)) for row in graph
+        ),
+        "atlas_entries": len(atlas),
+        "solve_contradictions": solve_contradictions,
+        "rows_without_one_cell_solution": no_one_cell_solution,
+        "one_hot_duality_failures": one_hot_failures,
+        "one_cell_support_failures": support_failures,
+        "maximum_private_dual_support_cells": maximum_cells,
+    }
+
+
+def proper_cubic_frames() -> tuple[np.ndarray, ...]:
+    frames = []
+    for permutation in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            frame = np.zeros((3, 3), dtype=int)
+            for target_axis, source_axis in enumerate(permutation):
+                frame[target_axis, source_axis] = signs[target_axis]
+            if round(float(np.linalg.det(frame))) == 1:
+                frames.append(frame)
+    if len(frames) != 24:
+        raise AssertionError("proper cubic frame census is not 24")
+    return tuple(frames)
+
+
+def affine_cell(cell, frame, shift) -> tuple[int, int, int]:
+    return tuple(
+        int(value)
+        for value in (
+            frame @ np.asarray(cell, dtype=int)
+            + np.asarray(shift, dtype=int)
+        )
+    )
+
+
+def apply_physical_images(row, images) -> IntPauli:
+    x_images, z_images = images
+    output = IntPauli(int(row.phase) % 4)
+    bits = int(row.x)
+    while bits:
+        low = bits & -bits
+        output = pauli_multiply(
+            output, ip(x_images[low.bit_length() - 1])
+        )
+        bits ^= low
+    bits = int(row.z)
+    while bits:
+        low = bits & -bits
+        output = pauli_multiply(
+            output, ip(z_images[low.bit_length() - 1])
+        )
+        bits ^= low
+    return output
+
+
+def reversed_physical_terms(fixture, edge_index: int) -> tuple:
+    left, right, _owner, axis, left_mode, right_mode = (
+        fixture.edges[edge_index]
+    )
+    reversed_record = (
+        right,
+        left,
+        fixture.cells[right],
+        axis,
+        right_mode,
+        left_mode,
+    )
+    reversed_fixture = copy(fixture)
+    edges = list(fixture.edges)
+    edges[edge_index] = reversed_record
+    object.__setattr__(reversed_fixture, "edges", tuple(edges))
+    return tuple(reversed_fixture.physical_terms(edge_index))
+
+
+def transported_edge_index(
+    source, source_edge: int, target, frame, shift
+) -> int | None:
+    left, right, *_rest = source.edges[source_edge]
+    endpoints = frozenset((
+        affine_cell(source.cells[left], frame, shift),
+        affine_cell(source.cells[right], frame, shift),
+    ))
+    for edge_index, edge in enumerate(target.edges):
+        if frozenset((
+            target.cells[edge[0]], target.cells[edge[1]]
+        )) == endpoints:
+            return edge_index
+    return None
+
+
+def seam_class_certificate() -> dict[str, object]:
+    source = fixture_222()
+    frames = proper_cubic_frames()
+    shifts = tuple(product((0, 1), repeat=3))
+    forward_classes = reversed_classes = 0
+    missing_edge_failures = 0
+    zero_class_failures = double_class_failures = 0
+    quadruples = 0
+    first_failure = None
+    for frame_index, frame in enumerate(frames):
+        for shift in shifts:
+            target = O.arbitrary_fixture(
+                Q.affine_cells(source.cells, frame, shift)
+            )
+            images = Q.physical_images(source, target, frame, shift)
+            for source_edge in range(len(source.edges)):
+                quadruples += 1
+                target_edge = transported_edge_index(
+                    source, source_edge, target, frame, shift
+                )
+                if target_edge is None:
+                    missing_edge_failures += 1
+                    continue
+                transported = tuple(
+                    apply_physical_images(row, images)
+                    for row in source.physical_terms(source_edge)
+                )
+                forward = tuple(
+                    ip(row) for row in target.physical_terms(target_edge)
+                )
+                reversed_rows = tuple(
+                    ip(row)
+                    for row in reversed_physical_terms(
+                        target, target_edge
+                    )
+                )
+                matches = (
+                    transported == forward,
+                    transported == reversed_rows,
+                )
+                forward_classes += matches[0] and not matches[1]
+                reversed_classes += matches[1] and not matches[0]
+                zero_class_failures += not any(matches)
+                double_class_failures += all(matches)
+                if (
+                    first_failure is None
+                    and sum(bool(value) for value in matches) != 1
+                ):
+                    first_failure = {
+                        "frame_index": frame_index,
+                        "shift": shift,
+                        "source_edge": source_edge,
+                        "target_edge": target_edge,
+                        "forward_match": bool(matches[0]),
+                        "reversed_match": bool(matches[1]),
+                    }
+    return {
+        "shape": (2, 2, 2),
+        "proper_cubic_frames": len(frames),
+        "translation_parities": len(shifts),
+        "contexts": len(frames) * len(shifts),
+        "transported_quadruples": quadruples,
+        "forward_class_count": forward_classes,
+        "reversed_class_count": reversed_classes,
+        "missing_edge_failures": missing_edge_failures,
+        "zero_class_failures": zero_class_failures,
+        "double_class_failures": double_class_failures,
+        "first_failure": first_failure,
+        "transport_surface": "Q.affine_cells plus Q.physical_images",
+        "reversed_surface": (
+            "fixture.physical_terms after explicit endpoint/mode reordering"
+        ),
+    }
+
+
+def greedy_layers(supports: Iterable[frozenset[int]]) -> tuple[int, ...]:
+    occupied: list[set[int]] = []
+    assignment = []
+    for support in supports:
+        for layer, used in enumerate(occupied):
+            if not used.intersection(support):
+                used.update(support)
+                assignment.append(layer)
+                break
+        else:
+            occupied.append(set(support))
+            assignment.append(len(occupied) - 1)
+    return tuple(assignment)
+
+
+def merge_accesses(entries: Iterable[tuple[int, str]]) -> dict[int, str]:
+    rank = {"read": 0, "write": 1}
+    output: dict[int, str] = {}
+    for register, mode in entries:
+        if register not in output or rank[mode] > rank[output[register]]:
+            output[register] = mode
+    return output
+
+
+def route_rails(
+    fixture, route, rail_base: int
+) -> tuple[int, ...]:
+    lookup = {cell: index for index, cell in enumerate(fixture.cells)}
+    return tuple(sorted({
+        rail_base + lookup[cell]
+        for transition in route
+        for cell in transition
+    }))
+
+
+def independent_liveness_walk(
+    slots: list[dict[str, object]],
+    handoffs: set[tuple[str, str, int]],
+) -> dict[str, object]:
+    """Own literal owner walk; every ownership transfer needs a named edge."""
+    owner: dict[int, str] = {}
+    executed: set[str] = set()
+    consumed: set[tuple[str, str, int]] = set()
+    violations = []
+    collision_count = 0
+    touches = 0
+    for slot_index, slot in enumerate(slots):
+        claimed = {}
+        for word in slot["words"]:
+            for register in word["accesses"]:
+                if register in claimed:
+                    collision_count += 1
+                    violations.append(
+                        f"collision:slot={slot_index}:register={register}:"
+                        f"{claimed[register]}:{word['id']}"
+                    )
+                else:
+                    claimed[register] = word["id"]
+        for word in slot["words"]:
+            word_id = word["id"]
+            for register, mode in word["accesses"].items():
+                touches += 1
+                previous = owner.get(register)
+                if previous is None:
+                    if mode == "read":
+                        violations.append(
+                            f"read_before_write:slot={slot_index}:"
+                            f"register={register}:word={word_id}"
+                        )
+                elif previous != word_id:
+                    edge = (previous, word_id, register)
+                    if edge not in handoffs:
+                        violations.append(
+                            f"missing_handoff:slot={slot_index}:"
+                            f"register={register}:{previous}->{word_id}"
+                        )
+                    elif previous not in executed:
+                        violations.append(
+                            f"handoff_before_producer:slot={slot_index}:"
+                            f"register={register}:{previous}->{word_id}"
+                        )
+                    else:
+                        consumed.add(edge)
+                owner[register] = word_id
+            executed.add(word_id)
+    for producer, consumer, register in sorted(handoffs - consumed):
+        violations.append(
+            f"declared_handoff_unconsumed:register={register}:"
+            f"{producer}->{consumer}"
+        )
+    return {
+        "slots_walked": len(slots),
+        "words_walked": sum(len(slot["words"]) for slot in slots),
+        "register_touches": touches,
+        "registers_seen": len(owner),
+        "handoffs_declared": len(handoffs),
+        "handoffs_consumed": len(consumed),
+        "collision_count": collision_count,
+        "ownership_or_handoff_violation_count": len(violations),
+        "violations": tuple(violations[:30]),
+    }
+
+
+def declare_handoffs(
+    slots: list[dict[str, object]],
+) -> set[tuple[str, str, int]]:
+    last: dict[int, str] = {}
+    handoffs = set()
+    for slot in slots:
+        for word in slot["words"]:
+            for register in word["accesses"]:
+                if register in last and last[register] != word["id"]:
+                    handoffs.add(
+                        (last[register], word["id"], register)
+                    )
+                last[register] = word["id"]
+    return handoffs
+
+
+def row_route(fixture, row, anchor):
+    support = set(P.pauli_cells(fixture, row))
+    support.add(anchor)
+    return P.returned_route(anchor, frozenset(support))
+
+
+def epoch_liveness_certificate() -> dict[str, object]:
+    fixture = fixture_222()
+    root = min(fixture.cells)
+    axis_order = (2, 1, 0)
+    atlas = P.build_private_atlases()
+    pump_rows, pump_tags, _pump_report = P.schedule_basis(
+        fixture, root, axis_order
+    )
+    pump_corrections = tuple(
+        P.schedule_correction(fixture, tag, atlas)
+        for tag in pump_tags
+    )
+    graph, tags, coupling_rows, restriction_failures = (
+        rebuilt_companion_rows(fixture)
+    )
+    corrections = tuple(
+        P.correction_from_atlas(fixture, tag, atlas)
+        for tag in tags
+    )
+    correction_supports = tuple(
+        frozenset(support_indices(row)) for row in corrections
+    )
+    correction_assignment = greedy_layers(correction_supports)
+    correction_order = tuple(sorted(
+        range(len(corrections)),
+        key=lambda index: (correction_assignment[index], index),
+    ))
+
+    placed = U.placement(fixture)
+    physical_word, update_report = U.physical_word(fixture, placed)
+    routed, route_report = U.c707.route_word(physical_word)
+    q = fixture.qubits
+    placed_sites = tuple(tuple(site) for site in placed["sites_by_qubit"])
+    placed_lookup = {
+        site: qubit for qubit, site in enumerate(placed_sites)
+    }
+    touched_sites = {
+        tuple(site)
+        for instruction in routed
+        for site in instruction.sites
+    }
+    extra_sites = tuple(sorted(touched_sites - set(placed_lookup)))
+    g_register = dict(placed_lookup)
+    g_register.update(
+        (site, 2 * q + index)
+        for index, site in enumerate(extra_sites)
+    )
+    cursor = 2 * q + len(extra_sites)
+    bell_base = cursor
+    cursor += len(coupling_rows)
+    pump_base = cursor
+    cursor += len(pump_rows)
+    rail_base = cursor
+    cursor += len(fixture.cells)
+
+    slots: list[dict[str, object]] = []
+    stages = []
+    routes = []
+
+    def add_word(stage: str, word_id: str, entries) -> None:
+        stages.append(stage)
+        slots.append({
+            "stage": stage,
+            "words": [{
+                "id": word_id,
+                "stage": stage,
+                "accesses": merge_accesses(entries),
+            }],
+        })
+
+    add_word(
+        "A",
+        "A:clean_code_and_bank_supply",
+        ((register, "write") for register in range(2 * q)),
+    )
+
+    for index, (row, tag, correction) in enumerate(
+        zip(pump_rows, pump_tags, pump_corrections)
+    ):
+        syndrome = pump_base + index
+        anchor = tag_anchor(fixture, tag)
+        route = row_route(fixture, row, anchor)
+        routes.append((f"A:pump_measure:{index}", anchor, route))
+        add_word(
+            "A",
+            f"A:pump_measure:{index}",
+            (
+                *((register, "write") for register in support_indices(row)),
+                (syndrome, "write"),
+                *((register, "write") for register in route_rails(
+                    fixture, route, rail_base
+                )),
+            ),
+        )
+        correction_route = row_route(fixture, correction, anchor)
+        routes.append((
+            f"A:pump_correction:{index}", anchor, correction_route
+        ))
+        add_word(
+            "A",
+            f"A:pump_correction:{index}",
+            (
+                *((register, "write") for register in support_indices(
+                    correction
+                )),
+                (syndrome, "read"),
+                *((register, "write") for register in route_rails(
+                    fixture, correction_route, rail_base
+                )),
+            ),
+        )
+
+    for index, (tag, row) in enumerate(zip(tags, coupling_rows)):
+        ancilla = bell_base + index
+        anchor = tag_anchor(fixture, tag)
+        cells = set(doubled_row_cells(fixture, row))
+        cells.add(anchor)
+        route = P.returned_route(anchor, frozenset(cells))
+        routes.append((f"B:coupling:{index}", anchor, route))
+        add_word(
+            "B",
+            f"B:coupling:{index}",
+            (
+                *((register, "write") for register in support_indices(row)),
+                (ancilla, "write"),
+                *((register, "write") for register in route_rails(
+                    fixture, route, rail_base
+                )),
+            ),
+        )
+
+    for index in correction_order:
+        correction = corrections[index]
+        tag = tags[index]
+        ancilla = bell_base + index
+        anchor = tag_anchor(fixture, tag)
+        route = row_route(fixture, correction, anchor)
+        routes.append((f"C:correction:{index}", anchor, route))
+        add_word(
+            "C",
+            f"C:correction:{index}",
+            (
+                *((register, "write") for register in support_indices(
+                    correction
+                )),
+                (ancilla, "read"),
+                *((register, "write") for register in route_rails(
+                    fixture, route, rail_base
+                )),
+            ),
+        )
+
+    for index, instruction in enumerate(routed):
+        add_word(
+            "D",
+            f"D:G:{index}",
+            (
+                (g_register[tuple(site)], "write")
+                for site in instruction.sites
+            ),
+        )
+
+    handoffs = declare_handoffs(slots)
+    lawful = independent_liveness_walk(slots, handoffs)
+    route_failures = Counter()
+    for word_id, anchor, route in routes:
+        forward, inverse = P.route_execution_failures(anchor, route)
+        route_failures["forward"] += forward
+        route_failures["inverse"] += inverse
+
+    dropped_edge = next(
+        edge for edge in sorted(handoffs)
+        if edge[0].startswith("B:coupling:")
+        and edge[1].startswith("C:correction:")
+    )
+    dropped_handoffs = set(handoffs)
+    dropped_handoffs.remove(dropped_edge)
+    dropped_walk = independent_liveness_walk(
+        slots, dropped_handoffs
+    )
+    dropped_named = any(
+        violation.startswith("missing_handoff:")
+        and f"register={dropped_edge[2]}" in violation
+        for violation in dropped_walk["violations"]
+    )
+
+    duplicate_index = next(
+        index
+        for index, slot in enumerate(slots)
+        if slot["words"][0]["id"].startswith("B:coupling:")
+    )
+    duplicate_slots = list(slots)
+    original = slots[duplicate_index]["words"][0]
+    duplicate = {
+        "id": f"{original['id']}:duplicate_owner",
+        "stage": original["stage"],
+        "accesses": dict(original["accesses"]),
+    }
+    duplicate_slots[duplicate_index] = {
+        "stage": slots[duplicate_index]["stage"],
+        "words": [original, duplicate],
+    }
+    duplicate_walk = independent_liveness_walk(
+        duplicate_slots, handoffs
+    )
+    duplicate_named = any(
+        violation.startswith("collision:")
+        for violation in duplicate_walk["violations"]
+    )
+
+    stage_rank = {stage: index for index, stage in enumerate("ABCD")}
+    stage_order_failures = sum(
+        stage_rank[right] < stage_rank[left]
+        for left, right in zip(stages, stages[1:])
+    )
+    correction_layer_sequence = tuple(
+        correction_assignment[index] for index in correction_order
+    )
+    correction_layer_order_failures = sum(
+        right < left
+        for left, right in zip(
+            correction_layer_sequence,
+            correction_layer_sequence[1:],
+        )
+    )
+    return {
+        "shape": (2, 2, 2),
+        "root": root,
+        "axis_order": axis_order,
+        "pump_rows": len(pump_rows),
+        "pump_onsite_rows": sum(
+            tag[0].startswith("onsite") for tag in pump_tags
+        ),
+        "pump_tree_rows": sum(tag[0] == "tree" for tag in pump_tags),
+        "pump_fill_rows": sum(
+            tag[0] == "plaquette" for tag in pump_tags
+        ),
+        "coupling_rows": len(coupling_rows),
+        "coupling_physical_restriction_failures": restriction_failures,
+        "coupling_graph_tag_order_failures": int(
+            tuple(tags) != tuple(P.direct_graph_basis(fixture)[1])
+        ),
+        "correction_layers": (
+            max(correction_assignment, default=-1) + 1
+        ),
+        "correction_layer_order_failures": (
+            correction_layer_order_failures
+        ),
+        "stage_order_failures": stage_order_failures,
+        "recurrent_placement_collisions": int(
+            placed["placement_collisions"]
+        ),
+        "recurrent_logical_update_factors": int(
+            update_report["logical_update_factors"]
+        ),
+        "recurrent_routed_primitives": len(routed),
+        "recurrent_route_return_failures": int(
+            route_report["route_return_failures"]
+        ),
+        "recurrent_non_NN_failures": int(
+            route_report["non_NN_failures"]
+        ),
+        "A_B_C_route_failures": dict(route_failures),
+        "namespace": {
+            "code": (0, q),
+            "companion_encoded_bank": (q, 2 * q),
+            "G_routed_only_sites": (
+                2 * q, 2 * q + len(extra_sites)
+            ),
+            "Bell_ancillae": (
+                bell_base, bell_base + len(coupling_rows)
+            ),
+            "pump_syndromes": (
+                pump_base, pump_base + len(pump_rows)
+            ),
+            "route_rails": (
+                rail_base, rail_base + len(fixture.cells)
+            ),
+            "total_registers": cursor,
+        },
+        "lawful_walk": lawful,
+        "dropped_handoff_control": {
+            "deleted_edge": dropped_edge,
+            "violation_count": dropped_walk[
+                "ownership_or_handoff_violation_count"
+            ],
+            "named_missing_handoff_detected": dropped_named,
+        },
+        "duplicated_owner_control": {
+            "slot": duplicate_index,
+            "duplicated_word": original["id"],
+            "collision_count": duplicate_walk["collision_count"],
+            "named_collision_detected": duplicate_named,
+        },
+    }
+
+
+def fixed_sector_kraus_certificate() -> dict[str, object]:
+    """Derive dense Bell-branch Kraus maps without importing the EB runner."""
+    identity = np.eye(2, dtype=complex)
+    x = np.asarray(((0, 1), (1, 0)), dtype=complex)
+    z = np.asarray(((1, 0), (0, -1)), dtype=complex)
+    y = 1j * x @ z
+    correction_candidates = (identity, x, y, z)
+    phi = np.asarray((1, 0, 0, 1), dtype=complex) / math.sqrt(2)
+    bell_generators = (identity, x, z, x @ z)
+    bell_states = tuple(
+        np.kron(identity, generator) @ phi
+        for generator in bell_generators
+    )
+    bell_gram = np.asarray([
+        [np.vdot(left, right) for right in bell_states]
+        for left in bell_states
+    ])
+    isometry = np.kron(identity, phi.reshape(-1, 1))
+    uncorrected = tuple(
+        np.kron(bell.conj().reshape(1, 4), identity) @ isometry
+        for bell in bell_states
+    )
+    corrections = []
+    corrected = []
+    branch_identity_residual = 0.0
+    for kraus in uncorrected:
+        candidates = []
+        for correction in correction_candidates:
+            branch = correction @ kraus
+            scalar = np.trace(branch) / 2
+            residual = float(np.linalg.norm(
+                branch - scalar * identity
+            ))
+            candidates.append((residual, correction, branch, scalar))
+        residual, correction, branch, scalar = min(
+            candidates, key=lambda item: item[0]
+        )
+        corrections.append(correction)
+        corrected.append(branch)
+        branch_identity_residual = max(
+            branch_identity_residual,
+            residual,
+            abs(abs(scalar) - 0.5),
+        )
+    uncorrected_completeness = sum(
+        operator.conj().T @ operator for operator in uncorrected
+    )
+    corrected_completeness = sum(
+        operator.conj().T @ operator for operator in corrected
+    )
+    bell_residual = float(np.linalg.norm(
+        bell_gram - np.eye(4, dtype=complex)
+    ))
+    uncorrected_residual = float(np.linalg.norm(
+        uncorrected_completeness - identity
+    ))
+    corrected_residual = float(np.linalg.norm(
+        corrected_completeness - identity
+    ))
+    sectors = {}
+    maximum = max(
+        bell_residual,
+        uncorrected_residual,
+        corrected_residual,
+        branch_identity_residual,
+    )
+    for name, basis in (
+        ("even", (0, 3)),
+        ("odd", (1, 2)),
+    ):
+        embedding = np.eye(4, dtype=complex)[:, basis]
+        projector = embedding @ embedding.conj().T
+        lifted = tuple(
+            embedding @ operator @ embedding.conj().T
+            for operator in corrected
+        )
+        leakage = max(
+            float(np.linalg.norm(
+                (np.eye(4) - projector) @ operator @ projector
+            ))
+            for operator in lifted
+        )
+        lifted_completeness = sum(
+            operator.conj().T @ operator for operator in lifted
+        )
+        sector_residual = float(np.linalg.norm(
+            lifted_completeness - projector
+        ))
+        maximum = max(maximum, sector_residual, leakage)
+        sectors[name] = {
+            "sector_dimension": 2,
+            "Kraus_operators": len(lifted),
+            "completeness_residual": sector_residual,
+            "sector_leakage_residual": leakage,
+        }
+    return {
+        "physical_modes": 2,
+        "fixed_parity_sector_dimension": 2,
+        "outcomes_per_sector": 4,
+        "Bell_basis_orthonormality_residual": bell_residual,
+        "uncorrected_Kraus_completeness_residual": (
+            uncorrected_residual
+        ),
+        "corrected_Kraus_completeness_residual": corrected_residual,
+        "corrected_branch_identity_residual": (
+            branch_identity_residual
+        ),
+        "sectors": sectors,
+        "maximum_residual": maximum,
+        "construction": (
+            "four Kraus maps derived by contracting an input/resource Bell "
+            "basis against a dense Bell pair, corrected by the independently "
+            "selected logical Pauli, then embedded in each two-mode parity "
+            "sector"
+        ),
+    }
+
+
+def fixture_certificate(
+    conventions: dict[str, object],
+) -> dict[str, object]:
+    eb_module = (
+        "frontier_cycle720_companion_fixed_sector_even_car_bell_2026_07_27"
+    )
+    eb_present_before = eb_module in sys.modules
+    mass = U.C.R.local_free_contact_mass()["mass_contact"]
+    cycle230 = U.C712.cycle230_semantic_certificate(
+        U.C712.decoded_word(2)[0]
+    )
+    mass_fields = (
+        "one_particle_mass_residual",
+        "contact_vacuum_and_one_particle_residual",
+        "contact_double_occupation_phase_residual",
+    )
+    cycle230_fields = (
+        "coin_matrix_residual",
+        "mass_residual",
+        "FSWAP_matrix_residual",
+        "onsite_64_state_contact_residual",
+        "internal_depth_two_stream_residual",
+    )
+    mass_selected = {
+        name: float(mass[name]) for name in mass_fields
+    }
+    cycle230_selected = {
+        name: float(cycle230[name]) for name in cycle230_fields
+    }
+    kraus = fixed_sector_kraus_certificate()
+    return {
+        "mass_contact_residuals": mass_selected,
+        "cycle230_residuals": cycle230_selected,
+        "maximum_inherited_residual": max(
+            (*mass_selected.values(), *cycle230_selected.values())
+        ),
+        "EB_module_present_before_dense_rebuild": eb_present_before,
+        "EB_module_present_after_dense_rebuild": eb_module in sys.modules,
+        "two_mode_fixed_sector_Kraus": kraus,
+        "docstring_fixed_sector_inventory_evidence": (
+            conventions["F1_declares_fixed_X_and_character_Z"]
+            and conventions["F2_declares_one_six_mode_live_bank"]
+        ),
+    }
+
+
+def all_zero(mapping: dict[str, int]) -> bool:
+    return all(int(value) == 0 for value in mapping.values())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+    )
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    started = perf_counter()
+    source_root = args.source_root.resolve()
+    conventions = declared_conventions(source_root)
+    load_dependencies(source_root)
+
+    exchange = exchange_port_certificate(conventions)
+    dilation = dilation_certificate()
+    atlas = atlas_correction_certificate()
+    seam = seam_class_certificate()
+    epoch = epoch_liveness_certificate()
+    fixtures = fixture_certificate(conventions)
+    checks = []
+
+    def check(label: str, condition: bool) -> None:
+        checks.append({"label": label, "pass": bool(condition)})
+        print("PASS" if condition else "FAIL", label)
+
+    check(
+        "exchange_port_certificate",
+        exchange["convention_evidence_pass"]
+        and exchange["six_SWAP_blocks"] == 6
+        and exchange["CNOT_primitives"] == 18
+        and exchange["port_dictionary_rows"] == 36
+        and exchange["forward_dictionary_exchange_failures"] == 0
+        and exchange["reverse_dictionary_exchange_failures"] == 0
+        and exchange["all_affected_dictionary_exchange_failures"] == 0
+        and exchange["unaffected_dictionary_invariance_failures"] == 0
+        and exchange["cell_parity_image_failures"] == 0
+        and exchange["joint_parity_invariance_failures"] == 0
+        and exchange["odd_bank_detection_failures"] == 0
+        and exchange["odd_image_detection_failures"] == 0
+        and exchange["support_cells"] == 1
+        and exchange["support_diameter"] == 0
+        and exchange["dense_integer_Pauli_selftest"]["mismatches"] == 0,
+    )
+    check(
+        "dilation_certificate",
+        dilation["physical_restriction_tag_rebuild_failures"] == 0
+        and dilation["compiled_commutator_failures"] == 0
+        and dilation["graph_rank"] == dilation["compiled_rank"]
+        and dilation["graph_rank"] == dilation["rows"]
+        and dilation["dilation_X_invariance_failures"] == 0
+        and dilation["dilation_Z_character_failures"] == 0
+        and dilation["support_gate_failures"] == 0
+        and dilation["maximum_compiled_support_cells"] <= 2
+        and dilation["maximum_compiled_support_diameter"] <= 1,
+    )
+    check(
+        "atlas_correction_certificate",
+        atlas["graph_rank"] == atlas["graph_rows"]
+        and atlas["atlas_entries"] == atlas["graph_rows"]
+        and atlas["solve_contradictions"] == 0
+        and atlas["rows_without_one_cell_solution"] == 0
+        and atlas["one_hot_duality_failures"] == 0
+        and atlas["one_cell_support_failures"] == 0
+        and atlas["maximum_private_dual_support_cells"] <= 1,
+    )
+    check(
+        "seam_class_certificate",
+        seam["proper_cubic_frames"] == 24
+        and seam["translation_parities"] == 8
+        and seam["contexts"] == 24 * 8
+        and seam["missing_edge_failures"] == 0
+        and seam["zero_class_failures"] == 0
+        and seam["double_class_failures"] == 0
+        and seam["forward_class_count"] > 0
+        and seam["reversed_class_count"] > 0
+        and (
+            seam["forward_class_count"] + seam["reversed_class_count"]
+            == seam["transported_quadruples"]
+        ),
+    )
+    check(
+        "epoch_liveness_certificate",
+        epoch["coupling_physical_restriction_failures"] == 0
+        and epoch["coupling_graph_tag_order_failures"] == 0
+        and epoch["correction_layer_order_failures"] == 0
+        and epoch["stage_order_failures"] == 0
+        and epoch["recurrent_placement_collisions"] == 0
+        and epoch["recurrent_route_return_failures"] == 0
+        and epoch["recurrent_non_NN_failures"] == 0
+        and all_zero(epoch["A_B_C_route_failures"])
+        and epoch["lawful_walk"]["collision_count"] == 0
+        and (
+            epoch["lawful_walk"][
+                "ownership_or_handoff_violation_count"
+            ]
+            == 0
+        )
+        and epoch["dropped_handoff_control"][
+            "named_missing_handoff_detected"
+        ]
+        and epoch["dropped_handoff_control"]["violation_count"] > 0
+        and epoch["duplicated_owner_control"][
+            "named_collision_detected"
+        ]
+        and epoch["duplicated_owner_control"]["collision_count"] > 0,
+    )
+    check(
+        "fixture_certificate",
+        fixtures["maximum_inherited_residual"] < TOL
+        and not fixtures["EB_module_present_before_dense_rebuild"]
+        and not fixtures["EB_module_present_after_dense_rebuild"]
+        and fixtures["two_mode_fixed_sector_Kraus"][
+            "maximum_residual"
+        ] < 1e-12,
+    )
+
+    wording_corrections = [
+        (
+            "The epoch runner's description of its alternate port as the F2 "
+            "leg needs a namespace qualifier: standalone F2 declares one "
+            "six-qubit bank [q,q+6), whereas the epoch embeds a port-indexed "
+            "six-qubit sub-block inside the q-wide F1 bank [q,2q).  These "
+            "register conventions coincide only for port index zero."
+        )
+    ]
+    passing = all(row["pass"] for row in checks)
+    report = {
+        "status": "PASS" if passing else "FAIL",
+        "authority": "none",
+        "audit": "unset",
+        "top_level_blocklist": sorted(TOP_LEVEL_BLOCKLIST),
+        "blocked_primary_imports_present": sorted(
+            TOP_LEVEL_BLOCKLIST & set(sys.modules)
+        ),
+        "declared_conventions": conventions,
+        "checks": checks,
+        "certificates": {
+            "exchange_port": exchange,
+            "dilation": dilation,
+            "atlas_correction": atlas,
+            "seam_class": seam,
+            "epoch_liveness": epoch,
+            "fixture": fixtures,
+        },
+        "wording_corrections": wording_corrections,
+        "runtime_seconds": perf_counter() - started,
+    }
+    report["report_sha256"] = sha256(json.dumps(
+        report, sort_keys=True, separators=(",", ":")
+    ).encode()).hexdigest()
+    payload = json.dumps(report, indent=2, sort_keys=True)
+    if args.output:
+        args.output.write_text(payload + "\n")
+    print(payload)
+    print(
+        "CYCLE721_TOURNAMENT_INDEPENDENT_ADVERSARY_PASS"
+        if passing
+        else "CYCLE721_TOURNAMENT_INDEPENDENT_ADVERSARY_FAIL"
+    )
+    if not passing:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Cycle 721 of the computation-connection campaign: the three-route literal
physical-input and epoch-integration tournament declared in the Cycle-720
note's "Verdict and next experiment", closed positively at the
**bounded_theorem** ceiling (authority none, audit unset) on the unchanged
supplied inventory.

- **Route 1 — input-Bell M2 compiler**: every doubled even-CAR Bell row
  (`11N+E`, up to 995 rows on `5x5x3`) compiles to a literal
  `H; controlled-Pauli; H` physical word with retained ancilla and returned
  NN routing; the preregistered two-cell/diameter-one support gate passes on
  all six boxes; measurement conflict coloring obeys the exact law
  `3 + maximum cell degree` (interior saturation certified on `4x4x4` and
  `5x5x3`); corrections stay the frozen Cycle-720 one-cell private duals.
  The Cycle-720 receipt flag
  `even_car_input_bell_measurement_physical_M2_compiled` becomes **true** at
  this package's resolution.
- **Route 2 — encoded-input Clifford port**: an 18-primitive reversible
  even-exchange port, exact on the full 36-row port dictionary; the
  seam-extended coupling synthesizes **port-local** (support 1 cell,
  diameter 0) — the constructive counterpoint to the Cycle-720 raw-mode
  route's 7-cell/diameter-4 growth. The `V_s`-restriction compiler remains
  `UNTESTED/OPEN` (no public factorization-object API; measured locality
  ceiling recorded).
- **Route 3 — collision-free epoch**: Choi pump + input coupling (both
  legs) + retained correction banks + the unchanged recurrent word compose
  on one literal site map under a Cycle-54-compliant register-liveness slot
  walk (76,376 slots / 159,219 touches on `5x3x2`, zero violations), with
  recurrent one-step, orientation/interleave/deletion, mass/contact, and
  Cycle-230 fixture gates unchanged, and schedule-key covariance over 192
  frame/parity contexts.
- **Independent adversary**: blocklists the three primaries, rebuilds the
  algebra with independently written conjugation (8,208 dense comparisons),
  6/6 certificates; its one wording correction is adopted in the note.

## Artifacts

- Note: `docs/CAR_BELL_INPUT_PHYSICAL_M2_COMPILER_CYCLE721_BOUNDED_THEOREM_NOTE_2026-07-28.md`
- Runners: `scripts/frontier_cycle721_{car_bell_input_m2_compiler,encoded_input_clifford_port,collision_free_epoch_composition,tournament_independent_adversary}_2026_07_28.py`
- Content-pinned caches: `logs/runner-cache/frontier_cycle721_*.txt`
- Receipt: `outputs/car_bell_input_epoch_tournament_cycle721_receipt_2026_07_28.json`
- Loop pack (branch-local): `.claude/science/physics-loops/computation-connection-20260727/`
  — `GOAL.md` (target contract), `ROUTE_PORTFOLIO.md` (prior-art sweep at
  `2f2f4878ca`, commands + matched-hit classification), `NO_GO_LEDGER.md`,
  `ASSUMPTIONS_AND_IMPORTS.md` (counterfactual pass),
  `APPROACH_REGISTRY.md`, `TRACE_GATE.md`, `CLAIM_STATUS_CERTIFICATE.md`,
  `REVIEW_HISTORY.md` (V1-V5 record + supervisor review log),
  `HANDOFF.md`, `STATE.yaml`.

## Verification

```
PYTHONPATH=scripts python3 scripts/frontier_cycle721_car_bell_input_m2_compiler_2026_07_28.py       # 10/10 PASS, ~240s
PYTHONPATH=scripts python3 scripts/frontier_cycle721_encoded_input_clifford_port_2026_07_28.py       # 22/22 PASS, ~21s
PYTHONPATH=scripts python3 scripts/frontier_cycle721_collision_free_epoch_composition_2026_07_28.py  # 6/6 PASS, ~82s
PYTHONPATH=scripts python3 scripts/frontier_cycle721_tournament_independent_adversary_2026_07_28.py  # 6/6 PASS, ~6s
```

All four rerun by the supervisor in this worktree; caches refreshed through
`runner_cache.execute_and_write_cache` (content + declared-input pinned).

## Trace / imports / status

- Trace: `direct_blocker_closure` — retires, at bounded resolution, the two
  quoted Cycle-720 Open items ("a literal physical-M2 circuit for the
  input-side even-CAR Bell measurements"; "a collision-free composition of
  Choi preparation, Bell coupling, correction controller, and recurrent
  matter word on one literal site map") and moves N1 escape route 4
  (direct encoded-input Clifford) from UNTESTED/OPEN to
  ATTEMPTED-constructive. `reachability: partially_closes` — autonomy,
  genesis, boundary-free recurrence, renewal, and all downstream
  time/Record/Born/source content remain open exactly as inherited.
- Imports: zero external; landed Cycle-720 modules imported as prior
  bounded authority (authority none, audit unset); registered primitives
  not load-bearing. Two new supplied conventions are declared:
  companion-encoded input bank; declared-port chart.
- Negative claims: none ship (see the note's negative-claim discipline
  section; design-history statements are supplied conventions; the
  Cycle-720 raw-Bell diagnostic is cited only at its original scope).
- **Independent audit is still required before the repo may treat any part
  of this as retained-grade.** Review-loop and audit lanes are
  owner-operated; this PR is the handoff surface.

## Remaining blockers (inherited, unchanged)

Autonomous sector/genesis/enforcement; boundary-free translation-invariant
recurrence; periodic topology/fault repair/renewal/multi-source
composition; `V_s`-restriction compiler (needs a public
factorization-object API in a new module); objective actuality/admission,
physical time/rate, permanent Record, Born weighting, source/gravity
meaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
