### PR TITLE
science-fix: attempt to close dm_neutrino_odd_circulant_z2_slot_the...

### DIFF
--- a/docs/DM_NEUTRINO_ODD_CIRCULANT_Z2_SLOT_THEOREM_NOTE_2026-04-15.md
+++ b/docs/DM_NEUTRINO_ODD_CIRCULANT_Z2_SLOT_THEOREM_NOTE_2026-04-15.md
@@ -11,6 +11,13 @@
 **Runner cache:**
 [`logs/runner-cache/frontier_dm_neutrino_odd_circulant_z2_slot_theorem.txt`](../logs/runner-cache/frontier_dm_neutrino_odd_circulant_z2_slot_theorem.txt)
 
+**Re-audit certificate:** the canonical cache header pins runner SHA-256
+`f0b4cf68aef149efa7528d885017cfc8c754e0cb018ef72443a4e19521926cb9`
+and a fingerprint of this declared note input. Its unabridged stdout section is
+below the legacy `6,000`-character packet limit, includes all 37 named checks,
+and terminates with `MUTATION KILLS=6/6` and
+`PASS=37 FAIL=0`.
+
 ## Question
 
 For the supplied cyclic shift `S` and exchange matrix `P_23`, what is the exact

--- a/logs/runner-cache/frontier_dm_neutrino_odd_circulant_z2_slot_theorem.txt
+++ b/logs/runner-cache/frontier_dm_neutrino_odd_circulant_z2_slot_theorem.txt
@@ -1,39 +1,40 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_dm_neutrino_odd_circulant_z2_slot_theorem.py
-runner_sha256: 4e3622ac6b11d4350fa7f37bb1e055357ce70983fd5ea7a424fb59798ce6352a
+runner_sha256: f0b4cf68aef149efa7528d885017cfc8c754e0cb018ef72443a4e19521926cb9
+input_fingerprint_sha256: 2f8964e53cd3dad0cb229e4097e0c3ee09f8475cba98d64e9413b6a6874a768a
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.57
+elapsed_sec: 0.72
 status: ok
 ----- stdout -----
-============================================================================================
+========================================================================
 SUPPLIED 3x3 HERMITIAN-CIRCULANT / P23 EVEN-ODD ALGEBRA THEOREM
-============================================================================================
+========================================================================
 
 Typed surface:
   input  = displayed finite matrices, basis, indices, and trace pairing
   output = exact commutant, extraction, parity, and coordinate identity
 
-============================================================================================
+========================================================================
 PART 1: EXACT FULL HERMITIAN COMMUTANT
-============================================================================================
+========================================================================
   [PASS] The supplied cyclic shift convention is exact
   [PASS] Independent nine-real-coordinate constraints have rank six  (rank=6, nullity=3)
   [PASS] I, S+S^2, and i(S-S^2) are independent Hermitian commutant elements  (basis rank=3)
   [PASS] The displayed basis spans the full Hermitian commutant  (commutant dimension=3, basis rank=3)
 
-============================================================================================
+========================================================================
 PART 2: EXACT GRAM MATRIX, EXTRACTION, AND PARITY REPRESENTATION
-============================================================================================
+========================================================================
   [PASS] P23 exchanges S and S^2
   [PASS] The Hilbert-Schmidt Gram matrix is diag(3,6,6)  (G=Matrix([[3, 0, 0], [0, 6, 0], [0, 0, 6]]))
   [PASS] Hilbert-Schmidt extraction recovers the symbolic coefficient triple
   [PASS] The independently extracted parity representation is diag(+1,+1,-1)  (R=Matrix([[1, 0, 0], [0, 1, 0], [0, 0, -1]]))
   [PASS] The exact parity multiplicities are two even and one odd  (multiplicities=(2, 1))
 
-============================================================================================
+========================================================================
 PART 3: EXACT SIGNED AND ZERO COEFFICIENT CASES
