### PR TITLE
feat(gravity): finite assembly-defect weight classification and resolved-entry census (cycle 713)

### DIFF
--- a/docs/PHYSICAL_DEFECT_WEIGHT_LAW_AND_COMPLETE_CENSUS_CYCLE713_NOTE_2026-08-02.md
+++ b/docs/PHYSICAL_DEFECT_WEIGHT_LAW_AND_COMPLETE_CENSUS_CYCLE713_NOTE_2026-08-02.md
@@ -1,0 +1,203 @@
+# Physical Assembly-Defect Weight Law and the Complete Census — Cycle 713
+
+**Claim type: bounded_theorem.** Finite, recomputed statements about the landed
+Cycle-696 open-coframe endpoint compiler chain at box sizes L ∈ {3, 4, 5, 6, 7,
+8, 9}. The magnitude law, its support-signature resolution, the closed-form
+census polynomials, and the codimension grading are exact finite statements
+verified by complete scan over all 18 mixed frames; the identification of the
+compiler chain with the static spatial sector is inherited, not re-derived here.
+
+## What Cycles 711 and 712 left open
+
+The Cycle-711 exact stencil swap law (stem
+`PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02`,
+in flight) derived the mixed-frame comparator −4 exactly and recorded its
+per-sign census as measured, not derived. The Cycle-712 family law (stem
+`PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02`, in
+flight) derived those counts from a positional box-descriptor mechanism, but
+took the four magnitudes {2, 2·√2, 2·√3, 4} themselves as a measured menu, and
+counted only the entries above the supplied cut 2.0e+00 — the sub-cut
+population was never classified at all.
+
+This cycle derives the menu, classifies every remaining entry, and gives the
+census in closed form. The magnitude of a defect entry is a function of the two
+edge classes it connects, and of nothing else: it factorizes over the two
+coframe legs. All statements below are computational identities of the landed
+compiler chain, recomputed in this cycle's runner.
+
+## Setup
+
+The compiler chain is the landed Cycle-696 static-sector assembler: path-simplex
+templates on the open box, spatial edge classes, and the assembled static
+Hessian Q, with tick multiplier LT = 2 and central finite-difference step
+1.0e-04 as supplied compiler constants. Each coframe variable i carries a
+spatial direction vector v_i fixed by its edge class, with **support**
+s_i = |v_i|² ∈ {1, 2, 3}: support 1 for the three axis classes, 2 for the six
+face-diagonal classes, 3 for the body-diagonal class. Frames are the 24 proper
+cubic rotations of the landed Cycle-576 table; the transport permutation Π_g is
+the bounding-box dof relabeling of Cycle 710, and the assembly defect is
+E_g = Π_g^T Q Π_g − Q. The six constant-sign frames (the sextet) have defect
+ceiling below 1.0e-09 and are exact zeros; the census lives on the 18 mixed
+frames.
+
+## Theorem I — the weight law
+
+For every mixed frame and every box size in the scan, **every** nonzero entry of
+the assembly defect satisfies
+
+> |E_ij| = w · LT · |v_i| · |v_j| = w · LT · √(s_i s_j),  w ∈ {1, 1/2},
+
+matched within 2.0e-07, with worst deviation 6.1e-08 over all 2418192 nonzero
+entries scanned, and **zero** entries left unclassified. Two facts sharpen it:
+
+- **Half weight is axis-locked.** The realized signature set of the w = 1/2
+  population is exactly {(1, 1)} — half weight occurs on axis-by-axis pairs and
+  nowhere else. Its magnitude is therefore always 1.0e+00.
+- **Three signatures are never realized.** The w = 1 population realizes exactly
+  the signatures (1,1), (1,2), (2,1), (1,3), (3,1), (2,2); the signatures
+  (2,3), (3,2), (3,3) carry no defect entry at any frame or size.
+
+Consequently the magnitude is determined by the support signature alone, and the
+Cycle-712 menu is the list of values LT·√(s_i s_j) that the realized signatures
+produce: (1,1) → 2, (1,2) and (2,1) → 2·√2, (1,3) and (3,1) → 2·√3, (2,2) → 4,
+plus the half-weight value 1 that the Cycle-712 cut had removed. The cut 2.0e+00
+is exactly the full/half separator: the largest half-weight magnitude is
+1.0e+00 and the smallest full-weight magnitude is 2.0e+00, so the entries above
+the Cycle-712 cut coincide with the full-weight entries at every frame and size.
+
+The law is not a fit to a plausible-looking form. The additive alternative
+LT·√(s_i + s_j) — which agrees at signature (2,2), where both read 4 — misses by
+at least 0.54 wherever the two differ. Swapping the axis and body-diagonal
+support assignments leaves 1656 entries outside the law at a single frame and
+size. A site-graded diagonal ramp on Q, which the relabeling does not commute
+with, leaves 272 entries outside it. A uniform diagonal shift, by contrast,
+leaves the defect exactly unchanged — the relabeling is a permutation, so a
+multiple of the identity cancels between the two terms of E_g.
+
+## Theorem II — the complete census in closed form
+
+Per mixed frame, and identically for all 18 of them, the counts are exact
+polynomials in the box size:
+
+| population | per sign | L = 3 … 9 |
+|---|---|---|
+| full weight | 48(L−1)³ + 8(L−1)² + 4(L−1) | 424, 1380, 3216, 6220, 10680, 16884, 25120 |
+| half weight | 16(L−1)² | 64, 144, 256, 400, 576, 784, 1024 |
+| all nonzeros (both signs) | 96(L−1)³ + 48(L−1)² + 8(L−1) | 976, 3048, 6944, 13240, 22512, 35336, 52288 |
+
+Plus and minus counts are equal for both weights at every size and frame. The
+magnitude-resolved census follows from Theorem I, one polynomial per magnitude,
+per sign:
+
+| magnitude | signature | per sign |
+|---|---|---|
+| 4 | (2,2) | 8(L−1)³ |
+| 2·√3 | (1,3), (3,1) | 8(L−1)³ |
+| 2·√2 | (1,2), (2,1) | 12(L−1)³ + 16(L−1)² |
+| 2 | (1,1), w = 1 | 20(L−1)³ − 8(L−1)² + 4(L−1) |
+| 1 | (1,1), w = 1/2 | 16(L−1)² |
+
+The four full-weight rows partition the full-weight population, and their
+cubic coefficients 8 + 8 + 12 + 20 = 48, quadratic coefficients 16 − 8 = 8, and
+linear coefficient 4 reassemble the full-weight polynomial exactly.
+
+The laws were fitted on L ∈ {3, 4, 5, 6} and then tested against L = 7, 8 and 9.
+A cubic interpolated through the four fitting sizes predicts the full-weight
+count and the nonzero count at all three held-out sizes with no residual;
+L = 8 and L = 9 were measured by no earlier cycle. Independently, the
+polynomials reproduce the landed Cycle-711 per-sign census totals 424 at L = 3
+and 10680 at L = 7, and — after the two magnitudes 2·√2 and 2·√3 are merged, as
+the Cycle-711 rounded buckets merge them — its bucket composition as well.
+
+## Theorem III — codimension grading and the carrier
+
+The three polynomial degrees are the three codimensions of the box. The leading
+term is a bulk density: **96 nonzero defect entries per unit cell per mixed
+frame**, 48 per sign, independent of L. The quadratic term 48(L−1)² is a surface
+population and the linear term 8(L−1) an edge population; in the Cycle-712
+box-descriptor language the degree is 3 minus the number of pinned axes, so the
+wall family sits at degree 2 and the edge family at degree 1.
+
+The carrier is small and frame-independent: exactly **30 ordered edge-class
+pairs** carry full-weight entries, at every frame and every size, partitioned by
+support signature as 8 pairs of type (1,1), 7 each of types (1,2) and (2,1), 2
+each of types (1,3) and (3,1), and 4 of type (2,2). Seven spatial classes admit
+49 ordered pairs; 19 of them never carry a defect entry.
+
+The bulk-extensivity statement has a direct consequence for the transport
+question. A re-anchoring of the transport at the box boundary can move at most
+the surface and edge populations, 48(L−1)² + 8(L−1) entries per frame. The
+bulk term 96(L−1)³ is untouched by any boundary convention, so the assembly
+defect is not a boundary artifact of the open box at any size.
+
+## Boundary — what this cycle does not establish
+
+- **The weight bit is measured, not derived.** Theorem I says that w ∈ {1, 1/2}
+  and that w = 1/2 occurs exactly on axis-by-axis pairs. It does not derive
+  *why* the axis-by-axis population splits into a full and a half branch while
+  every other signature carries only the full branch.
+- **The three absent signatures are a fact, not yet a mechanism.** That (2,3),
+  (3,2) and (3,3) never appear is a complete-scan statement over the sizes and
+  frames listed; the incidence reason is not given here.
+- **Signs are not classified.** The census is sign-balanced, and the magnitudes
+  are fully determined, but which entry carries which sign is left to the
+  Cycle-711 swap law and the Cycle-712 descriptor.
+- **Finite scan, not induction.** The polynomials are verified at seven sizes,
+  three of them held out from the fit. That is strong evidence and a clean
+  extrapolation, not a proof for all L.
+- **This is the static spatial sector.** No dynamical or interacting statement
+  is made, and no claim about the wrapped stencil, which the Cycle-696 header
+  places outside the executed path.
+
+## The next paths opened
+
+- **Derive the weight bit.** The half branch is exactly the axis-by-axis
+  signature and exactly the 16(L−1)² surface population — the same quadratic
+  that carries the Cycle-712 wall family. Testing whether the half branch *is*
+  the wall family, entry for entry, is a sharp finite question and would turn
+  the weight bit into a positional statement.
+- **Derive the three absent signatures.** The face-diagonal-by-body-diagonal and
+  body-diagonal-by-body-diagonal pairs would carry magnitudes 2·√6 and 6. Their
+  absence is an incidence cancellation of the same kind the Cycle-711 stencil
+  computation resolved for the comparator, and is the natural next target for
+  that machinery.
+- **Propagate the bulk density to the response floor.** The Cycle-709
+  minus-branch floor (stem
+  `PHYSICAL_MINUS_BRANCH_RESPONSE_FLOOR_ASSEMBLY_DEFECT_LAW_CYCLE709_NOTE_2026-08-02`,
+  in flight) consumes the assembly defect through a solve. A defect with an
+  exact bulk density and a factorized magnitude law is a much stronger input to
+  a floor-scaling law than a measured count was.
+- **Test the factorization against the source-side census.** The magnitude
+  factorizes over the two coframe legs, so it carries no direction-pair
+  correlation beyond the product of the leg lengths. Whether the same
+  factorization holds for the source-side edit sets is a direct question for the
+  Cycle-708 signed classification.
+
+## Relation to the interacting cycle
+
+This cycle stays inside the static spatial sector of the landed 3+1 module. The
+frame sextet that carries the exact zeros of the weight law is the same
+constant-sign sextet whose source-stabilizer role is analyzed in
+[PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01](PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01.md);
+the in-flight Cycle-708 classification (stem
+`PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02`)
+maps the same boundary at the signed level, and the in-flight Cycle-710
+covariance-boundary census (stem
+`PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_LAW_AND_COVARIANCE_BOUNDARY_CYCLE710_NOTE_2026-08-02`)
+supplied the defect object this cycle now classifies completely.
+
+## Runner
+
+`scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py`
+— class-A finite check, stdlib + numpy, self-contained against the Cycle-696
+compiler chain. Gate groups: sextet exact zeros and relabeling bijectivity;
+complete magnitude classification with zero unclassified entries and the
+weight-law deviation ceiling; half-weight signature locking, realized full
+signatures, and absent signatures; the additive-law rejector, the full/half
+separator, and the coincidence of the Cycle-712 cut with the weight split; sign
+balance and frame uniformity; the three census polynomials and the four
+magnitude polynomials at L = 3..9; held-out cubic extrapolation to L = 7, 8, 9;
+the Cycle-711 census anchors; carrier size and carrier signature partition; and
+three operator-level rejectors — support shuffle, uniform-shift invariance, and
+a site-graded ramp. Prints TOTAL: PASS=28 FAIL=0 with a JSON receipt in
+`outputs/`.

--- a/docs/PHYSICAL_DEFECT_WEIGHT_LAW_AND_COMPLETE_CENSUS_CYCLE713_NOTE_2026-08-02.md
+++ b/docs/PHYSICAL_DEFECT_WEIGHT_LAW_AND_COMPLETE_CENSUS_CYCLE713_NOTE_2026-08-02.md
@@ -1,6 +1,15 @@
 # Physical Assembly-Defect Weight Law and the Complete Census — Cycle 713
 
-**Claim type: bounded_theorem.** Finite, recomputed statements about the landed
+Date: 2026-08-02
+
+Claim type: bounded_theorem
+
+Status: proposed_retained
+
+Authority: none. Audit status is set only by the independent audit lane; this
+note changes no axiom, approved primitive, premise registry, or policy surface.
+
+Finite, recomputed statements about the landed
 Cycle-696 open-coframe endpoint compiler chain at box sizes L ∈ {3, 4, 5, 6, 7,
 8, 9}. The magnitude law, its support-signature resolution, the finite census
 values, and their polynomial agreement are bounded computational statements
@@ -43,9 +52,10 @@ same finite scan to `L = 8, 9` and classifies the sub-cut population.
 
 This cycle derives the finite menu, classifies every remaining entry, and
 records the complete scanned census. Within the scanned compiler surface, the
-magnitude of a defect entry is a function of the two edge classes it connects:
-it factorizes over the two coframe legs. All statements below are recomputed
-from the landed compiler chain in this cycle's runner.
+full-weight magnitude factorizes over the two coframe-leg lengths; a separate
+measured bit selects a half-weight subpopulation within the axis-axis
+signature. All statements below are recomputed from the landed compiler chain
+in this cycle's runner.
 
 ## Setup
 
@@ -62,15 +72,31 @@ E_g = Π_g^T Q Π_g − Q. The six constant-sign frames (the sextet) have measur
 defect ceiling below 1.0e-09 at the probed `L = 3`; this is a numerical gate,
 not an exact-zero theorem. The census lives on the 18 mixed frames.
 
+### Supplied and measured inputs
+
+- The open-box Cycle-696 compiler, its seven spatial edge classes, `LT = 2`,
+  finite-difference step `1e-4`, and proper-frame table are supplied compiler
+  structure. This note does not derive their physical interpretation.
+- The strict comparison cut `2.0` and the two finite per-sign anchor counts
+  `424` (`L = 3`) and `10680` (`L = 7`) are imported from Cycle 711 only as
+  cross-check targets. The runner recomputes the entries that meet them.
+- The unpinned/one-axis-pinned/two-axis-pinned interpretation is imported from
+  Cycle 712. The complete resolved-entry values at `L = 3..9`, including the
+  new `L = 8, 9` data, are measured by this runner.
+- No fitted, observational, or literature constant enters. The displayed
+  polynomials are interpolation/finite-agreement descriptions, not supplied
+  physics inputs.
+
 ## Theorem I — the weight law
 
-For every mixed frame and every box size in the scan, **every** nonzero entry of
-the assembly defect satisfies
+For every mixed frame and every box size in the scan, every **resolved** entry
+of the assembly defect, defined here by `|E_ij| > 1e-9`, satisfies
 
 > |E_ij| = w · LT · |v_i| · |v_j| = w · LT · √(s_i s_j),  w ∈ {1, 1/2},
 
