### PR TITLE
fix(audit): rotate distributed forensic targets

### DIFF
--- a/docs/audit/scripts/orchestrate_audit_loop.py
+++ b/docs/audit/scripts/orchestrate_audit_loop.py
@@ -693,12 +693,14 @@ def first_ready_forensic_claim(
     excluded_claim_ids: set[str] | None = None,
     *,
     include_alternate_sources: bool = False,
+    worker_id: str = "",
 ) -> str | None:
     PROGRESS["last_canary_source"] = None
     excluded = excluded_claim_ids or set()
     if include_alternate_sources:
         ledger_rows = batch.load_rows()
         for source in ("dispatch", "reaudit"):
+            eligible: list[dict] = []
             for row in batch.source_queue_rows(source, ledger_rows):
                 claim_id = row.get("claim_id")
                 if (
@@ -718,27 +720,35 @@ def first_ready_forensic_claim(
                 if batch.source_requires_forensic(
                     ledger_rows.get(claim_id) or row
                 ):
-                    PROGRESS["last_canary_source"] = source
-                    return claim_id
+                    eligible.append(row)
+            if worker_id and eligible:
+                eligible = batch.rotate_priority_tiers(eligible, worker_id)
+            if eligible:
+                PROGRESS["last_canary_source"] = source
+                return eligible[0]["claim_id"]
     if not QUEUE.exists():
         return None
     rows = json.loads(QUEUE.read_text(encoding="utf-8")).get("queue", [])
+    eligible: list[dict] = []
     for row in rows:
-        if (
+        if not (
             row.get("ready")
             and row.get("audit_work_kind", "fresh_scientific_audit")
             == "fresh_scientific_audit"
             and row.get("audit_status") in {"unaudited", "audit_in_progress"}
             and batch.source_requires_forensic(row)
         ):
-            claim_id = row.get("claim_id")
-            if (
-                isinstance(claim_id, str)
-                and claim_id
-                and claim_id not in excluded
-            ):
-                return claim_id
-    return None
+            continue
+        claim_id = row.get("claim_id")
+        if (
+            isinstance(claim_id, str)
+            and claim_id
+            and claim_id not in excluded
+        ):
+            eligible.append(row)
+    if worker_id and eligible:
+        eligible = batch.rotate_priority_tiers(eligible, worker_id)
+    return eligible[0]["claim_id"] if eligible else None
 
 
 def forensic_canary_terminal_record(
@@ -959,6 +969,7 @@ def run_forensic_canary(
         claim_id = first_ready_forensic_claim(
             excluded,
             include_alternate_sources=True,
+            worker_id=getattr(args, "worker_id", ""),
         )
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         emit(f"cannot authenticate forensic selection sources: {exc}")

--- a/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
+++ b/docs/audit/scripts/tests/test_audit_loop_orchestrator.py
@@ -5576,6 +5576,97 @@ class CampaignContractTest(unittest.TestCase):
                 selected = audit_loop.first_ready_forensic_claim({"quarantined"})
         self.assertEqual(selected, "next_canary")
 
+    def test_forensic_selector_applies_worker_rotation_within_queue(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            queue = Path(tmp) / "queue.json"
+            queue.write_text(
+                json.dumps(
+                    {
+                        "queue": [
+                            {
+                                "claim_id": "first",
+                                "ready": True,
+                                "audit_status": "unaudited",
+                                "criticality": "critical",
+                            },
+                            {
+                                "claim_id": "rotated",
+                                "ready": True,
+                                "audit_status": "unaudited",
+                                "criticality": "critical",
+                            },
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch.object(audit_loop, "QUEUE", queue), mock.patch.object(
+                batch, "source_requires_forensic", return_value=True
+            ), mock.patch.object(
+                batch,
+                "rotate_priority_tiers",
+                side_effect=lambda rows, _worker_id: list(reversed(rows)),
+            ) as rotate:
+                selected = audit_loop.first_ready_forensic_claim(
+                    worker_id="employee-beta"
+                )
+
+        self.assertEqual(selected, "rotated")
+        rotate.assert_called_once()
+        self.assertEqual(rotate.call_args.args[1], "employee-beta")
+
+    def test_forensic_selector_applies_worker_rotation_to_alternate_source(self):
+        ledger_rows = {
+            "first": {"claim_id": "first", "criticality": "critical"},
+            "rotated": {
+                "claim_id": "rotated",
+                "criticality": "critical",
+            },
+        }
+        with mock.patch.object(
+            batch, "load_rows", return_value=ledger_rows
+        ), mock.patch.object(
+            batch,
+            "source_queue_rows",
+            side_effect=lambda source, _rows: (
+                list(ledger_rows.values()) if source == "dispatch" else []
+            ),
+        ), mock.patch.object(
+            batch.audit_runner,
+            "determine_audit_role",
+            return_value=("first", "cross_family"),
+        ), mock.patch.object(
+            batch, "source_requires_forensic", return_value=True
+        ), mock.patch.object(
+            batch,
+            "rotate_priority_tiers",
+            side_effect=lambda rows, _worker_id: list(reversed(rows)),
+        ):
+            selected = audit_loop.first_ready_forensic_claim(
+                include_alternate_sources=True,
+                worker_id="employee-beta",
+            )
+
+        self.assertEqual(selected, "rotated")
+        self.assertEqual(audit_loop.PROGRESS["last_canary_source"], "dispatch")
+
+    def test_forensic_canary_forwards_worker_id_to_selector(self):
+        args = _args()
+        args.worker_id = "employee-beta"
+        with mock.patch.object(
+            batch, "load_campaign_exclusion_records", return_value=[]
+        ), mock.patch.object(
+            audit_loop, "first_ready_forensic_claim", return_value=None
+        ) as selector:
+            rc = audit_loop.run_forensic_canary(args)
+
+        self.assertEqual(rc, 0)
+        selector.assert_called_once_with(
+            set(),
+            include_alternate_sources=True,
+            worker_id="employee-beta",
+        )
+
     def test_forensic_mechanics_circuit_uses_distinct_claims(self):
         def record(claim_id: str, detail: str) -> dict:
             return {


### PR DESCRIPTION
## Summary
- forward the canonical worker ID into forensic target selection
- rotate queue and alternate-source forensic candidates within existing criticality tiers
- preserve the full eligible candidate set, source precedence, campaign exclusions, and all apply-time authority checks

## Production evidence
Four independent canonical top-level drainers with distinct generated worker IDs all selected the same first forensic claim. The distributed-drain contract promises worker-specific target dispersion, but only development batches applied the rotation; `first_ready_forensic_claim` ignored `worker_id` entirely. The extra supervisors were interrupted at their child-owned transaction boundaries so they cannot repeat the collision.

## Review-loop validation
- frozen reviewed head: `f658ed84fdfa9702bb0274cbbe06893c1de2f723`
- 6 focused selection, exclusion, tier-rotation, and forwarding contracts passed
- 192/192 audit-loop orchestrator tests passed
- adversarial actual-selector probe: four worker IDs selected four distinct critical-tier targets; excluding each first choice advanced; dispatch precedence remained intact
- post-pipeline authenticated-source probe: four worker IDs selected four distinct ready forensic targets; exclusions advanced safely
- full 18-stage audit pipeline passed
- strict audit lint passed with zero errors
- changed audit evidence: `checked=0 failures=0 control_failures=0`
- vocabulary lint, Python compilation, and Git diff checks passed

Generated audit-state outputs were restored before landing per review-loop policy. No science, claim, no-go, ledger, queue, or verdict artifact is changed by this PR. The review applied no audit verdict.
