### PR TITLE
fix(audit): bind N8 mechanisms without new seats

### DIFF
--- a/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
+++ b/docs/audit/AUDIT_AGENT_PROMPT_TEMPLATE.md
@@ -600,7 +600,7 @@ validator still requires substantive values whenever the condition applies.
         "retired": null,
         "applicable": "<true or false; decide for the current scope independently of retirement>",
         "addressed": true,
-        "disposition": "<40+ normalized characters explaining retirement/applicability and treatment>",
+        "disposition": "<copy this echo's complete mechanism verbatim, then use 40+ normalized characters to explain retirement/applicability and treatment>",
         "evidence_path": "<manifest path>",
         "evidence_locator": "<actual locator>"
       }
@@ -781,13 +781,15 @@ case-folded normalization, plus the route's complete
 `mechanism` and `attempt` verbatim. Copy
 `N7.resolution` byte-for-byte as one contiguous line from its independent
 resolution surface, and select a line meeting the same raw and normalized
-minimums that names an evidenced N2 wall. Do not paraphrase either field. N8 must bind
-each mechanism to its exact indexed candidate record. Copy known retirement
-state exactly; when the indexed `lifecycle_state` is `unknown`, preserve
-`retired` as JSON `null`. Applicability is a separate current-scope decision
-and must be boolean for PASS. Copy the complete authenticated no-go-row
-universe count and digest even though only relevance-selected candidates
-receive full echoes.
+minimums that names an evidenced N2 wall. Do not paraphrase either field. N8
+must bind each mechanism to its exact indexed candidate record. Copy each
+echo's complete `mechanism` string verbatim into that same echo's
+`disposition`, then explain its retirement, applicability, and treatment; a
+paraphrase does not satisfy the indexed binding. Copy known retirement state
+exactly; when the indexed `lifecycle_state` is `unknown`, preserve `retired` as
+JSON `null`. Applicability is a separate current-scope decision and must be
+boolean for PASS. Copy the complete authenticated no-go-row universe count and
+digest even though only relevance-selected candidates receive full echoes.
 FAIL narrowing must be a strict lexical subset that preserves logical polarity
 when the prior scope is supplied. For a blind re-audit carrying
 `WITHHELD_FOR_FRESH_CONTEXT`, derive the top-level scope only from the current

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -1342,37 +1342,6 @@ def terminate_workers(jobs: list[dict]) -> None:
             job["log_handle"].close()
 
 
-def schema_repair_guidance(blob: dict, validator_error: str | None) -> str:
-    """Render exact, judgment-preserving guidance for known schema errors."""
-    if not validator_error:
-        return ""
-    match = re.fullmatch(
-        r"N8 echo (\d+)\.disposition must name its indexed mechanism",
-        validator_error,
-    )
-    if match:
-        index = int(match.group(1)) - 1
-        packet = blob.get("no_go_discipline")
-        echoes = (
-            packet.get("N8_cross_cycle_echo", {}).get("echoes")
-            if isinstance(packet, dict)
-            else None
-        )
-        if isinstance(echoes, list) and 0 <= index < len(echoes):
-            echo = echoes[index]
-            mechanism = echo.get("mechanism") if isinstance(echo, dict) else None
-            if isinstance(mechanism, str) and mechanism.strip():
-                quoted = json.dumps(mechanism, ensure_ascii=False)
-                return (
-                    "\nMechanical repair guidance: preserve every judgment and "
-                    f"copy the exact mechanism string {quoted} verbatim into "
-                    f"N8_cross_cycle_echo.echoes[{index}].disposition. The "
-                    "validator requires that exact normalized substring; do not "
-                    "paraphrase it or change the mechanism field.\n"
-                )
-    return ""
-
-
 def _wait_for_packet_completion(proc: subprocess.Popen) -> tuple[bool, int]:
     """Wait for packet repair, killing promptly when the committer is cancelled."""
     deadline = time.monotonic() + PACKET_COMPLETION_STALL_SECONDS
@@ -1435,7 +1404,6 @@ def packet_completion_pass(
     error_block = (
         "\nThe validator rejected the previous packet with EXACTLY this "
         f"error — fix precisely this, nothing else:\n    {validator_error}\n"
-        f"{schema_repair_guidance(blob, validator_error)}"
         if validator_error
         else ""
     )
@@ -1641,6 +1609,15 @@ def finalize_worker(job: dict) -> tuple[dict | None, dict]:
         "transport_bounded_n8": job["transport_bound"] is not None,
     }
     error = audit_runner.validate_verdict(blob, cid, **validation_args)