-matched within 2.0e-07, with worst deviation 6.1e-08 over all 2418192 nonzero
-entries scanned, and **zero** entries left unclassified. Two facts sharpen it:
+matched within 2.0e-07, with worst deviation 6.1e-08 over all 2,418,192 resolved
+entries scanned, and **zero resolved entries** left unclassified. Entries at or
+below the numerical floor are outside the classification. Two facts sharpen it:
 
 - **Half weight is axis-locked.** The realized signature set of the w = 1/2
   population is exactly {(1, 1)} — half weight occurs on axis-by-axis pairs and
@@ -79,10 +105,12 @@ entries scanned, and **zero** entries left unclassified. Two facts sharpen it:
   the signatures (1,1), (1,2), (2,1), (1,3), (3,1), (2,2); the signatures
   (2,3), (3,2), (3,3) carry no defect entry at any scanned frame or size.
 
-Consequently the magnitude is determined by the support signature alone, and the
-Cycle-712 menu is the list of values LT·√(s_i s_j) that the realized signatures
-produce: (1,1) → 2, (1,2) and (2,1) → 2·√2, (1,3) and (3,1) → 2·√3, (2,2) → 4,
-plus the half-weight value 1 that the Cycle-712 cut had removed. The cut 2.0e+00
+Consequently the support signature determines the full-weight magnitude, while
+the extra measured weight bit distinguishes magnitudes 1 and 2 inside the
+axis-axis signature. The Cycle-712 menu is the list of values
+LT·√(s_i s_j) that the realized full-weight signatures produce: (1,1) → 2,
+(1,2) and (2,1) → 2·√2, (1,3) and (3,1) → 2·√3, (2,2) → 4, plus the half-weight
+value 1 that the Cycle-712 cut had removed. The cut 2.0e+00
 is exactly the full/half separator: the largest half-weight magnitude is
 1.0e+00 and the smallest full-weight magnitude is 2.0e+00, so the entries above
 the Cycle-712 cut coincide with the full-weight entries at every frame and size.
@@ -105,7 +133,7 @@ following integer polynomials at every scanned size `L = 3..9`:
 |---|---|---|
 | full weight | 48(L−1)³ + 8(L−1)² + 4(L−1) | 424, 1380, 3216, 6220, 10680, 16884, 25120 |
 | half weight | 16(L−1)² | 64, 144, 256, 400, 576, 784, 1024 |
-| all nonzeros (both signs) | 96(L−1)³ + 48(L−1)² + 8(L−1) | 976, 3048, 6944, 13240, 22512, 35336, 52288 |
+| all resolved entries (both signs) | 96(L−1)³ + 48(L−1)² + 8(L−1) | 976, 3048, 6944, 13240, 22512, 35336, 52288 |
 
 Plus and minus counts are equal for both weights at every scanned size and
 frame. The magnitude-resolved finite census agrees with one integer polynomial
@@ -125,7 +153,7 @@ linear coefficient 4 reassemble the full-weight polynomial exactly.
 
 The laws were fitted on L ∈ {3, 4, 5, 6} and then tested against L = 7, 8 and 9.
 A cubic interpolated through the four fitting sizes predicts the full-weight
-count and the nonzero count at all three held-out sizes with no residual;
+count and the resolved-entry count at all three held-out sizes with no residual;
 L = 8 and L = 9 were measured by no earlier cycle. Independently, the
 polynomials reproduce the landed Cycle-711 per-sign census totals 424 at L = 3
 and 10680 at L = 7, and — after the two magnitudes 2·√2 and 2·√3 are merged, as
@@ -136,14 +164,16 @@ the Cycle-711 rounded buckets merge them — its bucket composition as well.
 The finite fits have cubic, quadratic, and linear terms. On the scanned boxes,
 their Cycle-712 descriptor interpretation is respectively unpinned,
 one-axis-pinned, and two-axis-pinned populations. The leading coefficient is
-96 nonzero defect entries per unit-cell factor `(L-1)^3` per mixed frame, 48
+96 resolved defect entries per unit-cell factor `(L-1)^3` per mixed frame, 48
 per sign; the fitted subleading terms are `48(L-1)^2` and `8(L-1)`.
 
-The carrier is small and frame-independent: exactly **30 ordered edge-class
-pairs** carry full-weight entries at every scanned frame and size. They are
-partitioned by support signature as 8 pairs of type (1,1), 7 each of types
-(1,2) and (2,1), 2 each of types (1,3) and (3,1), and 4 of type (2,2). Seven
-spatial classes admit 49 ordered pairs; 19 of them never carry a defect entry.
+The carrier size and support-signature partition are frame-independent: exactly
+**30 ordered edge-class pairs** carry full-weight entries at every scanned frame
+and size. They are partitioned as 8 pairs of type (1,1), 7 each of types (1,2)
+and (2,1), 2 each of types (1,3) and (3,1), and 4 of type (2,2). The identities
+of the pairs form three frame-dependent carrier sets. Seven spatial classes
+admit 49 ordered pairs, so 19 pairs are absent at each frame; they are not a
+single universal set of 19.
 
 Scope limit: only the supplied open-box relabeling is executed. Alternative
 boundary re-anchorings and arbitrary box sizes remain outside this result.
@@ -151,7 +181,7 @@ boundary re-anchorings and arbitrary box sizes remain outside this result.
 ## Exact target and proof obligations
 
 **Exact target.** For the imported Cycle-696 open-box compiler at each
-`L in {3,...,9}`, classify every numerically nonzero entry of `E_g` at all 18
+`L in {3,...,9}`, classify every resolved entry of `E_g` at all 18
 mixed frames by the two-leg weight menu; report the complete finite counts,
 their agreement with the displayed integer polynomials, and the finite carrier
 census.
@@ -176,16 +206,16 @@ finite `L = 3..9` theorem does not require that lemma; a universal polynomial
 or boundary-convention theorem would.
 
 Degenerate and boundary cases: the smallest scanned box is `L = 3`; all 18
-mixed frames and every nonzero matrix entry above the declared numerical floor
+mixed frames and every matrix entry above the declared numerical floor
 are included. The six constant-sign frames are checked separately only for a
 numerical ceiling at `L = 3` and are not part of the weight census.
 
 ## Scope boundary
 
 - **The weight bit is measured, not derived.** Theorem I says that w ∈ {1, 1/2}
-  and that w = 1/2 occurs exactly on axis-by-axis pairs. It does not derive
-  *why* the axis-by-axis population splits into a full and a half branch while
-  every other signature carries only the full branch.
+  and that w = 1/2 occurs only on axis-by-axis pairs. It does not derive *which*
+  axis-axis entries take half weight or why that population splits while every
+  other realized signature carries only the full branch.
 - **The three absent signatures are a fact, not yet a mechanism.** That (2,3),
   (3,2) and (3,3) never appear is a complete-scan statement over the sizes and
   frames listed; the incidence reason is not given here.
@@ -215,7 +245,8 @@ numerical ceiling at `L = 3` and are not part of the weight census.
   computation resolved for the comparator, and is the natural next target for
   that machinery.
 - **Propagate the fitted leading density to the response floor.** The
-  [Cycle-709 minus-branch response-floor note](PHYSICAL_MINUS_BRANCH_RESPONSE_FLOOR_ASSEMBLY_DEFECT_LAW_CYCLE709_NOTE_2026-08-02.md)
+  Cycle-709 minus-branch response-floor note
+  `PHYSICAL_MINUS_BRANCH_RESPONSE_FLOOR_ASSEMBLY_DEFECT_LAW_CYCLE709_NOTE_2026-08-02`
   consumes the assembly defect through a solve. A finite defect census with a
   factorized magnitude law is a stronger input to a future floor-scaling law
   than an isolated measured count.
@@ -230,7 +261,7 @@ numerical ceiling at `L = 3` and are not part of the weight census.
 This cycle stays inside the static spatial sector of the landed 3+1 module. The
 frame sextet that carries the numerical near-zero ceiling is the same
 constant-sign sextet whose source-stabilizer role is analyzed in
-[PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01](PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01.md);
+`PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01`;
 the landed Cycle-708 classification is complementary source-side context. The
 [Cycle-710 finite assembly-defect cocycle and mixed-frame comparator](PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_AND_MIXED_FRAME_COMPARATOR_CYCLE710_NOTE_2026-08-02.md)
 supplied the finite defect object this cycle classifies. Cycle 708 is not used
@@ -253,3 +284,31 @@ the Cycle-711 census anchors; carrier size and carrier signature partition; and
 three operator-level rejectors — support shuffle, uniform-shift invariance, and
 a site-graded ramp. Prints TOTAL: PASS=28 FAIL=0 with a JSON receipt in
 `outputs/`.
+
+## Load-bearing dependencies
+
+- [Cycle 710](PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_AND_MIXED_FRAME_COMPARATOR_CYCLE710_NOTE_2026-08-02.md)
+  supplies the bounded finite assembly-defect object and mixed-frame comparator
+  interpretation used here.
+- [Cycle 711](PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02.md)
+  supplies the finite strict-cut anchor census and exact `0 <-> -4` local swap
+  context used as cross-checks.
+- [Cycle 712](PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md)
+  supplies the finite component-box descriptor interpretation used for the
+  polynomial grading.
+
+Provenance-only mentions of Cycles 707, 708, and 709 above deliberately remain
+non-linking because no result here depends on their claims.
+
+## Review record
+
+Review removed the submitted universal statement that a boundary re-anchoring
+can change only the fitted quadratic/linear populations and therefore cannot
+remove the cubic population. The runner constructs no alternative transport,
+so that negative conclusion was unsupported. The durable result is the finite
+weight classification, finite per-frame carrier census, and polynomial agreement on the
+declared `L = 3..9` surface. Review also replaced an exact-zero claim for the
+constant-sign sextet with the numerical ceiling actually gated at `L = 3`,
+made the `1e-9` resolved-entry floor explicit, and bound the runner cache to the
+complete transitive compiler-source closure. Independent audit remains required
+before any effective retained grade.

--- a/docs/PHYSICAL_DEFECT_WEIGHT_LAW_AND_COMPLETE_CENSUS_CYCLE713_NOTE_2026-08-02.md
+++ b/docs/PHYSICAL_DEFECT_WEIGHT_LAW_AND_COMPLETE_CENSUS_CYCLE713_NOTE_2026-08-02.md
@@ -1,4 +1,4 @@
-# Physical Assembly-Defect Weight Law and the Complete Census — Cycle 713
+# Physical Assembly-Defect Weight Classification and Complete Resolved-Entry Census — Cycle 713
 
 Date: 2026-08-02
 
@@ -8,6 +8,13 @@ Status: proposed_retained
 
 Authority: none. Audit status is set only by the independent audit lane; this
 note changes no axiom, approved primitive, premise registry, or policy surface.
