### PR TITLE
Fix audit dispatch context contract drift

### DIFF
--- a/docs/audit/data/anomaly_forces_time_reaudit_queue_2026-06-21.json
+++ b/docs/audit/data/anomaly_forces_time_reaudit_queue_2026-06-21.json
@@ -2,11 +2,7 @@
   "allowed_context_paths": [
     "docs/audit/README.md",
     "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
-    "docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md",
-    "docs/ANOMALY_FORCES_TIME_ABJ_INCONSISTENCY_ACCEPTED_PREMISE_BRIDGE_BOUNDED_NOTE_2026-05-26.md",
-    "docs/ANOMALY_FORCES_TIME_BRIDGE_PREMISE_MANIFEST_RECHECK_NOTE_2026-06-17.md",
-    "docs/ANOMALY_FORCES_TIME_THEOREM.md",
-    "docs/ONE_TIME_DIMENSION_DT1_REDUCES_TO_EMERGENT_DYNAMICS_GATE_OPEN_GATE_NOTE_2026-06-17.md"
+    "docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md"
   ],
   "forbidden_context": [
     "this dispatcher manifest as evidence",

--- a/docs/audit/data/cl3_pauli_irrep_uniqueness_reaudit_queue_2026-07-25.json
+++ b/docs/audit/data/cl3_pauli_irrep_uniqueness_reaudit_queue_2026-07-25.json
@@ -8,9 +8,7 @@
     "docs/ai_methodology/skills/no-go-discipline/SKILL.md",
     "docs/CL3_PAULI_IRREP_UNIQUENESS_NARROW_THEOREM_NOTE_2026-05-10.md",
     "scripts/audit_companion_cl3_pauli_irrep_uniqueness_exact_2026_05_10.py",
-    "scripts/cl3_pauli_irrep_faithful_direct_sum_n7_independent_2026_07_17.py",
-    "logs/runner-cache/audit_companion_cl3_pauli_irrep_uniqueness_exact_2026_05_10.txt",
-    "logs/runner-cache/cl3_pauli_irrep_uniqueness_n1_complete_certificate_2026-07-25.txt"
+    "scripts/cl3_pauli_irrep_faithful_direct_sum_n7_independent_2026_07_17.py"
   ],
   "forbidden_context": [
     "this dispatcher manifest as evidence",

--- a/docs/audit/data/lsp_projective_reaudit_queue_2026-05-22.json
+++ b/docs/audit/data/lsp_projective_reaudit_queue_2026-05-22.json
@@ -3,9 +3,7 @@
     "docs/audit/README.md",
     "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
     "docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md",
-    "docs/audit/ALGEBRAIC_DECORATION_POLICY.md",
-    "docs/MINIMAL_AXIOMS_2026-05-20.md",
-    "docs/QUBIT_AXIOM_HARDENING_NOTE_2026-05-20.md"
+    "docs/audit/ALGEBRAIC_DECORATION_POLICY.md"
   ],
   "forbidden_context": [
     "this dispatcher manifest as evidence",

--- a/docs/audit/data/r1_qubit_k1_reaudit_queue_2026-05-22.json
+++ b/docs/audit/data/r1_qubit_k1_reaudit_queue_2026-05-22.json
@@ -3,9 +3,7 @@
     "docs/audit/README.md",
     "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
     "docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md",
-    "docs/audit/ALGEBRAIC_DECORATION_POLICY.md",
-    "docs/MINIMAL_AXIOMS_2026-05-20.md",
-    "docs/QUBIT_AXIOM_HARDENING_NOTE_2026-05-20.md"
+    "docs/audit/ALGEBRAIC_DECORATION_POLICY.md"
   ],
   "forbidden_context": [
     "this dispatcher manifest as evidence",

--- a/docs/audit/data/teleportation_acceptance_suite_note_reaudit_queue_2026-07-28.json
+++ b/docs/audit/data/teleportation_acceptance_suite_note_reaudit_queue_2026-07-28.json
@@ -5,8 +5,7 @@
     "docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md",
     "docs/TELEPORTATION_ACCEPTANCE_SUITE_NOTE.md",
     "scripts/frontier_teleportation_acceptance_suite_note_sync_check.py",
-    "scripts/frontier_teleportation_acceptance_suite.py",
-    "logs/runner-cache/frontier_teleportation_acceptance_suite_note_sync_check.txt"
+    "scripts/frontier_teleportation_acceptance_suite.py"
   ],
   "forbidden_context": [
     "this dispatcher manifest as evidence",

--- a/docs/audit/data/universal_gr_picurv_parent_reaudit_queue_2026-06-18.json
+++ b/docs/audit/data/universal_gr_picurv_parent_reaudit_queue_2026-06-18.json
@@ -2,9 +2,7 @@
   "allowed_context_paths": [
     "docs/audit/README.md",
     "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
-    "docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md",
-    "docs/UNIVERSAL_GR_POLARIZATION_FRAME_BUNDLE_BLOCKER_NOTE.md",
-    "docs/UNIVERSAL_GR_PICURV_ROUTE_EXHAUSTION_NO_GO_NOTE_2026-06-18.md"
+    "docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md"
   ],
   "forbidden_context": [
     "this dispatcher manifest as evidence",
@@ -21,7 +19,7 @@
       "order": 1,
       "targets": [
         {
-          "audit_question": "Fresh-context review target: does UNIVERSAL_GR_PICURV_ROUTE_EXHAUSTION_NO_GO_NOTE_2026-06-18.md supply the route-exhaustion gate requested for UNIVERSAL_GR_POLARIZATION_FRAME_BUNDLE_BLOCKER_NOTE.md without overclaiming absolute GR impossibility or demoting positive A1/Casimir/Regge/spin-2 routes?",
+          "audit_question": "Fresh-context review target: does UNIVERSAL_GR_POLARIZATION_FRAME_BUNDLE_BLOCKER_NOTE.md itself, using only its ledger-owned source/dependency/runner packet, justify its bounded scope without overclaiming absolute GR impossibility or demoting positive A1/Casimir/Regge/spin-2 routes?",
           "claim_id": "universal_gr_polarization_frame_bundle_blocker_note",
           "current_audit_status": "unaudited",
           "current_claim_type": "bounded_theorem",

--- a/docs/audit/scripts/compute_audit_dispatch_queue.py
+++ b/docs/audit/scripts/compute_audit_dispatch_queue.py
@@ -68,6 +68,20 @@ DEFAULT_READY_STATUSES = {
     "meta",
 }
 
+# Dispatcher sidecars may select a target, but they may not widen the
+# restricted audit packet arbitrarily.  Keep this process-only allowlist beside
+# the producer so both queue generation and queue consumption use one policy.
+DISPATCH_ALLOWED_PROCESS_PATHS = frozenset({
+    "docs/audit/README.md",
+    "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
+    "docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md",
+    "docs/audit/ALGEBRAIC_DECORATION_POLICY.md",
+    "docs/audit/data/axiom_premise_nodes.json",
+    "docs/audit/data/derivation_obligations.json",
+    "docs/ai_methodology/skills/no-go-discipline/SKILL.md",
+    "docs/ai_methodology/skills/physics-loop/references/proof-search-governance.md",
+})
+
 # Resolution reasons recorded on entries in `resolved_targets`.
 RESOLUTION_REASON_FRESH_CONTEXT = "same_status_fresh_context_reaudit_after_manifest"
 RESOLUTION_REASON_BOUNDED_TERMINAL = "bounded_terminal_after_reaudit"
@@ -75,6 +89,63 @@ RESOLUTION_REASON_BOUNDED_TERMINAL = "bounded_terminal_after_reaudit"
 
 def load_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_allowed_context_paths(
+    allowed_context_paths,
+    *,
+    claim_id: str,
+    row: dict,
+    rows: dict[str, dict],
+) -> list[str]:
+    """Validate a dispatch manifest's restricted-context declaration.
+
+    The normal packet builder already owns the selected note, its one-hop
+    dependency notes, primary/helper runners, registered premise sources, and
+    standard audit methodology.  A sidecar may enumerate only those surfaces;
+    it cannot inject unrelated science or cached transcripts.  This function
+    is intentionally shared by the producer and consumer so a sidecar that
+    would stop the drainer instead fails during pipeline generation.
+    """
+    if not isinstance(allowed_context_paths, list) or not all(
+        isinstance(path, str) and path for path in allowed_context_paths
+    ):
+        raise ValueError(
+            f"dispatch target {claim_id} has malformed allowed_context_paths"
+        )
+
+    permitted_paths = set(DISPATCH_ALLOWED_PROCESS_PATHS)
+    permitted_paths.update(filter(None, (
+        row.get("note_path"),
+        row.get("runner_path"),
+    )))
+    permitted_paths.update(row.get("helper_runner_paths") or [])
+    for dep_id in row.get("deps") or []:
+        dep_path = (rows.get(dep_id) or {}).get("note_path")
+        if dep_path:
+            permitted_paths.add(dep_path)
+
+    unexpected_paths = set(allowed_context_paths) - permitted_paths
+    if unexpected_paths:
+        try:
+            premise_registry = load_json(DATA_DIR / "axiom_premise_nodes.json")
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(
+                "cannot validate dispatch allowed_context_paths"
+            ) from exc
+        permitted_paths.update(
+            str(node.get("current_path"))
+            for node in (premise_registry.get("nodes") or {}).values()
+            if node.get("current_path")
+        )
+        unexpected_paths = set(allowed_context_paths) - permitted_paths
+
+    if unexpected_paths:
+        raise ValueError(
+            f"dispatch target {claim_id} requests nonstandard context paths: "
+            + ", ".join(sorted(unexpected_paths))
+        )
+    return list(allowed_context_paths)
 
 
 def source_sidecars() -> list[Path]:
@@ -178,7 +249,17 @@ def normalize_promotion_manifest(
 
     Returns (live, resolved_or_invalid, retired, resolved_targets).
     """
-    allowed_context = list(manifest.get("allowed_context_paths") or [])
+    allowed_context = manifest.get("allowed_context_paths")
+    if allowed_context is None:
+        allowed_context = []
+    if not isinstance(allowed_context, list) or not all(
+        isinstance(context_path, str) and context_path
+        for context_path in allowed_context
+    ):
+        raise ValueError(
+            f"{path.relative_to(REPO_ROOT)} has malformed allowed_context_paths"
+        )
+    allowed_context = list(allowed_context)
     forbidden_context = list(manifest.get("forbidden_context") or [])
     manifest_date = manifest.get("generated_date")
     live: list[dict] = []
@@ -283,6 +364,17 @@ def normalize_promotion_manifest(
                 base["resolution_manifest_date"] = manifest_date
                 resolved_targets.append(base)
                 continue
+            try:
+                base["allowed_context_paths"] = validate_allowed_context_paths(
+                    allowed_context,
+                    claim_id=cid,
+                    row=row,
+                    rows=rows,
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    f"{path.relative_to(REPO_ROOT)}: {exc}"
+                ) from exc
             base["state"] = "live"
             dep_blockers = row_dep_blockers(row, rows)
             base["ready"] = group_ready and not dep_blockers

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -411,6 +411,10 @@ def _import(module_name: str):
 def _import_codex_audit_runner():
     """Import the repo-root codex audit runner without changing sys.path."""
     sys.modules.pop("ledger_io", None)
+    # The runner imports the shared dispatch validator at module load.  Force
+    # that dependency fresh too so producer tests that redirect its DATA_DIR
+    # to a temporary fixture cannot leak the deleted fixture into runner tests.
+    sys.modules.pop("compute_audit_dispatch_queue", None)
     module_name = "codex_audit_runner_under_test"
     if module_name in sys.modules:
         del sys.modules[module_name]
@@ -11883,6 +11887,61 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
                     }
                 })
 
+    def test_dispatch_accepts_canonical_methodology_context(self):
+        m = _import_codex_audit_runner()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "dispatch.json"
+            allowed = [
+                "docs/ai_methodology/skills/no-go-discipline/SKILL.md",
+                (
+                    "docs/ai_methodology/skills/physics-loop/references/"
+                    "proof-search-governance.md"
+                ),
+            ]
+            path.write_text(json.dumps({
+                "schema": "audit_dispatch_queue.v1",
+                "policy": "target_selection_only_not_audit_evidence",
+                "live": [{
+                    "claim_id": "ready",
+                    "ready": True,
+                    "allowed_context_paths": allowed,
+                }]
+            }), encoding="utf-8")
+            m.DISPATCH_QUEUE_PATH = path
+            rows = m.load_dispatch_targets({
+                "ready": {
+                    "claim_id": "ready",
+                    "note_path": "docs/READY.md",
+                    "deps": [],
+                }
+            })
+            self.assertEqual(rows[0]["allowed_context_paths"], allowed)
+
+    def test_dispatch_rejects_falsey_nonlist_allowed_context(self):
+        m = _import_codex_audit_runner()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "dispatch.json"
+            path.write_text(json.dumps({
+                "schema": "audit_dispatch_queue.v1",
+                "policy": "target_selection_only_not_audit_evidence",
+                "live": [{
+                    "claim_id": "ready",
+                    "ready": True,
+                    "allowed_context_paths": "",
+                }]
+            }), encoding="utf-8")
+            m.DISPATCH_QUEUE_PATH = path
+            with self.assertRaisesRegex(
+                ValueError, "malformed allowed_context_paths"
+            ):
+                m.load_dispatch_targets({
+                    "ready": {
+                        "claim_id": "ready",
+                        "note_path": "docs/READY.md",
+                        "deps": [],
+                    }
+                })
+
     def test_canonical_dispatch_rejects_forged_live_entry(self):
         m = _import_codex_audit_runner()
         with tempfile.TemporaryDirectory() as tmp:
@@ -14225,6 +14284,85 @@ class ComputeAuditDispatchQueueTest(unittest.TestCase):
         return json.loads(
             (self.fx.data_dir / "audit_dispatch_queue.json").read_text(encoding="utf-8")
         )
+
+    def test_live_sidecar_context_is_validated_during_generation(self):
+        m = _import("compute_audit_dispatch_queue")
+        self._patch_dispatch_module(m)
+        rows = {
+            "row": self._row(
+                "row",
+                audit_status="unaudited",
+                claim_type="positive_theorem",
+                effective_status="unaudited",
+            ),
+        }
+        rows["row"]["note_path"] = "docs/ROW.md"
+        self.fx.write_ledger({"schema_version": 1, "rows": rows})
+        (self.fx.data_dir / "axiom_premise_nodes.json").write_text(
+            json.dumps({"schema_version": 1, "nodes": {}}) + "\n",
+            encoding="utf-8",
+        )
+        manifest = self._basic_manifest(
+            generated_date="2026-07-29",
+            group_id="invalid_context",
+            targets=[{
+                "claim_id": "row",
+                "note_path": "docs/ROW.md",
+                "audit_question": "Audit row.",
+                "current_audit_status": "unaudited",
+                "current_claim_type": "positive_theorem",
+                "current_effective_status": "unaudited",
+            }],
+        )
+        manifest["allowed_context_paths"] = ["docs/UNRELATED_SCIENCE.md"]
+        self._write_sidecar("promotion_reaudit_queue_2026-07-29.json", manifest)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            (
+                "promotion_reaudit_queue_2026-07-29.json: dispatch target row "
+                "requests nonstandard context paths: "
+                "docs/UNRELATED_SCIENCE.md"
+            ),
+        ):
+            m.main()
+
+    def test_live_sidecar_accepts_shared_methodology_context(self):
+        m = _import("compute_audit_dispatch_queue")
+        self._patch_dispatch_module(m)
+        rows = {
+            "row": self._row(
+                "row",
+                audit_status="unaudited",
+                claim_type="positive_theorem",
+                effective_status="unaudited",
+            ),
+        }
+        rows["row"]["note_path"] = "docs/ROW.md"
+        self.fx.write_ledger({"schema_version": 1, "rows": rows})
+        manifest = self._basic_manifest(
+            generated_date="2026-07-29",
+            group_id="methodology_context",
+            targets=[{
+                "claim_id": "row",
+                "note_path": "docs/ROW.md",
+                "audit_question": "Audit row.",
+                "current_audit_status": "unaudited",
+                "current_claim_type": "positive_theorem",
+                "current_effective_status": "unaudited",
+            }],
+        )
+        manifest["allowed_context_paths"] = [
+            "docs/ai_methodology/skills/no-go-discipline/SKILL.md",
+            (
+                "docs/ai_methodology/skills/physics-loop/references/"
+                "proof-search-governance.md"
+            ),
+        ]
+        self._write_sidecar("promotion_reaudit_queue_2026-07-29.json", manifest)
+
+        m.main()
+        self.assertEqual(self._read_output()["live_count"], 1)
 
     def test_same_status_fresh_context_reaudit_resolves_to_resolved_targets(self):
         """A row whose audit_date is on/after the manifest's generated_date

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -77,15 +77,6 @@ APPLY_AUDIT_SCRIPT = AUDIT_DIR / "scripts" / "apply_audit.py"
 PIPELINE_SCRIPT = AUDIT_DIR / "scripts" / "run_pipeline.sh"
 ISOLATED_BASE = Path("/tmp/codex-audit-isolated")
 LOG_DIR = REPO_ROOT / "logs" / "codex-audit-runs"
-DISPATCH_ALLOWED_PROCESS_PATHS = {
-    "docs/audit/README.md",
-    "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
-    "docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md",
-    "docs/audit/ALGEBRAIC_DECORATION_POLICY.md",
-    "docs/audit/data/axiom_premise_nodes.json",
-    "docs/audit/data/derivation_obligations.json",
-}
-
 # These fields are NOT controlled by the LLM; we set them on the runner side.
 # The runner selects the best available full Codex model at xhigh and records
 # the exact model/family. The numeric floor is stable while newer frontier
@@ -999,41 +990,18 @@ def load_dispatch_targets(
         row["source_json_path"] = entry.get("source_json_path")
         row["source_schema"] = entry.get("source_schema")
         row["queue_reason"] = "targeted_dispatch"
-        allowed_context_paths = entry.get("allowed_context_paths") or []
-        if not isinstance(allowed_context_paths, list) or not all(
-            isinstance(path, str) and path for path in allowed_context_paths
-        ):
-            raise ValueError(f"dispatch target {cid} has malformed allowed_context_paths")
-        permitted_paths = set(DISPATCH_ALLOWED_PROCESS_PATHS)
-        permitted_paths.update(filter(None, (
-            ledger_row.get("note_path"),
-            ledger_row.get("runner_path"),
-        )))
-        permitted_paths.update(ledger_row.get("helper_runner_paths") or [])
-        for dep_id in ledger_row.get("deps") or []:
-            dep_path = (ledger_rows.get(dep_id) or {}).get("note_path")
-            if dep_path:
-                permitted_paths.add(dep_path)
-        try:
-            premise_registry = json.loads(
-                (AUDIT_DIR / "data" / "axiom_premise_nodes.json").read_text(
-                    encoding="utf-8"
-                )
+        row["allowed_context_paths"] = (
+            compute_audit_dispatch_queue.validate_allowed_context_paths(
+                (
+                    entry["allowed_context_paths"]
+                    if entry.get("allowed_context_paths") is not None
+                    else []
+                ),
+                claim_id=cid,
+                row=ledger_row,
+                rows=ledger_rows,
             )
-        except (OSError, json.JSONDecodeError) as exc:
-            raise ValueError("cannot validate dispatch allowed_context_paths") from exc
-        permitted_paths.update(
-            str(node.get("current_path"))
-            for node in (premise_registry.get("nodes") or {}).values()
-            if node.get("current_path")
         )
-        unexpected_paths = sorted(set(allowed_context_paths) - permitted_paths)
-        if unexpected_paths:
-            raise ValueError(
-                f"dispatch target {cid} requests nonstandard context paths: "
-                + ", ".join(unexpected_paths)
-            )
-        row["allowed_context_paths"] = list(allowed_context_paths)
         normalized.append(row)
         seen_ids.add(cid)
     return normalized


### PR DESCRIPTION
## Summary

- centralize `allowed_context_paths` validation in the dispatch queue producer and share it with the canonical consumer
- reject invalid live sidecars during pipeline generation instead of stopping the audit drainer
- remove cached, stale, or unregistered context declarations from the six affected live sidecars
- narrow the universal-GR dispatch question to its authenticated packet-owned target
- add producer/consumer regression coverage, including malformed values and test isolation

## Root cause

Consumer-side validation was added without an equivalent producer-side gate. Later sidecars could therefore generate an authenticated live queue that the drainer deterministically rejected. The failure stayed latent until an affected entry reached the front of the queue.

## Verification

- 454 audit-pipeline unit tests
- 150 audit-loop orchestrator tests
- full `docs/audit/scripts/run_pipeline.sh`
- `audit_lint.py --strict` (no errors)
- vocabulary lint and `git diff --check`
- three independent review-loop passes: PASS
- in-memory queue rebuild: all 11 live entries accepted (2 ready)

No audit verdicts, source-science claims, proofs, imports, or generated audit outputs are included.