### PR TITLE
fix(audit): preserve judgments during packet repair

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -502,16 +502,27 @@ current transaction can land, and a stale duplicate is discarded. Do not add
 intra-clone forensic fan-out; duplicate cross-clone attempts cost compute but
 do not weaken the N1-N8 packet or apply gates.
 
-The canary gets the bounded three-seat fresh-schema budget because distinct
-packet-completion defects can surface serially (for example, an N1 route-class
-marker mismatch followed by an N5 rhetoric-scan coverage mismatch). Coverage
-rejects require one exact N3/N5 disposition for every authenticated
+The canary gets exactly one independent scientific seat. If that prompt-bound
+judgment has a complete top-level scientific core but its N1-N8 packet is
+rejected, it may receive at most three focused packet-completion passes because
+distinct structural defects can surface serially (for example, an N1
+route-class marker mismatch followed by an N5 rhetoric-scan coverage mismatch).
+Those passes may add or replace only `no_go_discipline`; the verdict, claim
+type/scope, chain judgment, rationale, negative declaration, invocation, and
+every other top-level value remain canonically identical. The existing N1-N8
+`required` and `status` gate fields are immutable too, so completion cannot
+promote FAIL to PASS. A nonzero legacy
+fresh-schema retry budget is a hard configuration error. Coverage rejects
+require one exact N3/N5 disposition for every authenticated
 `full_phrase_groups` record on every applicable manifest path; records that
 share a group id or digest are still distinct when their phrase/path tuple is
 distinct. If that bounded budget still ends in malformed JSON or a validator
 reject, quarantine only that row for the campaign and continue to the next
-ready forensic row. That is not a landed canary and does not authorize
-forensic fan-out.
+ready forensic row. Record the typed validator code, repair class, preserved
+run-log location, scientific-seat count, and focused-completion attempt count.
+That is not a landed canary, does
+not authorize forensic fan-out, and must never be described as multiple
+scientific audits.
 
 **Seat-blocked judicial rows are reseated, never frozen and never retried
 as recorded.** A disagreement whose recorded seats lack invocation-bound
@@ -676,7 +687,7 @@ Repair and re-entry are reason-specific:
 
 | Operational result | Required repair | Re-entry |
 | --- | --- | --- |
-| `schema_invalid_quarantined` | Preserve the malformed response, exact validator errors, and any `forensic-canary-*.jsonl` artifact; correct the CLI transport schema, prompt, or bounded packet-completion defect. A failed forensic row enters this route while the worker advances through the remaining non-excluded backlog. Never edit the scientific judgment into validity. | Start a new campaign so a fresh restricted-context seat is selected. Reusing the old workdir keeps the claim excluded. |
+| `schema_invalid_quarantined` | Preserve the malformed response, exact validator errors, typed error code/class, scientific-seat count, and any `forensic-canary-*.jsonl` artifact; correct the CLI transport schema, prompt, or bounded packet-completion defect. A failed forensic row enters this route while the worker advances through the remaining non-excluded backlog. Never edit the scientific judgment into validity. | Do not immediately spend another full scientific seat. Repair the typed packet/evidence prerequisite first; use a fresh scientific seat only when the preserved judgment is absent, invalid, or cannot be proven current. Reusing the old workdir keeps the claim excluded. |
 | `compute_required_quarantined` / `compute_required` | Produce a SHA-pinned runner cache with `cached_runner_output.py`, a sliced deterministic certificate, or an independent derivation; then run the full pipeline and strict lint. | Start a new campaign after the artifact is current. |
 | `blocked_row_reentry_quarantined` | Repair the recorded classifier promotion, dependency/status cycle, note-hash drift, or other invalidation cause. Require one converged full pipeline. | Start a new campaign only after the row no longer immediately returns to the same dep-ready state. |
 | `claim_transaction_quarantined` | Fix the recorded apply, pipeline, or lint defect and prove the clean full pipeline converges. The failed delivery minted no verdict. | Use a fresh seat in a new campaign unless canonical tooling verifies an exact preserved-envelope replay against the current source/seat fingerprint. |

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -504,14 +504,17 @@ do not weaken the N1-N8 packet or apply gates.
 
 The canary gets exactly one independent scientific seat. If that prompt-bound
 judgment has a complete top-level scientific core but its N1-N8 packet is
-rejected, it may receive at most three focused packet-completion passes because
-distinct structural defects can surface serially (for example, an N1
-route-class marker mismatch followed by an N5 rhetoric-scan coverage mismatch).
-Those passes may add or replace only `no_go_discipline`; the verdict, claim
-type/scope, chain judgment, rationale, negative declaration, invocation, and
-every other top-level value remain canonically identical. The existing N1-N8
-`required` and `status` gate fields are immutable too, so completion cannot
-promote FAIL to PASS. A nonzero legacy
+rejected on citation or authenticated-occurrence mechanics, it may receive at
+most three focused packet-mechanics passes because distinct binding defects can
+surface serially (for example, an evidence-locator mismatch followed by an
+authenticated occurrence-tuple mismatch). Those passes may change only N1-N8
+evidence path/locator fields and authenticated occurrence metadata. The
+verdict, claim type/scope, chain judgment, rationale, negative declaration,
+invocation, every other top-level value, and every substantive N1-N8 route,
+wall, classification, residual match, resolution, closure, steelman, and echo
+disposition remain canonically identical. The existing N1-N8 `required` and
+`status` gate fields are immutable too, so completion cannot promote FAIL to
+PASS. A nonzero legacy
 fresh-schema retry budget is a hard configuration error. Coverage rejects
 require one exact N3/N5 disposition for every authenticated
 `full_phrase_groups` record on every applicable manifest path; records that
@@ -572,7 +575,7 @@ returned JSON that the audit contract cannot apply (for example malformed
 JSON, an incomplete N1-N8 packet, or a field whose value contradicts the
 schema). It does not show that the source claim is false or needs editing.
 
-- Every restricted Codex seat (ordinary audit, focused packet completion, and
+- Every restricted Codex seat (ordinary audit, focused packet mechanics, and
   judicial judge) must use CLI `--output-schema` with a transport-level JSON
   object schema. The canonical Python validators remain the only semantic
   schema authority; the CLI schema prevents fences/preambles/malformed JSON
@@ -582,11 +585,13 @@ schema). It does not show that the source claim is false or needs editing.
   accepts the same verdict, declaration, rationale, and every other field with
   `no_go_discipline=null`. Do this before launching completion. Never use this
   normalization for clean authority, a no-go source/type, or forensic work.
-- Give parseable N1-N8 structural-packet rejects bounded, error-specific
-  completion attempts in the same restricted seat. Preserve every top-level
-  scientific judgment; only repair the rejected structural packet. Malformed
-  JSON and other contract rejects without a narrow judgment-preserving repair
-  target go directly to the same exhausted-delivery path.
+- Give parseable N1-N8 citation/occurrence-mechanics rejects bounded,
+  error-specific correction attempts in the same restricted seat. Preserve
+  every top-level scientific judgment and every substantive N1-N8 value; only
+  repair authenticated evidence path/locator and occurrence-tuple metadata.
+  Malformed JSON, missing packet content, and other contract rejects without a
+  narrow judgment-preserving repair target go directly to the same
+  exhausted-delivery path.
 - Treat an incompatible verdict/type tuple as a schema-invalid delivery, not
   as a scientific seat. In particular, `audited_decoration` requires
   `claim_type=decoration` plus a decoration parent, while `audited_clean`

--- a/docs/audit/scripts/audit_campaign_repair.py
+++ b/docs/audit/scripts/audit_campaign_repair.py
@@ -76,14 +76,33 @@ def repair_route(
             ),
         }
     if reason == SCHEMA_QUARANTINE:
+        failure_classes = {
+            failure.get("failure_class")
+            for failure in result["failures"]
+            if isinstance(failure, dict)
+        }
+        if failure_classes == {"packet_completion_exhausted"}:
+            return {
+                **result,
+                "route": "repair_packet_completion_contract",
+                "ready_for_new_campaign": False,
+                "action": (
+                    "Keep the preserved scientific judgment non-authoritative "
+                    "but do not spend another full seat. Repair the typed "
+                    "N1-N8 packet/prompt defect named in failures and retain "
+                    "the forensic run log for fingerprint-bound packet-only "
+                    "recovery."
+                ),
+            }
         return {
             **result,
-            "route": "fresh_schema_valid_seat",
+            "route": "fresh_scientific_seat_required",
             "ready_for_new_campaign": True,
             "action": (
                 "Keep the malformed output non-authoritative. Correct the "
-                "transport/prompt defect named in failures, then start a new "
-                "campaign so a fresh restricted-context seat is selected."
+                "top-level contract defect named in failures, then start a "
+                "new campaign so a fresh restricted-context scientific seat "
+                "is selected."
             ),
         }
     if reason == COMPUTE_QUARANTINE:

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -1412,11 +1412,12 @@ def packet_completion_pass(
     validator_error: str | None = None,
     attempt: int = 1,
 ) -> dict | None:
-    """Mechanically complete or repair one structural N1-N8 packet.
+    """Mechanically correct one already-present structural N1-N8 packet.
 
     The same restricted audit seat sees only its original packet, rejected
