### PR TITLE
fix(audit): freeze claim evidence across seats

### DIFF
--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -989,6 +989,7 @@ def launch_worker(
         "It is the complete restricted packet. Do not inspect any other file. "
         "Return only the response required by that packet."
     )
+    proc: subprocess.Popen | None = None
     try:
         proc = subprocess.Popen(
             [
@@ -1004,10 +1005,6 @@ def launch_worker(
             cwd=isolated,
             start_new_session=True,
         )
-    except Exception:
-        log_handle.close()
-        raise
-    try:
         return {
             "cid": cid,
             "row": row,
@@ -1036,6 +1033,19 @@ def launch_worker(
             "deadline_exceeded": False,
         }
     except BaseException as primary_error:
+        if proc is None:
+            log_failures = close_worker_logs(
+                [{"cid": cid, "log_handle": log_handle}]
+            )
+            if log_failures and hasattr(primary_error, "add_note"):
+                try:
+                    primary_error.add_note(
+                        "worker log cleanup also failed: "
+                        f"{'; '.join(log_failures)}"
+                    )
+                except BaseException:
+                    pass
+            raise
         # Keep ownership even under an exceptional post-Popen failure.  The
         # caller cannot clean a process whose job record was never returned.
         cleanup_error: BaseException | None = None

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -920,6 +920,15 @@ def prepare_claim_packet(
         "invocation_placeholder": invocation_placeholder,
         "evidence_manifest": evidence_manifest,
         "transport_bound": transport_bound,
+        # Freeze the governed source/provenance identity at the same point as
+        # the rendered evidence.  No exception-capable fingerprinting may run
+        # after an auditor process has been started but before the caller owns
+        # its job record.
+        "selection_fingerprint": selection_fingerprint(
+            row,
+            rows,
+            evidence_manifest,
+        ),
     }
 
 
@@ -954,6 +963,11 @@ def launch_worker(
     )
     evidence_manifest = copy.deepcopy(prepared["evidence_manifest"])
     transport_bound = copy.deepcopy(prepared["transport_bound"])
+    frozen_selection_fingerprint = prepared["selection_fingerprint"]
+    independence = seat_independence(row, pass_no)
+    selection_source = row.get("_selection_source")
+    source_fingerprint = row.get("_source_fingerprint")
+    now = time.monotonic()
 
     # Artifact names carry the round so a claim legitimately re-entering a
     # later round (e.g. a critical row resuming at awaiting_second) never
@@ -993,38 +1007,71 @@ def launch_worker(
     except Exception:
         log_handle.close()
         raise
-    now = time.monotonic()
-    return {
-        "cid": cid,
-        "row": row,
-        "pass": pass_no,
-        "proc": proc,
-        "process_group": proc.pid,
-        "raw_output": raw_output,
-        "delivery": delivery,
-        "log_path": log_path,
-        "log_handle": log_handle,
-        "isolated": isolated,
-        "evidence_manifest": evidence_manifest,
-        "invocation_id": invocation_id,
-        "selection_fingerprint": selection_fingerprint(
-            row,
-            rows,
-            evidence_manifest,
-        ),
-        "selection_source": row.get("_selection_source"),
-        "source_fingerprint": row.get("_source_fingerprint"),
-        "transport_bound": transport_bound,
-        "auditor": f"codex-audit-batch-{ident}",
-        "independence": seat_independence(row, pass_no),
-        "workdir": workdir,
-        "started": now,
-        "last_size": 0,
-        "last_activity": (0, 0.0),
-        "last_progress": now,
-        "stalled": False,
-        "deadline_exceeded": False,
-    }
+    try:
+        return {
+            "cid": cid,
+            "row": row,
+            "pass": pass_no,
+            "proc": proc,
+            "process_group": proc.pid,
+            "raw_output": raw_output,
+            "delivery": delivery,
+            "log_path": log_path,
+            "log_handle": log_handle,
+            "isolated": isolated,
+            "evidence_manifest": evidence_manifest,
+            "invocation_id": invocation_id,
+            "selection_fingerprint": frozen_selection_fingerprint,
+            "selection_source": selection_source,
+            "source_fingerprint": source_fingerprint,
+            "transport_bound": transport_bound,
+            "auditor": f"codex-audit-batch-{ident}",
+            "independence": independence,
+            "workdir": workdir,
+            "started": now,
+            "last_size": 0,
+            "last_activity": (0, 0.0),
+            "last_progress": now,
+            "stalled": False,
+            "deadline_exceeded": False,
+        }
+    except BaseException as primary_error:
+        # Keep ownership even under an exceptional post-Popen failure.  The
+        # caller cannot clean a process whose job record was never returned.
+        cleanup_error: BaseException | None = None
+        try:
+            terminate_read_only_seat(
+                {
+                    "cid": cid,
+                    "proc": proc,
+                    "process_group": proc.pid,
+                }
+            )
+        except BaseException as exc:
+            cleanup_error = exc
+        log_failures = close_worker_logs(
+            [{"cid": cid, "log_handle": log_handle}]
+        )
+        if cleanup_error is not None:
+            log_detail = (
+                f"; log cleanup also failed: {'; '.join(log_failures)}"
+                if log_failures
+                else ""
+            )
+            raise CleanupIntegrityError(
+                "launched read-only auditor could not be contained after "
+                "job-record construction failed: "
+                f"{safe_exception_text(cleanup_error)}{log_detail}"
+            ) from cleanup_error
+        if log_failures and hasattr(primary_error, "add_note"):
+            try:
+                primary_error.add_note(
+                    "worker log cleanup also failed: "
+                    f"{'; '.join(log_failures)}"
+                )
+            except BaseException:
+                pass
+        raise
 
 
 PROGRESS = {
@@ -3705,6 +3752,8 @@ def main() -> int:
                         # applies to every peer; do not rebuild expensive live
                         # evidence only to reproduce it.
                         break
+                    except CleanupIntegrityError:
+                        raise
                     except Exception as exc:
                         launch_blocked = True
                         report.append({
@@ -3713,6 +3762,14 @@ def main() -> int:
                             "result": "worker_launch_failed",
                             "detail": f"{type(exc).__name__}: {exc}",
                         })
+                        # If no packet was frozen, this failure happened in
+                        # claim-level preparation.  A peer retry would rerun
+                        # live scientific evidence and could not satisfy the
+                        # same-packet cross-confirmation contract.  A failure
+                        # after preparation (for example Popen) retains the
+                        # cache and may still launch the peer from it.
+                        if row["claim_id"] not in claim_packet_cache:
+                            break
         except BaseException:
             terminate_workers(jobs)
             raise

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -19,6 +19,7 @@ clean guard is repeated immediately before every mutation and race retry.
 from __future__ import annotations
 
 import argparse
+import copy
 import fcntl
 import hashlib
 import json
@@ -859,19 +860,20 @@ def fit_worker_prompt_to_transport_limit(
     )
 
 
-def launch_worker(
+def prepare_claim_packet(
     row: dict,
     rows: dict[str, dict],
-    pass_no: int,
-    workdir: Path,
     runner_timeout: int,
-    round_no: int = 1,
 ) -> dict:
+    """Render one immutable evidence packet for every seat on a claim.
+
+    Cross-confirmation is independence of judgment over the same restricted
+    evidence, not a request to execute the scientific runner once per judge.
+    The placeholder is exactly UUID-sized, so replacing it with each seat's
+    invocation id cannot change the transport decision.
+    """
     cid = row["claim_id"]
-    key = artifact_key(cid)
-    seat = "A" if pass_no == 1 else "B"
-    ident = f"{seat}-{datetime.now(timezone.utc).strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
-    invocation_id = uuid.uuid4().hex
+    invocation_placeholder = uuid.uuid4().hex
     evidence_manifest: dict[str, dict] = {}
     template = audit_runner.PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
     prompt = audit_runner.render_prompt(
@@ -881,7 +883,7 @@ def launch_worker(
         runner_timeout,
         use_cache=False,
         evidence_manifest_out=evidence_manifest,
-        audit_invocation_id=invocation_id,
+        audit_invocation_id=invocation_placeholder,
     )
     clipped_evidence = prompt_has_clipped_evidence(evidence_manifest)
     if clipped_evidence:
@@ -909,6 +911,49 @@ def launch_worker(
             f"{cid}: development packet is {len(prompt)} characters; "
             "packet must be narrowed without converting transport size into a verdict"
         )
+    if prompt.count(invocation_placeholder) != 1:
+        raise ValueError(
+            f"{cid}: prepared packet must contain exactly one invocation placeholder"
+        )
+    return {
+        "prompt": prompt,
+        "invocation_placeholder": invocation_placeholder,
+        "evidence_manifest": evidence_manifest,
+        "transport_bound": transport_bound,
+    }
+
+
+def launch_worker(
+    row: dict,
+    rows: dict[str, dict],
+    pass_no: int,
+    workdir: Path,
+    runner_timeout: int,
+    round_no: int = 1,
+    claim_packet_cache: dict[str, dict] | None = None,
+) -> dict:
+    cid = row["claim_id"]
+    key = artifact_key(cid)
+    seat = "A" if pass_no == 1 else "B"
+    ident = f"{seat}-{datetime.now(timezone.utc).strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
+    invocation_id = uuid.uuid4().hex
+    prepared = (
+        claim_packet_cache.get(cid)
+        if claim_packet_cache is not None
+        else None
+    )
+    if prepared is None:
+        prepared = prepare_claim_packet(row, rows, runner_timeout)
+        if claim_packet_cache is not None:
+            claim_packet_cache[cid] = prepared
+    invocation_placeholder = prepared["invocation_placeholder"]
+    prompt = prepared["prompt"].replace(
+        invocation_placeholder,
+        invocation_id,
+        1,
+    )
+    evidence_manifest = copy.deepcopy(prepared["evidence_manifest"])
+    transport_bound = copy.deepcopy(prepared["transport_bound"])
 
     # Artifact names carry the round so a claim legitimately re-entering a
     # later round (e.g. a critical row resuming at awaiting_second) never
@@ -3637,12 +3682,14 @@ def main() -> int:
         transport_quarantines: set[str] = set()
         try:
             for row in batch:
+                claim_packet_cache: dict[str, dict] = {}
                 for pass_no in passes_for_row(row):
                     try:
                         jobs.append(
                             launch_worker(
                                 row, rows, pass_no, workdir,
                                 args.runner_timeout_sec, round_no,
+                                claim_packet_cache,
                             )
                         )
                     except PromptTransportBlockedError as exc:
@@ -3653,6 +3700,11 @@ def main() -> int:
                             "result": "prompt_transport_blocked",
                             "detail": str(exc),
                         })
+                        # Every seat on this claim receives the same complete
+                        # packet. A deterministic transport failure therefore
+                        # applies to every peer; do not rebuild expensive live
+                        # evidence only to reproduce it.
+                        break
                     except Exception as exc:
                         launch_blocked = True
                         report.append({

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -22,7 +22,6 @@ import itertools
 import json
 import math
 import os
-import signal
 import subprocess
 import sys
 import tempfile
@@ -67,8 +66,7 @@ PROGRESS = {
     "quarantine_file": None,
 }
 _STOP_HEARTBEAT = threading.Event()
-PHASE_INTERRUPT_GRACE_SECONDS = 30
-PHASE_TERMINATION_GRACE_SECONDS = 5
+PHASE_INTERRUPT_STATUS_SECONDS = 30
 _DRAIN_LOCK_HANDLE: TextIO | None = None
 DEFAULT_SERVICE_RETRY_INITIAL_SECONDS = 60
 DEFAULT_SERVICE_RETRY_MAX_SECONDS = 15 * 60
@@ -366,35 +364,33 @@ def git_head() -> str:
     return proc.stdout.strip()
 
 
-def terminate_phase_process_group(proc: subprocess.Popen) -> None:
-    """Contain one owned orchestration phase after parent interruption."""
-    if proc.poll() is not None:
-        proc.wait()
-        return
-    for signum, grace in (
-        (signal.SIGINT, PHASE_INTERRUPT_GRACE_SECONDS),
-        (signal.SIGTERM, PHASE_TERMINATION_GRACE_SECONDS),
-    ):
+def await_phase_cleanup_boundary(proc: subprocess.Popen) -> None:
+    """Retain supervision until an interrupted child phase exits itself.
+
+    Batch and panel children own read-only auditor sessions that are detached
+    from the phase process group, and a batch child may simultaneously own a
+    serialized mutation transaction.  The supervisor therefore must not
+    signal or time-escalate the child session: process exit is the only safe
+    acknowledgment that detached seats were handled and any mutation reached
+    its rollback/push-reconciliation boundary.  Repeated parent interrupts are
+    preserved as diagnostics but cannot abandon that ownership contract.
+    """
+    while True:
         try:
-            os.killpg(proc.pid, signum)
-        except ProcessLookupError:
-            pass
-        try:
-            proc.wait(timeout=grace)
+            proc.wait(timeout=PHASE_INTERRUPT_STATUS_SECONDS)
             return
         except subprocess.TimeoutExpired:
+            emit_preserving_primary_result(
+                "INTERRUPT still deferred; the owned child phase has not yet "
+                "acknowledged its cleanup/transaction boundary"
+            )
             continue
-    try:
-        os.killpg(proc.pid, signal.SIGKILL)
-    except ProcessLookupError:
-        pass
-    try:
-        proc.wait(timeout=PHASE_TERMINATION_GRACE_SECONDS)
-    except subprocess.TimeoutExpired as exc:
-        raise batch.CleanupIntegrityError(
-            "owned audit phase process group survived interrupt containment: "
-            f"pgid={proc.pid}"
-        ) from exc
+        except BaseException as secondary_interrupt:
+            emit_preserving_primary_result(
+                "INTERRUPT still deferred until the owned child phase reaches "
+                "its cleanup/transaction boundary: "
+                f"{finalization_failure('secondary interrupt', secondary_interrupt)}"
+            )
 
 
 def run_command(label: str, command: list[str], env: dict[str, str] | None = None) -> int:
@@ -421,7 +417,11 @@ def run_command(label: str, command: list[str], env: dict[str, str] | None = Non
     try:
         returncode = proc.wait()
     except BaseException:
-        terminate_phase_process_group(proc)
+        emit_preserving_primary_result(
+            "INTERRUPT deferred until the isolated child phase exits under "
+            "its own seat-cleanup and mutation-transaction rules"
+        )
+        await_phase_cleanup_boundary(proc)
         raise
     if label.startswith("panel-"):
         state = "complete" if returncode == 0 else f"failed_exit_{returncode}"

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -407,16 +407,19 @@ def run_command(label: str, command: list[str], env: dict[str, str] | None = Non
         lock_fd = _DRAIN_LOCK_HANDLE.fileno()
         child_env[batch.INHERITED_DRAIN_LOCK_FD_ENV] = str(lock_fd)
         pass_fds = (lock_fd,)
-    proc = subprocess.Popen(
-        command,
-        cwd=REPO_ROOT,
-        env=child_env,
-        pass_fds=pass_fds,
-        start_new_session=True,
-    )
+    proc: subprocess.Popen | None = None
     try:
+        proc = subprocess.Popen(
+            command,
+            cwd=REPO_ROOT,
+            env=child_env,
+            pass_fds=pass_fds,
+            start_new_session=True,
+        )
         returncode = proc.wait()
     except BaseException:
+        if proc is None:
+            raise
         emit_preserving_primary_result(
             "INTERRUPT deferred until the isolated child phase exits under "
             "its own seat-cleanup and mutation-transaction rules"

--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -22,6 +22,7 @@ import itertools
 import json
 import math
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -66,6 +67,8 @@ PROGRESS = {
     "quarantine_file": None,
 }
 _STOP_HEARTBEAT = threading.Event()
+PHASE_INTERRUPT_GRACE_SECONDS = 30
+PHASE_TERMINATION_GRACE_SECONDS = 5
 _DRAIN_LOCK_HANDLE: TextIO | None = None
 DEFAULT_SERVICE_RETRY_INITIAL_SECONDS = 60
 DEFAULT_SERVICE_RETRY_MAX_SECONDS = 15 * 60
@@ -363,6 +366,37 @@ def git_head() -> str:
     return proc.stdout.strip()
 
 
+def terminate_phase_process_group(proc: subprocess.Popen) -> None:
+    """Contain one owned orchestration phase after parent interruption."""
+    if proc.poll() is not None:
+        proc.wait()
+        return
+    for signum, grace in (
+        (signal.SIGINT, PHASE_INTERRUPT_GRACE_SECONDS),
+        (signal.SIGTERM, PHASE_TERMINATION_GRACE_SECONDS),
+    ):
+        try:
+            os.killpg(proc.pid, signum)
+        except ProcessLookupError:
+            pass
+        try:
+            proc.wait(timeout=grace)
+            return
+        except subprocess.TimeoutExpired:
+            continue
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    try:
+        proc.wait(timeout=PHASE_TERMINATION_GRACE_SECONDS)
+    except subprocess.TimeoutExpired as exc:
+        raise batch.CleanupIntegrityError(
+            "owned audit phase process group survived interrupt containment: "
+            f"pgid={proc.pid}"
+        ) from exc
+
+
 def run_command(label: str, command: list[str], env: dict[str, str] | None = None) -> int:
     PROGRESS["phase"] = label
     PROGRESS["attempts"] += 1
@@ -377,31 +411,37 @@ def run_command(label: str, command: list[str], env: dict[str, str] | None = Non
         lock_fd = _DRAIN_LOCK_HANDLE.fileno()
         child_env[batch.INHERITED_DRAIN_LOCK_FD_ENV] = str(lock_fd)
         pass_fds = (lock_fd,)
-    proc = subprocess.run(
+    proc = subprocess.Popen(
         command,
         cwd=REPO_ROOT,
         env=child_env,
         pass_fds=pass_fds,
+        start_new_session=True,
     )
+    try:
+        returncode = proc.wait()
+    except BaseException:
+        terminate_phase_process_group(proc)
+        raise
     if label.startswith("panel-"):
-        state = "complete" if proc.returncode == 0 else f"failed_exit_{proc.returncode}"
+        state = "complete" if returncode == 0 else f"failed_exit_{returncode}"
         PROGRESS["panel_state"] = f"{state}:{label}"
     if label.startswith("forensic-canary-"):
-        state = "complete" if proc.returncode == 0 else f"failed_exit_{proc.returncode}"
+        state = "complete" if returncode == 0 else f"failed_exit_{returncode}"
         PROGRESS["canary_state"] = f"{state}:{label}"
-    if proc.returncode != 0:
-        PROGRESS["failures"].append(f"{label}:exit={proc.returncode}")
+    if returncode != 0:
+        PROGRESS["failures"].append(f"{label}:exit={returncode}")
     try:
-        emit(f"END {label}: exit={proc.returncode} head={git_head()}")
+        emit(f"END {label}: exit={returncode} head={git_head()}")
     except BaseException as exc:
-        if proc.returncode != batch.CLEANUP_INTEGRITY_EXIT_CODE:
+        if returncode != batch.CLEANUP_INTEGRITY_EXIT_CODE:
             raise
         batch.cleanup_integrity_diagnostic(
             "GLOBAL cleanup integrity child result retained after END "
             "reporting failed",
             exc,
         )
-    return proc.returncode
+    return returncode
 
 
 def _lane_names(payload: object) -> list[str]:

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -1001,6 +1001,76 @@ class BatchExitSemanticsTest(unittest.TestCase):
         wait_workers.assert_not_called()
         lock.close.assert_called_once_with()
 
+    def test_unfrozen_claim_failure_stops_peer_without_transport_reclassification(self):
+        row = {
+            "claim_id": "fingerprint-failed",
+            "claim_type": "bounded_theorem",
+            "criticality": "critical",
+        }
+        lock = mock.Mock()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workdir = root / "batch"
+            quarantine = root / "campaign-row-exclusions.jsonl"
+            with mock.patch.dict(
+                os.environ,
+                {"AUDIT_BATCH_WORKDIR": str(workdir)},
+            ), mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "orchestrate_audit_batch.py",
+                    "--claims",
+                    "fingerprint-failed",
+                    "--max-workers",
+                    "2",
+                    "--rounds",
+                    "1",
+                    "--campaign-quarantine-file",
+                    str(quarantine),
+                ],
+            ), mock.patch.object(
+                batch,
+                "acquire_exclusive_drain_lock",
+                return_value=lock,
+            ), mock.patch.object(
+                batch, "clean_main_error", return_value=None
+            ), mock.patch.object(
+                batch,
+                "load_rows",
+                return_value={"fingerprint-failed": row},
+            ), mock.patch.object(
+                batch, "scope_for_args", return_value={"fingerprint-failed"}
+            ), mock.patch.object(
+                batch, "compute_targets", return_value=([row], [])
+            ), mock.patch.object(
+                batch,
+                "launch_worker",
+                side_effect=OSError("fingerprint unreadable"),
+            ) as launch_worker, mock.patch.object(
+                batch, "start_progress_ticker"
+            ), mock.patch.object(
+                batch, "maybe_progress_summary"
+            ), mock.patch.object(
+                batch, "wait_workers"
+            ) as wait_workers:
+                rc = batch.main()
+
+            report = [
+                json.loads(line)
+                for line in (workdir / "report.jsonl").read_text().splitlines()
+            ]
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(launch_worker.call_count, 1)
+        self.assertEqual(
+            [item["result"] for item in report],
+            ["worker_launch_failed"],
+        )
+        self.assertIn("fingerprint unreadable", report[0]["detail"])
+        wait_workers.assert_not_called()
+        lock.close.assert_called_once_with()
+
     def test_banked_clean_seat_defers_only_the_invalid_peer(self):
         report = [
             {"cid": "row", "result": "validation_failed"},
@@ -6194,11 +6264,15 @@ class CampaignContractTest(unittest.TestCase):
             ):
                 audit_loop.run_command("batch-probe", ["child"])
 
-    def test_parent_interrupt_contains_owned_child_phase_before_reraising(self):
+    def test_parent_interrupt_waits_for_child_owned_cleanup_before_reraising(self):
         original_progress = dict(audit_loop.PROGRESS)
         child = mock.Mock(pid=4321)
-        child.poll.return_value = None
-        child.wait.side_effect = [KeyboardInterrupt(), 0]
+        child.wait.side_effect = [
+            KeyboardInterrupt(),
+            subprocess.TimeoutExpired(["child"], 30),
+            KeyboardInterrupt(),
+            0,
+        ]
         try:
             with mock.patch.object(
                 audit_loop.subprocess, "Popen", return_value=child
@@ -6206,13 +6280,28 @@ class CampaignContractTest(unittest.TestCase):
                 audit_loop.os, "killpg"
             ) as killpg, mock.patch.object(
                 audit_loop, "emit"
-            ), self.assertRaises(KeyboardInterrupt):
+            ) as emit, self.assertRaises(KeyboardInterrupt):
                 audit_loop.run_command("batch-probe", ["child"])
 
             self.assertTrue(popen.call_args.kwargs["start_new_session"])
-            killpg.assert_called_once_with(4321, audit_loop.signal.SIGINT)
+            killpg.assert_not_called()
             child.wait.assert_has_calls(
-                [mock.call(), mock.call(timeout=30)]
+                [
+                    mock.call(),
+                    mock.call(timeout=30),
+                    mock.call(timeout=30),
+                    mock.call(timeout=30),
+                ]
+            )
+            emitted = [str(call.args[0]) for call in emit.call_args_list]
+            self.assertTrue(
+                any("INTERRUPT deferred" in message for message in emitted)
+            )
+            self.assertTrue(
+                any("secondary interrupt" in message for message in emitted)
+            )
+            self.assertTrue(
+                any("has not yet acknowledged" in message for message in emitted)
             )
         finally:
             audit_loop.PROGRESS.clear()

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -928,7 +928,7 @@ class BatchExitSemanticsTest(unittest.TestCase):
         row = {
             "claim_id": "oversized",
             "claim_type": "bounded_theorem",
-            "criticality": "ordinary",
+            "criticality": "critical",
         }
         lock = mock.Mock()
         with tempfile.TemporaryDirectory() as tmp:
@@ -946,7 +946,7 @@ class BatchExitSemanticsTest(unittest.TestCase):
                     "--claims",
                     "oversized",
                     "--max-workers",
-                    "1",
+                    "2",
                     "--rounds",
                     "1",
                     "--campaign-quarantine-file",
@@ -970,7 +970,7 @@ class BatchExitSemanticsTest(unittest.TestCase):
                 side_effect=batch.PromptTransportBlockedError(
                     "prompt remains 1636029 chars after removing rendered N8"
                 ),
-            ), mock.patch.object(
+            ) as launch_worker, mock.patch.object(
                 batch, "start_progress_ticker"
             ), mock.patch.object(
                 batch, "maybe_progress_summary"
@@ -997,6 +997,7 @@ class BatchExitSemanticsTest(unittest.TestCase):
                 batch.PROMPT_TRANSPORT_QUARANTINE_RESULT,
             },
         )
+        self.assertEqual(launch_worker.call_count, 1)
         wait_workers.assert_not_called()
         lock.close.assert_called_once_with()
 
@@ -6153,11 +6154,10 @@ class CampaignContractTest(unittest.TestCase):
                             raise OSError("HEAD unavailable after child exit")
                         return "same"
 
-                    completed = mock.Mock(
-                        returncode=batch.CLEANUP_INTEGRITY_EXIT_CODE
-                    )
+                    child = mock.Mock(pid=4321)
+                    child.wait.return_value = batch.CLEANUP_INTEGRITY_EXIT_CODE
                     with mock.patch.object(
-                        audit_loop.subprocess, "run", return_value=completed
+                        audit_loop.subprocess, "Popen", return_value=child
                     ), mock.patch.object(
                         audit_loop, "git_head", side_effect=git_head
                     ), mock.patch.object(
@@ -6174,14 +6174,15 @@ class CampaignContractTest(unittest.TestCase):
             audit_loop.PROGRESS.update(original_progress)
 
     def test_child_end_reporting_failure_still_propagates_on_ordinary_result(self):
-        completed = mock.Mock(returncode=1)
+        child = mock.Mock(pid=4321)
+        child.wait.return_value = 1
 
         def emit(message):
             if message.startswith("END "):
                 raise OSError("stdout unavailable after ordinary child exit")
 
         with mock.patch.object(
-            audit_loop.subprocess, "run", return_value=completed
+            audit_loop.subprocess, "Popen", return_value=child
         ), mock.patch.object(
             audit_loop, "git_head", return_value="same"
         ), mock.patch.object(
@@ -6192,6 +6193,30 @@ class CampaignContractTest(unittest.TestCase):
                 "stdout unavailable after ordinary child exit",
             ):
                 audit_loop.run_command("batch-probe", ["child"])
+
+    def test_parent_interrupt_contains_owned_child_phase_before_reraising(self):
+        original_progress = dict(audit_loop.PROGRESS)
+        child = mock.Mock(pid=4321)
+        child.poll.return_value = None
+        child.wait.side_effect = [KeyboardInterrupt(), 0]
+        try:
+            with mock.patch.object(
+                audit_loop.subprocess, "Popen", return_value=child
+            ) as popen, mock.patch.object(
+                audit_loop.os, "killpg"
+            ) as killpg, mock.patch.object(
+                audit_loop, "emit"
+            ), self.assertRaises(KeyboardInterrupt):
+                audit_loop.run_command("batch-probe", ["child"])
+
+            self.assertTrue(popen.call_args.kwargs["start_new_session"])
+            killpg.assert_called_once_with(4321, audit_loop.signal.SIGINT)
+            child.wait.assert_has_calls(
+                [mock.call(), mock.call(timeout=30)]
+            )
+        finally:
+            audit_loop.PROGRESS.clear()
+            audit_loop.PROGRESS.update(original_progress)
 
     def test_parent_finalizers_propagate_ordinary_failure_after_exhaustive_close(
         self,

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -6307,6 +6307,20 @@ class CampaignContractTest(unittest.TestCase):
             audit_loop.PROGRESS.clear()
             audit_loop.PROGRESS.update(original_progress)
 
+    def test_phase_spawn_failure_does_not_enter_child_cleanup_wait(self):
+        with mock.patch.object(
+            audit_loop.subprocess,
+            "Popen",
+            side_effect=OSError("phase spawn failed"),
+        ), mock.patch.object(
+            audit_loop, "await_phase_cleanup_boundary"
+        ) as await_boundary, self.assertRaisesRegex(
+            OSError, "phase spawn failed"
+        ):
+            audit_loop.run_command("batch-probe", ["child"])
+
+        await_boundary.assert_not_called()
+
     def test_parent_finalizers_propagate_ordinary_failure_after_exhaustive_close(
         self,
     ):

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -12107,11 +12107,21 @@ class BatchOrchestratorRoundSemanticsTest(unittest.TestCase):
         workdir.mkdir(parents=True)
         surviving = mock.Mock(pid=1235)
         packet_cache: dict[str, dict] = {}
+        log_handles = []
+        original_open = Path.open
+
+        def tracked_open(path, *args, **kwargs):
+            handle = original_open(path, *args, **kwargs)
+            if path.name.startswith("log-"):
+                log_handles.append(handle)
+            return handle
 
         def rendered_prompt(*_args, audit_invocation_id=None, **_kwargs):
             return f"one live compute\ninvocation={audit_invocation_id}\n"
 
         with mock.patch.object(
+            Path, "open", new=tracked_open
+        ), mock.patch.object(
             m.audit_runner, "render_prompt", side_effect=rendered_prompt
         ) as render, mock.patch.object(
             m.audit_runner, "PROMPT_TEMPLATE_PATH"
@@ -12133,6 +12143,8 @@ class BatchOrchestratorRoundSemanticsTest(unittest.TestCase):
         self.assertEqual(render.call_count, 1)
         self.assertEqual(selection.call_count, 1)
         self.assertEqual(second["selection_fingerprint"], "selection")
+        self.assertEqual(len(log_handles), 2)
+        self.assertTrue(log_handles[0].closed)
 
     def test_conditional_rows_wait_for_repair_across_runs(self):
         """A re-queued audited_conditional row is not re-targeted until its

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -11914,7 +11914,8 @@ class BatchOrchestratorRoundSemanticsTest(unittest.TestCase):
             return True, set(), set(), []
 
         launch = mock.Mock(
-            side_effect=lambda row, all_rows, pass_no, wd, timeout, round_no=1: {
+            side_effect=lambda row, all_rows, pass_no, wd, timeout, round_no=1,
+            claim_packet_cache=None: {
                 "cid": row["claim_id"], "pass": pass_no, "round": round_no,
             }
         )
@@ -11942,8 +11943,12 @@ class BatchOrchestratorRoundSemanticsTest(unittest.TestCase):
         workdir = self.root / "wd2"
         workdir.mkdir(parents=True)
         proc = mock.Mock(pid=1234)
+
+        def rendered_prompt(*_args, audit_invocation_id=None, **_kwargs):
+            return f"packet invocation={audit_invocation_id}"
+
         with mock.patch.object(
-            m.audit_runner, "render_prompt", return_value="packet"
+            m.audit_runner, "render_prompt", side_effect=rendered_prompt
         ), mock.patch.object(
             m.audit_runner, "PROMPT_TEMPLATE_PATH"
         ) as template_path, mock.patch.object(
@@ -11970,6 +11975,51 @@ class BatchOrchestratorRoundSemanticsTest(unittest.TestCase):
         self.assertEqual(schema["type"], "object")
         self.assertFalse(schema["additionalProperties"])
         self.assertIn("compute_required", schema["required"])
+
+    def test_critical_seats_share_one_frozen_claim_packet(self):
+        m = _import("orchestrate_audit_batch")
+        row = {**self._row(), "criticality": "critical"}
+        rows = {"spin_row": row}
+        workdir = self.root / "wd-frozen-packet"
+        workdir.mkdir(parents=True)
+        processes = [mock.Mock(pid=1234), mock.Mock(pid=1235)]
+
+        def rendered_prompt(*_args, audit_invocation_id=None, **_kwargs):
+            return f"frozen evidence\ninvocation={audit_invocation_id}\n"
+
+        packet_cache: dict[str, dict] = {}
+        with mock.patch.object(
+            m.audit_runner, "render_prompt", side_effect=rendered_prompt
+        ) as render, mock.patch.object(
+            m.audit_runner, "PROMPT_TEMPLATE_PATH"
+        ) as template_path, mock.patch.object(
+            m, "selection_fingerprint", return_value="selection"
+        ), mock.patch.object(
+            m.subprocess, "Popen", side_effect=processes
+        ):
+            template_path.read_text.return_value = "template"
+            first = m.launch_worker(
+                row, rows, 1, workdir, 120, 1, packet_cache
+            )
+            self.addCleanup(first["log_handle"].close)
+            second = m.launch_worker(
+                row, rows, 2, workdir, 120, 1, packet_cache
+            )
+            self.addCleanup(second["log_handle"].close)
+
+        self.assertEqual(render.call_count, 1)
+        self.assertEqual(set(packet_cache), {"spin_row"})
+        first_prompt = (first["isolated"] / "AUDIT_TASK.md").read_text()
+        second_prompt = (second["isolated"] / "AUDIT_TASK.md").read_text()
+        self.assertIn(first["invocation_id"], first_prompt)
+        self.assertIn(second["invocation_id"], second_prompt)
+        self.assertNotEqual(first["invocation_id"], second["invocation_id"])
+        self.assertEqual(
+            first_prompt.replace(first["invocation_id"], "INVOCATION"),
+            second_prompt.replace(second["invocation_id"], "INVOCATION"),
+        )
+        self.assertEqual(first["evidence_manifest"], second["evidence_manifest"])
+        self.assertIsNot(first["evidence_manifest"], second["evidence_manifest"])
 
     def test_conditional_rows_wait_for_repair_across_runs(self):
         """A re-queued audited_conditional row is not re-targeted until its

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -11984,7 +11984,17 @@ class BatchOrchestratorRoundSemanticsTest(unittest.TestCase):
         workdir.mkdir(parents=True)
         processes = [mock.Mock(pid=1234), mock.Mock(pid=1235)]
 
-        def rendered_prompt(*_args, audit_invocation_id=None, **_kwargs):
+        def rendered_prompt(
+            *_args,
+            audit_invocation_id=None,
+            evidence_manifest_out=None,
+            **_kwargs,
+        ):
+            evidence_manifest_out["docs/source.md"] = {
+                "path": "docs/source.md",
+                "roles": ["source"],
+                "text": "authenticated evidence",
+            }
             return f"frozen evidence\ninvocation={audit_invocation_id}\n"
 
         packet_cache: dict[str, dict] = {}
@@ -11994,7 +12004,7 @@ class BatchOrchestratorRoundSemanticsTest(unittest.TestCase):
             m.audit_runner, "PROMPT_TEMPLATE_PATH"
         ) as template_path, mock.patch.object(
             m, "selection_fingerprint", return_value="selection"
-        ), mock.patch.object(
+        ) as selection, mock.patch.object(
             m.subprocess, "Popen", side_effect=processes
         ):
             template_path.read_text.return_value = "template"
@@ -12008,6 +12018,8 @@ class BatchOrchestratorRoundSemanticsTest(unittest.TestCase):
             self.addCleanup(second["log_handle"].close)
 
         self.assertEqual(render.call_count, 1)
+        self.assertIs(render.call_args.kwargs["use_cache"], False)
+        self.assertEqual(selection.call_count, 1)
         self.assertEqual(set(packet_cache), {"spin_row"})
         first_prompt = (first["isolated"] / "AUDIT_TASK.md").read_text()
         second_prompt = (second["isolated"] / "AUDIT_TASK.md").read_text()
@@ -12020,6 +12032,107 @@ class BatchOrchestratorRoundSemanticsTest(unittest.TestCase):
         )
         self.assertEqual(first["evidence_manifest"], second["evidence_manifest"])
         self.assertIsNot(first["evidence_manifest"], second["evidence_manifest"])
+        self.assertIsNot(
+            first["evidence_manifest"]["docs/source.md"],
+            second["evidence_manifest"]["docs/source.md"],
+        )
+        self.assertEqual(first["transport_bound"], second["transport_bound"])
+        self.assertEqual(first["selection_fingerprint"], "selection")
+        self.assertEqual(second["selection_fingerprint"], "selection")
+        self.assertNotEqual(first["auditor"], second["auditor"])
+        self.assertEqual(first["independence"], "cross_family")
+        self.assertEqual(second["independence"], "fresh_context")
+
+    def test_packet_fingerprint_failure_precedes_process_launch(self):
+        m = _import("orchestrate_audit_batch")
+        row = self._row()
+        workdir = self.root / "wd-fingerprint-failure"
+        workdir.mkdir(parents=True)
+
+        def rendered_prompt(*_args, audit_invocation_id=None, **_kwargs):
+            return f"packet invocation={audit_invocation_id}"
+
+        with mock.patch.object(
+            m.audit_runner, "render_prompt", side_effect=rendered_prompt
+        ), mock.patch.object(
+            m.audit_runner, "PROMPT_TEMPLATE_PATH"
+        ) as template_path, mock.patch.object(
+            m, "selection_fingerprint", side_effect=OSError("fingerprint unreadable")
+        ), mock.patch.object(m.subprocess, "Popen") as popen:
+            template_path.read_text.return_value = "template"
+            with self.assertRaisesRegex(OSError, "fingerprint unreadable"):
+                m.launch_worker(row, {"spin_row": row}, 1, workdir, 120, 1)
+
+        popen.assert_not_called()
+
+    def test_post_popen_job_record_failure_contains_launched_seat(self):
+        m = _import("orchestrate_audit_batch")
+        row = self._row()
+        workdir = self.root / "wd-job-record-failure"
+        workdir.mkdir(parents=True)
+        proc = mock.Mock()
+        type(proc).pid = mock.PropertyMock(
+            side_effect=[OSError("pid read interrupted"), 1234]
+        )
+
+        def rendered_prompt(*_args, audit_invocation_id=None, **_kwargs):
+            return f"packet invocation={audit_invocation_id}"
+
+        with mock.patch.object(
+            m.audit_runner, "render_prompt", side_effect=rendered_prompt
+        ), mock.patch.object(
+            m.audit_runner, "PROMPT_TEMPLATE_PATH"
+        ) as template_path, mock.patch.object(
+            m, "selection_fingerprint", return_value="selection"
+        ), mock.patch.object(
+            m.subprocess, "Popen", return_value=proc
+        ), mock.patch.object(
+            m, "terminate_read_only_seat"
+        ) as terminate:
+            template_path.read_text.return_value = "template"
+            with self.assertRaisesRegex(OSError, "pid read interrupted"):
+                m.launch_worker(row, {"spin_row": row}, 1, workdir, 120, 1)
+
+        terminate.assert_called_once()
+        self.assertEqual(
+            terminate.call_args.args[0]["process_group"],
+            1234,
+        )
+
+    def test_seat_launch_failure_does_not_rerun_frozen_claim_compute(self):
+        m = _import("orchestrate_audit_batch")
+        row = {**self._row(), "criticality": "critical"}
+        rows = {"spin_row": row}
+        workdir = self.root / "wd-launch-retry"
+        workdir.mkdir(parents=True)
+        surviving = mock.Mock(pid=1235)
+        packet_cache: dict[str, dict] = {}
+
+        def rendered_prompt(*_args, audit_invocation_id=None, **_kwargs):
+            return f"one live compute\ninvocation={audit_invocation_id}\n"
+
+        with mock.patch.object(
+            m.audit_runner, "render_prompt", side_effect=rendered_prompt
+        ) as render, mock.patch.object(
+            m.audit_runner, "PROMPT_TEMPLATE_PATH"
+        ) as template_path, mock.patch.object(
+            m, "selection_fingerprint", return_value="selection"
+        ) as selection, mock.patch.object(
+            m.subprocess,
+            "Popen",
+            side_effect=[OSError("seat A launch failed"), surviving],
+        ):
+            template_path.read_text.return_value = "template"
+            with self.assertRaisesRegex(OSError, "seat A launch failed"):
+                m.launch_worker(row, rows, 1, workdir, 120, 1, packet_cache)
+            second = m.launch_worker(
+                row, rows, 2, workdir, 120, 1, packet_cache
+            )
+            self.addCleanup(second["log_handle"].close)
+
+        self.assertEqual(render.call_count, 1)
+        self.assertEqual(selection.call_count, 1)
+        self.assertEqual(second["selection_fingerprint"], "selection")
 
     def test_conditional_rows_wait_for_repair_across_runs(self):
         """A re-queued audited_conditional row is not re-targeted until its


### PR DESCRIPTION
## Summary

- render and authenticate one immutable restricted packet per claim, then give each independent seat byte-equivalent evidence with only its invocation id changed
- execute primary and marked helper scientific runners once per claim with use_cache=False, while preserving distinct auditor identity and seat independence
- stop peer launch after deterministic transport or unfrozen packet-preparation failure without reclassifying unrelated failures
- freeze packet/source selection identity before process launch and retain verified ownership if post-launch job bookkeeping fails
- isolate each top-level child phase and, after parent interruption, wait without signal escalation until the child acknowledges its own seat-cleanup and mutation-transaction boundary

## Production evidence

The canonical drain executed the same 900-second-capable runner twice for one critical claim before launching judges, recorded duplicate deterministic transport failures for another claim, and could lose ownership of a read-only seat when post-Popen fingerprinting failed. Fixed-grace top-level escalation could also kill a batch during rollback or push reconciliation while its detached auditor sessions survived. This patch closes those control-plane paths without modifying verdict content, scientific claims, or scientific gates.

## Review fixes

- selection fingerprints, source provenance, independence, and timestamps are frozen before Popen
- process creation and all subsequent job-record or phase-wait bookkeeping share one exception-protected ownership scope
- defensive post-Popen failure handling proves the launched process group absent and preserves cleanup-integrity failures
- claim preparation failures stop the peer before any second live render; later seat-launch failures reuse the frozen packet
- parent interruption is preserved and reraised only after isolated child exit; no SIGTERM or SIGKILL timer can preempt the child transaction

## Validation

- focused containment suite: 8 tests pass on the final head
- full relevant suite: 687 tests pass across audit pipeline, audit-loop orchestrator, and science fingerprint/invalidation modules
- full audit pipeline passes on current main 7b248063e: 3970 rows, one Cycle-870 seed, zero evidence-universe re-audit targets, zero hard invalidations
- strict audit lint passes with zero errors
- changed-audit-evidence gate passes with checked=0, failures=0, control_failures=0
- current-ledger packet probe confirms prepared/current selection fingerprint equality and exactly one invocation placeholder
- vocabulary lint, Python compilation, and git diff --check pass
- generated pipeline surfaces were validation-only and restored; no audit verdict, generated audit/status artifact, or review scratch file is included

No-Go Discipline is not applicable: this is tooling-only and makes no negative scientific claim.