### PR TITLE
methodology: workhorse two-profile worker policy (Claude workers first-class; robustness conditions; owner directive 2026-08-03)

### DIFF
--- a/docs/ai_methodology/skills/workhorse/SKILL.md
+++ b/docs/ai_methodology/skills/workhorse/SKILL.md
@@ -22,12 +22,51 @@ Claude model is driving the conversation (e.g. Fable, or the strongest available
 Claude model at the time). It is not a separately pinned or named model; it
 follows the in-chat model.
 
-Use the strongest configured text reasoning worker available through the local
-`codex exec` setup for bounded execution. If a named preferred worker profile is
-unavailable, do not substitute an image, visual-generation, document-rendering,
-or low-reasoning model. Use the strongest available text reasoning profile,
-disclose the substitution in the work log, and keep the supervising agent
-responsible for the result.
+Two worker profiles are first-class (owner directive 2026-08-03, after the
+2026-08-03 campaign ran eleven Claude workers with zero failed deliveries and
+the checker lane refuting a supervisor-authored primary):
+
+- **Codex text-reasoning worker** — the local `codex exec` setup, preferred
+  profile `gpt-5.6-sol` at `model_reasoning_effort=max` (owner directive
+  2026-07-08; verify slug and effort live against the local install). Launch
+  and reliability rules below.
+- **Claude worker** — a subagent of the host session (the Agent tool or
+  equivalent), running the strongest available Claude model at maximum
+  reasoning effort (farmed work runs at max — owner directive 2026-06-26;
+  subagents inherit the session's effort, so the session must be at max).
+  Launched as background workers, one per block, each in its own durable
+  worktree. The codex failure modes (stdin start-hang, context exhaustion
+  mid-delivery) do not apply; the bounded-read discipline still does.
+
+Profile selection is the supervising agent's discretion, with one preference:
+when both lanes are available, pair them — primary from one family, checker
+from the other — because cross-model checker independence is strictly stronger
+than cross-context. When only one family is available (quota, outage), the
+single-family setup is admissible ONLY under the robustness conditions below,
+and every shipped block must disclose its independence class (cross-model vs
+cross-context) in the note, receipt, and PR.
+
+Never substitute an image, visual-generation, document-rendering, or
+low-reasoning model for either profile. Disclose any substitution in the work
+log and keep the supervising agent responsible for the result.
+
+## Robustness Conditions (mandatory; load-bearing when primary and checker share a model family)
+
+- Every block ships an independent checker spec'd to REFUTE, built on
+  machinery disjoint from the primary's (different arithmetic route,
+  different enumeration/allocation, no import of the primary — text/AST pins
+  behind an import firewall).
+- Checker teeth must be demonstrated, not asserted: mutation probes or
+  planted defects that the checker provably catches, and tamper tests that
+  fail closed.
+- The supervising agent reviews every worker diff line-by-line and
+  hand-verifies the load-bearing mathematics of at least the central claim
+  before accepting a block; cache terminals are verified against emitted
+  certificates.
+- Integrity gates never encode desired outcomes; findings are generated from
+  computed values.
+- These conditions are what make same-family worker/checker pairs admissible;
+  they are good practice for cross-model pairs too.
 
 The supervising agent:
 
@@ -54,7 +93,20 @@ The worker must not:
 - decide to land, merge, or close PRs;
 - route science work through visual/image-generation tooling.
 
-## Codex Worker Launch & Reliability (REQUIRED)
+## Claude Worker Launch (when using the Claude profile)
+
+- Spawn one background subagent per block, each pointed at its own durable
+  worktree (never a tmp path — reboots purge tmp; the 2026-08-02 campaign
+  interruption is the precedent), with the block spec inline in the prompt.
+- The spec carries the same bounds as a codex spec: named read caps, exact
+  deliverable filenames, commit-incrementally-with-prefix, no docs/ edits,
+  no pushes (the supervisor pushes after review), raw final report with a
+  line cap.
+- Workers commit locally; the supervisor reviews, then commits any
+  supervisor-side artifacts (note, receipt) and pushes. Worker scripts are
+  committed BEFORE their first certified run wherever recovery matters.
+
+## Codex Worker Launch & Reliability (REQUIRED when using the codex profile)
 
 `codex exec` workers hang or silently fail to deliver in two confirmed ways. Both
 have a fix; apply all of the following every time.

