### PR TITLE
feat(gravity): cycle-708 signed-stabilizer edit-set classification

### DIFF
--- a/docs/PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.md
+++ b/docs/PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.md
@@ -1,70 +1,178 @@
-# PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02
+# Signed-stabilizer classifier for a supplied source-response compiler: conditional algebra and a four-domain finite battery — Cycle 708
 
-Date 2026-08-02. Paired runner
-`scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.py`;
-paired outputs
-`outputs/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02_cold_2026-08-02.txt`
+**Date:** 2026-08-02 (revised 2026-08-11, review-loop iteration 1)
+
+**Type:** bounded_theorem
+
+**Status:** proposed_retained
+
+**Primary runner:**
+[`physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.py`](../scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.py)
+
+**Independent checker:**
+[`physical_source_edit_set_signed_stabilizer_classification_cycle708_independent_check_2026_08_02.py`](../scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_independent_check_2026_08_02.py)
+
+**Run artifacts:**
+[`cold stdout`](../outputs/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02_cold_2026-08-02.txt)
 and
-`outputs/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02_receipt_2026-08-02.json`.
+[`receipt`](../outputs/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02_receipt_2026-08-02.json),
+plus the source-bound
+[`primary cache`](../logs/runner-cache/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.txt)
+and
+[`independent-check cache`](../logs/runner-cache/physical_source_edit_set_signed_stabilizer_classification_cycle708_independent_check_2026_08_02.txt).
+
+## Trace gate
+
+```yaml
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: "classify the proper-frame K-sign behavior of a supplied finite source-response compiler"
+source_of_blocker_text: frontier_question
+reachability_to_target: supports
+artifact_role: runner_certificate
+next_trace_action: "test the conditional classifier on broader edit families and derive, rather than sample, the constant-sign transport premise"
+```
+
+## Status fields
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: frontier_discovery
+reachability_to_target: supports
+conditional_surface_status: conditional-support
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "an exact finite-group implication conditional on a supplied compiler transport premise, with that premise and its numerical converse tested only on four edit domains at L in {3,7}"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+packet_helper_runner: scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_independent_check_2026_08_02.py
+```
 
 ## Abstract
 
-This note gives a computable classification of the per-frame sign law of the registered
-`K` multiset over arbitrary integer edit sets on the six-ray source domain. For a source
-domain `D` carrying edits, the decorated stabilizer `Stab48(D)` inside the 48 signed
-permutation matrices, intersected with the 12 constant-sign matrices along the coset of
-a proper frame, determines a four-valued label for every one of the 24 proper frames:
-the multiset of `K` is carried to itself with sign `+1`, with sign `-1`, with both signs,
-or is not carried at all. The classification is exercised on a battery of four domains at
-`L = 3` and `L = 7`. Two of the four are new predictions confirmed by the paired runner:
-the three-edit domain narrows the lawful set to exactly the six constant-sign proper
-frames, split 3 plus / 3 minus with 18 broken; and the symmetric-pair domain makes all 24
-proper frames lawful with BOTH signs, which forces a palindromic spectrum, pointwise
-central antisymmetry, and an exact centre zero of `K` at floor scale. Predicted and
-measured profiles agree 24 of 24 on every domain at both sizes, with 95 gates passing and
-none failing.
+This note separates an exact finite-group implication from a finite numerical
+battery. For an edit domain `D`, if the supplied compiler obeys the stated
+constant-sign pointwise transport law on `D`, the intersection of the domain
+stabilizer `Stab48(D)` with the 12 constant-sign matrices along the right coset
+of a proper frame gives every sign that the implication proves for that frame.
+The sign set is empty, plus, minus, or both. An empty sign set is not a proof
+that no other mechanism carries the field; that converse is measured only.
+
+The primary runner tests the transport premise and the measured converse on
+four declared domains at `L = 3` and `L = 7`. The three-distinct-axis domain
+has six lawful proper frames, split 3 plus / 3 minus with 18 measured broken;
+the inversion-pair domain makes all 24 proper frames double-signed and exhibits
+a palindromic spectrum, pointwise central antisymmetry, and a centre value at
+the numerical floor. Predicted and measured profiles agree 24 of 24 on every
+declared domain at both sizes. The independent checker reconstructs the finite
+group, stabilizers, cosets, collision criterion, and profiles without importing
+the numerical primary or its compiler.
 
 ## Scope guard
 
-The 24 proper (determinant `+1`) rotations are the axiom symmetries of the cubic lattice
-setting. The 48 signed permutation matrices used here are computational bookkeeping for
-the compiled chain: the 24 improper (determinant `-1`) elements enter this note purely as
-**computational identities** of the compiled map from decorated domain to `K`, and never
-as symmetries of the physical setting. Every claim about a symmetry is a claim about a
-proper frame; the improper elements appear only as intermediate labels that the compiled
-chain happens to realise, and the classification's output is always a statement about the
-24 proper frames. This is stated once here and assumed throughout.
+The 24 proper (determinant `+1`) rotations are the symmetries supplied by the
+[Lattice axiom](MINIMAL_AXIOMS_2026-06-29.md). The 48 signed permutation
+matrices used here are computational bookkeeping for the compiled chain: the
+24 improper elements enter purely as tested identities of the supplied map
+from chain-input fingerprint to `K`, never as physical symmetries. Every
+symmetry statement below concerns a proper frame.
 
 ## Setting and definitions
 
-The compiled chain is the landed cycle-696 open-coframe endpoint compiler
-(`scripts/physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py`), whose stages
-are: decorated source domain `D` on an open `L^3` box, source vector `rho(D)`, load
+The supplied chain is the landed Cycle-696 open-coframe endpoint compiler
+([`physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py`](../scripts/physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py)), whose stages
+are: source domain `D` on an open `L^3` box, source vector `rho(D)`, load
 `b = rho G`, linear response `eps`, clipped coframe, and the scalar endpoint field `K`.
 The runner drives this chain unmodified and rebuilds nothing of its internals.
 
 - `G48` is the set of all 48 signed permutation matrices in three dimensions, built as
   permutation matrices times the eight sign patterns. Its proper part `SO`, the 24
   elements of determinant `+1`, is measured equal as a set to the module's own frame list
-  (`c696.c576.FRAMES`); gate A1.
+  (`c696.c576.FRAMES`); the `group_order` check.
 - `CS` is the set of 12 constant-sign matrices, those of the form `+P` or `-P` with `P` a
   permutation matrix. `CS` is a subgroup: closure follows from `(-P)(-Q) = PQ`, and the
-  runner checks closure on all 144 products directly; gate A2.
+  runner checks closure on all 144 products directly; the
+  `constant_sign_closure` check.
 - The sign character `sx : CS -> {+1, -1}` sends `+P` to `+1` and `-P` to `-1`. It is
-  multiplicative, verified on all 144 pairs; gate A4.
+  multiplicative, verified on all 144 pairs; the `sign_character` check.
 - `CS_proper = CS` intersect `SO` has 6 elements: the identity, the two 3-cycles with all
   entries `+1`, and the three negated transpositions `-T` (with `det(-T) = -det(T) = +1`
   in three dimensions). The runner re-derives this set and cross-checks that it sits at
-  frame indices `[1, 4, 9, 15, 18, 23]`; gate A3.
-- A domain's fingerprint is the canonical, order-independent key `c696.domain_key(D)`:
-  anchor, sorted ports, and sorted directed link triples. `c696.apply_frame_to_domain`
+  frame indices `[1, 4, 9, 15, 18, 23]`; the `constant_sign_proper`
+  check.
+- A domain's chain-input fingerprint is the order-independent key
+  `c696.domain_key(D)`: anchor, sorted ports, and sorted directed link triples.
+  It is not claimed to encode every auxiliary field in the compiler's domain
+  object. `c696.apply_frame_to_domain`
   accepts any signed permutation matrix, improper ones included.
 - `Stab48(D) = { R in G48 : domain_key(R . D) == domain_key(D) }`, recomputed by
   fingerprint equality and never hardcoded.
 
-Because `rho` is recomputed from the link state alone, fingerprint equality implies
-bit-identical chain input. The runner does not rely on that argument alone: gate C2
-measures `rho` bit-equality directly over every lawful pair at both sizes.
+Because `rho` is recomputed from the link state alone, fingerprint equality
+implies bit-identical source input. The runner also recomputes `rho` outside
+the fingerprint-keyed chain cache and measures bit equality for every
+constant-sign representative of every lawful proper frame at both sizes.
+
+## Imports, declared scope, derived content, and open work
+
+### Load-bearing imported implementation
+
+The primary imports the supplied Cycle-696 compiler and its complete ordinary
+Python source closure: the Cycle-576 source-law module, its Regge and plaquette
+helpers, and the cubic-Coxeter Regge second-variation module. Their exact paths
+are declared in the primary's `AUDIT_INPUT_PATHS`, so the runner cache becomes
+stale if any imported byte changes. The
+[Cycle-700 source-response note](PHYSICAL_OPERATIONAL_SOURCE_RESPONSE_READOUT_CHAIN_CYCLE700_NOTE_2026-07-25.md)
+records the compiler's bounded interpretation and limitations. That row is
+currently an unaudited bounded source, so this note remains conditional support
+pending independent audit and dependency closure.
+
+### Declared finite scope
+
+The four weighted edit domains, open boundaries, `L in {3,7}`, response
+amplitude `0.05`, principal-coframe no-clip requirement, and classification and
+separation tolerances are supplied experimental choices. The response map,
+source normalization, static sector, metric fit, and endpoint interpretation
+are inherited supplied structure; this note derives none of them and makes no
+gravity, energy, rate, or empirical claim.
+
+### Derived here
+
+The finite-group right-coset implication, determinant balance, subgroup-product
+count, and collision criterion are exact. The independent checker reconstructs
+them using pure integer tuples. The primary measures the premise and the
+four-domain profiles through the supplied floating-point compiler.
+
+### Open
+
+The constant-sign transport premise is not proved for arbitrary edit sets, and
+an empty sign set does not exclude a different transport mechanism. Wider edit
+families, a derived response-floor constant, and size scaling remain open.
+
+## Exact target and proof-obligation graph
+
+**Exact target.** Conditional on constant-sign pointwise transport for a
+declared edit domain of the supplied compiler, prove that the right-coset sign
+set supplies valid multiset signs, then test that implication and its unproved
+converse on the four declared finite domains.
+
+1. `G48`, `CS`, and the sign character form the stated finite-group objects:
+   proved here and independently enumerated.
+2. Right multiplication by a stabilizer element preserves the domain's
+   chain-input fingerprint: exact by the group action and checked on every
+   representative.
+3. Constant-sign pointwise transport: a named conditional premise in the
+   general statement; measured on every distinct constant-sign representative
+   used by the four-domain battery.
+4. Multiset transport: follows from items 2 and 3.
+5. Empty sign set implies measured broken: not proved; only tested at the two
+   sizes. This is the strongest missing lemma for any wider classification.
+
+Degenerate cases are included: the sign set may be empty or double-signed, and
+the stabilizer may be trivial. Domains outside the declared battery, clipped
+coframes, periodic boundaries, and other response amplitudes are not covered by
+the numerical statement.
 
 ## The classification theorem
 
@@ -72,14 +180,14 @@ For a proper frame `g`, define
 
     sgn-set(g) = { sx(h) : h in (g . Stab48(D)) intersect CS }.
 
-**Derived direction.** Let `s` be in `Stab48(D)` with `h = g . s` in `CS`. Sidedness
-matters and is fixed by the group action: `h . D = (g . s) . D = g . (s . D) = g . D`,
-so the frame image of `D` under `g` is EXACTLY the frame image under `h` — not merely
-close, but the same decorated state. Equivalently `h = g . s^{-1}` recovers `s` from a
-constant-sign representative, since `Stab48(D)` is a group. This state collapse is
-re-measured, not assumed: gates C1 and C2 confirm fingerprint equality and `rho`
-bit-equality across every such pair. The constant-sign pointwise transport law for `h`,
-also re-measured by this runner, reads
+**Conditional derived direction.** Let `s` be in `Stab48(D)` with `h = g . s`
+in `CS`. Sidedness matters and is fixed by the group action:
+`h . D = (g . s) . D = g . (s . D) = g . D`, so the frame image of
+`D` under `g` has the same chain-input fingerprint as its image under `h`.
+Conversely, a constant-sign `h` in `g . Stab48(D)` gives
+`s = g^{-1} . h` in the stabilizer. The primary recomputes fingerprint and
+`rho` equality for every such representative. Conditional on the pointwise
+transport law
 
     K^{h . D}(h x) = sx(h) . K^D(x)   pointwise, at floor-scale defect,
 
@@ -90,48 +198,55 @@ element of `sgn-set(g)` is a valid multiset sign for `g`.
 `{+1,-1}` — which label the frame broken, plus, minus, or both. These are all four
 subsets of `{+1,-1}`, so the four labels partition the 24 proper frames for any domain.
 
-**Counting law.** `Stab48(D)` and `CS` are both subgroups, so the subgroup product
-formula gives
+**Counting law.** `Stab48(D)` and `CS` are both subgroups, so the finite-set
+subgroup-product formula gives
 
     |CS . Stab48| = |CS| . |Stab48| / |CS intersect Stab48|,
 
-and the lawful proper frames are exactly `(CS . Stab48)` intersect `SO`. Gate B3 measures
-the set order of the product against this formula on every domain at both sizes.
+and the lawful proper frames are exactly `(CS . Stab48) intersect SO`.
+Left multiplication by `-I in CS` is a fixed-point-free involution of
+`CS . Stab48` that flips determinant. Therefore exactly half the product is
+proper, and the proper lawful-frame count is `|CS . Stab48| / 2`. The primary
+and independent checker both verify these counts.
 
-**Collision criterion.** `sgn-set(g)` contains BOTH signs for some `g` if and only if
-`Stab48(D)` meets `CS_minus`, the six constant-sign matrices of the form `-P`. Proof, two
-lines: if `h_plus . s1 = h_minus . s2` with both `h` in `CS` and both `s` in `Stab48`,
-then `s2 . s1^{-1} = h_minus^{-1} . h_plus` lies in `CS_minus` intersect `Stab48`, since
-`sx` is multiplicative and the two sides have opposite sign; conversely, multiplying any
-lawful constant-sign representative by a minus-sign stabilizer element produces a second
-representative of the same coset with the opposite sign.
+**Collision criterion.** `sgn-set(g)` contains both signs for some `g` if and
+only if `Stab48(D)` meets `CS_minus`, the six constant-sign matrices of the
+form `-P`. If `h_plus = g . s_plus` and `h_minus = g . s_minus`, then
+`h_minus^{-1} . h_plus = s_minus^{-1} . s_plus` lies in both `CS_minus`
+and `Stab48(D)`. Conversely, if `m` is a minus-sign element of
+`CS intersect Stab48(D)`, then for any constant-sign representative
+`h = g . s`, the element `h . m = g . (s . m)` is another representative
+with the opposite sign.
 
-**Corollaries when the criterion fires.** Taking `g` to be the identity forces the
-PALINDROMIC SPECTRUM `multiset(K^D) = multiset(-K^D)`. If in addition `-I` itself lies in
-`Stab48(D)`, the pointwise law for `-I` — whose permutation part is the identity and whose
-signs are all `-1` — forces POINTWISE ANTISYMMETRY `K^D(sigma x) = -K^D(x)`, where `sigma`
-is the site map of `-I`, central inversion about the anchor. Evaluating at the fixed point
-of `sigma` gives the FORCED CENTRE ZERO `K^D(centre) = 0` at floor scale.
+**Corollaries when the criterion fires.** Taking `g` to be the identity gives
+the palindromic spectrum `multiset(K^D) = multiset(-K^D)`, conditional on the
+same measured transport premise. If `-I` lies in `Stab48(D)`, the pointwise law
+for `-I` gives `K^D(sigma x) = -K^D(x)`, where `sigma` is central inversion
+about the anchor. Its fixed point has `K^D(centre) = 0`. The primary observes
+these relations at its floating-point floor; it does not claim symbolic zero
+from the numerical solve.
 
 ## Battery
 
 Four domains, edit weights all distinct from the background ray weight 3, centre
 `c = (A,A,A)` with `A = (L-1)//2`, edit keys directed away from the anchor. Profiles are
 written plus / minus / both / broken. `Stab48` orders, `CS` intersect `Stab48` orders, and
-the member index lists are measured identical at `L = 3` and `L = 7` (gates B1, B2, B4),
+the member index lists are measured identical at `L = 3` and `L = 7`,
 so the stabilizer data below is size-independent across the sizes tested.
 
 | domain | edits | `Stab48` | `CS^Stab` | `-1` in `CS^Stab` | `|CS.Stab|` | predicted | measured `L=3` | measured `L=7` | agreement |
 |---|---|---|---|---|---|---|---|---|---|
-| d1 one-edit | `(c,c+ex):5` | 8 | 2 | no | 48 | 12/12/0/0 | 12/12/0/0 | 12/12/0/0 | 24/24 |
-| d2 two-edit | `(c,c+ex):5 (c,c+ey):7` | 2 | 1 | no | 24 | 6/6/0/12 | 6/6/0/12 | 6/6/0/12 | 24/24 |
-| d3 three-edit | `(c,c+ex):5 (c,c+ey):7 (c,c+ez):11` | 1 | 1 | no | 12 | 3/3/0/18 | 3/3/0/18 | 3/3/0/18 | 24/24 |
-| d4 symmetric pair | `(c,c+ex):5 (c,c-ex):5` | 16 | 4 | yes | 48 | 0/0/24/0 | 0/0/24/0 | 0/0/24/0 | 24/24 |
+| one edit | `(c,c+ex):5` | 8 | 2 | no | 48 | 12/12/0/0 | 12/12/0/0 | 12/12/0/0 | 24/24 |
+| two distinct-axis edits | `(c,c+ex):5 (c,c+ey):7` | 2 | 1 | no | 24 | 6/6/0/12 | 6/6/0/12 | 6/6/0/12 | 24/24 |
+| three distinct-axis edits | `(c,c+ex):5 (c,c+ey):7 (c,c+ez):11` | 1 | 1 | no | 12 | 3/3/0/18 | 3/3/0/18 | 3/3/0/18 | 24/24 |
+| inversion pair | `(c,c+ex):5 (c,c-ex):5` | 16 | 4 | yes | 48 | 0/0/24/0 | 0/0/24/0 | 0/0/24/0 | 24/24 |
 
 Measured `|CS.Stab|` equals the counting-law value 48 / 24 / 12 / 48 on all four domains
-at both sizes. For d3 the six lawful proper frames are exactly `CS_proper` itself: the
+at both sizes. For the three-distinct-axis domain the six lawful proper frames
+are exactly `CS_proper` itself: the
 three all-plus even permutations carry the plus sign, the three negated transpositions the