-    JSON, and exact validator error.  Every top-level judgment remains
-    immutable; only ``no_go_discipline`` may be added or replaced.
+    JSON, and exact validator error. Every top-level and substantive N1-N8
+    judgment remains immutable; only authenticated citation/occurrence
+    mechanics may change.
     """
 
     cid = job["row"]["claim_id"]
@@ -1445,23 +1446,13 @@ def packet_completion_pass(
         "evidence. "
         f"Your audit JSON for claim {cid} is at: {blob_path}\n"
         f"{error_block}\n"
-        "Your verdict output names walls/negative boundaries, so the apply "
-        "gate requires a structural `no_go_discipline` object (development "
-        "tier). Use the N1-N8 schema in AUDIT_TASK.md and author it "
-        "SCHEMA-HONESTLY:\n"
-        "- Claim gate status PASS only if it genuinely passes: at least 5 "
-        "DISTINCT route_class values among evidenced N1 routes, every route "
-        "closed, complete N2-N8, and a resolved N7 steelman whose route_id "
-        "names an N1 route and whose evidence_path MATCHES that route's "
-        "evidence_path.\n"
-        "- Otherwise set status FAIL with the honest failures list AND the "
-        "FAIL-only fields (demotion, prior_claim_scope, narrowed_claim_scope, "
-        "corrected_wall_set, next_route). For an existing non-clean verdict, "
-        "an honest FAIL gate is legitimate and validates; an unearned PASS "
-        "does not. Preserve the existing verdict either way.\n"
-        "- Structured judgments with quoted evidence from the note/runner you "
-        "already audited (structural validation; no manifest-containment, "
-        "live-stdout, transport, or full-universe disposition plumbing).\n"
+        "The existing `no_go_discipline` object is scientific authority. "
+        "Preserve every route, wall, classification, residual match, "
+        "resolution, closure, steelman, echo disposition, required/status "
+        "gate, and all other substantive values exactly. You may correct only "
+        "evidence_path/evidence_locator citation fields and authenticated "
+        "occurrence_group_id, occurrence_count, and "
+        "occurrence_locator_sha256 metadata against AUDIT_TASK.md.\n"
         "Change NOTHING else — preserve every original field and value. "
         "Return the complete JSON as your final response: one JSON object, "
         "with no code fence or commentary."
@@ -1518,21 +1509,10 @@ def packet_completion_pass(
         return None
     if completed.get("compute_required") is None:
         completed.pop("compute_required", None)
-    packet = completed.get("no_go_discipline")
-    if not isinstance(packet, dict):
+    if not isinstance(completed.get("no_go_discipline"), dict):
         return None
 
-    # This is packet completion, not a second scientific audit: the only
-    # permitted delta is adding or replacing the structural packet.
-    expected = dict(blob)
-    expected["no_go_discipline"] = packet
-    canonical_completed = json.dumps(
-        completed, sort_keys=True, separators=(",", ":"), ensure_ascii=False
-    )
-    canonical_expected = json.dumps(
-        expected, sort_keys=True, separators=(",", ":"), ensure_ascii=False
-    )
-    if canonical_completed != canonical_expected:
+    if audit_runner.validation_repair_preservation_error(blob, completed):
         return None
     return completed
 
@@ -1661,11 +1641,15 @@ def finalize_worker(job: dict) -> tuple[dict | None, dict]:
         "transport_bounded_n8": job["transport_bound"] is not None,
     }
     error = audit_runner.validate_verdict(blob, cid, **validation_args)
+
     def _packet_error(err: object) -> bool:
         return bool(re.search(
             r"(?:\bN[1-8](?:\b|_)|No-Go Discipline|no_go_discipline)",
             str(err or ""),
         ))
+
+    def _packet_mechanics_error(err: object) -> bool:
+        return audit_runner.packet_completion_eligible_error(str(err or ""))
 
     optional_packet_dropped = False
     forensic_tier = bool(
@@ -1700,7 +1684,7 @@ def finalize_worker(job: dict) -> tuple[dict | None, dict]:
     while (
         error
         and not source_requires_no_go
-        and _packet_error(error)
+        and _packet_mechanics_error(error)
         and completion_attempt < 2
     ):
         completion_attempt += 1
@@ -1716,7 +1700,7 @@ def finalize_worker(job: dict) -> tuple[dict | None, dict]:
     if not error and blob.get("verdict") == "audited_clean" and clipped:
         error = f"audited_clean packet has clipped evidence: {clipped}"
     if error:
-        packet_error = _packet_error(error)
+        packet_error = _packet_mechanics_error(error)
         return None, {
             **base,
             "result": "validation_failed",
@@ -2535,6 +2519,11 @@ def _contains_non_finite_json_number(value: object) -> bool:
     return False
 
 
+def _campaign_validator_detail(detail: str) -> str:
+    """Remove only the campaign artifact pointer from validator detail."""
+    return detail.split("; preserved_run_log=", 1)[0]
+
+
 def _campaign_failure_schema_error(
     claim_id: str,
     reason: str,
@@ -2632,6 +2621,14 @@ def _campaign_failure_schema_error(
         error_code = failure.get("error_code")
         if not isinstance(error_code, str) or not error_code.strip():
             return "campaign exclusion failure has no error_code"
+        expected_code = audit_runner.schema_failure_code(
+            _campaign_validator_detail(str(failure["detail"]))
+        )
+        if error_code != expected_code:
+            return (
+                "campaign exclusion error_code does not match validator "
+                f"detail (expected={expected_code!r}, got={error_code!r})"
+            )
         if failure.get("failure_class") not in {
             "packet_completion_exhausted",
             "scientific_reaudit_required",

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -1716,7 +1716,19 @@ def finalize_worker(job: dict) -> tuple[dict | None, dict]:
     if not error and blob.get("verdict") == "audited_clean" and clipped:
         error = f"audited_clean packet has clipped evidence: {clipped}"
     if error:
-        return None, {**base, "result": "validation_failed", "detail": error}
+        packet_error = _packet_error(error)
+        return None, {
+            **base,
+            "result": "validation_failed",
+            "detail": error,
+            "error_code": audit_runner.schema_failure_code(str(error)),
+            "failure_class": audit_runner.validation_failure_class(
+                str(error),
+                packet_completion_eligible=packet_error,
+            ),
+            "scientific_seat_count": 1,
+            "packet_completion_attempt_count": completion_attempt,
+        }
 
     full_blob = audit_runner.add_auditor_metadata(
         blob,
@@ -2540,6 +2552,15 @@ def _campaign_failure_schema_error(
         expected = {"cid", "pass", "result"}
         if result == "validation_failed":
             expected.add("detail")
+            typed_fields = {
+                "error_code",
+                "failure_class",
+                "scientific_seat_count",
+                "packet_completion_attempt_count",
+            }
+            present_typed_fields = typed_fields & set(failure)
+            if present_typed_fields:
+                expected.update(typed_fields)
         elif result != "malformed_json":
             return (
                 "campaign exclusion failure result is incompatible with "
@@ -2607,6 +2628,26 @@ def _campaign_failure_schema_error(
         detail = failure.get("detail")
         if not isinstance(detail, str) or not detail.strip():
             return "campaign exclusion failure has no detail"
+    if "error_code" in expected:
+        error_code = failure.get("error_code")
+        if not isinstance(error_code, str) or not error_code.strip():
+            return "campaign exclusion failure has no error_code"
+        if failure.get("failure_class") not in {
+            "packet_completion_exhausted",
+            "scientific_reaudit_required",
+        }:
+            return "campaign exclusion failure has invalid failure_class"
+        if (
+            type(failure.get("scientific_seat_count")) is not int
+            or failure.get("scientific_seat_count") != 1
+        ):
+            return "campaign exclusion scientific_seat_count must be 1"
+        completion_count = failure.get("packet_completion_attempt_count")
+        if type(completion_count) is not int or not 0 <= completion_count <= 3:
+            return (
+                "campaign exclusion packet_completion_attempt_count must be "
+                "an integer from 0 through 3"
+            )
     return None
 
 

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -182,8 +182,15 @@ def forensic_mechanics_circuit(
         for failure in record.get("failures") or []:
             if not isinstance(failure, dict):
                 continue
-            signature = forensic_schema_failure_signature(
-                str(failure.get("detail") or "")
+            error_code = failure.get("error_code")
+            signature = (
+                error_code
+                if isinstance(error_code, str)
+                and error_code
+                and error_code != "AUDIT_SCHEMA_REJECT"
+                else forensic_schema_failure_signature(
+                    str(failure.get("detail") or "")
+                )
             )
             if signature is not None:
                 claims_by_signature.setdefault(signature, set()).add(claim_id)
@@ -759,17 +766,38 @@ def forensic_canary_claim_local_failure(
     if phase == "validate_failed":
         detail = str(terminal.get("error") or "").strip()
         if not detail or detail.startswith(
-            (
-                "fresh schema retry codex exec failed:",
-                "validation repair codex exec failed:",
-            )
+            "validation repair codex exec failed:"
         ):
             return None
+        error_code = terminal.get("error_code")
+        if not isinstance(error_code, str) or not error_code:
+            error_code = batch.audit_runner.schema_failure_code(detail)
+        failure_class = terminal.get("failure_class")
+        if failure_class not in {
+            "packet_completion_exhausted",
+            "scientific_reaudit_required",
+        }:
+            failure_class = batch.audit_runner.validation_failure_class(
+                detail,
+                packet_completion_eligible=(
+                    batch.audit_runner.packet_completion_eligible_error(detail)
+                ),
+            )
+        scientific_seat_count = terminal.get("scientific_seat_count")
+        if type(scientific_seat_count) is not int or scientific_seat_count != 1:
+            scientific_seat_count = 1
+        completion_count = terminal.get("packet_completion_attempt_count")
+        if type(completion_count) is not int or not 0 <= completion_count <= 3:
+            completion_count = 0
         return batch.SCHEMA_QUARANTINE_RESULT, {
             "cid": claim_id,
             "pass": 1,
             "result": "validation_failed",
             "detail": f"{detail}; preserved_run_log={run_log.name}",
+            "error_code": error_code,
+            "failure_class": failure_class,
+            "scientific_seat_count": scientific_seat_count,
+            "packet_completion_attempt_count": completion_count,
         }, 1
     if phase == "json_parse_failed":
         return batch.SCHEMA_QUARANTINE_RESULT, {
@@ -817,12 +845,7 @@ def forensic_canary_transient_diagnostic(terminal: dict | None) -> str:
         return str(terminal.get("stderr") or "")
     if phase == "validate_failed":
         error = str(terminal.get("error") or "")
-        if error.startswith(
-            (
-                "fresh schema retry codex exec failed:",
-                "validation repair codex exec failed:",
-            )
-        ):
+        if error.startswith("validation repair codex exec failed:"):
             return error
     return ""
 
@@ -887,10 +910,10 @@ def run_forensic_canary(
         str(args.codex_timeout_sec),
         "--runner-timeout-sec",
         str(args.runner_timeout_sec),
-        "--validation-repair-attempts",
-        "1",
-        "--fresh-schema-retry-attempts",
+        "--packet-completion-attempts",
         "3",
+        "--fresh-schema-retry-attempts",
+        "0",
         "--run-log-path",
         str(run_log),
     ]

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -150,20 +150,6 @@ def forensic_schema_failure_signature(detail: str) -> str | None:
     """Normalize known control-plane schema defects without verdict content."""
     if "evidence_locator must contain at least 12 normalized characters" in detail:
         return "EVIDENCE_LOCATOR_MIN_LENGTH"
-    if no_go_discipline_gate.n7_steelman_normalized_length_error() in detail:
-        return "N7_MIN_LENGTH"
-    if (
-        detail.startswith("N1 route ")
-        and ".route_class=" in detail
-        and "is not supported by its evidenced" in detail
-    ):
-        return "N1_ROUTE_CLASS_MARKER_MISMATCH"
-    if (
-        detail.startswith("N5 statement ")
-        and "tested resolution is not evidenced at resolution_evidence_path"
-        in detail
-    ):
-        return "N5_TESTED_RESOLUTION_VERBATIM_MISMATCH"
     return None
 
 
@@ -182,16 +168,33 @@ def forensic_mechanics_circuit(
         for failure in record.get("failures") or []:
             if not isinstance(failure, dict):
                 continue
-            error_code = failure.get("error_code")
-            signature = (
-                error_code
-                if isinstance(error_code, str)
-                and error_code
-                and error_code != "AUDIT_SCHEMA_REJECT"
-                else forensic_schema_failure_signature(
+            typed_fields = {
+                "error_code",
+                "failure_class",
+                "scientific_seat_count",
+                "packet_completion_attempt_count",
+            }
+            if typed_fields & set(failure):
+                if (
+                    failure.get("failure_class")
+                    != "packet_completion_exhausted"
+                ):
+                    continue
+                error_code = failure.get("error_code")
+                signature = (
+                    error_code
+                    if isinstance(error_code, str)
+                    and error_code
+                    and error_code != "AUDIT_SCHEMA_REJECT"
+                    else forensic_schema_failure_signature(
+                        str(failure.get("detail") or "")
+                    )
+                )
+            else:
+                # Campaign records from before typed failures remain readable.
+                signature = forensic_schema_failure_signature(
                     str(failure.get("detail") or "")
                 )
-            )
             if signature is not None:
                 claims_by_signature.setdefault(signature, set()).add(claim_id)
     eligible = [
@@ -769,25 +772,50 @@ def forensic_canary_claim_local_failure(
             "validation repair codex exec failed:"
         ):
             return None
-        error_code = terminal.get("error_code")
-        if not isinstance(error_code, str) or not error_code:
+        typed_fields = {
+            "error_code",
+            "failure_class",
+            "scientific_seat_count",
+            "packet_completion_attempt_count",
+        }
+        present_typed_fields = typed_fields & set(terminal)
+        if present_typed_fields:
+            # Current runner artifacts are a closed typed contract. Do not
+            # normalize a partial or corrupt typed record into campaign state.
+            if present_typed_fields != typed_fields:
+                return None
+            error_code = terminal.get("error_code")
+            if error_code != batch.audit_runner.schema_failure_code(detail):
+                return None
+            failure_class = terminal.get("failure_class")
+            if failure_class not in {
+                "packet_completion_exhausted",
+                "scientific_reaudit_required",
+            }:
+                return None
+            scientific_seat_count = terminal.get("scientific_seat_count")
+            if (
+                type(scientific_seat_count) is not int
+                or scientific_seat_count != 1
+            ):
+                return None
+            completion_count = terminal.get("packet_completion_attempt_count")
+            if (
+                type(completion_count) is not int
+                or not 0 <= completion_count <= 3
+            ):
+                return None
+        else:
+            # Legacy terminal records had only the exact validator detail.
             error_code = batch.audit_runner.schema_failure_code(detail)
-        failure_class = terminal.get("failure_class")
-        if failure_class not in {
-            "packet_completion_exhausted",
-            "scientific_reaudit_required",
-        }:
+            completion_eligible = (
+                batch.audit_runner.packet_completion_eligible_error(detail)
+            )
             failure_class = batch.audit_runner.validation_failure_class(
                 detail,
-                packet_completion_eligible=(
-                    batch.audit_runner.packet_completion_eligible_error(detail)
-                ),
+                packet_completion_eligible=completion_eligible,
             )
-        scientific_seat_count = terminal.get("scientific_seat_count")
-        if type(scientific_seat_count) is not int or scientific_seat_count != 1:
             scientific_seat_count = 1
-        completion_count = terminal.get("packet_completion_attempt_count")
-        if type(completion_count) is not int or not 0 <= completion_count <= 3:
             completion_count = 0
         return batch.SCHEMA_QUARANTINE_RESULT, {
             "cid": claim_id,

--- a/docs/audit/scripts/tests/test_audit_campaign_repair.py
+++ b/docs/audit/scripts/tests/test_audit_campaign_repair.py
@@ -93,7 +93,7 @@ class CampaignRepairTest(unittest.TestCase):
                 "reason": repair.SCHEMA_QUARANTINE,
                 "failures": [{
                     "failure_class": "packet_completion_exhausted",
-                    "error_code": "N6_INDEXED_BASIS_VERBATIM_MISMATCH",
+                    "error_code": "N2_WALL_EVIDENCE_BINDING_MISMATCH",
                 }],
             },
             {"audit_status": "unaudited", "effective_status": "unaudited"},

--- a/docs/audit/scripts/tests/test_audit_campaign_repair.py
+++ b/docs/audit/scripts/tests/test_audit_campaign_repair.py
@@ -45,7 +45,13 @@ class CampaignRepairTest(unittest.TestCase):
             },
         }
         exclusions = [
-            {"claim_id": "schema", "reason": repair.SCHEMA_QUARANTINE},
+            {
+                "claim_id": "schema",
+                "reason": repair.SCHEMA_QUARANTINE,
+                "failures": [{
+                    "failure_class": "scientific_reaudit_required",
+                }],
+            },
             {"claim_id": "compute", "reason": repair.COMPUTE_QUARANTINE},
             {
                 "claim_id": "blocked",
@@ -61,7 +67,9 @@ class CampaignRepairTest(unittest.TestCase):
         plan = repair.build_plan(exclusions, rows)
         by_claim = {item["claim_id"]: item for item in plan}
 
-        self.assertEqual(by_claim["schema"]["route"], "fresh_schema_valid_seat")
+        self.assertEqual(
+            by_claim["schema"]["route"], "fresh_scientific_seat_required"
+        )
         self.assertTrue(by_claim["schema"]["ready_for_new_campaign"])
         self.assertEqual(by_claim["compute"]["route"], "supply_compute_artifact")
         self.assertEqual(
@@ -77,6 +85,23 @@ class CampaignRepairTest(unittest.TestCase):
             by_claim["transaction"]["route"], "repair_claim_transaction"
         )
         self.assertTrue(all("audit_status" in item["current"] for item in plan))
+
+    def test_exhausted_packet_completion_does_not_request_full_reaudit(self):
+        item = repair.repair_route(
+            {
+                "claim_id": "row",
+                "reason": repair.SCHEMA_QUARANTINE,
+                "failures": [{
+                    "failure_class": "packet_completion_exhausted",
+                    "error_code": "N6_INDEXED_BASIS_VERBATIM_MISMATCH",
+                }],
+            },
+            {"audit_status": "unaudited", "effective_status": "unaudited"},
+        )
+
+        self.assertEqual(item["route"], "repair_packet_completion_contract")
+        self.assertFalse(item["ready_for_new_campaign"])
+        self.assertIn("do not spend another full seat", item["action"])
 
     def test_resolved_blocked_reentry_is_safe_to_reconsider(self):
         item = repair.repair_route(

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -1622,6 +1622,19 @@ class SchemaRecoveryTest(unittest.TestCase):
                 '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
                 "invalid failure_class",
             ),
+            "typed code detail mismatch": (
+                '{"claim_id":"row","reason":"schema_invalid_quarantined",'
+                '"failures":[{"cid":"row","pass":1,'
+                '"result":"validation_failed",'
+                '"detail":"N2.walls must each be evidenced at '
+                'N2.evidence_path",'
+                '"error_code":"N5_CANONICAL_RESOLUTION_SET_INCOMPLETE",'
+                '"failure_class":"packet_completion_exhausted",'
+                '"scientific_seat_count":1,'
+                '"packet_completion_attempt_count":3}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "error_code does not match validator detail",
+            ),
             "wrong reason evidence": (
                 '{"claim_id":"row","reason":"compute_required_quarantined",'
                 '"failures":[{"cid":"row","pass":1,'
@@ -1885,10 +1898,13 @@ class SchemaRecoveryTest(unittest.TestCase):
             ) as completion:
                 envelope, result = batch.finalize_worker(job)
 
-        completion.assert_called_once()
+        completion.assert_not_called()
         self.assertIsNone(envelope)
         self.assertEqual(result["result"], "validation_failed")
         self.assertIn("N1_alternative_routes", result["detail"])
+        self.assertEqual(
+            result["failure_class"], "scientific_reaudit_required"
+        )
 
     def test_terminal_verdict_cannot_mix_compute_required(self):
         invocation = "c" * 32
@@ -3243,6 +3259,52 @@ class ClaimTransactionTest(unittest.TestCase):
         self.assertEqual(proc.wait.call_args_list, [mock.call()])
         killpg.assert_called_once_with(4321, signal.SIGKILL)
         self.assertLess(time.monotonic() - started, 1)
+
+    def test_packet_completion_rejects_scientific_packet_change(self):
+        blob = {
+            "verdict": "audited_clean",
+            "verdict_rationale": "x" * 240,
+            "no_go_discipline": {
+                "required": True,
+                "status": "PASS",
+                "N3_hidden_wall_scan": {
+                    "hits": [{
+                        "classification": "non_load_bearing",
+                        "evidence_path": "docs/SOURCE.md",
+                        "evidence_locator": "original locator text",
+                    }],
+                },
+            },
+        }
+        completed = json.loads(json.dumps(blob))
+        completed["no_go_discipline"]["N3_hidden_wall_scan"]["hits"][0][
+            "classification"
+        ] = "hidden_admission"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            out_path = root / "completion-row-p1-a1-out.json"
+
+            def fake_popen(*_args, **_kwargs):
+                out_path.write_text(json.dumps(completed), encoding="utf-8")
+                return mock.Mock()
+
+            job = {
+                "row": {"claim_id": "row"},
+                "pass": 1,
+                "auditor": "test-auditor",
+                "isolated": root,
+            }
+            with mock.patch.object(
+                batch.shutil, "which", return_value=sys.executable
+            ), mock.patch.object(
+                batch.subprocess, "Popen", side_effect=fake_popen
+            ), mock.patch.object(
+                batch, "_wait_for_packet_completion", return_value=(False, 0)
+            ):
+                result = batch.packet_completion_pass(job, blob, root)
+
+        self.assertIsNone(result)
 
     def test_checkpoint_abort_cannot_delete_concurrent_build(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -5290,14 +5352,26 @@ class CampaignContractTest(unittest.TestCase):
                 "reason": batch.SCHEMA_QUARANTINE_RESULT,
                 "failures": [{
                     "detail": "redacted validator detail",
-                    "error_code": "N6_INDEXED_BASIS_VERBATIM_MISMATCH",
+                    "error_code": "N2_WALL_EVIDENCE_BINDING_MISMATCH",
+                    "failure_class": "packet_completion_exhausted",
+                    "scientific_seat_count": 1,
+                    "packet_completion_attempt_count": 3,
                 }],
             }
             for claim_id in ("claim_d", "claim_e", "claim_f")
         ]
         self.assertEqual(
             audit_loop.forensic_mechanics_circuit(typed_records),
-            ("N6_INDEXED_BASIS_VERBATIM_MISMATCH", 3),
+            ("N2_WALL_EVIDENCE_BINDING_MISMATCH", 3),
+        )
+
+        scientific_records = json.loads(json.dumps(typed_records))
+        for record in scientific_records:
+            record["failures"][0][
+                "failure_class"
+            ] = "scientific_reaudit_required"
+        self.assertIsNone(
+            audit_loop.forensic_mechanics_circuit(scientific_records)
         )
 
     def test_open_forensic_mechanics_circuit_spends_no_new_seat(self):
@@ -5308,9 +5382,9 @@ class CampaignContractTest(unittest.TestCase):
             args.campaign_quarantine_file = (
                 campaign / "campaign-row-exclusions.jsonl"
             )
-            n7_length_error = (
-                audit_loop.no_go_discipline_gate.
-                n7_steelman_normalized_length_error()
+            locator_error = (
+                "N3 hit 1 evidence_locator must contain at least 12 "
+                "normalized characters"
             )
             report = [
                 {
@@ -5318,7 +5392,7 @@ class CampaignContractTest(unittest.TestCase):
                     "pass": 1,
                     "result": "validation_failed",
                     "detail": (
-                        n7_length_error + "; "
+                        locator_error + "; "
                         "preserved_run_log=forensic.jsonl"
                     ),
                 }
@@ -5342,19 +5416,18 @@ class CampaignContractTest(unittest.TestCase):
         run_command.assert_not_called()
         self.assertEqual(
             audit_loop.PROGRESS["canary_state"],
-            "mechanics_circuit_open:N7_MIN_LENGTH:3",
+            "mechanics_circuit_open:EVIDENCE_LOCATOR_MIN_LENGTH:3",
         )
 
-    def test_forensic_n7_signature_follows_shared_minimum(self):
+    def test_forensic_n7_scientific_defect_is_not_mechanics_signature(self):
         gate = audit_loop.no_go_discipline_gate
         with mock.patch.object(
             gate, "N7_STEELMAN_MIN_NORMALIZED_CHARS", 81
         ):
             detail = gate.n7_steelman_normalized_length_error()
             self.assertIn("81 normalized characters", detail)
-            self.assertEqual(
-                audit_loop.forensic_schema_failure_signature(detail),
-                "N7_MIN_LENGTH",
+            self.assertIsNone(
+                audit_loop.forensic_schema_failure_signature(detail)
             )
 
     def test_forensic_schema_failure_is_quarantined_and_returns_success(self):
@@ -5413,7 +5486,7 @@ class CampaignContractTest(unittest.TestCase):
             )
             self.assertEqual(
                 records[0]["failures"][0]["failure_class"],
-                "packet_completion_exhausted",
+                "scientific_reaudit_required",
             )
             self.assertEqual(
                 records[0]["failures"][0]["scientific_seat_count"], 1
@@ -5427,6 +5500,24 @@ class CampaignContractTest(unittest.TestCase):
             self.assertTrue(
                 audit_loop.PROGRESS["canary_state"].startswith("quarantined:")
             )
+
+    def test_forensic_canary_rejects_corrupt_typed_terminal_record(self):
+        terminal = {
+            "phase": "validate_failed",
+            "error": "N2.walls must each be evidenced at N2.evidence_path",
+            "error_code": "N5_CANONICAL_RESOLUTION_SET_INCOMPLETE",
+            "failure_class": "packet_completion_exhausted",
+            "scientific_seat_count": 1,
+            "packet_completion_attempt_count": 3,
+        }
+
+        self.assertIsNone(
+            audit_loop.forensic_canary_claim_local_failure(
+                terminal,
+                "forensic_row",
+                Path("forensic.jsonl"),
+            )
+        )
 
     def test_forensic_alternate_source_is_forwarded_to_restricted_runner(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -1603,6 +1603,25 @@ class SchemaRecoveryTest(unittest.TestCase):
                 '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
                 "invalid campaign exclusion failure fields",
             ),
+            "partial typed failure": (
+                '{"claim_id":"row","reason":"schema_invalid_quarantined",'
+                '"failures":[{"cid":"row","pass":1,'
+                '"result":"validation_failed","detail":"bad schema",'
+                '"error_code":"AUDIT_SCHEMA_REJECT"}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "invalid campaign exclusion failure fields",
+            ),
+            "invalid typed failure class": (
+                '{"claim_id":"row","reason":"schema_invalid_quarantined",'
+                '"failures":[{"cid":"row","pass":1,'
+                '"result":"validation_failed","detail":"bad schema",'
+                '"error_code":"AUDIT_SCHEMA_REJECT",'
+                '"failure_class":"verdict_failed",'
+                '"scientific_seat_count":1,'
+                '"packet_completion_attempt_count":3}],'
+                '"recorded_at":"2026-07-23T12:00:00+00:00"}\n',
+                "invalid failure_class",
+            ),
             "wrong reason evidence": (
                 '{"claim_id":"row","reason":"compute_required_quarantined",'
                 '"failures":[{"cid":"row","pass":1,'
@@ -5265,6 +5284,22 @@ class CampaignContractTest(unittest.TestCase):
             ("EVIDENCE_LOCATOR_MIN_LENGTH", 3),
         )
 
+        typed_records = [
+            {
+                "claim_id": claim_id,
+                "reason": batch.SCHEMA_QUARANTINE_RESULT,
+                "failures": [{
+                    "detail": "redacted validator detail",
+                    "error_code": "N6_INDEXED_BASIS_VERBATIM_MISMATCH",
+                }],
+            }
+            for claim_id in ("claim_d", "claim_e", "claim_f")
+        ]
+        self.assertEqual(
+            audit_loop.forensic_mechanics_circuit(typed_records),
+            ("N6_INDEXED_BASIS_VERBATIM_MISMATCH", 3),
+        )
+
     def test_open_forensic_mechanics_circuit_spends_no_new_seat(self):
         with tempfile.TemporaryDirectory() as tmp:
             campaign = Path(tmp)
@@ -5372,6 +5407,23 @@ class CampaignContractTest(unittest.TestCase):
                 "preserved_run_log",
                 records[0]["failures"][0]["detail"],
             )
+            self.assertEqual(
+                records[0]["failures"][0]["error_code"],
+                "N5_AUTHENTICATED_GROUP_COVERAGE_MISMATCH",
+            )
+            self.assertEqual(
+                records[0]["failures"][0]["failure_class"],
+                "packet_completion_exhausted",
+            )
+            self.assertEqual(
+                records[0]["failures"][0]["scientific_seat_count"], 1
+            )
+            self.assertEqual(
+                records[0]["failures"][0][
+                    "packet_completion_attempt_count"
+                ],
+                0,
+            )
             self.assertTrue(
                 audit_loop.PROGRESS["canary_state"].startswith("quarantined:")
             )
@@ -5416,6 +5468,18 @@ class CampaignContractTest(unittest.TestCase):
 
         self.assertEqual(rc, 0)
         self.assertIn("--from-reaudit-candidates", seen_command)
+        self.assertEqual(
+            seen_command[
+                seen_command.index("--packet-completion-attempts") + 1
+            ],
+            "3",
+        )
+        self.assertEqual(
+            seen_command[
+                seen_command.index("--fresh-schema-retry-attempts") + 1
+            ],
+            "0",
+        )
 
     def test_forensic_compute_skip_is_quarantined_and_returns_success(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -5496,7 +5560,7 @@ class CampaignContractTest(unittest.TestCase):
             self.assertEqual(rc, 1)
             self.assertFalse(args.campaign_quarantine_file.exists())
 
-    def test_forensic_fresh_schema_execution_failure_is_not_quarantined(self):
+    def test_forensic_packet_completion_execution_failure_is_not_quarantined(self):
         with tempfile.TemporaryDirectory() as tmp:
             campaign = Path(tmp)
             args = _args()
@@ -5514,7 +5578,7 @@ class CampaignContractTest(unittest.TestCase):
                             "claim_id": claim_id,
                             "phase": "validate_failed",
                             "error": (
-                                "fresh schema retry codex exec failed: "
+                                "validation repair codex exec failed: "
                                 "transport died"
                             ),
                             "blob": {},
@@ -5535,7 +5599,7 @@ class CampaignContractTest(unittest.TestCase):
             self.assertEqual(rc, 1)
             self.assertFalse(args.campaign_quarantine_file.exists())
 
-    def test_forensic_schema_retry_503_uses_only_execution_diagnostic(self):
+    def test_forensic_packet_completion_503_uses_only_execution_diagnostic(self):
         with tempfile.TemporaryDirectory() as tmp:
             campaign = Path(tmp)
             args = _args()
@@ -5553,7 +5617,7 @@ class CampaignContractTest(unittest.TestCase):
                             "claim_id": claim_id,
                             "phase": "validate_failed",
                             "error": (
-                                "fresh schema retry codex exec failed: "
+                                "validation repair codex exec failed: "
                                 "HTTP 503 Service Unavailable"
                             ),
                             "blob": {
@@ -5597,7 +5661,7 @@ class CampaignContractTest(unittest.TestCase):
                             "claim_id": claim_id,
                             "phase": "validate_failed",
                             "error": (
-                                "fresh schema retry codex exec failed: opaque "
+                                "validation repair codex exec failed: opaque "
                                 "worker exit"
                             ),
                             "blob": {

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -9782,7 +9782,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         base["verdict"] = "audited_decoration"
         self.assertIsNone(m.validate_verdict(base, "target"))
 
-    def test_validation_repair_prompt_reuses_packet_and_preserves_strict_gate(self):
+    def test_packet_completion_prompt_reuses_evidence_and_preserves_strict_gate(self):
         m = _import_codex_audit_runner()
         original_prompt = "restricted packet with EXACT EVIDENCE LOCATOR"
         rejected = {
@@ -9812,9 +9812,11 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         )
         self.assertIn("12+ character verbatim substring", flat_prompt)
         self.assertIn("Do not invent evidence", flat_prompt)
-        self.assertIn("or change the verdict itself", flat_prompt)
-        self.assertIn("untrusted correction target, not evidence", flat_prompt)
-        self.assertIn("may not add a top-level field", flat_prompt)
+        self.assertIn("may not change the verdict", flat_prompt)
+        self.assertIn("untrusted completion target, not evidence", flat_prompt)
+        self.assertIn("only the structured N1-N8 packet", flat_prompt)
+        self.assertIn("cannot flip FAIL to PASS", flat_prompt)
+        self.assertIn("honest FAIL packet is valid", flat_prompt)
         self.assertNotIn("accept despite", prompt.casefold())
 
     def test_validation_repair_cannot_change_scientific_judgment(self):
@@ -9907,18 +9909,16 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         changed_route_disposition["no_go_discipline"][
             "N1_alternative_routes"
         ][0]["disposition"] = "CLOSED"
-        self.assertIn(
-            "changed preserved no-go judgment content",
+        self.assertIsNone(
             m.validation_repair_preservation_error(
                 rejected, changed_route_disposition
             )
-            or "",
         )
 
         changed_packet_status = json.loads(json.dumps(locator_repair))
         changed_packet_status["no_go_discipline"]["status"] = "PASS"
         self.assertIn(
-            "changed preserved no-go judgment content",
+            "changed preserved N1-N8 gate field 'status'",
             m.validation_repair_preservation_error(
                 rejected, changed_packet_status
             )
@@ -9932,7 +9932,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 "N1 route 1 evidence_locator is not present in docs/TARGET.md",
             )
         )
-        self.assertFalse(
+        self.assertTrue(
             m.validation_repair_eligible(
                 rejected,
                 "target",
@@ -12086,14 +12086,14 @@ class CodexAuditRunnerModelPolicyTest(unittest.TestCase):
             len(raw_short_casefold_expands), n7["argument"]["minLength"]
         )
 
-    def test_n7_constants_drive_schema_prompt_error_and_fresh_retry(self):
+    def test_n7_constants_drive_schema_prompt_error_and_failure_code(self):
         m = _import_codex_audit_runner()
         gate = m.no_go_discipline_gate
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             note = root / "docs" / "TARGET.md"
             note.parent.mkdir(parents=True, exist_ok=True)
-            note.write_text("Exact source.\n", encoding="utf-8")
+            note.write_text("Exact source.\\n", encoding="utf-8")
             row = {
                 "claim_id": "target",
                 "note_path": "docs/TARGET.md",
@@ -12119,16 +12119,13 @@ class CodexAuditRunnerModelPolicyTest(unittest.TestCase):
                 )
                 error = gate.n7_steelman_length_error("x" * 80, "x" * 80)
                 self.assertIsNotNone(error)
-                code = m.fresh_schema_retry_code(error or "")
-                retry = m.render_fresh_schema_retry_prompt(prompt, code, 1)
+                code = m.schema_failure_code(error or "")
 
         self.assertEqual(schema["argument"]["minLength"], 82)
         self.assertEqual(schema["resolution"]["minLength"], 82)
         self.assertIn("raw=82 normalized=81", prompt)
         self.assertIn("at least 81 normalized characters", error or "")
         self.assertEqual(code, "N7_EXECUTION_EVIDENCE_VERBATIM_MISMATCH")
-        self.assertIn("82 raw Unicode code points", retry)
-        self.assertIn("81 characters after whitespace-collapsed", retry)
 
     def test_best_cached_model_uses_highest_full_gpt_version_not_cache_order(self):
         m = _import_codex_audit_runner()
@@ -12200,6 +12197,20 @@ class CodexAuditRunnerModelPolicyTest(unittest.TestCase):
         ), self.assertRaises(SystemExit) as caught:
             m.main()
         self.assertEqual(caught.exception.code, 2)
+
+    def test_nonzero_full_schema_reaudit_budget_is_rejected(self):
+        m = _import_codex_audit_runner()
+        with mock.patch.object(
+            sys,
+            "argv",
+            [
+                "codex_audit_runner.py",
+                "--dry-run",
+                "--fresh-schema-retry-attempts",
+                "1",
+            ],
+        ):
+            self.assertEqual(m.main(), 2)
 
     def test_reused_auditor_base_still_gets_distinct_run_identity(self):
         m = _import_codex_audit_runner()
@@ -13371,7 +13382,7 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         )
         self.assertEqual(candidate["evidence_locator"], "absent quoted basis prefix")
 
-    def test_locator_repair_preservation_allows_bound_metadata_only(self):
+    def test_packet_completion_may_replace_packet_only(self):
         m = _import_codex_audit_runner()
         rejected = {
             "verdict": "audited_clean",
@@ -13404,256 +13415,60 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             m.validation_repair_preservation_error(rejected, repaired)
         )
         repaired_hit["classification"] = "hidden_admission"
+        self.assertIsNone(
+            m.validation_repair_preservation_error(rejected, repaired)
+        )
+        repaired["verdict"] = "audited_conditional"
         self.assertIn(
-            "changed preserved no-go judgment content",
+            "changed preserved scientific field 'verdict'",
             m.validation_repair_preservation_error(rejected, repaired) or "",
         )
 
-    def test_fresh_schema_retry_exposes_error_not_rejected_conclusion(self):
+    def test_packet_completion_errors_get_typed_conclusion_free_codes(self):
         m = _import_codex_audit_runner()
-        self.assertTrue(m.fresh_schema_retry_eligible(
-            "N5 statement 1 must record one tested resolution per required class"
-        ))
-        self.assertTrue(m.fresh_schema_retry_eligible(
-            "no_go_discipline.status must be PASS or FAIL"
-        ))
-        transport_error = "transport-bounded N8 evidence forbids audited_clean"
-        self.assertTrue(m.fresh_schema_retry_eligible(transport_error))
+        cases = {
+            "N5 statement 1 must record one tested resolution per required class":
+                "N5_CANONICAL_RESOLUTION_SET_INCOMPLETE",
+            "N2.walls must each be evidenced at N2.evidence_path":
+                "N2_WALL_EVIDENCE_BINDING_MISMATCH",
+            "N3.hits must exactly disposition orchestrator phrase scan; "
+            "missing=[('secret_path', 'sector', 'secret_id')], extra=[]":
+                "N3_AUTHENTICATED_GROUP_COVERAGE_MISMATCH",
+            "N6 candidate 1.closure_mechanism must use its indexed_basis":
+                "N6_INDEXED_BASIS_VERBATIM_MISMATCH",
+        }
+        for error, expected_code in cases.items():
+            with self.subTest(error=error):
+                self.assertTrue(m.packet_completion_eligible_error(error))
+                self.assertEqual(m.schema_failure_code(error), expected_code)
+                self.assertEqual(
+                    m.validation_failure_class(
+                        error, packet_completion_eligible=True
+                    ),
+                    "packet_completion_exhausted",
+                )
+
+        self.assertFalse(m.packet_completion_eligible_error("claim_id mismatch"))
         self.assertEqual(
-            m.fresh_schema_retry_code(transport_error),
+            m.schema_failure_code("claim_id mismatch"), "AUDIT_SCHEMA_REJECT"
+        )
+        self.assertEqual(
+            m.validation_failure_class(
+                "claim_id mismatch", packet_completion_eligible=False
+            ),
+            "scientific_reaudit_required",
+        )
+        transport_error = "transport-bounded N8 evidence forbids audited_clean"
+        self.assertEqual(
+            m.schema_failure_code(transport_error),
             "N8_TRANSPORT_BOUND_DISPOSITION_MISMATCH",
         )
-        self.assertFalse(m.fresh_schema_retry_eligible("claim_id mismatch"))
-        code = m.fresh_schema_retry_code(
-            "N1 route prior_secret.route_class exposes prior content"
-        )
-        self.assertEqual(code, "AUDIT_SCHEMA_REJECT")
-        prompt = m.render_fresh_schema_retry_prompt(
-            "ORIGINAL RESTRICTED PACKET",
-            code,
-            1,
-        )
-        self.assertIn("ORIGINAL RESTRICTED PACKET", prompt)
-        self.assertIn("AUDIT_SCHEMA_REJECT", prompt)
-        self.assertNotIn("N1_SCHEMA_REJECT", prompt)
-        self.assertNotIn("N1-N8 validator", prompt)
-        self.assertNotIn("Recheck every N1-N8", prompt)
-        self.assertNotIn("prior_secret", prompt)
-        self.assertIn("not given its JSON or conclusion", prompt)
         self.assertEqual(
-            m.fresh_schema_retry_code(
-                "N5 statement 1 must record one tested resolution per "
-                "required class"
+            m.validation_failure_class(
+                transport_error, packet_completion_eligible=False
             ),
-            "N5_CANONICAL_RESOLUTION_SET_INCOMPLETE",
+            "scientific_reaudit_required",
         )
-        self.assertEqual(
-            m.fresh_schema_retry_code(
-                "N2.walls must each be evidenced at N2.evidence_path"
-            ),
-            "N2_WALL_EVIDENCE_BINDING_MISMATCH",
-        )
-        accumulated_prompt = m.render_fresh_schema_retry_prompt(
-            "ORIGINAL RESTRICTED PACKET",
-            [
-                "N5_CANONICAL_RESOLUTION_SET_INCOMPLETE",
-                "N2_WALL_EVIDENCE_BINDING_MISMATCH",
-            ],
-            2,
-        )
-        self.assertIn("VALIDATOR CODES:", accumulated_prompt)
-        self.assertIn(
-            "N5_CANONICAL_RESOLUTION_SET_INCOMPLETE", accumulated_prompt
-        )
-        self.assertIn(
-            "N2_WALL_EVIDENCE_BINDING_MISMATCH", accumulated_prompt
-        )
-        self.assertIn(
-            "per_element, per_site, per_mode", accumulated_prompt
-        )
-        self.assertIn("name both complete wall strings", accumulated_prompt)
-        n3_code = m.fresh_schema_retry_code(
-            "N3 retained_authority hit 1 is not retained or accepted in the manifest"
-        )
-        self.assertEqual(
-            n3_code, "N3_RETAINED_AUTHORITY_PROVENANCE_MISMATCH"
-        )
-        n3_prompt = m.render_fresh_schema_retry_prompt(
-            "ORIGINAL RESTRICTED PACKET", n3_code, 1,
-        )
-        self.assertIn("describes path provenance", n3_prompt)
-        self.assertNotIn("hit 1", n3_prompt)
-        n1_code = m.fresh_schema_retry_code(
-            "N1 route 2.route_class='symmetry_or_representation' "
-            "is not supported by its evidenced mechanism/attempt/outcome vocabulary"
-        )
-        self.assertEqual(n1_code, "N1_ROUTE_CLASS_MARKER_MISMATCH")
-        n1_prompt = m.render_fresh_schema_retry_prompt(
-            "ORIGINAL RESTRICTED PACKET", n1_code, 1,
-        )
-        self.assertIn("at least one individual mechanism", n1_prompt)
-        self.assertNotIn("route 2", n1_prompt)
-        n5_code = m.fresh_schema_retry_code(
-            "N5 statement 1 tested resolution is not evidenced at "
-            "resolution_evidence_path"
-        )
-        self.assertEqual(n5_code, "N5_TESTED_RESOLUTION_VERBATIM_MISMATCH")
-        n5_prompt = m.render_fresh_schema_retry_prompt(
-            "ORIGINAL RESTRICTED PACKET", n5_code, 1,
-        )
-        self.assertIn("byte-for-byte as a contiguous line", n5_prompt)
-        self.assertNotIn("statement 1", n5_prompt)
-        n3_tuple_code = m.fresh_schema_retry_code(
-            "N3 hit 2.occurrence_group_id must be a 16-hex context digest"
-        )
-        self.assertEqual(
-            n3_tuple_code, "N3_AUTHENTICATED_GROUP_TUPLE_MISMATCH"
-        )
-        n3_tuple_prompt = m.render_fresh_schema_retry_prompt(
-            "ORIGINAL RESTRICTED PACKET", n3_tuple_code, 1,
-        )
-        self.assertIn("from one same full_phrase_groups record", n3_tuple_prompt)
-        self.assertIn("may share a context-derived id or digest", n3_tuple_prompt)
-        self.assertIn("Never infer an unlisted phrase", n3_tuple_prompt)
-        self.assertNotIn("hit 2", n3_tuple_prompt)
-        n3_scan_code = m.fresh_schema_retry_code(
-            "N3.hits must exactly disposition orchestrator phrase scan; "
-            "missing=[], extra=[('secret_path', 'sector', 'secret_id')]"
-        )
-        self.assertEqual(
-            n3_scan_code, "N3_AUTHENTICATED_GROUP_COVERAGE_MISMATCH"
-        )
-        n3_scan_prompt = m.render_fresh_schema_retry_prompt(
-            "ORIGINAL RESTRICTED PACKET", n3_scan_code, 1,
-        )
-        self.assertIn(
-            "every authenticated full_phrase_groups record", n3_scan_prompt
-        )
-        self.assertIn("exactly once in N3.hits", n3_scan_prompt)
-        self.assertIn(
-            "(evidence_path, phrase, occurrence_group_id)", n3_scan_prompt
-        )
-        self.assertNotIn("secret_path", n3_scan_prompt)
-        self.assertNotIn("secret_id", n3_scan_prompt)
-        n5_scan_code = m.fresh_schema_retry_code(
-            "N5.statements must exactly disposition orchestrator rhetoric scan; "
-            "missing=[('secret_path', 'cannot', 'secret_id')], extra=[]"
-        )
-        self.assertEqual(
-            n5_scan_code, "N5_AUTHENTICATED_GROUP_COVERAGE_MISMATCH"
-        )
-        n5_scan_prompt = m.render_fresh_schema_retry_prompt(
-            "ORIGINAL RESTRICTED PACKET", n5_scan_code, 1,
-        )
-        self.assertIn(
-            "every authenticated full_phrase_groups record", n5_scan_prompt
-        )
-        self.assertIn("exactly once in N5.statements", n5_scan_prompt)
-        self.assertIn(
-            "Shared group ids or digests do not merge", n5_scan_prompt
-        )
-        self.assertNotIn("secret_path", n5_scan_prompt)
-        self.assertNotIn("secret_id", n5_scan_prompt)
-        for n7_error in (
-            "N7.argument is not evidenced at its N1 execution path",
-            "N7.resolution is not evidenced at resolution_evidence_path",
-            "N7.argument must name the steelmanned route mechanism",
-            "N7.argument must name the steelmanned route attempt",
-            m.no_go_discipline_gate.n7_steelman_normalized_length_error(),
-        ):
-            n7_code = m.fresh_schema_retry_code(n7_error)
-            self.assertEqual(
-                n7_code, "N7_EXECUTION_EVIDENCE_VERBATIM_MISMATCH"
-            )
-            n7_prompt = m.render_fresh_schema_retry_prompt(
-                "ORIGINAL RESTRICTED PACKET", n7_code, 1,
-            )
-            self.assertIn("one complete contiguous live-execution line", n7_prompt)
-            self.assertIn("route mechanism and attempt verbatim", n7_prompt)
-            self.assertIn("raw Unicode code points", n7_prompt)
-            self.assertIn("whitespace-collapsed, case-folded", n7_prompt)
-            self.assertIn("names an evidenced N2 wall", n7_prompt)
-            self.assertNotIn(n7_error, n7_prompt)
-        locator_error = (
-            "N3 hit 1 evidence_locator must contain at least 12 normalized characters"
-        )
-        locator_code = m.fresh_schema_retry_code(locator_error)
-        self.assertEqual(
-            locator_code,
-            "EVIDENCE_LOCATOR_VERBATIM_LENGTH_MISMATCH",
-        )
-        locator_prompt = m.render_fresh_schema_retry_prompt(
-            "ORIGINAL RESTRICTED PACKET", locator_code, 1,
-        )
-        self.assertIn("contiguous 12+ normalized-character substring", locator_prompt)
-        self.assertIn("12+ normalized-character", locator_prompt)
-        self.assertNotIn("hit 1", locator_prompt)
-        n4_errors = [
-            "N4 witness 1.witness_residual_id must be non-empty",
-            "N4 witness 1.claim_residual_id must be a stable residual:<id>",
-            "N4 witness 1 witness residual must cite an authority at secret/path",
-            "N4 witness 1 claim residual must cite the source secret_claim_id",
-            "N4 witness 1 requires non-empty evidence_path and evidence_locator",
-            "N4 witness 1 claim residual requires non-empty evidence_path and evidence_locator",
-        ]
-        for n4_error in n4_errors:
-            with self.subTest(n4_error=n4_error):
-                n4_code = m.fresh_schema_retry_code(n4_error)
-                self.assertEqual(n4_code, "N4_WITNESS_SCHEMA_MISMATCH")
-                n4_prompt = m.render_fresh_schema_retry_prompt(
-                    "ORIGINAL RESTRICTED PACKET", n4_code, 1,
-                )
-                self.assertIn("when no N1 route is RULED OUT BY PRIOR", n4_prompt)
-                self.assertIn("stable residual:<id> strings", n4_prompt)
-                self.assertIn("authority evidence_path and evidence_locator", n4_prompt)
-                self.assertIn(
-                    "source claim_evidence_path and claim_evidence_locator",
-                    n4_prompt,
-                )
-                self.assertIn("witness surface must have the authority role", n4_prompt)
-                self.assertNotIn("witness 1", n4_prompt)
-                self.assertNotIn("secret/path", n4_prompt)
-                self.assertNotIn("secret_claim_id", n4_prompt)
-        n5_nesting_error = (
-            "N5 contains unknown fields ['resolution_classes_checked', "
-            "'tested_resolutions', 'secret_field_value']"
-        )
-        n5_nesting_code = m.fresh_schema_retry_code(n5_nesting_error)
-        self.assertEqual(
-            n5_nesting_code, "N5_STATEMENT_FIELD_NESTING_MISMATCH"
-        )
-        n5_nesting_prompt = m.render_fresh_schema_retry_prompt(
-            "ORIGINAL RESTRICTED PACKET", n5_nesting_code, 1,
-        )
-        self.assertIn("belong inside each statements[] object", n5_nesting_prompt)
-        self.assertNotIn("secret_field_value", n5_nesting_prompt)
-        n6_basis_error = (
-            "N6 candidate 1.closure_mechanism must use its indexed_basis"
-        )
-        n6_basis_code = m.fresh_schema_retry_code(n6_basis_error)
-        self.assertEqual(
-            n6_basis_code, "N6_INDEXED_BASIS_VERBATIM_MISMATCH"
-        )
-        n6_basis_prompt = m.render_fresh_schema_retry_prompt(
-            "ORIGINAL RESTRICTED PACKET", n6_basis_code, 1,
-        )
-        self.assertIn("copy indexed_basis exactly", n6_basis_prompt)
-        self.assertIn("complete text verbatim", n6_basis_prompt)
-        self.assertNotIn("candidate 1", n6_basis_prompt)
-        n6_wall_error = (
-            "N6 candidate 1.disposition must name its affected_wall secret_wall"
-        )
-        n6_wall_code = m.fresh_schema_retry_code(n6_wall_error)
-        self.assertEqual(
-            n6_wall_code, "N6_AFFECTED_WALL_VERBATIM_MISMATCH"
-        )
-        n6_wall_prompt = m.render_fresh_schema_retry_prompt(
-            "ORIGINAL RESTRICTED PACKET", n6_wall_code, 1,
-        )
-        self.assertIn("copy affected_wall exactly", n6_wall_prompt)
-        self.assertIn("complete text verbatim inside its disposition", n6_wall_prompt)
-        self.assertNotIn("candidate 1", n6_wall_prompt)
-        self.assertNotIn("secret_wall", n6_wall_prompt)
 
     def test_forensic_readiness_requires_live_n5_resolution_certificate(self):
         m = _import_codex_audit_runner()
@@ -13709,24 +13524,58 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             m.forensic_evidence_readiness_issue(evidence_manifest)
         )
 
-    def test_failed_locator_repair_preserves_fresh_schema_eligibility(self):
+    def test_packet_completion_requires_prompt_bound_scientific_core(self):
         m = _import_codex_audit_runner()
-        initial = "N1 route 1.outcome is not evidenced at evidence_path"
-        preservation = "validation repair changed preserved no-go judgment content"
-        self.assertEqual(
-            m.fresh_schema_retry_error(preservation, initial),
-            initial,
+        invocation = "a" * 32
+        rejected = {
+            field: "stable" for field in m.REQUIRED_VERDICT_FIELDS
+        }
+        rejected.update({
+            "claim_id": "target",
+            "audit_invocation_id": invocation,
+            "no_go_discipline": {"required": True, "status": "PASS"},
+        })
+        error = "N1-N8 packet is required for this source or verdict"
+        self.assertTrue(
+            m.validation_repair_eligible(
+                rejected,
+                "target",
+                error,
+                expected_invocation_id=invocation,
+            )
         )
-        self.assertEqual(
-            m.fresh_schema_retry_error("N3 scan is incomplete", initial),
-            "N3 scan is incomplete",
+        self.assertFalse(
+            m.validation_repair_eligible(
+                rejected,
+                "target",
+                error,
+                expected_invocation_id="b" * 32,
+            )
         )
-        self.assertEqual(
-            m.fresh_schema_retry_error("claim_id mismatch", None),
-            "claim_id mismatch",
+        missing_packet = {**rejected, "no_go_discipline": None}
+        self.assertFalse(
+            m.validation_repair_eligible(
+                missing_packet,
+                "target",
+                error,
+                expected_invocation_id=invocation,
+            )
         )
-        self.assertIsNone(
-            m.fresh_schema_retry_error(None, initial),
+        self.assertFalse(
+            m.validation_repair_eligible(
+                rejected,
+                "target",
+                "transport-bounded N8 evidence forbids audited_clean",
+                expected_invocation_id=invocation,
+            )
+        )
+        self.assertFalse(
+            m.validation_repair_eligible(
+                rejected,
+                "target",
+                "claim_id mismatch",
+                expected_invocation_id=invocation,
+            )
         )
 
     def test_oversized_validation_repair_is_detected_before_transport(self):

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -9814,7 +9814,12 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         self.assertIn("Do not invent evidence", flat_prompt)
         self.assertIn("may not change the verdict", flat_prompt)
         self.assertIn("untrusted completion target, not evidence", flat_prompt)
-        self.assertIn("only the structured N1-N8 packet", flat_prompt)
+        self.assertIn(
+            "only evidence_path/evidence_locator citation fields", flat_prompt
+        )
+        self.assertIn(
+            "substantive N1-N8 value must remain exactly stable", flat_prompt
+        )
         self.assertIn("cannot flip FAIL to PASS", flat_prompt)
         self.assertIn("honest FAIL packet is valid", flat_prompt)
         self.assertNotIn("accept despite", prompt.casefold())
@@ -9909,10 +9914,11 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         changed_route_disposition["no_go_discipline"][
             "N1_alternative_routes"
         ][0]["disposition"] = "CLOSED"
-        self.assertIsNone(
+        self.assertIn(
+            "changed preserved no-go scientific content",
             m.validation_repair_preservation_error(
                 rejected, changed_route_disposition
-            )
+            ) or "",
         )
 
         changed_packet_status = json.loads(json.dumps(locator_repair))
@@ -9932,7 +9938,7 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 "N1 route 1 evidence_locator is not present in docs/TARGET.md",
             )
         )
-        self.assertTrue(
+        self.assertFalse(
             m.validation_repair_eligible(
                 rejected,
                 "target",
@@ -13382,7 +13388,7 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         )
         self.assertEqual(candidate["evidence_locator"], "absent quoted basis prefix")
 
-    def test_packet_completion_may_replace_packet_only(self):
+    def test_packet_completion_preserves_scientific_packet_content(self):
         m = _import_codex_audit_runner()
         rejected = {
             "verdict": "audited_clean",
@@ -13415,8 +13421,9 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             m.validation_repair_preservation_error(rejected, repaired)
         )
         repaired_hit["classification"] = "hidden_admission"
-        self.assertIsNone(
-            m.validation_repair_preservation_error(rejected, repaired)
+        self.assertIn(
+            "changed preserved no-go scientific content",
+            m.validation_repair_preservation_error(rejected, repaired) or "",
         )
         repaired["verdict"] = "audited_conditional"
         self.assertIn(
@@ -13428,24 +13435,32 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         m = _import_codex_audit_runner()
         cases = {
             "N5 statement 1 must record one tested resolution per required class":
-                "N5_CANONICAL_RESOLUTION_SET_INCOMPLETE",
+                ("N5_CANONICAL_RESOLUTION_SET_INCOMPLETE", False),
             "N2.walls must each be evidenced at N2.evidence_path":
-                "N2_WALL_EVIDENCE_BINDING_MISMATCH",
+                ("N2_WALL_EVIDENCE_BINDING_MISMATCH", True),
             "N3.hits must exactly disposition orchestrator phrase scan; "
             "missing=[('secret_path', 'sector', 'secret_id')], extra=[]":
-                "N3_AUTHENTICATED_GROUP_COVERAGE_MISMATCH",
+                ("N3_AUTHENTICATED_GROUP_COVERAGE_MISMATCH", False),
             "N6 candidate 1.closure_mechanism must use its indexed_basis":
-                "N6_INDEXED_BASIS_VERBATIM_MISMATCH",
+                ("N6_INDEXED_BASIS_VERBATIM_MISMATCH", False),
         }
-        for error, expected_code in cases.items():
+        for error, (expected_code, completion_eligible) in cases.items():
             with self.subTest(error=error):
-                self.assertTrue(m.packet_completion_eligible_error(error))
+                self.assertEqual(
+                    m.packet_completion_eligible_error(error),
+                    completion_eligible,
+                )
                 self.assertEqual(m.schema_failure_code(error), expected_code)
                 self.assertEqual(
                     m.validation_failure_class(
-                        error, packet_completion_eligible=True
+                        error,
+                        packet_completion_eligible=completion_eligible,
                     ),
-                    "packet_completion_exhausted",
+                    (
+                        "packet_completion_exhausted"
+                        if completion_eligible
+                        else "scientific_reaudit_required"
+                    ),
                 )
 
         self.assertFalse(m.packet_completion_eligible_error("claim_id mismatch"))
@@ -13535,7 +13550,10 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
             "audit_invocation_id": invocation,
             "no_go_discipline": {"required": True, "status": "PASS"},
         })
-        error = "N1-N8 packet is required for this source or verdict"
+        error = (
+            "N1 route 1 evidence_locator is not present in "
+            "'docs/TARGET.md'"
+        )
         self.assertTrue(
             m.validation_repair_eligible(
                 rejected,
@@ -13558,6 +13576,14 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
                 missing_packet,
                 "target",
                 error,
+                expected_invocation_id=invocation,
+            )
+        )
+        self.assertFalse(
+            m.validation_repair_eligible(
+                rejected,
+                "target",
+                "N1-N8 packet is required for this source or verdict",
                 expected_invocation_id=invocation,
             )
         )

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -654,18 +654,13 @@ REQUIRED_VERDICT_FIELDS = {
     "negative_assertion_classes",
 }
 
-# A validator-guided correction pass may repair evidence locators in the
-# already-present structured N1-N8 packet, but it is not a second scientific
-# audit.  Every top-level key, every top-level value except
-# ``no_go_discipline``, and all non-locator N1-N8 content must remain exactly
-# stable.  This also prevents the correction pass from injecting optional
-# apply controls such as ``pre_audit_prose_fix`` or
+# A validator-guided packet-completion pass is not a second scientific audit.
+# Every top-level key and value except ``no_go_discipline`` remains exactly
+# stable. This prevents the focused pass from changing the verdict, type,
+# scope, closure judgment, rationale, declarations, confidence, or optional
+# apply controls such as ``pre_audit_prose_fix`` and
 # ``cross_confirmation_role``.
 VALIDATION_REPAIR_MUTABLE_FIELD = "no_go_discipline"
-VALIDATION_REPAIR_LOCATOR_FIELDS = {
-    "evidence_path",
-    "evidence_locator",
-}
 
 # Map JSON-extracted-from-stdout to apply_audit.py's input schema. apply_audit
 # expects `verdict` etc. plus the runner-side fields auditor/auditor_family/
@@ -3000,41 +2995,44 @@ def render_validation_repair_prompt(
     validation_error: str,
     attempt: int,
 ) -> str:
-    """Ask the same restricted-packet auditor to correct invalid JSON.
+    """Ask a focused pass to complete only the rejected N1-N8 packet.
 
-    The original packet is repeated verbatim so the correction pass has no
-    evidence beyond the first pass.  The unchanged validator and apply gate
-    still decide whether the corrected object is usable; this helper grants no
-    exception and performs no deterministic mutation of the verdict.
+    The original restricted evidence and rejected object are repeated verbatim.
+    The unchanged validator and apply gate still decide whether the completed
+    object is usable. Every top-level scientific judgment remains immutable;
+    only ``no_go_discipline`` may be added or replaced.
     """
     prior_json = json.dumps(verdict_blob, indent=2, sort_keys=True)
     return (
         f"{original_prompt}\n\n"
         "---\n"
-        f"VALIDATOR-GUIDED CORRECTION PASS {attempt} (binding):\n"
+        f"FOCUSED N1-N8 PACKET COMPLETION PASS {attempt} (binding):\n"
         "Your preceding JSON object was rejected before apply. Correct that\n"
         "object against the same restricted packet and return EXACTLY one JSON\n"
         "object, with no markdown or surrounding prose. The ordinary validator\n"
         "and apply gate remain unchanged. Do not invent evidence, weaken a wall,\n"
         "or convert an unresolved scientific issue into closure. Preserve the\n"
-        "scientific judgment, the complete top-level key set, and every\n"
-        "top-level value except no_go_discipline exactly. Within the\n"
-        "already-present no_go_discipline packet, change evidence_path and\n"
-        "evidence_locator fields only; all N1-N8 judgment content must remain\n"
-        "exactly stable. This pass may not add a top-level field or change the\n"
-        "verdict itself. The rejected JSON is an untrusted correction target,\n"
-        "not evidence.\n"
+        "complete top-level key set and every top-level value except\n"
+        "no_go_discipline exactly. You may add or replace only the structured\n"
+        "N1-N8 packet. In particular, this pass may not change the verdict,\n"
+        "claim type, scope, chain-closure judgment, rationale, negative-claim\n"
+        "declaration, invocation id, or any other top-level field. The rejected\n"
+        "JSON is an untrusted completion target, not evidence.\n"
+        "Preserve the packet's existing required and status gate fields exactly;\n"
+        "a completion pass cannot flip FAIL to PASS or PASS to FAIL.\n"
+        "An honest FAIL packet is valid for a non-clean judgment; never force\n"
+        "PASS merely to match the preserved verdict.\n"
         "Every evidence_locator must be a 12+ character verbatim substring of\n"
         "the content at its evidence_path in the restricted packet; copy it\n"
-        "exactly. Do not revise any classification or internal N1-N8\n"
-        "reference.\n\n"
+        "exactly. Recheck the complete N1-N8 packet against the exact validator\n"
+        "error before returning.\n\n"
         f"VALIDATION ERROR:\n{validation_error}\n\n"
         f"REJECTED JSON TO CORRECT:\n{prior_json}\n"
     )
 
 