-============================================================================================
+========================================================================
   [PASS] Case 0: extraction and reconstruction recover all coefficients  (expected=(5/2, 5/4, 3/4), extracted=(5/2, 5/4, 3/4))
   [PASS] Case 1: extraction and reconstruction recover all coefficients  (expected=(-1, -2, 3), extracted=(-1, -2, 3))
   [PASS] Case 2: extraction and reconstruction recover all coefficients  (expected=(0, 9/2, -1/2), extracted=(0, 9/2, -1/2))
@@ -42,9 +43,9 @@ PART 3: EXACT SIGNED AND ZERO COEFFICIENT CASES
   [PASS] Case 5: extraction and reconstruction recover all coefficients  (expected=(0, 0, 0), extracted=(0, 0, 0))
   [PASS] The supplied entry convention has K_01 = c_even + i c_odd  (K_01=3/2 - I/4, K_02=3/2 + I/4)
 
-============================================================================================
+========================================================================
 PART 4: EXACT COORDINATE POLYNOMIAL
-============================================================================================
+========================================================================
   [PASS] Actual symbolic entry multiplication gives 2 c_even c_odd  (A_01=2*c_even*c_odd)
   [PASS] P23 changes the exact coordinate polynomial by one minus sign  (A_01(PKP)=-2*c_even*c_odd)
   [PASS] Case 0: actual matrix multiplication matches the coordinate identity  (coefficients=(5/2, 5/4, 3/4))
@@ -54,24 +55,24 @@ PART 4: EXACT COORDINATE POLYNOMIAL
   [PASS] Case 4: actual matrix multiplication matches the coordinate identity  (coefficients=(7, -3/2, 0))
   [PASS] Case 5: actual matrix multiplication matches the coordinate identity  (coefficients=(0, 0, 0))
 
-============================================================================================
+========================================================================
 PART 5: EXACT SIMULTANEOUS BASIS TRANSFORMATION
-============================================================================================
+========================================================================
   [PASS] The chosen basis transformation is exactly unitary
   [PASS] Simultaneous conjugation preserves the symbolic coefficient triple
   [PASS] Simultaneous conjugation preserves parity multiplicities
   [PASS] The raw 01-entry polynomial changes under this basis transformation  (original=-14/25, transformed=0)
 
-============================================================================================
+========================================================================
 PART 6: POSITIVE THEOREM-SURFACE CONSISTENCY
-============================================================================================
+========================================================================
   [PASS] The note declares every finite-matrix input and theorem output  (missing count=0)
   [PASS] The theorem surface contains only its positive finite-matrix content  (stale-term count=0)
   [PASS] Exit policy maps every positive failure count to a nonzero exit
 
-============================================================================================
+========================================================================
 PART 7: HOSTILE MUTATIONS THROUGH LOAD-BEARING VALIDATORS
-============================================================================================
+========================================================================
   [PASS] Hostile mutation killed: noncirculant Hermitian member
   [PASS] Hostile mutation killed: wrong even/odd parity assignment
   [PASS] Hostile mutation killed: reversed overall sign in the coordinate identity
@@ -79,9 +80,9 @@ PART 7: HOSTILE MUTATIONS THROUGH LOAD-BEARING VALIDATORS
   [PASS] Hostile mutation killed: altered coefficient-extraction denominator
   [PASS] Hostile mutation killed: reversed cyclic-shift convention
 
-============================================================================================
+========================================================================
 RESULT
-============================================================================================
+========================================================================
   Positive finite-matrix theorem:
     - the Hermitian commutant is exactly three-real-dimensional
     - its parity multiplicities are exactly two even and one odd

--- a/scripts/frontier_dm_neutrino_odd_circulant_z2_slot_theorem.py
+++ b/scripts/frontier_dm_neutrino_odd_circulant_z2_slot_theorem.py
@@ -37,6 +37,10 @@ NOTE_PATH = (
     / "docs"
     / "DM_NEUTRINO_ODD_CIRCULANT_Z2_SLOT_THEOREM_NOTE_2026-04-15.md"
 )
