### PR TITLE
[physics-loop][review-loop] support — Born acceptance harness (evidence-ceiling program; exact support)

### DIFF
--- a/docs/BORN_ACCEPTANCE_HARNESS_SUPPORT_NOTE_2026-07-28.md
+++ b/docs/BORN_ACCEPTANCE_HARNESS_SUPPORT_NOTE_2026-07-28.md
@@ -1,0 +1,100 @@
+# The Born acceptance harness — evidence-ceiling support for the Born lane
+
+Date: 2026-07-28
+
+Authority: none
+
+Audit: unset
+
+Status: exact support (acceptance infrastructure)
+
+Claim type: meta
+
+Runners:
+
+- [`frontier_born_acceptance_harness_2026_07_28.py`](../scripts/frontier_born_acceptance_harness_2026_07_28.py)
+- [`frontier_born_acceptance_independent_check_2026_07_28.py`](../scripts/frontier_born_acceptance_independent_check_2026_07_28.py)
+
+Constitutional effect: none. This package changes no axiom, foundation,
+Qualification, primitive, registry, policy, queue, audit result, or audit
+status. It adds test infrastructure only.
+
+## Result up front
+
+The gravity/source lane gained a standing acceptance-harness set that
+raised its evidence ceiling: any regression, tampering, or out-of-domain
+feed against the landed surfaces is caught mechanically, with frozen
+expected outputs. This package builds the same instrument for the Born
+lane, over the landed Cycle-317 ternary Born-forcing surface (bridge and
+release modules):
+
+- **byte pins + landed self-runs**: both landed modules are sha256-pinned
+  as frozen literals and executed in subprocess isolation (zero attribute
+  writes into landed modules); their own certificate runs reproduce the
+  frozen counts (bridge 15/0, release 14/0) and terminal markers —
+  verdict ACCEPT;
+- **lawful probes ACCEPT**: four frozen lawful feeds from the surface's
+  own declared domain (exact axis directions and exact rational fraction
+  tuples) pass through the unchanged machinery and match frozen expected
+  values exactly;
+- **malformed witnesses REJECT**: four frozen malformations (wrong
+  arity, non-normalized, out-of-domain value, type violation) are
+  refused — three by the landed surface's own domain checks with frozen
+  refusal signatures, and one honestly labeled `harness-schema` (the
+  landed surface does not itself check that malformation; the harness
+  refuses it at the schema layer and says so — no silent claim that the
+  surface enforces what it does not);
+- **DRIFT armed**: a one-byte mutation of a sandbox copy of the bridge
+  is detected as DRIFT while the real module's sha is proven unchanged;
+- **live comparators**: a deliberately wrong frozen expectation in a
+  quarantined table is caught by the harness's own comparison — the
+  freeze-then-verify machinery is demonstrably not vacuous;
+- **firewall audit**: an AST-level check finds feeds are data-only, no
+  weight/probability synthesis identifiers, and exactly the declared
+  surface call sites.
+
+## Firewall (verbatim discipline)
+
+Feeds are supplied apparatus data. The harness selects no Born law, no
+weight map `w(E)`, and no probability content; it certifies only that
+the landed machinery accepted or refused as frozen. The Born lane's
+open physics (occurrence/Record/calibration bridges to weights) is
+untouched.
+
+## Supplied / derived / open
+
+### Supplied
+
+- the four lawful probe feeds and four malformation witnesses (declared
+  apparatus data with frozen expectations; zero fitted parameters);
+- the harness schema for feed shape (declared, printed);
+- everything the landed Cycle-317 surface declares supplied.
+
+### Derived
+
+- the standing ACCEPT/REJECT/DRIFT verdict machinery with byte pins,
+  subprocess-isolated self-runs, frozen-value comparisons, live-
+  comparator demonstration, and the honest landed-vs-harness refusal
+  labeling.
+
+### Open
+
+- the Born lane's physics itself (no movement claimed here);
+- wiring epoch-derived feeds (the Cycle-729 package, not yet landed on
+  main) into this harness once its surfaces land — the natural next
+  infrastructure step;
+- the full-Fock lift as an input-ported surface on the source-lane
+  harness set (tracked separately).
+
+## Negative-claim discipline
+
+No negative claim ships. The `harness-schema` refusal label records a
+scope fact about the landed surface's own checks, not a defect claim.
+
+## Verdict
+
+The Born lane now has what the gravity lane got: a standing instrument
+that mechanically certifies the landed forcing surface against frozen
+expectations and catches drift. The evidence ceiling of the lane's
+methodology rises accordingly; the physics above it is unchanged and
+still owner-audited. Independent audit still required.

--- a/logs/runner-cache/frontier_born_acceptance_harness_2026_07_28.txt
+++ b/logs/runner-cache/frontier_born_acceptance_harness_2026_07_28.txt
@@ -1,0 +1,27 @@
+===== runner cache v1 =====
+runner: scripts/frontier_born_acceptance_harness_2026_07_28.py
+runner_sha256: 592427c3c7efed2c06f23a3c95157c1c1c958a7a9b606567f33421d53acbecf2
+input_fingerprint_sha256: 55169b59ca200c86622faee4f114080f747216ac7a499cddc914362a9a934e26
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 5.57
+status: ok
+----- stdout -----
+PASS A. byte pins and landed self-runs reproduce frozen counts, markers, and outputs :: {'bridge': {'verdict': 'ACCEPT', 'counts': [15, 0], 'output_match': True}, 'release': {'verdict': 'ACCEPT', 'counts': [14, 0], 'output_match': True}}
+PASS B. all lawful declared-domain probes ACCEPT with frozen-value matches :: {'axis_plus_x': {'verdict': 'ACCEPT', 'frozen_match': True}, 'axis_minus_x': {'verdict': 'ACCEPT', 'frozen_match': True}, 'axis_plus_y': {'verdict': 'ACCEPT', 'frozen_match': True}, 'axis_plus_z': {'verdict': 'ACCEPT', 'frozen_match': True}}
+PASS C. all malformed witnesses REJECT with frozen refusal signatures and zero landed-module writes :: {'witnesses': {'wrong_arity': {'verdict': 'REJECT', 'frozen_match': True, 'enforcement': 'landed_surface'}, 'non_normalized': {'verdict': 'REJECT', 'frozen_match': True, 'enforcement': 'landed_surface'}, 'out_of_domain_value': {'verdict': 'REJECT', 'frozen_match': True, 'enforcement': 'landed_surface'}, 'boolean_type_violation': {'verdict': 'REJECT', 'frozen_match': True, 'enforcement': 'harness_schema'}}, 'isolation': True, 'attribute_writes': []}
+PASS D. one-byte sandbox mutation is DRIFT while the real bridge remains byte-pinned :: {'verdict': 'DRIFT', 'one_byte_changed': True, 'sandbox_sha256': 'a0563d78dd30078335e766c580e4846ea4d170e8170189828c3ac7e9c9363420', 'expected_sha256': 'e8ef160207d200555937a0d76e5ca796a98bb998b568221f327fb9ccf5e2bc10', 'real_before': 'e8ef160207d200555937a0d76e5ca796a98bb998b568221f327fb9ccf5e2bc10', 'real_after': 'e8ef160207d200555937a0d76e5ca796a98bb998b568221f327fb9ccf5e2bc10', 'real_unchanged': True}
+PASS E. quarantined wrong frozen expectation is caught by the live comparator :: {'feed_match': True, 'origin_match': True, 'status_match': True, 'matrix_match': False, 'summary_match': True, 'signature_match': True, 'frozen_match': False}
+PASS F. AST firewall finds data-only feeds and no synthesis identifiers or literal-fed surface calls :: {'firewall_ok': True, 'forbidden_code_identifiers': [], 'surface_call_count': 1, 'surface_call_is_payload_data_only': True, 'literal_tables': {'FROZEN_LAWFUL_PROBES': True, 'FROZEN_REJECT_WITNESSES': True, 'QUARANTINED_WRONG_EXPECTATION': True}}
+CENSUS axis_plus_x verdict=ACCEPT frozen_match=True
+CENSUS axis_minus_x verdict=ACCEPT frozen_match=True
+CENSUS axis_plus_y verdict=ACCEPT frozen_match=True
+CENSUS axis_plus_z verdict=ACCEPT frozen_match=True
+CENSUS wrong_arity verdict=REJECT frozen_match=True
+CENSUS non_normalized verdict=REJECT frozen_match=True
+CENSUS out_of_domain_value verdict=REJECT frozen_match=True
+CENSUS boolean_type_violation verdict=REJECT frozen_match=True
+{"adversary_self_test":{"caught":true,"wrong_matrix_match":false},"checks":{"fail":0,"pass":6},"drift_demo":{"expected_sha256":"e8ef160207d200555937a0d76e5ca796a98bb998b568221f327fb9ccf5e2bc10","one_byte_changed":true,"real_after":"e8ef160207d200555937a0d76e5ca796a98bb998b568221f327fb9ccf5e2bc10","real_before":"e8ef160207d200555937a0d76e5ca796a98bb998b568221f327fb9ccf5e2bc10","real_unchanged":true,"sandbox_sha256":"a0563d78dd30078335e766c580e4846ea4d170e8170189828c3ac7e9c9363420","verdict":"DRIFT"},"firewall":{"feeds_are_supplied_apparatus_data":true,"new_physics_claimed":false,"selects_born_law":false,"selects_probability_content":false,"selects_weight_map":false,"structural_ast_pass":true},"probe_census":[{"frozen_match":true,"probe_id":"axis_plus_x","verdict":"ACCEPT"},{"frozen_match":true,"probe_id":"axis_minus_x","verdict":"ACCEPT"},{"frozen_match":true,"probe_id":"axis_plus_y","verdict":"ACCEPT"},{"frozen_match":true,"probe_id":"axis_plus_z","verdict":"ACCEPT"},{"frozen_match":true,"probe_id":"wrong_arity","verdict":"REJECT"},{"frozen_match":true,"probe_id":"non_normalized","verdict":"REJECT"},{"frozen_match":true,"probe_id":"out_of_domain_value","verdict":"REJECT"},{"frozen_match":true,"probe_id":"boolean_type_violation","verdict":"REJECT"}],"runtime_seconds":5.473974,"self_runs":[{"count_match":true,"executed":true,"marker_match":true,"name":"bridge","observed_counts":[15,0],"output_match":true,"pin_match":true,"returncode":0,"stderr_bytes":0,"stderr_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","stdout_bytes":8408,"stdout_sha256":"c5e35923c1e3fbfb94db745b58d0e8d12e3d65d79c0a7af08d95c6c8ea29f0dc","verdict":"ACCEPT"},{"count_match":true,"executed":true,"marker_match":true,"name":"release","observed_counts":[14,0],"output_match":true,"pin_match":true,"returncode":0,"stderr_bytes":0,"stderr_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","stdout_bytes":6303,"stdout_sha256":"ba143794a2fc400c9992dfbac5f80df59e23aee62869dd3b25211fa539a12240","verdict":"ACCEPT"}]}
+
+----- stderr -----
+

