### PR TITLE
feat(gravity): cycle 707 — source-stabilizer coset collapse of the K sign law

### DIFF
--- a/docs/PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01.md
+++ b/docs/PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01.md
@@ -1,0 +1,330 @@
+# The all-24 frame sign law of the source-driven K field, derived by source-stabilizer coset collapse — Cycle 707
+
+Date: 2026-08-01
+
+Claim type: bounded_theorem
+
+Authority: none. Audit: unset. Constitutional effect: none. This cycle edits no
+axiom, foundation, Qualification, primitive, registry, policy, queue,
+audit-status, or PR-control surface. No new axiom or primitive is proposed or
+adopted.
+
+No coupling value, sign, or scale is selected or derived in this cycle; every
+such object is named as supplied.
+
+The frame sign behaviour of the un-averaged, source-driven endpoint field `K` is
+derived here as a composition of two exactly executed statements. First, a
+**pointwise** transport law holds on the constant-sign signed permutations and
+only there: for a frame whose nonzero entries all share one sign, the coframe
+conjugates, the per-axis parts permute with that common sign, and `K` carries the
+common sign at every site, with measured floors `6.1e-15` on the all-plus branch
+and `1.5e-11` on the all-minus branch at `L = 3`. Second, **every** proper
+rotation's image of the single-edit source domain collapses exactly onto a
+constant-sign representative's image, because the source's own proper stabilizer
+is the four-element rotation quartet about the edited axis and each coset of that
+quartet contains exactly one constant-sign element. The all-24 multiset sign law
+`multiset(K^{g.dom}) = multiset(sx(g) K^{dom})` is therefore a corollary of the
+pointwise law rather than an independent measurement, with the `12 / 12` split of
+`chi(g) = sx(g)` derived from the coset structure. The mixed-sign obstruction is
+real and is measured at the coframe stage, not assumed: the minimum over the 18
+mixed proper rotations of the coframe-conjugation defect is `2.4e-01` at `L = 3`
+and `6.3e-01` at `L = 7`. Finally, a stage ladder locates the reflection floor:
+the source multiset is bit-exact, the assembled load multiset agrees at `2.1e-14`,
+and the response multiset already carries `6.9e-11`, so the negation floor enters
+at the linear-response solve, and the endpoint defect is linear in the amplitude
+dial with successive ratios `2.0e+00` and `2.0e+00` over `AMP` `0.05 / 0.10 / 0.20`.
+
+## Improper-frame framing
+
+The runner also executes the six constant-sign signed permutations with
+determinant `-1`. These are bookkeeping, not physics:
+improper (det = -1) signed permutations are NOT axiom symmetries
+— the LATTICE axiom names proper cubic rotations only. They enter this note ONLY
+as derived computational identities of the compiled chain (exact relabelings
+composed with the reflection asymmetry measured here), and
+every physical frame-scope statement in this note is over the 24 proper rotations.
+Nothing in this cycle enlarges the framework's symmetry group, and no statement
+below counts elements outside the 24.
+
+## Setup
+
+The compiled chain is the landed Cycle-696 open-coframe endpoint compiler
+`scripts/physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py`, used
+verbatim and never re-implemented:
+
+```
+rho = c696.rho_vector(dom, model["site_index"])
+b   = rho @ model["G"]
+eps = c696.response(model, sol, b)["eps"]
+mc  = c696.metric_and_coframe(L, AMP * eps, model["index"])
+kf  = c696.k_field(mc["e_clipped"])
+```
+
+with `model = c696.assemble_static_hessian(L, wrap=False)` and
+`sol = c696.sector_solve(model)`. `k_field` returns the per-axis parts stacked on
+a trailing axis together with their sum `K`; the parts are the objects that carry
+the transformation law, and the whole of Claim C1 is a statement about them.
+
+Two decorated source domains are used at each box size `L` in `(3, 7)`, with
+`A = (L-1)//2` and the response amplitude `AMP = 2.0e-01`:
+
+- `dom0` (called x5): `edits = {((A,A,A),(A+1,A,A)): 5}`, a single relabelled link
+  on the `+x` ray;
+- `dom1` (called x5y7): the same edit together with
+  `((A,A,A),(A,A+1,A)): 7` on the `+y` ray.
+
+Frames are `c696.c576.FRAMES`, the 24 proper cubic rotations. The site action is
+`c696.frame_site_map(L, R)`, the exact affine map `s -> R(s - c) + c`; the
+decorated action on a domain is `c696.apply_frame_to_domain(dom, R)`, which maps
+sites, links, anchor, ports, and ray directions together.
+
+Signed-permutation conventions. For a frame `R`, `p[i] = argmax|R[i]|` is the
+permutation word and `s[i] = R[i, p[i]]` the sign word; `sx` is the sign attached
+to the `x` axis, `sx = s[p.index(0)]`, and `sy = s[p.index(1)]` likewise. A frame
+is **constant-sign** when every nonzero entry shares one sign, which is exactly
+the condition under which the landed `frame_K_parity` returns `+1` or `-1` rather
+than `None`. Of the 24 proper rotations, 6 are constant-sign — 3 all-plus and
+3 all-minus — and 18 are mixed.
+
+## Claims
+
+### C1 — the constant-sign pointwise transport law, and its two floors
+
+For every constant-sign signed permutation `R` with common sign `eps_R`, and at
+every site `x`, with `sigma = frame_site_map(L, R)`:
+
+```
+e^{R.dom}(sigma x)       = R e^{dom}(x) R^T
+parts_i^{R.dom}(sigma x) = eps_R * parts_{p[i]}^{dom}(x)
+K^{R.dom}(sigma x)       = eps_R * K^{dom}(x)
+```
+
+The coframe relation is sign-blind, since `s_i s_j = +1` entrywise on a
+constant-sign frame, while the parts relation carries the sign once and `K`
+inherits it. Measured as the maximum over sites of the largest of the coframe,
+parts, and `K` defects, and then over the frames of each branch (6 proper plus
+6 improper constant-sign elements):
+
+| branch | `L = 3` | `L = 7` |
+|---|---|---|
+| all-plus | `6.1e-15` | `4.6e-13` |
+| all-minus | `1.5e-11` | `3.1e-10` |
+| identity frame | `0.0e+00` | `0.0e+00` |
+
+The identity frame's total defect is exactly zero, bit-for-bit, at both box
+sizes. The minus-branch magnitudes are identical across all six minus elements,
+proper and improper alike: the six are related to one another by the exactly
+equivariant plus subgroup, so they share one reflection asymmetry rather than six
+independent ones. The branch asymmetry is gated directly — the minus floor
+exceeds ten times the plus floor by measured factors `2.5e+03` at `L = 3` and
+`6.7e+02` at `L = 7`.
+
+### C2 — the mixed-sign obstruction is real, at the coframe stage
+
+Every mixed-sign proper rotation breaks the coframe conjugation relation
+outright. The minimum over the 18 mixed proper rotations of the max-site coframe
+defect measures `2.4e-01` at `L = 3` and `6.3e-01` at `L = 7`. There is no
+pointwise law to floor there: the `None` region of the landed `frame_K_parity` is
+the true absence of a law, not a weaker version of one. This reproduces, at the
+coframe stage and from the un-averaged source-driven field, the landed six-frame
+restriction of the single-carrier transport rows.
+
+### C3 — the source's stabilizer quartet, its transversal, and `sx` invariance
+
+All of C3 is exact integer and link-dictionary computation, independent of `L`
+and of every floating-point stage.
+
+- The proper stabilizer of `dom0` by link-dictionary equality is the frame set
+  `(20, 21, 22, 23)` — four elements.
+- Those four are exactly the four powers of the `x`-axis rotation
+  `[[1,0,0],[0,0,-1],[0,1,0]]`, verified as a set of integer matrices.
+- Every proper rotation `g` has **exactly one** quartet element `t` with `g t`
+  constant-sign: `24/24`.
+- `sx(g t) = sx(g)` for every proper `g` and every quartet element `t`: `96/96`.
+  The quartet fixes the `x` axis with sign `+1`, so composing with it cannot move
+  the `x` sign.
+
+### C4 — exact coset collapse, and the all-24 multiset law as a corollary
+
+Because each quartet element fixes `dom0` exactly, the decorated image of `g` and
+of its constant-sign coset representative `g t` are the *same* domain:
+
+- link-dictionary equality `g.dom0 == (g t).dom0` holds `24/24` at `L = 3` and
+  `24/24` at `L = 7`;
+- the number of distinct domain images over the 24 frames is exactly `6`, which
+  is `24` divided by the four-element quartet;
+- on one representative per distinct image, the compiled `K` arrays of
+  `chain(g.dom0)` and `chain((g t).dom0)` are bit-identical, `6/6` at `L = 3`.
+  That row is chain determinism, stated as such: equal link states produce equal
+  arrays, which is what licenses transporting the pointwise law from the
+  representative to `g`.
+
+Consequently the all-24 multiset law
+`multiset(K^{g.dom0}) = multiset(sx(g) K^{dom0})` follows from C1 rather than
+standing on its own measurement. Measured multiset defects, maximum over the
+frames of each sign class:
+
+| `chi(g) = sx(g)` | count | `L = 3` | `L = 7` |
+|---|---|---|---|
+| `+1` | 12 | `4.8e-15` | `3.8e-13` |
+| `-1` | 12 | `1.0e-11` | `3.1e-10` |
+
+The `12 / 12` split is derived: `sx` is constant on quartet cosets by C3, and
+each coset carries exactly one constant-sign representative whose common sign is
+its `sx`. Two rejectors keep the rows discriminating. Testing the pointwise law
+on an all-minus frame with the sign forced to `+1` gives a `K` defect of
+`6.7e-01` at `L = 3` and `9.9e-01` at `L = 7`. Comparing an all-minus frame's
+multiset against the unsigned base gives `2.1e-01` at `L = 3`; the same quantity
+prints `4.1e-02` at `L = 7` and is reported unscored there.
+
+### C5 — the two-edit trichotomy, derived
+
+For `dom1` the mirror `m_z = diag(1, 1, -1)` fixes the domain exactly, by link
+dictionary, at both box sizes. Writing `u = g` when `g` is constant-sign and
+`u = g m_z` otherwise, `u` is constant-sign exactly when `(sx, sy)` lies in
+`{(+,+), (-,-)}`, and the sign classes count `6 / 6 / 12`. On those 12 frames the
+collapse is again exact: `12/12` frames have a constant-sign coset member, and
+`12/12` satisfy `g.dom1 == u.dom1` as link dictionaries, at both box sizes. The
+resulting trichotomy is therefore derived rather than tabulated:
+
+| class | count | behaviour | `L = 3` | `L = 7` |
+|---|---|---|---|---|
+| `(+,+)` | 6 | preserved | `9.5e-15` | `9.7e-13` |
+| `(-,-)` | 6 | negated | `9.7e-11` | `5.5e-10` |
+| mixed `(sx, sy)` | 12 | broken | `1.9e-01` | `1.0e-01` |
+
+The broken-class entry is the minimum over those 12 frames of the smaller of the
+two compare-sign multiset defects, so no choice of overall sign rescues them.
+This derives the landed `6 / 6 / 12` classification of the same field.
+
+### C6 — where the floor lives, and how it scales with the dial
+
+The ladder is run for one all-minus proper rotation against one all-plus
+three-cycle rotation, comparing sorted multisets stage by stage:
+
+| stage | all-minus `L = 3` | all-plus `L = 3` | all-minus `L = 7` | all-plus `L = 7` |
+|---|---|---|---|---|
+| `rho` | `0.0e+00` | `0.0e+00` | `0.0e+00` | `0.0e+00` |
+| `b` | `2.1e-14` | `2.9e-15` | `1.0e-14` | `1.8e-15` |
+| `eps` | `6.9e-11` | `9.8e-15` | `1.5e-09` | `1.5e-12` |
+
+The source multiset is bit-exact and the assembled load multiset matches at the
+`1e-14` level, while the response multiset already carries the whole defect —
+the negation floor enters at the linear-response solve, and no later stage
+amplifies it. The metric stage inherits it through the amplitude dial alone: the
+per-site sorted edge-length defect measures `1.4e-11` at `L = 3` against the
+predicted `AMP * d_eps = 1.4e-11`, a product identity gated at half the predicted
+value. At `L = 7` the same length defect prints `2.7e-10` and is reported
+unscored. The endpoint consequence is amplitude-linearity of the negation floor:
+the all-minus multiset defect measures `2.5e-12`, `4.9e-12`, `1.0e-11` at `AMP`
+`0.05`, `0.10`, `0.20`, with successive ratios `2.0e+00` and `2.0e+00`.
+
+## Derivation sketch
+
+The argument has three finite steps, each verified exactly by finite computation
+in the runner using integer matrices and link-dictionary equality.
+
+1. *Every quartet element fixes the source.* The edited link lies on the `+x`
+   ray. A rotation about the `x` axis fixes the anchor and the `+x` direction, so
+   it fixes the edited link and permutes the remaining rays among themselves;
+   those rays carry one common weight, so the link dictionary comes back
+   unchanged. Hence `t.dom0 = dom0` for all four `t`, and therefore
+   `g.dom0 = (g t).dom0` for every proper `g` and every `t` — the decorated action
+   is an action, so applying `g` to equal states gives equal states.
+
+2. *Exactly one coset member is constant-sign.* At fixed `sx`, the quartet's four
+   elements realize the four sign patterns available on the `(y, z)` block while
+   leaving the `x` sign alone. Composing `g` with the quartet therefore sweeps
+   those four patterns and reaches the all-same-sign pattern exactly once. This is
+   the `24/24` transversal row of C3, and it is what makes the coset
+   representative unique rather than merely existent.
+
+3. *The invariant is `sx`.* Each quartet element carries `sx = +1`, so `sx` is
+   constant along each coset (the `96/96` row of C3). The unique constant-sign
+   representative's common sign is its own `sx`, which is `sx(g)`. Composing step
+   1 with C1 at the representative gives the multiset statement for `g` itself,
+   with sign `chi(g) = sx(g)`.
+
+Steps 1 and 3 are exact. The only floating-point content in the final statement
+is the floor inherited from C1, which is why C6 locates that floor rather than
+leaving it as an unexplained residue.
+
+## Honest boundary
+
+- The all-plus branch is exactly equivariant to within accumulation noise; the
+  all-minus branch is not, and the size of its floor — `1.5e-11` at `L = 3`,
+  `3.1e-10` at `L = 7` — together with its growth in `L` is
+  measured, not derived. No constant is fitted anywhere in this cycle, and none
+  is claimed.
+- The magnitude of the mixed-sign breakage is likewise measured, not derived. The
+  statement that is derived is its *scope*: the law holds on constant-sign frames
+  and nowhere else, which the `frame_K_parity` biconditional gates in both
+  directions at both box sizes.
+- Improper elements are computational identities of the compiled chain only, per
+  the framing section above.
+- The collapse mechanism is specific to these two source domains and their
+  stabilizers. A classification of stabilizers and collapse behaviour for general
+  edit sets is not attempted here and is named as a next route below.
+- Nothing in this cycle touches the amplitude dial's status, the response
+  normalization, or any coupling; `AMP` is a supplied nuisance scale and the
+  linearity row of C6 is a statement about it, not a derivation of it.
+
+## The next paths opened
+
+- **Derive the response-stage reflection floor constant.** C6 localizes the
+  defect to the `b -> eps` solve; the next path opened is to characterize the
+  constant itself from the open-box static operator and its sector
+  regularization, turning a measured floor into a derived one.
+- **Classify stabilizers and collapse for general edit sets.** The quartet and
+  the mirror are the stabilizers of two particular sources. The next path opened
+  is a general statement: for which edit sets does the stabilizer meet every
+  coset of the constant-sign subgroup, and what replaces the multiset law when it
+  does not.
+- **Derive the `L`-scaling of the two branch floors.** The plus branch moves from
+  `6.1e-15` to `4.6e-13` and the minus branch from `1.5e-11` to `3.1e-10` between
+  `L = 3` and `L = 7`; the next path opened is a scaling law for both, which would
+  also predict the mixed-sign breakage's mild decrease.
+
+## Relation to the sibling cycles
+
+The orbit-averaged all-24 carrier transport law of cycle 705
+(`PHYSICAL_ORBIT_AVERAGED_K_ENDPOINT_TRANSPORT_D3_SELECTION_CYCLE705_NOTE_2026-08-01.md`)
+concerns the AVERAGED carrier, whereas this note concerns the un-averaged
+source-driven `K` field, whose all-24 law arises by coset collapse instead. The
+frame classification measured in cycle 706
+(`PHYSICAL_ENDPOINT_READOUT_QUBIT_STINESPRING_CHANNEL_CYCLE706_NOTE_2026-08-01.md`)
+— the `12` plus / `12` minus single-axis split, the `6 / 6 / 12` two-axis
+trichotomy, and the `1.0e-11` negation floor — is here derived in its counts and
+located in its floor stage. Both sibling notes are unaudited open work, which is
+why they appear in backticks here rather than as links.
+
+## Runner
+
+`scripts/physical_source_stabilizer_coset_collapse_k_sign_law_cycle707_2026_08_01.py`
+executes every row above and reports
+
+```
+TOTAL: PASS=71 FAIL=0
+```
+
+with exit code `0`, `3483` characters of standard output, and a wall clock of
+about `5.8` seconds on the development machine. Two consecutive runs produce
+byte-identical standard output and a byte-identical receipt. The receipt is
+written to
+`outputs/physical_source_stabilizer_coset_collapse_k_sign_law_cycle707_2026_08_01_receipt_2026-08-01.json`
+and carries no timestamp, no wall clock, no host name, and no absolute path, so
+it is comparable across machines.
+
+Every number quoted in this note is the runner's own measurement in the run that
+produced that `TOTAL` line; none is copied from an earlier probe.
+
+## Citations
+
+- [Minimal axioms](MINIMAL_AXIOMS_2026-06-29.md)
+- [Cycle 700](PHYSICAL_OPERATIONAL_SOURCE_RESPONSE_READOUT_CHAIN_CYCLE700_NOTE_2026-07-25.md)
+- [joined-compiler tournament note](work_history/repo/review_feedback/PHYSICAL_OPEN_COFRAME_K_ENDPOINT_JOINED_COMPILER_TOURNAMENT_NOTE_2026-07-23.md)
+
+Cycle 700 and the joined-compiler tournament note are landed. Backticked context
+only, with no links: `physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py`,
+`PHYSICAL_ORBIT_AVERAGED_K_ENDPOINT_TRANSPORT_D3_SELECTION_CYCLE705_NOTE_2026-08-01.md`,
+and `PHYSICAL_ENDPOINT_READOUT_QUBIT_STINESPRING_CHANNEL_CYCLE706_NOTE_2026-08-01.md`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15386,
- "node_count": 4622,
+ "edge_count": 15389,
+ "node_count": 4623,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -10497,6 +10497,10 @@
   "physical_record_readout_carrier_three_way_split_cycle693_note_2026-07-25": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
