### PR TITLE
audit: keep drainer live across oversized packets

### DIFF
--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -902,7 +902,7 @@ def launch_worker(
             prompt,
             evidence_manifest,
         )
-    except ValueError as exc:
+    except audit_runner.PromptTransportCapacityError as exc:
         raise PromptTransportBlockedError(str(exc)) from exc
     if len(prompt) > audit_runner.CODEX_INPUT_CHAR_LIMIT:
         raise PromptTransportBlockedError(
@@ -3833,11 +3833,15 @@ def hard_blocking_report_items(report: list[dict]) -> list[dict]:
         | SCHEMA_RECOVERY_RESULTS
         | CAMPAIGN_EXCLUSION_RESULTS
     )
-    recovered = {
+    schema_recovered = {
         item.get("cid")
         for item in report
-        if item.get("result")
-        in SCHEMA_RECOVERY_RESULTS | {PROMPT_TRANSPORT_QUARANTINE_RESULT}
+        if item.get("result") in SCHEMA_RECOVERY_RESULTS
+    }
+    transport_quarantined = {
+        item.get("cid")
+        for item in report
+        if item.get("result") == PROMPT_TRANSPORT_QUARANTINE_RESULT
     }
     transaction_quarantined = {
         item.get("cid")
@@ -3849,9 +3853,8 @@ def hard_blocking_report_items(report: list[dict]) -> list[dict]:
         for item in report
         if item.get("result") == TRANSIENT_SERVICE_FAILURE_RESULT
     }
-    quarantine_companions = SCHEMA_INVALID_RESULTS | {
+    schema_quarantine_companions = SCHEMA_INVALID_RESULTS | {
         "critical_peer_pending",
-        "prompt_transport_blocked",
     }
     transient_companions = {
         "critical_peer_delivery_missing",
@@ -3862,8 +3865,12 @@ def hard_blocking_report_items(report: list[dict]) -> list[dict]:
         for item in report
         if item.get("result") not in accepted
         and not (
-            item.get("cid") in recovered
-            and item.get("result") in quarantine_companions
+            item.get("cid") in schema_recovered
+            and item.get("result") in schema_quarantine_companions
+        )
+        and not (
+            item.get("cid") in transport_quarantined
+            and item.get("result") == "prompt_transport_blocked"
         )
         and not (
             item.get("cid") in transaction_quarantined

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -76,6 +76,7 @@ SCHEMA_DEFERRED_RESULT = "schema_invalid_peer_deferred"
 SCHEMA_SUPERSEDED_RESULT = "schema_invalid_attempt_superseded"
 BLOCKED_ROW_QUARANTINE_RESULT = "blocked_row_reentry_quarantined"
 COMPUTE_QUARANTINE_RESULT = "compute_required_quarantined"
+PROMPT_TRANSPORT_QUARANTINE_RESULT = "prompt_transport_quarantined"
 CLAIM_TRANSACTION_QUARANTINE_RESULT = "claim_transaction_quarantined"
 SCHEMA_RECOVERY_RESULTS = {
     SCHEMA_QUARANTINE_RESULT,
@@ -85,6 +86,7 @@ SCHEMA_RECOVERY_RESULTS = {
 CAMPAIGN_EXCLUSION_RESULTS = {
     BLOCKED_ROW_QUARANTINE_RESULT,
     COMPUTE_QUARANTINE_RESULT,
+    PROMPT_TRANSPORT_QUARANTINE_RESULT,
     CLAIM_TRANSACTION_QUARANTINE_RESULT,
 }
 CAMPAIGN_EXCLUSION_REASONS = {
@@ -201,6 +203,10 @@ NON_RETRYABLE_SERVICE_MARKERS = (
 
 class CleanupIntegrityError(RuntimeError):
     """An owned read-only seat group could not be proven absent."""
+
+
+class PromptTransportBlockedError(ValueError):
+    """A complete authenticated worker packet cannot fit Codex transport."""
 
 
 def safe_exception_type_name(exc: BaseException) -> str:
@@ -814,6 +820,45 @@ def prompt_has_clipped_evidence(manifest: dict[str, dict]) -> list[str]:
     )
 
 
+def worker_prompt_requires_forensic_bound(
+    row: dict,
+    rows: dict[str, dict],
+) -> bool:
+    """Return whether an N8 transport bound must forbid a clean verdict."""
+    cid = str(row.get("claim_id") or "")
+    ledger_row = rows.get(cid, {})
+    note_path = row.get("note_path") or ledger_row.get("note_path") or ""
+    note_body = (
+        (audit_runner.read_note_body(note_path) or "") if note_path else ""
+    )
+    claim_type = row.get("claim_type") or ledger_row.get("claim_type") or ""
+    dispatch_target = bool(row.get("dispatch_target"))
+    return bool(
+        audit_runner.no_go_discipline_gate.source_requires_no_go_discipline(
+            note_path,
+            note_body,
+            "" if dispatch_target else claim_type,
+        )
+        or (not dispatch_target and claim_type == "no_go")
+        or audit_runner.no_go_discipline_gate.forensic_mode()
+    )
+
+
+def fit_worker_prompt_to_transport_limit(
+    row: dict,
+    rows: dict[str, dict],
+    prompt: str,
+    evidence_manifest: dict[str, dict],
+) -> tuple[str, dict[str, int] | None]:
+    """Apply the canonical deterministic N8 bound before batch transport."""
+    return audit_runner.fit_prompt_to_transport_limit(
+        prompt,
+        evidence_manifest,
+        str(row.get("claim_id") or ""),
+        forensic_bound=worker_prompt_requires_forensic_bound(row, rows),
+    )
+
+
 def launch_worker(
     row: dict,
     rows: dict[str, dict],
@@ -850,8 +895,17 @@ def launch_worker(
             "leave no_go_discipline=null unless you can supply a structurally "
             "valid optional packet from the rendered evidence.\n"
         )
+    try:
+        prompt, transport_bound = fit_worker_prompt_to_transport_limit(
+            row,
+            rows,
+            prompt,
+            evidence_manifest,
+        )
+    except ValueError as exc:
+        raise PromptTransportBlockedError(str(exc)) from exc
     if len(prompt) > audit_runner.CODEX_INPUT_CHAR_LIMIT:
-        raise ValueError(
+        raise PromptTransportBlockedError(
             f"{cid}: development packet is {len(prompt)} characters; "
             "packet must be narrowed without converting transport size into a verdict"
         )
@@ -915,7 +969,7 @@ def launch_worker(
         ),
         "selection_source": row.get("_selection_source"),
         "source_fingerprint": row.get("_source_fingerprint"),
-        "transport_bound": None,
+        "transport_bound": transport_bound,
         "auditor": f"codex-audit-batch-{ident}",
         "independence": seat_independence(row, pass_no),
         "workdir": workdir,
@@ -2498,6 +2552,13 @@ def _campaign_failure_schema_error(
                 f"{reason!r}"
             )
         expected = {"cid", "pass", "result", "detail"}
+    elif reason == PROMPT_TRANSPORT_QUARANTINE_RESULT:
+        if result != "prompt_transport_blocked":
+            return (
+                "campaign exclusion failure result is incompatible with "
+                f"{reason!r}"
+            )
+        expected = {"cid", "pass", "result", "detail"}
     elif reason == CLAIM_TRANSACTION_QUARANTINE_RESULT:
         if result == "apply_or_gate_failed":
             expected = {
@@ -2961,6 +3022,20 @@ def persist_compute_required_skips(
         reason=COMPUTE_QUARANTINE_RESULT,
         report=report,
         companion_results={"compute_required"},
+    )
+
+
+def persist_prompt_transport_quarantines(
+    path: Path | None,
+    claim_ids: set[str],
+    report: list[dict],
+) -> None:
+    persist_campaign_exclusions(
+        path,
+        claim_ids,
+        reason=PROMPT_TRANSPORT_QUARANTINE_RESULT,
+        report=report,
+        companion_results={"prompt_transport_blocked"},
     )
 
 
@@ -3542,6 +3617,7 @@ def main() -> int:
             break
         jobs: list[dict] = []
         launch_blocked = False
+        transport_quarantines: set[str] = set()
         try:
             for row in batch:
                 for pass_no in passes_for_row(row):
@@ -3552,8 +3628,8 @@ def main() -> int:
                                 args.runner_timeout_sec, round_no,
                             )
                         )
-                    except ValueError as exc:
-                        launch_blocked = True
+                    except PromptTransportBlockedError as exc:
+                        transport_quarantines.add(row["claim_id"])
                         report.append({
                             "cid": row["claim_id"],
                             "pass": pass_no,
@@ -3571,6 +3647,21 @@ def main() -> int:
         except BaseException:
             terminate_workers(jobs)
             raise
+        session_skipped.update(transport_quarantines)
+        for cid in sorted(transport_quarantines):
+            report.append({
+                "cid": cid,
+                "result": PROMPT_TRANSPORT_QUARANTINE_RESULT,
+                "detail": (
+                    "complete authenticated packet cannot fit the bounded "
+                    "Codex transport; excluded claim-locally for this campaign"
+                ),
+            })
+        persist_prompt_transport_quarantines(
+            args.campaign_quarantine_file,
+            transport_quarantines,
+            report,
+        )
         if not jobs:
             break
         print(
@@ -3745,7 +3836,8 @@ def hard_blocking_report_items(report: list[dict]) -> list[dict]:
     recovered = {
         item.get("cid")
         for item in report
-        if item.get("result") in SCHEMA_RECOVERY_RESULTS
+        if item.get("result")
+        in SCHEMA_RECOVERY_RESULTS | {PROMPT_TRANSPORT_QUARANTINE_RESULT}
     }
     transaction_quarantined = {
         item.get("cid")
@@ -3757,7 +3849,10 @@ def hard_blocking_report_items(report: list[dict]) -> list[dict]:
         for item in report
         if item.get("result") == TRANSIENT_SERVICE_FAILURE_RESULT
     }
-    quarantine_companions = SCHEMA_INVALID_RESULTS | {"critical_peer_pending"}
+    quarantine_companions = SCHEMA_INVALID_RESULTS | {
+        "critical_peer_pending",
+        "prompt_transport_blocked",
+    }
     transient_companions = {
         "critical_peer_delivery_missing",
         "critical_peer_pending",

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -3870,7 +3870,8 @@ def hard_blocking_report_items(report: list[dict]) -> list[dict]:
         )
         and not (
             item.get("cid") in transport_quarantined
-            and item.get("result") == "prompt_transport_blocked"
+            and item.get("result")
+            in {"prompt_transport_blocked", "critical_peer_pending"}
         )
         and not (
             item.get("cid") in transaction_quarantined

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -211,6 +211,12 @@ def compute_quarantine_count() -> int:
     return campaign_exclusion_count(batch.COMPUTE_QUARANTINE_RESULT)
 
 
+def prompt_transport_quarantine_count() -> int:
+    return campaign_exclusion_count(
+        batch.PROMPT_TRANSPORT_QUARANTINE_RESULT
+    )
+
+
 def claim_transaction_quarantine_count() -> int:
     return campaign_exclusion_count(batch.CLAIM_TRANSACTION_QUARANTINE_RESULT)
 
@@ -257,6 +263,9 @@ def summary_line(final: bool = False) -> str:
         exclusions = campaign_exclusion_counts()
         schema_count: int | str = exclusions[batch.SCHEMA_QUARANTINE_RESULT]
         compute_count: int | str = exclusions[batch.COMPUTE_QUARANTINE_RESULT]
+        transport_count: int | str = exclusions[
+            batch.PROMPT_TRANSPORT_QUARANTINE_RESULT
+        ]
         transaction_count: int | str = exclusions[
             batch.CLAIM_TRANSACTION_QUARANTINE_RESULT
         ]
@@ -266,7 +275,8 @@ def summary_line(final: bool = False) -> str:
     except (OSError, ValueError):
         # The main control path treats malformed campaign state as a hard stop.
         # Heartbeat/final summaries remain printable without hiding that state.
-        schema_count = compute_count = transaction_count = blocked_count = "invalid"
+        schema_count = compute_count = transport_count = "invalid"
+        transaction_count = blocked_count = "invalid"
     return (
         f"== audit-loop {'final ' if final else ''}summary "
         f"elapsed={elapsed // 3600}h{(elapsed % 3600) // 60:02d}m "
@@ -280,6 +290,7 @@ def summary_line(final: bool = False) -> str:
         f"remaining_lane_blockers={blockers if blockers is not None else 'unknown'} "
         f"schema_quarantined={schema_count} "
         f"compute_quarantined={compute_count} "
+        f"prompt_transport_quarantined={transport_count} "
         f"transaction_quarantined={transaction_count} "
         f"blocked_row_reentries={blocked_count}"
     )
@@ -1355,6 +1366,13 @@ def main(argv: list[str] | None = None) -> int:
                         "fixed point excludes compute-required rows until their "
                         "runner cache, sliced certificate, or independent "
                         f"derivation is repaired: {args.campaign_quarantine_file}"
+                    )
+                if exclusions[batch.PROMPT_TRANSPORT_QUARANTINE_RESULT]:
+                    emit(
+                        "fixed point excludes packets whose complete "
+                        "authenticated evidence exceeds the Codex transport "
+                        "limit; split or narrow their load-bearing packet "
+                        f"before a new campaign: {args.campaign_quarantine_file}"
                     )
                 if exclusions[batch.CLAIM_TRANSACTION_QUARANTINE_RESULT]:
                     emit(

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -910,6 +910,20 @@ class BatchExitSemanticsTest(unittest.TestCase):
                 self.assertTrue(batch.report_has_hard_blocker(report))
                 self.assertEqual(batch.report_exit_code(report), 1)
 
+    def test_transport_quarantine_recovers_banked_critical_peer(self):
+        report = [
+            {"cid": "critical", "result": "prompt_transport_blocked"},
+            {
+                "cid": "critical",
+                "result": batch.PROMPT_TRANSPORT_QUARANTINE_RESULT,
+            },
+            {"cid": "critical", "result": "critical_peer_pending"},
+            {"cid": "critical", "result": "audited_clean"},
+        ]
+
+        self.assertFalse(batch.report_has_hard_blocker(report))
+        self.assertEqual(batch.report_exit_code(report), 0)
+
     def test_batch_quarantines_untransportable_claim_and_exits_cleanly(self):
         row = {
             "claim_id": "oversized",

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -878,6 +878,95 @@ class BatchExitSemanticsTest(unittest.TestCase):
         report.append({"cid": "other", "result": "validation_failed"})
         self.assertTrue(batch.report_has_hard_blocker(report))
 
+    def test_prompt_transport_quarantine_makes_only_its_failure_resumable(self):
+        report = [
+            {"cid": "quarantined", "result": "prompt_transport_blocked"},
+            {
+                "cid": "quarantined",
+                "result": batch.PROMPT_TRANSPORT_QUARANTINE_RESULT,
+            },
+        ]
+        self.assertFalse(batch.report_has_hard_blocker(report))
+
+        report.append({"cid": "other", "result": "prompt_transport_blocked"})
+        self.assertTrue(batch.report_has_hard_blocker(report))
+
+    def test_batch_quarantines_untransportable_claim_and_exits_cleanly(self):
+        row = {
+            "claim_id": "oversized",
+            "claim_type": "bounded_theorem",
+            "criticality": "ordinary",
+        }
+        lock = mock.Mock()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workdir = root / "batch"
+            quarantine = root / "campaign-row-exclusions.jsonl"
+            with mock.patch.dict(
+                os.environ,
+                {"AUDIT_BATCH_WORKDIR": str(workdir)},
+            ), mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "orchestrate_audit_batch.py",
+                    "--claims",
+                    "oversized",
+                    "--max-workers",
+                    "1",
+                    "--rounds",
+                    "1",
+                    "--campaign-quarantine-file",
+                    str(quarantine),
+                ],
+            ), mock.patch.object(
+                batch,
+                "acquire_exclusive_drain_lock",
+                return_value=lock,
+            ), mock.patch.object(
+                batch, "clean_main_error", return_value=None
+            ), mock.patch.object(
+                batch, "load_rows", return_value={"oversized": row}
+            ), mock.patch.object(
+                batch, "scope_for_args", return_value={"oversized"}
+            ), mock.patch.object(
+                batch, "compute_targets", return_value=([row], [])
+            ), mock.patch.object(
+                batch,
+                "launch_worker",
+                side_effect=batch.PromptTransportBlockedError(
+                    "prompt remains 1636029 chars after removing rendered N8"
+                ),
+            ), mock.patch.object(
+                batch, "start_progress_ticker"
+            ), mock.patch.object(
+                batch, "maybe_progress_summary"
+            ), mock.patch.object(
+                batch, "wait_workers"
+            ) as wait_workers:
+                rc = batch.main()
+
+            records = batch.load_campaign_exclusion_records(quarantine)
+            report = [
+                json.loads(line)
+                for line in (workdir / "report.jsonl").read_text().splitlines()
+            ]
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            records[0]["reason"],
+            batch.PROMPT_TRANSPORT_QUARANTINE_RESULT,
+        )
+        self.assertEqual(
+            {item["result"] for item in report},
+            {
+                "prompt_transport_blocked",
+                batch.PROMPT_TRANSPORT_QUARANTINE_RESULT,
+            },
+        )
+        wait_workers.assert_not_called()
+        lock.close.assert_called_once_with()
+
     def test_banked_clean_seat_defers_only_the_invalid_peer(self):
         report = [
             {"cid": "row", "result": "validation_failed"},
@@ -1240,6 +1329,28 @@ class SchemaRecoveryTest(unittest.TestCase):
             by_claim["transaction"]["failures"][0]["detail"],
             "pipeline failed",
         )
+
+    def test_prompt_transport_exclusion_persists_exact_packet_failure(self):
+        report = [
+            {
+                "cid": "oversized",
+                "pass": 1,
+                "result": "prompt_transport_blocked",
+                "detail": "complete packet remains 1636029 chars",
+            }
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "quarantine.jsonl"
+            batch.persist_prompt_transport_quarantines(
+                path, {"oversized"}, report
+            )
+            records = batch.load_campaign_exclusion_records(path)
+
+        self.assertEqual(
+            records[0]["reason"],
+            batch.PROMPT_TRANSPORT_QUARANTINE_RESULT,
+        )
+        self.assertEqual(records[0]["failures"], report)
 
     def test_mixed_seat_causes_persist_both_typed_reasons(self):
         report = [
@@ -4170,6 +4281,123 @@ class CampaignContractTest(unittest.TestCase):
             )
 
         self.assertEqual(actual, expected)
+
+    def test_batch_worker_bounds_oversized_development_n8_packet(self):
+        cid = "oversized-development"
+        row = {
+            "claim_id": cid,
+            "claim_type": "bounded_theorem",
+            "deps": [],
+        }
+        candidates = [
+            {
+                "candidate_id": f"candidate-{index}",
+                "evidence": "x" * 2500,
+            }
+            for index in range(450)
+        ]
+        full_text = json.dumps(
+            {
+                "candidate_universe_count": len(candidates),
+                "candidate_universe_sha256": "f" * 64,
+                "candidates": candidates,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        cross_path = batch.audit_runner.no_go_discipline_gate.cross_cycle_index_path(
+            cid
+        )
+        manifest = {
+            cross_path: {
+                "path": cross_path,
+                "roles": ["cross_cycle_index"],
+                "text": full_text,
+            }
+        }
+        prompt = (
+            "restricted packet\n"
+            + full_text
+            + batch.audit_runner.OUTPUT_INSTRUCTIONS_MARKER
+            + "\noutput contract"
+        )
+        self.assertGreater(
+            len(prompt), batch.audit_runner.CODEX_INPUT_CHAR_LIMIT
+        )
+
+        with mock.patch.object(
+            batch.audit_runner.no_go_discipline_gate,
+            "forensic_mode",
+            return_value=False,
+        ):
+            fitted, metadata = batch.fit_worker_prompt_to_transport_limit(
+                row,
+                {cid: row},
+                prompt,
+                manifest,
+            )
+
+        self.assertLessEqual(
+            len(fitted), batch.audit_runner.CODEX_INPUT_CHAR_LIMIT
+        )
+        self.assertIsNotNone(metadata)
+        self.assertLess(
+            metadata["rendered_candidates"],
+            metadata["authenticated_candidates"],
+        )
+        self.assertIn(
+            "development-tier transport bound does not force a verdict",
+            fitted,
+        )
+        self.assertEqual(
+            manifest[cross_path]["transport_bounded_full_candidate_count"],
+            len(candidates),
+        )
+
+    def test_batch_worker_marks_no_go_transport_bound_forensic(self):
+        cid = "forensic-target"
+        row = {"claim_id": cid, "claim_type": "no_go"}
+        expected_metadata = {
+            "authenticated_candidates": 2,
+            "rendered_candidates": 1,
+            "prompt_chars_before": 20,
+            "prompt_chars_after": 10,
+        }
+        with mock.patch.object(
+            batch.audit_runner,
+            "fit_prompt_to_transport_limit",
+            return_value=("fitted", expected_metadata),
+        ) as fitter, mock.patch.object(
+            batch.audit_runner.no_go_discipline_gate,
+            "forensic_mode",
+            return_value=False,
+        ):
+            actual = batch.fit_worker_prompt_to_transport_limit(
+                row,
+                {cid: row},
+                "oversized",
+                {},
+            )
+
+        self.assertEqual(actual, ("fitted", expected_metadata))
+        self.assertTrue(fitter.call_args.kwargs["forensic_bound"])
+
+    def test_batch_launch_types_untransportable_complete_packet(self):
+        row = {"claim_id": "oversized", "claim_type": "bounded_theorem"}
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            batch.audit_runner,
+            "render_prompt",
+            return_value="oversized prompt",
+        ), mock.patch.object(
+            batch,
+            "fit_worker_prompt_to_transport_limit",
+            side_effect=ValueError("complete packet still too large"),
+        ):
+            with self.assertRaisesRegex(
+                batch.PromptTransportBlockedError,
+                "complete packet still too large",
+            ):
+                batch.launch_worker(row, {"oversized": row}, 1, Path(tmp), 1)
 
     def test_packet_fingerprint_binds_dependency_bytes_and_seat_provenance(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -891,6 +891,25 @@ class BatchExitSemanticsTest(unittest.TestCase):
         report.append({"cid": "other", "result": "prompt_transport_blocked"})
         self.assertTrue(batch.report_has_hard_blocker(report))
 
+    def test_typed_quarantines_do_not_cross_mask_same_claim_failures(self):
+        wrong_pairs = (
+            [
+                {"cid": "row", "result": "validation_failed"},
+                {
+                    "cid": "row",
+                    "result": batch.PROMPT_TRANSPORT_QUARANTINE_RESULT,
+                },
+            ],
+            [
+                {"cid": "row", "result": "prompt_transport_blocked"},
+                {"cid": "row", "result": batch.SCHEMA_QUARANTINE_RESULT},
+            ],
+        )
+        for report in wrong_pairs:
+            with self.subTest(results=[item["result"] for item in report]):
+                self.assertTrue(batch.report_has_hard_blocker(report))
+                self.assertEqual(batch.report_exit_code(report), 1)
+
     def test_batch_quarantines_untransportable_claim_and_exits_cleanly(self):
         row = {
             "claim_id": "oversized",
@@ -4391,13 +4410,37 @@ class CampaignContractTest(unittest.TestCase):
         ), mock.patch.object(
             batch,
             "fit_worker_prompt_to_transport_limit",
-            side_effect=ValueError("complete packet still too large"),
+            side_effect=batch.audit_runner.PromptTransportCapacityError(
+                "complete packet still too large"
+            ),
         ):
             with self.assertRaisesRegex(
                 batch.PromptTransportBlockedError,
                 "complete packet still too large",
             ):
                 batch.launch_worker(row, {"oversized": row}, 1, Path(tmp), 1)
+
+    def test_batch_launch_keeps_transport_integrity_failure_hard(self):
+        row = {"claim_id": "malformed", "claim_type": "bounded_theorem"}
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            batch.audit_runner,
+            "render_prompt",
+            return_value="oversized prompt",
+        ), mock.patch.object(
+            batch,
+            "fit_worker_prompt_to_transport_limit",
+            side_effect=ValueError("authenticated N8 index is not valid JSON"),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "authenticated N8 index is not valid JSON",
+            ) as raised:
+                batch.launch_worker(row, {"malformed": row}, 1, Path(tmp), 1)
+
+        self.assertNotIsInstance(
+            raised.exception,
+            batch.PromptTransportBlockedError,
+        )
 
     def test_packet_fingerprint_binds_dependency_bytes_and_seat_provenance(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -12124,6 +12124,55 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             "transport-bounded N8 evidence forbids audited_clean",
         )
 
+    def test_transport_capacity_error_is_distinct_from_manifest_integrity(self):
+        m = _import_codex_audit_runner()
+        cid = "oversized-source"
+        path = m.no_go_discipline_gate.cross_cycle_index_path(cid)
+        full = json.dumps(
+            {
+                "claim_id": cid,
+                "candidates": [{"candidate_id": "candidate-0"}],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        manifest = {path: {"text": full, "roles": ["cross_cycle_index"]}}
+        prompt = (
+            "x" * 3000
+            + full
+            + m.OUTPUT_INSTRUCTIONS_MARKER
+            + "\noutput contract"
+        )
+
+        with self.assertRaises(m.PromptTransportCapacityError):
+            m.fit_prompt_to_transport_limit(
+                prompt,
+                manifest,
+                cid,
+                max_chars=2500,
+            )
+
+        malformed = {
+            path: {"text": "not-json", "roles": ["cross_cycle_index"]}
+        }
+        malformed_prompt = (
+            "x" * 3000
+            + "not-json"
+            + m.OUTPUT_INSTRUCTIONS_MARKER
+            + "\noutput contract"
+        )
+        with self.assertRaises(ValueError) as raised:
+            m.fit_prompt_to_transport_limit(
+                malformed_prompt,
+                malformed,
+                cid,
+                max_chars=2500,
+            )
+        self.assertNotIsInstance(
+            raised.exception,
+            m.PromptTransportCapacityError,
+        )
+
     def test_development_runner_validation_ignores_locator_containment(self):
         m = _import_codex_audit_runner()
         blob = {field: "x" for field in m.REQUIRED_VERDICT_FIELDS}

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -141,6 +141,10 @@ CODEX_HARD_INPUT_CHAR_LIMIT = 1_048_576
 OUTPUT_INSTRUCTIONS_MARKER = "\n\n---\nOUTPUT INSTRUCTIONS (binding):"
 
 
+class PromptTransportCapacityError(ValueError):
+    """A valid complete packet cannot fit after its safe N8 reduction."""
+
+
 def _closed_schema(properties: dict[str, dict]) -> dict:
     return {
         "type": "object",
@@ -2188,7 +2192,7 @@ def fit_prompt_to_transport_limit(
             high = mid - 1
     if best is None:
         zero = render(0)
-        raise ValueError(
+        raise PromptTransportCapacityError(
             f"prompt remains {len(zero)} chars after removing rendered N8 "
             "candidates; source/runner packet must be repaired or split"
         )


### PR DESCRIPTION
## Root cause

The canonical batch producer rendered the complete authenticated packet and then failed the whole batch when it exceeded the 1,000,000-character Codex transport ceiling. The recurrent companion row authenticates 47 transitive helper sources; even after removing every rendered N8 candidate, its packet remains 1,636,029 characters. This is a legitimate claim-local capacity condition, not an audit verdict and not a global drainer failure. Because no campaign exclusion was written, every new campaign selected the same row and stopped again.

## Fix

- apply the existing authenticated-prefix N8 transport fitter in the batch producer, matching the standalone runner;
- introduce a dedicated `prompt_transport_quarantined` campaign exclusion for complete packets that still cannot fit;
- preserve fail-closed semantics: no helper/source evidence is clipped and no verdict is inferred from transport size;
- make the top-level drainer report this typed fixed-point inventory and continue draining unrelated eligible rows;
- add regression coverage for N8 fitting, forensic-mode propagation, typed exception routing, durable exclusion validation, clean batch exit, and hard-failure isolation.

## Verification

- `python3 -m unittest docs.audit.scripts.tests.test_audit_loop_orchestrator` — 173 tests passed
- focused canonical transport tests — 8 tests passed
- `bash docs/audit/scripts/run_pipeline.sh` — all 18 stages passed
- `python3 docs/audit/scripts/audit_lint.py --strict` — zero errors
- `python3 scripts/vocab_lint.py --fix ...` — zero violations
- `git diff --check` — clean

No audit verdict or generated audit-status surface is included. The independent audit loop remains the only verdict authority.
