### PR TITLE
fix(audit): bind verdicts to scientific provenance

### DIFF
--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -863,12 +863,14 @@ python3 docs/audit/scripts/audit_lint.py --strict
 
 Then re-attempt selection (steps 1-5). If the refreshed fresh-science selector
 is empty, inspect and report `by_work_kind`. The audit lane is genuinely
-caught up only when there is also no `legacy_packet_upgrade`,
-`provenance_reconstruction_required`, or `evidence_repair_required` work.
-Those are mechanical preparation/certification lanes, never permission to
-spend a fresh scientific seat. Do not refresh repeatedly in one session and
-do not invoke `gh workflow run audit.yml` from inside the audit loop (the CI
-workflow runs its own pipeline and could race the local one).
+caught up only when there is no pending `fresh_scientific_audit`,
+`legacy_packet_upgrade`, or `evidence_repair_required` work. The latter two
+are mechanical preparation/certification lanes, never permission to spend a
+fresh scientific seat. Missing or ambiguous v2 provenance is conservatively
+routed to `fresh_scientific_audit`, so it cannot rest in an undrained
+preparation category. Do not refresh repeatedly in one session and do not
+invoke `gh workflow run audit.yml` from inside the audit loop (the CI workflow
+runs its own pipeline and could race the local one).
 
 The empty-queue refresh exists because runner caches and audit verdicts land continuously; the queue snapshot can lag behind by several commits when the session started. A single local refresh covers the common case where a recent PR (e.g. a compute-limited backlog repair) made dozens of rows newly auditable but the local queue hasn't yet caught up.
 

--- a/docs/ai_methodology/skills/audit-loop/SKILL.md
+++ b/docs/ai_methodology/skills/audit-loop/SKILL.md
@@ -840,7 +840,12 @@ now-unblocked downstream conditionals.
 Default fall-through selection is the highest-priority ready scoped claim:
 
 1. Read `docs/audit/data/audit_queue.json`.
-2. Pick the first row with `ready = true`, `audit_status` in `{unaudited, audit_in_progress}`, and `claim_type` in `{positive_theorem, bounded_theorem, no_go, open_gate}`.
+2. Pick the first row with `ready = true`, `audit_work_kind =
+   fresh_scientific_audit`, `audit_status` in `{unaudited,
+   audit_in_progress}`, and `claim_type` in `{positive_theorem,
+   bounded_theorem, no_go, open_gate}`. `ready` is the conjunction of
+   `dependency_ready` and `forensic_evidence_ready`; it is no longer a
+   dependency-only flag.
 3. If the user explicitly says strict queue order, take the top queue row even if `claim_type` is unset.
 4. Exclude any claim id recorded in the current session's blocked/skip set by the Blocked-Row Loop Guard.
 5. If only `meta` or `decoration` rows remain, process them only when the user explicitly asks for those classes.
@@ -856,7 +861,14 @@ bash docs/audit/scripts/run_pipeline.sh
 python3 docs/audit/scripts/audit_lint.py --strict
 ```
 
-Then re-attempt selection (steps 1-5). If the refreshed queue is still empty by the same filters, the audit lane is genuinely caught up — report the empty queue, the refresh attempt, and stop the loop. Do not refresh repeatedly in one session and do not invoke `gh workflow run audit.yml` from inside the audit loop (the CI workflow runs its own pipeline and could race the local one).
+Then re-attempt selection (steps 1-5). If the refreshed fresh-science selector
+is empty, inspect and report `by_work_kind`. The audit lane is genuinely
+caught up only when there is also no `legacy_packet_upgrade`,
+`provenance_reconstruction_required`, or `evidence_repair_required` work.
+Those are mechanical preparation/certification lanes, never permission to
+spend a fresh scientific seat. Do not refresh repeatedly in one session and
+do not invoke `gh workflow run audit.yml` from inside the audit loop (the CI
+workflow runs its own pipeline and could race the local one).
 
 The empty-queue refresh exists because runner caches and audit verdicts land continuously; the queue snapshot can lag behind by several commits when the session started. A single local refresh covers the common case where a recent PR (e.g. a compute-limited backlog repair) made dozens of rows newly auditable but the local queue hasn't yet caught up.
 
@@ -867,7 +879,9 @@ python3 - <<'PY'
 import json
 q=json.load(open("docs/audit/data/audit_queue.json"))["queue"]
 for e in q:
-    if e.get("ready") and e.get("claim_type") in {"positive_theorem","bounded_theorem","no_go","open_gate"}:
+    if (e.get("ready")
+            and e.get("audit_work_kind") == "fresh_scientific_audit"
+            and e.get("claim_type") in {"positive_theorem","bounded_theorem","no_go","open_gate"}):
         print(e["claim_id"], e["note_path"], e.get("runner_path") or "-")
         break
 PY

--- a/docs/ai_methodology/skills/review-loop/PREFLIGHT.md
+++ b/docs/ai_methodology/skills/review-loop/PREFLIGHT.md
@@ -89,6 +89,13 @@ mutation per check family (on a scratch copy or reverted immediately), and
 the check must fail. A check that asserts the formula it is supposed to test
 confirms nothing. Record the mutations you ran in the PR body.
 
+After the full pipeline refreshes changed-runner caches, run
+`python3 docs/audit/scripts/check_changed_audit_evidence.py --base
+origin/main`. Fix every named missing runner/input/current compute result or
+incomplete N5 certificate before requesting review. This is preflight only:
+the independent audit reruns the exact runner live and does not inherit a PR
+author's verdict.
+
 ## 9. Clean-state validation
 
 From a worktree with no untracked pipeline residue (`git clean` generated

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -897,11 +897,12 @@ python3 docs/audit/scripts/check_changed_audit_evidence.py --base origin/main
 ```
 
 This gate is mechanical preparation, not an audit. It must pass for every
-changed non-meta scientific note and every row bound to a changed primary or
-helper runner. A missing runner, invalid/unreadable declared input, stale or
-failed SHA/input-bound compute result, or incomplete forensic N5 resolution
-certificate blocks review-loop PASS. Repair the evidence surface in the PR,
-or make intentionally incomplete work an explicit `open_gate`; do not let the
+changed row not classified as `meta`, `open_gate`, or `decoration`, including
+every such row bound to a changed primary or helper runner. A missing runner,
+invalid/unreadable declared input, stale or failed SHA/input-bound compute
+result, or incomplete forensic N5 resolution certificate blocks review-loop
+PASS. Intentionally incomplete work must be typed as an explicit `open_gate`
+and remains outside this seat-readiness gate until promoted; do not let the
 independent audit discover a deterministic compute omission after spending a
 seat. The cache/result used here is non-authoritative review evidence only.
 The audit lane must still execute the current runner live and authenticate its

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -819,6 +819,21 @@ repair first, or ask for explicit user approval to spend the audit capacity.
 Never trade a clean audit graph for cosmetic source-note churn without making
 that cost explicit.
 