+
+Primary runner:
+`scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py`;
+cached stdout:
+`logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt`;
+paired receipt:
+`outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json`.
 
 Finite, recomputed statements about the landed
 Cycle-696 open-coframe endpoint compiler chain at box sizes L ∈ {3, 4, 5, 6, 7,
@@ -50,8 +57,8 @@ took the four magnitudes {2, 2·√2, 2·√3, 4} themselves as a measured menu 
 counted only the entries above the supplied cut 2.0e+00. This note extends the
 same finite scan to `L = 8, 9` and classifies the sub-cut population.
 
-This cycle derives the finite menu, classifies every remaining entry, and
-records the complete scanned census. Within the scanned compiler surface, the
+This cycle derives the finite menu, classifies every remaining resolved entry,
+and records the complete scanned census. Within the scanned compiler surface, the
 full-weight magnitude factorizes over the two coframe-leg lengths; a separate
 measured bit selects a half-weight subpopulation within the axis-axis
 signature. All statements below are recomputed from the landed compiler chain
@@ -64,8 +71,8 @@ templates on the open box, spatial edge classes, and the assembled static
 Hessian Q, with tick multiplier LT = 2 and central finite-difference step
 1.0e-04 as supplied compiler constants. Each coframe variable i carries a
 spatial direction vector v_i fixed by its edge class, with **support**
-s_i = |v_i|² ∈ {1, 2, 3}: support 1 for the three axis classes, 2 for the six
-face-diagonal classes, 3 for the body-diagonal class. Frames are the 24 proper
+s_i = |v_i|² ∈ {1, 2, 3}: support 1 for the three axis classes, 2 for the three
+admitted face-diagonal classes, 3 for the body-diagonal class. Frames are the 24 proper
 cubic rotations of the landed Cycle-576 table; the transport permutation Π_g is
 the bounding-box dof relabeling of Cycle 710, and the assembly defect is
 E_g = Π_g^T Q Π_g − Q. The six constant-sign frames (the sextet) have measured
@@ -76,7 +83,7 @@ not an exact-zero theorem. The census lives on the 18 mixed frames.
 
 - The open-box Cycle-696 compiler, its seven spatial edge classes, `LT = 2`,
   finite-difference step `1e-4`, and proper-frame table are supplied compiler
-  structure. This note does not derive their physical interpretation.
+  structure. Their physical interpretation remains inherited.
 - The strict comparison cut `2.0` and the two finite per-sign anchor counts
   `424` (`L = 3`) and `10680` (`L = 7`) are imported from Cycle 711 only as
   cross-check targets. The runner recomputes the entries that meet them.
@@ -101,9 +108,8 @@ below the numerical floor are outside the classification. Two facts sharpen it:
 - **Half weight is axis-locked.** The realized signature set of the w = 1/2
   population is exactly {(1, 1)} — half weight occurs on axis-by-axis pairs and
   nowhere else. Its magnitude is therefore always 1.0e+00.
-- **Three signatures are never realized.** The w = 1 population realizes exactly
-  the signatures (1,1), (1,2), (2,1), (1,3), (3,1), (2,2); the signatures
-  (2,3), (3,2), (3,3) carry no defect entry at any scanned frame or size.
+- **Full-weight signature support.** The realized signature set is exactly
+  {(1,1), (1,2), (2,1), (1,3), (3,1), (2,2)} at every scanned frame and size.
 
 Consequently the support signature determines the full-weight magnitude, while
 the extra measured weight bit distinguishes magnitudes 1 and 2 inside the
@@ -119,8 +125,8 @@ The law is not a fit to a plausible-looking form. The additive alternative
 LT·√(s_i + s_j) — which agrees at signature (2,2), where both read 4 — misses by
 at least 0.54 wherever the two differ. Swapping the axis and body-diagonal
 support assignments leaves 1656 entries outside the law at a single frame and
-size. A site-graded diagonal ramp on Q, which the relabeling does not commute
-with, leaves 272 entries outside it. A uniform diagonal shift, by contrast,
+size. A site-graded diagonal ramp on Q, noncommuting with the relabeling,
+leaves 272 entries outside it. A uniform diagonal shift, by contrast,
 leaves the defect exactly unchanged — the relabeling is a permutation, so a
 multiple of the identity cancels between the two terms of E_g.
 
@@ -172,8 +178,8 @@ The carrier size and support-signature partition are frame-independent: exactly
 and size. They are partitioned as 8 pairs of type (1,1), 7 each of types (1,2)
 and (2,1), 2 each of types (1,3) and (3,1), and 4 of type (2,2). The identities
 of the pairs form three frame-dependent carrier sets. Seven spatial classes
-admit 49 ordered pairs, so 19 pairs are absent at each frame; they are not a
-single universal set of 19.
+admit 49 ordered pairs, so the per-frame complement contains 19 pairs and
+varies with the carrier identity set.
 
 Scope limit: only the supplied open-box relabeling is executed. Alternative
 boundary re-anchorings and arbitrary box sizes remain outside this result.
@@ -201,9 +207,9 @@ Obligation graph:
    comparison.
 
 The strongest missing lemma is an arbitrary-size combinatorial derivation of
-the weight bit and descriptor counts from the stencil incidence rules. The
-finite `L = 3..9` theorem does not require that lemma; a universal polynomial
-or boundary-convention theorem would.
+the weight bit and descriptor counts from the stencil incidence rules. That
+lemma is needed only for a universal polynomial or boundary-convention theorem,
+outside the finite `L = 3..9` target.
 
 Degenerate and boundary cases: the smallest scanned box is `L = 3`; all 18
 mixed frames and every matrix entry above the declared numerical floor
@@ -213,12 +219,11 @@ numerical ceiling at `L = 3` and are not part of the weight census.
 ## Scope boundary
 
 - **The weight bit is measured, not derived.** Theorem I says that w ∈ {1, 1/2}
-  and that w = 1/2 occurs only on axis-by-axis pairs. It does not derive *which*
-  axis-axis entries take half weight or why that population splits while every
-  other realized signature carries only the full branch.
-- **The three absent signatures are a fact, not yet a mechanism.** That (2,3),
-  (3,2) and (3,3) never appear is a complete-scan statement over the sizes and
-  frames listed; the incidence reason is not given here.
+  and that w = 1/2 occurs only on axis-by-axis pairs. The selection of *which*
+  axis-axis entries take half weight and why that population splits while every
+  other realized signature carries only the full branch remains open.
+- **Signature-set completeness is measured.** The exact six-signature set is a
+  complete finite-scan statement; its incidence mechanism remains open.
 - **Signs are not classified.** The census is sign-balanced, and the magnitudes
   are fully determined, but which entry carries which sign is left to the
   Cycle-711 swap law and the Cycle-712 descriptor.
@@ -235,26 +240,24 @@ numerical ceiling at `L = 3` and are not part of the weight census.
 ## The next paths opened
 
 - **Derive the weight bit.** The half branch is exactly the axis-by-axis
-  signature and exactly the 16(L−1)² surface population — the same quadratic
+  signature and exactly the per-sign 16(L−1)² surface population — the same quadratic
   that carries the Cycle-712 wall family. Testing whether the half branch *is*
   the wall family, entry for entry, is a sharp finite question and would turn
   the weight bit into a positional statement.
-- **Derive the three absent signatures.** The face-diagonal-by-body-diagonal and
-  body-diagonal-by-body-diagonal pairs would carry magnitudes 2·√6 and 6. Their
-  absence is an incidence cancellation of the same kind the Cycle-711 stencil
-  computation resolved for the comparator, and is the natural next target for
-  that machinery.
+- **Derive the signature-set completeness.** A stencil-incidence account of
+  why the exact realized set stops at the six reported signatures is the
+  natural next target for the Cycle-711 machinery.
 - **Propagate the fitted leading density to the response floor.** The
   Cycle-709 minus-branch response-floor note
   `PHYSICAL_MINUS_BRANCH_RESPONSE_FLOOR_ASSEMBLY_DEFECT_LAW_CYCLE709_NOTE_2026-08-02`
   consumes the assembly defect through a solve. A finite defect census with a
   factorized magnitude law is a stronger input to a future floor-scaling law
   than an isolated measured count.
-- **Test the factorization against the source-side census.** The magnitude
-  factorizes over the two coframe legs, so it carries no direction-pair
-  correlation beyond the product of the leg lengths. Whether the same
-  factorization holds for the source-side edit sets is a direct question for the
-  Cycle-708 signed classification.
+- **Test the factorization against the source-side census.** The full-weight
+  magnitude factorizes over the two coframe-leg lengths, while the additional
+  half-weight bit remains positional. Whether the same two-part structure holds
+  for the source-side edit sets is a direct question for the Cycle-708 signed
+  classification.
 
 ## Relation to the interacting cycle
 
@@ -273,10 +276,10 @@ as a premise or numerical input here.
 — finite check, stdlib + numpy, self-contained against the Cycle-696 compiler
 chain. `AUDIT_INPUT_PATHS` declares that compiler and its four transitive
 script imports, and `AUDIT_TIMEOUT_SEC = 600`; no sibling cycle's numeric
-output is read. Gate groups: the numerical sextet ceiling and relabeling
-bijectivity; complete magnitude classification with zero unclassified entries and the
+output is read at runtime. Gate groups: the numerical sextet ceiling and
+relabeling bijectivity; complete magnitude classification with zero unclassified entries and the
 weight-law deviation ceiling; half-weight signature locking, realized full
-signatures, and absent signatures; the additive-law rejector, the full/half
+signatures and signature-set completeness; the additive-law rejector, the full/half
 separator, and the coincidence of the Cycle-712 cut with the weight split; sign
 balance and frame uniformity; the three census polynomials and the four
 magnitude polynomials at L = 3..9; held-out cubic extrapolation to L = 7, 8, 9;
@@ -302,12 +305,11 @@ non-linking because no result here depends on their claims.
 
 ## Review record
 
-Review removed the submitted universal statement that a boundary re-anchoring
-can change only the fitted quadratic/linear populations and therefore cannot
-remove the cubic population. The runner constructs no alternative transport,
+Review removed the submitted universal statement that every boundary
+re-anchoring preserves the fitted cubic population. The runner constructs no alternative transport,
 so that negative conclusion was unsupported. The durable result is the finite
-weight classification, finite per-frame carrier census, and polynomial agreement on the
-declared `L = 3..9` surface. Review also replaced an exact-zero claim for the
+weight classification, finite per-frame carrier census, and polynomial
+agreement on the declared `L = 3..9` surface. Review also replaced an exact-zero claim for the
 constant-sign sextet with the numerical ceiling actually gated at `L = 3`,
 made the `1e-9` resolved-entry floor explicit, and bound the runner cache to the
 complete transitive compiler-source closure. Independent audit remains required

--- a/docs/PHYSICAL_DEFECT_WEIGHT_LAW_AND_COMPLETE_CENSUS_CYCLE713_NOTE_2026-08-02.md
+++ b/docs/PHYSICAL_DEFECT_WEIGHT_LAW_AND_COMPLETE_CENSUS_CYCLE713_NOTE_2026-08-02.md
@@ -2,28 +2,50 @@
 
 **Claim type: bounded_theorem.** Finite, recomputed statements about the landed
 Cycle-696 open-coframe endpoint compiler chain at box sizes L ∈ {3, 4, 5, 6, 7,
-8, 9}. The magnitude law, its support-signature resolution, the closed-form
-census polynomials, and the codimension grading are exact finite statements
+8, 9}. The magnitude law, its support-signature resolution, the finite census
+values, and their polynomial agreement are bounded computational statements
 verified by complete scan over all 18 mixed frames; the identification of the
 compiler chain with the static spatial sector is inherited, not re-derived here.
 
-## What Cycles 711 and 712 left open
+```yaml
+trace_class: upstream_support
+target_claim_id: null
+target_blocker_text: "derive the finite weight split and support-signature mechanism, then prove any arbitrary-size counting extension rather than inferring it from seven boxes"
+source_of_blocker_text: strongest_missing_lemma
+reachability_to_target: supports
+artifact_role: runner_certificate
+next_trace_action: "derive the half-weight incidence mechanism and an arbitrary-L descriptor-count theorem, then test alternative transport definitions separately"
+```
 
-The Cycle-711 exact stencil swap law (stem
-`PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02`,
-in flight) derived the mixed-frame comparator −4 exactly and recorded its
-per-sign census as measured, not derived. The Cycle-712 family law (stem
-`PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02`, in
-flight) derived those counts from a positional box-descriptor mechanism, but
-took the four magnitudes {2, 2·√2, 2·√3, 4} themselves as a measured menu, and
-counted only the entries above the supplied cut 2.0e+00 — the sub-cut
-population was never classified at all.
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: upstream_support
+reachability_to_target: supports
+conditional_surface_status: "Complete finite scan of the supplied Cycle-696 compiler at L in {3,...,9}; polynomial and factorization statements are not extended beyond that enumerated domain."
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "the runner exhausts the declared finite frame-size surface, while the compiler identification, floating finite-difference values, arbitrary-size law, and alternative boundary transports are not derived here"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
 
-This cycle derives the menu, classifies every remaining entry, and gives the
-census in closed form. The magnitude of a defect entry is a function of the two
-edge classes it connects, and of nothing else: it factorizes over the two
-coframe legs. All statements below are computational identities of the landed
-compiler chain, recomputed in this cycle's runner.
+## Finite targets inherited from Cycles 711 and 712
+
+The [Cycle-711 exact stencil swap law](PHYSICAL_MIXED_FRAME_COMPARATOR_EXACT_STENCIL_SWAP_LAW_CYCLE711_NOTE_2026-08-02.md)
+derived the mixed-frame comparator −4 exactly at `L in {3, 7}` and recorded its
+per-sign census as measured, not derived. The
+[Cycle-712 finite family census](PHYSICAL_MIXED_FRAME_DEFECT_CENSUS_FAMILY_LAW_CYCLE712_NOTE_2026-08-02.md)
+derived the `L = 3..7` counts from a positional box-descriptor mechanism, but
+took the four magnitudes {2, 2·√2, 2·√3, 4} themselves as a measured menu and
+counted only the entries above the supplied cut 2.0e+00. This note extends the
+same finite scan to `L = 8, 9` and classifies the sub-cut population.
+
+This cycle derives the finite menu, classifies every remaining entry, and
+records the complete scanned census. Within the scanned compiler surface, the
+magnitude of a defect entry is a function of the two edge classes it connects:
+it factorizes over the two coframe legs. All statements below are recomputed
+from the landed compiler chain in this cycle's runner.
 
 ## Setup
 
@@ -36,9 +58,9 @@ s_i = |v_i|² ∈ {1, 2, 3}: support 1 for the three axis classes, 2 for the six
 face-diagonal classes, 3 for the body-diagonal class. Frames are the 24 proper
 cubic rotations of the landed Cycle-576 table; the transport permutation Π_g is
 the bounding-box dof relabeling of Cycle 710, and the assembly defect is
-E_g = Π_g^T Q Π_g − Q. The six constant-sign frames (the sextet) have defect
-ceiling below 1.0e-09 and are exact zeros; the census lives on the 18 mixed
-frames.
+E_g = Π_g^T Q Π_g − Q. The six constant-sign frames (the sextet) have measured
+defect ceiling below 1.0e-09 at the probed `L = 3`; this is a numerical gate,
+not an exact-zero theorem. The census lives on the 18 mixed frames.
 
 ## Theorem I — the weight law
 
@@ -55,7 +77,7 @@ entries scanned, and **zero** entries left unclassified. Two facts sharpen it:
   nowhere else. Its magnitude is therefore always 1.0e+00.
 - **Three signatures are never realized.** The w = 1 population realizes exactly
   the signatures (1,1), (1,2), (2,1), (1,3), (3,1), (2,2); the signatures
-  (2,3), (3,2), (3,3) carry no defect entry at any frame or size.
+  (2,3), (3,2), (3,3) carry no defect entry at any scanned frame or size.
 
 Consequently the magnitude is determined by the support signature alone, and the
 Cycle-712 menu is the list of values LT·√(s_i s_j) that the realized signatures
@@ -74,10 +96,10 @@ with, leaves 272 entries outside it. A uniform diagonal shift, by contrast,
 leaves the defect exactly unchanged — the relabeling is a permutation, so a
 multiple of the identity cancels between the two terms of E_g.
 
-## Theorem II — the complete census in closed form
+## Theorem II — the complete finite census and polynomial agreement
 
-Per mixed frame, and identically for all 18 of them, the counts are exact
-polynomials in the box size:
+Per mixed frame, and identically for all 18 of them, the counts agree with the
+following integer polynomials at every scanned size `L = 3..9`:
 
 | population | per sign | L = 3 … 9 |
 |---|---|---|
@@ -85,9 +107,9 @@ polynomials in the box size:
 | half weight | 16(L−1)² | 64, 144, 256, 400, 576, 784, 1024 |
 | all nonzeros (both signs) | 96(L−1)³ + 48(L−1)² + 8(L−1) | 976, 3048, 6944, 13240, 22512, 35336, 52288 |
 
-Plus and minus counts are equal for both weights at every size and frame. The
-magnitude-resolved census follows from Theorem I, one polynomial per magnitude,
-per sign:
+Plus and minus counts are equal for both weights at every scanned size and
+frame. The magnitude-resolved finite census agrees with one integer polynomial
+per magnitude and sign at every scanned size:
 
 | magnitude | signature | per sign |
 |---|---|---|
@@ -109,28 +131,56 @@ polynomials reproduce the landed Cycle-711 per-sign census totals 424 at L = 3
 and 10680 at L = 7, and — after the two magnitudes 2·√2 and 2·√3 are merged, as
 the Cycle-711 rounded buckets merge them — its bucket composition as well.
 
-## Theorem III — codimension grading and the carrier
+## Finite polynomial grading and the carrier
 
-The three polynomial degrees are the three codimensions of the box. The leading
-term is a bulk density: **96 nonzero defect entries per unit cell per mixed
-frame**, 48 per sign, independent of L. The quadratic term 48(L−1)² is a surface
-population and the linear term 8(L−1) an edge population; in the Cycle-712
-box-descriptor language the degree is 3 minus the number of pinned axes, so the
-wall family sits at degree 2 and the edge family at degree 1.
+The finite fits have cubic, quadratic, and linear terms. On the scanned boxes,
+their Cycle-712 descriptor interpretation is respectively unpinned,
+one-axis-pinned, and two-axis-pinned populations. The leading coefficient is
+96 nonzero defect entries per unit-cell factor `(L-1)^3` per mixed frame, 48
+per sign; the fitted subleading terms are `48(L-1)^2` and `8(L-1)`.
 
 The carrier is small and frame-independent: exactly **30 ordered edge-class
-pairs** carry full-weight entries, at every frame and every size, partitioned by
-support signature as 8 pairs of type (1,1), 7 each of types (1,2) and (2,1), 2
-each of types (1,3) and (3,1), and 4 of type (2,2). Seven spatial classes admit
-49 ordered pairs; 19 of them never carry a defect entry.
+pairs** carry full-weight entries at every scanned frame and size. They are
+partitioned by support signature as 8 pairs of type (1,1), 7 each of types
+(1,2) and (2,1), 2 each of types (1,3) and (3,1), and 4 of type (2,2). Seven
+spatial classes admit 49 ordered pairs; 19 of them never carry a defect entry.
 
-The bulk-extensivity statement has a direct consequence for the transport
-question. A re-anchoring of the transport at the box boundary can move at most
-the surface and edge populations, 48(L−1)² + 8(L−1) entries per frame. The
-bulk term 96(L−1)³ is untouched by any boundary convention, so the assembly
-defect is not a boundary artifact of the open box at any size.
+Scope limit: only the supplied open-box relabeling is executed. Alternative
+boundary re-anchorings and arbitrary box sizes remain outside this result.
 
-## Boundary — what this cycle does not establish
+## Exact target and proof obligations
+
+**Exact target.** For the imported Cycle-696 open-box compiler at each
+`L in {3,...,9}`, classify every numerically nonzero entry of `E_g` at all 18
+mixed frames by the two-leg weight menu; report the complete finite counts,
+their agreement with the displayed integer polynomials, and the finite carrier
+census.
+
+Obligation graph:
+
+1. The 18 analyzed maps are bijective label relabelings: checked exactly by
+   integer permutation enumeration at every scanned size.
+2. Every entry above the declared `1e-9` numerical floor belongs to exactly one
+   weight branch within `2e-7`: checked exhaustively over 2,418,192 entries.
+3. The frame-uniform sign, magnitude, and carrier censuses equal the displayed
+   formulas at all seven sizes: checked by exact integer comparison after the
+   finite floating classification.
+4. Arbitrary-`L` extension remains open. Four sizes determine each cubic and
+   three held-out sizes test it, but finite interpolation is not induction.
+5. Alternative boundary transports remain open and are outside the executed
+   comparison.
+
+The strongest missing lemma is an arbitrary-size combinatorial derivation of
+the weight bit and descriptor counts from the stencil incidence rules. The
+finite `L = 3..9` theorem does not require that lemma; a universal polynomial
+or boundary-convention theorem would.
+
+Degenerate and boundary cases: the smallest scanned box is `L = 3`; all 18
+mixed frames and every nonzero matrix entry above the declared numerical floor
+are included. The six constant-sign frames are checked separately only for a
+numerical ceiling at `L = 3` and are not part of the weight census.
+
+## Scope boundary
 
 - **The weight bit is measured, not derived.** Theorem I says that w ∈ {1, 1/2}
   and that w = 1/2 occurs exactly on axis-by-axis pairs. It does not derive