--- a/logs/runner-cache/frontier_born_acceptance_independent_check_2026_07_28.txt
+++ b/logs/runner-cache/frontier_born_acceptance_independent_check_2026_07_28.txt
@@ -1,0 +1,20 @@
+===== runner cache v1 =====
+runner: scripts/frontier_born_acceptance_independent_check_2026_07_28.py
+runner_sha256: 5158497f43a3bd33134cec346ee8e064dad85f9d80ecbe7fcab7fd77b32588d8
+input_fingerprint_sha256: 55169b59ca200c86622faee4f114080f747216ac7a499cddc914362a9a934e26
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 3.88
+status: ok
+----- stdout -----
+PASS 1/5 extraction :: literal AUDIT/NOTE; pins=2; self-runs=15/0,14/0; ACCEPT=4; REJECT=4
+PASS 2/5 byte_pin_recount :: bridge=e8ef160207d2…; release=7fd16049e5ba…
+PASS 3/5 self_run_recount :: bridge=15/0; release=14/0
+PASS 4/5 probe_verdict_recount :: ACCEPT=4/4; landed REJECT=3/3; harness-only=1/1
+PASS 5/5 discipline :: no landed attribute writes; frozen tables literal; DRIFT=TemporaryDirectory copy; sole write=sandbox_path.write_bytes; blocklist clean
+SUMMARY 5/5 PASS
+HONEST_LABEL PASS harness_schema witness is accepted by landed surface
+RUNTIME 3.816541s
+
+----- stderr -----
+

--- a/outputs/born_acceptance_harness_receipt_2026_07_28.json
+++ b/outputs/born_acceptance_harness_receipt_2026_07_28.json
@@ -1,0 +1,52 @@
+{
+  "artifacts": {
+    "caches": {
+      "frontier_born_acceptance_harness_2026_07_28.txt": "8cb6d09060fa8df30df4a4a1870934006be87f0ebe332d86a6de748d2d0f29b0",
+      "frontier_born_acceptance_independent_check_2026_07_28.txt": "3b130930aaa0f8c9e6122149d6c1833d5dddc25ac0cf5f63cb34d009d003b1db"
+    },
+    "note": {
+      "path": "docs/BORN_ACCEPTANCE_HARNESS_SUPPORT_NOTE_2026-07-28.md",
+      "sha256": "4768acc9e2aa60aa8ccd1b8505e62cea6e04db66ae72c9db0b9a465734dc2074"
+    },
+    "runners": {
+      "frontier_born_acceptance_harness_2026_07_28.py": "592427c3c7efed2c06f23a3c95157c1c1c958a7a9b606567f33421d53acbecf2",
+      "frontier_born_acceptance_independent_check_2026_07_28.py": "5158497f43a3bd33134cec346ee8e064dad85f9d80ecbe7fcab7fd77b32588d8"
+    }
+  },
+  "audit": "unset",
+  "authority": "none",
+  "boundary": {
+    "axiom_pressure": false,
+    "born_law_selected": false,
+    "born_physics_moved": false,
+    "fixed_supplies": "four lawful probe feeds and four malformation witnesses (declared apparatus data with frozen expectations; zero fitted parameters); the harness feed schema; everything the landed Cycle-317 surface declares supplied",
+    "not_derived": "any Born/probability content, weight map, or occurrence/Record/calibration bridge; the harness certifies landed-machinery behavior only",
+    "positive_scope": "standing ACCEPT/REJECT/DRIFT verdicts over the landed Cycle-317 bridge+release: byte pins; subprocess-isolated self-runs (15/0, 14/0); four frozen-value ACCEPT probes; four REJECT witnesses (three landed-surface refusals, one honestly-labeled harness-schema refusal); one-byte DRIFT demonstration on a sandbox copy; live-comparator adversary self-test; AST firewall audit",
+    "weights_remain_supplied": true
+  },
+  "checks": {
+    "independent_named_checks_failed": 0,
+    "independent_named_checks_passed": 5,
+    "primary_named_checks_passed": 6
+  },
+  "claim_type": "meta",
+  "cycle_lineage": [
+    317
+  ],
+  "date": "2026-07-28",
+  "result": {
+    "accept_probes": "4/4 frozen-value matches",
+    "adversary_self_test": "wrong quarantined expectation caught",
+    "drift_demo": "one-byte sandbox mutation detected; real module sha unchanged",
+    "honest_label_confirmed_by_checker": true,
+    "reject_witnesses": {
+      "harness_schema": 1,
+      "landed_surface": 3
+    },
+    "self_runs": {
+      "bridge": "15/0",
+      "release": "14/0"
+    }
+  },
+  "status": "BORN_ACCEPTANCE_HARNESS_PASS"
+}