--- a/docs/ai_methodology/skills/workhorse/SKILL.md
+++ b/docs/ai_methodology/skills/workhorse/SKILL.md
@@ -22,21 +22,39 @@ Claude model is driving the conversation (e.g. Fable, or the strongest available
 Claude model at the time). It is not a separately pinned or named model; it
 follows the in-chat model.
 
-Two worker profiles are first-class (owner directive 2026-08-03, after the
-2026-08-03 campaign ran eleven Claude workers with zero failed deliveries and
-the checker lane refuting a supervisor-authored primary):
+Two worker profiles are first-class (owner directive 2026-08-03; the full
+2026-08 campaign window ran 20+ Claude workers across 23 shipped blocks with
+zero failed deliveries — the checker lane refuted a supervisor-authored
+primary, caught a verdict-flipping rubric defect in its own primary, and
+landed 3/3 pre-registered predictions on never-evaluated objects):
 
 - **Codex text-reasoning worker** — the local `codex exec` setup, preferred
   profile `gpt-5.6-sol` at `model_reasoning_effort=max` (owner directive
   2026-07-08; verify slug and effort live against the local install). Launch
   and reliability rules below.
 - **Claude worker** — a subagent of the host session (the Agent tool or
-  equivalent), running the strongest available Claude model at maximum
-  reasoning effort (farmed work runs at max — owner directive 2026-06-26;
-  subagents inherit the session's effort, so the session must be at max).
-  Launched as background workers, one per block, each in its own durable
-  worktree. The codex failure modes (stdin start-hang, context exhaustion
-  mid-delivery) do not apply; the bounded-read discipline still does.
+  equivalent), running the strongest available WORKER-TIER Claude model
+  (currently Opus 5 — the tier below the supervising frontier model) at
+  maximum reasoning effort (farmed work runs at max — owner directive
+  2026-06-26; subagents inherit the session's effort, so the session must
+  be at max). Launched as background workers, one per block, each in its
+  own durable worktree. The codex failure modes (stdin start-hang, context
+  exhaustion mid-delivery) do not apply; the bounded-read discipline still
+  does.
+
+  Worker-tier rationale (owner-ratified 2026-08-04): the frontier model is
+  NOT the default worker even though it is the strongest available Claude
+  model. The default split concentrates the frontier model where its
+  capability is load-bearing — spec judgment, line-by-line review, and
+  landing — and preserves the shared capacity pool across a long window
+  (parallel frontier workers would burn the window's budget on the lane
+  where discipline, not raw capability, carries robustness: the 2026-08
+  window shipped 23 blocks with zero failed worker deliveries, and every
+  defect that mattered was caught by the verification structure, including
+  two supervisor spec errors caught BY workers). The supervising agent MAY
+  escalate an individual block's worker or checker to the frontier model
+  when that block's difficulty warrants it; escalation is a profile fact
+  and is disclosed in the ship note like any other.
 
 Profile selection is the supervising agent's discretion, with one preference:
 when both lanes are available, pair them — primary from one family, checker

--- a/docs/ai_methodology/skills/workhorse/SKILL.md
+++ b/docs/ai_methodology/skills/workhorse/SKILL.md
@@ -22,11 +22,15 @@ Claude model is driving the conversation (e.g. Fable, or the strongest available
 Claude model at the time). It is not a separately pinned or named model; it
 follows the in-chat model.
 
