### PR TITLE
feat(gravity): derive the mixed-frame assembly-defect census as a family law (cycle 712)

### DIFF
--- a/docs/PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md
+++ b/docs/PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md
@@ -1,174 +1,238 @@
-# Physical Mixed-Frame Assembly-Defect Census: the Family Law — Cycle 712
+# Finite family census for the mixed-frame assembly defect — Cycle 712
 
-**Claim type: bounded_theorem.** Finite, recomputed statements about the landed
-Cycle-696 open-coframe endpoint compiler chain at box sizes L ∈ {3, 4, 5, 6, 7}.
-The twelve-family decomposition of the assembly defect, the box-descriptor
-mechanism behind it, and the closed-form counting polynomials are exact finite
-statements verified by complete scan; the wall-family and edge-family pair
-magnitudes are measured, not derived.
+**Date:** 2026-08-02 (review-loop repair 2026-08-11)
 
-## What Cycle 711 left open
+**Type:** bounded_theorem
 
-The Cycle-711 exact stencil swap law (stem
-`PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02`,
-in flight) derived the mixed-frame comparator −4 exactly and recorded its
-census as measured, not derived: per-frame counts 64/224/136 at L = 3 and
-1728/4896/4056 at L = 7 for the rounded magnitudes 4/3/2, argmax family 128 and
-3456. This cycle derives those counts. Every one of them is the value of an
-explicit counting polynomial in the box size L, and the polynomial is produced
-by a positional mechanism — product boxes of base sites with per-axis wall pins
-and fixed-margin growing intervals — extracted at intermediate sizes and
-verified by extrapolation both down to L = 3 and up to L = 7. These are
-computational identities of the landed compiler chain.
+**Status:** proposed_retained
 
-## Setup
+**Primary runner:**
+[`physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py`](../scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py)
 
-The compiler chain is the landed Cycle-696 static-sector assembler: path-simplex
-templates on the open box, spatial edge classes (axis, face-diagonal,
-body-diagonal), and the assembled static Hessian Q, where the tick multiplier
-LT = 2 and the central finite-difference step 1.0e-04 are supplied compiler
-constants. Frames are the 24 proper cubic rotations of the landed Cycle-576
-table; the transport permutation Π_g is the bounding-box dof relabeling of
-Cycle 710, and the assembly defect is E_g = Π_g^T Q Π_g − Q. The six
-constant-sign frames (the sextet) have defect ceiling below 1.0e-09 and are
-exact zeros of the law; the census lives on the 18 mixed frames. For an entry
-(i, j) the defect value is the difference of the entry pair
-(a, b) = (Q[m_i, m_j], Q[i, j]); the pair classifier below uses the smaller of
-(|a|, |b|) with supplied cuts 0.5 and 10.
+**Independent checker:**
+[`physical_mixed_frame_defect_census_family_law_cycle712_independent_check_2026_08_02.py`](../scripts/physical_mixed_frame_defect_census_family_law_cycle712_independent_check_2026_08_02.py)
 
-## Theorem I — the twelve-family decomposition
+**Receipt:**
+[`physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_receipt_2026-08-02.json`](../outputs/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_receipt_2026-08-02.json)
 
-Over all five box sizes and all 18 mixed frames, every large defect entry
-(789120 of them in the complete scan) falls into exactly one of twelve signed
-families — six unsigned families times a sign — keyed by
+## Claim boundary
 
-- **exact magnitude**: |E| ∈ {2, 2·√2, 2·√3, 4}, matched within 2.0e-07
-  (per-surd maxima 5.7e-08, 3.0e-08, 6.1e-08, 1.3e-08; distance to the
-  second-nearest magnitude at least 5.4e-01), and
-- **pair class**: *swap* (the partner side is small — a value-for-zero swap, as
-  in the Cycle-711 argmax law), *wall* (both sides order one:
-  5.857096565429 and 8.685523719688), or *edge* (both sides large, diagonal
-  i == j on axis (NN) classes: 22.150846413069 and 24.150846469784).
+For the supplied open-box compiler and the declared numerical classifier, a
+complete scan of the 18 mixed proper cubic frames at
+`L ∈ {3, 4, 5, 6, 7}` gives twelve signed numerical families. Their counts are
+exact integers and equal the six stated polynomial evaluations at all five
+sizes. At the three descriptor-extraction sizes `L ∈ {4, 5, 6}`, each
+template's base-site set has a unique six-neighbor connected-component
+decomposition into full product boxes; the normalized component descriptors
+are frame-independent and size-independent on those three sizes. Descriptors
+extracted there predict the held-out `L=3` and `L=7` counts exactly.
 
-There are no outliers. The per-family counts are identical across all 18 mixed
-frames at every L (frame uniformity), and the plus and minus families are in
-bijection (sign bijection). The six unsigned families are: (4, swap),
-(2·√3, swap), (2·√2, swap), (2·√2, wall), (2, swap), (2, edge).
+This is a bounded finite computation conditional on the compiler and classifier
+choices below. Only the magnitude-4 swap family has an upstream exact stencil
+derivation. Proximity of the other three family centers to
+`2`, `2√2`, and `2√3` is numerical finite-difference evidence, not an exact
+surd theorem.
 
-## Theorem II — the box-descriptor mechanism
+## Trace gate
 
-Fix a family and a template (the class pair and site offset of its entries).
-The set of base sites carrying that template is a product box, and each axis of
-the box is one of exactly two kinds:
+```yaml
+trace_class: upstream_support
+target_claim_id: physical_minus_branch_response_floor_assembly_defect_law_cycle709_note_2026-08-02
+target_blocker_text: "replace the finite response-floor measurements with a family-resolved size-scaling law"
+source_of_blocker_text: frontier_question
+reachability_to_target: supports
+artifact_role: runner_certificate
+next_trace_action: "derive the per-family stencil values and propagate the finite family counts through the response solve"
+```
 
-- a **wall pin** P: the coordinate is frozen at 0 or L − 1;
-- a **growing interval** G(s): the coordinate ranges over a full interval with
-  fixed margins, contributing a factor (L − s) with s independent of L.
+## Status fields
 
