### PR TITLE
Audit: preserve all critical-seat disagreements

### DIFF
--- a/docs/audit/data/cross_seat_disagreement_reaudit_manifest_2026-08-03.json
+++ b/docs/audit/data/cross_seat_disagreement_reaudit_manifest_2026-08-03.json
@@ -1,0 +1,16 @@
+{
+  "description": "One-shot guarded resets for rows whose simultaneous critical-seat results were applied before the audit contract preserved conditional/decoration disagreements. This is targeting metadata only and carries no scientific verdict.",
+  "schema": "cross_seat_disagreement_reaudit_manifest_v1",
+  "targets": [
+    {
+      "claim_id": "gstar_thermal_seven_eighths_stefan_boltzmann_bridge_narrow_theorem_note_2026-06-06",
+      "expected_audit_invocation_id": "8758cbe3d8b8465d8848d77de552981c",
+      "expected_audit_status": "audited_decoration",
+      "expected_claim_type": "decoration",
+      "expected_criticality": "critical",
+      "expected_cross_confirmation_status": null,
+      "expected_note_hash": "ba90bbb603ce1b887f4db3422b8f264e744627e07310b755a67f289a5a0ca7be",
+      "observed_batch_commit": "23fc6260b98edaaca2d431b5262471f1eb75b848"
+    }
+  ]
+}

--- a/docs/audit/scripts/apply_audit.py
+++ b/docs/audit/scripts/apply_audit.py
@@ -462,6 +462,8 @@ JUDICIAL_REVIEWABLE_STATUSES = {
 }
 TERMINAL_CROSS_CONFIRM_VERDICTS = {
     "audited_renaming",
+    "audited_conditional",
+    "audited_decoration",
     "audited_numerical_match",
     "audited_failed",
 }

--- a/docs/audit/scripts/invalidate_stale_audits.py
+++ b/docs/audit/scripts/invalidate_stale_audits.py
@@ -26,9 +26,10 @@ Triggers (any of):
          live as `cross_confirmation.first_audit`, the lane just waits
          for an independent second auditor). Audits with
          `independence == "weak"` are hard-invalidated. Audits already
-         cross-confirmed are no-ops. Terminal non-clean verdicts
-         (audited_conditional, audited_numerical_match, etc.) are also
-         no-ops — cross-confirmation does not apply to them.
+         cross-confirmed are no-ops. A later topology bump does not
+         retroactively invent a second seat for an older terminal non-clean
+         verdict, so those rows are also no-ops here. New paired high/critical
+         audits still preserve terminal-seat disagreement in `apply_audit.py`.
   5. The audited runner hash changed since audit time, or an
      audited_conditional `runner_artifact_issue` row that asked for a current
      runner/log now has a fresh OK cache matching the current runner source.
@@ -802,12 +803,11 @@ def _categorize_criticality_bump(row: dict, target_criticality: str) -> str:
     indep = row.get("independence")
 
     # Terminal non-clean verdicts (audited_conditional, audited_numerical_match,
-    # audited_renaming, audited_decoration, audited_failed) are already in
-    # their final state. Cross-confirmation does not apply to them
-    # (`apply_audit.py`'s cross-confirmation flow only fires for
-    # `verdict == "audited_clean"`). A criticality bump does not change
-    # whether the chain closed, so leave them alone — re-auditing under a
-    # stricter rule will produce the same terminal verdict.
+    # audited_renaming, audited_decoration, audited_failed) are already final
+    # for the earlier single-seat transaction. A later topology bump cannot
+    # reconstruct a simultaneous second seat, so it leaves them alone. This is
+    # distinct from a new paired high/critical transaction: `apply_audit.py`
+    # cross-confirms those terminal seats and preserves any disagreement.
     if audit_status != "audited_clean":
         return "noop"
 

--- a/docs/audit/scripts/invalidate_stale_audits.py
+++ b/docs/audit/scripts/invalidate_stale_audits.py
@@ -43,6 +43,10 @@ Triggers (any of):
   8. A live No-Go Discipline packet no longer validates against the current
      evidence/premise policy. Archive it and return the row to fresh audit
      instead of leaving strict lint blocked on stale authority.
+  9. A reviewed one-shot cross-seat disagreement repair manifest exactly
+     matches the current claim, invocation, note, status, criticality, and
+     cross-confirmation state. Archive that state and reopen the row for a
+     fresh simultaneous critical pair under the repaired apply contract.
 
 When triggered, the prior audit fields are archived into previous_audits
 with an `invalidation_reason`, and audit_status is reset to unaudited.