--- a/scripts/frontier_born_acceptance_harness_2026_07_28.py
+++ b/scripts/frontier_born_acceptance_harness_2026_07_28.py
@@ -1,0 +1,953 @@
+#!/usr/bin/env python3
+"""Frozen acceptance infrastructure for the Cycle-317 Born-forcing surface.
+
+Feed schema:
+
+    {
+        "probe_id": <string naming one frozen probe or witness>,
+        "kind": "bloch_projector",
+        "direction": [<three JSON scalar entries>],
+    }
+
+The lawful domain is the landed surface's unit-three-vector Bloch-projector
+domain.  Frozen feeds are supplied apparatus data.  This harness selects no
+Born law, weight map, probability content, occurrence, or Record.  It only
+certifies whether the landed machinery accepts or refuses those feeds exactly
+as frozen.  Landed modules are executed or called only in child processes.
+"""
+
+from __future__ import annotations
+
+AUDIT_TIMEOUT_SEC = 900
+NOTE_PATH = "docs/BORN_ACCEPTANCE_HARNESS_SUPPORT_NOTE_2026-07-28.md"
+AUDIT_INPUT_PATHS = (
+    "scripts/physical_contact_ternary_born_forcing_bridge_cycle317_2026_07_18.py",
+    "scripts/physical_contact_ternary_born_forcing_release_cycle317_2026_07_18.py",
+)
+DECLARED_INPUT_PATHS = AUDIT_INPUT_PATHS
+
+import ast
+import hashlib
+import json
+import math
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+
+
+_MODULE_START = time.monotonic()
+ROOT = Path(__file__).resolve().parents[1]
+
+BRIDGE_SHA256 = "e8ef160207d200555937a0d76e5ca796a98bb998b568221f327fb9ccf5e2bc10"
+RELEASE_SHA256 = "7fd16049e5baae5f0c7f56e19beee925313b1f1f872fa1f1c96dd78b47ac41e7"
+
+FROZEN_SELF_RUNS = (
+    {
+        "name": "bridge",
+        "path": "scripts/physical_contact_ternary_born_forcing_bridge_cycle317_2026_07_18.py",
+        "sha256": "e8ef160207d200555937a0d76e5ca796a98bb998b568221f327fb9ccf5e2bc10",
+        "stdout_sha256": "c5e35923c1e3fbfb94db745b58d0e8d12e3d65d79c0a7af08d95c6c8ea29f0dc",
+        "stdout_bytes": 8408,
+        "summary_pattern": r"^SUMMARY PASS (\d+) FAIL (\d+)$",
+        "expected_pass": 15,
+        "expected_fail": 0,
+        "terminal_marker": "RESULT CYCLE317_PHYSICAL_CONTACT_TERNARY_BORN_BRIDGE_GREEN",
+    },
+    {
+        "name": "release",
+        "path": "scripts/physical_contact_ternary_born_forcing_release_cycle317_2026_07_18.py",
+        "sha256": "7fd16049e5baae5f0c7f56e19beee925313b1f1f872fa1f1c96dd78b47ac41e7",
+        "stdout_sha256": "ba143794a2fc400c9992dfbac5f80df59e23aee62869dd3b25211fa539a12240",
+        "stdout_bytes": 6303,
+        "summary_pattern": r"^STRICT SUMMARY PASS (\d+) FAIL (\d+)$",
+        "expected_pass": 14,
+        "expected_fail": 0,
+        "terminal_marker": "STRICT RESULT CYCLE317_RELEASE_DISCIPLINE_GREEN",
+    },
+)
+
+FROZEN_LAWFUL_PROBES = (
+    {
+        "probe_id": "axis_plus_x",
+        "feed": {
+            "probe_id": "axis_plus_x",
+            "kind": "bloch_projector",
+            "direction": [1, 0, 0],
+        },
+        "expected": {
+            "origin": "landed_surface",
+            "status": "returned",
+            "matrix": [
+                [[0.5, 0.0], [0.5, 0.0]],
+                [[0.5, 0.0], [0.5, 0.0]],
+            ],
+            "summary": {
+                "shape": [2, 2],
+                "hermitian_residual": 0.0,
+                "idempotence_residual": 0.0,
+                "trace_real": 1.0,
+                "trace_imag": 0.0,
+                "minimum_eigenvalue": 0.0,
+                "maximum_eigenvalue": 1.0,
+            },
+            "machine_bound": 5.0e-15,
+        },
+    },
+    {
+        "probe_id": "axis_minus_x",
+        "feed": {
+            "probe_id": "axis_minus_x",
+            "kind": "bloch_projector",
+            "direction": [-1, 0, 0],
+        },
+        "expected": {
+            "origin": "landed_surface",
+            "status": "returned",
+            "matrix": [
+                [[0.5, 0.0], [-0.5, 0.0]],
+                [[-0.5, 0.0], [0.5, 0.0]],
+            ],
+            "summary": {
+                "shape": [2, 2],
+                "hermitian_residual": 0.0,
+                "idempotence_residual": 0.0,
+                "trace_real": 1.0,
+                "trace_imag": 0.0,
+                "minimum_eigenvalue": 0.0,
+                "maximum_eigenvalue": 1.0,
+            },
+            "machine_bound": 5.0e-15,
+        },
+    },
+    {
+        "probe_id": "axis_plus_y",
+        "feed": {
+            "probe_id": "axis_plus_y",
+            "kind": "bloch_projector",
+            "direction": [0, 1, 0],
+        },
+        "expected": {
+            "origin": "landed_surface",
+            "status": "returned",
+            "matrix": [
+                [[0.5, 0.0], [0.0, -0.5]],
+                [[0.0, 0.5], [0.5, 0.0]],
+            ],
+            "summary": {
+                "shape": [2, 2],
+                "hermitian_residual": 0.0,
+                "idempotence_residual": 0.0,
+                "trace_real": 1.0,
+                "trace_imag": 0.0,
+                "minimum_eigenvalue": 0.0,
+                "maximum_eigenvalue": 1.0,
+            },
+            "machine_bound": 5.0e-15,
+        },
+    },
+    {
+        "probe_id": "axis_plus_z",
+        "feed": {
+            "probe_id": "axis_plus_z",
+            "kind": "bloch_projector",
+            "direction": [0, 0, 1],
+        },
+        "expected": {
+            "origin": "landed_surface",
+            "status": "returned",
+            "matrix": [
+                [[1.0, 0.0], [0.0, 0.0]],
+                [[0.0, 0.0], [0.0, 0.0]],
+            ],
+            "summary": {
+                "shape": [2, 2],
+                "hermitian_residual": 0.0,
+                "idempotence_residual": 0.0,
+                "trace_real": 1.0,
+                "trace_imag": 0.0,
+                "minimum_eigenvalue": 0.0,
+                "maximum_eigenvalue": 1.0,
+            },
+            "machine_bound": 5.0e-15,
+        },
+    },
+)
+
+FROZEN_REJECT_WITNESSES = (
+    {
+        "probe_id": "wrong_arity",
+        "feed": {
+            "probe_id": "wrong_arity",
+            "kind": "bloch_projector",
+            "direction": [1, 0],
+        },
+        "enforcement": "landed_surface",
+        "expected": {
+            "origin": "landed_surface",
+            "status": "raised",
+            "exception_type": "ValueError",
+            "message": "a Bloch projector needs one unit three-vector",
+        },
+    },
+    {
+        "probe_id": "non_normalized",
+        "feed": {
+            "probe_id": "non_normalized",
+            "kind": "bloch_projector",
+            "direction": [1, 1, 1],
+        },
+        "enforcement": "landed_surface",
+        "expected": {
+            "origin": "landed_surface",
+            "status": "raised",
+            "exception_type": "ValueError",
+            "message": "a Bloch projector needs one unit three-vector",
+        },
+    },
+    {
+        "probe_id": "out_of_domain_value",
+        "feed": {
+            "probe_id": "out_of_domain_value",
+            "kind": "bloch_projector",
+            "direction": [2, 0, 0],
+        },
+        "enforcement": "landed_surface",
+        "expected": {
+            "origin": "landed_surface",
+            "status": "raised",
+            "exception_type": "ValueError",
+            "message": "a Bloch projector needs one unit three-vector",
+        },
+    },
+    {
+        "probe_id": "boolean_type_violation",
+        "feed": {
+            "probe_id": "boolean_type_violation",
+            "kind": "bloch_projector",
+            "direction": [True, 0, 0],
+        },
+        "enforcement": "harness_schema",
+        "expected": {
+            "origin": "harness_schema",
+            "status": "raised",
+            "exception_type": "SchemaRefusal",
+            "message": (
+                "HARNESS_SCHEMA: direction entries must be finite JSON numbers "
+                "and booleans are excluded"
+            ),
+        },
+    },
+)
+
+QUARANTINED_WRONG_EXPECTATION = {
+    "probe_id": "axis_plus_x",
+    "purpose": "independent-adversary comparison liveness only",
+    "expected": {
+        "origin": "landed_surface",
+        "status": "returned",
+        "matrix": [
+            [[0.75, 0.0], [0.5, 0.0]],
+            [[0.5, 0.0], [0.5, 0.0]],
+        ],
+        "summary": {
+            "shape": [2, 2],
+            "hermitian_residual": 0.0,
+            "idempotence_residual": 0.0,
+            "trace_real": 1.0,
+            "trace_imag": 0.0,
+            "minimum_eigenvalue": 0.0,
+            "maximum_eigenvalue": 1.0,
+        },
+        "machine_bound": 5.0e-15,
+    },
+}
+
+_SURFACE_DRIVER = r"""
+import json
+import sys
+
+import numpy as np
+import physical_contact_ternary_born_forcing_bridge_cycle317_2026_07_18 as surface
+
+payload = json.load(sys.stdin)
+try:
+    projector = surface.projector_bloch(payload["direction"])
+    hermitian = (projector + projector.conj().T) / 2
+    eigenvalues = np.linalg.eigvalsh(hermitian)
+    record = {
+        "origin": "landed_surface",
+        "status": "returned",
+        "matrix": [
+            [[float(value.real), float(value.imag)] for value in row]
+            for row in projector
+        ],
+        "summary": {
+            "shape": list(projector.shape),
+            "hermitian_residual": float(
+                np.linalg.norm(projector - projector.conj().T)
+            ),
+            "idempotence_residual": float(
+                np.linalg.norm(projector @ projector - projector)
+            ),
+            "trace_real": float(np.trace(projector).real),
+            "trace_imag": float(np.trace(projector).imag),
+            "minimum_eigenvalue": float(np.min(eigenvalues)),
+            "maximum_eigenvalue": float(np.max(eigenvalues)),
+        },
+    }
+except Exception as exc:
+    record = {
+        "origin": "landed_surface",
+        "status": "raised",
+        "exception_type": type(exc).__name__,
+        "message": str(exc),
+    }
+print(json.dumps(record, allow_nan=False, sort_keys=True))
+"""
+
+_PASS = 0
+_FAIL = 0
+
+
+def check(label: str, condition: bool, detail: Any = "") -> bool:
+    """Print one certificate line and update the local census."""
+    global _PASS, _FAIL
+    if condition:
+        _PASS += 1
+        status = "PASS"
+    else:
+        _FAIL += 1
+        status = "FAIL"
+    print(f"{status} {label} :: {detail}")
+    return condition
+
+
+def _sha256_path(relative_path: str) -> str:
+    return hashlib.sha256((ROOT / relative_path).read_bytes()).hexdigest()
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _same_data(left: Any, right: Any) -> bool:
+    try:
+        left_json = json.dumps(
+            left, allow_nan=False, separators=(",", ":"), sort_keys=True
+        )
+        right_json = json.dumps(
+            right, allow_nan=False, separators=(",", ":"), sort_keys=True
+        )
+    except (TypeError, ValueError):
+        return False
+    return left_json == right_json
+
+
+def _frozen_numeric_match(observed: Any, expected: Any, bound: float) -> bool:
+    if isinstance(expected, bool) or expected is None or isinstance(expected, str):
+        return observed == expected
+    if isinstance(expected, (int, float)):
+        return (
+            isinstance(observed, (int, float))
+            and not isinstance(observed, bool)
+            and math.isfinite(float(observed))
+            and abs(float(observed) - float(expected)) <= bound
+        )
+    if isinstance(expected, list):
+        return (
+            isinstance(observed, list)
+            and len(observed) == len(expected)
+            and all(
+                _frozen_numeric_match(actual, frozen, bound)
+                for actual, frozen in zip(observed, expected)
+            )
+        )
+    if isinstance(expected, dict):
+        return (
+            isinstance(observed, dict)
+            and set(observed) == set(expected)
+            and all(
+                _frozen_numeric_match(observed[key], value, bound)
+                for key, value in expected.items()
+            )
+        )
+    return observed == expected
+
+
+def _current_pins() -> dict[str, dict[str, Any]]:
+    rows = {}
+    for frozen in FROZEN_SELF_RUNS:
+        actual = _sha256_path(frozen["path"])
+        rows[frozen["name"]] = {
+            "path": frozen["path"],
+            "expected": frozen["sha256"],
+            "actual": actual,
+            "match": actual == frozen["sha256"],
+        }
+    return rows
+
+
+def _self_run(frozen: dict[str, Any]) -> dict[str, Any]:
+    actual_sha = _sha256_path(frozen["path"])
+    if actual_sha != frozen["sha256"]:
+        return {
+            "name": frozen["name"],
+            "verdict": "DRIFT",
+            "pin_match": False,
+            "executed": False,
+            "output_match": False,
+        }
+    try:
+        completed = subprocess.run(
+            [sys.executable, str(ROOT / frozen["path"])],
+            cwd=ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=AUDIT_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "name": frozen["name"],
+            "verdict": "DRIFT",
+            "pin_match": True,
+            "executed": True,
+            "output_match": False,
+            "timeout": exc.timeout,
+        }
+
+    stdout_text = completed.stdout.decode("utf-8", errors="replace")
+    matches = re.findall(
+        frozen["summary_pattern"], stdout_text, flags=re.MULTILINE
+    )
+    observed_counts = (
+        [int(value) for value in matches[-1]] if matches else None
+    )
+    lines = stdout_text.splitlines()
+    marker_match = bool(lines and lines[-1] == frozen["terminal_marker"])
+    count_match = observed_counts == [
+        frozen["expected_pass"],
+        frozen["expected_fail"],
+    ]
+    output_match = (
+        completed.returncode == 0
+        and _sha256_bytes(completed.stdout) == frozen["stdout_sha256"]
+        and len(completed.stdout) == frozen["stdout_bytes"]
+        and completed.stderr == b""
+        and count_match
+        and marker_match
+    )
+    return {
+        "name": frozen["name"],
+        "verdict": "ACCEPT" if output_match else "DRIFT",
+        "pin_match": True,
+        "executed": True,
+        "output_match": output_match,
+        "returncode": completed.returncode,
+        "stdout_sha256": _sha256_bytes(completed.stdout),
+        "stdout_bytes": len(completed.stdout),
+        "stderr_sha256": _sha256_bytes(completed.stderr),
+        "stderr_bytes": len(completed.stderr),
+        "observed_counts": observed_counts,
+        "count_match": count_match,
+        "marker_match": marker_match,
+    }
+
+
+def _lookup_frozen(probe_id: Any) -> tuple[str, dict[str, Any]] | None:
+    for row in FROZEN_LAWFUL_PROBES:
+        if row["probe_id"] == probe_id:
+            return "lawful", row
+    for row in FROZEN_REJECT_WITNESSES:
+        if row["probe_id"] == probe_id:
+            return "reject", row
+    return None
+
+
+def _schema_refusal() -> dict[str, Any]:
+    return {
+        "origin": "harness_schema",
+        "status": "raised",
+        "exception_type": "SchemaRefusal",
+        "message": (
+            "HARNESS_SCHEMA: direction entries must be finite JSON numbers "
+            "and booleans are excluded"
+        ),
+    }
+
+
+def _surface_observation(feed: dict[str, Any]) -> dict[str, Any]:
+    try:
+        encoded = json.dumps(feed, allow_nan=False, sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        return {
+            "origin": "harness_schema",
+            "status": "raised",
+            "exception_type": "SchemaRefusal",
+            "message": f"HARNESS_SCHEMA: non-JSON feed: {type(exc).__name__}",
+        }
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", _SURFACE_DRIVER],
+            cwd=ROOT,
+            input=encoded,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=AUDIT_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "origin": "subprocess_driver",
+            "status": "driver_error",
+            "message": f"timeout after {exc.timeout} seconds",
+        }
+    if completed.returncode != 0:
+        return {
+            "origin": "subprocess_driver",
+            "status": "driver_error",
+            "returncode": completed.returncode,
+            "stderr_sha256": _sha256_bytes(completed.stderr.encode("utf-8")),
+        }
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "origin": "subprocess_driver",
+            "status": "driver_error",
+            "message": f"JSONDecodeError: {exc}",
+        }
+
+
+def _compare_observation(
+    category: str,
+    feed: Any,
+    frozen: dict[str, Any],
+    observed: dict[str, Any],
+) -> dict[str, bool]:
+    expected = frozen["expected"]
+    feed_match = _same_data(feed, frozen["feed"])
+    origin_match = observed.get("origin") == expected["origin"]
+    status_match = observed.get("status") == expected["status"]
+    if category == "lawful":
+        bound = expected["machine_bound"]
+        matrix_match = _frozen_numeric_match(
+            observed.get("matrix"), expected["matrix"], bound
+        )
+        summary_match = _frozen_numeric_match(
+            observed.get("summary"), expected["summary"], bound
+        )
+        signature_match = True
+    else:
+        matrix_match = True
+        summary_match = True
+        signature_match = (
+            observed.get("exception_type") == expected["exception_type"]
+            and observed.get("message") == expected["message"]
+        )
+    frozen_match = (
+        feed_match
+        and origin_match
+        and status_match
+        and matrix_match
+        and summary_match
+        and signature_match
+    )
+    return {
+        "feed_match": feed_match,
+        "origin_match": origin_match,
+        "status_match": status_match,
+        "matrix_match": matrix_match,
+        "summary_match": summary_match,
+        "signature_match": signature_match,
+        "frozen_match": frozen_match,
+    }
+
+
+def run_acceptance(feed: Any) -> dict[str, Any]:
+    """Return ACCEPT, REJECT, or DRIFT for one declared-shape feed object."""
+    pins = _current_pins()
+    if not all(row["match"] for row in pins.values()):
+        return {
+            "probe_id": feed.get("probe_id") if isinstance(feed, dict) else None,
+            "verdict": "DRIFT",
+            "pins": pins,
+            "comparison": {"frozen_match": False},
+            "observation": {"status": "not_run_on_unpinned_surface"},
+        }
+    if not isinstance(feed, dict):
+        return {
+            "probe_id": None,
+            "verdict": "REJECT",
+            "pins": pins,
+            "comparison": {"frozen_match": False},
+            "observation": {
+                "origin": "harness_schema",
+                "status": "raised",
+                "exception_type": "SchemaRefusal",
+                "message": "HARNESS_SCHEMA: feed must be an object",
+            },
+        }
+
+    lookup = _lookup_frozen(feed.get("probe_id"))
+    exact_keys = set(feed) == {"probe_id", "kind", "direction"}
+    exact_kind = feed.get("kind") == "bloch_projector"
+    if lookup is None or not exact_keys or not exact_kind:
+        return {
+            "probe_id": feed.get("probe_id"),
+            "verdict": "REJECT",
+            "pins": pins,
+            "comparison": {"frozen_match": False},
+            "observation": {
+                "origin": "harness_schema",
+                "status": "raised",
+                "exception_type": "SchemaRefusal",
+                "message": (
+                    "HARNESS_SCHEMA: feed must exactly name one frozen "
+                    "bloch_projector probe"
+                ),
+            },
+        }
+
+    category, frozen = lookup
+    if frozen.get("enforcement") == "harness_schema":
+        observed = _schema_refusal()
+    else:
+        observed = _surface_observation(feed)
+    comparison = _compare_observation(category, feed, frozen, observed)
+    if comparison["feed_match"] and not comparison["frozen_match"]:
+        verdict = "DRIFT"
+    elif category == "lawful" and comparison["frozen_match"]:
+        verdict = "ACCEPT"
+    else:
+        verdict = "REJECT"
+    return {
+        "probe_id": frozen["probe_id"],
+        "category": category,
+        "enforcement": frozen.get("enforcement", "landed_surface"),
+        "verdict": verdict,
+        "pins": pins,
+        "comparison": comparison,
+        "observation": observed,
+    }
+
+
+def _sandbox_drift_demo() -> dict[str, Any]:
+    real_before = _sha256_path(AUDIT_INPUT_PATHS[0])
+    with tempfile.TemporaryDirectory(prefix="born-acceptance-drift-") as folder:
+        sandbox_path = Path(folder) / Path(AUDIT_INPUT_PATHS[0]).name
+        shutil.copyfile(ROOT / AUDIT_INPUT_PATHS[0], sandbox_path)
+        original = sandbox_path.read_bytes()
+        changed = bytearray(original)
+        changed[-1] ^= 1
+        sandbox_path.write_bytes(bytes(changed))
+        sandbox_sha = hashlib.sha256(sandbox_path.read_bytes()).hexdigest()
+        differing_bytes = sum(
+            left != right for left, right in zip(original, changed)
+        )
+        sandbox_verdict = (
+            "ACCEPT" if sandbox_sha == BRIDGE_SHA256 else "DRIFT"
+        )
+    real_after = _sha256_path(AUDIT_INPUT_PATHS[0])
+    return {
+        "verdict": sandbox_verdict,
+        "one_byte_changed": differing_bytes == 1,
+        "sandbox_sha256": sandbox_sha,
+        "expected_sha256": BRIDGE_SHA256,
+        "real_before": real_before,
+        "real_after": real_after,
+        "real_unchanged": (
+            real_before == real_after == BRIDGE_SHA256
+        ),
+    }
+
+
+def _landed_attribute_writes(tree: ast.AST, alias: str) -> list[str]:
+    writes = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute) or not isinstance(
+            node.ctx, ast.Store
+        ):
+            continue
+        base = node.value
+        if isinstance(base, ast.Name) and base.id == alias:
+            writes.append(node.attr)
+    return writes
+
+
+def _table_node(tree: ast.Module, name: str) -> ast.AST | None:
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in node.targets
+        ):
+            return node.value
+    return None
+
+
+def _structural_audit() -> dict[str, Any]:
+    source = Path(__file__).read_text(encoding="utf-8")
+    outer = ast.parse(source, filename=str(Path(__file__)))
+    driver = ast.parse(_SURFACE_DRIVER, filename="<surface-driver>")
+    landed_names = {
+        Path(path).stem for path in AUDIT_INPUT_PATHS
+    }
+    outer_imports = {
+        alias.name
+        for node in ast.walk(outer)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    } | {
+        node.module
+        for node in ast.walk(outer)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    }
+    parent_imports_landed = bool(landed_names & outer_imports)
+
+    identifiers = []
+    for node in ast.walk(outer):
+        if isinstance(node, ast.Name):
+            identifiers.append(node.id.lower())
+        elif isinstance(node, ast.Attribute):
+            identifiers.append(node.attr.lower())
+        elif isinstance(node, (ast.FunctionDef, ast.ClassDef)):
+            identifiers.append(node.name.lower())
+    forbidden_fragments = ("weight", "probab", "random", "sample", "choice")
+    forbidden_identifiers = sorted(
+        {
+            name
+            for name in identifiers
+            if any(fragment in name for fragment in forbidden_fragments)
+        }
+    )
+
+    surface_calls = [
+        node
+        for node in ast.walk(driver)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "surface"
+    ]
+    data_only_call = False
+    if len(surface_calls) == 1:
+        call = surface_calls[0]
+        argument = call.args[0] if len(call.args) == 1 else None
+        data_only_call = (
+            call.func.attr == "projector_bloch"
+            and isinstance(argument, ast.Subscript)
+            and isinstance(argument.value, ast.Name)
+            and argument.value.id == "payload"
+            and isinstance(argument.slice, ast.Constant)
+            and argument.slice.value == "direction"
+            and not call.keywords
+        )
+
+    literal_tables = {}
+    for name in (
+        "FROZEN_LAWFUL_PROBES",
+        "FROZEN_REJECT_WITNESSES",
+        "QUARANTINED_WRONG_EXPECTATION",
+    ):
+        node = _table_node(outer, name)
+        try:
+            ast.literal_eval(node) if node is not None else None
+            literal_tables[name] = node is not None
+        except (ValueError, TypeError):
+            literal_tables[name] = False
+
+    driver_writes = _landed_attribute_writes(driver, "surface")
+    parent_modules_clean = all(name not in sys.modules for name in landed_names)
+    return {
+        "parent_imports_landed": parent_imports_landed,
+        "parent_modules_clean": parent_modules_clean,
+        "landed_attribute_writes": driver_writes,
+        "forbidden_code_identifiers": forbidden_identifiers,
+        "surface_call_count": len(surface_calls),
+        "surface_call_is_payload_data_only": data_only_call,
+        "literal_feed_and_expectation_tables": literal_tables,
+        "subprocess_isolation_ok": (
+            not parent_imports_landed
+            and parent_modules_clean
+            and not driver_writes
+        ),
+        "firewall_ok": (
+            not forbidden_identifiers
+            and data_only_call
+            and all(literal_tables.values())
+        ),
+    }
+
+
+def main() -> int:
+    global _PASS, _FAIL
+    _PASS = 0
+    _FAIL = 0
+
+    self_runs = [_self_run(row) for row in FROZEN_SELF_RUNS]
+    check(
+        "A. byte pins and landed self-runs reproduce frozen counts, markers, and outputs",
+        all(row["verdict"] == "ACCEPT" for row in self_runs),
+        {
+            row["name"]: {
+                "verdict": row["verdict"],
+                "counts": row.get("observed_counts"),
+                "output_match": row["output_match"],
+            }
+            for row in self_runs
+        },
+    )
+
+    lawful = [run_acceptance(row["feed"]) for row in FROZEN_LAWFUL_PROBES]
+    check(
+        "B. all lawful declared-domain probes ACCEPT with frozen-value matches",
+        len(lawful) >= 4
+        and all(
+            row["verdict"] == "ACCEPT"
+            and row["comparison"]["frozen_match"]
+            for row in lawful
+        ),
+        {
+            row["probe_id"]: {
+                "verdict": row["verdict"],
+                "frozen_match": row["comparison"]["frozen_match"],
+            }
+            for row in lawful
+        },
+    )
+
+    rejected = [
+        run_acceptance(row["feed"]) for row in FROZEN_REJECT_WITNESSES
+    ]
+    structure = _structural_audit()
+    check(
+        "C. all malformed witnesses REJECT with frozen refusal signatures and zero landed-module writes",
+        len(rejected) >= 4
+        and all(
+            row["verdict"] == "REJECT"
+            and row["comparison"]["frozen_match"]
+            and row["comparison"]["signature_match"]
+            for row in rejected
+        )
+        and structure["subprocess_isolation_ok"],
+        {
+            "witnesses": {
+                row["probe_id"]: {
+                    "verdict": row["verdict"],
+                    "frozen_match": row["comparison"]["frozen_match"],
+                    "enforcement": row["enforcement"],
+                }
+                for row in rejected
+            },
+            "isolation": structure["subprocess_isolation_ok"],
+            "attribute_writes": structure["landed_attribute_writes"],
+        },
+    )
+
+    drift_demo = _sandbox_drift_demo()
+    check(
+        "D. one-byte sandbox mutation is DRIFT while the real bridge remains byte-pinned",
+        drift_demo["verdict"] == "DRIFT"
+        and drift_demo["one_byte_changed"]
+        and drift_demo["real_unchanged"],
+        drift_demo,
+    )
+
+    adversary_source = next(
+        row for row in lawful if row["probe_id"] == "axis_plus_x"
+    )
+    adversary_frozen = {
+        "feed": next(
+            row["feed"]
+            for row in FROZEN_LAWFUL_PROBES
+            if row["probe_id"] == "axis_plus_x"
+        ),
+        "expected": QUARANTINED_WRONG_EXPECTATION["expected"],
+    }
+    adversary_comparison = _compare_observation(
+        "lawful",
+        adversary_frozen["feed"],
+        adversary_frozen,
+        adversary_source["observation"],
+    )
+    adversary_caught = not adversary_comparison["frozen_match"]
+    check(
+        "E. quarantined wrong frozen expectation is caught by the live comparator",
+        adversary_caught
+        and not adversary_comparison["matrix_match"],
+        adversary_comparison,
+    )
+
+    check(
+        "F. AST firewall finds data-only feeds and no synthesis identifiers or literal-fed surface calls",
+        structure["firewall_ok"],
+        {
+            "firewall_ok": structure["firewall_ok"],
+            "forbidden_code_identifiers": structure[
+                "forbidden_code_identifiers"
+            ],
+            "surface_call_count": structure["surface_call_count"],
+            "surface_call_is_payload_data_only": structure[
+                "surface_call_is_payload_data_only"
+            ],
+            "literal_tables": structure[
+                "literal_feed_and_expectation_tables"
+            ],
+        },
+    )
+
+    census = [
+        {
+            "probe_id": row["probe_id"],
+            "verdict": row["verdict"],
+            "frozen_match": row["comparison"]["frozen_match"],
+        }
+        for row in lawful + rejected
+    ]
+    for row in census:
+        print(
+            "CENSUS",
+            row["probe_id"],
+            "verdict=" + row["verdict"],
+            "frozen_match=" + str(row["frozen_match"]),
+        )
+
+    elapsed = time.monotonic() - _MODULE_START
+    final_record = {
+        "adversary_self_test": {
+            "caught": adversary_caught,
+            "wrong_matrix_match": adversary_comparison["matrix_match"],
+        },
+        "checks": {"fail": _FAIL, "pass": _PASS},
+        "drift_demo": drift_demo,
+        "firewall": {
+            "feeds_are_supplied_apparatus_data": True,
+            "new_physics_claimed": False,
+            "selects_born_law": False,
+            "selects_probability_content": False,
+            "selects_weight_map": False,
+            "structural_ast_pass": structure["firewall_ok"],
+        },
+        "probe_census": census,
+        "runtime_seconds": round(elapsed, 6),
+        "self_runs": self_runs,
+    }
+    print(
+        json.dumps(
+            final_record,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+    return int(_FAIL != 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/frontier_born_acceptance_independent_check_2026_07_28.py
+++ b/scripts/frontier_born_acceptance_independent_check_2026_07_28.py
@@ -1,0 +1,772 @@
+#!/usr/bin/env python3
+"""Independent checker for the frozen Cycle-317 Born acceptance harness."""
+
+from __future__ import annotations
+
+AUDIT_TIMEOUT_SEC = 900
+NOTE_PATH = "docs/BORN_ACCEPTANCE_HARNESS_SUPPORT_NOTE_2026-07-28.md"
+AUDIT_INPUT_PATHS = (
+    "scripts/physical_contact_ternary_born_forcing_bridge_cycle317_2026_07_18.py",
+    "scripts/physical_contact_ternary_born_forcing_release_cycle317_2026_07_18.py",
+)
+
+import ast
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+from typing import Any, Callable
+
+
+_START = time.monotonic()
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS_PATH = ROOT / "scripts/frontier_born_acceptance_harness_2026_07_28.py"
+BLOCKLIST = ("frontier_born_acceptance_harness_2026_07_28",)
+_HARNESS_WAS_PRELOADED = any(name in sys.modules for name in BLOCKLIST)
+_EXTRACTED: dict[str, Any] | None = None
+_HONEST_LABEL_RESULT = "not verified"
+
+
+class _HarnessImportBlocker:
+    """Make an accidental harness import fail closed."""
+
+    @staticmethod
+    def find_spec(
+        fullname: str, path: object = None, target: object = None
+    ) -> None:
+        del path, target
+        if fullname in BLOCKLIST:
+            raise ImportError(f"blocklisted data-only module: {fullname}")
+        return None
+
+
+_IMPORT_BLOCKER = _HarnessImportBlocker()
+sys.meta_path.insert(0, _IMPORT_BLOCKER)
+
+
+class CertificateError(RuntimeError):
+    """A certificate could not establish its claimed fact."""
+
+
+def _assignment_node(tree: ast.Module, name: str) -> ast.AST:
+    matches: list[ast.AST] = []
+    for statement in tree.body:
+        if isinstance(statement, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in statement.targets
+        ):
+            matches.append(statement.value)
+        elif (
+            isinstance(statement, ast.AnnAssign)
+            and isinstance(statement.target, ast.Name)
+            and statement.target.id == name
+        ):
+            matches.append(statement.value)
+    if len(matches) != 1:
+        raise CertificateError(
+            f"{name}: expected one top-level assignment, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _literal(tree: ast.Module, name: str) -> Any:
+    node = _assignment_node(tree, name)
+    try:
+        return ast.literal_eval(node)
+    except (TypeError, ValueError, SyntaxError) as exc:
+        raise CertificateError(f"{name} is not a pure literal") from exc
+
+
+def _sha256(relative_path: str) -> str:
+    return hashlib.sha256((ROOT / relative_path).read_bytes()).hexdigest()
+
+
+def _same_json(left: Any, right: Any) -> bool:
+    try:
+        return json.dumps(
+            left, allow_nan=False, separators=(",", ":"), sort_keys=True
+        ) == json.dumps(
+            right, allow_nan=False, separators=(",", ":"), sort_keys=True
+        )
+    except (TypeError, ValueError):
+        return False
+
+
+def _numeric_match(observed: Any, expected: Any, bound: float) -> bool:
+    if isinstance(expected, bool) or expected is None or isinstance(expected, str):
+        return observed == expected
+    if isinstance(expected, (int, float)):
+        return (
+            isinstance(observed, (int, float))
+            and not isinstance(observed, bool)
+            and math.isfinite(float(observed))
+            and abs(float(observed) - float(expected)) <= bound
+        )
+    if isinstance(expected, list):
+        return (
+            isinstance(observed, list)
+            and len(observed) == len(expected)
+            and all(
+                _numeric_match(actual, frozen, bound)
+                for actual, frozen in zip(observed, expected)
+            )
+        )
+    if isinstance(expected, dict):
+        return (
+            isinstance(observed, dict)
+            and set(observed) == set(expected)
+            and all(
+                _numeric_match(observed[key], value, bound)
+                for key, value in expected.items()
+            )
+        )
+    return observed == expected
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise CertificateError(message)
+
+
+def extraction() -> str:
+    """AST-extract and validate every frozen datum used by later certificates."""
+    global _EXTRACTED
+
+    source = HARNESS_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(HARNESS_PATH))
+    audit_paths = _literal(tree, "AUDIT_INPUT_PATHS")
+    note_path = _literal(tree, "NOTE_PATH")
+    bridge_pin = _literal(tree, "BRIDGE_SHA256")
+    release_pin = _literal(tree, "RELEASE_SHA256")
+    self_runs = _literal(tree, "FROZEN_SELF_RUNS")
+    lawful = _literal(tree, "FROZEN_LAWFUL_PROBES")
+    rejected = _literal(tree, "FROZEN_REJECT_WITNESSES")
+
+    _require(
+        isinstance(audit_paths, tuple) and audit_paths == AUDIT_INPUT_PATHS,
+        "harness AUDIT_INPUT_PATHS is not the checker header tuple",
+    )
+    _require(note_path == NOTE_PATH, "harness NOTE_PATH does not match")
+    _require(
+        isinstance(self_runs, tuple) and len(self_runs) == 2,
+        "FROZEN_SELF_RUNS must contain exactly two literal rows",
+    )
+    _require(
+        isinstance(lawful, tuple) and len(lawful) == 4,
+        "FROZEN_LAWFUL_PROBES must contain exactly four literal rows",
+    )
+    _require(
+        isinstance(rejected, tuple) and len(rejected) == 4,
+        "FROZEN_REJECT_WITNESSES must contain exactly four literal rows",
+    )
+
+    expected_counts = {"bridge": (15, 0), "release": (14, 0)}
+    expected_pins = {"bridge": bridge_pin, "release": release_pin}
+    expected_paths = dict(zip(("bridge", "release"), AUDIT_INPUT_PATHS))
+    rows_by_name = {
+        row.get("name"): row for row in self_runs if isinstance(row, dict)
+    }
+    _require(
+        set(rows_by_name) == set(expected_counts),
+        "self-run labels are not exactly bridge/release",
+    )
+    for name, counts in expected_counts.items():
+        row = rows_by_name[name]
+        _require(
+            (row.get("expected_pass"), row.get("expected_fail")) == counts,
+            f"{name} frozen count is not {counts[0]}/{counts[1]}",
+        )
+        _require(row.get("path") == expected_paths[name], f"{name} path drift")
+        _require(row.get("sha256") == expected_pins[name], f"{name} pin split")
+        _require(
+            isinstance(expected_pins[name], str)
+            and re.fullmatch(r"[0-9a-f]{64}", expected_pins[name]) is not None,
+            f"{name} pin is not a lowercase sha256",
+        )
+
+    lawful_labels = tuple(row.get("probe_id") for row in lawful)
+    _require(
+        lawful_labels
+        == ("axis_plus_x", "axis_minus_x", "axis_plus_y", "axis_plus_z"),
+        "lawful probe labels/order drifted",
+    )
+    for row in lawful:
+        _require(
+            isinstance(row, dict)
+            and row.get("feed", {}).get("probe_id") == row.get("probe_id"),
+            "lawful feed label is not intact",
+        )
+        expected = row.get("expected")
+        _require(
+            isinstance(expected, dict)
+            and expected.get("origin") == "landed_surface"
+            and expected.get("status") == "returned"
+            and isinstance(expected.get("matrix"), list)
+            and isinstance(expected.get("summary"), dict)
+            and isinstance(expected.get("machine_bound"), float),
+            f"{row.get('probe_id')} has no frozen returned-value expectation",
+        )
+
+    expected_reject_labels = {
+        "wrong_arity": "landed_surface",
+        "non_normalized": "landed_surface",
+        "out_of_domain_value": "landed_surface",
+        "boolean_type_violation": "harness_schema",
+    }
+    rejected_by_label = {
+        row.get("probe_id"): row for row in rejected if isinstance(row, dict)
+    }
+    _require(
+        tuple(rejected_by_label) == tuple(expected_reject_labels),
+        "reject witness labels/order drifted",
+    )
+    for label, enforcement in expected_reject_labels.items():
+        row = rejected_by_label[label]
+        expected = row.get("expected")
+        _require(row.get("enforcement") == enforcement, f"{label} label is false")
+        _require(
+            row.get("feed", {}).get("probe_id") == label,
+            f"{label} feed label is not intact",
+        )
+        _require(
+            isinstance(expected, dict)
+            and expected.get("origin") == enforcement
+            and expected.get("status") == "raised"
+            and isinstance(expected.get("exception_type"), str)
+            and isinstance(expected.get("message"), str),
+            f"{label} has no frozen refusal signature",
+        )
+
+    _EXTRACTED = {
+        "source": source,
+        "tree": tree,
+        "audit_paths": audit_paths,
+        "bridge_pin": bridge_pin,
+        "release_pin": release_pin,
+        "self_runs": self_runs,
+        "lawful": lawful,
+        "rejected": rejected,
+    }
+    return "literal AUDIT/NOTE; pins=2; self-runs=15/0,14/0; ACCEPT=4; REJECT=4"
+
+
+def _frozen() -> dict[str, Any]:
+    if _EXTRACTED is None:
+        raise CertificateError("frozen harness data was not extracted")
+    return _EXTRACTED
+
+
+def byte_pin_recount() -> str:
+    """Recompute both landed-surface hashes from disk."""
+    frozen = _frozen()
+    rows = {row["name"]: row for row in frozen["self_runs"]}
+    observed = {
+        name: _sha256(row["path"]) for name, row in rows.items()
+    }
+    _require(
+        observed["bridge"] == rows["bridge"]["sha256"]
+        == frozen["bridge_pin"],
+        "bridge byte pin mismatch",
+    )
+    _require(
+        observed["release"] == rows["release"]["sha256"]
+        == frozen["release_pin"],
+        "release byte pin mismatch",
+    )
+    return (
+        f"bridge={observed['bridge'][:12]}…; "
+        f"release={observed['release'][:12]}…"
+    )
+
+
+def self_run_recount() -> str:
+    """Run each landed module independently and count its PASS/FAIL lines."""
+    frozen = _frozen()
+    observed_rows: list[str] = []
+    for row in frozen["self_runs"]:
+        current_pin = _sha256(row["path"])
+        _require(
+            current_pin == row["sha256"],
+            f"{row['name']} drifted before its self-run",
+        )
+        try:
+            completed = subprocess.run(
+                [sys.executable, str(ROOT / row["path"])],
+                cwd=ROOT,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=AUDIT_TIMEOUT_SEC,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise CertificateError(
+                f"{row['name']} self-run timed out after {exc.timeout}s"
+            ) from exc
+        stdout = completed.stdout.decode("utf-8", errors="replace")
+        pass_count = sum(
+            re.match(r"^(?:STRICT )?PASS ", line) is not None
+            for line in stdout.splitlines()
+        )
+        fail_count = sum(
+            re.match(r"^(?:STRICT )?FAIL ", line) is not None
+            for line in stdout.splitlines()
+        )
+        expected = (row["expected_pass"], row["expected_fail"])
+        _require(
+            completed.returncode == 0,
+            f"{row['name']} self-run exit={completed.returncode}",
+        )
+        _require(
+            completed.stderr == b"",
+            f"{row['name']} self-run emitted {len(completed.stderr)} stderr bytes",
+        )
+        _require(
+            (pass_count, fail_count) == expected,
+            (
+                f"{row['name']} line recount {pass_count}/{fail_count} "
+                f"!= {expected[0]}/{expected[1]}"
+            ),
+        )
+        _require(
+            _sha256(row["path"]) == current_pin,
+            f"{row['name']} self-run changed its source bytes",
+        )
+        observed_rows.append(f"{row['name']}={pass_count}/{fail_count}")
+    return "; ".join(observed_rows)
+
+
+_PROBE_DRIVER = r"""
+import json
+import sys
+
+import numpy as np
+import physical_contact_ternary_born_forcing_bridge_cycle317_2026_07_18 as landed
+
+records = []
+for feed in json.load(sys.stdin):
+    try:
+        projector = landed.projector_bloch(feed["direction"])
+        hermitian = (projector + projector.conj().T) / 2
+        eigenvalues = np.linalg.eigvalsh(hermitian)
+        record = {
+            "origin": "landed_surface",
+            "status": "returned",
+            "matrix": [
+                [[float(value.real), float(value.imag)] for value in row]
+                for row in projector
+            ],
+            "summary": {
+                "shape": list(projector.shape),
+                "hermitian_residual": float(
+                    np.linalg.norm(projector - projector.conj().T)
+                ),
+                "idempotence_residual": float(
+                    np.linalg.norm(projector @ projector - projector)
+                ),
+                "trace_real": float(np.trace(projector).real),
+                "trace_imag": float(np.trace(projector).imag),
+                "minimum_eigenvalue": float(np.min(eigenvalues)),
+                "maximum_eigenvalue": float(np.max(eigenvalues)),
+            },
+        }
+    except Exception as exc:
+        record = {
+            "origin": "landed_surface",
+            "status": "raised",
+            "exception_type": type(exc).__name__,
+            "message": str(exc),
+        }
+    records.append({"probe_id": feed["probe_id"], "observation": record})
+print(json.dumps(records, allow_nan=False, separators=(",", ":"), sort_keys=True))
+"""
+
+
+def probe_verdict_recount() -> str:
+    """Drive the landed projector and independently compare all eight probes."""
+    global _HONEST_LABEL_RESULT
+
+    frozen = _frozen()
+    bridge_row = next(
+        row for row in frozen["self_runs"] if row["name"] == "bridge"
+    )
+    _require(
+        _sha256(bridge_row["path"]) == bridge_row["sha256"],
+        "bridge drifted before probe recount",
+    )
+    rows = list(frozen["lawful"]) + list(frozen["rejected"])
+    feeds = [row["feed"] for row in rows]
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", _PROBE_DRIVER],
+            cwd=ROOT,
+            input=json.dumps(feeds, allow_nan=False),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=AUDIT_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise CertificateError(
+            f"landed probe driver timed out after {exc.timeout}s"
+        ) from exc
+    _require(completed.returncode == 0, f"probe driver exit={completed.returncode}")
+    _require(
+        completed.stderr == "",
+        f"probe driver emitted {len(completed.stderr)} stderr characters",
+    )
+    try:
+        decoded = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise CertificateError("probe driver did not return one JSON record") from exc
+    _require(
+        isinstance(decoded, list) and len(decoded) == len(rows),
+        "probe driver result count mismatch",
+    )
+    observations = {
+        item.get("probe_id"): item.get("observation")
+        for item in decoded
+        if isinstance(item, dict)
+    }
+    _require(
+        len(observations) == len(rows),
+        "probe driver returned duplicate or malformed labels",
+    )
+
+    lawful_pass = 0
+    for row in frozen["lawful"]:
+        expected = row["expected"]
+        expected_value = {
+            key: value for key, value in expected.items() if key != "machine_bound"
+        }
+        if _numeric_match(
+            observations.get(row["probe_id"]),
+            expected_value,
+            expected["machine_bound"],
+        ):
+            lawful_pass += 1
+    _require(lawful_pass == 4, f"lawful frozen-value matches={lawful_pass}/4")
+
+    landed_reject_pass = 0
+    schema_row: dict[str, Any] | None = None
+    for row in frozen["rejected"]:
+        if row["enforcement"] == "landed_surface":
+            if _same_json(observations.get(row["probe_id"]), row["expected"]):
+                landed_reject_pass += 1
+        elif row["enforcement"] == "harness_schema":
+            schema_row = row
+    _require(
+        landed_reject_pass == 3,
+        f"landed refusal signature matches={landed_reject_pass}/3",
+    )
+    _require(schema_row is not None, "missing harness-schema witness")
+    schema_observed = observations.get(schema_row["probe_id"])
+    honest = (
+        schema_row["expected"].get("origin") == "harness_schema"
+        and schema_row["expected"].get("exception_type") == "SchemaRefusal"
+        and isinstance(schema_observed, dict)
+        and schema_observed.get("origin") == "landed_surface"
+        and schema_observed.get("status") == "returned"
+    )
+    _HONEST_LABEL_RESULT = (
+        "PASS harness_schema witness is accepted by landed surface"
+        if honest
+        else "FAIL harness_schema witness was not shown to be harness-only"
+    )
+    _require(honest, "harness-schema witness enforcement label is not honest")
+    _require(
+        _sha256(bridge_row["path"]) == bridge_row["sha256"],
+        "probe driver changed the bridge source bytes",
+    )
+    return "ACCEPT=4/4; landed REJECT=3/3; harness-only=1/1"
+
+
+def _imported_names(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            names.add(node.module)
+    return names
+
+
+def _root_name(node: ast.AST) -> str | None:
+    while isinstance(node, (ast.Attribute, ast.Subscript)):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else None
+
+
+def _attribute_mutations(tree: ast.AST, alias: str) -> list[str]:
+    mutations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and isinstance(
+            node.ctx, (ast.Store, ast.Del)
+        ) and _root_name(node) == alias:
+            mutations.append(node.attr)
+        elif (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.ctx, (ast.Store, ast.Del))
+            and _root_name(node) == alias
+        ):
+            mutations.append("<subscript>")
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in {"setattr", "delattr"}
+            and node.args
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == alias
+        ):
+            mutations.append(node.func.id)
+    return mutations
+
+
+def _function(tree: ast.Module, name: str) -> ast.FunctionDef:
+    matches = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    if len(matches) != 1:
+        raise CertificateError(f"{name}: expected one function definition")
+    return matches[0]
+
+
+def _contains_name(node: ast.AST, name: str) -> bool:
+    return any(
+        isinstance(child, ast.Name) and child.id == name
+        for child in ast.walk(node)
+    )
+
+
+def _drift_path_audit(tree: ast.Module) -> tuple[bool, str]:
+    function = _function(tree, "_sandbox_drift_demo")
+    temp_names: set[str] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.With):
+            continue
+        for item in node.items:
+            call = item.context_expr
+            if (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and isinstance(call.func.value, ast.Name)
+                and call.func.value.id == "tempfile"
+                and call.func.attr == "TemporaryDirectory"
+                and isinstance(item.optional_vars, ast.Name)
+            ):
+                temp_names.add(item.optional_vars.id)
+    if not temp_names:
+        return False, "no TemporaryDirectory-bound sandbox"
+
+    sandbox_names: set[str] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Assign):
+            continue
+        targets = [
+            target.id for target in node.targets if isinstance(target, ast.Name)
+        ]
+        if (
+            targets
+            and any(_contains_name(node.value, name) for name in temp_names)
+            and _contains_name(node.value, "AUDIT_INPUT_PATHS")
+        ):
+            sandbox_names.update(targets)
+    if "sandbox_path" not in sandbox_names:
+        return False, "sandbox copy path is not derived from temp dir and input name"
+
+    copy_calls = [
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "shutil"
+        and node.func.attr == "copyfile"
+    ]
+    copy_ok = (
+        len(copy_calls) == 1
+        and len(copy_calls[0].args) >= 2
+        and _contains_name(copy_calls[0].args[0], "AUDIT_INPUT_PATHS")
+        and isinstance(copy_calls[0].args[1], ast.Name)
+        and copy_calls[0].args[1].id in sandbox_names
+    )
+    if not copy_ok:
+        return False, "DRIFT copy is not landed-source to sandbox-destination"
+
+    mutation_methods = {
+        "chmod",
+        "hardlink_to",
+        "mkdir",
+        "rename",
+        "replace",
+        "rmdir",
+        "symlink_to",
+        "touch",
+        "unlink",
+        "write_bytes",
+        "write_text",
+    }
+    path_mutations: list[ast.Call] = []
+    forbidden_open = False
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call):
+            continue
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in mutation_methods
+        ):
+            path_mutations.append(node)
+        if (
+            (isinstance(node.func, ast.Name) and node.func.id == "open")
+            or (isinstance(node.func, ast.Attribute) and node.func.attr == "open")
+        ):
+            mode_node = (
+                node.args[1]
+                if len(node.args) >= 2
+                else next(
+                    (
+                        keyword.value
+                        for keyword in node.keywords
+                        if keyword.arg == "mode"
+                    ),
+                    None,
+                )
+            )
+            if mode_node is None:
+                continue
+            try:
+                mode = ast.literal_eval(mode_node)
+            except (TypeError, ValueError, SyntaxError):
+                forbidden_open = True
+            else:
+                forbidden_open |= isinstance(mode, str) and any(
+                    marker in mode for marker in "wax+"
+                )
+    mutations_ok = (
+        len(path_mutations) == 1
+        and isinstance(path_mutations[0].func, ast.Attribute)
+        and isinstance(path_mutations[0].func.value, ast.Name)
+        and path_mutations[0].func.value.id in sandbox_names
+        and path_mutations[0].func.attr == "write_bytes"
+        and not forbidden_open
+    )
+    if not mutations_ok:
+        return False, "a DRIFT write is not confined to sandbox_path.write_bytes"
+
+    real_hash_reads = [
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_sha256_path"
+        and node.args
+        and _contains_name(node.args[0], "AUDIT_INPUT_PATHS")
+    ]
+    if len(real_hash_reads) < 2:
+        return False, "real landed path is not hashed before and after sandbox demo"
+    return True, "TemporaryDirectory copy; sole write=sandbox_path.write_bytes"
+
+
+def discipline() -> str:
+    """Audit literal tables, import isolation, and sandbox-only DRIFT writes."""
+    frozen = _frozen()
+    tree = frozen["tree"]
+    landed_names = {Path(path).stem for path in AUDIT_INPUT_PATHS}
+    outer_landed_imports = _imported_names(tree) & landed_names
+    _require(not outer_landed_imports, "harness imports landed module in parent")
+
+    driver_source = _literal(tree, "_SURFACE_DRIVER")
+    _require(isinstance(driver_source, str), "_SURFACE_DRIVER is not literal text")
+    driver_tree = ast.parse(driver_source, filename="<frozen-surface-driver>")
+    bridge_name = Path(AUDIT_INPUT_PATHS[0]).stem
+    landed_aliases = [
+        alias.asname or alias.name
+        for node in ast.walk(driver_tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+        if alias.name == bridge_name
+    ]
+    _require(
+        landed_aliases == ["surface"],
+        "surface driver does not have one explicit landed alias",
+    )
+    _require(
+        not _attribute_mutations(driver_tree, "surface"),
+        "surface driver writes through its landed-module alias",
+    )
+
+    literal_names = (
+        "AUDIT_INPUT_PATHS",
+        "FROZEN_SELF_RUNS",
+        "FROZEN_LAWFUL_PROBES",
+        "FROZEN_REJECT_WITNESSES",
+        "QUARANTINED_WRONG_EXPECTATION",
+    )
+    for name in literal_names:
+        _literal(tree, name)
+
+    drift_ok, drift_detail = _drift_path_audit(tree)
+    _require(drift_ok, drift_detail)
+    _require(
+        not _HARNESS_WAS_PRELOADED
+        and all(name not in sys.modules for name in BLOCKLIST),
+        "blocklisted harness appeared in sys.modules",
+    )
+    _require(
+        all(name not in sys.modules for name in landed_names),
+        "landed module escaped a child process into checker sys.modules",
+    )
+    return (
+        "no landed attribute writes; frozen tables literal; "
+        f"DRIFT={drift_detail}; blocklist clean"
+    )
+
+
+def _one_line(value: object, limit: int = 700) -> str:
+    text = " ".join(str(value).split())
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _run_certificate(
+    index: int, name: str, function: Callable[[], str]
+) -> bool:
+    try:
+        detail = function()
+    except Exception as exc:
+        print(
+            f"FAIL {index}/5 {name} :: "
+            f"{type(exc).__name__}: {_one_line(exc)}"
+        )
+        return False
+    print(f"PASS {index}/5 {name} :: {_one_line(detail)}")
+    return True
+
+
+def main() -> int:
+    checks = (
+        ("extraction", extraction),
+        ("byte_pin_recount", byte_pin_recount),
+        ("self_run_recount", self_run_recount),
+        ("probe_verdict_recount", probe_verdict_recount),
+        ("discipline", discipline),
+    )
+    results = [
+        _run_certificate(index, name, function)
+        for index, (name, function) in enumerate(checks, start=1)
+    ]
+    passed = sum(results)
+    print(f"SUMMARY {passed}/{len(results)} {'PASS' if passed == len(results) else 'FAIL'}")
+    print(f"HONEST_LABEL {_HONEST_LABEL_RESULT}")
+    print(f"RUNTIME {time.monotonic() - _START:.6f}s")
+    return int(passed != len(results))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Support — Born acceptance harness (evidence-ceiling program, Born lane)

Physics-loop campaign `computation-connection-20260727`, support package (base `main`; imports only the landed Cycle-317 bridge/release modules). The Born-lane analog of the landed gravity source-acceptance harness set (#5704).

**Claim (exact support / meta; authority none; audit unset).** A standing instrument giving ACCEPT / REJECT / DRIFT verdicts over the landed Cycle-317 ternary Born-forcing surface against frozen literal expectations: byte pins + subprocess-isolated landed self-runs (bridge 15/0, release 14/0); four lawful declared-domain probes ACCEPT with frozen-value matches; four malformation witnesses REJECT — three by the landed surface's own domain checks, one honestly labeled `harness-schema` (the checker independently confirmed the landed surface does NOT refuse that witness, so the label is truthful); a one-byte sandbox mutation detected as DRIFT with the real module's sha proven unchanged; a live-comparator adversary self-test (a deliberately wrong quarantined expectation is caught); an AST firewall audit (feeds are data; no weight/probability synthesis).

**Firewall (verbatim).** Feeds are supplied apparatus data; no Born law, weight map, or probability content is selected; no Born physics moves in this package.

**Artifacts.** Harness runner (6/6), independent checker (5/5), support note, pinned runner caches, receipt.

Open: wiring epoch-derived feeds (Cycle-729 package) into this harness once its surfaces land on main.

Independent audit still required. Review-loop and audit-loop remain owner-operated lanes; this PR only prepares that surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