-Two worker profiles are first-class (owner directive 2026-08-03; the full
-2026-08 campaign window ran 20+ Claude workers across 23 shipped blocks with
-zero failed deliveries — the checker lane refuted a supervisor-authored
-primary, caught a verdict-flipping rubric defect in its own primary, and
-landed 3/3 pre-registered predictions on never-evaluated objects):
+Two worker profiles are first-class (owner directive 2026-08-03).
+Operational support — support-only evidence, NOT on `origin/main`: the
+2026-08 campaign work-log (`STATE.yaml` and `REVIEW_HISTORY.md` under
+`.claude/science/physics-loops/toe-time-expansion-20260802/` on the pack
+branch `physics-loop/toe-close-pack-20260729`) records that window's Claude
+workers block by block, including a checker refuting a supervisor-authored
+primary, a worker catching a verdict-flipping rubric defect in its own
+primary, and 3/3 pre-registered checker predictions on never-evaluated
+windows. The profiles:
 
 - **Codex text-reasoning worker** — the local `codex exec` setup, preferred
   profile `gpt-5.6-sol` at `model_reasoning_effort=max` (owner directive
@@ -38,9 +42,11 @@ landed 3/3 pre-registered predictions on never-evaluated objects):
   maximum reasoning effort (farmed work runs at max — owner directive
   2026-06-26; subagents inherit the session's effort, so the session must
   be at max). Launched as background workers, one per block, each in its
-  own durable worktree. The codex failure modes (stdin start-hang, context
-  exhaustion mid-delivery) do not apply; the bounded-read discipline still
-  does.
+  own durable worktree. The codex start-hang/stdin failure modes have not
+  been observed with Claude workers (no CLI stdin is involved at launch),
+  but context exhaustion from oversized reads or tool output remains
+  possible for any bounded-context worker: the bounded-read and
+  incremental-delivery discipline applies to this profile too.
 
   Worker-tier rationale (owner-ratified 2026-08-04): the frontier model is
   NOT the default worker even though it is the strongest available Claude
@@ -48,21 +54,31 @@ landed 3/3 pre-registered predictions on never-evaluated objects):
   capability is load-bearing — spec judgment, line-by-line review, and
   landing — and preserves the shared capacity pool across a long window
   (parallel frontier workers would burn the window's budget on the lane
-  where discipline, not raw capability, carries robustness: the 2026-08
-  window shipped 23 blocks with zero failed worker deliveries, and every
-  defect that mattered was caught by the verification structure, including
-  two supervisor spec errors caught BY workers). The supervising agent MAY
-  escalate an individual block's worker or checker to the frontier model
-  when that block's difficulty warrants it; escalation is a profile fact
-  and is disclosed in the ship note like any other.
+  where discipline, not raw capability, carries robustness). Per the
+  campaign work-log cited above: the defects that were caught in that
+  window were caught by the verification structure, including supervisor
+  spec errors caught BY workers; that record says nothing about defects
+  that went undetected, and no completeness claim is made. The supervising
+  agent MAY escalate an individual block's worker or checker to the
+  frontier model when that block's difficulty warrants it; escalation is a
+  profile fact and is disclosed in the ship note like any other.
 
 Profile selection is the supervising agent's discretion, with one preference:
 when both lanes are available, pair them — primary from one family, checker
-from the other — because cross-model checker independence is strictly stronger
-than cross-context. When only one family is available (quota, outage), the
-single-family setup is admissible ONLY under the robustness conditions below,
-and every shipped block must disclose its independence class (cross-model vs
-cross-context) in the note, receipt, and PR.
+from the other — because a checker built by a different model family is more
+independent than a checker built in a separate context of the same family.
+When only one family is available (quota, outage), the same-family setup is
+admissible ONLY under the robustness conditions below, and every shipped
+block must say plainly in the note, receipt, and PR whether its checker was
+built by a different model family or in a separate context of the same
+family (and say so if context separation cannot be established). This
+describes the checker pairing only; it is not an audit-independence grade —
+audit rows use the controlled `independence` vocabulary in
+`docs/repo/CONTROLLED_VOCABULARY.md`.
+
+Known residual: the canonical `/workhorse` command surface and its
+science-command callers still carry the earlier Codex-first launch default;
+they are updated in a separate change, not by this file.
 
 Never substitute an image, visual-generation, document-rendering, or
 low-reasoning model for either profile. Disclose any substitution in the work
@@ -117,9 +133,10 @@ The worker must not:
   worktree (never a tmp path — reboots purge tmp; the 2026-08-02 campaign
   interruption is the precedent), with the block spec inline in the prompt.
 - The spec carries the same bounds as a codex spec: named read caps, exact
