### PR TITLE
Cycle 823: compile companion full-seam endpoint instrument

### DIFF
--- a/docs/COMPANION_FULL_SEAM_ENDPOINT_INSTRUMENT_CYCLE823_BOUNDED_THEOREM_NOTE_2026-07-30.md
+++ b/docs/COMPANION_FULL_SEAM_ENDPOINT_INSTRUMENT_CYCLE823_BOUNDED_THEOREM_NOTE_2026-07-30.md
@@ -12,6 +12,12 @@
 **Load-bearing companion construction:**
 [`RECURRENT_COMPANION_PHYSICAL_M2_UPDATE_LOCAL_CHOI_PREPARATION_CYCLE720_BOUNDED_THEOREM_NOTE_2026-07-27.md`](RECURRENT_COMPANION_PHYSICAL_M2_UPDATE_LOCAL_CHOI_PREPARATION_CYCLE720_BOUNDED_THEOREM_NOTE_2026-07-27.md)
 
+**Runner:**
+[`frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py`](../scripts/frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py)
+
+**Receipt:**
+[`companion_full_seam_endpoint_instrument_cycle823_receipt_2026_07_30.json`](../outputs/companion_full_seam_endpoint_instrument_cycle823_receipt_2026_07_30.json)
+
 **Non-load-bearing comparison:**
 `PHYSICAL_M2_ENDPOINT_INSTRUMENT_CYCLE704_CYCLE612_BRIDGE_CYCLE713_BOUNDED_THEOREM_NOTE_2026-07-26.md`
 
@@ -118,15 +124,19 @@ neutral-only SWAP, H, T, and OR factors, every added primitive commutes with the
 one rebuilt coordinate product `P_ext`.  Across the combined circuit there are
 zero untyped uses, elementary parity failures, or cumulative-prefix failures.
 
-The one-particle mass residual remains `5.551115123125783e-17`; the free,
-seam, and contact fixtures are not modified.
+The runner reruns the inherited Cycle-822 one-particle mass and contact
+regression, obtaining mass residual `5.551115123125783e-17`.  The source rows,
+couplings, and factor order are not modified.  This is not a composed theorem
+that the matter-only mass/contact channel is unchanged after retaining or
+discarding the new pointer; that question remains open.
 
 ## Covariance and schedule boundary
 
-The compiled coordinates, types, endpoint registers, routes, and fixed program
-transport through all 24 proper-cubic frames, eight tested physical origins,
-and all 576 ordered frame products with zero nearest-neighbour, palette,
-typing, collision, colour, coordinate-product, or colour-product failures.
+For each held box, the compiled coordinates, types, endpoint registers, routes,
+and fixed program transport through all 24 proper-cubic frames, eight tested
+physical origins, and all 576 ordered frame products with zero nearest-
+neighbour, palette, typing, collision, colour, coordinate-product, or colour-
+product failures.
 
 This is transported-program covariance.  The lab-chart breadth-first router is
 not rerun and proved equal to the transported route atlas in every frame.  The
@@ -180,12 +190,14 @@ Derived:
   persistent neutral M2 per edge;
 - zero schedule/type/parity-prefix failures on four held boxes and transported
   24-frame/eight-origin/576-product covariance; and
-- preservation of the landed one-particle mass, free, seam, and contact
-  fixtures.
+- a rerun of the inherited one-particle mass/contact regression with its source
+  rows and couplings unchanged, not a composed matter-only pointer theorem.
 
 Open:
 
 - physical consumption/reset or fresh-bank renewal for the retained pointer;
+- the composed matter-only mass/contact channel after retaining, consuming, or
+  discarding the pointer;
 - autonomous clean-register/code/route genesis, enforcement, fault repair,
   program generation, and occurrence;
 - a translation-local query-free route law, target-native frame

--- a/docs/COMPANION_FULL_SEAM_ENDPOINT_INSTRUMENT_CYCLE823_BOUNDED_THEOREM_NOTE_2026-07-30.md
+++ b/docs/COMPANION_FULL_SEAM_ENDPOINT_INSTRUMENT_CYCLE823_BOUNDED_THEOREM_NOTE_2026-07-30.md
@@ -12,8 +12,8 @@
 **Load-bearing companion construction:**
 [`RECURRENT_COMPANION_PHYSICAL_M2_UPDATE_LOCAL_CHOI_PREPARATION_CYCLE720_BOUNDED_THEOREM_NOTE_2026-07-27.md`](RECURRENT_COMPANION_PHYSICAL_M2_UPDATE_LOCAL_CHOI_PREPARATION_CYCLE720_BOUNDED_THEOREM_NOTE_2026-07-27.md)
 
-**Predecessor endpoint instrument, used only for comparison:**
-[`PHYSICAL_M2_ENDPOINT_INSTRUMENT_CYCLE704_CYCLE612_BRIDGE_CYCLE713_BOUNDED_THEOREM_NOTE_2026-07-26.md`](PHYSICAL_M2_ENDPOINT_INSTRUMENT_CYCLE704_CYCLE612_BRIDGE_CYCLE713_BOUNDED_THEOREM_NOTE_2026-07-26.md)
+**Non-load-bearing comparison:**
+`PHYSICAL_M2_ENDPOINT_INSTRUMENT_CYCLE704_CYCLE612_BRIDGE_CYCLE713_BOUNDED_THEOREM_NOTE_2026-07-26.md`
 
 ## Question and answer
 
@@ -58,9 +58,8 @@ and maps `(a,b)` to `(b,a)`.  The physical word may also flip its declared pair
 of companion ports; it never changes an additional matter occupation.
 
 There are zero row-mask, monomial-output, endpoint-swap, scratch, or pointer
-failures.  The primary sparse-algebra residual is exactly zero in its retained
-dictionary.  An independent implementation found maximum floating residual
-`2.24e-17` over the same 1,312 cases.
+failures.  The runner's sparse-algebra residual is exactly zero in its retained
+dictionary.
 
 The complete four-factor boundary matters.  An individual off-diagonal
 `pi/2` Pauli rotation is a coherent identity/flip superposition and is not an

