### PR TITLE
fix: add bounded certificate for slow Poisson audit runner

### DIFF
--- a/docs/POISSON_SELF_CONSISTENT_WELL_DEPTH_FINITE_VOLUME_BOUNDED_THEOREM_NOTE_2026-07-27.md
+++ b/docs/POISSON_SELF_CONSISTENT_WELL_DEPTH_FINITE_VOLUME_BOUNDED_THEOREM_NOTE_2026-07-27.md
@@ -3,8 +3,10 @@
 **Date:** 2026-07-27
 **Status:** bounded support proposed for independent audit; not an audit verdict
 **Type:** bounded_theorem
-**Primary runner:** [`scripts/physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27.py`](../scripts/physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27.py)
-**Cached runner output:** [`logs/runner-cache/physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27.txt`](../logs/runner-cache/physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27.txt)
+**Primary runner:** [`scripts/physical_poisson_self_consistent_well_depth_certificate_2026_07_29.py`](../scripts/physical_poisson_self_consistent_well_depth_certificate_2026_07_29.py)
+**Underlying full runner:** [`scripts/physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27.py`](../scripts/physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27.py)
+**Completed full-run output:** [`logs/runner-cache/physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27.txt`](../logs/runner-cache/physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27.txt)
+**Cached certificate output:** [`logs/runner-cache/physical_poisson_self_consistent_well_depth_certificate_2026_07_29.txt`](../logs/runner-cache/physical_poisson_self_consistent_well_depth_certificate_2026_07_29.txt)
 
 Independent audit is required before the repository may assign retained grade.
 
@@ -209,9 +211,13 @@ in R14, and that test causes the narrowing recorded above.
 ## Verification
 
 ```bash
-python3 scripts/physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27.py
+python3 scripts/cached_runner_output.py scripts/physical_poisson_self_consistent_well_depth_certificate_2026_07_29.py
 ```
 
-The runner first verifies that the imported parent module matches its committed
-blob, then requires every scored fixed point and every thesis dependency to
-PASS.
+The certificate verifies that the completed `PASS=14 FAIL=0` full-run log was
+committed together with the byte-identical underlying runner, that the runner's
+repo-local helper module matches the reviewed blob and its function used through
+`F` has the same AST now as at that paired commit, and that a current
+deterministic `N=12` slice reproduces the logged result. It is a provenance and
+compute certificate, not a claim that the pathologically slow full sweep was
+rerun during every audit.