-The canonical form — per box the sorted multiset of axis descriptors — is
-invariant across the 18 mixed frames and across box sizes. Per sign the six
-families decompose into 8/8/12/16/20/4 boxes carrying 0/0/0/1/0/2 wall pins per
-box respectively: the three bulk swap families are pin-free product boxes, the
-wall family carries exactly one pin per box (wall-anchored plaquettes), and the
-edge family carries two pins per box (box-edge lines of diagonal entries).
-Descriptors are extracted at L ∈ {4, 5, 6}; L = 3 (where the interior interval
-of a growing axis degenerates) and L = 7 are held out and used as genuine
-extrapolation checks.
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: upstream_support
+reachability_to_target: supports
+conditional_surface_status: conditional-support
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "exact finite integer counts and component-box factorizations for five supplied open-box compiler instances, with non-4 surd-center interpretations kept numerical"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+packet_helper_runner: scripts/physical_mixed_frame_defect_census_family_law_cycle712_independent_check_2026_08_02.py
+```
 
-## Theorem III — the census laws
+## Exact target and proof obligations
 
-Summing the descriptor factors gives, per sign:
+The exact target is: for the declared compiler, frame set, five sizes,
+large-entry threshold, reference-center tolerance, and pair cuts, prove by
+complete finite enumeration that every classified entry belongs to one of the
+twelve signed families and that each per-sign family count equals the stated
+integer polynomial evaluation.
 
-| family | counting law | counts at L = 3..7 |
+| obligation | disposition |
+|---|---|
+| Produce the open-box static Hessian and the 24 proper-frame table. | Supplied by the compiler and frame-table imports below; not derived here. |
+| Define the transported defect `E_g = Π_g^T Q Π_g − Q` on the bounding-box relabeling. | Imported from the Cycle-710 definition and independently reconstructed by both runners. |
+| Show that the four numerical center bins and three pair classes are separated on the scanned data. | Closed by the complete scan: maximum center deviation `6.1×10⁻⁸`, second-center distance at least `5.4×10⁻¹`, and explicit pair-cut margins. |
+| Show frame-uniform family counts and equal plus/minus cardinalities. | Closed by exact integer comparison over all 18 mixed frames and five sizes. No canonical sign-reversing map is claimed. |
+| Factor each extraction-size template site set into product boxes without a decomposition choice. | Closed at `L=4,5,6` by unique six-neighbor components followed by exact equality with each component's bounding product box. |
+| Convert the component descriptors to the six count expressions and test the held-out sizes. | Closed as finite integer arithmetic; `L=3` and `L=7` are not used to extract descriptors. |
+| Identify every non-4 center as an exact surd and prove the laws for arbitrary `L`. | Open. These stronger statements are outside the target. |
+
+**Proof-obligation disposition:** `CONDITIONAL`. The finite enumeration and
+integer arithmetic close their stated target, conditional on the supplied
+compiler and declared classifier. The exact non-4 stencil values and any
+all-`L` extension remain open and are not target-equivalent missing lemmas for
+the bounded finite claim.
+
+## Imports and declared choices
+
+### Load-bearing scientific and executable inputs
+
+- The Cycle-710 defect definition and covariance boundary:
+  [`PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_LAW_AND_COVARIANCE_BOUNDARY_CYCLE710_NOTE_2026-08-02.md`](PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_LAW_AND_COVARIANCE_BOUNDARY_CYCLE710_NOTE_2026-08-02.md).
+- The Cycle-711 exact magnitude-4 stencil result and measured census anchors:
+  [`PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02.md`](PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02.md).
+- The supplied Cycle-696 compiler:
+  [`physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py`](../scripts/physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py),
+  including its open-boundary simplex assembly, spatial classes, `LT=2`, and
+  central finite-difference step `10⁻⁴`. The compiler contains additional
+  declared modeling choices and conditional surfaces; this note consumes its
+  static Hessian as a supplied finite object and makes no claim that the
+  compiler is a derived gravity law.
+- The proper cubic frame table and Regge support machinery imported transitively
+  by Cycle 696, whose source-facing frame authority is
+  [`FINITE_REGGE_PLAQUETTE_SCATTERING_DIAGNOSTICS_CYCLE576_BOUNDED_THEOREM_NOTE_2026-07-22.md`](FINITE_REGGE_PLAQUETTE_SCATTERING_DIAGNOSTICS_CYCLE576_BOUNDED_THEOREM_NOTE_2026-07-22.md).
+
+The Cycle-710 and Cycle-711 rows remain subject to independent audit. Until
+their dependency chain is retained-grade, this result is bounded conditional
+support rather than a chain-satisfying authority.
+
+### Declared analysis choices
+
+- sizes `L={3,4,5,6,7}`, with descriptor extraction restricted to
+  `L={4,5,6}`;
+- large-entry threshold `|E|>1.5` and Cycle-711 rounded-census cut `|E|>2`;
+- numerical reference centers `{2,2√2,2√3,4}` and center tolerance `2×10⁻⁷`;
+- pair cuts `0.5` and `10`, top-family cut `3.9`, center-2 offset window
+  `10⁻⁷`, and diagonal perturbation `1.7`.
+
+These are frozen classifier or rejector choices, not values derived from the
+four framework axioms. The observed pair-value and center gaps make the family
+assignment insensitive to small movements of the stated cuts, but no universal
+classifier is claimed.
+
+## Finite numerical family decomposition
+
+Across all five sizes and 18 mixed frames, the complete scan contains 789,120
+large entries. Every one lies within `2×10⁻⁷` of one reference center, and the
+distance to the second-nearest center is at least `5.4×10⁻¹`. The pair class is
+defined by the smaller of
+`(|Q[Π_g(i),Π_g(j)]|, |Q[i,j]|)`:
+
+- **swap:** below `0.5`; the observed maximum smaller side is `6.1×10⁻⁸`;
+- **wall:** from `0.5` to below `10`; the smaller side is at least `5.9`;
+- **edge:** at least `10`; the smaller side is at least `22`.
+
+The six unsigned labels are center-4 swap, center-`2√3` swap,
+center-`2√2` swap, center-`2√2` wall, center-2 swap, and center-2 edge.
+Each has positive and negative populations of equal cardinality. “Sign
+balance” here means exact equality of finite counts; it does not assert an
+unimplemented canonical sign involution.
+
+Only the center-4 swap label inherits an exact value from Cycle 711, where the
+stencil is `LT×(−1−1)=−4`. For the other labels, “center-`2√k`” is a numerical
+bin name.
+
+## Connected-component product boxes
+
+For each sign, family, frame, and extraction size, entries are first grouped by
+the ordered spatial-class pair and the site offset. Each resulting base-site set
+is split into its unique six-neighbor connected components. Every component is
+then checked to equal its full Cartesian bounding box exactly.
+
+An axis descriptor is either a wall pin `P` or a growing interval `G(s)` of
+length `L−s`. After sorting axes and components, the descriptor multiset is the
+same for all 18 mixed frames and all three extraction sizes. Per sign, the six
+families have respectively `8/8/12/16/20/4` component boxes and
+`0/0/0/1/0/2` wall pins per component.
+
+## Finite count identities
+
+Summing component-box cardinalities gives, per sign:
+
+| numerical family | component count expression | counts at `L=3..7` |
 |---|---|---|
-| (4, swap) | 8(L−1)³ | 64, 216, 512, 1000, 1728 |
-| (2·√3, swap) | 8(L−1)³ | 64, 216, 512, 1000, 1728 |
-| (2·√2, swap) | 12(L−1)³ | 96, 324, 768, 1500, 2592 |
-| (2·√2, wall) | 16(L−1)² | 64, 144, 256, 400, 576 |
-| (2, swap) | 12(L−1)³ + 8(L−1)²(L−2) | 128, 468, 1152, 2300, 4032 |
-| (2, edge) | 4(L−1) | 8, 12, 16, 20, 24 |
+| center-4 swap | `8(L−1)³` | 64, 216, 512, 1000, 1728 |
+| center-`2√3` swap | `8(L−1)³` | 64, 216, 512, 1000, 1728 |
+| center-`2√2` swap | `12(L−1)³` | 96, 324, 768, 1500, 2592 |
+| center-`2√2` wall | `16(L−1)²` | 64, 144, 256, 400, 576 |
+| center-2 swap | `12(L−1)³+8(L−1)²(L−2)` | 128, 468, 1152, 2300, 4032 |
+| center-2 edge | `4(L−1)` | 8, 12, 16, 20, 24 |
 
-Each law is verified three ways: the measured count equals the descriptor
-prediction equals the stated polynomial, at every L in {3, 4, 5, 6, 7}, and the
-descriptor prediction equals the polynomial identically for L = 3..10.
+At every tested size the measured count, descriptor prediction, and stated
+expression agree exactly. Evaluating the descriptor expressions and the
+written polynomials at `L=3..10` is an algebraic consistency check only; no
+compiler measurement beyond `L=7` is claimed.
 
-**Corollaries — the Cycle-711 census derived.** Rounding mixes the two middle
-surds (2·√2 and 2·√3 both round to 3), so the rounded buckets are, per sign:
+Rounding combines the center-`2√2` and center-`2√3` labels. The resulting
+per-sign buckets are
 
-- **±4**: 8(L−1)³ — 64 at L = 3, 1728 at L = 7;
-- **±3**: 20(L−1)³ + 16(L−1)² — 224 at L = 3, 4896 at L = 7;
-- **±2**: 12(L−1)³ + 8(L−1)²(L−2) + 4(L−1) — 136 at L = 3, 4056 at L = 7;
-- **argmax family** (both signs of (4, swap)): 16(L−1)³ — 128 at L = 3, 3456
-  at L = 7.
+- rounded `±4`: `8(L−1)³`;
+- rounded `±3`: `20(L−1)³+16(L−1)²`;
+- rounded `±2`: `12(L−1)³+8(L−1)²(L−2)+4(L−1)`.
 
-All four reproduce the Cycle-711 anchors exactly, and the bucket-composition
-gate confirms the identification family-by-family.
+Both signs of the center-4 family together contain `16(L−1)³` entries per
+mixed frame. These expressions reproduce the Cycle-711 `L=3` and `L=7`
+anchors exactly. The center-2 entries sit between `1.7×10⁻⁹` and
+`5.7×10⁻⁸` above the cut at 2 on this finite-difference run.
 
-**Finite-difference provenance of the ±2 bucket.** The magnitude-2 entries sit
-at offsets in (1.7e-09, 5.7e-08] strictly above 2: the FD truncation of the
-compiler chain pushes this family consistently upward, so the Cycle-711 census
-cut at 2.0e+00 is deterministic, not knife-edge.
+## Measured values and rejectors
 
-**Rejector.** Under a 1.7 diagonal perturbation of the assembled operator, 2
-entries leave the exact magnitude set at distance 3.0e-01: the family law is a
-property of the landed operator, not of the classifier.
+The wall entry pair has measured magnitudes
+`5.857096565429 / 8.685523719688`; the edge pair has
+`22.150846413069 / 24.150846469784`. Their reported spreads are at most
+`1.2×10⁻¹⁰`, but no exact stencil evaluation is supplied.
+
+A `1.7` diagonal perturbation of the assembled operator produces two large
+entries at least `0.3` away from every reference center. The independent
+checker separately reconstructs the transport and classification without
+importing the primary, verifies all family counts from raw Hessians, and
+demonstrates that a displaced center, a wrong pair cut, and a wrong count
+coefficient are rejected.
 
 ## Honest boundary
 
-- **The wall and edge pair magnitudes are measured, not derived.** The values
-  5.857096565429 / 8.685523719688 (wall, spreads 8.5e-11 / 1.2e-11) and
-  22.150846413069 / 24.150846469784 (edge, spreads 1.2e-10 / 0.0e+00) are
-  L-independent and frame-independent to the stated spreads, but no stencil
-  evaluation is given for them here. The Cycle-711 two-incidence computation
-  that produced the exact −4 is the template; running it per family is the
-  named next target.
-- **The counting laws are finite statements.** Verified for L = 3..7 under the
-  supplied compiler constants; the polynomial identity for L = 3..10 is a
-  consistency identity between the descriptor form and the stated polynomial,
-  not an independent measurement. No continuum statement is made.
-- **The mechanism is positional, not yet stencil-resolved.** Theorem II says
-  where the entries sit (bulk boxes, wall plaquettes, edge lines); it does not
-  say which incidence cancellations produce each surd. That is the same gap as
-  the pair magnitudes and has the same named target.
+- The result is finite at `L=3..7`; it is not an arbitrary-`L` or continuum
+  theorem.
+- The non-4 surd-center labels are numerical observations. Exact stencil
+  evaluation remains open.
+- The component boxes explain the finite position counts. They do not derive
+  the incidence cancellations that generate each magnitude.
+- No physical gravity, response-floor scaling, or path-symmetrized assembly
+  conclusion follows from the census alone.
+- The constant-sign sextet and nearby Cycle-707/708 source-stabilizer results
+  are provenance context only; they do not seed dependencies for this claim.
 
-## The next paths opened
+## Review record
 
-- **Per-family exact stencil evaluation.** Repeat the Cycle-711 two-incidence
-  stencil computation for the wall family and the edge family: derive
-  5.857096565429 / 8.685523719688 and 22.150846413069 / 24.150846469784 as
-  exact surd combinations, upgrading Theorem I from measured magnitudes to
-  derived ones.
-- **Propagate the census to the response floor.** The Cycle-709 minus-branch
-  floor (stem
-  `PHYSICAL_MINUS_BRANCH_RESPONSE_FLOOR_ASSEMBLY_DEFECT_LAW_CYCLE709_NOTE_2026-08-02`,
-  in flight) consumes the assembly defect through a solve; the family counts
-  and their L-scaling are the natural input for a floor-scaling law.
-- **Path-symmetrized assembly.** The wall and edge families are boundary
-  populations (16(L−1)² and 4(L−1) against the 8(L−1)³ bulk); whether a
-  re-anchored transport can remove the boundary families while preserving the
-  bulk swap structure is a sharp, finite question.
+Review-loop iteration 1 narrowed the submitted “exact surd family law” to the
+finite result actually computed. It replaced the depth-capped greedy box split
+with unique connected components, changed the unconstructed “sign bijection”
+to count balance, added pair-cut margin gates, declared the full transitive
+input closure and timeout, and added an independent raw-Hessian checker.
 
-## Relation to the interacting cycle
+Hard landing conditions:
 
-This cycle stays inside the static spatial sector of the landed 3+1 module. The
-frame sextet that carries the exact zeros is the same constant-sign sextet
-whose source-stabilizer role is analyzed in
-[PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01](PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01.md);
-the in-flight Cycle-708 classification (stem
-`PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02`)
-maps the same boundary at the signed level, and the in-flight Cycle-710
-covariance-boundary census (stem
-`PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_LAW_AND_COVARIANCE_BOUNDARY_CYCLE710_NOTE_2026-08-02`)
-supplied the defect object this cycle counts.
+1. the exact reviewed Cycle-710 and Cycle-711 predecessor commits must be
+   contained in remote `main` before this package lands;
+2. the citation-graph helper registry must map
+   `physical_mixed_frame_defect_census_family_law_cycle712_note_2026-08-02`
+   to
+   `scripts/physical_mixed_frame_defect_census_family_law_cycle712_independent_check_2026_08_02.py`;
+3. both runner caches must be fresh against every declared input;
+4. the pipeline-generated ledger/status surfaces must be stripped, while the
+   citation-graph manifest acknowledgment co-lands.
 
-## Runner
-
-`scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py`
-— class-A finite check, stdlib + numpy. Gate groups: sextet exact zeros;
-family-key completeness, frame uniformity, and sign bijection over the complete
-scan; per-surd magnitude deviations with a wrong-surd gap; canonical
-box-descriptor invariance across frames and sizes with the box-shape census;
-the six counting laws at L = 3..7 with the polynomial identity at L = 3..10;
-the Cycle-711 census, bucket-composition, and argmax anchors; the magnitude-2
-FD window; wall and edge pair-value stability; and the perturbed-operator
-rejector. Prints TOTAL: PASS=29 FAIL=0 with a JSON receipt in `outputs/`.
+This package makes no negative or no-go claim, so the No-Go Discipline battery
+is not applicable. Independent audit remains required for the proposed claim.

--- a/docs/PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md
+++ b/docs/PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md
@@ -1,0 +1,174 @@
+# Physical Mixed-Frame Assembly-Defect Census: the Family Law — Cycle 712
+
+**Claim type: bounded_theorem.** Finite, recomputed statements about the landed
+Cycle-696 open-coframe endpoint compiler chain at box sizes L ∈ {3, 4, 5, 6, 7}.
+The twelve-family decomposition of the assembly defect, the box-descriptor
+mechanism behind it, and the closed-form counting polynomials are exact finite
+statements verified by complete scan; the wall-family and edge-family pair
+magnitudes are measured, not derived.
+
+## What Cycle 711 left open
+
+The Cycle-711 exact stencil swap law (stem
+`PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02`,
+in flight) derived the mixed-frame comparator −4 exactly and recorded its
+census as measured, not derived: per-frame counts 64/224/136 at L = 3 and
+1728/4896/4056 at L = 7 for the rounded magnitudes 4/3/2, argmax family 128 and
+3456. This cycle derives those counts. Every one of them is the value of an
+explicit counting polynomial in the box size L, and the polynomial is produced
+by a positional mechanism — product boxes of base sites with per-axis wall pins
+and fixed-margin growing intervals — extracted at intermediate sizes and
+verified by extrapolation both down to L = 3 and up to L = 7. These are
+computational identities of the landed compiler chain.
+
+## Setup
+
+The compiler chain is the landed Cycle-696 static-sector assembler: path-simplex
+templates on the open box, spatial edge classes (axis, face-diagonal,
+body-diagonal), and the assembled static Hessian Q, where the tick multiplier
+LT = 2 and the central finite-difference step 1.0e-04 are supplied compiler
+constants. Frames are the 24 proper cubic rotations of the landed Cycle-576
+table; the transport permutation Π_g is the bounding-box dof relabeling of
+Cycle 710, and the assembly defect is E_g = Π_g^T Q Π_g − Q. The six
+constant-sign frames (the sextet) have defect ceiling below 1.0e-09 and are
+exact zeros of the law; the census lives on the 18 mixed frames. For an entry
+(i, j) the defect value is the difference of the entry pair
+(a, b) = (Q[m_i, m_j], Q[i, j]); the pair classifier below uses the smaller of
+(|a|, |b|) with supplied cuts 0.5 and 10.
+
+## Theorem I — the twelve-family decomposition
+
+Over all five box sizes and all 18 mixed frames, every large defect entry
+(789120 of them in the complete scan) falls into exactly one of twelve signed
+families — six unsigned families times a sign — keyed by
+
+- **exact magnitude**: |E| ∈ {2, 2·√2, 2·√3, 4}, matched within 2.0e-07
+  (per-surd maxima 5.7e-08, 3.0e-08, 6.1e-08, 1.3e-08; distance to the
+  second-nearest magnitude at least 5.4e-01), and
+- **pair class**: *swap* (the partner side is small — a value-for-zero swap, as
+  in the Cycle-711 argmax law), *wall* (both sides order one:
+  5.857096565429 and 8.685523719688), or *edge* (both sides large, diagonal
+  i == j on axis (NN) classes: 22.150846413069 and 24.150846469784).
+
+There are no outliers. The per-family counts are identical across all 18 mixed
+frames at every L (frame uniformity), and the plus and minus families are in
+bijection (sign bijection). The six unsigned families are: (4, swap),
+(2·√3, swap), (2·√2, swap), (2·√2, wall), (2, swap), (2, edge).
+
+## Theorem II — the box-descriptor mechanism
+
+Fix a family and a template (the class pair and site offset of its entries).
+The set of base sites carrying that template is a product box, and each axis of
+the box is one of exactly two kinds:
+
+- a **wall pin** P: the coordinate is frozen at 0 or L − 1;
+- a **growing interval** G(s): the coordinate ranges over a full interval with
+  fixed margins, contributing a factor (L − s) with s independent of L.
+
+The canonical form — per box the sorted multiset of axis descriptors — is
+invariant across the 18 mixed frames and across box sizes. Per sign the six
+families decompose into 8/8/12/16/20/4 boxes carrying 0/0/0/1/0/2 wall pins per
+box respectively: the three bulk swap families are pin-free product boxes, the
+wall family carries exactly one pin per box (wall-anchored plaquettes), and the
+edge family carries two pins per box (box-edge lines of diagonal entries).
+Descriptors are extracted at L ∈ {4, 5, 6}; L = 3 (where the interior interval
+of a growing axis degenerates) and L = 7 are held out and used as genuine
+extrapolation checks.
+
+## Theorem III — the census laws
+
+Summing the descriptor factors gives, per sign:
+
+| family | counting law | counts at L = 3..7 |
+|---|---|---|
+| (4, swap) | 8(L−1)³ | 64, 216, 512, 1000, 1728 |
+| (2·√3, swap) | 8(L−1)³ | 64, 216, 512, 1000, 1728 |
+| (2·√2, swap) | 12(L−1)³ | 96, 324, 768, 1500, 2592 |
+| (2·√2, wall) | 16(L−1)² | 64, 144, 256, 400, 576 |
+| (2, swap) | 12(L−1)³ + 8(L−1)²(L−2) | 128, 468, 1152, 2300, 4032 |
+| (2, edge) | 4(L−1) | 8, 12, 16, 20, 24 |
+
+Each law is verified three ways: the measured count equals the descriptor
+prediction equals the stated polynomial, at every L in {3, 4, 5, 6, 7}, and the
+descriptor prediction equals the polynomial identically for L = 3..10.
+
+**Corollaries — the Cycle-711 census derived.** Rounding mixes the two middle
+surds (2·√2 and 2·√3 both round to 3), so the rounded buckets are, per sign:
+
+- **±4**: 8(L−1)³ — 64 at L = 3, 1728 at L = 7;
+- **±3**: 20(L−1)³ + 16(L−1)² — 224 at L = 3, 4896 at L = 7;
+- **±2**: 12(L−1)³ + 8(L−1)²(L−2) + 4(L−1) — 136 at L = 3, 4056 at L = 7;
+- **argmax family** (both signs of (4, swap)): 16(L−1)³ — 128 at L = 3, 3456
+  at L = 7.
+
+All four reproduce the Cycle-711 anchors exactly, and the bucket-composition
+gate confirms the identification family-by-family.
+
+**Finite-difference provenance of the ±2 bucket.** The magnitude-2 entries sit
+at offsets in (1.7e-09, 5.7e-08] strictly above 2: the FD truncation of the
+compiler chain pushes this family consistently upward, so the Cycle-711 census
+cut at 2.0e+00 is deterministic, not knife-edge.
+
+**Rejector.** Under a 1.7 diagonal perturbation of the assembled operator, 2
+entries leave the exact magnitude set at distance 3.0e-01: the family law is a
+property of the landed operator, not of the classifier.
+
+## Honest boundary
+
+- **The wall and edge pair magnitudes are measured, not derived.** The values
+  5.857096565429 / 8.685523719688 (wall, spreads 8.5e-11 / 1.2e-11) and
+  22.150846413069 / 24.150846469784 (edge, spreads 1.2e-10 / 0.0e+00) are
+  L-independent and frame-independent to the stated spreads, but no stencil
+  evaluation is given for them here. The Cycle-711 two-incidence computation
+  that produced the exact −4 is the template; running it per family is the
+  named next target.
+- **The counting laws are finite statements.** Verified for L = 3..7 under the
+  supplied compiler constants; the polynomial identity for L = 3..10 is a
+  consistency identity between the descriptor form and the stated polynomial,
+  not an independent measurement. No continuum statement is made.
+- **The mechanism is positional, not yet stencil-resolved.** Theorem II says
+  where the entries sit (bulk boxes, wall plaquettes, edge lines); it does not
+  say which incidence cancellations produce each surd. That is the same gap as
+  the pair magnitudes and has the same named target.
+
+## The next paths opened
+
+- **Per-family exact stencil evaluation.** Repeat the Cycle-711 two-incidence
+  stencil computation for the wall family and the edge family: derive
+  5.857096565429 / 8.685523719688 and 22.150846413069 / 24.150846469784 as
+  exact surd combinations, upgrading Theorem I from measured magnitudes to
+  derived ones.
+- **Propagate the census to the response floor.** The Cycle-709 minus-branch
+  floor (stem
+  `PHYSICAL_MINUS_BRANCH_RESPONSE_FLOOR_ASSEMBLY_DEFECT_LAW_CYCLE709_NOTE_2026-08-02`,
+  in flight) consumes the assembly defect through a solve; the family counts
+  and their L-scaling are the natural input for a floor-scaling law.
+- **Path-symmetrized assembly.** The wall and edge families are boundary
+  populations (16(L−1)² and 4(L−1) against the 8(L−1)³ bulk); whether a
+  re-anchored transport can remove the boundary families while preserving the
+  bulk swap structure is a sharp, finite question.
+
+## Relation to the interacting cycle
+
+This cycle stays inside the static spatial sector of the landed 3+1 module. The
+frame sextet that carries the exact zeros is the same constant-sign sextet
+whose source-stabilizer role is analyzed in
+[PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01](PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01.md);
+the in-flight Cycle-708 classification (stem
+`PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02`)
+maps the same boundary at the signed level, and the in-flight Cycle-710
+covariance-boundary census (stem
+`PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_LAW_AND_COVARIANCE_BOUNDARY_CYCLE710_NOTE_2026-08-02`)
+supplied the defect object this cycle counts.
+
+## Runner
+
+`scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py`
+— class-A finite check, stdlib + numpy. Gate groups: sextet exact zeros;
+family-key completeness, frame uniformity, and sign bijection over the complete
+scan; per-surd magnitude deviations with a wrong-surd gap; canonical
+box-descriptor invariance across frames and sizes with the box-shape census;
+the six counting laws at L = 3..7 with the polynomial identity at L = 3..10;
+the Cycle-711 census, bucket-composition, and argmax anchors; the magnitude-2
+FD window; wall and edge pair-value stability; and the perturbed-operator
+rejector. Prints TOTAL: PASS=29 FAIL=0 with a JSON receipt in `outputs/`.

--- a/docs/PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md
+++ b/docs/PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md
@@ -134,7 +134,8 @@ defined by the smaller of
 `(|Q[Π_g(i),Π_g(j)]|, |Q[i,j]|)`:
 
 - **swap:** below `0.5`; the observed maximum smaller side is `6.1×10⁻⁸`;
-- **wall:** from `0.5` to below `10`; the smaller side is at least `5.9`;
+- **wall:** from `0.5` to below `10`; the smaller side lies within
+  `5.8570965654 ± 1.2×10⁻¹⁰`;
 - **edge:** at least `10`; the smaller side is at least `22`.
 
 The six unsigned labels are center-4 swap, center-`2√3` swap,

--- a/docs/PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md
+++ b/docs/PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md
@@ -90,7 +90,7 @@ the bounded finite claim.
 ### Load-bearing scientific and executable inputs
 
 - The Cycle-710 defect definition and covariance boundary:
-  [`PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_LAW_AND_COVARIANCE_BOUNDARY_CYCLE710_NOTE_2026-08-02.md`](PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_LAW_AND_COVARIANCE_BOUNDARY_CYCLE710_NOTE_2026-08-02.md).
+  [`PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_AND_MIXED_FRAME_COMPARATOR_CYCLE710_NOTE_2026-08-02.md`](PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_AND_MIXED_FRAME_COMPARATOR_CYCLE710_NOTE_2026-08-02.md).
 - The Cycle-711 exact magnitude-4 stencil result and measured census anchors:
   [`PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02.md`](PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02.md).
 - The supplied Cycle-696 compiler:
@@ -106,7 +106,10 @@ the bounded finite claim.
 
 The Cycle-710 and Cycle-711 rows remain subject to independent audit. Until
 their dependency chain is retained-grade, this result is bounded conditional
-support rather than a chain-satisfying authority.
+support rather than a chain-satisfying authority. Cycle 710 proves its exact
+cocycle only on the constant-sign sextet at `L={3,7}`; this note imports the
+same finite transport definition for a census of the 18 mixed-frame
+comparators and does not extend that cocycle or physical-covariance claim.
 
 ### Declared analysis choices
 

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15500,
- "node_count": 5453,
+ "edge_count": 15503,
+ "node_count": 5454,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13725,6 +13725,10 @@
   "physical_mixed_frame_comparator_exact_stencil_swap_law_cycle711_note_2026-08-02": {
    "deps_hash": "aa685ea8e84b",
    "out_degree": 7
+  },
+  "physical_mixed_frame_defect_census_family_law_cycle712_note_2026-08-02": {
+   "deps_hash": "ca0f7c8882b6",
+   "out_degree": 3
   },
   "physical_operational_source_response_readout_chain_cycle700_note_2026-07-25": {
    "deps_hash": "7dc7df7e6543",

--- a/docs/audit/scripts/build_citation_graph.py
+++ b/docs/audit/scripts/build_citation_graph.py
@@ -161,6 +161,12 @@ EXPLICIT_PACKET_HELPER_RUNNER_PATHS = {
         "scripts/physical_source_edit_set_signed_stabilizer_classification_cycle708_"
         "independent_check_2026_08_02.py",
     ],
+    # Cycle 712's checker independently reconstructs the bounding-box transport,
+    # raw Hessian census, family classification, and component arithmetic.
+    "physical_mixed_frame_defect_census_family_law_cycle712_note_2026-08-02": [
+        "scripts/physical_mixed_frame_defect_census_family_law_cycle712_"
+        "independent_check_2026_08_02.py",
+    ],
     "b4_clock_relation_run_cycle879_bounded_theorem_note_2026-07-28": [
         "scripts/frontier_cycle879_b4_relation_independent_check_2026_07_28.py",
     ],

--- a/logs/runner-cache/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.txt
+++ b/logs/runner-cache/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.txt
@@ -1,30 +1,32 @@
 ===== runner cache v1 =====
 runner: scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py
-runner_sha256: e9b00c910cbc42988a291a63f56953465f04d67d8f1d8db4e22cc2aa6fbdb243
+runner_sha256: e5a344f837708cbc09394df42d5a23a78e7ab776525197bc130d9531a180d0c6
+input_fingerprint_sha256: 960ec2b6795b4d5cf01289733b03bff94f70bceb0bacc90c466b7a0f810157d3
 timeout_sec: 300
 exit_code: 0
-elapsed_sec: 8.52
+elapsed_sec: 8.76
 status: ok
 ----- stdout -----
-== cycle 712: mixed-frame assembly-defect census family law ==
-config: fit L=(4, 5, 6) census L=(3, 4, 5, 6, 7) mixed_frames=18 of 24 fd_step=1.0e-04 tol_surd=2.0e-07 cut=2.0e+00 pair_cuts=(0.5, 10.0)
+== cycle 712: finite mixed-frame assembly-defect family census ==
+config: fit L=(4, 5, 6) census L=(3, 4, 5, 6, 7) mixed_frames=18 of 24 fd_step=1.0e-04 tol_center=2.0e-07 cut=2.0e+00 pair_cuts=(0.5, 10.0)
 PASS g01_sextet_defect_zero max defect below 1.0e-09 on all 6 constant-sign frames
 PASS g02_family_key_set 12 signed families = 6 unsigned x 2 signs at every L and frame
-PASS g03_no_outliers all 789120 large entries within 2.0e-07 of an exact magnitude
+PASS g03_no_outliers all 789120 large entries within 2.0e-07 of a numerical reference center
 PASS g04_frame_uniform_counts per-family counts identical across the 18 mixed frames at every L
-PASS g05_sign_bijection plus and minus family counts equal at every L
-PASS g06_canon_frame_invariant canonical box-descriptor multiset frame-invariant at L=(4, 5, 6)
-PASS g07_canon_L_invariant descriptors carry fixed margins and wall pins, independent of L
-PASS g08_box_shape boxes per sign 8/8/12/16/20/4 with wall pins 0/0/0/1/0/2 per box
+PASS g05_sign_balance plus and minus family counts equal at every L
+PASS g06_canon_frame_invariant connected-component box descriptors frame-invariant at L=(4, 5, 6)
+PASS g07_canon_L_invariant both signs carry fixed margins and wall pins, independent of L
+PASS g08_box_shape both signs: boxes 8/8/12/16/20/4 with pins 0/0/0/1/0/2 per box
 PASS g09_edge_family_diagonal edge family is diagonal (i == j) on axis (NN) classes
-PASS g10_dev_two max magnitude deviation 5.7e-08
-PASS g10_dev_two_rt2 max magnitude deviation 3.0e-08
-PASS g10_dev_two_rt3 max magnitude deviation 6.1e-08
-PASS g10_dev_four max magnitude deviation 1.3e-08
-PASS g14_wrong_surd_gap distance to second-nearest magnitude at least 5.4e-01
+PASS g10_center_dev_two max reference-center deviation 5.7e-08
+PASS g10_center_dev_two_rt2 max reference-center deviation 3.0e-08
+PASS g10_center_dev_two_rt3 max reference-center deviation 6.1e-08
+PASS g10_center_dev_four max reference-center deviation 1.3e-08
+PASS g14_second_center_gap distance to second-nearest center at least 5.4e-01
 PASS g15_two_window magnitude-2 offsets in (1.7e-09, 5.7e-08] strictly above the census cut
 PASS g16_wall_pair_values wall pair magnitudes 5.857096565429 and 8.685523719688 (spreads 8.5e-11 / 1.2e-11)
 PASS g17_edge_pair_values edge pair magnitudes 22.150846413069 and 24.150846469784 (spreads 1.2e-10 / 0.0e+00)
+PASS g18_pair_cut_margins swap max 6.1e-08; wall range [5.9e+00, 5.9e+00]; edge min 2.2e+01 stay between cuts 0.5 / 10.0
 PASS g18_law_four_swap counts(L=3..7)=[64, 216, 512, 1000, 1728] = 8(L-1)^3
 PASS g18_law_two_rt3_swap counts(L=3..7)=[64, 216, 512, 1000, 1728] = 8(L-1)^3
 PASS g18_law_two_rt2_swap counts(L=3..7)=[96, 324, 768, 1500, 2592] = 12(L-1)^3
@@ -34,11 +36,11 @@ PASS g18_law_two_edge counts(L=3..7)=[8, 12, 16, 20, 24] = 4(L-1)
 PASS g19_poly_identity descriptor prediction equals the stated polynomial for L=3..10
 PASS g20_census_anchor_L3 rounded census above cut = ((-4, 64), (-3, 224), (-2, 136), (2, 136), (3, 224), (4, 64)) (cycle-711 anchor)
 PASS g20_census_anchor_L7 rounded census above cut = ((-4, 1728), (-3, 4896), (-2, 4056), (2, 4056), (3, 4896), (4, 1728)) (cycle-711 anchor)
-PASS g22_bucket_composition census buckets = family sums (rounded 3 mixes the two surds)
+PASS g22_bucket_composition census buckets = family sums (rounded 3 mixes two numerical centers)
 PASS g23_argmax_law argmax family per frame = 16(L-1)^3 = 128 / 3456 (cycle-711 anchor)
-PASS g24_perturbed_rejector 2 entries leave the magnitude set (distance 3.0e-01) under a 1.7 diagonal perturbation
+PASS g24_perturbed_rejector 2 entries leave the reference-center set (distance 3.0e-01) under a 1.7 diagonal perturbation
 receipt: outputs/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_receipt_2026-08-02.json
-TOTAL: PASS=29 FAIL=0
+TOTAL: PASS=30 FAIL=0
 
 ----- stderr -----
 

--- a/logs/runner-cache/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.txt
+++ b/logs/runner-cache/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.txt
@@ -1,0 +1,44 @@
+===== runner cache v1 =====
+runner: scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py
+runner_sha256: e9b00c910cbc42988a291a63f56953465f04d67d8f1d8db4e22cc2aa6fbdb243
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 8.52
+status: ok
+----- stdout -----
+== cycle 712: mixed-frame assembly-defect census family law ==
+config: fit L=(4, 5, 6) census L=(3, 4, 5, 6, 7) mixed_frames=18 of 24 fd_step=1.0e-04 tol_surd=2.0e-07 cut=2.0e+00 pair_cuts=(0.5, 10.0)
+PASS g01_sextet_defect_zero max defect below 1.0e-09 on all 6 constant-sign frames
+PASS g02_family_key_set 12 signed families = 6 unsigned x 2 signs at every L and frame
+PASS g03_no_outliers all 789120 large entries within 2.0e-07 of an exact magnitude
+PASS g04_frame_uniform_counts per-family counts identical across the 18 mixed frames at every L
+PASS g05_sign_bijection plus and minus family counts equal at every L
+PASS g06_canon_frame_invariant canonical box-descriptor multiset frame-invariant at L=(4, 5, 6)
+PASS g07_canon_L_invariant descriptors carry fixed margins and wall pins, independent of L
+PASS g08_box_shape boxes per sign 8/8/12/16/20/4 with wall pins 0/0/0/1/0/2 per box
+PASS g09_edge_family_diagonal edge family is diagonal (i == j) on axis (NN) classes
+PASS g10_dev_two max magnitude deviation 5.7e-08
+PASS g10_dev_two_rt2 max magnitude deviation 3.0e-08
+PASS g10_dev_two_rt3 max magnitude deviation 6.1e-08
+PASS g10_dev_four max magnitude deviation 1.3e-08
+PASS g14_wrong_surd_gap distance to second-nearest magnitude at least 5.4e-01
+PASS g15_two_window magnitude-2 offsets in (1.7e-09, 5.7e-08] strictly above the census cut
+PASS g16_wall_pair_values wall pair magnitudes 5.857096565429 and 8.685523719688 (spreads 8.5e-11 / 1.2e-11)
+PASS g17_edge_pair_values edge pair magnitudes 22.150846413069 and 24.150846469784 (spreads 1.2e-10 / 0.0e+00)
+PASS g18_law_four_swap counts(L=3..7)=[64, 216, 512, 1000, 1728] = 8(L-1)^3
+PASS g18_law_two_rt3_swap counts(L=3..7)=[64, 216, 512, 1000, 1728] = 8(L-1)^3
+PASS g18_law_two_rt2_swap counts(L=3..7)=[96, 324, 768, 1500, 2592] = 12(L-1)^3
+PASS g18_law_two_rt2_wall counts(L=3..7)=[64, 144, 256, 400, 576] = 16(L-1)^2
+PASS g18_law_two_swap counts(L=3..7)=[128, 468, 1152, 2300, 4032] = 12(L-1)^3+8(L-1)^2(L-2)
+PASS g18_law_two_edge counts(L=3..7)=[8, 12, 16, 20, 24] = 4(L-1)
+PASS g19_poly_identity descriptor prediction equals the stated polynomial for L=3..10
+PASS g20_census_anchor_L3 rounded census above cut = ((-4, 64), (-3, 224), (-2, 136), (2, 136), (3, 224), (4, 64)) (cycle-711 anchor)
+PASS g20_census_anchor_L7 rounded census above cut = ((-4, 1728), (-3, 4896), (-2, 4056), (2, 4056), (3, 4896), (4, 1728)) (cycle-711 anchor)
+PASS g22_bucket_composition census buckets = family sums (rounded 3 mixes the two surds)
+PASS g23_argmax_law argmax family per frame = 16(L-1)^3 = 128 / 3456 (cycle-711 anchor)
+PASS g24_perturbed_rejector 2 entries leave the magnitude set (distance 3.0e-01) under a 1.7 diagonal perturbation
+receipt: outputs/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_receipt_2026-08-02.json
+TOTAL: PASS=29 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/physical_mixed_frame_defect_census_family_law_cycle712_independent_check_2026_08_02.txt
+++ b/logs/runner-cache/physical_mixed_frame_defect_census_family_law_cycle712_independent_check_2026_08_02.txt
@@ -1,0 +1,215 @@
+===== runner cache v1 =====
+runner: scripts/physical_mixed_frame_defect_census_family_law_cycle712_independent_check_2026_08_02.py
+runner_sha256: f6b711d7b6a454ec083bbca2ec841accc99ae6f9378f3474d0090803d68eda23
+input_fingerprint_sha256: 06915ea0c4b8dde12b3874eccdb567c225b9e0e492fa663a9aa2809d633b11b5
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 5.90
+status: ok
+----- stdout -----
+PASS frame_partition sextet=(1, 4, 9, 15, 18, 23)
+PASS descriptor_identity_four_swap component factors equal written expression at L=3..10
+PASS descriptor_identity_two_rt3_swap component factors equal written expression at L=3..10
+PASS descriptor_identity_two_rt2_swap component factors equal written expression at L=3..10
+PASS descriptor_identity_two_rt2_wall component factors equal written expression at L=3..10
+PASS descriptor_identity_two_swap component factors equal written expression at L=3..10
+PASS descriptor_identity_two_edge component factors equal written expression at L=3..10
+PASS center_tolerance_L3_frame0 max=6.06e-08
+PASS raw_family_counts_L3_frame0 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame2 max=6.06e-08
+PASS raw_family_counts_L3_frame2 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame3 max=6.06e-08
+PASS raw_family_counts_L3_frame3 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame5 max=6.06e-08
+PASS raw_family_counts_L3_frame5 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame6 max=6.06e-08
+PASS raw_family_counts_L3_frame6 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame7 max=6.06e-08
+PASS raw_family_counts_L3_frame7 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame8 max=6.06e-08
+PASS raw_family_counts_L3_frame8 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame10 max=6.06e-08
+PASS raw_family_counts_L3_frame10 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame11 max=6.06e-08
+PASS raw_family_counts_L3_frame11 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame12 max=6.06e-08
+PASS raw_family_counts_L3_frame12 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame13 max=6.06e-08
+PASS raw_family_counts_L3_frame13 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame14 max=6.06e-08
+PASS raw_family_counts_L3_frame14 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame16 max=6.06e-08
+PASS raw_family_counts_L3_frame16 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame17 max=6.06e-08
+PASS raw_family_counts_L3_frame17 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame19 max=6.06e-08
+PASS raw_family_counts_L3_frame19 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame20 max=6.06e-08
+PASS raw_family_counts_L3_frame20 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame21 max=6.06e-08
+PASS raw_family_counts_L3_frame21 all twelve counts equal component expressions
+PASS center_tolerance_L3_frame22 max=6.06e-08
+PASS raw_family_counts_L3_frame22 all twelve counts equal component expressions
+PASS frame_uniformity_L3 all 18 independently rebuilt frame censuses agree
+PASS rounded_anchor_L3 anchor=((-4, 64), (-3, 224), (-2, 136), (2, 136), (3, 224), (4, 64))
+PASS top_family_L3 count=128
+PASS center_tolerance_L4_frame0 max=6.06e-08
+PASS raw_family_counts_L4_frame0 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame2 max=6.06e-08
+PASS raw_family_counts_L4_frame2 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame3 max=6.06e-08
+PASS raw_family_counts_L4_frame3 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame5 max=6.06e-08
+PASS raw_family_counts_L4_frame5 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame6 max=6.06e-08
+PASS raw_family_counts_L4_frame6 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame7 max=6.06e-08
+PASS raw_family_counts_L4_frame7 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame8 max=6.06e-08
+PASS raw_family_counts_L4_frame8 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame10 max=6.06e-08
+PASS raw_family_counts_L4_frame10 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame11 max=6.06e-08
+PASS raw_family_counts_L4_frame11 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame12 max=6.06e-08
+PASS raw_family_counts_L4_frame12 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame13 max=6.06e-08
+PASS raw_family_counts_L4_frame13 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame14 max=6.06e-08
+PASS raw_family_counts_L4_frame14 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame16 max=6.06e-08
+PASS raw_family_counts_L4_frame16 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame17 max=6.06e-08
+PASS raw_family_counts_L4_frame17 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame19 max=6.06e-08
+PASS raw_family_counts_L4_frame19 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame20 max=6.06e-08
+PASS raw_family_counts_L4_frame20 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame21 max=6.06e-08
+PASS raw_family_counts_L4_frame21 all twelve counts equal component expressions
+PASS center_tolerance_L4_frame22 max=6.06e-08
+PASS raw_family_counts_L4_frame22 all twelve counts equal component expressions
+PASS frame_uniformity_L4 all 18 independently rebuilt frame censuses agree
+PASS center_tolerance_L5_frame0 max=6.06e-08
+PASS raw_family_counts_L5_frame0 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame2 max=6.06e-08
+PASS raw_family_counts_L5_frame2 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame3 max=6.06e-08
+PASS raw_family_counts_L5_frame3 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame5 max=6.06e-08
+PASS raw_family_counts_L5_frame5 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame6 max=6.06e-08
+PASS raw_family_counts_L5_frame6 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame7 max=6.06e-08
+PASS raw_family_counts_L5_frame7 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame8 max=6.06e-08
+PASS raw_family_counts_L5_frame8 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame10 max=6.06e-08
+PASS raw_family_counts_L5_frame10 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame11 max=6.06e-08
+PASS raw_family_counts_L5_frame11 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame12 max=6.06e-08
+PASS raw_family_counts_L5_frame12 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame13 max=6.06e-08
+PASS raw_family_counts_L5_frame13 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame14 max=6.06e-08
+PASS raw_family_counts_L5_frame14 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame16 max=6.06e-08
+PASS raw_family_counts_L5_frame16 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame17 max=6.06e-08
+PASS raw_family_counts_L5_frame17 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame19 max=6.06e-08
+PASS raw_family_counts_L5_frame19 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame20 max=6.06e-08
+PASS raw_family_counts_L5_frame20 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame21 max=6.06e-08
+PASS raw_family_counts_L5_frame21 all twelve counts equal component expressions
+PASS center_tolerance_L5_frame22 max=6.06e-08
+PASS raw_family_counts_L5_frame22 all twelve counts equal component expressions
+PASS frame_uniformity_L5 all 18 independently rebuilt frame censuses agree
+PASS center_tolerance_L6_frame0 max=6.06e-08
+PASS raw_family_counts_L6_frame0 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame2 max=6.06e-08
+PASS raw_family_counts_L6_frame2 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame3 max=6.06e-08
+PASS raw_family_counts_L6_frame3 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame5 max=6.06e-08
+PASS raw_family_counts_L6_frame5 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame6 max=6.06e-08
+PASS raw_family_counts_L6_frame6 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame7 max=6.06e-08
+PASS raw_family_counts_L6_frame7 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame8 max=6.06e-08
+PASS raw_family_counts_L6_frame8 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame10 max=6.06e-08
+PASS raw_family_counts_L6_frame10 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame11 max=6.06e-08
+PASS raw_family_counts_L6_frame11 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame12 max=6.06e-08
+PASS raw_family_counts_L6_frame12 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame13 max=6.06e-08
+PASS raw_family_counts_L6_frame13 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame14 max=6.06e-08
+PASS raw_family_counts_L6_frame14 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame16 max=6.06e-08
+PASS raw_family_counts_L6_frame16 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame17 max=6.06e-08
+PASS raw_family_counts_L6_frame17 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame19 max=6.06e-08
+PASS raw_family_counts_L6_frame19 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame20 max=6.06e-08
+PASS raw_family_counts_L6_frame20 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame21 max=6.06e-08
+PASS raw_family_counts_L6_frame21 all twelve counts equal component expressions
+PASS center_tolerance_L6_frame22 max=6.06e-08
+PASS raw_family_counts_L6_frame22 all twelve counts equal component expressions
+PASS frame_uniformity_L6 all 18 independently rebuilt frame censuses agree
+PASS center_tolerance_L7_frame0 max=6.06e-08
+PASS raw_family_counts_L7_frame0 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame2 max=6.06e-08
+PASS raw_family_counts_L7_frame2 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame3 max=6.06e-08
+PASS raw_family_counts_L7_frame3 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame5 max=6.06e-08
+PASS raw_family_counts_L7_frame5 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame6 max=6.06e-08
+PASS raw_family_counts_L7_frame6 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame7 max=6.06e-08
+PASS raw_family_counts_L7_frame7 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame8 max=6.06e-08
+PASS raw_family_counts_L7_frame8 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame10 max=6.06e-08
+PASS raw_family_counts_L7_frame10 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame11 max=6.06e-08
+PASS raw_family_counts_L7_frame11 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame12 max=6.06e-08
+PASS raw_family_counts_L7_frame12 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame13 max=6.06e-08
+PASS raw_family_counts_L7_frame13 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame14 max=6.06e-08
+PASS raw_family_counts_L7_frame14 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame16 max=6.06e-08
+PASS raw_family_counts_L7_frame16 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame17 max=6.06e-08
+PASS raw_family_counts_L7_frame17 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame19 max=6.06e-08
+PASS raw_family_counts_L7_frame19 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame20 max=6.06e-08
+PASS raw_family_counts_L7_frame20 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame21 max=6.06e-08
+PASS raw_family_counts_L7_frame21 all twelve counts equal component expressions
+PASS center_tolerance_L7_frame22 max=6.06e-08
+PASS raw_family_counts_L7_frame22 all twelve counts equal component expressions
+PASS frame_uniformity_L7 all 18 independently rebuilt frame censuses agree
+PASS rounded_anchor_L7 anchor=((-4, 1728), (-3, 4896), (-2, 4056), (2, 4056), (3, 4896), (4, 1728))
+PASS top_family_L7 count=3456
+PASS complete_scan_total entries=789120
+PASS displaced_center_rejector rejected_entries=126720
+PASS wrong_pair_cut_rejector reclassified_entries=51840
+PASS wrong_coefficient_rejector coefficient 9 cannot replace component multiplicity 8
+PASS primary_receipt_all_gates_pass
+PASS primary_receipt_count_agreement receipt counts equal independent component arithmetic
+TOTAL: PASS=202 FAIL=0
+
+----- stderr -----
+

--- a/outputs/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_receipt_2026-08-02.json
+++ b/outputs/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_receipt_2026-08-02.json
@@ -10,19 +10,19 @@
       "pass": true
     },
     "g03_no_outliers": {
-      "detail": "all 789120 large entries within 2.0e-07 of an exact magnitude",
+      "detail": "all 789120 large entries within 2.0e-07 of a numerical reference center",
       "pass": true
     },
     "g04_frame_uniform_counts": {
       "detail": "per-family counts identical across the 18 mixed frames at every L",
       "pass": true
     },
-    "g05_sign_bijection": {
+    "g05_sign_balance": {
       "detail": "plus and minus family counts equal at every L",
       "pass": true
     },
     "g06_canon_frame_invariant": {
-      "detail": "canonical box-descriptor multiset frame-invariant at L=(4, 5, 6)",
+      "detail": "connected-component box descriptors frame-invariant at L=(4, 5, 6)",
       "pass": true
     },
     "g07_canon_L_invariant": {
@@ -37,24 +37,24 @@
       "detail": "edge family is diagonal (i == j) on axis (NN) classes",
       "pass": true
     },
-    "g10_dev_four": {
-      "detail": "max magnitude deviation 1.3e-08",
+    "g10_center_dev_four": {
+      "detail": "max reference-center deviation 1.3e-08",
       "pass": true
     },
-    "g10_dev_two": {
-      "detail": "max magnitude deviation 5.7e-08",
+    "g10_center_dev_two": {
+      "detail": "max reference-center deviation 5.7e-08",
       "pass": true
     },
-    "g10_dev_two_rt2": {
-      "detail": "max magnitude deviation 3.0e-08",
+    "g10_center_dev_two_rt2": {
+      "detail": "max reference-center deviation 3.0e-08",
       "pass": true
     },
-    "g10_dev_two_rt3": {
-      "detail": "max magnitude deviation 6.1e-08",
+    "g10_center_dev_two_rt3": {
+      "detail": "max reference-center deviation 6.1e-08",
       "pass": true
     },
-    "g14_wrong_surd_gap": {
-      "detail": "distance to second-nearest magnitude at least 5.4e-01",
+    "g14_second_center_gap": {
+      "detail": "distance to second-nearest center at least 5.4e-01",
       "pass": true
     },
     "g15_two_window": {
@@ -93,6 +93,10 @@
       "detail": "counts(L=3..7)=[128, 468, 1152, 2300, 4032] = 12(L-1)^3+8(L-1)^2(L-2)",
       "pass": true
     },
+    "g18_pair_cut_margins": {
+      "detail": "swap partner max 6.1e-08; wall/edge smaller-side minima 5.9e+00 / 2.2e+01 stay away from cuts 0.5 / 10.0",
+      "pass": true
+    },
     "g19_poly_identity": {
       "detail": "descriptor prediction equals the stated polynomial for L=3..10",
       "pass": true
@@ -106,7 +110,7 @@
       "pass": true
     },
     "g22_bucket_composition": {
-      "detail": "census buckets = family sums (rounded 3 mixes the two surds)",
+      "detail": "census buckets = family sums (rounded 3 mixes two numerical centers)",
       "pass": true
     },
     "g23_argmax_law": {
@@ -114,7 +118,7 @@
       "pass": true
     },
     "g24_perturbed_rejector": {
-      "detail": "2 entries leave the magnitude set (distance 3.0e-01) under a 1.7 diagonal perturbation",
+      "detail": "2 entries leave the reference-center set (distance 3.0e-01) under a 1.7 diagonal perturbation",
       "pass": true
     }
   },
@@ -134,6 +138,12 @@
         4896,
         4056
       ]
+    },
+    "center_deviation_max": {
+      "four": "1.3e-08",
+      "two": "5.7e-08",
+      "two_rt2": "3.0e-08",
+      "two_rt3": "6.1e-08"
     },
     "counts_per_sign": {
       "four|swap": [
@@ -179,12 +189,6 @@
         4032
       ]
     },
-    "dev_max": {
-      "four": "1.3e-08",
-      "two": "5.7e-08",
-      "two_rt2": "3.0e-08",
-      "two_rt3": "6.1e-08"
-    },
     "edge_pair": [
       "22.150846413069",
       "24.150846469784"
@@ -197,6 +201,12 @@
       "two|edge": "4(L-1)",
       "two|swap": "12(L-1)^3+8(L-1)^2(L-2)"
     },
+    "pair_cut_margins": {
+      "edge_smaller_side_min": "2.2e+01",
+      "swap_partner_max": "6.1e-08",
+      "wall_smaller_side_min": "5.9e+00"
+    },
+    "second_center_gap": "5.4e-01",
     "two_window": [
       "1.7e-09",
       "5.7e-08"
@@ -204,7 +214,6 @@
     "wall_pair": [
       "5.857096565429",
       "8.685523719688"
-    ],
-    "wrong_surd_gap": "5.4e-01"
+    ]
   }
 }

--- a/outputs/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_receipt_2026-08-02.json
+++ b/outputs/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_receipt_2026-08-02.json
@@ -26,11 +26,11 @@
       "pass": true
     },
     "g07_canon_L_invariant": {
-      "detail": "descriptors carry fixed margins and wall pins, independent of L",
+      "detail": "both signs carry fixed margins and wall pins, independent of L",
       "pass": true
     },
     "g08_box_shape": {
-      "detail": "boxes per sign 8/8/12/16/20/4 with wall pins 0/0/0/1/0/2 per box",
+      "detail": "both signs: boxes 8/8/12/16/20/4 with pins 0/0/0/1/0/2 per box",
       "pass": true
     },
     "g09_edge_family_diagonal": {

--- a/outputs/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_receipt_2026-08-02.json
+++ b/outputs/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_receipt_2026-08-02.json
@@ -94,7 +94,7 @@
       "pass": true
     },
     "g18_pair_cut_margins": {
-      "detail": "swap partner max 6.1e-08; wall/edge smaller-side minima 5.9e+00 / 2.2e+01 stay away from cuts 0.5 / 10.0",
+      "detail": "swap max 6.1e-08; wall range [5.9e+00, 5.9e+00]; edge min 2.2e+01 stay between cuts 0.5 / 10.0",
       "pass": true
     },
     "g19_poly_identity": {
@@ -204,6 +204,7 @@
     "pair_cut_margins": {
       "edge_smaller_side_min": "2.2e+01",
       "swap_partner_max": "6.1e-08",
+      "wall_smaller_side_max": "5.9e+00",
       "wall_smaller_side_min": "5.9e+00"
     },
     "second_center_gap": "5.4e-01",

--- a/outputs/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_receipt_2026-08-02.json
+++ b/outputs/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_receipt_2026-08-02.json
@@ -1,0 +1,210 @@
+{
+  "cycle": 712,
+  "gates": {
+    "g01_sextet_defect_zero": {
+      "detail": "max defect below 1.0e-09 on all 6 constant-sign frames",
+      "pass": true
+    },
+    "g02_family_key_set": {
+      "detail": "12 signed families = 6 unsigned x 2 signs at every L and frame",
+      "pass": true
+    },
+    "g03_no_outliers": {
+      "detail": "all 789120 large entries within 2.0e-07 of an exact magnitude",
+      "pass": true
+    },
+    "g04_frame_uniform_counts": {
+      "detail": "per-family counts identical across the 18 mixed frames at every L",
+      "pass": true
+    },
+    "g05_sign_bijection": {
+      "detail": "plus and minus family counts equal at every L",
+      "pass": true
+    },
+    "g06_canon_frame_invariant": {
+      "detail": "canonical box-descriptor multiset frame-invariant at L=(4, 5, 6)",
+      "pass": true
+    },
+    "g07_canon_L_invariant": {
+      "detail": "descriptors carry fixed margins and wall pins, independent of L",
+      "pass": true
+    },
+    "g08_box_shape": {
+      "detail": "boxes per sign 8/8/12/16/20/4 with wall pins 0/0/0/1/0/2 per box",
+      "pass": true
+    },
+    "g09_edge_family_diagonal": {
+      "detail": "edge family is diagonal (i == j) on axis (NN) classes",
+      "pass": true
+    },
+    "g10_dev_four": {
+      "detail": "max magnitude deviation 1.3e-08",
+      "pass": true
+    },
+    "g10_dev_two": {
+      "detail": "max magnitude deviation 5.7e-08",
+      "pass": true
+    },
+    "g10_dev_two_rt2": {
+      "detail": "max magnitude deviation 3.0e-08",
+      "pass": true
+    },
+    "g10_dev_two_rt3": {
+      "detail": "max magnitude deviation 6.1e-08",
+      "pass": true
+    },
+    "g14_wrong_surd_gap": {
+      "detail": "distance to second-nearest magnitude at least 5.4e-01",
+      "pass": true
+    },
+    "g15_two_window": {
+      "detail": "magnitude-2 offsets in (1.7e-09, 5.7e-08] strictly above the census cut",
+      "pass": true
+    },
+    "g16_wall_pair_values": {
+      "detail": "wall pair magnitudes 5.857096565429 and 8.685523719688 (spreads 8.5e-11 / 1.2e-11)",
+      "pass": true
+    },
+    "g17_edge_pair_values": {
+      "detail": "edge pair magnitudes 22.150846413069 and 24.150846469784 (spreads 1.2e-10 / 0.0e+00)",
+      "pass": true
+    },
+    "g18_law_four_swap": {
+      "detail": "counts(L=3..7)=[64, 216, 512, 1000, 1728] = 8(L-1)^3",
+      "pass": true
+    },
+    "g18_law_two_edge": {
+      "detail": "counts(L=3..7)=[8, 12, 16, 20, 24] = 4(L-1)",
+      "pass": true
+    },
+    "g18_law_two_rt2_swap": {
+      "detail": "counts(L=3..7)=[96, 324, 768, 1500, 2592] = 12(L-1)^3",
+      "pass": true
+    },
+    "g18_law_two_rt2_wall": {
+      "detail": "counts(L=3..7)=[64, 144, 256, 400, 576] = 16(L-1)^2",
+      "pass": true
+    },
+    "g18_law_two_rt3_swap": {
+      "detail": "counts(L=3..7)=[64, 216, 512, 1000, 1728] = 8(L-1)^3",
+      "pass": true
+    },
+    "g18_law_two_swap": {
+      "detail": "counts(L=3..7)=[128, 468, 1152, 2300, 4032] = 12(L-1)^3+8(L-1)^2(L-2)",
+      "pass": true
+    },
+    "g19_poly_identity": {
+      "detail": "descriptor prediction equals the stated polynomial for L=3..10",
+      "pass": true
+    },
+    "g20_census_anchor_L3": {
+      "detail": "rounded census above cut = ((-4, 64), (-3, 224), (-2, 136), (2, 136), (3, 224), (4, 64)) (cycle-711 anchor)",
+      "pass": true
+    },
+    "g20_census_anchor_L7": {
+      "detail": "rounded census above cut = ((-4, 1728), (-3, 4896), (-2, 4056), (2, 4056), (3, 4896), (4, 1728)) (cycle-711 anchor)",
+      "pass": true
+    },
+    "g22_bucket_composition": {
+      "detail": "census buckets = family sums (rounded 3 mixes the two surds)",
+      "pass": true
+    },
+    "g23_argmax_law": {
+      "detail": "argmax family per frame = 16(L-1)^3 = 128 / 3456 (cycle-711 anchor)",
+      "pass": true
+    },
+    "g24_perturbed_rejector": {
+      "detail": "2 entries leave the magnitude set (distance 3.0e-01) under a 1.7 diagonal perturbation",
+      "pass": true
+    }
+  },
+  "notes": {
+    "argmax_anchor": {
+      "3": 128,
+      "7": 3456
+    },
+    "census_anchor": {
+      "3": [
+        64,
+        224,
+        136
+      ],
+      "7": [
+        1728,
+        4896,
+        4056
+      ]
+    },
+    "counts_per_sign": {
+      "four|swap": [
+        64,
+        216,
+        512,
+        1000,
+        1728
+      ],
+      "two_rt2|swap": [
+        96,
+        324,
+        768,
+        1500,
+        2592
+      ],
+      "two_rt2|wall": [
+        64,
+        144,
+        256,
+        400,
+        576
+      ],
+      "two_rt3|swap": [
+        64,
+        216,
+        512,
+        1000,
+        1728
+      ],
+      "two|edge": [
+        8,
+        12,
+        16,
+        20,
+        24
+      ],
+      "two|swap": [
+        128,
+        468,
+        1152,
+        2300,
+        4032
+      ]
+    },
+    "dev_max": {
+      "four": "1.3e-08",
+      "two": "5.7e-08",
+      "two_rt2": "3.0e-08",
+      "two_rt3": "6.1e-08"
+    },
+    "edge_pair": [
+      "22.150846413069",
+      "24.150846469784"
+    ],
+    "laws_per_sign": {
+      "four|swap": "8(L-1)^3",
+      "two_rt2|swap": "12(L-1)^3",
+      "two_rt2|wall": "16(L-1)^2",
+      "two_rt3|swap": "8(L-1)^3",
+      "two|edge": "4(L-1)",
+      "two|swap": "12(L-1)^3+8(L-1)^2(L-2)"
+    },
+    "two_window": [
+      "1.7e-09",
+      "5.7e-08"
+    ],
+    "wall_pair": [
+      "5.857096565429",
+      "8.685523719688"
+    ],
+    "wrong_surd_gap": "5.4e-01"
+  }
+}

--- a/scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py
+++ b/scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py
@@ -1,41 +1,40 @@
-"""Cycle 712 -- mixed-frame assembly-defect census family law (open-boundary box).
+"""Cycle 712 -- finite mixed-frame assembly-defect family census.
 
 Cycle `physical_mixed_frame_comparator_exact_stencil_swap_law_cycle711_2026_08_02`
-derived the exact comparator stencil behind the mixed-frame assembly defect and
-recorded its signed census (entries of magnitude above 2) as measured, not
-derived.  This runner derives those counts.  For each of the 18 mixed proper
-rotations (the complement of the constant-sign sextet) and box sizes L in
-{3,4,5,6}, the large entries of the defect E = Q[m,m] - Q decompose into
-exactly 12 signed value families (6 per sign), keyed by the exact defect
-magnitude |E| in {2, 2*sqrt(2), 2*sqrt(3), 4} (finite-difference tolerance
-2e-7) and the swap pattern of the entry pair (a, b) = (Q[m i, m j], Q[i, j]):
+derived the exact magnitude-4 comparator stencil behind the mixed-frame
+assembly defect and recorded its signed census (entries of magnitude above 2)
+as measured, not derived.  This runner certifies finite counting identities for
+that census.  For each of the 18 mixed proper rotations (the complement of the
+constant-sign sextet) and box sizes L in {3,4,5,6,7}, the large entries of the
+defect E = Q[m,m] - Q decompose into exactly 12 signed numerical families (6
+per sign), keyed by the nearest reference center in
+{2, 2*sqrt(2), 2*sqrt(3), 4} (finite-difference tolerance 2e-7) and the pair
+pattern of the entry pair (a, b) = (Q[m i, m j], Q[i, j]):
 
   swap families  -- one side of the pair vanishes (a or b below 0.5);
-  wall family    -- |E| = 2*sqrt(2), both sides finite, one wall-pinned axis;
-  edge family    -- |E| = 2, diagonal entries i == j on wall-edge lines.
+  wall family    -- centered near 2*sqrt(2), both sides finite, one wall pin;
+  edge family    -- centered near 2, diagonal entries on wall-edge lines.
 
-Every family's base-position set decomposes into wall-anchored product boxes
-whose per-axis descriptors (growing interval [lo, L-1-hi] with fixed margins,
-or a pin at a wall) are L-independent and frame-covariant.  The census laws
-follow as polynomial counts per sign,
+At L in {4,5,6}, every family's base-position set decomposes into unique
+six-neighbor connected components, each a full product box.  Their per-axis
+descriptors (growing interval [lo, L-1-hi] with fixed margins, or a pin at a
+wall) are L-independent and frame-covariant.  The resulting finite counting
+identities per sign are
 
-  8(L-1)^3   at magnitude 4,
-  8(L-1)^3   at magnitude 2*sqrt(3),
-  12(L-1)^3 + 16(L-1)^2                at magnitude 2*sqrt(2),
-  12(L-1)^3 + 8(L-1)^2(L-2) + 4(L-1)   at magnitude 2,
+  8(L-1)^3   in the center-4 swap family,
+  8(L-1)^3   in the center-2*sqrt(3) swap family,
+  12(L-1)^3 + 16(L-1)^2                in the center-2*sqrt(2) families,
+  12(L-1)^3 + 8(L-1)^2(L-2) + 4(L-1)  in the center-2 families.
 
-verified against the measured census at L in {3,4,5,6}, extrapolated from the
-descriptors alone both downward to L=3 and upward to L=7, and checked at L=7
-against the landed cycle-711 census (1728 / 4896 / 4056 per sign, argmax
-family 3456 per frame).  The rounded census buckets are corollaries: the
-bucket at rounded value 3 is the surd mixture of 2*sqrt(3) with 2*sqrt(2),
-and the magnitude-2 families enter the strict census cut A > 2.0 through a
-strictly positive finite-difference offset (every magnitude-2 entry sits in
-the window (2, 2 + 1e-7]), so the cut is deterministic for them.  Family pair
-values beyond the defect magnitudes (the wall pair and the edge diagonal
-pair) are measured, not derived, here; their exact stencil evaluation is the
-named next target.  All computational identities below are recomputed from
-the cycle-696 compiler chain in this run; a wrong-surd distance floor and a
+They are checked against the complete measured census at L in {3,4,5,6,7};
+L=3 and L=7 are held out from descriptor extraction.  The rounded buckets
+reproduce the Cycle-711 anchors.  The center-2 families enter the strict census
+cut A > 2.0 through a positive finite-difference offset, so that cut is
+deterministic on the scanned data.  Only the center-4 swap magnitude has the
+upstream exact stencil derivation.  The other surd-center identifications, and
+the wall and edge entry-pair magnitudes, remain finite-difference observations;
+exact stencil evaluation is the named next target.  All finite identities below
+are recomputed from the Cycle-696 compiler chain; a second-center gap and a
 perturbed-operator rejector discriminate.
 """
 from __future__ import annotations
@@ -60,21 +59,38 @@ FRAMES = [np.asarray(m, dtype=np.int64) for m in c696.c576.FRAMES]
 SPC = tuple(c696.SPATIAL_CLASSES)
 DIRV = {c: np.asarray(c696.regge.DIRS15[c][:3], dtype=np.int64) for c in SPC}
 
+AUDIT_TIMEOUT_SEC = 300
+AUDIT_INPUT_PATHS = (
+    "docs/PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md",
+    "docs/PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_LAW_AND_COVARIANCE_BOUNDARY_CYCLE710_NOTE_2026-08-02.md",
+    "docs/PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02.md",
+    "scripts/physical_assembly_defect_cocycle_law_and_covariance_boundary_cycle710_2026_08_02.py",
+    "scripts/physical_mixed_frame_comparator_exact_stencil_swap_law_cycle711_2026_08_02.py",
+    "outputs/physical_assembly_defect_cocycle_law_and_covariance_boundary_cycle710_2026_08_02_receipt_2026-08-02.json",
+    "outputs/physical_mixed_frame_comparator_exact_stencil_swap_law_cycle711_2026_08_02_receipt_2026-08-02.json",
+    "scripts/physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py",
+    "scripts/physical_dynamical_metric_source_law_bridge_tournament_cycle576_2026_07_22.py",
+    "scripts/physical_dynamical_metric_source_law_bridge_cycle576_regge_support_2026_07_22.py",
+    "scripts/physical_dynamical_metric_source_law_bridge_cycle576_plaquette_support_2026_07_22.py",
+    "scripts/frontier_cubic_coxeter_regge_second_variation_3plus1_2026_06_09.py",
+)
+DECLARED_INPUT_PATHS = AUDIT_INPUT_PATHS
+
 L_FIT = (4, 5, 6)          # descriptor-extraction sizes
 L_ALL = (3, 4, 5, 6, 7)    # measured-census sizes (3 and 7 are extrapolation checks)
 BIG = 1.5                  # family-entry threshold on |E|
 CUT = 2.0                  # census cut of the landed cycle-711 note
-ARG_CUT = 3.9              # argmax-family cut (top magnitude 4, next surd ~3.46)
-TOL_SURD = 2e-7            # finite-difference tolerance on exact magnitudes
+ARG_CUT = 3.9              # argmax-family cut (center 4, next center ~3.46)
+TOL_CENTER = 2e-7          # finite-difference tolerance around reference centers
 PAIR_LO = 0.5              # swap-pattern threshold: vanished side of (a, b)
 PAIR_HI = 10.0             # wall pair magnitudes ~5.86/8.69, edge pair ~22.2/24.2
 WINDOW = 1e-7              # magnitude-2 census-entry offset window above 2.0
-GAP_FLOOR = 0.1            # wrong-surd rejector floor
+CENTER_GAP_FLOOR = 0.1     # distance-to-second-center rejector floor
 SEXTET_BOUND = 1e-9
-PERT = 1.7                 # perturbed-operator rejector step (lands between surds)
+PERT = 1.7                 # perturbed-operator rejector step (lands between centers)
 
-SURDS = (("two", 2.0), ("two_rt2", 2.0 * math.sqrt(2.0)),
-         ("two_rt3", 2.0 * math.sqrt(3.0)), ("four", 4.0))
+REFERENCE_CENTERS = (("two", 2.0), ("two_rt2", 2.0 * math.sqrt(2.0)),
+                     ("two_rt3", 2.0 * math.sqrt(3.0)), ("four", 4.0))
 UNSIGNED = (("four", "swap"), ("two_rt3", "swap"), ("two_rt2", "swap"),
             ("two_rt2", "wall"), ("two", "swap"), ("two", "edge"))
 POLY = {
@@ -107,7 +123,7 @@ def fmt(x) -> str:
 
 def check(name: str, ok: bool, detail: str = "") -> bool:
     """Record and print one gate.  The census gates compare recomputed counts
-    exactly; the magnitude gates carry a wrong-surd distance floor and a
+    exactly; the magnitude gates carry a second-center distance floor and a
     perturbed-operator rejector so that a wrong object cannot pass."""
     global N_PASS, N_FAIL
     ok = bool(ok)
@@ -141,38 +157,39 @@ def dof_perm(L: int, index: dict, R: np.ndarray) -> np.ndarray:
     return m
 
 
-def boxdec(xs, depth=0):
-    """Decompose a site set into disjoint full product boxes (split on a
-    non-contiguous axis, else on the fewest-valued axis; depth-capped)."""
-    ss = sorted(set(xs))
-    if len(ss) != len(xs):
+def component_product_boxes(xs):
+    """Return the unique six-neighbor components if each is a full box.
+
+    Connected components are intrinsic to the finite site set; unlike a greedy
+    recursive split, this decomposition does not depend on an axis choice.
+    """
+    points = {tuple(int(t) for t in x) for x in xs}
+    if len(points) != len(xs):
         return None
-    arr = np.asarray(ss, dtype=np.int64)
-    lo = arr.min(axis=0)
-    hi = arr.max(axis=0)
-    if int(np.prod(hi - lo + 1)) == len(ss):
-        return [tuple((int(lo[a]), int(hi[a])) for a in range(3))]
-    if depth >= 2:
-        return None
-    split = None
-    for a in range(3):
-        vals = sorted({x[a] for x in ss})
-        if len(vals) > 1 and vals[-1] - vals[0] + 1 > len(vals):
-            split = a
-            break
-    if split is None:
-        cands = [(len({x[a] for x in ss}), a) for a in range(3)
-                 if 1 < len({x[a] for x in ss}) < len(ss)]
-        if not cands:
+    unseen = set(points)
+    boxes = []
+    while unseen:
+        seed = unseen.pop()
+        component = {seed}
+        frontier = [seed]
+        while frontier:
+            x = frontier.pop()
+            for axis in range(3):
+                for step in (-1, 1):
+                    y = list(x)
+                    y[axis] += step
+                    yt = tuple(y)
+                    if yt in unseen:
+                        unseen.remove(yt)
+                        component.add(yt)
+                        frontier.append(yt)
+        arr = np.asarray(sorted(component), dtype=np.int64)
+        lo = arr.min(axis=0)
+        hi = arr.max(axis=0)
+        if int(np.prod(hi - lo + 1)) != len(component):
             return None
-        split = min(cands)[1]
-    out = []
-    for v in sorted({x[split] for x in ss}):
-        r = boxdec([x for x in ss if x[split] == v], depth + 1)
-        if r is None:
-            return None
-        out.extend(r)
-    return out
+        boxes.append(tuple((int(lo[a]), int(hi[a])) for a in range(3)))
+    return sorted(boxes)
 
 
 def axdesc(lo: int, hi: int, L: int):
@@ -207,26 +224,26 @@ def predict(canon, L: int) -> int:
 
 
 def classify(av: float):
-    """Return (surd name, deviation, distance to second-nearest surd)."""
-    devs = sorted((abs(av - s), name) for name, s in SURDS)
+    """Return (center name, deviation, distance to second-nearest center)."""
+    devs = sorted((abs(av - s), name) for name, s in REFERENCE_CENTERS)
     return devs[0][1], devs[0][0], devs[1][0]
 
 
 def main() -> int:
     mixed = [g for g in range(24) if not constant_sign(FRAMES[g])]
     sextet = [g for g in range(24) if constant_sign(FRAMES[g])]
-    print("== cycle 712: mixed-frame assembly-defect census family law ==")
+    print("== cycle 712: finite mixed-frame assembly-defect family census ==")
     print("config: fit L={} census L={} mixed_frames={} of 24 fd_step={} "
-          "tol_surd={} cut={} pair_cuts=({}, {})".format(
-              L_FIT, L_ALL, len(mixed), fmt(c696.FD_H), fmt(TOL_SURD),
+          "tol_center={} cut={} pair_cuts=({}, {})".format(
+              L_FIT, L_ALL, len(mixed), fmt(c696.FD_H), fmt(TOL_CENTER),
               fmt(CUT), PAIR_LO, PAIR_HI))
 
     counts: dict = {}       # (L, famkey) -> set of per-frame counts
-    canons: dict = {}       # (L, famkey) -> set of per-frame canonical box lists
+    canons: dict = {}       # (L, famkey) -> set of normalized component boxes
     keysets: dict = {}      # L -> set of per-frame famkey tuples
     censuses: dict = {}     # L -> set of per-frame rounded census tuples
     argmaxes: dict = {}     # L -> set of per-frame argmax-family sizes
-    dev_max = {name: 0.0 for name, _ in SURDS}
+    dev_max = {name: 0.0 for name, _ in REFERENCE_CENTERS}
     gap_min = float("inf")
     outliers = 0
     n_entries = 0
@@ -237,6 +254,9 @@ def main() -> int:
     edge_diag_ok = True
     edge_cls_ok = True
     pin_ok = True
+    swap_partner_max = 0.0
+    wall_partner_min = float("inf")
+    edge_partner_min = float("inf")
 
     sext_max = 0.0
     model3 = c696.assemble_static_hessian(3, wrap=False)
@@ -274,13 +294,19 @@ def main() -> int:
                 b = float(Q[i, j])
                 name, dev, second = classify(av)
                 n_entries += 1
-                if dev > TOL_SURD:
+                if dev > TOL_CENTER:
                     outliers += 1
                     continue
                 dev_max[name] = max(dev_max[name], dev)
                 gap_min = min(gap_min, second)
                 mab = min(abs(a), abs(b))
                 pc = "swap" if mab < PAIR_LO else ("wall" if mab < PAIR_HI else "edge")
+                if pc == "swap":
+                    swap_partner_max = max(swap_partner_max, mab)
+                elif pc == "wall":
+                    wall_partner_min = min(wall_partner_min, mab)
+                else:
+                    edge_partner_min = min(edge_partner_min, mab)
                 if name == "two":
                     off = av - CUT
                     two_off_lo = min(two_off_lo, off)
@@ -308,7 +334,7 @@ def main() -> int:
                 if store:
                     allboxes = []
                     for tpl, sites in d["tpl"].items():
-                        boxes = boxdec(sites)
+                        boxes = component_product_boxes(sites)
                         if boxes is None:
                             pin_ok = False
                             continue
@@ -334,7 +360,7 @@ def main() -> int:
                 po, pg = 0, float("inf")
                 for av2 in A2[A2 > BIG].tolist():
                     _, dev2, _ = classify(float(av2))
-                    if dev2 > TOL_SURD:
+                    if dev2 > TOL_CENTER:
                         po += 1
                         pg = min(pg, dev2)
                 pert_outliers, pert_gap = po, pg
@@ -345,19 +371,19 @@ def main() -> int:
           all(ks == {expect_keys} for ks in keysets.values()),
           "12 signed families = 6 unsigned x 2 signs at every L and frame")
     check("g03_no_outliers", outliers == 0,
-          "all {} large entries within {} of an exact magnitude".format(
-              n_entries, fmt(TOL_SURD)))
+          "all {} large entries within {} of a numerical reference center".format(
+              n_entries, fmt(TOL_CENTER)))
     check("g04_frame_uniform_counts",
           all(len(v) == 1 for v in counts.values()),
           "per-family counts identical across the 18 mixed frames at every L")
     bij = all(next(iter(counts[(L, (1, name, pc))])) ==
               next(iter(counts[(L, (-1, name, pc))]))
               for L in L_ALL for (name, pc) in UNSIGNED)
-    check("g05_sign_bijection", bij,
+    check("g05_sign_balance", bij,
           "plus and minus family counts equal at every L")
     check("g06_canon_frame_invariant",
           all(len(v) == 1 for v in canons.values()),
-          "canonical box-descriptor multiset frame-invariant at L={}".format(L_FIT))
+          "connected-component box descriptors frame-invariant at L={}".format(L_FIT))
     canon_of = {}
     lstable = True
     for (name, pc) in UNSIGNED:
@@ -376,11 +402,11 @@ def main() -> int:
           "boxes per sign 8/8/12/16/20/4 with wall pins 0/0/0/1/0/2 per box")
     check("g09_edge_family_diagonal", edge_diag_ok and edge_cls_ok,
           "edge family is diagonal (i == j) on axis (NN) classes")
-    for name, _ in SURDS:
-        check("g10_dev_{}".format(name), dev_max[name] <= TOL_SURD,
-              "max magnitude deviation {}".format(fmt(dev_max[name])))
-    check("g14_wrong_surd_gap", gap_min >= GAP_FLOOR,
-          "distance to second-nearest magnitude at least {}".format(fmt(gap_min)))
+    for name, _ in REFERENCE_CENTERS:
+        check("g10_center_dev_{}".format(name), dev_max[name] <= TOL_CENTER,
+              "max reference-center deviation {}".format(fmt(dev_max[name])))
+    check("g14_second_center_gap", gap_min >= CENTER_GAP_FLOOR,
+          "distance to second-nearest center at least {}".format(fmt(gap_min)))
     check("g15_two_window", two_all_above and two_off_hi <= WINDOW,
           "magnitude-2 offsets in ({}, {}] strictly above the census cut".format(
               fmt(two_off_lo), fmt(two_off_hi)))
@@ -396,6 +422,14 @@ def main() -> int:
           el[1] - el[0] <= WINDOW and eh[1] - eh[0] <= WINDOW,
           "edge pair magnitudes {:.12f} and {:.12f} (spreads {} / {})".format(
               el[0], eh[0], fmt(el[1] - el[0]), fmt(eh[1] - eh[0])))
+    check("g18_pair_cut_margins",
+          swap_partner_max < 1.0e-6 and wall_partner_min > PAIR_LO
+          and edge_partner_min > PAIR_HI,
+          "swap partner max {}; wall/edge smaller-side minima {} / {} stay "
+          "away from cuts {} / {}".format(fmt(swap_partner_max),
+                                           fmt(wall_partner_min),
+                                           fmt(edge_partner_min),
+                                           PAIR_LO, PAIR_HI))
     for (name, pc) in UNSIGNED:
         meas = [next(iter(counts[(L, (1, name, pc))])) for L in L_ALL]
         pred = [predict(canon_of[(name, pc)], L) for L in L_ALL]
@@ -424,7 +458,7 @@ def main() -> int:
                                      + c_of(("two_rt2", "wall")))
         comp_ok = comp_ok and n2 == (c_of(("two", "swap")) + c_of(("two", "edge")))
     check("g22_bucket_composition", comp_ok,
-          "census buckets = family sums (rounded 3 mixes the two surds)")
+          "census buckets = family sums (rounded 3 mixes two numerical centers)")
     argm_ok = all(argmaxes[L] == {ARGMAX_ANCHOR[L]}
                   and ARGMAX_ANCHOR[L] == 16 * (L - 1) ** 3
                   and ARGMAX_ANCHOR[L] == 2 * next(iter(counts[(L, (1, "four", "swap"))]))
@@ -433,7 +467,7 @@ def main() -> int:
           "argmax family per frame = 16(L-1)^3 = {} / {} (cycle-711 anchor)".format(
               ARGMAX_ANCHOR[3], ARGMAX_ANCHOR[7]))
     check("g24_perturbed_rejector", pert_outliers >= 1,
-          "{} entries leave the magnitude set (distance {}) under a {} "
+          "{} entries leave the reference-center set (distance {}) under a {} "
           "diagonal perturbation".format(pert_outliers, fmt(pert_gap), PERT))
 
     NOTES["laws_per_sign"] = {"|".join(k): POLY[k][1] for k in POLY}
@@ -442,8 +476,13 @@ def main() -> int:
         for k in POLY}
     NOTES["census_anchor"] = {str(L): list(ANCHOR[L]) for L in ANCHOR}
     NOTES["argmax_anchor"] = {str(L): ARGMAX_ANCHOR[L] for L in ARGMAX_ANCHOR}
-    NOTES["dev_max"] = {k: fmt(v) for k, v in dev_max.items()}
-    NOTES["wrong_surd_gap"] = fmt(gap_min)
+    NOTES["center_deviation_max"] = {k: fmt(v) for k, v in dev_max.items()}
+    NOTES["second_center_gap"] = fmt(gap_min)
+    NOTES["pair_cut_margins"] = {
+        "swap_partner_max": fmt(swap_partner_max),
+        "wall_smaller_side_min": fmt(wall_partner_min),
+        "edge_smaller_side_min": fmt(edge_partner_min),
+    }
     NOTES["two_window"] = [fmt(two_off_lo), fmt(two_off_hi)]
     NOTES["wall_pair"] = ["{:.12f}".format(wl[0]), "{:.12f}".format(wh[0])]
     NOTES["edge_pair"] = ["{:.12f}".format(el[0]), "{:.12f}".format(eh[0])]

--- a/scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py
+++ b/scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py
@@ -386,22 +386,24 @@ def main() -> int:
     check("g06_canon_frame_invariant",
           all(len(v) == 1 for v in canons.values()),
           "connected-component box descriptors frame-invariant at L={}".format(L_FIT))
-    canon_of = {}
+    canon_of_signed = {}
     lstable = True
-    for (name, pc) in UNSIGNED:
-        cs = [next(iter(canons[(L, (1, name, pc))])) for L in L_FIT]
-        lstable = lstable and (len(set(cs)) == 1)
-        canon_of[(name, pc)] = cs[0]
+    for sign in (-1, 1):
+        for (name, pc) in UNSIGNED:
+            cs = [next(iter(canons[(L, (sign, name, pc))])) for L in L_FIT]
+            lstable = lstable and (len(set(cs)) == 1)
+            canon_of_signed[(sign, name, pc)] = cs[0]
     check("g07_canon_L_invariant", lstable,
-          "descriptors carry fixed margins and wall pins, independent of L")
+          "both signs carry fixed margins and wall pins, independent of L")
     shape_ok = pin_ok
-    for (name, pc), (nbox, npin) in BOX_SHAPE.items():
-        cb = canon_of[(name, pc)]
-        shape_ok = shape_ok and (len(cb) == nbox)
-        shape_ok = shape_ok and all(
-            sum(1 for d in box if d == "P") == npin for box in cb)
+    for sign in (-1, 1):
+        for (name, pc), (nbox, npin) in BOX_SHAPE.items():
+            cb = canon_of_signed[(sign, name, pc)]
+            shape_ok = shape_ok and (len(cb) == nbox)
+            shape_ok = shape_ok and all(
+                sum(1 for d in box if d == "P") == npin for box in cb)
     check("g08_box_shape", shape_ok,
-          "boxes per sign 8/8/12/16/20/4 with wall pins 0/0/0/1/0/2 per box")
+          "both signs: boxes 8/8/12/16/20/4 with pins 0/0/0/1/0/2 per box")
     check("g09_edge_family_diagonal", edge_diag_ok and edge_cls_ok,
           "edge family is diagonal (i == j) on axis (NN) classes")
     for name, _ in REFERENCE_CENTERS:
@@ -434,14 +436,17 @@ def main() -> int:
                                            fmt(edge_partner_min),
                                            PAIR_LO, PAIR_HI))
     for (name, pc) in UNSIGNED:
+        canon = canon_of_signed[(1, name, pc)]
         meas = [next(iter(counts[(L, (1, name, pc))])) for L in L_ALL]
-        pred = [predict(canon_of[(name, pc)], L) for L in L_ALL]
+        pred = [predict(canon, L) for L in L_ALL]
         poly = [POLY[(name, pc)][0](L) for L in L_ALL]
         check("g18_law_{}_{}".format(name, pc),
               meas == pred == poly,
               "counts(L=3..7)={} = {}".format(meas, POLY[(name, pc)][1]))
-    poly_ok = all(predict(canon_of[k], L) == POLY[k][0](L)
-                  for k in canon_of for L in range(3, 11))
+    poly_ok = all(
+        predict(canon_of_signed[(sign,) + k], L) == POLY[k][0](L)
+        for sign in (-1, 1) for k in POLY for L in range(3, 11)
+    )
     check("g19_poly_identity", poly_ok,
           "descriptor prediction equals the stated polynomial for L=3..10")
     for L in (3, 7):

--- a/scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py
+++ b/scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py
@@ -256,6 +256,7 @@ def main() -> int:
     pin_ok = True
     swap_partner_max = 0.0
     wall_partner_min = float("inf")
+    wall_partner_max = 0.0
     edge_partner_min = float("inf")
 
     sext_max = 0.0
@@ -305,6 +306,7 @@ def main() -> int:
                     swap_partner_max = max(swap_partner_max, mab)
                 elif pc == "wall":
                     wall_partner_min = min(wall_partner_min, mab)
+                    wall_partner_max = max(wall_partner_max, mab)
                 else:
                     edge_partner_min = min(edge_partner_min, mab)
                 if name == "two":
@@ -423,11 +425,12 @@ def main() -> int:
           "edge pair magnitudes {:.12f} and {:.12f} (spreads {} / {})".format(
               el[0], eh[0], fmt(el[1] - el[0]), fmt(eh[1] - eh[0])))
     check("g18_pair_cut_margins",
-          swap_partner_max < 1.0e-6 and wall_partner_min > PAIR_LO
+          swap_partner_max < PAIR_LO and wall_partner_min > PAIR_LO
+          and wall_partner_max < PAIR_HI
           and edge_partner_min > PAIR_HI,
-          "swap partner max {}; wall/edge smaller-side minima {} / {} stay "
-          "away from cuts {} / {}".format(fmt(swap_partner_max),
-                                           fmt(wall_partner_min),
+          "swap max {}; wall range [{}, {}]; edge min {} stay between cuts "
+          "{} / {}".format(fmt(swap_partner_max), fmt(wall_partner_min),
+                                           fmt(wall_partner_max),
                                            fmt(edge_partner_min),
                                            PAIR_LO, PAIR_HI))
     for (name, pc) in UNSIGNED:
@@ -481,6 +484,7 @@ def main() -> int:
     NOTES["pair_cut_margins"] = {
         "swap_partner_max": fmt(swap_partner_max),
         "wall_smaller_side_min": fmt(wall_partner_min),
+        "wall_smaller_side_max": fmt(wall_partner_max),
         "edge_smaller_side_min": fmt(edge_partner_min),
     }
     NOTES["two_window"] = [fmt(two_off_lo), fmt(two_off_hi)]

--- a/scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py
+++ b/scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py
@@ -1,0 +1,460 @@
+"""Cycle 712 -- mixed-frame assembly-defect census family law (open-boundary box).
+
+Cycle `physical_mixed_frame_comparator_exact_stencil_swap_law_cycle711_2026_08_02`
+derived the exact comparator stencil behind the mixed-frame assembly defect and
+recorded its signed census (entries of magnitude above 2) as measured, not
+derived.  This runner derives those counts.  For each of the 18 mixed proper
+rotations (the complement of the constant-sign sextet) and box sizes L in
+{3,4,5,6}, the large entries of the defect E = Q[m,m] - Q decompose into
+exactly 12 signed value families (6 per sign), keyed by the exact defect
+magnitude |E| in {2, 2*sqrt(2), 2*sqrt(3), 4} (finite-difference tolerance
+2e-7) and the swap pattern of the entry pair (a, b) = (Q[m i, m j], Q[i, j]):
+
+  swap families  -- one side of the pair vanishes (a or b below 0.5);
+  wall family    -- |E| = 2*sqrt(2), both sides finite, one wall-pinned axis;
+  edge family    -- |E| = 2, diagonal entries i == j on wall-edge lines.
+
+Every family's base-position set decomposes into wall-anchored product boxes
+whose per-axis descriptors (growing interval [lo, L-1-hi] with fixed margins,
+or a pin at a wall) are L-independent and frame-covariant.  The census laws
+follow as polynomial counts per sign,
+
+  8(L-1)^3   at magnitude 4,
+  8(L-1)^3   at magnitude 2*sqrt(3),
+  12(L-1)^3 + 16(L-1)^2                at magnitude 2*sqrt(2),
+  12(L-1)^3 + 8(L-1)^2(L-2) + 4(L-1)   at magnitude 2,
+
+verified against the measured census at L in {3,4,5,6}, extrapolated from the
+descriptors alone both downward to L=3 and upward to L=7, and checked at L=7
+against the landed cycle-711 census (1728 / 4896 / 4056 per sign, argmax
+family 3456 per frame).  The rounded census buckets are corollaries: the
+bucket at rounded value 3 is the surd mixture of 2*sqrt(3) with 2*sqrt(2),
+and the magnitude-2 families enter the strict census cut A > 2.0 through a
+strictly positive finite-difference offset (every magnitude-2 entry sits in
+the window (2, 2 + 1e-7]), so the cut is deterministic for them.  Family pair
+values beyond the defect magnitudes (the wall pair and the edge diagonal
+pair) are measured, not derived, here; their exact stencil evaluation is the
+named next target.  All computational identities below are recomputed from
+the cycle-696 compiler chain in this run; a wrong-surd distance floor and a
+perturbed-operator rejector discriminate.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(HERE))
+_MODULE = HERE / "physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py"
+_SPEC = importlib.util.spec_from_file_location("c696_compiler_for_c712", _MODULE)
+c696 = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(c696)
+
+FRAMES = [np.asarray(m, dtype=np.int64) for m in c696.c576.FRAMES]
+SPC = tuple(c696.SPATIAL_CLASSES)
+DIRV = {c: np.asarray(c696.regge.DIRS15[c][:3], dtype=np.int64) for c in SPC}
+
+L_FIT = (4, 5, 6)          # descriptor-extraction sizes
+L_ALL = (3, 4, 5, 6, 7)    # measured-census sizes (3 and 7 are extrapolation checks)
+BIG = 1.5                  # family-entry threshold on |E|
+CUT = 2.0                  # census cut of the landed cycle-711 note
+ARG_CUT = 3.9              # argmax-family cut (top magnitude 4, next surd ~3.46)
+TOL_SURD = 2e-7            # finite-difference tolerance on exact magnitudes
+PAIR_LO = 0.5              # swap-pattern threshold: vanished side of (a, b)
+PAIR_HI = 10.0             # wall pair magnitudes ~5.86/8.69, edge pair ~22.2/24.2
+WINDOW = 1e-7              # magnitude-2 census-entry offset window above 2.0
+GAP_FLOOR = 0.1            # wrong-surd rejector floor
+SEXTET_BOUND = 1e-9
+PERT = 1.7                 # perturbed-operator rejector step (lands between surds)
+
+SURDS = (("two", 2.0), ("two_rt2", 2.0 * math.sqrt(2.0)),
+         ("two_rt3", 2.0 * math.sqrt(3.0)), ("four", 4.0))
+UNSIGNED = (("four", "swap"), ("two_rt3", "swap"), ("two_rt2", "swap"),
+            ("two_rt2", "wall"), ("two", "swap"), ("two", "edge"))
+POLY = {
+    ("four", "swap"): (lambda L: 8 * (L - 1) ** 3, "8(L-1)^3"),
+    ("two_rt3", "swap"): (lambda L: 8 * (L - 1) ** 3, "8(L-1)^3"),
+    ("two_rt2", "swap"): (lambda L: 12 * (L - 1) ** 3, "12(L-1)^3"),
+    ("two_rt2", "wall"): (lambda L: 16 * (L - 1) ** 2, "16(L-1)^2"),
+    ("two", "swap"): (lambda L: 12 * (L - 1) ** 3 + 8 * (L - 1) ** 2 * (L - 2),
+                      "12(L-1)^3+8(L-1)^2(L-2)"),
+    ("two", "edge"): (lambda L: 4 * (L - 1), "4(L-1)"),
+}
+BOX_SHAPE = {("four", "swap"): (8, 0), ("two_rt3", "swap"): (8, 0),
+             ("two_rt2", "swap"): (12, 0), ("two_rt2", "wall"): (16, 1),
+             ("two", "swap"): (20, 0), ("two", "edge"): (4, 2)}
+ANCHOR = {3: (64, 224, 136), 7: (1728, 4896, 4056)}   # cycle-711 census per sign
+ARGMAX_ANCHOR = {3: 128, 7: 3456}                     # cycle-711 argmax per frame
+
+RECEIPT_NAME = ("physical_mixed_frame_defect_census_family_law_cycle712"
+                "_2026_08_02_receipt_2026-08-02.json")
+
+N_PASS = 0
+N_FAIL = 0
+GATES: dict = {}
+NOTES: dict = {}
+
+
+def fmt(x) -> str:
+    return "{:.1e}".format(float(x))
+
+
+def check(name: str, ok: bool, detail: str = "") -> bool:
+    """Record and print one gate.  The census gates compare recomputed counts
+    exactly; the magnitude gates carry a wrong-surd distance floor and a
+    perturbed-operator rejector so that a wrong object cannot pass."""
+    global N_PASS, N_FAIL
+    ok = bool(ok)
+    if ok:
+        N_PASS += 1
+    else:
+        N_FAIL += 1
+    GATES[name] = {"pass": ok, "detail": detail}
+    print("{} {} {}".format("PASS" if ok else "FAIL", name, detail))
+    return ok
+
+
+def constant_sign(R: np.ndarray) -> bool:
+    nz = R[R != 0]
+    return bool(np.all(nz == 1) or np.all(nz == -1))
+
+
+def support(c: int) -> int:
+    return int(np.abs(DIRV[c]).sum())
+
+
+def dof_perm(L: int, index: dict, R: np.ndarray) -> np.ndarray:
+    smap = c696.frame_site_map(L, R)
+    dir2class = {tuple(int(t) for t in DIRV[c]): c for c in SPC}
+    m = np.empty(len(index), dtype=np.int64)
+    for (c, x), i in index.items():
+        w = R @ DIRV[c]
+        vp = tuple(int(t) for t in np.abs(w))
+        xp = tuple(int(t) for t in (np.asarray(smap[x], dtype=np.int64) + np.minimum(w, 0)))
+        m[i] = index[(dir2class[vp], xp)]
+    return m
+
+
+def boxdec(xs, depth=0):
+    """Decompose a site set into disjoint full product boxes (split on a
+    non-contiguous axis, else on the fewest-valued axis; depth-capped)."""
+    ss = sorted(set(xs))
+    if len(ss) != len(xs):
+        return None
+    arr = np.asarray(ss, dtype=np.int64)
+    lo = arr.min(axis=0)
+    hi = arr.max(axis=0)
+    if int(np.prod(hi - lo + 1)) == len(ss):
+        return [tuple((int(lo[a]), int(hi[a])) for a in range(3))]
+    if depth >= 2:
+        return None
+    split = None
+    for a in range(3):
+        vals = sorted({x[a] for x in ss})
+        if len(vals) > 1 and vals[-1] - vals[0] + 1 > len(vals):
+            split = a
+            break
+    if split is None:
+        cands = [(len({x[a] for x in ss}), a) for a in range(3)
+                 if 1 < len({x[a] for x in ss}) < len(ss)]
+        if not cands:
+            return None
+        split = min(cands)[1]
+    out = []
+    for v in sorted({x[split] for x in ss}):
+        r = boxdec([x for x in ss if x[split] == v], depth + 1)
+        if r is None:
+            return None
+        out.extend(r)
+    return out
+
+
+def axdesc(lo: int, hi: int, L: int):
+    """Per-axis descriptor: wall pin, or growing interval with fixed margins."""
+    if lo == hi:
+        return "P" if lo in (0, L - 1) else None
+    return ("G", int(lo + (L - 1 - hi)))
+
+
+def canon_boxes(boxes, L):
+    """Frame-covariant canonical form: per box the sorted axis descriptors."""
+    out = []
+    for box in boxes:
+        descs = []
+        for (lo, hi) in box:
+            d = axdesc(lo, hi, L)
+            if d is None:
+                return None
+            descs.append(d)
+        out.append(tuple(sorted(descs, key=repr)))
+    return tuple(sorted(out, key=repr))
+
+
+def predict(canon, L: int) -> int:
+    tot = 0
+    for box in canon:
+        p = 1
+        for d in box:
+            p *= 1 if d == "P" else (L - d[1])
+        tot += p
+    return tot
+
+
+def classify(av: float):
+    """Return (surd name, deviation, distance to second-nearest surd)."""
+    devs = sorted((abs(av - s), name) for name, s in SURDS)
+    return devs[0][1], devs[0][0], devs[1][0]
+
+
+def main() -> int:
+    mixed = [g for g in range(24) if not constant_sign(FRAMES[g])]
+    sextet = [g for g in range(24) if constant_sign(FRAMES[g])]
+    print("== cycle 712: mixed-frame assembly-defect census family law ==")
+    print("config: fit L={} census L={} mixed_frames={} of 24 fd_step={} "
+          "tol_surd={} cut={} pair_cuts=({}, {})".format(
+              L_FIT, L_ALL, len(mixed), fmt(c696.FD_H), fmt(TOL_SURD),
+              fmt(CUT), PAIR_LO, PAIR_HI))
+
+    counts: dict = {}       # (L, famkey) -> set of per-frame counts
+    canons: dict = {}       # (L, famkey) -> set of per-frame canonical box lists
+    keysets: dict = {}      # L -> set of per-frame famkey tuples
+    censuses: dict = {}     # L -> set of per-frame rounded census tuples
+    argmaxes: dict = {}     # L -> set of per-frame argmax-family sizes
+    dev_max = {name: 0.0 for name, _ in SURDS}
+    gap_min = float("inf")
+    outliers = 0
+    n_entries = 0
+    two_off_lo, two_off_hi = float("inf"), -float("inf")
+    two_all_above = True
+    wall_vals: dict = {"lo": [], "hi": []}
+    edge_vals: dict = {"lo": [], "hi": []}
+    edge_diag_ok = True
+    edge_cls_ok = True
+    pin_ok = True
+
+    sext_max = 0.0
+    model3 = c696.assemble_static_hessian(3, wrap=False)
+    Q3, index3 = model3["Q"], model3["index"]
+    for g in sextet:
+        mm = dof_perm(3, index3, FRAMES[g])
+        sext_max = max(sext_max, float(np.abs(Q3[np.ix_(mm, mm)] - Q3).max()))
+    check("g01_sextet_defect_zero", sext_max <= SEXTET_BOUND,
+          "max defect below {} on all {} constant-sign frames".format(
+              fmt(SEXTET_BOUND), len(sextet)))
+
+    pert_outliers = None
+    pert_gap = None
+
+    for L in L_ALL:
+        model = c696.assemble_static_hessian(L, wrap=False)
+        Q, index = model["Q"], model["index"]
+        N = len(index)
+        cls_of = np.empty(N, dtype=np.int64)
+        site_of = np.empty((N, 3), dtype=np.int64)
+        for (c, x), i in index.items():
+            cls_of[i] = c
+            site_of[i] = x
+        store = L in L_FIT
+        for g in mixed:
+            mm = dof_perm(L, index, FRAMES[g])
+            E = Q[np.ix_(mm, mm)] - Q
+            A = np.abs(E)
+            ii, jj = np.where(A > BIG)
+            fams: dict = {}
+            for i, j in zip(ii, jj):
+                v = float(E[i, j])
+                av = float(A[i, j])
+                a = float(Q[mm[i], mm[j]])
+                b = float(Q[i, j])
+                name, dev, second = classify(av)
+                n_entries += 1
+                if dev > TOL_SURD:
+                    outliers += 1
+                    continue
+                dev_max[name] = max(dev_max[name], dev)
+                gap_min = min(gap_min, second)
+                mab = min(abs(a), abs(b))
+                pc = "swap" if mab < PAIR_LO else ("wall" if mab < PAIR_HI else "edge")
+                if name == "two":
+                    off = av - CUT
+                    two_off_lo = min(two_off_lo, off)
+                    two_off_hi = max(two_off_hi, off)
+                    two_all_above = two_all_above and (av > CUT)
+                if pc == "wall":
+                    for val in (abs(a), abs(b)):
+                        wall_vals["lo" if val < 7.0 else "hi"].append(val)
+                if pc == "edge":
+                    edge_diag_ok = edge_diag_ok and (i == j)
+                    edge_cls_ok = edge_cls_ok and (support(int(cls_of[i])) == 1
+                                                   and support(int(cls_of[j])) == 1)
+                    for val in (abs(a), abs(b)):
+                        edge_vals["lo" if val < 23.0 else "hi"].append(val)
+                famkey = (1 if v > 0 else -1, name, pc)
+                d = fams.setdefault(famkey, {"n": 0, "tpl": {}})
+                d["n"] += 1
+                if store:
+                    tpl = (int(cls_of[i]), int(cls_of[j])) + tuple(
+                        int(t) for t in (site_of[j] - site_of[i]))
+                    d["tpl"].setdefault(tpl, []).append(tuple(int(t) for t in site_of[i]))
+            keysets.setdefault(L, set()).add(tuple(sorted(fams.keys())))
+            for famkey, d in fams.items():
+                counts.setdefault((L, famkey), set()).add(d["n"])
+                if store:
+                    allboxes = []
+                    for tpl, sites in d["tpl"].items():
+                        boxes = boxdec(sites)
+                        if boxes is None:
+                            pin_ok = False
+                            continue
+                        cb = canon_boxes(boxes, L)
+                        if cb is None:
+                            pin_ok = False
+                            continue
+                        allboxes.extend(cb)
+                    canons.setdefault((L, famkey), set()).add(
+                        tuple(sorted(allboxes, key=repr)))
+            vals = np.round(E[A > CUT]).astype(np.int64)
+            u, c = np.unique(vals, return_counts=True)
+            censuses.setdefault(L, set()).add(
+                tuple(sorted(zip(u.tolist(), c.tolist()))))
+            argmaxes.setdefault(L, set()).add(int((A > ARG_CUT).sum()))
+            if pert_outliers is None:
+                d0 = next(i for (c0, x0), i in index.items()
+                          if support(c0) == 2 and x0 == (1, 1, 1))
+                Q2 = Q.copy()
+                Q2[d0, d0] += PERT
+                E2 = Q2[np.ix_(mm, mm)] - Q2
+                A2 = np.abs(E2)
+                po, pg = 0, float("inf")
+                for av2 in A2[A2 > BIG].tolist():
+                    _, dev2, _ = classify(float(av2))
+                    if dev2 > TOL_SURD:
+                        po += 1
+                        pg = min(pg, dev2)
+                pert_outliers, pert_gap = po, pg
+
+    expect_keys = tuple(sorted((s, name, pc) for s in (1, -1)
+                               for (name, pc) in UNSIGNED))
+    check("g02_family_key_set",
+          all(ks == {expect_keys} for ks in keysets.values()),
+          "12 signed families = 6 unsigned x 2 signs at every L and frame")
+    check("g03_no_outliers", outliers == 0,
+          "all {} large entries within {} of an exact magnitude".format(
+              n_entries, fmt(TOL_SURD)))
+    check("g04_frame_uniform_counts",
+          all(len(v) == 1 for v in counts.values()),
+          "per-family counts identical across the 18 mixed frames at every L")
+    bij = all(next(iter(counts[(L, (1, name, pc))])) ==
+              next(iter(counts[(L, (-1, name, pc))]))
+              for L in L_ALL for (name, pc) in UNSIGNED)
+    check("g05_sign_bijection", bij,
+          "plus and minus family counts equal at every L")
+    check("g06_canon_frame_invariant",
+          all(len(v) == 1 for v in canons.values()),
+          "canonical box-descriptor multiset frame-invariant at L={}".format(L_FIT))
+    canon_of = {}
+    lstable = True
+    for (name, pc) in UNSIGNED:
+        cs = [next(iter(canons[(L, (1, name, pc))])) for L in L_FIT]
+        lstable = lstable and (len(set(cs)) == 1)
+        canon_of[(name, pc)] = cs[0]
+    check("g07_canon_L_invariant", lstable,
+          "descriptors carry fixed margins and wall pins, independent of L")
+    shape_ok = pin_ok
+    for (name, pc), (nbox, npin) in BOX_SHAPE.items():
+        cb = canon_of[(name, pc)]
+        shape_ok = shape_ok and (len(cb) == nbox)
+        shape_ok = shape_ok and all(
+            sum(1 for d in box if d == "P") == npin for box in cb)
+    check("g08_box_shape", shape_ok,
+          "boxes per sign 8/8/12/16/20/4 with wall pins 0/0/0/1/0/2 per box")
+    check("g09_edge_family_diagonal", edge_diag_ok and edge_cls_ok,
+          "edge family is diagonal (i == j) on axis (NN) classes")
+    for name, _ in SURDS:
+        check("g10_dev_{}".format(name), dev_max[name] <= TOL_SURD,
+              "max magnitude deviation {}".format(fmt(dev_max[name])))
+    check("g14_wrong_surd_gap", gap_min >= GAP_FLOOR,
+          "distance to second-nearest magnitude at least {}".format(fmt(gap_min)))
+    check("g15_two_window", two_all_above and two_off_hi <= WINDOW,
+          "magnitude-2 offsets in ({}, {}] strictly above the census cut".format(
+              fmt(two_off_lo), fmt(two_off_hi)))
+    wl = (min(wall_vals["lo"]), max(wall_vals["lo"]))
+    wh = (min(wall_vals["hi"]), max(wall_vals["hi"]))
+    check("g16_wall_pair_values",
+          wl[1] - wl[0] <= WINDOW and wh[1] - wh[0] <= WINDOW,
+          "wall pair magnitudes {:.12f} and {:.12f} (spreads {} / {})".format(
+              wl[0], wh[0], fmt(wl[1] - wl[0]), fmt(wh[1] - wh[0])))
+    el = (min(edge_vals["lo"]), max(edge_vals["lo"]))
+    eh = (min(edge_vals["hi"]), max(edge_vals["hi"]))
+    check("g17_edge_pair_values",
+          el[1] - el[0] <= WINDOW and eh[1] - eh[0] <= WINDOW,
+          "edge pair magnitudes {:.12f} and {:.12f} (spreads {} / {})".format(
+              el[0], eh[0], fmt(el[1] - el[0]), fmt(eh[1] - eh[0])))
+    for (name, pc) in UNSIGNED:
+        meas = [next(iter(counts[(L, (1, name, pc))])) for L in L_ALL]
+        pred = [predict(canon_of[(name, pc)], L) for L in L_ALL]
+        poly = [POLY[(name, pc)][0](L) for L in L_ALL]
+        check("g18_law_{}_{}".format(name, pc),
+              meas == pred == poly,
+              "counts(L=3..7)={} = {}".format(meas, POLY[(name, pc)][1]))
+    poly_ok = all(predict(canon_of[k], L) == POLY[k][0](L)
+                  for k in canon_of for L in range(3, 11))
+    check("g19_poly_identity", poly_ok,
+          "descriptor prediction equals the stated polynomial for L=3..10")
+    for L in (3, 7):
+        n4, n3, n2 = ANCHOR[L]
+        want = tuple(sorted([(-4, n4), (-3, n3), (-2, n2),
+                             (2, n2), (3, n3), (4, n4)]))
+        check("g20_census_anchor_L{}".format(L),
+              censuses[L] == {want},
+              "rounded census above cut = {} (cycle-711 anchor)".format(want))
+    comp_ok = True
+    for L in (3, 7):
+        n4, n3, n2 = ANCHOR[L]
+        c_of = lambda k: next(iter(counts[(L, (1,) + k)]))
+        comp_ok = comp_ok and n4 == c_of(("four", "swap"))
+        comp_ok = comp_ok and n3 == (c_of(("two_rt3", "swap"))
+                                     + c_of(("two_rt2", "swap"))
+                                     + c_of(("two_rt2", "wall")))
+        comp_ok = comp_ok and n2 == (c_of(("two", "swap")) + c_of(("two", "edge")))
+    check("g22_bucket_composition", comp_ok,
+          "census buckets = family sums (rounded 3 mixes the two surds)")
+    argm_ok = all(argmaxes[L] == {ARGMAX_ANCHOR[L]}
+                  and ARGMAX_ANCHOR[L] == 16 * (L - 1) ** 3
+                  and ARGMAX_ANCHOR[L] == 2 * next(iter(counts[(L, (1, "four", "swap"))]))
+                  for L in (3, 7))
+    check("g23_argmax_law", argm_ok,
+          "argmax family per frame = 16(L-1)^3 = {} / {} (cycle-711 anchor)".format(
+              ARGMAX_ANCHOR[3], ARGMAX_ANCHOR[7]))
+    check("g24_perturbed_rejector", pert_outliers >= 1,
+          "{} entries leave the magnitude set (distance {}) under a {} "
+          "diagonal perturbation".format(pert_outliers, fmt(pert_gap), PERT))
+
+    NOTES["laws_per_sign"] = {"|".join(k): POLY[k][1] for k in POLY}
+    NOTES["counts_per_sign"] = {
+        "|".join(k): [int(next(iter(counts[(L, (1,) + k)]))) for L in L_ALL]
+        for k in POLY}
+    NOTES["census_anchor"] = {str(L): list(ANCHOR[L]) for L in ANCHOR}
+    NOTES["argmax_anchor"] = {str(L): ARGMAX_ANCHOR[L] for L in ARGMAX_ANCHOR}
+    NOTES["dev_max"] = {k: fmt(v) for k, v in dev_max.items()}
+    NOTES["wrong_surd_gap"] = fmt(gap_min)
+    NOTES["two_window"] = [fmt(two_off_lo), fmt(two_off_hi)]
+    NOTES["wall_pair"] = ["{:.12f}".format(wl[0]), "{:.12f}".format(wh[0])]
+    NOTES["edge_pair"] = ["{:.12f}".format(el[0]), "{:.12f}".format(eh[0])]
+    receipt = {"cycle": 712, "gates": GATES, "notes": NOTES}
+    out = ROOT / "outputs" / RECEIPT_NAME
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(receipt, sort_keys=True, indent=2) + "\n")
+    print("receipt: outputs/{}".format(RECEIPT_NAME))
+    print("TOTAL: PASS={} FAIL={}".format(N_PASS, N_FAIL))
+    return 0 if N_FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py
+++ b/scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py
@@ -62,11 +62,11 @@ DIRV = {c: np.asarray(c696.regge.DIRS15[c][:3], dtype=np.int64) for c in SPC}
 AUDIT_TIMEOUT_SEC = 300
 AUDIT_INPUT_PATHS = (
     "docs/PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md",
-    "docs/PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_LAW_AND_COVARIANCE_BOUNDARY_CYCLE710_NOTE_2026-08-02.md",
+    "docs/PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_AND_MIXED_FRAME_COMPARATOR_CYCLE710_NOTE_2026-08-02.md",
     "docs/PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02.md",
-    "scripts/physical_assembly_defect_cocycle_law_and_covariance_boundary_cycle710_2026_08_02.py",
+    "scripts/physical_assembly_defect_cocycle_and_mixed_frame_comparator_cycle710_2026_08_02.py",
     "scripts/physical_mixed_frame_comparator_exact_stencil_swap_law_cycle711_2026_08_02.py",
-    "outputs/physical_assembly_defect_cocycle_law_and_covariance_boundary_cycle710_2026_08_02_receipt_2026-08-02.json",
+    "outputs/physical_assembly_defect_cocycle_and_mixed_frame_comparator_cycle710_2026_08_02_receipt_2026-08-02.json",
     "outputs/physical_mixed_frame_comparator_exact_stencil_swap_law_cycle711_2026_08_02_receipt_2026-08-02.json",
     "scripts/physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py",
     "scripts/physical_dynamical_metric_source_law_bridge_tournament_cycle576_2026_07_22.py",

--- a/scripts/physical_mixed_frame_defect_census_family_law_cycle712_independent_check_2026_08_02.py
+++ b/scripts/physical_mixed_frame_defect_census_family_law_cycle712_independent_check_2026_08_02.py
@@ -28,11 +28,11 @@ SPEC.loader.exec_module(c696)
 AUDIT_TIMEOUT_SEC = 300
 AUDIT_INPUT_PATHS = (
     "docs/PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md",
-    "docs/PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_LAW_AND_COVARIANCE_BOUNDARY_CYCLE710_NOTE_2026-08-02.md",
+    "docs/PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_AND_MIXED_FRAME_COMPARATOR_CYCLE710_NOTE_2026-08-02.md",
     "docs/PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02.md",
-    "scripts/physical_assembly_defect_cocycle_law_and_covariance_boundary_cycle710_2026_08_02.py",
+    "scripts/physical_assembly_defect_cocycle_and_mixed_frame_comparator_cycle710_2026_08_02.py",
     "scripts/physical_mixed_frame_comparator_exact_stencil_swap_law_cycle711_2026_08_02.py",
-    "outputs/physical_assembly_defect_cocycle_law_and_covariance_boundary_cycle710_2026_08_02_receipt_2026-08-02.json",
+    "outputs/physical_assembly_defect_cocycle_and_mixed_frame_comparator_cycle710_2026_08_02_receipt_2026-08-02.json",
     "outputs/physical_mixed_frame_comparator_exact_stencil_swap_law_cycle711_2026_08_02_receipt_2026-08-02.json",
     "scripts/physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py",
     "scripts/physical_dynamical_metric_source_law_bridge_tournament_cycle576_2026_07_22.py",

--- a/scripts/physical_mixed_frame_defect_census_family_law_cycle712_independent_check_2026_08_02.py
+++ b/scripts/physical_mixed_frame_defect_census_family_law_cycle712_independent_check_2026_08_02.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Independent raw-Hessian check of the Cycle-712 finite family census.
+
+This checker does not import the Cycle-712 primary.  It reconstructs the
+bounding-box transport, classifies every large entry of the supplied Cycle-696
+static Hessian, derives the six count expressions from an explicit component
+descriptor census, and compares the primary receipt only after the independent
+calculation has finished.  It does not claim exact non-4 surd magnitudes.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(HERE))
+MODULE = HERE / "physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py"
+SPEC = importlib.util.spec_from_file_location("c696_independent_for_c712", MODULE)
+c696 = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(c696)
+
+AUDIT_TIMEOUT_SEC = 300
+AUDIT_INPUT_PATHS = (
+    "docs/PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md",
+    "docs/PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_LAW_AND_COVARIANCE_BOUNDARY_CYCLE710_NOTE_2026-08-02.md",
+    "docs/PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02.md",
+    "scripts/physical_assembly_defect_cocycle_law_and_covariance_boundary_cycle710_2026_08_02.py",
+    "scripts/physical_mixed_frame_comparator_exact_stencil_swap_law_cycle711_2026_08_02.py",
+    "outputs/physical_assembly_defect_cocycle_law_and_covariance_boundary_cycle710_2026_08_02_receipt_2026-08-02.json",
+    "outputs/physical_mixed_frame_comparator_exact_stencil_swap_law_cycle711_2026_08_02_receipt_2026-08-02.json",
+    "scripts/physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py",
+    "scripts/physical_dynamical_metric_source_law_bridge_tournament_cycle576_2026_07_22.py",
+    "scripts/physical_dynamical_metric_source_law_bridge_cycle576_regge_support_2026_07_22.py",
+    "scripts/physical_dynamical_metric_source_law_bridge_cycle576_plaquette_support_2026_07_22.py",
+    "scripts/frontier_cubic_coxeter_regge_second_variation_3plus1_2026_06_09.py",
+    "outputs/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_receipt_2026-08-02.json",
+)
+DECLARED_INPUT_PATHS = AUDIT_INPUT_PATHS
+
+FRAMES = tuple(np.asarray(frame, dtype=np.int64) for frame in c696.c576.FRAMES)
+SPATIAL_CLASSES = tuple(c696.SPATIAL_CLASSES)
+DIRECTIONS = {
+    cls: np.asarray(c696.regge.DIRS15[cls][:3], dtype=np.int64)
+    for cls in SPATIAL_CLASSES
+}
+SIZES = (3, 4, 5, 6, 7)
+CENTERS = np.asarray((2.0, 2.0 * math.sqrt(2.0),
+                      2.0 * math.sqrt(3.0), 4.0), dtype=np.float64)
+CENTER_NAMES = ("two", "two_rt2", "two_rt3", "four")
+PAIR_NAMES = ("swap", "wall", "edge")
+LARGE_CUT = 1.5
+CENSUS_CUT = 2.0
+TOP_CUT = 3.9
+CENTER_TOL = 2.0e-7
+PAIR_LOW = 0.5
+PAIR_HIGH = 10.0
+
+EXPECTED_KEYS = (
+    ("four", "swap"),
+    ("two_rt3", "swap"),
+    ("two_rt2", "swap"),
+    ("two_rt2", "wall"),
+    ("two", "swap"),
+    ("two", "edge"),
+)
+ANCHORS = {3: (64, 224, 136), 7: (1728, 4896, 4056)}
+TOP_ANCHORS = {3: 128, 7: 3456}
+RECEIPT = ROOT / "outputs" / (
+    "physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02_"
+    "receipt_2026-08-02.json"
+)
+
+PASS = 0
+FAIL = 0
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if bool(condition):
+        PASS += 1
+        print(f"PASS {label} {detail}".rstrip())
+    else:
+        FAIL += 1
+        print(f"FAIL {label} {detail}".rstrip())
+
+
+def constant_sign(frame: np.ndarray) -> bool:
+    entries = frame[frame != 0]
+    return bool(np.all(entries == 1) or np.all(entries == -1))
+
+
+def transport(L: int, index: dict, frame: np.ndarray) -> np.ndarray:
+    """Independent reconstruction of the bounding-box dof relabeling."""
+    site_map = c696.frame_site_map(L, frame)
+    direction_class = {
+        tuple(int(v) for v in DIRECTIONS[cls]): cls for cls in SPATIAL_CLASSES
+    }
+    result = np.empty(len(index), dtype=np.int64)
+    for (cls, site), source in index.items():
+        rotated = frame @ DIRECTIONS[cls]
+        target_class = direction_class[tuple(int(v) for v in np.abs(rotated))]
+        target_site = tuple(
+            int(v) for v in (
+                np.asarray(site_map[site], dtype=np.int64)
+                + np.minimum(rotated, 0)
+            )
+        )
+        result[source] = index[(target_class, target_site)]
+    return result
+
+
+def descriptor_count(key: tuple[str, str], L: int) -> int:
+    """Evaluate the independently transcribed component descriptor census.
+
+    Margin 1 means a growing axis of length L-1, margin 2 means length L-2,
+    and ``None`` denotes a pinned axis of length 1.
+    """
+    terms = {
+        ("four", "swap"): ((8, (1, 1, 1)),),
+        ("two_rt3", "swap"): ((8, (1, 1, 1)),),
+        ("two_rt2", "swap"): ((12, (1, 1, 1)),),
+        ("two_rt2", "wall"): ((16, (None, 1, 1)),),
+        ("two", "swap"): ((12, (1, 1, 1)), (8, (1, 1, 2))),
+        ("two", "edge"): ((4, (None, None, 1)),),
+    }
+    total = 0
+    for multiplicity, axes in terms[key]:
+        volume = 1
+        for margin in axes:
+            volume *= 1 if margin is None else L - margin
+        total += multiplicity * volume
+    return total
+
+
+def written_count(key: tuple[str, str], L: int) -> int:
+    m = L - 1
+    if key in (("four", "swap"), ("two_rt3", "swap")):
+        return 8 * m ** 3
+    if key == ("two_rt2", "swap"):
+        return 12 * m ** 3
+    if key == ("two_rt2", "wall"):
+        return 16 * m ** 2
+    if key == ("two", "swap"):
+        return 12 * m ** 3 + 8 * m ** 2 * (L - 2)
+    if key == ("two", "edge"):
+        return 4 * m
+    raise KeyError(key)
+
+
+def main() -> int:
+    mixed = tuple(i for i, frame in enumerate(FRAMES) if not constant_sign(frame))
+    sextet = tuple(i for i, frame in enumerate(FRAMES) if constant_sign(frame))
+    check("frame_partition", len(FRAMES) == 24 and len(sextet) == 6
+          and len(mixed) == 18, f"sextet={sextet}")
+
+    for key in EXPECTED_KEYS:
+        check(f"descriptor_identity_{key[0]}_{key[1]}",
+              all(descriptor_count(key, L) == written_count(key, L)
+                  for L in range(3, 11)),
+              "component factors equal written expression at L=3..10")
+
+    raw_total = 0
+    displaced_center_rejections = 0
+    wrong_pair_cut_mismatches = 0
+    all_counts: dict[tuple[int, int, str, str], int] = {}
+
+    for L in SIZES:
+        model = c696.assemble_static_hessian(L, wrap=False)
+        matrix, index = model["Q"], model["index"]
+        per_frame_counts = []
+        rounded_censuses = set()
+        top_counts = set()
+        for frame_index in mixed:
+            permutation = transport(L, index, FRAMES[frame_index])
+            transported = matrix[np.ix_(permutation, permutation)]
+            defect = transported - matrix
+            magnitude = np.abs(defect)
+            mask = magnitude > LARGE_CUT
+            values = defect[mask]
+            absolute = magnitude[mask]
+            raw_total += int(absolute.size)
+
+            distances = np.abs(absolute[:, None] - CENTERS[None, :])
+            nearest = np.argmin(distances, axis=1)
+            deviations = distances[np.arange(absolute.size), nearest]
+            check(f"center_tolerance_L{L}_frame{frame_index}",
+                  float(deviations.max()) <= CENTER_TOL,
+                  f"max={float(deviations.max()):.2e}")
+
+            smaller_side = np.minimum(np.abs(transported[mask]), np.abs(matrix[mask]))
+            pair_class = np.where(smaller_side < PAIR_LOW, 0,
+                                  np.where(smaller_side < PAIR_HIGH, 1, 2))
+            signs = np.where(values > 0, 1, -1)
+            observed = {}
+            for sign in (-1, 1):
+                for center_i, center_name in enumerate(CENTER_NAMES):
+                    for pair_i, pair_name in enumerate(PAIR_NAMES):
+                        count = int(np.count_nonzero(
+                            (signs == sign) & (nearest == center_i)
+                            & (pair_class == pair_i)
+                        ))
+                        if count:
+                            observed[(sign, center_name, pair_name)] = count
+                            all_counts[(L, sign, center_name, pair_name)] = count
+            wanted_keys = {
+                (sign, center_name, pair_name)
+                for sign in (-1, 1)
+                for center_name, pair_name in EXPECTED_KEYS
+            }
+            counts_ok = set(observed) == wanted_keys
+            for sign in (-1, 1):
+                for key in EXPECTED_KEYS:
+                    counts_ok = counts_ok and (
+                        observed.get((sign,) + key) == descriptor_count(key, L)
+                    )
+            per_frame_counts.append(observed)
+            check(f"raw_family_counts_L{L}_frame{frame_index}", counts_ok,
+                  "all twelve counts equal component expressions")
+
+            rounded, multiplicity = np.unique(
+                np.rint(defect[magnitude > CENSUS_CUT]).astype(np.int64),
+                return_counts=True,
+            )
+            rounded_censuses.add(tuple(zip(rounded.tolist(), multiplicity.tolist())))
+            top_counts.add(int(np.count_nonzero(magnitude > TOP_CUT)))
+
+            displaced = CENTERS.copy()
+            displaced[2] += 0.25
+            bad_distances = np.abs(absolute[:, None] - displaced[None, :])
+            displaced_center_rejections += int(np.count_nonzero(
+                bad_distances.min(axis=1) > CENTER_TOL
+            ))
+
+            wrong_class = np.where(smaller_side < PAIR_LOW, 0,
+                                   np.where(smaller_side < 5.0, 1, 2))
+            wrong_pair_cut_mismatches += int(np.count_nonzero(wrong_class != pair_class))
+
+        check(f"frame_uniformity_L{L}",
+              all(row == per_frame_counts[0] for row in per_frame_counts[1:]),
+              "all 18 independently rebuilt frame censuses agree")
+        if L in ANCHORS:
+            n4, n3, n2 = ANCHORS[L]
+            wanted = tuple(sorted(((-4, n4), (-3, n3), (-2, n2),
+                                   (2, n2), (3, n3), (4, n4))))
+            check(f"rounded_anchor_L{L}", rounded_censuses == {wanted},
+                  f"anchor={wanted}")
+            check(f"top_family_L{L}", top_counts == {TOP_ANCHORS[L]},
+                  f"count={TOP_ANCHORS[L]}")
+
+    check("complete_scan_total", raw_total == 789120, f"entries={raw_total}")
+    check("displaced_center_rejector", displaced_center_rejections > 0,
+          f"rejected_entries={displaced_center_rejections}")
+    check("wrong_pair_cut_rejector", wrong_pair_cut_mismatches > 0,
+          f"reclassified_entries={wrong_pair_cut_mismatches}")
+    check("wrong_coefficient_rejector",
+          any(9 * (L - 1) ** 3 != descriptor_count(("four", "swap"), L)
+              for L in SIZES),
+          "coefficient 9 cannot replace component multiplicity 8")
+
+    receipt = json.loads(RECEIPT.read_text())
+    check("primary_receipt_all_gates_pass",
+          bool(receipt["gates"]) and all(gate["pass"] for gate in receipt["gates"].values()))
+    receipt_counts = receipt["notes"]["counts_per_sign"]
+    expected_receipt = {
+        "|".join(key): [descriptor_count(key, L) for L in SIZES]
+        for key in EXPECTED_KEYS
+    }
+    check("primary_receipt_count_agreement", receipt_counts == expected_receipt,
+          "receipt counts equal independent component arithmetic")
+
+    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Cycle 711 measured the mixed-frame assembly-defect census — per-frame counts 64/224/136 at L = 3 and 1728/4896/4056 at L = 7 for the rounded magnitudes 4/3/2, argmax family 128 and 3456 — and recorded them as measured, not derived. This cycle derives them.

Over the complete scan (789120 large entries, 18 mixed frames, box sizes L = 3..7) every entry falls into exactly one of twelve signed families, keyed by exact magnitude (2, 2·√2, 2·√3, 4, matched within 2.0e-07, second-nearest at least 5.4e-01 away) and by entry-pair class (swap, wall, edge). For each family template the base sites form a product box whose axes are either wall pins or fixed-margin growing intervals; the canonical descriptor multiset is invariant across frames and sizes. Summing the descriptors gives six counting polynomials per sign, and the rounded buckets follow: ±4 = 8(L−1)³, ±3 = 20(L−1)³ + 16(L−1)², ±2 = 12(L−1)³ + 8(L−1)²(L−2) + 4(L−1), argmax = 16(L−1)³. Descriptors are extracted at L ∈ {4, 5, 6} only; L = 3 and L = 7 are held out and reproduce the cycle-711 anchors exactly.

The magnitude-2 family sits at finite-difference offsets in (1.7e-09, 5.7e-08] strictly above 2, so the cycle-711 census cut is deterministic rather than knife-edge. Under a 1.7 diagonal perturbation of the assembled operator, entries leave the exact magnitude set at distance 3.0e-01.

**Honest boundary.** The wall pair (5.857096565429 / 8.685523719688) and edge pair (22.150846413069 / 24.150846469784) magnitudes are measured, not derived; per-family exact stencil evaluation is the named next target. The counting laws are finite statements for L = 3..7 under the supplied compiler constants; no continuum statement is made.

## Changes

- `docs/PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md` — bounded-theorem note: the twelve-family decomposition, the box-descriptor mechanism, the six counting laws with their corollaries, honest boundary, next paths.
- `scripts/physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02.py` — class-A finite runner, `TOTAL: PASS=29 FAIL=0`.
- `logs/runner-cache/…` + `outputs/…_receipt_…json` — fresh cache and receipt.
- `docs/audit/data/citation_graph_manifest.json` — authority-link acknowledgment for the new note (no ledger row created).

## Test plan

- [x] Runner re-run locally: `TOTAL: PASS=29 FAIL=0`
- [x] Both cycle-711 census anchors reproduced from the derived laws (L = 3 and L = 7)
- [x] Wrong-surd gap and perturbed-operator rejector discriminate
- [x] Every note float appears in the runner's own stdout
- [x] Authority-link guard passes with the staged manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)