-def fresh_schema_retry_eligible(validation_error: str | None) -> bool:
-    """Allow a new isolated audit for structured N1-N8 disposition rejects."""
+def packet_completion_eligible_error(validation_error: str | None) -> bool:
+    """Recognize a structured N1-N8 reject without reading verdict content."""
     if not validation_error:
         return False
     return bool(re.match(
@@ -3043,7 +3041,7 @@ def fresh_schema_retry_eligible(validation_error: str | None) -> bool:
     ))
 
 
-def fresh_schema_retry_code(validation_error: str) -> str:
+def schema_failure_code(validation_error: str) -> str:
     """Reduce validator text to a conclusion-free control-plane code."""
     if (
         validation_error.startswith("N5 statement ")
@@ -3149,205 +3147,24 @@ def fresh_schema_retry_code(validation_error: str) -> str:
     return "AUDIT_SCHEMA_REJECT"
 
 
-def fresh_schema_retry_error(
-    current_error: str | None,
-    initial_validation_error: str | None,
-) -> str | None:
-    """Keep a structured reject eligible after a failed locator repair.
-
-    Locator repair cannot change N1-N8 judgment content. A repair that
-    violates that rule, fails parsing, or fails operationally must not erase
-    the original structured validator reject and suppress the independent
-    fresh-schema retry.
-    """
-    if current_error is None:
-        return None
-    if fresh_schema_retry_eligible(current_error):
-        return current_error
-    if fresh_schema_retry_eligible(initial_validation_error):
-        return initial_validation_error
-    return current_error
-
-
-def render_fresh_schema_retry_prompt(
-    original_prompt: str,
-    validation_code: str | list[str],
-    attempt: int,
+def validation_failure_class(
+    validation_error: str | None,
+    *,
+    packet_completion_eligible: bool,
 ) -> str:
-    """Request a fresh judgment without exposing the rejected JSON.
-
-    Unlike locator repair, this starts a distinct isolated Codex context and
-    discards the prior object completely. The generic validator code reveals
-    no failed section, scientific framing, or prior conclusion.
-    """
-    guidance_by_code = {
-        "N5_CANONICAL_RESOLUTION_SET_INCOMPLETE": (
-            "Static N5 invariant: every statements[] entry must list the five "
-            "canonical resolution classes exactly once and copy exactly five "
-            "substantive tested_resolutions lines from live current-cycle "
-            "runner_stdout: per_element, per_site, per_mode, per_block, and "
-            "lattice_wide. Recheck every statement before returning.\n"
-        ),
-        "N3_RETAINED_AUTHORITY_PROVENANCE_MISMATCH": (
-            "Static N3 invariant: retained_authority describes path provenance, "
-            "not phrase semantics. Use it exactly when the hit path has an "
-            "authority/framework_premise/premise_registry role and retained-grade "
-            "status or accepted axiom/approved-primitive type. A source-role path "
-            "must instead be classified from its actual load-bearing use.\n"
-        ),
-        "N1_ROUTE_CLASS_MARKER_MISMATCH": (
-            "Static N1 invariant: at least one individual mechanism, attempt, or "
-            "outcome field must contain a documented literal marker for the "
-            "selected route_class. "
-            "Identifier separators '_' and '-' count as lexical boundaries, and "
-            "ordinary carrier/sector/module/space/irrep plurals are accepted. "
-            "For normalization routes, unit/units must be whole tokens; exact "
-            "W_unit/W_units may cross underscore boundaries, while preW_unit, "
-            "W_unit_post, W_unitary, and W__unit are reserved lookalikes. The "
-            "normalization markers use literal ASCII spelling, and Unicode "
-            "letters or combining marks continue a token. "
-            "At least one of those fields must itself copy the marker. When a "
-            "check label lacks it, use an evidenced marker-bearing live section "
-            "header that genuinely names the same route; do not duplicate fields "
-            "unless stdout supplies the same text for distinct semantic roles.\n"
-        ),
-        "N1_ROUTE_EVIDENCE_COMPLETENESS_MISMATCH": (
-            "Static N1 invariant: mechanisms and attempts must be semantically "
-            "distinct, not numbered paraphrases. Every ATTEMPTED route must cite "
-            "live current-cycle runner_stdout and copy a 12+ character locator "
-            "from that exact surface. Do not invent extra routes to reach five; "
-            "an honestly incomplete N1 set must remain FAIL.\n"
-        ),
-        "N2_WALL_EVIDENCE_BINDING_MISMATCH": (
-            "Static N2 invariant: copy every wall verbatim from the cited "
-            "evidence, and make each pairwise rationale name both complete wall "
-            "strings while remaining a verbatim-supported locator on the same "
-            "surface. Recheck every wall and pair, not only the first reject.\n"
-        ),
-        "EVIDENCE_LOCATOR_VERBATIM_LENGTH_MISMATCH": (
-            "Static evidence invariant: every evidence_locator must copy a "
-            "contiguous 12+ normalized-character substring from its cited "
-            "authenticated path. Section-level scan locators are subject to the "
-            "same rule. Recheck all N1-N8 locators before returning.\n"
-        ),
-        "N3_AUTHENTICATED_GROUP_TUPLE_MISMATCH": (
-            "Static N3 invariant: copy phrase, occurrence_group_id, "
-            "occurrence_count, occurrence_locator_sha256, and evidence_locator "
-            "from one same full_phrase_groups record. Separate authenticated "
-            "phrase records may share a context-derived id or digest; reproduce "
-            "that sharing only when each complete phrase record is listed. Never "
-            "infer an unlisted phrase from a shared id or cross-label a count, "
-            "digest, or locator from another record.\n"
-        ),
-        "N3_AUTHENTICATED_GROUP_COVERAGE_MISMATCH": (
-            "Static N3 coverage invariant: enumerate every authenticated "
-            "full_phrase_groups record from every applicable manifest path "
-            "exactly once in N3.hits. Key coverage by the complete "
-            "(evidence_path, phrase, occurrence_group_id) tuple. Do not "
-            "deduplicate records merely because they share a context-derived "
-            "group id or digest, and do not add a phrase absent from the "
-            "authenticated records. Copy each record's complete occurrence "
-            "tuple without cross-labeling fields.\n"
-        ),
-        "N5_AUTHENTICATED_GROUP_TUPLE_MISMATCH": (
-            "Static N5 invariant: copy phrase, occurrence_group_id, "
-            "occurrence_count, occurrence_locator_sha256, and evidence_locator "
-            "from one same full_phrase_groups record. Never cross-label a group "
-            "id, count, digest, or locator under another phrase.\n"
-        ),
-        "N5_AUTHENTICATED_GROUP_COVERAGE_MISMATCH": (
-            "Static N5 coverage invariant: enumerate every authenticated "
-            "full_phrase_groups record from every applicable manifest path "
-            "exactly once in N5.statements. Key coverage by the complete "
-            "(evidence_path, phrase, occurrence_group_id) tuple. Shared group "
-            "ids or digests do not merge distinct phrase records. Do not omit, "
-            "deduplicate, or invent records; copy each record's complete "
-            "occurrence tuple from that same record.\n"
-        ),
-        "N5_TESTED_RESOLUTION_VERBATIM_MISMATCH": (
-            "Static N5 invariant: copy every complete tested_resolutions entry, "
-            "including its canonical class prefix and body, byte-for-byte as a "
-            "contiguous line from the cited live current-cycle runner_stdout. "
-            "Do not summarize, shorten, or paraphrase those five lines.\n"
-        ),
-        "N7_EXECUTION_EVIDENCE_VERBATIM_MISMATCH": (
-            "Static N7 invariant: copy argument byte-for-byte as one complete "
-            "contiguous live-execution line from the selected N1 route surface; "
-            "that line must contain the route mechanism and attempt verbatim. "
-            f"Both copied lines must contain at least "
-            f"{no_go_discipline_gate.N7_STEELMAN_TRANSPORT_MIN_RAW_CHARS} raw "
-            "Unicode code points for the transport prefilter and at least "
-            f"{no_go_discipline_gate.N7_STEELMAN_MIN_NORMALIZED_CHARS} "
-            "characters after whitespace-collapsed, case-folded normalization. "
-            "Copy resolution byte-for-byte as one complete contiguous line from "
-            "the cited independent execution or retained/accepted authority, "
-            "and choose a line that names an evidenced N2 wall. Do not paraphrase "
-            "either field.\n"
-        ),
-        "N4_WITNESS_SCHEMA_MISMATCH": (
-            "Static N4 invariant: when no N1 route is RULED OUT BY PRIOR, emit "
-            "witnesses as an empty list with a substantive none_found_reason; "
-            "never fabricate a placeholder witness. Otherwise every witness "
-            "must include witness_residual_id and claim_residual_id as stable "
-            "residual:<id> strings, plus separate authority evidence_path and "
-            "evidence_locator fields and separate source claim_evidence_path and "
-            "claim_evidence_locator fields. The witness surface must have the "
-            "authority role and the claim surface must have the source role. Copy "
-            "each residual text and ID verbatim from its own cited packet surface.\n"
-        ),
-        "N5_STATEMENT_FIELD_NESTING_MISMATCH": (
-            "Static N5 invariant: resolution_classes_checked, "
-            "tested_resolutions, untested_resolutions, resolution_evidence_path, "
-            "and resolution_evidence_locator belong inside each statements[] "
-            "object, never on the N5_rhetoric_audit section object. Preserve all "
-            "statement content while placing each field at that documented level.\n"
-        ),
-        "N6_INDEXED_BASIS_VERBATIM_MISMATCH": (
-            "Static N6 invariant: copy indexed_basis exactly from the candidate "
-            "record and include that complete text verbatim inside the same "
-            "candidate's closure_mechanism before the explanation of how it could "
-            "affect the named wall. Do not paraphrase or shorten indexed_basis.\n"
-        ),
-        "N6_AFFECTED_WALL_VERBATIM_MISMATCH": (
-            "Static N6 invariant: copy affected_wall exactly from the same "
-            "candidate and include that complete text verbatim inside its "
-            "disposition before explaining why the candidate does or does not "
-            "close the wall. Do not paraphrase or shorten affected_wall.\n"
-        ),
-    }
-    validation_codes = (
-        [validation_code]
-        if isinstance(validation_code, str)
-        else list(dict.fromkeys(validation_code))
-    )
-    guidance = "".join(
-        guidance_by_code.get(code, "")
-        for code in validation_codes
-    )
-    code_label = "VALIDATOR CODE" if len(validation_codes) == 1 else "VALIDATOR CODES"
-    code_text = "\n".join(validation_codes)
-    return (
-        f"{original_prompt}\n\n"
-        "---\n"
-        f"FRESH SCHEMA RETRY {attempt} (binding):\n"
-        "A separate restricted-context attempt was rejected before apply by "
-        "the unchanged deterministic audit schema validator. You are not given its "
-        "JSON or conclusion. Reperform the scientific audit from the supplied "
-        "evidence and return a wholly fresh JSON object. The validator error "
-        "below is a sanitized control-plane schema code only, not scientific evidence. "
-        "Do not infer or preserve any prior verdict. Recheck the complete "
-        "output schema and every invariant already stated in the original "
-        "restricted packet before responding.\n\n"
-        f"{code_label}:\n{code_text}\n"
-        f"{guidance}"
-    )
+    """Route a no-verdict reject without treating it as scientific evidence."""
+    if packet_completion_eligible and packet_completion_eligible_error(
+        validation_error
+    ):
+        return "packet_completion_exhausted"
+    return "scientific_reaudit_required"
 
 
 def validation_repair_preservation_error(
     rejected_blob: dict,
     repaired_blob: dict,
 ) -> str | None:
-    """Reject a format correction that changes the scientific judgment."""
+    """Reject packet completion that changes any top-level judgment."""
     rejected_fields = set(rejected_blob)
     repaired_fields = set(repaired_blob)
     if repaired_fields != rejected_fields:
@@ -3358,33 +3175,34 @@ def validation_repair_preservation_error(
             f"(added={added}, removed={removed})"
         )
     for field in sorted(rejected_fields - {VALIDATION_REPAIR_MUTABLE_FIELD}):
-        if repaired_blob.get(field) != rejected_blob.get(field):
+        rejected_value = json.dumps(
+            rejected_blob.get(field),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        repaired_value = json.dumps(
+            repaired_blob.get(field),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        if repaired_value != rejected_value:
             return (
                 "validation repair changed preserved scientific field "
                 f"{field!r}"
             )
-    def without_locator_fields(value: object) -> object:
-        if isinstance(value, dict):
-            return {
-                key: without_locator_fields(item)
-                for key, item in value.items()
-                if key not in (
-                    VALIDATION_REPAIR_LOCATOR_FIELDS
-                    | set(AUTHENTICATED_OCCURRENCE_FIELDS)
+    rejected_packet = rejected_blob.get(VALIDATION_REPAIR_MUTABLE_FIELD)
+    repaired_packet = repaired_blob.get(VALIDATION_REPAIR_MUTABLE_FIELD)
+    if not isinstance(repaired_packet, dict):
+        return "validation repair did not supply a structured N1-N8 packet"
+    if isinstance(rejected_packet, dict):
+        for field in ("required", "status"):
+            if repaired_packet.get(field) != rejected_packet.get(field):
+                return (
+                    "validation repair changed preserved N1-N8 gate field "
+                    f"{field!r}"
                 )
-            }
-        if isinstance(value, list):
-            return [without_locator_fields(item) for item in value]
-        return value
-
-    rejected_packet = without_locator_fields(
-        rejected_blob.get(VALIDATION_REPAIR_MUTABLE_FIELD)
-    )
-    repaired_packet = without_locator_fields(
-        repaired_blob.get(VALIDATION_REPAIR_MUTABLE_FIELD)
-    )
-    if repaired_packet != rejected_packet:
-        return "validation repair changed preserved no-go judgment content"
     return None
 
 
@@ -3392,20 +3210,29 @@ def validation_repair_eligible(
     rejected_blob: dict,
     expected_cid: str,
     validation_error: str | None,
+    expected_invocation_id: str | None = None,
 ) -> bool:
-    """True only for a complete verdict with an N1-N8 locator failure."""
-    if not validation_error:
+    """True only for a complete, prompt-bound judgment with an N1-N8 reject."""
+    if not packet_completion_eligible_error(validation_error):
         return False
-    locator_error = validation_error.casefold()
-    if not any(
-        marker in locator_error
-        for marker in ("evidence_path", "evidence path", "evidence_locator")
+    if validation_error == "transport-bounded N8 evidence forbids audited_clean":
+        return False
+    if not isinstance(rejected_blob, dict):
+        return False
+    if not REQUIRED_VERDICT_FIELDS.issubset(rejected_blob):
+        return False
+    if rejected_blob.get("claim_id") != expected_cid:
+        return False
+    if (
+        expected_invocation_id is not None
+        and rejected_blob.get("audit_invocation_id") != expected_invocation_id
     ):
         return False
+    packet = rejected_blob.get(VALIDATION_REPAIR_MUTABLE_FIELD)
     return (
-        REQUIRED_VERDICT_FIELDS.issubset(rejected_blob)
-        and rejected_blob.get("claim_id") == expected_cid
-        and isinstance(rejected_blob.get(VALIDATION_REPAIR_MUTABLE_FIELD), dict)
+        isinstance(packet, dict)
+        and packet.get("required") is True
+        and packet.get("status") in {"PASS", "FAIL"}
     )
 
 
@@ -3473,19 +3300,31 @@ def main() -> int:
                         "codex-cli-<model>-<utc-yyyymmdd-hhmm>-<run-id>")
     p.add_argument("--codex-timeout-sec", type=int, default=600,
                    help="Per-row codex exec timeout (default 600).")
-    p.add_argument("--validation-repair-attempts", type=int, default=1,
-                   help="After a complete parsed verdict fails strict N1-N8 "
-                        "evidence-locator validation, ask "
-                        "the same restricted-packet auditor for this many "
-                        "validator-guided JSON corrections (default 1; 0 "
-                        "disables). Every correction must pass the unchanged "
-                        "validator and apply gate.")
-    p.add_argument("--fresh-schema-retry-attempts", type=int, default=2,
-                   help="After a complete verdict fails an N1-N8 structural "
-                        "schema rule that is not eligible for locator-only "
-                        "repair, rerun the full restricted audit in this many "
-                        "new isolated contexts (default 2; 0 disables). The "
-                        "rejected JSON/conclusion is never passed forward.")
+    p.add_argument(
+        "--packet-completion-attempts",
+        "--validation-repair-attempts",
+        dest="validation_repair_attempts",
+        type=int,
+        default=1,
+        help=(
+            "After a complete prompt-bound judgment fails a strict N1-N8 "
+            "packet rule, run this many focused completions that may replace "
+            "only no_go_discipline (default 1; 0 disables). Every other "
+            "top-level value is immutable and the unchanged validator/apply "
+            "gates still bind. The legacy --validation-repair-attempts name "
+            "is accepted as an alias."
+        ),
+    )
+    p.add_argument(
+        "--fresh-schema-retry-attempts",
+        type=int,
+        default=0,
+        help=(
+            "Deprecated fail-closed compatibility option. Only 0 is "
+            "accepted; a schema reject never launches another full "
+            "scientific audit."
+        ),
+    )
     p.add_argument("--runner-timeout-sec", type=int, default=120,
                    help="Per-row primary-runner timeout (default 120).")
     p.add_argument("--no-propagate", action="store_true",
@@ -3577,8 +3416,12 @@ def main() -> int:
     if not 0 <= args.validation_repair_attempts <= 3:
         print("REFUSING: --validation-repair-attempts must be between 0 and 3.")
         return 2
-    if not 0 <= args.fresh_schema_retry_attempts <= 3:
-        print("REFUSING: --fresh-schema-retry-attempts must be between 0 and 3.")
+    if args.fresh_schema_retry_attempts != 0:
+        print(
+            "REFUSING: --fresh-schema-retry-attempts is retired; use 0. "
+            "Packet rejects may receive only judgment-preserving focused "
+            "completion."
+        )
         return 2
     if args.from_dispatch and args.from_reaudit_candidates:
         print("REFUSING: choose only one of --from-dispatch and --from-reaudit-candidates.")
@@ -3782,7 +3625,6 @@ def main() -> int:
     propagation_failed = False
     for i, row in enumerate(targets, 1):
         cid = row["claim_id"]
-        fresh_retry_dirs: list[Path] = []
         print(f"\n[{i}/{len(targets)}] {cid}")
         try:
             # Determine first-pass vs second-pass vs skip BEFORE invoking codex.
@@ -4141,9 +3983,16 @@ def main() -> int:
             initial_validation_error = err
             initial_rejected_blob = blob
             repair_elapsed = 0.0
-            repair_eligible = validation_repair_eligible(blob, cid, err)
+            repair_attempts_used = 0
+            repair_eligible = validation_repair_eligible(
+                blob,
+                cid,
+                err,
+                expected_invocation_id=audit_invocation_id,
+            )
             if err and args.validation_repair_attempts > 0 and repair_eligible:
                 for repair_attempt in range(1, args.validation_repair_attempts + 1):
+                    repair_attempts_used = repair_attempt
                     print(
                         f"  validation repair {repair_attempt}/"
                         f"{args.validation_repair_attempts}: {err}"
@@ -4294,179 +4143,33 @@ def main() -> int:
                         )
                         break
                 elapsed += repair_elapsed
-            err = fresh_schema_retry_error(err, initial_validation_error)
-            schema_retry_compute_required: str | None = None
             if (
                 err
-                and args.fresh_schema_retry_attempts > 0
-                and fresh_schema_retry_eligible(err)
+                and initial_validation_error
+                and repair_eligible
+                and not err.startswith("validation repair codex exec failed:")
             ):
-                schema_elapsed = 0.0
-                schema_retry_codes: list[str] = []
-                for schema_attempt in range(1, args.fresh_schema_retry_attempts + 1):
-                    retry_code = fresh_schema_retry_code(err)
-                    if retry_code not in schema_retry_codes:
-                        schema_retry_codes.append(retry_code)
-                    print(
-                        f"  fresh schema retry {schema_attempt}/"
-                        f"{args.fresh_schema_retry_attempts}: {retry_code}"
-                    )
-                    schema_prompt = render_fresh_schema_retry_prompt(
-                        prompt, schema_retry_codes, schema_attempt
-                    )
-                    if prompt_exceeds_hard_input_limit(schema_prompt):
-                        err = "fresh schema retry prompt exceeds Codex hard input limit"
-                        break
-                    schema_dir = ISOLATED_BASE / (
-                        f"{run_id}-{i:03d}-fresh-schema-{schema_attempt:02d}"
-                    )
-                    fresh_retry_dirs.append(schema_dir)
-                    schema_t0 = time.time()
-                    schema_ok, schema_stdout, schema_stderr = run_codex(
-                        schema_prompt,
-                        schema_dir,
-                        args.codex_timeout_sec,
-                        reasoning_effort=reasoning_effort,
-                        model=audit_model,
-                    )
-                    schema_elapsed += time.time() - schema_t0
-                    if not schema_ok:
-                        err = (
-                            "fresh schema retry codex exec failed: "
-                            f"{schema_stderr.strip()[:300]}"
-                        )
-                        with run_log.open("a", encoding="utf-8") as f:
-                            f.write(json.dumps({
-                                "claim_id": cid,
-                                "phase": "fresh_schema_retry_codex_failed",
-                                "attempt": schema_attempt,
-                                "error": err,
-                            }) + "\n")
-                        continue
-                    schema_reply = extract_response(schema_stdout)
-                    schema_retry_compute_required = compute_required_reason(schema_reply)
-                    if schema_retry_compute_required:
-                        break
-                    schema_blob = parse_verdict_json(schema_reply or "")
-                    if schema_blob is None:
-                        err = "fresh schema retry reply not valid JSON"
-                        with run_log.open("a", encoding="utf-8") as f:
-                            f.write(json.dumps({
-                                "claim_id": cid,
-                                "phase": "fresh_schema_retry_json_parse_failed",
-                                "attempt": schema_attempt,
-                                "reply": schema_reply or "",
-                            }) + "\n")
-                        continue
-                    schema_casefold_path_bindings = (
-                        bind_authenticated_casefold_evidence_paths(
-                            schema_blob, exact_evidence_manifest
-                        )
-                    )
-                    if schema_casefold_path_bindings:
-                        with run_log.open("a", encoding="utf-8") as f:
-                            f.write(json.dumps({
-                                "claim_id": cid,
-                                "phase": (
-                                    "fresh_schema_retry_authenticated_casefold_"
-                                    "evidence_paths_bound"
-                                ),
-                                "attempt": schema_attempt,
-                                "bindings": schema_casefold_path_bindings,
-                            }) + "\n")
-                    schema_n8_universe_bindings = (
-                        bind_authenticated_n8_universe_metadata(
-                            schema_blob, exact_evidence_manifest
-                        )
-                    )
-                    if schema_n8_universe_bindings:
-                        with run_log.open("a", encoding="utf-8") as f:
-                            f.write(json.dumps({
-                                "claim_id": cid,
-                                "phase": (
-                                    "fresh_schema_retry_authenticated_n8_"
-                                    "universe_metadata_bound"
-                                ),
-                                "attempt": schema_attempt,
-                                "bindings": schema_n8_universe_bindings,
-                            }) + "\n")
-                    schema_bindings = bind_authenticated_occurrence_metadata(
-                        schema_blob, exact_evidence_manifest
-                    )
-                    if schema_bindings:
-                        with run_log.open("a", encoding="utf-8") as f:
-                            f.write(json.dumps({
-                                "claim_id": cid,
-                                "phase": (
-                                    "fresh_schema_retry_authenticated_"
-                                    "occurrence_metadata_bound"
-                                ),
-                                "attempt": schema_attempt,
-                                "bindings": schema_bindings,
-                            }) + "\n")
-                    schema_n6_locator_bindings = (
-                        bind_authenticated_n6_candidate_locators(
-                            schema_blob, exact_evidence_manifest
-                        )
-                    )
-                    if schema_n6_locator_bindings:
-                        with run_log.open("a", encoding="utf-8") as f:
-                            f.write(json.dumps({
-                                "claim_id": cid,
-                                "phase": (
-                                    "fresh_schema_retry_authenticated_n6_"
-                                    "candidate_locators_bound"
-                                ),
-                                "attempt": schema_attempt,
-                                "bindings": schema_n6_locator_bindings,
-                            }) + "\n")
-                    schema_error = validate_verdict(
-                        schema_blob,
-                        cid,
-                        source_requires_no_go=source_requires_no_go,
-                        evidence_manifest=exact_evidence_manifest,
-                        prior_claim_scope=prior_claim_scope_for_row(full_led_row),
-                        expected_invocation_id=audit_invocation_id,
-                        transport_bounded_n8=transport_bound is not None,
-                    )
-                    with run_log.open("a", encoding="utf-8") as f:
-                        f.write(json.dumps({
-                            "claim_id": cid,
-                            "phase": (
-                                "fresh_schema_retry_passed"
-                                if schema_error is None
-                                else "fresh_schema_retry_failed"
-                            ),
-                            "attempt": schema_attempt,
-                            "error": schema_error,
-                        }) + "\n")
-                    blob = schema_blob
-                    err = schema_error
-                    if err is None:
-                        print(
-                            "  fresh schema retry passed "
-                            f"({schema_elapsed:.1f}s cumulative)"
-                        )
-                        break
-                elapsed += schema_elapsed
-            if schema_retry_compute_required is not None:
-                print(f"  COMPUTE_REQUIRED: {schema_retry_compute_required[:200]}")
-                skipped += 1
-                with run_log.open("a", encoding="utf-8") as f:
-                    f.write(json.dumps({
-                        "claim_id": cid,
-                        "phase": "compute_required",
-                        "elapsed_sec": elapsed,
-                        "reason": schema_retry_compute_required,
-                    }) + "\n")
-                continue
+                # A malformed or judgment-changing completion cannot replace
+                # the original validator reject. Preserve the exact routing
+                # signal while keeping the rejected scientific tuple intact.
+                err = initial_validation_error
             if err:
                 print(f"  FAIL validate: {err}")
                 failed += 1
+                failure_code = schema_failure_code(err)
+                failure_class = validation_failure_class(
+                    err,
+                    packet_completion_eligible=repair_eligible,
+                )
                 with run_log.open("a", encoding="utf-8") as f:
                     f.write(json.dumps({
                         "claim_id": cid, "phase": "validate_failed",
-                        "error": err, "blob": blob
+                        "error": err,
+                        "error_code": failure_code,
+                        "failure_class": failure_class,
+                        "scientific_seat_count": 1,
+                        "packet_completion_attempt_count": repair_attempts_used,
+                        "blob": blob,
                     }) + "\n")
                 continue
 
@@ -4589,9 +4292,6 @@ def main() -> int:
             iso = ISOLATED_BASE / f"{run_id}-{i:03d}"
             if iso.exists():
                 shutil.rmtree(iso, ignore_errors=True)
-            for retry_dir in fresh_retry_dirs:
-                if retry_dir.exists():
-                    shutil.rmtree(retry_dir, ignore_errors=True)
 
     # Batch push mode: one commit covering the whole run
     if (

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -654,13 +654,23 @@ REQUIRED_VERDICT_FIELDS = {
     "negative_assertion_classes",
 }
 
-# A validator-guided packet-completion pass is not a second scientific audit.
-# Every top-level key and value except ``no_go_discipline`` remains exactly
-# stable. This prevents the focused pass from changing the verdict, type,
-# scope, closure judgment, rationale, declarations, confidence, or optional
-# apply controls such as ``pre_audit_prose_fix`` and
-# ``cross_confirmation_role``.
+# A validator-guided packet-mechanics pass is not a second scientific audit.
+# Every top-level key/value and every substantive N1-N8 value remains exactly
+# stable. The focused pass may correct only citation bindings and authenticated
+# occurrence metadata, which the unchanged validator checks against the
+# restricted packet. This prevents the pass from changing the verdict, type,
+# scope, closure judgment, rationale, declarations, confidence, packet
+# classifications/dispositions, or optional apply controls such as
+# ``pre_audit_prose_fix`` and ``cross_confirmation_role``.
 VALIDATION_REPAIR_MUTABLE_FIELD = "no_go_discipline"
+VALIDATION_REPAIR_LOCATOR_FIELDS = {
+    "evidence_path",
+    "evidence_locator",
+    "claim_evidence_path",
+    "claim_evidence_locator",
+    "resolution_evidence_path",
+    "resolution_evidence_locator",
+}
 
 # Map JSON-extracted-from-stdout to apply_audit.py's input schema. apply_audit
 # expects `verdict` etc. plus the runner-side fields auditor/auditor_family/
@@ -2995,26 +3005,31 @@ def render_validation_repair_prompt(
     validation_error: str,
     attempt: int,
 ) -> str:
-    """Ask a focused pass to complete only the rejected N1-N8 packet.
+    """Ask a focused pass to correct only rejected N1-N8 mechanics.
 
     The original restricted evidence and rejected object are repeated verbatim.
     The unchanged validator and apply gate still decide whether the completed
-    object is usable. Every top-level scientific judgment remains immutable;
-    only ``no_go_discipline`` may be added or replaced.
+    object is usable. Every scientific judgment, including substantive N1-N8
+    content, remains immutable.
     """
     prior_json = json.dumps(verdict_blob, indent=2, sort_keys=True)
     return (
         f"{original_prompt}\n\n"
         "---\n"
-        f"FOCUSED N1-N8 PACKET COMPLETION PASS {attempt} (binding):\n"
+        f"FOCUSED N1-N8 PACKET-MECHANICS PASS {attempt} (binding):\n"
         "Your preceding JSON object was rejected before apply. Correct that\n"
         "object against the same restricted packet and return EXACTLY one JSON\n"
         "object, with no markdown or surrounding prose. The ordinary validator\n"
         "and apply gate remain unchanged. Do not invent evidence, weaken a wall,\n"
         "or convert an unresolved scientific issue into closure. Preserve the\n"
         "complete top-level key set and every top-level value except\n"
-        "no_go_discipline exactly. You may add or replace only the structured\n"
-        "N1-N8 packet. In particular, this pass may not change the verdict,\n"
+        "no_go_discipline exactly. Within the already-present structured N1-N8\n"
+        "packet, you may change only evidence_path/evidence_locator citation\n"
+        "fields and authenticated occurrence_group_id, occurrence_count, and\n"
+        "occurrence_locator_sha256 metadata. Every classification, route, wall,\n"
+        "residual match, resolution, closure, steelman, echo disposition, and\n"
+        "other substantive N1-N8 value must remain exactly stable. In\n"
+        "particular, this pass may not change the verdict,\n"
         "claim type, scope, chain-closure judgment, rationale, negative-claim\n"
         "declaration, invocation id, or any other top-level field. The rejected\n"
         "JSON is an untrusted completion target, not evidence.\n"
@@ -3032,13 +3047,15 @@ def render_validation_repair_prompt(
 
 
 def packet_completion_eligible_error(validation_error: str | None) -> bool:
-    """Recognize a structured N1-N8 reject without reading verdict content."""
+    """Recognize a mechanical N1-N8 reject without reading verdict content."""
     if not validation_error:
         return False
-    return bool(re.match(
-        r"^(?:N[1-8]\b|No-Go Discipline\b|no_go_discipline\b|transport-bounded N8\b)",
-        validation_error,
-    ))
+    if not re.match(r"^N[1-8]\b", validation_error):
+        return False
+    return any(
+        marker in validation_error
+        for marker in ("evidence_path", "evidence_locator", "occurrence_")
+    )
 
 
 def schema_failure_code(validation_error: str) -> str:
@@ -3164,7 +3181,7 @@ def validation_repair_preservation_error(
     rejected_blob: dict,
     repaired_blob: dict,
 ) -> str | None:
-    """Reject packet completion that changes any top-level judgment."""
+    """Reject packet completion that changes any scientific judgment."""
     rejected_fields = set(rejected_blob)
     repaired_fields = set(repaired_blob)
     if repaired_fields != rejected_fields:
@@ -3203,6 +3220,36 @@ def validation_repair_preservation_error(
                     "validation repair changed preserved N1-N8 gate field "
                     f"{field!r}"
                 )
+    mechanical_fields = (
+        VALIDATION_REPAIR_LOCATOR_FIELDS
+        | set(AUTHENTICATED_OCCURRENCE_FIELDS)
+    )
+
+    def without_mechanical_fields(value: object) -> object:
+        if isinstance(value, dict):
+            return {
+                key: without_mechanical_fields(item)
+                for key, item in value.items()
+                if key not in mechanical_fields
+            }
+        if isinstance(value, list):
+            return [without_mechanical_fields(item) for item in value]
+        return value
+
+    rejected_science = json.dumps(
+        without_mechanical_fields(rejected_packet),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    repaired_science = json.dumps(
+        without_mechanical_fields(repaired_packet),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    if repaired_science != rejected_science:
+        return "validation repair changed preserved no-go scientific content"
     return None
 
 
@@ -3308,11 +3355,11 @@ def main() -> int:
         default=1,
         help=(
             "After a complete prompt-bound judgment fails a strict N1-N8 "
-            "packet rule, run this many focused completions that may replace "
-            "only no_go_discipline (default 1; 0 disables). Every other "
-            "top-level value is immutable and the unchanged validator/apply "
-            "gates still bind. The legacy --validation-repair-attempts name "
-            "is accepted as an alias."
+            "citation or occurrence-metadata rule, run this many focused "
+            "mechanics corrections (default 1; 0 disables). Every top-level "
+            "value and substantive N1-N8 value is immutable, and the "
+            "unchanged validator/apply gates still bind. The legacy "
+            "--validation-repair-attempts name is accepted as an alias."
         ),
     )
     p.add_argument(
@@ -3419,8 +3466,8 @@ def main() -> int:
     if args.fresh_schema_retry_attempts != 0:
         print(
             "REFUSING: --fresh-schema-retry-attempts is retired; use 0. "
-            "Packet rejects may receive only judgment-preserving focused "
-            "completion."
+            "Eligible packet rejects may receive only judgment-preserving "
+            "focused mechanics correction."
         )
         return 2
     if args.from_dispatch and args.from_reaudit_candidates:
@@ -3981,6 +4028,7 @@ def main() -> int:
                 transport_bounded_n8=transport_bound is not None,
             )
             initial_validation_error = err
+            routing_validation_error = err
             initial_rejected_blob = blob
             repair_elapsed = 0.0
             repair_attempts_used = 0
@@ -4135,12 +4183,19 @@ def main() -> int:
                         }) + "\n")
                     if preservation_error is None:
                         blob = repair_blob
+                        if repair_error is not None:
+                            routing_validation_error = repair_error
                     err = repair_error
                     if err is None:
                         print(
                             f"  validation repair passed "
                             f"({repair_elapsed:.1f}s cumulative)"
                         )
+                        break
+                    if (
+                        preservation_error is None
+                        and not packet_completion_eligible_error(err)
+                    ):
                         break
                 elapsed += repair_elapsed
             if (
@@ -4150,16 +4205,22 @@ def main() -> int:
                 and not err.startswith("validation repair codex exec failed:")
             ):
                 # A malformed or judgment-changing completion cannot replace
-                # the original validator reject. Preserve the exact routing
-                # signal while keeping the rejected scientific tuple intact.
-                err = initial_validation_error
+                # the last validator reject reached by an accepted mechanical
+                # correction. Preserve that exact routing signal while keeping
+                # the rejected scientific tuple intact.
+                err = routing_validation_error
             if err:
                 print(f"  FAIL validate: {err}")
                 failed += 1
                 failure_code = schema_failure_code(err)
                 failure_class = validation_failure_class(
                     err,
-                    packet_completion_eligible=repair_eligible,
+                    packet_completion_eligible=validation_repair_eligible(
+                        blob,
+                        cid,
+                        err,
+                        expected_invocation_id=audit_invocation_id,
+                    ),
                 )
                 with run_log.open("a", encoding="utf-8") as f:
                     f.write(json.dumps({


### PR DESCRIPTION
## Problem

The forensic canary spent up to four independent xhigh science seats on one row: one initial audit plus three full fresh-schema retries. Validator defects were therefore re-adjudicating science and consuming credits without landing verdicts.

## Change

- permit exactly one independent scientific seat per forensic canary
- replace full-schema science retries with at most three focused N1-N8 packet completions
- freeze every top-level scientific field and the existing N1-N8 required/status gate; completion cannot change verdict, type, scope, rationale, chain closure, declarations, invocation, or flip FAIL/PASS
- explicitly refuse any nonzero legacy full-schema retry budget
- persist typed error code, failure class, scientific-seat count, and packet-completion count in campaign quarantine records
- stop campaign repair from routing exhausted packet completion directly into another full audit
- open the repeated-mechanics circuit from typed codes across distinct claims
- update the canonical audit-loop skill

## Verification

- 661 audit runner/orchestrator tests passed
- focused post-rebase tests passed
- full audit pipeline passed
- strict audit lint passed with zero errors
- audit-loop skill quick validation passed
- Python compilation and git diff checks passed

No validator, evidence, N1-N8, apply, independence, pipeline, lint, or push gate is weakened.