### PR TITLE
science: full-Fock Cycle-320 unit-weight auxiliary source (support, n_max=2)

### DIFF
--- a/docs/FULL_FOCK_UNIT_WEIGHT_SOURCE_SUPPORT_NOTE_2026-07-28.md
+++ b/docs/FULL_FOCK_UNIT_WEIGHT_SOURCE_SUPPORT_NOTE_2026-07-28.md
@@ -1,0 +1,92 @@
+# The full-Fock unit-weight auxiliary source — constructed
+
+Date: 2026-07-28
+
+Authority: none
+
+Audit: unset
+
+Status: bounded conditional construction
+
+Claim type: bounded_theorem
+
+Runners:
+
+- [`frontier_full_fock_unit_weight_source_2026_07_28.py`](../scripts/frontier_full_fock_unit_weight_source_2026_07_28.py)
+- [`frontier_full_fock_independent_check_2026_07_28.py`](../scripts/frontier_full_fock_independent_check_2026_07_28.py)
+
+Constitutional effect: none. This package changes no axiom, foundation,
+Qualification, primitive, registry, policy, queue, audit result, or audit
+status.
+
+## Result up front
+
+The landed Cycle-322 reciprocity surface names "full-Fock Cycle-320
+unit-weight auxiliary sources" as its absent deeper lift, and the
+Cycle-322 lineage recorded that lift as its sharpest next test. This
+package constructs it at the smallest honest scope — occupancy truncation
+`n_max = 2` on the landed two-cell fixture, reusing the landed modules'
+own state and operator machinery with one declared embedding convention
+(occupancy layers as local six-mode matter masks with
+`bit_count(mask) = n`; the endpoint reservoir and the landed matched
+unit-weight pair unchanged):
+
+- **per-layer channels 0 / 6 / 24** for `n = 0, 1, 2` (the binomial
+  pair arithmetic of six modes);
+- **layer 1 reproduces the landed one-carrier anchor exactly**: emitted
+  unit weight `0.1258992161287137` with component residual `1.1e-16` —
+  the regression anchor to the landed mechanism;
+- **exact per-channel recoil algebra in every layer**:
+  `ΔP_matter = -2d`, `P_F = +d`, `P_A = +d` — the unit-weight law holds
+  layer by layer;
+- **layer independence, exhaustive**: zero cross-layer leakage across
+  all 6,776 two-cell columns of the truncated Fock space; reciprocity
+  residual `3.35e-16` per layer and for superposed two-layer states;
+- the byte-pinned Cycle-322 harness reruns unchanged (20/20) as the
+  anchor; a deliberately mis-embedded layer (`n=2 -> 1`) breaks the
+  number-commutator detectably (norm `1.414...`);
+- `full_fock_construction_achieved: true`; no obstruction was
+  encountered — the landed algebra supports independent layers without
+  new supplied structure beyond the declared truncation and embedding.
+
+## Supplied / derived / open
+
+### Supplied
+
+- the occupancy truncation `n_max = 2` and the layer-embedding
+  convention (declared, printed);
+- everything the landed Cycle-320/322 surfaces themselves declare.
+
+### Derived
+
+- the full-Fock lift at the declared truncation: per-layer unit-weight
+  recoil, exhaustive layer independence, per-layer and superposed
+  reciprocity, with the landed layer-1 anchor exact;
+- the mis-embedding detection control;
+- the unchanged byte-pinned harness anchor.
+
+### Open
+
+- higher truncations (`n_max > 2`) and any untruncated statement;
+- everything the landed surfaces leave open at their scopes (no source
+  law, response law, or gravity content is selected here — the
+  `C_source` firewall applies verbatim);
+- wiring this lift into the acceptance-harness set as an input-ported
+  surface (the natural next infrastructure step, completing the
+  source-lane ceiling program).
+
+## Negative-claim discipline
+
+No negative claim ships. The construction succeeded; the truncation and
+embedding are declared supplies; the mis-embedding control is a
+sensitivity demonstration.
+
+## Verdict
+
+The source lane's own sharpest-next-test language is discharged at
+bounded truncation: the full-Fock unit-weight auxiliary source exists,
+anchored to the landed mechanism, with exhaustive layer independence.
+Together with the acceptance-harness set, the gravity/source lane now
+has both the missing construction and the missing test infrastructure;
+what remains above is review ratification and the physics that must pass
+through them.

--- a/logs/runner-cache/frontier_full_fock_independent_check_2026_07_28.txt
+++ b/logs/runner-cache/frontier_full_fock_independent_check_2026_07_28.txt
@@ -1,0 +1,22 @@
+===== runner cache v1 =====
+runner: scripts/frontier_full_fock_independent_check_2026_07_28.py
+runner_sha256: eef9e28a1cf24ac33dce931fc47a5117d0272491d98abecccd55d27e39e76ce2
+input_fingerprint_sha256: ccacfbb9fd83f2b249499e0ea0259515f748f24be23abced19d78ad4d672bf2a
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 45.75
+status: ok
+----- stdout -----
+FULL-FOCK INDEPENDENT CHECK
+primary_mode = AST data only; import blocklisted
+PASS extraction() :: {'audit_tuple_literal_eval': ('scripts/unit_weight_carried_link_recoil_cycle320_2026_07_18.py', 'scripts/two_cell_two_source_recoil_reciprocity_cycle322_2026_07_18.py'), 'cycle322_sha256': '4f7e25a20bcea41c285bfb52b122f84ec5c41f1f6095b6ec0068d2a228ed5d75', 'embedding': 'P_n selects local six-mode matter masks with bit_count(mask)=n; q=0 is the endpoint reservoir and q=1+d is the landed matched unit-weight pair (F_d,A_d).  The two-cell factors are V_left tensor I and I tensor V_right in S322.JOINT_INDEX, so the spectator mask and every other number sector are unchanged.', 'frozen_layer1_weight': 0.12589921612871374, 'frozen_layer_channel_counts': (0, 6, 24), 'n_max': 2, 'reservoir_q': 0, 'pair_q': '1+d', 'summary_anchor': (20, 0)}
+PASS layer1_anchor_recount() :: {'directions': 6, 'frozen_weight': 0.12589921612871374, 'weight_range': (0.12589921612871374, 0.12589921612871374), 'maximum_ulp_error': 0.0}
+PASS layer_channel_recount() :: {'C(6,n)_mask_counts': (1, 6, 15), 'active_channel_counts': (0, 6, 24), 'formula_6*C(4,n-1)': (0, 6, 24), 'hop_mismatches': 0}
+PASS leakage_spot_recount() :: {'cell': (0, 0, 0), 'channel_family': 'all n=1 x n=2 active channel pairs', 'channel_pairs': 144, 'directed_operator_entries_checked': 2304, 'maximum_cross_layer_leakage': 0.0, 'operator_residuals_against_landed': {'exchange': 0.0, 'vertex': 0.0}, 'recoil_channels_checked': 30, 'recoil_equation': '(-2d, +d, +d)', 'recoil_failures': 0}
+PASS anchor_replay() :: {'returncode': 0, 'pass_lines': 20, 'fail_lines': 0, 'frozen_result': (20, 0), 'runtime_seconds': 45.33926, 'stderr_tail': ''}
+PASS discipline() :: {'blocklist': ('frontier_full_fock_unit_weight_source_2026_07_28',), 'blocklisted_modules_loaded': (), 'conventions_are_literal_eval_data': True, 'misembedding_control_in_primary_ast': True, 'primary_attribute_writes': []}
+SUMMARY {'pass': 6, 'fail': 0, 'runtime_seconds': 45.382301}
+FINAL ALL_PASS 6/6
+
+----- stderr -----
+

