### PR TITLE
fix(audit): enforce N7 steelman minimums in transport

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -581,8 +581,8 @@ validator still requires substantive values whenever the condition applies.
   },
   "N7_steelman": {
     "route_id": "<the evidenced N1 route that instantiates the strongest steelman>",
-    "argument": "<copy one complete contiguous live-execution line of at least 80 normalized characters that contains the selected N1 route mechanism and attempt verbatim>",
-    "resolution": "<copy one complete contiguous line of at least 80 normalized characters from the cited independent execution or retained/accepted authority; it must name an N2 wall>",
+    "argument": "<copy one complete contiguous live-execution line of at least {{N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS}} raw Unicode code points and {{N7_STEELMAN_MIN_NORMALIZED_CHARS}} normalized characters that contains the selected N1 route mechanism and attempt verbatim>",
+    "resolution": "<copy one complete contiguous line of at least {{N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS}} raw Unicode code points and {{N7_STEELMAN_MIN_NORMALIZED_CHARS}} normalized characters from the cited independent execution or retained/accepted authority; it must name an N2 wall>",
     "resolved": true,
     "evidence_path": "<live runner_stdout path containing the complete argument and matching N1 evidence>",
     "evidence_locator": "<actual locator>",
@@ -774,11 +774,14 @@ for the steelman and either orchestrator-marked independent execution or a
 retained/accepted, byte-authenticated authority for the resolution; a merely
 different path is not independence. Copy `N7.argument` byte-for-byte as one
 contiguous line from the selected N1 route's live execution surface; that line
-must contain at least 80 normalized characters and the route's complete
+must contain at least {{N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS}} raw Unicode code
+points for the transport prefilter and at least
+{{N7_STEELMAN_MIN_NORMALIZED_CHARS}} characters after whitespace-collapsed,
+case-folded normalization, plus the route's complete
 `mechanism` and `attempt` verbatim. Copy
 `N7.resolution` byte-for-byte as one contiguous line from its independent
-resolution surface, and select a line of at least 80 normalized characters
-that names an evidenced N2 wall. Do not paraphrase either field. N8 must bind
+resolution surface, and select a line meeting the same raw and normalized
+minimums that names an evidenced N2 wall. Do not paraphrase either field. N8 must bind
 each mechanism to its exact indexed candidate record. Copy known retirement
 state exactly; when the indexed `lifecycle_state` is `unknown`, preserve
 `retired` as JSON `null`. Applicability is a separate current-scope decision

--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -581,8 +581,8 @@ validator still requires substantive values whenever the condition applies.
   },
   "N7_steelman": {
     "route_id": "<the evidenced N1 route that instantiates the strongest steelman>",
-    "argument": "<copy one complete contiguous live-execution line that contains the selected N1 route mechanism and attempt verbatim>",
-    "resolution": "<copy one complete contiguous line from the cited independent execution or retained/accepted authority; it must name an N2 wall>",
+    "argument": "<copy one complete contiguous live-execution line of at least 80 normalized characters that contains the selected N1 route mechanism and attempt verbatim>",
+    "resolution": "<copy one complete contiguous line of at least 80 normalized characters from the cited independent execution or retained/accepted authority; it must name an N2 wall>",
     "resolved": true,
     "evidence_path": "<live runner_stdout path containing the complete argument and matching N1 evidence>",
     "evidence_locator": "<actual locator>",
@@ -774,10 +774,11 @@ for the steelman and either orchestrator-marked independent execution or a
 retained/accepted, byte-authenticated authority for the resolution; a merely
 different path is not independence. Copy `N7.argument` byte-for-byte as one
 contiguous line from the selected N1 route's live execution surface; that line
-must contain the route's complete `mechanism` and `attempt` verbatim. Copy
+must contain at least 80 normalized characters and the route's complete
+`mechanism` and `attempt` verbatim. Copy
 `N7.resolution` byte-for-byte as one contiguous line from its independent
-resolution surface, and select a line that names an evidenced N2 wall. Do not
-paraphrase either field. N8 must bind
+resolution surface, and select a line of at least 80 normalized characters
+that names an evidenced N2 wall. Do not paraphrase either field. N8 must bind
 each mechanism to its exact indexed candidate record. Copy known retirement
 state exactly; when the indexed `lifecycle_state` is `unknown`, preserve
 `retired` as JSON `null`. Applicability is a separate current-scope decision

--- a/docs/audit/scripts/no_go_discipline_gate.py
+++ b/docs/audit/scripts/no_go_discipline_gate.py
@@ -20,6 +20,11 @@ from typing import Any
 
 
 RETAINED_GRADE = {"retained", "retained_bounded", "retained_no_go"}
+# JSON Schema ``minLength`` counts raw Unicode code points and cannot express
+# this module's whitespace-collapsed, case-folded normalization.  Keep the raw
+# transport prefilter distinct from the authoritative normalized-length gate so
+# neither contract is mistaken for the other.
+N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS = 80
 N7_STEELMAN_MIN_NORMALIZED_CHARS = 80
 
 # Publication-strength rank, mirroring compute_effective_status.RANK. This
@@ -3150,6 +3155,24 @@ def _norm(value: str) -> str:
     return re.sub(r"\s+", " ", value.strip().casefold())
 
 
+def n7_steelman_normalized_length_error() -> str:
+    """Return the canonical N7 normalized-length rejection text."""
+    return (
+        "N7.argument and N7.resolution must each contain at least "
+        f"{N7_STEELMAN_MIN_NORMALIZED_CHARS} normalized characters"
+    )
+
+
+def n7_steelman_length_error(argument: str, resolution: str) -> str | None:
+    """Apply the authoritative normalized N7 evidence-line length gate."""
+    if (
+        len(_norm(argument)) < N7_STEELMAN_MIN_NORMALIZED_CHARS
+        or len(_norm(resolution)) < N7_STEELMAN_MIN_NORMALIZED_CHARS
+    ):
+        return n7_steelman_normalized_length_error()
+    return None
+
+
 def _semantic_norm(value: str) -> str:
     normalized = re.sub(
         r"\b(?:zero|one|two|three|four|five|six|seven|eight|nine|ten|first|second|third|fourth|fifth)\b|\d+",
@@ -4234,14 +4257,11 @@ def _validate_n7(packet: dict, status: str, manifest: dict[str, dict] | None) ->
         return "N7.route_id, N7.argument, and N7.resolution must be non-empty"
     if not isinstance(section.get("resolved"), bool):
         return "N7.resolved must be boolean"
-    if (
-        len(_norm(section["argument"])) < N7_STEELMAN_MIN_NORMALIZED_CHARS
-        or len(_norm(section["resolution"])) < N7_STEELMAN_MIN_NORMALIZED_CHARS
-    ):
-        return (
-            "N7.argument and N7.resolution must each contain at least "
-            f"{N7_STEELMAN_MIN_NORMALIZED_CHARS} normalized characters"
-        )
+    error = n7_steelman_length_error(
+        section["argument"], section["resolution"]
+    )
+    if error:
+        return error
     error = _locator_error(section.get("evidence_path"), section.get("evidence_locator"), manifest, "N7")
     if error:
         return error

--- a/docs/audit/scripts/no_go_discipline_gate.py
+++ b/docs/audit/scripts/no_go_discipline_gate.py
@@ -20,6 +20,7 @@ from typing import Any
 
 
 RETAINED_GRADE = {"retained", "retained_bounded", "retained_no_go"}
+N7_STEELMAN_MIN_NORMALIZED_CHARS = 80
 
 # Publication-strength rank, mirroring compute_effective_status.RANK. This
 # module is a leaf import for the whole audit lane (apply, invalidate, queue,
@@ -4233,8 +4234,14 @@ def _validate_n7(packet: dict, status: str, manifest: dict[str, dict] | None) ->
         return "N7.route_id, N7.argument, and N7.resolution must be non-empty"
     if not isinstance(section.get("resolved"), bool):
         return "N7.resolved must be boolean"
-    if len(_norm(section["argument"])) < 80 or len(_norm(section["resolution"])) < 80:
-        return "N7.argument and N7.resolution must each contain at least 80 normalized characters"
+    if (
+        len(_norm(section["argument"])) < N7_STEELMAN_MIN_NORMALIZED_CHARS
+        or len(_norm(section["resolution"])) < N7_STEELMAN_MIN_NORMALIZED_CHARS
+    ):
+        return (
+            "N7.argument and N7.resolution must each contain at least "
+            f"{N7_STEELMAN_MIN_NORMALIZED_CHARS} normalized characters"
+        )
     error = _locator_error(section.get("evidence_path"), section.get("evidence_locator"), manifest, "N7")
     if error:
         return error

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -46,6 +46,7 @@ QUEUE = DATA / "audit_queue.json"
 
 sys.path.insert(0, str(SCRIPTS))
 import orchestrate_audit_batch as batch  # noqa: E402
+import no_go_discipline_gate  # noqa: E402
 
 
 PROGRESS = {
@@ -149,10 +150,7 @@ def forensic_schema_failure_signature(detail: str) -> str | None:
     """Normalize known control-plane schema defects without verdict content."""
     if "evidence_locator must contain at least 12 normalized characters" in detail:
         return "EVIDENCE_LOCATOR_MIN_LENGTH"
-    if (
-        "N7.argument and N7.resolution must each contain at least 80 "
-        "normalized characters"
-    ) in detail:
+    if no_go_discipline_gate.n7_steelman_normalized_length_error() in detail:
         return "N7_MIN_LENGTH"
     if (
         detail.startswith("N1 route ")

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -5273,14 +5273,17 @@ class CampaignContractTest(unittest.TestCase):
             args.campaign_quarantine_file = (
                 campaign / "campaign-row-exclusions.jsonl"
             )
+            n7_length_error = (
+                audit_loop.no_go_discipline_gate.
+                n7_steelman_normalized_length_error()
+            )
             report = [
                 {
                     "cid": claim_id,
                     "pass": 1,
                     "result": "validation_failed",
                     "detail": (
-                        "N7.argument and N7.resolution must each contain at "
-                        "least 80 normalized characters; "
+                        n7_length_error + "; "
                         "preserved_run_log=forensic.jsonl"
                     ),
                 }
@@ -5306,6 +5309,18 @@ class CampaignContractTest(unittest.TestCase):
             audit_loop.PROGRESS["canary_state"],
             "mechanics_circuit_open:N7_MIN_LENGTH:3",
         )
+
+    def test_forensic_n7_signature_follows_shared_minimum(self):
+        gate = audit_loop.no_go_discipline_gate
+        with mock.patch.object(
+            gate, "N7_STEELMAN_MIN_NORMALIZED_CHARS", 81
+        ):
+            detail = gate.n7_steelman_normalized_length_error()
+            self.assertIn("81 normalized characters", detail)
+            self.assertEqual(
+                audit_loop.forensic_schema_failure_signature(detail),
+                "N7_MIN_LENGTH",
+            )
 
     def test_forensic_schema_failure_is_quarantined_and_returns_success(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -10076,7 +10076,13 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             template_flat,
         )
         self.assertIn(
-            "must contain the route's complete `mechanism` and `attempt` verbatim",
+            "must contain at least 80 normalized characters and the route's "
+            "complete `mechanism` and `attempt` verbatim",
+            template_flat,
+        )
+        self.assertIn(
+            "select a line of at least 80 normalized characters that names an "
+            "evidenced N2 wall",
             template_flat,
         )
         self.assertIn(
@@ -12030,6 +12036,19 @@ class CodexAuditRunnerModelPolicyTest(unittest.TestCase):
         self.assertEqual(panel_schema["type"], "object")
         assert_closed(audit_schema)
         assert_closed(panel_schema)
+
+    def test_codex_output_schema_enforces_n7_steelman_minimum_lengths(self):
+        m = _import_codex_audit_runner()
+        gate = _import("no_go_discipline_gate")
+
+        n7 = (
+            m.audit_verdict_output_schema()["properties"]["no_go_discipline"]
+            ["anyOf"][0]["properties"]["N7_steelman"]["properties"]
+        )
+        expected = gate.N7_STEELMAN_MIN_NORMALIZED_CHARS
+
+        self.assertEqual(n7["argument"]["minLength"], expected)
+        self.assertEqual(n7["resolution"]["minLength"], expected)
 
     def test_best_cached_model_uses_highest_full_gpt_version_not_cache_order(self):
         m = _import_codex_audit_runner()

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -10076,13 +10076,16 @@ class NoGoDisciplineGateTest(unittest.TestCase):
             template_flat,
         )
         self.assertIn(
-            "must contain at least 80 normalized characters and the route's "
+            "must contain at least {{N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS}} "
+            "raw Unicode code points for the transport prefilter and at least "
+            "{{N7_STEELMAN_MIN_NORMALIZED_CHARS}} characters after "
+            "whitespace-collapsed, case-folded normalization, plus the route's "
             "complete `mechanism` and `attempt` verbatim",
             template_flat,
         )
         self.assertIn(
-            "select a line of at least 80 normalized characters that names an "
-            "evidenced N2 wall",
+            "select a line meeting the same raw and normalized minimums that "
+            "names an evidenced N2 wall",
             template_flat,
         )
         self.assertIn(
@@ -12045,10 +12048,87 @@ class CodexAuditRunnerModelPolicyTest(unittest.TestCase):
             m.audit_verdict_output_schema()["properties"]["no_go_discipline"]
             ["anyOf"][0]["properties"]["N7_steelman"]["properties"]
         )
-        expected = gate.N7_STEELMAN_MIN_NORMALIZED_CHARS
+        expected = gate.N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS
 
         self.assertEqual(n7["argument"]["minLength"], expected)
         self.assertEqual(n7["resolution"]["minLength"], expected)
+
+    def test_n7_transport_minimum_is_an_explicit_raw_prefilter(self):
+        m = _import_codex_audit_runner()
+        gate = m.no_go_discipline_gate
+        n7 = (
+            m.audit_verdict_output_schema()["properties"]["no_go_discipline"]
+            ["anyOf"][0]["properties"]["N7_steelman"]["properties"]
+        )
+        raw_long_normalized_short = "x " * 40
+        raw_short_casefold_expands = "ß" * 40
+
+        self.assertEqual(len(raw_long_normalized_short), 80)
+        self.assertEqual(len(gate._norm(raw_long_normalized_short)), 79)
+        self.assertEqual(
+            gate.n7_steelman_length_error(
+                raw_long_normalized_short, raw_long_normalized_short
+            ),
+            gate.n7_steelman_normalized_length_error(),
+        )
+        self.assertGreaterEqual(
+            len(raw_long_normalized_short), n7["argument"]["minLength"]
+        )
+
+        self.assertEqual(len(raw_short_casefold_expands), 40)
+        self.assertEqual(len(gate._norm(raw_short_casefold_expands)), 80)
+        self.assertIsNone(
+            gate.n7_steelman_length_error(
+                raw_short_casefold_expands, raw_short_casefold_expands
+            )
+        )
+        self.assertLess(
+            len(raw_short_casefold_expands), n7["argument"]["minLength"]
+        )
+
+    def test_n7_constants_drive_schema_prompt_error_and_fresh_retry(self):
+        m = _import_codex_audit_runner()
+        gate = m.no_go_discipline_gate
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            note = root / "docs" / "TARGET.md"
+            note.parent.mkdir(parents=True, exist_ok=True)
+            note.write_text("Exact source.\n", encoding="utf-8")
+            row = {
+                "claim_id": "target",
+                "note_path": "docs/TARGET.md",
+                "deps": [],
+            }
+            with mock.patch.object(m, "REPO_ROOT", root), mock.patch.object(
+                gate, "N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS", 82
+            ), mock.patch.object(
+                gate, "N7_STEELMAN_MIN_NORMALIZED_CHARS", 81
+            ):
+                schema = (
+                    m.audit_verdict_output_schema()["properties"]
+                    ["no_go_discipline"]["anyOf"][0]["properties"]
+                    ["N7_steelman"]["properties"]
+                )
+                prompt = m.render_prompt(
+                    row,
+                    {"target": row},
+                    "raw={{N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS}} "
+                    "normalized={{N7_STEELMAN_MIN_NORMALIZED_CHARS}}",
+                    1,
+                    skip_runner_stdout=True,
+                )
+                error = gate.n7_steelman_length_error("x" * 80, "x" * 80)
+                self.assertIsNotNone(error)
+                code = m.fresh_schema_retry_code(error or "")
+                retry = m.render_fresh_schema_retry_prompt(prompt, code, 1)
+
+        self.assertEqual(schema["argument"]["minLength"], 82)
+        self.assertEqual(schema["resolution"]["minLength"], 82)
+        self.assertIn("raw=82 normalized=81", prompt)
+        self.assertIn("at least 81 normalized characters", error or "")
+        self.assertEqual(code, "N7_EXECUTION_EVIDENCE_VERBATIM_MISMATCH")
+        self.assertIn("82 raw Unicode code points", retry)
+        self.assertIn("81 characters after whitespace-collapsed", retry)
 
     def test_best_cached_model_uses_highest_full_gpt_version_not_cache_order(self):
         m = _import_codex_audit_runner()
@@ -13479,7 +13559,7 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             "N7.resolution is not evidenced at resolution_evidence_path",
             "N7.argument must name the steelmanned route mechanism",
             "N7.argument must name the steelmanned route attempt",
-            "N7.argument and N7.resolution must each contain at least 80 normalized characters",
+            m.no_go_discipline_gate.n7_steelman_normalized_length_error(),
         ):
             n7_code = m.fresh_schema_retry_code(n7_error)
             self.assertEqual(
@@ -13490,6 +13570,8 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             )
             self.assertIn("one complete contiguous live-execution line", n7_prompt)
             self.assertIn("route mechanism and attempt verbatim", n7_prompt)
+            self.assertIn("raw Unicode code points", n7_prompt)
+            self.assertIn("whitespace-collapsed, case-folded", n7_prompt)
             self.assertIn("names an evidenced N2 wall", n7_prompt)
             self.assertNotIn(n7_error, n7_prompt)
         locator_error = (

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -166,10 +166,16 @@ def _nullable(schema: dict) -> dict:
     return {"anyOf": [schema, {"type": "null"}]}
 
 
-def _string_schema(*, enum: tuple[str, ...] | None = None) -> dict:
+def _string_schema(
+    *,
+    enum: tuple[str, ...] | None = None,
+    min_length: int | None = None,
+) -> dict:
     schema: dict = {"type": "string"}
     if enum is not None:
         schema["enum"] = list(enum)
+    if min_length is not None:
+        schema["minLength"] = min_length
     return schema
 
 
@@ -323,8 +329,12 @@ def no_go_output_schema() -> dict:
         }),
         "N7_steelman": _closed_schema({
             "route_id": _string_schema(),
-            "argument": _string_schema(),
-            "resolution": _string_schema(),
+            "argument": _string_schema(
+                min_length=no_go_discipline_gate.N7_STEELMAN_MIN_NORMALIZED_CHARS,
+            ),
+            "resolution": _string_schema(
+                min_length=no_go_discipline_gate.N7_STEELMAN_MIN_NORMALIZED_CHARS,
+            ),
             "resolved": {"type": "boolean"},
             **evidence_fields,
             "resolution_evidence_path": _string_schema(),

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -330,10 +330,14 @@ def no_go_output_schema() -> dict:
         "N7_steelman": _closed_schema({
             "route_id": _string_schema(),
             "argument": _string_schema(
-                min_length=no_go_discipline_gate.N7_STEELMAN_MIN_NORMALIZED_CHARS,
+                min_length=(
+                    no_go_discipline_gate.N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS
+                ),
             ),
             "resolution": _string_schema(
-                min_length=no_go_discipline_gate.N7_STEELMAN_MIN_NORMALIZED_CHARS,
+                min_length=(
+                    no_go_discipline_gate.N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS
+                ),
             ),
             "resolved": {"type": "boolean"},
             **evidence_fields,
@@ -2018,6 +2022,12 @@ def render_prompt(row: dict, ledger_rows: dict[str, dict],
         "{{CLAIM_TYPE_HINT}}": claim_type_hint or "(none)",
         "{{RUNNER_PATH}}": runner_path or "(none)",
         "{{NO_GO_DISCIPLINE_REQUIRED}}": "true" if no_go_required else "false",
+        "{{N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS}}": str(
+            no_go_discipline_gate.N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS
+        ),
+        "{{N7_STEELMAN_MIN_NORMALIZED_CHARS}}": str(
+            no_go_discipline_gate.N7_STEELMAN_MIN_NORMALIZED_CHARS
+        ),
         "{{PRIOR_CLAIM_SCOPE}}": prior_claim_scope,
         "{{NO_GO_EVIDENCE_MANIFEST}}": evidence_manifest_text,
         "{{NOTE_BODY}}": note_body,
@@ -3070,7 +3080,7 @@ def fresh_schema_retry_code(validation_error: str) -> str:
         "N7.resolution is not evidenced at resolution_evidence_path",
         "N7.argument must name the steelmanned route mechanism",
         "N7.argument must name the steelmanned route attempt",
-        "N7.argument and N7.resolution must each contain at least 80 normalized characters",
+        no_go_discipline_gate.n7_steelman_normalized_length_error(),
     }:
         return "N7_EXECUTION_EVIDENCE_VERBATIM_MISMATCH"
     if validation_error.startswith("transport-bounded N8"):
@@ -3264,6 +3274,11 @@ def render_fresh_schema_retry_prompt(
             "Static N7 invariant: copy argument byte-for-byte as one complete "
             "contiguous live-execution line from the selected N1 route surface; "
             "that line must contain the route mechanism and attempt verbatim. "
+            f"Both copied lines must contain at least "
+            f"{no_go_discipline_gate.N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS} raw "
+            "Unicode code points for the transport prefilter and at least "
+            f"{no_go_discipline_gate.N7_STEELMAN_MIN_NORMALIZED_CHARS} "
+            "characters after whitespace-collapsed, case-folded normalization. "
             "Copy resolution byte-for-byte as one complete contiguous line from "
             "the cited independent execution or retained/accepted authority, "
             "and choose a line that names an evidenced N2 wall. Do not paraphrase "


### PR DESCRIPTION
## Summary
- centralize the canonical N7 steelman minimum length
- enforce it in the Codex structured-output schema
- state the same bound in initial and retry prompts
- add schema/prompt regression coverage

## Incident
The canonical audit drainer stopped after three distinct forensic claims produced N7 resolutions shorter than the validator's 80-normalized-character requirement. The transport schema accepted arbitrary strings and the prompt did not state the minimum, so invalid seats were repeatedly spent until the mechanics circuit opened.

## Validation
- focused N7/mechanics regressions: PASS
- Codex runner + No-Go Discipline classes: 126 tests PASS
- full audit pipeline: PASS (zero invalidations)
- strict audit lint: PASS (zero errors)
- orchestrator suite: 175/176 in full order; the remaining cleanup test passes alone on both origin/main and this branch, confirming pre-existing order-dependent test pollution
- generated audit/status outputs stripped from the PR

Audit status remains owned by the independent audit lane; this PR changes control-plane validation only.