@@ -145,6 +195,9 @@ defect is not a boundary artifact of the open box at any size.
 - **Finite scan, not induction.** The polynomials are verified at seven sizes,
   three of them held out from the fit. That is strong evidence and a clean
   extrapolation, not a proof for all L.
+- **Alternative transports remain open.** The scan uses one supplied open-box
+  relabeling. Other re-anchorings and interior-changing transport definitions
+  are outside the executed comparison.
 - **This is the static spatial sector.** No dynamical or interacting statement
   is made, and no claim about the wrapped stencil, which the Cycle-696 header
   places outside the executed path.
@@ -161,12 +214,11 @@ defect is not a boundary artifact of the open box at any size.
   absence is an incidence cancellation of the same kind the Cycle-711 stencil
   computation resolved for the comparator, and is the natural next target for
   that machinery.
-- **Propagate the bulk density to the response floor.** The Cycle-709
-  minus-branch floor (stem
-  `PHYSICAL_MINUS_BRANCH_RESPONSE_FLOOR_ASSEMBLY_DEFECT_LAW_CYCLE709_NOTE_2026-08-02`,
-  in flight) consumes the assembly defect through a solve. A defect with an
-  exact bulk density and a factorized magnitude law is a much stronger input to
-  a floor-scaling law than a measured count was.
+- **Propagate the fitted leading density to the response floor.** The
+  [Cycle-709 minus-branch response-floor note](PHYSICAL_MINUS_BRANCH_RESPONSE_FLOOR_ASSEMBLY_DEFECT_LAW_CYCLE709_NOTE_2026-08-02.md)
+  consumes the assembly defect through a solve. A finite defect census with a
+  factorized magnitude law is a stronger input to a future floor-scaling law
+  than an isolated measured count.
 - **Test the factorization against the source-side census.** The magnitude
   factorizes over the two coframe legs, so it carries no direction-pair
   correlation beyond the product of the leg lengths. Whether the same
@@ -176,22 +228,22 @@ defect is not a boundary artifact of the open box at any size.
 ## Relation to the interacting cycle
 
 This cycle stays inside the static spatial sector of the landed 3+1 module. The
-frame sextet that carries the exact zeros of the weight law is the same
+frame sextet that carries the numerical near-zero ceiling is the same
 constant-sign sextet whose source-stabilizer role is analyzed in
 [PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01](PHYSICAL_SOURCE_STABILIZER_COSET_COLLAPSE_K_SIGN_LAW_CYCLE707_NOTE_2026-08-01.md);
-the in-flight Cycle-708 classification (stem
-`PHYSICAL_SOURCE_EDIT_SET_SIGNED_STABILIZER_CLASSIFICATION_CYCLE708_NOTE_2026-08-02`)
-maps the same boundary at the signed level, and the in-flight Cycle-710
-covariance-boundary census (stem
-`PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_LAW_AND_COVARIANCE_BOUNDARY_CYCLE710_NOTE_2026-08-02`)
-supplied the defect object this cycle now classifies completely.
+the landed Cycle-708 classification is complementary source-side context. The
+[Cycle-710 finite assembly-defect cocycle and mixed-frame comparator](PHYSICAL_ASSEMBLY_DEFECT_COCYCLE_AND_MIXED_FRAME_COMPARATOR_CYCLE710_NOTE_2026-08-02.md)
+supplied the finite defect object this cycle classifies. Cycle 708 is not used
+as a premise or numerical input here.
 
 ## Runner
 
 `scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py`