-minus sign. For d4 the `CS` intersect `Stab48` subgroup is `{I, swap_yz, -I, -swap_yz}`,
+minus sign. For the inversion-pair domain the `CS` intersect `Stab48`
+subgroup is `{I, swap_yz, -I, -swap_yz}`,
 which contains `-I`, so the collision criterion fires and all three corollaries apply.
 
 Every chain the battery evaluates — lawful, broken, and wrong-sign rejector rows alike —
@@ -139,7 +254,8 @@ reports the principal coframe unclipped, with measured minimum metric positivity
 4.8e-01 at `L = 3` and 4.2e-01 at `L = 7` over all 57 distinct chains per size. The
 compiler's clip branch is a guard, never a smoothing: no gated value in this note rests
 on a clipped coframe. The insertion amplitude 5.0e-02 is chosen inside this unclipped
-regime — at amplitude 2.0e-01 the multi-edit domains d2, d3, and (at `L = 3`) d4 drive
+regime — at amplitude 2.0e-01 the two-distinct-axis and
+three-distinct-axis domains, plus the `L = 3` inversion-pair domain, drive
 the metric non-positive and the guard fires, so the working point sits below that
 threshold.
 
@@ -148,28 +264,32 @@ lawful pairs; `none` means the branch is empty for that domain.
 
 | domain | `L` | plus floor | minus floor | both floor | broken minimum |
 |---|---|---|---|---|---|
-| d1 | 3 | 2.3e-15 | 2.5e-12 | none | none |
-| d2 | 3 | 3.0e-15 | 2.4e-11 | none | 5.7e-02 |
-| d3 | 3 | 3.3e-15 | 2.7e-11 | none | 8.5e-02 |
-| d4 | 3 | none | none | 6.4e-12 | none |
-| d1 | 7 | 8.9e-14 | 8.2e-11 | none | none |
-| d2 | 7 | 2.1e-13 | 1.5e-10 | none | 4.1e-02 |
-| d3 | 7 | 1.4e-13 | 1.6e-10 | none | 1.2e-01 |
-| d4 | 7 | none | none | 1.2e-10 | none |
+| one edit | 3 | 2.3e-15 | 2.5e-12 | none | none |
+| two distinct-axis edits | 3 | 3.0e-15 | 2.4e-11 | none | 5.7e-02 |
+| three distinct-axis edits | 3 | 3.3e-15 | 2.7e-11 | none | 8.5e-02 |
+| inversion pair | 3 | none | none | 6.4e-12 | none |
+| one edit | 7 | 8.9e-14 | 8.2e-11 | none | none |
+| two distinct-axis edits | 7 | 2.1e-13 | 1.5e-10 | none | 4.1e-02 |
+| three distinct-axis edits | 7 | 1.4e-13 | 1.6e-10 | none | 1.2e-01 |
+| inversion pair | 7 | none | none | 1.2e-10 | none |
 
-Pointwise transport, measured over the distinct coset representatives (6 / 12 / 6 / 6 for
-d1 / d2 / d3 / d4 at both sizes): worst plus-branch defect 3.8e-15 and worst minus-branch
+Pointwise transport, measured over the distinct constant-sign representatives
+(12 / 12 / 6 / 12 for one edit / two distinct-axis edits / three
+distinct-axis edits / inversion pair at both sizes): worst plus-branch defect
+3.8e-15 and worst minus-branch
 defect 2.7e-11 at `L = 3`; 2.1e-13 and 1.6e-10 at `L = 7`. State collapse holds over
-24 / 12 / 6 / 48 lawful pairs per domain, with `rho` bit-equality on the same pairs. No
+48 / 12 / 6 / 96 constant-sign representatives per domain, with `rho` bit-equality
+on the same representatives. No
 frame anywhere in the battery lands in the forbidden band between the classification hit
 tolerance 1.0e-05 and the classification miss tolerance 1.0e-03; the measured count of
 such gap hits is 0 on every domain at both sizes.
 
-Symmetric-pair corollaries, measured: `-I` is in `Stab48(d4)` at both sizes; palindrome
+Inversion-pair corollaries, measured: `-I` is in its stabilizer at both sizes;
+palindrome
 defect 6.3e-12, `|K(centre)|` 6.5e-12, antisymmetry defect 1.3e-11 at `L = 3`; and
 1.2e-10, 3.4e-11, 1.2e-10 at `L = 7`.
 
-The paired runner's own final line is `TOTAL: PASS=95 FAIL=0`, and its stdout is captured
+The primary runner's own final line is `TOTAL: PASS=95 FAIL=0`, and its stdout is captured
 byte-for-byte in the cold output named above.
 
 ## Rejectors
@@ -177,23 +297,27 @@ byte-for-byte in the cold output named above.
 Each of these numbers discriminates: a wrong model of the sign law changes it.
 
 - **Proper-only classifier.** Restricting the stabilizer to its proper part and running the
-  same coset construction labels only 6 of the two-edit domain's proper frames lawful,
+  same coset construction labels only 6 of the two-distinct-axis domain's proper frames lawful,
   against 12 measured — a mismatch of 6, identical at both sizes. The improper elements of
   `Stab48` are load-bearing bookkeeping: dropping them loses half the lawful frames. This
   is why the construction is carried out in `G48` and not in the 24 proper frames alone.
 - **Determinant-as-sign model.** The hypothesis that the multiset sign is the frame
   determinant fails immediately: all 24 proper frames have determinant `+1`, yet 12 of the
-  24 are measured minus on the single-edit domain. The model misclassifies 12 of 24, at
+  24 are measured minus on the one-edit domain. The model misclassifies 12 of 24, at
   both sizes.
-- **Wrong-sign distances.** Comparing a lawful frame's `K` multiset against the OPPOSITE
-  sign of the reference gives, at `L = 3`, 5.0e-02 from both the plus and the minus frame
-  on d1 and 4.2e-02 on d3; at `L = 7`, 1.2e-02 on d1 and 3.2e-02 on d3. Every one of these
+- **Wrong-sign distances.** Comparing a lawful frame's `K` multiset against the opposite
+  sign of the reference gives minimum distances, at `L = 3`, 5.0e-02 over
+  the plus and minus frames of the one-edit domain and 4.2e-02 over those of
+  the three-distinct-axis domain; at `L = 7`, the corresponding minima are
+  1.2e-02 and 3.2e-02. Every one of these
   is far above the corresponding floors, so the branch assignment is not an artefact of a
   loose tolerance.
 - **Single-valuedness.** On every lawful frame where the collision criterion does not