+  },
+  "physical_source_stabilizer_coset_collapse_k_sign_law_cycle707_note_2026-08-01": {
+   "deps_hash": "ef9523891aaa",
+   "out_degree": 3
   },
   "physics_critic_tracker": {
    "deps_hash": "8ed7e6bfb298",

--- a/outputs/physical_source_stabilizer_coset_collapse_k_sign_law_cycle707_2026_08_01_cold_2026-08-01.txt
+++ b/outputs/physical_source_stabilizer_coset_collapse_k_sign_law_cycle707_2026_08_01_cold_2026-08-01.txt
@@ -1,0 +1,78 @@
+c707 source-stabilizer coset collapse of the compiled K sign law
+24 proper rotations, 6 improper constant-sign identities, AMP 2.0e-01
+-- L=3 --
+PASS G1.L3.p01 cs -1 e 1.5e-11 p 1.3e-11 K 1.0e-11
+PASS G1.L3.p04 cs -1 e 1.5e-11 p 1.3e-11 K 1.0e-11
+PASS G1.L3.p09 cs -1 e 1.5e-11 p 1.3e-11 K 1.0e-11
+PASS G1.L3.p15 cs +1 e 4.6e-15 p 4.8e-15 K 4.9e-15
+PASS G1.L3.p18 cs +1 e 4.4e-15 p 5.1e-15 K 6.1e-15
+PASS G1.L3.p23 cs +1 e 0.0e+00 p 0.0e+00 K 0.0e+00
+PASS G1.L3.i0 cs -1 e 1.5e-11 p 1.3e-11 K 1.0e-11
+PASS G1.L3.i1 cs +1 e 2.8e-15 p 4.2e-15 K 5.9e-15
+PASS G1.L3.i2 cs +1 e 4.6e-15 p 4.8e-15 K 4.8e-15
+PASS G1.L3.i3 cs -1 e 1.5e-11 p 1.3e-11 K 1.0e-11
+PASS G1.L3.i4 cs -1 e 1.5e-11 p 1.3e-11 K 1.0e-11
+PASS G1.L3.i5 cs +1 e 2.8e-15 p 2.6e-15 K 2.8e-15
+PASS G1.L3.id identity total defect 0.0e+00
+PASS G2.L3 minus/plus floor 2.5e+03
+PASS G3.L3 mixed min d_e 2.4e-01 over 18 frames
+PASS G4.L3.cs parity not None -> law 6/6
+PASS G4.L3.mix parity None -> no law 18/18
+PASS G4.L3.imp improper det -1 parity match 6/6
+PASS G4.L3.rej wrong-sign d_K 6.7e-01
+PASS G5.stab proper stabilizer of x5 (20, 21, 22, 23)
+PASS G5.c4 quartet = powers of the x-axis rotation
+PASS G5.transversal exactly one constant-sign coset member 24/24
+PASS G5.sx sx coset-invariant 96/96
+PASS G6.L3.collapse link-dict equality g.dom == (g t).dom 24/24
+PASS G6.L3.images distinct domain images 6
+PASS G6.L3.determinism chain determinism on collapsed pairs 6/6
+PASS G7.L3.plus chi=+1 multiset max 4.8e-15
+PASS G7.L3.minus chi=-1 multiset max 1.0e-11
+PASS G7.L3.counts chi split 12/12
+PASS G7.L3.rej plus-compare on a minus frame 2.1e-01
+PASS G8.L3.rho.minus d_rho 0.0e+00
+PASS G8.L3.rho.plus d_rho 0.0e+00
+PASS G8.L3.b.minus d_b 2.1e-14
+PASS G8.L3.b.plus d_b 2.9e-15
+PASS G8.L3.eps.minus d_eps 6.9e-11 over 100 d_b 2.1e-12
+PASS G8.L3.eps.plus d_eps 9.8e-15
+PASS G8.L3.len d_len 1.4e-11 vs AMP d_eps 1.4e-11
+PASS G9.L3.r1 d 2.5e-12 4.9e-12 ratio 2.0e+00
+PASS G9.L3.r2 d 1.0e-11 ratio 2.0e+00
+PASS G10.L3.mz m_z = diag(1,1,-1) fixes x5y7
+PASS G10.L3.classes pp/mm/broken 6/6/12
+PASS G10.L3.collapse coset 12/12 link-equal 12/12
+PASS G10.L3.pp pp multiset max 9.5e-15
+PASS G10.L3.mm mm multiset max 9.7e-11
+PASS G10.L3.broken broken min over both compare signs 1.9e-01
+-- L=7 --
+PASS G1.L7.plus branch max over 6 frames 4.6e-13
+PASS G1.L7.minus branch max over 6 frames 3.1e-10
+PASS G1.L7.id identity total defect 0.0e+00
+PASS G2.L7 minus/plus floor 6.7e+02
+PASS G3.L7 mixed min d_e 6.3e-01 over 18 frames
+PASS G4.L7.cs parity not None -> law 6/6
+PASS G4.L7.mix parity None -> no law 18/18
+PASS G4.L7.imp improper det -1 parity match 6/6
+PASS G4.L7.rej wrong-sign d_K 9.9e-01
+PASS G6.L7.collapse link-dict equality g.dom == (g t).dom 24/24
+PASS G6.L7.images distinct domain images 6
+PASS G7.L7.plus chi=+1 multiset max 3.8e-13
+PASS G7.L7.minus chi=-1 multiset max 3.1e-10
+PASS G7.L7.counts chi split 12/12
+note G7.L7 plus-compare on a minus frame 4.1e-02 unscored
+PASS G8.L7.rho.minus d_rho 0.0e+00
+PASS G8.L7.rho.plus d_rho 0.0e+00
+PASS G8.L7.b.minus d_b 1.0e-14
+PASS G8.L7.b.plus d_b 1.8e-15
+PASS G8.L7.eps.minus d_eps 1.5e-09 over 100 d_b 1.0e-12
+PASS G8.L7.eps.plus d_eps 1.5e-12
+note G8.L7 minus d_len 2.7e-10 unscored
+PASS G10.L7.mz m_z = diag(1,1,-1) fixes x5y7
+PASS G10.L7.classes pp/mm/broken 6/6/12
+PASS G10.L7.collapse coset 12/12 link-equal 12/12
+PASS G10.L7.pp pp multiset max 9.7e-13
+PASS G10.L7.mm mm multiset max 5.5e-10
+PASS G10.L7.broken broken min over both compare signs 1.0e-01
+TOTAL: PASS=71 FAIL=0

--- a/outputs/physical_source_stabilizer_coset_collapse_k_sign_law_cycle707_2026_08_01_receipt_2026-08-01.json
+++ b/outputs/physical_source_stabilizer_coset_collapse_k_sign_law_cycle707_2026_08_01_receipt_2026-08-01.json
@@ -1,0 +1,305 @@
+{
+  "amp": "2.0e-01",
+  "amp_ladder": [
+    "5.0e-02",
+    "1.0e-01",
+    "2.0e-01"
+  ],
+  "box_sizes": [
+    3,
+    7
+  ],
+  "fail": 0,
+  "gates": {
+    "G1.L3.i0": {
+      "detail": "cs -1 e 1.5e-11 p 1.3e-11 K 1.0e-11",
+      "pass": true
+    },
+    "G1.L3.i1": {
+      "detail": "cs +1 e 2.8e-15 p 4.2e-15 K 5.9e-15",
+      "pass": true
+    },
+    "G1.L3.i2": {
+      "detail": "cs +1 e 4.6e-15 p 4.8e-15 K 4.8e-15",
+      "pass": true
+    },
+    "G1.L3.i3": {
+      "detail": "cs -1 e 1.5e-11 p 1.3e-11 K 1.0e-11",
+      "pass": true
+    },
+    "G1.L3.i4": {
+      "detail": "cs -1 e 1.5e-11 p 1.3e-11 K 1.0e-11",
+      "pass": true
+    },
+    "G1.L3.i5": {
+      "detail": "cs +1 e 2.8e-15 p 2.6e-15 K 2.8e-15",
+      "pass": true
+    },
+    "G1.L3.id": {
+      "detail": "identity total defect 0.0e+00",
+      "pass": true
+    },
+    "G1.L3.p01": {
+      "detail": "cs -1 e 1.5e-11 p 1.3e-11 K 1.0e-11",
+      "pass": true
+    },
+    "G1.L3.p04": {
+      "detail": "cs -1 e 1.5e-11 p 1.3e-11 K 1.0e-11",
+      "pass": true
+    },
+    "G1.L3.p09": {
+      "detail": "cs -1 e 1.5e-11 p 1.3e-11 K 1.0e-11",
+      "pass": true
+    },
+    "G1.L3.p15": {
+      "detail": "cs +1 e 4.6e-15 p 4.8e-15 K 4.9e-15",
+      "pass": true
+    },
+    "G1.L3.p18": {
+      "detail": "cs +1 e 4.4e-15 p 5.1e-15 K 6.1e-15",
+      "pass": true
+    },
+    "G1.L3.p23": {
+      "detail": "cs +1 e 0.0e+00 p 0.0e+00 K 0.0e+00",
+      "pass": true
+    },
+    "G1.L7.id": {
+      "detail": "identity total defect 0.0e+00",
+      "pass": true
+    },
+    "G1.L7.minus": {
+      "detail": "branch max over 6 frames 3.1e-10",
+      "pass": true
+    },
+    "G1.L7.plus": {
+      "detail": "branch max over 6 frames 4.6e-13",
+      "pass": true
+    },
+    "G10.L3.broken": {
+      "detail": "broken min over both compare signs 1.9e-01",
+      "pass": true
+    },
+    "G10.L3.classes": {
+      "detail": "pp/mm/broken 6/6/12",
+      "pass": true
+    },
+    "G10.L3.collapse": {
+      "detail": "coset 12/12 link-equal 12/12",
+      "pass": true
+    },
+    "G10.L3.mm": {
+      "detail": "mm multiset max 9.7e-11",
+      "pass": true
+    },
+    "G10.L3.mz": {
+      "detail": "m_z = diag(1,1,-1) fixes x5y7",
+      "pass": true
+    },
+    "G10.L3.pp": {
+      "detail": "pp multiset max 9.5e-15",
+      "pass": true
+    },
+    "G10.L7.broken": {
+      "detail": "broken min over both compare signs 1.0e-01",
+      "pass": true
+    },
+    "G10.L7.classes": {
+      "detail": "pp/mm/broken 6/6/12",
+      "pass": true
+    },
+    "G10.L7.collapse": {
+      "detail": "coset 12/12 link-equal 12/12",
+      "pass": true
+    },
+    "G10.L7.mm": {
+      "detail": "mm multiset max 5.5e-10",
+      "pass": true
+    },
+    "G10.L7.mz": {
+      "detail": "m_z = diag(1,1,-1) fixes x5y7",
+      "pass": true
+    },
+    "G10.L7.pp": {
+      "detail": "pp multiset max 9.7e-13",
+      "pass": true
+    },
+    "G2.L3": {
+      "detail": "minus/plus floor 2.5e+03",
+      "pass": true
+    },
+    "G2.L7": {
+      "detail": "minus/plus floor 6.7e+02",
+      "pass": true
+    },
+    "G3.L3": {
+      "detail": "mixed min d_e 2.4e-01 over 18 frames",
+      "pass": true
+    },
+    "G3.L7": {
+      "detail": "mixed min d_e 6.3e-01 over 18 frames",
+      "pass": true
+    },
+    "G4.L3.cs": {
+      "detail": "parity not None -> law 6/6",
+      "pass": true
+    },
+    "G4.L3.imp": {
+      "detail": "improper det -1 parity match 6/6",
+      "pass": true
+    },
+    "G4.L3.mix": {
+      "detail": "parity None -> no law 18/18",
+      "pass": true
+    },
+    "G4.L3.rej": {
+      "detail": "wrong-sign d_K 6.7e-01",
+      "pass": true
+    },
+    "G4.L7.cs": {
+      "detail": "parity not None -> law 6/6",
+      "pass": true
+    },
+    "G4.L7.imp": {
+      "detail": "improper det -1 parity match 6/6",
+      "pass": true
+    },
+    "G4.L7.mix": {
+      "detail": "parity None -> no law 18/18",
+      "pass": true
+    },
+    "G4.L7.rej": {
+      "detail": "wrong-sign d_K 9.9e-01",
+      "pass": true
+    },
+    "G5.c4": {
+      "detail": "quartet = powers of the x-axis rotation",
+      "pass": true
+    },
+    "G5.stab": {
+      "detail": "proper stabilizer of x5 (20, 21, 22, 23)",
+      "pass": true
+    },
+    "G5.sx": {
+      "detail": "sx coset-invariant 96/96",
+      "pass": true
+    },
+    "G5.transversal": {
+      "detail": "exactly one constant-sign coset member 24/24",
+      "pass": true
+    },
+    "G6.L3.collapse": {
+      "detail": "link-dict equality g.dom == (g t).dom 24/24",
+      "pass": true
+    },
+    "G6.L3.determinism": {
+      "detail": "chain determinism on collapsed pairs 6/6",
+      "pass": true
+    },
+    "G6.L3.images": {
+      "detail": "distinct domain images 6",
+      "pass": true
+    },
+    "G6.L7.collapse": {
+      "detail": "link-dict equality g.dom == (g t).dom 24/24",
+      "pass": true
+    },
+    "G6.L7.images": {
+      "detail": "distinct domain images 6",
+      "pass": true
+    },
+    "G7.L3.counts": {
+      "detail": "chi split 12/12",
+      "pass": true
+    },
+    "G7.L3.minus": {
+      "detail": "chi=-1 multiset max 1.0e-11",
+      "pass": true
+    },
+    "G7.L3.plus": {
+      "detail": "chi=+1 multiset max 4.8e-15",
+      "pass": true
+    },
+    "G7.L3.rej": {
+      "detail": "plus-compare on a minus frame 2.1e-01",
+      "pass": true
+    },
+    "G7.L7.counts": {
+      "detail": "chi split 12/12",
+      "pass": true
+    },
+    "G7.L7.minus": {
+      "detail": "chi=-1 multiset max 3.1e-10",
+      "pass": true
+    },
+    "G7.L7.plus": {
+      "detail": "chi=+1 multiset max 3.8e-13",
+      "pass": true
+    },
+    "G8.L3.b.minus": {
+      "detail": "d_b 2.1e-14",
+      "pass": true
+    },
+    "G8.L3.b.plus": {
+      "detail": "d_b 2.9e-15",
+      "pass": true
+    },
+    "G8.L3.eps.minus": {
+      "detail": "d_eps 6.9e-11 over 100 d_b 2.1e-12",
+      "pass": true
+    },
+    "G8.L3.eps.plus": {
+      "detail": "d_eps 9.8e-15",
+      "pass": true
+    },
+    "G8.L3.len": {
+      "detail": "d_len 1.4e-11 vs AMP d_eps 1.4e-11",
+      "pass": true
+    },
+    "G8.L3.rho.minus": {
+      "detail": "d_rho 0.0e+00",
+      "pass": true
+    },
+    "G8.L3.rho.plus": {
+      "detail": "d_rho 0.0e+00",
+      "pass": true
+    },
+    "G8.L7.b.minus": {
+      "detail": "d_b 1.0e-14",
+      "pass": true
+    },
+    "G8.L7.b.plus": {
+      "detail": "d_b 1.8e-15",
+      "pass": true
+    },
+    "G8.L7.eps.minus": {
+      "detail": "d_eps 1.5e-09 over 100 d_b 1.0e-12",
+      "pass": true
+    },
+    "G8.L7.eps.plus": {
+      "detail": "d_eps 1.5e-12",
+      "pass": true
+    },
+    "G8.L7.rho.minus": {
+      "detail": "d_rho 0.0e+00",
+      "pass": true
+    },
+    "G8.L7.rho.plus": {
+      "detail": "d_rho 0.0e+00",
+      "pass": true
+    },
+    "G9.L3.r1": {
+      "detail": "d 2.5e-12 4.9e-12 ratio 2.0e+00",
+      "pass": true
+    },
+    "G9.L3.r2": {
+      "detail": "d 1.0e-11 ratio 2.0e+00",
+      "pass": true
+    }
+  },
+  "notes": {
+    "G7.L7.plus_compare": "4.1e-02",
+    "G8.L7.d_len_minus": "2.7e-10"
+  },
+  "pass": 71,
+  "runner": "physical_source_stabilizer_coset_collapse_k_sign_law_cycle707_2026_08_01.py"
+}

--- a/scripts/physical_source_stabilizer_coset_collapse_k_sign_law_cycle707_2026_08_01.py
+++ b/scripts/physical_source_stabilizer_coset_collapse_k_sign_law_cycle707_2026_08_01.py
@@ -1,0 +1,501 @@
+"""Cycle 707 -- source-stabilizer coset collapse of the compiled K sign law.
+
+Class-A finite check script (stdlib + numpy only).  It executes the landed Cycle-696
+open-coframe endpoint compiler chain
+
+    rho -> b -> eps -> (h, e) -> (parts, K)
+
+on two decorated source domains and measures, from that chain alone:
+
+  G1  the constant-sign pointwise transport law on the 12 constant-sign signed
+      permutations (6 proper rotations plus 6 improper computational identities);
+  G2  the plus/minus branch asymmetry of the measured floors;
+  G3  the mixed-sign obstruction on the 18 remaining proper rotations;
+  G4  the biconditional between the landed frame parity function and the law;
+  G5  the proper stabilizer quartet of the single-edit source and its transversal;
+  G6  the exact collapse of every frame image onto a constant-sign representative;
+  G7  the all-24 multiset sign law with chi = sx;
+  G8  the stage ladder that locates the negation floor;
+  G9  the amplitude-linearity of the negation floor;
+  G10 the two-edit trichotomy.
+
+No value is read from a pinned table: every number printed here is recomputed from
+the compiler chain in this run.
+"""
+from __future__ import annotations
+
+import importlib.util
+import itertools
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(HERE))
+_MODULE = HERE / "physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py"
+_SPEC = importlib.util.spec_from_file_location("c696_compiler_for_c707", _MODULE)
+c696 = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(c696)
+
+FRAMES = [np.asarray(m, dtype=np.int64) for m in c696.c576.FRAMES]
+EYE3 = np.eye(3, dtype=np.int64)
+MZ = np.diag([1, 1, -1]).astype(np.int64)
+
+AMP = 0.20
+AMP_LADDER = (0.05, 0.10, 0.20)
+L_LIST = (3, 7)
+QUARTET_EXPECTED = (20, 21, 22, 23)
+BOUND_PLUS = 1e-11
+BOUND_MINUS = 1e-7
+BOUND_B = 1e-12
+BOUND_EPS_PLUS = 1e-10
+BREAK_FLOOR = 1e-2
+PP_FLOOR = 1e-10
+RATIO_LO = 1.6
+RATIO_HI = 2.4
+
+RECEIPT_NAME = ("physical_source_stabilizer_coset_collapse_k_sign_law_cycle707"
+                "_2026_08_01_receipt_2026-08-01.json")
+
+N_PASS = 0
+N_FAIL = 0
+GATES: dict = {}
+NOTES: dict = {}
+
+
+def fmt(x) -> str:
+    return "{:.1e}".format(float(x))
+
+
+def check(name: str, ok: bool, detail: str = "") -> bool:
+    """Record and print one gate.  Every gate below is discriminating: each has an
+    explicit wrong-value, wrong-sign, wrong-branch, or absent-law rejector."""
+    global N_PASS, N_FAIL
+    ok = bool(ok)
+    if ok:
+        N_PASS += 1
+    else:
+        N_FAIL += 1
+    GATES[name] = {"pass": ok, "detail": detail}
+    print("{} {} {}".format("PASS" if ok else "FAIL", name, detail))
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# signed-permutation frame utilities (written here, not imported from a probe)
+# ---------------------------------------------------------------------------
+def sp_data(R: np.ndarray):
+    """p[i] = argmax|R[i]|, s[i] = R[i, p[i]] -- the permutation and sign words."""
+    p = [int(np.argmax(np.abs(R[i]))) for i in range(3)]
+    s = [int(R[i, p[i]]) for i in range(3)]
+    return p, s
+
+
+def cs_sign(R: np.ndarray):
+    """+1 / -1 when every nonzero entry shares one sign, None otherwise."""
+    nz = R[R != 0]
+    if np.all(nz == 1):
+        return 1
+    if np.all(nz == -1):
+        return -1
+    return None
+
+
+def sx_of(R: np.ndarray) -> int:
+    p, s = sp_data(R)
+    return s[p.index(0)]
+
+
+def sy_of(R: np.ndarray) -> int:
+    p, s = sp_data(R)
+    return s[p.index(1)]
+
+
+def det_int(R: np.ndarray) -> int:
+    return int(round(float(np.linalg.det(R.astype(float)))))
+
+
+def improper_constant_sign():
+    """The 6 constant-sign signed permutations with det = -1, in a fixed order."""
+    out = []
+    for perm in itertools.permutations(range(3)):
+        P = np.zeros((3, 3), dtype=np.int64)
+        for i, j in enumerate(perm):
+            P[i, j] = 1
+        for sgn in (1, -1):
+            M = (sgn * P).astype(np.int64)
+            if det_int(M) == -1 and cs_sign(M) is not None:
+                out.append(M)
+    return out
+
+
+IMPROPER = improper_constant_sign()
+
+
+def links_key(dom: dict) -> tuple:
+    return tuple(sorted((u, v, w) for (u, v), w in dom["links"].items()))
+
+
+# ---------------------------------------------------------------------------
+# the landed Cycle-696 chain, quoted verbatim
+# ---------------------------------------------------------------------------
+def build_ctx(L: int) -> dict:
+    model = c696.assemble_static_hessian(L, wrap=False)
+    sol = c696.sector_solve(model)
+    A = (L - 1) // 2
+    dom0 = c696.build_domain(L, edits={((A, A, A), (A + 1, A, A)): 5})
+    dom1 = c696.build_domain(L, edits={((A, A, A), (A + 1, A, A)): 5,
+                                       ((A, A, A), (A, A + 1, A)): 7})
+    return {"L": L, "model": model, "sol": sol, "dom0": dom0, "dom1": dom1,
+            "sites": model["site_index"],
+            "all": list(itertools.product(range(L), repeat=3))}
+
+
+def chain(ctx: dict, dom: dict, amp: float = AMP) -> dict:
+    model = ctx["model"]
+    rho = c696.rho_vector(dom, model["site_index"])
+    b = rho @ model["G"]
+    eps = c696.response(model, ctx["sol"], b)["eps"]
+    mc = c696.metric_and_coframe(ctx["L"], amp * eps, model["index"])
+    kf = c696.k_field(mc["e_clipped"])
+    return {"rho": rho, "b": b, "eps": eps, "h": mc["h"], "e": mc["e_clipped"],
+            "lengths": np.asarray(mc["lengths"]),
+            "parts": np.asarray(kf["parts"]), "K": np.asarray(kf["K"])}
+
+
+def transport_defects(ctx: dict, c0: dict, cR: dict, R: np.ndarray):
+    """Max-over-sites defects of
+         e^{R.dom}(sigma x)       = P e^{dom}(x) P^T
+         parts_i^{R.dom}(sigma x) = s[i] parts_{p[i]}^{dom}(x)
+         K^{R.dom}(sigma x)       = sum_i s[i] parts_{p[i]}^{dom}(x).
+    """
+    smap = c696.frame_site_map(ctx["L"], R)
+    p, s = sp_data(R)
+    Rf = R.astype(float)
+    d_e = 0.0
+    d_parts = 0.0
+    d_K = 0.0
+    for x in ctx["all"]:
+        ix = smap[x]
+        d_e = max(d_e, float(np.abs(cR["e"][ix] - Rf @ c0["e"][x] @ Rf.T).max()))
+        pred = 0.0
+        for i in range(3):
+            term = s[i] * float(c0["parts"][x][p[i]])
+            d_parts = max(d_parts, abs(float(cR["parts"][ix][i]) - term))
+            pred += term
+        d_K = max(d_K, abs(float(cR["K"][ix]) - pred))
+    return d_e, d_parts, d_K
+
+
+def wrong_sign_dK(ctx: dict, c0: dict, cR: dict, R: np.ndarray) -> float:
+    """Rejector: the SAME law with the common sign forced to +1."""
+    smap = c696.frame_site_map(ctx["L"], R)
+    p, _s = sp_data(R)
+    worst = 0.0
+    for x in ctx["all"]:
+        pred = 0.0
+        for i in range(3):
+            pred += float(c0["parts"][x][p[i]])
+        worst = max(worst, abs(float(cR["K"][smap[x]]) - pred))
+    return worst
+
+
+def multiset_defect(Ka, Kb) -> float:
+    a = np.sort(np.asarray(Ka).ravel())
+    b = np.sort(np.asarray(Kb).ravel())
+    return float(np.abs(a - b).max())
+
+
+def ladder_defects(ctx: dict, c0: dict, cR: dict, R: np.ndarray) -> dict:
+    """Stage-by-stage sorted-multiset defects along rho -> b -> eps -> lengths."""
+    L = ctx["L"]
+    sites = ctx["sites"]
+    smap = c696.frame_site_map(L, R)
+    d_rho = 0.0
+    for x in ctx["all"]:
+        d_rho = max(d_rho, abs(float(cR["rho"][sites[smap[x]]] - c0["rho"][sites[x]])))
+    d_b = float(np.abs(np.sort(cR["b"]) - np.sort(c0["b"])).max())
+    d_eps = float(np.abs(np.sort(cR["eps"]) - np.sort(c0["eps"])).max())
+    d_len = 0.0
+    for x in ctx["all"]:
+        u = np.sort(np.asarray(cR["lengths"][smap[x]]).ravel())
+        v = np.sort(np.asarray(c0["lengths"][x]).ravel())
+        d_len = max(d_len, float(np.abs(u - v).max()))
+    return {"rho": d_rho, "b": d_b, "eps": d_eps, "len": d_len}
+
+
+# ---------------------------------------------------------------------------
+def run_L(ctx: dict) -> None:
+    L = ctx["L"]
+    tag = "L{}".format(L)
+    dom0 = ctx["dom0"]
+    c0 = chain(ctx, dom0)
+
+    ident = next(g for g in range(24) if np.array_equal(FRAMES[g], EYE3))
+    minus_g = next(g for g in range(24) if cs_sign(FRAMES[g]) == -1)
+    plus_g = next(g for g in range(24)
+                  if cs_sign(FRAMES[g]) == 1 and not np.array_equal(FRAMES[g], EYE3))
+
+    plus_floor = 0.0
+    minus_floor = 0.0
+    mixed_min = float("inf")
+    ms_plus = 0.0
+    ms_minus = 0.0
+    n_plus = 0
+    n_minus = 0
+    cs_ok = 0
+    cs_n = 0
+    mix_ok = 0
+    mix_n = 0
+    ident_total = None
+    rej_sign = 0.0
+    rej_branch = 0.0
+    lad: dict = {}
+
+    for g in range(24):
+        R = FRAMES[g]
+        cR = chain(ctx, c696.apply_frame_to_domain(dom0, R))
+        d_e, d_p, d_k = transport_defects(ctx, c0, cR, R)
+        sg = cs_sign(R)
+        sxg = sx_of(R)
+        ms = multiset_defect(cR["K"], sxg * c0["K"])
+        if sxg == 1:
+            n_plus += 1
+            ms_plus = max(ms_plus, ms)
+        else:
+            n_minus += 1
+            ms_minus = max(ms_minus, ms)
+        if sg is None:
+            mix_n += 1
+            mixed_min = min(mixed_min, d_e)
+            if d_e > BREAK_FLOOR:
+                mix_ok += 1
+        else:
+            cs_n += 1
+            worst = max(d_e, d_p, d_k)
+            bound = BOUND_PLUS if sg == 1 else BOUND_MINUS
+            if worst < bound:
+                cs_ok += 1
+            if sg == 1:
+                plus_floor = max(plus_floor, worst)
+            else:
+                minus_floor = max(minus_floor, worst)
+            if g == ident:
+                ident_total = worst
+            if L == 3:
+                check("G1.{}.p{:02d}".format(tag, g), worst < bound,
+                      "cs {:+d} e {} p {} K {}".format(sg, fmt(d_e), fmt(d_p), fmt(d_k)))
+        if g == minus_g:
+            rej_sign = wrong_sign_dK(ctx, c0, cR, R)
+            rej_branch = multiset_defect(cR["K"], c0["K"])
+            lad["minus"] = ladder_defects(ctx, c0, cR, R)
+        if g == plus_g:
+            lad["plus"] = ladder_defects(ctx, c0, cR, R)
+
+    imp_ok = 0
+    for j, M in enumerate(IMPROPER):
+        cM = chain(ctx, c696.apply_frame_to_domain(dom0, M))
+        d_e, d_p, d_k = transport_defects(ctx, c0, cM, M)
+        sg = cs_sign(M)
+        worst = max(d_e, d_p, d_k)
+        bound = BOUND_PLUS if sg == 1 else BOUND_MINUS
+        if sg == 1:
+            plus_floor = max(plus_floor, worst)
+        else:
+            minus_floor = max(minus_floor, worst)
+        if c696.frame_K_parity(M) == sg and det_int(M) == -1:
+            imp_ok += 1
+        if L == 3:
+            check("G1.{}.i{}".format(tag, j), worst < bound,
+                  "cs {:+d} e {} p {} K {}".format(sg, fmt(d_e), fmt(d_p), fmt(d_k)))
+
+    if L != 3:
+        check("G1.{}.plus".format(tag), plus_floor < BOUND_PLUS,
+              "branch max over 6 frames {}".format(fmt(plus_floor)))
+        check("G1.{}.minus".format(tag), minus_floor < BOUND_MINUS,
+              "branch max over 6 frames {}".format(fmt(minus_floor)))
+    check("G1.{}.id".format(tag), ident_total == 0.0,
+          "identity total defect {}".format(fmt(ident_total)))
+
+    ratio = minus_floor / max(plus_floor, 1e-300)
+    check("G2.{}".format(tag), ratio > 10.0, "minus/plus floor {}".format(fmt(ratio)))
+
+    check("G3.{}".format(tag), mixed_min > BREAK_FLOOR,
+          "mixed min d_e {} over {} frames".format(fmt(mixed_min), mix_n))
+
+    check("G4.{}.cs".format(tag), cs_ok == cs_n and cs_n == 6,
+          "parity not None -> law {}/{}".format(cs_ok, cs_n))
+    check("G4.{}.mix".format(tag), mix_ok == mix_n and mix_n == 18,
+          "parity None -> no law {}/{}".format(mix_ok, mix_n))
+    check("G4.{}.imp".format(tag), imp_ok == 6,
+          "improper det -1 parity match {}/6".format(imp_ok))
+    check("G4.{}.rej".format(tag), rej_sign > BREAK_FLOOR,
+          "wrong-sign d_K {}".format(fmt(rej_sign)))
+
+    stab = [g for g in range(24)
+            if c696.apply_frame_to_domain(dom0, FRAMES[g])["links"] == dom0["links"]]
+    transversal = {}
+    n_uniq = 0
+    for g in range(24):
+        ts = [t for t in stab if cs_sign(FRAMES[g] @ FRAMES[t]) is not None]
+        if len(ts) == 1:
+            n_uniq += 1
+        transversal[g] = ts[0] if ts else stab[0]
+
+    if L == 3:
+        check("G5.stab", tuple(stab) == QUARTET_EXPECTED,
+              "proper stabilizer of x5 {}".format(tuple(stab)))
+        Rx = np.asarray([[1, 0, 0], [0, 0, -1], [0, 1, 0]], dtype=np.int64)
+        pw = sorted(tuple(np.linalg.matrix_power(Rx, k).ravel().tolist()) for k in range(4))
+        qm = sorted(tuple(FRAMES[t].ravel().tolist()) for t in stab)
+        check("G5.c4", pw == qm, "quartet = powers of the x-axis rotation")
+        check("G5.transversal", n_uniq == 24,
+              "exactly one constant-sign coset member {}/24".format(n_uniq))
+        n_sx = sum(1 for g in range(24) for t in stab
+                   if sx_of(FRAMES[g] @ FRAMES[t]) == sx_of(FRAMES[g]))
+        check("G5.sx", n_sx == 96, "sx coset-invariant {}/96".format(n_sx))
+
+    ok_link = 0
+    reps: dict = {}
+    for g in range(24):
+        d_g = c696.apply_frame_to_domain(dom0, FRAMES[g])
+        d_t = c696.apply_frame_to_domain(dom0, FRAMES[g] @ FRAMES[transversal[g]])
+        if d_g["links"] == d_t["links"]:
+            ok_link += 1
+        reps.setdefault(links_key(d_g), g)
+    check("G6.{}.collapse".format(tag), ok_link == 24,
+          "link-dict equality g.dom == (g t).dom {}/24".format(ok_link))
+    check("G6.{}.images".format(tag), len(reps) == 6,
+          "distinct domain images {}".format(len(reps)))
+    if L == 3:
+        ok_bits = 0
+        for g in sorted(reps.values()):
+            ka = chain(ctx, c696.apply_frame_to_domain(dom0, FRAMES[g]))["K"]
+            kb = chain(ctx, c696.apply_frame_to_domain(
+                dom0, FRAMES[g] @ FRAMES[transversal[g]]))["K"]
+            if np.array_equal(ka, kb):
+                ok_bits += 1
+        check("G6.L3.determinism", ok_bits == 6,
+              "chain determinism on collapsed pairs {}/6".format(ok_bits))
+
+    check("G7.{}.plus".format(tag), ms_plus < BOUND_PLUS,
+          "chi=+1 multiset max {}".format(fmt(ms_plus)))
+    check("G7.{}.minus".format(tag), ms_minus < BOUND_MINUS,
+          "chi=-1 multiset max {}".format(fmt(ms_minus)))
+    check("G7.{}.counts".format(tag), n_plus == 12 and n_minus == 12,
+          "chi split {}/{}".format(n_plus, n_minus))
+    if L == 3:
+        check("G7.L3.rej", rej_branch > BREAK_FLOOR,
+              "plus-compare on a minus frame {}".format(fmt(rej_branch)))
+    else:
+        NOTES["G7.L7.plus_compare"] = fmt(rej_branch)
+        print("note G7.L7 plus-compare on a minus frame {} unscored".format(fmt(rej_branch)))
+
+    lm = lad["minus"]
+    lp = lad["plus"]
+    check("G8.{}.rho.minus".format(tag), lm["rho"] == 0.0, "d_rho {}".format(fmt(lm["rho"])))
+    check("G8.{}.rho.plus".format(tag), lp["rho"] == 0.0, "d_rho {}".format(fmt(lp["rho"])))
+    check("G8.{}.b.minus".format(tag), lm["b"] < BOUND_B, "d_b {}".format(fmt(lm["b"])))
+    check("G8.{}.b.plus".format(tag), lp["b"] < BOUND_B, "d_b {}".format(fmt(lp["b"])))
+    check("G8.{}.eps.minus".format(tag), lm["eps"] > 100.0 * lm["b"],
+          "d_eps {} over 100 d_b {}".format(fmt(lm["eps"]), fmt(100.0 * lm["b"])))
+    check("G8.{}.eps.plus".format(tag), lp["eps"] < BOUND_EPS_PLUS,
+          "d_eps {}".format(fmt(lp["eps"])))
+    if L == 3:
+        pred = AMP * lm["eps"]
+        check("G8.L3.len", abs(lm["len"] - pred) < 0.5 * pred,
+              "d_len {} vs AMP d_eps {}".format(fmt(lm["len"]), fmt(pred)))
+    else:
+        NOTES["G8.L7.d_len_minus"] = fmt(lm["len"])
+        print("note G8.L7 minus d_len {} unscored".format(fmt(lm["len"])))
+
+    if L == 3:
+        ds = []
+        for a in AMP_LADDER:
+            base = chain(ctx, dom0, a)
+            rot = chain(ctx, c696.apply_frame_to_domain(dom0, FRAMES[minus_g]), a)
+            ds.append(multiset_defect(rot["K"], -base["K"]))
+        r1 = ds[1] / ds[0]
+        r2 = ds[2] / ds[1]
+        check("G9.L3.r1", RATIO_LO <= r1 <= RATIO_HI,
+              "d {} {} ratio {}".format(fmt(ds[0]), fmt(ds[1]), fmt(r1)))
+        check("G9.L3.r2", RATIO_LO <= r2 <= RATIO_HI,
+              "d {} ratio {}".format(fmt(ds[2]), fmt(r2)))
+
+    dom1 = ctx["dom1"]
+    c1 = chain(ctx, dom1)
+    check("G10.{}.mz".format(tag),
+          c696.apply_frame_to_domain(dom1, MZ)["links"] == dom1["links"],
+          "m_z = diag(1,1,-1) fixes x5y7")
+    n_pp = sum(1 for g in range(24) if sx_of(FRAMES[g]) == 1 and sy_of(FRAMES[g]) == 1)
+    n_mm = sum(1 for g in range(24) if sx_of(FRAMES[g]) == -1 and sy_of(FRAMES[g]) == -1)
+    n_br = 24 - n_pp - n_mm
+    check("G10.{}.classes".format(tag), (n_pp, n_mm, n_br) == (6, 6, 12),
+          "pp/mm/broken {}/{}/{}".format(n_pp, n_mm, n_br))
+
+    n_cs = 0
+    ok_cs = 0
+    matched = 0
+    for g in range(24):
+        R = FRAMES[g]
+        u = R if cs_sign(R) is not None else R @ MZ
+        if cs_sign(u) is None:
+            continue
+        n_cs += 1
+        if sx_of(R) == sy_of(R):
+            matched += 1
+        if (c696.apply_frame_to_domain(dom1, R)["links"]
+                == c696.apply_frame_to_domain(dom1, u)["links"]):
+            ok_cs += 1
+    check("G10.{}.collapse".format(tag), n_cs == 12 and ok_cs == 12 and matched == 12,
+          "coset {}/12 link-equal {}/12".format(n_cs, ok_cs))
+
+    pp = 0.0
+    mm = 0.0
+    brk = float("inf")
+    for g in range(24):
+        R = FRAMES[g]
+        cg = chain(ctx, c696.apply_frame_to_domain(dom1, R))
+        d_pos = multiset_defect(cg["K"], c1["K"])
+        d_neg = multiset_defect(cg["K"], -c1["K"])
+        if sx_of(R) == 1 and sy_of(R) == 1:
+            pp = max(pp, d_pos)
+        elif sx_of(R) == -1 and sy_of(R) == -1:
+            mm = max(mm, d_neg)
+        else:
+            brk = min(brk, min(d_pos, d_neg))
+    check("G10.{}.pp".format(tag), pp < PP_FLOOR, "pp multiset max {}".format(fmt(pp)))
+    check("G10.{}.mm".format(tag), mm < BOUND_MINUS, "mm multiset max {}".format(fmt(mm)))
+    check("G10.{}.broken".format(tag), brk > BREAK_FLOOR,
+          "broken min over both compare signs {}".format(fmt(brk)))
+
+
+def main() -> int:
+    print("c707 source-stabilizer coset collapse of the compiled K sign law")
+    print("24 proper rotations, {} improper constant-sign identities, AMP {}".format(
+        len(IMPROPER), fmt(AMP)))
+    for L in L_LIST:
+        print("-- L={} --".format(L))
+        run_L(build_ctx(L))
+
+    receipt = {"amp": fmt(AMP),
+               "amp_ladder": [fmt(a) for a in AMP_LADDER],
+               "box_sizes": list(L_LIST),
+               "fail": N_FAIL,
+               "gates": GATES,
+               "notes": NOTES,
+               "pass": N_PASS,
+               "runner": Path(__file__).name}
+    out = ROOT / "outputs" / RECEIPT_NAME
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(receipt, sort_keys=True, indent=2) + "\n")
+
+    print("TOTAL: PASS={} FAIL={}".format(N_PASS, N_FAIL))
+    return 1 if N_FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Cycle 707 in the gravity evidence-ceiling lane. The landed compiled chain (cycle 696 / cycle 700) registers a curvature-like scalar K from a single-edit source domain, and cycle 700 measured a sign dichotomy of K under frame transport. This cycle derives where that sign law lives and why it holds for all 24 proper frames:

- **Constant-sign pointwise transport law.** On the 12 constant-sign signed permutation matrices (6 proper rotations plus 6 improper matrices used as computational identities only — improper frames are not axiom symmetries), the compiled parts field transports pointwise: parts_i at the mapped site equals s_i times parts_{p(i)} at the source site. Measured floors: plus branch 6.1e-15 (L=3) / 4.6e-13 (L=7), minus branch 1.5e-11 / 3.1e-10, identity exactly 0.0 at both sizes. Mixed-sign frames break covariance already at the coframe stage (defect at least 2.4e-01), reproducing the landed single-carrier obstruction at an earlier stage of the chain.
- **Stabilizer quartet and exact coset collapse.** The proper stabilizer of the single-edit domain is the order-4 group of x-axis rotation powers. Every proper frame has exactly one constant-sign representative in its stabilizer coset (24/24), the frame image of the domain collapses exactly onto that representative at the link-dictionary level (24/24 at both sizes), and the coset character sx is coset-invariant (96/96). Composing the collapse with the pointwise law derives the all-24 multiset sign law — multiset(K under g) = multiset(sx(g) · K) — with the 12/12 branch split and floors: plus 4.8e-15 / 3.8e-13, minus 1.0e-11 / 3.1e-10. Wrong-sign and wrong-branch rejectors sit 9 to 10 orders above the law's floors.
- **Two-edit trichotomy.** For the two-edit domain the same argument runs through the diag(1,1,-1) domain stabilizer: 6 frames preserve, 6 negate, 12 broken (floors 9.5e-15 / 9.7e-11 / 1.9e-01 at L=3), with the coset collapse 12/12.
- **Floor located at the linear-response solve.** Along the chain, rho transports bit-exactly (0.0) and b at 2.1e-14, while eps jumps to 6.9e-11 on the negation branch versus 9.8e-15 on the plus branch — a two-orders separation localizing the minus-branch floor at the b-to-eps solve. The floor is amplitude-linear (ratio 2.0 under amplitude doubling), consistent with a solver-conditioning origin rather than a structural defect.