-— class-A finite check, stdlib + numpy, self-contained against the Cycle-696
-compiler chain. Gate groups: sextet exact zeros and relabeling bijectivity;
-complete magnitude classification with zero unclassified entries and the
+— finite check, stdlib + numpy, self-contained against the Cycle-696 compiler
+chain. `AUDIT_INPUT_PATHS` declares that compiler and its four transitive
+script imports, and `AUDIT_TIMEOUT_SEC = 600`; no sibling cycle's numeric
+output is read. Gate groups: the numerical sextet ceiling and relabeling
+bijectivity; complete magnitude classification with zero unclassified entries and the
 weight-law deviation ceiling; half-weight signature locking, realized full
 signatures, and absent signatures; the additive-law rejector, the full/half
 separator, and the coincidence of the Cycle-712 cut with the weight split; sign

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15503,
- "node_count": 5454,
+ "edge_count": 15504,
+ "node_count": 5455,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13669,6 +13669,10 @@
   "physical_cycle704_fswap_endpoint_cube_bridge_cycle708_bounded_theorem_note_2026-07-26": {
    "deps_hash": "45ce5a497291",
    "out_degree": 3
+  },
+  "physical_defect_weight_law_and_complete_census_cycle713_note_2026-08-02": {
+   "deps_hash": "4da3dcedb546",
+   "out_degree": 1
   },
   "physical_direction_set_vs_triangulation_covariance_cycle695_note_2026-07-25": {
    "deps_hash": "b5d4aaddc594",

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,5 +1,5 @@
 {
- "edge_count": 15504,
+ "edge_count": 15506,
  "node_count": 5455,
  "nodes": {
   "3d_correction_master_note": {
@@ -13671,8 +13671,8 @@
    "out_degree": 3
   },
   "physical_defect_weight_law_and_complete_census_cycle713_note_2026-08-02": {
-   "deps_hash": "4da3dcedb546",
-   "out_degree": 1
+   "deps_hash": "3a81cc48c4e6",
+   "out_degree": 3
   },
   "physical_direction_set_vs_triangulation_covariance_cycle695_note_2026-07-25": {
    "deps_hash": "b5d4aaddc594",

--- a/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
+++ b/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
@@ -1,10 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
-runner_sha256: 6a1f4d9b7c6c79f14547c9aec43ea41222d29e0eba2e42ef91ed315730b58bea
+runner_sha256: a3474fb73effa9e2e8ac23a133d2f2a0da67aac0903037b6588a237b606928eb
 input_fingerprint_sha256: f16228dfa22ac9810d4cc316446c432694b1b6d39236992c2bac39c9cf2f5eab
 timeout_sec: 600
 exit_code: 0
-elapsed_sec: 10.58
+elapsed_sec: 10.41
 status: ok
 ----- stdout -----
 == cycle 713: assembly-defect weight law and complete census ==
@@ -15,7 +15,7 @@ PASS g03_complete_classification all 2418192 resolved entries above 1.0e-09 obey
 PASS g04_weight_law_dev max weight-law deviation 6.1e-08
 PASS g05_half_signature_axis_only half weight occurs only on axis-axis pairs, signature set [(1, 1)]
 PASS g06_full_signatures realized full signatures [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1)]
-PASS g07_absent_signatures signatures [(2, 3), (3, 2), (3, 3)] are never realized
+PASS g07_signature_set_complete realized signature set is exactly [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1)]
 PASS g08_additive_rejector additive alternative LT*sqrt(s_i+s_j) misses by at least 0.54 where it differs
 PASS g09_full_half_gap largest half-weight magnitude 1.0e+00 below the cycle-711 cut 2.0e+00, smallest full-weight magnitude 2.0e+00
 PASS g10_cut_is_weight_separator entries above the cycle-711 cut equal the full-weight entries at every size and frame
@@ -36,7 +36,7 @@ PASS g21_carrier_size 30 ordered class pairs carry the full-weight entries, at e
 PASS g22_carrier_signature carrier support signatures {'(1, 1)': 8, '(1, 2)': 7, '(1, 3)': 2, '(2, 1)': 7, '(2, 2)': 4, '(3, 1)': 2}, with 3 frame-dependent identity sets
 PASS g23_support_shuffle_rejector swapping the axis and body-diagonal supports leaves 1656 entries outside the weight law
 PASS g24_uniform_shift_invariance a uniform 1.7 diagonal shift leaves the defect unchanged, because the frame relabelling is a permutation
-PASS g25_ramp_rejector a site-graded diagonal ramp of height 1.7, which the relabelling does not commute with, leaves 272 entries outside the weight law
+PASS g25_ramp_rejector a site-graded diagonal ramp of height 1.7, noncommuting with the relabeling, leaves 272 entries outside the weight law
 receipt: outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json
 TOTAL: PASS=28 FAIL=0
 

--- a/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
+++ b/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
@@ -1,17 +1,17 @@
 ===== runner cache v1 =====
 runner: scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
-runner_sha256: 369a418144fb6049c3184133b772cbbb081048d164a35c4b552cfb160c6a3200
+runner_sha256: 6a1f4d9b7c6c79f14547c9aec43ea41222d29e0eba2e42ef91ed315730b58bea
 input_fingerprint_sha256: f16228dfa22ac9810d4cc316446c432694b1b6d39236992c2bac39c9cf2f5eab
 timeout_sec: 600
 exit_code: 0
-elapsed_sec: 10.97
+elapsed_sec: 10.58
 status: ok
 ----- stdout -----
 == cycle 713: assembly-defect weight law and complete census ==
 config: LT=2 supports=(1, 2, 3) fit L=(3, 4, 5, 6) held-out L=(7, 8, 9) mixed_frames=18 of 24 fd_step=1.0e-04 tol=2.0e-07 cut=2.0e+00
 PASS g01_sextet_defect_ceiling measured max defect below 1.0e-09 on all 6 constant-sign frames at L=3
 PASS g02_frame_relabel_bijective frame relabelling is a permutation of the coframe variables
-PASS g03_complete_classification all 2418192 nonzero entries obey |E| = w*LT*sqrt(s_i s_j), w in (1, 1/2); unclassified 0
+PASS g03_complete_classification all 2418192 resolved entries above 1.0e-09 obey |E| = w*LT*sqrt(s_i s_j), w in (1, 1/2); unclassified 0
 PASS g04_weight_law_dev max weight-law deviation 6.1e-08
 PASS g05_half_signature_axis_only half weight occurs only on axis-axis pairs, signature set [(1, 1)]
 PASS g06_full_signatures realized full signatures [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1)]
@@ -23,9 +23,9 @@ PASS g11_sign_balance plus and minus counts equal for both weights at every size
 PASS g12_frame_uniform per-frame weight counts identical across the 18 mixed frames at every size
 PASS g13_full_law full per sign L=(3, 4, 5, 6, 7, 8, 9): [424, 1380, 3216, 6220, 10680, 16884, 25120] = 48(L-1)^3+8(L-1)^2+4(L-1)
 PASS g14_half_law half per sign L=(3, 4, 5, 6, 7, 8, 9): [64, 144, 256, 400, 576, 784, 1024] = 16(L-1)^2
-PASS g15_total_law nonzeros per frame L=(3, 4, 5, 6, 7, 8, 9): [976, 3048, 6944, 13240, 22512, 35336, 52288] = 96(L-1)^3+48(L-1)^2+8(L-1)
+PASS g15_total_law resolved entries per frame L=(3, 4, 5, 6, 7, 8, 9): [976, 3048, 6944, 13240, 22512, 35336, 52288] = 96(L-1)^3+48(L-1)^2+8(L-1)
 PASS g16_heldout_full cubic fitted on L=(3, 4, 5, 6) predicts full per sign at L=(7, 8, 9): [10680, 16884, 25120]
-PASS g17_heldout_total cubic fitted on L=(3, 4, 5, 6) predicts nonzeros per frame at L=(7, 8, 9): [22512, 35336, 52288]
+PASS g17_heldout_total cubic fitted on L=(3, 4, 5, 6) predicts resolved entries per frame at L=(7, 8, 9): [22512, 35336, 52288]
 PASS g18_census_anchor full per sign [424, 10680] at L=[3, 7] (cycle-711 census totals)
 PASS g19_mag_four per sign L=(3, 4, 5, 6, 7, 8, 9): [64, 216, 512, 1000, 1728, 2744, 4096] = 8(L-1)^3
 PASS g19_mag_two_rt3 per sign L=(3, 4, 5, 6, 7, 8, 9): [64, 216, 512, 1000, 1728, 2744, 4096] = 8(L-1)^3
@@ -33,7 +33,7 @@ PASS g19_mag_two_rt2 per sign L=(3, 4, 5, 6, 7, 8, 9): [160, 468, 1024, 1900, 31
 PASS g19_mag_two per sign L=(3, 4, 5, 6, 7, 8, 9): [136, 480, 1168, 2320, 4056, 6496, 9760] = 20(L-1)^3-8(L-1)^2+4(L-1)
 PASS g20_magnitudes_sum the four full magnitudes partition the full-weight population
 PASS g21_carrier_size 30 ordered class pairs carry the full-weight entries, at every size and frame
-PASS g22_carrier_signature carrier support signatures {'(1, 1)': 8, '(1, 2)': 7, '(1, 3)': 2, '(2, 1)': 7, '(2, 2)': 4, '(3, 1)': 2}
+PASS g22_carrier_signature carrier support signatures {'(1, 1)': 8, '(1, 2)': 7, '(1, 3)': 2, '(2, 1)': 7, '(2, 2)': 4, '(3, 1)': 2}, with 3 frame-dependent identity sets
 PASS g23_support_shuffle_rejector swapping the axis and body-diagonal supports leaves 1656 entries outside the weight law
 PASS g24_uniform_shift_invariance a uniform 1.7 diagonal shift leaves the defect unchanged, because the frame relabelling is a permutation
 PASS g25_ramp_rejector a site-graded diagonal ramp of height 1.7, which the relabelling does not commute with, leaves 272 entries outside the weight law

--- a/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
+++ b/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
@@ -1,0 +1,43 @@
+===== runner cache v1 =====
+runner: scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
+runner_sha256: e16950925cd50cd5d8ce306e1ef16acac393e1b9bd185534b2dc1d67fb5b7c16
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 18.80
+status: ok
+----- stdout -----
+== cycle 713: assembly-defect weight law and complete census ==
+config: LT=2 supports=(1, 2, 3) fit L=(3, 4, 5, 6) held-out L=(7, 8, 9) mixed_frames=18 of 24 fd_step=1.0e-04 tol=2.0e-07 cut=2.0e+00
+PASS g01_sextet_defect_zero max defect below 1.0e-09 on all 6 constant-sign frames
+PASS g02_frame_relabel_bijective frame relabelling is a permutation of the coframe variables
+PASS g03_complete_classification all 2418192 nonzero entries obey |E| = w*LT*sqrt(s_i s_j), w in (1, 1/2); unclassified 0
+PASS g04_weight_law_dev max weight-law deviation 6.1e-08
+PASS g05_half_signature_axis_only half weight occurs only on axis-axis pairs, signature set [(1, 1)]
+PASS g06_full_signatures realized full signatures [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1)]
+PASS g07_absent_signatures signatures [(2, 3), (3, 2), (3, 3)] are never realized
+PASS g08_additive_rejector additive alternative LT*sqrt(s_i+s_j) misses by at least 0.54 where it differs
+PASS g09_full_half_gap largest half-weight magnitude 1.0e+00 below the cycle-711 cut 2.0e+00, smallest full-weight magnitude 2.0e+00
+PASS g10_cut_is_weight_separator entries above the cycle-711 cut equal the full-weight entries at every size and frame
+PASS g11_sign_balance plus and minus counts equal for both weights at every size
+PASS g12_frame_uniform per-frame weight counts identical across the 18 mixed frames at every size
+PASS g13_full_law full per sign L=(3, 4, 5, 6, 7, 8, 9): [424, 1380, 3216, 6220, 10680, 16884, 25120] = 48(L-1)^3+8(L-1)^2+4(L-1)
+PASS g14_half_law half per sign L=(3, 4, 5, 6, 7, 8, 9): [64, 144, 256, 400, 576, 784, 1024] = 16(L-1)^2
+PASS g15_total_law nonzeros per frame L=(3, 4, 5, 6, 7, 8, 9): [976, 3048, 6944, 13240, 22512, 35336, 52288] = 96(L-1)^3+48(L-1)^2+8(L-1)
+PASS g16_heldout_full cubic fitted on L=(3, 4, 5, 6) predicts full per sign at L=(7, 8, 9): [10680, 16884, 25120]
+PASS g17_heldout_total cubic fitted on L=(3, 4, 5, 6) predicts nonzeros per frame at L=(7, 8, 9): [22512, 35336, 52288]
+PASS g18_census_anchor full per sign [424, 10680] at L=[3, 7] (cycle-711 census totals)
+PASS g19_mag_four per sign L=(3, 4, 5, 6, 7, 8, 9): [64, 216, 512, 1000, 1728, 2744, 4096] = 8(L-1)^3
+PASS g19_mag_two_rt3 per sign L=(3, 4, 5, 6, 7, 8, 9): [64, 216, 512, 1000, 1728, 2744, 4096] = 8(L-1)^3
+PASS g19_mag_two_rt2 per sign L=(3, 4, 5, 6, 7, 8, 9): [160, 468, 1024, 1900, 3168, 4900, 7168] = 12(L-1)^3+16(L-1)^2
+PASS g19_mag_two per sign L=(3, 4, 5, 6, 7, 8, 9): [136, 480, 1168, 2320, 4056, 6496, 9760] = 20(L-1)^3-8(L-1)^2+4(L-1)
+PASS g20_magnitudes_sum the four full magnitudes partition the full-weight population
+PASS g21_carrier_size 30 ordered class pairs carry the full-weight entries, at every size and frame
+PASS g22_carrier_signature carrier support signatures {'(1, 1)': 8, '(1, 2)': 7, '(1, 3)': 2, '(2, 1)': 7, '(2, 2)': 4, '(3, 1)': 2}
+PASS g23_support_shuffle_rejector swapping the axis and body-diagonal supports leaves 1656 entries outside the weight law
+PASS g24_uniform_shift_invariance a uniform 1.7 diagonal shift leaves the defect unchanged, because the frame relabelling is a permutation
+PASS g25_ramp_rejector a site-graded diagonal ramp of height 1.7, which the relabelling does not commute with, leaves 272 entries outside the weight law
+receipt: outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json
+TOTAL: PASS=28 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
+++ b/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
@@ -1,10 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
-runner_sha256: a3474fb73effa9e2e8ac23a133d2f2a0da67aac0903037b6588a237b606928eb
+runner_sha256: 902e9577eeca8ce9c83a6be30572a188344f99e9acdf1c40675455fec5fb0d79
 input_fingerprint_sha256: f16228dfa22ac9810d4cc316446c432694b1b6d39236992c2bac39c9cf2f5eab
 timeout_sec: 600
 exit_code: 0
-elapsed_sec: 10.41
+elapsed_sec: 10.36
 status: ok
 ----- stdout -----
 == cycle 713: assembly-defect weight law and complete census ==
@@ -20,7 +20,7 @@ PASS g08_additive_rejector additive alternative LT*sqrt(s_i+s_j) misses by at le
 PASS g09_full_half_gap largest half-weight magnitude 1.0e+00 below the cycle-711 cut 2.0e+00, smallest full-weight magnitude 2.0e+00
 PASS g10_cut_is_weight_separator entries above the cycle-711 cut equal the full-weight entries at every size and frame
 PASS g11_sign_balance plus and minus counts equal for both weights at every size
-PASS g12_frame_uniform per-frame weight counts identical across the 18 mixed frames at every size
+PASS g12_frame_uniform per-frame weight and magnitude-resolved sign counts identical across the 18 mixed frames at every size
 PASS g13_full_law full per sign L=(3, 4, 5, 6, 7, 8, 9): [424, 1380, 3216, 6220, 10680, 16884, 25120] = 48(L-1)^3+8(L-1)^2+4(L-1)
 PASS g14_half_law half per sign L=(3, 4, 5, 6, 7, 8, 9): [64, 144, 256, 400, 576, 784, 1024] = 16(L-1)^2
 PASS g15_total_law resolved entries per frame L=(3, 4, 5, 6, 7, 8, 9): [976, 3048, 6944, 13240, 22512, 35336, 52288] = 96(L-1)^3+48(L-1)^2+8(L-1)

--- a/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
+++ b/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
@@ -1,14 +1,15 @@
 ===== runner cache v1 =====
 runner: scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
-runner_sha256: e16950925cd50cd5d8ce306e1ef16acac393e1b9bd185534b2dc1d67fb5b7c16
-timeout_sec: 300
+runner_sha256: 7941a85a9eae68395fd48b04195fa68ebe7bb5b8c769dd4eb42e583b4b8c2467
+input_fingerprint_sha256: f16228dfa22ac9810d4cc316446c432694b1b6d39236992c2bac39c9cf2f5eab
+timeout_sec: 600
 exit_code: 0
-elapsed_sec: 18.80
+elapsed_sec: 10.63
 status: ok
 ----- stdout -----
 == cycle 713: assembly-defect weight law and complete census ==
 config: LT=2 supports=(1, 2, 3) fit L=(3, 4, 5, 6) held-out L=(7, 8, 9) mixed_frames=18 of 24 fd_step=1.0e-04 tol=2.0e-07 cut=2.0e+00
-PASS g01_sextet_defect_zero max defect below 1.0e-09 on all 6 constant-sign frames
+PASS g01_sextet_defect_ceiling measured max defect below 1.0e-09 on all 6 constant-sign frames at L=3
 PASS g02_frame_relabel_bijective frame relabelling is a permutation of the coframe variables
 PASS g03_complete_classification all 2418192 nonzero entries obey |E| = w*LT*sqrt(s_i s_j), w in (1, 1/2); unclassified 0
 PASS g04_weight_law_dev max weight-law deviation 6.1e-08

--- a/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
+++ b/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
@@ -1,10 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
-runner_sha256: 7941a85a9eae68395fd48b04195fa68ebe7bb5b8c769dd4eb42e583b4b8c2467
+runner_sha256: 369a418144fb6049c3184133b772cbbb081048d164a35c4b552cfb160c6a3200
 input_fingerprint_sha256: f16228dfa22ac9810d4cc316446c432694b1b6d39236992c2bac39c9cf2f5eab
 timeout_sec: 600
 exit_code: 0
-elapsed_sec: 10.63
+elapsed_sec: 10.97
 status: ok
 ----- stdout -----
 == cycle 713: assembly-defect weight law and complete census ==

--- a/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
+++ b/logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt
@@ -1,10 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
-runner_sha256: 902e9577eeca8ce9c83a6be30572a188344f99e9acdf1c40675455fec5fb0d79
+runner_sha256: 25833d055ef0aaed75a4be75570f6a82719a23338c8f22e5318055f736be3f78
 input_fingerprint_sha256: f16228dfa22ac9810d4cc316446c432694b1b6d39236992c2bac39c9cf2f5eab
 timeout_sec: 600
 exit_code: 0
-elapsed_sec: 10.36
+elapsed_sec: 10.51
 status: ok
 ----- stdout -----
 == cycle 713: assembly-defect weight law and complete census ==

--- a/outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json
+++ b/outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json
@@ -1,0 +1,185 @@
+{
+  "LT": 2,
+  "additive_gap": "0.54",
+  "cycle": 713,
+  "entries_scanned": 2418192,
+  "fail": 0,
+  "full_per_sign": [
+    424,
+    1380,
+    3216,
+    6220,
+    10680,
+    16884,
+    25120
+  ],
+  "gates": {
+    "g01_sextet_defect_zero": {
+      "detail": "max defect below 1.0e-09 on all 6 constant-sign frames",
+      "pass": true
+    },
+    "g02_frame_relabel_bijective": {
+      "detail": "frame relabelling is a permutation of the coframe variables",
+      "pass": true
+    },
+    "g03_complete_classification": {
+      "detail": "all 2418192 nonzero entries obey |E| = w*LT*sqrt(s_i s_j), w in (1, 1/2); unclassified 0",
+      "pass": true
+    },
+    "g04_weight_law_dev": {
+      "detail": "max weight-law deviation 6.1e-08",
+      "pass": true
+    },
+    "g05_half_signature_axis_only": {
+      "detail": "half weight occurs only on axis-axis pairs, signature set [(1, 1)]",
+      "pass": true
+    },
+    "g06_full_signatures": {
+      "detail": "realized full signatures [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1)]",
+      "pass": true
+    },
+    "g07_absent_signatures": {
+      "detail": "signatures [(2, 3), (3, 2), (3, 3)] are never realized",
+      "pass": true
+    },
+    "g08_additive_rejector": {
+      "detail": "additive alternative LT*sqrt(s_i+s_j) misses by at least 0.54 where it differs",
+      "pass": true
+    },
+    "g09_full_half_gap": {
+      "detail": "largest half-weight magnitude 1.0e+00 below the cycle-711 cut 2.0e+00, smallest full-weight magnitude 2.0e+00",
+      "pass": true
+    },
+    "g10_cut_is_weight_separator": {
+      "detail": "entries above the cycle-711 cut equal the full-weight entries at every size and frame",
+      "pass": true
+    },
+    "g11_sign_balance": {
+      "detail": "plus and minus counts equal for both weights at every size",
+      "pass": true
+    },
+    "g12_frame_uniform": {
+      "detail": "per-frame weight counts identical across the 18 mixed frames at every size",
+      "pass": true
+    },
+    "g13_full_law": {
+      "detail": "full per sign L=(3, 4, 5, 6, 7, 8, 9): [424, 1380, 3216, 6220, 10680, 16884, 25120] = 48(L-1)^3+8(L-1)^2+4(L-1)",
+      "pass": true
+    },
+    "g14_half_law": {
+      "detail": "half per sign L=(3, 4, 5, 6, 7, 8, 9): [64, 144, 256, 400, 576, 784, 1024] = 16(L-1)^2",
+      "pass": true
+    },
+    "g15_total_law": {
+      "detail": "nonzeros per frame L=(3, 4, 5, 6, 7, 8, 9): [976, 3048, 6944, 13240, 22512, 35336, 52288] = 96(L-1)^3+48(L-1)^2+8(L-1)",
+      "pass": true
+    },
+    "g16_heldout_full": {
+      "detail": "cubic fitted on L=(3, 4, 5, 6) predicts full per sign at L=(7, 8, 9): [10680, 16884, 25120]",
+      "pass": true
+    },
+    "g17_heldout_total": {
+      "detail": "cubic fitted on L=(3, 4, 5, 6) predicts nonzeros per frame at L=(7, 8, 9): [22512, 35336, 52288]",
+      "pass": true
+    },
+    "g18_census_anchor": {
+      "detail": "full per sign [424, 10680] at L=[3, 7] (cycle-711 census totals)",
+      "pass": true
+    },
+    "g19_mag_four": {
+      "detail": "per sign L=(3, 4, 5, 6, 7, 8, 9): [64, 216, 512, 1000, 1728, 2744, 4096] = 8(L-1)^3",
+      "pass": true
+    },
+    "g19_mag_two": {
+      "detail": "per sign L=(3, 4, 5, 6, 7, 8, 9): [136, 480, 1168, 2320, 4056, 6496, 9760] = 20(L-1)^3-8(L-1)^2+4(L-1)",
+      "pass": true
+    },
+    "g19_mag_two_rt2": {
+      "detail": "per sign L=(3, 4, 5, 6, 7, 8, 9): [160, 468, 1024, 1900, 3168, 4900, 7168] = 12(L-1)^3+16(L-1)^2",
+      "pass": true
+    },
+    "g19_mag_two_rt3": {
+      "detail": "per sign L=(3, 4, 5, 6, 7, 8, 9): [64, 216, 512, 1000, 1728, 2744, 4096] = 8(L-1)^3",
+      "pass": true
+    },
+    "g20_magnitudes_sum": {
+      "detail": "the four full magnitudes partition the full-weight population",
+      "pass": true
+    },
+    "g21_carrier_size": {
+      "detail": "30 ordered class pairs carry the full-weight entries, at every size and frame",
+      "pass": true
+    },
+    "g22_carrier_signature": {
+      "detail": "carrier support signatures {'(1, 1)': 8, '(1, 2)': 7, '(1, 3)': 2, '(2, 1)': 7, '(2, 2)': 4, '(3, 1)': 2}",
+      "pass": true
+    },
+    "g23_support_shuffle_rejector": {
+      "detail": "swapping the axis and body-diagonal supports leaves 1656 entries outside the weight law",
+      "pass": true
+    },
+    "g24_uniform_shift_invariance": {
+      "detail": "a uniform 1.7 diagonal shift leaves the defect unchanged, because the frame relabelling is a permutation",
+      "pass": true
+    },
+    "g25_ramp_rejector": {
+      "detail": "a site-graded diagonal ramp of height 1.7, which the relabelling does not commute with, leaves 272 entries outside the weight law",
+      "pass": true
+    }
+  },
+  "half_per_sign": [
+    64,
+    144,
+    256,
+    400,
+    576,
+    784,
+    1024
+  ],
+  "mixed_frames": 18,
+  "nonzeros_per_frame": [
+    976,
+    3048,
+    6944,
+    13240,
+    22512,
+    35336,
+    52288
+  ],
+  "notes": {
+    "carrier_pairs": 30,
+    "full_min": "2.0e+00",
+    "full_per_sign_poly": "48(L-1)^3 + 8(L-1)^2 + 4(L-1)",
+    "half_max": "1.0e+00",
+    "half_per_sign_poly": "16(L-1)^2",
+    "magnitude_polys": {
+      "four": "8(L-1)^3",
+      "two": "20(L-1)^3-8(L-1)^2+4(L-1)",
+      "two_rt2": "12(L-1)^3+16(L-1)^2",
+      "two_rt3": "8(L-1)^3"
+    },
+    "nonzeros_per_frame_poly": "96(L-1)^3 + 48(L-1)^2 + 8(L-1)",
+    "weight_law": "|E_ij| = w * LT * sqrt(s_i s_j), w in (1, 1/2)"
+  },
+  "object": "assembly-defect weight law and complete census",
+  "pass": 28,
+  "sizes": [
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9
+  ],
+  "supports": {
+    "1": 1,
+    "11": 2,
+    "13": 3,
+    "3": 1,
+    "5": 2,
+    "7": 1,
+    "9": 2
+  },
+  "weight_law_dev": "6.1e-08"
+}

--- a/outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json
+++ b/outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json
@@ -38,8 +38,8 @@
       "detail": "realized full signatures [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1)]",
       "pass": true
     },