@@ -65,6 +69,20 @@ LEDGER_PATH = DATA_DIR / "audit_ledger.json"
 RUNNER_CLASSIFICATION_PATH = DATA_DIR / "runner_classification.json"
 SOURCE_PATH_ALIASES_PATH = DATA_DIR / "source_path_aliases.json"
 AXIOM_PREMISE_NODES_PATH = DATA_DIR / "axiom_premise_nodes.json"
+CROSS_SEAT_REAUDIT_MANIFEST_PATH = (
+    DATA_DIR / "cross_seat_disagreement_reaudit_manifest_2026-08-03.json"
+)
+CROSS_SEAT_REAUDIT_SCHEMA = "cross_seat_disagreement_reaudit_manifest_v1"
+CROSS_SEAT_REAUDIT_TARGET_FIELDS = frozenset({
+    "claim_id",
+    "expected_audit_invocation_id",
+    "expected_audit_status",
+    "expected_claim_type",
+    "expected_criticality",
+    "expected_cross_confirmation_status",
+    "expected_note_hash",
+    "observed_batch_commit",
+})
 
 _AXIOM_PREMISE_IDS: set[str] | None = None
 
@@ -100,6 +118,118 @@ def _load_runner_classification() -> dict:
 
 _RUNNER_CLASSIFICATION_CACHE: dict | None = None
 _SOURCE_PATH_ALIAS_REPLACEMENTS: list[tuple[str, str]] | None = None
+
+
+def parse_cross_seat_reaudit_manifest(payload: object) -> dict[str, dict]:
+    """Validate guarded one-shot resets without interpreting science.
+
+    Every target binds the exact ledger authority that was produced by the
+    affected batch transaction. A moved row is left untouched; it has either
+    already been reset or acquired newer authority and must not be rolled back
+    by stale repair metadata.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("cross-seat re-audit manifest must be a JSON object")
+    allowed_top = {"schema", "description", "targets"}
+    unexpected_top = set(payload) - allowed_top
+    if unexpected_top:
+        raise ValueError(
+            "cross-seat re-audit manifest has unexpected fields: "
+            + ", ".join(sorted(unexpected_top))
+        )
+    if payload.get("schema") != CROSS_SEAT_REAUDIT_SCHEMA:
+        raise ValueError("cross-seat re-audit manifest has unsupported schema")
+    targets = payload.get("targets")
+    if not isinstance(targets, list):
+        raise ValueError("cross-seat re-audit manifest targets must be a list")
+
+    parsed: dict[str, dict] = {}
+    for index, target in enumerate(targets):
+        if not isinstance(target, dict):
+            raise ValueError(f"cross-seat re-audit target {index} is not an object")
+        fields = set(target)
+        if fields != CROSS_SEAT_REAUDIT_TARGET_FIELDS:
+            missing = CROSS_SEAT_REAUDIT_TARGET_FIELDS - fields
+            extra = fields - CROSS_SEAT_REAUDIT_TARGET_FIELDS
+            raise ValueError(
+                f"cross-seat re-audit target {index} field mismatch; "
+                f"missing={sorted(missing)} extra={sorted(extra)}"
+            )
+        cid = target.get("claim_id")
+        if not isinstance(cid, str) or not cid:
+            raise ValueError(f"cross-seat re-audit target {index} has invalid claim_id")
+        if cid in parsed:
+            raise ValueError(f"duplicate cross-seat re-audit target: {cid}")
+        invocation_id = target.get("expected_audit_invocation_id")
+        if not isinstance(invocation_id, str) or re.fullmatch(
+            r"[0-9a-f]{32}", invocation_id
+        ) is None:
+            raise ValueError(
+                f"cross-seat re-audit target {cid} has invalid invocation id"
+            )
+        note_hash = target.get("expected_note_hash")
+        if not isinstance(note_hash, str) or re.fullmatch(
+            r"[0-9a-f]{64}", note_hash
+        ) is None:
+            raise ValueError(f"cross-seat re-audit target {cid} has invalid note hash")
+        commit = target.get("observed_batch_commit")
+        if not isinstance(commit, str) or re.fullmatch(r"[0-9a-f]{40}", commit) is None:
+            raise ValueError(
+                f"cross-seat re-audit target {cid} has invalid batch commit"
+            )
+        for field in (
+            "expected_audit_status",
+            "expected_claim_type",
+            "expected_criticality",
+        ):
+            if not isinstance(target.get(field), str) or not target[field]:
+                raise ValueError(
+                    f"cross-seat re-audit target {cid} has invalid {field}"
+                )
+        cross_status = target.get("expected_cross_confirmation_status")
+        if cross_status is not None and not isinstance(cross_status, str):
+            raise ValueError(
+                f"cross-seat re-audit target {cid} has invalid cross status"
+            )
+        parsed[cid] = dict(target)
+    return parsed
+
+
+def load_cross_seat_reaudit_targets() -> dict[str, dict]:
+    if not CROSS_SEAT_REAUDIT_MANIFEST_PATH.exists():
+        return {}
+    try:
+        payload = json.loads(
+            CROSS_SEAT_REAUDIT_MANIFEST_PATH.read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("cannot read cross-seat re-audit manifest") from exc
+    return parse_cross_seat_reaudit_manifest(payload)
+
+
+def cross_seat_reaudit_reason(row: dict, target: dict | None) -> str | None:
+    """Return a reset reason only for the manifest's exact current authority."""
+    if target is None:
+        return None
+    expected = {
+        "claim_id": target["claim_id"],
+        "audit_invocation_id": target["expected_audit_invocation_id"],
+        "audit_status": target["expected_audit_status"],
+        "claim_type": target["expected_claim_type"],
+        "criticality": target["expected_criticality"],
+        "note_hash": target["expected_note_hash"],
+    }
+    if any(row.get(field) != value for field, value in expected.items()):
+        return None
+    cross = row.get("cross_confirmation")
+    cross_status = cross.get("status") if isinstance(cross, dict) else None
+    if cross_status != target["expected_cross_confirmation_status"]:
+        return None
+    return (
+        "cross_seat_disagreement_contract_reaudit:"
+        f"{target['observed_batch_commit']}:"
+        f"{target['expected_audit_invocation_id']}"
+    )
 
 
 def _get_runner_classification() -> dict:
@@ -927,6 +1057,10 @@ def main() -> int:
     invalidated: list[tuple[str, str]] = []
     soft_reset: list[tuple[str, str]] = []
     science_epoch_cache: dict[str, str] = {}
+    try:
+        cross_seat_targets = load_cross_seat_reaudit_targets()
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
     for cid, row in rows.items():
         if row.get("audit_status", "unaudited") == "unaudited":
             continue
@@ -935,11 +1069,13 @@ def main() -> int:
             and not audit_in_progress_has_live_judgment(row)
         ):
             continue
-        reason = detect_invalidation(
-            row,
-            rows,
-            epoch_cache=science_epoch_cache,
-        )
+        reason = cross_seat_reaudit_reason(row, cross_seat_targets.get(cid))
+        if reason is None:
+            reason = detect_invalidation(
+                row,
+                rows,
+                epoch_cache=science_epoch_cache,
+            )
         if reason is None:
             continue
         if reason.startswith("criticality_soft_reset:"):

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -6261,7 +6261,8 @@ class InvalidateStaleAuditsCriticalityBumpTest(unittest.TestCase):
     cases:
 
     - 'noop': the existing audit already qualifies, OR the verdict is
-      terminal-non-clean (cross-confirmation doesn't apply).
+      terminal-non-clean (a later criticality bump does not retroactively
+      synthesize a second seat for the older transaction).
     - 'soft_reset': audited_clean + non-weak independence + bump to
       critical without cross-confirmation. Mirrors apply_audit's
       first-pass flow: audit_in_progress + awaiting_cross_confirmation,

--- a/docs/audit/scripts/tests/test_audit_pipeline.py
+++ b/docs/audit/scripts/tests/test_audit_pipeline.py
@@ -2059,6 +2059,154 @@ class ApplyAuditTest(unittest.TestCase):
             "b" * 32,
         )
 