+AUDIT_INPUT_PATHS = (
+    "docs/DM_NEUTRINO_ODD_CIRCULANT_Z2_SLOT_THEOREM_NOTE_2026-04-15.md",
+)
+SECTION_RULE = "=" * 72
 
 PASS_COUNT = 0
 FAIL_COUNT = 0
@@ -294,9 +298,9 @@ def raw_coordinate_is_basis_invariant(matrix: Matrix, unitary: Matrix) -> bool:
 
 
 def part1_full_hermitian_commutant() -> None:
-    print("\n" + "=" * 92)
+    print("\n" + SECTION_RULE)
     print("PART 1: EXACT FULL HERMITIAN COMMUTANT")
-    print("=" * 92)
+    print(SECTION_RULE)
 
     valid, constraint_rank, nullity, basis_rank = validate_commutant_basis()
     check(
@@ -321,9 +325,9 @@ def part1_full_hermitian_commutant() -> None:
 
 
 def part2_gram_extraction_and_parity() -> None:
-    print("\n" + "=" * 92)
+    print("\n" + SECTION_RULE)
     print("PART 2: EXACT GRAM MATRIX, EXTRACTION, AND PARITY REPRESENTATION")
-    print("=" * 92)
+    print(SECTION_RULE)
 
     d, c_even, c_odd = symbols("d c_even c_odd", real=True)
     symbolic_matrix = matrix_from_coefficients(d, c_even, c_odd)
@@ -356,9 +360,9 @@ def part2_gram_extraction_and_parity() -> None:
 
 
 def part3_signed_and_zero_extraction_cases() -> None:
-    print("\n" + "=" * 92)
+    print("\n" + SECTION_RULE)
     print("PART 3: EXACT SIGNED AND ZERO COEFFICIENT CASES")
-    print("=" * 92)
+    print(SECTION_RULE)
 
     for index, (d, c_even, c_odd) in enumerate(SIGNED_ZERO_SAMPLES):
         matrix = raw_hermitian_circulant(d, c_even, c_odd)
@@ -380,9 +384,9 @@ def part3_signed_and_zero_extraction_cases() -> None:
 
 
 def part4_exact_coordinate_polynomial() -> None:
-    print("\n" + "=" * 92)
+    print("\n" + SECTION_RULE)
     print("PART 4: EXACT COORDINATE POLYNOMIAL")
-    print("=" * 92)
+    print(SECTION_RULE)
 
     d, c_even, c_odd = symbols("d c_even c_odd", real=True)
     symbolic_matrix = matrix_from_coefficients(d, c_even, c_odd)
@@ -410,9 +414,9 @@ def part4_exact_coordinate_polynomial() -> None:
 
 
 def part5_exact_basis_transformation() -> None:
-    print("\n" + "=" * 92)
+    print("\n" + SECTION_RULE)
     print("PART 5: EXACT SIMULTANEOUS BASIS TRANSFORMATION")
-    print("=" * 92)
+    print(SECTION_RULE)
 
     unitary = exact_basis_change()
     d, c_even, c_odd = symbols("d c_even c_odd", real=True)
@@ -452,9 +456,9 @@ def part5_exact_basis_transformation() -> None:
 
 
 def part6_theorem_surface_consistency() -> None:
-    print("\n" + "=" * 92)
+    print("\n" + SECTION_RULE)
     print("PART 6: POSITIVE THEOREM-SURFACE CONSISTENCY")
-    print("=" * 92)
+    print(SECTION_RULE)
 
     note = NOTE_PATH.read_text(encoding="utf-8")
     required = (
@@ -512,9 +516,9 @@ def part6_theorem_surface_consistency() -> None:
 
 
 def part7_hostile_mutations() -> None:
-    print("\n" + "=" * 92)
+    print("\n" + SECTION_RULE)
     print("PART 7: HOSTILE MUTATIONS THROUGH LOAD-BEARING VALIDATORS")
-    print("=" * 92)
+    print(SECTION_RULE)
 
     noncirculant_hermitian = Matrix.diag(1, 2, 3)
     mutation_check(
@@ -549,9 +553,9 @@ def part7_hostile_mutations() -> None:
 
 
 def main() -> int:
-    print("=" * 92)
+    print(SECTION_RULE)
     print("SUPPLIED 3x3 HERMITIAN-CIRCULANT / P23 EVEN-ODD ALGEBRA THEOREM")
-    print("=" * 92)
+    print(SECTION_RULE)
     print()
     print("Typed surface:")
     print("  input  = displayed finite matrices, basis, indices, and trace pairing")
@@ -565,9 +569,9 @@ def main() -> int:
     part6_theorem_surface_consistency()
     part7_hostile_mutations()
 
-    print("\n" + "=" * 92)
+    print("\n" + SECTION_RULE)
     print("RESULT")
-    print("=" * 92)
+    print(SECTION_RULE)
     print("  Positive finite-matrix theorem:")
     print("    - the Hermitian commutant is exactly three-real-dimensional")
     print("    - its parity multiplicities are exactly two even and one odd")


### PR DESCRIPTION
## Summary

Automated attempt by `scripts/science_fix_loop.py` to
close the missing derivation in
`dm_neutrino_odd_circulant_z2_slot_theorem_note_2026-04-15`.

- **Category:** `conditional_runner_artifact_issue`
- **Transitive descendants if closed:** 811
- **Repair source:** docs/audit/MISSING_DERIVATION_PROMPTS.md

## What this PR does

Codex gpt-5.6-sol at xhigh reasoning was given the
missing-derivation prompt
in a clean worktree off `origin/main`. It made the diff in this PR.

## Review checklist

- [ ] Run the repo-native review-loop before landing; automated science
      attempts can be wrong
- [ ] If the new derivation survives review-loop, land it through the normal
      path and let the independent audit batch re-audit the row after merge
- [ ] If the diff is wrong-headed, close this PR; the loop won't retry
      automatically (state file: `logs/science-fix-state.json`)

## Codex output tail

```
Closed the source-side audit blocker; the note is re-audit ready.

- Added a documented unabridged certificate to the [theorem note](/private/tmp/science-fix-worktrees/dm_neutrino_odd_circulant_z2_slot_theorem_note_2026-04-15-da452889/docs/DM_NEUTRINO_ODD_CIRCULANT_Z2_SLOT_THEOREM_NOTE_2026-04-15.md:14).
- Updated the [runner](/private/tmp/science-fix-worktrees/dm_neutrino_odd_circulant_z2_slot_theorem_note_2026-04-15-da452889/scripts/frontier_dm_neutrino_odd_circulant_z2_slot_theorem.py:40) to fingerprint the note input and emit compact, unclipped output.
- Regenerated the [SHA-pinned cache](/private/tmp/science-fix-worktrees/dm_neutrino_odd_circulant_z2_slot_theorem_note_2026-04-15-da452889/logs/runner-cache/frontier_dm_neutrino_odd_circulant_z2_slot_theorem.txt:1).

Verification:

- `PASS=37 FAIL=0`, `MUTATION KILLS=6/6`
- Live and cached stdout match byte-for-byte.
- Stdout is 5,761 characters—below the legacy 6,000-character limit.
- Cache freshness and 16 cache-input tests pass.
- Audit candidate builder classifies it as `runner_artifact_repaired_since_audit`.
- Vocabulary lint and `git diff --check` pass.

Audit authority data was intentionally left unchanged; an independent re-audit must apply the final verdict.

```

🤖 Generated by `scripts/science_fix_loop.py` (codex gpt-5.6-sol, xhigh)