-    "g07_absent_signatures": {
-      "detail": "signatures [(2, 3), (3, 2), (3, 3)] are never realized",
+    "g07_signature_set_complete": {
+      "detail": "realized signature set is exactly [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1)]",
       "pass": true
     },
     "g08_additive_rejector": {
@@ -123,7 +123,7 @@
       "pass": true
     },
     "g25_ramp_rejector": {
-      "detail": "a site-graded diagonal ramp of height 1.7, which the relabelling does not commute with, leaves 272 entries outside the weight law",
+      "detail": "a site-graded diagonal ramp of height 1.7, noncommuting with the relabeling, leaves 272 entries outside the weight law",
       "pass": true
     }
   },

--- a/outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json
+++ b/outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json
@@ -14,8 +14,8 @@
     25120
   ],
   "gates": {
-    "g01_sextet_defect_zero": {
-      "detail": "max defect below 1.0e-09 on all 6 constant-sign frames",
+    "g01_sextet_defect_ceiling": {
+      "detail": "measured max defect below 1.0e-09 on all 6 constant-sign frames at L=3",
       "pass": true
     },
     "g02_frame_relabel_bijective": {

--- a/outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json
+++ b/outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json
@@ -59,7 +59,7 @@
       "pass": true
     },
     "g12_frame_uniform": {
-      "detail": "per-frame weight counts identical across the 18 mixed frames at every size",
+      "detail": "per-frame weight and magnitude-resolved sign counts identical across the 18 mixed frames at every size",
       "pass": true
     },
     "g13_full_law": {

--- a/outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json
+++ b/outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json
@@ -23,7 +23,7 @@
       "pass": true
     },
     "g03_complete_classification": {
-      "detail": "all 2418192 nonzero entries obey |E| = w*LT*sqrt(s_i s_j), w in (1, 1/2); unclassified 0",
+      "detail": "all 2418192 resolved entries above 1.0e-09 obey |E| = w*LT*sqrt(s_i s_j), w in (1, 1/2); unclassified 0",
       "pass": true
     },
     "g04_weight_law_dev": {
@@ -71,7 +71,7 @@
       "pass": true
     },
     "g15_total_law": {
-      "detail": "nonzeros per frame L=(3, 4, 5, 6, 7, 8, 9): [976, 3048, 6944, 13240, 22512, 35336, 52288] = 96(L-1)^3+48(L-1)^2+8(L-1)",
+      "detail": "resolved entries per frame L=(3, 4, 5, 6, 7, 8, 9): [976, 3048, 6944, 13240, 22512, 35336, 52288] = 96(L-1)^3+48(L-1)^2+8(L-1)",
       "pass": true
     },
     "g16_heldout_full": {
@@ -79,7 +79,7 @@
       "pass": true
     },
     "g17_heldout_total": {
-      "detail": "cubic fitted on L=(3, 4, 5, 6) predicts nonzeros per frame at L=(7, 8, 9): [22512, 35336, 52288]",
+      "detail": "cubic fitted on L=(3, 4, 5, 6) predicts resolved entries per frame at L=(7, 8, 9): [22512, 35336, 52288]",
       "pass": true
     },
     "g18_census_anchor": {
@@ -111,7 +111,7 @@
       "pass": true
     },
     "g22_carrier_signature": {
-      "detail": "carrier support signatures {'(1, 1)': 8, '(1, 2)': 7, '(1, 3)': 2, '(2, 1)': 7, '(2, 2)': 4, '(3, 1)': 2}",
+      "detail": "carrier support signatures {'(1, 1)': 8, '(1, 2)': 7, '(1, 3)': 2, '(2, 1)': 7, '(2, 2)': 4, '(3, 1)': 2}, with 3 frame-dependent identity sets",
       "pass": true
     },
     "g23_support_shuffle_rejector": {
@@ -137,16 +137,8 @@
     1024
   ],
   "mixed_frames": 18,
-  "nonzeros_per_frame": [
-    976,
-    3048,
-    6944,
-    13240,
-    22512,
-    35336,
-    52288
-  ],
   "notes": {
+    "carrier_identity_sets": 3,
     "carrier_pairs": 30,
     "full_min": "2.0e+00",
     "full_per_sign_poly": "48(L-1)^3 + 8(L-1)^2 + 4(L-1)",
@@ -158,11 +150,20 @@
       "two_rt2": "12(L-1)^3+16(L-1)^2",
       "two_rt3": "8(L-1)^3"
     },
-    "nonzeros_per_frame_poly": "96(L-1)^3 + 48(L-1)^2 + 8(L-1)",
+    "resolved_entries_per_frame_poly": "96(L-1)^3 + 48(L-1)^2 + 8(L-1)",
     "weight_law": "|E_ij| = w * LT * sqrt(s_i s_j), w in (1, 1/2)"
   },
   "object": "assembly-defect weight law and complete census",
   "pass": 28,
+  "resolved_entries_per_frame": [
+    976,
+    3048,
+    6944,
+    13240,
+    22512,
+    35336,
+    52288
+  ],
   "sizes": [
     3,
     4,

--- a/scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
+++ b/scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
@@ -207,6 +207,7 @@ def main() -> int:
     full_sig = Counter()
     per_L = {}
     uniform = {}
+    mag_uniform = {}
     carrier_ok = True
     carrier_sig_ok = True
     carrier_sets = set()
@@ -226,7 +227,7 @@ def main() -> int:
                 m = dof_perm(L, index, FRAMES[k])
                 sextet_max = max(sextet_max, float(np.abs(Q[np.ix_(m, m)] - Q).max()))
         rec = []
-        mag = Counter()
+        mag_rec = []
         for k in mixed:
             m = dof_perm(L, index, FRAMES[k])
             perm_ok = perm_ok and len(np.unique(m)) == len(m)
@@ -262,11 +263,17 @@ def main() -> int:
             for (ca, cb) in pairs:
                 sigc[(SUP[ca], SUP[cb])] += 1
             carrier_sig_ok = carrier_sig_ok and dict(sigc) == CARRIER_SIG
+            one_mag = []
             for name, target, _, _ in MAG_LAW:
-                mag[name] += int((np.abs(e["av"] - target) < TOL_W).sum())
+                mask = np.abs(e["av"] - target) < TOL_W
+                one_mag.append((name, int((mask & (v > 0)).sum()),
+                                int((mask & (v < 0)).sum())))
+            mag_rec.append(tuple(one_mag))
         uniform[L] = len(set(rec)) == 1
+        mag_uniform[L] = (len(set(mag_rec)) == 1
+                          and all(pos == neg for _, pos, neg in mag_rec[0]))
         per_L[L] = rec[0]
-        mag_counts[L] = {n: mag[n] // (2 * len(mixed)) for n, _, _, _ in MAG_LAW}
+        mag_counts[L] = {name: pos for name, pos, _ in mag_rec[0]}
         del Q, model
 
     check("g01_sextet_defect_ceiling", sextet_max < SEXTET_BOUND,
@@ -302,9 +309,9 @@ def main() -> int:
     check("g11_sign_balance",
           all(r[0] == r[1] and r[2] == r[3] for r in per_L.values()),
           "plus and minus counts equal for both weights at every size")
-    check("g12_frame_uniform", all(uniform.values()),
-          "per-frame weight counts identical across the {} mixed "
-          "frames at every size".format(len(mixed)))
+    check("g12_frame_uniform", all(uniform.values()) and all(mag_uniform.values()),
+          "per-frame weight and magnitude-resolved sign counts identical "
+          "across the {} mixed frames at every size".format(len(mixed)))
 
     full_meas = [per_L[L][2] for L in L_ALL]
     half_meas = [per_L[L][0] for L in L_ALL]

--- a/scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
+++ b/scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
@@ -1,0 +1,405 @@
+"""Cycle 713 -- assembly-defect weight law and complete census (open-boundary box).
+
+Cycle `physical_mixed_frame_comparator_exact_stencil_swap_law_cycle711_2026_08_02`
+recorded the mixed-frame assembly-defect census as measured, not derived, and
+cycle `physical_mixed_frame_defect_census_family_law_cycle712_2026_08_02`
+derived the counts of the six entry families above the census cut while taking
+the four defect magnitudes {2, 2*sqrt(2), 2*sqrt(3), 4} as a measured menu.
+This runner derives the menu and completes the census.
+
+Let v_i be the spatial direction vector of the coframe variable i in the
+cycle-696 open compiler chain and s_i = |v_i|^2 its support (1 for the three
+axis directions, 2 for the six face diagonals, 3 for the body diagonal), and
+let LT = 2 be the tick length of the landed 3+1 module.  For every proper
+rotation R outside the constant-sign sextet, and every box size L, EVERY
+nonzero entry of the assembly defect E = Q[m, m] - Q obeys the weight law
+
+    |E_ij| = w * LT * |v_i| * |v_j| = w * LT * sqrt(s_i s_j),   w in {1, 1/2},
+
+with half weight w = 1/2 occurring exactly on axis-axis (support (1,1)) pairs.
+The four magnitudes above the cut are the four realized values of LT|v_i||v_j|;
+the support signatures (2,3), (3,2) and (3,3) are never realized.  The census
+then holds at three polynomials, per mixed frame and frame-uniform:
+
+    full weight, per sign : 48(L-1)^3 + 8(L-1)^2 + 4(L-1)
+    half weight, per sign : 16(L-1)^2
+    nonzero entries       : 96(L-1)^3 + 48(L-1)^2 + 8(L-1)
+
+so the defect carries a bulk density of exactly 96 entries per unit cell, a
+surface term, and an edge term -- a re-anchoring of the box boundary can move
+at most the two subleading terms.  The cycle-711 cut at 2.0 is exactly the
+full/half separator (largest half magnitude 1, smallest full magnitude 2).
+The laws are fitted on L in {3, 4, 5, 6} and tested against L = 7, 8 and 9,
+which no earlier cycle measured, and against the landed cycle-711 per-sign
+census totals at L = 3 and L = 7.  All computational identities below are
+recomputed from the cycle-696 compiler chain in this run.  An additive
+alternative LT*sqrt(s_i + s_j), a shuffled support assignment, and a
+perturbed operator all fail the weight law by wide margins.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import sys
+from collections import Counter
+from pathlib import Path
+
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(HERE))
+_MODULE = HERE / "physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py"
+_SPEC = importlib.util.spec_from_file_location("c696_compiler_for_c713", _MODULE)
+c696 = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(c696)
+
+FRAMES = [np.asarray(m, dtype=np.int64) for m in c696.c576.FRAMES]
+SPC = tuple(c696.SPATIAL_CLASSES)
+DIRV = {c: np.asarray(c696.regge.DIRS15[c][:3], dtype=np.int64) for c in SPC}
+SUP = {c: int(np.abs(DIRV[c]).sum()) for c in SPC}
+LT = int(c696.LT)
+
+L_FIT = (3, 4, 5, 6)          # law-fitting sizes
+L_HELD = (7, 8, 9)            # held-out sizes measured by no earlier cycle
+L_ALL = L_FIT + L_HELD
+ZERO = 1e-9                   # nonzero-entry floor on |E|
+TOL_W = 2e-7                  # weight-law tolerance (finite-difference scale)
+CUT = 2.0                     # census cut of the landed cycle-711 note
+SEXTET_BOUND = 1e-9
+ADD_FLOOR = 0.5               # additive-alternative rejector floor
+PERT = 1.7                    # perturbed-operator rejector step
+CARRIER = 30                  # ordered class pairs carrying full-weight entries
+ANCHOR_FULL = {3: 424, 7: 10680}   # cycle-711 per-sign census totals
+SIG_FULL = ((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1))
+SIG_ABSENT = ((2, 3), (3, 2), (3, 3))
+CARRIER_SIG = {(1, 1): 8, (1, 2): 7, (2, 1): 7, (1, 3): 2, (3, 1): 2, (2, 2): 4}
+MAG_LAW = (
+    ("four", 4.0, lambda L: 8 * (L - 1) ** 3, "8(L-1)^3"),
+    ("two_rt3", 2.0 * math.sqrt(3.0), lambda L: 8 * (L - 1) ** 3, "8(L-1)^3"),
+    ("two_rt2", 2.0 * math.sqrt(2.0),
+     lambda L: 12 * (L - 1) ** 3 + 16 * (L - 1) ** 2, "12(L-1)^3+16(L-1)^2"),
+    ("two", 2.0,
+     lambda L: 20 * (L - 1) ** 3 - 8 * (L - 1) ** 2 + 4 * (L - 1),
+     "20(L-1)^3-8(L-1)^2+4(L-1)"),
+)
+
+RECEIPT_NAME = ("physical_defect_weight_law_and_complete_census_cycle713"
+                "_2026_08_02_receipt_2026-08-02.json")
+
+N_PASS = 0
+N_FAIL = 0
+GATES: dict = {}
+NOTES: dict = {}
+
+
+def fmt(x) -> str:
+    return "{:.1e}".format(float(x))
+
+
+def check(name: str, ok: bool, detail: str = "") -> bool:
+    """Record and print one gate.  The census gates compare recomputed integer
+    counts exactly; the weight-law gates carry an additive-alternative floor, a
+    shuffled-support rejector and a perturbed-operator rejector, so a wrong
+    magnitude rule cannot pass them."""
+    global N_PASS, N_FAIL
+    ok = bool(ok)
+    if ok:
+        N_PASS += 1
+    else:
+        N_FAIL += 1
+    GATES[name] = {"pass": ok, "detail": detail}
+    print("{} {} {}".format("PASS" if ok else "FAIL", name, detail))
+    return ok
+
+
+def constant_sign(R: np.ndarray) -> bool:
+    nz = R[R != 0]
+    return bool(np.all(nz == 1) or np.all(nz == -1))
+
+
+def dof_perm(L: int, index: dict, R: np.ndarray) -> np.ndarray:
+    """Frame relabelling of the coframe variables induced by the rotation R."""
+    smap = c696.frame_site_map(L, R)
+    dir2class = {tuple(int(t) for t in DIRV[c]): c for c in SPC}
+    m = np.empty(len(index), dtype=np.int64)
+    for (c, x), i in index.items():
+        w = R @ DIRV[c]
+        vp = tuple(int(t) for t in np.abs(w))
+        xp = tuple(int(t) for t in (np.asarray(smap[x], dtype=np.int64)
+                                    + np.minimum(w, 0)))
+        m[i] = index[(dir2class[vp], xp)]
+    return m
+
+
+def class_vector(index: dict) -> np.ndarray:
+    cls = np.empty(len(index), dtype=np.int64)
+    for (c, x), i in index.items():
+        cls[i] = c
+    return cls
+
+
+def entries(Q, cls, m, sup):
+    """Nonzero defect entries with their support signature and weight split."""
+    E = Q[np.ix_(m, m)] - Q
+    ii, jj = np.nonzero(np.abs(E) > ZERO)
+    val = E[ii, jj]
+    av = np.abs(val)
+    si = sup[cls[ii]]
+    sj = sup[cls[jj]]
+    full = LT * np.sqrt(si * sj)
+    isf = np.abs(av - full) < TOL_W
+    ish = np.abs(av - full / 2.0) < TOL_W
+    return {"i": ii, "j": jj, "val": val, "av": av, "si": si, "sj": sj,
+            "full": full, "isf": isf, "ish": ish,
+            "dev": np.minimum(np.abs(av - full), np.abs(av - full / 2.0))}
+
+
+def cubic_from(vals):
+    """Exact integer Lagrange fit of a cubic in L through L_FIT, evaluated at L."""
+    xs = list(L_FIT)
+
+    def at(L):
+        tot = 0.0
+        for a in range(4):
+            t = float(vals[a])
+            for b in range(4):
+                if b != a:
+                    t *= (L - xs[b]) / (xs[a] - xs[b])
+            tot += t
+        return int(round(tot))
+    return at
+
+
+def main() -> int:
+    supmax = max(SPC) + 1
+    sup = np.zeros(supmax, dtype=np.int64)
+    for c in SPC:
+        sup[c] = SUP[c]
+    mixed = [k for k, R in enumerate(FRAMES) if not constant_sign(R)]
+    sextet = [k for k, R in enumerate(FRAMES) if constant_sign(R)]
+
+    print("== cycle 713: assembly-defect weight law and complete census ==")
+    print("config: LT={} supports={} fit L={} held-out L={} mixed_frames={} of {} "
+          "fd_step={} tol={} cut={}".format(
+              LT, tuple(sorted(set(SUP.values()))), L_FIT, L_HELD, len(mixed),
+              len(FRAMES), fmt(c696.FD_H), fmt(TOL_W), fmt(CUT)))
+
+    dev_all = 0.0
+    unclassified = 0
+    add_gap = []
+    half_sig = Counter()
+    full_sig = Counter()
+    per_L = {}
+    uniform = {}
+    carrier_ok = True
+    carrier_sig_ok = True
+    mag_counts = {}
+    sextet_max = 0.0
+    scanned = 0
+    perm_ok = True
+    half_max = 0.0
+    full_min = float("inf")
+
+    for L in L_ALL:
+        model = c696.assemble_static_hessian(L, wrap=False)
+        Q, index = model["Q"], model["index"]
+        cls = class_vector(index)
+        if L == L_FIT[0]:
+            for k in sextet:
+                m = dof_perm(L, index, FRAMES[k])
+                sextet_max = max(sextet_max, float(np.abs(Q[np.ix_(m, m)] - Q).max()))
+        rec = []
+        mag = Counter()
+        for k in mixed:
+            m = dof_perm(L, index, FRAMES[k])
+            perm_ok = perm_ok and len(np.unique(m)) == len(m)
+            e = entries(Q, cls, m, sup)
+            scanned += int(e["av"].size)
+            good = e["isf"] | e["ish"]
+            unclassified += int((~good).sum())
+            dev_all = max(dev_all, float(e["dev"].max()) if e["av"].size else 0.0)
+            if e["ish"].any():
+                half_max = max(half_max, float(e["av"][e["ish"]].max()))
+            if e["isf"].any():
+                full_min = min(full_min, float(e["av"][e["isf"]].min()))
+            add = LT * np.sqrt(e["si"] + e["sj"])
+            sel = (np.abs(e["full"] - add) > ZERO) & e["isf"]
+            if sel.any():
+                add_gap.append(float(np.abs(e["av"][sel] - add[sel]).min()))
+            for a, b in zip(e["si"][e["ish"]], e["sj"][e["ish"]]):
+                half_sig[(int(a), int(b))] += 1
+            for a, b in zip(e["si"][e["isf"]], e["sj"][e["isf"]]):
+                full_sig[(int(a), int(b))] += 1
+            v = e["val"]
+            rec.append((int((e["ish"] & (v > 0)).sum()),
+                        int((e["ish"] & (v < 0)).sum()),
+                        int((e["isf"] & (v > 0)).sum()),
+                        int((e["isf"] & (v < 0)).sum()),
+                        int((e["av"] > CUT).sum())))
+            pairs = Counter()
+            for a, b in zip(cls[e["i"][e["isf"]]], cls[e["j"][e["isf"]]]):
+                pairs[(int(a), int(b))] += 1
+            carrier_ok = carrier_ok and len(pairs) == CARRIER
+            sigc = Counter()
+            for (ca, cb) in pairs:
+                sigc[(SUP[ca], SUP[cb])] += 1
+            carrier_sig_ok = carrier_sig_ok and dict(sigc) == CARRIER_SIG
+            for name, target, _, _ in MAG_LAW:
+                mag[name] += int((np.abs(e["av"] - target) < TOL_W).sum())
+        uniform[L] = len(set(rec)) == 1
+        per_L[L] = rec[0]
+        mag_counts[L] = {n: mag[n] // (2 * len(mixed)) for n, _, _, _ in MAG_LAW}
+        del Q, model
+
+    check("g01_sextet_defect_zero", sextet_max < SEXTET_BOUND,
+          "max defect below {} on all {} constant-sign frames".format(
+              fmt(SEXTET_BOUND), len(sextet)))
+    check("g02_frame_relabel_bijective", perm_ok,
+          "frame relabelling is a permutation of the coframe variables")
+    check("g03_complete_classification", unclassified == 0,
+          "all {} nonzero entries obey |E| = w*LT*sqrt(s_i s_j), w in "
+          "(1, 1/2); unclassified {}".format(scanned, unclassified))
+    check("g04_weight_law_dev", dev_all < TOL_W,
+          "max weight-law deviation {}".format(fmt(dev_all)))
+    check("g05_half_signature_axis_only", set(half_sig) == {(1, 1)},
+          "half weight occurs only on axis-axis pairs, signature set "
+          "{}".format(sorted(half_sig)))
+    check("g06_full_signatures", tuple(sorted(full_sig)) == SIG_FULL,
+          "realized full signatures {}".format(sorted(full_sig)))
+    check("g07_absent_signatures",
+          all(s not in full_sig and s not in half_sig for s in SIG_ABSENT),
+          "signatures {} are never realized".format(list(SIG_ABSENT)))
+    check("g08_additive_rejector", min(add_gap) >= ADD_FLOOR,
+          "additive alternative LT*sqrt(s_i+s_j) misses by at least "
+          "{:.2f} where it differs".format(min(add_gap)))
+    check("g09_full_half_gap", half_max < CUT <= full_min,
+          "largest half-weight magnitude {} below the cycle-711 cut {}, "
+          "smallest full-weight magnitude {}".format(
+              fmt(half_max), fmt(CUT), fmt(full_min)))
+    check("g10_cut_is_weight_separator",
+          all(r[4] == r[2] + r[3] for r in per_L.values()),
+          "entries above the cycle-711 cut equal the full-weight entries "
+          "at every size and frame")
+    check("g11_sign_balance",
+          all(r[0] == r[1] and r[2] == r[3] for r in per_L.values()),
+          "plus and minus counts equal for both weights at every size")
+    check("g12_frame_uniform", all(uniform.values()),
+          "per-frame weight counts identical across the {} mixed "
+          "frames at every size".format(len(mixed)))
+
+    full_meas = [per_L[L][2] for L in L_ALL]
+    half_meas = [per_L[L][0] for L in L_ALL]
+    tot_meas = [2 * (per_L[L][0] + per_L[L][2]) for L in L_ALL]
+    full_law = [48 * (L - 1) ** 3 + 8 * (L - 1) ** 2 + 4 * (L - 1) for L in L_ALL]
+    half_law = [16 * (L - 1) ** 2 for L in L_ALL]
+    tot_law = [96 * (L - 1) ** 3 + 48 * (L - 1) ** 2 + 8 * (L - 1) for L in L_ALL]
+    check("g13_full_law", full_meas == full_law,
+          "full per sign L={}: {} = 48(L-1)^3+8(L-1)^2+4(L-1)".format(
+              L_ALL, full_meas))
+    check("g14_half_law", half_meas == half_law,
+          "half per sign L={}: {} = 16(L-1)^2".format(L_ALL, half_meas))
+    check("g15_total_law", tot_meas == tot_law,
+          "nonzeros per frame L={}: {} = 96(L-1)^3+48(L-1)^2+8(L-1)".format(
+              L_ALL, tot_meas))
+
+    fit_full = cubic_from([per_L[L][2] for L in L_FIT])
+    fit_tot = cubic_from([2 * (per_L[L][0] + per_L[L][2]) for L in L_FIT])
+    check("g16_heldout_full",
+          all(fit_full(L) == per_L[L][2] for L in L_HELD),
+          "cubic fitted on L={} predicts full per sign at L={}: {}".format(
+              L_FIT, L_HELD, [fit_full(L) for L in L_HELD]))
+    check("g17_heldout_total",
+          all(fit_tot(L) == 2 * (per_L[L][0] + per_L[L][2]) for L in L_HELD),
+          "cubic fitted on L={} predicts nonzeros per frame at L={}: {}".format(
+              L_FIT, L_HELD, [fit_tot(L) for L in L_HELD]))
+    check("g18_census_anchor",
+          all(per_L[L][2] == ANCHOR_FULL[L] for L in ANCHOR_FULL),
+          "full per sign {} at L={} (cycle-711 census totals)".format(
+              [ANCHOR_FULL[L] for L in sorted(ANCHOR_FULL)],
+              sorted(ANCHOR_FULL)))
+
+    for name, _, poly, text in MAG_LAW:
+        got = [mag_counts[L][name] for L in L_ALL]
+        want = [poly(L) for L in L_ALL]
+        check("g19_mag_{}".format(name), got == want,
+              "per sign L={}: {} = {}".format(L_ALL, got, text))
+    check("g20_magnitudes_sum",
+          all(sum(mag_counts[L].values()) == per_L[L][2] for L in L_ALL),
+          "the four full magnitudes partition the full-weight population")
+    check("g21_carrier_size", carrier_ok,
+          "{} ordered class pairs carry the full-weight entries, at every "
+          "size and frame".format(CARRIER))
+    check("g22_carrier_signature", carrier_sig_ok,
+          "carrier support signatures {}".format(
+              {str(k): v for k, v in sorted(CARRIER_SIG.items())}))
+
+    L = L_FIT[1]
+    model = c696.assemble_static_hessian(L, wrap=False)
+    Q, index = model["Q"], model["index"]
+    cls = class_vector(index)
+    m = dof_perm(L, index, FRAMES[mixed[0]])
+    shuf = sup.copy()
+    shuf[1], shuf[13] = sup[13], sup[1]
+    e_sh = entries(Q, cls, m, shuf)
+    check("g23_support_shuffle_rejector", int((~(e_sh["isf"] | e_sh["ish"])).sum()) > 0,
+          "swapping the axis and body-diagonal supports leaves {} entries "
+          "outside the weight law".format(
+              int((~(e_sh["isf"] | e_sh["ish"])).sum())))
+    n = Q.shape[0]
+    d = np.arange(n)
+    Qu = Q.copy()
+    Qu[d, d] += PERT
+    e_u = entries(Qu, cls, m, sup)
+    check("g24_uniform_shift_invariance",
+          float(np.abs(np.abs(Qu[np.ix_(m, m)] - Qu) - np.abs(Q[np.ix_(m, m)] - Q)).max()) < ZERO
+          and int(e_u["av"].size) == int(entries(Q, cls, m, sup)["av"].size),
+          "a uniform {:.1f} diagonal shift leaves the defect unchanged, "
+          "because the frame relabelling is a permutation".format(PERT))
+    Qr = Q.copy()
+    Qr[d, d] += PERT * d / float(n)
+    e_r = entries(Qr, cls, m, sup)
+    bad = ~(e_r["isf"] | e_r["ish"])
+    check("g25_ramp_rejector", int(bad.sum()) > 0,
+          "a site-graded diagonal ramp of height {:.1f}, which the relabelling "
+          "does not commute with, leaves {} entries outside the weight "
+          "law".format(PERT, int(bad.sum())))
+
+    NOTES["weight_law"] = "|E_ij| = w * LT * sqrt(s_i s_j), w in (1, 1/2)"
+    NOTES["full_per_sign_poly"] = "48(L-1)^3 + 8(L-1)^2 + 4(L-1)"
+    NOTES["half_per_sign_poly"] = "16(L-1)^2"
+    NOTES["nonzeros_per_frame_poly"] = "96(L-1)^3 + 48(L-1)^2 + 8(L-1)"
+    NOTES["magnitude_polys"] = {n: t for n, _, _, t in MAG_LAW}
+    NOTES["half_max"] = fmt(half_max)
+    NOTES["full_min"] = fmt(full_min)
+    NOTES["carrier_pairs"] = CARRIER
+
+    receipt = {
+        "cycle": 713,
+        "object": "assembly-defect weight law and complete census",
+        "LT": LT,
+        "supports": {str(c): SUP[c] for c in SPC},
+        "mixed_frames": len(mixed),
+        "sizes": list(L_ALL),
+        "full_per_sign": full_meas,
+        "half_per_sign": half_meas,
+        "nonzeros_per_frame": tot_meas,
+        "weight_law_dev": fmt(dev_all),
+        "additive_gap": "{:.2f}".format(min(add_gap)),
+        "entries_scanned": scanned,
+        "gates": GATES,
+        "notes": NOTES,
+        "pass": N_PASS,
+        "fail": N_FAIL,
+    }
+    out = ROOT / "outputs" / RECEIPT_NAME
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+    print("receipt: outputs/{}".format(RECEIPT_NAME))
+    print("TOTAL: PASS={} FAIL={}".format(N_PASS, N_FAIL))
+    return 0 if N_FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
+++ b/scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
@@ -211,6 +211,7 @@ def main() -> int:
     carrier_ok = True
     carrier_sig_ok = True
     carrier_sets = set()
+    carrier_sets_by_L = {}
     mag_counts = {}
     sextet_max = 0.0
     scanned = 0
@@ -228,6 +229,7 @@ def main() -> int:
                 sextet_max = max(sextet_max, float(np.abs(Q[np.ix_(m, m)] - Q).max()))
         rec = []
         mag_rec = []
+        one_L_carrier_sets = set()
         for k in mixed:
             m = dof_perm(L, index, FRAMES[k])
             perm_ok = perm_ok and len(np.unique(m)) == len(m)
@@ -259,6 +261,7 @@ def main() -> int:
                 pairs[(int(a), int(b))] += 1
             carrier_ok = carrier_ok and len(pairs) == CARRIER
             carrier_sets.add(tuple(sorted(pairs)))
+            one_L_carrier_sets.add(tuple(sorted(pairs)))
             sigc = Counter()
             for (ca, cb) in pairs:
                 sigc[(SUP[ca], SUP[cb])] += 1
@@ -274,6 +277,7 @@ def main() -> int:
                           and all(pos == neg for _, pos, neg in mag_rec[0]))
         per_L[L] = rec[0]
         mag_counts[L] = {name: pos for name, pos, _ in mag_rec[0]}
+        carrier_sets_by_L[L] = one_L_carrier_sets
         del Q, model
 
     check("g01_sextet_defect_ceiling", sextet_max < SEXTET_BOUND,
@@ -356,7 +360,8 @@ def main() -> int:
     check("g21_carrier_size", carrier_ok,
           "{} ordered class pairs carry the full-weight entries, at every "
           "size and frame".format(CARRIER))
-    check("g22_carrier_signature", carrier_sig_ok and len(carrier_sets) == 3,
+    check("g22_carrier_signature", carrier_sig_ok and len(carrier_sets) == 3
+          and all(len(sets) == 3 for sets in carrier_sets_by_L.values()),
           "carrier support signatures {}, with {} frame-dependent identity "
           "sets".format({str(k): v for k, v in sorted(CARRIER_SIG.items())},
                          len(carrier_sets)))

--- a/scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
+++ b/scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
@@ -11,8 +11,9 @@ Let v_i be the spatial direction vector of the coframe variable i in the
 cycle-696 open compiler chain and s_i = |v_i|^2 its support (1 for the three
 axis directions, 2 for the six face diagonals, 3 for the body diagonal), and
 let LT = 2 be the tick length of the landed 3+1 module.  For every proper
-rotation R outside the constant-sign sextet, and every box size L, EVERY
-nonzero entry of the assembly defect E = Q[m, m] - Q obeys the weight law
+rotation R outside the constant-sign sextet, and every scanned box size L,
+EVERY resolved entry of the assembly defect E = Q[m, m] - Q, meaning
+|E_ij| > 1e-9, obeys the weight law
 
     |E_ij| = w * LT * |v_i| * |v_j| = w * LT * sqrt(s_i s_j),   w in {1, 1/2},
 
@@ -23,7 +24,7 @@ then holds at three polynomials, per mixed frame and frame-uniform:
 
     full weight, per sign : 48(L-1)^3 + 8(L-1)^2 + 4(L-1)
     half weight, per sign : 16(L-1)^2
-    nonzero entries       : 96(L-1)^3 + 48(L-1)^2 + 8(L-1)
+    resolved entries      : 96(L-1)^3 + 48(L-1)^2 + 8(L-1)
 
 so the finite census agrees with a cubic leading coefficient of 96, a
 quadratic term, and a linear term at the scanned sizes.  No alternative
@@ -77,7 +78,7 @@ LT = int(c696.LT)
 L_FIT = (3, 4, 5, 6)          # law-fitting sizes
 L_HELD = (7, 8, 9)            # held-out sizes measured by no earlier cycle
 L_ALL = L_FIT + L_HELD
-ZERO = 1e-9                   # nonzero-entry floor on |E|
+ZERO = 1e-9                   # resolved-entry floor on |E|
 TOL_W = 2e-7                  # weight-law tolerance (finite-difference scale)
 CUT = 2.0                     # census cut of the landed cycle-711 note
 SEXTET_BOUND = 1e-9
@@ -154,7 +155,7 @@ def class_vector(index: dict) -> np.ndarray:
 
 
 def entries(Q, cls, m, sup):
-    """Nonzero defect entries with their support signature and weight split."""
+    """Resolved defect entries with their support signature and weight split."""
     E = Q[np.ix_(m, m)] - Q
     ii, jj = np.nonzero(np.abs(E) > ZERO)
     val = E[ii, jj]
@@ -208,6 +209,7 @@ def main() -> int:
     uniform = {}
     carrier_ok = True
     carrier_sig_ok = True
+    carrier_sets = set()
     mag_counts = {}
     sextet_max = 0.0
     scanned = 0
@@ -255,6 +257,7 @@ def main() -> int:
             for a, b in zip(cls[e["i"][e["isf"]]], cls[e["j"][e["isf"]]]):
                 pairs[(int(a), int(b))] += 1
             carrier_ok = carrier_ok and len(pairs) == CARRIER
+            carrier_sets.add(tuple(sorted(pairs)))
             sigc = Counter()
             for (ca, cb) in pairs:
                 sigc[(SUP[ca], SUP[cb])] += 1
@@ -272,8 +275,9 @@ def main() -> int:
     check("g02_frame_relabel_bijective", perm_ok,
           "frame relabelling is a permutation of the coframe variables")
     check("g03_complete_classification", unclassified == 0,
-          "all {} nonzero entries obey |E| = w*LT*sqrt(s_i s_j), w in "
-          "(1, 1/2); unclassified {}".format(scanned, unclassified))
+          "all {} resolved entries above {} obey |E| = w*LT*sqrt(s_i s_j), "
+          "w in (1, 1/2); unclassified {}".format(
+              scanned, fmt(ZERO), unclassified))
     check("g04_weight_law_dev", dev_all < TOL_W,
           "max weight-law deviation {}".format(fmt(dev_all)))
     check("g05_half_signature_axis_only", set(half_sig) == {(1, 1)},
@@ -314,7 +318,8 @@ def main() -> int:
     check("g14_half_law", half_meas == half_law,
           "half per sign L={}: {} = 16(L-1)^2".format(L_ALL, half_meas))
     check("g15_total_law", tot_meas == tot_law,
-          "nonzeros per frame L={}: {} = 96(L-1)^3+48(L-1)^2+8(L-1)".format(
+          "resolved entries per frame L={}: {} = "
+          "96(L-1)^3+48(L-1)^2+8(L-1)".format(
               L_ALL, tot_meas))
 
     fit_full = cubic_from([per_L[L][2] for L in L_FIT])
@@ -325,7 +330,7 @@ def main() -> int:
               L_FIT, L_HELD, [fit_full(L) for L in L_HELD]))
     check("g17_heldout_total",
           all(fit_tot(L) == 2 * (per_L[L][0] + per_L[L][2]) for L in L_HELD),
-          "cubic fitted on L={} predicts nonzeros per frame at L={}: {}".format(
+          "cubic fitted on L={} predicts resolved entries per frame at L={}: {}".format(
               L_FIT, L_HELD, [fit_tot(L) for L in L_HELD]))
     check("g18_census_anchor",
           all(per_L[L][2] == ANCHOR_FULL[L] for L in ANCHOR_FULL),
@@ -344,9 +349,10 @@ def main() -> int:
     check("g21_carrier_size", carrier_ok,
           "{} ordered class pairs carry the full-weight entries, at every "
           "size and frame".format(CARRIER))
-    check("g22_carrier_signature", carrier_sig_ok,
-          "carrier support signatures {}".format(
-              {str(k): v for k, v in sorted(CARRIER_SIG.items())}))
+    check("g22_carrier_signature", carrier_sig_ok and len(carrier_sets) == 3,
+          "carrier support signatures {}, with {} frame-dependent identity "
+          "sets".format({str(k): v for k, v in sorted(CARRIER_SIG.items())},
+                         len(carrier_sets)))
 
     L = L_FIT[1]
     model = c696.assemble_static_hessian(L, wrap=False)
@@ -382,11 +388,12 @@ def main() -> int:
     NOTES["weight_law"] = "|E_ij| = w * LT * sqrt(s_i s_j), w in (1, 1/2)"
     NOTES["full_per_sign_poly"] = "48(L-1)^3 + 8(L-1)^2 + 4(L-1)"
     NOTES["half_per_sign_poly"] = "16(L-1)^2"
-    NOTES["nonzeros_per_frame_poly"] = "96(L-1)^3 + 48(L-1)^2 + 8(L-1)"
+    NOTES["resolved_entries_per_frame_poly"] = "96(L-1)^3 + 48(L-1)^2 + 8(L-1)"
     NOTES["magnitude_polys"] = {n: t for n, _, _, t in MAG_LAW}
     NOTES["half_max"] = fmt(half_max)
     NOTES["full_min"] = fmt(full_min)
     NOTES["carrier_pairs"] = CARRIER
+    NOTES["carrier_identity_sets"] = len(carrier_sets)
 
     receipt = {
         "cycle": 713,
@@ -397,7 +404,7 @@ def main() -> int:
         "sizes": list(L_ALL),
         "full_per_sign": full_meas,
         "half_per_sign": half_meas,
-        "nonzeros_per_frame": tot_meas,
+        "resolved_entries_per_frame": tot_meas,
         "weight_law_dev": fmt(dev_all),
         "additive_gap": "{:.2f}".format(min(add_gap)),
         "entries_scanned": scanned,

--- a/scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
+++ b/scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
@@ -9,7 +9,7 @@ This runner derives the menu and completes the census.
 
 Let v_i be the spatial direction vector of the coframe variable i in the
 cycle-696 open compiler chain and s_i = |v_i|^2 its support (1 for the three
-axis directions, 2 for the six face diagonals, 3 for the body diagonal), and
+axis directions, 2 for the three admitted face diagonals, 3 for the body diagonal), and
 let LT = 2 be the tick length of the landed 3+1 module.  For every proper
 rotation R outside the constant-sign sextet, and every scanned box size L,
 EVERY resolved entry of the assembly defect E = Q[m, m] - Q, meaning
@@ -87,7 +87,7 @@ PERT = 1.7                    # perturbed-operator rejector step
 CARRIER = 30                  # ordered class pairs carrying full-weight entries
 ANCHOR_FULL = {3: 424, 7: 10680}   # cycle-711 per-sign census totals
 SIG_FULL = ((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1))
-SIG_ABSENT = ((2, 3), (3, 2), (3, 3))
+SIG_UNREALIZED = ((2, 3), (3, 2), (3, 3))
 CARRIER_SIG = {(1, 1): 8, (1, 2): 7, (2, 1): 7, (1, 3): 2, (3, 1): 2, (2, 2): 4}
 MAG_LAW = (
     ("four", 4.0, lambda L: 8 * (L - 1) ** 3, "8(L-1)^3"),
@@ -116,7 +116,7 @@ def check(name: str, ok: bool, detail: str = "") -> bool:
     """Record and print one gate.  The census gates compare recomputed integer
     counts exactly; the weight-law gates carry an additive-alternative floor, a
     shuffled-support rejector and a perturbed-operator rejector, so a wrong
-    magnitude rule cannot pass them."""
+    magnitude rule is rejected."""
     global N_PASS, N_FAIL
     ok = bool(ok)
     if ok:
@@ -285,9 +285,9 @@ def main() -> int:
           "{}".format(sorted(half_sig)))
     check("g06_full_signatures", tuple(sorted(full_sig)) == SIG_FULL,
           "realized full signatures {}".format(sorted(full_sig)))
-    check("g07_absent_signatures",
-          all(s not in full_sig and s not in half_sig for s in SIG_ABSENT),
-          "signatures {} are never realized".format(list(SIG_ABSENT)))
+    check("g07_signature_set_complete",
+          all(s not in full_sig and s not in half_sig for s in SIG_UNREALIZED),
+          "realized signature set is exactly {}".format(list(SIG_FULL)))
     check("g08_additive_rejector", min(add_gap) >= ADD_FLOOR,
           "additive alternative LT*sqrt(s_i+s_j) misses by at least "
           "{:.2f} where it differs".format(min(add_gap)))
@@ -381,8 +381,8 @@ def main() -> int:
     e_r = entries(Qr, cls, m, sup)
     bad = ~(e_r["isf"] | e_r["ish"])
     check("g25_ramp_rejector", int(bad.sum()) > 0,
-          "a site-graded diagonal ramp of height {:.1f}, which the relabelling "
-          "does not commute with, leaves {} entries outside the weight "
+          "a site-graded diagonal ramp of height {:.1f}, noncommuting with the "
+          "relabeling, leaves {} entries outside the weight "
           "law".format(PERT, int(bad.sum())))
 
     NOTES["weight_law"] = "|E_ij| = w * LT * sqrt(s_i s_j), w in (1, 1/2)"

--- a/scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
+++ b/scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py
@@ -25,10 +25,11 @@ then holds at three polynomials, per mixed frame and frame-uniform:
     half weight, per sign : 16(L-1)^2
     nonzero entries       : 96(L-1)^3 + 48(L-1)^2 + 8(L-1)
 
-so the defect carries a bulk density of exactly 96 entries per unit cell, a
-surface term, and an edge term -- a re-anchoring of the box boundary can move
-at most the two subleading terms.  The cycle-711 cut at 2.0 is exactly the
-full/half separator (largest half magnitude 1, smallest full magnitude 2).
+so the finite census agrees with a cubic leading coefficient of 96, a
+quadratic term, and a linear term at the scanned sizes.  No alternative
+boundary re-anchoring is constructed or tested.  The cycle-711 cut at 2.0 is
+exactly the full/half separator (largest half magnitude 1, smallest full
+magnitude 2).
 The laws are fitted on L in {3, 4, 5, 6} and tested against L = 7, 8 and 9,
 which no earlier cycle measured, and against the landed cycle-711 per-sign
 census totals at L = 3 and L = 7.  All computational identities below are
@@ -54,6 +55,18 @@ _MODULE = HERE / "physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.
 _SPEC = importlib.util.spec_from_file_location("c696_compiler_for_c713", _MODULE)
 c696 = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(c696)
+
+# The complete repository-source closure used by the imported Cycle-696
+# compiler.  The cache binds these bytes so a transitive compiler change makes
+# this result stale instead of silently reusing old output.
+AUDIT_INPUT_PATHS = (
+    "scripts/physical_open_coframe_k_endpoint_compiler_cycle696_2026_07_25.py",
+    "scripts/physical_dynamical_metric_source_law_bridge_tournament_cycle576_2026_07_22.py",
+    "scripts/physical_dynamical_metric_source_law_bridge_cycle576_regge_support_2026_07_22.py",
+    "scripts/physical_dynamical_metric_source_law_bridge_cycle576_plaquette_support_2026_07_22.py",
+    "scripts/frontier_cubic_coxeter_regge_second_variation_3plus1_2026_06_09.py",
+)
+AUDIT_TIMEOUT_SEC = 600
 
 FRAMES = [np.asarray(m, dtype=np.int64) for m in c696.c576.FRAMES]
 SPC = tuple(c696.SPATIAL_CLASSES)
@@ -253,8 +266,8 @@ def main() -> int:
         mag_counts[L] = {n: mag[n] // (2 * len(mixed)) for n, _, _, _ in MAG_LAW}
         del Q, model
 
-    check("g01_sextet_defect_zero", sextet_max < SEXTET_BOUND,
-          "max defect below {} on all {} constant-sign frames".format(
+    check("g01_sextet_defect_ceiling", sextet_max < SEXTET_BOUND,
+          "measured max defect below {} on all {} constant-sign frames at L=3".format(
               fmt(SEXTET_BOUND), len(sextet)))
     check("g02_frame_relabel_bijective", perm_ok,
           "frame relabelling is a permutation of the coframe variables")


### PR DESCRIPTION
## What this adds

Cycle 713 classifies the entries resolved by the landed Cycle-696 finite
open-box compiler across all 18 mixed frames and the explicitly scanned sizes
`L=3..9`.  It also connects the landed Cycle-710 comparator, Cycle-711 stencil
identity/census anchors, and Cycle-712 finite defect census as direct graph
dependencies.

## Bounded finite result

For entries with `|E_ij| > 1e-9`, the scan finds

> `|E_ij| = w * LT * sqrt(s_i s_j)`, with `w in {1, 1/2}` and `LT=2`,

within tolerance `2e-7`.  Across 2,418,192 resolved entries the maximum
deviation is `6.1e-08`, with no resolved entry left unclassified.  Half weight
occurs only for support signature `(1,1)`; the full-weight signatures are
exactly `(1,1)`, `(1,2)`, `(2,1)`, `(1,3)`, `(3,1)`, and `(2,2)`.

For each scanned `L`, the finite counts agree with these polynomials in
`n=L-1`:

- full weight, per sign: `48n^3 + 8n^2 + 4n`;
- half weight, per sign: `16n^2`;
- all resolved entries, both signs: `96n^3 + 48n^2 + 8n`.

The per-frame carrier has 30 ordered edge-class pairs and an invariant support
partition, while its pair identities realize three frame-dependent sets.

## Review repairs and boundary

The review removed the original universal boundary-reanchoring conclusion and
the arbitrary-size/codimension framing: no alternative transport was
constructed, and the polynomial agreement is proved here only on the seven
enumerated sizes.  It also replaced mathematical “nonzero”/“exact zero” claims
with the declared `1e-9` resolution rule, made the per-frame carrier variation
explicit, and hardened the runner so magnitude counts and carrier variants are
checked separately at every frame and size.

This PR therefore makes no arbitrary-`L`, continuum, covariance,
boundary-artifact, exact-zero, or mechanism claim.  Deriving the weight bit and
the arbitrary-size combinatorics remains open.  Independent audit remains the
only authority for a retained grade.

## Evidence

- `docs/PHYSICAL_DEFECT_WEIGHT_LAW_AND_COMPLETE_CENSUS_CYCLE713_NOTE_2026-08-02.md`
- `scripts/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.py`
  (`TOTAL: PASS=28 FAIL=0`)
- `logs/runner-cache/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02.txt`
- `outputs/physical_defect_weight_law_and_complete_census_cycle713_2026_08_02_receipt_2026-08-02.json`
- `docs/audit/data/citation_graph_manifest.json` (graph-delta acknowledgment)

The exact-current-main audit pipeline, strict lint, repository invariants,
changed-evidence readiness, hostile mutations, and an independent dense-matrix
reconstruction all pass for the bounded surface.