+    n8_mechanism_bindings: list[dict[str, object]] = []
+    while error:
+        binding = audit_runner.bind_n8_indexed_mechanism_disposition(
+            blob, str(error)
+        )
+        if binding is None:
+            break
+        n8_mechanism_bindings.append(binding)
+        error = audit_runner.validate_verdict(blob, cid, **validation_args)
 
     def _packet_error(err: object) -> bool:
         return bool(re.search(
@@ -1730,6 +1707,8 @@ def finalize_worker(job: dict) -> tuple[dict | None, dict]:
     temporary.write_text(json.dumps(envelope, sort_keys=True), encoding="utf-8")
     temporary.replace(job["delivery"])
     result = {**base, "result": "delivery_validated"}
+    if n8_mechanism_bindings:
+        result["n8_mechanism_binding_count"] = len(n8_mechanism_bindings)
     if optional_packet_dropped:
         result["detail"] = "invalid optional development-tier no_go_discipline dropped"
     return envelope, result

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -1045,27 +1045,65 @@ class BatchExitSemanticsTest(unittest.TestCase):
 
 
 class SchemaRecoveryTest(unittest.TestCase):
-    def test_known_n8_failure_gets_exact_mechanism_repair_guidance(self):
+    def test_known_n8_failure_is_bound_without_a_completion_model_call(self):
         blob = {
+            "claim_id": "row",
             "no_go_discipline": {
                 "N8_cross_cycle_echo": {
                     "echoes": [
                         {
                             "mechanism": "projector-kernel obstruction",
-                            "disposition": "paraphrased obstruction",
+                            "disposition": (
+                                "The paraphrased obstruction remains applicable "
+                                "and is addressed by the current bounded scope."
+                            ),
                         }
                     ]
                 }
             }
         }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            raw = root / "raw.json"
+            raw.write_text(json.dumps(blob), encoding="utf-8")
+            job = {
+                "cid": "row",
+                "pass": 1,
+                "stalled": False,
+                "returncode": 0,
+                "raw_output": raw,
+                "row": {"claim_id": "row", "note_path": ""},
+                "evidence_manifest": {},
+                "invocation_id": "invocation",
+                "transport_bound": None,
+                "auditor": "test-auditor",
+                "independence": "cross_family",
+                "delivery": root / "delivery.json",
+                "workdir": root,
+                "isolated": root,
+            }
+            with mock.patch.object(
+                batch.audit_runner.no_go_discipline_gate,
+                "source_requires_no_go_discipline",
+                return_value=False,
+            ), mock.patch.object(
+                batch.audit_runner,
+                "validate_verdict",
+                side_effect=[
+                    "N8 echo 1.disposition must name its indexed mechanism",
+                    None,
+                ],
+            ), mock.patch.object(batch, "packet_completion_pass") as completion:
+                envelope, result = batch.finalize_worker(job)
 
-        guidance = batch.schema_repair_guidance(
-            blob,
-            "N8 echo 1.disposition must name its indexed mechanism",
-        )
-
-        self.assertIn('"projector-kernel obstruction"', guidance)
-        self.assertIn("copy the exact mechanism string", guidance)
+        completion.assert_not_called()
+        self.assertIsNotNone(envelope)
+        self.assertEqual(result["result"], "delivery_validated")
+        self.assertEqual(result["n8_mechanism_binding_count"], 1)
+        disposition = envelope["audit"]["no_go_discipline"][
+            "N8_cross_cycle_echo"
+        ]["echoes"][0]["disposition"]
+        self.assertIn("projector-kernel obstruction", disposition)
 
     def test_worker_503_is_typed_as_retryable_service_failure(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -9587,6 +9587,27 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         _set_no_go_scan_coverage(packet, manifest)
         audit = {"claim_type": "no_go", "verdict": "audited_clean", "chain_closes": True, "no_go_discipline": packet}
         self.assertIsNone(m.validate_no_go_discipline(audit, evidence_manifest=manifest))
+        echo = packet["N8_cross_cycle_echo"]["echoes"][0]
+        echo["disposition"] = (
+            "The earlier selector obstruction is retired or inapplicable to "
+            "the current residual and therefore does not reopen this wall."
+        )
+        binding_error = m.validate_no_go_discipline(
+            audit, evidence_manifest=manifest
+        )
+        self.assertEqual(
+            binding_error,
+            "N8 echo 1.disposition must name its indexed mechanism",
+        )
+        runner = _import_codex_audit_runner()
+        self.assertIsNotNone(
+            runner.bind_n8_indexed_mechanism_disposition(
+                audit, binding_error
+            )
+        )
+        self.assertIsNone(
+            m.validate_no_go_discipline(audit, evidence_manifest=manifest)
+        )
         packet["N8_cross_cycle_echo"]["echoes"][0]["mechanism"] = "invented unrelated mechanism"
         packet["N8_cross_cycle_echo"]["echoes"][0]["disposition"] = (
             "The invented unrelated mechanism is retired or inapplicable to the "
@@ -10237,6 +10258,15 @@ class NoGoDisciplineGateTest(unittest.TestCase):
         self.assertIn(
             "select a line meeting the same raw and normalized minimums that "
             "names an evidenced N2 wall",
+            template_flat,
+        )
+        self.assertIn(
+            "Copy each echo's complete `mechanism` string verbatim into that "
+            "same echo's `disposition`",
+            template_flat,
+        )
+        self.assertIn(
+            "a paraphrase does not satisfy the indexed binding",
             template_flat,
         )
         self.assertIn(
@@ -13591,6 +13621,69 @@ class CodexAuditRunnerTargetSelectionTest(unittest.TestCase):
         self.assertIn(
             "changed preserved scientific field 'verdict'",
             m.validation_repair_preservation_error(rejected, repaired) or "",
+        )
+
+    def test_n8_mechanism_binding_is_exact_additive_and_narrow(self):
+        m = _import_codex_audit_runner()
+        mechanism = "projector-kernel obstruction from the indexed candidate"
+        disposition = (
+            "The earlier obstruction remains applicable and is addressed by "
+            "the current bounded treatment."
+        )
+        blob = {
+            "verdict": "audited_clean",
+            "no_go_discipline": {
+                "required": True,
+                "status": "PASS",
+                "N8_cross_cycle_echo": {
+                    "echoes": [{
+                        "candidate_id": "candidate-1",
+                        "mechanism": mechanism,
+                        "retired": False,
+                        "applicable": True,
+                        "addressed": True,
+                        "disposition": disposition,
+                    }],
+                },
+            },
+        }
+        before = json.loads(json.dumps(blob))
+
+        binding = m.bind_n8_indexed_mechanism_disposition(
+            blob,
+            "N8 echo 1.disposition must name its indexed mechanism",
+        )
+
+        self.assertEqual(
+            binding["operation"], "append_exact_indexed_mechanism"
+        )
+        expected = json.loads(json.dumps(before))
+        expected["no_go_discipline"]["N8_cross_cycle_echo"]["echoes"][0][
+            "disposition"
+        ] = disposition + "\nIndexed mechanism (verbatim): " + mechanism
+        self.assertEqual(blob, expected)
+        self.assertIn(
+            "changed preserved no-go scientific content",
+            m.validation_repair_preservation_error(before, blob) or "",
+        )
+
+        self.assertIsNone(
+            m.bind_n8_indexed_mechanism_disposition(
+                blob,
+                "N8 echo 1.disposition must name its indexed mechanism",
+            )
+        )
+        self.assertIsNone(
+            m.bind_n8_indexed_mechanism_disposition(
+                before,
+                "N8 echo 2.disposition must name its indexed mechanism",
+            )
+        )
+        self.assertIsNone(
+            m.bind_n8_indexed_mechanism_disposition(
+                before,
+                "N8 echo 1.addressed must be boolean",
+            )
         )
 
     def test_packet_completion_errors_get_typed_conclusion_free_codes(self):

--- a/scripts/codex_audit_runner.py
+++ b/scripts/codex_audit_runner.py
@@ -2939,6 +2939,67 @@ def bind_authenticated_n6_candidate_locators(
     return changes
 
 
+_N8_MECHANISM_DISPOSITION_ERROR = re.compile(
+    r"N8 echo (\d+)\.disposition must name its indexed mechanism"
+)
+
+
+def bind_n8_indexed_mechanism_disposition(
+    blob: dict,
+    validation_error: str | None,
+) -> dict[str, object] | None:
+    """Append one exact, redundant N8 mechanism binding after its rejection.
+
+    The auditor already selected both the indexed ``mechanism`` and the
+    scientific ``disposition``. This repair copies that same mechanism into
+    the same echo's disposition only when the canonical validator returns the
+    exact verbatim-binding error. It changes no retirement, applicability,
+    addressed, lifecycle, verdict, or packet-gate judgment, and the complete
+    packet is always revalidated by the caller.
+
+    Keeping this deterministic avoids spending another model call on a
+    formatting defect while preserving the strict validator unchanged.
+    """
+    if not isinstance(validation_error, str):
+        return None
+    match = _N8_MECHANISM_DISPOSITION_ERROR.fullmatch(validation_error)
+    if match is None:
+        return None
+    packet = blob.get("no_go_discipline")
+    section = (
+        packet.get("N8_cross_cycle_echo")
+        if isinstance(packet, dict)
+        else None
+    )
+    echoes = section.get("echoes") if isinstance(section, dict) else None
+    index = int(match.group(1)) - 1
+    if not isinstance(echoes, list) or not 0 <= index < len(echoes):
+        return None
+    echo = echoes[index]
+    if not isinstance(echo, dict):
+        return None
+    mechanism = echo.get("mechanism")
+    disposition = echo.get("disposition")
+    if not all(
+        isinstance(value, str) and value.strip()
+        for value in (mechanism, disposition)
+    ):
+        return None
+    if no_go_discipline_gate._norm(mechanism) in no_go_discipline_gate._norm(
+        disposition
+    ):
+        return None
+    echo["disposition"] = (
+        disposition + "\nIndexed mechanism (verbatim): " + mechanism
+    )
+    return {
+        "section": "N8_cross_cycle_echo",
+        "index": index + 1,
+        "field": "disposition",
+        "operation": "append_exact_indexed_mechanism",
+    }
+
+
 def compute_required_reason(reply: str | None) -> str | None:
     """Accept only the governed compute-required escape protocols.
 
@@ -4002,6 +4063,28 @@ def main() -> int:
                 expected_invocation_id=audit_invocation_id,
                 transport_bounded_n8=transport_bound is not None,
             )
+            n8_mechanism_bindings: list[dict[str, object]] = []
+            while err:
+                binding = bind_n8_indexed_mechanism_disposition(blob, err)
+                if binding is None:
+                    break
+                n8_mechanism_bindings.append(binding)
+                err = validate_verdict(
+                    blob,
+                    cid,
+                    source_requires_no_go=source_requires_no_go,
+                    evidence_manifest=exact_evidence_manifest,
+                    prior_claim_scope=prior_claim_scope_for_row(full_led_row),
+                    expected_invocation_id=audit_invocation_id,
+                    transport_bounded_n8=transport_bound is not None,
+                )
+            if n8_mechanism_bindings:
+                with run_log.open("a", encoding="utf-8") as f:
+                    f.write(json.dumps({
+                        "claim_id": cid,
+                        "phase": "n8_indexed_mechanism_dispositions_bound",
+                        "bindings": n8_mechanism_bindings,
+                    }) + "\n")
             initial_validation_error = err
             routing_validation_error = err
             initial_rejected_blob = blob


### PR DESCRIPTION
## Summary

- state the exact N8 mechanism/disposition binding in the primary auditor prompt
- only after the unchanged canonical validator returns the exact indexed-mechanism error, append the already-selected mechanism verbatim to that same disposition and re-run the complete validator
- apply the same bounded deterministic repair in the direct runner and batch worker without spending another model seat
- remove unreachable completion guidance that conflicted with packet-science immutability
- cover the production forensic validator, batch path, prompt contract, idempotence, and preservation boundary

## Safety

The strict N8 validator is unchanged. The deterministic helper is gated by a full-match of the validator's exact error, mutates only the selected echo's `disposition` by suffix addition, is idempotent, and immediately returns to full canonical validation. It changes no verdict, applicability, retirement, addressed state, lifecycle, packet-complete flag, required/status gate, or other scientific judgment. Arbitrary disposition or judgment edits remain rejected by the packet-completion preservation guard.

The changed runtime files are packet-policy surfaces outside `science_fingerprint_v2` and its dependency-policy epoch. No ledger row binds `scripts/codex_audit_runner.py` as a scientific primary/helper runner, so valid scientific audits are not invalidated by this packet-only change.

## Validation

- `python3 -m unittest docs.audit.scripts.tests.test_audit_pipeline docs.audit.scripts.tests.test_audit_science_fingerprint docs.audit.scripts.tests.test_audit_loop_orchestrator` — 680 tests PASS serially
- independent additive/idempotence/error-gate/preservation mutation probes — PASS
- `bash docs/audit/scripts/run_pipeline.sh` — PASS on 3,969 rows; 0 newly seeded, 0 hash changes, 0 invalidations, 0 restorations
- generated queue remains 3,019 pending / 464 ready; 0 dep-ratified or runner-drift re-audit candidates
- `python3 docs/audit/scripts/audit_lint.py --strict` — PASS with existing warnings/notices and 0 errors
- `python3 docs/audit/scripts/check_changed_audit_evidence.py --base origin/main` — PASS (`checked=0`, `failures=0`, `control_failures=0`)
- Python compilation, vocabulary lint, portable-link check, and `git diff --check` — PASS
- pipeline-generated audit/status residue stripped; hard generated-output gate is empty

No generated audit state, audit verdict payloads, ledger/status outputs, or queue/front-door artifacts are included.