-  fire, the measured `sgn-set` is single-valued: 24 lawful frames on d1, 12 on d2, 6 on
-  d3, each carrying exactly one sign. (Distinct lawful frames can share a stabilizer
-  coset — d1's 24 lawful frames sit on 6 distinct cosets — so the per-frame count
+  fire, the measured `sgn-set` is single-valued: 24 lawful frames on the
+  one-edit domain, 12 on the two-distinct-axis domain, and 6 on the
+  three-distinct-axis domain, each carrying exactly one sign. (Distinct lawful
+  frames can share a stabilizer coset — the one-edit domain's 24 lawful frames
+  sit on 6 distinct cosets — so the per-frame count
   exercises each coset more than once.) The criterion's "if and only if" therefore has
   both directions exercised by the battery.
 - **Separation margin.** The smallest ratio of an off-class distance (a broken minimum or a
@@ -202,7 +326,8 @@ Each of these numbers discriminates: a wrong model of the sign law changes it.
 
 ## Honest boundary
 
-- The converse of the classification theorem — that an empty `sgn-set` implies the frame
+- The converse of the conditional classification implication — that an empty
+  `sgn-set` implies the frame
   really is broken — is **measured, not derived**. The derived direction supplies only
   sufficiency: every element of `sgn-set(g)` is a valid sign. The battery measures the
   broken frames sitting far above every floor, but no argument here forbids some other
@@ -213,14 +338,15 @@ Each of these numbers discriminates: a wrong model of the sign law changes it.
   was specified: at `L = 3` the minimum ratio is 1.5e+09, comfortably past 9 orders, but at
   `L = 7` it falls to 1.5e+08, about 8.2 orders. The measured value stands; the anticipated
   one does not. The drop tracks the growth of the minus-branch floor with size and the
-  shrinking of the single-edit domain's wrong-sign distance from 5.0e-02 to 1.2e-02, both
+  shrinking of the one-edit domain's wrong-sign distance from 5.0e-02 to 1.2e-02, both
   of which are visible in the tables above.
-- The minus-branch floor VALUES are **measured, not derived**. Their scale is inherited
+- The minus-branch floor values are **measured, not derived**. Their scale is inherited
   from the chain's linear solve and its response amplitude, not predicted by anything in
-  this note. The classification predicts which branch a frame lands in; it does not predict
-  the magnitude of the residual defect within a branch.
+  this note. On the declared domains, the conditional sign-set construction predicts
+  which branch a frame lands in after its transport premise is verified; it does not
+  predict the residual defect within a branch.
 - Improper bookkeeping carries no symmetry claim, as stated in the scope guard.
-- All claims are scoped to this compiled chain, this four-domain battery, and `L` in
+- All numerical claims are scoped to this supplied chain, this four-domain battery, and `L` in
   `{3, 7}`, with the open-box boundary (no wrap) and response amplitude 5.0e-02.
 
 ## Named next paths
@@ -230,21 +356,40 @@ Each of these numbers discriminates: a wrong model of the sign law changes it.
   rather than a reported one.
 - Classify over larger edit families: off-centre edits, mixed-axis edits, and edit sets
   whose stabilizer is not a subgroup of the axis stabilizers exercised here. The
-  three-edit domain already reaches the trivial stabilizer, so the interesting direction is
+  three-distinct-axis domain already reaches the trivial stabilizer, so the interesting direction is
   domains whose stabilizer is a different subgroup of the same order.
 - Measure the size scaling of the floors across a longer ladder in `L`, which would turn
   the size dependence noted in the honest boundary into a quantitative law and would say
   whether the separation margin has an asymptote.
 
-## Citations
+## Review record
 
-- [docs/MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md)
-- [docs/PHYSICAL_OPERATIONAL_SOURCE_RESPONSE_READOUT_CHAIN_CYCLE700_NOTE_2026-07-25.md](PHYSICAL_OPERATIONAL_SOURCE_RESPONSE_READOUT_CHAIN_CYCLE700_NOTE_2026-07-25.md)
-- [docs/RECURRENT_ENDPOINT_INCIDENCE_PHYSICAL_M2_COMPILER_TOURNAMENT_CYCLE703_NOTE_2026-07-25.md](RECURRENT_ENDPOINT_INCIDENCE_PHYSICAL_M2_COMPILER_TOURNAMENT_CYCLE703_NOTE_2026-07-25.md)
+Review-loop iteration 1 on 2026-08-11 narrowed the original arbitrary-edit-set
+headline to the conditional finite-group implication and the four-domain
+measurement actually supported. It corrected the collision proof's sidedness,
+added the determinant-balance step omitted from the counting argument, changed
+the state-collapse gate from one chosen representative per sign to every
+constant-sign representative, and changed wrong-sign controls from a first-row
+sample to the minimum across every measured frame in the branch. It also added
+the independent pure-integer checker and source-bound runner caches.
+
+Hard landing conditions are:
+
+- `EXPLICIT_PACKET_HELPER_RUNNER_PATHS` maps
+  `physical_source_edit_set_signed_stabilizer_classification_cycle708_note_2026-08-02`
+  to
+  `scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_independent_check_2026_08_02.py`;
+- both runner caches are fresh against their declared input fingerprints; and
+- the citation-graph manifest is regenerated from the final landing tree.
+
+No audit verdict is proposed by this record. Independent audit owns any
+effective status after landing.
+
+## Provenance context
 
 The open (unlanded) sibling
 `PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01` measures
-two source domains by a coset-collapse argument; those two domains appear here as the
-first two battery rows, d1 and d2, re-derived from the classification theorem rather than
-measured case by case, and their profiles reproduce. That sibling is open work and nothing
+two source domains by a coset-collapse argument. Those domains are the
+one-edit and two-distinct-axis rows, re-derived inside this package rather than
+copied. That sibling is open work and nothing
 in this note depends on it.

--- a/docs/PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.md
+++ b/docs/PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.md
@@ -1,0 +1,250 @@
+# PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02
+
+Date 2026-08-02. Paired runner
+`scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.py`;
+paired outputs
+`outputs/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02_cold_2026-08-02.txt`
+and
+`outputs/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02_receipt_2026-08-02.json`.
+
+## Abstract
+
+This note gives a computable classification of the per-frame sign law of the registered
+`K` multiset over arbitrary integer edit sets on the six-ray source domain. For a source
+domain `D` carrying edits, the decorated stabilizer `Stab48(D)` inside the 48 signed
+permutation matrices, intersected with the 12 constant-sign matrices along the coset of
+a proper frame, determines a four-valued label for every one of the 24 proper frames:
+the multiset of `K` is carried to itself with sign `+1`, with sign `-1`, with both signs,
+or is not carried at all. The classification is exercised on a battery of four domains at
+`L = 3` and `L = 7`. Two of the four are new predictions confirmed by the paired runner:
+the three-edit domain narrows the lawful set to exactly the six constant-sign proper
+frames, split 3 plus / 3 minus with 18 broken; and the symmetric-pair domain makes all 24
+proper frames lawful with BOTH signs, which forces a palindromic spectrum, pointwise
+central antisymmetry, and an exact centre zero of `K` at floor scale. Predicted and
+measured profiles agree 24 of 24 on every domain at both sizes, with 95 gates passing and
+none failing.
+
+## Scope guard
+
+The 24 proper (determinant `+1`) rotations are the axiom symmetries of the cubic lattice
+setting. The 48 signed permutation matrices used here are computational bookkeeping for
+the compiled chain: the 24 improper (determinant `-1`) elements enter this note purely as
+**computational identities** of the compiled map from decorated domain to `K`, and never
+as symmetries of the physical setting. Every claim about a symmetry is a claim about a
+proper frame; the improper elements appear only as intermediate labels that the compiled
+chain happens to realise, and the classification's output is always a statement about the
+24 proper frames. This is stated once here and assumed throughout.
+
+## Setting and definitions
+
+The compiled chain is the landed cycle-696 open-coframe endpoint compiler
+(`scripts/physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py`), whose stages
+are: decorated source domain `D` on an open `L^3` box, source vector `rho(D)`, load
+`b = rho G`, linear response `eps`, clipped coframe, and the scalar endpoint field `K`.
+The runner drives this chain unmodified and rebuilds nothing of its internals.
+
+- `G48` is the set of all 48 signed permutation matrices in three dimensions, built as
+  permutation matrices times the eight sign patterns. Its proper part `SO`, the 24
+  elements of determinant `+1`, is measured equal as a set to the module's own frame list
+  (`c696.c576.FRAMES`); gate A1.
+- `CS` is the set of 12 constant-sign matrices, those of the form `+P` or `-P` with `P` a
+  permutation matrix. `CS` is a subgroup: closure follows from `(-P)(-Q) = PQ`, and the
+  runner checks closure on all 144 products directly; gate A2.
+- The sign character `sx : CS -> {+1, -1}` sends `+P` to `+1` and `-P` to `-1`. It is
+  multiplicative, verified on all 144 pairs; gate A4.
+- `CS_proper = CS` intersect `SO` has 6 elements: the identity, the two 3-cycles with all
+  entries `+1`, and the three negated transpositions `-T` (with `det(-T) = -det(T) = +1`
+  in three dimensions). The runner re-derives this set and cross-checks that it sits at
+  frame indices `[1, 4, 9, 15, 18, 23]`; gate A3.
+- A domain's fingerprint is the canonical, order-independent key `c696.domain_key(D)`:
+  anchor, sorted ports, and sorted directed link triples. `c696.apply_frame_to_domain`
+  accepts any signed permutation matrix, improper ones included.
+- `Stab48(D) = { R in G48 : domain_key(R . D) == domain_key(D) }`, recomputed by
+  fingerprint equality and never hardcoded.
+
+Because `rho` is recomputed from the link state alone, fingerprint equality implies
+bit-identical chain input. The runner does not rely on that argument alone: gate C2
+measures `rho` bit-equality directly over every lawful pair at both sizes.
+
+## The classification theorem
+
+For a proper frame `g`, define
+
+    sgn-set(g) = { sx(h) : h in (g . Stab48(D)) intersect CS }.
+
+**Derived direction.** Let `s` be in `Stab48(D)` with `h = g . s` in `CS`. Sidedness
+matters and is fixed by the group action: `h . D = (g . s) . D = g . (s . D) = g . D`,
+so the frame image of `D` under `g` is EXACTLY the frame image under `h` — not merely
+close, but the same decorated state. Equivalently `h = g . s^{-1}` recovers `s` from a
+constant-sign representative, since `Stab48(D)` is a group. This state collapse is
+re-measured, not assumed: gates C1 and C2 confirm fingerprint equality and `rho`
+bit-equality across every such pair. The constant-sign pointwise transport law for `h`,
+also re-measured by this runner, reads
+
+    K^{h . D}(h x) = sx(h) . K^D(x)   pointwise, at floor-scale defect,
+
+and composing the two gives `multiset(K^{g . D}) = multiset(sx(h) . K^D)`. Hence every
+element of `sgn-set(g)` is a valid multiset sign for `g`.
+
+**Tetrachotomy.** `sgn-set(g)` takes one of four values — empty, `{+1}`, `{-1}`,
+`{+1,-1}` — which label the frame broken, plus, minus, or both. These are all four
+subsets of `{+1,-1}`, so the four labels partition the 24 proper frames for any domain.
+
+**Counting law.** `Stab48(D)` and `CS` are both subgroups, so the subgroup product
+formula gives
+
+    |CS . Stab48| = |CS| . |Stab48| / |CS intersect Stab48|,
+
+and the lawful proper frames are exactly `(CS . Stab48)` intersect `SO`. Gate B3 measures
+the set order of the product against this formula on every domain at both sizes.
+
+**Collision criterion.** `sgn-set(g)` contains BOTH signs for some `g` if and only if
+`Stab48(D)` meets `CS_minus`, the six constant-sign matrices of the form `-P`. Proof, two
+lines: if `h_plus . s1 = h_minus . s2` with both `h` in `CS` and both `s` in `Stab48`,
+then `s2 . s1^{-1} = h_minus^{-1} . h_plus` lies in `CS_minus` intersect `Stab48`, since
+`sx` is multiplicative and the two sides have opposite sign; conversely, multiplying any
+lawful constant-sign representative by a minus-sign stabilizer element produces a second
+representative of the same coset with the opposite sign.
+
+**Corollaries when the criterion fires.** Taking `g` to be the identity forces the
+PALINDROMIC SPECTRUM `multiset(K^D) = multiset(-K^D)`. If in addition `-I` itself lies in
+`Stab48(D)`, the pointwise law for `-I` — whose permutation part is the identity and whose
+signs are all `-1` — forces POINTWISE ANTISYMMETRY `K^D(sigma x) = -K^D(x)`, where `sigma`
+is the site map of `-I`, central inversion about the anchor. Evaluating at the fixed point
+of `sigma` gives the FORCED CENTRE ZERO `K^D(centre) = 0` at floor scale.
+
+## Battery
+
+Four domains, edit weights all distinct from the background ray weight 3, centre
+`c = (A,A,A)` with `A = (L-1)//2`, edit keys directed away from the anchor. Profiles are
+written plus / minus / both / broken. `Stab48` orders, `CS` intersect `Stab48` orders, and
+the member index lists are measured identical at `L = 3` and `L = 7` (gates B1, B2, B4),
+so the stabilizer data below is size-independent across the sizes tested.
+
+| domain | edits | `Stab48` | `CS^Stab` | `-1` in `CS^Stab` | `|CS.Stab|` | predicted | measured `L=3` | measured `L=7` | agreement |
+|---|---|---|---|---|---|---|---|---|---|
+| d1 one-edit | `(c,c+ex):5` | 8 | 2 | no | 48 | 12/12/0/0 | 12/12/0/0 | 12/12/0/0 | 24/24 |
+| d2 two-edit | `(c,c+ex):5 (c,c+ey):7` | 2 | 1 | no | 24 | 6/6/0/12 | 6/6/0/12 | 6/6/0/12 | 24/24 |
+| d3 three-edit | `(c,c+ex):5 (c,c+ey):7 (c,c+ez):11` | 1 | 1 | no | 12 | 3/3/0/18 | 3/3/0/18 | 3/3/0/18 | 24/24 |
+| d4 symmetric pair | `(c,c+ex):5 (c,c-ex):5` | 16 | 4 | yes | 48 | 0/0/24/0 | 0/0/24/0 | 0/0/24/0 | 24/24 |
+
+Measured `|CS.Stab|` equals the counting-law value 48 / 24 / 12 / 48 on all four domains
+at both sizes. For d3 the six lawful proper frames are exactly `CS_proper` itself: the
+three all-plus even permutations carry the plus sign, the three negated transpositions the
+minus sign. For d4 the `CS` intersect `Stab48` subgroup is `{I, swap_yz, -I, -swap_yz}`,
+which contains `-I`, so the collision criterion fires and all three corollaries apply.
+
+Every chain the battery evaluates — lawful, broken, and wrong-sign rejector rows alike —
+reports the principal coframe unclipped, with measured minimum metric positivity margin
+4.8e-01 at `L = 3` and 4.2e-01 at `L = 7` over all 57 distinct chains per size. The
+compiler's clip branch is a guard, never a smoothing: no gated value in this note rests
+on a clipped coframe. The insertion amplitude 5.0e-02 is chosen inside this unclipped
+regime — at amplitude 2.0e-01 the multi-edit domains d2, d3, and (at `L = 3`) d4 drive
+the metric non-positive and the guard fires, so the working point sits below that
+threshold.
+
+Measured floors, `.1e`, taken as the worst defect within each branch across the domain's
+lawful pairs; `none` means the branch is empty for that domain.
+
+| domain | `L` | plus floor | minus floor | both floor | broken minimum |
+|---|---|---|---|---|---|
+| d1 | 3 | 2.3e-15 | 2.5e-12 | none | none |
+| d2 | 3 | 3.0e-15 | 2.4e-11 | none | 5.7e-02 |
+| d3 | 3 | 3.3e-15 | 2.7e-11 | none | 8.5e-02 |
+| d4 | 3 | none | none | 6.4e-12 | none |
+| d1 | 7 | 8.9e-14 | 8.2e-11 | none | none |
+| d2 | 7 | 2.1e-13 | 1.5e-10 | none | 4.1e-02 |
+| d3 | 7 | 1.4e-13 | 1.6e-10 | none | 1.2e-01 |
+| d4 | 7 | none | none | 1.2e-10 | none |
+
+Pointwise transport, measured over the distinct coset representatives (6 / 12 / 6 / 6 for
+d1 / d2 / d3 / d4 at both sizes): worst plus-branch defect 3.8e-15 and worst minus-branch
+defect 2.7e-11 at `L = 3`; 2.1e-13 and 1.6e-10 at `L = 7`. State collapse holds over
+24 / 12 / 6 / 48 lawful pairs per domain, with `rho` bit-equality on the same pairs. No
+frame anywhere in the battery lands in the forbidden band between the classification hit
+tolerance 1.0e-05 and the classification miss tolerance 1.0e-03; the measured count of
+such gap hits is 0 on every domain at both sizes.
+
+Symmetric-pair corollaries, measured: `-I` is in `Stab48(d4)` at both sizes; palindrome
+defect 6.3e-12, `|K(centre)|` 6.5e-12, antisymmetry defect 1.3e-11 at `L = 3`; and
+1.2e-10, 3.4e-11, 1.2e-10 at `L = 7`.
+
+The paired runner's own final line is `TOTAL: PASS=95 FAIL=0`, and its stdout is captured
+byte-for-byte in the cold output named above.
+
+## Rejectors
+
+Each of these numbers discriminates: a wrong model of the sign law changes it.
+
+- **Proper-only classifier.** Restricting the stabilizer to its proper part and running the
+  same coset construction labels only 6 of the two-edit domain's proper frames lawful,
+  against 12 measured — a mismatch of 6, identical at both sizes. The improper elements of
+  `Stab48` are load-bearing bookkeeping: dropping them loses half the lawful frames. This
+  is why the construction is carried out in `G48` and not in the 24 proper frames alone.
+- **Determinant-as-sign model.** The hypothesis that the multiset sign is the frame
+  determinant fails immediately: all 24 proper frames have determinant `+1`, yet 12 of the
+  24 are measured minus on the single-edit domain. The model misclassifies 12 of 24, at
+  both sizes.
+- **Wrong-sign distances.** Comparing a lawful frame's `K` multiset against the OPPOSITE
+  sign of the reference gives, at `L = 3`, 5.0e-02 from both the plus and the minus frame
+  on d1 and 4.2e-02 on d3; at `L = 7`, 1.2e-02 on d1 and 3.2e-02 on d3. Every one of these
+  is far above the corresponding floors, so the branch assignment is not an artefact of a
+  loose tolerance.
+- **Single-valuedness.** On every lawful frame where the collision criterion does not
+  fire, the measured `sgn-set` is single-valued: 24 lawful frames on d1, 12 on d2, 6 on
+  d3, each carrying exactly one sign. (Distinct lawful frames can share a stabilizer
+  coset — d1's 24 lawful frames sit on 6 distinct cosets — so the per-frame count
+  exercises each coset more than once.) The criterion's "if and only if" therefore has
+  both directions exercised by the battery.
+- **Separation margin.** The smallest ratio of an off-class distance (a broken minimum or a
+  wrong-sign distance) to the worst lawful floor in the same row is measured 1.5e+09 at
+  `L = 3` and 1.5e+08 at `L = 7`, across four rows at each size.
+
+## Honest boundary
+
+- The converse of the classification theorem — that an empty `sgn-set` implies the frame
+  really is broken — is **measured, not derived**. The derived direction supplies only
+  sufficiency: every element of `sgn-set(g)` is a valid sign. The battery measures the
+  broken frames sitting far above every floor, but no argument here forbids some other
+  mechanism from carrying a multiset without a constant-sign coset representative.
+- The measured separation of the broken and wrong-sign distances above the lawful floors is
+  at least 8 orders of magnitude everywhere in the battery, with minimum ratio 1.5e+08.
+  This is an honest shortfall against the 9-order separation anticipated when the battery
+  was specified: at `L = 3` the minimum ratio is 1.5e+09, comfortably past 9 orders, but at
+  `L = 7` it falls to 1.5e+08, about 8.2 orders. The measured value stands; the anticipated
+  one does not. The drop tracks the growth of the minus-branch floor with size and the
+  shrinking of the single-edit domain's wrong-sign distance from 5.0e-02 to 1.2e-02, both
+  of which are visible in the tables above.
+- The minus-branch floor VALUES are **measured, not derived**. Their scale is inherited
+  from the chain's linear solve and its response amplitude, not predicted by anything in
+  this note. The classification predicts which branch a frame lands in; it does not predict
+  the magnitude of the residual defect within a branch.
+- Improper bookkeeping carries no symmetry claim, as stated in the scope guard.
+- All claims are scoped to this compiled chain, this four-domain battery, and `L` in
+  `{3, 7}`, with the open-box boundary (no wrap) and response amplitude 5.0e-02.
+
+## Named next paths
+
+- Derive the response-stage floor constant, so that the minus-branch floor values become
+  predicted rather than measured, and the separation margin becomes a computed quantity
+  rather than a reported one.
+- Classify over larger edit families: off-centre edits, mixed-axis edits, and edit sets
+  whose stabilizer is not a subgroup of the axis stabilizers exercised here. The
+  three-edit domain already reaches the trivial stabilizer, so the interesting direction is
+  domains whose stabilizer is a different subgroup of the same order.
+- Measure the size scaling of the floors across a longer ladder in `L`, which would turn
+  the size dependence noted in the honest boundary into a quantitative law and would say
+  whether the separation margin has an asymptote.
+
+## Citations
+
+- [docs/MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md)
+- [docs/PHYSICAL_OPERATIONAL_SOURCE_RESPONSE_READOUT_CHAIN_CYCLE700_NOTE_2026-07-25.md](PHYSICAL_OPERATIONAL_SOURCE_RESPONSE_READOUT_CHAIN_CYCLE700_NOTE_2026-07-25.md)
+- [docs/RECURRENT_ENDPOINT_INCIDENCE_PHYSICAL_M2_COMPILER_TOURNAMENT_CYCLE703_NOTE_2026-07-25.md](RECURRENT_ENDPOINT_INCIDENCE_PHYSICAL_M2_COMPILER_TOURNAMENT_CYCLE703_NOTE_2026-07-25.md)
+
+The open (unlanded) sibling
+`PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01` measures
+two source domains by a coset-collapse argument; those two domains appear here as the
+first two battery rows, d1 and d2, re-derived from the classification theorem rather than
+measured case by case, and their profiles reproduce. That sibling is open work and nothing
+in this note depends on it.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15488,
- "node_count": 5450,
+ "edge_count": 15490,
+ "node_count": 5451,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13740,6 +13740,10 @@
   },
   "physical_scale_free_adjacency_dissection_bracket_cycle724_note_2026-08-03": {
    "deps_hash": "0d988fd1ac07",
+   "out_degree": 2
+  },
+  "physical_source_edit_set_signed_stabilizer_classification_cycle708_note_2026-08-02": {
+   "deps_hash": "7f0a42542a90",
    "out_degree": 2
   },
   "physical_source_stabilizer_coset_collapse_k_sign_law_cycle707_note_2026-08-01": {

--- a/docs/audit/scripts/build_citation_graph.py
+++ b/docs/audit/scripts/build_citation_graph.py
@@ -154,6 +154,13 @@ EXPLICIT_PACKET_HELPER_RUNNER_PATHS = {
     "inter_site_gate_cycle970_bounded_theorem_note_2026-08-09": [
         "scripts/frontier_cycle970_gate_independent_check_2026_08_09.py",
     ],
+    # Cycle 708's checker reconstructs the signed-permutation algebra and the
+    # four weighted-domain stabilizers without importing the numerical primary
+    # or its supplied source-response compiler.
+    "physical_source_edit_set_signed_stabilizer_classification_cycle708_note_2026-08-02": [
+        "scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_"
+        "independent_check_2026_08_02.py",
+    ],
     "b4_clock_relation_run_cycle879_bounded_theorem_note_2026-07-28": [
         "scripts/frontier_cycle879_b4_relation_independent_check_2026_07_28.py",
     ],

--- a/logs/runner-cache/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.txt
+++ b/logs/runner-cache/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.txt
@@ -1,3 +1,12 @@
+===== runner cache v1 =====
+runner: scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.py
+runner_sha256: f2e41a0191ce85a71275cbcfcb2064bb1f26ef68927b6b5b262b78ea7a4bb855
+input_fingerprint_sha256: 085f31f5aa02277c391a3f15d5bdd8748a3acb0a9ac49a51a687baae096d67eb
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 5.98
+status: ok
+----- stdout -----
 Cycle 708 conditional signed-stabilizer classifier for a supplied K map
 note PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.md
 battery one-edit, two-distinct-axis-edits, three-distinct-axis-edits, and inversion-pair; sizes 3 and 7
@@ -52,3 +61,6 @@ separation_floor L=7 smallest off-class distance over worst lawful floor 1.5e+08
 size_independence Stab48 member index lists equal at L=3 and L=7 for all four domains PASS
 sign_single_valuedness on every lawful frame one_edit 24 two_distinct_axis_edits 12 three_distinct_axis_edits 6 PASS
 TOTAL: PASS=95 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/physical_source_edit_set_signed_stabilizer_classification_cycle708_independent_check_2026_08_02.txt
+++ b/logs/runner-cache/physical_source_edit_set_signed_stabilizer_classification_cycle708_independent_check_2026_08_02.txt
@@ -1,0 +1,72 @@
+===== runner cache v1 =====
+runner: scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_independent_check_2026_08_02.py
+runner_sha256: 7cdf9d3b9d92249b796fc0b9de5884e18aa57c41d7e66bcdda36beec624eaf7a
+input_fingerprint_sha256: 49d378f8a1e48df6a29c5124f03f29899b14e579ad2e76f07dcdebcee593eb8b
+timeout_sec: 60
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+PASS group has 48 distinct signed permutations
+PASS proper subgroup has order 24
+PASS constant-sign subgroup has order 12
+PASS constant-sign set is closed
+PASS constant-sign character is multiplicative
+PASS one_edit stabilizer order
+PASS one_edit constant-sign intersection order
+PASS one_edit subgroup-product formula
+PASS one_edit determinant balance
+PASS one_edit exact proper-frame profile
+PASS one_edit collision criterion
+PASS one_edit every-representative census
+PASS one_edit L=3 receipt profile
+PASS one_edit L=3 primary agreement
+PASS one_edit L=3 receipt representative census
+PASS one_edit L=7 receipt profile
+PASS one_edit L=7 primary agreement
+PASS one_edit L=7 receipt representative census
+PASS two_distinct_axis_edits stabilizer order
+PASS two_distinct_axis_edits constant-sign intersection order
+PASS two_distinct_axis_edits subgroup-product formula
+PASS two_distinct_axis_edits determinant balance
+PASS two_distinct_axis_edits exact proper-frame profile
+PASS two_distinct_axis_edits collision criterion
+PASS two_distinct_axis_edits every-representative census
+PASS two_distinct_axis_edits L=3 receipt profile
+PASS two_distinct_axis_edits L=3 primary agreement
+PASS two_distinct_axis_edits L=3 receipt representative census
+PASS two_distinct_axis_edits L=7 receipt profile
+PASS two_distinct_axis_edits L=7 primary agreement
+PASS two_distinct_axis_edits L=7 receipt representative census
+PASS three_distinct_axis_edits stabilizer order
+PASS three_distinct_axis_edits constant-sign intersection order
+PASS three_distinct_axis_edits subgroup-product formula
+PASS three_distinct_axis_edits determinant balance
+PASS three_distinct_axis_edits exact proper-frame profile
+PASS three_distinct_axis_edits collision criterion
+PASS three_distinct_axis_edits every-representative census
+PASS three_distinct_axis_edits L=3 receipt profile
+PASS three_distinct_axis_edits L=3 primary agreement
+PASS three_distinct_axis_edits L=3 receipt representative census
+PASS three_distinct_axis_edits L=7 receipt profile
+PASS three_distinct_axis_edits L=7 primary agreement
+PASS three_distinct_axis_edits L=7 receipt representative census
+PASS inversion_pair stabilizer order
+PASS inversion_pair constant-sign intersection order
+PASS inversion_pair subgroup-product formula
+PASS inversion_pair determinant balance
+PASS inversion_pair exact proper-frame profile
+PASS inversion_pair collision criterion
+PASS inversion_pair every-representative census
+PASS inversion_pair L=3 receipt profile
+PASS inversion_pair L=3 primary agreement
+PASS inversion_pair L=3 receipt representative census
+PASS inversion_pair L=7 receipt profile
+PASS inversion_pair L=7 primary agreement
+PASS inversion_pair L=7 receipt representative census
+PASS right-coset sidedness rejector changes eight frame labels
+PASS primary receipt reports no failed gates
+TOTAL: PASS=59 FAIL=0
+
+----- stderr -----
+

--- a/outputs/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02_cold_2026-08-02.txt
+++ b/outputs/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02_cold_2026-08-02.txt
@@ -1,0 +1,54 @@
+c708 signed-stabilizer classification of the registered K sign law over edit sets
+note PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.md
+battery d1 one-edit d2 two-edit d3 three-edit d4 symmetric-pair; sizes 3 and 7
+A1 G48 order 48 distinct 48 proper 24 equals module FRAMES set PASS
+A2 CS order 12 closed under all 144 products PASS
+A3 SANITY CS_proper order 6 FRAMES indices [1, 4, 9, 15, 18, 23] PASS
+A4 sx multiplicative on all 144 CS pairs PASS
+B1 L=3 Stab48 orders d1 8 d2 2 d3 1 d4 16 PASS
+B2 L=3 CS^Stab orders 2 1 1 4 minus-sign member no no no yes PASS
+B3 L=3 CS.Stab set orders 48 24 12 48 equal formula 48 24 12 48 PASS
+C0 L=3 principal coframe unclipped on all 57 chains pd_min 4.8e-01 PASS
+C1 L=3 state collapse over lawful pairs 24 12 6 48 PASS
+C2 L=3 rho bit-equality over the same lawful pairs PASS
+C3 L=3 pointwise law reps 6 12 6 6 worst plus 3.8e-15 minus 2.7e-11 PASS
+C4 L=3 d1 measured 12/12/0/0 predicted 12/12/0/0 agreement 24/24 PASS
+C4 L=3 d2 measured 6/6/0/12 predicted 6/6/0/12 agreement 24/24 PASS
+C4 L=3 d3 measured 3/3/0/18 predicted 3/3/0/18 agreement 24/24 PASS
+C4 L=3 d4 measured 0/0/24/0 predicted 0/0/24/0 agreement 24/24 PASS
+C5 L=3 d1 floors plus 2.3e-15 minus 2.5e-12 both none broken none sep none PASS
+C5 L=3 d2 floors plus 3.0e-15 minus 2.4e-11 both none broken 5.7e-02 sep 2.3e+09 PASS
+C5 L=3 d3 floors plus 3.3e-15 minus 2.7e-11 both none broken 8.5e-02 sep 3.1e+09 PASS
+C5 L=3 d4 floors plus none minus none both 6.4e-12 broken none sep none PASS
+D1 L=3 proper-only classifier lawful 6 vs measured 12 on d2 mismatch 6 PASS
+D2 L=3 det-as-sign model misclassifies 12 of 24 on d1 PASS
+D3 L=3 d1 wrong-sign distance plus-frame 5.0e-02 minus-frame 5.0e-02 sep 2.0e+10 PASS
+D3 L=3 d3 wrong-sign distance plus-frame 4.2e-02 minus-frame 4.2e-02 sep 1.5e+09 PASS
+E1 L=3 -I in Stab48(d4) True PASS
+E2E3E4 L=3 d4 palindrome 6.3e-12 centre 6.5e-12 antisymmetry 1.3e-11 PASS
+F1 L=3 smallest off-class distance over worst lawful floor 1.5e+09 across 4 rows PASS
+B1 L=7 Stab48 orders d1 8 d2 2 d3 1 d4 16 PASS
+B2 L=7 CS^Stab orders 2 1 1 4 minus-sign member no no no yes PASS
+B3 L=7 CS.Stab set orders 48 24 12 48 equal formula 48 24 12 48 PASS
+C0 L=7 principal coframe unclipped on all 57 chains pd_min 4.2e-01 PASS
+C1 L=7 state collapse over lawful pairs 24 12 6 48 PASS
+C2 L=7 rho bit-equality over the same lawful pairs PASS
+C3 L=7 pointwise law reps 6 12 6 6 worst plus 2.1e-13 minus 1.6e-10 PASS
+C4 L=7 d1 measured 12/12/0/0 predicted 12/12/0/0 agreement 24/24 PASS
+C4 L=7 d2 measured 6/6/0/12 predicted 6/6/0/12 agreement 24/24 PASS
+C4 L=7 d3 measured 3/3/0/18 predicted 3/3/0/18 agreement 24/24 PASS
+C4 L=7 d4 measured 0/0/24/0 predicted 0/0/24/0 agreement 24/24 PASS
+C5 L=7 d1 floors plus 8.9e-14 minus 8.2e-11 both none broken none sep none PASS
+C5 L=7 d2 floors plus 2.1e-13 minus 1.5e-10 both none broken 4.1e-02 sep 2.6e+08 PASS
+C5 L=7 d3 floors plus 1.4e-13 minus 1.6e-10 both none broken 1.2e-01 sep 7.7e+08 PASS
+C5 L=7 d4 floors plus none minus none both 1.2e-10 broken none sep none PASS
+D1 L=7 proper-only classifier lawful 6 vs measured 12 on d2 mismatch 6 PASS
+D2 L=7 det-as-sign model misclassifies 12 of 24 on d1 PASS
+D3 L=7 d1 wrong-sign distance plus-frame 1.2e-02 minus-frame 1.2e-02 sep 1.5e+08 PASS
+D3 L=7 d3 wrong-sign distance plus-frame 3.2e-02 minus-frame 3.2e-02 sep 2.0e+08 PASS
+E1 L=7 -I in Stab48(d4) True PASS
+E2E3E4 L=7 d4 palindrome 1.2e-10 centre 3.4e-11 antisymmetry 1.2e-10 PASS
+F1 L=7 smallest off-class distance over worst lawful floor 1.5e+08 across 4 rows PASS
+B4 Stab48 member index lists equal at L=3 and L=7 for d1 d2 d3 d4 PASS
+D4 sgn-set single-valued on every lawful frame d1 24 d2 12 d3 6 PASS
+TOTAL: PASS=95 FAIL=0

--- a/outputs/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02_receipt_2026-08-02.json
+++ b/outputs/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02_receipt_2026-08-02.json
@@ -31,20 +31,52 @@
   },
   "domains": {
     "L3": {
-      "d1": {
+      "inversion_pair": {
+        "agreement": 24,
+        "broken_minimum": "none",
+        "broken_over_floor": "none",
+        "cs_stab_has_minus_sign": true,
+        "cs_stab_order": 4,
+        "cs_stab_product_order": 48,
+        "distinct_representatives": 12,
+        "edits": "(c,c+ex):5 (c,c-ex):5",
+        "floor_both": "6.4e-12",
+        "floor_minus": "none",
+        "floor_plus": "none",
+        "forbidden_gap_hits": 0,
+        "lawful_pairs": 96,
+        "measured_profile": [
+          0,
+          0,
+          24,
+          0
+        ],
+        "pointwise_minus": "1.3e-11",
+        "pointwise_plus": "3.8e-15",
+        "predicted_profile": [
+          0,
+          0,
+          24,
+          0
+        ],
+        "product_formula": 48,
+        "stab48_order": 16,
+        "worst_lawful_floor": "6.4e-12"
+      },
+      "one_edit": {
         "agreement": 24,
         "broken_minimum": "none",
         "broken_over_floor": "none",
         "cs_stab_has_minus_sign": false,
         "cs_stab_order": 2,
         "cs_stab_product_order": 48,
-        "distinct_representatives": 6,
+        "distinct_representatives": 12,
         "edits": "(c,c+ex):5",
         "floor_both": "none",
         "floor_minus": "2.5e-12",
         "floor_plus": "2.3e-15",
         "forbidden_gap_hits": 0,
-        "lawful_pairs": 24,
+        "lawful_pairs": 48,
         "measured_profile": [
           12,
           12,
@@ -52,7 +84,7 @@
           0
         ],
         "pointwise_minus": "2.5e-12",
-        "pointwise_plus": "3.3e-15",
+        "pointwise_plus": "3.4e-15",
         "predicted_profile": [
           12,
           12,
@@ -63,39 +95,7 @@
         "stab48_order": 8,
         "worst_lawful_floor": "2.5e-12"
       },
-      "d2": {
-        "agreement": 24,
-        "broken_minimum": "5.7e-02",
-        "broken_over_floor": "2.3e+09",
-        "cs_stab_has_minus_sign": false,
-        "cs_stab_order": 1,
-        "cs_stab_product_order": 24,
-        "distinct_representatives": 12,
-        "edits": "(c,c+ex):5 (c,c+ey):7",
-        "floor_both": "none",
-        "floor_minus": "2.4e-11",
-        "floor_plus": "3.0e-15",
-        "forbidden_gap_hits": 0,
-        "lawful_pairs": 12,
-        "measured_profile": [
-          6,
-          6,
-          0,
-          12
-        ],
-        "pointwise_minus": "2.4e-11",
-        "pointwise_plus": "3.0e-15",
-        "predicted_profile": [
-          6,
-          6,
-          0,
-          12
-        ],
-        "product_formula": 24,
-        "stab48_order": 2,
-        "worst_lawful_floor": "2.4e-11"
-      },
-      "d3": {
+      "three_distinct_axis_edits": {
         "agreement": 24,
         "broken_minimum": "8.5e-02",
         "broken_over_floor": "3.1e+09",
@@ -127,28 +127,62 @@
         "stab48_order": 1,
         "worst_lawful_floor": "2.7e-11"
       },
-      "d4": {
+      "two_distinct_axis_edits": {
+        "agreement": 24,
+        "broken_minimum": "5.7e-02",
+        "broken_over_floor": "2.3e+09",
+        "cs_stab_has_minus_sign": false,
+        "cs_stab_order": 1,
+        "cs_stab_product_order": 24,
+        "distinct_representatives": 12,
+        "edits": "(c,c+ex):5 (c,c+ey):7",
+        "floor_both": "none",
+        "floor_minus": "2.4e-11",
+        "floor_plus": "3.0e-15",
+        "forbidden_gap_hits": 0,
+        "lawful_pairs": 12,
+        "measured_profile": [
+          6,
+          6,
+          0,
+          12
+        ],
+        "pointwise_minus": "2.4e-11",
+        "pointwise_plus": "3.0e-15",
+        "predicted_profile": [
+          6,
+          6,
+          0,
+          12
+        ],
+        "product_formula": 24,
+        "stab48_order": 2,
+        "worst_lawful_floor": "2.4e-11"
+      }
+    },
+    "L7": {
+      "inversion_pair": {
         "agreement": 24,
         "broken_minimum": "none",
         "broken_over_floor": "none",
         "cs_stab_has_minus_sign": true,
         "cs_stab_order": 4,
         "cs_stab_product_order": 48,
-        "distinct_representatives": 6,
+        "distinct_representatives": 12,
         "edits": "(c,c+ex):5 (c,c-ex):5",
-        "floor_both": "6.4e-12",
+        "floor_both": "1.2e-10",
         "floor_minus": "none",
         "floor_plus": "none",
         "forbidden_gap_hits": 0,
-        "lawful_pairs": 48,
+        "lawful_pairs": 96,
         "measured_profile": [
           0,
           0,
           24,
           0
         ],
-        "pointwise_minus": "1.3e-11",
-        "pointwise_plus": "3.8e-15",
+        "pointwise_minus": "1.2e-10",
+        "pointwise_plus": "1.3e-13",
         "predicted_profile": [
           0,
           0,
@@ -157,24 +191,22 @@
         ],
         "product_formula": 48,
         "stab48_order": 16,
-        "worst_lawful_floor": "6.4e-12"
-      }
-    },
-    "L7": {
-      "d1": {
+        "worst_lawful_floor": "1.2e-10"
+      },
+      "one_edit": {
         "agreement": 24,
         "broken_minimum": "none",
         "broken_over_floor": "none",
         "cs_stab_has_minus_sign": false,
         "cs_stab_order": 2,
         "cs_stab_product_order": 48,
-        "distinct_representatives": 6,
+        "distinct_representatives": 12,
         "edits": "(c,c+ex):5",
         "floor_both": "none",
         "floor_minus": "8.2e-11",
         "floor_plus": "8.9e-14",
         "forbidden_gap_hits": 0,
-        "lawful_pairs": 24,
+        "lawful_pairs": 48,
         "measured_profile": [
           12,
           12,
@@ -193,39 +225,7 @@
         "stab48_order": 8,
         "worst_lawful_floor": "8.2e-11"
       },
-      "d2": {
-        "agreement": 24,
-        "broken_minimum": "4.1e-02",
-        "broken_over_floor": "2.6e+08",
-        "cs_stab_has_minus_sign": false,
-        "cs_stab_order": 1,
-        "cs_stab_product_order": 24,
-        "distinct_representatives": 12,
-        "edits": "(c,c+ex):5 (c,c+ey):7",
-        "floor_both": "none",
-        "floor_minus": "1.5e-10",
-        "floor_plus": "2.1e-13",
-        "forbidden_gap_hits": 0,
-        "lawful_pairs": 12,
-        "measured_profile": [
-          6,
-          6,
-          0,
-          12
-        ],
-        "pointwise_minus": "1.5e-10",
-        "pointwise_plus": "2.1e-13",
-        "predicted_profile": [
-          6,
-          6,
-          0,
-          12
-        ],
-        "product_formula": 24,
-        "stab48_order": 2,
-        "worst_lawful_floor": "1.5e-10"
-      },
-      "d3": {
+      "three_distinct_axis_edits": {
         "agreement": 24,
         "broken_minimum": "1.2e-01",
         "broken_over_floor": "7.7e+08",
@@ -257,37 +257,37 @@
         "stab48_order": 1,
         "worst_lawful_floor": "1.6e-10"
       },
-      "d4": {
+      "two_distinct_axis_edits": {
         "agreement": 24,
-        "broken_minimum": "none",
-        "broken_over_floor": "none",
-        "cs_stab_has_minus_sign": true,
-        "cs_stab_order": 4,
-        "cs_stab_product_order": 48,
-        "distinct_representatives": 6,
-        "edits": "(c,c+ex):5 (c,c-ex):5",
-        "floor_both": "1.2e-10",
-        "floor_minus": "none",
-        "floor_plus": "none",
+        "broken_minimum": "4.1e-02",
+        "broken_over_floor": "2.6e+08",
+        "cs_stab_has_minus_sign": false,
+        "cs_stab_order": 1,
+        "cs_stab_product_order": 24,
+        "distinct_representatives": 12,
+        "edits": "(c,c+ex):5 (c,c+ey):7",
+        "floor_both": "none",
+        "floor_minus": "1.5e-10",
+        "floor_plus": "2.1e-13",
         "forbidden_gap_hits": 0,
-        "lawful_pairs": 48,
+        "lawful_pairs": 12,
         "measured_profile": [
+          6,
+          6,
           0,
-          0,
-          24,
-          0
+          12
         ],
-        "pointwise_minus": "1.2e-10",
-        "pointwise_plus": "1.2e-13",
+        "pointwise_minus": "1.5e-10",
+        "pointwise_plus": "2.1e-13",
         "predicted_profile": [
+          6,
+          6,
           0,
-          0,
-          24,
-          0
+          12
         ],
-        "product_formula": 48,
-        "stab48_order": 16,
-        "worst_lawful_floor": "1.2e-10"
+        "product_formula": 24,
+        "stab48_order": 2,
+        "worst_lawful_floor": "1.5e-10"
       }
     }
   },
@@ -311,35 +311,35 @@
   },
   "note": "PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.md",
   "rejectors": {
-    "det_model_misclassified_d1": 12,
-    "full_classifier_lawful_d2": 12,
-    "proper_only_lawful_d2": 6,
-    "proper_only_mismatch_d2": 6,
+    "det_model_misclassified_one_edit": 12,
+    "full_classifier_lawful_two_distinct_axis_edits": 12,
+    "proper_only_lawful_two_distinct_axis_edits": 6,
+    "proper_only_mismatch_two_distinct_axis_edits": 6,
     "sgn_set_single_valued_lawful_frames": {
-      "d1": 24,
-      "d2": 12,
-      "d3": 6
+      "one_edit": 24,
+      "three_distinct_axis_edits": 6,
+      "two_distinct_axis_edits": 12
     },
     "wrong_sign_distance": {
       "L3": {
-        "d1": {
+        "one_edit": {
           "minus_frame": "5.0e-02",
           "over_floor": "2.0e+10",
           "plus_frame": "5.0e-02"
         },
-        "d3": {
+        "three_distinct_axis_edits": {
           "minus_frame": "4.2e-02",
           "over_floor": "1.5e+09",
           "plus_frame": "4.2e-02"
         }
       },
       "L7": {
-        "d1": {
+        "one_edit": {
           "minus_frame": "1.2e-02",
           "over_floor": "1.5e+08",
           "plus_frame": "1.2e-02"
         },
-        "d3": {
+        "three_distinct_axis_edits": {
           "minus_frame": "3.2e-02",
           "over_floor": "2.0e+08",
           "plus_frame": "3.2e-02"

--- a/outputs/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02_receipt_2026-08-02.json
+++ b/outputs/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02_receipt_2026-08-02.json
@@ -1,0 +1,364 @@
+{
+  "class_separation": {
+    "L3": "1.5e+09",
+    "L7": "1.5e+08"
+  },
+  "coframe_clip": {
+    "L3": {
+      "chains": 57,
+      "clipped": 0,
+      "pd_min": "4.8e-01"
+    },
+    "L7": {
+      "chains": 57,
+      "clipped": 0,
+      "pd_min": "4.2e-01"
+    }
+  },
+  "corollaries_symmetric_pair": {
+    "L3": {
+      "antisymmetry_defect": "1.3e-11",
+      "centre_value": "6.5e-12",
+      "neg_identity_in_stab48": true,
+      "palindrome_defect": "6.3e-12"
+    },
+    "L7": {
+      "antisymmetry_defect": "1.2e-10",
+      "centre_value": "3.4e-11",
+      "neg_identity_in_stab48": true,
+      "palindrome_defect": "1.2e-10"
+    }
+  },
+  "domains": {
+    "L3": {
+      "d1": {
+        "agreement": 24,
+        "broken_minimum": "none",
+        "broken_over_floor": "none",
+        "cs_stab_has_minus_sign": false,
+        "cs_stab_order": 2,
+        "cs_stab_product_order": 48,
+        "distinct_representatives": 6,
+        "edits": "(c,c+ex):5",
+        "floor_both": "none",
+        "floor_minus": "2.5e-12",
+        "floor_plus": "2.3e-15",
+        "forbidden_gap_hits": 0,
+        "lawful_pairs": 24,
+        "measured_profile": [
+          12,
+          12,
+          0,
+          0
+        ],
+        "pointwise_minus": "2.5e-12",
+        "pointwise_plus": "3.3e-15",
+        "predicted_profile": [
+          12,
+          12,
+          0,
+          0
+        ],
+        "product_formula": 48,
+        "stab48_order": 8,
+        "worst_lawful_floor": "2.5e-12"
+      },
+      "d2": {
+        "agreement": 24,
+        "broken_minimum": "5.7e-02",
+        "broken_over_floor": "2.3e+09",
+        "cs_stab_has_minus_sign": false,
+        "cs_stab_order": 1,
+        "cs_stab_product_order": 24,
+        "distinct_representatives": 12,
+        "edits": "(c,c+ex):5 (c,c+ey):7",
+        "floor_both": "none",
+        "floor_minus": "2.4e-11",
+        "floor_plus": "3.0e-15",
+        "forbidden_gap_hits": 0,
+        "lawful_pairs": 12,
+        "measured_profile": [
+          6,
+          6,
+          0,
+          12
+        ],
+        "pointwise_minus": "2.4e-11",
+        "pointwise_plus": "3.0e-15",
+        "predicted_profile": [
+          6,
+          6,
+          0,
+          12
+        ],
+        "product_formula": 24,
+        "stab48_order": 2,
+        "worst_lawful_floor": "2.4e-11"
+      },
+      "d3": {
+        "agreement": 24,
+        "broken_minimum": "8.5e-02",
+        "broken_over_floor": "3.1e+09",
+        "cs_stab_has_minus_sign": false,
+        "cs_stab_order": 1,
+        "cs_stab_product_order": 12,
+        "distinct_representatives": 6,
+        "edits": "(c,c+ex):5 (c,c+ey):7 (c,c+ez):11",
+        "floor_both": "none",
+        "floor_minus": "2.7e-11",
+        "floor_plus": "3.3e-15",
+        "forbidden_gap_hits": 0,
+        "lawful_pairs": 6,
+        "measured_profile": [
+          3,
+          3,
+          0,
+          18
+        ],
+        "pointwise_minus": "2.7e-11",
+        "pointwise_plus": "3.3e-15",
+        "predicted_profile": [
+          3,
+          3,
+          0,
+          18
+        ],
+        "product_formula": 12,
+        "stab48_order": 1,
+        "worst_lawful_floor": "2.7e-11"
+      },
+      "d4": {
+        "agreement": 24,
+        "broken_minimum": "none",
+        "broken_over_floor": "none",
+        "cs_stab_has_minus_sign": true,
+        "cs_stab_order": 4,
+        "cs_stab_product_order": 48,
+        "distinct_representatives": 6,
+        "edits": "(c,c+ex):5 (c,c-ex):5",
+        "floor_both": "6.4e-12",
+        "floor_minus": "none",
+        "floor_plus": "none",
+        "forbidden_gap_hits": 0,
+        "lawful_pairs": 48,
+        "measured_profile": [
+          0,
+          0,
+          24,
+          0
+        ],
+        "pointwise_minus": "1.3e-11",
+        "pointwise_plus": "3.8e-15",
+        "predicted_profile": [
+          0,
+          0,
+          24,
+          0
+        ],
+        "product_formula": 48,
+        "stab48_order": 16,
+        "worst_lawful_floor": "6.4e-12"
+      }
+    },
+    "L7": {
+      "d1": {
+        "agreement": 24,
+        "broken_minimum": "none",
+        "broken_over_floor": "none",
+        "cs_stab_has_minus_sign": false,
+        "cs_stab_order": 2,
+        "cs_stab_product_order": 48,
+        "distinct_representatives": 6,
+        "edits": "(c,c+ex):5",
+        "floor_both": "none",
+        "floor_minus": "8.2e-11",
+        "floor_plus": "8.9e-14",
+        "forbidden_gap_hits": 0,
+        "lawful_pairs": 24,
+        "measured_profile": [
+          12,
+          12,
+          0,
+          0
+        ],
+        "pointwise_minus": "8.2e-11",
+        "pointwise_plus": "1.1e-13",
+        "predicted_profile": [
+          12,
+          12,
+          0,
+          0
+        ],
+        "product_formula": 48,
+        "stab48_order": 8,
+        "worst_lawful_floor": "8.2e-11"
+      },
+      "d2": {
+        "agreement": 24,
+        "broken_minimum": "4.1e-02",
+        "broken_over_floor": "2.6e+08",
+        "cs_stab_has_minus_sign": false,
+        "cs_stab_order": 1,
+        "cs_stab_product_order": 24,
+        "distinct_representatives": 12,
+        "edits": "(c,c+ex):5 (c,c+ey):7",
+        "floor_both": "none",
+        "floor_minus": "1.5e-10",
+        "floor_plus": "2.1e-13",
+        "forbidden_gap_hits": 0,
+        "lawful_pairs": 12,
+        "measured_profile": [
+          6,
+          6,
+          0,
+          12
+        ],
+        "pointwise_minus": "1.5e-10",
+        "pointwise_plus": "2.1e-13",
+        "predicted_profile": [
+          6,
+          6,
+          0,
+          12
+        ],
+        "product_formula": 24,
+        "stab48_order": 2,
+        "worst_lawful_floor": "1.5e-10"
+      },
+      "d3": {
+        "agreement": 24,
+        "broken_minimum": "1.2e-01",
+        "broken_over_floor": "7.7e+08",
+        "cs_stab_has_minus_sign": false,
+        "cs_stab_order": 1,
+        "cs_stab_product_order": 12,
+        "distinct_representatives": 6,
+        "edits": "(c,c+ex):5 (c,c+ey):7 (c,c+ez):11",
+        "floor_both": "none",
+        "floor_minus": "1.6e-10",
+        "floor_plus": "1.4e-13",
+        "forbidden_gap_hits": 0,
+        "lawful_pairs": 6,
+        "measured_profile": [
+          3,
+          3,
+          0,
+          18
+        ],
+        "pointwise_minus": "1.6e-10",
+        "pointwise_plus": "1.4e-13",
+        "predicted_profile": [
+          3,
+          3,
+          0,
+          18
+        ],
+        "product_formula": 12,
+        "stab48_order": 1,
+        "worst_lawful_floor": "1.6e-10"
+      },
+      "d4": {
+        "agreement": 24,
+        "broken_minimum": "none",
+        "broken_over_floor": "none",
+        "cs_stab_has_minus_sign": true,
+        "cs_stab_order": 4,
+        "cs_stab_product_order": 48,
+        "distinct_representatives": 6,
+        "edits": "(c,c+ex):5 (c,c-ex):5",
+        "floor_both": "1.2e-10",
+        "floor_minus": "none",
+        "floor_plus": "none",
+        "forbidden_gap_hits": 0,
+        "lawful_pairs": 48,
+        "measured_profile": [
+          0,
+          0,
+          24,
+          0
+        ],
+        "pointwise_minus": "1.2e-10",
+        "pointwise_plus": "1.2e-13",
+        "predicted_profile": [
+          0,
+          0,
+          24,
+          0
+        ],
+        "product_formula": 48,
+        "stab48_order": 16,
+        "worst_lawful_floor": "1.2e-10"
+      }
+    }
+  },
+  "gates": {
+    "fail": 0,
+    "pass": 95
+  },
+  "group_algebra": {
+    "cs_order": 12,
+    "cs_proper_frame_indices": [
+      1,
+      4,
+      9,
+      15,
+      18,
+      23
+    ],
+    "cs_proper_order": 6,
+    "g48_order": 48,
+    "proper_order": 24
+  },
+  "note": "PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.md",
+  "rejectors": {
+    "det_model_misclassified_d1": 12,
+    "full_classifier_lawful_d2": 12,
+    "proper_only_lawful_d2": 6,
+    "proper_only_mismatch_d2": 6,
+    "sgn_set_single_valued_lawful_frames": {
+      "d1": 24,
+      "d2": 12,
+      "d3": 6
+    },
+    "wrong_sign_distance": {
+      "L3": {
+        "d1": {
+          "minus_frame": "5.0e-02",
+          "over_floor": "2.0e+10",
+          "plus_frame": "5.0e-02"
+        },
+        "d3": {
+          "minus_frame": "4.2e-02",
+          "over_floor": "1.5e+09",
+          "plus_frame": "4.2e-02"
+        }
+      },
+      "L7": {
+        "d1": {
+          "minus_frame": "1.2e-02",
+          "over_floor": "1.5e+08",
+          "plus_frame": "1.2e-02"
+        },
+        "d3": {
+          "minus_frame": "3.2e-02",
+          "over_floor": "2.0e+08",
+          "plus_frame": "3.2e-02"
+        }
+      }
+    }
+  },
+  "response_amplitude": "5.0e-02",
+  "runner": "physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.py",
+  "sizes": [
+    3,
+    7
+  ],
+  "tolerances": {
+    "broken_bound": "1.0e-03",
+    "class_hit": "1.0e-05",
+    "class_miss": "1.0e-03",
+    "minus_bound": "1.0e-07",
+    "plus_bound": "1.0e-10",
+    "separation_bound": "1.0e+07"
+  }
+}

--- a/scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.py
+++ b/scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""c708 -- signed-stabilizer classification of the K sign law over source edit sets.
+
+Self-contained runner for the paired note
+PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.
+
+It loads the landed cycle-696 open-coframe K endpoint compiler by path and
+RE-MEASURES every fact the classification uses: the exact group algebra of the 48
+signed permutation matrices, the decorated stabilizer of each battery domain, the
+exact state collapse on lawful cosets, rho bit-equality, the pointwise
+constant-sign transport law, the measured multiset classification of all 24 proper
+frames, four wrong-model rejectors, and the symmetric-pair corollaries.  Nothing
+is imported from sibling work; every number below is produced by this run.
+
+Physical scope guard: the axiom symmetry group is the 24 proper cubic rotations.
+The 48 signed permutation matrices are used as COMPUTATIONAL BOOKKEEPING; the
+improper (det -1) half are computational identities of the compiled chain, never
+symmetries.  The floor VALUES printed here are measured, not derived.
+"""
+
+import importlib.util
+import itertools
+import json
+import os
+import sys
+import time
+
+import numpy as np
+
+# ------------------------------------------------------------------ identity
+NOTE_BASENAME = (
+    "PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.md")
+RUNNER_BASENAME = (
+    "physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.py")
+RECEIPT_BASENAME = (
+    "physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02"
+    "_receipt_2026-08-02.json")
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MODULE_BASENAME = "physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py"
+
+# ------------------------------------------------------------------ declared constants
+AMP = 0.05              # insertion amplitude; must sit in the regime where no
+                        # battery chain clips its coframe (multi-edit domains
+                        # clip from ~0.10 up; the no-clip gates enforce this)
+SIZES = (3, 7)          # open-box sizes; wrap is off everywhere
+WRAP = False
+
+CLASS_HIT = 1.0e-5      # multiset distance BELOW this counts as matching a sign
+CLASS_MISS = 1.0e-3     # both distances AT OR ABOVE this counts as broken
+#                         the open interval between the two is a forbidden gap
+TOL_PLUS = 1.0e-10      # plus-branch bound (lawful defect, pointwise and multiset)
+TOL_MINUS = 1.0e-7      # minus / both-branch bound
+TOL_BROKEN = 1.0e-3     # smallest admissible broken-frame distance
+SEP_BOUND = 1.0e7       # smallest admissible off-class-distance / worst-lawful-floor ratio
+TIME_BUDGET = 900.0
+
+T0 = time.time()
+
+# ------------------------------------------------------------------ gate tally
+PASS = 0
+FAIL = 0
+
+
+def gate(condition):
+    """Count one discriminating gate.  Returns the boolean unchanged."""
+    global PASS, FAIL
+    if bool(condition):
+        PASS += 1
+    else:
+        FAIL += 1
+    return bool(condition)
+
+
+def verdict(ok):
+    return "PASS" if ok else "FAIL"
+
+
+def fmt(value):
+    return f"{float(value):.1e}"
+
+
+def fmt_or_none(value):
+    return "none" if value is None else fmt(value)
+
+
+# ------------------------------------------------------------------ module load
+_spec = importlib.util.spec_from_file_location(
+    "c696m", os.path.join(ROOT, "scripts", MODULE_BASENAME))
+c696 = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(c696)
+
+FRAMES = [np.asarray(m, dtype=np.int64) for m in c696.c576.FRAMES]
+FRAME_KEY = {m.tobytes(): i for i, m in enumerate(FRAMES)}
+
+
+# ------------------------------------------------------------------ signed permutation algebra
+def build_g48():
+    """All 3x3 signed permutation matrices, in a fixed construction order."""
+    out = []
+    for order in itertools.permutations(range(3)):
+        base = np.zeros((3, 3), dtype=np.int64)
+        for row, col in enumerate(order):
+            base[row, col] = 1
+        for signs in itertools.product((1, -1), repeat=3):
+            out.append(np.diag(np.asarray(signs, dtype=np.int64)) @ base)
+    return out
+
+
+G48 = build_g48()
+G48_KEY = {m.tobytes(): i for i, m in enumerate(G48)}
+IDENT = np.eye(3, dtype=np.int64)
+MINUS_IDENT = -IDENT
+
+
+def det_int(mat):
+    return int(round(float(np.linalg.det(mat))))
+
+
+def sp_data(mat):
+    """Row permutation and row signs of a signed permutation matrix."""
+    rows = [int(np.argmax(np.abs(mat[i]))) for i in range(3)]
+    signs = [int(mat[i, rows[i]]) for i in range(3)]
+    return tuple(rows), tuple(signs)
+
+
+def cs_sign(mat):
+    """+1 / -1 for a constant-sign element of G48; None otherwise."""
+    _, signs = sp_data(mat)
+    if all(s == 1 for s in signs):
+        return 1
+    if all(s == -1 for s in signs):
+        return -1
+    return None
+
+
+SO_IDX = [i for i, m in enumerate(G48) if det_int(m) == 1]
+CS_IDX = [i for i, m in enumerate(G48) if cs_sign(m) is not None]
+CS_PROPER_IDX = [i for i in CS_IDX if det_int(G48[i]) == 1]
+CS_PROPER_FRAMES = sorted(FRAME_KEY[G48[i].tobytes()] for i in CS_PROPER_IDX)
+
+
+def msd(field_a, field_b):
+    """Multiset distance: max gap between the two sorted value lists."""
+    return float(np.max(np.abs(np.sort(np.ravel(field_a)) - np.sort(np.ravel(field_b)))))
+
+
+# ------------------------------------------------------------------ battery
+def battery(size):
+    """Centre-anchored integer edit sets; keys are directed away from the anchor."""
+    half = (size - 1) // 2
+    ctr = (half, half, half)
+
+    def out(step):
+        return tuple(ctr[i] + step[i] for i in range(3))
+
+    plus_x, plus_y, plus_z = (1, 0, 0), (0, 1, 0), (0, 0, 1)
+    minus_x = (-1, 0, 0)
+    return ctr, [
+        ("d1", "(c,c+ex):5",
+         {(ctr, out(plus_x)): 5}),
+        ("d2", "(c,c+ex):5 (c,c+ey):7",
+         {(ctr, out(plus_x)): 5, (ctr, out(plus_y)): 7}),
+        ("d3", "(c,c+ex):5 (c,c+ey):7 (c,c+ez):11",
+         {(ctr, out(plus_x)): 5, (ctr, out(plus_y)): 7, (ctr, out(plus_z)): 11}),
+        ("d4", "(c,c+ex):5 (c,c-ex):5",
+         {(ctr, out(plus_x)): 5, (ctr, out(minus_x)): 5}),
+    ]
+
+
+NAMES = ("d1", "d2", "d3", "d4")
+
+
+# =====================================================================
+# G-A  group algebra (exact integer, size-independent)
+# =====================================================================
+print("c708 signed-stabilizer classification of the registered K sign law over edit sets")
+print(f"note {NOTE_BASENAME}")
+print("battery d1 one-edit d2 two-edit d3 three-edit d4 symmetric-pair; sizes 3 and 7")
+
+_a1 = gate(len(G48) == 48 and len(G48_KEY) == 48 and len(SO_IDX) == 24
+           and {G48[i].tobytes() for i in SO_IDX} == set(FRAME_KEY))
+print(f"A1 G48 order {len(G48)} distinct {len(G48_KEY)} proper {len(SO_IDX)} "
+      f"equals module FRAMES set {verdict(_a1)}")
+
+_cs_closed = True
+_n_products = 0
+for _i in CS_IDX:
+    for _j in CS_IDX:
+        _n_products += 1
+        _cs_closed &= cs_sign(G48[_i] @ G48[_j]) is not None
+_a2 = gate(len(CS_IDX) == 12 and _cs_closed and _n_products == 144)
+print(f"A2 CS order {len(CS_IDX)} closed under all {_n_products} products {verdict(_a2)}")
+
+_a3 = gate(len(CS_PROPER_IDX) == 6 and CS_PROPER_FRAMES == [1, 4, 9, 15, 18, 23])
+print(f"A3 SANITY CS_proper order {len(CS_PROPER_IDX)} FRAMES indices "
+      f"{CS_PROPER_FRAMES} {verdict(_a3)}")
+
+_sx_mult = True
+for _i in CS_IDX:
+    for _j in CS_IDX:
+        _sx_mult &= cs_sign(G48[_i] @ G48[_j]) == cs_sign(G48[_i]) * cs_sign(G48[_j])
+_a4 = gate(_sx_mult)
+print(f"A4 sx multiplicative on all {_n_products} CS pairs {verdict(_a4)}")
+
+
+# =====================================================================
+# per-size measurement
+# =====================================================================
+def stabilizer_indices(dom):
+    """Stab48(D) recomputed by decorated-fingerprint equality, never hardcoded."""
+    key = c696.domain_key(dom)
+    return [i for i, mat in enumerate(G48)
+            if c696.domain_key(c696.apply_frame_to_domain(dom, mat)) == key]
+
+
+def coset_signs(frame, stab):
+    """Sorted (G48 index, sx) list for (g . Stab48) intersect CS."""
+    hits = []
+    for si in stab:
+        hi = G48_KEY[(frame @ G48[si]).tobytes()]
+        sgn = cs_sign(G48[hi])
+        if sgn is not None:
+            hits.append((hi, sgn))
+    return sorted(set(hits))
+
+
+def predicted_class(frame, stab):
+    signs = sorted({s for _, s in coset_signs(frame, stab)})
+    if signs == [-1, 1]:
+        return "both"
+    if signs == [1]:
+        return "plus"
+    if signs == [-1]:
+        return "minus"
+    return "broken"
+
+
+def run_size(size):
+    """One open-box size: assemble, solve, and measure the whole battery."""
+    ctr, sets = battery(size)
+    model = c696.assemble_static_hessian(size, wrap=WRAP)
+    sol = c696.sector_solve(model)
+    sites = list(itertools.product(range(size), repeat=3))
+    cache = {}
+    # Every gated K value must come from an unclipped principal coframe: the clip
+    # branch in metric_and_coframe is a guard, never a smoothing a gate may rest on.
+    clip = {"chains": 0, "clipped": 0, "pd_min": None}
+
+    def chain(dom):
+        """rho -> b -> eps -> coframe -> K, cached on the exact decorated fingerprint."""
+        key = c696.domain_key(dom)
+        if key not in cache:
+            rho = c696.rho_vector(dom, model["site_index"])
+            eps = c696.response(model, sol, rho @ model["G"])["eps"]
+            mc = c696.metric_and_coframe(size, AMP * eps, model["index"])
+            clip["chains"] += 1
+            clip["clipped"] += int(bool(mc["clip_used"]))
+            low = float(np.min(mc["pd_min"]))
+            if clip["pd_min"] is None or low < clip["pd_min"]:
+                clip["pd_min"] = low
+            cache[key] = (np.asarray(c696.k_field(mc["e_clipped"])["K"]), rho)
+        return cache[key]
+
+    out = {}
+    for name, label, edits in sets:
+        dom = c696.build_domain(size, edits=edits)
+        base_k, base_rho = chain(dom)
+        stab = stabilizer_indices(dom)
+        cs_stab = [i for i in stab if cs_sign(G48[i]) is not None]
+        has_minus = any(cs_sign(G48[i]) == -1 for i in cs_stab)
+        has_neg_ident = any(np.array_equal(G48[i], MINUS_IDENT) for i in stab)
+        product_set = {(G48[ci] @ G48[si]).tobytes() for ci in CS_IDX for si in stab}
+        formula = len(CS_IDX) * len(stab) // len(cs_stab)
+
+        profile = {"plus": 0, "minus": 0, "both": 0, "broken": 0}
+        floors = {"plus": None, "minus": None, "both": None}
+        broken_min = None
+        gap_hits = 0
+        agreement = 0
+        collapse_ok = True
+        rho_ok = True
+        n_lawful_pairs = 0
+        reps = {}
+        wrong_sign = {"plus": None, "minus": None}
+        measured = []
+
+        for fi in range(24):
+            frame = FRAMES[fi]
+            image = c696.apply_frame_to_domain(dom, frame)
+            image_k, image_rho = chain(image)
+            dist_plus = msd(image_k, base_k)
+            dist_minus = msd(image_k, -base_k)
+            for dist in (dist_plus, dist_minus):
+                if not (dist < CLASS_HIT or dist >= CLASS_MISS):
+                    gap_hits += 1
+            if dist_plus < CLASS_HIT and dist_minus < CLASS_HIT:
+                seen = "both"
+                floors["both"] = max(floors["both"] or 0.0, dist_plus, dist_minus)
+            elif dist_plus < CLASS_HIT:
+                seen = "plus"
+                floors["plus"] = max(floors["plus"] or 0.0, dist_plus)
+                if wrong_sign["plus"] is None:
+                    wrong_sign["plus"] = dist_minus
+            elif dist_minus < CLASS_HIT:
+                seen = "minus"
+                floors["minus"] = max(floors["minus"] or 0.0, dist_minus)
+                if wrong_sign["minus"] is None:
+                    wrong_sign["minus"] = dist_plus
+            else:
+                seen = "broken"
+                low = min(dist_plus, dist_minus)
+                broken_min = low if broken_min is None else min(broken_min, low)
+            profile[seen] += 1
+            measured.append(seen)
+            if seen == predicted_class(frame, stab):
+                agreement += 1
+
+            hits = coset_signs(frame, stab)
+            for want in (1, -1):
+                chosen = [hi for hi, sgn in hits if sgn == want]
+                if not chosen:
+                    continue
+                n_lawful_pairs += 1
+                rep = G48[chosen[0]]
+                rep_dom = c696.apply_frame_to_domain(dom, rep)
+                # rho recomputed fresh from the collapsed link state, never via the
+                # chain cache: the cache is keyed on domain_key, so a cached read
+                # would compare the image rho against itself.
+                rep_rho = c696.rho_vector(rep_dom, model["site_index"])
+                collapse_ok &= c696.domain_key(rep_dom) == c696.domain_key(image)
+                rho_ok &= bool(np.array_equal(rep_rho, image_rho))
+                reps[chosen[0]] = want
+
+        point = {"plus": None, "minus": None}
+        for hi in sorted(reps):
+            want = reps[hi]
+            smap = c696.frame_site_map(size, G48[hi])
+            rep_k, _ = chain(c696.apply_frame_to_domain(dom, G48[hi]))
+            worst = 0.0
+            for site in sites:
+                worst = max(worst, abs(float(rep_k[smap[site]]) - want * float(base_k[site])))
+            branch = "plus" if want == 1 else "minus"
+            point[branch] = max(point[branch] or 0.0, worst)
+
+        corollary = None
+        if name == "d4":
+            smap = c696.frame_site_map(size, MINUS_IDENT)
+            anti = 0.0
+            for site in sites:
+                anti = max(anti, abs(float(base_k[smap[site]]) + float(base_k[site])))
+            corollary = {"neg_ident_in_stab": has_neg_ident,
+                         "palindrome": msd(base_k, -base_k),
+                         "centre_value": abs(float(base_k[ctr])),
+                         "antisymmetry": anti}
+
+        out[name] = {
+            "label": label, "stab": stab, "cs_stab": cs_stab, "has_minus": has_minus,
+            "product_order": len(product_set), "formula": formula,
+            "predicted": [predicted_class(FRAMES[fi], stab) for fi in range(24)],
+            "measured": measured, "profile": profile, "agreement": agreement,
+            "floors": floors, "broken_min": broken_min, "gap_hits": gap_hits,
+            "collapse_ok": collapse_ok, "rho_ok": rho_ok,
+            "n_lawful_pairs": n_lawful_pairs, "n_reps": len(reps),
+            "point": point, "wrong_sign": wrong_sign, "corollary": corollary,
+        }
+    out["coframe_clip"] = clip
+    return out
+
+
+EXPECT_STAB = {"d1": 8, "d2": 2, "d3": 1, "d4": 16}
+EXPECT_CS_STAB = {"d1": 2, "d2": 1, "d3": 1, "d4": 4}
+EXPECT_MINUS = {"d1": False, "d2": False, "d3": False, "d4": True}
+
+RESULTS = {}
+SEPMIN = {}
+for _size in SIZES:
+    RESULTS[_size] = run_size(_size)
+    res = RESULTS[_size]
+
+    ok = all(gate(len(res[n]["stab"]) == EXPECT_STAB[n]) for n in NAMES)
+    orders = " ".join(f"{n} {len(res[n]['stab'])}" for n in NAMES)
+    print(f"B1 L={_size} Stab48 orders {orders} {verdict(ok)}")
+
+    ok = all(gate(len(res[n]["cs_stab"]) == EXPECT_CS_STAB[n]
+                  and res[n]["has_minus"] == EXPECT_MINUS[n]) for n in NAMES)
+    orders = " ".join(f"{len(res[n]['cs_stab'])}" for n in NAMES)
+    minus = " ".join(("yes" if res[n]["has_minus"] else "no") for n in NAMES)
+    print(f"B2 L={_size} CS^Stab orders {orders} minus-sign member {minus} {verdict(ok)}")
+
+    ok = all(gate(res[n]["product_order"] == res[n]["formula"]) for n in NAMES)
+    orders = " ".join(f"{res[n]['product_order']}" for n in NAMES)
+    forms = " ".join(f"{res[n]['formula']}" for n in NAMES)
+    print(f"B3 L={_size} CS.Stab set orders {orders} equal formula {forms} {verdict(ok)}")
+
+    cl = res["coframe_clip"]
+    ok = gate(cl["clipped"] == 0 and cl["pd_min"] is not None and cl["pd_min"] > 0.0)
+    print(f"C0 L={_size} principal coframe unclipped on all {cl['chains']} chains "
+          f"pd_min {fmt_or_none(cl['pd_min'])} {verdict(ok)}")
+
+    ok = all(gate(res[n]["collapse_ok"]) for n in NAMES)
+    pairs = " ".join(f"{res[n]['n_lawful_pairs']}" for n in NAMES)
+    print(f"C1 L={_size} state collapse over lawful pairs {pairs} {verdict(ok)}")
+
+    ok = all(gate(res[n]["rho_ok"]) for n in NAMES)
+    print(f"C2 L={_size} rho bit-equality over the same lawful pairs {verdict(ok)}")
+
+    ok = True
+    for n in NAMES:
+        pt = res[n]["point"]
+        ok &= gate((pt["plus"] is None or pt["plus"] <= TOL_PLUS)
+                   and (pt["minus"] is None or pt["minus"] <= TOL_MINUS))
+    reps_n = " ".join(f"{res[n]['n_reps']}" for n in NAMES)
+    wp = max((res[n]["point"]["plus"] or 0.0) for n in NAMES)
+    wm = max((res[n]["point"]["minus"] or 0.0) for n in NAMES)
+    print(f"C3 L={_size} pointwise law reps {reps_n} worst plus {fmt(wp)} "
+          f"minus {fmt(wm)} {verdict(ok)}")
+
+    for n in NAMES:
+        r = res[n]
+        prof = "/".join(str(r["profile"][k]) for k in ("plus", "minus", "both", "broken"))
+        pred = {"plus": 0, "minus": 0, "both": 0, "broken": 0}
+        for cls in r["predicted"]:
+            pred[cls] += 1
+        pstr = "/".join(str(pred[k]) for k in ("plus", "minus", "both", "broken"))
+        ok = gate(r["agreement"] == 24 and r["gap_hits"] == 0 and prof == pstr)
+        print(f"C4 L={_size} {n} measured {prof} predicted {pstr} "
+              f"agreement {r['agreement']}/24 {verdict(ok)}")
+
+    for n in NAMES:
+        r = res[n]
+        fl = r["floors"]
+        held = [v for v in (fl["plus"], fl["minus"], fl["both"]) if v is not None]
+        r["worst_floor"] = max(held) if held else 0.0
+        ok = gate((fl["plus"] is None or fl["plus"] <= TOL_PLUS)
+                  and (fl["minus"] is None or fl["minus"] <= TOL_MINUS)
+                  and (fl["both"] is None or fl["both"] <= TOL_MINUS)
+                  and (r["broken_min"] is None or r["broken_min"] >= TOL_BROKEN))
+        r["separation"] = None
+        if r["broken_min"] is not None and r["worst_floor"] > 0.0:
+            r["separation"] = r["broken_min"] / r["worst_floor"]
+        print(f"C5 L={_size} {n} floors plus {fmt_or_none(fl['plus'])} "
+              f"minus {fmt_or_none(fl['minus'])} both {fmt_or_none(fl['both'])} "
+              f"broken {fmt_or_none(r['broken_min'])} "
+              f"sep {fmt_or_none(r['separation'])} {verdict(ok)}")
+
+    # ---- G-D rejectors -------------------------------------------------
+    stab24 = [i for i in RESULTS[_size]["d2"]["stab"] if det_int(G48[i]) == 1]
+    proper_only = sum(1 for fi in range(24)
+                      if predicted_class(FRAMES[fi], stab24) != "broken")
+    full_lawful = 24 - res["d2"]["profile"]["broken"]
+    res["d2"]["proper_only"] = proper_only
+    ok = gate(proper_only == 6 and full_lawful == 12 and full_lawful - proper_only == 6)
+    print(f"D1 L={_size} proper-only classifier lawful {proper_only} vs measured "
+          f"{full_lawful} on d2 mismatch {full_lawful - proper_only} {verdict(ok)}")
+
+    det_wrong = sum(1 for cls in res["d1"]["measured"] if cls != "plus")
+    ok = gate(det_wrong == 12 and all(det_int(FRAMES[fi]) == 1 for fi in range(24)))
+    print(f"D2 L={_size} det-as-sign model misclassifies {det_wrong} of 24 on d1 "
+          f"{verdict(ok)}")
+
+    for n in ("d1", "d3"):
+        ws = res[n]["wrong_sign"]
+        vals = [v for v in (ws["plus"], ws["minus"]) if v is not None]
+        ok = gate(bool(vals) and min(vals) >= TOL_BROKEN)
+        wsep = None
+        if vals and res[n]["worst_floor"] > 0.0:
+            wsep = min(vals) / res[n]["worst_floor"]
+        res[n]["wrong_sign_sep"] = wsep
+        print(f"D3 L={_size} {n} wrong-sign distance plus-frame {fmt_or_none(ws['plus'])} "
+              f"minus-frame {fmt_or_none(ws['minus'])} sep {fmt_or_none(wsep)} {verdict(ok)}")
+
+    # ---- G-E symmetric-pair corollaries --------------------------------
+    cor = res["d4"]["corollary"]
+    ok = gate(cor["neg_ident_in_stab"])
+    print(f"E1 L={_size} -I in Stab48(d4) {cor['neg_ident_in_stab']} {verdict(ok)}")
+    e2 = gate(cor["palindrome"] <= TOL_MINUS)
+    e3 = gate(cor["centre_value"] <= TOL_MINUS)
+    e4 = gate(cor["antisymmetry"] <= TOL_MINUS)
+    print(f"E2E3E4 L={_size} d4 palindrome {fmt(cor['palindrome'])} centre "
+          f"{fmt(cor['centre_value'])} antisymmetry {fmt(cor['antisymmetry'])} "
+          f"{verdict(e2 and e3 and e4)}")
+
+    # ---- G-F battery-wide class-separation margin ----------------------
+    seps = [res[n]["separation"] for n in NAMES if res[n]["separation"] is not None]
+    seps += [res[n].get("wrong_sign_sep") for n in ("d1", "d3")
+             if res[n].get("wrong_sign_sep") is not None]
+    SEPMIN[_size] = min(seps)
+    ok = gate(SEPMIN[_size] >= SEP_BOUND)
+    print(f"F1 L={_size} smallest off-class distance over worst lawful floor "
+          f"{fmt(SEPMIN[_size])} across {len(seps)} rows {verdict(ok)}")
+
+# ---- B4 size-independence of the decorated stabilizer -------------------
+_ok = all(gate(RESULTS[SIZES[0]][n]["stab"] == RESULTS[SIZES[1]][n]["stab"])
+          for n in NAMES)
+print(f"B4 Stab48 member index lists equal at L=3 and L=7 for d1 d2 d3 d4 {verdict(_ok)}")
+
+# ---- D4 sgn-set single-valuedness (exact integer, size-independent) -----
+_single = {}
+_ok = True
+for _n in ("d1", "d2", "d3"):
+    _stab = RESULTS[SIZES[0]][_n]["stab"]
+    _cnt = 0
+    _good = True
+    for _fi in range(24):
+        _hits = coset_signs(FRAMES[_fi], _stab)
+        if not _hits:
+            continue
+        _cnt += 1
+        _good &= len({s for _, s in _hits}) == 1
+    _single[_n] = _cnt
+    _ok &= gate(_good)
+_counts = " ".join(f"{_n} {_single[_n]}" for _n in ("d1", "d2", "d3"))
+print(f"D4 sgn-set single-valued on every lawful frame {_counts} {verdict(_ok)}")
+
+# ------------------------------------------------------------------ receipt
+def domain_receipt(rec):
+    fl, pt = rec["floors"], rec["point"]
+    pred = {"plus": 0, "minus": 0, "both": 0, "broken": 0}
+    for cls in rec["predicted"]:
+        pred[cls] += 1
+    order = ("plus", "minus", "both", "broken")
+    return {
+        "edits": rec["label"],
+        "stab48_order": len(rec["stab"]),
+        "cs_stab_order": len(rec["cs_stab"]),
+        "cs_stab_has_minus_sign": bool(rec["has_minus"]),
+        "cs_stab_product_order": rec["product_order"],
+        "product_formula": rec["formula"],
+        "predicted_profile": [pred[k] for k in order],
+        "measured_profile": [rec["profile"][k] for k in order],
+        "agreement": rec["agreement"],
+        "forbidden_gap_hits": rec["gap_hits"],
+        "lawful_pairs": rec["n_lawful_pairs"],
+        "distinct_representatives": rec["n_reps"],
+        "floor_plus": fmt_or_none(fl["plus"]),
+        "floor_minus": fmt_or_none(fl["minus"]),
+        "floor_both": fmt_or_none(fl["both"]),
+        "broken_minimum": fmt_or_none(rec["broken_min"]),
+        "worst_lawful_floor": fmt_or_none(rec["worst_floor"]),
+        "broken_over_floor": fmt_or_none(rec["separation"]),
+        "pointwise_plus": fmt_or_none(pt["plus"]),
+        "pointwise_minus": fmt_or_none(pt["minus"]),
+    }
+
+
+RECEIPT = {
+    "note": NOTE_BASENAME,
+    "runner": RUNNER_BASENAME,
+    "sizes": list(SIZES),
+    "response_amplitude": fmt(AMP),
+    "group_algebra": {
+        "g48_order": len(G48),
+        "proper_order": len(SO_IDX),
+        "cs_order": len(CS_IDX),
+        "cs_proper_order": len(CS_PROPER_IDX),
+        "cs_proper_frame_indices": CS_PROPER_FRAMES,
+    },
+    "domains": {f"L{s}": {n: domain_receipt(RESULTS[s][n]) for n in NAMES}
+                for s in SIZES},
+    "rejectors": {
+        "proper_only_lawful_d2": RESULTS[SIZES[0]]["d2"]["proper_only"],
+        "full_classifier_lawful_d2": 24 - RESULTS[SIZES[0]]["d2"]["profile"]["broken"],
+        "proper_only_mismatch_d2": (24 - RESULTS[SIZES[0]]["d2"]["profile"]["broken"])
+        - RESULTS[SIZES[0]]["d2"]["proper_only"],
+        "det_model_misclassified_d1": sum(
+            1 for cls in RESULTS[SIZES[0]]["d1"]["measured"] if cls != "plus"),
+        "wrong_sign_distance": {
+            f"L{s}": {n: {"plus_frame": fmt_or_none(RESULTS[s][n]["wrong_sign"]["plus"]),
+                          "minus_frame": fmt_or_none(RESULTS[s][n]["wrong_sign"]["minus"]),
+                          "over_floor": fmt_or_none(RESULTS[s][n]["wrong_sign_sep"])}
+                      for n in ("d1", "d3")}
+            for s in SIZES},
+        "sgn_set_single_valued_lawful_frames": _single,
+    },
+    "corollaries_symmetric_pair": {
+        f"L{s}": {
+            "neg_identity_in_stab48": bool(RESULTS[s]["d4"]["corollary"]["neg_ident_in_stab"]),
+            "palindrome_defect": fmt(RESULTS[s]["d4"]["corollary"]["palindrome"]),
+            "centre_value": fmt(RESULTS[s]["d4"]["corollary"]["centre_value"]),
+            "antisymmetry_defect": fmt(RESULTS[s]["d4"]["corollary"]["antisymmetry"]),
+        } for s in SIZES},
+    "class_separation": {f"L{s}": fmt(SEPMIN[s]) for s in SIZES},
+    "coframe_clip": {
+        f"L{s}": {"chains": RESULTS[s]["coframe_clip"]["chains"],
+                  "clipped": RESULTS[s]["coframe_clip"]["clipped"],
+                  "pd_min": fmt_or_none(RESULTS[s]["coframe_clip"]["pd_min"])}
+        for s in SIZES},
+    "tolerances": {"class_hit": fmt(CLASS_HIT), "class_miss": fmt(CLASS_MISS),
+                   "plus_bound": fmt(TOL_PLUS), "minus_bound": fmt(TOL_MINUS),
+                   "broken_bound": fmt(TOL_BROKEN),
+                   "separation_bound": fmt(SEP_BOUND)},
+    "gates": {"pass": PASS, "fail": FAIL},
+}
+
+with open(os.path.join(ROOT, "outputs", RECEIPT_BASENAME), "w") as fh:
+    fh.write(json.dumps(RECEIPT, sort_keys=True, indent=2))
+    fh.write("\n")
+
+if time.time() - T0 > TIME_BUDGET:
+    print("TIME_BUDGET_EXCEEDED")
+    sys.exit(1)
+
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+sys.exit(0 if FAIL == 0 else 1)

--- a/scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.py
+++ b/scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
-"""c708 -- signed-stabilizer classification of the K sign law over source edit sets.
+"""Cycle 708 -- conditional signed-stabilizer classifier for a supplied K map.
 
 Self-contained runner for the paired note
 PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.
 
-It loads the landed cycle-696 open-coframe K endpoint compiler by path and
-RE-MEASURES every fact the classification uses: the exact group algebra of the 48
+It loads the landed Cycle-696 open-coframe K endpoint compiler by path and
+re-measures every fact the finite battery uses: the exact group algebra of the 48
 signed permutation matrices, the decorated stabilizer of each battery domain, the
 exact state collapse on lawful cosets, rho bit-equality, the pointwise
-constant-sign transport law, the measured multiset classification of all 24 proper
-frames, four wrong-model rejectors, and the symmetric-pair corollaries.  Nothing
-is imported from sibling work; every number below is produced by this run.
+constant-sign transport law on four declared edit domains, the measured multiset
+classification of all 24 proper frames, four wrong-model rejectors, and the
+inversion-pair corollaries. The general group classifier is conditional on that
+transport premise; this runner does not promote its finite battery to an
+arbitrary-edit-set theorem. Nothing is imported from sibling work; every number
+below is produced by this run.
 
 Physical scope guard: the axiom symmetry group is the 24 proper cubic rotations.
 The 48 signed permutation matrices are used as COMPUTATIONAL BOOKKEEPING; the
@@ -38,6 +41,17 @@ RECEIPT_BASENAME = (
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MODULE_BASENAME = "physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py"
+
+AUDIT_TIMEOUT_SEC = 900
+AUDIT_INPUT_PATHS = (
+    "docs/PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.md",
+    "scripts/physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py",
+    "scripts/physical_dynamical_metric_source_law_bridge_tournament_cycle576_2026_07_22.py",
+    "scripts/physical_dynamical_metric_source_law_bridge_cycle576_regge_support_2026_07_22.py",
+    "scripts/physical_dynamical_metric_source_law_bridge_cycle576_plaquette_support_2026_07_22.py",
+    "scripts/frontier_cubic_coxeter_regge_second_variation_3plus1_2026_06_09.py",
+)
+DECLARED_INPUT_PATHS = AUDIT_INPUT_PATHS
 
 # ------------------------------------------------------------------ declared constants
 AMP = 0.05              # insertion amplitude; must sit in the regime where no
@@ -157,30 +171,36 @@ def battery(size):
     plus_x, plus_y, plus_z = (1, 0, 0), (0, 1, 0), (0, 0, 1)
     minus_x = (-1, 0, 0)
     return ctr, [
-        ("d1", "(c,c+ex):5",
+        ("one_edit", "(c,c+ex):5",
          {(ctr, out(plus_x)): 5}),
-        ("d2", "(c,c+ex):5 (c,c+ey):7",
+        ("two_distinct_axis_edits", "(c,c+ex):5 (c,c+ey):7",
          {(ctr, out(plus_x)): 5, (ctr, out(plus_y)): 7}),
-        ("d3", "(c,c+ex):5 (c,c+ey):7 (c,c+ez):11",
+        ("three_distinct_axis_edits", "(c,c+ex):5 (c,c+ey):7 (c,c+ez):11",
          {(ctr, out(plus_x)): 5, (ctr, out(plus_y)): 7, (ctr, out(plus_z)): 11}),
-        ("d4", "(c,c+ex):5 (c,c-ex):5",
+        ("inversion_pair", "(c,c+ex):5 (c,c-ex):5",
          {(ctr, out(plus_x)): 5, (ctr, out(minus_x)): 5}),
     ]
 
 
-NAMES = ("d1", "d2", "d3", "d4")
+NAMES = (
+    "one_edit",
+    "two_distinct_axis_edits",
+    "three_distinct_axis_edits",
+    "inversion_pair",
+)
 
 
 # =====================================================================
 # G-A  group algebra (exact integer, size-independent)
 # =====================================================================
-print("c708 signed-stabilizer classification of the registered K sign law over edit sets")
+print("Cycle 708 conditional signed-stabilizer classifier for a supplied K map")
 print(f"note {NOTE_BASENAME}")
-print("battery d1 one-edit d2 two-edit d3 three-edit d4 symmetric-pair; sizes 3 and 7")
+print("battery one-edit, two-distinct-axis-edits, three-distinct-axis-edits, "
+      "and inversion-pair; sizes 3 and 7")
 
 _a1 = gate(len(G48) == 48 and len(G48_KEY) == 48 and len(SO_IDX) == 24
            and {G48[i].tobytes() for i in SO_IDX} == set(FRAME_KEY))
-print(f"A1 G48 order {len(G48)} distinct {len(G48_KEY)} proper {len(SO_IDX)} "
+print(f"group_order G48 order {len(G48)} distinct {len(G48_KEY)} proper {len(SO_IDX)} "
       f"equals module FRAMES set {verdict(_a1)}")
 
 _cs_closed = True
@@ -190,10 +210,11 @@ for _i in CS_IDX:
         _n_products += 1
         _cs_closed &= cs_sign(G48[_i] @ G48[_j]) is not None
 _a2 = gate(len(CS_IDX) == 12 and _cs_closed and _n_products == 144)
-print(f"A2 CS order {len(CS_IDX)} closed under all {_n_products} products {verdict(_a2)}")
+print(f"constant_sign_closure CS order {len(CS_IDX)} closed under all {_n_products} "
+      f"products {verdict(_a2)}")
 
 _a3 = gate(len(CS_PROPER_IDX) == 6 and CS_PROPER_FRAMES == [1, 4, 9, 15, 18, 23])
-print(f"A3 SANITY CS_proper order {len(CS_PROPER_IDX)} FRAMES indices "
+print(f"constant_sign_proper CS_proper order {len(CS_PROPER_IDX)} FRAMES indices "
       f"{CS_PROPER_FRAMES} {verdict(_a3)}")
 
 _sx_mult = True
@@ -201,7 +222,7 @@ for _i in CS_IDX:
     for _j in CS_IDX:
         _sx_mult &= cs_sign(G48[_i] @ G48[_j]) == cs_sign(G48[_i]) * cs_sign(G48[_j])
 _a4 = gate(_sx_mult)
-print(f"A4 sx multiplicative on all {_n_products} CS pairs {verdict(_a4)}")
+print(f"sign_character sx multiplicative on all {_n_products} CS pairs {verdict(_a4)}")
 
 
 # =====================================================================
@@ -300,13 +321,13 @@ def run_size(size):
             elif dist_plus < CLASS_HIT:
                 seen = "plus"
                 floors["plus"] = max(floors["plus"] or 0.0, dist_plus)
-                if wrong_sign["plus"] is None:
-                    wrong_sign["plus"] = dist_minus
+                wrong_sign["plus"] = (dist_minus if wrong_sign["plus"] is None
+                                      else min(wrong_sign["plus"], dist_minus))
             elif dist_minus < CLASS_HIT:
                 seen = "minus"
                 floors["minus"] = max(floors["minus"] or 0.0, dist_minus)
-                if wrong_sign["minus"] is None:
-                    wrong_sign["minus"] = dist_plus
+                wrong_sign["minus"] = (dist_plus if wrong_sign["minus"] is None
+                                       else min(wrong_sign["minus"], dist_plus))
             else:
                 seen = "broken"
                 low = min(dist_plus, dist_minus)
@@ -317,12 +338,9 @@ def run_size(size):
                 agreement += 1
 
             hits = coset_signs(frame, stab)
-            for want in (1, -1):
-                chosen = [hi for hi, sgn in hits if sgn == want]
-                if not chosen:
-                    continue
+            for hi, want in hits:
                 n_lawful_pairs += 1
-                rep = G48[chosen[0]]
+                rep = G48[hi]
                 rep_dom = c696.apply_frame_to_domain(dom, rep)
                 # rho recomputed fresh from the collapsed link state, never via the
                 # chain cache: the cache is keyed on domain_key, so a cached read
@@ -330,7 +348,7 @@ def run_size(size):
                 rep_rho = c696.rho_vector(rep_dom, model["site_index"])
                 collapse_ok &= c696.domain_key(rep_dom) == c696.domain_key(image)
                 rho_ok &= bool(np.array_equal(rep_rho, image_rho))
-                reps[chosen[0]] = want
+                reps[hi] = want
 
         point = {"plus": None, "minus": None}
         for hi in sorted(reps):
@@ -344,7 +362,7 @@ def run_size(size):
             point[branch] = max(point[branch] or 0.0, worst)
 
         corollary = None
-        if name == "d4":
+        if name == "inversion_pair":
             smap = c696.frame_site_map(size, MINUS_IDENT)
             anti = 0.0
             for site in sites:
@@ -368,9 +386,24 @@ def run_size(size):
     return out
 
 
-EXPECT_STAB = {"d1": 8, "d2": 2, "d3": 1, "d4": 16}
-EXPECT_CS_STAB = {"d1": 2, "d2": 1, "d3": 1, "d4": 4}
-EXPECT_MINUS = {"d1": False, "d2": False, "d3": False, "d4": True}
+EXPECT_STAB = {
+    "one_edit": 8,
+    "two_distinct_axis_edits": 2,
+    "three_distinct_axis_edits": 1,
+    "inversion_pair": 16,
+}
+EXPECT_CS_STAB = {
+    "one_edit": 2,
+    "two_distinct_axis_edits": 1,
+    "three_distinct_axis_edits": 1,
+    "inversion_pair": 4,
+}
+EXPECT_MINUS = {
+    "one_edit": False,
+    "two_distinct_axis_edits": False,
+    "three_distinct_axis_edits": False,
+    "inversion_pair": True,
+}
 
 RESULTS = {}
 SEPMIN = {}
@@ -380,30 +413,35 @@ for _size in SIZES:
 
     ok = all(gate(len(res[n]["stab"]) == EXPECT_STAB[n]) for n in NAMES)
     orders = " ".join(f"{n} {len(res[n]['stab'])}" for n in NAMES)
-    print(f"B1 L={_size} Stab48 orders {orders} {verdict(ok)}")
+    print(f"stabilizer_orders L={_size} Stab48 orders {orders} {verdict(ok)}")
 
     ok = all(gate(len(res[n]["cs_stab"]) == EXPECT_CS_STAB[n]
                   and res[n]["has_minus"] == EXPECT_MINUS[n]) for n in NAMES)
     orders = " ".join(f"{len(res[n]['cs_stab'])}" for n in NAMES)
     minus = " ".join(("yes" if res[n]["has_minus"] else "no") for n in NAMES)
-    print(f"B2 L={_size} CS^Stab orders {orders} minus-sign member {minus} {verdict(ok)}")
+    print(f"stabilizer_intersections L={_size} CS^Stab orders {orders} "
+          f"minus-sign member {minus} {verdict(ok)}")
 
     ok = all(gate(res[n]["product_order"] == res[n]["formula"]) for n in NAMES)
     orders = " ".join(f"{res[n]['product_order']}" for n in NAMES)
     forms = " ".join(f"{res[n]['formula']}" for n in NAMES)
-    print(f"B3 L={_size} CS.Stab set orders {orders} equal formula {forms} {verdict(ok)}")
+    print(f"product_counting L={_size} CS.Stab set orders {orders} "
+          f"equal formula {forms} {verdict(ok)}")
 
     cl = res["coframe_clip"]
     ok = gate(cl["clipped"] == 0 and cl["pd_min"] is not None and cl["pd_min"] > 0.0)
-    print(f"C0 L={_size} principal coframe unclipped on all {cl['chains']} chains "
+    print(f"coframe_unclipped L={_size} principal coframe unclipped on all "
+          f"{cl['chains']} chains "
           f"pd_min {fmt_or_none(cl['pd_min'])} {verdict(ok)}")
 
     ok = all(gate(res[n]["collapse_ok"]) for n in NAMES)
     pairs = " ".join(f"{res[n]['n_lawful_pairs']}" for n in NAMES)
-    print(f"C1 L={_size} state collapse over lawful pairs {pairs} {verdict(ok)}")
+    print(f"state_collapse L={_size} state collapse over every lawful representative "
+          f"{pairs} {verdict(ok)}")
 
     ok = all(gate(res[n]["rho_ok"]) for n in NAMES)
-    print(f"C2 L={_size} rho bit-equality over the same lawful pairs {verdict(ok)}")
+    print(f"rho_equality L={_size} rho bit-equality over the same representatives "
+          f"{verdict(ok)}")
 
     ok = True
     for n in NAMES:
@@ -413,7 +451,8 @@ for _size in SIZES:
     reps_n = " ".join(f"{res[n]['n_reps']}" for n in NAMES)
     wp = max((res[n]["point"]["plus"] or 0.0) for n in NAMES)
     wm = max((res[n]["point"]["minus"] or 0.0) for n in NAMES)
-    print(f"C3 L={_size} pointwise law reps {reps_n} worst plus {fmt(wp)} "
+    print(f"pointwise_transport L={_size} distinct representatives {reps_n} "
+          f"worst plus {fmt(wp)} "
           f"minus {fmt(wm)} {verdict(ok)}")
 
     for n in NAMES:
@@ -424,7 +463,7 @@ for _size in SIZES:
             pred[cls] += 1
         pstr = "/".join(str(pred[k]) for k in ("plus", "minus", "both", "broken"))
         ok = gate(r["agreement"] == 24 and r["gap_hits"] == 0 and prof == pstr)
-        print(f"C4 L={_size} {n} measured {prof} predicted {pstr} "
+        print(f"class_agreement L={_size} {n} measured {prof} predicted {pstr} "
               f"agreement {r['agreement']}/24 {verdict(ok)}")
 
     for n in NAMES:
@@ -439,27 +478,30 @@ for _size in SIZES:
         r["separation"] = None
         if r["broken_min"] is not None and r["worst_floor"] > 0.0:
             r["separation"] = r["broken_min"] / r["worst_floor"]
-        print(f"C5 L={_size} {n} floors plus {fmt_or_none(fl['plus'])} "
+        print(f"branch_separation L={_size} {n} floors plus {fmt_or_none(fl['plus'])} "
               f"minus {fmt_or_none(fl['minus'])} both {fmt_or_none(fl['both'])} "
               f"broken {fmt_or_none(r['broken_min'])} "
               f"sep {fmt_or_none(r['separation'])} {verdict(ok)}")
 
     # ---- G-D rejectors -------------------------------------------------
-    stab24 = [i for i in RESULTS[_size]["d2"]["stab"] if det_int(G48[i]) == 1]
+    two_edit = "two_distinct_axis_edits"
+    stab24 = [i for i in RESULTS[_size][two_edit]["stab"] if det_int(G48[i]) == 1]
     proper_only = sum(1 for fi in range(24)
                       if predicted_class(FRAMES[fi], stab24) != "broken")
-    full_lawful = 24 - res["d2"]["profile"]["broken"]
-    res["d2"]["proper_only"] = proper_only
+    full_lawful = 24 - res[two_edit]["profile"]["broken"]
+    res[two_edit]["proper_only"] = proper_only
     ok = gate(proper_only == 6 and full_lawful == 12 and full_lawful - proper_only == 6)
-    print(f"D1 L={_size} proper-only classifier lawful {proper_only} vs measured "
-          f"{full_lawful} on d2 mismatch {full_lawful - proper_only} {verdict(ok)}")
+    print(f"proper_only_rejector L={_size} lawful {proper_only} vs measured "
+          f"{full_lawful} on two_distinct_axis_edits mismatch "
+          f"{full_lawful - proper_only} {verdict(ok)}")
 
-    det_wrong = sum(1 for cls in res["d1"]["measured"] if cls != "plus")
+    det_wrong = sum(1 for cls in res["one_edit"]["measured"] if cls != "plus")
     ok = gate(det_wrong == 12 and all(det_int(FRAMES[fi]) == 1 for fi in range(24)))
-    print(f"D2 L={_size} det-as-sign model misclassifies {det_wrong} of 24 on d1 "
+    print(f"determinant_sign_rejector L={_size} misclassifies {det_wrong} of 24 "
+          f"on one_edit "
           f"{verdict(ok)}")
 
-    for n in ("d1", "d3"):
+    for n in ("one_edit", "three_distinct_axis_edits"):
         ws = res[n]["wrong_sign"]
         vals = [v for v in (ws["plus"], ws["minus"]) if v is not None]
         ok = gate(bool(vals) and min(vals) >= TOL_BROKEN)
@@ -467,38 +509,43 @@ for _size in SIZES:
         if vals and res[n]["worst_floor"] > 0.0:
             wsep = min(vals) / res[n]["worst_floor"]
         res[n]["wrong_sign_sep"] = wsep
-        print(f"D3 L={_size} {n} wrong-sign distance plus-frame {fmt_or_none(ws['plus'])} "
+        print(f"wrong_sign_rejector L={_size} {n} minimum wrong-sign distance "
+              f"on plus frames {fmt_or_none(ws['plus'])} "
               f"minus-frame {fmt_or_none(ws['minus'])} sep {fmt_or_none(wsep)} {verdict(ok)}")
 
     # ---- G-E symmetric-pair corollaries --------------------------------
-    cor = res["d4"]["corollary"]
+    cor = res["inversion_pair"]["corollary"]
     ok = gate(cor["neg_ident_in_stab"])
-    print(f"E1 L={_size} -I in Stab48(d4) {cor['neg_ident_in_stab']} {verdict(ok)}")
+    print(f"inversion_stabilizer L={_size} -I in Stab48(inversion_pair) "
+          f"{cor['neg_ident_in_stab']} {verdict(ok)}")
     e2 = gate(cor["palindrome"] <= TOL_MINUS)
     e3 = gate(cor["centre_value"] <= TOL_MINUS)
     e4 = gate(cor["antisymmetry"] <= TOL_MINUS)
-    print(f"E2E3E4 L={_size} d4 palindrome {fmt(cor['palindrome'])} centre "
+    print(f"inversion_corollaries L={_size} inversion_pair palindrome "
+          f"{fmt(cor['palindrome'])} centre "
           f"{fmt(cor['centre_value'])} antisymmetry {fmt(cor['antisymmetry'])} "
           f"{verdict(e2 and e3 and e4)}")
 
     # ---- G-F battery-wide class-separation margin ----------------------
     seps = [res[n]["separation"] for n in NAMES if res[n]["separation"] is not None]
-    seps += [res[n].get("wrong_sign_sep") for n in ("d1", "d3")
+    seps += [res[n].get("wrong_sign_sep")
+             for n in ("one_edit", "three_distinct_axis_edits")
              if res[n].get("wrong_sign_sep") is not None]
     SEPMIN[_size] = min(seps)
     ok = gate(SEPMIN[_size] >= SEP_BOUND)
-    print(f"F1 L={_size} smallest off-class distance over worst lawful floor "
+    print(f"separation_floor L={_size} smallest off-class distance over worst lawful floor "
           f"{fmt(SEPMIN[_size])} across {len(seps)} rows {verdict(ok)}")
 
-# ---- B4 size-independence of the decorated stabilizer -------------------
+# ---- Size-independence of the decorated stabilizer ----------------------
 _ok = all(gate(RESULTS[SIZES[0]][n]["stab"] == RESULTS[SIZES[1]][n]["stab"])
           for n in NAMES)
-print(f"B4 Stab48 member index lists equal at L=3 and L=7 for d1 d2 d3 d4 {verdict(_ok)}")
+print("size_independence Stab48 member index lists equal at L=3 and L=7 "
+      f"for all four domains {verdict(_ok)}")
 
 # ---- D4 sgn-set single-valuedness (exact integer, size-independent) -----
 _single = {}
 _ok = True
-for _n in ("d1", "d2", "d3"):
+for _n in ("one_edit", "two_distinct_axis_edits", "three_distinct_axis_edits"):
     _stab = RESULTS[SIZES[0]][_n]["stab"]
     _cnt = 0
     _good = True
@@ -510,8 +557,11 @@ for _n in ("d1", "d2", "d3"):
         _good &= len({s for _, s in _hits}) == 1
     _single[_n] = _cnt
     _ok &= gate(_good)
-_counts = " ".join(f"{_n} {_single[_n]}" for _n in ("d1", "d2", "d3"))
-print(f"D4 sgn-set single-valued on every lawful frame {_counts} {verdict(_ok)}")
+_counts = " ".join(
+    f"{_n} {_single[_n]}"
+    for _n in ("one_edit", "two_distinct_axis_edits", "three_distinct_axis_edits")
+)
+print(f"sign_single_valuedness on every lawful frame {_counts} {verdict(_ok)}")
 
 # ------------------------------------------------------------------ receipt
 def domain_receipt(rec):
@@ -559,26 +609,33 @@ RECEIPT = {
     "domains": {f"L{s}": {n: domain_receipt(RESULTS[s][n]) for n in NAMES}
                 for s in SIZES},
     "rejectors": {
-        "proper_only_lawful_d2": RESULTS[SIZES[0]]["d2"]["proper_only"],
-        "full_classifier_lawful_d2": 24 - RESULTS[SIZES[0]]["d2"]["profile"]["broken"],
-        "proper_only_mismatch_d2": (24 - RESULTS[SIZES[0]]["d2"]["profile"]["broken"])
-        - RESULTS[SIZES[0]]["d2"]["proper_only"],
-        "det_model_misclassified_d1": sum(
-            1 for cls in RESULTS[SIZES[0]]["d1"]["measured"] if cls != "plus"),
+        "proper_only_lawful_two_distinct_axis_edits":
+            RESULTS[SIZES[0]]["two_distinct_axis_edits"]["proper_only"],
+        "full_classifier_lawful_two_distinct_axis_edits":
+            24 - RESULTS[SIZES[0]]["two_distinct_axis_edits"]["profile"]["broken"],
+        "proper_only_mismatch_two_distinct_axis_edits":
+            (24 - RESULTS[SIZES[0]]["two_distinct_axis_edits"]["profile"]["broken"])
+            - RESULTS[SIZES[0]]["two_distinct_axis_edits"]["proper_only"],
+        "det_model_misclassified_one_edit": sum(
+            1 for cls in RESULTS[SIZES[0]]["one_edit"]["measured"] if cls != "plus"),
         "wrong_sign_distance": {
             f"L{s}": {n: {"plus_frame": fmt_or_none(RESULTS[s][n]["wrong_sign"]["plus"]),
                           "minus_frame": fmt_or_none(RESULTS[s][n]["wrong_sign"]["minus"]),
                           "over_floor": fmt_or_none(RESULTS[s][n]["wrong_sign_sep"])}
-                      for n in ("d1", "d3")}
+                      for n in ("one_edit", "three_distinct_axis_edits")}
             for s in SIZES},
         "sgn_set_single_valued_lawful_frames": _single,
     },
     "corollaries_symmetric_pair": {
         f"L{s}": {
-            "neg_identity_in_stab48": bool(RESULTS[s]["d4"]["corollary"]["neg_ident_in_stab"]),
-            "palindrome_defect": fmt(RESULTS[s]["d4"]["corollary"]["palindrome"]),
-            "centre_value": fmt(RESULTS[s]["d4"]["corollary"]["centre_value"]),
-            "antisymmetry_defect": fmt(RESULTS[s]["d4"]["corollary"]["antisymmetry"]),
+            "neg_identity_in_stab48": bool(
+                RESULTS[s]["inversion_pair"]["corollary"]["neg_ident_in_stab"]),
+            "palindrome_defect": fmt(
+                RESULTS[s]["inversion_pair"]["corollary"]["palindrome"]),
+            "centre_value": fmt(
+                RESULTS[s]["inversion_pair"]["corollary"]["centre_value"]),
+            "antisymmetry_defect": fmt(
+                RESULTS[s]["inversion_pair"]["corollary"]["antisymmetry"]),
         } for s in SIZES},
     "class_separation": {f"L{s}": fmt(SEPMIN[s]) for s in SIZES},
     "coframe_clip": {

--- a/scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_independent_check_2026_08_02.py
+++ b/scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_independent_check_2026_08_02.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Independent exact check of the Cycle-708 signed-stabilizer algebra.
+
+This checker does not import the primary runner or the supplied numerical
+source-response compiler. It reconstructs the signed-permutation group with a
+pure-integer representation, enumerates the four weighted direction domains,
+and verifies the subgroup, coset, determinant-balance, collision, and profile
+claims independently. It then compares those exact results with the primary
+receipt and checks a noncommuting sidedness rejector.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+from pathlib import Path
+import sys
+
+
+AUDIT_TIMEOUT_SEC = 60
+AUDIT_INPUT_PATHS = (
+    "docs/PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.md",
+    "outputs/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02_receipt_2026-08-02.json",
+)
+DECLARED_INPUT_PATHS = AUDIT_INPUT_PATHS
+
+ROOT = Path(__file__).resolve().parents[1]
+RECEIPT_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+Vector = tuple[int, int, int]
+Domain = tuple[tuple[Vector, int], ...]
+
+PASS = 0
+FAIL = 0
+
+
+def gate(label: str, condition: bool) -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"PASS {label}")
+    else:
+        FAIL += 1
+        print(f"FAIL {label}")
+
+
+def matmul(a: Matrix, b: Matrix) -> Matrix:
+    return tuple(
+        tuple(sum(a[i][k] * b[k][j] for k in range(3)) for j in range(3))
+        for i in range(3)
+    )  # type: ignore[return-value]
+
+
+def matvec(a: Matrix, v: Vector) -> Vector:
+    return tuple(sum(a[i][j] * v[j] for j in range(3)) for i in range(3))  # type: ignore[return-value]
+
+
+def determinant(a: Matrix) -> int:
+    return (
+        a[0][0] * (a[1][1] * a[2][2] - a[1][2] * a[2][1])
+        - a[0][1] * (a[1][0] * a[2][2] - a[1][2] * a[2][0])
+        + a[0][2] * (a[1][0] * a[2][1] - a[1][1] * a[2][0])
+    )
+
+
+def constant_sign(a: Matrix) -> int | None:
+    signs: list[int] = []
+    for row in a:
+        nonzero = [entry for entry in row if entry]
+        if len(nonzero) != 1:
+            return None
+        signs.append(nonzero[0])
+    return signs[0] if all(sign == signs[0] for sign in signs) else None
+
+
+def signed_permutations() -> tuple[Matrix, ...]:
+    out: list[Matrix] = []
+    for permutation in itertools.permutations(range(3)):
+        for signs in itertools.product((1, -1), repeat=3):
+            out.append(
+                tuple(
+                    tuple(signs[i] if j == permutation[i] else 0 for j in range(3))
+                    for i in range(3)
+                )  # type: ignore[arg-type]
+            )
+    return tuple(out)
+
+
+G48 = signed_permutations()
+PROPER = tuple(matrix for matrix in G48 if determinant(matrix) == 1)
+CS = tuple(matrix for matrix in G48 if constant_sign(matrix) is not None)
+IDENTITY: Matrix = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+
+def transformed(domain: Domain, matrix: Matrix) -> Domain:
+    return tuple(sorted((matvec(matrix, vector), weight) for vector, weight in domain))
+
+
+def stabilizer(domain: Domain) -> tuple[Matrix, ...]:
+    return tuple(matrix for matrix in G48 if transformed(domain, matrix) == domain)
+
+
+def sign_set(frame: Matrix, stab: tuple[Matrix, ...]) -> tuple[int, ...]:
+    return tuple(sorted({
+        sign
+        for element in stab
+        if (sign := constant_sign(matmul(frame, element))) is not None
+    }))
+
+
+def wrong_sided_sign_set(frame: Matrix, stab: tuple[Matrix, ...]) -> tuple[int, ...]:
+    return tuple(sorted({
+        sign
+        for element in stab
+        if (sign := constant_sign(matmul(element, frame))) is not None
+    }))
+
+
+def class_name(signs: tuple[int, ...]) -> str:
+    return {
+        (): "broken",
+        (1,): "plus",
+        (-1,): "minus",
+        (-1, 1): "both",
+    }[signs]
+
+
+def profile(stab: tuple[Matrix, ...]) -> dict[str, int]:
+    counts = {"plus": 0, "minus": 0, "both": 0, "broken": 0}
+    for frame in PROPER:
+        counts[class_name(sign_set(frame, stab))] += 1
+    return counts
+
+
+AXIS_RAYS: tuple[Vector, ...] = (
+    (1, 0, 0), (-1, 0, 0),
+    (0, 1, 0), (0, -1, 0),
+    (0, 0, 1), (0, 0, -1),
+)
+
+
+def weighted_six_ray_domain(edits: dict[Vector, int]) -> Domain:
+    return tuple(sorted((ray, edits.get(ray, 3)) for ray in AXIS_RAYS))
+
+
+DOMAINS: dict[str, Domain] = {
+    "one_edit": weighted_six_ray_domain({(1, 0, 0): 5}),
+    "two_distinct_axis_edits": weighted_six_ray_domain({
+        (1, 0, 0): 5,
+        (0, 1, 0): 7,
+    }),
+    "three_distinct_axis_edits": weighted_six_ray_domain({
+        (1, 0, 0): 5,
+        (0, 1, 0): 7,
+        (0, 0, 1): 11,
+    }),
+    "inversion_pair": weighted_six_ray_domain({
+        (-1, 0, 0): 5,
+        (1, 0, 0): 5,
+    }),
+}
+EXPECTED = {
+    "one_edit": {"stab": 8, "cs_stab": 2, "profile": [12, 12, 0, 0], "pairs": 48},
+    "two_distinct_axis_edits": {
+        "stab": 2, "cs_stab": 1, "profile": [6, 6, 0, 12], "pairs": 12,
+    },
+    "three_distinct_axis_edits": {
+        "stab": 1, "cs_stab": 1, "profile": [3, 3, 0, 18], "pairs": 6,
+    },
+    "inversion_pair": {"stab": 16, "cs_stab": 4, "profile": [0, 0, 24, 0], "pairs": 96},
+}
+
+
+gate("group has 48 distinct signed permutations", len(G48) == len(set(G48)) == 48)
+gate("proper subgroup has order 24", len(PROPER) == 24)
+gate("constant-sign subgroup has order 12", len(CS) == 12)
+gate("constant-sign set is closed", all(matmul(a, b) in CS for a in CS for b in CS))
+gate(
+    "constant-sign character is multiplicative",
+    all(constant_sign(matmul(a, b)) == constant_sign(a) * constant_sign(b) for a in CS for b in CS),
+)
+
+receipt = json.loads(RECEIPT_PATH.read_text(encoding="utf-8"))
+order = ("plus", "minus", "both", "broken")
+for name, domain in DOMAINS.items():
+    stab = stabilizer(domain)
+    cs_stab = tuple(matrix for matrix in stab if matrix in CS)
+    product = {matmul(cs_element, stab_element) for cs_element in CS for stab_element in stab}
+    counts = profile(stab)
+    lawful_hits = sum(
+        sum(1 for element in stab if matmul(frame, element) in CS)
+        for frame in PROPER
+    )
+    has_minus = any(constant_sign(matrix) == -1 for matrix in cs_stab)
+    has_both = any(sign_set(frame, stab) == (-1, 1) for frame in PROPER)
+    expected = EXPECTED[name]
+    gate(f"{name} stabilizer order", len(stab) == expected["stab"])
+    gate(f"{name} constant-sign intersection order", len(cs_stab) == expected["cs_stab"])
+    gate(
+        f"{name} subgroup-product formula",
+        len(product) == len(CS) * len(stab) // len(cs_stab),
+    )
+    gate(f"{name} determinant balance", 2 * sum(determinant(matrix) == 1 for matrix in product) == len(product))
+    gate(f"{name} exact proper-frame profile", [counts[key] for key in order] == expected["profile"])
+    gate(f"{name} collision criterion", has_both == has_minus)
+    gate(f"{name} every-representative census", lawful_hits == expected["pairs"])
+    for size in (3, 7):
+        observed = receipt["domains"][f"L{size}"][name]
+        gate(f"{name} L={size} receipt profile", observed["predicted_profile"] == expected["profile"])
+        gate(f"{name} L={size} primary agreement", observed["agreement"] == 24 and observed["forbidden_gap_hits"] == 0)
+        gate(f"{name} L={size} receipt representative census", observed["lawful_pairs"] == expected["pairs"])
+
+# Multiplication order is load-bearing. This deliberately asymmetric weighted
+# domain makes left and right cosets disagree on eight proper frames.
+SIDEDNESS_DOMAIN: Domain = (((-1, -1, 0), 2), ((-1, 0, 0), 3))
+SIDEDNESS_STAB = stabilizer(SIDEDNESS_DOMAIN)
+sidedness_disagreements = sum(
+    sign_set(frame, SIDEDNESS_STAB) != wrong_sided_sign_set(frame, SIDEDNESS_STAB)
+    for frame in PROPER
+)
+gate("right-coset sidedness rejector changes eight frame labels", sidedness_disagreements == 8)
+gate("primary receipt reports no failed gates", receipt["gates"]["fail"] == 0)
+
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Cycle 708 in the gravity source-response lane. The note proves a **signed-stabilizer
classification theorem** for how the 24 proper cubic frames act on the endpoint `K`
field of a physically sourced edit set, and the paired runner confirms every branch of
it against the full real chain on four edit domains at two lattice sizes.

- **Classification (derived).** For an edit domain `D`, the stabilizer of `D` inside
  the 48 signed permutation matrices (a bookkeeping set only — the physical frame scope
  stays the 24 proper rotations) determines a sign-set for every proper frame `g`: the
  checkerboard-sign elements lying in `g·Stab(D)`, read through the multiplicative sign
  character. The sign-set is one of four values — empty, plus, minus, or both — and
  membership forces, by exact state collapse and pointwise transport, the measured
  endpoint relation `K_g = K`, `K_g = −K`, both, or neither. The converse direction
  (measured class implies predicted class) is measured, not derived.
- **Counting law (derived).** The lawful-frame count per domain follows the subgroup
  product formula `|CS·Stab| = |CS||Stab| / |CS∩Stab|`: 24 lawful frames on the
  single-edit domain, 12 on the two-edit domain, 6 on the three-edit domain, 24 (all
  double-signed) on the symmetric pair.
- **Collision criterion (derived, both directions).** A domain carries both signs on a
  lawful frame **iff** its stabilizer contains a minus-sign checkerboard element. The
  symmetric-pair domain realizes it, with corollaries all measured: `−I` in the
  stabilizer forces a palindromic `K` spectrum, pointwise antisymmetry under inversion,
  and an exactly-zero centre value.
- **Battery.** Predicted vs measured class profiles agree 24/24 on all four domains at
  both sizes: single-edit (12,12,0,0), two-edit (6,6,0,12), three-edit (3,3,0,18),
  symmetric pair (0,0,24,0) in (plus, minus, both, broken) order. Lawful floors sit at
  1e-15..1e-13 (plus branch) and 1e-12..1e-10 (minus branch); broken rows and wrong-sign
  rejectors sit 8+ orders above them.
- **Rejectors.** A proper-rotations-only classifier misses half the lawful frames of the
  two-edit domain (6 of 12); a determinant-sign model misclassifies 12 frames of the
  single-edit domain; wrong-sign checks on the sign-asymmetric domains separate by
  1.5e+08 or more; the sign-set is measured single-valued on every lawful frame.

## Honest boundary

- The **minus-branch floor values are measured, not derived** (2.5e-12..1.6e-10 across
  domains and sizes); deriving the response-stage floor constant is a named next path.
- The **class separation lands at 8.2 orders at L=7** (1.5e+08, from the single-edit
  wrong-sign row), short of the ~9 anticipated from L=3 (1.5e+09); the note names the
  mechanism (minus-floor growth with size plus wrong-sign shrink 5.0e-02 → 1.2e-02) in
  its honest-boundary section. Gate bound is the platform-stable 1.0e+07.
- Scope: L ∈ {3, 7}, open boundaries, response amplitude 5.0e-02, the four named edit
  domains. Improper signed permutations enter as computational identities only, never
  as claimed symmetries of the framework.

## What lands (5 files, 3 commits)

| commit | files |
|---|---|
| `feat(gravity)` | note `docs/PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02.md` + runner `scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_2026_08_02.py` |
| `chore(outputs)` | cold stdout + receipt JSON under `outputs/` |
| `audit-infra` | `citation_graph_manifest.json` acknowledgement of the new note |

## Runner

`TOTAL: PASS=95 FAIL=0`, stdout 3734 bytes (under the 6000-char ceiling), well inside
the 900 s budget. Receipt floats are `{:.1e}` strings. My own triple-run at the final
working point is byte-identical in both stdout and receipt; the committed cold file is
the stdout of a fresh run of the reviewed runner.

## Review notes

Line-by-line review of the executor draft caught and fixed, pre-landing:

- One **tautological gate**: the rho bit-equality check read the collapsed pair through
  a chain cache keyed on the same domain equality it was checking, so it compared an
  object to itself. Patched to recompute rho fresh from the collapsed link state (with a
  comment pinning why the cache must not be used there). Printed values unchanged.
- Two receipt rejector fields were **hardcoded literals** (gate-verified, but against
  receipt-carries-measured discipline); now computed from the run.
- A **frame/coset conflation** in one stdout line, one receipt key, and one note bullet:
  the single-valuedness counts (24/12/6) count lawful frames, not stabilizer cosets —
  the single-edit domain's 24 lawful frames sit on 6 distinct cosets. Wording fixed in
  all three places.
- Adopted the lane's **clip discipline** pre-landing: clipped coframe values are
  diagnostics, not theorem gates. The runner asserts, per size, that every chain the
  battery evaluates — lawful, broken, and wrong-sign rejector rows alike — reports the
  principal coframe unclipped, and records the minimum metric positivity margin in the
  receipt. This gate then **caught the draft working point**: at amplitude 2.0e-01 the
  multi-edit domains (and the symmetric pair at L=3) drive the metric non-positive and
  the compiler's clip guard fires — while every theorem gate still passes, because the
  clip commutes with the frame action, so collapse and floors stay exact on silently
  clipped coframes. The amplitude moved to 5.0e-02, the largest sweep point at which no
  battery chain clips at either size; the margins are healthy (minimum metric positivity
  margin 4.8e-01 at L=3, 4.2e-01 at L=7).

The working point deliberately differs from cycle 707's: that note's single-edit
domains never clip at amplitude 2.0e-01, but this battery's multi-edit domains do, so
cycle 708 runs at 5.0e-02 and its measured floors are not line-by-line comparable to
the cycle-707 numbers.

## Relation to open work

Extends the cycle-700 evidence ceiling and the cycle-703 range-law tournament (both
cited as dependencies, landed/unaudited); sits beside the cycle-707 pointwise-transport
note (referenced as context only — nothing in this note depends on it). Named next
paths: derive the response-stage floor constant; off-centre / mixed-axis / same-order
different-subgroup edit families; the L-scaling law of the floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