+**Dependency/axiom impact guard.** `science_fingerprint_v2` binds the complete
+framework-premise epoch and dependency-policy epoch. A branch that changes an
+axiom/approved primitive, premise membership or classification, document
+authority/admission registry, citation/dependency extraction policy,
+chain-sufficiency policy, or the fresh-look dependency standard must inspect
+the pipeline's resulting invalidation set before PASS. The safe default is a
+fresh scientific audit for every mismatching fingerprint, including
+transitive consumers. Narrowing that blast radius requires a separate,
+reviewed machine-readable equivalence/impact record; neither the PR author nor
+review-loop may silently declare existing scientific judgments unaffected.
+`docs/audit/data/legacy_science_epoch_baseline.json` is an immutable
+deployment anchor, not a rolling manifest: never refresh it to make a policy
+change pass. A mismatch must invalidate remaining pre-v2 judgments or be
+resolved by a separately reviewed, row-specific provenance migration.
+
 0. Before applying a PR, inventory any audit-status surface it touches:
 
 ```bash
@@ -873,6 +888,24 @@ git diff --check
 
 The known graph-cycle warning is acceptable. Any strict-lint error blocks a
 review-loop PASS.
+
+6a. **Changed-science evidence-readiness PASS gate (hard).** After the full
+pipeline has executed or refreshed every changed runner, run:
+
+```bash
+python3 docs/audit/scripts/check_changed_audit_evidence.py --base origin/main
+```
+
+This gate is mechanical preparation, not an audit. It must pass for every
+changed non-meta scientific note and every row bound to a changed primary or
+helper runner. A missing runner, invalid/unreadable declared input, stale or
+failed SHA/input-bound compute result, or incomplete forensic N5 resolution
+certificate blocks review-loop PASS. Repair the evidence surface in the PR,
+or make intentionally incomplete work an explicit `open_gate`; do not let the
+independent audit discover a deterministic compute omission after spending a
+seat. The cache/result used here is non-authoritative review evidence only.
+The audit lane must still execute the current runner live and authenticate its
+invocation-bound stdout before applying a verdict.
 
 **`note_hash` drift is a notice for non-retained rows, an error only for
 retained-grade rows.** `note_hash` is a *source-content* hash, not an audit

--- a/docs/audit/data/dependency_policy_epoch.json
+++ b/docs/audit/data/dependency_policy_epoch.json
@@ -1,0 +1,15 @@
+{
+  "description": "Reviewed identity of the policy surfaces that determine citation dependencies, accepted-premise classification, chain sufficiency, and audit readiness. Any source hash change must update this controlled manifest through review-loop; science_fingerprint_v2 then invalidates affected judgments under the new epoch.",
+  "epoch": "dependency_policy_v1",
+  "schema": "dependency_policy_epoch_manifest_v1",
+  "sources": {
+    "docs/audit/FRESH_LOOK_REQUIREMENTS.md": "9893d3d632ae3fc3dc0584b7d6c430f7429448d70d9761797a37d36b3f9f6be8",
+    "docs/audit/data/doc_authority_registry.json": "35ff01d3e5e0f92508d0e444d4c342ec928b1ea0fa1e5bcf44daf3ead7364173",
+    "docs/audit/data/owner_governed_premise_nodes.json": null,
+    "docs/audit/data/source_path_aliases.json": "f99befd84da12bba9a39659fcb30fd98e4065873f80de19942110a8249297638",
+    "docs/audit/data/tier_a_admissions.json": null,
+    "docs/audit/scripts/build_citation_graph.py": "e09dbee45c074c5f62f0133fa1261bee95b8671adae9147584febb3b658a541e",
+    "docs/audit/scripts/compute_effective_status.py": "f0a78fd0679b6c94684224af74938a6b6f108f64b32bbb713470827eac4ac422",
+    "docs/audit/scripts/premise_nodes.py": "932d901c18c5b17c80213bf908e857d67a851fc7ba1d5a7f9e96a83e351499cf"
+  }
+}

--- a/docs/audit/data/dependency_policy_epoch.json
+++ b/docs/audit/data/dependency_policy_epoch.json
@@ -8,7 +8,7 @@
     "docs/audit/data/owner_governed_premise_nodes.json": null,
     "docs/audit/data/source_path_aliases.json": "f99befd84da12bba9a39659fcb30fd98e4065873f80de19942110a8249297638",
     "docs/audit/data/tier_a_admissions.json": null,
-    "docs/audit/scripts/audit_science_fingerprint.py": "b8df2241339f83d83de5105c492e8ff675f1f4584fefcfa0161d3aeb8b4240b2",
+    "docs/audit/scripts/audit_science_fingerprint.py": "23ca0c90aff6cc0f3f53e63d2930a8751e1d5dfffa3357debed0a1d9906f5348",
     "docs/audit/scripts/build_citation_graph.py": "e09dbee45c074c5f62f0133fa1261bee95b8671adae9147584febb3b658a541e",
     "docs/audit/scripts/classify_runner_passes.py": "00bbc8c1dadef177542b0a98c75ead2e15c13c94c4b5595406d9818ec9129289",
     "docs/audit/scripts/compute_audit_queue.py": "9cfe60140554ac19c38bfd8637d3a5348b665beae6059d61e127af1b9cba1ff6",

--- a/docs/audit/data/dependency_policy_epoch.json
+++ b/docs/audit/data/dependency_policy_epoch.json
@@ -1,6 +1,6 @@
 {
   "description": "Reviewed identity of the policy surfaces that determine citation dependencies, accepted-premise classification, chain sufficiency, and audit readiness. Any source hash change must update this controlled manifest through review-loop; science_fingerprint_v2 then invalidates affected judgments under the new epoch.",
-  "epoch": "dependency_policy_v1",
+  "epoch": "dependency_policy_v2",
   "schema": "dependency_policy_epoch_manifest_v1",
   "sources": {
     "docs/audit/FRESH_LOOK_REQUIREMENTS.md": "9893d3d632ae3fc3dc0584b7d6c430f7429448d70d9761797a37d36b3f9f6be8",
@@ -8,8 +8,14 @@
     "docs/audit/data/owner_governed_premise_nodes.json": null,
     "docs/audit/data/source_path_aliases.json": "f99befd84da12bba9a39659fcb30fd98e4065873f80de19942110a8249297638",
     "docs/audit/data/tier_a_admissions.json": null,
+    "docs/audit/scripts/audit_science_fingerprint.py": "b8df2241339f83d83de5105c492e8ff675f1f4584fefcfa0161d3aeb8b4240b2",
     "docs/audit/scripts/build_citation_graph.py": "e09dbee45c074c5f62f0133fa1261bee95b8671adae9147584febb3b658a541e",
+    "docs/audit/scripts/classify_runner_passes.py": "00bbc8c1dadef177542b0a98c75ead2e15c13c94c4b5595406d9818ec9129289",
+    "docs/audit/scripts/compute_audit_queue.py": "9cfe60140554ac19c38bfd8637d3a5348b665beae6059d61e127af1b9cba1ff6",
     "docs/audit/scripts/compute_effective_status.py": "f0a78fd0679b6c94684224af74938a6b6f108f64b32bbb713470827eac4ac422",
-    "docs/audit/scripts/premise_nodes.py": "932d901c18c5b17c80213bf908e857d67a851fc7ba1d5a7f9e96a83e351499cf"
+    "docs/audit/scripts/forensic_evidence_readiness.py": "516e28fafd6fd752a967b6d491b0c9cb8058b60fb6fc7c849b279b185df87f97",
+    "docs/audit/scripts/premise_nodes.py": "932d901c18c5b17c80213bf908e857d67a851fc7ba1d5a7f9e96a83e351499cf",
+    "docs/audit/scripts/runner_pin_gate.py": "8dbb4d2a8ad4ac753f4b261f0e9d05ddb7a401af6edcd73c5cebf9a48819ec7e",
+    "scripts/runner_cache.py": "1f534bb856d68140359e7204b08577c204195ff6077e7d7f6c4974e92f0afaf2"
   }
 }

--- a/docs/audit/data/legacy_science_epoch_baseline.json
+++ b/docs/audit/data/legacy_science_epoch_baseline.json
@@ -1,5 +1,5 @@
 {
-  "dependency_policy_epoch_digest": "729eb5e07f5cfa1dd6bbf7861e45d249a5684d32c09fe09b7bff8f3918b2dfe1",
+  "dependency_policy_epoch_digest": "2b8150fbbe023645cdf719e191879d783c36236f4dea9dbfe9b81a117ae27d69",
   "description": "Immutable deployment anchor for active audit judgments that predate science_fingerprint_v2. Do not refresh these digests when an axiom, approved premise, or dependency policy changes: a mismatch deliberately forces those legacy judgments through fresh audit or a separately reviewed provenance migration.",
   "framework_premise_epoch_digest": "165602dd6159ee02ffbcfafd6ad5ef57379927914d0eab015d33beca8f07942c",
   "schema": "legacy_science_epoch_baseline_v1"

--- a/docs/audit/data/legacy_science_epoch_baseline.json
+++ b/docs/audit/data/legacy_science_epoch_baseline.json
@@ -1,5 +1,5 @@
 {
-  "dependency_policy_epoch_digest": "2b8150fbbe023645cdf719e191879d783c36236f4dea9dbfe9b81a117ae27d69",
+  "dependency_policy_epoch_digest": "851282352b8361355483ed852ac492b64c4b0cb73a3f66f311046cc94ac934dc",
   "description": "Immutable deployment anchor for active audit judgments that predate science_fingerprint_v2. Do not refresh these digests when an axiom, approved premise, or dependency policy changes: a mismatch deliberately forces those legacy judgments through fresh audit or a separately reviewed provenance migration.",
   "framework_premise_epoch_digest": "165602dd6159ee02ffbcfafd6ad5ef57379927914d0eab015d33beca8f07942c",
   "schema": "legacy_science_epoch_baseline_v1"

--- a/docs/audit/data/legacy_science_epoch_baseline.json
+++ b/docs/audit/data/legacy_science_epoch_baseline.json
@@ -1,0 +1,6 @@
+{
+  "dependency_policy_epoch_digest": "729eb5e07f5cfa1dd6bbf7861e45d249a5684d32c09fe09b7bff8f3918b2dfe1",
+  "description": "Immutable deployment anchor for active audit judgments that predate science_fingerprint_v2. Do not refresh these digests when an axiom, approved premise, or dependency policy changes: a mismatch deliberately forces those legacy judgments through fresh audit or a separately reviewed provenance migration.",
+  "framework_premise_epoch_digest": "165602dd6159ee02ffbcfafd6ad5ef57379927914d0eab015d33beca8f07942c",
+  "schema": "legacy_science_epoch_baseline_v1"
+}

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -41,6 +41,7 @@ from pathlib import Path
 import no_go_discipline_gate
 import audit_invocation
 import audit_contract
+import audit_science_fingerprint
 
 import ledger_io
 
@@ -804,6 +805,21 @@ def snapshot_audit_state(row: dict, rows: dict[str, dict]) -> dict:
         "transitive_descendants": row.get("transitive_descendants"),
         "runner_hash": runner_hash_value,
         "helper_runner_hashes": helper_runner_hashes,
+        # Scientific provenance and packet-policy provenance are deliberately
+        # separate.  Exact science drift forces a new scientific audit; a
+        # policy-only drift may be handled by a governed packet upgrade that
+        # cannot alter the prior judgment.
+        "science_fingerprint": audit_science_fingerprint.build_science_fingerprint(
+            row,
+            rows,
+            REPO_ROOT,
+        ),
+        "packet_policy_fingerprint": (
+            audit_science_fingerprint.packet_policy_fingerprint(REPO_ROOT)
+        ),
+        "judgment_fingerprint": (
+            audit_science_fingerprint.judgment_fingerprint(row)
+        ),
     }
     # v1 blocker-fingerprint stamp for NEW conditional/failed verdict writes
     # only (dispatch-retarget design note, 2026-07-16, section 3b). Callers
@@ -1581,6 +1597,12 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
 
     def accept_row() -> None:
         """Commit the detached row and consume this invocation exactly once."""
+        if row.get("audit_status") not in {None, "unaudited"}:
+            # Several governed paths return before the ordinary field-apply
+            # tail (first critical seat, disagreements, explicit second
+            # seats).  They still contain a scientific judgment and therefore
+            # need the same fail-closed provenance baseline.
+            row["audit_state_snapshot"] = snapshot_audit_state(row, rows)
         consume_audit_invocation(row, invocation_id)
         rows[cid] = row
         ledger["rows"] = rows

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -1549,8 +1549,8 @@ def apply_judicial_review(ledger: dict, judgment: dict) -> tuple[bool, str]:
     else:
         row["no_go_discipline"] = judgment.get("no_go_discipline")
     row["blocker"] = None
-    row["audit_state_snapshot"] = snapshot_audit_state(row, rows)
     consume_audit_invocation(row, invocation_id)
+    row["audit_state_snapshot"] = snapshot_audit_state(row, rows)
     rows[cid] = row
     ledger["rows"] = rows
     return True, f"judicial panel majority confirmed {side} verdict"
@@ -1597,13 +1597,13 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
 
     def accept_row() -> None:
         """Commit the detached row and consume this invocation exactly once."""
+        consume_audit_invocation(row, invocation_id)
         if row.get("audit_status") not in {None, "unaudited"}:
             # Several governed paths return before the ordinary field-apply
             # tail (first critical seat, disagreements, explicit second
             # seats).  They still contain a scientific judgment and therefore
             # need the same fail-closed provenance baseline.
             row["audit_state_snapshot"] = snapshot_audit_state(row, rows)
-        consume_audit_invocation(row, invocation_id)
         rows[cid] = row
         ledger["rows"] = rows
 
@@ -2079,10 +2079,6 @@ def apply_one(ledger: dict, audit: dict) -> tuple[bool, str]:
         if "prose_corrections" in audit:
             row["prose_corrections"] = audit["prose_corrections"]
 
-    # Snapshot the state at audit time so invalidate_stale_audits.py can
-    # detect changes that warrant re-audit (dep added/removed, dep status
-    # changed, criticality bumped).
-    row["audit_state_snapshot"] = snapshot_audit_state(row, rows)
     accept_row()
     if terminal_second_pass_error:
         return False, terminal_second_pass_error

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -59,6 +59,7 @@ import premise_nodes
 import ledger_io
 import no_go_discipline_gate
 import audit_contract
+import audit_science_fingerprint
 import runner_pin_gate
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -2039,6 +2040,75 @@ def main() -> int:
         # (e.g. via invalidate_stale_audits.py or note-hash drift), the
         # snapshot is just historical noise and shouldn't generate a warning.
         snap = row.get("audit_state_snapshot")
+        if snap is not None and a not in {None, "unaudited"}:
+            science_baseline = snap.get("science_fingerprint")
+            if science_baseline is not None:
+                science_problems = (
+                    audit_science_fingerprint.science_fingerprint_problems(
+                        science_baseline
+                    )
+                )
+                if science_problems:
+                    errors.append(
+                        f"{cid}: malformed science_fingerprint_v2: "
+                        f"{science_problems}"
+                    )
+                else:
+                    try:
+                        current_science = (
+                            audit_science_fingerprint.build_science_fingerprint(
+                                {**row, "claim_id": cid},
+                                rows,
+                                REPO_ROOT,
+                            )
+                        )
+                    except audit_science_fingerprint.ScienceFingerprintError as exc:
+                        errors.append(
+                            f"{cid}: cannot recompute science_fingerprint_v2: {exc}"
+                        )
+                    else:
+                        science_change = (
+                            audit_science_fingerprint.science_fingerprint_change(
+                                science_baseline,
+                                current_science,
+                            )
+                        )
+                        if science_change is not None:
+                            errors.append(
+                                f"{cid}: stale science_fingerprint_v2: "
+                                f"{science_change}; run invalidation before "
+                                "treating this audit as live"
+                            )
+            else:
+                try:
+                    legacy_epoch_change = (
+                        audit_science_fingerprint.legacy_science_epoch_change(
+                            REPO_ROOT
+                        )
+                    )
+                except audit_science_fingerprint.ScienceFingerprintError as exc:
+                    errors.append(
+                        f"{cid}: cannot validate legacy science-epoch "
+                        f"baseline: {exc}"
+                    )
+                else:
+                    if legacy_epoch_change is not None:
+                        errors.append(
+                            f"{cid}: {legacy_epoch_change}; run invalidation "
+                            "before treating this legacy audit as live"
+                        )
+            judgment_baseline = snap.get("judgment_fingerprint")
+            if judgment_baseline is not None:
+                judgment_change = (
+                    audit_science_fingerprint.judgment_fingerprint_change(
+                        judgment_baseline,
+                        {**row, "claim_id": cid},
+                    )
+                )
+                if judgment_change is not None:
+                    errors.append(
+                        f"{cid}: stale frozen audit judgment: {judgment_change}"
+                    )
         if snap is not None and a not in {None, "unaudited", "audit_in_progress"}:
             crit_now = row.get("criticality") or "leaf"
             crit_at_audit = snap.get("criticality") or "leaf"

--- a/docs/audit/scripts/audit_lint.py
+++ b/docs/audit/scripts/audit_lint.py
@@ -1151,6 +1151,7 @@ def main() -> int:
     errors: list[str] = []
     warnings: dict[str, list[str]] = defaultdict(list)
     notices: dict[str, list[str]] = defaultdict(list)
+    science_epoch_cache: dict[str, str] = {}
 
     def add_warning(category: str, message: str) -> None:
         warnings[category].append(message)
@@ -2034,14 +2035,17 @@ def main() -> int:
                     )
 
         # Criticality bump after audit (warn that re-audit may be needed).
-        # Skip rows already at unaudited / audit_in_progress: the warning is
-        # only meaningful for an ACTIVE audit verdict whose snapshot might be
-        # stale relative to current criticality. Once the row has been reset
-        # (e.g. via invalidate_stale_audits.py or note-hash drift), the
-        # snapshot is just historical noise and shouldn't generate a warning.
+        # Scientific provenance applies to every active judgment, including an
+        # awaiting-second-seat ``audit_in_progress`` row.  Criticality-specific
+        # warnings below still exclude in-progress rows.  Once fully reset to
+        # unaudited, the snapshot is historical noise.
         snap = row.get("audit_state_snapshot")
-        if snap is not None and a not in {None, "unaudited"}:
-            science_baseline = snap.get("science_fingerprint")
+        if a not in {None, "unaudited"}:
+            science_baseline = (
+                snap.get("science_fingerprint")
+                if isinstance(snap, dict)
+                else None
+            )
             if science_baseline is not None:
                 science_problems = (
                     audit_science_fingerprint.science_fingerprint_problems(
@@ -2060,6 +2064,7 @@ def main() -> int:
                                 {**row, "claim_id": cid},
                                 rows,
                                 REPO_ROOT,
+                                epoch_cache=science_epoch_cache,
                             )
                         )
                     except audit_science_fingerprint.ScienceFingerprintError as exc:
@@ -2083,7 +2088,8 @@ def main() -> int:
                 try:
                     legacy_epoch_change = (
                         audit_science_fingerprint.legacy_science_epoch_change(
-                            REPO_ROOT
+                            REPO_ROOT,
+                            epoch_cache=science_epoch_cache,
                         )
                     )
                 except audit_science_fingerprint.ScienceFingerprintError as exc:
@@ -2097,7 +2103,16 @@ def main() -> int:
                             f"{cid}: {legacy_epoch_change}; run invalidation "
                             "before treating this legacy audit as live"
                         )
-            judgment_baseline = snap.get("judgment_fingerprint")
+                if snap is not None and not isinstance(snap, dict):
+                    errors.append(
+                        f"{cid}: malformed legacy audit_state_snapshot; "
+                        "run invalidation before treating this audit as live"
+                    )
+            judgment_baseline = (
+                snap.get("judgment_fingerprint")
+                if isinstance(snap, dict)
+                else None
+            )
             if judgment_baseline is not None:
                 judgment_change = (
                     audit_science_fingerprint.judgment_fingerprint_change(
@@ -2109,7 +2124,7 @@ def main() -> int:
                     errors.append(
                         f"{cid}: stale frozen audit judgment: {judgment_change}"
                     )
-        if snap is not None and a not in {None, "unaudited", "audit_in_progress"}:
+        if isinstance(snap, dict) and a not in {None, "unaudited", "audit_in_progress"}:
             crit_now = row.get("criticality") or "leaf"
             crit_at_audit = snap.get("criticality") or "leaf"
             crit_rank = {"leaf": 0, "medium": 1, "high": 2, "critical": 3}

--- a/docs/audit/scripts/audit_science_fingerprint.py
+++ b/docs/audit/scripts/audit_science_fingerprint.py
@@ -633,7 +633,6 @@ def judgment_fingerprint(row: dict) -> dict[str, Any]:
         "auditor_model",
         "auditor_reasoning_effort",
         "audit_invocation_id",
-        "audit_invocation_history",
         "independence",
         "claim_type",
         "claim_scope",

--- a/docs/audit/scripts/audit_science_fingerprint.py
+++ b/docs/audit/scripts/audit_science_fingerprint.py
@@ -18,7 +18,7 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
@@ -27,6 +27,32 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
 SCIENCE_FINGERPRINT_SCHEMA = "science_fingerprint_v2"
 PACKET_POLICY_FINGERPRINT_SCHEMA = "packet_policy_fingerprint_v1"
 JUDGMENT_FINGERPRINT_SCHEMA = "frozen_audit_judgment_v1"
+
+# These sources define which inputs are admissible, how dependency readiness
+# is interpreted, and whether runner evidence is authentic and complete.  The
+# manifest in ``dependency_policy_epoch.json`` must contain this exact set.
+# Keep the tuple centralized so tests and maintenance tools cannot silently
+# mirror a narrower policy boundary.
+DEPENDENCY_POLICY_SOURCES = (
+    "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
+    "docs/audit/scripts/audit_science_fingerprint.py",
+    "docs/audit/scripts/build_citation_graph.py",
+    "docs/audit/scripts/classify_runner_passes.py",
+    "docs/audit/scripts/compute_audit_queue.py",
+    "docs/audit/scripts/compute_effective_status.py",
+    "docs/audit/scripts/forensic_evidence_readiness.py",
+    "docs/audit/scripts/premise_nodes.py",
+    "docs/audit/scripts/runner_pin_gate.py",
+    "scripts/runner_cache.py",
+    "docs/audit/data/doc_authority_registry.json",
+    "docs/audit/data/tier_a_admissions.json",
+    "docs/audit/data/owner_governed_premise_nodes.json",
+    "docs/audit/data/source_path_aliases.json",
+)
+OPTIONAL_DEPENDENCY_POLICY_SOURCES = {
+    "docs/audit/data/tier_a_admissions.json",
+    "docs/audit/data/owner_governed_premise_nodes.json",
+}
 
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
@@ -52,6 +78,26 @@ def _canonical_json(value: object) -> bytes:
 
 def _digest(value: object) -> str:
     return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _epoch_value(
+    repo_root: Path,
+    cache: dict[str, str] | None,
+    key: str,
+    builder: Callable[[Path], str],
+) -> str:
+    """Memoize repository-wide epochs only when a caller owns the cache.
+
+    Direct calls remain uncached so unit tests, migrations, and review probes
+    observe filesystem edits immediately.  Long ledger sweeps pass a cache
+    whose lifetime is one immutable repository read, avoiding thousands of
+    repeated hashes of the same governed sources.
+    """
+    if cache is None:
+        return builder(repo_root)
+    if key not in cache:
+        cache[key] = builder(repo_root)
+    return cache[key]
 
 
 def _file_sha256(path: Path, *, required: bool = False) -> str | None:
@@ -213,23 +259,12 @@ def dependency_policy_epoch(repo_root: Path) -> str:
     governed policy surfaces makes a premise/admission/readiness rule change a
     deliberate re-audit event whose blast radius is visible in review.
     """
-    paths = (
-        "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
-        "docs/audit/scripts/build_citation_graph.py",
-        "docs/audit/scripts/compute_effective_status.py",
-        "docs/audit/scripts/premise_nodes.py",
-        "docs/audit/data/doc_authority_registry.json",
-        "docs/audit/data/tier_a_admissions.json",
-        "docs/audit/data/owner_governed_premise_nodes.json",
-        "docs/audit/data/source_path_aliases.json",
-    )
-    optional = {
-        "docs/audit/data/tier_a_admissions.json",
-        "docs/audit/data/owner_governed_premise_nodes.json",
-    }
     actual_sources = {
-        path: _file_sha256(repo_root / path, required=path not in optional)
-        for path in paths
+        path: _file_sha256(
+            repo_root / path,
+            required=path not in OPTIONAL_DEPENDENCY_POLICY_SOURCES,
+        )
+        for path in DEPENDENCY_POLICY_SOURCES
     }
     manifest_path = (
         repo_root / "docs" / "audit" / "data" /
@@ -257,7 +292,11 @@ def dependency_policy_epoch(repo_root: Path) -> str:
     )
 
 
-def legacy_science_epoch_change(repo_root: Path) -> str | None:
+def legacy_science_epoch_change(
+    repo_root: Path,
+    *,
+    epoch_cache: dict[str, str] | None = None,
+) -> str | None:
     """Protect pre-v2 judgments against future premise/policy drift.
 
     Existing audit snapshots predate the per-judgment premise and policy
@@ -291,9 +330,19 @@ def legacy_science_epoch_change(repo_root: Path) -> str | None:
             "legacy science-epoch baseline is malformed; do not refresh "
             "it to silence premise or policy drift"
         )
-    if framework_premise_epoch(repo_root) != expected_framework:
+    if _epoch_value(
+        repo_root,
+        epoch_cache,
+        "framework_premise_epoch",
+        framework_premise_epoch,
+    ) != expected_framework:
         return "legacy_framework_premise_epoch_changed"
-    if dependency_policy_epoch(repo_root) != expected_policy:
+    if _epoch_value(
+        repo_root,
+        epoch_cache,
+        "dependency_policy_epoch",
+        dependency_policy_epoch,
+    ) != expected_policy:
         return "legacy_dependency_policy_epoch_changed"
     return None
 
@@ -365,6 +414,8 @@ def build_science_fingerprint(
     row: dict,
     rows: dict[str, dict],
     repo_root: Path,
+    *,
+    epoch_cache: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Build the exact scientific-input baseline for one audit judgment."""
     claim_id = row.get("claim_id")
@@ -438,8 +489,18 @@ def build_science_fingerprint(
         },
         "dependencies": dependency_states,
         "runners": runners,
-        "framework_premise_epoch": framework_premise_epoch(repo_root),
-        "dependency_policy_epoch": dependency_policy_epoch(repo_root),
+        "framework_premise_epoch": _epoch_value(
+            repo_root,
+            epoch_cache,
+            "framework_premise_epoch",
+            framework_premise_epoch,
+        ),
+        "dependency_policy_epoch": _epoch_value(
+            repo_root,
+            epoch_cache,
+            "dependency_policy_epoch",
+            dependency_policy_epoch,
+        ),
     }
     body["digest"] = _digest(body)
     return body
@@ -571,6 +632,8 @@ def judgment_fingerprint(row: dict) -> dict[str, Any]:
         "auditor_family",
         "auditor_model",
         "auditor_reasoning_effort",
+        "audit_invocation_id",
+        "audit_invocation_history",
         "independence",
         "claim_type",
         "claim_scope",

--- a/docs/audit/scripts/audit_science_fingerprint.py
+++ b/docs/audit/scripts/audit_science_fingerprint.py
@@ -1,0 +1,628 @@
+#!/usr/bin/env python3
+"""Content-addressed scientific provenance for audit judgments.
+
+``science_fingerprint_v2`` deliberately excludes audit-packet policy.  A
+packet/schema change may require a new certificate, but it does not by itself
+change the scientific judgment.  Conversely, every surface that can change
+the meaning or evidential basis of that judgment is captured here and must
+match exactly before any prior judgment can be reused.
+
+The fingerprint is shared by apply, invalidation, restoration, and queue
+routing.  Do not mirror this logic in a caller: a provenance comparison is a
+security boundary and must have one producer/comparator.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+
+SCIENCE_FINGERPRINT_SCHEMA = "science_fingerprint_v2"
+PACKET_POLICY_FINGERPRINT_SCHEMA = "packet_policy_fingerprint_v1"
+JUDGMENT_FINGERPRINT_SCHEMA = "frozen_audit_judgment_v1"
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ScienceFingerprintError(ValueError):
+    """A scientific provenance baseline cannot be produced or validated."""
+
+
+def _canonical_json(value: object) -> bytes:
+    try:
+        rendered = json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ScienceFingerprintError(
+            f"scientific provenance is not canonical JSON: {exc}"
+        ) from exc
+    return rendered.encode("utf-8")
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _file_sha256(path: Path, *, required: bool = False) -> str | None:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as exc:
+        if required:
+            raise ScienceFingerprintError(
+                f"required scientific provenance surface is unreadable: {path}"
+            ) from exc
+        return None
+
+
+def _load_json_object(path: Path, label: str) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ScienceFingerprintError(f"cannot read {label}: {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ScienceFingerprintError(f"{label} must contain a JSON object: {path}")
+    return value
+
+
+def _premise_registry(repo_root: Path) -> dict:
+    path = repo_root / "docs" / "audit" / "data" / "axiom_premise_nodes.json"
+    registry = _load_json_object(path, "axiom-premise registry")
+    canonical_ids = registry.get("canonical_ids")
+    nodes = registry.get("nodes")
+    if (
+        not isinstance(canonical_ids, list)
+        or not all(isinstance(item, str) and item for item in canonical_ids)
+        or len(canonical_ids) != len(set(canonical_ids))
+        or not isinstance(nodes, dict)
+    ):
+        raise ScienceFingerprintError("axiom-premise registry has an invalid shape")
+    for claim_id in canonical_ids:
+        node = nodes.get(claim_id)
+        current_path = node.get("current_path") if isinstance(node, dict) else None
+        if not isinstance(current_path, str) or not current_path:
+            raise ScienceFingerprintError(
+                f"axiom-premise registry has no current_path for {claim_id}"
+            )
+    return registry
+
+
+def _non_evidence_context_ids(repo_root: Path) -> set[str]:
+    path = repo_root / "docs" / "audit" / "data" / "doc_authority_registry.json"
+    registry = _load_json_object(path, "document-authority registry")
+    rows = registry.get("rows")
+    if not isinstance(rows, list):
+        raise ScienceFingerprintError("document-authority registry rows must be a list")
+    return {
+        str(item["claim_id"])
+        for item in rows
+        if isinstance(item, dict)
+        and item.get("chain_satisfying") is False
+        and isinstance(item.get("claim_id"), str)
+        and item.get("claim_id")
+    }
+
+
+def accepted_premise_ids(repo_root: Path) -> set[str]:
+    """Return the current canonical axiom/approved-primitive membership."""
+    return set(_premise_registry(repo_root)["canonical_ids"])
+
+
+def legacy_premise_snapshot_change(
+    snapshot: dict,
+    row: dict,
+    rows: dict[str, dict],
+    repo_root: Path,
+) -> str | None:
+    """Fail-closed compatibility check for pre-v2 premise hash snapshots.
+
+    A key in ``dep_axiom_premise_note_hash`` proves that the dependency was an
+    accepted premise when audited.  It must therefore remain both a direct
+    dependency and an accepted premise, and its registered note hash must
+    still match.  Crucially, iteration starts from the historical keys; using
+    current registry membership here would make removal/reclassification
+    invisible.
+    """
+    historical = snapshot.get("dep_axiom_premise_note_hash") or {}
+    if not isinstance(historical, dict):
+        return "legacy_premise_snapshot_invalid"
+    current_deps = set(row.get("deps") or [])
+    current_premises = accepted_premise_ids(repo_root)
+    historical_premises = set(historical)
+    current_direct_premises = current_deps & current_premises
+    newly_classified = sorted(current_direct_premises - historical_premises)
+    if newly_classified:
+        return f"axiom_premise_classification_changed:{newly_classified[0]}"
+    for dep_id, before in sorted(historical.items()):
+        if dep_id not in current_deps:
+            return f"axiom_premise_dependency_removed:{dep_id}"
+        if dep_id not in current_premises:
+            return f"axiom_premise_classification_changed:{dep_id}"
+        after = (rows.get(dep_id) or {}).get("note_hash")
+        if before != after:
+            before_short = before[:8] if isinstance(before, str) else "missing"
+            after_short = after[:8] if isinstance(after, str) else "missing"
+            return (
+                f"axiom_premise_changed:{dep_id}:"
+                f"{before_short}->{after_short}"
+            )
+    return None
+
+
+def premise_classification(
+    dep_id: str,
+    *,
+    accepted_premise_ids: set[str],
+    non_evidence_context_ids: set[str],
+) -> str:
+    if dep_id in accepted_premise_ids:
+        return "accepted_premise"
+    if dep_id in non_evidence_context_ids:
+        return "non_evidence_context"
+    return "ordinary_claim"
+
+
+def framework_premise_epoch(repo_root: Path) -> str:
+    """Bind premise membership, governance metadata, paths, and source bytes.
+
+    The full registry hash is intentional.  A change to what an axiom or
+    approved primitive means, how it is classified, or which source owns it is
+    scientifically relevant even when every ledger row remains ``meta``.
+    """
+    registry_path = (
+        repo_root / "docs" / "audit" / "data" / "axiom_premise_nodes.json"
+    )
+    registry = _premise_registry(repo_root)
+    node_sources: list[dict[str, str]] = []
+    for claim_id in registry["canonical_ids"]:
+        current_path = registry["nodes"][claim_id]["current_path"]
+        node_sources.append(
+            {
+                "claim_id": claim_id,
+                "current_path": current_path,
+                "source_sha256": _file_sha256(
+                    repo_root / current_path,
+                    required=True,
+                ),
+            }
+        )
+    return _digest(
+        {
+            "schema": "framework_premise_epoch_v2",
+            "registry_sha256": _file_sha256(registry_path, required=True),
+            "node_sources": node_sources,
+        }
+    )
+
+
+def dependency_policy_epoch(repo_root: Path) -> str:
+    """Bind the rules that decide dependency identity and chain sufficiency.
+
+    Exact row/dependency bytes are insufficient when the interpretation of a
+    dependency changes while its stored status string does not.  Hashing these
+    governed policy surfaces makes a premise/admission/readiness rule change a
+    deliberate re-audit event whose blast radius is visible in review.
+    """
+    paths = (
+        "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
+        "docs/audit/scripts/build_citation_graph.py",
+        "docs/audit/scripts/compute_effective_status.py",
+        "docs/audit/scripts/premise_nodes.py",
+        "docs/audit/data/doc_authority_registry.json",
+        "docs/audit/data/tier_a_admissions.json",
+        "docs/audit/data/owner_governed_premise_nodes.json",
+        "docs/audit/data/source_path_aliases.json",
+    )
+    optional = {
+        "docs/audit/data/tier_a_admissions.json",
+        "docs/audit/data/owner_governed_premise_nodes.json",
+    }
+    actual_sources = {
+        path: _file_sha256(repo_root / path, required=path not in optional)
+        for path in paths
+    }
+    manifest_path = (
+        repo_root / "docs" / "audit" / "data" /
+        "dependency_policy_epoch.json"
+    )
+    manifest = _load_json_object(manifest_path, "dependency-policy epoch")
+    if (
+        manifest.get("schema") != "dependency_policy_epoch_manifest_v1"
+        or not isinstance(manifest.get("epoch"), str)
+        or not manifest.get("epoch")
+        or manifest.get("sources") != actual_sources
+    ):
+        raise ScienceFingerprintError(
+            "dependency-policy epoch manifest does not exactly match its "
+            "governed sources; review the policy change and refresh "
+            "docs/audit/data/dependency_policy_epoch.json"
+        )
+    return _digest(
+        {
+            "schema": "dependency_policy_epoch_v1",
+            "epoch": manifest["epoch"],
+            "manifest_sha256": _file_sha256(manifest_path, required=True),
+            "sources": actual_sources,
+        }
+    )
+
+
+def legacy_science_epoch_change(repo_root: Path) -> str | None:
+    """Protect pre-v2 judgments against future premise/policy drift.
+
+    Existing audit snapshots predate the per-judgment premise and policy
+    epochs. The immutable deployment baseline records both governed epochs as
+    installed when v2 was introduced. Once either moves, any still-legacy
+    judgment must receive a fresh audit (or a separately reviewed provenance
+    migration) instead of silently inheriting changed axioms or dependency
+    criteria.
+    """
+    baseline_path = (
+        repo_root
+        / "docs"
+        / "audit"
+        / "data"
+        / "legacy_science_epoch_baseline.json"
+    )
+    baseline = _load_json_object(
+        baseline_path,
+        "legacy science-epoch baseline",
+    )
+    expected_framework = baseline.get("framework_premise_epoch_digest")
+    expected_policy = baseline.get("dependency_policy_epoch_digest")
+    if (
+        baseline.get("schema") != "legacy_science_epoch_baseline_v1"
+        or not isinstance(expected_framework, str)
+        or not _SHA256_RE.fullmatch(expected_framework)
+        or not isinstance(expected_policy, str)
+        or not _SHA256_RE.fullmatch(expected_policy)
+    ):
+        raise ScienceFingerprintError(
+            "legacy science-epoch baseline is malformed; do not refresh "
+            "it to silence premise or policy drift"
+        )
+    if framework_premise_epoch(repo_root) != expected_framework:
+        return "legacy_framework_premise_epoch_changed"
+    if dependency_policy_epoch(repo_root) != expected_policy:
+        return "legacy_dependency_policy_epoch_changed"
+    return None
+
+
+def _declared_input_state(runner_path: Path, repo_root: Path) -> dict[str, Any]:
+    # Import lazily so this module remains usable by small migration tools that
+    # set up the repository script path after import.
+    import runner_cache
+
+    declared = runner_cache.declared_input_paths(runner_path)
+    if declared == ():
+        raise ScienceFingerprintError(
+            f"invalid AUDIT_INPUT_PATHS declaration: {runner_path}"
+        )
+    if declared is None:
+        return {
+            "declared_input_paths": None,
+            "declared_input_fingerprint_sha256": None,
+            "declared_inputs": [],
+        }
+
+    digest = hashlib.sha256()
+    digest.update(b"runner-cache-input-fingerprint-v1\0")
+    inputs: list[dict[str, str]] = []
+    for relative in declared:
+        source_path = repo_root / relative
+        try:
+            body = source_path.read_bytes()
+        except OSError as exc:
+            raise ScienceFingerprintError(
+                f"declared runner input is unreadable: {relative}"
+            ) from exc
+        relative_bytes = relative.encode("utf-8")
+        digest.update(len(relative_bytes).to_bytes(8, "big"))
+        digest.update(relative_bytes)
+        digest.update(len(body).to_bytes(8, "big"))
+        digest.update(body)
+        inputs.append(
+            {
+                "path": relative,
+                "sha256": hashlib.sha256(body).hexdigest(),
+            }
+        )
+    return {
+        "declared_input_paths": list(declared),
+        "declared_input_fingerprint_sha256": digest.hexdigest(),
+        "declared_inputs": inputs,
+    }
+
+
+def _runner_state(path: str, role: str, repo_root: Path) -> dict[str, Any]:
+    absolute = repo_root / path
+    source_sha = _file_sha256(absolute)
+    state: dict[str, Any] = {
+        "role": role,
+        "path": path,
+        "present": source_sha is not None,
+        "sha256": source_sha,
+        "declared_input_paths": None,
+        "declared_input_fingerprint_sha256": None,
+        "declared_inputs": [],
+    }
+    if source_sha is not None:
+        state.update(_declared_input_state(absolute, repo_root))
+    return state
+
+
+def build_science_fingerprint(
+    row: dict,
+    rows: dict[str, dict],
+    repo_root: Path,
+) -> dict[str, Any]:
+    """Build the exact scientific-input baseline for one audit judgment."""
+    claim_id = row.get("claim_id")
+    note_path = row.get("note_path")
+    if not isinstance(claim_id, str) or not claim_id:
+        raise ScienceFingerprintError("audit row has no claim_id")
+    if not isinstance(note_path, str) or not note_path:
+        raise ScienceFingerprintError(f"audit row {claim_id} has no note_path")
+
+    registry = _premise_registry(repo_root)
+    accepted_ids = set(registry["canonical_ids"])
+    non_evidence_ids = _non_evidence_context_ids(repo_root)
+    deps = sorted(row.get("deps") or [])
+    if not all(isinstance(dep, str) and dep for dep in deps):
+        raise ScienceFingerprintError(f"audit row {claim_id} has invalid dependencies")
+    if len(deps) != len(set(deps)):
+        raise ScienceFingerprintError(f"audit row {claim_id} has duplicate dependencies")
+
+    dependency_states: list[dict[str, Any]] = []
+    for dep_id in deps:
+        dep = rows.get(dep_id)
+        dep_path = dep.get("note_path") if isinstance(dep, dict) else None
+        dependency_states.append(
+            {
+                "claim_id": dep_id,
+                "present": isinstance(dep, dict),
+                "note_path": dep_path,
+                "note_sha256": (
+                    _file_sha256(repo_root / dep_path)
+                    if isinstance(dep_path, str) and dep_path
+                    else None
+                ),
+                "ledger_note_hash": (
+                    dep.get("note_hash") if isinstance(dep, dict) else None
+                ),
+                "claim_type": (
+                    dep.get("claim_type") if isinstance(dep, dict) else None
+                ),
+                "claim_scope": (
+                    dep.get("claim_scope") if isinstance(dep, dict) else None
+                ),
+                "effective_status": (
+                    dep.get("effective_status") if isinstance(dep, dict) else None
+                ),
+                "premise_classification": premise_classification(
+                    dep_id,
+                    accepted_premise_ids=accepted_ids,
+                    non_evidence_context_ids=non_evidence_ids,
+                ),
+            }
+        )
+
+    runners: list[dict[str, Any]] = []
+    primary = row.get("runner_path")
+    if isinstance(primary, str) and primary:
+        runners.append(_runner_state(primary, "primary", repo_root))
+    helpers = sorted(set(row.get("helper_runner_paths") or []))
+    if not all(isinstance(path, str) and path for path in helpers):
+        raise ScienceFingerprintError(f"audit row {claim_id} has invalid helper paths")
+    runners.extend(_runner_state(path, "helper", repo_root) for path in helpers)
+
+    body: dict[str, Any] = {
+        "schema": SCIENCE_FINGERPRINT_SCHEMA,
+        "target": {
+            "claim_id": claim_id,
+            "note_path": note_path,
+            "note_sha256": _file_sha256(repo_root / note_path, required=True),
+            "ledger_note_hash": row.get("note_hash"),
+            "claim_type": row.get("claim_type"),
+            "claim_scope": row.get("claim_scope"),
+        },
+        "dependencies": dependency_states,
+        "runners": runners,
+        "framework_premise_epoch": framework_premise_epoch(repo_root),
+        "dependency_policy_epoch": dependency_policy_epoch(repo_root),
+    }
+    body["digest"] = _digest(body)
+    return body
+
+
+def science_fingerprint_problems(value: object) -> list[str]:
+    if not isinstance(value, dict):
+        return ["fingerprint:not_object"]
+    problems: list[str] = []
+    if value.get("schema") != SCIENCE_FINGERPRINT_SCHEMA:
+        problems.append("schema:not_science_fingerprint_v2")
+    if not isinstance(value.get("target"), dict):
+        problems.append("target:not_object")
+    if not isinstance(value.get("dependencies"), list):
+        problems.append("dependencies:not_list")
+    if not isinstance(value.get("runners"), list):
+        problems.append("runners:not_list")
+    if not (
+        isinstance(value.get("framework_premise_epoch"), str)
+        and _SHA256_RE.fullmatch(value["framework_premise_epoch"])
+    ):
+        problems.append("framework_premise_epoch:not_sha256")
+    if not (
+        isinstance(value.get("dependency_policy_epoch"), str)
+        and _SHA256_RE.fullmatch(value["dependency_policy_epoch"])
+    ):
+        problems.append("dependency_policy_epoch:not_sha256")
+    digest = value.get("digest")
+    if not isinstance(digest, str) or not _SHA256_RE.fullmatch(digest):
+        problems.append("digest:not_sha256")
+    elif digest != _digest({k: v for k, v in value.items() if k != "digest"}):
+        problems.append("digest:mismatch")
+    return problems
+
+
+def science_fingerprint_change(
+    before: object,
+    after: object,
+) -> str | None:
+    """Return a typed scientific drift reason, or ``None`` for exact equality."""
+    before_problems = science_fingerprint_problems(before)
+    if before_problems:
+        return "science_fingerprint_invalid:" + ",".join(before_problems[:3])
+    after_problems = science_fingerprint_problems(after)
+    if after_problems:
+        return "science_fingerprint_current_invalid:" + ",".join(after_problems[:3])
+    assert isinstance(before, dict) and isinstance(after, dict)
+    if before["digest"] == after["digest"]:
+        return None
+    if before["framework_premise_epoch"] != after["framework_premise_epoch"]:
+        return "science_changed:framework_premise_epoch"
+    if before["dependency_policy_epoch"] != after["dependency_policy_epoch"]:
+        return "science_changed:dependency_policy_epoch"
+    if before["target"] != after["target"]:
+        return "science_changed:target_source"
+
+    before_deps = {
+        item.get("claim_id"): item
+        for item in before["dependencies"]
+        if isinstance(item, dict)
+    }
+    after_deps = {
+        item.get("claim_id"): item
+        for item in after["dependencies"]
+        if isinstance(item, dict)
+    }
+    if set(before_deps) != set(after_deps):
+        return "science_changed:dependency_membership"
+    dependency_fields = (
+        "present",
+        "note_path",
+        "note_sha256",
+        "ledger_note_hash",
+        "claim_type",
+        "claim_scope",
+        "effective_status",
+        "premise_classification",
+    )
+    for dep_id in sorted(before_deps):
+        for field in dependency_fields:
+            if before_deps[dep_id].get(field) != after_deps[dep_id].get(field):
+                return f"science_changed:dependency:{dep_id}:{field}"
+    if before["runners"] != after["runners"]:
+        return "science_changed:runner_or_declared_input"
+    return "science_changed:unclassified"
+
+
+def packet_policy_fingerprint(repo_root: Path) -> dict[str, str]:
+    """Fingerprint packet-generation/validation policy separately from science."""
+    paths = (
+        "docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md",
+        "docs/audit/scripts/apply_audit.py",
+        "docs/audit/scripts/audit_contract.py",
+        "docs/audit/scripts/no_go_discipline_gate.py",
+        "docs/audit/scripts/orchestrate_audit_loop.py",
+        "docs/ai_methodology/skills/audit-loop/SKILL.md",
+        "scripts/codex_audit_runner.py",
+    )
+    sources = {
+        path: _file_sha256(repo_root / path, required=True)
+        for path in paths
+    }
+    body = {
+        "schema": PACKET_POLICY_FINGERPRINT_SCHEMA,
+        "sources": sources,
+    }
+    return {**body, "digest": _digest(body)}
+
+
+def _without_packet(value: object) -> object:
+    """Remove supplemental packet material while retaining seat judgments."""
+    if isinstance(value, dict):
+        return {
+            key: _without_packet(item)
+            for key, item in value.items()
+            if key != "no_go_discipline"
+        }
+    if isinstance(value, list):
+        return [_without_packet(item) for item in value]
+    return value
+
+
+def judgment_fingerprint(row: dict) -> dict[str, Any]:
+    """Freeze the prior scientific judgment independently of its N1-N8 packet."""
+    fields = (
+        "audit_status",
+        "audit_date",
+        "auditor",
+        "auditor_family",
+        "auditor_model",
+        "auditor_reasoning_effort",
+        "independence",
+        "claim_type",
+        "claim_scope",
+        "claim_type_provenance",
+        "load_bearing_step",
+        "load_bearing_step_class",
+        "chain_closes",
+        "chain_closure_explanation",
+        "verdict_rationale",
+        "notes_for_re_audit_if_any",
+        "open_dependency_paths",
+        "decoration_parent_claim_id",
+        "auditor_confidence",
+        "negative_assertion_classes",
+        "runner_check_breakdown",
+        "cross_confirmation",
+    )
+    body: dict[str, Any] = {
+        "schema": JUDGMENT_FINGERPRINT_SCHEMA,
+        "claim_id": row.get("claim_id"),
+        "judgment": _without_packet(
+            {field: row.get(field) for field in fields}
+        ),
+    }
+    body["digest"] = _digest(body)
+    return body
+
+
+def judgment_fingerprint_problems(value: object) -> list[str]:
+    if not isinstance(value, dict):
+        return ["judgment_fingerprint:not_object"]
+    problems: list[str] = []
+    if value.get("schema") != JUDGMENT_FINGERPRINT_SCHEMA:
+        problems.append("schema:not_frozen_audit_judgment_v1")
+    if not isinstance(value.get("claim_id"), str) or not value.get("claim_id"):
+        problems.append("claim_id:invalid")
+    if not isinstance(value.get("judgment"), dict):
+        problems.append("judgment:not_object")
+    digest = value.get("digest")
+    if not isinstance(digest, str) or not _SHA256_RE.fullmatch(digest):
+        problems.append("digest:not_sha256")
+    elif digest != _digest({k: v for k, v in value.items() if k != "digest"}):
+        problems.append("digest:mismatch")
+    return problems
+
+
+def judgment_fingerprint_change(before: object, row: dict) -> str | None:
+    problems = judgment_fingerprint_problems(before)
+    if problems:
+        return "judgment_fingerprint_invalid:" + ",".join(problems[:3])
+    assert isinstance(before, dict)
+    current = judgment_fingerprint(row)
+    if before["digest"] == current["digest"]:
+        return None
+    return "audit_judgment_changed_without_new_fingerprint"

--- a/docs/audit/scripts/check_changed_audit_evidence.py
+++ b/docs/audit/scripts/check_changed_audit_evidence.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Review-time evidence-readiness gate for changed scientific surfaces.
+
+Run after the audit pipeline.  It maps the branch diff to ledger rows and
+fails when a changed source/runner/helper is mechanically incapable of
+supplying the forensic packet expected after merge.  This is not an audit and
+never grants a verdict: the audit lane re-executes the runner live.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+import forensic_evidence_readiness
+import ledger_io
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LEDGER_PATH = REPO_ROOT / "docs" / "audit" / "data" / "audit_ledger.json"
+
+
+def _git(*args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip())
+    return proc.stdout
+
+
+def changed_paths(base: str) -> set[str]:
+    merge_base = _git("merge-base", base, "HEAD").strip()
+    if not merge_base:
+        raise RuntimeError(f"cannot resolve merge-base against {base}")
+    return {
+        line.strip()
+        for line in _git("diff", "--name-only", f"{merge_base}...HEAD").splitlines()
+        if line.strip()
+    }
+
+
+def affected_rows(
+    rows: dict[str, dict],
+    paths: set[str],
+) -> list[tuple[str, dict, list[str]]]:
+    affected: list[tuple[str, dict, list[str]]] = []
+    for claim_id, row in rows.items():
+        surfaces = {
+            str(row.get("note_path") or ""),
+            str(row.get("runner_path") or ""),
+            *(str(path) for path in row.get("helper_runner_paths") or []),
+        }
+        overlap = sorted((surfaces - {""}) & paths)
+        if not overlap:
+            continue
+        claim_type = row.get("claim_type") or row.get("claim_type_author_hint")
+        if claim_type in {"meta", "open_gate", "decoration"}:
+            continue
+        affected.append((claim_id, row, overlap))
+    return affected
+
+
+def build_report(base: str) -> dict:
+    ledger_io.ensure_cache()
+    ledger = json.loads(LEDGER_PATH.read_text(encoding="utf-8"))
+    rows = ledger.get("rows") or {}
+    paths = changed_paths(base)
+    checked: list[dict] = []
+    failures: list[dict] = []
+    for claim_id, row, overlap in affected_rows(rows, paths):
+        issue = forensic_evidence_readiness.cached_row_readiness_issue(
+            {**row, "claim_id": claim_id},
+            rows,
+            REPO_ROOT,
+        )
+        record = {
+            "claim_id": claim_id,
+            "changed_surfaces": overlap,
+            "runner_path": row.get("runner_path"),
+            "helper_runner_paths": list(row.get("helper_runner_paths") or []),
+            "forensic_evidence_ready": issue is None,
+            "issue": issue,
+        }
+        checked.append(record)
+        if issue is not None:
+            failures.append(record)
+    return {
+        "schema": "changed_audit_evidence_readiness_v1",
+        "base": base,
+        "changed_path_count": len(paths),
+        "checked": checked,
+        "failures": failures,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    try:
+        report = build_report(args.base)
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        print(f"changed-audit-evidence: ERROR: {exc}")
+        return 2
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            "changed-audit-evidence: "
+            f"checked={len(report['checked'])} failures={len(report['failures'])}"
+        )
+        for failure in report["failures"]:
+            print(f"  {failure['claim_id']}: {failure['issue']}")
+    return 1 if report["failures"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/audit/scripts/check_changed_audit_evidence.py
+++ b/docs/audit/scripts/check_changed_audit_evidence.py
@@ -19,6 +19,9 @@ import ledger_io
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 LEDGER_PATH = REPO_ROOT / "docs" / "audit" / "data" / "audit_ledger.json"
+LEGACY_EPOCH_BASELINE_PATH = (
+    "docs/audit/data/legacy_science_epoch_baseline.json"
+)
 
 
 def _git(*args: str) -> str:
@@ -35,15 +38,48 @@ def _git(*args: str) -> str:
     return proc.stdout
 
 
-def changed_paths(base: str) -> set[str]:
+def merge_base_commit(base: str) -> str:
     merge_base = _git("merge-base", base, "HEAD").strip()
     if not merge_base:
         raise RuntimeError(f"cannot resolve merge-base against {base}")
+    return merge_base
+
+
+def changed_paths(base: str) -> set[str]:
+    merge_base = merge_base_commit(base)
     return {
         line.strip()
         for line in _git("diff", "--name-only", f"{merge_base}...HEAD").splitlines()
         if line.strip()
     }
+
+
+def immutable_control_failures(base: str, paths: set[str]) -> list[dict]:
+    """Reject edits to a deployed one-time baseline, while allowing bootstrap."""
+    if LEGACY_EPOCH_BASELINE_PATH not in paths:
+        return []
+    merge_base = merge_base_commit(base)
+    existed_at_base = LEGACY_EPOCH_BASELINE_PATH in {
+        line.strip()
+        for line in _git(
+            "ls-tree",
+            "--name-only",
+            merge_base,
+            "--",
+            LEGACY_EPOCH_BASELINE_PATH,
+        ).splitlines()
+        if line.strip()
+    }
+    if not existed_at_base:
+        return []
+    return [{
+        "control": "immutable_legacy_science_epoch_baseline",
+        "changed_surfaces": [LEGACY_EPOCH_BASELINE_PATH],
+        "issue": (
+            "legacy_science_epoch_baseline_is_immutable_after_deployment; "
+            "do not refresh it to absorb premise or dependency-policy drift"
+        ),
+    }]
 
 
 def affected_rows(
@@ -72,6 +108,7 @@ def build_report(base: str) -> dict:
     ledger = json.loads(LEDGER_PATH.read_text(encoding="utf-8"))
     rows = ledger.get("rows") or {}
     paths = changed_paths(base)
+    control_failures = immutable_control_failures(base, paths)
     checked: list[dict] = []
     failures: list[dict] = []
     for claim_id, row, overlap in affected_rows(rows, paths):
@@ -97,6 +134,7 @@ def build_report(base: str) -> dict:
         "changed_path_count": len(paths),
         "checked": checked,
         "failures": failures,
+        "control_failures": control_failures,
     }
 
 
@@ -115,11 +153,15 @@ def main() -> int:
     else:
         print(
             "changed-audit-evidence: "
-            f"checked={len(report['checked'])} failures={len(report['failures'])}"
+            f"checked={len(report['checked'])} "
+            f"failures={len(report['failures'])} "
+            f"control_failures={len(report['control_failures'])}"
         )
         for failure in report["failures"]:
             print(f"  {failure['claim_id']}: {failure['issue']}")
-    return 1 if report["failures"] else 0
+        for failure in report["control_failures"]:
+            print(f"  {failure['control']}: {failure['issue']}")
+    return 1 if report["failures"] or report["control_failures"] else 0
 
 
 if __name__ == "__main__":

--- a/docs/audit/scripts/compute_audit_queue.py
+++ b/docs/audit/scripts/compute_audit_queue.py
@@ -32,6 +32,8 @@ import classify_runner_passes
 import no_go_discipline_gate
 import premise_nodes
 import ledger_io
+import audit_science_fingerprint
+import forensic_evidence_readiness
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DATA_DIR = REPO_ROOT / "docs" / "audit" / "data"
@@ -100,6 +102,81 @@ def needs_audit(row: dict) -> tuple[bool, str]:
     if audit_status == "audited_failed" and not row.get("note_path", "").startswith("archive_unlanded/"):
         return True, "non_terminal_failed"
     return False, "not_pending"
+
+
+PACKET_ONLY_INVALIDATION_PREFIXES = (
+    "no_go_discipline_packet_missing",
+    "no_go_discipline_packet_invalid",
+    "no_go_discipline_cross_confirmation_packet_invalid",
+    "cross_confirmation_first_audit_no_go_packet_invalid",
+    "cross_confirmation_second_audit_no_go_packet_invalid",
+    "cross_confirmation_third_audit_no_go_packet_invalid",
+)
+
+
+def _latest_archived_audit(row: dict) -> dict | None:
+    history = row.get("previous_audits") or []
+    for archived in reversed(history):
+        if isinstance(archived, dict) and archived.get("audit_status"):
+            return archived
+    return None
+
+
+def audit_work_kind(row: dict, rows: dict[str, dict]) -> tuple[str, str | None]:
+    """Route mechanical preparation separately from scientific re-audit.
+
+    A prior judgment is packet-upgrade eligible only when its v2 scientific
+    baseline exactly matches current state.  Legacy rows with no such proof
+    are sent to deterministic provenance reconstruction; ambiguity never
+    falls through to the cheaper path.
+    """
+    archived = _latest_archived_audit(row)
+    if archived is None:
+        return "fresh_scientific_audit", None
+    invalidation_reason = str(archived.get("invalidation_reason") or "")
+    if not invalidation_reason.startswith(PACKET_ONLY_INVALIDATION_PREFIXES):
+        return "fresh_scientific_audit", invalidation_reason or None
+    snapshot = archived.get("audit_state_snapshot") or {}
+    baseline = snapshot.get("science_fingerprint")
+    if baseline is None:
+        return (
+            "provenance_reconstruction_required",
+            "legacy audit has no science_fingerprint_v2",
+        )
+    judgment_baseline = snapshot.get("judgment_fingerprint")
+    judgment_problems = (
+        audit_science_fingerprint.judgment_fingerprint_problems(
+            judgment_baseline
+        )
+    )
+    if judgment_problems:
+        return (
+            "provenance_reconstruction_required",
+            "legacy audit has no valid frozen judgment fingerprint: "
+            + ",".join(judgment_problems[:3]),
+        )
+    try:
+        current = audit_science_fingerprint.build_science_fingerprint(
+            {
+                **row,
+                # Invalidation resets auditor-owned classification fields.
+                # Compare the archived judgment's exact target classification
+                # while recomputing every factual source/dependency surface.
+                "claim_type": archived.get("claim_type"),
+                "claim_scope": archived.get("claim_scope"),
+            },
+            rows,
+            REPO_ROOT,
+        )
+    except audit_science_fingerprint.ScienceFingerprintError as exc:
+        return "provenance_reconstruction_required", str(exc)
+    change = audit_science_fingerprint.science_fingerprint_change(
+        baseline,
+        current,
+    )
+    if change is not None:
+        return "fresh_scientific_audit", change
+    return "legacy_packet_upgrade", None
 
 
 def cycle_break_targets(rows: dict[str, dict]) -> list[dict]:
@@ -594,7 +671,21 @@ def main() -> int:
             continue
         a = row.get("audit_status", "unaudited")
         criticality = row.get("criticality") or "leaf"
-        ready = is_ready(row, rows)
+        dependency_ready = is_ready(row, rows)
+        evidence_issue = forensic_evidence_readiness.cached_row_readiness_issue(
+            {**row, "claim_id": cid},
+            rows,
+            REPO_ROOT,
+        )
+        forensic_evidence_ready = evidence_issue is None
+        work_kind, work_reason = audit_work_kind(
+            {**row, "claim_id": cid},
+            rows,
+        )
+        if evidence_issue is not None:
+            work_kind = "evidence_repair_required"
+            work_reason = evidence_issue
+        ready = dependency_ready and forensic_evidence_ready
         entry = {
             "claim_id": cid,
             "note_path": row.get("note_path"),
@@ -613,6 +704,11 @@ def main() -> int:
             "helper_runner_paths": list(row.get("helper_runner_paths") or []),
             "deps": list(row.get("deps", [])),
             "ready": ready,
+            "dependency_ready": dependency_ready,
+            "forensic_evidence_ready": forensic_evidence_ready,
+            "forensic_evidence_readiness_issue": evidence_issue,
+            "audit_work_kind": work_kind,
+            "audit_work_reason": work_reason,
             "blocker": row.get("blocker"),
             "cross_confirmation_status": (row.get("cross_confirmation") or {}).get("status"),
             "audit_independence_required": (
@@ -643,6 +739,12 @@ def main() -> int:
     queue = {
         "total_pending": len(pending),
         "ready_count": sum(1 for e in pending if e["ready"]),
+        "dependency_ready_count": sum(
+            1 for e in pending if e["dependency_ready"]
+        ),
+        "forensic_evidence_ready_count": sum(
+            1 for e in pending if e["forensic_evidence_ready"]
+        ),
         "shadow_would_park_count": sum(
             1 for e in pending if e.get("would_park") is True
         ),
@@ -657,6 +759,15 @@ def main() -> int:
             c: sum(1 for e in pending if e["criticality"] == c)
             for c in ("critical", "high", "medium", "leaf")
         },
+        "by_work_kind": {
+            kind: sum(1 for e in pending if e["audit_work_kind"] == kind)
+            for kind in (
+                "fresh_scientific_audit",
+                "legacy_packet_upgrade",
+                "evidence_repair_required",
+                "provenance_reconstruction_required",
+            )
+        },
         "cycle_break_targets": cycle_targets,
         "cycle_break_target_count": len(cycle_targets),
         "queue": pending,
@@ -669,12 +780,18 @@ def main() -> int:
         "# Audit Queue",
         "",
         f"**Total pending:** {queue['total_pending']}",
-        f"**Ready (all deps at retained-grade/metadata tiers or supplied axioms/approved primitives):** {queue['ready_count']}",
+        f"**Ready (dependencies and deterministic forensic evidence):** {queue['ready_count']}",
+        f"**Dependency-ready:** {queue['dependency_ready_count']}",
+        f"**Forensic-evidence-ready:** {queue['forensic_evidence_ready_count']}",
         "",
         "By criticality:",
     ]
     for c in ("critical", "high", "medium", "leaf"):
         md_lines.append(f"- `{c}`: {queue['by_criticality'][c]}")
+    md_lines.append("")
+    md_lines.append("By work kind:")
+    for kind, count in queue["by_work_kind"].items():
+        md_lines.append(f"- `{kind}`: {count}")
     md_lines.append("")
     md_lines.append(
         "Auditor (current best Codex GPT model at maximum reasoning by "
@@ -686,12 +803,13 @@ def main() -> int:
     md_lines.append("## Top 50")
     md_lines.append("")
     md_lines.append(
-        "| # | claim_id | claim_type | reason | criticality | desc | score | ready | indep required | runner |"
+        "| # | claim_id | work kind | claim_type | reason | criticality | desc | score | ready | indep required | runner |"
     )
-    md_lines.append("|---:|---|---|---|---|---:|---:|:---:|---|---|")
+    md_lines.append("|---:|---|---|---|---|---|---:|---:|:---:|---|---|")
     for i, e in enumerate(top, 1):
         md_lines.append(
-            f"| {i} | `{e['claim_id']}` | {e.get('claim_type') or '-'} | "
+            f"| {i} | `{e['claim_id']}` | {e['audit_work_kind']} | "
+            f"{e.get('claim_type') or '-'} | "
             f"{e['queue_reason']} | {e['criticality']} | "
             f"{e['transitive_descendants']} | "
             f"{e['load_bearing_score']:.2f} | "

--- a/docs/audit/scripts/compute_audit_queue.py
+++ b/docs/audit/scripts/compute_audit_queue.py
@@ -116,20 +116,46 @@ PACKET_ONLY_INVALIDATION_PREFIXES = (
 
 def _latest_archived_audit(row: dict) -> dict | None:
     history = row.get("previous_audits") or []
-    for archived in reversed(history):
-        if isinstance(archived, dict) and archived.get("audit_status"):
-            return archived
-    return None
+    if not isinstance(history, list) or not history:
+        return None
+    archived = history[-1]
+    if not isinstance(archived, dict) or not archived.get("audit_status"):
+        return None
+    return archived
 
 
-def audit_work_kind(row: dict, rows: dict[str, dict]) -> tuple[str, str | None]:
+def audit_work_kind(
+    row: dict,
+    rows: dict[str, dict],
+    *,
+    epoch_cache: dict[str, str] | None = None,
+) -> tuple[str, str | None]:
     """Route mechanical preparation separately from scientific re-audit.
 
     A prior judgment is packet-upgrade eligible only when its v2 scientific
-    baseline exactly matches current state.  Legacy rows with no such proof
-    are sent to deterministic provenance reconstruction; ambiguity never
-    falls through to the cheaper path.
+    baseline and frozen judgment exactly match current state.  Any missing or
+    ambiguous proof consumes a fresh scientific seat; there is no separate
+    provenance lane that can strand queue work indefinitely.
     """
+    live_status = row.get("audit_status") or "unaudited"
+    if live_status not in {"unaudited", "audit_in_progress"}:
+        return (
+            "fresh_scientific_audit",
+            f"live scientific judgment supersedes archive:{live_status}",
+        )
+    # Packet upgrade is valid only immediately after a full invalidation
+    # reset.  An in-progress first/second seat is a newer live lifecycle even
+    # if an older packet-invalidated archive still exists below it.
+    live_judgment_fields = (
+        "audit_state_snapshot",
+        "cross_confirmation",
+        "audit_date",
+        "auditor",
+        "verdict_rationale",
+    )
+    if any(row.get(field) is not None for field in live_judgment_fields):
+        return "fresh_scientific_audit", "newer live audit lifecycle exists"
+
     archived = _latest_archived_audit(row)
     if archived is None:
         return "fresh_scientific_audit", None
@@ -140,7 +166,7 @@ def audit_work_kind(row: dict, rows: dict[str, dict]) -> tuple[str, str | None]:
     baseline = snapshot.get("science_fingerprint")
     if baseline is None:
         return (
-            "provenance_reconstruction_required",
+            "fresh_scientific_audit",
             "legacy audit has no science_fingerprint_v2",
         )
     judgment_baseline = snapshot.get("judgment_fingerprint")
@@ -151,10 +177,16 @@ def audit_work_kind(row: dict, rows: dict[str, dict]) -> tuple[str, str | None]:
     )
     if judgment_problems:
         return (
-            "provenance_reconstruction_required",
+            "fresh_scientific_audit",
             "legacy audit has no valid frozen judgment fingerprint: "
             + ",".join(judgment_problems[:3]),
         )
+    judgment_change = audit_science_fingerprint.judgment_fingerprint_change(
+        judgment_baseline,
+        {**archived, "claim_id": row.get("claim_id")},
+    )
+    if judgment_change is not None:
+        return "fresh_scientific_audit", judgment_change
     try:
         current = audit_science_fingerprint.build_science_fingerprint(
             {
@@ -167,9 +199,10 @@ def audit_work_kind(row: dict, rows: dict[str, dict]) -> tuple[str, str | None]:
             },
             rows,
             REPO_ROOT,
+            epoch_cache=epoch_cache,
         )
     except audit_science_fingerprint.ScienceFingerprintError as exc:
-        return "provenance_reconstruction_required", str(exc)
+        return "fresh_scientific_audit", str(exc)
     change = audit_science_fingerprint.science_fingerprint_change(
         baseline,
         current,
@@ -665,6 +698,7 @@ def main() -> int:
     rows = ledger.get("rows", {})
 
     pending: list[dict] = []
+    science_epoch_cache: dict[str, str] = {}
     for cid, row in rows.items():
         include, queue_reason = needs_audit(row)
         if not include:
@@ -681,6 +715,7 @@ def main() -> int:
         work_kind, work_reason = audit_work_kind(
             {**row, "claim_id": cid},
             rows,
+            epoch_cache=science_epoch_cache,
         )
         if evidence_issue is not None:
             work_kind = "evidence_repair_required"
@@ -765,7 +800,6 @@ def main() -> int:
                 "fresh_scientific_audit",
                 "legacy_packet_upgrade",
                 "evidence_repair_required",
-                "provenance_reconstruction_required",
             )
         },
         "cycle_break_targets": cycle_targets,

--- a/docs/audit/scripts/forensic_evidence_readiness.py
+++ b/docs/audit/scripts/forensic_evidence_readiness.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Deterministic preflight for evidence needed by a forensic audit seat.
+
+This module never makes a scientific judgment.  It detects only mechanical
+conditions that make the authenticated N1-N8 contract impossible to satisfy,
+so they can be repaired before spending an independent model seat.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import no_go_discipline_gate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import runner_cache  # noqa: E402
+
+
+def live_manifest_readiness_issue(
+    evidence_manifest: dict[str, dict],
+) -> str | None:
+    """Return a definite N5 evidence gap in an invocation-bound manifest."""
+    required_statements = no_go_discipline_gate.required_phrase_groups(
+        evidence_manifest,
+        {"source"},
+        no_go_discipline_gate.N5_SCAN_PHRASES,
+    )
+    if not required_statements:
+        return None
+
+    runner_text = "\n".join(
+        str(entry.get("text") or "")
+        for entry in evidence_manifest.values()
+        if "runner_stdout" in set(entry.get("roles") or [])
+    )
+    missing: list[str] = []
+    for resolution_class in sorted(no_go_discipline_gate.N5_RESOLUTION_CLASSES):
+        marker = f"{resolution_class}:"
+        found = False
+        for line in runner_text.splitlines():
+            normalized = re.sub(r"\s+", " ", line.strip().casefold())
+            marker_index = normalized.find(marker)
+            if marker_index >= 0 and len(normalized[marker_index:]) >= 40:
+                found = True
+                break
+        if not found:
+            missing.append(resolution_class)
+    if not missing:
+        return None
+    return (
+        "forensic_n5_execution_certificate_incomplete: current-cycle "
+        "runner_stdout lacks substantive canonical resolution lines for "
+        f"{','.join(missing)}"
+    )
+
+
+def _runner_source_issue(path: str, repo_root: Path) -> str | None:
+    absolute = repo_root / path
+    if not absolute.is_file():
+        return f"runner_source_missing:{path}"
+    declared = runner_cache.declared_input_paths(absolute)
+    if declared == ():
+        return f"runner_declared_inputs_invalid:{path}"
+    for input_path in declared or ():
+        if not (repo_root / input_path).is_file():
+            return f"runner_declared_input_missing:{path}:{input_path}"
+    return None
+
+
+def cached_row_readiness_issue(
+    row: dict,
+    rows: dict[str, dict],
+    repo_root: Path | None = None,
+) -> str | None:
+    """Return a deterministic pre-seat gap using the SHA/input-bound cache.
+
+    Cached stdout is only a readiness signal.  The forensic runner still
+    executes the current runner live and authenticates that output before
+    apply.
+    """
+    root = REPO_ROOT if repo_root is None else repo_root
+    note_path = str(row.get("note_path") or "")
+    try:
+        note_body = (root / note_path).read_text(encoding="utf-8")
+    except OSError:
+        return f"target_source_missing:{note_path or '<unset>'}"
+
+    for path in [
+        row.get("runner_path"),
+        *(row.get("helper_runner_paths") or []),
+    ]:
+        if not isinstance(path, str) or not path:
+            continue
+        issue = _runner_source_issue(path, root)
+        if issue is not None:
+            return issue
+
+    if not no_go_discipline_gate.source_requires_no_go_discipline(
+        note_path,
+        note_body,
+        row.get("claim_type") or row.get("claim_type_author_hint"),
+    ):
+        return None
+
+    manifest: dict[str, dict] = {}
+    no_go_discipline_gate.set_packet_evidence(
+        manifest,
+        path=note_path,
+        role="source",
+        text=note_body,
+    )
+    required_statements = no_go_discipline_gate.required_phrase_groups(
+        manifest,
+        {"source"},
+        no_go_discipline_gate.N5_SCAN_PHRASES,
+    )
+    if not required_statements:
+        return None
+
+    runner_path = row.get("runner_path")
+    if not isinstance(runner_path, str) or not runner_path:
+        return "forensic_n5_runner_missing"
+    # runner_cache is rooted at the live repository.  Queue production uses
+    # that root; tests or historical tools with another root conservatively
+    # inspect source shape only and report that execution is required.
+    if root.resolve() != REPO_ROOT.resolve():
+        return "forensic_n5_current_execution_required"
+    cached_stdout = runner_cache.cache_excerpt_for_audit(
+        runner_path,
+        tail_chars=200_000,
+    )
+    if cached_stdout is None:
+        return f"forensic_runner_cache_not_fresh:{runner_path}"
+    no_go_discipline_gate.set_packet_evidence(
+        manifest,
+        path=no_go_discipline_gate.runner_stdout_evidence_path(
+            str(row.get("claim_id") or "")
+        ),
+        role="runner_stdout",
+        text=cached_stdout,
+    )
+    return live_manifest_readiness_issue(manifest)

--- a/docs/audit/scripts/invalidate_stale_audits.py
+++ b/docs/audit/scripts/invalidate_stale_audits.py
@@ -898,6 +898,25 @@ def soft_reset_to_cross_confirmation_pending(row: dict, reason: str) -> dict:
     return new_row
 
 
+def audit_in_progress_has_live_judgment(row: dict) -> bool:
+    """Distinguish an empty work claim from an already-recorded audit seat."""
+    if row.get("audit_status") != "audit_in_progress":
+        return False
+    if isinstance(row.get("cross_confirmation"), dict):
+        return True
+    return any(
+        row.get(field) is not None
+        for field in (
+            "audit_state_snapshot",
+            "audit_date",
+            "auditor",
+            "audit_invocation_id",
+            "chain_closes",
+            "verdict_rationale",
+        )
+    )
+
+
 def main() -> int:
     ledger_io.ensure_cache()
     if not LEDGER_PATH.exists():
@@ -913,7 +932,7 @@ def main() -> int:
             continue
         if (
             row.get("audit_status") == "audit_in_progress"
-            and not isinstance(row.get("cross_confirmation"), dict)
+            and not audit_in_progress_has_live_judgment(row)
         ):
             continue
         reason = detect_invalidation(

--- a/docs/audit/scripts/invalidate_stale_audits.py
+++ b/docs/audit/scripts/invalidate_stale_audits.py
@@ -281,7 +281,12 @@ INDEX_GROWTH_TARGETS: list[dict] = []
 GROWTH_TARGETS_PATH = REPO_ROOT / "docs" / "audit" / "data" / "no_go_index_growth_targets.json"
 
 
-def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
+def detect_invalidation(
+    row: dict,
+    rows: dict[str, dict],
+    *,
+    epoch_cache: dict[str, str] | None = None,
+) -> str | None:
     audit_status = row.get("audit_status")
     if audit_status == "audited_clean" and not clean_auditor_provenance_is_valid(row):
         return "auditor_provenance_incomplete"
@@ -312,6 +317,7 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
             row,
             rows,
             REPO_ROOT,
+            epoch_cache=epoch_cache,
         )
         science_reason = audit_science_fingerprint.science_fingerprint_change(
             science_baseline,
@@ -319,14 +325,20 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
         )
         if science_reason is not None:
             return science_reason
-    elif isinstance(snap, dict):
+    else:
+        # Every active pre-v2 judgment is governed by the immutable deployment
+        # anchor, including the oldest rows that have no snapshot at all and
+        # awaiting-second-seat lifecycles whose first seat predates snapshots.
         legacy_epoch_reason = (
             audit_science_fingerprint.legacy_science_epoch_change(
-                REPO_ROOT
+                REPO_ROOT,
+                epoch_cache=epoch_cache,
             )
         )
         if legacy_epoch_reason is not None:
             return legacy_epoch_reason
+        if snap is not None and not isinstance(snap, dict):
+            return "audit_state_snapshot_invalid"
     judgment_baseline = (
         snap.get("judgment_fingerprint")
         if isinstance(snap, dict)
@@ -895,6 +907,7 @@ def main() -> int:
 
     invalidated: list[tuple[str, str]] = []
     soft_reset: list[tuple[str, str]] = []
+    science_epoch_cache: dict[str, str] = {}
     for cid, row in rows.items():
         if row.get("audit_status", "unaudited") == "unaudited":
             continue
@@ -903,7 +916,11 @@ def main() -> int:
             and not isinstance(row.get("cross_confirmation"), dict)
         ):
             continue
-        reason = detect_invalidation(row, rows)
+        reason = detect_invalidation(
+            row,
+            rows,
+            epoch_cache=science_epoch_cache,
+        )
         if reason is None:
             continue
         if reason.startswith("criticality_soft_reset:"):

--- a/docs/audit/scripts/invalidate_stale_audits.py
+++ b/docs/audit/scripts/invalidate_stale_audits.py
@@ -84,6 +84,7 @@ import runner_cache as rc  # noqa: E402
 import no_go_discipline_gate  # noqa: E402
 
 import compute_audit_queue
+import audit_science_fingerprint
 import ledger_io
 
 
@@ -296,6 +297,51 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
         note_path, note_body, row.get("claim_type")
     )
 
+    snap = row.get("audit_state_snapshot")
+    science_baseline = (
+        snap.get("science_fingerprint")
+        if isinstance(snap, dict)
+        else None
+    )
+    if science_baseline is not None:
+        # Run the scientific comparison before packet-policy checks.  This
+        # preserves the important distinction between a certificate migration
+        # and a changed scientific basis: only an exact science match is ever
+        # eligible for packet-only work.
+        current_science = audit_science_fingerprint.build_science_fingerprint(
+            row,
+            rows,
+            REPO_ROOT,
+        )
+        science_reason = audit_science_fingerprint.science_fingerprint_change(
+            science_baseline,
+            current_science,
+        )
+        if science_reason is not None:
+            return science_reason
+    elif isinstance(snap, dict):
+        legacy_epoch_reason = (
+            audit_science_fingerprint.legacy_science_epoch_change(
+                REPO_ROOT
+            )
+        )
+        if legacy_epoch_reason is not None:
+            return legacy_epoch_reason
+    judgment_baseline = (
+        snap.get("judgment_fingerprint")
+        if isinstance(snap, dict)
+        else None
+    )
+    if judgment_baseline is not None:
+        judgment_reason = (
+            audit_science_fingerprint.judgment_fingerprint_change(
+                judgment_baseline,
+                row,
+            )
+        )
+        if judgment_reason is not None:
+            return judgment_reason
+
     packet = row.get("no_go_discipline")
     _forensic = bool(
         source_required
@@ -440,7 +486,6 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
         if packet is not None and not isinstance(packet, dict):
             return "no_go_discipline_packet_invalid"
 
-    snap = row.get("audit_state_snapshot")
     if snap is not None:
         is_v1 = snap.get("schema") == compute_audit_queue.BLOCKER_FINGERPRINT_V1
         if is_v1:
@@ -561,16 +606,16 @@ def detect_invalidation(row: dict, rows: dict[str, dict]) -> str | None:
     # text changes. Compare the dep's note_hash at audit time against the
     # current one and re-look the direct citer when the axiom actually
     # changed. (Older snapshots predate this map; in that case skip.)
-    snap_axiom_hash = snap.get("dep_axiom_premise_note_hash") or {}
-    if snap_axiom_hash:
-        premise_ids = axiom_premise_ids()
-        for d in current_deps:
-            if d not in premise_ids:
-                continue
-            before = snap_axiom_hash.get(d)
-            after = rows.get(d, {}).get("note_hash")
-            if before is not None and after is not None and before != after:
-                return f"axiom_premise_changed:{d}:{before[:8]}->{after[:8]}"
+    legacy_premise_reason = (
+        audit_science_fingerprint.legacy_premise_snapshot_change(
+            snap,
+            row,
+            rows,
+            REPO_ROOT,
+        )
+    )
+    if legacy_premise_reason is not None:
+        return legacy_premise_reason
 
     snap_crit = snap.get("criticality") or "leaf"
     cur_crit = row.get("criticality") or "leaf"

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -683,6 +683,8 @@ def first_ready_forensic_claim(
     for row in rows:
         if (
             row.get("ready")
+            and row.get("audit_work_kind", "fresh_scientific_audit")
+            == "fresh_scientific_audit"
             and row.get("audit_status") in {"unaudited", "audit_in_progress"}
             and batch.source_requires_forensic(row)
         ):

--- a/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
+++ b/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
@@ -105,12 +105,14 @@ from pathlib import Path
 
 import no_go_discipline_gate
 import audit_contract
+import audit_science_fingerprint
 
 import ledger_io
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DATA_DIR = REPO_ROOT / "docs" / "audit" / "data"
 LEDGER_PATH = DATA_DIR / "audit_ledger.json"
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 # Mirror of `invalidate_stale_audits.ARCHIVED_FIELDS`. These are the
 # audit-owned fields that `archive_and_reset` snapshots into
@@ -543,20 +545,42 @@ def restore_audit_from_previous(
     if not history:
         return None
     archived = history[-1]
-    # Axiom-premise pre-check (mirrors invalidate_stale_audits.py's
-    # axiom_premise_changed trigger exactly, including its tolerance for
-    # snapshots that predate the hash map): an audit performed under
-    # different axiom-premise text is re-audit material, never restore
-    # material. Without this, a restored stale-premise verdict is briefly
-    # LIVE in the ledger until the next sweep re-invalidates it — a window
-    # in which dispatch producers, lane certification, or a collaborator
-    # can read a verdict audited under different axioms as current.
+    # Scientific-provenance pre-check: an audit performed under different
+    # target/dependency/runner/premise state is re-audit material, never
+    # restoration material.  Check before writing so stale authority is not
+    # briefly live between restoration and the next invalidation sweep.
     if rows is not None:
         snap = archived.get("audit_state_snapshot") or {}
-        snap_axiom_hash = snap.get("dep_axiom_premise_note_hash") or {}
-        for dep, before in snap_axiom_hash.items():
-            after = (rows.get(dep) or {}).get("note_hash")
-            if before is not None and after is not None and before != after:
+        science_baseline = snap.get("science_fingerprint")
+        if science_baseline is not None:
+            current_science = audit_science_fingerprint.build_science_fingerprint(
+                {
+                    **row,
+                    "claim_type": archived.get("claim_type"),
+                    "claim_scope": archived.get("claim_scope"),
+                },
+                rows,
+                REPO_ROOT,
+            )
+            if audit_science_fingerprint.science_fingerprint_change(
+                science_baseline,
+                current_science,
+            ) is not None:
+                return None
+        else:
+            if (
+                audit_science_fingerprint.legacy_science_epoch_change(
+                    REPO_ROOT
+                )
+                is not None
+            ):
+                return None
+            if audit_science_fingerprint.legacy_premise_snapshot_change(
+                snap,
+                row,
+                rows,
+                REPO_ROOT,
+            ) is not None:
                 return None
     new_row = dict(row)
     new_row["previous_audits"] = history

--- a/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
+++ b/docs/audit/scripts/restore_overaggressively_invalidated_audits.py
@@ -545,13 +545,32 @@ def restore_audit_from_previous(
     if not history:
         return None
     archived = history[-1]
+    if not isinstance(archived, dict):
+        return None
+    raw_snapshot = archived.get("audit_state_snapshot")
+    snap = raw_snapshot if isinstance(raw_snapshot, dict) else {}
+    science_baseline = snap.get("science_fingerprint")
+    judgment_baseline = snap.get("judgment_fingerprint")
+    # A v2 scientific baseline is reusable only together with its matching
+    # frozen judgment.  Recompute against the archived fields themselves so a
+    # hand-edited rationale, scope, verdict, or seat record cannot be restored
+    # under an otherwise valid source fingerprint.
+    if science_baseline is not None and judgment_baseline is None:
+        return None
+    if judgment_baseline is not None:
+        frozen_claim_id = row.get("claim_id")
+        if frozen_claim_id is None and isinstance(judgment_baseline, dict):
+            frozen_claim_id = judgment_baseline.get("claim_id")
+        if audit_science_fingerprint.judgment_fingerprint_change(
+            judgment_baseline,
+            {**archived, "claim_id": frozen_claim_id},
+        ) is not None:
+            return None
     # Scientific-provenance pre-check: an audit performed under different
     # target/dependency/runner/premise state is re-audit material, never
     # restoration material.  Check before writing so stale authority is not
     # briefly live between restoration and the next invalidation sweep.
     if rows is not None:
-        snap = archived.get("audit_state_snapshot") or {}
-        science_baseline = snap.get("science_fingerprint")
         if science_baseline is not None:
             current_science = audit_science_fingerprint.build_science_fingerprint(
                 {

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -724,7 +724,7 @@ def _patch_repo_root(module, tmp_root: Path) -> None:
     # Conditional/failed verdict writers now hash required policy surfaces
     # fail-loudly. General apply-audit fixtures provide real minimal surfaces;
     # dedicated fingerprint tests separately exercise missing/read failures.
-    if hasattr(module, "snapshot_audit_state"):
+    if hasattr(module, "audit_science_fingerprint"):
         prompt = tmp_root / "docs" / "audit" / "AUDIT_AGENT_PROMPT_TEMPLATE.md"
         prompt.parent.mkdir(parents=True, exist_ok=True)
         if not prompt.exists():
@@ -771,12 +771,17 @@ def _patch_repo_root(module, tmp_root: Path) -> None:
                 json.dumps({"schema_version": 1, "rows": []}) + "\n",
                 encoding="utf-8",
             )
-        for relative in (
-            "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
-            "docs/audit/scripts/build_citation_graph.py",
-            "docs/audit/scripts/compute_effective_status.py",
-            "docs/audit/scripts/premise_nodes.py",
+        science_module = module.audit_science_fingerprint
+        policy_data_paths = {
+            "docs/audit/data/doc_authority_registry.json",
+            "docs/audit/data/tier_a_admissions.json",
+            "docs/audit/data/owner_governed_premise_nodes.json",
             "docs/audit/data/source_path_aliases.json",
+        }
+        for relative in (
+            path
+            for path in science_module.DEPENDENCY_POLICY_SOURCES
+            if path not in policy_data_paths
         ):
             policy_surface = tmp_root / relative
             policy_surface.parent.mkdir(parents=True, exist_ok=True)
@@ -785,16 +790,9 @@ def _patch_repo_root(module, tmp_root: Path) -> None:
                     "{}\n" if relative.endswith(".json") else "# fixture\n",
                     encoding="utf-8",
                 )
-        dependency_policy_paths = (
-            "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
-            "docs/audit/scripts/build_citation_graph.py",
-            "docs/audit/scripts/compute_effective_status.py",
-            "docs/audit/scripts/premise_nodes.py",
-            "docs/audit/data/doc_authority_registry.json",
-            "docs/audit/data/tier_a_admissions.json",
-            "docs/audit/data/owner_governed_premise_nodes.json",
-            "docs/audit/data/source_path_aliases.json",
-        )
+        source_aliases = tmp_root / "docs/audit/data/source_path_aliases.json"
+        if not source_aliases.exists():
+            source_aliases.write_text("{}\n", encoding="utf-8")
         policy_manifest = module.DATA_DIR / "dependency_policy_epoch.json"
         policy_manifest.write_text(
             json.dumps({
@@ -806,11 +804,25 @@ def _patch_repo_root(module, tmp_root: Path) -> None:
                         if (tmp_root / relative).is_file()
                         else None
                     )
-                    for relative in dependency_policy_paths
+                    for relative in science_module.DEPENDENCY_POLICY_SOURCES
                 },
             }) + "\n",
             encoding="utf-8",
         )
+        legacy_baseline = module.DATA_DIR / "legacy_science_epoch_baseline.json"
+        if not legacy_baseline.exists():
+            legacy_baseline.write_text(
+                json.dumps({
+                    "schema": "legacy_science_epoch_baseline_v1",
+                    "framework_premise_epoch_digest": (
+                        science_module.framework_premise_epoch(tmp_root)
+                    ),
+                    "dependency_policy_epoch_digest": (
+                        science_module.dependency_policy_epoch(tmp_root)
+                    ),
+                }) + "\n",
+                encoding="utf-8",
+            )
         module.AXIOM_PREMISE_NODES_PATH = registry
         module._AXIOM_PREMISE_IDS = None
     # Writers persist through the sharded ledger; point the module's OWN
@@ -1265,6 +1277,16 @@ class ApplyAuditTest(unittest.TestCase):
         }
         ok, msg = m.apply_one(led, audit)
         self.assertTrue(ok, msg)
+        applied = led["rows"]["test_invocation_replay"]
+        frozen = applied["audit_state_snapshot"]["judgment_fingerprint"]
+        self.assertEqual(
+            m.audit_science_fingerprint.judgment_fingerprint_change(
+                frozen,
+                applied,
+            ),
+            None,
+        )
+        self.assertEqual(applied["audit_invocation_id"], "a" * 32)
         ok, msg = m.apply_one(led, audit)
         self.assertFalse(ok)
         self.assertIn("already been consumed", msg)
@@ -2361,6 +2383,13 @@ class ApplyAuditTest(unittest.TestCase):
             ok, msg = m.apply_one(led, fresh_audit)
         self.assertTrue(ok, msg)
         self.assertIn("first audit recorded", msg)
+        first_seat_row = led["rows"]["legacy_pending_no_go"]
+        self.assertIsNone(
+            m.audit_science_fingerprint.judgment_fingerprint_change(
+                first_seat_row["audit_state_snapshot"]["judgment_fingerprint"],
+                first_seat_row,
+            )
+        )
 
         second_audit = {
             **fresh_audit,
@@ -4837,6 +4866,47 @@ class AuditLintTest(unittest.TestCase):
             row["note_hash"] = hashlib.sha256(body.encode("utf-8")).hexdigest()
             row.setdefault("deps", [])
         self.fx.write_ledger({"schema_version": 1, "rows": rows})
+
+    def test_snapshotless_active_judgment_obeys_legacy_policy_epoch(self):
+        m = _import("audit_lint")
+        _patch_repo_root(m, self.tmp_root)
+        rows = {
+            "awaiting_second": {
+                "claim_id": "awaiting_second",
+                "audit_status": "audit_in_progress",
+                "claim_type": "positive_theorem",
+                "claim_scope": "legacy first-seat scope",
+                "audit_state_snapshot": None,
+                "cross_confirmation": {
+                    "status": "awaiting_second",
+                    "first_audit": {"verdict": "audited_clean"},
+                    "second_audit": None,
+                },
+                "blocker": "awaiting_cross_confirmation",
+                "criticality": "critical",
+            },
+        }
+        self._write_minimal_ledger(rows)
+        policy_path = self.tmp_root / "docs/audit/scripts/premise_nodes.py"
+        policy_path.write_text("# reviewed fixture policy v2\n", encoding="utf-8")
+        manifest_path = (
+            self.tmp_root / "docs/audit/data/dependency_policy_epoch.json"
+        )
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["epoch"] = "fixture_dependency_policy_v2"
+        manifest["sources"]["docs/audit/scripts/premise_nodes.py"] = (
+            hashlib.sha256(policy_path.read_bytes()).hexdigest()
+        )
+        manifest_path.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            "legacy_dependency_policy_epoch_changed",
+            output.getvalue(),
+        )
 
     def test_cross_confirmation_tuple_normalization_matches_apply_gate(self):
         m = _import("audit_lint")
@@ -11309,10 +11379,15 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 "claim_scope": "legacy obstruction",
                 "chain_closes": True,
             }
-            self.assertEqual(
-                m.detect_invalidation(row, {"legacy_no_go": row}),
-                "no_go_discipline_packet_missing",
-            )
+            with mock.patch.object(
+                m.audit_science_fingerprint,
+                "legacy_science_epoch_change",
+                return_value=None,
+            ):
+                self.assertEqual(
+                    m.detect_invalidation(row, {"legacy_no_go": row}),
+                    "no_go_discipline_packet_missing",
+                )
 
     def test_packetless_declared_negative_conditional_remains_repair_queue(self):
         m = _import("invalidate_stale_audits")
@@ -11477,10 +11552,15 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                     claim_id="legacy_no_go",
                 ),
             }
-            self.assertEqual(
-                m.detect_invalidation(row, {"legacy_no_go": row}),
-                "no_go_discipline_packet_invalid",
-            )
+            with mock.patch.object(
+                m.audit_science_fingerprint,
+                "legacy_science_epoch_change",
+                return_value=None,
+            ):
+                self.assertEqual(
+                    m.detect_invalidation(row, {"legacy_no_go": row}),
+                    "no_go_discipline_packet_invalid",
+                )
 
     def test_legacy_clean_authority_without_exact_model_detail_is_preserved(self):
         m = _import("invalidate_stale_audits")
@@ -11496,7 +11576,14 @@ class NoGoDisciplineGateTest(unittest.TestCase):
                 "auditor": "legacy", "auditor_family": "codex-gpt-5.6",
                 "negative_assertion_classes": [],
             }
-            self.assertIsNone(m.detect_invalidation(row, {"positive": row}))
+            with mock.patch.object(
+                m.audit_science_fingerprint,
+                "legacy_science_epoch_change",
+                return_value=None,
+            ):
+                self.assertIsNone(
+                    m.detect_invalidation(row, {"positive": row})
+                )
 
 
 class ComputeLaneCertificationTest(unittest.TestCase):
@@ -13830,18 +13917,16 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
         self.addCleanup(self._tmp.cleanup)
         self.tmp_root = Path(self._tmp.name)
         self.fx = CleanLedgerFixture(self.tmp_root)
+        science = _import("audit_science_fingerprint")
         for relative in (
-            "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
-            "docs/audit/scripts/build_citation_graph.py",
-            "docs/audit/scripts/compute_effective_status.py",
-            "docs/audit/scripts/premise_nodes.py",
-            "docs/audit/data/doc_authority_registry.json",
-            "docs/audit/data/source_path_aliases.json",
+            *science.DEPENDENCY_POLICY_SOURCES,
             "docs/audit/data/dependency_policy_epoch.json",
         ):
             destination = self.tmp_root / relative
             destination.parent.mkdir(parents=True, exist_ok=True)
-            destination.write_bytes((PROJECT_ROOT / relative).read_bytes())
+            source = PROJECT_ROOT / relative
+            if source.is_file():
+                destination.write_bytes(source.read_bytes())
         data_dir = self.tmp_root / "docs" / "audit" / "data"
         data_dir.mkdir(parents=True, exist_ok=True)
         (data_dir / "axiom_premise_nodes.json").write_text(

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -729,13 +729,88 @@ def _patch_repo_root(module, tmp_root: Path) -> None:
         prompt.parent.mkdir(parents=True, exist_ok=True)
         if not prompt.exists():
             prompt.write_text("# Fixture audit prompt\n", encoding="utf-8")
+        packet_gate = (
+            tmp_root / "docs" / "audit" / "scripts" /
+            "no_go_discipline_gate.py"
+        )
+        packet_gate.parent.mkdir(parents=True, exist_ok=True)
+        if not packet_gate.exists():
+            packet_gate.write_text("# Fixture packet gate\n", encoding="utf-8")
+        for relative in (
+            "docs/audit/scripts/apply_audit.py",
+            "docs/audit/scripts/audit_contract.py",
+            "docs/audit/scripts/orchestrate_audit_loop.py",
+            "scripts/codex_audit_runner.py",
+        ):
+            packet_surface = tmp_root / relative
+            packet_surface.parent.mkdir(parents=True, exist_ok=True)
+            if not packet_surface.exists():
+                packet_surface.write_text(
+                    "# Fixture packet policy\n",
+                    encoding="utf-8",
+                )
+        audit_skill = (
+            tmp_root / "docs" / "ai_methodology" / "skills" /
+            "audit-loop" / "SKILL.md"
+        )
+        audit_skill.parent.mkdir(parents=True, exist_ok=True)
+        if not audit_skill.exists():
+            audit_skill.write_text("# Fixture audit skill\n", encoding="utf-8")
         registry = module.DATA_DIR / "axiom_premise_nodes.json"
         registry.parent.mkdir(parents=True, exist_ok=True)
         if not registry.exists():
             registry.write_text(
-                json.dumps({"schema_version": 1, "canonical_ids": []}) + "\n",
+                json.dumps(
+                    {"schema_version": 1, "canonical_ids": [], "nodes": {}}
+                ) + "\n",
                 encoding="utf-8",
             )
+        authority_registry = module.DATA_DIR / "doc_authority_registry.json"
+        if not authority_registry.exists():
+            authority_registry.write_text(
+                json.dumps({"schema_version": 1, "rows": []}) + "\n",
+                encoding="utf-8",
+            )
+        for relative in (
+            "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
+            "docs/audit/scripts/build_citation_graph.py",
+            "docs/audit/scripts/compute_effective_status.py",
+            "docs/audit/scripts/premise_nodes.py",
+            "docs/audit/data/source_path_aliases.json",
+        ):
+            policy_surface = tmp_root / relative
+            policy_surface.parent.mkdir(parents=True, exist_ok=True)
+            if not policy_surface.exists():
+                policy_surface.write_text(
+                    "{}\n" if relative.endswith(".json") else "# fixture\n",
+                    encoding="utf-8",
+                )
+        dependency_policy_paths = (
+            "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
+            "docs/audit/scripts/build_citation_graph.py",
+            "docs/audit/scripts/compute_effective_status.py",
+            "docs/audit/scripts/premise_nodes.py",
+            "docs/audit/data/doc_authority_registry.json",
+            "docs/audit/data/tier_a_admissions.json",
+            "docs/audit/data/owner_governed_premise_nodes.json",
+            "docs/audit/data/source_path_aliases.json",
+        )
+        policy_manifest = module.DATA_DIR / "dependency_policy_epoch.json"
+        policy_manifest.write_text(
+            json.dumps({
+                "schema": "dependency_policy_epoch_manifest_v1",
+                "epoch": "fixture_dependency_policy_v1",
+                "sources": {
+                    relative: (
+                        hashlib.sha256((tmp_root / relative).read_bytes()).hexdigest()
+                        if (tmp_root / relative).is_file()
+                        else None
+                    )
+                    for relative in dependency_policy_paths
+                },
+            }) + "\n",
+            encoding="utf-8",
+        )
         module.AXIOM_PREMISE_NODES_PATH = registry
         module._AXIOM_PREMISE_IDS = None
     # Writers persist through the sharded ledger; point the module's OWN
@@ -13755,6 +13830,52 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
         self.addCleanup(self._tmp.cleanup)
         self.tmp_root = Path(self._tmp.name)
         self.fx = CleanLedgerFixture(self.tmp_root)
+        for relative in (
+            "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
+            "docs/audit/scripts/build_citation_graph.py",
+            "docs/audit/scripts/compute_effective_status.py",
+            "docs/audit/scripts/premise_nodes.py",
+            "docs/audit/data/doc_authority_registry.json",
+            "docs/audit/data/source_path_aliases.json",
+            "docs/audit/data/dependency_policy_epoch.json",
+        ):
+            destination = self.tmp_root / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes((PROJECT_ROOT / relative).read_bytes())
+        data_dir = self.tmp_root / "docs" / "audit" / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / "axiom_premise_nodes.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "canonical_ids": [],
+                    "nodes": {},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        self._write_legacy_epoch_baseline()
+
+    def _write_legacy_epoch_baseline(self):
+        science = _import("audit_science_fingerprint")
+        data_dir = self.tmp_root / "docs" / "audit" / "data"
+        (data_dir / "legacy_science_epoch_baseline.json").write_text(
+            json.dumps(
+                {
+                    "schema": "legacy_science_epoch_baseline_v1",
+                    "framework_premise_epoch_digest": (
+                        science.framework_premise_epoch(self.tmp_root)
+                    ),
+                    "dependency_policy_epoch_digest": (
+                        science.dependency_policy_epoch(self.tmp_root)
+                    ),
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
 
     def _archived_audit(self, *, audit_status="audited_clean",
                         independence="cross_family", cc_status=None,
@@ -13812,8 +13933,37 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
         m.ledger_io.DATA = m.DATA_DIR
         return m
 
+    def _write_premise_registry(self, module):
+        module.DATA_DIR.mkdir(parents=True, exist_ok=True)
+        (self.tmp_root / "docs" / "MINIMAL.md").write_text(
+            "# Fixture minimal axiom\n",
+            encoding="utf-8",
+        )
+        (self.tmp_root / "docs" / "SCALE.md").write_text(
+            "# Fixture scale premise\n",
+            encoding="utf-8",
+        )
+        (module.DATA_DIR / "axiom_premise_nodes.json").write_text(
+            json.dumps({
+                "schema_version": 1,
+                "canonical_ids": [
+                    "minimal_axioms",
+                    "scale_reference_primitive",
+                ],
+                "nodes": {
+                    "minimal_axioms": {"current_path": "docs/MINIMAL.md"},
+                    "scale_reference_primitive": {
+                        "current_path": "docs/SCALE.md"
+                    },
+                },
+            }) + "\n",
+            encoding="utf-8",
+        )
+        self._write_legacy_epoch_baseline()
+
     def test_restore_refuses_stale_axiom_premise_hash(self):
         m = self._import_and_patch()
+        self._write_premise_registry(m)
         matching_hash = "c8201cb1" + "0" * 56
         archived = self._archived_audit()
         archived["audit_state_snapshot"] = {
@@ -13844,6 +13994,7 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
 
     def test_restore_proceeds_on_matching_or_absent_axiom_premise_hash(self):
         m = self._import_and_patch()
+        self._write_premise_registry(m)
         matching_hash = "c8201cb1" + "0" * 56
         matching_primitive_hash = "9a2f106e" + "0" * 56
         archived = self._archived_audit()
@@ -13856,6 +14007,7 @@ class RestoreOveraggressivelyInvalidatedAuditsTest(unittest.TestCase):
             },
         }
         row = self._seed_with_archived("matching_premise_row", archived)
+        row["deps"] = ["minimal_axioms", "scale_reference_primitive"]
         rows = {
             "matching_premise_row": row,
             "minimal_axioms": {

--- a/docs/audit/scripts/tests/test_audit_science_fingerprint.py
+++ b/docs/audit/scripts/tests/test_audit_science_fingerprint.py
@@ -346,6 +346,33 @@ class ScienceFingerprintFixture(unittest.TestCase):
                 "legacy_framework_premise_epoch_changed",
             )
 
+    def test_in_progress_sweep_skips_only_empty_placeholders(self) -> None:
+        empty = {
+            "audit_status": "audit_in_progress",
+            "audit_state_snapshot": None,
+            "cross_confirmation": None,
+            "auditor": None,
+        }
+        self.assertFalse(
+            invalidate_stale_audits.audit_in_progress_has_live_judgment(empty)
+        )
+        self.assertTrue(
+            invalidate_stale_audits.audit_in_progress_has_live_judgment(
+                {**empty, "auditor": "recorded-first-seat"}
+            )
+        )
+        self.assertTrue(
+            invalidate_stale_audits.audit_in_progress_has_live_judgment(
+                {
+                    **empty,
+                    "cross_confirmation": {
+                        "status": "awaiting_second",
+                        "first_audit": {"verdict": "audited_clean"},
+                    },
+                }
+            )
+        )
+
     def test_future_policy_change_invalidates_legacy_snapshots(self) -> None:
         target = dict(self.rows["target"])
         target["audit_state_snapshot"] = {
@@ -460,6 +487,19 @@ class ScienceFingerprintFixture(unittest.TestCase):
             science.judgment_fingerprint_change(baseline, changed_seat),
             "audit_judgment_changed_without_new_fingerprint",
         )
+        extended_replay_history = {
+            **packet_only,
+            "audit_invocation_history": [
+                "11111111-1111-4111-8111-111111111111",
+                "22222222-2222-4222-8222-222222222222",
+            ],
+        }
+        self.assertIsNone(
+            science.judgment_fingerprint_change(
+                baseline,
+                extended_replay_history,
+            )
+        )
 
     def test_live_invalidator_catches_legacy_premise_reclassification(self) -> None:
         target = dict(self.rows["target"])
@@ -540,6 +580,56 @@ class ScienceFingerprintFixture(unittest.TestCase):
         rows = {**self.rows, "target": reset}
         with mock.patch.object(restore, "REPO_ROOT", self.root):
             self.assertIsNone(restore.restore_audit_from_previous(reset, rows))
+
+    def test_restore_preserves_frozen_seat_when_replay_history_grows(self) -> None:
+        invocation_id = "11111111-1111-4111-8111-111111111111"
+        audited = {
+            **self.rows["target"],
+            "audit_status": "audited_numerical_match",
+            "audit_date": "2026-08-01",
+            "auditor": "independent-seat",
+            "audit_invocation_id": invocation_id,
+            "audit_invocation_history": [invocation_id],
+            "verdict_rationale": "original frozen rationale",
+        }
+        snapshot = {
+            "science_fingerprint": science.build_science_fingerprint(
+                audited, self.rows, self.root
+            ),
+            "judgment_fingerprint": science.judgment_fingerprint(audited),
+        }
+        archived = {
+            **audited,
+            "audit_state_snapshot": snapshot,
+            "invalidation_reason": "criticality_increased:leaf->medium",
+        }
+        reset = {
+            **self.rows["target"],
+            "audit_status": "unaudited",
+            "audit_invocation_id": None,
+            "audit_invocation_history": [
+                "22222222-2222-4222-8222-222222222222"
+            ],
+            "previous_audits": [archived],
+        }
+        rows = {**self.rows, "target": reset}
+        with mock.patch.object(restore, "REPO_ROOT", self.root):
+            restored = restore.restore_audit_from_previous(reset, rows)
+        self.assertIsNotNone(restored)
+        assert restored is not None
+        self.assertIsNone(
+            science.judgment_fingerprint_change(
+                snapshot["judgment_fingerprint"],
+                restored,
+            )
+        )
+        self.assertEqual(
+            restored["audit_invocation_history"],
+            [
+                invocation_id,
+                "22222222-2222-4222-8222-222222222222",
+            ],
+        )
 
     def test_queue_routes_only_exact_science_to_packet_upgrade(self) -> None:
         baseline = science.build_science_fingerprint(

--- a/docs/audit/scripts/tests/test_audit_science_fingerprint.py
+++ b/docs/audit/scripts/tests/test_audit_science_fingerprint.py
@@ -1,0 +1,551 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+
+import audit_science_fingerprint as science
+import codex_audit_runner
+import compute_audit_queue
+import invalidate_stale_audits
+import restore_overaggressively_invalidated_audits as restore
+
+
+def _sha(body: str) -> str:
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+class ScienceFingerprintFixture(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.data = self.root / "docs" / "audit" / "data"
+        self.data.mkdir(parents=True)
+        self._write("docs/AXIOM.md", "# Stable axiom\n")
+        self._write("docs/DEP.md", "# Stable dependency\n")
+        self._write("docs/TARGET.md", "# Target theorem\n")
+        self._write("docs/CHAIN.md", "# Downstream theorem\n")
+        self._write("docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md", "prompt-v1\n")
+        self._write(
+            "docs/audit/scripts/no_go_discipline_gate.py",
+            "# packet-policy-v1\n",
+        )
+        for relative in (
+            "docs/audit/scripts/apply_audit.py",
+            "docs/audit/scripts/audit_contract.py",
+            "docs/audit/scripts/orchestrate_audit_loop.py",
+            "scripts/codex_audit_runner.py",
+        ):
+            self._write(relative, "# packet-policy-v1\n")
+        self._write(
+            "docs/ai_methodology/skills/audit-loop/SKILL.md",
+            "# audit-loop-v1\n",
+        )
+        for relative in (
+            "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
+            "docs/audit/scripts/build_citation_graph.py",
+            "docs/audit/scripts/compute_effective_status.py",
+            "docs/audit/scripts/premise_nodes.py",
+            "docs/audit/data/source_path_aliases.json",
+        ):
+            self._write(
+                relative,
+                "{}\n" if relative.endswith(".json") else "# policy-v1\n",
+            )
+        self._write_json(
+            "docs/audit/data/axiom_premise_nodes.json",
+            {
+                "schema_version": 1,
+                "canonical_ids": ["axiom"],
+                "nodes": {
+                    "axiom": {
+                        "current_path": "docs/AXIOM.md",
+                        "aliased_paths": ["docs/AXIOM.md"],
+                        "note": "fixture axiom",
+                    }
+                },
+            },
+        )
+        self._write_json(
+            "docs/audit/data/doc_authority_registry.json",
+            {"schema_version": 1, "rows": []},
+        )
+        dependency_policy_paths = (
+            "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
+            "docs/audit/scripts/build_citation_graph.py",
+            "docs/audit/scripts/compute_effective_status.py",
+            "docs/audit/scripts/premise_nodes.py",
+            "docs/audit/data/doc_authority_registry.json",
+            "docs/audit/data/tier_a_admissions.json",
+            "docs/audit/data/owner_governed_premise_nodes.json",
+            "docs/audit/data/source_path_aliases.json",
+        )
+        self._write_json(
+            "docs/audit/data/dependency_policy_epoch.json",
+            {
+                "schema": "dependency_policy_epoch_manifest_v1",
+                "epoch": "fixture_dependency_policy_v1",
+                "sources": {
+                    relative: (
+                        hashlib.sha256((self.root / relative).read_bytes()).hexdigest()
+                        if (self.root / relative).is_file()
+                        else None
+                    )
+                    for relative in dependency_policy_paths
+                },
+            },
+        )
+        self._write_json(
+            "docs/audit/data/legacy_science_epoch_baseline.json",
+            {
+                "schema": "legacy_science_epoch_baseline_v1",
+                "framework_premise_epoch_digest": (
+                    science.framework_premise_epoch(self.root)
+                ),
+                "dependency_policy_epoch_digest": (
+                    science.dependency_policy_epoch(self.root)
+                ),
+            },
+        )
+        self.rows = {
+            "axiom": self._row(
+                "axiom", "docs/AXIOM.md", claim_type="meta",
+                effective_status="meta",
+            ),
+            "dep": self._row(
+                "dep", "docs/DEP.md", claim_type="positive_theorem",
+                effective_status="retained",
+            ),
+            "target": self._row(
+                "target", "docs/TARGET.md", deps=["axiom"],
+                claim_type="positive_theorem", effective_status="retained",
+            ),
+            "chain": self._row(
+                "chain", "docs/CHAIN.md", deps=["target"],
+                claim_type="positive_theorem", effective_status="retained",
+            ),
+        }
+
+    def _write(self, relative: str, body: str) -> None:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+    def _write_json(self, relative: str, value: object) -> None:
+        self._write(relative, json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+    def _row(
+        self,
+        claim_id: str,
+        note_path: str,
+        *,
+        deps: list[str] | None = None,
+        claim_type: str,
+        effective_status: str,
+    ) -> dict:
+        body = (self.root / note_path).read_text(encoding="utf-8")
+        return {
+            "claim_id": claim_id,
+            "note_path": note_path,
+            "note_hash": _sha(body),
+            "deps": list(deps or []),
+            "claim_type": claim_type,
+            "claim_scope": f"scope for {claim_id}",
+            "effective_status": effective_status,
+            "audit_status": "audited_numerical_match",
+            "criticality": "leaf",
+            "runner_path": None,
+            "helper_runner_paths": [],
+        }
+
+    def test_axiom_edit_invalidates_direct_and_transitive_science(self) -> None:
+        direct_before = science.build_science_fingerprint(
+            self.rows["target"], self.rows, self.root
+        )
+        transitive_before = science.build_science_fingerprint(
+            self.rows["chain"], self.rows, self.root
+        )
+
+        self._write("docs/AXIOM.md", "# Materially revised axiom\n")
+
+        direct_after = science.build_science_fingerprint(
+            self.rows["target"], self.rows, self.root
+        )
+        transitive_after = science.build_science_fingerprint(
+            self.rows["chain"], self.rows, self.root
+        )
+        self.assertEqual(
+            science.science_fingerprint_change(direct_before, direct_after),
+            "science_changed:framework_premise_epoch",
+        )
+        self.assertEqual(
+            science.science_fingerprint_change(transitive_before, transitive_after),
+            "science_changed:framework_premise_epoch",
+        )
+
+    def test_same_status_dependency_content_change_invalidates(self) -> None:
+        target = dict(self.rows["target"])
+        target["deps"] = ["dep"]
+        before = science.build_science_fingerprint(target, self.rows, self.root)
+        self._write("docs/DEP.md", "# Changed dependency, same retained tier\n")
+        after = science.build_science_fingerprint(target, self.rows, self.root)
+        self.assertEqual(
+            science.science_fingerprint_change(before, after),
+            "science_changed:dependency:dep:note_sha256",
+        )
+
+    def test_dependency_criteria_change_invalidates_without_status_change(self) -> None:
+        before = science.build_science_fingerprint(
+            self.rows["chain"], self.rows, self.root
+        )
+        self._write(
+            "docs/audit/scripts/premise_nodes.py",
+            "# policy-v2: changed accepted-dependency criteria\n",
+        )
+        manifest_path = "docs/audit/data/dependency_policy_epoch.json"
+        manifest = json.loads((self.root / manifest_path).read_text())
+        manifest["epoch"] = "fixture_dependency_policy_v2"
+        manifest["sources"]["docs/audit/scripts/premise_nodes.py"] = (
+            hashlib.sha256(
+                (self.root / "docs/audit/scripts/premise_nodes.py").read_bytes()
+            ).hexdigest()
+        )
+        self._write_json(manifest_path, manifest)
+        after = science.build_science_fingerprint(
+            self.rows["chain"], self.rows, self.root
+        )
+        self.assertEqual(
+            science.science_fingerprint_change(before, after),
+            "science_changed:dependency_policy_epoch",
+        )
+
+    def test_unreviewed_dependency_policy_change_fails_closed(self) -> None:
+        self._write(
+            "docs/audit/scripts/premise_nodes.py",
+            "# changed without refreshing the governed epoch manifest\n",
+        )
+        with self.assertRaisesRegex(
+            science.ScienceFingerprintError,
+            "dependency-policy epoch manifest",
+        ):
+            science.build_science_fingerprint(
+                self.rows["target"], self.rows, self.root
+            )
+
+    def test_premise_removal_is_visible_to_legacy_snapshots(self) -> None:
+        snapshot = {
+            "deps": ["axiom"],
+            "dep_axiom_premise_note_hash": {
+                "axiom": self.rows["axiom"]["note_hash"]
+            },
+        }
+        self._write_json(
+            "docs/audit/data/axiom_premise_nodes.json",
+            {"schema_version": 1, "canonical_ids": [], "nodes": {}},
+        )
+        self.assertEqual(
+            science.legacy_premise_snapshot_change(
+                snapshot, self.rows["target"], self.rows, self.root
+            ),
+            "axiom_premise_classification_changed:axiom",
+        )
+
+    def test_premise_addition_is_visible_to_legacy_snapshots(self) -> None:
+        target = dict(self.rows["target"])
+        target["deps"] = ["dep"]
+        snapshot = {
+            "deps": ["dep"],
+            "dep_axiom_premise_note_hash": {},
+        }
+        self._write_json(
+            "docs/audit/data/axiom_premise_nodes.json",
+            {
+                "schema_version": 1,
+                "canonical_ids": ["dep"],
+                "nodes": {
+                    "dep": {
+                        "current_path": "docs/DEP.md",
+                        "aliased_paths": ["docs/DEP.md"],
+                        "note": "newly classified fixture premise",
+                    }
+                },
+            },
+        )
+        self.assertEqual(
+            science.legacy_premise_snapshot_change(
+                snapshot, target, self.rows, self.root
+            ),
+            "axiom_premise_classification_changed:dep",
+        )
+
+    def test_future_axiom_change_invalidates_legacy_snapshots(self) -> None:
+        target = dict(self.rows["target"])
+        target["deps"] = ["dep"]
+        target["audit_state_snapshot"] = {
+            "deps": ["dep"],
+            "dep_effective_status": {"dep": "retained"},
+            "dep_claim_type": {"dep": "positive_theorem"},
+            "dep_claim_scope": {"dep": "scope for dep"},
+            "dep_axiom_premise_note_hash": {},
+            "criticality": "leaf",
+            "runner_hash": None,
+            "helper_runner_hashes": {},
+        }
+        rows = {**self.rows, "target": target}
+        self._write("docs/AXIOM.md", "# Reviewed axiom revision\n")
+
+        with mock.patch.object(invalidate_stale_audits, "REPO_ROOT", self.root):
+            self.assertEqual(
+                invalidate_stale_audits.detect_invalidation(target, rows),
+                "legacy_framework_premise_epoch_changed",
+            )
+
+    def test_future_policy_change_invalidates_legacy_snapshots(self) -> None:
+        target = dict(self.rows["target"])
+        target["audit_state_snapshot"] = {
+            "deps": ["axiom"],
+            "dep_effective_status": {"axiom": "meta"},
+            "dep_claim_type": {"axiom": "meta"},
+            "dep_claim_scope": {"axiom": "scope for axiom"},
+            "dep_axiom_premise_note_hash": {
+                "axiom": self.rows["axiom"]["note_hash"]
+            },
+            "criticality": "leaf",
+            "runner_hash": None,
+            "helper_runner_hashes": {},
+        }
+        rows = {**self.rows, "target": target}
+        policy_path = "docs/audit/scripts/premise_nodes.py"
+        self._write(policy_path, "# reviewed dependency policy v2\n")
+        manifest_path = "docs/audit/data/dependency_policy_epoch.json"
+        manifest = json.loads((self.root / manifest_path).read_text())
+        manifest["epoch"] = "fixture_dependency_policy_v2"
+        manifest["sources"][policy_path] = hashlib.sha256(
+            (self.root / policy_path).read_bytes()
+        ).hexdigest()
+        self._write_json(manifest_path, manifest)
+
+        with mock.patch.object(invalidate_stale_audits, "REPO_ROOT", self.root):
+            self.assertEqual(
+                invalidate_stale_audits.detect_invalidation(target, rows),
+                "legacy_dependency_policy_epoch_changed",
+            )
+
+        archived = {
+            **target,
+            "audit_state_snapshot": target["audit_state_snapshot"],
+            "invalidation_reason": "criticality_increased:leaf->medium",
+        }
+        reset = {
+            **target,
+            "audit_status": "unaudited",
+            "previous_audits": [archived],
+        }
+        with mock.patch.object(restore, "REPO_ROOT", self.root):
+            self.assertIsNone(
+                restore.restore_audit_from_previous(
+                    reset,
+                    {**rows, "target": reset},
+                )
+            )
+
+    def test_declared_runner_input_change_invalidates(self) -> None:
+        self._write("data/input.json", '{"value": 1}\n')
+        self._write(
+            "scripts/check_target.py",
+            "AUDIT_INPUT_PATHS = ('data/input.json',)\nprint('PASS')\n",
+        )
+        target = dict(self.rows["target"])
+        target["runner_path"] = "scripts/check_target.py"
+        before = science.build_science_fingerprint(target, self.rows, self.root)
+        self._write("data/input.json", '{"value": 2}\n')
+        after = science.build_science_fingerprint(target, self.rows, self.root)
+        self.assertEqual(
+            science.science_fingerprint_change(before, after),
+            "science_changed:runner_or_declared_input",
+        )
+
+    def test_packet_policy_change_does_not_change_science(self) -> None:
+        before_science = science.build_science_fingerprint(
+            self.rows["target"], self.rows, self.root
+        )
+        before_policy = science.packet_policy_fingerprint(self.root)
+        self._write("docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md", "prompt-v2\n")
+        after_science = science.build_science_fingerprint(
+            self.rows["target"], self.rows, self.root
+        )
+        after_policy = science.packet_policy_fingerprint(self.root)
+        self.assertIsNone(
+            science.science_fingerprint_change(before_science, after_science)
+        )
+        self.assertNotEqual(before_policy["digest"], after_policy["digest"])
+
+    def test_packet_upgrade_cannot_change_frozen_judgment(self) -> None:
+        row = {
+            **self.rows["target"],
+            "verdict_rationale": "frozen scientific rationale",
+            "no_go_discipline": {"required": True, "status": "FAIL"},
+        }
+        baseline = science.judgment_fingerprint(row)
+        packet_only = {
+            **row,
+            "no_go_discipline": {"required": True, "status": "PASS"},
+        }
+        self.assertIsNone(
+            science.judgment_fingerprint_change(baseline, packet_only)
+        )
+        changed_judgment = {
+            **packet_only,
+            "verdict_rationale": "rewritten rationale",
+        }
+        self.assertEqual(
+            science.judgment_fingerprint_change(baseline, changed_judgment),
+            "audit_judgment_changed_without_new_fingerprint",
+        )
+
+    def test_live_invalidator_catches_legacy_premise_reclassification(self) -> None:
+        target = dict(self.rows["target"])
+        target["audit_state_snapshot"] = {
+            "deps": ["axiom"],
+            "dep_effective_status": {"axiom": "meta"},
+            "dep_claim_type": {"axiom": "meta"},
+            "dep_claim_scope": {"axiom": "scope for axiom"},
+            "dep_axiom_premise_note_hash": {
+                "axiom": self.rows["axiom"]["note_hash"]
+            },
+            "criticality": "leaf",
+            "runner_hash": None,
+            "helper_runner_hashes": {},
+        }
+        rows = {**self.rows, "target": target}
+        self._write_json(
+            "docs/audit/data/axiom_premise_nodes.json",
+            {"schema_version": 1, "canonical_ids": [], "nodes": {}},
+        )
+        baseline_path = "docs/audit/data/legacy_science_epoch_baseline.json"
+        baseline = json.loads((self.root / baseline_path).read_text())
+        baseline["framework_premise_epoch_digest"] = (
+            science.framework_premise_epoch(self.root)
+        )
+        self._write_json(baseline_path, baseline)
+        with mock.patch.object(invalidate_stale_audits, "REPO_ROOT", self.root):
+            self.assertEqual(
+                invalidate_stale_audits.detect_invalidation(target, rows),
+                "axiom_premise_classification_changed:axiom",
+            )
+
+    def test_restore_refuses_any_v2_science_drift(self) -> None:
+        baseline = science.build_science_fingerprint(
+            self.rows["target"], self.rows, self.root
+        )
+        archived = {
+            "audit_status": "audited_numerical_match",
+            "audit_state_snapshot": {"science_fingerprint": baseline},
+            "invalidation_reason": "criticality_increased:leaf->medium",
+        }
+        reset = {
+            **self.rows["target"],
+            "audit_status": "unaudited",
+            "previous_audits": [archived],
+        }
+        rows = {**self.rows, "target": reset}
+        self._write("docs/AXIOM.md", "# Changed before restore\n")
+        with mock.patch.object(restore, "REPO_ROOT", self.root):
+            self.assertIsNone(restore.restore_audit_from_previous(reset, rows))
+
+    def test_queue_routes_only_exact_science_to_packet_upgrade(self) -> None:
+        baseline = science.build_science_fingerprint(
+            self.rows["target"], self.rows, self.root
+        )
+        archived = {
+            "audit_status": "audited_clean",
+            "claim_type": self.rows["target"]["claim_type"],
+            "claim_scope": self.rows["target"]["claim_scope"],
+            "invalidation_reason": "no_go_discipline_packet_missing",
+        }
+        archived["audit_state_snapshot"] = {
+            "science_fingerprint": baseline,
+            "judgment_fingerprint": science.judgment_fingerprint(
+                {**self.rows["target"], **archived}
+            ),
+        }
+        target = {
+            **self.rows["target"],
+            "audit_status": "unaudited",
+            "previous_audits": [archived],
+        }
+        rows = {**self.rows, "target": target}
+        with mock.patch.object(compute_audit_queue, "REPO_ROOT", self.root):
+            self.assertEqual(
+                compute_audit_queue.audit_work_kind(target, rows),
+                ("legacy_packet_upgrade", None),
+            )
+            target_without_proof = {
+                **target,
+                "previous_audits": [
+                    {**archived, "audit_state_snapshot": {}}
+                ],
+            }
+            self.assertEqual(
+                compute_audit_queue.audit_work_kind(
+                    target_without_proof,
+                    {**rows, "target": target_without_proof},
+                )[0],
+                "provenance_reconstruction_required",
+            )
+
+            self._write("docs/AXIOM.md", "# Changed axiom after audit\n")
+            self.assertEqual(
+                compute_audit_queue.audit_work_kind(target, rows)[0],
+                "fresh_scientific_audit",
+            )
+
+    def test_scientific_selector_excludes_preflight_and_packet_work(self) -> None:
+        queue_path = self.root / "queue.json"
+        queue_path.write_text(
+            json.dumps({
+                "queue": [
+                    {
+                        "claim_id": "fresh",
+                        "ready": True,
+                        "audit_work_kind": "fresh_scientific_audit",
+                    },
+                    {
+                        "claim_id": "evidence",
+                        "ready": False,
+                        "audit_work_kind": "evidence_repair_required",
+                    },
+                    {
+                        "claim_id": "upgrade",
+                        "ready": True,
+                        "audit_work_kind": "legacy_packet_upgrade",
+                    },
+                    {
+                        "claim_id": "reconstruct",
+                        "ready": True,
+                        "audit_work_kind": "provenance_reconstruction_required",
+                    },
+                ]
+            }),
+            encoding="utf-8",
+        )
+        with mock.patch.object(codex_audit_runner, "QUEUE_PATH", queue_path):
+            self.assertEqual(
+                [row["claim_id"] for row in codex_audit_runner.load_queue()],
+                ["fresh"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/audit/scripts/tests/test_audit_science_fingerprint.py
+++ b/docs/audit/scripts/tests/test_audit_science_fingerprint.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
 import audit_science_fingerprint as science
+import check_changed_audit_evidence
 import codex_audit_runner
 import compute_audit_queue
 import invalidate_stale_audits
@@ -52,17 +53,22 @@ class ScienceFingerprintFixture(unittest.TestCase):
             "docs/ai_methodology/skills/audit-loop/SKILL.md",
             "# audit-loop-v1\n",
         )
-        for relative in (
-            "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
-            "docs/audit/scripts/build_citation_graph.py",
-            "docs/audit/scripts/compute_effective_status.py",
-            "docs/audit/scripts/premise_nodes.py",
+        policy_data_paths = {
+            "docs/audit/data/doc_authority_registry.json",
+            "docs/audit/data/tier_a_admissions.json",
+            "docs/audit/data/owner_governed_premise_nodes.json",
             "docs/audit/data/source_path_aliases.json",
+        }
+        for relative in (
+            path
+            for path in science.DEPENDENCY_POLICY_SOURCES
+            if path not in policy_data_paths
         ):
             self._write(
                 relative,
                 "{}\n" if relative.endswith(".json") else "# policy-v1\n",
             )
+        self._write_json("docs/audit/data/source_path_aliases.json", {})
         self._write_json(
             "docs/audit/data/axiom_premise_nodes.json",
             {
@@ -81,16 +87,6 @@ class ScienceFingerprintFixture(unittest.TestCase):
             "docs/audit/data/doc_authority_registry.json",
             {"schema_version": 1, "rows": []},
         )
-        dependency_policy_paths = (
-            "docs/audit/FRESH_LOOK_REQUIREMENTS.md",
-            "docs/audit/scripts/build_citation_graph.py",
-            "docs/audit/scripts/compute_effective_status.py",
-            "docs/audit/scripts/premise_nodes.py",
-            "docs/audit/data/doc_authority_registry.json",
-            "docs/audit/data/tier_a_admissions.json",
-            "docs/audit/data/owner_governed_premise_nodes.json",
-            "docs/audit/data/source_path_aliases.json",
-        )
         self._write_json(
             "docs/audit/data/dependency_policy_epoch.json",
             {
@@ -102,7 +98,7 @@ class ScienceFingerprintFixture(unittest.TestCase):
                         if (self.root / relative).is_file()
                         else None
                     )
-                    for relative in dependency_policy_paths
+                    for relative in science.DEPENDENCY_POLICY_SOURCES
                 },
             },
         )
@@ -243,6 +239,27 @@ class ScienceFingerprintFixture(unittest.TestCase):
                 self.rows["target"], self.rows, self.root
             )
 
+    def test_readiness_policy_is_inside_dependency_epoch(self) -> None:
+        before = science.build_science_fingerprint(
+            self.rows["chain"], self.rows, self.root
+        )
+        policy_path = "docs/audit/scripts/forensic_evidence_readiness.py"
+        self._write(policy_path, "# reviewed readiness policy v2\n")
+        manifest_path = "docs/audit/data/dependency_policy_epoch.json"
+        manifest = json.loads((self.root / manifest_path).read_text())
+        manifest["epoch"] = "fixture_dependency_policy_v2"
+        manifest["sources"][policy_path] = hashlib.sha256(
+            (self.root / policy_path).read_bytes()
+        ).hexdigest()
+        self._write_json(manifest_path, manifest)
+        after = science.build_science_fingerprint(
+            self.rows["chain"], self.rows, self.root
+        )
+        self.assertEqual(
+            science.science_fingerprint_change(before, after),
+            "science_changed:dependency_policy_epoch",
+        )
+
     def test_premise_removal_is_visible_to_legacy_snapshots(self) -> None:
         snapshot = {
             "deps": ["axiom"],
@@ -305,6 +322,24 @@ class ScienceFingerprintFixture(unittest.TestCase):
         rows = {**self.rows, "target": target}
         self._write("docs/AXIOM.md", "# Reviewed axiom revision\n")
 
+        with mock.patch.object(invalidate_stale_audits, "REPO_ROOT", self.root):
+            self.assertEqual(
+                invalidate_stale_audits.detect_invalidation(target, rows),
+                "legacy_framework_premise_epoch_changed",
+            )
+
+    def test_future_axiom_change_invalidates_snapshotless_active_judgment(self) -> None:
+        target = {
+            **self.rows["target"],
+            "audit_status": "audit_in_progress",
+            "audit_state_snapshot": None,
+            "cross_confirmation": {
+                "status": "awaiting_second",
+                "first_audit": {"verdict": "audited_clean"},
+            },
+        }
+        rows = {**self.rows, "target": target}
+        self._write("docs/AXIOM.md", "# Reviewed axiom revision\n")
         with mock.patch.object(invalidate_stale_audits, "REPO_ROOT", self.root):
             self.assertEqual(
                 invalidate_stale_audits.detect_invalidation(target, rows),
@@ -395,6 +430,10 @@ class ScienceFingerprintFixture(unittest.TestCase):
         row = {
             **self.rows["target"],
             "verdict_rationale": "frozen scientific rationale",
+            "audit_invocation_id": "11111111-1111-4111-8111-111111111111",
+            "audit_invocation_history": [
+                "11111111-1111-4111-8111-111111111111"
+            ],
             "no_go_discipline": {"required": True, "status": "FAIL"},
         }
         baseline = science.judgment_fingerprint(row)
@@ -411,6 +450,14 @@ class ScienceFingerprintFixture(unittest.TestCase):
         }
         self.assertEqual(
             science.judgment_fingerprint_change(baseline, changed_judgment),
+            "audit_judgment_changed_without_new_fingerprint",
+        )
+        changed_seat = {
+            **packet_only,
+            "audit_invocation_id": "22222222-2222-4222-8222-222222222222",
+        }
+        self.assertEqual(
+            science.judgment_fingerprint_change(baseline, changed_seat),
             "audit_judgment_changed_without_new_fingerprint",
         )
 
@@ -464,6 +511,36 @@ class ScienceFingerprintFixture(unittest.TestCase):
         with mock.patch.object(restore, "REPO_ROOT", self.root):
             self.assertIsNone(restore.restore_audit_from_previous(reset, rows))
 
+    def test_restore_rejects_tampered_frozen_judgment(self) -> None:
+        audited = {
+            **self.rows["target"],
+            "audit_status": "audited_numerical_match",
+            "audit_date": "2026-08-01",
+            "auditor": "independent-seat",
+            "verdict_rationale": "original frozen rationale",
+        }
+        science_baseline = science.build_science_fingerprint(
+            audited, self.rows, self.root
+        )
+        snapshot = {
+            "science_fingerprint": science_baseline,
+            "judgment_fingerprint": science.judgment_fingerprint(audited),
+        }
+        archived = {
+            **audited,
+            "verdict_rationale": "tampered archived rationale",
+            "audit_state_snapshot": snapshot,
+            "invalidation_reason": "no_go_discipline_packet_missing",
+        }
+        reset = {
+            **self.rows["target"],
+            "audit_status": "unaudited",
+            "previous_audits": [archived],
+        }
+        rows = {**self.rows, "target": reset}
+        with mock.patch.object(restore, "REPO_ROOT", self.root):
+            self.assertIsNone(restore.restore_audit_from_previous(reset, rows))
+
     def test_queue_routes_only_exact_science_to_packet_upgrade(self) -> None:
         baseline = science.build_science_fingerprint(
             self.rows["target"], self.rows, self.root
@@ -502,7 +579,36 @@ class ScienceFingerprintFixture(unittest.TestCase):
                     target_without_proof,
                     {**rows, "target": target_without_proof},
                 )[0],
-                "provenance_reconstruction_required",
+                "fresh_scientific_audit",
+            )
+
+            newer_live_judgment = {
+                **target,
+                "audit_status": "audited_conditional",
+                "verdict_rationale": "newer live scientific judgment",
+            }
+            self.assertEqual(
+                compute_audit_queue.audit_work_kind(
+                    newer_live_judgment,
+                    {**rows, "target": newer_live_judgment},
+                )[0],
+                "fresh_scientific_audit",
+            )
+
+            newer_archive = {
+                **archived,
+                "invalidation_reason": "science_changed:target_source",
+            }
+            reset_with_newer_archive = {
+                **target,
+                "previous_audits": [archived, newer_archive],
+            }
+            self.assertEqual(
+                compute_audit_queue.audit_work_kind(
+                    reset_with_newer_archive,
+                    {**rows, "target": reset_with_newer_archive},
+                )[0],
+                "fresh_scientific_audit",
             )
 
             self._write("docs/AXIOM.md", "# Changed axiom after audit\n")
@@ -536,6 +642,11 @@ class ScienceFingerprintFixture(unittest.TestCase):
                         "ready": True,
                         "audit_work_kind": "provenance_reconstruction_required",
                     },
+                    {
+                        "claim_id": "blocked-fresh",
+                        "ready": False,
+                        "audit_work_kind": "fresh_scientific_audit",
+                    },
                 ]
             }),
             encoding="utf-8",
@@ -544,6 +655,61 @@ class ScienceFingerprintFixture(unittest.TestCase):
             self.assertEqual(
                 [row["claim_id"] for row in codex_audit_runner.load_queue()],
                 ["fresh"],
+            )
+            self.assertEqual(
+                [
+                    row["claim_id"]
+                    for row in codex_audit_runner.load_queue(ready_only=False)
+                ],
+                ["fresh", "blocked-fresh"],
+            )
+
+    def test_deployed_legacy_epoch_baseline_change_fails_review_gate(self) -> None:
+        paths = {check_changed_audit_evidence.LEGACY_EPOCH_BASELINE_PATH}
+        with (
+            mock.patch.object(
+                check_changed_audit_evidence,
+                "merge_base_commit",
+                return_value="base-sha",
+            ),
+            mock.patch.object(
+                check_changed_audit_evidence,
+                "_git",
+                return_value=(
+                    check_changed_audit_evidence.LEGACY_EPOCH_BASELINE_PATH
+                    + "\n"
+                ),
+            ),
+        ):
+            failures = check_changed_audit_evidence.immutable_control_failures(
+                "origin/main",
+                paths,
+            )
+        self.assertEqual(
+            failures[0]["control"],
+            "immutable_legacy_science_epoch_baseline",
+        )
+
+    def test_initial_legacy_epoch_baseline_introduction_is_allowed(self) -> None:
+        paths = {check_changed_audit_evidence.LEGACY_EPOCH_BASELINE_PATH}
+        with (
+            mock.patch.object(
+                check_changed_audit_evidence,
+                "merge_base_commit",
+                return_value="base-sha",
+            ),
+            mock.patch.object(
+                check_changed_audit_evidence,
+                "_git",
+                return_value="",
+            ),
+        ):
+            self.assertEqual(
+                check_changed_audit_evidence.immutable_control_failures(
+                    "origin/main",
+                    paths,
+                ),
+                [],
             )
 
 

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -66,6 +66,7 @@ import audit_invocation
 import audit_contract
 import compute_audit_dispatch_queue
 import compute_reaudit_candidates
+import forensic_evidence_readiness
 
 LEDGER_PATH = AUDIT_DIR / "data" / "audit_ledger.json"
 QUEUE_PATH = AUDIT_DIR / "data" / "audit_queue.json"
@@ -828,7 +829,12 @@ def load_queue(criticality_filter: str | None = None,
     if criticality_filter:
         rows = [r for r in rows if (r.get("criticality") or "") == criticality_filter]
     if ready_only:
-        rows = [r for r in rows if r.get("ready")]
+        rows = [
+            r for r in rows
+            if r.get("ready")
+            and r.get("audit_work_kind", "fresh_scientific_audit")
+            == "fresh_scientific_audit"
+        ]
     # rows are already pre-sorted by descending score in audit_queue.json
     return rows
 
@@ -1149,6 +1155,8 @@ AUDIT_PACKET_CONTROL_PATHS = (
     "docs/audit/scripts/apply_audit.py",
     "docs/audit/scripts/audit_contract.py",
     "docs/audit/scripts/audit_invocation.py",
+    "docs/audit/scripts/audit_science_fingerprint.py",
+    "docs/audit/scripts/forensic_evidence_readiness.py",
     "docs/audit/scripts/no_go_discipline_gate.py",
     "docs/audit/scripts/premise_nodes.py",
     "docs/audit/scripts/run_pipeline.sh",
@@ -2102,43 +2110,8 @@ def forensic_evidence_readiness_issue(
     Detect only that necessary condition here; all scientific judgments and
     every remaining N1-N8 gate stay with the restricted auditor and validator.
     """
-    required_statements = no_go_discipline_gate.required_phrase_groups(
-        evidence_manifest,
-        {"source"},
-        no_go_discipline_gate.N5_SCAN_PHRASES,
-    )
-    if not required_statements:
-        return None
-
-    runner_text = "\n".join(
-        str(entry.get("text") or "")
-        for entry in evidence_manifest.values()
-        if "runner_stdout" in set(entry.get("roles") or [])
-    )
-    missing: list[str] = []
-    for resolution_class in sorted(
-        no_go_discipline_gate.N5_RESOLUTION_CLASSES
-    ):
-        marker = f"{resolution_class}:"
-        found = False
-        for line in runner_text.splitlines():
-            normalized = re.sub(r"\s+", " ", line.strip().casefold())
-            marker_index = normalized.find(marker)
-            if (
-                marker_index >= 0
-                and len(normalized[marker_index:]) >= 40
-            ):
-                found = True
-                break
-        if not found:
-            missing.append(resolution_class)
-    if not missing:
-        return None
-    return (
-        "forensic N5 execution certificate is incomplete: current-cycle "
-        "runner_stdout lacks substantive canonical resolution lines for "
-        f"{','.join(missing)}; add a deterministic runner certificate with "
-        "per_element, per_site, per_mode, per_block, and lattice_wide lines"
+    return forensic_evidence_readiness.live_manifest_readiness_issue(
+        evidence_manifest
     )
 
 

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -822,19 +822,21 @@ def load_queue(criticality_filter: str | None = None,
     retained-grade deterministically yields audited_conditional and burns a
     Codex call without compounding progress. The 'ready' flag in the queue
     encodes the dep-readiness condition computed by compute_audit_queue.py.
-    Pass --allow-blocked to opt into auditing blocked rows anyway.
+    Pass --allow-blocked to opt into auditing dependency/evidence-blocked rows
+    anyway.  That flag never admits mechanical packet/preparation work into a
+    fresh scientific auditor seat.
     """
     q = json.loads(QUEUE_PATH.read_text(encoding="utf-8"))
     rows = q.get("queue", [])
     if criticality_filter:
         rows = [r for r in rows if (r.get("criticality") or "") == criticality_filter]
+    rows = [
+        r for r in rows
+        if r.get("audit_work_kind", "fresh_scientific_audit")
+        == "fresh_scientific_audit"
+    ]
     if ready_only:
-        rows = [
-            r for r in rows
-            if r.get("ready")
-            and r.get("audit_work_kind", "fresh_scientific_audit")
-            == "fresh_scientific_audit"
-        ]
+        rows = [r for r in rows if r.get("ready")]
     # rows are already pre-sorted by descending score in audit_queue.json
     return rows
 


### PR DESCRIPTION
## Summary

- bind every newly accepted audit judgment to a content-addressed scientific fingerprint covering target source, exact dependency membership and state, runner/helper bytes, declared inputs, the framework-premise epoch, and the governed dependency-policy epoch
- keep packet-policy fingerprints separate and freeze the scientific judgment, including invocation identity and critical cross-confirmation provenance, so packet-only certificate repair cannot rewrite verdict, scope, rationale, or seat provenance
- protect pre-v2 audits with an immutable framework/policy deployment anchor and a fail-closed changed-file guard; future axiom, premise-registry, dependency-policy, or baseline edits cannot silently preserve legacy judgments
- route queue work into fresh scientific audit, exact legacy packet upgrade, or evidence repair; missing or ambiguous provenance conservatively returns to fresh scientific audit
- keep fresh auditor seats restricted to fresh scientific work even when blocked readiness rows are requested, while the independent auditor still reruns evidence live
- make invalidation cover snapshotless/non-dict active judgments, propagate dependency invalidations to a fixed point, and require exact archived frozen-judgment matching for restoration
- update audit-loop/review-loop methodology so executable routing, readiness exclusions, and backlog reporting agree

## Rigor and re-audit behavior

A fresh scientific audit is required when any captured scientific input changes or cannot be proven unchanged: target/dependency bytes, dependency membership/type/scope/status/classification, runners/helpers/declared inputs, axioms/approved premises, or dependency policy. The pipeline propagates direct invalidations to transitive consumers to a fixed point.

A packet-policy-only change may use judgment-preserving packet completion only when the latest archive has an exact v2 scientific fingerprint and exact frozen judgment matching the live row. Critical clean claims still require independent cross-confirmation. Cached readiness is scheduling evidence only and never substitutes for the live audit rerun.

The legacy science-epoch baseline is immutable after introduction. Review-loop is instructed not to refresh it to silence drift; narrowing a future axiom/policy blast radius requires a separately reviewed row-specific equivalence/impact record.

## Validation

- `python3 -m unittest docs.audit.scripts.tests.test_audit_pipeline docs.audit.scripts.tests.test_audit_science_fingerprint` — 500 tests PASS
- `bash docs/audit/scripts/run_pipeline.sh` on `origin/main` `4d6dedee8` plus this PR — PASS; 3,969 rows scanned, 0 invalidations, 0 lint errors, all invariants PASS
- generated pending queue after the pipeline: 3,019 rows (`fresh_scientific_audit=2,537`, `evidence_repair=482`, `legacy_packet_upgrade=0`), of which 464 are ready; no provenance-reconstruction category remains
- `python3 docs/audit/scripts/audit_lint.py --strict` — PASS
- `python3 docs/audit/scripts/check_changed_audit_evidence.py --base origin/main` — PASS (`failures=0`, `control_failures=0`)
- `git diff --check`, changed-script `py_compile`, and vocabulary lint — PASS
- audit-loop and review-loop skill validators — PASS

No audit verdicts, generated ledger/status outputs, or generated queue/front-door artifacts are included in this PR.