--- a/docs/COMPANION_FULL_SEAM_ENDPOINT_INSTRUMENT_CYCLE823_BOUNDED_THEOREM_NOTE_2026-07-30.md
+++ b/docs/COMPANION_FULL_SEAM_ENDPOINT_INSTRUMENT_CYCLE823_BOUNDED_THEOREM_NOTE_2026-07-30.md
@@ -1,0 +1,212 @@
+# Cycle 823: companion full-seam endpoint instrument
+
+**Type:** bounded_theorem
+
+**Authority:** none
+
+**Audit:** unset
+
+**Landed input:**
+[`PHYSICAL_M2_TYPED_RADIUS_ONE_COMPILER_TOURNAMENT_CYCLE822_BOUNDED_THEOREM_NOTE_2026-07-30.md`](PHYSICAL_M2_TYPED_RADIUS_ONE_COMPILER_TOURNAMENT_CYCLE822_BOUNDED_THEOREM_NOTE_2026-07-30.md)
+
+**Load-bearing companion construction:**
+[`RECURRENT_COMPANION_PHYSICAL_M2_UPDATE_LOCAL_CHOI_PREPARATION_CYCLE720_BOUNDED_THEOREM_NOTE_2026-07-27.md`](RECURRENT_COMPANION_PHYSICAL_M2_UPDATE_LOCAL_CHOI_PREPARATION_CYCLE720_BOUNDED_THEOREM_NOTE_2026-07-27.md)
+
+**Predecessor endpoint instrument, used only for comparison:**
+[`PHYSICAL_M2_ENDPOINT_INSTRUMENT_CYCLE704_CYCLE612_BRIDGE_CYCLE713_BOUNDED_THEOREM_NOTE_2026-07-26.md`](PHYSICAL_M2_ENDPOINT_INSTRUMENT_CYCLE704_CYCLE612_BRIDGE_CYCLE713_BOUNDED_THEOREM_NOTE_2026-07-26.md)
+
+## Question and answer
+
+Can the landed Cycle-822 companion physical-M2 circuit expose its seam's
+matter-endpoint change coherently, on the same physical code and fixed parity
+typing, without copying a branch ray or asking a host-side predicate?
+
+The finite one-use answer is positive.  Around each complete four-factor
+Cycle-720 seam, Cycle 823 inserts three neutral physical M2 registers
+`(du,dv,p)`.  On the declared clean register domain it constructs
+
+\[
+ |a,b,000\rangle\longmapsto
+ e^{i\phi(a,b,\mathrm{background})}
+ |b,a,00,a\mathbin{\mathtt{xor}}b\rangle,
+\]
+
+while retaining the physical companion-port change required by the landed
+seam.  Here `p=a xor b` is a coherent endpoint-exchange opportunity pointer.
+It is not an occurrence, actuality, admission decision, Record, Born weight,
+source variable, clock tick, duration, or rate.
+
+This closes a same-code finite physical-M2 endpoint instrument.  It does not
+close recurrent reuse: `p` is retained, so the next use needs a derived
+consume/uncompute/reset law or a supplied fresh pointer bank.  Clean auxiliary
+genesis and update occurrence also remain supplied.
+
+## Exact full-seam algebra
+
+The runner exhausts every reachable joint endpoint/Pauli-phase signature for
+both the physical companion rows and their target rows.  Across the held
+`(2,1,1)`, `(3,1,1)`, `(3,2,2)`, and `(5,3,2)` boxes it checks:
+
+- 82 edges;
+- 328 matched physical/target Pauli-row pairs; and
+- 1,312 physical-or-target full-seam signature classes.
+
+Factors zero and one flip neither declared matter endpoint.  Factors two and
+three flip both and no other matter bit.  For every signature, the ordered
+product of all four `exp(-i pi P/4)` factors has exactly one output basis word
+and maps `(a,b)` to `(b,a)`.  The physical word may also flip its declared pair
+of companion ports; it never changes an additional matter occupation.
+
+There are zero row-mask, monomial-output, endpoint-swap, scratch, or pointer
+failures.  The primary sparse-algebra residual is exactly zero in its retained
+dictionary.  An independent implementation found maximum floating residual
+`2.24e-17` over the same 1,312 cases.
+
+The complete four-factor boundary matters.  An individual off-diagonal
+`pi/2` Pauli rotation is a coherent identity/flip superposition and is not an
+endpoint swap.  Cycle 823 instruments the ordered product once; it does not
+instrument or measure each factor branch.
+
+## Instrument word
+
+Starting with `(du,dv,p)=000`, execute:
+
+1. `CNOT(left -> du)` and `CNOT(right -> dv)`;
+2. the complete ordered four-factor seam;
+3. `CNOT(left_out -> du)` and `CNOT(right_out -> dv)`;
+4. reversible OR into `p` using two CNOTs and one Toffoli; and
+5. `CNOT(p -> du)` and `CNOT(p -> dv)`.
+
+After the seam, the two delta registers both equal `a xor b`.  The reversible
+OR retains that value in `p`; the final two CNOTs clean both scratch registers.
+The Toffoli is not a three-site primitive.  Its exact 15-factor H/T/CNOT
+decomposition has matrix residual `7.346882794269506e-16` and uses only one-
+and two-M2 operations.
+
+Cycle 713's four endpoint-driven cleanup is also exact around this complete
+swap.  It is not exact around an individual Pauli factor.  Cycle 823 uses the
+two pointer-driven cleanup CNOTs because their proof needs only
+`du=dv=p`, saves two returned routes per edge, and makes the equality used for
+cleanup explicit.
+
+## Literal physical-M2 routes and typing
+
+Each edge receives three persistent neutral M2 registers and three reserved
+neutral access coordinates.  The augmented palette is collision-free on all
+four boxes.  The charged atlas is rebuilt with the added persistent sites and
+ports reserved before neutral routes are compiled; no identity with the old
+Cycle-822 coordinate digest is claimed.
+
+Each edge adds exactly 14 returned two-site CNOT route macros: two prewrites,
+two postwrites, two outer OR CNOTs, six Toffoli CNOTs, and two pointer cleanup
+CNOTs.  The complete held-box census is:
+
+| shape | edges | base routes | instrument routes | base primitives | instrument primitives | combined primitives |
+|---|---:|---:|---:|---:|---:|---:|
+| `(2,1,1)` | 1 | 412 | 14 | 9,956 | 243 | 10,199 |
+| `(3,1,1)` | 2 | 644 | 28 | 16,103 | 478 | 16,581 |
+| `(3,2,2)` | 20 | 4,400 | 280 | 144,272 | 4,836 | 149,108 |
+| `(5,3,2)` | 59 | 11,708 | 826 | 394,640 | 14,289 | 408,929 |
+
+Every emitted two-site primitive is nearest-neighbour.  Every route returns,
+there are zero internal persistent-palette hits, the maximum observed route
+distance remains 43, and the fixed stage/colour/slot collision graph has zero
+edges on every held box.
+
+Matter is always the control and a neutral register the target in endpoint
+writes.  Therefore it does not change a charged occupation.  Together with
+neutral-only SWAP, H, T, and OR factors, every added primitive commutes with the
+one rebuilt coordinate product `P_ext`.  Across the combined circuit there are
+zero untyped uses, elementary parity failures, or cumulative-prefix failures.
+
+The one-particle mass residual remains `5.551115123125783e-17`; the free,
+seam, and contact fixtures are not modified.
+
+## Covariance and schedule boundary
+
+The compiled coordinates, types, endpoint registers, routes, and fixed program
+transport through all 24 proper-cubic frames, eight tested physical origins,
+and all 576 ordered frame products with zero nearest-neighbour, palette,
+typing, collision, colour, coordinate-product, or colour-product failures.
+
+This is transported-program covariance.  The lab-chart breadth-first router is
+not rerun and proved equal to the transported route atlas in every frame.  The
+finite offline atlas, directed-edge ownership, factor order, stage/colour/slot
+program, coframe, and circuit occurrence remain supplied.  Stage labels and
+factor ordinals are circuit structure, not physical time.
+
+The prewrites for all edges may precede the complete seam layer because the
+row census proves that another edge changes none of this edge's declared
+matter endpoints.  Postwrite/OR/cleanup follows the seam layer and precedes
+contact.  No schedule counter is introduced.
+
+## Active controls and limitations
+
+For each of 164 physical-or-target edge families, the runner detects:
+
+- deletion of an endpoint-changing seam factor;
+- a single-endpoint X-mask mutation;
+- deletion of the nonlinear OR Toffoli; and
+- deletion of a pointer-to-scratch cleanup CNOT.
+
+All seven dirty three-register basis inputs per edge are outside the declared
+clean domain.  They are reported as unlawful inputs, not silently repaired.
+The endpoint instrument is phase-insensitive by design: deleting or reversing
+a diagonal factor can change the seam unitary without changing the endpoint
+pointer.  Full row tuples, order, angle, and matrix semantics remain separately
+bound to Cycle 720/822; the pointer is not promoted into a complete seam
+identity test.
+
+The construction supplies no pointer consumption, reset, renewal, fault
+repair, or permanent storage.  Keeping `p` is a reversible isometry and does
+not make a Record.  Discarding or reading it would require a separate physical
+law and cannot be inferred from this circuit.
+
+## Supplied, derived, and open inventory
+
+Supplied:
+
+- the Cycle-720 companion code/gauge sector, total-parity label, physical row
+  dictionary, couplings, order, finite boundary, and prepared O-bank state;
+- the Cycle-822 fixed finite program, coframe, typed offline atlas, clean route
+  inputs, Bell/pump/correction preparation, and circuit occurrence; and
+- three clean neutral endpoint registers and access coordinates per edge.
+
+Derived:
+
+- the exact full-seam matter-endpoint swap on every reachable phase class in
+  both physical and target row families;
+- a coherent pointer `p=a xor b` with both delta registers returned clean;
+- a literal radius-one implementation with 14 returned route macros and three
+  persistent neutral M2 per edge;
+- zero schedule/type/parity-prefix failures on four held boxes and transported
+  24-frame/eight-origin/576-product covariance; and
+- preservation of the landed one-particle mass, free, seam, and contact
+  fixtures.
+
+Open:
+
+- physical consumption/reset or fresh-bank renewal for the retained pointer;
+- autonomous clean-register/code/route genesis, enforcement, fault repair,
+  program generation, and occurrence;
+- a translation-local query-free route law, target-native frame
+  recompilation, periodic/glued boundaries, and unbounded-family overhead;
+- objective actuality/admissibility, irreversible Record formation, Born
+  weighting, and realized-history selection; and
+- attachment to derived causal duration, conserved source/gravity response,
+  and a no-refit prediction surface.
+
+## TOE disposition
+
+Cycle 823 materially strengthens the operational-quantum physical bridge: the
+same companion code that executes the finite recurrent update now exposes a
+coherent local matter-endpoint opportunity pointer with explicit physical M2,
+routes, typing, and covariance.  It does not change causal-time,
+source/gravity, or Born/history closure, because opportunity is not occurrence
+and reversible pointer retention is not a Record.
+
+The result is positive.  It makes no impossibility, minimum-content,
+shared-obstruction, or axiom-pressure claim.  The best next constructive test
+is a bounded pointer-consume/reset tournament tied to the landed
+actuality/admissibility interface, with a fresh-bank route retained as an
+independent alternative.

--- a/docs/COMPANION_FULL_SEAM_ENDPOINT_INSTRUMENT_CYCLE823_BOUNDED_THEOREM_NOTE_2026-07-30.md
+++ b/docs/COMPANION_FULL_SEAM_ENDPOINT_INSTRUMENT_CYCLE823_BOUNDED_THEOREM_NOTE_2026-07-30.md
@@ -144,10 +144,11 @@ finite offline atlas, directed-edge ownership, factor order, stage/colour/slot
 program, coframe, and circuit occurrence remain supplied.  Stage labels and
 factor ordinals are circuit structure, not physical time.
 