-  deliverable filenames, commit-incrementally-with-prefix, no docs/ edits,
-  no pushes (the supervisor pushes after review), raw final report with a
-  line cap.
+  deliverable filenames, commit-incrementally-with-prefix, no docs/ edits
+  except deliverable paths the spec names exactly (a note draft assigned
+  under the worker contract is such a deliverable), no pushes (the
+  supervisor pushes after review), raw final report with a line cap.
 - Workers commit locally; the supervisor reviews, then commits any
   supervisor-side artifacts (note, receipt) and pushes. Worker scripts are
   committed BEFORE their first certified run wherever recovery matters.


### PR DESCRIPTION
Owner-directed methodology update (2026-08-03, wording ratified 2026-08-04): the workhorse execution split gains a second first-class worker profile.

## What changes

- **Two first-class profiles**: the existing codex lane (gpt-5.6-sol at max, 2026-07-08 policy folded into the skill text — the repo copy had dropped it) and **Claude workers** (host-session subagents at max reasoning effort per the 2026-06-26 farmed-work directive), launched per-block in durable worktrees.
- **The worker tier, stated precisely** (owner question 2026-08-04: "wouldn't the strongest available model just be Fable 5 itself?" — yes, read literally, which is not the intended rule): the supervisor runs on the frontier model driving the session; Claude workers run on the strongest available WORKER-TIER model (currently Opus 5). Rationale in the skill text: the frontier model concentrates where its capability is load-bearing (spec judgment, line-by-line review, landing) and the shared capacity pool survives a long window — the evidence says discipline, not worker tier, carries robustness. The supervisor MAY escalate an individual block's worker or checker to the frontier model when its difficulty warrants; escalation is disclosed in the ship note like any profile fact.
- **Pairing preference**: when both lanes are available, primary from one family + checker from the other (cross-model independence is strictly stronger). Single-family setups are admissible ONLY under the mandatory robustness conditions, with the independence class (cross-model vs cross-context) disclosed in every note/receipt/PR.
- **Robustness conditions** (mandatory, load-bearing for same-family pairs): disjoint-machinery checkers spec'd to REFUTE behind import firewalls; demonstrated teeth (mutation probes / planted defects / fail-closed tamper tests); supervisor line-by-line review with hand-verification of the central claim's mathematics; outcome-neutral integrity gates.
- **Claude launch guidance**: durable worktrees (tmp purge precedent: the 2026-08-02 reboot), bounded specs identical in discipline to codex specs, workers never push (supervisor pushes after review), scripts committed before first certified run.
- Codex launch/reliability section retained unchanged, scoped to the codex profile.

## Evidence base (the full 2026-08 window, PRs #5921-#5952)

23 science blocks, 20+ Claude workers, zero failed deliveries, zero start-hangs/salvages. The same-family robustness conditions were exercised hard and held:

- the checker lane REFUTED a supervisor-authored primary (blockP25 v2 locality probe) and materially narrowed or corrected the primary in 10+ blocks (the 885 extent-residual widening; the 886 menu-changing S3 find; the 888 V_edge decomposition trap; the 890 verdict-flipping rubric defect caught in the checker's OWN primary lineage; the 891 honest carrier-level holdout miss);
- pre-registered prediction discipline: 892's checker recorded predictions for three never-evaluated windows BEFORE computing them — 3/3 landed; 891's derive/holdout split was cryptographically SEALED before the holdout corpora existed and audited from the rule's stated text alone;
- a stated conjecture was closed by its own falsifier with a falsifier-visibility control proving no blind spot (889);
- two SUPERVISOR spec errors were caught by workers spec'd to refute (Cycle 880's channel premise; Cycle 885's pin-path premise, where the worker verified digests and refused the instructed repoint);
- workers disclosed their own refuted hypotheses and HONEST_FAILs unprompted (890, 891, 892).

Efficiency: blocks ran 15-50 min each, up to five in parallel; the window's queue was exhausted at PR-worthy quality with ~9h unspent.

## What does not change

The split itself (supervisor plans/specs/reviews/lands; workers execute bounded tasks), the worker prohibitions, the no-go/narrowing discipline, and lane hand-off rules are untouched. This is a worker-profile policy update only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)