### PR TITLE
fix(audit): prevent redundant batch attempts

### DIFF
--- a/docs/audit/scripts/compute_reaudit_candidates.py
+++ b/docs/audit/scripts/compute_reaudit_candidates.py
@@ -319,8 +319,9 @@ def build_payload(rows: dict[str, dict]) -> dict:
             "hash has changed since the audit_state_snapshot was taken; or "
             "(c) the audit requested complete runner stdout and a usable "
             "source-bound cache falls above the legacy 6k limit but within "
-            "the current 20k head+tail transport budget, and the terminal "
-            "audit predates the current packet-policy fingerprint."
+            "the current 20k head+tail transport budget, unless the terminal "
+            "audit used the current packet-policy fingerprint and every "
+            "recorded blocker fingerprint remains unchanged."
         ),
         "packet_policy_fingerprint": packet_policy,
         "eligible_claim_types": sorted(ELIGIBLE_CLAIM_TYPES),

--- a/docs/audit/scripts/compute_reaudit_candidates.py
+++ b/docs/audit/scripts/compute_reaudit_candidates.py
@@ -23,6 +23,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+import audit_science_fingerprint
 import premise_nodes
 import ledger_io
 
@@ -86,6 +87,15 @@ def stdout_transport_reaudit_candidate(row: dict) -> tuple[bool, int | None]:
         and LEGACY_RUNNER_STDOUT_CHAR_LIMIT < stdout_chars <= RUNNER_STDOUT_CHAR_LIMIT,
         stdout_chars,
     )
+
+
+def audited_under_packet_policy(row: dict, packet_policy: dict[str, str]) -> bool:
+    """Whether the row's terminal audit already used this packet policy."""
+    snapshot = row.get("audit_state_snapshot")
+    if not isinstance(snapshot, dict):
+        return False
+    recorded = snapshot.get("packet_policy_fingerprint")
+    return isinstance(recorded, dict) and recorded == packet_policy
 
 CRITICALITY_RANK = {"critical": 3, "high": 2, "medium": 1, "leaf": 0}
 RATIFIED_DEP_STATUSES = {"retained", "retained_no_go", "retained_bounded"}
@@ -216,6 +226,7 @@ def sort_key(entry: dict) -> tuple:
 
 def build_payload(rows: dict[str, dict]) -> dict:
     """Return the canonical cache payload from current authoritative inputs."""
+    packet_policy = audit_science_fingerprint.packet_policy_fingerprint(REPO_ROOT)
     candidates: list[dict] = []
     runner_drift_candidates: list[dict] = []
     runner_stdout_transport_candidates: list[dict] = []
@@ -255,7 +266,9 @@ def build_payload(rows: dict[str, dict]) -> dict:
                     runner_drift_candidates.append(entry)
 
             transport_freed, stdout_chars = stdout_transport_reaudit_candidate(row)