Honest boundary (stated in the note): the numeric value of the minus-branch floor is measured, not derived; deriving the response-stage constant, classifying stabilizers for general edit sets, and the size-scaling of the floors are the named next paths.

## What lands

5 files, 3 commits, following the lane convention:

- `docs/PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01.md` (bounded_theorem note)
- `scripts/physical_source_stabilizer_coset_collapse_k_sign_law_cycle707_2026_08_01.py` (paired runner)
- `outputs/..._receipt_2026-08-01.json` and `outputs/..._cold_2026-08-01.txt` (receipt + cold stdout)
- `docs/audit/data/citation_graph_manifest.json` (audit-infra: acknowledge the new note)

## Runner

`TOTAL: PASS=71 FAIL=0` across L=3 and L=7; stdout 3483 chars (under the 6000-char ceiling); reviewer double run byte-identical in both stdout and receipt; exits nonzero on any gate failure. Gates include wrong-sign and wrong-branch rejectors, a mixed-frame break floor, and an amplitude-ratio window that a quadratic or constant floor would fail.

## Review notes

- Receipt stores all floats as 1-significant-digit scientific strings (matching stdout formatting), keeping the receipt byte-deterministic.
- Branch floors are maxima over coframe, parts, and K pointwise defects; the K-only figure at L=7 plus branch is 3.8e-13 against the 4.6e-13 quoted maximum.
- The note cites only landed notes (minimal axioms, cycle 700 chain, joined-compiler tournament note); open sibling cycles are referenced as unaudited open work without citation edges.

## Relation to open work

Independent of the open sibling PRs (#5884–#5889): branched directly off origin/main and cites nothing from those branches, so it can land in any order relative to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