--- a/logs/runner-cache/frontier_full_fock_unit_weight_source_2026_07_28.txt
+++ b/logs/runner-cache/frontier_full_fock_unit_weight_source_2026_07_28.txt
@@ -1,0 +1,25 @@
+===== runner cache v1 =====
+runner: scripts/frontier_full_fock_unit_weight_source_2026_07_28.py
+runner_sha256: fe5ce8e2e993a1da5ff1b05f18706a62a44c3ad6d28347b28fa4493fd24ba8c9
+input_fingerprint_sha256: ccacfbb9fd83f2b249499e0ea0259515f748f24be23abced19d78ad4d672bf2a
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 45.45
+status: ok
+----- stdout -----
+FULL-FOCK CYCLE-320 UNIT-WEIGHT AUXILIARY SOURCE
+occupancy_truncation_n_max = 2
+layer_embedding = P_n selects local six-mode matter masks with bit_count(mask)=n; q=0 is the endpoint reservoir and q=1+d is the landed matched unit-weight pair (F_d,A_d).  The two-cell factors are V_left tensor I and I tensor V_right in S322.JOINT_INDEX, so the spectator mask and every other number sector are unchanged.
+interpretation = dimensionless source/recoil algebra only
+PASS the landed coefficient-two diagonal splits exactly into mediator weight one plus auxiliary weight one :: {'generator_P_commutators': (0.0, 0.0, 0.0), 'unit_weights': (1, 1, 1), 'vertex_P_commutators': (0.0, 0.0, 0.0)}
+PASS the reused source preserves Q and local occupation number :: {'Q_commutator': 0.0, 'number_commutator': 0.0}
+PASS layer 1 reproduces all six landed U320 LinkState recoil rows :: {'emitted_weight_range': (0.1258992161287137, 0.12589921612871374), 'maximum_component_residual': 1.1102230246251565e-16, 'matter_recoil_magnitude': 0.2517984322574274, 'mediator_flux_magnitude': 0.1258992161287137, 'auxiliary_flux_magnitude': 0.1258992161287137}
+PASS every allowed channel through n_max has the exact landed unit-weight recoil ledger :: {'layers': [{'active_channels': 0, 'generator_ledger_residual': 0.0, 'number': 0}, {'active_channels': 6, 'generator_ledger_residual': 0.0, 'number': 1}, {'active_channels': 24, 'generator_ledger_residual': 0.0, 'number': 2}], 'recoil_equation': 'Delta P_matter=-2 d; P_F=+d; P_A=+d'}
+PASS the two-cell truncated Fock space is exhaustively layer-independent :: {'active_q_columns_checked': 6776, 'cross_layer_failures': 0, 'joint_matter_states': 484, 'maximum_cross_layer_amplitude': 0.0}
+PASS reciprocity holds in every layer and on a coherent n=1 plus n=2 state :: {'maximum_layer_reciprocity_residual': 3.347971367310914e-16, 'superposed_state': {'inverse_residual': 1.1102230246251565e-16, 'layer_weight_residual': 5.551115123125783e-17, 'norm_residual': 1.1102230246251565e-16}, 'superposed_matrix_element': {'forward_abs': 0.4282003106804182, 'matrix_element_residual': 0.0, 'reverse_abs': 0.4282003106804182}}
+PASS a deliberate n=2 to n=1 mis-embedding breaks layer independence :: {'cross_layer_generator_amplitude': 1.0, 'number_commutator_frobenius': 1.4142135623730951, 'source_number': 2, 'target_number': 1}
+PASS the byte-pinned Cycle-322 harness reruns unchanged :: {'returncode': 0, 'runtime_seconds': 44.775871, 'sha256_after': '4f7e25a20bcea41c285bfb52b122f84ec5c41f1f6095b6ec0068d2a228ed5d75', 'sha256_before': '4f7e25a20bcea41c285bfb52b122f84ec5c41f1f6095b6ec0068d2a228ed5d75', 'stderr_empty': True, 'summary_pinned': True, 'terminal_marker_pinned': True}
+FINAL_JSON {"audit_input_paths": ["scripts/unit_weight_carried_link_recoil_cycle320_2026_07_18.py", "scripts/two_cell_two_source_recoil_reciprocity_cycle322_2026_07_18.py"], "certificate_failures": [], "cycle322_anchor": {"returncode": 0, "runtime_seconds": 44.775871, "sha256": "4f7e25a20bcea41c285bfb52b122f84ec5c41f1f6095b6ec0068d2a228ed5d75"}, "full_fock_construction_achieved": true, "layer_embedding": "P_n selects local six-mode matter masks with bit_count(mask)=n; q=0 is the endpoint reservoir and q=1+d is the landed matched unit-weight pair (F_d,A_d).  The two-cell factors are V_left tensor I and I tensor V_right in S322.JOINT_INDEX, so the spectator mask and every other number sector are unchanged.", "layer_rows": [{"active_channels": 0, "dimension": 7, "emitted_weight_max": 0.0, "emitted_weight_min": 0.0, "generator_ledger_residual": 0.0, "number": 0, "reciprocity_residual": 0.0, "unitarity_residual": 0.0, "vacuum_source_is_identity": true}, {"active_channels": 6, "dimension": 42, "emitted_weight_max": 0.12589921612871374, "emitted_weight_min": 0.1258992161287137, "generator_ledger_residual": 0.0, "number": 1, "reciprocity_residual": 1.9229626863835638e-16, "unitarity_residual": 3.3306690738754696e-16, "vacuum_source_is_identity": true}, {"active_channels": 24, "dimension": 105, "emitted_weight_max": 0.12042616790869433, "emitted_weight_min": 0.1204261679086943, "generator_ledger_residual": 0.0, "number": 2, "reciprocity_residual": 3.347971367310914e-16, "unitarity_residual": 7.274926451295658e-16, "vacuum_source_is_identity": true}], "n_max": 2, "note_path": "docs/FULL_FOCK_UNIT_WEIGHT_SOURCE_SUPPORT_NOTE_2026-07-28.md", "obstruction": null, "runtime_seconds": 44.866817, "scope": "local full-Fock source algebra on the landed two-cell fixture; no new recurrent simultaneous-carrier transport claim", "summary": {"fail": 0, "pass": 8}}
+
+----- stderr -----
+

--- a/outputs/full_fock_unit_weight_source_receipt_2026_07_28.json
+++ b/outputs/full_fock_unit_weight_source_receipt_2026_07_28.json
@@ -1,0 +1,53 @@
+{
+  "artifacts": {
+    "caches": {
+      "frontier_full_fock_independent_check_2026_07_28.txt": "acc36f3546d3fc160f98573482dc8b9d219f7ebed402f5ce08755cf1feb215df",
+      "frontier_full_fock_unit_weight_source_2026_07_28.txt": "46721134800fd67c163502e0885276b299af76c496d40ba463e5732c2c9febad"
+    },
+    "note": {
+      "path": "docs/FULL_FOCK_UNIT_WEIGHT_SOURCE_SUPPORT_NOTE_2026-07-28.md",
+      "sha256": "fbf1e66e5eb92cfacff26be4fc84b64f49605bf9c52b85f54f0c0b69a4fa9dc1"
+    },
+    "runners": {
+      "frontier_full_fock_independent_check_2026_07_28.py": "eef9e28a1cf24ac33dce931fc47a5117d0272491d98abecccd55d27e39e76ce2",
+      "frontier_full_fock_unit_weight_source_2026_07_28.py": "fe5ce8e2e993a1da5ff1b05f18706a62a44c3ad6d28347b28fa4493fd24ba8c9"
+    }
+  },
+  "audit": "unset",
+  "authority": "none",
+  "boundary": {
+    "axiom_pressure": false,
+    "c_source_firewall": "no source law, response law, or gravity content is selected; the package is dimensionless source/recoil algebra on the landed two-cell fixture",
+    "fixed_supplies": "the occupancy truncation n_max=2 and the declared layer-embedding convention (occupancy layers as local six-mode matter masks with bit_count(mask)=n; endpoint reservoir q=0 and the landed matched unit-weight pair unchanged), plus everything the landed Cycle-320/322 surfaces themselves declare supplied",
+    "full_fock_construction_achieved": true,
+    "not_derived": "higher truncations (n_max>2) or any untruncated statement; no recurrent simultaneous-carrier transport claim; everything the landed surfaces leave open at their scopes",
+    "occupancy_truncation_n_max": 2,
+    "positive_scope": "per-layer channels 0/6/24; layer-1 landed one-carrier anchor exact (0 ULP recount); exact per-channel recoil algebra (-2d,+d,+d) in every layer; exhaustive layer independence over all 6776 active two-cell columns; per-layer and superposed reciprocity at machine scale; byte-pinned Cycle-322 harness unchanged (20/20); mis-embedding detection control"
+  },
+  "checks": {
+    "independent_named_checks_failed": 0,
+    "independent_named_checks_passed": 6,
+    "primary_named_checks_passed": 8
+  },
+  "claim_type": "bounded_theorem",
+  "cycle_lineage": [
+    320,
+    322
+  ],
+  "date": "2026-07-28",
+  "result": {
+    "cross_layer_failures_over_6776_columns": 0,
+    "cycle322_anchor_replay": "20/20",
+    "layer1_anchor_max_ulp_error": 0.0,
+    "layer1_anchor_weight": 0.1258992161287137,
+    "layer_channel_counts": [
+      0,
+      6,
+      24
+    ],
+    "misembedding_control_number_commutator_frobenius": 1.4142135623730951,
+    "obstruction": null,
+    "recoil_equation": "Delta P_matter=-2d; P_F=+d; P_A=+d"
+  },
+  "status": "FULL_FOCK_UNIT_WEIGHT_SOURCE_PASS"
+}