-The prewrites for all edges may precede the complete seam layer because the
-row census proves that another edge changes none of this edge's declared
-matter endpoints.  Postwrite/OR/cleanup follows the seam layer and precedes
-contact.  No schedule counter is introduced.
+The prewrites for all edges may precede the complete seam layer because an
+explicit pairwise census finds zero shared declared matter endpoints between
+distinct edges in every held box, while the row census proves that every seam
+row changes only its own declared endpoint pair.  Postwrite/OR/cleanup follows
+the seam layer and precedes contact.  No schedule counter is introduced.
 
 ## Active controls and limitations
 

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15346,
- "node_count": 4607,
+ "edge_count": 15348,
+ "node_count": 4608,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2452,6 +2452,10 @@
   },
   "companion_bank_static_certificate_povm_input_convention_meta_note_2026-07-30": {
    "deps_hash": "9ec29ca50bf8",
+   "out_degree": 2
+  },
+  "companion_full_seam_endpoint_instrument_cycle823_bounded_theorem_note_2026-07-30": {
+   "deps_hash": "56fa6ec242c3",
    "out_degree": 2
   },
   "companion_gauge_work_center_controllability_cycle797_bounded_theorem_note_2026-07-30": {

--- a/outputs/companion_full_seam_endpoint_instrument_cycle823_receipt_2026_07_30.json
+++ b/outputs/companion_full_seam_endpoint_instrument_cycle823_receipt_2026_07_30.json
@@ -3,7 +3,7 @@
   "audit": "unset",
   "authority": "none",
   "artifact_provenance_sha256": {
-    "note": "c3593b3903b64c5d96c4ff0e0723d1976ad7069061a2a21cb2b80989526e18cd",
+    "note": "7838206e0d69ba29f6cfdac718aff21872d4d96c9f2d85733ca43a3cd0a0a9ae",
     "runner": "c23370fdc02ca2e70dcb68e7de816da518c76425db84d2b1d6d69f02e63cb543"
   },
   "checks_passed": 9,
@@ -18,8 +18,7 @@
     "monomial_full_seam_failures": 0,
     "endpoint_swap_failures": 0,
     "instrument_isometry_failures": 0,
-    "maximum_primary_instrument_residual": 0.0,
-    "maximum_independent_instrument_residual": 2.24e-17,
+    "maximum_instrument_residual": 0.0,
     "dirty_ancilla_unlawful_inputs_per_edge": 7
   },
   "active_controls": {

--- a/outputs/companion_full_seam_endpoint_instrument_cycle823_receipt_2026_07_30.json
+++ b/outputs/companion_full_seam_endpoint_instrument_cycle823_receipt_2026_07_30.json
@@ -4,10 +4,10 @@
   "authority": "none",
   "artifact_provenance_sha256": {
     "note": "c3593b3903b64c5d96c4ff0e0723d1976ad7069061a2a21cb2b80989526e18cd",
-    "runner": "ceaffb990160fa53475ea0e485294b15e1dc0c376a8a7a6bb1192b70ce9555e0"
+    "runner": "c23370fdc02ca2e70dcb68e7de816da518c76425db84d2b1d6d69f02e63cb543"
   },
-  "checks_passed": 10,
-  "checks_total": 10,
+  "checks_passed": 9,
+  "checks_total": 9,
   "claim_scope": "finite held-box coherent endpoint-opportunity instrument on the landed Cycle822 companion seam; not an autonomous occurrence or recurrent-reset law",
   "full_seam_algebra": {
     "held_shapes": 4,

--- a/outputs/companion_full_seam_endpoint_instrument_cycle823_receipt_2026_07_30.json
+++ b/outputs/companion_full_seam_endpoint_instrument_cycle823_receipt_2026_07_30.json
@@ -1,0 +1,122 @@
+{
+  "artifact": "frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py",
+  "audit": "unset",
+  "authority": "none",
+  "artifact_provenance_sha256": {
+    "note": "c3593b3903b64c5d96c4ff0e0723d1976ad7069061a2a21cb2b80989526e18cd",
+    "runner": "ceaffb990160fa53475ea0e485294b15e1dc0c376a8a7a6bb1192b70ce9555e0"
+  },
+  "checks_passed": 10,
+  "checks_total": 10,
+  "claim_scope": "finite held-box coherent endpoint-opportunity instrument on the landed Cycle822 companion seam; not an autonomous occurrence or recurrent-reset law",
+  "full_seam_algebra": {
+    "held_shapes": 4,
+    "edges": 82,
+    "matched_physical_target_row_pairs": 328,
+    "physical_and_target_signature_classes": 1312,
+    "row_endpoint_mask_failures": 0,
+    "monomial_full_seam_failures": 0,
+    "endpoint_swap_failures": 0,
+    "instrument_isometry_failures": 0,
+    "maximum_primary_instrument_residual": 0.0,
+    "maximum_independent_instrument_residual": 2.24e-17,
+    "dirty_ancilla_unlawful_inputs_per_edge": 7
+  },
+  "active_controls": {
+    "physical_or_target_edge_families_per_control": 164,
+    "endpoint_changing_factor_deletions_detected": 164,
+    "single_endpoint_mutations_detected": 164,
+    "OR_Toffoli_deletions_detected": 164,
+    "pointer_cleanup_deletions_detected": 164,
+    "Cycle713_swap_specific_cleanup_equivalence_failures": 0
+  },
+  "decomposed_Toffoli": {
+    "one_and_two_M2_factors": 15,
+    "maximum_matrix_residual": 7.346882794269506e-16,
+    "literal_three_M2_primitive_used": false
+  },
+  "held_metrics": [
+    {
+      "shape": [2, 1, 1],
+      "edges": 1,
+      "base_route_macros": 412,
+      "instrument_route_macros": 14,
+      "total_route_macros": 426,
+      "base_primitives": 9956,
+      "instrument_primitives": 243,
+      "combined_primitives": 10199,
+      "charged_coordinates": 459,
+      "neutral_coordinates": 1353,
+      "collision_edges": 0,
+      "global_P_ext_sha256": "1bb05bf43bb3e99da7e87e29c23d8a89f468f0b6e36840e5d3f88c9efce8ef69"
+    },
+    {
+      "shape": [3, 1, 1],
+      "edges": 2,
+      "base_route_macros": 644,
+      "instrument_route_macros": 28,
+      "total_route_macros": 672,
+      "base_primitives": 16103,
+      "instrument_primitives": 478,
+      "combined_primitives": 16581,
+      "charged_coordinates": 702,
+      "neutral_coordinates": 2185,
+      "collision_edges": 0,
+      "global_P_ext_sha256": "9e439005a6edf8883d55636878c9542d75a940978a93b832b7171222d485cd24"
+    },
+    {
+      "shape": [3, 2, 2],
+      "edges": 20,
+      "base_route_macros": 4400,
+      "instrument_route_macros": 280,
+      "total_route_macros": 4680,
+      "base_primitives": 144272,
+      "instrument_primitives": 4836,
+      "combined_primitives": 149108,
+      "charged_coordinates": 3433,
+      "neutral_coordinates": 14054,
+      "collision_edges": 0,
+      "global_P_ext_sha256": "270545d934058de3b8454af5174a5dc7fd9e2b0c45e93f6b358be317e7aa1004"
+    },
+    {
+      "shape": [5, 3, 2],
+      "edges": 59,
+      "base_route_macros": 11708,
+      "instrument_route_macros": 826,
+      "total_route_macros": 12534,
+      "base_primitives": 394640,
+      "instrument_primitives": 14289,
+      "combined_primitives": 408929,
+      "charged_coordinates": 8985,
+      "neutral_coordinates": 37062,
+      "collision_edges": 0,
+      "global_P_ext_sha256": "8844cd75a6e507523439fec776db6cc4c9280bd853b101a2c423a7f733282390"
+    }
+  ],
+  "global_controls": {
+    "maximum_route_distance": 43,
+    "nearest_neighbour_failures": 0,
+    "route_return_failures": 0,
+    "internal_persistent_route_hits": 0,
+    "charged_neutral_overlap": 0,
+    "untyped_primitive_uses": 0,
+    "elementary_global_P_ext_failures": 0,
+    "prefix_global_P_ext_failures": 0,
+    "proper_cubic_frames": 24,
+    "translation_origins": 8,
+    "ordered_frame_products": 576,
+    "transported_program_covariance": true,
+    "target_native_route_recompilation_proved": false
+  },
+  "preserved_fixtures": {
+    "one_particle_mass": 0.45340565417488515,
+    "one_particle_mass_residual": 5.551115123125783e-17,
+    "one_particle_coin_eigen_residual": 2.594441202963249e-16,
+    "contact_vacuum_and_one_particle_residual": 0.0,
+    "contact_double_occupation_phase_residual": 0.0
+  },
+  "stage_labels_are_physical_time": false,
+  "pointer_is_occurrence_actuality_Record_Born_source_or_clock": false,
+  "pointer_reset_or_fresh_bank_derived": false,
+  "status": "cycle823-companion-full-seam-endpoint-instrument-bounded-positive"
+}

--- a/outputs/companion_full_seam_endpoint_instrument_cycle823_receipt_2026_07_30.json
+++ b/outputs/companion_full_seam_endpoint_instrument_cycle823_receipt_2026_07_30.json
@@ -3,8 +3,8 @@
   "audit": "unset",
   "authority": "none",
   "artifact_provenance_sha256": {
-    "note": "7838206e0d69ba29f6cfdac718aff21872d4d96c9f2d85733ca43a3cd0a0a9ae",
-    "runner": "c23370fdc02ca2e70dcb68e7de816da518c76425db84d2b1d6d69f02e63cb543"
+    "note": "34a781ac76b04dd3cd7ead87ed4a542ec73b7e5772e9b4733c690eb8ef1e4d50",
+    "runner": "edc2805c123d052cb9bc21be51ff5f435da918eaf24187dbf3bf474dbd96792d"
   },
   "checks_passed": 9,
   "checks_total": 9,
@@ -13,6 +13,7 @@
     "held_shapes": 4,
     "edges": 82,
     "matched_physical_target_row_pairs": 328,
+    "four_plus_four_row_cardinality_failures": 0,
     "physical_and_target_signature_classes": 1312,
     "row_endpoint_mask_failures": 0,
     "monomial_full_seam_failures": 0,
@@ -104,16 +105,18 @@
     "proper_cubic_frames": 24,
     "translation_origins": 8,
     "ordered_frame_products": 576,
+    "held_boxes_with_covariance_replay": 4,
     "transported_program_covariance": true,
     "target_native_route_recompilation_proved": false
   },
-  "preserved_fixtures": {
+  "inherited_fixture_regression_not_composed_with_pointer": {
     "one_particle_mass": 0.45340565417488515,
     "one_particle_mass_residual": 5.551115123125783e-17,
     "one_particle_coin_eigen_residual": 2.594441202963249e-16,
     "contact_vacuum_and_one_particle_residual": 0.0,
     "contact_double_occupation_phase_residual": 0.0
   },
+  "composed_matter_only_mass_contact_pointer_theorem": false,
   "stage_labels_are_physical_time": false,
   "pointer_is_occurrence_actuality_Record_Born_source_or_clock": false,
   "pointer_reset_or_fresh_bank_derived": false,

--- a/outputs/companion_full_seam_endpoint_instrument_cycle823_receipt_2026_07_30.json
+++ b/outputs/companion_full_seam_endpoint_instrument_cycle823_receipt_2026_07_30.json
@@ -3,17 +3,18 @@
   "audit": "unset",
   "authority": "none",
   "artifact_provenance_sha256": {
-    "note": "34a781ac76b04dd3cd7ead87ed4a542ec73b7e5772e9b4733c690eb8ef1e4d50",
-    "runner": "edc2805c123d052cb9bc21be51ff5f435da918eaf24187dbf3bf474dbd96792d"
+    "note": "8679f0f737a399b024193bb000158f86049ea10932cccfe1965b5d403ca310f4",
+    "runner": "1c70bf782005bbf90608c99417470dcb0f964749644849c8835ef6314c61a737"
   },
-  "checks_passed": 9,
-  "checks_total": 9,
+  "checks_passed": 11,
+  "checks_total": 11,
   "claim_scope": "finite held-box coherent endpoint-opportunity instrument on the landed Cycle822 companion seam; not an autonomous occurrence or recurrent-reset law",
   "full_seam_algebra": {
     "held_shapes": 4,
     "edges": 82,
     "matched_physical_target_row_pairs": 328,
     "four_plus_four_row_cardinality_failures": 0,
+    "endpoint_pair_overlap_failures": 0,
     "physical_and_target_signature_classes": 1312,
     "row_endpoint_mask_failures": 0,
     "monomial_full_seam_failures": 0,

--- a/scripts/frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py
+++ b/scripts/frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py
@@ -31,6 +31,8 @@ NOTE_PATH = (
 AUDIT_INPUT_PATHS = (
     NOTE_PATH,
     "scripts/frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py",
+    "docs/PHYSICAL_M2_TYPED_RADIUS_ONE_COMPILER_TOURNAMENT_"
+    "CYCLE822_BOUNDED_THEOREM_NOTE_2026-07-30.md",
     "docs/ROUTEC_STAGGERED_RADIUS_ONE_PARITY_EVEN_TRANSPORT_"
     "CYCLE822_BOUNDED_THEOREM_NOTE_2026-07-30.md",
     "scripts/frontier_cycle822_routec_staggered_radius_one_parity_even_"
@@ -186,6 +188,7 @@ def expected_instrument_output(
 def full_seam_algebra_certificate() -> dict[str, object]:
     row_pairs = signature_classes = instrument_cases = 0
     row_cardinality_failures = 0
+    endpoint_pair_overlap_failures = 0
     row_mask_failures = swap_failures = monomial_failures = 0
     instrument_failures = 0
     maximum_instrument_residual = 0.0
@@ -197,6 +200,13 @@ def full_seam_algebra_certificate() -> dict[str, object]:
         fixture = M720.CompanionFixture.build(shape)
         shape_classes = shape_failures = 0
         row_payload = []
+        endpoint_pairs = tuple((edge[4], edge[5]) for edge in fixture.edges)
+        shape_endpoint_pair_overlap_failures = sum(
+            bool(set(first) & set(second))
+            for index, first in enumerate(endpoint_pairs)
+            for second in endpoint_pairs[index + 1:]
+        )
+        endpoint_pair_overlap_failures += shape_endpoint_pair_overlap_failures
         for edge_index, edge in enumerate(fixture.edges):
             left, right = edge[4], edge[5]
             endpoint_mask = (1 << left) | (1 << right)
@@ -304,6 +314,7 @@ def full_seam_algebra_certificate() -> dict[str, object]:
             "edges": len(fixture.edges),
             "physical_and_target_signature_classes": shape_classes,
             "full_seam_endpoint_swap_failures": shape_failures,
+            "endpoint_pair_overlap_failures": shape_endpoint_pair_overlap_failures,
             "row_tuple_sha256": sha256(repr(tuple(row_payload)).encode()).hexdigest(),
         })
     mutation_trials = 2 * sum(row["edges"] for row in per_shape)
@@ -311,6 +322,7 @@ def full_seam_algebra_certificate() -> dict[str, object]:
         "held_shapes": len(SHAPES),
         "matched_physical_target_row_pairs": row_pairs,
         "four_plus_four_row_cardinality_failures": row_cardinality_failures,
+        "endpoint_pair_overlap_failures": endpoint_pair_overlap_failures,
         "physical_and_target_signature_classes": signature_classes,
         "monomial_full_seam_failures": monomial_failures,
         "full_seam_endpoint_swap_failures": swap_failures,
@@ -665,6 +677,16 @@ def main() -> None:
     mass = R822.one_particle_mass_fixture()
     total_edges = sum(box["edges"] for box in boxes)
     checks = {
+        "declared_inputs_are_unique_existing_repo_relative_files": (
+            len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS))
+            and NOTE_PATH in AUDIT_INPUT_PATHS
+            and "scripts/frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py"
+            in AUDIT_INPUT_PATHS
+            and all(
+                not Path(path).is_absolute() and (ROOT / path).is_file()
+                for path in AUDIT_INPUT_PATHS
+            )
+        ),
         "complete_physical_and_target_seams_swap_declared_endpoints": (
             algebra["matched_physical_target_row_pairs"] == 328
             and algebra["four_plus_four_row_cardinality_failures"] == 0
@@ -672,6 +694,9 @@ def main() -> None:
             and algebra["row_endpoint_mask_failures"] == 0
             and algebra["monomial_full_seam_failures"] == 0
             and algebra["full_seam_endpoint_swap_failures"] == 0
+        ),
+        "edge_endpoint_pairs_are_pairwise_disjoint_in_every_held_box": (
+            algebra["endpoint_pair_overlap_failures"] == 0
         ),
         "coherent_endpoint_instrument_is_exact_on_clean_domain": (
             algebra["instrument_clean_domain_cases"] == 1312

--- a/scripts/frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py
+++ b/scripts/frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py
@@ -1,0 +1,794 @@
+#!/usr/bin/env python3
+"""Cycle 823: coherent endpoint instrument on the Cycle-822 companion seam.
+
+The instrument surrounds the complete four-factor seam, not its individual
+Pauli-rotation factors.  Its fixed stage labels are circuit structure, never
+physical time.  The output pointer is a reversible opportunity certificate;
+it is not occurrence, actuality, a Record, a Born weight, or a source law.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from hashlib import sha256
+from itertools import product
+import json
+import math
+from pathlib import Path
+import time
+
+import numpy as np
+
+import frontier_cycle720_cell_majorana_companion_geometry_2026_07_27 as M720
+import frontier_cycle822_routec_staggered_radius_one_parity_even_transport_2026_07_30 as R822
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    "docs/COMPANION_FULL_SEAM_ENDPOINT_INSTRUMENT_"
+    "CYCLE823_BOUNDED_THEOREM_NOTE_2026-07-30.md"
+)
+AUDIT_INPUT_PATHS = (
+    NOTE_PATH,
+    "scripts/frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py",
+    "docs/ROUTEC_STAGGERED_RADIUS_ONE_PARITY_EVEN_TRANSPORT_"
+    "CYCLE822_BOUNDED_THEOREM_NOTE_2026-07-30.md",
+    "scripts/frontier_cycle822_routec_staggered_radius_one_parity_even_"
+    "transport_2026_07_30.py",
+    "docs/RECURRENT_COMPANION_PHYSICAL_M2_UPDATE_LOCAL_CHOI_PREPARATION_"
+    "CYCLE720_BOUNDED_THEOREM_NOTE_2026-07-27.md",
+    "scripts/frontier_cycle720_cell_majorana_companion_geometry_2026_07_27.py",
+)
+DECLARED_INPUT_PATHS = AUDIT_INPUT_PATHS
+SHAPES = R822.SHAPES
+TOL = 3.0e-11
+INSTRUMENT_STAGE_ORDER = (
+    "pump",
+    "bell_measure",
+    "bell_correction",
+    "recurrent_coin",
+    "recurrent_reverse_FSWAP",
+    "endpoint_pre",
+    "recurrent_seam",
+    "endpoint_post_or_clean",
+    "recurrent_contact",
+)
+
+
+def digest(path: Path) -> str:
+    return sha256(path.read_bytes()).hexdigest()
+
+
+def pauli_action(row, basis: int) -> tuple[int, complex]:
+    return (
+        basis ^ row.x,
+        (1j ** row.phase) * ((-1) ** ((row.z & basis).bit_count())),
+    )
+
+
+def rotate_sparse(state: dict[int, complex], row) -> dict[int, complex]:
+    output: dict[int, complex] = defaultdict(complex)
+    coefficient = 1.0 / math.sqrt(2.0)
+    for basis, amplitude in state.items():
+        output[basis] += coefficient * amplitude
+        target, phase = pauli_action(row, basis)
+        output[target] += -1j * coefficient * phase * amplitude
+    return {
+        basis: amplitude
+        for basis, amplitude in output.items()
+        if abs(amplitude) > 1.0e-13
+    }
+
+
+def apply_full_seam(rows, basis: int) -> dict[int, complex]:
+    state = {basis: 1.0 + 0.0j}
+    for row in rows:
+        state = rotate_sparse(state, row)
+    return state
+
+
+def signature_representatives(rows, left: int, right: int) -> tuple[int, ...]:
+    """One basis representative for every reachable phase/endpoint class."""
+    forms = tuple(row.z for row in rows) + (1 << left, 1 << right)
+    bit_positions = sorted({
+        bit
+        for form in forms
+        for bit in range(form.bit_length())
+        if (form >> bit) & 1
+    })
+    representatives = {0: 0}
+    for bit in bit_positions:
+        signature = sum(
+            ((form >> bit) & 1) << index
+            for index, form in enumerate(forms)
+        )
+        for old_signature, basis in tuple(representatives.items()):
+            representatives.setdefault(
+                old_signature ^ signature, basis ^ (1 << bit)
+            )
+    return tuple(representatives[key] for key in sorted(representatives))
+
+
+def cnot_sparse(
+    state: dict[int, complex], control: int, target: int
+) -> dict[int, complex]:
+    return {
+        basis ^ ((((basis >> control) & 1) << target)): amplitude
+        for basis, amplitude in state.items()
+    }
+
+
+def toffoli_sparse(
+    state: dict[int, complex], first: int, second: int, target: int
+) -> dict[int, complex]:
+    return {
+        basis ^ (
+            (((basis >> first) & 1) & ((basis >> second) & 1)) << target
+        ): amplitude
+        for basis, amplitude in state.items()
+    }
+
+
+def instrument_sparse(
+    rows,
+    basis: int,
+    left: int,
+    right: int,
+    width: int,
+    *,
+    delete_or_toffoli: bool = False,
+    delete_pointer_cleanup: bool = False,
+    old_endpoint_cleanup: bool = False,
+) -> dict[int, complex]:
+    du, dv, pointer = width, width + 1, width + 2
+    state = {basis: 1.0 + 0.0j}
+    state = cnot_sparse(state, left, du)
+    state = cnot_sparse(state, right, dv)
+    for row in rows:
+        state = rotate_sparse(state, row)
+    state = cnot_sparse(state, left, du)
+    state = cnot_sparse(state, right, dv)
+    state = cnot_sparse(state, du, pointer)
+    state = cnot_sparse(state, dv, pointer)
+    if not delete_or_toffoli:
+        state = toffoli_sparse(state, du, dv, pointer)
+    if old_endpoint_cleanup:
+        state = cnot_sparse(state, left, du)
+        state = cnot_sparse(state, right, du)
+        state = cnot_sparse(state, left, dv)
+        state = cnot_sparse(state, right, dv)
+    else:
+        state = cnot_sparse(state, pointer, du)
+        if not delete_pointer_cleanup:
+            state = cnot_sparse(state, pointer, dv)
+    return state
+
+
+def dictionary_residual(
+    left: dict[int, complex], right: dict[int, complex]
+) -> float:
+    return math.sqrt(sum(
+        abs(left.get(key, 0.0j) - right.get(key, 0.0j)) ** 2
+        for key in set(left) | set(right)
+    ))
+
+
+def expected_instrument_output(
+    seam: dict[int, complex], input_basis: int, left: int, right: int, width: int
+) -> dict[int, complex]:
+    pointer = width + 2
+    value = ((input_basis >> left) & 1) ^ ((input_basis >> right) & 1)
+    return {
+        basis ^ (value << pointer): amplitude for basis, amplitude in seam.items()
+    }
+
+
+def full_seam_algebra_certificate() -> dict[str, object]:
+    row_pairs = signature_classes = instrument_cases = 0
+    row_mask_failures = swap_failures = monomial_failures = 0
+    instrument_failures = 0
+    maximum_instrument_residual = 0.0
+    deleted_factor_detected = single_endpoint_detected = 0
+    old_cleanup_equivalence_failures = 0
+    or_deletion_detected = cleanup_deletion_detected = 0
+    per_shape = []
+    for shape in SHAPES:
+        fixture = M720.CompanionFixture.build(shape)
+        shape_classes = shape_failures = 0
+        row_payload = []
+        for edge_index, edge in enumerate(fixture.edges):
+            left, right = edge[4], edge[5]
+            endpoint_mask = (1 << left) | (1 << right)
+            physical_rows = fixture.physical_terms(edge_index)
+            target_rows = fixture.target_terms(edge_index)
+            row_pairs += len(physical_rows)
+            for factor, (physical, target) in enumerate(
+                zip(physical_rows, target_rows)
+            ):
+                expected = 0 if factor < 2 else endpoint_mask
+                physical_matter = physical.x & ((1 << fixture.matter_qubits) - 1)
+                row_mask_failures += physical_matter != expected or target.x != expected
+                row_payload.append((
+                    factor,
+                    physical.phase, physical.x, physical.z,
+                    target.phase, target.x, target.z,
+                ))
+            for family, rows in (("physical", physical_rows), ("target", target_rows)):
+                representatives = signature_representatives(rows, left, right)
+                width = fixture.qubits if family == "physical" else fixture.matter_qubits
+                for basis in representatives:
+                    signature_classes += 1
+                    shape_classes += 1
+                    seam = apply_full_seam(rows, basis)
+                    monomial_failures += len(seam) != 1
+                    input_left = (basis >> left) & 1
+                    input_right = (basis >> right) & 1
+                    swapped = all(
+                        ((output >> left) & 1) == input_right
+                        and ((output >> right) & 1) == input_left
+                        for output in seam
+                    )
+                    swap_failures += not swapped
+                    shape_failures += not swapped
+                    executed = instrument_sparse(rows, basis, left, right, width)
+                    expected = expected_instrument_output(
+                        seam, basis, left, right, width
+                    )
+                    residual = dictionary_residual(executed, expected)
+                    maximum_instrument_residual = max(
+                        maximum_instrument_residual, residual
+                    )
+                    instrument_failures += residual > TOL
+                    instrument_cases += 1
+
+                deleted_bad = single_bad = or_bad = cleanup_bad = False
+                old_bad = False
+                mutated = list(rows)
+                mutated[2] = type(rows[2])(
+                    rows[2].phase, rows[2].x ^ (1 << left), rows[2].z
+                )
+                for witness in representatives:
+                    seam_witness = apply_full_seam(rows, witness)
+                    ideal = expected_instrument_output(
+                        seam_witness, witness, left, right, width
+                    )
+                    deleted = apply_full_seam(rows[:-1], witness)
+                    deleted_good = len(deleted) == 1 and all(
+                        ((output >> left) & 1) == ((witness >> right) & 1)
+                        and ((output >> right) & 1) == ((witness >> left) & 1)
+                        for output in deleted
+                    )
+                    deleted_bad |= not deleted_good
+                    single_bad |= dictionary_residual(
+                        instrument_sparse(
+                            tuple(mutated), witness, left, right, width
+                        ),
+                        expected_instrument_output(
+                            apply_full_seam(tuple(mutated), witness),
+                            witness, left, right, width,
+                        ),
+                    ) > 1.0e-6
+                    old_bad |= dictionary_residual(
+                        instrument_sparse(
+                            rows, witness, left, right, width,
+                            old_endpoint_cleanup=True,
+                        ),
+                        ideal,
+                    ) > 1.0e-6
+                    or_bad |= dictionary_residual(
+                        instrument_sparse(
+                            rows, witness, left, right, width,
+                            delete_or_toffoli=True,
+                        ),
+                        ideal,
+                    ) > 1.0e-6
+                    cleanup_bad |= dictionary_residual(
+                        instrument_sparse(
+                            rows, witness, left, right, width,
+                            delete_pointer_cleanup=True,
+                        ),
+                        ideal,
+                    ) > 1.0e-6
+                deleted_factor_detected += deleted_bad
+                single_endpoint_detected += single_bad
+                old_cleanup_equivalence_failures += old_bad
+                or_deletion_detected += or_bad
+                cleanup_deletion_detected += cleanup_bad
+        per_shape.append({
+            "shape": shape,
+            "cells": len(fixture.cells),
+            "edges": len(fixture.edges),
+            "physical_and_target_signature_classes": shape_classes,
+            "full_seam_endpoint_swap_failures": shape_failures,
+            "row_tuple_sha256": sha256(repr(tuple(row_payload)).encode()).hexdigest(),
+        })
+    mutation_trials = 2 * sum(row["edges"] for row in per_shape)
+    return {
+        "held_shapes": len(SHAPES),
+        "matched_physical_target_row_pairs": row_pairs,
+        "physical_and_target_signature_classes": signature_classes,
+        "monomial_full_seam_failures": monomial_failures,
+        "full_seam_endpoint_swap_failures": swap_failures,
+        "row_endpoint_mask_failures": row_mask_failures,
+        "instrument_clean_domain_cases": instrument_cases,
+        "instrument_isometry_failures": instrument_failures,
+        "maximum_instrument_isometry_residual": maximum_instrument_residual,
+        "factor_deletion_trials_detected": deleted_factor_detected,
+        "single_endpoint_mutation_trials_detected": single_endpoint_detected,
+        "old_Cycle713_swap_specific_cleanup_equivalence_failures": (
+            old_cleanup_equivalence_failures
+        ),
+        "OR_Toffoli_deletion_trials_detected": or_deletion_detected,
+        "pointer_cleanup_deletion_trials_detected": cleanup_deletion_detected,
+        "expected_mutation_trials_per_control": mutation_trials,
+        "dirty_ancilla_unlawful_inputs_per_edge": 7,
+        "per_shape": tuple(per_shape),
+    }
+
+
+def add(left, right):
+    return tuple(a + b for a, b in zip(left, right))
+
+
+def auxiliary_offset(axis: int, register: int):
+    return (
+        (6, -6, -6 + register),
+        (-6, 6, -6 + register),
+        (-6 + register, -6, 6),
+    )[axis]
+
+
+def port_offset(axis: int, register: int):
+    return (
+        (5, -6, -6 + register),
+        (-6, 5, -6 + register),
+        (-6 + register, -6, 5),
+    )[axis]
+
+
+def augment_context(context):
+    persistent = set(context["persistent"])
+    ports = set(context["neutral_access_ports"])
+    auxiliaries = {}
+    collision_failures = 0
+    for edge_index, edge in enumerate(context["fixture"].edges):
+        center = context["centers"][edge[2]]
+        sites = tuple(
+            add(center, auxiliary_offset(edge[3], register))
+            for register in range(3)
+        )
+        access = tuple(
+            add(center, port_offset(edge[3], register))
+            for register in range(3)
+        )
+        collision_failures += len(set(sites)) != 3
+        collision_failures += bool(set(sites) & (persistent | ports))
+        collision_failures += bool(set(access) & (persistent | ports | set(sites)))
+        persistent.update(sites)
+        ports.update(access)
+        auxiliaries[edge_index] = sites
+    output = dict(context)
+    output["persistent"] = frozenset(persistent)
+    output["neutral_access_ports"] = frozenset(ports)
+    output["charged_route_obstacles"] = frozenset(persistent)
+    output["neutral_route_obstacles"] = frozenset(persistent)
+    output["endpoint_auxiliaries"] = auxiliaries
+    output["endpoint_palette_collision_failures"] = collision_failures
+    return output
+
+
+def routed_cnot(
+    context,
+    routes,
+    control,
+    target,
+    *,
+    role: str,
+    bias: int,
+    charged_control: bool = False,
+):
+    if charged_control:
+        return R822.routed_two_site(
+            "endpoint_CNOT",
+            target,
+            control,
+            context["neutral_route_obstacles"],
+            routes,
+            role=role,
+            exchange="SWAP",
+            bias=bias,
+            target_first=True,
+        )
+    return R822.routed_two_site(
+        "endpoint_CNOT",
+        control,
+        target,
+        context["neutral_route_obstacles"],
+        routes,
+        role=role,
+        exchange="SWAP",
+        bias=bias,
+    )
+
+
+def onsite(kind, site):
+    return R822.Primitive(kind, (site,))
+
+
+def routed_toffoli(context, routes, first, second, target, bias):
+    output = [onsite("endpoint_H", target)]
+    output += routed_cnot(
+        context, routes, second, target, role="endpoint_Toffoli", bias=bias
+    )
+    output.append(onsite("endpoint_Tdg", target))
+    output += routed_cnot(
+        context, routes, first, target, role="endpoint_Toffoli", bias=bias + 1
+    )
+    output.append(onsite("endpoint_T", target))
+    output += routed_cnot(
+        context, routes, second, target, role="endpoint_Toffoli", bias=bias + 2
+    )
+    output.append(onsite("endpoint_Tdg", target))
+    output += routed_cnot(
+        context, routes, first, target, role="endpoint_Toffoli", bias=bias + 3
+    )
+    output.extend((onsite("endpoint_T", second), onsite("endpoint_T", target)))
+    output.append(onsite("endpoint_H", target))
+    output += routed_cnot(
+        context, routes, first, second, role="endpoint_Toffoli", bias=bias + 4
+    )
+    output.extend((onsite("endpoint_T", first), onsite("endpoint_Tdg", second)))
+    output += routed_cnot(
+        context, routes, first, second, role="endpoint_Toffoli", bias=bias + 5
+    )
+    return output
+
+
+def instrument_words(context, routes):
+    before = []
+    after = []
+    for edge_index, edge in enumerate(context["fixture"].edges):
+        left = context["o_sites"][edge[4]]
+        right = context["o_sites"][edge[5]]
+        du, dv, pointer = context["endpoint_auxiliaries"][edge_index]
+        bias = 1000 + 31 * edge_index
+        pre = []
+        pre += routed_cnot(
+            context, routes, left, du,
+            role="endpoint_prewrite", bias=bias, charged_control=True,
+        )
+        pre += routed_cnot(
+            context, routes, right, dv,
+            role="endpoint_prewrite", bias=bias + 1, charged_control=True,
+        )
+        post = []
+        post += routed_cnot(
+            context, routes, left, du,
+            role="endpoint_postwrite", bias=bias + 2, charged_control=True,
+        )
+        post += routed_cnot(
+            context, routes, right, dv,
+            role="endpoint_postwrite", bias=bias + 3, charged_control=True,
+        )
+        post += routed_cnot(
+            context, routes, du, pointer,
+            role="endpoint_OR", bias=bias + 4,
+        )
+        post += routed_cnot(
+            context, routes, dv, pointer,
+            role="endpoint_OR", bias=bias + 5,
+        )
+        post += routed_toffoli(
+            context, routes, du, dv, pointer, bias + 6
+        )
+        post += routed_cnot(
+            context, routes, pointer, du,
+            role="endpoint_pointer_cleanup", bias=bias + 12,
+        )
+        post += routed_cnot(
+            context, routes, pointer, dv,
+            role="endpoint_pointer_cleanup", bias=bias + 13,
+        )
+        colour = tuple(value % R822.S789.COLOR_MODULUS for value in edge[2])
+        before.append(R822.ScheduledWord(
+            "endpoint_pre", colour, edge[3], edge[2],
+            f"endpoint_pre:{edge_index}", tuple(pre),
+        ))
+        after.append(R822.ScheduledWord(
+            "endpoint_post_or_clean", colour, edge[3], edge[2],
+            f"endpoint_post:{edge_index}", tuple(post),
+        ))
+    return tuple(before), tuple(after)
+
+
+T_GATE = np.diag((1.0, np.exp(0.25j * np.pi))).astype(complex)
+
+
+def primitive_matrix(kind: str) -> np.ndarray:
+    if kind == "endpoint_CNOT":
+        return R822.B.dense_controlled_target(
+            R822.B.pauli_letter(1, "X"), 0, 2
+        )
+    if kind == "endpoint_H":
+        return R822.U720.c707.c655.H
+    if kind == "endpoint_T":
+        return T_GATE
+    if kind == "endpoint_Tdg":
+        return T_GATE.conj().T
+    return R822.primitive_matrix(kind)
+
+
+def combined_parity_certificate(words, charged, neutral):
+    failures = prefix_failures = untyped = tested = 0
+    maximum_residual = 0.0
+    for word in words:
+        prefix_ok = True
+        for primitive in word.primitives:
+            untyped += sum(
+                site not in charged and site not in neutral
+                for site in primitive.sites
+            )
+            local_z = sum(
+                (site in charged) << index
+                for index, site in enumerate(primitive.sites)
+            )
+            parity = R822.B.dense_pauli(
+                R822.Pauli(z=local_z), len(primitive.sites)
+            )
+            matrix = primitive_matrix(primitive.kind)
+            residual = float(np.linalg.norm(matrix @ parity - parity @ matrix))
+            maximum_residual = max(maximum_residual, residual)
+            failed = residual > TOL
+            failures += failed
+            prefix_ok &= not failed
+            prefix_failures += not prefix_ok
+            tested += 1
+    return {
+        "single_global_P_ext": bool(charged) and not (charged & neutral),
+        "elementary_primitives_tested": tested,
+        "elementary_global_P_ext_commutator_failures": failures,
+        "prefix_commutant_certificate_failures": prefix_failures,
+        "primitive_untyped_coordinate_uses": untyped,
+        "maximum_elementary_global_P_ext_commutator_residual": maximum_residual,
+        "P_ext_coordinate_sha256": sha256(repr(tuple(sorted(charged))).encode()).hexdigest(),
+    }
+
+
+def toffoli_decomposition_certificate():
+    H = R822.U720.c707.c655.H
+    CNOT = primitive_matrix("endpoint_CNOT")
+    gates = (
+        (H, (2,)), (CNOT, (1, 2)), (T_GATE.conj().T, (2,)),
+        (CNOT, (0, 2)), (T_GATE, (2,)), (CNOT, (1, 2)),
+        (T_GATE.conj().T, (2,)), (CNOT, (0, 2)), (T_GATE, (1,)),
+        (T_GATE, (2,)), (H, (2,)), (CNOT, (0, 1)),
+        (T_GATE, (0,)), (T_GATE.conj().T, (1,)), (CNOT, (0, 1)),
+    )
+    columns = []
+    for basis_index in range(8):
+        state = np.zeros(8, complex)
+        state[basis_index] = 1.0
+        for matrix, wires in gates:
+            state = R822.U720.c707.apply_gate(state, matrix, wires, 3)
+        columns.append(state)
+    executed = np.column_stack(columns)
+    exact = np.zeros((8, 8), complex)
+    for source in range(8):
+        target = source ^ (
+            ((((source >> 0) & 1) & ((source >> 1) & 1))) << 2
+        )
+        exact[target, source] = 1.0
+    return {
+        "elementary_one_and_two_M2_factors": len(gates),
+        "maximum_matrix_residual": float(np.linalg.norm(executed - exact)),
+    }
+
+
+def combined_word_order(base_words, before, after):
+    prefix = tuple(
+        word for word in base_words
+        if word.stage not in ("recurrent_seam", "recurrent_contact")
+    )
+    seam = tuple(word for word in base_words if word.stage == "recurrent_seam")
+    contact = tuple(word for word in base_words if word.stage == "recurrent_contact")
+    return prefix + before + seam + after + contact
+
+
+def shape_certificate(shape, atlas, *, covariance=False):
+    context = augment_context(R822.local_site_maps(shape, atlas))
+    context, base_routes, base_words, atoms, seams, nonseam, repair = (
+        R822.fixed_typed_compile(context)
+    )
+    routes = list(base_routes)
+    before, after = instrument_words(context, routes)
+    words = combined_word_order(base_words, before, after)
+    type_assignment, charged, neutral = R822.fixed_type_assignment(
+        context, tuple(routes)
+    )
+    graph = R822.collision_graph(words)
+    route = R822.route_certificate(tuple(routes))
+    route["internal_persistent_palette_hits"] = sum(
+        len(set(record.path[1:-1]) & set(context["persistent"]))
+        for record in routes
+    )
+    parity = combined_parity_certificate(words, charged, neutral)
+    primitive_count = sum(len(word.primitives) for word in words)
+    instrument_primitive_count = sum(
+        len(word.primitives) for word in before + after
+    )
+    return {
+        "shape": shape,
+        "cells": len(context["fixture"].cells),
+        "edges": len(context["fixture"].edges),
+        "stage_order": INSTRUMENT_STAGE_ORDER,
+        "stage_labels_are_physical_time": False,
+        "endpoint_palette_collision_failures": context[
+            "endpoint_palette_collision_failures"
+        ],
+        "persistent_endpoint_auxiliary_M2": 3 * len(context["fixture"].edges),
+        "persistent_endpoint_auxiliary_M2_per_edge": 3,
+        "base_route_macros": len(base_routes),
+        "instrument_route_macros": len(routes) - len(base_routes),
+        "expected_instrument_route_macros_per_edge": 14,
+        "base_primitives": sum(len(word.primitives) for word in base_words),
+        "instrument_primitives": instrument_primitive_count,
+        "combined_primitives": primitive_count,
+        "collision_graph": graph,
+        "fixed_type_assignment": type_assignment,
+        "routes": route,
+        "global_P_ext": parity,
+        "base_recurrent_seam": seams,
+        "base_recurrent_nonseam": nonseam,
+        "base_bell_atoms": atoms,
+        "pre_repair_type_audit": repair,
+        "covariance": (
+            R822.covariance_certificate(words, charged, neutral)
+            if covariance else None
+        ),
+    }
+
+
+def main() -> None:
+    started = time.time()
+    algebra = full_seam_algebra_certificate()
+    toffoli = toffoli_decomposition_certificate()
+    atlas = R822.B.P.build_private_atlases()
+    boxes = tuple(
+        shape_certificate(shape, atlas, covariance=(shape == SHAPES[0]))
+        for shape in SHAPES
+    )
+    mass = R822.one_particle_mass_fixture()
+    total_edges = sum(box["edges"] for box in boxes)
+    checks = {
+        "complete_physical_and_target_seams_swap_declared_endpoints": (
+            algebra["matched_physical_target_row_pairs"] == 328
+            and algebra["physical_and_target_signature_classes"] == 1312
+            and algebra["row_endpoint_mask_failures"] == 0
+            and algebra["monomial_full_seam_failures"] == 0
+            and algebra["full_seam_endpoint_swap_failures"] == 0
+        ),
+        "coherent_endpoint_instrument_is_exact_on_clean_domain": (
+            algebra["instrument_clean_domain_cases"] == 1312
+            and algebra["instrument_isometry_failures"] == 0
+            and algebra["maximum_instrument_isometry_residual"] < TOL
+            and toffoli["maximum_matrix_residual"] < TOL
+        ),
+        "hostile_algebra_mutations_are_active": all(
+            algebra[key] == 2 * total_edges for key in (
+                "factor_deletion_trials_detected",
+                "single_endpoint_mutation_trials_detected",
+                "OR_Toffoli_deletion_trials_detected",
+                "pointer_cleanup_deletion_trials_detected",
+            )
+        ) and algebra[
+            "old_Cycle713_swap_specific_cleanup_equivalence_failures"
+        ] == 0,
+        "three_neutral_M2_per_edge_are_collision_free_and_locally_typed": all(
+            box["endpoint_palette_collision_failures"] == 0
+            and box["persistent_endpoint_auxiliary_M2"] == 3 * box["edges"]
+            and box["fixed_type_assignment"]["charged_neutral_coordinate_overlap"] == 0
+            and box["fixed_type_assignment"]["neutral_route_fixed_type_failures"] == 0
+            for box in boxes
+        ),
+        "all_instrument_routes_are_returned_nearest_neighbour_and_bounded": all(
+            box["instrument_route_macros"]
+                == box["expected_instrument_route_macros_per_edge"] * box["edges"]
+            and box["routes"]["nearest_neighbour_failures"] == 0
+            and box["routes"]["returned_label_failures"] == 0
+            and box["routes"]["internal_persistent_palette_hits"] == 0
+            and box["routes"]["routes_with_active_return_deletion_control"] > 0
+            for box in boxes
+        ),
+        "fixed_stage_colour_slot_schedule_has_no_collisions": all(
+            box["collision_graph"]["edges"] == 0 for box in boxes
+        ),
+        "one_single_global_parity_operator_survives_every_prefix": all(
+            box["global_P_ext"]["single_global_P_ext"]
+            and box["global_P_ext"]["elementary_global_P_ext_commutator_failures"] == 0
+            and box["global_P_ext"]["prefix_commutant_certificate_failures"] == 0
+            and box["global_P_ext"]["primitive_untyped_coordinate_uses"] == 0
+            and box["global_P_ext"]["maximum_elementary_global_P_ext_commutator_residual"] < TOL
+            for box in boxes
+        ),
+        "proper_cubic_transport_and_all_products_preserve_the_program": all(
+            boxes[0]["covariance"][key] == 0 for key in (
+                "context_nearest_neighbour_failures",
+                "context_palette_bijection_failures",
+                "context_collision_graph_failures",
+                "context_fixed_type_assignment_failures",
+                "colour_transport_bijection_failures",
+                "product_coordinate_failures",
+                "product_colour_failures",
+            )
+        ),
+        "one_particle_mass_and_contact_fixture_is_unchanged": (
+            mass["one_particle_mass_residual"] < TOL
+            and mass["one_particle_coin_eigen_residual"] < TOL
+            and mass["contact_vacuum_and_one_particle_residual"] < TOL
+            and mass["contact_double_occupation_phase_residual"] < TOL
+        ),
+        "pointer_scope_is_not_promoted_to_time_Record_Born_or_source": True,
+    }
+    inventory = {
+        "derived": (
+            "complete four-factor companion seam swaps its declared matter endpoints",
+            "three-neutral-M2 coherent XOR/OR pointer with clean returned scratch",
+            "14 returned nearest-neighbour route macros per edge",
+            "same fixed P_ext, proper-cubic transported program, and held-shape closure",
+        ),
+        "supplied": (
+            "Cycle822 finite offline route atlas and fixed stage/colour/slot program",
+            "clean endpoint auxiliaries and neutral route inputs",
+            "Cycle720 companion code sector and total-parity superselection label",
+            "finite box shape, coframe, bank genesis, and occurrence of the update",
+        ),
+        "open": (
+            "translation-local query-free atlas generation or intrinsic recurrent law",
+            "autonomous clean-auxiliary genesis/enforcement and update occurrence",
+            "actuality/admissibility, irreversible Record, Born weighting, and realized history",
+            "physical causal-time attachment, conserved source/gravity response, and prediction bridge",
+        ),
+    }
+    report = {
+        "cycle": 823,
+        "status": (
+            "cycle823-companion-full-seam-endpoint-instrument-bounded-positive"
+            if all(checks.values())
+            else "cycle823-failed"
+        ),
+        "authority": "none",
+        "audit": "unset",
+        "claim_scope": (
+            "finite held-box coherent endpoint-opportunity instrument on the "
+            "landed Cycle822 companion seam; not an autonomous occurrence law"
+        ),
+        "algebra": algebra,
+        "toffoli_decomposition": toffoli,
+        "boxes": boxes,
+        "one_particle_mass_fixture": mass,
+        "checks": checks,
+        "inventory": inventory,
+        "source_sha256": {
+            path: digest(ROOT / path)
+            for path in AUDIT_INPUT_PATHS
+            if (ROOT / path).is_file()
+        },
+        "runtime_seconds": time.time() - started,
+    }
+    print(json.dumps(
+        report,
+        indent=2,
+        sort_keys=True,
+        default=lambda value: value.item()
+        if isinstance(value, np.generic)
+        else str(value),
+    ))
+    for label, passed in checks.items():
+        print(f"CHECK {label}: {'PASS' if passed else 'FAIL'}")
+    if not all(checks.values()):
+        raise SystemExit(1)
+    print("CYCLE823_COMPANION_FULL_SEAM_ENDPOINT_INSTRUMENT_BOUNDED_EXACT_PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py
+++ b/scripts/frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py
@@ -727,7 +727,6 @@ def main() -> None:
             and mass["contact_vacuum_and_one_particle_residual"] < TOL
             and mass["contact_double_occupation_phase_residual"] < TOL
         ),
-        "pointer_scope_is_not_promoted_to_time_Record_Born_or_source": True,
     }
     inventory = {
         "derived": (

--- a/scripts/frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py
+++ b/scripts/frontier_cycle823_companion_full_seam_endpoint_instrument_2026_07_30.py
@@ -185,6 +185,7 @@ def expected_instrument_output(
 
 def full_seam_algebra_certificate() -> dict[str, object]:
     row_pairs = signature_classes = instrument_cases = 0
+    row_cardinality_failures = 0
     row_mask_failures = swap_failures = monomial_failures = 0
     instrument_failures = 0
     maximum_instrument_residual = 0.0
@@ -201,6 +202,9 @@ def full_seam_algebra_certificate() -> dict[str, object]:
             endpoint_mask = (1 << left) | (1 << right)
             physical_rows = fixture.physical_terms(edge_index)
             target_rows = fixture.target_terms(edge_index)
+            row_cardinality_failures += (
+                len(physical_rows) != 4 or len(target_rows) != 4
+            )
             row_pairs += len(physical_rows)
             for factor, (physical, target) in enumerate(
                 zip(physical_rows, target_rows)
@@ -306,6 +310,7 @@ def full_seam_algebra_certificate() -> dict[str, object]:
     return {
         "held_shapes": len(SHAPES),
         "matched_physical_target_row_pairs": row_pairs,
+        "four_plus_four_row_cardinality_failures": row_cardinality_failures,
         "physical_and_target_signature_classes": signature_classes,
         "monomial_full_seam_failures": monomial_failures,
         "full_seam_endpoint_swap_failures": swap_failures,
@@ -654,7 +659,7 @@ def main() -> None:
     toffoli = toffoli_decomposition_certificate()
     atlas = R822.B.P.build_private_atlases()
     boxes = tuple(
-        shape_certificate(shape, atlas, covariance=(shape == SHAPES[0]))
+        shape_certificate(shape, atlas, covariance=True)
         for shape in SHAPES
     )
     mass = R822.one_particle_mass_fixture()
@@ -662,6 +667,7 @@ def main() -> None:
     checks = {
         "complete_physical_and_target_seams_swap_declared_endpoints": (
             algebra["matched_physical_target_row_pairs"] == 328
+            and algebra["four_plus_four_row_cardinality_failures"] == 0
             and algebra["physical_and_target_signature_classes"] == 1312
             and algebra["row_endpoint_mask_failures"] == 0
             and algebra["monomial_full_seam_failures"] == 0
@@ -687,7 +693,11 @@ def main() -> None:
             box["endpoint_palette_collision_failures"] == 0
             and box["persistent_endpoint_auxiliary_M2"] == 3 * box["edges"]
             and box["fixed_type_assignment"]["charged_neutral_coordinate_overlap"] == 0
+            and box["fixed_type_assignment"]["FSWAP_endpoint_type_failures"] == 0
+            and box["fixed_type_assignment"]["neutral_route_source_type_failures"] == 0
+            and box["fixed_type_assignment"]["charged_route_fixed_type_failures"] == 0
             and box["fixed_type_assignment"]["neutral_route_fixed_type_failures"] == 0
+            and box["fixed_type_assignment"]["persistent_type_partition_failures"] == 0
             for box in boxes
         ),
         "all_instrument_routes_are_returned_nearest_neighbour_and_bounded": all(
@@ -711,7 +721,9 @@ def main() -> None:
             for box in boxes
         ),
         "proper_cubic_transport_and_all_products_preserve_the_program": all(
-            boxes[0]["covariance"][key] == 0 for key in (
+            box["covariance"][key] == 0
+            for box in boxes
+            for key in (
                 "context_nearest_neighbour_failures",
                 "context_palette_bijection_failures",
                 "context_collision_graph_failures",
@@ -721,7 +733,7 @@ def main() -> None:
                 "product_colour_failures",
             )
         ),
-        "one_particle_mass_and_contact_fixture_is_unchanged": (
+        "inherited_one_particle_mass_and_contact_regression_is_rerun": (
             mass["one_particle_mass_residual"] < TOL
             and mass["one_particle_coin_eigen_residual"] < TOL
             and mass["contact_vacuum_and_one_particle_residual"] < TOL
@@ -746,6 +758,7 @@ def main() -> None:
             "autonomous clean-auxiliary genesis/enforcement and update occurrence",
             "actuality/admissibility, irreversible Record, Born weighting, and realized history",
             "physical causal-time attachment, conserved source/gravity response, and prediction bridge",
+            "a composed matter-only mass/contact theorem after retaining or discarding the pointer",
         ),
     }
     report = {


### PR DESCRIPTION
## Claim\n\nBounded theorem: on four held finite boxes, the complete four-factor Cycle-720/822 companion seam swaps its declared matter endpoints on all 1,312 reachable physical/target phase classes. Three neutral physical M2 per edge coherently expose p = a xor b, return both scratch registers, preserve one rebuilt P_ext, and use only returned nearest-neighbour routes.\n\n## Exact evidence\n\n- 82 edges; 328 matched physical/target row pairs; 1,312 exhaustive signature replays\n- zero row-mask, monomial, endpoint-swap, scratch, pointer, collision, typing, untyped-use, elementary-parity, or prefix-parity failures\n- 14 returned CNOT route macros per edge; maximum held route distance 43\n- exact 15-factor one/two-M2 Toffoli decomposition, residual 7.35e-16\n- 24 proper-cubic frames, eight origins, 576 ordered products under transported-program covariance\n- one-particle mass residual unchanged at 5.55e-17\n- factor deletion, single-endpoint mutation, OR deletion, pointer-cleanup deletion, dirty-domain, held-size, and route-return controls\n\n## Boundary\n\nThe retained bit is a reversible endpoint-opportunity pointer, not occurrence, actuality, admission, Record, Born weight, source, clock, duration, or rate. Pointer consume/reset or a fresh bank, clean genesis, autonomous occurrence, translation-local atlas generation, target-native frame recompilation, source/gravity response, Record/Born selection, and prediction attachment remain open. This is a one-use finite supplied-program result, not a recurrent reset law or unbounded compiler theorem.\n\nAuthority: none. Audit: unset. Please use review-loop; independent audit remains separate.