--- a/logs/runner-cache/physical_poisson_self_consistent_well_depth_certificate_2026_07_29.txt
+++ b/logs/runner-cache/physical_poisson_self_consistent_well_depth_certificate_2026_07_29.txt
@@ -1,0 +1,117 @@
+===== runner cache v1 =====
+runner: scripts/physical_poisson_self_consistent_well_depth_certificate_2026_07_29.py
+runner_sha256: 51ae291ab48b1d3f5f3c00fbc4d09624f8a411e3835c586cc3c6dafe07a2da24
+input_fingerprint_sha256: d72eff12ca2d735b545535301238fbcaed1b79a12752b600cbd7d03fd994e052
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.71
+status: ok
+----- stdout -----
+==============================================================================
+POISSON FINITE-VOLUME COMPLETED-LOG AND DETERMINISTIC-SLICE CERTIFICATE
+==============================================================================
+[PASS] A1 paired artifact: runner and completed log were last changed together at 870573b35c1c
+[PASS] A2 exact artifacts: runner blob 5ac4ed61155e, completed-log blob fa5b859ea436, helper blob 761ea4b41cbe
+[PASS] B1 imported surface: full runner imports only F.build_laplacian_sparse
+[PASS] B2 imported numerical identity: build_laplacian_sparse AST matches the paired completed-log commit
+[PASS] C1 completed full sweep: paired log records the full scored sweep with PASS=14 FAIL=0
+----- BEGIN BLOB-VERIFIED COMPLETED FULL-SWEEP OUTPUT -----
+==============================================================================
+FINITE-VOLUME SELF-CONSISTENT LOCALIZATION AND
+ABSOLUTE-WELL-DEPTH MODEL COMPARISONS
+==============================================================================
+
+P0  provenance
+  [PASS] P0: the imported parent module matches its committed blob, so every row below is measured against the tree as landed: frontier_self_consistent_field_equation.py 49c4c97c96a9
+
+R0  source-sign normalization
+  [PASS] R0: all four operators produce V <= 0 everywhere on the interior
+
+R3/R4  Poisson -- extent and well depth against the box
+      g= 20.0 N= 12  rms=  3.0595  depth=  0.4392  iters= 64
+      g= 20.0 N= 20  rms=  4.6727  depth=  0.3277  iters= 84
+      g= 20.0 N= 28  rms=  5.4886  depth=  0.3129  iters=110
+      g= 20.0 N= 36  rms=  5.6833  depth=  0.3267  iters=123
+      g= 20.0 N= 44  rms=  5.7047  depth=  0.3407  iters=125
+      g= 20.0 N= 52  rms=  5.7063  depth=  0.3508  iters=126
+      g= 50.0 N= 12  rms=  1.9051  depth=  2.2108  iters=164
+      g= 50.0 N= 16  rms=  1.9367  depth=  2.3560  iters=176
+      g= 50.0 N= 20  rms=  1.9377  depth=  2.4540  iters=177
+      g= 50.0 N= 24  rms=  1.9377  depth=  2.5180  iters=178
+      g= 50.0 N= 32  rms=  1.9376  depth=  2.5964  iters=179
+      g= 50.0 N= 40  rms=  1.9376  depth=  2.6425  iters=180
+      g= 50.0 N= 48  rms=  1.9376  depth=  2.6729  iters=180
+  [PASS] R3: the finite-size extent increments fall by more than two orders of magnitude and end below 1e-3 -- g=20: 3.0595 -> 5.7063, relative step 3.45e-01 -> 2.71e-04; g=50: 1.9051 -> 1.9376, relative step 1.63e-02 -> 7.60e-07; no infinite-volume limit is claimed
+  [PASS] R4: for g=50 the full finite-size depth sequence prefers a+c/M (a=2.7945, rss 5.21e-04) over a+b*M (rss 2.31e-02); g=20 is explicitly inconclusive because its full sequence prefers a+c/M (a=0.2957, rss 3.84e-03 vs 8.28e-03) but its last four sizes prefer the linear model (4.19e-06 vs 1.56e-05); no limit is inferred
+
+R5  biharmonic -- finite-volume extent and depth trends
+      N= 12  rms=  2.8397  depth=  0.7874  iters= 59
+      N= 16  rms=  2.9127  depth=  1.3393  iters= 65
+      N= 20  rms=  2.8062  depth=  1.9519  iters= 64
+      N= 24  rms=  2.7410  depth=  2.5637  iters= 63
+      N= 28  rms=  2.7003  depth=  3.1740  iters= 62
+      N= 32  rms=  2.6725  depth=  3.7835  iters= 62
+  [PASS] R5: the extent stays in the narrow range 2.6725-2.9127 over the tested boxes, while the absolute depth runs 0.7874 -> 3.7835 and fits a + b*M with b = 0.1507 per interior site (linear rss 1.61e-03 beats a+c/M rss 6.72e-01); this is a finite-range model comparison, not a proof of divergence
+
+R6/R7  a PRESCRIBED unit source of fixed extent -- kernel only
+      Dirichlet     poisson:   0.04598   0.05137   0.05355   0.05473
+      Dirichlet  biharmonic:   0.10792   0.22717   0.34791   0.46910
+      Dirichlet    screened:   0.03107   0.03126   0.03126   0.03126
+      Dirichlet       local:   0.04364   0.04364   0.04364   0.04364
+  [PASS] R6: with self-consistency removed entirely, the same split appears: biharmonic's peak |phi| runs 0.1079 -> 0.4691 and is fit by the linear family, while poisson (0.0460 -> 0.0547), screened (0.0311 -> 0.0313) and local (0.0436 -> 0.0436) are fit by a+c/M over these sizes -- the linear trend does not require the nonlinear fixed point
+      torus         poisson:   0.04476   0.04935   0.05167   0.05401   0.05518   0.05635
+      torus      biharmonic:   0.11228   0.19456   0.27812   0.44654   0.61560   0.95439
+      torus        screened:   0.03030   0.03097   0.03114   0.03122   0.03124   0.03125
+  [PASS] R7: on a boundary-free torus with the zero mode removed the same holds -- biharmonic 0.1123 -> 0.9544, linear in N (b = 0.0105); poisson 0.0448 -> 0.0564, preferring a+c/N with fitted a=0.0587; the observed biharmonic growth is therefore not specific to the Dirichlet wall
+
+R8/R9  the other two members of the parent note's family
+      local    g=100 N= 12  rms=  0.0245  depth=  99.9399
+      local    g=100 N= 16  rms=  0.0245  depth=  99.9399
+      local    g=100 N= 20  rms=  0.0245  depth=  99.9399
+      local    g=100 N= 24  rms=  5.9968  depth=   0.1904
+      local    g=100 N= 28  rms=  7.5743  depth=   0.0778
+  [PASS] R8: the identical V=0-start protocol is discontinuous across the finite-size sweep: the converged extent jumps 0.0245 -> 7.5743; this sampled sweep does not exhibit a smooth local-operator continuation, without proving fixed-N bistability
+      screened g=100 N= 12  rms=  0.1633  depth=  20.6868
+      screened g=100 N= 16  rms=  0.1633  depth=  20.7044
+      screened g=100 N= 20  rms=  0.1633  depth=  20.7063
+      screened g=100 N= 24  rms=  0.1633  depth=  20.7065
+      screened g=100 N= 28  rms=  0.1633  depth=  20.7065
+  [PASS] R9: over the tested boxes screened Poisson has extent 0.1633 (spread 1.1e-05), depth 20.6868 -> 20.7065, and the depth sequence prefers a+c/M with fitted a=20.7219; the finite well-depth diagnostic does not single out unscreened Poisson
+
+R10/R11/R12  matched point-source kernel, same operator, same boundary condition, window [4,10]
+      poisson    N= 25 M= 23  rms= 1.8575  site offset=0.0000  median ratio=  1.00013  scatter=1.03e-03  residual=1.94e-09
+      poisson    N= 33 M= 31  rms= 1.8575  site offset=0.0000  median ratio=  1.00008  scatter=9.03e-04  residual=1.93e-09
+      poisson    N= 41 M= 39  rms= 1.8575  site offset=0.0000  median ratio=  1.00007  scatter=8.42e-04  residual=1.99e-09
+      poisson    N= 49 M= 47  rms= 1.8575  site offset=0.0000  median ratio=  1.00006  scatter=8.07e-04  residual=1.91e-09
+  [PASS] R10: over the tested exterior window, the self-consistent Poisson field's median ratio to the matched point-source field of the same operator lies in 1.00006-1.00013 across N=25..49 (maximum deviation 1.33e-04); this finite localization check uses the already chosen field solver and is not the parent transfer propagator's susceptibility
+      parity control -- the same comparison with the centroid between sites instead of on one:
+      poisson    N= 24 M= 22 (even)  site offset=0.8660  median=  1.01389  scatter=1.29e-01  residual=1.96e-09
+      poisson    N= 25 M= 23 (odd )  site offset=0.0000  median=  1.00013  scatter=1.03e-03  residual=1.94e-09
+      poisson    N= 32 M= 30 (even)  site offset=0.8660  median=  1.01228  scatter=1.09e-01  residual=1.93e-09
+      poisson    N= 33 M= 31 (odd )  site offset=0.0000  median=  1.00008  scatter=9.03e-04  residual=1.93e-09
+  [PASS] R11: the even-width residual is strongly reduced when the comparison point source is aligned with the centroid: moving it from half a spacing off in each axis (offset 0.8660) to exactly on a site (offset 0.0000) shrinks the mean absolute deviation by a factor 203 at N=24 vs 25 and 212 at N=32 vs 33, and the median ratio moves 1.01389 -> 1.00013 and 1.01228 -> 1.00008
+  [PASS] R12: the same matched comparison for the other two operators that have an extended field: biharmonic 0.95287-0.97743; screened 1.00111-1.00111 (scored only as a broad 0.90-1.05 localization check on converged fixed points; it is not the operator discriminator)
+
+R14  reference the potential to a fixed radius instead of to the well bottom
+          poisson  C_N:   0.44796   0.44802   0.44803   depth:   2.5180   2.5964   2.6425
+       biharmonic  C_N:   1.15613   1.34469   1.45532   depth:   2.5637   3.7835   5.0018
+         screened  C_N:   0.18568   0.18544   0.18543   depth:  20.7065  20.7065  20.7065
+  [PASS] R14: the observable choice matters: across the same boxes the biharmonic shell contrast C_N over the fixed window runs 1.15613 -> 1.45532 and is fit by the bounded family, while its well depth runs 2.5637 -> 5.0018 and prefers the linear model; the finite-volume separation is about absolute well depth under the Dirichlet-zero reference, not the shell contrast (poisson C_N 0.44796 -> 0.44803, screened 0.18568 -> 0.18543)
+
+THESIS
+  [PASS] T: On the supplied four-operator family and Dirichlet lattice, with the source sign normalized so no operator is handed a repulsive well, the tested finite-volume sequences produce converged self-consistent states. At the scored couplings, Poisson g=50 and screened Poisson prefer a+c/M for absolute well depth, biharmonic prefers a+b*M, and the local V=0-start sweep is discontinuous. These are finite-range model preferences under an explicit potential reference, not proofs of limits, physical binding energies, operator uniqueness, or the parent susceptibility bridge.
+
+==============================================================================
+SUMMARY: SELF-CONSISTENT WELL DEPTH PASS=14 FAIL=0
+elapsed 419.2s
+==============================================================================
+----- END BLOB-VERIFIED COMPLETED FULL-SWEEP OUTPUT -----
+[PASS] C2 deterministic current slice: current N=12 result rms=3.0595, depth=0.4392, iters=64 versus paired completed log
+full_runner_sha256=1f61250c40aed3217d8213bbf705c931b4e0406ac724bffe5a6b7e898ad8209a
+helper_sha256=9e49b83bb9ce50ecdff58092da859dd2ee5b5d2558bf428d0c840b38be4af4f6
+completed_log_sha256=f31841fbde68b8bc2ceb552d747723c3184faca1a5824fe3ffca4fb0e16b2bff
+PASS (C): source-identity-pinned completed sweep plus current deterministic slice
+SUMMARY: CERTIFICATE PASS=6 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_poisson_self_consistent_well_depth_certificate_2026_07_29.py
+++ b/scripts/physical_poisson_self_consistent_well_depth_certificate_2026_07_29.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Fast source-identity and deterministic-slice certificate for the Poisson row.
+
+The complete numerical runner contains a large ``N=52`` sparse eigenvalue
+solve that can be pathologically slow on some SciPy/ARPACK builds.  A completed
+14/14 output was committed together with the current full runner.  This
+certificate proves that the numerical code used by that output is still the
+code in the tree, pins the repo-local helper module and checks the helper
+function used through ``F`` by AST identity, then reruns the small ``N=12``
+slice against the completed output.
+
+This is a compute/provenance certificate.  It does not mint or predict an audit
+verdict and it does not claim that the full sweep was rerun in this process.
+"""
+from __future__ import annotations
+
+import ast
+import hashlib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27 as full
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FULL_RUNNER = "scripts/physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27.py"
+HELPER = "scripts/frontier_self_consistent_field_equation.py"
+COMPLETED_LOG = "logs/runner-cache/physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27.txt"
+PAIRED_COMMIT = "870573b35c1c5fa3c0a5a822984aa951e3c6477e"
+FULL_RUNNER_BLOB = "5ac4ed61155e093c554cb464f096d59d0954c86c"
+COMPLETED_LOG_BLOB = "fa5b859ea4366fc1c72a613ef33b38d337ae520e"
+HELPER_BLOB = "761ea4b41cbe1eee28dc9561eb947e87bfb4bad8"
+
+AUDIT_TIMEOUT_SEC = 120
+AUDIT_INPUT_PATHS = (
+    "scripts/physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27.py",
+    "scripts/frontier_self_consistent_field_equation.py",
+    "logs/runner-cache/physical_poisson_self_consistent_well_depth_finite_volume_2026_07_27.txt",
+)
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(REPO_ROOT), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def sha256(path: str) -> str:
+    return hashlib.sha256((REPO_ROOT / path).read_bytes()).hexdigest()
+
+
+def function_ast(source: str, name: str) -> str:
+    matches = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == name
+    ]
+    if len(matches) != 1:
+        raise ValueError(f"expected one {name} definition, found {len(matches)}")
+    return ast.dump(matches[0], include_attributes=False)
+
+
+def imported_full_symbols(source: str) -> set[str]:
+    return {
+        node.attr
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "F"
+    }
+
+
+def checked(label: str, condition: bool, detail: str) -> bool:
+    print(f"[{'PASS' if condition else 'FAIL'}] {label}: {detail}")
+    return condition
+
+
+def summarize(checks: list[bool]) -> int:
+    passed = sum(checks)
+    failed = len(checks) - passed
+    status = "PASS" if failed == 0 else "FAIL"
+    print(
+        f"{status} (C): source-identity-pinned completed sweep plus "
+        "current deterministic slice"
+    )
+    print(f"SUMMARY: CERTIFICATE PASS={passed} FAIL={failed}")
+    return 0 if failed == 0 else 1
+
+
+def main() -> int:
+    print("=" * 78)
+    print("POISSON FINITE-VOLUME COMPLETED-LOG AND DETERMINISTIC-SLICE CERTIFICATE")
+    print("=" * 78)
+
+    checks: list[bool] = []
+
+    def record(label: str, condition: bool, detail: str) -> None:
+        checks.append(checked(label, condition, detail))
+
+    runner_commit = git("log", "-1", "--format=%H", "--", FULL_RUNNER)
+    log_commit = git("log", "-1", "--format=%H", "--", COMPLETED_LOG)
+    runner_blob = git("hash-object", str(REPO_ROOT / FULL_RUNNER))
+    log_blob = git("hash-object", str(REPO_ROOT / COMPLETED_LOG))
+    helper_blob = git("hash-object", str(REPO_ROOT / HELPER))
+    record(
+        "A1 paired artifact",
+        runner_commit == log_commit == PAIRED_COMMIT,
+        f"runner and completed log were last changed together at {runner_commit[:12]}",
+    )
+    artifacts_exact = (
+        runner_blob == FULL_RUNNER_BLOB
+        and log_blob == COMPLETED_LOG_BLOB
+        and helper_blob == HELPER_BLOB
+    )
+    record(
+        "A2 exact artifacts",
+        artifacts_exact,
+        f"runner blob {runner_blob[:12]}, completed-log blob {log_blob[:12]}, "
+        f"helper blob {helper_blob[:12]}",
+    )
+
+    runner_source = (REPO_ROOT / FULL_RUNNER).read_text(encoding="utf-8")
+    helper_source = (REPO_ROOT / HELPER).read_text(encoding="utf-8")
+    paired_helper_source = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "show", f"{PAIRED_COMMIT}:{HELPER}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    used_symbols = imported_full_symbols(runner_source)
+    helper_same = function_ast(helper_source, "build_laplacian_sparse") == function_ast(
+        paired_helper_source, "build_laplacian_sparse"
+    )
+    record(
+        "B1 imported surface",
+        used_symbols == {"build_laplacian_sparse"},
+        f"full runner imports only F.{', F.'.join(sorted(used_symbols))}",
+    )
+    record(
+        "B2 imported numerical identity",
+        helper_same,
+        "build_laplacian_sparse AST matches the paired completed-log commit",
+    )
+
+    completed = (REPO_ROOT / COMPLETED_LOG).read_text(encoding="utf-8")
+    summary_ok = "SUMMARY: SELF-CONSISTENT WELL DEPTH PASS=14 FAIL=0" in completed
+    record(
+        "C1 completed full sweep",
+        summary_ok,
+        "paired log records the full scored sweep with PASS=14 FAIL=0",
+    )
+    if artifacts_exact and summary_ok:
+        print("----- BEGIN BLOB-VERIFIED COMPLETED FULL-SWEEP OUTPUT -----")
+        print(completed.rstrip())
+        print("----- END BLOB-VERIFIED COMPLETED FULL-SWEEP OUTPUT -----")
+    else:
+        print("completed full-sweep output omitted because its identity check failed")
+
+    match = re.search(
+        r"g=\s*20\.0\s+N=\s*12\s+rms=\s*([0-9.]+)\s+"
+        r"depth=\s*([0-9.]+)\s+iters=\s*(\d+)",
+        completed,
+    )
+    if match is None:
+        record("C2 historical slice", False, "N=12 row missing from completed log")
+    else:
+        expected_rms = float(match.group(1))
+        expected_depth = float(match.group(2))
+        expected_iters = int(match.group(3))
+        slice_result = full.self_consistent(12, "poisson", 20.0)
+        slice_ok = (
+            slice_result["conv"]
+            and abs(slice_result["rms"] - expected_rms) <= 1e-4
+            and abs(slice_result["depth"] - expected_depth) <= 1e-4
+            and slice_result["it"] == expected_iters
+        )
+        record(
+            "C2 deterministic current slice",
+            slice_ok,
+            "current N=12 result "
+            f"rms={slice_result['rms']:.4f}, depth={slice_result['depth']:.4f}, "
+            f"iters={slice_result['it']} versus paired completed log",
+        )
+
+    print(f"full_runner_sha256={sha256(FULL_RUNNER)}")
+    print(f"helper_sha256={sha256(HELPER)}")
+    print(f"completed_log_sha256={sha256(COMPLETED_LOG)}")
+    return summarize(checks)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- replace the pathologically slow full Poisson audit runner as the primary audit artifact with a bounded provenance-plus-slice certificate
- pin the byte-identical full runner, the complete reviewed helper module, and the paired completed 14/14 log
- expose the blob-verified full-sweep output to the restricted audit packet and rerun the current N=12 slice
- cache the certificate with input fingerprints; generated audit/ledger outputs are deliberately excluded from the PR

## Campaign repair target

> Produce a SHA-pinned runner cache, sliced deterministic certificate, or independent derivation; run the full pipeline and strict lint; then start a new campaign.

## Review-loop fixes

- fail closed on any full-helper identity drift, including post-definition rebinding
- report exact PASS/FAIL counts and never print PASS (C) on failure
- transport all detailed historical sweep rows only after artifact identity and 14/0 summary checks pass
- squash the PR to one source-only commit so no intermediate generated ledger churn can enter main history

## Verification

- certificate: 6 checks passed; cached status ok
- negative injection: two failures return nonzero with FAIL (C), exact 4/2 accounting, and no historical evidence emission
- independent N=4 Dirichlet-cube enumeration: exact matrix, 24 directed edges, analytic spectrum
- independent N=12 Kronecker/Lobpcg recomputation: rms 3.0595490498, depth 0.4391614081, 64 iterations
- rendered restricted packet: includes N=20, R14, full 14/0 summary, and certificate 6/0 summary
- full audit pipeline: all 18 stages passed
- strict audit lint: no errors after generated-output stripping
- vocabulary, portable-link, no-verdict, no-go-shape, overlap, and diff checks: passed

The underlying full runner and completed log remain in the restricted helper packet. This PR repairs compute transport and requeue visibility; it does not apply or predict a scientific audit verdict.