### PR TITLE
fix: automation-lock default paths derive from the repo root (unbreaks the lock off-machine)

### DIFF
--- a/scripts/automation_lock.py
+++ b/scripts/automation_lock.py
@@ -17,8 +17,9 @@ import sys
 from typing import Any
 
 
-DEFAULT_LOCK_PATH = "/Users/jonreilly/Projects/Physics/logs/physics_worker_lock.json"
-DEFAULT_META_LOCK_PATH = "/Users/jonreilly/Projects/Physics/logs/.physics_worker_lock.guard"
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_LOCK_PATH = str(_REPO_ROOT / "logs" / "physics_worker_lock.json")
+DEFAULT_META_LOCK_PATH = str(_REPO_ROOT / "logs" / ".physics_worker_lock.guard")
 DEFAULT_HOLDER_ENV = "CODEX_THREAD_ID"
 
 


### PR DESCRIPTION
The cooperative lock's DEFAULT_LOCK_PATH/DEFAULT_META_LOCK_PATH hardcoded `/Users/jonreilly/Projects/Physics/logs/...`, so on any other machine every campaign fails the lock preflight with Permission denied and has to fall back to branch-local supervisor locks (as the last two campaigns did, recorded in their packs). This derives the defaults from the script's own location (`<repo>/logs/...`); the `--lock-path`/`--meta-lock-path` overrides are unchanged, so existing owner automation that passes explicit paths is unaffected. Verified: import works, default resolves under the repo, `--help` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)