--- a/scripts/frontier_full_fock_independent_check_2026_07_28.py
+++ b/scripts/frontier_full_fock_independent_check_2026_07_28.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""Independent checker for the bounded full-Fock unit-weight construction.
+
+The construction source is parsed as data and is never imported.  Numerical
+operators below are independently assembled from the landed U320 and S322
+public interfaces.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+import math
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+from typing import Any, Callable
+
+import numpy as np
+from scipy.linalg import expm
+
+
+AUDIT_TIMEOUT_SEC = 900
+NOTE_PATH = "docs/FULL_FOCK_UNIT_WEIGHT_SOURCE_SUPPORT_NOTE_2026-07-28.md"
+AUDIT_INPUT_PATHS = (
+    "scripts/unit_weight_carried_link_recoil_cycle320_2026_07_18.py",
+    "scripts/two_cell_two_source_recoil_reciprocity_cycle322_2026_07_18.py",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+PRIMARY_DATA_PATH = (
+    ROOT / "scripts/frontier_full_fock_unit_weight_source_2026_07_28.py"
+)
+IMPORT_BLOCKLIST = (
+    "frontier_full_fock_unit_weight_source_2026_07_28",
+)
+
+# Frozen audit anchors.  The first two are independently recounted below.
+FROZEN_N_MAX = 2
+FROZEN_LAYER_CHANNEL_COUNTS = (0, 6, 24)
+FROZEN_LAYER1_WEIGHT = 0.12589921612871374
+FROZEN_S322_PASS = 20
+FROZEN_S322_FAIL = 0
+FROZEN_CYCLE322_SHA256 = (
+    "4f7e25a20bcea41c285bfb52b122f84ec5c41f1f6095b6ec0068d2a228ed5d75"
+)
+TOLERANCE = 3e-10
+
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import unit_weight_carried_link_recoil_cycle320_2026_07_18 as U320
+import two_cell_two_source_recoil_reciprocity_cycle322_2026_07_18 as S322
+
+
+PASS = 0
+FAIL = 0
+
+
+@dataclass(frozen=True)
+class ExtractedConvention:
+    text: str
+    n_max: int
+    reservoir_q: int
+    pair_q_offset: int
+    audit_input_paths: tuple[str, ...]
+    tolerance: float
+    cycle322_sha256: str
+    cycle322_summary_marker: str
+    cycle322_terminal_marker: str
+
+
+@dataclass(frozen=True)
+class Channel:
+    number: int
+    source_mask: int
+    target_mask: int
+    direction: int
+    sign: int
+    reservoir_index: int
+    pair_index: int
+
+
+def check(label: str, condition: bool, detail: object = "") -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print("PASS", label, "::", detail)
+    else:
+        FAIL += 1
+        print("FAIL", label, "::", detail)
+
+
+def _literal_assignments(tree: ast.AST) -> dict[str, Any]:
+    assignments: dict[str, Any] = {}
+    for node in getattr(tree, "body", ()):
+        name: str | None = None
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            if isinstance(node.targets[0], ast.Name):
+                name = node.targets[0].id
+                value = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            name = node.target.id
+            value = node.value
+        if name is None or value is None:
+            continue
+        try:
+            assignments[name] = ast.literal_eval(value)
+        except (ValueError, TypeError):
+            continue
+    return assignments
+
+
+def _primary_ast() -> tuple[str, ast.Module]:
+    source = PRIMARY_DATA_PATH.read_text(encoding="utf-8")
+    return source, ast.parse(source, filename=str(PRIMARY_DATA_PATH))
+
+
+def extraction() -> tuple[bool, dict[str, object], ExtractedConvention | None]:
+    """Extract only literal conventions and anchors from the primary AST."""
+    _source, tree = _primary_ast()
+    literals = _literal_assignments(tree)
+    required = (
+        "AUDIT_TIMEOUT_SEC",
+        "NOTE_PATH",
+        "AUDIT_INPUT_PATHS",
+        "N_MAX",
+        "TOLERANCE",
+        "CYCLE322_SHA256",
+        "LAYER_EMBEDDING",
+    )
+    missing = tuple(name for name in required if name not in literals)
+    if missing:
+        return False, {"missing_literal_assignments": missing}, None
+
+    embedding = literals["LAYER_EMBEDDING"]
+    source_audit_paths = literals["AUDIT_INPUT_PATHS"]
+    strings = {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+    summary_marker = (
+        f"SUMMARY {{'pass': {FROZEN_S322_PASS}, 'fail': {FROZEN_S322_FAIL}}}"
+    )
+    terminal_marker = "RESULT TWO_CELL_TWO_SOURCE_RECOIL_RECIPROCITY_CERTIFIED"
+
+    reservoir_match = re.search(r"\bq=(\d+)\s+is the endpoint reservoir", embedding)
+    pair_match = re.search(r"\bq=(\d+)\+d\s+is the landed matched", embedding)
+    convention = None
+    if reservoir_match and pair_match:
+        convention = ExtractedConvention(
+            text=embedding,
+            n_max=literals["N_MAX"],
+            reservoir_q=int(reservoir_match.group(1)),
+            pair_q_offset=int(pair_match.group(1)),
+            audit_input_paths=source_audit_paths,
+            tolerance=literals["TOLERANCE"],
+            cycle322_sha256=literals["CYCLE322_SHA256"],
+            cycle322_summary_marker=summary_marker,
+            cycle322_terminal_marker=terminal_marker,
+        )
+
+    conditions = (
+        isinstance(embedding, str)
+        and "P_n selects local six-mode matter masks with bit_count(mask)=n"
+        in embedding
+        and "(F_d,A_d)" in embedding
+        and "V_left tensor I" in embedding
+        and "I tensor V_right" in embedding
+        and convention is not None
+        and convention.reservoir_q == 0
+        and convention.pair_q_offset == 1
+        and literals["N_MAX"] == FROZEN_N_MAX
+        and literals["TOLERANCE"] == TOLERANCE
+        and literals["CYCLE322_SHA256"] == FROZEN_CYCLE322_SHA256
+        and source_audit_paths == AUDIT_INPUT_PATHS
+        and literals["AUDIT_TIMEOUT_SEC"] == AUDIT_TIMEOUT_SEC
+        and literals["NOTE_PATH"] == NOTE_PATH
+        and summary_marker in strings
+        and terminal_marker in strings
+    )
+    ok = bool(conditions)
+    detail = {
+        "audit_tuple_literal_eval": source_audit_paths,
+        "cycle322_sha256": literals["CYCLE322_SHA256"],
+        "embedding": embedding,
+        "frozen_layer1_weight": FROZEN_LAYER1_WEIGHT,
+        "frozen_layer_channel_counts": FROZEN_LAYER_CHANNEL_COUNTS,
+        "n_max": literals["N_MAX"],
+        "reservoir_q": None if convention is None else convention.reservoir_q,
+        "pair_q": None if convention is None else "1+d",
+        "summary_anchor": (FROZEN_S322_PASS, FROZEN_S322_FAIL),
+    }
+    return ok, detail, convention
+
+
+def layer1_anchor_recount() -> tuple[bool, dict[str, object]]:
+    """Recount the six U320 source branches without using the primary."""
+    origin = (0, 0, 0)
+    rows = []
+    for direction in range(6):
+        excited = np.zeros(6, dtype=complex)
+        excited[direction] = 1.0
+        state = U320.LinkState({origin: excited}, {})
+        output, report = U320.vertex_gate(state, U320.ANGLE)
+        pair = output.pair[(origin, origin)]
+        emitted_weight = float(np.vdot(pair, pair).real)
+        expected_index = (
+            U320.REVERSE[direction],
+            direction,
+            direction,
+        )
+        support = tuple(
+            tuple(int(index) for index in row)
+            for row in np.argwhere(abs(pair) > 0.0)
+        )
+        rows.append(
+            {
+                "direction": direction,
+                "emitted_weight": emitted_weight,
+                "expected_index": expected_index,
+                "support": support,
+                "local_Q_residual": report["local_Q_residual"],
+                "local_P_residual": report["local_P_residual"],
+            }
+        )
+
+    weights = tuple(row["emitted_weight"] for row in rows)
+    maximum_ulp_error = max(
+        abs(weight - FROZEN_LAYER1_WEIGHT) / math.ulp(FROZEN_LAYER1_WEIGHT)
+        for weight in weights
+    )
+    ok = (
+        all(weight == FROZEN_LAYER1_WEIGHT for weight in weights)
+        and all(row["support"] == (row["expected_index"],) for row in rows)
+        and max(row["local_Q_residual"] for row in rows) < TOLERANCE
+        and max(row["local_P_residual"] for row in rows) < TOLERANCE
+    )
+    return ok, {
+        "directions": len(rows),
+        "frozen_weight": FROZEN_LAYER1_WEIGHT,
+        "weight_range": (min(weights), max(weights)),
+        "maximum_ulp_error": maximum_ulp_error,
+    }
+
+
+def _own_hop(mask: int, direction: int) -> tuple[int, int] | None:
+    target = U320.REVERSE[direction]
+    if not ((mask >> direction) & 1) or ((mask >> target) & 1):
+        return None
+    source_parity = (mask & ((1 << direction) - 1)).bit_count()
+    reduced = mask ^ (1 << direction)
+    target_parity = (reduced & ((1 << target) - 1)).bit_count()
+    sign = -1 if (source_parity + target_parity) % 2 else 1
+    return reduced | (1 << target), sign
+
+
+def layer_channel_recount() -> tuple[bool, dict[str, object]]:
+    """Recount bit masks and active opposing-mode hops for n=0,1,2."""
+    masks = tuple(range(1 << 6))
+    mask_counts = []
+    channel_counts = []
+    formula_counts = []
+    landed_hop_mismatches = []
+    for number in range(FROZEN_N_MAX + 1):
+        layer_masks = tuple(mask for mask in masks if mask.bit_count() == number)
+        channels = 0
+        for mask in layer_masks:
+            for direction in range(6):
+                own = _own_hop(mask, direction)
+                landed = S322.fermion_hop(
+                    mask, direction, U320.REVERSE[direction]
+                )
+                channels += own is not None
+                if own != landed:
+                    landed_hop_mismatches.append((mask, direction, own, landed))
+        mask_counts.append(len(layer_masks))
+        channel_counts.append(channels)
+        formula_counts.append(6 * math.comb(4, number - 1) if number else 0)
+
+    expected_masks = tuple(math.comb(6, number) for number in range(3))
+    ok = (
+        tuple(mask_counts) == expected_masks
+        and tuple(channel_counts) == FROZEN_LAYER_CHANNEL_COUNTS
+        and tuple(formula_counts) == FROZEN_LAYER_CHANNEL_COUNTS
+        and set(S322.LOCAL_MASKS) == set(masks)
+        and not landed_hop_mismatches
+    )
+    return ok, {
+        "C(6,n)_mask_counts": tuple(mask_counts),
+        "active_channel_counts": tuple(channel_counts),
+        "formula_6*C(4,n-1)": tuple(formula_counts),
+        "hop_mismatches": len(landed_hop_mismatches),
+    }
+
+
+def _own_local_operators(
+    convention: ExtractedConvention,
+) -> tuple[np.ndarray, np.ndarray, tuple[Channel, ...]]:
+    dimension = len(S322.LOCAL_MASKS) * 7
+    exchange = np.zeros((dimension, dimension), dtype=complex)
+    channels = []
+    for source_index, source_mask in enumerate(S322.LOCAL_MASKS):
+        for direction in range(6):
+            hopped = _own_hop(source_mask, direction)
+            if hopped is None:
+                continue
+            target_mask, sign = hopped
+            target_index = S322.LOCAL_INDEX[target_mask]
+            reservoir_index = 7 * source_index + convention.reservoir_q
+            pair_index = (
+                7 * target_index + convention.pair_q_offset + direction
+            )
+            exchange[pair_index, reservoir_index] += sign
+            exchange[reservoir_index, pair_index] += sign
+            channels.append(
+                Channel(
+                    number=source_mask.bit_count(),
+                    source_mask=source_mask,
+                    target_mask=target_mask,
+                    direction=direction,
+                    sign=sign,
+                    reservoir_index=reservoir_index,
+                    pair_index=pair_index,
+                )
+            )
+    vertex = expm(1j * U320.ANGLE * exchange)
+    return exchange, vertex, tuple(channels)
+
+
+def _mask_vector(mask: int) -> np.ndarray:
+    total = np.zeros(3, dtype=int)
+    for direction in range(6):
+        if (mask >> direction) & 1:
+            total += U320.c210.DIRECTIONS[direction]
+    return total
+
+
+def leakage_spot_recount(
+    convention: ExtractedConvention,
+) -> tuple[bool, dict[str, object]]:
+    """Check every active n=1 by n=2 channel pair on the left local cell."""
+    exchange, vertex, channels = _own_local_operators(convention)
+    layer1 = tuple(channel for channel in channels if channel.number == 1)
+    layer2 = tuple(channel for channel in channels if channel.number == 2)
+
+    maximum_leakage = 0.0
+    leakage_entries_checked = 0
+    recoil_failures = []
+    for left in layer1:
+        for right in layer2:
+            for left_index in (left.reservoir_index, left.pair_index):
+                for right_index in (right.reservoir_index, right.pair_index):
+                    values = (
+                        exchange[left_index, right_index],
+                        exchange[right_index, left_index],
+                        vertex[left_index, right_index],
+                        vertex[right_index, left_index],
+                    )
+                    leakage_entries_checked += len(values)
+                    maximum_leakage = max(
+                        maximum_leakage,
+                        max(float(abs(value)) for value in values),
+                    )
+
+    for channel in layer1 + layer2:
+        direction_vector = U320.c210.DIRECTIONS[channel.direction]
+        recoil = _mask_vector(channel.target_mask) - _mask_vector(
+            channel.source_mask
+        )
+        triple = (
+            tuple(int(value) for value in recoil),
+            tuple(int(value) for value in direction_vector),
+            tuple(int(value) for value in direction_vector),
+        )
+        expected = (
+            tuple(int(value) for value in -2 * direction_vector),
+            tuple(int(value) for value in direction_vector),
+            tuple(int(value) for value in direction_vector),
+        )
+        if triple != expected:
+            recoil_failures.append(
+                (channel.source_mask, channel.direction, triple, expected)
+            )
+
+    landed_exchange, landed_vertex, *_rest = S322.local_source_blocks(
+        U320.ANGLE
+    )
+    operator_residuals = {
+        "exchange": float(np.linalg.norm(exchange - landed_exchange)),
+        "vertex": float(np.linalg.norm(vertex - landed_vertex)),
+    }
+    ok = (
+        len(layer1) == FROZEN_LAYER_CHANNEL_COUNTS[1]
+        and len(layer2) == FROZEN_LAYER_CHANNEL_COUNTS[2]
+        and len(layer1) * len(layer2) == 144
+        and leakage_entries_checked == 2304
+        and maximum_leakage == 0.0
+        and not recoil_failures
+        and max(operator_residuals.values()) < TOLERANCE
+    )
+    return ok, {
+        "cell": S322.LEFT,
+        "channel_family": "all n=1 x n=2 active channel pairs",
+        "channel_pairs": len(layer1) * len(layer2),
+        "directed_operator_entries_checked": leakage_entries_checked,
+        "maximum_cross_layer_leakage": maximum_leakage,
+        "operator_residuals_against_landed": operator_residuals,
+        "recoil_channels_checked": len(layer1) + len(layer2),
+        "recoil_equation": "(-2d, +d, +d)",
+        "recoil_failures": len(recoil_failures),
+    }
+
+
+def anchor_replay(
+    convention: ExtractedConvention,
+) -> tuple[bool, dict[str, object]]:
+    """Run the landed S322 main and require its frozen 20/20 result."""
+    source_path = ROOT / convention.audit_input_paths[1]
+    environment = os.environ.copy()
+    scripts_path = str(ROOT / "scripts")
+    environment["PYTHONPATH"] = (
+        scripts_path
+        if not environment.get("PYTHONPATH")
+        else scripts_path + os.pathsep + environment["PYTHONPATH"]
+    )
+    started = time.monotonic()
+    try:
+        completed = subprocess.run(
+            [sys.executable, str(source_path)],
+            cwd=ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=AUDIT_TIMEOUT_SEC,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        return False, {
+            "timeout_seconds": AUDIT_TIMEOUT_SEC,
+            "stdout_tail": (error.stdout or "")[-500:],
+            "stderr_tail": (error.stderr or "")[-500:],
+        }
+    runtime = time.monotonic() - started
+    pass_lines = sum(
+        line.startswith("PASS ") for line in completed.stdout.splitlines()
+    )
+    fail_lines = sum(
+        line.startswith("FAIL ") for line in completed.stdout.splitlines()
+    )
+    ok = (
+        completed.returncode == 0
+        and pass_lines == FROZEN_S322_PASS
+        and fail_lines == FROZEN_S322_FAIL
+        and convention.cycle322_summary_marker in completed.stdout
+        and convention.cycle322_terminal_marker in completed.stdout
+        and completed.stderr == ""
+    )
+    return ok, {
+        "returncode": completed.returncode,
+        "pass_lines": pass_lines,
+        "fail_lines": fail_lines,
+        "frozen_result": (FROZEN_S322_PASS, FROZEN_S322_FAIL),
+        "runtime_seconds": round(runtime, 6),
+        "stderr_tail": completed.stderr[-500:],
+    }
+
+
+def _target_roots(target: ast.AST) -> set[str]:
+    while isinstance(target, (ast.Attribute, ast.Subscript)):
+        target = target.value
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.Tuple, ast.List)):
+        roots: set[str] = set()
+        for element in target.elts:
+            roots.update(_target_roots(element))
+        return roots
+    return set()
+
+
+def discipline() -> tuple[bool, dict[str, object]]:
+    """Enforce data-only primary use and inspect its AST mutation controls."""
+    _source, tree = _primary_ast()
+    forbidden_writes = []
+    for node in ast.walk(tree):
+        targets: tuple[ast.AST, ...] = ()
+        if isinstance(node, ast.Assign):
+            targets = tuple(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            targets = (node.target,)
+        elif isinstance(node, ast.AugAssign):
+            targets = (node.target,)
+        elif isinstance(node, ast.NamedExpr):
+            targets = (node.target,)
+        elif isinstance(node, ast.Delete):
+            targets = tuple(node.targets)
+        for target in targets:
+            roots = _target_roots(target)
+            if roots & {"U320", "S322"}:
+                forbidden_writes.append((node.lineno, type(node).__name__))
+
+    function_defs = {
+        node.name: node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    misembedding = function_defs.get("misembedding_control")
+    misembedding_names = (
+        {node.id for node in ast.walk(misembedding) if isinstance(node, ast.Name)}
+        if misembedding is not None
+        else set()
+    )
+    misembedding_strings = (
+        {
+            node.value
+            for node in ast.walk(misembedding)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        }
+        if misembedding is not None
+        else set()
+    )
+    literals = _literal_assignments(tree)
+    convention_literals = (
+        "LAYER_EMBEDDING" in literals
+        and "N_MAX" in literals
+        and "AUDIT_INPUT_PATHS" in literals
+    )
+    blocklisted_loaded = tuple(
+        module for module in IMPORT_BLOCKLIST if module in sys.modules
+    )
+    ok = (
+        IMPORT_BLOCKLIST
+        == ("frontier_full_fock_unit_weight_source_2026_07_28",)
+        and not blocklisted_loaded
+        and not forbidden_writes
+        and convention_literals
+        and misembedding is not None
+        and {"bad_exchange", "bad_target_mask", "commutator"}
+        <= misembedding_names
+        and "cross_layer_generator_amplitude" in misembedding_strings
+        and "number_commutator_frobenius" in misembedding_strings
+    )
+    return ok, {
+        "blocklist": IMPORT_BLOCKLIST,
+        "blocklisted_modules_loaded": blocklisted_loaded,
+        "conventions_are_literal_eval_data": convention_literals,
+        "misembedding_control_in_primary_ast": misembedding is not None,
+        "primary_attribute_writes": forbidden_writes,
+    }
+
+
+def _run(
+    label: str,
+    certificate: Callable[[], tuple[bool, dict[str, object]]],
+) -> None:
+    try:
+        condition, detail = certificate()
+    except Exception as error:
+        condition = False
+        detail = {
+            "exception": type(error).__name__,
+            "message": str(error),
+        }
+    check(label, condition, detail)
+
+
+def main() -> int:
+    started = time.monotonic()
+    print("FULL-FOCK INDEPENDENT CHECK")
+    print("primary_mode = AST data only; import blocklisted")
+
+    convention: ExtractedConvention | None = None
+    try:
+        extracted_ok, extracted_detail, convention = extraction()
+    except Exception as error:
+        extracted_ok = False
+        extracted_detail = {
+            "exception": type(error).__name__,
+            "message": str(error),
+        }
+    check("extraction()", extracted_ok, extracted_detail)
+
+    _run("layer1_anchor_recount()", layer1_anchor_recount)
+    _run("layer_channel_recount()", layer_channel_recount)
+    if convention is None:
+        check(
+            "leakage_spot_recount()",
+            False,
+            "skipped because extraction produced no valid convention",
+        )
+        check(
+            "anchor_replay()",
+            False,
+            "skipped because extraction produced no valid convention",
+        )
+    else:
+        _run(
+            "leakage_spot_recount()",
+            lambda: leakage_spot_recount(convention),
+        )
+        _run("anchor_replay()", lambda: anchor_replay(convention))
+    _run("discipline()", discipline)
+
+    runtime = time.monotonic() - started
+    print(
+        "SUMMARY",
+        {
+            "pass": PASS,
+            "fail": FAIL,
+            "runtime_seconds": round(runtime, 6),
+        },
+    )
+    print(
+        "FINAL",
+        "ALL_PASS" if FAIL == 0 else "HONEST_FAIL",
+        f"{PASS}/{PASS + FAIL}",
+    )
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/frontier_full_fock_unit_weight_source_2026_07_28.py
+++ b/scripts/frontier_full_fock_unit_weight_source_2026_07_28.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+"""Bounded full-Fock lift of the landed Cycle-320 unit-weight source.
+
+The construction is deliberately narrow.  It combines the Cycle-322 local
+fermionic Fock hop with the Cycle-320 interpretation of each directional
+source branch as the matched pair (F_d, A_d), with unit vector weight on
+each member.  Occupation number is truncated only for the exhaustive
+certificate; the landed 64-mask operator itself is left unchanged.
+
+This certifies the source/recoil/reciprocity algebra on the landed two-cell
+fixture.  It does not claim a new recurrent physical encoding or an
+auxiliary catch-up law for simultaneous carriers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+import numpy as np
+
+
+AUDIT_TIMEOUT_SEC = 900
+NOTE_PATH = "docs/FULL_FOCK_UNIT_WEIGHT_SOURCE_SUPPORT_NOTE_2026-07-28.md"
+AUDIT_INPUT_PATHS = (
+    "scripts/unit_weight_carried_link_recoil_cycle320_2026_07_18.py",
+    "scripts/two_cell_two_source_recoil_reciprocity_cycle322_2026_07_18.py",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import unit_weight_carried_link_recoil_cycle320_2026_07_18 as U320
+import two_cell_two_source_recoil_reciprocity_cycle322_2026_07_18 as S322
+
+
+N_MAX = 2
+TOLERANCE = 3e-10
+CYCLE322_SHA256 = "4f7e25a20bcea41c285bfb52b122f84ec5c41f1f6095b6ec0068d2a228ed5d75"
+LAYER_EMBEDDING = (
+    "P_n selects local six-mode matter masks with bit_count(mask)=n; "
+    "q=0 is the endpoint reservoir and q=1+d is the landed matched "
+    "unit-weight pair (F_d,A_d).  The two-cell factors are V_left tensor I "
+    "and I tensor V_right in S322.JOINT_INDEX, so the spectator mask and "
+    "every other number sector are unchanged."
+)
+
+PASS = 0
+FAIL = 0
+FAILED_LABELS: list[str] = []
+
+
+def check(label: str, condition: bool, detail: object = "") -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print("PASS", label, "::", detail)
+    else:
+        FAIL += 1
+        FAILED_LABELS.append(label)
+        print("FAIL", label, "::", detail)
+
+
+def mask_vector(mask: int) -> np.ndarray:
+    return sum(
+        (
+            U320.c210.DIRECTIONS[direction]
+            for direction in range(6)
+            if (mask >> direction) & 1
+        ),
+        start=np.zeros(3, dtype=int),
+    )
+
+
+def component_operators() -> tuple[
+    tuple[np.ndarray, ...],
+    tuple[np.ndarray, ...],
+    tuple[np.ndarray, ...],
+    tuple[np.ndarray, ...],
+]:
+    """Split S322's coefficient-two diagonal into two landed unit weights."""
+    matter = []
+    mediator = []
+    auxiliary = []
+    total = []
+    for axis in range(3):
+        matter_values = []
+        mediator_values = []
+        auxiliary_values = []
+        for mask in S322.LOCAL_MASKS:
+            base = float(mask_vector(mask)[axis])
+            matter_values.extend([base] * 7)
+            mediator_values.append(0.0)
+            auxiliary_values.append(0.0)
+            mediator_values.extend(
+                float(U320.c210.DIRECTIONS[direction, axis])
+                for direction in range(6)
+            )
+            auxiliary_values.extend(
+                float(U320.c210.DIRECTIONS[direction, axis])
+                for direction in range(6)
+            )
+        matter_axis = np.diag(matter_values)
+        mediator_axis = np.diag(mediator_values)
+        auxiliary_axis = np.diag(auxiliary_values)
+        matter.append(matter_axis)
+        mediator.append(mediator_axis)
+        auxiliary.append(auxiliary_axis)
+        total.append(matter_axis + mediator_axis + auxiliary_axis)
+    return tuple(matter), tuple(mediator), tuple(auxiliary), tuple(total)
+
+
+def layer_indices(number: int) -> list[int]:
+    return [
+        7 * local_index + q_index
+        for local_index, mask in enumerate(S322.LOCAL_MASKS)
+        if mask.bit_count() == number
+        for q_index in range(7)
+    ]
+
+
+def landed_one_carrier_rows(vertex: np.ndarray) -> tuple[list[dict], float]:
+    """Use U320.LinkState and compare its six numerical response rows."""
+    origin = (0, 0, 0)
+    rows = []
+    maximum_residual = 0.0
+    for direction in range(6):
+        excited = np.zeros(6, dtype=complex)
+        excited[direction] = 1.0
+        landed_input = U320.LinkState({origin: excited}, {})
+        landed_output, _report = U320.vertex_gate(landed_input, U320.ANGLE)
+        landed_excited = landed_output.excited[origin]
+        landed_pair = landed_output.pair[(origin, origin)]
+
+        pair_probabilities = abs(landed_pair) ** 2
+        landed_matter = (
+            abs(landed_excited) ** 2
+            + np.sum(pair_probabilities, axis=(1, 2))
+        ) @ U320.c210.DIRECTIONS
+        landed_mediator = (
+            np.sum(pair_probabilities, axis=(0, 2)) @ U320.c210.DIRECTIONS
+        )
+        landed_auxiliary = (
+            np.sum(pair_probabilities, axis=(0, 1)) @ U320.c210.DIRECTIONS
+        )
+
+        source_index = S322.LOCAL_INDEX[1 << direction]
+        local_input = np.zeros(448, dtype=complex)
+        local_input[7 * source_index] = 1.0
+        local_output = vertex @ local_input
+        lifted_matter = np.zeros(3)
+        lifted_mediator = np.zeros(3)
+        lifted_auxiliary = np.zeros(3)
+        for local_index, mask in enumerate(S322.LOCAL_MASKS):
+            for q_index in range(7):
+                probability = float(abs(local_output[7 * local_index + q_index]) ** 2)
+                lifted_matter += probability * mask_vector(mask)
+                if q_index:
+                    lifted_mediator += (
+                        probability * U320.c210.DIRECTIONS[q_index - 1]
+                    )
+                    lifted_auxiliary += (
+                        probability * U320.c210.DIRECTIONS[q_index - 1]
+                    )
+
+        initial = U320.c210.DIRECTIONS[direction].astype(float)
+        component_residual = max(
+            float(np.max(abs(lifted_matter - landed_matter))),
+            float(np.max(abs(lifted_mediator - landed_mediator))),
+            float(np.max(abs(lifted_auxiliary - landed_auxiliary))),
+        )
+        maximum_residual = max(maximum_residual, component_residual)
+        emitted_index = (
+            7 * S322.LOCAL_INDEX[1 << U320.REVERSE[direction]]
+            + 1
+            + direction
+        )
+        rows.append(
+            {
+                "direction": direction,
+                "emitted_weight": float(abs(local_output[emitted_index]) ** 2),
+                "matter_recoil": [
+                    float(value) for value in (lifted_matter - initial)
+                ],
+                "mediator_flux": [float(value) for value in lifted_mediator],
+                "auxiliary_flux": [float(value) for value in lifted_auxiliary],
+            }
+        )
+    return rows, maximum_residual
+
+
+def per_layer_certificates(
+    exchange: np.ndarray,
+    vertex: np.ndarray,
+) -> tuple[list[dict], float, float]:
+    """Certify exact generator ledgers and reciprocal number blocks."""
+    rows = []
+    maximum_ledger_residual = 0.0
+    maximum_reciprocity_residual = 0.0
+    for number in range(N_MAX + 1):
+        indices = layer_indices(number)
+        block = vertex[np.ix_(indices, indices)]
+        channels = 0
+        emitted_weights = []
+        layer_ledger_residual = 0.0
+        for source_index, mask in enumerate(S322.LOCAL_MASKS):
+            if mask.bit_count() != number:
+                continue
+            for direction in range(6):
+                hopped = S322.fermion_hop(
+                    mask, direction, U320.REVERSE[direction]
+                )
+                if hopped is None:
+                    continue
+                target_mask, sign = hopped
+                target_index = S322.LOCAL_INDEX[target_mask]
+                reservoir_column = 7 * source_index
+                pair_row = 7 * target_index + 1 + direction
+                edge_exact = (
+                    exchange[pair_row, reservoir_column] == sign
+                    and exchange[reservoir_column, pair_row] == sign
+                )
+                matter_recoil = mask_vector(target_mask) - mask_vector(mask)
+                mediator_flux = U320.c210.DIRECTIONS[direction]
+                auxiliary_flux = U320.c210.DIRECTIONS[direction]
+                expected_recoil = -2 * U320.c210.DIRECTIONS[direction]
+                residual = max(
+                    float(np.max(abs(matter_recoil - expected_recoil))),
+                    float(
+                        np.max(
+                            abs(
+                                matter_recoil
+                                + mediator_flux
+                                + auxiliary_flux
+                            )
+                        )
+                    ),
+                    0.0 if edge_exact else 1.0,
+                )
+                layer_ledger_residual = max(layer_ledger_residual, residual)
+                emitted_weights.append(
+                    float(abs(vertex[pair_row, reservoir_column]) ** 2)
+                )
+                channels += 1
+        reciprocity_residual = float(np.linalg.norm(block.T - block))
+        unitarity_residual = float(
+            np.linalg.norm(block.conj().T @ block - np.eye(len(indices)))
+        )
+        maximum_ledger_residual = max(
+            maximum_ledger_residual, layer_ledger_residual
+        )
+        maximum_reciprocity_residual = max(
+            maximum_reciprocity_residual, reciprocity_residual
+        )
+        rows.append(
+            {
+                "active_channels": channels,
+                "dimension": len(indices),
+                "emitted_weight_max": max(emitted_weights, default=0.0),
+                "emitted_weight_min": min(emitted_weights, default=0.0),
+                "generator_ledger_residual": layer_ledger_residual,
+                "number": number,
+                "reciprocity_residual": reciprocity_residual,
+                "unitarity_residual": unitarity_residual,
+                "vacuum_source_is_identity": number != 0
+                or float(np.linalg.norm(block - np.eye(len(indices)))) == 0.0,
+            }
+        )
+    return rows, maximum_ledger_residual, maximum_reciprocity_residual
+
+
+def exhaustive_two_cell_independence(
+    vertex: np.ndarray,
+) -> tuple[int, int, float]:
+    """Exhaust all active q columns on the n<=2 two-cell matter fixture."""
+    allowed = [
+        index
+        for index, mask in enumerate(S322.LOCAL_MASKS)
+        if mask.bit_count() <= N_MAX
+    ]
+    supports = {
+        (local_index, q_index): np.flatnonzero(
+            abs(vertex[:, 7 * local_index + q_index]) > 2e-13
+        )
+        for local_index in allowed
+        for q_index in range(7)
+    }
+    failures = 0
+    columns_checked = 0
+    maximum_cross_layer_amplitude = 0.0
+    for endpoint in range(2):
+        for local_index in allowed:
+            source_number = S322.LOCAL_MASKS[local_index].bit_count()
+            for spectator_index in allowed:
+                joint_index = (
+                    S322.JOINT_INDEX[(local_index, spectator_index)]
+                    if endpoint == 0
+                    else S322.JOINT_INDEX[(spectator_index, local_index)]
+                )
+                left_number, _left_label, right_number, _right_label = (
+                    S322.LABELS[joint_index]
+                )
+                expected_numbers = (
+                    (source_number, S322.LOCAL_MASKS[spectator_index].bit_count())
+                    if endpoint == 0
+                    else (S322.LOCAL_MASKS[spectator_index].bit_count(), source_number)
+                )
+                if (left_number, right_number) != expected_numbers:
+                    failures += 1
+                for q_index in range(7):
+                    columns_checked += 1
+                    for row in supports[(local_index, q_index)]:
+                        target_number = S322.LOCAL_MASKS[row // 7].bit_count()
+                        if target_number != source_number:
+                            failures += 1
+                            maximum_cross_layer_amplitude = max(
+                                maximum_cross_layer_amplitude,
+                                float(
+                                    abs(
+                                        vertex[
+                                            row,
+                                            7 * local_index + q_index,
+                                        ]
+                                    )
+                                ),
+                            )
+    return columns_checked, failures, maximum_cross_layer_amplitude
+
+
+def superposed_layer_control() -> dict[str, float]:
+    """Exercise S322.LogicalState on a coherent n=1/n=2 source state."""
+    vacuum = S322.LOCAL_INDEX[0]
+    one = S322.LOCAL_INDEX[1 << 0]
+    two = S322.LOCAL_INDEX[(1 << 0) | (1 << 2)]
+    matter = np.zeros(4096, dtype=complex)
+    matter[S322.JOINT_INDEX[(one, vacuum)]] = 1 / np.sqrt(2)
+    matter[S322.JOINT_INDEX[(two, vacuum)]] = 1j / np.sqrt(2)
+    state = S322.LogicalState({S322.q_reservoir(0): matter})
+
+    before_weights = layer_weights(state, endpoint=0)
+    emitted = S322.apply_source(state, 0, angle=U320.ANGLE)
+    after_weights = layer_weights(emitted, endpoint=0)
+    recovered = S322.apply_source(
+        emitted, 0, angle=U320.ANGLE, inverse=True
+    )
+    return {
+        "inverse_residual": S322.state_residual(recovered, state),
+        "layer_weight_residual": max(
+            abs(after_weights[number] - before_weights[number])
+            for number in range(N_MAX + 1)
+        ),
+        "norm_residual": abs(S322.state_norm(emitted) - S322.state_norm(state)),
+    }
+
+
+def layer_weights(state: S322.LogicalState, endpoint: int) -> dict[int, float]:
+    weights = {number: 0.0 for number in range(N_MAX + 1)}
+    for vector in state.values():
+        for index, amplitude in enumerate(vector):
+            if amplitude == 0:
+                continue
+            left_number, _left, right_number, _right = S322.LABELS[index]
+            number = left_number if endpoint == 0 else right_number
+            if number <= N_MAX:
+                weights[number] += float(abs(amplitude) ** 2)
+    return weights
+
+
+def reciprocal_superposition(vertex: np.ndarray, exchange: np.ndarray) -> dict[str, float]:
+    one = S322.LOCAL_INDEX[1 << 0]
+    two = S322.LOCAL_INDEX[(1 << 0) | (1 << 2)]
+    reservoir = np.zeros(448, dtype=complex)
+    reservoir[7 * one] = 1 / np.sqrt(2)
+    reservoir[7 * two] = 1 / np.sqrt(2)
+    paired = exchange @ reservoir
+    paired /= np.linalg.norm(paired)
+    forward = np.vdot(paired, vertex @ reservoir)
+    reverse = np.vdot(reservoir, vertex @ paired)
+    return {
+        "forward_abs": float(abs(forward)),
+        "matrix_element_residual": float(abs(forward - reverse)),
+        "reverse_abs": float(abs(reverse)),
+    }
+
+
+def misembedding_control(exchange: np.ndarray) -> dict[str, float | int]:
+    """Move the smallest n=2 target into n=1 and expose the number leak."""
+    source_mask = (1 << 0) | (1 << 2)
+    source_index = S322.LOCAL_INDEX[source_mask]
+    proper_target_mask, sign = S322.fermion_hop(
+        source_mask, 0, U320.REVERSE[0]
+    )
+    proper_row = 7 * S322.LOCAL_INDEX[proper_target_mask] + 1
+    bad_target_mask = 1 << U320.REVERSE[0]
+    bad_row = 7 * S322.LOCAL_INDEX[bad_target_mask] + 1
+    source_column = 7 * source_index
+
+    bad_exchange = exchange.copy()
+    bad_exchange[proper_row, source_column] = 0
+    bad_exchange[source_column, proper_row] = 0
+    bad_exchange[bad_row, source_column] = sign
+    bad_exchange[source_column, bad_row] = sign
+    _exchange, _vertex, _charge, number, _momenta = (
+        S322.local_source_blocks(U320.ANGLE)
+    )
+    commutator = bad_exchange @ number - number @ bad_exchange
+    return {
+        "cross_layer_generator_amplitude": float(
+            abs(bad_exchange[bad_row, source_column])
+        ),
+        "number_commutator_frobenius": float(np.linalg.norm(commutator)),
+        "source_number": source_mask.bit_count(),
+        "target_number": bad_target_mask.bit_count(),
+    }
+
+
+def cycle322_anchor() -> dict[str, object]:
+    source_path = ROOT / AUDIT_INPUT_PATHS[1]
+    before = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    environment = os.environ.copy()
+    scripts_path = str(ROOT / "scripts")
+    environment["PYTHONPATH"] = (
+        scripts_path
+        if not environment.get("PYTHONPATH")
+        else scripts_path + os.pathsep + environment["PYTHONPATH"]
+    )
+    started = time.monotonic()
+    completed = subprocess.run(
+        [sys.executable, str(source_path)],
+        cwd=ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=AUDIT_TIMEOUT_SEC,
+        check=False,
+    )
+    runtime = time.monotonic() - started
+    after = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    return {
+        "returncode": completed.returncode,
+        "runtime_seconds": round(runtime, 6),
+        "sha256_after": after,
+        "sha256_before": before,
+        "stderr_empty": completed.stderr == "",
+        "summary_pinned": "SUMMARY {'pass': 20, 'fail': 0}" in completed.stdout,
+        "terminal_marker_pinned": (
+            "RESULT TWO_CELL_TWO_SOURCE_RECOIL_RECIPROCITY_CERTIFIED"
+            in completed.stdout
+        ),
+    }
+
+
+def main() -> int:
+    started = time.monotonic()
+    print("FULL-FOCK CYCLE-320 UNIT-WEIGHT AUXILIARY SOURCE")
+    print("occupancy_truncation_n_max =", N_MAX)
+    print("layer_embedding =", LAYER_EMBEDDING)
+    print("interpretation = dimensionless source/recoil algebra only")
+
+    exchange, vertex, charge, number, landed_total_momenta = (
+        S322.local_source_blocks(U320.ANGLE)
+    )
+    _matter_ops, _mediator_ops, _auxiliary_ops, unit_total_ops = (
+        component_operators()
+    )
+
+    split_matches_landed = all(
+        np.array_equal(unit_total_ops[axis], landed_total_momenta[axis])
+        for axis in range(3)
+    )
+    generator_commutators = tuple(
+        float(
+            np.linalg.norm(
+                exchange @ unit_total_ops[axis]
+                - unit_total_ops[axis] @ exchange
+            )
+        )
+        for axis in range(3)
+    )
+    vertex_commutators = tuple(
+        float(
+            np.linalg.norm(
+                vertex @ unit_total_ops[axis]
+                - unit_total_ops[axis] @ vertex
+            )
+        )
+        for axis in range(3)
+    )
+    check(
+        "the landed coefficient-two diagonal splits exactly into mediator weight one plus auxiliary weight one",
+        split_matches_landed
+        and max(generator_commutators) == 0.0
+        and max(vertex_commutators) < TOLERANCE,
+        {
+            "generator_P_commutators": generator_commutators,
+            "unit_weights": (1, 1, 1),
+            "vertex_P_commutators": vertex_commutators,
+        },
+    )
+    check(
+        "the reused source preserves Q and local occupation number",
+        float(np.linalg.norm(vertex @ charge - charge @ vertex)) == 0.0
+        and float(np.linalg.norm(vertex @ number - number @ vertex)) == 0.0,
+        {
+            "Q_commutator": float(
+                np.linalg.norm(vertex @ charge - charge @ vertex)
+            ),
+            "number_commutator": float(
+                np.linalg.norm(vertex @ number - number @ vertex)
+            ),
+        },
+    )
+
+    landed_rows, anchor_residual = landed_one_carrier_rows(vertex)
+    anchor_weight_min = min(row["emitted_weight"] for row in landed_rows)
+    anchor_weight_max = max(row["emitted_weight"] for row in landed_rows)
+    check(
+        "layer 1 reproduces all six landed U320 LinkState recoil rows",
+        anchor_residual < TOLERANCE
+        and abs(anchor_weight_min - np.sin(U320.ANGLE) ** 2) < TOLERANCE
+        and abs(anchor_weight_max - np.sin(U320.ANGLE) ** 2) < TOLERANCE,
+        {
+            "emitted_weight_range": (anchor_weight_min, anchor_weight_max),
+            "maximum_component_residual": anchor_residual,
+            "matter_recoil_magnitude": 2 * anchor_weight_min,
+            "mediator_flux_magnitude": anchor_weight_min,
+            "auxiliary_flux_magnitude": anchor_weight_min,
+        },
+    )
+
+    layer_rows, ledger_residual, reciprocity_residual = per_layer_certificates(
+        exchange, vertex
+    )
+    check(
+        "every allowed channel through n_max has the exact landed unit-weight recoil ledger",
+        ledger_residual == 0.0
+        and all(row["vacuum_source_is_identity"] for row in layer_rows),
+        {
+            "layers": [
+                {
+                    "active_channels": row["active_channels"],
+                    "generator_ledger_residual": row[
+                        "generator_ledger_residual"
+                    ],
+                    "number": row["number"],
+                }
+                for row in layer_rows
+            ],
+            "recoil_equation": "Delta P_matter=-2 d; P_F=+d; P_A=+d",
+        },
+    )
+
+    columns_checked, independence_failures, cross_layer_amplitude = (
+        exhaustive_two_cell_independence(vertex)
+    )
+    check(
+        "the two-cell truncated Fock space is exhaustively layer-independent",
+        columns_checked == 6776
+        and independence_failures == 0
+        and cross_layer_amplitude == 0.0,
+        {
+            "active_q_columns_checked": columns_checked,
+            "cross_layer_failures": independence_failures,
+            "joint_matter_states": 22**2,
+            "maximum_cross_layer_amplitude": cross_layer_amplitude,
+        },
+    )
+
+    superposed = superposed_layer_control()
+    reciprocal = reciprocal_superposition(vertex, exchange)
+    check(
+        "reciprocity holds in every layer and on a coherent n=1 plus n=2 state",
+        reciprocity_residual < TOLERANCE
+        and max(superposed.values()) < TOLERANCE
+        and reciprocal["matrix_element_residual"] < TOLERANCE
+        and reciprocal["forward_abs"] > 0.1,
+        {
+            "maximum_layer_reciprocity_residual": reciprocity_residual,
+            "superposed_state": superposed,
+            "superposed_matrix_element": reciprocal,
+        },
+    )
+
+    bad = misembedding_control(exchange)
+    check(
+        "a deliberate n=2 to n=1 mis-embedding breaks layer independence",
+        bad["source_number"] == 2
+        and bad["target_number"] == 1
+        and bad["cross_layer_generator_amplitude"] == 1.0
+        and bad["number_commutator_frobenius"] > 1.4,
+        bad,
+    )
+
+    anchor = cycle322_anchor()
+    check(
+        "the byte-pinned Cycle-322 harness reruns unchanged",
+        anchor["sha256_before"] == CYCLE322_SHA256
+        and anchor["sha256_after"] == CYCLE322_SHA256
+        and anchor["returncode"] == 0
+        and anchor["stderr_empty"]
+        and anchor["summary_pinned"]
+        and anchor["terminal_marker_pinned"],
+        anchor,
+    )
+
+    runtime = time.monotonic() - started
+    achieved = FAIL == 0
+    package = {
+        "audit_input_paths": list(AUDIT_INPUT_PATHS),
+        "certificate_failures": FAILED_LABELS,
+        "cycle322_anchor": {
+            "returncode": anchor["returncode"],
+            "runtime_seconds": anchor["runtime_seconds"],
+            "sha256": anchor["sha256_after"],
+        },
+        "full_fock_construction_achieved": achieved,
+        "layer_embedding": LAYER_EMBEDDING,
+        "layer_rows": layer_rows,
+        "n_max": N_MAX,
+        "note_path": NOTE_PATH,
+        "obstruction": None,
+        "runtime_seconds": round(runtime, 6),
+        "scope": (
+            "local full-Fock source algebra on the landed two-cell fixture; "
+            "no new recurrent simultaneous-carrier transport claim"
+        ),
+        "summary": {"fail": FAIL, "pass": PASS},
+    }
+    print("FINAL_JSON", json.dumps(package, sort_keys=True))
+
+    # A failed certificate without a numerically frozen obstruction would be
+    # an incomplete/dishonest package, so only that state exits nonzero.
+    return 0 if achieved else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Support — the full-Fock Cycle-320 unit-weight auxiliary source, constructed

Physics-loop campaign `computation-connection-20260727`, support package (base `main`; imports only landed Cycle-320/322 modules).

**Claim (bounded conditional construction; authority none; audit unset).** The landed Cycle-322 reciprocity surface names "full-Fock Cycle-320 unit-weight auxiliary sources" as its absent deeper lift. This package constructs it at occupancy truncation `n_max = 2` on the landed two-cell fixture, with one declared embedding convention: per-layer channels 0/6/24; the landed one-carrier anchor reproduced exactly (independent recount at 0 ULP); exact per-channel recoil algebra (−2d, +d, +d) in every layer; exhaustive layer independence (zero cross-layer leakage over all 6,776 active two-cell columns); per-layer and superposed reciprocity at machine scale; the byte-pinned Cycle-322 harness unchanged (20/20); a mis-embedding detection control. `full_fock_construction_achieved: true`; no obstruction encountered.

**C_source firewall (verbatim scope).** Dimensionless source/recoil algebra only — no source law, response law, or gravity content is selected.

**Artifacts.** Primary runner (8/8), independent checker (6/6, own recounts + subprocess anchor replay), support note, pinned runner caches, receipt.

Open: `n_max > 2` and untruncated statements; wiring this lift into the acceptance-harness set as an input-ported surface.

Independent audit still required. Review-loop and audit-loop remain owner-operated lanes; this PR only prepares that surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