-            if transport_freed:
+            if transport_freed and not audited_under_packet_policy(
+                row, packet_policy
+            ):
                 entry = candidate_entry(cid, row, rows, [])
                 entry["candidate_reason"] = (
                     "runner_stdout_transport_unclipped_by_head_tail_v2"
@@ -280,7 +293,7 @@ def build_payload(rows: dict[str, dict]) -> dict:
         entry["generated_order"] = idx
 
     return {
-        "policy": "reaudit_unblocked_v3_dep_runner_or_stdout_transport",
+        "policy": "reaudit_unblocked_v4_dep_runner_or_stdout_transport",
         "policy_summary": (
             "Non-clean audited theorem/no-go/open-gate claims surfaced under "
             "one of three policies: (a) all current one-hop deps are "
@@ -289,8 +302,10 @@ def build_payload(rows: dict[str, dict]) -> dict:
             "hash has changed since the audit_state_snapshot was taken; or "
             "(c) the audit requested complete runner stdout and a usable "
             "source-bound cache falls above the legacy 6k limit but within "
-            "the current 20k head+tail transport budget."
+            "the current 20k head+tail transport budget, and the terminal "
+            "audit predates the current packet-policy fingerprint."
         ),
+        "packet_policy_fingerprint": packet_policy,
         "eligible_claim_types": sorted(ELIGIBLE_CLAIM_TYPES),
         "eligible_audit_statuses": sorted(ELIGIBLE_AUDIT_STATUSES),
         "ratified_dependency_statuses": sorted(RATIFIED_DEP_STATUSES),

--- a/docs/audit/scripts/compute_reaudit_candidates.py
+++ b/docs/audit/scripts/compute_reaudit_candidates.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import audit_science_fingerprint
+import compute_audit_queue
 import premise_nodes
 import ledger_io
 
@@ -89,13 +90,29 @@ def stdout_transport_reaudit_candidate(row: dict) -> tuple[bool, int | None]:
     )
 
 
-def audited_under_packet_policy(row: dict, packet_policy: dict[str, str]) -> bool:
-    """Whether the row's terminal audit already used this packet policy."""
+def audited_under_unchanged_packet_policy(
+    row: dict,
+    rows: dict[str, dict],
+    packet_policy: dict,
+) -> bool:
+    """Whether the same packet policy saw the same recorded blockers."""
     snapshot = row.get("audit_state_snapshot")
     if not isinstance(snapshot, dict):
         return False
     recorded = snapshot.get("packet_policy_fingerprint")
-    return isinstance(recorded, dict) and recorded == packet_policy
+    if not isinstance(recorded, dict) or recorded != packet_policy:
+        return False
+
+    # Packet-policy equality prevents the immediate same-status retry only
+    # while the terminal verdict's complete blocker fingerprint is unchanged.
+    # In particular, a cache that became fresh after the audit is new evidence
+    # even though the transport policy itself did not move.  Reuse the audit
+    # queue's canonical comparator instead of mirroring its provenance rules.
+    parked, _reason = compute_audit_queue._live_conditional_would_park(
+        row, rows
+    )
+    return parked
+
 
 CRITICALITY_RANK = {"critical": 3, "high": 2, "medium": 1, "leaf": 0}
 RATIFIED_DEP_STATUSES = {"retained", "retained_no_go", "retained_bounded"}
@@ -266,8 +283,8 @@ def build_payload(rows: dict[str, dict]) -> dict:
                     runner_drift_candidates.append(entry)
 
             transport_freed, stdout_chars = stdout_transport_reaudit_candidate(row)
-            if transport_freed and not audited_under_packet_policy(
-                row, packet_policy
+            if transport_freed and not audited_under_unchanged_packet_policy(
+                row, rows, packet_policy
             ):
                 entry = candidate_entry(cid, row, rows, [])
                 entry["candidate_reason"] = (

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -3440,6 +3440,7 @@ def apply_serialized(
 
 def selected_batch(targets: list[dict], max_workers: int) -> list[dict]:
     selected: list[dict] = []
+    reserved: set[str] = set()
     used = 0
     for row in targets:
         seats = len(passes_for_row(row))
@@ -3447,7 +3448,21 @@ def selected_batch(targets: list[dict], max_workers: int) -> list[dict]:
             continue
         if used + seats > max_workers:
             continue
+        # A verdict can update an ordinary dependency's derived status or
+        # topology (notably when a decoration relation is established).  Do
+        # not launch a sibling packet whose selection fingerprint would then
+        # be stale.  Canonical accepted premises are immutable policy inputs
+        # and therefore do not serialize otherwise-independent targets.
+        collision_keys = {row["claim_id"]}
+        collision_keys.update(
+            dep
+            for dep in (row.get("deps") or [])
+            if isinstance(dep, str) and dep and not accepted(dep)
+        )
+        if reserved.intersection(collision_keys):
+            continue
         selected.append(row)
+        reserved.update(collision_keys)
         used += seats
     return selected
 

--- a/docs/audit/scripts/orchestrate_audit_batch.py
+++ b/docs/audit/scripts/orchestrate_audit_batch.py
@@ -617,8 +617,18 @@ def source_queue_rows(source: str, rows: dict[str, dict]) -> list[dict]:
 
 
 def source_row_fingerprint(row: dict) -> str:
+    # generated_order is presentation/ranking metadata.  Removing an earlier
+    # independent candidate renumbers the remaining stream but does not change
+    # this target's eligibility, evidence, or dispatch contract.
+    stable_row = {
+        key: value for key, value in row.items() if key != "generated_order"
+    }
     return hashlib.sha256(
-        json.dumps(row, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        json.dumps(
+            stable_row,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
     ).hexdigest()
 
 
@@ -3438,9 +3448,38 @@ def apply_serialized(
     )
 
 
-def selected_batch(targets: list[dict], max_workers: int) -> list[dict]:
+def ordinary_dependency_closure(row: dict, rows: dict[str, dict]) -> set[str]:
+    """Return transitive ordinary-claim dependencies for batch isolation."""
+    seen: set[str] = set()
+    stack = list(row.get("deps") or [])
+    while stack:
+        dep = stack.pop()
+        if not isinstance(dep, str) or not dep or dep in seen:
+            continue
+        dep_row = rows.get(dep)
+        if accepted(dep) or (
+            isinstance(dep_row, dict)
+            and (
+                dep_row.get("claim_type") == "meta"
+                or dep_row.get("effective_status") == "meta"
+            )
+        ):
+            continue
+        seen.add(dep)
+        if isinstance(dep_row, dict):
+            stack.extend(dep_row.get("deps") or [])
+    return seen
+
+
+def selected_batch(
+    targets: list[dict],
+    max_workers: int,
+    rows: dict[str, dict] | None = None,
+) -> list[dict]:
+    all_rows = rows or {row["claim_id"]: row for row in targets}
     selected: list[dict] = []
-    reserved: set[str] = set()
+    selected_claim_ids: set[str] = set()
+    selected_upstream_ids: set[str] = set()
     used = 0
     for row in targets:
         seats = len(passes_for_row(row))
@@ -3448,21 +3487,22 @@ def selected_batch(targets: list[dict], max_workers: int) -> list[dict]:
             continue
         if used + seats > max_workers:
             continue
-        # A verdict can update an ordinary dependency's derived status or
-        # topology (notably when a decoration relation is established).  Do
-        # not launch a sibling packet whose selection fingerprint would then
-        # be stale.  Canonical accepted premises are immutable policy inputs
-        # and therefore do not serialize otherwise-independent targets.
-        collision_keys = {row["claim_id"]}
-        collision_keys.update(
-            dep
-            for dep in (row.get("deps") or [])
-            if isinstance(dep, str) and dep and not accepted(dep)
-        )
-        if reserved.intersection(collision_keys):
+        # Applying a verdict can propagate through every downstream consumer.
+        # Select an antichain over the transitive ordinary-claim dependency
+        # order so no launched packet contains a ledger row that an earlier
+        # selected target can update.  Siblings may still run together: one
+        # sibling does not mutate their shared dependency.  Canonical accepted
+        # premises and stable meta context terminate the mutable closure.
+        cid = row["claim_id"]
+        upstream = ordinary_dependency_closure(row, all_rows)
+        if (
+            cid in selected_upstream_ids
+            or bool(selected_claim_ids.intersection(upstream))
+        ):
             continue
         selected.append(row)
-        reserved.update(collision_keys)
+        selected_claim_ids.add(cid)
+        selected_upstream_ids.update(upstream)
         used += seats
     return selected
 
@@ -3738,7 +3778,7 @@ def main() -> int:
             return finish(2)
         if not targets:
             break
-        batch = selected_batch(targets, args.max_workers)
+        batch = selected_batch(targets, args.max_workers, rows)
         if not batch:
             print("no target fits the configured worker limit (critical rows require two seats)")
             return finish(2)

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -4459,7 +4459,7 @@ class CampaignContractTest(unittest.TestCase):
         self.assertNotIn("--coordinator", help_text)
         self.assertIn("--max-runtime-hours", help_text)
 
-    def test_batch_selection_skips_siblings_with_mutable_shared_dep(self):
+    def test_batch_selection_allows_siblings_with_shared_dependency(self):
         targets = [
             {"claim_id": "first", "deps": ["shared"]},
             {"claim_id": "sibling", "deps": ["shared"]},
@@ -4470,7 +4470,89 @@ class CampaignContractTest(unittest.TestCase):
 
         self.assertEqual(
             [row["claim_id"] for row in selected],
-            ["first", "independent"],
+            ["first", "sibling"],
+        )
+
+    def test_batch_selection_excludes_selected_dependency_and_consumers(self):
+        rows = {
+            "shared": {"claim_id": "shared", "deps": []},
+            "first": {"claim_id": "first", "deps": ["shared"]},
+            "sibling": {"claim_id": "sibling", "deps": ["shared"]},
+            "independent": {"claim_id": "independent", "deps": []},
+        }
+        targets = [
+            rows["shared"],
+            rows["first"],
+            rows["sibling"],
+            rows["independent"],
+        ]
+        with mock.patch.object(batch, "accepted", return_value=False):
+            selected = batch.selected_batch(
+                targets, max_workers=3, rows=rows
+            )
+
+        self.assertEqual(
+            [row["claim_id"] for row in selected],
+            ["shared", "independent"],
+        )
+
+    def test_batch_selection_excludes_transitive_dependency_collision(self):
+        rows = {
+            "ancestor": {"claim_id": "ancestor", "deps": []},
+            "middle": {"claim_id": "middle", "deps": ["ancestor"]},
+            "descendant": {"claim_id": "descendant", "deps": ["middle"]},
+            "independent": {"claim_id": "independent", "deps": []},
+        }
+        targets = [
+            rows["ancestor"],
+            rows["descendant"],
+            rows["independent"],
+        ]
+        with mock.patch.object(batch, "accepted", return_value=False):
+            selected = batch.selected_batch(
+                targets, max_workers=3, rows=rows
+            )
+
+        self.assertEqual(
+            [row["claim_id"] for row in selected],
+            ["ancestor", "independent"],
+        )
+
+        reverse_targets = [
+            rows["descendant"],
+            rows["ancestor"],
+            rows["independent"],
+        ]
+        with mock.patch.object(batch, "accepted", return_value=False):
+            reverse_selected = batch.selected_batch(
+                reverse_targets, max_workers=3, rows=rows
+            )
+
+        self.assertEqual(
+            [row["claim_id"] for row in reverse_selected],
+            ["descendant", "independent"],
+        )
+
+    def test_batch_selection_stops_dependency_closure_at_meta_context(self):
+        rows = {
+            "ancestor": {"claim_id": "ancestor", "deps": []},
+            "context": {
+                "claim_id": "context",
+                "claim_type": "meta",
+                "effective_status": "meta",
+                "deps": ["ancestor"],
+            },
+            "consumer": {"claim_id": "consumer", "deps": ["context"]},
+        }
+        targets = [rows["ancestor"], rows["consumer"]]
+        with mock.patch.object(batch, "accepted", return_value=False):
+            selected = batch.selected_batch(
+                targets, max_workers=2, rows=rows
+            )
+
+        self.assertEqual(
+            [row["claim_id"] for row in selected],
+            ["ancestor", "consumer"],
         )
 
     def test_batch_selection_allows_shared_accepted_premise(self):
@@ -4499,6 +4581,27 @@ class CampaignContractTest(unittest.TestCase):
         self.assertEqual(
             [row["claim_id"] for row in selected],
             ["critical"],
+        )
+
+    def test_source_row_fingerprint_ignores_generated_order_only(self):
+        first = {
+            "claim_id": "target",
+            "candidate_reason": "runner_artifact_repaired_since_audit",
+            "generated_order": 1,
+        }
+        renumbered = {**first, "generated_order": 2}
+        changed_reason = {
+            **renumbered,
+            "candidate_reason": "dependency_strengthened",
+        }
+
+        self.assertEqual(
+            batch.source_row_fingerprint(first),
+            batch.source_row_fingerprint(renumbered),
+        )
+        self.assertNotEqual(
+            batch.source_row_fingerprint(first),
+            batch.source_row_fingerprint(changed_reason),
         )
 
     def test_packet_fingerprint_normalizes_transport_bounded_virtual_index(self):

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -4459,6 +4459,48 @@ class CampaignContractTest(unittest.TestCase):
         self.assertNotIn("--coordinator", help_text)
         self.assertIn("--max-runtime-hours", help_text)
 
+    def test_batch_selection_skips_siblings_with_mutable_shared_dep(self):
+        targets = [
+            {"claim_id": "first", "deps": ["shared"]},
+            {"claim_id": "sibling", "deps": ["shared"]},
+            {"claim_id": "independent", "deps": ["other"]},
+        ]
+        with mock.patch.object(batch, "accepted", return_value=False):
+            selected = batch.selected_batch(targets, max_workers=2)
+
+        self.assertEqual(
+            [row["claim_id"] for row in selected],
+            ["first", "independent"],
+        )
+
+    def test_batch_selection_allows_shared_accepted_premise(self):
+        targets = [
+            {"claim_id": "first", "deps": ["axiom"]},
+            {"claim_id": "second", "deps": ["axiom"]},
+        ]
+        with mock.patch.object(
+            batch, "accepted", side_effect=lambda cid: cid == "axiom"
+        ):
+            selected = batch.selected_batch(targets, max_workers=2)
+
+        self.assertEqual(
+            [row["claim_id"] for row in selected],
+            ["first", "second"],
+        )
+
+    def test_batch_selection_preserves_multi_seat_capacity(self):
+        targets = [
+            {"claim_id": "critical", "criticality": "critical", "deps": []},
+            {"claim_id": "leaf", "criticality": "leaf", "deps": []},
+        ]
+        with mock.patch.object(batch, "accepted", return_value=False):
+            selected = batch.selected_batch(targets, max_workers=2)
+
+        self.assertEqual(
+            [row["claim_id"] for row in selected],
+            ["critical"],
+        )
+
     def test_packet_fingerprint_normalizes_transport_bounded_virtual_index(self):
         row = {"claim_id": "target", "deps": []}
         rows = {"target": row}

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -6467,6 +6467,60 @@ class ComputeReauditCandidatesTest(unittest.TestCase):
             )
         self.assertEqual(payload["runner_stdout_transport_candidates"], [])
 
+    def test_stdout_transport_does_not_requeue_current_packet_policy(self):
+        m = _import("compute_reaudit_candidates")
+        packet_policy = {
+            "schema": "packet_policy_fingerprint_v1",
+            "sources": {"policy.py": "a" * 64},
+            "digest": "b" * 64,
+        }
+        row = {
+            "claim_type": "bounded_theorem",
+            "audit_status": "audited_conditional",
+            "criticality": "leaf",
+            "deps": [],
+            "runner_path": "scripts/fixture.py",
+            "notes_for_re_audit_if_any": (
+                "runner_artifact_issue: provide complete unclipped stdout."
+            ),
+            "audit_state_snapshot": {
+                "packet_policy_fingerprint": packet_policy,
+            },
+        }
+
+        with mock.patch.object(
+            m.audit_science_fingerprint,
+            "packet_policy_fingerprint",
+            return_value=packet_policy,
+        ), mock.patch.object(
+            m, "cached_runner_stdout_chars", return_value=7_500
+        ):
+            payload = m.build_payload({"current": row})
+
+        self.assertEqual(payload["packet_policy_fingerprint"], packet_policy)
+        self.assertEqual(payload["runner_stdout_transport_candidates"], [])
+
+        row["audit_state_snapshot"]["packet_policy_fingerprint"] = {
+            **packet_policy,
+            "digest": "c" * 64,
+        }
+        with mock.patch.object(
+            m.audit_science_fingerprint,
+            "packet_policy_fingerprint",
+            return_value=packet_policy,
+        ), mock.patch.object(
+            m, "cached_runner_stdout_chars", return_value=7_500
+        ):
+            payload = m.build_payload({"stale": row})
+
+        self.assertEqual(
+            [
+                entry["claim_id"]
+                for entry in payload["runner_stdout_transport_candidates"]
+            ],
+            ["stale"],
+        )
+
 
 class NoGoDisciplineGateTest(unittest.TestCase):
     def setUp(self):

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -6494,6 +6494,10 @@ class ComputeReauditCandidatesTest(unittest.TestCase):
             return_value=packet_policy,
         ), mock.patch.object(
             m, "cached_runner_stdout_chars", return_value=7_500
+        ), mock.patch.object(
+            m.compute_audit_queue,
+            "_live_conditional_would_park",
+            return_value=(True, "no_recorded_blocker_movement"),
         ):
             payload = m.build_payload({"current": row})
 
@@ -6510,6 +6514,10 @@ class ComputeReauditCandidatesTest(unittest.TestCase):
             return_value=packet_policy,
         ), mock.patch.object(
             m, "cached_runner_stdout_chars", return_value=7_500
+        ), mock.patch.object(
+            m.compute_audit_queue,
+            "_live_conditional_would_park",
+            return_value=(True, "no_recorded_blocker_movement"),
         ):
             payload = m.build_payload({"stale": row})
 
@@ -6519,6 +6527,48 @@ class ComputeReauditCandidatesTest(unittest.TestCase):
                 for entry in payload["runner_stdout_transport_candidates"]
             ],
             ["stale"],
+        )
+
+    def test_stdout_transport_requeues_current_policy_after_blocker_moves(self):
+        m = _import("compute_reaudit_candidates")
+        packet_policy = {
+            "schema": "packet_policy_fingerprint_v1",
+            "sources": {"policy.py": "a" * 64},
+            "digest": "b" * 64,
+        }
+        row = {
+            "claim_type": "bounded_theorem",
+            "audit_status": "audited_conditional",
+            "criticality": "leaf",
+            "deps": [],
+            "runner_path": "scripts/fixture.py",
+            "notes_for_re_audit_if_any": (
+                "runner_artifact_issue: provide complete unclipped stdout."
+            ),
+            "audit_state_snapshot": {
+                "packet_policy_fingerprint": packet_policy,
+            },
+        }
+
+        with mock.patch.object(
+            m.audit_science_fingerprint,
+            "packet_policy_fingerprint",
+            return_value=packet_policy,
+        ), mock.patch.object(
+            m, "cached_runner_stdout_chars", return_value=7_500
+        ), mock.patch.object(
+            m.compute_audit_queue,
+            "_live_conditional_would_park",
+            return_value=(False, "runner_cache_state_changed"),
+        ):
+            payload = m.build_payload({"moved": row})
+
+        self.assertEqual(
+            [
+                entry["claim_id"]
+                for entry in payload["runner_stdout_transport_candidates"]
+            ],
+            ["moved"],
         )
 
 


### PR DESCRIPTION
## Summary
- suppress same-policy stdout-transport re-audits only while the terminal audit's complete blocker fingerprint is also unchanged
- requeue when cache, dependency, runner, or other authenticated blocker state moves under the same packet policy
- select parallel audit waves as an antichain over transitive mutable ordinary dependencies while preserving safe sibling and accepted-premise parallelism
- exclude presentation-only `generated_order` from alternate-source row identity so unrelated candidate renumbering does not stale independent deliveries

## Why
A production audit window exposed avoidable repeat work and packet invalidation across concurrent targets. The original patch removed immediate same-policy repeats, but review found that policy equality alone could strand a real artifact repair and that direct-dependency collision keys both serialized safe siblings and missed ancestor/descendant collisions. The reviewed implementation uses the canonical blocker comparator and the full ordinary-dependency relation without changing evidence, packet, or verdict standards.

## Validation
- 189 audit-loop orchestration tests passed serially
- 485 audit-pipeline tests passed
- 62 focused changed-path tests passed
- 21 dispatch-shadow tests passed
- 22 audit-science-fingerprint tests passed
- full audit pipeline passed
- strict audit lint passed with zero errors
- changed audit evidence: checked=0 failures=0 control_failures=0
- vocabulary lint passed
- Python compilation passed
- git diff check passed

Generated audit-state outputs were restored before publication per review-loop policy. No audit verdicts or status artifacts are included.