+    def test_terminal_conditional_decoration_disagreement_is_preserved(self):
+        m = _import("apply_audit")
+        _patch_repo_root(m, self.tmp_root)
+        self._seed_one_row(
+            "test_conditional_decoration_disagreement",
+            criticality="critical",
+        )
+        led = self.fx.read_ledger()
+        first = {
+            "claim_id": "test_conditional_decoration_disagreement",
+            "verdict": "audited_conditional",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "first bounded scope",
+            "auditor": "first-auditor",
+            "negative_assertion_classes": [],
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "load_bearing_step_class": "B",
+            "audit_invocation_id": "c" * 32,
+        }
+        ok, msg = m.apply_one(led, first)
+        self.assertTrue(ok, msg)
+        self.assertEqual(
+            led["rows"]["test_conditional_decoration_disagreement"]["audit_status"],
+            "audited_conditional",
+        )
+
+        second = {
+            **first,
+            "verdict": "audited_decoration",
+            "claim_type": "decoration",
+            "claim_scope": "second decoration scope",
+            "auditor": "second-auditor",
+            "load_bearing_step_class": "A",
+            "decoration_parent_claim_id": "retained_parent",
+            "audit_invocation_id": "d" * 32,
+        }
+        ok, msg = m.apply_one(led, second)
+        self.assertTrue(ok, msg)
+        updated = led["rows"]["test_conditional_decoration_disagreement"]
+        self.assertEqual(updated["audit_status"], "audit_in_progress")
+        self.assertEqual(updated["blocker"], "cross_confirmation_disagreement")
+        self.assertEqual(updated["cross_confirmation"]["status"], "disagreement")
+        self.assertEqual(
+            updated["cross_confirmation"]["first_audit"]["verdict"],
+            "audited_conditional",
+        )
+        self.assertEqual(
+            updated["cross_confirmation"]["second_audit"]["verdict"],
+            "audited_decoration",
+        )
+        self.assertEqual(updated["auditor"], "first-auditor")
+
+    def test_terminal_decoration_conditional_disagreement_is_preserved(self):
+        m = _import("apply_audit")
+        _patch_repo_root(m, self.tmp_root)
+        self._seed_one_row(
+            "test_decoration_conditional_disagreement",
+            audit_status="audited_decoration",
+            claim_type="decoration",
+            criticality="high",
+        )
+        led = self.fx.read_ledger()
+        row = led["rows"]["test_decoration_conditional_disagreement"]
+        row.update({
+            "auditor": "first-auditor",
+            "negative_assertion_classes": [],
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "claim_scope": "first decoration scope",
+            "load_bearing_step_class": "A",
+            "decoration_parent_claim_id": "retained_parent",
+            "verdict_rationale": "first rationale",
+            "audit_invocation_id": "e" * 32,
+        })
+        incoming = {
+            "claim_id": "test_decoration_conditional_disagreement",
+            "verdict": "audited_conditional",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "second bounded scope",
+            "auditor": "second-auditor",
+            "negative_assertion_classes": [],
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "load_bearing_step_class": "B",
+            "audit_invocation_id": "f" * 32,
+        }
+        ok, msg = m.apply_one(led, incoming)
+        self.assertTrue(ok, msg)
+        updated = led["rows"]["test_decoration_conditional_disagreement"]
+        self.assertEqual(updated["audit_status"], "audit_in_progress")
+        self.assertEqual(updated["blocker"], "cross_confirmation_disagreement")
+        self.assertEqual(updated["cross_confirmation"]["status"], "disagreement")
+        self.assertEqual(
+            updated["cross_confirmation"]["first_audit"]["verdict"],
+            "audited_decoration",
+        )
+        self.assertEqual(
+            updated["cross_confirmation"]["second_audit"]["verdict"],
+            "audited_conditional",
+        )
+        self.assertEqual(updated["verdict_rationale"], "first rationale")
+
+    def test_matching_terminal_conditionals_are_cross_confirmed(self):
+        m = _import("apply_audit")
+        _patch_repo_root(m, self.tmp_root)
+        self._seed_one_row(
+            "test_matching_conditionals",
+            criticality="critical",
+        )
+        led = self.fx.read_ledger()
+        first = {
+            "claim_id": "test_matching_conditionals",
+            "verdict": "audited_conditional",
+            "claim_type": "bounded_theorem",
+            "claim_scope": "shared bounded scope",
+            "auditor": "first-auditor",
+            "negative_assertion_classes": [],
+            "auditor_family": "codex-gpt-5.6",
+            "auditor_model": "gpt-5.6-sol",
+            "auditor_reasoning_effort": "xhigh",
+            "independence": "fresh_context",
+            "load_bearing_step_class": "B",
+            "audit_invocation_id": "1" * 32,
+        }
+        ok, msg = m.apply_one(led, first)
+        self.assertTrue(ok, msg)
+        second = {
+            **first,
+            "auditor": "second-auditor",
+            "audit_invocation_id": "2" * 32,
+        }
+        ok, msg = m.apply_one(led, second)
+        self.assertTrue(ok, msg)
+        updated = led["rows"]["test_matching_conditionals"]
+        self.assertEqual(updated["audit_status"], "audited_conditional")
+        self.assertEqual(updated["cross_confirmation"]["status"], "confirmed")
+        self.assertEqual(
+            updated["cross_confirmation"]["agreement_schema"],
+            "audit_tuple_v2",
+        )
+
     def test_main_persists_disagreement_as_applied_and_runs_propagation(self):
         m = _import("apply_audit")
         _patch_repo_root(m, self.tmp_root)
@@ -6035,6 +6183,77 @@ class CheckStagedClaimTypingTest(unittest.TestCase):
         # No ledger written at all: the gate must not fail on non-doc commits.
         rc, _ = self._run(m, "scripts/foo.py\nlogs/runner-cache/x.json\n")
         self.assertEqual(rc, 0)
+
+
+class CrossSeatDisagreementReauditManifestTest(unittest.TestCase):
+    def _target(self):
+        return {
+            "claim_id": "test_cross_seat_reaudit",
+            "expected_audit_invocation_id": "a" * 32,
+            "expected_audit_status": "audited_decoration",
+            "expected_claim_type": "decoration",
+            "expected_criticality": "critical",
+            "expected_cross_confirmation_status": None,
+            "expected_note_hash": "b" * 64,
+            "observed_batch_commit": "c" * 40,
+        }
+
+    def test_manifest_parser_accepts_closed_guard_schema(self):
+        m = _import("invalidate_stale_audits")
+        target = self._target()
+        parsed = m.parse_cross_seat_reaudit_manifest({
+            "schema": "cross_seat_disagreement_reaudit_manifest_v1",
+            "description": "targeting metadata only",
+            "targets": [target],
+        })
+        self.assertEqual(parsed, {target["claim_id"]: target})
+
+    def test_manifest_parser_rejects_unknown_target_fields(self):
+        m = _import("invalidate_stale_audits")
+        target = {**self._target(), "verdict": "audited_clean"}
+        with self.assertRaisesRegex(ValueError, "field mismatch"):
+            m.parse_cross_seat_reaudit_manifest({
+                "schema": "cross_seat_disagreement_reaudit_manifest_v1",
+                "description": "targeting metadata only",
+                "targets": [target],
+            })
+
+    def test_reaudit_reason_requires_exact_current_authority(self):
+        m = _import("invalidate_stale_audits")
+        target = self._target()
+        row = {
+            "claim_id": target["claim_id"],
+            "audit_invocation_id": target["expected_audit_invocation_id"],
+            "audit_status": target["expected_audit_status"],
+            "claim_type": target["expected_claim_type"],
+            "criticality": target["expected_criticality"],
+            "note_hash": target["expected_note_hash"],
+            "cross_confirmation": None,
+        }
+        self.assertEqual(
+            m.cross_seat_reaudit_reason(row, target),
+            "cross_seat_disagreement_contract_reaudit:"
+            + target["observed_batch_commit"]
+            + ":"
+            + target["expected_audit_invocation_id"],
+        )
+        for field in (
+            "claim_id",
+            "audit_invocation_id",
+            "audit_status",
+            "claim_type",
+            "criticality",
+            "note_hash",
+        ):
+            moved = dict(row)
+            moved[field] = "moved"
+            self.assertIsNone(
+                m.cross_seat_reaudit_reason(moved, target),
+                field,
+            )
+        moved = dict(row)
+        moved["cross_confirmation"] = {"status": "confirmed"}
+        self.assertIsNone(m.cross_seat_reaudit_reason(moved, target))
 
 
 class InvalidateStaleAuditsCriticalityBumpTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- require cross-confirmation for critical/high conditional and decoration verdicts, so a later seat cannot overwrite a differing first judgment
- preserve disagreements as audit_in_progress for the governed five-judge panel
- add an exact, one-shot guarded reset for the single affected gstar row so it receives a fresh simultaneous pair
- add regression coverage for both disagreement directions, matching conditionals, manifest schema validation, and exact reset guards

## Validation

- 491 audit-pipeline tests pass
- strict audit lint passes with no errors
- vocabulary lint reports zero violations
- pipeline integration reset exactly one guarded row and converged with zero additional resets on the second invalidation pass

## Scope

Infrastructure only. This PR changes no axiom, primitive, scientific claim, or audit verdict. Generated audit surfaces are excluded.